### PR TITLE
Clean DataFrame naming conventions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -100,7 +100,7 @@ class Scalar(Base):
     @classmethod
     def _get_unary_operator(cls, op):
         def f(self):
-            name = tokenize(self)
+            name = funcname(op) + '-' + tokenize(self)
             dsk = {(name, 0): (op, (self._name, 0))}
             return Scalar(merge(dsk, self.dask), name)
         return f
@@ -111,7 +111,7 @@ class Scalar(Base):
 
 
 def _scalar_binary(op, a, b, inv=False):
-    name = '{0}-{1}'.format(op.__name__, tokenize(a, b))
+    name = '{0}-{1}'.format(funcname(op), tokenize(a, b))
 
     dsk = a.dask
     if not isinstance(b, Base):
@@ -1920,7 +1920,7 @@ def elemwise(op, *args, **kwargs):
     """ Elementwise operation for dask.Dataframes """
     columns = kwargs.pop('columns', no_default)
 
-    _name = 'elemwise-' + tokenize(op, kwargs, *args)
+    _name = funcname(op) + '-' + tokenize(op, kwargs, *args)
 
     args = _maybe_from_pandas(args)
 

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -101,7 +101,7 @@ class Resampler(object):
     def _agg(self, how, columns=None, fill_value=np.nan):
         rule = self._rule
         kwargs = self._kwargs
-        name = tokenize(self.obj, rule, kwargs, how)
+        name = 'resample-' + tokenize(self.obj, rule, kwargs, how)
 
         # Create a grouper to determine closed and label conventions
         newdivs, outdivs = _resample_bin_and_out_divs(self.obj.divisions, rule,

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -6,6 +6,7 @@ import pandas.util.testing as tm
 import pytest
 
 from dask.utils import raises
+from dask.dataframe.utils import eq
 import dask.dataframe as dd
 
 
@@ -26,17 +27,16 @@ else:
 def test_series_resample(method, npartitions, freq, closed, label):
     index = pd.date_range('1-1-2000', '2-15-2000', freq='h')
     index = index.union(pd.date_range('4-15-2000', '5-15-2000', freq='h'))
-    df = pd.Series(range(len(index)), index=index)
-    ds = dd.from_pandas(df, npartitions=npartitions)
+    ps = pd.Series(range(len(index)), index=index)
+    ds = dd.from_pandas(ps, npartitions=npartitions)
     # Series output
+
     result = resample(ds, freq, how=method, closed=closed, label=label)
+    expected = resample(ps, freq, how=method, closed=closed, label=label)
+    eq(result, expected, check_dtype=False)
+
     divisions = result.divisions
-    result = result.compute()
-    expected = resample(df, freq, how=method, closed=closed, label=label)
-    if method != 'ohlc':
-        tm.assert_series_equal(result, expected, check_dtype=False)
-    else:
-        tm.assert_frame_equal(result, expected, check_dtype=False)
+
     assert expected.index[0] == divisions[0]
     assert expected.index[-1] == divisions[-1]
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -232,4 +232,4 @@ def assert_sane_keynames(ddf):
         assert len(k) < 100
         assert ' ' not in k
         if sys.version_info[0] >= 3:
-            assert k.split('-')[0].isidentifier() or len(k) in (32, 40)
+            assert k.split('-')[0].isidentifier()


### PR DESCRIPTION
In a few places we still had full hash-strings popping up (notably
resample and unary elemwise operations.)  Now we fully test that all
cases use an identifier for a first term in the name.