### PR TITLE
Drop unneeded wraps decorator

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -243,7 +243,6 @@ def rfftfreq(n, d=1.0, chunks=None):
     return _fftfreq_helper(n, d=d, chunks=chunks, real=True)
 
 
-@wraps(np.fft.fftshift)
 def _fftshift_helper(x, axes=None, inverse=False):
     if axes is None:
         axes = list(range(x.ndim))


### PR DESCRIPTION
This is a private helper function that is not really wrapping anything. So it does not need the `wraps` decorator. Hence its proposed removal.