### PR TITLE
Refactor Scalar class

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -101,16 +101,15 @@ class Scalar(Base):
     def _meta_nonempty(self):
         return self._meta
 
-    def __getattr__(self, key):
-        if key == 'dtype':
-            return self._meta.dtype
-        raise AttributeError("'Scalar' object has no attribute %r" % key)
+    @property
+    def dtype(self):
+        return self._meta.dtype
 
     def __dir__(self):
         o = set(dir(type(self)))
         o.update(self.__dict__)
-        if hasattr(self._meta, 'dtype'):
-            o.add('dtype')
+        if not hasattr(self._meta, 'dtype'):
+            o.remove('dtype')  # dtype only in `dir` if available
         return list(o)
 
     @property
@@ -1199,10 +1198,16 @@ class Series(_Frame):
         """ Return data type """
         return self._meta.dtype
 
-    def __getattr__(self, key):
-        if key == 'cat':
-            return self._meta.cat
-        raise AttributeError("'Series' object has no attribute %r" % key)
+    @property
+    def cat(self):
+        return self._meta.cat
+
+    def __dir__(self):
+        o = set(dir(type(self)))
+        o.update(self.__dict__)
+        if not hasattr(self._meta, 'cat'):
+            o.remove('cat')  # cat only in `dir` if available
+        return list(o)
 
     @property
     def column_info(self):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -101,10 +101,30 @@ class Scalar(Base):
     def _meta_nonempty(self):
         return self._meta
 
+    def __getattr__(self, key):
+        if key == 'dtype':
+            return self._meta.dtype
+        raise AttributeError("'Scalar' object has no attribute %r" % key)
+
+    def __dir__(self):
+        o = set(dir(type(self)))
+        o.update(self.__dict__)
+        if hasattr(self._meta, 'dtype'):
+            o.add('dtype')
+        return list(o)
+
     @property
     def divisions(self):
         """Dummy divisions to be compat with Series and DataFrame"""
         return [None, None]
+
+    def __repr__(self):
+        name = self._name if len(self._name) < 10 else self._name[:7] + '...'
+        if hasattr(self._meta, 'dtype'):
+            extra = ', dtype=%s' % self._meta.dtype
+        else:
+            extra = ', type=%s' % type(self._meta).__name__
+        return "dd.Scalar<%s%s>" % (name, extra)
 
     def __array__(self):
         # array interface is required to support pandas instance + Scalar

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -66,7 +66,7 @@ import pandas as pd
 from ..base import tokenize
 from ..compatibility import apply
 from .core import (_Frame, Scalar, DataFrame, map_partitions,
-                   Index, _maybe_from_pandas)
+                   Index, _maybe_from_pandas, new_dd_object)
 from .io import from_pandas
 from .shuffle import shuffle, rearrange_by_divisions
 
@@ -371,8 +371,8 @@ def concat_unindexed_dataframes(dfs):
 
     meta = pd.concat([df._meta for df in dfs], axis=1)
 
-    return _Frame(toolz.merge(dsk, *[df.dask for df in dfs]),
-                  name, meta, dfs[0].divisions)
+    return new_dd_object(toolz.merge(dsk, *[df.dask for df in dfs]),
+                         name, meta, dfs[0].divisions)
 
 
 def concat_indexed_dataframes(dfs, axis=0, join='outer'):
@@ -396,8 +396,8 @@ def concat_indexed_dataframes(dfs, axis=0, join='outer'):
     dsk = dict(((name, i), (_pdconcat, part, axis, join))
                 for i, part in enumerate(parts2))
 
-    return _Frame(toolz.merge(dsk, *[df.dask for df in dfs2]),
-                  name, meta, divisions)
+    return new_dd_object(toolz.merge(dsk, *[df.dask for df in dfs2]),
+                         name, meta, divisions)
 
 
 def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
@@ -613,8 +613,8 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
                     # remove last to concatenate with next
                     divisions += df.divisions[:-1]
                 divisions += dfs[-1].divisions
-                return _Frame(toolz.merge(dsk, *[df.dask for df in dfs]),
-                              name, meta, divisions)
+                return new_dd_object(toolz.merge(dsk, *[df.dask for df in dfs]),
+                                     name, meta, divisions)
             else:
                 if interleave_partitions:
                     return concat_indexed_dataframes(dfs, join=join)
@@ -642,8 +642,8 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
             dsk, meta = _concat_dfs(dfs, name, join=join)
 
             divisions = [None] * (sum([df.npartitions for df in dfs]) + 1)
-            return _Frame(toolz.merge(dsk, *[df.dask for df in dfs]),
-                          name, meta, divisions)
+            return new_dd_object(toolz.merge(dsk, *[df.dask for df in dfs]),
+                                 name, meta, divisions)
 
 
 ###############################################################
@@ -665,7 +665,7 @@ def _append(df, other, divisions):
         dsk[(name, npart + j)] = (other._name, j)
     dsk = toolz.merge(dsk, df.dask, other.dask)
     meta = df._meta.append(other._meta)
-    return _Frame(dsk, name, meta, divisions)
+    return new_dd_object(dsk, name, meta, divisions)
 
 
 ###############################################################

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -353,15 +353,14 @@ def check_frame_arithmetics(l, r, el, er, allow_comparison_ops=True):
 
 
 def test_scalar_arithmetics():
-    l = dd.core.Scalar({('l', 0): 10}, 'l')
-    r = dd.core.Scalar({('r', 0): 4}, 'r')
-    el = 10
-    er = 4
+    el = np.int64(10)
+    er = np.int64(4)
+    l = dd.core.Scalar({('l', 0): el}, 'l', 'i8')
+    r = dd.core.Scalar({('r', 0): er}, 'r', 'i8')
 
     assert isinstance(l, dd.core.Scalar)
     assert isinstance(r, dd.core.Scalar)
 
-    # l, r may be repartitioned, test whether repartition keeps original data
     assert eq(l, el)
     assert eq(r, er)
 
@@ -424,7 +423,7 @@ def test_scalar_arithmetics():
 
 
 def test_scalar_arithmetics_with_dask_instances():
-    s = dd.core.Scalar({('s', 0): 10}, 's')
+    s = dd.core.Scalar({('s', 0): 10}, 's', 'i8')
     e = 10
 
     pds = pd.Series([1, 2, 3, 4, 5, 6, 7])
@@ -487,7 +486,7 @@ def test_frame_series_arithmetic_methods():
     ds1 = ddf1.A
     ds2 = ddf2.A
 
-    s = dd.core.Scalar({('s', 0): 4}, 's')
+    s = dd.core.Scalar({('s', 0): 4}, 's', 'i8')
 
     for l, r, el, er in [(ddf1, ddf2, pdf1, pdf2), (ds1, ds2, ps1, ps2),
                          (ddf1.repartition(['a', 'f', 'j']), ddf2, pdf1, pdf2),

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -58,7 +58,9 @@ def test_dataframe_categoricals():
     df.x = df.x.astype('category')
     ddf = dd.from_pandas(df, npartitions=2)
     assert (ddf.x.cat.categories == pd.Index(['a', 'b', 'c'])).all()
+    assert 'cat' in dir(ddf.x)
     assert not hasattr(df.y, 'cat')
+    assert 'cat' not in dir(ddf.y)
 
 
 def test_categories():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -128,6 +128,22 @@ def test_Index():
         assert raises(AttributeError, lambda: ddf.index.index)
 
 
+def test_Scalar():
+    val = np.int64(1)
+    s = Scalar({('a', 0): val}, 'a', 'i8')
+    assert hasattr(s, 'dtype')
+    assert 'dtype' in dir(s)
+    assert eq(s, val)
+    assert repr(s) == "dd.Scalar<a, dtype=int64>"
+
+    val = pd.Timestamp('2001-01-01')
+    s = Scalar({('a', 0): val}, 'a', val)
+    assert not hasattr(s, 'dtype')
+    assert 'dtype' not in dir(s)
+    assert eq(s, val)
+    assert repr(s) == "dd.Scalar<a, type=Timestamp>"
+
+
 def test_attributes():
     assert 'a' in dir(d)
     assert 'foo' not in dir(d)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1549,6 +1549,18 @@ def test_corr():
     pytest.raises(TypeError, lambda: da.corr(ddf))
 
 
+def test_cov_corr_meta():
+    df = pd.DataFrame({'a': np.array([1, 2, 3]),
+                       'b': np.array([1.0, 2.0, 3.0], dtype='f4'),
+                       'c': np.array([1.0, 2.0, 3.0])},
+                       index=pd.Index([1, 2, 3], name='myindex'))
+    ddf = dd.from_pandas(df, npartitions=2)
+    eq(ddf.corr(), df.corr())
+    eq(ddf.cov(), df.cov())
+    assert ddf.a.cov(ddf.b)._meta.dtype == 'f8'
+    assert ddf.a.corr(ddf.b)._meta.dtype == 'f8'
+
+
 @pytest.mark.slow
 def test_cov_corr_stable():
     df = pd.DataFrame(np.random.random((20000000, 2)) * 2 - 1, columns=['a', 'b'])

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -19,7 +19,7 @@ def test_align_partitions():
                      index=[30, 70, 80, 100])
     b = dd.repartition(B, [30, 80, 100])
 
-    s = dd.core.Scalar({('s', 0): 10}, 's')
+    s = dd.core.Scalar({('s', 0): 10}, 's', 'i8')
 
     (aa, bb), divisions, L = align_partitions(a, b)
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -3,6 +3,8 @@ import pandas as pd
 import dask.dataframe as dd
 from dask.dataframe.utils import shard_df_on_index, meta_nonempty, make_meta
 
+import pytest
+
 
 def test_shard_df_on_index():
     df = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': list('abdabd')},
@@ -76,17 +78,19 @@ def test_make_meta():
     meta = make_meta(1.0)
     assert isinstance(meta, np.float64)
 
-    # datetime
-    x = pd.datetime(2000, 1, 1)
+    # Timestamp
+    x = pd.Timestamp(2000, 1, 1)
     meta = make_meta(x)
     assert meta is x
 
-    # categorical
-    x = pd.Categorical(['a', 'b', 'c'], ordered=True)
-    meta = make_meta(x)
-    assert (meta.categories == x.categories).all()
-    assert meta.ordered
-    assert len(meta) == 1
+    # Dtype expressions
+    meta = make_meta('i8')
+    assert isinstance(meta, np.int64)
+    meta = make_meta(float)
+    assert isinstance(meta, np.dtype(float).type)
+    meta = make_meta(np.dtype('bool'))
+    assert isinstance(meta, np.bool_)
+    assert pytest.raises(TypeError, lambda: make_meta(None))
 
 
 def test_meta_nonempty():
@@ -102,6 +106,7 @@ def test_meta_nonempty():
                        columns=list('DCBAHGFE'))
     df2 = df1.iloc[0:0]
     df3 = meta_nonempty(df2)
+    assert (df3.dtypes == df2.dtypes).all()
     assert df3['A'][0] == 'Alice'
     assert df3['B'][0] == 'foo'
     assert df3['C'][0] == 'foo'
@@ -113,6 +118,7 @@ def test_meta_nonempty():
     assert df3['H'][0] == 'foo'
 
     s = meta_nonempty(df2['A'])
+    assert s.dtype == df2['A'].dtype
     assert (df3['A'] == s).all()
 
 
@@ -168,3 +174,12 @@ def test_meta_nonempty_index():
         assert type(idx1) is type(idx2)
         assert idx1.name == idx2.name
     assert res.names == idx.names
+
+
+def test_meta_nonempty_scalar():
+    meta = meta_nonempty(np.float64(1.0))
+    assert isinstance(meta, np.float64)
+
+    x = pd.Timestamp(2000, 1, 1)
+    meta = meta_nonempty(x)
+    assert meta is x

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -133,11 +133,11 @@ def make_meta(x, index=None):
 
     Parameters
     ----------
-    x : dict, tuple, list, pd.Series, pd.DataFrame, pd.Index, scalar
+    x : dict, tuple, list, pd.Series, pd.DataFrame, pd.Index, dtype, scalar
         To create a DataFrame, provide a `dict` mapping of `{name: dtype}`, or
         an iterable of `(name, dtype)` tuples. To create a `Series`, provide a
         tuple of `(name, dtype)`. If a pandas object, names, dtypes, and index
-        should match the desired output. If a scalar, a numpy scalar of the
+        should match the desired output. If a dtype or scalar, a scalar of the
         same dtype is returned.
     index :  pd.Index, optional
         Any pandas index to use in the metadata. If none provided, a
@@ -151,6 +151,8 @@ def make_meta(x, index=None):
     Index: []
     >>> make_meta(('a', 'f8'))
     Series([], Name: a, dtype: float64)
+    >>> make_meta('i8')
+    1
     """
     if hasattr(x, '_meta'):
         return x._meta
@@ -171,18 +173,21 @@ def make_meta(x, index=None):
                              "got {0}".format(x))
         return pd.DataFrame({c: pd.Series([], dtype=d) for (c, d) in x},
                             columns=[c for c, d in x], index=index)
-    # For operations that return scalars:
-    elif isinstance(x, pd.Categorical):
-        return pd.Categorical(x.categories[:1], categories=x.categories,
-                              ordered=x.ordered)
-    elif isinstance(x, (pd.Timestamp, pd.Timedelta, pd.Period, pd.datetime)):
-        return x
-    elif hasattr(x, 'dtype'):
-        return _fake_np_scalar(x.dtype)
-    elif np.isscalar(x):
-        return np.array([x])[0]
-    else:
-        raise TypeError("Don't know how to create metadata from {0}".format(x))
+    elif not hasattr(x, 'dtype') and x is not None:
+        # could be a string, a dtype object, or a python type. Skip `None`,
+        # because it is implictly converted to `dtype('f8')`, which we don't
+        # want here.
+        try:
+            dtype = np.dtype(x)
+            return _scalar_from_dtype(dtype)
+        except:
+            # Continue on to next check
+            pass
+
+    if is_pd_scalar(x):
+        return _nonempty_scalar(x)
+
+    raise TypeError("Don't know how to create metadata from {0}".format(x))
 
 
 def _nonempty_index(idx):
@@ -220,34 +225,58 @@ def _nonempty_index(idx):
 
 
 _simple_fake_mapping = {
-    'b': True,
-    'c': complex(1, 0),
-    'V': np.array([b' '], dtype=np.void)[0],
+    'b': np.bool_(True),
+    'V': np.void(b' '),
     'M': np.datetime64('1970-01-01'),
     'm': np.timedelta64(1, 'D'),
+    'S': np.str_('foo'),
+    'a': np.str_('foo'),
+    'U': np.unicode_('foo'),
     'O': 'foo'
 }
 
-def _fake_np_scalar(dtype):
-    if dtype.kind in ['i', 'f', 'u']:
+def _scalar_from_dtype(dtype):
+    if dtype.kind in ('i', 'f', 'u'):
         return dtype.type(1)
+    elif dtype.kind == 'c':
+        return dtype.type(complex(1, 0))
     elif dtype.kind in _simple_fake_mapping:
         return _simple_fake_mapping[dtype.kind]
     else:
         raise TypeError("Can't handle dtype: {0}".format(dtype))
 
 
+def _nonempty_scalar(x):
+    if isinstance(x, (pd.Timestamp, pd.Timedelta, pd.Period)):
+        return x
+    elif np.isscalar(x):
+        dtype = x.dtype if hasattr(x, 'dtype') else np.dtype(type(x))
+        return _scalar_from_dtype(dtype)
+    else:
+        raise TypeError("Can't handle meta of type "
+                        "'{0}'".format(type(x).__name__))
+
+
+def is_pd_scalar(x):
+    """Whether the object is a scalar type"""
+    return (np.isscalar(x) or isinstance(x, (pd.Timestamp, pd.Timedelta,
+                                             pd.Period)))
+
+
 def _nonempty_series(s, idx):
     dtype = s.dtype
     if is_datetime64tz_dtype(dtype):
         entry = pd.Timestamp('1970-01-01', tz=dtype.tz)
+        data = [entry, entry]
     elif is_categorical_dtype(dtype):
-        entry = pd.Categorical([s.cat.categories[0]],
+        entry = s.cat.categories[0]
+        data = pd.Categorical([entry, entry],
                                categories=s.cat.categories,
                                ordered=s.cat.ordered)
     else:
-        entry = _fake_np_scalar(dtype)
-    return pd.Series([entry, entry], name=s.name, index=idx)
+        entry = _scalar_from_dtype(dtype)
+        data = [entry, entry]
+    return pd.Series(data, name=s.name, index=idx)
 
 
 def meta_nonempty(x):
@@ -265,8 +294,10 @@ def meta_nonempty(x):
         idx = _nonempty_index(x.index)
         data = {c: _nonempty_series(x[c], idx) for c in x.columns}
         return pd.DataFrame(data, columns=x.columns, index=idx)
+    elif is_pd_scalar(x):
+        return _nonempty_scalar(x)
     else:
-        raise TypeError("Expected Index, Series, or DataFrame, "
+        raise TypeError("Expected Index, Series, DataFrame, or scalar, "
                         "got {0}".format(type(x).__name__))
 
 
@@ -313,6 +344,8 @@ def _check_dask(dsk, check_names=True, check_dtypes=True):
         elif isinstance(dsk, dd.core.Scalar):
             assert (np.isscalar(result) or
                     isinstance(result, (pd.Timestamp, pd.Timedelta)))
+            if check_dtypes:
+                assert_dask_dtypes(dsk, result)
         else:
             msg = 'Unsupported dask instance {0} found'.format(type(dsk))
             raise AssertionError(msg)
@@ -413,7 +446,9 @@ def assert_dask_dtypes(ddf, res, numeric_equal=True):
     useful due to the implicit conversion of integer to floating upon
     encountering missingness, which is hard to infer statically."""
 
-    eq_types = {'i', 'f'} if numeric_equal else {}
+    eq_types = {'O', 'S', 'U', 'a'}     # treat object and strings alike
+    if numeric_equal:
+        eq_types.update(('i', 'f'))
 
     if isinstance(res, pd.DataFrame):
         for col, a, b in pd.concat([ddf._meta.dtypes, res.dtypes],
@@ -423,3 +458,14 @@ def assert_dask_dtypes(ddf, res, numeric_equal=True):
         a = ddf._meta.dtype
         b = res.dtype
         assert (a.kind in eq_types and b.kind in eq_types) or (a == b)
+    else:
+        if hasattr(ddf._meta, 'dtype'):
+            a = ddf._meta.dtype
+            if not hasattr(res, 'dtype'):
+                assert np.isscalar(res)
+                b = np.dtype(type(res))
+            else:
+                b = res.dtype
+            assert (a.kind in eq_types and b.kind in eq_types) or (a == b)
+        else:
+            assert type(ddf._meta) == type(res)


### PR DESCRIPTION
Previously the `Scalar` class wouldn't track metadata at all. This caused problems with metadata inference if `Scalar` was used in any operation. To fix this, the `Scalar` class has been refactored as follows:

- Each scalar has a `_meta` attribute, same as all other `dask.dataframe` objects. This attribute is a non-empty scalar of the appropriate type. Supported types include any subclass of `np.generic`, as well as `str`/`unicode`, and custom pandas scalars like `pd.Timestamp` and `pd.Timedelta`. A corresponding `_meta_nonempty` attribute is also provided - this just returns `_meta`.

- Inference is added to `reduction` and `Scalar` returning `map_partitions`. Operators that work on scalars are modified to infer metadata based off the scalar dtype as well.

- `make_meta` is modified to dispatch on raw `dtype` arguments. This means that `make_meta('i8')` will produce the appropriate metadata for  a scalar containing an int64.

- Add `dtype` attribute if present on `_meta`

- Add nice `__repr__` that shows `name` and `dtype`/`type`.

Caveat: If a type is supported as a numpy scalar, a numpy scalar is used. This does mean that for some (rare) operations, the `_meta` object on a scalar may be a `np.int64`, but the computed result is an `int`.

Fixes #1451.