### PR TITLE
Re-add the castra tests.

### DIFF
--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -592,11 +592,11 @@ def test_from_dask_array_struct_dtype():
               pd.DataFrame(x, columns=['b', 'a']))
 
 
-@pytest.mark.xfail(reason="from_castra inference in castra broken")
 def test_to_castra():
-    pytest.importorskip('castra')
+    castra = pytest.importorskip('castra')
     blosc = pytest.importorskip('blosc')
-    if LooseVersion(blosc.__version__) == '1.3.0':
+    if (LooseVersion(blosc.__version__) == '1.3.0' or
+            LooseVersion(castra.__version__) < '0.1.8'):
         pytest.skip()
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
                        'y': [2, 3, 4, 5]},
@@ -641,11 +641,11 @@ def test_to_castra():
         c2.drop()
 
 
-@pytest.mark.xfail(reason="from_castra inference in castra broken")
 def test_from_castra():
-    pytest.importorskip('castra')
+    castra = pytest.importorskip('castra')
     blosc = pytest.importorskip('blosc')
-    if LooseVersion(blosc.__version__) == '1.3.0':
+    if (LooseVersion(blosc.__version__) == '1.3.0' or
+            LooseVersion(castra.__version__) < '0.1.8'):
         pytest.skip()
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
                        'y': [2, 3, 4, 5]},
@@ -666,15 +666,15 @@ def test_from_castra():
         del with_fn, c
 
 
-@pytest.mark.xfail(reason="from_castra inference in castra broken")
 def test_from_castra_with_selection():
     """ Optimizations fuse getitems with load_partitions
 
     We used to use getitem for both column access and selections
     """
-    pytest.importorskip('castra')
+    castra = pytest.importorskip('castra')
     blosc = pytest.importorskip('blosc')
-    if LooseVersion(blosc.__version__) == '1.3.0':
+    if (LooseVersion(blosc.__version__) == '1.3.0' or
+            LooseVersion(castra.__version__) < '0.1.8'):
         pytest.skip()
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
                        'y': [2, 3, 4, 5]},

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -36,11 +36,11 @@ def test_column_optimizations_with_bcolz_and_rewrite():
         assert result == expected
 
 
-@pytest.mark.xfail(reason="from_castra inference in castra broken")
 def test_castra_column_store():
     castra = pytest.importorskip('castra')
     blosc = pytest.importorskip('blosc')
-    if LooseVersion(blosc.__version__) == '1.3.0':
+    if (LooseVersion(blosc.__version__) == '1.3.0' or
+            LooseVersion(castra.__version__) < '0.1.8'):
         pytest.skip()
 
     df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})


### PR DESCRIPTION
These were xfailed in https://github.com/dask/dask/pull/1422, as the
last release of castra was incompatible with the new metadata. This was
fixed in https://github.com/blaze/castra/pull/64, and a new release was
made (0.1.8). We now only run these tests if castra version is >= 0.1.8