### PR TITLE
Unify example doc pages into one

### DIFF
--- a/docs/source/array-examples.rst
+++ b/docs/source/array-examples.rst
@@ -1,9 +1,0 @@
-Examples
-========
-
-.. toctree::
-   :maxdepth: 1
-
-   examples/array-numpy.rst
-   examples/array-hdf5.rst
-   examples/array-random.rst

--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -10,7 +10,6 @@ blocked algorithms and task scheduling.
    array-overview.rst
    array-creation.rst
    array-api.rst
-   array-examples.rst
 
 Other topics
 

--- a/docs/source/bag-examples.rst
+++ b/docs/source/bag-examples.rst
@@ -1,8 +1,0 @@
-Examples
-========
-
-.. toctree::
-   :maxdepth: 1
-
-   examples/bag-json.rst
-   examples/bag-word-count-hdfs.rst

--- a/docs/source/bag.rst
+++ b/docs/source/bag.rst
@@ -11,4 +11,3 @@ semi-structured data like JSON blobs or log files.
    bag-overview.rst
    bag-creation.rst
    bag-api.rst
-   bag-examples.rst

--- a/docs/source/dataframe-examples.rst
+++ b/docs/source/dataframe-examples.rst
@@ -1,8 +1,0 @@
-Examples
-========
-
-.. toctree::
-   :maxdepth: 1
-
-   examples/dataframe-csv.rst
-   examples/dataframe-hdf5.rst

--- a/docs/source/dataframe.rst
+++ b/docs/source/dataframe.rst
@@ -11,7 +11,6 @@ the complete pandas interface.
    dataframe-overview.rst
    dataframe-create.rst
    dataframe-api.rst
-   dataframe-examples.rst
 
 Other topics
 

--- a/docs/source/delayed-examples.rst
+++ b/docs/source/delayed-examples.rst
@@ -1,8 +1,0 @@
-Examples
-========
-
-.. toctree::
-   :maxdepth: 1
-
-   examples/delayed-array.rst
-   examples/delayed-custom.rst

--- a/docs/source/delayed.rst
+++ b/docs/source/delayed.rst
@@ -12,5 +12,4 @@ directly with a light annotation of normal python code.
 
    delayed-overview.rst
    delayed-api.rst
-   delayed-examples.rst
    delayed-collections.rst

--- a/docs/source/examples-tutorials.rst
+++ b/docs/source/examples-tutorials.rst
@@ -1,35 +1,74 @@
-Examples and Tutorials
-======================
-
 Examples
+========
+
+Array
+------
+
+:doc:`Array documentation<array>`
+
+.. toctree::
+   :maxdepth: 1
+
+   examples/array-numpy.rst
+   examples/array-hdf5.rst
+   examples/array-random.rst
+
+*  `Use Dask.array to generate task graphs <https://gist.github.com/mrocklin/b61f795004ec0a70e43de350e453e97e>`_
+
+Bag
+---
+
+:doc:`Bag documentation<array>`
+
+.. toctree::
+   :maxdepth: 1
+
+   examples/bag-json.rst
+   examples/bag-word-count-hdfs.rst
+
+DataFrame
+----------
+
+:doc:`DataFrame documentation<array>`
+
+.. toctree::
+   :maxdepth: 1
+
+   examples/dataframe-csv.rst
+   examples/dataframe-hdf5.rst
+
+*  `Distributed DataFrames on NYCTaxi data <https://gist.github.com/mrocklin/fa8e30776e82d46015bfe8fd3b35fcb1>`_
+*  `Build Parallel Algorithms for Pandas <https://gist.github.com/mrocklin/d009e5d4a1f49ecdb433107f3d72c7f3#file-pygotham-dataframes-ipynb>`_
+*  `Simple distributed joins <https://gist.github.com/mrocklin/7b3d3c1b9ed3e747aaf04ad70debc8e9>`_
+*  `Build Dask.dataframes from custom format, feather <https://gist.github.com/mrocklin/e7b7b3a65f2835cda813096332ec73ca>`_
+
+
+Delayed
+-------
+
+:doc:`Delayed documentation<array>`
+
+.. toctree::
+   :maxdepth: 1
+
+   examples/delayed-array.rst
+   examples/delayed-custom.rst
+
+*  `Basic Delayed example <https://gist.github.com/mrocklin/d009e5d4a1f49ecdb433107f3d72c7f3#file-pygotham-delayed-ipynb>`_
+*  `Build Parallel Algorithms for Pandas <https://gist.github.com/mrocklin/d009e5d4a1f49ecdb433107f3d72c7f3#file-pygotham-dataframes-ipynb>`_
+*  `Build Dask.dataframes from custom format, feather <https://gist.github.com/mrocklin/e7b7b3a65f2835cda813096332ec73ca>`_
+
+Distributed Concurrent.futures
+------------------------------
+
+`Concurrent.futures documentation <http://distributed.readthedocs.io/en/latest/quickstart.html#map-and-submit-functions>`_
+
+*  `Custom workflows <https://gist.github.com/mrocklin/ef9ccd29a6ec5f4de84d6192be95042a>`_
+*  `Ad Hoc Distributed Random Forests <https://gist.github.com/mrocklin/9f5720d8658e5f2f66666815b1f03f00>`_
+
+
+Tutorial
 --------
 
-You can view examples for each Dask collection:
-
-* :doc:`Dask Array Examples <array-examples>`
-* :doc:`Dask Bag Examples <bag-examples>`
-* :doc:`Dask DataFrame Examples <dataframe-examples>`
-* :doc:`Dask delayed Examples <delayed-examples>`
-
-
-Tutorials
----------
-
-You can view a tutorial of Dask, including slides and notebooks on Dask arrays,
-graphs, dataframes, delayed, and bags in the
-`dask-tutorials repository <https://github.com/dask/dask-tutorial>`_.
-
-You can try a live tutorial of dask dataframe's basics `here
-<http://mybinder.org/repo/dask/dask-examples/dask-dataframe-basics.ipynb>`_.
-
-Dask dataframe's timeseries functionality is demonstrated on `Binder
-<http://mybinder.org/repo/dask/dask-examples/time-series-binder.ipynb>`_. And
-static notebook with more data and profiling is on `nbviewer
-<http://nbviewer.ipython.org/github/dask/dask-examples/blob/master/time-series.ipynb>`_.
-
-
-Notebooks
----------
-
-You can view example Dask notebooks in the
-`dask-examples repository <https://github.com/dask/dask-examples>`_.
+A Dask tutorial from July 2015 (fairly old) is available here:
+https://github.com/dask/dask-tutorial


### PR DESCRIPTION
This is one of the most visited pages in the docs, and yet it is fairly
bare.  This pushes all of the doc pages into a single site to encourage
cross-polination.  In also includes links to notebooks that I keep in
gists.