### PR TITLE
Drop dask from doc requirements

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -4,4 +4,3 @@ sphinx_rtd_theme
 toolz
 cloudpickle
 pandas>=0.19.0
-dask


### PR DESCRIPTION
Not entirely sure why this is listed as a requirement as it is already met with the source code. Also this results in masking out more recent information in the source by using the version from PyPI instead.