### PR TITLE
.str accessor needs to pass thru both args & kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ log
 .DS_Store
 *.swp
 *.swo
+.cache/

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3262,8 +3262,8 @@ class StringAccessor(Accessor):
         return getattr(obj.str, attr)
 
     @staticmethod
-    def call(obj, attr, *args):
-        return getattr(obj.str, attr)(*args)
+    def call(obj, attr, *args, **kwargs):
+        return getattr(obj.str, attr)(*args, **kwargs)
 
 
 class CategoricalAccessor(Accessor):


### PR DESCRIPTION
- small fix for windows compat on testing
- xfail test added for possible bug in ``._meta`` determination on derived ``.dask``