### PR TITLE
Optimize reshaping when the shape is unchanged

### DIFF
--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -163,6 +163,9 @@ def reshape(x, shape):
     if reduce(mul, shape, 1) != x.size:
         raise ValueError('total size of new array must be unchanged')
 
+    if x.shape == shape:
+        return x
+
     name = 'reshape-' + tokenize(x, shape)
 
     if x.npartitions == 1:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -748,7 +748,14 @@ def test_ravel():
 def test_reshape(original_shape, new_shape, chunks):
     x = np.random.randint(10, size=original_shape)
     a = from_array(x, chunks=chunks)
-    assert_eq(x.reshape(new_shape), a.reshape(new_shape))
+
+    xr = x.reshape(new_shape)
+    ar = a.reshape(new_shape)
+
+    if a.shape == new_shape:
+        assert a is ar
+
+    assert_eq(xr, ar)
 
 
 def test_reshape_exceptions():


### PR DESCRIPTION
If `reshape` is called on a Dask Array and the shape isn't changed, there should be no need to perform reshape. So simply return the original array unchanged. Test that the array is unchanged in this case as well.