### PR TITLE
Remove conda-forge from default install instructions

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -6,11 +6,11 @@ You can install dask with ``conda``, with ``pip``, or by installing from source.
 Conda
 -----
 
-To install the latest version of Dask from the
-`conda-forge <https://conda-forge.github.io/>`_ repository using
+Binary Dask packages are maintained on both the ``defaults`` and `conda-forge
+<https://conda-forge.github.io/>`_ channels.  You can install them using
 `conda <https://www.continuum.io/downloads>`_::
 
-    conda install dask -c conda-forge
+    conda install dask
 
 This installs dask and all common dependencies, including Pandas and NumPy.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -3,16 +3,24 @@ Install Dask
 
 You can install dask with ``conda``, with ``pip``, or by installing from source.
 
+Anaconda
+--------
+
+
 Conda
 -----
 
-Binary Dask packages are maintained on both the ``defaults`` and `conda-forge
-<https://conda-forge.github.io/>`_ channels.  You can install them using
-`conda <https://www.continuum.io/downloads>`_::
+Dask is installed by default in `Anaconda <https://www.continuum.io/downloads>`_::
+
+You can update Dask using `conda <https://www.continuum.io/downloads>`_::
 
     conda install dask
 
-This installs dask and all common dependencies, including Pandas and NumPy.
+This installs Dask and all common dependencies, including Pandas and NumPy.
+
+Dask packages are maintained both on the default channel and on and
+`conda-forge <https://conda-forge.github.io/>`_.
+
 
 Pip
 ---


### PR DESCRIPTION
Apparently people were confused by this, and thought that Dask was only
maintained on the conda-forge channel.  We change installation
instructions to explicitly state that Dask is available on either
defaults or conda-forge.  This removes the `-c conda-forge` flag from
the conda install line.