### PR TITLE
ResourceProfiler works with multiple gets

### DIFF
--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -92,6 +92,29 @@ def test_resource_profiler():
             get(dsk, 'e')
 
 
+@pytest.mark.skipif("not psutil")
+def test_resource_profiler_multiple_gets():
+    with ResourceProfiler(dt=0.01) as rprof:
+        get(dsk2, 'c')
+        assert len(rprof.results) == 0
+        get(dsk2, 'c')
+    results = rprof.results
+    assert all(isinstance(i, tuple) and len(i) == 3 for i in results)
+
+    rprof.clear()
+    rprof.register()
+    get(dsk2, 'c')
+    assert len(rprof.results) > 0
+    get(dsk2, 'c')
+    rprof.unregister()
+
+    results = rprof.results
+    assert all(isinstance(i, tuple) and len(i) == 3 for i in results)
+
+    rprof.close()
+    assert not rprof._tracker.is_alive()
+
+
 def test_cache_profiler():
     with CacheProfiler() as cprof:
         out = get(dsk2, 'c')


### PR DESCRIPTION
Previously `ResourceProfiler` would start and stop the background
tracker after each scheduler run. This adds overhead for iterative
passes that you'd want to do with dask. Now the profiler collects
resource usage the entire time it runs as a context manager, but
maintains the same behavior as before when registered globally.