### PR TITLE
``dd.map_partitions`` works with scalar outputs

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -50,7 +50,10 @@ def _concat(args, **kwargs):
     if isinstance(args[0], (pd.Index)):
         args = [arg for arg in args if len(arg)]
         return args[0].append(args[1:])
-    return args
+    try:
+        return pd.Series(args)
+    except:
+        return args
 
 
 def _get_return_type(meta):
@@ -2621,6 +2624,10 @@ def map_partitions(func, *args, **kwargs):
         dask = {(name, 0):
                 (apply, func, (tuple, [(arg._name, 0) for arg in args]), kwargs)}
         return Scalar(merge(dask, *[arg.dask for arg in args]), name, meta)
+    elif not isinstance(meta, (pd.Series, pd.DataFrame, pd.Index)):
+        # If `meta` is not a pandas object, the concatenated results will be a
+        # different type
+        meta = _concat([meta])
 
     if isinstance(meta, pd.DataFrame):
         columns = meta.columns

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -453,6 +453,13 @@ def test_map_partitions():
     assert eq(d.map_partitions(lambda df: df), full)
     result = d.map_partitions(lambda df: df.sum(axis=1))
     assert eq(result, full.sum(axis=1))
+    assert eq(d.map_partitions(lambda df: 1), pd.Series([1, 1, 1]),
+              check_divisions=False)
+    x = Scalar({('x', 0): 1}, 'x', int)
+    result = dd.map_partitions(lambda x: 2, x)
+    assert result.dtype in (np.int32, np.int64) and result.compute() == 2
+    result = dd.map_partitions(lambda x: 4.0, x)
+    assert result.dtype == np.float64 and result.compute() == 4.0
 
 
 def test_map_partitions_names():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -367,9 +367,11 @@ def _maybe_sort(a):
     return a.sort_index()
 
 
-def eq(a, b, check_names=True, check_dtypes=True, **kwargs):
-    assert_divisions(a)
-    assert_divisions(b)
+def eq(a, b, check_names=True, check_dtypes=True, check_divisions=True,
+       **kwargs):
+    if check_divisions:
+        assert_divisions(a)
+        assert_divisions(b)
     assert_sane_keynames(a)
     assert_sane_keynames(b)
     a = _check_dask(a, check_names=check_names, check_dtypes=check_dtypes)


### PR DESCRIPTION
Previously if a user defined function returned a scalar, the output of
`dd.map_partitions` would be a `Scalar`, even if the input type was
a series. This fixes that so that scalar returning functions return a
series, unless all inputs are scalars (in which case the output is a
scalar as before). Fixes
http://stackoverflow.com/questions/39215617/what-is-map-partitions-doing.