### PR TITLE
Abstract FFT interface

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -89,73 +89,29 @@ def _ihfft_out_chunks(a, n, axis):
     return chunks
 
 
-def fft_wrapper(fft_func):
+def fft_wrapper(fft_func, kind):
     """ Wrapper of 1D complex FFT functions
 
-    Takes a function that behaves like ``numpy.fft.fft``.
+    Takes a function that behaves like ``numpy.fft`` functions.
     """
 
-    return _fft_wrap(np.complex_, _fft_out_chunks)(fft_func)
+    if kind == "fft":
+        return _fft_wrap(np.complex_, _fft_out_chunks)(fft_func)
+    elif kind == "ifft":
+        return _fft_wrap(np.complex_, _fft_out_chunks)(fft_func)
+    elif kind == "rfft":
+        return _fft_wrap(np.complex_, _rfft_out_chunks)(fft_func)
+    elif kind == "irfft":
+        return _fft_wrap(np.float_, _irfft_out_chunks)(fft_func)
+    elif kind == "hfft":
+        return _fft_wrap(np.float_, _hfft_out_chunks)(fft_func)
+    elif kind == "ihfft":
+        return _fft_wrap(np.complex_, _ihfft_out_chunks)(fft_func)
 
 
-def ifft_wrapper(fft_func):
-    """ wrapper of 1D complex inverse FFT functions
-
-    takes a function that behaves like ``numpy.fft.ifft``.
-    """
-
-    return _fft_wrap(np.complex_, _fft_out_chunks)(fft_func)
-
-
-def rfft_wrapper(fft_func):
-    """ wrapper of 1D real FFT functions
-
-    takes a function that behaves like ``numpy.fft.rfft``.
-    """
-
-    return _fft_wrap(np.complex_, _rfft_out_chunks)(fft_func)
-
-
-def irfft_wrapper(fft_func):
-    """ wrapper of 1D real inverse FFT functions
-
-    takes a function that behaves like ``numpy.fft.irfft``.
-    """
-
-    return _fft_wrap(np.float_, _irfft_out_chunks)(fft_func)
-
-
-def hfft_wrapper(fft_func):
-    """ wrapper of 1D hermitian complex FFT functions
-
-    takes a function that behaves like ``numpy.fft.hfft``.
-    """
-
-    return _fft_wrap(np.float_, _hfft_out_chunks)(fft_func)
-
-
-def ihfft_wrapper(fft_func):
-    """ wrapper of 1D hermitian complex inverse FFT functions
-
-    takes a function that behaves like ``numpy.fft.ihfft``.
-    """
-
-    return _fft_wrap(np.complex_, _ihfft_out_chunks)(fft_func)
-
-
-fft = fft_wrapper(npfft.fft)
-
-
-ifft = ifft_wrapper(npfft.ifft)
-
-
-rfft = rfft_wrapper(npfft.rfft)
-
-
-irfft = irfft_wrapper(npfft.irfft)
-
-
-hfft = hfft_wrapper(npfft.hfft)
-
-
-ihfft = ihfft_wrapper(npfft.ihfft)
+fft = fft_wrapper(npfft.fft, kind="fft")
+ifft = fft_wrapper(npfft.ifft, kind="ifft")
+rfft = fft_wrapper(npfft.rfft, kind="rfft")
+irfft = fft_wrapper(npfft.irfft, kind="irfft")
+hfft = fft_wrapper(npfft.hfft, kind="hfft")
+ihfft = fft_wrapper(npfft.ihfft, kind="ihfft")

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -107,6 +107,8 @@ def fft_wrapper(fft_func, kind):
         return _fft_wrap(np.float_, _hfft_out_chunks)(fft_func)
     elif kind == "ihfft":
         return _fft_wrap(np.complex_, _ihfft_out_chunks)(fft_func)
+    else:
+        raise ValueError("Given unknown `kind` %s." % kind)
 
 
 fft = fft_wrapper(npfft.fft, kind="fft")

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -26,7 +26,7 @@ fft_preamble = """
 
 def _fft_wrap(fft_func, dtype=None, out_chunk_fn=None):
     if dtype is None:
-        dtype = fft_func(np.ones(1)).dtype
+        dtype = fft_func(np.ones(8)).dtype
     def func(a, n=None, axis=-1):
         if len(a.chunks[axis]) != 1:
             raise ValueError(chunk_error % (axis, a.chunks[axis]))
@@ -88,13 +88,6 @@ def _ihfft_out_chunks(a, n, axis):
     return chunks
 
 
-dtypes = {'fft': np.complex_,
-          'ifft': np.complex_,
-          'rfft': np.complex_,
-          'irfft': np.float_,
-          'hfft': np.float_,
-          'ihfft': np.complex}
-
 out_chunk_fns = {'fft': _fft_out_chunks,
                  'ifft': _fft_out_chunks,
                  'rfft': _rfft_out_chunks,
@@ -103,7 +96,7 @@ out_chunk_fns = {'fft': _fft_out_chunks,
                  'ihfft': _ihfft_out_chunks}
 
 
-def fft_wrapper(fft_func, kind=None):
+def fft_wrapper(fft_func, kind=None, dtype=None):
     """ Wrapper of 1D complex FFT functions
 
     Takes a function that behaves like ``numpy.fft`` functions and
@@ -123,7 +116,6 @@ def fft_wrapper(fft_func, kind=None):
     """
     if kind is None:
         kind = fft_func.__name__
-    dtype = dtypes.get(kind)
     try:
         out_chunk_fn = out_chunk_fns[kind]
     except KeyError:
@@ -132,9 +124,9 @@ def fft_wrapper(fft_func, kind=None):
         return _fft_wrap(fft_func, out_chunk_fn=out_chunk_fn, dtype=dtype)
 
 
-fft = fft_wrapper(np.fft.fft)
-ifft = fft_wrapper(np.fft.ifft)
-rfft = fft_wrapper(np.fft.rfft)
-irfft = fft_wrapper(np.fft.irfft)
-hfft = fft_wrapper(np.fft.hfft)
-ihfft = fft_wrapper(np.fft.ihfft)
+fft = fft_wrapper(np.fft.fft, dtype=np.complex_)
+ifft = fft_wrapper(np.fft.ifft, dtype=np.complex_)
+rfft = fft_wrapper(np.fft.rfft, dtype=np.complex_)
+irfft = fft_wrapper(np.fft.irfft, dtype=np.float_)
+hfft = fft_wrapper(np.fft.hfft, dtype=np.float_)
+ihfft = fft_wrapper(np.fft.ihfft, dtype=np.complex_)

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -95,19 +95,36 @@ def fft_wrapper(fft_func, kind):
     Takes a function that behaves like ``numpy.fft`` functions.
     """
 
-    if kind == "fft":
-        return _fft_wrap(np.complex_, _fft_out_chunks)(fft_func)
-    elif kind == "ifft":
-        return _fft_wrap(np.complex_, _fft_out_chunks)(fft_func)
-    elif kind == "rfft":
-        return _fft_wrap(np.complex_, _rfft_out_chunks)(fft_func)
-    elif kind == "irfft":
-        return _fft_wrap(np.float_, _irfft_out_chunks)(fft_func)
-    elif kind == "hfft":
-        return _fft_wrap(np.float_, _hfft_out_chunks)(fft_func)
-    elif kind == "ihfft":
-        return _fft_wrap(np.complex_, _ihfft_out_chunks)(fft_func)
-    else:
+    params = {
+        "fft": {
+            "dtype": np.complex_,
+            "out_chunk_fn" : _fft_out_chunks
+        },
+        "ifft": {
+            "dtype": np.complex_,
+            "out_chunk_fn" : _fft_out_chunks
+        },
+        "rfft": {
+            "dtype": np.complex_,
+            "out_chunk_fn" : _rfft_out_chunks
+        },
+        "irfft": {
+            "dtype": np.float_,
+            "out_chunk_fn" : _irfft_out_chunks
+        },
+        "hfft": {
+            "dtype": np.float_,
+            "out_chunk_fn" : _hfft_out_chunks
+        },
+        "ihfft": {
+            "dtype": np.complex_,
+            "out_chunk_fn" : _ihfft_out_chunks
+        },
+    }
+
+    try:
+        return _fft_wrap(**params[kind])(fft_func)
+    except KeyError:
         raise ValueError("Given unknown `kind` %s." % kind)
 
 

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -100,10 +100,10 @@ def fft_wrap(fft_func, kind=None, dtype=None):
     except KeyError:
         raise ValueError("Given unknown `kind` %s." % kind)
 
-    if dtype is None:
-        dtype = fft_func(np.ones(8)).dtype
-
     def func(a, n=None, axis=-1):
+        if dtype is None:
+            dtype = fft_func(np.ones(8, dtype=a.dtype)).dtype
+
         if len(a.chunks[axis]) != 1:
             raise ValueError(chunk_error % (axis, a.chunks[axis]))
 

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -100,7 +100,9 @@ def fft_wrap(fft_func, kind=None, dtype=None):
     except KeyError:
         raise ValueError("Given unknown `kind` %s." % kind)
 
+    _dtype = dtype
     def func(a, n=None, axis=-1):
+        dtype = _dtype
         if dtype is None:
             dtype = fft_func(np.ones(8, dtype=a.dtype)).dtype
 

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -64,12 +64,12 @@ def _ihfft_out_chunks(a, n, axis):
     return chunks
 
 
-out_chunk_fns = {'fft': _fft_out_chunks,
-                 'ifft': _fft_out_chunks,
-                 'rfft': _rfft_out_chunks,
-                 'irfft': _irfft_out_chunks,
-                 'hfft': _hfft_out_chunks,
-                 'ihfft': _ihfft_out_chunks}
+_out_chunk_fns = {'fft': _fft_out_chunks,
+                  'ifft': _fft_out_chunks,
+                  'rfft': _rfft_out_chunks,
+                  'irfft': _irfft_out_chunks,
+                  'hfft': _hfft_out_chunks,
+                  'ihfft': _ihfft_out_chunks}
 
 
 def fft_wrap(fft_func, kind=None, dtype=None):
@@ -96,7 +96,7 @@ def fft_wrap(fft_func, kind=None, dtype=None):
     if kind is None:
         kind = fft_func.__name__
     try:
-        out_chunk_fn = out_chunk_fns[kind]
+        out_chunk_fn = _out_chunk_fns[kind]
     except KeyError:
         raise ValueError("Given unknown `kind` %s." % kind)
 

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -72,8 +72,8 @@ out_chunk_fns = {'fft': _fft_out_chunks,
                  'ihfft': _ihfft_out_chunks}
 
 
-def fft_wrapper(fft_func, kind=None, dtype=None):
-    """ Wrapper of 1D complex FFT functions
+def fft_wrap(fft_func, kind=None, dtype=None):
+    """ Wrap 1D complex FFT functions
 
     Takes a function that behaves like ``numpy.fft`` functions and
     a specified kind to match it to that are named after the functions
@@ -88,7 +88,10 @@ def fft_wrapper(fft_func, kind=None, dtype=None):
         * hfft
         * ihfft
 
-    >>> fft = fft_wrapper(np.fft.fft, kind="fft")
+    Examples
+    --------
+    >>> parallel_fft = fft_wrap(np.fft.fft)
+    >>> parallel_ifft = fft_wrap(np.fft.ifft)
     """
     if kind is None:
         kind = fft_func.__name__
@@ -116,9 +119,9 @@ def fft_wrapper(fft_func, kind=None, dtype=None):
     return func
 
 
-fft = fft_wrapper(np.fft.fft, dtype=np.complex_)
-ifft = fft_wrapper(np.fft.ifft, dtype=np.complex_)
-rfft = fft_wrapper(np.fft.rfft, dtype=np.complex_)
-irfft = fft_wrapper(np.fft.irfft, dtype=np.float_)
-hfft = fft_wrapper(np.fft.hfft, dtype=np.float_)
-ihfft = fft_wrapper(np.fft.ihfft, dtype=np.complex_)
+fft = fft_wrap(np.fft.fft, dtype=np.complex_)
+ifft = fft_wrap(np.fft.ifft, dtype=np.complex_)
+rfft = fft_wrap(np.fft.rfft, dtype=np.complex_)
+irfft = fft_wrap(np.fft.irfft, dtype=np.float_)
+hfft = fft_wrap(np.fft.hfft, dtype=np.float_)
+ihfft = fft_wrap(np.fft.ihfft, dtype=np.complex_)

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -92,7 +92,20 @@ def _ihfft_out_chunks(a, n, axis):
 def fft_wrapper(fft_func, kind):
     """ Wrapper of 1D complex FFT functions
 
-    Takes a function that behaves like ``numpy.fft`` functions.
+    Takes a function that behaves like ``numpy.fft`` functions and
+    a specified kind to match it to that are named after the functions
+    in the ``numpy.fft`` API.
+
+    Supported kinds include:
+
+        * fft
+        * ifft
+        * rfft
+        * irfft
+        * hfft
+        * ihfft
+
+    >>> fft = fft_wrapper(npfft.fft, kind="fft")
     """
 
     params = {

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -89,19 +89,73 @@ def _ihfft_out_chunks(a, n, axis):
     return chunks
 
 
-fft = _fft_wrap(np.complex_, _fft_out_chunks)(npfft.fft)
+def fft_wrapper(fft_func):
+    """ Wrapper of 1D complex FFT functions
+
+    Takes a function that behaves like ``numpy.fft.fft``.
+    """
+
+    return _fft_wrap(np.complex_, _fft_out_chunks)(fft_func)
 
 
-ifft = _fft_wrap(np.complex_, _fft_out_chunks)(npfft.ifft)
+def ifft_wrapper(fft_func):
+    """ wrapper of 1D complex inverse FFT functions
+
+    takes a function that behaves like ``numpy.fft.ifft``.
+    """
+
+    return _fft_wrap(np.complex_, _fft_out_chunks)(fft_func)
 
 
-rfft = _fft_wrap(np.complex_, _rfft_out_chunks)(npfft.rfft)
+def rfft_wrapper(fft_func):
+    """ wrapper of 1D real FFT functions
+
+    takes a function that behaves like ``numpy.fft.rfft``.
+    """
+
+    return _fft_wrap(np.complex_, _rfft_out_chunks)(fft_func)
 
 
-irfft = _fft_wrap(np.float_, _irfft_out_chunks)(npfft.irfft)
+def irfft_wrapper(fft_func):
+    """ wrapper of 1D real inverse FFT functions
+
+    takes a function that behaves like ``numpy.fft.irfft``.
+    """
+
+    return _fft_wrap(np.float_, _irfft_out_chunks)(fft_func)
 
 
-hfft = _fft_wrap(np.float_, _hfft_out_chunks)(npfft.hfft)
+def hfft_wrapper(fft_func):
+    """ wrapper of 1D hermitian complex FFT functions
+
+    takes a function that behaves like ``numpy.fft.hfft``.
+    """
+
+    return _fft_wrap(np.float_, _hfft_out_chunks)(fft_func)
 
 
-ihfft = _fft_wrap(np.complex_, _ihfft_out_chunks)(npfft.ihfft)
+def ihfft_wrapper(fft_func):
+    """ wrapper of 1D hermitian complex inverse FFT functions
+
+    takes a function that behaves like ``numpy.fft.ihfft``.
+    """
+
+    return _fft_wrap(np.complex_, _ihfft_out_chunks)(fft_func)
+
+
+fft = fft_wrapper(npfft.fft)
+
+
+ifft = ifft_wrapper(npfft.ifft)
+
+
+rfft = rfft_wrapper(npfft.rfft)
+
+
+irfft = irfft_wrapper(npfft.irfft)
+
+
+hfft = hfft_wrapper(npfft.hfft)
+
+
+ihfft = ihfft_wrapper(npfft.ihfft)

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import numbers
-
 import numpy as np
 
 
@@ -21,7 +19,7 @@ fft_preamble = """
     """
 
 
-def _fft_out_chunks(a, n, axis, rtype):
+def _fft_out_chunks(a, n, axis):
     """ For computing the output chunks of fft and ifft"""
     if n is None:
         return a.chunks
@@ -30,29 +28,15 @@ def _fft_out_chunks(a, n, axis, rtype):
     return chunks
 
 
-def _rfft_out_chunks(a, n, axis, rtype):
+def _rfft_out_chunks(a, n, axis):
     if n is None:
         n = a.chunks[axis][0]
     chunks = list(a.chunks)
-    if issubclass(np.dtype(rtype).type, numbers.Real):
-        chunks[axis] = (n,)
-    else:
-        chunks[axis] = (n // 2 + 1,)
+    chunks[axis] = (n // 2 + 1,)
     return chunks
 
 
-def _irfft_out_chunks(a, n, axis, rtype):
-    if n is None:
-        n = a.chunks[axis][0]
-    chunks = list(a.chunks)
-    if issubclass(a.dtype.type, numbers.Real):
-        chunks[axis] = (n,)
-    else:
-        chunks[axis] = (2 * (n - 1),)
-    return chunks
-
-
-def _hfft_out_chunks(a, n, axis, rtype):
+def _irfft_out_chunks(a, n, axis):
     if n is None:
         n = 2 * (a.chunks[axis][0] - 1)
     chunks = list(a.chunks)
@@ -60,7 +44,15 @@ def _hfft_out_chunks(a, n, axis, rtype):
     return chunks
 
 
-def _ihfft_out_chunks(a, n, axis, rtype):
+def _hfft_out_chunks(a, n, axis):
+    if n is None:
+        n = 2 * (a.chunks[axis][0] - 1)
+    chunks = list(a.chunks)
+    chunks[axis] = (n,)
+    return chunks
+
+
+def _ihfft_out_chunks(a, n, axis):
     if n is None:
         n = a.chunks[axis][0]
     chunks = list(a.chunks)
@@ -118,7 +110,7 @@ def fft_wrap(fft_func, kind=None, dtype=None):
         if len(a.chunks[axis]) != 1:
             raise ValueError(chunk_error % (axis, a.chunks[axis]))
 
-        chunks = out_chunk_fn(a, n, axis, dtype)
+        chunks = out_chunk_fn(a, n, axis)
 
         return a.map_blocks(fft_func, n=n, axis=axis, dtype=dtype,
                             chunks=chunks)

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -109,6 +109,7 @@ def fft_wrap(fft_func, kind=None, dtype=None):
         raise ValueError("Given unknown `kind` %s." % kind)
 
     _dtype = dtype
+
     def func(a, n=None, axis=-1):
         dtype = _dtype
         if dtype is None:

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -2,6 +2,12 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+try:
+    import scipy
+    import scipy.fftpack
+except ImportError:
+    scipy = None
+
 
 chunk_error = ("Dask array only supports taking an FFT along an axis that \n"
                "has a single chunk. An FFT operation was tried on axis %s \n"
@@ -93,6 +99,12 @@ def fft_wrap(fft_func, kind=None, dtype=None):
     >>> parallel_fft = fft_wrap(np.fft.fft)
     >>> parallel_ifft = fft_wrap(np.fft.ifft)
     """
+    if scipy is not None:
+        if fft_func is scipy.fftpack.rfft:
+            raise ValueError("SciPy's `rfft` doesn't match the NumPy API.")
+        elif fft_func is scipy.fftpack.irfft:
+            raise ValueError("SciPy's `irfft` doesn't match the NumPy API.")
+
     if kind is None:
         kind = fft_func.__name__
     try:

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -134,3 +134,9 @@ def test_wrap_ffts(modname, funcname):
     assert_eq(wfunc(darr), func(nparr))
     assert_eq(wfunc(darr, axis=1), func(nparr, axis=1))
     assert_eq(wfunc(darr2, axis=0), func(nparr, axis=0))
+    assert_eq(wfunc(darr, n=len(darr)-1),
+              func(nparr, n=len(darr)-1))
+    assert_eq(wfunc(darr, axis=1, n=darr.shape[1]-1),
+              func(nparr, n=darr.shape[1]-1))
+    assert_eq(wfunc(darr2, axis=0, n=darr2.shape[0]-1),
+              func(nparr, axis=0, n=darr2.shape[0]-1))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -118,8 +118,7 @@ def test_wrap_bad_kind():
 
 
 @pytest.mark.parametrize("modname", ["numpy.fft", "scipy.fftpack"])
-@pytest.mark.parametrize(
-    "funcname",
+@pytest.mark.parametrize("funcname",
     ["fft", "ifft", "rfft", "irfft", "hfft", "ihfft"]
 )
 def test_wrap_ffts(modname, funcname):

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -131,6 +131,9 @@ def test_wrap_ffts(modname, funcname):
         pytest.skip("`%s` missing function `%s`." % (modname, funcname))
 
     wfunc = fft_wrap(func)
+    assert_eq(wfunc(darr).dtype, func(nparr).dtype)
+    assert_eq(wfunc(darr.astype(np.float32)).dtype,
+              func(nparr.astype(np.float32)).dtype)
     assert_eq(wfunc(darr), func(nparr))
     assert_eq(wfunc(darr, axis=1), func(nparr, axis=1))
     assert_eq(wfunc(darr2, axis=0), func(nparr, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -139,3 +139,15 @@ def test_wrap_numpy():
     ihfft = ihfft_wrapper(npfft.ihfft)
     assert_eq(ihfft(darr), npfft.ihfft(nparr))
     assert_eq(ihfft(darr2, axis=0), npfft.ihfft(nparr, axis=0))
+
+
+def test_wrap_scipy():
+    spfft = pytest.importorskip("scipy.fftpack")
+
+    fft = fft_wrapper(spfft.fft)
+    assert_eq(fft(darr), spfft.fft(nparr))
+    assert_eq(fft(darr2, axis=0), spfft.fft(nparr, axis=0))
+
+    ifft = ifft_wrapper(spfft.ifft)
+    assert_eq(ifft(darr), spfft.ifft(nparr))
+    assert_eq(ifft(darr2, axis=0), spfft.ifft(nparr, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -117,22 +117,24 @@ def test_wrap_bad_kind():
         fft_wrapper(npfft.fft, kind="foo")
 
 
-@pytest.mark.parametrize("funcname", ["rfft", "irfft"])
-def test_wrap_numpy_real(funcname):
-    func = getattr(npfft, funcname)
-    wfunc = fft_wrapper(func, kind=funcname)
-    assert_eq(wfunc(darr), func(nparr))
-    assert_eq(wfunc(darr2, axis=0), func(nparr, axis=0))
-
-
 @pytest.mark.parametrize("modname", ["numpy.fft", "scipy.fftpack"])
-@pytest.mark.parametrize("funcname", ["fft", "ifft", "hfft", "ihfft"])
+@pytest.mark.parametrize(
+    "funcname",
+    ["fft", "ifft", "rfft", "irfft", "hfft", "ihfft"]
+)
 def test_wrap_ffts(modname, funcname):
     fft_mod = pytest.importorskip(modname)
     try:
         func = getattr(fft_mod, funcname)
     except AttributeError:
         pytest.skip("`%s` missing function `%s`." % (modname, funcname))
+
+    if modname == "scipy.fftpack" and "rfft" in funcname:
+        pytest.skip(
+            "`%s` function `%s` doesn't support the NumPy API." % (
+                modname, funcname
+            )
+        )
 
     wfunc = fft_wrapper(func, kind=funcname)
     assert_eq(wfunc(darr), func(nparr))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -114,7 +114,7 @@ def test_fft_consistent_names():
 
 def test_wrap_bad_kind():
     with pytest.raises(ValueError):
-        fft_wrapper(npfft.fft, kind="foo")
+        fft_wrapper(np.ones)
 
 
 @pytest.mark.parametrize("modname", ["numpy.fft", "scipy.fftpack"])
@@ -129,6 +129,6 @@ def test_wrap_ffts(modname, funcname):
     except AttributeError:
         pytest.skip("`%s` missing function `%s`." % (modname, funcname))
 
-    wfunc = fft_wrapper(func, kind=funcname)
+    wfunc = fft_wrapper(func)
     assert_eq(wfunc(darr), func(nparr))
     assert_eq(wfunc(darr2, axis=0), func(nparr, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -1,11 +1,10 @@
 import numpy as np
-import numpy.fft as npfft
 
 import pytest
 
 import dask.array as da
 from dask.array.fft import (
-    fft_wrapper, fft, ifft, rfft, irfft, hfft, ihfft,
+    fft_wrap, fft, ifft, rfft, irfft, hfft, ihfft,
 )
 from dask.array.utils import assert_eq
 
@@ -26,84 +25,86 @@ darr2 = da.from_array(nparr, chunks=(10, 1))
 
 def test_cant_fft_chunked_axis():
     bad_darr = da.from_array(nparr, chunks=(5, 5))
-    pytest.raises(ValueError, lambda: fft(bad_darr))
-    pytest.raises(ValueError, lambda: fft(bad_darr, axis=0))
+    with pytest.raises(ValueError):
+        fft(bad_darr)
+    with pytest.raises(ValueError):
+        fft(bad_darr, axis=0)
 
 
 def test_fft():
-    assert_eq(fft(darr), npfft.fft(nparr))
-    assert_eq(fft(darr2, axis=0), npfft.fft(nparr, axis=0))
+    assert_eq(fft(darr), np.fft.fft(nparr))
+    assert_eq(fft(darr2, axis=0), np.fft.fft(nparr, axis=0))
 
 
 def test_fft_n_kwarg():
-    assert_eq(fft(darr, 5), npfft.fft(nparr, 5))
-    assert_eq(fft(darr, 13), npfft.fft(nparr, 13))
-    assert_eq(fft(darr2, 5, axis=0), npfft.fft(nparr, 5, axis=0))
-    assert_eq(fft(darr2, 13, axis=0), npfft.fft(nparr, 13, axis=0))
+    assert_eq(fft(darr, 5), np.fft.fft(nparr, 5))
+    assert_eq(fft(darr, 13), np.fft.fft(nparr, 13))
+    assert_eq(fft(darr2, 5, axis=0), np.fft.fft(nparr, 5, axis=0))
+    assert_eq(fft(darr2, 13, axis=0), np.fft.fft(nparr, 13, axis=0))
 
 
 def test_ifft():
-    assert_eq(ifft(darr), npfft.ifft(nparr))
-    assert_eq(ifft(darr2, axis=0), npfft.ifft(nparr, axis=0))
+    assert_eq(ifft(darr), np.fft.ifft(nparr))
+    assert_eq(ifft(darr2, axis=0), np.fft.ifft(nparr, axis=0))
 
 
 def test_ifft_n_kwarg():
-    assert_eq(ifft(darr, 5), npfft.ifft(nparr, 5))
-    assert_eq(ifft(darr, 13), npfft.ifft(nparr, 13))
-    assert_eq(ifft(darr2, 5, axis=0), npfft.ifft(nparr, 5, axis=0))
-    assert_eq(ifft(darr2, 13, axis=0), npfft.ifft(nparr, 13, axis=0))
+    assert_eq(ifft(darr, 5), np.fft.ifft(nparr, 5))
+    assert_eq(ifft(darr, 13), np.fft.ifft(nparr, 13))
+    assert_eq(ifft(darr2, 5, axis=0), np.fft.ifft(nparr, 5, axis=0))
+    assert_eq(ifft(darr2, 13, axis=0), np.fft.ifft(nparr, 13, axis=0))
 
 
 def test_rfft():
-    assert_eq(rfft(darr), npfft.rfft(nparr))
-    assert_eq(rfft(darr2, axis=0), npfft.rfft(nparr, axis=0))
+    assert_eq(rfft(darr), np.fft.rfft(nparr))
+    assert_eq(rfft(darr2, axis=0), np.fft.rfft(nparr, axis=0))
 
 
 def test_rfft_n_kwarg():
-    assert_eq(rfft(darr, 5), npfft.rfft(nparr, 5))
-    assert_eq(rfft(darr, 13), npfft.rfft(nparr, 13))
-    assert_eq(rfft(darr2, 5, axis=0), npfft.rfft(nparr, 5, axis=0))
-    assert_eq(rfft(darr2, 13, axis=0), npfft.rfft(nparr, 13, axis=0))
-    assert_eq(rfft(darr2, 12, axis=0), npfft.rfft(nparr, 12, axis=0))
+    assert_eq(rfft(darr, 5), np.fft.rfft(nparr, 5))
+    assert_eq(rfft(darr, 13), np.fft.rfft(nparr, 13))
+    assert_eq(rfft(darr2, 5, axis=0), np.fft.rfft(nparr, 5, axis=0))
+    assert_eq(rfft(darr2, 13, axis=0), np.fft.rfft(nparr, 13, axis=0))
+    assert_eq(rfft(darr2, 12, axis=0), np.fft.rfft(nparr, 12, axis=0))
 
 
 def test_irfft():
-    assert_eq(irfft(darr), npfft.irfft(nparr))
-    assert_eq(irfft(darr2, axis=0), npfft.irfft(nparr, axis=0))
+    assert_eq(irfft(darr), np.fft.irfft(nparr))
+    assert_eq(irfft(darr2, axis=0), np.fft.irfft(nparr, axis=0))
 
 
 def test_irfft_n_kwarg():
-    assert_eq(irfft(darr, 5), npfft.irfft(nparr, 5))
-    assert_eq(irfft(darr, 13), npfft.irfft(nparr, 13))
-    assert_eq(irfft(darr2, 5, axis=0), npfft.irfft(nparr, 5, axis=0))
-    assert_eq(irfft(darr2, 13, axis=0), npfft.irfft(nparr, 13, axis=0))
-    assert_eq(irfft(darr2, 12, axis=0), npfft.irfft(nparr, 12, axis=0))
+    assert_eq(irfft(darr, 5), np.fft.irfft(nparr, 5))
+    assert_eq(irfft(darr, 13), np.fft.irfft(nparr, 13))
+    assert_eq(irfft(darr2, 5, axis=0), np.fft.irfft(nparr, 5, axis=0))
+    assert_eq(irfft(darr2, 13, axis=0), np.fft.irfft(nparr, 13, axis=0))
+    assert_eq(irfft(darr2, 12, axis=0), np.fft.irfft(nparr, 12, axis=0))
 
 
 def test_hfft():
-    assert_eq(hfft(darr), npfft.hfft(nparr))
-    assert_eq(hfft(darr2, axis=0), npfft.hfft(nparr, axis=0))
+    assert_eq(hfft(darr), np.fft.hfft(nparr))
+    assert_eq(hfft(darr2, axis=0), np.fft.hfft(nparr, axis=0))
 
 
 def test_hfft_nkwarg():
-    assert_eq(hfft(darr, 5), npfft.hfft(nparr, 5))
-    assert_eq(hfft(darr, 13), npfft.hfft(nparr, 13))
-    assert_eq(hfft(darr2, 5, axis=0), npfft.hfft(nparr, 5, axis=0))
-    assert_eq(hfft(darr2, 13, axis=0), npfft.hfft(nparr, 13, axis=0))
-    assert_eq(hfft(darr2, 12, axis=0), npfft.hfft(nparr, 12, axis=0))
+    assert_eq(hfft(darr, 5), np.fft.hfft(nparr, 5))
+    assert_eq(hfft(darr, 13), np.fft.hfft(nparr, 13))
+    assert_eq(hfft(darr2, 5, axis=0), np.fft.hfft(nparr, 5, axis=0))
+    assert_eq(hfft(darr2, 13, axis=0), np.fft.hfft(nparr, 13, axis=0))
+    assert_eq(hfft(darr2, 12, axis=0), np.fft.hfft(nparr, 12, axis=0))
 
 
 def test_ihfft():
-    assert_eq(ihfft(darr), npfft.ihfft(nparr))
-    assert_eq(ihfft(darr2, axis=0), npfft.ihfft(nparr, axis=0))
+    assert_eq(ihfft(darr), np.fft.ihfft(nparr))
+    assert_eq(ihfft(darr2, axis=0), np.fft.ihfft(nparr, axis=0))
 
 
 def test_ihfft_n_kwarg():
-    assert_eq(ihfft(darr, 5), npfft.ihfft(nparr, 5))
-    assert_eq(ihfft(darr, 13), npfft.ihfft(nparr, 13))
-    assert_eq(ihfft(darr2, 5, axis=0), npfft.ihfft(nparr, 5, axis=0))
-    assert_eq(ihfft(darr2, 13, axis=0), npfft.ihfft(nparr, 13, axis=0))
-    assert_eq(ihfft(darr2, 12, axis=0), npfft.ihfft(nparr, 12, axis=0))
+    assert_eq(ihfft(darr, 5), np.fft.ihfft(nparr, 5))
+    assert_eq(ihfft(darr, 13), np.fft.ihfft(nparr, 13))
+    assert_eq(ihfft(darr2, 5, axis=0), np.fft.ihfft(nparr, 5, axis=0))
+    assert_eq(ihfft(darr2, 13, axis=0), np.fft.ihfft(nparr, 13, axis=0))
+    assert_eq(ihfft(darr2, 12, axis=0), np.fft.ihfft(nparr, 12, axis=0))
 
 
 def test_fft_consistent_names():
@@ -114,7 +115,7 @@ def test_fft_consistent_names():
 
 def test_wrap_bad_kind():
     with pytest.raises(ValueError):
-        fft_wrapper(np.ones)
+        fft_wrap(np.ones)
 
 
 @pytest.mark.parametrize("modname", ["numpy.fft", "scipy.fftpack"])
@@ -129,6 +130,6 @@ def test_wrap_ffts(modname, funcname):
     except AttributeError:
         pytest.skip("`%s` missing function `%s`." % (modname, funcname))
 
-    wfunc = fft_wrapper(func)
+    wfunc = fft_wrap(func)
     assert_eq(wfunc(darr), func(nparr))
     assert_eq(wfunc(darr2, axis=0), func(nparr, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -137,6 +137,7 @@ def test_wrap_ffts(modname, funcname, dtype):
 
     wfunc = fft_wrap(func)
     assert wfunc(darrc).dtype == func(nparrc).dtype
+    assert wfunc(darrc).shape == func(nparrc).shape
     assert_eq(wfunc(darrc), func(nparrc))
     assert_eq(wfunc(darrc, axis=1), func(nparrc, axis=1))
     assert_eq(wfunc(darr2c, axis=0), func(nparrc, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -132,4 +132,5 @@ def test_wrap_ffts(modname, funcname):
 
     wfunc = fft_wrap(func)
     assert_eq(wfunc(darr), func(nparr))
+    assert_eq(wfunc(darr, axis=1), func(nparr, axis=1))
     assert_eq(wfunc(darr2, axis=0), func(nparr, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -131,12 +131,6 @@ def test_wrap_ffts(modname, funcname, dtype):
     except AttributeError:
         pytest.skip("`%s` missing function `%s`." % (modname, funcname))
 
-    if modname == "numpy.fft" and funcname == "irfft":
-        if dtype == "float32":
-            dtype = "complex64"
-        elif dtype == "float64":
-            dtype = "complex128"
-
     darrc = darr.astype(dtype)
     darr2c = darr2.astype(dtype)
     nparrc = nparr.astype(dtype)

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -112,39 +112,23 @@ def test_fft_consistent_names():
     assert not same_keys(fft(darr, 5), fft(darr, 13))
 
 
-def test_wrap_numpy():
-    fft = fft_wrapper(npfft.fft, kind="fft")
-    assert_eq(fft(darr), npfft.fft(nparr))
-    assert_eq(fft(darr2, axis=0), npfft.fft(nparr, axis=0))
-
-    ifft = fft_wrapper(npfft.ifft, kind="ifft")
-    assert_eq(ifft(darr), npfft.ifft(nparr))
-    assert_eq(ifft(darr2, axis=0), npfft.ifft(nparr, axis=0))
-
-    rfft = fft_wrapper(npfft.rfft, kind="rfft")
-    assert_eq(rfft(darr), npfft.rfft(nparr))
-    assert_eq(rfft(darr2, axis=0), npfft.rfft(nparr, axis=0))
-
-    irfft = fft_wrapper(npfft.irfft, kind="irfft")
-    assert_eq(irfft(darr), npfft.irfft(nparr))
-    assert_eq(irfft(darr2, axis=0), npfft.irfft(nparr, axis=0))
-
-    hfft = fft_wrapper(npfft.hfft, kind="hfft")
-    assert_eq(hfft(darr), npfft.hfft(nparr))
-    assert_eq(hfft(darr2, axis=0), npfft.hfft(nparr, axis=0))
-
-    ihfft = fft_wrapper(npfft.ihfft, kind="ihfft")
-    assert_eq(ihfft(darr), npfft.ihfft(nparr))
-    assert_eq(ihfft(darr2, axis=0), npfft.ihfft(nparr, axis=0))
+@pytest.mark.parametrize("funcname", ["rfft", "irfft"])
+def test_wrap_numpy_real(funcname):
+    func = getattr(npfft, funcname)
+    wfunc = fft_wrapper(func, kind=funcname)
+    assert_eq(wfunc(darr), func(nparr))
+    assert_eq(wfunc(darr2, axis=0), func(nparr, axis=0))
 
 
-def test_wrap_scipy():
-    spfft = pytest.importorskip("scipy.fftpack")
+@pytest.mark.parametrize("modname", ["numpy.fft", "scipy.fftpack"])
+@pytest.mark.parametrize("funcname", ["fft", "ifft", "hfft", "ihfft"])
+def test_wrap_ffts(modname, funcname):
+    fft_mod = pytest.importorskip(modname)
+    try:
+        func = getattr(fft_mod, funcname)
+    except AttributeError:
+        pytest.skip("`%s` missing function `%s`." % (modname, funcname))
 
-    fft = fft_wrapper(spfft.fft, kind="fft")
-    assert_eq(fft(darr), spfft.fft(nparr))
-    assert_eq(fft(darr2, axis=0), spfft.fft(nparr, axis=0))
-
-    ifft = fft_wrapper(spfft.ifft, kind="fft")
-    assert_eq(ifft(darr), spfft.ifft(nparr))
-    assert_eq(ifft(darr2, axis=0), spfft.ifft(nparr, axis=0))
+    wfunc = fft_wrapper(func, kind=funcname)
+    assert_eq(wfunc(darr), func(nparr))
+    assert_eq(wfunc(darr2, axis=0), func(nparr, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -136,7 +136,7 @@ def test_wrap_ffts(modname, funcname, dtype):
     nparrc = nparr.astype(dtype)
 
     wfunc = fft_wrap(func)
-    assert_eq(wfunc(darrc).dtype, func(nparrc).dtype)
+    assert wfunc(darrc).dtype == func(nparrc).dtype
     assert_eq(wfunc(darrc), func(nparrc))
     assert_eq(wfunc(darrc, axis=1), func(nparrc, axis=1))
     assert_eq(wfunc(darr2c, axis=0), func(nparrc, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -4,7 +4,12 @@ import numpy.fft as npfft
 import pytest
 
 import dask.array as da
-from dask.array.fft import fft, ifft, rfft, irfft, hfft, ihfft
+from dask.array.fft import (
+    fft, ifft, rfft, irfft, hfft, ihfft,
+    fft_wrapper, ifft_wrapper,
+    rfft_wrapper, irfft_wrapper,
+    hfft_wrapper, ihfft_wrapper
+)
 from dask.array.utils import assert_eq
 
 
@@ -108,3 +113,29 @@ def test_fft_consistent_names():
     assert same_keys(fft(darr, 5), fft(darr, 5))
     assert same_keys(fft(darr2, 5, axis=0), fft(darr2, 5, axis=0))
     assert not same_keys(fft(darr, 5), fft(darr, 13))
+
+
+def test_wrap_numpy():
+    fft = fft_wrapper(npfft.fft)
+    assert_eq(fft(darr), npfft.fft(nparr))
+    assert_eq(fft(darr2, axis=0), npfft.fft(nparr, axis=0))
+
+    ifft = ifft_wrapper(npfft.ifft)
+    assert_eq(ifft(darr), npfft.ifft(nparr))
+    assert_eq(ifft(darr2, axis=0), npfft.ifft(nparr, axis=0))
+
+    rfft = rfft_wrapper(npfft.rfft)
+    assert_eq(rfft(darr), npfft.rfft(nparr))
+    assert_eq(rfft(darr2, axis=0), npfft.rfft(nparr, axis=0))
+
+    irfft = irfft_wrapper(npfft.irfft)
+    assert_eq(irfft(darr), npfft.irfft(nparr))
+    assert_eq(irfft(darr2, axis=0), npfft.irfft(nparr, axis=0))
+
+    hfft = hfft_wrapper(npfft.hfft)
+    assert_eq(hfft(darr), npfft.hfft(nparr))
+    assert_eq(hfft(darr2, axis=0), npfft.hfft(nparr, axis=0))
+
+    ihfft = ihfft_wrapper(npfft.ihfft)
+    assert_eq(ihfft(darr), npfft.ihfft(nparr))
+    assert_eq(ihfft(darr2, axis=0), npfft.ihfft(nparr, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -123,23 +123,26 @@ def test_wrap_bad_kind():
     "funcname",
     ["fft", "ifft", "rfft", "irfft", "hfft", "ihfft"]
 )
-def test_wrap_ffts(modname, funcname):
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+def test_wrap_ffts(modname, funcname, dtype):
     fft_mod = pytest.importorskip(modname)
     try:
         func = getattr(fft_mod, funcname)
     except AttributeError:
         pytest.skip("`%s` missing function `%s`." % (modname, funcname))
 
+    darrc = darr.astype(dtype)
+    darr2c = darr2.astype(dtype)
+    nparrc = nparr.astype(dtype)
+
     wfunc = fft_wrap(func)
-    assert_eq(wfunc(darr).dtype, func(nparr).dtype)
-    assert_eq(wfunc(darr.astype(np.float32)).dtype,
-              func(nparr.astype(np.float32)).dtype)
-    assert_eq(wfunc(darr), func(nparr))
-    assert_eq(wfunc(darr, axis=1), func(nparr, axis=1))
-    assert_eq(wfunc(darr2, axis=0), func(nparr, axis=0))
-    assert_eq(wfunc(darr, n=len(darr)-1),
-              func(nparr, n=len(darr)-1))
-    assert_eq(wfunc(darr, axis=1, n=darr.shape[1]-1),
-              func(nparr, n=darr.shape[1]-1))
-    assert_eq(wfunc(darr2, axis=0, n=darr2.shape[0]-1),
-              func(nparr, axis=0, n=darr2.shape[0]-1))
+    assert_eq(wfunc(darrc).dtype, func(nparrc).dtype)
+    assert_eq(wfunc(darrc), func(nparrc))
+    assert_eq(wfunc(darrc, axis=1), func(nparrc, axis=1))
+    assert_eq(wfunc(darr2c, axis=0), func(nparrc, axis=0))
+    assert_eq(wfunc(darrc, n=len(darrc)-1),
+              func(nparrc, n=len(darrc)-1))
+    assert_eq(wfunc(darrc, axis=1, n=darrc.shape[1]-1),
+              func(nparrc, n=darrc.shape[1]-1))
+    assert_eq(wfunc(darr2c, axis=0, n=darr2c.shape[0]-1),
+              func(nparrc, axis=0, n=darr2c.shape[0]-1))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -135,15 +135,19 @@ def test_wrap_ffts(modname, funcname, dtype):
     darr2c = darr2.astype(dtype)
     nparrc = nparr.astype(dtype)
 
-    wfunc = fft_wrap(func)
-    assert wfunc(darrc).dtype == func(nparrc).dtype
-    assert wfunc(darrc).shape == func(nparrc).shape
-    assert_eq(wfunc(darrc), func(nparrc))
-    assert_eq(wfunc(darrc, axis=1), func(nparrc, axis=1))
-    assert_eq(wfunc(darr2c, axis=0), func(nparrc, axis=0))
-    assert_eq(wfunc(darrc, n=len(darrc) - 1),
-              func(nparrc, n=len(darrc) - 1))
-    assert_eq(wfunc(darrc, axis=1, n=darrc.shape[1] - 1),
-              func(nparrc, n=darrc.shape[1] - 1))
-    assert_eq(wfunc(darr2c, axis=0, n=darr2c.shape[0] - 1),
-              func(nparrc, axis=0, n=darr2c.shape[0] - 1))
+    if modname == "scipy.fftpack" and "rfft" in funcname:
+        with pytest.raises(ValueError):
+            wfunc = fft_wrap(func)
+    else:
+        wfunc = fft_wrap(func)
+        assert wfunc(darrc).dtype == func(nparrc).dtype
+        assert wfunc(darrc).shape == func(nparrc).shape
+        assert_eq(wfunc(darrc), func(nparrc))
+        assert_eq(wfunc(darrc, axis=1), func(nparrc, axis=1))
+        assert_eq(wfunc(darr2c, axis=0), func(nparrc, axis=0))
+        assert_eq(wfunc(darrc, n=len(darrc) - 1),
+                  func(nparrc, n=len(darrc) - 1))
+        assert_eq(wfunc(darrc, axis=1, n=darrc.shape[1] - 1),
+                  func(nparrc, n=darrc.shape[1] - 1))
+        assert_eq(wfunc(darr2c, axis=0, n=darr2c.shape[0] - 1),
+                  func(nparrc, axis=0, n=darr2c.shape[0] - 1))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -128,13 +128,6 @@ def test_wrap_ffts(modname, funcname):
     except AttributeError:
         pytest.skip("`%s` missing function `%s`." % (modname, funcname))
 
-    if modname == "scipy.fftpack" and "rfft" in funcname:
-        pytest.skip(
-            "`%s` function `%s` doesn't support the NumPy API." % (
-                modname, funcname
-            )
-        )
-
     wfunc = fft_wrapper(func, kind=funcname)
     assert_eq(wfunc(darr), func(nparr))
     assert_eq(wfunc(darr2, axis=0), func(nparr, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -112,6 +112,11 @@ def test_fft_consistent_names():
     assert not same_keys(fft(darr, 5), fft(darr, 13))
 
 
+def test_wrap_bad_kind():
+    with pytest.raises(ValueError):
+        fft_wrapper(npfft.fft, kind="foo")
+
+
 @pytest.mark.parametrize("funcname", ["rfft", "irfft"])
 def test_wrap_numpy_real(funcname):
     func = getattr(npfft, funcname)

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -5,10 +5,7 @@ import pytest
 
 import dask.array as da
 from dask.array.fft import (
-    fft, ifft, rfft, irfft, hfft, ihfft,
-    fft_wrapper, ifft_wrapper,
-    rfft_wrapper, irfft_wrapper,
-    hfft_wrapper, ihfft_wrapper
+    fft_wrapper, fft, ifft, rfft, irfft, hfft, ihfft,
 )
 from dask.array.utils import assert_eq
 
@@ -116,27 +113,27 @@ def test_fft_consistent_names():
 
 
 def test_wrap_numpy():
-    fft = fft_wrapper(npfft.fft)
+    fft = fft_wrapper(npfft.fft, kind="fft")
     assert_eq(fft(darr), npfft.fft(nparr))
     assert_eq(fft(darr2, axis=0), npfft.fft(nparr, axis=0))
 
-    ifft = ifft_wrapper(npfft.ifft)
+    ifft = fft_wrapper(npfft.ifft, kind="ifft")
     assert_eq(ifft(darr), npfft.ifft(nparr))
     assert_eq(ifft(darr2, axis=0), npfft.ifft(nparr, axis=0))
 
-    rfft = rfft_wrapper(npfft.rfft)
+    rfft = fft_wrapper(npfft.rfft, kind="rfft")
     assert_eq(rfft(darr), npfft.rfft(nparr))
     assert_eq(rfft(darr2, axis=0), npfft.rfft(nparr, axis=0))
 
-    irfft = irfft_wrapper(npfft.irfft)
+    irfft = fft_wrapper(npfft.irfft, kind="irfft")
     assert_eq(irfft(darr), npfft.irfft(nparr))
     assert_eq(irfft(darr2, axis=0), npfft.irfft(nparr, axis=0))
 
-    hfft = hfft_wrapper(npfft.hfft)
+    hfft = fft_wrapper(npfft.hfft, kind="hfft")
     assert_eq(hfft(darr), npfft.hfft(nparr))
     assert_eq(hfft(darr2, axis=0), npfft.hfft(nparr, axis=0))
 
-    ihfft = ihfft_wrapper(npfft.ihfft)
+    ihfft = fft_wrapper(npfft.ihfft, kind="ihfft")
     assert_eq(ihfft(darr), npfft.ihfft(nparr))
     assert_eq(ihfft(darr2, axis=0), npfft.ihfft(nparr, axis=0))
 
@@ -144,10 +141,10 @@ def test_wrap_numpy():
 def test_wrap_scipy():
     spfft = pytest.importorskip("scipy.fftpack")
 
-    fft = fft_wrapper(spfft.fft)
+    fft = fft_wrapper(spfft.fft, kind="fft")
     assert_eq(fft(darr), spfft.fft(nparr))
     assert_eq(fft(darr2, axis=0), spfft.fft(nparr, axis=0))
 
-    ifft = ifft_wrapper(spfft.ifft)
+    ifft = fft_wrapper(spfft.ifft, kind="fft")
     assert_eq(ifft(darr), spfft.ifft(nparr))
     assert_eq(ifft(darr2, axis=0), spfft.ifft(nparr, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -118,7 +118,8 @@ def test_wrap_bad_kind():
 
 
 @pytest.mark.parametrize("modname", ["numpy.fft", "scipy.fftpack"])
-@pytest.mark.parametrize("funcname",
+@pytest.mark.parametrize(
+    "funcname",
     ["fft", "ifft", "rfft", "irfft", "hfft", "ihfft"]
 )
 def test_wrap_ffts(modname, funcname):

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -131,6 +131,12 @@ def test_wrap_ffts(modname, funcname, dtype):
     except AttributeError:
         pytest.skip("`%s` missing function `%s`." % (modname, funcname))
 
+    if modname == "numpy.fft" and funcname == "irfft":
+        if dtype == "float32":
+            dtype = "complex64"
+        elif dtype == "float64":
+            dtype = "complex128"
+
     darrc = darr.astype(dtype)
     darr2c = darr2.astype(dtype)
     nparrc = nparr.astype(dtype)

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -147,9 +147,9 @@ def test_wrap_ffts(modname, funcname, dtype):
     assert_eq(wfunc(darrc), func(nparrc))
     assert_eq(wfunc(darrc, axis=1), func(nparrc, axis=1))
     assert_eq(wfunc(darr2c, axis=0), func(nparrc, axis=0))
-    assert_eq(wfunc(darrc, n=len(darrc)-1),
-              func(nparrc, n=len(darrc)-1))
-    assert_eq(wfunc(darrc, axis=1, n=darrc.shape[1]-1),
-              func(nparrc, n=darrc.shape[1]-1))
-    assert_eq(wfunc(darr2c, axis=0, n=darr2c.shape[0]-1),
-              func(nparrc, axis=0, n=darr2c.shape[0]-1))
+    assert_eq(wfunc(darrc, n=len(darrc) - 1),
+              func(nparrc, n=len(darrc) - 1))
+    assert_eq(wfunc(darrc, axis=1, n=darrc.shape[1] - 1),
+              func(nparrc, n=darrc.shape[1] - 1))
+    assert_eq(wfunc(darr2c, axis=0, n=darr2c.shape[0] - 1),
+              func(nparrc, axis=0, n=darr2c.shape[0] - 1))


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2092

Provides wrappers for things that implement the standard FFT interface like that of NumPy. Recasts the existing FFT interface with these wrappers. Also adds some tests that exercise this wrapping with NumPy and SciPy.