### PR TITLE
Fix slicing bug

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -6,7 +6,7 @@ from numbers import Number
 from operator import getitem, add
 
 import numpy as np
-from toolz import merge, first, accumulate
+from toolz import merge, first, accumulate, pluck
 
 from ..base import tokenize
 from ..compatibility import long
@@ -242,9 +242,10 @@ def slice_slices_and_integers(out_name, in_name, blockdims, index):
 
     # Get a list (for each dimension) of dicts{blocknum: slice()}
     block_slices = list(map(_slice_1d, shape, blockdims, index))
+    sorted_block_slices = [sorted(i.items()) for i in block_slices]
 
     # (in_name, 1, 1, 2), (in_name, 1, 1, 4), (in_name, 2, 1, 2), ...
-    in_names = list(product([in_name], *[sorted(i.keys()) for i in block_slices]))
+    in_names = list(product([in_name], *[pluck(0, s) for s in sorted_block_slices]))
 
     # (out_name, 0, 0, 0), (out_name, 0, 0, 1), (out_name, 0, 1, 0), ...
     out_names = list(product([out_name],
@@ -252,7 +253,7 @@ def slice_slices_and_integers(out_name, in_name, blockdims, index):
                                  for d, i in zip(block_slices, index)
                                  if not isinstance(i, (int, long))]))
 
-    all_slices = list(product(*[i.values() for i in block_slices]))
+    all_slices = list(product(*[pluck(1, s) for s in sorted_block_slices]))
 
     dsk_out = dict((out_name, (getitem, in_name, slices))
                    for out_name, in_name, slices

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -477,3 +477,25 @@ def test_sanitize_index():
 
     assert sanitize_index(pd.Series([1, 2, 3])) == [1, 2, 3]
     assert sanitize_index((1, 2, 3)) == [1, 2, 3]
+
+
+def test_uneven_blockdims():
+    blockdims = ((31, 28, 31,  30,  31,  30,  31,  31,  30,  31, 30), (100,))
+    index = (slice(240, 270), slice(None))
+    dsk_out, bd_out = slice_array('in', 'out', blockdims, index)
+    sol = {('in', 0, 0): (getitem, ('out', 7, 0), (slice(28, 31, 1), slice(None))),
+           ('in', 1, 0): (getitem, ('out', 8, 0), (slice(0, 27, 1), slice(None)))}
+    assert dsk_out == sol
+    assert bd_out == ((3, 27), (100,))
+
+    blockdims = ((31, 28, 31,  30,  31,  30,  31,  31,  30,  31, 30),) * 2
+    index = (slice(240, 270), slice(180, 230))
+    dsk_out, bd_out = slice_array('in', 'out', blockdims, index)
+    sol = {('in', 0, 0): (getitem, ('out', 7, 5), (slice(28, 31, 1), slice(29, 30, 1))),
+           ('in', 0, 1): (getitem, ('out', 7, 6), (slice(28, 31, 1), slice(None))),
+           ('in', 0, 2): (getitem, ('out', 7, 7), (slice(28, 31, 1), slice(0, 18, 1))),
+           ('in', 1, 0): (getitem, ('out', 8, 5), (slice(0, 27, 1), slice(29, 30, 1))),
+           ('in', 1, 1): (getitem, ('out', 8, 6), (slice(0, 27, 1), slice(None))),
+           ('in', 1, 2): (getitem, ('out', 8, 7), (slice(0, 27, 1), slice(0, 18, 1)))}
+    assert dsk_out == sol
+    assert bd_out == ((3, 27), (1, 31, 18))


### PR DESCRIPTION
This fixes a pretty bad bug due to iterating through a dictionary, relying on it to be sorted (but never actually sorting it). This was causing slices to be inserted incorrectly in the generated slicing graphs, which led to incorrect output.

Should fix https://github.com/pydata/xarray/issues/783.