### PR TITLE
use function name within array keys

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -24,7 +24,7 @@ from .slicing import slice_array
 from . import numpy_compat
 from ..base import Base, compute, tokenize, normalize_token
 from ..utils import (deepmap, ignoring, repr_long_list, concrete, is_integer,
-        IndexCallable)
+        IndexCallable, funcname)
 from ..compatibility import unicode, long, getargspec, zip_longest
 from .. import threaded, core
 
@@ -1665,7 +1665,7 @@ def atop(func, out_ind, *args, **kwargs):
     argindsstr = list(concat([(a.name, ind) for a, ind in arginds]))
     # Finish up the name
     if not out:
-        out = 'atop-' + tokenize(func, out_ind, argindsstr, dtype)
+        out = funcname(func) + '-' + tokenize(func, out_ind, argindsstr, dtype)
 
     dsk = top(func, out, out_ind, *argindsstr, numblocks=numblocks)
     dsks = [a.dask for a, _ in arginds]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1948,3 +1948,9 @@ def test_tril_triu_errors():
     dA = da.from_array(A, chunks=(5, 5))
     assert raises(NotImplementedError, lambda: da.triu(dA))
 
+
+def test_atop_names():
+    x = da.ones(5, chunks=(2,))
+    y = atop(add, 'i', x, 'i')
+    assert y.name.startswith('add')
+

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -337,3 +337,13 @@ def test_tree_reduce_set_options():
     with set_options(split_every={0: 2, 1: 3}):
         assert_max_deps(x.sum(), 2 * 3)
         assert_max_deps(x.sum(axis=0), 2)
+
+
+def test_reduction_names():
+    x = da.ones(5, chunks=(2,))
+    assert x.sum().name.startswith('sum')
+    assert 'max' in x.max().name.split('-')[0]
+    assert x.var().name.startswith('var')
+    assert x.all().name.startswith('all')
+    assert any(k[0].startswith('nansum') for k in da.nansum(x).dask)
+    assert x.mean().name.startswith('mean')


### PR DESCRIPTION
We're seeing names like `p_reduce-..` and `atop-...` within distributed diagnostics.  This starts to use `funcname` more aggressively when constructing names.

I'm getting some odd errors.  CC @jcrist in case the origin of these issues is apparent to him.