### PR TITLE
Sort index on shuffle

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -378,7 +378,8 @@ def set_partition_tasks(df, index, divisions, max_branch=32, drop=True):
     dsk = merge(df2.dask, start, end, *(groups + splits + joins))
 
     meta = df._pd.set_index(index if np.isscalar(index) else index._pd)
-    return DataFrame(dsk, 'shuffle-' + token, meta, divisions)
+    result = DataFrame(dsk, 'shuffle-' + token, meta, divisions)
+    return result.map_partitions(pd.DataFrame.sort_index, result)
 
 
 def set_partition_disk(df, index, divisions, compute=False, drop=True, **kwargs):
@@ -457,4 +458,5 @@ def set_partition_disk(df, index, divisions, compute=False, drop=True, **kwargs)
     if compute:
         dsk, _ = cull(dsk, list(dsk4.keys()))
 
-    return DataFrame(dsk, name, metadata, divisions)
+    result = DataFrame(dsk, name, metadata, divisions)
+    return result.map_partitions(pd.DataFrame.sort_index, result)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -182,3 +182,14 @@ def test_shuffle_pre_partition():
                 assert part == len(divisions) - 2
             else:
                 assert divisions[part] <= x < divisions[part + 1]
+
+
+@pytest.mark.parametrize('method', ['tasks', 'disk'])
+def test_shuffle_sort(method):
+    df = pd.DataFrame({'x': [1, 2, 3, 2, 1], 'y': [9, 8, 7, 1, 5]})
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    df2 = df.set_index('x').sort_index()
+    ddf2 = ddf.set_index('x', method=method)
+
+    eq(ddf2.loc[2:3], df2.loc[2:3])


### PR DESCRIPTION
Otherwise loc operations were failing after shuffles

```python
In [1]: import pandas as pd

In [2]: df = pd.DataFrame({'x': [1, 2, 3, 4]}, index=[1, 2, 3, 2])

In [3]: df
Out[3]: 
   x
1  1
2  2
3  3
2  4

In [4]: df.loc[2:3]
KeyError: 'Cannot get left slice bound for non-unique label: 2'
```