### PR TITLE
WIP/RFC: add watch mode to Profiler

### DIFF
--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -88,9 +88,8 @@ class Profiler(Callback):
         data += (end, id)
         task_data = TaskData(*data)
         self.results.append(task_data)
-        # TODO: we really should coalesce updates to reduce notebook load when
-        # a lot of short tasks finish quickly
-        self.update_plot()
+        if self._tasks_plot:
+            self._tasks_plot.update_task(task_data, self._dsk)
 
     def _finish(self, dsk, state, failed):
         self._results.clear()
@@ -100,10 +99,6 @@ class Profiler(Callback):
         self._tasks_plot = TasksPlot(**kwargs)
         self._tasks_plot.update(self.results, self._dsk, push=False)
         return self._tasks_plot.plot
-
-    def update_plot(self):
-        if self._tasks_plot:
-            self._tasks_plot.update(self.results, self._dsk)
 
     def visualize(self, **kwargs):
         """Visualize the profiling run in a bokeh plot.

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -57,7 +57,7 @@ class Profiler(Callback):
         self._results = {}
         self.results = []
         self._dsk = {}
-        self._update = None
+        self._tasks_plot = None
         self.watch = watch
         self.watching = False
 
@@ -70,7 +70,7 @@ class Profiler(Callback):
 
     def __exit__(self, exc_type, exc_val, tb):
         self.watching = False
-        self._update = None
+        self._tasks_plot = None
 
     def _start(self, dsk):
         self._dsk.update(dsk)
@@ -96,15 +96,14 @@ class Profiler(Callback):
         self._results.clear()
 
     def _plot(self, **kwargs):
-        from .profile_visualize import plot_tasks
-        p, update = plot_tasks(**kwargs)
-        self._update = update
-        self._update(self.results, self._dsk, push=False)
-        return p
+        from .profile_visualize import TasksPlot
+        self._tasks_plot = TasksPlot(**kwargs)
+        self._tasks_plot.update(self.results, self._dsk, push=False)
+        return self._tasks_plot.plot
 
     def update_plot(self):
-        if self._update:
-            self._update(self.results, self._dsk)
+        if self._tasks_plot:
+            self._tasks_plot.update(self.results, self._dsk)
 
     def visualize(self, **kwargs):
         """Visualize the profiling run in a bokeh plot.
@@ -123,7 +122,7 @@ class Profiler(Callback):
         del self.results[:]
         self._dsk = {}
         self.watching = False
-        self._update = None
+        self._tasks_plot = None
 
 
 ResourceData = namedtuple('ResourceData', ('time', 'mem', 'cpu'))

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -53,16 +53,20 @@ class Profiler(Callback):
     >>> prof.clear()
 
     """
-    def __init__(self):
+    def __init__(self, watch=False):
         self._results = {}
         self.results = []
         self._dsk = {}
         self._update = None
+        self.watch = watch
         self.watching = False
 
     def __enter__(self):
         self.clear()
-        return super(Profiler, self).__enter__()
+        r = super(Profiler, self).__enter__()
+        if self.watch:
+            self.visualize(watch=True)
+        return r
 
     def __exit__(self, exc_type, exc_val, tb):
         self.watching = False

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -71,11 +71,15 @@ class Profiler(Callback):
 
     def _posttask(self, key, value, dsk, state, id):
         end = default_timer()
-        self._results[key] += (end, id)
+        try:
+            data = self._results.pop(key)
+        except KeyError:
+            return
+        data += (end, id)
+        task_data = TaskData(*data)
+        self.results.append(task_data)
 
     def _finish(self, dsk, state, failed):
-        results = dict((k, v) for k, v in self._results.items() if len(v) == 5)
-        self.results += list(starmap(TaskData, results.values()))
         self._results.clear()
 
     def _plot(self, **kwargs):

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -84,6 +84,8 @@ class Profiler(Callback):
         data += (end, id)
         task_data = TaskData(*data)
         self.results.append(task_data)
+        # TODO: we really should coalesce updates to reduce notebook load when
+        # a lot of short tasks finish quickly
         self.update_plot()
 
     def _finish(self, dsk, state, failed):

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -289,10 +289,12 @@ class TasksPlot(object):
         left = min(starts)
         # right = max(ends)
 
-        data['width'] = width = [e - s for (s, e) in zip(starts, ends)]
+        funcs = [pprint_task(i, dsk, self.label_size) for i in tasks]
+        width = [e - s for (s, e) in zip(starts, ends)]
+        data['width'] = width
         data['x'] = [w/2 + s - left for (w, s) in zip(width, starts)]
         data['y'] = [id_lk[i] + 1 for i in ids]
-        data['function'] = funcs = [pprint_task(i, dsk, self.label_size) for i in tasks]
+        data['function'] = funcs
         data['color'] = get_colors(self.palette, funcs)
         data['key'] = [str(i) for i in keys]
 

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -4,6 +4,7 @@ from itertools import cycle
 from operator import itemgetter, add
 
 from toolz import unique, groupby, accumulate, pluck
+from toolz.compatibility import iteritems, zip
 import bokeh.plotting as bp
 from bokeh.io import _state, push_notebook
 from bokeh.palettes import brewer
@@ -258,10 +259,11 @@ def plot_tasks(palette='YlGnBu', label_size=60, **kwargs):
         keys, tasks, starts, ends, ids = zip(*results)
 
         id_group = groupby(itemgetter(4), results)
-        timings = dict((k, [i.end_time - i.start_time for i in v]) for (k, v) in
-                    id_group.items())
-        id_lk = dict((t[0], n) for (n, t) in enumerate(sorted(timings.items(),
-                    key=itemgetter(1), reverse=True)))
+        timings = ((k, [i.end_time - i.start_time for i in v])
+                   for (k, v) in iteritems(id_group))
+        timings = sorted(timings, key=itemgetter(1), reverse=True)
+
+        id_lk = dict((t[0], n) for (n, t) in enumerate(timings))
 
         left = min(starts)
         # right = max(ends)

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -5,7 +5,7 @@ from operator import itemgetter, add
 
 from toolz import unique, groupby, accumulate, pluck
 import bokeh.plotting as bp
-from bokeh.io import _state
+from bokeh.io import _state, push_notebook
 from bokeh.palettes import brewer
 from bokeh.models import HoverTool, LinearAxis, Range1d
 
@@ -233,7 +233,7 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
     r = p.rect(source=source, x='x', y='y', height=1, width='width',
         color='color', line_color='gray')
 
-    def update(results, dsk):
+    def update(results, dsk, push=True):
         data = r.data_source.data
 
         if not results:
@@ -263,6 +263,10 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
         data['color'] = get_colors(palette, funcs)
         data['key'] = [str(i) for i in keys]
 
+        if push and _state._notebook:
+            # TODO: verify last plot is p-ish
+            push_notebook()
+
     p.grid.grid_line_color = None
     p.axis.axis_line_color = None
     p.axis.major_tick_line_color = None
@@ -282,7 +286,7 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
     """
     hover.point_policy = 'follow_mouse'
 
-    update(results, dsk)
+    update(results, dsk, push=False)
     return p
 
 

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -195,15 +195,11 @@ def visualize(profilers, file_path=None, show=True, save=True, **kwargs):
     return p
 
 
-def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
+def plot_tasks(palette='YlGnBu', label_size=60, **kwargs):
     """Visualize the results of profiling in a bokeh plot.
 
     Parameters
     ----------
-    results : sequence
-        Output of Profiler.results
-    dsk : dict
-        The dask graph being profiled.
     palette : string, optional
         Name of the bokeh palette to use, must be key in bokeh.palettes.brewer.
     label_size: int (optional)
@@ -234,6 +230,20 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
         color='color', line_color='gray')
 
     def update(results, dsk, push=True):
+        '''
+        Update the task plot data source
+
+        Parameters
+        ----------
+        results : sequence
+            Output of Profiler.results
+        dsk : dict
+            The dask graph being profiled.
+        push : bool, optional
+            If True (the default) call bokeh.io.push_notebook(); useful to set
+            this False for the first update before output_notebook() has
+            happened.
+        '''
         data = r.data_source.data
 
         if not results:
@@ -286,8 +296,7 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
     """
     hover.point_policy = 'follow_mouse'
 
-    update(results, dsk, push=False)
-    return p
+    return p, update
 
 
 def plot_resources(results, palette='YlGnBu', **kwargs):

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -231,6 +231,7 @@ class TasksPlot(object):
         self.plot.yaxis.axis_label = "Worker ID"
         self.plot.xaxis.axis_label = "Time (s)"
 
+        self.worker_y = {}
         self.left = None
         self.worker_tasks = defaultdict(list)
 
@@ -248,7 +249,7 @@ class TasksPlot(object):
         hover.point_policy = 'follow_mouse'
 
         # TODO: was there any benefit to the discrete y_range:
-        # y_range=[str(i) for i in range(len(id_lk))], x_range=[0, right - left]
+        # y_range=[str(i) for i in range(len(self.worker_y))], x_range=[0, right - left]
 
         self.rect = self.plot.rect(
             source=bp.ColumnDataSource(data={}),
@@ -290,14 +291,13 @@ class TasksPlot(object):
                    for (k, v) in iteritems(self.worker_tasks))
         timings = sorted(timings, key=itemgetter(1), reverse=True)
 
-        id_lk = dict((t[0], n) for (n, t) in enumerate(timings))
-
+        self.worker_y = dict((t[0], n) for (n, t) in enumerate(timings))
         self.left = min(starts)
         funcs = [pprint_task(i, dsk, self.label_size) for i in tasks]
         width = [e - s for (s, e) in zip(starts, ends)]
         data['width'] = width
         data['x'] = [w/2 + s - self.left for (w, s) in zip(width, starts)]
-        data['y'] = [id_lk[i] + 1 for i in ids]
+        data['y'] = [self.worker_y[i] + 1 for i in ids]
         data['function'] = funcs
         data['color'] = get_colors(self.palette, funcs)
         data['key'] = [str(i) for i in keys]

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -230,9 +230,11 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
     # y_range=[str(i) for i in range(len(id_lk))], x_range=[0, right - left]
 
     source = bp.ColumnDataSource(data={})
+    r = p.rect(source=source, x='x', y='y', height=1, width='width',
+        color='color', line_color='gray')
 
     if results:
-        data = source.data
+        data = r.data_source.data
         keys, tasks, starts, ends, ids = zip(*results)
 
         id_group = groupby(itemgetter(4), results)
@@ -250,9 +252,6 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
         data['function'] = funcs = [pprint_task(i, dsk, label_size) for i in tasks]
         data['color'] = get_colors(palette, funcs)
         data['key'] = [str(i) for i in keys]
-
-        p.rect(source=source, x='x', y='y', height=1, width='width',
-            color='color', line_color='gray')
 
     p.grid.grid_line_color = None
     p.axis.axis_line_color = None

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -256,6 +256,25 @@ class TasksPlot(object):
             x='x', y='y', height=1, width='width',
             color='color', line_color='gray')
 
+    def update_task(self, task, dsk, push=True):
+        if self.left is None:
+            self.left = task.start_time
+        if task.worker_id not in self.worker_y:
+            self.worker_y[task.worker_id] = len(self.worker_y)
+        width = task.end_time - task.start_time
+        func = pprint_task(task.task, dsk, self.label_size)
+        data = self.rect.data_source.data
+        data['width'].append(width)
+        data['x'].append(width / 2 + task.start_time - self.left)
+        data['y'].append(self.worker_y[task.worker_id] + 1)
+        data['function'].append(func)
+        data['color'] = get_colors(self.palette, data['function'])
+        data['key'].append(str(task.key))
+
+        if push and _state._notebook:
+            # TODO: verify last plot is p-ish
+            push_notebook()
+
     def update(self, results, dsk, push=True):
         '''
         Update the task plot data source

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -231,6 +231,7 @@ class TasksPlot(object):
         self.plot.yaxis.axis_label = "Worker ID"
         self.plot.xaxis.axis_label = "Time (s)"
 
+        self.left = None
         self.worker_tasks = defaultdict(list)
 
         hover = self.plot.select(HoverTool)
@@ -291,13 +292,11 @@ class TasksPlot(object):
 
         id_lk = dict((t[0], n) for (n, t) in enumerate(timings))
 
-        left = min(starts)
-        # right = max(ends)
-
+        self.left = min(starts)
         funcs = [pprint_task(i, dsk, self.label_size) for i in tasks]
         width = [e - s for (s, e) in zip(starts, ends)]
         data['width'] = width
-        data['x'] = [w/2 + s - left for (w, s) in zip(width, starts)]
+        data['x'] = [w/2 + s - self.left for (w, s) in zip(width, starts)]
         data['y'] = [id_lk[i] + 1 for i in ids]
         data['function'] = funcs
         data['color'] = get_colors(self.palette, funcs)

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -233,8 +233,18 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
     r = p.rect(source=source, x='x', y='y', height=1, width='width',
         color='color', line_color='gray')
 
-    if results:
+    def update(results, dsk):
         data = r.data_source.data
+
+        if not results:
+            data['width'] = []
+            data['x'] = []
+            data['y'] = []
+            data['function'] = []
+            data['color'] = []
+            data['key'] = []
+            return
+
         keys, tasks, starts, ends, ids = zip(*results)
 
         id_group = groupby(itemgetter(4), results)
@@ -272,6 +282,7 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
     """
     hover.point_policy = 'follow_mouse'
 
+    update(results, dsk)
     return p
 
 

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -229,7 +229,10 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
     # TODO: was there any benefit to the discrete y_range:
     # y_range=[str(i) for i in range(len(id_lk))], x_range=[0, right - left]
 
+    source = bp.ColumnDataSource(data={})
+
     if results:
+        data = source.data
         keys, tasks, starts, ends, ids = zip(*results)
 
         id_group = groupby(itemgetter(4), results)
@@ -241,15 +244,12 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
         left = min(starts)
         # right = max(ends)
 
-        data = {}
         data['width'] = width = [e - s for (s, e) in zip(starts, ends)]
         data['x'] = [w/2 + s - left for (w, s) in zip(width, starts)]
         data['y'] = [id_lk[i] + 1 for i in ids]
         data['function'] = funcs = [pprint_task(i, dsk, label_size) for i in tasks]
         data['color'] = get_colors(palette, funcs)
         data['key'] = [str(i) for i in keys]
-
-        source = bp.ColumnDataSource(data=data)
 
         p.rect(source=source, x='x', y='y', height=1, width='width',
             color='color', line_color='gray')

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from collections import defaultdict
 from itertools import cycle
 from operator import itemgetter, add
 
@@ -230,6 +231,8 @@ class TasksPlot(object):
         self.plot.yaxis.axis_label = "Worker ID"
         self.plot.xaxis.axis_label = "Time (s)"
 
+        self.worker_tasks = defaultdict(list)
+
         hover = self.plot.select(HoverTool)
         hover.tooltips = """
         <div>
@@ -277,11 +280,13 @@ class TasksPlot(object):
             data['key'] = []
             return
 
+        for task in results:
+            self.worker_tasks[task.id].append(task)
+
         keys, tasks, starts, ends, ids = zip(*results)
 
-        id_group = groupby(itemgetter(4), results)
         timings = ((k, [i.end_time - i.start_time for i in v])
-                   for (k, v) in iteritems(id_group))
+                   for (k, v) in iteritems(self.worker_tasks))
         timings = sorted(timings, key=itemgetter(1), reverse=True)
 
         id_lk = dict((t[0], n) for (n, t) in enumerate(timings))

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -230,6 +230,10 @@ def plot_tasks(palette='YlGnBu', label_size=60, **kwargs):
     r = p.rect(source=source, x='x', y='y', height=1, width='width',
         color='color', line_color='gray')
 
+    # TODO: reify this closure, maybe even rework to get direct pre/post task
+    # callbacks so we can cause even less churn to the plot data, plus show
+    # ongoing tasks somehow
+
     def update(results, dsk, push=True):
         '''
         Update the task plot data source

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -223,6 +223,12 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
     defaults.update((k, v) for (k, v) in kwargs.items() if k in
                     bp.Figure.properties())
 
+    p = bp.figure(**defaults)
+    p.x_range.start = 0
+    p.y_range.start = 0
+    # TODO: was there any benefit to the discrete y_range:
+    # y_range=[str(i) for i in range(len(id_lk))], x_range=[0, right - left]
+
     if results:
         keys, tasks, starts, ends, ids = zip(*results)
 
@@ -233,10 +239,7 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
                     key=itemgetter(1), reverse=True)))
 
         left = min(starts)
-        right = max(ends)
-
-        p = bp.figure(y_range=[str(i) for i in range(len(id_lk))],
-                    x_range=[0, right - left], **defaults)
+        # right = max(ends)
 
         data = {}
         data['width'] = width = [e - s for (s, e) in zip(starts, ends)]
@@ -250,9 +253,7 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
 
         p.rect(source=source, x='x', y='y', height=1, width='width',
             color='color', line_color='gray')
-    else:
-        p = bp.figure(y_range=[str(i) for i in range(8)], x_range=[0, 10],
-                      **defaults)
+
     p.grid.grid_line_color = None
     p.axis.axis_line_color = None
     p.axis.major_tick_line_color = None


### PR DESCRIPTION
Proof of concept WIP that allows Profiler to update its bokeh plot as tasks complete, turning it into an excellent complement to the ProgressBar.

To use:
```python

bokeh.io.output_notebook() # this needs to have been called at some point before

with dask.diagnostics.Profiler() as prof:
    prof.visualize(watch=True)
    dask.compute(some_expensive_thing)
```

Demo: https://youtu.be/sUTYlnCcgTg

TODO:
- [ ] plot_tasks() is creaking under its current architecture, refactoring it to its own Callback subclass would more easily allow progressive data source updates and enable drawing pending/current tasks
- [ ] generalize this to all the other profilers as well; this goes along well with carving out a better base class for all profiler-plotters
- [ ] drive the incremental update mindset all the way through to the mutations on the bokeh data source to reduce churn; this might start to become meaningful to performance of the notebook process around (tens of?) thousands of tasks