### PR TITLE
#1964. Fuse tasks that form reductions (aka diamond fuse)

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -28,7 +28,7 @@ def optimize(dsk, keys, fuse_keys=None, fast_functions=None,
 
     dsk2, dependencies = cull(dsk, keys)
     dsk4, dependencies = fuse(dsk2, keys + (fuse_keys or []), dependencies,
-                              rename_fused_keys=rename_fused_keys)
+                              rename_keys=rename_fused_keys)
     dsk5 = optimize_slices(dsk4)
     dsk6 = inline_functions(dsk5, keys, dependencies=dependencies,
                             fast_functions=inline_functions_fast_functions)

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -74,14 +74,14 @@ def test_optimize_slicing():
            'e': (getarray, 'd', (slice(None, None, None),))}
 
     expected = {'e': (getarray, (range, 10), (slice(0, 5, None),))}
-    result = optimize_slices(fuse(dsk, [], rename_fused_keys=False)[0])
+    result = optimize_slices(fuse(dsk, [], rename_keys=False)[0])
     assert result == expected
 
     # protect output keys
     expected = {'c': (getarray, (range, 10), (slice(0, None, None),)),
                 'd': (getarray, 'c', (slice(0, 5, None),)),
                 'e': (getarray, 'd', (slice(None, None, None),))}
-    result = optimize_slices(fuse(dsk, ['c', 'd', 'e'], rename_fused_keys=False)[0])
+    result = optimize_slices(fuse(dsk, ['c', 'd', 'e'], rename_keys=False)[0])
 
     assert result == expected
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -109,7 +109,7 @@ def optimize(dsk, keys, fuse_keys=None, rename_fused_keys=True, **kwargs):
     """ Optimize a dask from a dask.bag """
     dsk2, dependencies = cull(dsk, keys)
     dsk3, dependencies = fuse(dsk2, keys + (fuse_keys or []), dependencies,
-                              rename_fused_keys=rename_fused_keys)
+                              rename_keys=rename_fused_keys)
     dsk4 = inline_singleton_lists(dsk3, dependencies)
     dsk5 = lazify(dsk4)
     return dsk5

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -514,21 +514,19 @@ def fuse_reductions(dsk, keys=None, ave_width=2, max_depth_new_edges=None,
         children_stack.append(parent)
         children_stack.extend(reducible & deps[parent])
         while True:
-            child = children_stack[-1]
+            child = children_stack.pop()
             if child != parent:
                 children = reducible & deps[child]
                 if children:
                     # Depth-first search
+                    children_stack.append(child)
                     children_stack.extend(children)
                     parent = child
-                    continue
-                # This is a leaf node in the reduction region
-                # key, task, height, width, number of nodes, set of edges
-                info_stack.append((child, dsk[child], 0, 1, 1, deps[child] - reducible))
-                child = children_stack.pop()
-
-            if child == parent:
-                children_stack.pop()
+                else:
+                    # This is a leaf node in the reduction region
+                    # key, task, height, width, number of nodes, set of edges
+                    info_stack.append((child, dsk[child], 0, 1, 1, deps[child] - reducible))
+            else:
                 # Calculate metrics and fuse as appropriate
                 edges = deps[parent] - reducible
                 num_children = len(deps[parent]) - len(edges)

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -475,16 +475,13 @@ def fuse_reductions(dsk, keys=None, dependencies=None, ave_width=None, max_width
         Don't fuse if total width is greater than this
 
     """
-    # XXX: uncomment to allow `fuse_reducible` to run against the `fuse` tests
-    # if rename_fused_keys:
-    #     return fuse(dsk, keys=keys, dependencies=dependencies, rename_fused_keys=True)
     if keys is not None and not isinstance(keys, set):
         if not isinstance(keys, list):
             keys = [keys]
         keys = set(flatten(keys))
 
     # Assign reasonable, not too restrictive defaults
-    ave_width = ave_width or _globals.get('fuse_ave_width') or 1
+    ave_width = ave_width or _globals.get('fuse_ave_width') or 2
     max_height = max_height or _globals.get('fuse_max_height') or len(dsk)
     max_depth_new_edges = (
         max_depth_new_edges or
@@ -564,7 +561,9 @@ def fuse_reductions(dsk, keys=None, dependencies=None, ave_width=None, max_width
 
                 edges |= children_edges
                 # Fudge factor to account for possible parallelism with the boundaries
-                num_nodes += min(num_children - 1, max(0, len(edges) - max_num_edges))
+                num_nodes += min(num_children - 1, max(0, len(children_edges) - max_num_edges))
+                if len(edges) > len(children_edges):
+                    num_nodes += 1
                 if (
                     width <= max_width and
                     height <= max_height and

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -10,7 +10,7 @@ from .compatibility import unicode
 from .context import _globals
 from .core import add, inc  # noqa: F401
 from .core import (istask, get_dependencies, subs, toposort, flatten,
-                   reverse_dict, ishashable)
+                   reverse_dict, ishashable, _get_recursive)
 
 
 def cull(dsk, keys):
@@ -479,8 +479,19 @@ def default_fused_keys_renamer3(keys_tree):
         return ('-'.join(names),) + first_key[1:]
 
 
+def fancy_subs(task, children, deps):
+    deps = tuple(deps)
+    keys, vals = zip(*children.items())
+    return (fancy_get, {'task': task, 'keys': deps + keys},) + deps + vals
+
+
+def fancy_get(delayed_task, *vals):
+    subdsk = dict(zip(delayed_task['keys'], vals))
+    return _get_recursive(subdsk, delayed_task['task'])
+
+
 def fuse_reductions(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
-                    max_height=None, max_depth_new_edges=None, rename_keys=None):
+                    max_height=None, max_depth_new_edges=None, rename_keys=None, is_fancy=False):
     """ Fuse tasks that form reductions; a more advanced version of ``fuse``
 
     This trades parallelism opportunities for faster scheduling by making
@@ -553,7 +564,7 @@ def fuse_reductions(dsk, keys=None, dependencies=None, ave_width=None, max_width
         key_renamer = rename_keys
 
     if dependencies is None:
-        deps = {k: get_dependencies(dsk, k, as_list=True) for k in dsk}
+        deps = {k: get_dependencies(dsk, k, as_list=not is_fancy) for k in dsk}
     else:
         deps = dict(dependencies)
 
@@ -633,11 +644,14 @@ def fuse_reductions(dsk, keys=None, dependencies=None, ave_width=None, max_width
                         # Sanity check; don't go too deep if new levels introduce new edge dependencies
                         (no_new_edges or height < max_depth_new_edges)
                     ):
-                        # Perform substitutions as we go
-                        val = subs(dsk[parent], child_key, child_task)
-                        del rv[child_key]
                         deps_parent.remove(child_key)
                         deps_parent |= deps_pop(child_key)
+                        # Perform substitutions as we go
+                        if is_fancy:
+                            val = fancy_subs(dsk[parent], {child_key: child_task}, deps_parent)
+                        else:
+                            val = subs(dsk[parent], child_key, child_task)
+                        del rv[child_key]
                         reducible_remove(child_key)
                         if key_renamer is not None:
                             child_keys.append(parent)
@@ -710,17 +724,23 @@ def fuse_reductions(dsk, keys=None, dependencies=None, ave_width=None, max_width
                     ):
                         # Perform substitutions as we go
                         val = dsk[parent]
+                        fancy_children = {}
                         for child_info in children_info:
                             cur_child = child_info[0]
-                            val = subs(val, cur_child, child_info[1])
+                            if is_fancy:
+                                fancy_children[cur_child] = child_info[1]
+                            else:
+                                val = subs(val, cur_child, child_info[1])
                             del rv[cur_child]
                             deps_parent |= deps_pop(cur_child)
                             reducible_remove(cur_child)
                             if key_renamer is not None:
                                 fused_trees_pop(cur_child, None)
                                 child_keys.extend(child_info[2])
-
                         deps_parent -= children
+                        if is_fancy:
+                            val = fancy_subs(val, fancy_children, deps_parent)
+
                         if key_renamer is not None:
                             child_keys.append(parent)
                             fused_trees[parent] = child_keys

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -75,12 +75,14 @@ def default_fused_keys_renamer(keys):
         return None
 
 
-def fuse(dsk, keys=None, dependencies=None, rename_keys=True):
+def fuse_linear(dsk, keys=None, dependencies=None, rename_keys=True):
     """ Return new dask graph with linear sequence of tasks fused together.
 
     If specified, the keys in ``keys`` keyword argument are *not* fused.
     Supply ``dependencies`` from output of ``cull`` if available to avoid
     recomputing dependencies.
+
+    **This function is mostly superseded by ``fuse``**
 
     Parameters
     ----------
@@ -431,7 +433,7 @@ def fuse_getitem(dsk, func, place):
 
 
 def default_fused_keys_renamer2(keys_tree):
-    """Create new keys for ``fuse_reductions`` tasks"""
+    """Create new keys for ``fuse`` tasks"""
     first_key = keys_tree[0]
     typ = type(first_key)
     flattened_keys = []
@@ -458,7 +460,7 @@ def default_fused_keys_renamer2(keys_tree):
 
 
 def default_fused_keys_renamer3(keys_tree):
-    """Create new keys for ``fuse_reductions`` tasks"""
+    """Create new keys for ``fuse`` tasks"""
     it = reversed(keys_tree)
     first_key = next(it)
     typ = type(first_key)
@@ -497,8 +499,8 @@ def fancy_get(delayed_task, *vals):
     return _get_recursive(subdsk, delayed_task['task'])
 
 
-def fuse_reductions(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
-                    max_height=None, max_depth_new_edges=None, rename_keys=None, is_fancy=False):
+def fuse(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
+         max_height=None, max_depth_new_edges=None, rename_keys=None, is_fancy=False):
     """ Fuse tasks that form reductions; a more advanced version of ``fuse``
 
     This trades parallelism opportunities for faster scheduling by making

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -490,7 +490,7 @@ def fuse_reductions(dsk, keys=None, dependencies=None, ave_width=2,
     if dependencies is None:
         deps = {k: get_dependencies(dsk, k, as_list=True) for k in dsk}
     else:
-        deps = dict(deps)
+        deps = dict(dependencies)
 
     rdeps = {}
     for k, vals in deps.items():

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -511,9 +511,8 @@ def fuse_reductions(dsk, keys=None, ave_width=2, max_depth_new_edges=None,
     while reducible:
         child = next(iter(reducible))
         parent = rdeps[child][0]
-        siblings = reducible & deps[parent]
         children_stack.append(parent)
-        children_stack.extend(siblings)
+        children_stack.extend(reducible & deps[parent])
         while True:
             child = children_stack[-1]
             if child != parent:
@@ -571,7 +570,11 @@ def fuse_reductions(dsk, keys=None, ave_width=2, max_depth_new_edges=None,
                         reducible.remove(child_info[0])
                     if parent in reducible:
                         # key, task, height, width, number of nodes, set of edges
-                        info_stack.append((parent, val, height + 1, width, num_nodes + 1, edges))
+                        if num_children == 1 and len(edges) == len(children_edges):
+                            # Linear fuse
+                            info_stack.append((parent, val, height, width, num_nodes, edges))
+                        else:
+                            info_stack.append((parent, val, height + 1, width, num_nodes + 1, edges))
                     else:
                         rv[parent] = val
                         break

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -513,7 +513,7 @@ def fuse_reductions(dsk, keys=None, ave_width=2, max_depth_new_edges=10,
                 continue
 
             # Prepare and handle fusing
-            if len(children_stack) > 1 or not num_processing:
+            if children_stack[-1] != parent or not num_processing:
                 # This is a leaf node in the reduction region
                 edges = irreducible.intersection(deps[child])
                 # key, task, height, width, number of nodes, set of edges
@@ -522,57 +522,59 @@ def fuse_reductions(dsk, keys=None, ave_width=2, max_depth_new_edges=10,
 
             if children_stack and children_stack[-1] == parent:
                 # Fuse as appropriate
+                is_fused = False
                 children_stack.pop()
                 num_children = num_processing.pop()
+                if num_children > 0:
+                    height = 1
+                    width = 0
+                    num_single_nodes = 0
+                    num_nodes = 0
+                    edges = set()
+                    max_num_edges = 0
+                    children_info = info_stack[-num_children:]
+                    del info_stack[-num_children:]
+                    for cur_key, cur_task, cur_height, cur_width, cur_num_nodes, cur_edges in children_info:
+                        if cur_height == 0:
+                            num_single_nodes += 1
+                        elif cur_height > height:
+                            height = cur_height
+                        width += cur_width
+                        num_nodes += cur_num_nodes
+                        if len(cur_edges) > max_num_edges:
+                            max_num_edges = len(cur_edges)
+                        edges |= cur_edges
 
-                height = 1
-                width = 0
-                num_single_nodes = 0
-                num_nodes = 0
-                edges = set()
-                max_num_edges = 0
-                children_info = info_stack[-num_children:]
-                del info_stack[-num_children:]
-                for cur_key, cur_task, cur_height, cur_width, cur_num_nodes, cur_edges in children_info:
-                    if cur_height == 0:
-                        num_single_nodes += 1
-                    elif cur_height > height:
-                        height = cur_height
-                    width += cur_width
-                    num_nodes += cur_num_nodes
-                    if len(cur_edges) > max_num_edges:
-                        max_num_edges = len(cur_edges)
-                    edges |= cur_edges
-
-                is_fused = False
-                if (
-                    width <= max_width and
-                    height <= max_height and
-                    num_single_nodes <= ave_width and
-                    num_nodes / height <= ave_width
-                ):
-                    parent_edges = irreducible.intersection(deps[parent])
-                    len_wo_parent = len(edges)
-                    edges |= parent_edges
-                    # Sanity check; don't go too deep if new levels introduce new edge dependencies
-                    if len(edges) <= len_wo_parent and height < max_depth_new_edges:
-                        if len(parent_edges) > max_num_edges:
-                            max_num_edges = len(parent_edges)
-                        # Fudge factor to account for possible parallelism with the boundaries
-                        num_nodes += min(num_children - 1, len(edges) - max_num_edges)
-                        if num_nodes / height <= ave_width:
-                            # Perform substitutions as we go
-                            val = dsk[parent]
-                            for child_info in children_info:
-                                val = subs(val, child_info[0], child_info[1])
-                                del rv[child_info[0]]
-                            # key, task, height, width, number of nodes, set of edges
-                            info_stack.append((parent, val, height + 1, width, num_nodes + 1, edges))
-                            is_fused = True
+                    if (
+                        width <= max_width and
+                        height <= max_height and
+                        num_single_nodes <= ave_width and
+                        num_nodes / height <= ave_width
+                    ):
+                        parent_edges = irreducible.intersection(deps[parent])
+                        len_wo_parent = len(edges)
+                        edges |= parent_edges
+                        # Sanity check; don't go too deep if new levels introduce new edge dependencies
+                        if len(edges) <= len_wo_parent and height < max_depth_new_edges:
+                            if len(parent_edges) > max_num_edges:
+                                max_num_edges = len(parent_edges)
+                            # Fudge factor to account for possible parallelism with the boundaries
+                            num_nodes += min(num_children - 1, len(edges) - max_num_edges)
+                            if num_nodes / height <= ave_width:
+                                # Perform substitutions as we go
+                                val = dsk[parent]
+                                for child_info in children_info:
+                                    val = subs(val, child_info[0], child_info[1])
+                                    del rv[child_info[0]]
+                                # key, task, height, width, number of nodes, set of edges
+                                info_stack.append((parent, val, height + 1, width, num_nodes + 1, edges))
+                                is_fused = True
 
                 if not is_fused:
                     for child_info in children_info:
                         rv[child_info[0]] = child_info[1]
+                    if num_processing:
+                        num_processing[-1] -= 1
 
                 if num_processing:
                     parent = rdeps[parent][0]
@@ -587,7 +589,7 @@ def fuse_reductions(dsk, keys=None, ave_width=2, max_depth_new_edges=10,
                 reducible.discard(parent)
                 siblings = reducible.intersection(deps[new_parent])
                 if siblings:
-                    num_processing.append(len(siblings) + 1)
+                    num_processing.append(len(siblings) + len(info_stack))
                     children_stack = [new_parent] + list(siblings)
                     reducible -= siblings
                     parent = new_parent

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -876,4 +876,4 @@ def test_fuse_reductions_multiple_input():
     )
     # XXX: A more aggressive heuristic could do this at `ave_width=2`.  Perhaps
     # we can improve this.  Nevertheless, this is behaving as intended.
-    assert fuse_reductions(d, ave_width=4) == expected
+    assert fuse_reductions(d, ave_width=3) == expected

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -947,7 +947,8 @@ def test_fuse_stressed():
         ('cholesky-upper-26a6b670a8aabb7e2f8936db7ccb6a88', 1, 0),
         ('cholesky-upper-26a6b670a8aabb7e2f8936db7ccb6a88', 1, 1),
     }
-    fuse(d, keys=keys, ave_width=2, rename_keys=True)
+    rv = fuse(d, keys=keys, ave_width=2, rename_keys=True)
+    assert rv == with_deps(rv[0])
 
 
 def test_fuse_reductions_multiple_input():

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -449,3 +449,135 @@ def test_fuse_reductions_single_input():
         'd': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
     }
     assert fuse_reductions(d, ave_width=3) == expected
+
+    d = {
+        'a': 1,
+        'b1': (f, 'a'),
+        'b2': (f, 'a'),
+        'b3': (f, 'a'),
+        'b4': (f, 'a'),
+        'b5': (f, 'a'),
+        'b6': (f, 'a'),
+        'b7': (f, 'a'),
+        'b8': (f, 'a'),
+        'c1': (f, 'b1', 'b2'),
+        'c2': (f, 'b3', 'b4'),
+        'c3': (f, 'b5', 'b6'),
+        'c4': (f, 'b7', 'b8'),
+        'd1': (f, 'c1', 'c2'),
+        'd2': (f, 'c3', 'c4'),
+        'e': (f, 'd1', 'd2'),
+    }
+    assert fuse_reductions(d, ave_width=1.9) == d
+    expected = {
+        'a': 1,
+        'c1': (f, (f, 'a'), (f, 'a')),
+        'c2': (f, (f, 'a'), (f, 'a')),
+        'c3': (f, (f, 'a'), (f, 'a')),
+        'c4': (f, (f, 'a'), (f, 'a')),
+        'd1': (f, 'c1', 'c2'),
+        'd2': (f, 'c3', 'c4'),
+        'e': (f, 'd1', 'd2'),
+    }
+    assert fuse_reductions(d, ave_width=2) == expected
+    assert fuse_reductions(d, ave_width=2.9) == expected
+    expected = {
+        'a': 1,
+        'd1': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+        'd2': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+        'e': (f, 'd1', 'd2'),
+    }
+    assert fuse_reductions(d, ave_width=3) == expected
+    assert fuse_reductions(d, ave_width=4.6) == expected
+    expected = {
+        'a': 1,
+        'e': (f, (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+              (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))))
+    }
+    assert fuse_reductions(d, ave_width=4.7) == expected
+
+    d = {
+        'a': 1,
+        'b1': (f, 'a'),
+        'b2': (f, 'a'),
+        'b3': (f, 'a'),
+        'b4': (f, 'a'),
+        'b5': (f, 'a'),
+        'b6': (f, 'a'),
+        'b7': (f, 'a'),
+        'b8': (f, 'a'),
+        'b9': (f, 'a'),
+        'b10': (f, 'a'),
+        'b11': (f, 'a'),
+        'b12': (f, 'a'),
+        'b13': (f, 'a'),
+        'b14': (f, 'a'),
+        'b15': (f, 'a'),
+        'b16': (f, 'a'),
+        'c1': (f, 'b1', 'b2'),
+        'c2': (f, 'b3', 'b4'),
+        'c3': (f, 'b5', 'b6'),
+        'c4': (f, 'b7', 'b8'),
+        'c5': (f, 'b9', 'b10'),
+        'c6': (f, 'b11', 'b12'),
+        'c7': (f, 'b13', 'b14'),
+        'c8': (f, 'b15', 'b16'),
+        'd1': (f, 'c1', 'c2'),
+        'd2': (f, 'c3', 'c4'),
+        'd3': (f, 'c5', 'c6'),
+        'd4': (f, 'c7', 'c8'),
+        'e1': (f, 'd1', 'd2'),
+        'e2': (f, 'd3', 'd4'),
+        'f': (f, 'e1', 'e2'),
+    }
+    assert fuse_reductions(d, ave_width=1.9) == d
+    expected = {
+        'a': 1,
+        'c1': (f, (f, 'a'), (f, 'a')),
+        'c2': (f, (f, 'a'), (f, 'a')),
+        'c3': (f, (f, 'a'), (f, 'a')),
+        'c4': (f, (f, 'a'), (f, 'a')),
+        'c5': (f, (f, 'a'), (f, 'a')),
+        'c6': (f, (f, 'a'), (f, 'a')),
+        'c7': (f, (f, 'a'), (f, 'a')),
+        'c8': (f, (f, 'a'), (f, 'a')),
+        'd1': (f, 'c1', 'c2'),
+        'd2': (f, 'c3', 'c4'),
+        'd3': (f, 'c5', 'c6'),
+        'd4': (f, 'c7', 'c8'),
+        'e1': (f, 'd1', 'd2'),
+        'e2': (f, 'd3', 'd4'),
+        'f': (f, 'e1', 'e2'),
+    }
+    assert fuse_reductions(d, ave_width=2) == expected
+    assert fuse_reductions(d, ave_width=2.9) == expected
+    expected = {
+        'a': 1,
+        'd1': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+        'd2': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+        'd3': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+        'd4': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+        'e1': (f, 'd1', 'd2'),
+        'e2': (f, 'd3', 'd4'),
+        'f': (f, 'e1', 'e2'),
+    }
+    assert fuse_reductions(d, ave_width=3) == expected
+    assert fuse_reductions(d, ave_width=4.6) == expected
+    expected = {
+        'a': 1,
+        'e1': (f, (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+               (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a')))),
+        'e2': (f, (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+               (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a')))),
+        'f': (f, 'e1', 'e2'),
+    }
+    assert fuse_reductions(d, ave_width=4.7) == expected
+    assert fuse_reductions(d, ave_width=7.4) == expected
+    expected = {
+        'a': 1,
+        'f': (f, (f, (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+                  (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a')))),
+              (f, (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+               (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))))),
+    }
+    assert fuse_reductions(d, ave_width=7.5, max_width=16) == expected

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -607,6 +607,65 @@ def test_fuse_reductions_single_input():
     }
     assert fuse_reductions(d, ave_width=1) == {'d': (f, (f, (f, 1)))}
 
+    d = {
+        'a': 1,
+        'b': (f, 'a'),
+        'c': (f, 'a', 'b'),
+        'd': (f, 'a', 'c'),
+    }
+    assert fuse_reductions(d, ave_width=1) == {
+        'a': 1,
+        'd': (f, 'a', (f, 'a', (f, 'a'))),
+    }
+
+    d = {
+        'a': 1,
+        'b1': (f, 'a'),
+        'b2': (f, 'a'),
+        'c1': (f, 'b1'),
+        'd1': (f, 'c1'),
+        'e1': (f, 'd1'),
+        'f': (f, 'e1', 'b2'),
+    }
+    expected = {
+        'a': 1,
+        'b2': (f, 'a'),
+        'e1': (f, (f, (f, (f, 'a')))),
+        'f': (f, 'e1', 'b2'),
+
+    }
+    assert fuse_reductions(d, ave_width=1) == expected
+    assert fuse_reductions(d, ave_width=1.9) == expected
+    expected = {
+        'a': 1,
+        'f': (f, (f, (f, (f, (f, 'a')))), (f, 'a')),
+    }
+    assert fuse_reductions(d, ave_width=2) == expected
+
+    d = {
+        'a': 1,
+        'b1': (f, 'a'),
+        'b2': (f, 'a'),
+        'c1': (f, 'a', 'b1'),
+        'd1': (f, 'a', 'c1'),
+        'e1': (f, 'a', 'd1'),
+        'f': (f, 'a', 'e1', 'b2'),
+    }
+    expected = {
+        'a': 1,
+        'b2': (f, 'a'),
+        'e1': (f, 'a', (f, 'a', (f, 'a', (f, 'a')))),
+        'f': (f, 'a', 'e1', 'b2'),
+
+    }
+    assert fuse_reductions(d, ave_width=1) == expected
+    assert fuse_reductions(d, ave_width=1.9) == expected
+    expected = {
+        'a': 1,
+        'f': (f, 'a', (f, 'a', (f, 'a', (f, 'a', (f, 'a')))), (f, 'a')),
+    }
+    assert fuse_reductions(d, ave_width=2) == expected
+
 
 def test_fuse_reductions_multiple_input():
     def f(*args):

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -26,6 +26,7 @@ def test_cull():
 
 
 def test_fuse():
+    # fuse = fuse_reductions  # XXX
     d = {
         'w': (inc, 'x'),
         'x': (inc, 'y'),
@@ -186,6 +187,7 @@ def test_fuse():
 
 
 def test_fuse_keys():
+    # fuse = fuse_reductions  # XXX
     d = {
         'a': 1,
         'b': (inc, 'a'),
@@ -399,7 +401,7 @@ def test_fuse_reductions_single_input():
             'a': 1,
             'c': (f, (f, 'a'), (f, 'a', 'a')),
         },
-        {'a': set(), 'c': {'a', 'b1', 'b2'}}
+        {'a': set(), 'c': {'a'}}
     )
 
     d = {

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -380,7 +380,7 @@ def test_inline_cull_dependencies():
     inline(d2, {'b'}, dependencies=dependencies)
 
 
-def test_fuse_reductions():
+def test_fuse_reductions_single_input():
     def f(*args):
         return args
 
@@ -424,3 +424,28 @@ def test_fuse_reductions():
         'e': (f, (f, 'c'), (f, 'c')),
     }
     assert fuse_reductions(d, ave_width=1.9) == d
+
+    d = {
+        'a': 1,
+        'b1': (f, 'a'),
+        'b2': (f, 'a'),
+        'b3': (f, 'a'),
+        'b4': (f, 'a'),
+        'c1': (f, 'b1', 'b2'),
+        'c2': (f, 'b3', 'b4'),
+        'd': (f, 'c1', 'c2'),
+    }
+    assert fuse_reductions(d, ave_width=1.9) == d
+    expected = {
+        'a': 1,
+        'c1': (f, (f, 'a'), (f, 'a')),
+        'c2': (f, (f, 'a'), (f, 'a')),
+        'd': (f, 'c1', 'c2'),
+    }
+    assert fuse_reductions(d, ave_width=2) == expected
+    assert fuse_reductions(d, ave_width=2.9) == expected
+    expected = {
+        'a': 1,
+        'd': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
+    }
+    assert fuse_reductions(d, ave_width=3) == expected

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -592,7 +592,7 @@ def test_fuse_reductions_single_input():
               (f, (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
                (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))))),
     }
-    assert fuse_reductions(d, ave_width=7.5, max_width=16) == expected
+    assert fuse_reductions(d, ave_width=7.5) == expected
 
     d = {
         'a': 1,
@@ -608,7 +608,7 @@ def test_fuse_reductions_single_input():
     assert fuse_reductions(d, ave_width=1) == {'d': (f, (f, (f, 1)))}
 
 
-def test_fuse_reductions__input():
+def test_fuse_reductions_multiple_input():
     def f(*args):
         return args
 

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -390,11 +390,17 @@ def test_fuse_reductions_single_input():
         'b2': (f, 'a', 'a'),
         'c': (f, 'b1', 'b2'),
     }
-    assert fuse_reductions(d, ave_width=1.9) == d
-    assert fuse_reductions(d, ave_width=2) == {
-        'a': 1,
-        'c': (f, (f, 'a'), (f, 'a', 'a')),
-    }
+    assert fuse_reductions(d, ave_width=1.9) == (
+        d,
+        {'a': set(), 'b1': {'a'}, 'b2': {'a'}, 'c': {'b2', 'b1'}}
+    )
+    assert fuse_reductions(d, ave_width=2) == (
+        {
+            'a': 1,
+            'c': (f, (f, 'a'), (f, 'a', 'a')),
+        },
+        {'a': set(), 'c': {'a', 'b1', 'b2'}}
+    )
 
     d = {
         'a': 1,
@@ -403,11 +409,11 @@ def test_fuse_reductions_single_input():
         'b3': (f, 'a', 'a', 'a'),
         'c': (f, 'b1', 'b2', 'b3'),
     }
-    assert fuse_reductions(d, ave_width=3) == {
+    assert fuse_reductions(d, ave_width=3)[0] == {
         'a': 1,
         'c': (f, (f, 'a'), (f, 'a', 'a'), (f, 'a', 'a', 'a')),
     }
-    assert fuse_reductions(d, ave_width=2.9) == d
+    assert fuse_reductions(d, ave_width=2.9)[0] == d
 
     d = {
         'a': 1,
@@ -415,8 +421,8 @@ def test_fuse_reductions_single_input():
         'b2': (f, 'a'),
         'c': (f, 'a', 'b1', 'b2'),
     }
-    assert fuse_reductions(d, ave_width=1.9) == d
-    assert fuse_reductions(d, ave_width=2) == {
+    assert fuse_reductions(d, ave_width=1.9)[0] == d
+    assert fuse_reductions(d, ave_width=2)[0] == {
         'a': 1,
         'c': (f, 'a', (f, 'a'), (f, 'a')),
     }
@@ -430,12 +436,12 @@ def test_fuse_reductions_single_input():
         'd2': (f, 'c'),
         'e': (f, 'd1', 'd2'),
     }
-    assert fuse_reductions(d, ave_width=2) == {
+    assert fuse_reductions(d, ave_width=2)[0] == {
         'a': 1,
         'c': (f, (f, 'a'), (f, 'a')),
         'e': (f, (f, 'c'), (f, 'c')),
     }
-    assert fuse_reductions(d, ave_width=1.9) == d
+    assert fuse_reductions(d, ave_width=1.9)[0] == d
 
     d = {
         'a': 1,
@@ -447,20 +453,20 @@ def test_fuse_reductions_single_input():
         'c2': (f, 'b3', 'b4'),
         'd': (f, 'c1', 'c2'),
     }
-    assert fuse_reductions(d, ave_width=1.9) == d
+    assert fuse_reductions(d, ave_width=1.9)[0] == d
     expected = {
         'a': 1,
         'c1': (f, (f, 'a'), (f, 'a')),
         'c2': (f, (f, 'a'), (f, 'a')),
         'd': (f, 'c1', 'c2'),
     }
-    assert fuse_reductions(d, ave_width=2) == expected
-    assert fuse_reductions(d, ave_width=2.9) == expected
+    assert fuse_reductions(d, ave_width=2)[0] == expected
+    assert fuse_reductions(d, ave_width=2.9)[0] == expected
     expected = {
         'a': 1,
         'd': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
     }
-    assert fuse_reductions(d, ave_width=3) == expected
+    assert fuse_reductions(d, ave_width=3)[0] == expected
 
     d = {
         'a': 1,
@@ -480,7 +486,7 @@ def test_fuse_reductions_single_input():
         'd2': (f, 'c3', 'c4'),
         'e': (f, 'd1', 'd2'),
     }
-    assert fuse_reductions(d, ave_width=1.9) == d
+    assert fuse_reductions(d, ave_width=1.9)[0] == d
     expected = {
         'a': 1,
         'c1': (f, (f, 'a'), (f, 'a')),
@@ -491,22 +497,22 @@ def test_fuse_reductions_single_input():
         'd2': (f, 'c3', 'c4'),
         'e': (f, 'd1', 'd2'),
     }
-    assert fuse_reductions(d, ave_width=2) == expected
-    assert fuse_reductions(d, ave_width=2.9) == expected
+    assert fuse_reductions(d, ave_width=2)[0] == expected
+    assert fuse_reductions(d, ave_width=2.9)[0] == expected
     expected = {
         'a': 1,
         'd1': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
         'd2': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
         'e': (f, 'd1', 'd2'),
     }
-    assert fuse_reductions(d, ave_width=3) == expected
-    assert fuse_reductions(d, ave_width=4.6) == expected
+    assert fuse_reductions(d, ave_width=3)[0] == expected
+    assert fuse_reductions(d, ave_width=4.6)[0] == expected
     expected = {
         'a': 1,
         'e': (f, (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
               (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))))
     }
-    assert fuse_reductions(d, ave_width=4.7) == expected
+    assert fuse_reductions(d, ave_width=4.7)[0] == expected
 
     d = {
         'a': 1,
@@ -542,7 +548,7 @@ def test_fuse_reductions_single_input():
         'e2': (f, 'd3', 'd4'),
         'f': (f, 'e1', 'e2'),
     }
-    assert fuse_reductions(d, ave_width=1.9) == d
+    assert fuse_reductions(d, ave_width=1.9)[0] == d
     expected = {
         'a': 1,
         'c1': (f, (f, 'a'), (f, 'a')),
@@ -561,8 +567,8 @@ def test_fuse_reductions_single_input():
         'e2': (f, 'd3', 'd4'),
         'f': (f, 'e1', 'e2'),
     }
-    assert fuse_reductions(d, ave_width=2) == expected
-    assert fuse_reductions(d, ave_width=2.9) == expected
+    assert fuse_reductions(d, ave_width=2)[0] == expected
+    assert fuse_reductions(d, ave_width=2.9)[0] == expected
     expected = {
         'a': 1,
         'd1': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
@@ -573,8 +579,8 @@ def test_fuse_reductions_single_input():
         'e2': (f, 'd3', 'd4'),
         'f': (f, 'e1', 'e2'),
     }
-    assert fuse_reductions(d, ave_width=3) == expected
-    assert fuse_reductions(d, ave_width=4.6) == expected
+    assert fuse_reductions(d, ave_width=3)[0] == expected
+    assert fuse_reductions(d, ave_width=4.6)[0] == expected
     expected = {
         'a': 1,
         'e1': (f, (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
@@ -583,8 +589,8 @@ def test_fuse_reductions_single_input():
                (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a')))),
         'f': (f, 'e1', 'e2'),
     }
-    assert fuse_reductions(d, ave_width=4.7) == expected
-    assert fuse_reductions(d, ave_width=7.4) == expected
+    assert fuse_reductions(d, ave_width=4.7)[0] == expected
+    assert fuse_reductions(d, ave_width=7.4)[0] == expected
     expected = {
         'a': 1,
         'f': (f, (f, (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
@@ -592,20 +598,20 @@ def test_fuse_reductions_single_input():
               (f, (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
                (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))))),
     }
-    assert fuse_reductions(d, ave_width=7.5) == expected
+    assert fuse_reductions(d, ave_width=7.5)[0] == expected
 
     d = {
         'a': 1,
         'b': (f, 'a'),
     }
-    assert fuse_reductions(d, ave_width=1) == {'b': (f, 1)}
+    assert fuse_reductions(d, ave_width=1)[0] == {'b': (f, 1)}
     d = {
         'a': 1,
         'b': (f, 'a'),
         'c': (f, 'b'),
         'd': (f, 'c'),
     }
-    assert fuse_reductions(d, ave_width=1) == {'d': (f, (f, (f, 1)))}
+    assert fuse_reductions(d, ave_width=1)[0] == {'d': (f, (f, (f, 1)))}
 
     d = {
         'a': 1,
@@ -613,7 +619,7 @@ def test_fuse_reductions_single_input():
         'c': (f, 'a', 'b'),
         'd': (f, 'a', 'c'),
     }
-    assert fuse_reductions(d, ave_width=1) == {
+    assert fuse_reductions(d, ave_width=1)[0] == {
         'a': 1,
         'd': (f, 'a', (f, 'a', (f, 'a'))),
     }
@@ -634,13 +640,13 @@ def test_fuse_reductions_single_input():
         'f': (f, 'e1', 'b2'),
 
     }
-    assert fuse_reductions(d, ave_width=1) == expected
-    assert fuse_reductions(d, ave_width=1.9) == expected
+    assert fuse_reductions(d, ave_width=1)[0] == expected
+    assert fuse_reductions(d, ave_width=1.9)[0] == expected
     expected = {
         'a': 1,
         'f': (f, (f, (f, (f, (f, 'a')))), (f, 'a')),
     }
-    assert fuse_reductions(d, ave_width=2) == expected
+    assert fuse_reductions(d, ave_width=2)[0] == expected
 
     d = {
         'a': 1,
@@ -658,13 +664,13 @@ def test_fuse_reductions_single_input():
         'f': (f, 'a', 'e1', 'b2'),
 
     }
-    assert fuse_reductions(d, ave_width=1) == expected
-    assert fuse_reductions(d, ave_width=1.9) == expected
+    assert fuse_reductions(d, ave_width=1)[0] == expected
+    assert fuse_reductions(d, ave_width=1.9)[0] == expected
     expected = {
         'a': 1,
         'f': (f, 'a', (f, 'a', (f, 'a', (f, 'a', (f, 'a')))), (f, 'a')),
     }
-    assert fuse_reductions(d, ave_width=2) == expected
+    assert fuse_reductions(d, ave_width=2)[0] == expected
 
 
 def test_fuse_reductions_multiple_input():
@@ -677,8 +683,8 @@ def test_fuse_reductions_multiple_input():
         'b': (f, 'a1', 'a2'),
         'c': (f, 'b'),
     }
-    assert fuse_reductions(d, ave_width=2) == {'c': (f, (f, 1, 2))}
-    assert fuse_reductions(d, ave_width=1) == {
+    assert fuse_reductions(d, ave_width=2)[0] == {'c': (f, (f, 1, 2))}
+    assert fuse_reductions(d, ave_width=1)[0] == {
         'a1': 1,
         'a2': 2,
         'c': (f, (f, 'a1', 'a2')),

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -390,11 +390,11 @@ def test_fuse_reductions_single_input():
         'b2': (f, 'a', 'a'),
         'c': (f, 'b1', 'b2'),
     }
+    assert fuse_reductions(d, ave_width=1.9) == d
     assert fuse_reductions(d, ave_width=2) == {
         'a': 1,
         'c': (f, (f, 'a'), (f, 'a', 'a')),
     }
-    assert fuse_reductions(d, ave_width=1.9) == d
 
     d = {
         'a': 1,
@@ -408,6 +408,18 @@ def test_fuse_reductions_single_input():
         'c': (f, (f, 'a'), (f, 'a', 'a'), (f, 'a', 'a', 'a')),
     }
     assert fuse_reductions(d, ave_width=2.9) == d
+
+    d = {
+        'a': 1,
+        'b1': (f, 'a'),
+        'b2': (f, 'a'),
+        'c': (f, 'a', 'b1', 'b2'),
+    }
+    assert fuse_reductions(d, ave_width=1.9) == d
+    assert fuse_reductions(d, ave_width=2) == {
+        'a': 1,
+        'c': (f, 'a', (f, 'a'), (f, 'a')),
+    }
 
     d = {
         'a': 1,
@@ -581,3 +593,29 @@ def test_fuse_reductions_single_input():
                (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))))),
     }
     assert fuse_reductions(d, ave_width=7.5, max_width=16) == expected
+
+    d = {
+        'a': 1,
+        'b': (f, 'a'),
+    }
+    assert fuse_reductions(d, ave_width=1) == {'b': (f, 1)}
+    d = {
+        'a': 1,
+        'b': (f, 'a'),
+        'c': (f, 'b'),
+        'd': (f, 'c'),
+    }
+    assert fuse_reductions(d, ave_width=1) == {'d': (f, (f, (f, 1)))}
+
+
+def test_fuse_reductions__input():
+    def f(*args):
+        return args
+
+    d = {
+        'a1': 1,
+        'a2': 2,
+        'b': (f, 'a1', 'a2'),
+        'c': (f, 'b'),
+    }
+    assert fuse_reductions(d, ave_width=2) == {'c': (f, (f, 1, 2))}

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -29,6 +29,8 @@ def test_cull():
 def fuse2(*args, **kwargs):
     """Run both `fuse` and `fuse_reductions` and compare results"""
     rv1 = fuse(*args, **kwargs)
+    if kwargs.get('rename_keys') is not False:
+        return rv1
     rv2 = fuse_reductions(*args, **kwargs)
     assert rv1 == rv2
     return rv1
@@ -781,8 +783,8 @@ def test_fuse_reductions_single_input():
     })
     assert fuse_reductions(d, ave_width=2, rename_keys=True) == with_deps({
         'a': 1,
-        'b1-c1-d1-b2-e1-f': (f, (f, (f, (f, (f, 'a')))), (f, 'a')),
-        'f': 'b1-c1-d1-b2-e1-f',
+        'b1-b2-c1-d1-e1-f': (f, (f, (f, (f, (f, 'a')))), (f, 'a')),
+        'f': 'b1-b2-c1-d1-e1-f',
     })
 
     d = {
@@ -818,8 +820,8 @@ def test_fuse_reductions_single_input():
     })
     assert fuse_reductions(d, ave_width=2, rename_keys=True) == with_deps({
         'a': 1,
-        'b1-c1-d1-b2-e1-f': (f, 'a', (f, 'a', (f, 'a', (f, 'a', (f, 'a')))), (f, 'a')),
-        'f': 'b1-c1-d1-b2-e1-f',
+        'b1-b2-c1-d1-e1-f': (f, 'a', (f, 'a', (f, 'a', (f, 'a', (f, 'a')))), (f, 'a')),
+        'f': 'b1-b2-c1-d1-e1-f',
     })
 
     d = {
@@ -945,7 +947,6 @@ def test_fuse_stressed():
         ('cholesky-upper-26a6b670a8aabb7e2f8936db7ccb6a88', 1, 0),
         ('cholesky-upper-26a6b670a8aabb7e2f8936db7ccb6a88', 1, 1),
     }
-
     fuse_reductions(d, keys=keys, ave_width=2, rename_keys=True)
 
 

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -619,3 +619,8 @@ def test_fuse_reductions_multiple_input():
         'c': (f, 'b'),
     }
     assert fuse_reductions(d, ave_width=2) == {'c': (f, (f, 1, 2))}
+    assert fuse_reductions(d, ave_width=1) == {
+        'a1': 1,
+        'a2': 2,
+        'c': (f, (f, 'a1', 'a2')),
+    }


### PR DESCRIPTION
This trades parallelism opportunities for faster scheduling by making tasks less granular.

This is a very rough cut.  The code is not well tested and probably broken, so I don't recommend exercising it yet.  Nevertheless, there may be value in sharing this early and allowing for discussions to take place.

There are many options (and opinions) for what the parameterization of this function should be.  For the sake of experimentation, I have included many parameters as described below.  My gut feeling right now is that we only need one parameter, `ave_width`, and to choose a reasonable value of `max_depth_new_edges` based on `ave_width` (this controls against pathologies while allowing desirable behavior).

This optimization operation is more general than "single input, single output".  It applies to all reductions, so it may be "multiple input, single output".  I have attempted to make this well-behaved and robust against pathologies and surprises.  Notably, by allowing multiple inputs (what I refer to as `edges` in the code), there may be parallelism opportunities w.r.t. the edges that are otherwise not captured by analyzing the fusible reduction tasks alone.  I added a cheap-to-compute heuristic that is conservative; i.e., it will never underestimate the degree of edge parallelism.  This heuristic increases the value compared against `min_width`--a measure of parallizability--which is one of the reasons I prefer `min_width`.

I think it will be easy for this operation to supersede `fuse`, so we won't have to call `fuse` before calling `fuse_reductions`.  I'm ignoring task renaming for now.
```
Parameters
----------
dsk: dict
    dask graph
keys: list or set
    Keys that must remain in the dask graph
ave_width: float
    Limit for `width = num_nodes / height`, a good measure of parallelizability
max_depth_new_edges: int
    Don't fuse if new dependencies are added after this many levels
max_height: int
    Don't fuse more than this many levels
max_width: int
    Don't fuse if total width is greater than this
```
(No CC's, because it's the weekend!)