### PR TITLE
Add custom docstring to dd.to_csv, mentioning that one file per partition is written

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -890,8 +890,71 @@ class _Frame(Base):
         from .io import to_hdf
         return to_hdf(self, path_or_buf, key, mode, append, get=get, **kwargs)
 
-    @derived_from(pd.DataFrame)
     def to_csv(self, filename, **kwargs):
+        """Write DataFrame to a series of comma-separated values (csv) files
+
+        One filename per partition will be written.
+
+        Parameters
+        ----------
+        filename : string
+            Path glob indicating the naming scheme for the output files
+        sep : character, default ','
+            Field delimiter for the output file.
+        na_rep : string, default ''
+            Missing data representation
+        float_format : string, default None
+            Format string for floating point numbers
+        columns : sequence, optional
+            Columns to write
+        header : boolean or list of string, default True
+            Write out column names. If a list of string is given it is assumed
+            to be aliases for the column names
+        index : boolean, default True
+            Write row names (index)
+        index_label : string or sequence, or False, default None
+            Column label for index column(s) if desired. If None is given, and
+            `header` and `index` are True, then the index names are used. A
+            sequence should be given if the DataFrame uses MultiIndex.  If
+            False do not print fields for index names. Use index_label=False
+            for easier importing in R
+        nanRep : None
+            deprecated, use na_rep
+        mode : str
+            Python write mode, default 'w'
+        encoding : string, optional
+            A string representing the encoding to use in the output file,
+            defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
+        compression : string, optional
+            a string representing the compression to use in the output file,
+            allowed values are 'gzip', 'bz2', 'xz',
+            only used when the first argument is a filename
+        line_terminator : string, default '\\n'
+            The newline character or character sequence to use in the output
+            file
+        quoting : optional constant from csv module
+            defaults to csv.QUOTE_MINIMAL
+        quotechar : string (length 1), default '\"'
+            character used to quote fields
+        doublequote : boolean, default True
+            Control quoting of `quotechar` inside a field
+        escapechar : string (length 1), default None
+            character used to escape `sep` and `quotechar` when appropriate
+        chunksize : int or None
+            rows to write at a time
+        tupleize_cols : boolean, default False
+            write multi_index columns as a list of tuples (if True)
+            or new (expanded format) if False)
+        date_format : string, default None
+            Format string for datetime objects
+        decimal: string, default '.'
+            Character recognized as decimal separator. E.g. use ',' for
+            European data
+
+        Examples
+        --------
+        >>> df.to_csv('/path/to/data/export-*.csv')  # doctest: +SKIP
+        """
         from .io import to_csv
         return to_csv(self, filename, **kwargs)
 


### PR DESCRIPTION
Previously it was copying the pandas one, so there was no reference anywhere to the fact that multiple files were being created and a globstring is expected.

See #1506.