### PR TITLE
`dd.get_dummies` raises on object dtype

### DIFF
--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -50,14 +50,20 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
                               columns=columns, sparse=sparse,
                               drop_first=drop_first)
 
+    not_cat_msg = ("`get_dummies` with non-categorical dtypes is not "
+                   "supported. Please use `df.categorize()` beforehand to "
+                   "convert to categorical dtype.")
+
     if isinstance(data, Series) and not is_categorical_dtype(data):
-        raise ValueError('data must have category dtype')
+        raise NotImplementedError(not_cat_msg)
     elif isinstance(data, DataFrame):
         if columns is None:
+            if (data.dtypes == 'object').any():
+                raise NotImplementedError(not_cat_msg)
             columns = data._meta.select_dtypes(include=['category']).columns
         else:
             if not all(is_categorical_dtype(data[c]) for c in columns):
-                raise ValueError('target columns must have category dtype')
+                raise NotImplementedError(not_cat_msg)
 
     if sparse:
         raise NotImplementedError('sparse=True is not supported')

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -28,24 +28,21 @@ def test_get_dummies_object():
     df = pd.DataFrame({'a': pd.Categorical([1, 2, 3, 4, 4, 3, 2, 1]),
                        'b': list('abcdabcd'),
                        'c': pd.Categorical(list('abcdabcd'))})
-    # exclude object columns
+    ddf = dd.from_pandas(df, 2)
+
+    # Explicitly exclude object columns
     exp = pd.get_dummies(df, columns=['a', 'c'])
-
-    ddf = dd.from_pandas(df, 2)
-    res = dd.get_dummies(ddf)
+    res = dd.get_dummies(ddf, columns=['a', 'c'])
     assert_eq(res, exp)
     tm.assert_index_equal(res.columns, exp.columns)
 
-    exp = pd.get_dummies(df, columns=['a'])
+    with pytest.raises(NotImplementedError):
+        dd.get_dummies(ddf)
 
-    ddf = dd.from_pandas(df, 2)
-    res = dd.get_dummies(ddf, columns=['a'])
-    assert_eq(res, exp)
-    tm.assert_index_equal(res.columns, exp.columns)
+    with pytest.raises(NotImplementedError):
+        dd.get_dummies(ddf.b)
 
-    # cannot target object columns
-    msg = 'target columns must have category dtype'
-    with tm.assertRaisesRegexp(ValueError, msg):
+    with pytest.raises(NotImplementedError):
         dd.get_dummies(ddf, columns=['b'])
 
 
@@ -88,8 +85,7 @@ def test_get_dummies_kwargs():
 
 
 def test_get_dummies_errors():
-    msg = 'data must have category dtype'
-    with tm.assertRaisesRegexp(ValueError, msg):
+    with pytest.raises(NotImplementedError):
         # not Categorical
         s = pd.Series([1, 1, 1, 2, 2, 1, 3, 4])
         ds = dd.from_pandas(s, 2)


### PR DESCRIPTION
Previously `dd.get_dummies` would pass through object dtype unchanged,
differing from the pandas implementation. This was confusing for users.
Now we error when behavior would differ between pandas and dask.

Fixes #1809.