### PR TITLE
Use of glob based filenames to output to csv

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -890,6 +890,11 @@ class _Frame(Base):
     def to_csv(self, filename, **kwargs):
         from .io import to_csv
         return to_csv(self, filename, **kwargs)
+        """ Export dataframe to csv file
+
+        Recommend to use glob based filename e.g. '/foo/output_*.csv' to create multiple files 
+        as parallel execution makes writing to a single csv file problematic.  
+        """
 
     def to_imperative(self):
         warnings.warn("Deprecation warning: moved to to_delayed")


### PR DESCRIPTION
Highlight the need to use glob based file names to output dask dataframe to csv based file.