### PR TITLE
Only fuse simple indexing with getarray backends

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -21,10 +21,10 @@ from dask.utils import raises, ignoring, tmpfile, tmpdir
 from dask.utils_test import inc
 
 from dask.array import chunk
-from dask.array.core import (getem, getarray, top, dotmany, concatenate3,
-                             broadcast_dimensions, Array, stack, concatenate,
-                             from_array, take, elemwise, isnull, notnull,
-                             broadcast_shapes, partial_by_order, exp,
+from dask.array.core import (getem, getarray, getarray_nofancy, top, dotmany,
+                             concatenate3, broadcast_dimensions, Array, stack,
+                             concatenate, from_array, take, elemwise, isnull,
+                             notnull, broadcast_shapes, partial_by_order, exp,
                              tensordot, choose, where, coarsen, insert,
                              broadcast_to, reshape, fromfunction,
                              blockdims_from_blockshape, store, optimize,
@@ -51,11 +51,12 @@ def same_keys(a, b):
 
 
 def test_getem():
-    assert getem('X', (2, 3), shape=(4, 6)) == \
-    {('X', 0, 0): (getarray, 'X', (slice(0, 2), slice(0, 3))),
-     ('X', 1, 0): (getarray, 'X', (slice(2, 4), slice(0, 3))),
-     ('X', 1, 1): (getarray, 'X', (slice(2, 4), slice(3, 6))),
-     ('X', 0, 1): (getarray, 'X', (slice(0, 2), slice(3, 6)))}
+    for fancy, getter in [(True, getarray), (False, getarray_nofancy)]:
+        sol = {('X', 0, 0): (getter, 'X', (slice(0, 2), slice(0, 3))),
+               ('X', 1, 0): (getter, 'X', (slice(2, 4), slice(0, 3))),
+               ('X', 1, 1): (getter, 'X', (slice(2, 4), slice(3, 6))),
+               ('X', 0, 1): (getter, 'X', (slice(0, 2), slice(3, 6)))}
+        assert getem('X', (2, 3), shape=(4, 6), fancy=fancy) == sol
 
 
 def test_top():

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -7,7 +7,7 @@ from dask.array.optimization import (getitem, optimize, optimize_slices,
         fuse_slice)
 
 from dask.utils import raises
-from dask.array.core import getarray
+from dask.array.core import getarray, getarray_nofancy
 
 
 def test_fuse_getitem():
@@ -18,12 +18,20 @@ def test_fuse_getitem():
                         (slice(15, 20), slice(50, 60))),
               (getarray, 'x', (slice(1015, 1020), slice(150, 160)))),
 
+             ((getitem, (getarray_nofancy, 'x', (slice(1000, 2000), slice(100, 200))),
+                        (slice(15, 20), slice(50, 60))),
+              (getarray_nofancy, 'x', (slice(1015, 1020), slice(150, 160)))),
+
              ((getarray, (getarray, 'x', slice(1000, 2000)), 10),
               (getarray, 'x', 1010)),
 
              ((getitem, (getarray, 'x', (slice(1000, 2000), 10)),
                         (slice(15, 20),)),
               (getarray, 'x', (slice(1015, 1020), 10))),
+
+             ((getitem, (getarray_nofancy, 'x', (slice(1000, 2000), 10)),
+                        (slice(15, 20),)),
+              (getarray_nofancy, 'x', (slice(1015, 1020), 10))),
 
              ((getarray, (getarray, 'x', (10, slice(1000, 2000))),
                         (slice(15, 20),)),
@@ -119,16 +127,10 @@ def test_dont_fuse_different_slices():
     assert len(dsk) > 100
 
 
-def test_dont_fuse_lists_in_getarray():
-    dsk = {'a': (getitem, (getarray, 'x', (slice(10, 20, None), slice(100, 200, None))),
+def test_dont_fuse_fancy_indexing_in_getarray_nofancy():
+    dsk = {'a': (getitem, (getarray_nofancy, 'x', (slice(10, 20, None), slice(100, 200, None))),
                  ([1, 3], slice(50, 60, None)))}
-    res = optimize_slices(dsk)
-    sol = {'a': (getarray, (getarray, 'x', (slice(10, 20, None), slice(100, 200, None))),
-                 ([1, 3], slice(50, 60, None)))}
-    assert res == sol
+    assert optimize_slices(dsk) == dsk
 
-    dsk = {'a': (getitem, (getitem, 'x', (slice(10, 20, None), slice(100, 200, None))),
-                 ([1, 3], slice(50, 60, None)))}
-    res = optimize_slices(dsk)
-    sol = {'a': (getitem, 'x', ([11, 13], slice(150, 160, None)))}
-    assert res == sol
+    dsk = {'a': (getitem, (getarray_nofancy, 'x', [1, 2, 3]), 0)}
+    assert optimize_slices(dsk) == dsk


### PR DESCRIPTION
Certain numpy-array-like-things may not support all of the indexing methods that numpy uses. When fusing getitem/getarray calls together, we shouldn't pass "fancy indexing" requests to these backends. The easiest way to do this is to not propogate fusing of these types back inside calls to `getarray`.

This PR includes the following changes:
- Don't fuse indexing using lists or arrays inside calls to `getarray`.
- Make `from_array` use `getitem` when used with numpy types that return
  instances of `ndarray` when indexed. This is a small optimization to
  make use of `np.memmap` and `np.ndarray` still as fast as before.

Fixes #1528.

```python
In [1]: import zarr

In [2]: import numpy as np

In [3]: import dask.array as da

In [4]: x = np.random.randint(0, 4, size=(10000, 100))

In [5]: f = np.random.randint(0, 2, size=10000).astype(bool)

In [6]: zx = zarr.array(x)

In [7]: dzx = da.from_array(zx, chunks=zx.chunks)

In [8]: res = da.compress(f, dzx, axis=0)

In [9]: res.compute()
Out[9]:
array([[0, 3, 0, ..., 1, 3, 0],
       [0, 1, 0, ..., 3, 2, 3],
       [0, 2, 2, ..., 2, 1, 3],
       ...,
       [2, 3, 3, ..., 0, 2, 2],
       [3, 0, 0, ..., 1, 0, 0],
       [3, 0, 3, ..., 3, 0, 1]])
```