### PR TITLE
COMPAT: compat with pandas 0.20.0 for movement of pandas.util.hashing

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -10,7 +10,6 @@ import warnings
 
 from toolz import merge, first, unique, partition_all, remove
 import pandas as pd
-from pandas.util.decorators import cache_readonly
 import numpy as np
 
 try:
@@ -38,8 +37,10 @@ from .utils import (meta_nonempty, make_meta, insert_meta_param_description,
 no_default = '__no_default__'
 
 if PANDAS_VERSION >= '0.20.0':
+    from pandas.util import cache_readonly
     pd.core.computation.expressions.set_use_numexpr(False)
 else:
+    from pandas.util.decorators import cache_readonly
     pd.computation.expressions.set_use_numexpr(False)
 
 

--- a/dask/dataframe/hashing.py
+++ b/dask/dataframe/hashing.py
@@ -25,7 +25,7 @@ from .utils import PANDAS_VERSION
 # versioneer, since the release tags aren't ancestors of master. As such, we
 # need to use this hacky awfulness to check if we're > 0.19.2.
 if PANDAS_VERSION >= '0.20.0':
-    from pandas.util.hashing import hash_pandas_object
+    from pandas.util import hash_pandas_object
 elif PANDAS_VERSION not in ('0.19.1', '0.19.2') and PANDAS_VERSION > '0.19.0+460':
     from pandas.tools.hashing import hash_pandas_object
 else:


### PR DESCRIPTION
Fixes #2293.