### PR TITLE
Add fftfreq

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from functools import wraps
 import inspect
 
 import numpy as np
@@ -9,6 +10,9 @@ try:
     import scipy.fftpack
 except ImportError:
     scipy = None
+
+from .creation import linspace as _linspace
+from .core import concatenate as _concatenate
 
 
 chunk_error = ("Dask array only supports taking an FFT along an axis that \n"
@@ -211,3 +215,15 @@ irfft2 = fft_wrap(np.fft.irfft2, dtype=np.float_)
 irfftn = fft_wrap(np.fft.irfftn, dtype=np.float_)
 hfft = fft_wrap(np.fft.hfft, dtype=np.float_)
 ihfft = fft_wrap(np.fft.ihfft, dtype=np.complex_)
+
+
+@wraps(np.fft.fftfreq)
+def fftfreq(n, d=1.0, chunks=None):
+    n_1 = n + 1
+    n_2 = n_1 // 2
+
+    l = _linspace(0, 1, n_1, chunks=chunks)
+    r = _concatenate([l[:n_2], l[n_2:-1] - 1])
+    r /= d
+
+    return r

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -195,3 +195,9 @@ def test_wrap_fftns(modname, funcname, dtype):
         wfunc(darr2c, (darr2c.shape[0] - 1, darr2c.shape[1] - 1), (0, 1)),
         func(nparrc, (nparrc.shape[0] - 1, nparrc.shape[1] - 1), (0, 1))
     )
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 6, 7])
+@pytest.mark.parametrize("d", [1.0, 0.5, 2 * np.pi])
+def test_fftfreq(n, d):
+    assert_eq(da.fft.fftfreq(n, d, chunks=n), np.fft.fftfreq(n, d))


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2319

Adds an implementation of [`fftfreq`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.fft.fftfreq.html ) using Dask Arrays to the `fft` module. Tests it to make sure it has the same behavior as the NumPy function over a range of different parameters.

cc @jcrist