### PR TITLE
Fix outdated link in resample error message

### DIFF
--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -81,7 +81,7 @@ class Resampler(object):
     def __init__(self, obj, rule, **kwargs):
         if not obj.known_divisions:
             msg = ("Can only resample dataframes with known divisions\n"
-                   "See dask.pydata.io/en/latest/dataframe-partitions.html\n"
+                   "See dask.pydata.org/en/latest/dataframe-design.html#partitions\n"
                    "for more information.")
             raise ValueError(msg)
         self.obj = obj


### PR DESCRIPTION
I found this while trying to reproduce the plot here:

http://matthewrocklin.com/blog/work/2017/01/12/dask-dataframes#time-series

I'm still figuring out what to do with the error but in the meanwhile I fixed the docs :)