### PR TITLE
Clear divisions on single_partitions_merge

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -310,9 +310,6 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
 def single_partition_join(left, right, **kwargs):
     # if the merge is perfomed on_index, divisions can be kept, otherwise the
     # new index will not necessarily correspond the current divisions
-    get_divisions = lambda divisions, on_index: (
-        divisions if on_index else [None for _ in divisions]
-    )
 
     meta = pd.merge(left._meta_nonempty, right._meta_nonempty, **kwargs)
     name = 'merge-' + tokenize(left, right, **kwargs)
@@ -321,14 +318,22 @@ def single_partition_join(left, right, **kwargs):
         dsk = dict(((name, i), (apply, pd.merge, [left_key, right_key],
                                 kwargs))
                    for i, right_key in enumerate(right._keys()))
-        divisions = get_divisions(right.divisions, kwargs.get('right_index'))
+
+        if kwargs.get('right_index'):
+            divisions = right.divisions
+        else:
+            divisions = [None for _ in right.divisions]
 
     elif right.npartitions == 1:
         right_key = first(right._keys())
         dsk = dict(((name, i), (apply, pd.merge, [left_key, right_key],
                                 kwargs))
                    for i, left_key in enumerate(left._keys()))
-        divisions = get_divisions(left.divisions, kwargs.get('left_index'))
+
+        if kwargs.get('left_index'):
+            divisions = left.divisions
+        else:
+            divisions = [None for _ in left.divisions]
 
     return DataFrame(toolz.merge(dsk, left.dask, right.dask), name,
                      meta, divisions)

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -322,6 +322,8 @@ def single_partition_join(left, right, **kwargs):
                                 kwargs))
                    for i, left_key in enumerate(left._keys()))
         divisions = left.divisions
+
+    divisions = [None for _ in divisions]
     return DataFrame(toolz.merge(dsk, left.dask, right.dask), name,
                      meta, divisions)
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -6,7 +6,7 @@ from dask.dataframe.multi import (align_partitions, merge_indexed_dataframes,
                                   _maybe_align_partitions)
 import pandas.util.testing as tm
 from dask.async import get_sync
-from dask.dataframe.utils import eq
+from dask.dataframe.utils import eq, assert_divisions
 
 import pytest
 
@@ -679,6 +679,18 @@ def test_cheap_single_partition_merge():
 
     list_eq(aa.merge(bb, on='x', how='inner'),
             a.merge(b, on='x', how='inner'))
+
+
+def test_cheap_single_partition_merge_divisions():
+    a = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': list('abdabd')},
+                     index=[10, 20, 30, 40, 50, 60])
+    aa = dd.from_pandas(a, npartitions=3)
+
+    b = pd.DataFrame({'x': [1, 2, 3, 4], 'z': list('abda')})
+    bb = dd.from_pandas(b, npartitions=1, sort=False)
+
+    assert_divisions(aa.merge(bb, on='x', how='inner'))
+    assert_divisions(bb.merge(aa, on='x', how='inner'))
 
 
 def test_merge_maintains_columns():

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -693,6 +693,20 @@ def test_cheap_single_partition_merge_divisions():
     assert_divisions(bb.merge(aa, on='x', how='inner'))
 
 
+def test_cheap_single_partition_merge_on_index():
+    a = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': list('abdabd')},
+                     index=[10, 20, 30, 40, 50, 60])
+    aa = dd.from_pandas(a, npartitions=3)
+
+    b = pd.DataFrame({'x': [1, 2, 3, 4], 'z': list('abda')})
+    bb = dd.from_pandas(b, npartitions=1, sort=False)
+
+    assert eq(aa.merge(bb, left_index=True, right_on='x', how='inner'),
+              a.merge(b, left_index=True, right_on='x', how='inner'))
+    assert eq(bb.merge(aa, right_index=True, left_on='x', how='inner'),
+              b.merge(a, right_index=True, left_on='x', how='inner'))
+
+
 def test_merge_maintains_columns():
     lhs = pd.DataFrame({'A': [1, 2, 3],
                         'B': list('abc'),

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -689,8 +689,13 @@ def test_cheap_single_partition_merge_divisions():
     b = pd.DataFrame({'x': [1, 2, 3, 4], 'z': list('abda')})
     bb = dd.from_pandas(b, npartitions=1, sort=False)
 
-    assert_divisions(aa.merge(bb, on='x', how='inner'))
-    assert_divisions(bb.merge(aa, on='x', how='inner'))
+    actual = aa.merge(bb, on='x', how='inner')
+    assert not actual.known_divisions
+    assert_divisions(actual)
+
+    actual = bb.merge(aa, on='x', how='inner')
+    assert not actual.known_divisions
+    assert_divisions(actual)
 
 
 def test_cheap_single_partition_merge_on_index():
@@ -701,10 +706,17 @@ def test_cheap_single_partition_merge_on_index():
     b = pd.DataFrame({'x': [1, 2, 3, 4], 'z': list('abda')})
     bb = dd.from_pandas(b, npartitions=1, sort=False)
 
-    assert eq(aa.merge(bb, left_index=True, right_on='x', how='inner'),
-              a.merge(b, left_index=True, right_on='x', how='inner'))
-    assert eq(bb.merge(aa, right_index=True, left_on='x', how='inner'),
-              b.merge(a, right_index=True, left_on='x', how='inner'))
+    actual = aa.merge(bb, left_index=True, right_on='x', how='inner')
+    expected = a.merge(b, left_index=True, right_on='x', how='inner')
+
+    assert actual.known_divisions
+    assert eq(actual, expected)
+
+    actual = bb.merge(aa, right_index=True, left_on='x', how='inner')
+    expected = b.merge(a, right_index=True, left_on='x', how='inner')
+
+    assert actual.known_divisions
+    assert eq(actual, expected)
 
 
 def test_merge_maintains_columns():


### PR DESCRIPTION
I ran into a problem when performing joins with small dataframes in my unittests using the eq helper, where assert_divisions raised an error. I belief the reason for this behavior to be, that the single partition merge copies the divisions from one dataframe. If I understand the division concept correctly, they give divisions of the index values. However, in general the index after a pandas merge is not related to the original index. Therefore, I belief that the divisions should be reset after a single partition merge.

I added a unittest that fails with dask head, but passes with an additional reset of the divisions.