### PR TITLE
Ignore index when concating trivial indices

### DIFF
--- a/dask/dataframe/tests/test_csv.py
+++ b/dask/dataframe/tests/test_csv.py
@@ -32,7 +32,8 @@ files = {'2014-01-01.csv': (b'name,amount,id\n'
 
 header = files['2014-01-01.csv'].split(b'\n')[0] + b'\n'
 
-expected = pd.concat([pd.read_csv(BytesIO(files[k])) for k in sorted(files)])
+expected = pd.concat([pd.read_csv(BytesIO(files[k])) for k in sorted(files)],
+                     ignore_index=True)
 
 
 def test_bytes_read_csv():


### PR DESCRIPTION
If all partitions have trivial indices (unnamed `RangeIndex` starting at
0 and incrementing by 1), we now concatenate together while ignoring the
indices. Note that this isn't a perfect solution, as filtering steps
might get rid of the trivial index (e.g. `df.a[df.a > 10]` will convert
a `RangeIndex` to an `Int64Index`. In those cases we fall back to the
current behavior of just concatenating the indices.

Fixes #1047.