### PR TITLE
Avoid pickle when tokenizing __main__ functions

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -249,7 +249,9 @@ def normalize_function(func):
         return (normalize_function(func.func), func.args, kws)
     else:
         try:
-            return pickle.dumps(func, protocol=0)
+            result = pickle.dumps(func, protocol=0)
+            assert b'__main__' not in result  # abort on dynamic functions
+            return result
         except:
             try:
                 import cloudpickle

--- a/dask/base.py
+++ b/dask/base.py
@@ -250,14 +250,15 @@ def normalize_function(func):
     else:
         try:
             result = pickle.dumps(func, protocol=0)
-            assert b'__main__' not in result  # abort on dynamic functions
-            return result
+            if b'__main__' not in result:  # abort on dynamic functions
+                return result
         except:
-            try:
-                import cloudpickle
-                return cloudpickle.dumps(func, protocol=0)
-            except:
-                return str(func)
+            pass
+        try:
+            import cloudpickle
+            return cloudpickle.dumps(func, protocol=0)
+        except:
+            return str(func)
 
 
 normalize_token = Dispatch()

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -288,11 +288,12 @@ def test_visualize():
 
 def test_use_cloudpickle_to_tokenize_functions_in__main__():
     import sys
+    from textwrap import dedent
 
-    defn = """
-def inc():
-    return x
-    """
+    defn = dedent("""
+    def inc():
+        return x
+    """)
 
     __main__ = sys.modules['__main__']
     exec(compile(defn, '<test>', 'exec'), __main__.__dict__)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -284,3 +284,19 @@ def test_visualize():
         dsk = {'a': 1, 'b': (add, 'a', 2), 'c': (mul, 'a', 1)}
         visualize(x, dsk, filename=os.path.join(d, 'mydask.png'))
         assert os.path.exists(os.path.join(d, 'mydask.png'))
+
+
+def test_use_cloudpickle_to_tokenize_functions_in__main__():
+    import sys
+
+    defn = """
+def inc():
+    return x
+    """
+
+    __main__ = sys.modules['__main__']
+    exec(compile(defn, '<test>', 'exec'), __main__.__dict__)
+    f = __main__.inc
+
+    t = normalize_token(f)
+    assert b'__main__' not in t


### PR DESCRIPTION
Previously two functions defined in main with the same name would
tokenize to the same value.  This is because `pickle` would return
the same value in both cases without raising an exception (as might be
expected)

This now checks the result for the bytestring b`__main__` and if present
continues on to use cloudpickle.

Fixes https://github.com/dask/distributed/issues/487

Unfortunately, I don't know how to test for this.  It's hard to make a function from the `__main__` module when not operating from a prompt.