### PR TITLE
ENH: Add drop option to set_index

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1335,9 +1335,9 @@ class DataFrame(_Frame):
             return self._pd_cache.dtypes
 
     @derived_from(pd.DataFrame)
-    def set_index(self, other, **kwargs):
+    def set_index(self, other, drop=True, **kwargs):
         from .shuffle import set_index
-        return set_index(self, other, **kwargs)
+        return set_index(self, other, drop=drop, **kwargs)
 
     def set_partition(self, column, divisions, **kwargs):
         """ Set explicit divisions for new column index

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -137,13 +137,47 @@ def test_set_index():
     assert d4.index.name == 'b'
     assert eq(d4, full.set_index('b'))
 
+@pytest.mark.parametrize('drop', [True, False])
+def test_set_index_drop(drop):
+
+    pdf = pd.DataFrame({'A': list('ABAABBABAA'),
+                        'B': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                        'C': [1, 2, 3, 2, 1, 3, 2, 4, 2, 3]})
+    ddf = dd.from_pandas(pdf, 3)
+
+    assert eq(ddf.set_index('A', drop=drop),
+              pdf.set_index('A', drop=drop))
+    assert eq(ddf.set_index('B', drop=drop),
+              pdf.set_index('B', drop=drop))
+    assert eq(ddf.set_index('C', drop=drop),
+              pdf.set_index('C', drop=drop))
+    assert eq(ddf.set_index(ddf.A, drop=drop),
+              pdf.set_index(pdf.A, drop=drop))
+    assert eq(ddf.set_index(ddf.B, drop=drop),
+              pdf.set_index(pdf.B, drop=drop))
+    assert eq(ddf.set_index(ddf.C, drop=drop),
+              pdf.set_index(pdf.C, drop=drop))
+
+    # numeric columns
+    pdf = pd.DataFrame({0: list('ABAABBABAA'),
+                        1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                        2: [1, 2, 3, 2, 1, 3, 2, 4, 2, 3]})
+    ddf = dd.from_pandas(pdf, 3)
+    assert eq(ddf.set_index(0, drop=drop),
+              pdf.set_index(0, drop=drop))
+    assert eq(ddf.set_index(2, drop=drop),
+              pdf.set_index(2, drop=drop))
+
 
 def test_set_index_raises_error_on_bad_input():
     df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
                         'b': [7, 6, 5, 4, 3, 2, 1]})
     ddf = dd.from_pandas(df, 2)
 
-    assert raises(NotImplementedError, lambda: ddf.set_index(['a', 'b']))
+    msg = r"Dask dataframe does not yet support multi-indexes"
+    with tm.assertRaisesRegexp(NotImplementedError, msg):
+        ddf.set_index(['a', 'b'])
+
 
 def test_rename_columns():
     # GH 819


### PR DESCRIPTION
```
df = pd.DataFrame({'X': ["A", "B", "A", "B", "A"], 'Y': [1, 2, 3, 4, 5]})
ddf = dd.from_pandas(df, 2)
ddf.set_index('X', drop=False).compute()
#    X  Y
# X      
# A  A  1
# A  A  3
# B  B  2
# A  A  5
# B  B  4
```