### PR TITLE
Better error message on metadata inference failure

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -7,8 +7,8 @@ import pandas as pd
 
 from .core import DataFrame, Series, Index, aca, map_partitions, no_default
 from .shuffle import shuffle
-from .utils import make_meta, insert_meta_param_description
-from ..utils import derived_from, M
+from .utils import make_meta, insert_meta_param_description, raise_on_meta_error
+from ..utils import derived_from, M, funcname
 
 
 def _maybe_slice(grouped, columns):
@@ -324,11 +324,8 @@ class _GroupBy(object):
                    "  or:     .apply(func, meta=('x', 'f8'))            for series result")
             warnings.warn(msg)
 
-            try:
+            with raise_on_meta_error("groupby.apply({0})".format(funcname(func))):
                 meta = self._meta_nonempty.apply(func)
-            except:
-                raise ValueError("Metadata inference failed, please provide "
-                                 "`meta` keyword")
         else:
             meta = make_meta(meta)
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pandas as pd
 import dask.dataframe as dd
-from dask.dataframe.utils import shard_df_on_index, meta_nonempty, make_meta
+from dask.dataframe.utils import (shard_df_on_index, meta_nonempty, make_meta,
+                                  raise_on_meta_error)
 
 import pytest
 
@@ -187,3 +188,19 @@ def test_meta_nonempty_scalar():
     x = pd.Timestamp(2000, 1, 1)
     meta = meta_nonempty(x)
     assert meta is x
+
+
+def test_raise_on_meta_error():
+    try:
+        with raise_on_meta_error():
+            raise RuntimeError("Bad stuff")
+    except Exception as e:
+        assert e.args[0].startswith("Metadata inference failed.\n")
+        assert 'RuntimeError' in e.args[0]
+
+    try:
+        with raise_on_meta_error("myfunc"):
+            raise RuntimeError("Bad stuff")
+    except Exception as e:
+        assert e.args[0].startswith("Metadata inference failed in `myfunc`.\n")
+        assert 'RuntimeError' in e.args[0]


### PR DESCRIPTION
Previously we'd just throw an error stating that metadata inference
failed. This made debugging the cause of these failures tricky. Now we
raise an error indicating that metadata inference failed, and include
the original error and traceback as well.