### PR TITLE
Several modifications to fix slicing bug

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -55,6 +55,24 @@ def getarray(a, b, lock=None):
     return c
 
 
+def getarray_vector(a, b, lock=None):
+    """ A simple wrapper around ``getarray``.
+
+    Used to indicate to the optimization passes that the backend supports
+    "vector" fancy indexing. "Vector" fancy indexing is like numpy.
+    """
+    return getarray(a, b, lock=lock)
+
+
+def getarray_outer(a, b, lock=None):
+    """ A simple wrapper around ``getarray``.
+
+    Used to indicate to the optimization passes that the backend supports
+    "outer" fancy indexing. "Outer" fancy indexing is like h5py, netcdf4-python.
+    """
+    return getarray(a, b, lock=lock)
+
+
 def getarray_nofancy(a, b, lock=None):
     """ A simple wrapper around ``getarray``.
 
@@ -105,7 +123,13 @@ def getem(arr, chunks, shape=None, out_name=None, fancy=True, lock=False):
 
     keys = list(product([out_name], *[range(len(bds)) for bds in chunks]))
     slices = slices_from_chunks(chunks)
-    getter = getarray if fancy else getarray_nofancy
+    getter = getarray_nofancy if (isinstance(fancy, bool) and not fancy) else getarray_vector
+    if (isinstance(fancy, str) and
+       fancy not in ['vector', 'outer']):
+        raise NotImplemented('fancy indexing ca either be a boolean or a choice in '
+                             '["outer", "vector"].')
+    if fancy == 'outer':
+        getter = getarray_outer
 
     if lock:
         values = [(getter, arr, x, lock) for x in slices]
@@ -1713,9 +1737,12 @@ def from_array(x, chunks, name=None, lock=False, fancy=True):
     lock : bool or Lock, optional
         If ``x`` doesn't support concurrent reads then provide a lock here, or
         pass in True to have dask.array create one for you.
-    fancy : bool, optional
+    fancy : bool or str, optional
         If ``x`` doesn't support fancy indexing (e.g. indexing with lists or
         arrays) then set to False. Default is True.
+        True means that ``x`` supports vector indexing, like numpy.
+        Fancy can also be set to ``outer`` if ``x`` supports outer
+        indexing, like h5py, netcdf4-python, etc.
 
     Examples
     --------

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -22,7 +22,8 @@ from dask.utils import ignoring, tmpfile, tmpdir
 from dask.utils_test import inc
 
 from dask.array import chunk
-from dask.array.core import (getem, getarray, getarray_nofancy, top, dotmany,
+from dask.array.core import (getem, getarray, getarray_vector, getarray_outer,
+                             getarray_nofancy, top, dotmany,
                              concatenate3, broadcast_dimensions, Array, stack,
                              concatenate, from_array, take, elemwise, isnull,
                              notnull, broadcast_shapes, partial_by_order,
@@ -53,7 +54,8 @@ def same_keys(a, b):
 
 
 def test_getem():
-    for fancy, getter in [(True, getarray), (False, getarray_nofancy)]:
+    for fancy, getter in [(True, getarray_vector), (False, getarray_nofancy),
+                          ('outer', getarray_outer)]:
         sol = {('X', 0, 0): (getter, 'X', (slice(0, 2), slice(0, 3))),
                ('X', 1, 0): (getter, 'X', (slice(2, 4), slice(0, 3))),
                ('X', 1, 1): (getter, 'X', (slice(2, 4), slice(3, 6))),

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -6,47 +6,47 @@ from dask.optimize import fuse
 from dask.array.optimization import (getitem, optimize, optimize_slices,
                                      fuse_slice)
 
-from dask.array.core import getarray, getarray_nofancy
+from dask.array.core import getarray_vector, getarray_outer, getarray_nofancy
 
 
 def test_fuse_getitem():
-    pairs = [((getarray, (getarray, 'x', slice(1000, 2000)), slice(15, 20)),
-              (getarray, 'x', slice(1015, 1020))),
+    pairs = [((getarray_vector, (getarray_vector, 'x', slice(1000, 2000)), slice(15, 20)),
+              (getarray_vector, 'x', slice(1015, 1020))),
 
-             ((getitem, (getarray, 'x', (slice(1000, 2000), slice(100, 200))),
+             ((getitem, (getarray_vector, 'x', (slice(1000, 2000), slice(100, 200))),
                         (slice(15, 20), slice(50, 60))),
-              (getarray, 'x', (slice(1015, 1020), slice(150, 160)))),
+              (getarray_vector, 'x', (slice(1015, 1020), slice(150, 160)))),
 
              ((getitem, (getarray_nofancy, 'x', (slice(1000, 2000), slice(100, 200))),
                         (slice(15, 20), slice(50, 60))),
               (getarray_nofancy, 'x', (slice(1015, 1020), slice(150, 160)))),
 
-             ((getarray, (getarray, 'x', slice(1000, 2000)), 10),
-              (getarray, 'x', 1010)),
+             ((getarray_vector, (getarray_vector, 'x', slice(1000, 2000)), 10),
+              (getarray_vector, 'x', 1010)),
 
-             ((getitem, (getarray, 'x', (slice(1000, 2000), 10)),
+             ((getitem, (getarray_vector, 'x', (slice(1000, 2000), 10)),
                         (slice(15, 20),)),
-              (getarray, 'x', (slice(1015, 1020), 10))),
+              (getarray_vector, 'x', (slice(1015, 1020), 10))),
 
              ((getitem, (getarray_nofancy, 'x', (slice(1000, 2000), 10)),
                         (slice(15, 20),)),
               (getarray_nofancy, 'x', (slice(1015, 1020), 10))),
 
-             ((getarray, (getarray, 'x', (10, slice(1000, 2000))),
+             ((getarray_vector, (getarray_vector, 'x', (10, slice(1000, 2000))),
                (slice(15, 20), )),
-              (getarray, 'x', (10, slice(1015, 1020)))),
+              (getarray_vector, 'x', (10, slice(1015, 1020)))),
 
-             ((getarray, (getarray, 'x', (slice(1000, 2000), slice(100, 200))),
+             ((getarray_vector, (getarray_vector, 'x', (slice(1000, 2000), slice(100, 200))),
                (slice(None, None), slice(50, 60))),
-              (getarray, 'x', (slice(1000, 2000), slice(150, 160)))),
+              (getarray_vector, 'x', (slice(1000, 2000), slice(150, 160)))),
 
-             ((getarray, (getarray, 'x', (None, slice(None, None))),
+             ((getarray_vector, (getarray_vector, 'x', (None, slice(None, None))),
                (slice(None, None), 5)),
-              (getarray, 'x', (None, 5))),
+              (getarray_vector, 'x', (None, 5))),
 
-             ((getarray, (getarray, 'x', (slice(1000, 2000), slice(10, 20))),
+             ((getarray_vector, (getarray_vector, 'x', (slice(1000, 2000), slice(10, 20))),
                (slice(5, 10),)),
-              (getarray, 'x', (slice(1005, 1010), slice(10, 20)))),
+              (getarray_vector, 'x', (slice(1005, 1010), slice(10, 20)))),
 
              ((getitem, (getitem, 'x', (slice(1000, 2000),)),
                (slice(5, 10), slice(10, 20))),
@@ -59,29 +59,29 @@ def test_fuse_getitem():
 
 def test_optimize_with_getitem_fusion():
     dsk = {'a': 'some-array',
-           'b': (getarray, 'a', (slice(10, 20), slice(100, 200))),
-           'c': (getarray, 'b', (5, slice(50, 60)))}
+           'b': (getarray_vector, 'a', (slice(10, 20), slice(100, 200))),
+           'c': (getarray_vector, 'b', (5, slice(50, 60)))}
 
     result = optimize(dsk, ['c'])
-    expected = {'c': (getarray, 'some-array', (15, slice(150, 160)))}
+    expected = {'c': (getarray_vector, 'some-array', (15, slice(150, 160)))}
     assert result == expected
 
 
 def test_optimize_slicing():
     dsk = {'a': (range, 10),
-           'b': (getarray, 'a', (slice(None, None, None),)),
-           'c': (getarray, 'b', (slice(None, None, None),)),
-           'd': (getarray, 'c', (slice(0, 5, None),)),
-           'e': (getarray, 'd', (slice(None, None, None),))}
+           'b': (getarray_vector, 'a', (slice(None, None, None),)),
+           'c': (getarray_vector, 'b', (slice(None, None, None),)),
+           'd': (getarray_vector, 'c', (slice(0, 5, None),)),
+           'e': (getarray_vector, 'd', (slice(None, None, None),))}
 
-    expected = {'e': (getarray, (range, 10), (slice(0, 5, None),))}
+    expected = {'e': (getarray_vector, (range, 10), (slice(0, 5, None),))}
     result = optimize_slices(fuse(dsk, [])[0])
     assert result == expected
 
     # protect output keys
-    expected = {'c': (getarray, (range, 10), (slice(0, None, None),)),
-                'd': (getarray, 'c', (slice(0, 5, None),)),
-                'e': (getarray, 'd', (slice(None, None, None),))}
+    expected = {'c': (getarray_vector, (range, 10), (slice(0, None, None),)),
+                'd': (getarray_vector, 'c', (slice(0, 5, None),)),
+                'e': (getarray_vector, 'd', (slice(None, None, None),))}
     result = optimize_slices(fuse(dsk, ['c', 'd', 'e'])[0])
 
     assert result == expected
@@ -112,9 +112,9 @@ def test_fuse_slice_with_lists():
 
 
 def test_hard_fuse_slice_cases():
-    dsk = {'x': (getarray, (getarray, 'x', (None, slice(None, None))),
+    dsk = {'x': (getarray_vector, (getarray_vector, 'x', (None, slice(None, None))),
                  (slice(None, None), 5))}
-    assert optimize_slices(dsk) == {'x': (getarray, 'x', (None, 5))}
+    assert optimize_slices(dsk) == {'x': (getarray_vector, 'x', (None, 5))}
 
 
 def test_dont_fuse_different_slices():
@@ -122,6 +122,22 @@ def test_dont_fuse_different_slices():
     y = x.rechunk((1, 10))
     dsk = optimize(y.dask, y._keys())
     assert len(dsk) > 100
+
+
+def test_dont_fuse_fancy_indexing_in_some_getarray_vector():
+    dsk = {'a': (getitem, (getarray_vector, 'x', (1, slice(100, 200, None),
+                                                  slice(None, None, None))),
+                 (slice(50, 60, None), [1, 3]))}
+    assert optimize_slices(dsk) == dsk
+
+
+def test_fuse_fancy_indexing_in_some_getarray_outer():
+    dsk = {'a': (getitem, (getarray_outer, 'x', (slice(10, 20, None),
+                                                 slice(100, 200, None),
+                                                 slice(None))),
+                 (1, slice(50, 60, None), [1, 3]))}
+    expected = {'a': (getarray_outer, 'x', (11, slice(150, 160, None), [1, 3]))}
+    assert optimize_slices(dsk) == expected
 
 
 def test_dont_fuse_fancy_indexing_in_getarray_nofancy():

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -414,6 +414,13 @@ def test_empty_slice():
     assert_eq(y, np.ones((5, 5), dtype='i4')[:0])
 
 
+def test_singleton_slicing():
+    a = np.arange(15).reshape((1, 5, 3))
+    d1 = da.from_array(a, chunks=(1, 3, 3))
+    d2 = d1[0, :, [0, 2]]
+    assert_eq(d2, a[0,...][:, [0, 2]])
+
+
 def test_multiple_list_slicing():
     x = np.random.rand(6, 7, 8)
     a = da.from_array(x, chunks=(3, 3, 3))


### PR DESCRIPTION
This commit fixes issue #1770.

As mentioned in my comment on that issue, the solution is to prevent fusing slices in specific cases in order to prevent unintended numpy-style slicing.

However, this might not always be desirable, especially when the underlying array support "outer" slicing like in h5py and netcdf4-python. This was discussed in #433 in the context of slicing dask arrays. The problem of slicing optimizations on the underlying array was discussed in #1529. In that discussion, the addition of a ``fancy`` keyword was introduced to allow finer-grained optimizations. In the current PR, I propose to extend this concept by allowing a user to specify that the underlying array support ``outer`` indexing. By default, ``fancy=True`` would mean that the underlying array supports numpy-style vector indexing.

By adding this disctinction, it now possible to avoid issue #1770 by preventing the offending optimization only for vector indexing. By providing ``fancy='outer'`` a user could then allow this optimization when it is safe to use on the underlying array.

Comments?