### PR TITLE
da.random with state is consistent across sizes

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -120,9 +120,11 @@ def test_different_seeds():
     seeds2 = set(different_seeds(n, state))
     assert seeds == seeds2
 
-    # Should be sorted
-    smallseeds = different_seeds(10, 1234)
-    assert smallseeds == sorted(smallseeds)
+    # Consistent ordering
+    seeds = different_seeds(10, 1234)
+    seeds2 = different_seeds(20, 1234)
+
+    assert seeds == seeds2[:10]
 
 
 def test_infer_storage_options():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -411,12 +411,14 @@ def different_seeds(n, random_state=None):
 
     big_n = np.iinfo(np.int32).max
 
-    seeds = set(random_state.randint(big_n, size=n))
+    seeds = []
+    seen = set()
     while len(seeds) < n:
-        seeds.add(random_state.randint(big_n))
-
-    # Sorting makes it easier to know what seeds are for what chunk
-    return sorted(seeds)
+        s = random_state.randint(big_n)
+        if s not in seen:
+            seeds.append(s)
+            seen.add(s)
+    return seeds
 
 
 def is_integer(i):


### PR DESCRIPTION
Previously seeds were culled down in `different_seeds`, and then
returned in sorted order. This causes problems when changing the size of
the output array, as the seeds might be in different order, leading to:

```python
x1 = da.random.RandomState(123).random(20, chunks=20)
x2 = da.random.RandomState(123).random(200, chunks=20)[:20]
assert (x1 == x2).all()
```

to fail. This now returns seeds in the order created, making this
consistent across sizes. Fixes #1684.