### PR TITLE
CI: Catch some additional warnings for pytest

### DIFF
--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -1,5 +1,4 @@
 import operator
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -234,7 +233,7 @@ def test_categorical_accessor_presence():
 def test_categorize_nan():
     df = dd.from_pandas(pd.DataFrame({"A": ['a', 'b', 'a', float('nan')]}),
                         npartitions=2)
-    with warnings.catch_warnings(record=True) as record:
+    with pytest.warns(None) as record:
         df.categorize().compute()
     assert len(record) == 0
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -12,8 +12,12 @@ from contextlib import contextmanager
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
-from pandas.core.common import is_datetime64tz_dtype
 from pandas.api.types import is_categorical_dtype, is_scalar
+try:
+    from pandas.api.types import is_datetime64tz_dtype
+except ImportError:
+    # pandas < 0.19.2
+    from pandas.core.common import is_datetime64tz_dtype
 
 from ..core import get_deps
 from ..local import get_sync


### PR DESCRIPTION
This is causing some failures in our test suite (see
https://travis-ci.org/dask/dask/jobs/235253007). Disable it for now,
but should eventually re-enable it when the pytest bug is fixed