### PR TITLE
bag.zip: support scalar Items

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1427,7 +1427,7 @@ def bag_range(n, npartitions):
     return Bag(dsk, name, npartitions)
 
 
-def bag_zip(*bags):
+def bag_zip(*parts):
     """ Partition-wise bag zip
 
     All passed bags must have the same number of partitions.
@@ -1463,16 +1463,17 @@ def bag_zip(*bags):
     [(0, 0), (3, None), (None, 5), (6, None), (None 10), (9, None),
      (12, None), (15, 15), (18, None), (None, 20), (None, 25), (None, 30)]
     """
-    assert all(isinstance(bag, Bag)
-               for bag in bags)
+    assert all(isinstance(part, Bag)
+               for part in parts)
+    bags = parts
     npartitions = bags[0].npartitions
     assert all(bag.npartitions == npartitions for bag in bags)
     # TODO: do more checks
 
-    name = 'zip-' + tokenize(*bags)
-    dsk = merge(*(bag.dask for bag in bags))
+    name = 'zip-' + tokenize(*parts)
+    dsk = merge(*(part.dask for part in parts))
     dsk.update(
-        ((name, i), (reify, (zip,) + tuple((bag.name, i) for bag in bags)))
+        ((name, i), (reify, (zip,) + tuple((bag.name, i) for bag in parts)))
         for i in range(npartitions))
     return Bag(dsk, name, npartitions)
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1470,11 +1470,11 @@ def bag_zip(*bags):
     # TODO: do more checks
 
     name = 'zip-' + tokenize(*bags)
-    dsk = dict(
+    dsk = merge(*(bag.dask for bag in bags))
+    dsk.update(
         ((name, i), (reify, (zip,) + tuple((bag.name, i) for bag in bags)))
         for i in range(npartitions))
-    bags_dsk = merge(*(bag.dask for bag in bags))
-    return Bag(merge(bags_dsk, dsk), name, npartitions)
+    return Bag(dsk, name, npartitions)
 
 
 def _reduce(binop, sequence, initial=no_default):

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1463,9 +1463,9 @@ def bag_zip(*bags):
     [(0, 0), (3, None), (None, 5), (6, None), (None 10), (9, None),
      (12, None), (15, 15), (18, None), (None, 20), (None, 25), (None, 30)]
     """
-    npartitions = bags[0].npartitions
     assert all(isinstance(bag, Bag)
                for bag in bags)
+    npartitions = bags[0].npartitions
     assert all(bag.npartitions == npartitions for bag in bags)
     # TODO: do more checks
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1464,6 +1464,8 @@ def bag_zip(*bags):
      (12, None), (15, 15), (18, None), (None, 20), (None, 25), (None, 30)]
     """
     npartitions = bags[0].npartitions
+    assert all(isinstance(bag, Bag)
+               for bag in bags)
     assert all(bag.npartitions == npartitions for bag in bags)
     # TODO: do more checks
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -19,6 +19,7 @@ import bz2
 import io
 import shutil
 import os
+import sys
 import partd
 from tempfile import mkdtemp
 
@@ -866,6 +867,10 @@ def test_zip(npartitions, hi=1000):
     pairs = db.zip(evens, odds)
     assert pairs.npartitions == npartitions
     assert list(pairs) == list(zip(range(0, hi, 2), range(1, hi, 2)))
+    nums = db.from_sequence(range(hi), npartitions=npartitions)
+    assert abs(1.0 - db.zip(nums, nums.sum())
+               .map(lambda n, total: float(n) / total).sum().compute()
+               ) <= sys.float_info.epsilon
 
 
 def test_repartition():


### PR DESCRIPTION
Support scalar `dask.bag.Item`s under `dask.bag.zip` by lifting their computed values through `itertools.repeat`.

See docstring updates for example usage.