### PR TITLE
Unify column names in dd.read_csv

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -56,6 +56,8 @@ def pandas_read_text(reader, b, header, kwargs, dtypes=None, columns=None,
 
     if enforce and columns and (list(df.columns) != list(columns)):
         raise ValueError("Columns do not match", df.columns, columns)
+    elif columns:
+        df.columns = columns
     return df
 
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -667,6 +667,17 @@ def test_read_csv_singleton_dtype():
                   dd.read_csv(fn, dtype=float))
 
 
+def test_robust_column_mismatch():
+    files = csv_files.copy()
+    k = sorted(files)[-1]
+    files[k] = files[k].replace(b'name', b'Name')
+    with filetexts(files, mode='b'):
+        ddf = dd.read_csv('2014-01-*.csv')
+        df = pd.read_csv('2014-01-01.csv')
+        assert (df.columns == ddf.columns).all()
+        assert_eq(ddf, ddf)
+
+
 ############
 #  to_csv  #
 ############


### PR DESCRIPTION
Perhaps we should do this somewhere more globally?
Perhaps we shouldn't do this at all?

cc @jcrist thoughts on how to improve?  Should we remove?