### PR TITLE
Update install.rst to contain the extras in quotes

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -20,11 +20,11 @@ Pip
 To install Dask with ``pip`` there are a few options, depending on which
 dependencies you would like to keep up to date:
 
-*   ``pip install dask[complete]``: Install everything
-*   ``pip install dask[array]``: Install dask and numpy
-*   ``pip install dask[bag]``: Install dask and cloudpickle
-*   ``pip install dask[dataframe]``: Install dask, numpy, and pandas
-*   ``pip install dask``: Install only dask, which depends only on the standard
+*   ``pip install "dask[complete]"``: Install everything
+*   ``pip install "dask[array]"``: Install dask and numpy
+*   ``pip install "dask[bag]"``: Install dask and cloudpickle
+*   ``pip install "dask[dataframe]"``: Install dask, numpy, and pandas
+*   ``pip install "dask"``: Install only dask, which depends only on the standard
     library.  This is appropriate if you only want the task schedulers.
 
 We do this so that users of the lightweight core dask scheduler aren't required


### PR DESCRIPTION
On my system (`pip 9.0.1` and macOS El Capitan) the neat `pip` syntax using square brackets is working only if I surround the last argument in quotes. It took me 10 minutes to get it working, so maybe it helps other people.