### PR TITLE
Add dask_key_name to docs, fix bug in methods

### DIFF
--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -58,6 +58,8 @@ def test_methods():
     assert a.split(' ').compute() == ['a', 'b', 'c', 'd', 'e']
     assert a.upper().replace('B', 'A').split().count('A').compute() == 2
     assert a.split(' ', pure=True).key == a.split(' ', pure=True).key
+    o = a.split(' ', dask_key_name='test')
+    assert o.key == 'test'
 
 
 def test_attributes():


### PR DESCRIPTION
- Add ``dask_key_name`` examples to docstring
- Fix bug with using ``dask_key_name`` on method calls

Fixes #1239