### PR TITLE
Add constructor plugins to dask.array

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -6,7 +6,7 @@ from .core import (Array, stack, concatenate, take, tensordot, transpose,
         roll, fromfunction, unique, store, squeeze, topk, bincount, tile,
         digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
-        from_delayed, round, swapaxes, repeat, asarray, constructor_plugins)
+        from_delayed, round, swapaxes, repeat, asarray)
 from .core import (around, isnull, notnull, isclose, eye, triu,
                    tril, diag, corrcoef)
 from .reshape import reshape

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -6,7 +6,7 @@ from .core import (Array, stack, concatenate, take, tensordot, transpose,
         roll, fromfunction, unique, store, squeeze, topk, bincount, tile,
         digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
-        from_delayed, round, swapaxes, repeat, asarray)
+        from_delayed, round, swapaxes, repeat, asarray, constructor_plugins)
 from .core import (around, isnull, notnull, isclose, eye, triu,
                    tril, diag, corrcoef)
 from .reshape import reshape

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -973,12 +973,11 @@ class Array(Base):
 
         return self
 
-    @property
-    def _args(self):
+    def __getnewargs__(self):
         return (self.dask, self.name, self.chunks, self.dtype)
 
     def __getstate__(self):
-        return self._args
+        return self.__getnewargs__()
 
     def __setstate__(self, state):
         self.dask, self.name, self._chunks, self.dtype = state

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -973,9 +973,6 @@ class Array(Base):
 
         return self
 
-    def __getnewargs__(self):
-        return (self.dask, self.name, self.chunks, self.dtype)
-
     def __reduce__(self):
         return (Array, (self.dask, self.name, self.chunks, self.dtype))
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -949,18 +949,8 @@ class Array(Base):
     _default_get = staticmethod(threaded.get)
     _finalize = staticmethod(finalize)
 
-    def __new__(cls, *args, **kwargs):
-        obj = super(Array, cls).__new__(cls)
-        cls.__init__(obj, *args, **kwargs)
-
-        for plugin in _global_constructor_plugins:
-            result = plugin(obj)
-            if result is not None:
-                obj = result
-
-        return obj
-
-    def __init__(self, dask, name, chunks, dtype, shape=None):
+    def __new__(cls, dask, name, chunks, dtype, shape=None):
+        self = super(Array, cls).__new__(cls)
         assert isinstance(dask, Mapping)
         if not isinstance(dask, ShareDict):
             s = ShareDict()
@@ -974,6 +964,13 @@ class Array(Base):
         if dtype is None:
             raise ValueError("You must specify the dtype of the array")
         self.dtype = np.dtype(dtype)
+
+        for plugin in _global_constructor_plugins:
+            result = plugin(self)
+            if result is not None:
+                self = result
+
+        return self
 
     @property
     def _args(self):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -976,6 +976,9 @@ class Array(Base):
     def __getnewargs__(self):
         return (self.dask, self.name, self.chunks, self.dtype)
 
+    def __reduce__(self):
+        return (Array, (self.dask, self.name, self.chunks, self.dtype))
+
     @property
     def numblocks(self):
         return tuple(map(len, self.chunks))

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -976,12 +976,6 @@ class Array(Base):
     def __getnewargs__(self):
         return (self.dask, self.name, self.chunks, self.dtype)
 
-    def __getstate__(self):
-        return self.__getnewargs__()
-
-    def __setstate__(self, state):
-        self.dask, self.name, self._chunks, self.dtype = state
-
     @property
     def numblocks(self):
         return tuple(map(len, self.chunks))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1481,12 +1481,6 @@ def test_Array_normalizes_dtype():
     assert isinstance(x.dtype, np.dtype)
 
 
-def test_args():
-    x = da.ones((10, 2), chunks=(3, 1), dtype='i4') + 1
-    y = Array(*x._args)
-    assert_eq(x, y)
-
-
 def test_from_array_with_lock():
     x = np.arange(10)
     d = da.from_array(x, chunks=5, lock=True)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2907,3 +2907,20 @@ def test_elemwise_with_lists(chunks, other):
     d3 = d2 * other
 
     assert_eq(x3, d3)
+
+
+def test_constructor_plugin():
+    L = []
+    L2 = []
+    with da.constructor_plugins(L.append, L2.append):
+        x = da.ones(10, chunks=5)
+        y = x + 1
+
+    assert L == L2 == [x, y]
+
+    with da.constructor_plugins(lambda x: x.compute()):
+        x = da.ones(10, chunks=5)
+        y = x + 1
+
+    assert isinstance(y, np.ndarray)
+    assert len(L) == 2

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2912,13 +2912,13 @@ def test_elemwise_with_lists(chunks, other):
 def test_constructor_plugin():
     L = []
     L2 = []
-    with da.constructor_plugins(L.append, L2.append):
+    with dask.set_options(array_plugins=[L.append, L2.append]):
         x = da.ones(10, chunks=5)
         y = x + 1
 
     assert L == L2 == [x, y]
 
-    with da.constructor_plugins(lambda x: x.compute()):
+    with dask.set_options(array_plugins=[lambda x: x.compute()]):
         x = da.ones(10, chunks=5)
         y = x + 1
 


### PR DESCRIPTION
This adds a `__new__` constructor to the Array class that enables
user-defined plugins to override array construction.

Some comments/concerns:

1.  Using `__new__` is powerful but also dangerous.  Are there other
    alternatives?  This may break other code; for example, this
    inadvertently breaks pickling.
2.  Do we want to apply this to the Base class?  If so then how do we
    want to enable users to define class-specific plugins?  Add them to
    the class as class variables?
3.  Are there better names for `da.constructor_plugins`?

cc @shoyer @pwolfram @jcrist 

Example
----------

```python
def test_constructor_plugin():
    L = []
    L2 = []
    with da.constructor_plugins(L.append, L2.append):
        x = da.ones(10, chunks=5)
        y = x + 1

    assert L == L2 == [x, y]

    with da.constructor_plugins(lambda x: x.compute()):
        x = da.ones(10, chunks=5)
        y = x + 1

    assert isinstance(y, np.ndarray)
    assert len(L) == 2
```