### PR TITLE
Autodoc `repeat`

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -361,6 +361,7 @@ Other functions
 .. autofunction:: ravel
 .. autofunction:: real
 .. autofunction:: rechunk
+.. autofunction:: repeat
 .. autofunction:: reshape
 .. autofunction:: rint
 .. autofunction:: roll


### PR DESCRIPTION
Adds the missing `autofunction` line for `repeat`.