### PR TITLE
Test that numpy literals in graph don't get inlined

### DIFF
--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -65,8 +65,9 @@ def test_optimize_with_getitem_fusion():
            'c': (getarray, 'b', (5, slice(50, 60)))}
 
     result = optimize(dsk, ['c'])
-    expected = {'c': (getarray, 'some-array', (15, slice(150, 160)))}
-    assert result == expected
+    expected_task = (getarray, 'some-array', (15, slice(150, 160)))
+    assert any(v == expected_task for v in result.values())
+    assert len(result) < len(dsk)
 
 
 def test_optimize_slicing():

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -2,6 +2,7 @@ import pytest
 pytest.importorskip('numpy')
 
 import numpy as np
+import dask
 import dask.array as da
 from dask.optimize import fuse
 from dask.array.optimization import (getitem, optimize, optimize_slices,
@@ -124,7 +125,25 @@ def test_dont_fuse_numpy_arrays():
         y = da.from_array(x, chunks=(10,))
 
         dsk = y._optimize(y.dask, y._keys())
-        assert sum(isinstance(v, np.ndarray) for v in dsk) == 1
+        assert sum(isinstance(v, np.ndarray) for v in dsk.values()) == 1
+
+
+def test_minimize_data_transfer():
+    x = np.ones(100)
+    y = da.from_array(x, chunks=25)
+    z = y + 1
+    dsk = z._optimize(z.dask, z._keys())
+
+    keys = list(dsk)
+    results = dask.get(dsk, keys)
+    big_key = [k for k, r in zip(keys, results) if r is x][0]
+    dependencies, dependents = dask.core.get_deps(dsk)
+    deps = dependents[big_key]
+
+    assert len(deps) == 4
+    for dep in deps:
+        assert dsk[dep][0] in (getitem, getarray)
+        assert dsk[dep][1] == big_key
 
 
 def test_dont_fuse_fancy_indexing_in_getarray_nofancy():


### PR DESCRIPTION
OK, so it's important that numpy arrays stay where they are in the graph and don't get fused.  This is important for two reasons:

1.  We can serialize values better if they are naked in the graph rather than enclosed within tasks
2.  If a value becomes inlined into a fast-function task (like getitem) then it can be copied to many other tasks during fast_function_inlining.  This can cause blowup of serialization costs.

cc @eriknw any thoughts on how to address this cheaply?