### PR TITLE
Infer metadata from scalars

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -68,6 +68,24 @@ def test_make_meta():
     assert isinstance(meta.index, pd.Int64Index)
     assert len(meta.index) == 0
 
+    # Numpy scalar
+    meta = make_meta(np.float64(1.0))
+    assert isinstance(meta, np.ndarray)
+    assert meta.shape == (0,)
+    assert meta.dtype == 'f8'
+
+    # Python scalar
+    meta = make_meta(1.0)
+    assert isinstance(meta, np.ndarray)
+    assert meta.shape == (0,)
+    assert meta.dtype == 'f8'
+
+    # datetime
+    meta = make_meta(pd.NaT)
+    assert isinstance(meta, np.ndarray)
+    assert meta.shape == (0,)
+    assert meta.dtype == pd.Series(pd.NaT).dtype
+
 
 def test_meta_nonempty():
     df1 = pd.DataFrame({'A': pd.Categorical(['Alice', 'Bob', 'Carol']),

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -172,8 +172,13 @@ def make_meta(x, index=None):
                              "got {0}".format(x))
         return pd.DataFrame({c: pd.Series([], dtype=d) for (c, d) in x},
                             columns=[c for c, d in x], index=index)
+    # For operations that return scalars:
     elif hasattr(x, 'dtype'):
         return np.array([], dtype=x.dtype)
+    elif isinstance(x, pd.datetime):
+        return pd.Series([x]).as_matrix()[:0]
+    elif np.isscalar(x):
+        return np.array([x])[:0]
     else:
         raise TypeError("Don't know how to create metadata from {0}".format(x))
 


### PR DESCRIPTION
Some pandas operations can return python objects instead of things with
`dtype` attributes. Now we infer `dtype` from all scalars.