### PR TITLE
Boundary slice excluded

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3686,6 +3686,7 @@ def repartition(df, divisions=None, force=False):
 
     >>> ddf = dd.repartition(df, [0, 5, 10, 20])  # doctest: +SKIP
     """
+
     token = tokenize(df, divisions)
     if isinstance(df, _Frame):
         tmp = 'repartition-split-' + token

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -60,9 +60,9 @@ def boundary_slice(df, start, stop, right_boundary=True, left_boundary=True,
         # on monotonic vs. non-monotonic indexes
         # If the index is monotonic, `df.loc[start:stop]` is fine.
         # If it's not, `df.loc[start:stop]` raises when `start` is missing
-        if start:
+        if start is not None:
             df = df[df.index >= start]
-        if stop:
+        if stop is not None:
             df = df[df.index <= stop]
         result = df
     else:

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -55,13 +55,18 @@ def boundary_slice(df, start, stop, right_boundary=True, left_boundary=True,
     2  20
     2  30
     """
-    # Pandas treats missing keys differently for label-slicing
-    # on monotonic vs. non-monotonic indexes
-    # If the index is monotonic, `df.loc[start:stop]` is fine.
-    # If it's not, `df.loc[start:stop]` raises when `start` is missing
     if kind == 'loc' and not df.index.is_monotonic:
-        df = df.sort_index()
-    result = getattr(df, kind)[start:stop]
+        # Pandas treats missing keys differently for label-slicing
+        # on monotonic vs. non-monotonic indexes
+        # If the index is monotonic, `df.loc[start:stop]` is fine.
+        # If it's not, `df.loc[start:stop]` raises when `start` is missing
+        if start:
+            df = df[df.index >= start]
+        if stop:
+            df = df[df.index <= stop]
+        result = df
+    else:
+        result = getattr(df, kind)[start:stop]
     if not right_boundary:
         right_index = result.index.get_slice_bound(stop, 'left', kind)
         result = result.iloc[:right_index]

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -55,6 +55,12 @@ def boundary_slice(df, start, stop, right_boundary=True, left_boundary=True,
     2  20
     2  30
     """
+    # Pandas treats missing keys differently for label-slicing
+    # on monotonic vs. non-monotonic indexes
+    # If the index is monotonic, `df.loc[start:stop]` is fine.
+    # If it's not, `df.loc[start:stop]` raises when `start` is missing
+    if kind == 'loc' and not df.index.is_monotonic:
+        df = df.sort_index()
     result = getattr(df, kind)[start:stop]
     if not right_boundary:
         right_index = result.index.get_slice_bound(stop, 'left', kind)


### PR DESCRIPTION
Changes `boundary_slice` to handle cases where

- the index is not sorted
- using label-based indexing (loc)
- the start or stop is missing

See https://github.com/pandas-dev/pandas/issues/8613 for details on the pandas
side, but the short version is pandas will raise a KeyError doing `.loc[start:stop]` if the index is not monotonic and start or stop are missing.

Closes https://github.com/dask/dask/issues/2211