### PR TITLE
Add conda recipes

### DIFF
--- a/conda-recipes/README.md
+++ b/conda-recipes/README.md
@@ -1,0 +1,26 @@
+## Building conda packages
+
+Conda packages for dask can be built on CentOS 5.8 (ami-15bad87c) using the
+following commands:
+
+```
+export CONDA_DIR=~/miniconda2
+
+yum install epel-release -y
+yum install git-all -y
+
+curl http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -o ~/miniconda.sh
+bash ~/miniconda.sh -b -p $CONDA_DIR
+$CONDA_DIR/bin/conda install conda-build anaconda-client -y
+
+git clone https://github.com/dask/dask.git ~/dask
+cd ~/dask/conda-recipes
+$CONDA_DIR/bin/conda build dask --python 2.7 --python 3.4 --python 3.5
+
+cd $CONDA_DIR/conda-bld/linux-64
+$CONDA_DIR/bin/conda convert --platform osx-64 *.tar.bz2 -o ../
+$CONDA_DIR/bin/conda convert --platform win-64 *.tar.bz2 -o ../
+
+$CONDA_DIR/bin/anaconda login
+$CONDA_DIR/bin/anaconda upload $CONDA_DIR/conda-bld/*/*.tar.bz2 -u dask
+```

--- a/conda-recipes/dask/bld.bat
+++ b/conda-recipes/dask/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda-recipes/dask/build.sh
+++ b/conda-recipes/dask/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda-recipes/dask/meta.yaml
+++ b/conda-recipes/dask/meta.yaml
@@ -1,0 +1,36 @@
+package:
+  name: dask
+  version: "0.8.0"
+
+source:
+  path: ../..
+
+requirements:
+  build:
+    - python
+    - cloudpickle
+    - numpy
+    - pandas
+    - partd
+    - toolz
+  run:
+    - python
+    - cloudpickle
+    - numpy
+    - pandas
+    - partd
+    - toolz
+
+test:
+  imports:
+    - dask
+    - dask.array
+    - dask.bag
+    - dask.dataframe
+    - dask.diagnostics
+    - dask.store
+
+about:
+  home: http://github.com/dask/dask/
+  license: BSD
+  summary: 'Minimal task scheduling abstraction'


### PR DESCRIPTION
Conda packages for dask 0.8.0 built and available on the `dask` channel on anaconda.org for win-64, linux-64, and osx-64 for Python 2.7, 3.4, and 3.5:

```
conda install dask -c dask
```