### PR TITLE
Test divisions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2450,7 +2450,7 @@ def repartition_divisions(a, b, name, out1, out2, force=False):
         k += 1
 
     # right part of new division can remain
-    if a[-1] < b[-1]:
+    if a[-1] < b[-1] or b[-1] == b[-2]:
         for _j in range(j, len(b)):
             # always use right-most of old division
             # because it may contain last element
@@ -2479,7 +2479,7 @@ def repartition_divisions(a, b, name, out1, out2, force=False):
         while c[i] < b[j]:
             tmp.append((out1, i))
             i += 1
-        if last_elem and c[i] == b[-1] and i < k:
+        if last_elem and c[i] == b[-1] and (b[-1] != b[-2] or j == len(b) - 1) and i < k:
             # append if last split is not included
             tmp.append((out1, i))
             i += 1

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -380,10 +380,13 @@ class _Frame(Base):
         """ Helper function for the .loc accessor """
         if isinstance(ind, Series):
             return self._loc_series(ind)
-        elif isinstance(ind, slice):
-            return self._loc_slice(ind)
+        if self.known_divisions:
+            if isinstance(ind, slice):
+                return self._loc_slice(ind)
+            else:
+                return self._loc_element(ind)
         else:
-            return self._loc_element(ind)
+            return map_partitions(try_loc, self, self, ind)
 
     def _loc_series(self, ind):
         if not self.divisions == ind.divisions:
@@ -396,14 +399,13 @@ class _Frame(Base):
         part = _partition_of_index_value(self.divisions, ind)
         if ind < self.divisions[0] or ind > self.divisions[-1]:
             raise KeyError('the label [%s] is not in the index' % str(ind))
-        dsk = {(name, 0): (lambda df: df.loc[ind], (self._name, part))}
+        dsk = {(name, 0): (lambda df: df.loc[ind:ind], (self._name, part))}
 
         if self.ndim == 1:
             columns = self.name
         else:
             columns = ind
-        return self._constructor_sliced(merge(self.dask, dsk), name,
-                                        columns, [ind, ind])
+        return self._constructor(merge(self.dask, dsk), name, self, [ind, ind])
 
     def _loc_slice(self, ind):
         name = 'loc-slice-%s-%s' % (str(ind), self._name)
@@ -2034,21 +2036,22 @@ def _emulate(func, *args, **kwargs):
     return func(*_extract_pd(args), **_extract_pd(kwargs))
 
 
-def map_partitions(func, columns, *args, **kwargs):
+def map_partitions(func, metadata, *args, **kwargs):
     """ Apply Python function on each DataFrame block
 
     Parameters
     ----------
 
-    column_info : tuple or string
-        Column names or name of the output
+    metadata: _Frame, columns, name
+        Metadata for output
     targets : list
         List of target DataFrame / Series.
     """
+    metadata = _extract_pd(metadata)
 
     assert callable(func)
     token = kwargs.pop('token', 'map-partitions')
-    token_key = tokenize(token or func, columns, kwargs, *args)
+    token_key = tokenize(token or func, metadata, kwargs, *args)
     name = '{0}-{1}'.format(token, token_key)
 
     if all(isinstance(arg, Scalar) for arg in args):
@@ -2061,14 +2064,20 @@ def map_partitions(func, columns, *args, **kwargs):
     args = _maybe_align_partitions(args)
     dfs = [df for df in args if isinstance(df, _Frame)]
 
-    if columns is no_default:
+    if metadata is no_default:
         # pass no_default as much, because it updates internal cache
         try:
-            columns = _emulate(func, *args, **kwargs)
+            metadata = _emulate(func, *args, **kwargs)
         except Exception:
             # user function may fail
-            columns = None
-    metadata = columns
+            metadata = None
+
+    if isinstance(metadata, pd.DataFrame):
+        columns = metadata.columns
+    elif isinstance(metadata, pd.Series):
+        columns = metadata.name
+    else:
+        columns = metadata
 
     return_type = _get_return_type(dfs[0], metadata)
 
@@ -2077,7 +2086,7 @@ def map_partitions(func, columns, *args, **kwargs):
         values = [(arg._name, i if isinstance(arg, _Frame) else 0)
                   if isinstance(arg, (_Frame, Scalar)) else arg for arg in args]
         values = (apply, func, (tuple, values), kwargs)
-        dsk[(name, i)] = (_rename, metadata, values)
+        dsk[(name, i)] = (_rename, columns, values)
 
     dasks = [arg.dask for arg in args if isinstance(arg, (_Frame, Scalar))]
     return return_type(merge(dsk, *dasks), name, metadata, args[0].divisions)
@@ -2610,3 +2619,10 @@ class StringAccessor(Accessor):
     @staticmethod
     def call(obj, attr, *args):
         return getattr(obj.str, attr)(*args)
+
+
+def try_loc(df, ind):
+    try:
+        return df.loc[ind]
+    except KeyError:
+        return df.head(0)

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -343,7 +343,6 @@ def from_pandas(data, npartitions=None, chunksize=None, sort=True):
     chunksize : int, optional
         The size of the partitions of the index.
 
-
     Returns
     -------
     dask.DataFrame or dask.Series
@@ -386,7 +385,9 @@ def from_pandas(data, npartitions=None, chunksize=None, sort=True):
 
     if ((npartitions is None) == (chunksize is None)):
         raise ValueError('Exactly one of npartitions and chunksize must be specified.')
+
     nrows = len(data)
+
     if chunksize is None:
         chunksize = int(ceil(nrows / npartitions))
     else:
@@ -891,3 +892,51 @@ def from_imperative(dfs, metadata=None, divisions=None, columns=None):
         return Series(merge(dsk, dsk2), name, metadata, divisions)
     else:
         return DataFrame(merge(dsk, dsk2), name, metadata, divisions)
+
+
+def sorted_division_locations(seq, npartitions=None, chunksize=None):
+    """ Find division locations and values in sorted list
+
+    Examples
+    --------
+
+    >>> L = ['A', 'B', 'C', 'D', 'E', 'F']
+    >>> sorted_division_locations(L, chunksize=2)
+    (['A', 'C', 'E', 'F'], [0, 2, 4, 6])
+
+    >>> sorted_division_locations(L, chunksize=3)
+    (['A', 'D', 'F'], [0, 3, 6])
+
+    >>> L = ['A', 'A', 'A', 'A', 'B', 'B', 'B', 'C']
+    >>> sorted_division_locations(L, chunksize=3)
+    (['A', 'B', 'C'], [0, 4, 8])
+
+    >>> sorted_division_locations(L, chunksize=2)
+    (['A', 'B', 'C'], [0, 4, 8])
+
+    >>> sorted_division_locations(['A'], chunksize=2)
+    (['A', 'A'], [0, 1])
+    """
+    if ((npartitions is None) == (chunksize is None)):
+        raise ValueError('Exactly one of npartitions and chunksize must be specified.')
+
+    if npartitions:
+        chunksize = ceil(len(seq) / npartitions)
+
+    positions = [0]
+    values = [seq[0]]
+    for pos in list(range(0, len(seq), chunksize)):
+        if pos <= positions[-1]:
+            continue
+        while pos + 1 < len(seq) and seq[pos - 1] == seq[pos]:
+            pos += 1
+        values.append(seq[pos])
+        if pos == len(seq) - 1:
+            pos += 1
+        positions.append(pos)
+
+    if positions[-1] != len(seq):
+        positions.append(len(seq))
+        values.append(seq[-1])
+
+    return values, positions

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -23,7 +23,7 @@ dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]},
                               index=[5, 6, 8]),
        ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
                               index=[9, 9, 9])}
-d = dd.DataFrame(dsk, 'x', ['a', 'b'], [0, 4, 9, 9])
+d = dd.DataFrame(dsk, 'x', ['a', 'b'], [0, 5, 9, 9])
 full = d.compute()
 
 
@@ -944,6 +944,10 @@ def test_append():
     ddf = dd.from_pandas(df, 2)
     ddf2 = dd.from_pandas(df2, 2)
     ddf3 = dd.from_pandas(df3, 2)
+
+    s = pd.Series([7, 8], name=6, index=['a', 'b'])
+    assert eq(ddf.append(s), df.append(s))
+
     assert eq(ddf.append(ddf2), df.append(df2))
     assert eq(ddf.a.append(ddf2.a), df.a.append(df2.a))
     # different columns
@@ -956,9 +960,6 @@ def test_append():
 
     assert eq(ddf.append(df3), df.append(df3))
     assert eq(ddf.a.append(df3.b), df.a.append(df3.b))
-
-    s = pd.Series([7, 8], name=6, index=['a', 'b'])
-    assert eq(ddf.append(s), df.append(s))
 
 
 
@@ -1141,7 +1142,13 @@ def test_repartition():
 
 
 def test_repartition_divisions():
-    result = repartition_divisions([1, 3, 7], [1, 4, 6, 7], 'a', 'b', 'c')  # doctest: +SKIP
+    result = repartition_divisions([0, 6], [0, 6, 6], 'a', 'b', 'c')
+    assert result == {('b', 0): (_loc, ('a', 0), 0, 6, False),
+                      ('b', 1): (_loc, ('a', 0), 6, 6, True),
+                      ('c', 0): ('b', 0),
+                      ('c', 1): ('b', 1)}
+
+    result = repartition_divisions([1, 3, 7], [1, 4, 6, 7], 'a', 'b', 'c')
     assert result == {('b', 0): (_loc, ('a', 0), 1, 3, False),
                       ('b', 1): (_loc, ('a', 1), 3, 4, False),
                       ('b', 2): (_loc, ('a', 1), 4, 6, False),
@@ -1149,6 +1156,7 @@ def test_repartition_divisions():
                       ('c', 0): (pd.concat, (list, [('b', 0), ('b', 1)])),
                       ('c', 1): ('b', 2),
                       ('c', 2): ('b', 3)}
+
 
 def test_repartition_on_pandas_dataframe():
     df = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': list('abdabd')},

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -642,12 +642,12 @@ def test_loc():
 
     assert d.loc[5].divisions == (5, 5)
 
-    assert eq(d.loc[5], full.loc[5])
+    assert eq(d.loc[5], full.loc[5:5])
     assert eq(d.loc[3:8], full.loc[3:8])
     assert eq(d.loc[:8], full.loc[:8])
     assert eq(d.loc[3:], full.loc[3:])
 
-    assert eq(d.a.loc[5], full.a.loc[5])
+    assert eq(d.a.loc[5], full.a.loc[5:5])
     assert eq(d.a.loc[3:8], full.a.loc[3:8])
     assert eq(d.a.loc[:8], full.a.loc[:8])
     assert eq(d.a.loc[3:], full.a.loc[3:])
@@ -660,11 +660,27 @@ def test_loc():
     assert sorted(d.loc[5].dask) != sorted(d.loc[6].dask)
 
 
+def test_loc_non_informative_index():
+    df = pd.DataFrame({'x': [1, 2, 3, 4]}, index=[10, 20, 30, 40])
+    ddf = dd.from_pandas(df, npartitions=2, sort=True)
+    ddf.divisions = (None,) * 3
+    assert not ddf.known_divisions
+
+    ddf.loc[20:30].compute(get=dask.get)
+
+    assert eq(ddf.loc[20:30], df.loc[20:30])
+
+
+    df = pd.DataFrame({'x': [1, 2, 3, 4]}, index=[10, 20, 20, 40])
+    ddf = dd.from_pandas(df, npartitions=2, sort=True)
+    assert eq(ddf.loc[20], df.loc[20:20])
+
+
 def test_loc_with_text_dates():
     A = tm.makeTimeSeries(10).iloc[:5]
     B = tm.makeTimeSeries(10).iloc[5:]
     s = dd.Series({('df', 0): A, ('df', 1): B}, 'df', None,
-                  [A.index.min(), A.index.max(), B.index.max()])
+                  [A.index.min(), B.index.min(), B.index.max()])
 
     assert s.loc['2000': '2010'].divisions == s.divisions
     assert eq(s.loc['2000': '2010'], s)
@@ -764,8 +780,6 @@ def test_unknown_divisions():
 
     assert eq(d.a.sum(), full.a.sum())
     assert eq(d.a + d.b + 1, full.a + full.b + 1)
-
-    assert raises(ValueError, lambda: d.loc[3])
 
 
 def test_concat2():

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -342,7 +342,7 @@ def test_from_bcolz_column_order():
     t = bcolz.ctable([[1, 2, 3], [1., 2., 3.], ['a', 'b', 'a']],
                      names=['x', 'y', 'a'])
     df = dd.from_bcolz(t, chunksize=2)
-    assert list(df.loc[0].compute().index) == ['x', 'y', 'a']
+    assert list(df.loc[0].compute().columns) == ['x', 'y', 'a']
 
 
 def test_skipinitialspace():

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -480,6 +480,13 @@ def test_from_pandas_non_sorted():
     eq(df, ddf)
 
 
+def test_from_pandas_single_row():
+    df = pd.DataFrame({'x': [1]}, index=[1])
+    ddf = dd.from_pandas(df, npartitions=1)
+    assert ddf.divisions == (1, 1)
+    assert eq(ddf, df)
+
+
 def test_DataFrame_from_dask_array():
     x = da.ones((10, 3), chunks=(4, 2))
 


### PR DESCRIPTION
We weren't using divisions consistently across all functions.  This adds extra tests to the `eq` method used for testing and has revealed a few small issues in `repartition`, `from_pandas`, and `loc`

Fixes https://github.com/dask/dask/issues/1057
Fixes https://github.com/dask/dask/issues/916

This changes the API slightly.  `df.loc[element]` always returns a `DataFrame`.  This is a break from Pandas.

cc @sinhrks 