### PR TITLE
Fix dot_graph filename split bug

### DIFF
--- a/dask/dot.py
+++ b/dask/dot.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import re
+import os
 from functools import partial
 
 from graphviz import Digraph
@@ -211,8 +212,8 @@ def dot_graph(dsk, filename='mydask', format=None, **kwargs):
 
     fmts = ['.png', '.pdf', '.dot', '.svg', '.jpeg', '.jpg']
     if format is None and any(filename.lower().endswith(fmt) for fmt in fmts):
-        format = filename.lower().split('.')[-1]
-        filename = filename.rsplit('.')[0]
+        filename, format = os.path.splitext(filename)
+        format = format[1:].lower()
 
     if format is None:
         format = 'png'

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -138,9 +138,9 @@ def test_dot_graph_defaults():
 
 def test_filenames_and_formats():
     # Test with a variety of user provided args
-    filenames = ['mydaskpdf', 'mydask.pdf', 'mydask.pdf', 'mydaskpdf']
-    formats = ['svg', None, 'svg', None]
-    targets = ['mydaskpdf.svg', 'mydask.pdf', 'mydask.pdf.svg', 'mydaskpdf.png']
+    filenames = ['mydaskpdf', 'mydask.pdf', 'mydask.pdf', 'mydaskpdf', 'mydask.pdf.svg']
+    formats = ['svg', None, 'svg', None, None]
+    targets = ['mydaskpdf.svg', 'mydask.pdf', 'mydask.pdf.svg', 'mydaskpdf.png', 'mydask.pdf.svg']
 
     result_types = {
         'png': Image,


### PR DESCRIPTION
When dot_graph successfully guesses the format (using extension) it then tries to strip the extension from the file name. It seems that when it does that, it accidentally strips anything after the first dot instead
i.e when trying to save a dot_graph, when passing no format and the name "abc.def.svg" i'll get an svg file named "abc.svg" instead

It looks like the intention was for calling `rsplit` with `maxsplit=1`, but that's not the case.
I chose to replace it with the clearer `os.path.splitext` function, but i can also add `maxsplit=1` to the original call.

Signed-off-by: Nir Izraeli <nir@sentinel-labs.com>