### PR TITLE
Opt slice fix

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -3,12 +3,10 @@ from __future__ import absolute_import, division, print_function
 from operator import getitem
 
 import numpy as np
-from toolz import valmap, partial
 
 from .core import getarray
 from ..core import flatten
-from ..optimize import cull, fuse, dealias, inline_functions
-from ..rewrite import RuleSet, RewriteRule
+from ..optimize import cull, fuse, inline_functions
 
 
 def optimize(dsk, keys, **kwargs):
@@ -20,12 +18,12 @@ def optimize(dsk, keys, **kwargs):
     """
     keys = list(flatten(keys))
     fast_functions = kwargs.get('fast_functions',
-                             set([getarray, np.transpose]))
+                                set([getarray, np.transpose]))
     dsk2, dependencies = cull(dsk, keys)
     dsk4, dependencies = fuse(dsk2, keys, dependencies)
     dsk5 = optimize_slices(dsk4)
     dsk6 = inline_functions(dsk5, keys, fast_functions=fast_functions,
-            dependencies=dependencies)
+                            dependencies=dependencies)
     return dsk6
 
 
@@ -38,16 +36,17 @@ def optimize_slices(dsk):
     See also:
         fuse_slice_dict
     """
+    getters = (getarray, getitem)
     dsk = dsk.copy()
     for k, v in dsk.items():
         if type(v) is tuple:
-            if v[0] is getitem or v[0] is getarray:
+            if v[0] in getters:
                 try:
                     func, a, a_index = v
                     use_getarray = func is getarray
                 except ValueError:  # has four elements, includes a lock
                     continue
-                while type(a) is tuple and (a[0] is getitem or a[0] is getarray):
+                while type(a) is tuple and a[0] in getters:
                     try:
                         f2, b, b_index = a
                         use_getarray |= f2 is getarray
@@ -56,8 +55,8 @@ def optimize_slices(dsk):
                     if (type(a_index) is tuple) != (type(b_index) is tuple):
                         break
                     if ((type(a_index) is tuple) and
-                        (len(a_index) != len(b_index)) and
-                        any(i is None for i in b_index + a_index)):
+                            (len(a_index) != len(b_index)) and
+                            any(i is None for i in b_index + a_index)):
                         break
                     try:
                         c_index = fuse_slice(b_index, a_index)
@@ -67,9 +66,9 @@ def optimize_slices(dsk):
                 if use_getarray:
                     dsk[k] = (getarray, a, a_index)
                 elif (type(a_index) is slice and
-                    not a_index.start and
-                    a_index.stop is None and
-                    a_index.step is None):
+                      not a_index.start and
+                      a_index.stop is None and
+                      a_index.step is None):
                     dsk[k] = a
                 elif type(a_index) is tuple and all(type(s) is slice and
                                                     not s.start and
@@ -171,7 +170,7 @@ def fuse_slice(a, b):
     if isinstance(a, tuple) and isinstance(b, tuple):
 
         if (any(isinstance(item, list) for item in a) and
-            any(isinstance(item, list) for item in b)):
+                any(isinstance(item, list) for item in b)):
             raise NotImplementedError("Can't handle multiple list indexing")
 
         j = 0

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -939,10 +939,7 @@ def test_store_locks():
 
 
 def test_to_hdf5():
-    try:
-        import h5py
-    except ImportError:
-        return
+    h5py = pytest.importorskip('h5py')
     x = da.ones((4, 4), chunks=(2, 2))
     y = da.ones(4, chunks=2, dtype='i4')
 
@@ -1296,6 +1293,17 @@ def test_from_array_with_lock():
     assert_eq(e + f, x + x)
 
 
+def test_from_array_slicing_results_in_ndarray():
+    x = np.matrix(np.arange(100).reshape((10, 10)))
+    dx = da.from_array(x, chunks=(5, 5))
+    s1 = dx[0:5]
+    assert type(dx[0:5].compute()) == np.ndarray
+    s2 = s1[0:3]
+    assert type(s2.compute()) == np.ndarray
+    s3 = s2[:, 0]
+    assert type(s3.compute()) == np.ndarray
+
+
 def test_from_func():
     x = np.arange(10)
     f = lambda n: n * x
@@ -1550,10 +1558,7 @@ def test_long_slice():
 
 
 def test_h5py_newaxis():
-    try:
-        import h5py
-    except ImportError:
-        return
+    h5py = pytest.importorskip('h5py')
 
     with tmpfile('h5') as fn:
         with h5py.File(fn) as f:

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -16,14 +16,14 @@ def test_fuse_getitem():
 
              ((getitem, (getarray, 'x', (slice(1000, 2000), slice(100, 200))),
                         (slice(15, 20), slice(50, 60))),
-              (getitem, 'x', (slice(1015, 1020), slice(150, 160)))),
+              (getarray, 'x', (slice(1015, 1020), slice(150, 160)))),
 
              ((getarray, (getarray, 'x', slice(1000, 2000)), 10),
               (getarray, 'x', 1010)),
 
              ((getitem, (getarray, 'x', (slice(1000, 2000), 10)),
                         (slice(15, 20),)),
-              (getitem, 'x', (slice(1015, 1020), 10))),
+              (getarray, 'x', (slice(1015, 1020), 10))),
 
              ((getarray, (getarray, 'x', (10, slice(1000, 2000))),
                         (slice(15, 20),)),
@@ -73,9 +73,9 @@ def test_optimize_slicing():
     assert result == expected
 
     # protect output keys
-    expected = {'c': (range, 10),
+    expected = {'c': (getarray, (range, 10), (slice(0, None, None),)),
                 'd': (getarray, 'c', (slice(0, 5, None),)),
-                'e': 'd'}
+                'e': (getarray, 'd', (slice(None, None, None),))}
     result = optimize_slices(fuse(dsk, ['c', 'd', 'e'])[0])
 
     assert result == expected


### PR DESCRIPTION
When slicing an unknown array-like object, ``getarray`` is used to ensure that the output of the slicing operation is a numpy array, instead of another array-like. When optimizing nested slices, we need to
ensure that if ``getarray`` is used at all in the chain, then the slicing still happens. A bug in this logic was introduced in the recent work on speeding up the optimization passes. This patch fixes this bug, and reverts the changes to the tests made that allowed it to pass.

As a separate commit, also removed unused imports, and fixed several indenting pep8 things (mostly due to indent lining up with block, making if blocks harder to read).

Fixes #1235.