### PR TITLE
Groupby works with multiprocessing

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -484,3 +484,13 @@ def test_groupby_apply_tasks():
             b = ddf.groupby(ind(ddf)).B.apply(len)
             assert eq(a, b.compute())
             assert not any('partd' in k[0] for k in b.dask)
+
+
+def test_groupby_multiprocessing():
+    from dask.multiprocessing import get
+    df = pd.DataFrame({'A': [1, 2, 3, 4, 5],
+                       'B': ['1','1','a','a','a']})
+    ddf = dd.from_pandas(df, npartitions=3)
+    with dask.set_options(get=get):
+        assert eq(ddf.groupby('B').apply(lambda x: x),
+                  df.groupby('B').apply(lambda x: x))


### PR DESCRIPTION
Previously this would fail, as the partd was buffered, and wouldn't
write to disk some/all of the data. Since we still want to use the
buffer with the threaded scheduler, we solve this by switching behavior
if the partd creation function is serialized. If the function isn't
serialized, a buffer is used, if it is serialized then a file based
partd is used.

Fixes #1587.