### PR TITLE
Mark the 4 slowest tests as slow to get a faster suite by default.

### DIFF
--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytest
 import numpy as np
 import pandas as pd
 
@@ -8,6 +9,7 @@ import dask.dataframe as dd
 from dask.dataframe.utils import eq, assert_dask_graph
 
 
+@pytest.mark.slow
 def test_arithmetics():
     dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]},
                                   index=[0, 1, 3]),
@@ -109,6 +111,7 @@ def test_arithmetics():
                                 allow_comparison_ops=False)
 
 
+@pytest.mark.slow
 def test_arithmetics_different_index():
     # index are different, but overwraps
     pdf1 = pd.DataFrame({'a': [1, 2, 3, 4, 5], 'b': [3, 5, 2, 5, 7]},

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1035,6 +1035,7 @@ def test_set_partition_2():
     assert list(result.compute(get=get_sync).index[-2:]) == ['d', 'd']
 
 
+@pytest.mark.slow
 def test_repartition():
     def _check_split_data(orig, d):
         """Check data is split properly"""
@@ -1461,6 +1462,7 @@ def test_corr():
     pytest.raises(TypeError, lambda: da.corr(ddf))
 
 
+@pytest.mark.slow
 def test_cov_corr_stable():
     df = pd.DataFrame(np.random.random((20000000, 2)) * 2 - 1, columns=['a', 'b'])
     ddf = dd.from_pandas(df, npartitions=50)


### PR DESCRIPTION
See #1317.

These tests can still be run using the `--runslow` flag, which is currently activated in Travis.