### PR TITLE
Cull dask.arrays on slicing

### DIFF
--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -482,3 +482,11 @@ def test_index_with_dask_array_errors():
 
     with pytest.raises(NotImplementedError):
         x[0, x > 10]
+
+
+def test_cull():
+    x = da.ones(1000, chunks=(10,))
+
+    for slc in [1, slice(0, 30), slice(0, None, 100)]:
+        y = x[slc]
+        assert len(y.dask) < len(x.dask)

--- a/dask/core.py
+++ b/dask/core.py
@@ -191,7 +191,7 @@ def _deps(dsk, arg):
     return [arg]
 
 
-def get_dependencies(dsk, task, as_list=False):
+def get_dependencies(dsk, key=None, task=None, as_list=False):
     """ Get the immediate tasks on which this task depends
 
     >>> dsk = {'x': 1,
@@ -214,8 +214,16 @@ def get_dependencies(dsk, task, as_list=False):
 
     >>> get_dependencies(dsk, 'a')  # Ignore non-keys
     set(['x'])
+
+    >>> get_dependencies(dsk, task=(inc, 'x'))  # provide tasks directly
+    set(['x'])
     """
-    args = [dsk[task]]
+    if key is not None:
+        args = [dsk[key]]
+    elif task is not None:
+        args = [task]
+    else:
+        raise ValueError("Provide either key or task")
     result = []
     while args:
         arg = args.pop()

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -94,6 +94,16 @@ def test_get_dependencies_list():
     assert get_dependencies(dsk, 'z') == set(['x', 'y'])
 
 
+def test_get_dependencies_task():
+    dsk = {'x': 1, 'y': 2, 'z': ['x', [(inc, 'y')]]}
+    assert get_dependencies(dsk, task=(inc, 'x')) == set(['x'])
+
+
+def test_get_dependencies_nothing():
+    with pytest.raises(ValueError):
+        get_dependencies({})
+
+
 def test_flatten():
     assert list(flatten(())) == []
     assert list(flatten('foo')) == ['foo']


### PR DESCRIPTION
This prevents the propagation of large dask.arrays after slicing events

cc @shoyer this might affect you