### PR TITLE
Remove `raises`, use pytest.raises instead

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -18,7 +18,7 @@ import dask.array as da
 from dask.base import tokenize
 from dask.delayed import delayed
 from dask.async import get_sync
-from dask.utils import raises, ignoring, tmpfile, tmpdir
+from dask.utils import ignoring, tmpfile, tmpdir
 from dask.utils_test import inc
 
 from dask.array import chunk
@@ -253,7 +253,7 @@ def test_stack():
                                            (colon, colon, None))
     assert same_keys(s2, stack([a, b, c], axis=2))
 
-    assert raises(ValueError, lambda: stack([a, b, c], axis=3))
+    pytest.raises(ValueError, lambda: stack([a, b, c], axis=3))
 
     assert set(b.dask.keys()).issubset(s2.dask.keys())
 
@@ -302,7 +302,7 @@ def test_concatenate():
     assert (concatenate([a, b, c], axis=-1).chunks ==
             concatenate([a, b, c], axis=1).chunks)
 
-    assert raises(ValueError, lambda: concatenate([a, b, c], axis=2))
+    pytest.raises(ValueError, lambda: concatenate([a, b, c], axis=2))
 
 
 def test_concatenate_fixlen_strings():
@@ -356,7 +356,7 @@ def test_take():
 
     assert_eq(np.take(x, 3, axis=0), take(a, 3, axis=0))
     assert_eq(np.take(x, [3, 4, 5], axis=-1), take(a, [3, 4, 5], axis=-1))
-    assert raises(ValueError, lambda: take(a, 3, axis=2))
+    pytest.raises(ValueError, lambda: take(a, 3, axis=2))
     assert same_keys(take(a, [3, 4, 5], axis=-1), take(a, [3, 4, 5], axis=-1))
 
 
@@ -416,8 +416,8 @@ def test_broadcast_shapes():
     assert (3, 4, 5) == broadcast_shapes((3, 4, 5), (4, 1), ())
     assert (3, 4) == broadcast_shapes((3, 1), (1, 4), (4,))
     assert (5, 6, 7, 3, 4) == broadcast_shapes((3, 1), (), (5, 6, 7, 1, 4))
-    assert raises(ValueError, lambda: broadcast_shapes((3,), (3, 4)))
-    assert raises(ValueError, lambda: broadcast_shapes((2, 3), (2, 3, 1)))
+    pytest.raises(ValueError, lambda: broadcast_shapes((3,), (3, 4)))
+    pytest.raises(ValueError, lambda: broadcast_shapes((2, 3), (2, 3, 1)))
 
 
 def test_elemwise_on_scalars():
@@ -450,8 +450,8 @@ def test_elemwise_with_ndarrays():
     assert_eq(a + y, x + y)
     assert_eq(y + a, x + y)
     # Error on shape mismatch
-    assert raises(ValueError, lambda: a + y.T)
-    assert raises(ValueError, lambda: a + np.arange(2))
+    pytest.raises(ValueError, lambda: a + y.T)
+    pytest.raises(ValueError, lambda: a + np.arange(2))
 
 
 def test_elemwise_differently_chunked():
@@ -631,9 +631,9 @@ def test_insert():
               insert(a, [2] * 3 + [5] * 2, b, axis=0))
     assert_eq(np.insert(x, 0, y[0], axis=1),
               insert(a, 0, b[0], axis=1))
-    assert raises(NotImplementedError, lambda: insert(a, [4, 2], -1, axis=0))
-    assert raises(IndexError, lambda: insert(a, [3], -1, axis=2))
-    assert raises(IndexError, lambda: insert(a, [3], -1, axis=-3))
+    pytest.raises(NotImplementedError, lambda: insert(a, [4, 2], -1, axis=0))
+    pytest.raises(IndexError, lambda: insert(a, [3], -1, axis=2))
+    pytest.raises(IndexError, lambda: insert(a, [3], -1, axis=-3))
     assert same_keys(insert(a, [2, 3, 8, 8, -2, -2], -1, axis=0),
                      insert(a, [2, 3, 8, 8, -2, -2], -1, axis=0))
 
@@ -653,8 +653,8 @@ def test_broadcast_to():
         assert_eq(chunk.broadcast_to(x, shape),
                   broadcast_to(a, shape))
 
-    assert raises(ValueError, lambda: broadcast_to(a, (2, 1, 6)))
-    assert raises(ValueError, lambda: broadcast_to(a, (3,)))
+    pytest.raises(ValueError, lambda: broadcast_to(a, (2, 1, 6)))
+    pytest.raises(ValueError, lambda: broadcast_to(a, (3,)))
 
 
 def test_ravel():
@@ -744,7 +744,7 @@ def test_reshape_unknown_dimensions():
             a = from_array(x, 24)
             assert_eq(x.reshape(new_shape), a.reshape(new_shape))
 
-    assert raises(ValueError, lambda: reshape(a, (-1, -1)))
+    pytest.raises(ValueError, lambda: reshape(a, (-1, -1)))
 
 
 def test_full():
@@ -828,7 +828,7 @@ def test_fromfunction():
 
 def test_from_function_requires_block_args():
     x = np.arange(10)
-    assert raises(Exception, lambda: from_array(x))
+    pytest.raises(Exception, lambda: from_array(x))
 
 
 def test_repr():
@@ -870,7 +870,7 @@ def test_dtype():
 
 def test_blockdims_from_blockshape():
     assert blockdims_from_blockshape((10, 10), (4, 3)) == ((4, 4, 2), (3, 3, 3, 1))
-    assert raises(TypeError, lambda: blockdims_from_blockshape((10,), None))
+    pytest.raises(TypeError, lambda: blockdims_from_blockshape((10,), None))
     assert blockdims_from_blockshape((1e2, 3), [1e1, 3]) == ((10, ) * 10, (3, ))
     assert blockdims_from_blockshape((np.int8(10), ), (5, )) == ((5, 5), )
 
@@ -895,9 +895,9 @@ def test_store():
     assert (at == 2).all()
     assert (bt == 3).all()
 
-    assert raises(ValueError, lambda: store([a], [at, bt]))
-    assert raises(ValueError, lambda: store(at, at))
-    assert raises(ValueError, lambda: store([at, bt], [at, bt]))
+    pytest.raises(ValueError, lambda: store([a], [at, bt]))
+    pytest.raises(ValueError, lambda: store(at, at))
+    pytest.raises(ValueError, lambda: store([at, bt], [at, bt]))
 
 
 def test_store_compute_false():
@@ -1617,7 +1617,7 @@ def test_raise_on_no_chunks():
     except ValueError as e:
         assert "dask.pydata.org" in str(e)
 
-    assert raises(ValueError, lambda: da.ones(6))
+    pytest.raises(ValueError, lambda: da.ones(6))
 
 
 def test_chunks_is_immutable():
@@ -1716,11 +1716,11 @@ def test_slice_with_floats():
 
 def test_vindex_errors():
     d = da.ones((5, 5, 5), chunks=(3, 3, 3))
-    assert raises(IndexError, lambda: d.vindex[0])
-    assert raises(IndexError, lambda: d.vindex[[1, 2, 3]])
-    assert raises(IndexError, lambda: d.vindex[[1, 2, 3], [1, 2, 3], 0])
-    assert raises(IndexError, lambda: d.vindex[[1], [1, 2, 3]])
-    assert raises(IndexError, lambda: d.vindex[[1, 2, 3], [[1], [2], [3]]])
+    pytest.raises(IndexError, lambda: d.vindex[0])
+    pytest.raises(IndexError, lambda: d.vindex[[1, 2, 3]])
+    pytest.raises(IndexError, lambda: d.vindex[[1, 2, 3], [1, 2, 3], 0])
+    pytest.raises(IndexError, lambda: d.vindex[[1], [1, 2, 3]])
+    pytest.raises(IndexError, lambda: d.vindex[[1, 2, 3], [[1], [2], [3]]])
 
 
 def test_vindex_merge():
@@ -1761,7 +1761,7 @@ def test_cov():
     assert_eq(da.cov(d, e), np.cov(x, y))
     assert_eq(da.cov(e, d), np.cov(y, x))
 
-    assert raises(ValueError, lambda: da.cov(d, ddof=1.5))
+    pytest.raises(ValueError, lambda: da.cov(d, ddof=1.5))
 
 
 def test_corrcoef():
@@ -2079,11 +2079,11 @@ def test_tril_triu():
 def test_tril_triu_errors():
     A = np.random.random_integers(0, 10, (10, 10, 10))
     dA = da.from_array(A, chunks=(5, 5, 5))
-    assert raises(ValueError, lambda: da.triu(dA))
+    pytest.raises(ValueError, lambda: da.triu(dA))
 
     A = np.random.random_integers(0, 10, (30, 35))
     dA = da.from_array(A, chunks=(5, 5))
-    assert raises(NotImplementedError, lambda: da.triu(dA))
+    pytest.raises(NotImplementedError, lambda: da.triu(dA))
 
 
 def test_atop_names():

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -1,7 +1,8 @@
 import numpy as np
 import numpy.fft as npfft
 
-from dask.utils import raises
+import pytest
+
 import dask.array as da
 from dask.array.fft import fft, ifft, rfft, irfft, hfft, ihfft
 from dask.array.utils import assert_eq
@@ -23,8 +24,8 @@ darr2 = da.from_array(nparr, chunks=(10, 1))
 
 def test_cant_fft_chunked_axis():
     bad_darr = da.from_array(nparr, chunks=(5, 5))
-    assert raises(ValueError, lambda: fft(bad_darr))
-    assert raises(ValueError, lambda: fft(bad_darr, axis=0))
+    pytest.raises(ValueError, lambda: fft(bad_darr))
+    pytest.raises(ValueError, lambda: fft(bad_darr, axis=0))
 
 
 def test_fft():

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -9,7 +9,6 @@ import scipy.linalg
 
 import dask.array as da
 from dask.array.linalg import tsqr, svd_compressed, qr, svd
-from dask.utils import raises
 from dask.array.utils import assert_eq
 
 
@@ -214,15 +213,15 @@ def test_lu_3(size):
 def test_lu_errors():
     A = np.random.random_integers(0, 10, (10, 10, 10))
     dA = da.from_array(A, chunks=(5, 5, 5))
-    assert raises(ValueError, lambda: da.linalg.lu(dA))
+    pytest.raises(ValueError, lambda: da.linalg.lu(dA))
 
     A = np.random.random_integers(0, 10, (10, 8))
     dA = da.from_array(A, chunks=(5, 4))
-    assert raises(ValueError, lambda: da.linalg.lu(dA))
+    pytest.raises(ValueError, lambda: da.linalg.lu(dA))
 
     A = np.random.random_integers(0, 10, (20, 20))
     dA = da.from_array(A, chunks=(5, 4))
-    assert raises(ValueError, lambda: da.linalg.lu(dA))
+    pytest.raises(ValueError, lambda: da.linalg.lu(dA))
 
 
 @pytest.mark.parametrize(('shape', 'chunk'), [(20, 10), (50, 10), (70, 20)])
@@ -302,13 +301,13 @@ def test_solve_triangular_errors():
     b = np.random.random_integers(1, 10, 10)
     dA = da.from_array(A, chunks=(5, 5, 5))
     db = da.from_array(b, chunks=5)
-    assert raises(ValueError, lambda: da.linalg.solve_triangular(dA, db))
+    pytest.raises(ValueError, lambda: da.linalg.solve_triangular(dA, db))
 
     A = np.random.random_integers(0, 10, (10, 10))
     b = np.random.random_integers(1, 10, 10)
     dA = da.from_array(A, chunks=(3, 3))
     db = da.from_array(b, chunks=5)
-    assert raises(ValueError, lambda: da.linalg.solve_triangular(dA, db))
+    pytest.raises(ValueError, lambda: da.linalg.solve_triangular(dA, db))
 
 
 @pytest.mark.parametrize(('shape', 'chunk'), [(20, 10), (50, 10)])

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -6,7 +6,6 @@ from dask.optimize import fuse
 from dask.array.optimization import (getitem, optimize, optimize_slices,
                                      fuse_slice)
 
-from dask.utils import raises
 from dask.array.core import getarray, getarray_nofancy
 
 
@@ -100,9 +99,8 @@ def test_fuse_slice():
     assert (fuse_slice((1, slice(10, 20)), (None, None, 3, None)) ==
             (1, None, None, 13, None))
 
-    assert (raises(NotImplementedError,
-                   lambda: fuse_slice(slice(10, 15, 2), -1)) or
-            fuse_slice(slice(10, 15, 2), -1) == 14)
+    with pytest.raises(NotImplementedError):
+        fuse_slice(slice(10, 15, 2), -1)
 
 
 def test_fuse_slice_with_lists():

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -6,7 +6,6 @@ import numpy as np
 from dask.array.rechunk import intersect_chunks, rechunk, normalize_chunks
 from dask.array.rechunk import cumdims_label, _breakpoints, _intersect_1d
 import dask.array as da
-from dask.utils import raises
 
 
 def test_rechunk_internals_1():
@@ -155,7 +154,7 @@ def test_rechunk_with_dict():
 def test_rechunk_with_empty_input():
     x = da.ones((24, 24), chunks=(4, 8))
     assert x.rechunk(chunks={}).chunks == x.chunks
-    assert raises(ValueError, lambda: x.rechunk(chunks=()))
+    pytest.raises(ValueError, lambda: x.rechunk(chunks=()))
 
 
 def test_rechunk_with_null_dimensions():

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -18,7 +18,7 @@ from dask.bag.core import (Bag, lazify, lazify_task, map, collect,
                            optimize, from_delayed)
 from dask.async import get_sync
 from dask.compatibility import BZ2File, GzipFile, PY2
-from dask.utils import filetexts, tmpfile, tmpdir, raises, open
+from dask.utils import filetexts, tmpfile, tmpdir, open
 from dask.utils_test import inc, add
 
 
@@ -149,7 +149,7 @@ def test_pluck():
 
 def test_pluck_with_default():
     b = db.from_sequence(['Hello', '', 'World'])
-    assert raises(IndexError, lambda: list(b.pluck(0)))
+    pytest.raises(IndexError, lambda: list(b.pluck(0)))
     assert list(b.pluck(0, None)) == ['H', None, 'W']
     assert b.pluck(0, None).name == b.pluck(0, None).name
     assert b.pluck(0).name != b.pluck(0, None).name
@@ -507,7 +507,7 @@ def test_read_text():
         assert (set(line.strip() for line in db.read_text('a*.log')) ==
                 set('ABCD'))
 
-    assert raises(ValueError, lambda: db.read_text('non-existent-*-path'))
+    pytest.raises(ValueError, lambda: db.read_text('non-existent-*-path'))
 
 
 def test_read_text_large():
@@ -772,7 +772,7 @@ def test_to_textfiles_inputs():
         B.to_textfiles(dirname)
         assert os.path.exists(dirname)
         assert os.path.exists(os.path.join(dirname, '0.part'))
-    assert raises(ValueError, lambda: B.to_textfiles(5))
+    pytest.raises(ValueError, lambda: B.to_textfiles(5))
 
 
 def test_to_textfiles_endlines():
@@ -797,7 +797,7 @@ def test_string_namespace():
                                       ['Charlie', 'Smith']]
     assert list(b.str.match('*Smith')) == ['Alice Smith', 'Charlie Smith']
 
-    assert raises(AttributeError, lambda: b.str.sfohsofhf)
+    pytest.raises(AttributeError, lambda: b.str.sfohsofhf)
     assert b.str.match('*Smith').name == b.str.match('*Smith').name
     assert b.str.match('*Smith').name != b.str.match('*John').name
 

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -4,7 +4,6 @@ import pytest
 import numpy as np
 import pandas as pd
 
-from dask.utils import raises
 import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq, assert_dask_graph, make_meta
 
@@ -576,7 +575,7 @@ def test_frame_series_arithmetic_methods():
         assert_eq(l.rmod(r, axis=0), el.rmod(er, axis=0))
         assert_eq(l.rpow(r, axis=0), el.rpow(er, axis=0))
 
-        assert raises(ValueError, lambda: l.add(r, axis=1))
+        pytest.raises(ValueError, lambda: l.add(r, axis=1))
 
     for l, r, el, er in [(ddf1, pdf2, pdf1, pdf2), (ddf1, ps2, pdf1, ps2)]:
         assert_eq(l, el)
@@ -713,23 +712,23 @@ def test_reduction_series_invalid_axis():
 
     for axis in [1, 'columns']:
         for s in [ddf1.a, pdf1.a]:    # both must behave the same
-            assert raises(ValueError, lambda: s.sum(axis=axis))
-            assert raises(ValueError, lambda: s.min(axis=axis))
-            assert raises(ValueError, lambda: s.max(axis=axis))
+            pytest.raises(ValueError, lambda: s.sum(axis=axis))
+            pytest.raises(ValueError, lambda: s.min(axis=axis))
+            pytest.raises(ValueError, lambda: s.max(axis=axis))
             # only count doesn't have axis keyword
-            assert raises(TypeError, lambda: s.count(axis=axis))
-            assert raises(ValueError, lambda: s.std(axis=axis))
-            assert raises(ValueError, lambda: s.var(axis=axis))
-            assert raises(ValueError, lambda: s.mean(axis=axis))
+            pytest.raises(TypeError, lambda: s.count(axis=axis))
+            pytest.raises(ValueError, lambda: s.std(axis=axis))
+            pytest.raises(ValueError, lambda: s.var(axis=axis))
+            pytest.raises(ValueError, lambda: s.mean(axis=axis))
 
 
 def test_reductions_non_numeric_dtypes():
     # test non-numric blocks
 
     def check_raises(d, p, func):
-        assert raises((TypeError, ValueError),
+        pytest.raises((TypeError, ValueError),
                       lambda: getattr(d, func)().compute())
-        assert raises((TypeError, ValueError),
+        pytest.raises((TypeError, ValueError),
                       lambda: getattr(p, func)())
 
     pds = pd.Series(['a', 'b', 'c', 'd', 'e'])
@@ -818,7 +817,7 @@ def test_reductions_frame(split_every):
         assert_eq(ddf1.mean(axis=axis, split_every=split_every),
                   pdf1.mean(axis=axis))
 
-    assert raises(ValueError, lambda: ddf1.sum(axis='incorrect').compute())
+    pytest.raises(ValueError, lambda: ddf1.sum(axis='incorrect').compute())
 
     # axis=0
     assert_dask_graph(ddf1.sum(split_every=split_every), 'dataframe-sum')

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -9,7 +9,7 @@ import pytest
 import dask
 from dask.async import get_sync
 from dask import delayed
-from dask.utils import raises, ignoring, put_lines
+from dask.utils import ignoring, put_lines
 import dask.dataframe as dd
 
 from dask.dataframe.core import (repartition_divisions, _loc, aca, _concat,
@@ -127,7 +127,7 @@ def test_Index():
         ddf = dd.from_pandas(case, 3)
         assert_eq(ddf.index, case.index)
         assert repr(ddf.index).startswith('dd.Index')
-        assert raises(AttributeError, lambda: ddf.index.index)
+        pytest.raises(AttributeError, lambda: ddf.index.index)
 
 
 def test_Scalar():
@@ -844,7 +844,7 @@ def test_dataframe_quantile():
     assert (result < maxexp).all().all()
 
     assert_eq(ddf.quantile(axis=1), df.quantile(axis=1))
-    assert raises(ValueError, lambda: ddf.quantile([0.25, 0.75], axis=1))
+    pytest.raises(ValueError, lambda: ddf.quantile([0.25, 0.75], axis=1))
 
 
 def test_index():
@@ -898,7 +898,7 @@ def test_map():
     assert_eq(d.b.map(lk), full.b.map(lk))
     assert_eq(d.b.map(lk, meta=d.b), full.b.map(lk))
     assert_eq(d.b.map(lk, meta=('b', 'i8')), full.b.map(lk))
-    assert raises(TypeError, lambda: d.a.map(d.b))
+    pytest.raises(TypeError, lambda: d.a.map(d.b))
 
 
 def test_concat():
@@ -1347,7 +1347,7 @@ def test_repartition():
                 [10, 50, 20, 60],    # not sorted
                 [10, 10, 20, 60]]:   # not unique (last element can be duplicated)
 
-        assert raises(ValueError, lambda: a.repartition(divisions=div))
+        pytest.raises(ValueError, lambda: a.repartition(divisions=div))
 
     pdf = pd.DataFrame(np.random.randn(7, 5), columns=list('abxyz'))
     for p in range(1, 7):
@@ -1870,7 +1870,7 @@ def test_rename_function():
 
 def test_rename_index():
     renamer = {0: 1}
-    assert raises(ValueError, lambda: d.rename(index=renamer))
+    pytest.raises(ValueError, lambda: d.rename(index=renamer))
 
 
 def test_to_timestamp():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2,8 +2,9 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 
+import pytest
+
 import dask
-from dask.utils import raises
 import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq, assert_dask_graph
 
@@ -96,8 +97,8 @@ def test_full_groupby():
                       index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
     ddf = dd.from_pandas(df, npartitions=3)
 
-    assert raises(Exception, lambda: df.groupby('does_not_exist'))
-    assert raises(Exception, lambda: df.groupby('a').does_not_exist)
+    pytest.raises(Exception, lambda: df.groupby('does_not_exist'))
+    pytest.raises(Exception, lambda: df.groupby('a').does_not_exist)
     assert 'b' in dir(df.groupby('a'))
 
     def func(df):
@@ -273,7 +274,7 @@ def test_series_groupby_errors():
         ss.groupby([])   # dask should raise the same error
 
     sss = dd.from_pandas(s, npartitions=3)
-    assert raises(NotImplementedError, lambda: ss.groupby(sss))
+    pytest.raises(NotImplementedError, lambda: ss.groupby(sss))
 
     with tm.assertRaises(KeyError):
         s.groupby('x')    # pandas
@@ -292,7 +293,7 @@ def test_groupby_index_array():
 def test_groupby_set_index():
     df = tm.makeTimeDataFrame()
     ddf = dd.from_pandas(df, npartitions=2)
-    assert raises(NotImplementedError,
+    pytest.raises(NotImplementedError,
                   lambda: ddf.groupby(df.index.month, as_index=False))
 
 
@@ -401,11 +402,11 @@ def test_split_apply_combine_on_series():
             sorted(ddf.groupby(ddf.a > 3).b.mean().dask))
 
     # test raises with incorrect key
-    assert raises(KeyError, lambda: ddf.groupby('x'))
-    assert raises(KeyError, lambda: ddf.groupby(['a', 'x']))
-    assert raises(KeyError, lambda: ddf.groupby('a')['x'])
-    assert raises(KeyError, lambda: ddf.groupby('a')['b', 'x'])
-    assert raises(KeyError, lambda: ddf.groupby('a')[['b', 'x']])
+    pytest.raises(KeyError, lambda: ddf.groupby('x'))
+    pytest.raises(KeyError, lambda: ddf.groupby(['a', 'x']))
+    pytest.raises(KeyError, lambda: ddf.groupby('a')['x'])
+    pytest.raises(KeyError, lambda: ddf.groupby('a')['b', 'x'])
+    pytest.raises(KeyError, lambda: ddf.groupby('a')[['b', 'x']])
 
     # test graph node labels
     assert_dask_graph(ddf.groupby('b').a.sum(), 'series-groupby-sum')

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -1,10 +1,10 @@
-
 import pandas as pd
 import pandas.util.testing as tm
 import numpy as np
 
+import pytest
+
 import dask
-from dask.utils import raises
 import dask.dataframe as dd
 
 from dask.dataframe.core import _coerce_loc_index
@@ -38,7 +38,7 @@ def test_loc():
     assert_eq(d.a.loc[:8], full.a.loc[:8])
     assert_eq(d.a.loc[3:], full.a.loc[3:])
 
-    assert raises(KeyError, lambda: d.loc[1000])
+    pytest.raises(KeyError, lambda: d.loc[1000])
     assert_eq(d.loc[1000:], full.loc[1000:])
     assert_eq(d.loc[-2000:-1000], full.loc[-2000:-1000])
 
@@ -97,9 +97,9 @@ def test_getitem():
 
     assert_eq(ddf[ddf.C.repartition([0, 2, 5, 8])], df[df.C])
 
-    assert raises(KeyError, lambda: df['X'])
-    assert raises(KeyError, lambda: df[['A', 'X']])
-    assert raises(AttributeError, lambda: df.X)
+    pytest.raises(KeyError, lambda: df['X'])
+    pytest.raises(KeyError, lambda: df[['A', 'X']])
+    pytest.raises(AttributeError, lambda: df.X)
 
     # not str/unicode
     df = pd.DataFrame(np.random.randn(10, 5))
@@ -107,8 +107,8 @@ def test_getitem():
     assert_eq(ddf[0], df[0])
     assert_eq(ddf[[1, 2]], df[[1, 2]])
 
-    assert raises(KeyError, lambda: df[8])
-    assert raises(KeyError, lambda: df[[1, 8]])
+    pytest.raises(KeyError, lambda: df[8])
+    pytest.raises(KeyError, lambda: df[[1, 8]])
 
 
 def test_getitem_slice():

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq
-from dask.utils import raises, ignoring
+from dask.utils import ignoring
 
 
 def mad(x):
@@ -147,23 +147,23 @@ def test_rolling_functions_raises():
     df = pd.DataFrame({'a': np.random.randn(25).cumsum(),
                        'b': np.random.randint(100, size=(25,))})
     ddf = dd.from_pandas(df, 3)
-    assert raises(TypeError, lambda: dd.rolling_mean(ddf, 1.5))
-    assert raises(ValueError, lambda: dd.rolling_mean(ddf, -1))
-    assert raises(NotImplementedError, lambda: dd.rolling_mean(ddf, 3, freq=2))
-    assert raises(NotImplementedError, lambda: dd.rolling_mean(ddf, 3, how='min'))
+    pytest.raises(TypeError, lambda: dd.rolling_mean(ddf, 1.5))
+    pytest.raises(ValueError, lambda: dd.rolling_mean(ddf, -1))
+    pytest.raises(NotImplementedError, lambda: dd.rolling_mean(ddf, 3, freq=2))
+    pytest.raises(NotImplementedError, lambda: dd.rolling_mean(ddf, 3, how='min'))
 
 
 def test_rolling_raises():
     df = pd.DataFrame({'a': np.random.randn(25).cumsum(),
                        'b': np.random.randint(100, size=(25,))})
     ddf = dd.from_pandas(df, 3)
-    assert raises(ValueError, lambda: ddf.rolling(1.5))
-    assert raises(ValueError, lambda: ddf.rolling(-1))
-    assert raises(ValueError, lambda: ddf.rolling(3, min_periods=1.2))
-    assert raises(ValueError, lambda: ddf.rolling(3, min_periods=-2))
-    assert raises(ValueError, lambda: ddf.rolling(3, axis=10))
-    assert raises(ValueError, lambda: ddf.rolling(3, axis='coulombs'))
-    assert raises(NotImplementedError, lambda: ddf.rolling(100).mean().compute())
+    pytest.raises(ValueError, lambda: ddf.rolling(1.5))
+    pytest.raises(ValueError, lambda: ddf.rolling(-1))
+    pytest.raises(ValueError, lambda: ddf.rolling(3, min_periods=1.2))
+    pytest.raises(ValueError, lambda: ddf.rolling(3, min_periods=-2))
+    pytest.raises(ValueError, lambda: ddf.rolling(3, axis=10))
+    pytest.raises(ValueError, lambda: ddf.rolling(3, axis='coulombs'))
+    pytest.raises(NotImplementedError, lambda: ddf.rolling(100).mean().compute())
 
 
 def test_rolling_functions_names():
@@ -205,7 +205,8 @@ def test_rolling_function_partition_size():
     for obj, dobj in [(df, ddf), (df[0], ddf[0])]:
         assert_eq(pd.rolling_mean(obj, 10), dd.rolling_mean(dobj, 10))
         assert_eq(pd.rolling_mean(obj, 11), dd.rolling_mean(dobj, 11))
-        raises(NotImplementedError, lambda: dd.rolling_mean(dobj, 12))
+        with pytest.raises(NotImplementedError):
+            dd.rolling_mean(dobj, 12).compute()
 
 
 def test_rolling_partition_size():
@@ -215,7 +216,8 @@ def test_rolling_partition_size():
     for obj, dobj in [(df, ddf), (df[0], ddf[0])]:
         assert_eq(obj.rolling(10).mean(), dobj.rolling(10).mean())
         assert_eq(obj.rolling(11).mean(), dobj.rolling(11).mean())
-        raises(NotImplementedError, lambda: dobj.rolling(12).mean())
+        with pytest.raises(NotImplementedError):
+            dobj.rolling(12).mean().compute()
 
 
 def test_rolling_repr():

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -3,7 +3,6 @@ from itertools import product
 import pandas as pd
 import pytest
 
-from dask.utils import raises
 from dask.dataframe.utils import assert_eq
 import dask.dataframe as dd
 
@@ -40,7 +39,7 @@ def test_series_resample_not_implemented():
     s = pd.Series(range(len(index)), index=index)
     ds = dd.from_pandas(s, npartitions=5)
     # Frequency doesn't evenly divide day
-    assert raises(NotImplementedError, lambda: resample(ds, '57T'))
+    pytest.raises(NotImplementedError, lambda: resample(ds, '57T'))
 
 
 def test_unknown_divisions_error():

--- a/dask/store/tests/test_store.py
+++ b/dask/store/tests/test_store.py
@@ -1,5 +1,6 @@
+import pytest
+
 from dask.store import Store
-from dask.utils import raises
 from dask.utils_test import inc, add
 
 
@@ -33,7 +34,7 @@ def test_basic():
 
     def reassign():
         s['x'] = 2
-    assert raises(Exception, reassign)
+    pytest.raises(Exception, reassign)
 
 
 def test_update():
@@ -44,5 +45,6 @@ def test_update():
 
     assert s['y'] == 2
 
-    assert raises(Exception, lambda: s.update({'x': 2}))
-    assert not raises(Exception, lambda: s.update({'x': 1}))
+    pytest.raises(Exception, lambda: s.update({'x': 2}))
+    # Test that it doesn't raise
+    s.update({'x': 1})

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -8,7 +8,7 @@ import sys
 import dask
 from dask.base import (compute, tokenize, normalize_token, normalize_function,
                        visualize)
-from dask.utils import raises, tmpdir, tmpfile, ignoring
+from dask.utils import tmpdir, tmpfile, ignoring
 from dask.utils_test import inc, dec
 from dask.compatibility import unicode
 
@@ -281,7 +281,7 @@ def test_compute_array_bag():
     x = da.arange(5, chunks=2)
     b = db.from_sequence([1, 2, 3])
 
-    assert raises(ValueError, lambda: compute(x, b))
+    pytest.raises(ValueError, lambda: compute(x, b))
 
     xx, bb = compute(x, b, get=dask.async.get_sync)
     assert np.allclose(xx, np.arange(5))

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
-from dask.utils import raises
+import pytest
+
 from dask.utils_test import GetFunctionTestMixin, inc, add
 from dask import core
 from dask.core import (istask, get_dependencies, flatten, subs,
@@ -67,7 +68,7 @@ def test_GetFunctionTestMixin_class():
         get = staticmethod(lambda x, y: 1)
 
     custom_testget = TestCustomGetFail()
-    raises(AssertionError, custom_testget.test_get)
+    pytest.raises(AssertionError, custom_testget.test_get)
 
     class TestCustomGetPass(GetFunctionTestMixin):
         get = staticmethod(core.get)

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -1,7 +1,9 @@
 from itertools import count
 from operator import mul, getitem
 from functools import partial
-from dask.utils import raises
+
+import pytest
+
 from dask.utils_test import add, inc
 from dask.optimize import (cull, fuse, inline, inline_functions, functions_of,
                            dealias, equivalent, sync_keys, merge_sync,
@@ -22,7 +24,7 @@ def test_cull():
     assert cull(d, 'out') == cull(d, ['out'])
     assert cull(d, ['out', 'z'])[0] == d
     assert cull(d, [['out'], ['z']]) == cull(d, ['out', 'z'])
-    assert raises(KeyError, lambda: cull(d, 'badkey'))
+    pytest.raises(KeyError, lambda: cull(d, 'badkey'))
 
 
 def test_fuse():
@@ -284,7 +286,7 @@ class Uncomparable(object):
 def test_equivalence_uncomparable():
     t1 = Uncomparable()
     t2 = Uncomparable()
-    assert raises(TypeError, lambda: t1 == t2)
+    pytest.raises(TypeError, lambda: t1 == t2)
     assert equivalent(t1, t1)
     assert not equivalent(t1, t2)
     assert equivalent((add, t1, 0), (add, t1, 0))

--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -1,12 +1,12 @@
 from multiprocessing.pool import ThreadPool
-
 import threading
 from threading import Thread
 from time import time, sleep
 
+import pytest
+
 from dask.context import set_options
 from dask.threaded import get
-from dask.utils import raises
 from dask.utils_test import inc, add
 
 
@@ -32,7 +32,7 @@ def bad(x):
 
 def test_exceptions_rise_to_top():
     dsk = {'x': 1, 'y': (bad, 'x')}
-    assert raises(ValueError, lambda: get(dsk, 'y'))
+    pytest.raises(ValueError, lambda: get(dsk, 'y'))
 
 
 def test_reuse_pool():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -26,14 +26,6 @@ if system_encoding == 'ascii':
     system_encoding = 'utf-8'
 
 
-def raises(err, lamda):
-    try:
-        lamda()
-        return False
-    except err:
-        return True
-
-
 def deepmap(func, *seqs):
     """ Apply function inside nested lists
 


### PR DESCRIPTION
No need to duplicate code that's in pytest. Found a few cases where the test wasn't actually testing anything either.