### PR TITLE
 Expand options for fillna.

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -841,6 +841,14 @@ class _Frame(Base):
         return parts.map_overlap(M.fillna, before, after, method=method,
                                  limit=limit, meta=meta)
 
+    @derived_from(pd.DataFrame)
+    def ffill(self, axis=None, limit=None):
+        return self.fillna(method='ffill', limit=limit, axis=axis)
+
+    @derived_from(pd.DataFrame)
+    def bfill(self, axis=None, limit=None):
+        return self.fillna(method='bfill', limit=limit, axis=axis)
+
     def sample(self, frac, replace=False, random_state=None):
         """ Random sample of items
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -149,6 +149,15 @@ def drop_columns(df, columns, dtype):
     return df
 
 
+def fillna_check(df, method, check=True):
+    out = df.fillna(method=method)
+    if check and out.isnull().values.all(axis=0).any():
+        raise ValueError("All NaN partition encountered in `fillna`. Try "
+                         "using ``df.repartition`` to increase the partition "
+                         "size, or specify `limit` in `fillna`.")
+    return out
+
+
 # ---------------------------------
 # reshape
 # ---------------------------------

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1599,6 +1599,16 @@ def test_fillna():
               ddf.fillna(method='pad', limit=3))
 
 
+def test_ffill_bfill():
+    df = tm.makeMissingDataframe(0.8, 42)
+    ddf = dd.from_pandas(df, npartitions=5, sort=False)
+
+    assert_eq(ddf.ffill(), df.ffill())
+    assert_eq(ddf.bfill(), df.bfill())
+    assert_eq(ddf.ffill(axis=1), df.ffill(axis=1))
+    assert_eq(ddf.bfill(axis=1), df.bfill(axis=1))
+
+
 def test_sample():
     df = pd.DataFrame({'x': [1, 2, 3, 4, None, 6], 'y': list('abdabd')},
                       index=[10, 20, 30, 40, 50, 60])


### PR DESCRIPTION
`df.fillna` now supports the following options:

- `method`
- `limit`
- `axis`

Fixes #1812.

Also add `bfill` and `ffill`.