### PR TITLE
WIP: Feature/dataframe aggregate (implements #1619)

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -193,15 +193,26 @@ def _normalize_spec(spec, non_group_columns):
 
 def _build_agg_args(spec):
     """
-    Create the transformation functions for a normalized aggregate spec.
+    Create transformation functions for a normalized aggregate spec.
+
+    Parameters
+    ----------
+    spec: a list of (result-column, aggregation-function, input-column) triples.
+        To work with all arugment forms understood by pandas use
+        ``_normalize_spec`` to normalize the argment before passing it on to
+        ``_build_agg_args``.
 
     Returns
     -------
-    chunk_funcs: TODO: document
+    chunk_funcs: a list of (intermediate-column, function, keyword) triples
+        that are applied on grouped chunks of the initial dataframe.
 
-    agg_funcs: TODO: document
+    agg_funcs: a list of (intermediate-column, functions, keword) triples that
+        are applied on the grouped concatination of the preprocessed chunks.
 
-    finalizers: TODO: document
+    finalizers: a list of (result-column, function, keyword) triples that are
+        applied after the ``agg_funcs``. They are used to create final results
+        from intermediate representations.
     """
     # generator for consecutive IDs (for intermediate results). Ids are
     # generated for (result, func) pairs. Once an id for a pair has been

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -190,35 +190,33 @@ def _normalize_spec(spec, non_group_columns):
     The non-group columns are a list of all column names that are not used in
     the groupby operation.
 
-    Usually, the result columns are be a mutli-level names, returned as a
-    tuples. If only a single function is supplied or dictionary mapping columns
+    Usually, the result columns are mutli-level names, returned as tuples.
+    If only a single function is supplied or dictionary mapping columns
     to single functions, simple names are returned as strings (see the first
     two examples below).
 
     Examples
     --------
+    >>> _normalize_spec('mean', ['a', 'b', 'c'])
+    [('a', 'mean', 'a'), ('b', 'mean', 'b'), ('c', 'mean', 'c')]
 
-        >>> _normalize_spec('mean', ['a', 'b', 'c'])
-        [('a', 'mean', 'a'), ('b', 'mean', 'b'), ('c', 'mean', 'c')]
+    >>> _normalize_spec({'a': 'mean', 'b': 'count'}, ['a', 'b', 'c'])
+    [('a', 'mean', 'a'), ('b', 'count', 'b')]
 
-        >>> _normalize_spec({'a': 'mean', 'b': 'count'}, ['a', 'b', 'c'])
-        [('a', 'mean', 'a'), ('b', 'count', 'b')]
+    >>> _normalize_spec(['var', 'mean'], ['a', 'b', 'c'])
+    [(('a', 'var'), 'var', 'a'), (('a', 'mean'), 'mean', 'a'),
+     (('b', 'var'), 'var', 'b'), (('b', 'mean'), 'mean', 'b'),
+     (('c', 'var'), 'var', 'c'), (('c', 'mean'), 'mean', 'c')]
 
-        >>> _normalize_spec(['var', 'mean'], ['a', 'b', 'c'])
-        [(('a', 'var'), 'var', 'a'), (('a', 'mean'), 'mean', 'a'),
-         (('b', 'var'), 'var', 'b'), (('b', 'mean'), 'mean', 'b'),
-         (('c', 'var'), 'var', 'c'), (('c', 'mean'), 'mean', 'c')]
+    >>> _normalize_spec({'a': 'mean', 'b': ['sum', 'count']}, ['a', 'b', 'c'])
+    [(('a', 'mean'), 'mean', 'a'), (('b', 'sum'), 'sum', 'b'),
+      (('b', 'count'), 'count', 'b')]
 
-        >>> _normalize_spec({'a': 'mean', 'b': ['sum', 'count']},
-        ...                 ['a', 'b', 'c'])
-        [(('a', 'mean'), 'mean', 'a'), (('b', 'sum'), 'sum', 'b'),
-          (('b', 'count'), 'count', 'b')]
-
-        >>> _normalize_spec({'a': ['mean', 'size'],
-        ...                  'b': {'e': 'count', 'f': 'var'}},
-        ...                 ['a', 'b', 'c'])
-        [(('a', 'mean'), 'mean', 'a'), (('a', 'size'), 'size', 'a'),
-         (('b', 'e'), 'count', 'b'), (('b', 'f'), 'var', 'b')]
+    >>> _normalize_spec({'a': ['mean', 'size'],
+    ...                  'b': {'e': 'count', 'f': 'var'}},
+    ...                 ['a', 'b', 'c'])
+    [(('a', 'mean'), 'mean', 'a'), (('a', 'size'), 'size', 'a'),
+     (('b', 'e'), 'count', 'b'), (('b', 'f'), 'var', 'b')]
     """
     if not isinstance(spec, dict):
         spec = collections.OrderedDict(zip(non_group_columns, it.repeat(spec)))
@@ -400,25 +398,20 @@ def _groupby_apply_funcs(df, *index, **kwargs):
 
     Parameters
     ----------
-
     df: pandas.DataFrame
         The dataframe to work on.
-
     index: list of groupers
         If given, they are added to the keyword arguments as the ``by``
         argument.
-
     funcs: list of result-colum, function, keywordargument triples
         The list of functions that are applied on the grouped data frame.
         Has to be passed as a keyword argument.
-
     kwargs:
         All keyword arguments, but ``funcs``, are passed verbatim to the groupby
         operation of the dataframe
 
     Returns
     -------
-
     aggregated:
         the aggregated dataframe.
     """

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -695,8 +695,9 @@ class DataFrameGroupBy(_GroupBy):
         else:
             levels = 0
 
-        # TODO: add normed spec as an additional part to the token
-        token = 'aggregate-'
+        # TODO: add normed spec as an additional part to the token?
+        token = 'aggregate'
+        finalize_token = '{}-finalize'.format(token)
 
         meta_groupby = pd.Series([], dtype=bool, index=self.obj._meta.index)
         meta = _aggregate_meta(self.obj._meta, meta_groupby, 0, chunk_funcs,
@@ -715,8 +716,8 @@ class DataFrameGroupBy(_GroupBy):
                   aggregate_kwargs=dict(funcs=aggregate_funcs, level=levels),
                   meta=meta, token=token, split_every=split_every)
 
-        return map_partitions(_agg_finalize, obj, meta=meta, token=token,
-                              funcs=finalizers)
+        return map_partitions(_agg_finalize, obj, meta=meta,
+                              token=finalize_token, funcs=finalizers)
 
     @derived_from(pd.core.groupby.DataFrameGroupBy)
     def agg(self, arg, split_every=None):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -714,6 +714,8 @@ class DataFrameGroupBy(_GroupBy):
                   chunk_kwargs=dict(funcs=chunk_funcs),
                   aggregate=_groupby_apply_funcs,
                   aggregate_kwargs=dict(funcs=aggregate_funcs, level=levels),
+                  combine=_groupby_apply_funcs,
+                  combine_kwargs=dict(funcs=aggregate_funcs, level=levels),
                   meta=meta, token=token, split_every=split_every)
 
         return map_partitions(_agg_finalize, obj, meta=meta,

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -168,7 +168,7 @@ def _make_agg_id_factory():
             return ids[func,column]
 
         except KeyError:
-            new_id = '{}‐{!s}‐{!s}'.format(next(integers), func, column)
+            new_id = '{}-{!s}-{!s}'.format(next(integers), func, column)
             return ids.setdefault((func,column), new_id)
 
     return factory

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from .core import DataFrame, Series, Index, aca, map_partitions, no_default
+from .core import DataFrame, Series, aca, map_partitions, no_default
 from .shuffle import shuffle
 from .utils import make_meta, insert_meta_param_description, raise_on_meta_error
 from ..utils import derived_from, M, funcname
@@ -422,7 +422,7 @@ def _normalize_index(df, index):
         return [_normalize_index(df, col) for col in index]
 
     elif (isinstance(index, Series) and index.name in df.columns and
-           index._name == df[index.name]._name):
+          index._name == df[index.name]._name):
             return index.name
 
     elif (isinstance(index, DataFrame) and

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -592,11 +592,9 @@ class DataFrameGroupBy(_GroupBy):
         except KeyError as e:
             raise AttributeError(e)
 
-    def aggregate(self, spec):
-        """
-        TODO: add docs
-        """
-        spec = _normalize_spec(spec)
+    @derived_from(pd.core.groupby.DataFrameGroupBy)
+    def aggregate(self, arg):
+        spec = _normalize_spec(arg)
         chunk_funcs, aggregate_funcs, finalizers = _build_agg_args(spec)
 
         if isinstance(self.index, (tuple, list)) and len(self.index) > 1:
@@ -620,11 +618,9 @@ class DataFrameGroupBy(_GroupBy):
         return map_partitions(_agg_finalize, obj, meta=meta, token=token,
                               result_column_func_pairs=finalizers)
 
-    def agg(self, spec):
-        """
-        TODO: add docs
-        """
-        return self.aggregate(spec)
+    @derived_from(pd.core.groupby.DataFrameGroupBy)
+    def agg(self, arg):
+        return self.aggregate(arg)
 
 
 class SeriesGroupBy(_GroupBy):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -653,7 +653,7 @@ class DataFrameGroupBy(_GroupBy):
             raise AttributeError(e)
 
     @derived_from(pd.core.groupby.DataFrameGroupBy)
-    def aggregate(self, arg):
+    def aggregate(self, arg, split_every=None):
         non_group_columns = [col for col in self.obj.columns
                              if col not in self.index]
         spec = _normalize_spec(arg, non_group_columns)
@@ -675,14 +675,14 @@ class DataFrameGroupBy(_GroupBy):
                   chunk_kwargs=dict(funcs=chunk_funcs, by=self.index),
                   aggregate=_groupby_apply_funcs,
                   aggregate_kwargs=dict(funcs=aggregate_funcs, level=levels),
-                  meta=meta, token=token)
+                  meta=meta, token=token, split_every=split_every)
 
         return map_partitions(_agg_finalize, obj, meta=meta, token=token,
                               funcs=finalizers)
 
     @derived_from(pd.core.groupby.DataFrameGroupBy)
-    def agg(self, arg):
-        return self.aggregate(arg)
+    def agg(self, arg, split_every=None):
+        return self.aggregate(arg, split_every=split_every)
 
 
 class SeriesGroupBy(_GroupBy):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -200,22 +200,28 @@ def _normalize_spec(spec, non_group_columns):
     >>> _normalize_spec('mean', ['a', 'b', 'c'])
     [('a', 'mean', 'a'), ('b', 'mean', 'b'), ('c', 'mean', 'c')]
 
-    >>> _normalize_spec({'a': 'mean', 'b': 'count'}, ['a', 'b', 'c'])
+    >>> spec = collections.OrderedDict([('a', 'mean'), ('b', 'count')])
+    >>> _normalize_spec(spec, ['a', 'b', 'c'])
     [('a', 'mean', 'a'), ('b', 'count', 'b')]
 
     >>> _normalize_spec(['var', 'mean'], ['a', 'b', 'c'])
-    [(('a', 'var'), 'var', 'a'), (('a', 'mean'), 'mean', 'a'),
-     (('b', 'var'), 'var', 'b'), (('b', 'mean'), 'mean', 'b'),
+    ... # doctest: +NORMALIZE_WHITESPACE
+    [(('a', 'var'), 'var', 'a'), (('a', 'mean'), 'mean', 'a'), \
+     (('b', 'var'), 'var', 'b'), (('b', 'mean'), 'mean', 'b'), \
      (('c', 'var'), 'var', 'c'), (('c', 'mean'), 'mean', 'c')]
 
-    >>> _normalize_spec({'a': 'mean', 'b': ['sum', 'count']}, ['a', 'b', 'c'])
-    [(('a', 'mean'), 'mean', 'a'), (('b', 'sum'), 'sum', 'b'),
+    >>> spec = collections.OrderedDict([('a', 'mean'), ('b', ['sum', 'count'])])
+    >>> _normalize_spec(spec, ['a', 'b', 'c'])
+    ... # doctest: +NORMALIZE_WHITESPACE
+    [(('a', 'mean'), 'mean', 'a'), (('b', 'sum'), 'sum', 'b'), \
       (('b', 'count'), 'count', 'b')]
 
-    >>> _normalize_spec({'a': ['mean', 'size'],
-    ...                  'b': {'e': 'count', 'f': 'var'}},
-    ...                 ['a', 'b', 'c'])
-    [(('a', 'mean'), 'mean', 'a'), (('a', 'size'), 'size', 'a'),
+    >>> spec = collections.OrderedDict()
+    >>> spec['a'] = ['mean', 'size']
+    >>> spec['b'] = collections.OrderedDict([('e', 'count'), ('f', 'var')])
+    >>> _normalize_spec(spec, ['a', 'b', 'c'])
+    ... # doctest: +NORMALIZE_WHITESPACE
+    [(('a', 'mean'), 'mean', 'a'), (('a', 'size'), 'size', 'a'), \
      (('b', 'e'), 'count', 'b'), (('b', 'f'), 'var', 'b')]
     """
     if not isinstance(spec, dict):

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1,5 +1,4 @@
 import collections
-import operator
 
 import numpy as np
 import pandas as pd
@@ -574,7 +573,6 @@ def test_groupby_normalize_index():
 
     assert d.groupby([d['a'], d['b']]).index == ['a', 'b']
     assert d.groupby([d['a'], 'b']).index == ['a', 'b']
-
 
 
 @pytest.mark.parametrize('spec', [

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -554,3 +554,25 @@ def test_groupby_multiprocessing():
     with dask.set_options(get=get):
         assert_eq(ddf.groupby('B').apply(lambda x: x),
                   df.groupby('B').apply(lambda x: x))
+
+
+def test_aggregate_examples():
+    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7],
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2],
+                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8]},
+                       index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
+    ddf = dd.from_pandas(pdf, npartitions=3)
+
+    spec = {'b': {'c': 'sum'}}
+    assert eq(pdf.groupby('a').agg(spec), ddf.groupby('a').agg(spec))
+
+    spec = {'b': {'c': 'mean'}, 'c': {'a': 'max', 'a': 'min'}}
+    assert eq(pdf.groupby('a').agg(spec), ddf.groupby('a').agg(spec))
+
+    spec = {'b': 'mean', 'c': 'max'}
+    assert eq(pdf.groupby('a').agg(spec), ddf.groupby('a').agg(spec))
+
+    spec = {'b': 'mean', 'c': ['min', 'max']}
+    assert eq(pdf.groupby('a').agg(spec), ddf.groupby('a').agg(spec))
+
+    # TODO: add more tests: var, std, nunique, multiple group columns, ...

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -560,7 +560,8 @@ def test_aggregate_examples():
     pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7],
                         'b': [4, 2, 7, 3, 3, 1, 1, 1, 2],
                         'c': [0, 1, 2, 3, 4, 5, 6, 7, 8]},
-                       index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
+                       index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
+                       columns=['c', 'b', 'a'])
     ddf = dd.from_pandas(pdf, npartitions=3)
 
     spec = {'b': {'c': 'sum'}}
@@ -573,6 +574,15 @@ def test_aggregate_examples():
     assert eq(pdf.groupby('a').agg(spec), ddf.groupby('a').agg(spec))
 
     spec = {'b': 'mean', 'c': ['min', 'max']}
+    assert eq(pdf.groupby('a').agg(spec), ddf.groupby('a').agg(spec))
+
+    spec = {'b': np.sum, 'c': ['min', np.max]}
+    assert eq(pdf.groupby('a').agg(spec), ddf.groupby('a').agg(spec))
+
+    spec = np.sum
+    assert eq(pdf.groupby('a').agg(spec), ddf.groupby('a').agg(spec))
+
+    spec = 'mean'
     assert eq(pdf.groupby('a').agg(spec), ddf.groupby('a').agg(spec))
 
     # TODO: add more tests: var, std, nunique, multiple group columns, ...

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -569,18 +569,19 @@ def test_groupby_multiprocessing():
     'var',
     'std',
 ])
-def test_aggregate_examples(spec):
-    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7],
-                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2],
-                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8]},
-                       index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
+@pytest.mark.parametrize('split_every', [False, 3, None])
+def test_aggregate_examples(spec, split_every):
+    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 20,
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 20,
+                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 20},
                        columns=['c', 'b', 'a'])
-    ddf = dd.from_pandas(pdf, npartitions=3)
+    ddf = dd.from_pandas(pdf, npartitions=20)
 
-    assert_eq(pdf.groupby('a').agg(spec), ddf.groupby('a').agg(spec))
-    assert_eq(pdf.groupby('a').aggregate(spec), ddf.groupby('a').aggregate(spec))
+    assert_eq(pdf.groupby('a').agg(spec),
+              ddf.groupby('a').agg(spec, split_every=split_every))
 
-    # TODO: add more tests: var, std, nunique, multiple group columns, ...
+    assert_eq(pdf.groupby('a').aggregate(spec),
+              ddf.groupby('a').aggregate(spec, split_every=split_every))
 
 
 def test_aggregate_build_agg_args__reuse_of_intermediates():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -563,9 +563,11 @@ def test_groupby_multiprocessing():
     {'b': {'c': 'mean'}, 'c': {'a': 'max', 'a': 'min'}},
     {'b': 'mean', 'c': 'max'},
     {'b': 'mean', 'c': ['min', 'max']},
-    {'b': np.sum, 'c': ['min', np.max]},
-    ['sum', 'mean', 'min', 'max', 'count', 'size'],
+    {'b': np.sum, 'c': ['min', np.max, np.std, np.var]},
+    ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var'],
     'mean',
+    'var',
+    'std',
 ])
 def test_aggregate_examples(spec):
     pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7],
@@ -604,6 +606,6 @@ def test_aggregate_build_agg_args__reuse_of_intermediates():
 
     assert len(no_mean_chunks) == len(with_mean_chunks)
     assert len(no_mean_aggs) == len(with_mean_aggs)
-    
+
     assert len(no_mean_finalizers) == len(no_mean_spec)
     assert len(with_mean_finalizers) == len(with_mean_spec)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -10,8 +10,6 @@ import dask
 import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq, assert_dask_graph, assert_max_deps
 
-import pytest
-
 
 def groupby_internal_repr():
     pdf = pd.DataFrame({'x': [1, 2, 3, 4, 6, 7, 8, 9, 10],


### PR DESCRIPTION
After the great experience with #1666, I started to implement `dd.DataFrame(...).groupby(...).agg(...)` on a recent, particularly long, train ride. The implementation is pretty much feature-complete. However, support for `var` and `std` is still missing. As of now, there are no changes to the existing dask code base for implementing this feature. Since this fact results in some code duplication and there are further design consideration to be discussed, I wanted to open a PR early to ask for feedback. I hope opening such a big issue as a PR without prior announcement is OK.

# Implementation notes

The implementation supports all documented argument values of pandas aggregate: 

- function (`.agg('mean')`
- list of functions (`.agg(['mean', 'sum'])`)
- dict of columns -> functions (`.agg({'b': 'mean', 'c': 'max'})`)
- nested dict of names -> dicts of functions (`.agg({'b': {'c': 'mean'}, 'c': {'a': 'max', 'a': 'min'}})`)

The aggregation functions `sum`, `min`, `max`, `count`, `size`, and `mean` are currently supported. When function objects are used, they are matched by name against known aggregates. Support for `std` and `var` is still missing.

I followed closely the implementation of the existing aggregate functions. However, I added an additional finalize-step to make it easy to support tree aggregations (since this topic seems to be discussed). This design results in three stages: chunk functions, aggregate functions, and finalizers. In `aggregate`, `aca` (chunk functions + aggregate functions) is followed by `map_partitions` (finalizers). 

Each stage applies multiple function objects to the (grouped) input dataframe and returns a fragment of the result dataframe. The full results is obtained by concatenating all fragments (`_groupby_apply_funcs` and `_agg_finalize`).

Most of the heavy lifting is performed by generating function objects that are applied to the dataframe and return fragments of the result dataframe (`_build_agg_args`). Since aggregate and finalize steps work on intermediate results of prior phases, `agg` forms an implicit expression graph. As of now, each aggregate generates its own independent graph by writing anonymous columns in intermediate dataframes (`next_id`). An alternative would be to use fixed names for intermediates and thereby reuse them between aggregates. For example, `.agg(['sum', 'mean', 'count'])` would only compute one sum and one count per input-column. 

Currently, all aggregations are implemented by calling individual aggregate functions on grouped dataframes (following existing code). Another option would be to call the pandas `agg` implementation to generate intermediates. Depending on the perfomance of the pandas implementation this change could improve overall performance.

Implements #1619.