### PR TITLE
Drop the random module from the function API list

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -111,7 +111,6 @@ Top level user functions:
    prod
    rad2deg
    radians
-   random
    ravel
    real
    rechunk


### PR DESCRIPTION
As `random` is a module and not a function, it shouldn't be in the function API listing. Besides the Random section shows up just below this anyways.