### PR TITLE
Deprecations

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -13,6 +13,7 @@ import os
 import pickle
 from threading import Lock
 import uuid
+import warnings
 
 from toolz.curried import (pipe, partition, concat, pluck, join, first,
                            memoize, map, groupby, valmap, accumulate, merge,
@@ -1025,6 +1026,10 @@ class Array(Base):
          ('x', 1): array([5, 7]),
          ('x', 2): array([9])}
         """
+        warnings.warn("Deprecation Warning: The `cache` method is deprecated, "
+                      "and will be removed in the next release. To achieve "
+                      "the same behavior, either write to disk or use "
+                      "`Client.persist`, from `dask.distributed`.")
         if store is not None and hasattr(store, 'shape'):
             self.store(store)
             return from_array(store, chunks=self.chunks)
@@ -3482,7 +3487,6 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
             ddof = 0
     fact = float(N - ddof)
     if fact <= 0:
-        import warnings
         warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning)
         fact = 0.0
 

--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-from .core import (Bag, Item, from_sequence, from_filenames, from_url,
-                   to_textfiles, concat, from_castra, from_delayed,
-                   bag_range as range, bag_zip as zip)
+from .core import (Bag, Item, from_sequence, from_url, to_textfiles, concat,
+                   from_castra, from_delayed, bag_range as range,
+                   bag_zip as zip)
 from .text import read_text
 from ..context import set_options
 from ..base import compute

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1211,15 +1211,6 @@ def collect(grouper, group, p, barrier_token):
     return list(d.items())
 
 
-def from_filenames(filenames, chunkbytes=None, compression='infer',
-                   encoding=system_encoding, linesep=os.linesep):
-    """ Deprecated.  See read_text """
-    warn("db.from_filenames is deprecated in favor of db.read_text")
-    from .text import read_text
-    return read_text(filenames, blocksize=chunkbytes, compression=compression,
-            encoding=encoding, linedelimiter=linesep)
-
-
 def write(data, filename, compression, encoding):
     dirname = os.path.dirname(filename)
     if not os.path.exists(dirname):

--- a/dask/base.py
+++ b/dask/base.py
@@ -6,7 +6,6 @@ from operator import attrgetter
 import pickle
 import os
 import uuid
-import warnings
 
 from toolz import merge, groupby, curry, identity
 from toolz.functoolz import Compose
@@ -60,13 +59,6 @@ class Base(object):
         """
         return visualize(self, filename=filename, format=format,
                          optimize_graph=optimize_graph, **kwargs)
-
-    def _visualize(self, filename='mydask', format=None, optimize_graph=False):
-        warn = DeprecationWarning("``_visualize`` is deprecated, use "
-                                  "``visualize`` instead.")
-        warnings.warn(warn)
-        return self.visualize(filename=filename, format=format,
-                              optimize_graph=optimize_graph)
 
     def compute(self, **kwargs):
         """Compute several dask collections at once.

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -252,16 +252,6 @@ class _Frame(Base):
         return len(self.divisions) - 1
 
     @property
-    def _pd(self):
-        warnings.warn('Deprecation warning: use `_meta` instead')
-        return self._meta
-
-    @property
-    def _pd_nonempty(self):
-        warnings.warn('Deprecation warning: use `_meta_nonempty` instead')
-        return self._meta_nonempty
-
-    @property
     def _meta_nonempty(self):
         """ A non-empty version of `_meta` with fake data."""
         return meta_nonempty(self._meta)
@@ -307,10 +297,6 @@ class _Frame(Base):
     def clear_divisions(self):
         divisions = (None,) * (self.npartitions + 1)
         return type(self)(self.dask, self._name, self._meta, divisions)
-
-    def get_division(self, n):
-        warnings.warn("Deprecation warning: use `get_partition` instead")
-        return self.get_partition(self, n)
 
     def get_partition(self, n):
         """Get a dask DataFrame/Series representing the `nth` partition."""
@@ -1464,12 +1450,6 @@ class Series(_Frame):
         return list(o)
 
     @property
-    def column_info(self):
-        """ Return Series.name """
-        warnings.warn('column_info is deprecated, use name')
-        return self.name
-
-    @property
     def nbytes(self):
         return self.reduction(methods.nbytes, np.sum, token='nbytes', meta=int)
 
@@ -2003,12 +1983,6 @@ class DataFrame(_Frame):
         """
         from .shuffle import set_partition
         return set_partition(self, column, divisions, **kwargs)
-
-    @property
-    def column_info(self):
-        """ Return the Index of column names """
-        warnings.warn('column_info is deprecated, use columns')
-        return self.columns
 
     @derived_from(pd.DataFrame)
     def nlargest(self, n=5, columns=None):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -329,6 +329,10 @@ class _Frame(Base):
 
         Uses chest by default to store data on disk
         """
+        warnings.warn("Deprecation Warning: The `cache` method is deprecated, "
+                      "and will be removed in the next release. To achieve "
+                      "the same behavior, either write to disk or use "
+                      "`Client.persist`, from `dask.distributed`.")
         if callable(cache):
             cache = cache()
 

--- a/dask/dataframe/csv.py
+++ b/dask/dataframe/csv.py
@@ -138,9 +138,9 @@ else:
     AUTO_BLOCKSIZE = 2**25
 
 
-def read_csv(urlpath, blocksize=AUTO_BLOCKSIZE, chunkbytes=None,
-             collection=True, lineterminator=None, compression=None,
-             sample=256000, enforce=False, storage_options=None, **kwargs):
+def read_csv(urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
+             lineterminator=None, compression=None, sample=256000,
+             enforce=False, storage_options=None, **kwargs):
     """ Read CSV files into a Dask.DataFrame
 
     This parallelizes the ``pandas.read_csv`` file in the following ways:
@@ -193,9 +193,6 @@ def read_csv(urlpath, blocksize=AUTO_BLOCKSIZE, chunkbytes=None,
         kwargs['lineterminator'] = lineterminator
     else:
         lineterminator = '\n'
-    if chunkbytes is not None:
-        warn("Deprecation warning: chunksize csv keyword renamed to blocksize")
-        blocksize = chunkbytes
     if 'index' in kwargs or 'index_col' in kwargs:
         raise ValueError("Keyword 'index' not supported "
                          "dd.read_csv(...).set_index('my-index') instead")

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -378,11 +378,6 @@ class DataFrameGroupBy(_GroupBy):
         super(DataFrameGroupBy, self).__init__(df, index=index,
                                                slice=slice, **kwargs)
 
-    @property
-    def column_info(self):
-        warnings.warn('column_info is deprecated')
-        return self.obj.columns
-
     def __getitem__(self, key):
         if isinstance(key, list):
             g = DataFrameGroupBy(self.obj, index=self.index,
@@ -425,11 +420,6 @@ class SeriesGroupBy(_GroupBy):
                 df._meta.groupby(index)
         super(SeriesGroupBy, self).__init__(df, index=index,
                                             slice=slice, **kwargs)
-
-    @property
-    def column_info(self):
-        warnings.warn('column_info is deprecated')
-        return self._slice
 
     def nunique(self):
         name = self._meta.obj.name

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -15,7 +15,6 @@ Top level user functions:
     DataFrame.astype
     DataFrame.cache
     DataFrame.categorize
-    DataFrame.column_info
     DataFrame.columns
     DataFrame.compute
     DataFrame.corr
@@ -33,10 +32,9 @@ Top level user functions:
     DataFrame.dtypes
     DataFrame.fillna
     DataFrame.floordiv
-    DataFrame.get_division
+    DataFrame.get_partition
     DataFrame.groupby
     DataFrame.head
-    DataFrame.iloc
     DataFrame.index
     DataFrame.iterrows
     DataFrame.itertuples


### PR DESCRIPTION
- Deprecate `cache` methods
- Remove several long since deprecated methods/functions/keywords

Fixes #1607.