### PR TITLE
Create new threadpool when operating from thread

### DIFF
--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -1,6 +1,8 @@
 from multiprocessing.pool import ThreadPool
 
+import threading
 from threading import Thread
+from time import time, sleep
 
 from dask.context import set_options
 from dask.threaded import get
@@ -43,12 +45,57 @@ def test_reuse_pool():
 def test_threaded_within_thread():
     L = []
     def f(i):
-        result = get({'x': (lambda: i,)}, 'x')
+        result = get({'x': (lambda: i,)}, 'x', num_workers=2)
         L.append(result)
 
-    t = Thread(target=f, args=(1,))
-    t.daemon = True
-    t.start()
-    t.join()
+    before = threading.active_count()
 
-    assert L == [1]
+    for i in range(20):
+        t = Thread(target=f, args=(1,))
+        t.daemon = True
+        t.start()
+        t.join()
+        assert L == [1]
+        del L[:]
+
+    start = time()  # wait for most threads to join
+    while threading.active_count() > before + 10:
+        sleep(0.01)
+        assert time() < start + 5
+
+
+def test_dont_spawn_too_many_threads():
+    before = threading.active_count()
+
+    dsk = {('x', i): (lambda: i,) for i in range(10)}
+    dsk['x'] = (sum, list(dsk))
+    for i in range(20):
+        get(dsk, 'x', num_workers=4)
+
+    after = threading.active_count()
+
+    assert after <= before + 8
+
+
+def test_thread_safety():
+    def f(x):
+        return 1
+
+    dsk = {'x': (sleep, 0.05), 'y': (f, 'x')}
+
+    L = []
+
+    def test_f():
+        L.append(get(dsk, 'y'))
+
+    threads = []
+    for i in range(20):
+        t = Thread(target=test_f)
+        t.daemon = True
+        t.start()
+        threads.append(t)
+
+    for thread in threads:
+        thread.join()
+
+    assert L == [1] * 20

--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -13,11 +13,12 @@ from .context import _globals
 from .utils_test import inc, add  # noqa: F401
 
 
-default_pool = ThreadPool()
-
-
 def _thread_get_id():
     return current_thread().ident
+
+
+default_pool = ThreadPool()
+default_thread = _thread_get_id()
 
 
 def get(dsk, result, cache=None, num_workers=None, **kwargs):
@@ -48,6 +49,8 @@ def get(dsk, result, cache=None, num_workers=None, **kwargs):
 
     if pool is None:
         if num_workers:
+            pool = ThreadPool(num_workers)
+        elif _thread_get_id() != default_thread:
             pool = ThreadPool(num_workers)
         else:
             pool = default_pool


### PR DESCRIPTION
This cleans up some issues in the threaded scheduler when operating from other threads.

1.  https://github.com/dask/distributed/pull/441 shows that dask.threaded.get can block when being called from other threads
2.  We were creating but not cleaning up threadpools when using `num_workers=` keyword argument

Now we keep a pool of pools around, keyed by thread and num_workers.  These get cleaned up at every call to get.

Reported by @AlbertDeFusco