### PR TITLE
A few small tweaks to da.Array.astype

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1212,11 +1212,46 @@ class Array(Base):
         return topk(k, self)
 
     def astype(self, dtype, **kwargs):
-        """ Copy of the array, cast to a specified type """
-        if dtype == self._dtype:
-            return self
-        name = 'astype-' + tokenize(self, dtype, kwargs)
-        return elemwise(_astype, self, dtype, name=name)
+        """Copy of the array, cast to a specified type.
+
+        Parameters
+        ----------
+        dtype : str or dtype
+            Typecode or data-type to which the array is cast.
+        casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
+            Controls what kind of data casting may occur. Defaults to 'unsafe'
+            for backwards compatibility.
+
+            * 'no' means the data types should not be cast at all.
+            * 'equiv' means only byte-order changes are allowed.
+            * 'safe' means only casts which can preserve values are allowed.
+            * 'same_kind' means only safe casts or casts within a kind,
+                like float64 to float32, are allowed.
+            * 'unsafe' means any data conversions may be done.
+        copy : bool, optional
+            By default, astype always returns a newly allocated array. If this
+            is set to False and the `dtype` requirement is satisfied, the input
+            array is returned instead of a copy.
+        """
+        # Scalars don't take `casting` or `copy` kwargs - as such we only pass
+        # them to `map_blocks` if specified by user (different than defaults).
+        extra = set(kwargs) - {'casting', 'copy'}
+        if extra:
+            raise TypeError("astype does not take the following keyword "
+                            "arguments: {0!s}".format(list(extra)))
+        casting = kwargs.get('casting', 'unsafe')
+        copy = kwargs.get('copy', True)
+        dtype = np.dtype(dtype)
+        if self._dtype is not None:
+            if self._dtype == dtype:
+                return self
+            elif not np.can_cast(self._dtype, dtype, casting=casting):
+                raise TypeError("Cannot cast array from {0!r} to {1!r}"
+                                " according to the rule "
+                                "{2!r}".format(self._dtype, dtype, casting))
+        name = 'astype-' + tokenize(self, dtype, casting, copy)
+        return self.map_blocks(_astype, dtype=dtype, name=name,
+                               astype_dtype=dtype, **kwargs)
 
     def __abs__(self):
         return elemwise(operator.abs, self)
@@ -3684,8 +3719,8 @@ def from_npy_stack(dirname, mmap_mode='r'):
     return Array(dsk, name, chunks, dtype)
 
 
-def _astype(x, dtype, **kwargs):
-    return x.astype(dtype, **kwargs)
+def _astype(x, astype_dtype=None, **kwargs):
+    return x.astype(astype_dtype, **kwargs)
 
 
 @wraps(np.round)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1093,14 +1093,31 @@ def test_dtype_complex():
 
 
 def test_astype():
-    x = np.ones(5, dtype='f4')
-    d = da.from_array(x, chunks=(2,))
+    x = np.ones((5, 5), dtype='f8')
+    d = da.from_array(x, chunks=(2,2))
 
     assert d.astype('i8')._dtype == 'i8'
     assert_eq(d.astype('i8'), x.astype('i8'))
     assert same_keys(d.astype('i8'), d.astype('i8'))
 
-    assert d.astype(d.dtype) is d
+    with pytest.raises(TypeError):
+        d.astype('i8', casting='safe')
+
+    with pytest.raises(TypeError):
+        d.astype('i8', not_a_real_kwarg='foo')
+
+    # smoketest with kwargs
+    assert_eq(d.astype('i8', copy=False), x.astype('i8', copy=False))
+
+    # Check it's a noop
+    assert d.astype('f8') is d
+
+    # Check arrays with unknown dtype are not noops. Since `dtype('f8') == None`
+    # is True, comparing dtypes directly can lead to bugs
+    d._dtype = None
+    d2 = d.astype('f8')
+    assert d2 is not d
+    assert_eq(d2, x.astype('f8'))
 
 
 def test_arithmetic():


### PR DESCRIPTION
- Support `copy` and `casting` arguments
- Error at graph build time when casting doesn't work
- Fix a bug when dtype is unknown and casting to `f8`. Previously this
  would result in a no-op, as `np.dtype('f8') == None`, now `_astype` is
  applied as it should be.