### PR TITLE
Add `size` kwarg to `da.random.gamma`

### DIFF
--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -184,9 +184,9 @@ class RandomState(object):
                           size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.gamma)
-    def gamma(self, shape, scale=1.0, chunks=None):
-        return self._wrap(np.random.RandomState.gamma, scale,
-                          size=shape, chunks=chunks)
+    def gamma(self, shape, scale=1.0, size=None, chunks=None):
+        return self._wrap(np.random.RandomState.gamma, shape, scale,
+                          size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.geometric)
     def geometric(self, p, size=None, chunks=None):

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -136,7 +136,7 @@ def test_random_all():
     da.random.chisquare(1, size=5, chunks=3).compute()
     da.random.exponential(1, size=5, chunks=3).compute()
     da.random.f(1, 2, size=5, chunks=3).compute()
-    da.random.gamma(5, 1, chunks=3).compute()
+    da.random.gamma(5, 1, size=5, chunks=3).compute()
     da.random.geometric(1, size=5, chunks=3).compute()
     da.random.gumbel(1, size=5, chunks=3).compute()
     da.random.hypergeometric(1, 2, 3, size=5, chunks=3).compute()


### PR DESCRIPTION
`size` kwarg was missing, appears there was a past confusion equating
the `shape` and `size` arguments.