### PR TITLE
Few travis fixes, pandas version >= 0.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ sudo: false
 
 env:
   matrix:
-    - PYTHON=2.7 NUMPY=1.10.4 PANDAS=0.17.0
-    - PYTHON=2.7 NUMPY=1.11.0 PANDAS=0.18.0
-    - PYTHON=3.3 NUMPY=1.9.2 PANDAS=0.16.2
-    - PYTHON=3.4 NUMPY=1.10.4 PANDAS=0.18.0
-    - PYTHON=3.5 NUMPY=1.11.0 PANDAS=0.18.1
+    - PYTHON=2.7 NUMPY=1.10.4 PANDAS=0.18.0 COVERAGE='true'
+    - PYTHON=2.7 NUMPY=1.11.0 PANDAS=0.18.1 COVERAGE='false'
+    - PYTHON=3.3 NUMPY=1.9.2 PANDAS=0.18.1 COVERAGE='false'
+    - PYTHON=3.4 NUMPY=1.10.4 PANDAS=0.18.0 COVERAGE='false'
+    - PYTHON=3.5 NUMPY=1.11.0 PANDAS=0.18.1 COVERAGE='false'
 
 addons:
     apt:
@@ -26,8 +26,9 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$PYTHON
   - source activate test-environment
-  - conda install numpy=$NUMPY scipy pandas=$PANDAS pytables h5py bcolz pytest coverage toolz scikit-learn cytoolz chest blosc cython psutil ipython
-  - if [[ $PYTHON != '3.3' ]]; then conda install distributed cloudpickle bokeh; fi
+  - conda install numpy=$NUMPY scipy pytables h5py bcolz pytest coverage toolz scikit-learn cytoolz chest blosc cython psutil ipython
+  - if [[ $PYTHON != '3.3' ]]; then conda install pandas=$PANDAS distributed cloudpickle bokeh; fi
+  - if [[ $PYTHON == '3.3' ]]; then pip install pandas==$PANDAS; fi
   - if [[ $PYTHON == '2.7' ]]; then pip install backports.lzma; fi
   - pip install git+https://github.com/mrocklin/partd --upgrade
   - pip install git+https://github.com/mrocklin/cachey --upgrade
@@ -39,10 +40,10 @@ install:
   - pip install --no-deps -e .[complete]
 
 script:
-    - if [[ $PYTHON == '2.7' ]]; then coverage run $(which py.test) dask --runslow --doctest-modules --verbose; else py.test dask --verbose; fi
+    - if [[ $COVERAGE == 'true' ]]; then coverage run $(which py.test) dask --runslow --doctest-modules --verbose; else py.test dask --verbose; fi
 
 after_success:
-    - if [[ $PYTHON == '2.7' ]]; then coverage report --show-missing; pip install coveralls ; coveralls ; fi
+    - if [[ $coverage == 'true' ]]; then coverage report --show-missing; pip install coveralls ; coveralls ; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - if [[ $PYTHON < '3' ]]; then pip install git+https://github.com/Blosc/castra; fi
 
   # Install dask
-  - pip install -e .[complete]
+  - pip install --no-deps -e .[complete]
 
 script:
     - if [[ $PYTHON == '2.7' ]]; then coverage run $(which py.test) dask --runslow --doctest-modules --verbose; else py.test dask --verbose; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - source activate test-environment
   - conda install numpy=$NUMPY scipy pytables h5py bcolz pytest coverage toolz scikit-learn cytoolz chest blosc cython psutil ipython
   - if [[ $PYTHON != '3.3' ]]; then conda install pandas=$PANDAS distributed cloudpickle bokeh; fi
-  - if [[ $PYTHON == '3.3' ]]; then pip install pandas==$PANDAS; fi
+  - if [[ $PYTHON == '3.3' ]]; then pip install cloudpickle pandas==$PANDAS; fi
   - if [[ $PYTHON == '2.7' ]]; then pip install backports.lzma; fi
   - pip install git+https://github.com/mrocklin/partd --upgrade
   - pip install git+https://github.com/mrocklin/cachey --upgrade

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 from collections import Iterator
 from datetime import datetime
-from distutils.version import LooseVersion
 import math
 import operator
 from operator import getitem, setitem
@@ -1152,10 +1151,7 @@ class Series(_Frame):
     @derived_from(pd.Series)
     def value_counts(self):
         chunk = lambda s: s.value_counts()
-        if LooseVersion(pd.__version__) > '0.16.2':
-            agg = lambda s: s.groupby(level=0).sum().sort_values(ascending=False)
-        else:
-            agg = lambda s: s.groupby(level=0).sum().sort(inplace=False, ascending=False)
+        agg = lambda s: s.groupby(level=0).sum().sort_values(ascending=False)
         return aca(self, chunk=chunk, aggregate=agg, columns=self.name,
                    token='value-counts')
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -280,11 +280,7 @@ def shuffle_pre_partition_series(df, index, divisions, drop):
 
 def shuffle_group(df, stage, k):
     df['.old-index'] = df.index
-    if pd.__version__ >= '0.17':
-        index = df.index // k ** stage % k
-    else:
-        values = df.index.values // k ** stage % k
-        index = pd.Index(values)
+    index = df.index // k ** stage % k
     inds = set(index.drop_duplicates())
     df = df.set_index(index)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,5 +1,4 @@
 from operator import getitem
-from distutils.version import LooseVersion
 
 import pandas as pd
 import pandas.util.testing as tm
@@ -490,12 +489,7 @@ def test_drop_duplicates_subset():
                        'y': ['a', 'a', 'b', 'b', 'c', 'c']})
     ddf = dd.from_pandas(df, npartitions=2)
 
-    if pd.__version__ < '0.17':
-        kwargs = [{'take_last': False}, {'take_last': True}]
-    else:
-        kwargs = [{'keep': 'first'}, {'keep': 'last'}]
-
-    for kwarg in kwargs:
+    for kwarg in [{'keep': 'first'}, {'keep': 'last'}]:
         assert eq(df.x.drop_duplicates(**kwarg),
                   ddf.x.drop_duplicates(**kwarg))
         for ss in [['x'], 'y', ['x', 'y']]:
@@ -1279,8 +1273,6 @@ def test_query():
         assert eq(q, df.query('x**2 > y'))
 
 
-@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.18.0',
-                    reason="eval inplace not supported")
 def test_eval():
     p = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})
     d = dd.from_pandas(p, npartitions=2)
@@ -1520,8 +1512,6 @@ def test_index_time_properties():
     assert (i.index.month == a.index.month.compute()).all()
 
 
-@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.16.2',
-                    reason="nlargest not in pandas pre 0.16.2")
 def test_nlargest():
     from string import ascii_lowercase
     df = pd.DataFrame({'a': np.random.permutation(10),
@@ -1533,8 +1523,6 @@ def test_nlargest():
     eq(res, exp)
 
 
-@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.16.2',
-                    reason="nlargest not in pandas pre 0.16.2")
 def test_nlargest_multiple_columns():
     from string import ascii_lowercase
     df = pd.DataFrame({'a': np.random.permutation(10),

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -1,7 +1,5 @@
-from distutils.version import LooseVersion
 import pandas as pd
 import pandas.util.testing as tm
-import pytest
 import numpy as np
 
 import dask.dataframe as dd
@@ -18,6 +16,7 @@ def eq(p, d):
 
 def mad(x):
     return np.fabs(x - x.mean()).mean()
+
 
 def rolling_functions_tests(p, d):
     # Old-fashioned rolling API
@@ -40,6 +39,7 @@ def rolling_functions_tests(p, d):
     eq(pd.rolling_sum(p, 1), dd.rolling_sum(d, 1))
     # Test with kwargs
     eq(pd.rolling_sum(p, 3, min_periods=3), dd.rolling_sum(d, 3, min_periods=3))
+
 
 def basic_rolling_tests(p, d): # Works for series or df
     # New rolling API
@@ -64,14 +64,13 @@ def basic_rolling_tests(p, d): # Works for series or df
     # Test with kwargs
     eq(p.rolling(3, min_periods=2).sum(), d.rolling(3, min_periods=2).sum())
 
+
 def test_rolling_functions_series():
     ts = pd.Series(np.random.randn(25).cumsum())
     dts = dd.from_pandas(ts, 3)
     rolling_functions_tests(ts, dts)
 
 
-@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.18.0',
-                    reason="rolling object not supported")
 def test_rolling_series():
     for ts in [
             pd.Series(np.random.randn(25).cumsum()),
@@ -87,8 +86,6 @@ def test_rolling_funtions_dataframe():
     rolling_functions_tests(df, ddf)
 
 
-@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.18.0',
-                    reason="rolling object not supported")
 def test_rolling_dataframe():
     df = pd.DataFrame({'a': np.random.randn(25).cumsum(),
                        'b': np.random.randint(100, size=(25,))})
@@ -105,8 +102,7 @@ def test_rolling_functions_raises():
     assert raises(NotImplementedError, lambda: dd.rolling_mean(ddf, 3, freq=2))
     assert raises(NotImplementedError, lambda: dd.rolling_mean(ddf, 3, how='min'))
 
-@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.18.0',
-                    reason="rolling object not supported")
+
 def test_rolling_raises():
     df = pd.DataFrame({'a': np.random.randn(25).cumsum(),
                        'b': np.random.randint(100, size=(25,))})
@@ -126,16 +122,14 @@ def test_rolling_functions_names():
     a = dd.from_pandas(df, npartitions=2)
     assert sorted(dd.rolling_sum(a, 2).dask) == sorted(dd.rolling_sum(a, 2).dask)
 
-@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.18.0',
-                    reason="rolling object not supported")
+
 def test_rolling_names():
     df = pd.DataFrame({'a': [1, 2, 3],
                        'b': [4, 5, 6]})
     a = dd.from_pandas(df, npartitions=2)
     assert sorted(a.rolling(2).sum().dask) == sorted(a.rolling(2).sum().dask)
 
-@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.18.0',
-                    reason="rolling object not supported")
+
 def test_rolling_axis():
     df = pd.DataFrame(np.random.randn(20, 16))
     ddf = dd.from_pandas(df, npartitions=3)
@@ -153,6 +147,7 @@ def test_rolling_axis():
     ds = ddf[3]
     eq(s.rolling(5, axis=0).std(), ds.rolling(5, axis=0).std())
 
+
 def test_rolling_function_partition_size():
     df = pd.DataFrame(np.random.randn(50, 2))
     ddf = dd.from_pandas(df, npartitions=5)
@@ -162,8 +157,7 @@ def test_rolling_function_partition_size():
         eq(pd.rolling_mean(obj, 11), dd.rolling_mean(dobj, 11))
         raises(NotImplementedError, lambda: dd.rolling_mean(dobj, 12))
 
-@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.18.0',
-                    reason="rolling object not supported")
+
 def test_rolling_partition_size():
     df = pd.DataFrame(np.random.randn(50, 2))
     ddf = dd.from_pandas(df, npartitions=5)
@@ -173,8 +167,7 @@ def test_rolling_partition_size():
         eq(obj.rolling(11).mean(), dobj.rolling(11).mean())
         raises(NotImplementedError, lambda: dobj.rolling(12).mean())
 
-@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.18.0',
-                    reason="rolling object not supported")
+
 def test_rolling_repr():
     ddf = dd.from_pandas(pd.DataFrame([10]*30), npartitions=3)
     assert repr(ddf.rolling(4)) in ['Rolling [window=4,axis=0]',

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -1,8 +1,6 @@
 from itertools import product
-from distutils.version import LooseVersion
 
 import pandas as pd
-import pandas.util.testing as tm
 import pytest
 
 from dask.utils import raises
@@ -10,12 +8,8 @@ from dask.dataframe.utils import eq
 import dask.dataframe as dd
 
 
-if LooseVersion(pd.__version__) >= '0.18.0':
-    def resample(df, freq, how='mean', **kwargs):
-        return getattr(df.resample(freq, **kwargs), how)()
-else:
-    def resample(df, freq, how='mean', **kwargs):
-        return df.resample(freq, how=how, **kwargs)
+def resample(df, freq, how='mean', **kwargs):
+    return getattr(df.resample(freq, **kwargs), how)()
 
 
 @pytest.mark.parametrize(['method', 'npartitions', 'freq', 'closed', 'label'],


### PR DESCRIPTION
Without --no-deps, pip would upgrade all packages that were out of date,
even if this was intentional by the pandas/numpy build matrix.