### PR TITLE
Fix typo in pip install requirements path

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -217,7 +217,7 @@ and API documentation.
 To build the documentation locally, first install requirements::
 
    cd docs/
-   pip install -r requirements_docs.txt
+   pip install -r requirements-docs.txt
 
 Then build documentation with ``make``::
 


### PR DESCRIPTION
file name in repo is `requirements-docs.txt`, name in documentation was `requirements_docs.txt`

Signed-off-by: Nir Izraeli <nirizr@gmail.com>