### PR TITLE
Avoid calling list on partitions

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -14,8 +14,7 @@ from distutils.version import LooseVersion
 from ..utils import ignoring, eq_strict
 
 from toolz import (merge, take, reduce, valmap, map, partition_all, filter,
-                   remove, compose, curry, first, second, accumulate, cons,
-                   peek)
+                   remove, compose, curry, first, second, accumulate, peek)
 from toolz.compatibility import iteritems, zip
 import toolz
 _implement_accumulate = LooseVersion(toolz.__version__) > '0.7.4'

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -14,7 +14,8 @@ from distutils.version import LooseVersion
 from ..utils import ignoring, eq_strict
 
 from toolz import (merge, take, reduce, valmap, map, partition_all, filter,
-                   remove, compose, curry, first, second, accumulate)
+                   remove, compose, curry, first, second, accumulate, cons,
+                   peek)
 from toolz.compatibility import iteritems, zip
 import toolz
 _implement_accumulate = LooseVersion(toolz.__version__) > '0.7.4'
@@ -1617,11 +1618,14 @@ def groupby_disk(b, grouper, npartitions=None, blocksize=2**20):
 
 
 def empty_safe_apply(func, part):
-    part = list(part)
-    if part:
-        return func(part)
+    if isinstance(part, Iterator):
+        try:
+            _, part = peek(part)
+            return func(part)
+        except StopIteration:
+            return no_result
     else:
-        return no_result
+        return func(part)
 
 
 def empty_safe_aggregate(func, parts):


### PR DESCRIPTION
Previously we accidentally called `list` on partitions in certain reductions to
ensure that they were not empty.  This instead employs a peek utility function
to do the same.