### PR TITLE
ENH: Proposing to allow purity default set by user

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -104,7 +104,8 @@ def tokenize(*args, **kwargs):
         fails, then a unique identifier is used. If False (default), then a
         unique identifier is always used.
     """
-    if kwargs.pop('pure', False):
+    pure = kwargs.pop('pure', False)
+    if pure:
         return base.tokenize(*args, **kwargs)
     else:
         return str(uuid.uuid4())
@@ -484,7 +485,11 @@ class DelayedAttr(Delayed):
         self._pure_default = pure_default
         self._obj = obj
         self._attr = attr
-        self._key = 'getattr-%s' % tokenize(obj, attr, pure=pure_default)
+        if pure_default is None:
+            pure = True
+        else:
+            pure = False
+        self._key = 'getattr-%s' % tokenize(obj, attr, pure=pure)
 
     @property
     def dask(self):

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -111,7 +111,7 @@ def tokenize(*args, **kwargs):
 
 
 @curry
-def delayed(obj, name=None, pure=None, pure_default=False, nout=None, traverse=True):
+def delayed(obj, name=None, pure=None, pure_default=None, nout=None, traverse=True):
     """Wraps a function or object to produce a ``Delayed``.
 
     ``Delayed`` objects act as proxies for the object they wrap, but all
@@ -276,7 +276,10 @@ def delayed(obj, name=None, pure=None, pure_default=False, nout=None, traverse=T
     Delayed("count_2")
     """
     if pure is None:
-        pure = pure_default
+        if pure_default is None:
+            pure = False
+        else:
+            pure = pure_default
 
     if isinstance(obj, Delayed):
         return obj
@@ -337,7 +340,7 @@ class Delayed(base.Base):
     _default_get = staticmethod(threaded.get)
     _optimize = staticmethod(lambda d, k, **kwds: d)
 
-    def __init__(self, key, dsk, pure_default=False, length=None):
+    def __init__(self, key, dsk, pure_default=None, length=None):
         self._pure_default = pure_default
         self._key = key
         if type(dsk) is list:  # compatibility with older versions
@@ -420,9 +423,12 @@ class Delayed(base.Base):
     _get_unary_operator = _get_binary_operator
 
 
-def call_function(func, func_token, args, kwargs, pure=None, pure_default=False, nout=None):
+def call_function(func, func_token, args, kwargs, pure=None, pure_default=None, nout=None):
     if pure is None:
-        pure = pure_default
+        if pure_default is None:
+            pure = False
+        else:
+            pure = pure_default
     dask_key_name = kwargs.pop('dask_key_name', None)
     pure = kwargs.pop('pure', pure)
 
@@ -449,7 +455,12 @@ def call_function(func, func_token, args, kwargs, pure=None, pure_default=False,
 class DelayedLeaf(Delayed):
     __slots__ = ('_obj', '_key', '_pure', '_nout', '_pure_default')
 
-    def __init__(self, obj, key, pure=None, pure_default=False, nout=None):
+    def __init__(self, obj, key, pure=None, pure_default=None, nout=None):
+        if pure is None:
+            if pure_default is None:
+                pure = False
+            else:
+                pure = pure_default
         self._obj = obj
         self._key = key
         self._pure = pure
@@ -469,7 +480,7 @@ class DelayedLeaf(Delayed):
 class DelayedAttr(Delayed):
     __slots__ = ('_obj', '_attr', '_key', '_pure_default')
 
-    def __init__(self, obj, attr, pure_default=True):
+    def __init__(self, obj, attr, pure_default=None):
         self._pure_default = pure_default
         self._obj = obj
         self._attr = attr

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -481,8 +481,9 @@ class DelayedAttr(Delayed):
         return sharedict.merge(self._obj.dask, (self._key, dsk))
 
     def __call__(self, *args, **kwargs):
-        return call_function(methodcaller(self._attr), self._attr, (self._obj,)\
-                + args, kwargs, pure_default=self._pure_default)
+        return call_function(methodcaller(self._attr), self._attr,
+                             (self._obj, ) + args, kwargs,
+                             pure_default=self._pure_default)
 
 
 for op in [operator.abs, operator.neg, operator.pos, operator.invert,


### PR DESCRIPTION
This is a proposed API enhancement. I would find inheriting purity very convenient. This amounts to adding a new kwarg for `Delayed` objects, setting the `pure=None` as default and checking `if pure is None: pure=pure_default`.

This is kind of a continuation of the discussion in #2073.

Motivation is that I would like sub functions of classes to inherit purity. This would make life easier for us. I hope the code helps better outline what we want, and maybe you have better suggestions? I am not implying that I think this is good, mainly trying to open a better discussion to better my understanding.  Thanks as usual for the continued support :-)


```python
from dask import delayed

class class1:
    def __init__(self, a):
        self.a = a

    def get(self):
        return self.a

@delayed(pure_default=True)
def get_class_v1(cls, g):
    a = cls(g)
    return a

@delayed(pure=True)
def get_class_v2(cls, g):
    a = cls(g)
    return a

@delayed(pure=False)
def get_class_v3(cls, g):
    a = cls(g)
    return a

def test_class(func, cls,  num, version):

    a = func(cls, num)
    print("class {} instantiation key \t\t{}".format(version, a.key))

    a = func(cls, num)
    print("class {} instantiation key (again) \t{}".format(version, a.key))

    print("class {} member getattr key \t\t{}".format(version, a.get().key))
    print("class {} member getattr key (again) \t{}".format(version, a.get().key))

    print("computed result : {}".format(a.get().compute()))


test_class(get_class_v1, class1, 1, "v1")
test_class(get_class_v2, class1, 2, "v2")
test_class(get_class_v3, class1, 3, "v3")
```
Output:
```
class v1 instantiation key              get_class_v1-9c37603e911bdcb648b7955a2386899f
class v1 instantiation key (again)      get_class_v1-9c37603e911bdcb648b7955a2386899f
class v1 member getattr key             get-57697589615a90ec21c04baf483c6109
class v1 member getattr key (again)     get-57697589615a90ec21c04baf483c6109
computed result : 1
class v2 instantiation key              get_class_v2-9b5bb3fdd1b815d8305980906a4516ab
class v2 instantiation key (again)      get_class_v2-9b5bb3fdd1b815d8305980906a4516ab
class v2 member getattr key             get-d2211284-2daa-450a-99f5-6ac154856152
class v2 member getattr key (again)     get-78647ae3-640e-442c-a1c0-9cb0f27d50b9
computed result : 2
class v3 instantiation key              get_class_v3-60366fbf-3a6a-462d-8f17-f3a93834061a
class v3 instantiation key (again)      get_class_v3-a725e845-df3e-4e19-b24a-85730c637150
class v3 member getattr key             get-13a0ddaa-5a7b-45a1-acf4-60058954aa96
class v3 member getattr key (again)     get-f7721d96-8ed2-4a6f-ab14-272533487d0f
computed result : 3
```


In these three cases, `class1`'s `__init__` is pure, and so are all calls to its attributes.
In the case of `class2`, it's `__init__` is pure, but not subsequent calls to its attributes.
Finally, `class3` is never pure.