### PR TITLE
Allow non-informative chunk sizes in dask.array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1957,6 +1957,7 @@ def unify_chunks(*args, **kwargs):
         warnings.warn("Increasing number of chunks by factor of %d" %
                       (nparts / max_parts))
     arrays = [a.rechunk(tuple(chunkss[j] if a.shape[n] > 1 else 1
+                                 if not np.isnan(sum(chunkss[j])) else None
                               for n, j in enumerate(i)))
               for a, i in arginds]
     return chunkss, arrays
@@ -2491,7 +2492,8 @@ def is_scalar_for_elemwise(arg):
 
 
 def broadcast_shapes(*shapes):
-    """Determines output shape from broadcasting arrays.
+    """
+    Determines output shape from broadcasting arrays.
 
     Parameters
     ----------
@@ -2512,7 +2514,7 @@ def broadcast_shapes(*shapes):
     out = []
     for sizes in zip_longest(*map(reversed, shapes), fillvalue=1):
         dim = max(sizes)
-        if any(i != 1 and i != dim for i in sizes):
+        if any(i != 1 and i != dim and not np.isnan(i) for i in sizes):
             raise ValueError("operands could not be broadcast together with "
                              "shapes {0}".format(' '.join(map(str, shapes))))
         out.append(dim)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1956,8 +1956,9 @@ def unify_chunks(*args, **kwargs):
     if warn and nparts >= max_parts * 10:
         warnings.warn("Increasing number of chunks by factor of %d" %
                       (nparts / max_parts))
-    arrays = [a.rechunk(tuple(chunkss[j] if a.shape[n] > 1 else 1
-                                 if not np.isnan(sum(chunkss[j])) else None
+    arrays = [a.rechunk(tuple(chunkss[j]
+                              if a.shape[n] > 1 else 1
+                              if not np.isnan(sum(chunkss[j])) else None
                               for n, j in enumerate(i)))
               for a, i in arginds]
     return chunkss, arrays

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3749,15 +3749,3 @@ def repeat(a, repeats, axis=None):
         out.append(result)
 
     return concatenate(out, axis=axis)
-
-
-def _flatten_seq(seq):
-    stack = list(seq)
-    out = []
-    while stack:
-        item = stack.pop()
-        if isinstance(item, (tuple, list)):
-            stack.extend(item)
-        else:
-            out.append(item)
-    return out

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -254,6 +254,10 @@ def slice_slices_and_integers(out_name, in_name, blockdims, index):
     """
     shape = tuple(map(sum, blockdims))
 
+    for dim, ind in zip(shape, index):
+        if np.isnan(dim) and ind != slice(None, None, None):
+            raise ValueError("Arrays chunk sizes are unknown: %s", shape)
+
     assert all(isinstance(ind, (slice, int, long)) for ind in index)
     assert len(index) == len(blockdims)
 
@@ -639,6 +643,8 @@ def new_blockdim(dim_shape, lengths, index):
     >>> new_blockdim(100, [20, 10, 20, 10, 40], slice(90, 10, -2))
     [16, 5, 10, 5, 4]
     """
+    if index == slice(None, None, None):
+        return lengths
     if isinstance(index, list):
         return [len(index)]
     assert not isinstance(index, (int, long))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2532,6 +2532,8 @@ def test_no_chunks():
     assert_eq((x + 1).std(), (X + 1).std())
     assert_eq((x + x).std(), (X + X).std())
 
+
+def test_no_chunks_2d():
     X = np.arange(24).reshape((4, 6))
     x = da.from_array(X, chunks=(2, 2))
     x._chunks = ((np.nan, np.nan), (np.nan, np.nan, np.nan))
@@ -2540,3 +2542,13 @@ def test_no_chunks():
     assert_eq(x.T, X.T)
     assert_eq(x.sum(axis=0, keepdims=True), X.sum(axis=0, keepdims=True))
     assert_eq(x.dot(x.T + 1), X.dot(X.T + 1))
+
+
+def test_no_chunks_yes_chunks():
+    X = np.arange(24).reshape((4, 6))
+    x = da.from_array(X, chunks=(2, 2))
+    x._chunks = ((2, 2), (np.nan, np.nan, np.nan))
+
+    assert (x + 1).chunks == ((2, 2), (np.nan, np.nan, np.nan))
+    assert (x.T).chunks == ((np.nan, np.nan, np.nan), (2, 2))
+    assert (x.dot(x.T)).chunks == ((2, 2), (2, 2))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2521,3 +2521,22 @@ def test_map_blocks_delayed():
     assert_eq(z, zz)
 
     assert yy.key in zz.dask
+
+
+def test_no_chunks():
+    X = np.arange(11)
+    dsk = {('x', 0): np.arange(5), ('x', 1): np.arange(5, 11)}
+    x = Array(dsk, 'x', ((np.nan, np.nan,),), np.arange(1).dtype)
+    assert_eq(x + 1, X + 1)
+    assert_eq(x.sum(), X.sum())
+    assert_eq((x + 1).std(), (X + 1).std())
+    assert_eq((x + x).std(), (X + X).std())
+
+    X = np.arange(24).reshape((4, 6))
+    x = da.from_array(X, chunks=(2, 2))
+    x._chunks = ((np.nan, np.nan), (np.nan, np.nan, np.nan))
+
+    assert_eq(da.log(x), np.log(X))
+    assert_eq(x.T, X.T)
+    assert_eq(x.sum(axis=0, keepdims=True), X.sum(axis=0, keepdims=True))
+    assert_eq(x.dot(x.T + 1), X.dot(X.T + 1))

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -441,7 +441,6 @@ def test_no_chunks_svd():
 
         du, ds, dv = da.linalg.svd(dx)
 
-        du.visualize(filename='dask.pdf')
         assert_eq(s, ds)
         assert_eq(u.dot(np.diag(s)).dot(v),
                   du.dot(da.diag(ds)).dot(dv))

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1698,6 +1698,21 @@ class _Frame(Base):
                    aggregate=hyperloglog.estimate_count,
                    split_every=split_every, b=16, meta=float)
 
+    @property
+    def values(self):
+        from ..array.core import Array
+        name = 'values-' + tokenize(self)
+        chunks = ((np.nan,) * self.npartitions,)
+        x = self._meta.values
+        if isinstance(self, DataFrame):
+            chunks = chunks + ((x.shape[1],),)
+            suffix = (0,)
+        else:
+            suffix = ()
+        dsk = {(name, i) + suffix: (getattr, key, 'values')
+               for (i, key) in enumerate(self._keys())}
+        return Array(merge(self.dask, dsk), name, chunks, x.dtype)
+
 
 normalize_token.register((Scalar, _Frame), lambda a: a._name)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2804,6 +2804,17 @@ class DataFrame(_Frame):
         return pivot_table(self, index=index, columns=columns, values=values,
                            aggfunc=aggfunc)
 
+    def to_records(self, index=False):
+        """ Convert to a dask array with struct dtype
+
+        Examples
+        --------
+        >>> df.to_records()  # doctest: +SKIP
+        dask.array<shape=(nan,), dtype=(numpy.record, [('ind', '<f8'), ('x', 'O'), ('y', '<i8')]), chunksize=(nan,)>
+        """
+        from .io import to_records
+        return to_records(self)
+
 
 # bind operators
 for op in [operator.abs, operator.add, operator.and_, operator_div,

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1700,6 +1700,12 @@ class _Frame(Base):
 
     @property
     def values(self):
+        """ Return a dask.array of the values of this dataframe
+
+        Warning: This creates a dask.array without precise shape information.
+        Operations that depend on shape information, like slicing or reshaping,
+        will not work.
+        """
         from ..array.core import Array
         name = 'values-' + tokenize(self)
         chunks = ((np.nan,) * self.npartitions,)
@@ -2821,6 +2827,10 @@ class DataFrame(_Frame):
 
     def to_records(self, index=False):
         """ Convert to a dask array with struct dtype
+
+        Warning: This creates a dask.array without precise shape information.
+        Operations that depend on shape information, like slicing or reshaping,
+        will not work.
 
         Examples
         --------

--- a/dask/dataframe/io/__init__.py
+++ b/dask/dataframe/io/__init__.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from .io import (from_array, from_bcolz, from_array, from_bcolz,
                  from_pandas, from_dask_array, from_castra, to_castra,
-                 from_delayed, dataframe_from_ctable, to_bag)
+                 from_delayed, dataframe_from_ctable, to_bag, to_records)
 from .csv import read_csv, to_csv, read_table
 from .hdf import read_hdf, to_hdf
 from . import demo

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -467,6 +467,18 @@ def to_bag(df, index=False):
     return Bag(dsk, name, df.npartitions)
 
 
+def to_records(df):
+    from ...array.core import Array
+    if not isinstance(df, (DataFrame, Series)):
+        raise TypeError("df must be either DataFrame or Series")
+    name = 'to-records-' + tokenize(df)
+    dsk = {(name, i): (M.to_records, key)
+           for (i, key) in enumerate(df._keys())}
+    x = df._meta.to_records()
+    chunks = ((np.nan,) * df.npartitions,)
+    return Array(merge(df.dask, dsk), name, chunks, x.dtype)
+
+
 @insert_meta_param_description
 def from_delayed(dfs, meta=None, divisions=None, prefix='from-delayed',
                  metadata=None):

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -551,7 +551,7 @@ def test_to_records():
     from dask.array.utils import assert_eq
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
                        'y': [2, 3, 4, 5]},
-                       index=pd.Index([1., 2., 3., 4.], name='ind'))
+                      index=pd.Index([1., 2., 3., 4.], name='ind'))
     ddf = dd.from_pandas(df, 2)
 
     assert_eq(df.to_records(), ddf.to_records())

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -544,3 +544,15 @@ def test_to_bag():
     assert ddf.to_bag(True).compute() == list(a.itertuples(True))
     assert ddf.x.to_bag(True).compute() == list(a.x.iteritems())
     assert ddf.x.to_bag().compute() == list(a.x)
+
+
+def test_to_records():
+    pytest.importorskip('dask.array')
+    from dask.array.utils import assert_eq
+    df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
+                       'y': [2, 3, 4, 5]},
+                       index=pd.Index([1., 2., 3., 4.], name='ind'))
+    ddf = dd.from_pandas(df, 2)
+
+    import pdb; pdb.set_trace()
+    assert_eq(df.to_records(), ddf.to_records())

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -554,5 +554,4 @@ def test_to_records():
                        index=pd.Index([1., 2., 3., 4.], name='ind'))
     ddf = dd.from_pandas(df, 2)
 
-    import pdb; pdb.set_trace()
     assert_eq(df.to_records(), ddf.to_records())

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2820,3 +2820,16 @@ def test_split_out_value_counts(split_every):
 
     assert ddf.x.value_counts(split_out=10, split_every=split_every).npartitions == 10
     assert_eq(ddf.x.value_counts(split_out=10, split_every=split_every), df.x.value_counts())
+
+
+def test_values():
+    from dask.array.utils import assert_eq
+    df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
+                       'y': [2, 3, 4, 5]},
+                       index=pd.Index([1., 2., 3., 4.], name='ind'))
+    ddf = dd.from_pandas(df, 2)
+
+    assert_eq(df.values, ddf.values)
+    assert_eq(df.x.values, ddf.x.values)
+    assert_eq(df.y.values, ddf.y.values)
+    assert_eq(df.index.values, ddf.index.values)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2826,7 +2826,7 @@ def test_values():
     from dask.array.utils import assert_eq
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
                        'y': [2, 3, 4, 5]},
-                       index=pd.Index([1., 2., 3., 4.], name='ind'))
+                      index=pd.Index([1., 2., 3., 4.], name='ind'))
     ddf = dd.from_pandas(df, 2)
 
     assert_eq(df.values, ddf.values)


### PR DESCRIPTION
We use np.nan to represent a chunk size whose value we do not know.  This ends up being fairly easy because of the toxic nature of np.nan.