### PR TITLE
Cache tokenize normalize_function

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -269,7 +269,7 @@ def normalize_function(func):
         return function_cache[func]
     except KeyError:
         result = _normalize_function(func)
-        if len(function_cache) > 10000:  # clear half of cache if full
+        if len(function_cache) > 500:  # clear half of cache if full
             for k in list(function_cache)[::2]:
                 del function_cache[k]
         function_cache[func] = result

--- a/dask/base.py
+++ b/dask/base.py
@@ -269,6 +269,9 @@ def normalize_function(func):
         return function_cache[func]
     except KeyError:
         result = _normalize_function(func)
+        if len(function_cache) > 10000:  # clear half of cache if full
+            for k in list(function_cache)[::2]:
+                del function_cache[k]
         function_cache[func] = result
         return result
     except TypeError:  # not hashable

--- a/dask/base.py
+++ b/dask/base.py
@@ -261,7 +261,21 @@ def visualize(*args, **kwargs):
     return dot_graph(dsk, filename=filename, **kwargs)
 
 
+function_cache = {}
+
+
 def normalize_function(func):
+    try:
+        return function_cache[func]
+    except KeyError:
+        result = _normalize_function(func)
+        function_cache[func] = result
+        return result
+    except TypeError:  # not hashable
+        return _normalize_function(func)
+
+
+def _normalize_function(func):
     if isinstance(func, curry):
         func = func._partial
     if isinstance(func, Compose):

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -453,9 +453,8 @@ def test_persist_array_bag():
     assert list(b) == list(bb)
 
 
-@pytest.mark.slow
 def test_normalize_function_limited_size():
-    for i in range(11000):
+    for i in range(1000):
         normalize_function(lambda x: x)
 
-    assert 1000 < len(function_cache) < 10000
+    assert 50 < len(function_cache) < 500

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -9,7 +9,7 @@ import sys
 import dask
 from dask import delayed
 from dask.base import (compute, tokenize, normalize_token, normalize_function,
-                       visualize, persist)
+                       visualize, persist, function_cache)
 from dask.delayed import Delayed
 from dask.utils import tmpdir, tmpfile, ignoring
 from dask.utils_test import inc, dec
@@ -451,3 +451,11 @@ def test_persist_array_bag():
 
     assert np.allclose(x, xx)
     assert list(b) == list(bb)
+
+
+@pytest.mark.slow
+def test_normalize_function_limited_size():
+    for i in range(11000):
+        normalize_function(lambda x: x)
+
+    assert 1000 < len(function_cache) < 10000


### PR DESCRIPTION
This is a modest fraction of overhead when computing many small functions

cc @jcrist 