### PR TITLE
Tokenize mmap works without filename

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -318,7 +318,7 @@ with ignoring(ImportError):
     def normalize_array(x):
         if not x.shape:
             return (str(x), x.dtype)
-        if hasattr(x, 'mode') and hasattr(x, 'filename'):
+        if hasattr(x, 'mode') and getattr(x, 'filename', None):
             return x.filename, os.path.getmtime(x.filename), x.dtype, x.shape
         if x.dtype.hasobject:
             try:

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -121,6 +121,19 @@ def test_tokenize_numpy_memmap():
     assert y != z
 
 
+@pytest.mark.skipif('not np')
+def test_tokenize_numpy_memmap_no_filename():
+    # GH 1562:
+    with tmpfile('.npy') as fn1, tmpfile('.npy') as fn2:
+        x = np.arange(5)
+        np.save(fn1, x)
+        np.save(fn2, x)
+
+        a = np.load(fn1, mmap_mode='r')
+        b = a + a
+        assert tokenize(b) == tokenize(b)
+
+
 def test_normalize_base():
     for i in [1, 1.1, '1', slice(1, 2, 3)]:
         assert normalize_token(i) is i


### PR DESCRIPTION
Due to a bug in numpy, ufuncs performed on `memmap`'s return an
instance of `memmap`, even though the data is already in memory. In
these cases `memmap.filename` is `None`, which causes `tokenize` to
error. We now treat `memmap` files where `filename is None` the same as
an in-memory file.

Fixes #1562.