### PR TITLE
Improve docstring for read_csv/read_table

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc',
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.mathjax',
               'sphinx.ext.autosummary', 'sphinx.ext.extlinks', 'numpydoc']
 
 numpydoc_show_class_members = False


### PR DESCRIPTION
- Add note about dtype inference, and what to do if it fails
- Fix formatting of docstring
- Fix a few typos

Also re-add the `mathjax` sphinx extension, as the array docs require it.

Fixes #2357.