### PR TITLE
Fix bug in da.map_blocks

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -639,7 +639,7 @@ def map_blocks(func, *args, **kwargs):
         numblocks = list(arrs[0].numblocks)
     else:
         dims = broadcast_dimensions(argpairs, numblocks)
-        numblocks = [b for (_, b) in reversed(list(dims.items()))]
+        numblocks = [b for (_, b) in sorted(dims.items(), reverse=True)]
 
     if drop_axis:
         if any(numblocks[i] > 1 for i in drop_axis):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -845,6 +845,13 @@ def test_map_blocks_with_kwargs():
               np.array([4, 9]))
 
 
+def test_map_blocks_with_chunks():
+    dx = da.ones((5, 3), chunks=(2, 2))
+    dy = da.ones((5, 3), chunks=(2, 2))
+    dz = da.map_blocks(np.add, dx, dy, chunks=dx.chunks)
+    assert_eq(dz, np.ones((5, 3)) * 2)
+
+
 def test_map_blocks_dtype_inference():
     x = np.arange(50).reshape((5, 10))
     y = np.arange(10)


### PR DESCRIPTION
Previously we were accidently calling `reversed` instead of `sorted(...,
reverse=True)`, which would cause failures in `map_blocks` if chunks
were provided explicitly. Fixes #1947.