### PR TITLE
Error if type not supported in dataframe assign

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1711,6 +1711,11 @@ class DataFrame(_Frame):
 
     @derived_from(pd.DataFrame)
     def assign(self, **kwargs):
+        for k, v in kwargs.items():
+            if not (isinstance(v, (Series, Scalar, pd.Series))
+                    or np.isscalar(v)):
+                raise TypeError("Column assignment doesn't support type "
+                                "{0}".format(type(v).__name__))
         pairs = list(sum(kwargs.items(), ()))
 
         # Figure out columns of the output

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -698,8 +698,20 @@ def test_index():
 
 
 def test_assign():
-    assert eq(d.assign(c=d.a + 1, e=d.a + d.b),
-              full.assign(c=full.a + 1, e=full.a + full.b))
+    res = d.assign(c=1,
+                   d='string',
+                   e=np.float64(1),
+                   f=d.a.sum(),
+                   g=d.a + 1,
+                   h=d.a + d.b)
+    sol = full.assign(c=1,
+                      d='string',
+                      e=np.float64(1),
+                      f=full.a.sum(),
+                      g=full.a + 1,
+                      h=full.a + full.b)
+    assert eq(res, sol)
+    pytest.raises(TypeError, lambda: d.assign(c=list(range(9))))
 
 
 def test_map():


### PR DESCRIPTION
Previously assigning to a column with an unsupported type wouldn't fail
until runtime. This adds an error message if the assignment is
unsupported, and improves our test coverage for what is supported. This
was pointed out in #1426.

cc @ankravch