### PR TITLE
Fix #1656: failures when parallel testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ sudo: false
 
 env:
   matrix:
-    - PYTHON=2.7 NUMPY=1.10.4 PANDAS=0.19.0 COVERAGE='true' XTRATESTARGS=
-    - PYTHON=2.7 NUMPY=1.11.0 PANDAS=0.18.1 COVERAGE='false' PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
-    - PYTHON=3.3 NUMPY=1.9.2 PANDAS=0.18.1 COVERAGE='false' XTRATESTARGS=
-    - PYTHON=3.4 NUMPY=1.10.4 PANDAS=0.18.0 COVERAGE='false' PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
-    - PYTHON=3.5 NUMPY=1.11.0 PANDAS=0.19.0 COVERAGE='false' XTRATESTARGS=
+    - PYTHON=2.7 NUMPY=1.10.4 PANDAS=0.19.0 COVERAGE='true' PARALLEL='false' XTRATESTARGS=
+    - PYTHON=2.7 NUMPY=1.11.0 PANDAS=0.18.1 COVERAGE='false' PARALLEL='true' PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
+    - PYTHON=3.3 NUMPY=1.9.2 PANDAS=0.18.1 COVERAGE='false' PARALLEL='true' XTRATESTARGS=
+    - PYTHON=3.4 NUMPY=1.10.4 PANDAS=0.18.0 COVERAGE='false' PARALLEL='true' PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
+    - PYTHON=3.5 NUMPY=1.11.0 PANDAS=0.19.0 COVERAGE='false' PARALLEL='true' XTRATESTARGS=
 
 addons:
     apt:
@@ -35,11 +35,16 @@ install:
   - pip install blosc --upgrade
   - pip install graphviz moto flake8
   - if [[ $PYTHON < '3' ]]; then pip install git+https://github.com/Blosc/castra; fi
+  # For parallel testing (`-n` argument in XTRATESTARGS)
+  - pip install pytest-xdist
 
   # Install dask
   - pip install --no-deps -e .[complete]
 
 script:
+    # Need to make test order deterministic when parallelizing tests, hence PYTHONHASHSEED
+    # (see https://github.com/pytest-dev/pytest-xdist/issues/63)
+    - if [[ $PARALLEL == 'true' ]]; then export XTRATESTARGS="-n=auto $XTRATESTARGS"; export PYTHONHASHSEED=42; fi
     - if [[ $COVERAGE == 'true' ]]; then coverage run $(which py.test) dask --runslow --doctest-modules --verbose $XTRATESTARGS; else py.test dask --runslow --verbose $XTRATESTARGS; fi
     - flake8 dask
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 script:
     # Need to make test order deterministic when parallelizing tests, hence PYTHONHASHSEED
     # (see https://github.com/pytest-dev/pytest-xdist/issues/63)
-    - if [[ $PARALLEL == 'true' ]]; then export XTRATESTARGS="-n=auto $XTRATESTARGS"; export PYTHONHASHSEED=42; fi
+    - if [[ $PARALLEL == 'true' ]]; then export XTRATESTARGS="-n3 $XTRATESTARGS"; export PYTHONHASHSEED=42; fi
     - if [[ $COVERAGE == 'true' ]]; then coverage run $(which py.test) dask --runslow --doctest-modules --verbose $XTRATESTARGS; else py.test dask --runslow --verbose $XTRATESTARGS; fi
     - flake8 dask
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -8,7 +8,7 @@ from toolz import concat, valmap, partial
 
 from dask import compute, get, delayed
 from dask.compatibility import FileNotFoundError
-from dask.utils import filetexts
+from dask.utils import filetexts, tmp_cwd
 from dask.bytes import compression
 from dask.bytes.local import read_bytes, open_files, getsize, open_file_write
 from dask.bytes.core import open_text_files, write_bytes

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -8,7 +8,7 @@ from toolz import concat, valmap, partial
 
 from dask import compute, get, delayed
 from dask.compatibility import FileNotFoundError
-from dask.utils import filetexts, tmp_cwd
+from dask.utils import filetexts
 from dask.bytes import compression
 from dask.bytes.local import read_bytes, open_files, getsize, open_file_write
 from dask.bytes.core import open_text_files, write_bytes


### PR DESCRIPTION
Parallel testing works using the `pytest-xdist` plugin with a hard-coded PYTHONHASHSEED, e.g.:

$ PYTHONHASHSEED=1 py.test -n=auto dask