### PR TITLE
Check for tricky cases when fusing fancy indices

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
 from operator import getitem
-from itertools import zip_longest
 
 import numpy as np
 
 from .core import getarray, getarray_nofancy, getarray_inline
 from ..context import defer_to_globals
+from ..compatibility import zip_longest
 from ..core import flatten, reverse_dict
 from ..optimize import cull, fuse, inline_functions, dont_optimize
 from ..utils import ensure_dict

--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from operator import getitem
+from itertools import zip_longest
 
 import numpy as np
 
@@ -152,6 +153,20 @@ def normalize_slice(s):
     return slice(start, stop, step)
 
 
+def check_for_nonfusible_fancy_indexing(fancy, normal):
+    # Check for fancy indexing and normal indexing, where the fancy
+    # indexed dimensions != normal indexed dimensions with integers. E.g.:
+    # disallow things like:
+    # x[:, [1, 2], :][0, :, :] -> x[0, [1, 2], :] or
+    # x[0, :, :][:, [1, 2], :] -> x[0, [1, 2], :]
+    for f, n in zip_longest(fancy, normal, fillvalue=slice(None)):
+        if type(f) is not list and isinstance(n, int):
+            raise NotImplementedError("Can't handle normal indexing with "
+                                      "integers and fancy indexing if the "
+                                      "integers and fancy indices don't "
+                                      "align with the same dimensions.")
+
+
 def fuse_slice(a, b):
     """ Fuse stacked slices together
 
@@ -224,9 +239,15 @@ def fuse_slice(a, b):
     # and newaxes
     if isinstance(a, tuple) and isinstance(b, tuple):
 
-        if (any(isinstance(item, list) for item in a) and
-                any(isinstance(item, list) for item in b)):
+        # Check for non-fusible cases with fancy-indexing
+        a_has_lists = any(isinstance(item, list) for item in a)
+        b_has_lists = any(isinstance(item, list) for item in b)
+        if a_has_lists and b_has_lists:
             raise NotImplementedError("Can't handle multiple list indexing")
+        elif a_has_lists:
+            check_for_nonfusible_fancy_indexing(a, b)
+        elif b_has_lists:
+            check_for_nonfusible_fancy_indexing(b, a)
 
         j = 0
         result = list()


### PR DESCRIPTION
Previously we'd fuse normal and fancy indexing like:

```python
a[:, :, [0, 1], :][0, :, :, :] -> a[0, :, [0, 1], :]
```

This is incorrect, and was leading to bugs:

```python
>>> a = np.ones((11, 13, 20, 12))
>>> a[:, :, [0, 1], :][0, :, :, :].shape
(13, 2, 12)
>>> a[0, :, [0, 1], :].shape
(2, 13, 12)
```

Let `ind1` and `ind2` represent two index operations as in
`x[ind1][ind2]`. We now only fuse indices involving fancy indexing if:
- Only one of the two uses fancy indexing
- Dimensions where fancy indexing isn't used are non-integers

This means that the following will be fused:

```
a[:10, [1, 2, 3]][:5, 0]
```

but this won't:

```
a[:10, [1, 2, 3][0, 0]
```

This does exclude some valid cases, but is easier to write than
following all the checks required when mixing fancy and non-fancy
indexing.