### PR TITLE
Add AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,39 @@
+# Environment loosely based on https://github.com/conda/conda/blob/master/appveyor.yml
+
+environment:
+
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\continuous_integration\\run_with_env.cmd"
+
+  matrix:
+    # Since appveyor is quite slow, we only use a single configuration
+    - PYTHON: "3.5"
+      ARCH: "64"
+      NUMPY: "1.11"
+      # Note Pandas 0.19 crashes in test_split_apply_combine_on_series,
+      # see https://ci.appveyor.com/project/pitrou/dask/build/1.0.40#L316
+      PANDAS: "0.18"
+      CONDA_ENV: testenv
+
+init:
+  # Use AppVeyor's provided Miniconda: https://www.appveyor.com/docs/installed-software#python
+  - if "%ARCH%" == "64" set MINICONDA=C:\Miniconda35-x64
+  - if "%ARCH%" == "32" set MINICONDA=C:\Miniconda35
+  - set PATH=%MINICONDA%;%MINICONDA%/Scripts;%MINICONDA%/Library/bin;%PATH%
+
+install:
+  # Update to a known good conda
+  # (to workaround http://help.appveyor.com/discussions/problems/4910)
+  - conda install -q -y conda=4.2.9
+  - continuous_integration\\setup_conda_environment.cmd
+
+build_script:
+  - continuous_integration\\build.cmd
+
+test_script:
+  # %CMD_IN_ENV% is needed for distutils/setuptools-based tests
+  # on certain build configurations.
+  - "%CMD_IN_ENV% continuous_integration\\run_tests.cmd"

--- a/continuous_integration/build.cmd
+++ b/continuous_integration/build.cmd
@@ -1,0 +1,6 @@
+call activate %CONDA_ENV%
+
+@echo on
+
+@rem Install Dask
+%PIP_INSTALL% --no-deps -e .[complete]

--- a/continuous_integration/run_tests.cmd
+++ b/continuous_integration/run_tests.cmd
@@ -1,0 +1,11 @@
+call activate %CONDA_ENV%
+
+@echo on
+
+set PYTHONFAULTHANDLER=1
+
+@rem `--capture=sys` avoids clobbering faulthandler tracebacks on crash
+set PYTEST=py.test --capture=sys
+
+@rem %PYTEST% -v --runslow dask\dataframe\tests\test_groupby.py
+%PYTEST% dask

--- a/continuous_integration/run_with_env.cmd
+++ b/continuous_integration/run_with_env.cmd
@@ -1,0 +1,90 @@
+:: From https://github.com/ogrisel/python-appveyor-demo
+::
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds, and 64-bit builds for 3.5 and beyond, do not require specific
+:: environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+::
+:: Notes about batch files for Python people:
+::
+:: Quotes in values are literally part of the values:
+::      SET FOO="bar"
+:: FOO is now five characters long: " b a r "
+:: If you don't want quotes, don't include them on the right-hand side.
+::
+:: The CALL lines at the end of this file look redundant, but if you move them
+:: outside of the IF clauses, they do not run properly in the SET_SDK_64==Y
+:: case, I don't know why.
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+SET WIN_WDK=c:\Program Files (x86)\Windows Kits\10\Include\wdf
+
+:: Extract the major and minor versions, and allow for the minor version to be
+:: more than 9.  This requires the version number to have two dots in it.
+SET MAJOR_PYTHON_VERSION=%PYTHON:~0,1%
+IF "%PYTHON:~3,1%" == "." (
+    SET MINOR_PYTHON_VERSION=%PYTHON:~2,1%
+) ELSE (
+    SET MINOR_PYTHON_VERSION=%PYTHON:~2,2%
+)
+
+:: Based on the Python version, determine what SDK version to use, and whether
+:: to set the SDK for 64-bit.
+IF %MAJOR_PYTHON_VERSION% == 2 (
+    SET WINDOWS_SDK_VERSION="v7.0"
+    SET SET_SDK_64=Y
+) ELSE (
+    IF %MAJOR_PYTHON_VERSION% == 3 (
+        SET WINDOWS_SDK_VERSION="v7.1"
+        IF %MINOR_PYTHON_VERSION% LEQ 4 (
+            SET SET_SDK_64=Y
+        ) ELSE (
+            SET SET_SDK_64=N
+            IF EXIST "%WIN_WDK%" (
+                :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
+                REN "%WIN_WDK%" 0wdf
+            )
+        )
+    ) ELSE (
+        ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+        EXIT 1
+    )
+)
+
+IF %ARCH% == 64 (
+    IF %SET_SDK_64% == Y (
+        ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+        SET DISTUTILS_USE_SDK=1
+        SET MSSdk=1
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    ) ELSE (
+        ECHO Using default MSVC build environment for 64 bit architecture
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    )
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -1,0 +1,37 @@
+@rem The cmd /C hack circumvents a regression where conda installs a conda.bat
+@rem script in non-root environments.
+set CONDA=cmd /C conda
+set CONDA_INSTALL=%CONDA% install -q -y
+set PIP_INSTALL=pip install -q
+
+@echo on
+
+@rem Deactivate any environment
+call deactivate
+@rem Display root environment (for debugging)
+conda list
+@rem Clean up any left-over from a previous build
+conda remove --all -q -y -n %CONDA_ENV%
+
+@rem Create test environment
+@rem (note: no cytoolz as it seems to prevent faulthandler tracebacks on crash)
+conda create -n %CONDA_ENV% -q -y python=%PYTHON% pytest toolz
+
+call activate %CONDA_ENV%
+
+@rem Install optional dependencies for tests
+%CONDA_INSTALL% numpy=%NUMPY% pandas=%PANDAS% cloudpickle distributed
+%CONDA_INSTALL% s3fs psutil pytables bokeh bcolz scipy h5py ipython
+
+%PIP_INSTALL% git+https://github.com/mrocklin/partd --upgrade
+%PIP_INSTALL% git+https://github.com/mrocklin/cachey --upgrade
+%PIP_INSTALL% blosc --upgrade
+%PIP_INSTALL% moto
+
+if %PYTHON% LSS 3.0 (%PIP_INSTALL% git+https://github.com/Blosc/castra)
+if %PYTHON% LSS 3.0 (%PIP_INSTALL% backports.lzma mock)
+
+@rem Display final environment (for reproducing)
+%CONDA% list
+%CONDA% list --explicit
+python -m site


### PR DESCRIPTION
There are a couple of test failures: see https://ci.appveyor.com/project/pitrou/dask/build/1.0.44.
Also Pandas is pinned to 0.18, as one of the tests crashes on 0.19: see https://ci.appveyor.com/project/pitrou/dask/build/1.0.40.

Activating this on the dask repo will require one the dask maintainers to create a AppVeyor account and create a new project there.