### PR TITLE
Add optimization to deduplicate constants

### DIFF
--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -673,6 +673,8 @@ def dedupe_constants(dsk, predicate):
             constants[const_id] = const
             key_lk[const_id].add(k)
     key_lk = {c_id: k for c_id, k in key_lk.items() if len(k) > 1}
+    if not key_lk:
+        return dsk
     keys = set()
     keys.update(*key_lk.values())
     dsk2 = {}


### PR DESCRIPTION
Adds a function ``dedupe_constants`` to remove duplicate constants in
dask graphs. The function takes a dask graph and a predicate function
indicating whether a constant may be extracted. Any duplicate
extractable constants are pulled out into their own key, with the key
name determined by ``tokenize``.

Example:

```python
>>> big_str = 'abcde' * 1000
>>> d = {'a': (len, big_str), 'b': (len, big_str), 'c': (add, 'a', 'b')}
>>> def is_big_str(x):
...     return isinstance(x, str) and len(x) > 1000
>>> dsk = dedupe_constants(d, is_big_str)
>>> dsk
{'a': (len, 'const-ee82b7de828a74a003c1228ff7e186cf'),
 'b': (len, 'const-ee82b7de828a74a003c1228ff7e186cf'),
 'c': (add, 'a', 'b'),
 'const-ee82b7de828a74a003c1228ff7e186cf': 'abcdeabcdeab...'}
```

Fixes #1795.