### PR TITLE
DataFrame metadata cleanup

### DIFF
--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -36,7 +36,7 @@ def categorize(df, columns=None, **kwargs):
 
     func = partial(_categorize_block, categories=dict(zip(columns, values)))
 
-    meta = func(df._pd)
+    meta = func(df._meta)
     return df.map_partitions(func, meta=meta)
 
 

--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -37,7 +37,7 @@ def categorize(df, columns=None, **kwargs):
     func = partial(_categorize_block, categories=dict(zip(columns, values)))
 
     meta = func(df._pd)
-    return df.map_partitions(func, columns=meta)
+    return df.map_partitions(func, meta=meta)
 
 
 def _categorize(categories, df):

--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -27,7 +27,7 @@ def categorize(df, columns=None, **kwargs):
     if columns is None:
         dtypes = df.dtypes
         columns = [name for name, dt in zip(dtypes.index, dtypes.values)
-                    if dt == 'O']
+                   if dt == 'O']
     if not isinstance(columns, (list, tuple)):
         columns = [columns]
 
@@ -35,7 +35,9 @@ def categorize(df, columns=None, **kwargs):
     values = compute(*distincts, **kwargs)
 
     func = partial(_categorize_block, categories=dict(zip(columns, values)))
-    return df.map_partitions(func, columns=df.columns)
+
+    meta = func(df._pd)
+    return df.map_partitions(func, columns=meta)
 
 
 def _categorize(categories, df):
@@ -98,6 +100,7 @@ def strip_categories(df):
                               if iscategorical(df.index.dtype)
                               else df.index)
 
+
 def iscategorical(dt):
     return isinstance(dt, pd.core.common.CategoricalDtype)
 
@@ -116,4 +119,3 @@ def get_categories(df):
     if iscategorical(df.index.dtype):
         result['.index'] = df.index.categories
     return result
-

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -292,8 +292,8 @@ class _Frame(Base):
             instead of a dataframe, or a tuple instead of a series. If a dict,
             should be a mapping of column name to dtype. If a tuple, should be
             length 2 with name and dtype. If not provided, dask will try to
-            infer the metadata. This may take some time, and lead to unexpected
-            results, so providing `meta` is recommended.
+            infer the metadata. This may lead to unexpected results, so
+            providing `meta` is recommended.
 
         Examples
         --------
@@ -1409,8 +1409,8 @@ class Series(_Frame):
             instead of a dataframe, or a tuple instead of a series. If a dict,
             should be a mapping of column name to dtype. If a tuple, should be
             length 2 with name and dtype. If not provided, dask will try to
-            infer the metadata. This may take some time, and lead to unexpected
-            results, so providing `meta` is recommended.
+            infer the metadata. This may lead to unexpected results, so
+            providing `meta` is recommended.
         name: list, scalar or None, optional
             Deprecated, use `meta` instead. If list is given, the result is a
             DataFrame which columns is specified list. Otherwise, the result is
@@ -1444,14 +1444,9 @@ class Series(_Frame):
                 meta = _emulate(pd.Series.apply, self._meta_nonempty, func,
                                 convert_dtype=convert_dtype,
                                 args=args, **kwds)
-            except:
-                try:
-                    meta = _emulate(pd.Series.apply, self.head(), func,
-                                    convert_dtype=convert_dtype,
-                                    args=args, **kwds)
-                except:
-                    raise ValueError("Metadata inference failed, please"
-                                     "provide `meta` keyword")
+            except Exception:
+                raise ValueError("Metadata inference failed, please provide "
+                                 "`meta` keyword")
 
         return map_partitions(pd.Series.apply, meta, self, func,
                               convert_dtype, args, **kwds)
@@ -1980,8 +1975,8 @@ class DataFrame(_Frame):
             instead of a dataframe, or a tuple instead of a series. If a dict,
             should be a mapping of column name to dtype. If a tuple, should be
             length 2 with name and dtype. If not provided, dask will try to
-            infer the metadata. This may take some time, and lead to unexpected
-            results, so providing `meta` is recommended.
+            infer the metadata. This may lead to unexpected results, so
+            providing `meta` is recommended.
         columns: list, scalar or None
             Deprecated, please use `meta` instead. If list is given, the result
             is a DataFrame which columns is specified list. Otherwise, the
@@ -2022,13 +2017,9 @@ class DataFrame(_Frame):
             try:
                 meta = _emulate(pd.DataFrame.apply, self._meta_nonempty, func,
                                 axis=axis, args=args, **kwds)
-            except:
-                try:
-                    meta = _emulate(pd.DataFrame.apply, self.head(), func,
-                                    axis=axis, args=args, **kwds)
-                except:
-                    raise ValueError("Metadata inference failed, please"
-                                     "provide `meta` keyword")
+            except Exception:
+                raise ValueError("Metadata inference failed, please provide "
+                                 "`meta` keyword")
 
         return map_partitions(pd.DataFrame.apply, meta, self, func, axis,
                               False, False, None, args, **kwds)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2498,9 +2498,9 @@ def quantile(df, q):
         q = [q]
 
     if isinstance(df, Index):
-        meta = pd.Series(df._pd).quantile(q)
+        meta = pd.Series(df._pd_nonempty).quantile(q)
     else:
-        meta = df._pd.quantile(q)
+        meta = df._pd_nonempty.quantile(q)
 
     # pandas uses quantile in [0, 1]
     # numpy / everyone else uses [0, 100]

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -184,11 +184,6 @@ class _Frame(Base):
         """Return number of partitions"""
         return len(self.divisions) - 1
 
-    @classmethod
-    def _build_pd(cls, metadata):
-        """ build pandas instance from passed metadata """
-        raise NotImplementedError
-
     @property
     def _pd_nonempty(self):
         """ A non-empty version of `_pd` with fake data."""
@@ -1110,19 +1105,9 @@ class Series(_Frame):
         result = object.__new__(cls)
         result.dask = dsk
         result._name = _name
-        result._pd = cls._build_pd(meta)
+        result._pd = make_meta(meta)
         result.divisions = tuple(divisions)
         return result
-
-    @classmethod
-    def _build_pd(cls, metadata):
-        if isinstance(metadata, cls):
-            _pd = metadata._pd
-        elif isinstance(metadata, pd.Series):
-            _pd = metadata.iloc[0:0]
-        else:
-            raise ValueError("no metadata")
-        return _pd
 
     @property
     def _constructor_sliced(self):
@@ -1496,16 +1481,6 @@ class Index(Series):
     _partition_type = pd.Index
     _token_prefix = 'index-'
 
-    @classmethod
-    def _build_pd(cls, metadata):
-        if isinstance(metadata, cls):
-            _pd = metadata._pd
-        elif isinstance(metadata, pd.Index):
-            _pd = metadata[0:0]
-        else:
-            raise ValueError("no metadata")
-        return _pd
-
     @property
     def index(self):
         msg = "'{0}' object has no attribute 'index'"
@@ -1572,19 +1547,9 @@ class DataFrame(_Frame):
         result = object.__new__(cls)
         result.dask = dsk
         result._name = name
-        result._pd = cls._build_pd(meta)
+        result._pd = make_meta(meta)
         result.divisions = tuple(divisions)
         return result
-
-    @classmethod
-    def _build_pd(cls, metadata):
-        if isinstance(metadata, cls):
-            _pd = metadata._pd
-        elif isinstance(metadata, pd.DataFrame):
-            _pd = metadata.iloc[0:0]
-        else:
-            raise ValueError("no metadata")
-        return _pd
 
     @property
     def _constructor_sliced(self):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -430,6 +430,9 @@ class SeriesGroupBy(_GroupBy):
 
     def nunique(self):
         name = self._pd.obj.name
+        meta = pd.Series([], dtype='int64',
+                         index=pd.Index([], dtype=self._pd.obj.dtype),
+                         name=name)
 
         if isinstance(self.obj, DataFrame):
 
@@ -438,7 +441,7 @@ class SeriesGroupBy(_GroupBy):
 
             return aca([self.obj, self.index],
                        chunk=_nunique_df_chunk, aggregate=agg,
-                       columns=name, token='series-groupby-nunique')
+                       columns=meta, token='series-groupby-nunique')
         else:
 
             def agg(df):
@@ -446,4 +449,4 @@ class SeriesGroupBy(_GroupBy):
 
             return aca([self.obj, self.index],
                        chunk=_nunique_series_chunk, aggregate=agg,
-                       columns=name, token='series-groupby-nunique')
+                       columns=meta, token='series-groupby-nunique')

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -649,7 +649,7 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
 
     from dask.dataframe.core import no_default
 
-    return frame.map_partitions(pd.melt, no_default, id_vars=id_vars,
+    return frame.map_partitions(pd.melt, meta=no_default, id_vars=id_vars,
                                 value_vars=value_vars,
                                 var_name=var_name, value_name=value_name,
                                 col_level=col_level, token='melt')

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -468,7 +468,7 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
             left = rearrange_by_divisions(left, left_on, right.divisions,
                     max_branch, shuffle=shuffle)
             right = right.clear_divisions()
-        return map_partitions(pd.merge, meta, left, right, how=how, on=on,
+        return map_partitions(pd.merge, left, right, meta=meta, how=how, on=on,
                 left_on=left_on, right_on=right_on, left_index=left_index,
                 right_index=right_index, suffixes=suffixes)
     # Catch all hash join

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -220,10 +220,10 @@ def join_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix=''):
                           lsuffix, rsuffix)
 
     # dummy result
-    dummy = left_empty.join(right_empty, on=None, how=how,
-                            lsuffix=lsuffix, rsuffix=rsuffix)
+    meta = left_empty.join(right_empty, on=None, how=how,
+                           lsuffix=lsuffix, rsuffix=rsuffix)
     return DataFrame(toolz.merge(lhs.dask, rhs.dask, dsk),
-                     name, dummy, divisions)
+                     name, meta, divisions)
 
 
 def _pdmerge(left, right, how, left_on, right_on,
@@ -274,10 +274,10 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
         right_index = False
 
     # dummy result
-    dummy = pd.merge(lhs._pd_nonempty, rhs._pd_nonempty, how, None,
-                     left_on=left_on, right_on=right_on,
-                     left_index=left_index, right_index=right_index,
-                     suffixes=suffixes)
+    meta = pd.merge(lhs._pd_nonempty, rhs._pd_nonempty, how, None,
+                    left_on=left_on, right_on=right_on,
+                    left_index=left_index, right_index=right_index,
+                    suffixes=suffixes)
 
     merger = partial(_pdmerge, suffixes=suffixes,
                      default_left_columns=list(lhs.columns),
@@ -299,7 +299,7 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
 
     divisions = [None] * (npartitions + 1)
     return DataFrame(toolz.merge(lhs2.dask, rhs2.dask, dsk),
-                     name, dummy, divisions)
+                     name, meta, divisions)
 
 
 def single_partition_join(left, right, **kwargs):
@@ -381,7 +381,7 @@ def concat_indexed_dataframes(dfs, axis=0, join='outer'):
         raise ValueError("'join' must be 'inner' or 'outer'")
 
     from dask.dataframe.core import _emulate
-    dummy = _emulate(pd.concat, dfs, axis=axis, join=join)
+    meta = _emulate(pd.concat, dfs, axis=axis, join=join)
 
     dfs = _maybe_from_pandas(dfs)
     dfs2, divisions, parts = align_partitions(*dfs)
@@ -396,7 +396,7 @@ def concat_indexed_dataframes(dfs, axis=0, join='outer'):
                 for i, part in enumerate(parts2))
 
     return _Frame(toolz.merge(dsk, *[df.dask for df in dfs2]),
-                  name, dummy, divisions)
+                  name, meta, divisions)
 
 
 def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
@@ -456,9 +456,10 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
           right_index and right.known_divisions and not left_index):
         left_empty = left._pd_nonempty
         right_empty = right._pd_nonempty
-        dummy = pd.merge(left_empty, right_empty, how=how, on=on, left_on=left_on,
-                right_on=right_on, left_index=left_index, right_index=right_index,
-                suffixes=suffixes)
+        meta = pd.merge(left_empty, right_empty, how=how, on=on,
+                        left_on=left_on, right_on=right_on,
+                        left_index=left_index, right_index=right_index,
+                        suffixes=suffixes)
         if left_index and left.known_divisions:
             right = rearrange_by_divisions(right, right_on, left.divisions,
                     max_branch, shuffle=shuffle)
@@ -467,7 +468,7 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
             left = rearrange_by_divisions(left, left_on, right.divisions,
                     max_branch, shuffle=shuffle)
             right = right.clear_divisions()
-        return map_partitions(pd.merge, dummy, left, right, how=how, on=on,
+        return map_partitions(pd.merge, meta, left, right, how=how, on=on,
                 left_on=left_on, right_on=right_on, left_index=left_index,
                 right_index=right_index, suffixes=suffixes)
     # Catch all hash join
@@ -487,13 +488,13 @@ def _concat_dfs(dfs, name, join='outer'):
     i = 0
 
     empties = [df._pd for df in dfs]
-    dummy = pd.concat(empties, axis=0, join=join)
+    meta = pd.concat(empties, axis=0, join=join)
 
-    if isinstance(dummy, pd.Series):
+    if isinstance(meta, pd.Series):
         # in this case, input must be all Series. No need to care DataFrame.
         columns = pd.Index([])
     else:
-        columns = dummy.columns
+        columns = meta.columns
         if len(columns) == 0:
             raise ValueError('Failed to concat, no columns remain')
 
@@ -509,7 +510,7 @@ def _concat_dfs(dfs, name, join='outer'):
             dsk[(name, i)] = key
             i += 1
 
-    return dsk, dummy
+    return dsk, meta
 
 
 def concat(dfs, axis=0, join='outer', interleave_partitions=False):
@@ -604,7 +605,7 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
             if all(dfs[i].divisions[-1] < dfs[i + 1].divisions[0]
                    for i in range(len(dfs) - 1)):
                 name = 'concat-{0}'.format(tokenize(*dfs))
-                dsk, dummy = _concat_dfs(dfs, name, join=join)
+                dsk, meta = _concat_dfs(dfs, name, join=join)
 
                 divisions = []
                 for df in dfs[:-1]:
@@ -612,7 +613,7 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
                     divisions += df.divisions[:-1]
                 divisions += dfs[-1].divisions
                 return _Frame(toolz.merge(dsk, *[df.dask for df in dfs]),
-                              name, dummy, divisions)
+                              name, meta, divisions)
             else:
                 if interleave_partitions:
                     return concat_indexed_dataframes(dfs, join=join)
@@ -637,11 +638,11 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
             # concat will not regard Series as row
             dfs = _maybe_from_pandas(dfs)
             name = 'concat-{0}'.format(tokenize(*dfs))
-            dsk, dummy = _concat_dfs(dfs, name, join=join)
+            dsk, meta = _concat_dfs(dfs, name, join=join)
 
             divisions = [None] * (sum([df.npartitions for df in dfs]) + 1)
             return _Frame(toolz.merge(dsk, *[df.dask for df in dfs]),
-                          name, dummy, divisions)
+                          name, meta, divisions)
 
 
 
@@ -662,8 +663,8 @@ def _append(df, other, divisions):
     for j in range(other.npartitions):
         dsk[(name, npart + j)] = (other._name, j)
     dsk = toolz.merge(dsk, df.dask, other.dask)
-    dummy = df._pd.append(other._pd)
-    return _Frame(dsk, name, dummy, divisions)
+    meta = df._pd.append(other._pd)
+    return _Frame(dsk, name, meta, divisions)
 
 
 ###############################################################

--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -459,4 +459,4 @@ def partition_quantiles(df, npartitions, upsample=1.0, random_state=None):
                                           npartitions, (name0, 0)))}
 
     dsk = merge(df.dask, dtype_dsk, val_dsk, merge_dsk, last_dsk)
-    return return_type(dsk, name3, df._pd, new_divisions)
+    return return_type(dsk, name3, df._meta, new_divisions)

--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -459,4 +459,4 @@ def partition_quantiles(df, npartitions, upsample=1.0, random_state=None):
                                           npartitions, (name0, 0)))}
 
     dsk = merge(df.dask, dtype_dsk, val_dsk, merge_dsk, last_dsk)
-    return return_type(dsk, name3, df_name, new_divisions)
+    return return_type(dsk, name3, df._pd, new_divisions)

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -106,7 +106,7 @@ class Rolling(object):
         self.axis = axis
 
         # Allow pandas to raise if appropriate
-        obj._pd.rolling(**self._rolling_kwargs())
+        obj._meta.rolling(**self._rolling_kwargs())
 
     def _rolling_kwargs(self):
         return {
@@ -153,9 +153,9 @@ class Rolling(object):
             else:
                 # Either we are only looking backward or this was the
                 # only chunk.
-                next_partition = self.obj._pd
+                next_partition = self.obj._meta
             dsk[new_name, 0] = (call_pandas_rolling_method_with_neighbors,
-                self.obj._pd, (old_name, 0), next_partition, 0, after,
+                self.obj._meta, (old_name, 0), next_partition, 0, after,
                 self._rolling_kwargs(), method_name, args, kwargs)
 
             # All the middle chunks
@@ -178,11 +178,11 @@ class Rolling(object):
 
                 dsk[new_name, end] = (
                     call_pandas_rolling_method_with_neighbors,
-                    (tail_name, end-1), (old_name, end), self.obj._pd, before, 0,
+                    (tail_name, end-1), (old_name, end), self.obj._meta, before, 0,
                     self._rolling_kwargs(), method_name, args, kwargs)
 
         # Do the pandas operation to get the appropriate thing for metadata
-        pd_rolling = self.obj._pd.rolling(**self._rolling_kwargs())
+        pd_rolling = self.obj._meta.rolling(**self._rolling_kwargs())
         metadata = getattr(pd_rolling, method_name)(*args, **kwargs)
 
         return self.obj._constructor(

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -196,14 +196,14 @@ def rearrange_by_column_disk(df, column, npartitions=None, compute=False):
 
     # Collect groups
     name = 'shuffle-collect-' + token
-    dsk4 = {(name, i): (collect, p, i, df._pd, barrier_token)
+    dsk4 = {(name, i): (collect, p, i, df._meta, barrier_token)
                 for i in range(npartitions)}
 
     divisions = (None,) * (npartitions + 1)
 
     dsk = merge(dsk, dsk1, dsk3, dsk4)
 
-    return DataFrame(dsk, name, df._pd, divisions)
+    return DataFrame(dsk, name, df._meta, divisions)
 
 
 def rearrange_by_column_tasks(df, column, max_branch=32, npartitions=None):
@@ -235,7 +235,7 @@ def rearrange_by_column_tasks(df, column, max_branch=32, npartitions=None):
     token = tokenize(df, column, max_branch)
 
     start = dict((('shuffle-join-' + token, 0, inp),
-                  (df._name, i) if i < df.npartitions else df._pd)
+                  (df._name, i) if i < df.npartitions else df._meta)
                  for i, inp in enumerate(inputs))
 
     for stage in range(1, stages + 1):

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -203,7 +203,7 @@ def rearrange_by_column_disk(df, column, npartitions=None, compute=False):
 
     dsk = merge(dsk, dsk1, dsk3, dsk4)
 
-    return DataFrame(dsk, name, df.columns, divisions)
+    return DataFrame(dsk, name, df._pd, divisions)
 
 
 def rearrange_by_column_tasks(df, column, max_branch=32, npartitions=None):

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -87,11 +87,11 @@ def set_partition(df, index, divisions, max_branch=32, drop=True, shuffle=None,
     """
     if np.isscalar(index):
         partitions = df[index].map_partitions(set_partitions_pre,
-                divisions=divisions, columns=pd.Series([0]))
+                divisions=divisions, meta=pd.Series([0]))
         df2 = df.assign(_partitions=partitions)
     else:
         partitions = index.map_partitions(set_partitions_pre,
-                divisions=divisions, columns=pd.Series([0]))
+                divisions=divisions, meta=pd.Series([0]))
         df2 = df.assign(_partitions=partitions, _index=index)
 
     df3 = rearrange_by_column(df2, '_partitions', max_branch=max_branch,
@@ -132,7 +132,7 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32,
         index = df[index]
     partitions = index.map_partitions(partitioning_index,
                                       npartitions=npartitions or df.npartitions,
-                                      columns=pd.Series([0]))
+                                      meta=pd.Series([0]))
     df2 = df.assign(_partitions=partitions)
     df3 = rearrange_by_column(df2, '_partitions', npartitions=npartitions,
                               max_branch=max_branch, shuffle=shuffle,
@@ -145,7 +145,7 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32,
 def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None):
     """ Shuffle dataframe so that column separates along divisions """
     partitions = df[column].map_partitions(set_partitions_pre,
-                divisions=divisions, columns=pd.Series([0]))
+                divisions=divisions, meta=pd.Series([0]))
     df2 = df.assign(_partitions=partitions)
     df3 = rearrange_by_column(df2, '_partitions', max_branch=max_branch,
                               npartitions=len(divisions) - 1, shuffle=shuffle)

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from dask.utils import raises
 import dask.dataframe as dd
-from dask.dataframe.utils import eq, assert_dask_graph, make_empty_frame
+from dask.dataframe.utils import eq, assert_dask_graph, make_meta
 
 
 @pytest.mark.slow
@@ -17,7 +17,7 @@ def test_arithmetics():
                                   index=[5, 6, 8]),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
                                   index=[9, 9, 9])}
-    meta = make_empty_frame({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+    meta = make_meta({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
     ddf1 = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
@@ -576,7 +576,7 @@ def test_reductions():
                                   index=[5, 6, 8]),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
                                   index=[9, 9, 9])}
-    meta = make_empty_frame({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+    meta = make_meta({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
     ddf1 = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
@@ -641,7 +641,7 @@ def test_reduction_series_invalid_axis():
                                   index=[5, 6, 8]),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
                                   index=[9, 9, 9])}
-    meta = make_empty_frame({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+    meta = make_meta({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
     ddf1 = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
@@ -717,7 +717,7 @@ def test_reductions_frame():
                                   index=[5, 6, 8]),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
                                   index=[9, 9, 9])}
-    meta = make_empty_frame({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+    meta = make_meta({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
     ddf1 = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from dask.utils import raises
 import dask.dataframe as dd
-from dask.dataframe.utils import eq, assert_dask_graph
+from dask.dataframe.utils import eq, assert_dask_graph, make_empty_frame
 
 
 @pytest.mark.slow
@@ -17,7 +17,8 @@ def test_arithmetics():
                                   index=[5, 6, 8]),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
                                   index=[9, 9, 9])}
-    ddf1 = dd.DataFrame(dsk, 'x', ['a', 'b'], [0, 4, 9, 9])
+    meta = make_empty_frame({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+    ddf1 = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
     pdf2 = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8],
@@ -33,7 +34,7 @@ def test_arithmetics():
                                    index=[5, 6, 8]),
             ('y', 2): pd.DataFrame({'a': [1, 4, 10], 'b': [1, 0, 5]},
                                    index=[9, 9, 9])}
-    ddf4 = dd.DataFrame(dsk4, 'y', ['a', 'b'], [0, 4, 9, 9])
+    ddf4 = dd.DataFrame(dsk4, 'y', meta, [0, 4, 9, 9])
     pdf4 = ddf4.compute()
 
     # Arithmetics
@@ -575,7 +576,8 @@ def test_reductions():
                                   index=[5, 6, 8]),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
                                   index=[9, 9, 9])}
-    ddf1 = dd.DataFrame(dsk, 'x', ['a', 'b'], [0, 4, 9, 9])
+    meta = make_empty_frame({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+    ddf1 = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
     nans1 = pd.Series([1] + [np.nan] * 4 + [2] + [np.nan] * 3)
@@ -639,7 +641,8 @@ def test_reduction_series_invalid_axis():
                                   index=[5, 6, 8]),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
                                   index=[9, 9, 9])}
-    ddf1 = dd.DataFrame(dsk, 'x', ['a', 'b'], [0, 4, 9, 9])
+    meta = make_empty_frame({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+    ddf1 = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
     for axis in [1, 'columns']:
@@ -714,7 +717,8 @@ def test_reductions_frame():
                                   index=[5, 6, 8]),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
                                   index=[9, 9, 9])}
-    ddf1 = dd.DataFrame(dsk, 'x', ['a', 'b'], [0, 4, 9, 9])
+    meta = make_empty_frame({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+    ddf1 = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
     assert eq(ddf1.sum(), pdf1.sum())
@@ -783,14 +787,6 @@ def test_reductions_frame_dtypes():
 
     numerics = ddf[['int', 'float']]
     assert numerics._get_numeric_data().dask == numerics.dask
-
-
-def test_get_numeric_data_unknown_part():
-    df = pd.DataFrame({'a': range(5), 'b': range(5), 'c': list('abcde')})
-    ddf = dd.from_pandas(df, 3)
-    # Drop dtype information
-    ddf = dd.DataFrame(ddf.dask, ddf._name, ['a', 'b', 'c'], ddf.divisions)
-    assert eq(ddf._get_numeric_data(), df._get_numeric_data())
 
 
 def test_reductions_frame_nan():

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -5,7 +5,7 @@ import pytest
 import dask
 from dask.async import get_sync
 import dask.dataframe as dd
-from dask.dataframe.utils import make_empty_frame
+from dask.dataframe.utils import make_meta
 
 
 def test_categorize():
@@ -15,7 +15,7 @@ def test_categorize():
            ('x', 1): pd.DataFrame({'a': ['Bob', 'Charlie', 'Charlie'],
                                    'b': ['A', 'A', 'B']},
                                   index=[3, 4, 5])}
-    meta = make_empty_frame({'a': 'O', 'b': 'O'}, index=pd.Index([], 'i8'))
+    meta = make_meta({'a': 'O', 'b': 'O'}, index=pd.Index([], 'i8'))
     d = dd.DataFrame(dsk, 'x', meta, [0, 3, 5])
     full = d.compute()
 

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -5,6 +5,7 @@ import pytest
 import dask
 from dask.async import get_sync
 import dask.dataframe as dd
+from dask.dataframe.utils import make_empty_frame
 
 
 def test_categorize():
@@ -14,7 +15,8 @@ def test_categorize():
            ('x', 1): pd.DataFrame({'a': ['Bob', 'Charlie', 'Charlie'],
                                    'b': ['A', 'A', 'B']},
                                   index=[3, 4, 5])}
-    d = dd.DataFrame(dsk, 'x', ['a', 'b'], [0, 3, 5])
+    meta = make_empty_frame({'a': 'O', 'b': 'O'}, index=pd.Index([], 'i8'))
+    d = dd.DataFrame(dsk, 'x', meta, [0, 3, 5])
     full = d.compute()
 
     c = d.categorize('a')

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -12,7 +12,7 @@ import dask.dataframe as dd
 
 from dask.dataframe.core import (repartition_divisions, _loc,
         _coerce_loc_index, aca, reduction, _concat, _Frame)
-from dask.dataframe.utils import eq, make_empty_frame
+from dask.dataframe.utils import eq, make_meta
 
 
 dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]},
@@ -21,7 +21,7 @@ dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]},
                               index=[5, 6, 8]),
        ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
                               index=[9, 9, 9])}
-meta = make_empty_frame({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+meta = make_meta({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
 d = dd.DataFrame(dsk, 'x', meta, [0, 5, 9, 9])
 full = d.compute()
 
@@ -739,7 +739,7 @@ def test_unknown_divisions():
     dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]}),
            ('x', 1): pd.DataFrame({'a': [4, 5, 6], 'b': [3, 2, 1]}),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]})}
-    meta = make_empty_frame({'a': 'i8', 'b': 'i8'})
+    meta = make_meta({'a': 'i8', 'b': 'i8'})
     d = dd.DataFrame(dsk, 'x', meta, [None, None, None, None])
     full = d.compute(get=dask.get)
 
@@ -751,7 +751,7 @@ def test_concat2():
     dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]}),
            ('x', 1): pd.DataFrame({'a': [4, 5, 6], 'b': [3, 2, 1]}),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]})}
-    meta = make_empty_frame({'a': 'i8', 'b': 'i8'})
+    meta = make_meta({'a': 'i8', 'b': 'i8'})
     a = dd.DataFrame(dsk, 'x', meta, [None, None])
     dsk = {('y', 0): pd.DataFrame({'a': [10, 20, 30], 'b': [40, 50, 60]}),
            ('y', 1): pd.DataFrame({'a': [40, 50, 60], 'b': [30, 20, 10]}),
@@ -760,7 +760,7 @@ def test_concat2():
 
     dsk = {('y', 0): pd.DataFrame({'b': [10, 20, 30], 'c': [40, 50, 60]}),
            ('y', 1): pd.DataFrame({'b': [40, 50, 60], 'c': [30, 20, 10]})}
-    meta = make_empty_frame({'b': 'i8', 'c': 'i8'})
+    meta = make_meta({'b': 'i8', 'c': 'i8'})
     c = dd.DataFrame(dsk, 'y', meta, [None, None])
 
     dsk = {('y', 0): pd.DataFrame({'b': [10, 20, 30], 'c': [40, 50, 60],
@@ -768,7 +768,7 @@ def test_concat2():
            ('y', 1): pd.DataFrame({'b': [40, 50, 60], 'c': [30, 20, 10],
                                    'd': [90, 80, 70]},
                                   index=[3, 4, 5])}
-    meta = make_empty_frame({'b': 'i8', 'c': 'i8', 'd': 'i8'},
+    meta = make_meta({'b': 'i8', 'c': 'i8', 'd': 'i8'},
                             index=pd.Index([], 'i8'))
     d = dd.DataFrame(dsk, 'y', meta, [0, 3, 5])
 
@@ -963,7 +963,7 @@ def test_append2():
     dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]}),
            ('x', 1): pd.DataFrame({'a': [4, 5, 6], 'b': [3, 2, 1]}),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]})}
-    meta = make_empty_frame({'a': 'i8', 'b': 'i8'})
+    meta = make_meta({'a': 'i8', 'b': 'i8'})
     ddf1 = dd.DataFrame(dsk, 'x', meta, [None, None])
 
     dsk = {('y', 0): pd.DataFrame({'a': [10, 20, 30], 'b': [40, 50, 60]}),
@@ -973,7 +973,7 @@ def test_append2():
 
     dsk = {('y', 0): pd.DataFrame({'b': [10, 20, 30], 'c': [40, 50, 60]}),
            ('y', 1): pd.DataFrame({'b': [40, 50, 60], 'c': [30, 20, 10]})}
-    meta = make_empty_frame({'b': 'i8', 'c': 'i8'})
+    meta = make_meta({'b': 'i8', 'c': 'i8'})
     ddf3 = dd.DataFrame(dsk, 'y', meta, [None, None])
 
     assert eq(ddf1.append(ddf2), ddf1.compute().append(ddf2.compute()))
@@ -1259,7 +1259,7 @@ def test_str_accessor():
 
 
 def test_empty_max():
-    meta = make_empty_frame({'x': 'i8'})
+    meta = make_meta({'x': 'i8'})
     a = dd.DataFrame({('x', 0): pd.DataFrame({'x': [1]}),
                       ('x', 1): pd.DataFrame({'x': []})}, 'x',
                       meta, [None, None, None])

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -279,7 +279,7 @@ def test_rename_columns():
     ddf.columns = ['x', 'y']
     df.columns = ['x', 'y']
     tm.assert_index_equal(ddf.columns, pd.Index(['x', 'y']))
-    tm.assert_index_equal(ddf._pd.columns, pd.Index(['x', 'y']))
+    tm.assert_index_equal(ddf._meta.columns, pd.Index(['x', 'y']))
     assert eq(ddf, df)
 
     msg = r"Length mismatch: Expected axis has 2 elements, new values have 4 elements"
@@ -1370,10 +1370,10 @@ def test_deterministic_apply_concat_apply_names():
     # Test aca without passing in token string
     f = lambda a: a.nlargest(5)
     f2 = lambda a: a.nlargest(3)
-    assert (sorted(aca(a.x, f, f, a.x._pd).dask) !=
-            sorted(aca(a.x, f2, f2, a.x._pd).dask))
-    assert (sorted(aca(a.x, f, f, a.x._pd).dask) ==
-            sorted(aca(a.x, f, f, a.x._pd).dask))
+    assert (sorted(aca(a.x, f, f, a.x._meta).dask) !=
+            sorted(aca(a.x, f2, f2, a.x._meta).dask))
+    assert (sorted(aca(a.x, f, f, a.x._meta).dask) ==
+            sorted(aca(a.x, f, f, a.x._meta).dask))
 
 
 def test_gh_517():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1699,12 +1699,6 @@ def test_timeseries_sorted():
        df)
 
 
-def test_build_pd():
-    s = dd.Series._build_pd(pd.NaT)
-    assert isinstance(s, pd.Series)
-    assert np.issubdtype(s.dtype, np.datetime64)
-
-
 def test_column_assignment():
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [1, 0, 1, 0]})
     ddf = dd.from_pandas(df, npartitions=2)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -16,14 +16,14 @@ def groupby_internal_repr():
     gp = pdf.groupby('y')
     dp = ddf.groupby('y')
     assert isinstance(dp, dd.groupby.DataFrameGroupBy)
-    assert isinstance(dp._pd, pd.core.groupby.DataFrameGroupBy)
+    assert isinstance(dp._meta, pd.core.groupby.DataFrameGroupBy)
     assert isinstance(dp.obj, dd.DataFrame)
     assert eq(dp.obj, gp.obj)
 
     gp = pdf.groupby('y')['x']
     dp = ddf.groupby('y')['x']
     assert isinstance(dp, dd.groupby.SeriesGroupBy)
-    assert isinstance(dp._pd, pd.core.groupby.SeriesGroupBy)
+    assert isinstance(dp._meta, pd.core.groupby.SeriesGroupBy)
     # slicing should not affect to internal
     assert isinstance(dp.obj, dd.Series)
     assert eq(dp.obj, gp.obj)
@@ -31,7 +31,7 @@ def groupby_internal_repr():
     gp = pdf.groupby('y')[['x']]
     dp = ddf.groupby('y')[['x']]
     assert isinstance(dp, dd.groupby.DataFrameGroupBy)
-    assert isinstance(dp._pd, pd.core.groupby.DataFrameGroupBy)
+    assert isinstance(dp._meta, pd.core.groupby.DataFrameGroupBy)
     # slicing should not affect to internal
     assert isinstance(dp.obj, dd.DataFrame)
     assert eq(dp.obj, gp.obj)
@@ -39,7 +39,7 @@ def groupby_internal_repr():
     gp = pdf.groupby(pdf.y)['x']
     dp = ddf.groupby(ddf.y)['x']
     assert isinstance(dp, dd.groupby.SeriesGroupBy)
-    assert isinstance(dp._pd, pd.core.groupby.SeriesGroupBy)
+    assert isinstance(dp._meta, pd.core.groupby.SeriesGroupBy)
     # slicing should not affect to internal
     assert isinstance(dp.obj, dd.Series)
     assert eq(dp.obj, gp.obj)
@@ -47,7 +47,7 @@ def groupby_internal_repr():
     gp = pdf.groupby(pdf.y)[['x']]
     dp = ddf.groupby(ddf.y)[['x']]
     assert isinstance(dp, dd.groupby.DataFrameGroupBy)
-    assert isinstance(dp._pd, pd.core.groupby.DataFrameGroupBy)
+    assert isinstance(dp._meta, pd.core.groupby.DataFrameGroupBy)
     # slicing should not affect to internal
     assert isinstance(dp.obj, dd.DataFrame)
     assert eq(dp.obj, gp.obj)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -186,7 +186,8 @@ def test_groupby_get_group():
                                   index=[5, 6, 8]),
            ('x', 2): pd.DataFrame({'a': [4, 3, 7], 'b': [1, 1, 3]},
                                   index=[9, 9, 9])}
-    d = dd.DataFrame(dsk, 'x', ['a', 'b'], [0, 4, 9, 9])
+    meta = dsk[('x', 0)]
+    d = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
     full = d.compute()
 
     for ddkey, pdkey in [('b', 'b'), (d.b, full.b),

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -225,7 +225,7 @@ def test_series_groupby_propagates_names():
     ddf = dd.from_pandas(df, 2)
     func = lambda df: df['y'].sum()
 
-    result = ddf.groupby('x').apply(func, columns='y')
+    result = ddf.groupby('x').apply(func, meta=('y', 'i8'))
 
     expected = df.groupby('x').apply(func)
     expected.name = 'y'

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -8,7 +8,7 @@ from dask.utils import raises
 import dask.dataframe as dd
 
 from dask.dataframe.core import _coerce_loc_index
-from dask.dataframe.utils import eq
+from dask.dataframe.utils import eq, make_meta
 
 
 dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]},
@@ -17,7 +17,8 @@ dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]},
                               index=[5, 6, 8]),
        ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
                               index=[9, 9, 9])}
-d = dd.DataFrame(dsk, 'x', ['a', 'b'], [0, 5, 9, 9])
+meta = make_meta({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+d = dd.DataFrame(dsk, 'x', meta, [0, 5, 9, 9])
 full = d.compute()
 
 
@@ -63,7 +64,7 @@ def test_loc_non_informative_index():
 def test_loc_with_text_dates():
     A = tm.makeTimeSeries(10).iloc[:5]
     B = tm.makeTimeSeries(10).iloc[5:]
-    s = dd.Series({('df', 0): A, ('df', 1): B}, 'df', None,
+    s = dd.Series({('df', 0): A, ('df', 1): B}, 'df', A,
                   [A.index.min(), B.index.min(), B.index.max()])
 
     assert s.loc['2000': '2010'].divisions == s.divisions

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -87,13 +87,13 @@ def test_getitem():
     ddf = dd.from_pandas(df, 2)
     assert eq(ddf['A'], df['A'])
     # check cache consistency
-    tm.assert_series_equal(ddf['A']._pd, ddf._pd['A'])
+    tm.assert_series_equal(ddf['A']._meta, ddf._meta['A'])
 
     assert eq(ddf[['A', 'B']], df[['A', 'B']])
-    tm.assert_frame_equal(ddf[['A', 'B']]._pd, ddf._pd[['A', 'B']])
+    tm.assert_frame_equal(ddf[['A', 'B']]._meta, ddf._meta[['A', 'B']])
 
     assert eq(ddf[ddf.C], df[df.C])
-    tm.assert_series_equal(ddf.C._pd, ddf._pd.C)
+    tm.assert_series_equal(ddf.C._meta, ddf._meta.C)
 
     assert eq(ddf[ddf.C.repartition([0, 2, 5, 8])], df[df.C])
 

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -130,23 +130,23 @@ def test_usecols():
 ####################
 
 
-def test_dummy_from_array():
+def test_meta_from_array():
     x = np.array([[1, 2], [3, 4]], dtype=np.int64)
-    res = dd.io._dummy_from_array(x)
+    res = dd.io._meta_from_array(x)
     assert isinstance(res, pd.DataFrame)
     assert res[0].dtype == np.int64
     assert res[1].dtype == np.int64
     tm.assert_index_equal(res.columns, pd.Index([0, 1]))
 
     x = np.array([[1., 2.], [3., 4.]], dtype=np.float64)
-    res = dd.io._dummy_from_array(x, columns=['a', 'b'])
+    res = dd.io._meta_from_array(x, columns=['a', 'b'])
     assert isinstance(res, pd.DataFrame)
     assert res['a'].dtype == np.float64
     assert res['b'].dtype == np.float64
     tm.assert_index_equal(res.columns, pd.Index(['a', 'b']))
 
     with pytest.raises(ValueError):
-        dd.io._dummy_from_array(x, columns=['a', 'b', 'c'])
+        dd.io._meta_from_array(x, columns=['a', 'b', 'c'])
 
     np.random.seed(42)
     x = np.random.rand(201, 2)
@@ -154,45 +154,45 @@ def test_dummy_from_array():
     assert len(x.divisions) == 6 # Should be 5 partitions and the end
 
 
-def test_dummy_from_1darray():
+def test_meta_from_1darray():
     x = np.array([1., 2., 3.], dtype=np.float64)
-    res = dd.io._dummy_from_array(x)
+    res = dd.io._meta_from_array(x)
     assert isinstance(res, pd.Series)
     assert res.dtype == np.float64
 
     x = np.array([1, 2, 3], dtype=np.object_)
-    res = dd.io._dummy_from_array(x, columns='x')
+    res = dd.io._meta_from_array(x, columns='x')
     assert isinstance(res, pd.Series)
     assert res.name == 'x'
     assert res.dtype == np.object_
 
     x = np.array([1, 2, 3], dtype=np.object_)
-    res = dd.io._dummy_from_array(x, columns=['x'])
+    res = dd.io._meta_from_array(x, columns=['x'])
     assert isinstance(res, pd.DataFrame)
     assert res['x'].dtype == np.object_
     tm.assert_index_equal(res.columns, pd.Index(['x']))
 
     with pytest.raises(ValueError):
-        dd.io._dummy_from_array(x, columns=['a', 'b'])
+        dd.io._meta_from_array(x, columns=['a', 'b'])
 
 
-def test_dummy_from_recarray():
+def test_meta_from_recarray():
     x = np.array([(i, i*10) for i in range(10)],
                  dtype=[('a', np.float64), ('b', np.int64)])
-    res = dd.io._dummy_from_array(x)
+    res = dd.io._meta_from_array(x)
     assert isinstance(res, pd.DataFrame)
     assert res['a'].dtype == np.float64
     assert res['b'].dtype == np.int64
     tm.assert_index_equal(res.columns, pd.Index(['a', 'b']))
 
-    res = dd.io._dummy_from_array(x, columns=['b', 'a'])
+    res = dd.io._meta_from_array(x, columns=['b', 'a'])
     assert isinstance(res, pd.DataFrame)
     assert res['a'].dtype == np.float64
     assert res['b'].dtype == np.int64
     tm.assert_index_equal(res.columns, pd.Index(['b', 'a']))
 
     with pytest.raises(ValueError):
-        dd.io._dummy_from_array(x, columns=['a', 'b', 'c'])
+        dd.io._meta_from_array(x, columns=['a', 'b', 'c'])
 
 
 def test_from_array():

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -144,8 +144,7 @@ def test_dummy_from_array():
     assert res['b'].dtype == np.float64
     tm.assert_index_equal(res.columns, pd.Index(['a', 'b']))
 
-    msg = r"""Length mismatch: Expected axis has 2 elements, new values have 3 elements"""
-    with tm.assertRaisesRegexp(ValueError, msg):
+    with pytest.raises(ValueError):
         dd.io._dummy_from_array(x, columns=['a', 'b', 'c'])
 
     np.random.seed(42)
@@ -172,8 +171,7 @@ def test_dummy_from_1darray():
     assert res['x'].dtype == np.object_
     tm.assert_index_equal(res.columns, pd.Index(['x']))
 
-    msg = r"""Length mismatch: Expected axis has 1 elements, new values have 2 elements"""
-    with tm.assertRaisesRegexp(ValueError, msg):
+    with pytest.raises(ValueError):
         dd.io._dummy_from_array(x, columns=['a', 'b'])
 
 
@@ -186,14 +184,13 @@ def test_dummy_from_recarray():
     assert res['b'].dtype == np.int64
     tm.assert_index_equal(res.columns, pd.Index(['a', 'b']))
 
-    res = dd.io._dummy_from_array(x, columns=['x', 'y'])
+    res = dd.io._dummy_from_array(x, columns=['b', 'a'])
     assert isinstance(res, pd.DataFrame)
-    assert res['x'].dtype == np.float64
-    assert res['y'].dtype == np.int64
-    tm.assert_index_equal(res.columns, pd.Index(['x', 'y']))
+    assert res['a'].dtype == np.float64
+    assert res['b'].dtype == np.int64
+    tm.assert_index_equal(res.columns, pd.Index(['b', 'a']))
 
-    msg = r"""Length mismatch: Expected axis has 2 elements, new values have 3 elements"""
-    with tm.assertRaisesRegexp(ValueError, msg):
+    with pytest.raises(ValueError):
         dd.io._dummy_from_array(x, columns=['a', 'b', 'c'])
 
 
@@ -514,11 +511,10 @@ def test_Series_from_dask_array():
 def test_from_dask_array_compat_numpy_array():
     x = da.ones((3, 3, 3), chunks=2)
 
-    msg = r"from_array does not input more than 2D array, got array with shape \(3, 3, 3\)"
-    with tm.assertRaisesRegexp(ValueError, msg):
+    with pytest.raises(ValueError):
         from_dask_array(x)       # dask
 
-    with tm.assertRaisesRegexp(ValueError, msg):
+    with pytest.raises(ValueError):
         from_array(x.compute())  # numpy
 
     x = da.ones((10, 3), chunks=(3, 3))
@@ -532,11 +528,10 @@ def test_from_dask_array_compat_numpy_array():
     assert (d2.compute().values == x.compute()).all()
     tm.assert_index_equal(d2.columns, pd.Index([0, 1, 2]))
 
-    msg = r"""Length mismatch: Expected axis has 3 elements, new values have 1 elements"""
-    with tm.assertRaisesRegexp(ValueError, msg):
+    with pytest.raises(ValueError):
         from_dask_array(x, columns=['a'])       # dask
 
-    with tm.assertRaisesRegexp(ValueError, msg):
+    with pytest.raises(ValueError):
         from_array(x.compute(), columns=['a'])  # numpy
 
     d1 = from_dask_array(x, columns=['a', 'b', 'c'])       # dask

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -591,6 +591,7 @@ def test_from_dask_array_struct_dtype():
               pd.DataFrame(x, columns=['b', 'a']))
 
 
+@pytest.mark.xfail(reason="from_castra inference in castra broken")
 def test_to_castra():
     pytest.importorskip('castra')
     blosc = pytest.importorskip('blosc')
@@ -638,6 +639,8 @@ def test_to_castra():
         c1.drop()
         c2.drop()
 
+
+@pytest.mark.xfail(reason="from_castra inference in castra broken")
 def test_from_castra():
     pytest.importorskip('castra')
     blosc = pytest.importorskip('blosc')
@@ -662,6 +665,7 @@ def test_from_castra():
         del with_fn, c
 
 
+@pytest.mark.xfail(reason="from_castra inference in castra broken")
 def test_from_castra_with_selection():
     """ Optimizations fuse getitems with load_partitions
 

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -49,7 +49,6 @@ def test_read_csv():
     with filetext(text) as fn:
         f = dd.read_csv(fn, chunkbytes=30, lineterminator=os.linesep)
         assert list(f.columns) == ['name', 'amount']
-        assert f._known_dtype
         result = f.compute(get=dask.get)
         # index may be different
         assert eq(result.reset_index(drop=True),
@@ -63,7 +62,6 @@ def test_read_multiple_csv():
         with open('_foo.2.csv', 'w') as f:
             f.write(text)
         df = dd.read_csv('_foo.*.csv', chunkbytes=30)
-        assert df._known_dtype
         assert df.npartitions > 2
 
         assert (len(dd.read_csv('_foo.*.csv').compute()) ==
@@ -92,7 +90,6 @@ def test_consistent_dtypes():
     with filetext(text) as fn:
         df = dd.read_csv(fn, chunkbytes=30)
         assert isinstance(df.amount.sum().compute(), float)
-        assert df._known_dtype
 
 datetime_csv_file = """
 name,amount,when
@@ -106,7 +103,6 @@ Dan,400,2014-01-01
 def test_read_csv_index():
     with filetext(text) as fn:
         f = dd.read_csv(fn, chunkbytes=20).set_index('amount')
-        assert f._known_dtype
         result = f.compute(get=get_sync)
         assert result.index.name == 'amount'
 
@@ -205,14 +201,12 @@ def test_from_array():
     x = np.arange(10 * 3).reshape(10, 3)
     d = dd.from_array(x, chunksize=4)
     assert isinstance(d, dd.DataFrame)
-    assert d._known_dtype
     tm.assert_index_equal(d.columns, pd.Index([0, 1, 2]))
     assert d.divisions == (0, 4, 8, 9)
     assert (d.compute().values == x).all()
 
     d = dd.from_array(x, chunksize=4, columns=list('abc'))
     assert isinstance(d, dd.DataFrame)
-    assert d._known_dtype
     tm.assert_index_equal(d.columns, pd.Index(['a', 'b', 'c']))
     assert d.divisions == (0, 4, 8, 9)
     assert (d.compute().values == x).all()
@@ -226,7 +220,6 @@ def test_from_array_with_record_dtype():
                  dtype=[('a', 'i4'), ('b', 'i4')])
     d = dd.from_array(x, chunksize=4)
     assert isinstance(d, dd.DataFrame)
-    assert d._known_dtype
     assert list(d.columns) == ['a', 'b']
     assert d.divisions == (0, 4, 8, 9)
 
@@ -271,7 +264,6 @@ def test_from_bcolz():
     t = bcolz.ctable([[1, 2, 3], [1., 2., 3.], ['a', 'b', 'a']],
                      names=['x', 'y', 'a'])
     d = dd.from_bcolz(t, chunksize=2)
-    assert d._known_dtype
     assert d.npartitions == 2
     assert str(d.dtypes['a']) == 'category'
     assert list(d.x.compute(get=get_sync)) == [1, 2, 3]
@@ -1096,7 +1088,6 @@ def test_read_hdf():
         df.to_hdf(fn, '/data', format='table')
         a = dd.read_hdf(fn, '/data', chunksize=2)
         assert a.npartitions == 2
-        assert a._known_dtype
 
         tm.assert_frame_equal(a.compute(), df)
 

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -36,6 +36,7 @@ def test_column_optimizations_with_bcolz_and_rewrite():
         assert result == expected
 
 
+@pytest.mark.xfail(reason="from_castra inference in castra broken")
 def test_castra_column_store():
     castra = pytest.importorskip('castra')
     blosc = pytest.importorskip('blosc')

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -7,7 +7,7 @@ import dask.dataframe as dd
 from dask.dataframe.shuffle import (shuffle, hash_series, partitioning_index,
         rearrange_by_column, rearrange_by_divisions)
 from dask.async import get_sync
-from dask.dataframe.utils import eq
+from dask.dataframe.utils import eq, make_meta
 
 dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [1, 4, 7]},
                               index=[0, 1, 3]),
@@ -15,7 +15,8 @@ dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [1, 4, 7]},
                               index=[5, 6, 8]),
        ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [3, 6, 9]},
                               index=[9, 9, 9])}
-d = dd.DataFrame(dsk, 'x', ['a', 'b'], [0, 4, 9, 9])
+meta = make_meta({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+d = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
 full = d.compute()
 
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from dask.dataframe.utils import shard_df_on_index, nonempty_sample_df
+from dask.dataframe.utils import shard_df_on_index, nonempty_pd
 
 
 def test_shard_df_on_index():
@@ -13,7 +13,7 @@ def test_shard_df_on_index():
     assert list(result[2].index) == [50, 60]
 
 
-def test_nonempty_sample_df():
+def test_nonempty_pd():
     df1 = pd.DataFrame({'A': pd.Categorical(['Alice', 'Bob', 'Carol']),
                         'B': list('abc'),
                         'C': 'bar',
@@ -25,7 +25,7 @@ def test_nonempty_sample_df():
                         'H': np.void(b' ')},
                        columns=list('DCBAHGFE'))
     df2 = df1.iloc[0:0]
-    df3 = nonempty_sample_df(df2)
+    df3 = nonempty_pd(df2)
     assert df3['A'][0] == 'Alice'
     assert df3['B'][0] == 'foo'
     assert df3['C'][0] == 'foo'
@@ -35,3 +35,60 @@ def test_nonempty_sample_df():
                                        tz='America/New_York')
     assert df3['G'][0] == pd.Timedelta('1 days')
     assert df3['H'][0] == 'foo'
+
+    s = nonempty_pd(df2['A'])
+    assert (df3['A'] == s).all()
+
+
+def test_nonempty_pd_index():
+    idx = pd.RangeIndex(1, name='foo')
+    res = nonempty_pd(idx)
+    assert type(res) is pd.RangeIndex
+    assert res.name == idx.name
+
+    idx = pd.Int64Index([1], name='foo')
+    res = nonempty_pd(idx)
+    assert type(res) is pd.Int64Index
+    assert res.name == idx.name
+
+    idx = pd.Index(['a'], name='foo')
+    res = nonempty_pd(idx)
+    assert type(res) is pd.Index
+    assert res.name == idx.name
+
+    idx = pd.DatetimeIndex(['1970-01-01'], freq='d',
+                           tz='America/New_York', name='foo')
+    res = nonempty_pd(idx)
+    assert type(res) is pd.DatetimeIndex
+    assert res.tz == idx.tz
+    assert res.freq == idx.freq
+    assert res.name == idx.name
+
+    idx = pd.PeriodIndex(['1970-01-01'], freq='d', name='foo')
+    res = nonempty_pd(idx)
+    assert type(res) is pd.PeriodIndex
+    assert res.freq == idx.freq
+    assert res.name == idx.name
+
+    idx = pd.TimedeltaIndex([np.timedelta64(1, 'D')], freq='d', name='foo')
+    res = nonempty_pd(idx)
+    assert type(res) is pd.TimedeltaIndex
+    assert res.freq == idx.freq
+    assert res.name == idx.name
+
+    idx = pd.CategoricalIndex(['a'], ['a', 'b'], ordered=True, name='foo')
+    res = nonempty_pd(idx)
+    assert type(res) is pd.CategoricalIndex
+    assert (res.categories == idx.categories).all()
+    assert res.ordered == idx.ordered
+    assert res.name == idx.name
+
+    levels = [pd.Int64Index([1], name='a'),
+              pd.Float64Index([1.0], name='b')]
+    idx = pd.MultiIndex(levels=levels, labels=[[0], [0]], names=['a', 'b'])
+    res = nonempty_pd(idx)
+    assert type(res) is pd.MultiIndex
+    for idx1, idx2 in zip(idx.levels, res.levels):
+        assert type(idx1) is type(idx2)
+        assert idx1.name == idx2.name
+    assert res.names == idx.names

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -109,7 +109,7 @@ class Resampler(object):
                               rule, kwargs, how, fill_value)
 
         # Infer output metadata
-        meta_r = self.obj._pd_nonempty.resample(self._rule, **self._kwargs)
+        meta_r = self.obj._meta_nonempty.resample(self._rule, **self._kwargs)
         meta = getattr(meta_r, how)()
 
         if isinstance(meta, pd.DataFrame):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -120,8 +120,8 @@ def make_meta(meta, index=None):
     >>> make_meta(('a', 'f8'))
     Series([], Name: a, dtype: float64)
     """
-    if hasattr(meta, '_pd'):
-        return meta._pd
+    if hasattr(meta, '_meta'):
+        return meta._meta
     if isinstance(meta, (pd.Series, pd.DataFrame)):
         return meta.iloc[0:0]
     elif isinstance(meta, pd.Index):
@@ -207,7 +207,7 @@ def _nonempty_series(s, idx):
     return pd.Series([entry, entry], name=s.name, index=idx)
 
 
-def nonempty_pd(x):
+def meta_nonempty(x):
     """Create a nonempty pandas object from the given metadata.
 
     Returns a pandas DataFrame, Series, or Index that contains two rows
@@ -241,9 +241,9 @@ def _check_dask(dsk, check_names=True, check_dtypes=True):
             if check_names:
                 assert dsk.name == result.name
             # cache
-            assert isinstance(dsk._pd, pd.Index), type(dsk._pd)
+            assert isinstance(dsk._meta, pd.Index), type(dsk._meta)
             if check_names:
-                assert dsk._pd.name == result.name
+                assert dsk._meta.name == result.name
             if check_dtypes:
                 assert_dask_dtypes(dsk, result)
         elif isinstance(dsk, dd.Series):
@@ -251,9 +251,9 @@ def _check_dask(dsk, check_names=True, check_dtypes=True):
             if check_names:
                 assert dsk.name == result.name, (dsk.name, result.name)
             # cache
-            assert isinstance(dsk._pd, pd.Series), type(dsk._pd)
+            assert isinstance(dsk._meta, pd.Series), type(dsk._meta)
             if check_names:
-                assert dsk._pd.name == result.name
+                assert dsk._meta.name == result.name
             if check_dtypes:
                 assert_dask_dtypes(dsk, result)
         elif isinstance(dsk, dd.DataFrame):
@@ -262,9 +262,9 @@ def _check_dask(dsk, check_names=True, check_dtypes=True):
             if check_names:
                 tm.assert_index_equal(dsk.columns, result.columns)
             # cache
-            assert isinstance(dsk._pd, pd.DataFrame), type(dsk._pd)
+            assert isinstance(dsk._meta, pd.DataFrame), type(dsk._meta)
             if check_names:
-                tm.assert_index_equal(dsk._pd.columns, result.columns)
+                tm.assert_index_equal(dsk._meta.columns, result.columns)
             if check_dtypes:
                 assert_dask_dtypes(dsk, result)
         elif isinstance(dsk, dd.core.Scalar):
@@ -373,10 +373,10 @@ def assert_dask_dtypes(ddf, res, numeric_equal=True):
     eq_types = {'i', 'f'} if numeric_equal else {}
 
     if isinstance(res, pd.DataFrame):
-        for col, a, b in pd.concat([ddf._pd.dtypes, res.dtypes],
+        for col, a, b in pd.concat([ddf._meta.dtypes, res.dtypes],
                                    axis=1).itertuples():
             assert (a.kind in eq_types and b.kind in eq_types) or (a == b)
     elif isinstance(res, (pd.Series, pd.Index)):
-        a = ddf._pd.dtype
+        a = ddf._meta.dtype
         b = res.dtype
         assert (a.kind in eq_types and b.kind in eq_types) or (a == b)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -117,6 +117,13 @@ _simple_fake_mapping = {
 }
 
 
+def make_empty_frame(dtypes, index=None):
+    """Create an empty dataframe from a mapping of column -> dtype"""
+    return pd.DataFrame({c: pd.Series([], dtype=d)
+                         for (c, d) in dtypes.items()},
+                        index=index)
+
+
 def nonempty_sample_df(empty):
     """ Create a dataframe from the given empty dataframe that contains one
     row of fake data (generated from the empty dataframe's dtypes).

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -96,11 +96,35 @@ def unique(divisions):
     raise NotImplementedError()
 
 
-def make_empty_frame(dtypes, index=None):
-    """Create an empty dataframe from a mapping of column -> dtype"""
-    return pd.DataFrame({c: pd.Series([], dtype=d)
-                         for (c, d) in dtypes.items()},
-                        index=index)
+def make_meta(meta, index=None):
+    """Create an empty pandas object containing the desired metadata.
+
+    Parameters
+    ----------
+    meta : dict, tuple, pd.Series, pd.DataFrame, pd.Index
+        To create a DataFrame, provide a `dict` mapping of `{name: dtype}`. To
+        create a `Series`, provide a tuple of `(name, dtype)`. If a pandas
+        object, names, dtypes, and index should match the desired output.
+    index :  pd.Index, optional
+        Any pandas index to use in the metadata. If none provided, a
+        `RangeIndex` will be used.
+    """
+    if isinstance(meta, (pd.Series, pd.DataFrame)):
+        return meta.iloc[0:0]
+    elif isinstance(meta, pd.Index):
+        return meta[0:0]
+    index = index if index is None else index[0:0]
+    if isinstance(meta, dict):
+        return pd.DataFrame({c: pd.Series([], dtype=d)
+                             for (c, d) in meta.items()},
+                            index=index)
+    elif isinstance(meta, tuple):
+        if len(meta) != 2:
+            raise ValueError("Expected tuple of (name, dtype), "
+                             "got {0}".format(meta))
+        return pd.Series([], dtype=meta[1], name=meta[0], index=index)
+    else:
+        raise TypeError("Expected dict or tuple, got {0}".format(meta))
 
 
 def _nonempty_index(idx):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import textwrap
 from distutils.version import LooseVersion
 
 from collections import Iterator, Iterable
@@ -94,6 +95,37 @@ def unique(divisions):
     if isinstance(divisions, (tuple, list, Iterator)):
         return tuple(toolz.unique(divisions))
     raise NotImplementedError()
+
+
+_META_TYPES = "meta : pd.DataFrame, pd.Series, dict, iterable, tuple, optional"
+_META_DESCRIPTION = """\
+An empty ``pd.DataFrame`` or ``pd.Series`` that matches the dtypes and
+column names of the output. This metadata is necessary for many algorithms
+in dask dataframe to work.  For ease of use, some alternative inputs are
+also available. Instead of a ``DataFrame``, a ``dict`` of ``{name: dtype}``
+or iterable of ``(name, dtype)`` can be provided. Instead of a series, a
+tuple of ``(name, dtype)`` can be used. If not provided, dask will try to
+infer the metadata. This may lead to unexpected results, so providing
+``meta`` is recommended. For more information, see
+``dask.dataframe.utils.make_meta``.
+"""
+
+
+def insert_meta_param_description(*args, **kwargs):
+    """Replace `$META` in docstring with param description.
+
+    If pad keyword is provided, will pad description by that number of
+    spaces (default is 8)."""
+    if not args:
+        return lambda f: insert_meta_param_description(f, **kwargs)
+    f = args[0]
+    if f.__doc__:
+        indent = " "*kwargs.get('pad', 8)
+        body = textwrap.wrap(_META_DESCRIPTION, initial_indent=indent,
+                             subsequent_indent=indent, width=78)
+        descr = '{0}\n{1}'.format(_META_TYPES, '\n'.join(body))
+        f.__doc__ = f.__doc__.replace('$META', descr)
+    return f
 
 
 def make_meta(x, index=None):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -96,12 +96,12 @@ def unique(divisions):
     raise NotImplementedError()
 
 
-def make_meta(meta, index=None):
+def make_meta(x, index=None):
     """Create an empty pandas object containing the desired metadata.
 
     Parameters
     ----------
-    meta : dict, tuple, iterable, pd.Series, pd.DataFrame, pd.Index, scalar
+    x : dict, tuple, iterable, pd.Series, pd.DataFrame, pd.Index, scalar
         To create a DataFrame, provide a `dict` mapping of `{name: dtype}`, or
         an iterable of `(name, dtype)` tuples. To create a `Series`, provide a
         tuple of `(name, dtype)`. If a pandas object, names, dtypes, and index
@@ -120,30 +120,30 @@ def make_meta(meta, index=None):
     >>> make_meta(('a', 'f8'))
     Series([], Name: a, dtype: float64)
     """
-    if hasattr(meta, '_meta'):
-        return meta._meta
-    if isinstance(meta, (pd.Series, pd.DataFrame)):
-        return meta.iloc[0:0]
-    elif isinstance(meta, pd.Index):
-        return meta[0:0]
+    if hasattr(x, '_meta'):
+        return x._meta
+    if isinstance(x, (pd.Series, pd.DataFrame)):
+        return x.iloc[0:0]
+    elif isinstance(x, pd.Index):
+        return x[0:0]
     index = index if index is None else index[0:0]
-    if isinstance(meta, dict):
+    if isinstance(x, dict):
         return pd.DataFrame({c: pd.Series([], dtype=d)
-                             for (c, d) in meta.items()},
+                             for (c, d) in x.items()},
                             index=index)
-    elif isinstance(meta, tuple) and len(meta) == 2:
-        return pd.Series([], dtype=meta[1], name=meta[0], index=index)
-    elif isinstance(meta, Iterable):
-        meta = list(meta)
-        if not all(isinstance(i, tuple) and len(i) == 2 for i in meta):
+    elif isinstance(x, tuple) and len(x) == 2:
+        return pd.Series([], dtype=x[1], name=x[0], index=index)
+    elif isinstance(x, Iterable):
+        x = list(x)
+        if not all(isinstance(i, tuple) and len(i) == 2 for i in x):
             raise ValueError("Expected iterable of tuples of (name, dtype), "
-                             "got {0}".format(meta))
-        return pd.DataFrame({c: pd.Series([], dtype=d) for (c, d) in meta},
-                            columns=[c for c, d in meta], index=index)
-    elif hasattr(meta, 'dtype'):
-        return np.array([], dtype=meta.dtype)
+                             "got {0}".format(x))
+        return pd.DataFrame({c: pd.Series([], dtype=d) for (c, d) in x},
+                            columns=[c for c, d in x], index=index)
+    elif hasattr(x, 'dtype'):
+        return np.array([], dtype=x.dtype)
     else:
-        raise TypeError("Expected dict or tuple, got {0}".format(meta))
+        raise TypeError("Don't know how to create metadata from {0}".format(x))
 
 
 def _nonempty_index(idx):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -101,14 +101,17 @@ def make_meta(meta, index=None):
 
     Parameters
     ----------
-    meta : dict, tuple, pd.Series, pd.DataFrame, pd.Index
+    meta : dict, tuple, pd.Series, pd.DataFrame, pd.Index, scalar
         To create a DataFrame, provide a `dict` mapping of `{name: dtype}`. To
         create a `Series`, provide a tuple of `(name, dtype)`. If a pandas
-        object, names, dtypes, and index should match the desired output.
+        object, names, dtypes, and index should match the desired output. If a
+        scalar, a numpy scalar of the same dtype is returned.
     index :  pd.Index, optional
         Any pandas index to use in the metadata. If none provided, a
         `RangeIndex` will be used.
     """
+    if hasattr(meta, '_pd'):
+        return meta._pd
     if isinstance(meta, (pd.Series, pd.DataFrame)):
         return meta.iloc[0:0]
     elif isinstance(meta, pd.Index):
@@ -123,6 +126,8 @@ def make_meta(meta, index=None):
             raise ValueError("Expected tuple of (name, dtype), "
                              "got {0}".format(meta))
         return pd.Series([], dtype=meta[1], name=meta[0], index=index)
+    elif hasattr(meta, 'dtype'):
+        return np.array([], dtype=meta.dtype)
     else:
         raise TypeError("Expected dict or tuple, got {0}".format(meta))
 


### PR DESCRIPTION
This PR is an attempt to enforce that dask dataframes always know their full metadata (fixes #1209). Previously we allowed partial knowledge, with full dtype/column name computation done lazily if needed. This seemed like a good idea at the time, but masked many hidden metadata inference issues (functions could forget to pass along dtype, and we'd just recompute later). We also had to keep track of which bits of metadata were known, and which were unknown, resulting in frequent incorrect dtype inference.

Inference with pandas is much trickier than it is with numpy, as the dtype of the output series can change depending on values as well as input dtypes. Some functions also return different dtypes if a series is empty vs if it isn't. To get around this, a `_pd_nonempty` attribute is added to all `_Frame` objects, which matches `_pd`'s metadata, but contains one row of fake data. This helps for many situations, but not all.

Todo:
- [x] Figure out a way to smoothly deprecate the old behavior (unless we decide to make this a breaking change)
- [x] Figure out a good way to handle methods that take user provided functions like `apply`, `map_partitions`, etc...
- [x] Improve test suite to check that metadata actually matches on outputs.