### PR TITLE
Progess bar process should be deamon

### DIFF
--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -85,6 +85,7 @@ class ProgressBar(Callback):
         # Start background thread
         self._running = True
         self._timer = threading.Thread(target=self._timer_func)
+        self._timer.daemon = True
         self._timer.start()
 
     def _pretask(self, key, dsk, state):


### PR DESCRIPTION
Fix usage of progress bar making compute hang on error

I've experienced this happening with CloudPickle errors, where CloudPickle raises an error ("Cannot pickle max recursion reached") and this thread keeps the entire process alive.

This is to make that python process exit when the timer thread is the only thing still alive.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>