### PR TITLE
Use `delayed(x).compute()` instead of `compute(*x)`

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -171,8 +171,8 @@ def to_textfiles(b, path, name_function=None, compression='infer',
     out = write_bytes(b.to_delayed(), path, name_function, compression,
                       encoding=encoding)
     if compute:
-        from dask import compute
-        compute(*out)
+        from dask import delayed
+        delayed(out).compute()
     else:
         return out
 

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -409,8 +409,7 @@ def to_csv(df, filename, name_function=None, compression=None, compute=True,
                          encoding=None)
 
     if compute:
-        from dask import compute
-        compute(*values, get=get)
+        delayed(values).compute(get=get)
     else:
         return values
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -2,7 +2,7 @@ import pandas as pd
 from toolz import first, partial
 
 from ..core import DataFrame, Series
-from ...base import compute, tokenize, normalize_token
+from ...base import tokenize, normalize_token
 from ...compatibility import PY3
 from ...delayed import delayed
 from ...bytes.core import OpenFileCreator
@@ -238,7 +238,7 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
               compression=compression)
               for outfile, partition in zip(outfiles, partitions)]
 
-    out = compute(*writes)
+    out = delayed(writes).compute()
 
     for fn, rg in zip(filenames, out):
         for chunk in rg.columns:


### PR DESCRIPTION
Previously `compute(*args)` is used in several places to compute a list
of `Delayed` values - usually for I/O purposes. This uses the generic
`compute` function from `dask.base`. This is a generic method that
has no knowledge of `Delayed`, and instead works with the `dask`
attributes on objects. Because of this, it does unnecessary merging of
dictionaries that can be skipped by using `delayed(args).compute()`
instead. For large numbers of `Delayed` objects, this can be much
faster, and uses less memory.

Fixes #1888.