### PR TITLE
Remove unnecessary calls to list

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -728,7 +728,7 @@ def topk(k, x):
     dsk = dict(((name, i), (chunk.topk, k, key))
                for i, key in enumerate(x._keys()))
     name2 = 'topk-' + token
-    dsk[(name2, 0)] = (getitem, (np.sort, (np.concatenate, (list, list(dsk)))),
+    dsk[(name2, 0)] = (getitem, (np.sort, (np.concatenate, list(dsk))),
                        slice(-1, -k - 1, -1))
     chunks = ((k,),)
 
@@ -2896,7 +2896,7 @@ def bincount(x, weights=None, minlength=None):
 
     # Sum up all of the intermediate bincounts per block
     name = 'bincount-sum-' + token
-    dsk[(name, 0)] = (np.sum, (list, list(dsk)), 0)
+    dsk[(name, 0)] = (np.sum, list(dsk), 0)
 
     chunks = ((minlength,),)
 

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -515,11 +515,10 @@ def take(outname, inname, blockdims, index, axis=0):
     keys = list(product([outname], *dims))
 
     rev_index = list(map(sorted(index).index, index))
-    vals = [(getitem,
-             (np.concatenate,
-              (list, [(getitem, ((inname, ) + d[:axis] + (i, ) + d[axis + 1:]),
-                      ((colon, ) * axis + (IL, ) + (colon, ) * (n - axis - 1)))
-                      for i, IL in enumerate(index_lists) if IL]), axis),
+    vals = [(getitem, (np.concatenate,
+                       [(getitem, ((inname, ) + d[:axis] + (i, ) + d[axis + 1:]),
+                         ((colon, ) * axis + (IL, ) + (colon, ) * (n - axis - 1)))
+                        for i, IL in enumerate(index_lists) if IL], axis),
              ((colon, ) * axis + (rev_index, ) + (colon, ) * (n - axis - 1)))
             for d in product(*dims)]
 

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -247,38 +247,32 @@ def test_slicing_with_newaxis():
 
 def test_take():
     chunks, dsk = take('y', 'x', [(20, 20, 20, 20)], [5, 1, 47, 3], axis=0)
-    expected = {
-        ('y', 0): (getitem,
-                   (np.concatenate, (list, [(getitem, ('x', 0), ([1, 3, 5],)),
-                                            (getitem, ('x', 2), ([7],))]),
-                    0),
-                   ([2, 0, 3, 1], ))}
+    expected = {('y', 0): (getitem, (np.concatenate,
+                                     [(getitem, ('x', 0), ([1, 3, 5],)),
+                                      (getitem, ('x', 2), ([7],))], 0),
+                           ([2, 0, 3, 1], ))}
     assert dsk == expected
     assert chunks == ((4,),)
 
     chunks, dsk = take('y', 'x', [(20, 20, 20, 20), (20, 20)], [5, 1, 47, 3], axis=0)
-    expected = dict(
-        (('y', 0, j), (getitem,
-                       (np.concatenate, (list, [(getitem, ('x', 0, j),
-                                                ([1, 3, 5], slice(None, None, None))),
-                                                (getitem, ('x', 2, j),
-                                                ([7], slice(None, None, None)))]),
-                        0),
-                       ([2, 0, 3, 1], slice(None, None, None))))
-        for j in range(2))
+    expected = {('y', 0, j): (getitem, (np.concatenate,
+                                        [(getitem, ('x', 0, j),
+                                          ([1, 3, 5], slice(None, None, None))),
+                                         (getitem, ('x', 2, j),
+                                          ([7], slice(None, None, None)))], 0),
+                              ([2, 0, 3, 1], slice(None, None, None)))
+                for j in range(2)}
     assert dsk == expected
     assert chunks == ((4,), (20, 20))
 
     chunks, dsk = take('y', 'x', [(20, 20, 20, 20), (20, 20)], [5, 1, 37, 3], axis=1)
-    expected = dict(
-        (('y', i, 0), (getitem,
-                       (np.concatenate, (list, [(getitem, ('x', i, 0),
-                                                 (slice(None, None, None), [1, 3, 5])),
-                                                (getitem, ('x', i, 1),
-                                                 (slice(None, None, None), [17]))]),
-                        1),
-                       (slice(None, None, None), [2, 0, 3, 1])))
-        for i in range(4))
+    expected = {('y', i, 0): (getitem, (np.concatenate,
+                                        [(getitem, ('x', i, 0),
+                                          (slice(None, None, None), [1, 3, 5])),
+                                         (getitem, ('x', i, 1),
+                                          (slice(None, None, None), [17]))], 1),
+                              (slice(None, None, None), [2, 0, 3, 1]))
+                for i in range(4)}
     assert dsk == expected
     assert chunks == ((20, 20, 20, 20), (4,))
 
@@ -304,15 +298,13 @@ def test_take_sorted():
 def test_slice_lists():
     y, chunks = slice_array('y', 'x', ((3, 3, 3, 1), (3, 3, 3, 1)),
                             ([2, 1, 9], slice(None, None, None)))
-    exp = dict(
-        (('y', 0, i), (getitem,
-                       (np.concatenate, (list, [(getitem, ('x', 0, i),
-                                                 ([1, 2], slice(None, None, None))),
-                                                (getitem, ('x', 3, i),
-                                                 ([0], slice(None, None, None)))]),
-                        0),
-                       ([1, 0, 2], slice(None, None, None))))
-        for i in range(4))
+    exp = {('y', 0, i): (getitem, (np.concatenate,
+                                   [(getitem, ('x', 0, i),
+                                     ([1, 2], slice(None, None, None))),
+                                    (getitem, ('x', 3, i),
+                                     ([0], slice(None, None, None)))], 0),
+                         ([1, 0, 2], slice(None, None, None)))
+           for i in range(4)}
     assert y == exp
     assert chunks == ((3,), (3, 3, 3, 1))
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -32,7 +32,7 @@ except:
 from ..base import Base, normalize_token, tokenize
 from ..compatibility import apply, urlopen
 from ..context import _globals
-from ..core import list2, quote, istask, get_dependencies, reverse_dict
+from ..core import quote, istask, get_dependencies, reverse_dict
 from ..multiprocessing import get as mpget
 from ..optimize import fuse, cull, inline
 from ..utils import (open, system_encoding, takes_multiple_arguments, funcname,
@@ -74,6 +74,11 @@ def lazify(dsk):
     ``dask.bag.core.lazify_task``
     """
     return valmap(lazify_task, dsk)
+
+
+def list2(L):
+    """A call to list that won't get removed by lazify"""
+    return list(L)
 
 
 def inline_singleton_lists(dsk, dependencies=None):

--- a/dask/core.py
+++ b/dask/core.py
@@ -439,19 +439,11 @@ def isdag(d, keys):
     return not getcycle(d, keys)
 
 
-def list2(L):
-    return list(L)
-
-
 def quote(x):
     """ Ensure that this value remains this value in a dask graph
 
-    Some values in dask graph take on special meaning.  Lists become iterators,
-    tasks get executed.  Sometimes we want to ensure that our data is not
-    interpreted but remains literal.
-
-    >>> quote([1, 2, 3])
-    [1, 2, 3]
+    Some values in dask graph take on special meaning. Sometimes we want to
+    ensure that our data is not interpreted but remains literal.
 
     >>> quote((add, 1, 2))  # doctest: +SKIP
     (tuple, [add, 1, 2])

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1276,12 +1276,12 @@ class _Frame(Base):
             qnames = [(_q._name, 0) for _q in quantiles]
 
             if isinstance(quantiles[0], Scalar):
-                dask[(keyname, 0)] = (pd.Series, (list, qnames), num.columns)
+                dask[(keyname, 0)] = (pd.Series, qnames, num.columns)
                 divisions = (min(num.columns), max(num.columns))
                 return Series(dask, keyname, meta, divisions)
             else:
                 from .multi import _pdconcat
-                dask[(keyname, 0)] = (_pdconcat, (list, qnames), 1)
+                dask[(keyname, 0)] = (_pdconcat, qnames, 1)
                 return DataFrame(dask, keyname, meta, quantiles[0].divisions)
 
     @derived_from(pd.DataFrame)
@@ -1299,7 +1299,7 @@ class _Frame(Base):
 
         name = 'describe--' + tokenize(self, split_every)
         dsk = merge(num.dask, *(s.dask for s in stats))
-        dsk[(name, 0)] = (methods.describe_aggregate, (list, stats_names))
+        dsk[(name, 0)] = (methods.describe_aggregate, stats_names)
 
         return self._constructor(dsk, name, num._meta, divisions=[None, None])
 
@@ -1950,8 +1950,7 @@ class DataFrame(_Frame):
             # error is raised from pandas
             meta = self._meta[_extract_meta(key)]
 
-            dsk = dict(((name, i), (operator.getitem,
-                                    (self._name, i), (list, key)))
+            dsk = dict(((name, i), (operator.getitem, (self._name, i), key))
                        for i in range(self.npartitions))
             return self._constructor(merge(self.dask, dsk), name,
                                      meta, self.divisions)
@@ -3229,7 +3228,7 @@ def repartition_divisions(a, b, name, out1, out2, force=False):
                 raise ValueError('check for duplicate partitions\nold:\n%s\n\n'
                                  'new:\n%s\n\ncombined:\n%s'
                                  % (pformat(a), pformat(b), pformat(c)))
-            d[(out2, j - 1)] = (pd.concat, (list, tmp))
+            d[(out2, j - 1)] = (pd.concat, tmp)
         j += 1
     return d
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -425,8 +425,6 @@ def to_castra(df, fn=None, categories=None, sorted_index_column=None,
     Castra.to_dask
     """
     from castra import Castra
-    if isinstance(categories, list):
-        categories = (list, categories)
 
     name = 'to-castra-' + uuid.uuid1().hex
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1422,7 +1422,7 @@ def test_repartition_divisions():
                       ('b', 1): (_loc, ('a', 1), 3, 4, False),
                       ('b', 2): (_loc, ('a', 1), 4, 6, False),
                       ('b', 3): (_loc, ('a', 1), 6, 7, True),
-                      ('c', 0): (pd.concat, (list, [('b', 0), ('b', 1)])),
+                      ('c', 0): (pd.concat, [('b', 0), ('b', 1)]),
                       ('c', 1): ('b', 2),
                       ('c', 2): ('b', 3)}
 

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -24,11 +24,11 @@ def test_column_optimizations_with_bcolz_and_rewrite():
                           (dataframe_from_ctable, bc, slice(0, 2), cols, {}))
                           for i in [1, 2, 3]),
                      dict((('y', i),
-                          (getitem, ('x', i), (list, ['a', 'b'])))
+                          (getitem, ('x', i), ['a', 'b']))
                           for i in [1, 2, 3]))
 
         expected = dict((('y', i), (dataframe_from_ctable,
-                                    bc, slice(0, 2), (list, ['a', 'b']), {}))
+                                    bc, slice(0, 2), ['a', 'b'], {}))
                         for i in [1, 2, 3])
 
         result = dd.optimize(dsk2, [('y', i) for i in [1, 2, 3]])
@@ -53,8 +53,8 @@ def test_castra_column_store():
 
         dsk = dd.optimize(df2.dask, df2._keys())
 
-        assert dsk == {(df2._name, 0): (castra.Castra.load_partition, c, '0--2',
-                                        (list, ['x']))}
+        assert dsk == {(df2._name, 0): (castra.Castra.load_partition, c,
+                                        '0--2', ['x'])}
         df3 = df.index
         dsk = dd.optimize(df3.dask, df3._keys())
         assert dsk == {(df3._name, 0): (castra.Castra.load_index, c, '0--2')}

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -14,7 +14,13 @@ def test_to_task_dasks():
     a = delayed(1, name='a')
     b = delayed(2, name='b')
     task, dasks = to_task_dasks([a, b, 3])
-    assert task == (list, ['a', 'b', 3])
+    assert task == ['a', 'b', 3]
+    assert len(dasks) == 2
+    assert a.dask in dasks
+    assert b.dask in dasks
+
+    task, dasks = to_task_dasks((a, b, 3))
+    assert task == (tuple, ['a', 'b', 3])
     assert len(dasks) == 2
     assert a.dask in dasks
     assert b.dask in dasks


### PR DESCRIPTION
This removes some unnecessary calls to `list` in graphs due to two previous scheduler behaviors:

- List literals would be computed as iterators, which required placing explicit calls to list in the graph. This was changed in https://github.com/dask/dask/pull/834.

- Top-level lists weren't treated as tasks, requiring them to be wrapped in a call to `list`. This was changed in https://github.com/dask/dask/pull/1250.