### PR TITLE
Pandas compat fixes, 0.18.0rc2

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1771,8 +1771,7 @@ def _loc(df, start, stop, include_right_boundary=True):
     """
     result = df.loc[start:stop]
     if not include_right_boundary:
-        right_index = result.index.get_slice_bound(stop, 'left',
-                                                   result.index.inferred_type)
+        right_index = result.index.get_slice_bound(stop, 'left', 'loc')
         result = result.iloc[:right_index]
     return result
 

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -18,7 +18,7 @@ def getnanos(rule):
 
 if LooseVersion(pd.__version__) >= '0.18.0':
     def _resample_apply(s, rule, how, resample_kwargs):
-        return getattr(s.resample(rule, how=how, **resample_kwargs), how)()
+        return getattr(s.resample(rule, **resample_kwargs), how)()
 
     def _resample(obj, rule, how, **kwargs):
         resampler = Resampler(obj, rule, **kwargs)


### PR DESCRIPTION
- Fix resample tests to use the appropriate api, depending on pandas version installed.
- Fix bug in resample implementation for 0.18.0
- Fix bug in loc implementation that was exposed by new assert statement in pandas code.

Tested and passed with both pandas 0.17.1 and 0.18.0rc2