### PR TITLE
Update to highlight the use of glob based file naming option for data…

### DIFF
--- a/docs/source/dataframe-overview.rst
+++ b/docs/source/dataframe-overview.rst
@@ -119,6 +119,9 @@ or distributed scheduler.
 
 See :doc:`scheduler docs<scheduler-overview>` for more information.
 
+Exporting to Disk
+---------
+``dask.dataframe`` supports a variety of output methods to write your data to disk include ``to_csv()`` ``to_castra`` ``to_hdf()``. Please consult the API for a complete list. To maximise the opportunity for parallel execution users should provide a glob based file name e.g ``DataExport-*.csv`` to generate a sequential list of files instead of a single monolith file. Single file names are prone to performance and usability issues including write permission based errors.
 
 Limitations
 -----------


### PR DESCRIPTION
…frame exports

Added a section to highlight users should use glob based file names instead of trying to write to a single file. Issue occurs with to_csv() but may affect other export options. The use of glob based naming is reported here https://groups.google.com/a/continuum.io/forum/#!searchin/blaze-dev/to_csv/blaze-dev/NCQfCoOWEcI/S7fwuCfeCgAJ as being common practice for parallel librarys
