### PR TITLE
Handle empty partitions in dask.bag.to_textfiles

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1094,7 +1094,11 @@ def write(data, filename, compression, encoding):
 
     # Check presence of endlines
     data = iter(data)
-    firstline = next(data)
+    try:
+        firstline = next(data)
+    except StopIteration:
+        f.close()
+        return
     if not (firstline.endswith(os.linesep) or firstline.endswith('\n')):
         sep = os.linesep if firstline.endswith(os.linesep) else '\n'
         firstline = firstline + sep

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -889,3 +889,10 @@ def test_groupby_tasks_names():
             set(b.groupby(func, max_branch=2, method='tasks').dask))
     assert (set(b.groupby(func, max_branch=4, method='tasks').dask) !=
             set(b.groupby(func2, max_branch=4, method='tasks').dask))
+
+
+def test_to_textfiles_empty_partitions():
+    with tmpdir() as d:
+        b = db.range(5, npartitions=5).filter(lambda x: x == 1).map(str)
+        b.to_textfiles(os.path.join(d, '*.txt'))
+        assert len(os.listdir(d)) == 5


### PR DESCRIPTION
Fixes http://stackoverflow.com/questions/37709962/dask-bag-to-textfiles-works-with-single-partition-but-not-multiple