### PR TITLE
#2017 fixed with a test.

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -118,6 +118,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
     meta = pd.DataFrame({c: pd.Series([], dtype=d)
                         for (c, d) in dtypes.items()},
                         columns=[c for c in pf.columns if c in dtypes])
+    meta = meta[list(all_columns)]
 
     for cat in categories:
         meta[cat] = pd.Series(pd.Categorical([],

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -245,6 +245,21 @@ def test_ordering():
         assert_eq(ddf, ddf2)
 
 
+def test_read_parquet_custom_columns():
+    with tmpdir() as tmp:
+        tmp = str(tmp)
+        data = pd.DataFrame({'i32': np.arange(1000, dtype=np.int32),
+                             'f': np.arange(1000, dtype=np.float64)})
+        df = dd.from_pandas(data, chunksize=50)
+        df.to_parquet(tmp, write_index=False)
+
+        columns = ['i32', 'f']
+        df2 = read_parquet(tmp, index=False, columns=columns)
+
+        assert (df2._meta.columns == np.asarray(columns)).all(), \
+            'Order of columns incorrect.'
+
+
 @pytest.mark.parametrize('df,write_kwargs,read_kwargs', [
     (pd.DataFrame({'x': [3, 2, 1]}), {}, {}),
     (pd.DataFrame({'x': ['c', 'a', 'b']}), {'object_encoding': 'utf8'}, {}),

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -251,13 +251,13 @@ def test_read_parquet_custom_columns():
         data = pd.DataFrame({'i32': np.arange(1000, dtype=np.int32),
                              'f': np.arange(1000, dtype=np.float64)})
         df = dd.from_pandas(data, chunksize=50)
-        df.to_parquet(tmp, write_index=False)
+        df.to_parquet(tmp)
 
-        columns = ['i32', 'f']
-        df2 = read_parquet(tmp, index=False, columns=columns)
+        df2 = read_parquet(tmp, columns=['i32', 'f'])
+        assert_eq(df2, df2, check_index=False)
 
-        assert (df2._meta.columns == np.asarray(columns)).all(), \
-            'Order of columns incorrect.'
+        df3 = read_parquet(tmp, columns=['f', 'i32'])
+        assert_eq(df3, df3, check_index=False)
 
 
 @pytest.mark.parametrize('df,write_kwargs,read_kwargs', [


### PR DESCRIPTION
Added reordering of the columns to meta, so that we keep the same order as we have given in the parameter ```columns```.

Fixes #2017.