### PR TITLE
Add dd.demo.daily_stock function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - if [[ $PYTHON == '3.3' ]]; then pip install cloudpickle pandas==$PANDAS; fi
   - if [[ $PYTHON == '2.7' ]]; then pip install backports.lzma mock; fi
   - if [[ $PYTHON == '3.5' ]]; then pip install git+https://github.com/dask/fastparquet; fi
-  - pip install partd cachey blosc graphviz moto flake8 --upgrade
+  - pip install partd cachey blosc graphviz moto flake8 pandas_datareader --upgrade --no-deps
   - if [[ $PYTHON < '3' ]]; then pip install git+https://github.com/Blosc/castra; fi
   # For parallel testing (`-n` argument in XTRATESTARGS)
   - pip install pytest-xdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ install:
   - if [[ $PYTHON == '3.3' ]]; then pip install cloudpickle pandas==$PANDAS; fi
   - if [[ $PYTHON == '2.7' ]]; then pip install backports.lzma mock; fi
   - if [[ $PYTHON == '3.5' ]]; then pip install git+https://github.com/dask/fastparquet; fi
-  - pip install partd cachey blosc graphviz moto pandas_datareader --upgrade --no-deps
-  - pip install flake8
+  - pip install partd cachey blosc graphviz moto --upgrade --no-deps
+  - pip install flake8 pandas_datareader
   - if [[ $PYTHON < '3' ]]; then pip install git+https://github.com/Blosc/castra; fi
   # For parallel testing (`-n` argument in XTRATESTARGS)
   - pip install pytest-xdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ install:
   - if [[ $PYTHON == '3.3' ]]; then pip install cloudpickle pandas==$PANDAS; fi
   - if [[ $PYTHON == '2.7' ]]; then pip install backports.lzma mock; fi
   - if [[ $PYTHON == '3.5' ]]; then pip install git+https://github.com/dask/fastparquet; fi
-  - pip install partd cachey blosc graphviz moto flake8 pandas_datareader --upgrade --no-deps
+  - pip install partd cachey blosc graphviz moto pandas_datareader --upgrade --no-deps
+  - pip install flake8
   - if [[ $PYTHON < '3' ]]; then pip install git+https://github.com/Blosc/castra; fi
   # For parallel testing (`-n` argument in XTRATESTARGS)
   - pip install pytest-xdist

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -121,9 +121,9 @@ def generate_day(date, open, high, low, close, volume,
         values[ind] = (values[ind] - mx) * (high - mx) / (values.max() - mx) + mx
         ind = values < mn
         values[ind] = (values[ind] - mn) * (low - mn) / (values.min() - mn) + mn
-        if (np.allclose(values.max(), high) and  # The process fails if min/max
-            np.allclose(values.min(), low)):     # are the same as open close
-            break                                # this is pretty rare though
+        # The process fails if min/max are the same as open close.  This is rare
+        if (np.allclose(values.max(), high) and np.allclose(values.min(), low)):
+            break
 
     s = pd.Series(values.round(3), index=time)
     rs = s.resample(freq)

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -4,6 +4,8 @@ import pandas as pd
 import numpy as np
 
 from ..core import tokenize, DataFrame
+from .io import from_delayed
+from ...delayed import delayed
 from ...utils import random_state_data
 
 __all__ = ['make_timeseries']
@@ -72,7 +74,7 @@ def make_timeseries(start, end, dtypes, freq, partition_freq, seed=None):
     >>> df = dd.demo.make_timeseries('2000', '2010',
     ...                              {'value': float, 'name': str, 'id': int},
     ...                              freq='2H', partition_freq='1D', seed=1)
-    >>> df.head()
+    >>> df.head()  # doctest: +SKIP
                            id      name     value
     2000-01-01 00:00:00   969     Jerry -0.309014
     2000-01-01 02:00:00  1010       Ray -0.760675
@@ -89,3 +91,112 @@ def make_timeseries(start, end, dtypes, freq, partition_freq, seed=None):
            for i in range(len(divisions) - 1)}
     head = make_timeseries_part('2000', '2000', dtypes, '1H', state_data[0])
     return DataFrame(dsk, name, head, divisions)
+
+
+def generate_day(date, open, high, low, close, volume,
+                 freq=pd.Timedelta(seconds=60), random_state=None):
+    """ Generate a day of financial data from open/close high/low values """
+    if not isinstance(random_state, np.random.RandomState):
+        random_state = np.random.RandomState(random_state)
+    if not isinstance(date, pd.Timestamp):
+        date = pd.Timestamp(date)
+    if not isinstance(freq, pd.Timedelta):
+        freq = pd.Timedelta(freq)
+
+    time = pd.date_range(date + pd.Timedelta(hours=9),
+                         date + pd.Timedelta(hours=12 + 4),
+                         freq=freq / 5, name='timestamp')
+    n = len(time)
+    while True:
+        values = (random_state.random_sample(n) - 0.5).cumsum()
+        values *= (high - low) / (values.max() - values.min())  # scale
+        values += np.linspace(open - values[0], close - values[-1],
+                              len(values))  # endpoints
+        assert np.allclose(open, values[0])
+        assert np.allclose(close, values[-1])
+
+        mx = max(close, open)
+        mn = min(close, open)
+        ind = values > mx
+        values[ind] = (values[ind] - mx) * (high - mx) / (values.max() - mx) + mx
+        ind = values < mn
+        values[ind] = (values[ind] - mn) * (low - mn) / (values.min() - mn) + mn
+        if (np.allclose(values.max(), high) and  # The process fails if min/max
+            np.allclose(values.min(), low)):     # are the same as open close
+            break                                # this is pretty rare though
+
+    s = pd.Series(values.round(3), index=time)
+    rs = s.resample(freq)
+    # TODO: add in volume
+    return pd.DataFrame({'open': rs.first(),
+                         'close': rs.last(),
+                         'high': rs.max(),
+                         'low': rs.min()})
+
+
+def daily_stock(symbol, start, stop, freq=pd.Timedelta(seconds=1),
+                data_source='yahoo', random_state=None):
+    """ Create artificial stock data
+
+    This data matches daily open/high/low/close values from Yahoo! Finance, but
+    interpolates values within each day with random values.  This makes the
+    results look natural without requiring the downloading of large volumes of
+    data.  This is useful for education and benchmarking.
+
+    Parameters
+    ----------
+    symbol: string
+        A stock symbol like "GOOG" or "F"
+    start: date, str, or pd.Timestamp
+        The start date, input will be fed into pd.Timestamp for normalization
+    stop: date, str, or pd.Timestamp
+        The start date, input will be fed into pd.Timestamp for normalization
+    freq: timedelta, str, or pd.Timedelta
+        The frequency of sampling
+    data_source: str, optional
+        defaults to 'yahoo'.  See pandas_datareader.data.DataReader for options
+    random_state: int, np.random.RandomState object
+        random seed, defaults to randomly chosen
+
+    Examples
+    --------
+    >>> import dask.dataframe as dd
+    >>> df = dd.demo.daily_stock('GOOG', '2010', '2011', freq='1s')
+    >>> df  # doctest: +NORMALIZE_WHITESPACE
+    Dask DataFrame Structure:
+                           close     high      low     open
+    npartitions=252
+    2010-01-04 09:00:00  float64  float64  float64  float64
+    2010-01-05 09:00:00      ...      ...      ...      ...
+    ...                      ...      ...      ...      ...
+    2010-12-31 09:00:00      ...      ...      ...      ...
+    2010-12-31 16:00:00      ...      ...      ...      ...
+    Dask Name: from-delayed, 504 tasks
+
+    >>> df.head()  # doctest: +SKIP
+                           close     high      low     open
+    timestamp
+    2010-01-04 09:00:00  626.944  626.964  626.944  626.951
+    2010-01-04 09:00:01  626.906  626.931  626.906  626.931
+    2010-01-04 09:00:02  626.901  626.911  626.901  626.905
+    2010-01-04 09:00:03  626.920  626.920  626.905  626.905
+    2010-01-04 09:00:04  626.894  626.917  626.894  626.906
+    """
+    from pandas_datareader import data
+    df = data.DataReader(symbol, data_source, start, stop)
+    seeds = random_state_data(len(df), random_state=random_state)
+    parts = []
+    divisions = []
+    for i, seed in zip(range(len(df)), seeds):
+        s = df.iloc[i]
+        part = delayed(generate_day)(s.name, s.loc['Open'], s.loc['High'], s.loc['Low'],
+                                     s.loc['Close'], s.loc['Volume'],
+                                     freq=freq, random_state=seeds)
+        parts.append(part)
+        divisions.append(s.name + pd.Timedelta(hours=9))
+
+    divisions.append(s.name + pd.Timedelta(hours=12 + 4))
+
+    meta = generate_day('2000-01-01', 1, 2, 0, 1, 100)
+
+    return from_delayed(parts, meta=meta, divisions=divisions)

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -1,6 +1,8 @@
-import dask.dataframe as dd
 import pandas.util.testing as tm
 import pandas as pd
+import pytest
+
+import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq
 
 

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -1,6 +1,7 @@
 import dask.dataframe as dd
 import pandas.util.testing as tm
 import pandas as pd
+from dask.dataframe.utils import assert_eq
 
 
 def test_make_timeseries():
@@ -32,3 +33,10 @@ def test_no_overlaps():
     assert all(df.get_partition(i).index.max().compute() <
                df.get_partition(i + 1).index.min().compute()
                for i in range(df.npartitions - 2))
+
+
+def test_finance():
+    df = dd.demo.daily_stock('GOOG', start='2010-01-01', stop='2010-01-30', freq='1h')
+    assert isinstance(df, dd.DataFrame)
+    assert 10 < df.npartitions < 31
+    assert_eq(df, df)

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -35,7 +35,8 @@ def test_no_overlaps():
                for i in range(df.npartitions - 2))
 
 
-def test_finance():
+def test_daily_stock():
+    pytest.importorskip('pandas_datareader')
     df = dd.demo.daily_stock('GOOG', start='2010-01-01', stop='2010-01-30', freq='1h')
     assert isinstance(df, dd.DataFrame)
     assert 10 < df.npartitions < 31


### PR DESCRIPTION
This adds a function to generate fake stock data to the
dask.dataframe.demo submodule.  This is useful for benchmarking and
teaching.

Examples
--------

```python
    >>> import dask.dataframe as dd
    >>> df = dd.demo.daily_stock('GOOG', '2010', '2011', freq='1s')
    >>> df
    Dask DataFrame Structure:
                           close     high      low     open
    npartitions=252
    2010-01-04 09:00:00  float64  float64  float64  float64
    2010-01-05 09:00:00      ...      ...      ...      ...
    ...                      ...      ...      ...      ...
    2010-12-31 09:00:00      ...      ...      ...      ...
    2010-12-31 16:00:00      ...      ...      ...      ...
    Dask Name: from-delayed, 504 tasks

    >>> df.head()
                           close     high      low     open
    timestamp
    2010-01-04 09:00:00  626.944  626.964  626.944  626.951
    2010-01-04 09:00:01  626.906  626.931  626.906  626.931
    2010-01-04 09:00:02  626.901  626.911  626.901  626.905
    2010-01-04 09:00:03  626.920  626.920  626.905  626.905
    2010-01-04 09:00:04  626.894  626.917  626.894  626.906
```

This is intended to replace the library
https://github.com/mrocklin/fakestockdata

cc @martindurant @dhavide