### PR TITLE
More unknown shape improvements

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1161,6 +1161,18 @@ class Array(Base):
     def __complex__(self):
         return complex(self.compute())
 
+    def __setitem__(self, key, value):
+        if isinstance(key, Array):
+            y = where(key, value, self)
+            self.dtype = y.dtype
+            self.dask = y.dask
+            self.name = y.name
+            return self
+        else:
+            raise NotImplementedError("Item assignment with %s not supported"
+                    % type(key))
+        out = 'getitem-' + tokenize(self, index)
+
     def __getitem__(self, index):
         out = 'getitem-' + tokenize(self, index)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2589,3 +2589,23 @@ def test_no_chunks_slicing_2d():
         with pytest.raises(ValueError) as e:
             op()
         assert 'chunk' in str(e) and 'unknown' in str(e)
+
+
+def test_index_array_with_array_1d():
+    x = np.arange(10)
+    dx = da.from_array(x, chunks=(5,))
+    dx._chunks = ((np.nan, np.nan),)
+
+    assert_eq(x[x > 6], dx[dx > 6])
+    assert_eq(x[x % 2 == 0], dx[dx % 2 == 0])
+
+
+def test_index_array_with_array_2d():
+    x = np.arange(24).reshape((4, 6))
+    dx = da.from_array(x, chunks=(2, 2))
+    dx._chunks = ((2, 2), (np.nan, np.nan, np.nan))
+
+    assert (sorted(x[x % 2 == 0].tolist()) ==
+            sorted(dx[dx % 2 == 0].compute().tolist()))
+    assert (sorted(x[x > 6].tolist()) ==
+            sorted(dx[dx > 6].compute().tolist()))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2609,3 +2609,29 @@ def test_index_array_with_array_2d():
             sorted(dx[dx % 2 == 0].compute().tolist()))
     assert (sorted(x[x > 6].tolist()) ==
             sorted(dx[dx > 6].compute().tolist()))
+
+
+def test_setitem_1d():
+    x = np.arange(10)
+    dx = da.from_array(x.copy(), chunks=(5,))
+
+    x[x > 6] = -1
+    x[x % 2 == 0] = -2
+
+    dx[dx > 6] = -1
+    dx[dx % 2 == 0] = -2
+
+    assert_eq(x, dx)
+
+
+def test_setitem_2d():
+    x = np.arange(24).reshape((4, 6))
+    dx = da.from_array(x, chunks=(2, 2))
+
+    x[x > 6] = -1
+    x[x % 2 == 0] = -2
+
+    dx[dx > 6] = -1
+    dx[dx % 2 == 0] = -2
+
+    assert_eq(x, dx)

--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -71,6 +71,22 @@ as described above.
 See :doc:`documentation on using dask.delayed with collections<delayed-collections>`.
 
 
+From Dask.dataframe
+-------------------
+
+You can create dask arrays from dask dataframes using the ``.values`` attribute
+or the ``.to_records()`` method.
+
+.. code-block:: python
+
+   >>> x = df.values
+   >>> x = df.to_records()
+
+However these arrays do not have known chunk sizes (dask.dataframe does not
+track the number of rows in each partition) and so some operations like slicing
+will not operate correctly.
+
+
 Chunks
 ------
 
@@ -98,6 +114,23 @@ For performance, a good choice of ``chunks`` follows the following rules:
     efficient if your chunks are aligned so that you have to touch fewer
     chunks.  If you want to add two arrays then its convenient if those arrays
     have matching chunks patterns.
+
+
+Unknown Chunks
+~~~~~~~~~~~~~~
+
+Some arrays have unknown chunk sizes.  These are designated using ``np.nan``
+rather than an integer.  These arrays support many but not all operations.  In
+particular, opeations like slicing are not possible and will result in an
+error.
+
+.. code-block:: python
+
+   >>> x.shape
+   (np.nan, np.nan)
+
+   >>> x[0]
+   ValueError: Array chunk sizes unknown
 
 
 Chunks Examples

--- a/docs/source/array-overview.rst
+++ b/docs/source/array-overview.rst
@@ -58,16 +58,10 @@ Limitations
 Dask array does not implement the entire numpy interface.  Users expecting this
 will be disappointed.  Notably, Dask array has the following limitations:
 
-1.  Dask arrays are immutable.  You can not change elements within a dask
-    array.
-2.  Dask array does not implement all of ``np.linalg``.  This has been done by a
+1.  Dask array does not implement all of ``np.linalg``.  This has been done by a
     number of excellent BLAS/LAPACK implementations, and is the focus of
     numerous ongoing academic research projects.
-3.  Dask array does not support any operation where the resulting shape
-    depends on the values of the array.  In order to form the dask graph we
-    must be able to infer the shape of the array before actually executing the
-    operation.  This precludes operations like indexing one Dask array with
-    another or operations like ``np.where``.
+2.  Dask array with unknown shapes do not support all operations
 4.  Dask array does not attempt operations like ``sort`` which are notoriously
     difficult to do in parallel, and are of somewhat diminished value on very
     large data (you rarely actually need a full sort).

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -76,9 +76,11 @@ Top level user functions:
     DataFrame.tail
     DataFrame.to_bag
     DataFrame.to_csv
-    DataFrame.to_hdf
     DataFrame.to_delayed
+    DataFrame.to_hdf
+    DataFrame.to_records
     DataFrame.truediv
+    DataFrame.values
     DataFrame.var
     DataFrame.visualize
     DataFrame.where


### PR DESCRIPTION
Follows on https://github.com/dask/dask/pull/1838

Implements the following:

1.  Slicing one dask.array with another `x[x > 100]`
2.  Setting values with dask arrays `x[x > 0] = 0` (actually retains shape)
3.  Small documentation improvements

cc @shoyer 