### PR TITLE
Linear operator

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1958,6 +1958,16 @@ def tensordot(lhs, rhs, axes=2):
         raise NotImplementedError("Simultaneous Contractions of multiple "
                 "indices not yet supported")
 
+    if isinstance(lhs, np.ndarray):
+        chunks = [(d,) for d in lhs.shape]
+        chunks[left_axes[0]] = rhs.chunks[right_axes[0]]
+        lhs = from_array(lhs, chunks=chunks)
+
+    if isinstance(rhs, np.ndarray):
+        chunks = [(d,) for d in rhs.shape]
+        chunks[right_axes[0]] = lhs.chunks[left_axes[0]]
+        rhs = from_array(rhs, chunks=chunks)
+
     if lhs._dtype is not None and rhs._dtype is not None :
         dt = np.promote_types(lhs._dtype, rhs._dtype)
     else:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1033,6 +1033,10 @@ class Array(Base):
         return tensordot(self, other, axes=((self.ndim-1,), (other.ndim-2,)))
 
     @property
+    def A(self):
+        return self
+
+    @property
     def T(self):
         return transpose(self)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -504,12 +504,15 @@ def test_field_access():
 
 def test_tensordot():
     x = np.arange(400).reshape((20, 20))
-    a = from_array(x, chunks=(5, 5))
+    a = from_array(x, chunks=(5, 4))
     y = np.arange(200).reshape((20, 10))
-    b = from_array(y, chunks=(5, 5))
+    b = from_array(y, chunks=(4, 5))
 
-    assert_eq(tensordot(a, b, axes=1), np.tensordot(x, y, axes=1))
-    assert_eq(tensordot(a, b, axes=(1, 0)), np.tensordot(x, y, axes=(1, 0)))
+    for axes in [1, (1, 0)]:
+        assert_eq(tensordot(a, b, axes=axes), np.tensordot(x, y, axes=axes))
+        assert_eq(tensordot(x, b, axes=axes), np.tensordot(x, y, axes=axes))
+        assert_eq(tensordot(a, y, axes=axes), np.tensordot(x, y, axes=axes))
+
     assert same_keys(tensordot(a, b, axes=(1, 0)), tensordot(a, b, axes=(1, 0)))
     assert not same_keys(tensordot(a, b, axes=0), tensordot(a, b, axes=1))
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1996,3 +1996,7 @@ def test_atop_names():
     y = atop(add, 'i', x, 'i')
     assert y.name.startswith('add')
 
+
+def test_A_property():
+    x = da.ones(5, chunks=(2,))
+    assert x.A is x

--- a/dask/array/tests/test_linearoperator.py
+++ b/dask/array/tests/test_linearoperator.py
@@ -1,0 +1,34 @@
+import pytest
+pytest.importorskip('scipy')
+
+import numpy as np
+import dask.array as da
+import scipy.sparse.linalg
+
+
+def test_LinearOperator():
+    X = np.random.random(size=(3, 2))
+    y = np.random.random(size=(2, 1))
+    w = np.random.random(size=(3, 1))
+    square = np.random.random(size=(2, 2))
+
+    dX = da.from_array(X, chunks=(2, 1))
+
+    npLO = scipy.sparse.linalg.aslinearoperator(X)
+    daLO = scipy.sparse.linalg.interface.MatrixLinearOperator(dX)
+
+    functions = [lambda x, y: x.matvec(y),
+                 lambda x, y: x * y,
+                 lambda x, y: x.dot(y)]
+    for func in functions:
+        assert np.allclose(func(npLO, y),
+                           func(daLO, y))
+
+    assert np.allclose(npLO.matmat(square),
+                       daLO.matmat(square))
+
+    assert np.allclose(npLO.rmatvec(w),
+                       daLO.rmatvec(w))
+
+    assert npLO.dtype == daLO.dtype
+    assert npLO.shape == daLO.shape

--- a/docs/source/array-linear-operator.rst
+++ b/docs/source/array-linear-operator.rst
@@ -1,0 +1,28 @@
+LinearOperator
+==============
+
+Dask arrays implement the SciPy LinearOperator_ interface and so can be used
+with any SciPy algorithm depending on that interface.
+
+Example
+-------
+
+.. code-block:: python
+
+   import dask.array as da
+   x = da.random.random(size=(10000, 10000), chunks=(1000, 1000))
+
+   from scipy.sparse.linalg.interface import MatrixLinearOperator
+   A = MatrixLinearOperator(x)
+
+   import numpy as np
+   b = np.random.random(10000)
+
+   from scipy.sparse.linalg import gmres
+   x = gmres(A, b)
+
+*Disclaimer: This is just a toy example and not necessarily the best way to
+solve this problem for this data.*
+
+
+.. _LinearOperator: http://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html

--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -22,3 +22,4 @@ Other topics
    array-ghost.rst
    array-design.rst
    array-extend.rst
+   array-linear-operator.rst


### PR DESCRIPTION
This makes dask.array compliant with the `scipy.sparse.linalg.interface.MatrixLinearOperator` class.  On the way we added support for `da.tensordot(da.Array, np.ndarray)`.

cc @teoliphant 

See added doc page for example