### PR TITLE
Unify shuffle algorithms

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1823,10 +1823,14 @@ class DataFrame(_Frame):
                    **kwargs)
 
     @derived_from(pd.DataFrame)
-    def drop(self, labels, axis=0):
+    def drop(self, labels, axis=0, dtype=None):
         if axis != 1:
             raise NotImplementedError("Drop currently only works for axis=1")
-        return elemwise(pd.DataFrame.drop, self, labels, axis)
+
+        if dtype is not None:
+            return elemwise(drop_columns, self, labels, dtype)
+        else:
+            return elemwise(pd.DataFrame.drop, self, labels, axis)
 
     @derived_from(pd.DataFrame)
     def merge(self, right, how='inner', on=None, left_on=None, right_on=None,
@@ -2940,3 +2944,9 @@ def _var(x, **kwargs):
 
 def _std(x, **kwargs):
     return x.std(**kwargs)
+
+
+def drop_columns(df, columns, dtype):
+    df = df.drop(columns, axis=1)
+    df.columns = df.columns.astype(dtype)
+    return df

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -245,6 +245,10 @@ class _Frame(Base):
         """Whether divisions are already known"""
         return len(self.divisions) > 0 and self.divisions[0] is not None
 
+    def clear_divisions(self):
+        divisions = (None,) * (self.npartitions + 1)
+        return type(self)(self.dask, self._name, self._pd, divisions)
+
     def get_division(self, n):
         """ Get nth division of the data """
         if 0 <= n < self.npartitions:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1827,7 +1827,7 @@ class DataFrame(_Frame):
     @derived_from(pd.DataFrame)
     def merge(self, right, how='inner', on=None, left_on=None, right_on=None,
               left_index=False, right_index=False,
-              suffixes=('_x', '_y'), npartitions=None, method=None):
+              suffixes=('_x', '_y'), npartitions=None, shuffle=None):
 
         if not isinstance(right, (DataFrame, pd.DataFrame)):
             raise ValueError('right must be DataFrame')
@@ -1836,11 +1836,11 @@ class DataFrame(_Frame):
         return merge(self, right, how=how, on=on,
                      left_on=left_on, right_on=right_on,
                      left_index=left_index, right_index=right_index,
-                     suffixes=suffixes, npartitions=npartitions, method=method)
+                     suffixes=suffixes, npartitions=npartitions, shuffle=shuffle)
 
     @derived_from(pd.DataFrame)
     def join(self, other, on=None, how='left',
-             lsuffix='', rsuffix='', npartitions=None, method=None):
+             lsuffix='', rsuffix='', npartitions=None, shuffle=None):
 
         if not isinstance(other, (DataFrame, pd.DataFrame)):
             raise ValueError('other must be DataFrame')
@@ -1849,7 +1849,7 @@ class DataFrame(_Frame):
         return merge(self, other, how=how,
                      left_index=on is None, right_index=True,
                      left_on=on, suffixes=[lsuffix, rsuffix],
-                     npartitions=npartitions, method=method)
+                     npartitions=npartitions, shuffle=shuffle)
 
     @derived_from(pd.DataFrame)
     def append(self, other):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -343,11 +343,11 @@ class _GroupBy(object):
         if isinstance(self.index, DataFrame):  # extract index from dataframe
             cols = ['_index_' + c for c in self.index.columns]
             index2 = df3[cols]
-            df4 = df3.drop(cols, axis=1)
+            df4 = df3.drop(cols, axis=1, dtype=dummy.columns.dtype)
         elif isinstance(self.index, Series):
             index2 = df3['_index']
             index2.name = self.index.name
-            df4 = df3.drop('_index', axis=1)
+            df4 = df3.drop('_index', axis=1, dtype=dummy.columns.dtype)
         else:
             df4 = df3
             index2 = self.index

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -343,11 +343,13 @@ class _GroupBy(object):
         if isinstance(self.index, DataFrame):  # extract index from dataframe
             cols = ['_index_' + c for c in self.index.columns]
             index2 = df3[cols]
-            df4 = df3.drop(cols, axis=1, dtype=dummy.columns.dtype)
+            df4 = df3.drop(cols, axis=1, dtype=dummy.columns.dtype if
+                    isinstance(dummy, pd.DataFrame) else None)
         elif isinstance(self.index, Series):
             index2 = df3['_index']
             index2.name = self.index.name
-            df4 = df3.drop('_index', axis=1, dtype=dummy.columns.dtype)
+            df4 = df3.drop('_index', axis=1, dtype=dummy.columns.dtype if
+                    isinstance(dummy, pd.DataFrame) else None)
         else:
             df4 = df3
             index2 = self.index

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -190,7 +190,6 @@ def from_bcolz(x, chunksize=None, categorize=True, index=None, lock=lock,
 
     Parameters
     ----------
-
     x : bcolz.ctable
         Input data
     chunksize : int, optional
@@ -205,7 +204,6 @@ def from_bcolz(x, chunksize=None, categorize=True, index=None, lock=lock,
 
     See Also
     --------
-
     from_array: more generic function not optimized for bcolz
     """
     if lock is True:
@@ -254,7 +252,7 @@ def from_bcolz(x, chunksize=None, categorize=True, index=None, lock=lock,
         assert index in x.names
         a = da.from_array(x[index], chunks=(chunksize * len(x.names),))
         q = np.linspace(0, 100, len(x) // chunksize + 2)
-        divisions = da.percentile(a, q).compute()
+        divisions = tuple(da.percentile(a, q).compute())
         return set_partition(result, index, divisions, **kwargs)
     else:
         return result
@@ -265,7 +263,6 @@ def dataframe_from_ctable(x, slc, columns=None, categories=None, lock=lock):
 
     Parameters
     ----------
-
     x: bcolz.ctable
     slc: slice
     columns: list of column names or None
@@ -468,7 +465,7 @@ def to_hdf(df, path_or_buf, key, mode='a', append=False, complevel=0,
             warn("To preserve order between partitions name_function "
                  "must preserve the order of its input")
 
-    # If user did not specify scheduler and write is sequential default to the 
+    # If user did not specify scheduler and write is sequential default to the
     # sequential scheduler. otherwise let the _get method choose the scheduler
     if get is None and not 'get' in _globals and single_node and single_file:
         get = get_sync

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -242,8 +242,11 @@ def _pdmerge(left, right, how, left_on, right_on,
     return result
 
 
+shuffle_func = shuffle  # name sometimes conflicts with keyword argument
+
+
 def hash_join(lhs, left_on, rhs, right_on, how='inner',
-              npartitions=None, suffixes=('_x', '_y'), method=None):
+              npartitions=None, suffixes=('_x', '_y'), shuffle=None):
     """ Join two DataFrames on particular columns with hash join
 
     This shuffles both datasets on the joined column and then performs an
@@ -254,8 +257,8 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
     if npartitions is None:
         npartitions = max(lhs.npartitions, rhs.npartitions)
 
-    lhs2 = shuffle(lhs, left_on, npartitions=npartitions, method=method)
-    rhs2 = shuffle(rhs, right_on, npartitions=npartitions, method=method)
+    lhs2 = shuffle_func(lhs, left_on, npartitions=npartitions, shuffle=shuffle)
+    rhs2 = shuffle_func(rhs, right_on, npartitions=npartitions, shuffle=shuffle)
 
     if isinstance(left_on, Index):
         left_on = None
@@ -285,7 +288,7 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
         right_on = (list, tuple(right_on))
 
     token = tokenize(lhs2, left_on, rhs2, right_on, left_index, right_index,
-                     how, npartitions, suffixes, method)
+                     how, npartitions, suffixes, shuffle)
     name = 'hash-join-' + token
 
     dsk = dict(((name, i), (merger, (lhs2._name, i), (rhs2._name, i),
@@ -379,7 +382,7 @@ def concat_indexed_dataframes(dfs, axis=0, join='outer'):
 
 def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
           left_index=False, right_index=False, suffixes=('_x', '_y'),
-          npartitions=None, method=None, max_branch=None):
+          npartitions=None, shuffle=None, max_branch=None):
 
     if not on and not left_on and not right_on and not left_index and not right_index:
         on = [c for c in left.columns if c in right.columns]
@@ -427,7 +430,7 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
                 right_index=right_index, suffixes=suffixes)
 
     # One side is indexed, the other not
-    elif (method == 'tasks' and
+    elif (shuffle == 'tasks' and
         (left_index and left.known_divisions and not right_index or
         right_index and right.known_divisions and not left_index)):
         left_empty = left._pd_nonempty
@@ -450,7 +453,7 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
     else:
         return hash_join(left, left.index if left_index else left_on,
                          right, right.index if right_index else right_on,
-                         how, npartitions, suffixes, method=method)
+                         how, npartitions, suffixes, shuffle=shuffle)
 
 
 ###############################################################

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -383,7 +383,6 @@ def concat_indexed_dataframes(dfs, axis=0, join='outer'):
 def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
           left_index=False, right_index=False, suffixes=('_x', '_y'),
           npartitions=None, shuffle=None, max_branch=None):
-
     if not on and not left_on and not right_on and not left_index and not right_index:
         on = [c for c in left.columns if c in right.columns]
         if not on:
@@ -430,9 +429,8 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
                 right_index=right_index, suffixes=suffixes)
 
     # One side is indexed, the other not
-    elif (shuffle == 'tasks' and
-        (left_index and left.known_divisions and not right_index or
-        right_index and right.known_divisions and not left_index)):
+    elif (left_index and left.known_divisions and not right_index or
+          right_index and right.known_divisions and not left_index):
         left_empty = left._pd_nonempty
         right_empty = right._pd_nonempty
         dummy = pd.merge(left_empty, right_empty, how=how, on=on, left_on=left_on,
@@ -440,12 +438,12 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
                 suffixes=suffixes)
         if left_index and left.known_divisions:
             right = rearrange_by_divisions(right, right_on, left.divisions,
-                    max_branch)
-            left.divisions = (None,) * (left.npartitions + 1)
+                    max_branch, shuffle=shuffle)
+            left = left.clear_divisions()
         elif right_index and right.known_divisions:
             left = rearrange_by_divisions(left, left_on, right.divisions,
-                    max_branch)
-            right.divisions = (None,) * (right.npartitions + 1)
+                    max_branch, shuffle=shuffle)
+            right = right.clear_divisions()
         return map_partitions(pd.merge, dummy, left, right, how=how, on=on,
                 left_on=left_on, right_on=right_on, left_index=left_index,
                 right_index=right_index, suffixes=suffixes)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -137,7 +137,8 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32,
     df3 = rearrange_by_column(df2, '_partitions', npartitions=npartitions,
                               max_branch=max_branch, shuffle=shuffle,
                               compute=compute)
-    df4 = df3.drop('_partitions', axis=1)
+
+    df4 = df3.drop('_partitions', axis=1, dtype=df.columns.dtype)
     return df4
 
 
@@ -148,7 +149,7 @@ def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None)
     df2 = df.assign(_partitions=partitions)
     df3 = rearrange_by_column(df2, '_partitions', max_branch=max_branch,
                               npartitions=len(divisions) - 1, shuffle=shuffle)
-    return df3.drop('_partitions', axis=1)
+    return df3.drop('_partitions', axis=1, dtype=df.columns.dtype)
 
 
 def rearrange_by_column(df, col, npartitions=None, max_branch=None,

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -48,7 +48,7 @@ def set_index(df, index, npartitions=None, shuffle=None, compute=True,
                   ._repartition_quantiles(npartitions, upsample=upsample)
                   .compute()).tolist()
 
-    return set_partition(df, index, divisions, compute=compute,
+    return set_partition(df, index, divisions,
                          shuffle=shuffle, drop=drop, **kwargs)
 
 
@@ -58,51 +58,6 @@ def new_categories(categories, index):
         categories = categories.copy()
         categories['.index'] = categories.pop(index)
     return categories
-
-
-def set_partition(df, index, divisions, shuffle=None, compute=False, drop=True,
-                  max_branch=32, **kwargs):
-    """ Group DataFrame by index
-
-    Sets a new index and partitions data along that index according to
-    divisions.  Divisions are often found by computing approximate quantiles.
-    The function ``set_index`` will do both of these steps.
-
-    Parameters
-    ----------
-    df: DataFrame/Series
-        Data that we want to re-partition
-    index: string or Series
-        Column to become the new index
-    divisions: list
-        Values to form new divisions between partitions
-    drop: bool, default True
-        Whether to delete columns to be used as the new index
-    shuffle: str (optional)
-        Either 'disk' for an on-disk shuffle or 'tasks' to use the task
-        scheduling framework.  Use 'disk' if you are on a single machine
-        and 'tasks' if you are on a distributed cluster.
-    max_branch: int (optional)
-        If using the task-based shuffle, the amount of splitting each
-        partition undergoes.  Increase this for fewer copies but more
-        scheduler overhead.
-
-    See Also
-    --------
-    set_index
-    shuffle
-    partd
-    """
-    shuffle = shuffle or _globals.get('shuffle', 'disk')
-
-    if shuffle == 'disk':
-        return set_partition_disk(df, index, divisions, compute=compute,
-                drop=drop, **kwargs)
-    elif shuffle == 'tasks':
-        return set_partition_tasks(df, index, divisions,
-                max_branch=max_branch, drop=drop)
-    else:
-        raise NotImplementedError("Unknown shuffle method %s" % shuffle)
 
 
 def barrier(args):
@@ -129,6 +84,7 @@ def _set_collect(group, p, barrier_token, columns):
         # which has the same columns as original
         return pd.DataFrame(columns=columns)
 
+
 def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32):
     """ Group DataFrame by index
 
@@ -147,77 +103,29 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32):
     shuffle_disk
     shuffle_tasks
     """
-    shuffle = shuffle or _globals.get('shuffle', 'disk')
-    if shuffle == 'disk':
-        return shuffle_disk(df, index, npartitions)
-    elif shuffle == 'tasks':
-        if not isinstance(index, _Frame):
-            index = df[index]
-        return shuffle_tasks(df, index, max_branch, npartitions=npartitions)
-    raise NotImplementedError()
-
-
-def shuffle_tasks(df, index, max_branch=32, npartitions=None):
-    """ Shuffle by creating many tasks """
-    assert isinstance(index, _Frame)
-    if npartitions is not None and npartitions < df.npartitions:
-        raise ValueError("Must create as many or more partitions in shuffle")
+    if not isinstance(index, _Frame):
+        index = df[index]
     partitions = index.map_partitions(partitioning_index,
                                       npartitions=npartitions or df.npartitions,
                                       columns=pd.Series([0]))
     df2 = df.assign(_partitions=partitions)
-    df3 = rearrange_by_column(df2, '_partitions', max_branch, npartitions)
-
+    df3 = rearrange_by_column(df2, '_partitions', npartitions=npartitions,
+                              max_branch=max_branch, shuffle=shuffle)
     df4 = df3.drop('_partitions', axis=1)
     return df4
 
 
-def shuffle_disk(df, index, npartitions=None):
-    """ Shuffle using local disk """
-    if isinstance(index, _Frame):
-        assert df.divisions == index.divisions
-    if npartitions is None:
-        npartitions = df.npartitions
-
-    token = tokenize(df, index, npartitions)
-    always_new_token = uuid.uuid1().hex
-
-    import partd
-    p = ('zpartd-' + always_new_token,)
-    dsk1 = {p: (partd.PandasBlocks, (partd.Buffer, (partd.Dict,),
-                                                   (partd.File,)))}
-
-    # Partition data on disk
-    name = 'shuffle-partition-' + always_new_token
-    if isinstance(index, _Frame):
-        dsk2 = dict(((name, i),
-                     (partition, part, ind, npartitions, p))
-                     for i, (part, ind)
-                     in enumerate(zip(df._keys(), index._keys())))
+def rearrange_by_column(df, col, npartitions=None, max_branch=None,
+        shuffle=None):
+    shuffle = shuffle or _globals.get('shuffle', 'disk')
+    if shuffle == 'disk':
+        return rearrange_by_column_disk(df, col, npartitions)
+    elif shuffle == 'tasks':
+        if npartitions is not None and npartitions < df.npartitions:
+            raise ValueError("Must create as many or more partitions in shuffle")
+        return rearrange_by_column_tasks(df, col, max_branch, npartitions)
     else:
-        dsk2 = dict(((name, i),
-                     (partition, part, index, npartitions, p))
-                     for i, part
-                     in enumerate(df._keys()))
-
-    # Barrier
-    barrier_token = 'barrier-' + always_new_token
-    dsk3 = {barrier_token: (barrier, list(dsk2))}
-
-    # Collect groups
-    name = 'shuffle-collect-' + token
-    meta = df._pd
-    dsk4 = dict(((name, i),
-                 (collect, i, p, meta, barrier_token))
-                for i in range(npartitions))
-
-    divisions = [None] * (npartitions + 1)
-
-    dsk = merge(df.dask, dsk1, dsk2, dsk3, dsk4)
-    if isinstance(index, _Frame):
-        dsk.update(index.dask)
-
-    return DataFrame(dsk, name, df.columns, divisions)
+        raise NotImplementedError("Unknown shuffle method %s" % shuffle)
 
 
 def partitioning_index(df, npartitions):
@@ -280,15 +188,15 @@ def partition(df, index, npartitions, p):
     p.append(d, fsync=True)
 
 
-def collect(group, p, meta, barrier_token):
+def collect(p, part, meta, barrier_token):
     """ Collect partitions from partd, yield dataframes """
-    res = p.get(group)
+    res = p.get(part)
     return res if len(res) > 0 else meta
 
 
 def set_partitions_pre(s, divisions):
     partitions = pd.Series(divisions).searchsorted(s, side='right') - 1
-    partitions[(s == divisions[-1]).values] = len(divisions) - 2
+    partitions[(s >= divisions[-1]).values] = len(divisions) - 2
     return partitions
 
 
@@ -312,6 +220,12 @@ def shuffle_group(df, col, stage, k, npartitions):
     return {i: g.get_group(i) if i in g.groups else df.head(0) for i in range(k)}
 
 
+def shuffle_group_3(df, col, npartitions, p):
+    g = df.groupby(col)
+    d = {i: g.get_group(i) for i in g.groups}
+    p.append(d, fsync=True)
+
+
 def set_index_post_scalar(df, index_name, drop):
     return (df.drop('_partitions', axis=1)
               .set_index(index_name, drop=drop))
@@ -322,7 +236,41 @@ def set_index_post_series(df, index_name, drop):
     return df2
 
 
-def rearrange_by_column(df, column, max_branch=32, npartitions=None):
+def rearrange_by_column_disk(df, column, npartitions=None):
+    """ Shuffle using local disk """
+    if npartitions is None:
+        npartitions = df.npartitions
+
+    token = tokenize(df, column, npartitions)
+    always_new_token = uuid.uuid1().hex
+
+    import partd
+    p = ('zpartd-' + always_new_token,)
+    dsk1 = {p: (partd.PandasBlocks, (partd.Buffer, (partd.Dict,),
+                                                   (partd.File,)))}
+
+    # Partition data on disk
+    name = 'shuffle-partition-' + always_new_token
+    dsk2 = {(name, i): (shuffle_group_3, key, column, npartitions, p)
+            for i, key in enumerate(df._keys())}
+
+    # Barrier
+    barrier_token = 'barrier-' + always_new_token
+    dsk3 = {barrier_token: (barrier, list(dsk2))}
+
+    # Collect groups
+    name = 'shuffle-collect-' + token
+    dsk4 = {(name, i): (collect, p, i, df._pd, barrier_token)
+                for i in range(npartitions)}
+
+    divisions = (None,) * (npartitions + 1)
+
+    dsk = merge(df.dask, dsk1, dsk2, dsk3, dsk4)
+
+    return DataFrame(dsk, name, df.columns, divisions)
+
+
+def rearrange_by_column_tasks(df, column, max_branch=32, npartitions=None):
     """ Order divisions of DataFrame so that all values within column align
 
     This enacts a task-based shuffle
@@ -401,22 +349,47 @@ def rearrange_by_column(df, column, max_branch=32, npartitions=None):
     return df3
 
 
-def rearrange_by_divisions(df, column, divisions, max_branch):
+def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None):
     """ Shuffle dataframe so that column separates along divisions """
     partitions = df[column].map_partitions(set_partitions_pre,
                 divisions=divisions, columns=pd.Series([0]))
     df2 = df.assign(_partitions=partitions)
-    df3 = rearrange_by_column(df2, '_partitions', max_branch,
-                              npartitions=len(divisions) - 1)
+    df3 = rearrange_by_column(df2, '_partitions', max_branch=max_branch,
+                              npartitions=len(divisions) - 1, shuffle=shuffle)
     return df3.drop('_partitions', axis=1)
 
 
-def set_partition_tasks(df, index, divisions, max_branch=32, drop=True):
-    """ Set partitions using task based scheme
+def set_partition(df, index, divisions, max_branch=32, drop=True, shuffle=None):
+    """ Group DataFrame by index
 
-    See also:
-        set_partition
-        set_partition_disk
+    Sets a new index and partitions data along that index according to
+    divisions.  Divisions are often found by computing approximate quantiles.
+    The function ``set_index`` will do both of these steps.
+
+    Parameters
+    ----------
+    df: DataFrame/Series
+        Data that we want to re-partition
+    index: string or Series
+        Column to become the new index
+    divisions: list
+        Values to form new divisions between partitions
+    drop: bool, default True
+        Whether to delete columns to be used as the new index
+    shuffle: str (optional)
+        Either 'disk' for an on-disk shuffle or 'tasks' to use the task
+        scheduling framework.  Use 'disk' if you are on a single machine
+        and 'tasks' if you are on a distributed cluster.
+    max_branch: int (optional)
+        If using the task-based shuffle, the amount of splitting each
+        partition undergoes.  Increase this for fewer copies but more
+        scheduler overhead.
+
+    See Also
+    --------
+    set_index
+    shuffle
+    partd
     """
     assert len(divisions) == len(df.divisions)
     if np.isscalar(index):
@@ -428,7 +401,8 @@ def set_partition_tasks(df, index, divisions, max_branch=32, drop=True):
                 divisions=divisions, columns=pd.Series([0]))
         df2 = df.assign(_partitions=partitions, _index=index)
 
-    df3 = rearrange_by_column(df2, '_partitions', max_branch)
+    df3 = rearrange_by_column(df2, '_partitions', max_branch=max_branch,
+            npartitions=len(divisions) - 1, shuffle=shuffle)
 
     if np.isscalar(index):
         df4 = df3.map_partitions(set_index_post_scalar, index_name=index,
@@ -440,83 +414,3 @@ def set_partition_tasks(df, index, divisions, max_branch=32, drop=True):
     df4.divisions = divisions
 
     return df4.map_partitions(pd.DataFrame.sort_index)
-
-
-def set_partition_disk(df, index, divisions, compute=False, drop=True, **kwargs):
-    """ Group DataFrame by index using local disk for staging
-
-    See Also
-    --------
-    partd
-    """
-    if isinstance(index, Series):
-        assert df.divisions == index.divisions
-        metadata = df._pd.set_index(index._pd, drop=drop)
-    elif np.isscalar(index):
-        metadata = df._pd.set_index(index, drop=drop)
-    else:
-         raise ValueError('index must be Series or scalar, {0} given'.format(type(index)))
-
-    token = tokenize(df, index, divisions)
-    always_new_token = uuid.uuid1().hex
-    import partd
-
-    p = ('zpartd-' + always_new_token,)
-
-    # Get Categories
-    catname = 'set-partition--get-categories-old-' + always_new_token
-    catname2 = 'set-partition--get-categories-new-' + always_new_token
-
-    dsk1 = {catname: (get_categories, df._keys()[0]),
-            p: (partd.PandasBlocks, (partd.Buffer, (partd.Dict,), (partd.File,))),
-            catname2: (new_categories, catname,
-                       index.name if isinstance(index, Series) else index)}
-
-    # Partition data on disk
-    name = 'set-partition--partition-' + always_new_token
-    if isinstance(index, _Frame):
-        dsk2 = dict(((name, i),
-                     (_set_partition, part, ind, divisions, p, drop))
-                     for i, (part, ind)
-                     in enumerate(zip(df._keys(), index._keys())))
-    else:
-        dsk2 = dict(((name, i),
-                     (_set_partition, part, index, divisions, p, drop))
-                     for i, part
-                     in enumerate(df._keys()))
-
-    # Barrier
-    barrier_token = 'barrier-' + always_new_token
-    dsk3 = {barrier_token: (barrier, list(dsk2))}
-
-    if compute:
-        dsk = merge(df.dask, dsk1, dsk2, dsk3)
-        if isinstance(index, _Frame):
-            dsk.update(index.dask)
-        p, barrier_token, categories = df._get(dsk, [p, barrier_token, catname2], **kwargs)
-        dsk4 = {catname2: categories}
-    else:
-        dsk4 = {}
-
-    # Collect groups
-    name = 'set-partition--collect-' + token
-    if compute and not categories:
-        dsk4.update(dict(((name, i),
-                     (_set_collect, i, p, barrier_token, df.columns))
-                     for i in range(len(divisions) - 1)))
-    else:
-        dsk4.update(dict(((name, i),
-                     (_categorize, catname2,
-                        (_set_collect, i, p, barrier_token, df.columns)))
-                    for i in range(len(divisions) - 1)))
-
-    dsk = merge(df.dask, dsk1, dsk2, dsk3, dsk4)
-
-    if isinstance(index, Series):
-        dsk.update(index.dask)
-
-    if compute:
-        dsk, _ = cull(dsk, list(dsk4.keys()))
-
-    result = DataFrame(dsk, name, metadata, divisions)
-    return result.map_partitions(pd.DataFrame.sort_index, result)

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pandas.util.testing as tm
+import pytest
 
 import dask
 from dask.async import get_sync
@@ -26,12 +27,13 @@ def test_categorize():
     assert (d.categorize().compute().dtypes == 'category').all()
 
 
-def test_categorical_set_index():
+@pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
+def test_categorical_set_index(shuffle):
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': ['a', 'b', 'b', 'c']})
-    df['y'] = df.y.astype('category')
+    df['y'] = df.y.astype('category', ordered=True)
     a = dd.from_pandas(df, npartitions=2)
 
-    with dask.set_options(get=get_sync):
+    with dask.set_options(get=get_sync, shuffle=shuffle):
         b = a.set_index('y')
         df2 = df.set_index('y')
         d1, d2 = b.get_division(0), b.get_division(1)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -115,11 +115,15 @@ def test_join_indexed_dataframe_to_indexed_dataframe():
            sorted(join_indexed_dataframes(a, b, how='outer').dask)
 
 
-def list_eq(a, b):
-    if isinstance(a, dd.DataFrame):
-        a = a.compute(get=get_sync)
-    if isinstance(b, dd.DataFrame):
-        b = b.compute(get=get_sync)
+def list_eq(aa, bb):
+    if isinstance(aa, dd.DataFrame):
+        a = aa.compute(get=get_sync)
+    else:
+        a = aa
+    if isinstance(bb, dd.DataFrame):
+        b = bb.compute(get=get_sync)
+    else:
+        b = bb
     tm.assert_index_equal(a.columns, b.columns)
 
     # ToDo: As of pandas 0,17, tm.assert_numpy_array_equal can

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import dask.dataframe as dd
 from dask.dataframe.shuffle import (shuffle, hash_series, partitioning_index,
-        rearrange_by_column)
+        rearrange_by_column, rearrange_by_divisions)
 from dask.async import get_sync
 from dask.dataframe.utils import eq
 
@@ -220,3 +220,12 @@ def test_rearrange():
     parts = get_sync(result.dask, result._keys())
     for i in a.y.drop_duplicates():
         assert sum(i in part.y for part in parts) == 1
+
+
+def test_rearrange_by_column_with_narrow_divisions():
+    from dask.dataframe.tests.test_multi import list_eq
+    A = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': [1, 1, 2, 2, 3, 4]})
+    a = dd.repartition(A, [0, 4, 5])
+
+    df = rearrange_by_divisions(a, 'x', (0, 2, 5))
+    list_eq(df, a)


### PR DESCRIPTION
This unifies the disk and task-based shuffle algorithms and the hash-based shuffle and sorted-index shuffles to a shared codebase.  Previously we had a lot of repeated logic both for multiple uses of partd and for the partd-task split.  Now everything is refactored so that task and partd logic exist in a single, fairly low level place.  The test suite now covers both.