### PR TITLE
xfail test_interrupt on py3 non-windows

### DIFF
--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -113,6 +113,7 @@ def test_interrupt():
     elif os.name == 'nt':
         from _thread import interrupt_main
     else:
+        pytest.xfail("This test fails intermittently on non-windows PY3.")
         main_thread = threading.get_ident()
 
         def interrupt_main():


### PR DESCRIPTION
Still periodically failing, not sure why. I believe it's an issue with test and not the code, but it's cost enough dev time already trying to debug this (see #2261). XFailing on python3 non-windows for now.