### PR TITLE
Error nicely when indexing Array with Array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1097,6 +1097,9 @@ class Array(Base):
         if not isinstance(index, tuple):
             index = (index,)
 
+        if any(isinstance(i, Array) for i in index):
+            raise NotImplementedError("Indexing with a dask Array")
+
         if all(isinstance(i, slice) and i == slice(None) for i in index):
             return self
 

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -496,3 +496,12 @@ def test_oob_check():
         x[[6]]
     with pytest.raises(IndexError):
         x[0, 0]
+
+
+def test_index_with_dask_array_errors():
+    x = da.ones((5, 5), chunks=2)
+    with pytest.raises(NotImplementedError):
+        x[x > 10]
+
+    with pytest.raises(NotImplementedError):
+        x[0, x > 10]


### PR DESCRIPTION
Raise a nice error instead of accidentally calling compute when a user
indexes a dask Array with a dask Array.

Fixes #1628.