### PR TITLE
Ensure to_task_dasks always returns a task

### DIFF
--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -21,7 +21,7 @@ def test_to_task_dasks():
     a = delayed(1, name='a')
     b = delayed(2, name='b')
     task, dasks = to_task_dasks([a, b, 3])
-    assert task == ['a', 'b', 3]
+    assert task == (list, ['a', 'b', 3])
     assert len(dasks) == 2
     assert a.dask in dasks
     assert b.dask in dasks
@@ -132,6 +132,8 @@ def test_literates():
     b = a + 1
     lit = (a, b, 3)
     assert delayed(lit).compute() == (1, 2, 3)
+    lit = [a, b, 3]
+    assert delayed(lit).compute() == [1, 2, 3]
     lit = set((a, b, 3))
     assert delayed(lit).compute() == set((1, 2, 3))
     lit = {a: 'a', b: 'b', 3: 'c'}


### PR DESCRIPTION
Previously lists were special cased to return a list of keys. This
worked fine, except when fusing was used. Fusing resulted in a list
of tasks, which the scheduler wouldn't recognize as a task unless there
were external dependencies involved.

This fix ensures that any task returned by `to_task_dasks` is an actual
task. Nested lists can still contain lists, as long as the outer thing
is a task. Fixes http://stackoverflow.com/questions/37535160/using-dask-multi-threaded-module.