### PR TITLE
Mandatory dtypes on dask-array

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -47,7 +47,8 @@ def linspace(start, stop, num=50, chunks=None, dtype=None):
 
     space = float(range_) / (num - 1)
 
-    dtype = dtype or np.linspace(0, 1, 1).dtype
+    if dtype is None:
+        dtype = np.linspace(0, 1, 1).dtype
 
     name = 'linspace-' + tokenize((start, stop, num, chunks, dtype))
 

--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -139,7 +139,7 @@ def ghost_internal(x, axes):
             chunks.append(left + mid + right)
 
     return Array(merge(interior_slices, ghost_blocks, x.dask),
-                 name, chunks, dtype=x._dtype)
+                 name, chunks, dtype=x.dtype)
 
 
 def trim_internal(x, axes):
@@ -237,7 +237,7 @@ def constant(x, axis, depth, value):
     chunks[axis] = (depth,)
 
     c = wrap.full(tuple(map(sum, chunks)), value,
-                  chunks=tuple(chunks), dtype=x._dtype)
+                  chunks=tuple(chunks), dtype=x.dtype)
 
     return concatenate([c, x, c], axis=axis)
 

--- a/dask/array/learn.py
+++ b/dask/array/learn.py
@@ -90,9 +90,8 @@ def predict(model, x):
 
     Parameters
     ----------
-
-    model: scikit learn classifier
-    x: dask Array
+    model : scikit learn classifier
+    x : dask Array
 
     See docstring for ``da.learn.fit``
     """
@@ -100,6 +99,6 @@ def predict(model, x):
     if len(x.chunks[1]) > 1:
         x = x.reblock(chunks=(x.chunks[0], sum(x.chunks[1])))
     func = partial(_predict, model)
-    xx = np.ones((1, x.shape[1]), dtype=x.dtype)
+    xx = np.zeros((1, x.shape[1]), dtype=x.dtype)
     dt = model.predict(xx).dtype
     return x.map_blocks(func, chunks=(x.chunks[0], (1,)), dtype=dt).squeeze()

--- a/dask/array/learn.py
+++ b/dask/array/learn.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import numpy as np
 from toolz import merge, partial
 
 from ..base import tokenize
@@ -99,4 +100,6 @@ def predict(model, x):
     if len(x.chunks[1]) > 1:
         x = x.reblock(chunks=(x.chunks[0], sum(x.chunks[1])))
     func = partial(_predict, model)
-    return x.map_blocks(func, chunks=(x.chunks[0], (1,))).squeeze()
+    xx = np.ones((1, x.shape[1]), dtype=x.dtype)
+    dt = model.predict(xx).dtype
+    return x.map_blocks(func, chunks=(x.chunks[0], (1,)), dtype=dt).squeeze()

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -30,14 +30,17 @@ def reduction(x, chunk, aggregate, axis=None, keepdims=None, dtype=None,
         axis = (axis,)
     axis = tuple(i if i >= 0 else x.ndim + i for i in axis)
 
-    if dtype is not None and 'dtype' in getargspec(chunk).args:
+    if dtype is None:
+        raise ValueError("Must specify dtype")
+    if 'dtype' in getargspec(chunk).args:
         chunk = partial(chunk, dtype=dtype)
-    if dtype is not None and 'dtype' in getargspec(aggregate).args:
+    if 'dtype' in getargspec(aggregate).args:
         aggregate = partial(aggregate, dtype=dtype)
 
     # Map chunk across all blocks
     inds = tuple(range(x.ndim))
-    tmp = atop(chunk, inds, x, inds, axis=axis, keepdims=True)
+    # The dtype of `tmp` doesn't actually matter, and may be incorrect.
+    tmp = atop(chunk, inds, x, inds, axis=axis, keepdims=True, dtype=x.dtype)
     tmp._chunks = tuple((1, ) * len(c) if i in axis else c for (i, c)
                         in enumerate(tmp.chunks))
 
@@ -69,12 +72,11 @@ def _tree_reduce(x, aggregate, axis, keepdims, dtype, split_every=None,
     func = compose(partial(combine or aggregate, axis=axis, keepdims=True),
                    partial(_concatenate2, axes=axis))
     for i in range(depth - 1):
-        x = partial_reduce(func, x, split_every, True, None,
+        x = partial_reduce(func, x, split_every, True, dtype=dtype,
                            name=(name or funcname(combine or aggregate)) + '-partial')
     func = compose(partial(aggregate, axis=axis, keepdims=keepdims),
                    partial(_concatenate2, axes=axis))
-    return partial_reduce(func, x, split_every, keepdims=keepdims,
-                          dtype=dtype,
+    return partial_reduce(func, x, split_every, keepdims=keepdims, dtype=dtype,
                           name=(name or funcname(aggregate)) + '-aggregate')
 
 
@@ -120,10 +122,8 @@ def partial_reduce(func, x, split_every, keepdims=False, dtype=None, name=None):
 def sum(a, axis=None, dtype=None, keepdims=False, split_every=None):
     if dtype is not None:
         dt = dtype
-    elif a._dtype is not None:
-        dt = np.empty((1,), dtype=a._dtype).sum().dtype
     else:
-        dt = None
+        dt = np.empty((1,), dtype=a.dtype).sum().dtype
     return reduction(a, chunk.sum, chunk.sum, axis=axis, keepdims=keepdims,
                      dtype=dt, split_every=split_every)
 
@@ -132,10 +132,8 @@ def sum(a, axis=None, dtype=None, keepdims=False, split_every=None):
 def prod(a, axis=None, dtype=None, keepdims=False, split_every=None):
     if dtype is not None:
         dt = dtype
-    elif a._dtype is not None:
-        dt = np.empty((1,), dtype=a._dtype).prod().dtype
     else:
-        dt = None
+        dt = np.empty((1,), dtype=a.dtype).prod().dtype
     return reduction(a, chunk.prod, chunk.prod, axis=axis, keepdims=keepdims,
                      dtype=dt, split_every=split_every)
 
@@ -143,13 +141,13 @@ def prod(a, axis=None, dtype=None, keepdims=False, split_every=None):
 @wraps(chunk.min)
 def min(a, axis=None, keepdims=False, split_every=None):
     return reduction(a, chunk.min, chunk.min, axis=axis, keepdims=keepdims,
-                     dtype=a._dtype, split_every=split_every)
+                     dtype=a.dtype, split_every=split_every)
 
 
 @wraps(chunk.max)
 def max(a, axis=None, keepdims=False, split_every=None):
     return reduction(a, chunk.max, chunk.max, axis=axis, keepdims=keepdims,
-                     dtype=a._dtype, split_every=split_every)
+                     dtype=a.dtype, split_every=split_every)
 
 
 @wraps(chunk.any)
@@ -168,10 +166,8 @@ def all(a, axis=None, keepdims=False, split_every=None):
 def nansum(a, axis=None, dtype=None, keepdims=False, split_every=None):
     if dtype is not None:
         dt = dtype
-    elif a._dtype is not None:
-        dt = chunk.nansum(np.empty((1,), dtype=a._dtype)).dtype
     else:
-        dt = None
+        dt = chunk.nansum(np.empty((1,), dtype=a.dtype)).dtype
     return reduction(a, chunk.nansum, chunk.sum, axis=axis, keepdims=keepdims,
                      dtype=dt, split_every=split_every)
 
@@ -181,10 +177,8 @@ with ignoring(AttributeError):
     def nanprod(a, axis=None, dtype=None, keepdims=False, split_every=None):
         if dtype is not None:
             dt = dtype
-        elif a._dtype is not None:
-            dt = chunk.nanprod(np.empty((1,), dtype=a._dtype)).dtype
         else:
-            dt = None
+            dt = chunk.nanprod(np.empty((1,), dtype=a.dtype)).dtype
         return reduction(a, chunk.nanprod, chunk.prod, axis=axis,
                          keepdims=keepdims, dtype=dt, split_every=split_every)
 
@@ -200,13 +194,13 @@ with ignoring(AttributeError):
 @wraps(chunk.nanmin)
 def nanmin(a, axis=None, keepdims=False, split_every=None):
     return reduction(a, chunk.nanmin, chunk.nanmin, axis=axis,
-                     keepdims=keepdims, dtype=a._dtype, split_every=split_every)
+                     keepdims=keepdims, dtype=a.dtype, split_every=split_every)
 
 
 @wraps(chunk.nanmax)
 def nanmax(a, axis=None, keepdims=False, split_every=None):
     return reduction(a, chunk.nanmax, chunk.nanmax, axis=axis,
-                     keepdims=keepdims, dtype=a._dtype, split_every=split_every)
+                     keepdims=keepdims, dtype=a.dtype, split_every=split_every)
 
 
 def numel(x, **kwargs):
@@ -247,10 +241,8 @@ def mean_agg(pair, dtype='f8', **kwargs):
 def mean(a, axis=None, dtype=None, keepdims=False, split_every=None):
     if dtype is not None:
         dt = dtype
-    elif a._dtype is not None:
-        dt = np.mean(np.empty(shape=(1,), dtype=a._dtype)).dtype
     else:
-        dt = None
+        dt = np.mean(np.empty(shape=(1,), dtype=a.dtype)).dtype
     return reduction(a, mean_chunk, mean_agg, axis=axis, keepdims=keepdims,
                      dtype=dt, split_every=split_every, combine=mean_combine)
 
@@ -258,10 +250,8 @@ def mean(a, axis=None, dtype=None, keepdims=False, split_every=None):
 def nanmean(a, axis=None, dtype=None, keepdims=False, split_every=None):
     if dtype is not None:
         dt = dtype
-    elif a._dtype is not None:
-        dt = np.mean(np.empty(shape=(1,), dtype=a._dtype)).dtype
     else:
-        dt = None
+        dt = np.mean(np.empty(shape=(1,), dtype=a.dtype)).dtype
     return reduction(a, partial(mean_chunk, sum=chunk.nansum, numel=nannumel),
                      mean_agg, axis=axis, keepdims=keepdims, dtype=dt,
                      split_every=split_every,
@@ -345,10 +335,8 @@ def moment(a, order, axis=None, dtype=None, keepdims=False, ddof=0,
         raise ValueError("Order must be an integer >= 2")
     if dtype is not None:
         dt = dtype
-    elif a._dtype is not None:
-        dt = np.var(np.ones(shape=(1,), dtype=a._dtype)).dtype
     else:
-        dt = None
+        dt = np.var(np.ones(shape=(1,), dtype=a.dtype)).dtype
     return reduction(a, partial(moment_chunk, order=order),
                      partial(moment_agg, order=order, ddof=ddof),
                      axis=axis, keepdims=keepdims,
@@ -360,10 +348,8 @@ def moment(a, order, axis=None, dtype=None, keepdims=False, ddof=0,
 def var(a, axis=None, dtype=None, keepdims=False, ddof=0, split_every=None):
     if dtype is not None:
         dt = dtype
-    elif a._dtype is not None:
-        dt = np.var(np.ones(shape=(1,), dtype=a._dtype)).dtype
     else:
-        dt = None
+        dt = np.var(np.ones(shape=(1,), dtype=a.dtype)).dtype
     return reduction(a, moment_chunk, partial(moment_agg, ddof=ddof), axis=axis,
                      keepdims=keepdims, dtype=dt, split_every=split_every,
                      combine=moment_combine, name='var')
@@ -372,10 +358,8 @@ def var(a, axis=None, dtype=None, keepdims=False, ddof=0, split_every=None):
 def nanvar(a, axis=None, dtype=None, keepdims=False, ddof=0, split_every=None):
     if dtype is not None:
         dt = dtype
-    elif a._dtype is not None:
-        dt = np.var(np.ones(shape=(1,), dtype=a._dtype)).dtype
     else:
-        dt = None
+        dt = np.var(np.ones(shape=(1,), dtype=a.dtype)).dtype
     return reduction(a, partial(moment_chunk, sum=chunk.nansum, numel=nannumel),
                      partial(moment_agg, sum=np.nansum, ddof=ddof), axis=axis,
                      keepdims=keepdims, dtype=dt, split_every=split_every,
@@ -532,7 +516,8 @@ def arg_reduction(x, chunk, combine, agg, axis=None, split_every=None):
                    in enumerate(x.chunks))
     dsk = dict(((name,) + k, (chunk, (old,) + k, axis, off)) for (k, off)
                in zip(keys, offset_info))
-    tmp = Array(merge(dsk, x.dask), name, chunks)
+    # The dtype of `tmp` doesn't actually matter, just need to provide something
+    tmp = Array(merge(dsk, x.dask), name, chunks, dtype=x.dtype)
     return _tree_reduce(tmp, agg, axis, False, np.int64, split_every, combine)
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2114,7 +2114,7 @@ def test_tril_triu_errors():
 
 def test_atop_names():
     x = da.ones(5, chunks=(2,))
-    y = atop(add, 'i', x, 'i')
+    y = atop(add, 'i', x, 'i', dtype=x.dtype)
     assert y.name.startswith('add')
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -173,7 +173,7 @@ def test_Array():
     chunks = (100, 100)
     name = 'x'
     dsk = merge({name: 'some-array'}, getem(name, chunks, shape=shape))
-    a = Array(dsk, name, chunks, shape=shape)
+    a = Array(dsk, name, chunks, shape=shape, dtype='f8')
 
     assert a.numblocks == (10, 10)
 
@@ -188,7 +188,7 @@ def test_Array():
 
 
 def test_uneven_chunks():
-    a = Array({}, 'x', chunks=(3, 3), shape=(10, 10))
+    a = Array({}, 'x', chunks=(3, 3), shape=(10, 10), dtype='f8')
     assert a.chunks == ((3, 3, 3, 1), (3, 3, 3, 1))
 
 
@@ -197,22 +197,22 @@ def test_numblocks_suppoorts_singleton_block_dims():
     chunks = (10, 10)
     name = 'x'
     dsk = merge({name: 'some-array'}, getem(name, shape=shape, chunks=chunks))
-    a = Array(dsk, name, chunks, shape=shape)
+    a = Array(dsk, name, chunks, shape=shape, dtype='f8')
 
     assert set(concat(a._keys())) == set([('x', i, 0) for i in range(100 // 10)])
 
 
 def test_keys():
     dsk = dict((('x', i, j), ()) for i in range(5) for j in range(6))
-    dx = Array(dsk, 'x', chunks=(10, 10), shape=(50, 60))
+    dx = Array(dsk, 'x', chunks=(10, 10), shape=(50, 60), dtype='f8')
     assert dx._keys() == [[(dx.name, i, j) for j in range(6)]
                           for i in range(5)]
-    d = Array({}, 'x', (), shape=())
+    d = Array({}, 'x', (), shape=(), dtype='f8')
     assert d._keys() == [('x',)]
 
 
 def test_Array_computation():
-    a = Array({('x', 0, 0): np.eye(3)}, 'x', shape=(3, 3), chunks=(3, 3))
+    a = Array({('x', 0, 0): np.eye(3)}, 'x', shape=(3, 3), chunks=(3, 3), dtype='f8')
     assert_eq(np.array(a), np.eye(3))
     assert isinstance(a.compute(), np.ndarray)
     assert float(a[0, 0]) == 1
@@ -220,7 +220,7 @@ def test_Array_computation():
 
 def test_stack():
     a, b, c = [Array(getem(name, chunks=(2, 3), shape=(4, 6)),
-                     name, shape=(4, 6), chunks=(2, 3))
+                     name, chunks=(2, 3), dtype='f8', shape=(4, 6))
                for name in 'ABC']
 
     s = stack([a, b, c], axis=0)
@@ -291,7 +291,7 @@ def test_stack_rechunk():
 
 def test_concatenate():
     a, b, c = [Array(getem(name, chunks=(2, 3), shape=(4, 6)),
-                     name, shape=(4, 6), chunks=(2, 3))
+                     name, chunks=(2, 3), dtype='f8', shape=(4, 6))
                for name in 'ABC']
 
     x = concatenate([a, b, c], axis=0)
@@ -408,10 +408,10 @@ def test_compress():
 
 
 def test_binops():
-    a = Array(dict((('a', i), np.array([''])) for i in range(3)),
-              'a', chunks=((1, 1, 1),))
-    b = Array(dict((('b', i), np.array([''])) for i in range(3)),
-              'b', chunks=((1, 1, 1),))
+    a = Array(dict((('a', i), np.array([0])) for i in range(3)),
+              'a', chunks=((1, 1, 1),), dtype='i8')
+    b = Array(dict((('b', i), np.array([0])) for i in range(3)),
+              'b', chunks=((1, 1, 1),), dtype='i8')
 
     result = elemwise(add, a, b, name='c')
     assert result.dask == merge(a.dask, b.dask,
@@ -863,13 +863,13 @@ def test_repr():
     d = da.ones((4, 4), chunks=(2, 2))
     assert d.name[:5] in repr(d)
     assert str(d.shape) in repr(d)
-    assert str(d._dtype) in repr(d)
+    assert str(d.dtype) in repr(d)
     d = da.ones((4000, 4), chunks=(4, 2))
     assert len(str(d)) < 1000
     # Empty array
     d = da.Array({}, 'd', ((), (3, 4)), dtype='i8')
     assert str(d.shape) in repr(d)
-    assert str(d._dtype) in repr(d)
+    assert str(d.dtype) in repr(d)
 
 
 def test_slicing_with_ellipsis():
@@ -1087,44 +1087,44 @@ def test_dtype_complex():
                 isinstance(b, np.dtype) and
                 str(a) == str(b))
 
-    assert_eq(a._dtype, x.dtype)
-    assert_eq(b._dtype, y.dtype)
+    assert_eq(a.dtype, x.dtype)
+    assert_eq(b.dtype, y.dtype)
 
-    assert_eq((a + 1)._dtype, (x + 1).dtype)
-    assert_eq((a + b)._dtype, (x + y).dtype)
-    assert_eq(a.T._dtype, x.T.dtype)
-    assert_eq(a[:3]._dtype, x[:3].dtype)
-    assert_eq((a.dot(b.T))._dtype, (x.dot(y.T)).dtype)
+    assert_eq((a + 1).dtype, (x + 1).dtype)
+    assert_eq((a + b).dtype, (x + y).dtype)
+    assert_eq(a.T.dtype, x.T.dtype)
+    assert_eq(a[:3].dtype, x[:3].dtype)
+    assert_eq((a.dot(b.T)).dtype, (x.dot(y.T)).dtype)
 
-    assert_eq(stack([a, b])._dtype, np.vstack([x, y]).dtype)
-    assert_eq(concatenate([a, b])._dtype, np.concatenate([x, y]).dtype)
+    assert_eq(stack([a, b]).dtype, np.vstack([x, y]).dtype)
+    assert_eq(concatenate([a, b]).dtype, np.concatenate([x, y]).dtype)
 
-    assert_eq(b.std()._dtype, y.std().dtype)
-    assert_eq(c.sum()._dtype, z.sum().dtype)
-    assert_eq(a.min()._dtype, a.min().dtype)
-    assert_eq(b.std()._dtype, b.std().dtype)
-    assert_eq(a.argmin(axis=0)._dtype, a.argmin(axis=0).dtype)
+    assert_eq(b.std().dtype, y.std().dtype)
+    assert_eq(c.sum().dtype, z.sum().dtype)
+    assert_eq(a.min().dtype, a.min().dtype)
+    assert_eq(b.std().dtype, b.std().dtype)
+    assert_eq(a.argmin(axis=0).dtype, a.argmin(axis=0).dtype)
 
-    assert_eq(da.sin(c)._dtype, np.sin(z).dtype)
-    assert_eq(da.exp(b)._dtype, np.exp(y).dtype)
-    assert_eq(da.floor(a)._dtype, np.floor(x).dtype)
-    assert_eq(da.isnan(b)._dtype, np.isnan(y).dtype)
+    assert_eq(da.sin(c).dtype, np.sin(z).dtype)
+    assert_eq(da.exp(b).dtype, np.exp(y).dtype)
+    assert_eq(da.floor(a).dtype, np.floor(x).dtype)
+    assert_eq(da.isnan(b).dtype, np.isnan(y).dtype)
     with ignoring(ImportError):
-        assert da.isnull(b)._dtype == 'bool'
-        assert da.notnull(b)._dtype == 'bool'
+        assert da.isnull(b).dtype == 'bool'
+        assert da.notnull(b).dtype == 'bool'
 
     x = np.array([('a', 1)], dtype=[('text', 'S1'), ('numbers', 'i4')])
     d = da.from_array(x, chunks=(1,))
 
-    assert_eq(d['text']._dtype, x['text'].dtype)
-    assert_eq(d[['numbers', 'text']]._dtype, x[['numbers', 'text']].dtype)
+    assert_eq(d['text'].dtype, x['text'].dtype)
+    assert_eq(d[['numbers', 'text']].dtype, x[['numbers', 'text']].dtype)
 
 
 def test_astype():
     x = np.ones((5, 5), dtype='f8')
     d = da.from_array(x, chunks=(2,2))
 
-    assert d.astype('i8')._dtype == 'i8'
+    assert d.astype('i8').dtype == 'i8'
     assert_eq(d.astype('i8'), x.astype('i8'))
     assert same_keys(d.astype('i8'), d.astype('i8'))
 
@@ -1139,13 +1139,6 @@ def test_astype():
 
     # Check it's a noop
     assert d.astype('f8') is d
-
-    # Check arrays with unknown dtype are not noops. Since `dtype('f8') == None`
-    # is True, comparing dtypes directly can lead to bugs
-    d._dtype = None
-    d2 = d.astype('f8')
-    assert d2 is not d
-    assert_eq(d2, x.astype('f8'))
 
 
 def test_arithmetic():
@@ -2130,7 +2123,7 @@ def test_atop_new_axes():
         return x[:, None] * np.ones((1, 7))
     x = da.ones(5, chunks=2)
     y = atop(f, 'aq', x, 'a', new_axes={'q': 7}, concatenate=True,
-             dtype=x._dtype)
+             dtype=x.dtype)
     assert y.chunks == ((2, 2, 1), (7,))
     assert_eq(y, np.ones((5, 7)))
 
@@ -2138,7 +2131,7 @@ def test_atop_new_axes():
         return x[None, :] * np.ones((7, 1))
     x = da.ones(5, chunks=2)
     y = atop(f, 'qa', x, 'a', new_axes={'q': 7}, concatenate=True,
-             dtype=x._dtype)
+             dtype=x.dtype)
     assert y.chunks == ((7,), (2, 2, 1))
     assert_eq(y, np.ones((7, 5)))
 
@@ -2148,7 +2141,7 @@ def test_atop_new_axes():
 
     x = da.ones((4, 6), chunks=(2, 2))
     y = atop(f, 'aq', x, 'ab', new_axes={'q': 5}, concatenate=True,
-             dtype=x._dtype)
+             dtype=x.dtype)
     assert y.chunks == ((2, 2), (5,))
     assert_eq(y, np.ones((4, 5)) * 6)
 
@@ -2307,10 +2300,10 @@ def test_atop_concatenate():
 
         return (a + b).sum(axis=(1, 2))
 
-    z = atop(f, 'i', x, 'ijk', y, 'jk', concatenate=True, dtype=x._dtype)
+    z = atop(f, 'i', x, 'ijk', y, 'jk', concatenate=True, dtype=x.dtype)
     assert_eq(z, np.ones(4) * 32)
 
-    z = atop(add, 'ij', y, 'ij', y, 'ij', concatenate=True, dtype=x._dtype)
+    z = atop(add, 'ij', y, 'ij', y, 'ij', concatenate=True, dtype=x.dtype)
     assert_eq(z, np.ones((4, 4)) * 2)
 
     def f(a, b, c):
@@ -2325,7 +2318,7 @@ def test_atop_concatenate():
         return np.ones(5)
 
     z = atop(f, 'j', x, 'ijk', y, 'ki', y, 'ij', concatenate=True,
-             dtype=x._dtype)
+             dtype=x.dtype)
     assert_eq(z, np.ones(10))
 
 
@@ -2370,7 +2363,7 @@ def test_elemwise_uneven_chunks():
 def test_uneven_chunks_atop():
     x = da.random.random((10, 10), chunks=((2, 3, 2, 3), (5, 5)))
     y = da.random.random((10, 10), chunks=((4, 4, 2), (4, 2, 4)))
-    z = atop(np.dot, 'ik', x, 'ij', y, 'jk', dtype=x._dtype, concatenate=True)
+    z = atop(np.dot, 'ik', x, 'ij', y, 'jk', dtype=x.dtype, concatenate=True)
     assert z.chunks == (x.chunks[0], y.chunks[1])
 
     assert_eq(z, x.compute().dot(y))

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -62,7 +62,7 @@ def test_arange():
 
 
 def test_arange_has_dtype():
-    assert da.arange(5, chunks=2)._dtype is not None
+    assert da.arange(5, chunks=2).dtype == np.arange(5).dtype
 
 
 def test_arange_working_float_step():

--- a/dask/array/tests/test_ghost.py
+++ b/dask/array/tests/test_ghost.py
@@ -192,14 +192,14 @@ def test_ghost():
 def test_map_overlap():
     x = da.arange(10, chunks=5)
 
-    y = x.map_overlap(lambda x: x + len(x), depth=2, dtype=x._dtype)
+    y = x.map_overlap(lambda x: x + len(x), depth=2, dtype=x.dtype)
     assert_eq(y, np.arange(10) + 5 + 2 + 2)
 
     x = np.arange(16).reshape((4, 4))
     d = da.from_array(x, chunks=(2, 2))
-    exp1 = d.map_overlap(lambda x: x + x.size, depth=1, dtype=d._dtype)
+    exp1 = d.map_overlap(lambda x: x + x.size, depth=1, dtype=d.dtype)
     exp2 = d.map_overlap(lambda x: x + x.size, depth={0: 1, 1: 1},
-                         boundary={0: 'reflect', 1: 'none'}, dtype=d._dtype)
+                         boundary={0: 'reflect', 1: 'none'}, dtype=d.dtype)
     assert_eq(exp1, x + 16)
     assert_eq(exp2, x + 12)
 

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -138,7 +138,7 @@ def test_rechunk_blockshape():
 
 def test_dtype():
     x = da.ones(5, chunks=(2,))
-    assert x.rechunk(chunks=(1,))._dtype == x._dtype
+    assert x.rechunk(chunks=(1,)).dtype == x.dtype
 
 
 def test_rechunk_with_dict():

--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -35,7 +35,7 @@ def test_full():
     a = da.full((3, 3), 100, chunks=(2, 2), dtype='i8')
 
     assert (a.compute() == 100).all()
-    assert a._dtype == a.compute(get=dask.get).dtype == 'i8'
+    assert a.dtype == a.compute(get=dask.get).dtype == 'i8'
 
 
 def test_can_make_really_big_array_of_ones():

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -113,7 +113,8 @@ absolute = wrap_elemwise(np.absolute)
 
 
 def frexp(x):
-    tmp = elemwise(np.frexp, x)
+    # Not actually object dtype, just need to specify something
+    tmp = elemwise(np.frexp, x, dtype=object)
     left = 'mantissa-' + tmp.name
     right = 'exponent-' + tmp.name
     ldsk = dict(((left,) + key[1:], (getitem, key, 0))
@@ -121,14 +122,10 @@ def frexp(x):
     rdsk = dict(((right,) + key[1:], (getitem, key, 1))
                 for key in core.flatten(tmp._keys()))
 
-    if x._dtype is not None:
-        a = np.empty((1, ), dtype=x._dtype)
-        l, r = np.frexp(a)
-        ldt = l.dtype
-        rdt = r.dtype
-    else:
-        ldt = None
-        rdt = None
+    a = np.empty((1, ), dtype=x.dtype)
+    l, r = np.frexp(a)
+    ldt = l.dtype
+    rdt = r.dtype
 
     L = Array(merge(tmp.dask, ldsk), left, chunks=tmp.chunks, dtype=ldt)
     R = Array(merge(tmp.dask, rdsk), right, chunks=tmp.chunks, dtype=rdt)
@@ -138,7 +135,8 @@ frexp.__doc__ = skip_doctest(np.frexp.__doc__)
 
 
 def modf(x):
-    tmp = elemwise(np.modf, x)
+    # Not actually object dtype, just need to specify something
+    tmp = elemwise(np.modf, x, dtype=object)
     left = 'modf1-' + tmp.name
     right = 'modf2-' + tmp.name
     ldsk = dict(((left,) + key[1:], (getitem, key, 0))
@@ -146,19 +144,13 @@ def modf(x):
     rdsk = dict(((right,) + key[1:], (getitem, key, 1))
                 for key in core.flatten(tmp._keys()))
 
-    if x._dtype is not None:
-        a = np.empty((1,), dtype=x._dtype)
-        l, r = np.modf(a)
-        ldt = l.dtype
-        rdt = r.dtype
-    else:
-        ldt = None
-        rdt = None
+    a = np.empty((1,), dtype=x.dtype)
+    l, r = np.modf(a)
+    ldt = l.dtype
+    rdt = r.dtype
 
     L = Array(merge(tmp.dask, ldsk), left, chunks=tmp.chunks, dtype=ldt)
-
     R = Array(merge(tmp.dask, rdsk), right, chunks=tmp.chunks, dtype=rdt)
-
     return L, R
 
 modf.__doc__ = skip_doctest(np.modf.__doc__)

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -32,14 +32,13 @@ def _maybe_check_dtype(a, dtype=None):
 
 def assert_eq(a, b, **kwargs):
     if isinstance(a, Array):
-        adt = a._dtype
-        assert adt is not None
+        adt = a.dtype
         a = a.compute(get=get_sync)
         _maybe_check_dtype(a, adt)
     else:
         adt = getattr(a, 'dtype', None)
     if isinstance(b, Array):
-        bdt = b._dtype
+        bdt = b.dtype
         assert bdt is not None
         b = b.compute(get=get_sync)
         _maybe_check_dtype(b, bdt)

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -209,6 +209,8 @@ def test_raise_on_meta_error():
     except Exception as e:
         assert e.args[0].startswith("Metadata inference failed.\n")
         assert 'RuntimeError' in e.args[0]
+    else:
+        assert False, "should have errored"
 
     try:
         with raise_on_meta_error("myfunc"):
@@ -216,3 +218,5 @@ def test_raise_on_meta_error():
     except Exception as e:
         assert e.args[0].startswith("Metadata inference failed in `myfunc`.\n")
         assert 'RuntimeError' in e.args[0]
+    else:
+        assert False, "should have errored"


### PR DESCRIPTION
Previously `dask.array` allowed known dtype to be optional, computing it dynamically as needed. This proved to be difficult to reason about, leading to unexpected computation (#1718). As done in #1422, we remove the optional dtype, falling back to inference if dtype isn't specified (if possible).

- [x] Make known `dtype` mandatory for all `dask.array.Array` objects
- [x] Fix failing functionality
- [x] Add inference to map_blocks/atop/reduction as needed.

Fixes #1718