### PR TITLE
`meta_nonempty` works with empty categories

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -139,6 +139,25 @@ def test_meta_duplicated():
     tm.assert_frame_equal(res, exp)
 
 
+def test_meta_nonempty_empty_categories():
+    for dtype in ['O', 'f8', 'M8']:
+        # Index
+        idx = pd.CategoricalIndex([], pd.Index([], dtype=dtype),
+                                  ordered=True, name='foo')
+        res = meta_nonempty(idx)
+        assert type(res) is pd.CategoricalIndex
+        assert type(res.categories) is type(idx.categories)
+        assert res.ordered == idx.ordered
+        assert res.name == idx.name
+        # Series
+        s = idx.to_series()
+        res = meta_nonempty(s)
+        assert res.dtype == s.dtype
+        assert type(res.cat.categories) is type(s.cat.categories)
+        assert res.cat.ordered == s.cat.ordered
+        assert res.name == s.name
+
+
 def test_meta_nonempty_index():
     idx = pd.RangeIndex(1, name='foo')
     res = meta_nonempty(idx)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -251,9 +251,13 @@ def _nonempty_index(idx):
         return pd.TimedeltaIndex(data, start=start, periods=2, freq=idx.freq,
                                  name=idx.name)
     elif typ is pd.CategoricalIndex:
-        element = idx.categories[0]
-        return pd.CategoricalIndex([element, element],
-                                   categories=idx.categories,
+        if len(idx.categories):
+            data = [idx.categories[0]] * 2
+            cats = idx.categories
+        else:
+            data = _nonempty_index(idx.categories)
+            cats = data.unique()
+        return pd.CategoricalIndex(data, categories=cats,
                                    ordered=idx.ordered, name=idx.name)
     elif typ is pd.MultiIndex:
         levels = [_nonempty_index(i) for i in idx.levels]
@@ -311,9 +315,13 @@ def _nonempty_series(s, idx):
         entry = pd.Timestamp('1970-01-01', tz=dtype.tz)
         data = [entry, entry]
     elif is_categorical_dtype(dtype):
-        entry = s.cat.categories[0]
-        data = pd.Categorical([entry, entry],
-                              categories=s.cat.categories,
+        if len(s.cat.categories):
+            data = [s.cat.categories[0]] * 2
+            cats = s.cat.categories
+        else:
+            data = _nonempty_index(s.cat.categories)
+            cats = data.unique()
+        data = pd.Categorical(data, categories=cats,
                               ordered=s.cat.ordered)
     else:
         entry = _scalar_from_dtype(dtype)


### PR DESCRIPTION
Previously this expected all categorical series/indices to have at least
one category. This was causing issues, in particular with parquet
support. Fixes #1905.