### PR TITLE
Test simple parquet scheme

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -117,6 +117,5 @@ def test_roundtrip_from_pandas():
     with tmpfile() as fn:
         df = pd.DataFrame({'x': [1, 2, 3]})
         fastparquet.write(fn, df)
-        ddf = dd.io.parquet.read_parquet(fn)
-        import pdb; pdb.set_trace()
+        ddf = dd.io.parquet.read_parquet(fn, index=False)
         assert_eq(df, ddf)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 import dask
-from dask.utils import tmpdir
+from dask.utils import tmpdir, tmpfile
 import dask.dataframe as dd
 from dask.dataframe.io.parquet import read_parquet, to_parquet
 from dask.dataframe.utils import assert_eq
@@ -111,3 +111,12 @@ def test_optimize(fn, c):
     dsk = x._optimize(x.dask, x._keys())
     assert len(dsk) == x.npartitions
     assert all(v[4] == c for v in dsk.values())
+
+
+def test_roundtrip_from_pandas():
+    with tmpfile() as fn:
+        df = pd.DataFrame({'x': [1, 2, 3]})
+        fastparquet.write(fn, df)
+        ddf = dd.io.parquet.read_parquet(fn)
+        import pdb; pdb.set_trace()
+        assert_eq(df, ddf)


### PR DESCRIPTION
Took a quick stab at supporting single-file parquet datasets from dask.dataframe.  Added a test here.  Also tried making the following changes to fastparquet

```diff
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -45,14 +45,16 @@ class ParquetFile(object):
         try:
             fn2 = sep.join([fn, '_metadata'])
             f = open_with(fn2, 'rb')
+            with f as f:
+                self._parse_header(f, verify)
             fn = fn2
         except (IOError, OSError):
             f = open_with(fn, 'rb')
+            with f as f:
+                self._parse_header(f, verify)
         self.open = open_with
         self.fn = fn
         self.sep = sep
-        with f as f:
-            self._parse_header(f, verify)
         self._read_partitions()
 
     def _parse_header(self, f, verify=True):
@@ -106,8 +108,11 @@ class ParquetFile(object):
         self.cats = {key: list(v) for key, v in cats.items()}
 
     def row_group_filename(self, rg):
-        return self.sep.join([os.path.dirname(self.fn),
-                              rg.columns[0].file_path])
+        if rg.columns[0].file_path:
+            return self.sep.join([os.path.dirname(self.fn),
+                                  rg.columns[0].file_path])
+        else:
+            return self.fn
```

Though now I have to step out for the day.  cc @martindurant 