### PR TITLE
meta_nonempty returns types of correct size

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -97,25 +97,29 @@ def test_meta_nonempty():
     df1 = pd.DataFrame({'A': pd.Categorical(['Alice', 'Bob', 'Carol']),
                         'B': list('abc'),
                         'C': 'bar',
-                        'D': 3.0,
-                        'E': pd.Timestamp('2016-01-01'),
-                        'F': pd.date_range('2016-01-01', periods=3,
+                        'D': np.float32(1),
+                        'E': np.int32(1),
+                        'F': pd.Timestamp('2016-01-01'),
+                        'G': pd.date_range('2016-01-01', periods=3,
                                            tz='America/New_York'),
-                        'G': pd.Timedelta('1 hours'),
-                        'H': np.void(b' ')},
-                       columns=list('DCBAHGFE'))
+                        'H': pd.Timedelta('1 hours', 'ms'),
+                        'I': np.void(b' ')},
+                       columns=list('DCBAHGFEI'))
     df2 = df1.iloc[0:0]
     df3 = meta_nonempty(df2)
     assert (df3.dtypes == df2.dtypes).all()
     assert df3['A'][0] == 'Alice'
     assert df3['B'][0] == 'foo'
     assert df3['C'][0] == 'foo'
-    assert df3['D'][0] == 1.0
-    assert df3['E'][0] == pd.Timestamp('1970-01-01 00:00:00')
-    assert df3['F'][0] == pd.Timestamp('1970-01-01 00:00:00',
+    assert df3['D'][0] == np.float32(1)
+    assert df3['D'][0].dtype == 'f4'
+    assert df3['E'][0] == np.int32(1)
+    assert df3['E'][0].dtype == 'i4'
+    assert df3['F'][0] == pd.Timestamp('1970-01-01 00:00:00')
+    assert df3['G'][0] == pd.Timestamp('1970-01-01 00:00:00',
                                        tz='America/New_York')
-    assert df3['G'][0] == pd.Timedelta('1 days')
-    assert df3['H'][0] == 'foo'
+    assert df3['H'][0] == pd.Timedelta('1', 'ms')
+    assert df3['I'][0] == 'foo'
 
     s = meta_nonempty(df2['A'])
     assert s.dtype == df2['A'].dtype

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -229,7 +229,7 @@ _simple_fake_mapping = {
     'b': np.bool_(True),
     'V': np.void(b' '),
     'M': np.datetime64('1970-01-01'),
-    'm': np.timedelta64(1, 'D'),
+    'm': np.timedelta64(1),
     'S': np.str_('foo'),
     'a': np.str_('foo'),
     'U': np.unicode_('foo'),
@@ -242,7 +242,8 @@ def _scalar_from_dtype(dtype):
     elif dtype.kind == 'c':
         return dtype.type(complex(1, 0))
     elif dtype.kind in _simple_fake_mapping:
-        return _simple_fake_mapping[dtype.kind]
+        o = _simple_fake_mapping[dtype.kind]
+        return o.astype(dtype) if dtype.kind in ('m', 'M') else o
     else:
         raise TypeError("Can't handle dtype: {0}".format(dtype))
 
@@ -276,7 +277,7 @@ def _nonempty_series(s, idx):
                                ordered=s.cat.ordered)
     else:
         entry = _scalar_from_dtype(dtype)
-        data = [entry, entry]
+        data = np.array([entry, entry], dtype=dtype)
     return pd.Series(data, name=s.name, index=idx)
 
 


### PR DESCRIPTION
This was a bug with `pd.Series([instance_of_correct_dtype])` upcasting
implicitly. This was leading to `meta_nonempty(int32_series)`
returning a series of dtype `int64`. Fixes #1512.

Also fixed units passing through for objects of type `np.timedelta64`
and `np.datetime64`.