### PR TITLE
Add divisions= keyword to set_index

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2389,6 +2389,15 @@ class DataFrame(_Frame):
         >>> df2 = df.set_index('x')  # doctest: +SKIP
         >>> df2 = df.set_index(d.x)  # doctest: +SKIP
         >>> df2 = df.set_index(d.timestamp, sorted=True)  # doctest: +SKIP
+
+        A common case is when we have a datetime column that we know to be
+        sorted and is cleanly divided by day.  We can set this index for free
+        by specifying both that the column is pre-sorted and the particular
+        divisions along which is is separated
+
+        >>> import pandas as pd
+        >>> divisions = pd.date_range('2000', '2010', freq='1D')
+        >>> df2 = df.set_index('timestamp', sorted=True, divisions=divisions)  # doctest: +SKIP
         """
         if sorted:
             return set_sorted_index(self, other, drop=drop, **kwargs)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -17,15 +17,9 @@ from ..context import _globals
 from ..utils import digit, insert, M
 
 
-def set_index(df, index, npartitions=None, shuffle=None, compute=True,
-              drop=True, upsample=1.0, **kwargs):
-    """ Set DataFrame index to new column
-
-    Sorts index and realigns Dataframe to new sorted order.
-
-    This shuffles and repartitions your data. If done in parallel the
-    resulting order is non-deterministic.
-    """
+def set_index(df, index, npartitions=None, shuffle=None, compute=False,
+              drop=True, upsample=1.0, divisions=None, **kwargs):
+    """ See _Frame.set_index for docstring """
     if (isinstance(index, Series) and index._name == df.index._name):
         return df
     if isinstance(index, (DataFrame, tuple, list)):
@@ -40,12 +34,13 @@ def set_index(df, index, npartitions=None, shuffle=None, compute=True,
     else:
         index2 = index
 
-    divisions = (index2
-                 ._repartition_quantiles(npartitions, upsample=upsample)
-                 .compute()).tolist()
+    if divisions is None:
+        divisions = (index2
+                     ._repartition_quantiles(npartitions, upsample=upsample)
+                     .compute()).tolist()
 
     return set_partition(df, index, divisions, shuffle=shuffle, drop=drop,
-                         **kwargs)
+                         compute=compute, **kwargs)
 
 
 def set_partition(df, index, divisions, max_branch=32, drop=True, shuffle=None,

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -69,7 +69,7 @@ def test_categorical_set_index(shuffle):
         assert list(d1.index.compute()) == ['a']
         assert list(sorted(d2.index.compute())) == ['b', 'b', 'c']
 
-        b = a.set_partition('y', ['a', 'b', 'c'])
+        b = a.set_index('y', divisions=['a', 'b', 'c'])
         d1, d2 = b.get_partition(0), b.get_partition(1)
         assert list(d1.index.compute()) == ['a']
         assert list(sorted(d2.index.compute())) == ['b', 'b', 'c']

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -660,23 +660,23 @@ def test_drop_duplicates_subset():
 
 
 def test_set_partition():
-    d2 = d.set_partition('b', [0, 2, 9])
+    d2 = d.set_index('b', divisions=[0, 2, 9])
     assert d2.divisions == (0, 2, 9)
     expected = full.set_index('b')
     assert_eq(d2, expected)
 
 
 def test_set_partition_compute():
-    d2 = d.set_partition('b', [0, 2, 9])
-    d3 = d.set_partition('b', [0, 2, 9], compute=True)
+    d2 = d.set_index('b', divisions=[0, 2, 9], compute=False)
+    d3 = d.set_index('b', divisions=[0, 2, 9], compute=True)
 
     assert_eq(d2, d3)
     assert_eq(d2, full.set_index('b'))
     assert_eq(d3, full.set_index('b'))
     assert len(d2.dask) > len(d3.dask)
 
-    d4 = d.set_partition(d.b, [0, 2, 9])
-    d5 = d.set_partition(d.b, [0, 2, 9], compute=True)
+    d4 = d.set_index(d.b, divisions=[0, 2, 9], compute=False)
+    d5 = d.set_index(d.b, divisions=[0, 2, 9], compute=True)
     exp = full.copy()
     exp.index = exp.b
     assert_eq(d4, d5)
@@ -1398,7 +1398,7 @@ def test_set_partition_2():
     df = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': list('abdabd')})
     ddf = dd.from_pandas(df, 2)
 
-    result = ddf.set_partition('y', ['a', 'c', 'd'])
+    result = ddf.set_index('y', divisions=['a', 'c', 'd'])
     assert result.divisions == ('a', 'c', 'd')
 
     assert list(result.compute(get=get_sync).index[-2:]) == ['d', 'd']


### PR DESCRIPTION
This allows us to remove set_partitions from public API.  We also
significanltly enhance the set_index docstring.