### PR TITLE
Two fixes for split_out

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2832,10 +2832,14 @@ def _maybe_from_pandas(dfs):
 def hash_shard(df, nparts, index):
     if index:
         h = df.index
+        if isinstance(h, pd.MultiIndex):
+            h = pd.DataFrame([], index=h).reset_index()
     else:
         h = df
-    h = hash_pandas_object(h) % nparts
-
+    h = hash_pandas_object(h, index=False)
+    if isinstance(h, pd.Series):
+        h = h._values
+    h %= nparts
     return {i: df.iloc[h == i] for i in range(nparts)}
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2740,7 +2740,7 @@ def test_hash_split_unique(npartitions, split_every, split_out):
 
     assert len([k for k, v in dependencies.items() if not v]) == npartitions
     assert dropped.npartitions == (split_out or 1)
-    assert sorted(dropped.compute()) == sorted(s.unique())
+    assert sorted(dropped.compute(get=dask.get)) == sorted(s.unique())
 
 
 @pytest.mark.parametrize('split_every', [None, 2])

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -950,3 +950,16 @@ def test_hash_groupby_aggregate(npartitions, split_every, split_out):
     assert len([k for k, v in dependencies.items() if not v]) == npartitions
 
     assert_eq(result, df.groupby('x').y.var())
+
+
+def test_split_out_multi_column_groupby():
+    df = pd.DataFrame({'x': np.arange(100) % 10,
+                       'y': np.ones(100),
+                       'z': [1, 2, 3, 4, 5] * 20})
+
+    ddf = dd.from_pandas(df, npartitions=10)
+
+    result = ddf.groupby(['x', 'y']).z.mean(split_out=4)
+    expected = df.groupby(['x', 'y']).z.mean()
+
+    assert_eq(result, expected, check_dtype=False)

--- a/dask/dataframe/tests/test_hashing.py
+++ b/dask/dataframe/tests/test_hashing.py
@@ -3,22 +3,7 @@ import pandas as pd
 
 import pytest
 
-from dask.dataframe.hashing import hash_array, hash_pandas_object
-
-df = pd.DataFrame({'i32': np.array([1, 2, 3] * 3, dtype='int32'),
-                   'f32': np.array([None, 2.5, 3.5] * 3, dtype='float32'),
-                   'cat': pd.Series(['a', 'b', 'c'] * 3).astype('category'),
-                   'obj': pd.Series(['d', 'e', 'f'] * 3),
-                   'bool': np.array([True, False, True] * 3),
-                   'dt': pd.Series(pd.date_range('20130101', periods=9)),
-                   'dt_tz': pd.Series(pd.date_range('20130101', periods=9, tz='US/Eastern')),
-                   'td': pd.Series(pd.timedelta_range('2000', periods=9))})
-
-
-def test_hash_array():
-    for name, s in df.iteritems():
-        a = s.values
-        np.testing.assert_equal(hash_array(a), hash_array(a))
+from dask.dataframe.hashing import hash_pandas_object
 
 
 @pytest.mark.parametrize('obj', [


### PR DESCRIPTION
1.  Support new hashing code in pandas 0.19.2
2.  Support MultiIndex objects