### PR TITLE
ENH: Refactoring to support multiple Parquet readers, add PyArrow reader

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -62,7 +62,7 @@ pip install -q git+https://github.com/dask/zict --upgrade --no-deps
 pip install -q git+https://github.com/dask/distributed --upgrade --no-deps
 
 if [[ $PYTHONOPTIMIZE != '2' ]]; then
-    conda install -q -c conda-forge numba cython
+    conda install -q -c conda-forge numba cython pyarrow
     pip install -q git+https://github.com/dask/fastparquet
 fi
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -44,6 +44,7 @@ conda install -q -c conda-forge \
     ipython \
     partd \
     psutil \
+    pyarrow \
     pytables \
     pytest \
     scikit-image \
@@ -62,7 +63,7 @@ pip install -q git+https://github.com/dask/zict --upgrade --no-deps
 pip install -q git+https://github.com/dask/distributed --upgrade --no-deps
 
 if [[ $PYTHONOPTIMIZE != '2' ]]; then
-    conda install -q -c conda-forge numba cython pyarrow
+    conda install -q -c conda-forge numba cython
     pip install -q git+https://github.com/dask/fastparquet
 fi
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -11,8 +11,6 @@ from ...compatibility import PY3
 from ...delayed import delayed
 from ...bytes.core import get_fs_paths_myopen
 
-_REGISTERED_FASTPARQUET = False
-
 
 class GenericParquetReader(object):
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -11,27 +11,357 @@ from ...compatibility import PY3
 from ...delayed import delayed
 from ...bytes.core import get_fs_paths_myopen
 
-try:
-    import fastparquet
-    from fastparquet import parquet_thrift
-    from fastparquet.core import read_row_group_file
-    from fastparquet.api import _pre_allocate
-    from fastparquet.util import check_column_names
-    default_encoding = parquet_thrift.Encoding.PLAIN
-except:
-    fastparquet = False
-    default_encoding = None
+_REGISTERED_FASTPARQUET = False
 
 
-def read_parquet(path, columns=None, filters=None, categories=None, index=None,
-                 storage_options=None):
+class GenericParquetReader(object):
+
+    def _meta_from_dtypes(self, to_read_columns, file_columns, file_dtypes):
+        meta = pd.DataFrame({c: pd.Series([], dtype=d)
+                            for (c, d) in file_dtypes.items()},
+                            columns=[c for c in file_columns
+                                     if c in file_dtypes])
+        return meta[list(to_read_columns)]
+
+
+# ----------------------------------------------------------------------
+# Fastparquet interface
+
+
+class FastparquetReader(GenericParquetReader):
     """
     Read ParquetFile into a Dask DataFrame
 
     This reads a directory of Parquet data into a Dask.dataframe, one file per
     partition.  It selects the index among the sorted columns if any exist.
 
-    This uses the fastparquet project: http://fastparquet.readthedocs.io/en/latest
+    This uses the fastparquet project:
+
+        http://fastparquet.readthedocs.io/en/latest
+
+    Parameters
+    ----------
+    path : string
+        Source directory for data. May be a glob string.
+        Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
+    columns: list or None
+        List of column names to load
+    filters: list
+        List of filters to apply, like ``[('x', '>' 0), ...]``
+    index: string or None (default) or False
+        Name of index column to use if that column is sorted;
+        False to force dask to not use any column as the index
+    categories: list, dict or None
+        For any fields listed here, if the parquet encoding is Dictionary,
+        the column will be created with dtype category. Use only if it is
+        guaranteed that the column is encoded as dictionary in all row-groups.
+        If a list, assumes up to 2**16-1 labels; if a dict, specify the number
+        of labels expected; if None, will load categories automatically for
+        data written by dask/fastparquet, not otherwise.
+
+    Examples
+    --------
+    >>> df = read_parquet('s3://bucket/my-parquet-data')  # doctest: +SKIP
+
+    See Also
+    --------
+    to_parquet
+    """
+    _REGISTERED_TOKENIZE = False
+
+    def __init__(self, fs, paths, file_opener, columns=None, filters=None,
+                 categories=None, index=None):
+        import fastparquet  # noqa
+        self._ensure_registered()
+
+        self.fs = fs
+        self.paths = paths
+        self.file_opener = file_opener
+
+        self.filters = filters or []
+
+        if isinstance(columns, list):
+            columns = tuple(columns)
+
+        self.columns = columns
+        self.categories = categories
+        self.index = index
+
+        self.dataset = self._load_paths_and_metadata()
+        self.task_name = 'read-parquet-' + tokenize(self.dataset, self.columns,
+                                                    self.categories)
+
+    def _ensure_registered(self):
+        if self._REGISTERED_TOKENIZE:
+            return
+        import fastparquet
+
+        @partial(normalize_token.register, fastparquet.ParquetFile)
+        def normalize_ParquetFile(pf):
+            return (type(pf), pf.fn, pf.sep) + normalize_token(pf.open)
+
+        self._REGISTERED_TOKENIZE = True
+
+    def get_pandas_deferred(self):
+        row_groups = self._get_filtered_row_groups()
+
+        (out_type, frame_meta, index_col, all_columns,
+         categories, divisions) = self._resolve_metadata(row_groups)
+
+        task_plan = {
+            (self.task_name, i): (_read_parquet_row_group,
+                                  self.file_opener,
+                                  self.dataset.row_group_filename(rg),
+                                  index_col,
+                                  all_columns,
+                                  rg,
+                                  out_type == Series,
+                                  categories,
+                                  self.dataset.schema,
+                                  self.dataset.cats,
+                                  self.dataset.dtypes)
+            for i, rg in enumerate(row_groups)
+        }
+
+        return out_type(task_plan, self.task_name, frame_meta, divisions)
+
+    def _get_filtered_row_groups(self):
+        import fastparquet.api as fpapi
+
+        def _exclude_row_group(rg):
+            return (fpapi.filter_out_stats(rg, self.filters,
+                                           self.dataset.schema) or
+                    fpapi.filter_out_cats(rg, self.filters))
+
+        return [rg for rg in self.dataset.row_groups
+                if not _exclude_row_group(rg)]
+
+    def _load_paths_and_metadata(self):
+        from fastparquet import ParquetFile
+        from fastparquet.util import check_column_names
+
+        path_sep = self.fs.sep
+
+        if len(self.paths) > 1:
+            pf = ParquetFile(self.paths, open_with=self.file_opener,
+                             sep=path_sep)
+        else:
+            try:
+                metadata_path = self.paths[0] + path_sep + '_metadata'
+                pf = ParquetFile(metadata_path, open_with=self.file_opener,
+                                 sep=path_sep)
+            except:
+                pf = ParquetFile(self.paths[0], open_with=self.file_opener,
+                                 sep=path_sep)
+
+        check_column_names(pf.columns, self.categories)
+        return pf
+
+    def _resolve_metadata(self, row_groups):
+        pf = self.dataset
+
+        if self.columns is None:
+            all_columns = tuple(pf.columns + list(pf.cats))
+        else:
+            all_columns = self.columns
+
+        if not isinstance(all_columns, tuple):
+            out_type = Series
+            all_columns = (all_columns,)
+        else:
+            out_type = DataFrame
+
+        index_col, divisions = self._infer_index_and_divisions(row_groups)
+
+        if index_col and index_col not in all_columns:
+            all_columns = all_columns + (index_col,)
+
+        categories = self.categories
+        if categories is None:
+            categories = pf.categories
+
+        dtypes = pf._dtypes(categories)
+
+        meta = self._meta_from_dtypes(all_columns, pf.columns, dtypes)
+
+        for cat in categories:
+            meta[cat] = pd.Series(pd.Categorical([],
+                                  categories=[UNKNOWN_CATEGORIES]))
+
+        if index_col:
+            meta = meta.set_index(index_col)
+
+        if out_type == Series:
+            assert len(meta.columns) == 1
+            meta = meta[meta.columns[0]]
+
+        return out_type, meta, index_col, all_columns, categories, divisions
+
+    def _infer_index_and_divisions(self, row_groups):
+        import fastparquet.api as fpapi
+
+        # Find an index among the partially sorted columns
+        minmax = fpapi.sorted_partitioned_columns(self.dataset)
+
+        if self.index is False:
+            index_col = None
+        elif len(minmax) == 1:
+            index_col = first(minmax)
+        elif len(minmax) > 1:
+            if self.index:
+                index_col = self.index
+            elif 'index' in minmax:
+                index_col = 'index'
+            else:
+                raise ValueError("Multiple possible indexes exist: %s.  "
+                                 "Please select one with index='index-name'"
+                                 % sorted(minmax))
+        else:
+            index_col = None
+
+        if index_col:
+            divisions = (list(minmax[index_col]['min']) +
+                         [minmax[index_col]['max'][-1]])
+        else:
+            divisions = (None,) * (len(row_groups) + 1)
+
+        if isinstance(divisions[0], np.datetime64):
+            divisions = [pd.Timestamp(d) for d in divisions]
+
+        return index_col, divisions
+
+
+def _read_parquet_row_group(open, fn, index, columns, rg, series, categories,
+                            schema, cs, dt, *args):
+    from fastparquet.core import read_row_group_file
+    from fastparquet.api import _pre_allocate
+
+    if not isinstance(columns, (tuple, list)):
+        columns = (columns,)
+        series = True
+    if index and index not in columns:
+        columns = columns + type(columns)([index])
+    df, views = _pre_allocate(rg.num_rows, columns, categories, index, cs, dt)
+    read_row_group_file(fn, rg, columns, categories, schema, cs,
+                        open=open, assign=views)
+
+    if series:
+        return df[df.columns[0]]
+    else:
+        return df
+
+
+# ----------------------------------------------------------------------
+# pyarrow interfaceGenericParquetReader
+
+
+class ArrowReader(GenericParquetReader):
+
+    _REGISTERED_TOKENIZE = False
+
+    def __init__(self, fs, paths, file_opener, columns=None, filters=None,
+                 categories=None, index=None):
+        import pyarrow.parquet as pq
+        self.api = pq
+
+        self.fs = fs
+        self.paths = paths
+        self.file_opener = file_opener
+
+        if filters is not None:
+            raise NotImplemented("Predicate pushdown not implemented")
+
+        if categories is not None:
+            raise NotImplemented("Categorical reads not yet implemented")
+
+        if isinstance(columns, tuple):
+            columns = list(columns)
+
+        self.columns = columns
+
+        self.dataset = self.api.ParquetDataset(self.paths)
+        self.schema = self.dataset.schema.to_arrow_schema()
+        self.task_name = 'read-parquet-' + tokenize(self.dataset, self.columns)
+
+    def _ensure_registered(self):
+        if self._REGISTERED_TOKENIZE:
+            return
+
+        @partial(normalize_token.register, self.api.ParquetDataset)
+        def normalize_PyArrowParquetDataset(ds):
+            return (type(ds), ds.paths)
+
+        self._REGISTERED_TOKENIZE = True
+
+    def get_pandas_deferred(self):
+        pieces = self.dataset.pieces
+
+        (out_type, frame_meta,
+         all_columns, divisions) = self._resolve_metadata()
+
+        task_plan = {
+            (self.task_name, i): (_read_arrow_parquet_piece,
+                                  self.file_opener,
+                                  piece,
+                                  all_columns,
+                                  out_type == Series,
+                                  self.dataset.partitions)
+            for i, piece in enumerate(pieces)
+        }
+
+        return out_type(task_plan, self.task_name, frame_meta, divisions)
+
+    def _resolve_metadata(self):
+        if self.columns is None:
+            all_columns = self.schema.names
+        else:
+            all_columns = self.columns
+
+        if not isinstance(all_columns, list):
+            out_type = Series
+            all_columns = [all_columns]
+        else:
+            out_type = DataFrame
+
+        divisions = (None,) * (len(self.dataset.pieces) + 1)
+
+        dtypes = self._get_schema_expected_dtypes()
+        meta = self._meta_from_dtypes(all_columns, self.schema.names, dtypes)
+        return out_type, meta, all_columns, divisions
+
+    def _get_schema_expected_dtypes(self):
+        dtypes = {}
+        for i in range(len(self.schema)):
+            field = self.schema[i]
+            numpy_dtype = field.type.to_pandas_dtype()
+            dtypes[field.name] = numpy_dtype
+
+        return dtypes
+
+
+def _read_arrow_parquet_piece(open_file_func, piece, columns, is_series,
+                              partitions):
+    with open_file_func(piece.path, mode='rb') as f:
+        table = piece.read(columns=columns,  partitions=partitions,
+                           file=f)
+    df = table.to_pandas()
+
+    if is_series:
+        return df[df.columns[0]]
+    else:
+        return df
+
+
+# ----------------------------------------------------------------------
+# User read API
+
+def read_parquet(path, columns=None, filters=None, categories=None, index=None,
+                 storage_options=None, engine='fastparquet'):
+    """
+    Read ParquetFile into a Dask DataFrame
+
+    This reads a directory of Parquet data into a Dask.dataframe, one file per
+    partition.  It selects the index among the sorted columns if any exist.
 
     Parameters
     ----------
@@ -54,6 +384,8 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
         data written by dask/fastparquet, not otherwise.
     storage_options : dict
         Key/value pairs to be passed on to the file-system backend, if any.
+    engine : {'fastparquet', 'arrow'}, default 'fastparquet'
+        Parquet reader library to use
 
     Examples
     --------
@@ -63,122 +395,27 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
     --------
     to_parquet
     """
-    if fastparquet is False:
-        raise ImportError("fastparquet not installed")
-    if filters is None:
-        filters = []
-    fs, paths, myopen = get_fs_paths_myopen(path, None, 'rb',
-                                            **(storage_options or {}))
+    fs, paths, file_opener = get_fs_paths_myopen(path, None, 'rb',
+                                                 **(storage_options or {}))
 
-    if isinstance(columns, list):
-        columns = tuple(columns)
-
-    if len(paths) > 1:
-        pf = fastparquet.ParquetFile(paths, open_with=myopen, sep=myopen.fs.sep)
+    if engine == 'fastparquet':
+        klass = FastparquetReader
+    elif engine == 'arrow':
+        klass = ArrowReader
     else:
-        try:
-            pf = fastparquet.ParquetFile(paths[0] + fs.sep + '_metadata',
-                                         open_with=myopen,
-                                         sep=fs.sep)
-        except:
-            pf = fastparquet.ParquetFile(paths[0], open_with=myopen, sep=fs.sep)
+        raise ValueError('Unsupported engine: {0}'.format(engine))
 
-    check_column_names(pf.columns, categories)
-    name = 'read-parquet-' + tokenize(pf, columns, categories)
+    reader = klass(fs, paths, file_opener, columns=columns,
+                   filters=filters,
+                   categories=categories, index=index)
 
-    rgs = [rg for rg in pf.row_groups if
-           not(fastparquet.api.filter_out_stats(rg, filters, pf.schema)) and
-           not(fastparquet.api.filter_out_cats(rg, filters))]
-
-    # Find an index among the partially sorted columns
-    minmax = fastparquet.api.sorted_partitioned_columns(pf)
-
-    if index is False:
-        index_col = None
-    elif len(minmax) == 1:
-        index_col = first(minmax)
-    elif len(minmax) > 1:
-        if index:
-            index_col = index
-        elif 'index' in minmax:
-            index_col = 'index'
-        else:
-            raise ValueError("Multiple possible indexes exist: %s.  "
-                             "Please select one with index='index-name'"
-                             % sorted(minmax))
-    else:
-        index_col = None
-
-    if columns is None:
-        all_columns = tuple(pf.columns + list(pf.cats))
-    else:
-        all_columns = columns
-    if not isinstance(all_columns, tuple):
-        out_type = Series
-        all_columns = (all_columns,)
-    else:
-        out_type = DataFrame
-    if index_col and index_col not in all_columns:
-        all_columns = all_columns + (index_col,)
-
-    if categories is None:
-        categories = pf.categories
-    dtypes = pf._dtypes(categories)
-
-    meta = pd.DataFrame({c: pd.Series([], dtype=d)
-                        for (c, d) in dtypes.items()},
-                        columns=[c for c in pf.columns if c in dtypes])
-    meta = meta[list(all_columns)]
-
-    for cat in categories:
-        meta[cat] = pd.Series(pd.Categorical([],
-                              categories=[UNKNOWN_CATEGORIES]))
-
-    if index_col:
-        meta = meta.set_index(index_col)
-
-    if out_type == Series:
-        assert len(meta.columns) == 1
-        meta = meta[meta.columns[0]]
-
-    dsk = {(name, i): (_read_parquet_row_group, myopen, pf.row_group_filename(rg),
-                       index_col, all_columns, rg, out_type == Series,
-                       categories, pf.schema, pf.cats, pf.dtypes)
-           for i, rg in enumerate(rgs)}
-
-    if index_col:
-        divisions = list(minmax[index_col]['min']) + [minmax[index_col]['max'][-1]]
-    else:
-        divisions = (None,) * (len(rgs) + 1)
-
-    if isinstance(divisions[0], np.datetime64):
-        divisions = [pd.Timestamp(d) for d in divisions]
-
-    return out_type(dsk, name, meta, divisions)
-
-
-def _read_parquet_row_group(open, fn, index, columns, rg, series, categories,
-                            schema, cs, dt, *args):
-    if not isinstance(columns, (tuple, list)):
-        columns = (columns,)
-        series = True
-    if index and index not in columns:
-        columns = columns + type(columns)([index])
-    df, views = _pre_allocate(rg.num_rows, columns, categories, index, cs, dt)
-    read_row_group_file(fn, rg, columns, categories, schema, cs,
-                        open=open, assign=views)
-
-    if series:
-        return df[df.columns[0]]
-    else:
-        return df
+    return reader.get_pandas_deferred()
 
 
 def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
                fixed_text=None, object_encoding=None, storage_options=None,
                append=False, ignore_divisions=False):
-    """
-    Store Dask.dataframe to Parquet files
+    """Store Dask.dataframe to Parquet files
 
     Notes
     -----
@@ -212,14 +449,15 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
     storage_options : dict
         Key/value pairs to be passed on to the file-system backend, if any.
     append: bool (False)
-        If False, construct data-set from scratch; if True, add new row-group(s)
-        to existing data-set. In the latter case, the data-set must exist,
-        and the schema must match the input data.
+        If False, construct data-set from scratch; if True, add new
+        row-group(s) to existing data-set. In the latter case, the data-set
+        must exist, and the schema must match the input data.
     ignore_divisions: bool (False)
         If False raises error when previous divisions overlap with the new
         appended divisions. Ignored if append=False.
 
-    This uses the fastparquet project: http://fastparquet.readthedocs.io/en/latest
+    This uses the fastparquet project:
+    http://fastparquet.readthedocs.io/en/latest
 
     Examples
     --------
@@ -229,9 +467,9 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
     See Also
     --------
     read_parquet: Read parquet data to dask.dataframe
+
     """
-    if fastparquet is False:
-        raise ImportError("fastparquet not installed")
+    import fastparquet
 
     fs, paths, myopen = get_fs_paths_myopen(path, None, 'wb',
                                             **(storage_options or {}))
@@ -314,12 +552,6 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
 
     fn = sep.join([path, '_common_metadata'])
     fastparquet.writer.write_common_metadata(fn, fmd, open_with=myopen)
-
-
-if fastparquet:
-    @partial(normalize_token.register, fastparquet.ParquetFile)
-    def normalize_ParquetFile(pf):
-        return (type(pf), pf.fn, pf.sep) + normalize_token(pf.open)
 
 
 if PY3:

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -250,7 +250,7 @@ def _read_parquet_row_group(open, fn, index, columns, rg, series, categories,
 
 
 # ----------------------------------------------------------------------
-# pyarrow interfaceGenericParquetReader
+# PyArrow interface
 
 
 class ArrowReader(GenericParquetReader):

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -25,7 +25,7 @@ except:
 try:
     import pyarrow.parquet as pyarrow_parquet
 except:
-    pa_pq = False
+    pyarrow_parquet = False
 
 
 def _meta_from_dtypes(to_read_columns, file_columns, file_dtypes):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -125,16 +125,16 @@ def test_names(fn, engine):
     def read(fn):
         return read_parquet(fn, engine=engine)
 
-    assert (set(read_parquet(fn).dask) == set(read_parquet(fn).dask))
+    assert (set(read(fn).dask) == set(read(fn).dask))
 
-    assert (set(read_parquet(fn).dask) !=
-            set(read_parquet(fn, columns=['x']).dask))
+    assert (set(read(fn).dask) !=
+            set(read(fn, columns=['x']).dask))
 
-    assert (set(read_parquet(fn, columns='x').dask) !=
-            set(read_parquet(fn, columns=['x']).dask))
+    assert (set(read(fn, columns='x').dask) !=
+            set(read(fn, columns=['x']).dask))
 
-    assert (set(read_parquet(fn, columns=('x',)).dask) ==
-            set(read_parquet(fn, columns=['x']).dask))
+    assert (set(read(fn, columns=('x',)).dask) ==
+            set(read(fn, columns=['x']).dask))
 
 
 @pytest.mark.parametrize('c', [['x'], 'x', ['x', 'y'], []])

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -122,15 +122,12 @@ def test_series(fn):
 
 
 def test_names(fn, engine):
-    def read(fn):
-        return read_parquet(fn, engine=engine)
+    def read(fn, **kwargs):
+        return read_parquet(fn, engine=engine, **kwargs)
 
     assert (set(read(fn).dask) == set(read(fn).dask))
 
     assert (set(read(fn).dask) !=
-            set(read(fn, columns=['x']).dask))
-
-    assert (set(read(fn, columns='x').dask) !=
             set(read(fn, columns=['x']).dask))
 
     assert (set(read(fn, columns=('x',)).dask) ==

--- a/docs/source/dataframe-create.rst
+++ b/docs/source/dataframe-create.rst
@@ -2,10 +2,10 @@ Create and Store Dask DataFrames
 ================================
 
 Dask can create dataframes from various data storage formats like CSV, HDF,
-Parquet, and others.  For most formats this data can live on various storage
-systems including local disk, network file systems (NFS), the Hadoop File
-System (HDFS), and Amazon's S3 (excepting HDF, which is only available on POSIX
-like file systems).
+Apache Parquet, and others.  For most formats this data can live on various
+storage systems including local disk, network file systems (NFS), the Hadoop
+File System (HDFS), and Amazon's S3 (excepting HDF, which is only available on
+POSIX like file systems).
 
 See the `Overview section
 <http://dask.pydata.org/en/latest/dataframe-overview.html>`_ for an in depth
@@ -51,9 +51,9 @@ Pandas:
 Locations
 ---------
 
-For text, CSV, and Parquet formats data can come from local disk, from the
-Hadoop File System, from S3FS, or others, by prepending the filenames with a
-protocol.
+For text, CSV, and Apache Parquet formats data can come from local disk, from
+the Hadoop File System, from S3FS, or others, by prepending the filenames with
+a protocol.
 
 .. code-block:: python
 

--- a/docs/source/dataframe-performance.rst
+++ b/docs/source/dataframe-performance.rst
@@ -184,19 +184,40 @@ operation.
    dd.merge(a, b, left_on='id', right_on='id')  # slow
 
 
-Store Data in Parquet
----------------------
+Store Data in Apache Parquet Format
+-----------------------------------
 
-Pandas users who care about performance typically store their data in HDF5.
-We encourage Dask.dataframe users to `store and load data
+HDF5 is a popular choice for Pandas users with high performance needs.  We
+encourage Dask.dataframe users to `store and load data
 <http://dask.pydata.org/en/latest/dataframe-create.html>`_ using Parquet
-instead.  Parquet is a columnar binary format that is easy to split into
-multiple files (easier for parallel loading) and is generally much simpler to
-deal with than HDF5 (from the library's perspective).  It is also a common
-format used by other big data systems like Hadoop/Spark/Impala and so is useful
-to interchange with other systems.
+instead.  `Apache Parquet <http://parquet.apache.org/>`_ is a columnar binary
+format that is easy to split into multiple files (easier for parallel loading)
+and is generally much simpler to deal with than HDF5 (from the library's
+perspective).  It is also a common format used by other big data systems like
+`Apache Spark <http://spark.apache.org/>`_ and `Apache Impala (incubating)
+<http://impala.apache.org/>`_ and so is useful to interchange with other
+systems.
 
 .. code-block:: python
 
    df.to_parquet('path/to/my-results/')
    df = dd.read_parquet('path/to/my-results/')
+
+Dask supports reading with multiple implementations of the Apache Parquet
+format for Python.
+
+.. code-block:: python
+
+   df1 = dd.read_parquet('path/to/my-results/', engine='fastparquet')
+   df2 = dd.read_parquet('path/to/my-results/', engine='arrow')
+
+These libraries be installed using
+
+.. code-block:: shell
+
+   conda install fastparquet pyarrow -c conda-forge
+
+Fastparquet is a Python-based implementation that uses the `Numba
+<http://numba.pydata.org/>`_ Python-to-LLVM compiler. PyArrow is part of the
+`Apache Arrow <http://arrow.apache.org/>`_ project and uses the `C++
+implementation of Apache Parquet <https://github.com/apache/parquet-cpp>`_.


### PR DESCRIPTION
This is based on @mrocklin's initial patch #2175 and additional work from me (I needed to squash and rebase to resolve conflicts that happened in the meantime).

I have some changes in https://github.com/apache/arrow/pull/543 to help with this integration. The existing Fastparquet read path is unaffected (all the tests pass).

There's some notable things missing:

* Support writing the DataFrame index automatically, then reading it from the file (see below)
* I am not splitting files at the row group level; if this is needed, it can be added in a follow up patch
* Categorical support (Parquet doesn't have a Categorical type, but there's workarounds to simulate it that are in use in Dask)

There's a couple issues we ought to resolve to conform the semantics of how pandas.DataFrame is written to Parquet, and how we read it:

* Index handling, inferring the index column, and other metadata: #2222 
* The `has_nulls` argument -- this doesn't impact the pyarrow read path, but if we want to support pyarrow writes, then it would be good to do the same thing by default across implementations: #2177 

On the pandas index, I think the most reliable thing we could do is to write special metadata to the Parquet file footer to indicate that a column is the index. This is a lot cleaner than inferring based on the column name or the column statistics. 

My goal in subsequent patches will be to add the `engine` parameter to the test cases where it isn't being used. Thanks!