### PR TITLE
Use strides, shape, and offset in memmap tokenize

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -316,7 +316,13 @@ with ignoring(ImportError):
         if not x.shape:
             return (str(x), x.dtype)
         if hasattr(x, 'mode') and getattr(x, 'filename', None):
-            return x.filename, os.path.getmtime(x.filename), x.dtype, x.shape
+            if hasattr(x.base, 'ctypes'):
+                offset = (x.ctypes.get_as_parameter().value -
+                          x.base.ctypes.get_as_parameter().value)
+            else:
+                offset = 0  # root memmap's have mmap object as base
+            return (x.filename, os.path.getmtime(x.filename), x.dtype,
+                    x.shape, x.strides, offset)
         if x.dtype.hasobject:
             try:
                 data = md5('-'.join(x.flat).encode('utf-8')).hexdigest()

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -123,6 +123,19 @@ def test_tokenize_numpy_memmap():
 
     assert y != z
 
+    with tmpfile('.npy') as fn:
+        x = np.random.normal(size=(10, 10))
+        np.save(fn, x)
+        mm = np.load(fn, mmap_mode='r')
+        mm2 = np.load(fn, mmap_mode='r')
+        a = tokenize(mm[0, :])
+        b = tokenize(mm[1, :])
+        c = tokenize(mm[0:3, :])
+        d = tokenize(mm[:, 0])
+        assert len(set([a, b, c, d])) == 4
+        assert tokenize(mm) == tokenize(mm2)
+        assert tokenize(mm[1, :]) == tokenize(mm2[1, :])
+
 
 @pytest.mark.skipif('not np')
 def test_tokenize_numpy_memmap_no_filename():


### PR DESCRIPTION
Previously `tokenize` on `np.memmap` objects would return the same token
for slices of the same array. To fix this, we now include all the
metadata needed to fully define the array in the token. This includes
the array strides, shape, and the pointer offset.

Fixes #1645.