### PR TITLE
Add rename support for multi-level columns

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2793,26 +2793,30 @@ def map_partitions(func, *args, **kwargs):
         # If `meta` is not a pandas object, the concatenated results will be a
         # different type
         meta = _concat([meta])
-
-    if isinstance(meta, pd.DataFrame):
-        columns = meta.columns
-    elif isinstance(meta, (pd.Series, pd.Index)):
-        columns = meta.name
-    else:
-        columns = None
+    meta = make_meta(meta)
 
     dfs = [df for df in args if isinstance(df, _Frame)]
     dsk = {}
     for i in range(dfs[0].npartitions):
         values = [(arg._name, i if isinstance(arg, _Frame) else 0)
                   if isinstance(arg, (_Frame, Scalar)) else arg for arg in args]
-        values = (apply, func, (tuple, values), kwargs)
-        if columns is not None:
-            values = (_rename, columns, values)
-        dsk[(name, i)] = values
+        dsk[(name, i)] = (apply_and_enforce, func, values, kwargs, meta)
 
     dasks = [arg.dask for arg in args if isinstance(arg, (_Frame, Scalar))]
     return new_dd_object(merge(dsk, *dasks), name, meta, args[0].divisions)
+
+
+def apply_and_enforce(func, args, kwargs, meta):
+    """Apply a function, and enforce the output to match meta
+
+    Ensures the output has the same columns, even if empty."""
+    df = func(*args, **kwargs)
+    if isinstance(df, (pd.DataFrame, pd.Series, pd.Index)):
+        if len(df) == 0:
+            return meta
+        c = meta.columns if isinstance(df, pd.DataFrame) else meta.name
+        return _rename(c, df)
+    return df
 
 
 def _rename(columns, df):
@@ -2851,9 +2855,9 @@ def _rename(columns, df):
     elif isinstance(df, (pd.Series, pd.Index)):
         if isinstance(columns, (pd.Series, pd.Index)):
             columns = columns.name
-        if name == columns:
+        if df.name == columns:
             return df
-        return pd.Series(df, name=columns)
+        return df.rename(columns)
     # map_partition may pass other types
     return df
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -728,8 +728,7 @@ class _GroupBy(object):
 
             with raise_on_meta_error("groupby.apply({0})".format(funcname(func))):
                 meta = self._meta_nonempty.apply(func)
-        else:
-            meta = make_meta(meta)
+        meta = make_meta(meta)
 
         df = self.obj
         if isinstance(self.index, DataFrame):  # add index columns to dataframe

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -514,6 +514,7 @@ def test_frame_series_arithmetic_methods():
                         index=list('abcdefghjk'), columns=list('ABCX'))
     ps1 = pdf1.A
     ps2 = pdf2.A
+    ps3 = pd.Series(np.random.randn(10), index=list('ABCDXabcde'))
 
     ddf1 = dd.from_pandas(pdf1, 2)
     ddf2 = dd.from_pandas(pdf2, 2)
@@ -577,7 +578,7 @@ def test_frame_series_arithmetic_methods():
 
         pytest.raises(ValueError, lambda: l.add(r, axis=1))
 
-    for l, r, el, er in [(ddf1, pdf2, pdf1, pdf2), (ddf1, ps2, pdf1, ps2)]:
+    for l, r, el, er in [(ddf1, pdf2, pdf1, pdf2), (ddf1, ps3, pdf1, ps3)]:
         assert_eq(l, el)
         assert_eq(r, er)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -308,6 +308,16 @@ def test_rename_columns():
     with tm.assertRaisesRegexp(ValueError, msg):
         ddf.columns = [1, 2, 3, 4]
 
+    # Multi-index columns
+    df = pd.DataFrame({('A', '0') : [1, 2, 2, 3], ('B', 1) : [1, 2, 3, 4]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    df.columns = ['x', 'y']
+    ddf.columns = ['x', 'y']
+    tm.assert_index_equal(ddf.columns, pd.Index(['x', 'y']))
+    tm.assert_index_equal(ddf._meta.columns, pd.Index(['x', 'y']))
+    assert_eq(ddf, df)
+
 
 def test_rename_series():
     # GH 819

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -329,6 +329,13 @@ def test_rename_series():
     assert s.name == 'renamed'
     assert_eq(ds, s)
 
+    ind = s.index
+    dind = ds.index
+    ind.name = 'renamed'
+    dind.name = 'renamed'
+    assert ind.name == 'renamed'
+    assert_eq(dind, ind)
+
 
 def test_describe():
     # prepare test case which approx quantiles will be the same as actuals
@@ -1546,8 +1553,8 @@ def test_datetime_accessor():
     assert_eq(a.x.dt.date, df.x.dt.date, check_names=False)
     assert (a.x.dt.to_pydatetime().compute() == df.x.dt.to_pydatetime()).all()
 
-    assert a.x.dt.date.dask == a.x.dt.date.dask
-    assert a.x.dt.to_pydatetime().dask == a.x.dt.to_pydatetime().dask
+    assert set(a.x.dt.date.dask) == set(a.x.dt.date.dask)
+    assert set(a.x.dt.to_pydatetime().dask) == set(a.x.dt.to_pydatetime().dask)
 
 
 def test_str_accessor():
@@ -1557,27 +1564,27 @@ def test_str_accessor():
 
     assert 'upper' in dir(a.x.str)
     assert_eq(a.x.str.upper(), df.x.str.upper())
-    assert a.x.str.upper().dask == a.x.str.upper().dask
+    assert set(a.x.str.upper().dask) == set(a.x.str.upper().dask)
 
     assert 'upper' in dir(a.index.str)
     assert_eq(a.index.str.upper(), df.index.str.upper())
-    assert a.index.str.upper().dask == a.index.str.upper().dask
+    assert set(a.index.str.upper().dask) == set(a.index.str.upper().dask)
 
     # make sure to pass thru args & kwargs
     assert 'contains' in dir(a.x.str)
     assert_eq(a.x.str.contains('a'), df.x.str.contains('a'))
-    assert a.x.str.contains('a').dask == a.x.str.contains('a').dask
+    assert set(a.x.str.contains('a').dask) == set(a.x.str.contains('a').dask)
 
     assert_eq(a.x.str.contains('d', case=False), df.x.str.contains('d', case=False))
-    assert a.x.str.contains('d', case=False).dask == a.x.str.contains('d', case=False).dask
+    assert set(a.x.str.contains('d', case=False).dask) == set(a.x.str.contains('d', case=False).dask)
 
     for na in [True, False]:
         assert_eq(a.x.str.contains('a', na=na), df.x.str.contains('a', na=na))
-        assert a.x.str.contains('a', na=na).dask == a.x.str.contains('a', na=na).dask
+        assert set(a.x.str.contains('a', na=na).dask) == set(a.x.str.contains('a', na=na).dask)
 
     for regex in [True, False]:
         assert_eq(a.x.str.contains('a', regex=regex), df.x.str.contains('a', regex=regex))
-        assert a.x.str.contains('a', regex=regex).dask == a.x.str.contains('a', regex=regex).dask
+        assert set(a.x.str.contains('a', regex=regex).dask) == set(a.x.str.contains('a', regex=regex).dask)
 
 
 def test_empty_max():


### PR DESCRIPTION
Fixes #1694.

Also found a bug in the method versions of operators when applied to
Series with axis=1. `map_partitions` was automatically repartitioning
this, resulting in an incorrect answer. However, the old way of renaming
columns was actually creating new columns filled with `NaN`. Since the
data it was being tried had no matches between columns and index, the
output was also all `NaN`, masking the issue. This changes the test so
it would have caught the issue, and fixes the implementation of the
operator.