### PR TITLE
Allow `dask.bag` reductions to work on very sparse data.

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -727,8 +727,9 @@ class Bag(Base):
         depth = 0
         while k > 1:
             c = fmt + str(depth)
+            is_last = k <= split_every
             dsk2 = dict(((c, i), (empty_safe_aggregate, aggregate,
-                                  [(b, j) for j in inds]))
+                                  [(b, j) for j in inds], is_last))
                         for i, inds in enumerate(partition_all(split_every,
                                                                range(k))))
             dsk.update(dsk2)
@@ -1646,8 +1647,10 @@ def empty_safe_apply(func, part):
         return func(part)
 
 
-def empty_safe_aggregate(func, parts):
-    parts2 = [p for p in parts if not eq_strict(p, no_result)]
+def empty_safe_aggregate(func, parts, is_last):
+    parts2 = (p for p in parts if not eq_strict(p, no_result))
+    if is_last:
+        parts2 = list(parts2)
     return empty_safe_apply(func, parts2)
 
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1450,6 +1450,10 @@ def from_delayed(values):
 
 
 def merge_frequencies(seqs):
+    if isinstance(seqs, Iterable):
+        seqs = list(seqs)
+    if not seqs:
+        return {}
     first, rest = seqs[0], seqs[1:]
     if not rest:
         return first

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -687,7 +687,7 @@ class Bag(Base):
         >>> sorted(b.distinct())
         ['Alice', 'Bob']
         """
-        return self.reduction(set, curry(apply, set.union), out_type=Bag,
+        return self.reduction(set, merge_distinct, out_type=Bag,
                               name='distinct')
 
     def reduction(self, perpartition, aggregate, split_every=None,
@@ -1447,6 +1447,10 @@ def from_delayed(values):
     dsk2 = dict(zip(names, values))
 
     return Bag(merge(dsk, dsk2), name, len(values))
+
+
+def merge_distinct(seqs):
+    return set().union(*seqs)
 
 
 def merge_frequencies(seqs):

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -198,7 +198,7 @@ def test_distinct():
     assert b.distinct().name == b.distinct().name
     assert 'distinct' in b.distinct().name
     assert b.distinct().count().compute() == 5
-    bag = db.from_sequence([0]*50, npartitions=50)
+    bag = db.from_sequence([0] * 50, npartitions=50)
     assert bag.filter(None).distinct().compute() == []
 
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -198,6 +198,8 @@ def test_distinct():
     assert b.distinct().name == b.distinct().name
     assert 'distinct' in b.distinct().name
     assert b.distinct().count().compute() == 5
+    bag = db.from_sequence([0]*50, npartitions=50)
+    assert bag.filter(None).distinct().compute() == []
 
 
 def test_frequencies():

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1028,6 +1028,14 @@ def test_reduction_empty():
     assert b.filter(lambda x: x % 2 == 0).min().compute(get=dask.get) == 0
 
 
+def test_reduction_empty_aggregate():
+    b = db.from_sequence([0, 0, 0, 1], npartitions=4)
+    assert b.filter(None).min(split_every=2).compute(get=dask.get) == 1
+    with pytest.raises(ValueError):
+        b = db.from_sequence([0, 0, 0, 0], npartitions=4)
+        b.filter(None).min(split_every=2).compute(get=dask.get)
+
+
 class StrictReal(int):
     def __eq__(self, other):
         assert isinstance(other, StrictReal)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -208,6 +208,9 @@ def test_frequencies():
     assert c.name == b.frequencies().name
     assert c.name != c2.name
     assert c2.name == b.frequencies(split_every=2).name
+    bag = db.from_sequence([0, 0, 0, 0], npartitions=4)
+    bag2 = bag.filter(None).frequencies(split_every=2)
+    assert dict(bag2.compute(get=dask.get)) == {}
 
 
 def test_topk():


### PR DESCRIPTION
Now, the `aggregate` function that merges results can return `no_result` if all the inputs are also `no_results`.  However, the very last call to the `aggregate` function will not return `no_results`, so it will still error as appropriate.