### PR TITLE
Add dask.array.digitize.

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -12,4 +12,4 @@ try:
 except ImportError:
     pass
 
-__version__ = '0.10.0'
+__version__ = '0.10.1'

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -4,7 +4,7 @@ from ..utils import ignoring
 from .core import (Array, stack, concatenate, take, tensordot, transpose,
         from_array, from_imperative, choose, where, coarsen, insert,
         broadcast_to, ravel, reshape, fromfunction, unique, store, squeeze,
-        topk, bincount, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
+        topk, bincount, digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
         from_delayed)
 from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2663,8 +2663,8 @@ def bincount(x, weights=None, minlength=None):
 @wraps(np.digitize)
 def digitize(a, bins, right=False):
     bins = np.asarray(bins)
-    func = partial(np.digitize, bins=bins, right=right)
-    return elemwise(func, a)
+    dtype = np.digitize([0], bins, right=False).dtype
+    return a.map_blocks(np.digitize, dtype=dtype, bins=bins, right=right)
 
 def histogram(a, bins=None, range=None, normed=False, weights=None, density=None):
     """

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2660,6 +2660,10 @@ def bincount(x, weights=None, minlength=None):
 
     return Array(dsk, name, chunks, dtype)
 
+@wraps(np.digitize)
+def digitize(a, bins, right=False):
+    func = partial(np.digitize, bins=bins, right=right)
+    return elemwise(func, a)
 
 def histogram(a, bins=None, range=None, normed=False, weights=None, density=None):
     """

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2662,6 +2662,7 @@ def bincount(x, weights=None, minlength=None):
 
 @wraps(np.digitize)
 def digitize(a, bins, right=False):
+    bins = np.asarray(bins)
     func = partial(np.digitize, bins=bins, right=right)
     return elemwise(func, a)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1373,6 +1373,15 @@ def test_bincount_raises_informative_error_on_missing_minlength_kwarg():
     else:
         assert False
 
+def test_digitize():
+    x = np.array([2, 4, 5, 6, 1])
+    d = da.from_array(x, chunks=2)
+    bins = np.array([1, 2, 3, 4, 5])
+    e = da.digitize(d, bins, right=False)
+    assert_eq(e, np.digitize(x, bins, right=False))
+
+    e = da.digitize(d, bins, right=True)
+    assert_eq(e, np.digitize(x, bins, right=True))
 
 def test_histogram():
     # Test for normal, flattened input

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -40,6 +40,7 @@ Top level user functions:
    deg2rad
    degrees
    diag
+   digitize
    dot
    dstack
    empty
@@ -275,6 +276,7 @@ Other functions
 .. autofunction:: deg2rad
 .. autofunction:: degrees
 .. autofunction:: diag
+.. autofunction:: digitize
 .. autofunction:: dot
 .. autofunction:: dstack
 .. autofunction:: empty


### PR DESCRIPTION
Note that bins is assumed to be a regular array. This seems to be already
implied in dask.array.histogram.

How safe is this assumption?