### PR TITLE
Object arrays with missing values hash the same

### DIFF
--- a/dask/dataframe/tests/test_hashing.py
+++ b/dask/dataframe/tests/test_hashing.py
@@ -46,3 +46,12 @@ def test_categorical_consistency():
             h3 = hash_pandas_object(s3, categorize=categorize)
             tm.assert_series_equal(h1, h2)
             tm.assert_series_equal(h1, h3)
+
+
+def test_object_missing_values():
+    # Check that the presence of missing values doesn't change how object dtype
+    # is hashed.
+    s = pd.Series(['a', 'b', 'c', None])
+    h1 = hash_pandas_object(s).iloc[:3]
+    h2 = hash_pandas_object(s.iloc[:3])
+    tm.assert_series_equal(h1, h2)


### PR DESCRIPTION
Due to a bug in the pandas hashing code, the presence of missing values in an object series would cause it to hash differently. This was fixed in pandas in https://github.com/pandas-dev/pandas/commit/e351ed0fd211a204f960b9116bc13f75ed1f97c4 but was never backported to dask.

Fixes #2237.