### PR TITLE
avoid c: in infer_storage_options

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -202,6 +202,8 @@ def to_textfiles(b, path, name_function=None, compression='infer',
 
 
 def finalize(results):
+    if not results:
+        return results
     if isinstance(results, Iterator):
         results = list(results)
     if isinstance(results[0], Iterable) and not isinstance(results[0], str):

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -983,3 +983,7 @@ def test_reduction_empty():
     b = db.from_sequence(range(10), npartitions=100)
     assert b.filter(lambda x: x % 2 == 0).max().compute(get=dask.get) == 8
     assert b.filter(lambda x: x % 2 == 0).min().compute(get=dask.get) == 0
+
+
+def test_empty():
+    list(db.from_sequence([])) == []

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -150,3 +150,8 @@ def test_infer_storage_options():
         infer_storage_options('file:///bucket/file.csv', {'path': 'collide'})
     with pytest.raises(KeyError):
         infer_storage_options('hdfs:///bucket/file.csv', {'protocol': 'collide'})
+
+
+def test_infer_storage_options_c():
+    so = infer_storage_options(r'c:\foo\bar')
+    assert so['protocol'] == 'file'

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -690,6 +690,10 @@ def infer_storage_options(urlpath, inherit_storage_options=None):
     "host": "node", "port": 123, "path": "/mnt/datasets/test.csv",
     "url_query": "q=1", "extra": "value"}
     """
+    if ':\\' in urlpath:
+        return {'protocol': 'file',
+                'path': urlpath}
+
     parsed_path = urlsplit(urlpath)
 
     inferred_storage_options = {


### PR DESCRIPTION
This was failing in windows because `C:` was being treated as a protocol.