### PR TITLE
Support datetimes in DataFrame._build_pd

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import Iterator
+from datetime import datetime
 from distutils.version import LooseVersion
 import math
 import operator
@@ -200,9 +201,13 @@ class _Frame(Base):
         else:
             if np.isscalar(metadata) or metadata is None:
                 _pd = cls._partition_type([], name=metadata)
+                known_dtype = False
+            elif isinstance(metadata, datetime):
+                _pd = cls._partition_type([metadata]).iloc[0:0]
+                known_dtype = True
             else:
                 _pd = cls._partition_type(columns=metadata)
-            known_dtype = False
+                known_dtype = False
         return _pd, known_dtype
 
     @property

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1704,3 +1704,17 @@ def test_gh_1301():
        df.assign(y=df[1].astype(int)))
 
     assert ddf2.dtypes['y'] == np.dtype(int)
+
+
+def test_timeseries_sorted():
+    df = tm.makeTimeDataFrame()
+    ddf = dd.from_pandas(df.reset_index(), npartitions=2)
+    df.index.name = 'index'
+    eq(ddf.set_index('index', sorted=True, drop=True),
+       df)
+
+
+def test_build_pd():
+    s, known_dtype = dd.Series._build_pd(pd.NaT)
+    assert isinstance(s, pd.Series)
+    assert np.issubdtype(s.dtype, np.datetime64)


### PR DESCRIPTION
Previously set_index(..., sorted=True) failed because pandas Timestamps
aren't numpy scalars.  This adds a special case for them in _build_pd.

More general solutions welcome.