### PR TITLE
Fix last 'line' in sample; prevents open quotes.

### DIFF
--- a/dask/dataframe/csv.py
+++ b/dask/dataframe/csv.py
@@ -220,6 +220,7 @@ def read_csv(urlpath, blocksize=AUTO_BLOCKSIZE, chunkbytes=None,
                                          sample=sample,
                                          compression=compression,
                                          **(storage_options or {}))
+
     if not isinstance(values[0], (tuple, list)):
         values = [values]
 
@@ -230,7 +231,13 @@ def read_csv(urlpath, blocksize=AUTO_BLOCKSIZE, chunkbytes=None,
         header = b''
     else:
         header = sample.split(b_lineterminator)[0] + b_lineterminator
-    head = pd.read_csv(BytesIO(sample), **kwargs)
+
+    try:
+        head = pd.read_csv(BytesIO(sample), **kwargs)
+    except:
+        # Remove the last row from the sample due to buffer row split:
+        sample = sample[:(sample.rfind(b_lineterminator))]
+        head = pd.read_csv(BytesIO(sample), **kwargs)
 
     df = read_csv_from_bytes(values, header, head, kwargs,
                              collection=collection, enforce=enforce)

--- a/dask/dataframe/tests/test_csv.py
+++ b/dask/dataframe/tests/test_csv.py
@@ -245,3 +245,9 @@ def test_auto_blocksize_csv(monkeypatch):
         read_csv('2014-01-01.csv')
         assert mock_read_bytes.called
         assert mock_read_bytes.call_args[1]['blocksize'] == expected_block_size
+
+
+def test_head_partial_line_fix():
+    with filetexts({'.overflow.csv': 'a,b\n0,"abcdefghijklmnopqrstuvwxyz"\n1,"abcdefghijklmnopqrstuvwxyz"'}):
+        # 64 byte file, 52 characters is mid-quote; this should not cause exception in head-handling code.
+        read_csv('.overflow.csv', sample=52)


### PR DESCRIPTION
The last line of the sample var may be an incomplete line. This causes the 'head' value to throw a CParserError:

>  Error tokenizing data. C error: EOF inside string starting at line 821

This occurs because of a hanging quote in the cut-off line. This patch will prevent this error during the head variable assignment.