### PR TITLE
`dask.bag.from_delayed` may create iterators.  Reify to lists if necessary

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1444,7 +1444,7 @@ def from_delayed(values):
 
     name = 'bag-from-delayed-' + tokenize(*values)
     names = [(name, i) for i in range(len(values))]
-    values = [v.key for v in values]
+    values = [(reify, v.key) for v in values]
     dsk2 = dict(zip(names, values))
 
     return Bag(merge(dsk, dsk2), name, len(values))

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -920,9 +920,8 @@ def test_from_delayed_iterator():
         bag.count(),
         bag.pluck('operations').count(),
         bag.pluck('operations').concat().count(),
-        bag.pluck('operations').concat().pluck('bad', None).count(),
         get=dask.get,
-    ) == (25, 25, 50, 50)
+    ) == (25, 25, 50)
 
 
 def test_range():

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -908,6 +908,23 @@ def test_from_delayed():
     assert asum_value.compute() == asum_item.compute() == 6
 
 
+def test_from_delayed_iterator():
+    from dask.delayed import delayed
+
+    def lazy_records(n):
+        return ({'operations': [1, 2]} for _ in range(n))
+
+    delayed_records = delayed(lazy_records, pure=False)
+    bag = db.from_delayed([delayed_records(5) for _ in range(5)])
+    assert db.compute(
+        bag.count(),
+        bag.pluck('operations').count(),
+        bag.pluck('operations').concat().count(),
+        bag.pluck('operations').concat().pluck('bad', None).count(),
+        get=dask.get,
+    ) == (25, 25, 50, 50)
+
+
 def test_range():
     for npartitions in [1, 7, 10, 28]:
         b = db.range(100, npartitions=npartitions)


### PR DESCRIPTION
If the `delayed` functions used to create bags return iterators, then we should convert them to lists iff they are directly used by multiple tasks.  If we don't do this, then the first task will exhaust the iterator, thereby leaving nothing for the second task to operate on.

`reify` and `list` will be optimized out by the bag optimizations as appropriate.