### PR TITLE
`get` functions work on ShareDict

### DIFF
--- a/dask/async.py
+++ b/dask/async.py
@@ -441,7 +441,7 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
         result_flat = set([result])
     results = set(result_flat)
 
-    dsk = dsk.copy()
+    dsk = dict(dsk)
     started_cbs = []
     try:
         for cb in callbacks:

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -125,3 +125,13 @@ class GetFunctionTestMixin(object):
             assert False, msg
 
         assert self.get(d, 'x4999') == 4999
+
+    def test_with_sharedict(self):
+        from .sharedict import ShareDict
+
+        dsk = ShareDict()
+        dsk.update({'x': 1,
+                    'y': (inc, 'x')})
+        dsk.update({'z': (add, (inc, 'x'), 'y')})
+
+        assert self.get(dsk, 'z') == 4


### PR DESCRIPTION
Fixes #2009