### PR TITLE
Add __deepcopy__ method to dask.array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1712,6 +1712,11 @@ class Array(Base):
         """
         return Array(self.dask, self.name, self.chunks, self.dtype)
 
+    def __deepcopy__(self, memo):
+        c = self.copy()
+        memo[id(self)] = c
+        return c
+
     def to_delayed(self):
         """ Convert Array into dask Delayed objects
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+import copy
 
 import pytest
 np = pytest.importorskip('numpy')
@@ -2290,6 +2291,8 @@ def test_A_property():
 def test_copy_mutate():
     x = da.arange(5, chunks=(2,))
     y = x.copy()
+    memo = {}
+    y2 = copy.deepcopy(x, memo=memo)
     x[x % 2 == 0] = -1
 
     xx = np.arange(5)
@@ -2297,6 +2300,8 @@ def test_copy_mutate():
     assert_eq(x, xx)
 
     assert_eq(y, np.arange(5))
+    assert_eq(y2, np.arange(5))
+    assert memo[id(x)] is y2
 
 
 def test_npartitions():


### PR DESCRIPTION
Currently ``dask.array`` has a ``copy`` method, but ``copy.deepcopy`` fails on a ``dask.array`` while it works on a ``numpy.array``. This pull request adds ``__deepcopy__`` method that simply returns the output of ``dask.array.copy``. The goal is increasing compatibility with code written for numpy arrays.