### PR TITLE
Correctly slice arrays with empty lists

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1188,7 +1188,7 @@ class Array(Base):
 
         # Field access, e.g. x['a'] or x[['a', 'b']]
         if (isinstance(index, (str, unicode)) or
-                (isinstance(index, list) and
+                (isinstance(index, list) and index and
                  all(isinstance(i, (str, unicode)) for i in index))):
             if isinstance(index, (str, unicode)):
                 dt = self.dtype[index]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2670,3 +2670,11 @@ def test_setitem_mixed_d():
     x[x[None, 0] > 2] = -1
     dx[dx[None, 0] > 2] = -1
     assert_eq(x, dx)
+
+
+def test_zero_slice_dtypes():
+    x = da.arange(5, chunks=1)
+    y = x[[]]
+    assert y.dtype == x.dtype
+    assert y.shape == (0,)
+    assert_eq(x[[]], np.arange(5)[[]])


### PR DESCRIPTION
Previously we were falling into the wrong branch due to the
vacuous truth of an empty all([]) condition