### PR TITLE
Changes `delayed(nout=1)`-behaviour to be more consistent.

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -129,6 +129,7 @@ def delayed(obj, name=None, pure=False, nout=None):
         object. If provided, the ``Delayed`` output of the call can be iterated
         into ``nout`` objects, allowing for unpacking of results. By default
         iteration over ``Delayed`` objects will error.
+        Note, that ``nout=1`` expects ``obj``, to return a tuple of length 1.
 
     Examples
     --------

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -129,7 +129,8 @@ def delayed(obj, name=None, pure=False, nout=None):
         object. If provided, the ``Delayed`` output of the call can be iterated
         into ``nout`` objects, allowing for unpacking of results. By default
         iteration over ``Delayed`` objects will error.
-        Note, that ``nout=1`` expects ``obj``, to return a tuple of length 1.
+        Note, that ``nout=1`` expects ``obj``, to return a tuple of length 1,
+        and consequently for `nout=0``, ``obj`` should return an empty tuple.
 
     Examples
     --------
@@ -409,7 +410,7 @@ def call_function(func, args, kwargs, pure=False, nout=None):
 
     dasks = flat_unique(dasks)
     dasks.append({name: task})
-    nout = nout if nout and nout > 0 else None
+    nout = nout if nout is not None else None
     return Delayed(name, dasks, length=nout)
 
 

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -408,7 +408,7 @@ def call_function(func, args, kwargs, pure=False, nout=None):
 
     dasks = flat_unique(dasks)
     dasks.append({name: task})
-    nout = nout if nout and nout > 1 else None
+    nout = nout if nout and nout > 0 else None
     return Delayed(name, dasks, length=nout)
 
 

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -209,7 +209,7 @@ def test_nout():
     x = func(1)
     assert len(x) == 1
     a, = x
-    assert compute(a) == (1, )
+    assert a.compute() == 1
     assert a._length is None
     pytest.raises(TypeError, lambda: len(a))
 

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -199,10 +199,18 @@ def test_nout():
     pytest.raises(ValueError, lambda: delayed(add, nout=-1))
     pytest.raises(ValueError, lambda: delayed(add, nout=True))
 
-    func = delayed(add, nout=1)
+    func = delayed(add, nout=None)
     a = func(1)
     assert a._length is None
     pytest.raises(TypeError, lambda: list(a))
+    pytest.raises(TypeError, lambda: len(a))
+
+    func = delayed(lambda x: (x,), nout=1, pure=True)
+    x = func(1)
+    assert len(x) == 1
+    a, = x
+    assert compute(a) == (1, )
+    assert a._length is None
     pytest.raises(TypeError, lambda: len(a))
 
 

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -213,6 +213,11 @@ def test_nout():
     assert a._length is None
     pytest.raises(TypeError, lambda: len(a))
 
+    func = delayed(lambda x: tuple(), nout=0, pure=True)
+    x = func(1)
+    assert len(x) == 0
+    assert x.compute() == tuple()
+
 
 def test_kwargs():
     def mysum(a, b, c=(), **kwargs):

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -36,6 +36,11 @@ DataFrame
   drop_duplicates) (:pr:`1808`), (:pr:`1823`) (:pr:`1828`)
 - Add delitem and copy to DataFrames, increasing mutation support (:pr:`1858`)
 
+Delayed
++++++++
+
+- ``delayed(nout=1)`` does not default to ``out=None`` any more. I.e. functions
+  with return tuples of length 1 can be handled correctly.
 
 Core
 ++++

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -39,8 +39,13 @@ DataFrame
 Delayed
 +++++++
 
-- ``delayed(nout=1)`` does not default to ``out=None`` any more. I.e. functions
-  with return tuples of length 1 can be handled correctly.
+- Changed behaviour for ``delayed(nout=0)`` and ``delayed(nout=1)``:
+  ``delayed(nout=1)`` does not default to ``out=None`` anymore, and
+  ``delayed(nout=0)`` is also enabled. I.e. functions with return
+  tuples of length 1 or 0 can be handled correctly. This is especially
+  handy, if functions with a variable amount of outputs are wrapped by
+  ``delayed``. E.g. a trivial example:
+  ``delayed(lambda *args: args, nout=len(vals))(*vals)``
 
 Core
 ++++


### PR DESCRIPTION
Hello,

I find the bahavior of `delayed(nout=1)` behaving like `delayed(nout=None)` inconsistent and it becomes inconvenient in application, when corner-cases, such as ``numpy.meshgrid(*args)`` with only one argument, or similar functions with variable amount of return arguments are handled.

I propose to change this behavior. Let me please know, what you think about it and if I need to make further changes, if the idea suits `dask`. 

Thanks for the great work!

Markus 