### PR TITLE
Ensure worker processes have different random seeds

### DIFF
--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -59,7 +59,8 @@ def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
     """
     pool = _globals['pool']
     if pool is None:
-        pool = multiprocessing.Pool(num_workers)
+        pool = multiprocessing.Pool(num_workers,
+                                    initializer=initialize_worker_process)
         cleanup = True
     else:
         cleanup = False
@@ -88,3 +89,14 @@ def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
         if cleanup:
             pool.close()
     return result
+
+
+def initialize_worker_process():
+    """
+    Initialize a worker process before running any tasks in it.
+    """
+    # If Numpy is already imported, presumably its random state was
+    # inherited from the parent => re-seed it.
+    np = sys.modules.get('numpy')
+    if np is not None:
+        np.random.seed()

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -109,6 +109,7 @@ def test_optimize_graph_false():
 def py_random():
     return tuple(random.randint(0, 1000) for i in range(5))
 
+
 def np_random():
     return tuple(np.random.randint(1000) for i in range(5))
 
@@ -127,6 +128,7 @@ def check_random_seed_in_children(func, N=10):
 
 def test_py_random_seeds():
     check_random_seed_in_children(py_random)
+
 
 def test_np_random_seeds():
     check_random_seed_in_children(np_random)


### PR DESCRIPTION
This doesn't work if the user instantiates their own process pool (unless they take care of passing the `initializer` argument). I don't think there is a simple way of overcoming that limitation.