### PR TITLE
Extract dtype in dd.from_bcolz

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -237,7 +237,8 @@ def from_bcolz(x, chunksize=None, categorize=True, index=None, lock=lock,
                  columns, categories, lock))
                for i in range(0, int(ceil(len(x) / chunksize))))
 
-    result = DataFrame(dsk, new_name, columns, divisions)
+    meta = dataframe_from_ctable(x, slice(0, 0), columns, categories, lock)
+    result = DataFrame(dsk, new_name, meta, divisions)
 
     if index:
         assert index in x.names

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -269,6 +269,7 @@ def test_from_bcolz():
     t = bcolz.ctable([[1, 2, 3], [1., 2., 3.], ['a', 'b', 'a']],
                      names=['x', 'y', 'a'])
     d = dd.from_bcolz(t, chunksize=2)
+    assert d._known_dtype
     assert d.npartitions == 2
     assert str(d.dtypes['a']) == 'category'
     assert list(d.x.compute(get=get_sync)) == [1, 2, 3]


### PR DESCRIPTION
Previously the dtype was unknown, which could cause problems later.
Fixes #1207.