### PR TITLE
Use lists in db.from_sequence

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1311,7 +1311,7 @@ def from_sequence(seq, partition_size=None, npartitions=None):
 
     parts = list(partition_all(partition_size, seq))
     name = 'from_sequence-' + tokenize(seq, partition_size)
-    d = dict(((name, i), part) for i, part in enumerate(parts))
+    d = dict(((name, i), list(part)) for i, part in enumerate(parts))
     return Bag(d, name, len(d))
 
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1055,3 +1055,9 @@ def test_msgpack_unicode():
     b = db.from_sequence([{"a": 1}]).groupby("a")
     result = b.compute(get=dask.async.get_sync)
     assert dict(result) == {1: [{'a': 1}]}
+
+
+def test_bag_with_single_callable():
+    f = lambda: None
+    b = db.from_sequence([f])
+    assert list(b.compute(get=dask.get)) == [f]


### PR DESCRIPTION
This avoids putting callables in tuples, which can be dangerous.

Fixes https://github.com/dask/dask/issues/1489