### PR TITLE
WIP: Add even-odd block sort for dataframes

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2605,3 +2605,20 @@ def test_boundary_slice_same(index, left, right):
     df = pd.DataFrame({"A": range(len(index))}, index=index)
     result = boundary_slice(df, left, right)
     tm.assert_frame_equal(result, df)
+
+
+@pytest.mark.parametrize('npartitions,ascending', [
+    (1, True),
+    (10, True),
+    (1, False),
+    (10, False),
+])
+def test_sort_values(npartitions, ascending):
+    vals = list(num % 100 for num in range(50, 150))
+    df = pd.DataFrame({'val': vals})
+    ddf = dd.from_pandas(df, npartitions=npartitions)
+
+    np.testing.assert_allclose(
+        ddf.sort_values('val', ascending=ascending).val.compute(),
+        df.sort_values('val', ascending=ascending).val,
+    )


### PR DESCRIPTION
This PR implements #958. It uses a block-wise even-odd sort. Currently, only `DataFrame.sort_values` is implemented. I'd prefer to gauge interest first, before implementing `Series.sort_values` (which should take minimal effort).

The sort is performed in approximately `npartitions` iterations. For each iteration, two neighboring partitions are merged, sorted and split again. To transfer information, the neighborhoods are shifted for each iteration. Within each partition the pandas standard, i.e., quicksort, is used.  
