### PR TITLE
read_bytes works with int-like blocksize

### DIFF
--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -12,7 +12,7 @@ from .utils import (SeekableFile, read_block, infer_compression,
 from ..compatibility import PY2, unicode
 from ..base import tokenize, normalize_token
 from ..delayed import delayed
-from ..utils import import_required, ensure_bytes, ensure_unicode
+from ..utils import import_required, ensure_bytes, ensure_unicode, is_integer
 
 
 def write_block_to_file(data, lazy_file):
@@ -137,6 +137,11 @@ def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
     client = None
     if len(paths) == 0:
         raise IOError("%s resolved to no files" % urlpath)
+
+    if blocksize is not None:
+        if not is_integer(blocksize):
+            raise TypeError("blocksize must be an integer")
+        blocksize = int(blocksize)
 
     blocks, lengths, machines = fs.get_block_locations(paths)
     if blocks:

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -62,6 +62,18 @@ def test_read_bytes_blocksize_none():
         assert sum(map(len, values)) == len(files)
 
 
+def test_read_bytes_blocksize_float():
+    with filetexts(files, mode='b'):
+        sample, vals = read_bytes('.test.account*', blocksize=5.0)
+        results = compute(*concat(vals))
+        ourlines = b"".join(results).split(b'\n')
+        testlines = b"".join(files.values()).split(b'\n')
+        assert set(ourlines) == set(testlines)
+
+        with pytest.raises(TypeError):
+            read_bytes('.test.account*', blocksize=5.5)
+
+
 def test_with_urls():
     with filetexts(files, mode='b'):
         # OS-independent file:// URI with glob *

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -11,12 +11,13 @@ from errno import ENOENT
 from collections import Iterator
 from contextlib import contextmanager
 from importlib import import_module
+from numbers import Integral
 from threading import Lock
 import multiprocessing as mp
 import uuid
 from weakref import WeakValueDictionary
 
-from .compatibility import long, getargspec, PY3, unicode, urlsplit
+from .compatibility import getargspec, PY3, unicode, urlsplit
 from .core import get_deps
 from .context import _globals
 from .optimize import key_split    # noqa: F401
@@ -285,15 +286,7 @@ def is_integer(i):
     >>> is_integer('abc')
     False
     """
-    import numpy as np
-    if isinstance(i, (int, long)):
-        return True
-    if isinstance(i, float):
-        return (i).is_integer()
-    if issubclass(type(i), np.integer):
-        return i
-    else:
-        return False
+    return isinstance(i, Integral) or (isinstance(i, float) and i.is_integer())
 
 
 ONE_ARITY_BUILTINS = set([abs, all, any, bool, bytearray, bytes, callable, chr,


### PR DESCRIPTION
Allows using integer-like floats for blocksize in all reading functions.

Fixes #2353.