### PR TITLE
String accessor works with indexes

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3178,13 +3178,15 @@ class Accessor(object):
         self._series = series
 
     def _property_map(self, key):
-        out = self.getattr(self._series._meta, key)
-        meta = pd.Series([], dtype=out.dtype, name=getattr(out, 'name', None))
+        out = self.getattr(self._series._meta_nonempty, key)
+        meta = self._series._partition_type([], dtype=out.dtype,
+                name=getattr(out, 'name', None))
         return map_partitions(self.getattr, self._series, key, meta=meta)
 
     def _function_map(self, key, *args):
-        out = self.call(self._series._meta, key, *args)
-        meta = pd.Series([], dtype=out.dtype, name=getattr(out, 'name', None))
+        out = self.call(self._series._meta_nonempty, key, *args)
+        meta = self._series._partition_type([], dtype=out.dtype,
+                name=getattr(out, 'name', None))
         return map_partitions(self.call, self._series, key, *args, meta=meta)
 
     def __dir__(self):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1349,15 +1349,17 @@ def test_datetime_accessor():
 
 
 def test_str_accessor():
-    df = pd.DataFrame({'x': ['a', 'b', 'c', 'D']})
+    df = pd.DataFrame({'x': ['a', 'b', 'c', 'D']}, index=['e', 'f', 'g', 'H'])
 
-    a = dd.from_pandas(df, 2)
+    a = dd.from_pandas(df, 2, sort=False)
 
     assert 'upper' in dir(a.x.str)
-
     assert eq(a.x.str.upper(), df.x.str.upper())
-
     assert a.x.str.upper().dask == a.x.str.upper().dask
+
+    assert 'upper' in dir(a.index.str)
+    assert eq(a.index.str.upper(), df.index.str.upper())
+    assert a.index.str.upper().dask == a.index.str.upper().dask
 
 
 def test_empty_max():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -419,15 +419,17 @@ def assert_divisions(ddf):
     if not ddf.known_divisions:
         return
 
+    index = lambda x: x if isinstance(x, pd.Index) else x.index
+
     results = get_sync(ddf.dask, ddf._keys())
     for i, df in enumerate(results[:-1]):
         if len(df):
-            assert df.index.min() >= ddf.divisions[i]
-            assert df.index.max() < ddf.divisions[i + 1]
+            assert index(df).min() >= ddf.divisions[i]
+            assert index(df).max() < ddf.divisions[i + 1]
 
     if len(results[-1]):
-        assert results[-1].index.min() >= ddf.divisions[-2]
-        assert results[-1].index.max() <= ddf.divisions[-1]
+        assert index(results[-1]).min() >= ddf.divisions[-2]
+        assert index(results[-1]).max() <= ddf.divisions[-1]
 
 
 def assert_sane_keynames(ddf):


### PR DESCRIPTION
Previously the string accessor would error on indexes due to a pandas peculiarity. Fixes #1560.