### PR TITLE
Optimize fusion

### DIFF
--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -176,3 +176,16 @@ def test_fuse_getarray_with_asarray(chunks):
         assert n_getarrays == 0
 
     assert_eq(z, x + 1)
+
+
+def test_turn_off_fusion():
+    x = da.ones(10, chunks=(5,))
+    y = da.sum(x + 1 + 2 + 3)
+
+    a = y._optimize(y.dask, y._keys())
+
+    with dask.set_options(fuse_ave_width=0):
+        b = y._optimize(y.dask, y._keys())
+
+    assert dask.get(a, y._keys()) == dask.get(b, y._keys())
+    assert len(a) < len(b)

--- a/dask/core.py
+++ b/dask/core.py
@@ -286,22 +286,24 @@ def subs(task, key, val):
     >>> subs((inc, 'x'), 'x', 1)  # doctest: +SKIP
     (inc, 1)
     """
-    if not istask(task):
+    type_task = type(task)
+    if not (type_task is tuple and task and callable(task[0])):  # istask(task):
         try:
-            if type(task) is type(key) and task == key:
+            if type_task is type(key) and task == key:
                 return val
         except Exception:
             pass
-        if isinstance(task, list):
+        if type_task is list:
             return [subs(x, key, val) for x in task]
         return task
     newargs = []
     for arg in task[1:]:
-        if istask(arg):
+        type_arg = type(arg)
+        if type(arg) is tuple and arg and callable(arg[0]):  # istask(task):
             arg = subs(arg, key, val)
-        elif isinstance(arg, list):
+        elif type_arg is list:
             arg = [subs(x, key, val) for x in arg]
-        elif type(arg) is type(key) and arg == key:
+        elif type_arg is type(key) and arg == key:
             arg = val
         newargs.append(arg)
     return task[:1] + tuple(newargs)

--- a/dask/core.py
+++ b/dask/core.py
@@ -270,7 +270,7 @@ def reverse_dict(d):
     {'a': set([]), 'b': set(['a']}, 'c': set(['a', 'b'])}
     """
     terms = list(d.keys()) + list(chain.from_iterable(d.values()))
-    result = dict((t, set()) for t in terms)
+    result = {t: set() for t in terms}
     for k, vals in d.items():
         for val in vals:
             result[val].add(k)
@@ -299,7 +299,7 @@ def subs(task, key, val):
     newargs = []
     for arg in task[1:]:
         type_arg = type(arg)
-        if type(arg) is tuple and arg and callable(arg[0]):  # istask(task):
+        if type_arg is tuple and arg and callable(arg[0]):  # istask(task):
             arg = subs(arg, key, val)
         elif type_arg is list:
             arg = [subs(x, key, val) for x in arg]

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -22,7 +22,6 @@ def optimize(dsk, keys, **kwargs):
     dsk = fuse_getitem(dsk, dataframe_from_ctable, 3)
     if _read_parquet_row_group:
         dsk = fuse_getitem(dsk, _read_parquet_row_group, 4)
-    if _globals.get('fuse_ave_width'):
-        dsk, dependencies = fuse(dsk, keys, dependencies=dependencies)
+    dsk, dependencies = fuse(dsk, keys, dependencies=dependencies)
     dsk, _ = cull(dsk, keys)
     return dsk

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -22,6 +22,7 @@ def optimize(dsk, keys, **kwargs):
     dsk = fuse_getitem(dsk, dataframe_from_ctable, 3)
     if _read_parquet_row_group:
         dsk = fuse_getitem(dsk, _read_parquet_row_group, 4)
-    dsk, dependencies = fuse(dsk, keys, dependencies=dependencies)
+    dsk, dependencies = fuse(dsk, keys, dependencies=dependencies,
+                             ave_width=_globals.get('fuse_ave_width', 0))
     dsk, _ = cull(dsk, keys)
     return dsk

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -505,8 +505,18 @@ def fuse(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
         keys = set(flatten(keys))
 
     # Assign reasonable, not too restrictive defaults
-    ave_width = ave_width or _globals.get('fuse_ave_width') or 1
-    max_height = max_height or _globals.get('fuse_max_height') or len(dsk)
+    if ave_width is None:
+        if _globals.get('fuse_ave_width') is None:
+            ave_width = 1
+        else:
+            ave_width = _globals['fuse_ave_width']
+
+    if max_height is None:
+        if _globals.get('fuse_max_height') is None:
+            max_height = len(dsk)
+        else:
+            max_height = _globals['fuse_max_height']
+
     max_depth_new_edges = (
         max_depth_new_edges or
         _globals.get('fuse_max_depth_new_edges') or
@@ -517,6 +527,10 @@ def fuse(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
         _globals.get('fuse_max_width') or
         1.5 + ave_width * math.log(ave_width + 1)
     )
+
+    if not ave_width or not max_height:
+        return dsk, dependencies
+
     if rename_keys is None:
         rename_keys = _globals.get('fuse_rename_keys', True)
     if rename_keys is True:


### PR DESCRIPTION
This is an effort to reduce optimization costs in large dask.arrays, particularly `fuse`.  This takes two approaches:

1.  Micro-optimize `subs` using standard isinstance->type tricks and inlining istask
2.  Provide hooks for the user to turn off fusion.

The second point is slightly contentious because it can lead to lots of small options.  The way I've taken to resolve this in this PR is that `fuse` always gets called, but it doesn't mind checking `_globals` for keyword specific to it (it was doing this already).  If those keywords are such that it wouldn't end up doing any work anyway, it short circuits and returns early.

This opens the door for lots of options, but diffuses the logic for those options within the optimizations themselves, which seems more maintainable.

cc @eriknw @jcrist 