### PR TITLE
Mark some array tests as slow

### DIFF
--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -111,6 +111,7 @@ def test_wrap_bad_kind():
         fft_wrap(np.ones)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("funcname", all_nd_funcnames)
 @pytest.mark.parametrize("dtype", ["float32", "float64"])
 def test_nd_ffts_axes(funcname, dtype):

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -111,7 +111,6 @@ def test_wrap_bad_kind():
         fft_wrap(np.ones)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("funcname", all_nd_funcnames)
 @pytest.mark.parametrize("dtype", ["float32", "float64"])
 def test_nd_ffts_axes(funcname, dtype):

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -190,6 +190,7 @@ def test_lu_1():
         _check_lu_result(dp, dl, du, A)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize('size', [10, 20, 30, 50])
 def test_lu_2(size):
     np.random.seed(10)
@@ -200,6 +201,7 @@ def test_lu_2(size):
     _check_lu_result(dp, dl, du, A)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize('size', [50, 100, 200])
 def test_lu_3(size):
     np.random.seed(10)

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -116,6 +116,7 @@ def test_reduction_errors():
         x.sum(axis=-3)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize('dtype', ['f4', 'i4'])
 def test_reductions_2D(dtype):
     x = np.arange(1, 122).reshape((11, 11)).astype(dtype)

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -524,6 +524,7 @@ def test_slicing_none_int_ellipses(a, b, c, d):
 """
 
 
+@pytest.mark.slow
 def test_slicing_none_int_ellipes():
     shape = (2,3,5,7,11)
     x = np.arange(np.prod(shape)).reshape(shape)


### PR DESCRIPTION
These five tests take up about half of the test runtime.

These still get tested on travis.ci, just not when run locally without
the --runslow keyword