### PR TITLE
Drop unused variable in FFT wrapper test

### DIFF
--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -137,7 +137,7 @@ def test_wrap_ffts(modname, funcname, dtype):
 
     if modname == "scipy.fftpack" and "rfft" in funcname:
         with pytest.raises(ValueError):
-            wfunc = fft_wrap(func)
+            fft_wrap(func)
     else:
         wfunc = fft_wrap(func)
         assert wfunc(darrc).dtype == func(nparrc).dtype


### PR DESCRIPTION
Drops an unused assigned variable from the FFT wrapper tests.