### PR TITLE
`subs` doesn't needlessly compare keys and values

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -306,7 +306,7 @@ def subs(task, key, val):
     """
     if not istask(task):
         try:
-            if task == key:
+            if type(task) is type(key) and task == key:
                 return val
         except Exception:
             pass

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -111,6 +111,25 @@ def test_subs():
     assert subs((sum, [1, ['x']]), 'x', 2) == (sum, [1, [2]])
 
 
+class MutateOnEq(object):
+    hit_eq = 0
+    def __eq__(self, other):
+        self.hit_eq += 1
+        return False
+
+
+def test_subs_no_key_data_eq():
+    # Numpy throws a deprecation warning on bool(array == scalar), which
+    # pollutes the terminal. This test checks that `subs` never tries to
+    # compare keys (scalars) with values (which could be arrays)`subs` never
+    # tries to compare keys (scalars) with values (which could be arrays).
+    a = MutateOnEq()
+    subs(a, 'x', 1)
+    assert a.hit_eq == 0
+    subs((add, a, 'x'), 'x', 1)
+    assert a.hit_eq == 0
+
+
 def test_subs_with_unfriendly_eq():
     try:
         import numpy as np


### PR DESCRIPTION
Numpy throws a deprecation warning on `bool(array == scalar)`, which would come up in `subs` periodically, polluting the terminal. This fix ensures comparison only happens if the key and task are the same type, removing these warnings.