### PR TITLE
Remove `iloc` property on `dask.dataframe`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -455,13 +455,8 @@ class _Frame(Base):
         >>> df.loc["b":"d"]  # doctest: +SKIP"""
         return IndexCallable(self._loc)
 
-    @property
-    def iloc(self):
-        """ Not implemented """
-
-        # not implemented because of performance concerns.
-        # see https://github.com/dask/dask/pull/507
-        raise NotImplementedError("Dask Dataframe does not support iloc")
+    # NOTE: `iloc` is not implemented because of performance concerns.
+    # see https://github.com/dask/dask/pull/507
 
     def repartition(self, divisions=None, npartitions=None, force=False):
         """ Repartition dataframe along new divisions

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -711,10 +711,6 @@ def test_loc_with_series():
     assert sorted(d.loc[d.a % 2].dask) != sorted(d.loc[d.a % 3].dask)
 
 
-def test_iloc_raises():
-    assert raises(NotImplementedError, lambda: d.iloc[:5])
-
-
 def test_getitem():
     df = pd.DataFrame({'A': [1, 2, 3, 4, 5, 6, 7, 8, 9],
                        'B': [9, 8, 7, 6, 5, 4, 3, 2, 1],


### PR DESCRIPTION
However, retain comment and reference to PR explaining why this is not implemented. Closes #1202 