### PR TITLE
Bag speedups

### DIFF
--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -189,8 +189,11 @@ def test_frequencies():
 
 def test_topk():
     assert list(b.topk(4)) == [4, 4, 4, 3]
-    assert list(b.topk(4, key=lambda x: -x).compute(get=dask.get)) == \
-            [0, 0, 0, 1]
+    c = b.topk(4, key=lambda x: -x)
+    assert list(c) == [0, 0, 0, 1]
+    c2 = b.topk(4, key=lambda x: -x, split_every=2)
+    assert list(c2) == [0, 0, 0, 1]
+    assert c.name != c2.name
     assert b.topk(4).name == b.topk(4).name
 
 


### PR DESCRIPTION
A few speedups and cleanups for `dask.bag`

- Previously results of the map step of `frequencies` were passed around as lists of tuples, and were repeatedly transformed into dicts, then back into lists during each reduction step. For large dicts, this was very expensive (45 seconds for the enron dataset for each intermediate). Switching to passing around dicts as intermediates drops this to only 5 seconds.

- No longer use `toolz.merge_with` to merge frequencies. This function created a list of all the values for each key, then applies `sum` to them. This is less efficient than just manually incrementing counts.

- Move `topk` to use the `reduction` interface. It now takes the `split_every` keyword, like all the other reductions.

These changes result in a drop from 12:40 to 7:30 for doing wordcount on the enron emails on my laptop.

I also removed some dead imports/code, and made some pep8 cleanups.