### PR TITLE
Fix no_default/no_result comparison against custom types.

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -12,7 +12,7 @@ from random import Random
 from warnings import warn
 from distutils.version import LooseVersion
 
-from ..utils import ignoring
+from ..utils import ignoring, eq_strict
 
 from toolz import (merge, take, reduce, valmap, map, partition_all, filter,
                    remove, compose, curry, first, second, accumulate)
@@ -44,6 +44,7 @@ from ..bytes.core import write_bytes
 
 
 no_default = '__no__default__'
+no_result = '__no__result__'
 
 
 def lazify_task(task, start=True):
@@ -1607,9 +1608,9 @@ def empty_safe_apply(func, part):
     if part:
         return func(part)
     else:
-        return '--no-result--'
+        return no_result
 
 
 def empty_safe_aggregate(func, parts):
-    parts2 = [p for p in parts if p != '--no-result--']
+    parts2 = [p for p in parts if not eq_strict(p, no_result)]
     return empty_safe_apply(func, parts2)

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 from dask.compatibility import BZ2File, GzipFile, LZMAFile, LZMA_AVAILABLE
 from dask.utils import (textblock, filetext, takes_multiple_arguments,
                         Dispatch, tmpfile, different_seeds, file_size,
-                        infer_storage_options)
+                        infer_storage_options, eq_strict)
 
 
 SKIP_XZ = pytest.mark.skipif(not LZMA_AVAILABLE, reason="no lzma library")
@@ -172,3 +172,8 @@ def test_infer_storage_options():
 def test_infer_storage_options_c():
     so = infer_storage_options(r'c:\foo\bar')
     assert so['protocol'] == 'file'
+
+
+def test_eq_strict():
+    assert eq_strict('a', 'a')
+    assert not eq_strict(b'a', u'a')

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -756,3 +756,10 @@ def dependency_depth(dsk):
         return d
 
     return max(max_depth_by_deps(dep_key) for dep_key in deps.keys())
+
+
+def eq_strict(a, b):
+    """Returns True if both values have the same type and are equal."""
+    if type(a) is type(b):
+        return a == b
+    return False


### PR DESCRIPTION
When the intermediate output of reduction is a type with custom
comparison, the code breaks due to the `obj == <string>` comparison (for
instance, a ``csr_matrix``).