### PR TITLE
Sample from `read_bytes` ends on a delimiter

### DIFF
--- a/dask/bytes/local.py
+++ b/dask/bytes/local.py
@@ -31,7 +31,7 @@ def read_bytes(path, delimiter=None, not_zero=False, blocksize=2**27,
     if '*' in path:
         filenames = list(map(os.path.abspath, sorted(glob(path))))
         sample, first = read_bytes(filenames[0], delimiter, not_zero,
-                                   blocksize, sample=True,
+                                   blocksize, sample=sample,
                                    compression=compression)
         rest = [read_bytes(f, delimiter, not_zero, blocksize, sample=False,
                            compression=compression)[1]
@@ -65,7 +65,7 @@ def read_bytes(path, delimiter=None, not_zero=False, blocksize=2**27,
                 nbytes = sample
             else:
                 nbytes = 10000
-            sample = read_block_from_file(path, 0, nbytes, None, compression)
+            sample = read_block_from_file(path, 0, nbytes, delimiter, compression)
 
         return sample, values
 

--- a/dask/bytes/s3.py
+++ b/dask/bytes/s3.py
@@ -80,7 +80,7 @@ def read_bytes(path, s3=None, delimiter=None, not_zero=False, blocksize=2**27,
         if not filenames:
             raise IOError("No such files: '%s'" % s3_path)
         sample, first = read_bytes(filenames[0], s3, delimiter, not_zero,
-                                   blocksize, sample=True,
+                                   blocksize, sample=sample,
                                    compression=compression)
         rest = [read_bytes(f, s3, delimiter, not_zero, blocksize,
                        sample=False, compression=compression)[1]

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -30,6 +30,7 @@ def test_read_bytes():
         sample, values = read_bytes('.test.accounts.*')
         assert isinstance(sample, bytes)
         assert sample[:5] == files[sorted(files)[0]][:5]
+        assert sample.endswith(b'\n')
 
         assert isinstance(values, (list, tuple))
         assert isinstance(values[0], (list, tuple))
@@ -38,6 +39,19 @@ def test_read_bytes():
         assert sum(map(len, values)) >= len(files)
         results = compute(*concat(values))
         assert set(results) == set(files.values())
+
+
+def test_read_bytes_sample_delimiter():
+    with filetexts(files, mode='b'):
+        sample, values = read_bytes('.test.accounts.*',
+                                    sample=80, delimiter=b'\n')
+        assert sample.endswith(b'\n')
+        sample, values = read_bytes('.test.accounts.1.json',
+                                    sample=80, delimiter=b'\n')
+        assert sample.endswith(b'\n')
+        sample, values = read_bytes('.test.accounts.1.json',
+                                    sample=2, delimiter=b'\n')
+        assert sample.endswith(b'\n')
 
 
 def test_read_bytes_blocksize_none():
@@ -103,6 +117,7 @@ def test_compression(fmt, blocksize):
         sample, values = read_bytes('.test.accounts.*.json',
                 blocksize=blocksize, delimiter=b'\n', compression=fmt)
         assert sample[:5] == files[sorted(files)[0]][:5]
+        assert sample.endswith(b'\n')
 
         results = compute(*concat(values))
         assert (b''.join(results) ==

--- a/dask/dataframe/csv.py
+++ b/dask/dataframe/csv.py
@@ -232,12 +232,7 @@ def read_csv(urlpath, blocksize=AUTO_BLOCKSIZE, chunkbytes=None,
     else:
         header = sample.split(b_lineterminator)[0] + b_lineterminator
 
-    try:
-        head = pd.read_csv(BytesIO(sample), **kwargs)
-    except:
-        # Remove the last row from the sample due to buffer row split:
-        sample = sample[:(sample.rfind(b_lineterminator))]
-        head = pd.read_csv(BytesIO(sample), **kwargs)
+    head = pd.read_csv(BytesIO(sample), **kwargs)
 
     df = read_csv_from_bytes(values, header, head, kwargs,
                              collection=collection, enforce=enforce)

--- a/dask/dataframe/tests/test_csv.py
+++ b/dask/dataframe/tests/test_csv.py
@@ -248,6 +248,19 @@ def test_auto_blocksize_csv(monkeypatch):
 
 
 def test_head_partial_line_fix():
-    with filetexts({'.overflow.csv': 'a,b\n0,"abcdefghijklmnopqrstuvwxyz"\n1,"abcdefghijklmnopqrstuvwxyz"'}):
+    files = {'.overflow1.csv': ('a,b\n'
+                                '0,"abcdefghijklmnopqrstuvwxyz"\n'
+                                '1,"abcdefghijklmnopqrstuvwxyz"'),
+             '.overflow2.csv': ('a,b\n'
+                                '111111,-11111\n'
+                                '222222,-22222\n'
+                                '333333,-33333\n')}
+    with filetexts(files):
         # 64 byte file, 52 characters is mid-quote; this should not cause exception in head-handling code.
-        read_csv('.overflow.csv', sample=52)
+        read_csv('.overflow1.csv', sample=52)
+
+        # 35 characters is cuts off before the second number on the last line
+        # Should sample to end of line, otherwise pandas will infer `b` to be
+        # a float dtype
+        df = read_csv('.overflow2.csv', sample=35)
+        assert (df.dtypes == 'i8').all()


### PR DESCRIPTION
If a delimiter is provided to `read_bytes`, the sample will end with the
delimiter.  This was specified in the docstring, but wasn't actually
implemented, since the delimiter wasn't forwarded. The `sample` kwarg
was also dropped in a few places throughout.

This PR fixes these issues, and removes the need to adjust the end of
the sample in ``dd.read_csv`` added in #1495. Pandas won't error a
numeric field is errored, which led to the failure in #1532. A test has
been added for this, and confirmed to fix on the provided csv.

Fixes #1532.