### PR TITLE
Improve checks for dtype and shape in dask.array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -847,7 +847,7 @@ class Array(Base):
         >>> da.ones((10, 10), chunks=(5, 5), dtype='i4')
         dask.array<..., shape=(10, 10), dtype=int32, chunksize=(5, 5)>
         """
-        chunksize = str(tuple(c[0] for c in self.chunks))
+        chunksize = str(tuple(c[0] if c else 0 for c in self.chunks))
         name = self.name if len(self.name) < 10 else self.name[:7] + '...'
         return ("dask.array<%s, shape=%s, dtype=%s, chunksize=%s>" %
                 (name, self.shape, self._dtype, chunksize))
@@ -3030,7 +3030,7 @@ def concatenate3(arrays):
     if not ndim:
         return arrays
     if not arrays:
-        return np.empty(())
+        return np.empty(0)
     chunks = chunks_from_arrays(arrays)
     shape = tuple(map(sum, chunks))
 

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -741,7 +741,7 @@ def lstsq(a, b):
     q, r = qr(a)
     x = solve_triangular(r, q.T.dot(b))
     residuals = b - a.dot(x)
-    residuals = (residuals ** 2).sum()
+    residuals = (residuals ** 2).sum(keepdims=True)
 
     token = tokenize(a, b)
 

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -29,9 +29,9 @@ def reduction(x, chunk, aggregate, axis=None, keepdims=None, dtype=None,
         axis = (axis,)
     axis = tuple(i if i >= 0 else x.ndim + i for i in axis)
 
-    if dtype and 'dtype' in getargspec(chunk).args:
+    if dtype is not None and 'dtype' in getargspec(chunk).args:
         chunk = partial(chunk, dtype=dtype)
-    if dtype and 'dtype' in getargspec(aggregate).args:
+    if dtype is not None and 'dtype' in getargspec(aggregate).args:
         aggregate = partial(aggregate, dtype=dtype)
 
     # Map chunk across all blocks

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -804,7 +804,10 @@ def test_repr():
     assert str(d._dtype) in repr(d)
     d = da.ones((4000, 4), chunks=(4, 2))
     assert len(str(d)) < 1000
-
+    # Empty array
+    d = da.Array({}, 'd', ((), (3, 4)), dtype='i8')
+    assert str(d.shape) in repr(d)
+    assert str(d._dtype) in repr(d)
 
 def test_slicing_with_ellipsis():
     x = np.arange(256).reshape((4, 4, 4, 4))

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -5,15 +5,34 @@ import numpy as np
 from .core import Array
 from ..async import get_sync
 
+
+def _not_empty(x):
+    return x.shape and 0 not in x.shape
+
+
+def _maybe_check_dtype(a, dtype=None):
+    # Only check dtype matches for non-empty
+    if _not_empty(a):
+        assert a.dtype == dtype
+
+
 def assert_eq(a, b, **kwargs):
     if isinstance(a, Array):
         adt = a._dtype
         a = a.compute(get=get_sync)
+        if adt is not None:
+            _maybe_check_dtype(a, adt)
+        else:
+            adt = getattr(a, 'dtype', None)
     else:
         adt = getattr(a, 'dtype', None)
     if isinstance(b, Array):
         bdt = b._dtype
         b = b.compute(get=get_sync)
+        if bdt is not None:
+            _maybe_check_dtype(b, bdt)
+        else:
+            bdt = getattr(b, 'dtype', None)
     else:
         bdt = getattr(b, 'dtype', None)
 
@@ -23,7 +42,10 @@ def assert_eq(a, b, **kwargs):
                              os.linesep.join(diff))
 
     try:
-        assert np.allclose(a, b, **kwargs)
+        if _not_empty(a) and _not_empty(b):
+            # Treat all empty arrays as equivalent
+            assert a.shape == b.shape
+            assert np.allclose(a, b, **kwargs)
         return
     except TypeError:
         pass

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -1,9 +1,23 @@
+from distutils.version import LooseVersion
 import difflib
 import os
 import numpy as np
 
 from .core import Array
 from ..async import get_sync
+
+if LooseVersion(np.__version__) >= '1.10.0':
+    allclose = np.allclose
+else:
+    def allclose(a, b, **kwargs):
+        if kwargs.pop('equal_nan', False):
+            a_nans = np.isnan(a)
+            b_nans = np.isnan(b)
+            if not (a_nans == b_nans).all():
+                return False
+            a = a[~a_nans]
+            b = b[~b_nans]
+        return np.allclose(a, b, **kwargs)
 
 
 def _not_empty(x):
@@ -45,7 +59,7 @@ def assert_eq(a, b, **kwargs):
         if _not_empty(a) and _not_empty(b):
             # Treat all empty arrays as equivalent
             assert a.shape == b.shape
-            assert np.allclose(a, b, **kwargs)
+            assert allclose(a, b, **kwargs)
         return
     except TypeError:
         pass


### PR DESCRIPTION
The testing functions in numpy broadcast their arguments, which was
silently ignoring some bugs in dask.array. This tightens up those
checks, and fixes the bugs that appeared. Summary:

- Fix repr bug with empty arrays
- Ensure that `dtype` is passed through in reductions (Fixes #1394).
  Turns out `bool(np.dtype(...))` is always False (not what I would
  expect).
- `residuals` in `da.linalg.lstsq` returns an array of shape (1,)
  instead of a scalar.
- `da.array.Array._finalize([])` returns an empty array instead of a
  scalar with uninitialized memory.