### PR TITLE
Add a roll function for Dask Arrays

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from ..utils import ignoring
 from .core import (Array, stack, concatenate, take, tensordot, transpose,
         from_array, choose, where, coarsen, insert, broadcast_to, ravel,
-        fromfunction, unique, store, squeeze, topk, bincount,
+        roll, fromfunction, unique, store, squeeze, topk, bincount,
         digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
         from_delayed, round, swapaxes, repeat, asarray)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -712,6 +712,16 @@ def test_ravel():
     assert_eq(np.ravel(x), da.ravel(a))
 
 
+@pytest.mark.parametrize('chunks', [(4, 6), (2, 6)])
+@pytest.mark.parametrize('shift', [3, 7, 9])
+@pytest.mark.parametrize('axis', [None, 0, 1, -1])
+def test_roll(chunks, shift, axis):
+    x = np.random.randint(10, size=(4, 6))
+    a = from_array(x, chunks=chunks)
+
+    assert_eq(np.roll(x, shift, axis), da.roll(a, shift, axis))
+
+
 @pytest.mark.parametrize('original_shape,new_shape,chunks', [
     ((10,), (10,), (3, 3, 4)),
     ((10,), (10, 1, 1), 5),

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -118,6 +118,7 @@ Top level user functions:
    repeat
    reshape
    rint
+   roll
    round
    sign
    signbit
@@ -348,6 +349,7 @@ Other functions
 .. autofunction:: rechunk
 .. autofunction:: reshape
 .. autofunction:: rint
+.. autofunction:: roll
 .. autofunction:: round
 .. autofunction:: sign
 .. autofunction:: signbit


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2132

Provides a function that performs the same operation as NumPy's roll except on Dask Arrays. This is done by using a mixture of slicing and concatenating. The effect is a Dask Array that is either raveled, rolled, and reshaped or rolled along specified axes. Added a few tests and added the function to the API doc.