### PR TITLE
Support concat with unknown divisions

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -789,11 +789,6 @@ def test_concat2():
         assert eq(pd.concat(pdcase, join='inner'), result)
         assert result.dask == dd.concat(case, join='inner').dask
 
-        msg = ('Unable to concatenate DataFrame with unknown division '
-               'specifying axis=1')
-        with tm.assertRaisesRegexp(ValueError, msg):
-            dd.concat(case, axis=1)
-
 
 def test_concat3():
     pdf1 = pd.DataFrame(np.random.randn(6, 5),

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -656,3 +656,20 @@ def test_errors_for_merge_on_frame_columns():
 
     with pytest.raises(NotImplementedError):
         dd.merge(aa, bb, left_on=aa.x, right_on=bb.y)
+
+
+def test_concat_unknown_divisions():
+    import pandas as pd
+    a = pd.Series([1, 2, 3, 4])
+    b = pd.Series([4, 3, 2, 1])
+    aa = dd.from_pandas(a, npartitions=2, sort=False)
+    bb = dd.from_pandas(b, npartitions=2, sort=False)
+
+    assert not aa.known_divisions
+
+    assert eq(pd.concat([a, b], axis=1),
+              dd.concat([aa, bb], axis=1))
+
+    cc = dd.from_pandas(b, npartitions=1, sort=False)
+    with pytest.raises(ValueError):
+        dd.concat([aa, cc], axis=1)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -659,7 +659,6 @@ def test_errors_for_merge_on_frame_columns():
 
 
 def test_concat_unknown_divisions():
-    import pandas as pd
     a = pd.Series([1, 2, 3, 4])
     b = pd.Series([4, 3, 2, 1])
     aa = dd.from_pandas(a, npartitions=2, sort=False)
@@ -673,3 +672,13 @@ def test_concat_unknown_divisions():
     cc = dd.from_pandas(b, npartitions=1, sort=False)
     with pytest.raises(ValueError):
         dd.concat([aa, cc], axis=1)
+
+
+def test_concat_unknown_divisions_errors():
+    a = pd.Series([1, 2, 3, 4, 5, 6])
+    b = pd.Series([4, 3, 2, 1])
+    aa = dd.from_pandas(a, npartitions=2, sort=False)
+    bb = dd.from_pandas(b, npartitions=2, sort=False)
+
+    with pytest.raises(ValueError):
+        dd.concat([aa, bb], axis=1).compute()


### PR DESCRIPTION
We historically haven't allowed this because it isn't always safe.  It's easy to get wrong results.  At the moment this runs and raises a warning.  I think that there should be some way to opt in to this functionality if you know what you're doing is correct.  Perhaps we add a flag to concat?

cc @sinhrks 

Raised by @kumarivin in http://stackoverflow.com/questions/38627111/error-while-concatenating-dask-series-into-dataframe