### PR TITLE
Fix pickling issue in dataframe to_bag

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -735,16 +735,20 @@ def to_csv(df, filename, name_function=None, compression=None, get=None, compute
         return delayed([Delayed(key, [dsk]) for key in keys])
 
 
+def _df_to_bag(df, index=False):
+    if isinstance(df, pd.DataFrame):
+        return list(map(tuple, df.itertuples(index)))
+    elif isinstance(df, pd.Series):
+        return list(df.iteritems()) if index else list(df)
+
+
 def to_bag(df, index=False):
     from ..bag.core import Bag
-    if isinstance(df, DataFrame):
-        func = lambda df: list(df.itertuples(index))
-    elif isinstance(df, Series):
-        func = (lambda df: list(df.iteritems())) if index else list
-    else:
+    if not isinstance(df, (DataFrame, Series)):
         raise TypeError("df must be either DataFrame or Series")
     name = 'to_bag-' + tokenize(df, index)
-    dsk = dict(((name, i), (func, block)) for (i, block) in enumerate(df._keys()))
+    dsk = dict(((name, i), (_df_to_bag, block, index))
+               for (i, block) in enumerate(df._keys()))
     dsk.update(df._optimize(df.dask, df._keys()))
     return Bag(dsk, name, df.npartitions)
 

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -1270,10 +1270,10 @@ def test_to_bag():
                      index=pd.Index([1., 2., 3., 4.], name='ind'))
     ddf = dd.from_pandas(a, 2)
 
-    assert ddf.to_bag().compute(get=get_sync) == list(a.itertuples(False))
-    assert ddf.to_bag(True).compute(get=get_sync) == list(a.itertuples(True))
-    assert ddf.x.to_bag(True).compute(get=get_sync) == list(a.x.iteritems())
-    assert ddf.x.to_bag().compute(get=get_sync) == list(a.x)
+    assert ddf.to_bag().compute() == list(a.itertuples(False))
+    assert ddf.to_bag(True).compute() == list(a.itertuples(True))
+    assert ddf.x.to_bag(True).compute() == list(a.x.iteritems())
+    assert ddf.x.to_bag().compute() == list(a.x)
 
 
 @pytest.mark.xfail(reason='we might want permissive behavior here')


### PR DESCRIPTION
This was caused due to pandas returning namedtuples in itertuples, which
can't be pickled. To fix, we cast the namedtuples to normal tuples.

Also pulled out some lambdas into a separate function to reduce
serialization cost.

Fixes #1382.