### PR TITLE
Test N-D FFTs when s is defined and axes are not

### DIFF
--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -70,6 +70,8 @@ def test_fft2n_shapes(funcname):
     np_fft = getattr(np.fft, funcname)
     assert_eq(da_fft(darr3),
               np_fft(nparr))
+    assert_eq(da_fft(darr3, (8, 9)),
+              np_fft(nparr, (8, 9)))
     assert_eq(da_fft(darr3, (8, 9), axes=(1, 0)),
               np_fft(nparr, (8, 9), axes=(1, 0)))
     assert_eq(da_fft(darr3, (12, 11), axes=(1, 0)),


### PR DESCRIPTION
Make sure that we are coming up with the right axes when only the output shape is specified. This exercises both the 2-D and N-D FFT cases. Also improves the line coverage a bit.

Edit: FTR this [line]( https://coveralls.io/builds/11064998/source?filename=dask%2Farray%2Ffft.py#L149 ) is the one we are missing, which we now [cover]( https://coveralls.io/builds/11081040/source?filename=dask%2Farray%2Ffft.py#L149 ).