### PR TITLE
Fix categorical partitioning

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -83,7 +83,7 @@ def set_partition(df, index, divisions, compute=False, drop=True, **kwargs):
     elif np.isscalar(index):
         metadata = df._pd.set_index(index, drop=drop)
     else:
-         raise ValueError('index must be Series or scalar, {0} given'.format(type(index)))
+        raise ValueError('index must be Series or scalar, {0} given'.format(type(index)))
 
     token = tokenize(df, index, divisions)
     always_new_token = uuid.uuid1().hex
@@ -153,9 +153,14 @@ def barrier(args):
     list(args)
     return 0
 
+
 def _set_partition(df, index, divisions, p, drop=True):
     """ Shard partition and dump into partd """
     df = df.set_index(index, drop=drop)
+    if is_categorical_dtype(df.index):
+        # the divisions need to be codes not categories
+        categories = df.index.categories.tolist()
+        divisions = [categories.index(d) for d in divisions]
     df = strip_categories(df)
     divisions = list(divisions)
     shards = shard_df_on_index(df, divisions[1:-1])

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -27,7 +27,7 @@ def test_categorize():
 
 
 def test_categorical_set_index():
-    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': ['a', 'b', 'b', 'c']})
+    df = pd.DataFrame({'x': [1, 2, 2, 4], 'y': ['a', 'b', 'b', 'c']})
     df['y'] = df.y.astype('category')
     a = dd.from_pandas(df, npartitions=2)
 
@@ -36,9 +36,13 @@ def test_categorical_set_index():
         df2 = df.set_index('y')
         assert list(b.index.compute()), list(df2.index)
 
+
         b = a.set_index(a.y)
         df2 = df.set_index(df.y)
         assert list(b.index.compute()), list(df2.index)
+
+        c = a.set_index(a.x)
+        assert len(b.get_division(0)) == len(c.get_division(0))
 
 
 def test_dataframe_categoricals():


### PR DESCRIPTION
The issue here was that if you set the index on a categorical and then get the quantiles, you get back the category. Then you call strip_categories and turn the index into the codes but leave the divisions as categories. For some reason `searchsorted` doesn't complain about this and you get back an unexpected answer in terms of where the partitions should be, which almost always shoves things into one partition, depending I suppose on what the type of your categories is.

I'm not sure why numpy doesn't complain about this.

Closes #1200.