### PR TITLE
Set_index automatically repartitions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2153,7 +2153,7 @@ class DataFrame(_Frame):
         cs = self._meta.select_dtypes(include=include, exclude=exclude).columns
         return self[list(cs)]
 
-    def set_index(self, other, drop=True, sorted=False, **kwargs):
+    def set_index(self, other, drop=True, sorted=False, npartitions='auto', **kwargs):
         """
         Set the DataFrame index (row labels) using an existing column
 
@@ -2183,8 +2183,9 @@ class DataFrame(_Frame):
         ----------
         df: Dask DataFrame
         index: string or Dask Series
-        npartitions: int
-            The ideal number of output partitions
+        npartitions: int, None, or 'auto'
+            The ideal number of output partitions.   If None use the same as
+            the input.  If 'auto' then decide by size.
         shuffle: string, optional
             Either ``'disk'`` for single-node operation or ``'tasks'`` for
             distributed operation.  Will be inferred by your current scheduler.
@@ -2217,7 +2218,8 @@ class DataFrame(_Frame):
             return set_sorted_index(self, other, drop=drop, **kwargs)
         else:
             from .shuffle import set_index
-            return set_index(self, other, drop=drop, **kwargs)
+            return set_index(self, other, drop=drop, npartitions=npartitions,
+                    **kwargs)
 
     def set_partition(self, column, divisions, **kwargs):
         """ Set explicit divisions for new column index

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2153,7 +2153,7 @@ class DataFrame(_Frame):
         cs = self._meta.select_dtypes(include=include, exclude=exclude).columns
         return self[list(cs)]
 
-    def set_index(self, other, drop=True, sorted=False, npartitions='auto', **kwargs):
+    def set_index(self, other, drop=True, sorted=False, npartitions=None, **kwargs):
         """
         Set the DataFrame index (row labels) using an existing column
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2219,7 +2219,7 @@ class DataFrame(_Frame):
         else:
             from .shuffle import set_index
             return set_index(self, other, drop=drop, npartitions=npartitions,
-                    **kwargs)
+                             **kwargs)
 
     def set_partition(self, column, divisions, **kwargs):
         """ Set explicit divisions for new column index

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2185,7 +2185,7 @@ class DataFrame(_Frame):
         index: string or Dask Series
         npartitions: int, None, or 'auto'
             The ideal number of output partitions.   If None use the same as
-            the input.  If 'auto' then decide by size.
+            the input.  If 'auto' then decide by memory use.
         shuffle: string, optional
             Either ``'disk'`` for single-node operation or ``'tasks'`` for
             distributed operation.  Will be inferred by your current scheduler.

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -14,11 +14,11 @@ from .hashing import hash_pandas_object
 
 from .. import base
 from ..base import tokenize
-from ..delayed import delayed
 from ..context import _globals
+from ..delayed import delayed
+from ..sizeof import sizeof
 from ..utils import digit, insert, M
 
-from distributed.sizeof import sizeof
 
 
 def set_index(df, index, npartitions='auto', shuffle=None, compute=False,

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -20,7 +20,7 @@ from ..sizeof import sizeof
 from ..utils import digit, insert, M
 
 
-def set_index(df, index, npartitions='auto', shuffle=None, compute=False,
+def set_index(df, index, npartitions=None, shuffle=None, compute=False,
               drop=True, upsample=1.0, divisions=None, **kwargs):
     """ See _Frame.set_index for docstring """
     if (isinstance(index, Series) and index._name == df.index._name):
@@ -33,7 +33,7 @@ def set_index(df, index, npartitions='auto', shuffle=None, compute=False,
 
     if npartitions == 'auto':
         repartition = True
-        npartitions = min(100, df.npartitions)
+        npartitions = max(100, df.npartitions)
     else:
         if npartitions is None:
             npartitions = df.npartitions

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -20,7 +20,6 @@ from ..sizeof import sizeof
 from ..utils import digit, insert, M
 
 
-
 def set_index(df, index, npartitions='auto', shuffle=None, compute=False,
               drop=True, upsample=1.0, divisions=None, **kwargs):
     """ See _Frame.set_index for docstring """

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -199,17 +199,18 @@ def test_categorical_set_index(shuffle):
     a = dd.from_pandas(df, npartitions=2)
 
     with dask.set_options(get=get_sync, shuffle=shuffle):
-        b = a.set_index('y')
+        b = a.set_index('y', npartitions=a.npartitions)
         d1, d2 = b.get_partition(0), b.get_partition(1)
         assert list(d1.index.compute()) == ['a']
         assert list(sorted(d2.index.compute())) == ['b', 'b', 'c']
 
-        b = a.set_index(a.y)
+        b = a.set_index(a.y, npartitions=a.npartitions)
         d1, d2 = b.get_partition(0), b.get_partition(1)
         assert list(d1.index.compute()) == ['a']
         assert list(sorted(d2.index.compute())) == ['b', 'b', 'c']
 
-        b = a.set_index('y', divisions=['a', 'b', 'c'])
+        b = a.set_index('y', divisions=['a', 'b', 'c'],
+                        npartitions=a.nparititons)
         d1, d2 = b.get_partition(0), b.get_partition(1)
         assert list(d1.index.compute()) == ['a']
         assert list(sorted(d2.index.compute())) == ['b', 'b', 'c']

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -295,7 +295,7 @@ def test_set_index_reduces_partitions_small(shuffle):
     df = pd.DataFrame({'x': range(100)})
     ddf = dd.from_pandas(df, npartitions=50)
 
-    ddf2 = ddf.set_index('x', shuffle=shuffle)
+    ddf2 = ddf.set_index('x', shuffle=shuffle, npartitions='auto')
     assert ddf2.npartitions < 10
 
 
@@ -305,7 +305,7 @@ def test_set_index_reduces_partitions_large(shuffle):
     df = pd.DataFrame({'x': np.arange(n), 'y': np.arange(n), 'z': np.arange(n)})
     ddf = dd.from_pandas(df, npartitions=50, name='x', sort=False)
 
-    ddf2 = ddf.set_index('x', shuffle=shuffle)
+    ddf2 = ddf.set_index('x', shuffle=shuffle, npartitions='auto')
     assert 1 < ddf2.npartitions < 20
 
 
@@ -315,5 +315,5 @@ def test_set_index_doesnt_increase_partitions(shuffle):
     df = pd.DataFrame({'x': np.arange(n), 'y': np.arange(n), 'z': np.arange(n)})
     ddf = dd.from_pandas(df, npartitions=2, name='x', sort=False)
 
-    ddf2 = ddf.set_index('x', shuffle=shuffle)
+    ddf2 = ddf.set_index('x', shuffle=shuffle, npartitions='auto')
     assert ddf2.npartitions <= ddf.npartitions

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -219,7 +219,8 @@ def test_set_partition_tasks_3(shuffle):
     df = pd.DataFrame(np.random.random((10, 2)), columns=['x', 'y'])
     ddf = dd.from_pandas(df, npartitions=5)
 
-    ddf2 = ddf.set_index('x', shuffle=shuffle, max_branch=2)
+    ddf2 = ddf.set_index('x', shuffle=shuffle, max_branch=2,
+                         npartitions=ddf.npartitions)
     df2 = df.set_index('x')
     assert_eq(df2, ddf2)
     assert ddf2.npartitions == ddf.npartitions
@@ -308,6 +309,7 @@ def test_set_index_reduces_partitions_large(shuffle):
     assert 1 < ddf2.npartitions < 20
 
 
+@pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
 def test_set_index_doesnt_increase_partitions(shuffle):
     n = 2**23
     df = pd.DataFrame({'x': range(n), 'y': range(n), 'z': range(n)})

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -301,8 +301,8 @@ def test_set_index_reduces_partitions_small(shuffle):
 
 @pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
 def test_set_index_reduces_partitions_large(shuffle):
-    n = 2**23
-    df = pd.DataFrame({'x': range(n), 'y': range(n), 'z': range(n)})
+    n = 2**24
+    df = pd.DataFrame({'x': np.arange(n), 'y': np.arange(n), 'z': np.arange(n)})
     ddf = dd.from_pandas(df, npartitions=50, name='x', sort=False)
 
     ddf2 = ddf.set_index('x', shuffle=shuffle)
@@ -311,9 +311,9 @@ def test_set_index_reduces_partitions_large(shuffle):
 
 @pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
 def test_set_index_doesnt_increase_partitions(shuffle):
-    n = 2**23
-    df = pd.DataFrame({'x': range(n), 'y': range(n), 'z': range(n)})
+    n = 2**24
+    df = pd.DataFrame({'x': np.arange(n), 'y': np.arange(n), 'z': np.arange(n)})
     ddf = dd.from_pandas(df, npartitions=2, name='x', sort=False)
 
     ddf2 = ddf.set_index('x', shuffle=shuffle)
-    assert ddf2.npartitions == ddf.npartitions
+    assert ddf2.npartitions <= ddf.npartitions

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -306,3 +306,12 @@ def test_set_index_reduces_partitions_large(shuffle):
 
     ddf2 = ddf.set_index('x', shuffle=shuffle)
     assert 1 < ddf2.npartitions < 20
+
+
+def test_set_index_doesnt_increase_partitions(shuffle):
+    n = 2**23
+    df = pd.DataFrame({'x': range(n), 'y': range(n), 'z': range(n)})
+    ddf = dd.from_pandas(df, npartitions=2, name='x', sort=False)
+
+    ddf2 = ddf.set_index('x', shuffle=shuffle)
+    assert ddf2.npartitions == ddf.npartitions

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -287,3 +287,22 @@ def test_set_index_with_explicit_divisions():
 
     df2 = df.set_index('x')
     assert_eq(ddf2, df2)
+
+
+@pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
+def test_set_index_reduces_partitions_small(shuffle):
+    df = pd.DataFrame({'x': range(100)})
+    ddf = dd.from_pandas(df, npartitions=50)
+
+    ddf2 = ddf.set_index('x', shuffle=shuffle)
+    assert ddf2.npartitions < 10
+
+
+@pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
+def test_set_index_reduces_partitions_large(shuffle):
+    n = 2**23
+    df = pd.DataFrame({'x': range(n), 'y': range(n), 'z': range(n)})
+    ddf = dd.from_pandas(df, npartitions=50, name='x', sort=False)
+
+    ddf2 = ddf.set_index('x', shuffle=shuffle)
+    assert 1 < ddf2.npartitions < 20

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import sys
 
-from dask.utils import Dispatch
+from .utils import Dispatch
 
 try:  # PyPy does not support sys.getsizeof
     sys.getsizeof(1)
@@ -11,7 +11,7 @@ except (AttributeError, TypeError):  # Monkey patch
     getsizeof = lambda x: 100
 
 
-sizeof = Dispatch()
+sizeof = Dispatch(name='sizeof')
 
 
 @sizeof.register(object)

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -1,0 +1,79 @@
+from __future__ import print_function, division, absolute_import
+
+import sys
+
+from dask.utils import Dispatch
+
+try:  # PyPy does not support sys.getsizeof
+    sys.getsizeof(1)
+    getsizeof = sys.getsizeof
+except (AttributeError, TypeError):  # Monkey patch
+    getsizeof = lambda x: 100
+
+
+sizeof = Dispatch()
+
+
+@sizeof.register(object)
+def sizeof_default(o):
+    return getsizeof(o)
+
+
+@sizeof.register(list)
+@sizeof.register(tuple)
+@sizeof.register(set)
+@sizeof.register(frozenset)
+def sizeof_python_collection(seq):
+    return getsizeof(seq) + sum(map(sizeof, seq))
+
+
+@sizeof.register_lazy("numpy")
+def register_numpy():
+    import numpy as np
+
+    @sizeof.register(np.ndarray)
+    def sizeof_numpy_ndarray(x):
+        return int(x.nbytes)
+
+
+@sizeof.register_lazy("pandas")
+def register_pandas():
+    import pandas as pd
+
+    @sizeof.register(pd.DataFrame)
+    def sizeof_pandas_dataframe(df):
+        p = int(df.memory_usage(index=True).sum())
+        obj = int((df.dtypes == object).sum() * len(df) * 100)
+        if df.index.dtype == object:
+            obj += len(df) * 100
+        return int(p + obj) + 1000
+
+    @sizeof.register(pd.Series)
+    def sizeof_pandas_series(s):
+        p = int(s.memory_usage(index=True))
+        if s.dtype == object:
+            p += len(s) * 100
+        if s.index.dtype == object:
+            p += len(s) * 100
+        return int(p) + 1000
+
+    @sizeof.register(pd.Index)
+    def sizeof_pandas_index(i):
+        p = int(i.memory_usage())
+        obj = len(i) * 100 if i.dtype == object else 0
+        return int(p + obj) + 1000
+
+
+@sizeof.register_lazy("scipy")
+def register_spmatrix():
+    from scipy import sparse
+
+    @sizeof.register(sparse.dok_matrix)
+    def sizeof_spmatrix_dok(s):
+        return s.__sizeof__()
+
+    @sizeof.register(sparse.spmatrix)
+    def sizeof_spmatrix(s):
+        return sum(
+            sizeof(v) for v in s.__dict__.values()
+        )

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -24,7 +24,7 @@ def test_numpy():
 
 def test_pandas():
     pd = pytest.importorskip('pandas')
-    df = pd.DataFrame({'x': [1, 2, 3], 'y': ['a'*100, 'b'*100, 'c'*100]},
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': ['a' * 100, 'b' * 100, 'c' * 100]},
                       index=[10, 20, 30])
 
     assert sizeof(df) >= sizeof(df.x) + sizeof(df.y) - sizeof(df.index)

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -5,10 +5,15 @@ import sys
 import pytest
 
 from dask.sizeof import sizeof, getsizeof
+from dask.utils import funcname
 
 
 def test_base():
     assert sizeof(1) == getsizeof(1)
+
+
+def test_name():
+    assert funcname(sizeof) == 'sizeof'
 
 
 def test_containers():

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -1,0 +1,50 @@
+from __future__ import print_function, division, absolute_import
+
+import sys
+
+import pytest
+
+from dask.sizeof import sizeof, getsizeof
+
+
+def test_base():
+    assert sizeof(1) == getsizeof(1)
+
+
+def test_containers():
+    assert sizeof([1, 2, [3]]) > (getsizeof(3) * 3 + getsizeof([]))
+
+
+def test_numpy():
+    np = pytest.importorskip('numpy')
+    assert sizeof(np.empty(1000, dtype='f8')) == 8000
+    dt = np.dtype('f8')
+    assert sizeof(dt) == sys.getsizeof(dt)
+
+
+def test_pandas():
+    pd = pytest.importorskip('pandas')
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': ['a'*100, 'b'*100, 'c'*100]},
+                      index=[10, 20, 30])
+
+    assert sizeof(df) >= sizeof(df.x) + sizeof(df.y) - sizeof(df.index)
+    assert sizeof(df.x) >= sizeof(df.index)
+    if pd.__version__ >= '0.17.1':
+        assert sizeof(df.y) >= 100 * 3
+    assert sizeof(df.index) >= 20
+
+    assert isinstance(sizeof(df), int)
+    assert isinstance(sizeof(df.x), int)
+    assert isinstance(sizeof(df.index), int)
+
+
+def test_sparse_matrix():
+    sparse = pytest.importorskip('scipy.sparse')
+    sp = sparse.eye(10)
+    assert sizeof(sp.todia()) >= 152
+    assert sizeof(sp.tobsr()) >= 232
+    assert sizeof(sp.tocoo()) >= 252
+    assert sizeof(sp.tocsc()) >= 232
+    assert sizeof(sp.tocsr()) >= 260
+    assert sizeof(sp.todok()) >= 260
+    assert sizeof(sp.tolil()) >= 324

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -542,9 +542,11 @@ def takes_multiple_arguments(func):
 
 class Dispatch(object):
     """Simple single dispatch."""
-    def __init__(self):
+    def __init__(self, name=None):
         self._lookup = {}
         self._lazy = {}
+        if name:
+            self.__name__ = name
 
     def register(self, type, func=None):
         """Register dispatch of `func` on arguments of type `type`"""


### PR DESCRIPTION
When we have to look through a dataset to find approximate quantiles
lets also look through and find memory use.  Based on that use lets repartition
our data into chunks of different size

This needs more heuristics if we accept it

- [x] Don't clobber intentionally larger partitions
- [ ] Perhaps prefer a minimum number of partitions like ncores
- [ ] Extend this to a general method to repartition on persisted data

Fixes #2007 