### PR TITLE
Document the indices function

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -60,6 +60,7 @@ Top level user functions:
    hstack
    hypot
    imag
+   indices
    insert
    isclose
    iscomplex
@@ -318,6 +319,7 @@ Other functions
 .. autofunction:: hstack
 .. autofunction:: hypot
 .. autofunction:: imag
+.. autofunction:: indices
 .. autofunction:: insert
 .. autofunction:: isclose
 .. autofunction:: iscomplex


### PR DESCRIPTION
Adds the `indices` function from PR ( https://github.com/dask/dask/pull/2268 ) to the API documentation.