### PR TITLE
Better scheduler errors

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -54,6 +54,11 @@ if PY3:
     def _getargspec(func):
         return inspect.getfullargspec(func)
 
+    def reraise(exc, tb=None):
+        if exc.__traceback__ is not tb:
+            raise exc.with_traceback(tb)
+        raise exc
+
 else:
     import __builtin__ as builtins
     from Queue import Queue, Empty
@@ -72,6 +77,16 @@ else:
     reduce = reduce
     operator_div = operator.div
     FileNotFoundError = IOError
+
+    def _make_reraise():
+        _code = ("def reraise(exc, tb=None):"
+                "    raise type(exc), exc, tb")
+        namespace = {}
+        exec("exec _code in namespace")
+        return namespace['reraise']
+
+    reraise = _make_reraise()
+    del _make_reraise
 
     def _getargspec(func):
         return inspect.getargspec(func)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -353,7 +353,7 @@ def test_categories(fn):
     cats_set = ddf2.map_partitions(lambda x: x.y.cat.categories).compute()
     assert cats_set.tolist() == ['a', 'c', 'a', 'b']
     assert_eq(ddf.y, ddf2.y, check_names=False)
-    with pytest.raises(dask.async.RemoteException):
+    with pytest.raises(TypeError):
         # attempt to load as category that which is not so encoded
         ddf2 = dd.read_parquet(fn, categories=['x']).compute()
 

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import multiprocessing
+import traceback
 import pickle
 import sys
 
@@ -34,6 +35,94 @@ _loads = pickle.loads
 
 def _process_get_id():
     return multiprocessing.current_process().ident
+
+
+# -- Remote Exception Handling --
+# By default, tracebacks can't be serialized using pickle. However, the
+# `tblib` library can enable support for this. Since we don't mandate
+# that tblib is installed, we do the following:
+#
+# - If tblib is installed, use it to serialize the traceback and reraise
+#   in the scheduler process
+# - Otherwise, use a ``RemoteException`` class to contain a serialized
+#   version of the formatted traceback, which will then print in the
+#   scheduler process.
+#
+# To enable testing of the ``RemoteException`` class even when tblib is
+# installed, we don't wrap the class in the try block below
+class RemoteException(Exception):
+    """ Remote Exception
+
+    Contains the exception and traceback from a remotely run task
+    """
+    def __init__(self, exception, traceback):
+        self.exception = exception
+        self.traceback = traceback
+
+    def __str__(self):
+        return (str(self.exception) + "\n\n"
+                "Traceback\n"
+                "---------\n" +
+                self.traceback)
+
+    def __dir__(self):
+        return sorted(set(dir(type(self)) +
+                      list(self.__dict__) +
+                      dir(self.exception)))
+
+    def __getattr__(self, key):
+        try:
+            return object.__getattribute__(self, key)
+        except AttributeError:
+            return getattr(self.exception, key)
+
+
+exceptions = dict()
+
+
+def remote_exception(exc, tb):
+    """ Metaclass that wraps exception type in RemoteException """
+    if type(exc) in exceptions:
+        typ = exceptions[type(exc)]
+        return typ(exc, tb)
+    else:
+        try:
+            typ = type(exc.__class__.__name__,
+                       (RemoteException, type(exc)),
+                       {'exception_type': type(exc)})
+            exceptions[type(exc)] = typ
+            return typ(exc, tb)
+        except TypeError:
+            return exc
+
+
+try:
+    import tblib.pickling_support
+    tblib.pickling_support.install()
+    from dask.compatibility import reraise
+
+    def _pack_traceback(tb):
+        return tb
+
+except ImportError:
+    def _pack_traceback(tb):
+        return ''.join(traceback.format_tb(tb))
+
+    def reraise(exc, tb):
+        exc = remote_exception(exc, tb)
+        raise exc
+
+
+def pack_exception(e, dumps):
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    tb = _pack_traceback(exc_traceback)
+    try:
+        result = dumps((e, tb))
+    except BaseException as e:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        tb = _pack_traceback(exc_traceback)
+        result = dumps((e, tb))
+    return result
 
 
 def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
@@ -83,8 +172,9 @@ def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
     try:
         # Run
         result = get_async(pool.apply_async, len(pool._pool), dsk3, keys,
-                           get_id=_process_get_id,
-                           dumps=dumps, loads=loads, **kwargs)
+                           get_id=_process_get_id, dumps=dumps, loads=loads,
+                           pack_exception=pack_exception,
+                           raise_exception=reraise, **kwargs)
     finally:
         if cleanup:
             pool.close()

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import dask
 
-from dask.async import (start_state_from_dask, get_sync, finish_task, sortkey,
-                        remote_exception)
+from dask.async import start_state_from_dask, get_sync, finish_task, sortkey
 from dask.order import order
 from dask.utils_test import GetFunctionTestMixin, inc, add
 
@@ -174,22 +173,9 @@ def test_exceptions_propagate():
         assert False
     except MyException as e:
         assert "My Exception!" in str(e)
-        assert "Traceback" in str(e)
         assert 'a' in dir(e)
-        assert 'traceback' in dir(e)
-        assert e.exception.a == 1 and e.exception.b == 2
-        assert e.a == 1 and e.b == 2
-
-
-def test_remote_exception():
-    e = TypeError("hello")
-    a = remote_exception(e, 'traceback')
-    b = remote_exception(e, 'traceback')
-
-    assert type(a) == type(b)
-    assert isinstance(a, TypeError)
-    assert 'hello' in str(a)
-    assert 'traceback' in str(a)
+        assert e.a == 1
+        assert e.b == 2
 
 
 def test_ordering():

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -9,7 +9,7 @@ import pytest
 
 from dask import compute, delayed
 from dask.context import set_options
-from dask.multiprocessing import get, _dumps, _loads
+from dask.multiprocessing import get, _dumps, _loads, remote_exception
 from dask.utils_test import inc
 
 
@@ -35,6 +35,18 @@ def test_errors_propagate():
     except Exception as e:
         assert isinstance(e, ValueError)
         assert "12345" in str(e)
+
+
+def test_remote_exception():
+    e = TypeError("hello")
+    a = remote_exception(e, 'traceback-body')
+    b = remote_exception(e, 'traceback-body')
+
+    assert type(a) == type(b)
+    assert isinstance(a, TypeError)
+    assert 'hello' in str(a)
+    assert 'Traceback' in str(a)
+    assert 'traceback-body' in str(a)
 
 
 def make_bad_result():

--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -5,6 +5,7 @@ See async.py
 """
 from __future__ import absolute_import, division, print_function
 
+import sys
 from collections import defaultdict
 from multiprocessing.pool import ThreadPool
 import threading
@@ -29,6 +30,10 @@ main_thread = current_thread()
 
 pools = defaultdict(dict)
 pools_lock = Lock()
+
+
+def pack_exception(e, dumps):
+    return e, sys.exc_info()[2]
 
 
 def get(dsk, result, cache=None, num_workers=None, **kwargs):
@@ -73,7 +78,7 @@ def get(dsk, result, cache=None, num_workers=None, **kwargs):
 
     results = get_async(pool.apply_async, len(pool._pool), dsk, result,
                         cache=cache, get_id=_thread_get_id,
-                        **kwargs)
+                        pack_exception=pack_exception, **kwargs)
 
     # Cleanup pools associated to dead threads
     with pools_lock:


### PR DESCRIPTION
Previously we used our own ``RemoteException`` class to show errors when
using the threaded/multiprocessing schedulers. This provided suboptimal
tracebacks, which made debugging harder. We now do the following:

- Synchronous scheduler: no change

- Threaded scheduler: reraise the error in the main process with the
  original traceback.

- Multiprocessing scheduler: If ``tblib`` is installed, use it to
  serialize the traceback, and then reraise the error in the main
  process with the original traceback. If it's not installed, fallback
  to the old ``RemoteException`` class.

A benefit of this approach is that now pdb plays nice with the threaded
scheduler, making debugging a lot easier.

Fixes #831, Fixes #2298