### PR TITLE
A few changes to `dask.delayed`

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 from ..utils import ignoring
 from .core import (Array, stack, concatenate, take, tensordot, transpose,
-        from_array, from_imperative, choose, where, coarsen, insert,
-        broadcast_to, ravel, reshape, fromfunction, unique, store, squeeze,
-        topk, bincount, digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
+        from_array, choose, where, coarsen, insert, broadcast_to, ravel,
+        reshape, fromfunction, unique, store, squeeze, topk, bincount,
+        digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
         from_delayed)
 from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,

--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 from .core import (Bag, Item, from_sequence, from_filenames, from_url,
-                   to_textfiles, concat, from_castra, from_imperative,
-                   from_delayed, bag_range as range, bag_zip as zip)
+                   to_textfiles, concat, from_castra, from_delayed,
+                   bag_range as range, bag_zip as zip)
 from .text import read_text
 from ..context import set_options
 from ..base import compute

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -864,29 +864,29 @@ def test_bag_compute_forward_kwargs():
 
 
 def test_to_delayed():
-    from dask.delayed import Value
+    from dask.delayed import Delayed
 
     b = db.from_sequence([1, 2, 3, 4, 5, 6], npartitions=3)
     a, b, c = b.map(inc).to_delayed()
-    assert all(isinstance(x, Value) for x in [a, b, c])
+    assert all(isinstance(x, Delayed) for x in [a, b, c])
     assert b.compute() == [4, 5]
 
     b = db.from_sequence([1, 2, 3, 4, 5, 6], npartitions=3)
     t = b.sum().to_delayed()
-    assert isinstance(t, Value)
+    assert isinstance(t, Delayed)
     assert t.compute() == 21
 
 
 def test_from_delayed():
-    from dask.delayed import value, do
-    a, b, c = value([1, 2, 3]), value([4, 5, 6]), value([7, 8, 9])
+    from dask.delayed import delayed
+    a, b, c = delayed([1, 2, 3]), delayed([4, 5, 6]), delayed([7, 8, 9])
     bb = from_delayed([a, b, c])
     assert bb.name == from_delayed([a, b, c]).name
 
     assert isinstance(bb, Bag)
     assert list(bb) == [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-    asum_value = do(lambda X: sum(X))(a)
+    asum_value = delayed(lambda X: sum(X))(a)
     asum_item = db.Item.from_delayed(asum_value)
     assert asum_value.compute() == asum_item.compute() == 6
 

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -4,7 +4,7 @@ from .core import (DataFrame, Series, Index, _Frame, map_partitions,
                    repartition)
 from .io import (from_array, from_bcolz, from_array, from_bcolz,
                  from_pandas, from_dask_array, from_castra, read_hdf,
-                 from_imperative, from_delayed)
+                 from_delayed)
 from .optimize import optimize
 from .multi import merge, concat, melt
 from .rolling import (rolling_count, rolling_sum, rolling_mean, rolling_median,

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1001,10 +1001,6 @@ class _Frame(Base):
         from .io import to_csv
         return to_csv(self, filename, **kwargs)
 
-    def to_imperative(self):
-        warnings.warn("Deprecation warning: moved to to_delayed")
-        return self.to_delayed()
-
     def to_delayed(self):
         """ Convert dataframe into dask Values
 

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -782,11 +782,6 @@ def to_bag(df, index=False):
     return Bag(dsk, name, df.npartitions)
 
 
-def from_imperative(*args, **kwargs):
-    warn("Deprecation warning: moved to from_delayed")
-    return from_delayed(*args, **kwargs)
-
-
 @insert_meta_param_description
 def from_delayed(dfs, meta=None, divisions=None, prefix='from-delayed',
                  metadata=None):
@@ -794,7 +789,7 @@ def from_delayed(dfs, meta=None, divisions=None, prefix='from-delayed',
 
     Parameters
     ----------
-    dfs : list of Values
+    dfs : list of Delayed
         An iterable of ``dask.delayed.Delayed`` objects, such as come from
         ``dask.delayed`` These comprise the individual partitions of the
         resulting dataframe.

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 from collections import Iterator
 from itertools import chain
-from warnings import warn
 import operator
 import uuid
 
@@ -50,8 +49,8 @@ def to_task_dasks(expr, **kwargs):
     Examples
     --------
 
-    >>> a = value(1, 'a')
-    >>> b = value(2, 'b')
+    >>> a = delayed(1, 'a')
+    >>> b = delayed(2, 'b')
     >>> task, dasks = to_task_dasks([a, b, 3])
     >>> task # doctest: +SKIP
     (list, ['a', 'b', 3])
@@ -281,7 +280,7 @@ def compute(*args, **kwargs):
 
     Examples
     --------
-    >>> a = value(1)
+    >>> a = delayed(1)
     >>> b = a + 2
     >>> c = a + 3
     >>> compute(b, c)  # Compute both simultaneously
@@ -461,10 +460,3 @@ for op in [operator.abs, operator.neg, operator.pos, operator.invert,
 
 
 base.normalize_token.register(Delayed, lambda a: a.key)
-
-Value = Delayed
-
-
-def value(val, name=None):
-    warn("``dask.imperative.value`` is renamed to ``delayed``")
-    return delayed(val, name=name)

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -1,8 +1,0 @@
-# flake8: noqa
-from __future__ import print_function, division, absolute_import
-
-from warnings import warn
-
-from .delayed import do, value, Delayed, Value, delayed
-
-warn("dask.imperative has been moved to dask.delayed")

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -185,8 +185,8 @@ def test_nout():
     assert len(x) == 2
     a, b = x
     assert compute(a, b) == (1, -1)
-    assert a._n is None
-    assert b._n is None
+    assert a._length is None
+    assert b._length is None
     pytest.raises(TypeError, lambda: len(a))
     pytest.raises(TypeError, lambda: list(a))
 
@@ -195,8 +195,9 @@ def test_nout():
 
     func = delayed(add, nout=1)
     a = func(1)
-    assert a._n == 1
+    assert a._length is None
     pytest.raises(TypeError, lambda: list(a))
+    pytest.raises(TypeError, lambda: len(a))
 
 
 def test_kwargs():
@@ -257,7 +258,7 @@ def test_delayed_picklable():
     y = pickle.loads(pickle.dumps(x))
     assert x.dask == y.dask
     assert x._key == y._key
-    assert x._n == y._n
+    assert x._length == y._length
     # DelayedLeaf
     x = delayed(1j + 2)
     y = pickle.loads(pickle.dumps(x))


### PR DESCRIPTION
This makes a few separate changes to `dask.delayed`:

- Adds an optional `nout` keyword to `delayed` objects, allowing for
  splatting and iteration over results.  If not provided, iteration will
  still error. Fixes #795.

  ```python
  @delayed(pure=True, nout=2)
  def foo(a):
      return a, -a

  x, y = foo(1)
  ```

- Cleanup method calling behavior through use of small `DelayedAttr`
  object. Use `dask.utils.methodcaller` to do the actual method calls.
  This is cleaner than trying to inline the method getattrs later.

- Cleanup the test suite for delayed, removing a few duplicate tests.

- Remove long since deprecated `dask.imperative` and `dask.imperative.Value` namings.