### PR TITLE
Fix `drop_duplicates` with `split_out`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -351,11 +351,22 @@ class _Frame(Base):
 
     @derived_from(pd.DataFrame)
     def drop_duplicates(self, split_every=None, split_out=1, **kwargs):
-        assert all(k in ('keep', 'subset', 'take_last') for k in kwargs)
+        # Let pandas error on bad inputs
+        self._meta_nonempty.drop_duplicates(**kwargs)
+        if 'subset' in kwargs and kwargs['subset'] is not None:
+            split_out_setup = split_out_on_cols
+            split_out_setup_kwargs = {'cols': kwargs['subset']}
+        else:
+            split_out_setup = split_out_setup_kwargs = None
+
+        if 'keep' in kwargs and kwargs['keep'] is False:
+            raise NotImplementedError("drop_duplicates with keep=False")
+
         chunk = M.drop_duplicates
         return aca(self, chunk=chunk, aggregate=chunk, meta=self._meta,
                    token='drop-duplicates', split_every=split_every,
-                   split_out=split_out, split_index=False, **kwargs)
+                   split_out=split_out, split_out_setup=split_out_setup,
+                   split_out_setup_kwargs=split_out_setup_kwargs, **kwargs)
 
     def __len__(self):
         return self.reduction(len, np.sum, token='len', meta=int,
@@ -1831,8 +1842,7 @@ class Series(_Frame):
         """
         return aca(self, chunk=methods.unique, aggregate=methods.unique,
                    meta=self._meta, token='unique', split_every=split_every,
-                   series_name=self.name, split_out=split_out,
-                   split_index=False)
+                   series_name=self.name, split_out=split_out)
 
     @derived_from(pd.Series)
     def nunique(self, split_every=None):
@@ -1845,7 +1855,7 @@ class Series(_Frame):
                    combine=methods.value_counts_combine,
                    meta=self._meta.value_counts(), token='value-counts',
                    split_every=split_every, split_out=split_out,
-                   split_index=True)
+                   split_out_setup=split_out_on_index)
 
     @derived_from(pd.Series)
     def nlargest(self, n=5, split_every=None):
@@ -2867,11 +2877,9 @@ def _maybe_from_pandas(dfs):
     return dfs
 
 
-def hash_shard(df, nparts, index):
-    if index:
-        h = df.index
-        if isinstance(h, pd.MultiIndex):
-            h = pd.DataFrame([], index=h).reset_index()
+def hash_shard(df, nparts, split_out_setup=None, split_out_setup_kwargs=None):
+    if split_out_setup:
+        h = split_out_setup(df, **(split_out_setup_kwargs or {}))
     else:
         h = df
     h = hash_pandas_object(h, index=False)
@@ -2881,11 +2889,23 @@ def hash_shard(df, nparts, index):
     return {i: df.iloc[h == i] for i in range(nparts)}
 
 
+def split_out_on_index(df):
+    h = df.index
+    if isinstance(h, pd.MultiIndex):
+        h = pd.DataFrame([], index=h).reset_index()
+    return h
+
+
+def split_out_on_cols(df, cols=None):
+    return df[cols]
+
+
 @insert_meta_param_description
 def apply_concat_apply(args, chunk=None, aggregate=None, combine=None,
-                       meta=no_default, token=None, split_every=None,
-                       chunk_kwargs=None, aggregate_kwargs=None,
-                       combine_kwargs=None, split_out=None, split_index=None, **kwargs):
+                       meta=no_default, token=None, chunk_kwargs=None,
+                       aggregate_kwargs=None, combine_kwargs=None,
+                       split_every=None, split_out=None, split_out_setup=None,
+                       split_out_setup_kwargs=None, **kwargs):
     """Apply a function to blocks, then concat, then apply again
 
     Parameters
@@ -2903,22 +2923,26 @@ def apply_concat_apply(args, chunk=None, aggregate=None, combine=None,
     $META
     token : str, optional
         The name to use for the output keys.
+    chunk_kwargs : dict, optional
+        Keywords for the chunk function only.
+    aggregate_kwargs : dict, optional
+        Keywords for the aggregate function only.
+    combine_kwargs : dict, optional
+        Keywords for the combine function only.
     split_every : int, optional
         Group partitions into groups of this size while performing a
         tree-reduction. If set to False, no tree-reduction will be used,
         and all intermediates will be concatenated and passed to ``aggregate``.
         Default is 8.
     split_out : int, optional
-        Number of output partitions.  Split occurs after first chunk reduction
-    split_index : bool
-        When hashing to produce output partitions, should we hash only the
-        output or all columns.
-    chunk_kwargs : dict, optional
-        Keywords for the chunk function only.
-    aggregate_kwargs : dict, optional
-        Keywords for the aggregate function only.
-    combine_kwargs : dict, optional
-        Keywords for the combine function only
+        Number of output partitions. Split occurs after first chunk reduction.
+    split_out_setup : callable, optional
+        If provided, this function is called on each chunk before performing
+        the hash-split. It should return a pandas object, where each row
+        (excluding the index) is hashed. If not provided, the chunk is hashed
+        as is.
+    split_out_setup_kwargs : dict, optional
+        Keywords for the `split_out_setup` function only.
     kwargs :
         All remaining keywords will be passed to ``chunk``, ``aggregate``, and
         ``combine``.
@@ -2968,7 +2992,8 @@ def apply_concat_apply(args, chunk=None, aggregate=None, combine=None,
 
     token_key = tokenize(token or (chunk, aggregate), meta, args,
                          chunk_kwargs, aggregate_kwargs, combine_kwargs,
-                         split_every, split_out, split_index)
+                         split_every, split_out, split_out_setup,
+                         split_out_setup_kwargs)
 
     # Chunk
     a = '{0}-chunk-{1}'.format(token or funcname(chunk), token_key)
@@ -2985,7 +3010,8 @@ def apply_concat_apply(args, chunk=None, aggregate=None, combine=None,
         split_prefix = 'split-%s' % token_key
         shard_prefix = 'shard-%s' % token_key
         for i in range(args[0].npartitions):
-            dsk[(split_prefix, i)] = (hash_shard, (a, 0, i, 0), split_out, split_index)
+            dsk[(split_prefix, i)] = (hash_shard, (a, 0, i, 0), split_out,
+                                      split_out_setup, split_out_setup_kwargs)
             for j in range(split_out):
                 dsk[(shard_prefix, 0, i, j)] = (getitem, (split_prefix, i), j)
         a = shard_prefix

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -359,7 +359,7 @@ class _Frame(Base):
         else:
             split_out_setup = split_out_setup_kwargs = None
 
-        if 'keep' in kwargs and kwargs['keep'] is False:
+        if kwargs.get('keep', True) is False:
             raise NotImplementedError("drop_duplicates with keep=False")
 
         chunk = M.drop_duplicates

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -8,7 +8,8 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from .core import DataFrame, Series, aca, map_partitions, no_default
+from .core import (DataFrame, Series, aca, map_partitions, no_default,
+                   split_out_on_index)
 from .methods import drop_columns
 from .shuffle import shuffle
 from .utils import make_meta, insert_meta_param_description, raise_on_meta_error
@@ -611,7 +612,7 @@ class _GroupBy(object):
                    aggregate=_groupby_aggregate,
                    meta=meta, token=token, split_every=split_every,
                    aggregate_kwargs=dict(aggfunc=aggfunc, levels=levels),
-                   split_out=split_out, split_index=True)
+                   split_out=split_out, split_out_setup=split_out_on_index)
 
     @derived_from(pd.core.groupby.GroupBy)
     def sum(self, split_every=None, split_out=1):
@@ -654,7 +655,7 @@ class _GroupBy(object):
                      aggregate_kwargs={'ddof': ddof, 'levels': levels},
                      combine_kwargs={'levels': levels},
                      split_every=split_every, split_out=split_out,
-                     split_index=True)
+                     split_out_setup=split_out_on_index)
 
         if isinstance(self.obj, Series):
             result = result[result.columns[0]]
@@ -740,7 +741,7 @@ class _GroupBy(object):
                   combine=_groupby_apply_funcs,
                   combine_kwargs=dict(funcs=aggregate_funcs, level=levels),
                   meta=meta, token='aggregate', split_every=split_every,
-                  split_out=split_out, split_index=True)
+                  split_out=split_out, split_out_setup=split_out_on_index)
 
         return map_partitions(_agg_finalize, obj, meta=meta,
                               token='aggregate-finalize', funcs=finalizers)
@@ -928,7 +929,7 @@ class SeriesGroupBy(_GroupBy):
                    aggregate_kwargs={'levels': levels, 'name': name},
                    combine_kwargs={'levels': levels},
                    split_every=split_every, split_out=split_out,
-                   split_index=True)
+                   split_out_setup=split_out_on_index)
 
     @derived_from(pd.core.groupby.SeriesGroupBy)
     def aggregate(self, arg, split_every=None, split_out=1):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -642,7 +642,8 @@ def test_drop_duplicates():
     assert_eq(res2, sol)
     assert res._name != res2._name
 
-    pytest.raises(NotImplementedError, lambda: d.drop_duplicates(keep=False))
+    with pytest.raises(NotImplementedError):
+        d.drop_duplicates(keep=False)
 
 
 def test_drop_duplicates_subset():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,6 +1,7 @@
 import sys
 from copy import copy
 from operator import getitem, add
+from itertools import product
 
 import pandas as pd
 import pandas.util.testing as tm
@@ -640,6 +641,8 @@ def test_drop_duplicates():
     assert_eq(res, sol)
     assert_eq(res2, sol)
     assert res._name != res2._name
+
+    pytest.raises(NotImplementedError, lambda: d.drop_duplicates(keep=False))
 
 
 def test_drop_duplicates_subset():
@@ -2791,12 +2794,22 @@ def test_hash_split_unique(npartitions, split_every, split_out):
 
 @pytest.mark.parametrize('split_every', [None, 2])
 def test_split_out_drop_duplicates(split_every):
-    df = pd.DataFrame({'x': [1, 2, 3] * 100})
-    ddf = dd.from_pandas(df, npartitions=5)
+    x = np.concatenate([np.arange(10)] * 100)[:, None]
+    y = x.copy()
+    z = np.concatenate([np.arange(20)] * 50)[:, None]
+    rs = np.random.RandomState(1)
+    rs.shuffle(x)
+    rs.shuffle(y)
+    rs.shuffle(z)
+    df = pd.DataFrame(np.concatenate([x, y, z], axis=1), columns=['x', 'y', 'z'])
+    ddf = dd.from_pandas(df, npartitions=20)
 
-    assert ddf.drop_duplicates(split_out=10, split_every=split_every).npartitions == 10
-    assert_eq(ddf.drop_duplicates(split_out=10, split_every=split_every),
-              df.drop_duplicates())
+    for subset, keep in product([None, ['x', 'z']], ['first', 'last']):
+        sol = df.drop_duplicates(subset=subset, keep=keep)
+        res = ddf.drop_duplicates(subset=subset, keep=keep,
+                                  split_every=split_every, split_out=10)
+        assert res.npartitions == 10
+        assert_eq(sol, res)
 
 
 @pytest.mark.parametrize('split_every', [None, 2])


### PR DESCRIPTION
The `split_out` kwarg was added to `aca` in 303d038. This allows for
outputs to be split by hashing the rows, improving efficiency for large
outputs. However, this defaulted to hashing all columns in the output
dataframe, which didn't play well with the `subset` kwarg to
`drop_duplicates`. This was resulting in not all duplicate rows being
dropped, as they'd hash to different partitions since the hashed columns
weren't being subset.

To fix this, we replace the `split_index` kwarg with `split_out_setup`,
which optionally takes a function to apply to each chunk before being
hashed. `split_out_setup_kwargs` is also available to pass keywords to
this function. `drop_duplicates` was modified to adjust for this change.