### PR TITLE
Fix columns in merge

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -30,6 +30,7 @@ from ..utils import (repr_long_list, IndexCallable,
                      pseudorandom, derived_from, different_seeds, funcname)
 from ..base import Base, compute, tokenize, normalize_token
 from ..async import get_sync
+from .utils import nonempty_sample_df
 
 no_default = '__no_default__'
 return_scalar = '__return_scalar__'
@@ -1372,6 +1373,11 @@ class DataFrame(_Frame):
     @property
     def _constructor(self):
         return DataFrame
+
+    @property
+    def _pd_nonempty(self):
+        """ A Pandas dataframe with the same metadata but fake data."""
+        return nonempty_sample_df(self._pd)
 
     @property
     def columns(self):

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -203,8 +203,8 @@ def join_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix=''):
     (lhs, rhs), divisions, parts = align_partitions(lhs, rhs)
     divisions, parts = require(divisions, parts, required[how])
 
-    left_empty = lhs._pd
-    right_empty = rhs._pd
+    left_empty = lhs._pd_nonempty
+    right_empty = rhs._pd_nonempty
 
     name = 'join-indexed-' + tokenize(lhs, rhs, how, lsuffix, rsuffix)
 
@@ -270,7 +270,7 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
         right_index = False
 
     # dummy result
-    dummy = pd.merge(lhs._pd, rhs._pd, how, None,
+    dummy = pd.merge(lhs._pd_nonempty, rhs._pd_nonempty, how, None,
                      left_on=left_on, right_on=right_on,
                      left_index=left_index, right_index=right_index,
                      suffixes=suffixes)
@@ -299,7 +299,7 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
 
 
 def single_partition_join(left, right, **kwargs):
-    meta = pd.merge(left._pd, right._pd, **kwargs)
+    meta = pd.merge(left._pd_nonempty, right._pd_nonempty, **kwargs)
     name = 'merge-' + tokenize(left, right, **kwargs)
     if left.npartitions == 1:
         left_key = first(left._keys())
@@ -623,4 +623,3 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
                                 value_vars=value_vars,
                                 var_name=var_name, value_name=value_name,
                                 col_level=col_level, token='melt')
-

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -556,3 +556,22 @@ def test_cheap_single_partition_merge():
 
     list_eq(aa.merge(bb, on='x', how='inner'),
             a.merge(b, on='x', how='inner'))
+
+
+def test_merge_maintains_columns():
+    df1 = pd.DataFrame({'A': [1, 2, 3],
+                        'B': list('abc'),
+                        'C': 'foo',
+                        'D': 1.0},
+                       columns=list('DCBA'))
+
+    df2 = pd.DataFrame({'G': [4, 5],
+                        'H': 6.0,
+                        'I': 'bar',
+                        'B': list('ab')},
+                       columns=list('GHIB'))
+
+    ddf = dd.from_pandas(df1, npartitions=3)
+
+    merged = dd.merge(ddf, df2, on='B').compute()
+    assert tuple(merged.columns) == ('D', 'C', 'A', 'G', 'H', 'I', 'B')

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -574,4 +574,4 @@ def test_merge_maintains_columns():
     ddf = dd.from_pandas(df1, npartitions=3)
 
     merged = dd.merge(ddf, df2, on='B').compute()
-    assert tuple(merged.columns) == ('D', 'C', 'A', 'G', 'H', 'I', 'B')
+    assert tuple(merged.columns) == ('D', 'C', 'B', 'A', 'G', 'H', 'I')

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -558,20 +558,17 @@ def test_cheap_single_partition_merge():
             a.merge(b, on='x', how='inner'))
 
 
-def test_merge_maintains_columns():
-    df1 = pd.DataFrame({'A': [1, 2, 3],
-                        'B': list('abc'),
-                        'C': 'foo',
-                        'D': 1.0},
-                       columns=list('DCBA'))
-
-    df2 = pd.DataFrame({'G': [4, 5],
-                        'H': 6.0,
-                        'I': 'bar',
-                        'B': list('ab')},
-                       columns=list('GHIB'))
-
-    ddf = dd.from_pandas(df1, npartitions=3)
-
-    merged = dd.merge(ddf, df2, on='B').compute()
+@pytest.mark.parametrize('lhs', [pd.DataFrame({'A': [1, 2, 3],
+                                               'B': list('abc'),
+                                               'C': 'foo',
+                                               'D': 1.0},
+                                              columns=list('DCBA'))])
+@pytest.mark.parametrize('rhs', [pd.DataFrame({'G': [4, 5],
+                                               'H': 6.0,
+                                               'I': 'bar',
+                                               'B': list('ab')},
+                                              columns=list('GHIB'))])
+def test_merge_maintains_columns(lhs, rhs):
+    ddf = dd.from_pandas(lhs, npartitions=1)
+    merged = dd.merge(ddf, rhs, on='B').compute()
     assert tuple(merged.columns) == ('D', 'C', 'B', 'A', 'G', 'H', 'I')

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from dask.dataframe.utils import shard_df_on_index, nonempty_sample_df
 
@@ -16,11 +17,21 @@ def test_nonempty_sample_df():
     df1 = pd.DataFrame({'A': pd.Categorical(['Alice', 'Bob', 'Carol']),
                         'B': list('abc'),
                         'C': 'bar',
-                        'D': 3.0},
-                       columns=list('DCBA'))
+                        'D': 3.0,
+                        'E': pd.Timestamp('2016-01-01'),
+                        'F': pd.date_range('2016-01-01', periods=3,
+                                           tz='America/New_York'),
+                        'G': pd.Timedelta('1 hours'),
+                        'H': np.void(b' ')},
+                       columns=list('DCBAHGFE'))
     df2 = df1.iloc[0:0]
     df3 = nonempty_sample_df(df2)
     assert df3['A'][0] == 'Alice'
     assert df3['B'][0] == 'foo'
     assert df3['C'][0] == 'foo'
     assert df3['D'][0] == 1.0
+    assert df3['E'][0] == pd.Timestamp('1970-01-01 00:00:00')
+    assert df3['F'][0] == pd.Timestamp('1970-01-01 00:00:00',
+                                       tz='America/New_York')
+    assert df3['G'][0] == pd.Timedelta('1 days')
+    assert df3['H'][0] == 'foo'

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from dask.dataframe.utils import shard_df_on_index
+from dask.dataframe.utils import shard_df_on_index, nonempty_sample_df
 
 
 def test_shard_df_on_index():
@@ -11,3 +11,16 @@ def test_shard_df_on_index():
     assert list(result[1].index) == [20, 30, 40]
     assert list(result[2].index) == [50, 60]
 
+
+def test_nonempty_sample_df():
+    df1 = pd.DataFrame({'A': pd.Categorical(['Alice', 'Bob', 'Carol']),
+                        'B': list('abc'),
+                        'C': 'bar',
+                        'D': 3.0},
+                       columns=list('DCBA'))
+    df2 = df1.iloc[0:0]
+    df3 = nonempty_sample_df(df2)
+    assert df3['A'][0] == 'Alice'
+    assert df3['B'][0] == 'foo'
+    assert df3['C'][0] == 'foo'
+    assert df3['D'][0] == 1.0

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -90,6 +90,38 @@ def unique(divisions):
     raise NotImplementedError()
 
 
+_simple_fake_mapping = {
+    'b': True,   # boolean
+    'i': -1,   # signed int
+    'u': 1,   # unsigned int
+    'f': 1.0,   # float
+    'c': complex(1, 0),   # complex
+    'S': b'foo',   # bytestring
+    'U': u'foo',   # unicode string
+    'V': np.void0,   # void
+}
+
+
+def nonempty_sample_df(empty):
+    """ Create a dataframe from the given empty dataframe that contains one
+    row of fake data (generated from the empty dataframe's dtypes).
+    """
+    fake_values = {}
+    for key, dtype in empty.dtypes.iteritems():
+        if dtype.kind in _simple_fake_mapping:
+            fake = _simple_fake_mapping[dtype.kind]
+        elif dtype.name == 'category':
+            fake = empty[key].cat.categories[0]
+        elif dtype.name == 'object':
+            fake = 'foo'
+        else:
+            raise TypeError("Can't handle dtype: {}".format(dtype))
+        fake_values[key] = fake
+
+    nonempty = empty.append(fake_values, ignore_index=True)
+    return nonempty
+
+
 ###############################################################
 # Testing
 ###############################################################


### PR DESCRIPTION
Uses a non-empty Pandas dataframe, populated with fake data, as the metadata for merges, avoiding the case where empty Pandas dataframes behave differently from non-empty ones. Adds utility functions for computing this, so that the non-empty dataframe helper can be used elsewhere as well.

Closes #959 
