### PR TITLE
BUG: set_index now sorts with single partition

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -71,7 +71,8 @@ def set_index(df, index, npartitions=None, shuffle=None, compute=False,
                 divisions = [divisions[i] for i in indexes]
 
         if (mins == sorted(mins) and maxes == sorted(maxes) and
-                all(mx < mn for mx, mn in zip(maxes[:-1], mins[1:]))):
+                all(mx < mn for mx, mn in zip(maxes[:-1], mins[1:])) and
+                len(mins) > 1 and len(maxes) > 1):
             divisions = mins + [maxes[-1]]
             return set_sorted_index(df, index, drop=drop, divisions=divisions)
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -344,3 +344,17 @@ def test_temporary_directory():
         ddf2 = ddf.set_index('x', shuffle='disk')
         ddf2.compute()
         assert any(fn.endswith('.partd') for fn in os.listdir(os.getcwd()))
+
+
+def test_set_index_single_partition_sorts():
+    idx = np.array([1483228800084000000, 1483228800188000000, 1483228800404999936,
+                    1483228800433000192, 1483228800546999808, 1483228800636000000,
+                    1483228800670000128, 1483228800670000128, 1483228800848999936,
+                    1483228801116000000, 1483228801428000000, 1483228801568000000,
+                    1483228801851000064, 1483228801900999936, 1483228801900999936,
+                    1483228802105999872, 1483228802101999872, 1483228802516999936])
+
+    df = pd.DataFrame({"A": np.arange(len(idx)),
+                       "B": pd.to_datetime(idx, unit='ns')})
+    ddf = dd.from_pandas(df, 1).set_index("B")
+    assert ddf.index.compute().is_monotonic


### PR DESCRIPTION
Had an edge case in `df.set_index` where you could end up with
an unsorted index when you have a single partition.

xref https://github.com/dask/dask/issues/2211 (doesn't close)