### PR TITLE
Fix map_overlap with trivial depth

### DIFF
--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -359,9 +359,8 @@ def add_dummy_padding(x, depth, boundary):
     array([..., 0, 1, 2, 3, 4, 5, ...])
     """
     for k, v in boundary.items():
-        if v == 'none':
-            d = depth[k]
-
+        d = depth[k]
+        if v == 'none' and d > 0:
             empty_shape = list(x.shape)
             empty_shape[k] = d
 

--- a/dask/array/tests/test_ghost.py
+++ b/dask/array/tests/test_ghost.py
@@ -204,6 +204,21 @@ def test_map_overlap():
     assert_eq(exp2, x + 12)
 
 
+@pytest.mark.parametrize("boundary", [
+    None,
+    "reflect",
+    "periodic",
+    "nearest",
+    "none",
+    0
+])
+def test_map_overlap_no_depth(boundary):
+    x = da.arange(10, chunks=5)
+
+    y = x.map_overlap(lambda i: i, depth=0, boundary=boundary, dtype=x.dtype)
+    assert_eq(y, x)
+
+
 def test_nearest_ghost():
     a = np.arange(144).reshape(12, 12).astype(float)
 


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2258

Adds a test for `map_overlap` with trivial depth to demonstrate the failure. Also provides a potential fix.