### PR TITLE
Define finalize function for dask.dataframe.Scalar

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -43,8 +43,6 @@ def _concat(args, **kwargs):
         return args
     if isinstance(first(core.flatten(args)), np.ndarray):
         return da.core.concatenate3(args)
-    if len(args) == 1:
-        return args[0]
     if isinstance(args[0], (pd.DataFrame, pd.Series)):
         args2 = [arg for arg in args if len(arg)]
         if not args2:
@@ -73,7 +71,7 @@ class Scalar(Base):
 
     _optimize = staticmethod(optimize)
     _default_get = staticmethod(threaded.get)
-    _finalize = staticmethod(finalize)
+    _finalize = staticmethod(first)
 
     def __init__(self, dsk, _name, name=None, divisions=None):
         self.dask = dsk

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1733,3 +1733,10 @@ def test_methods_tokenize_differently():
     df = dd.from_pandas(df, npartitions=1)
     assert (df.x.map_partitions(pd.Series.min)._name !=
             df.x.map_partitions(pd.Series.max)._name)
+
+
+def test_sorted_index_single_partition():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [1, 0, 1, 0]})
+    ddf = dd.from_pandas(df, npartitions=1)
+    eq(ddf.set_index('x', sorted=True),
+        df.set_index('x'))


### PR DESCRIPTION
Previously we special cased the single-element-list-of-ints case in
finalize to just return the first element.  This was correct for Scalar
but wrong for everything else.  Now we just define a separate finalize
function for scalar, which removes an ugly special case.

Fixes #1180