### PR TITLE
Masked arrays

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -32,7 +32,9 @@ from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
 from .percentile import percentile
 with ignoring(ImportError):
     from .reductions import nanprod, nancumprod, nancumsum
-from . import random, linalg, ghost, learn, fft, ma
+with ignoring(ImportError):
+    from . import ma
+from . import random, linalg, ghost, learn, fft
 from .wrap import ones, zeros, empty, full
 from .creation import ones_like, zeros_like, empty_like, full_like
 from .rechunk import rechunk

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -32,7 +32,7 @@ from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
 from .percentile import percentile
 with ignoring(ImportError):
     from .reductions import nanprod, nancumprod, nancumsum
-from . import random, linalg, ghost, learn, fft
+from . import random, linalg, ghost, learn, fft, ma
 from .wrap import ones, zeros, empty, full
 from .creation import ones_like, zeros_like, empty_like, full_like
 from .rechunk import rechunk

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -33,12 +33,26 @@ from ..base import Base, tokenize, normalize_token
 from ..context import _globals
 from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      is_integer, IndexCallable, funcname, derived_from,
-                     SerializableLock, ensure_dict, package_of)
+                     SerializableLock, ensure_dict, Dispatch)
 from ..compatibility import unicode, long, getargspec, zip_longest, apply
 from ..delayed import to_task_dask
 from .. import threaded, core
 from .. import sharedict
 from ..sharedict import ShareDict
+
+
+concatenate_lookup = Dispatch('concatenate')
+tensordot_lookup = Dispatch('tensordot')
+concatenate_lookup.register((object, np.ndarray), np.concatenate)
+tensordot_lookup.register((object, np.ndarray), np.tensordot)
+
+
+@tensordot_lookup.register_lazy('sparse')
+@concatenate_lookup.register_lazy('sparse')
+def register_sparse():
+    import sparse
+    concatenate_lookup.register(sparse.COO, sparse.concatenate)
+    tensordot_lookup.register(sparse.COO, sparse.tensordot)
 
 
 def getter(a, b, asarray=True, lock=None):
@@ -477,8 +491,8 @@ def _concatenate2(arrays, axes=[]):
         return arrays
     if len(axes) > 1:
         arrays = [_concatenate2(a, axes=axes[1:]) for a in arrays]
-    module = package_of(type(max(arrays, key=lambda x: x.__array_priority__))) or np
-    return module.concatenate(arrays, axis=axes[0])
+    concatenate = concatenate_lookup.dispatch(type(max(arrays, key=lambda x: x.__array_priority__)))
+    return concatenate(arrays, axis=axes[0])
 
 
 def apply_infer_dtype(func, args, kwargs, funcname, suggest_dtype=True):
@@ -2832,8 +2846,7 @@ def concatenate3(arrays):
 
     advanced = max(core.flatten(arrays, container=(list, tuple)),
                    key=lambda x: getattr(x, '__array_priority__', 0))
-    module = package_of(type(advanced)) or np
-    if module is not np and hasattr(module, 'concatenate'):
+    if concatenate_lookup.dispatch(type(advanced)) is not np.concatenate:
         x = unpack_singleton(arrays)
         return _concatenate2(arrays, axes=list(range(x.ndim)))
 

--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -1,0 +1,83 @@
+from __future__ import absolute_import, division, print_function
+
+from functools import wraps
+
+import numpy as np
+
+from .core import concatenate_lookup, tensordot_lookup
+
+
+concatenate_lookup.register(np.ma.masked_array, np.ma.concatenate)
+
+
+@tensordot_lookup.register(np.ma.masked_array)
+def _tensordot(a, b, axes=2):
+    # Much of this is stolen from numpy/core/numeric.py::tensordot
+    # Please see license at https://github.com/numpy/numpy/blob/master/LICENSE.txt
+    try:
+        iter(axes)
+    except:
+        axes_a = list(range(-axes, 0))
+        axes_b = list(range(0, axes))
+    else:
+        axes_a, axes_b = axes
+    try:
+        na = len(axes_a)
+        axes_a = list(axes_a)
+    except TypeError:
+        axes_a = [axes_a]
+        na = 1
+    try:
+        nb = len(axes_b)
+        axes_b = list(axes_b)
+    except TypeError:
+        axes_b = [axes_b]
+        nb = 1
+
+    # a, b = asarray(a), asarray(b)  # <--- modified
+    as_ = a.shape
+    nda = a.ndim
+    bs = b.shape
+    ndb = b.ndim
+    equal = True
+    if na != nb:
+        equal = False
+    else:
+        for k in range(na):
+            if as_[axes_a[k]] != bs[axes_b[k]]:
+                equal = False
+                break
+            if axes_a[k] < 0:
+                axes_a[k] += nda
+            if axes_b[k] < 0:
+                axes_b[k] += ndb
+    if not equal:
+        raise ValueError("shape-mismatch for sum")
+
+    # Move the axes to sum over to the end of "a"
+    # and to the front of "b"
+    notin = [k for k in range(nda) if k not in axes_a]
+    newaxes_a = notin + axes_a
+    N2 = 1
+    for axis in axes_a:
+        N2 *= as_[axis]
+    newshape_a = (-1, N2)
+    olda = [as_[axis] for axis in notin]
+
+    notin = [k for k in range(ndb) if k not in axes_b]
+    newaxes_b = axes_b + notin
+    N2 = 1
+    for axis in axes_b:
+        N2 *= bs[axis]
+    newshape_b = (N2, -1)
+    oldb = [bs[axis] for axis in notin]
+
+    at = a.transpose(newaxes_a).reshape(newshape_a)
+    bt = b.transpose(newaxes_b).reshape(newshape_b)
+    res = np.ma.dot(at, bt)
+    return res.reshape(olda + oldb)
+
+
+@wraps(np.ma.filled)
+def filled(a, fill_value=None):
+    return a.map_blocks(np.ma.filled, fill_value)

--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -138,3 +138,13 @@ def masked_values(x, value, rtol=1e-05, atol=1e-08, shrink=True):
 @wraps(np.ma.fix_invalid)
 def fix_invalid(a, mask=False, fill_value=None):
     return map_blocks(np.ma.fix_invalid, a, mask, fill_value=fill_value)
+
+
+@wraps(np.ma.getdata)
+def getdata(a):
+    return a.map_blocks(np.ma.getdata)
+
+
+@wraps(np.ma.getmaskarray)
+def getmaskarray(a):
+    return a.map_blocks(np.ma.getmaskarray)

--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -1,10 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
 from functools import wraps, update_wrapper
+from distutils.version import LooseVersion
 
 import numpy as np
 
 from .core import concatenate_lookup, tensordot_lookup, map_blocks, Array
+
+
+if LooseVersion(np.__version__) < '1.11.0':
+    raise ImportError("dask.array.ma requires numpy >= 1.11.0")
 
 
 @concatenate_lookup.register(np.ma.masked_array)

--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -148,3 +148,18 @@ def getdata(a):
 @wraps(np.ma.getmaskarray)
 def getmaskarray(a):
     return a.map_blocks(np.ma.getmaskarray)
+
+
+def _set_fill_value(x, fill_value):
+    if isinstance(x, np.ma.masked_array):
+        x = x.copy()
+        np.ma.set_fill_value(x, fill_value=fill_value)
+    return x
+
+
+@wraps(np.ma.set_fill_value)
+def set_fill_value(a, fill_value):
+    fill_value = np.ma.core._check_fill_value(fill_value, a.dtype)
+    res = a.map_blocks(_set_fill_value, fill_value)
+    a.dask = res.dask
+    a.name = res.name

--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -5,11 +5,19 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
+from ..base import normalize_token
 from .core import concatenate_lookup, tensordot_lookup, map_blocks, Array
 
 
 if LooseVersion(np.__version__) < '1.11.0':
     raise ImportError("dask.array.ma requires numpy >= 1.11.0")
+
+
+@normalize_token.register(np.ma.masked_array)
+def normalize_masked_array(x):
+    data = normalize_token(x.data)
+    mask = normalize_token(x.mask)
+    return (data, mask, x.fill_value)
 
 
 @concatenate_lookup.register(np.ma.masked_array)

--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -1,13 +1,21 @@
 from __future__ import absolute_import, division, print_function
 
-from functools import wraps
+from functools import wraps, update_wrapper
 
 import numpy as np
 
-from .core import concatenate_lookup, tensordot_lookup
+from .core import concatenate_lookup, tensordot_lookup, elemwise, Array
 
 
-concatenate_lookup.register(np.ma.masked_array, np.ma.concatenate)
+@concatenate_lookup.register(np.ma.masked_array)
+def _concatenate(arrays, axis=0):
+    fill_values = [i.fill_value for i in arrays if hasattr(i, 'fill_value')]
+    out = np.ma.concatenate(arrays, axis=axis)
+    if fill_values:
+        fill_values = np.unique(fill_values)
+        if len(fill_values) == 1:
+            out.fill_value = fill_values[0]
+    return out
 
 
 @tensordot_lookup.register(np.ma.masked_array)
@@ -80,4 +88,52 @@ def _tensordot(a, b, axes=2):
 
 @wraps(np.ma.filled)
 def filled(a, fill_value=None):
-    return a.map_blocks(np.ma.filled, fill_value)
+    return elemwise(np.ma.filled, a, fill_value=fill_value)
+
+
+def _wrap_masked(f):
+    return update_wrapper(lambda a, value: elemwise(f, a, value), f)
+
+
+masked_greater = _wrap_masked(np.ma.masked_greater)
+masked_greater_equal = _wrap_masked(np.ma.masked_greater_equal)
+masked_less = _wrap_masked(np.ma.masked_less)
+masked_less_equal = _wrap_masked(np.ma.masked_less_equal)
+masked_equal = _wrap_masked(np.ma.masked_equal)
+masked_not_equal = _wrap_masked(np.ma.masked_not_equal)
+
+
+@wraps(np.ma.masked_invalid)
+def masked_invalid(a):
+    return elemwise(np.ma.masked_invalid, a)
+
+
+@wraps(np.ma.masked_inside)
+def masked_inside(x, v1, v2):
+    return elemwise(np.ma.masked_inside, x, v1, v2)
+
+
+@wraps(np.ma.masked_outside)
+def masked_outside(x, v1, v2):
+    return elemwise(np.ma.masked_outside, x, v1, v2)
+
+
+@wraps(np.ma.masked_where)
+def masked_where(condition, a):
+    cshape = getattr(condition, 'shape', ())
+    if not isinstance(a, Array):
+        raise TypeError("a must be a dask.Array")
+    if cshape != a.shape:
+        raise IndexError("Inconsistant shape between the condition and the "
+                         "input (got %s and %s)" % (cshape, a.shape))
+    return elemwise(np.ma.masked_where, condition, a)
+
+
+@wraps(np.ma.masked_values)
+def masked_values(x, value, rtol=1e-05, atol=1e-08, shrink=True):
+    return elemwise(value, x, rtol=rtol, atol=atol, shrink=shrink)
+
+
+@wraps(np.ma.fix_invalid)
+def fix_invalid(a, mask=False, fill_value=None):
+    return elemwise(np.ma.fix_invalid, a, mask, True, fill_value)

--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -34,6 +34,7 @@ try:
             raise TypeError('Divide not working with dtype: '
                             'https://github.com/numpy/numpy/issues/3484')
         divide = np.divide
+        ma_divide = np.ma.divide
 
 except TypeError:
     # Divide with dtype doesn't work on Python 3
@@ -46,6 +47,10 @@ except TypeError:
         if dtype is not None:
             x = x.astype(dtype)
         return x
+
+    ma_divide = np.ma.core._DomainedBinaryOperation(divide,
+                                                    np.ma.core._DomainSafeDivide(),
+                                                    0, 1)
 
 # functions copied from numpy
 try:

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -14,12 +14,11 @@ from toolz import concat, sliding_window, interleave
 from .. import sharedict
 from ..core import flatten
 from ..base import tokenize
-from ..utils import package_of
 from . import numpy_compat, chunk
 
 from .core import (Array, map_blocks, elemwise, from_array, asarray,
                    concatenate, stack, atop, broadcast_shapes,
-                   is_scalar_for_elemwise, broadcast_to)
+                   is_scalar_for_elemwise, broadcast_to, tensordot_lookup)
 
 
 @wraps(np.array)
@@ -111,8 +110,8 @@ ALPHABET = alphabet.upper()
 
 def _tensordot(a, b, axes):
     x = max([a, b], key=lambda x: x.__array_priority__)
-    module = package_of(type(x)) or np
-    x = module.tensordot(a, b, axes=axes)
+    tensordot = tensordot_lookup.dispatch(type(x))
+    x = tensordot(a, b, axes=axes)
     ind = [slice(None, None)] * x.ndim
     for a in sorted(axes[0]):
         ind.insert(a, None)

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -41,7 +41,7 @@ functions = [
 @pytest.mark.parametrize('func', functions)
 def test_basic(func):
     x = da.random.random((2, 3, 4), chunks=(1, 2, 2))
-    x[x < 0.8] = 0
+    x[x < 0.4] = 0
 
     y = da.ma.masked_equal(x, 0)
 
@@ -57,9 +57,9 @@ def test_basic(func):
 
 def test_tensordot():
     x = da.random.random((2, 3, 4), chunks=(1, 2, 2))
-    x[x < 0.8] = 0
+    x[x < 0.4] = 0
     y = da.random.random((4, 3, 2), chunks=(2, 2, 1))
-    y[y < 0.8] = 0
+    y[y < 0.4] = 0
 
     xx = da.ma.masked_equal(x, 0)
     yy = da.ma.masked_equal(y, 0)
@@ -77,7 +77,7 @@ def test_mixed_concatenate(func):
     x = da.random.random((2, 3, 4), chunks=(1, 2, 2))
     y = da.random.random((2, 3, 4), chunks=(1, 2, 2))
 
-    y[y < 0.8] = 0
+    y[y < 0.4] = 0
     yy = da.ma.masked_equal(y, 0)
 
     d = da.concatenate([x, y], axis=0)
@@ -91,7 +91,7 @@ def test_mixed_concatenate(func):
 @pytest.mark.parametrize('func', functions)
 def test_mixed_random(func):
     d = da.random.random((4, 3, 4), chunks=(1, 2, 2))
-    d[d < 0.7] = 0
+    d[d < 0.4] = 0
 
     fn = lambda x: np.ma.masked_equal(x, 0) if random.random() < 0.5 else x
     s = d.map_blocks(fn)
@@ -104,7 +104,7 @@ def test_mixed_random(func):
 
 def test_mixed_output_type():
     y = da.random.random((10, 10), chunks=(5, 5))
-    y[y < 0.8] = 0
+    y[y < 0.4] = 0
 
     y = da.ma.masked_equal(y, 0)
     x = da.zeros((10, 1), chunks=(5, 1))
@@ -197,8 +197,8 @@ def test_reductions(dtype, reduction):
 def test_arg_reductions(reduction):
     x = np.random.random((10, 10, 10))
     dx = da.from_array(x, chunks=(3, 4, 5))
-    mx = np.ma.masked_greater(x, 0.5)
-    dmx = da.ma.masked_greater(dx, 0.5)
+    mx = np.ma.masked_greater(x, 0.4)
+    dmx = da.ma.masked_greater(dx, 0.4)
 
     dfunc = getattr(da, reduction)
     func = getattr(np, reduction)
@@ -212,9 +212,21 @@ def test_arg_reductions(reduction):
 def test_cumulative():
     x = np.random.RandomState(0).rand(20, 24, 13)
     dx = da.from_array(x, chunks=(6, 5, 4))
-    mx = np.ma.masked_greater(x, 0.5)
-    dmx = da.ma.masked_greater(dx, 0.5)
+    mx = np.ma.masked_greater(x, 0.4)
+    dmx = da.ma.masked_greater(dx, 0.4)
 
     for axis in [0, 1, 2]:
         assert_eq_ma(dmx.cumsum(axis=axis), mx.cumsum(axis=axis))
         assert_eq_ma(dmx.cumprod(axis=axis), mx.cumprod(axis=axis))
+
+
+def test_accessors():
+    x = np.random.random((10, 10, 10))
+    dx = da.from_array(x, chunks=(3, 4, 5))
+    mx = np.ma.masked_greater(x, 0.4)
+    dmx = da.ma.masked_greater(dx, 0.4)
+
+    assert_eq(da.ma.getmaskarray(dmx), np.ma.getmaskarray(mx))
+    assert_eq(da.ma.getmaskarray(dx), np.ma.getmaskarray(x))
+    assert_eq(da.ma.getdata(dmx), np.ma.getdata(mx))
+    assert_eq(da.ma.getdata(dx), np.ma.getdata(x))

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -4,9 +4,21 @@ import numpy as np
 import pytest
 
 import dask.array as da
+from dask.base import tokenize
 from dask.array.utils import assert_eq
 
 pytest.importorskip("dask.array.ma")
+
+
+def test_tokenize_masked_array():
+    m = np.ma.masked_array([1, 2, 3], mask=[True, True, False], fill_value=10)
+    m2 = np.ma.masked_array([1, 2, 3], mask=[True, True, False], fill_value=0)
+    m3 = np.ma.masked_array([1, 2, 3], mask=False, fill_value=10)
+    assert tokenize(m) == tokenize(m)
+    assert tokenize(m2) == tokenize(m2)
+    assert tokenize(m3) == tokenize(m3)
+    assert tokenize(m) != tokenize(m2)
+    assert tokenize(m) != tokenize(m3)
 
 
 functions = [

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -221,8 +221,8 @@ def test_cumulative():
 
 
 def test_accessors():
-    x = np.random.random((10, 10, 10))
-    dx = da.from_array(x, chunks=(3, 4, 5))
+    x = np.random.random((10, 10))
+    dx = da.from_array(x, chunks=(3, 4))
     mx = np.ma.masked_greater(x, 0.4)
     dmx = da.ma.masked_greater(dx, 0.4)
 
@@ -230,3 +230,21 @@ def test_accessors():
     assert_eq(da.ma.getmaskarray(dx), np.ma.getmaskarray(x))
     assert_eq(da.ma.getdata(dmx), np.ma.getdata(mx))
     assert_eq(da.ma.getdata(dx), np.ma.getdata(x))
+
+
+def test_set_fill_value():
+    x = np.random.randint(0, 10, (10, 10))
+    dx = da.from_array(x, chunks=(3, 4))
+    mx = np.ma.masked_greater(x, 3)
+    dmx = da.ma.masked_greater(dx, 3)
+
+    da.ma.set_fill_value(dmx, -10)
+    np.ma.set_fill_value(mx, -10)
+    assert_eq_ma(dmx, mx)
+
+    da.ma.set_fill_value(dx, -10)
+    np.ma.set_fill_value(x, -10)
+    assert_eq_ma(dx, x)
+
+    with pytest.raises(TypeError):
+        da.ma.set_fill_value(dmx, 1e20)

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -1,0 +1,118 @@
+import random
+
+import numpy as np
+import pytest
+
+import dask.array as da
+from dask.array.utils import assert_eq
+
+
+functions = [
+    lambda x: x,
+    lambda x: da.expm1(x),
+    lambda x: 2 * x,
+    lambda x: x / 2,
+    lambda x: x**2,
+    lambda x: x + x,
+    lambda x: x * x,
+    lambda x: x[0],
+    lambda x: x[:, 1],
+    lambda x: x[:1, None, 1:3],
+    lambda x: x.T,
+    lambda x: da.transpose(x, (1, 2, 0)),
+    lambda x: x.sum(),
+    lambda x: x.dot(np.arange(x.shape[-1])),
+    lambda x: x.dot(np.eye(x.shape[-1])),
+    lambda x: da.tensordot(x, np.ones(x.shape[:2]), axes=[(0, 1), (0, 1)]),
+    lambda x: x.sum(axis=0),
+    lambda x: x.max(axis=0),
+    lambda x: x.sum(axis=(1, 2)),
+    lambda x: x.astype(np.complex128),
+    lambda x: x.map_blocks(lambda x: x * 2),
+    lambda x: x.round(1),
+    lambda x: x.reshape((x.shape[0] * x.shape[1], x.shape[2])),
+    lambda x: abs(x),
+    lambda x: x > 0.5,
+    lambda x: x.rechunk((4, 4, 4)),
+    lambda x: x.rechunk((2, 2, 1)),
+]
+
+
+@pytest.mark.parametrize('func', functions)
+def test_basic(func):
+    x = da.random.random((2, 3, 4), chunks=(1, 2, 2))
+    x[x < 0.8] = 0
+
+    y = x.map_blocks(np.ma.masked_equal, 0)
+
+    xx = func(x)
+    yy = func(y)
+
+    assert_eq(xx, da.ma.filled(yy, 0))
+
+    if yy.shape:
+        zz = yy.compute()
+        assert isinstance(zz, np.ma.masked_array)
+
+
+def test_tensordot():
+    x = da.random.random((2, 3, 4), chunks=(1, 2, 2))
+    x[x < 0.8] = 0
+    y = da.random.random((4, 3, 2), chunks=(2, 2, 1))
+    y[y < 0.8] = 0
+
+    xx = x.map_blocks(np.ma.masked_equal, 0)
+    yy = y.map_blocks(np.ma.masked_equal, 0)
+
+    assert_eq(da.tensordot(x, y, axes=(2, 0)),
+              da.ma.filled(da.tensordot(xx, yy, axes=(2, 0)), 0))
+    assert_eq(da.tensordot(x, y, axes=(1, 1)),
+              da.ma.filled(da.tensordot(xx, yy, axes=(1, 1)), 0))
+    assert_eq(da.tensordot(x, y, axes=((1, 2), (1, 0))),
+              da.ma.filled(da.tensordot(xx, yy, axes=((1, 2), (1, 0))), 0))
+
+
+@pytest.mark.parametrize('func', functions)
+def test_mixed_concatenate(func):
+    x = da.random.random((2, 3, 4), chunks=(1, 2, 2))
+
+    y = da.random.random((2, 3, 4), chunks=(1, 2, 2))
+    y[y < 0.8] = 0
+    yy = y.map_blocks(np.ma.masked_equal, 0)
+
+    d = da.concatenate([x, y], axis=0)
+    s = da.concatenate([x, yy], axis=0)
+
+    dd = func(d)
+    ss = func(s)
+
+    assert_eq(dd, ss)
+
+
+@pytest.mark.parametrize('func', functions)
+def test_mixed_random(func):
+    d = da.random.random((4, 3, 4), chunks=(1, 2, 2))
+    d[d < 0.7] = 0
+
+    fn = lambda x: np.ma.masked_equal(x, 0) if random.random() < 0.5 else x
+    s = d.map_blocks(fn)
+
+    dd = func(d)
+    ss = func(s)
+
+    assert_eq(dd, ss)
+
+
+def test_mixed_output_type():
+    y = da.random.random((10, 10), chunks=(5, 5))
+    y[y < 0.8] = 0
+    y = y.map_blocks(np.ma.masked_equal, 0)
+
+    x = da.zeros((10, 1), chunks=(5, 1))
+
+    z = da.concatenate([x, y], axis=1)
+
+    assert z.shape == (10, 11)
+
+    zz = z.compute()
+    assert isinstance(zz, np.ma.masked_array)

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -271,6 +271,29 @@ def test_accessors():
     assert_eq(da.ma.getdata(dx), np.ma.getdata(x))
 
 
+def test_masked_array():
+    x = np.random.random((10, 10)).astype('f4')
+    dx = da.from_array(x, chunks=(3, 4))
+    f1 = da.from_array(np.array(1), chunks=())
+
+    fill_values = [(None, None), (0.5, 0.5), (1, f1)]
+    for data, (df, f) in product([x, dx], fill_values):
+        assert_eq(da.ma.masked_array(data, fill_value=df),
+                  np.ma.masked_array(x, fill_value=f))
+        assert_eq(da.ma.masked_array(data, mask=data > 0.4, fill_value=df),
+                  np.ma.masked_array(x, mask=x > 0.4, fill_value=f))
+        assert_eq(da.ma.masked_array(data, mask=data > 0.4, fill_value=df),
+                  np.ma.masked_array(x, mask=x > 0.4, fill_value=f))
+        assert_eq(da.ma.masked_array(data, fill_value=df, dtype='f8'),
+                  np.ma.masked_array(x, fill_value=f, dtype='f8'))
+
+    with pytest.raises(ValueError):
+        da.ma.masked_array(dx, fill_value=dx)
+
+    with pytest.raises(np.ma.MaskError):
+        da.ma.masked_array(dx, mask=dx[:3, :3])
+
+
 def test_set_fill_value():
     x = np.random.randint(0, 10, (10, 10))
     dx = da.from_array(x, chunks=(3, 4))

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -6,6 +6,8 @@ import pytest
 import dask.array as da
 from dask.array.utils import assert_eq
 
+pytest.importorskip("dask.array.ma")
+
 
 functions = [
     lambda x: x,

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -22,6 +22,12 @@ def test_tokenize_masked_array():
     assert tokenize(m) != tokenize(m3)
 
 
+def test_from_array_masked_array():
+    m = np.ma.masked_array([1, 2, 3], mask=[True, True, False], fill_value=10)
+    dm = da.from_array(m, chunks=(2,), asarray=False)
+    assert_eq(dm, m)
+
+
 functions = [
     lambda x: x,
     lambda x: da.expm1(x),

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -8,7 +8,7 @@ from dask.sharedict import ShareDict
 from dask.utils import (takes_multiple_arguments, Dispatch, random_state_data,
                         memory_repr, methodcaller, M, skip_doctest,
                         SerializableLock, funcname, ndeepmap, ensure_dict,
-                        package_of, extra_titles, asciitable, itemgetter)
+                        extra_titles, asciitable, itemgetter)
 from dask.utils_test import inc
 
 
@@ -302,17 +302,6 @@ def test_ensure_dict():
     md['x'] = 1
     assert type(ensure_dict(md)) is dict
     assert ensure_dict(md) == d
-
-
-def test_package_of():
-    import math
-    assert package_of(math.sin) is math
-    try:
-        import numpy
-    except ImportError:
-        pass
-    else:
-        assert package_of(numpy.memmap) is numpy
 
 
 def test_itemgetter():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -824,28 +824,6 @@ def ensure_dict(d):
     return dict(d)
 
 
-_packages = {}
-
-
-def package_of(typ):
-    """ Return package containing type's definition
-
-    Or return None if not found
-    """
-    try:
-        return _packages[typ]
-    except KeyError:
-        # http://stackoverflow.com/questions/43462701/get-package-of-python-object/43462865#43462865
-        mod = inspect.getmodule(typ)
-        if not mod:
-            result = None
-        else:
-            base, _sep, _stem = mod.__name__.partition('.')
-            result = sys.modules[base]
-        _packages[typ] = result
-        return result
-
-
 # XXX: Kept to keep old versions of distributed/dask in sync. After
 # distributed's dask requirement is updated to > this commit, this function can
 # be moved to dask.bytes.utils.

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -192,6 +192,28 @@ Linear Algebra
    linalg.svd_compressed
    linalg.tsqr
 
+Masked Arrays
+~~~~~~~~~~~~~
+
+.. autosummary::
+   ma.filled
+   ma.fix_invalid
+   ma.getdata
+   ma.getmaskarray
+   ma.masked_array
+   ma.masked_equal
+   ma.masked_greater
+   ma.masked_greater_equal
+   ma.masked_inside
+   ma.masked_invalid
+   ma.masked_less
+   ma.masked_less_equal
+   ma.masked_not_equal
+   ma.masked_outside
+   ma.masked_values
+   ma.masked_where
+   ma.set_fill_value
+
 Random
 ~~~~~~
 
@@ -457,6 +479,25 @@ Other functions
 .. autofunction:: svd
 .. autofunction:: svd_compressed
 .. autofunction:: tsqr
+
+.. currentmodule:: dask.array.ma
+.. autofunction:: filled
+.. autofunction:: fix_invalid
+.. autofunction:: getdata
+.. autofunction:: getmaskarray
+.. autofunction:: masked_array
+.. autofunction:: masked_equal
+.. autofunction:: masked_greater
+.. autofunction:: masked_greater_equal
+.. autofunction:: masked_inside
+.. autofunction:: masked_invalid
+.. autofunction:: masked_less
+.. autofunction:: masked_less_equal
+.. autofunction:: masked_not_equal
+.. autofunction:: masked_outside
+.. autofunction:: masked_values
+.. autofunction:: masked_where
+.. autofunction:: set_fill_value
 
 .. currentmodule:: dask.array.ghost
 

--- a/docs/source/array-sparse.rst
+++ b/docs/source/array-sparse.rst
@@ -55,18 +55,21 @@ following operations:
 
 1.  Simple slicing with slices, lists, and elements (for slicing, rechunking,
     reshaping, etc).
-2.  A ``concatenate`` function at the top level of the package (for assembling
-    results)
+2.  A ``concatenate`` function matching the interface of ``np.concatenate``.
+    This must be registered in ``dask.array.core.concatenate_lookup``.
 3.  All ufuncs must support the full ufunc interface, including ``dtype=`` and
     ``out=`` parameters (even if they don't function properly)
 4.  All reductions must support the full ``axis=`` and ``keepdims=`` keywords
     and behave like numpy in this respect
 5.  The array class should follow the ``__array_priority__`` protocol and be
     prepared to respond to other arrays of lower priority.
+6.  If ``dot`` support is desired, a ``tensordot`` function matching the
+    interface of ``np.tensordot`` should be registered in
+    ``dask.array.core.tensordot_lookup``.
 
-The implementation of other operations like tensordot, reshape, transpose, etc.
+The implementation of other operations like reshape, transpose, etc.
 should follow standard NumPy conventions regarding shape and dtype.  Not
-implementing these is fine; the parallel dask.array will err at runtime if
+implementing these is fine; the parallel ``dask.array`` will err at runtime if
 these operations are attempted.
 
 


### PR DESCRIPTION
Adds support for masked arrays, similar to how we support sparse arrays.

Supports:
- reductions (regular, cumulative, and arg)
- slicing
- dot
- concatenate
- ufuncs
- elementwise
- creation functions like `da.ma.masked_greater`
- accessor functions like `da.ma.getmaskarray`
- setting fill value with `da.ma.set_fill_value`

The last one is a little weird because it matches the numpy api of mutating the array instead of returning a new one. I figured it was better to match numpy here than to match dask, but could go either way.

Fixes #1928.

---

Note that this adds a type-level registry for package-level functions like `concatenate` and `tensordot` instead of using the `package_of` function from before. This is necessary because:
- `package_of` returns `np` for masked arrays
- No tensordot for masked_arrays
- `np.ma.concatenate` doesn't persist the `fill_value` of its inputs

I also think this is cleaner than relying on inspecting the object to find its module.
