### PR TITLE
Support inplace operators in dataframe

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1930,6 +1930,17 @@ class DataFrame(_Frame):
         self._name = df._name
         self._meta = df._meta
 
+    def __setattr__(self, key, value):
+        try:
+            columns = object.__getattribute__(self, '_meta').columns
+        except AttributeError:
+            columns = ()
+
+        if key in columns:
+            self[key] = value
+        else:
+            object.__setattr__(self, key, value)
+
     def __getattr__(self, key):
         if key in self.columns:
             meta = self._meta[key]

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2003,6 +2003,26 @@ def test_columns_assignment():
     eq(df, ddf)
 
 
+def test_attribute_assignment():
+    df = pd.DataFrame({'x': [1, 2, 3, 4, 5],
+                       'y': [1., 2., 3., 4., 5.]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    ddf.y = ddf.x + ddf.y
+    eq(ddf, df.assign(y=df.x + df.y))
+
+
+def test_inplace_operators():
+    df = pd.DataFrame({'x': [1, 2, 3, 4, 5],
+                       'y': [1., 2., 3., 4., 5.]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    ddf.y **= 0.5
+
+    eq(ddf.y, df.y ** 0.5)
+    eq(ddf, df.assign(y=df.y ** 0.5))
+
+
 @pytest.mark.parametrize("skipna", [True, False])
 @pytest.mark.parametrize("idx", [
     np.arange(100),


### PR DESCRIPTION
Adds support for mutation of *existing* columns via mutation. This
supports both direct assignment (`df.x = df.x + 1`) and inplace operators
(`df.x += 1`). This matches the pandas api, where new columns can't be
created via attribute assignment. Fixes #1584.