### PR TITLE
Add temporary_directory support to on-disk shuffles

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -57,6 +57,7 @@ conda install -q -c conda-forge \
     distributed \
     cloudpickle \
 
+pip install -q git+https://github.com/dask/partd --upgrade --no-deps
 pip install -q git+https://github.com/dask/zict --upgrade --no-deps
 pip install -q git+https://github.com/dask/distributed --upgrade --no-deps
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1578,10 +1578,15 @@ def groupby_disk(b, grouper, npartitions=None, blocksize=2**20):
 
     import partd
     p = ('partd-' + token,)
+    dirname = _globals.get('temporary_directory', None)
+    if dirname:
+        file = (apply, partd.File, (), {'dir': dirname})
+    else:
+        file = (partd.File,)
     try:
-        dsk1 = {p: (partd.Python, (partd.Snappy, (partd.File,)))}
+        dsk1 = {p: (partd.Python, (partd.Snappy, file))}
     except AttributeError:
-        dsk1 = {p: (partd.Python, (partd.File,))}
+        dsk1 = {p: (partd.Python, file)}
 
     # Partition data on disk
     name = 'groupby-part-{0}-{1}'.format(funcname(grouper), token)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1128,3 +1128,12 @@ def test_repeated_groupby():
     b = db.range(10, npartitions=4)
     c = b.groupby(lambda x: x % 3)
     assert valmap(len, dict(c)) == valmap(len, dict(c))
+
+
+def test_temporary_directory():
+    b = db.range(10, npartitions=4)
+
+    with dask.set_options(temporary_directory=os.getcwd()):
+        b2 = b.groupby(lambda x: x % 2)
+        b2.compute()
+        assert any(fn.endswith('.partd') for fn in os.listdir(os.getcwd()))

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -206,10 +206,15 @@ class maybe_buffered_partd(object):
 
     def __call__(self, *args, **kwargs):
         import partd
-        if self.buffer:
-            return partd.PandasBlocks(partd.Buffer(partd.Dict(), partd.File()))
+        dirname = _globals.get('temporary_directory', None)
+        if dirname:
+            file = partd.File(dir=dirname)
         else:
-            return partd.PandasBlocks(partd.File())
+            file = partd.File()
+        if self.buffer:
+            return partd.PandasBlocks(partd.Buffer(partd.Dict(), file))
+        else:
+            return partd.PandasBlocks(file)
 
 
 def rearrange_by_column_disk(df, column, npartitions=None, compute=False):


### PR DESCRIPTION
Fixes  https://github.com/dask/dask/issues/2139

Depends on https://github.com/dask/partd/pull/24 to be effective, but
doesn't break anything without it

Example
-------
```python
dask.set_options(temporary_directory='/path/to/tmpdir')

df2 = df.set_index('x')...  # now stages in /path/to/tmpdir
```

cc @moody-marlin