### PR TITLE
ENH: dataframe.from_pandas ... accept npartitions or chunksize

### DIFF
--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -401,6 +401,11 @@ def test_from_pandas_dataframe():
     assert len(ddf.divisions) == len(ddf.dask) + 1
     assert type(ddf.divisions[0]) == type(df.index[0])
     tm.assert_frame_equal(df, ddf.compute())
+    ddf = dd.from_pandas(df, chunksize=8)
+    assert len(ddf.dask) == 3
+    assert len(ddf.divisions) == len(ddf.dask) + 1
+    assert type(ddf.divisions[0]) == type(df.index[0])
+    tm.assert_frame_equal(df, ddf.compute())
 
 
 def test_from_pandas_small():
@@ -410,6 +415,12 @@ def test_from_pandas_small():
         assert len(a.compute()) == 3
         assert a.divisions[0] == 0
         assert a.divisions[-1] == 2
+
+        a = dd.from_pandas(df, chunksize=i)
+        assert len(a.compute()) == 3
+        assert a.divisions[0] == 0
+        assert a.divisions[-1] == 2
+
 
 
 def test_from_pandas_series():
@@ -422,10 +433,20 @@ def test_from_pandas_series():
     assert type(ds.divisions[0]) == type(s.index[0])
     tm.assert_series_equal(s, ds.compute())
 
+    ds = dd.from_pandas(s, chunksize=8)
+    assert len(ds.dask) == 3
+    assert len(ds.divisions) == len(ds.dask) + 1
+    assert type(ds.divisions[0]) == type(s.index[0])
+    tm.assert_series_equal(s, ds.compute())
+
 
 def test_from_pandas_non_sorted():
     df = pd.DataFrame({'x': [1, 2, 3]}, index=[3, 1, 2])
     ddf = dd.from_pandas(df, npartitions=2, sort=False)
+    assert not ddf.known_divisions
+    eq(df, ddf)
+    
+    ddf = dd.from_pandas(df, chunksize=2, sort=False)
     assert not ddf.known_divisions
     eq(df, ddf)
 
@@ -905,7 +926,8 @@ def test_from_pandas_with_datetime_index():
                          parse_dates=['Date'])
         ddf = dd.from_pandas(df, 2)
         eq(df, ddf)
-
+        ddf = dd.from_pandas(df, chunksize=2)
+        eq(df, ddf)
 
 @pytest.mark.parametrize('encoding', ['utf-16', 'utf-16-le', 'utf-16-be'])
 def test_encoding_gh601(encoding):

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -276,6 +276,8 @@ def test_from_bcolz():
     assert str(d.dtypes['a']) == 'category'
     assert list(d.x.compute(get=get_sync)) == [1, 2, 3]
     assert list(d.a.compute(get=get_sync)) == ['a', 'b', 'a']
+    L = list(d.index.compute(get=get_sync))
+    assert L == [0, 1, 2]
 
     d = dd.from_bcolz(t, chunksize=2, index='x')
     L = list(d.index.compute(get=get_sync))


### PR DESCRIPTION
Hello,

In the project I'm building, I've found it much more convenient if I can make a constant dataframe of the same size and with the same shape as my `from_bcolz` data frame. (So the dataframe is just a column of zero's or one's or whatnot.) 

I wanted the divisions to be the same as well to make the processing easier.... and this was the easiest route to that.

Let me know your thoughts. 

Thanks. 