### PR TITLE
Avoid shuffles when merging with Pandas objects

### DIFF
--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -540,3 +540,19 @@ def test_cheap_inner_merge_with_pandas_object():
 
     list_eq(da.merge(b, on='x', how='inner'),
              a.merge(b, on='x', how='inner'))
+
+
+def test_cheap_single_partition_merge():
+    a = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': list('abdabd')},
+                     index=[10, 20, 30, 40, 50, 60])
+    aa = dd.from_pandas(a, npartitions=3)
+
+    b = pd.DataFrame({'x': [1, 2, 3, 4], 'z': list('abda')})
+    bb = dd.from_pandas(b, npartitions=1, sort=False)
+
+    cc = aa.merge(bb, on='x', how='inner')
+    assert all('shuffle' not in k[0] for k in cc.dask)
+    assert len(cc.dask) == len(aa.dask) * 2 + len(bb.dask)
+
+    list_eq(aa.merge(bb, on='x', how='inner'),
+            a.merge(b, on='x', how='inner'))

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -526,3 +526,17 @@ def test_melt():
             pd.melt(pdf, value_vars=['A', 'C'], var_name='myvar'))
     list_eq(dd.melt(ddf, id_vars='B', value_vars=['A', 'C'], value_name='myval'),
             pd.melt(pdf, id_vars='B', value_vars=['A', 'C'], value_name='myval'))
+
+
+def test_cheap_inner_merge_with_pandas_object():
+    a = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': list('abdabd')},
+                     index=[10, 20, 30, 40, 50, 60])
+    da = dd.from_pandas(a, npartitions=3)
+
+    b = pd.DataFrame({'x': [1, 2, 3, 4], 'z': list('abda')})
+
+    dc = da.merge(b, on='x', how='inner')
+    assert all('shuffle' not in k[0] for k in dc.dask)
+
+    list_eq(da.merge(b, on='x', how='inner'),
+             a.merge(b, on='x', how='inner'))


### PR DESCRIPTION
Previously dask.dataframe would convert all Pandas objects into
dask.dataframe objects.  In some cases this causes unnecessary shuffles.

In particular when you join a non-index column of a large dask.dataframe
against a small pandas table the right thing to do is to just move the
small pandas dataframe to all tasks, turning the computation into an
embarrassingly parallel one.

This isn't very clean.  Review welcome.  

cc @sinhrks 