### PR TITLE
groupby().cumsum()/cumprod() implementation

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -539,11 +539,11 @@ def _cum_agg_aligned(part, cum_last, index, columns, func, neutral):
 def _cum_agg_filled(a, b, func, neutral):
     union = a.index.union(b.index)
     return func(a.reindex(union, fill_value=neutral),
-                b.reindex(union, fill_value=neutral))
+                b.reindex(union, fill_value=neutral), fill_value=neutral)
 
 
-def _add_plus_one(a, b):
-    return a + b + 1
+def _add_plus_one(a, b, fill_value=None):
+    return a.add(b, fill_value=fill_value) + 1
 
 
 class _GroupBy(object):
@@ -688,7 +688,7 @@ class _GroupBy(object):
         else:
             return self._cum_agg('cumsum',
                                  chunk=M.cumsum,
-                                 aggregate=operator.add,
+                                 aggregate=M.add,
                                  neutral=0)
 
     @derived_from(pd.core.groupby.GroupBy)
@@ -698,7 +698,7 @@ class _GroupBy(object):
         else:
             return self._cum_agg('cumprod',
                                  chunk=M.cumprod,
-                                 aggregate=operator.mul,
+                                 aggregate=M.mul,
                                  neutral=1)
 
     @derived_from(pd.core.groupby.GroupBy)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -983,7 +983,7 @@ def test_cumulative(func, key, sel):
                        'c': np.random.randn(54),
                        'd': np.random.randn(54)},
                       columns=['a', 'b', 'c', 'd'])
-    df.d.iloc[-18, -12, -6] = np.nan
+    df.iloc[[-18, -12, -6], -1] = np.nan
     ddf = dd.from_pandas(df, npartitions=10)
 
     g, dg = [d.groupby(key)[sel] for d in (df, ddf)]
@@ -997,7 +997,7 @@ def test_cumulative_axis1(func):
     df = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 2,
                        'b': np.random.randn(18),
                        'c': np.random.randn(18)})
-    df.b.iloc[-6] = np.nan
-    ddf = dd.from_pandas(df, npartitions=3)
+    df.iloc[-6, -1] = np.nan
+    ddf = dd.from_pandas(df, npartitions=4)
     assert_eq(getattr(df.groupby('a'), func)(axis=1),
               getattr(ddf.groupby('a'), func)(axis=1))

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -971,3 +971,21 @@ def test_groupby_numeric_column():
 
     assert_eq(ddf.groupby(ddf.A)[0].sum(),
               df.groupby(df.A)[0].sum())
+
+
+@pytest.mark.parametrize('func', ['cumsum', 'cumprod'])
+@pytest.mark.parametrize('key', ['a', ['a', 'b']])
+@pytest.mark.parametrize('sel', ['d', ['c', 'd'], None])
+def test_cumulative(func, key, sel):
+    df = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 6,
+                       'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 6,
+                       'c': np.random.randn(54),
+                       'd': np.random.randn(54)},
+                      columns=['a', 'b', 'c', 'd'])
+    ddf = dd.from_pandas(df, npartitions=10)
+
+    g, dg = [d.groupby(key) for d in (df, ddf)]
+    if sel:
+        g, dg = g[sel], dg[sel]
+
+    assert_eq(getattr(g, func)(), getattr(dg, func)())

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -976,7 +976,7 @@ def test_groupby_numeric_column():
 
 @pytest.mark.parametrize('sel', ['c', 'd', ['c', 'd']])
 @pytest.mark.parametrize('key', ['a', ['a', 'b']])
-@pytest.mark.parametrize('func', ['cumsum', 'cumprod'])
+@pytest.mark.parametrize('func', ['cumsum', 'cumprod', 'cumcount'])
 def test_cumulative(func, key, sel):
     df = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 6,
                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 6,


### PR DESCRIPTION
I've implemented `cumsum` and `cumprod` on `groupby` object following the same logic as on `_Frame` with added handling of groupings inside `map_partitions`.