### PR TITLE
delayed(dask_object) -> Delayed

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -31,7 +31,7 @@ from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      is_integer, IndexCallable, funcname, derived_from,
                      SerializableLock)
 from ..compatibility import unicode, long, getargspec, zip_longest, apply
-from ..delayed import to_task_dasks
+from ..delayed import to_task_dask
 from .. import threaded, core
 from .. import sharedict
 from ..sharedict import ShareDict
@@ -407,7 +407,7 @@ def top(func, output, out_indices, *arrind_pairs, **kwargs):
 
     # Unpack delayed objects in kwargs
     if kwargs:
-        task, dsk2 = to_task_dasks(kwargs)
+        task, dsk2 = to_task_dask(kwargs)
         if dsk2:
             dsk.update(dsk2)
             kwargs2 = task

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -144,8 +144,8 @@ def test_cache_profiler():
 @pytest.mark.skipif("not bokeh")
 def test_unquote():
     from dask.diagnostics.profile_visualize import unquote
-    from dask.delayed import to_task_dasks
-    f = lambda x: to_task_dasks(x)[0]
+    from dask.delayed import to_task_dask
+    f = lambda x: to_task_dask(x)[0]
     t = {'a': 1, 'b': 2, 'c': 3}
     assert unquote(f(t)) == t
     t = {'a': [1, 2, 3], 'b': 2, 'c': 3}


### PR DESCRIPTION
This used to work, but a regression was introduced in #1985 where the
graph was mistakenly assumed to be a `sharedict.ShareDict`. This PR
fixes this, along with some general cleanups:

- Rename `to_task_dasks` to `to_task_dask`
- Update docstring to be consistent with new behavior introduced in
  #1985
- Fix bug when calling `delayed` on a Base object, and add test for it
- Unskip test for `to_task_dask`, and update to pass