### PR TITLE
Merge dask.array.concatenate_axes logic with dask.array.concatenate3

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3305,7 +3305,7 @@ def shapelist(a):
 def reshapelist(shape, seq):
     """ Reshape iterator to nested shape
 
-    >>> reshape((2, 3), range(6))
+    >>> reshapelist((2, 3), range(6))
     [[0, 1, 2], [3, 4, 5]]
     """
     if len(shape) == 1:
@@ -3333,7 +3333,7 @@ def transposelist(arrays, axes, extradims=0):
 
     ndim = max(axes)+1
     shape = shapelist(arrays)
-    newshape = [shape[axes.index(i)] if i in axes else 1 for i in xrange(ndim+extradims)]
+    newshape = [shape[axes.index(i)] if i in axes else 1 for i in range(ndim+extradims)]
 
     result = list(core.flatten(arrays))
     return reshapelist(newshape, result)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3295,12 +3295,14 @@ def ndimlist(seq):
     else:
         return 1 + ndimlist(seq[0])
 
+
 def shapelist(a):
     """ Get the shape of nested list """
     if type(a) is list:
         return tuple([len(a)] + list(shapelist(a[0])))
     else:
         return ()
+
 
 def reshapelist(shape, seq):
     """ Reshape iterator to nested shape
@@ -3321,7 +3323,7 @@ def transposelist(arrays, axes, extradims=0):
     >>> transposelist([[1,1,1],[1,1,1]], [2,1])
     [[[1, 1], [1, 1], [1, 1]]]
 
-    >>> transposelist([[1,1,1],[1,1,1]], [2,1], extradims=1) 
+    >>> transposelist([[1,1,1],[1,1,1]], [2,1], extradims=1)
     [[[[1], [1]], [[1], [1]], [[1], [1]]]]
     """
     if len(axes) != ndimlist(arrays):
@@ -3331,12 +3333,13 @@ def transposelist(arrays, axes, extradims=0):
     if len(axes) > len(set(axes)):
         raise ValueError("`axes` should be unique")
 
-    ndim = max(axes)+1
+    ndim = max(axes) + 1
     shape = shapelist(arrays)
-    newshape = [shape[axes.index(i)] if i in axes else 1 for i in range(ndim+extradims)]
+    newshape = [shape[axes.index(i)] if i in axes else 1 for i in range(ndim + extradims)]
 
     result = list(core.flatten(arrays))
     return reshapelist(newshape, result)
+
 
 def concatenate3(arrays):
     """ Recursive np.concatenate
@@ -3386,8 +3389,9 @@ def concatenate_axes(arrays, axes):
     if len(axes) != ndimlist(arrays):
         raise ValueError("Length of axes should equal depth of nested arrays")
 
-    extradims=max(0, deepfirst(arrays).ndim-(max(axes)+1))
+    extradims = max(0, deepfirst(arrays).ndim - (max(axes) + 1))
     return concatenate3(transposelist(arrays, axes, extradims=extradims))
+
 
 def to_hdf5(filename, *args, **kwargs):
     """ Store arrays in HDF5 file

--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -9,7 +9,7 @@ from toolz.curried import map
 from ..base import tokenize
 from ..core import flatten
 from ..utils import concrete
-from .core import Array, map_blocks, concatenate, concatenate3
+from .core import Array, map_blocks, concatenate, concatenate3, reshapelist
 from . import chunk, wrap
 
 
@@ -79,20 +79,7 @@ def expand_key(k, dims):
 
     seq = list(product([k[0]], *[inds(i, ind)
                                  for i, ind in enumerate(k[1:])]))
-    return reshape(shape, seq)
-
-
-def reshape(shape, seq):
-    """ Reshape iterator to nested shape
-
-    >>> reshape((2, 3), range(6))
-    [[0, 1, 2], [3, 4, 5]]
-    """
-    if len(shape) == 1:
-        return list(seq)
-    else:
-        n = int(len(seq) / shape[0])
-        return [reshape(shape[1:], part) for part in partition(n, seq)]
+    return reshapelist(shape, seq)
 
 
 def ghost_internal(x, axes):

--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from operator import getitem
 from itertools import product
 
-from toolz import merge, pipe, concat, partition, partial
+from toolz import merge, pipe, concat, partial
 from toolz.curried import map
 
 from ..base import tokenize


### PR DESCRIPTION
Aiming to implement these TODO's. concatenate_axes can be expressed as concatenate3 so decided to take that route. Haven't tested for performance in a real application, but did run the tests. And it should perform as well as concatenate3 since it is just munging the lists of array references. Please let me know if I have overlooked anything as this is my first PR to dask.