### PR TITLE
Field access works with non-scalar fields

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -493,6 +493,16 @@ def test_field_access():
     assert same_keys(y[['b', 'a']], y[['b', 'a']])
 
 
+def test_field_access_with_shape():
+    dtype = [('col1', ('f4', (3, 2))), ('col2', ('f4', 3))]
+    data = np.ones((100, 50), dtype=dtype)
+    x = da.from_array(data, 10)
+    assert_eq(x['col1'], data['col1'])
+    assert_eq(x[['col1']], data[['col1']])
+    assert_eq(x['col2'], data['col2'])
+    assert_eq(x[['col1', 'col2']], data[['col1', 'col2']])
+
+
 def test_tensordot():
     x = np.arange(400).reshape((20, 20))
     a = from_array(x, chunks=(5, 4))


### PR DESCRIPTION
Previously field access in structured dtype arrays would fail if the
field had a shape. This was due to the output array not being the same
shape as the input array. This fixes that by inferring the output shape
and adjusting accordingly.

Fixes #1482.