### PR TITLE
Add doc examples for dask.array.histogram. 

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2668,15 +2668,36 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
     Follows the signature of numpy.histogram exactly with the following
     exceptions:
 
-    - either the ``bins`` or ``range`` argument is required as computing
-      ``min`` and ``max`` over blocked arrays is an expensive operation
-      that must be performed explicitly.
+    - Either an iterable specifying the ``bins`` or the number of ``bins``
+      and a ``range`` argument is required as computing ``min`` and ``max``
+      over blocked arrays is an expensive operation that must be performed
+      explicitly.
 
     - ``weights`` must be a dask.array.Array with the same block structure
-       as ``a``.
+      as ``a``.
 
-    Original signature follows below.
-    """ + np.histogram.__doc__
+    Examples
+    --------
+    Using number of bins and range:
+
+    >>> import dask.array as da
+    >>> import numpy as np
+    >>> x = da.from_array(np.arange(10000), chunks=10)
+    >>> h, bins = da.histogram(x, bins=10, range=[0, 10000])
+    >>> bins
+    array([     0.,   1000.,   2000.,   3000.,   4000.,   5000.,   6000.,
+             7000.,   8000.,   9000.,  10000.])
+    >>> h.compute()
+    array([1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000])
+
+    Explicitly specifying the bins:
+
+    >>> h, bins = da.histogram(x, bins=np.array([0, 5000, 10000]))
+    >>> bins
+    array([    0,  5000, 10000])
+    >>> h.compute()
+    array([5000, 5000])
+    """
     if bins is None or (range is None and bins is None):
         raise ValueError('dask.array.histogram requires either bins '
                          'or bins and range to be defined.')


### PR DESCRIPTION
Resolves #1349.

It was clarified that either a range and a numeric number of bins or a specific array of bins are needed, as shown in the examples.

The `+ np.histogram.__doc__` at the end of the `dask.array.histogram` docstring was causing sphinx to not generate the docs appropriately for that function. Even though this can be solved using `histogram.__doc__ += np.histogram.__doc__`, dropping it was preferred since the numpy docstring was quite long. `np.histogram` docs are probably just browser search away anyways.