### PR TITLE
Improve dataframe metadata handling

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1249,7 +1249,6 @@ class DataFrame(_Frame):
         result._name = name
 
         result._pd_cache, result._know_dtype = cls._build_pd(metadata)
-
         result.divisions = tuple(divisions)
         return result
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -142,7 +142,6 @@ class DataFrameGroupBy(_GroupBy):
         """
         if (isinstance(self.index, Series) and
             self.index._name == self.df.index._name):
-            df = self.df
             return map_partitions(_groupby_apply_level0,
                                   columns or self.df.columns,
                                   self.df, func)
@@ -207,7 +206,6 @@ class SeriesGroupBy(_GroupBy):
         """
         # df = set_index(self.df, self.index, **self.kwargs)
         if self.index._name == self.df.index._name:
-            df = self.df
             return map_partitions(_groupby_level0_getitem_apply,
                                   self.df, self.key, func,
                                   columns=columns)

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -165,7 +165,7 @@ def _fill_kwargs(fn, **kwargs):
         kwargs['compression'] = infer_compression(fn)
 
     if 'names' not in kwargs:
-        kwargs['names'] = csv_names(fn, **kwargs)
+        kwargs['names'] = _csv_names(fn, **kwargs)
         if 'header' not in kwargs:
             kwargs['header'] = 0
     else:
@@ -233,12 +233,11 @@ def read_csv(fn, **kwargs):
 
     # Create dask graph
     dsk = dict(((name, i), (_read_csv, fn, i, chunkbytes,
-                                       kwargs['compression'], rest_kwargs,
-                                       bom))
+                            kwargs['compression'], rest_kwargs, bom))
                for i in range(1, nchunks))
 
     dsk[(name, 0)] = (_read_csv, fn, 0, chunkbytes, kwargs['compression'],
-                                 first_kwargs, b'')
+                      first_kwargs, b'')
 
     result = DataFrame(dsk, name, head, divisions)
 
@@ -248,16 +247,16 @@ def read_csv(fn, **kwargs):
     return result
 
 
-def csv_names(fn, encoding='utf-8', compression=None, names=None,
-                parse_dates=None, usecols=None, dtype=None, **kwargs):
+def _csv_names(fn, encoding='utf-8', compression=None, names=None,
+               parse_dates=None, usecols=None, dtype=None, **kwargs):
     try:
         kwargs['nrows'] = 5
         df = pd.read_csv(fn, encoding=encoding, compression=compression,
-                names=names, **kwargs)
+                         names=names, **kwargs)
     except StopIteration:
         kwargs['nrows'] = None
         df = pd.read_csv(fn, encoding=encoding, compression=compression,
-                names=names, **kwargs)
+                         names=names, **kwargs)
     return list(df.columns)
 
 

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -265,10 +265,8 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
     else:
         right_index = False
 
-    # fake column names
-    left_empty = lhs._pd
-    right_empty = rhs._pd
-    dummy = pd.merge(left_empty, right_empty, how, None,
+    # dummy result
+    dummy = pd.merge(lhs._pd, rhs._pd, how, None,
                      left_on=left_on, right_on=right_on,
                      left_index=left_index, right_index=right_index,
                      suffixes=suffixes)

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -200,8 +200,8 @@ def join_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix=''):
     (lhs, rhs), divisions, parts = align_partitions(lhs, rhs)
     divisions, parts = require(divisions, parts, required[how])
 
-    left_empty = lhs._empty_partition
-    right_empty = rhs._empty_partition
+    left_empty = lhs._pd
+    right_empty = rhs._pd
 
     name = 'join-indexed-' + tokenize(lhs, rhs, how, lsuffix, rsuffix)
 
@@ -267,8 +267,8 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
         right_index = False
 
     # fake column names
-    left_empty = lhs._empty_partition
-    right_empty = rhs._empty_partition
+    left_empty = lhs._pd
+    right_empty = rhs._pd
     j = pd.merge(left_empty, right_empty, how, None,
                  left_on=left_on, right_on=right_on,
                  left_index=left_index, right_index=right_index,
@@ -344,7 +344,7 @@ def concat_indexed_dataframes(dfs, axis=0, join='outer'):
 
     dfs2, divisions, parts = align_partitions(*dfs)
 
-    empties = [df._empty_partition for df in dfs]
+    empties = [df._pd for df in dfs]
     result = pd.concat(empties, axis=axis, join=join)
     if isinstance(result, pd.Series):
         columns = result.name
@@ -578,5 +578,5 @@ def _append(df, other, divisions):
     for j in range(other.npartitions):
         dsk[(name, npart + j)] = (other._name, j)
     dsk = toolz.merge(dsk, df.dask, other.dask)
-    dummy = df._empty_partition.append(other._empty_partition)
+    dummy = df._pd.append(other._pd)
     return _Frame(dsk, name, dummy, divisions)

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -411,16 +411,16 @@ def _concat_dfs(dfs, name, join='outer'):
 
     if isinstance(dummy, pd.Series):
         # in this case, input must be all Series. No need to care DataFrame.
-        columns = []
+        columns = pd.Index([])
     else:
-        columns = dummy.columns.tolist()
+        columns = dummy.columns
         if len(columns) == 0:
             raise ValueError('Failed to concat, no columns remain')
 
     for df in dfs:
         if isinstance(df, DataFrame):
             # filter DataFrame columns
-            if columns != df.columns:
+            if not columns.equals(df.columns):
                 df = df[[c for c in columns if c in df.columns]]
         # Series must remain if output columns exist
 
@@ -550,27 +550,12 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
             # concat will not regard Series as row
             dfs = _maybe_from_pandas(dfs)
             name = 'concat-{0}'.format(tokenize(*dfs))
-<<<<<<< 108b45bb4f9ee53674a12704b8ae4cc7fd2d033c
-<<<<<<< 67169c91bb885da8c073313194763838ad7b4e2b
             dsk, dummy = _concat_dfs(dfs, name, join=join)
 
             divisions = [None] * (sum([df.npartitions for df in dfs]) + 1)
             return _Frame(toolz.merge(dsk, *[df.dask for df in dfs]),
                           name, dummy, divisions)
-=======
-            dsk, empty = _concat_dfs(dfs, name, join=join)
 
-            divisions = [None] * (sum([df.npartitions for df in dfs]) + 1)
-            return _Frame(toolz.merge(dsk, *[df.dask for df in dfs]),
-                          name, empty, divisions)
->>>>>>> Fix io and merge to preserve metadata
-=======
-            dsk, dummy = _concat_dfs(dfs, name, join=join)
-
-            divisions = [None] * (sum([df.npartitions for df in dfs]) + 1)
-            return _Frame(toolz.merge(dsk, *[df.dask for df in dfs]),
-                          name, dummy, divisions)
->>>>>>> Infer result using internal cache
 
 def _append(df, other, divisions):
     """ Internal function to append 2 dd.DataFrame/Series instances """

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -415,7 +415,7 @@ def _concat_dfs(dfs, name, join='outer'):
     dsk = dict()
     i = 0
 
-    empties = [df._empty_partition for df in dfs]
+    empties = [df._pd for df in dfs]
     dummy = pd.concat(empties, axis=0, join=join)
 
     if isinstance(dummy, pd.Series):

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -39,8 +39,8 @@ def wrap_rolling(func):
         for i in range(1, arg.npartitions + 1):
             dsk[(new_name, i)] = (rolling_chunk, f, (old_name, i - 1),
                                   (old_name, i), window) + args
-        return type(arg)(merge(arg.dask, dsk), new_name,
-                         arg.column_info, arg.divisions)
+        return arg._constructor(merge(arg.dask, dsk), new_name,
+                                arg, arg.divisions)
     return rolling
 
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -9,6 +9,7 @@ from toolz import merge
 
 from ..optimize import cull
 from ..base import tokenize
+from ..compatibility import unicode
 from .core import DataFrame, Series, _Frame
 from dask.dataframe.categorical import (strip_categories, _categorize,
                                         get_categories)
@@ -72,14 +73,16 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
     partd
     """
 
-    if isinstance(index, _Frame):
+    if isinstance(index, Series):
         assert df.divisions == index.divisions
         metadata = df._pd
         metadata.index.name = index.name
-    else:
+    elif isinstance(index, (str, unicode)):
         columns = [c for c in df.columns if c != index]
         metadata = df._pd[columns]
         metadata.index.name = index
+    else:
+        raise ValueError('index must be Series or str, {0} given'.format(type(index)))
 
     token = tokenize(df, index, divisions)
     always_new_token = uuid.uuid1().hex
@@ -94,7 +97,7 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
     dsk1 = {catname: (get_categories, df._keys()[0]),
             p: (partd.PandasBlocks, (partd.Buffer, (partd.Dict,), (partd.File,))),
             catname2: (new_categories, catname,
-                            index.name if isinstance(index, Series) else index)}
+                       index.name if isinstance(index, Series) else index)}
 
     # Partition data on disk
     name = 'set-partition--partition-' + always_new_token
@@ -135,7 +138,8 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
                     for i in range(len(divisions) - 1)))
 
     dsk = merge(df.dask, dsk1, dsk2, dsk3, dsk4)
-    if isinstance(index, _Frame):
+
+    if isinstance(index, Series):
         dsk.update(index.dask)
 
     if compute:

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -74,11 +74,11 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
 
     if isinstance(index, _Frame):
         assert df.divisions == index.divisions
-        metadata = df._empty_partition
+        metadata = df._pd
         metadata.index.name = index.name
     else:
         columns = [c for c in df.columns if c != index]
-        metadata = df._empty_partition[columns]
+        metadata = df._pd[columns]
         metadata.index.name = index
 
     token = tokenize(df, index, divisions)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -71,11 +71,15 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
     shuffle
     partd
     """
+
     if isinstance(index, _Frame):
         assert df.divisions == index.divisions
-        columns = df.columns
+        metadata = df._empty_partition
+        metadata.index.name = index.name
     else:
-        columns = tuple([c for c in df.columns if c != index])
+        columns = [c for c in df.columns if c != index]
+        metadata = df._empty_partition[columns]
+        metadata.index.name = index
 
     token = tokenize(df, index, divisions)
     always_new_token = uuid.uuid1().hex
@@ -137,7 +141,7 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
     if compute:
         dsk = cull(dsk, list(dsk4.keys()))
 
-    return DataFrame(dsk, name, columns, divisions)
+    return DataFrame(dsk, name, metadata, divisions)
 
 
 def barrier(args):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -150,20 +150,22 @@ def test_set_index_raises_error_on_bad_input():
 def test_rename_columns():
     # GH 819
     df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
-                        'b': [7, 6, 5, 4, 3, 2, 1]})
+                       'b': [7, 6, 5, 4, 3, 2, 1]})
     ddf = dd.from_pandas(df, 2)
 
     ddf.columns = ['x', 'y']
     df.columns = ['x', 'y']
     tm.assert_index_equal(ddf.columns, pd.Index(['x', 'y']))
+    tm.assert_index_equal(ddf._pd.columns, pd.Index(['x', 'y']))
     assert eq(ddf, df)
 
-    with tm.assertRaises(ValueError):
+    msg = r"""Length mismatch: Expected axis has 2 elements, new values have 3 elements"""
+    with tm.assertRaisesRegexp(ValueError, msg):
         ddf.columns = [1, 2, 3, 4]
 
 
 def test_rename_series():
-    # GH 819,
+    # GH 819
     s = pd.Series([1, 2, 3, 4, 5, 6, 7], name='x')
     ds = dd.from_pandas(s, 2)
 
@@ -171,7 +173,6 @@ def test_rename_series():
     ds.name = 'renamed'
     assert s.name == 'renamed'
     assert eq(ds, s)
-
 
 
 def test_describe():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -148,19 +148,29 @@ def test_set_index_raises_error_on_bad_input():
     assert raises(NotImplementedError, lambda: ddf.set_index(['a', 'b']))
 
 def test_rename_columns():
-    # GH 819,
+    # GH 819
     df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
                         'b': [7, 6, 5, 4, 3, 2, 1]})
     ddf = dd.from_pandas(df, 2)
 
     ddf.columns = ['x', 'y']
     df.columns = ['x', 'y']
+    tm.assert_index_equal(ddf.columns, pd.Index(['x', 'y']))
     assert eq(ddf, df)
 
-    def len_mismatch():
+    with tm.assertRaises(ValueError):
         ddf.columns = [1, 2, 3, 4]
 
-    assert raises(ValueError, lambda: len_mismatch())
+
+def test_rename_series():
+    # GH 819,
+    s = pd.Series([1, 2, 3, 4, 5, 6, 7], name='x')
+    ds = dd.from_pandas(s, 2)
+
+    s.name = 'renamed'
+    ds.name = 'renamed'
+    assert s.name == 'renamed'
+    assert eq(ds, s)
 
 
 
@@ -1385,7 +1395,7 @@ def test_reset_index():
 
     assert len(res.index.compute()) == len(exp.index)
     tm.assert_index_equal(res.columns, exp.columns)
-    eq(res, exp)
+    tm.assert_numpy_array_equal(res.compute().values, exp.values)
 
 
 def test_dataframe_compute_forward_kwargs():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -28,17 +28,14 @@ full = d.compute()
 
 
 def test_Dataframe():
-    result = (d['a'] + 1).compute()
     expected = pd.Series([2, 3, 4, 5, 6, 7, 8, 9, 10],
                         index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
                         name='a')
 
-    assert eq(result, expected)
+    assert eq(d['a'] + 1, expected)
 
-    assert list(d.columns) == list(['a', 'b'])
+    tm.assert_index_equal(d.columns, pd.Index(['a', 'b']))
 
-
-    full = d.compute()
     assert eq(d[d['b'] > 2], full[full['b'] > 2])
     assert eq(d[['a', 'b']], full[['a', 'b']])
     assert eq(d.a, full.a)
@@ -109,10 +106,11 @@ def test_column_names():
 def test_index_names():
     assert d.index.name is None
 
-    df = pd.DataFrame(np.random.randn(10, 5),
-                      index=pd.Index([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], name='x'))
+    idx = pd.Index([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], name='x')
+    df = pd.DataFrame(np.random.randn(10, 5), idx)
     ddf = dd.from_pandas(df, 3)
     assert ddf.index.name == 'x'
+    assert ddf.index.compute().name == 'x'
 
 
 def test_set_index():
@@ -159,7 +157,7 @@ def test_rename_columns():
     tm.assert_index_equal(ddf._pd.columns, pd.Index(['x', 'y']))
     assert eq(ddf, df)
 
-    msg = r"""Length mismatch: Expected axis has 2 elements, new values have 3 elements"""
+    msg = r"Length mismatch: Expected axis has 2 elements, new values have 4 elements"
     with tm.assertRaisesRegexp(ValueError, msg):
         ddf.columns = [1, 2, 3, 4]
 
@@ -381,6 +379,7 @@ def test_map_partitions_keeps_kwargs_in_dict():
 
 
 def test_drop_duplicates():
+    # can't detect duplicates only from cached data
     assert eq(d.a.drop_duplicates(), full.a.drop_duplicates())
     assert eq(d.drop_duplicates(), full.drop_duplicates())
     assert eq(d.index.drop_duplicates(), full.index.drop_duplicates())
@@ -439,25 +438,28 @@ def test_get_division():
     # DataFrame
     div1 = ddf.get_division(0)
     assert isinstance(div1, dd.DataFrame)
-    eq(div1, pdf.loc[0:3])
+    assert eq(div1, pdf.loc[0:3])
     div2 = ddf.get_division(1)
-    eq(div2, pdf.loc[4:7])
+    assert eq(div2, pdf.loc[4:7])
     div3 = ddf.get_division(2)
-    eq(div3, pdf.loc[8:9])
+    assert eq(div3, pdf.loc[8:9])
     assert len(div1) + len(div2) + len(div3) == len(pdf)
 
     # Series
     div1 = ddf.a.get_division(0)
     assert isinstance(div1, dd.Series)
-    eq(div1, pdf.a.loc[0:3])
+    assert eq(div1, pdf.a.loc[0:3])
     div2 = ddf.a.get_division(1)
-    eq(div2, pdf.a.loc[4:7])
+    assert eq(div2, pdf.a.loc[4:7])
     div3 = ddf.a.get_division(2)
-    eq(div3, pdf.a.loc[8:9])
+    assert eq(div3, pdf.a.loc[8:9])
     assert len(div1) + len(div2) + len(div3) == len(pdf.a)
 
-    assert raises(ValueError, lambda: ddf.get_division(-1))
-    assert raises(ValueError, lambda: ddf.get_division(3))
+    with tm.assertRaises(ValueError):
+        ddf.get_division(-1)
+
+    with tm.assertRaises(ValueError):
+        ddf.get_division(3)
 
 
 def test_ndim():
@@ -646,8 +648,14 @@ def test_getitem():
                       columns=list('ABC'))
     ddf = dd.from_pandas(df, 2)
     assert eq(ddf['A'], df['A'])
+    tm.assert_series_equal(ddf['A']._pd, ddf._pd['A']) # check cache consistency
+
     assert eq(ddf[['A', 'B']], df[['A', 'B']])
+    tm.assert_frame_equal(ddf[['A', 'B']]._pd, ddf._pd[['A', 'B']])
+
     assert eq(ddf[ddf.C], df[df.C])
+    tm.assert_series_equal(ddf.C._pd, ddf._pd.C)
+
     assert eq(ddf[ddf.C.repartition([0, 2, 5, 8])], df[df.C])
 
     assert raises(KeyError, lambda: df['X'])
@@ -1151,7 +1159,6 @@ def test_sample():
 
     c = a.sample(0.5, random_state=1234)
     d = a.sample(0.5, random_state=1234)
-
     assert eq(c, d)
 
     assert a.sample(0.5)._name != a.sample(0.5)._name
@@ -1337,19 +1344,67 @@ def test_to_frame():
 
 def test_apply():
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
-    a = dd.from_pandas(df, npartitions=2)
+    ddf = dd.from_pandas(df, npartitions=2)
 
     func = lambda row: row['x'] + row['y']
-    eq(a.x.apply(lambda x: x + 1), df.x.apply(lambda x: x + 1))
+    assert eq(ddf.x.apply(lambda x: x + 1),
+              df.x.apply(lambda x: x + 1))
 
-    eq(a.apply(lambda xy: xy[0] + xy[1], axis=1, columns=None),
-       df.apply(lambda xy: xy[0] + xy[1], axis=1))
+    # specify columns
+    assert eq(ddf.apply(lambda xy: xy[0] + xy[1], axis=1, columns=None),
+              df.apply(lambda xy: xy[0] + xy[1], axis=1))
 
-    assert raises(NotImplementedError, lambda: a.apply(lambda xy: xy, axis=0))
-    assert raises(ValueError, lambda: a.apply(lambda xy: xy, axis=1))
+    # inferrence
+    assert eq(ddf.apply(lambda xy: xy[0] + xy[1], axis=1),
+              df.apply(lambda xy: xy[0] + xy[1], axis=1))
+    assert eq(ddf.apply(lambda xy: xy, axis=1),
+              df.apply(lambda xy: xy, axis=1))
 
+    # dataframe
     func = lambda x: pd.Series([x, x])
-    eq(a.x.apply(func, name=[0, 1]), df.x.apply(func))
+    assert eq(ddf.x.apply(func, name=[0, 1]), df.x.apply(func))
+    # inference
+    assert eq(ddf.x.apply(func), df.x.apply(func))
+
+    # axis=0
+    with tm.assertRaises(NotImplementedError):
+        ddf.apply(lambda xy: xy, axis=0)
+
+
+def test_apply_infer_columns():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    def return_df(x):
+        # will create new DataFrame which columns is ['sum', 'mean']
+        return pd.Series([x.sum(), x.mean()], index=['sum', 'mean'])
+
+    # DataFrame to completely different DataFrame
+    result = ddf.apply(return_df, axis=1)
+    assert isinstance(result, dd.DataFrame)
+    tm.assert_index_equal(result.columns, pd.Index(['sum', 'mean']))
+    assert eq(result, df.apply(return_df, axis=1))
+
+    # DataFrame to Series
+    result = ddf.apply(lambda x: 1, axis=1)
+    assert isinstance(result, dd.Series)
+    assert result.name is None
+    assert eq(result, df.apply(lambda x: 1, axis=1))
+
+    def return_df2(x):
+        return pd.Series([x * 2, x * 3], index=['x2', 'x3'])
+
+    # Series to completely different DataFrame
+    result = ddf.x.apply(return_df2)
+    assert isinstance(result, dd.DataFrame)
+    tm.assert_index_equal(result.columns, pd.Index(['x2', 'x3']))
+    assert eq(result, df.x.apply(return_df2))
+
+    # Series to Series
+    result = ddf.x.apply(lambda x: 1)
+    assert isinstance(result, dd.Series)
+    assert result.name == 'x'
+    assert eq(result, df.x.apply(lambda x: 1))
 
 
 def test_index_time_properties():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pandas.util.testing as tm
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal
 
 import dask
 from dask.async import get_sync
@@ -147,6 +146,21 @@ def test_set_index_raises_error_on_bad_input():
     ddf = dd.from_pandas(df, 2)
 
     assert raises(NotImplementedError, lambda: ddf.set_index(['a', 'b']))
+
+def test_rename_columns():
+    # GH 819,
+    df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
+                        'b': [7, 6, 5, 4, 3, 2, 1]})
+    ddf = dd.from_pandas(df, 2)
+
+    ddf.columns = ['x', 'y']
+    df.columns = ['x', 'y']
+    assert eq(ddf, df)
+
+    def len_mismatch():
+        ddf.columns = [1, 2, 3, 4]
+
+    assert raises(ValueError, lambda: len_mismatch())
 
 
 
@@ -1371,7 +1385,7 @@ def test_reset_index():
 
     assert len(res.index.compute()) == len(exp.index)
     tm.assert_index_equal(res.columns, exp.columns)
-    assert_array_almost_equal(res.compute().values, exp.values)
+    eq(res, exp)
 
 
 def test_dataframe_compute_forward_kwargs():

--- a/dask/dataframe/tests/test_demo.py
+++ b/dask/dataframe/tests/test_demo.py
@@ -9,7 +9,7 @@ def test_make_timeseries():
 
     assert df.divisions[0] == pd.Timestamp('2000-01-31', offset='6M')
     assert df.divisions[-1] == pd.Timestamp('2014-07-31', offset='6M')
-    assert df.columns == ('A', 'B', 'C')
+    tm.assert_index_equal(df.columns, pd.Index(['A', 'B', 'C']))
     assert df['A'].head().dtype == float
     assert df['B'].head().dtype == int
     assert df['C'].head().dtype == object

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -53,7 +53,7 @@ def test_read_csv(open_comp_pair, infer):
                 lineterminator='\n')
         assert list(f.columns) == ['name', 'amount']
         assert f.npartitions > 1
-        assert f._know_dtype
+        assert f._known_dtype
         result = f.compute(get=dask.get)
         # index may be different
         assert eq(result.reset_index(drop=True),
@@ -75,7 +75,7 @@ def test_read_multiple_csv():
         with open('_foo.2.csv', 'w') as f:
             f.write(text)
         df = dd.read_csv('_foo.*.csv')
-        assert df._know_dtype
+        assert df._known_dtype
 
         assert (len(read_csv('_foo.*.csv').compute()) ==
                 len(read_csv('_foo.1.csv').compute()) * 2)
@@ -102,7 +102,7 @@ def test_consistent_dtypes():
     with filetext(text) as fn:
         df = dd.read_csv(fn, chunkbytes=30)
         assert isinstance(df.amount.sum().compute(), float)
-        assert df._know_dtype
+        assert df._known_dtype
 
 datetime_csv_file = """
 name,amount,when
@@ -116,7 +116,7 @@ Dan,400,2014-01-01
 def test_read_csv_index():
     with filetext(text) as fn:
         f = dd.read_csv(fn, chunkbytes=20, index='amount')
-        assert f._know_dtype
+        assert f._known_dtype
         result = f.compute(get=get_sync)
         assert result.index.name == 'amount'
 
@@ -207,14 +207,14 @@ def test_from_array():
     x = np.arange(10 * 3).reshape(10, 3)
     d = dd.from_array(x, chunksize=4)
     assert isinstance(d, dd.DataFrame)
-    assert d._know_dtype
+    assert d._known_dtype
     tm.assert_index_equal(d.columns, pd.Index([0, 1, 2]))
     assert d.divisions == (0, 4, 8, 9)
     assert (d.compute().values == x).all()
 
     d = dd.from_array(x, chunksize=4, columns=list('abc'))
     assert isinstance(d, dd.DataFrame)
-    assert d._know_dtype
+    assert d._known_dtype
     tm.assert_index_equal(d.columns, pd.Index(['a', 'b', 'c']))
     assert d.divisions == (0, 4, 8, 9)
     assert (d.compute().values == x).all()
@@ -227,7 +227,7 @@ def test_from_array_with_record_dtype():
                  dtype=[('a', 'i4'), ('b', 'i4')])
     d = dd.from_array(x, chunksize=4)
     assert isinstance(d, dd.DataFrame)
-    assert d._know_dtype
+    assert d._known_dtype
     assert list(d.columns) == ['a', 'b']
     assert d.divisions == (0, 4, 8, 9)
 

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -234,31 +234,6 @@ def test_from_array_with_record_dtype():
     assert (d.compute().to_records(index=False) == x).all()
 
 
-def test_dummy_from_array():
-    x = np.array([[1, 2], [3, 4]], dtype=np.int64)
-    res = dd.io._dummy_from_array(x)
-    assert isinstance(res, pd.DataFrame)
-    assert res[0].dtype == np.int64
-    assert res[1].dtype == np.int64
-
-    x = np.array([[1., 2.], [3., 4.]], dtype=np.float64)
-    res = dd.io._dummy_from_array(x, columns=['a', 'b'])
-    assert isinstance(res, pd.DataFrame)
-    assert res['a'].dtype == np.float64
-    assert res['b'].dtype == np.float64
-
-    x = np.array([1., 2., 3.], dtype=np.float64)
-    res = dd.io._dummy_from_array(x)
-    assert isinstance(res, pd.Series)
-    assert res.dtype == np.float64
-
-    x = np.array([1, 2, 3], dtype=np.object_)
-    res = dd.io._dummy_from_array(x, columns='x')
-    assert isinstance(res, pd.Series)
-    assert res.name == 'x'
-    assert res.dtype == np.object_
-
-
 def test_from_bcolz_multiple_threads():
     bcolz = pytest.importorskip('bcolz')
 

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -238,8 +238,8 @@ def test_dummy_from_array():
     x = np.array([[1, 2], [3, 4]], dtype=np.int64)
     res = dd.io._dummy_from_array(x)
     assert isinstance(res, pd.DataFrame)
-    assert res['0'].dtype == np.int64
-    assert res['1'].dtype == np.int64
+    assert res[0].dtype == np.int64
+    assert res[1].dtype == np.int64
 
     x = np.array([[1., 2.], [3., 4.]], dtype=np.float64)
     res = dd.io._dummy_from_array(x, columns=['a', 'b'])

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -426,14 +426,14 @@ def test_DataFrame_from_dask_array():
 
     df = from_dask_array(x, ['a', 'b', 'c'])
     assert isinstance(df, dd.DataFrame)
-    assert df.columns == ('a', 'b', 'c')
+    tm.assert_index_equal(df.columns, pd.Index(['a', 'b', 'c']))
     assert list(df.divisions) == [0, 4, 8, 9]
     assert (df.compute(get=get_sync).values == x.compute(get=get_sync)).all()
 
     # dd.from_array should re-route to from_dask_array
     df2 = dd.from_array(x, columns=['a', 'b', 'c'])
     assert isinstance(df, dd.DataFrame)
-    assert df2.columns == df.columns
+    tm.assert_index_equal(df2.columns, df.columns)
     assert df2.divisions == df.divisions
 
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -208,7 +208,9 @@ def test_concat():
 
     for (dd1, dd2, pd1, pd2) in [(ddf1, ddf2, pdf1, pdf2),
                                  (ddf1, ddf3, pdf1, pdf3)]:
+        print(1)
         for join in ['inner', 'outer']:
+            print(join)
             result = dd.concat([dd1, dd2], join=join)
             expected = pd.concat([pd1, pd2], join=join)
             assert eq(result, expected)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -115,9 +115,9 @@ def _check_dask(dsk, check_names=True):
                 assert dsk.name == result.name, (dsk.name, result.name)
         elif isinstance(dsk, dd.DataFrame):
             assert isinstance(result, pd.DataFrame), type(result)
-            assert isinstance(dsk.columns, tuple)
+            assert isinstance(dsk.columns, pd.Index), type(dsk.columns)
             if check_names:
-                columns = pd.Index(dsk.columns)
+                columns = dsk.columns
                 tm.assert_index_equal(columns, result.columns)
         elif isinstance(dsk, dd.core.Scalar):
             assert (np.isscalar(result) or

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -119,7 +119,7 @@ def _check_dask(dsk, check_names=True):
             assert isinstance(result, pd.DataFrame), type(result)
             assert isinstance(dsk._pd, pd.DataFrame), type(dsk._pd)
             assert isinstance(dsk.columns, pd.Index), type(dsk.columns)
-            # tm.assert_index_equal(dsk.columns, result.columns)
+            tm.assert_index_equal(dsk.columns, result.columns)
             if check_names:
                 columns = dsk.columns
                 tm.assert_index_equal(columns, result.columns)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -109,20 +109,29 @@ def _check_dask(dsk, check_names=True):
         result = dsk.compute(get=get_sync)
         if isinstance(dsk, dd.Index):
             assert isinstance(result, pd.Index), type(result)
+            if check_names:
+                assert dsk.name == result.name
+            # cache
             assert isinstance(dsk._pd, pd.Index), type(dsk._pd)
+            if check_names:
+                assert dsk._pd.name == result.name
         elif isinstance(dsk, dd.Series):
             assert isinstance(result, pd.Series), type(result)
-            assert isinstance(dsk._pd, pd.Series), type(dsk._pd)
             if check_names:
                 assert dsk.name == result.name, (dsk.name, result.name)
+            # cache
+            assert isinstance(dsk._pd, pd.Series), type(dsk._pd)
+            if check_names:
+                assert dsk._pd.name == result.name
         elif isinstance(dsk, dd.DataFrame):
             assert isinstance(result, pd.DataFrame), type(result)
-            assert isinstance(dsk._pd, pd.DataFrame), type(dsk._pd)
             assert isinstance(dsk.columns, pd.Index), type(dsk.columns)
-            tm.assert_index_equal(dsk.columns, result.columns)
             if check_names:
-                columns = dsk.columns
-                tm.assert_index_equal(columns, result.columns)
+                tm.assert_index_equal(dsk.columns, result.columns)
+            # cache
+            assert isinstance(dsk._pd, pd.DataFrame), type(dsk._pd)
+            if check_names:
+                tm.assert_index_equal(dsk._pd.columns, result.columns)
         elif isinstance(dsk, dd.core.Scalar):
             assert (np.isscalar(result) or
                     isinstance(result, (pd.Timestamp, pd.Timedelta)))
@@ -173,6 +182,7 @@ def eq(a, b, check_names=True, **kwargs):
             else:
                 assert np.allclose(a, b)
     return True
+
 
 def assert_dask_graph(dask, label):
     if hasattr(dask, 'dask'):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -108,14 +108,18 @@ def _check_dask(dsk, check_names=True):
     if hasattr(dsk, 'dask'):
         result = dsk.compute(get=get_sync)
         if isinstance(dsk, dd.Index):
-            assert isinstance(result, pd.Index)
+            assert isinstance(result, pd.Index), type(result)
+            assert isinstance(dsk._pd, pd.Index), type(dsk._pd)
         elif isinstance(dsk, dd.Series):
-            assert isinstance(result, pd.Series)
+            assert isinstance(result, pd.Series), type(result)
+            assert isinstance(dsk._pd, pd.Series), type(dsk._pd)
             if check_names:
                 assert dsk.name == result.name, (dsk.name, result.name)
         elif isinstance(dsk, dd.DataFrame):
             assert isinstance(result, pd.DataFrame), type(result)
+            assert isinstance(dsk._pd, pd.DataFrame), type(dsk._pd)
             assert isinstance(dsk.columns, pd.Index), type(dsk.columns)
+            # tm.assert_index_equal(dsk.columns, result.columns)
             if check_names:
                 columns = dsk.columns
                 tm.assert_index_equal(columns, result.columns)


### PR DESCRIPTION
Closes #956. Closes #812. Closes #819.

Currently, ``dd.DataFrame`` accepts ``list/tuple`` and ``dd.Series`` accepts ``name`` as metadata. 

This PR allows ``dd.DataFrame/dd.Series`` to be initialized by ``pd.DataFrame/pd.Series`` to preserve required metadata without increasing other metadata-related keywords. ``dd.DataFrame/dd.Series`` preserves empty ``pd.DataFrame/pd.Series`` to store all available metadata and give it to newly created instances via ``dask`` operations. 

Also, ``dd.DataFarme.columns`` is changed to return ``pd.Index`` rather than ``tuple``.

If this approach looks fine, I'll fix:

- Rename ``_empty_partition`` to ``_metadata`` and merge the logic, as both should return empty ``pd.DataFrame/pd.Series``
- Simplyfy ``_get_return_type`` specification.