### PR TITLE
BUG: boundary_slice with missing and unsorted.

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -74,11 +74,9 @@ def boundary_slice(df, start, stop, right_boundary=True, left_boundary=True,
     else:
         result = getattr(df, kind)[start:stop]
     if not right_boundary:
-        stop = min(stop, df.index.max())
         right_index = result.index.get_slice_bound(stop, 'left', kind)
         result = result.iloc[:right_index]
     if not left_boundary:
-        start = max(start, df.index.min())
         left_index = result.index.get_slice_bound(start, 'right', kind)
         result = result.iloc[left_index:]
     return result

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -61,16 +61,24 @@ def boundary_slice(df, start, stop, right_boundary=True, left_boundary=True,
         # If the index is monotonic, `df.loc[start:stop]` is fine.
         # If it's not, `df.loc[start:stop]` raises when `start` is missing
         if start is not None:
-            df = df[df.index >= start]
+            if left_boundary:
+                df = df[df.index >= start]
+            else:
+                df = df[df.index > start]
         if stop is not None:
-            df = df[df.index <= stop]
-        result = df
+            if right_boundary:
+                df = df[df.index <= stop]
+            else:
+                df = df[df.index < stop]
+        return df
     else:
         result = getattr(df, kind)[start:stop]
     if not right_boundary:
+        stop = min(stop, df.index.max())
         right_index = result.index.get_slice_bound(stop, 'left', kind)
         result = result.iloc[:right_index]
     if not left_boundary:
+        start = max(start, df.index.min())
         left_index = result.index.get_slice_bound(start, 'right', kind)
         result = result.iloc[left_index:]
     return result

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2774,6 +2774,27 @@ def test_boundary_slice_nonmonotonic():
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize('start, stop, right_boundary, left_boundary, drop', [
+    (-1, None, False, False, [-1, -2]),
+    (-1, None, False, True, [-2]),
+    (None, 3, False, False, [3, 4]),
+    (None, 3, True, False, [4]),
+    # Missing keys
+    (-.5, None, False, False, [-1, -2]),
+    (-.5, None, False, True, [-1, -2]),
+    (-1.5, None, False, True, [-2]),
+    (None, 3.5, False, False, [4]),
+    (None, 3.5, True, False, [4]),
+    (None, 2.5, False, False, [3, 4]),
+])
+def test_with_boundary(start, stop, right_boundary, left_boundary, drop):
+    x = np.array([-1, -2, 2, 4, 3])
+    df = pd.DataFrame({"B": range(len(x))}, index=x)
+    result = boundary_slice(df, start, stop, right_boundary, left_boundary)
+    expected = df.drop(drop)
+    tm.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize('index, left, right', [
     (range(10), 0, 9),
     (range(10), -1, None),


### PR DESCRIPTION
Missed a case in https://github.com/dask/dask/issues/2211 where
the index is not sorted and the key is not in the index and
either of the boundaries are not included.

xref https://github.com/dask/dask/pull/2217#issuecomment-294201817