### PR TITLE
Prepend optimization keywords with name of optimization

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2324,3 +2324,15 @@ def test_warn_bad_rechunking():
 
     assert record
     assert '20' in record[0].message.args[0]
+
+
+def test_optimize_fuse_keys():
+    x = da.ones(10, chunks=(5,))
+    y = x + 1
+    z = y + 1
+
+    dsk = z._optimize(z.dask, z._keys())
+    assert not set(y.dask) & set(dsk)
+
+    dsk = z._optimize(z.dask, z._keys(), fuse_keys=y._keys())
+    assert all(k in dsk for k in y._keys())

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -103,10 +103,10 @@ def inline_singleton_lists(dsk, dependencies=None):
     return dsk
 
 
-def optimize(dsk, keys, **kwargs):
+def optimize(dsk, keys, fuse_keys=None, **kwargs):
     """ Optimize a dask from a dask.bag """
     dsk2, dependencies = cull(dsk, keys)
-    dsk3, dependencies = fuse(dsk2, keys, dependencies)
+    dsk3, dependencies = fuse(dsk2, keys + (fuse_keys or []), dependencies)
     dsk4 = inline_singleton_lists(dsk3, dependencies)
     dsk5 = lazify(dsk4)
     return dsk5

--- a/docs/source/optimize.rst
+++ b/docs/source/optimize.rst
@@ -4,10 +4,9 @@ Optimization
 Performance can be significantly improved in different contexts by making
 small optimizations on the dask graph before calling the scheduler.
 
-The
-``dask.optimize`` module contains several functions to transform graphs in a
-variety of useful ways. In most cases, users won't need to interact with these
-functions directly, as specialized subsets of these transforms are done
+The ``dask.optimize`` module contains several functions to transform graphs in
+a variety of useful ways. In most cases, users won't need to interact with
+these functions directly, as specialized subsets of these transforms are done
 automatically in the dask collections (``dask.array``, ``dask.bag``, and
 ``dask.dataframe``). However, users working with custom graphs or computations
 may find that applying these methods results in substantial speedups.
@@ -263,6 +262,22 @@ to the top-level of the task, you can pass in ``strategy='top_level'`` as shown:
 The rewriting system provides a powerful abstraction for transforming
 computations at a task level. Again, for many users, directly interacting with
 these transformations will be unnecessary.
+
+
+Keyword Arguments
+-----------------
+
+Some optimizations take optional keyword arguments.  To pass keywords from the
+compute call down to the right optimization, prepend the keyword with the name
+of the optimization.  For example to send a ``keys=`` keyword argument to the
+``fuse`` optimization from a compute call, use the ``fuse_keys=`` keyword:
+
+.. code-block:: python
+
+   def fuse(dsk, keys=None):
+       ...
+
+   x.compute(fuse_keys=['x', 'y', 'z'])
 
 
 API


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/1688

This passes particular keywords to particular optimizations by creating
a convention that we prepend the name of the optimization to the
particular keyword argument.