### PR TITLE
Fix edge behavior for floating step arange

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -186,3 +186,8 @@ def topk(k, x):
     k = np.minimum(k, len(x))
     ind = np.argpartition(x, -k)[-k:]
     return np.sort(x[ind])[::-1]
+
+
+def arange(start, stop, step, length, dtype):
+    res = np.arange(start, stop, step, dtype)
+    return res[:-1] if len(res) > length else res

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -5,6 +5,7 @@ from functools import partial
 import numpy as np
 
 from .core import Array, normalize_chunks
+from . import chunk
 from ..base import tokenize
 
 
@@ -119,11 +120,7 @@ def arange(*args, **kwargs):
     if dtype is None:
         dtype = np.arange(0, 1, step).dtype
 
-    range_ = stop - start
-    num = int(abs(range_ // step))
-    if (range_ % step) != 0:
-        num += 1
-
+    num = max(np.ceil((stop - start) / step), 0)
     chunks = normalize_chunks(chunks, (num,))
 
     name = 'arange-' + tokenize((start, stop, step, chunks, num))
@@ -133,7 +130,7 @@ def arange(*args, **kwargs):
     for i, bs in enumerate(chunks[0]):
         blockstart = start + (elem_count * step)
         blockstop = start + ((elem_count + bs) * step)
-        task = (np.arange, blockstart, blockstop, step, dtype)
+        task = (chunk.arange, blockstart, blockstop, step, bs, dtype)
         dsk[(name, i)] = task
         elem_count += bs
 

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -60,18 +60,18 @@ def test_arange():
     assert (sorted(da.arange(77, chunks=13, dtype=float).dask) ==
             sorted(da.arange(77, chunks=13, dtype=float).dask))
 
+    # 0 size output
+    darr = da.arange(0, 1, -0.5, chunks=20)
+    nparr = np.arange(0, 1, -0.5)
+    assert_eq(darr, nparr)
+
+    darr = da.arange(0, -1, 0.5, chunks=20)
+    nparr = np.arange(0, -1, 0.5)
+    assert_eq(darr, nparr)
+
 
 def test_arange_has_dtype():
     assert da.arange(5, chunks=2).dtype == np.arange(5).dtype
-
-
-def test_arange_working_float_step():
-    """Sometimes floating point step arguments work, but this could be platform
-    dependent.
-    """
-    darr = da.arange(3.3, -9.1, -.25, chunks=3)
-    nparr = np.arange(3.3, -9.1, -.25)
-    assert_eq(darr, nparr)
 
 
 @pytest.mark.xfail(reason="Casting floats to ints is not supported since edge"
@@ -82,8 +82,6 @@ def test_arange_cast_float_int_step():
     assert_eq(darr, nparr)
 
 
-@pytest.mark.xfail(reason="arange with a floating point step value can fail"
-                          "due to numerical instability.")
 def test_arange_float_step():
     darr = da.arange(2., 13., .3, chunks=4)
     nparr = np.arange(2., 13., .3)
@@ -91,4 +89,12 @@ def test_arange_float_step():
 
     darr = da.arange(7.7, 1.5, -.8, chunks=3)
     nparr = np.arange(7.7, 1.5, -.8)
+    assert_eq(darr, nparr)
+
+    darr = da.arange(0, 1, 0.01, chunks=20)
+    nparr = np.arange(0, 1, 0.01)
+    assert_eq(darr, nparr)
+
+    darr = da.arange(0, 1, 0.03, chunks=20)
+    nparr = np.arange(0, 1, 0.03)
     assert_eq(darr, nparr)


### PR DESCRIPTION
Previously this would fail due to inconsistent boundary handling in
numpy. Fixes #1903.