### PR TITLE
BUG: Array divisions skip the last partition unnecessarily

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -312,8 +312,7 @@ def from_array(x, chunksize=50000, columns=None):
     dummy = _dummy_from_array(x, columns)
 
     divisions = tuple(range(0, len(x), chunksize))
-    if divisions[-1] != len(x) - 1:
-        divisions = divisions + (len(x) - 1,)
+    divisions = divisions + (len(x) - 1,)
     token = tokenize(x, chunksize, columns)
     name = 'from_array-' + token
 

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -161,6 +161,12 @@ def test_dummy_from_array():
     msg = r"""Length mismatch: Expected axis has 2 elements, new values have 3 elements"""
     with tm.assertRaisesRegexp(ValueError, msg):
         dd.io._dummy_from_array(x, columns=['a', 'b', 'c'])
+        
+    np.random.seed(42)    
+    x = np.random.rand(201, 2)
+    x = from_array(x, chunksize=50, columns=['a', 'b'])
+    assert len(x.divisions) == 6 # Should be 5 partitions and the end
+    
 
 def test_dummy_from_1darray():
     x = np.array([1., 2., 3.], dtype=np.float64)


### PR DESCRIPTION
Hello,

#1057

I think this gets array divisions to work per my note. 

I added a test to demonstrate what I think the appropriate behavior should be. 