### PR TITLE
ENH: Support Series in read_hdf

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,7 @@ DataFrame
 - Add ``dataframe.reduction`` and ``series.reduction`` methods to apply generic
   row-wise reduction to dataframes and series (:pr:`1483`)
 - Add ``dataframe.select_dtypes``, which mirrors the `pandas method<http://pandas.pydata.org/pandas-docs/version/0.18.1/generated/pandas.DataFrame.select_dtypes.html>`_ (:pr:`1556`)
+- ``dataframe.read_hdf`` now supports reading ``Series`` (:pr:`1564`)
 
 Distributed
 +++++++++++


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/1564

Modifies the reader to check for `name` in the case of Series,
and `columns` in the case of `DataFrame`.