### PR TITLE
Pass through storage_options in db.read_text

### DIFF
--- a/dask/bag/text.py
+++ b/dask/bag/text.py
@@ -81,7 +81,8 @@ def read_text(urlpath, blocksize=None, compression='infer',
 
         elif blocksize is None:
             files = open_text_files(urlpath, encoding=encoding, errors=errors,
-                                          compression=compression)
+                                    compression=compression,
+                                    **(storage_options or {}))
             blocks = [delayed(list)(file) for file in files]
 
         else:

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -242,3 +242,10 @@ def test_read_csv_passes_through_options():
     with s3_context('csv', {'a.csv': b'a,b\n1,2\n3,4'}) as s3:
         df = dd.read_csv('s3://csv/*.csv', storage_options={'s3': s3})
         assert df.a.sum().compute() == 1 + 3
+
+
+def test_read_text_passes_through_options():
+    db = pytest.importorskip('dask.bag')
+    with s3_context('csv', {'a.csv': b'a,b\n1,2\n3,4'}) as s3:
+        df = db.read_text('s3://csv/*.csv', storage_options={'s3': s3})
+        assert df.count().compute(get=get) == 3


### PR DESCRIPTION
Cleans up a bit from https://github.com/dask/dask/pull/1269
