### PR TITLE
Wraps repeat with the correct NumPy function

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3797,7 +3797,7 @@ def swapaxes(a, axis1, axis2):
                 dtype=a.dtype)
 
 
-@wraps(np.dot)
+@wraps(np.repeat)
 def repeat(a, repeats, axis=None):
     if axis is None:
         if a.ndim == 1:


### PR DESCRIPTION
Was wrapping with `numpy.dot` before, which is probably some copy-pasta. Have corrected it to wrap with `numpy.repeat`.