### PR TITLE
A few df fixes

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1134,7 +1134,7 @@ def partition(grouper, sequence, npartitions, p, nelements=2**20):
         d2 = defaultdict(list)
         for k, v in d.items():
             d2[abs(hash(k)) % npartitions].extend(v)
-        p.append(d2)
+        p.append(d2, fsync=True)
     return p
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1468,8 +1468,12 @@ class DataFrame(_Frame):
             raise AttributeError(e)
 
     def __dir__(self):
-        return sorted(set(dir(type(self)) + list(self.__dict__) +
-                      list(filter(pd.compat.isidentifier, self.columns))))
+        o = set(dir(type(self)))
+        o.update(self.__dict__)
+        o.update(c for c in self.columns if
+                 (isinstance(c, pd.compat.string_types) and
+                  pd.compat.isidentifier(c)))
+        return list(o)
 
     @property
     def ndim(self):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -16,6 +16,7 @@ def _maybe_slice(grouped, columns):
     """
     if isinstance(grouped, pd.core.groupby.DataFrameGroupBy):
         if columns is not None:
+            columns = columns if isinstance(columns, str) else list(columns)
             return grouped[columns]
     return grouped
 
@@ -58,6 +59,7 @@ def _apply_chunk(df, index, func, columns):
     if isinstance(df, pd.Series):
         return func(df.groupby(index))
     else:
+        columns = columns if isinstance(columns, str) else list(columns)
         return func(df.groupby(index)[columns])
 
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -118,7 +118,7 @@ def _set_partition(df, index, divisions, p, drop=True):
     divisions = list(divisions)
     shards = shard_df_on_index(df, divisions[1:-1])
     shards = list(map(strip_categories, shards))
-    p.append(dict(enumerate(shards)))
+    p.append(dict(enumerate(shards)), fsync=True)
 
 
 def _set_collect(group, p, barrier_token, columns):
@@ -252,7 +252,7 @@ def partition(df, index, npartitions, p):
     groups = rng.groupby(partitioning_index(index, npartitions))
     d = dict((i, df.iloc[groups.groups[i]]) for i in range(npartitions)
                                             if i in groups.groups)
-    p.append(d)
+    p.append(d, fsync=True)
 
 
 def collect(group, p, meta, barrier_token):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -110,6 +110,9 @@ def test_attributes():
 
     df = dd.from_pandas(pd.DataFrame({'a b c': [1, 2, 3]}), npartitions=2)
     assert 'a b c' not in dir(df)
+    df = dd.from_pandas(pd.DataFrame({'a': [1, 2], 5: [1, 2]}), npartitions=2)
+    assert 'a' in dir(df)
+    assert 5 not in dir(df)
 
 
 def test_column_names():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -460,3 +460,13 @@ def test_apply_shuffle():
 
     assert eq(ddf.groupby(ddf['A'] + 1)[['B', 'C']].apply(lambda x: x.sum()),
               pdf.groupby(pdf['A'] + 1)[['B', 'C']].apply(lambda x: x.sum()))
+
+
+def test_numeric_column_names():
+    # df.groupby(0)[df.columns] fails if all columns are numbers (pandas bug)
+    # This ensures that we cast all column iterables to list beforehand.
+    df = pd.DataFrame({0: [0, 1, 0, 1],
+                       1: [1, 2, 3, 4]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    eq(ddf.groupby(0).sum(), df.groupby(0).sum())
+    eq(ddf.groupby(0).apply(lambda x: x), df.groupby(0).apply(lambda x: x))


### PR DESCRIPTION
A few fixes for bugs discovered during the scipy sprints.

- Use fsync in `partd.append`. This was causing issues in some scenarios due to data not being consistently written to disk. This shouldn't have any significant performance impact, and covers some periodic edge cases.
- A few fixes to make things work with numeric column names. This was causing problems with `groupby` and `dir` specifically.