### PR TITLE
Separate Delayed into DelayedFunction

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -143,12 +143,11 @@ def normalize_function(func):
         return (normalize_function(func.func), func.args, kws)
     else:
         try:
-            return pickle.dumps(func, protocol=pickle.HIGHEST_PROTOCOL)
+            return pickle.dumps(func, protocol=0)
         except:
             try:
                 import cloudpickle
-                return cloudpickle.dumps(func,
-                        protocol=pickle.HIGHEST_PROTOCOL)
+                return cloudpickle.dumps(func, protocol=0)
             except:
                 return str(func)
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -151,7 +151,7 @@ normalize_token.register((int, float, str, unicode, bytes, type(None), type,
 
 @partial(normalize_token.register, dict)
 def normalize_dict(d):
-    return normalize_token(sorted(d.items()))
+    return normalize_token(sorted(d.items(), key=str))
 
 @partial(normalize_token.register, (tuple, list, set))
 def normalize_seq(seq):

--- a/dask/base.py
+++ b/dask/base.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from functools import partial
 from hashlib import md5
 from operator import attrgetter
+import pickle
 import os
 import sys
 import uuid
@@ -141,7 +142,15 @@ def normalize_function(func):
         kws = tuple(sorted(func.keywords.items())) if func.keywords else ()
         return (normalize_function(func.func), func.args, kws)
     else:
-        return str(func)
+        try:
+            return pickle.dumps(func, protocol=pickle.HIGHEST_PROTOCOL)
+        except:
+            try:
+                import cloudpickle
+                return cloudpickle.dumps(func,
+                        protocol=pickle.HIGHEST_PROTOCOL)
+            except:
+                return str(func)
 
 
 normalize_token = Dispatch()

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -347,6 +347,13 @@ class DelayedFunction(Delayed):
     def __call__(self, *args, **kwargs):
         dask_key_name = kwargs.pop('dask_key_name', None)
         pure = kwargs.pop('pure', False)
+
+        if dask_key_name is None:
+            name = ((self.prefix or funcname(self.function)) + '-' +
+                    tokenize(self._key, *args, pure=self.pure, **kwargs))
+        else:
+            name = dask_key_name
+
         args, dasks = unzip(map(to_task_dasks, args), 2)
         if kwargs:
             dask_kwargs, dasks2 = to_task_dasks(kwargs)
@@ -355,11 +362,6 @@ class DelayedFunction(Delayed):
         else:
             task = (self.function,) + args
 
-        if dask_key_name is None:
-            name = ((self.prefix or funcname(self.function)) + '-' +
-                    tokenize(self._key, args, pure=self.pure, **kwargs))
-        else:
-            name = dask_key_name
         dasks = flat_unique(dasks)
         dasks.append({name: task})
         return Delayed(name, dasks)

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -325,10 +325,6 @@ class Delayed(base.Base):
 
 
 class DelayedLeaf(Delayed):
-    _optimize = staticmethod(lambda dsk, keys, **kwargs: dsk)
-    _finalize = staticmethod(first)
-    _default_get = staticmethod(get_sync)
-
     def __init__(self, obj, name=None, pure=False):
         if name is None:
             try:

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -209,11 +209,13 @@ def delayed(obj, name=None, pure=False, prefix=None):
     """
     if isinstance(obj, Delayed):
         return obj
-    if callable(obj):
+
+    task, dasks = to_task_dasks(obj)
+
+    if not dasks and callable(obj):
         return DelayedFunction(obj, pure=pure, prefix=prefix)
     else:
-        task, dasks = to_task_dasks(obj)
-        name = name or '%s-%s' % (type(obj).__name__, tokenize(task, pure=pure))
+        name = name or '%s-%s' % (type(obj).__name__, tokenize(task))
         dasks.append({name: task})
         return Delayed(name, dasks)
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -21,19 +21,37 @@ from dask.compatibility import unicode
 def test_normalize_function():
     def f1(a, b, c=1):
         pass
-    cf1 = curry(f1)
     def f2(a, b=1, c=2):
         pass
     def f3(a):
         pass
-    assert normalize_function(f2) == str(f2)
+
+    assert normalize_function(f2)
+
     f = lambda a: a
-    assert normalize_function(f) == str(f)
-    comp = compose(partial(f2, b=2), f3)
-    assert normalize_function(comp) == ((str(f2), (), (('b', 2),)), str(f3))
-    assert normalize_function(cf1) == (str(f1), (), ())
-    assert normalize_function(cf1(2, c=2)) == (str(f1), (2,), (('c', 2),))
-    assert normalize_token(cf1) == normalize_function(cf1)
+    assert normalize_function(f)
+
+    assert (normalize_function(partial(f2, b=2)) ==
+            normalize_function(partial(f2, b=2)))
+
+    assert (normalize_function(partial(f2, b=2)) !=
+            normalize_function(partial(f2, b=3)))
+
+    assert (normalize_function(partial(f1, b=2)) !=
+            normalize_function(partial(f2, b=2)))
+
+    assert (normalize_function(compose(f2, f3)) ==
+            normalize_function(compose(f2, f3)))
+
+    assert (normalize_function(compose(f2, f3)) !=
+            normalize_function(compose(f2, f1)))
+
+    assert normalize_function(curry(f2)) == normalize_function(curry(f2))
+    assert normalize_function(curry(f2)) != normalize_function(curry(f1))
+    assert (normalize_function(curry(f2, b=1)) ==
+            normalize_function(curry(f2, b=1)))
+    assert (normalize_function(curry(f2, b=1)) !=
+            normalize_function(curry(f2, b=2)))
 
 
 def test_tokenize():

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -147,6 +147,10 @@ def test_tokenize_sequences():
     assert tokenize([x]) != tokenize([y])
 
 
+def test_tokenize_dict():
+    assert tokenize({'x': 1, 1: 'x'}) == tokenize({'x': 1, 1: 'x'})
+
+
 def test_tokenize_ordered_dict():
     with ignoring(ImportError):
         from collections import OrderedDict

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -3,6 +3,7 @@ from operator import add, setitem
 import pickle
 from random import random
 
+from toolz import identity, partial
 import pytest
 
 from dask.delayed import delayed, to_task_dasks, compute, Delayed
@@ -271,3 +272,13 @@ def test_callable_obj():
     assert f.compute() is foo
     assert f.a.compute() == 1
     assert f().compute() == 2
+
+
+def test_name_consitent_across_instances():
+    func = delayed(identity, pure=True)
+    assert func(1)._key == 'identity-2ad77b789acfb7f92e39cbb8cb91172d'
+
+
+def test_name_sensitive_to_partials():
+    assert (delayed(partial(add, 10), pure=True)(2)._key !=
+            delayed(partial(add, 20), pure=True)(2)._key)

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -248,12 +248,6 @@ def test_delayed_callable():
     assert f.compute() == add
 
 
-def test_delayed_prefix():
-    f = delayed(add, prefix='foo')
-    assert f(1, 2)._key.startswith('foo')
-    assert f(1, 2)._key != f(2, 3)._key
-
-
 def test_delayed_name_on_call():
     f = delayed(add, pure=True)
     assert f(1, 2, dask_key_name='foo')._key == 'foo'
@@ -278,12 +272,12 @@ def test_name_consitent_across_instances():
     func = delayed(identity, pure=True)
 
     data = {'x': 1, 'y': 25, 'z': [1, 2, 3]}
-    assert func(data)._key == 'identity-51ba0a5e8802714adbfebe0e459b329c'
+    assert func(data)._key == 'identity-96264b683ea5350c2067dede25197638'
 
     data = {'x': 1, 1: 'x'}
     assert func(data)._key == func(data)._key
 
-    assert func(1)._key == 'identity-4b2538dc5ee69432194831bfdfbe40c3'
+    assert func(1)._key == 'identity-dbec0aef480428bd17026e745b7e8e11'
 
 
 def test_sensitive_to_partials():

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -272,12 +272,12 @@ def test_name_consitent_across_instances():
     func = delayed(identity, pure=True)
 
     data = {'x': 1, 'y': 25, 'z': [1, 2, 3]}
-    assert func(data)._key == 'identity-96264b683ea5350c2067dede25197638'
+    assert func(data)._key == 'identity-6611a0dc9183f09b04a35db23d14fb7d'
 
     data = {'x': 1, 1: 'x'}
     assert func(data)._key == func(data)._key
 
-    assert func(1)._key == 'identity-dbec0aef480428bd17026e745b7e8e11'
+    assert func(1)._key == 'identity-1b6bde2fbd96b2278a4d2e7514366606'
 
 
 def test_sensitive_to_partials():

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -245,3 +245,14 @@ def test_delayed_callable():
 
     assert f.dask == {f.key: add}
     assert f.compute() == add
+
+
+def test_delayed_prefix():
+    f = delayed(add, prefix='foo')
+    assert f(1, 2)._key.startswith('foo')
+    assert f(1, 2)._key != f(2, 3)._key
+
+
+def test_delayed_name_on_call():
+    f = delayed(add, pure=True)
+    assert f(1, 2, dask_key_name='foo')._key == 'foo'

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -276,9 +276,16 @@ def test_callable_obj():
 
 def test_name_consitent_across_instances():
     func = delayed(identity, pure=True)
-    assert func(1)._key == 'identity-2ad77b789acfb7f92e39cbb8cb91172d'
+
+    data = {'x': 1, 'y': 25, 'z': [1, 2, 3]}
+    assert func(data)._key == 'identity-51ba0a5e8802714adbfebe0e459b329c'
+
+    data = {'x': 1, 1: 'x'}
+    assert func(data)._key == func(data)._key
+
+    assert func(1)._key == 'identity-4b2538dc5ee69432194831bfdfbe40c3'
 
 
-def test_name_sensitive_to_partials():
+def test_sensitive_to_partials():
     assert (delayed(partial(add, 10), pure=True)(2)._key !=
             delayed(partial(add, 20), pure=True)(2)._key)

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -6,6 +6,7 @@ from random import random
 from toolz import identity, partial
 import pytest
 
+from dask.compatibility import PY2, PY3
 from dask.delayed import delayed, to_task_dasks, compute, Delayed
 from dask.utils import raises
 
@@ -272,12 +273,18 @@ def test_name_consitent_across_instances():
     func = delayed(identity, pure=True)
 
     data = {'x': 1, 'y': 25, 'z': [1, 2, 3]}
-    assert func(data)._key == 'identity-6611a0dc9183f09b04a35db23d14fb7d'
+    if PY2:
+        assert func(data)._key == 'identity-69e6d664a9054dce0e4dcaf48b919b8b'
+    if PY3:
+        assert func(data)._key == 'identity-6611a0dc9183f09b04a35db23d14fb7d'
 
     data = {'x': 1, 1: 'x'}
     assert func(data)._key == func(data)._key
 
-    assert func(1)._key == 'identity-1b6bde2fbd96b2278a4d2e7514366606'
+    if PY2:
+        assert func(1)._key == 'identity-9ed591b193ff79d4909cc7ae58786091'
+    if PY3:
+        assert func(1)._key == 'identity-1b6bde2fbd96b2278a4d2e7514366606'
 
 
 def test_sensitive_to_partials():

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -256,3 +256,18 @@ def test_delayed_prefix():
 def test_delayed_name_on_call():
     f = delayed(add, pure=True)
     assert f(1, 2, dask_key_name='foo')._key == 'foo'
+
+
+def test_callable_obj():
+    class Foo(object):
+        def __init__(self, a):
+            self.a = a
+
+        def __call__(self):
+            return 2
+
+    foo = Foo(1)
+    f = delayed(foo)
+    assert f.compute() is foo
+    assert f.a.compute() == 1
+    assert f().compute() == 2

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -564,6 +564,5 @@ def funcname(func, full=False):
             return func.__qualname__
         else:
             return func.__name__
-
     except:
         return str(func)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -555,11 +555,15 @@ def derived_from(original_klass, version=None, ua_args=[]):
     return wrapper
 
 
-def funcname(func):
+def funcname(func, full=False):
     """Get the name of a function."""
     while hasattr(func, 'func'):
         func = func.func
     try:
-        return func.__name__
+        if full:
+            return func.__qualname__
+        else:
+            return func.__name__
+
     except:
         return str(func)


### PR DESCRIPTION
Added a `prefix=` keyword to delayed

    dfunc = delayed(function, prefix='add')

added a `dask_key_name=` keyword to calling a delayed function:

    dfunc(1, 2, dask_key_name='add-1-2')

It felt odd adding extra function-specific keyword arguments to the
`Delayed` class.  It feels like we're overloading one class with two
very different meanings so I'm also reseparating `Delayed` to
`DelayedFunction`

cc @jcrist 