### PR TITLE
Speed up one of the FFT tests

### DIFF
--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -117,8 +117,8 @@ def test_nd_ffts_axes(funcname, dtype):
     np_fft = getattr(np.fft, funcname)
     da_fft = getattr(da.fft, funcname)
 
-    shape = (6, 7, 8, 9)
-    chunk_size = (3, 3, 3, 3)
+    shape = (7, 8, 9)
+    chunk_size = (3, 3, 3)
     a = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
     d = da.from_array(a, chunks=chunk_size)
 


### PR DESCRIPTION
The `test_nd_ffts_axes` used a 4-D array for testing some N-D FFT functions. However there really is no reason to require a 4-D array. Here we change this to a 3-D array. This seems to cut ~3s off the test time of this test suite.

cc @mrocklin