### PR TITLE
Add validation and tests for order breaking name_function

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -36,7 +36,8 @@ from ..core import list2, quote, istask, get_dependencies, reverse_dict
 from ..multiprocessing import get as mpget
 from ..optimize import fuse, cull, inline
 from ..utils import (infer_compression, open, system_encoding,
-                     takes_multiple_arguments, funcname, digit, insert)
+                     takes_multiple_arguments, funcname, digit, insert,
+                     build_name_function)
 
 no_default = '__no__default__'
 
@@ -101,7 +102,7 @@ def optimize(dsk, keys, **kwargs):
     return dsk5
 
 
-def to_textfiles(b, path, name_function=str, compression='infer',
+def to_textfiles(b, path, name_function=None, compression='infer',
                  encoding=system_encoding, compute=True):
     """ Write bag to disk, one filename per partition, one line per element
 
@@ -158,6 +159,9 @@ def to_textfiles(b, path, name_function=str, compression='infer',
 
     """
     if isinstance(path, (str, unicode)):
+        if name_function is None:
+            name_function = build_name_function(b.npartitions - 1)
+
         if not '*' in path:
             path = os.path.join(path, '*.part')
 
@@ -507,7 +511,7 @@ class Bag(Base):
         return tuple(self.pluck(i) for i in range(n))
 
     @wraps(to_textfiles)
-    def to_textfiles(self, path, name_function=str, compression='infer',
+    def to_textfiles(self, path, name_function=None, compression='infer',
                      encoding=system_encoding, compute=True):
         return to_textfiles(self, path, name_function, compression, encoding, compute)
 

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -22,6 +22,7 @@ from ..async import get_sync
 from .core import _Frame, DataFrame, Series
 from .shuffle import set_partition
 
+from ..utils import build_name_function
 
 lock = Lock()
 
@@ -401,7 +402,7 @@ def _link(token, result):
 @wraps(pd.DataFrame.to_hdf)
 def to_hdf(df, path_or_buf, key, mode='a', append=False, complevel=0,
            complib=None, fletcher32=False, get=get_sync, dask_kwargs=None,
-           name_function=str, **kwargs):
+           name_function=None, **kwargs):
     name = 'to-hdf-' + uuid.uuid1().hex
 
     pd_to_hdf = getattr(df._partition_type, 'to_hdf')
@@ -417,6 +418,9 @@ def to_hdf(df, path_or_buf, key, mode='a', append=False, complevel=0,
             raise ValueError("A maximum of one asterisk is accepted in dataset key")
 
         fmt_obj = lambda path_or_buf, _: path_or_buf
+
+    if name_function is None:
+        name_function = build_name_function(df.npartitions - 1)
 
     # we guarantee partition order is preserved when its saved and read
     # so we enforce name_function to maintain the order of its input.

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -12,6 +12,7 @@ import struct
 import tempfile
 import inspect
 import codecs
+import math
 from sys import getdefaultencoding
 
 from .compatibility import long, getargspec, BZ2File, GzipFile, LZMAFile
@@ -625,3 +626,31 @@ def insert(tup, loc, val):
     L = list(tup)
     L[loc] = val
     return tuple(L)
+
+def build_name_function(max_int):
+    """ Returns a function that receives a single integer
+    and returns it as a string padded by enough zero characters
+    to align with maximum possible integer
+
+    >>> name_f = build_name_function(57)
+
+    >>> name_f(7)
+    '07'
+    >>> name_f(31)
+    '31'
+    >>> build_name_function(1000)(42)
+    '0042'
+    >>> build_name_function(999)(42)
+    '042'
+    >>> build_name_function(0)(0)
+    '0'
+    """
+    # handle corner cases max_int is 0 or exact power of 10
+    max_int += 1e-8
+
+    pad_length = int(math.ceil(math.log10(max_int)))
+
+    def name_function(i):
+        return str(i).zfill(pad_length)
+
+    return name_function


### PR DESCRIPTION
This bug was recently introduced by myself to dataframe.to_hdf and preexisted with bag.to_textfiles.
Saving to multiple files (as possible with asterisks in those functions) did not preserve the
partitions order.
