### PR TITLE
amend doc string to Bag.to_textfiles

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -147,10 +147,10 @@ def to_textfiles(b, path, name_function=str, compression='infer',
     **Compression**: Filenames with extensions corresponding to known
     compression algorithms (gz, bz2) will be compressed accordingly.
     
-     **Bag Contents**: The bag calling ``to_textfiles`` _must_ be a bag of
-    text strings. For example, a bag of
-    dictionaries could be written to JSON text files by mapping ``json.dumps``
-    on to the bag first, and then calling ``to_textfiles``:
+    **Bag Contents**: The bag calling ``to_textfiles`` _must_ be a bag of
+    text strings. For example, a bag of dictionaries could be written to 
+    JSON text files by mapping ``json.dumps``on to the bag first, and 
+    then calling ``to_textfiles``:
 
     >>> b_dict.map(json.dumps).to_textfiles("/path/to/data/*.json")
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -146,6 +146,14 @@ def to_textfiles(b, path, name_function=str, compression='infer',
 
     **Compression**: Filenames with extensions corresponding to known
     compression algorithms (gz, bz2) will be compressed accordingly.
+    
+     **Bag Contents**: The bag calling ``to_textfiles`` _must_ be a bag of
+    text strings. For example, a bag of
+    dictionaries could be written to JSON text files by mapping ``json.dumps``
+    on to the bag first, and then calling ``to_textfiles``:
+
+    >>> b_dict.map(json.dumps).to_textfiles("/path/to/data/*.json")
+
     """
     if isinstance(path, (str, unicode)):
         if '*' in path:

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -152,7 +152,7 @@ def to_textfiles(b, path, name_function=str, compression='infer',
     JSON text files by mapping ``json.dumps``on to the bag first, and 
     then calling ``to_textfiles``:
 
-    >>> b_dict.map(json.dumps).to_textfiles("/path/to/data/*.json")
+    >>> b_dict.map(json.dumps).to_textfiles("/path/to/data/*.json")  # doctest: +SKIP
 
     """
     if isinstance(path, (str, unicode)):


### PR DESCRIPTION
made explicit that bags that are to be written to text files must first be bags of text strings.