### PR TITLE
ENH: da.ufuncs now supports DataFrame/Series

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -7,14 +7,15 @@ from .core import (Array, stack, concatenate, take, tensordot, transpose,
         digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
         from_delayed, round, swapaxes, repeat)
-from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,
+from .core import (around, isnull, notnull, isclose, eye, triu,
+                   tril, diag, corrcoef)
+from .ufunc import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,
         expm1, sqrt, square, sin, cos, tan, arcsin, arccos, arctan, arctan2,
         hypot, sinh, cosh, tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg,
         logical_and, logical_or, logical_xor, logical_not, maximum, minimum,
         fmax, fmin, isreal, iscomplex, isfinite, isinf, isnan, signbit,
         copysign, nextafter, ldexp, fmod, floor, ceil, trunc, degrees, radians,
-        rint, fix, angle, real, imag, clip, fabs, sign, absolute, frexp, modf,
-        around, isnull, notnull, isclose, eye, triu, tril, diag, corrcoef)
+        rint, fix, angle, real, imag, clip, fabs, sign, absolute, frexp, modf)
 from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
                          moment,
                          argmin, argmax,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -973,6 +973,10 @@ class Array(Base):
             x = np.array(x)
         return x
 
+    @property
+    def _elemwise_(self):
+        return elemwise
+
     @wraps(store)
     def store(self, target, **kwargs):
         return store([self], [target], **kwargs)
@@ -1549,17 +1553,21 @@ class Array(Base):
 
     @property
     def real(self):
+        from .ufunc import real
         return real(self)
 
     @property
     def imag(self):
+        from .ufunc import imag
         return imag(self)
 
     def conj(self):
+        from .ufunc import conj
         return conj(self)
 
     @wraps(np.clip)
     def clip(self, min=None, max=None):
+        from .ufunc import clip
         return clip(self, min, max)
 
     def view(self, dtype, order='C'):
@@ -2520,147 +2528,6 @@ def elemwise(op, *args, **kwargs):
         return atop(op, expr_inds,
                     *concat((a, tuple(range(a.ndim)[::-1])) for a in arrays),
                     dtype=dt, name=name)
-
-
-def wrap_elemwise(func, **kwargs):
-    """ Wrap up numpy function into dask.array """
-    f = partial(elemwise, func, **kwargs)
-    f.__doc__ = func.__doc__
-    f.__name__ = func.__name__
-    return f
-
-
-# ufuncs, copied from this page:
-# http://docs.scipy.org/doc/numpy/reference/ufuncs.html
-
-# math operations
-logaddexp = wrap_elemwise(np.logaddexp)
-logaddexp2 = wrap_elemwise(np.logaddexp2)
-conj = wrap_elemwise(np.conj)
-exp = wrap_elemwise(np.exp)
-log = wrap_elemwise(np.log)
-log2 = wrap_elemwise(np.log2)
-log10 = wrap_elemwise(np.log10)
-log1p = wrap_elemwise(np.log1p)
-expm1 = wrap_elemwise(np.expm1)
-sqrt = wrap_elemwise(np.sqrt)
-square = wrap_elemwise(np.square)
-
-# trigonometric functions
-sin = wrap_elemwise(np.sin)
-cos = wrap_elemwise(np.cos)
-tan = wrap_elemwise(np.tan)
-arcsin = wrap_elemwise(np.arcsin)
-arccos = wrap_elemwise(np.arccos)
-arctan = wrap_elemwise(np.arctan)
-arctan2 = wrap_elemwise(np.arctan2)
-hypot = wrap_elemwise(np.hypot)
-sinh = wrap_elemwise(np.sinh)
-cosh = wrap_elemwise(np.cosh)
-tanh = wrap_elemwise(np.tanh)
-arcsinh = wrap_elemwise(np.arcsinh)
-arccosh = wrap_elemwise(np.arccosh)
-arctanh = wrap_elemwise(np.arctanh)
-deg2rad = wrap_elemwise(np.deg2rad)
-rad2deg = wrap_elemwise(np.rad2deg)
-
-# comparison functions
-logical_and = wrap_elemwise(np.logical_and, dtype='bool')
-logical_or = wrap_elemwise(np.logical_or, dtype='bool')
-logical_xor = wrap_elemwise(np.logical_xor, dtype='bool')
-logical_not = wrap_elemwise(np.logical_not, dtype='bool')
-maximum = wrap_elemwise(np.maximum)
-minimum = wrap_elemwise(np.minimum)
-fmax = wrap_elemwise(np.fmax)
-fmin = wrap_elemwise(np.fmin)
-
-# floating functions
-isreal = wrap_elemwise(np.isreal, dtype='bool')
-iscomplex = wrap_elemwise(np.iscomplex, dtype='bool')
-isfinite = wrap_elemwise(np.isfinite, dtype='bool')
-isinf = wrap_elemwise(np.isinf, dtype='bool')
-isnan = wrap_elemwise(np.isnan, dtype='bool')
-signbit = wrap_elemwise(np.signbit, dtype='bool')
-copysign = wrap_elemwise(np.copysign)
-nextafter = wrap_elemwise(np.nextafter)
-# modf: see below
-ldexp = wrap_elemwise(np.ldexp)
-# frexp: see below
-fmod = wrap_elemwise(np.fmod)
-floor = wrap_elemwise(np.floor)
-ceil = wrap_elemwise(np.ceil)
-trunc = wrap_elemwise(np.trunc)
-
-# more math routines, from this page:
-# http://docs.scipy.org/doc/numpy/reference/routines.math.html
-degrees = wrap_elemwise(np.degrees)
-radians = wrap_elemwise(np.radians)
-
-rint = wrap_elemwise(np.rint)
-fix = wrap_elemwise(np.fix)
-
-angle = wrap_elemwise(np.angle)
-real = wrap_elemwise(np.real)
-imag = wrap_elemwise(np.imag)
-
-clip = wrap_elemwise(np.clip)
-fabs = wrap_elemwise(np.fabs)
-sign = wrap_elemwise(np.sign)
-absolute = wrap_elemwise(np.absolute)
-
-
-def frexp(x):
-    tmp = elemwise(np.frexp, x)
-    left = 'mantissa-' + tmp.name
-    right = 'exponent-' + tmp.name
-    ldsk = dict(((left,) + key[1:], (getitem, key, 0))
-                for key in core.flatten(tmp._keys()))
-    rdsk = dict(((right,) + key[1:], (getitem, key, 1))
-                for key in core.flatten(tmp._keys()))
-
-    if x._dtype is not None:
-        a = np.empty((1,), dtype=x._dtype)
-        l, r = np.frexp(a)
-        ldt = l.dtype
-        rdt = r.dtype
-    else:
-        ldt = None
-        rdt = None
-
-    L = Array(merge(tmp.dask, ldsk), left, chunks=tmp.chunks, dtype=ldt)
-
-    R = Array(merge(tmp.dask, rdsk), right, chunks=tmp.chunks, dtype=rdt)
-
-    return L, R
-
-frexp.__doc__ = np.frexp
-
-
-def modf(x):
-    tmp = elemwise(np.modf, x)
-    left = 'modf1-' + tmp.name
-    right = 'modf2-' + tmp.name
-    ldsk = dict(((left,) + key[1:], (getitem, key, 0))
-                for key in core.flatten(tmp._keys()))
-    rdsk = dict(((right,) + key[1:], (getitem, key, 1))
-                for key in core.flatten(tmp._keys()))
-
-    if x._dtype is not None:
-        a = np.empty((1,), dtype=x._dtype)
-        l, r = np.modf(a)
-        ldt = l.dtype
-        rdt = r.dtype
-    else:
-        ldt = None
-        rdt = None
-
-    L = Array(merge(tmp.dask, ldsk), left, chunks=tmp.chunks, dtype=ldt)
-
-    R = Array(merge(tmp.dask, rdsk), right, chunks=tmp.chunks, dtype=rdt)
-
-    return L, R
-
-modf.__doc__ = np.modf
 
 
 @wraps(np.around)
@@ -3679,6 +3546,9 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
 
 @wraps(np.corrcoef)
 def corrcoef(x, y=None, rowvar=1):
+
+    from .ufunc import sqrt
+
     c = cov(x, y, rowvar)
     if c.shape == ():
         return c / c

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2508,7 +2508,7 @@ def elemwise(op, *args, **kwargs):
         # https://github.com/numpy/numpy/issues/6240
         # We don't inspect the values of 0d dask arrays, because these could
         # hold potentially very expensive calculations.
-        vals = [np.empty((1, ) * a.ndim, dtype=a.dtype)
+        vals = [np.empty((1,) * a.ndim, dtype=a.dtype)
                 if not is_scalar_for_elemwise(a) else a
                 for a in args]
         try:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -974,7 +974,7 @@ class Array(Base):
         return x
 
     @property
-    def _elemwise_(self):
+    def _elemwise(self):
         return elemwise
 
     @wraps(store)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2508,7 +2508,7 @@ def elemwise(op, *args, **kwargs):
         # https://github.com/numpy/numpy/issues/6240
         # We don't inspect the values of 0d dask arrays, because these could
         # hold potentially very expensive calculations.
-        vals = [np.empty((1,) * a.ndim, dtype=a.dtype)
+        vals = [np.empty((1, ) * a.ndim, dtype=a.dtype)
                 if not is_scalar_for_elemwise(a) else a
                 for a in args]
         try:

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -9,7 +9,8 @@ import numpy as np
 from toolz import compose, partition_all, merge, get, accumulate, pluck
 
 from . import chunk
-from .core import _concatenate2, Array, atop, sqrt, lol_tuples
+from .core import _concatenate2, Array, atop, lol_tuples
+from .ufunc import sqrt
 from .numpy_compat import divide
 from ..compatibility import getargspec, builtins
 from ..base import tokenize

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -25,7 +25,7 @@ from dask.array import chunk
 from dask.array.core import (getem, getarray, getarray_nofancy, top, dotmany,
                              concatenate3, broadcast_dimensions, Array, stack,
                              concatenate, from_array, take, elemwise, isnull,
-                             notnull, broadcast_shapes, partial_by_order, exp,
+                             notnull, broadcast_shapes, partial_by_order,
                              tensordot, choose, where, coarsen, insert,
                              broadcast_to, reshape, fromfunction,
                              blockdims_from_blockshape, store, optimize,
@@ -507,7 +507,7 @@ def test_operators():
     expr = (3 / a * b)**2 > 5
     assert_eq(expr, (3 / x * y)**2 > 5)
 
-    c = exp(a)
+    c = da.exp(a)
     assert_eq(c, np.exp(x))
 
     assert_eq(abs(-a), a)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1295,18 +1295,6 @@ def test_arithmetic():
     assert_eq(da.around(a, -1), np.around(x, -1))
 
 
-def test_clip():
-    x = np.random.normal(0, 10, size=(10, 10))
-    d = da.from_array(x, chunks=(3, 4))
-
-    assert_eq(x.clip(5), d.clip(5))
-    assert_eq(x.clip(1, 5), d.clip(1, 5))
-    assert_eq(x.clip(min=5), d.clip(min=5))
-    assert_eq(x.clip(max=5), d.clip(max=5))
-    assert_eq(x.clip(max=1, min=5), d.clip(max=1, min=5))
-    assert_eq(x.clip(min=1, max=5), d.clip(min=1, max=5))
-
-
 def test_elemwise_consistent_names():
     a = da.from_array(np.arange(5, dtype='f4'), chunks=(2,))
     b = da.from_array(np.arange(5, dtype='f4'), chunks=(2,))

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -11,19 +11,27 @@ def test_ufunc_meta():
     assert da.log.__name__ == 'log'
     assert da.log.__doc__.replace('    # doctest: +SKIP', '') == np.log.__doc__
 
+    assert da.modf.__name__ == 'modf'
+    assert da.modf.__doc__.replace('    # doctest: +SKIP', '') == np.modf.__doc__
+
+    assert da.frexp.__name__ == 'frexp'
+    assert da.frexp.__doc__.replace('    # doctest: +SKIP', '') == np.frexp.__doc__
+
 
 @pytest.mark.parametrize('ufunc',
                          ['conj', 'exp', 'log', 'log2', 'log10', 'log1p',
                           'expm1', 'sqrt', 'square', 'sin', 'cos', 'tan',
                           'arctan', 'sinh', 'cosh', 'tanh',
-                          'arcsinh', 'arccosh', 'deg2rad', 'rad2deg'
-                          ])
+                          'arcsinh', 'arccosh', 'deg2rad', 'rad2deg',
+                          'isfinite', 'isinf', 'isnan', 'signbit',
+                          'degrees', 'radians', 'rint', 'fabs', 'sign', 'absolute',
+                          'floor', 'ceil', 'trunc', 'logical_not'])
 def test_ufunc(ufunc):
 
     dafunc = getattr(da, ufunc)
     npfunc = getattr(np, ufunc)
 
-    arr = np.random.randint(1, 100, size=20)
+    arr = np.random.randint(1, 100, size=(20, 20))
     darr = da.from_array(arr, 3)
 
     # applying Dask ufunc doesn't trigger computation
@@ -34,21 +42,25 @@ def test_ufunc(ufunc):
     assert isinstance(npfunc(darr), np.ndarray)
     assert_eq(npfunc(darr), npfunc(arr))
 
-    # applying Dask ufunc to normal Series triggers computation
+    # applying Dask ufunc to normal ndarray triggers computation
     assert isinstance(dafunc(arr), np.ndarray)
     assert_eq(dafunc(arr), npfunc(arr))
 
 
-@pytest.mark.parametrize('ufunc', ['logaddexp', 'arctan2', 'hypot'])
+@pytest.mark.parametrize('ufunc', ['logaddexp', 'logaddexp2', 'arctan2',
+                                   'hypot', 'copysign', 'nextafter', 'ldexp',
+                                   'fmod', 'logical_and', 'logical_or',
+                                   'logical_xor', 'maximum', 'minimum',
+                                   'fmax', 'fmin'])
 def test_ufunc_2args(ufunc):
 
     dafunc = getattr(da, ufunc)
     npfunc = getattr(np, ufunc)
 
-    arr1 = np.random.randint(1, 100, size=20)
+    arr1 = np.random.randint(1, 100, size=(20, 20))
     darr1 = da.from_array(arr1, 3)
 
-    arr2 = np.random.randint(1, 100, size=20)
+    arr2 = np.random.randint(1, 100, size=(20, 20))
     darr2 = da.from_array(arr2, 3)
 
     # applying Dask ufunc doesn't trigger computation
@@ -59,6 +71,84 @@ def test_ufunc_2args(ufunc):
     assert isinstance(npfunc(darr1, darr2), np.ndarray)
     assert_eq(npfunc(darr1, darr2), npfunc(arr1, arr2))
 
-    # applying Dask ufunc to normal Series triggers computation
+    # applying Dask ufunc to normal ndarray triggers computation
     assert isinstance(dafunc(arr1, arr2), np.ndarray)
     assert_eq(dafunc(arr1, arr2), npfunc(arr1, arr2))
+
+
+@pytest.mark.parametrize('ufunc', ['isreal', 'iscomplex', 'real', 'imag'])
+def test_complex(ufunc):
+
+    dafunc = getattr(da, ufunc)
+    npfunc = getattr(np, ufunc)
+
+    real = np.random.randint(1, 100, size=(20, 20))
+    imag = np.random.randint(1, 100, size=(20, 20)) * 1j
+    comp = real + imag
+
+    dareal = da.from_array(real, 3)
+    daimag = da.from_array(imag, 3)
+    dacomp = da.from_array(comp, 3)
+
+    assert_eq(dacomp.real, comp.real)
+    assert_eq(dacomp.imag, comp.imag)
+    assert_eq(dacomp.conj(), comp.conj())
+
+    for darr, arr in [(dacomp, comp), (dareal, real), (daimag, imag)]:
+        # applying Dask ufunc doesn't trigger computation
+        assert isinstance(dafunc(darr), da.Array)
+        assert_eq(dafunc(darr), npfunc(arr))
+
+        # applying NumPy ufunc triggers computation
+        assert isinstance(npfunc(darr), np.ndarray)
+        assert_eq(npfunc(darr), npfunc(arr))
+
+        # applying Dask ufunc to normal ndarray triggers computation
+        assert isinstance(dafunc(arr), np.ndarray)
+        assert_eq(dafunc(arr), npfunc(arr))
+
+
+@pytest.mark.parametrize('ufunc', ['frexp', 'modf'])
+def test_ufunc_2results(ufunc):
+
+    dafunc = getattr(da, ufunc)
+    npfunc = getattr(np, ufunc)
+
+    arr = np.random.randint(1, 100, size=(20, 20))
+    darr = da.from_array(arr, 3)
+
+    # applying Dask ufunc doesn't trigger computation
+    res1, res2 = dafunc(darr)
+    assert isinstance(res1, da.Array)
+    assert isinstance(res2, da.Array)
+    exp1, exp2 = npfunc(arr)
+    assert_eq(res1, exp1)
+    assert_eq(res2, exp2)
+
+    # applying NumPy ufunc triggers computation
+    res1, res2 = npfunc(darr)
+    assert isinstance(res1, np.ndarray)
+    assert isinstance(res2, np.ndarray)
+    exp1, exp2 = npfunc(arr)
+    assert_eq(res1, exp1)
+    assert_eq(res2, exp2)
+
+    # applying Dask ufunc to normal ndarray triggers computation
+    res1, res2 = npfunc(darr)
+    assert isinstance(res1, np.ndarray)
+    assert isinstance(res2, np.ndarray)
+    exp1, exp2 = npfunc(arr)
+    assert_eq(res1, exp1)
+    assert_eq(res2, exp2)
+
+
+def test_clip():
+    x = np.random.normal(0, 10, size=(10, 10))
+    d = da.from_array(x, chunks=(3, 4))
+
+    assert_eq(x.clip(5), d.clip(5))
+    assert_eq(x.clip(1, 5), d.clip(1, 5))
+    assert_eq(x.clip(min=5), d.clip(min=5))
+    assert_eq(x.clip(max=5), d.clip(max=5))
+    assert_eq(x.clip(max=1, min=5), d.clip(max=1, min=5))
+    assert_eq(x.clip(min=1, max=5), d.clip(min=1, max=5))

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+np = pytest.importorskip('numpy')
+
+import dask.array as da
+
+
+def test_ufunc_meta():
+    assert da.log.__name__ == 'log'
+    assert da.log.__doc__.replace('    # doctest: +SKIP', '') == np.log.__doc__

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -37,3 +37,28 @@ def test_ufunc(ufunc):
     # applying Dask ufunc to normal Series triggers computation
     assert isinstance(dafunc(arr), np.ndarray)
     assert_eq(dafunc(arr), npfunc(arr))
+
+
+@pytest.mark.parametrize('ufunc', ['logaddexp', 'arctan2', 'hypot'])
+def test_ufunc_2args(ufunc):
+
+    dafunc = getattr(da, ufunc)
+    npfunc = getattr(np, ufunc)
+
+    arr1 = np.random.randint(1, 100, size=20)
+    darr1 = da.from_array(arr1, 3)
+
+    arr2 = np.random.randint(1, 100, size=20)
+    darr2 = da.from_array(arr2, 3)
+
+    # applying Dask ufunc doesn't trigger computation
+    assert isinstance(dafunc(darr1, darr2), da.Array)
+    assert_eq(dafunc(darr1, darr2), npfunc(arr1, arr2))
+
+    # applying NumPy ufunc triggers computation
+    assert isinstance(npfunc(darr1, darr2), np.ndarray)
+    assert_eq(npfunc(darr1, darr2), npfunc(arr1, arr2))
+
+    # applying Dask ufunc to normal Series triggers computation
+    assert isinstance(dafunc(arr1, arr2), np.ndarray)
+    assert_eq(dafunc(arr1, arr2), npfunc(arr1, arr2))

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -4,8 +4,36 @@ import pytest
 np = pytest.importorskip('numpy')
 
 import dask.array as da
+from dask.array.utils import assert_eq
 
 
 def test_ufunc_meta():
     assert da.log.__name__ == 'log'
     assert da.log.__doc__.replace('    # doctest: +SKIP', '') == np.log.__doc__
+
+
+@pytest.mark.parametrize('ufunc',
+                         ['conj', 'exp', 'log', 'log2', 'log10', 'log1p',
+                          'expm1', 'sqrt', 'square', 'sin', 'cos', 'tan',
+                          'arctan', 'sinh', 'cosh', 'tanh',
+                          'arcsinh', 'arccosh', 'deg2rad', 'rad2deg'
+                          ])
+def test_ufunc(ufunc):
+
+    dafunc = getattr(da, ufunc)
+    npfunc = getattr(np, ufunc)
+
+    arr = np.random.randint(1, 100, size=20)
+    darr = da.from_array(arr, 3)
+
+    # applying Dask ufunc doesn't trigger computation
+    assert isinstance(dafunc(darr), da.Array)
+    assert_eq(dafunc(darr), npfunc(arr))
+
+    # applying NumPy ufunc triggers computation
+    assert isinstance(npfunc(darr), np.ndarray)
+    assert_eq(npfunc(darr), npfunc(arr))
+
+    # applying Dask ufunc to normal Series triggers computation
+    assert isinstance(dafunc(arr), np.ndarray)
+    assert_eq(dafunc(arr), npfunc(arr))

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -134,7 +134,7 @@ def frexp(x):
     R = Array(merge(tmp.dask, rdsk), right, chunks=tmp.chunks, dtype=rdt)
     return L, R
 
-frexp.__doc__ = np.frexp.__doc__
+frexp.__doc__ = skip_doctest(np.frexp.__doc__)
 
 
 def modf(x):
@@ -161,4 +161,4 @@ def modf(x):
 
     return L, R
 
-modf.__doc__ = np.modf.__doc__
+modf.__doc__ = skip_doctest(np.modf.__doc__)

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -10,12 +10,19 @@ from .. import core
 from ..utils import skip_doctest
 
 
-def wrap_elemwise(numpy_ufunc):
+def _array_wrap(numpy_ufunc, x, *args, **kwargs):
+    return x.__array_wrap__(numpy_ufunc(x, *args, **kwargs))
+
+
+def wrap_elemwise(numpy_ufunc, array_wrap=False):
     """ Wrap up numpy function into dask.array """
 
     def wrapped(x, *args, **kwargs):
         if hasattr(x, '_elemwise'):
-            return x._elemwise(numpy_ufunc, x, *args, **kwargs)
+            if array_wrap:
+                return x._elemwise(_array_wrap, numpy_ufunc, x, *args, **kwargs)
+            else:
+                return x._elemwise(numpy_ufunc, x, *args, **kwargs)
         else:
             return numpy_ufunc(x, *args, **kwargs)
 
@@ -70,8 +77,8 @@ fmax = wrap_elemwise(np.fmax)
 fmin = wrap_elemwise(np.fmin)
 
 # floating functions
-isreal = wrap_elemwise(np.isreal)
-iscomplex = wrap_elemwise(np.iscomplex)
+isreal = wrap_elemwise(np.isreal, array_wrap=True)
+iscomplex = wrap_elemwise(np.iscomplex, array_wrap=True)
 isfinite = wrap_elemwise(np.isfinite)
 isinf = wrap_elemwise(np.isinf)
 isnan = wrap_elemwise(np.isnan)
@@ -92,11 +99,11 @@ degrees = wrap_elemwise(np.degrees)
 radians = wrap_elemwise(np.radians)
 
 rint = wrap_elemwise(np.rint)
-fix = wrap_elemwise(np.fix)
+fix = wrap_elemwise(np.fix, array_wrap=True)
 
-angle = wrap_elemwise(np.angle)
-real = wrap_elemwise(np.real)
-imag = wrap_elemwise(np.imag)
+angle = wrap_elemwise(np.angle, array_wrap=True)
+real = wrap_elemwise(np.real, array_wrap=True)
+imag = wrap_elemwise(np.imag, array_wrap=True)
 
 clip = wrap_elemwise(np.clip)
 fabs = wrap_elemwise(np.fabs)

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -1,0 +1,160 @@
+from __future__ import absolute_import, division, print_function
+
+from operator import getitem
+
+import numpy as np
+
+from toolz.curried import merge
+from .core import Array, elemwise
+from .. import core
+from ..utils import skip_doctest
+
+
+def wrap_elemwise(numpy_ufunc, **wrapped_kwargs):
+    """ Wrap up numpy function into dask.array """
+
+    def wrapped(x, *args, **kwargs):
+        if hasattr(x, '_elemwise_'):
+            return x._elemwise_(numpy_ufunc, x, *args, **kwargs)
+            # return x._elemwise_(numpy_ufunc, x, *args, **kwargs,
+            #                     **wrapped_kwargs)
+        else:
+            return numpy_ufunc(x, *args, **kwargs)
+
+    # functools.wraps cannot wrap ufunc in Python 2.x
+    wrapped.__name__ = numpy_ufunc.__name__
+    wrapped.__doc__ = skip_doctest(numpy_ufunc.__doc__)
+    return wrapped
+
+
+# ufuncs, copied from this page:
+# http://docs.scipy.org/doc/numpy/reference/ufuncs.html
+
+# math operations
+logaddexp = wrap_elemwise(np.logaddexp)
+logaddexp2 = wrap_elemwise(np.logaddexp2)
+conj = wrap_elemwise(np.conj)
+exp = wrap_elemwise(np.exp)
+log = wrap_elemwise(np.log)
+log2 = wrap_elemwise(np.log2)
+log10 = wrap_elemwise(np.log10)
+log1p = wrap_elemwise(np.log1p)
+expm1 = wrap_elemwise(np.expm1)
+sqrt = wrap_elemwise(np.sqrt)
+square = wrap_elemwise(np.square)
+
+# trigonometric functions
+sin = wrap_elemwise(np.sin)
+cos = wrap_elemwise(np.cos)
+tan = wrap_elemwise(np.tan)
+arcsin = wrap_elemwise(np.arcsin)
+arccos = wrap_elemwise(np.arccos)
+arctan = wrap_elemwise(np.arctan)
+arctan2 = wrap_elemwise(np.arctan2)
+hypot = wrap_elemwise(np.hypot)
+sinh = wrap_elemwise(np.sinh)
+cosh = wrap_elemwise(np.cosh)
+tanh = wrap_elemwise(np.tanh)
+arcsinh = wrap_elemwise(np.arcsinh)
+arccosh = wrap_elemwise(np.arccosh)
+arctanh = wrap_elemwise(np.arctanh)
+deg2rad = wrap_elemwise(np.deg2rad)
+rad2deg = wrap_elemwise(np.rad2deg)
+
+# comparison functions
+logical_and = wrap_elemwise(np.logical_and, dtype='bool')
+logical_or = wrap_elemwise(np.logical_or, dtype='bool')
+logical_xor = wrap_elemwise(np.logical_xor, dtype='bool')
+logical_not = wrap_elemwise(np.logical_not, dtype='bool')
+maximum = wrap_elemwise(np.maximum)
+minimum = wrap_elemwise(np.minimum)
+fmax = wrap_elemwise(np.fmax)
+fmin = wrap_elemwise(np.fmin)
+
+# floating functions
+isreal = wrap_elemwise(np.isreal, dtype='bool')
+iscomplex = wrap_elemwise(np.iscomplex, dtype='bool')
+isfinite = wrap_elemwise(np.isfinite, dtype='bool')
+isinf = wrap_elemwise(np.isinf, dtype='bool')
+isnan = wrap_elemwise(np.isnan, dtype='bool')
+signbit = wrap_elemwise(np.signbit, dtype='bool')
+copysign = wrap_elemwise(np.copysign)
+nextafter = wrap_elemwise(np.nextafter)
+# modf: see below
+ldexp = wrap_elemwise(np.ldexp)
+# frexp: see below
+fmod = wrap_elemwise(np.fmod)
+floor = wrap_elemwise(np.floor)
+ceil = wrap_elemwise(np.ceil)
+trunc = wrap_elemwise(np.trunc)
+
+# more math routines, from this page:
+# http://docs.scipy.org/doc/numpy/reference/routines.math.html
+degrees = wrap_elemwise(np.degrees)
+radians = wrap_elemwise(np.radians)
+
+rint = wrap_elemwise(np.rint)
+fix = wrap_elemwise(np.fix)
+
+angle = wrap_elemwise(np.angle)
+real = wrap_elemwise(np.real)
+imag = wrap_elemwise(np.imag)
+
+clip = wrap_elemwise(np.clip)
+fabs = wrap_elemwise(np.fabs)
+sign = wrap_elemwise(np.sign)
+absolute = wrap_elemwise(np.absolute)
+
+
+def frexp(x):
+    tmp = elemwise(np.frexp, x)
+    left = 'mantissa-' + tmp.name
+    right = 'exponent-' + tmp.name
+    ldsk = dict(((left,) + key[1:], (getitem, key, 0))
+                for key in core.flatten(tmp._keys()))
+    rdsk = dict(((right,) + key[1:], (getitem, key, 1))
+                for key in core.flatten(tmp._keys()))
+
+    if x._dtype is not None:
+        a = np.empty((1,), dtype=x._dtype)
+        l, r = np.frexp(a)
+        ldt = l.dtype
+        rdt = r.dtype
+    else:
+        ldt = None
+        rdt = None
+
+    L = Array(merge(tmp.dask, ldsk), left, chunks=tmp.chunks, dtype=ldt)
+
+    R = Array(merge(tmp.dask, rdsk), right, chunks=tmp.chunks, dtype=rdt)
+
+    return L, R
+
+frexp.__doc__ = np.frexp
+
+
+def modf(x):
+    tmp = elemwise(np.modf, x)
+    left = 'modf1-' + tmp.name
+    right = 'modf2-' + tmp.name
+    ldsk = dict(((left,) + key[1:], (getitem, key, 0))
+                for key in core.flatten(tmp._keys()))
+    rdsk = dict(((right,) + key[1:], (getitem, key, 1))
+                for key in core.flatten(tmp._keys()))
+
+    if x._dtype is not None:
+        a = np.empty((1,), dtype=x._dtype)
+        l, r = np.modf(a)
+        ldt = l.dtype
+        rdt = r.dtype
+    else:
+        ldt = None
+        rdt = None
+
+    L = Array(merge(tmp.dask, ldsk), left, chunks=tmp.chunks, dtype=ldt)
+
+    R = Array(merge(tmp.dask, rdsk), right, chunks=tmp.chunks, dtype=rdt)
+
+    return L, R
+
+modf.__doc__ = np.modf

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -10,14 +10,12 @@ from .. import core
 from ..utils import skip_doctest
 
 
-def wrap_elemwise(numpy_ufunc, **wrapped_kwargs):
+def wrap_elemwise(numpy_ufunc):
     """ Wrap up numpy function into dask.array """
 
     def wrapped(x, *args, **kwargs):
-        if hasattr(x, '_elemwise_'):
-            return x._elemwise_(numpy_ufunc, x, *args, **kwargs)
-            # return x._elemwise_(numpy_ufunc, x, *args, **kwargs,
-            #                     **wrapped_kwargs)
+        if hasattr(x, '_elemwise'):
+            return x._elemwise(numpy_ufunc, x, *args, **kwargs)
         else:
             return numpy_ufunc(x, *args, **kwargs)
 
@@ -62,22 +60,22 @@ deg2rad = wrap_elemwise(np.deg2rad)
 rad2deg = wrap_elemwise(np.rad2deg)
 
 # comparison functions
-logical_and = wrap_elemwise(np.logical_and, dtype='bool')
-logical_or = wrap_elemwise(np.logical_or, dtype='bool')
-logical_xor = wrap_elemwise(np.logical_xor, dtype='bool')
-logical_not = wrap_elemwise(np.logical_not, dtype='bool')
+logical_and = wrap_elemwise(np.logical_and)
+logical_or = wrap_elemwise(np.logical_or)
+logical_xor = wrap_elemwise(np.logical_xor)
+logical_not = wrap_elemwise(np.logical_not)
 maximum = wrap_elemwise(np.maximum)
 minimum = wrap_elemwise(np.minimum)
 fmax = wrap_elemwise(np.fmax)
 fmin = wrap_elemwise(np.fmin)
 
 # floating functions
-isreal = wrap_elemwise(np.isreal, dtype='bool')
-iscomplex = wrap_elemwise(np.iscomplex, dtype='bool')
-isfinite = wrap_elemwise(np.isfinite, dtype='bool')
-isinf = wrap_elemwise(np.isinf, dtype='bool')
-isnan = wrap_elemwise(np.isnan, dtype='bool')
-signbit = wrap_elemwise(np.signbit, dtype='bool')
+isreal = wrap_elemwise(np.isreal)
+iscomplex = wrap_elemwise(np.iscomplex)
+isfinite = wrap_elemwise(np.isfinite)
+isinf = wrap_elemwise(np.isinf)
+isnan = wrap_elemwise(np.isnan)
+signbit = wrap_elemwise(np.signbit)
 copysign = wrap_elemwise(np.copysign)
 nextafter = wrap_elemwise(np.nextafter)
 # modf: see below

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -10,7 +10,7 @@ from .. import core
 from ..utils import skip_doctest
 
 
-def _array_wrap(numpy_ufunc, x, *args, **kwargs):
+def __array_wrap__(numpy_ufunc, x, *args, **kwargs):
     return x.__array_wrap__(numpy_ufunc(x, *args, **kwargs))
 
 
@@ -20,7 +20,8 @@ def wrap_elemwise(numpy_ufunc, array_wrap=False):
     def wrapped(x, *args, **kwargs):
         if hasattr(x, '_elemwise'):
             if array_wrap:
-                return x._elemwise(_array_wrap, numpy_ufunc, x, *args, **kwargs)
+                return x._elemwise(__array_wrap__, numpy_ufunc,
+                                   x, *args, **kwargs)
             else:
                 return x._elemwise(numpy_ufunc, x, *args, **kwargs)
         else:
@@ -121,7 +122,7 @@ def frexp(x):
                 for key in core.flatten(tmp._keys()))
 
     if x._dtype is not None:
-        a = np.empty((1,), dtype=x._dtype)
+        a = np.empty((1, ), dtype=x._dtype)
         l, r = np.frexp(a)
         ldt = l.dtype
         rdt = r.dtype
@@ -130,12 +131,10 @@ def frexp(x):
         rdt = None
 
     L = Array(merge(tmp.dask, ldsk), left, chunks=tmp.chunks, dtype=ldt)
-
     R = Array(merge(tmp.dask, rdsk), right, chunks=tmp.chunks, dtype=rdt)
-
     return L, R
 
-frexp.__doc__ = np.frexp
+frexp.__doc__ = np.frexp.__doc__
 
 
 def modf(x):
@@ -162,4 +161,4 @@ def modf(x):
 
     return L, R
 
-modf.__doc__ = np.modf
+modf.__doc__ = np.modf.__doc__

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1614,7 +1614,10 @@ class Series(_Frame):
                                    right=right, inclusive=inclusive)
 
     @derived_from(pd.Series)
-    def clip(self, lower=None, upper=None):
+    def clip(self, lower=None, upper=None, out=None):
+        if out is not None:
+            raise ValueError("'out' must be None")
+        # np.clip may pass out
         return self.map_partitions(M.clip, lower=lower, upper=upper)
 
     @derived_from(pd.Series)
@@ -2105,7 +2108,9 @@ class DataFrame(_Frame):
         return self.map_partitions(M.dropna, how=how, subset=subset)
 
     @derived_from(pd.DataFrame)
-    def clip(self, lower=None, upper=None):
+    def clip(self, lower=None, upper=None, out=None):
+        if out is not None:
+            raise ValueError("'out' must be None")
         return self.map_partitions(M.clip, lower=lower, upper=upper)
 
     @derived_from(pd.DataFrame)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -279,6 +279,10 @@ class _Frame(Base):
                 (self.__class__.__name__, name, self.npartitions, div_text))
 
     @property
+    def _elemwise_(self):
+        return map_partitions
+
+    @property
     def index(self):
         """Return dask Index instance"""
         name = self._name + '-index'

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1794,6 +1794,9 @@ class Index(Series):
         msg = "'{0}' object has no attribute 'index'"
         raise AttributeError(msg.format(self.__class__.__name__))
 
+    def __array_wrap__(self, array, context=None):
+        return pd.Index(array, name=self.name)
+
     def head(self, n=5, compute=True):
         """ First n items of the Index.
 

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -7,16 +7,14 @@ import numpy as np
 
 import dask.array as da
 import dask.dataframe as dd
-from dask.dataframe.utils import eq
+from dask.dataframe.utils import assert_eq
 
 
 @pytest.mark.parametrize('ufunc',
                          ['conj', 'exp', 'log', 'log2', 'log10', 'log1p',
-                          'expm1', 'sqrt', 'square',
-                          'sin', 'cos', 'tan', 'arcsin','arccos',
-                          'arctan', 'sinh', 'cosh', 'tanh',
-                          'arcsinh', 'arccosh', 'arctanh', 'deg2rad', 'rad2deg'
-                          ])
+                          'expm1', 'sqrt', 'square', 'sin', 'cos', 'tan',
+                          'arcsin','arccos', 'arctan', 'sinh', 'cosh', 'tanh',
+                          'arcsinh', 'arccosh', 'arctanh', 'deg2rad', 'rad2deg'])
 def test_ufunc(ufunc):
 
     dafunc = getattr(da, ufunc)
@@ -27,15 +25,15 @@ def test_ufunc(ufunc):
 
     # applying Dask ufunc doesn't trigger computation
     assert isinstance(dafunc(ds), dd.Series)
-    assert eq(dafunc(ds), npfunc(s))
+    assert_eq(dafunc(ds), npfunc(s))
 
     # applying NumPy ufunc triggers computation
     assert isinstance(npfunc(ds), pd.Series)
-    assert eq(npfunc(ds), npfunc(s))
+    assert_eq(npfunc(ds), npfunc(s))
 
     # applying Dask ufunc to normal Series triggers computation
     assert isinstance(dafunc(s), pd.Series)
-    assert eq(dafunc(s), npfunc(s))
+    assert_eq(dafunc(s), npfunc(s))
 
     df = pd.DataFrame(np.random.randint(1, 100, size=(20, 2)),
                       columns=['A', 'B'])
@@ -43,12 +41,103 @@ def test_ufunc(ufunc):
 
     # applying Dask ufunc doesn't trigger computation
     assert isinstance(dafunc(ddf), dd.DataFrame)
-    assert eq(dafunc(ddf), npfunc(df))
+    assert_eq(dafunc(ddf), npfunc(df))
 
     # applying NumPy ufunc triggers computation
     assert isinstance(npfunc(ddf), pd.DataFrame)
-    assert eq(npfunc(ddf), npfunc(df))
+    assert_eq(npfunc(ddf), npfunc(df))
 
     # applying Dask ufunc to normal Series triggers computation
     assert isinstance(dafunc(df), pd.DataFrame)
-    assert eq(dafunc(df), npfunc(df))
+    assert_eq(dafunc(df), npfunc(df))
+
+
+@pytest.mark.parametrize('ufunc',
+                         ['conj', 'exp', 'log', 'log2', 'log10', 'log1p',
+                          'expm1', 'sqrt', 'square',
+                          'sin', 'cos', 'tan', 'arcsin','arccos',
+                          'arctan', 'sinh', 'cosh', 'tanh',
+                          'arcsinh', 'arccosh', 'arctanh', 'deg2rad', 'rad2deg'
+                          ])
+def test_ufunc_with_index(ufunc):
+
+    dafunc = getattr(da, ufunc)
+    npfunc = getattr(np, ufunc)
+
+    s = pd.Series(np.random.randint(1, 100, size=20),
+                  index=list('abcdefghijklmnopqrst'))
+    ds = dd.from_pandas(s, 3)
+
+    # applying Dask ufunc doesn't trigger computation
+    assert isinstance(dafunc(ds), dd.Series)
+    assert_eq(dafunc(ds), npfunc(s))
+
+    # applying NumPy ufunc triggers computation
+    assert isinstance(npfunc(ds), pd.Series)
+    assert_eq(npfunc(ds), npfunc(s))
+
+    # applying Dask ufunc to normal Series triggers computation
+    assert isinstance(dafunc(s), pd.Series)
+    assert_eq(dafunc(s), npfunc(s))
+
+    df = pd.DataFrame(np.random.randint(1, 100, size=(20, 2)),
+                      columns=['A', 'B'],
+                      index=list('abcdefghijklmnopqrst'))
+    ddf = dd.from_pandas(df, 3)
+
+    # applying Dask ufunc doesn't trigger computation
+    assert isinstance(dafunc(ddf), dd.DataFrame)
+    assert_eq(dafunc(ddf), npfunc(df))
+
+    # applying NumPy ufunc triggers computation
+    assert isinstance(npfunc(ddf), pd.DataFrame)
+    assert_eq(npfunc(ddf), npfunc(df))
+
+    # applying Dask ufunc to normal Series triggers computation
+    assert isinstance(dafunc(df), pd.DataFrame)
+    assert_eq(dafunc(df), npfunc(df))
+
+
+@pytest.mark.parametrize('ufunc', ['logaddexp', 'arctan2', 'hypot'])
+def test_ufunc_with_2args(ufunc):
+
+    dafunc = getattr(da, ufunc)
+    npfunc = getattr(np, ufunc)
+
+    s1 = pd.Series(np.random.randint(1, 100, size=20))
+    ds1 = dd.from_pandas(s1, 3)
+
+    s2 = pd.Series(np.random.randint(1, 100, size=20))
+    ds2 = dd.from_pandas(s2, 4)
+
+    # applying Dask ufunc doesn't trigger computation
+    assert isinstance(dafunc(ds1, ds2), dd.Series)
+    assert_eq(dafunc(ds1, ds2), npfunc(s1, s2))
+
+    # applying NumPy ufunc triggers computation
+    assert isinstance(npfunc(ds1, ds2), pd.Series)
+    assert_eq(npfunc(ds1, ds2), npfunc(s1, s2))
+
+    # applying Dask ufunc to normal Series triggers computation
+    assert isinstance(dafunc(s1, s2), pd.Series)
+    assert_eq(dafunc(s1, s2), npfunc(s1, s2))
+
+    df1 = pd.DataFrame(np.random.randint(1, 100, size=(20, 2)),
+                       columns=['A', 'B'])
+    ddf1 = dd.from_pandas(df1, 3)
+
+    df2 = pd.DataFrame(np.random.randint(1, 100, size=(20, 2)),
+                       columns=['A', 'B'])
+    ddf2 = dd.from_pandas(df2, 4)
+
+    # applying Dask ufunc doesn't trigger computation
+    assert isinstance(dafunc(ddf1, ddf2), dd.DataFrame)
+    assert_eq(dafunc(ddf1, ddf2), npfunc(df1, df2))
+
+    # applying NumPy ufunc triggers computation
+    assert isinstance(npfunc(ddf1, ddf2), pd.DataFrame)
+    assert_eq(npfunc(ddf1, ddf2), npfunc(df1, df2))
+
+    # applying Dask ufunc to normal Series triggers computation
+    assert isinstance(dafunc(df1, df2), pd.DataFrame)
+    assert_eq(dafunc(df1, df2), npfunc(df1, df2))

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -17,7 +17,8 @@ _BASE_UFUNCS = ['conj', 'exp', 'log', 'log2', 'log10', 'log1p',
                 'arcsinh', 'arccosh', 'arctanh', 'deg2rad', 'rad2deg',
                 'isfinite', 'isinf', 'isnan', 'signbit',
                 'degrees', 'radians', 'rint', 'fabs', 'sign', 'absolute',
-                'floor', 'ceil', 'trunc', 'logical_not', 'frexp', 'modf']
+                'floor', 'ceil', 'trunc', 'logical_not']
+
 
 @pytest.mark.parametrize('ufunc', _BASE_UFUNCS)
 def test_ufunc(ufunc):
@@ -95,7 +96,7 @@ def test_ufunc_with_index(ufunc):
     assert isinstance(dafunc(s), pd.Series)
     assert_eq(dafunc(s), npfunc(s))
 
-    s = pd.Series(np.abs(np.random.randn(100)),
+    s = pd.Series(np.abs(np.random.randn(20)),
                   index=list('abcdefghijklmnopqrst'))
     ds = dd.from_pandas(s, 3)
 

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -25,7 +25,7 @@ def test_ufunc(ufunc):
     s = pd.Series(np.random.randint(1, 100, size=20))
     ds = dd.from_pandas(s, 3)
 
-    # applying Dask ufunc doesn't trigger to computation
+    # applying Dask ufunc doesn't trigger computation
     assert isinstance(dafunc(ds), dd.Series)
     assert eq(dafunc(ds), npfunc(s))
 
@@ -36,3 +36,19 @@ def test_ufunc(ufunc):
     # applying Dask ufunc to normal Series triggers computation
     assert isinstance(dafunc(s), pd.Series)
     assert eq(dafunc(s), npfunc(s))
+
+    df = pd.DataFrame(np.random.randint(1, 100, size=(20, 2)),
+                      columns=['A', 'B'])
+    ddf = dd.from_pandas(df, 3)
+
+    # applying Dask ufunc doesn't trigger computation
+    assert isinstance(dafunc(ddf), dd.DataFrame)
+    assert eq(dafunc(ddf), npfunc(df))
+
+    # applying NumPy ufunc triggers computation
+    assert isinstance(npfunc(ddf), pd.DataFrame)
+    assert eq(npfunc(ddf), npfunc(df))
+
+    # applying Dask ufunc to normal Series triggers computation
+    assert isinstance(dafunc(df), pd.DataFrame)
+    assert eq(dafunc(df), npfunc(df))

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+pd = pytest.importorskip('pandas')
+
+import numpy as np
+
+import dask.array as da
+import dask.dataframe as dd
+from dask.dataframe.utils import eq
+
+
+@pytest.mark.parametrize('ufunc',
+                         ['conj', 'exp', 'log', 'log2', 'log10', 'log1p',
+                          'expm1', 'sqrt', 'square',
+                          'sin', 'cos', 'tan', 'arcsin','arccos',
+                          'arctan', 'sinh', 'cosh', 'tanh',
+                          'arcsinh', 'arccosh', 'arctanh', 'deg2rad', 'rad2deg'
+                          ])
+def test_ufunc(ufunc):
+
+    dafunc = getattr(da, ufunc)
+    npfunc = getattr(np, ufunc)
+
+    s = pd.Series(np.random.randint(1, 100, size=20))
+    ds = dd.from_pandas(s, 3)
+
+    # applying Dask ufunc doesn't trigger to computation
+    assert isinstance(dafunc(ds), dd.Series)
+    assert eq(dafunc(ds), npfunc(s))
+
+    # applying NumPy ufunc triggers computation
+    assert isinstance(npfunc(ds), pd.Series)
+    assert eq(npfunc(ds), npfunc(s))
+
+    # applying Dask ufunc to normal Series triggers computation
+    assert isinstance(dafunc(s), pd.Series)
+    assert eq(dafunc(s), npfunc(s))

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -56,6 +56,7 @@ def test_ufunc(ufunc):
     assert isinstance(dafunc(s), pd.Series)
     assert_eq(dafunc(s), npfunc(s))
 
+    # DataFrame
     df = pd.DataFrame({'A': np.random.randint(1, 100, size=20),
                        'B': np.random.randint(1, 100, size=20),
                        'C': np.abs(np.random.randn(20))})
@@ -69,8 +70,23 @@ def test_ufunc(ufunc):
     assert isinstance(npfunc(ddf), pd.DataFrame)
     assert_eq(npfunc(ddf), npfunc(df))
 
-    # applying Dask ufunc to normal Series triggers computation
+    # applying Dask ufunc to normal Dataframe triggers computation
     assert isinstance(dafunc(df), pd.DataFrame)
+    assert_eq(dafunc(df), npfunc(df))
+
+    # Index
+    if ufunc in ('logical_not', 'signbit', 'isnan', 'isinf', 'isfinite'):
+        return
+
+    assert isinstance(dafunc(ddf.index), dd.Index)
+    assert_eq(dafunc(ddf.index), npfunc(df.index))
+
+    # applying NumPy ufunc triggers computation
+    assert isinstance(npfunc(ddf.index), pd.Index)
+    assert_eq(npfunc(ddf.index), npfunc(df.index))
+
+    # applying Dask ufunc to normal Series triggers computation
+    assert isinstance(dafunc(df.index), pd.Index)
     assert_eq(dafunc(df), npfunc(df))
 
 
@@ -126,7 +142,7 @@ def test_ufunc_with_index(ufunc):
     assert isinstance(npfunc(ddf), pd.DataFrame)
     assert_eq(npfunc(ddf), npfunc(df))
 
-    # applying Dask ufunc to normal Series triggers computation
+    # applying Dask ufunc to normal DataFrame triggers computation
     assert isinstance(dafunc(df), pd.DataFrame)
     assert_eq(dafunc(df), npfunc(df))
 
@@ -223,7 +239,7 @@ def test_ufunc_with_2args(ufunc):
     assert isinstance(npfunc(ddf1, ddf2), pd.DataFrame)
     assert_eq(npfunc(ddf1, ddf2), npfunc(df1, df2))
 
-    # applying Dask ufunc to normal Series triggers computation
+    # applying Dask ufunc to normal DataFrame triggers computation
     assert isinstance(dafunc(df1, df2), pd.DataFrame)
     assert_eq(dafunc(df1, df2), npfunc(df1, df2))
 
@@ -259,6 +275,6 @@ def test_clip():
     assert isinstance(np.clip(ddf, 5.5, 40.5), dd.DataFrame)
     assert_eq(np.clip(ddf, 5.5, 40.5), np.clip(df, 5.5, 40.5))
 
-    # applying Dask ufunc to normal Series triggers computation
+    # applying Dask ufunc to normal DataFrame triggers computation
     assert isinstance(da.clip(df, 5.5, 40.5), pd.DataFrame)
     assert_eq(da.clip(df, 5.5, 40.5), np.clip(df, 5.5, 40.5))

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -225,7 +225,7 @@ def make_meta(x, index=None):
 
     if is_pd_scalar(x):
         return _nonempty_scalar(x)
-
+    print(x, type(x))
     raise TypeError("Don't know how to create metadata from {0}".format(x))
 
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -225,7 +225,7 @@ def make_meta(x, index=None):
 
     if is_pd_scalar(x):
         return _nonempty_scalar(x)
-    print(x, type(x))
+
     raise TypeError("Don't know how to create metadata from {0}".format(x))
 
 

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -8,7 +8,7 @@ from dask.compatibility import BZ2File, GzipFile, LZMAFile, LZMA_AVAILABLE
 from dask.utils import (textblock, filetext, takes_multiple_arguments,
                         Dispatch, tmpfile, random_state_data, file_size,
                         infer_storage_options, eq_strict, memory_repr,
-                        methodcaller, M)
+                        methodcaller, M, skip_doctest)
 
 
 SKIP_XZ = pytest.mark.skipif(not LZMA_AVAILABLE, reason="no lzma library")
@@ -198,3 +198,18 @@ def test_method_caller():
     assert M.count is f
     assert pickle.loads(pickle.dumps(f)) is f
     assert 'count' in dir(M)
+
+
+def test_skip_doctest():
+    example = """>>> xxx
+>>>
+>>> # comment
+>>> xxx"""
+
+    res = skip_doctest(example)
+    assert res == """>>> xxx    # doctest: +SKIP
+>>>
+>>> # comment
+>>> xxx    # doctest: +SKIP"""
+
+    assert skip_doctest(None) == ''

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -544,7 +544,7 @@ def ensure_not_exists(filename):
 
 
 def _skip_doctest(line):
-    # NumPY docstring contains cursor and comment only example
+    # NumPy docstring contains cursor and comment only example
     stripped = line.strip()
     if stripped == '>>>' or stripped.startswith('>>> #'):
         return stripped

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -544,10 +544,20 @@ def ensure_not_exists(filename):
 
 
 def _skip_doctest(line):
-    if '>>>' in line:
+    # NumPY docstring contains cursor and comment only example
+    stripped = line.strip()
+    if stripped == '>>>' or stripped.startswith('>>> #'):
+        return stripped
+    elif '>>>' in stripped:
         return line + '    # doctest: +SKIP'
     else:
         return line
+
+
+def skip_doctest(doc):
+    if doc is None:
+        return ''
+    return '\n'.join([_skip_doctest(line) for line in doc.split('\n')])
 
 
 def derived_from(original_klass, version=None, ua_args=[]):
@@ -589,7 +599,7 @@ def derived_from(original_klass, version=None, ua_args=[]):
                         "        Dask doesn't supports following argument(s).\n\n")
                 args = ''.join(['        * {0}\n'.format(a) for a in not_supported])
                 doc = doc + note + args
-            doc = '\n'.join([_skip_doctest(line) for line in doc.split('\n')])
+            doc = skip_doctest(doc)
             method.__doc__ = doc
             return method
 


### PR DESCRIPTION
On current master, `da.ufuncs` doesn't work with `dask.dataframe` instances. 

**On current master:**

```
import dask.array as da
import dask.dataframe as dd

s = pd.Series(np.random.randn(100))
ds = dd.from_pandas(s, 3)
da.sin(ds)
# ValueError: max() arg is an empty sequence
```

**After the PR:**

Now these return dask instances.

```
da.sin(ds)
# dd.Series<sin-cf1..., npartitions=3, divisions=(0, 34, 68, 99)>

da.sin(ds).compute()
#0    -0.329255
#1    -0.586025
#         ...   
#98    0.739737
#99    0.567551
# dtype: float64
```

To make impl simple, I'm adding `_elemwise` property to `Array/_Frame` which returns function used for element-wise op. 
- [x] Add `__array__` interface to `DataFrame` 
  - [x] `__array_wrap__` with non-default `Index`
- [x]  Tests
  - [x] ufunc which returns array
  - [x] ufunc with 2 arrays
