### PR TITLE
Add `db.map`, `Bag.starmap`, fix `Bag.map`

### DIFF
--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 from .core import (Bag, Item, from_sequence, from_url, to_textfiles, concat,
-                   from_delayed, bag_range as range, bag_zip as zip)
+                   from_delayed, bag_range as range, bag_zip as zip,
+                   bag_map as map)
 from .text import read_text
 from ..context import set_options
 from ..base import compute

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -440,7 +440,7 @@ class Bag(Base):
         >>> b.map(myadd, b.max()).compute()
         [4, 5, 6, 7, 8]
         """
-        if takes_multiple_arguments(func) and not args:
+        if takes_multiple_arguments(func, varargs=False) and not args:
             warn("Automatic 'splatting' of arguments in `Bag.map` is "
                  "deprecated and will be removed in a future release. "
                  "Please use `Bag.starmap` instead.")

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1587,7 +1587,7 @@ def map_chunk(f, args, bag_kwargs, kwargs):
         f = partial(f, **kwargs)
 
     args = [iter(a) for a in args]
-    iters = args.copy()
+    iters = list(args)
     if bag_kwargs:
         keys = list(bag_kwargs)
         kw_val_iters = [iter(v) for v in bag_kwargs.values()]

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -176,9 +176,16 @@ def test_map_method():
     assert (b.map(myadd, b.sum(), c=10).compute() ==
             [myadd(i, x_sum, 10) for i in x])
 
-    # check that works with multiarg functions. Can be removed after deprecated
-    # behavior is removed
+    # check that map works with multiarg functions. Can be removed after
+    # deprecated behavior is removed
     assert b.map(add, b2).compute() == list(map(add, x, x2))
+
+    # check that map works with vararg functions. Can be removed after
+    # deprecated behavior is removed
+    def vararg_inc(*args):
+        return inc(*args)
+
+    assert b.map(vararg_inc).compute(get=dask.get) == list(map(inc, x))
 
 
 def test_starmap():

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -150,6 +150,20 @@ def test_bag_map():
         db.map(myadd, b.sum(), 1, 2)
 
 
+def test_starmap():
+    data = [(1, 2), (3, 4), (5, 6), (7, 8), (9, 10)]
+    b = db.from_sequence(data, npartitions=2)
+
+    def myadd(a, b, c=0):
+        return a + b + c
+
+    assert b.starmap(myadd).compute() == [myadd(*a) for a in data]
+    assert b.starmap(myadd, c=10).compute() == [myadd(*a, c=10) for a in data]
+    max_second = b.pluck(1).max()
+    assert (b.starmap(myadd, c=max_second).compute() ==
+            [myadd(*a, c=max_second.compute()) for a in data])
+
+
 def test_filter():
     c = b.filter(iseven)
     expected = merge(dsk, dict(((c.name, i),

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -156,6 +156,13 @@ def test_bag_map():
     with pytest.raises(ValueError):
         db.map(myadd, b.sum(), 1, 2)
 
+    # Unequal partitioning
+    unequal = db.from_sequence(range(110), npartitions=10)
+    with pytest.raises(ValueError):
+        db.map(myadd, b, unequal, c=b2).compute()
+    with pytest.raises(ValueError):
+        db.map(myadd, b, b=unequal, c=b2).compute()
+
 
 def test_map_method():
     b = db.from_sequence(range(100), npartitions=10)

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -68,6 +68,17 @@ def test_takes_multiple_arguments():
     assert not takes_multiple_arguments(Singular)
     assert takes_multiple_arguments(Multi)
 
+    def f():
+        pass
+
+    assert not takes_multiple_arguments(f)
+
+    def vararg(*args):
+        pass
+
+    assert takes_multiple_arguments(vararg)
+    assert not takes_multiple_arguments(vararg, varargs=False)
+
 
 def test_dispatch():
     foo = Dispatch()

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -494,7 +494,7 @@ MULTI_ARITY_BUILTINS = set([compile, delattr, divmod, filter, getattr, hasattr,
                             isinstance, issubclass, map, pow, setattr])
 
 
-def takes_multiple_arguments(func):
+def takes_multiple_arguments(func, varargs=True):
     """ Does this function take multiple arguments?
 
     >>> def f(x, y): pass
@@ -534,12 +534,11 @@ def takes_multiple_arguments(func):
     except:
         is_constructor = False
 
-    if spec.varargs:
+    if varargs and spec.varargs:
         return True
 
-    if spec.defaults is None:
-        return len(spec.args) - is_constructor != 1
-    return len(spec.args) - len(spec.defaults) - is_constructor > 1
+    ndefaults = 0 if spec.defaults is None else len(spec.defaults)
+    return len(spec.args) - ndefaults - is_constructor > 1
 
 
 class Dispatch(object):

--- a/docs/source/bag-api.rst
+++ b/docs/source/bag-api.rst
@@ -30,6 +30,7 @@ Top level user functions:
     Bag.random_sample
     Bag.remove
     Bag.repartition
+    Bag.starmap
     Bag.std
     Bag.sum
     Bag.take
@@ -50,6 +51,7 @@ Create Bags
    from_url
    range
    concat
+   map
    zip
 
 Turn Bags into other things
@@ -74,4 +76,5 @@ Other functions
 .. autofunction:: from_url
 .. autofunction:: range
 .. autofunction:: concat
+.. autofunction:: map
 .. autofunction:: zip


### PR DESCRIPTION
- Implement `db.map`, a mapping function that has the same semantics as
`builtins.map`, with the following extensions:
  - Supports keyword arguments
  - Non-bag arguments are "broadcast" across all function calls

- Implement `db.Bag.starmap`. This is similar to `itertools.starmap`, except it also supports keyword arguments.

- Deprecate magic splatting behavior in `db.Bag.map`, pointing users to use `db.Bag.starmap` instead.

- Add support for positional arguments to `db.Bag.map` (just calls `db.map`).

Fixes #2332
Fixes #1906 
Fixes #1572
