### PR TITLE
Documentation for dev env is missing required dependencies

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -91,7 +91,8 @@ Install dask and dependencies::
 
 For development dask uses the following additional dependencies::
 
-   pip install pytest moto mock
+   pip install pytest moto mock partd sparse
+   conda install cloudpickle
 
 
 Run Tests


### PR DESCRIPTION
The required test env has apparently changed at some point and the docs were not updated. The tests now depend on `cloudpickly`, `partd` and `sparse` in addition to the packages already mentioned. This PR fixes adds those packages to the list of required ones.