### PR TITLE
Add new FFT functions to the API documentation

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -160,6 +160,10 @@ Fast Fourier Transforms
    fft.irfftn
    fft.hfft
    fft.ihfft
+   fft.fftfreq
+   fft.rfftfreq
+   fft.fftshift
+   fft.ifftshift
 
 Linear Algebra
 ~~~~~~~~~~~~~~
@@ -444,6 +448,10 @@ Other functions
 .. autofunction:: irfftn
 .. autofunction:: hfft
 .. autofunction:: ihfft
+.. autofunction:: fftfreq
+.. autofunction:: rfftfreq
+.. autofunction:: fftshift
+.. autofunction:: ifftshift
 
 .. currentmodule:: dask.array.random
 


### PR DESCRIPTION
Adds `fftfreq`, `rfftfreq`, `fftshift`, and `ifftshift` to the Dask Array's API documentation of the `fft` module.

Note: Went ahead and skipped CI as this is a doc only change. Hope that is ok. Can enable it again if needed.