### PR TITLE
dask.compute traverses python collections

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -7,13 +7,13 @@ import uuid
 
 from toolz import merge, unique, curry, first
 
+from . import base, threaded
+from .base import compute  # noqa: compute import for backwards compatability
+from .compatibility import apply
 from .core import quote
 from .utils import concrete, funcname, methodcaller
-from . import base
-from .compatibility import apply
-from . import threaded
 
-__all__ = ['compute', 'do', 'Delayed', 'delayed']
+__all__ = ['do', 'Delayed', 'delayed']
 
 
 def flat_unique(ls):
@@ -280,27 +280,6 @@ def delayed(obj, name=None, pure=False, nout=None, traverse=True):
 
 
 do = delayed
-
-
-def compute(*args, **kwargs):
-    """Evaluate more than one ``Delayed`` at once.
-
-    Note that the only difference between this function and
-    ``dask.base.compute`` is that this implicitly wraps python objects in
-    ``Delayed``, allowing for collections of dask objects to be computed.
-
-    Examples
-    --------
-    >>> a = delayed(1)
-    >>> b = a + 2
-    >>> c = a + 3
-    >>> compute(b, c)  # Compute both simultaneously
-    (3, 4)
-    >>> compute(a, [b, c])  # Works for lists of Delayed
-    (1, [3, 4])
-    """
-    args = [delayed(a) for a in args]
-    return base.compute(*args, **kwargs)
 
 
 def right(method):

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -330,6 +330,19 @@ def test_compute_with_literal():
     assert compute(5) == (5,)
 
 
+def test_compute_nested():
+    a = delayed(1) + 5
+    b = a + 1
+    c = a + 2
+    assert (compute({'a': a, 'b': [1, 2, b]}, (c, 2)) ==
+            ({'a': 6, 'b': [1, 2, 7]}, (8, 2)))
+
+    res = compute([a, b], c, traverse=False)
+    assert res[0][0] is a
+    assert res[0][1] is b
+    assert res[1] == 8
+
+
 @pytest.mark.skipif('not da')
 @pytest.mark.skipif(sys.flags.optimize == 2,
                     reason="graphviz exception with Python -OO flag")

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -103,15 +103,6 @@ def test_delayed_errors():
     pytest.raises(TypeError, lambda: bool(a))
 
 
-def test_compute():
-    a = delayed(1) + 5
-    b = a + 1
-    c = a + 2
-    assert compute(b, c) == (7, 8)
-    assert compute(b) == (7,)
-    assert compute([a, b], c) == ([6, 7], 8)
-
-
 def test_common_subexpressions():
     a = delayed([1, 2, 3])
     res = a[0] + a[0]

--- a/docs/source/delayed-api.rst
+++ b/docs/source/delayed-api.rst
@@ -5,7 +5,5 @@ API
 
 .. autosummary::
    delayed
-   compute
 
 .. autofunction:: delayed
-.. autofunction:: compute


### PR DESCRIPTION
Previously the top-level function ``dask.compute`` would pass through
all non-dask objects. We now wrap all python collections in
``dask.delayed``, allowing ``compute`` to handle builtin python
collections containing dask objects. Fixes #1968.