### PR TITLE
ENH: add dd.DataFrame.resample

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1385,6 +1385,11 @@ class _Frame(Base):
         """ bind operator method like DataFrame.add to this class """
         raise NotImplementedError
 
+    @derived_from(pd.DataFrame)
+    def resample(self, rule, how=None, closed=None, label=None):
+        from .tseries.resample import _resample
+        return _resample(self, rule, how=how, closed=closed, label=label)
+
 
 normalize_token.register((Scalar, _Frame), lambda a: a._name)
 
@@ -1502,11 +1507,6 @@ class Series(_Frame):
         """
         from .partitionquantiles import partition_quantiles
         return partition_quantiles(self, npartitions, upsample=upsample)
-
-    @derived_from(pd.Series)
-    def resample(self, rule, how=None, closed=None, label=None):
-        from .tseries.resample import _resample
-        return _resample(self, rule, how=how, closed=closed, label=label)
 
     def __getitem__(self, key):
         if isinstance(key, Series) and self.divisions == key.divisions:

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -11,16 +11,20 @@ def resample(df, freq, how='mean', **kwargs):
     return getattr(df.resample(freq, **kwargs), how)()
 
 
-@pytest.mark.parametrize(['method', 'npartitions', 'freq', 'closed', 'label'],
-                         list(product(['count', 'mean', 'ohlc'],
+@pytest.mark.parametrize(['obj', 'method', 'npartitions', 'freq', 'closed', 'label'],
+                         list(product(['series', 'frame'],
+                                      ['count', 'mean', 'ohlc'],
                                       [2, 5],
                                       ['30T', 'h', 'd', 'w', 'M'],
                                       ['right', 'left'],
                                       ['right', 'left'])))
-def test_series_resample(method, npartitions, freq, closed, label):
+def test_series_resample(obj, method, npartitions, freq, closed, label):
     index = pd.date_range('1-1-2000', '2-15-2000', freq='h')
     index = index.union(pd.date_range('4-15-2000', '5-15-2000', freq='h'))
-    ps = pd.Series(range(len(index)), index=index)
+    if obj == 'series':
+        ps = pd.Series(range(len(index)), index=index)
+    elif obj == 'frame':
+        ps = pd.DataFrame({'a':range(len(index))}, index=index)
     ds = dd.from_pandas(ps, npartitions=npartitions)
     # Series output
 


### PR DESCRIPTION
The existing resample machinery seems to work as is for dataframes, as I simply moved the `resample` method from `Series` to the base `_Frame`.

This gives only the basic resample (eg `df.resample(freq).mean()`), and not selecting columns on the Resampler object (like `df.resample(freq)[['col1', 'col2']].mean()` or more advanced agg specifications (like `df.resample(freq).agg({'col1': 'mean', 'col2': 'first'})`, but I don't think those are essential to start with.