### PR TITLE
Add **kwargs support to Bag.map and Bag.map_partitions

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -331,9 +331,11 @@ class Bag(Base):
         """
         name = 'map-partitions-{0}-{1}'.format(funcname(func),
                                                tokenize(self, func))
-        dsk = dict(((name, i), (func, (self.name, i)))
+        dsk = self.dask.copy()
+        dsk.update(((name, i),
+                    (func, (self.name, i)))
                    for i in range(self.npartitions))
-        return type(self)(merge(self.dask, dsk), name, self.npartitions)
+        return type(self)(dsk, name, self.npartitions)
 
     def pluck(self, key, default=no_default):
         """ Select item from all tuples/dicts in collection

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -278,9 +278,10 @@ class Bag(Base):
         name = 'map-{0}-{1}'.format(funcname(func), tokenize(self, func))
         if takes_multiple_arguments(func):
             func = partial(apply, func)
-        dsk = dict(((name, i), (reify, (map, func, (self.name, i))))
+        dsk = self.dask.copy()
+        dsk.update(((name, i), (reify, (map, func, (self.name, i))))
                    for i in range(self.npartitions))
-        return type(self)(merge(self.dask, dsk), name, self.npartitions)
+        return type(self)(dsk, name, self.npartitions)
 
     @property
     def _args(self):

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -183,6 +183,29 @@ def finalize_item(results):
     return results[0]
 
 
+def unpack_kwargs(kwargs):
+    """ Extracts dask values from kwargs
+
+    Currently only dask.bag.Item and python literal values are supported.
+
+    Returns a merged dask graph and a list of [key, val] pairs suitable for
+    eventually constructing a dict.
+    """
+    dsk = {}
+    kw_pairs = []
+    for key, val in iteritems(kwargs):
+        if isinstance(val, Item):
+            dsk.update(val.dask)
+            val = val.key
+        # TODO elif isinstance(val, Value):
+        elif isinstance(val, Base):
+            raise NotImplementedError(
+                '%s not supported as kwarg value to Bag.map_partitions'
+                % type(val).__name__)
+        kw_pairs.append([key, val])
+    return dsk, kw_pairs
+
+
 class Item(Base):
     _optimize = staticmethod(optimize)
     _default_get = staticmethod(mpget)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -103,6 +103,17 @@ def test_map_with_builtins():
         [True, False]
 
 
+def test_map_with_kwargs():
+    b = db.from_sequence(range(100), npartitions=10)
+    assert b.map(lambda x, factor=0: x * factor,
+                 factor=2).sum().compute() == 9900.0
+    assert b.map(lambda x, total=0: x / total,
+                 total=b.sum()).sum().compute() == 1.0
+    assert b.map(lambda x, factor=0, total=0: x * factor / total,
+                 total=b.sum(),
+                 factor=2).sum().compute() == 2.0
+
+
 def test_filter():
     c = b.filter(iseven)
     expected = merge(dsk, dict(((c.name, i),


### PR DESCRIPTION
Allows to pass non-dask python literals and `dask.bag.Item`s as values in **kwargs which pass through to the map func.