### PR TITLE
Propagate metadata in dask.dataframe functions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1813,7 +1813,6 @@ def apply_concat_apply(args, chunk=None, aggregate=None,
 
     Parameters
     ----------
-
     args: dask.DataFrames
         All Dataframes should be partitioned and indexed equivalently
     chunk: function [block-per-arg] -> block
@@ -1821,6 +1820,8 @@ def apply_concat_apply(args, chunk=None, aggregate=None,
     aggregate: function concatenated-block -> block
         Function to operate on the concatenated result of chunk
 
+    Examples
+    --------
     >>> def chunk(a_block, b_block):
     ...     pass
 
@@ -1839,9 +1840,13 @@ def apply_concat_apply(args, chunk=None, aggregate=None,
     token = token or 'apply-concat-apply'
 
     a = '{0}--first-{1}'.format(token, token_key)
-    dsk = dict(((a, i), (apply, chunk, (list, [(x._name, i)
-                                               if isinstance(x, _Frame)
-                                               else x for x in args])))
+    if len(args) == 1 and isinstance(args[0], _Frame):
+        dsk = dict(((a, i), (chunk, key))
+                   for i, key in enumerate(args[0]._keys()))
+    else:
+        dsk = dict(((a, i), (apply, chunk, [(x._name, i)
+                                            if isinstance(x, _Frame)
+                                            else x for x in args]))
                for i in range(args[0].npartitions))
 
     b = '{0}--second-{1}'.format(token, token_key)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1149,7 +1149,7 @@ class Series(_Frame):
     @derived_from(pd.Series)
     def to_frame(self, name=None):
         _name = name if name is not None else self.name
-        return map_partitions(pd.Series.to_frame, [_name], self, name)
+        return map_partitions(pd.Series.to_frame, self._pd.to_frame(name), self, name)
 
     @classmethod
     def _bind_operator_method(cls, name, op):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1336,6 +1336,7 @@ def test_to_frame():
     s = pd.Series([1, 2, 3], name='foo')
     a = dd.from_pandas(s, npartitions=2)
 
+    assert a.to_frame()._known_dtype
     assert eq(s.to_frame(), a.to_frame())
     assert eq(s.to_frame('bar'), a.to_frame('bar'))
 

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -655,6 +655,7 @@ def test_read_hdf():
         df.to_hdf(fn, '/data', format='table')
         a = dd.read_hdf(fn, '/data', chunksize=2)
         assert a.npartitions == 2
+        assert a._known_dtype
 
         tm.assert_frame_equal(a.compute(), df)
 


### PR DESCRIPTION
Following on from https://github.com/dask/dask/pull/961 .  This propagates full metadata rather than just columns in read_hdf and to_frame.  There are likely several cases like this we'll need to complete over time.