### PR TITLE
Autodoc round function

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -348,6 +348,7 @@ Other functions
 .. autofunction:: rechunk
 .. autofunction:: reshape
 .. autofunction:: rint
+.. autofunction:: round
 .. autofunction:: sign
 .. autofunction:: signbit
 .. autofunction:: sin


### PR DESCRIPTION
Seems the `round` function was not being autodoced in the API even though it was in the listing. So this adds `round` so it can be documented.