### PR TITLE
Infer metadata in dd.from_delayed

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -559,8 +559,8 @@ class _Frame(Base):
 
         Returns a list of values, one value per partition.
         """
-        from ..delayed import Value
-        return [Value(k, [self.dask]) for k in self._keys()]
+        from ..delayed import Delayed
+        return [Delayed(k, [self.dask]) for k in self._keys()]
 
     @classmethod
     def _get_unary_operator(cls, op):


### PR DESCRIPTION
- If no metadata is provided, infer it from the first delayed object
- Improve documentation of function
- Remove a few deprecated delayed things.

Fixes #1187