### PR TITLE
Remove dask runtime dependence on mock 2.7 backport.

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -28,7 +28,6 @@ if PY3:
     from urllib.request import urlopen
     from urllib.parse import urlparse
     from urllib.parse import quote, unquote
-    from unittest import mock
     FileNotFoundError = FileNotFoundError
     unicode = str
     long = int
@@ -56,7 +55,6 @@ else:
     from urllib2 import urlopen
     from urlparse import urlparse
     from urllib import quote, unquote
-    import mock
     unicode = unicode
     long = long
     apply = apply

--- a/dask/dataframe/tests/test_csv.py
+++ b/dask/dataframe/tests/test_csv.py
@@ -16,7 +16,6 @@ from dask.dataframe.csv import (read_csv_from_bytes, bytes_read_csv, read_csv,
 from dask.dataframe.utils import eq
 from dask.bytes.core import read_bytes
 from dask.utils import filetexts, filetext
-from dask.compatibility import mock
 
 compute = partial(compute, get=get_sync)
 
@@ -232,6 +231,10 @@ def test_auto_blocksize_max64mb():
 
 def test_auto_blocksize_csv(monkeypatch):
     psutil = pytest.importorskip('psutil')
+    try:
+        from unittest import mock
+    except ImportError:
+        mock = pytest.importorskip('mock')
     total_memory = psutil.virtual_memory().total
     cpu_count = psutil.cpu_count()
     mock_read_bytes = mock.Mock(wraps=read_bytes)


### PR DESCRIPTION
Remove runtime dependence on mock backport added in #1328.