### PR TITLE
TST: Mark network-using tests.

### DIFF
--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -501,6 +501,7 @@ def test_from_castra():
 
 
 @pytest.mark.slow
+@pytest.mark.network
 def test_from_url():
     a = db.from_url(['http://google.com', 'http://github.com'])
     assert a.npartitions == 2
@@ -561,6 +562,7 @@ def test_read_text_large_gzip():
 
 
 @pytest.mark.slow
+@pytest.mark.network
 def test_from_s3():
     # note we don't test connection modes with aws_access_key and
     # aws_secret_key because these are not on travis-ci

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -126,6 +126,7 @@ def test_read_bytes_blocksize_none(s3):
 
 
 @pytest.mark.slow
+@pytest.mark.network
 def test_read_bytes_blocksize_on_large_data():
     _, L = read_bytes('s3://dask-data/nyc-taxi/2015/yellow_tripdata_2015-01.csv',
                       blocksize=None, anon=True)


### PR DESCRIPTION
This allows builders without network access to skip that test.