### PR TITLE
Fix colormap lookup in diagnostics plots

### DIFF
--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -287,17 +287,26 @@ def test_saves_file():
 @pytest.mark.skipif("not bokeh")
 def test_get_colors():
     from dask.diagnostics.profile_visualize import get_colors
-    from bokeh.palettes import Blues9, Blues5, BrBG3
+    from bokeh.palettes import Blues9, Blues5, Viridis
     from itertools import cycle
     funcs = list(range(11))
     cmap = get_colors('Blues', funcs)
     lk = dict(zip(funcs, cycle(Blues9)))
     assert cmap == [lk[i] for i in funcs]
+
     funcs = list(range(5))
     cmap = get_colors('Blues', funcs)
     lk = dict(zip(funcs, Blues5))
     assert cmap == [lk[i] for i in funcs]
+
     funcs = [0, 1, 0, 1, 0, 1]
     cmap = get_colors('BrBG', funcs)
-    lk = dict(zip([0, 1], BrBG3))
-    assert cmap == [lk[i] for i in funcs]
+    assert len(set(cmap)) == 2
+
+    funcs = list(range(100))
+    cmap = get_colors('Viridis', funcs)
+    assert len(set(cmap)) == 100
+
+    funcs = list(range(300))
+    cmap = get_colors('Viridis', funcs)
+    assert len(set(cmap)) == len(set(Viridis[256]))


### PR DESCRIPTION
Some newer bokeh palettes contain non-contiguous integer variations
(e.g. Blues3, Blues4, ...). This was causing problems in our plotting
code when choosing a good colormap.

This fix changes to the following heuristic:
- If there is an integer variation that matches nfuncs, use that
- If nfuncs > the max integer variation, then cycle through
- Otherwise, find the next largest variation, shuffle that palette to
  prevent using just the low range, and then use that. The shuffle has a
  fixed seed to produce consistent plots.

Fixes #1772.