### PR TITLE
an attempt implementing DataFrameGroupBy.fillna

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -421,7 +421,6 @@ class DataFrameGroupBy(_GroupBy):
         except KeyError as e:
             raise AttributeError(e)
 
-    @derived_from(pd.core.groupby.DataFrameGroupBy)
     def fillna(self, value):
         meta = self.obj.head(1).groupby(self.index).fillna(value)
         if isinstance(meta, pd.DataFrame) and self._slice is not None:

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -179,6 +179,56 @@ def test_groupby_multilevel_agg():
     assert eq(res, sol)
 
 
+def test_groupby_min():
+    df = pd.DataFrame({'a': [1, 2, 3, 1, 2, 3],
+                       'b': [1, 2, 1, 4, 2, 1],
+                       'c': [1, 3, 2, 1, 1, 2],
+                       'd': [1, 2, 1, 1, 2, 2]})
+    ddf = dd.from_pandas(df, 2)
+
+    sol = df.groupby(['a']).min()
+    res = ddf.groupby(['a']).min()
+    assert eq(res, sol)
+
+    sol = df.groupby(['a', 'c']).min()
+    res = ddf.groupby(['a', 'c']).min()
+    assert eq(res, sol)
+
+
+def test_groupby_std():
+    df = pd.DataFrame({'a': [1, 4, 3, 1, 2, 3],
+                       'b': [1, 2, 1, 4, 2, 1],
+                       'c': [1, 3, 2, 1, 1, 2],
+                       'd': [1, 2, 1, 1, 2, 2]})
+    ddf = dd.from_pandas(df, 2)
+
+    sol = df.groupby(['a']).std()
+    res = ddf.groupby(['a']).std()
+    assert eq(res, sol)
+
+    sol = df.groupby(['a', 'c']).std()
+    # we don't support multiindex, so just force it through
+    res = ddf.groupby(['a', 'c']).std().compute()
+    res.index = sol.index
+    assert eq(res, sol)
+
+
+def test_groupby_fillna():
+    df = pd.DataFrame({'a': [1, 2, 3, 1, 2, 3],
+                       'b': [1, np.NaN, 1, np.NaN, 2, 1],
+                       'c': [1, 3, 2, 1, 1, 2],
+                       'd': [1, 2, 1, 1, np.NaN, 2]})
+    ddf = dd.from_pandas(df, 2)
+
+    sol = df.groupby(['a']).fillna(9)
+    res = ddf.groupby(['a']).fillna(9)
+    assert eq(res, sol)
+
+    sol = df.groupby(['a', 'c']).fillna(9)
+    res = ddf.groupby(['a', 'c']).fillna(9)
+    assert eq(res, sol)
+
+
 def test_groupby_get_group():
     dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 6], 'b': [4, 2, 7]},
                                   index=[0, 1, 3]),


### PR DESCRIPTION
I suspect there might be a cleaner way to implement this,
especially the `meta` calculation. For a reason that's beyond
me `self._meta` includes all four columns in the test, and only
calling `groupby` from within `fillna` works.

In the process i've also wrote some tests to help test similar
behavior, i've included those in the PR.

Signed-off-by: Nir Izraeli nirizr@gmail.com
