### PR TITLE
Micro-optimize fuse. `next(iter(myset))` is much slower than a pop then add

### DIFF
--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -567,6 +567,8 @@ def fuse(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
     children_stack = []
     # For speed
     deps_pop = deps.pop
+    reducible_add = reducible.add
+    reducible_pop = reducible.pop
     reducible_remove = reducible.remove
     fused_trees_pop = fused_trees.pop
     info_stack_append = info_stack.append
@@ -575,7 +577,8 @@ def fuse(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
     children_stack_extend = children_stack.extend
     children_stack_pop = children_stack.pop
     while reducible:
-        parent = next(iter(reducible))
+        parent = reducible_pop()
+        reducible_add(parent)
         while parent in reducible:
             # Go to the top
             parent = rdeps[parent][0]


### PR DESCRIPTION
Illustrative micro-benchmark:
```python
In [1]: import random

In [2]: L = list(range(100000))

In [3]: random.shuffle(L)

In [4]: s = set(L)

In [5]: %%time
   ...: while s:
   ...:     parent = next(iter(s))
   ...:     s.remove(parent)
   ...:_
CPU times: user 2.32 s, sys: 8 ms, total: 2.32 s
Wall time: 2.32 s

In [6]: s = set(L)

In [7]: %%time
   ...: while s:
   ...:     parent = s.pop()
   ...:     s.add(parent)
   ...:     s.remove(parent)
   ...:_
CPU times: user 32 ms, sys: 0 ns, total: 32 ms
Wall time: 30.3 ms
```