### PR TITLE
Fastparquet metadata

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -111,6 +111,8 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
         if index_col in minmax:
             divisions = (list(minmax[index_col]['min']) +
                          [minmax[index_col]['max'][-1]])
+            divisions = [divisions[i] for i, rg in enumerate(pf.row_groups)
+                         if rg in rgs] + [divisions[-1]]
         else:
             divisions = (None,) * (len(rgs) + 1)
     else:

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -296,7 +296,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
                              categories=categories, index=index)
 
 
-def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
+def to_parquet(path, df, compression=None, write_index=None, has_nulls=True,
                fixed_text=None, object_encoding=None, storage_options=None,
                append=False, ignore_divisions=False, partition_on=[]):
     """Store Dask.dataframe to Parquet files
@@ -317,11 +317,11 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
     write_index : boolean
         Whether or not to write the index.  Defaults to True *if* divisions are
         known.
-    has_nulls : bool, list or None
+    has_nulls : bool, list or 'infer'
         Specifies whether to write NULLs information for columns. If bools,
-        apply to all columns, if list, use for only the named columns, if None,
-        use only for columns which don't have a sentinel NULL marker (currently
-        object columns only).
+        apply to all columns, if list, use for only the named columns, if
+        'infer', use only for columns which don't have a sentinel NULL marker
+        (currently object columns only).
     fixed_text : dict {col: int}
         For column types that are written as bytes (bytes, utf8 strings, or
         json and bson-encoded objects), if a column is included here, the

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import pandas as pd
-from toolz import first, partial
 
 from ..core import DataFrame, Series
 from ..utils import UNKNOWN_CATEGORIES
@@ -109,8 +108,8 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
     if index_col:
         minmax = fastparquet.api.sorted_partitioned_columns(pf)
         if index_col in minmax:
-            divisions = list(minmax[index_col]['min']) + [minmax[
-                                        index_col]['max'][-1]]
+            divisions = (list(minmax[index_col]['min']) +
+                         [minmax[index_col]['max'][-1]])
         else:
             divisions = (None,) * (len(rgs) + 1)
     else:

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -69,24 +69,10 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
 
     if index is False:
         index_col = None
-    elif len(minmax) == 1:
-        index_col = first(minmax)
-    elif len(minmax) > 1:
-        if index:
-            index_col = index
-        elif index is None:
-            # attempt auto-index
-            index = pf._get_index()
-            if index:
-                index_col = index
-        elif 'index' in minmax:
-            index_col = 'index'
-        else:
-            raise ValueError("Multiple possible indexes exist: %s.  "
-                             "Please select one with index='index-name'"
-                             % sorted(minmax))
+    elif index is None:
+        index_col = pf._get_index()
     else:
-        index_col = None
+        index_col = index
 
     if columns is None:
         all_columns = tuple(pf.columns + list(pf.cats))

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -64,9 +64,6 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
            not(fastparquet.api.filter_out_stats(rg, filters, pf.schema)) and
            not(fastparquet.api.filter_out_cats(rg, filters))]
 
-    # Find an index among the partially sorted columns
-    minmax = fastparquet.api.sorted_partitioned_columns(pf)
-
     if index is False:
         index_col = None
     elif index is None:
@@ -110,7 +107,12 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
            for i, rg in enumerate(rgs)}
 
     if index_col:
-        divisions = list(minmax[index_col]['min']) + [minmax[index_col]['max'][-1]]
+        minmax = fastparquet.api.sorted_partitioned_columns(pf)
+        if index_col in minmax:
+            divisions = list(minmax[index_col]['min']) + [minmax[
+                                        index_col]['max'][-1]]
+        else:
+            divisions = (None,) * (len(rgs) + 1)
     else:
         divisions = (None,) * (len(rgs) + 1)
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -298,7 +298,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
 
 def to_parquet(path, df, compression=None, write_index=None, has_nulls=True,
                fixed_text=None, object_encoding=None, storage_options=None,
-               append=False, ignore_divisions=False, partition_on=[]):
+               append=False, ignore_divisions=False, partition_on=None):
     """Store Dask.dataframe to Parquet files
 
     Notes
@@ -358,6 +358,7 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=True,
 
     """
     import fastparquet
+    partition_on = partition_on or []
 
     fs, paths, myopen = get_fs_paths_myopen(path, None, 'wb',
                                             **(storage_options or {}))

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import pandas as pd
+from toolz import partial
 
 from ..core import DataFrame, Series
 from ..utils import UNKNOWN_CATEGORIES

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -74,6 +74,11 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
     elif len(minmax) > 1:
         if index:
             index_col = index
+        elif index is None:
+            # attempt auto-index
+            index = pf._get_index()
+            if index:
+                index_col = index
         elif 'index' in minmax:
             index_col = 'index'
         else:
@@ -361,6 +366,7 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
         index_col = df.columns[0]
     else:
         ignore_divisions = True
+        index_col = []
 
     object_encoding = object_encoding or 'utf8'
     if object_encoding == 'infer' or (isinstance(object_encoding, dict) and
@@ -369,7 +375,8 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=None,
                          'because this required data in memory.')
     fmd = fastparquet.writer.make_metadata(df._meta, has_nulls=has_nulls,
                                            fixed_text=fixed_text,
-                                           object_encoding=object_encoding)
+                                           object_encoding=object_encoding,
+                                           index_cols=[index_col])
 
     if append:
         pf = fastparquet.api.ParquetFile(path, open_with=myopen, sep=sep)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -424,17 +424,17 @@ def test_filters(fn):
                            filters=[('at', '==', 'aa')]).compute()
     assert_eq(ddf2, ddf)
 
-    # Ok with >1 partition and no filters
+    # with >1 partition and no filters
     ddf.repartition(npartitions=2, force=True).to_parquet(fn)
     dd.read_parquet(fn).compute()
     assert_eq(ddf2, ddf)
 
-    # Ok with >1 partition and filters using base fastparquet
+    # with >1 partition and filters using base fastparquet
     ddf.repartition(npartitions=2, force=True).to_parquet(fn)
     df2 = fastparquet.ParquetFile(fn).to_pandas(filters=[('at', '==', 'aa')])
     assert len(df2) > 0
 
-    # Fails with >1 partition and filters
+    # with >1 partition and filters
     ddf.repartition(npartitions=2, force=True).to_parquet(fn)
-    dd.read_parquet(fn, filters=[('at', '==', 'aa')]).compute()  # -> KeyError: ('read-parquet-e38d96ce99311317127a227242daf29c', 1)
+    dd.read_parquet(fn, filters=[('at', '==', 'aa')]).compute()
     assert len(ddf2) > 0

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -389,7 +389,6 @@ def test_timestamp_index():
 
 
 @pytest.mark.skipif(not pyarrow, reason='pyarrow not found')
-@pytest.mark.xfail(reason="to_parquet does not write nulls by default")
 def test_to_parquet_default_writes_nulls():
     import pyarrow.parquet as pq
 
@@ -399,7 +398,7 @@ def test_to_parquet_default_writes_nulls():
     with tmpfile() as fn:
         ddf.to_parquet(fn)
         table = pq.read_table(fn)
-        assert table[0].null_count == 2
+        assert table[1].null_count == 2
 
 
 def test_partition_on(tmpdir):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -13,10 +13,7 @@ import dask.dataframe as dd
 from dask.dataframe.io.parquet import read_parquet, to_parquet
 from dask.dataframe.utils import assert_eq
 
-try:
-    import fastparquet
-except ImportError:
-    fastparquet = False
+fastparquet = pytest.importorskip('fastparquet')
 
 try:
     import pyarrow.parquet as pyarrow  # noqa
@@ -416,7 +413,6 @@ def test_partition_on(tmpdir):
         assert set(df.b[df.a == val]) == set(out.b[out.a == val])
 
 
-@pytest.mark.skipif(not fastparquet, reason="Filters only in fastparquet")
 def test_filters(fn):
 
     df = pd.DataFrame({'at': ['ab', 'aa', 'ba', 'da', 'bb']})


### PR DESCRIPTION
Fixes #2222 

Fixes #2362 
Replaces #2354 

Could do with more tests on categories? In particular, what happens with different categories in partitions when you later try to load the same file via pandas' read_parquet or fastparquet to_pandas.