### PR TITLE
Feature/parquet append

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -192,7 +192,7 @@ def test_append_overlapping_divisions():
                                size=1000).astype("O")})
         half = len(df) // 2
         ddf1 = dd.from_pandas(df.iloc[:half], chunksize=100)
-        ddf2 = dd.from_pandas(df.iloc[half-10:], chunksize=100)
+        ddf2 = dd.from_pandas(df.iloc[half - 10:], chunksize=100)
         ddf1.to_parquet(tmp)
 
         with pytest.raises(ValueError) as excinfo:

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -208,16 +208,21 @@ def test_append_different_columns():
     with tmpdir() as tmp:
         df1 = pd.DataFrame({'i32': np.arange(100, dtype=np.int32)})
         df2 = pd.DataFrame({'i64': np.arange(100, dtype=np.int64)})
+        df3 = pd.DataFrame({'i32': np.arange(100, dtype=np.int64)})
 
         ddf1 = dd.from_pandas(df1, chunksize=2)
         ddf2 = dd.from_pandas(df2, chunksize=2)
+        ddf3 = dd.from_pandas(df3, chunksize=2)
 
         ddf1.to_parquet(tmp)
 
         with pytest.raises(ValueError) as excinfo:
             ddf2.to_parquet(tmp, append=True)
-
         assert 'Appended columns' in str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            ddf3.to_parquet(tmp, append=True)
+        assert 'Appended dtypes' in str(excinfo.value)
 
 
 def test_ordering():

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -136,15 +136,19 @@ def test_categorical():
         assert assert_eq(df, ddf2)
 
 def test_append(fn):
-    with tmpdir as tmp:
+    with tmpdir() as tmp:
+        df = pd.DataFrame({'i32': np.arange(1000, dtype=np.int32),
+                             'i64': np.arange(1000, dtype=np.int64),
+                             'f': np.arange(1000, dtype=np.float64),
+                             'bhello': np.random.choice(['hello', 'you', 'people'], size=1000).astype("O")})
         half = len(df) // 2
-        ddf1 = dd.from_pandas(df.iloc[:half])
-        ddf2 = dd.from_pandas(df.iloc[half:])
+        ddf1 = dd.from_pandas(df.iloc[:half], chunksize=100)
+        ddf2 = dd.from_pandas(df.iloc[half:], chunksize=100)
         ddf1.to_parquet(tmp)
         ddf2.to_parquet(tmp, append=True)
 
         ddf3 = read_parquet(tmp)
-        assert_eq(df, ddf3)
+        assert_eq(df, ddf3, check_index=False)
 
 
 def test_ordering():

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -135,6 +135,17 @@ def test_categorical():
         df.index.name = 'index'  # defaults to 'index' in this case
         assert assert_eq(df, ddf2)
 
+def test_append(fn):
+    with tmpdir as tmp:
+        half = len(df) // 2
+        ddf1 = dd.from_pandas(df.iloc[:half])
+        ddf2 = dd.from_pandas(df.iloc[half:])
+        ddf1.to_parquet(tmp)
+        ddf2.to_parquet(tmp, append=True)
+
+        ddf3 = read_parquet(tmp)
+        assert_eq(df, ddf3)
+
 
 def test_ordering():
     with tmpdir() as tmp:


### PR DESCRIPTION
Added append functionality for dask.DataFrame.to_parquet #1936. @martindurant
- columns equality check of existing parquet file and appended df
- divisions overlap check of existing parquet file and appended df
- basic test of append functionality
- documentation

