### PR TITLE
default to SerializableLock when storing arrays

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -13,7 +13,6 @@ import os
 import sys
 import traceback
 import pickle
-from threading import Lock
 import uuid
 import warnings
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2433,7 +2433,7 @@ def dot(a, b):
 
 def insert_to_ooc(out, arr, lock=True, region=None):
     if lock is True:
-        lock = Lock()
+        lock = SerializableLock()
 
     def store(x, index, lock, region):
         if lock:


### PR DESCRIPTION
Fixes dask/distributed#780

@mrocklin, would welcome a suggestion on how to test this. Should I actually create a `distributed.Client()` within `test_array_core.py`?