### PR TITLE
editing doc string in to_textfiles

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -147,10 +147,10 @@ def to_textfiles(b, path, name_function=str, compression='infer',
     **Compression**: Filenames with extensions corresponding to known
     compression algorithms (gz, bz2) will be compressed accordingly.
     
-    **Bag Contents**: The bag calling ``to_textfiles`` _must_ be a bag of
+    **Bag Contents**: The bag calling ``to_textfiles`` must be a bag of
     text strings. For example, a bag of dictionaries could be written to 
-    JSON text files by mapping ``json.dumps``on to the bag first, and 
-    then calling ``to_textfiles``:
+    JSON text files by mapping ``json.dumps`` on to the bag first, and 
+    then calling ``to_textfiles`` :
 
     >>> b_dict.map(json.dumps).to_textfiles("/path/to/data/*.json")  # doctest: +SKIP
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -147,10 +147,10 @@ def to_textfiles(b, path, name_function=str, compression='infer',
     **Compression**: Filenames with extensions corresponding to known
     compression algorithms (gz, bz2) will be compressed accordingly.
     
-     **Bag Contents**: The bag calling ``to_textfiles`` _must_ be a bag of
-    text strings. For example, a bag of
-    dictionaries could be written to JSON text files by mapping ``json.dumps``
-    on to the bag first, and then calling ``to_textfiles``:
+    **Bag Contents**: The bag calling ``to_textfiles`` _must_ be a bag of
+    text strings. For example, a bag of dictionaries could be written to 
+    JSON text files by mapping ``json.dumps``on to the bag first, and 
+    then calling ``to_textfiles``:
 
     >>> b_dict.map(json.dumps).to_textfiles("/path/to/data/*.json")
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -146,6 +146,14 @@ def to_textfiles(b, path, name_function=str, compression='infer',
 
     **Compression**: Filenames with extensions corresponding to known
     compression algorithms (gz, bz2) will be compressed accordingly.
+    
+     **Bag Contents**: The bag calling ``to_textfiles`` _must_ be a bag of
+    text strings. For example, a bag of
+    dictionaries could be written to JSON text files by mapping ``json.dumps``
+    on to the bag first, and then calling ``to_textfiles``:
+
+    >>> b_dict.map(json.dumps).to_textfiles("/path/to/data/*.json")
+
     """
     if isinstance(path, (str, unicode)):
         if '*' in path:

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -152,7 +152,7 @@ def to_textfiles(b, path, name_function=str, compression='infer',
     JSON text files by mapping ``json.dumps``on to the bag first, and 
     then calling ``to_textfiles``:
 
-    >>> b_dict.map(json.dumps).to_textfiles("/path/to/data/*.json")
+    >>> b_dict.map(json.dumps).to_textfiles("/path/to/data/*.json")  # doctest: +SKIP
 
     """
     if isinstance(path, (str, unicode)):


### PR DESCRIPTION
it was noticed that rendered html docs were incorrectly formatted due to missing spaces around double back-quotes - so spaces were inserted. Also, incorrect mark-up was used around the word 'must' so that was simply removed.