### PR TITLE
Deprecate dask.delayed `compute` and `do`

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -4,7 +4,7 @@ from .core import istask
 from .context import set_options
 from .async import get_sync as get
 try:
-    from .delayed import do, delayed, value
+    from .delayed import do, delayed
 except ImportError:
     pass
 try:

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -4,16 +4,16 @@ from collections import Iterator
 from itertools import chain
 import operator
 import uuid
+import warnings
 
 from toolz import merge, unique, curry, first
 
 from . import base, threaded
-from .base import compute  # noqa: compute import for backwards compatability
 from .compatibility import apply
 from .core import quote
 from .utils import concrete, funcname, methodcaller
 
-__all__ = ['do', 'Delayed', 'delayed']
+__all__ = ['Delayed', 'delayed']
 
 
 def flat_unique(ls):
@@ -280,6 +280,20 @@ def delayed(obj, name=None, pure=False, nout=None, traverse=True):
 
 
 do = delayed
+
+
+def do(*args, **kwargs):
+    """deprecated, please use ``dask.delayed.delayed``"""
+    warnings.warn("`dask.delayed.do` is deprecated, please use "
+                  "`dask.delayed.delayed` instead")
+    return delayed(*args, **kwargs)
+
+
+def compute(*args, **kwargs):
+    """deprecated, please use ``dask.compute``"""
+    warnings.warn("`dask.delayed.compute` is deprecated, please use "
+                  "`dask.compute` instead")
+    return base.compute(*args, **kwargs)
 
 
 def right(method):


### PR DESCRIPTION
``dask.delayed.compute`` was removed in #1975, and was made a simple
alias to ``dask.base.compute``. This deprecates the function found here,
and redirects users to import from elsewhere.

``dask.delayed.do`` was renamed to ``dask.delayed.delayed`` in #1085,
making ``dask.delayed.do`` a simple alias. This PR deprecates that
alias. Users can always import ``dask.delayed`` as an alias if needed:

```
from dask import delayed as do
```