### PR TITLE
Remove lambda/inner functions in dask.dataframe

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -8,7 +8,7 @@ from pprint import pformat
 import uuid
 import warnings
 
-from toolz import merge, partial, first, partition, unique
+from toolz import merge, partial, first, unique
 import pandas as pd
 from pandas.util.decorators import cache_readonly
 import numpy as np
@@ -24,9 +24,11 @@ from ..array.core import partial_by_order
 from .. import threaded
 from ..compatibility import apply, operator_div, bind_method
 from ..utils import (repr_long_list, IndexCallable,
-                     pseudorandom, derived_from, different_seeds, funcname, memory_repr, put_lines)
+                     pseudorandom, derived_from, different_seeds, funcname,
+                     memory_repr, put_lines)
 from ..base import Base, compute, tokenize, normalize_token
 from ..async import get_sync
+from . import methods
 from .indexing import (_partition_of_index_value, _loc, _try_loc,
                        _coerce_loc_index, _maybe_partial_time_string)
 from .utils import meta_nonempty, make_meta, insert_meta_param_description
@@ -341,9 +343,9 @@ class _Frame(Base):
     @derived_from(pd.DataFrame)
     def drop_duplicates(self, **kwargs):
         assert all(k in ('keep', 'subset', 'take_last') for k in kwargs)
-        chunk = lambda s: s.drop_duplicates(**kwargs)
+        chunk = methods.drop_duplicates
         return aca(self, chunk=chunk, aggregate=chunk, meta=self._meta,
-                   token='drop-duplicates')
+                   token='drop-duplicates', **kwargs)
 
     def __len__(self):
         return self.reduction(len, np.sum, token='len', meta=int).compute()
@@ -607,7 +609,7 @@ class _Frame(Base):
         Caveat, the only checks the last n rows of the last partition.
         """
         name = 'tail-%d-%s' % (n, self._name)
-        dsk = {(name, 0): (lambda x, n: x.tail(n=n),
+        dsk = {(name, 0): (methods.tail,
                 (self._name, self.npartitions - 1), n)}
 
         result = self._constructor(merge(self.dask, dsk), name,
@@ -633,15 +635,15 @@ class _Frame(Base):
     def _loc_series(self, ind):
         if not self.divisions == ind.divisions:
             raise ValueError("Partitions of dataframe and index not the same")
-        return map_partitions(lambda df, ind: df.loc[ind],
-                              self, ind, token='loc-series', meta=self)
+        return map_partitions(methods.loc, self, ind, token='loc-series',
+                              meta=self)
 
     def _loc_element(self, ind):
         name = 'loc-%s' % tokenize(ind, self)
         part = _partition_of_index_value(self.divisions, ind)
         if ind < self.divisions[0] or ind > self.divisions[-1]:
             raise KeyError('the label [%s] is not in the index' % str(ind))
-        dsk = {(name, 0): (lambda df: df.loc[ind:ind], (self._name, part))}
+        dsk = {(name, 0): (methods.loc, (self._name, part), slice(ind, ind))}
 
         return self._constructor(merge(self.dask, dsk), name, self, [ind, ind])
 
@@ -967,10 +969,10 @@ class _Frame(Base):
         meta = self._meta_nonempty.sum(axis=axis, skipna=skipna)
         token = self._token_prefix + 'sum'
         if axis == 1:
-            return self.map_partitions(_sum, meta=meta, token=token,
+            return self.map_partitions(methods.sum, meta=meta, token=token,
                                        skipna=skipna, axis=axis)
         else:
-            return self.reduction(_sum, meta=meta, token=token,
+            return self.reduction(methods.sum, meta=meta, token=token,
                                   skipna=skipna, axis=axis)
 
     @derived_from(pd.DataFrame)
@@ -979,10 +981,10 @@ class _Frame(Base):
         meta = self._meta_nonempty.max(axis=axis, skipna=skipna)
         token = self._token_prefix + 'max'
         if axis == 1:
-            return self.map_partitions(_max, meta=meta, token=token,
+            return self.map_partitions(methods.max, meta=meta, token=token,
                                        skipna=skipna, axis=axis)
         else:
-            return self.reduction(_max, meta=meta, token=token,
+            return self.reduction(methods.max, meta=meta, token=token,
                                   skipna=skipna, axis=axis)
 
     @derived_from(pd.DataFrame)
@@ -991,10 +993,10 @@ class _Frame(Base):
         meta = self._meta_nonempty.min(axis=axis, skipna=skipna)
         token = self._token_prefix + 'min'
         if axis == 1:
-            return self.map_partitions(_min, meta=meta, token=token,
+            return self.map_partitions(methods.min, meta=meta, token=token,
                                        skipna=skipna, axis=axis)
         else:
-            return self.reduction(_min, meta=meta, token=token,
+            return self.reduction(methods.min, meta=meta, token=token,
                                   skipna=skipna, axis=axis)
 
     @derived_from(pd.DataFrame)
@@ -1003,7 +1005,7 @@ class _Frame(Base):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.idxmax(axis=axis, skipna=skipna)
         if axis == 1:
-            return map_partitions(_idxmax, self, meta=meta,
+            return map_partitions(methods.idxmax, self, meta=meta,
                                   token=self._token_prefix + fn,
                                   skipna=skipna, axis=axis)
         else:
@@ -1017,7 +1019,7 @@ class _Frame(Base):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.idxmax(axis=axis)
         if axis == 1:
-            return map_partitions(_idxmin, self, meta=meta,
+            return map_partitions(methods.idxmin, self, meta=meta,
                                   token=self._token_prefix + fn,
                                   skipna=skipna, axis=axis)
         else:
@@ -1031,40 +1033,35 @@ class _Frame(Base):
         token = self._token_prefix + 'count'
         if axis == 1:
             meta = self._meta_nonempty.count(axis=axis)
-            return self.map_partitions(_count, meta=meta, token=token,
+            return self.map_partitions(methods.count, meta=meta, token=token,
                                        axis=axis)
         else:
             meta = self._meta_nonempty.count()
-            return self.reduction(_count, meta=meta, token=token,
-                                  aggregate=_sum)
+            return self.reduction(methods.count, meta=meta, token=token,
+                                  aggregate=methods.sum)
 
     @derived_from(pd.DataFrame)
     def mean(self, axis=None, skipna=True):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.mean(axis=axis, skipna=skipna)
         if axis == 1:
-            return map_partitions(_mean, self, meta=meta,
+            return map_partitions(methods.mean, self, meta=meta,
                                   token=self._token_prefix + 'mean',
                                   axis=axis, skipna=skipna)
         else:
             num = self._get_numeric_data()
             s = num.sum(skipna=skipna)
             n = num.count()
-
-            def f(s, n):
-                try:
-                    return s / n
-                except ZeroDivisionError:
-                    return np.nan
             name = self._token_prefix + 'mean-%s' % tokenize(self, axis, skipna)
-            return map_partitions(f, s, n, token=name, meta=meta)
+            return map_partitions(methods.mean_aggregate, s, n,
+                                  token=name, meta=meta)
 
     @derived_from(pd.DataFrame)
     def var(self, axis=None, skipna=True, ddof=1):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.var(axis=axis, skipna=skipna)
         if axis == 1:
-            return map_partitions(_var, self, meta=meta,
+            return map_partitions(methods.var, self, meta=meta,
                                   token=self._token_prefix + 'var',
                                   axis=axis, skipna=skipna, ddof=ddof)
         else:
@@ -1072,24 +1069,16 @@ class _Frame(Base):
             x = 1.0 * num.sum(skipna=skipna)
             x2 = 1.0 * (num ** 2).sum(skipna=skipna)
             n = num.count()
-
-            def f(x2, x, n):
-                try:
-                    result = (x2 / n) - (x / n)**2
-                    if ddof:
-                        result = result * n / (n - ddof)
-                    return result
-                except ZeroDivisionError:
-                    return np.nan
             name = self._token_prefix + 'var-%s' % tokenize(self, axis, skipna, ddof)
-            return map_partitions(f, x2, x, n, token=name, meta=meta)
+            return map_partitions(methods.var_aggregate, x2, x, n,
+                                  token=name, meta=meta, ddof=ddof)
 
     @derived_from(pd.DataFrame)
     def std(self, axis=None, skipna=True, ddof=1):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.std(axis=axis, skipna=skipna)
         if axis == 1:
-            return map_partitions(_std, self, meta=meta,
+            return map_partitions(methods.std, self, meta=meta,
                                   token=self._token_prefix + 'std',
                                   axis=axis, skipna=skipna, ddof=ddof)
         else:
@@ -1139,8 +1128,6 @@ class _Frame(Base):
 
     @derived_from(pd.DataFrame)
     def describe(self):
-        name = 'describe--' + tokenize(self)
-
         # currently, only numeric describe is supported
         num = self._get_numeric_data()
 
@@ -1148,21 +1135,11 @@ class _Frame(Base):
                  num.quantile([0.25, 0.5, 0.75]), num.max()]
         stats_names = [(s._name, 0) for s in stats]
 
-        def build_partition(values):
-            assert len(values) == 6
-            count, mean, std, min, q, max = values
-            part1 = self._partition_type([count, mean, std, min],
-                                         index=['count', 'mean', 'std', 'min'])
-            q.index = ['25%', '50%', '75%']
-            part3 = self._partition_type([max], index=['max'])
-            return pd.concat([part1, q, part3])
+        name = 'describe--' + tokenize(self)
+        dsk = merge(num.dask, *(s.dask for s in stats))
+        dsk[(name, 0)] = (methods.describe_aggregate,(list, stats_names))
 
-        dsk = dict()
-        dsk[(name, 0)] = (build_partition, (list, stats_names))
-        dsk = merge(dsk, num.dask, *[s.dask for s in stats])
-
-        return self._constructor(dsk, name, num._meta,
-                                 divisions=[None, None])
+        return self._constructor(dsk, name, num._meta, divisions=[None, None])
 
     def _cum_agg(self, token, chunk, aggregate, axis, skipna=True,
                  chunk_kwargs=None):
@@ -1204,47 +1181,33 @@ class _Frame(Base):
 
     @derived_from(pd.DataFrame)
     def cumsum(self, axis=None, skipna=True):
-        cumsum = lambda x, **kwargs: x.cumsum(**kwargs)
         return self._cum_agg('cumsum',
-                             chunk=cumsum,
+                             chunk=methods.cumsum,
                              aggregate=operator.add,
                              axis=axis, skipna=skipna,
                              chunk_kwargs=dict(axis=axis, skipna=skipna))
 
     @derived_from(pd.DataFrame)
     def cumprod(self, axis=None, skipna=True):
-        cumprod = lambda x, **kwargs: x.cumprod(**kwargs)
         return self._cum_agg('cumprod',
-                             chunk=cumprod,
+                             chunk=methods.cumprod,
                              aggregate=operator.mul,
                              axis=axis, skipna=skipna,
                              chunk_kwargs=dict(axis=axis, skipna=skipna))
 
     @derived_from(pd.DataFrame)
     def cummax(self, axis=None, skipna=True):
-        def aggregate(x, y):
-            if isinstance(x, (pd.Series, pd.DataFrame)):
-                return x.where((x > y) | x.isnull(), y, axis=x.ndim - 1)
-            else:       # scalar
-                return x if x > y else y
-        cummax = lambda x, **kwargs: x.cummax(**kwargs)
         return self._cum_agg('cummax',
-                             chunk=cummax,
-                             aggregate=aggregate,
+                             chunk=methods.cummax_chunk,
+                             aggregate=methods.cummax_aggregate,
                              axis=axis, skipna=skipna,
                              chunk_kwargs=dict(axis=axis, skipna=skipna))
 
     @derived_from(pd.DataFrame)
     def cummin(self, axis=None, skipna=True):
-        def aggregate(x, y):
-            if isinstance(x, (pd.Series, pd.DataFrame)):
-                return x.where((x < y) | x.isnull(), y, axis=x.ndim - 1)
-            else:       # scalar
-                return x if x < y else y
-        cummin = lambda x, **kwargs: x.cummin(**kwargs)
         return self._cum_agg('cummin',
-                             chunk=cummin,
-                             aggregate=aggregate,
+                             chunk=methods.cummin_chunk,
+                             aggregate=methods.cummin_aggregate,
                              axis=axis, skipna=skipna,
                              chunk_kwargs=dict(axis=axis, skipna=skipna))
 
@@ -1379,8 +1342,7 @@ class Series(_Frame):
 
     @property
     def nbytes(self):
-        return self.reduction(lambda s: s.nbytes, np.sum, token='nbytes',
-                              meta=int)
+        return self.reduction(methods.nbytes, np.sum, token='nbytes', meta=int)
 
     def __array__(self, dtype=None, **kwargs):
         x = np.array(self.compute())
@@ -1503,11 +1465,8 @@ class Series(_Frame):
         -------
         uniques : Series
         """
-        # unique returns np.ndarray, it must be wrapped
-        name = self.name
-        chunk = lambda x: pd.Series(pd.Series.unique(x), name=name)
-        return aca(self, chunk=chunk, aggregate=chunk,
-                   meta=self._meta, token='unique')
+        return aca(self, chunk=methods.unique, aggregate=methods.unique,
+                   meta=self._meta, token='unique', series_name=self.name)
 
     @derived_from(pd.Series)
     def nunique(self):
@@ -1515,17 +1474,15 @@ class Series(_Frame):
 
     @derived_from(pd.Series)
     def value_counts(self):
-        chunk = lambda s: s.value_counts()
-        agg = lambda s: s.groupby(level=0).sum().sort_values(ascending=False)
-        meta = self._meta.value_counts()
-        return aca(self, chunk=chunk, aggregate=agg, meta=meta,
-                   token='value-counts')
+        return aca(self, chunk=methods.value_counts,
+                   aggregate=methods.value_counts_aggregate,
+                   meta=self._meta.value_counts(), token='value-counts')
 
     @derived_from(pd.Series)
     def nlargest(self, n=5):
-        token = 'series-nlargest-n={0}'.format(n)
-        f = lambda s: s.nlargest(n)
-        return aca(self, f, f, meta=self._meta, token=token)
+        return aca(self, chunk=methods.nlargest, aggregate=methods.nlargest,
+                   meta=self._meta, token='series-nlargest-n={0}'.format(n),
+                   n=n)
 
     @derived_from(pd.Series)
     def isin(self, other):
@@ -1735,7 +1692,7 @@ class Index(Series):
         Caveat, this only checks the first partition.
         """
         name = 'head-%d-%s' % (n, self._name)
-        dsk = {(name, 0): (lambda x, n: x[:n], (self._name, 0), n)}
+        dsk = {(name, 0): (operator.getitem, (self._name, 0), slice(0, n))}
 
         result = self._constructor(merge(self.dask, dsk), name,
                                    self._meta, self.divisions[:2])
@@ -1749,17 +1706,17 @@ class Index(Series):
 
     @derived_from(pd.Index)
     def max(self):
-        return self.reduction(_max, meta=self._meta_nonempty.max(),
+        return self.reduction(methods.max, meta=self._meta_nonempty.max(),
                               token=self._token_prefix + 'max')
 
     @derived_from(pd.Index)
     def min(self):
-        return self.reduction(_min, meta=self._meta_nonempty.min(),
+        return self.reduction(methods.min, meta=self._meta_nonempty.min(),
                               token=self._token_prefix + 'min')
 
     def count(self):
-        return self.reduction(lambda x: pd.notnull(x).sum(),
-                              np.sum, token='index-count', meta=int)
+        return self.reduction(methods.index_count, np.sum,
+                              token='index-count', meta=int)
 
 
 class DataFrame(_Frame):
@@ -1949,8 +1906,8 @@ class DataFrame(_Frame):
     @derived_from(pd.DataFrame)
     def nlargest(self, n=5, columns=None):
         token = 'dataframe-nlargest-n={0}'.format(n)
-        f = lambda df: df.nlargest(n, columns)
-        return aca(self, f, f, meta=self._meta, token=token)
+        return aca(self, chunk=methods.nlargest, aggregate=methods.nlargest,
+                   meta=self._meta, token=token, n=n, columns=columns)
 
     @derived_from(pd.DataFrame)
     def reset_index(self):
@@ -2000,7 +1957,7 @@ class DataFrame(_Frame):
 
         # Figure out columns of the output
         df2 = self._meta.assign(**_extract_meta(kwargs))
-        return elemwise(_assign, self, *pairs, meta=df2)
+        return elemwise(methods.assign, self, *pairs, meta=df2)
 
     @derived_from(pd.DataFrame)
     def rename(self, index=None, columns=None):
@@ -2045,14 +2002,11 @@ class DataFrame(_Frame):
             raise NotImplementedError("Inplace eval not supported."
             " Please use inplace=False")
         meta = self._meta.eval(expr, inplace=inplace, **kwargs)
-        return self.map_partitions(_eval, expr, meta=meta, inplace=inplace, **kwargs)
+        return self.map_partitions(methods.eval, expr, meta=meta, inplace=inplace, **kwargs)
 
     @derived_from(pd.DataFrame)
     def dropna(self, how='any', subset=None):
-        # for cloudpickle
-        def f(df, how=how, subset=subset):
-            return df.dropna(how=how, subset=subset)
-        return self.map_partitions(f, how=how, subset=subset)
+        return self.map_partitions(methods.dropna, how=how, subset=subset)
 
     def to_castra(self, fn=None, categories=None, sorted_index_column=None,
                   compute=True, get=get_sync):
@@ -2378,11 +2332,6 @@ for name in ['nanosecond', 'microsecond', 'millisecond', 'second', 'minute',
              'hour', 'day', 'dayofweek', 'dayofyear', 'week', 'weekday',
              'weekofyear', 'month', 'quarter', 'year']:
     setattr(Index, name, property(partial(elemwise_property, name)))
-
-
-def _assign(df, *pairs):
-    kwargs = dict(partition(2, pairs))
-    return df.assign(**kwargs)
 
 
 def elemwise(op, *args, **kwargs):
@@ -2720,27 +2669,25 @@ def _rename_dask(df, names):
 
 
 def quantile(df, q):
-    """ Approximate quantiles of Series / single column DataFrame
+    """Approximate quantiles of Series.
 
     Parameters
     ----------
     q : list/array of floats
         Iterable of numbers ranging from 0 to 100 for the desired quantiles
     """
-    assert (isinstance(df, DataFrame) and len(df.columns) == 1 or
-            isinstance(df, Series))
+    assert isinstance(df, Series)
     from dask.array.percentile import _percentile, merge_percentiles
 
     # currently, only Series has quantile method
     if isinstance(q, (list, tuple, np.ndarray)):
         # Index.quantile(list-like) must be pd.Series, not pd.Index
         df_name = df.name
-        merge_type = lambda v: pd.Series(v, index=q, name=df_name)
-        return_type = Series if isinstance(df, Index) else df._constructor
+        finalize_tsk = lambda tsk: (methods.pd_series, tsk, q, df_name)
+        return_type = Series
     else:
-        typ = df._partition_type
-        merge_type = lambda v: typ(v).item()
-        return_type = df._constructor_sliced
+        finalize_tsk = lambda tsk: (getitem, tsk, 0)
+        return_type = Scalar
         q = [q]
 
     if isinstance(df, Index):
@@ -2768,8 +2715,9 @@ def quantile(df, q):
     len_dsk = dict(((name2, i), (len, key)) for i, key in enumerate(df._keys()))
 
     name3 = 'quantiles-3-' + token
-    merge_dsk = {(name3, 0): (merge_type, (merge_percentiles, qs, [qs] * df.npartitions,
-                                          sorted(val_dsk), sorted(len_dsk)))}
+    merge_dsk = {(name3, 0): finalize_tsk((merge_percentiles, qs,
+                                           [qs] * df.npartitions,
+                                           sorted(val_dsk), sorted(len_dsk)))}
     dsk = merge(df.dask, val_dsk, len_dsk, merge_dsk)
     return return_type(dsk, name3, meta, new_divisions)
 
@@ -3209,14 +3157,14 @@ def set_sorted_index(df, index, drop=True, **kwargs):
     else:
         meta = df._meta.set_index(index._meta, drop=drop)
 
-    result = map_partitions(_set_sorted_index, df, index, drop=drop, meta=meta)
+    result = map_partitions(methods.set_index, df, index, drop=drop, meta=meta)
 
     return compute_divisions(result, **kwargs)
 
 
 def compute_divisions(df, **kwargs):
-    mins = df.index.map_partitions(lambda x: pd.Series(x.min()), meta=df.index)
-    maxes = df.index.map_partitions(lambda x: pd.Series(x.max()), meta=df.index)
+    mins = df.index.map_partitions(methods.min, meta=df.index)
+    maxes = df.index.map_partitions(methods.max, meta=df.index)
     mins, maxes = compute(mins, maxes, **kwargs)
 
     if (sorted(mins) != list(mins) or
@@ -3231,50 +3179,6 @@ def compute_divisions(df, **kwargs):
     df.divisions = divisions
 
     return df
-
-
-def _set_sorted_index(df, idx, drop):
-    return df.set_index(idx, drop=drop)
-
-
-def _eval(df, expr, **kwargs):
-    return df.eval(expr, **kwargs)
-
-
-def _sum(x, **kwargs):
-    return x.sum(**kwargs)
-
-
-def _min(x, **kwargs):
-    return x.min(**kwargs)
-
-
-def _max(x, **kwargs):
-    return x.max(**kwargs)
-
-
-def _idxmax(x, **kwargs):
-    return x.idxmax(**kwargs)
-
-
-def _idxmin(x, **kwargs):
-    return x.idxmin(**kwargs)
-
-
-def _count(x, **kwargs):
-    return x.count(**kwargs)
-
-
-def _mean(x, **kwargs):
-    return x.mean(**kwargs)
-
-
-def _var(x, **kwargs):
-    return x.var(**kwargs)
-
-
-def _std(x, **kwargs):
-    return x.std(**kwargs)
 
 
 def _reduction_chunk(x, aca_chunk=None, **kwargs):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1220,6 +1220,19 @@ class _Frame(Base):
     def mask(self, cond, other=np.nan):
         return map_partitions(M.mask, self, cond, other)
 
+    @derived_from(pd.DataFrame)
+    def notnull(self):
+        return self.map_partitions(M.notnull)
+
+    @derived_from(pd.DataFrame)
+    def isnull(self):
+        return self.map_partitions(M.isnull)
+
+    @derived_from(pd.DataFrame)
+    def astype(self, dtype):
+        return self.map_partitions(M.astype, dtype=dtype,
+                                   meta=self._meta.astype(dtype))
+
     @derived_from(pd.Series)
     def append(self, other):
         # because DataFrame.append will override the method,
@@ -1508,11 +1521,6 @@ class Series(_Frame):
         return Series(dsk, name, meta, self.divisions)
 
     @derived_from(pd.Series)
-    def astype(self, dtype):
-        return self.map_partitions(M.astype, dtype=dtype,
-                                   meta=self._meta.astype(dtype))
-
-    @derived_from(pd.Series)
     def dropna(self):
         return self.map_partitions(M.dropna)
 
@@ -1524,14 +1532,6 @@ class Series(_Frame):
     @derived_from(pd.Series)
     def clip(self, lower=None, upper=None):
         return self.map_partitions(M.clip, lower=lower, upper=upper)
-
-    @derived_from(pd.Series)
-    def notnull(self):
-        return self.map_partitions(M.notnull)
-
-    @derived_from(pd.Series)
-    def isnull(self):
-        return self.map_partitions(M.isnull)
 
     def to_bag(self, index=False):
         """Convert to a dask Bag.
@@ -1844,14 +1844,6 @@ class DataFrame(_Frame):
     def dtypes(self):
         """ Return data types """
         return self._meta.dtypes
-
-    @derived_from(pd.DataFrame)
-    def notnull(self):
-        return self.map_partitions(M.notnull)
-
-    @derived_from(pd.DataFrame)
-    def isnull(self):
-        return self.map_partitions(M.isnull)
 
     def set_index(self, other, drop=True, sorted=False, **kwargs):
         """ Set the DataFrame index (row labels) using an existing column
@@ -2247,11 +2239,6 @@ class DataFrame(_Frame):
             raise NotImplementedError("Only Pearson correlation has been "
                                       "implemented")
         return cov_corr(self, min_periods, True)
-
-    @derived_from(pd.DataFrame)
-    def astype(self, dtype):
-        meta = self._meta.astype(dtype)
-        return self.map_partitions(M.astype, meta=meta, dtype=dtype)
 
     def info(self, buf=None, verbose=False, memory_usage=False):
         """

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -5,11 +5,10 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from . import methods
 from .core import DataFrame, Series, Index, aca, map_partitions, no_default
 from .shuffle import shuffle
 from .utils import make_meta, insert_meta_param_description
-from ..utils import derived_from
+from ..utils import derived_from, M
 
 
 def _maybe_slice(grouped, columns):
@@ -231,20 +230,20 @@ class _GroupBy(object):
 
     @derived_from(pd.core.groupby.GroupBy)
     def sum(self):
-        return self._aca_agg(token='sum', func=methods.sum)
+        return self._aca_agg(token='sum', func=M.sum)
 
     @derived_from(pd.core.groupby.GroupBy)
     def min(self):
-        return self._aca_agg(token='min', func=methods.min)
+        return self._aca_agg(token='min', func=M.min)
 
     @derived_from(pd.core.groupby.GroupBy)
     def max(self):
-        return self._aca_agg(token='max', func=methods.max)
+        return self._aca_agg(token='max', func=M.max)
 
     @derived_from(pd.core.groupby.GroupBy)
     def count(self):
-        return self._aca_agg(token='count', func=methods.count,
-                             aggfunc=methods.sum)
+        return self._aca_agg(token='count', func=M.count,
+                             aggfunc=M.sum)
 
     @derived_from(pd.core.groupby.GroupBy)
     def mean(self):

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -26,12 +26,11 @@ from ..context import _globals
 from ..delayed import Delayed, delayed
 import dask.multiprocessing
 
-from . import methods
 from .core import DataFrame, Series, new_dd_object
 from .shuffle import set_partition
 from .utils import insert_meta_param_description
 
-from ..utils import build_name_function
+from ..utils import build_name_function, M
 from ..bytes.core import write_bytes
 
 lock = Lock()
@@ -720,7 +719,7 @@ def to_castra(df, fn=None, categories=None, sorted_index_column=None,
     name = 'to-castra-' + uuid.uuid1().hex
 
     if sorted_index_column:
-        func = lambda part: (methods.set_index, part, sorted_index_column)
+        func = lambda part: (M.set_index, part, sorted_index_column)
     else:
         func = lambda part: part
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -5,36 +5,8 @@ import pandas as pd
 from toolz import partition
 
 
-# -- Indexing
-
-def head(x, n):
-    return x.head(n)
-
-
-def tail(x, n):
-    return x.tail(n)
-
-
 def loc(df, ind):
     return df.loc[ind]
-
-
-# -- Reductions --
-
-def sum(x, **kwargs):
-    return x.sum(**kwargs)
-
-
-def min(x, **kwargs):
-    return x.min(**kwargs)
-
-
-def max(x, **kwargs):
-    return x.max(**kwargs)
-
-
-def count(x, **kwargs):
-    return x.count(**kwargs)
 
 
 def index_count(x):
@@ -42,19 +14,11 @@ def index_count(x):
     return pd.notnull(x).sum()
 
 
-def mean(x, **kwargs):
-    return x.mean(**kwargs)
-
-
 def mean_aggregate(s, n):
     try:
         return s / n
     except ZeroDivisionError:
         return np.nan
-
-
-def var(x, **kwargs):
-    return x.var(**kwargs)
 
 
 def var_aggregate(x2, x, n, ddof):
@@ -65,10 +29,6 @@ def var_aggregate(x2, x, n, ddof):
         return result
     except ZeroDivisionError:
         return np.nan
-
-
-def std(x, **kwargs):
-    return x.std(**kwargs)
 
 
 def describe_aggregate(values):
@@ -82,37 +42,11 @@ def describe_aggregate(values):
     return pd.concat([part1, q, part3])
 
 
-def idxmax(x, **kwargs):
-    return x.idxmax(**kwargs)
-
-
-def idxmin(x, **kwargs):
-    return x.idxmin(**kwargs)
-
-
-# -- Cumulative operations --
-
-def cumsum(x, **kwargs):
-    return x.cumsum(**kwargs)
-
-
-def cumprod(x, **kwargs):
-    return x.cumprod(**kwargs)
-
-
-def cummin_chunk(x, **kwargs):
-    return x.cummin(**kwargs)
-
-
 def cummin_aggregate(x, y):
     if isinstance(x, (pd.Series, pd.DataFrame)):
         return x.where((x < y) | x.isnull(), y, axis=x.ndim - 1)
     else:       # scalar
         return x if x < y else y
-
-
-def cummax_chunk(x, **kwargs):
-    return x.cummax(**kwargs)
 
 
 def cummax_aggregate(x, y):
@@ -122,23 +56,9 @@ def cummax_aggregate(x, y):
         return x if x > y else y
 
 
-# -- Misc. --
-
 def assign(df, *pairs):
     kwargs = dict(partition(2, pairs))
     return df.assign(**kwargs)
-
-
-def set_index(df, keys, **kwargs):
-    return df.set_index(keys, **kwargs)
-
-
-def eval(df, expr, **kwargs):
-    return df.eval(expr, **kwargs)
-
-
-def drop_duplicates(x, **kwargs):
-    return x.drop_duplicates(**kwargs)
 
 
 def unique(x, series_name=None):
@@ -146,26 +66,9 @@ def unique(x, series_name=None):
     return pd.Series(pd.Series.unique(x), name=series_name)
 
 
-def value_counts(x):
-    return x.value_counts()
-
-
 def value_counts_aggregate(x):
     return x.groupby(level=0).sum().sort_values(ascending=False)
 
 
-def nlargest(x, **kwargs):
-    return x.nlargest(**kwargs)
-
-
-def dropna(x, **kwargs):
-    return x.dropna(**kwargs)
-
-
 def nbytes(x):
     return x.nbytes
-
-
-def pd_series(data, index, name):
-    # a constructor without keywords, removes need for kwargs/apply in task
-    return pd.Series(data, index=index, name=name)

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -1,0 +1,171 @@
+from __future__ import print_function, absolute_import, division
+
+import numpy as np
+import pandas as pd
+from toolz import partition
+
+
+# -- Indexing
+
+def head(x, n):
+    return x.head(n)
+
+
+def tail(x, n):
+    return x.tail(n)
+
+
+def loc(df, ind):
+    return df.loc[ind]
+
+
+# -- Reductions --
+
+def sum(x, **kwargs):
+    return x.sum(**kwargs)
+
+
+def min(x, **kwargs):
+    return x.min(**kwargs)
+
+
+def max(x, **kwargs):
+    return x.max(**kwargs)
+
+
+def count(x, **kwargs):
+    return x.count(**kwargs)
+
+
+def index_count(x):
+    # Workaround since Index doesn't implement `.count`
+    return pd.notnull(x).sum()
+
+
+def mean(x, **kwargs):
+    return x.mean(**kwargs)
+
+
+def mean_aggregate(s, n):
+    try:
+        return s / n
+    except ZeroDivisionError:
+        return np.nan
+
+
+def var(x, **kwargs):
+    return x.var(**kwargs)
+
+
+def var_aggregate(x2, x, n, ddof):
+    try:
+        result = (x2 / n) - (x / n)**2
+        if ddof != 0:
+            result = result * n / (n - ddof)
+        return result
+    except ZeroDivisionError:
+        return np.nan
+
+
+def std(x, **kwargs):
+    return x.std(**kwargs)
+
+
+def describe_aggregate(values):
+    assert len(values) == 6
+    count, mean, std, min, q, max = values
+    typ = pd.DataFrame if isinstance(count, pd.Series) else pd.Series
+    part1 = typ([count, mean, std, min],
+                index=['count', 'mean', 'std', 'min'])
+    q.index = ['25%', '50%', '75%']
+    part3 = typ([max], index=['max'])
+    return pd.concat([part1, q, part3])
+
+
+def idxmax(x, **kwargs):
+    return x.idxmax(**kwargs)
+
+
+def idxmin(x, **kwargs):
+    return x.idxmin(**kwargs)
+
+
+# -- Cumulative operations --
+
+def cumsum(x, **kwargs):
+    return x.cumsum(**kwargs)
+
+
+def cumprod(x, **kwargs):
+    return x.cumprod(**kwargs)
+
+
+def cummin_chunk(x, **kwargs):
+    return x.cummin(**kwargs)
+
+
+def cummin_aggregate(x, y):
+    if isinstance(x, (pd.Series, pd.DataFrame)):
+        return x.where((x < y) | x.isnull(), y, axis=x.ndim - 1)
+    else:       # scalar
+        return x if x < y else y
+
+
+def cummax_chunk(x, **kwargs):
+    return x.cummax(**kwargs)
+
+
+def cummax_aggregate(x, y):
+    if isinstance(x, (pd.Series, pd.DataFrame)):
+        return x.where((x > y) | x.isnull(), y, axis=x.ndim - 1)
+    else:       # scalar
+        return x if x > y else y
+
+
+# -- Misc. --
+
+def assign(df, *pairs):
+    kwargs = dict(partition(2, pairs))
+    return df.assign(**kwargs)
+
+
+def set_index(df, keys, **kwargs):
+    return df.set_index(keys, **kwargs)
+
+
+def eval(df, expr, **kwargs):
+    return df.eval(expr, **kwargs)
+
+
+def drop_duplicates(x, **kwargs):
+    return x.drop_duplicates(**kwargs)
+
+
+def unique(x, series_name=None):
+    # unique returns np.ndarray, it must be wrapped
+    return pd.Series(pd.Series.unique(x), name=series_name)
+
+
+def value_counts(x):
+    return x.value_counts()
+
+
+def value_counts_aggregate(x):
+    return x.groupby(level=0).sum().sort_values(ascending=False)
+
+
+def nlargest(x, **kwargs):
+    return x.nlargest(**kwargs)
+
+
+def dropna(x, **kwargs):
+    return x.dropna(**kwargs)
+
+
+def nbytes(x):
+    return x.nbytes
+
+
+def pd_series(data, index, name):
+    # a constructor without keywords, removes need for kwargs/apply in task
+    return pd.Series(data, index=index, name=name)

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -65,6 +65,7 @@ import pandas as pd
 
 from ..base import tokenize
 from ..compatibility import apply
+from ..utils import M
 from .core import (_Frame, DataFrame, map_partitions,
                    Index, _maybe_from_pandas, new_dd_object)
 from .io import from_pandas
@@ -217,7 +218,7 @@ def join_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix=''):
         if b is None and how in ('left', 'outer'):
             b = right_empty
 
-        dsk[(name, i)] = (pd.DataFrame.join, a, b, None, how,
+        dsk[(name, i)] = (M.join, a, b, None, how,
                           lsuffix, rsuffix)
 
     # dummy result

--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -78,7 +78,8 @@ from toolz import merge, merge_sorted, take
 
 from ..utils import different_seeds
 from ..base import tokenize
-from .core import Index, Series
+from .methods import pd_series
+from .core import Series
 from dask.compatibility import zip
 
 
@@ -419,17 +420,11 @@ def partition_quantiles(df, npartitions, upsample=1.0, random_state=None):
     """ Approximate quantiles of Series used for repartitioning
     """
     assert isinstance(df, Series)
-
-    qs = np.linspace(0, 1, npartitions + 1)
     # currently, only Series has quantile method
     # Index.quantile(list-like) must be pd.Series, not pd.Index
-    df_name = df.name
-    merge_type = lambda v: pd.Series(v, index=qs, name=df_name)
-    return_type = df._constructor
-    if issubclass(return_type, Index):
-        return_type = Series
+    return_type = Series
 
-    new_divisions = [0.0, 1.0]
+    qs = np.linspace(0, 1, npartitions + 1)
     token = tokenize(df, qs, upsample)
     if random_state is None:
         random_state = hash(token) % np.iinfo(np.int32).max
@@ -454,8 +449,9 @@ def partition_quantiles(df, npartitions, upsample=1.0, random_state=None):
     merged_key = max(merge_dsk)
 
     name3 = 're-quantiles-3-' + token
-    last_dsk = {(name3, 0): (merge_type, (process_val_weights, merged_key,
-                                          npartitions, (name0, 0)))}
+    last_dsk = {(name3, 0): (pd_series, (process_val_weights, merged_key,
+                                          npartitions, (name0, 0)), qs, df.name)}
 
     dsk = merge(df.dask, dtype_dsk, val_dsk, merge_dsk, last_dsk)
+    new_divisions = [0.0, 1.0]
     return return_type(dsk, name3, df._meta, new_divisions)

--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -78,7 +78,6 @@ from toolz import merge, merge_sorted, take
 
 from ..utils import different_seeds
 from ..base import tokenize
-from .methods import pd_series
 from .core import Series
 from dask.compatibility import zip
 
@@ -449,8 +448,8 @@ def partition_quantiles(df, npartitions, upsample=1.0, random_state=None):
     merged_key = max(merge_dsk)
 
     name3 = 're-quantiles-3-' + token
-    last_dsk = {(name3, 0): (pd_series, (process_val_weights, merged_key,
-                                          npartitions, (name0, 0)), qs, df.name)}
+    last_dsk = {(name3, 0): (pd.Series, (process_val_weights, merged_key,
+                                         npartitions, (name0, 0)), qs, None, df.name)}
 
     dsk = merge(df.dask, dtype_dsk, val_dsk, merge_dsk, last_dsk)
     new_divisions = [0.0, 1.0]

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -6,6 +6,7 @@ from toolz import merge
 import pandas as pd
 
 from ..base import tokenize
+from . import methods
 
 
 def rolling_chunk(func, part1, part2, window, *args):
@@ -81,14 +82,6 @@ def call_pandas_rolling_method_with_neighbors(
         return applied.iloc[before:]
 
 
-def tail(obj, n):
-    return obj.tail(n)
-
-
-def head(obj, n):
-    return obj.head(n)
-
-
 class Rolling(object):
     # What you get when you do ddf.rolling(...) or similar
     """Provides rolling window calculations.
@@ -153,7 +146,7 @@ class Rolling(object):
             # First chunk, only look after (if necessary)
             if after > 0:
                 next_partition = (head_name, 1)
-                dsk[next_partition] = (head, (old_name, 1), after)
+                dsk[next_partition] = (methods.head, (old_name, 1), after)
             else:
                 # Either we are only looking backward or this was the
                 # only chunk.
@@ -165,10 +158,10 @@ class Rolling(object):
             # All the middle chunks
             for i in range(1, self.obj.npartitions-1):
                 # Get just the needed values from the previous partition
-                dsk[tail_name, i-1] = (tail, (old_name, i-1), before)
+                dsk[tail_name, i-1] = (methods.tail, (old_name, i-1), before)
                 if after:
                     next_partition = (head_name, i+1)
-                    dsk[next_partition] = (head, (old_name, i+1), after)
+                    dsk[next_partition] = (methods.head, (old_name, i+1), after)
 
                 dsk[new_name, i] = (
                     call_pandas_rolling_method_with_neighbors,
@@ -178,7 +171,7 @@ class Rolling(object):
             # The last chunk
             if self.obj.npartitions > 1: # if the first wasn't the only partition
                 end = self.obj.npartitions - 1
-                dsk[tail_name, end-1] = (tail, (old_name, end-1), before)
+                dsk[tail_name, end-1] = (methods.tail, (old_name, end-1), before)
 
                 dsk[new_name, end] = (
                     call_pandas_rolling_method_with_neighbors,

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -6,7 +6,7 @@ from toolz import merge
 import pandas as pd
 
 from ..base import tokenize
-from . import methods
+from ..utils import M
 
 
 def rolling_chunk(func, part1, part2, window, *args):
@@ -146,7 +146,7 @@ class Rolling(object):
             # First chunk, only look after (if necessary)
             if after > 0:
                 next_partition = (head_name, 1)
-                dsk[next_partition] = (methods.head, (old_name, 1), after)
+                dsk[next_partition] = (M.head, (old_name, 1), after)
             else:
                 # Either we are only looking backward or this was the
                 # only chunk.
@@ -158,10 +158,10 @@ class Rolling(object):
             # All the middle chunks
             for i in range(1, self.obj.npartitions-1):
                 # Get just the needed values from the previous partition
-                dsk[tail_name, i-1] = (methods.tail, (old_name, i-1), before)
+                dsk[tail_name, i-1] = (M.tail, (old_name, i-1), before)
                 if after:
                     next_partition = (head_name, i+1)
-                    dsk[next_partition] = (methods.head, (old_name, i+1), after)
+                    dsk[next_partition] = (M.head, (old_name, i+1), after)
 
                 dsk[new_name, i] = (
                     call_pandas_rolling_method_with_neighbors,
@@ -171,7 +171,7 @@ class Rolling(object):
             # The last chunk
             if self.obj.npartitions > 1: # if the first wasn't the only partition
                 end = self.obj.npartitions - 1
-                dsk[tail_name, end-1] = (methods.tail, (old_name, end-1), before)
+                dsk[tail_name, end-1] = (M.tail, (old_name, end-1), before)
 
                 dsk[new_name, end] = (
                     call_pandas_rolling_method_with_neighbors,

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -13,7 +13,7 @@ from .core import DataFrame, Series, _Frame, _concat
 
 from ..base import tokenize
 from ..context import _globals
-from ..utils import digit, insert
+from ..utils import digit, insert, M
 
 
 def set_index(df, index, npartitions=None, shuffle=None, compute=True,
@@ -101,7 +101,7 @@ def set_partition(df, index, divisions, max_branch=32, drop=True, shuffle=None,
 
     df4.divisions = divisions
 
-    return df4.map_partitions(pd.DataFrame.sort_index)
+    return df4.map_partitions(M.sort_index)
 
 
 def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32,

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 
 import numpy as np
 import pytest
@@ -6,7 +7,8 @@ import pytest
 from dask.compatibility import BZ2File, GzipFile, LZMAFile, LZMA_AVAILABLE
 from dask.utils import (textblock, filetext, takes_multiple_arguments,
                         Dispatch, tmpfile, different_seeds, file_size,
-                        infer_storage_options, eq_strict, memory_repr)
+                        infer_storage_options, eq_strict, memory_repr,
+                        methodcaller, M)
 
 
 SKIP_XZ = pytest.mark.skipif(not LZMA_AVAILABLE, reason="no lzma library")
@@ -180,3 +182,13 @@ def test_eq_strict():
 def test_memory_repr():
     for power, mem_repr in enumerate(['1.0 bytes', '1.0 KB', '1.0 MB', '1.0 GB']):
         assert memory_repr(1024 ** power) == mem_repr
+
+
+def test_method_caller():
+    a = [1, 2, 3, 3, 3]
+    f = methodcaller('count')
+    assert f(a, 3) == a.count(3)
+    assert methodcaller('count') is f
+    assert M.count is f
+    assert pickle.loads(pickle.dumps(f)) is f
+    assert 'count' in dir(M)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -821,3 +821,45 @@ def key_split(s):
             return result
     except Exception:
         return 'Other'
+
+
+_method_cache = {}
+
+class methodcaller(object):
+    """Return a callable object that calls the given method on its operand.
+
+    Unlike the builtin `methodcaller`, this class is serializable"""
+
+    __slots__ = ('method',)
+    func = property(lambda self: self.method)  # For `funcname` to work
+
+    def __new__(cls, method):
+        if method in _method_cache:
+            return _method_cache[method]
+        self = object.__new__(cls)
+        self.method = method
+        _method_cache[method] = self
+        return self
+
+    def __call__(self, obj, *args, **kwargs):
+        return getattr(obj, self.method)(*args, **kwargs)
+
+    def __reduce__(self):
+        return (methodcaller, (self.method,))
+
+
+class MethodCache(object):
+    """Attribute access on this object returns a methodcaller for that
+    attribute.
+
+    Examples
+    --------
+    >>> a = [1, 3, 3]
+    >>> M.count(a, 3) == a.count(3)
+    True
+    """
+    __getattr__ = staticmethod(methodcaller)
+    __dir__ = lambda self: list(_method_cache)
+
+
+M = MethodCache()


### PR DESCRIPTION
These increased serialization costs, often contained closures making
debugging more difficult, and were sometimes defined in multiple places.
Most of these were moved to `dask.dataframe.methods`, where they can be
reused.