### PR TITLE
Deemphasize graphs in docs

### DIFF
--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -176,6 +176,9 @@ def inline(dsk, keys=None, inline_constants=True, dependencies=None):
     >>> inline(d, keys='y', inline_constants=False)  # doctest: +SKIP
     {'x': 1, 'y': (inc, 1), 'z': (add, 'x', (inc, 'x'))}
     """
+    if dependencies and isinstance(next(iter(dependencies.values())), list):
+        dependencies = {k: set(v) for k, v in dependencies.items()}
+
     keys = _flat_set(keys)
 
     if dependencies is None:

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -386,3 +386,14 @@ def test_fuse_selections():
     dsk2 = fuse_selections(dsk, getitem, load, merge)
     dsk2, dependencies = cull(dsk2, 'y')
     assert dsk2 == {'y': (load, 'store', 'part', 'a')}
+
+
+def test_inline_cull_dependencies():
+    d = {'a': 1,
+         'b': 'a',
+         'c': 'b',
+         'd': ['a', 'b', 'c'],
+         'e': (add, (len, 'd'), 'a')}
+
+    d2, dependencies = cull(d, ['d', 'e'])
+    inline(d2, {'b'}, dependencies=dependencies)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -167,30 +167,6 @@ then you should start here.
    dataframe.rst
    delayed.rst
 
-**Graphs**
-
-Dask graphs encode algorithms in a simple format involving Python dicts,
-tuples, and functions.  This graph format can be used in isolation from the
-dask collections.  Working directly with dask graphs is an excellent way to
-implement and test new algorithms in fields such as linear algebra,
-optimization, and machine learning.  If you are a *developer*, you should start
-here.
-
-* :doc:`graphs`
-* :doc:`spec`
-* :doc:`custom-graphs`
-* :doc:`optimize`
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Graphs
-
-   graphs.rst
-   spec.rst
-   custom-graphs.rst
-   optimize.rst
-
 **Scheduling**
 
 Schedulers execute task graphs.  Dask currently has two main schedulers, one
@@ -228,6 +204,29 @@ help make debugging and profiling graph execution easier.
 
    inspect.rst
    diagnostics.rst
+
+**Graphs**
+
+Internally Dask encodes algorithms in a simple format involving Python dicts,
+tuples, and functions.  This graph format can be used in isolation from the
+dask collections.  Working directly with dask graphs is rare unless you intend
+to develop new modules with Dask.  Even then, :doc:`dask.delayed <delayed>` is
+often a better choice.  If you are a *core developer*, then you should start here.
+
+* :doc:`graphs`
+* :doc:`spec`
+* :doc:`custom-graphs`
+* :doc:`optimize`
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: Graphs
+
+   graphs.rst
+   spec.rst
+   custom-graphs.rst
+   optimize.rst
 
 **Help & reference**
 


### PR DESCRIPTION
This moves the graphs section down in the index and provides warnings
that it is for core developers only.

This also updates the optimize docs so that they can be run through
cleanly.

Fixes https://github.com/dask/dask/issues/1530