### PR TITLE
remove xfail mark for blosc missing const

### DIFF
--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+from distutils.version import LooseVersion
 
 from toolz import (merge, join, pipe, filter, identity, merge_with, take,
         partial, valmap, groupby, pluck)
@@ -450,11 +451,13 @@ def test_can_use_dict_to_make_concrete():
     assert isinstance(dict(b.frequencies()), dict)
 
 
-@pytest.mark.xfail(reason="bloscpack BLOSC_MAX_BUFFERSIZE")
 def test_from_castra():
     castra = pytest.importorskip('castra')
     pd = pytest.importorskip('pandas')
     dd = pytest.importorskip('dask.dataframe')
+    blosc = pytest.importorskip('blosc')
+    if LooseVersion(blosc.__version__) == '1.3.0':
+        pytest.skip()
     df = pd.DataFrame({'x': list(range(100)),
                        'y': [str(i) for i in range(100)]})
     a = dd.from_pandas(df, 10)

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -631,10 +631,9 @@ def to_castra(df, fn=None, categories=None, sorted_index_column=None,
     dsk = merge(dsk, df.dask)
     keys = [(name, -1), (name, df.npartitions - 1)]
     if compute:
-        c, _ = DataFrame._get(dsk, keys, get=get)
-        return c
+        return DataFrame._get(dsk, keys, get=get)[0]
     else:
-        return delayed([Delayed(key, [dsk]) for key in keys])
+        return delayed([Delayed(key, [dsk]) for key in keys])[0]
 
 
 def to_csv(df, filename, name_function=None, compression=None, get=None, compute=True, **kwargs):

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -6,6 +6,7 @@ import sys
 import os
 import dask
 import pytest
+from distutils.version import LooseVersion
 from threading import Lock
 import shutil
 from time import sleep
@@ -14,6 +15,7 @@ import threading
 import dask.array as da
 import dask.dataframe as dd
 from dask.dataframe.io import (from_array, from_bcolz, from_dask_array)
+from dask.delayed import Delayed
 
 from dask.utils import filetext, filetexts, tmpfile, tmpdir
 from dask.async import get_sync
@@ -602,9 +604,11 @@ def test_from_dask_array_struct_dtype():
               pd.DataFrame(x, columns=['b', 'a']))
 
 
-@pytest.mark.xfail(reason="bloscpack BLOSC_MAX_BUFFERSIZE")
 def test_to_castra():
     pytest.importorskip('castra')
+    blosc = pytest.importorskip('blosc')
+    if LooseVersion(blosc.__version__) == '1.3.0':
+        pytest.skip()
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
                        'y': [2, 3, 4, 5]},
                       index=pd.Index([1., 2., 3., 4.], name='ind'))
@@ -630,16 +634,28 @@ def test_to_castra():
     finally:
         c.drop()
 
-    dsk, keys = a.to_castra(compute=False)
-    assert isinstance(dsk, dict)
-    assert isinstance(keys, list)
-    c, last = keys
-    assert last[1] == a.npartitions - 1
+    delayed = a.to_castra(compute=False)
+    assert isinstance(delayed, Delayed)
+    c = delayed.compute()
+    try:
+        tm.assert_frame_equal(c[:], df)
+    finally:
+        c.drop()
 
+    # make sure compute=False preserves the same interface
+    c1 = a.to_castra(compute=True)
+    c2 = a.to_castra(compute=False).compute()
+    try:
+        tm.assert_frame_equal(c1[:], c2[:])
+    finally:
+        c1.drop()
+        c2.drop()
 
-@pytest.mark.xfail(reason="bloscpack BLOSC_MAX_BUFFERSIZE")
 def test_from_castra():
     pytest.importorskip('castra')
+    blosc = pytest.importorskip('blosc')
+    if LooseVersion(blosc.__version__) == '1.3.0':
+        pytest.skip()
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
                        'y': [2, 3, 4, 5]},
                       index=pd.Index([1., 2., 3., 4.], name='ind'))
@@ -659,13 +675,15 @@ def test_from_castra():
         del with_fn, c
 
 
-@pytest.mark.xfail(reason="bloscpack BLOSC_MAX_BUFFERSIZE")
 def test_from_castra_with_selection():
     """ Optimizations fuse getitems with load_partitions
 
     We used to use getitem for both column access and selections
     """
     pytest.importorskip('castra')
+    blosc = pytest.importorskip('blosc')
+    if LooseVersion(blosc.__version__) == '1.3.0':
+        pytest.skip()
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
                        'y': [2, 3, 4, 5]},
                       index=pd.Index([1., 2., 3., 4.], name='ind'))
@@ -896,7 +914,7 @@ def test_to_csv_multiple_files_cornercases():
             a.to_csv(fn, mode='a')
 
 
-@pytest.mark.xfail(reason="bloscpack BLOSC_MAX_BUFFERSIZE")
+@pytest.mark.xfail(reason="to_csv does not support compression")
 def test_to_csv_gzip():
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
                        'y': [1, 2, 3, 4]}, index=[1., 2., 3., 4.])

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -1,4 +1,5 @@
 import pytest
+from distutils.version import LooseVersion
 from operator import getitem
 from toolz import merge
 from dask.dataframe.optimize import dataframe_from_ctable
@@ -35,9 +36,11 @@ def test_column_optimizations_with_bcolz_and_rewrite():
         assert result == expected
 
 
-@pytest.mark.xfail(reason="bloscpack BLOSC_MAX_BUFFERSIZE")
 def test_castra_column_store():
     castra = pytest.importorskip('castra')
+    blosc = pytest.importorskip('blosc')
+    if LooseVersion(blosc.__version__) == '1.3.0':
+        pytest.skip()
 
     df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
 


### PR DESCRIPTION
Some constants were removed in python-blosc v1.3.0 and brought back in
python-blosc v1.3.1, released 7 days later.  the short v1.3.0 timeframe suggest
these tests actually fail for a small portion of dask users.  The xfail marks
were added before v1.3.1 was released (a389a02)

In this commit I suggest removing the mark xfail and replacing it with
`pytest.skip` for python-blosc v1.3.0

dataframe/tests/test_io.py:test_to_castra was additionally failing because it
wasn't adjusted by commit 3b2e397, I also fix that.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>