### PR TITLE
Allow different category labels in parquet partitions

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -13,6 +13,7 @@ try:
     from fastparquet import parquet_thrift
     from fastparquet.core import read_row_group_file
     from fastparquet.api import _pre_allocate
+    from fastparquet.util import check_column_names
     default_encoding = parquet_thrift.Encoding.PLAIN
 except:
     fastparquet = False
@@ -72,6 +73,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
     except:
         pf = fastparquet.ParquetFile(path, open_with=myopen, sep=myopen.fs.sep)
 
+    check_column_names(pf.columns, categories)
     name = 'read-parquet-' + tokenize(pf, columns, categories)
 
     rgs = [rg for rg in pf.row_groups if

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -74,6 +74,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
         pf = fastparquet.ParquetFile(path, open_with=myopen, sep=myopen.fs.sep)
 
     check_column_names(pf.columns, categories)
+    categories = categories or []
     name = 'read-parquet-' + tokenize(pf, columns, categories)
 
     rgs = [rg for rg in pf.row_groups if
@@ -111,16 +112,14 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
     if index_col and index_col not in all_columns:
         all_columns = all_columns + (index_col,)
 
-    dtypes = {k: ('category' if k in (categories or []) else v) for k, v in
+    dtypes = {k: ('category' if k in categories else v) for k, v in
               pf.dtypes.items() if k in all_columns}
 
     meta = pd.DataFrame({c: pd.Series([], dtype=d)
                         for (c, d) in dtypes.items()},
                         columns=[c for c in pf.columns if c in dtypes])
 
-    for cat in categories or []:
-        if cat not in meta:
-            continue
+    for cat in categories:
         meta[cat] = pd.Series(pd.Categorical([],
                               categories=[UNKNOWN_CATEGORIES]))
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -117,6 +117,8 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
                         columns=[c for c in pf.columns if c in dtypes])
 
     for cat in categories or []:
+        if cat not in meta:
+            continue
         meta[cat] = pd.Series(pd.Categorical([],
                               categories=[UNKNOWN_CATEGORIES]))
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -116,7 +116,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
                         for (c, d) in dtypes.items()},
                         columns=[c for c in pf.columns if c in dtypes])
 
-    for cat in categories:
+    for cat in categories or []:
         meta[cat] = pd.Series(pd.Categorical([],
                               categories=[UNKNOWN_CATEGORIES]))
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -2,6 +2,7 @@ import pandas as pd
 from toolz import first, partial
 
 from ..core import DataFrame, Series
+from ..utils import UNKNOWN_CATEGORIES
 from ...base import tokenize, normalize_token
 from ...compatibility import PY3
 from ...delayed import delayed
@@ -77,11 +78,6 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
            not(fastparquet.api.filter_out_stats(rg, filters, pf.helper)) and
            not(fastparquet.api.filter_out_cats(rg, filters))]
 
-    # get category values from first row-group
-    categories = categories or []
-    cats = pf.grab_cats(categories)
-    categories = [cat for cat in categories if cats.get(cat, None) is not None]
-
     # Find an index among the partially sorted columns
     minmax = fastparquet.api.sorted_partitioned_columns(pf)
 
@@ -121,7 +117,8 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
                         columns=[c for c in pf.columns if c in dtypes])
 
     for cat in categories:
-        meta[cat] = pd.Series(pd.Categorical([], categories=cats[cat]))
+        meta[cat] = pd.Series(pd.Categorical([],
+                              categories=[UNKNOWN_CATEGORIES]))
 
     if index_col:
         meta = meta.set_index(index_col)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -206,4 +206,4 @@ def test_categories(fn):
     assert set(ddf2.y.compute().cat.categories) == {'a', 'b', 'c'}
     cats_set = ddf2.map_partitions(lambda x: x.y.cat.categories).compute()
     assert cats_set.tolist() == ['a', 'c', 'a', 'b']
-    assert ddf.compute().y.tolist() == ddf2.compute().y.tolist()
+    assert_eq(ddf.y, ddf2.y, check_names=False)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -130,7 +130,7 @@ def test_categorical():
 
         ddf2 = read_parquet(tmp, categories=['x'])
 
-        assert ddf2.x.cat.categories.tolist() == ['a', 'b', 'c']
+        assert ddf2.compute().x.cat.categories.tolist() == ['a', 'b', 'c']
         ddf2.loc[:1000].compute()
         df.index.name = 'index'  # defaults to 'index' in this case
         assert assert_eq(df, ddf2)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import dask
+import dask.async
 from dask.utils import tmpdir, tmpfile
 import dask.dataframe as dd
 from dask.dataframe.io.parquet import read_parquet, to_parquet
@@ -207,3 +208,10 @@ def test_categories(fn):
     cats_set = ddf2.map_partitions(lambda x: x.y.cat.categories).compute()
     assert cats_set.tolist() == ['a', 'c', 'a', 'b']
     assert_eq(ddf.y, ddf2.y, check_names=False)
+    with pytest.raises(dask.async.RemoteException):
+        # attempt to load as category that which is not so encoded
+        ddf2 = dd.read_parquet(fn, categories=['x']).compute()
+
+    # attempt to load as category unknown column
+    ddf2 = dd.read_parquet(fn, categories=['foo'])
+    assert 'foo' not in ddf2._meta

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -212,6 +212,6 @@ def test_categories(fn):
         # attempt to load as category that which is not so encoded
         ddf2 = dd.read_parquet(fn, categories=['x']).compute()
 
-    # attempt to load as category unknown column
-    ddf2 = dd.read_parquet(fn, categories=['foo'])
-    assert 'foo' not in ddf2._meta
+    with pytest.raises(ValueError):
+        # attempt to load as category unknown column
+        ddf2 = dd.read_parquet(fn, categories=['foo'])


### PR DESCRIPTION
Define the labels in the metadata using UNDEFINED_CATEGORIES.

Fixes #1836 