### PR TITLE
Fix metadata inference for groupby.agg

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -866,14 +866,6 @@ class _GroupBy(object):
         else:
             levels = 0
 
-        # apply the transformations to determine the meta object
-        meta_groupby = pd.Series([], dtype=bool, index=self.obj._meta.index)
-        meta_stage1 = _groupby_apply_funcs(self.obj._meta, funcs=chunk_funcs,
-                                           by=meta_groupby)
-        meta_stage2 = _groupby_apply_funcs(meta_stage1, funcs=aggregate_funcs,
-                                           level=0)
-        meta = _agg_finalize(meta_stage2, finalizers)
-
         if not isinstance(self.index, list):
             chunk_args = [self.obj, self.index]
 
@@ -887,11 +879,11 @@ class _GroupBy(object):
                   aggregate_kwargs=dict(funcs=aggregate_funcs, level=levels),
                   combine=_groupby_apply_funcs,
                   combine_kwargs=dict(funcs=aggregate_funcs, level=levels),
-                  meta=meta, token='aggregate', split_every=split_every,
+                  token='aggregate', split_every=split_every,
                   split_out=split_out, split_out_setup=split_out_on_index)
 
-        return map_partitions(_agg_finalize, obj, meta=meta,
-                              token='aggregate-finalize', funcs=finalizers)
+        return map_partitions(_agg_finalize, obj, token='aggregate-finalize',
+                              funcs=finalizers)
 
     @insert_meta_param_description(pad=12)
     def apply(self, func, meta=no_default, columns=no_default):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1035,10 +1035,6 @@ class SeriesGroupBy(_GroupBy):
 
     def nunique(self, split_every=None, split_out=1):
         name = self._meta.obj.name
-        meta = pd.Series([], dtype='int64',
-                         index=pd.Index([], dtype=self._meta.obj.dtype),
-                         name=name)
-
         levels = _determine_levels(self.index)
 
         if isinstance(self.obj, DataFrame):
@@ -1051,7 +1047,7 @@ class SeriesGroupBy(_GroupBy):
                    chunk=chunk,
                    aggregate=_nunique_df_aggregate,
                    combine=_nunique_df_combine,
-                   meta=meta, token='series-groupby-nunique',
+                   token='series-groupby-nunique',
                    chunk_kwargs={'levels': levels, 'name': name},
                    aggregate_kwargs={'levels': levels, 'name': name},
                    combine_kwargs={'levels': levels},

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -132,6 +132,7 @@ def pivot_table(df, index=None, columns=None,
     # the result must have CategoricalIndex columns
     new_columns = pd.CategoricalIndex(df[columns].cat.categories, name=columns)
     meta = pd.DataFrame(columns=new_columns, dtype=np.float64)
+    meta.index.name = index
 
     kwargs = {'index': index, 'columns': columns, 'values': values}
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -655,8 +655,12 @@ def test_aggregate__examples(spec, split_every, grouper):
                        columns=['c', 'b', 'a', 'd'])
     ddf = dd.from_pandas(pdf, npartitions=10)
 
-    assert_eq(pdf.groupby(grouper(pdf)).agg(spec),
-              ddf.groupby(grouper(ddf)).agg(spec, split_every=split_every))
+    sol = pdf.groupby(grouper(pdf)).agg(spec)
+    res = ddf.groupby(grouper(ddf)).agg(spec, split_every=split_every)
+    assert_eq(sol, res)
+    assert type(sol.index) == type(res._meta.index)
+    if isinstance(sol.index, pd.MultiIndex):
+        assert sol.index.names == res._meta.index.names
 
 
 @pytest.mark.parametrize('spec', [

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -258,11 +258,8 @@ def test_series_groupby_propagates_names():
     df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
     ddf = dd.from_pandas(df, 2)
     func = lambda df: df['y'].sum()
-
-    result = ddf.groupby('x').apply(func, meta=('y', 'i8'))
-
+    result = ddf.groupby('x').apply(func)
     expected = df.groupby('x').apply(func)
-    expected.name = 'y'
     assert_eq(result, expected)
 
 
@@ -655,12 +652,8 @@ def test_aggregate__examples(spec, split_every, grouper):
                        columns=['c', 'b', 'a', 'd'])
     ddf = dd.from_pandas(pdf, npartitions=10)
 
-    sol = pdf.groupby(grouper(pdf)).agg(spec)
-    res = ddf.groupby(grouper(ddf)).agg(spec, split_every=split_every)
-    assert_eq(sol, res)
-    assert type(sol.index) == type(res._meta.index)
-    if isinstance(sol.index, pd.MultiIndex):
-        assert sol.index.names == res._meta.index.names
+    assert_eq(pdf.groupby(grouper(pdf)).agg(spec),
+              ddf.groupby(grouper(ddf)).agg(spec, split_every=split_every))
 
 
 @pytest.mark.parametrize('spec', [


### PR DESCRIPTION
Previously this would result in incorrect metadata for multi-indices. We
now fallback to using the automatic inference in `aca` and
`map_partitions`.

Fixes #2278.