### PR TITLE
added xz file/lzma support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     apt:
         packages:
         - graphviz
+        - liblzma-dev
 
 install:
   # Install conda
@@ -27,6 +28,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.4' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then conda install numpy scipy pandas pytables h5py bcolz pytest coverage toolz scikit-learn cytoolz cloudpickle chest blosc cython psutil ipython; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then conda install unittest2; fi
   - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then conda install bokeh; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install backports.lzma; fi
   - pip install git+https://github.com/mrocklin/partd --upgrade
   - pip install git+https://github.com/mrocklin/cachey --upgrade
   - pip install blosc --upgrade

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -71,3 +71,5 @@
 [Wesley Emeneker](http://github.com/nevermindewe/)
 
 [Will Warner](https://github.com/electronwill/)
+
+[Daniel Davis](https://github.com/wabu)

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -16,6 +16,7 @@ if PY3:
     from io import StringIO, BytesIO
     from bz2 import BZ2File
     from gzip import GzipFile
+    from lzma import LZMAFile
     from urllib.request import urlopen
     from urllib.parse import urlparse
     from urllib.parse import quote, unquote
@@ -168,6 +169,14 @@ else:
                 return self.__obj.writelines(*args, **kwargs)
     else:
         GzipFile = gzip.GzipFile
+
+    try:
+        from backports.lzma import LZMAFile
+    except ImportError:
+        class LZMAFile:
+            def __init__(self, *args, **kwargs):
+                raise ValueError("xz files requires the lzma module. "
+                                 "To use, install backports.lzma.")
 
 
 def getargspec(func):

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -3,14 +3,16 @@ import os
 import numpy as np
 import pytest
 
-from dask.compatibility import BZ2File, GzipFile
+from dask.compatibility import BZ2File, GzipFile, LZMAFile
 from dask.utils import (textblock, filetext, takes_multiple_arguments,
                         Dispatch, tmpfile, different_seeds)
 
 
 @pytest.mark.parametrize('myopen,compression',
-                         [(open, None), (GzipFile, 'gzip'), (BZ2File, 'bz2')])
+                         [(open, None), (GzipFile, 'gzip'), (BZ2File, 'bz2'), (LZMAFile, 'xz')])
 def test_textblock(myopen, compression):
+    if compression == 'xz':
+        pytest.importorskip('lzma')
     text = b'123 456 789 abc def ghi'.replace(b' ', os.linesep.encode())
     with filetext(text, open=myopen, mode='wb') as fn:
         text = ''.join(textblock(fn, 1, 11, compression)).encode()

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -14,7 +14,7 @@ import inspect
 import codecs
 from sys import getdefaultencoding
 
-from .compatibility import long, getargspec, BZ2File, GzipFile
+from .compatibility import long, getargspec, BZ2File, GzipFile, LZMAFile
 
 
 system_encoding = getdefaultencoding()
@@ -142,7 +142,7 @@ def filetexts(d, open=open):
             os.remove(filename)
 
 
-compressions = {'gz': 'gzip', 'bz2': 'bz2'}
+compressions = {'gz': 'gzip', 'bz2': 'bz2', 'xz': 'xz'}
 
 
 def infer_compression(filename):
@@ -150,7 +150,7 @@ def infer_compression(filename):
     return compressions.get(extension, None)
 
 
-opens = {'gzip': GzipFile, 'bz2': BZ2File}
+opens = {'gzip': GzipFile, 'bz2': BZ2File, 'xz': LZMAFile}
 
 
 def open(filename, mode='rb', compression=None, **kwargs):


### PR DESCRIPTION
I added support for xz-files / lzma compression and would welcome some feedback. I'll add unit tests for this features soon.

Furthermore, our xz-files contain individually compressed chunks created by GNU parallel (details see below), so it would be nice if you could guild me on how it would be possible to implement this parallelization in dask.

Here's how the files are created and loaded using gnu parallel:
```
# compress: run xz on 2G block of data and simply concat output (this is ok for xz format)
parallel --gnu --block 2G --pipe --keep-order --verbose 'xz -e9 -S $description-{#}' < ${input}.raw > ${output}.xz

# decompress: split on xz header and decompress chunks individually
parallel --gnu --pipe --recstart `echo -e '\xfd7zXZ\x00'` 'xzcat | grep ${pattern}' < ${input}.xz | ...
```