### PR TITLE
Fix numeric stability for dd.corr and dd.cov

### DIFF
--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -779,6 +779,14 @@ def test_reductions_frame_dtypes():
     assert numerics._get_numeric_data().dask == numerics.dask
 
 
+def test_get_numeric_data_unknown_part():
+    df = pd.DataFrame({'a': range(5), 'b': range(5), 'c': list('abcde')})
+    ddf = dd.from_pandas(df, 3)
+    # Drop dtype information
+    ddf = dd.DataFrame(ddf.dask, ddf._name, ['a', 'b', 'c'], ddf.divisions)
+    assert eq(ddf._get_numeric_data(), df._get_numeric_data())
+
+
 def test_reductions_frame_nan():
     df = pd.DataFrame({'a': [1, 2, np.nan, 4, 5, 6, 7, 8],
                        'b': [1, 2, np.nan, np.nan, np.nan, 5, np.nan, np.nan],

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1454,6 +1454,13 @@ def test_corr():
     pytest.raises(TypeError, lambda: da.corr(ddf))
 
 
+def test_cov_corr_stable():
+    df = pd.DataFrame(np.random.random((20000000, 2)) * 2 - 1, columns=['a', 'b'])
+    ddf = dd.from_pandas(df, npartitions=50)
+    assert eq(ddf.cov(), df.cov())
+    assert eq(ddf.corr(), df.corr())
+
+
 def test_apply_infer_columns():
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
     ddf = dd.from_pandas(df, npartitions=2)


### PR DESCRIPTION
- Improve numeric stability of `corr` and `cov`
- Fix issue with `_get_numeric_data` when dtype is unknown

Fixes #1086.