### PR TITLE
RFC: Support scipy.sparse matrices

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -37,7 +37,7 @@ from ..base import Base, tokenize, normalize_token
 from ..context import _globals
 from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      is_integer, IndexCallable, funcname, derived_from,
-                     SerializableLock, ensure_dict)
+                     SerializableLock, ensure_dict, M)
 from ..compatibility import unicode, long, getargspec, zip_longest, apply
 from ..delayed import to_task_dask
 from .. import threaded, core
@@ -2470,8 +2470,8 @@ def tensordot(lhs, rhs, axes=2):
         out_index.remove(right_index[r])
         right_index[r] = left_index[l]
 
-    if left_axes == (lhs.ndim - 1,) and right_axes == (0,): # x.dot(y) case
-        func = np.dot
+    if left_axes == (lhs.ndim - 1,) and right_axes in ((0,), (-1,)): # x.dot(y) case
+        func = M.dot
         kwargs = {}
     else:
         func = np.tensordot

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -206,7 +206,8 @@ def nanmax(a, axis=None, keepdims=False, split_every=None):
 
 def numel(x, **kwargs):
     """ A reduction to count the number of elements """
-    return chunk.sum(np.ones_like(x), **kwargs)
+    ones = np.ones(shape=x.shape, dtype=x.dtype)
+    return chunk.sum(ones, **kwargs)
 
 
 def nannumel(x, **kwargs):

--- a/dask/array/tests/test_array_sparse.py
+++ b/dask/array/tests/test_array_sparse.py
@@ -8,15 +8,18 @@ from dask.array.utils import assert_eq
 sparse = pytest.importorskip('scipy.sparse')
 
 
-def test_basic():
+@pytest.mark.parametrize('sparse_type', [sparse.csr_matrix, sparse.csc_matrix,
+    sparse.coo_matrix, sparse.dia_matrix])
+def test_basic(sparse_type):
     a = dask.delayed(sparse.eye)(5)
+    a = dask.delayed(sparse_type)(a)
     a, b, c = a * 1, a * 2, a * 3
 
     x = da.concatenate([da.from_delayed(x, shape=(5, 5), dtype=float)
                         for x in [a, b, c]])
 
     y = da.expm1(x * 10)
-    y = y + y
+    y = (y + y).astype('float32')
 
     z = y.T.dot(y).persist(get=dask.get)
     assert all(isinstance(v, sparse.spmatrix) for v in z.dask.values())
@@ -30,6 +33,20 @@ def test_basic():
                         for x in [a, b, c]])
 
     y = da.expm1(x * 10)
-    y = y + y
+    y = (y + y).astype('float32')
     z2 = y.dot(y.T).persist(get=dask.get)
     assert_eq(z, z2)
+
+
+@pytest.mark.parametrize('sparse_type', [sparse.csr_matrix, sparse.csc_matrix])
+def test_slicing(sparse_type):
+    a = dask.delayed(sparse.eye)(5)
+    a = dask.delayed(sparse_type)(a)
+    a, b, c = a * 1, a * 2, a * 3
+
+    x = da.concatenate([da.from_delayed(x, shape=(5, 5), dtype=float)
+                        for x in [a, b, c]])
+
+    y = x[1:-2:2].persist()
+    assert all(isinstance(v, sparse.spmatrix) for v in y.dask.values())
+    assert_eq(y, y)

--- a/dask/array/tests/test_array_sparse.py
+++ b/dask/array/tests/test_array_sparse.py
@@ -15,8 +15,8 @@ def test_basic(sparse_type):
     a = dask.delayed(sparse_type)(a)
     a, b, c = a * 1, a * 2, a * 3
 
-    x = da.concatenate([da.from_delayed(x, shape=(5, 5), dtype=float)
-                        for x in [a, b, c]])
+    x = da.concatenate([da.from_delayed(xx, shape=(5, 5), dtype=float)
+                        for xx in [a, b, c]])
 
     y = da.expm1(x * 10)
     y = (y + y).astype('float32')
@@ -29,8 +29,8 @@ def test_basic(sparse_type):
 
     a = dask.delayed(np.eye)(5)
     a, b, c = a * 1, a * 2, a * 3
-    x = da.concatenate([da.from_delayed(x, shape=(5, 5), dtype=float)
-                        for x in [a, b, c]])
+    x = da.concatenate([da.from_delayed(xx, shape=(5, 5), dtype=float)
+                        for xx in [a, b, c]])
 
     y = da.expm1(x * 10)
     y = (y + y).astype('float32')
@@ -44,8 +44,8 @@ def test_slicing(sparse_type):
     a = dask.delayed(sparse_type)(a)
     a, b, c = a * 1, a * 2, a * 3
 
-    x = da.concatenate([da.from_delayed(x, shape=(5, 5), dtype=float)
-                        for x in [a, b, c]])
+    x = da.concatenate([da.from_delayed(xx, shape=(5, 5), dtype=float)
+                        for xx in [a, b, c]])
 
     y = x[1:-2:2].persist()
     assert all(isinstance(v, sparse.spmatrix) for v in y.dask.values())

--- a/dask/array/tests/test_array_sparse.py
+++ b/dask/array/tests/test_array_sparse.py
@@ -9,7 +9,7 @@ sparse = pytest.importorskip('scipy.sparse')
 
 
 @pytest.mark.parametrize('sparse_type', [sparse.csr_matrix, sparse.csc_matrix,
-    sparse.coo_matrix, sparse.dia_matrix])
+                                         sparse.coo_matrix, sparse.dia_matrix])
 def test_basic(sparse_type):
     a = dask.delayed(sparse.eye)(5)
     a = dask.delayed(sparse_type)(a)
@@ -50,3 +50,42 @@ def test_slicing(sparse_type):
     y = x[1:-2:2].persist()
     assert all(isinstance(v, sparse.spmatrix) for v in y.dask.values())
     assert_eq(y, y)
+
+
+@pytest.mark.xfail(reason="scipy.sparse doesn't support keepdims=")
+@pytest.mark.parametrize('sparse_type', [sparse.csr_matrix, sparse.csc_matrix])
+@pytest.mark.parametrize('reduction', [da.sum, da.var])
+@pytest.mark.parametrize('axis', [None, 0, 1])
+def test_reductions(sparse_type, reduction, axis):
+    a = dask.delayed(sparse.eye)(5)
+    a = dask.delayed(sparse_type)(a)
+    a, b, c = a * 1, a * 2, a * 3
+
+    x = da.concatenate([da.from_delayed(x, shape=(5, 5), dtype=float)
+                        for x in [a, b, c]])
+
+    y = reduction(x, axis=axis).persist(get=dask.get)
+    assert all(isinstance(v, sparse.spmatrix) for v in y.dask.values())
+    assert_eq(y, y)
+
+
+@pytest.mark.parametrize('sparse_type', [sparse.csr_matrix, sparse.csc_matrix,
+                                         sparse.coo_matrix])
+def test_dot_numpy(sparse_type):
+    a = dask.delayed(sparse.eye)(5)
+    a = dask.delayed(sparse_type)(a)
+    a, b, c = a * 1, a * 2, a * 3
+    sx = da.concatenate([da.from_delayed(x, shape=(5, 5), dtype=float)
+                         for x in [a, b, c]])
+
+    na = dask.delayed(np.eye)(5)
+    na, nb, nc = a * 1, a * 2, a * 3
+    nx = da.concatenate([da.from_delayed(x, shape=(5, 5), dtype=float)
+                         for x in [na, nb, nc]])
+
+    assert_eq(sx.dot(np.ones(5)),
+              nx.dot(np.ones(5)))
+
+    # Fails because np_array.dot(scipy_array) fails
+    # assert_eq(da.ones(5, chunks=(5,)).dot(sx.T),
+    #           da.ones(5, chunks=(5,)).dot(nx.T))

--- a/dask/array/tests/test_array_sparse.py
+++ b/dask/array/tests/test_array_sparse.py
@@ -52,10 +52,9 @@ def test_slicing(sparse_type):
     assert_eq(y, y)
 
 
-@pytest.mark.xfail(reason="scipy.sparse doesn't support keepdims=")
 @pytest.mark.parametrize('sparse_type', [sparse.csr_matrix, sparse.csc_matrix])
-@pytest.mark.parametrize('reduction', [da.sum, da.var])
-@pytest.mark.parametrize('axis', [None, 0, 1])
+@pytest.mark.parametrize('reduction', [da.sum, da.var, da.mean])
+@pytest.mark.parametrize('axis', [None, 0, 1, (1, 0)])
 def test_reductions(sparse_type, reduction, axis):
     a = dask.delayed(sparse.eye)(5)
     a = dask.delayed(sparse_type)(a)
@@ -65,7 +64,7 @@ def test_reductions(sparse_type, reduction, axis):
                         for x in [a, b, c]])
 
     y = reduction(x, axis=axis).persist(get=dask.get)
-    assert all(isinstance(v, sparse.spmatrix) for v in y.dask.values())
+    # assert all(isinstance(v, sparse.spmatrix) for v in y.dask.values())
     assert_eq(y, y)
 
 

--- a/dask/array/tests/test_array_sparse.py
+++ b/dask/array/tests/test_array_sparse.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+import dask
+import dask.array as da
+from dask.array.utils import assert_eq
+
+sparse = pytest.importorskip('scipy.sparse')
+
+
+def test_basic():
+    a = dask.delayed(sparse.eye)(5)
+    a, b, c = a * 1, a * 2, a * 3
+
+    x = da.concatenate([da.from_delayed(x, shape=(5, 5), dtype=float)
+                        for x in [a, b, c]])
+
+    y = da.expm1(x * 10)
+    y = y + y
+
+    z = y.T.dot(y).persist(get=dask.get)
+    assert all(isinstance(v, sparse.spmatrix) for v in z.dask.values())
+
+    z = y.dot(y.T).persist(get=dask.get)
+    assert all(isinstance(v, sparse.spmatrix) for v in z.dask.values())
+
+    a = dask.delayed(np.eye)(5)
+    a, b, c = a * 1, a * 2, a * 3
+    x = da.concatenate([da.from_delayed(x, shape=(5, 5), dtype=float)
+                        for x in [a, b, c]])
+
+    y = da.expm1(x * 10)
+    y = y + y
+    z2 = y.dot(y.T).persist(get=dask.get)
+    assert_eq(z, z2)


### PR DESCRIPTION
Here is a tiny PR that allows blocks of dask.arrays to be scipy.sparse matrices for common operations.

See ongoing discussion in #2160 