### PR TITLE
Add storage_options keyword to read_csv

### DIFF
--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -215,3 +215,10 @@ def test_modification_time_open_files():
         c = open_files('compress/test/accounts.*', s3=s3)
 
     assert [aa._key for aa in a] != [cc._key for cc in c]
+
+
+def test_read_csv_passes_through_options():
+    dd = pytest.importorskip('dask.dataframe')
+    with s3_context('csv', {'a.csv': b'a,b\n1,2\n3,4'}) as s3:
+        df = dd.read_csv('s3://csv/*.csv', storage_options={'s3': s3})
+        assert df.a.sum().compute() == 1 + 3

--- a/dask/dataframe/csv.py
+++ b/dask/dataframe/csv.py
@@ -115,7 +115,7 @@ def read_csv_from_bytes(block_lists, header, head, kwargs, collection=True,
 
 def read_csv(filename, blocksize=2**25, chunkbytes=None,
         collection=True, lineterminator='\n', compression=None,
-        sample=10000, enforce=False, **kwargs):
+        sample=10000, enforce=False, storage_options=None, **kwargs):
     """ Read CSV files into a Dask.DataFrame
 
     This parallelizes the ``pandas.read_csv`` file in the following ways:
@@ -177,7 +177,9 @@ def read_csv(filename, blocksize=2**25, chunkbytes=None,
     b_lineterminator = lineterminator.encode()
     sample, values = read_bytes(filename, delimiter=b_lineterminator,
                                           blocksize=blocksize,
-                                          sample=sample, compression=compression)
+                                          sample=sample,
+                                          compression=compression,
+                                          **(storage_options or {}))
     if not isinstance(values[0], (tuple, list)):
         values = [values]
 


### PR DESCRIPTION
Previously we had no way to pass down keyword arguments from read_csv
to a backend store like s3 or hdfs.  This is because `kwargs` was used
to supply pd.read_csv with options.  This commit adds a new
`storage_options` keyword that gets sent to the call to read_bytes.

cc @martindurant 