### PR TITLE
FIX: bcolz indexing

### DIFF
--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -276,6 +276,8 @@ def test_from_bcolz():
     assert str(d.dtypes['a']) == 'category'
     assert list(d.x.compute(get=get_sync)) == [1, 2, 3]
     assert list(d.a.compute(get=get_sync)) == ['a', 'b', 'a']
+    L = list(d.index.compute(get=get_sync))
+    assert L == [0, 1, 2]
 
     d = dd.from_bcolz(t, chunksize=2, index='x')
     L = list(d.index.compute(get=get_sync))


### PR DESCRIPTION
Hello, 

I was playing with `dataframe.from_bcolz` and realized that the indexing is screwed up. The `divisions` are different than what you have in `dataframe.from_pandas`. More critically, the indices repeat from chunk to chunk which causes `dataframe.concat`to not be able to concat properly when you have more than 1 chunk.

Thanks for your consideration.