### PR TITLE
Select dtypes

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1944,6 +1944,11 @@ class DataFrame(_Frame):
         """ Return data types """
         return self._meta.dtypes
 
+    @derived_from(pd.DataFrame)
+    def select_dtypes(self, include=None, exclude=None):
+        cs = self._meta.select_dtypes(include=include, exclude=exclude).columns
+        return self[list(cs)]
+
     def set_index(self, other, drop=True, sorted=False, **kwargs):
         """ Set the DataFrame index (row labels) using an existing column
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1398,6 +1398,25 @@ def test_eval():
                 d.eval('z = x + y', inplace=None)
 
 
+@pytest.mark.parametrize('include, exclude', [
+    ([int], None),
+    (None, [int]),
+    ([np.number, object], [float]),
+    (['datetime'], None)
+])
+def test_select_dtypes(include, exclude):
+    n = 10
+    df = pd.DataFrame({'cint': [1] * n,
+                       'cstr': ['a'] * n,
+                       'clfoat': [1.] * n,
+                       'cdt': pd.date_range('2016-01-01', periods=n)
+        })
+    a = dd.from_pandas(df, npartitions=2)
+    result = a.select_dtypes(include=include, exclude=exclude)
+    expected = df.select_dtypes(include=include, exclude=exclude)
+    assert eq(result, expected)
+
+
 def test_deterministic_arithmetic_names():
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})
     a = dd.from_pandas(df, npartitions=2)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ DataFrame
   (:pr:`1495`)
 - Add ``dataframe.reduction`` and ``series.reduction`` methods to apply generic
   row-wise reduction to dataframes and series (:pr:`1483`)
+- Add ``dataframe.select_dtypes``, which mirrors the `pandas method<http://pandas.pydata.org/pandas-docs/version/0.18.1/generated/pandas.DataFrame.select_dtypes.html>`_ (:pr:`1556`)
 
 Distributed
 +++++++++++


### PR DESCRIPTION
I ran into a problem today where the pandas [`select_dtypes`](http://pandas.pydata.org/pandas-docs/version/0.18.1/generated/pandas.DataFrame.select_dtypes.html) method would have been useful.

