### PR TITLE
Optionally use fancy-fuse dask dataframes

### DIFF
--- a/continuous_integration/appveyor/setup_conda_environment.cmd
+++ b/continuous_integration/appveyor/setup_conda_environment.cmd
@@ -29,7 +29,6 @@ call activate %CONDA_ENV%
 %PIP_INSTALL% blosc --upgrade
 %PIP_INSTALL% moto
 
-if %PYTHON% LSS 3.0 (%PIP_INSTALL% git+https://github.com/Blosc/castra)
 if %PYTHON% LSS 3.0 (%PIP_INSTALL% backports.lzma mock)
 
 @rem Display final environment (for reproducing)

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -44,8 +44,6 @@ pip install git+https://github.com/dask/distributed --upgrade --no-deps
 
 if [[ $PYTHON == '2.7' ]]; then
     pip install backports.lzma mock
-    conda install -c conda-forge bloscpack
-    pip install git+https://github.com/Blosc/castra --upgrade --no-deps
 fi
 
 if [[ $PYTHON == '3.5' ]]; then

--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from .core import (Bag, Item, from_sequence, from_url, to_textfiles, concat,
-                   from_castra, from_delayed, bag_range as range,
-                   bag_zip as zip)
+                   from_delayed, bag_range as range, bag_zip as zip)
 from .text import read_text
 from ..context import set_options
 from ..base import compute

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -6,7 +6,6 @@ import math
 import os
 import sys
 from collections import Iterator
-from distutils.version import LooseVersion
 
 import partd
 from toolz import merge, join, filter, identity, valmap, groupby, pluck
@@ -473,31 +472,6 @@ def test_map_is_lazy():
 
 def test_can_use_dict_to_make_concrete():
     assert isinstance(dict(b.frequencies()), dict)
-
-
-def test_from_castra():
-    pytest.importorskip('castra')
-    pd = pytest.importorskip('pandas')
-    dd = pytest.importorskip('dask.dataframe')
-    blosc = pytest.importorskip('blosc')
-    if LooseVersion(blosc.__version__) == '1.3.0':
-        pytest.skip()
-    df = pd.DataFrame({'x': list(range(100)),
-                       'y': [str(i) for i in range(100)]})
-    a = dd.from_pandas(df, 10)
-
-    with tmpfile('.castra') as fn:
-        c = a.to_castra(fn)
-        default = db.from_castra(c)
-        with_columns = db.from_castra(c, 'x')
-        with_index = db.from_castra(c, 'x', index=True)
-        assert (list(default) == [{'x': i, 'y': str(i)}
-                                  for i in range(100)] or
-                list(default) == [(i, str(i)) for i in range(100)])
-        assert list(with_columns) == list(range(100))
-        assert list(with_index) == list(zip(range(100), range(100)))
-        assert default.name != with_columns.name != with_index.name
-        assert with_index.name == db.from_castra(c, 'x', index=True).name
 
 
 @pytest.mark.slow

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 from .core import (DataFrame, Series, Index, _Frame, map_partitions,
                    repartition, to_delayed)
 from .io import (from_array, from_pandas, from_bcolz,
-                 from_dask_array, from_castra, read_hdf,
+                 from_dask_array, read_hdf,
                  from_delayed, read_csv, to_csv, read_table,
                  demo, to_hdf, to_records, to_bag)
 from .optimize import optimize

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -27,7 +27,6 @@ from ..utils import (random_state_data,
                      pseudorandom, derived_from, funcname, memory_repr,
                      put_lines, M, key_split)
 from ..base import Base, compute, tokenize, normalize_token
-from ..async import get_sync
 from . import methods
 from .accessor import DatetimeAccessor, StringAccessor
 from .categorical import CategoricalAccessor, categorize
@@ -2335,20 +2334,6 @@ class DataFrame(_Frame):
         df = elemwise(M.to_timestamp, self, freq, how, axis)
         df.divisions = tuple(pd.Index(self.divisions).to_timestamp())
         return df
-
-    def to_castra(self, fn=None, categories=None, sorted_index_column=None,
-                  compute=True, get=get_sync):
-        """ Write DataFrame to Castra on-disk store
-
-        See https://github.com/blosc/castra for details
-
-        See Also
-        --------
-        Castra.to_dask
-        """
-        from .io import to_castra
-        return to_castra(self, fn, categories, sorted_index_column,
-                         compute=compute, get=get)
 
     def to_bag(self, index=False):
         """Convert to a dask Bag of tuples of each row.

--- a/dask/dataframe/io/__init__.py
+++ b/dask/dataframe/io/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 from .io import (from_array, from_bcolz, from_array, from_bcolz,
-                 from_pandas, from_dask_array, from_castra, to_castra,
+                 from_pandas, from_dask_array,
                  from_delayed, dataframe_from_ctable, to_bag, to_records)
 from .csv import read_csv, to_csv, read_table
 from .hdf import read_hdf, to_hdf

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -2,7 +2,8 @@
 from __future__ import absolute_import, division, print_function
 
 from .io import dataframe_from_ctable
-from ..optimize import cull, fuse_getitem, fuse_selections
+from ..optimize import cull, fuse_getitem, fuse
+from ..context import _globals
 from .. import core
 
 try:
@@ -13,29 +14,15 @@ else:
     from .io.parquet import _read_parquet_row_group
 
 
-def fuse_castra_index(dsk):
-    from castra import Castra
-
-    def merge(a, b):
-        return (Castra.load_index, b[1], b[2]) if a[2] == 'index' else a
-    return fuse_selections(dsk, getattr, Castra.load_partition, merge)
-
-
 def optimize(dsk, keys, **kwargs):
     if isinstance(keys, list):
-        dsk2, dependencies = cull(dsk, list(core.flatten(keys)))
+        dsk, dependencies = cull(dsk, list(core.flatten(keys)))
     else:
-        dsk2, dependencies = cull(dsk, [keys])
-    try:
-        from castra import Castra
-        dsk3 = fuse_getitem(dsk2, Castra.load_partition, 3)
-        dsk4 = fuse_castra_index(dsk3)
-    except ImportError:
-        dsk4 = dsk2
-    dsk5 = fuse_getitem(dsk4, dataframe_from_ctable, 3)
+        dsk, dependencies = cull(dsk, [keys])
+    dsk = fuse_getitem(dsk, dataframe_from_ctable, 3)
     if _read_parquet_row_group:
-        dsk6 = fuse_getitem(dsk5, _read_parquet_row_group, 4)
-    else:
-        dsk6 = dsk5
-    dsk7, _ = cull(dsk6, keys)
-    return dsk7
+        dsk = fuse_getitem(dsk, _read_parquet_row_group, 4)
+    if _globals.get('fuse_ave_width'):
+        dsk, dependencies = fuse(dsk, keys, dependencies=dependencies)
+    dsk, _ = cull(dsk, keys)
+    return dsk


### PR DESCRIPTION
This also removes the castra optimizations

Due to recent work from @eriknw with optimizations.

This is *sometimes* cost saving.  It's still turned off by default but it's easy to turn it on now with `dask.set_options`.  This seems to have a positive effect once there are more than three or four terms in a query.