### PR TITLE
docs: Drop sphinx.ext.mathjax extension, it is unused

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.mathjax',
+extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary', 'sphinx.ext.extlinks', 'numpydoc']
 
 numpydoc_show_class_members = False


### PR DESCRIPTION
There are no uses of `:math:` role or `.. math::` directive in the Sphinx docs.