### PR TITLE
Adds support for loading partitioned parquet files with ddf.read_parquet

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -99,7 +99,7 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
         categories = pf.categories
     dtypes = pf._dtypes(categories)
 
-    meta = _meta_from_dtypes(all_columns, pf.columns, dtypes)
+    meta = _meta_from_dtypes(all_columns, tuple(pf.columns + list(pf.cats)), dtypes)
 
     for cat in categories:
         meta[cat] = pd.Series(pd.Categorical([],

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -265,6 +265,18 @@ def test_append_different_columns():
             ddf3.to_parquet(tmp, append=True)
         assert 'Appended dtypes' in str(excinfo.value)
 
+def test_partitions():
+    """Test the reading of partitioned directories"""
+    with tmpdir() as tmp:
+        path = os.path.join(str(tmp), 'subdir')
+        
+        df1 = pd.DataFrame({'a': [1], 'b': pd.Categorical([2])})
+        fastparquet.write(path, df1, partition_on=['b'], file_scheme='hive')
+        
+        df2 = dd.read_parquet(path, index=False)
+        
+        assert_eq(df1, df2)
+        
 
 def test_ordering():
     with tmpdir() as tmp:


### PR DESCRIPTION
The `columns` field of a ParquetFile omits columns used to [partition](http://fastparquet.readthedocs.io/en/latest/details.html#partitions-and-row-groups) the directory structure. The fix is to append the partitioning columns, just as is already done for the `all_comments` variable slightly earlier in the code.

