### PR TITLE
Fix as read_csv does not pass chunkbytes with glob-string

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -217,7 +217,8 @@ def read_csv(fn, **kwargs):
     # Handle glob strings
     if '*' in fn:
         from .multi import concat
-        return concat([read_csv(f, **kwargs) for f in sorted(glob(fn))])
+        return concat([read_csv(f, chunkbytes=chunkbytes, index=index, **kwargs)
+                       for f in sorted(glob(fn))])
 
     token = tokenize(os.path.getmtime(fn), kwargs)
     name = 'read-csv-%s-%s' % (fn, token)

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -74,8 +74,9 @@ def test_read_multiple_csv():
             f.write(text)
         with open('_foo.2.csv', 'w') as f:
             f.write(text)
-        df = dd.read_csv('_foo.*.csv')
+        df = dd.read_csv('_foo.*.csv', chunkbytes=30)
         assert df._known_dtype
+        assert df.npartitions > 2
 
         assert (len(read_csv('_foo.*.csv').compute()) ==
                 len(read_csv('_foo.1.csv').compute()) * 2)


### PR DESCRIPTION
`read_csv` does not pass chunkbytes and index to sub-tasks after the glob-string was resolved.
Also added a chunkbytes arg in `test_read_multiple_csv` and check on npartitions to test this.