### PR TITLE
Change to_textfiles behavior to compute right away

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -95,7 +95,7 @@ def optimize(dsk, keys, **kwargs):
 
 
 def to_textfiles(b, path, name_function=str, compression='infer',
-                 encoding=system_encoding):
+                 encoding=system_encoding, compute=True):
     """ Write bag to disk, one filename per partition, one line per element
 
     **Paths**: This will create one file for each partition in your bag. You
@@ -165,6 +165,8 @@ def to_textfiles(b, path, name_function=str, compression='infer',
     dsk = dict(((name, i), (write, (b.name, i), path, get_compression(path),
                             encoding))
                for i, path in enumerate(paths))
+    if compute:
+        return Bag(merge(b.dask, dsk), name, b.npartitions).compute()
 
     return Bag(merge(b.dask, dsk), name, b.npartitions)
 
@@ -461,8 +463,8 @@ class Bag(Base):
 
     @wraps(to_textfiles)
     def to_textfiles(self, path, name_function=str, compression='infer',
-                     encoding=system_encoding):
-        return to_textfiles(self, path, name_function, compression, encoding)
+                     encoding=system_encoding, compute=True):
+        return to_textfiles(self, path, name_function, compression, encoding, compute)
 
     def fold(self, binop, combine=None, initial=no_default, split_every=None):
         """ Parallelizable reduction

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -674,7 +674,7 @@ def test_to_textfiles():
     b = db.from_sequence(['abc', '123', 'xyz'], npartitions=2)
     dir = mkdtemp()
     for ext, myopen in [('gz', GzipFile), ('bz2', BZ2File), ('', open)]:
-        c = b.to_textfiles(os.path.join(dir, '*.' + ext))
+        c = b.to_textfiles(os.path.join(dir, '*.' + ext), compute=False)
         assert c.npartitions == b.npartitions
         try:
             c.compute(get=dask.get)
@@ -695,7 +695,7 @@ def test_to_textfiles_encoding():
     b = db.from_sequence([u'汽车', u'苹果', u'天气'], npartitions=2)
     dir = mkdtemp()
     for ext, myopen in [('gz', GzipFile), ('bz2', BZ2File), ('', open)]:
-        c = b.to_textfiles(os.path.join(dir, '*.' + ext), encoding='gb18030')
+        c = b.to_textfiles(os.path.join(dir, '*.' + ext), encoding='gb18030', compute=False)
         assert c.npartitions == b.npartitions
         try:
             c.compute(get=dask.get)
@@ -716,12 +716,12 @@ def test_to_textfiles_inputs():
     B = db.from_sequence(['abc', '123', 'xyz'], npartitions=2)
     with tmpfile() as a:
         with tmpfile() as b:
-            B.to_textfiles([a, b]).compute()
+            B.to_textfiles([a, b])
             assert os.path.exists(a)
             assert os.path.exists(b)
 
     with tmpfile() as dirname:
-        B.to_textfiles(dirname).compute()
+        B.to_textfiles(dirname)
         assert os.path.exists(dirname)
         assert os.path.exists(os.path.join(dirname, '0.part'))
     assert raises(ValueError, lambda: B.to_textfiles(5))


### PR DESCRIPTION
to_textfiles would write to files without the need to call compute()