### PR TITLE
Support column assignment in DataFrame

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1444,6 +1444,18 @@ class DataFrame(_Frame):
                                      self, self.divisions)
         raise NotImplementedError(key)
 
+    def __setitem__(self, key, value):
+        if isinstance(key, (tuple, list)):
+            df = self.assign(**{k: value[c]
+                                for k, c in zip(key, value.columns)})
+        else:
+            df = self.assign(**{key: value})
+
+        self.dask = df.dask
+        self._name = df._name
+        self._pd = df._pd
+        self._known_dtype = df._known_dtype
+
     def __getattr__(self, key):
         try:
             return self[key]

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1718,3 +1718,27 @@ def test_build_pd():
     s, known_dtype = dd.Series._build_pd(pd.NaT)
     assert isinstance(s, pd.Series)
     assert np.issubdtype(s.dtype, np.datetime64)
+
+
+def test_column_assignment():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [1, 0, 1, 0]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    from copy import copy
+    orig = copy(ddf)
+    ddf['z'] = ddf.x + ddf.y
+    df['z'] = df.x + df.y
+
+    eq(df, ddf)
+
+
+def test_columns_assignment():
+    df = pd.DataFrame({'x': [1, 2, 3, 4]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    df2 = df.assign(y=df.x + 1, z=df.x - 1)
+    df[['a', 'b']] = df2[['y', 'z']]
+
+    ddf2 = ddf.assign(y=ddf.x + 1, z=ddf.x - 1)
+    ddf[['a', 'b']] = ddf2[['y', 'z']]
+
+    eq(df, ddf)


### PR DESCRIPTION
```python
In [1]: import pandas as pd

In [2]: import dask.dataframe as dd

In [3]: df = pd.DataFrame({'x': [1, 2, 3]})

In [4]: ddf = dd.from_pandas(df, npartitions=2)

In [5]: ddf['y'] = ddf.x + 1

In [6]: ddf['z'] = ddf.x - 1

In [7]: ddf.compute()
Out[7]: 
   x  y  z
0  1  2  0
1  2  3  1
2  3  4  2
```