### PR TITLE
Ensure dtype is provided in additional tests

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3599,4 +3599,5 @@ def swapaxes(a, axis1, axis2):
     out = list(ind)
     out[axis1], out[axis2] = axis2, axis1
 
-    return atop(np.swapaxes, out, a, ind, axis1=axis1, axis2=axis2)
+    return atop(np.swapaxes, out, a, ind, axis1=axis1, axis2=axis2,
+                dtype=a._dtype)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2061,14 +2061,16 @@ def test_atop_new_axes():
     def f(x):
         return x[:, None] * np.ones((1, 7))
     x = da.ones(5, chunks=2)
-    y = atop(f, 'aq', x, 'a', new_axes={'q': 7}, concatenate=True)
+    y = atop(f, 'aq', x, 'a', new_axes={'q': 7}, concatenate=True,
+             dtype=x._dtype)
     assert y.chunks == ((2, 2, 1), (7,))
     assert_eq(y, np.ones((5, 7)))
 
     def f(x):
         return x[None, :] * np.ones((7, 1))
     x = da.ones(5, chunks=2)
-    y = atop(f, 'qa', x, 'a', new_axes={'q': 7}, concatenate=True)
+    y = atop(f, 'qa', x, 'a', new_axes={'q': 7}, concatenate=True,
+             dtype=x._dtype)
     assert y.chunks == ((7,), (2, 2, 1))
     assert_eq(y, np.ones((7, 5)))
 
@@ -2077,7 +2079,8 @@ def test_atop_new_axes():
         return y[:, None] * np.ones((1, 5))
 
     x = da.ones((4, 6), chunks=(2, 2))
-    y = atop(f, 'aq', x, 'ab', new_axes={'q': 5}, concatenate=True)
+    y = atop(f, 'aq', x, 'ab', new_axes={'q': 5}, concatenate=True,
+             dtype=x._dtype)
     assert y.chunks == ((2, 2), (5,))
     assert_eq(y, np.ones((4, 5)) * 6)
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -33,15 +33,15 @@ def _maybe_check_dtype(a, dtype=None):
 def assert_eq(a, b, **kwargs):
     if isinstance(a, Array):
         adt = a._dtype
-        a = a.compute(get=get_sync)
         assert adt is not None
+        a = a.compute(get=get_sync)
         _maybe_check_dtype(a, adt)
     else:
         adt = getattr(a, 'dtype', None)
     if isinstance(b, Array):
         bdt = b._dtype
-        b = b.compute(get=get_sync)
         assert bdt is not None
+        b = b.compute(get=get_sync)
         _maybe_check_dtype(b, bdt)
     else:
         bdt = getattr(b, 'dtype', None)


### PR DESCRIPTION
In https://github.com/dask/dask/pull/1617 we started testing that all
dask.array computations propagated dtype information.  Unfortunately
simultaneously merged PRs weren't tested under this before merging.

This PR cleans up the intersection.