### PR TITLE
optional estimated remaining time addition to progress

### DIFF
--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -37,6 +37,8 @@ class ProgressBar(Callback):
         Default is 0 (always display)
     width : int, optional
         Width of the bar
+    eta : bool, optional
+        If True include eta in progress bar
     dt : float, optional
         Update resolution in seconds, default is 0.1 seconds
 
@@ -73,10 +75,11 @@ class ProgressBar(Callback):
     [########################################] | 100% Completed | 10.4 s
     """
 
-    def __init__(self, minimum=0, width=40, dt=0.1):
+    def __init__(self, minimum=0, width=40, dt=0.1, eta=False):
         self._minimum = minimum
         self._width = width
         self._dt = dt
+        self._eta = eta
         self.last_duration = 0
 
     def _start(self, dsk):
@@ -95,21 +98,37 @@ class ProgressBar(Callback):
     def _finish(self, dsk, state, errored):
         self._running = False
         self._timer.join()
-        elapsed = default_timer() - self._start_time
+        elapsed = self._calc_elapsed()
         self.last_duration = elapsed
         if elapsed < self._minimum:
             return
         if not errored:
-            self._draw_bar(1, elapsed)
+            self._draw_bar(1, elapsed, 0)
         else:
             self._update_bar(elapsed)
         sys.stdout.write('\n')
         sys.stdout.flush()
 
+    def _calc_elapsed(self):
+        return default_timer() - self._start_time
+
+    def _calc_eta(self):
+        s = self._state
+        if not s:
+            return 0
+
+        ndone = len(s['finished'])
+        if not ndone:
+            return 0
+        nleft = sum(len(s[k]) for k in ['ready', 'waiting', 'running'])
+
+        return (self._calc_elapsed() / ndone) * nleft
+
     def _timer_func(self):
         """Background thread for updating the progress bar"""
         while self._running:
-            elapsed = default_timer() - self._start_time
+            elapsed = self._calc_elapsed()
+            eta = self._calc_eta()
             if elapsed > self._minimum:
                 self._update_bar(elapsed)
             time.sleep(self._dt)
@@ -117,18 +136,23 @@ class ProgressBar(Callback):
     def _update_bar(self, elapsed):
         s = self._state
         if not s:
-            self._draw_bar(0, elapsed)
+            self._draw_bar(0, elapsed, 0)
             return
         ndone = len(s['finished'])
         ntasks = sum(len(s[k]) for k in ['ready', 'waiting', 'running']) + ndone
-        self._draw_bar(ndone / ntasks if ntasks else 0, elapsed)
+        frac = ndone / ntasks if ntasks else 0.0
+        eta = self._calc_eta()
+        self._draw_bar(frac, elapsed, eta)
 
-    def _draw_bar(self, frac, elapsed):
+    def _draw_bar(self, frac, elapsed, eta):
         bar = '#' * int(self._width * frac)
         percent = int(100 * frac)
         elapsed = format_time(elapsed)
+        eta = format_time(eta)
         msg = '\r[{0:<{1}}] | {2}% Completed | {3}'.format(bar, self._width,
                                                            percent, elapsed)
+        if self._eta:
+            msg += " | {0} remaining".format(eta)
         with ignoring(ValueError):
             sys.stdout.write(msg)
             sys.stdout.flush()


### PR DESCRIPTION
Optionally show an estimated remaining time, defaults to False to preserve expected behavior.
Current estimation function is quite simple but could be improved if need arises.

Signed-off-by: Nir Izraeli <nirizr@gmail.com>