### PR TITLE
Fix Travis pinnings

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -30,8 +30,8 @@ echo "pandas $PANDAS" >> $HOME/miniconda/envs/test-environment/conda-meta/pinned
 # incompatible with the installed version of numpy leading to crashes. This
 # seems to have to do with differences between conda-forge and defaults.
 conda install -q -c conda-forge \
-    numpy=$NUMPY \
-    pandas=$PANDAS \
+    numpy \
+    pandas \
     bcolz \
     blosc \
     chest \
@@ -50,8 +50,6 @@ conda install -q -c conda-forge \
 
 # Specify numpy/pandas here to prevent upgrade/downgrade
 conda install -q -c conda-forge \
-    numpy=$NUMPY \
-    pandas=$PANDAS \
     distributed \
     cloudpickle \
     bokeh \

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -19,6 +19,11 @@ conda config --set always_yes yes --set changeps1 no
 conda create -q -n test-environment python=$PYTHON
 source activate test-environment
 
+# Pin matrix items
+touch $HOME/miniconda/envs/test-environment/conda-meta/pinned
+echo "numpy $NUMPY" >> $HOME/miniconda/envs/test-environment/conda-meta/pinned
+echo "pandas $PANDAS" >> $HOME/miniconda/envs/test-environment/conda-meta/pinned
+
 # Install dependencies.
 # XXX: Due to a weird conda dependency resolution issue, we need to install
 # dependencies in two separate calls, otherwise we sometimes get version


### PR DESCRIPTION
Appears some pinnings for NumPy and pandas were coming [loose]( https://travis-ci.org/dask/dask/jobs/219659319#L318-L319 ) in some cases. This switches to an explicit pinning file for the environment to enforce these version constraints always. Does a little tidying up afterwards.