### PR TITLE
Fix some bugs in the rolling implementation.

### DIFF
--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -9,7 +9,7 @@ from ..base import tokenize
 
 
 def rolling_chunk(func, part1, part2, window, *args):
-    if part1.shape[0] < window:
+    if part1.shape[0] < window-1:
         raise NotImplementedError("Window larger than partition size")
     if window > 1:
         extra = window - 1
@@ -60,10 +60,7 @@ rolling_window = wrap_rolling(pd.rolling_window)
 
 def call_pandas_rolling_method_single(this_partition, rolling_kwargs,
         method_name, method_args, method_kwargs):
-    # used for the start of the df/series
-    if this_partition.shape[0] < rolling_kwargs['window']:
-        raise NotImplementedError("Window larger than partition size")
-
+    # used for the start of the df/series (or for rolling through columns)
     method = getattr(this_partition.rolling(**rolling_kwargs), method_name)
     return method(*method_args, **method_kwargs)
 
@@ -72,7 +69,7 @@ def call_pandas_rolling_method_with_neighbor(prev_partition, this_partition,
     # used for everything except for the start
 
     window = rolling_kwargs['window']
-    if prev_partition.shape[0] < window:
+    if prev_partition.shape[0] < window-1:
         raise NotImplementedError("Window larger than partition size")
 
     if window > 1:

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -152,3 +152,23 @@ def test_rolling_axis():
     s = df[3]
     ds = ddf[3]
     eq(s.rolling(5, axis=0).std(), ds.rolling(5, axis=0).std())
+
+def test_rolling_function_partition_size():
+    df = pd.DataFrame(np.random.randn(50, 2))
+    ddf = dd.from_pandas(df, npartitions=5)
+
+    for obj, dobj in [(df, ddf), (df[0], ddf[0])]:
+        eq(pd.rolling_mean(obj, 10), dd.rolling_mean(dobj, 10))
+        eq(pd.rolling_mean(obj, 11), dd.rolling_mean(dobj, 11))
+        raises(NotImplementedError, lambda: dd.rolling_mean(dobj, 12))
+
+@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.18.0',
+                    reason="rolling object not supported")
+def test_rolling_partition_size():
+    df = pd.DataFrame(np.random.randn(50, 2))
+    ddf = dd.from_pandas(df, npartitions=5)
+
+    for obj, dobj in [(df, ddf), (df[0], ddf[0])]:
+        eq(obj.rolling(10).mean(), dobj.rolling(10).mean())
+        eq(obj.rolling(11).mean(), dobj.rolling(11).mean())
+        raises(NotImplementedError, lambda: dobj.rolling(12).mean())


### PR DESCRIPTION
 - off-by-one error when considering partition size
 - incorrect check for first-partition/axis=0 (should just give nan / not consider partition respectively)