### PR TITLE
Add clip to Array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1443,6 +1443,10 @@ class Array(Base):
     def conj(self):
         return conj(self)
 
+    @wraps(np.clip)
+    def clip(self, min=None, max=None):
+        return clip(self, min, max)
+
     def view(self, dtype, order='C'):
         """ Get a view of the array as a new data type
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1215,6 +1215,7 @@ def test_arithmetic():
     assert_eq((a + 1j * b).conj(), (x + 1j * y).conj())
 
     assert_eq(da.clip(b, 1, 4), np.clip(y, 1, 4))
+    assert_eq(b.clip(1, 4), y.clip(1, 4))
     assert_eq(da.fabs(b), np.fabs(y))
     assert_eq(da.sign(b - 2), np.sign(y - 2))
     assert_eq(da.absolute(b - 2), np.absolute(y - 2))
@@ -1231,6 +1232,18 @@ def test_arithmetic():
     assert_eq(l2, r2)
 
     assert_eq(da.around(a, -1), np.around(x, -1))
+
+
+def test_clip():
+    x = np.random.normal(0, 10, size=(10, 10))
+    d = da.from_array(x, chunks=(3, 4))
+
+    assert_eq(x.clip(5), d.clip(5))
+    assert_eq(x.clip(1, 5), d.clip(1, 5))
+    assert_eq(x.clip(min=5), d.clip(min=5))
+    assert_eq(x.clip(max=5), d.clip(max=5))
+    assert_eq(x.clip(max=1, min=5), d.clip(max=1, min=5))
+    assert_eq(x.clip(min=1, max=5), d.clip(min=1, max=5))
 
 
 def test_elemwise_consistent_names():


### PR DESCRIPTION
This was only a function before.  Adding it as a method is in line with NumPy.  Also the keyword argument handling for the method is a bit different than for the function.