### PR TITLE
Test using pyFFTW's NumPy interface

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -39,6 +39,10 @@ conda install -c conda-forge \
     cloudpickle \
     bokeh \
 
+# Install pyfftw for testing
+conda install -c conda-forge \
+    pyfftw
+
 pip install git+https://github.com/dask/zict --upgrade --no-deps
 pip install git+https://github.com/dask/distributed --upgrade --no-deps
 

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -118,7 +118,7 @@ def test_wrap_bad_kind():
         fft_wrap(np.ones)
 
 
-@pytest.mark.parametrize("modname", ["numpy.fft", "scipy.fftpack"])
+@pytest.mark.parametrize("modname", ["numpy.fft", "scipy.fftpack", "pyfftw.interfaces.numpy_fft"])
 @pytest.mark.parametrize(
     "funcname",
     ["fft", "ifft", "rfft", "irfft", "hfft", "ihfft"]


### PR DESCRIPTION
Disclaimer: FFTW is GPL2 (or proprietary license). So this would imply that pyFFTW is also GPL'd (though it has a BSD 3-Clause license which can work if the proprietary license of FFTW is purchased) as they are linked. Not sure what the impact would be on Dask licensing. So this might be an argument for rejection. That said, IANAL.

Make sure that we test compatibility against pyFFTW's NumPy interface. This is done to make sure that we can trivially wrap these functions.

Edit: Expanded upon the disclaimer.