### PR TITLE
Coerce rounded numbers to int in dask.array.ghost

### DIFF
--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -25,7 +25,7 @@ def fractional_slice(task, axes):
     >>> fractional_slice(('x', 2.9, 5.1), {0: 2, 1: 3})  # doctest: +SKIP
     (getitem, ('x', 3, 5), (slice(0, 2), slice(-3, None)))
     """
-    rounded = (task[0],) + tuple(map(round, task[1:]))
+    rounded = (task[0],) + tuple(int(round(i)) for i in task[1:])
 
     index = []
     for i, (t, r) in enumerate(zip(task[1:], rounded[1:])):

--- a/dask/array/tests/test_ghost.py
+++ b/dask/array/tests/test_ghost.py
@@ -42,6 +42,9 @@ def test_fractional_slice():
     assert fractional_slice(('x', 2.9, 5.1), {0: 2, 1: 3}) == \
             (getitem, ('x', 3, 5), (slice(0, 2), slice(-3, None)))
 
+    fs = fractional_slice(('x', 4.9), {0: 2})
+    assert isinstance(fs[1][1], int)
+
 
 def test_ghost_internal():
     x = np.arange(64).reshape((8, 8))


### PR DESCRIPTION
Previously in Python 2 these could remain floats.  This was fine for the
single machine scheduler because 1 and 1.0 hash to the same value and ==
each other.  However this would interfere with dask.distributed, which
relies on the string representaiton of the keys.