### PR TITLE
Add .key property to dataframe.Scalar

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -91,8 +91,12 @@ class Scalar(Base):
     def _args(self):
         return (self.dask, self._name)
 
+    @property
+    def key(self):
+        return (self._name, 0)
+
     def _keys(self):
-        return [(self._name, 0)]
+        return [self.key]
 
     @classmethod
     def _get_unary_operator(cls, op):


### PR DESCRIPTION
For consistency with `bag.Item` and `imperative.Value` as noticed in commentary on #1054 