### PR TITLE
Add persist function

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     pass
 try:
-    from .base import visualize, compute
+    from .base import visualize, compute, persist
 except ImportError:
     pass
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -62,8 +62,40 @@ class Base(object):
         return visualize(self, filename=filename, format=format,
                          optimize_graph=optimize_graph, **kwargs)
 
+    def persist(self, **kwargs):
+        """ Persist this dask collection into memory
+
+        This turns a lazy Dask collection into a Dask collection with the same
+        metadata, but now with its results actively computing.  For example a
+        lazy dask.array built up from many lazy calls will now be a dask.array
+        of the same shape, dtype, etc., but now with all of those lazy
+        operations either in memory (for single-machine computing) or actively
+        computing asynchronously (for distributed computing).
+
+        If using Dask on a single machine then you should ensure that the
+        dataset fits entirely within memory.
+
+        Parameters
+        ----------
+        get : callable, optional
+            A scheduler ``get`` function to use. If not provided, the default
+            is to check the global settings first, and then fall back to
+            the collection defaults.
+        optimize_graph : bool, optional
+            If True [default], the graph is optimized before computation.
+            Otherwise the graph is run as is. This can be useful for debugging.
+        kwargs
+            Extra keywords to forward to the scheduler ``get`` function.
+        """
+        return persist(self, **kwargs)[0]
+
     def compute(self, **kwargs):
-        """Compute several dask collections at once.
+        """ Compute this dask collection
+
+        This turns a lazy Dask collection into its in-memory equivalent.
+        For example a Dask.array turns into a NumPy array and a Dask.dataframe
+        turns into a Pandas dataframe.  The entire dataset must fit into memory
+        before calling this operation.
 
         Parameters
         ----------

--- a/dask/base.py
+++ b/dask/base.py
@@ -407,6 +407,14 @@ def redict_collection(c, dsk):
 
 
 def persist(*args, **kwargs):
+    try:
+        from distributed.client import default_client
+        if len(args) == 1:
+            return default_client().persist(*args, **kwargs)
+        else:
+            return default_client().persist(args, **kwargs)
+    except (ImportError, ValueError):
+        pass
     optimize_graph = kwargs.pop('optimize_graph', True)
     collections = [a for a in args if isinstance(a, Base)]
     if not collections:

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -7,8 +7,10 @@ import subprocess
 import sys
 
 import dask
+from dask import delayed
 from dask.base import (compute, tokenize, normalize_token, normalize_function,
-                       visualize)
+                       visualize, persist)
+from dask.delayed import Delayed
 from dask.utils import tmpdir, tmpfile, ignoring
 from dask.utils_test import inc, dec
 from dask.compatibility import unicode
@@ -374,3 +376,42 @@ def test_default_imports():
                  'partd', 's3fs', 'distributed']
     for mod in blacklist:
         assert mod not in modules
+
+
+def test_persist_literals():
+    assert persist(1, 2, 3) == (1, 2, 3)
+
+
+def test_persist_delayed():
+    x1 = delayed(1)
+    x2 = delayed(inc)(x1)
+    x3 = delayed(inc)(x2)
+
+    xx, = persist(x3)
+    assert isinstance(xx, Delayed)
+    assert xx.key == x3.key
+    assert len(xx.dask) == 1
+
+    assert x3.compute() == xx.compute()
+
+
+@pytest.mark.skipif('not da or not db')
+def test_persist_array_bag():
+    x = da.arange(5, chunks=2) + 1
+    b = db.from_sequence([1, 2, 3]).map(inc)
+
+    with pytest.raises(ValueError):
+        persist(x, b)
+
+    xx, bb = persist(x, b, get=dask.async.get_sync)
+
+    assert isinstance(xx, da.Array)
+    assert isinstance(bb, db.Bag)
+
+    assert xx.name == x.name
+    assert bb.name == b.name
+    assert len(xx.dask) == xx.npartitions < len(x.dask)
+    assert len(bb.dask) == bb.npartitions < len(b.dask)
+
+    assert np.allclose(x, xx)
+    assert list(b) == list(bb)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -261,6 +261,19 @@ def test_compute_array():
     assert np.allclose(out2, arr + 2)
 
 
+@pytest.mark.skipif('not da')
+def test_persist_array():
+    from dask.array.utils import assert_eq
+    arr = np.arange(100).reshape((10, 10))
+    x = da.from_array(arr, chunks=(5, 5))
+    x = (x + 1) - x.mean(axis=0)
+    y = x.persist()
+
+    assert_eq(x, y)
+    assert set(y.dask).issubset(x.dask)
+    assert len(y.dask) == y.npartitions
+
+
 @pytest.mark.skipif('not dd')
 def test_compute_dataframe():
     df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 5, 3, 3]})

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -1,6 +1,22 @@
 import pytest
 pytest.importorskip('distributed')
 
+from dask import persist, delayed
+from distributed import Client
+from distributed.client import _wait
+from distributed.utils_test import gen_cluster, inc
+
 
 def test_can_import_client():
     from dask.distributed import Client # noqa: F401
+
+
+@gen_cluster(client=True)
+def test_persist(c, s, a, b):
+    x = delayed(inc)(1)
+
+    x2 = persist(x)
+
+    yield _wait(x2)
+
+    assert x2.key in a.data or x2.key in b.data

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -2,7 +2,6 @@ import pytest
 pytest.importorskip('distributed')
 
 from dask import persist, delayed
-from distributed import Client
 from distributed.client import _wait
 from distributed.utils_test import gen_cluster, inc
 

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -14,9 +14,13 @@ def test_can_import_client():
 @gen_cluster(client=True)
 def test_persist(c, s, a, b):
     x = delayed(inc)(1)
-
-    x2 = persist(x)
+    x2, = persist(x)
 
     yield _wait(x2)
-
     assert x2.key in a.data or x2.key in b.data
+
+    y = delayed(inc)(10)
+    y2, one = persist(y, 1)
+
+    yield _wait(y2)
+    assert y2.key in a.data or y2.key in b.data


### PR DESCRIPTION
This is an initial step to resolve #1908 

This copies over some code from dask/distributed to implement a persist function that uses a get function to compute results and re-insert those results back into a Dask collection with the same keys.

Short term I'm likely to take this only as far as I need to accomplish current work.  If anyone else wants to jump in with longer-term thinking and commit directly to this branch they are most welcome. cc @jcrist 