### PR TITLE
[WIP] Fix scheduler behavior for top-level lists

### DIFF
--- a/dask/async.py
+++ b/dask/async.py
@@ -149,13 +149,8 @@ def has_tasks(dsk, x):
         pass
     if isinstance(x, list):
         for i in x:
-            if istask(i):
+            if has_tasks(dsk, i):
                 return True
-            try:
-                if i in dsk:
-                    return True
-            except:
-                pass
     return False
 
 

--- a/dask/async.py
+++ b/dask/async.py
@@ -118,8 +118,7 @@ from operator import add
 import sys
 import traceback
 
-from .core import (istask, flatten, reverse_dict, get_dependencies, ishashable,
-                   _deps)
+from .core import istask, flatten, reverse_dict, get_dependencies, ishashable
 from .context import _globals
 from .order import order
 from .callbacks import unpack_callbacks
@@ -131,6 +130,33 @@ def inc(x):
 
 
 DEBUG = False
+
+
+def has_tasks(dsk, x):
+    """Whether ``x`` has anything to compute.
+
+    Returns True if:
+    - ``x`` is a task
+    - ``x`` is a key in ``dsk``
+    - ``x`` is a list that contains any tasks or keys
+    """
+    if istask(x):
+        return True
+    try:
+        if x in dsk:
+            return True
+    except:
+        pass
+    if isinstance(x, list):
+        for i in x:
+            if istask(i):
+                return True
+            try:
+                if i in dsk:
+                    return True
+            except:
+                pass
+    return False
 
 
 def start_state_from_dask(dsk, cache=None, sortkey=None):
@@ -168,7 +194,7 @@ def start_state_from_dask(dsk, cache=None, sortkey=None):
         cache = dict()
     data_keys = set()
     for k, v in dsk.items():
-        if not (istask(v) or _deps(dsk, v)):
+        if not has_tasks(dsk, v):
             cache[k] = v
             data_keys.add(k)
 

--- a/dask/async.py
+++ b/dask/async.py
@@ -118,7 +118,8 @@ from operator import add
 import sys
 import traceback
 
-from .core import istask, flatten, reverse_dict, get_dependencies, ishashable
+from .core import (istask, flatten, reverse_dict, get_dependencies, ishashable,
+                   has_tasks)
 from .context import _globals
 from .order import order
 from .callbacks import unpack_callbacks
@@ -130,28 +131,6 @@ def inc(x):
 
 
 DEBUG = False
-
-
-def has_tasks(dsk, x):
-    """Whether ``x`` has anything to compute.
-
-    Returns True if:
-    - ``x`` is a task
-    - ``x`` is a key in ``dsk``
-    - ``x`` is a list that contains any tasks or keys
-    """
-    if istask(x):
-        return True
-    try:
-        if x in dsk:
-            return True
-    except:
-        pass
-    if isinstance(x, list):
-        for i in x:
-            if has_tasks(dsk, i):
-                return True
-    return False
 
 
 def start_state_from_dask(dsk, cache=None, sortkey=None):

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -98,21 +98,6 @@ def test_finish_task():
                            'z': set(['w'])}}
 
 
-def test_has_tasks():
-    dsk = {'a': [1, 2, 3],
-           'b': 'a',
-           'c': [1, (inc, 1)],
-           'd': [(sum, 'a')],
-           'e': ['a', 'b'],
-           'f': [['a', 'b'], 2, 3]}
-    assert not has_tasks(dsk, dsk['a'])
-    assert has_tasks(dsk, dsk['b'])
-    assert has_tasks(dsk, dsk['c'])
-    assert has_tasks(dsk, dsk['d'])
-    assert has_tasks(dsk, dsk['e'])
-    assert has_tasks(dsk, dsk['f'])
-
-
 class TestGetAsync(GetFunctionTestMixin):
     get = staticmethod(get_sync)
 

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -7,7 +7,7 @@ import dask
 import pytest
 
 from dask.async import *
-from dask.utils_test import GetFunctionTestCase
+from dask.utils_test import GetFunctionTestMixin
 
 
 fib_dask = {'f0': 0, 'f1': 1, 'f2': 1, 'f3': 2, 'f4': 3, 'f5': 5, 'f6': 8}
@@ -103,15 +103,17 @@ def test_has_tasks():
            'b': 'a',
            'c': [1, (inc, 1)],
            'd': [(sum, 'a')],
-           'e': ['a', 'b']}
+           'e': ['a', 'b'],
+           'f': [['a', 'b'], 2, 3]}
     assert not has_tasks(dsk, dsk['a'])
     assert has_tasks(dsk, dsk['b'])
     assert has_tasks(dsk, dsk['c'])
     assert has_tasks(dsk, dsk['d'])
     assert has_tasks(dsk, dsk['e'])
+    assert has_tasks(dsk, dsk['f'])
 
 
-class TestGetAsync(GetFunctionTestCase):
+class TestGetAsync(GetFunctionTestMixin):
     get = staticmethod(get_sync)
 
     def test_get_sync_num_workers(self):

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 from dask.utils import raises
-from dask.utils_test import GetFunctionTestCase
+from dask.utils_test import GetFunctionTestMixin
 from dask import core
 from dask.core import (istask, get_dependencies, flatten, subs,
                        preorder_traversal, quote, _deps)
@@ -41,21 +41,21 @@ def test_preorder_traversal():
     assert list(preorder_traversal(t)) == [add, sum, list, 1, 2, 3]
 
 
-class TestGet(GetFunctionTestCase):
+class TestGet(GetFunctionTestMixin):
     get = staticmethod(core.get)
 
 
-def test_GetFunctionTestCase_class():
-    class CustomTestGetFail(GetFunctionTestCase):
+def test_GetFunctionTestMixin_class():
+    class TestCustomGetFail(GetFunctionTestMixin):
         get = staticmethod(lambda x, y: 1)
 
-    custom_testget = CustomTestGetFail()
+    custom_testget = TestCustomGetFail()
     raises(AssertionError, custom_testget.test_get)
 
-    class CustomTestGetPass(GetFunctionTestCase):
+    class TestCustomGetPass(GetFunctionTestMixin):
         get = staticmethod(core.get)
 
-    custom_testget = CustomTestGetPass()
+    custom_testget = TestCustomGetPass()
     custom_testget.test_get()
 
 

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -75,6 +75,18 @@ class GetFunctionTestCase(unittest.TestCase):
         assert self.get(d, ['x', 'y']) == (1, 2)
         assert self.get(d, 'z') == 3
 
+    def test_get_with_list_top_level(self):
+        d = {'a': [1, 2, 3],
+             'b': 'a',
+             'c': [1, (inc, 1)],
+             'd': [(sum, 'a')],
+             'e': ['a', 'b']}
+        assert self.get(d, 'a') == [1, 2, 3]
+        assert self.get(d, 'b') == [1, 2, 3]
+        assert self.get(d, 'c') == [1, 2]
+        assert self.get(d, 'd') == [6]
+        assert self.get(d, 'e') == [[1, 2, 3], [1, 2, 3]]
+
     def test_get_with_nested_list(self):
         d = {'x': 1, 'y': 2, 'z': (sum, ['x', 'y'])}
 

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -49,7 +49,7 @@ class GetFunctionTestMixin(object):
         else:
             msg = 'Expected `{}` with badkey to raise KeyError.\n'
             msg += "Obtained '{}' instead.".format(result)
-            self.assertTrue(False, msg=msg.format(self.get.__name__))
+            assert False, msg.format(self.get.__name__)
 
     def test_nested_badkey(self):
         d = {'x': 1, 'y': 2, 'z': (sum, ['x', 'y'])}
@@ -61,7 +61,7 @@ class GetFunctionTestMixin(object):
         else:
             msg = 'Expected `{}` with badkey to raise KeyError.\n'
             msg += "Obtained '{}' instead.".format(result)
-            self.assertTrue(False, msg=msg.format(self.get.__name__))
+            assert False, msg.format(self.get.__name__)
 
     def test_data_not_in_dict_is_ok(self):
         d = {'x': 1, 'y': (add, 'x', 10)}
@@ -122,6 +122,6 @@ class GetFunctionTestMixin(object):
                 assert str(e).startswith('Found no accessible jobs in dask')
         else:
             msg = 'dask with infinite cycle should have raised an exception.'
-            self.assertTrue(False, msg=msg)
+            assert False, msg
 
         assert self.get(d, 'x4999') == 4999

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -1,35 +1,33 @@
 from __future__ import absolute_import, division, print_function
 
 from .core import get
-import unittest
+
 
 def inc(x):
     return x + 1
 
+
 def add(x, y):
     return x + y
 
-class GetFunctionTestCase(unittest.TestCase):
+
+class GetFunctionTestMixin(object):
     """
     The GetFunctionTestCase class can be imported and used to test foreign
     implementations of the `get` function specification. It aims to enforce all
-    known expecctations of `get` functions.
+    known expectations of `get` functions.
 
     To use the class, inherit from it and override the `get` function. For
     example:
 
-    > from dask.utils_test import GetFunctionTestCase
-    > class CustomGetTestCase(GetFunctionTestCase):
+    > from dask.utils_test import GetFunctionTestMixin
+    > class TestCustomGet(GetFunctionTestMixin):
          get = staticmethod(myget)
 
     Note that the foreign `myget` function has to be explicitly decorated as a
     staticmethod.
     """
     get = staticmethod(get)
-
-    def runTest(self):
-        """This method is needed for compatibility with PY2 unittest.TestCase"""
-        pass
 
     def test_get(self):
         d = {':x': 1,
@@ -80,12 +78,14 @@ class GetFunctionTestCase(unittest.TestCase):
              'b': 'a',
              'c': [1, (inc, 1)],
              'd': [(sum, 'a')],
-             'e': ['a', 'b']}
+             'e': ['a', 'b'],
+             'f': [[[(sum, 'a'), 'c'], (sum, 'b')], 2]}
         assert self.get(d, 'a') == [1, 2, 3]
         assert self.get(d, 'b') == [1, 2, 3]
         assert self.get(d, 'c') == [1, 2]
         assert self.get(d, 'd') == [6]
         assert self.get(d, 'e') == [[1, 2, 3], [1, 2, 3]]
+        assert self.get(d, 'f') == [[[6, [1, 2]], 6], 2]
 
     def test_get_with_nested_list(self):
         d = {'x': 1, 'y': 2, 'z': (sum, ['x', 'y'])}

--- a/docs/source/spec.rst
+++ b/docs/source/spec.rst
@@ -10,16 +10,17 @@ values.
 Definitions
 -----------
 
-A **dask graph** is a dictionary mapping data-keys to values or tasks:
+A **dask graph** is a dictionary mapping **keys** to **computations**:
 
 .. code-block:: python
 
    {'x': 1,
     'y': 2,
     'z': (add, 'x', 'y'),
-    'w': (sum, ['x', 'y', 'z'])}
+    'w': (sum, ['x', 'y', 'z']),
+    'v': [(sum, ['w', 'z']), 2]}
 
-A **key** is any hashable value that is not a task:
+A **key** is any hashable value that is not a **task**:
 
 .. code-block:: python
 
@@ -35,25 +36,27 @@ units of work meant to be run by a single worker. Example:
 
 We represent a task as a tuple such that the *first element is a callable
 function* (like ``add``), and the succeeding elements are *arguments* for that
-function.
+function. An *argument* may be any valid **computation**.
 
-An **argument** may be one of the following:
+A **computation** may be one of the following:
 
-1.  Any key present in the dask like ``'x'``
+1.  Any **key** present in the dask graph like ``'x'``
 2.  Any other value like ``1``, to be interpreted literally
-3.  Other tasks like ``(inc, 'x')``
-4.  List of arguments, like ``[1, 'x', (inc, 'x')]``
+3.  A **task** like ``(inc, 'x')`` (see below)
+4.  A list of **computations**, like ``[1, 'x', (inc, 'x')]``
 
-So all of the following are valid tasks:
+So all of the following are valid **computations**:
 
 .. code-block:: python
 
+   np.array([...])
    (add, 1, 2)
    (add, 'x', 2)
    (add, (inc, 'x'), 2)
    (sum, [1, 2])
    (sum, ['x', (inc, 'x')])
    (np.dot, np.array([...]), np.array([...]))
+   [(sum, ['x', 'y']), 'z']
 
 To encode keyword arguments, we recommend the use of ``functools.partial`` or
 ``toolz.curry``.


### PR DESCRIPTION
Previously lists were treated differently depending on if they were a toplevel key in the graph or not. The new behavior treats them the same as long as they're not nested lists. This is best illustrated with an
example:

```python
dsk = {'a': [1, 2, 3],
       'b': 'a',
       'c': [(inc, 1), 2],
       'd': [[1, 2, (inc, 1)], 4],
       'e': [(list, [1, 2, (inc, 1)]), 4],
       'f': ['a', 'b']}
```

In this example:
- 'a' is data, as none of the elements are keys or tasks
- 'b' is not data, it's just an alias to 'a' (a trivial task)
- 'c' is not data, as it contains a task
- 'd' is data, as the list contains no tasks.
- 'e' is not data, as it contains tasks. Note that the result of this is
  ``[[1, 2, 3], 4]``, which is probably the desired result for `d`.
- 'f' is not data as it contains keys in the graph

To summarize:

A value in the graph is computed if:
- It's a task
- It's a key in the graph
- It's a list that contains either tasks or keys

Note that this definition is not fully recursive, as lists of lists aren't traversed. It could be, but I didn't go that far yet.

Fixes #1192.

Todo:
- [x] decide on what the spec is
- [x] fix dask.core.get to match accordingly
- [x] figure out why the `GetFunctionTestCase` runs 3 times for dask.core.get, and stop that
- [x] document spec more thoroughly