### PR TITLE
Generate stable hashes for numpy ufuncs

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -401,6 +401,15 @@ def register_numpy():
     normalize_token.register(np.dtype, repr)
     normalize_token.register(np.generic, repr)
 
+    @normalize_token.register(np.ufunc)
+    def normalize_ufunc(x):
+        try:
+            name = x.__name__
+            if getattr(np, name) is x:
+                return 'np.' + name
+        except:
+            return normalize_function(x)
+
 
 def tokenize(*args, **kwargs):
     """ Deterministic token

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -155,6 +155,17 @@ def test_tokenize_numpy_memmap_no_filename():
         assert tokenize(b) == tokenize(b)
 
 
+@pytest.mark.skipif('not np')
+def test_tokenize_numpy_ufunc_consistent():
+    assert tokenize(np.sin) == '02106e2c67daf452fb480d264e0dac21'
+    assert tokenize(np.cos) == 'c99e52e912e4379882a9a4b387957a0b'
+
+    # Make a ufunc that isn't in the numpy namespace. Similar to
+    # any found in other packages.
+    inc = np.frompyfunc(lambda x: x + 1, 1, 1)
+    assert tokenize(inc) == tokenize(inc)
+
+
 def test_normalize_base():
     for i in [1, 1.1, '1', slice(1, 2, 3)]:
         assert normalize_token(i) is i


### PR DESCRIPTION
Due to non-deterministic behavior in how numpy pickles ufuncs,
`tokenize(ufunc)` would result in different hashes each run. They would
be consistent during a single run however, so this wouldn't result in
incorrect behavior, just possibly prevent sharing results between
different clients.

This adds a `normalize_token` implementation for `np.ufunc` that
provides consistent hashes for ufuncs defined in `numpy` only. Other
ufuncs will still fall back to the old behavior (which as stated above
isn't incorrect, just non-optimal).

Fixes #2341.