### PR TITLE
Fix pickle for all classes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -805,6 +805,12 @@ class Array(Base):
     def _args(self):
         return (self.dask, self.name, self.chunks, self.dtype)
 
+    def __getstate__(self):
+        return self._args
+
+    def __setstate__(self, state):
+        self.dask, self.name, self._chunks, self._dtype = state
+
     @property
     def numblocks(self):
         return tuple(map(len, self.chunks))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2083,3 +2083,11 @@ def test_from_array_names():
 
     names = countby(key_split, d.dask)
     assert set(names.values()) == set([1, 5])
+
+
+def test_array_picklable():
+    from pickle import loads, dumps
+
+    a = da.arange(100, chunks=25)
+    a2 = loads(dumps(a))
+    assert_eq(a, a2)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -213,6 +213,69 @@ def unpack_kwargs(kwargs):
     return dsk, kw_pairs
 
 
+class StringAccessor(object):
+    """ String processing functions
+
+    Examples
+    --------
+
+    >>> import dask.bag as db
+    >>> b = db.from_sequence(['Alice Smith', 'Bob Jones', 'Charlie Smith'])
+    >>> list(b.str.lower())
+    ['alice smith', 'bob jones', 'charlie smith']
+
+    >>> list(b.str.match('*Smith'))
+    ['Alice Smith', 'Charlie Smith']
+
+    >>> list(b.str.split(' '))
+    [['Alice', 'Smith'], ['Bob', 'Jones'], ['Charlie', 'Smith']]
+    """
+    def __init__(self, bag):
+        self._bag = bag
+
+    def __dir__(self):
+        return sorted(set(dir(type(self)) + dir(str)))
+
+    def _strmap(self, key, *args, **kwargs):
+        return self._bag.map(lambda s: getattr(s, key)(*args, **kwargs))
+
+    def __getattr__(self, key):
+        try:
+            return object.__getattribute__(self, key)
+        except AttributeError:
+            if key in dir(str):
+                func = getattr(str, key)
+                return robust_wraps(func)(partial(self._strmap, key))
+            else:
+                raise
+
+    def match(self, pattern):
+        """ Filter strings by those that match a pattern
+
+        Examples
+        --------
+
+        >>> import dask.bag as db
+        >>> b = db.from_sequence(['Alice Smith', 'Bob Jones', 'Charlie Smith'])
+        >>> list(b.str.match('*Smith'))
+        ['Alice Smith', 'Charlie Smith']
+
+        See Also
+        --------
+        fnmatch.fnmatch
+        """
+        from fnmatch import fnmatch
+        return self._bag.filter(partial(fnmatch, pat=pattern))
+
+
+def robust_wraps(wrapper):
+    """ A weak version of wraps that only copies doc """
+    def _(wrapped):
+        wrapped.__doc__ = wrapper.__doc__
+        return wrapped
+    return _
+
+
 class Item(Base):
     _optimize = staticmethod(optimize)
     _default_get = staticmethod(mpget)
@@ -253,8 +316,11 @@ class Item(Base):
     def _args(self):
         return (self.dask, self.key)
 
-    def __getnewargs__(self):
+    def __getstate__(self):
         return self._args
+
+    def __setstate__(self, state):
+        self.dask, self.key = state
 
     def _keys(self):
         return [self.key]
@@ -316,13 +382,14 @@ class Bag(Base):
         self.dask = dsk
         self.name = name
         self.npartitions = npartitions
-        self.str = StringAccessor(self)
 
     def __str__(self):
         name = self.name if len(self.name) < 10 else self.name[:7] + '...'
         return 'dask.bag<%s, npartitions=%d>' % (name, self.npartitions)
 
     __repr__ = __str__
+
+    str = property(fget=StringAccessor)
 
     def map(self, func, **kwargs):
         """ Map a function across all elements in collection
@@ -376,8 +443,11 @@ class Bag(Base):
     def _args(self):
         return (self.dask, self.name, self.npartitions)
 
-    def __getnewargs__(self):
+    def __getstate__(self):
         return self._args
+
+    def __setstate__(self, state):
+        self.dask, self.name, self.npartitions = state
 
     def filter(self, predicate):
         """ Filter elements in collection by a predicate function
@@ -1351,69 +1421,6 @@ def concat(bags):
     dsk = dict(((name, next(counter)), key)
                for bag in bags for key in sorted(bag._keys()))
     return Bag(merge(dsk, *[b.dask for b in bags]), name, len(dsk))
-
-
-class StringAccessor(object):
-    """ String processing functions
-
-    Examples
-    --------
-
-    >>> import dask.bag as db
-    >>> b = db.from_sequence(['Alice Smith', 'Bob Jones', 'Charlie Smith'])
-    >>> list(b.str.lower())
-    ['alice smith', 'bob jones', 'charlie smith']
-
-    >>> list(b.str.match('*Smith'))
-    ['Alice Smith', 'Charlie Smith']
-
-    >>> list(b.str.split(' '))
-    [['Alice', 'Smith'], ['Bob', 'Jones'], ['Charlie', 'Smith']]
-    """
-    def __init__(self, bag):
-        self._bag = bag
-
-    def __dir__(self):
-        return sorted(set(dir(type(self)) + dir(str)))
-
-    def _strmap(self, key, *args, **kwargs):
-        return self._bag.map(lambda s: getattr(s, key)(*args, **kwargs))
-
-    def __getattr__(self, key):
-        try:
-            return object.__getattribute__(self, key)
-        except AttributeError:
-            if key in dir(str):
-                func = getattr(str, key)
-                return robust_wraps(func)(partial(self._strmap, key))
-            else:
-                raise
-
-    def match(self, pattern):
-        """ Filter strings by those that match a pattern
-
-        Examples
-        --------
-
-        >>> import dask.bag as db
-        >>> b = db.from_sequence(['Alice Smith', 'Bob Jones', 'Charlie Smith'])
-        >>> list(b.str.match('*Smith'))
-        ['Alice Smith', 'Charlie Smith']
-
-        See Also
-        --------
-        fnmatch.fnmatch
-        """
-        from fnmatch import fnmatch
-        return self._bag.filter(partial(fnmatch, pat=pattern))
-
-
-def robust_wraps(wrapper):
-    """ A weak version of wraps that only copies doc """
-    def _(wrapped):
-        wrapped.__doc__ = wrapper.__doc__
-        return wrapped
-    return _
 
 
 def reify(seq):

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -249,6 +249,13 @@ class Item(Base):
         self.key = key
         self.name = key
 
+    @property
+    def _args(self):
+        return (self.dask, self.key)
+
+    def __getnewargs__(self):
+        return self._args
+
     def _keys(self):
         return [self.key]
 
@@ -368,6 +375,9 @@ class Bag(Base):
     @property
     def _args(self):
         return (self.dask, self.name, self.npartitions)
+
+    def __getnewargs__(self):
+        return self._args
 
     def filter(self, predicate):
         """ Filter elements in collection by a predicate function

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1049,3 +1049,15 @@ def test_reduction_with_sparse_matrices():
 
 def test_empty():
     list(db.from_sequence([])) == []
+
+
+def test_bag_picklable():
+    from pickle import loads, dumps
+
+    b = db.from_sequence(range(100))
+    b2 = loads(dumps(b))
+    assert b.compute() == b2.compute()
+
+    s = b.sum()
+    s2 = loads(dumps(s))
+    assert s.compute() == s2.compute()

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -89,6 +89,9 @@ class Scalar(Base):
     def _args(self):
         return (self.dask, self._name)
 
+    def __getnewargs__(self):
+        return self._args
+
     @property
     def key(self):
         return (self._name, 0)
@@ -200,7 +203,6 @@ class _Frame(Base):
         return (self.dask, self._name, self._meta, self.divisions)
 
     def __getnewargs__(self):
-        """ To load pickle """
         return self._args
 
     def _keys(self):
@@ -520,12 +522,6 @@ class _Frame(Base):
         else:
             raise ValueError(
                 "Provide either divisions= or npartitions= to repartition")
-
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, dict):
-        self.__dict__ = dict
 
     @derived_from(pd.Series)
     def fillna(self, value):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1038,16 +1038,29 @@ def test_append2():
     assert eq(ddf3.b.append(ddf1.compute()), ddf3.b.compute().append(ddf1.compute()))
 
 
-def test_dataframe_series_are_pickleable():
-    import pickle
+def test_dataframe_picklable():
+    from pickle import loads, dumps
     cloudpickle = pytest.importorskip('cloudpickle')
-
     dumps = cloudpickle.dumps
-    loads = pickle.loads
 
-    e = d.groupby(d.a).b.sum()
-    f = loads(dumps(e))
-    assert eq(e, f)
+    df = d + 2
+
+    # dataframe
+    df2 = loads(dumps(df))
+    assert eq(df, df2)
+
+    # series
+    a2 = loads(dumps(df.a))
+    assert eq(df.a, a2)
+
+    #index
+    i2 = loads(dumps(df.index))
+    assert eq(df.index, i2)
+
+    #scalar
+    s = df.a.sum()
+    s2 = loads(dumps(s))
+    assert eq(s, s2)
 
 
 def test_random_partitions():

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -249,7 +249,7 @@ def test_key_names_include_type_names():
     assert delayed(1).key.startswith('int')
 
 
-def test_value_picklable():
+def test_delayed_picklable():
     x = delayed(1)
     y = pickle.loads(pickle.dumps(x))
     assert x.dask == y.dask


### PR DESCRIPTION
Not all dask collections were pickleable. Further, the dataframe
implementation was broken, resulting in a shared `__dict__` between
objects. This fixes that, and adds tests for all classes to ensure
pickleable.