### PR TITLE
File size bug

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -9,6 +9,8 @@ import types
 PY3 = sys.version_info[0] == 3
 PY2 = sys.version_info[0] == 2
 
+LZMA_AVAILABLE = True
+
 if PY3:
     import builtins
     from queue import Queue, Empty
@@ -183,6 +185,7 @@ else:
             def __init__(self, *args, **kwargs):
                 raise ValueError("xz files requires the lzma module. "
                                  "To use, install lzmaffi or backports.lzma.")
+        LZMA_AVAILABLE = False
 
 
 def getargspec(func):

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -388,6 +388,10 @@ def file_size(fn, compression=None):
         with open(fn, 'rb') as f:
             f.seek(-4, 2)
             result = struct.unpack('I', f.read(4))[0]
+    elif compression:
+        # depending on the implementation, this may be inefficient
+        with open(fn, 'rb', compression) as f:
+            result = f.seek(0, 2)
     else:
         result = os.stat(fn).st_size
     return result


### PR DESCRIPTION
Found bug in `utils.file_size` giving wrong results with compressed files, resulting in `dataframe.read_csv` truncating bz2 and xz compressed files.

My easy fix is not efficient for bz2 and only efficient with using libaffi for xz (#1096) support.