### PR TITLE
Support new_axes= keyword in atop

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2044,6 +2044,31 @@ def test_atop_names():
     assert y.name.startswith('add')
 
 
+def test_atop_new_axes():
+    def f(x):
+        return x[:, None] * np.ones((1, 7))
+    x = da.ones(5, chunks=2)
+    y = atop(f, 'aq', x, 'a', new_axes={'q': 7}, concatenate=True)
+    assert y.chunks == ((2, 2, 1), (7,))
+    assert_eq(y, np.ones((5, 7)))
+
+    def f(x):
+        return x[None, :] * np.ones((7, 1))
+    x = da.ones(5, chunks=2)
+    y = atop(f, 'qa', x, 'a', new_axes={'q': 7}, concatenate=True)
+    assert y.chunks == ((7,), (2, 2, 1))
+    assert_eq(y, np.ones((7, 5)))
+
+    def f(x):
+        y = x.sum(axis=1)
+        return y[:, None] * np.ones((1, 5))
+
+    x = da.ones((4, 6), chunks=(2, 2))
+    y = atop(f, 'aq', x, 'ab', new_axes={'q': 5}, concatenate=True)
+    assert y.chunks == ((2, 2), (5,))
+    assert_eq(y, np.ones((4, 5)) * 6)
+
+
 def test_atop_kwargs():
     def f(a, b=0):
         return a + b

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,6 +27,8 @@ Array
 +++++
 - Add information about how ``dask.array`` ``chunks`` argument work (:pr:`1504`)
 - Fix field access with non-scalar fields in ``dask.array`` (:pr:`1484`)
+- Add concatenate= keyword to atop to concatenate chunks of contracted dimensions
+- Add new_axes= keyword to atop to support adding new dimensions
 
 Bag
 ++++


### PR DESCRIPTION
Add new single-chunk dimensions with the ``new_axes=`` keyword, including
the length of the new dimension.  New dimensions will always be in a
single  chunk.

    >>> def f(x):
    ...     return x[:, None] * np.ones((1, 5))

    >>> z = atop(f, 'az', x, 'a', new_axes={'z': 5})