### PR TITLE
delayed avoids repeat calls to normalize_function

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -400,13 +400,13 @@ class Delayed(base.Base):
     _get_unary_operator = _get_binary_operator
 
 
-def call_function(func, args, kwargs, pure=False, nout=None):
+def call_function(func, func_token, args, kwargs, pure=False, nout=None):
     dask_key_name = kwargs.pop('dask_key_name', None)
     pure = kwargs.pop('pure', pure)
 
     if dask_key_name is None:
-        name = '%s-%s' % (funcname(func), tokenize(func, *args,
-                                                   pure=pure, **kwargs))
+        name = '%s-%s' % (funcname(func),
+                          tokenize(func_token, *args, pure=pure, **kwargs))
     else:
         name = dask_key_name
 
@@ -442,7 +442,7 @@ class DelayedLeaf(Delayed):
         return [self.dask]
 
     def __call__(self, *args, **kwargs):
-        return call_function(self._obj, args, kwargs,
+        return call_function(self._obj, self._key, args, kwargs,
                              pure=self._pure, nout=self._nout)
 
 
@@ -459,7 +459,7 @@ class DelayedAttr(Delayed):
         return [{self._key: (getattr, self._obj._key, self._attr)}] + self._obj._dasks
 
     def __call__(self, *args, **kwargs):
-        return call_function(methodcaller(self._attr), (self._obj,) + args, kwargs)
+        return call_function(methodcaller(self._attr), self._attr, (self._obj,) + args, kwargs)
 
 
 for op in [operator.abs, operator.neg, operator.pos, operator.invert,

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -372,17 +372,17 @@ def test_name_consitent_across_instances():
 
     data = {'x': 1, 'y': 25, 'z': [1, 2, 3]}
     if PY2:
-        assert func(data)._key == 'identity-777036d61a8334229dc0eda4454830d7'
+        assert func(data)._key == 'identity-6700b857eea9a7d3079762c9a253ffbd'
     if PY3:
-        assert func(data)._key == 'identity-1de4057b4cfa0ba7faed76b9c383cc99'
+        assert func(data)._key == 'identity-84c5e2194036c17d1d97c4e3a2b90482'
 
     data = {'x': 1, 1: 'x'}
     assert func(data)._key == func(data)._key
 
     if PY2:
-        assert func(1)._key == 'identity-d3eda9ebeead15c7e491960e89605b7f'
+        assert func(1)._key == 'identity-91f02358e13dca18cde218a63fee436a'
     if PY3:
-        assert func(1)._key == 'identity-5390b9efe3ddb6ea0557139003eef253'
+        assert func(1)._key == 'identity-7126728842461bf3d2caecf7b954fa3b'
 
 
 def test_sensitive_to_partials():


### PR DESCRIPTION
We previously called ``normalize_function`` on every call to a delayed
function. This is expensive, and can be even more so if the function
requires cloudpickle. This fixes that to use a cached (but equivalent)
argument to represent the function.

Supersedes #1969.