### PR TITLE
Feature/groupby reductions multiple levels

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -890,10 +890,11 @@ class SeriesGroupBy(_GroupBy):
                 if isinstance(index, list):
                     if len(index) == 0:
                         raise ValueError("No group keys passed!")
-                    msg = "Grouper for '{0}' not 1-dimensional"
-                    raise ValueError(msg.format(index[0]))
+                    #msg = "Grouper for '{0}' not 1-dimensional"
+                    #raise ValueError(msg.format(index[0]))
                 # raise error from pandas
-                df._meta.groupby(index)
+                else:
+                    df._meta.groupby(index)
         super(SeriesGroupBy, self).__init__(df, index=index,
                                             slice=slice, **kwargs)
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -581,6 +581,7 @@ class _GroupBy(object):
         """
         Return whether index is a Series sliced from df
         """
+        # TODO: handle list of series
         if isinstance(df, Series):
             return False
         if (isinstance(index, Series) and index._name in df.columns and
@@ -598,12 +599,17 @@ class _GroupBy(object):
         """
         Return a pd.DataFrameGroupBy / pd.SeriesGroupBy which contains sample data.
         """
+        # TODO: unify with index logic
         sample = self.obj._meta_nonempty
         if isinstance(self.index, Series):
             if self._is_grouped_by_sliced_column(self.obj, self.index):
                 grouped = sample.groupby(sample[self.index.name])
             else:
                 grouped = sample.groupby(self.index._meta_nonempty)
+        elif (isinstance(self.index, list) and
+              any(isinstance(item, Series) for item in self.index)):
+            # TODO: implement this
+            raise NotImplementedError("raise an error to prevent a segfault")
         else:
             grouped = sample.groupby(self.index)
         return _maybe_slice(grouped, self._slice)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -492,6 +492,26 @@ def _determine_levels(index):
         return 0
 
 
+def _normalize_index(df, index):
+    if not isinstance(df, DataFrame):
+        return index
+
+    elif isinstance(index, list):
+        return [_normalize_index(df, col) for col in index]
+
+    elif (isinstance(index, Series) and index.name in df.columns and
+           index._name == df[index.name]._name):
+            return index.name
+
+    elif (isinstance(index, DataFrame) and
+          set(index.columns).issubset(df.columns) and
+          index._name == df[index.columns]._name):
+        return list(index.columns)
+
+    else:
+        return index
+
+
 class _GroupBy(object):
     """ Superclass for DataFrameGroupBy and SeriesGroupBy
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -506,7 +506,7 @@ def _normalize_index(df, index):
         return [_normalize_index(df, col) for col in index]
 
     elif (isinstance(index, Series) and index.name in df.columns and
-           index._name == df[index.name]._name):
+          index._name == df[index.name]._name):
             return index.name
 
     elif (isinstance(index, DataFrame) and

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -140,12 +140,23 @@ def _nunique_df_aggregate(df, levels, name):
     return df.groupby(level=levels)[name].nunique()
 
 
-def _nunique_series_chunk(df, index):
+def _nunique_series_chunk(df, *index):
+    # nunique_series strategy:
+    # build a dataframe with the target column as the first column and all
+    # group columns appended thereafter. Then 
     assert isinstance(df, pd.Series)
-    if isinstance(index, np.ndarray):
-        assert len(index) == len(df)
-        index = pd.Series(index, index=df.index)
-    grouped = pd.concat([df, index], axis=1).drop_duplicates()
+
+    group_index = []
+    for item in index:
+        if isinstance(item, np.ndarray):
+            assert len(item) == len(df)
+            group_index.append(pd.Series(item, index=df.index))
+
+        else:
+            group_index.append(item)
+
+    grouped = pd.concat([df] + group_index, axis=1).drop_duplicates()
+
     return grouped
 
 
@@ -154,7 +165,7 @@ def _nunique_series_combine(df):
 
 
 def _nunique_series_aggregate(df):
-    return df.groupby(df.columns[1])[df.columns[0]].nunique()
+    return df.groupby(list(df.columns[1:]))[df.columns[0]].nunique()
 
 
 ###############################################################

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -471,26 +471,6 @@ def _finalize_std(df, count_column, sum_column, sum2_column, ddof=1):
     return np.sqrt(result)
 
 
-def _normalize_index(df, index):
-    if not isinstance(df, DataFrame):
-        return index
-
-    elif isinstance(index, list):
-        return [_normalize_index(df, col) for col in index]
-
-    elif (isinstance(index, Series) and index.name in df.columns and
-          index._name == df[index.name]._name):
-            return index.name
-
-    elif (isinstance(index, DataFrame) and
-          set(index.columns).issubset(df.columns) and
-          index._name == df[index.columns]._name):
-        return list(index.columns)
-
-    else:
-        return index
-
-
 def _determine_levels(index):
     if isinstance(index, (tuple, list)) and len(index) > 1:
         return list(range(len(index)))

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -566,6 +566,12 @@ class _GroupBy(object):
             # otherwise, group key is regarded as a separate column
             self._meta = self.obj._meta.groupby(self.obj._meta[index.name])
 
+        elif isinstance(self.index, list):
+            self._meta = self.obj._meta.groupby([
+                item._meta if isinstance(item, Series) else item
+                for item in self.index
+            ])
+
         elif isinstance(self.index, Series):
             self._meta = self.obj._meta.groupby(self.index._meta)
         else:

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -830,4 +830,7 @@ def test_series_aggregations_multilevel(grouper, agg_func):
     ddf = dd.from_pandas(pdf, npartitions=10)
 
     assert_eq(call(pdf['c'].groupby(grouper(pdf)), agg_func),
-              call(ddf['c'].groupby(grouper(ddf)), agg_func, split_every=2))
+              call(ddf['c'].groupby(grouper(ddf)), agg_func, split_every=2),
+              # for pandas ~ 0.18, the name is not not properly propagated for
+              # the mean aggregation
+              check_names=(agg_func != 'mean'))

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -655,7 +655,7 @@ def test_aggregate__examples(spec, split_every, grouper):
 ])
 @pytest.mark.parametrize('split_every', [False, None])
 @pytest.mark.parametrize('grouper', [
-    pytest.mark.xfail(reason="Grouper for '{0}' not 1-dimensional")(lambda df: [df['a'], df['d']]),
+    lambda df: [df['a'], df['d']],
     lambda df: df['a'],
     lambda df: df['a'] > 2,
 ])

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -675,10 +675,7 @@ def test_series_aggregate__examples(spec, split_every, grouper):
 
 
 @pytest.mark.parametrize('spec', [
-    'sum', 'min', 'max', 'count', 'size',
-    'std', # NOTE: for std the result is not recast ot the original dtype
-    pytest.mark.xfail(reason="pandas recast to original type")('var'),
-    pytest.mark.xfail(reason="pandas recast to original type")('mean')
+    'sum', 'min', 'max', 'count', 'size', 'std', 'var', 'mean',
 ])
 def test_aggregate__single_element_groups(spec):
     pdf = pd.DataFrame({'a': [1, 1, 3, 3],
@@ -688,7 +685,13 @@ def test_aggregate__single_element_groups(spec):
                        columns=['c', 'b', 'a', 'd'])
     ddf = dd.from_pandas(pdf, npartitions=3)
 
-    assert_eq(pdf.groupby(['a', 'd']).agg(spec),
+    expected = pdf.groupby(['a', 'd']).agg(spec)
+
+    # NOTE: for std the result is not recast ot the original dtype
+    if spec in {'mean', 'var'}:
+        expected = expected.astype(float)
+
+    assert_eq(expected,
               ddf.groupby(['a', 'd']).agg(spec))
 
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -809,8 +809,7 @@ def test_dataframe_aggregations_multilevel(grouper, agg_func):
 
 
 @pytest.mark.parametrize('agg_func', [
-    'sum', 'var', 'mean', 'count', 'size', 'std', 'min', 'max',
-    pytest.mark.xfail(reason="nunique is not yet propery supported")('nunique'),
+    'sum', 'var', 'mean', 'count', 'size', 'std', 'min', 'max', 'nunique',
 ])
 @pytest.mark.parametrize('grouper', [
     lambda df: df['a'],

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -840,4 +840,4 @@ def test_series_aggregations_multilevel(grouper, agg_func):
               call(ddf['c'].groupby(grouper(ddf)), agg_func, split_every=2),
               # for pandas ~ 0.18, the name is not not properly propagated for
               # the mean aggregation
-              check_names=(agg_func != 'mean'))
+              check_names=(agg_func not in {'mean', 'nunique'}))

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -304,8 +304,13 @@ def test_groupby_index_array():
     df = tm.makeTimeDataFrame()
     ddf = dd.from_pandas(df, npartitions=2)
 
+    # first select column, then group
     assert_eq(df.A.groupby(df.index.month).nunique(),
               ddf.A.groupby(ddf.index.month).nunique(), check_names=False)
+
+    # first group, then select column
+    assert_eq(df.groupby(df.index.month).A.nunique(),
+              ddf.groupby(ddf.index.month).A.nunique(), check_names=False)
 
 
 def test_groupby_set_index():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -8,8 +8,6 @@ import dask
 import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq, assert_dask_graph, assert_max_deps
 
-import pytest
-
 
 def groupby_internal_repr():
     pdf = pd.DataFrame({'x': [1, 2, 3, 4, 6, 7, 8, 9, 10],

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -742,3 +742,9 @@ def test_aggregations_multilevel(agg_func):
 
     assert_eq(call(pdf.groupby(['a'])['c'], agg_func),
               call(ddf.groupby(['a'])['c'], agg_func))
+
+    assert_eq(call(pdf.groupby(pdf['a'])['c'], agg_func),
+              call(ddf.groupby(ddf['a'])['c'], agg_func))
+
+    assert_eq(call(pdf.groupby([pdf['a'], pdf['b']])['c'], agg_func),
+              call(ddf.groupby([ddf['a'], ddf['b']])['c'], agg_func))

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -726,16 +726,16 @@ def test_aggregate__dask():
 
 @pytest.mark.parametrize('agg_func', ['sum', 'var', 'mean', 'count', 'size',
                                       'std', 'nunique', 'min', 'max'])
-def test_aggs_multilevel(agg_func):
+def test_aggregations_multilevel(agg_func):
     def call(g, m, **kwargs):
         return getattr(g, m)(**kwargs)
 
-    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 20,
-                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 20,
-                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 20},
+    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10},
                        columns=['c', 'b', 'a'])
 
-    ddf = dd.from_pandas(pdf, npartitions=20)
+    ddf = dd.from_pandas(pdf, npartitions=10)
 
     assert_eq(call(pdf.groupby(['a', 'b'])['c'], agg_func),
               call(ddf.groupby(['a', 'b'])['c'], agg_func, split_every=2))

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -748,3 +748,6 @@ def test_aggregations_multilevel(agg_func):
 
     assert_eq(call(pdf.groupby([pdf['a'], pdf['b']])['c'], agg_func),
               call(ddf.groupby([ddf['a'], ddf['b']])['c'], agg_func))
+
+    assert_eq(call(pdf.groupby([pdf['a'] > 2, pdf['b'] > 1])['c'], agg_func),
+              call(ddf.groupby([ddf['a'] > 2, ddf['b'] > 1])['c'], agg_func))


### PR DESCRIPTION
While working on #1678, I found that the aggregates `std`, `var`, `nunique`  for  `df.groupby(...)` do not with multiple groupby columns. Further, grouping of multiple series that are transformations of columns  is not supported. 

Tests that fail with dask master for these cases are attached.
