### PR TITLE
Add rfftfreq

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -230,6 +230,18 @@ def fftfreq(n, d=1.0, chunks=None):
     return r
 
 
+@wraps(np.fft.rfftfreq)
+def rfftfreq(n, d=1.0, chunks=None):
+    n_1 = n + 1
+    n_2 = n // 2 + 1
+
+    l = _linspace(0, 1, n_1, chunks=chunks)
+    r = l[:n_2]
+    r /= d
+
+    return r
+
+
 @wraps(np.fft.fftshift)
 def _fftshift_helper(x, axes=None, inverse=False):
     if axes is None:

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -218,28 +218,29 @@ hfft = fft_wrap(np.fft.hfft, dtype=np.float_)
 ihfft = fft_wrap(np.fft.ihfft, dtype=np.complex_)
 
 
-@wraps(np.fft.fftfreq)
-def fftfreq(n, d=1.0, chunks=None):
-    n_1 = n + 1
-    n_2 = n_1 // 2
+def _fftfreq_helper(n, d=1.0, chunks=None, real=False):
+    r = _linspace(0, 1, n + 1, chunks=chunks)
 
-    l = _linspace(0, 1, n_1, chunks=chunks)
-    r = _concatenate([l[:n_2], l[n_2:-1] - 1])
+    if real:
+        n_2 = n // 2 + 1
+        r = r[:n_2]
+    else:
+        n_2 = (n + 1) // 2
+        r = _concatenate([r[:n_2], r[n_2:-1] - 1])
+
     r /= d
 
     return r
+
+
+@wraps(np.fft.fftfreq)
+def fftfreq(n, d=1.0, chunks=None):
+    return _fftfreq_helper(n, d=d, chunks=chunks, real=False)
 
 
 @wraps(np.fft.rfftfreq)
 def rfftfreq(n, d=1.0, chunks=None):
-    n_1 = n + 1
-    n_2 = n // 2 + 1
-
-    l = _linspace(0, 1, n_1, chunks=chunks)
-    r = l[:n_2]
-    r /= d
-
-    return r
+    return _fftfreq_helper(n, d=d, chunks=chunks, real=True)
 
 
 @wraps(np.fft.fftshift)

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -197,10 +197,14 @@ def test_wrap_fftns(modname, funcname, dtype):
     )
 
 
+@pytest.mark.parametrize("funcname", ["fftfreq", "rfftfreq"])
 @pytest.mark.parametrize("n", [1, 2, 3, 6, 7])
 @pytest.mark.parametrize("d", [1.0, 0.5, 2 * np.pi])
-def test_fftfreq(n, d):
-    assert_eq(da.fft.fftfreq(n, d, chunks=n), np.fft.fftfreq(n, d))
+def test_fftfreq(funcname, n, d):
+    np_func = getattr(np.fft, funcname)
+    da_func = getattr(da.fft, funcname)
+
+    assert_eq(da_func(n, d, chunks=n), np_func(n, d))
 
 
 @pytest.mark.parametrize("funcname", ["fftshift", "ifftshift"])


### PR DESCRIPTION
Adds an implementation of [`rfftfreq`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.fft.rfftfreq.html ) using Dask Arrays to the `fft` module. Tests it to make sure it has the same behavior as the NumPy function over a range of different parameters by reusing the `fftfreq` tests for the `rfftfreq` as the two functions share much in common. Also refactor a helper function for both cases to keep things maintainable.