### PR TITLE
Add support for converting imperative.Value <-> bag.Item

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -226,6 +226,14 @@ class Item(Base):
 
     __int__ = __float__ = __complex__ = __bool__ = Base.compute
 
+    def to_imperative(self):
+        """ Convert bag item to dask Value
+
+        Returns a single value.
+        """
+        from dask.imperative import Value
+        return Value(self.key, [self.dask])
+
 
 class Bag(Base):
     """ Parallel collection of Python objects

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -211,6 +211,27 @@ class Item(Base):
     _default_get = staticmethod(mpget)
     _finalize = staticmethod(finalize_item)
 
+    @staticmethod
+    def from_imperative(value):
+        """ Create bag item from an imperative value
+
+        Parameters
+        ----------
+        value: a Value
+            A single dask.imperative.Value object, such as come from dask.do
+
+        Returns
+        -------
+        Item
+
+        Examples
+        --------
+        >>> b = db.Item.from_imperative(x)  # doctest: +SKIP
+        """
+        from dask.imperative import Value
+        assert isinstance(value, Value)
+        return Item(value.dask, value.key)
+
     def __init__(self, dsk, key):
         self.dask = dsk
         self.key = key

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -848,13 +848,17 @@ def test_to_imperative():
 
 
 def test_from_imperative():
-    from dask.imperative import value
+    from dask.imperative import value, do
     a, b, c = value([1, 2, 3]), value([4, 5, 6]), value([7, 8, 9])
     bb = from_imperative([a, b, c])
     assert bb.name == from_imperative([a, b, c]).name
 
     assert isinstance(bb, Bag)
     assert list(bb) == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    asum_value = do(lambda X: sum(X))(a)
+    asum_item = db.Item.from_imperative(asum_value)
+    assert asum_value.compute() == asum_item.compute() == 6
 
 
 def test_range():

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -835,10 +835,16 @@ def test_bag_compute_forward_kwargs():
 
 def test_to_imperative():
     from dask.imperative import Value
+
     b = db.from_sequence([1, 2, 3, 4, 5, 6], npartitions=3)
     a, b, c = b.map(inc).to_imperative()
     assert all(isinstance(x, Value) for x in [a, b, c])
     assert b.compute() == [4, 5]
+
+    b = db.from_sequence([1, 2, 3, 4, 5, 6], npartitions=3)
+    t = b.sum().to_imperative()
+    assert isinstance(t, Value)
+    assert t.compute() == 21
 
 
 def test_from_imperative():


### PR DESCRIPTION
Comes in handy when mixing imperative work with bags.