### PR TITLE
Dataframe tree reductions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1109,7 +1109,7 @@ class _Frame(Base):
                        freq=freq, center=center, win_type=win_type, axis=axis)
 
     @derived_from(pd.DataFrame)
-    def sum(self, axis=None, skipna=True, split_every=None):
+    def sum(self, axis=None, skipna=True, split_every=False):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.sum(axis=axis, skipna=skipna)
         token = self._token_prefix + 'sum'
@@ -1122,7 +1122,7 @@ class _Frame(Base):
                                   split_every=split_every)
 
     @derived_from(pd.DataFrame)
-    def max(self, axis=None, skipna=True, split_every=None):
+    def max(self, axis=None, skipna=True, split_every=False):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.max(axis=axis, skipna=skipna)
         token = self._token_prefix + 'max'
@@ -1135,7 +1135,7 @@ class _Frame(Base):
                                   split_every=split_every)
 
     @derived_from(pd.DataFrame)
-    def min(self, axis=None, skipna=True, split_every=None):
+    def min(self, axis=None, skipna=True, split_every=False):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.min(axis=axis, skipna=skipna)
         token = self._token_prefix + 'min'
@@ -1148,7 +1148,7 @@ class _Frame(Base):
                                   split_every=split_every)
 
     @derived_from(pd.DataFrame)
-    def idxmax(self, axis=None, skipna=True, split_every=None):
+    def idxmax(self, axis=None, skipna=True, split_every=False):
         fn = 'idxmax'
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.idxmax(axis=axis, skipna=skipna)
@@ -1165,7 +1165,7 @@ class _Frame(Base):
                        skipna=skipna, fn=fn)
 
     @derived_from(pd.DataFrame)
-    def idxmin(self, axis=None, skipna=True, split_every=None):
+    def idxmin(self, axis=None, skipna=True, split_every=False):
         fn = 'idxmin'
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.idxmax(axis=axis)
@@ -1182,7 +1182,7 @@ class _Frame(Base):
                        skipna=skipna, fn=fn)
 
     @derived_from(pd.DataFrame)
-    def count(self, axis=None, split_every=None):
+    def count(self, axis=None, split_every=False):
         axis = self._validate_axis(axis)
         token = self._token_prefix + 'count'
         if axis == 1:
@@ -1195,7 +1195,7 @@ class _Frame(Base):
                                   token=token, split_every=split_every)
 
     @derived_from(pd.DataFrame)
-    def mean(self, axis=None, skipna=True, split_every=None):
+    def mean(self, axis=None, skipna=True, split_every=False):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.mean(axis=axis, skipna=skipna)
         if axis == 1:
@@ -1211,7 +1211,7 @@ class _Frame(Base):
                                   token=name, meta=meta)
 
     @derived_from(pd.DataFrame)
-    def var(self, axis=None, skipna=True, ddof=1, split_every=None):
+    def var(self, axis=None, skipna=True, ddof=1, split_every=False):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.var(axis=axis, skipna=skipna)
         if axis == 1:
@@ -1228,7 +1228,7 @@ class _Frame(Base):
                                   token=name, meta=meta, ddof=ddof)
 
     @derived_from(pd.DataFrame)
-    def std(self, axis=None, skipna=True, ddof=1, split_every=None):
+    def std(self, axis=None, skipna=True, ddof=1, split_every=False):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.std(axis=axis, skipna=skipna)
         if axis == 1:
@@ -1285,7 +1285,7 @@ class _Frame(Base):
                 return DataFrame(dask, keyname, meta, quantiles[0].divisions)
 
     @derived_from(pd.DataFrame)
-    def describe(self, split_every=None):
+    def describe(self, split_every=False):
         # currently, only numeric describe is supported
         num = self._get_numeric_data()
 
@@ -1613,64 +1613,8 @@ class Series(_Frame):
         return SeriesGroupBy(self, index, **kwargs)
 
     @derived_from(pd.Series)
-    def sum(self, axis=None, skipna=True, split_every=False):
-        return super(Series, self).sum(axis=axis, skipna=skipna,
-                                       split_every=None)
-
-    @derived_from(pd.Series)
-    def max(self, axis=None, skipna=True, split_every=False):
-        return super(Series, self).max(axis=axis, skipna=skipna,
-                                       split_every=split_every)
-
-    @derived_from(pd.Series)
-    def min(self, axis=None, skipna=True, split_every=False):
-        return super(Series, self).min(axis=axis, skipna=skipna,
-                                       split_every=split_every)
-
-    @derived_from(pd.Series)
-    def idx_max(self, axis=None, skipna=True, split_every=False):
-        return super(Series, self).idx_max(axis=axis, skipna=skipna,
-                                           split_every=split_every)
-
-    @derived_from(pd.Series)
-    def idx_min(self, axis=None, skipna=True, split_every=False):
-        return super(Series, self).idx_min(axis=axis, skipna=skipna,
-                                           split_every=split_every)
-
-    @derived_from(pd.Series)
     def count(self, split_every=False):
         return super(Series, self).count(split_every=split_every)
-
-    @derived_from(pd.Series)
-    def mean(self, axis=None, skipna=True, split_every=False):
-        return super(Series, self).mean(axis=axis, skipna=skipna,
-                                        split_every=split_every)
-
-    @derived_from(pd.Series)
-    def var(self, axis=None, ddof=1, skipna=True, split_every=False):
-        return super(Series, self).var(axis=axis, ddof=ddof, skipna=skipna,
-                                       split_every=split_every)
-
-    @derived_from(pd.Series)
-    def std(self, axis=None, ddof=1, skipna=True, split_every=False):
-        return super(Series, self).std(axis=axis, ddof=ddof, skipna=skipna,
-                                       split_every=split_every)
-
-    @derived_from(pd.Series)
-    def cumsum(self, axis=None, skipna=True):
-        return super(Series, self).cumsum(axis=axis, skipna=skipna)
-
-    @derived_from(pd.Series)
-    def cumprod(self, axis=None, skipna=True):
-        return super(Series, self).cumprod(axis=axis, skipna=skipna)
-
-    @derived_from(pd.Series)
-    def cummax(self, axis=None, skipna=True):
-        return super(Series, self).cummax(axis=axis, skipna=skipna)
-
-    @derived_from(pd.Series)
-    def cummin(self, axis=None, skipna=True):
-        return super(Series, self).cummin(axis=axis, skipna=skipna)
 
     def unique(self, split_every=None):
         """
@@ -1686,7 +1630,7 @@ class Series(_Frame):
 
     @derived_from(pd.Series)
     def nunique(self, split_every=None):
-        return self.drop_duplicates(split_every=None).count()
+        return self.drop_duplicates(split_every=split_every).count()
 
     @derived_from(pd.Series)
     def value_counts(self, split_every=None):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -258,7 +258,8 @@ class _Frame(Base):
 
     @property
     def size(self):
-        return self.reduction(methods.size, np.sum, token='size', meta=int)
+        return self.reduction(methods.size, np.sum, token='size', meta=int,
+                              split_every=False)
 
     @property
     def _meta_nonempty(self):
@@ -352,7 +353,8 @@ class _Frame(Base):
                    token='drop-duplicates', split_every=split_every, **kwargs)
 
     def __len__(self):
-        return self.reduction(len, np.sum, token='len', meta=int).compute()
+        return self.reduction(len, np.sum, token='len', meta=int,
+                              split_every=False).compute()
 
     @insert_meta_param_description(pad=12)
     def map_partitions(self, func, *args, **kwargs):
@@ -1536,7 +1538,8 @@ class Series(_Frame):
 
     @property
     def nbytes(self):
-        return self.reduction(methods.nbytes, np.sum, token='nbytes', meta=int)
+        return self.reduction(methods.nbytes, np.sum, token='nbytes',
+                              meta=int, split_every=False)
 
     def __array__(self, dtype=None, **kwargs):
         x = np.array(self.compute())
@@ -1610,36 +1613,46 @@ class Series(_Frame):
         return SeriesGroupBy(self, index, **kwargs)
 
     @derived_from(pd.Series)
-    def sum(self, axis=None, skipna=True, split_every=None):
+    def sum(self, axis=None, skipna=True, split_every=False):
         return super(Series, self).sum(axis=axis, skipna=skipna,
                                        split_every=None)
 
     @derived_from(pd.Series)
-    def max(self, axis=None, skipna=True, split_every=None):
+    def max(self, axis=None, skipna=True, split_every=False):
         return super(Series, self).max(axis=axis, skipna=skipna,
                                        split_every=split_every)
 
     @derived_from(pd.Series)
-    def min(self, axis=None, skipna=True, split_every=None):
+    def min(self, axis=None, skipna=True, split_every=False):
         return super(Series, self).min(axis=axis, skipna=skipna,
                                        split_every=split_every)
 
     @derived_from(pd.Series)
-    def count(self, split_every=None):
+    def idx_max(self, axis=None, skipna=True, split_every=False):
+        return super(Series, self).idx_max(axis=axis, skipna=skipna,
+                                           split_every=split_every)
+
+    @derived_from(pd.Series)
+    def idx_min(self, axis=None, skipna=True, split_every=False):
+        return super(Series, self).idx_min(axis=axis, skipna=skipna,
+                                           split_every=split_every)
+
+    @derived_from(pd.Series)
+    def count(self, split_every=False):
         return super(Series, self).count(split_every=split_every)
 
     @derived_from(pd.Series)
-    def mean(self, axis=None, skipna=True, split_every=None):
+    def mean(self, axis=None, skipna=True, split_every=False):
         return super(Series, self).mean(axis=axis, skipna=skipna,
                                         split_every=split_every)
 
     @derived_from(pd.Series)
-    def var(self, axis=None, ddof=1, skipna=True, split_every=None):
+    def var(self, axis=None, ddof=1, skipna=True, split_every=False):
         return super(Series, self).var(axis=axis, ddof=ddof, skipna=skipna,
                                        split_every=split_every)
 
     @derived_from(pd.Series)
-    def std(self, axis=None, ddof=1, skipna=True, split_every=None):
+    def std(self, axis=None, ddof=1, skipna=True, split_every=False):
         return super(Series, self).std(axis=axis, ddof=ddof, skipna=skipna,
                                        split_every=split_every)
 
@@ -1912,18 +1925,18 @@ class Index(Series):
         return result
 
     @derived_from(pd.Index)
-    def max(self, split_every=None):
+    def max(self, split_every=False):
         return self.reduction(M.max, meta=self._meta_nonempty.max(),
                               token=self._token_prefix + 'max',
                               split_every=split_every)
 
     @derived_from(pd.Index)
-    def min(self, split_every=None):
+    def min(self, split_every=False):
         return self.reduction(M.min, meta=self._meta_nonempty.min(),
                               token=self._token_prefix + 'min',
                               split_every=split_every)
 
-    def count(self, split_every=None):
+    def count(self, split_every=False):
         return self.reduction(methods.index_count, np.sum,
                               token='index-count', meta=int,
                               split_every=split_every)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -345,10 +345,11 @@ class _Frame(Base):
 
     @derived_from(pd.DataFrame)
     def drop_duplicates(self, **kwargs):
+        split_every = kwargs.pop('split_every', None)
         assert all(k in ('keep', 'subset', 'take_last') for k in kwargs)
         chunk = M.drop_duplicates
         return aca(self, chunk=chunk, aggregate=chunk, meta=self._meta,
-                   token='drop-duplicates', **kwargs)
+                   token='drop-duplicates', split_every=split_every, **kwargs)
 
     def __len__(self):
         return self.reduction(len, np.sum, token='len', meta=int).compute()
@@ -424,9 +425,9 @@ class _Frame(Base):
         return map_partitions(func, self, *args, **kwargs)
 
     @insert_meta_param_description(pad=12)
-    def reduction(self, chunk, aggregate=None, meta=no_default,
-                  token=None, chunk_kwargs=None, aggregate_kwargs=None,
-                  **kwargs):
+    def reduction(self, chunk, aggregate=None, combine=None, meta=no_default,
+                  token=None, split_every=None, chunk_kwargs=None,
+                  aggregate_kwargs=None, combine_kwargs=None, **kwargs):
         """Generic row-wise reductions.
 
         Parameters
@@ -436,7 +437,8 @@ class _Frame(Base):
             ``pandas.DataFrame``, ``pandas.Series``, or a scalar.
         aggregate : callable, optional
             Function to operate on the concatenated result of ``chunk``. If not
-            specified, defaults to ``chunk``.
+            specified, defaults to ``chunk``. Used to do the final aggregation
+            in a tree reduction.
 
             The input to ``aggregate`` depends on the output of ``chunk``.
             If the output of ``chunk`` is a:
@@ -448,16 +450,28 @@ class _Frame(Base):
 
             Should return a ``pandas.DataFrame``, ``pandas.Series``, or a
             scalar.
+        combine : callable, optional
+            Function to operate on intermediate concatenated results of
+            ``chunk`` in a tree-reduction. If not provided, defaults to
+            ``aggregate``. The input/output requirements should match that of
+            ``aggregate`` described above.
         $META
         token : str, optional
             The name to use for the output keys.
+        split_every : int, optional
+            Group partitions into groups of this size while performing a
+            tree-reduction. If set to False, no tree-reduction will be used,
+            and all intermediates will be concatenated and passed to
+            ``aggregate``. Default is 8.
         chunk_kwargs : dict, optional
             Keyword arguments to pass on to ``chunk`` only.
         aggregate_kwargs : dict, optional
             Keyword arguments to pass on to ``aggregate`` only.
+        combine_kwargs : dict, optional
+            Keyword arguments to pass on to ``combine`` only.
         kwargs :
-            All remaining keywords will be passed to both ``chunk`` and
-            ``aggregate``.
+            All remaining keywords will be passed to ``chunk``, ``combine``,
+            and ``aggregate``.
 
         Examples
         --------
@@ -513,15 +527,26 @@ class _Frame(Base):
         if aggregate is None:
             aggregate = chunk
 
+        if combine is None:
+            if combine_kwargs:
+                raise ValueError("`combine_kwargs` provided with no `combine`")
+            combine = aggregate
+            combine_kwargs = aggregate_kwargs
+
         chunk_kwargs = chunk_kwargs.copy() if chunk_kwargs else {}
         chunk_kwargs['aca_chunk'] = chunk
+
+        combine_kwargs = combine_kwargs.copy() if combine_kwargs else {}
+        combine_kwargs['aca_combine'] = combine
 
         aggregate_kwargs = aggregate_kwargs.copy() if aggregate_kwargs else {}
         aggregate_kwargs['aca_aggregate'] = aggregate
 
         return aca(self, chunk=_reduction_chunk, aggregate=_reduction_aggregate,
-                   meta=meta, token=token, chunk_kwargs=chunk_kwargs,
-                   aggregate_kwargs=aggregate_kwargs, **kwargs)
+                   combine=_reduction_combine, meta=meta, token=token,
+                   split_every=split_every, chunk_kwargs=chunk_kwargs,
+                   aggregate_kwargs=aggregate_kwargs,
+                   combine_kwargs=combine_kwargs, **kwargs)
 
     @derived_from(pd.DataFrame)
     def pipe(self, func, *args, **kwargs):
@@ -1082,7 +1107,7 @@ class _Frame(Base):
                        freq=freq, center=center, win_type=win_type, axis=axis)
 
     @derived_from(pd.DataFrame)
-    def sum(self, axis=None, skipna=True):
+    def sum(self, axis=None, skipna=True, split_every=None):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.sum(axis=axis, skipna=skipna)
         token = self._token_prefix + 'sum'
@@ -1091,10 +1116,11 @@ class _Frame(Base):
                                        token=token, skipna=skipna, axis=axis)
         else:
             return self.reduction(M.sum, meta=meta, token=token,
-                                  skipna=skipna, axis=axis)
+                                  skipna=skipna, axis=axis,
+                                  split_every=split_every)
 
     @derived_from(pd.DataFrame)
-    def max(self, axis=None, skipna=True):
+    def max(self, axis=None, skipna=True, split_every=None):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.max(axis=axis, skipna=skipna)
         token = self._token_prefix + 'max'
@@ -1103,10 +1129,11 @@ class _Frame(Base):
                                        skipna=skipna, axis=axis)
         else:
             return self.reduction(M.max, meta=meta, token=token,
-                                  skipna=skipna, axis=axis)
+                                  skipna=skipna, axis=axis,
+                                  split_every=split_every)
 
     @derived_from(pd.DataFrame)
-    def min(self, axis=None, skipna=True):
+    def min(self, axis=None, skipna=True, split_every=None):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.min(axis=axis, skipna=skipna)
         token = self._token_prefix + 'min'
@@ -1115,10 +1142,11 @@ class _Frame(Base):
                                        skipna=skipna, axis=axis)
         else:
             return self.reduction(M.min, meta=meta, token=token,
-                                  skipna=skipna, axis=axis)
+                                  skipna=skipna, axis=axis,
+                                  split_every=split_every)
 
     @derived_from(pd.DataFrame)
-    def idxmax(self, axis=None, skipna=True):
+    def idxmax(self, axis=None, skipna=True, split_every=None):
         fn = 'idxmax'
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.idxmax(axis=axis, skipna=skipna)
@@ -1127,12 +1155,15 @@ class _Frame(Base):
                                   token=self._token_prefix + fn,
                                   skipna=skipna, axis=axis)
         else:
+            scalar = not isinstance(meta, pd.Series)
             return aca([self], chunk=idxmaxmin_chunk, aggregate=idxmaxmin_agg,
-                       meta=meta, token=self._token_prefix + fn, skipna=skipna,
-                       known_divisions=self.known_divisions, fn=fn, axis=axis)
+                       combine=idxmaxmin_combine, meta=meta,
+                       aggregate_kwargs={'scalar': scalar},
+                       token=self._token_prefix + fn, split_every=split_every,
+                       skipna=skipna, fn=fn)
 
     @derived_from(pd.DataFrame)
-    def idxmin(self, axis=None, skipna=True):
+    def idxmin(self, axis=None, skipna=True, split_every=None):
         fn = 'idxmin'
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.idxmax(axis=axis)
@@ -1141,12 +1172,15 @@ class _Frame(Base):
                                   token=self._token_prefix + fn,
                                   skipna=skipna, axis=axis)
         else:
+            scalar = not isinstance(meta, pd.Series)
             return aca([self], chunk=idxmaxmin_chunk, aggregate=idxmaxmin_agg,
-                       meta=meta, token=self._token_prefix + fn, skipna=skipna,
-                       known_divisions=self.known_divisions, fn=fn, axis=axis)
+                       combine=idxmaxmin_combine, meta=meta,
+                       aggregate_kwargs={'scalar': scalar},
+                       token=self._token_prefix + fn, split_every=split_every,
+                       skipna=skipna, fn=fn)
 
     @derived_from(pd.DataFrame)
-    def count(self, axis=None):
+    def count(self, axis=None, split_every=None):
         axis = self._validate_axis(axis)
         token = self._token_prefix + 'count'
         if axis == 1:
@@ -1155,11 +1189,11 @@ class _Frame(Base):
                                        axis=axis)
         else:
             meta = self._meta_nonempty.count()
-            return self.reduction(M.count, meta=meta, token=token,
-                                  aggregate=M.sum)
+            return self.reduction(M.count, aggregate=M.sum, meta=meta,
+                                  token=token, split_every=split_every)
 
     @derived_from(pd.DataFrame)
-    def mean(self, axis=None, skipna=True):
+    def mean(self, axis=None, skipna=True, split_every=None):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.mean(axis=axis, skipna=skipna)
         if axis == 1:
@@ -1168,14 +1202,14 @@ class _Frame(Base):
                                   axis=axis, skipna=skipna)
         else:
             num = self._get_numeric_data()
-            s = num.sum(skipna=skipna)
-            n = num.count()
+            s = num.sum(skipna=skipna, split_every=split_every)
+            n = num.count(split_every=split_every)
             name = self._token_prefix + 'mean-%s' % tokenize(self, axis, skipna)
             return map_partitions(methods.mean_aggregate, s, n,
                                   token=name, meta=meta)
 
     @derived_from(pd.DataFrame)
-    def var(self, axis=None, skipna=True, ddof=1):
+    def var(self, axis=None, skipna=True, ddof=1, split_every=None):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.var(axis=axis, skipna=skipna)
         if axis == 1:
@@ -1184,15 +1218,15 @@ class _Frame(Base):
                                   axis=axis, skipna=skipna, ddof=ddof)
         else:
             num = self._get_numeric_data()
-            x = 1.0 * num.sum(skipna=skipna)
-            x2 = 1.0 * (num ** 2).sum(skipna=skipna)
-            n = num.count()
+            x = 1.0 * num.sum(skipna=skipna, split_every=split_every)
+            x2 = 1.0 * (num ** 2).sum(skipna=skipna, split_every=split_every)
+            n = num.count(split_every=split_every)
             name = self._token_prefix + 'var-%s' % tokenize(self, axis, skipna, ddof)
             return map_partitions(methods.var_aggregate, x2, x, n,
                                   token=name, meta=meta, ddof=ddof)
 
     @derived_from(pd.DataFrame)
-    def std(self, axis=None, skipna=True, ddof=1):
+    def std(self, axis=None, skipna=True, ddof=1, split_every=None):
         axis = self._validate_axis(axis)
         meta = self._meta_nonempty.std(axis=axis, skipna=skipna)
         if axis == 1:
@@ -1200,7 +1234,7 @@ class _Frame(Base):
                                   token=self._token_prefix + 'std',
                                   axis=axis, skipna=skipna, ddof=ddof)
         else:
-            v = self.var(skipna=skipna, ddof=ddof)
+            v = self.var(skipna=skipna, ddof=ddof, split_every=split_every)
             token = tokenize(self, axis, skipna, ddof)
             name = self._token_prefix + 'std-finish--%s' % token
             return map_partitions(np.sqrt, v, meta=meta, token=name)
@@ -1249,12 +1283,16 @@ class _Frame(Base):
                 return DataFrame(dask, keyname, meta, quantiles[0].divisions)
 
     @derived_from(pd.DataFrame)
-    def describe(self):
+    def describe(self, split_every=None):
         # currently, only numeric describe is supported
         num = self._get_numeric_data()
 
-        stats = [num.count(), num.mean(), num.std(), num.min(),
-                 num.quantile([0.25, 0.5, 0.75]), num.max()]
+        stats = [num.count(split_every=split_every),
+                 num.mean(split_every=split_every),
+                 num.std(split_every=split_every),
+                 num.min(split_every=split_every),
+                 num.quantile([0.25, 0.5, 0.75]),
+                 num.max(split_every=split_every)]
         stats_names = [(s._name, 0) for s in stats]
 
         name = 'describe--' + tokenize(self)
@@ -1572,32 +1610,38 @@ class Series(_Frame):
         return SeriesGroupBy(self, index, **kwargs)
 
     @derived_from(pd.Series)
-    def sum(self, axis=None, skipna=True):
-        return super(Series, self).sum(axis=axis, skipna=skipna)
+    def sum(self, axis=None, skipna=True, split_every=None):
+        return super(Series, self).sum(axis=axis, skipna=skipna,
+                                       split_every=None)
 
     @derived_from(pd.Series)
-    def max(self, axis=None, skipna=True):
-        return super(Series, self).max(axis=axis, skipna=skipna)
+    def max(self, axis=None, skipna=True, split_every=None):
+        return super(Series, self).max(axis=axis, skipna=skipna,
+                                       split_every=split_every)
 
     @derived_from(pd.Series)
-    def min(self, axis=None, skipna=True):
-        return super(Series, self).min(axis=axis, skipna=skipna)
+    def min(self, axis=None, skipna=True, split_every=None):
+        return super(Series, self).min(axis=axis, skipna=skipna,
+                                       split_every=split_every)
 
     @derived_from(pd.Series)
-    def count(self):
-        return super(Series, self).count()
+    def count(self, split_every=None):
+        return super(Series, self).count(split_every=split_every)
 
     @derived_from(pd.Series)
-    def mean(self, axis=None, skipna=True):
-        return super(Series, self).mean(axis=axis, skipna=skipna)
+    def mean(self, axis=None, skipna=True, split_every=None):
+        return super(Series, self).mean(axis=axis, skipna=skipna,
+                                        split_every=split_every)
 
     @derived_from(pd.Series)
-    def var(self, axis=None, ddof=1, skipna=True):
-        return super(Series, self).var(axis=axis, ddof=ddof, skipna=skipna)
+    def var(self, axis=None, ddof=1, skipna=True, split_every=None):
+        return super(Series, self).var(axis=axis, ddof=ddof, skipna=skipna,
+                                       split_every=split_every)
 
     @derived_from(pd.Series)
-    def std(self, axis=None, ddof=1, skipna=True):
-        return super(Series, self).std(axis=axis, ddof=ddof, skipna=skipna)
+    def std(self, axis=None, ddof=1, skipna=True, split_every=None):
+        return super(Series, self).std(axis=axis, ddof=ddof, skipna=skipna,
+                                       split_every=split_every)
 
     @derived_from(pd.Series)
     def cumsum(self, axis=None, skipna=True):
@@ -1615,7 +1659,7 @@ class Series(_Frame):
     def cummin(self, axis=None, skipna=True):
         return super(Series, self).cummin(axis=axis, skipna=skipna)
 
-    def unique(self):
+    def unique(self, split_every=None):
         """
         Return Series of unique values in the object. Includes NA values.
 
@@ -1624,23 +1668,26 @@ class Series(_Frame):
         uniques : Series
         """
         return aca(self, chunk=methods.unique, aggregate=methods.unique,
-                   meta=self._meta, token='unique', series_name=self.name)
+                   meta=self._meta, token='unique', split_every=split_every,
+                   series_name=self.name)
 
     @derived_from(pd.Series)
-    def nunique(self):
-        return self.drop_duplicates().count()
+    def nunique(self, split_every=None):
+        return self.drop_duplicates(split_every=None).count()
 
     @derived_from(pd.Series)
-    def value_counts(self):
+    def value_counts(self, split_every=None):
         return aca(self, chunk=M.value_counts,
                    aggregate=methods.value_counts_aggregate,
-                   meta=self._meta.value_counts(), token='value-counts')
+                   combine=methods.value_counts_combine,
+                   meta=self._meta.value_counts(), token='value-counts',
+                   split_every=split_every)
 
     @derived_from(pd.Series)
-    def nlargest(self, n=5):
+    def nlargest(self, n=5, split_every=None):
         return aca(self, chunk=M.nlargest, aggregate=M.nlargest,
                    meta=self._meta, token='series-nlargest-n={0}'.format(n),
-                   n=n)
+                   split_every=split_every, n=n)
 
     @derived_from(pd.Series)
     def isin(self, other):
@@ -1864,22 +1911,22 @@ class Index(Series):
             result = result.compute()
         return result
 
-    def nunique(self):
-        return self.drop_duplicates().count()
-
     @derived_from(pd.Index)
-    def max(self):
+    def max(self, split_every=None):
         return self.reduction(M.max, meta=self._meta_nonempty.max(),
-                              token=self._token_prefix + 'max')
+                              token=self._token_prefix + 'max',
+                              split_every=split_every)
 
     @derived_from(pd.Index)
-    def min(self):
+    def min(self, split_every=None):
         return self.reduction(M.min, meta=self._meta_nonempty.min(),
-                              token=self._token_prefix + 'min')
+                              token=self._token_prefix + 'min',
+                              split_every=split_every)
 
-    def count(self):
+    def count(self, split_every=None):
         return self.reduction(methods.index_count, np.sum,
-                              token='index-count', meta=int)
+                              token='index-count', meta=int,
+                              split_every=split_every)
 
 
 class DataFrame(_Frame):
@@ -2068,10 +2115,11 @@ class DataFrame(_Frame):
         return set_partition(self, column, divisions, **kwargs)
 
     @derived_from(pd.DataFrame)
-    def nlargest(self, n=5, columns=None):
+    def nlargest(self, n=5, columns=None, split_every=None):
         token = 'dataframe-nlargest-n={0}'.format(n)
         return aca(self, chunk=M.nlargest, aggregate=M.nlargest,
-                   meta=self._meta, token=token, n=n, columns=columns)
+                   meta=self._meta, token=token, split_every=split_every,
+                   n=n, columns=columns)
 
     @derived_from(pd.DataFrame)
     def reset_index(self):
@@ -2586,7 +2634,7 @@ def _maybe_from_pandas(dfs):
 
 @insert_meta_param_description
 def apply_concat_apply(args, chunk=None, aggregate=None, combine=None,
-                       meta=no_default, token=None, split_every=False,
+                       meta=no_default, token=None, split_every=None,
                        chunk_kwargs=None, aggregate_kwargs=None,
                        combine_kwargs=None, **kwargs):
     """Apply a function to blocks, then concat, then apply again
@@ -2635,14 +2683,18 @@ def apply_concat_apply(args, chunk=None, aggregate=None, combine=None,
         chunk_kwargs = dict()
     if aggregate_kwargs is None:
         aggregate_kwargs = dict()
-    if combine_kwargs is None:
-        combine_kwargs = dict()
     chunk_kwargs.update(kwargs)
     aggregate_kwargs.update(kwargs)
-    combine_kwargs.update(kwargs)
 
     if combine is None:
+        if combine_kwargs:
+            raise ValueError("`combine_kwargs` provided with no `combine`")
         combine = aggregate
+        combine_kwargs = aggregate_kwargs
+    else:
+        if combine_kwargs is None:
+            combine_kwargs = dict()
+        combine_kwargs.update(kwargs)
 
     if not isinstance(args, (tuple, list)):
         args = [args]
@@ -2657,6 +2709,8 @@ def apply_concat_apply(args, chunk=None, aggregate=None, combine=None,
         split_every = 8
     elif split_every is False:
         split_every = npartitions
+    elif split_every < 2 or not isinstance(split_every, int):
+        raise ValueError("split_every must be an integer >= 2")
 
     token_key = tokenize(token or (chunk, aggregate), meta, args,
                          chunk_kwargs, aggregate_kwargs, combine_kwargs,
@@ -2678,13 +2732,13 @@ def apply_concat_apply(args, chunk=None, aggregate=None, combine=None,
     depth = 0
     while k > split_every:
         b = prefix + str(depth)
-        for i, inds in enumerate(partition_all(split_every, range(k))):
+        for part_i, inds in enumerate(partition_all(split_every, range(k))):
             conc = (_concat, (list, [(a, i) for i in inds]))
             if combine_kwargs:
-                dsk[(b, i)] = (apply, combine, [conc], combine_kwargs)
+                dsk[(b, part_i)] = (apply, combine, [conc], combine_kwargs)
             else:
-                dsk[(b, i)] = (combine, conc)
-        k = i + 1
+                dsk[(b, part_i)] = (combine, conc)
+        k = part_i + 1
         a = b
         depth += 1
 
@@ -3323,6 +3377,14 @@ def _reduction_chunk(x, aca_chunk=None, **kwargs):
     return o.to_frame().T if isinstance(o, pd.Series) else o
 
 
+def _reduction_combine(x, aca_combine=None, **kwargs):
+    if isinstance(x, list):
+        x = pd.Series(x)
+    o = aca_combine(x, **kwargs)
+    # Return a dataframe so that the concatenated version is also a dataframe
+    return o.to_frame().T if isinstance(o, pd.Series) else o
+
+
 def _reduction_aggregate(x, aca_aggregate=None, **kwargs):
     if isinstance(x, list):
         x = pd.Series(x)
@@ -3335,39 +3397,35 @@ def drop_columns(df, columns, dtype):
     return df
 
 
-def idxmaxmin_chunk(x, fn, axis=0, skipna=True, **kwargs):
-    idx = getattr(x, fn)(axis=axis, skipna=skipna)
+def idxmaxmin_chunk(x, fn=None, skipna=True):
+    idx = getattr(x, fn)(skipna=skipna)
     minmax = 'max' if fn == 'idxmax' else 'min'
-    value = getattr(x, minmax)(axis=axis, skipna=skipna)
-    n = len(x)
-    if isinstance(idx, pd.Series):
-        chunk = pd.DataFrame({'idx': idx, 'value': value, 'n': [n] * len(idx)})
-        chunk['idx'] = chunk['idx'].astype(type(idx.iloc[0]))
-    else:
-        chunk = pd.DataFrame({'idx': [idx], 'value': [value], 'n': [n]})
-        chunk['idx'] = chunk['idx'].astype(type(idx))
-    return chunk
+    value = getattr(x, minmax)(skipna=skipna)
+    if isinstance(x, pd.DataFrame):
+        return pd.DataFrame({'idx': idx, 'value': value})
+    return pd.DataFrame({'idx': [idx], 'value': [value]})
 
 
-def idxmaxmin_row(x, fn, skipna=True):
-    idx = x.idx.reset_index(drop=True)
-    value = x.value.reset_index(drop=True)
-    subidx = getattr(value, fn)(skipna=skipna)
-
-    # if skipna is False, pandas returns NaN so mimic behavior
-    if pd.isnull(subidx):
-        return subidx
-
-    return idx.iloc[subidx]
+def idxmaxmin_row(x, fn=None, skipna=True):
+    x = x.set_index('idx')
+    idx = getattr(x.value, fn)(skipna=skipna)
+    minmax = 'max' if fn == 'idxmax' else 'min'
+    value = getattr(x.value, minmax)(skipna=skipna)
+    return pd.DataFrame({'idx': [idx], 'value': [value]})
 
 
-def idxmaxmin_agg(x, fn, skipna=True, **kwargs):
-    indices = list(set(x.index.tolist()))
-    idxmaxmin = [idxmaxmin_row(x.ix[idx], fn, skipna=skipna) for idx in indices]
-    if len(idxmaxmin) == 1:
-        return idxmaxmin[0]
-    else:
-        return pd.Series(idxmaxmin, index=indices)
+def idxmaxmin_combine(x, fn=None, skipna=True):
+    return (x.groupby(level=0)
+             .apply(idxmaxmin_row, fn=fn, skipna=skipna)
+             .reset_index(level=1, drop=True))
+
+
+def idxmaxmin_agg(x, fn=None, skipna=True, scalar=False):
+    res = idxmaxmin_combine(x, fn, skipna=skipna)['idx']
+    if scalar:
+        return res[0]
+    res.name = None
+    return res
 
 
 def safe_head(df, n):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1295,7 +1295,7 @@ class _Frame(Base):
                  num.max(split_every=split_every)]
         stats_names = [(s._name, 0) for s in stats]
 
-        name = 'describe--' + tokenize(self)
+        name = 'describe--' + tokenize(self, split_every)
         dsk = merge(num.dask, *(s.dask for s in stats))
         dsk[(name, 0)] = (methods.describe_aggregate, (list, stats_names))
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -632,7 +632,7 @@ class _Frame(Base):
             for i in range(npartitions):
                 dsk[(name_p, i)] = (M.head, (self._name, i), n)
 
-            concat = (_concat, ([(name_p, i) for i in range(npartitions)]))
+            concat = (_concat, [(name_p, i) for i in range(npartitions)])
             dsk[(name, 0)] = (safe_head, concat, n)
         else:
             dsk = {(name, 0): (safe_head, (self._name, 0), n)}
@@ -2733,7 +2733,7 @@ def apply_concat_apply(args, chunk=None, aggregate=None, combine=None,
     while k > split_every:
         b = prefix + str(depth)
         for part_i, inds in enumerate(partition_all(split_every, range(k))):
-            conc = (_concat, (list, [(a, i) for i in inds]))
+            conc = (_concat, [(a, i) for i in inds])
             if combine_kwargs:
                 dsk[(b, part_i)] = (apply, combine, [conc], combine_kwargs)
             else:
@@ -2744,7 +2744,7 @@ def apply_concat_apply(args, chunk=None, aggregate=None, combine=None,
 
     # Aggregate
     b = '{0}-agg-{1}'.format(token or funcname(aggregate), token_key)
-    conc = (_concat, (list, [(a, i) for i in range(k)]))
+    conc = (_concat, [(a, i) for i in range(k)])
     if aggregate_kwargs:
         dsk[(b, 0)] = (apply, aggregate, [conc], aggregate_kwargs)
     else:

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -66,6 +66,10 @@ def unique(x, series_name=None):
     return pd.Series(pd.Series.unique(x), name=series_name)
 
 
+def value_counts_combine(x):
+    return x.groupby(level=0).sum()
+
+
 def value_counts_aggregate(x):
     return x.groupby(level=0).sum().sort_values(ascending=False)
 

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -834,13 +834,20 @@ def test_reductions_frame(split_every):
     assert_dask_graph(ddf1.mean(split_every=split_every), 'dataframe-count')
 
     # axis=1
-    assert_dask_graph(ddf1.sum(axis=1, split_every=split_every), 'dataframe-sum')
-    assert_dask_graph(ddf1.min(axis=1, split_every=split_every), 'dataframe-min')
-    assert_dask_graph(ddf1.max(axis=1, split_every=split_every), 'dataframe-max')
-    assert_dask_graph(ddf1.count(axis=1, split_every=split_every), 'dataframe-count')
-    assert_dask_graph(ddf1.std(axis=1, split_every=split_every), 'dataframe-std')
-    assert_dask_graph(ddf1.var(axis=1, split_every=split_every), 'dataframe-var')
-    assert_dask_graph(ddf1.mean(axis=1, split_every=split_every), 'dataframe-mean')
+    assert_dask_graph(ddf1.sum(axis=1, split_every=split_every),
+                      'dataframe-sum')
+    assert_dask_graph(ddf1.min(axis=1, split_every=split_every),
+                      'dataframe-min')
+    assert_dask_graph(ddf1.max(axis=1, split_every=split_every),
+                      'dataframe-max')
+    assert_dask_graph(ddf1.count(axis=1, split_every=split_every),
+                      'dataframe-count')
+    assert_dask_graph(ddf1.std(axis=1, split_every=split_every),
+                      'dataframe-std')
+    assert_dask_graph(ddf1.var(axis=1, split_every=split_every),
+                      'dataframe-var')
+    assert_dask_graph(ddf1.mean(axis=1, split_every=split_every),
+                      'dataframe-mean')
 
 
 def test_reductions_frame_dtypes():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -467,7 +467,9 @@ def test_groupby_reduction_split_every():
               'var', 'std']:
         res = call(ddf.a.groupby(ddf.b), m, split_every=2)
         sol = call(pdf.a.groupby(pdf.b), m)
-        assert_eq(res, sol)
+        # There's a bug in pandas 0.18.0 with `pdf.a.groupby(pdf.b).count()`
+        # not forwarding the series name. Skip name checks here for now.
+        assert_eq(res, sol, check_names=False)
         assert call(ddf.a.groupby(ddf.b), m)._name != res._name
 
     res = call(ddf.a.groupby(ddf.b), 'var', split_every=2, ddof=2)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -297,138 +297,183 @@ def test_groupby_set_index():
 
 
 def test_split_apply_combine_on_series():
-    pdf1 = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7],
-                         'b': [4, 2, 7, 3, 3, 1, 1, 1, 2]},
-                        index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
-    ddf = dd.from_pandas(pdf1, npartitions=3)
-    ddf1 = ddf
+    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7],
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2]},
+                       index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
+    ddf = dd.from_pandas(pdf, npartitions=3)
 
-    for ddkey, pdkey in [('b', 'b'), (ddf1.b, pdf1.b),
-                         (ddf1.b + 1, pdf1.b + 1)]:
-        assert_eq(ddf1.groupby(ddkey).a.min(), pdf1.groupby(pdkey).a.min())
-        assert_eq(ddf1.groupby(ddkey).a.max(), pdf1.groupby(pdkey).a.max())
-        assert_eq(ddf1.groupby(ddkey).a.count(), pdf1.groupby(pdkey).a.count())
-        assert_eq(ddf1.groupby(ddkey).a.mean(), pdf1.groupby(pdkey).a.mean())
-        assert_eq(ddf1.groupby(ddkey).a.nunique(), pdf1.groupby(pdkey).a.nunique())
-        assert_eq(ddf1.groupby(ddkey).a.size(), pdf1.groupby(pdkey).a.size())
+    for ddkey, pdkey in [('b', 'b'), (ddf.b, pdf.b), (ddf.b + 1, pdf.b + 1)]:
+        assert_eq(ddf.groupby(ddkey).a.min(), pdf.groupby(pdkey).a.min())
+        assert_eq(ddf.groupby(ddkey).a.max(), pdf.groupby(pdkey).a.max())
+        assert_eq(ddf.groupby(ddkey).a.count(), pdf.groupby(pdkey).a.count())
+        assert_eq(ddf.groupby(ddkey).a.mean(), pdf.groupby(pdkey).a.mean())
+        assert_eq(ddf.groupby(ddkey).a.nunique(), pdf.groupby(pdkey).a.nunique())
+        assert_eq(ddf.groupby(ddkey).a.size(), pdf.groupby(pdkey).a.size())
         for ddof in [0, 1, 2]:
-            assert_eq(ddf1.groupby(ddkey).a.var(ddof),
-                      pdf1.groupby(pdkey).a.var(ddof))
-            assert_eq(ddf1.groupby(ddkey).a.std(ddof),
-                      pdf1.groupby(pdkey).a.std(ddof))
+            assert_eq(ddf.groupby(ddkey).a.var(ddof),
+                      pdf.groupby(pdkey).a.var(ddof))
+            assert_eq(ddf.groupby(ddkey).a.std(ddof),
+                      pdf.groupby(pdkey).a.std(ddof))
 
-        assert_eq(ddf1.groupby(ddkey).sum(), pdf1.groupby(pdkey).sum())
-        assert_eq(ddf1.groupby(ddkey).min(), pdf1.groupby(pdkey).min())
-        assert_eq(ddf1.groupby(ddkey).max(), pdf1.groupby(pdkey).max())
-        assert_eq(ddf1.groupby(ddkey).count(), pdf1.groupby(pdkey).count())
-        assert_eq(ddf1.groupby(ddkey).mean(), pdf1.groupby(pdkey).mean())
-        assert_eq(ddf1.groupby(ddkey).size(), pdf1.groupby(pdkey).size())
+        assert_eq(ddf.groupby(ddkey).sum(), pdf.groupby(pdkey).sum())
+        assert_eq(ddf.groupby(ddkey).min(), pdf.groupby(pdkey).min())
+        assert_eq(ddf.groupby(ddkey).max(), pdf.groupby(pdkey).max())
+        assert_eq(ddf.groupby(ddkey).count(), pdf.groupby(pdkey).count())
+        assert_eq(ddf.groupby(ddkey).mean(), pdf.groupby(pdkey).mean())
+        assert_eq(ddf.groupby(ddkey).size(), pdf.groupby(pdkey).size())
         for ddof in [0, 1, 2]:
-            assert_eq(ddf1.groupby(ddkey).var(ddof),
-                      pdf1.groupby(pdkey).var(ddof), check_dtype=False)
-            assert_eq(ddf1.groupby(ddkey).std(ddof),
-                      pdf1.groupby(pdkey).std(ddof), check_dtype=False)
+            assert_eq(ddf.groupby(ddkey).var(ddof),
+                      pdf.groupby(pdkey).var(ddof), check_dtype=False)
+            assert_eq(ddf.groupby(ddkey).std(ddof),
+                      pdf.groupby(pdkey).std(ddof), check_dtype=False)
 
-    for ddkey, pdkey in [(ddf1.b, pdf1.b), (ddf1.b + 1, pdf1.b + 1)]:
-        assert_eq(ddf1.a.groupby(ddkey).sum(), pdf1.a.groupby(pdkey).sum(), check_names=False)
-        assert_eq(ddf1.a.groupby(ddkey).max(), pdf1.a.groupby(pdkey).max(), check_names=False)
-        assert_eq(ddf1.a.groupby(ddkey).count(), pdf1.a.groupby(pdkey).count(), check_names=False)
-        assert_eq(ddf1.a.groupby(ddkey).mean(), pdf1.a.groupby(pdkey).mean(), check_names=False)
-        assert_eq(ddf1.a.groupby(ddkey).nunique(), pdf1.a.groupby(pdkey).nunique(), check_names=False)
+    for ddkey, pdkey in [(ddf.b, pdf.b), (ddf.b + 1, pdf.b + 1)]:
+        assert_eq(ddf.a.groupby(ddkey).sum(), pdf.a.groupby(pdkey).sum(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).max(), pdf.a.groupby(pdkey).max(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).count(), pdf.a.groupby(pdkey).count(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).mean(), pdf.a.groupby(pdkey).mean(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).nunique(), pdf.a.groupby(pdkey).nunique(), check_names=False)
         for ddof in [0, 1, 2]:
-            assert_eq(ddf1.a.groupby(ddkey).var(ddof),
-                      pdf1.a.groupby(pdkey).var(ddof))
-            assert_eq(ddf1.a.groupby(ddkey).std(ddof),
-                      pdf1.a.groupby(pdkey).std(ddof))
+            assert_eq(ddf.a.groupby(ddkey).var(ddof),
+                      pdf.a.groupby(pdkey).var(ddof))
+            assert_eq(ddf.a.groupby(ddkey).std(ddof),
+                      pdf.a.groupby(pdkey).std(ddof))
 
-    for i in range(8):
-        assert_eq(ddf1.groupby(ddf1.b > i).a.sum(), pdf1.groupby(pdf1.b > i).a.sum())
-        assert_eq(ddf1.groupby(ddf1.b > i).a.min(), pdf1.groupby(pdf1.b > i).a.min())
-        assert_eq(ddf1.groupby(ddf1.b > i).a.max(), pdf1.groupby(pdf1.b > i).a.max())
-        assert_eq(ddf1.groupby(ddf1.b > i).a.count(), pdf1.groupby(pdf1.b > i).a.count())
-        assert_eq(ddf1.groupby(ddf1.b > i).a.mean(), pdf1.groupby(pdf1.b > i).a.mean())
-        assert_eq(ddf1.groupby(ddf1.b > i).a.nunique(), pdf1.groupby(pdf1.b > i).a.nunique())
-        assert_eq(ddf1.groupby(ddf1.b > i).a.size(), pdf1.groupby(pdf1.b > i).a.size())
+    for i in [0, 4, 7]:
+        assert_eq(ddf.groupby(ddf.b > i).a.sum(), pdf.groupby(pdf.b > i).a.sum())
+        assert_eq(ddf.groupby(ddf.b > i).a.min(), pdf.groupby(pdf.b > i).a.min())
+        assert_eq(ddf.groupby(ddf.b > i).a.max(), pdf.groupby(pdf.b > i).a.max())
+        assert_eq(ddf.groupby(ddf.b > i).a.count(), pdf.groupby(pdf.b > i).a.count())
+        assert_eq(ddf.groupby(ddf.b > i).a.mean(), pdf.groupby(pdf.b > i).a.mean())
+        assert_eq(ddf.groupby(ddf.b > i).a.nunique(), pdf.groupby(pdf.b > i).a.nunique())
+        assert_eq(ddf.groupby(ddf.b > i).a.size(), pdf.groupby(pdf.b > i).a.size())
 
-        assert_eq(ddf1.groupby(ddf1.a > i).b.sum(), pdf1.groupby(pdf1.a > i).b.sum())
-        assert_eq(ddf1.groupby(ddf1.a > i).b.min(), pdf1.groupby(pdf1.a > i).b.min())
-        assert_eq(ddf1.groupby(ddf1.a > i).b.max(), pdf1.groupby(pdf1.a > i).b.max())
-        assert_eq(ddf1.groupby(ddf1.a > i).b.count(), pdf1.groupby(pdf1.a > i).b.count())
-        assert_eq(ddf1.groupby(ddf1.a > i).b.mean(), pdf1.groupby(pdf1.a > i).b.mean())
-        assert_eq(ddf1.groupby(ddf1.a > i).b.nunique(), pdf1.groupby(pdf1.a > i).b.nunique())
-        assert_eq(ddf1.groupby(ddf1.b > i).b.size(), pdf1.groupby(pdf1.b > i).b.size())
+        assert_eq(ddf.groupby(ddf.a > i).b.sum(), pdf.groupby(pdf.a > i).b.sum())
+        assert_eq(ddf.groupby(ddf.a > i).b.min(), pdf.groupby(pdf.a > i).b.min())
+        assert_eq(ddf.groupby(ddf.a > i).b.max(), pdf.groupby(pdf.a > i).b.max())
+        assert_eq(ddf.groupby(ddf.a > i).b.count(), pdf.groupby(pdf.a > i).b.count())
+        assert_eq(ddf.groupby(ddf.a > i).b.mean(), pdf.groupby(pdf.a > i).b.mean())
+        assert_eq(ddf.groupby(ddf.a > i).b.nunique(), pdf.groupby(pdf.a > i).b.nunique())
+        assert_eq(ddf.groupby(ddf.b > i).b.size(), pdf.groupby(pdf.b > i).b.size())
 
-        assert_eq(ddf1.groupby(ddf1.b > i).sum(), pdf1.groupby(pdf1.b > i).sum())
-        assert_eq(ddf1.groupby(ddf1.b > i).min(), pdf1.groupby(pdf1.b > i).min())
-        assert_eq(ddf1.groupby(ddf1.b > i).max(), pdf1.groupby(pdf1.b > i).max())
-        assert_eq(ddf1.groupby(ddf1.b > i).count(), pdf1.groupby(pdf1.b > i).count())
-        assert_eq(ddf1.groupby(ddf1.b > i).mean(), pdf1.groupby(pdf1.b > i).mean())
-        assert_eq(ddf1.groupby(ddf1.b > i).size(), pdf1.groupby(pdf1.b > i).size())
+        assert_eq(ddf.groupby(ddf.b > i).sum(), pdf.groupby(pdf.b > i).sum())
+        assert_eq(ddf.groupby(ddf.b > i).min(), pdf.groupby(pdf.b > i).min())
+        assert_eq(ddf.groupby(ddf.b > i).max(), pdf.groupby(pdf.b > i).max())
+        assert_eq(ddf.groupby(ddf.b > i).count(), pdf.groupby(pdf.b > i).count())
+        assert_eq(ddf.groupby(ddf.b > i).mean(), pdf.groupby(pdf.b > i).mean())
+        assert_eq(ddf.groupby(ddf.b > i).size(), pdf.groupby(pdf.b > i).size())
 
-        assert_eq(ddf1.groupby(ddf1.a > i).sum(), pdf1.groupby(pdf1.a > i).sum())
-        assert_eq(ddf1.groupby(ddf1.a > i).min(), pdf1.groupby(pdf1.a > i).min())
-        assert_eq(ddf1.groupby(ddf1.a > i).max(), pdf1.groupby(pdf1.a > i).max())
-        assert_eq(ddf1.groupby(ddf1.a > i).count(), pdf1.groupby(pdf1.a > i).count())
-        assert_eq(ddf1.groupby(ddf1.a > i).mean(), pdf1.groupby(pdf1.a > i).mean())
-        assert_eq(ddf1.groupby(ddf1.a > i).size(), pdf1.groupby(pdf1.a > i).size())
+        assert_eq(ddf.groupby(ddf.a > i).sum(), pdf.groupby(pdf.a > i).sum())
+        assert_eq(ddf.groupby(ddf.a > i).min(), pdf.groupby(pdf.a > i).min())
+        assert_eq(ddf.groupby(ddf.a > i).max(), pdf.groupby(pdf.a > i).max())
+        assert_eq(ddf.groupby(ddf.a > i).count(), pdf.groupby(pdf.a > i).count())
+        assert_eq(ddf.groupby(ddf.a > i).mean(), pdf.groupby(pdf.a > i).mean())
+        assert_eq(ddf.groupby(ddf.a > i).size(), pdf.groupby(pdf.a > i).size())
 
         for ddof in [0, 1, 2]:
-            assert_eq(ddf1.groupby(ddf1.b > i).std(ddof),
-                      pdf1.groupby(pdf1.b > i).std(ddof))
+            assert_eq(ddf.groupby(ddf.b > i).std(ddof),
+                      pdf.groupby(pdf.b > i).std(ddof))
 
-    for ddkey, pdkey in [('a', 'a'), (ddf1.a, pdf1.a),
-                         (ddf1.a + 1, pdf1.a + 1), (ddf1.a > 3, pdf1.a > 3)]:
-        assert_eq(ddf1.groupby(ddkey).b.sum(), pdf1.groupby(pdkey).b.sum())
-        assert_eq(ddf1.groupby(ddkey).b.min(), pdf1.groupby(pdkey).b.min())
-        assert_eq(ddf1.groupby(ddkey).b.max(), pdf1.groupby(pdkey).b.max())
-        assert_eq(ddf1.groupby(ddkey).b.count(), pdf1.groupby(pdkey).b.count())
-        assert_eq(ddf1.groupby(ddkey).b.mean(), pdf1.groupby(pdkey).b.mean())
-        assert_eq(ddf1.groupby(ddkey).b.nunique(), pdf1.groupby(pdkey).b.nunique())
-        assert_eq(ddf1.groupby(ddkey).b.size(), pdf1.groupby(pdkey).b.size())
+    for ddkey, pdkey in [('a', 'a'), (ddf.a, pdf.a),
+                         (ddf.a + 1, pdf.a + 1), (ddf.a > 3, pdf.a > 3)]:
+        assert_eq(ddf.groupby(ddkey).b.sum(), pdf.groupby(pdkey).b.sum())
+        assert_eq(ddf.groupby(ddkey).b.min(), pdf.groupby(pdkey).b.min())
+        assert_eq(ddf.groupby(ddkey).b.max(), pdf.groupby(pdkey).b.max())
+        assert_eq(ddf.groupby(ddkey).b.count(), pdf.groupby(pdkey).b.count())
+        assert_eq(ddf.groupby(ddkey).b.mean(), pdf.groupby(pdkey).b.mean())
+        assert_eq(ddf.groupby(ddkey).b.nunique(), pdf.groupby(pdkey).b.nunique())
+        assert_eq(ddf.groupby(ddkey).b.size(), pdf.groupby(pdkey).b.size())
 
-        assert_eq(ddf1.groupby(ddkey).sum(), pdf1.groupby(pdkey).sum())
-        assert_eq(ddf1.groupby(ddkey).min(), pdf1.groupby(pdkey).min())
-        assert_eq(ddf1.groupby(ddkey).max(), pdf1.groupby(pdkey).max())
-        assert_eq(ddf1.groupby(ddkey).count(), pdf1.groupby(pdkey).count())
-        assert_eq(ddf1.groupby(ddkey).mean(), pdf1.groupby(pdkey).mean().astype(float))
-        assert_eq(ddf1.groupby(ddkey).size(), pdf1.groupby(pdkey).size())
+        assert_eq(ddf.groupby(ddkey).sum(), pdf.groupby(pdkey).sum())
+        assert_eq(ddf.groupby(ddkey).min(), pdf.groupby(pdkey).min())
+        assert_eq(ddf.groupby(ddkey).max(), pdf.groupby(pdkey).max())
+        assert_eq(ddf.groupby(ddkey).count(), pdf.groupby(pdkey).count())
+        assert_eq(ddf.groupby(ddkey).mean(), pdf.groupby(pdkey).mean().astype(float))
+        assert_eq(ddf.groupby(ddkey).size(), pdf.groupby(pdkey).size())
 
         for ddof in [0, 1, 2]:
-            assert_eq(ddf1.groupby(ddkey).b.std(ddof),
-                      pdf1.groupby(pdkey).b.std(ddof))
+            assert_eq(ddf.groupby(ddkey).b.std(ddof),
+                      pdf.groupby(pdkey).b.std(ddof))
 
-    assert (sorted(ddf1.groupby('b').a.sum().dask) ==
-            sorted(ddf1.groupby('b').a.sum().dask))
-    assert (sorted(ddf1.groupby(ddf1.a > 3).b.mean().dask) ==
-            sorted(ddf1.groupby(ddf1.a > 3).b.mean().dask))
+    assert (sorted(ddf.groupby('b').a.sum().dask) ==
+            sorted(ddf.groupby('b').a.sum().dask))
+    assert (sorted(ddf.groupby(ddf.a > 3).b.mean().dask) ==
+            sorted(ddf.groupby(ddf.a > 3).b.mean().dask))
 
     # test raises with incorrect key
-    assert raises(KeyError, lambda: ddf1.groupby('x'))
-    assert raises(KeyError, lambda: ddf1.groupby(['a', 'x']))
-    assert raises(KeyError, lambda: ddf1.groupby('a')['x'])
-    assert raises(KeyError, lambda: ddf1.groupby('a')['b', 'x'])
-    assert raises(KeyError, lambda: ddf1.groupby('a')[['b', 'x']])
+    assert raises(KeyError, lambda: ddf.groupby('x'))
+    assert raises(KeyError, lambda: ddf.groupby(['a', 'x']))
+    assert raises(KeyError, lambda: ddf.groupby('a')['x'])
+    assert raises(KeyError, lambda: ddf.groupby('a')['b', 'x'])
+    assert raises(KeyError, lambda: ddf.groupby('a')[['b', 'x']])
 
     # test graph node labels
-    assert_dask_graph(ddf1.groupby('b').a.sum(), 'series-groupby-sum')
-    assert_dask_graph(ddf1.groupby('b').a.min(), 'series-groupby-min')
-    assert_dask_graph(ddf1.groupby('b').a.max(), 'series-groupby-max')
-    assert_dask_graph(ddf1.groupby('b').a.count(), 'series-groupby-count')
-    assert_dask_graph(ddf1.groupby('b').a.var(), 'series-groupby-var')
+    assert_dask_graph(ddf.groupby('b').a.sum(), 'series-groupby-sum')
+    assert_dask_graph(ddf.groupby('b').a.min(), 'series-groupby-min')
+    assert_dask_graph(ddf.groupby('b').a.max(), 'series-groupby-max')
+    assert_dask_graph(ddf.groupby('b').a.count(), 'series-groupby-count')
+    assert_dask_graph(ddf.groupby('b').a.var(), 'series-groupby-var')
     # mean consists from sum and count operations
-    assert_dask_graph(ddf1.groupby('b').a.mean(), 'series-groupby-sum')
-    assert_dask_graph(ddf1.groupby('b').a.mean(), 'series-groupby-count')
-    assert_dask_graph(ddf1.groupby('b').a.nunique(), 'series-groupby-nunique')
-    assert_dask_graph(ddf1.groupby('b').a.size(), 'series-groupby-size')
+    assert_dask_graph(ddf.groupby('b').a.mean(), 'series-groupby-sum')
+    assert_dask_graph(ddf.groupby('b').a.mean(), 'series-groupby-count')
+    assert_dask_graph(ddf.groupby('b').a.nunique(), 'series-groupby-nunique')
+    assert_dask_graph(ddf.groupby('b').a.size(), 'series-groupby-size')
 
-    assert_dask_graph(ddf1.groupby('b').sum(), 'dataframe-groupby-sum')
-    assert_dask_graph(ddf1.groupby('b').min(), 'dataframe-groupby-min')
-    assert_dask_graph(ddf1.groupby('b').max(), 'dataframe-groupby-max')
-    assert_dask_graph(ddf1.groupby('b').count(), 'dataframe-groupby-count')
+    assert_dask_graph(ddf.groupby('b').sum(), 'dataframe-groupby-sum')
+    assert_dask_graph(ddf.groupby('b').min(), 'dataframe-groupby-min')
+    assert_dask_graph(ddf.groupby('b').max(), 'dataframe-groupby-max')
+    assert_dask_graph(ddf.groupby('b').count(), 'dataframe-groupby-count')
     # mean consists from sum and count operations
-    assert_dask_graph(ddf1.groupby('b').mean(), 'dataframe-groupby-sum')
-    assert_dask_graph(ddf1.groupby('b').mean(), 'dataframe-groupby-count')
-    assert_dask_graph(ddf1.groupby('b').size(), 'dataframe-groupby-size')
+    assert_dask_graph(ddf.groupby('b').mean(), 'dataframe-groupby-sum')
+    assert_dask_graph(ddf.groupby('b').mean(), 'dataframe-groupby-count')
+    assert_dask_graph(ddf.groupby('b').size(), 'dataframe-groupby-size')
+
+
+def test_groupby_reduction_split_every():
+    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 100,
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100})
+    ddf = dd.from_pandas(pdf, npartitions=15)
+
+    def call(g, m, **kwargs):
+        return getattr(g, m)(**kwargs)
+
+    # DataFrame
+    for m in ['sum', 'min', 'max', 'count', 'mean', 'size', 'var', 'std']:
+        res = call(ddf.groupby('b'), m, split_every=2)
+        sol = call(pdf.groupby('b'), m)
+        assert_eq(res, sol)
+        assert call(ddf.groupby('b'), m)._name != res._name
+
+    res = call(ddf.groupby('b'), 'var', split_every=2, ddof=2)
+    sol = call(pdf.groupby('b'), 'var', ddof=2)
+    assert_eq(res, sol)
+    assert call(ddf.groupby('b'), 'var', ddof=2)._name != res._name
+
+    # Series, post select
+    for m in ['sum', 'min', 'max', 'count', 'mean', 'nunique', 'size',
+              'var', 'std']:
+        res = call(ddf.groupby('b').a, m, split_every=2)
+        sol = call(pdf.groupby('b').a, m)
+        assert_eq(res, sol)
+        assert call(ddf.groupby('b').a, m)._name != res._name
+
+    res = call(ddf.groupby('b').a, 'var', split_every=2, ddof=2)
+    sol = call(pdf.groupby('b').a, 'var', ddof=2)
+    assert_eq(res, sol)
+    assert call(ddf.groupby('b').a, 'var', ddof=2)._name != res._name
+
+    # Series, pre select
+    for m in ['sum', 'min', 'max', 'count', 'mean', 'nunique', 'size',
+              'var', 'std']:
+        res = call(ddf.a.groupby(ddf.b), m, split_every=2)
+        sol = call(pdf.a.groupby(pdf.b), m)
+        assert_eq(res, sol)
+        assert call(ddf.a.groupby(ddf.b), m)._name != res._name
+
+    res = call(ddf.a.groupby(ddf.b), 'var', split_every=2, ddof=2)
+    sol = call(pdf.a.groupby(pdf.b), 'var', ddof=2)
+    assert_eq(res, sol)
+    assert call(ddf.a.groupby(ddf.b), 'var', ddof=2)._name != res._name
 
 
 def test_apply_shuffle():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -15,6 +15,7 @@ import pandas.util.testing as tm
 from pandas.core.common import is_datetime64tz_dtype
 import toolz
 
+from ..core import get_deps
 from ..async import get_sync
 
 
@@ -524,3 +525,11 @@ def assert_dask_dtypes(ddf, res, numeric_equal=True):
             assert (a.kind in eq_types and b.kind in eq_types) or (a == b)
         else:
             assert type(ddf._meta) == type(res)
+
+
+def assert_max_deps(x, n, eq=True):
+    dependencies, dependents = get_deps(x.dask)
+    if eq:
+        assert max(map(len, dependencies.values())) == n
+    else:
+        assert max(map(len, dependencies.values())) <= n


### PR DESCRIPTION
This adds tree reductions to `dask.dataframe`, allowing for more efficient reductions on dataframes with many partitions. All relevant methods now include an optional keyword `split_every`, which indicates the max number of intermediates to bring together before reducing. The default is 8. The `reduction` method (and the less publicly used `apply_concat_apply` function) also take an optional `combine` function, to do the intermediate aggregations, before passing to `aggregate` for the final reduction.

Fixes #1658.

Todo:
- [x] methods in `groupby` support tree reductions
- [x] tests

~~[ ] `cov_corr` supports tree reductions~~
~~[ ] `quantile` supports tree reductions~~ (to be done later, see #1672)