### PR TITLE
Fixes for bokeh 0.12.0

### DIFF
--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -178,11 +178,11 @@ def visualize(profilers, file_path=None, show=True, save=True, **kwargs):
         for f in figs[1:]:
             f.x_range = top.x_range
             f.title = None
-            f.min_border_top -= 30
+            f.min_border_top = 20
             f.plot_height -= 30
         for f in figs[:-1]:
             f.xaxis.axis_label = None
-            f.min_border_bottom -= 30
+            f.min_border_bottom = 20
             f.plot_height -= 30
         for f in figs:
             f.min_border_left = 75
@@ -193,6 +193,10 @@ def visualize(profilers, file_path=None, show=True, save=True, **kwargs):
     if file_path and save:
         bp.save(p)
     return p
+
+
+_figure_keywords = bp.Figure.properties()
+_figure_keywords.add('tools')
 
 
 def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
@@ -221,7 +225,7 @@ def plot_tasks(results, dsk, palette='YlGnBu', label_size=60, **kwargs):
                     tools="hover,save,reset,resize,xwheel_zoom,xpan",
                     plot_width=800, plot_height=300)
     defaults.update((k, v) for (k, v) in kwargs.items() if k in
-                    bp.Figure.properties())
+                    _figure_keywords)
 
     if results:
         keys, tasks, starts, ends, ids = zip(*results)
@@ -296,7 +300,7 @@ def plot_resources(results, palette='YlGnBu', **kwargs):
                     tools="save,reset,resize,xwheel_zoom,xpan",
                     plot_width=800, plot_height=300)
     defaults.update((k, v) for (k, v) in kwargs.items() if k in
-                    bp.Figure.properties())
+                    _figure_keywords)
     if results:
         t, mem, cpu = zip(*results)
         left, right = min(t), max(t)
@@ -349,7 +353,7 @@ def plot_cache(results, dsk, start_time, metric_name, palette='YlGnBu',
                     tools="hover,save,reset,resize,wheel_zoom,xpan",
                     plot_width=800, plot_height=300)
     defaults.update((k, v) for (k, v) in kwargs.items() if k in
-                    bp.Figure.properties())
+                    _figure_keywords)
 
     if results:
         starts, ends = list(zip(*results))[3:]

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -1,6 +1,7 @@
 from operator import add, mul
 import os
 from time import sleep
+from distutils.version import LooseVersion
 
 from dask.diagnostics import Profiler, ResourceProfiler, CacheProfiler
 from dask.threaded import get
@@ -178,6 +179,11 @@ def test_pprint_task():
     assert pprint_task(task, keys) == 'foo(_, _, y=[_, *], z=*)'
 
 
+def check_title(p, title):
+    # bokeh 0.12 changed the title attribute to not a string
+    return getattr(p.title, 'text', p.title) == title
+
+
 @pytest.mark.skipif("not bokeh")
 def test_profiler_plot():
     with prof:
@@ -191,7 +197,7 @@ def test_profiler_plot():
     assert p.plot_height == 300
     assert len(p.tools) == 1
     assert isinstance(p.tools[0], bokeh.models.HoverTool)
-    assert p.title == "Not the default"
+    assert check_title(p, "Not the default")
     # Test empty, checking for errors
     prof.clear()
     prof.visualize(show=False, save=False)
@@ -211,7 +217,7 @@ def test_resource_profiler_plot():
     assert p.plot_height == 300
     assert len(p.tools) == 1
     assert isinstance(p.tools[0], bokeh.models.HoverTool)
-    assert p.title == "Not the default"
+    assert check_title(p, "Not the default")
     # Test empty, checking for errors
     rprof.clear()
     rprof.visualize(show=False, save=False)
@@ -230,7 +236,7 @@ def test_cache_profiler_plot():
     assert p.plot_height == 300
     assert len(p.tools) == 1
     assert isinstance(p.tools[0], bokeh.models.HoverTool)
-    assert p.title == "Not the default"
+    assert check_title(p, "Not the default")
     assert p.axis[1].axis_label == 'Cache Size (non-standard)'
     # Test empty, checking for errors
     cprof.clear()
@@ -241,18 +247,20 @@ def test_cache_profiler_plot():
 @pytest.mark.skipif("not psutil")
 def test_plot_multiple():
     from dask.diagnostics.profile_visualize import visualize
-    from bokeh.models import GridPlot
     with ResourceProfiler(dt=0.01) as rprof:
         with prof:
             get(dsk2, 'c')
     p = visualize([prof, rprof], label_size=50,
                   title="Not the default", show=False, save=False)
-    assert isinstance(p, GridPlot)
-    assert len(p.children) == 2
-    assert p.children[0][0].title == "Not the default"
-    assert p.children[0][0].xaxis[0].axis_label is None
-    assert p.children[1][0].title is None
-    assert p.children[1][0].xaxis[0].axis_label == 'Time (s)'
+    if LooseVersion(bokeh.__version__) >= '0.12.0':
+        figures = [r.children[0] for r in p.children[1].children]
+    else:
+        figures = [r[0] for r in p.children]
+    assert len(figures) == 2
+    assert check_title(figures[0], "Not the default")
+    assert figures[0].xaxis[0].axis_label is None
+    assert figures[1].title is None
+    assert figures[1].xaxis[0].axis_label == 'Time (s)'
     # Test empty, checking for errors
     prof.clear()
     rprof.clear()


### PR DESCRIPTION
- plot.title is no longer a string
- some layout attributes are now `None` by default

Mostly just adjustments to tests to work generally for new and previous versions. Tested locally on bokeh 0.11.1 and 0.12.0.