### PR TITLE
Don't inline getitem in dask.array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -989,7 +989,7 @@ class Array(Base):
                 dt = np.dtype([(name, self._dtype[name]) for name in index])
             else:
                 dt = None
-            return elemwise(getarray, self, index, dtype=dt, name=out)
+            return elemwise(getitem, self, index, dtype=dt, name=out)
 
         # Slicing
         if not isinstance(index, tuple):
@@ -1762,7 +1762,7 @@ def stack(seq, axis=0):
 
     inputs = [(names[key[axis+1]],) + key[1:axis + 1] + key[axis + 2:]
                 for key in keys]
-    values = [(getarray, inp, (slice(None, None, None),) * axis
+    values = [(getitem, inp, (slice(None, None, None),) * axis
                            + (None,)
                            + (slice(None, None, None),) * (ndim - axis))
                 for inp in inputs]

--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -20,7 +20,7 @@ def optimize(dsk, keys, **kwargs):
     """
     keys = list(flatten(keys))
     fast_functions = kwargs.get('fast_functions',
-                             set([getarray, getitem, np.transpose]))
+                             set([getarray, np.transpose]))
     dsk2 = cull(dsk, keys)
     dsk4 = fuse(dsk2, keys)
     dsk5 = optimize_slices(dsk4)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -207,27 +207,27 @@ def test_stack():
 
     assert s.shape == (3, 4, 6)
     assert s.chunks == ((1, 1, 1), (2, 2), (3, 3))
-    assert s.dask[(s.name, 0, 1, 0)] == (getarray, ('A', 1, 0),
+    assert s.dask[(s.name, 0, 1, 0)] == (getitem, ('A', 1, 0),
                                           (None, colon, colon))
-    assert s.dask[(s.name, 2, 1, 0)] == (getarray, ('C', 1, 0),
+    assert s.dask[(s.name, 2, 1, 0)] == (getitem, ('C', 1, 0),
                                           (None, colon, colon))
     assert same_keys(s, stack([a, b, c], axis=0))
 
     s2 = stack([a, b, c], axis=1)
     assert s2.shape == (4, 3, 6)
     assert s2.chunks == ((2, 2), (1, 1, 1), (3, 3))
-    assert s2.dask[(s2.name, 0, 1, 0)] == (getarray, ('B', 0, 0),
+    assert s2.dask[(s2.name, 0, 1, 0)] == (getitem, ('B', 0, 0),
                                             (colon, None, colon))
-    assert s2.dask[(s2.name, 1, 1, 0)] == (getarray, ('B', 1, 0),
+    assert s2.dask[(s2.name, 1, 1, 0)] == (getitem, ('B', 1, 0),
                                             (colon, None, colon))
     assert same_keys(s2, stack([a, b, c], axis=1))
 
     s2 = stack([a, b, c], axis=2)
     assert s2.shape == (4, 6, 3)
     assert s2.chunks == ((2, 2), (3, 3), (1, 1, 1))
-    assert s2.dask[(s2.name, 0, 1, 0)] == (getarray, ('A', 0, 1),
+    assert s2.dask[(s2.name, 0, 1, 0)] == (getitem, ('A', 0, 1),
                                             (colon, colon, None))
-    assert s2.dask[(s2.name, 1, 1, 2)] == (getarray, ('C', 1, 1),
+    assert s2.dask[(s2.name, 1, 1, 2)] == (getitem, ('C', 1, 1),
                                             (colon, colon, None))
     assert same_keys(s2, stack([a, b, c], axis=2))
 


### PR DESCRIPTION
Previously we would inline getitem, getarray, and transpose calls
because they were very cheap to recompute.  When we start considering
distributed memory systems this optimization ends up causing a lot more
data transfer than is necessary.

However, it's still very important to inline the initial getitem call
coming from an HDF5 or NetCDF file.  This avoids sucking a lot of data
into memory in common operation.  We still want to inline in this case.

As a compromise we inline getarray but not getitem and use getarray
when dealing with foreign data sources that may or may not provide
numpy arrays on slicing.

cc @shoyer  (also @shoyer, is there anyone else I should start including in issues that may affect xarray?)