### PR TITLE
Use task-based shuffle in hash_joins

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1840,7 +1840,7 @@ class DataFrame(_Frame):
 
     @derived_from(pd.DataFrame)
     def join(self, other, on=None, how='left',
-             lsuffix='', rsuffix='', npartitions=None):
+             lsuffix='', rsuffix='', npartitions=None, method=None):
 
         if not isinstance(other, (DataFrame, pd.DataFrame)):
             raise ValueError('other must be DataFrame')
@@ -1849,7 +1849,7 @@ class DataFrame(_Frame):
         return merge(self, other, how=how,
                      left_index=on is None, right_index=True,
                      left_on=on, suffixes=[lsuffix, rsuffix],
-                     npartitions=npartitions)
+                     npartitions=npartitions, method=method)
 
     @derived_from(pd.DataFrame)
     def append(self, other):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1827,7 +1827,7 @@ class DataFrame(_Frame):
     @derived_from(pd.DataFrame)
     def merge(self, right, how='inner', on=None, left_on=None, right_on=None,
               left_index=False, right_index=False,
-              suffixes=('_x', '_y'), npartitions=None):
+              suffixes=('_x', '_y'), npartitions=None, method=None):
 
         if not isinstance(right, (DataFrame, pd.DataFrame)):
             raise ValueError('right must be DataFrame')
@@ -1836,7 +1836,7 @@ class DataFrame(_Frame):
         return merge(self, right, how=how, on=on,
                      left_on=left_on, right_on=right_on,
                      left_index=left_index, right_index=right_index,
-                     suffixes=suffixes, npartitions=npartitions)
+                     suffixes=suffixes, npartitions=npartitions, method=method)
 
     @derived_from(pd.DataFrame)
     def join(self, other, on=None, how='left',

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2319,7 +2319,9 @@ def map_partitions(func, metadata, *args, **kwargs):
         values = [(arg._name, i if isinstance(arg, _Frame) else 0)
                   if isinstance(arg, (_Frame, Scalar)) else arg for arg in args]
         values = (apply, func, (tuple, values), kwargs)
-        dsk[(name, i)] = (_rename, columns, values)
+        if columns is not None:
+            values = (_rename, columns, values)
+        dsk[(name, i)] = values
 
     dasks = [arg.dask for arg in args if isinstance(arg, (_Frame, Scalar))]
     return return_type(merge(dsk, *dasks), name, metadata, args[0].divisions)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -335,8 +335,9 @@ class _GroupBy(object):
             dummy = columns
             columns = self._slice
 
-        if isinstance(self.index, Series):
-            if self.index._name == self.obj.index._name:
+        if not isinstance(self.index, (DataFrame, list, pd.Index)):
+            if (isinstance(self.index, Series) and
+                self.index._name == self.obj.index._name):
                 df = self.obj
             else:
                 df = self.obj.set_index(self.index, drop=False,
@@ -346,7 +347,10 @@ class _GroupBy(object):
                                   df, columns, func)
 
         else:
-            from .shuffle import shuffle
+            from .shuffle import shuffle_method, shuffle
+            if shuffle_method() == 'tasks':
+                raise NotImplementedError(
+                "Can only groupby-apply on single-column grouper")
             df = shuffle(self.obj, self.index, **self.kwargs)
             return map_partitions(_groupby_apply_index, dummy,
                                   df, self.index, columns, func)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -5,9 +5,9 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from dask.dataframe.core import (DataFrame, Series, Index,
-                                 aca, map_partitions, no_default)
-from dask.utils import derived_from
+from ..context import _globals
+from .core import (DataFrame, Series, Index, aca, map_partitions, no_default)
+from ..utils import derived_from
 
 
 def _maybe_slice(grouped, columns):
@@ -347,8 +347,8 @@ class _GroupBy(object):
                                   df, columns, func)
 
         else:
-            from .shuffle import shuffle_method, shuffle
-            if shuffle_method() == 'tasks':
+            from .shuffle import shuffle
+            if _globals.get('shuffle', None) == 'tasks':
                 raise NotImplementedError(
                 "Can only groupby-apply on single-column grouper")
             df = shuffle(self.obj, self.index, **self.kwargs)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -335,7 +335,7 @@ class _GroupBy(object):
             dummy = columns
             columns = self._slice
 
-        if not isinstance(self.index, (DataFrame, list, pd.Index)):
+        if isinstance(self.index, (DataFrame, list, pd.Index)):
             if (isinstance(self.index, Series) and
                 self.index._name == self.obj.index._name):
                 df = self.obj

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -67,7 +67,7 @@ from ..compatibility import apply
 from .core import (_Frame, Scalar, DataFrame, map_partitions,
                    Index, _maybe_from_pandas)
 from .io import from_pandas
-from .shuffle import shuffle
+from .shuffle import shuffle, rearrange_by_divisions
 
 
 def bound(seq, left, right):
@@ -379,7 +379,7 @@ def concat_indexed_dataframes(dfs, axis=0, join='outer'):
 
 def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
           left_index=False, right_index=False, suffixes=('_x', '_y'),
-          npartitions=None, method=None):
+          npartitions=None, method=None, max_branch=None):
 
     if not on and not left_on and not right_on and not left_index and not right_index:
         on = [c for c in left.columns if c in right.columns]
@@ -413,16 +413,40 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
 
     # Both sides are now dd.DataFrame or dd.Series objects
 
+    # Both sides indexed
     if (left_index and left.known_divisions and
         right_index and right.known_divisions):  # Do indexed join
         return join_indexed_dataframes(left, right, how=how,
                                        lsuffix=suffixes[0], rsuffix=suffixes[1])
 
+    # Single partition on one side
     elif (left.npartitions == 1 and how in ('inner', 'right') or
           right.npartitions == 1 and how in ('inner', 'left')):
         return single_partition_join(left, right, how=how, right_on=right_on,
                 left_on=left_on, left_index=left_index,
                 right_index=right_index, suffixes=suffixes)
+
+    # One side is indexed, the other not
+    elif (method == 'tasks' and
+        (left_index and left.known_divisions and not right_index or
+        right_index and right.known_divisions and not left_index)):
+        left_empty = left._pd_nonempty
+        right_empty = right._pd_nonempty
+        dummy = pd.merge(left_empty, right_empty, how=how, on=on, left_on=left_on,
+                right_on=right_on, left_index=left_index, right_index=right_index,
+                suffixes=suffixes)
+        if left_index and left.known_divisions:
+            right = rearrange_by_divisions(right, right_on, left.divisions,
+                    max_branch)
+            left.divisions = (None,) * (left.npartitions + 1)
+        elif right_index and right.known_divisions:
+            left = rearrange_by_divisions(left, left_on, right.divisions,
+                    max_branch)
+            right.divisions = (None,) * (right.npartitions + 1)
+        return map_partitions(pd.merge, dummy, left, right, how=how, on=on,
+                left_on=left_on, right_on=right_on, left_index=left_index,
+                right_index=right_index, suffixes=suffixes)
+    # Catch all hash join
     else:
         return hash_join(left, left.index if left_index else left_on,
                          right, right.index if right_index else right_on,

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -243,7 +243,7 @@ def _pdmerge(left, right, how, left_on, right_on,
 
 
 def hash_join(lhs, left_on, rhs, right_on, how='inner',
-              npartitions=None, suffixes=('_x', '_y')):
+              npartitions=None, suffixes=('_x', '_y'), method=None):
     """ Join two DataFrames on particular columns with hash join
 
     This shuffles both datasets on the joined column and then performs an
@@ -254,8 +254,8 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
     if npartitions is None:
         npartitions = max(lhs.npartitions, rhs.npartitions)
 
-    lhs2 = shuffle(lhs, left_on, npartitions=npartitions)
-    rhs2 = shuffle(rhs, right_on, npartitions=npartitions)
+    lhs2 = shuffle(lhs, left_on, npartitions=npartitions, method=method)
+    rhs2 = shuffle(rhs, right_on, npartitions=npartitions, method=method)
 
     if isinstance(left_on, Index):
         left_on = None
@@ -379,7 +379,7 @@ def concat_indexed_dataframes(dfs, axis=0, join='outer'):
 
 def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
           left_index=False, right_index=False, suffixes=('_x', '_y'),
-          npartitions=None):
+          npartitions=None, method=None):
 
     if not on and not left_on and not right_on and not left_index and not right_index:
         on = [c for c in left.columns if c in right.columns]
@@ -425,7 +425,7 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
     else:
         return hash_join(left, left.index if left_index else left_on,
                          right, right.index if right_index else right_on,
-                         how, npartitions, suffixes)
+                         how, npartitions, suffixes, method=method)
 
 
 ###############################################################

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -284,8 +284,8 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
     if isinstance(right_on, list):
         right_on = (list, tuple(right_on))
 
-    token = tokenize(lhs, left_on, rhs, right_on, left_index, right_index,
-                     how, npartitions, suffixes)
+    token = tokenize(lhs2, left_on, rhs2, right_on, left_index, right_index,
+                     how, npartitions, suffixes, method)
     name = 'hash-join-' + token
 
     dsk = dict(((name, i), (merger, (lhs2._name, i), (rhs2._name, i),

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -413,7 +413,8 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
 
     # Both sides are now dd.DataFrame or dd.Series objects
 
-    if left_index and right_index:  # Do indexed join
+    if (left_index and left.known_divisions and
+        right_index and right.known_divisions):  # Do indexed join
         return join_indexed_dataframes(left, right, how=how,
                                        lsuffix=suffixes[0], rsuffix=suffixes[1])
 

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -254,8 +254,8 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
     if npartitions is None:
         npartitions = max(lhs.npartitions, rhs.npartitions)
 
-    lhs2 = shuffle(lhs, left_on, npartitions)
-    rhs2 = shuffle(rhs, right_on, npartitions)
+    lhs2 = shuffle(lhs, left_on, npartitions=npartitions)
+    rhs2 = shuffle(rhs, right_on, npartitions=npartitions)
 
     if isinstance(left_on, Index):
         left_on = None

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -30,6 +30,8 @@ def set_index(df, index, npartitions=None, method=None, compute=True,
     This shuffles and repartitions your data. If done in parallel the
     resulting order is non-deterministic.
     """
+    if (isinstance(index, Series) and index._name == df.index._name):
+        return df
     if isinstance(index, (DataFrame, tuple, list)):
         raise NotImplementedError(
             "Dask dataframe does not yet support multi-indexes.\n"

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -90,13 +90,7 @@ def set_partition(df, index, divisions, method=None, compute=False, drop=True,
     shuffle
     partd
     """
-    if method is None:
-        get = _globals.get('get')
-        if (isinstance(get, types.MethodType) and
-            'distributed' in get.__func__.__module__):
-            method = 'tasks'
-        else:
-            method = 'disk'
+    method = method or shuffle_method()
 
     if method == 'disk':
         return set_partition_disk(df, index, divisions, compute=compute,
@@ -106,6 +100,15 @@ def set_partition(df, index, divisions, method=None, compute=False, drop=True,
                 max_branch=max_branch, drop=drop)
     else:
         raise NotImplementedError("Unknown method %s" % method)
+
+
+def shuffle_method():
+    get = _globals.get('get')
+    if (isinstance(get, types.MethodType) and
+        'distributed' in get.__func__.__module__):
+        return 'tasks'
+    else:
+        return 'disk'
 
 
 def barrier(args):

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -90,7 +90,7 @@ def set_partition(df, index, divisions, method=None, compute=False, drop=True,
     shuffle
     partd
     """
-    method = method or shuffle_method()
+    method = method or _globals.get('shuffle', 'disk')
 
     if method == 'disk':
         return set_partition_disk(df, index, divisions, compute=compute,
@@ -102,18 +102,10 @@ def set_partition(df, index, divisions, method=None, compute=False, drop=True,
         raise NotImplementedError("Unknown method %s" % method)
 
 
-def shuffle_method():
-    get = _globals.get('get')
-    if (isinstance(get, types.MethodType) and
-        'distributed' in get.__func__.__module__):
-        return 'tasks'
-    else:
-        return 'disk'
-
-
 def barrier(args):
     list(args)
     return 0
+
 
 def _set_partition(df, index, divisions, p, drop=True):
     """ Shard partition and dump into partd """

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -622,3 +622,19 @@ def test_merge_index_without_divisions(method):
 
     eq(aa.join(bb, how='inner', method=method),
        a.join(b, how='inner'))
+
+
+def test_half_indexed_dataframe_avoids_shuffle():
+    a = pd.DataFrame({'x': np.random.randint(100, size=1000)})
+    b = pd.DataFrame({'y': np.random.randint(100, size=100)},
+                     index=np.random.randint(100, size=100))
+
+    aa = dd.from_pandas(a, npartitions=100)
+    bb = dd.from_pandas(b, npartitions=2)
+
+    c = pd.merge(a, b, left_index=True, right_on='y')
+    cc = dd.merge(aa, bb, left_index=True, right_on='y', method='tasks')
+
+    list_eq(c, cc)
+
+    assert len(cc.dask) < 500

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -599,3 +599,15 @@ def test_merge_maintains_columns(lhs, rhs):
     ddf = dd.from_pandas(lhs, npartitions=1)
     merged = dd.merge(ddf, rhs, on='B').compute()
     assert tuple(merged.columns) == ('D', 'C', 'B', 'A', 'G', 'H', 'I')
+
+
+@pytest.mark.parametrize('method', ['disk', 'tasks'])
+def test_merge_index_without_divisions(method):
+    a = pd.DataFrame({'x': [1, 2, 3, 4, 5]}, index=[1, 2, 3, 4, 5])
+    b = pd.DataFrame({'y': [1, 2, 3, 4, 5]}, index=[5, 4, 3, 2, 1])
+
+    aa = dd.from_pandas(a, npartitions=3, sort=False)
+    bb = dd.from_pandas(b, npartitions=2)
+
+    eq(aa.join(bb, how='inner', method=method),
+       a.join(b, how='inner'))

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -267,8 +267,23 @@ def test_merge(how):
 
 
 
+def test_merge_tasks_passes_through():
+    a = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
+                      'b': [7, 6, 5, 4, 3, 2, 1]})
+    b = pd.DataFrame({'c': [1, 2, 3, 4, 5, 6, 7],
+                      'd': [7, 6, 5, 4, 3, 2, 1]})
+
+    aa = dd.from_pandas(a, npartitions=3)
+    bb = dd.from_pandas(b, npartitions=2)
+
+    cc = aa.merge(bb, left_on='a', right_on='d', method='tasks')
+
+    assert not any('partd' in k[0] for k in cc.dask)
+
+
+@pytest.mark.parametrize('method', ['disk', 'tasks'])
 @pytest.mark.parametrize('how', ['inner', 'outer', 'left', 'right'])
-def test_merge_by_index_patterns(how):
+def test_merge_by_index_patterns(how, method):
 
     pdf1l = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
                           'b': [7, 6, 5, 4, 3, 2, 1]})
@@ -325,35 +340,47 @@ def test_merge_by_index_patterns(how):
             ddl = dd.from_pandas(pdl, lpart)
             ddr = dd.from_pandas(pdr, rpart)
 
-            eq(dd.merge(ddl, ddr, how=how, left_index=True, right_index=True),
+            eq(dd.merge(ddl, ddr, how=how, left_index=True, right_index=True,
+                        method=method),
                pd.merge(pdl, pdr, how=how, left_index=True, right_index=True))
-            eq(dd.merge(ddr, ddl, how=how, left_index=True, right_index=True),
+            eq(dd.merge(ddr, ddl, how=how, left_index=True, right_index=True,
+                        method=method),
                pd.merge(pdr, pdl, how=how, left_index=True, right_index=True))
 
-            eq(ddr.merge(ddl, how=how, left_index=True, right_index=True),
+            eq(ddr.merge(ddl, how=how, left_index=True, right_index=True,
+                         method=method),
                pdr.merge(pdl, how=how, left_index=True, right_index=True))
-            eq(ddl.merge(ddr, how=how, left_index=True, right_index=True),
+            eq(ddl.merge(ddr, how=how, left_index=True, right_index=True,
+                         method=method),
                pdl.merge(pdr, how=how, left_index=True, right_index=True))
 
             # hash join
-            list_eq(dd.merge(ddl, ddr, how=how, left_on='a', right_on='c'),
+            list_eq(dd.merge(ddl, ddr, how=how, left_on='a', right_on='c',
+                             method=method),
                     pd.merge(pdl, pdr, how=how, left_on='a', right_on='c'))
-            list_eq(dd.merge(ddl, ddr, how=how, left_on='b', right_on='d'),
+            list_eq(dd.merge(ddl, ddr, how=how, left_on='b', right_on='d',
+                             method=method),
                     pd.merge(pdl, pdr, how=how, left_on='b', right_on='d'))
 
-            list_eq(dd.merge(ddr, ddl, how=how, left_on='c', right_on='a'),
+            list_eq(dd.merge(ddr, ddl, how=how, left_on='c', right_on='a',
+                             method=method),
                     pd.merge(pdr, pdl, how=how, left_on='c', right_on='a'))
-            list_eq(dd.merge(ddr, ddl, how=how, left_on='d', right_on='b'),
+            list_eq(dd.merge(ddr, ddl, how=how, left_on='d', right_on='b',
+                             method=method),
                     pd.merge(pdr, pdl, how=how, left_on='d', right_on='b'))
 
-            list_eq(ddl.merge(ddr, how=how, left_on='a', right_on='c'),
+            list_eq(ddl.merge(ddr, how=how, left_on='a', right_on='c',
+                              method=method),
                     pdl.merge(pdr, how=how, left_on='a', right_on='c'))
-            list_eq(ddl.merge(ddr, how=how, left_on='b', right_on='d'),
+            list_eq(ddl.merge(ddr, how=how, left_on='b', right_on='d',
+                              method=method),
                     pdl.merge(pdr, how=how, left_on='b', right_on='d'))
 
-            list_eq(ddr.merge(ddl, how=how, left_on='c', right_on='a'),
+            list_eq(ddr.merge(ddl, how=how, left_on='c', right_on='a',
+                              method=method),
                     pdr.merge(pdl, how=how, left_on='c', right_on='a'))
-            list_eq(ddr.merge(ddl, how=how, left_on='d', right_on='b'),
+            list_eq(ddr.merge(ddl, how=how, left_on='d', right_on='b',
+                              method=method),
                     pdr.merge(pdl, how=how, left_on='d', right_on='b'))
 
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -164,27 +164,6 @@ def test_set_partition_tasks_3():
     assert ddf2.npartitions == ddf.npartitions
 
 
-def test_shuffle_pre_partition():
-    from dask.dataframe.shuffle import (shuffle_pre_partition_scalar,
-                                        shuffle_pre_partition_series)
-    df = pd.DataFrame({'x': np.random.random(10),
-                       'y': np.random.random(10)},
-                       index=np.random.random(10))
-    divisions = df.x.quantile([0, 0.2, 0.4, 0.6, 0.8, 1.0]).tolist()
-
-    for ind, pre in [('x', shuffle_pre_partition_scalar),
-                     (df.x, shuffle_pre_partition_series)]:
-        result = pre(df, ind, divisions, True)
-        assert list(result.columns)[:2] == ['x', 'y']
-        assert result.index.name == 'partitions'
-        for x, part in result.reset_index()[['x', 'partitions']].values.tolist():
-            part = int(part)
-            if x == divisions[-1]:
-                assert part == len(divisions) - 2
-            else:
-                assert divisions[part] <= x < divisions[part + 1]
-
-
 @pytest.mark.parametrize('method', ['tasks', 'disk'])
 def test_shuffle_sort(method):
     df = pd.DataFrame({'x': [1, 2, 3, 2, 1], 'y': [9, 8, 7, 1, 5]})

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -91,8 +91,7 @@ def test_partitioning_index():
     np.testing.assert_equal(res, exp)
 
     res = partitioning_index(df2[['cat', 'bool', 'f32']], 2)
-    exp = np.array([1, 1, 0] * 3)
-    np.testing.assert_equal(res, exp)
+    assert ((0 <= res) & (res < 2)).all()
 
     res = partitioning_index(df2.index, 4)
     exp = np.array([0, 1, 2, 3, 0, 1, 2, 3, 0])
@@ -124,8 +123,21 @@ def test_set_partition_tasks(npartitions):
     eq(df.set_index(df.x + 1),
        ddf.set_index(ddf.x + 1, method='tasks'))
 
-    # eq(df.set_index(df.index),
-    #    ddf.set_index(ddf.index, method='tasks'))
+    eq(df.set_index(df.index),
+       ddf.set_index(ddf.index, method='tasks'))
+
+
+def test_set_index_self_index():
+    df = pd.DataFrame({'x': np.random.random(100),
+                       'y': np.random.random(100) // 0.2},
+                       index=np.random.random(100))
+
+    a = dd.from_pandas(df, npartitions=4)
+    b = a.set_index(a.index)
+    assert a is b
+
+    eq(b, df.set_index(df.index))
+
 
 def test_set_partition_tasks_names():
     df = pd.DataFrame({'x': np.random.random(100),

--- a/dask/distributed.py
+++ b/dask/distributed.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import, division, print_function
 
-from distributed import Executor, progress, s3, hdfs
+from distributed import Executor, progress, s3, hdfs, as_completed, wait


### PR DESCRIPTION
This refactors distributed dataframe shuffles so that they can be used more broadly, specifically in hash_joins and groupby-apply.

First, we implement a robust hash-shuffle for dataframes.  Previously we only performed a shuffle after pre-computing new divisions using approximate quantiles.  Now we support shuffling data by the hash of a column-or-set-of-columns.  This opens up new applications, notably in groupby-apply and joins.

Second, in groupby-apply we *always* hash-shuffle, rather than sometimes set-index.  This matches Pandas behavior a bit better and is now robustly available, even on distributed systmes.

Third, in merge, we support hash-joins using dataframe-shuffle.  We expand the dataframe shuffle to accept increasing the number of partitions, which comes up a lot in the multi-dataframe-join case.  We add and propagate `method=` keyword arguments through to merge/join methods.