### PR TITLE
dd.to_hdf: multiple files multiprocessing avoid locks

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -462,14 +462,18 @@ def to_hdf(df, path_or_buf, key, mode='a', append=False, complevel=0,
                  "must preserve the order of its input")
 
     # handle lock default based on wether we're writing to a single entity
+    _actual_get = get if get else dask.get
     if lock is None:
-        if not single_node or not single_file:
+        if not single_node:
+            lock = True
+        elif not single_file and not _actual_get is dask.multiprocessing.get:
+            # if we're writing to multiple files with the multiprocessing
+            # scheduler we don't need to lock
             lock = True
         else:
             lock = False
 
     if lock is True:
-        _actual_get = get if get else dask.get
         if _actual_get == dask.multiprocessing.get:
             lock = multiprocessing.Manager().Lock()
         else:

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -462,9 +462,8 @@ def to_hdf(df, path_or_buf, key, mode='a', append=False, complevel=0,
             warn("To preserve order between partitions name_function "
                  "must preserve the order of its input")
 
-    # If user did not specify get as param or context and write is sequential
-    # default to the sequential scheduler
-    # otherwise let the _get method choose the scheduler
+    # If user did not specify scheduler and write is sequential default to the 
+    # sequential scheduler. otherwise let the _get method choose the scheduler
     if get is None and not 'get' in _globals and single_node and single_file:
         get = get_sync
 

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -20,6 +20,7 @@ from ..base import tokenize
 from ..compatibility import unicode, apply
 from .. import array as da
 from ..async import get_sync
+from ..context import _globals
 from ..delayed import Delayed, delayed
 import dask.multiprocessing
 
@@ -462,7 +463,7 @@ def to_hdf(df, path_or_buf, key, mode='a', append=False, complevel=0,
                  "must preserve the order of its input")
 
     # handle lock default based on wether we're writing to a single entity
-    _actual_get = get if get else dask.get
+    _actual_get = get or _globals.get('get') or get_sync
     if lock is None:
         if not single_node:
             lock = True

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -462,8 +462,14 @@ def to_hdf(df, path_or_buf, key, mode='a', append=False, complevel=0,
             warn("To preserve order between partitions name_function "
                  "must preserve the order of its input")
 
-    # handle lock default based on wether we're writing to a single entity
-    _actual_get = get or _globals.get('get') or get_sync
+    # If user did not specify get as param or context and write is sequential
+    # default to the sequential scheduler
+    # otherwise let the _get method choose the scheduler
+    if get is None and not 'get' in _globals and single_node and single_file:
+        get = get_sync
+
+    # handle lock default based on whether we're writing to a single entity
+    _actual_get = get or _globals.get('get') or df._default_get
     if lock is None:
         if not single_node:
             lock = True


### PR DESCRIPTION
When writing to multiple files with multiple processes we're using a single hdf core per file.
Thus there are no potential thread safety issues nor any file locking issues.

These specific conditions allow an entirely parallel operation and improved performance

Signed-off-by: Nir Izraeli <nirizr@gmail.com>