### PR TITLE
Add fftshift/ifftshift

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import collections
 from functools import wraps
 import inspect
 
@@ -227,3 +228,28 @@ def fftfreq(n, d=1.0, chunks=None):
     r /= d
 
     return r
+
+
+@wraps(np.fft.fftshift)
+def fftshift(x, axes=None):
+    if axes is None:
+        axes = list(range(x.ndim))
+    elif not isinstance(axes, collections.Sequence):
+        axes = (axes,)
+
+    y = x
+    for i in axes:
+        n = y.shape[i]
+        n_2 = (n + 1) // 2
+
+        l = y.ndim * [slice(None)]
+        l[i] = slice(None, n_2)
+        l = tuple(l)
+
+        r = y.ndim * [slice(None)]
+        r[i] = slice(n_2, None)
+        r = tuple(r)
+
+        y = _concatenate([y[r], y[l]], axis=i)
+
+    return y

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -253,3 +253,28 @@ def fftshift(x, axes=None):
         y = _concatenate([y[r], y[l]], axis=i)
 
     return y
+
+
+@wraps(np.fft.ifftshift)
+def ifftshift(x, axes=None):
+    if axes is None:
+        axes = list(range(x.ndim))
+    elif not isinstance(axes, collections.Sequence):
+        axes = (axes,)
+
+    y = x
+    for i in axes:
+        n = y.shape[i]
+        n_2 = n // 2
+
+        l = y.ndim * [slice(None)]
+        l[i] = slice(None, n_2)
+        l = tuple(l)
+
+        r = y.ndim * [slice(None)]
+        r[i] = slice(n_2, None)
+        r = tuple(r)
+
+        y = _concatenate([y[r], y[l]], axis=i)
+
+    return y

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -231,7 +231,7 @@ def fftfreq(n, d=1.0, chunks=None):
 
 
 @wraps(np.fft.fftshift)
-def fftshift(x, axes=None):
+def _fftshift_helper(x, axes=None, inverse=False):
     if axes is None:
         axes = list(range(x.ndim))
     elif not isinstance(axes, collections.Sequence):
@@ -240,7 +240,7 @@ def fftshift(x, axes=None):
     y = x
     for i in axes:
         n = y.shape[i]
-        n_2 = (n + 1) // 2
+        n_2 = (n + int(inverse is False)) // 2
 
         l = y.ndim * [slice(None)]
         l[i] = slice(None, n_2)
@@ -253,28 +253,13 @@ def fftshift(x, axes=None):
         y = _concatenate([y[r], y[l]], axis=i)
 
     return y
+
+
+@wraps(np.fft.fftshift)
+def fftshift(x, axes=None):
+    return _fftshift_helper(x, axes=axes, inverse=False)
 
 
 @wraps(np.fft.ifftshift)
 def ifftshift(x, axes=None):
-    if axes is None:
-        axes = list(range(x.ndim))
-    elif not isinstance(axes, collections.Sequence):
-        axes = (axes,)
-
-    y = x
-    for i in axes:
-        n = y.shape[i]
-        n_2 = n // 2
-
-        l = y.ndim * [slice(None)]
-        l[i] = slice(None, n_2)
-        l = tuple(l)
-
-        r = y.ndim * [slice(None)]
-        r[i] = slice(n_2, None)
-        r = tuple(r)
-
-        y = _concatenate([y[r], y[l]], axis=i)
-
-    return y
+    return _fftshift_helper(x, axes=axes, inverse=True)

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -201,3 +201,25 @@ def test_wrap_fftns(modname, funcname, dtype):
 @pytest.mark.parametrize("d", [1.0, 0.5, 2 * np.pi])
 def test_fftfreq(n, d):
     assert_eq(da.fft.fftfreq(n, d, chunks=n), np.fft.fftfreq(n, d))
+
+
+@pytest.mark.parametrize("funcname", ["fftshift", "ifftshift"])
+@pytest.mark.parametrize("axes", [
+    None,
+    0,
+    1,
+    2,
+    (0, 1),
+    (1, 2),
+    (0, 2),
+    (0, 1, 2),
+])
+def test_fftshift(funcname, axes):
+    np_func = getattr(np.fft, funcname)
+    da_func = getattr(da.fft, funcname)
+
+    s = (5, 6, 7)
+    a = np.arange(np.prod(s)).reshape(s)
+    d = da.from_array(a, chunks=(2, 3, 4))
+
+    assert_eq(da_func(d, axes), np_func(a, axes))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -223,3 +223,28 @@ def test_fftshift(funcname, axes):
     d = da.from_array(a, chunks=(2, 3, 4))
 
     assert_eq(da_func(d, axes), np_func(a, axes))
+
+
+@pytest.mark.parametrize("funcname1, funcname2", [
+    ("fftshift", "ifftshift"),
+    ("ifftshift", "fftshift"),
+])
+@pytest.mark.parametrize("axes", [
+    None,
+    0,
+    1,
+    2,
+    (0, 1),
+    (1, 2),
+    (0, 2),
+    (0, 1, 2),
+])
+def test_fftshift_identity(funcname1, funcname2, axes):
+    da_func1 = getattr(da.fft, funcname1)
+    da_func2 = getattr(da.fft, funcname2)
+
+    s = (5, 6, 7)
+    a = np.arange(np.prod(s)).reshape(s)
+    d = da.from_array(a, chunks=(2, 3, 4))
+
+    assert_eq(d, da_func1(da_func2(d, axes), axes))


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2124

Adds equivalents of NumPy's [`fftshift`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.fft.fftshift.html ) and [`ifftshift`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.fft.ifftshift.html ) functions for Dask Arrays. Also includes tests to ensure that the results with Dask are equivalent to those with NumPy. Further add some identity tests to ensure that applying `fftshift` and then `ifftshift` or vice versa return the original array unchanged.