### PR TITLE
Support arithmetic with row-series

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -93,7 +93,9 @@ def align_partitions(*dfs):
         A list of lists of keys that show which data exist on which
         divisions
     """
-    dfs1 = [df for df in dfs if isinstance(df, _Frame)]
+    dfs1 = [df for df in dfs
+            if isinstance(df, _Frame) and
+            df.divisions != (0, 1)]  # single row
     if len(dfs) == 0:
         raise ValueError("dfs contains no DataFrame and Series")
     if not all(df.known_divisions for df in dfs1):
@@ -130,7 +132,9 @@ def _maybe_align_partitions(args):
     Note that if all divisions are unknown, but have equal npartitions, then
     they will be passed through unchanged. This is different than
     `align_partitions`, which will fail if divisions aren't all known"""
-    dfs = [df for df in args if isinstance(df, _Frame)]
+    dfs = [df for df in args
+           if isinstance(df, _Frame) and
+           df.divisions != (0, 1)]  # single row
     if not dfs:
         return args
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2658,3 +2658,15 @@ def test_memory_usage(index, deep):
               ddf.memory_usage(index=index, deep=deep))
     assert (df.x.memory_usage(index=index, deep=deep) ==
             ddf.x.memory_usage(index=index, deep=deep).compute())
+
+
+@pytest.mark.parametrize('reduction', ['sum', 'mean', 'std', 'var', 'count',
+                                       'min', 'max', 'idxmin', 'idxmax',
+                                       'prod', 'all', 'sem'])
+def test_dataframe_reductions_arithmetic(reduction):
+    df = pd.DataFrame({'x': [1, 2, 3, 4, 5],
+                       'y': [1.1, 2.2, 3.3, 4.4, 5.5]})
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    assert_eq(ddf - (getattr(ddf, reduction)() + 1),
+              df - (getattr(df, reduction)() + 1))


### PR DESCRIPTION
Sometimes a Series is just one row and is intended to be broadcast
across a Dataframe, rather than in an elementwise fashion.

This creates a convention, that a Series with divisions (0, 1) signals
that it is just a single row, and is thus appropriate for broadcasting.

This enables computations like the following (which used to err):

    df = df - df.mean()

However it also introduces silent failures if elementwise operation
against this series is intended, despite its divisions of (0, 1)

Fixes https://github.com/dask/dask/issues/1759

cc @jcrist for review