### PR TITLE
Modifies `ndeepmap` behavior for `ndim==0` and `seq` being a `list`...

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2055,6 +2055,11 @@ def test_to_delayed():
     [[a, b], [c, d]] = y.to_delayed()
     assert_eq(a.compute(), y[:2, :2])
 
+    s = 2
+    x = da.from_array(np.array(s), chunks=0)
+    a = x.to_delayed()[tuple()]
+    assert a.compute() == s
+
 
 def test_cumulative():
     x = da.arange(20, chunks=5)

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -316,6 +316,12 @@ def test_funcname_multipledispatch():
 
 
 def test_ndeepmap():
+    L = 1
+    assert ndeepmap(0, inc, L) == 2
+
+    L = [1]
+    assert ndeepmap(0, inc, L) == 2
+
     L = [1, 2, 3]
     assert ndeepmap(1, inc, L) == [2, 3, 4]
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -74,6 +74,8 @@ def ndeepmap(n, func, seq):
         return [func(item) for item in seq]
     elif n > 1:
         return [ndeepmap(n - 1, func, item) for item in seq]
+    elif isinstance(seq, list):
+        return func(seq[0])
     else:
         return func(seq)
 


### PR DESCRIPTION
…for a more consistent experience of `dask.array.Array().to_delayed()` for array objects only containing scalars.

Refer to #2029