### PR TITLE
Minor Cleanup of 1D FFTs

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -179,7 +179,7 @@ def fft_wrap(fft_func, kind=None, dtype=None):
         def func(a, n=None, axis=None):
             s = None
             if n is not None:
-                s = [n]
+                s = (n,)
 
             axes = None
             if axis is not None:

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -148,7 +148,7 @@ def fft_wrap(fft_func, kind=None, dtype=None):
                 else:
                     axes = tuple(range(len(s)))
             else:
-                raise ValueError("Expected 2d or nd fft.")
+                axes = (-1,)
         else:
             if len(set(axes)) < len(axes):
                 raise ValueError("Duplicate axes not allowed.")
@@ -177,11 +177,13 @@ def fft_wrap(fft_func, kind=None, dtype=None):
         _func = func
 
         def func(a, n=None, axis=None):
-            axes = (1,) if axis is None else (axis,)
-
             s = None
             if n is not None:
                 s = [n]
+
+            axes = None
+            if axis is not None:
+                axes = (axis,)
 
             return _func(a, s, axes)
 


### PR DESCRIPTION
Some minor cleanup of 1D FFTs.

* Handles the default `axes` value in the generic FFT wrapper function.
* Makes sure `s` is a `tuple` in 1-D case.
* Also removes this [uncovered line]( https://coveralls.io/builds/11064998/source?filename=dask%2Farray%2Ffft.py#L151 ) and replaces it with a [covered one]( https://coveralls.io/builds/11079102/source?filename=dask%2Farray%2Ffft.py#L151 ).

Edit: Added link to the Coveralls report with covered line.