### PR TITLE
Signature of Array.transpose matches numpy 

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -25,7 +25,7 @@ from .slicing import slice_array
 from . import numpy_compat
 from ..base import Base, tokenize, normalize_token
 from ..utils import (deepmap, ignoring, concrete, is_integer,
-                     IndexCallable, funcname)
+                     IndexCallable, funcname, derived_from)
 from ..compatibility import unicode, long, getargspec, zip_longest, apply
 from .. import threaded, core
 
@@ -1145,7 +1145,7 @@ class Array(Base):
     def T(self):
         return transpose(self)
 
-    @wraps(np.transpose)
+    @derived_from(np.ndarray)
     def transpose(self, *axes):
         if not axes:
             axes = None

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1146,8 +1146,12 @@ class Array(Base):
         return transpose(self)
 
     @wraps(np.transpose)
-    def transpose(self, axes=None):
-        return transpose(self, axes)
+    def transpose(self, *axes):
+        if not axes:
+            axes = None
+        elif len(axes) == 1 and isinstance(axes[0], Iterable):
+            axes = axes[0]
+        return transpose(self, axes=axes)
 
     @wraps(np.ravel)
     def ravel(self):
@@ -2110,7 +2114,11 @@ def _take_dask_array_from_numpy(a, indices, axis):
 
 @wraps(np.transpose)
 def transpose(a, axes=None):
-    axes = axes or tuple(range(a.ndim))[::-1]
+    if axes:
+        if len(axes) != a.ndim:
+            raise ValueError("axes don't match array")
+    else:
+        axes = tuple(range(a.ndim))[::-1]
     return atop(partial(np.transpose, axes=axes),
                 axes,
                 a, tuple(range(a.ndim)), dtype=a._dtype)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -144,6 +144,15 @@ def test_transpose():
               x.transpose((2, 0, 1)))
     assert same_keys(d.transpose((2, 0, 1)), d.transpose((2, 0, 1)))
 
+    assert_eq(d.transpose(2, 0, 1),
+              x.transpose(2, 0, 1))
+    assert same_keys(d.transpose(2, 0, 1), d.transpose(2, 0, 1))
+
+    with pytest.raises(ValueError):
+        d.transpose(1, 2)
+    with pytest.raises(ValueError):
+        d.transpose((1, 2))
+
 
 def test_broadcast_dimensions_works_with_singleton_dimensions():
     argpairs = [('x', 'i')]

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -556,10 +556,13 @@ def derived_from(original_klass, version=None, ua_args=[]):
             if doc is None:
                 doc = ''
 
-            method_args = getargspec(method).args
-            original_args = getargspec(original_method).args
+            try:
+                method_args = getargspec(method).args
+                original_args = getargspec(original_method).args
+                not_supported = [m for m in original_args if m not in method_args]
+            except TypeError:
+                not_supported = []
 
-            not_supported = [m for m in original_args if m not in method_args]
             if len(ua_args) > 0:
                 not_supported.extend(ua_args)
 


### PR DESCRIPTION
The signatures of `numpy.transpose` and `numpy.ndarray.transpose` don't
match. Previously we implemented the same signature for both, this PR
moves us inline with numpy's signatures. Fixes #1630.