### PR TITLE
Add `optimize_graph` keyword to `compute`.

### DIFF
--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -72,6 +72,16 @@ def test_dumps_loads():
     with set_options(func_dumps=pickle.dumps, func_loads=pickle.loads):
         assert get({'x': 1, 'y': (add, 'x', 2)}, 'y') == 3
 
+
 def test_fuse_doesnt_clobber_intermediates():
     d = {'x': 1, 'y': (inc, 'x'), 'z': (add, 10, 'y')}
     assert get(d, ['y', 'z']) == (2, 12)
+
+
+def test_optimize_graph_false():
+    from dask.callbacks import Callback
+    d = {'x': 1, 'y': (inc, 'x'), 'z': (add, 10, 'y')}
+    keys = []
+    with Callback(pretask=lambda key, *args: keys.append(key)):
+        get(d, 'z', optimize_graph=False)
+    assert len(keys) == 2


### PR DESCRIPTION
If true, the optimizations for each collection won't be run. Default is false. This can be useful for debugging, and mirrors the keyword for `visualize`. Also added docstrings for `compute`.

The keyword was added to the `multiprocessing.get` function as well, as it does `fuse` internally. 
I also removed the unused and untested `optimizations` keyword. This was inconsistent with the other schedulers, didn't seem super necessary, and has been broken for a while (without any complaints, so probably unused). Happy to add it back if others feel it's necessary.

Also fixed up some misuse of `pytest.importorskip` in the `test_base` file, and did some minor pep8 cleanups.