### PR TITLE
Tell setuptools that dask.imperative requires toolz

### DIFF
--- a/dask/tests/test_imperative.py
+++ b/dask/tests/test_imperative.py
@@ -178,11 +178,10 @@ def test_kwargs():
     assert ten.compute() == 10
 
 
-da = pytest.importorskip('dask.array')
-import numpy as np
-
-
 def test_array_imperative():
+    np = pytest.importorskip('numpy')
+    da = pytest.importorskip('dask.array')
+
     arr = np.arange(100).reshape((10, 10))
     darr = da.from_array(arr, chunks=(5, 5))
     val = do(sum)([arr, darr, 1])
@@ -200,10 +199,11 @@ def test_array_imperative():
     assert len(diff) == 1
 
 
-db = pytest.importorskip('dask.bag')
-
-
 def test_array_bag_imperative():
+    db = pytest.importorskip('dask.bag')
+    da = pytest.importorskip('dask.array')
+    np = pytest.importorskip('numpy')
+
     arr1 = np.arange(100).reshape((10, 10))
     arr2 = arr1.dot(arr1.T)
     darr1 = da.from_array(arr1, chunks=(5, 5))

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ extras_require = {
   'array': ['numpy', 'toolz >= 0.7.2'],
   'bag': ['cloudpickle', 'toolz >= 0.7.2', 'partd >= 0.3.2'],
   'dataframe': ['numpy', 'pandas >= 0.16.0', 'toolz >= 0.7.2', 'partd >= 0.3.2'],
+  'imperative': ['toolz >= 0.7.2'],
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 


### PR DESCRIPTION
I tested the change with this script:

```bash
#!/bin/bash

set -v
test -d testenv && exit 1

set +v
virtualenv testenv
source testenv/bin/activate

set -ev

pip install .[imperative]
pip freeze

pip install pytest
py.test dask/tests/test_imperative.py

set +ev
deactivate
set -v
rm -rf testenv
```

The tests had to be fixed up a bit so that they would run when dask.array and dask.bag are missing requirements.

I don't really see an easy way to add this sort of thing to the test suite, so I didn't :-P  But it's fixed right now!