### PR TITLE
try to load lzmaffi for efficient seek in .xz

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -16,7 +16,10 @@ if PY3:
     from io import StringIO, BytesIO
     from bz2 import BZ2File
     from gzip import GzipFile
-    from lzma import LZMAFile
+    try:
+        from lzmaffi import LZMAFile
+    except ImportError:
+        from lzma import LZMAFile
     from urllib.request import urlopen
     from urllib.parse import urlparse
     from urllib.parse import quote, unquote
@@ -171,12 +174,15 @@ else:
         GzipFile = gzip.GzipFile
 
     try:
-        from backports.lzma import LZMAFile
+        try:
+            from lzmaffi import LZMAFile
+        except ImportError:
+            from backports.lzma import LZMAFile
     except ImportError:
         class LZMAFile:
             def __init__(self, *args, **kwargs):
                 raise ValueError("xz files requires the lzma module. "
-                                 "To use, install backports.lzma.")
+                                 "To use, install lzmaffi or backports.lzma.")
 
 
 def getargspec(func):


### PR DESCRIPTION
Found an easy solution for efficient seek in xz files by using [lzmaffi](https://github.com/r3m0t/backports.lzma) if available.