### PR TITLE
More empty array work

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -208,6 +208,12 @@ def slice_wrap_lists(out_name, in_name, blockdims, index):
     where_list = [i for i, ind in enumerate(index) if isinstance(ind, list)]
     if len(where_list) > 1:
         raise NotImplementedError("Don't yet support nd fancy indexing")
+    # Is the single list an empty list? In this case just treat it as a zero
+    # length slice
+    if where_list and not index[where_list[0]]:
+        index2 = list(index2)
+        index2[where_list.pop()] = slice(0, 0, 1)
+        index2 = tuple(index2)
 
     # No lists, hooray! just use slice_slices_and_integers
     if not where_list:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1005,10 +1005,6 @@ def test_repr():
     assert str(d.dtype) in repr(d)
     d = da.ones((4000, 4), chunks=(4, 2))
     assert len(str(d)) < 1000
-    # Empty array
-    d = da.Array({}, 'd', ((), (3, 4)), dtype='i8')
-    assert str(d.shape) in repr(d)
-    assert str(d.dtype) in repr(d)
 
 
 def test_slicing_with_ellipsis():
@@ -2917,15 +2913,15 @@ def test_zero_sized_array_rechunk():
 def test_atop_zero_shape():
     da.atop(lambda x: x, 'i',
             da.arange(10, chunks=10), 'i',
-            da.from_array(np.ones((0, 2)), ((), 2)), 'ab',
-            da.from_array(np.ones((0,)), ((),)), 'a',
+            da.from_array(np.ones((0, 2)), ((0,), 2)), 'ab',
+            da.from_array(np.ones((0,)), ((0,),)), 'a',
             dtype='float64')
 
 
 def test_atop_zero_shape_new_axes():
     da.atop(lambda x: np.ones(42), 'i',
-            da.from_array(np.ones((0, 2)), ((), 2)), 'ab',
-            da.from_array(np.ones((0,)), ((),)), 'a',
+            da.from_array(np.ones((0, 2)), ((0,), 2)), 'ab',
+            da.from_array(np.ones((0,)), ((0,),)), 'a',
             dtype='float64', new_axes={'i': 42})
 
 

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -300,6 +300,19 @@ def test_reduction_on_scalar():
     assert (x == x).all()
 
 
+def test_reductions_with_empty_array():
+    dx1 = da.ones((10, 0, 5), chunks=4)
+    x1 = dx1.compute()
+    dx2 = da.ones((0, 0, 0), chunks=4)
+    x2 = dx2.compute()
+
+    for dx, x in [(dx1, x1), (dx2, x2)]:
+        assert_eq(dx.mean(), x.mean())
+        assert_eq(dx.mean(axis=0), x.mean(axis=0))
+        assert_eq(dx.mean(axis=1), x.mean(axis=1))
+        assert_eq(dx.mean(axis=2), x.mean(axis=2))
+
+
 def assert_max_deps(x, n, eq=True):
     dependencies, dependents = get_deps(x.dask)
     if eq:

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -420,6 +420,15 @@ def test_multiple_list_slicing():
     assert_eq(x[:, [0, 1, 2]][[0, 1]], a[:, [0, 1, 2]][[0, 1]])
 
 
+def test_empty_list():
+    x = np.ones((5, 5, 5), dtype='i4')
+    dx = da.from_array(x, chunks=2)
+
+    assert_eq(dx[[], :3, :2], x[[], :3, :2])
+    assert_eq(dx[:3, [], :2], x[:3, [], :2])
+    assert_eq(dx[:3, :2, []], x[:3, :2, []])
+
+
 def test_uneven_chunks():
     assert da.ones(20, chunks=5)[::2].chunks == ((3, 2, 3, 2),)
 


### PR DESCRIPTION
This contains a few fixes/tests for arrays with 0-length in certain dimensions.

- Forbid chunks with empty tuples in them. Previously this was used in certain places to indicate chunks with zero-length in that dimension. This was inconsistent with how chunks was used elsewhere, and was leading to bugs. We now enforce that all dimensions in chunks have at-least 1 element.
- Fix a bug in indexing with an empty list. Previously this would return graphs with an empty tuple along a single dimension, breaking the rule above. To fix this, we rewrite `x[[]]` to `x[:0]` when we find it. This is fine as long as we only accept a single list (which is all we currently support), but would be incorrect if full fancy-indexing was ever implemented. This was the easiest way to get a fix though.
- Add a test for reductions on arrays with zero-length along certain dimensions.