### PR TITLE
Support delayed values in array top

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2507,3 +2507,17 @@ def test_concatenate_stack_dont_warn():
     with warnings.catch_warnings(record=True) as record:
         da.stack([da.ones(2, chunks=1)] * 62)
     assert not record
+
+
+def test_map_blocks_delayed():
+    x = da.ones((10, 10), chunks=(5, 5))
+    y = np.ones((5, 5))
+
+    z = x.map_blocks(add, y, dtype=x.dtype)
+
+    yy = delayed(y)
+    zz = x.map_blocks(add, yy, dtype=x.dtype)
+
+    assert_eq(z, zz)
+
+    assert yy.key in zz.dask


### PR DESCRIPTION
This allows using dask.delayed values in dask.array top operations.  In particular this helps to deduplicate literal numpy arrays in task graphs.

```python
x = da.ones((10, 10), chunks=(5, 5))
y = np.ones((5, 5))

yy = delayed(y)
zz = x.map_blocks(add, yy, dtype=x.dtype)
```

cc @jcrist 

