### PR TITLE
Add code quality tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - pip install git+https://github.com/mrocklin/partd --upgrade
   - pip install git+https://github.com/mrocklin/cachey --upgrade
   - pip install blosc --upgrade
-  - pip install graphviz moto
+  - pip install graphviz moto flake8
   - if [[ $PYTHON < '3' ]]; then pip install git+https://github.com/Blosc/castra; fi
 
   # Install dask

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -146,7 +146,6 @@ def coarsen(reduction, x, axes, trim_excess=False):
     newshape = tuple(concat([(x.shape[i] / axes[i], axes[i])
                                 for i in range(x.ndim)]))
 
-
     return reduction(x.reshape(newshape), axis=tuple(range(1, x.ndim*2, 2)))
 
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -23,7 +23,7 @@ import numpy as np
 from . import chunk
 from .slicing import slice_array
 from . import numpy_compat
-from ..base import Base, compute, tokenize, normalize_token
+from ..base import Base, tokenize, normalize_token
 from ..utils import (deepmap, ignoring, concrete, is_integer,
         IndexCallable, funcname)
 from ..compatibility import unicode, long, getargspec, zip_longest, apply
@@ -1896,8 +1896,6 @@ def concatenate(seq, axis=0):
     dsk = dict(zip(keys, values))
     dsk2 = merge(dsk, *[a.dask for a in seq])
 
-
-
     return Array(dsk2, name, chunks, dtype=dt)
 
 
@@ -2220,7 +2218,6 @@ def elemwise(op, *args, **kwargs):
         return atop(op, expr_inds,
                 *concat((a, tuple(range(a.ndim)[::-1])) for a in arrays),
                 dtype=dt, name=name)
-
 
 
 def wrap_elemwise(func, **kwargs):
@@ -2748,7 +2745,6 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
     chunks = ((1,) * nchunks, (len(bins) - 1,))
 
     name = 'histogram-sum-' + token
-
 
     # Map the histogram to all bins
     def block_hist(x, weights=None):

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -768,4 +768,3 @@ def lstsq(a, b):
               chunks=r.shape[0], dtype=ss.dtype)
 
     return x, residuals, rank, s
-

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -139,7 +139,6 @@ def slice_array(out_name, in_name, blockdims, index):
     return dsk_out, bd_out
 
 
-
 def slice_with_newaxes(out_name, in_name, blockdims, index):
     """
     Handle indexing with Nones

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1,25 +1,36 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
-pytest.importorskip('numpy')
+np = pytest.importorskip('numpy')
 
-from distutils.version import LooseVersion
-from operator import add, sub
 import os
-import shutil
 import time
 import sys
+from distutils.version import LooseVersion
+from operator import add, sub, getitem
+from threading import Lock
 
-from toolz import merge, countby
+from toolz import merge, countby, concat
 from toolz.curried import identity
 
 import dask
 import dask.array as da
-import dask.dataframe as dd
+from dask.base import tokenize
 from dask.delayed import delayed
 from dask.async import get_sync
-from dask.array.core import *
 from dask.utils import raises, ignoring, tmpfile, tmpdir
+from dask.utils_test import inc
+
+from dask.array import chunk
+from dask.array.core import (getem, getarray, top, dotmany, concatenate3,
+                             broadcast_dimensions, Array, stack, concatenate,
+                             from_array, take, elemwise, isnull, notnull,
+                             broadcast_shapes, partial_by_order, exp,
+                             tensordot, choose, where, coarsen, insert,
+                             broadcast_to, unravel, reshape, fromfunction,
+                             blockdims_from_blockshape, store, optimize,
+                             from_func, normalize_chunks, broadcast_chunks,
+                             atop, from_delayed)
 from dask.array.utils import assert_eq
 
 # temporary until numpy functions migrated
@@ -29,9 +40,6 @@ except ImportError:  # pragma: no cover
     import dask.array.numpy_compat as npcompat
     nancumsum = npcompat.nancumsum
     nancumprod = npcompat.nancumprod
-
-def inc(x):
-    return x + 1
 
 
 def same_keys(a, b):
@@ -560,7 +568,7 @@ def test_where():
 def test_where_has_informative_error():
     x = da.ones(5, chunks=3)
     try:
-        result = da.where(x > 0)
+        da.where(x > 0)
     except Exception as e:
         assert 'dask' in str(e)
 
@@ -728,8 +736,6 @@ def test_full():
 
 
 def test_map_blocks():
-    inc = lambda x: x + 1
-
     x = np.arange(400).reshape((20, 20))
     d = from_array(x, chunks=(7, 7))
 
@@ -947,7 +953,7 @@ def test_store_locks():
 @pytest.mark.xfail(reason="can't lock with multiprocessing")
 def test_store_multiprocessing_lock():
     d = da.ones((10, 10), chunks=(2, 2))
-    a, b = d + 1, d + 2
+    a = d + 1
 
     at = np.zeros(shape=(10, 10))
     a.store(at, get=dask.multiprocessing.get, num_workers=10)
@@ -993,6 +999,7 @@ def test_to_hdf5():
 
 
 def test_to_dask_dataframe():
+    dd = pytest.importorskip('dask.dataframe')
     a = da.ones((4,), chunks=(2,))
     d = a.to_dask_dataframe()
     assert isinstance(d, dd.Series)
@@ -1256,7 +1263,6 @@ def test_slicing_with_non_ndarrays():
         def __getitem__(self, key):
             return ARangeSlice(key[0].start, key[0].stop)
 
-
     x = da.from_array(ARangeSlicable(10), chunks=(4,))
 
     assert_eq((x + 1).sum(), (np.arange(10, dtype=x.dtype) + 1).sum())
@@ -1428,8 +1434,6 @@ def test_histogram():
 
 def test_histogram_alternative_bins_range():
     v = da.random.random(100, chunks=10)
-    bins = np.arange(0, 1.01, 0.01)
-    # Other input
     (a1, b1) = da.histogram(v, bins=10, range=(0, 1))
     (a2, b2) = np.histogram(v, bins=10, range=(0, 1))
     assert_eq(a1, a2)
@@ -1673,8 +1677,6 @@ def test_slice_with_floats():
         d[[1, 1.5]]
 
 
-
-
 def test_vindex_errors():
     d = da.ones((5, 5, 5), chunks=(3, 3, 3))
     assert raises(IndexError, lambda: d.vindex[0])
@@ -1682,6 +1684,7 @@ def test_vindex_errors():
     assert raises(IndexError, lambda: d.vindex[[1, 2, 3], [1, 2, 3], 0])
     assert raises(IndexError, lambda: d.vindex[[1], [1, 2, 3]])
     assert raises(IndexError, lambda: d.vindex[[1, 2, 3], [[1], [2], [3]]])
+
 
 def test_vindex_merge():
     from dask.array.core import _vindex_merge
@@ -1951,7 +1954,6 @@ def test_cumulative():
     for axis in [0, 1, 2]:
         assert_eq(da.nancumsum(x, axis=axis), nancumsum(a, axis=axis))
         assert_eq(da.nancumprod(x, axis=axis), nancumprod(a, axis=axis))
-
 
 
 def test_eye():

--- a/dask/array/tests/test_ghost.py
+++ b/dask/array/tests/test_ghost.py
@@ -206,7 +206,7 @@ def test_map_overlap():
     x = np.arange(16).reshape((4, 4))
     d = da.from_array(x, chunks=(2, 2))
     exp1 = d.map_overlap(lambda x: x + x.size, depth=1).compute()
-    exp2 = d.map_overlap(lambda x: x + x.size, depth={0: 1, 1: 1},\
+    exp2 = d.map_overlap(lambda x: x + x.size, depth={0: 1, 1: 1},
                     boundary={0: 'reflect', 1: 'none'}).compute()
     assert eq(exp1, x + 16)
     assert eq(exp2, x + 12)

--- a/dask/array/tests/test_image.py
+++ b/dask/array/tests/test_image.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
 import os
-import shutil
 
 import pytest
 pytest.importorskip('skimage')

--- a/dask/array/tests/test_learn.py
+++ b/dask/array/tests/test_learn.py
@@ -38,4 +38,3 @@ def test_fit():
     result = da.learn.predict(sgd, Z)
     assert result.chunks == ((2, 2),)
     assert result.compute(get=dask.get).tolist() == [1, -1, 1, -1]
-

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -403,7 +403,6 @@ def test_cholesky(shape, chunk):
     assert_eq(da.linalg.cholesky(dA, lower=True), scipy.linalg.cholesky(A, lower=True))
 
 
-
 @pytest.mark.parametrize(("nrow", "ncol", "chunk"),
                          [(20, 10, 5), (100, 10, 10)])
 def test_lstsq(nrow, ncol, chunk):

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -104,7 +104,7 @@ def test_docs():
 
 
 def test_can_make_really_big_random_array():
-    x = normal(10, 1, (1000000, 1000000), chunks=(100000, 100000))
+    normal(10, 1, (1000000, 1000000), chunks=(100000, 100000))
 
 
 def test_random_seed():

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -73,7 +73,7 @@ def test_intersect_2():
 def test_rechunk_1d():
     """Try rechunking a random 1d matrix"""
     a = np.random.uniform(0,1,300)
-    x = da.from_array(a, chunks = ((100,)*3,))
+    x = da.from_array(a, chunks=((100,)*3,))
     new = ((50,)*6,)
     x2 =rechunk(x, chunks=new)
     assert x2.chunks == new
@@ -83,7 +83,7 @@ def test_rechunk_1d():
 def test_rechunk_2d():
     """Try rechunking a random 2d matrix"""
     a = np.random.uniform(0,1,300).reshape((10,30))
-    x = da.from_array(a, chunks = ((1,2,3,4),(5,)*6))
+    x = da.from_array(a, chunks=((1,2,3,4),(5,)*6))
     new = ((5,5), (15,)*2)
     x2 =rechunk(x, chunks=new)
     assert x2.chunks == new
@@ -94,9 +94,9 @@ def test_rechunk_4d():
     """Try rechunking a random 4d matrix"""
     old = ((5,5),)*4
     a = np.random.uniform(0,1,10000).reshape((10,) * 4)
-    x = da.from_array(a, chunks = old)
+    x = da.from_array(a, chunks=old)
     new = ((10,),)* 4
-    x2 =rechunk(x, chunks = new)
+    x2 =rechunk(x, chunks=new)
     assert x2.chunks == new
     assert np.all(x2.compute() == a)
 

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -290,7 +290,6 @@ def test_take():
     assert dsk == expected
     assert chunks == ((4,), (20, 20))
 
-
     chunks, dsk = take('y', 'x', [(20, 20, 20, 20), (20, 20)], [5, 1, 37, 3], axis=1)
     expected = dict((('y', i, 0),
             (getitem,

--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -33,8 +33,8 @@ def test_full():
     assert a._dtype == a.compute(get=dask.get).dtype == 'i8'
 
 def test_can_make_really_big_array_of_ones():
-    a = ones((1000000, 1000000), chunks=(100000, 100000))
-    a = ones(shape=(1000000, 1000000), chunks=(100000, 100000))
+    ones((1000000, 1000000), chunks=(100000, 100000))
+    ones(shape=(1000000, 1000000), chunks=(100000, 100000))
 
 
 def test_wrap_consistent_names():

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -56,16 +56,16 @@ def wrap_func_shape_as_first_arg(func, *args, **kwargs):
 @curry
 def wrap(wrap_func, func, **kwargs):
     f = partial(wrap_func, func, **kwargs)
+    template = """
+    Blocked variant of %(name)s
+
+    Follows the signature of %(name)s exactly except that it also requires a
+    keyword argument chunks=(...)
+
+    Original signature follows below.
+    """
     if func.__doc__ is not None:
-        f.__doc__ = """
-        Blocked variant of %(name)s
-    
-        Follows the signature of %(name)s exactly except that it also requires a
-        keyword argument chunks=(...)
-    
-        Original signature follows below.
-        """ % {'name': func.__name__} + func.__doc__
-    
+        f.__doc__ = template % {'name': func.__name__} + func.__doc__
         f.__name__ = 'blocked_' + func.__name__
     return f
 

--- a/dask/async.py
+++ b/dask/async.py
@@ -114,7 +114,6 @@ See the function ``inline_functions`` for more information.
 """
 from __future__ import absolute_import, division, print_function
 
-from operator import add
 import sys
 import traceback
 
@@ -124,10 +123,7 @@ from .context import _globals
 from .order import order
 from .callbacks import unpack_callbacks
 from .optimize import cull
-
-
-def inc(x):
-    return x + 1
+from .utils_test import add, inc  # noqa: F401
 
 
 DEBUG = False
@@ -512,6 +508,7 @@ Usually we supply a multi-core apply_async function.  Here we provide a
 sequential one.  This is useful for debugging and for code dominated by the
 GIL
 """
+
 
 def apply_sync(func, args=(), kwds={}):
     """ A naive synchronous version of apply_async """

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -4,7 +4,6 @@ from collections import Iterable, Iterator, defaultdict
 from functools import wraps, partial
 import itertools
 import math
-from operator import getitem
 import os
 import types
 import uuid
@@ -24,22 +23,20 @@ try:
     from cytoolz import (frequencies, merge_with, join, reduceby,
                          count, pluck, groupby, topk)
     if LooseVersion(cytoolz.__version__) > '0.7.3':
-        from cytoolz import accumulate
+        from cytoolz import accumulate  # noqa: F811
         _implement_accumulate = True
 except:
     from toolz import (frequencies, merge_with, join, reduceby,
                        count, pluck, groupby, topk)
 
 from ..base import Base, normalize_token, tokenize
-from ..compatibility import apply, unicode, urlopen
+from ..compatibility import apply, urlopen
 from ..context import _globals
 from ..core import list2, quote, istask, get_dependencies, reverse_dict
 from ..multiprocessing import get as mpget
 from ..optimize import fuse, cull, inline
-from ..utils import (infer_compression, open, system_encoding,
-                     takes_multiple_arguments, funcname, digit, insert,
-                     build_name_function, different_seeds)
-from ..delayed import Delayed, delayed
+from ..utils import (open, system_encoding, takes_multiple_arguments, funcname,
+                     digit, insert, different_seeds)
 from ..bytes.core import write_bytes
 
 
@@ -569,7 +566,6 @@ class Bag(Base):
                     if kwargs else (func, (self.name, i)))
                    for i in range(self.npartitions))
         return type(self)(dsk, name, self.npartitions)
-
 
     def pluck(self, key, default=no_default):
         """ Select item from all tuples/dicts in collection
@@ -1579,7 +1575,6 @@ def groupby_tasks(b, grouper, hash=hash, max_branch=32):
 
     inputs = [tuple(digit(i, j, k) for j in range(stages))
               for i in range(k**stages)]
-    sinputs = set(inputs)
 
     b2 = b.map(lambda x: (hash(grouper(x)), x))
 

--- a/dask/bag/tests/test_text.py
+++ b/dask/bag/tests/test_text.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import pytest
-from toolz import concat, valmap, partial
+from toolz import partial
 
 from dask import compute, get
 from dask.utils import filetexts
@@ -23,10 +23,9 @@ files = {'.test.accounts.1.json':  ('{"amount": 100, "name": "Alice"}\n'
 
 expected = ''.join([files[v] for v in sorted(files)])
 
-from dask.bytes.compression import compress, files as cfiles, seekable_files
-fmt_bs = ([(fmt, None) for fmt in cfiles]
-        + [(fmt, 10) for fmt in seekable_files]
-        + [(fmt, None) for fmt in seekable_files])
+fmt_bs = ([(fmt, None) for fmt in compression.files]
+        + [(fmt, 10) for fmt in compression.seekable_files]
+        + [(fmt, None) for fmt in compression.seekable_files])
 encodings = ['ascii', 'utf-8'] # + ['utf-16', 'utf-16-le', 'utf-16-be']
 fmt_bs_enc = [(fmt, bs, encoding) for fmt, bs in fmt_bs
                                   for encoding in encodings]

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -365,11 +365,12 @@ def open_text_files(urlpath, encoding=system_encoding, errors='strict',
 
 
 def ensure_protocol(protocol):
-    if protocol in _read_bytes or protocol in _open_files:
+    if (protocol not in ('s3', 'hdfs') and ((protocol in _read_bytes)
+            or (protocol in _open_files))):
         return
 
     if protocol == 's3':
-        import_required('dask.s3',
+        import_required('s3fs',
                         "Need to install `s3fs` library for s3 support\n"
                         "    conda install s3fs -c conda-forge\n"
                         "    or\n"

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -12,7 +12,8 @@ from ..compatibility import PY2, unicode
 from ..base import tokenize
 from ..delayed import delayed, Delayed, apply
 from ..utils import (infer_storage_options, system_encoding,
-                     build_name_function, infer_compression)
+                     build_name_function, infer_compression,
+                     import_required)
 
 delayed = delayed(pure=True)
 
@@ -289,7 +290,7 @@ def _expand_paths(path, name_function, num):
         if name_function is None:
             name_function = build_name_function(num - 1)
 
-        if not '*' in path:
+        if '*' not in path:
             path = os.path.join(path, '*.part')
 
         formatted_names = [name_function(i) for i in range(num)]
@@ -368,21 +369,18 @@ def ensure_protocol(protocol):
         return
 
     if protocol == 's3':
-        try:
-            import dask.s3
-        except ImportError:
-            raise ImportError("Need to install `s3fs` library for s3 support\n"
-                    "    conda install s3fs -c conda-forge\n"
-                    "    or\n"
-                    "    pip install s3fs")
+        import_required('dask.s3',
+                        "Need to install `s3fs` library for s3 support\n"
+                        "    conda install s3fs -c conda-forge\n"
+                        "    or\n"
+                        "    pip install s3fs")
 
     elif protocol == 'hdfs':
-        try:
-            import distributed.hdfs
-        except ImportError:
-            raise ImportError("Need to install `distributed` and `hdfs3` "
-                    "for HDFS support\n"
-                    "    conda install distributed hdfs3 -c conda-forge")
+        msg = ("Need to install `distributed` and `hdfs3` "
+               "for HDFS support\n"
+               "    conda install distributed hdfs3 -c conda-forge")
+        import_required('distributed.hdfs', msg)
+        import_required('hdfs3', msg)
 
     else:
         raise ValueError("Unknown protocol %s" % protocol)

--- a/dask/bytes/local.py
+++ b/dask/bytes/local.py
@@ -1,11 +1,9 @@
 from __future__ import print_function, division, absolute_import
 
 from glob import glob
-import io
 import logging
 import os
 import sys
-import time
 
 from .compression import files as compress_files, seekable_files
 from .utils import SeekableFile, read_block

--- a/dask/bytes/tests/test_bytes_utils.py
+++ b/dask/bytes/tests/test_bytes_utils.py
@@ -56,13 +56,13 @@ def test_seek_delimiter_endline():
 
 def test_ensure_protocol():
     try:
-        import hdfs3
-        return
+        import hdfs3  # noqa: F401
+        pytest.skip()
     except ImportError:
         pass
 
     dd = pytest.importorskip('dask.dataframe')
     try:
-        df = dd.read_csv('hdfs://data/*.csv')
-    except ImportError as e:
+        dd.read_csv('hdfs://data/*.csv')
+    except RuntimeError as e:
         assert "hdfs3" in str(e)

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -34,7 +34,7 @@ files = {'test/accounts.1.json':  (b'{"amount": 100, "name": "Alice"}\n'
 @pytest.yield_fixture
 def s3():
     # writable local S3 system
-    with moto.mock_s3() as m:
+    with moto.mock_s3():
         client = boto3.client('s3')
         client.create_bucket(Bucket=test_bucket_name, ACL='public-read-write')
         for f, data in files.items():

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from __future__ import absolute_import, division, print_function
 
 import functools
@@ -36,8 +37,7 @@ if PY3:
         pass
 
     from urllib.request import urlopen
-    from urllib.parse import urlparse
-    from urllib.parse import quote, unquote
+    from urllib.parse import urlparse, urlsplit, quote, unquote
     FileNotFoundError = FileNotFoundError
     unicode = str
     long = int
@@ -63,7 +63,7 @@ else:
     import bz2
     import gzip
     from urllib2 import urlopen
-    from urlparse import urlparse
+    from urlparse import urlparse, urlsplit
     from urllib import quote, unquote
     unicode = unicode
     long = long

--- a/dask/core.py
+++ b/dask/core.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from operator import add
-
 from itertools import chain
 
-def inc(x):
-    return x + 1
+from .utils_test import add, inc  # noqa: F401
+
 
 def ishashable(x):
     """ Is x hashable?

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -452,7 +452,6 @@ def test_scalar_arithmetics_with_dask_instances():
     assert isinstance(result, dd.Series)
     assert eq(result, pds + e)
 
-
     # pandas DataFrame
     result = pdf + s   # this result pd.DataFrame (automatically computed)
     assert isinstance(result, pd.DataFrame)
@@ -616,7 +615,6 @@ def test_reductions():
         assert eq(dds.std(skipna=False, ddof=0), pds.std(skipna=False, ddof=0))
         assert eq(dds.var(skipna=False, ddof=0), pds.var(skipna=False, ddof=0))
         assert eq(dds.mean(skipna=False), pds.mean(skipna=False))
-
 
     assert_dask_graph(ddf1.b.sum(), 'series-sum')
     assert_dask_graph(ddf1.b.min(), 'series-min')

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -37,19 +37,16 @@ def test_categorical_set_index(shuffle):
 
     with dask.set_options(get=get_sync, shuffle=shuffle):
         b = a.set_index('y')
-        df2 = df.set_index('y')
         d1, d2 = b.get_partition(0), b.get_partition(1)
         assert list(d1.index.compute()) == ['a']
         assert list(sorted(d2.index.compute())) == ['b', 'b', 'c']
 
         b = a.set_index(a.y)
-        df2 = df.set_index(df.y)
         d1, d2 = b.get_partition(0), b.get_partition(1)
         assert list(d1.index.compute()) == ['a']
         assert list(sorted(d2.index.compute())) == ['b', 'b', 'c']
 
         b = a.set_partition('y', ['a', 'b', 'c'])
-        df2 = df.set_index(df.y)
         d1, d2 = b.get_partition(0), b.get_partition(1)
         assert list(d1.index.compute()) == ['a']
         assert list(sorted(d2.index.compute())) == ['b', 'b', 'c']

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -12,8 +12,8 @@ from dask import delayed
 from dask.utils import raises, ignoring
 import dask.dataframe as dd
 
-from dask.dataframe.core import (repartition_divisions, _loc,
-        _coerce_loc_index, aca, reduction, _concat, _Frame)
+from dask.dataframe.core import (repartition_divisions, _loc, aca, reduction,
+                                 _concat, _Frame)
 from dask.dataframe.utils import eq, make_meta
 
 
@@ -1119,7 +1119,6 @@ def test_repartition():
     assert eq(a, b)
     assert eq(a._get(b.dask, (b._name, 0)), df.iloc[:1])
 
-
     for div in [[20, 60], [10, 50], [1], # first / last element mismatch
                 [0, 60], [10, 70], # do not allow to expand divisions by default
                 [10, 50, 20, 60],  # not sorted
@@ -1354,7 +1353,6 @@ def test_eval():
         if p.eval('z = x + y', inplace=None) is None:
             with pytest.raises(NotImplementedError):
                 d.eval('z = x + y', inplace=None)
-
 
 
 def test_deterministic_arithmetic_names():
@@ -1757,11 +1755,6 @@ def test_compute_divisions():
     assert b.known_divisions
 
 
-def test_columns_assignment():
-    df = pd.DataFrame({'x': [1, 2, 3, 4]})
-    ddf = dd.from_pandas(df, npartitions=2)
-
-
 def test_methods_tokenize_differently():
     df = pd.DataFrame({'x': [1, 2, 3, 4]})
     df = dd.from_pandas(df, npartitions=1)
@@ -1814,6 +1807,7 @@ def test_column_assignment():
     df['z'] = df.x + df.y
 
     eq(df, ddf)
+    assert 'z' not in orig.columns
 
 
 def test_columns_assignment():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -467,7 +467,6 @@ def test_numeric_column_names():
     eq(ddf.groupby(0).apply(lambda x: x), df.groupby(0).apply(lambda x: x))
 
 
-
 def test_groupby_apply_tasks():
     df = pd.util.testing.makeTimeDataFrame()
     df['A'] = df.A // 0.1

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -19,7 +19,6 @@ def test_column_optimizations_with_bcolz_and_rewrite():
     bcolz = pytest.importorskip('bcolz')
 
     bc = bcolz.ctable([[1, 2, 3], [10, 20, 30]], names=['a', 'b'])
-    func = lambda x: x
     for cols in [None, 'abc', ['abc']]:
         dsk2 = merge(dict((('x', i),
                           (dataframe_from_ctable, bc, slice(0, 2), cols, {}))

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -1,10 +1,8 @@
 import pandas as pd
-import pandas.util.testing as tm
 import pytest
 import numpy as np
 
 import dask.dataframe as dd
-from dask.async import get_sync
 from dask.dataframe.utils import eq
 from dask.utils import raises, ignoring
 
@@ -126,7 +124,7 @@ def test_rolling_dataframe(npartitions, method, args, window, center, axis,
                        'e': np.random.randint(100, size=(N,))})
     ddf = dd.from_pandas(df, npartitions)
 
-    prolling =  df.rolling(window, center=center, axis=axis)
+    prolling = df.rolling(window, center=center, axis=axis)
     drolling = ddf.rolling(window, center=center, axis=axis)
     eq(getattr(prolling, method)(*args), getattr(drolling, method)(*args),
        check_less_precise=check_less_precise)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -128,8 +128,6 @@ def test_set_partition_tasks(npartitions):
 
     ddf = dd.from_pandas(df, npartitions=npartitions)
 
-    divisions = [0, .25, .50, .75, 1.0]
-
     eq(df.set_index('x'),
        ddf.set_index('x', shuffle='tasks'))
 
@@ -170,8 +168,6 @@ def test_set_partition_names(shuffle):
 
     ddf = dd.from_pandas(df, npartitions=4)
 
-    divisions = [0, .25, .50, .75, 1.0]
-
     assert (set(ddf.set_index('x', shuffle=shuffle).dask) ==
             set(ddf.set_index('x', shuffle=shuffle).dask))
     assert (set(ddf.set_index('x', shuffle=shuffle).dask) !=
@@ -194,7 +190,6 @@ def test_set_partition_tasks_2(shuffle):
 
 @pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
 def test_set_partition_tasks_3(shuffle):
-    npartitions = 5
     df = pd.DataFrame(np.random.random((10, 2)), columns=['x', 'y'])
     ddf = dd.from_pandas(df, npartitions=5)
 

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -50,7 +50,7 @@ def test_profiler_works_under_error():
 
     with ignoring(ZeroDivisionError):
         with prof:
-            out = get(dsk, 'z')
+            get(dsk, 'z')
 
     assert all(len(v) == 5 for v in prof.results)
     assert len(prof.results) == 2
@@ -78,7 +78,7 @@ def test_two_gets():
 @pytest.mark.skipif("not psutil")
 def test_resource_profiler():
     with ResourceProfiler(dt=0.01) as rprof:
-        out = get(dsk2, 'c')
+        get(dsk2, 'c')
     results = rprof.results
     assert all(isinstance(i, tuple) and len(i) == 3 for i in results)
 
@@ -118,7 +118,7 @@ def test_resource_profiler_multiple_gets():
 
 def test_cache_profiler():
     with CacheProfiler() as cprof:
-        out = get(dsk2, 'c')
+        get(dsk2, 'c')
     results = cprof.results
     assert all(isinstance(i, tuple) and len(i) == 5 for i in results)
 
@@ -131,7 +131,7 @@ def test_cache_profiler():
         return tics[0]
 
     with CacheProfiler(nbytes) as cprof:
-        out = get(dsk2, 'c')
+        get(dsk2, 'c')
     results = cprof.results
     assert tics[-1] == len(results)
     assert tics[-1] == results[-1].metric

--- a/dask/distributed.py
+++ b/dask/distributed.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from __future__ import absolute_import, division, print_function
 
 from distributed import Executor, progress, s3, hdfs, as_completed, wait

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from __future__ import print_function, division, absolute_import
 
 from warnings import warn

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -5,8 +5,9 @@ from operator import getitem
 
 from .compatibility import zip_longest
 
+from .core import add, inc  # noqa: F401
 from .core import (istask, get_dependencies, subs, toposort, flatten,
-                   reverse_dict, add, inc, ishashable, preorder_traversal)
+                   reverse_dict, ishashable, preorder_traversal)
 from .rewrite import END
 
 

--- a/dask/order.py
+++ b/dask/order.py
@@ -56,9 +56,8 @@ the descendent on whose result the most tasks depend.
 """
 from __future__ import absolute_import, division, print_function
 
-from operator import add
-
-from .core import get_dependencies, reverse_dict, get_deps
+from .core import get_dependencies, reverse_dict, get_deps  # noqa: F401
+from .utils_test import add, inc  # noqa: F401
 
 
 def order(dsk, dependencies=None):
@@ -192,7 +191,3 @@ def dfs(dependencies, dependents, key=lambda x: x):
         i += 1
 
     return result
-
-
-def inc(x):
-    return x + 1

--- a/dask/store/core.py
+++ b/dask/store/core.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import defaultdict, MutableMapping
-from operator import getitem, add
+from operator import getitem
 from datetime import datetime
 from time import time
 
 from ..core import istask, ishashable
+from ..utils_test import add  # noqa: F401
 
 
 class Store(MutableMapping):

--- a/dask/store/tests/test_store.py
+++ b/dask/store/tests/test_store.py
@@ -1,10 +1,6 @@
 from dask.store import Store
-from operator import add, mul
 from dask.utils import raises
-
-
-def inc(x):
-    return x + 1
+from dask.utils_test import inc, add
 
 
 def test_basic():

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-from operator import add
-from copy import deepcopy
-
 import dask
-import pytest
 
-from dask.async import *
-from dask.utils_test import GetFunctionTestMixin
+from dask.async import (start_state_from_dask, get_sync, finish_task, sortkey,
+                        remote_exception)
+from dask.order import order
+from dask.utils_test import GetFunctionTestMixin, inc, add
 
 
 fib_dask = {'f0': 0, 'f1': 1, 'f2': 1, 'f3': 2, 'f4': 3, 'f5': 5, 'f6': 8}
@@ -17,23 +15,24 @@ def test_start_state():
     dsk = {'x': 1, 'y': 2, 'z': (inc, 'x'), 'w': (add, 'z', 'y')}
     result = start_state_from_dask(dsk)
 
-    expeted = {'cache': {'x': 1, 'y': 2},
-               'dependencies': {'w': set(['y', 'z']),
-                                'x': set([]),
-                                'y': set([]),
-                                'z': set(['x'])},
-               'dependents': {'w': set([]),
-                              'x': set(['z']),
-                              'y': set(['w']),
-                              'z': set(['w'])},
-               'finished': set([]),
-               'released': set([]),
-               'running': set([]),
-               'ready': ['z'],
-               'waiting': {'w': set(['z'])},
-               'waiting_data': {'x': set(['z']),
-                                'y': set(['w']),
-                                'z': set(['w'])}}
+    expected = {'cache': {'x': 1, 'y': 2},
+                'dependencies': {'w': set(['y', 'z']),
+                                 'x': set([]),
+                                 'y': set([]),
+                                 'z': set(['x'])},
+                'dependents': {'w': set([]),
+                               'x': set(['z']),
+                               'y': set(['w']),
+                               'z': set(['w'])},
+                'finished': set([]),
+                'released': set([]),
+                'running': set([]),
+                'ready': ['z'],
+                'waiting': {'w': set(['z'])},
+                'waiting_data': {'x': set(['z']),
+                                 'y': set(['w']),
+                                 'z': set(['w'])}}
+    assert result == expected
 
 
 def test_start_state_looks_at_cache():
@@ -75,7 +74,6 @@ def test_finish_task():
     task = 'z'
     result = 2
 
-    oldstate = deepcopy(state)
     state['cache']['z'] = result
     finish_task(dsk, task, state, set(), sortkey)
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import shutil
 import pytest
 from operator import add, mul
 import sys

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 from dask.utils import raises
-from dask.utils_test import GetFunctionTestMixin
+from dask.utils_test import GetFunctionTestMixin, inc, add
 from dask import core
 from dask.core import (istask, get_dependencies, flatten, subs,
                        preorder_traversal, quote, _deps, has_tasks)
@@ -16,14 +16,6 @@ def contains(a, b):
     False
     """
     return all(a.get(k) == v for k, v in b.items())
-
-
-def inc(x):
-    return x + 1
-
-
-def add(x, y):
-    return x + y
 
 
 def test_istask():

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -2,4 +2,4 @@ import pytest
 pytest.importorskip('distributed')
 
 def test_can_import_executor():
-    from dask.distributed import Executor
+    from dask.distributed import Executor  # noqa: F401

--- a/dask/tests/test_flake8.py
+++ b/dask/tests/test_flake8.py
@@ -1,0 +1,21 @@
+# This is based on bokeh's bokeh/tests/test_flake8.py
+
+from os import chdir, pardir
+from os.path import abspath, join, split
+from subprocess import PIPE, Popen
+
+import pytest
+
+TOP_PATH = abspath(join(split(__file__)[0], pardir, pardir))
+
+
+@pytest.mark.quality
+def test_flake8():
+    pytest.importorskip('flake8')
+
+    chdir(TOP_PATH)
+
+    proc = Popen(["flake8", "dask"], stdout=PIPE, stderr=PIPE)
+    out, err = proc.communicate()
+
+    assert proc.returncode == 0, "Flake8 issues:\n%s" % out.decode("utf-8")

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -5,9 +5,7 @@ from operator import add
 
 from dask.context import set_options
 from dask.multiprocessing import get, _dumps, _loads
-
-
-inc = lambda x: x + 1
+from dask.utils_test import inc
 
 
 def test_pickle_globals():

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -1,14 +1,11 @@
 from itertools import count
-from operator import add, mul, getitem
+from operator import mul, getitem
 from functools import partial
 from dask.utils import raises
+from dask.utils_test import add, inc
 from dask.optimize import (cull, fuse, inline, inline_functions, functions_of,
         dealias, equivalent, sync_keys, merge_sync, fuse_getitem,
         fuse_selections)
-
-
-def inc(x):
-    return x + 1
 
 
 def double(x):
@@ -221,7 +218,6 @@ def test_inline_functions_protects_output_keys():
 def test_functions_of():
     a = lambda x: x
     b = lambda x: x
-    c = lambda x: x
     assert functions_of((a, 1)) == set([a])
     assert functions_of((a, (b, 1))) == set([a, b])
     assert functions_of((a, [(b, 1)])) == set([a, b])

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -1,8 +1,8 @@
 from itertools import chain
-from operator import add
 
-from dask.order import dfs, child_max, ndependents, order, inc
+from dask.order import child_max, ndependents, order
 from dask.core import get_deps
+from dask.utils_test import add, inc
 
 
 def issorted(L, reverse=False):
@@ -45,9 +45,6 @@ def test_prefer_broker_nodes():
     dsk = {(a, 0): (f,), (a, 1): (f,),
            (b, 0): (f, (a, 0)), (b, 1): (f, (a, 1)), (b, 2): (f, (a, 1))}
 
-    dependencies, dependents = get_deps(dsk)
-    nd = ndependents(dependencies, dependents)
-    cm = child_max(dependencies, dependents, nd)
     o = order(dsk)
 
     assert o[(a, 1)] < o[(a, 0)]
@@ -110,10 +107,6 @@ def test_deep_bases_win_over_dependents():
     """
     dsk = {'a': (f, 'b', 'c', 'd'), 'b': (f, 'd', 'e'), 'c': (f, 'd'), 'd': 1,
             'e': 2}
-
-    dependencies, dependents = get_deps(dsk)
-    nd = ndependents(dependencies, dependents)
-    cm = child_max(dependencies, dependents, nd)
 
     o = order(dsk)
     assert o['d'] < o['e']
@@ -181,6 +174,6 @@ def test_break_ties_by_str():
 
 
 def test_order_doesnt_fail_on_mixed_type_keys():
-    o = order({'x': (inc, 1),
-              ('y', 0): (inc, 2),
-              'z': (add, 'x', ('y', 0))})
+    order({'x': (inc, 1),
+           ('y', 0): (inc, 2),
+           'z': (add, 'x', ('y', 0))})

--- a/dask/tests/test_rewrite.py
+++ b/dask/tests/test_rewrite.py
@@ -1,12 +1,5 @@
 from dask.rewrite import RewriteRule, RuleSet, head, args, VAR, Traverser
-
-
-def inc(x):
-    return x + 1
-
-
-def add(x, y):
-    return x + y
+from dask.utils_test import inc, add
 
 
 def double(x):

--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -1,12 +1,9 @@
-from dask.threaded import get
-from dask.async import inc
-from dask.utils import raises
-from operator import add
-from dask.context import set_options
 from multiprocessing.pool import ThreadPool
 
-
-inc = lambda x: x + 1
+from dask.context import set_options
+from dask.threaded import get
+from dask.utils import raises
+from dask.utils_test import inc, add
 
 
 def test_get():

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -1,4 +1,3 @@
-import io
 import os
 
 import numpy as np
@@ -86,7 +85,6 @@ def test_gh606():
     linesep = os.linesep
 
     bin_euro = u'\u20ac'.encode(encoding)
-    bin_yen = u'\u00a5'.encode(encoding)
     bin_linesep = linesep.encode(encoding)
 
     data = (euro * 10) + linesep + (yen * 10) + linesep + (euro * 10)

--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -7,9 +7,10 @@ from __future__ import absolute_import, division, print_function
 
 from multiprocessing.pool import ThreadPool
 from threading import current_thread
-from .async import get_async, inc, add
+from .async import get_async
 from .compatibility import Queue
 from .context import _globals
+from .utils_test import inc, add  # noqa: F401
 
 
 default_pool = ThreadPool()

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1,32 +1,27 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterator
-from contextlib import contextmanager
-from errno import ENOENT
+import codecs
 import functools
+import inspect
 import io
+import math
 import os
 import re
-import sys
 import shutil
 import struct
+import sys
 import tempfile
-import inspect
-import codecs
-import math
+from errno import ENOENT
+from collections import Iterator
+from contextlib import contextmanager
 from importlib import import_module
-from sys import getdefaultencoding
 
-try:
-    from urllib.parse import urlsplit
-except ImportError: # fallback to Python 2.x
-    from urlparse import urlsplit
-
-from .compatibility import long, getargspec, BZ2File, GzipFile, LZMAFile
+from .compatibility import (long, getargspec, BZ2File, GzipFile, LZMAFile, PY3,
+                            urlsplit)
 from .core import get_deps
 
 
-system_encoding = getdefaultencoding()
+system_encoding = sys.getdefaultencoding()
 if system_encoding == 'ascii':
     system_encoding = 'utf-8'
 
@@ -436,13 +431,12 @@ ONE_ARITY_BUILTINS = set([abs, all, any, bool, bytearray, bytes, callable, chr,
     classmethod, complex, dict, dir, enumerate, eval, float, format, frozenset,
     hash, hex, id, int, iter, len, list, max, min, next, oct, open, ord, range,
     repr, reversed, round, set, slice, sorted, staticmethod, str, sum, tuple,
-    type, vars, zip])
-if sys.version_info[0] == 3: # Python 3
-    ONE_ARITY_BUILTINS |= set([ascii])
-if sys.version_info[:2] != (2, 6):
-    ONE_ARITY_BUILTINS |= set([memoryview])
+    type, vars, zip, memoryview])
+if PY3:
+    ONE_ARITY_BUILTINS.add(ascii)  # noqa: F821
 MULTI_ARITY_BUILTINS = set([compile, delattr, divmod, filter, getattr, hasattr,
     isinstance, issubclass, map, pow, setattr])
+
 
 def takes_multiple_arguments(func):
     """ Does this function take multiple arguments?
@@ -633,7 +627,7 @@ def digit(n, k, base):
     >>> digit(1234, 3, 10)
     1
     """
-    return n // base**k  % base
+    return n // base**k % base
 
 
 def insert(tup, loc, val):

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from .core import get
-
 
 def inc(x):
     return x + 1
@@ -27,8 +25,6 @@ class GetFunctionTestMixin(object):
     Note that the foreign `myget` function has to be explicitly decorated as a
     staticmethod.
     """
-    get = staticmethod(get)
-
     def test_get(self):
         d = {':x': 1,
              ':y': (inc, ':x'),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,35 @@
+[flake8]
+# References:
+# http://flake8.readthedocs.org/en/latest/config.html
+# http://flake8.readthedocs.org/en/latest/warnings.html#error-codes
+
+# Note: there cannot be spaces after comma's here
+exclude = __init__.py
+ignore =
+    # Continuation indent errors
+    E12,E13,
+    # Missing spaces around operators
+    E225,E226,E227,E228,
+    # Extra space in brackets
+    E20,
+    # Multiple spaces around ","
+    E231,E241,
+    # Comments
+    E26,
+    # Too many or not enough lank lines
+    E3,
+    # Import formatting
+    E4,
+    # Comparing types instead of isinstance
+    E721,
+    # Assigning lambda expression
+    E731,
+    # Restrictions on naming things
+    E741,E742,E743,
+    # Line break before binary operator
+    W503,
+    # Imports shadowed by loop variable
+    F402,
+    # List comprehension redefines variable
+    F812
+max-line-length = 120


### PR DESCRIPTION
Add code quality tests, and squash all issues to make them pass. Code
quality is checked with `flake8`, using a subset of errors (see
`setup.cfg`). A test in `dask/tests/test_flake8.py` is added to check
that there are no flake8 errors from this subset. This can be easily run
using `py.test`:

```
py.test -m quality dask
```

To ignore certain errors locally you can use the `# noqa: errors` per
line, or `# flake8: noqa` at the top of a file. This is used sparingly
throughout to silence complaints that are invalid/not useful.