### PR TITLE
Add lineterminator to read_csv keywords

### DIFF
--- a/dask/dataframe/csv.py
+++ b/dask/dataframe/csv.py
@@ -141,6 +141,8 @@ def read_csv(filename, blocksize=2**25, chunkbytes=None,
     **kwargs: dict
         Options to pass down to ``pandas.read_csv``
     """
+    if len(lineterminator) == 1:
+        kwargs['lineterminator'] = lineterminator
     if chunkbytes is not None:
         warn("Deprecation warning: chunksize csv keyword renamed to blocksize")
         blocksize=chunkbytes

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -1044,3 +1044,10 @@ def test_to_hdf_kwargs():
     df2 = pd.read_hdf('tst.h5', 'foo4')
 
     tm.assert_frame_equal(df, df2)
+
+
+def test_read_csv_slash_r():
+    data = b'0,my\n1,data\n' * 1000 + b'2,foo\rbar'
+    with filetext(data, mode='wb') as fn:
+        dd.read_csv(fn, header=None, sep=',', lineterminator='\n',
+                    names=['a','b'], blocksize=200).compute(get=dask.get)


### PR DESCRIPTION
Previously we avoided putting lineterminator into keywords because we
often need to split on `\r\n` but can't pass this into pandas (only
terminators of length one are supported).  This caused problems when
the user explicitly stated that they were using `\n`, which has slightly
different behavior from default.

Now we pass in the lineterminator to pandas if it is of length one and
ignore it in pandas otherwise (staying with default).

Long term we might consider breaking this up into two arguments, one
for block splitting and one for within-block parsing.

Fixes #1132 

cc @wabu 