### PR TITLE
BUG: Handle grouping by and aggregating same column

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1069,3 +1069,34 @@ def test_groupby_unaligned_index():
 
     for (res, sol) in good:
         assert_eq(res, sol)
+
+
+def test_groupby_slice_agg_reduces():
+    d = pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, 5]})
+    a = dd.from_pandas(d, npartitions=2)
+    result = a.groupby("a")["b"].agg(['min', 'max'])
+    expected = d.groupby("a")['b'].agg(['min', 'max'])
+    assert_eq(result, expected)
+
+
+def test_groupby_agg_grouper_single():
+    # https://github.com/dask/dask/issues/2255
+    d = pd.DataFrame({'a': [1, 2, 3, 4]})
+    a = dd.from_pandas(d, npartitions=2)
+
+    result = a.groupby('a')['a'].agg(['min', 'max'])
+    expected = d.groupby('a')['a'].agg(['min', 'max'])
+    assert_eq(result, expected)
+
+
+@pytest.mark.parametrize('slice_', [
+    'a', ['a'], ['a', 'b'], ['b'],
+])
+def test_groupby_agg_grouper_multiple(slice_):
+    # https://github.com/dask/dask/issues/2255
+    d = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [1, 2, 3, 4]})
+    a = dd.from_pandas(d, npartitions=2)
+
+    result = a.groupby('a')[slice_].agg(['min', 'max'])
+    expected = d.groupby('a')[slice_].agg(['min', 'max'])
+    assert_eq(result, expected)


### PR DESCRIPTION
Previosuly we always excluded a grouping column from the columns
to be aggregated. Pandas will allow you to group and aggregate the
same column, assuming it's the only column to be aggregated.

```python
In [2]: import dask.dataframe as dd
   ...: import pandas as pd
   ...: import numpy as np
   ...:
   ...:
   ...: d = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [3, 4, 5, 6]})
   ...: a = dd.from_pandas(d, 2)
   ...:

In [7]: a.groupby('a')['a'].agg(['mean']).compute()
Out[7]:
   mean
a
1   1.0
2   2.0
3   3.0
4   4.0
```

Fixed a related bug with multiple aggregations not reducing
to a single-level MI when possible. Now we're consistent with pandas.

```python
In [3]: d.groupby('a')[['b']].agg(['mean'])
Out[3]:
     b
  mean
a
1    3
2    4
3    5
4    6

In [4]: d.groupby('a')['b'].agg(['mean'])
Out[4]:
   mean
a
1     3
2     4
3     5
4     6

In [5]: a.groupby('a')[['b']].agg(['mean']).compute()
Out[5]:
     b
  mean
a
1  3.0
2  4.0
3  5.0
4  6.0

In [6]: a.groupby('a')['b'].agg(['mean']).compute()
Out[6]:
   mean
a
1   3.0
2   4.0
3   5.0
4   6.0
```

Before, `Out[6]` would have been a MultiIndex of `(B, 'mean')`.

Closes https://github.com/dask/dask/issues/2255