### PR TITLE
Fix CI pinnings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
     # Since appveyor is quite slow, we only use a single configuration
     - PYTHON: "3.5"
       ARCH: "64"
-      NUMPY: "1.12"
+      NUMPY: "1.12.1"
       PANDAS: "0.19.2"
       CONDA_ENV: testenv
 

--- a/continuous_integration/appveyor/setup_conda_environment.cmd
+++ b/continuous_integration/appveyor/setup_conda_environment.cmd
@@ -19,6 +19,12 @@ conda create -n %CONDA_ENV% -q -y python=%PYTHON% pytest toolz
 
 call activate %CONDA_ENV%
 
+@rem Pin matrix items
+@rem Please see PR ( https://github.com/dask/dask/pull/2185 ) for details.
+copy NUL %CONDA_PREFIX%\conda-meta\pinned
+echo numpy %NUMPY% >> %CONDA_PREFIX%\conda-meta\pinned
+echo pandas %PANDAS% >> %CONDA_PREFIX%\conda-meta\pinned
+
 @rem Install optional dependencies for tests
 %CONDA_INSTALL% numpy=%NUMPY% pandas=%PANDAS% cloudpickle distributed
 %CONDA_INSTALL% s3fs psutil pytables bokeh bcolz scipy h5py ipython

--- a/continuous_integration/appveyor/setup_conda_environment.cmd
+++ b/continuous_integration/appveyor/setup_conda_environment.cmd
@@ -26,7 +26,7 @@ echo numpy %NUMPY% >> %CONDA_PREFIX%\conda-meta\pinned
 echo pandas %PANDAS% >> %CONDA_PREFIX%\conda-meta\pinned
 
 @rem Install optional dependencies for tests
-%CONDA_INSTALL% numpy=%NUMPY% pandas=%PANDAS% cloudpickle distributed
+%CONDA_INSTALL% numpy pandas cloudpickle distributed
 %CONDA_INSTALL% s3fs psutil pytables bokeh bcolz scipy h5py ipython
 
 %PIP_INSTALL% git+https://github.com/dask/partd --upgrade

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -19,6 +19,12 @@ conda config --set always_yes yes --set changeps1 no
 conda create -q -n test-environment python=$PYTHON
 source activate test-environment
 
+# Pin matrix items
+# Please see PR ( https://github.com/dask/dask/pull/2185 ) for details.
+touch $CONDA_PREFIX/conda-meta/pinned
+echo "numpy $NUMPY" >> $CONDA_PREFIX/conda-meta/pinned
+echo "pandas $PANDAS" >> $CONDA_PREFIX/conda-meta/pinned
+
 # Install dependencies.
 # XXX: Due to a weird conda dependency resolution issue, we need to install
 # dependencies in two separate calls, otherwise we sometimes get version

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -31,8 +31,8 @@ echo "pandas $PANDAS" >> $CONDA_PREFIX/conda-meta/pinned
 # incompatible with the installed version of numpy leading to crashes. This
 # seems to have to do with differences between conda-forge and defaults.
 conda install -q -c conda-forge \
-    numpy=$NUMPY \
-    pandas=$PANDAS \
+    numpy \
+    pandas \
     bcolz \
     blosc \
     bokeh \
@@ -52,8 +52,6 @@ conda install -q -c conda-forge \
 
 # Specify numpy/pandas here to prevent upgrade/downgrade
 conda install -q -c conda-forge \
-    numpy=$NUMPY \
-    pandas=$PANDAS \
     distributed \
     cloudpickle \
 


### PR DESCRIPTION
Appears some pinnings for NumPy and pandas were coming [loose]( https://travis-ci.org/dask/dask/jobs/219659319#L318-L319 ). This switches to using a `pinned` file to pin NumPy and pandas for all `conda` install and update operations with the environment.