### PR TITLE
Allow delayed targets in dask.array.store

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -17,7 +17,6 @@ from threading import Lock
 import uuid
 import warnings
 
-import toolz
 try:
     from cytoolz.curried import (partition, concat, pluck, join, first,
                                  groupby, valmap, accumulate, interleave,
@@ -869,7 +868,6 @@ def store(sources, targets, lock=True, regions=None, compute=True, **kwargs):
         raise ValueError("Different number of sources [%d] and targets [%d] than regions [%d]"
                          % (len(sources), len(targets), len(regions)))
 
-
     updates = {}
     keys = []
     for tgt, src, reg in zip(targets, sources, regions):
@@ -886,7 +884,6 @@ def store(sources, targets, lock=True, regions=None, compute=True, **kwargs):
 
         update.update(dsk)
         updates.update(update)
-
 
     name = 'store-' + tokenize(*keys)
     dsk = sharedict.merge((name, updates), *[src.dask for src in sources])
@@ -2520,10 +2517,9 @@ def insert_to_ooc(out, arr, lock=True, region=None):
 
     slices = slices_from_chunks(arr.chunks)
 
-
     name = 'store-%s' % arr.name
     dsk = dict(((name,) + t[1:], (store, out, t, slc, lock, region))
-                    for t, slc in zip(core.flatten(arr._keys()), slices))
+               for t, slc in zip(core.flatten(arr._keys()), slices))
 
     return dsk
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1003,7 +1003,7 @@ def test_store_delayed_target():
     targs = {}
 
     def make_target(key):
-        a = np.empty((4,4))
+        a = np.empty((4, 4))
         targs[key] = a
         return a
 
@@ -1016,8 +1016,8 @@ def test_store_delayed_target():
     at = targs['at']
     bt = targs['bt']
 
-    assert (at == 2).all()
-    assert (bt == 3).all()
+    assert_eq(at, a)
+    assert_eq(bt, b)
 
     pytest.raises(ValueError, lambda: store([a], [at, bt]))
     pytest.raises(ValueError, lambda: store(at, at))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -993,6 +993,36 @@ def test_coerce():
         assert complex(d)
 
 
+def test_store_delayed_target():
+    from dask.delayed import delayed
+    d = da.ones((4, 4), chunks=(2, 2))
+    a, b = d + 1, d + 2
+
+
+    # empty buffers to be used as targets
+    targs = {}
+
+    def make_target(key):
+        a = np.empty((4,4))
+        targs[key] = a
+        return a
+
+    # delayed calls to these targets
+    atd = delayed(make_target)('at')
+    btd = delayed(make_target)('bt')
+
+    store([a, b], [atd, btd])
+
+    at = targs['at']
+    bt = targs['bt']
+
+    assert (at == 2).all()
+    assert (bt == 3).all()
+
+    pytest.raises(ValueError, lambda: store([a], [at, bt]))
+    pytest.raises(ValueError, lambda: store(at, at))
+    pytest.raises(ValueError, lambda: store([at, bt], [at, bt]))
+
 def test_store():
     d = da.ones((4, 4), chunks=(2, 2))
     a, b = d + 1, d + 2

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -998,7 +998,6 @@ def test_store_delayed_target():
     d = da.ones((4, 4), chunks=(2, 2))
     a, b = d + 1, d + 2
 
-
     # empty buffers to be used as targets
     targs = {}
 
@@ -1022,6 +1021,7 @@ def test_store_delayed_target():
     pytest.raises(ValueError, lambda: store([a], [at, bt]))
     pytest.raises(ValueError, lambda: store(at, at))
     pytest.raises(ValueError, lambda: store([at, bt], [at, bt]))
+
 
 def test_store():
     d = da.ones((4, 4), chunks=(2, 2))


### PR DESCRIPTION
This issue came up in #2119. This PR can be used to dynamically create the target arrays as the graph is executed, and enables the following example:

```
import numpy as np
from dask.delayed import delayed
from collections import defaultdict
import dask.array as da
import h5py


files = {}

a = da.from_array(np.ones((10,10)), (10,10))

@delayed
def create_target(name="tmp.h5", sh=a.shape, chunks=a.chunks):
    print("Making variable")
    if name not in files:
        print("Creating new hdf5 file")
        f = h5py.File("tmp.h5", "a")
        files[name] = f
    else:
        f = files[name]

    ch = tuple(ch[0] for ch in chunks)

    if "a" in f:
        del f["a"]
    v = f.create_dataset("a", shape=sh, chunks=ch) 
    files[name] = f
    return v



r = a.store(create_target(), compute=False, lock=True)

print("Returned delayed object")
r.compute()
r.compute()

for _,f in files.items():
    f.close()
```