### PR TITLE
Update conda recipe

### DIFF
--- a/conda.recipe/README.md
+++ b/conda.recipe/README.md
@@ -1,0 +1,26 @@
+## Building conda packages
+
+Conda packages for dask can be built on linux-64 (tested on Ubuntu 14.04) using
+the following commands:
+
+```
+export CONDA_DIR=~/miniconda2
+
+sudo apt-get update
+sudo apt-get install git -y
+
+curl http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -o ~/miniconda.sh
+bash ~/miniconda.sh -b -p $CONDA_DIR
+$CONDA_DIR/bin/conda install conda-build anaconda-client -y
+
+git clone https://github.com/dask/dask.git ~/dask
+cd ~/dask
+$CONDA_DIR/bin/conda build conda.recipe --python 2.6 --python 2.7 --python 3.4 --python 3.5
+
+cd $CONDA_DIR/conda-bld/linux-64
+$CONDA_DIR/bin/conda convert --platform osx-64 *.tar.bz2 -o ../
+$CONDA_DIR/bin/conda convert --platform win-64 *.tar.bz2 -o ../
+
+$CONDA_DIR/bin/anaconda login
+$CONDA_DIR/bin/anaconda upload $CONDA_DIR/conda-bld/*/*.tar.bz2 -u dask
+```

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,18 +19,20 @@ requirements:
 
   run:
     - python
-    - toolz
+    - bokeh # [not py26]
+    - chest
+    - cloudpickle
     - numpy
     - pandas
-    - cloudpickle
     - partd
-    - chest
-    - bokeh # [not py26]
     - psutil
+    - toolz
 
 test:
   requires:
     - pytest
+    - numexpr
+    - scipy
 
 about:
   home: https://github.com/dask/dask

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -3,6 +3,5 @@ from os import environ, path
 
 import pytest
 
-
 out = pytest.main(['-vv', path.join(environ['SRC_DIR'], 'dask')])
 sys.exit(out)


### PR DESCRIPTION
* Add conda recipe README
* Add py.test dependencies (`numexpr` and `scipy`) to conda recipe

Conda packages for dask 0.8.0 are available in the `dask` channel on anaconda.org for linux-64, osx-64, and win-64 for Python 2.6, 2.7, 3.4, and 3.5.

```
conda install dask -c dask
```