### PR TITLE
WIP/RFC: Support computed task functions and support them through imperative values, used under Bag.map and co

### DIFF
--- a/dask/async.py
+++ b/dask/async.py
@@ -242,6 +242,8 @@ def _execute_task(arg, cache, dsk=None):
         return [_execute_task(a, cache) for a in arg]
     elif istask(arg):
         func, args = arg[0], arg[1:]
+        if istask(func):
+            func = _execute_task(func, cache)
         args2 = [_execute_task(a, cache) for a in args]
         return func(*args2)
     elif not ishashable(arg):

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -253,11 +253,12 @@ class Bag(Base):
         [0, 10, 20, 30, 40]
         """
         name = 'map-{0}-{1}'.format(funcname(func), tokenize(self, func))
+        dsk = self.dask.copy()
         if takes_multiple_arguments(func):
             func = partial(apply, func)
-        dsk = dict(((name, i), (reify, (map, func, (self.name, i))))
+        dsk.update(((name, i), (reify, (map, func, (self.name, i))))
                    for i in range(self.npartitions))
-        return type(self)(merge(self.dask, dsk), name, self.npartitions)
+        return type(self)(dsk, name, self.npartitions)
 
     @property
     def _args(self):

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -487,11 +487,17 @@ class Bag(Base):
         token = tokenize(self, perpartition, aggregate, split_every)
         a = '%s-part-%s' % (name or funcname(perpartition), token)
         dsk = self.dask.copy()
+        if isinstance(perpartition, Value):
+            dsk = merge(dsk, perpartition.dask)
+            perpartition = dsk.pop(perpartition.key)
         dsk.update(((a, i), (perpartition, (self.name, i)))
                    for i in range(self.npartitions))
         k = self.npartitions
         b = a
         fmt = '%s-aggregate-%s' % (name or funcname(aggregate), token)
+        if isinstance(aggregate, Value):
+            dsk = merge(dsk, aggregate.dask)
+            aggregate = dsk.pop(aggregate.key)
         depth = 0
         while k > 1:
             c = fmt + str(depth)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -477,7 +477,8 @@ class Bag(Base):
             split_every = self.npartitions
         token = tokenize(self, perpartition, aggregate, split_every)
         a = '%s-part-%s' % (name or funcname(perpartition), token)
-        dsk = dict(((a, i), (perpartition, (self.name, i)))
+        dsk = self.dask.copy()
+        dsk.update(((a, i), (perpartition, (self.name, i)))
                    for i in range(self.npartitions))
         k = self.npartitions
         b = a
@@ -495,9 +496,9 @@ class Bag(Base):
 
         if out_type is Item:
             dsk[b] = dsk.pop((b, 0))
-            return Item(merge(self.dask, dsk), b)
+            return Item(dsk, b)
         else:
-            return Bag(merge(self.dask, dsk), b, 1)
+            return Bag(dsk, b, 1)
 
     @wraps(sum)
     def sum(self, split_every=None):

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -314,6 +314,9 @@ class Bag(Base):
         name = 'map-partitions-{0}-{1}'.format(funcname(func),
                                                tokenize(self, func))
         dsk = self.dask.copy()
+        if isinstance(func, Value):
+            dsk = merge(dsk, func.dask)
+            func = dsk.pop(func.key)
         dsk.update(((name, i), (func, (self.name, i)))
                    for i in range(self.npartitions))
         return type(self)(dsk, name, self.npartitions)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -308,9 +308,10 @@ class Bag(Base):
         """
         name = 'map-partitions-{0}-{1}'.format(funcname(func),
                                                tokenize(self, func))
-        dsk = dict(((name, i), (func, (self.name, i)))
+        dsk = self.dask.copy()
+        dsk.update(((name, i), (func, (self.name, i)))
                    for i in range(self.npartitions))
-        return type(self)(merge(self.dask, dsk), name, self.npartitions)
+        return type(self)(dsk, name, self.npartitions)
 
     def pluck(self, key, default=no_default):
         """ Select item from all tuples/dicts in collection

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -406,6 +406,7 @@ class Bag(Base):
         """
         combine = combine or binop
         initial = quote(initial)
+        # TODO: support value-funcs
         if initial is not no_default:
             return self.reduction(curry(_reduce, binop, initial=initial),
                                   curry(_reduce, combine),

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -26,6 +26,7 @@ from ..base import Base, normalize_token, tokenize
 from ..compatibility import (apply, BytesIO, unicode, urlopen, urlparse,
                              GzipFile)
 from ..core import list2, quote, istask, get_dependencies, reverse_dict
+from ..imperative import Value
 from ..multiprocessing import get as mpget
 from ..optimize import fuse, cull, inline
 from ..utils import (file_size, infer_compression, open, system_encoding,
@@ -52,6 +53,7 @@ def lazify_task(task, start=True):
         task = task[1]
         return lazify_task(*tail, start=False)
     else:
+        head = lazify_task(head, start=False)
         return (head,) + tuple([lazify_task(arg, False) for arg in tail])
 
 

--- a/dask/core.py
+++ b/dask/core.py
@@ -304,6 +304,7 @@ def subs(task, key, val):
         if isinstance(task, list):
             return [subs(x, key, val) for x in task]
         return task
+    head = task[:1]
     newargs = []
     for arg in task[1:]:
         if istask(arg):
@@ -313,7 +314,7 @@ def subs(task, key, val):
         elif type(arg) is type(key) and arg == key:
             arg = val
         newargs.append(arg)
-    return task[:1] + tuple(newargs)
+    return head + tuple(newargs)
 
 
 def _toposort(dsk, keys=None, returncycle=False):

--- a/dask/core.py
+++ b/dask/core.py
@@ -38,7 +38,12 @@ def istask(x):
     >>> istask(1)
     False
     """
-    return type(x) is tuple and x and callable(x[0])
+    if type(x) is not tuple:
+        return False
+    head = x[0]
+    if callable(head):
+        return True
+    return False
 
 
 def preorder_traversal(task):

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from functools import partial
 from itertools import cycle
 from operator import itemgetter, add
 
@@ -66,8 +67,16 @@ def pprint_task(task, keys, label_size=60):
             tail = ')'
             args = unquote(task[2]) if len(task) > 2 else ()
             kwargs = unquote(task[3]) if len(task) > 3 else {}
+        elif func is partial:
+            head = 'partial(%s, ' % funcname(task[1])
+            args = task[2:]
+            kwargs = {}
+            tail = '))'
         else:
-            if hasattr(func, 'funcs'):
+            if istask(func):
+                head = pprint_task(func, keys, label_size)
+                tail = ')'
+            elif hasattr(func, 'funcs'):
                 head = '('.join(funcname(f) for f in func.funcs)
                 tail = ')'*len(func.funcs)
             else:

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -1,3 +1,4 @@
+from functools import partial
 from operator import add, mul
 import os
 from time import sleep
@@ -153,6 +154,11 @@ def test_pprint_task():
     task = (apply, foo, (tuple, ['a', 'b']),
             (dict, [['y', ['a', 1]], ['z', 1]]))
     assert pprint_task(task, keys) == 'foo(_, _, y=[_, *], z=*)'
+
+    # With computed function
+    # TODO: the extra internal parenthetical is undesirable
+    task = ((partial, add, 'a'), 'b')
+    assert pprint_task(task, keys) == 'partial(add, (_))(_)'
 
 
 @pytest.mark.skipif("not bokeh")

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from functools import partial
 from itertools import count
 from operator import getitem
 
@@ -220,7 +221,11 @@ def functions_of(task):
     result = set()
     if istask(task):
         args = set.union(*map(functions_of, task[1:])) if task[1:] else set()
-        return set([unwrap_partial(task[0])]) | args
+        if istask(task[0]):
+            args |= functions_of(task[0])
+        else:
+            args.add(unwrap_partial(task[0]))
+        return args
     if isinstance(task, (list, tuple)):
         if not task:
             return set()
@@ -229,7 +234,7 @@ def functions_of(task):
 
 
 def unwrap_partial(func):
-    while hasattr(func, 'func'):
+    while hasattr(func, 'func') and func is not partial:
         func = func.func
     return func
 

--- a/dask/rewrite.py
+++ b/dask/rewrite.py
@@ -362,7 +362,10 @@ def _top_level(net, term):
 
 def _bottom_up(net, term):
     if istask(term):
-        term = (head(term),) + tuple(_bottom_up(net, t) for t in args(term))
+        hd = head(term)
+        if istask(hd):
+            hd = _bottom_up(net, hd)
+        term = (hd,) + tuple(_bottom_up(net, t) for t in args(term))
     elif isinstance(term, list):
         term = [_bottom_up(net, t) for t in args(term)]
     return net._rewrite(term)

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from functools import partial
 from operator import add
 from copy import deepcopy
 
@@ -87,6 +88,15 @@ def test_finish_task():
 
 def test_get():
     dsk = {'x': 1, 'y': 2, 'z': (inc, 'x'), 'w': (add, 'z', 'y')}
+    assert get_sync(dsk, 'w') == 4
+    assert get_sync(dsk, ['w', 'z']) == (4, 2)
+
+
+def test_get_with_computed_func():
+    dsk = {'x': 1,
+           'y': 2,
+           'z': (inc, 'x'),
+           'w': ((partial, add, 'z'), 'y')}
     assert get_sync(dsk, 'w') == 4
     assert get_sync(dsk, ['w', 'z']) == (4, 2)
 

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from functools import partial
 from operator import add
 
 from dask.utils import raises
@@ -29,11 +30,13 @@ def test_istask():
     assert not istask((1, 2))
     f = namedtuple('f', ['x', 'y'])
     assert not istask(f(sum, 2))
+    assert istask(((partial, lambda a, b: a + b, 1), 2))
 
 
 d = {':x': 1,
      ':y': (inc, ':x'),
-     ':z': (add, ':x', ':y')}
+     ':z': (add, ':x', ':y'),
+     ':zz': ((partial, lambda a, b: a + b, ':x'), ':y')}
 
 
 def test_preorder_traversal():
@@ -49,6 +52,7 @@ def test_get():
     assert get(d, ':x') == 1
     assert get(d, ':y') == 2
     assert get(d, ':z') == 3
+    assert get(d, ':zz') == 3
     assert get(d, 'pass-through') == 'pass-through'
 
 

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -186,6 +186,7 @@ def test_functions_of():
     assert functions_of(1) == set()
     assert functions_of(a) == set()
     assert functions_of((a,)) == set([a])
+    assert functions_of(((partial, add, 1), 2)) == set([partial])
 
 
 def test_dealias():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -553,6 +553,9 @@ def derived_from(original_klass, version=None, ua_args=[]):
 
 def funcname(func):
     """Get the name of a function."""
+    from .imperative import Value
+    if isinstance(func, Value):
+        return 'value-func-' + str(func.key)
     while hasattr(func, 'func'):
         func = func.func
     try:


### PR DESCRIPTION
This PR is an alternative path to #1041 which permits a solution to #1040 without changing the signature of the Bag.map family, and at the same time supports other novel uses such as computed reduction functions.

If this direction is acceptable, then I plan to:
- [ ] breakout just the computed function prep work into a separate PR, and complete tests / polish
- [ ] break out the imperative module work around partialfunc, and consider what may be missed there; for example would we rathe have a special `class PartialFunc` rather than (ab/re)-using the `Value` plumbing?
- [ ] finally this PR would become the final mile support in the bag module, with more tests, and maybe completion for Bag.fold and any other misses