### PR TITLE
Allow atop to change chunk shape

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1966,8 +1966,15 @@ def atop(func, out_ind, *args, **kwargs):
     if rechunk:
         for i, ind in enumerate(out_ind):
             if ind in rechunk:
-                func = rechunk[ind]
-                chunks[i] = tuple(map(func, chunks[i]))
+                if callable(rechunk[ind]):
+                    chunks[i] = tuple(map(rechunk[ind], chunks[i]))
+                elif isinstance(rechunk[ind], int):
+                    chunks[i] = tuple(rechunk[ind] for _ in chunks[i])
+                elif isinstance(rechunk[ind], (tuple, list)):
+                    chunks[i] = tuple(rechunk[ind])
+                else:
+                    raise NotImplementedError(
+                        "rechunk values must be callable, int, or tuple")
     chunks = tuple(chunks)
 
     return Array(merge(dsk, *dsks), out, chunks, dtype=dtype)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2135,26 +2135,26 @@ def test_atop_chunks():
     def double(a, axis=0):
         return np.concatenate([a, a], axis=axis)
 
-    y = atop(double, 'ij', x, 'ij', rechunk={'i': lambda n: 2 * n}, axis=0,
-             dtype=x.dtype)
+    y = atop(double, 'ij', x, 'ij',
+             adjust_chunks={'i': lambda n: 2 * n}, axis=0, dtype=x.dtype)
     assert y.chunks == ((4, 2, 4), (3, 2))
     assert_eq(y, np.ones((10, 5)))
 
-    y = atop(double, 'ij', x, 'ij', rechunk={'j': lambda n: 2 * n}, axis=1,
-             dtype=x.dtype)
+    y = atop(double, 'ij', x, 'ij',
+             adjust_chunks={'j': lambda n: 2 * n}, axis=1, dtype=x.dtype)
     assert y.chunks == ((2, 1, 2), (6, 4))
     assert_eq(y, np.ones((5, 10)))
 
     x = da.ones((10, 10), chunks=(5, 5))
-    y = atop(double, 'ij', x, 'ij', axis=0, rechunk={'i': 10}, dtype=x.dtype)
+    y = atop(double, 'ij', x, 'ij', axis=0,
+             adjust_chunks={'i': 10}, dtype=x.dtype)
     assert y.chunks == ((10, 10), (5, 5))
     assert_eq(y, np.ones((20, 10)))
 
-    y = atop(double, 'ij', x, 'ij', axis=0, rechunk={'i': (10, 10)},
-             dtype=x.dtype)
+    y = atop(double, 'ij', x, 'ij', axis=0,
+             adjust_chunks={'i': (10, 10)}, dtype=x.dtype)
     assert y.chunks == ((10, 10), (5, 5))
     assert_eq(y, np.ones((20, 10)))
-
 
 
 def test_from_delayed():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2129,6 +2129,23 @@ def test_atop_kwargs():
     assert_eq(y, np.ones(5) + 10)
 
 
+def test_atop_chunks():
+    x = da.ones((5, 5), chunks=((2, 1, 2), (3, 2)))
+
+    def double(a, axis=0):
+        return np.concatenate([a, a], axis=axis)
+
+    y = atop(double, 'ij', x, 'ij', rechunk={'i': lambda n: 2 * n}, axis=0,
+             dtype=x.dtype)
+    assert y.chunks == ((4, 2, 4), (3, 2))
+    assert_eq(y, np.ones((10, 5)))
+
+    y = atop(double, 'ij', x, 'ij', rechunk={'j': lambda n: 2 * n}, axis=1,
+             dtype=x.dtype)
+    assert y.chunks == ((2, 1, 2), (6, 4))
+    assert_eq(y, np.ones((5, 10)))
+
+
 def test_from_delayed():
     v = delayed(np.ones)((5, 3))
     x = from_delayed(v, shape=(5, 3), dtype=np.ones(0).dtype)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2145,6 +2145,17 @@ def test_atop_chunks():
     assert y.chunks == ((2, 1, 2), (6, 4))
     assert_eq(y, np.ones((5, 10)))
 
+    x = da.ones((10, 10), chunks=(5, 5))
+    y = atop(double, 'ij', x, 'ij', axis=0, rechunk={'i': 10}, dtype=x.dtype)
+    assert y.chunks == ((10, 10), (5, 5))
+    assert_eq(y, np.ones((20, 10)))
+
+    y = atop(double, 'ij', x, 'ij', axis=0, rechunk={'i': (10, 10)},
+             dtype=x.dtype)
+    assert y.chunks == ((10, 10), (5, 5))
+    assert_eq(y, np.ones((20, 10)))
+
+
 
 def test_from_delayed():
     v = delayed(np.ones)((5, 3))


### PR DESCRIPTION
## Example

``` python
def double(a, axis=0):
    return np.concatenate([a, a], axis=axis)

y = atop(double, 'ij', x, 'ij', chunks={'i': lambda n: 2*n}, axis=0)

y = atop(double, 'ij', x, 'ij', chunks={'j': lambda n: 2*n}, axis=1)
```

cc @shoyer @jcrist 
