### PR TITLE
Fix 'visualize' import location in diagnostics documentation

### DIFF
--- a/docs/source/diagnostics.rst
+++ b/docs/source/diagnostics.rst
@@ -212,7 +212,7 @@ stack of plots aligned along the x-axis:
 
 .. code-block:: python
 
-    >>> from dask.diagnostics import visualize
+    >>> from dask import visualize
     >>> visualize([prof, rprof, cprof])
 
 


### PR DESCRIPTION
In issue #1372 a user complains he cannot import 'visualize' from 'dask.diagnostics'. This is because 'visualize' is exposed from 'dask' and the docs are misleading.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>