### PR TITLE
Slicing with negative index in list

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -709,7 +709,7 @@ def check_index(ind, dimension):
     """
     if isinstance(ind, list):
         x = np.array(ind)
-        if (x >= dimension).any() or (x <= -dimension).any():
+        if (x >= dimension).any() or (x < -dimension).any():
             raise IndexError("Index out of bounds %s" % dimension)
     elif isinstance(ind, slice):
         return

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -549,3 +549,9 @@ def test_None_overlap_int():
 
 def test_negative_n_slicing():
     assert_eq(da.ones(2, chunks=2)[-2], np.ones(2)[-2])
+
+
+def test_negative_list_slicing():
+    x = np.arange(5)
+    dx = da.from_array(x, chunks=2)
+    assert_eq(dx[[0, -5]], x[[0, -5]])

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -555,3 +555,4 @@ def test_negative_list_slicing():
     x = np.arange(5)
     dx = da.from_array(x, chunks=2)
     assert_eq(dx[[0, -5]], x[[0, -5]])
+    assert_eq(dx[[4, -1]], x[[4, -1]])


### PR DESCRIPTION
There was a bug in `check_index` where we weren't properly checking that
a negative list index was still in-bounds. This fixes that.

Fixes #2180.