### PR TITLE
Support sparse arrays

### DIFF
--- a/continuous_integration/appveyor/setup_conda_environment.cmd
+++ b/continuous_integration/appveyor/setup_conda_environment.cmd
@@ -32,6 +32,7 @@ echo pandas %PANDAS% >> %CONDA_PREFIX%\conda-meta\pinned
 %PIP_INSTALL% git+https://github.com/dask/partd --upgrade
 %PIP_INSTALL% git+https://github.com/dask/cachey --upgrade
 %PIP_INSTALL% git+https://github.com/dask/distributed --upgrade
+%PIP_INSTALL% git+https://github.com/mrocklin/sparse --upgrade
 %PIP_INSTALL% blosc --upgrade
 %PIP_INSTALL% moto
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -60,6 +60,7 @@ conda install -q -c conda-forge \
 pip install -q git+https://github.com/dask/partd --upgrade --no-deps
 pip install -q git+https://github.com/dask/zict --upgrade --no-deps
 pip install -q git+https://github.com/dask/distributed --upgrade --no-deps
+pip install -q git+https://github.com/mrocklin/sparse --upgrade --no-deps
 
 if [[ $PYTHONOPTIMIZE != '2' ]]; then
     conda install -q -c conda-forge numba cython

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3398,22 +3398,6 @@ def transposelist(arrays, axes, extradims=0):
     return reshapelist(newshape, result)
 
 
-def to_numpy_array(x):
-    """ Convert object to numpy array
-
-    Supports both the __array__ protocol and the todense() method often used by
-    sparse arrays
-    """
-    if type(x) is np.ndarray:
-        return x
-    elif hasattr(x, '__array__'):
-        return np.asarray(x)
-    elif hasattr(x, 'todense'):
-        return to_numpy_array(x.todense())
-    else:
-        return x  # pass through
-
-
 def concatenate3(arrays):
     """ Recursive np.concatenate
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -36,7 +36,7 @@ from ..base import Base, tokenize, normalize_token
 from ..context import _globals
 from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      is_integer, IndexCallable, funcname, derived_from,
-                     SerializableLock, ensure_dict)
+                     SerializableLock, ensure_dict, package_of)
 from ..compatibility import unicode, long, getargspec, zip_longest, apply
 from ..delayed import to_task_dask
 from .. import threaded, core
@@ -466,11 +466,7 @@ def _concatenate2(arrays, axes=[]):
         return arrays
     if len(axes) > 1:
         arrays = [_concatenate2(a, axes=axes[1:]) for a in arrays]
-    module = inspect.getmodule(arrays[0]) or np
-    try:
-        module.concatenate
-    except AttributeError:
-        module = np
+    module = package_of(arrays[0]) or np
     return module.concatenate(arrays, axis=axes[0])
 
 
@@ -2476,7 +2472,7 @@ ALPHABET = alphabet.upper()
 
 def _tensordot(a, b, axes):
     x = max([a, b], key=lambda x: x.__array_priority__)
-    module = inspect.getmodule(x) or np
+    module = package_of(x) or np
     x = module.tensordot(a, b, axes=axes)
     ind = [slice(None, None)] * x.ndim
     for a in sorted(axes[0]):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -930,9 +930,9 @@ def finalize(results):
         if len(results2) > 1:
             x = unpack_singleton(results)
             mod = inspect.getmodule(x)
-            if mod and mod is not np:
+            if mod and mod is not np and hasattr(np, 'concatenate'):
                 return _concatenate2(results, axes=list(range(x.ndim)))
-            else:
+            else:  # optimized solution for np or anything without concatenate
                 return concatenate3(results)
         else:
             results2 = results2[0]

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -928,12 +928,7 @@ def finalize(results):
     results2 = results
     while isinstance(results2, (tuple, list)):
         if len(results2) > 1:
-            x = unpack_singleton(results)
-            mod = inspect.getmodule(x)
-            if mod and mod is not np and hasattr(mod, 'concatenate'):
-                return _concatenate2(results, axes=list(range(x.ndim)))
-            else:  # optimized solution for np or anything without concatenate
-                return concatenate3(results)
+            return concatenate3(results)
         else:
             results2 = results2[0]
     return unpack_singleton(results)
@@ -3420,6 +3415,11 @@ def concatenate3(arrays):
            [1, 2, 1, 2],
            [1, 2, 1, 2]])
     """
+    x = unpack_singleton(arrays)
+    mod = inspect.getmodule(x)
+    if mod and mod is not np and hasattr(mod, 'concatenate'):
+        return _concatenate2(arrays, axes=list(range(x.ndim)))
+
     arrays = concrete(arrays)
     ndim = ndimlist(arrays)
     if not ndim:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -36,7 +36,7 @@ from ..base import Base, tokenize, normalize_token
 from ..context import _globals
 from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      is_integer, IndexCallable, funcname, derived_from,
-                     SerializableLock, ensure_dict, package_of)
+                     SerializableLock, ensure_dict, package_of, deepmap)
 from ..compatibility import unicode, long, getargspec, zip_longest, apply
 from ..delayed import to_task_dask
 from .. import threaded, core
@@ -467,7 +467,11 @@ def _concatenate2(arrays, axes=[]):
     if len(axes) > 1:
         arrays = [_concatenate2(a, axes=axes[1:]) for a in arrays]
     module = package_of(arrays[0]) or np
-    return module.concatenate(arrays, axis=axes[0])
+    try:
+        return module.concatenate(arrays, axis=axes[0])
+    except (ValueError, AttributeError):
+        arrays2 = [to_numpy_array(x) for x in arrays]
+        return np.concatenate(arrays2, axis=axes[0])
 
 
 def apply_infer_dtype(func, args, kwargs, funcname, suggest_dtype=True):
@@ -3398,6 +3402,22 @@ def transposelist(arrays, axes, extradims=0):
     return reshapelist(newshape, result)
 
 
+def to_numpy_array(x):
+    """ Convert object to numpy array
+
+    Supports both the __array__ protocol and the todense() method often used by
+    sparse arrays
+    """
+    if type(x) is np.ndarray:
+        return x
+    elif hasattr(x, '__array__'):
+        return np.asarray(x)
+    elif hasattr(x, 'todense'):
+        return to_numpy_array(x.todense())
+    else:
+        return x  # pass through
+
+
 def concatenate3(arrays):
     """ Recursive np.concatenate
 
@@ -3421,6 +3441,7 @@ def concatenate3(arrays):
         return _concatenate2(arrays, axes=list(range(x.ndim)))
 
     arrays = concrete(arrays)
+    arrays = deepmap(to_numpy_array, arrays)
     ndim = ndimlist(arrays)
     if not ndim:
         return arrays

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -466,12 +466,8 @@ def _concatenate2(arrays, axes=[]):
         return arrays
     if len(axes) > 1:
         arrays = [_concatenate2(a, axes=axes[1:]) for a in arrays]
-    module = package_of(arrays[0]) or np
-    try:
-        return module.concatenate(arrays, axis=axes[0])
-    except (ValueError, AttributeError):
-        arrays2 = [to_numpy_array(x) for x in arrays]
-        return np.concatenate(arrays2, axis=axes[0])
+    module = package_of(max(arrays, key=lambda x: x.__array_priority__)) or np
+    return module.concatenate(arrays, axis=axes[0])
 
 
 def apply_infer_dtype(func, args, kwargs, funcname, suggest_dtype=True):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -930,7 +930,7 @@ def finalize(results):
         if len(results2) > 1:
             x = unpack_singleton(results)
             mod = inspect.getmodule(x)
-            if mod and mod is not np and hasattr(np, 'concatenate'):
+            if mod and mod is not np and hasattr(mod, 'concatenate'):
                 return _concatenate2(results, axes=list(range(x.ndim)))
             else:  # optimized solution for np or anything without concatenate
                 return concatenate3(results)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3431,13 +3431,13 @@ def concatenate3(arrays):
            [1, 2, 1, 2],
            [1, 2, 1, 2]])
     """
-    x = unpack_singleton(arrays)
-    mod = inspect.getmodule(x)
-    if mod and mod is not np and hasattr(mod, 'concatenate'):
+    advanced = max(core.flatten(arrays, container=(list, tuple)), key=lambda x: x.__array_priority__)
+    module = package_of(advanced) or np
+    if module is not np and hasattr(module, 'concatenate'):
+        x = unpack_singleton(arrays)
         return _concatenate2(arrays, axes=list(range(x.ndim)))
 
     arrays = concrete(arrays)
-    arrays = deepmap(to_numpy_array, arrays)
     ndim = ndimlist(arrays)
     if not ndim:
         return arrays

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -929,7 +929,8 @@ def finalize(results):
     while isinstance(results2, (tuple, list)):
         if len(results2) > 1:
             x = unpack_singleton(results)
-            if inspect.getmodule(x):
+            mod = inspect.getmodule(x)
+            if mod and mod is not np:
                 return _concatenate2(results, axes=list(range(x.ndim)))
             else:
                 return concatenate3(results)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3431,18 +3431,20 @@ def concatenate3(arrays):
            [1, 2, 1, 2],
            [1, 2, 1, 2]])
     """
-    advanced = max(core.flatten(arrays, container=(list, tuple)), key=lambda x: x.__array_priority__)
+    arrays = concrete(arrays)
+    if not arrays:
+        return np.empty(0)
+
+    advanced = max(core.flatten(arrays, container=(list, tuple)),
+                   key=lambda x: getattr(x, '__array_priority__', 0))
     module = package_of(advanced) or np
     if module is not np and hasattr(module, 'concatenate'):
         x = unpack_singleton(arrays)
         return _concatenate2(arrays, axes=list(range(x.ndim)))
 
-    arrays = concrete(arrays)
     ndim = ndimlist(arrays)
     if not ndim:
         return arrays
-    if not arrays:
-        return np.empty(0)
     chunks = chunks_from_arrays(arrays)
     shape = tuple(map(sum, chunks))
 

--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -9,6 +9,7 @@ from .core import Array
 from ..base import tokenize
 from ..core import flatten
 from ..compatibility import reduce
+from ..utils import M
 from .. import sharedict
 
 
@@ -170,7 +171,7 @@ def reshape(x, shape):
 
     if x.npartitions == 1:
         key = next(flatten(x._keys()))
-        dsk = {(name,) + (0,) * len(shape): (np.reshape, key, shape)}
+        dsk = {(name,) + (0,) * len(shape): (M.reshape, key, shape)}
         chunks = tuple((d,) for d in shape)
         return Array(sharedict.merge((name, dsk), x.dask), name, chunks,
                      dtype=x.dtype)
@@ -183,7 +184,7 @@ def reshape(x, shape):
     in_keys = list(product([x2.name], *[range(len(c)) for c in inchunks]))
     out_keys = list(product([name], *[range(len(c)) for c in outchunks]))
     shapes = list(product(*outchunks))
-    dsk = {a: (np.reshape, b, shape) for a, b, shape in zip(out_keys, in_keys, shapes)}
+    dsk = {a: (M.reshape, b, shape) for a, b, shape in zip(out_keys, in_keys, shapes)}
 
     return Array(sharedict.merge((name, dsk), x2.dask), name, outchunks,
                  dtype=x.dtype)

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -1,0 +1,38 @@
+import pytest
+import sparse
+from dask.array.utils import assert_eq
+import dask.array as da
+import numpy as np
+
+
+@pytest.mark.parametrize('func', [
+    lambda x: x,
+    lambda x: da.expm1(x),
+    lambda x: 2 * x,
+    lambda x: x**2,
+    lambda x: x[0],
+    lambda x: x[:, 1],
+    lambda x: x[:1, None, 1:3],
+    lambda x: x.T,
+    lambda x: da.transpose(x, (1, 2, 0)),
+    lambda x: x.sum(),
+    lambda x: x.dot(np.arange(x.shape[-1])),
+    lambda x: x.dot(np.eye(x.shape[-1])),
+    lambda x: da.tensordot(x, np.ones(x.shape[:2]), axes=[(0, 1), (0, 1)]),
+    lambda x: x.sum(axis=0),
+    lambda x: x.max(axis=0),
+    lambda x: x.sum(axis=(1, 2)),
+])
+def test_basic(func):
+    x = da.random.random((2, 3, 4), chunks=(1, 2, 2))
+    x[x < 0.9] = 0
+
+    y = x.map_blocks(sparse.COO.from_numpy)
+
+    xx = func(x)
+    yy = func(y)
+
+    assert_eq(xx, yy)
+
+    if yy.shape:
+        assert isinstance(yy.compute(), sparse.COO)

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -109,3 +109,19 @@ def test_mixed_random(func):
     ss = func(s)
 
     assert_eq(dd, ss)
+
+
+def test_mixed_output_type():
+    y = da.random.random((10, 10), chunks=(5, 5))
+    y[y < 0.8] = 0
+    y = y.map_blocks(sparse.COO.from_numpy)
+
+    x = da.zeros((10, 1), chunks=(5, 1))
+
+    z = da.concatenate([x, y], axis=1)
+
+    assert z.shape == (10, 11)
+
+    zz = z.compute()
+    assert isinstance(zz, sparse.COO)
+    assert zz.nnz == y.compute().nnz

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -1,10 +1,15 @@
+import sys
+
+import numpy as np
 import pytest
 import sparse
-from dask.array.utils import assert_eq
+
 import dask.array as da
-import numpy as np
+from dask.array.utils import assert_eq
 
 
+@pytest.mark.skipif(sys.version_info[:2] == (3, 4),
+                    reason='indexing issues')
 @pytest.mark.parametrize('func', [
     lambda x: x,
     lambda x: da.expm1(x),

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -58,6 +58,8 @@ def assert_eq(a, b, check_shape=True, **kwargs):
         adt = a.dtype
         _check_dsk(a.dask)
         a = a.compute(get=get_sync)
+        if hasattr(a, 'todense'):
+            a = a.todense()
         if _not_empty(a):
             assert a.dtype == a_original.dtype
         if check_shape:
@@ -70,6 +72,8 @@ def assert_eq(a, b, check_shape=True, **kwargs):
         bdt = b.dtype
         _check_dsk(b.dask)
         b = b.compute(get=get_sync)
+        if hasattr(b, 'todense'):
+            b = b.todense()
         if _not_empty(b):
             assert b.dtype == b_original.dtype
         if check_shape:

--- a/dask/core.py
+++ b/dask/core.py
@@ -232,7 +232,7 @@ def get_deps(dsk):
     return dependencies, dependents
 
 
-def flatten(seq):
+def flatten(seq, container=list):
     """
 
     >>> list(flatten([1]))
@@ -254,8 +254,8 @@ def flatten(seq):
         yield seq
     else:
         for item in seq:
-            if isinstance(item, list):
-                for item2 in flatten(item):
+            if isinstance(item, container):
+                for item2 in flatten(item, container=container):
                     yield item2
             else:
                 yield item

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -11,7 +11,7 @@ from dask.utils import (textblock, filetext, takes_multiple_arguments,
                         Dispatch, tmpfile, random_state_data, file_size,
                         infer_storage_options, eq_strict, memory_repr,
                         methodcaller, M, skip_doctest, SerializableLock,
-                        funcname, ndeepmap, ensure_dict)
+                        funcname, ndeepmap, ensure_dict, package_of)
 from dask.utils_test import inc
 
 SKIP_XZ = pytest.mark.skipif(not LZMA_AVAILABLE, reason="no lzma library")
@@ -347,3 +347,14 @@ def test_ensure_dict():
     md['x'] = 1
     assert type(ensure_dict(md)) is dict
     assert ensure_dict(md) == d
+
+
+def test_package_of():
+    import math
+    assert package_of(math.sin) is math
+    try:
+        import numpy
+    except ImportError:
+        pass
+    else:
+        assert package_of(numpy.memmap) is numpy

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1062,5 +1062,7 @@ def package_of(obj):
     """
     # http://stackoverflow.com/questions/43462701/get-package-of-python-object/43462865#43462865
     mod = inspect.getmodule(obj)
+    if not mod:
+        return
     base, _sep, _stem = mod.__name__.partition('.')
     return sys.modules[base]

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1053,3 +1053,14 @@ def ensure_dict(d):
             result.update(dd)
         return result
     return dict(d)
+
+
+def package_of(obj):
+    """ Return package containing object's definition
+
+    Or return None if not found
+    """
+    # http://stackoverflow.com/questions/43462701/get-package-of-python-object/43462865#43462865
+    mod = inspect.getmodule(obj)
+    base, _sep, _stem = mod.__name__.partition('.')
+    return sys.modules[base]

--- a/docs/source/array-sparse.rst
+++ b/docs/source/array-sparse.rst
@@ -1,0 +1,80 @@
+Sparse Arrays
+=============
+
+By swapping out in-memory numpy arrays with in-memory sparse arrays we can
+reuse the blocked algorithms of Dask.array to achieve parallel and distributed
+sparse arrays.
+
+The blocked algorithms in Dask.array normally parallelize around in-memory
+numpy arrays.  However, if another in-memory array library supports the NumPy
+interface then it too can take advantage of dask.array's parallel algorithms.
+In particular the `sparse <https://github.com/mrocklin/sparse/>`_ array library
+satisfies a subset of the NumPy API and works well with, and is tested against,
+Dask.array.
+
+Example
+-------
+
+Say we have a dask.array with mostly zeros
+
+.. code-block:: python
+
+   x = da.random.random((100000, 100000), chunks=(1000, 1000))
+   x[x < 0.95] = 0
+
+We can convert each of these chunks of NumPy arrays into a sparse.COO array.
+
+.. code-block:: python
+
+   import sparse
+   s = x.map_blocks(sparse.COO)
+
+Now our array is composed not of many NumPy arrays, but rather of many
+sparse arrays.  Semantically this does not change anything.  Operations that
+work will work identically (assuming that the behavior of ``numpy`` and
+``sparse`` are identical) but performance characteristics and storage costs may
+change significantly
+
+.. code-block:: python
+
+   >>> s.sum(axis=0)[:100].compute()
+   <COO: shape=(100,), dtype=float64, nnz=100>
+
+   >>> _.todense()
+   array([ 4803.06859272,  4913.94964525,  4877.13266438,  4860.7470773 ,
+           4938.94446802,  4849.51326473,  4858.83977856,  4847.81468485,
+           ... ])
+
+Requirements
+------------
+
+Any in-memory library that copies the NumPy ndarray interface should work here.
+The `sparse <https://github.com/mrocklin/sparse/>`_ library is a minimal
+example.  In particular an in-memory library should implement at least the
+following operations:
+
+1.  Simple slicing with slices, lists, and elements (for slicing, rechunking,
+    reshaping, etc).
+2.  A ``concatenate`` function at the top level of the package (for assembling
+    results)
+3.  All ufuncs must support the full ufunc interface, including ``dtype=`` and
+    ``out=`` parameters (even if they don't function properly)
+4.  All reductions must support the full ``axis=`` and ``keepdims=`` keywords
+    and behave like numpy in this respect
+5.  The array class should follow the ``__array_priority__`` protocol and be
+    prepared to respond to other arrays of lower priority.
+
+The implementation of other operations like tensordot, reshape, transpose, etc.
+should follow standard NumPy conventions regarding shape and dtype.  Not
+implementing these is fine; the parallel dask.array will err at runtime if
+these operations are attempted.
+
+
+Mixed Arrays
+------------
+
+Dask.array supports mixing different kinds of in-memory arrays.  This relies
+on the in-memory arrays knowing how to interact with each other when necessary.
+When two arrays interact the functions from the array with the highest
+``__array_priority__`` will take precedence (for example for concatenate,
+tensordot, etc.).

--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -21,3 +21,4 @@ Other topics
    array-ghost.rst
    array-design.rst
    array-linear-operator.rst
+   array-sparse.rst


### PR DESCRIPTION
This supports sparse arrays mostly by relying on ufuncs to do the right
thing.  Additionally we check for operations like concatenate and
tensordot on the object's module.

Replaces https://github.com/dask/dask/pull/2179

Fixes #2160 