### PR TITLE
suggestion for: TestCase for get functions

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from .utils_test import GetFunctionTestCase
 from .core import istask
 from .context import set_options
 from .async import get_sync as get

--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from .utils_test import GetFunctionTestCase
 from .core import istask
 from .context import set_options
 from .async import get_sync as get

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -7,6 +7,7 @@ import dask
 import pytest
 
 from dask.async import *
+from dask.utils_test import GetFunctionTestCase
 
 
 fib_dask = {'f0': 0, 'f1': 1, 'f2': 1, 'f3': 2, 'f4': 3, 'f5': 5, 'f6': 8}
@@ -84,20 +85,11 @@ def test_finish_task():
           'waiting_data': {'y': set(['w']),
                            'z': set(['w'])}}
 
+class TestGetAsync(GetFunctionTestCase):
+    get = staticmethod(get_sync)
 
-def test_get():
-    dsk = {'x': 1, 'y': 2, 'z': (inc, 'x'), 'w': (add, 'z', 'y')}
-    assert get_sync(dsk, 'w') == 4
-    assert get_sync(dsk, ['w', 'z']) == (4, 2)
-
-
-def test_nested_get():
-    dsk = {'x': 1, 'y': 2, 'a': (add, 'x', 'y'), 'b': (sum, ['x', 'y'])}
-    assert get_sync(dsk, ['a', 'b']) == (3, 3)
-
-
-def test_get_sync_num_workers():
-    get_sync({'x': (inc, 'y'), 'y': 1}, 'x', num_workers=2)
+    def test_get_sync_num_workers(self):
+        self.get({'x': (inc, 'y'), 'y': 1}, 'x', num_workers=2)
 
 
 def test_cache_options():

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -1,9 +1,10 @@
 from collections import namedtuple
-from operator import add
 
 from dask.utils import raises
-from dask.core import (istask, get, get_dependencies, flatten, subs,
-                       preorder_traversal, quote, list2, _deps)
+from dask.utils_test import GetFunctionTestCase
+from dask import core
+from dask.core import (istask, get_dependencies, flatten, subs,
+                       preorder_traversal, quote, _deps)
 
 
 def contains(a, b):
@@ -31,11 +32,6 @@ def test_istask():
     assert not istask(f(sum, 2))
 
 
-d = {':x': 1,
-     ':y': (inc, ':x'),
-     ':z': (add, ':x', ':y')}
-
-
 def test_preorder_traversal():
     t = (add, 1, 2)
     assert list(preorder_traversal(t)) == [add, 1, 2]
@@ -45,20 +41,36 @@ def test_preorder_traversal():
     assert list(preorder_traversal(t)) == [add, sum, list, 1, 2, 3]
 
 
-def test_get():
-    assert get(d, ':x') == 1
-    assert get(d, ':y') == 2
-    assert get(d, ':z') == 3
-    assert get(d, 'pass-through') == 'pass-through'
+class TestGet(GetFunctionTestCase):
+    get = staticmethod(core.get)
+
+
+def test_GetFunctionTestCase_class():
+    class CustomTestGetFail(GetFunctionTestCase):
+        get = staticmethod(lambda x, y: 1)
+
+    custom_testget = CustomTestGetFail()
+    raises(AssertionError, custom_testget.test_get)
+
+    class CustomTestGetPass(GetFunctionTestCase):
+        get = staticmethod(core.get)
+
+    custom_testget = CustomTestGetPass()
+    custom_testget.test_get()
 
 
 def test_memoized_get():
+    d = {':x': 1,
+         ':y': (inc, ':x'),
+         ':z': (add, ':x', ':y')}
     try:
         import toolz
     except ImportError:
         return
     cache = dict()
-    getm = toolz.memoize(get, cache=cache, key=lambda args, kwargs: args[1:])
+
+    getm = toolz.memoize(core.get, cache=cache,
+                         key=lambda args, kwargs: args[1:])
 
     result = getm(d, ':z', get=getm)
     assert result == 3
@@ -67,31 +79,6 @@ def test_memoized_get():
                             (':y',): 2,
                             (':z',): 3})
 
-def test_data_not_in_dict_is_ok():
-    d = {'x': 1, 'y': (add, 'x', 10)}
-    assert get(d, 'y') == 11
-
-
-def test_get_with_list():
-    d = {'x': 1, 'y': 2, 'z': (sum, ['x', 'y'])}
-
-    assert get(d, ['x', 'y']) == [1, 2]
-    assert get(d, 'z') == 3
-
-
-def test_get_with_nested_list():
-    d = {'x': 1, 'y': 2, 'z': (sum, ['x', 'y'])}
-
-    assert get(d, [['x'], 'y']) == [[1], 2]
-    assert get(d, 'z') == 3
-
-
-def test_get_works_with_unhashables_in_values():
-    f = lambda x, y: x + len(y)
-    d = {'x': 1, 'y': (f, 'x', set([1]))}
-
-    assert get(d, 'y') == 2
-
 
 def test_get_laziness():
     def isconcrete(arg):
@@ -99,8 +86,8 @@ def test_get_laziness():
 
     d = {'x': 1, 'y': 2, 'z': (isconcrete, ['x', 'y'])}
 
-    assert get(d, ['x', 'y']) == [1, 2]
-    assert get(d, 'z') == False
+    assert core.get(d, ['x', 'y']) == (1, 2)
+    assert core.get(d, 'z') == False
 
 
 def test_get_dependencies_nested():
@@ -118,24 +105,6 @@ def test_get_dependencies_empty():
 def test_get_dependencies_list():
     dsk = {'x': 1, 'y': 2, 'z': ['x', [(inc, 'y')]]}
     assert get_dependencies(dsk, 'z') == set(['x', 'y'])
-
-
-def test_nested_tasks():
-    d = {'x': 1,
-         'y': (inc, 'x'),
-         'z': (add, (inc, 'x'), 'y')}
-
-    assert get(d, 'z') == 4
-
-
-def test_get_stack_limit():
-    d = dict(('x%s' % (i+1), (inc, 'x%s' % i)) for i in range(10000))
-    d['x0'] = 0
-    assert get(d, 'x10000') == 10000
-    # introduce cycle
-    d['x5000'] = (inc, 'x5001')
-    assert raises(RuntimeError, lambda: get(d, 'x10000'))
-    assert get(d, 'x4999') == 4999
 
 
 def test_flatten():
@@ -183,7 +152,7 @@ def test_quote():
                 [1, [2, 3]], (add, 1, (add, 2, 3))]
 
     for l in literals:
-        assert get({'x': quote(l)}, 'x') == l
+        assert core.get({'x': quote(l)}, 'x') == l
 
 
 def test__deps():

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -19,8 +19,9 @@ class GetFunctionTestCase(unittest.TestCase):
     To use the class, inherit from it and override the `get` function. For
     example:
 
-    class CustomGetTestCase(GetFunctionTestCase):
-        get = staticmethod(myget)
+    > from dask.utils_test import GetFunctionTestCase
+    > class CustomGetTestCase(GetFunctionTestCase):
+         get = staticmethod(myget)
 
     Note that the foreign `myget` function has to be explicitly decorated as a
     staticmethod.

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -1,0 +1,115 @@
+from __future__ import absolute_import, division, print_function
+
+from .utils import raises
+from .core import get
+import unittest
+
+def inc(x):
+    return x + 1
+
+def add(x, y):
+    return x + y
+
+class GetFunctionTestCase(unittest.TestCase):
+    """
+    The GetFunctionTestCase class can be imported and used to test foreign
+    implementations of the `get` function specification. It aims to enforce all
+    known expecctations of `get` functions.
+
+    To use the class, inherit from it and override the `get` function. For
+    example:
+
+    class CustomGetTestCase(GetFunctionTestCase):
+        get = staticmethod(myget)
+
+    Note that the foreign `myget` function has to be explicitly decorated as a
+    staticmethod.
+    """
+    get = staticmethod(get)
+
+    def runTest(self):
+        """This method is needed for compatibility with PY2 unittest.TestCase"""
+        pass
+
+    def test_get(self):
+        d = {':x': 1,
+             ':y': (inc, ':x'),
+             ':z': (add, ':x', ':y')}
+
+        assert self.get(d, ':x') == 1
+        assert self.get(d, ':y') == 2
+        assert self.get(d, ':z') == 3
+
+    def test_badkey(self):
+        d = {':x': 1,
+             ':y': (inc, ':x'),
+             ':z': (add, ':x', ':y')}
+        try:
+            result = self.get(d, 'badkey')
+        except KeyError as e:
+            pass
+        else:
+            msg = 'Expected `{}` with badkey to raise KeyError.\n'
+            msg += "Obtained '{}' instead.".format(result)
+            self.assertTrue(False, msg=msg.format(self.get.__name__))
+
+    def test_nested_badkey(self):
+        d = {'x': 1, 'y': 2, 'z': (sum, ['x', 'y'])}
+
+        try:
+            result = self.get(d, [['badkey'], 'y'])
+        except KeyError as e:
+            pass
+        else:
+            msg = 'Expected `{}` with badkey to raise KeyError.\n'
+            msg += "Obtained '{}' instead.".format(result)
+            self.assertTrue(False, msg=msg.format(self.get.__name__))
+
+    def test_data_not_in_dict_is_ok(self):
+        d = {'x': 1, 'y': (add, 'x', 10)}
+        assert self.get(d, 'y') == 11
+
+    def test_get_with_list(self):
+        d = {'x': 1, 'y': 2, 'z': (sum, ['x', 'y'])}
+
+        assert self.get(d, ['x', 'y']) == (1, 2)
+        assert self.get(d, 'z') == 3
+
+    def test_get_with_nested_list(self):
+        d = {'x': 1, 'y': 2, 'z': (sum, ['x', 'y'])}
+
+        assert self.get(d, [['x'], 'y']) == ((1,), 2)
+        assert self.get(d, 'z') == 3
+
+    def test_get_works_with_unhashables_in_values(self):
+        f = lambda x, y: x + len(y)
+        d = {'x': 1, 'y': (f, 'x', set([1]))}
+
+        assert self.get(d, 'y') == 2
+
+    def test_nested_tasks(self):
+        d = {'x': 1,
+             'y': (inc, 'x'),
+             'z': (add, (inc, 'x'), 'y')}
+
+        assert self.get(d, 'z') == 4
+
+    def test_get_stack_limit(self):
+        d = dict(('x%s' % (i+1), (inc, 'x%s' % i)) for i in range(10000))
+        d['x0'] = 0
+        assert self.get(d, 'x10000') == 10000
+        # introduce cycle
+        d['x5000'] = (inc, 'x5001')
+
+        try:
+            self.get(d, 'x10000')
+        except (RuntimeError, ValueError) as e:
+            if isinstance(e, RuntimeError):
+                assert str(e) == 'Cycle detected in Dask: x5001->x5000->x5001'
+            elif isinstance(e, ValueError):
+                assert str(e).startswith('Found no accessible jobs in dask')
+        else:
+            msg = 'dask with infinite cycle should have raised an exception.'
+            self.assertTrue(False, msg=msg)
+
+        assert self.get(d, 'x4999') == 4999


### PR DESCRIPTION
Hi, I started to work on issue #778.   Wanted to get some feedback on an initial idea for this.  The plan is to add all of the `get` test cases inside the `TestGet` class.  

The simple `TestGet` class that I have created based on @mrocklin 's suggestion can be tested from the command line using py.test

```
$ py.test dask/tests/test_core.py::TestGet
============================= test session starts ==============================
platform linux -- Python 3.5.1, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
rootdir: /home/pmd/Dropbox/pmd-laptop/my-sandbox/pydata/dask, inifile: 
collected 21 items 

dask/tests/test_core.py .

=========================== 1 passed in 0.44 seconds ===========================
```

It can also be imported and used directly:

```
Python 3.5.1 |Anaconda 2.4.0 (64-bit)| (default, Dec  7 2015, 11:16:01) 
Type "copyright", "credits" or "license" for more information.

IPython 4.0.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from dask.tests.test_core import TestGet

In [2]: mytest = TestGet()

In [3]: mytest.run()
Out[3]: <unittest.result.TestResult run=1 errors=0 failures=0>
```
