### PR TITLE
Add Bag.random_sample method.

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -418,9 +418,10 @@ class Bag(Base):
         return lambda _: random_state.random() < prob
 
     def random_sample(self, prob, random_state=None):
-        """ Return elements from bag with probability of prob
+        """ Return elements from bag with probability of ``prob``.
 
-        All elements are considered independently without replacement.
+        ``prob`` must be a number in the interval `[0, 1]`. All elements are
+        considered independently without replacement.
 
         Providing an integer seed for ``random_state`` will result in
         deterministic sampling. Given the same seed it will return the same
@@ -433,6 +434,8 @@ class Bag(Base):
         >>> list(b.random_sample(0.5, 42))
         [1, 3]
         """
+        if not 0 <= prob <= 1:
+            raise ValueError('prob must be a number in the interval [0, 1]')
         import numpy as np
         if random_state is None:
             random_state = np.random.randint(np.iinfo(np.int32).max)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -8,6 +8,7 @@ from operator import getitem
 import os
 import types
 import uuid
+from random import Random
 from warnings import warn
 from distutils.version import LooseVersion
 
@@ -37,7 +38,7 @@ from ..multiprocessing import get as mpget
 from ..optimize import fuse, cull, inline
 from ..utils import (infer_compression, open, system_encoding,
                      takes_multiple_arguments, funcname, digit, insert,
-                     build_name_function)
+                     build_name_function, different_seeds)
 from ..delayed import Delayed, delayed
 
 no_default = '__no__default__'
@@ -410,6 +411,43 @@ class Bag(Base):
                    for i in range(self.npartitions))
         return type(self)(merge(self.dask, dsk), name, self.npartitions)
 
+    def _get_rs_predicate(self, seed, prob):
+        """ Return sampling filter predicate for the given seed.
+        """
+        random_state = Random(seed)
+        return lambda _: random_state.random() < prob
+
+    def random_sample(self, prob, random_state=None):
+        """ Return elements from bag with probability of prob
+
+        All elements are considered independently without replacement.
+
+        Providing an integer seed for ``random_state`` will result in
+        deterministic sampling. Given the same seed it will return the same
+        sample every time.
+
+        >>> import dask.bag as db
+        >>> b = db.from_sequence(range(5))
+        >>> list(b.random_sample(0.5, 42))
+        [1, 3]
+        >>> list(b.random_sample(0.5, 42))
+        [1, 3]
+        """
+        import numpy as np
+        if random_state is None:
+            random_state = np.random.randint(np.iinfo(np.int32).max)
+
+        name = 'random-sample-{0}'.format(tokenize(self, prob, random_state))
+        # we need to generate a different random seed for each partition or
+        # otherwise we would be selecting the exact same positions at each
+        # partition
+        seeds = different_seeds(self.npartitions, random_state)
+
+        dsk = dict(((name, i), (reify, (filter,
+                   self._get_rs_predicate(seed, prob), (self.name, i))))
+                   for i, seed in zip(range(self.npartitions), seeds))
+        return type(self)(merge(self.dask, dsk), name, self.npartitions)
+
     def remove(self, predicate):
         """ Remove elements in collection that match predicate
 
@@ -473,6 +511,7 @@ class Bag(Base):
                     if kwargs else (func, (self.name, i)))
                    for i in range(self.npartitions))
         return type(self)(dsk, name, self.npartitions)
+
 
     def pluck(self, key, default=no_default):
         """ Select item from all tuples/dicts in collection

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -339,6 +339,36 @@ def test_map_partitions_with_kwargs():
         factor=2).sum().compute() == 2.0
 
 
+def test_random_sample_repeated_computation():
+    """
+    Repeated computation of a defined random sampling operation
+    generates identical results.
+    """
+    a = db.from_sequence(range(50), npartitions=5)
+    b = a.random_sample(0.2)
+    assert list(b) == list(b)  # computation happens here
+
+
+def test_random_sample_different_definitions():
+    """
+    Repeatedly defining a random sampling operation yields different results
+    upon computation if no random seed is specified.
+    """
+    a = db.from_sequence(range(50), npartitions=5)
+    assert list(a.random_sample(0.5)) != list(a.random_sample(0.5))
+    assert a.random_sample(0.5).name != a.random_sample(0.5).name
+
+
+def test_random_sample_random_state():
+    """
+    Sampling with fixed random seed generates identical results.
+    """
+    a = db.from_sequence(range(50), npartitions=5)
+    b = a.random_sample(0.5, 1234)
+    c = a.random_sample(0.5, 1234)
+    assert list(b) == list(c)
+
+
 def test_lazify_task():
     task = (sum, (reify, (map, inc, [1, 2, 3])))
     assert lazify_task(task) == (sum, (map, inc, [1, 2, 3]))

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -339,6 +339,16 @@ def test_map_partitions_with_kwargs():
         factor=2).sum().compute() == 2.0
 
 
+def test_random_sample_size():
+    """
+    Number of randomly sampled elements are in the expected range.
+    """
+    a = db.from_sequence(range(1000), npartitions=5)
+    # we expect a size of approx. 100, but leave large margins to avoid
+    # random failures
+    assert 10 < len(list(a.random_sample(0.1, 42))) < 300
+
+
 def test_random_sample_repeated_computation():
     """
     Repeated computation of a defined random sampling operation

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -349,6 +349,17 @@ def test_random_sample_size():
     assert 10 < len(list(a.random_sample(0.1, 42))) < 300
 
 
+def test_random_sample_prob_range():
+    """
+    Specifying probabilities outside the range [0, 1] raises ValueError.
+    """
+    a = db.from_sequence(range(50), npartitions=5)
+    with pytest.raises(ValueError):
+        a.random_sample(-1)
+    with pytest.raises(ValueError):
+        a.random_sample(1.1)
+
+
 def test_random_sample_repeated_computation():
     """
     Repeated computation of a defined random sampling operation

--- a/docs/source/bag-api.rst
+++ b/docs/source/bag-api.rst
@@ -27,6 +27,7 @@ Top level user functions:
     Bag.pluck
     Bag.product
     Bag.reduction
+    Bag.random_sample
     Bag.remove
     Bag.repartition
     Bag.std


### PR DESCRIPTION
See #1268.

I'm hesitant about the introduced numpy dependency just because of the random seed generation. Perhaps we can rewrite `different_seeds` without numpy?

Are the tests are thorough enough?