### PR TITLE
Handle extra chunks in *fftfreq functions

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -13,7 +13,10 @@ except ImportError:
     scipy = None
 
 from .creation import linspace as _linspace
-from .core import concatenate as _concatenate
+from .core import (
+    concatenate as _concatenate,
+    normalize_chunks as _normalize_chunks,
+)
 
 
 chunk_error = ("Dask array only supports taking an FFT along an axis that \n"
@@ -219,7 +222,15 @@ ihfft = fft_wrap(np.fft.ihfft, dtype=np.complex_)
 
 
 def _fftfreq_helper(n, d=1.0, chunks=None, real=False):
-    r = _linspace(0, 1, n + 1, chunks=chunks)
+    n = int(n)
+
+    l = n + 1
+    s = n // 2 + 1 if real else n
+    t = l - s
+
+    chunks = _normalize_chunks(chunks, (s,))[0] + (t,)
+
+    r = _linspace(0, 1, l, chunks=chunks)
 
     if real:
         n_2 = n // 2 + 1

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -197,14 +197,18 @@ def test_wrap_fftns(modname, funcname, dtype):
     )
 
 
-@pytest.mark.parametrize("funcname", ["fftfreq", "rfftfreq"])
 @pytest.mark.parametrize("n", [1, 2, 3, 6, 7])
 @pytest.mark.parametrize("d", [1.0, 0.5, 2 * np.pi])
-def test_fftfreq(funcname, n, d):
-    np_func = getattr(np.fft, funcname)
-    da_func = getattr(da.fft, funcname)
+def test_fftfreq(n, d):
+    assert_eq(da.fft.fftfreq(n, d, chunks=((n,),)), np.fft.fftfreq(n, d))
 
-    assert_eq(da_func(n, d, chunks=n), np_func(n, d))
+
+@pytest.mark.parametrize("n", [1, 2, 3, 6, 7])
+@pytest.mark.parametrize("d", [1.0, 0.5, 2 * np.pi])
+def test_rfftfreq(n, d):
+    assert_eq(
+        da.fft.rfftfreq(n, d, chunks=((n // 2 + 1,),)), np.fft.rfftfreq(n, d)
+    )
 
 
 @pytest.mark.parametrize("funcname", ["fftshift", "ifftshift"])

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -199,15 +199,19 @@ def test_wrap_fftns(modname, funcname, dtype):
 
 @pytest.mark.parametrize("n", [1, 2, 3, 6, 7])
 @pytest.mark.parametrize("d", [1.0, 0.5, 2 * np.pi])
-def test_fftfreq(n, d):
-    assert_eq(da.fft.fftfreq(n, d, chunks=((n,),)), np.fft.fftfreq(n, d))
+@pytest.mark.parametrize("c", [lambda m: m, lambda m: (1, m - 1)])
+def test_fftfreq(n, d, c):
+    c = c(n)
+    assert_eq(da.fft.fftfreq(n, d, chunks=c), np.fft.fftfreq(n, d))
 
 
 @pytest.mark.parametrize("n", [1, 2, 3, 6, 7])
 @pytest.mark.parametrize("d", [1.0, 0.5, 2 * np.pi])
-def test_rfftfreq(n, d):
+@pytest.mark.parametrize("c", [lambda m: m // 2 + 1, lambda m: (1, m // 2)])
+def test_rfftfreq(n, d, c):
+    c = c(n)
     assert_eq(
-        da.fft.rfftfreq(n, d, chunks=((n // 2 + 1,),)), np.fft.rfftfreq(n, d)
+        da.fft.rfftfreq(n, d, chunks=c), np.fft.rfftfreq(n, d)
     )
 
 


### PR DESCRIPTION
As we end up needing getting more values from `linspace` than we use, we can't get away with just passing `chunks` to `linspace` directly. Instead we tack on some additional chunks to those that the user specified to fill the gap. This gets the `chunks` to the right length for `linspace`, but still preserves the user's intent.

In the `fftfreq` and `ifftfreq`, this amounts to tacking on a singleton chunk at the end. As for `rfftfreq`, this amounts to tacking on another chunk that is the other half of what will be requested.