### PR TITLE
Parquet update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - if [[ $PYTHON != '3.3' ]]; then pip install git+https://github.com/dask/distributed --upgrade --no-deps; fi
   - if [[ $PYTHON == '3.3' ]]; then pip install cloudpickle pandas==$PANDAS; fi
   - if [[ $PYTHON == '2.7' ]]; then pip install backports.lzma mock; fi
-  - if [[ $PYTHON != '2.7' ]]; then pip install git+https://github.com/dask/fastparquet; fi
+  - if [[ $PYTHON == '3.5' ]]; then pip install git+https://github.com/dask/fastparquet; fi
   - pip install git+https://github.com/mrocklin/partd --upgrade
   - pip install git+https://github.com/mrocklin/cachey --upgrade
   - pip install blosc --upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
   - if [[ $PYTHON != '3.3' ]]; then pip install git+https://github.com/dask/distributed --upgrade --no-deps; fi
   - if [[ $PYTHON == '3.3' ]]; then pip install cloudpickle pandas==$PANDAS; fi
   - if [[ $PYTHON == '2.7' ]]; then pip install backports.lzma mock; fi
+  - if [[ $PYTHON != '2.7' ]]; then pip install git+https://github.com/dask/fastparquet --upgrade; fi
   - pip install git+https://github.com/mrocklin/partd --upgrade
   - pip install git+https://github.com/mrocklin/cachey --upgrade
   - pip install blosc --upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$PYTHON
   - source activate test-environment
-  - conda install -c conda-forge numpy=$NUMPY scipy pytables h5py bcolz pytest coverage toolz scikit-learn cytoolz chest blosc cython psutil ipython
+  - conda install -c conda-forge numpy=$NUMPY scipy pytables h5py bcolz pytest coverage toolz scikit-learn cytoolz chest blosc cython psutil ipython numba
   - if [[ $PYTHON != '3.3' ]]; then conda install -c conda-forge pandas=$PANDAS distributed cloudpickle bokeh python-lmdb; fi
   - if [[ $PYTHON != '3.3' ]]; then pip install git+https://github.com/dask/zict --upgrade --no-deps; fi
   - if [[ $PYTHON != '3.3' ]]; then pip install git+https://github.com/dask/distributed --upgrade --no-deps; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - if [[ $PYTHON != '3.3' ]]; then pip install git+https://github.com/dask/distributed --upgrade --no-deps; fi
   - if [[ $PYTHON == '3.3' ]]; then pip install cloudpickle pandas==$PANDAS; fi
   - if [[ $PYTHON == '2.7' ]]; then pip install backports.lzma mock; fi
-  - if [[ $PYTHON != '2.7' ]]; then pip install git+https://github.com/dask/fastparquet --upgrade; fi
+  - if [[ $PYTHON != '2.7' ]]; then pip install git+https://github.com/dask/fastparquet; fi
   - pip install git+https://github.com/mrocklin/partd --upgrade
   - pip install git+https://github.com/mrocklin/cachey --upgrade
   - pip install blosc --upgrade

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -123,6 +123,11 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None):
 
 
 def read_parquet_row_group(open, fn, index, columns, rg, series, *args):
+    if not isinstance(columns, (tuple, list)):
+        columns = (columns,)
+        series = True
+    if index not in columns:
+        columns = columns + type(columns)([index])
     df = read_row_group_file(fn, rg, columns, *args, open=open)
     if index:
         df = df.set_index(index)

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -213,6 +213,7 @@ def to_parquet(path, df, encoding=default_encoding, compression=None,
         fastparquet.writer.write_common_metadata(f, fmd)
 
 
-@partial(normalize_token.register, fastparquet.ParquetFile)
-def normalize_ParquetFile(pf):
-    return (type(pf), pf.fn, pf.sep) + normalize_token(pf.open)
+if fastparquet:
+    @partial(normalize_token.register, fastparquet.ParquetFile)
+    def normalize_ParquetFile(pf):
+        return (type(pf), pf.fn, pf.sep) + normalize_token(pf.open)

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -129,7 +129,7 @@ def read_parquet_row_group(open, fn, index, columns, rg, series, *args):
     if not isinstance(columns, (tuple, list)):
         columns = (columns,)
         series = True
-    if index not in columns:
+    if index and index not in columns:
         columns = columns + type(columns)([index])
     df = read_row_group_file(fn, rg, columns, *args, open=open)
     if index:

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -88,7 +88,10 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None):
     else:
         index_col = None
 
-    all_columns = columns or tuple(pf.columns + list(pf.cats))
+    if columns is None:
+        all_columns = tuple(pf.columns + list(pf.cats))
+    else:
+        all_columns = columns
     if not isinstance(all_columns, tuple):
         out_type = Series
         all_columns = (all_columns,)

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -112,7 +112,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None):
         assert len(meta.columns) == 1
         meta = meta[meta.columns[0]]
 
-    dsk = {(name, i): (read_parquet_row_group, open, pf.row_group_filename(rg),
+    dsk = {(name, i): (read_parquet_row_group, myopen, pf.row_group_filename(rg),
                        index_col, all_columns, rg, out_type == Series,
                        categories, pf.helper, pf.cats)
            for i, rg in enumerate(rgs)}

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -110,9 +110,9 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None):
         meta = meta[meta.columns[0]]
 
     dsk = {(name, i): (read_parquet_row_group, open, pf.row_group_filename(rg),
-                        index_col, all_columns, rg, out_type == Series,
-                        categories, pf.helper, pf.cats)
-             for i, rg in enumerate(rgs)}
+                       index_col, all_columns, rg, out_type == Series,
+                       categories, pf.helper, pf.cats)
+           for i, rg in enumerate(rgs)}
 
     if index_col:
         divisions = list(minmax[index_col]['min']) + [minmax[index_col]['max'][-1]]

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -9,6 +9,7 @@ import dask.dataframe as dd
 try:
     import fastparquet
     from fastparquet import parquet_thrift
+    from fastparquet.core import read_row_group_file
     default_encoding = parquet_thrift.Encoding.PLAIN
 except:
     fastparquet = False
@@ -65,7 +66,9 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
            not(fastparquet.api.filter_out_stats(rg, filters, pf.helper)) and
            not(fastparquet.api.filter_out_cats(rg, filters))]
 
-    parts = [delayed(pf.read_row_group_file)(rg, columns, categories, **kwargs)
+    parts = [delayed(read_row_group_file)(pf.row_group_filename(rg),
+                                          rg, columns, categories, pf.helper,
+                                          pf.cats, open=pf.open, **kwargs)
              for rg in rgs]
 
     # TODO: if categories vary from one rg to next, need to cope

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -49,3 +49,20 @@ def test_index():
 
         ddf2 = read_parquet(tmp)
         assert_eq(ddf, ddf2)
+
+
+def test_series():
+    with tmpdir() as tmp:
+        tmp = str(tmp)
+        df = pd.DataFrame({'x': [6, 2, 3, 4, 5],
+                           'y': [1.0, 2.0, 1.0, 2.0, 1.0]},
+                          index=pd.Index([10, 20, 30, 40, 50], name='myindex'))
+
+        ddf = dd.from_pandas(df, npartitions=3)
+        to_parquet(tmp, ddf)
+
+        ddf2 = read_parquet(tmp, columns=['x'])
+        assert_eq(df[['x']], ddf2)
+
+        ddf2 = read_parquet(tmp, columns='x', index='myindex')
+        assert_eq(df.x, ddf2)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -64,6 +64,16 @@ def test_index_column(fn):
     assert_eq(df[[]], ddf)
 
 
+def test_index_column_no_index(fn):
+    ddf = read_parquet(fn, columns=['myindex'])
+    assert_eq(df[[]], ddf)
+
+
+def test_index_column_no_index(fn):
+    ddf = read_parquet(fn, columns=['myindex'], index=False)
+    assert_eq(pd.DataFrame(df.index), ddf, check_index=False)
+
+
 def test_no_columns_yes_index(fn):
     ddf = read_parquet(fn, columns=[], index='myindex')
     assert_eq(df[[]], ddf)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -77,7 +77,6 @@ def test_names(fn):
             set(read_parquet(fn, columns=['x']).dask))
 
 
-
 @pytest.mark.parametrize('c', [['x'], 'x', ['x', 'y'], []])
 def test_optimize(fn, c):
     ddf = read_parquet(fn)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -54,6 +54,11 @@ def test_index(fn):
     assert_eq(df, ddf)
 
 
+def test_auto_add_index(fn):
+    ddf = read_parquet(fn, columns=['x'], index='myindex')
+    assert_eq(df[['x']], ddf)
+
+
 def test_series(fn):
     ddf = read_parquet(fn, columns=['x'])
     assert_eq(df[['x']], ddf)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import dask
 from dask.utils import tmpdir
 import dask.dataframe as dd
 from dask.dataframe.io.parquet import read_parquet, to_parquet
@@ -29,10 +30,10 @@ def test_local():
 
         assert len(df2.divisions) > 1
 
-        out, out2 = df.compute(), df2.compute().reset_index()
+        out = df2.compute(get=dask.get).reset_index()
 
         for column in df.columns:
-            assert (out[column] == out2[column]).all()
+            assert (data[column] == out[column]).all()
 
 
 def test_index():

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -73,3 +73,12 @@ def test_names(fn):
 
 
 
+@pytest.mark.parametrize('c', [['x'], 'x', ['x', 'y'], []])
+def test_optimize(fn, c):
+    ddf = read_parquet(fn)
+    assert_eq(df[c], ddf[c])
+    x = ddf[c]
+
+    dsk = x._optimize(x.dask, x._keys())
+    assert len(dsk) == x.npartitions
+    assert all(v[4] == c for v in dsk.values())

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -59,6 +59,21 @@ def test_auto_add_index(fn):
     assert_eq(df[['x']], ddf)
 
 
+def test_index_column(fn):
+    ddf = read_parquet(fn, columns=['myindex'], index='myindex')
+    assert_eq(df[[]], ddf)
+
+
+def test_no_columns_yes_index(fn):
+    ddf = read_parquet(fn, columns=[], index='myindex')
+    assert_eq(df[[]], ddf)
+
+
+def test_no_columns_no_index(fn):
+    ddf = read_parquet(fn, columns=[])
+    assert_eq(df[[]], ddf)
+
+
 def test_series(fn):
     ddf = read_parquet(fn, columns=['x'])
     assert_eq(df[['x']], ddf)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -69,7 +69,7 @@ def test_index_column_no_index(fn):
     assert_eq(df[[]], ddf)
 
 
-def test_index_column_no_index(fn):
+def test_index_column_false_index(fn):
     ddf = read_parquet(fn, columns=['myindex'], index=False)
     assert_eq(pd.DataFrame(df.index), ddf, check_index=False)
 

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -11,7 +11,6 @@ except ImportError:
     read_parquet_row_group = False
 
 
-
 def fuse_castra_index(dsk):
     from castra import Castra
 

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -5,6 +5,12 @@ from .io import dataframe_from_ctable
 from ..optimize import cull, fuse_getitem, fuse_selections
 from .. import core
 
+try:
+    from .io.parquet import read_parquet_row_group
+except ImportError:
+    read_parquet_row_group = False
+
+
 
 def fuse_castra_index(dsk):
     from castra import Castra
@@ -26,5 +32,9 @@ def optimize(dsk, keys, **kwargs):
     except ImportError:
         dsk4 = dsk2
     dsk5 = fuse_getitem(dsk4, dataframe_from_ctable, 3)
-    dsk6, _ = cull(dsk5, keys)
-    return dsk6
+    if read_parquet_row_group:
+        dsk6 = fuse_getitem(dsk5, read_parquet_row_group, 4)
+    else:
+        dsk6 = dsk5
+    dsk7, _ = cull(dsk6, keys)
+    return dsk7

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -567,6 +567,8 @@ def fuse_selections(dsk, head1, head2, merge):
         Takes ``task1`` and ``task2`` and returns a merged task to
         replace ``task1``.
 
+    Examples
+    --------
     >>> def load(store, partition, columns):
     ...     pass
     >>> dsk = {'x': (load, 'store', 'part', ['a', 'b']),
@@ -601,6 +603,8 @@ def fuse_getitem(dsk, func, place):
     place: int
         Location in task to insert the getitem key
 
+    Examples
+    --------
     >>> def load(store, partition, columns):
     ...     pass
     >>> dsk = {'x': (load, 'store', 'part', ['a', 'b']),


### PR DESCRIPTION
Two changes to Parquet 

1.  read_parquet no longer sends around the entire parquet file to every task, reducing communication and serialization costs.  Fixes https://github.com/dask/fastparquet/issues/26
2.  We fuse getitem calls into read_parquet calls to reduce loading data just before we forget it.  Fixes https://github.com/dask/dask/issues/1785

Depends on https://github.com/dask/fastparquet/pull/29