### PR TITLE
Support repartition on series

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3604,7 +3604,7 @@ def repartition_npartitions(df, npartitions):
         dsk[new_name, new_partition_index] = value
     divisions = [df.divisions[new_partition_index]
                  for new_partition_index in new_partitions_boundaries]
-    return DataFrame(merge(df.dask, dsk), new_name, df._meta, divisions)
+    return new_dd_object(merge(df.dask, dsk), new_name, df._meta, divisions)
 
 
 def repartition(df, divisions=None, force=False):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1288,6 +1288,16 @@ def test_repartition_npartitions():
             a.repartition(npartitions=5)
 
 
+def test_repartition_series_npartitions():
+    df = pd.DataFrame({'x': np.arange(1000)})
+    ddf = dd.from_pandas(df, npartitions=20)
+
+    for n in [1, 3, 10]:
+        x = ddf.x.repartition(npartitions=n)
+        assert x.npartitions == n
+        assert_eq(x, df.x)
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize('npartitions', [1, 20, 243])
 @pytest.mark.parametrize('freq', ['1D', '7D', '28h'])


### PR DESCRIPTION
This failed previously because we had hardcoded in the DataFrame
constructor to a generic function

cc @moody-marlin