### PR TITLE
`inline` no longer removes keys

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -92,7 +92,10 @@ def inline_singleton_lists(dsk, dependencies=None):
 
     keys = [k for k, v in dsk.items()
             if istask(v) and v and v[0] is list and len(dependents[k]) == 1]
-    return inline(dsk, keys, inline_constants=False)
+    dsk = inline(dsk, keys, inline_constants=False)
+    for k in keys:
+        del dsk[k]
+    return dsk
 
 
 def optimize(dsk, keys, **kwargs):


### PR DESCRIPTION
Previously `inline` would remove all inlined keys. This was causing problems in the distributed scheduler (see https://github.com/dask/distributed/issues/363), as it would accidently remove keys that were still needed by the output. One solution would be to add an `output` keyword, but this would bind a the distributed scheduler to the latest version of dask. A different (but equally good option) is to not remove keys in `inline`, instead opting for other operations for culling unneeded keys. This keeps the signature the same, requiring no changes in the `distributed` repo.

This change required changes in a few other places:
- Things that inline functions now handle key removal locally. This is
  fine and cheap to do, just a simple `del` operation.
- The behavior of `dealias` is changed to collapse aliasing chains, but
  not rewrite with `(identity, key)`. This makes the implementation
  simpler, matches the new definition of a dask graph (which allows
  aliases), and also seems more correct with the desired behavior. Note
  that since `dealias` isn't used anywhere anymore, it's unclear if this
  change is needed, or if the code should just be deleted.