### PR TITLE
ENH: add dd.pivot_table

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -13,5 +13,5 @@ from .rolling import (rolling_count, rolling_sum, rolling_mean, rolling_median,
                       rolling_window)
 from ..base import compute
 from .csv import read_csv
-from .reshape import get_dummies
+from .reshape import get_dummies, pivot_table
 from . import demo

--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -4,13 +4,6 @@ import pandas as pd
 from toolz import partial
 
 from dask.base import compute
-from .utils import PANDAS_VERSION
-
-
-if PANDAS_VERSION >= '0.19.0':
-    from pandas.api.types import is_categorical_dtype        # noqa
-else:
-    from pandas.core.common import is_categorical_dtype      # noqa
 
 
 def _categorize_block(df, categories):

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -76,3 +76,22 @@ def nbytes(x):
 
 def size(x):
     return x.size
+
+
+# ---------------------------------
+# reshape
+# ---------------------------------
+
+
+def pivot_agg(df):
+    return df.groupby(level=0).sum()
+
+
+def pivot_sum(df, index, columns, values):
+    return pd.pivot_table(df, index=index, columns=columns,
+                          values=values, aggfunc='sum')
+
+
+def pivot_count(df, index, columns, values):
+    return pd.pivot_table(df, index=index, columns=columns,
+                          values=values, aggfunc='count')

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -87,15 +87,15 @@ def pivot_table(df, index=None, columns=None,
     """
 
     if not is_scalar(index) or index is None:
-        raise ValueError("'index' must be a scalar")
+        raise ValueError("'index' must be the name of an existing column")
     if not is_scalar(columns) or columns is None:
-        raise ValueError("'columns' must be a scalar")
+        raise ValueError("'columns' must be the name of an existing column")
     if not is_categorical_dtype(df[columns]):
         raise ValueError("'columns' must be category dtype")
     if not is_scalar(values) or values is None:
-        raise ValueError("'values' must be a scalar")
+        raise ValueError("'values' must be the name of an existing column")
     if not is_scalar(aggfunc) or aggfunc not in ('mean', 'sum', 'count'):
-        raise ValueError("aggfunc must be either 'mean', 'sum', 'count'")
+        raise ValueError("aggfunc must be either 'mean', 'sum' or 'count'")
 
     # _emulate can't work for empty data
     # the result must have CategoricalIndex columns

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -8,8 +8,7 @@ import pytest
 import dask
 from dask.async import get_sync
 import dask.dataframe as dd
-from dask.dataframe.categorical import is_categorical_dtype
-from dask.dataframe.utils import make_meta, eq
+from dask.dataframe.utils import make_meta, eq, is_categorical_dtype
 
 
 @pytest.fixture(params=[True, False])

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -124,17 +124,17 @@ def test_pivot_table_errors():
                        'C': pd.Categorical(np.random.choice(list('abc'), size=10))})
     ddf = dd.from_pandas(df, 2)
 
-    msg = "'index' must be a scalar"
+    msg = "'index' must be the name of an existing column"
     with tm.assertRaisesRegexp(ValueError, msg):
         dd.pivot_table(ddf, index=['A'], columns='C', values='B')
-    msg = "'columns' must be a scalar"
+    msg = "'columns' must be the name of an existing column"
     with tm.assertRaisesRegexp(ValueError, msg):
         dd.pivot_table(ddf, index='A', columns=['C'], values='B')
-    msg = "'values' must be a scalar"
+    msg = "'values' must be the name of an existing column"
     with tm.assertRaisesRegexp(ValueError, msg):
         dd.pivot_table(ddf, index='A', columns='C', values=['B'])
 
-    msg = "aggfunc must be either 'mean', 'sum', 'count'"
+    msg = "aggfunc must be either 'mean', 'sum' or 'count'"
     with tm.assertRaisesRegexp(ValueError, msg):
         dd.pivot_table(ddf, index='A', columns='C', values='B', aggfunc=['sum'])
 

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -133,10 +133,11 @@ def test_pivot_table_errors():
     msg = "'values' must be a scalar"
     with tm.assertRaisesRegexp(ValueError, msg):
         dd.pivot_table(ddf, index='A', columns='C', values=['B'])
-    msg = "'aggfunc' must be a scalar"
+
+    msg = "aggfunc must be either 'mean', 'sum', 'count'"
     with tm.assertRaisesRegexp(ValueError, msg):
         dd.pivot_table(ddf, index='A', columns='C', values='B', aggfunc=['sum'])
-    msg = "aggfunc muset be either 'mean', 'sum', 'count'"
+
     with tm.assertRaisesRegexp(ValueError, msg):
         dd.pivot_table(ddf, index='A', columns='C', values='B', aggfunc='xx')
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pandas.util.testing as tm
 import dask.dataframe as dd
 from dask.dataframe.utils import (shard_df_on_index, meta_nonempty, make_meta,
                                   raise_on_meta_error)
@@ -125,6 +126,17 @@ def test_meta_nonempty():
     s = meta_nonempty(df2['A'])
     assert s.dtype == df2['A'].dtype
     assert (df3['A'] == s).all()
+
+
+def test_meta_duplicated():
+    df = pd.DataFrame(columns=['A', 'A', 'B'])
+    res = meta_nonempty(df)
+
+    exp = pd.DataFrame([['foo', 'foo', 'foo'],
+                        ['foo', 'foo', 'foo']],
+                       index=['a', 'b'],
+                       columns=['A', 'A', 'B'])
+    tm.assert_frame_equal(res, exp)
 
 
 def test_meta_nonempty_index():


### PR DESCRIPTION
Add ``dd.pivot_table`` which has following limitations compared to ``pd.pivot_table``.

- ``index``, ``columns``, ``values`` and ``aggfunc`` must be all scalar
- ``columns`` must be ``category`` dtype
- ``aggfunc`` must be either ``mean``, ``sum`` or ``count`` 

```
df = pd.DataFrame({'A': np.random.choice(list('abc'), size=100),
                   'B': np.random.randn(100),
                   'C': pd.Categorical(np.random.choice(list('abc'), size=100))})
ddf = dd.from_pandas(df, 3)

dd.pivot_table(ddf, index='A', columns='C', values='B', aggfunc='sum').compute()
# C         a         b         c
# A                              
# a -0.175581 -1.111197  2.238237
# b -1.974451  1.043855 -4.563244
# c -2.202667  1.232604 -0.559126
```
