### PR TITLE
Avoid shuffle when calling set_index on a sorted column

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -26,7 +26,7 @@ from ..compatibility import apply, operator_div, bind_method, PY3
 from ..utils import (random_state_data,
                      pseudorandom, derived_from, funcname, memory_repr,
                      put_lines, M, key_split)
-from ..base import Base, compute, tokenize, normalize_token
+from ..base import Base, tokenize, normalize_token
 from . import methods
 from .accessor import DatetimeAccessor, StringAccessor
 from .categorical import CategoricalAccessor, categorize

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -529,7 +529,7 @@ def from_delayed(dfs, meta=None, divisions=None, prefix='from-delayed',
     df = Frame(dsk3, name, meta, divs)
 
     if divisions == 'sorted':
-        from ..core import compute_divisions
+        from ..shuffle import compute_divisions
         divisions = compute_divisions(df)
         df.divisions = divisions
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -202,6 +202,9 @@ def concat(dfs, axis=0, join='outer', uniform=False):
     if axis == 1:
         return pd.concat(dfs, axis=axis, join=join)
 
+    if len(dfs) == 1:
+        return dfs[0]
+
     # Support concatenating indices along axis 0
     if isinstance(dfs[0], pd.Index):
         if isinstance(dfs[0], pd.CategoricalIndex):

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -54,7 +54,7 @@ def set_index(df, index, npartitions=None, shuffle=None, compute=False,
         iparts = index2.to_delayed()
         mins = [ipart.min() for ipart in iparts]
         maxes = [ipart.max() for ipart in iparts]
-        divisions, sizes, mins, maxes  = base.compute(divisions, sizes, mins, maxes)
+        divisions, sizes, mins, maxes = base.compute(divisions, sizes, mins, maxes)
         divisions = divisions.tolist()
 
         if repartition:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -224,19 +224,30 @@ def test_set_index_timezone():
     d1 = d.set_index('notz', npartitions=2)
     s1 = pd.DatetimeIndex(s_naive.values, dtype=s_naive.dtype)
     assert d1.divisions[0] == s_naive[0] == s1[0]
-    assert d1.divisions[2] == s_naive[2] == s1[2]
+    assert d1.divisions[-1] == s_naive[2] == s1[2]
 
     # We currently lose "freq".  Converting data with pandas-defined dtypes
     # to numpy or pure Python can be lossy like this.
     d2 = d.set_index('tz', npartitions=2)
-    s2 = pd.DatetimeIndex(s_aware.values, dtype=s_aware.dtype)
+    s2 = pd.DatetimeIndex(s_aware, dtype=s_aware.dtype)
     assert d2.divisions[0] == s2[0]
-    assert d2.divisions[2] == s2[2]
+    assert d2.divisions[-1] == s2[2]
     assert d2.divisions[0].tz == s2[0].tz
     assert d2.divisions[0].tz is not None
     s2badtype = pd.DatetimeIndex(s_aware.values, dtype=s_naive.dtype)
     with pytest.raises(TypeError):
         d2.divisions[0] == s2badtype[0]
+
+
+@pytest.mark.parametrize('npartitions', [1,
+    pytest.mark.xfail(2, reason='pandas join removes freq')])
+def test_timezone_freq(npartitions):
+    s_naive = pd.Series(pd.date_range('20130101', periods=10))
+    s_aware = pd.Series(pd.date_range('20130101', periods=10, tz='US/Eastern'))
+    pdf = pd.DataFrame({'tz': s_aware, 'notz': s_naive})
+    ddf = dd.from_pandas(pdf, npartitions=npartitions)
+
+    assert pdf.tz[0].freq == ddf.compute().tz[0].freq == ddf.tz.compute()[0].freq
 
 
 @pytest.mark.parametrize('drop', [True, False])

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -239,8 +239,10 @@ def test_set_index_timezone():
         d2.divisions[0] == s2badtype[0]
 
 
-@pytest.mark.parametrize('npartitions', [1,
-    pytest.mark.xfail(2, reason='pandas join removes freq')])
+@pytest.mark.parametrize(
+    'npartitions',
+    [1, pytest.mark.xfail(2, reason='pandas join removes freq')]
+)
 def test_timezone_freq(npartitions):
     s_naive = pd.Series(pd.date_range('20130101', periods=10))
     s_aware = pd.Series(pd.date_range('20130101', periods=10, tz='US/Eastern'))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -194,12 +194,12 @@ def test_set_index():
 
 
 def test_set_index_interpolate():
-    df = pd.DataFrame({'x': [1, 1, 1, 3, 3], 'y': [1., 1, 1, 1, 2]})
+    df = pd.DataFrame({'x': [4, 1, 1, 3, 3], 'y': [1., 1, 1, 1, 2]})
     d = dd.from_pandas(df, 2)
 
     d1 = d.set_index('x', npartitions=3)
     assert d1.npartitions == 3
-    assert set(d1.divisions) == set([1, 2, 3])
+    assert set(d1.divisions) == set([1, 2, 3, 4])
 
     d2 = d.set_index('y', npartitions=3)
     assert d2.divisions[0] == 1.
@@ -2176,7 +2176,7 @@ def test_set_index_sorted_true():
 
 
 def test_compute_divisions():
-    from dask.dataframe.core import compute_divisions
+    from dask.dataframe.shuffle import compute_divisions
     df = pd.DataFrame({'x': [1, 2, 3, 4],
                        'y': [10, 20, 30, 40],
                        'z': [4, 3, 2, 1]},

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -143,27 +143,27 @@ def test_groupby_dir():
 
 @pytest.mark.parametrize('get', [dask.async.get_sync, dask.threaded.get])
 def test_groupby_on_index(get):
-    full = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
                          'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
                         index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
-    d = dd.from_pandas(full, npartitions=3)
+    ddf = dd.from_pandas(pdf, npartitions=3)
 
-    e = d.set_index('a')
-    efull = full.set_index('a')
-    assert_eq(d.groupby('a').b.mean(), e.groupby(e.index).b.mean())
+    ddf2 = ddf.set_index('a')
+    pdf2 = pdf.set_index('a')
+    assert_eq(ddf.groupby('a').b.mean(), ddf2.groupby(ddf2.index).b.mean())
 
     def func(df):
         return df.assign(b=df.b - df.b.mean())
 
     with dask.set_options(get=get):
-        assert_eq(d.groupby('a').apply(func),
-                  full.groupby('a').apply(func))
+        assert_eq(ddf.groupby('a').apply(func),
+                  pdf.groupby('a').apply(func))
 
-        assert_eq(d.groupby('a').apply(func).set_index('a'),
-                  full.groupby('a').apply(func).set_index('a'))
+        assert_eq(ddf.groupby('a').apply(func).set_index('a'),
+                  pdf.groupby('a').apply(func).set_index('a'))
 
-        assert_eq(efull.groupby(efull.index).apply(func),
-                  e.groupby(e.index).apply(func))
+        assert_eq(pdf2.groupby(pdf2.index).apply(func),
+                  ddf2.groupby(ddf2.index).apply(func))
 
 
 def test_groupby_multilevel_getitem():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -144,8 +144,8 @@ def test_groupby_dir():
 @pytest.mark.parametrize('get', [dask.async.get_sync, dask.threaded.get])
 def test_groupby_on_index(get):
     pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
-                         'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-                        index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
+                        'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
+                       index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
     ddf = dd.from_pandas(pdf, npartitions=3)
 
     ddf2 = ddf.set_index('a')

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -240,7 +240,7 @@ def test_shuffle_sort(shuffle):
 @pytest.mark.parametrize('shuffle', ['tasks', 'disk'])
 @pytest.mark.parametrize('get', [threaded_get, mp_get])
 def test_rearrange(shuffle, get):
-    df = pd.DataFrame({'x': range(10)})
+    df = pd.DataFrame({'x': np.random.random(10)})
     ddf = dd.from_pandas(df, npartitions=4)
     ddf2 = ddf.assign(y=ddf.x % 4)
 
@@ -292,7 +292,7 @@ def test_set_index_with_explicit_divisions():
 
 @pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
 def test_set_index_reduces_partitions_small(shuffle):
-    df = pd.DataFrame({'x': range(100)})
+    df = pd.DataFrame({'x': np.random.random(100)})
     ddf = dd.from_pandas(df, npartitions=50)
 
     ddf2 = ddf.set_index('x', shuffle=shuffle, npartitions='auto')
@@ -302,7 +302,9 @@ def test_set_index_reduces_partitions_small(shuffle):
 @pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
 def test_set_index_reduces_partitions_large(shuffle):
     n = 2**24
-    df = pd.DataFrame({'x': np.arange(n), 'y': np.arange(n), 'z': np.arange(n)})
+    df = pd.DataFrame({'x': np.random.random(n),
+                       'y': np.random.random(n),
+                       'z': np.random.random(n)})
     ddf = dd.from_pandas(df, npartitions=50, name='x', sort=False)
 
     ddf2 = ddf.set_index('x', shuffle=shuffle, npartitions='auto')
@@ -312,8 +314,19 @@ def test_set_index_reduces_partitions_large(shuffle):
 @pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
 def test_set_index_doesnt_increase_partitions(shuffle):
     n = 2**24
-    df = pd.DataFrame({'x': np.arange(n), 'y': np.arange(n), 'z': np.arange(n)})
+    df = pd.DataFrame({'x': np.random.random(n),
+                       'y': np.random.random(n),
+                       'z': np.random.random(n)})
     ddf = dd.from_pandas(df, npartitions=2, name='x', sort=False)
 
     ddf2 = ddf.set_index('x', shuffle=shuffle, npartitions='auto')
     assert ddf2.npartitions <= ddf.npartitions
+
+
+@pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
+def test_set_index_detects_sorted_data(shuffle):
+    df = pd.DataFrame({'x': range(100), 'y': range(100)})
+    ddf = dd.from_pandas(df, npartitions=10, name='x', sort=False)
+
+    ddf2 = ddf.set_index('x', shuffle=shuffle)
+    assert len(ddf2.dask) < ddf.npartitions * 4


### PR DESCRIPTION
When we're already going through the index column to get divisions we
now also check to see if the column is sorted.  If so then we avoid the
shuffle entirely.

cc @AlbertDeFusco this would have saved you had it been around before.