### PR TITLE
Update to highlight the use of glob based file naming option for df exports

### DIFF
--- a/docs/source/dataframe-overview.rst
+++ b/docs/source/dataframe-overview.rst
@@ -119,9 +119,16 @@ or distributed scheduler.
 
 See :doc:`scheduler docs<scheduler-overview>` for more information.
 
+
 Exporting to Disk
----------
-``dask.dataframe`` supports a variety of output methods to write your data to disk include ``to_csv()`` ``to_castra`` ``to_hdf()``. Please consult the API for a complete list. To maximise the opportunity for parallel execution users should provide a glob based file name e.g ``DataExport-*.csv`` to generate a sequential list of files instead of a single monolith file. Single file names are prone to performance and usability issues including write permission based errors.
+-----------------
+``dask.dataframe`` supports a variety of output methods to write your data to
+disk including ``to_csv()``, ``to_castra`` and ``to_hdf()``. Please see the
+:doc:`dataframe API<dataframe-api>` for a complete list. To maximize the
+throughput during parallel execution you must provide a glob based file name
+e.g ``DataExport-*.csv`` to generate a sequential list of files instead of a
+single file.
+
 
 Limitations
 -----------

--- a/docs/source/dataframe-overview.rst
+++ b/docs/source/dataframe-overview.rst
@@ -119,6 +119,9 @@ or distributed scheduler.
 
 See :doc:`scheduler docs<scheduler-overview>` for more information.
 
+Exporting to Disk
+---------
+``dask.dataframe`` supports a variety of output methods to write your data to disk include ``to_csv()`` ``to_castra`` ``to_hdf()``. Please consult the API for a complete list. To maximise the opportunity for parallel execution users should provide a glob based file name e.g ``DataExport-*.csv`` to generate a sequential list of files instead of a single monolith file. Single file names are prone to performance and usability issues including write permission based errors.
 
 Limitations
 -----------


### PR DESCRIPTION
This builds on #1507 to solve #1506. However I don't know if it is really necessary.