### PR TITLE
Pass dependencies through optimizations

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -21,10 +21,11 @@ def optimize(dsk, keys, **kwargs):
     keys = list(flatten(keys))
     fast_functions = kwargs.get('fast_functions',
                              set([getarray, np.transpose]))
-    dsk2 = cull(dsk, keys)
-    dsk4 = fuse(dsk2, keys)
+    dsk2, dependencies = cull(dsk, keys)
+    dsk4, dependencies = fuse(dsk2, keys, dependencies)
     dsk5 = optimize_slices(dsk4)
-    dsk6 = inline_functions(dsk5, keys, fast_functions=fast_functions)
+    dsk6 = inline_functions(dsk5, keys, fast_functions=fast_functions,
+            dependencies=dependencies)
     return dsk6
 
 

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -69,14 +69,14 @@ def test_optimize_slicing():
            'e': (getarray, 'd', (slice(None, None, None),))}
 
     expected = {'e': (getarray, (range, 10), (slice(0, 5, None),))}
-    result = optimize_slices(fuse(dsk, []))
+    result = optimize_slices(fuse(dsk, [])[0])
     assert result == expected
 
     # protect output keys
     expected = {'c': (range, 10),
                 'd': (getarray, 'c', (slice(0, 5, None),)),
                 'e': 'd'}
-    result = optimize_slices(fuse(dsk, ['c', 'd', 'e']))
+    result = optimize_slices(fuse(dsk, ['c', 'd', 'e'])[0])
 
     assert result == expected
 

--- a/dask/async.py
+++ b/dask/async.py
@@ -434,7 +434,7 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
     for f in start_cbs:
         f(dsk)
 
-    dsk = cull(dsk, list(results))
+    dsk, dependencies = cull(dsk, list(results))
 
     keyorder = order(dsk)
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -64,7 +64,7 @@ def lazify(dsk):
     return valmap(lazify_task, dsk)
 
 
-def inline_singleton_lists(dsk):
+def inline_singleton_lists(dsk, dependencies=None):
     """ Inline lists that are only used once
 
     >>> d = {'b': (list, 'a'),
@@ -74,8 +74,8 @@ def inline_singleton_lists(dsk):
 
     Pairs nicely with lazify afterwards
     """
-
-    dependencies = dict((k, get_dependencies(dsk, k)) for k in dsk)
+    if dependencies is None:
+        dependencies = dict((k, get_dependencies(dsk, k)) for k in dsk)
     dependents = reverse_dict(dependencies)
 
     keys = [k for k, v in dsk.items()
@@ -85,9 +85,9 @@ def inline_singleton_lists(dsk):
 
 def optimize(dsk, keys, **kwargs):
     """ Optimize a dask from a dask.bag """
-    dsk2 = cull(dsk, keys)
-    dsk3 = fuse(dsk2, keys)
-    dsk4 = inline_singleton_lists(dsk3)
+    dsk2, dependencies = cull(dsk, keys)
+    dsk3, dependencies = fuse(dsk2, keys, dependencies)
+    dsk4 = inline_singleton_lists(dsk3, dependencies)
     dsk5 = lazify(dsk4)
     return dsk5
 

--- a/dask/core.py
+++ b/dask/core.py
@@ -319,7 +319,7 @@ def subs(task, key, val):
     return task[:1] + tuple(newargs)
 
 
-def _toposort(dsk, keys=None, returncycle=False):
+def _toposort(dsk, keys=None, returncycle=False, dependencies=None):
     # Stack-based depth-first search traversal.  This is based on Tarjan's
     # method for topological sorting (see wikipedia for pseudocode)
     if keys is None:
@@ -340,6 +340,9 @@ def _toposort(dsk, keys=None, returncycle=False):
     # that has already been added to `completed`.
     seen = set()
 
+    if dependencies is None:
+        dependencies = dict((k, get_dependencies(dsk, k)) for k in dsk)
+
     for key in keys:
         if key in completed:
             continue
@@ -355,7 +358,7 @@ def _toposort(dsk, keys=None, returncycle=False):
 
             # Add direct descendants of cur to nodes stack
             next_nodes = []
-            for nxt in get_dependencies(dsk, cur):
+            for nxt in dependencies[cur]:
                 if nxt not in completed:
                     if nxt in seen:
                         # Cycle detected!
@@ -385,9 +388,9 @@ def _toposort(dsk, keys=None, returncycle=False):
     return ordered
 
 
-def toposort(dsk):
+def toposort(dsk, dependencies=None):
     """ Return a list of keys of dask sorted in topological order."""
-    return _toposort(dsk)
+    return _toposort(dsk, dependencies=dependencies)
 
 
 def getcycle(d, keys):

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -15,9 +15,9 @@ def fuse_castra_index(dsk):
 
 def optimize(dsk, keys, **kwargs):
     if isinstance(keys, list):
-        dsk2 = cull(dsk, list(core.flatten(keys)))
+        dsk2, dependencies = cull(dsk, list(core.flatten(keys)))
     else:
-        dsk2 = cull(dsk, [keys])
+        dsk2, dependencies = cull(dsk, [keys])
     try:
         from castra import Castra
         dsk3 = fuse_getitem(dsk2, Castra.load_partition, 3)
@@ -25,5 +25,5 @@ def optimize(dsk, keys, **kwargs):
     except ImportError:
         dsk4 = dsk2
     dsk5 = fuse_getitem(dsk4, dataframe_from_ctable, 3)
-    dsk6 = cull(dsk5, keys)
+    dsk6, _ = cull(dsk5, keys)
     return dsk6

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -144,7 +144,7 @@ def set_partition(df, index, divisions, compute=False, drop=True, **kwargs):
         dsk.update(index.dask)
 
     if compute:
-        dsk = cull(dsk, list(dsk4.keys()))
+        dsk, _ = cull(dsk, list(dsk4.keys()))
 
     return DataFrame(dsk, name, metadata, divisions)
 

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -68,8 +68,9 @@ def get(dsk, keys, optimizations=[], num_workers=None,
                                           func_loads=func_loads)
 
     # Optimize Dask
-    dsk2 = fuse(dsk, keys)
-    dsk3 = pipe(dsk2, partial(cull, keys=keys), *optimizations)
+    dsk2, dependencies = cull(dsk, keys)
+    dsk3, dependencies = fuse(dsk2, keys, dependencies)
+    dsk4 = pipe(dsk3, *optimizations)
 
     try:
         # Run

--- a/dask/order.py
+++ b/dask/order.py
@@ -58,10 +58,10 @@ from __future__ import absolute_import, division, print_function
 
 from operator import add
 
-from .core import get_deps
+from .core import get_dependencies, reverse_dict, get_deps
 
 
-def order(dsk):
+def order(dsk, dependencies=None):
     """ Order nodes in dask graph
 
     The ordering will be a toposort but will also have other convenient
@@ -74,7 +74,10 @@ def order(dsk):
     >>> order(dsk)
     {'a': 2, 'c': 1, 'b': 3, 'd': 0}
     """
-    dependencies, dependents = get_deps(dsk)
+    if dependencies is None:
+        dependencies = dict((k, get_dependencies(dsk, k)) for k in dsk)
+    dependents = reverse_dict(dependencies)
+
     ndeps = ndependents(dependencies, dependents)
     maxes = child_max(dependencies, dependents, ndeps)
     return dfs(dependencies, dependents, key=maxes.get)

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -1,5 +1,6 @@
 from itertools import chain
-from dask.order import dfs, child_max, ndependents, order, inc, get_deps
+from dask.order import dfs, child_max, ndependents, order, inc
+from dask.core import get_deps
 
 
 def issorted(L, reverse=False):


### PR DESCRIPTION
This makes cull and fuse, two very common optimizations, return a
second ``dependencies`` result that is a frequently reused side effect
of the computation.  Dask.array was recreating this fairly expensive
data five times for a single optimization pass.

This is bad because it complicates optimizations.  This is good
because it halves total optimization time in some cases.

Fixes #1133 

cc @eriknw if you have a minute can you take a look at these changes to dask.optimize?