### PR TITLE
Raise IndexError on out of bounds slice.

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -181,7 +181,8 @@ def slice_wrap_lists(out_name, in_name, blockdims, index):
     """
     shape = tuple(map(sum, blockdims))
     assert all(isinstance(i, (slice, list, int, long)) for i in index)
-    assert len(blockdims) == len(index)
+    if not len(blockdims) == len(index):
+        raise IndexError("Too many indices for array")
     for bd, i in zip(blockdims, index):
         check_index(i, sum(bd))
 

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -505,3 +505,5 @@ def test_oob_check():
         x[6]
     with pytest.raises(IndexError):
         x[[6]]
+    with pytest.raises(IndexError):
+        x[0, 0]


### PR DESCRIPTION
I was getting `AssertionError`s on things like `da.arange(10, chunks...)[0, 0]`. This should probably be an `IndexError`.