### PR TITLE
Ensure travis test coverage 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,5 +2,6 @@
 omit =
     */test_*.py
     dask/compatibility.py
+    dask/_version.py
 source = 
     dask

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -39,8 +39,10 @@ conda install -q -c conda-forge \
     psutil \
     pytables \
     pytest \
+    scikit-image \
     scikit-learn \
     scipy \
+    sqlalchemy \
     toolz
 
 # Specify numpy/pandas here to prevent upgrade/downgrade


### PR DESCRIPTION
There were a few libraries that we weren't testing against: https://coveralls.io/github/dask/dask

Additionally, it looks like we aren't testing test_fft.py for some reason.  Does anyone have a guess as to why?  cc @jakirkham 