### PR TITLE
Add storage options to parquet functions

### DIFF
--- a/dask/bytes/s3.py
+++ b/dask/bytes/s3.py
@@ -14,7 +14,7 @@ class DaskS3FileSystem(S3FileSystem, core.FileSystem):
     sep = '/'
 
     def __init__(self, key=None, username=None, secret=None, password=None,
-                 blocksize=5 * 2 ** 20, path=None, host=None, s3=None, **kwargs):
+                 path=None, host=None, s3=None, **kwargs):
         if username is not None:
             if key is not None:
                 raise KeyError("S3 storage options got secrets argument "
@@ -33,15 +33,13 @@ class DaskS3FileSystem(S3FileSystem, core.FileSystem):
             secret = password
         if secret is not None:
             kwargs['secret'] = secret
-        self.blocksize = blocksize
         # S3FileSystem.__init__(self, kwargs)  # not sure what do do here
         S3FileSystem.__init__(self, **kwargs)
 
     def open(self, path, mode='rb', **kwargs):
         bucket = kwargs.pop('host', '')
         s3_path = bucket + path
-        return S3FileSystem.open(self, s3_path, mode=mode,
-                                 block_size=self.blocksize)
+        return S3FileSystem.open(self, s3_path, mode=mode)
 
     def glob(self, path, **kwargs):
         bucket = kwargs.pop('host', '')

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -330,3 +330,8 @@ def test_parquet_wstoragepars(s3):
     assert s3.current().default_fill_cache is False
     read_parquet(url, storage_options={'default_fill_cache': True})
     assert s3.current().default_fill_cache is True
+
+    read_parquet(url, storage_options={'default_block_size': 2**20})
+    assert s3.current().default_block_size == 2**20
+    with s3.current().open(url+'/_metadata') as f:
+        assert f.blocksize == 2**20

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -333,5 +333,5 @@ def test_parquet_wstoragepars(s3):
 
     read_parquet(url, storage_options={'default_block_size': 2**20})
     assert s3.current().default_block_size == 2**20
-    with s3.current().open(url+'/_metadata') as f:
+    with s3.current().open(url + '/_metadata') as f:
         assert f.blocksize == 2**20

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -326,7 +326,7 @@ def test_parquet_wstoragepars(s3):
     df = dd.from_pandas(data, chunksize=500)
     to_parquet(url, df, write_index=False)
 
-    df2 = read_parquet(url, storage_options={'default_fill_cache': False})
+    read_parquet(url, storage_options={'default_fill_cache': False})
     assert s3.current().default_fill_cache is False
-    df2 = read_parquet(url, storage_options={'default_fill_cache': True})
+    read_parquet(url, storage_options={'default_fill_cache': True})
     assert s3.current().default_fill_cache is True

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -310,3 +310,23 @@ def test_parquet(s3):
     assert len(df2.divisions) > 1
 
     pd.util.testing.assert_frame_equal(data, df2.compute())
+
+
+def test_parquet_wstoragepars(s3):
+    dd = pytest.importorskip('dask.dataframe')
+    pytest.importorskip('fastparquet')
+    from dask.dataframe.io.parquet import to_parquet, read_parquet
+
+    import pandas as pd
+    import numpy as np
+
+    url = 's3://%s/test.parquet' % test_bucket_name
+
+    data = pd.DataFrame({'i32': np.array([0, 5, 2, 5])})
+    df = dd.from_pandas(data, chunksize=500)
+    to_parquet(url, df, write_index=False)
+
+    df2 = read_parquet(url, storage_options={'default_fill_cache': False})
+    assert s3.current().default_fill_cache is False
+    df2 = read_parquet(url, storage_options={'default_fill_cache': True})
+    assert s3.current().default_fill_cache is True

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -18,7 +18,8 @@ except:
     default_encoding = None
 
 
-def read_parquet(path, columns=None, filters=None, categories=None, index=None):
+def read_parquet(path, columns=None, filters=None, categories=None, index=None,
+                 storage_options=None):
     """
     Read Dask DataFrame from ParquetFile
 
@@ -40,6 +41,8 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None):
         For any fields listed here, if the parquet encoding is Dictionary,
         the column will be created with dtype category. Use only if it is
         guaranteed that the column is encoded as dictionary in all row-groups.
+    storage_options : dict
+        Key/value pairs to be passed on to the file-system backend, if any.
 
     Examples
     --------
@@ -53,7 +56,8 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None):
         raise ImportError("fastparquet not installed")
     if filters is None:
         filters = []
-    myopen = OpenFileCreator(path, compression=None, text=False)
+    myopen = OpenFileCreator(path, compression=None, text=False,
+                             **(storage_options or {}))
 
     if isinstance(columns, list):
         columns = tuple(columns)
@@ -150,7 +154,7 @@ def _read_parquet_row_group(open, fn, index, columns, rg, series, categories,
 
 
 def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
-               fixed_text=None, object_encoding=None):
+               fixed_text=None, object_encoding=None, storage_options=None):
     """
     Write Dask.dataframe to parquet
 
@@ -183,6 +187,8 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
     object_encoding : dict {col: bytes|utf8|json|bson} or str
         For object columns, specify how to encode to bytes. If a str, same
         encoding is applied to all object columns.
+    storage_options : dict
+        Key/value pairs to be passed on to the file-system backend, if any.
 
     Examples
     --------
@@ -196,7 +202,8 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
     if fastparquet is False:
         raise ImportError("fastparquet not installed")
 
-    myopen = OpenFileCreator(path, compression=None, text=False)
+    myopen = OpenFileCreator(path, compression=None, text=False,
+                             **(storage_options or {}))
     myopen.fs.mkdirs(path)
     sep = myopen.fs.sep
     metadata_fn = sep.join([path, '_metadata'])


### PR DESCRIPTION
I couldn't think of any way to test this yet, except to somehow supply options that would cause an exception in the file-system backend. Suggestions?