### PR TITLE
Make attribute access pure on delayed objects

### DIFF
--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -69,6 +69,7 @@ def test_methods():
 
 def test_attributes():
     a = delayed(2 + 1j)
+    assert a.real._key == a.real._key
     assert a.real.compute() == 2
     assert a.imag.compute() == 1
     assert (a.real + a.imag).compute() == 3


### PR DESCRIPTION
Makes attribute access pure on delayed objects, and updates docstring to
better reflect this. It is now consistent that all "magic" methods are
pure on all delayed objects. Fixes #2073.