### PR TITLE
`dask.threaded.get` can be interrupted in python 2

### DIFF
--- a/dask/async.py
+++ b/dask/async.py
@@ -127,6 +127,13 @@ from .optimize import cull
 from .utils_test import add, inc  # noqa: F401
 
 
+# Due to a bug in python 2.7 Queue.get, if a timeout isn't specified then
+# `Queue.get` can't be interrupted. A workaround is to specify an extremely
+# long timeout, which then allows it to be interrupted.
+# For more information see: https://bugs.python.org/issue1360
+ONE_YEAR = 365 * 24 * 60 * 60
+
+
 DEBUG = False
 
 
@@ -488,7 +495,7 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
 
         # Main loop, wait on tasks to finish, insert new ones
         while state['waiting'] or state['ready'] or state['running']:
-            key, res_info = queue.get()
+            key, res_info = queue.get(block=True, timeout=ONE_YEAR)
             res, tb, worker_id = loads(res_info)
             if isinstance(res, BaseException):
                 if rerun_exceptions_locally:

--- a/dask/async.py
+++ b/dask/async.py
@@ -114,10 +114,11 @@ See the function ``inline_functions`` for more information.
 """
 from __future__ import absolute_import, division, print_function
 
+import os
 import sys
 import traceback
 
-from .compatibility import Queue
+from .compatibility import Queue, Empty
 from .core import (istask, flatten, reverse_dict, get_dependencies, ishashable,
                    has_tasks)
 from .context import _globals
@@ -127,11 +128,28 @@ from .optimize import cull
 from .utils_test import add, inc  # noqa: F401
 
 
-# Due to a bug in python 2.7 Queue.get, if a timeout isn't specified then
-# `Queue.get` can't be interrupted. A workaround is to specify an extremely
-# long timeout, which then allows it to be interrupted.
-# For more information see: https://bugs.python.org/issue1360
-ONE_YEAR = 365 * 24 * 60 * 60
+if sys.version_info.major < 3:
+    # Due to a bug in python 2.7 Queue.get, if a timeout isn't specified then
+    # `Queue.get` can't be interrupted. A workaround is to specify an extremely
+    # long timeout, which then allows it to be interrupted.
+    # For more information see: https://bugs.python.org/issue1360
+    def queue_get(q):
+        return q.get(block=True, timeout=(365 * 24 * 60 * 60))
+
+elif os.name == 'nt':
+    # Python 3 windows Queue.get also doesn't handle interrupts properly. To
+    # workaround this we poll at a sufficiently large interval that it
+    # shouldn't affect performance, but small enough that users trying to kill
+    # an application shouldn't care.
+    def queue_get(q):
+        while True:
+            try:
+                return q.get(block=True, timeout=0.1)
+            except Empty:
+                pass
+else:
+    def queue_get(q):
+        return q.get()
 
 
 DEBUG = False
@@ -495,7 +513,7 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
 
         # Main loop, wait on tasks to finish, insert new ones
         while state['waiting'] or state['ready'] or state['running']:
-            key, res_info = queue.get(block=True, timeout=ONE_YEAR)
+            key, res_info = queue_get(queue)
             res, tb, worker_id = loads(res_info)
             if isinstance(res, BaseException):
                 if rerun_exceptions_locally:

--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -127,7 +127,6 @@ get(dsk, 'x')
 """
 
 
-@pytest.mark.slow
 def test_interrupt():
     try:
         proc = subprocess.Popen([sys.executable, '-c', code],

--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -127,6 +127,11 @@ get(dsk, 'x')
 """
 
 
+# TODO: this test passes locally on windows, but fails on appveyor
+# because the ctrl-c event also tears down their infrastructure.
+# There's probably a better way to test this, but for now we'll mark
+# it slow (slow tests are skipped on appveyor).
+@pytest.mark.slow
 def test_interrupt():
     try:
         proc = subprocess.Popen([sys.executable, '-c', code],

--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -1,6 +1,8 @@
-from multiprocessing.pool import ThreadPool
 import threading
-from threading import Thread
+import signal
+import subprocess
+import sys
+from multiprocessing.pool import ThreadPool
 from time import time, sleep
 
 import pytest
@@ -52,7 +54,7 @@ def test_threaded_within_thread():
     before = threading.active_count()
 
     for i in range(20):
-        t = Thread(target=f, args=(1,))
+        t = threading.Thread(target=f, args=(1,))
         t.daemon = True
         t.start()
         t.join()
@@ -91,7 +93,7 @@ def test_thread_safety():
 
     threads = []
     for i in range(20):
-        t = Thread(target=test_f)
+        t = threading.Thread(target=test_f)
         t.daemon = True
         t.start()
         threads.append(t)
@@ -100,3 +102,53 @@ def test_thread_safety():
         thread.join()
 
     assert L == [1] * 20
+
+
+code = """
+import sys
+from dask.threaded import get
+
+def signal_started():
+    sys.stdout.write('started\\n')
+    sys.stdout.flush()
+
+def long_task(x):
+    out = 0
+    N = 100000
+    for i in range(N):
+        for j in range(N):
+            out += 1
+
+dsk = {('x', i): (long_task, 'started') for i in range(100)}
+dsk['started'] = (signal_started,)
+dsk['x'] = (sum, list(dsk.keys()))
+get(dsk, 'x')
+"""
+
+
+@pytest.mark.slow
+def test_interrupt():
+    try:
+        proc = subprocess.Popen([sys.executable, '-c', code],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+        # Wait for scheduler to start
+        msg = proc.stdout.readline()
+        if msg != 'started\n' and proc.poll() is not None:
+            assert False, "subprocess failed"
+        # Scheduler has started, send an interrupt
+        proc.send_signal(signal.SIGINT)
+        # Wait a bit for it to die
+        start = time()
+        while time() - start < 0.2:
+            if proc.poll() is not None:
+                break
+            sleep(0.05)
+        else:
+            assert False, "Interrupt Failed"
+        # Ensure KeyboardInterrupt in traceback
+        stderr = proc.stderr.read()
+        assert "KeyboardInterrupt" in stderr.decode()
+    except:
+        proc.terminate()
+        raise


### PR DESCRIPTION
Due to a bug in `Queue.get` in python 2, `get` is not interruptible if no timeout is set (see https://bugs.python.org/issue1360). To get around this, we specify an extremely long timeout. Benchmarking shows no noticeable overhead to specifying a timeout, and this allows `dask.threaded.get` to be interrupted.

Fixes #2143.