### PR TITLE
Add Task Shuffle

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -6,6 +6,7 @@ import itertools
 import math
 from operator import getitem
 import os
+import types
 import uuid
 from warnings import warn
 from distutils.version import LooseVersion
@@ -30,6 +31,7 @@ except:
 
 from ..base import Base, normalize_token, tokenize
 from ..compatibility import apply, unicode, urlopen
+from ..context import _globals
 from ..core import list2, quote, istask, get_dependencies, reverse_dict
 from ..multiprocessing import get as mpget
 from ..optimize import fuse, cull, inline
@@ -915,7 +917,12 @@ class Bag(Base):
         Bag.foldby
         """
         if method is None:
-            method = 'disk'
+            get = _globals.get('get')
+            if (isinstance(get, types.MethodType) and
+                'distributed' in get.__func__.__module__):
+                method = 'tasks'
+            else:
+                method = 'disk'
         if method == 'disk':
             return groupby_disk(self, grouper, npartitions=npartitions,
                                 blocksize=blocksize)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1504,6 +1504,7 @@ def groupby_tasks(b, grouper, hash=hash, max_branch=32,
 
     inputs = [tuple(digit(i, j, k) for j in range(stages))
               for i in range(n)]
+    sinputs = set(inputs)
 
     b2 = b.map(lambda x: (hash(grouper(x)), x))
 
@@ -1526,7 +1527,8 @@ def groupby_tasks(b, grouper, hash=hash, max_branch=32,
         join = dict(((name + '-join-' + token, stage, inp),
                      (list, (toolz.concat,
                         [(name + '-split-' + token, stage, inp[stage-1],
-                          insert(inp, stage - 1, j)) for j in range(k)])))
+                          insert(inp, stage - 1, j)) for j in range(k)
+                          if insert(inp, stage - 1, j) in sinputs])))
                      for inp in inputs)
         groups.append(group)
         splits.append(split)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -874,3 +874,13 @@ def test_groupby_tasks():
         for b in partitions:
             if a is not b:
                 assert not set(a) & set(b)
+
+
+    b = db.from_sequence(range(10000), npartitions=345)
+    out = b.groupby(lambda x: x % 2834, max_branch=24, method='tasks')
+    partitions = dask.get(out.dask, out._keys())
+
+    for a in partitions:
+        for b in partitions:
+            if a is not b:
+                assert not set(a) & set(b)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -854,10 +854,9 @@ def test_accumulate():
     assert b.accumulate(add).compute() == [1, 3, 6]
 
 
-def test_shuffle_tasks():
-    from dask.bag.core import shuffle_task
+def test_groupby_tasks():
     b = db.from_sequence(range(160), npartitions=4)
-    out = shuffle_task(b, lambda x: x % 10, max_branch=4)
+    out = b.groupby(lambda x: x % 10, max_branch=4, method='tasks')
     partitions = dask.get(out.dask, out._keys())
 
     for a in partitions:
@@ -867,7 +866,7 @@ def test_shuffle_tasks():
 
 
     b = db.from_sequence(range(1000), npartitions=100)
-    out = shuffle_task(b, lambda x: x % 123)
+    out = b.groupby(lambda x: x % 123, method='tasks')
     assert len(out.dask) < 100**2
     partitions = dask.get(out.dask, out._keys())
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -852,3 +852,26 @@ def test_accumulate():
 
     b = db.from_sequence([1, 2, 3], npartitions=1)
     assert b.accumulate(add).compute() == [1, 3, 6]
+
+
+def test_shuffle_tasks():
+    from dask.bag.core import shuffle_task
+    b = db.from_sequence(range(160), npartitions=4)
+    out = shuffle_task(b.map(lambda x: x % 10), max_branch=4)
+    partitions = dask.get(out.dask, out._keys())
+
+    for a in partitions:
+        for b in partitions:
+            if a is not b:
+                assert not set(a) & set(b)
+
+
+    b = db.from_sequence(range(1000), npartitions=100)
+    out = shuffle_task(b.map(lambda x: x % 123))
+    assert len(out.dask) < 100**2
+    partitions = dask.get(out.dask, out._keys())
+
+    for a in partitions:
+        for b in partitions:
+            if a is not b:
+                assert not set(a) & set(b)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -857,7 +857,7 @@ def test_accumulate():
 def test_shuffle_tasks():
     from dask.bag.core import shuffle_task
     b = db.from_sequence(range(160), npartitions=4)
-    out = shuffle_task(b.map(lambda x: x % 10), max_branch=4)
+    out = shuffle_task(b, lambda x: x % 10, max_branch=4)
     partitions = dask.get(out.dask, out._keys())
 
     for a in partitions:
@@ -867,7 +867,7 @@ def test_shuffle_tasks():
 
 
     b = db.from_sequence(range(1000), npartitions=100)
-    out = shuffle_task(b.map(lambda x: x % 123))
+    out = shuffle_task(b, lambda x: x % 123)
     assert len(out.dask) < 100**2
     partitions = dask.get(out.dask, out._keys())
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -884,3 +884,15 @@ def test_groupby_tasks():
         for b in partitions:
             if a is not b:
                 assert not set(a) & set(b)
+
+
+def test_groupby_tasks_names():
+    b = db.from_sequence(range(160), npartitions=4)
+    func = lambda x: x % 10
+    func2 = lambda x: x % 20
+    assert (set(b.groupby(func, max_branch=4, method='tasks').dask) ==
+            set(b.groupby(func, max_branch=4, method='tasks').dask))
+    assert (set(b.groupby(func, max_branch=4, method='tasks').dask) !=
+            set(b.groupby(func, max_branch=2, method='tasks').dask))
+    assert (set(b.groupby(func, max_branch=4, method='tasks').dask) !=
+            set(b.groupby(func2, max_branch=4, method='tasks').dask))

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2246,7 +2246,8 @@ def quantile(df, q):
     # currently, only Series has quantile method
     if isinstance(q, (list, tuple, np.ndarray)):
         # Index.quantile(list-like) must be pd.Series, not pd.Index
-        merge_type = lambda v: pd.Series(v, index=q, name=df.name)
+        df_name = df.name
+        merge_type = lambda v: pd.Series(v, index=q, name=df_name)
         return_type = df._constructor
         if issubclass(return_type, Index):
             return_type = Series

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -246,8 +246,12 @@ def collect(group, p, meta, barrier_token):
 
 
 def shuffle_pre_partition(df, index, divisions, drop):
-    parts = pd.Series(divisions).searchsorted(df[index], side='right') - 1
-    parts[(df[index] == divisions[-1]).values] = len(divisions) - 2
+    if np.isscalar(index):
+        ind = df[index]
+    else:
+        ind = df.loc[index]
+    parts = pd.Series(divisions).searchsorted(ind, side='right') - 1
+    parts[(ind == divisions[-1]).values] = len(divisions) - 2
     result = df.assign(partitions=parts).set_index('partitions', drop=drop)
     return result
 
@@ -268,9 +272,6 @@ def shuffle_post(df, index):
 
 def set_partition_tasks(df, index, divisions, max_branch=32, drop=True,
                         token=None):
-    if not np.isscalar(index):
-        raise NotImplemented()
-
     max_branch = max_branch or 32
     n = df.npartitions
     assert len(divisions) == n + 1
@@ -289,7 +290,8 @@ def set_partition_tasks(df, index, divisions, max_branch=32, drop=True,
     inputs = [tuple(digit(i, j, k) for j in range(stages))
               for i in range(n)]
 
-    meta = shuffle_pre_partition(df._pd, index, divisions, drop)
+    meta = shuffle_pre_partition(df._pd, index if np.isscalar(index) else
+            index._pd, divisions, drop)
     df2 = map_partitions(shuffle_pre_partition, meta, df, index, divisions,
             drop)
 
@@ -318,13 +320,20 @@ def set_partition_tasks(df, index, divisions, max_branch=32, drop=True,
         splits.append(split)
         joins.append(join)
 
-    end = dict(((name + '-' + token, i),
-                (shuffle_post, (name + '-join-' + token, stage, inp), index))
-                for i, inp in enumerate(inputs))
+    if np.isscalar(index):
+        end = dict(((name + '-' + token, i),
+                    (shuffle_post, (name + '-join-' + token, stage, inp), index))
+                    for i, inp in enumerate(inputs))
+    else:
+        end = dict(((name + '-' + token, i),
+                    (shuffle_post, (name + '-join-' + token, stage, inp),
+                                   index_key))
+                    for i, (inp, index_key) in enumerate(zip(inputs,
+                        index._keys())))
 
     dsk = merge(df2.dask, start, end, *(groups + splits + joins))
 
-    meta = df._pd.set_index(index)
+    meta = df._pd.set_index(index if np.isscalar(index) else index._pd)
     return DataFrame(dsk, name + '-' + token, meta, divisions)
 
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -290,8 +290,11 @@ def set_partition_tasks(df, index, divisions, max_branch=32, drop=True,
     inputs = [tuple(digit(i, j, k) for j in range(stages))
               for i in range(n)]
 
-    meta = shuffle_pre_partition(df._pd, index if np.isscalar(index) else
-            index._pd, divisions, drop)
+    if np.isscalar(index):
+        meta = shuffle_pre_partition(df._pd, index, divisions, drop)
+    else:
+        meta = df._pd.copy()
+        meta.index = index._pd
     df2 = map_partitions(shuffle_pre_partition, meta, df, index, divisions,
             drop)
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -249,7 +249,7 @@ def shuffle_pre_partition(df, index, divisions, drop):
     if np.isscalar(index):
         ind = df[index]
     else:
-        ind = df.loc[index]
+        ind = index
     parts = pd.Series(divisions).searchsorted(ind, side='right') - 1
     parts[(ind == divisions[-1]).values] = len(divisions) - 2
     result = df.assign(partitions=parts).set_index('partitions', drop=drop)
@@ -262,11 +262,18 @@ def shuffle_group(df, stage, k):
     df = df.set_index(index)
 
     result = {i: df.loc[i] if i in inds else df.head(0) for i in range(k)}
+    if isinstance(df, pd.DataFrame):
+        result = {k: pd.DataFrame(v).transpose()
+                     if isinstance(v, pd.Series) else v
+                  for k, v in result.items()}
+    assert all(list(df.columns) == ['x', 'y'] for df in result.values())
 
     return result
 
 
 def shuffle_post(df, index):
+    result = df.set_index(index, drop=True)
+    assert list(result.columns) == ['y']
     return df.set_index(index, drop=True)
 
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -106,6 +106,9 @@ def test_set_partition_tasks():
     eq(df.set_index('x'),
        ddf.set_index('x', method='tasks'))
 
+    eq(df.set_index(df.x),
+       ddf.set_index(ddf.x, method='tasks'))
+
 
 def test_shuffle_pre_partition():
     from dask.dataframe.shuffle import shuffle_pre_partition

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -103,13 +103,24 @@ def test_set_partition_tasks():
     ddf = dd.from_pandas(df, npartitions=4)
 
     divisions = [0, .25, .50, .75, 1.0]
-    result = ddf.set_index('x', method='tasks')
-    assert list(result.columns) == ['y']
-    eq(df.set_index('x'),
-       result)
 
-    # eq(df.set_index(df.x),
-    #    ddf.set_index(ddf.x, method='tasks'))
+    eq(df.set_index('x'),
+       ddf.set_index('x', method='tasks'))
+
+    eq(df.set_index('y'),
+       ddf.set_index('y', method='tasks'))
+
+    eq(df.set_index(df.x),
+       ddf.set_index(ddf.x, method='tasks'))
+
+    eq(df.set_index(df.x + df.y),
+       ddf.set_index(ddf.x + ddf.y, method='tasks'))
+
+    eq(df.set_index(df.x + 1),
+       ddf.set_index(ddf.x + 1, method='tasks'))
+
+    # eq(df.set_index(df.index),
+    #    ddf.set_index(ddf.index, method='tasks'))
 
 
 def test_shuffle_pre_partition():
@@ -121,7 +132,7 @@ def test_shuffle_pre_partition():
 
     for ind in ['x', df.x]:
         result = shuffle_pre_partition(df, ind, divisions, True)
-        assert list(result.columns) == ['x', 'y']
+        assert list(result.columns)[:2] == ['x', 'y']
         assert result.index.name == 'partitions'
         for x, part in result.reset_index()[['x', 'partitions']].values.tolist():
             part = int(part)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -124,6 +124,24 @@ def test_set_partition_tasks(npartitions):
     # eq(df.set_index(df.index),
     #    ddf.set_index(ddf.index, method='tasks'))
 
+def test_set_partition_tasks_names():
+    df = pd.DataFrame({'x': np.random.random(100),
+                       'y': np.random.random(100) // 0.2},
+                       index=np.random.random(100))
+
+    ddf = dd.from_pandas(df, npartitions=4)
+
+    divisions = [0, .25, .50, .75, 1.0]
+
+    assert (set(ddf.set_index('x', method='tasks').dask) ==
+            set(ddf.set_index('x', method='tasks').dask))
+    assert (set(ddf.set_index('x', method='tasks').dask) !=
+            set(ddf.set_index('y', method='tasks').dask))
+    assert (set(ddf.set_index('x', max_branch=4, method='tasks').dask) !=
+            set(ddf.set_index('x', max_branch=3, method='tasks').dask))
+    assert (set(ddf.set_index('x', drop=True, method='tasks').dask) !=
+            set(ddf.set_index('x', drop=False, method='tasks').dask))
+
 
 def test_set_partition_tasks():
     df = dd.demo.make_timeseries('2000', '2004',

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -5,6 +5,7 @@ import numpy as np
 import dask.dataframe as dd
 from dask.dataframe.shuffle import shuffle, hash_series, partitioning_index
 from dask.async import get_sync
+from dask.dataframe.utils import eq
 
 dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [1, 4, 7]},
                               index=[0, 1, 3]),
@@ -92,3 +93,17 @@ def test_partitioning_index():
     res = partitioning_index(df2.index, 4)
     exp = np.array([0, 1, 2, 3, 0, 1, 2, 3, 0])
     np.testing.assert_equal(res, exp)
+
+
+def test_set_partition_tasks():
+    from dask.dataframe.shuffle import set_partition_tasks
+    df = pd.DataFrame({'x': np.random.random(100),
+                       'y': np.random.random(100)},
+                       index=np.random.random(100))
+
+    ddf = dd.from_pandas(df, npartitions=4)
+
+    divisions = [0, .25, .50, .75, 1.0]
+    ddf2 = set_partition_tasks(ddf, 'x', divisions)
+    eq(df.set_index('x'), ddf2)
+    import pdb; pdb.set_trace()

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -584,3 +584,29 @@ def ensure_bytes(s):
         return s.encode()
     raise TypeError(
             "Object %s is neither a bytes object nor has an encode method" % s)
+
+
+def digit(n, k, base):
+    """
+
+    >>> digit(1234, 0, 10)
+    4
+    >>> digit(1234, 1, 10)
+    3
+    >>> digit(1234, 2, 10)
+    2
+    >>> digit(1234, 3, 10)
+    1
+    """
+    return n // base**k  % base
+
+
+def insert(tup, loc, val):
+    """
+
+    >>> insert(('a', 'b', 'c'), 0, 'x')
+    ('x', 'b', 'c')
+    """
+    L = list(tup)
+    L[loc] = val
+    return tuple(L)


### PR DESCRIPTION
This uses the transpose trick originally described in https://github.com/dask/dask/issues/417 by @shoyer to affect a shuffle using the task scheduling framework.  This is slower than partd on a single machine but can work with the distributed scheduler.

This operates in `log(n) / log(32)` full memory copies and `n_partitions * 32 * n_copies` tasks.