### PR TITLE
Inline getattr for dask.delayed objects

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -12,6 +12,8 @@ from .utils import concrete, funcname
 from . import base
 from .compatibility import apply
 from . import threaded
+from .optimize import inline_functions
+from .core import flatten
 
 __all__ = ['compute', 'do', 'Delayed', 'delayed']
 
@@ -256,9 +258,12 @@ class Delayed(base.Base):
     Equivalent to the output from a single key in a dask graph.
     """
     __slots__ = ('_key', '_dasks')
-    _optimize = staticmethod(lambda dsk, keys, **kwargs: dsk)
     _finalize = staticmethod(first)
     _default_get = staticmethod(threaded.get)
+
+    @staticmethod
+    def _optimize(dsk, keys, **kwargs):
+        return inline_functions(dsk, list(flatten(keys)), [getattr])
 
     def __init__(self, name, dasks):
         object.__setattr__(self, '_key', name)

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -66,6 +66,14 @@ def test_attributes():
     assert a.imag.compute() == 1
 
 
+def test_attr_optimize():
+    # Check that attribute access is inlined
+    a = delayed([1, 2, 3])
+    o = a.index(1)
+    dsk = o._optimize(o.dask, o._keys())
+    assert getattr not in set(v[0] for v in dsk.values())
+
+
 def test_value_errors():
     a = delayed([1, 2, 3])
     # Immutable


### PR DESCRIPTION
When using methods with `Delayed` values, a task is first created for
the attribute access, and a second task is created for the method call.
While the scheduler overhead of doing two tasks is minimal, this causes
problems when using delayed with distributed/multiprocessing, as methods
aren't necessarily pickleable. To fix this, we inline all calls to
`getattr` (which should also improve performance, since these calls are
cheap).