### PR TITLE
Add db.Bag.unzip

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -465,6 +465,24 @@ class Bag(Base):
                        for i in range(self.npartitions))
         return type(self)(merge(self.dask, dsk), name, self.npartitions)
 
+    def unzip(self, n):
+        """Transform a bag of tuples to ``n`` bags of their elements.
+
+        Example
+        -------
+        >>> b = from_sequence([(i, i + 1, i + 2) for i in range(10)])
+        >>> first, second, third = b.unzip(3)
+        >>> isinstance(first, Bag)
+        True
+        >>> first.compute()
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+        Note that this is equivalent to:
+
+        >>> first, second, third = (b.pluck(i) for i in range(3))
+        """
+        return tuple(self.pluck(i) for i in range(n))
+
     @wraps(to_textfiles)
     def to_textfiles(self, path, name_function=str, compression='infer',
                      encoding=system_encoding, compute=True):

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -158,6 +158,15 @@ def test_pluck_with_default():
     assert b.pluck(0).name != b.pluck(0, None).name
 
 
+def test_unzip():
+    b = db.from_sequence(range(100)).map(lambda x: (x, x + 1, x + 2))
+    one, two, three = b.unzip(3)
+    assert list(one) == list(range(100))
+    assert list(three) == [i + 2 for i in range(100)]
+    assert one.name == b.unzip(3)[0].name
+    assert one.name != two.name
+
+
 def test_fold():
     c = b.fold(add)
     assert c.compute() == sum(L)


### PR DESCRIPTION
Allows for easy conversion of bags of tuples to multiple bags of their
elements.

```
>>> bag = db.from_sequence([(i, 2*i, 3*i) for i in range(10)])
>>> first, second, third = bag.unzip(3)
```