### PR TITLE
Add `token` kwarg to `da.map_blocks`

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -895,6 +895,10 @@ def test_map_blocks():
     e = d.map_blocks(inc, name='increment')
     assert e.name == 'increment'
 
+    e = d.map_blocks(inc, token='increment')
+    assert e.name != 'increment'
+    assert e.name.startswith('increment')
+
     d = from_array(x, chunks=(10, 10))
     e = d.map_blocks(lambda x: x[::2, ::2], chunks=(5, 5), dtype=d.dtype)
 


### PR DESCRIPTION
Add the `token` kwarg to `map_blocks`, mirroring the `token` kwarg of `atop`. If provided, this is the prefix of the output key, but not the key itself.

Fixes #2380.