### PR TITLE
Multiprocess scheduler handles unpickling errors

### DIFF
--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -1,16 +1,22 @@
 from __future__ import absolute_import, division, print_function
 
-from toolz import curry
-from .optimize import fuse, cull
 import multiprocessing
-from .async import get_async # TODO: get better get
-from .context import _globals
-from sys import version
+import pickle
+import sys
 
-if version < '3':
+from .async import get_async  # TODO: get better get
+from .context import _globals
+from .optimize import fuse, cull
+
+import cloudpickle
+from toolz import curry
+
+
+if sys.version_info.major < 3:
     import copy_reg as copyreg
 else:
     import copyreg
+
 
 def _reduce_method_descriptor(m):
     return getattr, (m.__objclass__, m.__name__)
@@ -18,8 +24,6 @@ def _reduce_method_descriptor(m):
 # type(set.union) is used as a proxy to <class 'method_descriptor'>
 copyreg.pickle(type(set.union), _reduce_method_descriptor)
 
-import pickle
-import cloudpickle
 
 def _dumps(x):
     return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
@@ -63,8 +67,8 @@ def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
     queue = manager.Queue()
 
     apply_async = pickle_apply_async(pool.apply_async,
-                                          func_dumps=func_dumps,
-                                          func_loads=func_loads)
+                                     func_dumps=func_dumps,
+                                     func_loads=func_loads)
 
     # Optimize Dask
     dsk2, dependencies = cull(dsk, keys)
@@ -83,20 +87,37 @@ def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
     return result
 
 
-def apply_func(sfunc, sargs, skwds, loads=None):
+def apply_func(sfunc, may_fail, wont_fail, loads=None):
     loads = loads or _globals.get('loads') or _loads
     func = loads(sfunc)
-    args = loads(sargs)
-    kwds = loads(skwds)
-    return func(*args, **kwds)
+    key, queue, get_id, raise_on_exception = loads(wont_fail)
+    try:
+        task, data = loads(may_fail)
+    except Exception as e:
+        # Need a new reference for the exception, as `e` falls out of scope in
+        # python 3
+        exception = e
+        def serialization_failure():
+            raise exception
+        task = (serialization_failure,)
+        data = {}
+    return func(key, task, data, queue, get_id,
+                raise_on_exception=raise_on_exception)
 
 
 @curry
-def pickle_apply_async(apply_async, func, args=(), kwds={},
-                            func_loads=None, func_dumps=None):
+def pickle_apply_async(apply_async, func, args=(),
+                       func_loads=None, func_dumps=None):
+    # XXX: To deal with deserialization errors of tasks, this version of
+    # apply_async doesn't actually match that of `pool.apply_async`. It's
+    # customized to fit the signature of `dask.async.execute_task`, which is
+    # the only function ever actually passed as `func`. This is a bit of a
+    # hack, but it works pretty well. If the signature of `execute_task`
+    # changes, then this will need to be changed as well.
     dumps = func_dumps or _globals.get('func_dumps') or _dumps
+    key, task, data, queue, get_id, raise_on_exception = args
     sfunc = dumps(func)
-    sargs = dumps(args)
-    skwds = dumps(kwds)
+    may_fail = dumps((task, data))
+    wont_fail = dumps((key, queue, get_id, raise_on_exception))
     return apply_async(curry(apply_func, loads=func_loads),
-                       args=[sfunc, sargs, skwds])
+                       args=[sfunc, may_fail, wont_fail])

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -1,25 +1,13 @@
-import pytest
-
-from dask.multiprocessing import get, pickle_apply_async
-from dask.multiprocessing import _dumps, _loads
-from dask.context import set_options
 import multiprocessing
+import numpy as np
 import pickle
 from operator import add
-from dask.utils import raises
-import numpy as np
+
+from dask.context import set_options
+from dask.multiprocessing import get, _dumps, _loads
+
 
 inc = lambda x: x + 1
-
-
-def test_apply_lambda():
-    p = multiprocessing.Pool()
-    try:
-        result = pickle_apply_async(p.apply_async, lambda x: x + 1, args=[1])
-        assert isinstance(result, multiprocessing.pool.ApplyResult)
-        assert result.get() == 2
-    finally:
-        p.close()
 
 
 def test_pickle_globals():
@@ -40,7 +28,7 @@ def test_errors_propagate():
     dsk = {'x': (bad,)}
 
     try:
-        result = get(dsk, 'x')
+        get(dsk, 'x')
     except Exception as e:
         assert isinstance(e, ValueError)
         assert "12345" in str(e)
@@ -50,15 +38,45 @@ def make_bad_result():
     return lambda x: x + 1
 
 
-def test_unpicklable_results_genreate_errors():
+def test_unpicklable_results_generate_errors():
 
     dsk = {'x': (make_bad_result,)}
 
     try:
-        result = get(dsk, 'x')
+        get(dsk, 'x')
     except Exception as e:
         # can't use type because pickle / cPickle distinction
         assert type(e).__name__ in ('PicklingError', 'AttributeError')
+
+
+class NotUnpickleable(object):
+    def __getstate__(self):
+        return ()
+
+    def __setstate__(self, state):
+        raise ValueError("Can't unpickle me")
+
+
+def test_unpicklable_args_generate_errors():
+    a = NotUnpickleable()
+
+    def foo(a):
+        return 1
+
+    dsk = {'x': (foo, a)}
+
+    try:
+        get(dsk, 'x')
+    except Exception as e:
+        assert isinstance(e, ValueError)
+
+    dsk = {'x': (foo, 'a'),
+           'a': a}
+
+    try:
+        get(dsk, 'x')
+    except Exception as e:
+        assert isinstance(e, ValueError)
 
 
 def test_reuse_pool():


### PR DESCRIPTION
Previously if a task failed to be cleanly deserialized, the error wasn't handled gracefully and it would cause the scheduler to lock up. This fixes that issue by special casing the `apply_async` implementation in `dask.multiprocessing`. This means that it no longer matches the call signature of `pool.apply_async`, but in reality we always call `apply_async` with the same arguments. The special casing allows for deserialization errors to be handled the same as all other errors, and allows for a clean exit.

Also did a few small pep8 cleanups in the touched files.

Fixes #1342.