### PR TITLE
A few pep8 cleanups in dataframe

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import Iterator
-from datetime import datetime
-import math
 import operator
 from operator import getitem, setitem
 from pprint import pformat
@@ -239,7 +237,7 @@ class _Frame(Base):
 
     def get_division(self, n):
         warnings.warn("Deprecation warning: use `get_partition` instead")
-        return get_partition(self, n)
+        return self.get_partition(self, n)
 
     def get_partition(self, n):
         """Get a dask DataFrame/Series representing the `nth` partition."""
@@ -577,29 +575,29 @@ class _Frame(Base):
         Data saved by this function should be read by pandas dataframe
         compatible reader.
 
-	By providing a single asterisk in either the path_or_buf or key
-	parameters you direct dask to save each partition to a different file
-	or node (respectively). The asterisk will be replaced with a zero
-	padded partition number, as this is the default implementation of
-	name_function.
+        By providing a single asterisk in either the path_or_buf or key
+        parameters you direct dask to save each partition to a different file
+        or node (respectively). The asterisk will be replaced with a zero
+        padded partition number, as this is the default implementation of
+        name_function.
 
-	When writing to a single hdf node in a single hdf file, all hdf save
-	tasks are required to execute in a specific order, often becoming the
-	bottleneck of the entire execution graph. Saving to multiple nodes or
-	files removes that restriction (order is still preserved by enforcing
-	order on output, using name_function) and enables executing save tasks
-	in parallel.
+        When writing to a single hdf node in a single hdf file, all hdf save
+        tasks are required to execute in a specific order, often becoming the
+        bottleneck of the entire execution graph. Saving to multiple nodes or
+        files removes that restriction (order is still preserved by enforcing
+        order on output, using name_function) and enables executing save tasks
+        in parallel.
 
         Parameters
         ----------
         path_or_buf: HDFStore object or string
-	    Destination file(s). If string, can contain a single asterisk to
-	    save each partition to a different file. Only one asterisk is
-	    allowed in both path_or_buf and key parameters.
+        Destination file(s). If string, can contain a single asterisk to
+        save each partition to a different file. Only one asterisk is
+        allowed in both path_or_buf and key parameters.
         key: string
-	    A node / group path in file, can contain a single asterisk to save
-	    each partition to a different hdf node in a single file. Only one
-	    asterisk is allowed in both path_or_buf and key parameters.
+        A node / group path in file, can contain a single asterisk to save
+        each partition to a different hdf node in a single file. Only one
+        asterisk is allowed in both path_or_buf and key parameters.
         format: optional, default 'table'
             Default hdf storage format, currently only pandas' 'table' format
             is supported.
@@ -612,52 +610,52 @@ class _Frame(Base):
           ``'r+'``
               Append to existing files, files must already exist.
         append: optional, default False
-	    If False, overwrites existing node with the same name otherwise
-	    appends to it.
+        If False, overwrites existing node with the same name otherwise
+        appends to it.
         complevel: optional, 0-9, default 0
             compression level, higher means better compression ratio and
             possibly more CPU time. Depends on complib.
         complib: {'zlib', 'bzip2', 'lzo', 'blosc', None}, default None
-	    If complevel > 0 compress using this compression library when
-	    possible
+        If complevel > 0 compress using this compression library when
+        possible
         fletcher32: bool, default False
-	    If True and compression is used, additionally apply the fletcher32
-	    checksum.
+        If True and compression is used, additionally apply the fletcher32
+        checksum.
         get: callable, optional
-	    A scheduler `get` function to use. If not provided, the default is
-	    to check the global settings first, and then fall back to defaults
-	    for the collections.
+        A scheduler `get` function to use. If not provided, the default is
+        to check the global settings first, and then fall back to defaults
+        for the collections.
         dask_kwargs: dict, optional
-	    A dictionary of keyword arguments passed to the `get` function
-	    used.
+        A dictionary of keyword arguments passed to the `get` function
+        used.
         name_function: callable, optional, default None
-	    A callable called for each partition that accepts a single int
-	    representing the partition number. name_function must return a
-	    string representation of a partition's index in a way that will
-	    preserve the partition's location after a string sort.
+        A callable called for each partition that accepts a single int
+        representing the partition number. name_function must return a
+        string representation of a partition's index in a way that will
+        preserve the partition's location after a string sort.
 
-	    If None, a default name_function is used. The default name_function
-	    will return a zero padded string of received int. See
-	    dask.utils.build_name_function for more info.
+        If None, a default name_function is used. The default name_function
+        will return a zero padded string of received int. See
+        dask.utils.build_name_function for more info.
         compute: bool, default True
             If True, execute computation of resulting dask graph.
             If False, return a Delayed object.
         lock: bool, None or lock object, default None
-	    In to_hdf locks are needed for two reasons. First, to protect
-	    against writing to the same file from multiple processes or threads
-	    simultaneously.  Second, default libhdf5 is not thread safe, so we
-	    must additionally lock on it's usage. By default if lock is None
-	    lock will be determined optimally based on path_or_buf, key and the
-	    scheduler used. Manually setting this parameter is usually not
-	    required to improve performance.
+        In to_hdf locks are needed for two reasons. First, to protect
+        against writing to the same file from multiple processes or threads
+        simultaneously.  Second, default libhdf5 is not thread safe, so we
+        must additionally lock on it's usage. By default if lock is None
+        lock will be determined optimally based on path_or_buf, key and the
+        scheduler used. Manually setting this parameter is usually not
+        required to improve performance.
 
-	    Alternatively, you can specify specific values:
-	    If False, no locking will occur. If True, default lock object will
-	    be created (multiprocessing.Manager.Lock on multiprocessing
-	    scheduler, Threading.Lock otherwise), This can be used to force
-	    using a lock in scenarios the default behavior will be to avoid
-	    locking. Else, value is assumed to implement the lock interface,
-	    and will be the lock object used.
+        Alternatively, you can specify specific values:
+        If False, no locking will occur. If True, default lock object will
+        be created (multiprocessing.Manager.Lock on multiprocessing
+        scheduler, Threading.Lock otherwise), This can be used to force
+        using a lock in scenarios the default behavior will be to avoid
+        locking. Else, value is assumed to implement the lock interface,
+        and will be the lock object used.
 
         See Also
         --------
@@ -681,8 +679,8 @@ class _Frame(Base):
 
         >>> df.to_hdf('output_*.hdf', '/data')          # doctest: +SKIP
 
-	Saving multiple files with the multiprocessing scheduler and manually
-	disabling locks:
+        Saving multiple files with the multiprocessing scheduler and manually
+        disabling locks:
 
         >>> df.to_hdf('output_*.hdf', '/data',
         ...   get=dask.multiprocessing.get, lock=False) # doctest: +SKIP
@@ -1385,7 +1383,7 @@ class Series(_Frame):
         """ bind operator method like DataFrame.add to this class """
 
         def meth(self, other, level=None, fill_value=None, axis=0):
-            if not level is None:
+            if level is not None:
                 raise NotImplementedError('level must be None')
             return map_partitions(op, self, other, meta=self._meta,
                                   axis=axis, fill_value=fill_value)
@@ -1743,8 +1741,8 @@ class DataFrame(_Frame):
     @derived_from(pd.DataFrame)
     def assign(self, **kwargs):
         for k, v in kwargs.items():
-            if not (isinstance(v, (Series, Scalar, pd.Series))
-                    or np.isscalar(v)):
+            if not (isinstance(v, (Series, Scalar, pd.Series)) or
+                    np.isscalar(v)):
                 raise TypeError("Column assignment doesn't support type "
                                 "{0}".format(type(v).__name__))
         pairs = list(sum(kwargs.items(), ()))
@@ -2104,7 +2102,7 @@ def elemwise(op, *args, **kwargs):
              if not isinstance(arg, (_Frame, Scalar))]
 
     # adjust the key length of Scalar
-    keys = [d._keys() *  n if isinstance(d, Scalar)
+    keys = [d._keys() * n if isinstance(d, Scalar)
             else d._keys() for d in dasks]
 
     if other:
@@ -2971,8 +2969,8 @@ def set_sorted_index(df, index, drop=True, **kwargs):
     mins, maxes = compute(mins, maxes, **kwargs)
 
     if (sorted(mins) != list(mins) or
-        sorted(maxes) != list(maxes) or
-        any(a >= b for a, b in zip(mins, maxes))):
+            sorted(maxes) != list(maxes) or
+            any(a >= b for a, b in zip(mins, maxes))):
         raise ValueError("Column not properly sorted", mins, maxes)
 
     divisions = tuple(mins) + (list(maxes)[-1],)

--- a/dask/dataframe/csv.py
+++ b/dask/dataframe/csv.py
@@ -66,7 +66,7 @@ def coerce_dtypes(df, dtypes):
     for c in df.columns:
         if c in dtypes and df.dtypes[c] != dtypes[c]:
             if (np.issubdtype(df.dtypes[c], np.floating) and
-                np.issubdtype(dtypes[c], np.integer)):
+                    np.issubdtype(dtypes[c], np.integer)):
                 if (df[c] % 1).any():
                     raise TypeError("Runtime type mismatch. "
                     "Add {'%s': float} to dtype= keyword in read_csv" % c)
@@ -192,7 +192,7 @@ def read_csv(urlpath, blocksize=AUTO_BLOCKSIZE, chunkbytes=None,
         lineterminator = '\n'
     if chunkbytes is not None:
         warn("Deprecation warning: chunksize csv keyword renamed to blocksize")
-        blocksize=chunkbytes
+        blocksize = chunkbytes
     if 'index' in kwargs or 'index_col' in kwargs:
         raise ValueError("Keyword 'index' not supported "
                          "dd.read_csv(...).set_index('my-index') instead")

--- a/dask/dataframe/demo.py
+++ b/dask/dataframe/demo.py
@@ -12,6 +12,7 @@ __all__ = ['make_timeseries']
 def make_float(n, rstate):
     return rstate.rand(n) * 2 - 1
 
+
 def make_int(n, rstate):
     return rstate.poisson(1000, size=n)
 
@@ -86,5 +87,5 @@ def make_timeseries(start, end, dtypes, freq, partition_freq, seed=None):
     dsk = dict(((name, i), (make_timeseries_part, divisions[i], divisions[i + 1],
                                                  dtypes, freq, seeds[i]))
                 for i in range(len(divisions) - 1))
-    head = make_timeseries_part('2000','2000', dtypes, '1H', 1)
+    head = make_timeseries_part('2000', '2000', dtypes, '1H', 1)
     return DataFrame(dsk, name, head, divisions)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -145,14 +145,14 @@ class _GroupBy(object):
 
         # grouping key passed via groupby method
         if (isinstance(index, (DataFrame, Series, Index)) and
-            isinstance(df, DataFrame)):
+                isinstance(df, DataFrame)):
 
             if (isinstance(index, Series) and index.name in df.columns and
-                index._name == df[index.name]._name):
+                    index._name == df[index.name]._name):
                 index = index.name
             elif (isinstance(index, DataFrame) and
                 set(index.columns).issubset(df.columns) and
-                index._name == df[index.columns]._name):
+                    index._name == df[index.columns]._name):
                 index = list(index.columns)
 
         self.index = index
@@ -189,11 +189,11 @@ class _GroupBy(object):
         if isinstance(df, Series):
             return False
         if (isinstance(index, Series) and index._name in df.columns and
-            index._name == df[index.name]._name):
+                index._name == df[index.name]._name):
             return True
         if (isinstance(index, DataFrame) and
-            set(index.columns).issubset(df.columns) and
-            index._name == df[index.columns]._name):
+                set(index.columns).issubset(df.columns) and
+                index._name == df[index.columns]._name):
             index = list(index.columns)
             return True
         return False
@@ -349,7 +349,7 @@ class _GroupBy(object):
             df2 = df
             index = df[self.index]
 
-        df3 = shuffle(df2, index, **self.kwargs) # shuffle dataframe and index
+        df3 = shuffle(df2, index, **self.kwargs)  # shuffle dataframe and index
 
         if isinstance(self.index, DataFrame):  # extract index from dataframe
             cols = ['_index_' + c for c in self.index.columns]

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -65,7 +65,7 @@ import pandas as pd
 
 from ..base import tokenize
 from ..compatibility import apply
-from .core import (_Frame, Scalar, DataFrame, map_partitions, elemwise,
+from .core import (_Frame, Scalar, DataFrame, map_partitions,
                    Index, _maybe_from_pandas)
 from .io import from_pandas
 from .shuffle import shuffle, rearrange_by_divisions
@@ -198,6 +198,7 @@ def require(divisions, parts, required=None):
 ###############################################################
 
 required = {'left': [0], 'right': [1], 'inner': [0, 1], 'outer': []}
+
 
 def join_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix=''):
     """ Join two partitiond dataframes along their index """
@@ -416,7 +417,7 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
         on = None
 
     if (isinstance(left, (pd.Series, pd.DataFrame)) and
-        isinstance(right, (pd.Series, pd.DataFrame))):
+            isinstance(right, (pd.Series, pd.DataFrame))):
         return pd.merge(left, right, how=how, on=on, left_on=left_on,
                         right_on=right_on, left_index=left_index,
                         right_index=right_index, suffixes=suffixes)
@@ -440,7 +441,7 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
 
     # Both sides indexed
     if (left_index and left.known_divisions and
-        right_index and right.known_divisions):  # Do indexed join
+            right_index and right.known_divisions):  # Do indexed join
         return join_indexed_dataframes(left, right, how=how,
                                        lsuffix=suffixes[0], rsuffix=suffixes[1])
 
@@ -632,8 +633,8 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
 
     else:
         if axis == 1:
-             raise ValueError('Unable to concatenate DataFrame with unknown '
-                              'division specifying axis=1')
+            raise ValueError('Unable to concatenate DataFrame with unknown '
+                             'division specifying axis=1')
         else:
             # concat will not regard Series as row
             dfs = _maybe_from_pandas(dfs)
@@ -645,10 +646,10 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
                           name, meta, divisions)
 
 
-
 ###############################################################
 # Append
 ###############################################################
+
 
 def _append(df, other, divisions):
     """ Internal function to append 2 dd.DataFrame/Series instances """

--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -419,7 +419,6 @@ def partition_quantiles(df, npartitions, upsample=1.0, random_state=None):
     """ Approximate quantiles of Series used for repartitioning
     """
     assert isinstance(df, Series)
-    from dask.array.percentile import _percentile
 
     qs = np.linspace(0, 1, npartitions + 1)
     # currently, only Series has quantile method

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -65,6 +65,7 @@ def call_pandas_rolling_method_single(this_partition, rolling_kwargs,
     method = getattr(this_partition.rolling(**rolling_kwargs), method_name)
     return method(*method_args, **method_kwargs)
 
+
 def call_pandas_rolling_method_with_neighbors(
         prev_partition, this_partition, next_partition, before, after,
         rolling_kwargs, method_name, method_args, method_kwargs):
@@ -79,11 +80,14 @@ def call_pandas_rolling_method_with_neighbors(
     else:
         return applied.iloc[before:]
 
+
 def tail(obj, n):
     return obj.tail(n)
 
+
 def head(obj, n):
     return obj.head(n)
+
 
 class Rolling(object):
     # What you get when you do ddf.rolling(...) or similar
@@ -125,7 +129,7 @@ class Rolling(object):
 
         dsk = {}
         if self.axis in [1, 'columns'] or self.window <= 1 or self.obj.npartitions == 1:
-            # This is the easy scenario, we're rolling over columns (or not 
+            # This is the easy scenario, we're rolling over columns (or not
             # really rolling at all, so each chunk is independent.
             for i in range(self.obj.npartitions):
                 dsk[new_name, i] = (

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterator
 import math
 from operator import getitem
-import types
 import uuid
 
 import numpy as np
@@ -11,13 +9,10 @@ import pandas as pd
 from pandas.core.categorical import is_categorical_dtype
 from toolz import merge
 
-from .categorical import strip_categories, _categorize, get_categories
-from .core import DataFrame, Series, _Frame, map_partitions, _concat
-from .utils import shard_df_on_index
+from .core import DataFrame, Series, _Frame, _concat
 
 from ..base import tokenize
 from ..context import _globals
-from ..optimize import cull
 from ..utils import digit, insert
 
 
@@ -392,5 +387,3 @@ def set_index_post_series(df, index_name, drop, column_dtype):
     df2.index.name = index_name
     df2.columns = df2.columns.astype(column_dtype)
     return df2
-
-


### PR DESCRIPTION
- Kill use of tabs instead of spaces
- Remove unused imports
- Fix only the most glaring errors:
    - Visual indent lines up with nested scope
    - Missing/extra blank lines
    - `not foo is bar` and `not foo in bar`
    - Whitespace at end of lines