### PR TITLE
Refactor bytes

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -257,6 +257,7 @@ def nanmean(a, axis=None, dtype=None, keepdims=False, split_every=None):
                      split_every=split_every,
                      combine=partial(mean_combine, sum=chunk.nansum, numel=nannumel))
 
+
 with ignoring(AttributeError):
     nanmean = wraps(chunk.nanmean)(nanmean)
 
@@ -385,6 +386,7 @@ def nanstd(a, axis=None, dtype=None, keepdims=False, ddof=0, split_every=None):
     if dtype and dtype != result.dtype:
         result = result.astype(dtype)
     return result
+
 
 with ignoring(AttributeError):
     nanstd = wraps(chunk.nanstd)(nanstd)

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -131,6 +131,7 @@ def frexp(x):
     R = Array(merge(tmp.dask, rdsk), right, chunks=tmp.chunks, dtype=rdt)
     return L, R
 
+
 frexp.__doc__ = skip_doctest(np.frexp.__doc__)
 
 
@@ -152,5 +153,6 @@ def modf(x):
     L = Array(merge(tmp.dask, ldsk), left, chunks=tmp.chunks, dtype=ldt)
     R = Array(merge(tmp.dask, rdsk), right, chunks=tmp.chunks, dtype=rdt)
     return L, R
+
 
 modf.__doc__ = skip_doctest(np.modf.__doc__)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -708,6 +708,8 @@ def test_to_dataframe():
 ext_open = [('gz', GzipFile), ('', open)]
 if not PY2:
     ext_open.append(('bz2', BZ2File))
+
+
 @pytest.mark.parametrize('ext,myopen', ext_open)
 def test_to_textfiles(ext, myopen):
     b = db.from_sequence(['abc', '123', 'xyz'], npartitions=2)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -544,7 +544,7 @@ def test_read_text_large_gzip():
         f.close()
 
         with pytest.raises(ValueError):
-            db.read_text(fn, blocksize=100, linedelimiter='\n')
+            db.read_text(fn, blocksize=50, linedelimiter='\n')
 
         c = db.read_text(fn)
         assert c.npartitions == 1

--- a/dask/bag/text.py
+++ b/dask/bag/text.py
@@ -67,22 +67,12 @@ def read_text(urlpath, blocksize=None, compression='infer',
                       storage_options=storage_options)
                      for fn in urlpath], [])
     else:
-        if compression == 'infer':
-            compression = infer_compression(urlpath)
-
-        if blocksize and compression not in seekable_files:
-            msg = ("Compression %s does not support breaking apart files\n"
-                   "Use ``blocksize=None`` or decompress file externally")
-            raise ValueError(msg % compression)
-        if compression not in seekable_files and compression not in cfiles:
-            raise NotImplementedError("Compression format %s not installed" %
-                                      compression)
-
-        elif blocksize is None:
+        if blocksize is None:
             files = open_text_files(urlpath, encoding=encoding, errors=errors,
                                     compression=compression,
                                     **(storage_options or {}))
-            blocks = [delayed(list)(file) for file in files]
+            blocks = [delayed(list, pure=True)(delayed(file_to_blocks)(file))
+                      for file in files]
 
         else:
             _, blocks = read_bytes(urlpath, delimiter=linedelimiter.encode(),
@@ -101,6 +91,12 @@ def read_text(urlpath, blocksize=None, compression='infer',
         return blocks
     else:
         return from_delayed(blocks)
+
+
+def file_to_blocks(f):
+    with f as f:
+        for line in f:
+            yield line
 
 
 def decode(block, encoding, errors):

--- a/dask/bag/text.py
+++ b/dask/bag/text.py
@@ -5,9 +5,8 @@ import os
 
 from toolz import concat
 
-from ..utils import infer_compression, system_encoding
+from ..utils import system_encoding
 from ..delayed import delayed
-from ..bytes.compression import files as cfiles, seekable_files
 from ..bytes import open_text_files, read_bytes
 from .core import from_delayed
 

--- a/dask/bag/text.py
+++ b/dask/bag/text.py
@@ -93,8 +93,8 @@ def read_text(urlpath, blocksize=None, compression='infer',
         return from_delayed(blocks)
 
 
-def file_to_blocks(f):
-    with f as f:
+def file_to_blocks(lazy_file):
+    with lazy_file as f:
         for line in f:
             yield line
 

--- a/dask/bytes/compression.py
+++ b/dask/bytes/compression.py
@@ -43,15 +43,56 @@ with ignoring(ImportError):
     decompress['xz'] = lzma_decompress
     files['xz'] = LZMAFile
 
-with ignoring(ImportError):
-    import lzma
-    seekable_files['xz'] = lzma.LZMAFile
-
-with ignoring(ImportError):
-    import lzmaffi
-    seekable_files['xz'] = lzmaffi.LZMAFile
+# Seekable xz files actually tend to scan whole file - see `get_xz_blocks`
+# with ignoring(ImportError):
+#     import lzma
+#     seekable_files['xz'] = lzma.LZMAFile
+#
+# with ignoring(ImportError):
+#     import lzmaffi
+#     seekable_files['xz'] = lzmaffi.LZMAFile
 
 
 if sys.version_info[0] >= 3:
     import bz2
     files['bz2'] = bz2.BZ2File
+
+
+def get_xz_blocks(fp):
+    from lzmaffi import STREAM_HEADER_SIZE, decode_stream_footer, decode_index
+    fp.seek(0, 2)
+
+    def _peek(f, size):
+        data = f.read(size)
+        f.seek(-size, 1)
+        return data
+
+    if fp.tell() < 2 * STREAM_HEADER_SIZE:
+        raise LZMAError("file too small")
+
+    # read stream paddings (4 bytes each)
+    fp.seek(-4, 1)
+    padding = 0
+    while _peek(fp, 4) == b'\x00\x00\x00\x00':
+        fp.seek(-4, 1)
+        padding += 4
+
+    fp.seek(-STREAM_HEADER_SIZE + 4, 1)
+
+    stream_flags = decode_stream_footer(_peek(fp, STREAM_HEADER_SIZE))
+    fp.seek(-stream_flags.backward_size, 1)
+
+    index = decode_index(_peek(fp, stream_flags.backward_size), padding)
+    return {'offsets': [b.compressed_file_offset for i, b in index],
+            'lengths': [b.unpadded_size for i, b in index],
+            'check': stream_flags.check}
+
+
+def xz_decompress(data, check):
+    from lzmaffi import decode_block_header_size, LZMADecompressor, FORMAT_BLOCK
+    hsize = decode_block_header_size(data[:1])
+    header = data[:hsize]
+    dc = LZMADecompressor(format=FORMAT_BLOCK, header=header,
+                          unpadded_size=len(data), check=check)
+    return dc.decompress(data[len(header):])
+

--- a/dask/bytes/compression.py
+++ b/dask/bytes/compression.py
@@ -13,6 +13,7 @@ from ..utils import ignoring
 def noop_file(file, **kwargs):
     return file
 
+
 compress = {'gzip': gzip_compress,
             'zlib': zlib.compress,
             'bz2': bz2.compress,

--- a/dask/bytes/compression.py
+++ b/dask/bytes/compression.py
@@ -59,7 +59,8 @@ if sys.version_info[0] >= 3:
 
 
 def get_xz_blocks(fp):
-    from lzmaffi import STREAM_HEADER_SIZE, decode_stream_footer, decode_index
+    from lzmaffi import (STREAM_HEADER_SIZE, decode_stream_footer,
+                         decode_index, LZMAError)
     fp.seek(0, 2)
 
     def _peek(f, size):
@@ -95,4 +96,3 @@ def xz_decompress(data, check):
     dc = LZMADecompressor(format=FORMAT_BLOCK, header=header,
                           unpadded_size=len(data), check=check)
     return dc.decompress(data[len(header):])
-

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -7,7 +7,7 @@ from toolz import merge
 from warnings import warn
 
 from .compression import seekable_files, files as compress_files
-from .utils import SeekableFile
+from .utils import SeekableFile, read_block
 from ..compatibility import PY2, unicode
 from ..base import tokenize
 from ..delayed import delayed, Delayed, apply
@@ -15,7 +15,7 @@ from ..utils import (infer_storage_options, system_encoding,
                      build_name_function, infer_compression,
                      import_required)
 
-delayed = delayed(pure=True)
+# delayed = delayed(pure=True)
 
 # Global registration dictionaries for backend storage functions
 # See docstrings to functions below for more information
@@ -25,132 +25,70 @@ _open_files = dict()
 _open_text_files = dict()
 
 
-def write_block_to_file(data, f, compression, encoding):
+def write_block_to_file(data, lazy_file):
     """
     Parameters
     ----------
     data : data to write
         Either str/bytes, or iterable producing those, or something file-like
         which can be read.
-    f : file-like
-        backend-dependent file-like object
-    compression : string
-        a key of `compress_files`
-    encoding : string (None)
-        if a string (e.g., 'ascii', 'utf8'), implies text mode, otherwise no
-        encoding and binary mode.
+    lazy_file : file-like or file context
+        gives writable backend-dependent file-like object when used with `with`
     """
-    original = False
-    f2 = f
-    f = SeekableFile(f)
-    if compression:
-        original = True
-        f = compress_files[compression](f, mode='wb')
-    try:
+    binary = 'b' in str(getattr(lazy_file, 'mode', 'b'))
+    with lazy_file as f:
         if isinstance(data, (str, bytes)):
-            if encoding:
-                f.write(data.encode(encoding=encoding))
-            else:
-                f.write(data)
+            f.write(data)
         elif isinstance(data, io.IOBase):
             # file-like
             out = '1'
             while out:
                 out = data.read(64 * 2 ** 10)
-                if encoding:
-                    f.write(out.encode(encoding=encoding))
-                else:
-                    f.write(out)
+                f.write(out)
         else:
             # iterable, e.g., bag contents
             start = False
             for d in data:
                 if start:
-                    f.write(b'\n')
+                    if binary:
+                        try:
+                            f.write(b'\n')
+                        except TypeError:
+                            binary = False
+                            f.write('\n')
+                    else:
+                        f.write('\n')
                 else:
                     start = True
-                if encoding:
-                    f.write(d.encode(encoding=encoding))
-                else:
-                    f.write(d)
-    finally:
-        f.close()
-        if original:
-            f2.close()
+                f.write(d)
 
 
 def write_bytes(data, urlpath, name_function=None, compression=None,
                 encoding=None, **kwargs):
-    """For a list of values which evaluate to byte, produce delayed values
-    which, when executed, result in writing to files.
-
-    The path maybe a concrete directory, in which case it is interpreted
-    as a directory, or a template for numbered output.
-
-    The path may be preceded by a protocol, like ``s3://`` or ``hdfs://`` if
-    those libraries are installed.
+    """Write dask data to a set of files
 
     Parameters
     ----------
-    data: list of ``dask.Delayed`` objects or dask collection
-        the data to be written
-    urlpath: string
-        Absolute or relative filepaths, URLs (may include protocols like
-        ``s3://``); may be globstring (include `*`).
+    data: list of delayed objects
+        Producing data to write
+    urlpath: list or template
+        Location(s) to write to, including backend specifier.
     name_function: function or None
-        If using a globstring, this provides the conversion from part number
-        to test to replace `*` with.
-    compression: string or None
-        String like 'gzip' or 'xz'.  Must support efficient random access.
-    **kwargs: dict
-        Extra options that make sense to a particular storage connection, e.g.
-        host, port, username, password, etc.
-
-    Examples
-    --------
-    >>> values = write_bytes(vals, 's3://bucket/part-*.csv')  # doctest: +SKIP
-
-    Returns
-    -------
-    list of ``dask.Delayed`` objects
+        If urlpath is a template, use this function to create a string out
+        of the sequence number.
+    compression: str or None
+        Compression algorithm to apply (e.g., gzip), if any
+    encoding: str or None
+        If None, data must produce bytes, else will be encoded.
+    kwargs: passed to filesystem constructor
     """
-    if isinstance(urlpath, (tuple, list, set)):
-        if len(data) != len(urlpath):
-            raise ValueError('Number of paths and number of delayed objects'
-                             'must match (%s != %s)', len(urlpath), len(data))
-        storage_options = infer_storage_options(urlpath[0],
-                                                inherit_storage_options=kwargs)
-        del storage_options['path']
-        paths = [infer_storage_options(u, inherit_storage_options=kwargs)['path']
-                 for u in urlpath]
-    elif isinstance(urlpath, (str, unicode)):
-        storage_options = infer_storage_options(urlpath,
-                                                inherit_storage_options=kwargs)
-        path = storage_options.pop('path')
-        paths = _expand_paths(path, name_function, len(data))
-    else:
-        raise ValueError('URL spec must be string or sequence of strings')
-    if compression == 'infer':
-        compression = infer_compression(paths[0])
-    if compression is not None and compression not in compress_files:
-        raise ValueError("Compression type %s not supported" % compression)
+    mode = 'wb' if encoding is None else 'wt'
+    fs, names, myopen = get_fs_paths_myopen(urlpath, compression, mode,
+                   name_function=name_function, num=len(data),
+                   encoding=encoding, **kwargs)
 
-    protocol = storage_options.pop('protocol')
-    ensure_protocol(protocol)
-    try:
-        open_files_write = _open_files_write[protocol]
-    except KeyError:
-        raise NotImplementedError("Unknown protocol for writing %s (%s)" %
-                                  (protocol, urlpath))
-
-    keys = ['write-block-%s' % tokenize(d.key, p, storage_options,
-            compression, encoding) for (d, p) in zip(data, paths)]
-    return [Delayed(key, dasks=[{key: (write_block_to_file, v.key,
-                                       (apply, open_files_write, (p,),
-                                        storage_options),
-                                       compression, encoding),
-                                 }, v.dask])
-            for key, v, p in zip(keys, data, paths)]
+    return [delayed(write_block_to_file, pure=False)(d, myopen(f, mode='wb'))
+            for d, f in zip(data, names)]
 
 
 def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
@@ -194,56 +132,204 @@ def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
     10kB sample header and list of ``dask.Delayed`` objects or list of lists of
     delayed objects if ``fn`` is a globstring.
     """
-    if compression is not None and compression not in compress_files:
-        raise ValueError("Compression type %s not supported" % compression)
+    fs, paths, myopen = get_fs_paths_myopen(urlpath, compression, 'rb',
+                                            None, **kwargs)
+    client = None
+    if len(paths) == 0:
+        raise IOError("%s resolved to no files" % urlpath)
 
-    storage_options = infer_storage_options(urlpath,
-                                            inherit_storage_options=kwargs)
-    protocol = storage_options.pop('protocol')
-    ensure_protocol(protocol)
-    try:
-        read_bytes = _read_bytes[protocol]
-    except KeyError:
-        raise NotImplementedError("Unknown protocol for reading %s (%s)" %
-                                  (protocol, urlpath))
+    blocks, lengths, machines = fs.get_block_locations(paths)
+    if blocks:
+        offsets = blocks
+    elif blocksize is None:
+        offsets = [[0]] * len(paths)
+        lengths = [[None]] * len(offsets)
+        machines = [[None]] * len(offsets)
+    else:
+        offsets = []
+        lengths = []
+        for path in paths:
+            try:
+                size = fs.logical_size(path, compression)
+            except KeyError:
+                raise ValueError('Cannot read compressed files (%s) in byte chunks,'
+                                 'use blocksize=None' % infer_compression(urlpath))
+            off = list(range(0, size, blocksize))
+            length = [blocksize] * len(off)
+            if not_zero:
+                off[0] = 1
+                length[0] -= 1
+            offsets.append(off)
+            lengths.append(length)
+        machines = [[None]] * len(offsets)
 
-    return read_bytes(storage_options.pop('path'), delimiter=delimiter,
-                      not_zero=not_zero, blocksize=blocksize, sample=sample,
-                      compression=compression, **storage_options)
+    out = []
+    for path, offset, length, machine in zip(paths, offsets, lengths, machines):
+        ukey = fs.ukey(path)
+        keys = ['read-block-%s-%s' %
+                (o, tokenize(path, compression, offset, ukey, kwargs, delimiter))
+                for o in offset]
+        L = [delayed(read_block_from_file)(myopen(path, mode='rb'), off,
+                     l, delimiter, dask_key_name=key)
+             for (off, key, l) in zip(offset, keys, length)]
+        out.append(L)
+        if machine is not None:  # blocks are in preferred locations
+            if client is None:
+                try:
+                    from distributed.client import default_client
+                    client = default_client()
+                except (ImportError, ValueError):  # no distributed client
+                    client = False
+            if client:
+                restrictions = {key: w for key, w in zip(keys, machine)}
+                client._send_to_scheduler(
+                        {'op': 'update-graph', 'tasks': {},
+                         'dependencies': [], 'keys': [],
+                         'restrictions': restrictions,
+                         'loose_restrictions': list(restrictions),
+                         'client': client.id})
+
+    if sample is not True:
+        nbytes = sample
+    else:
+        nbytes = 10000
+    if sample:
+        # myopen = OpenFileCreator(urlpath, compression)
+        with myopen(paths[0], 'rb') as f:
+            sample = read_block(f, 0, nbytes, delimiter)
+    return sample, out
 
 
-def open_files_by(open_files_backend, path, compression=None, **kwargs):
-    """ Given open files backend and path return dask.delayed file-like objects
+def read_block_from_file(lazy_file, off, bs, delimiter):
+    with lazy_file as f:
+        return read_block(f, off, bs, delimiter)
 
-    NOTE: This is an internal helper function, please refer to
-    :func:`open_files` documentation for more details.
+
+class OpenFileCreator(object):
+    """
+    Produces a function-like instance, which generates open file contexts
+
+    Analyses the passed URL to determine the appropriate backend (local file,
+    s3, etc.), and then acts something like the builtin `open` in
+    with a context, where the further options such as compression are applied
+    to the file to be opened.
 
     Parameters
     ----------
-    path: string
-        Filepath or globstring
-    compression: string
-        Compression to use.  See ``dask.bytes.compression.files`` for options.
-    **kwargs: dict
-        Extra options that make sense to a particular storage connection, e.g.
-        host, port, username, password, etc.
+    urlpath: str
+        Template URL, like the files we wish to access, with optional
+        backend-specific parts
+    compression: str or None
+        One of the keys of `compress_files` or None; all files opened will use
+        this compression. If `'infer'`, will choose based on the urlpath
+    text: bool
+        Whether files should be binary or text
+    encoding: str
+        If files are text, the encoding to use
+    errors: str ['strict']
+        How to handle encoding errors for text files
+    kwargs: passed to filesystem instance constructor
 
-    Returns
-    -------
-    List of ``dask.delayed`` objects that compute to file-like objects
+    Examples
+    --------
+    >>> ofc = OpenFileCreator('2015-*-*.csv')  # doctest: +SKIP
+    >>> with ofc('2015-12-10.csv', 'rb') as f: # doctest: +SKIP
+    ...     f.read(10)                         # doctest: +SKIP
     """
-    files = open_files_backend(path, **kwargs)
+    def __init__(self, urlpath, compression=None, text=False, encoding='utf8',
+                 errors=None, **kwargs):
+        if compression == 'infer':
+            compression = infer_compression(urlpath)
+        if compression is not None and compression not in compress_files:
+            raise ValueError("Compression type %s not supported" % compression)
+        self.urlpath = urlpath
+        self.compression = compression
+        self.text = text
+        self.encoding = encoding
+        self.storage_options = infer_storage_options(
+                urlpath, inherit_storage_options=kwargs)
+        self.protocol = self.storage_options.pop('protocol')
+        ensure_protocol(self.protocol)
+        try:
+            self.fs = _filesystems[self.protocol](**self.storage_options)
+        except KeyError:
+            raise NotImplementedError("Unknown protocol %s (%s)" %
+                                      (protocol, urlpath))
 
-    if compression:
-        decompress = merge(seekable_files, compress_files)[compression]
+    def __call__(self, path, mode='rb'):
+        """Produces `OpenFile` instance"""
+        return OpenFile(self.fs.open, path, self.compression, mode,
+                        self.text, self.encoding)
+
+
+class OpenFile(object):
+    """
+    File-like object to be used in a context
+
+    These instances are safe to serialize, as the low-level file object
+    is not created until invoked using `with`.
+
+    Parameters
+    ----------
+    myopen: function
+        Opens the backend file. Should accept path and mode, as the builtin open
+    path: str
+        Location to open
+    compression: str or None
+        Compression to apply
+    mode: str like 'rb'
+        Mode of the opened file
+    text: bool
+        Whether to wrap the file to be text-like
+    encoding: if using text
+    errors: if using text
+    """
+    def __init__(self, myopen, path, compression, mode, text, encoding,
+                 errors=None):
+        self.myopen = myopen
+        self.path = path
+        self.compression = compression
+        self.mode = mode
+        self.text = text
+        self.encoding = encoding
+        self.closers = None
+        self.fobjects = None
+        self.errors = errors
+        self.f = None
+
+    def __enter__(self):
+        mode = self.mode.replace('t', '').replace('b', '') + 'b'
+        f = f2 = self.myopen(self.path, mode=mode)
+        CompressFile = merge(seekable_files, compress_files)[self.compression]
         if PY2:
-            files = [delayed(SeekableFile)(file) for file in files]
-        files = [delayed(decompress)(file) for file in files]
+            f2 = SeekableFile(f)
+        f3 = CompressFile(f2, mode=mode)
+        if self.text:
+            f4 = io.TextIOWrapper(f3, encoding=self.encoding,
+                                  errors=self.errors)
+        else:
+            f4 = f3
 
-    return files
+        self.closers = [f4.close, f3.close, f2.close, f.close]
+        self.fobjects = [f4, f3, f2, f]
+        self.f = f4
+        f4.close = self.close
+        return f4
+
+    def __exit__(self, *args):
+        self.close()
+
+    def close(self):
+        """ Close all encapsulated file objects
+        """
+        [_() for _ in self.closers]
+        del self.closers[:]
+        del self.fobjects[:]
+        self.f = None
 
 
-def open_files(urlpath, compression=None, **kwargs):
+def open_files(urlpath, compression=None, mode='rb', encoding='utf8',
+               errors=None, name_function=None, num=1, **kwargs):
     """ Given path return dask.delayed file-like objects
 
     Parameters
@@ -253,6 +339,18 @@ def open_files(urlpath, compression=None, **kwargs):
         ``s3://``), or globstring pointing to data.
     compression: string
         Compression to use.  See ``dask.bytes.compression.files`` for options.
+    mode: 'rb', 'wt', etc.
+    encoding: str
+        For text mode only
+    errors: None or str
+        Passed to TextIOWrapper in text mode
+    name_function: function or None
+        if opening a set of files for writing, those files do not yet exist,
+        so we need to generate their names by formatting the urlpath for
+        each sequence number
+    num: int [1]
+        if writing mode, number of files we expect to create (passed to
+        name+function)
     **kwargs: dict
         Extra options that make sense to a particular storage connection, e.g.
         host, port, username, password, etc.
@@ -266,21 +364,61 @@ def open_files(urlpath, compression=None, **kwargs):
     -------
     List of ``dask.delayed`` objects that compute to file-like objects
     """
-    if compression is not None and compression not in compress_files:
-        raise ValueError("Compression type %s not supported" % compression)
+    fs, paths, myopen = get_fs_paths_myopen(urlpath, compression, mode,
+                                            encoding=encoding, num=num,
+                                            name_function=name_function,
+                                            **kwargs)
+    return [myopen(path, mode) for path in paths]
 
-    storage_options = infer_storage_options(urlpath,
-                                            inherit_storage_options=kwargs)
-    protocol = storage_options.pop('protocol')
-    ensure_protocol(protocol)
-    try:
-        open_files_backend = _open_files[protocol]
-    except KeyError:
-        raise NotImplementedError("Unknown protocol %s (%s)" %
-                                  (protocol, urlpath))
 
-    return open_files_by(open_files_backend, storage_options.pop('path'),
-                         compression=compression, **storage_options)
+def get_fs_paths_myopen(urlpath, compression, mode, encoding='utf8',
+                        num=1, name_function=None, **kwargs):
+    if isinstance(urlpath, (str, unicode)):
+        myopen = OpenFileCreator(urlpath, compression, text='b' not in mode,
+                                 encoding=encoding, **kwargs)
+        if 'w' in mode:
+            paths = _expand_paths(urlpath, name_function, num)
+        elif "*" in urlpath:
+            paths = myopen.fs.glob(urlpath, **kwargs)
+        else:
+            paths = [urlpath]
+    elif isinstance(urlpath, (list, set, tuple, dict)):
+        myopen = OpenFileCreator(urlpath[0], compression, text='b' not in mode,
+                                 encoding=encoding, **kwargs)
+        paths = urlpath
+    else:
+        raise ValueError('url type not understood: %s' % urlpath)
+    return myopen.fs, paths, myopen
+
+
+def open_text_files(urlpath, compression=None, mode='rb', encoding='utf8',
+                    errors='strict', **kwargs):
+    """ Given path return dask.delayed file-like objects in text mode
+
+    Parameters
+    ----------
+    urlpath: string
+        Absolute or relative filepath, URL (may include protocols like
+        ``s3://``), or globstring pointing to data.
+    encoding: string
+    errors: string
+    compression: string
+        Compression to use.  See ``dask.bytes.compression.files`` for options.
+    **kwargs: dict
+        Extra options that make sense to a particular storage connection, e.g.
+        host, port, username, password, etc.
+
+    Examples
+    --------
+    >>> files = open_text_files('2015-*-*.csv', encoding='utf-8')  # doctest: +SKIP
+    >>> files = open_text_files('s3://bucket/2015-*-*.csv')  # doctest: +SKIP
+
+    Returns
+    -------
+    List of ``dask.delayed`` objects that compute to text file-like objects
+    """
+    return open_files(urlpath, compression, mode.replace('b', 't'), encoding,
+                      **kwargs)
 
 
 def _expand_paths(path, name_function, num):
@@ -308,65 +446,14 @@ def _expand_paths(path, name_function, num):
 1.  A list of paths -- ['foo.json', 'bar.json', ...]
 2.  A directory -- 'foo/
 3.  A path with a * in it -- 'foo.*.json'""")
+    print(path, paths)
     return paths
 
 
-def open_text_files(urlpath, encoding=system_encoding, errors='strict',
-                    compression=None, **kwargs):
-    """ Given path return dask.delayed file-like objects in text mode
-
-    Parameters
-    ----------
-    urlpath: string
-        Absolute or relative filepath, URL (may include protocols like
-        ``s3://``), or globstring pointing to data.
-    encoding: string
-    errors: string
-    compression: string
-        Compression to use.  See ``dask.bytes.compression.files`` for options.
-    **kwargs: dict
-        Extra options that make sense to a particular storage connection, e.g.
-        host, port, username, password, etc.
-
-    Examples
-    --------
-    >>> files = open_text_files('2015-*-*.csv', encoding='utf-8')  # doctest: +SKIP
-    >>> files = open_text_files('s3://bucket/2015-*-*.csv')  # doctest: +SKIP
-
-    Returns
-    -------
-    List of ``dask.delayed`` objects that compute to text file-like objects
-    """
-    if compression is not None and compression not in compress_files:
-        raise ValueError("Compression type %s not supported" % compression)
-
-    storage_options = infer_storage_options(urlpath,
-                                            inherit_storage_options=kwargs)
-    path = storage_options.pop('path')
-    protocol = storage_options.pop('protocol')
-    ensure_protocol(protocol)
-    if protocol in _open_text_files and compression is None:
-        return _open_text_files[protocol](path,
-                                          encoding=encoding,
-                                          errors=errors,
-                                          **storage_options)
-    elif protocol in _open_files:
-        files = open_files_by(_open_files[protocol],
-                              path,
-                              compression=compression,
-                              **storage_options)
-        if PY2:
-            files = [delayed(SeekableFile)(file) for file in files]
-        return [delayed(io.TextIOWrapper)(file, encoding=encoding,
-                                          errors=errors) for file in files]
-    else:
-        raise NotImplementedError("Unknown protocol %s (%s)" %
-                                  (protocol, urlpath))
-
-
 def ensure_protocol(protocol):
-    if (protocol not in ('s3', 'hdfs') and ((protocol in _read_bytes) or
-       (protocol in _open_files))):
+    if (protocol not in ('s3', 'hdfs') and
+        ((protocol in _read_bytes) or
+        (protocol in _filesystems))):
         return
 
     if protocol == 's3':
@@ -385,3 +472,26 @@ def ensure_protocol(protocol):
 
     else:
         raise ValueError("Unknown protocol %s" % protocol)
+
+
+_filesystems = dict()
+# see .local.LocalFileSystem for reference implementation
+
+
+class FileSystem(object):
+    def logical_size(self, path, compression):
+        if compression == 'infer':
+            compression = infer_compression(path)
+        if compression is None:
+            return self.size(path)
+        else:
+            with self.open(path, 'rb') as f:
+                f = SeekableFile(f)
+                g = seekable_files[compression](f)
+                g.seek(0, 2)
+                result = g.tell()
+                g.close()
+            return result
+
+    def get_block_locations(self, path):
+        return None, None, None

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -450,7 +450,6 @@ def _expand_paths(path, name_function, num):
 1.  A list of paths -- ['foo.json', 'bar.json', ...]
 2.  A directory -- 'foo/
 3.  A path with a * in it -- 'foo.*.json'""")
-    print(path, paths)
     return paths
 
 

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -313,7 +313,6 @@ class OpenFile(object):
         if self.text:
             f4 = io.TextIOWrapper(f3, encoding=self.encoding,
                                   errors=self.errors)
-            f4.read1 = f4.read
         else:
             f4 = f3
 
@@ -398,7 +397,7 @@ def get_fs_paths_myopen(urlpath, compression, mode, encoding='utf8',
     return myopen.fs, paths, myopen
 
 
-def open_text_files(urlpath, compression=None, mode='rb', encoding='utf8',
+def open_text_files(urlpath, compression=None, mode='rt', encoding='utf8',
                     errors='strict', **kwargs):
     """ Given path return dask.delayed file-like objects in text mode
 

--- a/dask/bytes/local.py
+++ b/dask/bytes/local.py
@@ -3,134 +3,73 @@ from __future__ import print_function, division, absolute_import
 from glob import glob
 import logging
 import os
-import sys
 
-from .compression import files as compress_files, seekable_files
-from .utils import SeekableFile, read_block
 from ..base import tokenize
-from ..compatibility import FileNotFoundError
-from ..delayed import delayed
-from ..utils import system_encoding
 
 logger = logging.getLogger(__name__)
 
 
-def open_file_write(paths):
-    """ Open list of files using delayed """
-    out = [delayed(open)(path, 'wb') for path in paths]
-    return out
-
-
-def open_file_write_direct(path):
-    return open(path, 'wb')
-
-
-def read_bytes(path, delimiter=None, not_zero=False, blocksize=2**27,
-               sample=True, compression=None):
-    """ See dask.bytes.core.read_bytes for docstring """
-    if '*' in path:
-        filenames = list(map(os.path.abspath, sorted(glob(path))))
-        sample, first = read_bytes(filenames[0], delimiter, not_zero,
-                                   blocksize, sample=sample,
-                                   compression=compression)
-        rest = [read_bytes(f, delimiter, not_zero, blocksize, sample=False,
-                           compression=compression)[1]
-                for f in filenames[1:]]
-        return sample, [first] + rest
-    else:
-        if not os.path.exists(path):
-            raise FileNotFoundError(path)
-
-        if blocksize is None:
-            offsets = [0]
-        else:
-            size = getsize(path, compression)
-
-            offsets = list(range(0, size, blocksize))
-            if not_zero:
-                offsets[0] = 1
-
-        token = tokenize(path, delimiter, blocksize, not_zero, compression,
-                         os.path.getmtime(path))
-
-        logger.debug("Read %d blocks of binary bytes from %s", len(offsets), path)
-        f = delayed(read_block_from_file)
-
-        values = [f(path, offset, blocksize, delimiter, compression,
-                    dask_key_name='read-file-block-%s-%d' % (token, offset))
-                  for offset in offsets]
-
-        if sample:
-            if sample is not True:
-                nbytes = sample
-            else:
-                nbytes = 10000
-            sample = read_block_from_file(path, 0, nbytes, delimiter, compression)
-
-        return sample, values
-
-
-def read_block_from_file(path, offset, length, delimiter, compression):
-    with open(path, 'rb') as f:
-        if compression:
-            f = SeekableFile(f)
-            f = compress_files[compression](f)
-        try:
-            result = read_block(f, offset, length, delimiter)
-        finally:
-            f.close()
-    return result
-
-
-def open_files(path):
-    """ Open many files.  Return delayed objects.
-
-    See Also
-    --------
-    dask.bytes.core.open_files: User function
-    """
-    myopen = delayed(open)
-    filepaths = sorted(glob(path))
-    return [myopen(_path, mode='rb',
-                   dask_key_name='open-%s' % tokenize(_path,
-                                                      os.path.getmtime(_path)))
-            for _path in filepaths]
-
-
 from . import core
-core._read_bytes['file'] = read_bytes
-core._open_files['file'] = open_files
-core._open_files_write['file'] = open_file_write_direct
 
-if sys.version_info[0] >= 3:
-    def open_text_files(path, encoding=system_encoding, errors='strict'):
-        """ Open many files in text mode.  Return delayed objects.
 
-        See Also
-        --------
-        dask.bytes.core.open_text_files: User function
+class LocalFileSystem(core.FileSystem):
+    """API spec for the methods a filesystem
+
+    A filesystem must provide these methods, if it is to be registered as
+    a backend for dask.
+
+    Implementation for local disc"""
+    sep = os.sep
+
+    def __init__(self, **storage_options):
         """
-        myopen = delayed(open)
-        filepaths = sorted(glob(path))
-        return [myopen(_path, encoding=encoding, errors=errors,
-                       dask_key_name='open-%s'
-                                     % tokenize(_path,
-                                                encoding,
-                                                errors,
-                                                os.path.getmtime(_path)))
-                for _path in filepaths]
+        Parameters
+        ----------
+        storage_options: key-value
+            May be credentials, or other configuration specific to the backend.
+        """
+        # no configuration necessary
+        pass
 
-    core._open_text_files['file'] = open_text_files
+    def glob(self, path):
+        """For a template path, return matching files"""
+        if path.startswith('file://'):
+            path = path[len('file://'):]
+        return sorted(glob(path))
+
+    def mkdirs(self, path):
+        """Make any intermediate directories to make path writable"""
+        if path.startswith('file://'):
+            path = path[len('file://'):]
+        return os.makedirs(path, exist_ok=True)
+
+    def open(self, path, mode='rb', **kwargs):
+        """Make a file-like object
+
+        Parameters
+        ----------
+        mode: string
+            normally "rb", "wb" or "ab" or other.
+        kwargs: key-value
+            Any other parameters, such as buffer size. May be better to set
+            these on the filesystem instance, to apply to all files created by
+            it. Not used for local.
+        """
+        if path.startswith('file://'):
+            path = path[len('file://'):]
+        return open(path, mode=mode)
+
+    def ukey(self, path):
+        """Unique identifier, so we can tell if a file changed"""
+        if path.startswith('file://'):
+            path = path[len('file://'):]
+        return tokenize(path, os.stat(path).st_mtime)
+
+    def size(self, path):
+        """Size in bytes of the file at path"""
+        if path.startswith('file://'):
+            path = path[len('file://'):]
+        return os.stat(path).st_size
 
 
-def getsize(path, compression=None):
-    if compression is None:
-        return os.path.getsize(path)
-    else:
-        with open(path, 'rb') as f:
-            f = SeekableFile(f)
-            g = seekable_files[compression](f)
-            g.seek(0, 2)
-            result = g.tell()
-            g.close()
-        return result
+core._filesystems['file'] = LocalFileSystem

--- a/dask/bytes/s3.py
+++ b/dask/bytes/s3.py
@@ -4,199 +4,58 @@ import logging
 
 from s3fs import S3FileSystem
 
-from .compression import files as compress_files, seekable_files
-from .utils import read_block
-
-from ..base import tokenize
-from ..delayed import delayed
+from . import core
 
 logger = logging.getLogger(__name__)
 
 
-def _get_s3(key=None, username=None, secret=None, password=None, **kwargs):
-    """ Reuse ``s3`` instance or construct a new S3FileSystem from storage_options.
+class DaskS3FileSystem(S3FileSystem, core.FileSystem):
 
-    >>> isinstance(_get_s3(), S3FileSystem)
-    True
-    >>> s3 = _get_s3(anon=False)
-    >>> s3.anon
-    False
-    """
-    if username is not None:
+    sep = '/'
+
+    def __init__(self, key=None, username=None, secret=None, password=None,
+                 blocksize=5 * 2 ** 20, path=None, host=None, s3=None, **kwargs):
+        if username is not None:
+            if key is not None:
+                raise KeyError("S3 storage options got secrets argument "
+                               "collision. Please, use either `key` "
+                               "storage option or password field in URLpath, "
+                               "not both options together.")
+            key = username
         if key is not None:
-            raise KeyError("S3 storage options got secrets argument "
-                           "collision. Please, use either `key` "
-                           "storage option or password field in URLpath, "
-                           "not both options together.")
-        key = username
-    if key is not None:
-        kwargs['key'] = key
-    if password is not None:
+            kwargs['key'] = key
+        if password is not None:
+            if secret is not None:
+                raise KeyError("S3 storage options got secrets argument "
+                               "collision. Please, use either `secret` "
+                               "storage option or password field in URLpath, "
+                               "not both options together.")
+            secret = password
         if secret is not None:
-            raise KeyError("S3 storage options got secrets argument "
-                           "collision. Please, use either `secret` "
-                           "storage option or password field in URLpath, "
-                           "not both options together.")
-        secret = password
-    if secret is not None:
-        kwargs['secret'] = secret
-    return S3FileSystem(**kwargs)
+            kwargs['secret'] = secret
+        self.blocksize = blocksize
+        # S3FileSystem.__init__(self, kwargs)  # not sure what do do here
+        S3FileSystem.__init__(self, **kwargs)
+
+    def open(self, path, mode='rb', **kwargs):
+        bucket = kwargs.pop('host', '')
+        s3_path = bucket + path
+        return S3FileSystem.open(self, s3_path, mode=mode,
+                                 block_size=self.blocksize)
+
+    def glob(self, path, **kwargs):
+        bucket = kwargs.pop('host', '')
+        s3_path = bucket + path
+        return S3FileSystem.glob(self, s3_path)
+
+    def mkdirs(self, path):
+        pass  # no need to pre-make paths on S3
+
+    def ukey(self, path):
+        return self.info(path)['ETag']
+
+    def size(self, path):
+        return self.info(path)['Size']
 
 
-def read_bytes(path, s3=None, delimiter=None, not_zero=False, blocksize=2**27,
-               sample=True, compression=None, **kwargs):
-    """ Convert location in S3 to a list of delayed values
-
-    Parameters
-    ----------
-    path: string
-        location in S3
-    s3: S3FileSystem
-    delimiter: bytes
-        An optional delimiter, like ``b'\n'`` on which to split blocks of bytes
-    not_zero: force seek of start-of-file delimiter, discarding header
-    blocksize: int (=128MB)
-        Chunk size
-    sample: bool, int
-        Whether or not to return a sample from the first 10k bytes
-    compression: string or None
-        String like 'gzip' or 'xz'.  Must support efficient random access.
-    **kwargs: dict
-        Extra keywords to send to boto3 session (anon, key, secret...) if
-        ``s3`` is None.
-
-    Returns
-    -------
-    10kB sample header and list of ``dask.Delayed`` objects or list of lists of
-    delayed objects if ``path`` is a globstring.
-    """
-    bucket = kwargs.pop('host', '')
-    s3_path = bucket + path
-    if s3 is None:
-        s3 = _get_s3(**kwargs)
-
-    if '*' in path:
-        filenames = sorted(s3.glob(s3_path))
-        if not filenames:
-            raise IOError("No such files: '%s'" % s3_path)
-        sample, first = read_bytes(filenames[0], s3, delimiter, not_zero,
-                                   blocksize, sample=sample,
-                                   compression=compression)
-        rest = [read_bytes(f, s3, delimiter, not_zero, blocksize,
-                           sample=False, compression=compression)[1]
-                for f in filenames[1:]]
-        return sample, [first] + rest
-    else:
-        if blocksize is None:
-            offsets = [0]
-        else:
-            size = getsize(s3_path, compression, s3)
-            offsets = list(range(0, size, blocksize))
-            if not_zero:
-                offsets[0] = 1
-
-        info = s3.ls(s3_path, detail=True)[0]
-
-        token = tokenize(info['ETag'], delimiter, blocksize, not_zero, compression)
-
-        s3_storage_options = s3.get_delegated_s3pars()
-
-        logger.debug("Read %d blocks of binary bytes from %s", len(offsets), s3_path)
-
-        delayed_read_block_from_s3 = delayed(read_block_from_s3)
-        values = [delayed_read_block_from_s3(s3_path, offset, blocksize,
-                                             delimiter=delimiter,
-                                             compression=compression,
-                                             dask_key_name='read-block-s3-%s-%d' % (token, offset),
-                                             **s3_storage_options)
-                  for offset in offsets]
-
-        if sample:
-            if isinstance(sample, int) and not isinstance(sample, bool):
-                nbytes = sample
-            else:
-                nbytes = 10000
-            sample = read_block_from_s3(s3_path, 0, nbytes, s3,
-                                        delimiter, compression, **kwargs)
-
-        return sample, values
-
-
-def read_block_from_s3(path, offset, length, s3=None,
-                       delimiter=None, compression=None, **kwargs):
-    bucket = kwargs.pop('host', '')
-    s3_path = bucket + path
-    if s3 is None:
-        s3 = _get_s3(**kwargs)
-    with s3.open(s3_path, 'rb') as f:
-        if compression:
-            f = compress_files[compression](f)
-        try:
-            result = read_block(f, offset, length, delimiter)
-        finally:
-            f.close()
-    return result
-
-
-def s3_open_file(path, s3=None, **kwargs):
-    bucket = kwargs.pop('host', '')
-    s3_path = bucket + path
-    if s3 is None:
-        s3 = _get_s3(**kwargs)
-    return s3.open(s3_path, mode='rb')
-
-
-def open_file_write(paths, s3=None, **kwargs):
-    """ Open list of files using delayed """
-    bucket = kwargs.pop('host', '')
-    if s3 is None:
-        s3 = _get_s3(**kwargs)
-    out = [delayed(s3.open)(bucket + path, 'wb') for path in paths]
-    return out
-
-
-def open_file_write_direct(path, s3=None, **kwargs):
-    bucket = kwargs.pop('host', '')
-    if s3 is None:
-        s3 = _get_s3(**kwargs)
-    return s3.open(bucket + path, 'wb')
-
-
-def open_files(path, s3=None, **kwargs):
-    """ Open many files.  Return delayed objects.
-
-    See Also
-    --------
-    dask.bytes.core.open_files:  User function
-    """
-    bucket = kwargs.pop('host', '')
-    s3_path = bucket + path
-    if s3 is None:
-        s3 = _get_s3(**kwargs)
-
-    filenames = sorted(s3.glob(s3_path))
-    myopen = delayed(s3_open_file)
-    s3_storage_options = s3.get_delegated_s3pars()
-
-    return [myopen(_s3_path,
-                   dask_key_name='s3-open-file-%s' % s3.info(_s3_path)['ETag'],
-                   **s3_storage_options)
-            for _s3_path in filenames]
-
-
-def getsize(path, compression, s3):
-    if compression is None:
-        return s3.info(path)['Size']
-    else:
-        with s3.open(path, 'rb') as f:
-            g = seekable_files[compression](f)
-            g.seek(0, 2)
-            result = g.tell()
-            g.close()
-        return result
-
-
-from . import core
-core._read_bytes['s3'] = read_bytes
-core._open_files['s3'] = open_files
-core._open_files_write['s3'] = open_file_write_direct
+core._filesystems['s3'] = DaskS3FileSystem

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -13,7 +13,7 @@ from dask.utils import filetexts
 from dask.bytes import compression
 from dask.bytes.local import LocalFileSystem
 from dask.bytes.core import (open_text_files, write_bytes, read_bytes,
-        open_files, OpenFileCreator)
+                             open_files, OpenFileCreator)
 
 compute = partial(compute, get=get)
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+import gzip
 import os
 import pickle
 from time import sleep
@@ -295,3 +296,16 @@ def test_pickability_of_lazy_files(tmpdir):
 
     lazy_file3 = pickle.loads(pickle.dumps(lazy_file))
     assert lazy_file.path == lazy_file3.path
+
+
+def test_py2_local_bytes(tmpdir):
+    fn = str(tmpdir / 'myfile.txt.gz')
+    with gzip.open(fn, mode='wb') as f:
+        f.write(b'hello\nworld')
+
+    ofc = OpenFileCreator(fn, text=True, open=open, mode='rt',
+                          compression='gzip', encoding='utf-8')
+    lazy_file = ofc(fn)
+
+    with lazy_file as f:
+        assert all(isinstance(line, unicode) for line in f)

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -213,7 +213,7 @@ def test_bad_compression():
 
 def test_not_found():
     fn = 'not-a-file'
-    with pytest.raises(FileNotFoundError) as e:
+    with pytest.raises((FileNotFoundError, OSError)) as e:
         read_bytes(fn)
     assert fn in str(e)
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import os
+import pickle
 from time import sleep
 
 import pytest
@@ -10,8 +11,9 @@ from dask import compute, get, delayed
 from dask.compatibility import FileNotFoundError
 from dask.utils import filetexts
 from dask.bytes import compression
-from dask.bytes.local import read_bytes, open_files, getsize, open_file_write
-from dask.bytes.core import open_text_files, write_bytes
+from dask.bytes.local import LocalFileSystem
+from dask.bytes.core import (open_text_files, write_bytes, read_bytes,
+        open_files, OpenFileCreator)
 
 compute = partial(compute, get=get)
 
@@ -135,11 +137,13 @@ def test_registered_read_bytes():
 
 
 def test_registered_open_files():
-    from dask.bytes.core import open_files
     with filetexts(files, mode='b'):
         myfiles = open_files('.test.accounts.*')
         assert len(myfiles) == len(files)
-        data = compute(*[file.read() for file in myfiles])
+        data = []
+        for file in myfiles:
+            with file as f:
+                data.append(f.read())
         assert list(data) == [files[k] for k in sorted(files)]
 
 
@@ -149,7 +153,10 @@ def test_registered_open_text_files(encoding):
     with filetexts(files, mode='b'):
         myfiles = open_text_files('.test.accounts.*', encoding=encoding)
         assert len(myfiles) == len(files)
-        data = compute(*[file.read() for file in myfiles])
+        data = []
+        for file in myfiles:
+            with file as f:
+                data.append(f.read())
         assert list(data) == [files[k].decode(encoding)
                               for k in sorted(files)]
 
@@ -158,17 +165,21 @@ def test_open_files():
     with filetexts(files, mode='b'):
         myfiles = open_files('.test.accounts.*')
         assert len(myfiles) == len(files)
-        data = compute(*[file.read() for file in myfiles])
-        assert list(data) == [files[k] for k in sorted(files)]
+        for lazy_file, data_file in zip(myfiles, sorted(files)):
+            with lazy_file as f:
+                x = f.read()
+                assert x == files[data_file]
 
 
 @pytest.mark.parametrize('fmt', list(compression.files))
 def test_compression_binary(fmt):
-    from dask.bytes.core import open_files
     files2 = valmap(compression.compress[fmt], files)
     with filetexts(files2, mode='b'):
         myfiles = open_files('.test.accounts.*', compression=fmt)
-        data = compute(*[file.read() for file in myfiles])
+        data = []
+        for file in myfiles:
+            with file as f:
+                data.append(f.read())
         assert list(data) == [files[k] for k in sorted(files)]
 
 
@@ -177,19 +188,22 @@ def test_compression_text(fmt):
     files2 = valmap(compression.compress[fmt], files)
     with filetexts(files2, mode='b'):
         myfiles = open_text_files('.test.accounts.*', compression=fmt)
-        data = compute(*[file.read() for file in myfiles])
+        data = []
+        for file in myfiles:
+            with file as f:
+                data.append(f.read())
         assert list(data) == [files[k].decode() for k in sorted(files)]
 
 
 @pytest.mark.parametrize('fmt', list(compression.seekable_files))
 def test_getsize(fmt):
+    fs = LocalFileSystem()
     compress = compression.compress[fmt]
     with filetexts({'.tmp.getsize': compress(b'1234567890')}, mode='b'):
-        assert getsize('.tmp.getsize', fmt) == 10
+        assert fs.logical_size('.tmp.getsize', fmt) == 10
 
 
 def test_bad_compression():
-    from dask.bytes.core import read_bytes, open_files, open_text_files
     with filetexts(files, mode='b'):
         for func in [read_bytes, open_files, open_text_files]:
             with pytest.raises(ValueError):
@@ -222,23 +236,6 @@ def test_names():
         _, c = read_bytes('.test.accounts.*')
         c = list(concat(c))
         assert [aa._key for aa in a] != [cc._key for cc in c]
-
-
-@pytest.mark.parametrize('open_files', [open_files, open_text_files])
-def test_modification_time_open_files(open_files):
-    with filetexts(files, mode='b'):
-        a = open_files('.test.accounts.*')
-        b = open_files('.test.accounts.*')
-
-        assert [aa._key for aa in a] == [bb._key for bb in b]
-
-    sleep(1)
-
-    double = lambda x: x + x
-    with filetexts(valmap(double, files), mode='b'):
-        c = open_files('.test.accounts.*')
-
-    assert [aa._key for aa in a] != [cc._key for cc in c]
 
 
 def test_simple_write(tmpdir):
@@ -274,8 +271,27 @@ def test_compressed_write(tmpdir):
 
 def test_open_files_write(tmpdir):
     tmpdir = str(tmpdir)
-    f = open_file_write([os.path.join(tmpdir, 'test1'),
-                         os.path.join(tmpdir, 'test2')])
-    assert len(f) == 2
-    files = compute(*f)
+    files = open_files([os.path.join(tmpdir, 'test1'),
+                        os.path.join(tmpdir, 'test2')], mode='wb')
+    assert len(files) == 2
     assert files[0].mode == 'wb'
+
+
+def test_pickability_of_lazy_files(tmpdir):
+    fn = os.path.join(str(tmpdir), 'foo')
+    with open(fn, 'wb') as f:
+        f.write(b'1')
+
+    opener = OpenFileCreator('file://foo.py', open=open)
+    opener2 = pickle.loads(pickle.dumps(opener))
+    assert type(opener2.fs) == type(opener.fs)
+
+    lazy_file = opener(fn, mode='rt')
+    lazy_file2 = pickle.loads(pickle.dumps(lazy_file))
+    assert lazy_file.path == lazy_file2.path
+
+    with lazy_file as f:
+        pass
+
+    lazy_file3 = pickle.loads(pickle.dumps(lazy_file))
+    assert lazy_file.path == lazy_file3.path

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -8,7 +8,7 @@ import pytest
 from toolz import concat, valmap, partial
 
 from dask import compute, get, delayed
-from dask.compatibility import FileNotFoundError
+from dask.compatibility import FileNotFoundError, unicode
 from dask.utils import filetexts
 from dask.bytes import compression
 from dask.bytes.local import LocalFileSystem

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 import gzip
 import os
-import pickle
 from time import sleep
 
 import pytest
@@ -279,22 +278,23 @@ def test_open_files_write(tmpdir):
 
 
 def test_pickability_of_lazy_files(tmpdir):
+    cloudpickle = pytest.importorskip('cloudpickle')
     fn = os.path.join(str(tmpdir), 'foo')
     with open(fn, 'wb') as f:
         f.write(b'1')
 
     opener = OpenFileCreator('file://foo.py', open=open)
-    opener2 = pickle.loads(pickle.dumps(opener))
+    opener2 = cloudpickle.loads(cloudpickle.dumps(opener))
     assert type(opener2.fs) == type(opener.fs)
 
     lazy_file = opener(fn, mode='rt')
-    lazy_file2 = pickle.loads(pickle.dumps(lazy_file))
+    lazy_file2 = cloudpickle.loads(cloudpickle.dumps(lazy_file))
     assert lazy_file.path == lazy_file2.path
 
     with lazy_file as f:
         pass
 
-    lazy_file3 = pickle.loads(pickle.dumps(lazy_file))
+    lazy_file3 = cloudpickle.loads(cloudpickle.dumps(lazy_file))
     assert lazy_file.path == lazy_file3.path
 
 

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -13,7 +13,8 @@ from toolz import concat, valmap, partial
 from s3fs import S3FileSystem
 
 from dask import compute, get, delayed
-from dask.bytes.s3 import _get_s3, read_bytes, open_files, getsize
+from dask.bytes.s3 import DaskS3FileSystem
+from dask.bytes.core import read_bytes, open_files, open_text_files
 from dask.bytes import core
 
 
@@ -51,7 +52,7 @@ def s3_context(bucket, files):
     for f, data in files.items():
         client.put_object(Bucket=bucket, Key=f, Body=data)
 
-    yield S3FileSystem(anon=True)
+    yield DaskS3FileSystem(anon=True)
 
     for f, data in files.items():
         try:
@@ -62,32 +63,32 @@ def s3_context(bucket, files):
 
 
 def test_get_s3():
-    s3 = _get_s3(key='key', secret='secret')
+    s3 = DaskS3FileSystem(key='key', secret='secret')
     assert s3.key == 'key'
     assert s3.secret == 'secret'
 
-    s3 = _get_s3(username='key', password='secret')
+    s3 = DaskS3FileSystem(username='key', password='secret')
     assert s3.key == 'key'
     assert s3.secret == 'secret'
 
     with pytest.raises(KeyError):
-        _get_s3(key='key', username='key')
+        DaskS3FileSystem(key='key', username='key')
     with pytest.raises(KeyError):
-        _get_s3(secret='key', password='key')
+        DaskS3FileSystem(secret='key', password='key')
 
 
 def test_write_bytes(s3):
     paths = ['s3://' + test_bucket_name + '/more/' + f for f in files]
     values = [delayed(v) for v in files.values()]
-    out = core.write_bytes(values, paths, s3=s3)
+    out = core.write_bytes(values, paths)
     compute(*out)
-    sample, values = read_bytes(test_bucket_name + '/more/test/accounts.*', s3=s3)
+    sample, values = read_bytes('s3://' + test_bucket_name + '/more/test/accounts.*')
     results = compute(*concat(values))
     assert set(list(files.values())) == set(results)
 
 
 def test_read_bytes(s3):
-    sample, values = read_bytes(test_bucket_name + '/test/accounts.*', s3=s3)
+    sample, values = read_bytes('s3://' + test_bucket_name + '/test/accounts.*')
     assert isinstance(sample, bytes)
     assert sample[:5] == files[sorted(files)[0]][:5]
     assert sample.endswith(b'\n')
@@ -102,25 +103,25 @@ def test_read_bytes(s3):
 
 
 def test_read_bytes_sample_delimiter(s3):
-    sample, values = read_bytes(test_bucket_name + '/test/accounts.*', s3=s3,
+    sample, values = read_bytes('s3://' + test_bucket_name + '/test/accounts.*',
                                 sample=80, delimiter=b'\n')
     assert sample.endswith(b'\n')
-    sample, values = read_bytes(test_bucket_name + '/test/accounts.1.json', s3=s3,
+    sample, values = read_bytes('s3://' + test_bucket_name + '/test/accounts.1.json',
                                 sample=80, delimiter=b'\n')
     assert sample.endswith(b'\n')
-    sample, values = read_bytes(test_bucket_name + '/test/accounts.1.json', s3=s3,
+    sample, values = read_bytes('s3://' + test_bucket_name + '/test/accounts.1.json',
                                 sample=2, delimiter=b'\n')
     assert sample.endswith(b'\n')
 
 
 def test_read_bytes_non_existing_glob(s3):
     with pytest.raises(IOError):
-        read_bytes(test_bucket_name + '/non-existing/*', s3=s3)
+        read_bytes('s3://' + test_bucket_name + '/non-existing/*')
 
 
 def test_read_bytes_blocksize_none(s3):
-    _, values = read_bytes(test_bucket_name + '/test/accounts.*', blocksize=None,
-                           s3=s3)
+    _, values = read_bytes('s3://' + test_bucket_name + '/test/accounts.*',
+                           blocksize=None)
     assert sum(map(len, values)) == len(files)
 
 
@@ -136,8 +137,8 @@ def test_read_bytes_blocksize_on_large_data():
 
 @pytest.mark.parametrize('blocksize', [5, 15, 45, 1500])
 def test_read_bytes_block(s3, blocksize):
-    _, vals = read_bytes(test_bucket_name + '/test/account*',
-                         blocksize=blocksize, s3=s3)
+    _, vals = read_bytes('s3://' + test_bucket_name + '/test/account*',
+                         blocksize=blocksize)
     assert (list(map(len, vals)) ==
             [(len(v) // blocksize + 1) for v in files.values()])
 
@@ -152,10 +153,10 @@ def test_read_bytes_block(s3, blocksize):
 
 @pytest.mark.parametrize('blocksize', [5, 15, 45, 1500])
 def test_read_bytes_delimited(s3, blocksize):
-    _, values = read_bytes(test_bucket_name + '/test/accounts*',
-                           blocksize=blocksize, delimiter=b'\n', s3=s3)
-    _, values2 = read_bytes(test_bucket_name + '/test/accounts*',
-                            blocksize=blocksize, delimiter=b'foo', s3=s3)
+    _, values = read_bytes('s3://' + test_bucket_name + '/test/accounts*',
+                           blocksize=blocksize, delimiter=b'\n')
+    _, values2 = read_bytes('s3://' + test_bucket_name + '/test/accounts*',
+                            blocksize=blocksize, delimiter=b'foo')
     assert ([a.key for a in concat(values)] !=
             [b.key for b in concat(values2)])
 
@@ -168,9 +169,8 @@ def test_read_bytes_delimited(s3, blocksize):
 
     # delimiter not at the end
     d = b'}'
-    _, values = read_bytes(test_bucket_name + '/test/accounts*',
-                           blocksize=blocksize, delimiter=d,
-                           s3=s3)
+    _, values = read_bytes('s3://' + test_bucket_name + '/test/accounts*',
+                           blocksize=blocksize, delimiter=d)
     results = compute(*concat(values))
     res = [r for r in results if r]
     # All should end in } except EOF
@@ -181,30 +181,29 @@ def test_read_bytes_delimited(s3, blocksize):
 
 
 def test_registered(s3):
-    from dask.bytes.core import read_bytes
-
-    sample, values = read_bytes('s3://%s/test/accounts.*.json' % test_bucket_name,
-                                s3=s3)
+    sample, values = read_bytes('s3://%s/test/accounts.*.json' % test_bucket_name)
 
     results = compute(*concat(values))
     assert set(results) == set(files.values())
 
 
 def test_registered_open_files(s3):
-    from dask.bytes.core import open_files
-    myfiles = open_files('s3://%s/test/accounts.*.json' % test_bucket_name,
-                         s3=s3)
+    myfiles = open_files('s3://%s/test/accounts.*.json' % test_bucket_name)
     assert len(myfiles) == len(files)
-    data = compute(*[file.read() for file in myfiles])
+    data = []
+    for file in myfiles:
+        with file as f:
+            data.append(f.read())
     assert list(data) == [files[k] for k in sorted(files)]
 
 
 def test_registered_open_text_files(s3):
-    from dask.bytes.core import open_text_files
-    myfiles = open_text_files('s3://%s/test/accounts.*.json' % test_bucket_name,
-                              s3=s3)
+    myfiles = open_text_files('s3://%s/test/accounts.*.json' % test_bucket_name)
     assert len(myfiles) == len(files)
-    data = compute(*[file.read() for file in myfiles])
+    data = []
+    for file in myfiles:
+        with file as f:
+            data.append(f.read())
     assert list(data) == [files[k].decode() for k in sorted(files)]
 
 
@@ -215,7 +214,7 @@ fmt_bs = [(fmt, None) for fmt in cfiles] + [(fmt, 10) for fmt in seekable_files]
 @pytest.mark.parametrize('fmt,blocksize', fmt_bs)
 def test_compression(s3, fmt, blocksize):
     with s3_context('compress', valmap(compress[fmt], files)) as s3:
-        sample, values = read_bytes('compress/test/accounts.*', s3=s3,
+        sample, values = read_bytes('s3://compress/test/accounts.*',
                                     compression=fmt, blocksize=blocksize)
         assert sample.startswith(files[sorted(files)[0]][:10])
         assert sample.endswith(b'\n')
@@ -225,16 +224,18 @@ def test_compression(s3, fmt, blocksize):
 
 
 def test_files(s3):
-    myfiles = open_files(test_bucket_name + '/test/accounts.*', s3=s3)
+    myfiles = open_files('s3://' + test_bucket_name + '/test/accounts.*')
     assert len(myfiles) == len(files)
-    data = compute(*[file.read() for file in myfiles])
-    assert list(data) == [files[k] for k in sorted(files)]
+    for lazy_file, path in zip(myfiles, sorted(files)):
+        with lazy_file as f:
+            data = f.read()
+            assert data == files[path]
 
 
 @pytest.mark.parametrize('fmt', list(seekable_files))
 def test_getsize(fmt):
     with s3_context('compress', {'x': compress[fmt](b'1234567890')}) as s3:
-        assert getsize('compress/x', fmt, s3=s3) == 10
+        assert s3.logical_size('compress/x', fmt) == 10
 
 
 double = lambda x: x * 2
@@ -242,26 +243,27 @@ double = lambda x: x * 2
 
 def test_modification_time_read_bytes():
     with s3_context('compress', files) as s3:
-        _, a = read_bytes('compress/test/accounts.*', s3=s3)
-        _, b = read_bytes('compress/test/accounts.*', s3=s3)
+        _, a = read_bytes('s3://compress/test/accounts.*')
+        _, b = read_bytes('s3://compress/test/accounts.*')
 
         assert [aa._key for aa in concat(a)] == [bb._key for bb in concat(b)]
 
     with s3_context('compress', valmap(double, files)) as s3:
-        _, c = read_bytes('compress/test/accounts.*', s3=s3)
+        _, c = read_bytes('s3://compress/test/accounts.*')
 
     assert [aa._key for aa in concat(a)] != [cc._key for cc in concat(c)]
 
 
+@pytest.mark.xfail()
 def test_modification_time_open_files():
     with s3_context('compress', files) as s3:
-        a = open_files('compress/test/accounts.*', s3=s3)
-        b = open_files('compress/test/accounts.*', s3=s3)
+        a = open_files('s3://compress/test/accounts.*')
+        b = open_files('s3://compress/test/accounts.*')
 
         assert [aa._key for aa in a] == [bb._key for bb in b]
 
     with s3_context('compress', valmap(double, files)) as s3:
-        c = open_files('compress/test/accounts.*', s3=s3)
+        c = open_files('s3://compress/test/accounts.*')
 
     assert [aa._key for aa in a] != [cc._key for cc in c]
 

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -213,7 +213,7 @@ fmt_bs = [(fmt, None) for fmt in cfiles] + [(fmt, 10) for fmt in seekable_files]
 
 @pytest.mark.parametrize('fmt,blocksize', fmt_bs)
 def test_compression(s3, fmt, blocksize):
-    with s3_context('compress', valmap(compress[fmt], files)) as s3:
+    with s3_context('compress', valmap(compress[fmt], files)):
         sample, values = read_bytes('s3://compress/test/accounts.*',
                                     compression=fmt, blocksize=blocksize)
         assert sample.startswith(files[sorted(files)[0]][:10])
@@ -242,13 +242,13 @@ double = lambda x: x * 2
 
 
 def test_modification_time_read_bytes():
-    with s3_context('compress', files) as s3:
+    with s3_context('compress', files):
         _, a = read_bytes('s3://compress/test/accounts.*')
         _, b = read_bytes('s3://compress/test/accounts.*')
 
         assert [aa._key for aa in concat(a)] == [bb._key for bb in concat(b)]
 
-    with s3_context('compress', valmap(double, files)) as s3:
+    with s3_context('compress', valmap(double, files)):
         _, c = read_bytes('s3://compress/test/accounts.*')
 
     assert [aa._key for aa in concat(a)] != [cc._key for cc in concat(c)]
@@ -256,13 +256,13 @@ def test_modification_time_read_bytes():
 
 @pytest.mark.xfail()
 def test_modification_time_open_files():
-    with s3_context('compress', files) as s3:
+    with s3_context('compress', files):
         a = open_files('s3://compress/test/accounts.*')
         b = open_files('s3://compress/test/accounts.*')
 
         assert [aa._key for aa in a] == [bb._key for bb in b]
 
-    with s3_context('compress', valmap(double, files)) as s3:
+    with s3_context('compress', valmap(double, files)):
         c = open_files('s3://compress/test/accounts.*')
 
     assert [aa._key for aa in a] != [cc._key for cc in c]

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -254,7 +254,7 @@ def test_modification_time_read_bytes():
     assert [aa._key for aa in concat(a)] != [cc._key for cc in concat(c)]
 
 
-@pytest.mark.xfail()
+@pytest.mark.skip()
 def test_modification_time_open_files():
     with s3_context('compress', files):
         a = open_files('s3://compress/test/accounts.*')

--- a/dask/bytes/utils.py
+++ b/dask/bytes/utils.py
@@ -21,7 +21,7 @@ if sys.version_info[0] < 3:
 
         def writable(self):
             try:
-                return self.file.readable()
+                return self.file.writable()
             except AttributeError:
                 return 'w' in self.file.mode
 
@@ -112,8 +112,11 @@ def read_block(f, offset, length, delimiter=None):
         start = f.tell()
         length -= start - offset
 
-        f.seek(start + length)
-        seek_delimiter(f, delimiter, 2**16)
+        try:
+            f.seek(start + length)
+            seek_delimiter(f, delimiter, 2**16)
+        except ValueError:
+            f.seek(0, 2)
         end = f.tell()
 
         offset = start

--- a/dask/bytes/utils.py
+++ b/dask/bytes/utils.py
@@ -25,9 +25,11 @@ if sys.version_info[0] < 3:
             except AttributeError:
                 return 'w' in self.file.mode
 
-        @property
-        def read1(self):  # https://bugs.python.org/issue12591
-            return self.file.read
+        def read1(self, *args, **kwargs):  # https://bugs.python.org/issue12591
+            return self.file.read(*args, **kwargs)
+
+        def __iter__(self):
+            return self.file.__iter__()
 
         def __getattr__(self, key):
             return getattr(self.file, key)

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -148,63 +148,60 @@ else:
     else:
         BZ2File = bz2.BZ2File
 
-    if sys.version_info[1] <= 6:
-        class GzipFile(BufferedIOBase):
-            def __init__(self, *args, **kwargs):
-                self.__obj = gzip.GzipFile(*args, **kwargs)
+    class GzipFile(BufferedIOBase):
+        def __init__(self, *args, **kwargs):
+            self.__obj = gzip.GzipFile(*args, **kwargs)
 
-            def close(self):
-                return self.__obj.close()
+        def close(self):
+            return self.__obj.close()
 
-            @property
-            def closed(self):
-                return self.__obj.fileobj is None
+        @property
+        def closed(self):
+            return self.__obj.fileobj is None
 
-            def flush(self, *args, **kwargs):
-                return self.__obj.flush(*args, **kwargs)
+        def flush(self, *args, **kwargs):
+            return self.__obj.flush(*args, **kwargs)
 
-            def isatty(self):
-                return self.__obj.isatty()
+        def isatty(self):
+            return self.__obj.isatty()
 
-            def read(self, *args, **kwargs):
-                return self.__obj.read(*args, **kwargs)
+        def read(self, *args, **kwargs):
+            return self.__obj.read(*args, **kwargs)
 
-            def read1(self, *args, **kwargs):
-                return self.__obj.read(*args, **kwargs)
+        def read1(self, *args, **kwargs):
+            return self.__obj.read(*args, **kwargs)
 
-            def readable(self):
-                return self.__obj.mode == gzip.READ
+        def readable(self):
+            return self.__obj.mode == gzip.READ
 
-            def readline(self, *args, **kwargs):
-                return self.__obj.readline(*args, **kwargs)
+        def readline(self, *args, **kwargs):
+            return self.__obj.readline(*args, **kwargs)
 
-            def readlines(self, *args, **kwargs):
-                return self.__obj.readlines(*args, **kwargs)
+        def readlines(self, *args, **kwargs):
+            return self.__obj.readlines(*args, **kwargs)
 
-            def seek(self, *args, **kwargs):
-                self.__obj.seek(*args, **kwargs)
-                return self.tell()
+        def seek(self, *args, **kwargs):
+            self.__obj.seek(*args, **kwargs)
+            return self.tell()
 
-            def seekable(self):
-                # See https://hg.python.org/cpython/file/2.7/Lib/gzip.py#l421
-                return True
+        def seekable(self):
+            # See https://hg.python.org/cpython/file/2.7/Lib/gzip.py#l421
+            return True
 
-            def tell(self):
-                return self.__obj.tell()
+        def tell(self):
+            return self.__obj.tell()
 
-            def truncate(self, *args, **kwargs):
-                return self.__obj.truncate(*args, **kwargs)
+        def truncate(self, *args, **kwargs):
+            return self.__obj.truncate(*args, **kwargs)
 
-            def writable(self):
-                return self.__obj.mode == gzip.WRITE
+        def writable(self):
+            return self.__obj.mode == gzip.WRITE
 
-            def write(self, *args, **kwargs):
-                return self.__obj.write(*args, **kwargs)
+        def write(self, *args, **kwargs):
+            return self.__obj.write(*args, **kwargs)
 
-            def writelines(self, *args, **kwargs):
-                return self.__obj.writelines(*args, **kwargs)
-    else:
-        GzipFile = gzip.GzipFile
+        def writelines(self, *args, **kwargs):
+            return self.__obj.writelines(*args, **kwargs)
 
     try:
         try:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3455,7 +3455,7 @@ def repartition(df, divisions=None, force=False):
     raise ValueError('Data must be DataFrame or Series')
 
 
-def set_sorted_index(df, index, drop=True, **kwargs):
+def set_sorted_index(df, index, drop=True, divisions=None, **kwargs):
     if not isinstance(index, Series):
         meta = df._meta.set_index(index, drop=drop)
     else:
@@ -3463,7 +3463,11 @@ def set_sorted_index(df, index, drop=True, **kwargs):
 
     result = map_partitions(M.set_index, df, index, drop=drop, meta=meta)
 
-    return compute_divisions(result, **kwargs)
+    if not divisions:
+        divisions = compute_divisions(result, **kwargs)
+
+    result.divisions = divisions
+    return result
 
 
 def compute_divisions(df, **kwargs):
@@ -3478,11 +3482,7 @@ def compute_divisions(df, **kwargs):
                          mins, maxes)
 
     divisions = tuple(mins) + (list(maxes)[-1],)
-
-    df = copy(df)
-    df.divisions = divisions
-
-    return df
+    return divisions
 
 
 def _reduction_chunk(x, aca_chunk=None, **kwargs):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import Iterator
-from copy import copy
 from distutils.version import LooseVersion
 import operator
 from operator import getitem, setitem

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2646,6 +2646,7 @@ def elemwise_property(attr, s):
     meta = pd.Series([], dtype=getattr(s._meta, attr).dtype)
     return map_partitions(getattr, s, attr, meta=meta)
 
+
 for name in ['nanosecond', 'microsecond', 'millisecond', 'second', 'minute',
              'hour', 'day', 'dayofweek', 'dayofyear', 'week', 'weekday',
              'weekofyear', 'month', 'quarter', 'year']:

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -31,6 +31,7 @@ def make_categorical(n, rstate):
     return pd.Categorical.from_codes(rstate.randint(0, len(names), size=n),
                                      names)
 
+
 make = {float: make_float,
         int: make_int,
         str: make_string,

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -25,8 +25,6 @@ from ...utils import build_name_function
 
 from .io import _link
 
-lock = Lock()
-
 
 def _pd_to_hdf(pd_to_hdf, lock, args, kwargs=None):
     """ A wrapper function around pd_to_hdf that enables locking"""

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -507,15 +507,14 @@ def from_delayed(dfs, meta=None, divisions=None, prefix='from-delayed',
     else:
         Frame = DataFrame
 
+    df = Frame(dsk3, name, meta, [None] * (len(dfs) + 1))
+
     if divisions == 'sorted':
         from ..core import compute_divisions
-        divisions = [None] * (len(dfs) + 1)
-        df = Frame(dsk3, name, meta, divisions)
-        return compute_divisions(df)
-    elif divisions is None:
-        divisions = [None] * (len(dfs) + 1)
+        divisions = compute_divisions(df)
+        df.divisions = divisions
 
-    return Frame(dsk3, name, meta, divisions)
+    return df
 
 
 def sorted_division_locations(seq, npartitions=None, chunksize=None):

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -486,7 +486,7 @@ def test_read_csv_raises_on_no_files():
     try:
         dd.read_csv(fn)
         assert False
-    except IOError as e:
+    except (OSError, IOError) as e:
         assert fn in str(e)
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,5 +1,6 @@
-import sys
+from copy import copy
 from operator import getitem
+import sys
 
 import pandas as pd
 import pandas.util.testing as tm
@@ -2321,7 +2322,10 @@ def test_compute_divisions():
     a = dd.from_pandas(df, 2, sort=False)
     assert not a.known_divisions
 
-    b = compute_divisions(a)
+    divisions = compute_divisions(a)
+    b = copy(a)
+    b.divisions = divisions
+
     assert_eq(a, b)
     assert b.known_divisions
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -626,7 +626,7 @@ def test_groupby_normalize_index():
 
 
 @pytest.mark.parametrize('spec', [
-    {'b': {'c': 'mean'}, 'c': {'a': 'max', 'a': 'min'}},
+    {'b': {'c': 'mean'}, 'c': {'a': 'max', 'b': 'min'}},
     {'b': 'mean', 'c': ['min', 'max']},
     {'b': np.sum, 'c': ['min', np.max, np.std, np.var]},
     ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var'],
@@ -735,7 +735,7 @@ def test_aggregate__dask():
     })
 
     specs = [
-        {'b': {'c': 'mean'}, 'c': {'a': 'max', 'a': 'min'}},
+        {'b': {'c': 'mean'}, 'c': {'a': 'max', 'b': 'min'}},
         {'b': 'mean', 'c': ['min', 'max']},
         ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var'],
         'sum', 'mean', 'min', 'max', 'count', 'std', 'var',

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -20,12 +20,14 @@ else:
 def _reduce_method_descriptor(m):
     return getattr, (m.__objclass__, m.__name__)
 
+
 # type(set.union) is used as a proxy to <class 'method_descriptor'>
 copyreg.pickle(type(set.union), _reduce_method_descriptor)
 
 
 def _dumps(x):
     return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
+
 
 _loads = pickle.loads
 

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -544,6 +544,7 @@ def merge_sync(dsk1, dsk2):
         new_dsk[new_key] = task
     return new_dsk, sd
 
+
 # store the name iterator in the function
 merge_sync.names = ('merge_%d' % i for i in count(1))
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -18,6 +18,7 @@ def import_or_none(path):
         return pytest.importorskip(path)
     return None
 
+
 tz = pytest.importorskip('toolz')
 da = import_or_none('dask.array')
 db = import_or_none('dask.bag')

--- a/dask/tests/test_rewrite.py
+++ b/dask/tests/test_rewrite.py
@@ -57,6 +57,7 @@ def repl_list(sd):
     else:
         return (list, x)
 
+
 rule6 = RewriteRule((list, 'x'), repl_list, ('x',))
 
 

--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -20,7 +20,11 @@ def _thread_get_id():
 
 
 default_pool = ThreadPool()
+
+
 default_thread = _thread_get_id()
+
+
 main_thread = current_thread()
 
 pools = defaultdict(dict)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -977,3 +977,8 @@ class SerializableLock(object):
 
     def __setstate__(self, token):
         self.__init__(token)
+
+    def __str__(self):
+        return "<%s: %s>" % (self.__class__.__name__, self.token)
+
+    __repr__ = __str__

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -651,6 +651,24 @@ def ensure_bytes(s):
     raise TypeError(msg % s)
 
 
+def ensure_unicode(s):
+    """ Turn string or bytes to bytes
+
+    >>> ensure_unicode(u'123')
+    u'123'
+    >>> ensure_unicode('123')
+    u'123'
+    >>> ensure_unicode(b'123')
+    u'123'
+    """
+    if isinstance(s, unicode):
+        return s
+    if hasattr(s, 'decode'):
+        return s.decode()
+    msg = "Object %s is neither a bytes object nor has an encode method"
+    raise TypeError(msg % s)
+
+
 def digit(n, k, base):
     """
 


### PR DESCRIPTION
Previously bytes backends (local, s3, hdfs) had to register several functions
like open_files, read_bytes, write_bytes, etc..  These generally returned
delayed values.

Now bytes backends register functions like open, mkdirs, glob that are dask
agnostic.  Dask.bytes.core uses these functions (organized into a class) to
implement all of the read_bytes, write_bytes, etc. functions.

This improves separation of concerns and allows the support of other formats,
such as Parquet.