### PR TITLE
WIP: Add user defined aggregations

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from .core import (DataFrame, Series, Index, _Frame, map_partitions,
                    repartition, to_delayed, to_datetime, to_timedelta)
+from .groupby import Aggregation
 from .io import (from_array, from_pandas, from_bcolz,
                  from_dask_array, read_hdf, read_sql_table,
                  from_delayed, read_csv, to_csv, read_table,

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import collections
 import itertools as it
+import operator
 import warnings
 
 import numpy as np

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -169,7 +169,7 @@ class Aggregation(object):
 
     Parameters
     ----------
-    name:str
+    name: str
         the name of the aggregation. It should be unique, since intermediate
         result will be identified by this name.
 
@@ -178,13 +178,13 @@ class Aggregation(object):
         partition. It can either return a single series or a tuple of series.
         The index has to be equal to the groups.
 
-    :agg: callable
+    agg: callable
         a function that will be called to aggregate the results of each chunk.
         Again the argument(s) will be grouped series. If ``chunk`` returned a
         tuple, ``agg`` will be called with all of them as individual positional
         arguments.
 
-    :finalize: callable
+    finalize: callable
         an optional finalizer that will be called with the results from the
         aggregation.
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -170,26 +170,26 @@ class Aggregation(object):
 
     Parameters
     ----------
-    name: str
+    name : str
         the name of the aggregation. It should be unique, since intermediate
         result will be identified by this name.
-
-    chunk: callable
+    chunk : callable
         a function that will be called with the grouped column of each
         partition. It can either return a single series or a tuple of series.
         The index has to be equal to the groups.
-
-    agg: callable
+    agg : callable
         a function that will be called to aggregate the results of each chunk.
         Again the argument(s) will be grouped series. If ``chunk`` returned a
         tuple, ``agg`` will be called with all of them as individual positional
         arguments.
-
-    finalize: callable
+    finalize : callable
         an optional finalizer that will be called with the results from the
         aggregation.
 
-    For example, ``sum`` can be implemented as::
+    Examples
+    --------
+
+    ``sum`` can be implemented as::
 
         custom_sum = dd.Aggregation('custom_sum', lambda s: s.sum(), lambda s0: s0.sum())
         df.groupby('g').agg(custom_sum)
@@ -200,7 +200,7 @@ class Aggregation(object):
             'custom_mean',
             lambda s: (s.count(), s.sum()),
             lambda count, sum: (count.sum(), sum.sum()),
-            lambda count, sum: sum/ count,
+            lambda count, sum: sum / count,
         )
         df.groupby('g').agg(custom_mean)
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -181,7 +181,7 @@ class Aggregation(object):
     :agg: callable
         a function that will be called to aggregate the results of each chunk.
         Again the argument(s) will be grouped series. If ``chunk`` returned a
-        tuple, `àgg`` will be called with all of them as individual positional
+        tuple, ``agg`` will be called with all of them as individual positional
         arguments.
 
     :finalize: callable

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -419,6 +419,16 @@ def _build_agg_args(spec):
     """
     known_np_funcs = {np.min: 'min', np.max: 'max'}
 
+    # check that there are no name conflicts for a single input column
+    by_name = {}
+    for _, func, input_column in spec:
+        key = funcname(known_np_funcs.get(func, func)), input_column
+        by_name.setdefault(key, []).append((func, input_column))
+
+    for funcs in by_name.values():
+        if len(funcs) != 1:
+            raise ValueError('conflicting aggregation functions: {}'.format(funcs))
+
     chunks = {}
     aggs = {}
     finalizers = []

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -637,8 +637,8 @@ def _apply_func_to_columns(df_like, prefix, func):
     if isinstance(df_like, pd.DataFrame):
         columns = df_like.columns
     else:
-        # TODO: this looks way to hacky
-        columns = list(df_like.dtypes.columns)
+        # handle GroupBy objects
+        columns = df_like._selected_obj.columns
 
     columns = sorted(col for col in columns if col.startswith(prefix))
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -188,7 +188,20 @@ class Aggregation(object):
         an optional finalizer that will be called with the results from the
         aggregation.
 
-    TODO: add examples
+    For example, ``sum`` can be implemented as::
+
+        custom_sum = dd.Aggregation('custom_sum', lambda s: s.sum(), lambda s0: s0.sum())
+        df.groupby('g').agg(custom_sum)
+
+    and ``mean`` can be implemented as::
+
+        custom_mean = dd.Aggregation(
+            'custom_mean',
+            lambda s: (s.count(), s.sum()),
+            lambda count, sum: (count.sum(), sum.sum()),
+            lambda count, sum: sum/ count,
+        )
+        df.groupby('g').agg(custom_mean)
 
     """
     def __init__(self, name, chunk, agg, finalize=None):

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -8,7 +8,7 @@ import pytest
 
 import dask
 import dask.dataframe as dd
-from dask.dataframe.utils import assert_eq, assert_dask_graph, assert_max_deps
+from dask.dataframe.utils import assert_eq, assert_dask_graph, assert_max_deps, PANDAS_VERSION
 
 
 def groupby_internal_repr():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -699,7 +699,9 @@ def test_series_aggregate__examples(spec, split_every, grouper):
     # but we should still test it for now
     with pytest.warns(None):
         assert_eq(ps.groupby(grouper(pdf)).agg(spec),
-                  ds.groupby(grouper(ddf)).agg(spec, split_every=split_every))
+                  ds.groupby(grouper(ddf)).agg(spec, split_every=split_every),
+                  # pandas < 0.20.0 does not propagate the name for size
+                  check_names=(spec != 'size'))
 
 
 @pytest.mark.parametrize('spec', [

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1235,7 +1235,7 @@ def test_groupby_column_and_index_apply(group_args, apply_func):
     assert len(result.dask) > (len(ddf_no_divs.dask) + ddf_no_divs.npartitions)
 
 
-def test_groupy_agg_custom_sum():
+def test_groupby_agg_custom_sum():
     d = pd.DataFrame({'g': [0, 0, 1] * 3, 'b': [1, 2, 3] * 3})
     a = dd.from_pandas(d, npartitions=2)
 
@@ -1247,7 +1247,7 @@ def test_groupy_agg_custom_sum():
     assert_eq(result, expected)
 
 
-def test_groupy_agg_custom_mean():
+def test_groupby_agg_custom_mean():
     d = pd.DataFrame({'g': [0, 0, 1] * 3, 'b': [1, 2, 3] * 3})
     a = dd.from_pandas(d, npartitions=2)
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -8,9 +8,7 @@ import pytest
 
 import dask
 import dask.dataframe as dd
-from dask.dataframe.utils import (assert_eq, assert_dask_graph,
-                                  assert_max_deps, PANDAS_VERSION)
-from dask.utils import M
+from dask.dataframe.utils import assert_eq, assert_dask_graph, assert_max_deps
 
 
 def groupby_internal_repr():

--- a/docs/source/dataframe-groupby.rst
+++ b/docs/source/dataframe-groupby.rst
@@ -130,7 +130,7 @@ For example, ``sum`` could be implemented as
 
 .. code-block:: python
 
-    custom_sum = dd.Aggregation('sum', lambda s: s.sum(), lambda s0: s0.sum())
+    custom_sum = dd.Aggregation('custom_sum', lambda s: s.sum(), lambda s0: s0.sum())
     df.groupby('g').agg(custom_sum)
 
 The name argument should be different from existing reductions to avoid data

--- a/docs/source/dataframe-groupby.rst
+++ b/docs/source/dataframe-groupby.rst
@@ -147,6 +147,6 @@ A mean function can be implemented as
         'custom_mean',
         lambda s: (s.count(), s.sum()),
         lambda count, sum: (count.sum(), sum.sum()),
-        lambda count, sum: sum/ count,
+        lambda count, sum: sum / count,
     )
     df.groupby('g').agg(custom_mean)

--- a/docs/source/dataframe-groupby.rst
+++ b/docs/source/dataframe-groupby.rst
@@ -104,3 +104,49 @@ keyword argument to ``groupby`` or ``set_index``
 
     df.set_index(column, method='disk')
     df.set_index(column, method='tasks')
+
+
+Aggregate
+=========
+
+Dask support Pandas' ``aggregate`` syntax to run multiple reductions on the
+same groups. Common reductions, such as ``max``, ``sum``, ``mean`` are directly
+supported:
+
+.. code-block:: python
+
+    >>> df.groupby(columns).aggregate(['sum', 'mean', 'max', 'min'])
+
+Dask also supports user defined reductions. To ensure proper performance, the
+reduction has to be formulated in terms of three independent steps. The
+``chunk`` step is applied to each partition independently and reduces the data
+within a partition. The ``aggregate`` combines the within partition results.
+The optional ``finalize`` step combines the results returned from the
+``aggregate`` step and should return a single final column. For Dask to
+recognize the reduction, it has to be passed as an instance of
+``dask.dataframe.Aggregation``.
+
+For example, ``sum`` could be implemented as
+
+.. code-block:: python
+
+    custom_sum = dd.Aggregation('sum', lambda s: s.sum(), lambda s0: s0.sum())
+    df.groupby('g').agg(custom_sum)
+
+The name argument should be different from existing reductions to avoid data
+corruption. The arguments to each function are pre-grouped series objects,
+similar to ``df.groupby('g')['value']``.
+
+Many reductions can only be implemented with multiple temporaries. To implement
+these reductions, the steps should return tuples and expect multiple arguments.
+A mean function can be implemented as
+
+.. code-block:: python
+
+    custom_mean = dd.Aggregation(
+        'custom_mean',
+        lambda s: (s.count(), s.sum()),
+        lambda count, sum: (count.sum(), sum.sum()),
+        lambda count, sum: sum/ count,
+    )
+    df.groupby('g').agg(custom_mean)


### PR DESCRIPTION
As discussed in #2340, a first draft of user defined aggregations. The changes are minimal and hook nicely into the existing aggregation machinery. As a test, I reimplemented mean / sum as custom aggregations. 

A small caveat: the implementation is somewhat hacky, since it relys on `GroupBy.dtypes.columns` to get the columns of a grouped dataframe. However, I didn't see any other way, except to change the signature of all existing aggregations.

Missing are more tests in general and tests for dd.Series objects in particular. 

Also: it could make sense to reimplement the existing aggregations in terms of `Aggregation` to cleanup the code.