### PR TITLE
Test rolling 2 axes at once

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2856,6 +2856,9 @@ def roll(array, shift, axis=None):
         except TypeError:
             axis = (axis,)
 
+    if len(shift) != len(axis):
+        raise ValueError("Must have the same number of shifts as axes.")
+
     for i, s in zip(axis, shift):
         s = -s
         s %= result.shape[i]

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2839,7 +2839,7 @@ def roll(array, shift, axis=None):
         result = ravel(result)
 
         if not isinstance(shift, Integral):
-            TypeError(
+            raise TypeError(
                 "Expect `shift` to be an instance of Integral"
                 " when `axis` is None."
             )

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -722,6 +722,22 @@ def test_roll(chunks, shift, axis):
     assert_eq(np.roll(x, shift, axis), da.roll(a, shift, axis))
 
 
+@pytest.mark.parametrize('chunks', [(4, 6), (2, 6)])
+@pytest.mark.parametrize('shift', [(3, 9), (7, 2)])
+@pytest.mark.parametrize('axis', [(0, 1), (1, 0)])
+def test_roll_multiple(chunks, shift, axis):
+    if LooseVersion(np.__version__) < LooseVersion("1.12.0"):
+        pytest.skip(
+            "NumPy %s doesn't support multiple axes."
+            " Need NumPy 1.12.0 or greater." % np.__version__
+        )
+
+    x = np.random.randint(10, size=(4, 6))
+    a = from_array(x, chunks=chunks)
+
+    assert_eq(np.roll(x, shift, axis), da.roll(a, shift, axis))
+
+
 @pytest.mark.parametrize('original_shape,new_shape,chunks', [
     ((10,), (10,), (3, 3, 4)),
     ((10,), (10, 1, 1), 5),


### PR DESCRIPTION
Follow-up to PR ( https://github.com/dask/dask/pull/2135 ).

Make sure that `roll` still works correctly on Dask Arrays when rolling 2 dimensions at once. This is done in addition to testing 1 dimension rolling.