### PR TITLE
Compat fix for pandas 0.18.1

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -952,9 +952,10 @@ class Series(_Frame):
 
     def __getattr__(self, key):
         if key == 'cat':
-            head = self.head()
-            if isinstance(head.dtype, pd.core.dtypes.CategoricalDtype):
-                return head.cat
+            # If unknown dtype, need to infer from head.
+            if not self._known_dtype:
+                self.dtype
+            return self._pd.cat
         raise AttributeError("'Series' object has no attribute %r" % key)
 
     @property

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -1,8 +1,5 @@
-from distutils.version import LooseVersion
-
 import pandas as pd
 import pandas.util.testing as tm
-import pytest
 
 import dask
 from dask.async import get_sync
@@ -44,8 +41,6 @@ def test_categorical_set_index():
         assert list(b.index.compute()), list(df2.index)
 
 
-@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.18.0',
-                    reason="pd.core.dtypes does not exist")
 def test_dataframe_categoricals():
     df = pd.DataFrame({'x': list('a'*5 + 'b'*5 + 'c'*5),
                        'y': range(15)})


### PR DESCRIPTION
Location of CategoricalDtype moved, but with the new metadata we no
longer need to import that anyway.