### PR TITLE
ENH: Support rechunk with some unknown dims

### DIFF
--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -481,7 +481,7 @@ def plan_rechunk(old_chunks, new_chunks, itemsize,
     has_nans = [any(math.isnan(y) for y in x) for x in old_chunks]
 
     if ndim <= 1 or not all(new_chunks) or any(has_nans):
-        # Trivial array => no need for an intermediate
+        # Trivial array / unknown dim => no need / ability for an intermediate
         return steps + [new_chunks]
 
     # Make it a number ef elements

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -141,12 +141,8 @@ def _old_to_new(old_chunks, new_chunks):
     old_to_new = [_intersect_1d(_breakpoints(cm[0], cm[1])) for cm in zip(cmo, cmn)]
     for idx, missing in enumerate(n_missing):
         if missing:
-            # inital is just len(the missing dim)
-            # TODO: why does this work? Why is this first element always at most length 3?
-            extra = [[(0, slice(0, None))] + [(1, slice(0, None)) for i in range(1, min(2, missing))]]
-
-            for _ in range(missing - 1):
-                extra.append([(1, slice(0, None))])
+            # Missing dimensions are always unchanged, so old -> new is everything
+            extra = [[(i, slice(0, None))] for i in range(missing)]
             # TODO: hmm avoid an insert here ideally. Build it up and then append?
             old_to_new.insert(idx, extra)
     return old_to_new

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -360,7 +360,6 @@ def find_merge_rechunk(old_chunks, new_chunks, block_size_limit):
     violating the *block_size_limit* (in number of elements).
     """
     ndim = len(old_chunks)
-    has_nans = [any(math.isnan(y) for y in x) for x in old_chunks]
 
     old_largest_width = [max(c) for c in old_chunks]
     new_largest_width = [max(c) for c in new_chunks]
@@ -379,8 +378,7 @@ def find_merge_rechunk(old_chunks, new_chunks, block_size_limit):
     # by merging some adjacent chunks, so consider dimensions where we can
     # reduce the # of chunks
     merge_candidates = [dim for dim in range(ndim)
-                        if graph_size_effect[dim] <= 1.0 and
-                        not has_nans[dim]]
+                        if graph_size_effect[dim] <= 1.0]
 
     # Merging along each dimension reduces the graph size by a certain factor
     # and increases memory largest block size by a certain factor.
@@ -397,8 +395,7 @@ def find_merge_rechunk(old_chunks, new_chunks, block_size_limit):
 
     sorted_candidates = sorted(merge_candidates, key=key)
 
-    largest_block_size = reduce(mul, filter(lambda x: not math.isnan(x),
-                                            old_largest_width))
+    largest_block_size = reduce(mul, old_largest_width)
 
     chunks = list(old_chunks)
     memory_limit_hit = False
@@ -424,9 +421,7 @@ def find_merge_rechunk(old_chunks, new_chunks, block_size_limit):
 
             memory_limit_hit = True
 
-    assert largest_block_size == _largest_block_size([
-        x for x in chunks if not any(math.isnan(y) for y in x)
-    ])
+    assert largest_block_size == _largest_block_size(chunks)
     assert largest_block_size <= block_size_limit
     return tuple(chunks), memory_limit_hit
 
@@ -475,10 +470,17 @@ def plan_rechunk(old_chunks, new_chunks, itemsize,
     block_size_limit: int
         The maximum block size (in bytes) we want to produce during an
         intermediate step
+
+    Notes
+    -----
+    No intermediate steps will be planned if any dimension of ``old_chunks``
+    is unknown.
     """
     ndim = len(new_chunks)
     steps = []
-    if ndim <= 1 or not all(new_chunks):
+    has_nans = [any(math.isnan(y) for y in x) for x in old_chunks]
+
+    if ndim <= 1 or not all(new_chunks) or any(has_nans):
         # Trivial array => no need for an intermediate
         return steps + [new_chunks]
 
@@ -486,11 +488,8 @@ def plan_rechunk(old_chunks, new_chunks, itemsize,
     block_size_limit /= itemsize
 
     # Fix block_size_limit if too small for either old_chunks or new_chunks
-    known_old_chunks = [x for x in old_chunks if not any(math.isnan(y) for y in x)]
-    known_new_chunks = [x for x in new_chunks if not any(math.isnan(y) for y in x)]
-
-    largest_old_block = _largest_block_size(known_old_chunks)
-    largest_new_block = _largest_block_size(known_new_chunks)
+    largest_old_block = _largest_block_size(old_chunks)
+    largest_new_block = _largest_block_size(new_chunks)
     block_size_limit = max([block_size_limit,
                             largest_old_block,
                             largest_new_block,

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -7,6 +7,7 @@ The rechunk module defines:
 """
 from __future__ import absolute_import, division, print_function
 
+import math
 import heapq
 
 from itertools import product, chain, count
@@ -150,8 +151,8 @@ def intersect_chunks(old_chunks, new_chunks):
     sums = [sum(o) for o in old_chunks]
     sums2 = [sum(n) for n in old_chunks]
 
-    sums = [x for x in sums if x == x]  # filter NaNs
-    sums2 = [x for x in sums2 if x == x]
+    sums = [x for x in sums if not math.isnan(x)]
+    sums2 = [x for x in sums2 if not math.isnan(x)]
     if not sums == sums2:
         raise ValueError('Cannot change dimensions from to %r' % sums2)
     old_to_new = [_intersect_1d(_breakpoints(cm[0], cm[1]))
@@ -244,7 +245,7 @@ def rechunk(x, chunks, threshold=DEFAULT_THRESHOLD,
     new_shapes = tuple(map(sum, chunks))
 
     for new, old in zip(new_shapes, x.shape):
-        if new != old and not np.isnan(old) and not np.isnan(new):
+        if new != old and not math.isnan(old) and not math.isnan(new):
             raise ValueError("Provided chunks are not consistent with shape")
 
     steps = plan_rechunk(x.chunks, chunks, x.dtype.itemsize,
@@ -619,7 +620,7 @@ def format_blocks(blocks):
     2*[10] | [5, 6] | 3*[2] | [7]
     """
     assert (isinstance(blocks, tuple) and
-            all(isinstance(x, int) or np.isnan(x)
+            all(isinstance(x, int) or math.isnan(x)
                 for x in blocks))
     return _PrettyBlocks(blocks)
 

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -397,7 +397,8 @@ def find_merge_rechunk(old_chunks, new_chunks, block_size_limit):
 
     sorted_candidates = sorted(merge_candidates, key=key)
 
-    largest_block_size = reduce(mul, filter(math.isfinite, old_largest_width))
+    largest_block_size = reduce(mul, filter(lambda x: not math.isnan(x),
+                                            old_largest_width))
 
     chunks = list(old_chunks)
     memory_limit_hit = False

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -395,30 +395,6 @@ def test_dont_concatenate_single_chunks(shape, chunks):
                    if dask.istask(task))
 
 
-def test_rechunk_unknown1():
-    dd = pytest.importorskip('dask.dataframe')
-    pd = pytest.importorskip('pandas')
-
-    x = dd.from_pandas(pd.DataFrame(np.random.randn(50, 10)), 2).values
-    # result = x.rechunk({1: 5})
-    result = x.rechunk((None, (5, 5)))
-    assert np.isnan(x.chunks[0]).all()
-    assert np.isnan(result.chunks[0]).all()
-    assert result.chunks[1] == (5, 5)
-
-
-def test_rechunk_unknown2():
-    import dask; dask.set_options(get=dask.get)  # noqa
-    dd = pytest.importorskip('dask.dataframe')
-    # pd = pytest.importorskip('pandas')
-    x = dd.from_array(da.ones(shape=(4, 4), chunks=(2, 2))).values
-    # result = x.rechunk({1: 5})
-    result = x.rechunk((None, 4))
-    assert np.isnan(x.chunks[0]).all()
-    assert np.isnan(result.chunks[0]).all()
-    assert x.chunks[1] == (4,)
-
-
 def test_breakpoints_order_nan():
     old = (('o', 0), ('o', np.nan), ('o', np.nan))
     new = (('n', 0), ('n', np.nan), ('n', np.nan))
@@ -432,6 +408,30 @@ def test_breakpoints_order_nan():
     assert result == expected
 
 
+def test_rechunk_unknown_from_pandas():
+    dd = pytest.importorskip('dask.dataframe')
+    pd = pytest.importorskip('pandas')
+
+    x = dd.from_pandas(pd.DataFrame(np.random.randn(50, 10)), 2).values
+    # result = x.rechunk({1: 5})
+    result = x.rechunk((None, (5, 5)))
+    assert np.isnan(x.chunks[0]).all()
+    assert np.isnan(result.chunks[0]).all()
+    assert result.chunks[1] == (5, 5)
+
+
+def test_rechunk_unknown_from_array():
+    import dask; dask.set_options(get=dask.get)  # noqa
+    dd = pytest.importorskip('dask.dataframe')
+    # pd = pytest.importorskip('pandas')
+    x = dd.from_array(da.ones(shape=(4, 4), chunks=(2, 2))).values
+    # result = x.rechunk({1: 5})
+    result = x.rechunk((None, 4))
+    assert np.isnan(x.chunks[0]).all()
+    assert np.isnan(result.chunks[0]).all()
+    assert x.chunks[1] == (4,)
+
+
 @pytest.mark.parametrize('x, chunks', [
     (da.ones(shape=(50, 10), chunks=(25, 10)), (None, 5)),
     (da.ones(shape=(50, 10), chunks=(25, 10)), {1: 5}),
@@ -441,10 +441,13 @@ def test_breakpoints_order_nan():
     (da.ones(shape=(1000, 10), chunks=(5, 10)), {1: 5}),
     (da.ones(shape=(1000, 10), chunks=(5, 10)), (None, (5, 5))),
 
-    # this block does fail...
     (da.ones(shape=(10, 10), chunks=(10, 10)), (None, 5)),
     (da.ones(shape=(10, 10), chunks=(10, 10)), {1: 5}),
     (da.ones(shape=(10, 10), chunks=(10, 10)), (None, (5, 5))),
+
+    (da.ones(shape=(10, 10), chunks=(10, 2)), (None, 5)),
+    (da.ones(shape=(10, 10), chunks=(10, 2)), {1: 5}),
+    (da.ones(shape=(10, 10), chunks=(10, 2)), (None, (5, 5))),
 ])
 def test_rechunk_unknown(x, chunks):
     dd = pytest.importorskip('dask.dataframe')

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -451,7 +451,6 @@ def test_rechunk_unknown_from_pandas():
 
 
 def test_rechunk_unknown_from_array():
-    import dask; dask.set_options(get=dask.get)  # noqa
     dd = pytest.importorskip('dask.dataframe')
     # pd = pytest.importorskip('pandas')
     x = dd.from_array(da.ones(shape=(4, 4), chunks=(2, 2))).values

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -301,14 +301,8 @@ def test_plan_rechunk():
     _assert_steps(steps, [(c + c, c + c), (f + f, c + c)])
 
     # Same, with unknown dim
-    steps = _plan((nc, c + c, c + f), (nc, f + f, c + c))
-    _assert_steps(steps, [(nc, c + c, c + c), (nc, f + f, c + c)])
-
-    steps = _plan((nc, f, c), (nc, c, f))
-    _assert_steps(steps, [(nc, c, c), (nc, c, f)])
-
-    steps = _plan((f, c, nf), (c, f, nf))
-    _assert_steps(steps, [(c, c, nf), (c, f, nf)])
+    steps = _plan((nc + nf, c + c, c + f), (nc + nf, f + f, c + c))
+    _assert_steps(steps, steps)
 
     # Just at the memory limit => an intermediate is used
     steps = _plan((f, c), (c, f), block_size_limit=400)
@@ -323,24 +317,13 @@ def test_plan_rechunk():
     steps2 = _plan((f, c), (c, f), block_size_limit=3999, itemsize=10)
     _assert_steps(steps2, steps)
 
-    # same with nan
-    steps = _plan((f, c, nc), (c, f, nc), block_size_limit=399)
-    _assert_steps(steps, [(m, c, nc), (c, f, nc)])
-
-    steps2 = _plan((f, c, nc), (c, f, nc), block_size_limit=3999, itemsize=10)
-    _assert_steps(steps2, steps)
-
     # Memory limit too low => no intermediate
     steps = _plan((f, c), (c, f), block_size_limit=40)
     _assert_steps(steps, [(c, f)])
 
-    # Memory limit too low => no intermediate (nan)
-    steps = _plan((f, nf, c), (c, nf, f), block_size_limit=40)
-    _assert_steps(steps, [(c, nf, f)])
-
     # Larger problem size => more intermediates
-    c = ((1000,) * 2)  # coarse
-    f = ((2,) * 1000)  # fine
+    c = ((1000,) * 2)   # coarse
+    f = ((2,) * 1000)   # fine
 
     steps = _plan((f, c), (c, f), block_size_limit=99999)
     assert len(steps) == 3

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -447,12 +447,14 @@ def test_rechunk_unknown_from_pandas():
     dd = pytest.importorskip('dask.dataframe')
     pd = pytest.importorskip('pandas')
 
-    x = dd.from_pandas(pd.DataFrame(np.random.randn(50, 10)), 2).values
-    # result = x.rechunk({1: 5})
+    arr = np.random.randn(50, 10)
+    x = dd.from_pandas(pd.DataFrame(arr), 2).values
     result = x.rechunk((None, (5, 5)))
     assert np.isnan(x.chunks[0]).all()
     assert np.isnan(result.chunks[0]).all()
     assert result.chunks[1] == (5, 5)
+    expected = da.from_array(arr, chunks=((25, 25), (10,))).rechunk((None, (5, 5)))
+    assert_eq(result, expected)
 
 
 def test_rechunk_unknown_from_array():


### PR DESCRIPTION
Expands the rechunking methods to support rechunking arrays
with some unknown dimensions, along known dimensions.

Closes https://github.com/dask/dask/issues/2236