### PR TITLE
Optimise read_hdf

### DIFF
--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -14,7 +14,7 @@ import dask
 from toolz import merge
 
 from ...async import get_sync
-from ...base import tokenize
+from ...base import compute, tokenize
 from ...context import _globals
 from ...delayed import Delayed, delayed
 import dask.multiprocessing
@@ -315,8 +315,9 @@ def read_hdf(pattern, key, start=0, stop=None, columns=None,
         raise ValueError("When assuming pre-partitioned data, data must be "
                          "read in its entirety using the same chunksizes")
     from ..multi import concat
-    return concat([_read_single_hdf(path, key, start=start, stop=stop,
-                                    columns=columns, chunksize=chunksize,
-                                    sorted_index=sorted_index,
-                                    lock=lock, mode=mode)
-                   for path in paths])
+    return concat(list(compute(*[
+        delayed(_read_single_hdf)(path, key, start=start, stop=stop,
+                                  columns=columns, chunksize=chunksize,
+                                  sorted_index=sorted_index,
+                                  lock=lock, mode=mode)
+        for path in paths])))

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -175,7 +175,13 @@ def _read_single_hdf(path, key, start=0, stop=None, columns=None,
         key.
         """
         with pd.HDFStore(path, mode=mode) as hdf:
-            keys = [k for k in hdf.keys() if fnmatch(k, key)]
+            # If the key doesn't use any special characters, we can avoid
+            # listing the entire HDF file
+            if any(c in key for c in ['*', '?', '[']):
+                keys = [k for k in hdf.keys() if fnmatch(k, key)]
+            else:
+                keys = [key]
+
             stops = []
             divisions = []
             for k in keys:


### PR DESCRIPTION
This PR helps mitigate the problem described in #1353 where `read_hdf` is very slow when reading from many files/files with many tables. The solution proposed here is comprised of two (and a half) parts:

1. Only load the keys from the hdf file if the key contains one of the special characters (as defined in [fnmatch](https://docs.python.org/3.5/library/fnmatch.html)).
2. Use `delayed`/`compute` to allow multiple files to be read simultaneously before concatenating.
3. @mrocklin suggested using `h5py` to access the keys within each file, the snippet below results in a 6x speed improvement over just using `HDFStore.keys` on file with ~30 tables. Though, I haven't included this as as it appears to result in a deadlock when used with the threaded scheduler. I also don't know if this is sufficiently general for all use cases.

```python
# Replace "keys = [k for k in hdf.keys() if fnmatch(k, key)]" with
def get_keys(key, obj):
    # If the object corresponding to this key is a `Dataset` and the key ends in
    # table then the pytables key is contained within `key` as follows:
    # key = "/{pytables_key}/table"
    if isinstance(obj, h5py._hl.dataset.Dataset) and key.split('/')[-1] == 'table':
        get_keys.result.append('/' + key[:-len('/table')])

get_keys.result = []
with h5py.File(path, mode='r') as h5py_f:
    h5py_f.visititems(get_keys)

keys = [k for k in get_keys.result if fnmatch(k, key)]
```