### PR TITLE
Fix dir for dataframe objects

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1394,7 +1394,7 @@ class DataFrame(_Frame):
 
     def __dir__(self):
         return sorted(set(dir(type(self)) + list(self.__dict__) +
-                      list(self.columns)))
+                      list(filter(pd.compat.isidentifier, self.columns))))
 
     @property
     def ndim(self):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -371,7 +371,7 @@ class DataFrameGroupBy(_GroupBy):
 
     def __dir__(self):
         return sorted(set(dir(type(self)) + list(self.__dict__) +
-                      list(self.obj.columns)))
+                      list(filter(pd.compat.isidentifier, self.obj.columns))))
 
     def __getattr__(self, key):
         try:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -109,6 +109,9 @@ def test_attributes():
     assert 'foo' not in dir(d)
     assert raises(AttributeError, lambda: d.foo)
 
+    df = dd.from_pandas(pd.DataFrame({'a b c': [1, 2, 3]}), npartitions=2)
+    assert 'a b c' not in dir(df)
+
 
 def test_column_names():
     tm.assert_index_equal(d.columns, pd.Index(['a', 'b']))

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -110,6 +110,14 @@ def test_full_groupby():
     assert eq(d.groupby('a').apply(func), full.groupby('a').apply(func))
 
 
+def test_groupby_dir():
+    df = pd.DataFrame({'a': range(10), 'b c d e': range(10)})
+    ddf = dd.from_pandas(df, npartitions=2)
+    g = ddf.groupby('a')
+    assert 'a' in dir(g)
+    assert 'b c d e' not in dir(g)
+
+
 def test_groupby_on_index():
     dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]},
                                   index=[0, 1, 3]),


### PR DESCRIPTION
Filter column names to ensure attributes are valid identifiers. Fixes #1189.