### PR TITLE
Improve error message for dtype inference error

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -867,6 +867,7 @@ def test_map_blocks_dtype_inference():
         dx.map_blocks(foo)
     except Exception as e:
         assert e.args[0].startswith("`dtype` inference failed")
+        assert "Please specify the dtype explicitly" in e.args[0]
         assert 'RuntimeError' in e.args[0]
     else:
         assert False, "Should have errored"


### PR DESCRIPTION
- Don't raise in the `except` block, as this makes a less clear
  traceback
- Suggest to use the `dtype` kwarg to address the error.

Fixes #1949.