### PR TITLE
Add docstring for getarray_inline

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -72,12 +72,30 @@ def getarray_nofancy(a, b, lock=None):
     """ A simple wrapper around ``getarray``.
 
     Used to indicate to the optimization passes that the backend doesn't
-    support "fancy indexing"
+    support fancy indexing.
     """
     return getarray(a, b, lock=lock)
 
 
 def getarray_inline(a, b, lock=None):
+    """ A getarray function that optimizations feel comfortable inlining
+
+    Slicing operations with this function may be inlined into a graph, such as
+    in the following rewrite
+
+    **Before**
+
+    >>> a = x[:10]  # doctest: +SKIP
+    >>> b = a + 1  # doctest: +SKIP
+    >>> c = a * 2  # doctest: +SKIP
+
+    **After**
+
+    >>> b = x[:10] + 1  # doctest: +SKIP
+    >>> c = x[:10] * 2  # doctest: +SKIP
+
+    This inlining can be relevant to operations when running off of disk.
+    """
     return getarray(a, b, lock=lock)
 
 


### PR DESCRIPTION
Relatedly I noticed that no tests fail if we remove this function entirely.  

It would be good to verify the use of inlining getitem calls with a small test or remove this function.  @shoyer I suspect that this was originally intended for single-machine xarray use, but am unable to recall exactly.  Do you have any insight here?