### PR TITLE
Spring cleaning

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -4,7 +4,7 @@ from .core import istask
 from .context import set_options
 from .local import get_sync as get
 try:
-    from .delayed import do, delayed
+    from .delayed import delayed
 except ImportError:
     pass
 try:

--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from itertools import count
 from functools import wraps
 from collections import Iterator
 
@@ -29,9 +28,6 @@ def _percentile(a, q, interpolation='linear'):
     if not np.issubdtype(a.dtype, np.number):
         interpolation = 'nearest'
     return np.percentile(a, q, interpolation=interpolation)
-
-
-names = ('percentile-%d' % i for i in count(1))
 
 
 def percentile(a, q, interpolation='linear'):

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -585,22 +585,6 @@ def posify_index(shape, ind):
     return ind
 
 
-def insert_many(seq, where, val):
-    """ Insert value at many locations in sequence
-
-    >>> insert_many(['a', 'b', 'c'], [0, 2], 'z')
-    ('z', 'a', 'z', 'b', 'c')
-    """
-    seq = list(seq)
-    result = []
-    for i in range(len(where) + len(seq)):
-        if i in where:
-            result.append(val)
-        else:
-            result.append(seq.pop(0))
-    return tuple(result)
-
-
 @memoize
 def _expander(where):
     if not where:
@@ -628,8 +612,7 @@ def _expander(where):
 
 
 def expander(where):
-    """ An optimized version of insert_many() when *where*
-    is known upfront and used many times.
+    """Create a function to insert value at many locations in sequence.
 
     >>> expander([0, 2])(['a', 'b', 'c'], 'z')
     ('z', 'a', 'z', 'b', 'c')

--- a/dask/array/tests/test_percentiles.py
+++ b/dask/array/tests/test_percentiles.py
@@ -1,7 +1,6 @@
 import pytest
 pytest.importorskip('numpy')
 
-from dask.utils import skip
 from dask.array.utils import assert_eq
 import dask.array as da
 import numpy as np
@@ -37,7 +36,7 @@ def test_percentile():
               np.array(['a', 'd', 'e'], dtype=x.dtype))
 
 
-@skip
+@pytest.mark.skip
 def test_percentile_with_categoricals():
     try:
         import pandas as pd

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -15,18 +15,6 @@ from .core import Array, normalize_chunks
 from .numpy_compat import full
 
 
-def dims_from_size(size, blocksize):
-    """
-
-    >>> list(dims_from_size(30, 8))
-    [8, 8, 8, 6]
-    """
-    result = (blocksize,) * (size // blocksize)
-    if size % blocksize:
-        result = result + (size % blocksize,)
-    return result
-
-
 def wrap_func_shape_as_first_arg(func, *args, **kwargs):
     """
     Transform np creation function into blocked version

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -37,11 +37,13 @@ from ..delayed import Delayed
 from ..multiprocessing import get as mpget
 from ..optimize import fuse, cull, inline, dont_optimize
 from ..utils import (system_encoding, takes_multiple_arguments, funcname,
-                     digit, insert, eq_strict)
+                     digit, insert)
 
 
 no_default = '__no__default__'
-no_result = '__no__result__'
+no_result = type('no_result', (object,),
+                 {'__slots__': (),
+                  '__reduce__': lambda self: 'no_result'})
 
 
 def lazify_task(task, start=True):
@@ -1826,7 +1828,7 @@ def empty_safe_apply(func, part, is_last):
 
 
 def empty_safe_aggregate(func, parts, is_last):
-    parts2 = (p for p in parts if not eq_strict(p, no_result))
+    parts2 = (p for p in parts if p is not no_result)
     return empty_safe_apply(func, parts2, is_last)
 
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -16,7 +16,7 @@ from dask.bag.core import (Bag, lazify, lazify_task, map, collect,
                            reduceby, reify, partition, inline_singleton_lists,
                            optimize, from_delayed)
 from dask.compatibility import BZ2File, GzipFile, PY2
-from dask.utils import filetexts, tmpfile, tmpdir, open
+from dask.utils import filetexts, tmpfile, tmpdir
 from dask.utils_test import inc, add
 
 

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -14,15 +14,6 @@ from ..delayed import delayed
 from ..utils import (build_name_function, infer_compression, import_required,
                      ensure_bytes, ensure_unicode, infer_storage_options)
 
-# delayed = delayed(pure=True)
-
-# Global registration dictionaries for backend storage functions
-# See docstrings to functions below for more information
-_read_bytes = dict()
-_open_files_write = dict()
-_open_files = dict()
-_open_text_files = dict()
-
 
 def write_block_to_file(data, lazy_file):
     """
@@ -462,10 +453,6 @@ def _expand_paths(path, name_function, num):
 
 
 def ensure_protocol(protocol):
-    if (protocol not in ('s3', 'hdfs') and ((protocol in _read_bytes) or
-       (protocol in _filesystems))):
-        return
-
     if protocol == 's3':
         import_required('s3fs',
                         "Need to install `s3fs` library for s3 support\n"
@@ -479,6 +466,9 @@ def ensure_protocol(protocol):
                "    conda install distributed hdfs3 -c conda-forge")
         import_required('distributed.hdfs', msg)
         import_required('hdfs3', msg)
+
+    elif protocol in _filesystems:
+        return
 
     else:
         raise ValueError("Unknown protocol %s" % protocol)

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -7,12 +7,12 @@ from toolz import merge, partial
 from warnings import warn
 
 from .compression import seekable_files, files as compress_files
-from .utils import SeekableFile, read_block
+from .utils import (SeekableFile, read_block, infer_compression,
+                    infer_storage_options, build_name_function)
 from ..compatibility import PY2, unicode
 from ..base import tokenize, normalize_token
 from ..delayed import delayed
-from ..utils import (build_name_function, infer_compression, import_required,
-                     ensure_bytes, ensure_unicode, infer_storage_options)
+from ..utils import import_required, ensure_bytes, ensure_unicode
 
 
 def write_block_to_file(data, lazy_file):

--- a/dask/bytes/local.py
+++ b/dask/bytes/local.py
@@ -1,13 +1,10 @@
 from __future__ import print_function, division, absolute_import
 
 from glob import glob
-import logging
 import os
 
 from ..base import tokenize
 from ..utils import infer_storage_options
-
-logger = logging.getLogger(__name__)
 
 from . import core
 

--- a/dask/bytes/local.py
+++ b/dask/bytes/local.py
@@ -3,10 +3,9 @@ from __future__ import print_function, division, absolute_import
 from glob import glob
 import os
 
-from ..base import tokenize
-from ..utils import infer_storage_options
-
 from . import core
+from .utils import infer_storage_options
+from ..base import tokenize
 
 
 class LocalFileSystem(core.FileSystem):

--- a/dask/bytes/s3.py
+++ b/dask/bytes/s3.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 from s3fs import S3FileSystem
 
 from . import core
-from ..utils import infer_storage_options
+from .utils import infer_storage_options
 
 
 class DaskS3FileSystem(S3FileSystem, core.FileSystem):

--- a/dask/bytes/s3.py
+++ b/dask/bytes/s3.py
@@ -1,13 +1,9 @@
 from __future__ import print_function, division, absolute_import
 
-import logging
-from ..utils import infer_storage_options
-
 from s3fs import S3FileSystem
 
 from . import core
-
-logger = logging.getLogger(__name__)
+from ..utils import infer_storage_options
 
 
 class DaskS3FileSystem(S3FileSystem, core.FileSystem):

--- a/dask/bytes/tests/test_bytes_utils.py
+++ b/dask/bytes/tests/test_bytes_utils.py
@@ -2,7 +2,7 @@ import io
 
 import pytest
 
-from dask.bytes.utils import read_block, seek_delimiter
+from dask.bytes.utils import read_block, seek_delimiter, infer_storage_options
 
 
 def test_read_block():
@@ -66,3 +66,63 @@ def test_ensure_protocol():
         dd.read_csv('hdfs://data/*.csv')
     except RuntimeError as e:
         assert "hdfs3" in str(e)
+
+
+def test_infer_storage_options():
+    so = infer_storage_options('/mnt/datasets/test.csv')
+    assert so.pop('protocol') == 'file'
+    assert so.pop('path') == '/mnt/datasets/test.csv'
+    assert not so
+
+    assert infer_storage_options('./test.csv')['path'] == './test.csv'
+    assert infer_storage_options('../test.csv')['path'] == '../test.csv'
+
+    so = infer_storage_options('C:\\test.csv')
+    assert so.pop('protocol') == 'file'
+    assert so.pop('path') == 'C:\\test.csv'
+    assert not so
+
+    assert infer_storage_options('d:\\test.csv')['path'] == 'd:\\test.csv'
+    assert infer_storage_options('\\test.csv')['path'] == '\\test.csv'
+    assert infer_storage_options('.\\test.csv')['path'] == '.\\test.csv'
+    assert infer_storage_options('test.csv')['path'] == 'test.csv'
+
+    so = infer_storage_options(
+        'hdfs://username:pwd@Node:123/mnt/datasets/test.csv?q=1#fragm',
+        inherit_storage_options={'extra': 'value'})
+    assert so.pop('protocol') == 'hdfs'
+    assert so.pop('username') == 'username'
+    assert so.pop('password') == 'pwd'
+    assert so.pop('host') == 'Node'
+    assert so.pop('port') == 123
+    assert so.pop('path') == '/mnt/datasets/test.csv'
+    assert so.pop('url_query') == 'q=1'
+    assert so.pop('url_fragment') == 'fragm'
+    assert so.pop('extra') == 'value'
+    assert not so
+
+    so = infer_storage_options('hdfs://User-name@Node-name.com/mnt/datasets/test.csv')
+    assert so.pop('username') == 'User-name'
+    assert so.pop('host') == 'Node-name.com'
+
+    assert infer_storage_options('s3://Bucket-name.com/test.csv')['host'] == 'Bucket-name.com'
+    assert infer_storage_options('http://127.0.0.1:8080/test.csv')['host'] == '127.0.0.1'
+
+    with pytest.raises(KeyError):
+        infer_storage_options('file:///bucket/file.csv', {'path': 'collide'})
+    with pytest.raises(KeyError):
+        infer_storage_options('hdfs:///bucket/file.csv', {'protocol': 'collide'})
+
+
+@pytest.mark.parametrize('urlpath, expected_path', (
+    (r'c:\foo\bar', r'c:\foo\bar'),
+    (r'C:\\foo\bar', r'C:\\foo\bar'),
+    (r'c:/foo/bar', r'c:/foo/bar'),
+    (r'file:///c|\foo\bar', r'c:\foo\bar'),
+    (r'file:///C|/foo/bar', r'C:/foo/bar'),
+    (r'file:///C:/foo/bar', r'C:/foo/bar'),
+))
+def test_infer_storage_options_c(urlpath, expected_path):
+    so = infer_storage_options(urlpath)
+    assert so['protocol'] == 'file'
+    assert so['path'] == expected_path

--- a/dask/bytes/utils.py
+++ b/dask/bytes/utils.py
@@ -2,11 +2,18 @@ from __future__ import print_function, division, absolute_import
 
 import math
 import os
-import re
 
 from toolz import identity
 
-from ..compatibility import urlsplit, PY2
+from ..compatibility import PY2
+
+# Ideally this function should be defined in this file, but old versions of
+# distributed rely on it being in dask.utils. We can't define it here and
+# import it there due to circular imports, so we leave the definition and
+# import it here. After distributed's dask version requirements are updated to
+# > this commit, the definition can be moved here and this can be deleted.
+from ..utils import infer_storage_options  # noqa
+
 
 if PY2:
     class SeekableFile(object):
@@ -48,80 +55,6 @@ compressions = {'gz': 'gzip', 'bz2': 'bz2', 'xz': 'xz'}
 def infer_compression(filename):
     extension = os.path.splitext(filename)[-1].strip('.')
     return compressions.get(extension, None)
-
-
-def infer_storage_options(urlpath, inherit_storage_options=None):
-    """ Infer storage options from URL path and merge it with existing storage
-    options.
-
-    Parameters
-    ----------
-    urlpath: str or unicode
-        Either local absolute file path or URL (hdfs://namenode:8020/file.csv)
-    storage_options: dict (optional)
-        Its contents will get merged with the inferred information from the
-        given path
-
-    Returns
-    -------
-    Storage options dict.
-
-    Examples
-    --------
-    >>> infer_storage_options('/mnt/datasets/test.csv')  # doctest: +SKIP
-    {"protocol": "file", "path", "/mnt/datasets/test.csv"}
-    >>> infer_storage_options(
-    ...          'hdfs://username:pwd@node:123/mnt/datasets/test.csv?q=1',
-    ...          inherit_storage_options={'extra': 'value'})  # doctest: +SKIP
-    {"protocol": "hdfs", "username": "username", "password": "pwd",
-    "host": "node", "port": 123, "path": "/mnt/datasets/test.csv",
-    "url_query": "q=1", "extra": "value"}
-    """
-    # Handle Windows paths including disk name in this special case
-    if re.match(r'^[a-zA-Z]:[\\/]', urlpath):
-        return {'protocol': 'file',
-                'path': urlpath}
-
-    parsed_path = urlsplit(urlpath)
-    protocol = parsed_path.scheme or 'file'
-    path = parsed_path.path
-    if protocol == 'file':
-        # Special case parsing file protocol URL on Windows according to:
-        # https://msdn.microsoft.com/en-us/library/jj710207.aspx
-        windows_path = re.match(r'^/([a-zA-Z])[:|]([\\/].*)$', path)
-        if windows_path:
-            path = '%s:%s' % windows_path.groups()
-
-    inferred_storage_options = {
-        'protocol': protocol,
-        'path': path,
-    }
-
-    if parsed_path.netloc:
-        # Parse `hostname` from netloc manually because `parsed_path.hostname`
-        # lowercases the hostname which is not always desirable (e.g. in S3):
-        # https://github.com/dask/dask/issues/1417
-        inferred_storage_options['host'] = parsed_path.netloc.rsplit('@', 1)[-1].rsplit(':', 1)[0]
-        if parsed_path.port:
-            inferred_storage_options['port'] = parsed_path.port
-        if parsed_path.username:
-            inferred_storage_options['username'] = parsed_path.username
-        if parsed_path.password:
-            inferred_storage_options['password'] = parsed_path.password
-
-    if parsed_path.query:
-        inferred_storage_options['url_query'] = parsed_path.query
-    if parsed_path.fragment:
-        inferred_storage_options['url_fragment'] = parsed_path.fragment
-
-    if inherit_storage_options:
-        if set(inherit_storage_options) & set(inferred_storage_options):
-            raise KeyError("storage options (%r) and path url options (%r) "
-                           "collision is detected"
-                           % (inherit_storage_options, inferred_storage_options))
-        inferred_storage_options.update(inherit_storage_options)
-
-    return inferred_storage_options
 
 
 def seek_delimiter(file, delimiter, blocksize):

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -9,18 +9,16 @@ from warnings import warn
 import pandas as pd
 from toolz import merge
 
-from ...local import get_sync
+from .io import _link
+from ..core import DataFrame, new_dd_object
+from ... import multiprocessing
 from ...base import tokenize
+from ...bytes.utils import build_name_function
 from ...compatibility import PY3
 from ...context import _globals
 from ...delayed import Delayed, delayed
-from ... import multiprocessing
-
-from ..core import DataFrame, new_dd_object
-
-from ...utils import build_name_function, effective_get, get_scheduler_lock
-
-from .io import _link
+from ...local import get_sync
+from ...utils import effective_get, get_scheduler_lock
 
 
 def _pd_to_hdf(pd_to_hdf, lock, args, kwargs=None):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -8,14 +8,12 @@ from collections import Iterator
 import sys
 import traceback
 from contextlib import contextmanager
-import warnings
 
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 from pandas.core.common import is_datetime64tz_dtype
 from pandas.api.types import is_categorical_dtype, is_scalar
-import toolz
 
 from ..core import get_deps
 from ..local import get_sync
@@ -78,30 +76,6 @@ def shard_df_on_index(df, divisions):
         for i in range(len(indices) - 1):
             yield df.iloc[indices[i]: indices[i + 1]]
         yield df.iloc[indices[-1]:]
-
-
-def unique(divisions):
-    """ Polymorphic unique function
-
-    >>> list(unique([1, 2, 3, 1, 2, 3]))
-    [1, 2, 3]
-
-    >>> unique(np.array([1, 2, 3, 1, 2, 3]))
-    array([1, 2, 3])
-
-    >>> unique(pd.Categorical(['Alice', 'Bob', 'Alice'], ordered=False))
-    [Alice, Bob]
-    Categories (2, object): [Alice, Bob]
-    """
-    if isinstance(divisions, np.ndarray):
-        return np.unique(divisions)
-    if isinstance(divisions, pd.Categorical):
-        return pd.Categorical.from_codes(np.unique(divisions.codes),
-                                         divisions.categories,
-                                         divisions.ordered)
-    if isinstance(divisions, (tuple, list, Iterator)):
-        return tuple(toolz.unique(divisions))
-    raise NotImplementedError()
 
 
 _META_TYPES = "meta : pd.DataFrame, pd.Series, dict, iterable, tuple, optional"
@@ -537,11 +511,6 @@ def assert_eq(a, b, check_names=True, check_dtypes=True,
             else:
                 assert np.allclose(a, b)
     return True
-
-
-def eq(*args, **kwargs):
-    warnings.warn('eq is deprecated. Use assert_frame instead', UserWarning)
-    assert_eq(*args, **kwargs)
 
 
 def assert_dask_graph(dask, label):

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from collections import Iterator
 import operator
 import uuid
-import warnings
 
 try:
     from cytoolz import curry, first
@@ -318,20 +317,6 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
             name = '%s-%s' % (type(obj).__name__, tokenize(task, pure=pure))
         dsk = sharedict.merge(dsk, (name, {name: task}))
         return Delayed(name, dsk)
-
-
-def do(*args, **kwargs):
-    """deprecated, please use ``dask.delayed.delayed``"""
-    warnings.warn("`dask.delayed.do` is deprecated, please use "
-                  "`dask.delayed.delayed` instead")
-    return delayed(*args, **kwargs)
-
-
-def compute(*args, **kwargs):
-    """deprecated, please use ``dask.compute``"""
-    warnings.warn("`dask.delayed.compute` is deprecated, please use "
-                  "`dask.compute` instead")
-    return base.compute(*args, **kwargs)
 
 
 def right(method):

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -1,15 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import Iterator
-from itertools import chain
 import operator
 import uuid
 import warnings
 
 try:
-    from cytoolz import unique, curry, first
+    from cytoolz import curry, first
 except ImportError:
-    from toolz import unique, curry, first
+    from toolz import curry, first
 
 from . import base, threaded
 from .compatibility import apply
@@ -20,11 +19,6 @@ from .utils import concrete, funcname, methodcaller, ensure_dict
 from . import sharedict
 
 __all__ = ['Delayed', 'delayed']
-
-
-def flat_unique(ls):
-    """Flatten ``ls``, filter by unique id, and return a list"""
-    return list(unique(chain.from_iterable(ls), key=id))
 
 
 def unzip(ls, nout):

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -6,9 +6,9 @@ from random import random
 from toolz import identity, partial, merge
 import pytest
 
-from dask import set_options
+from dask import set_options, compute
 from dask.compatibility import PY2, PY3
-from dask.delayed import delayed, to_task_dask, compute, Delayed
+from dask.delayed import delayed, to_task_dask, Delayed
 
 
 def test_to_task_dask():

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -6,7 +6,7 @@ import pytest
 
 from dask.sharedict import ShareDict
 from dask.utils import (takes_multiple_arguments, Dispatch, random_state_data,
-                        infer_storage_options, eq_strict, memory_repr,
+                        infer_storage_options, memory_repr,
                         methodcaller, M, skip_doctest, SerializableLock,
                         funcname, ndeepmap, ensure_dict, package_of)
 from dask.utils_test import inc
@@ -140,11 +140,6 @@ def test_infer_storage_options_c(urlpath, expected_path):
     so = infer_storage_options(urlpath)
     assert so['protocol'] == 'file'
     assert so['path'] == expected_path
-
-
-def test_eq_strict():
-    assert eq_strict('a', 'a')
-    assert not eq_strict(b'a', u'a')
 
 
 def test_memory_repr():

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -6,9 +6,9 @@ import pytest
 
 from dask.sharedict import ShareDict
 from dask.utils import (takes_multiple_arguments, Dispatch, random_state_data,
-                        infer_storage_options, memory_repr,
-                        methodcaller, M, skip_doctest, SerializableLock,
-                        funcname, ndeepmap, ensure_dict, package_of)
+                        memory_repr, methodcaller, M, skip_doctest,
+                        SerializableLock, funcname, ndeepmap, ensure_dict,
+                        package_of)
 from dask.utils_test import inc
 
 
@@ -80,66 +80,6 @@ def test_random_state_data():
 
     for s1, s2 in zip(states, states2):
         assert (s1 == s2).all()
-
-
-def test_infer_storage_options():
-    so = infer_storage_options('/mnt/datasets/test.csv')
-    assert so.pop('protocol') == 'file'
-    assert so.pop('path') == '/mnt/datasets/test.csv'
-    assert not so
-
-    assert infer_storage_options('./test.csv')['path'] == './test.csv'
-    assert infer_storage_options('../test.csv')['path'] == '../test.csv'
-
-    so = infer_storage_options('C:\\test.csv')
-    assert so.pop('protocol') == 'file'
-    assert so.pop('path') == 'C:\\test.csv'
-    assert not so
-
-    assert infer_storage_options('d:\\test.csv')['path'] == 'd:\\test.csv'
-    assert infer_storage_options('\\test.csv')['path'] == '\\test.csv'
-    assert infer_storage_options('.\\test.csv')['path'] == '.\\test.csv'
-    assert infer_storage_options('test.csv')['path'] == 'test.csv'
-
-    so = infer_storage_options(
-        'hdfs://username:pwd@Node:123/mnt/datasets/test.csv?q=1#fragm',
-        inherit_storage_options={'extra': 'value'})
-    assert so.pop('protocol') == 'hdfs'
-    assert so.pop('username') == 'username'
-    assert so.pop('password') == 'pwd'
-    assert so.pop('host') == 'Node'
-    assert so.pop('port') == 123
-    assert so.pop('path') == '/mnt/datasets/test.csv'
-    assert so.pop('url_query') == 'q=1'
-    assert so.pop('url_fragment') == 'fragm'
-    assert so.pop('extra') == 'value'
-    assert not so
-
-    so = infer_storage_options('hdfs://User-name@Node-name.com/mnt/datasets/test.csv')
-    assert so.pop('username') == 'User-name'
-    assert so.pop('host') == 'Node-name.com'
-
-    assert infer_storage_options('s3://Bucket-name.com/test.csv')['host'] == 'Bucket-name.com'
-    assert infer_storage_options('http://127.0.0.1:8080/test.csv')['host'] == '127.0.0.1'
-
-    with pytest.raises(KeyError):
-        infer_storage_options('file:///bucket/file.csv', {'path': 'collide'})
-    with pytest.raises(KeyError):
-        infer_storage_options('hdfs:///bucket/file.csv', {'protocol': 'collide'})
-
-
-@pytest.mark.parametrize('urlpath, expected_path', (
-    (r'c:\foo\bar', r'c:\foo\bar'),
-    (r'C:\\foo\bar', r'C:\\foo\bar'),
-    (r'c:/foo/bar', r'c:/foo/bar'),
-    (r'file:///c|\foo\bar', r'c:\foo\bar'),
-    (r'file:///C|/foo/bar', r'C:/foo/bar'),
-    (r'file:///C:/foo/bar', r'C:/foo/bar'),
-))
-def test_infer_storage_options_c(urlpath, expected_path):
-    so = infer_storage_options(urlpath)
-    assert so['protocol'] == 'file'
-    assert so['path'] == expected_path
 
 
 def test_memory_repr():

--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -20,14 +20,8 @@ def _thread_get_id():
     return current_thread().ident
 
 
-default_pool = None
-
-
-default_thread = _thread_get_id()
-
-
 main_thread = current_thread()
-
+default_pool = None
 pools = defaultdict(dict)
 pools_lock = Lock()
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -718,13 +718,6 @@ def dependency_depth(dsk):
     return max(max_depth_by_deps(dep_key) for dep_key in deps.keys())
 
 
-def eq_strict(a, b):
-    """Returns True if both values have the same type and are equal."""
-    if type(a) is type(b):
-        return a == b
-    return False
-
-
 def memory_repr(num):
     for x in ['bytes', 'KB', 'MB', 'GB', 'TB']:
         if num < 1024.0:

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -2,9 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import functools
 import inspect
-import math
 import os
-import re
 import shutil
 import sys
 import tempfile
@@ -17,7 +15,7 @@ import multiprocessing as mp
 import uuid
 from weakref import WeakValueDictionary
 
-from .compatibility import long, getargspec, PY3, urlsplit, unicode
+from .compatibility import long, getargspec, PY3, unicode
 from .core import get_deps
 from .context import _globals
 from .optimize import key_split    # noqa: F401
@@ -213,14 +211,6 @@ def filetexts(d, open=open, mode='t', use_tmpdir=True):
             if os.path.exists(filename):
                 with ignoring(OSError):
                     os.remove(filename)
-
-
-compressions = {'gz': 'gzip', 'bz2': 'bz2', 'xz': 'xz'}
-
-
-def infer_compression(filename):
-    extension = os.path.splitext(filename)[-1].strip('.')
-    return compressions.get(extension, None)
 
 
 def concrete(seq):
@@ -597,109 +587,6 @@ def insert(tup, loc, val):
     L = list(tup)
     L[loc] = val
     return tuple(L)
-
-
-def build_name_function(max_int):
-    """ Returns a function that receives a single integer
-    and returns it as a string padded by enough zero characters
-    to align with maximum possible integer
-
-    >>> name_f = build_name_function(57)
-
-    >>> name_f(7)
-    '07'
-    >>> name_f(31)
-    '31'
-    >>> build_name_function(1000)(42)
-    '0042'
-    >>> build_name_function(999)(42)
-    '042'
-    >>> build_name_function(0)(0)
-    '0'
-    """
-    # handle corner cases max_int is 0 or exact power of 10
-    max_int += 1e-8
-
-    pad_length = int(math.ceil(math.log10(max_int)))
-
-    def name_function(i):
-        return str(i).zfill(pad_length)
-
-    return name_function
-
-
-def infer_storage_options(urlpath, inherit_storage_options=None):
-    """ Infer storage options from URL path and merge it with existing storage
-    options.
-
-    Parameters
-    ----------
-    urlpath: str or unicode
-        Either local absolute file path or URL (hdfs://namenode:8020/file.csv)
-    storage_options: dict (optional)
-        Its contents will get merged with the inferred information from the
-        given path
-
-    Returns
-    -------
-    Storage options dict.
-
-    Examples
-    --------
-    >>> infer_storage_options('/mnt/datasets/test.csv')  # doctest: +SKIP
-    {"protocol": "file", "path", "/mnt/datasets/test.csv"}
-    >>> infer_storage_options(
-    ...          'hdfs://username:pwd@node:123/mnt/datasets/test.csv?q=1',
-    ...          inherit_storage_options={'extra': 'value'})  # doctest: +SKIP
-    {"protocol": "hdfs", "username": "username", "password": "pwd",
-    "host": "node", "port": 123, "path": "/mnt/datasets/test.csv",
-    "url_query": "q=1", "extra": "value"}
-    """
-    # Handle Windows paths including disk name in this special case
-    if re.match(r'^[a-zA-Z]:[\\/]', urlpath):
-        return {'protocol': 'file',
-                'path': urlpath}
-
-    parsed_path = urlsplit(urlpath)
-    protocol = parsed_path.scheme or 'file'
-    path = parsed_path.path
-    if protocol == 'file':
-        # Special case parsing file protocol URL on Windows according to:
-        # https://msdn.microsoft.com/en-us/library/jj710207.aspx
-        windows_path = re.match(r'^/([a-zA-Z])[:|]([\\/].*)$', path)
-        if windows_path:
-            path = '%s:%s' % windows_path.groups()
-
-    inferred_storage_options = {
-        'protocol': protocol,
-        'path': path,
-    }
-
-    if parsed_path.netloc:
-        # Parse `hostname` from netloc manually because `parsed_path.hostname`
-        # lowercases the hostname which is not always desirable (e.g. in S3):
-        # https://github.com/dask/dask/issues/1417
-        inferred_storage_options['host'] = parsed_path.netloc.rsplit('@', 1)[-1].rsplit(':', 1)[0]
-        if parsed_path.port:
-            inferred_storage_options['port'] = parsed_path.port
-        if parsed_path.username:
-            inferred_storage_options['username'] = parsed_path.username
-        if parsed_path.password:
-            inferred_storage_options['password'] = parsed_path.password
-
-    if parsed_path.query:
-        inferred_storage_options['url_query'] = parsed_path.query
-    if parsed_path.fragment:
-        inferred_storage_options['url_fragment'] = parsed_path.fragment
-
-    if inherit_storage_options:
-        if set(inherit_storage_options) & set(inferred_storage_options):
-            raise KeyError("storage options (%r) and path url options (%r) "
-                           "collision is detected"
-                           % (inherit_storage_options, inferred_storage_options))
-        inferred_storage_options.update(inherit_storage_options)
-
-    return inferred_storage_options
 
 
 def dependency_depth(dsk):

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import functools
 import inspect
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -15,7 +16,7 @@ import multiprocessing as mp
 import uuid
 from weakref import WeakValueDictionary
 
-from .compatibility import long, getargspec, PY3, unicode
+from .compatibility import long, getargspec, PY3, unicode, urlsplit
 from .core import get_deps
 from .context import _globals
 from .optimize import key_split    # noqa: F401
@@ -778,3 +779,80 @@ def package_of(typ):
             result = sys.modules[base]
         _packages[typ] = result
         return result
+
+
+# XXX: Kept to keep old versions of distributed/dask in sync. After
+# distributed's dask requirement is updated to > this commit, this function can
+# be moved to dask.bytes.utils.
+def infer_storage_options(urlpath, inherit_storage_options=None):
+    """ Infer storage options from URL path and merge it with existing storage
+    options.
+
+    Parameters
+    ----------
+    urlpath: str or unicode
+        Either local absolute file path or URL (hdfs://namenode:8020/file.csv)
+    storage_options: dict (optional)
+        Its contents will get merged with the inferred information from the
+        given path
+
+    Returns
+    -------
+    Storage options dict.
+
+    Examples
+    --------
+    >>> infer_storage_options('/mnt/datasets/test.csv')  # doctest: +SKIP
+    {"protocol": "file", "path", "/mnt/datasets/test.csv"}
+    >>> infer_storage_options(
+    ...          'hdfs://username:pwd@node:123/mnt/datasets/test.csv?q=1',
+    ...          inherit_storage_options={'extra': 'value'})  # doctest: +SKIP
+    {"protocol": "hdfs", "username": "username", "password": "pwd",
+    "host": "node", "port": 123, "path": "/mnt/datasets/test.csv",
+    "url_query": "q=1", "extra": "value"}
+    """
+    # Handle Windows paths including disk name in this special case
+    if re.match(r'^[a-zA-Z]:[\\/]', urlpath):
+        return {'protocol': 'file',
+                'path': urlpath}
+
+    parsed_path = urlsplit(urlpath)
+    protocol = parsed_path.scheme or 'file'
+    path = parsed_path.path
+    if protocol == 'file':
+        # Special case parsing file protocol URL on Windows according to:
+        # https://msdn.microsoft.com/en-us/library/jj710207.aspx
+        windows_path = re.match(r'^/([a-zA-Z])[:|]([\\/].*)$', path)
+        if windows_path:
+            path = '%s:%s' % windows_path.groups()
+
+    inferred_storage_options = {
+        'protocol': protocol,
+        'path': path,
+    }
+
+    if parsed_path.netloc:
+        # Parse `hostname` from netloc manually because `parsed_path.hostname`
+        # lowercases the hostname which is not always desirable (e.g. in S3):
+        # https://github.com/dask/dask/issues/1417
+        inferred_storage_options['host'] = parsed_path.netloc.rsplit('@', 1)[-1].rsplit(':', 1)[0]
+        if parsed_path.port:
+            inferred_storage_options['port'] = parsed_path.port
+        if parsed_path.username:
+            inferred_storage_options['username'] = parsed_path.username
+        if parsed_path.password:
+            inferred_storage_options['password'] = parsed_path.password
+
+    if parsed_path.query:
+        inferred_storage_options['url_query'] = parsed_path.query
+    if parsed_path.fragment:
+        inferred_storage_options['url_fragment'] = parsed_path.fragment
+
+    if inherit_storage_options:
+        if set(inherit_storage_options) & set(inferred_storage_options):
+            raise KeyError("storage options (%r) and path url options (%r) "
+                           "collision is detected"
+                           % (inherit_storage_options, inferred_storage_options))
+        inferred_storage_options.update(inherit_storage_options)
+
+    return inferred_storage_options


### PR DESCRIPTION
I noticed we'd accumulated some cruft over time. To solve this, I found unused functions using coverage, and unused top-level variables using a simple `ast` script. This PR removes all these.

- Delete unused functions and top-level variables
- Move some bytes-specific utility functions to `dask.bytes.utils` (last commit only, happy to revert)

Changes are split into separate many commits, so deleted/moved things that are used in external packages or that shouldn't be moved can be reverted.