### PR TITLE
Coerce datetime divisions to timestamps in read_parquet

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from toolz import first, partial
 
@@ -140,6 +141,9 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
         divisions = list(minmax[index_col]['min']) + [minmax[index_col]['max'][-1]]
     else:
         divisions = (None,) * (len(rgs) + 1)
+
+    if isinstance(divisions[0], np.datetime64):
+        divisions = [pd.Timestamp(d) for d in divisions]
 
     return out_type(dsk, name, meta, divisions)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import numpy as np
 import pandas as pd
+import pandas.util.testing as tm
 import pytest
 
 import dask
@@ -340,3 +341,13 @@ def test_empty_partition(fn):
     ddf2 = ddf[ddf.a <= -5]
     with pytest.raises(ValueError):
         ddf2.to_parquet(fn)
+
+
+def test_timestamp_index():
+    with tmpfile() as fn:
+        df = tm.makeTimeDataFrame()
+        df.index.name = 'foo'
+        ddf = dd.from_pandas(df, npartitions=5)
+        ddf.to_parquet(fn)
+        ddf2 = dd.read_parquet(fn)
+        assert_eq(ddf, ddf2)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2188,7 +2188,7 @@ def test_compute_divisions():
     b = copy(a)
     b.divisions = divisions
 
-    assert_eq(a, b)
+    assert_eq(a, b, check_divisions=False)
     assert b.known_divisions
 
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -496,8 +496,10 @@ def assert_eq(a, b, check_names=True, check_dtypes=True,
     if check_divisions:
         assert_divisions(a)
         assert_divisions(b)
-    if hasattr(a, 'divisions') and hasattr(b, 'divisions'):
-        assert type(a.divisions[0]) == type(b.divisions[0])
+        if hasattr(a, 'divisions') and hasattr(b, 'divisions'):
+            at = type(np.asarray(a.divisions).tolist()[0])  # numpy to python
+            bt = type(np.asarray(b.divisions).tolist()[0])  # scalar conversion
+            assert at == bt, (at, bt)
     assert_sane_keynames(a)
     assert_sane_keynames(b)
     a = _check_dask(a, check_names=check_names, check_dtypes=check_dtypes)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -496,6 +496,8 @@ def assert_eq(a, b, check_names=True, check_dtypes=True,
     if check_divisions:
         assert_divisions(a)
         assert_divisions(b)
+    if hasattr(a, 'divisions') and hasattr(b, 'divisions'):
+        assert type(a.divisions[0]) == type(b.divisions[0])
     assert_sane_keynames(a)
     assert_sane_keynames(b)
     a = _check_dask(a, check_names=check_names, check_dtypes=check_dtypes)


### PR DESCRIPTION
This also improves generic type testing in division in assert_eq