### PR TITLE
[WIP] Read hdf partitioned

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -543,12 +543,12 @@ and stopping index per file, or starting and stopping index of the global
 dataset."""
 
 def _read_single_hdf(path, key, start=0, stop=None, columns=None,
-                     chunksize=int(1e6), lock=None):
+                     chunksize=int(1e6), assume_partitioned=False, lock=None):
     """
     Read a single hdf file into a dask.dataframe. Used for each file in
     read_hdf.
     """
-    def get_keys_and_stops(path, key, stop):
+    def get_keys_stops_divisions(path, key, stop, assume_partitioned):
         """
         Get the "keys" or group identifiers which match the given key, which
         can contain wildcards. This uses the hdf file identified by the
@@ -558,6 +558,7 @@ def _read_single_hdf(path, key, start=0, stop=None, columns=None,
         with pd.HDFStore(path) as hdf:
             keys = [k for k in hdf.keys() if fnmatch(k, key)]
             stops = []
+            divisions = []
             for k in keys:
                 storer = hdf.get_storer(k)
                 if storer.format_type != 'table':
@@ -569,10 +570,16 @@ def _read_single_hdf(path, key, start=0, stop=None, columns=None,
                                      "of rows ({})".format(storer.nrows))
                 else:
                     stops.append(stop)
-        return keys, stops
+                if assume_partitioned:
+                    division_start = storer.read_column('index', start=0, stop=1)[0]
+                    division_end = storer.read_column('index', start=storer.nrows-1, stop=storer.nrows)[0]
+                    divisions.append([division_start, division_end])
+                else:
+                    divisions.append(None)
+        return keys, stops, divisions
 
 
-    def one_path_one_key(path, key, start, stop, columns, chunksize, lock):
+    def one_path_one_key(path, key, start, stop, columns, chunksize, division, lock):
         """
         Get the data frame corresponding to one path and one key (which should
         not contain any wildcards).
@@ -582,28 +589,35 @@ def _read_single_hdf(path, key, start=0, stop=None, columns=None,
             empty = empty[columns]
 
         token = tokenize((path, os.path.getmtime(path), key, start,
-                          stop, empty, chunksize))
+                          stop, empty, chunksize, division))
         name = 'read-hdf-' + token
 
         if start >= stop:
             raise ValueError("Start row number ({}) is above or equal to stop "
                              "row number ({})".format(start, stop))
 
-        dsk = dict(((name, i), (_pd_read_hdf, path, key, lock,
-                                 {'start': s,
-                                  'stop': s + chunksize,
-                                  'columns': empty.columns}))
-                    for i, s in enumerate(range(start, stop, chunksize)))
+        if division:
+            dsk = {(name, 0): (_pd_read_hdf, path, key, lock,
+                                 {'columns': empty.columns})}
 
-        divisions = [None] * (len(dsk) + 1)
+            divisions = division
+        else:
+            dsk = dict(((name, i), (_pd_read_hdf, path, key, lock,
+                                     {'start': s,
+                                      'stop': s + chunksize,
+                                      'columns': empty.columns}))
+                        for i, s in enumerate(range(start, stop, chunksize)))
+
+            divisions = [None]  * (len(dsk) + 1)
+
         return DataFrame(dsk, name, empty, divisions)
 
-    keys, stops = get_keys_and_stops(path, key, stop)
+    keys, stops, divisions = get_keys_stops_divisions(path, key, stop, assume_partitioned)
     if (start != 0 or stop is not None) and len(keys) > 1:
         raise NotImplementedError(read_hdf_error_msg)
     from .multi import concat
-    return concat([one_path_one_key(path, k, start, s, columns, chunksize, lock)
-                   for k, s in zip(keys, stops)])
+    return concat([one_path_one_key(path, k, start, s, columns, chunksize, d, lock)
+                   for k, s, d in zip(keys, stops, divisions)])
 
 
 def _pd_read_hdf(path, key, lock, kwargs):
@@ -620,7 +634,7 @@ def _pd_read_hdf(path, key, lock, kwargs):
 
 @wraps(pd.read_hdf)
 def read_hdf(pattern, key, start=0, stop=None, columns=None,
-             chunksize=1000000, lock=True):
+             chunksize=1000000, assume_partitioned=False, lock=True):
     """
     Read hdf files into a dask dataframe. Like pandas.read_hdf, except it we
     can read multiple files, and read multiple keys from the same file by using
@@ -663,11 +677,16 @@ def read_hdf(pattern, key, start=0, stop=None, columns=None,
     paths = sorted(glob(pattern))
     if (start != 0 or stop is not None) and len(paths) > 1:
         raise NotImplementedError(read_hdf_error_msg)
-    if chunksize <= 0:
+    if not (chunksize is None and assume_partitioned) and chunksize <= 0:
         raise ValueError("Chunksize must be a positive integer")
+    if (start != 0 or stop is not None or chunksize is not None) \
+        and assume_partitioned:
+        raise ValueError("When assuming pre-partitioned data, data must be "
+                         "read in its entirety using the same chunksizes")
     from .multi import concat
     return concat([_read_single_hdf(path, key, start=start, stop=stop,
                                     columns=columns, chunksize=chunksize,
+                                    assume_partitioned=assume_partitioned,
                                     lock=lock)
                    for path in paths])
 

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -1116,10 +1116,14 @@ def test_read_hdf_multiple():
 
     with tmpfile('h5') as fn:
         a.to_hdf(fn, '/data*')
-        r = dd.read_hdf(fn, '/data*')
-        eq(a, r)
+        with pytest.raises(ValueError) as e:
+            r = dd.read_hdf(fn, '/data*', assume_partitioned=True)
+        assert 'entirety' in str(e)
+
+        r = dd.read_hdf(fn, '/data*', chunksize=None, assume_partitioned=True)
         assert a.npartitions == r.npartitions
         assert a.divisions == r.divisions
+        eq(a, r)
 
 
 def test_read_hdf_start_stop_values():

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -1107,6 +1107,20 @@ def test_read_hdf():
         assert (sorted(dd.read_hdf(fn, '/data').dask) ==
                 sorted(dd.read_hdf(fn, '/data').dask))
 
+def test_read_hdf_multiple():
+    pytest.importorskip('tables')
+    df = pd.DataFrame({'x': ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'],
+                       'y': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]},
+                            index=[1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.])
+    a = dd.from_pandas(df, 16)
+
+    with tmpfile('h5') as fn:
+        a.to_hdf(fn, '/data*')
+        r = dd.read_hdf(fn, '/data*')
+        eq(a, r)
+        assert a.npartitions == r.npartitions
+        assert a.divisions == r.divisions
+
 
 def test_read_hdf_start_stop_values():
     pytest.importorskip('tables')

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -1116,11 +1116,7 @@ def test_read_hdf_multiple():
 
     with tmpfile('h5') as fn:
         a.to_hdf(fn, '/data*')
-        with pytest.raises(ValueError) as e:
-            r = dd.read_hdf(fn, '/data*', assume_partitioned=True)
-        assert 'entirety' in str(e)
-
-        r = dd.read_hdf(fn, '/data*', chunksize=None, assume_partitioned=True)
+        r = dd.read_hdf(fn, '/data*', sorted_index=True)
         assert a.npartitions == r.npartitions
         assert a.divisions == r.divisions
         eq(a, r)


### PR DESCRIPTION
This PR adds a new parameter to `dd.read_hdf` temporarily called `assume_parititioned`.
The interface will probably change.

This operates under the assumption input is divided into partitions (either partition per file or per dataset, as data is saved using `to_hdf` with an asterisk) and allows reading divisions data from hdf itself, resulting in a partitioned dataframe. 

This should be better than reading a dataframe unpartitioned and then partitioning it because of the extra work in `concat` and partitioning, using the extra information that data is already partitioned.

I hope this sounds reasonable.
Input, suggestions and opinions are most welcome! 