### PR TITLE
ERR: Better error message describe with non-numeric data

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1304,6 +1304,8 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
     def describe(self, split_every=False):
         # currently, only numeric describe is supported
         num = self._get_numeric_data()
+        if num.columns.empty:
+            raise ValueError("DataFrame contains only non-numeric data.")
 
         stats = [num.count(split_every=split_every),
                  num.mean(split_every=split_every),

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1304,8 +1304,10 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
     def describe(self, split_every=False):
         # currently, only numeric describe is supported
         num = self._get_numeric_data()
-        if num.columns.empty:
+        if self.ndim == 2 and len(num.columns) == 0:
             raise ValueError("DataFrame contains only non-numeric data.")
+        elif self.ndim == 1 and self.dtype == 'object':
+            raise ValueError("Cannot compute ``describe`` on object dtype.")
 
         stats = [num.count(split_every=split_every),
                  num.mean(split_every=split_every),

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -261,6 +261,11 @@ def test_describe_empty():
         ddf.describe()
     assert rec.match('DataFrame contains only non-numeric data.')
 
+    with pytest.raises(ValueError) as rec:
+        ddf.A.describe()
+    assert rec.match('Cannot compute ``describe`` on object dtype.')
+
+
 
 def test_cumulative():
     df = pd.DataFrame(np.random.randn(100, 5), columns=list('abcde'))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -254,6 +254,14 @@ def test_describe():
     assert_eq(df.describe(), ddf.describe(split_every=2))
 
 
+def test_describe_empty():
+    # https://github.com/dask/dask/issues/2326
+    ddf = dd.from_pandas(pd.DataFrame({"A": ['a', 'b']}), 2)
+    with pytest.raises(ValueError) as rec:
+        ddf.describe()
+    assert rec.match('DataFrame contains only non-numeric data.')
+
+
 def test_cumulative():
     df = pd.DataFrame(np.random.randn(100, 5), columns=list('abcde'))
     ddf = dd.from_pandas(df, 5)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -266,7 +266,6 @@ def test_describe_empty():
     assert rec.match('Cannot compute ``describe`` on object dtype.')
 
 
-
 def test_cumulative():
     df = pd.DataFrame(np.random.randn(100, 5), columns=list('abcde'))
     ddf = dd.from_pandas(df, 5)


### PR DESCRIPTION
Closes #2326 

The other option is to return an empty dataframe. I think most users would prefer an exception though.