### PR TITLE
da.stack properly handles mixed dtypes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2255,6 +2255,9 @@ def stack(seq, axis=0):
     uc_args = list(concat((x, ind) for x in seq))
     _, seq = unify_chunks(*uc_args)
 
+    dt = reduce(np.promote_types, [a.dtype for a in seq])
+    seq = [x.astype(dt) for x in seq]
+
     assert len(set(a.chunks for a in seq)) == 1  # same chunks
     chunks = (seq[0].chunks[:axis] + ((1,) * n,) + seq[0].chunks[axis:])
 
@@ -2270,8 +2273,6 @@ def stack(seq, axis=0):
 
     dsk = dict(zip(keys, values))
     dsk2 = sharedict.merge((name, dsk), *[a.dask for a in seq])
-
-    dt = reduce(np.promote_types, [a.dtype for a in seq])
 
     return Array(dsk2, name, chunks, dtype=dt)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -277,6 +277,15 @@ def test_stack_scalars():
     assert s.compute().tolist() == [np.arange(4).mean(), np.arange(4).sum()]
 
 
+def test_stack_promote_type():
+    i = np.arange(10, dtype='i4')
+    f = np.arange(10, dtype='f4')
+    di = da.from_array(i, chunks=5)
+    df = da.from_array(f, chunks=5)
+    res = da.stack([di, df])
+    assert_eq(res, np.stack([i, f]))
+
+
 @pytest.mark.skipif(LooseVersion(np.__version__) < '1.10.0',
                     reason="NumPy doesn't yet support stack")
 def test_stack_rechunk():


### PR DESCRIPTION
Previously we'd fail to convert partitions, leading to mismatched
dask/numpy dtypes.

Fixes #2273.