### PR TITLE
Fix when performing multiple reductions on a sparse bag.

### DIFF
--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1039,8 +1039,9 @@ def test_reduction_empty():
 
 
 def test_reduction_empty_aggregate():
-    b = db.from_sequence([0, 0, 0, 1], npartitions=4)
-    assert b.filter(None).min(split_every=2).compute(get=dask.get) == 1
+    b = db.from_sequence([0, 0, 0, 1], npartitions=4).filter(None)
+    assert b.min(split_every=2).compute(get=dask.get) == 1
+    assert db.compute(b.min(), b.max(), get=dask.get) == (1, 1)
     with pytest.raises(ValueError):
         b = db.from_sequence([0, 0, 0, 0], npartitions=4)
         b.filter(None).min(split_every=2).compute(get=dask.get)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1041,7 +1041,8 @@ def test_reduction_empty():
 def test_reduction_empty_aggregate():
     b = db.from_sequence([0, 0, 0, 1], npartitions=4).filter(None)
     assert b.min(split_every=2).compute(get=dask.get) == 1
-    assert db.compute(b.min(), b.max(), get=dask.get) == (1, 1)
+    vals = db.compute(b.min(split_every=2), b.max(split_every=2), get=dask.get)
+    assert vals == (1, 1)
     with pytest.raises(ValueError):
         b = db.from_sequence([0, 0, 0, 0], npartitions=4)
         b.filter(None).min(split_every=2).compute(get=dask.get)


### PR DESCRIPTION
When doing `db.compute(bag.min(), bag.max())`, the iterable on each partition is converted to a list so it can be passed to both reducers.  Previously, if `empty_safe_apply` was given a list, it wouldn't return `no_result`.  We are now explicit about which tasks are the final aggregations.