### PR TITLE
Update toolz version requirement (>=0.7.2 to >=0.7.3)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,12 @@ import versioneer
 # NOTE: These are tested in `continuous_integration/travis/test_imports.sh` If
 # you modify these, make sure to change the corresponding line there.
 extras_require = {
-  'array': ['numpy', 'toolz >= 0.8.2'],
-  'bag': ['cloudpickle >= 0.2.1', 'toolz >= 0.8.2', 'partd >= 0.3.7'],
-  'dataframe': ['numpy', 'pandas >= 0.19.0', 'toolz >= 0.8.2',
+  'array': ['numpy', 'toolz >= 0.7.3'],
+  'bag': ['cloudpickle >= 0.2.1', 'toolz >= 0.7.3', 'partd >= 0.3.7'],
+  'dataframe': ['numpy', 'pandas >= 0.19.0', 'toolz >= 0.7.3',
                 'partd >= 0.3.7', 'cloudpickle >= 0.2.1'],
   'distributed': ['distributed >= 1.15', 's3fs >= 0.0.8'],
-  'delayed': ['toolz >= 0.8.2'],
+  'delayed': ['toolz >= 0.7.3'],
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,12 @@ import versioneer
 # NOTE: These are tested in `continuous_integration/travis/test_imports.sh` If
 # you modify these, make sure to change the corresponding line there.
 extras_require = {
-  'array': ['numpy', 'toolz >= 0.7.2'],
-  'bag': ['cloudpickle >= 0.2.1', 'toolz >= 0.7.2', 'partd >= 0.3.7'],
-  'dataframe': ['numpy', 'pandas >= 0.19.0', 'toolz >= 0.7.2',
+  'array': ['numpy', 'toolz >= 0.8.2'],
+  'bag': ['cloudpickle >= 0.2.1', 'toolz >= 0.8.2', 'partd >= 0.3.7'],
+  'dataframe': ['numpy', 'pandas >= 0.19.0', 'toolz >= 0.8.2',
                 'partd >= 0.3.7', 'cloudpickle >= 0.2.1'],
   'distributed': ['distributed >= 1.15', 's3fs >= 0.0.8'],
-  'delayed': ['toolz >= 0.7.2'],
+  'delayed': ['toolz >= 0.8.2'],
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 


### PR DESCRIPTION
With toolz 0.7.2, `import dask.bag` fails.

```
$ pip freeze | grep toolz
toolz==0.7.2
$ python -c 'from toolz import peek'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'peek'
$ pip install toolz==0.8.2
...
$ pip freeze | grep toolz
toolz==0.8.2
$ python -c 'from toolz import peek'
```