### PR TITLE
Add `traverse` kwarg to `delayed`

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -635,7 +635,6 @@ class Bag(Base):
         Bag.foldby
         """
         combine = combine or binop
-        initial = quote(initial)
         if initial is not no_default:
             return self.reduction(curry(_reduce, binop, initial=initial),
                                   curry(_reduce, combine),

--- a/dask/core.py
+++ b/dask/core.py
@@ -423,6 +423,25 @@ def isdag(d, keys):
     return not getcycle(d, keys)
 
 
+class literal(object):
+    """A small serializable object to wrap literal values without copying"""
+    __slots__ = ('data',)
+
+    def __init__(self, data):
+        self.data = data
+
+    def __repr__(self):
+        return 'literal<type=%s>' % type(self.data).__name__
+
+    def __reduce__(self):
+        return (literal, (self.data,))
+
+
+def extract_literal(x):
+    """Extract the object wrapped in a literal"""
+    return x.data
+
+
 def quote(x):
     """ Ensure that this value remains this value in a dask graph
 
@@ -430,8 +449,8 @@ def quote(x):
     ensure that our data is not interpreted but remains literal.
 
     >>> quote((add, 1, 2))  # doctest: +SKIP
-    (tuple, [add, 1, 2])
+    (extract_literal, literal<type=tuple>)
     """
-    if istask(x):
-        return (tuple, list(map(quote, x)))
+    if istask(x) or type(x) is list:
+        return (extract_literal, literal(x))
     return x

--- a/dask/core.py
+++ b/dask/core.py
@@ -436,10 +436,8 @@ class literal(object):
     def __reduce__(self):
         return (literal, (self.data,))
 
-
-def extract_literal(x):
-    """Extract the object wrapped in a literal"""
-    return x.data
+    def __call__(self):
+        return self.data
 
 
 def quote(x):
@@ -449,8 +447,8 @@ def quote(x):
     ensure that our data is not interpreted but remains literal.
 
     >>> quote((add, 1, 2))  # doctest: +SKIP
-    (extract_literal, literal<type=tuple>)
+    (literal<type=tuple>,)
     """
     if istask(x) or type(x) is list:
-        return (extract_literal, literal(x))
+        return (literal(x),)
     return x

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -1,11 +1,12 @@
 from collections import namedtuple
 
 import pytest
+import pickle
 
 from dask.utils_test import GetFunctionTestMixin, inc, add
 from dask import core
 from dask.core import (istask, get_dependencies, get_deps, flatten, subs,
-                       preorder_traversal, quote, has_tasks)
+                       preorder_traversal, literal, quote, has_tasks)
 
 
 def contains(a, b):
@@ -226,3 +227,8 @@ def test_quote():
 
     for l in literals:
         assert core.get({'x': quote(l)}, 'x') == l
+
+
+def test_literal_serializable():
+    l = literal((add, 1, 2))
+    assert pickle.loads(pickle.dumps(l)).data == (add, 1, 2)

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -197,6 +197,14 @@ def test_traverse_false():
     assert res[0] == fail
     assert res[1] is a
 
+    # list containing task-like-things
+    x = [1, (fail, a), a]
+    res = delayed(x, traverse=False).compute()
+    assert isinstance(res, list)
+    assert res[0] == 1
+    assert res[1][0] == fail and res[1][1] is a
+    assert res[2] is a
+
     # traverse=False still hits top level
     b = delayed(1)
     x = delayed(b, traverse=False)


### PR DESCRIPTION
By default dask traverses builtin python collections looking for dask
objects passed to ``delayed``. For large collections this can be
expensive. This PR adds a keyword ``traverse`` to ``delayed``, to tell
dask to avoid doing this traversal.

Fixes #1884.