### PR TITLE
Break ordering ties by str

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -80,7 +80,12 @@ def order(dsk, dependencies=None):
 
     ndeps = ndependents(dependencies, dependents)
     maxes = child_max(dependencies, dependents, ndeps)
-    return dfs(dependencies, dependents, key=lambda x: (-maxes.get(x), str(x)))
+    def key(x):
+        try:
+            return -maxes[x], str(x)
+        except KeyError:
+            return 0, str(x)
+    return dfs(dependencies, dependents, key=key)
 
 
 def ndependents(dependencies, dependents):
@@ -166,7 +171,7 @@ def dfs(dependencies, dependents, key=lambda x: x):
     >>> dependencies, dependents = get_deps(dsk)
 
     >>> sorted(dfs(dependencies, dependents).items())
-    [('a', 2), ('b', 3), ('c', 1), ('d', 0)]
+    [('a', 3), ('b', 1), ('c', 2), ('d', 0)]
     """
     result = dict()
     i = 0

--- a/dask/order.py
+++ b/dask/order.py
@@ -80,7 +80,7 @@ def order(dsk, dependencies=None):
 
     ndeps = ndependents(dependencies, dependents)
     maxes = child_max(dependencies, dependents, ndeps)
-    return dfs(dependencies, dependents, key=maxes.get)
+    return dfs(dependencies, dependents, key=lambda x: (-maxes.get(x), str(x)))
 
 
 def ndependents(dependencies, dependents):
@@ -172,7 +172,7 @@ def dfs(dependencies, dependents, key=lambda x: x):
     i = 0
 
     roots = [k for k, v in dependents.items() if not v]
-    stack = sorted(roots, key=key)
+    stack = sorted(roots, key=key, reverse=True)
     seen = set()
 
     while stack:
@@ -185,7 +185,7 @@ def dfs(dependencies, dependents, key=lambda x: x):
         deps = dependencies[item]
         if deps:
             deps = deps - seen
-            deps = sorted(deps, key=key)
+            deps = sorted(deps, key=key, reverse=True)
             stack.extend(deps)
         i += 1
 

--- a/dask/order.py
+++ b/dask/order.py
@@ -81,10 +81,7 @@ def order(dsk, dependencies=None):
     ndeps = ndependents(dependencies, dependents)
     maxes = child_max(dependencies, dependents, ndeps)
     def key(x):
-        try:
-            return -maxes[x], str(x)
-        except KeyError:
-            return 0, str(x)
+        return -maxes.get(x, 0), str(x)
     return dfs(dependencies, dependents, key=key)
 
 

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -192,3 +192,17 @@ def test_remote_exception():
     assert isinstance(a, TypeError)
     assert 'hello' in str(a)
     assert 'traceback' in str(a)
+
+
+def test_ordering():
+    L = []
+    def append(i):
+        L.append(i)
+
+    dsk = {('x', i): (append, i) for i in range(10)}
+    x_keys = sorted(dsk)
+    dsk['y'] = (lambda *args: None, list(x_keys))
+
+    get_sync(dsk, 'y')
+
+    assert L == sorted(L)

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -107,7 +107,7 @@ class GetFunctionTestMixin(object):
         assert self.get(d, 'z') == 4
 
     def test_get_stack_limit(self):
-        d = dict(('x%s' % (i+1), (inc, 'x%s' % i)) for i in range(10000))
+        d = dict(('x%d' % (i+1), (inc, 'x%d' % i)) for i in range(10000))
         d['x0'] = 0
         assert self.get(d, 'x10000') == 10000
         # introduce cycle


### PR DESCRIPTION
This changes task ordering to break ties using the string representation
of the key.  This is particularly useful when computing dask collections
on an asynchronous scheduler, because the beginning parts of the
computation start first.  This will allow for `df.head()` for example to
work almost immediately after `e.persist(df)`.  The keys like `('df',
0)` will run before keys like `('df', 242)`.

I haven't benchmarked this to see if it significantly affects overhead.