### PR TITLE
WIP: Parquet engine

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -24,7 +24,7 @@ except:
 
 
 def read_parquet(path, columns=None, filters=None, categories=None, index=None,
-                 storage_options=None):
+                 storage_options=None, engine='fastparquet'):
     """
     Read ParquetFile into a Dask DataFrame
 
@@ -63,6 +63,17 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
     --------
     to_parquet
     """
+    engine = engine.lower()
+    if engine == 'fastparquet':
+        return _read_fastparquet(path, columns=columns, filters=filters,
+                categories=categories, index=index,
+                storage_options=storage_options)
+    else:
+        raise NotImplementedError("Engine %s not found" % engine)
+
+
+def _read_fastparquet(path, columns=None, filters=None, categories=None,
+                      index=None, storage_options=None):
     if fastparquet is False:
         raise ImportError("fastparquet not installed")
     if filters is None:

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import glob
+import os
 
 import numpy as np
 import pandas as pd
@@ -172,7 +173,13 @@ def _read_fastparquet(path, columns=None, filters=None, categories=None,
 
 def _read_arrow(path, columns):
     import pyarrow.parquet as pq
-    paths = sorted(glob.glob(path))
+    if '*' in path:
+        paths = sorted(glob.glob(path))
+    elif os.path.isdir(path):
+        paths = sorted(glob.glob(os.path.join(path, '*')))
+    else:
+        paths = [path]
+    paths = [path for path in paths if not path.endswith('metadata')]
     dfs = [delayed(pq.read_table)(path, columns=columns).to_pandas() for path in paths]
     return from_delayed(dfs)
 


### PR DESCRIPTION
This is for eventual support of Parquet-CPP through PyArrow

cc @martindurant @wesm @jreback @cpcloud 

### TODO list for Arrow

- [ ] Function to produce a list of `(filename, row-group)` pairs that encompasses all of the files of the parquet dataset given a friendly user input like `/path/to/myfile.parquet`, `/path/to/mydirectory/` or `/path/to/mydirectory/*` (if this is common).  Presumably the same filename may occur in several such tuples.
- [ ]  Statistics for each of these row groups.  In particular we care about min and max values.
- [ ] A function that accepts a filename, row-group, and column names and returns a single Pandas DataFrame
- [ ] A function that returns the dtypes of a parquet dataset so that we can construct a representative Pandas dataframe
