### PR TITLE
Use different names for input and output in from_array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -76,7 +76,7 @@ def slices_from_chunks(chunks):
                 for start, shape in zip(starts, shapes)]
 
 
-def getem(arr, chunks, shape=None):
+def getem(arr, chunks, shape=None, out_name=None):
     """ Dask getting various chunks from an array-like
 
     >>> getem('X', chunks=(2, 3), shape=(4, 6))  # doctest: +SKIP
@@ -91,9 +91,10 @@ def getem(arr, chunks, shape=None):
      ('X', 1, 1): (getarray, 'X', (slice(2, 4), slice(3, 6))),
      ('X', 0, 1): (getarray, 'X', (slice(0, 2), slice(3, 6)))}
     """
+    out_name = out_name or arr
     chunks = normalize_chunks(chunks, shape)
 
-    keys = list(product([arr], *[range(len(bds)) for bds in chunks]))
+    keys = list(product([out_name], *[range(len(bds)) for bds in chunks]))
 
     values = [(getarray, arr, x) for x in slices_from_chunks(chunks)]
 
@@ -1496,13 +1497,14 @@ def from_array(x, chunks, name=None, lock=False):
     if len(chunks) != len(x.shape):
         raise ValueError("Input array has %d dimensions but the supplied "
                 "chunks has only %d dimensions" % (len(x.shape), len(chunks)))
-    name = name or 'from-array-' + tokenize(x, chunks)
-    dsk = getem(name, chunks)
+    token = tokenize(x, chunks)
+    name = name or 'array-' + token
+    dsk = getem(name, chunks, out_name='from-' + name)
     if lock is True:
         lock = Lock()
     if lock:
         dsk = dict((k, v + (lock,)) for k, v in dsk.items())
-    return Array(merge({name: x}, dsk), name, chunks, dtype=x.dtype)
+    return Array(merge({name: x}, dsk), 'from-' + name, chunks, dtype=x.dtype)
 
 
 def from_imperative(*args, **kwargs):


### PR DESCRIPTION
Using the same name causes us to misjudge times for future computations.  This is a stop-gap measure.  The distributed scheduler needs to become more robust to misjudging computation times.