### PR TITLE
Improve `fuse` performance by allowing tasks to reference old key name aliases

### DIFF
--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -48,4 +48,4 @@ def test_fuse_ave_width():
     b = s._optimize(s.dask, s._keys())
 
     assert len(a) < len(b)
-    assert len(a) <= 10
+    assert len(a) <= 15

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -727,34 +727,13 @@ def fuse(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
                 parent = rdeps[parent][0]
 
     if key_renamer is not None:
-        alias_names = {}
         for root_key, fused_keys in fused_trees.items():
             alias = key_renamer(fused_keys)
             if alias is not None and alias not in rv:
-                alias_names[root_key] = alias
                 rv[alias] = rv[root_key]
                 rv[root_key] = alias
                 deps[alias] = deps[root_key]
                 deps[root_key] = {alias}
-        aliases_set = set(alias_names)
-        for root_key, alias in alias_names.items():
-            if root_key in rdeps:
-                for key in set(rdeps[root_key]) - aliases_set:
-                    if key in rv and root_key in deps[key]:
-                        rv[key] = subs(rv[key], root_key, alias)
-                        deps[key].remove(root_key)
-                        deps[key].add(alias)
-        for root_key in fused_trees:
-            alias = alias_names[root_key] if root_key in alias_names else root_key
-            for key in deps[alias] & aliases_set:
-                key_alias = alias_names[key]
-                rv[alias] = subs(rv[alias], key, key_alias)
-                deps[alias].remove(key)
-                deps[alias].add(key_alias)
-        if keys is not None:
-            for key in aliases_set - keys:
-                del rv[key]
-                del deps[key]
     return rv, deps
 
 

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -419,7 +419,7 @@ def test_fuse_reductions_single_input():
     assert fuse(d, ave_width=2, rename_keys=True) == with_deps({
         'a': 1,
         'b1-b2-c': (f, (f, 'a'), (f, 'a')),
-        'd1-d2-e': (f, (f, 'b1-b2-c'), (f, 'b1-b2-c')),
+        'd1-d2-e': (f, (f, 'c'), (f, 'c')),
         'c': 'b1-b2-c',
         'e': 'd1-d2-e',
     })
@@ -448,7 +448,7 @@ def test_fuse_reductions_single_input():
         'a': 1,
         'b1-b2-c1': (f, (f, 'a'), (f, 'a')),
         'b3-b4-c2': (f, (f, 'a'), (f, 'a')),
-        'd': (f, 'b1-b2-c1', 'b3-b4-c2'),
+        'd': (f, 'c1', 'c2'),
         'c1': 'b1-b2-c1',
         'c2': 'b3-b4-c2',
     })
@@ -502,8 +502,8 @@ def test_fuse_reductions_single_input():
         'b3-b4-c2': (f, (f, 'a'), (f, 'a')),
         'b5-b6-c3': (f, (f, 'a'), (f, 'a')),
         'b7-b8-c4': (f, (f, 'a'), (f, 'a')),
-        'd1': (f, 'b1-b2-c1', 'b3-b4-c2'),
-        'd2': (f, 'b5-b6-c3', 'b7-b8-c4'),
+        'd1': (f, 'c1', 'c2'),
+        'd2': (f, 'c3', 'c4'),
         'e': (f, 'd1', 'd2'),
         'c1': 'b1-b2-c1',
         'c2': 'b3-b4-c2',
@@ -524,7 +524,7 @@ def test_fuse_reductions_single_input():
         'a': 1,
         'b1-b2-b3-b4-c1-c2-d1': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
         'b5-b6-b7-b8-c3-c4-d2': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
-        'e': (f, 'b1-b2-b3-b4-c1-c2-d1', 'b5-b6-b7-b8-c3-c4-d2'),
+        'e': (f, 'd1', 'd2'),
         'd1': 'b1-b2-b3-b4-c1-c2-d1',
         'd2': 'b5-b6-b7-b8-c3-c4-d2',
 
@@ -612,10 +612,10 @@ def test_fuse_reductions_single_input():
         'b11-b12-c6': (f, (f, 'a'), (f, 'a')),
         'b13-b14-c7': (f, (f, 'a'), (f, 'a')),
         'b15-b16-c8': (f, (f, 'a'), (f, 'a')),
-        'd1': (f, 'b1-b2-c1', 'b3-b4-c2'),
-        'd2': (f, 'b5-b6-c3', 'b7-b8-c4'),
-        'd3': (f, 'b10-b9-c5', 'b11-b12-c6'),
-        'd4': (f, 'b13-b14-c7', 'b15-b16-c8'),
+        'd1': (f, 'c1', 'c2'),
+        'd2': (f, 'c3', 'c4'),
+        'd3': (f, 'c5', 'c6'),
+        'd4': (f, 'c7', 'c8'),
         'e1': (f, 'd1', 'd2'),
         'e2': (f, 'd3', 'd4'),
         'f': (f, 'e1', 'e2'),
@@ -648,8 +648,8 @@ def test_fuse_reductions_single_input():
         'b5-b6-b7-b8-c3-c4-d2': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
         'b10-b11-b12-b9-c5-c6-d3': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
         'b13-b14-b15-b16-c7-c8-d4': (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
-        'e1': (f, 'b1-b2-b3-b4-c1-c2-d1', 'b5-b6-b7-b8-c3-c4-d2'),
-        'e2': (f, 'b10-b11-b12-b9-c5-c6-d3', 'b13-b14-b15-b16-c7-c8-d4'),
+        'e1': (f, 'd1', 'd2'),
+        'e2': (f, 'd3', 'd4'),
         'f': (f, 'e1', 'e2'),
         'd1': 'b1-b2-b3-b4-c1-c2-d1',
         'd2': 'b5-b6-b7-b8-c3-c4-d2',
@@ -680,7 +680,7 @@ def test_fuse_reductions_single_input():
             (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a'))),
             (f, (f, (f, 'a'), (f, 'a')), (f, (f, 'a'), (f, 'a')))
         ),
-        'f': (f, 'b1-b2-b3-b4-b5-b6-b7-b8-c1-c2-c3-c4-d1-d2-e1', 'b10-b11-b12-b13-b14-b15-b16-b9-c5-c6-c7-c8-d3-d4-e2'),
+        'f': (f, 'e1', 'e2'),
         'e1': 'b1-b2-b3-b4-b5-b6-b7-b8-c1-c2-c3-c4-d1-d2-e1',
         'e2': 'b10-b11-b12-b13-b14-b15-b16-b9-c5-c6-c7-c8-d3-d4-e2',
 
@@ -771,7 +771,7 @@ def test_fuse_reductions_single_input():
         'a': 1,
         'b2': (f, 'a'),
         'b1-c1-d1-e1': (f, (f, (f, (f, 'a')))),
-        'f': (f, 'b1-c1-d1-e1', 'b2'),
+        'f': (f, 'e1', 'b2'),
         'e1': 'b1-c1-d1-e1',
 
     })
@@ -809,7 +809,7 @@ def test_fuse_reductions_single_input():
         'a': 1,
         'b2': (f, 'a'),
         'b1-c1-d1-e1': (f, 'a', (f, 'a', (f, 'a', (f, 'a')))),
-        'f': (f, 'a', 'b1-c1-d1-e1', 'b2'),
+        'f': (f, 'a', 'e1', 'b2'),
         'e1': 'b1-c1-d1-e1',
     })
     assert fuse(d, ave_width=1, rename_keys=True) == expected
@@ -851,7 +851,7 @@ def test_fuse_reductions_single_input():
         'b1-c1-d1': (f, (f, (f, 'a'))),
         'b2-c2-d2': (f, (f, (f, 'a'))),
         'b3-c3-d3': (f, (f, (f, 'a'))),
-        'e-f-g': (f, (f, (f, 'b1-c1-d1', 'b2-c2-d2', 'b3-c3-d3'))),
+        'e-f-g': (f, (f, (f, 'd1', 'd2', 'd3'))),
         'd1': 'b1-c1-d1',
         'd2': 'b2-c2-d2',
         'd3': 'b3-c3-d3',
@@ -874,8 +874,8 @@ def test_fuse_reductions_single_input():
     })
     assert fuse(d, ave_width=1, rename_keys=True) == with_deps({
         'a-b': (f, 1),
-        'c-d': (f, 'a-b', (f, 'a-b')),
-        'e-f-g': (f, 'c-d', (f, (f, 'c-d'))),
+        'c-d': (f, 'b', (f, 'b')),
+        'e-f-g': (f, 'd', (f, (f, 'd'))),
         'b': 'a-b',
         'd': 'c-d',
         'g': 'e-f-g',


### PR DESCRIPTION
Previously, tasks that depend on fused tasks whose keys were renamed would be updated via `subs` to use the new task keys.  In some cases, the number of tasks that depend on fused tasks would greatly outnumber the number of fused tasks, and calling `subs` on them would dominate the calculation time.

Now, we don't call `subs` on tasks that depend on renamed fused tasks.  These tasks are no longer modified and use the previous key name, which is now an alias, `{old_key: new_key}`.  This can result in a larger graph and slightly more scheduler overhead, but the performance increase to `fuse` can be significant.