### PR TITLE
Add nice error messages on import failures

### DIFF
--- a/dask/diagnostics/__init__.py
+++ b/dask/diagnostics/__init__.py
@@ -2,7 +2,4 @@ from __future__ import absolute_import, division, print_function
 
 from .profile import Profiler, ResourceProfiler, CacheProfiler
 from .progress import ProgressBar
-try:
-    from .profile_visualize import visualize
-except ImportError:
-    pass
+from .profile_visualize import visualize

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -7,6 +7,7 @@ from time import sleep
 from multiprocessing import Process, Pipe, current_process
 
 from ..callbacks import Callback
+from ..utils import import_required
 
 
 # Stores execution data for each task
@@ -194,7 +195,8 @@ class ResourceProfiler(Callback):
 class _Tracker(Process):
     """Background process for tracking resource usage"""
     def __init__(self, dt=1):
-        import psutil
+        psutil = import_required("psutil", "Tracking resource usage requires "
+                                           "`psutil` to be installed")
         Process.__init__(self)
         self.daemon = True
         self.dt = dt

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -4,10 +4,14 @@ import re
 import os
 from functools import partial
 
-from graphviz import Digraph
-
 from .core import istask, get_dependencies, ishashable
-from .utils import funcname
+from .utils import funcname, import_required
+
+
+graphviz = import_required("graphviz", "Drawing dask graphs requires the "
+                                       "`graphviz` python library and the "
+                                       "`graphviz` system library to be "
+                                       "installed.")
 
 
 def task_label(task):
@@ -105,7 +109,7 @@ def to_graphviz(dsk, data_attributes=None, function_attributes=None, **kwargs):
 
     attributes = {'rankdir': 'BT'}
     attributes.update(kwargs)
-    g = Digraph(graph_attr=attributes)
+    g = graphviz.Digraph(graph_attr=attributes)
 
     seen = set()
     cache = {}

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -13,6 +13,7 @@ import tempfile
 import inspect
 import codecs
 import math
+from importlib import import_module
 from sys import getdefaultencoding
 
 try:
@@ -60,6 +61,17 @@ def ignoring(*exceptions):
         yield
     except exceptions:
         pass
+
+
+def import_required(mod_name, error_msg):
+    """Attempt to import a required dependency.
+
+    Raises a RuntimeError if the requested module is not available.
+    """
+    try:
+        return import_module(mod_name)
+    except ImportError:
+        raise RuntimeError(error_msg)
 
 
 @contextmanager


### PR DESCRIPTION
- Throw a nice error when imports fail on optional dependencies.
- Make the `dask.diagnostics.visualize` function always importable,
  moving the missing dependency failure to runtime.

Fixes #1372.