### PR TITLE
Adding documentation to create dask DataFrame from HDF5

### DIFF
--- a/docs/source/dataframe-create.rst
+++ b/docs/source/dataframe-create.rst
@@ -11,7 +11,7 @@ that function's options.  Additionally it gains two new functionalities
 
 .. code-block:: python
 
-   >>> df = dd.read_csv('data.*.csv') # doctest: +SKIP
+   >>> df = dd.read_csv('data.*.csv') 
 
 2.  You can specify the size of each block of data in bytes of uncompressed
     data.  Note that, especially for text data the size on disk may be much
@@ -29,7 +29,7 @@ NumPy arrays and HDF5 datasets.
 
 .. code-block:: Python
 
-   >>> dd.from_array(x, chunksize=1000000) # doctest: +SKIP
+   >>> dd.from_array(x, chunksize=1000000) 
 
 From BColz
 ----------
@@ -40,7 +40,7 @@ it.  There is a special ``from_bcolz`` function.
 
 .. code-block:: Python
 
-   >>> df = dd.from_bcolz('myfile.bcolz', chunksize=1000000) # doctest: +SKIP
+   >>> df = dd.from_bcolz('myfile.bcolz', chunksize=1000000) 
 
 In particular column access on a dask.dataframe backed by a ``bcolz.ctable``
 will only read the necessary columns from disk.  This can provide dramatic
@@ -59,8 +59,8 @@ and not actively maintained; use at your own risk.
 .. code-block:: Python
 
    >>> from castra import Castra # doctest: +SKIP
-   >>> c = Castra(path='/my/castra/file') # doctest: +SKIP
-   >>> df = c.to_dask() # doctest: +SKIP
+   >>> c = Castra(path='/my/castra/file') 
+   >>> df = c.to_dask() 
 
 .. _Castra: http://github.com/blaze/castra
 
@@ -72,15 +72,15 @@ From HDF5
 .. code-block:: Python
 
    >>> # Load hdf5 into dask DataFrame 
-   >>> dd.read_hdf('myfile.1.hdf5', '/x', chunksize=1000000) # doctest: +SKIP
+   >>> dd.read_hdf('myfile.1.hdf5', '/x', chunksize=1000000) 
    
    
    >>> # OR Load multiple hdf5 files into dask DataFrame # 
-   >>> dd.read_hdf('myfile.*.hdf5', '/x', chunksize=1000000) # doctest: +SKIP 
+   >>> dd.read_hdf('myfile.*.hdf5', '/x', chunksize=1000000)  
    
    
    >>> # OR Load multiple hdf5 datasets into a dask DataFrame 
-   >>> dd.read_hdf('myfile.1.hdf5', '/*', chunksize=1000000) # doctest: +SKIP
+   >>> dd.read_hdf('myfile.1.hdf5', '/*', chunksize=1000000) 
 
 From Bags
 ---------

--- a/docs/source/dataframe-create.rst
+++ b/docs/source/dataframe-create.rst
@@ -11,7 +11,7 @@ that function's options.  Additionally it gains two new functionalities
 
 .. code-block:: python
 
-   >>> df = dd.read_csv('data.*.csv')
+   >>> df = dd.read_csv('data.*.csv') # doctest: +SKIP
 
 2.  You can specify the size of each block of data in bytes of uncompressed
     data.  Note that, especially for text data the size on disk may be much
@@ -19,7 +19,7 @@ that function's options.  Additionally it gains two new functionalities
 
 .. code-block:: python
 
-   >>> df = dd.read_csv('data.csv', chunkbytes=1000000)  # 1MB chunks
+   >>> df = dd.read_csv('data.csv', chunkbytes=1000000)  # 1MB chunks # doctest: +SKIP
 
 From an Array
 -------------
@@ -29,7 +29,7 @@ NumPy arrays and HDF5 datasets.
 
 .. code-block:: Python
 
-   >>> dd.from_array(x, chunksize=1000000)
+   >>> dd.from_array(x, chunksize=1000000) # doctest: +SKIP
 
 From BColz
 ----------
@@ -40,7 +40,7 @@ it.  There is a special ``from_bcolz`` function.
 
 .. code-block:: Python
 
-   >>> df = dd.from_bcolz('myfile.bcolz', chunksize=1000000)
+   >>> df = dd.from_bcolz('myfile.bcolz', chunksize=1000000) # doctest: +SKIP
 
 In particular column access on a dask.dataframe backed by a ``bcolz.ctable``
 will only read the necessary columns from disk.  This can provide dramatic
@@ -58,29 +58,39 @@ and not actively maintained; use at your own risk.
 
 .. code-block:: Python
 
-   >>> from castra import Castra
-   >>> c = Castra(path='/my/castra/file')
-   >>> df = c.to_dask()
+   >>> from castra import Castra # doctest: +SKIP
+   >>> c = Castra(path='/my/castra/file') # doctest: +SKIP
+   >>> df = c.to_dask() # doctest: +SKIP
 
 .. _Castra: http://github.com/blaze/castra
 
 From HDF5
 ----------
 
-`HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ is a Hierarchical Data Format (HDF) designed to store and organize large amounts of data.  Similar to the `pandas I\/O API <http://pandas.pydata.org/pandas-docs/stable/io.html>`_,    `dask <(http://dask.pydata.org/en/latest/index.html>`_ can create a DataFrame directly from `HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ datasets.
+`HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ is a Hierarchical Data Format (HDF) designed to store and organize large amounts of data.  
+
+First, we create a random HDF5 dataset.
 
 .. code-block:: Python
 
-   >>> # Load hdf5 into dask DataFrame
-   >>> dd.read_hdf('myfile.1.hdf5', '/x', chunksize=1000000)
+   >>> import h5py
+   >>> import numpy as np
+   >>> f = h5py.File("myfile.hdf5", "w")
+   >>> dset = f.create_dataset("mydataset", (1000000,), dtype='i')
+   >>> dset[...] = np.arange(1000000)
+   >>> print dset.shape
+   (1000000,)
    
+Similar to the `pandas I\/O API <http://pandas.pydata.org/pandas-docs/stable/io.html>`_,    `dask <(http://dask.pydata.org/en/latest/index.html>`_ can create a DataFrame directly from `HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ datasets.
+
+.. code-block:: Python   
+
+   >>> import dask.dataframe as dd
+   >>> dd.read_hdf('myfile.1.hdf5', '/mydataset', chunksize=1000) # doctest: +SKIP
    
-   >>> # OR Load multiple hdf5 files into dask DataFrame
-   >>> dd.read_hdf('myfile.*.hdf5', '/x', chunksize=1000000)  
-   
-   
-   >>> # OR Load multiple hdf5 datasets into a dask DataFrame
-   >>> dd.read_hdf('myfile.1.hdf5', '/*', chunksize=1000000) 
+There are other examples on HDF5 functionality within `dask` here_
+
+.. _here: https://github.com/dask/dask/blob/master/dask/dataframe/io.py#L637-L649
 
 From Bags
 ---------

--- a/docs/source/dataframe-create.rst
+++ b/docs/source/dataframe-create.rst
@@ -1,6 +1,10 @@
 Create Dask DataFrames
 ======================
 
+Dask can create dataframes objects from various data storage formats.  Dask dataframes are commonly used to quickly inspect and analyze large volumes of tabular data stored in CSV, HDF5, or other tabular formats.  
+
+See the `Overview section <http://dask.pydata.org/en/latest/dataframe-overview.html>`_ for an in depth discussion of ``dask.dataframe`` scope, use, limitations.    
+
 From CSV files
 --------------
 
@@ -19,13 +23,40 @@ that function's options.  Additionally it gains two new functionalities
 
 .. code-block:: python
 
-   >>> df = dd.read_csv('data.csv', chunkbytes=1000000)  # 1MB chunks # doctest: +SKIP
+   >>> df = dd.read_csv('data.csv', chunkbytes=1000000)  # 1MB chunks 
+   
+From HDF5
+----------
 
+`HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ is a Hierarchical Data Format (HDF) designed to store and organize large amounts of data.  Similar to the `pandas I\/O API <http://pandas.pydata.org/pandas-docs/stable/io.html>`_,  ``dask.dataframe`` can create a DataFrame directly from `HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ datasets.
+
+``dask.dataframe`` can read a single HDF5 ('myfile.hdf5') file by referencing a group key ('/x'):
+
+.. code-block:: Python
+
+   >>> import dask.dataframe as dd
+   >>> dd.read_hdf('myfile1.hdf5', '/x', chunksize=1000000) 
+
+It is also possible to create a DataFrame object from multiple HDF5 files in a directory with similar group keys by using a wildcard character (\*).  The ``dask.dataframe`` syntax for this task is:
+
+.. code-block:: Python
+
+   >>> import dask.dataframe as dd
+   >>> dd.read_hdf('myfile*.hdf5', '/x', chunksize=1000000) 
+   
+Finally, ``dask.dataframe`` can load multiple datasets from a single HDF5 file using this syntax:
+
+.. code-block:: Python
+   
+   >>> import dask.dataframe as dd 
+   >>> dd.read_hdf('myfile1.hdf5', '/*', chunksize=1000000) 
+   
 From an Array
 -------------
 
 You can create a DataFrame from any sliceable array like object including both
-NumPy arrays and HDF5 datasets.
+NumPy arrays and HDF5 datasets. For a discussion of ``dask.array`` capabilities and
+instruction on creating dask arrays, see the `Array Overview <http://dask.pydata.org/en/latest/array-overview.html>`_ and `Create Dask Arrays <http://dask.pydata.org/en/latest/array-creation.html>`_ sections.
 
 .. code-block:: Python
 
@@ -58,29 +89,12 @@ and not actively maintained; use at your own risk.
 
 .. code-block:: Python
 
-   >>> from castra import Castra # doctest: +SKIP
+   >>> from castra import Castra 
    >>> c = Castra(path='/my/castra/file') 
    >>> df = c.to_dask() 
 
 .. _Castra: http://github.com/blaze/castra
 
-From HDF5
-----------
-
-`HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ is a Hierarchical Data Format (HDF) designed to store and organize large amounts of data.  Similar to the `pandas I\/O API <http://pandas.pydata.org/pandas-docs/stable/io.html>`_,    `dask <(http://dask.pydata.org/en/latest/index.html>`_ can create a DataFrame directly from `HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ datasets.
-
-.. code-block:: Python
-
-   >>> # Load hdf5 into dask DataFrame 
-   >>> dd.read_hdf('myfile.1.hdf5', '/x', chunksize=1000000) 
-   
-   
-   >>> # OR Load multiple hdf5 files into dask DataFrame # 
-   >>> dd.read_hdf('myfile.*.hdf5', '/x', chunksize=1000000)  
-   
-   
-   >>> # OR Load multiple hdf5 datasets into a dask DataFrame 
-   >>> dd.read_hdf('myfile.1.hdf5', '/*', chunksize=1000000) 
 
 From Bags
 ---------

--- a/docs/source/dataframe-create.rst
+++ b/docs/source/dataframe-create.rst
@@ -67,30 +67,20 @@ and not actively maintained; use at your own risk.
 From HDF5
 ----------
 
-`HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ is a Hierarchical Data Format (HDF) designed to store and organize large amounts of data.  
-
-First, we create a random HDF5 dataset.
+`HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ is a Hierarchical Data Format (HDF) designed to store and organize large amounts of data.  Similar to the `pandas I\/O API <http://pandas.pydata.org/pandas-docs/stable/io.html>`_,    `dask <(http://dask.pydata.org/en/latest/index.html>`_ can create a DataFrame directly from `HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ datasets.
 
 .. code-block:: Python
 
-   >>> import h5py
-   >>> import numpy as np
-   >>> f = h5py.File("myfile.hdf5", "w")
-   >>> dset = f.create_dataset("mydataset", (1000000,), dtype='i')
-   >>> dset[...] = np.arange(1000000)
-   >>> print dset.shape
-   (1000000,)
+   >>> # Load hdf5 into dask DataFrame 
+   >>> dd.read_hdf('myfile.1.hdf5', '/x', chunksize=1000000) # doctest: +SKIP
    
-Similar to the `pandas I\/O API <http://pandas.pydata.org/pandas-docs/stable/io.html>`_,    `dask <(http://dask.pydata.org/en/latest/index.html>`_ can create a DataFrame directly from `HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ datasets.
-
-.. code-block:: Python   
-
-   >>> import dask.dataframe as dd
-   >>> dd.read_hdf('myfile.1.hdf5', '/mydataset', chunksize=1000) # doctest: +SKIP
    
-There are other examples on HDF5 functionality within `dask` here_
-
-.. _here: https://github.com/dask/dask/blob/master/dask/dataframe/io.py#L637-L649
+   >>> # OR Load multiple hdf5 files into dask DataFrame # 
+   >>> dd.read_hdf('myfile.*.hdf5', '/x', chunksize=1000000) # doctest: +SKIP 
+   
+   
+   >>> # OR Load multiple hdf5 datasets into a dask DataFrame 
+   >>> dd.read_hdf('myfile.1.hdf5', '/*', chunksize=1000000) # doctest: +SKIP
 
 From Bags
 ---------

--- a/docs/source/dataframe-create.rst
+++ b/docs/source/dataframe-create.rst
@@ -64,6 +64,23 @@ and not actively maintained; use at your own risk.
 
 .. _Castra: http://github.com/blaze/castra
 
+From HDF5
+----------
+
+`HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ is a Hierarchical Data Format (HDF) designed to store and organize large amounts of data.  Similar to the `pandas I\/O API <http://pandas.pydata.org/pandas-docs/stable/io.html>`_,    `dask <(http://dask.pydata.org/en/latest/index.html>`_ can create a DataFrame directly from `HDF5 <https://www.hdfgroup.org/HDF5/doc/H5.intro.html>`_ datasets.
+
+.. code-block:: Python
+
+   >>> # Load hdf5 into dask DataFrame
+   >>> dd.read_hdf('myfile.1.hdf5', '/x', chunksize=1000000)
+   
+   
+   >>> # OR Load multiple hdf5 files into dask DataFrame
+   >>> dd.read_hdf('myfile.*.hdf5', '/x', chunksize=1000000)  
+   
+   
+   >>> # OR Load multiple hdf5 datasets into a dask DataFrame
+   >>> dd.read_hdf('myfile.1.hdf5', '/*', chunksize=1000000) 
 
 From Bags
 ---------


### PR DESCRIPTION
I wrote this recommendation up in issue #664, but wanted to put the same write up here.  The bottomline is, I'd like to add a small paragraph of documentation to the [`dask` DataFrame creation](http://dask.pydata.org/en/latest/dataframe.html) section.  

For [excruciating detail (with screen shots), please read the linked issue](https://github.com/dask/dask/pull/664#issuecomment-234730449), but in short, this pull request should help marry the [dask.dataframe.io.py](https://github.com/dask/dask/blob/master/dask/dataframe/io.py#L537-L664) comments up with the `dask` documentation.  

