### PR TITLE
Avoid using dir=self.tempdir when not necessary

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -203,11 +203,17 @@ class maybe_buffered_partd(object):
         self.buffer = buffer
 
     def __reduce__(self):
-        return (maybe_buffered_partd, (False, self.tempdir))
+        if self.tempdir:
+            return (maybe_buffered_partd, (False, self.tempdir))
+        else:
+            return (maybe_buffered_partd, (False,))
 
     def __call__(self, *args, **kwargs):
         import partd
-        file = partd.File(dir=self.tempdir)
+        if self.tempdir:
+            file = partd.File(dir=self.tempdir)
+        else:
+            file = partd.File()
         if self.buffer:
             return partd.PandasBlocks(partd.Buffer(partd.Dict(), file))
         else:


### PR DESCRIPTION
This allows us to support non-git-master versions of partd

This slipped in in https://github.com/dask/dask/pull/2197