### PR TITLE
Use assert_eq everywhere in dask.array tests

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -44,6 +44,8 @@ def linspace(start, stop, num=50, chunks=None, dtype=None):
 
     space = float(range_) / (num - 1)
 
+    dtype = dtype or np.linspace(0, 1, 1).dtype
+
     name = 'linspace-' + tokenize((start, stop, num, chunks, dtype))
 
     dsk = {}

--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -139,7 +139,7 @@ def ghost_internal(x, axes):
             chunks.append(left + mid + right)
 
     return Array(merge(interior_slices, ghost_blocks, x.dask),
-                 name, chunks)
+                 name, chunks, dtype=x._dtype)
 
 
 def trim_internal(x, axes):
@@ -161,7 +161,8 @@ def trim_internal(x, axes):
 
     chunks = tuple(olist)
 
-    return map_blocks(partial(chunk.trim, axes=axes), x, chunks=chunks)
+    return map_blocks(partial(chunk.trim, axes=axes), x, chunks=chunks,
+                      dtype=x.dtype)
 
 
 def periodic(x, axis, depth):

--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -51,7 +51,12 @@ def percentile(a, q, interpolation='linear'):
     dsk2 = {(name2, 0): (merge_percentiles, q, [q] * len(a.chunks[0]),
                          sorted(dsk), a.chunks[0], interpolation)}
 
-    return Array(merge(a.dask, dsk, dsk2), name2, chunks=((len(q),),))
+    dtype = a.dtype
+    if np.issubdtype(dtype, np.integer):
+        dtype = (np.array([], dtype=dtype) / 0.5).dtype
+
+    return Array(merge(a.dask, dsk, dsk2), name2, chunks=((len(q),),),
+                 dtype=dtype)
 
 
 def merge_percentiles(finalq, qs, vals, Ns, interpolation='lower'):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2156,10 +2156,10 @@ def test_atop_concatenate():
 
         return (a + b).sum(axis=(1, 2))
 
-    z = atop(f, 'i', x, 'ijk', y, 'jk', concatenate=True)
+    z = atop(f, 'i', x, 'ijk', y, 'jk', concatenate=True, dtype=x._dtype)
     assert_eq(z, np.ones(4) * 32)
 
-    z = atop(add, 'ij', y, 'ij', y, 'ij', concatenate=True)
+    z = atop(add, 'ij', y, 'ij', y, 'ij', concatenate=True, dtype=x._dtype)
     assert_eq(z, np.ones((4, 4)) * 2)
 
 
@@ -2174,5 +2174,6 @@ def test_atop_concatenate():
 
         return np.ones(5)
 
-    z = atop(f, 'j', x, 'ijk', y, 'ki', y, 'ij', concatenate=True)
+    z = atop(f, 'j', x, 'ijk', y, 'ki', y, 'ij', concatenate=True,
+             dtype=x._dtype)
     assert_eq(z, np.ones(10))

--- a/dask/array/tests/test_chunk.py
+++ b/dask/array/tests/test_chunk.py
@@ -93,13 +93,6 @@ def test_keepdims_wrapper_two_axes():
     assert (rwf == np.array([[60, 92, 124]])).all()
 
 
-def eq(a, b):
-    c = a == b
-    if isinstance(c, np.ndarray):
-        c = c.all()
-    return c
-
-
 def test_coarsen():
     x = np.random.randint(10, size=(24, 24))
     y = coarsen(np.sum, x, {0: 2, 1: 4})

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -2,38 +2,28 @@ import pytest
 pytest.importorskip('numpy')
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 import pytest
 
 import dask.array as da
-
-
-def eq(a, b):
-    """a is a dask array, b is a numpy array. Checks dtype, shape and value. No
-    `assert` needed.
-    """
-    a = np.array(a)
-    assert a.shape == b.shape
-    assert a.dtype == b.dtype
-    assert_array_almost_equal(a, b)
+from dask.array.utils import assert_eq
 
 
 def test_linspace():
     darr = da.linspace(6, 49, chunks=5)
     nparr = np.linspace(6, 49)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
 
     darr = da.linspace(1.4, 4.9, chunks=5, num=13)
     nparr = np.linspace(1.4, 4.9, num=13)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
 
     darr = da.linspace(6, 49, chunks=5, dtype=float)
     nparr = np.linspace(6, 49, dtype=float)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
 
     darr = da.linspace(1.4, 4.9, chunks=5, num=13, dtype=int)
     nparr = np.linspace(1.4, 4.9, num=13, dtype=int)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
     assert sorted(da.linspace(1.4, 4.9, chunks=5, num=13).dask) ==\
            sorted(da.linspace(1.4, 4.9, chunks=5, num=13).dask)
     assert sorted(da.linspace(6, 49, chunks=5, dtype=float).dask) ==\
@@ -43,28 +33,28 @@ def test_linspace():
 def test_arange():
     darr = da.arange(77, chunks=13)
     nparr = np.arange(77)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
 
     darr = da.arange(2, 13, chunks=5)
     nparr = np.arange(2, 13)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
 
     darr = da.arange(4, 21, 9, chunks=13)
     nparr = np.arange(4, 21, 9)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
 
     # negative steps
     darr = da.arange(53, 5, -3, chunks=5)
     nparr = np.arange(53, 5, -3)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
 
     darr = da.arange(77, chunks=13, dtype=float)
     nparr = np.arange(77, dtype=float)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
 
     darr = da.arange(2, 13, chunks=5, dtype=int)
     nparr = np.arange(2, 13, dtype=int)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
     assert sorted(da.arange(2, 13, chunks=5).dask) ==\
            sorted(da.arange(2, 13, chunks=5).dask)
     assert sorted(da.arange(77, chunks=13, dtype=float).dask) ==\
@@ -81,7 +71,7 @@ def test_arange_working_float_step():
     """
     darr = da.arange(3.3, -9.1, -.25, chunks=3)
     nparr = np.arange(3.3, -9.1, -.25)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
 
 
 @pytest.mark.xfail(reason="Casting floats to ints is not supported since edge"
@@ -89,7 +79,7 @@ def test_arange_working_float_step():
 def test_arange_cast_float_int_step():
     darr = da.arange(3.3, -9.1, -.25, chunks=3, dtype='i8')
     nparr = np.arange(3.3, -9.1, -.25, dtype='i8')
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
 
 
 @pytest.mark.xfail(reason="arange with a floating point step value can fail"
@@ -97,8 +87,8 @@ def test_arange_cast_float_int_step():
 def test_arange_float_step():
     darr = da.arange(2., 13., .3, chunks=4)
     nparr = np.arange(2., 13., .3)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)
 
     darr = da.arange(7.7, 1.5, -.8, chunks=3)
     nparr = np.arange(7.7, 1.5, -.8)
-    eq(darr, nparr)
+    assert_eq(darr, nparr)

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -1,44 +1,10 @@
 import numpy as np
 import numpy.fft as npfft
 
-import dask
-from dask.array.core import Array
 from dask.utils import raises
 import dask.array as da
 from dask.array.fft import fft, ifft, rfft, irfft, hfft, ihfft
-
-
-def mismatch_err(mismatch_type, got, expected):
-    return '%s mismatch, got %s, expected %s' % (mismatch_type, got, expected)
-
-
-def eq(a, b):
-    assert a.shape == b.shape, mismatch_err('shape', a.shape, b.shape)
-
-    if isinstance(a, Array):
-        adt = a._dtype
-        a = a.compute(get=dask.get)
-    else:
-        adt = getattr(a, 'dtype', None)
-    if isinstance(b, Array):
-        bdt = b._dtype
-        b = b.compute(get=dask.get)
-    else:
-        bdt = getattr(b, 'dtype', None)
-
-    assert str(adt) == str(bdt), mismatch_err('dtype', str(adt), str(bdt))
-
-    try:
-        return np.allclose(a, b)
-    except TypeError:
-        pass
-
-    c = a == b
-
-    if isinstance(c, np.ndarray):
-        return c.all()
-    else:
-        return c
+from dask.array.utils import assert_eq
 
 
 def same_keys(a, b):
@@ -62,79 +28,79 @@ def test_cant_fft_chunked_axis():
 
 
 def test_fft():
-    assert eq(fft(darr), npfft.fft(nparr))
-    assert eq(fft(darr2, axis=0), npfft.fft(nparr, axis=0))
+    assert_eq(fft(darr), npfft.fft(nparr))
+    assert_eq(fft(darr2, axis=0), npfft.fft(nparr, axis=0))
 
 
 def test_fft_n_kwarg():
-    assert eq(fft(darr, 5), npfft.fft(nparr, 5))
-    assert eq(fft(darr, 13), npfft.fft(nparr, 13))
-    assert eq(fft(darr2, 5, axis=0), npfft.fft(nparr, 5, axis=0))
-    assert eq(fft(darr2, 13, axis=0), npfft.fft(nparr, 13, axis=0))
+    assert_eq(fft(darr, 5), npfft.fft(nparr, 5))
+    assert_eq(fft(darr, 13), npfft.fft(nparr, 13))
+    assert_eq(fft(darr2, 5, axis=0), npfft.fft(nparr, 5, axis=0))
+    assert_eq(fft(darr2, 13, axis=0), npfft.fft(nparr, 13, axis=0))
 
 
 def test_ifft():
-    assert eq(ifft(darr), npfft.ifft(nparr))
-    assert eq(ifft(darr2, axis=0), npfft.ifft(nparr, axis=0))
+    assert_eq(ifft(darr), npfft.ifft(nparr))
+    assert_eq(ifft(darr2, axis=0), npfft.ifft(nparr, axis=0))
 
 
 def test_ifft_n_kwarg():
-    assert eq(ifft(darr, 5), npfft.ifft(nparr, 5))
-    assert eq(ifft(darr, 13), npfft.ifft(nparr, 13))
-    assert eq(ifft(darr2, 5, axis=0), npfft.ifft(nparr, 5, axis=0))
-    assert eq(ifft(darr2, 13, axis=0), npfft.ifft(nparr, 13, axis=0))
+    assert_eq(ifft(darr, 5), npfft.ifft(nparr, 5))
+    assert_eq(ifft(darr, 13), npfft.ifft(nparr, 13))
+    assert_eq(ifft(darr2, 5, axis=0), npfft.ifft(nparr, 5, axis=0))
+    assert_eq(ifft(darr2, 13, axis=0), npfft.ifft(nparr, 13, axis=0))
 
 
 def test_rfft():
-    assert eq(rfft(darr), npfft.rfft(nparr))
-    assert eq(rfft(darr2, axis=0), npfft.rfft(nparr, axis=0))
+    assert_eq(rfft(darr), npfft.rfft(nparr))
+    assert_eq(rfft(darr2, axis=0), npfft.rfft(nparr, axis=0))
 
 
 def test_rfft_n_kwarg():
-    assert eq(rfft(darr, 5), npfft.rfft(nparr, 5))
-    assert eq(rfft(darr, 13), npfft.rfft(nparr, 13))
-    assert eq(rfft(darr2, 5, axis=0), npfft.rfft(nparr, 5, axis=0))
-    assert eq(rfft(darr2, 13, axis=0), npfft.rfft(nparr, 13, axis=0))
-    assert eq(rfft(darr2, 12, axis=0), npfft.rfft(nparr, 12, axis=0))
+    assert_eq(rfft(darr, 5), npfft.rfft(nparr, 5))
+    assert_eq(rfft(darr, 13), npfft.rfft(nparr, 13))
+    assert_eq(rfft(darr2, 5, axis=0), npfft.rfft(nparr, 5, axis=0))
+    assert_eq(rfft(darr2, 13, axis=0), npfft.rfft(nparr, 13, axis=0))
+    assert_eq(rfft(darr2, 12, axis=0), npfft.rfft(nparr, 12, axis=0))
 
 
 def test_irfft():
-    assert eq(irfft(darr), npfft.irfft(nparr))
-    assert eq(irfft(darr2, axis=0), npfft.irfft(nparr, axis=0))
+    assert_eq(irfft(darr), npfft.irfft(nparr))
+    assert_eq(irfft(darr2, axis=0), npfft.irfft(nparr, axis=0))
 
 
 def test_irfft_n_kwarg():
-    assert eq(irfft(darr, 5), npfft.irfft(nparr, 5))
-    assert eq(irfft(darr, 13), npfft.irfft(nparr, 13))
-    assert eq(irfft(darr2, 5, axis=0), npfft.irfft(nparr, 5, axis=0))
-    assert eq(irfft(darr2, 13, axis=0), npfft.irfft(nparr, 13, axis=0))
-    assert eq(irfft(darr2, 12, axis=0), npfft.irfft(nparr, 12, axis=0))
+    assert_eq(irfft(darr, 5), npfft.irfft(nparr, 5))
+    assert_eq(irfft(darr, 13), npfft.irfft(nparr, 13))
+    assert_eq(irfft(darr2, 5, axis=0), npfft.irfft(nparr, 5, axis=0))
+    assert_eq(irfft(darr2, 13, axis=0), npfft.irfft(nparr, 13, axis=0))
+    assert_eq(irfft(darr2, 12, axis=0), npfft.irfft(nparr, 12, axis=0))
 
 
 def test_hfft():
-    assert eq(hfft(darr), npfft.hfft(nparr))
-    assert eq(hfft(darr2, axis=0), npfft.hfft(nparr, axis=0))
+    assert_eq(hfft(darr), npfft.hfft(nparr))
+    assert_eq(hfft(darr2, axis=0), npfft.hfft(nparr, axis=0))
 
 
 def test_hfft_nkwarg():
-    assert eq(hfft(darr, 5), npfft.hfft(nparr, 5))
-    assert eq(hfft(darr, 13), npfft.hfft(nparr, 13))
-    assert eq(hfft(darr2, 5, axis=0), npfft.hfft(nparr, 5, axis=0))
-    assert eq(hfft(darr2, 13, axis=0), npfft.hfft(nparr, 13, axis=0))
-    assert eq(hfft(darr2, 12, axis=0), npfft.hfft(nparr, 12, axis=0))
+    assert_eq(hfft(darr, 5), npfft.hfft(nparr, 5))
+    assert_eq(hfft(darr, 13), npfft.hfft(nparr, 13))
+    assert_eq(hfft(darr2, 5, axis=0), npfft.hfft(nparr, 5, axis=0))
+    assert_eq(hfft(darr2, 13, axis=0), npfft.hfft(nparr, 13, axis=0))
+    assert_eq(hfft(darr2, 12, axis=0), npfft.hfft(nparr, 12, axis=0))
 
 
 def test_ihfft():
-    assert eq(ihfft(darr), npfft.ihfft(nparr))
-    assert eq(ihfft(darr2, axis=0), npfft.ihfft(nparr, axis=0))
+    assert_eq(ihfft(darr), npfft.ihfft(nparr))
+    assert_eq(ihfft(darr2, axis=0), npfft.ihfft(nparr, axis=0))
 
 
 def test_ihfft_n_kwarg():
-    assert eq(ihfft(darr, 5), npfft.ihfft(nparr, 5))
-    assert eq(ihfft(darr, 13), npfft.ihfft(nparr, 13))
-    assert eq(ihfft(darr2, 5, axis=0), npfft.ihfft(nparr, 5, axis=0))
-    assert eq(ihfft(darr2, 13, axis=0), npfft.ihfft(nparr, 13, axis=0))
-    assert eq(ihfft(darr2, 12, axis=0), npfft.ihfft(nparr, 12, axis=0))
+    assert_eq(ihfft(darr, 5), npfft.ihfft(nparr, 5))
+    assert_eq(ihfft(darr, 13), npfft.ihfft(nparr, 13))
+    assert_eq(ihfft(darr2, 5, axis=0), npfft.ihfft(nparr, 5, axis=0))
+    assert_eq(ihfft(darr2, 13, axis=0), npfft.ihfft(nparr, 13, axis=0))
+    assert_eq(ihfft(darr2, 12, axis=0), npfft.ihfft(nparr, 12, axis=0))
 
 
 def test_fft_consistent_names():

--- a/dask/array/tests/test_percentiles.py
+++ b/dask/array/tests/test_percentiles.py
@@ -2,20 +2,9 @@ import pytest
 pytest.importorskip('numpy')
 
 from dask.utils import skip
+from dask.array.utils import assert_eq
 import dask.array as da
-import dask
 import numpy as np
-
-
-def eq(a, b):
-    if isinstance(a, da.Array):
-        a = a.compute(get=dask.get)
-    if isinstance(b, da.Array):
-        b = b.compute(get=dask.get)
-    c = a == b
-    if isinstance(c, np.ndarray):
-        c = c.all()
-    return c
 
 
 def same_keys(a, b):
@@ -29,11 +18,14 @@ def same_keys(a, b):
 
 def test_percentile():
     d = da.ones((16,), chunks=(4,))
-    assert eq(da.percentile(d, [0, 50, 100]), [1, 1, 1])
+    assert_eq(da.percentile(d, [0, 50, 100]),
+              np.array([1, 1, 1], dtype=d.dtype))
 
     x = np.array([0, 0, 5, 5, 5, 5, 20, 20])
     d = da.from_array(x, chunks=(3,))
-    assert eq(da.percentile(d, [0, 50, 100]), [0, 5, 20])
+    result = da.percentile(d, [0, 50, 100])
+    assert_eq(da.percentile(d, [0, 50, 100]),
+              np.array([0, 5, 20], dtype=result.dtype))
     assert same_keys(da.percentile(d, [0, 50, 100]),
                     da.percentile(d, [0, 50, 100]))
     assert not same_keys(da.percentile(d, [0, 50, 100]),
@@ -41,7 +33,8 @@ def test_percentile():
 
     x = np.array(['a', 'a', 'd', 'd', 'd', 'e'])
     d = da.from_array(x, chunks=(3,))
-    assert eq(da.percentile(d, [0, 50, 100]), ['a', 'd', 'e'])
+    assert_eq(da.percentile(d, [0, 50, 100]),
+              np.array(['a', 'd', 'e'], dtype=x.dtype))
 
 
 @skip
@@ -66,4 +59,4 @@ def test_percentile_with_categoricals():
 
 def test_percentiles_with_empty_arrays():
     x = da.ones(10, chunks=((5, 0, 5),))
-    assert da.percentile(x, [10, 50, 90]).compute().tolist() == [1, 1, 1]
+    assert_eq(da.percentile(x, [10, 50, 90]), np.array([1, 1, 1], dtype=x.dtype))

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -34,19 +34,15 @@ def assert_eq(a, b, **kwargs):
     if isinstance(a, Array):
         adt = a._dtype
         a = a.compute(get=get_sync)
-        if adt is not None:
-            _maybe_check_dtype(a, adt)
-        else:
-            adt = getattr(a, 'dtype', None)
+        assert adt is not None
+        _maybe_check_dtype(a, adt)
     else:
         adt = getattr(a, 'dtype', None)
     if isinstance(b, Array):
         bdt = b._dtype
         b = b.compute(get=get_sync)
-        if bdt is not None:
-            _maybe_check_dtype(b, bdt)
-        else:
-            bdt = getattr(b, 'dtype', None)
+        assert bdt is not None
+        _maybe_check_dtype(b, bdt)
     else:
         bdt = getattr(b, 'dtype', None)
 


### PR DESCRIPTION
Previously we had a bunch of custom eq functions defined.
These were not as comprehensive as dask.array.utils.assert_eq.
In particular many of them failed to check dtypes.

Now we use assert_eq everywhere and we ensure that all dask.array
functions propagate dtype information.