### PR TITLE
TST/CLN: Catch more warnings

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -543,9 +543,11 @@ def test_operators():
     assert_eq(c, x + x.reshape((10, 1)))
 
     expr = (3 / a * b)**2 > 5
-    assert_eq(expr, (3 / x * y)**2 > 5)
+    with pytest.warns(None):  # ZeroDivisionWarning
+        assert_eq(expr, (3 / x * y)**2 > 5)
 
-    c = da.exp(a)
+    with pytest.warns(None):  # OverflowWarning
+        c = da.exp(a)
     assert_eq(c, np.exp(x))
 
     assert_eq(abs(-a), a)
@@ -592,7 +594,8 @@ def test_tensordot():
         assert_eq(tensordot(a, y, axes=axes), np.tensordot(x, y, axes=axes))
 
     assert same_keys(tensordot(a, b, axes=(1, 0)), tensordot(a, b, axes=(1, 0)))
-    assert not same_keys(tensordot(a, b, axes=0), tensordot(a, b, axes=1))
+    with pytest.warns(None):  # Increasing number of chunks warning
+        assert not same_keys(tensordot(a, b, axes=0), tensordot(a, b, axes=1))
 
     # assert (tensordot(a, a).chunks
     #      == tensordot(a, a, axes=((1, 0), (0, 1))).chunks)
@@ -1405,11 +1408,13 @@ def test_arithmetic():
 
     assert_eq(da.logaddexp(a, b), np.logaddexp(x, y))
     assert_eq(da.logaddexp2(a, b), np.logaddexp2(x, y))
-    assert_eq(da.exp(b), np.exp(y))
+    with pytest.warns(None):  # Overflow warning
+        assert_eq(da.exp(b), np.exp(y))
     assert_eq(da.log(a), np.log(x))
     assert_eq(da.log10(a), np.log10(x))
     assert_eq(da.log1p(a), np.log1p(x))
-    assert_eq(da.expm1(b), np.expm1(y))
+    with pytest.warns(None):  # Overflow warning
+        assert_eq(da.expm1(b), np.expm1(y))
     assert_eq(da.sqrt(a), np.sqrt(x))
     assert_eq(da.square(a), np.square(x))
 
@@ -1422,7 +1427,8 @@ def test_arithmetic():
     assert_eq(da.arctan2(b * 10, a), np.arctan2(y * 10, x))
     assert_eq(da.hypot(b, a), np.hypot(y, x))
     assert_eq(da.sinh(a), np.sinh(x))
-    assert_eq(da.cosh(b), np.cosh(y))
+    with pytest.warns(None):  # Overflow warning
+        assert_eq(da.cosh(b), np.cosh(y))
     assert_eq(da.tanh(a), np.tanh(x))
     assert_eq(da.arcsinh(b * 10), np.arcsinh(y * 10))
     assert_eq(da.arccosh(b * 10), np.arccosh(y * 10))
@@ -1447,7 +1453,8 @@ def test_arithmetic():
     assert_eq(da.signbit(a - 3), np.signbit(x - 3))
     assert_eq(da.copysign(a - 3, b), np.copysign(x - 3, y))
     assert_eq(da.nextafter(a - 3, b), np.nextafter(x - 3, y))
-    assert_eq(da.ldexp(c, c), np.ldexp(z, z))
+    with pytest.warns(None):  # overflow warning
+        assert_eq(da.ldexp(c, c), np.ldexp(z, z))
     assert_eq(da.fmod(a * 12, b), np.fmod(x * 12, y))
     assert_eq(da.floor(a * 0.5), np.floor(x * 0.5))
     assert_eq(da.ceil(a), np.ceil(x))
@@ -1994,7 +2001,8 @@ def test_cov():
 
     assert_eq(da.cov(d), np.cov(x))
     assert_eq(da.cov(d, rowvar=0), np.cov(x, rowvar=0))
-    assert_eq(da.cov(d, ddof=10), np.cov(x, ddof=10))
+    with pytest.warns(None):  # warning dof <= 0 for slice
+        assert_eq(da.cov(d, ddof=10), np.cov(x, ddof=10))
     assert_eq(da.cov(d, bias=1), np.cov(x, bias=1))
     assert_eq(da.cov(d, d), np.cov(x, x))
 
@@ -2077,6 +2085,7 @@ def test_view():
 def test_view_fortran():
     x = np.asfortranarray(np.arange(64).reshape((8, 8)))
     d = da.from_array(x, chunks=(2, 3))
+    # TODO: DeprecationWarning: Changing the shape of non-C contiguous array by
     assert_eq(x.view('i4'), d.view('i4', order='F'))
     assert_eq(x.view('i2'), d.view('i2', order='F'))
 
@@ -2344,11 +2353,11 @@ def test_tril_triu():
 
 
 def test_tril_triu_errors():
-    A = np.random.random_integers(0, 10, (10, 10, 10))
+    A = np.random.randint(0, 11, (10, 10, 10))
     dA = da.from_array(A, chunks=(5, 5, 5))
     pytest.raises(ValueError, lambda: da.triu(dA))
 
-    A = np.random.random_integers(0, 10, (30, 35))
+    A = np.random.randint(0, 11, (30, 35))
     dA = da.from_array(A, chunks=(5, 5))
     pytest.raises(NotImplementedError, lambda: da.triu(dA))
 
@@ -2765,7 +2774,8 @@ def test_no_chunks_2d():
     x = da.from_array(X, chunks=(2, 2))
     x._chunks = ((np.nan, np.nan), (np.nan, np.nan, np.nan))
 
-    assert_eq(da.log(x), np.log(X))
+    with pytest.warns(None):  # zero division warning
+        assert_eq(da.log(x), np.log(X))
     assert_eq(x.T, X.T)
     assert_eq(x.sum(axis=0, keepdims=True), X.sum(axis=0, keepdims=True))
     assert_eq(x.sum(axis=1, keepdims=True), X.sum(axis=1, keepdims=True))

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -194,7 +194,7 @@ def test_lu_1():
 @pytest.mark.parametrize('size', [10, 20, 30, 50])
 def test_lu_2(size):
     np.random.seed(10)
-    A = np.random.random_integers(0, 10, (size, size))
+    A = np.random.randint(0, 10, (size, size))
 
     dA = da.from_array(A, chunks=(5, 5))
     dp, dl, du = da.linalg.lu(dA)
@@ -205,7 +205,7 @@ def test_lu_2(size):
 @pytest.mark.parametrize('size', [50, 100, 200])
 def test_lu_3(size):
     np.random.seed(10)
-    A = np.random.random_integers(0, 10, (size, size))
+    A = np.random.randint(0, 10, (size, size))
 
     dA = da.from_array(A, chunks=(25, 25))
     dp, dl, du = da.linalg.lu(dA)
@@ -213,15 +213,15 @@ def test_lu_3(size):
 
 
 def test_lu_errors():
-    A = np.random.random_integers(0, 10, (10, 10, 10))
+    A = np.random.randint(0, 11, (10, 10, 10))
     dA = da.from_array(A, chunks=(5, 5, 5))
     pytest.raises(ValueError, lambda: da.linalg.lu(dA))
 
-    A = np.random.random_integers(0, 10, (10, 8))
+    A = np.random.randint(0, 11, (10, 8))
     dA = da.from_array(A, chunks=(5, 4))
     pytest.raises(ValueError, lambda: da.linalg.lu(dA))
 
-    A = np.random.random_integers(0, 10, (20, 20))
+    A = np.random.randint(0, 11, (20, 20))
     dA = da.from_array(A, chunks=(5, 4))
     pytest.raises(ValueError, lambda: da.linalg.lu(dA))
 
@@ -230,8 +230,8 @@ def test_lu_errors():
 def test_solve_triangular_vector(shape, chunk):
     np.random.seed(1)
 
-    A = np.random.random_integers(1, 10, (shape, shape))
-    b = np.random.random_integers(1, 10, shape)
+    A = np.random.randint(1, 11, (shape, shape))
+    b = np.random.randint(1, 11, shape)
 
     # upper
     Au = np.triu(A)
@@ -254,8 +254,8 @@ def test_solve_triangular_vector(shape, chunk):
 def test_solve_triangular_matrix(shape, chunk):
     np.random.seed(1)
 
-    A = np.random.random_integers(1, 10, (shape, shape))
-    b = np.random.random_integers(1, 10, (shape, 5))
+    A = np.random.randint(1, 10, (shape, shape))
+    b = np.random.randint(1, 10, (shape, 5))
 
     # upper
     Au = np.triu(A)
@@ -278,8 +278,8 @@ def test_solve_triangular_matrix(shape, chunk):
 def test_solve_triangular_matrix2(shape, chunk):
     np.random.seed(1)
 
-    A = np.random.random_integers(1, 10, (shape, shape))
-    b = np.random.random_integers(1, 10, (shape, shape))
+    A = np.random.randint(1, 10, (shape, shape))
+    b = np.random.randint(1, 10, (shape, shape))
 
     # upper
     Au = np.triu(A)
@@ -299,14 +299,14 @@ def test_solve_triangular_matrix2(shape, chunk):
 
 
 def test_solve_triangular_errors():
-    A = np.random.random_integers(0, 10, (10, 10, 10))
-    b = np.random.random_integers(1, 10, 10)
+    A = np.random.randint(0, 10, (10, 10, 10))
+    b = np.random.randint(1, 10, 10)
     dA = da.from_array(A, chunks=(5, 5, 5))
     db = da.from_array(b, chunks=5)
     pytest.raises(ValueError, lambda: da.linalg.solve_triangular(dA, db))
 
-    A = np.random.random_integers(0, 10, (10, 10))
-    b = np.random.random_integers(1, 10, 10)
+    A = np.random.randint(0, 10, (10, 10))
+    b = np.random.randint(1, 10, 10)
     dA = da.from_array(A, chunks=(3, 3))
     db = da.from_array(b, chunks=5)
     pytest.raises(ValueError, lambda: da.linalg.solve_triangular(dA, db))
@@ -316,11 +316,11 @@ def test_solve_triangular_errors():
 def test_solve(shape, chunk):
     np.random.seed(1)
 
-    A = np.random.random_integers(1, 10, (shape, shape))
+    A = np.random.randint(1, 10, (shape, shape))
     dA = da.from_array(A, (chunk, chunk))
 
     # vector
-    b = np.random.random_integers(1, 10, shape)
+    b = np.random.randint(1, 10, shape)
     db = da.from_array(b, chunk)
 
     res = da.linalg.solve(dA, db)
@@ -328,7 +328,7 @@ def test_solve(shape, chunk):
     assert_eq(dA.dot(res), b.astype(float))
 
     # tall-and-skinny matrix
-    b = np.random.random_integers(1, 10, (shape, 5))
+    b = np.random.randint(1, 10, (shape, 5))
     db = da.from_array(b, (chunk, 5))
 
     res = da.linalg.solve(dA, db)
@@ -336,7 +336,7 @@ def test_solve(shape, chunk):
     assert_eq(dA.dot(res), b.astype(float))
 
     # matrix
-    b = np.random.random_integers(1, 10, (shape, shape))
+    b = np.random.randint(1, 10, (shape, shape))
     db = da.from_array(b, (chunk, chunk))
 
     res = da.linalg.solve(dA, db)
@@ -348,7 +348,7 @@ def test_solve(shape, chunk):
 def test_inv(shape, chunk):
     np.random.seed(1)
 
-    A = np.random.random_integers(1, 10, (shape, shape))
+    A = np.random.randint(1, 10, (shape, shape))
     dA = da.from_array(A, (chunk, chunk))
 
     res = da.linalg.inv(dA)
@@ -358,7 +358,7 @@ def test_inv(shape, chunk):
 
 def _get_symmat(size):
     np.random.seed(1)
-    A = np.random.random_integers(1, 20, (size, size))
+    A = np.random.randint(1, 21, (size, size))
     lA = np.tril(A)
     return lA.dot(lA.T)
 
@@ -371,7 +371,7 @@ def test_solve_sym_pos(shape, chunk):
     dA = da.from_array(A, (chunk, chunk))
 
     # vector
-    b = np.random.random_integers(1, 10, shape)
+    b = np.random.randint(1, 10, shape)
     db = da.from_array(b, chunk)
 
     res = da.linalg.solve(dA, db, sym_pos=True)
@@ -379,7 +379,7 @@ def test_solve_sym_pos(shape, chunk):
     assert_eq(dA.dot(res), b.astype(float))
 
     # tall-and-skinny matrix
-    b = np.random.random_integers(1, 10, (shape, 5))
+    b = np.random.randint(1, 10, (shape, 5))
     db = da.from_array(b, (chunk, 5))
 
     res = da.linalg.solve(dA, db, sym_pos=True)
@@ -387,7 +387,7 @@ def test_solve_sym_pos(shape, chunk):
     assert_eq(dA.dot(res), b.astype(float))
 
     # matrix
-    b = np.random.random_integers(1, 10, (shape, shape))
+    b = np.random.randint(1, 10, (shape, shape))
     db = da.from_array(b, (chunk, chunk))
 
     res = da.linalg.solve(dA, db, sym_pos=True)
@@ -408,8 +408,8 @@ def test_cholesky(shape, chunk):
                          [(20, 10, 5), (100, 10, 10)])
 def test_lstsq(nrow, ncol, chunk):
     np.random.seed(1)
-    A = np.random.random_integers(1, 20, (nrow, ncol))
-    b = np.random.random_integers(1, 20, nrow)
+    A = np.random.randint(1, 20, (nrow, ncol))
+    b = np.random.randint(1, 20, nrow)
 
     dA = da.from_array(A, (chunk, ncol))
     db = da.from_array(b, chunk)

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -176,21 +176,25 @@ def test_arg_reductions(dfunc, func):
                          [(da.nanargmin, np.nanargmin),
                           (da.nanargmax, np.nanargmax)])
 def test_nanarg_reductions(dfunc, func):
+
     x = np.random.random((10, 10, 10))
     x[5] = np.nan
     a = da.from_array(x, chunks=(3, 4, 5))
     assert_eq(dfunc(a), func(x))
     assert_eq(dfunc(a, 0), func(x, 0))
     with pytest.raises(ValueError):
-        dfunc(a, 1).compute()
+        with pytest.warns(None):  # All NaN axis
+            dfunc(a, 1).compute()
 
     with pytest.raises(ValueError):
-        dfunc(a, 2).compute()
+        with pytest.warns(None):  # All NaN axis
+            dfunc(a, 2).compute()
 
     x[:] = np.nan
     a = da.from_array(x, chunks=(3, 4, 5))
     with pytest.raises(ValueError):
-        dfunc(a).compute()
+        with pytest.warns(None):  # All NaN axis
+            dfunc(a).compute()
 
 
 def test_reductions_2D_nans():
@@ -214,23 +218,33 @@ def test_reductions_2D_nans():
     reduction_2d_test(da.nansum, a, np.nansum, x, False, False)
     reduction_2d_test(da.nanprod, a, nanprod, x, False, False)
     reduction_2d_test(da.nanmean, a, np.nanmean, x, False, False)
-    reduction_2d_test(da.nanvar, a, np.nanvar, x, False, False)
-    reduction_2d_test(da.nanstd, a, np.nanstd, x, False, False)
-    reduction_2d_test(da.nanmin, a, np.nanmin, x, False, False)
-    reduction_2d_test(da.nanmax, a, np.nanmax, x, False, False)
+    with pytest.warns(None):  # division by 0 warning
+        reduction_2d_test(da.nanvar, a, np.nanvar, x, False, False)
+    with pytest.warns(None):  # division by 0 warning
+        reduction_2d_test(da.nanstd, a, np.nanstd, x, False, False)
+    with pytest.warns(None):  # all NaN axis warning
+        reduction_2d_test(da.nanmin, a, np.nanmin, x, False, False)
+    with pytest.warns(None):  # all NaN axis warning
+        reduction_2d_test(da.nanmax, a, np.nanmax, x, False, False)
 
     assert_eq(da.argmax(a), np.argmax(x))
     assert_eq(da.argmin(a), np.argmin(x))
-    assert_eq(da.nanargmax(a), np.nanargmax(x))
-    assert_eq(da.nanargmin(a), np.nanargmin(x))
+    with pytest.warns(None):  # all NaN axis warning
+        assert_eq(da.nanargmax(a), np.nanargmax(x))
+    with pytest.warns(None):  # all NaN axis warning
+        assert_eq(da.nanargmin(a), np.nanargmin(x))
     assert_eq(da.argmax(a, axis=0), np.argmax(x, axis=0))
     assert_eq(da.argmin(a, axis=0), np.argmin(x, axis=0))
-    assert_eq(da.nanargmax(a, axis=0), np.nanargmax(x, axis=0))
-    assert_eq(da.nanargmin(a, axis=0), np.nanargmin(x, axis=0))
+    with pytest.warns(None):  # all NaN axis warning
+        assert_eq(da.nanargmax(a, axis=0), np.nanargmax(x, axis=0))
+    with pytest.warns(None):  # all NaN axis warning
+        assert_eq(da.nanargmin(a, axis=0), np.nanargmin(x, axis=0))
     assert_eq(da.argmax(a, axis=1), np.argmax(x, axis=1))
     assert_eq(da.argmin(a, axis=1), np.argmin(x, axis=1))
-    assert_eq(da.nanargmax(a, axis=1), np.nanargmax(x, axis=1))
-    assert_eq(da.nanargmin(a, axis=1), np.nanargmin(x, axis=1))
+    with pytest.warns(None):  # all NaN axis warning
+        assert_eq(da.nanargmax(a, axis=1), np.nanargmax(x, axis=1))
+    with pytest.warns(None):  # all NaN axis warning
+        assert_eq(da.nanargmin(a, axis=1), np.nanargmin(x, axis=1))
 
 
 def test_moment():
@@ -307,10 +321,11 @@ def test_reductions_with_empty_array():
     x2 = dx2.compute()
 
     for dx, x in [(dx1, x1), (dx2, x2)]:
-        assert_eq(dx.mean(), x.mean())
-        assert_eq(dx.mean(axis=0), x.mean(axis=0))
-        assert_eq(dx.mean(axis=1), x.mean(axis=1))
-        assert_eq(dx.mean(axis=2), x.mean(axis=2))
+        with pytest.warns(None):  # empty slice warning
+            assert_eq(dx.mean(), x.mean())
+            assert_eq(dx.mean(axis=0), x.mean(axis=0))
+            assert_eq(dx.mean(axis=1), x.mean(axis=1))
+            assert_eq(dx.mean(axis=2), x.mean(axis=2))
 
 
 def assert_max_deps(x, n, eq=True):

--- a/dask/array/tests/test_stats.py
+++ b/dask/array/tests/test_stats.py
@@ -74,8 +74,9 @@ def test_two(kind, kwargs):
     dask_test = getattr(dask.array.stats, kind)
     scipy_test = getattr(scipy.stats, kind)
 
-    result = dask_test(a_, b_, **kwargs)
-    expected = scipy_test(a, b, **kwargs)
+    with pytest.warns(None):  # maybe overflow warning (powrer_divergence)
+        result = dask_test(a_, b_, **kwargs)
+        expected = scipy_test(a, b, **kwargs)
 
     assert isinstance(result, Delayed)
     assert allclose(result.compute(), expected)

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -58,22 +58,24 @@ def test_unary_ufunc(ufunc):
     arr = np.random.randint(1, 100, size=(20, 20))
     darr = da.from_array(arr, 3)
 
-    # applying Dask ufunc doesn't trigger computation
-    assert isinstance(dafunc(darr), da.Array)
-    assert_eq(dafunc(darr), npfunc(arr), equal_nan=True)
+    with pytest.warns(None):  # some invalid values (arccos, arcsin, etc.)
+        # applying Dask ufunc doesn't trigger computation
+        assert isinstance(dafunc(darr), da.Array)
+        assert_eq(dafunc(darr), npfunc(arr), equal_nan=True)
 
-    # applying NumPy ufunc triggers computation
-    assert isinstance(npfunc(darr), np.ndarray)
-    assert_eq(npfunc(darr), npfunc(arr), equal_nan=True)
+    with pytest.warns(None):  # some invalid values (arccos, arcsin, etc.)
+        # applying NumPy ufunc triggers computation
+        assert isinstance(npfunc(darr), np.ndarray)
+        assert_eq(npfunc(darr), npfunc(arr), equal_nan=True)
 
-    # applying Dask ufunc to normal ndarray triggers computation
-    assert isinstance(dafunc(arr), np.ndarray)
-    assert_eq(dafunc(arr), npfunc(arr), equal_nan=True)
+    with pytest.warns(None):  # some invalid values (arccos, arcsin, etc.)
+        # applying Dask ufunc to normal ndarray triggers computation
+        assert isinstance(dafunc(arr), np.ndarray)
+        assert_eq(dafunc(arr), npfunc(arr), equal_nan=True)
 
 
 @pytest.mark.parametrize('ufunc', binary_ufuncs)
 def test_binary_ufunc(ufunc):
-
     dafunc = getattr(da, ufunc)
     npfunc = getattr(np, ufunc)
 
@@ -99,14 +101,16 @@ def test_binary_ufunc(ufunc):
     assert isinstance(dafunc(darr1, 10), da.Array)
     assert_eq(dafunc(darr1, 10), npfunc(arr1, 10))
 
-    assert isinstance(dafunc(10, darr1), da.Array)
-    assert_eq(dafunc(10, darr1), npfunc(10, arr1))
+    with pytest.warns(None):  # overflow in ldexp
+        assert isinstance(dafunc(10, darr1), da.Array)
+        assert_eq(dafunc(10, darr1), npfunc(10, arr1))
 
     assert isinstance(dafunc(arr1, 10), np.ndarray)
     assert_eq(dafunc(arr1, 10), npfunc(arr1, 10))
 
-    assert isinstance(dafunc(10, arr1), np.ndarray)
-    assert_eq(dafunc(10, arr1), npfunc(10, arr1))
+    with pytest.warns(None):  # overflow in ldexp
+        assert isinstance(dafunc(10, arr1), np.ndarray)
+        assert_eq(dafunc(10, arr1), npfunc(10, arr1))
 
 
 def test_ufunc_outer():

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -911,7 +911,7 @@ class _GroupBy(object):
                    "  Before: .apply(func)\n"
                    "  After:  .apply(func, meta={'x': 'f8', 'y': 'f8'}) for dataframe result\n"
                    "  or:     .apply(func, meta=('x', 'f8'))            for series result")
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
             with raise_on_meta_error("groupby.apply({0})".format(funcname(func))):
                 meta = self._meta_nonempty.apply(func)

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -436,11 +436,12 @@ def test_warn_non_seekable_files():
         assert 'blocksize=None' in msg
 
         with pytest.warns(None) as w:
-            df = dd.read_csv('2014-01-*.csv', compression='gzip', blocksize=None)
+            df = dd.read_csv('2014-01-*.csv', compression='gzip',
+                             blocksize=None)
         assert len(w) == 0
 
         with pytest.raises(NotImplementedError):
-            with pytest.warns(None):
+            with pytest.warns(UserWarning):  # needed for pytest
                 df = dd.read_csv('2014-01-*.csv', compression='foo')
 
 
@@ -730,8 +731,8 @@ def test_read_csv_sep():
     charlie###300""")
 
     with filetext(sep_text) as fn:
-        ddf = dd.read_csv(fn, sep="###")
-        df = pd.read_csv(fn, sep="###")
+        ddf = dd.read_csv(fn, sep="###", engine="python")
+        df = pd.read_csv(fn, sep="###", engine="python")
 
         assert (df.columns == ddf.columns).all()
         assert len(df) == len(ddf)

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -310,12 +310,14 @@ def test_from_pandas_single_row():
     assert_eq(ddf, df)
 
 
+@pytest.mark.skipif(np.__version__ < '1.11',
+                    reason='datetime unit unsupported in NumPy < 1.11')
 def test_from_pandas_with_datetime_index():
     df = pd.DataFrame({"Date": ["2015-08-28", "2015-08-27", "2015-08-26",
                                 "2015-08-25", "2015-08-24", "2015-08-21",
                                 "2015-08-20", "2015-08-19", "2015-08-18"],
                        "Val": list(range(9))})
-    df.Date = df.Date.astype('datetime64')
+    df.Date = df.Date.astype('datetime64[ns]')
     ddf = dd.from_pandas(df, 2)
     assert_eq(df, ddf)
     ddf = dd.from_pandas(df, chunksize=2)

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -635,9 +635,15 @@ def test_reductions(split_every):
         assert_eq(dds.min(split_every=split_every), pds.min())
         assert_eq(dds.max(split_every=split_every), pds.max())
         assert_eq(dds.count(split_every=split_every), pds.count())
-        assert_eq(dds.std(split_every=split_every), pds.std())
-        assert_eq(dds.var(split_every=split_every), pds.var())
-        assert_eq(dds.sem(split_every=split_every), pds.sem())
+        with pytest.warns(None):
+            # runtime warnings; https://github.com/dask/dask/issues/2381
+            assert_eq(dds.std(split_every=split_every), pds.std())
+        with pytest.warns(None):
+            # runtime warnings; https://github.com/dask/dask/issues/2381
+            assert_eq(dds.var(split_every=split_every), pds.var())
+        with pytest.warns(None):
+            # runtime warnings; https://github.com/dask/dask/issues/2381
+            assert_eq(dds.sem(split_every=split_every), pds.sem())
         assert_eq(dds.std(ddof=0, split_every=split_every), pds.std(ddof=0))
         assert_eq(dds.var(ddof=0, split_every=split_every), pds.var(ddof=0))
         assert_eq(dds.sem(ddof=0, split_every=split_every), pds.sem(ddof=0))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,5 +1,4 @@
 import sys
-import warnings
 from operator import add
 from itertools import product
 
@@ -1736,7 +1735,7 @@ def test_apply():
         ddf.apply(lambda xy: xy, axis='index')
 
 
-@pytest.mark.skipif(sys.version_info <= (2, 7),
+@pytest.mark.skipif(sys.version_info <= (3, 0),
                     reason="Global filter is applied by another library, and "
                            "not reset properly.")
 def test_apply_warns():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1736,9 +1736,10 @@ def test_apply():
         ddf.apply(lambda xy: xy, axis='index')
 
 
+@pytest.mark.skipif(sys.version_info <= (2, 7),
+                    reason="Global filter is applied by another library, and "
+                           "not reset properly.")
 def test_apply_warns():
-    if ('once', None, Warning, None, 0) in warnings.filters:
-        pytest.skip("Global warning filter interferes with this test")
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
     ddf = dd.from_pandas(df, npartitions=2)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1381,6 +1381,7 @@ def test_eval():
         with pytest.raises(NotImplementedError):
             d.eval('z = x + y', inplace=True)
 
+        # catch FutureWarning from pandas about assignment in eval
         with pytest.warns(None):
             if p.eval('z = x + y', inplace=None) is None:
                 with pytest.raises(NotImplementedError):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1381,9 +1381,10 @@ def test_eval():
         with pytest.raises(NotImplementedError):
             d.eval('z = x + y', inplace=True)
 
-        if p.eval('z = x + y', inplace=None) is None:
-            with pytest.raises(NotImplementedError):
-                d.eval('z = x + y', inplace=None)
+        with pytest.warns(None):
+            if p.eval('z = x + y', inplace=None) is None:
+                with pytest.raises(NotImplementedError):
+                    d.eval('z = x + y', inplace=None)
 
 
 @pytest.mark.parametrize('include, exclude', [
@@ -1702,7 +1703,7 @@ def test_apply():
     ddf = dd.from_pandas(df, npartitions=2)
 
     func = lambda row: row['x'] + row['y']
-    assert_eq(ddf.x.apply(lambda x: x + 1),
+    assert_eq(ddf.x.apply(lambda x: x + 1, meta=("x", int)),
               df.x.apply(lambda x: x + 1))
 
     # specify meta
@@ -1712,16 +1713,19 @@ def test_apply():
               df.apply(lambda xy: xy[0] + xy[1], axis='columns'))
 
     # inference
-    assert_eq(ddf.apply(lambda xy: xy[0] + xy[1], axis=1),
-              df.apply(lambda xy: xy[0] + xy[1], axis=1))
-    assert_eq(ddf.apply(lambda xy: xy, axis=1),
-              df.apply(lambda xy: xy, axis=1))
+    with pytest.warns(None):
+        assert_eq(ddf.apply(lambda xy: xy[0] + xy[1], axis=1),
+                  df.apply(lambda xy: xy[0] + xy[1], axis=1))
+    with pytest.warns(None):
+        assert_eq(ddf.apply(lambda xy: xy, axis=1),
+                  df.apply(lambda xy: xy, axis=1))
 
     # specify meta
     func = lambda x: pd.Series([x, x])
     assert_eq(ddf.x.apply(func, meta=[(0, int), (1, int)]), df.x.apply(func))
     # inference
-    assert_eq(ddf.x.apply(func), df.x.apply(func))
+    with pytest.warns(None):
+        assert_eq(ddf.x.apply(func), df.x.apply(func))
 
     # axis=0
     with pytest.raises(NotImplementedError):
@@ -1729,6 +1733,21 @@ def test_apply():
 
     with pytest.raises(NotImplementedError):
         ddf.apply(lambda xy: xy, axis='index')
+
+
+def test_apply_warns():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    func = lambda row: row['x'] + row['y']
+
+    with pytest.warns(UserWarning) as w:
+        ddf.apply(func, axis=1)
+    assert len(w) == 1
+
+    with pytest.warns(None) as w:
+        ddf.apply(func, axis=1, meta=(None, int))
+    assert len(w) == 0
 
 
 def test_applymap():
@@ -1886,13 +1905,15 @@ def test_apply_infer_columns():
         return pd.Series([x.sum(), x.mean()], index=['sum', 'mean'])
 
     # DataFrame to completely different DataFrame
-    result = ddf.apply(return_df, axis=1)
+    with pytest.warns(None):
+        result = ddf.apply(return_df, axis=1)
     assert isinstance(result, dd.DataFrame)
     tm.assert_index_equal(result.columns, pd.Index(['sum', 'mean']))
     assert_eq(result, df.apply(return_df, axis=1))
 
     # DataFrame to Series
-    result = ddf.apply(lambda x: 1, axis=1)
+    with pytest.warns(None):
+        result = ddf.apply(lambda x: 1, axis=1)
     assert isinstance(result, dd.Series)
     assert result.name is None
     assert_eq(result, df.apply(lambda x: 1, axis=1))
@@ -1901,13 +1922,15 @@ def test_apply_infer_columns():
         return pd.Series([x * 2, x * 3], index=['x2', 'x3'])
 
     # Series to completely different DataFrame
-    result = ddf.x.apply(return_df2)
+    with pytest.warns(None):
+        result = ddf.x.apply(return_df2)
     assert isinstance(result, dd.DataFrame)
     tm.assert_index_equal(result.columns, pd.Index(['x2', 'x3']))
     assert_eq(result, df.x.apply(return_df2))
 
     # Series to Series
-    result = ddf.x.apply(lambda x: 1)
+    with pytest.warns(None):
+        result = ddf.x.apply(lambda x: 1)
     assert isinstance(result, dd.Series)
     assert result.name == 'x'
     assert_eq(result, df.x.apply(lambda x: 1))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from operator import add
 from itertools import product
 
@@ -1736,6 +1737,8 @@ def test_apply():
 
 
 def test_apply_warns():
+    if ('once', None, Warning, None, 0) in warnings.filters:
+        pytest.skip("Global warning filter interferes with this test")
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
     ddf = dd.from_pandas(df, npartitions=2)
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -110,7 +110,7 @@ def test_full_groupby():
         return df
 
     assert_eq(df.groupby('a').apply(func),
-              ddf.groupby('a').apply(func))
+              ddf.groupby('a').apply(func, meta={"a": int, "b": float}))
 
 
 @pytest.mark.parametrize('grouper', [
@@ -131,8 +131,10 @@ def test_full_groupby_multilevel(grouper):
         df['b'] = df.b - df.b.mean()
         return df
 
+    # last one causes a DeprcationWarning from pandas, hard to track down...
     assert_eq(df.groupby(grouper(df)).apply(func),
-              ddf.groupby(grouper(ddf)).apply(func))
+              ddf.groupby(grouper(ddf)).apply(func, meta={"a": int, "d": int,
+                                                          "b": float}))
 
 
 def test_groupby_dir():
@@ -158,14 +160,15 @@ def test_groupby_on_index(get):
         return df.assign(b=df.b - df.b.mean())
 
     with dask.set_options(get=get):
-        assert_eq(ddf.groupby('a').apply(func),
-                  pdf.groupby('a').apply(func))
+        with pytest.warns(None):
+            assert_eq(ddf.groupby('a').apply(func),
+                      pdf.groupby('a').apply(func))
 
-        assert_eq(ddf.groupby('a').apply(func).set_index('a'),
-                  pdf.groupby('a').apply(func).set_index('a'))
+            assert_eq(ddf.groupby('a').apply(func).set_index('a'),
+                      pdf.groupby('a').apply(func).set_index('a'))
 
-        assert_eq(pdf2.groupby(pdf2.index).apply(func),
-                  ddf2.groupby(ddf2.index).apply(func))
+            assert_eq(pdf2.groupby(pdf2.index).apply(func),
+                      ddf2.groupby(ddf2.index).apply(func))
 
 
 def test_groupby_multilevel_getitem():
@@ -258,7 +261,8 @@ def test_series_groupby_propagates_names():
     df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
     ddf = dd.from_pandas(df, 2)
     func = lambda df: df['y'].sum()
-    result = ddf.groupby('x').apply(func)
+    with pytest.warns(UserWarning):
+        result = ddf.groupby('x').apply(func)
     expected = df.groupby('x').apply(func)
     assert_eq(result, expected)
 
@@ -513,34 +517,35 @@ def test_apply_shuffle():
                         'D': np.random.randn(20)})
     ddf = dd.from_pandas(pdf, 3)
 
-    assert_eq(ddf.groupby('A').apply(lambda x: x.sum()),
-              pdf.groupby('A').apply(lambda x: x.sum()))
+    with pytest.warns(UserWarning):
+        assert_eq(ddf.groupby('A').apply(lambda x: x.sum()),
+                  pdf.groupby('A').apply(lambda x: x.sum()))
 
-    assert_eq(ddf.groupby(ddf['A']).apply(lambda x: x.sum()),
-              pdf.groupby(pdf['A']).apply(lambda x: x.sum()))
+        assert_eq(ddf.groupby(ddf['A']).apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A']).apply(lambda x: x.sum()))
 
-    assert_eq(ddf.groupby(ddf['A'] + 1).apply(lambda x: x.sum()),
-              pdf.groupby(pdf['A'] + 1).apply(lambda x: x.sum()))
+        assert_eq(ddf.groupby(ddf['A'] + 1).apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A'] + 1).apply(lambda x: x.sum()))
 
-    # SeriesGroupBy
-    assert_eq(ddf.groupby('A')['B'].apply(lambda x: x.sum()),
-              pdf.groupby('A')['B'].apply(lambda x: x.sum()))
+        # SeriesGroupBy
+        assert_eq(ddf.groupby('A')['B'].apply(lambda x: x.sum()),
+                  pdf.groupby('A')['B'].apply(lambda x: x.sum()))
 
-    assert_eq(ddf.groupby(ddf['A'])['B'].apply(lambda x: x.sum()),
-              pdf.groupby(pdf['A'])['B'].apply(lambda x: x.sum()))
+        assert_eq(ddf.groupby(ddf['A'])['B'].apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A'])['B'].apply(lambda x: x.sum()))
 
-    assert_eq(ddf.groupby(ddf['A'] + 1)['B'].apply(lambda x: x.sum()),
-              pdf.groupby(pdf['A'] + 1)['B'].apply(lambda x: x.sum()))
+        assert_eq(ddf.groupby(ddf['A'] + 1)['B'].apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A'] + 1)['B'].apply(lambda x: x.sum()))
 
-    # DataFrameGroupBy with column slice
-    assert_eq(ddf.groupby('A')[['B', 'C']].apply(lambda x: x.sum()),
-              pdf.groupby('A')[['B', 'C']].apply(lambda x: x.sum()))
+        # DataFrameGroupBy with column slice
+        assert_eq(ddf.groupby('A')[['B', 'C']].apply(lambda x: x.sum()),
+                  pdf.groupby('A')[['B', 'C']].apply(lambda x: x.sum()))
 
-    assert_eq(ddf.groupby(ddf['A'])[['B', 'C']].apply(lambda x: x.sum()),
-              pdf.groupby(pdf['A'])[['B', 'C']].apply(lambda x: x.sum()))
+        assert_eq(ddf.groupby(ddf['A'])[['B', 'C']].apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A'])[['B', 'C']].apply(lambda x: x.sum()))
 
-    assert_eq(ddf.groupby(ddf['A'] + 1)[['B', 'C']].apply(lambda x: x.sum()),
-              pdf.groupby(pdf['A'] + 1)[['B', 'C']].apply(lambda x: x.sum()))
+        assert_eq(ddf.groupby(ddf['A'] + 1)[['B', 'C']].apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A'] + 1)[['B', 'C']].apply(lambda x: x.sum()))
 
 
 @pytest.mark.parametrize('grouper', [
@@ -559,17 +564,18 @@ def test_apply_shuffle_multilevel(grouper):
                         'D': np.random.randn(20)})
     ddf = dd.from_pandas(pdf, 3)
 
-    # DataFrameGroupBy
-    assert_eq(ddf.groupby(grouper(ddf)).apply(lambda x: x.sum()),
-              pdf.groupby(grouper(pdf)).apply(lambda x: x.sum()))
+    with pytest.warns(UserWarning):
+        # DataFrameGroupBy
+        assert_eq(ddf.groupby(grouper(ddf)).apply(lambda x: x.sum()),
+                  pdf.groupby(grouper(pdf)).apply(lambda x: x.sum()))
 
-    # SeriesGroupBy
-    assert_eq(ddf.groupby(grouper(ddf))['B'].apply(lambda x: x.sum()),
-              pdf.groupby(grouper(pdf))['B'].apply(lambda x: x.sum()))
+        # SeriesGroupBy
+        assert_eq(ddf.groupby(grouper(ddf))['B'].apply(lambda x: x.sum()),
+                  pdf.groupby(grouper(pdf))['B'].apply(lambda x: x.sum()))
 
-    # DataFrameGroupBy with column slice
-    assert_eq(ddf.groupby(grouper(ddf))[['B', 'C']].apply(lambda x: x.sum()),
-              pdf.groupby(grouper(pdf))[['B', 'C']].apply(lambda x: x.sum()))
+        # DataFrameGroupBy with column slice
+        assert_eq(ddf.groupby(grouper(ddf))[['B', 'C']].apply(lambda x: x.sum()),
+                  pdf.groupby(grouper(pdf))[['B', 'C']].apply(lambda x: x.sum()))
 
 
 def test_numeric_column_names():
@@ -581,7 +587,7 @@ def test_numeric_column_names():
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf.groupby(0).sum(), df.groupby(0).sum())
     assert_eq(ddf.groupby([0, 2]).sum(), df.groupby([0, 2]).sum())
-    assert_eq(ddf.groupby(0).apply(lambda x: x),
+    assert_eq(ddf.groupby(0).apply(lambda x: x, meta={0: int, 1: int, 2: int}),
               df.groupby(0).apply(lambda x: x))
 
 
@@ -594,12 +600,14 @@ def test_groupby_apply_tasks():
     with dask.set_options(shuffle='tasks'):
         for ind in [lambda x: 'A', lambda x: x.A]:
             a = df.groupby(ind(df)).apply(len)
-            b = ddf.groupby(ind(ddf)).apply(len)
+            with pytest.warns(UserWarning):
+                b = ddf.groupby(ind(ddf)).apply(len)
             assert_eq(a, b.compute())
             assert not any('partd' in k[0] for k in b.dask)
 
             a = df.groupby(ind(df)).B.apply(len)
-            b = ddf.groupby(ind(ddf)).B.apply(len)
+            with pytest.warns(UserWarning):
+                b = ddf.groupby(ind(ddf)).B.apply(len)
             assert_eq(a, b.compute())
             assert not any('partd' in k[0] for k in b.dask)
 
@@ -610,7 +618,8 @@ def test_groupby_multiprocessing():
                        'B': ['1','1','a','a','a']})
     ddf = dd.from_pandas(df, npartitions=3)
     with dask.set_options(get=get):
-        assert_eq(ddf.groupby('B').apply(lambda x: x),
+        assert_eq(ddf.groupby('B').apply(lambda x: x, meta={"A": int,
+                                                            "B": object}),
                   df.groupby('B').apply(lambda x: x))
 
 
@@ -652,8 +661,12 @@ def test_aggregate__examples(spec, split_every, grouper):
                        columns=['c', 'b', 'a', 'd'])
     ddf = dd.from_pandas(pdf, npartitions=10)
 
-    assert_eq(pdf.groupby(grouper(pdf)).agg(spec),
-              ddf.groupby(grouper(ddf)).agg(spec, split_every=split_every))
+    # Warning from pandas deprecation .agg(dict[dict])
+    # it's from pandas, so no reason to assert the deprecation warning,
+    # but we should still test it for now
+    with pytest.warns(None):
+        assert_eq(pdf.groupby(grouper(pdf)).agg(spec),
+                  ddf.groupby(grouper(ddf)).agg(spec, split_every=split_every))
 
 
 @pytest.mark.parametrize('spec', [
@@ -678,9 +691,12 @@ def test_series_aggregate__examples(spec, split_every, grouper):
 
     ddf = dd.from_pandas(pdf, npartitions=10)
     ds = ddf['c']
-
-    assert_eq(ps.groupby(grouper(pdf)).agg(spec),
-              ds.groupby(grouper(ddf)).agg(spec, split_every=split_every))
+    # Warning from pandas deprecation .agg(dict[dict])
+    # it's from pandas, so no reason to assert the deprecation warning,
+    # but we should still test it for now
+    with pytest.warns(None):
+        assert_eq(ps.groupby(grouper(pdf)).agg(spec),
+                  ds.groupby(grouper(ddf)).agg(spec, split_every=split_every))
 
 
 @pytest.mark.parametrize('spec', [

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -131,7 +131,8 @@ def test_full_groupby_multilevel(grouper):
         df['b'] = df.b - df.b.mean()
         return df
 
-    # last one causes a DeprcationWarning from pandas, hard to track down...
+    # last one causes a DeprcationWarning from pandas.
+    # See https://github.com/pandas-dev/pandas/issues/16481
     assert_eq(df.groupby(grouper(df)).apply(func),
               ddf.groupby(grouper(ddf)).apply(func, meta={"a": int, "d": int,
                                                           "b": float}))
@@ -261,7 +262,7 @@ def test_series_groupby_propagates_names():
     df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
     ddf = dd.from_pandas(df, 2)
     func = lambda df: df['y'].sum()
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning):  # meta inference
         result = ddf.groupby('x').apply(func)
     expected = df.groupby('x').apply(func)
     assert_eq(result, expected)
@@ -517,7 +518,7 @@ def test_apply_shuffle():
                         'D': np.random.randn(20)})
     ddf = dd.from_pandas(pdf, 3)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning):  # meta inference
         assert_eq(ddf.groupby('A').apply(lambda x: x.sum()),
                   pdf.groupby('A').apply(lambda x: x.sum()))
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -822,7 +822,7 @@ def test_concat_unknown_divisions_errors():
     bb = dd.from_pandas(b, npartitions=2, sort=False)
 
     with pytest.raises(ValueError):
-        with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning):  # Concat with unknown divisions
             dd.concat([aa, bb], axis=1).compute()
 
 
@@ -1117,6 +1117,7 @@ def test_append2():
     assert_eq(ddf2.append(ddf1), ddf2.compute().append(ddf1.compute()))
     # Series + DataFrame
     with pytest.warns(None):
+        # RuntimeWarning from pandas on comparing int and str
         assert_eq(ddf1.a.append(ddf2), ddf1.a.compute().append(ddf2.compute()))
         assert_eq(ddf2.a.append(ddf1), ddf2.a.compute().append(ddf1.compute()))
 
@@ -1125,6 +1126,7 @@ def test_append2():
     assert_eq(ddf3.append(ddf1), ddf3.compute().append(ddf1.compute()))
     # Series + DataFrame
     with pytest.warns(None):
+        # RuntimeWarning from pandas on comparing int and str
         assert_eq(ddf1.a.append(ddf3), ddf1.a.compute().append(ddf3.compute()))
         assert_eq(ddf3.b.append(ddf1), ddf3.b.compute().append(ddf1.compute()))
 
@@ -1133,6 +1135,7 @@ def test_append2():
     assert_eq(ddf2.append(ddf1.compute()), ddf2.compute().append(ddf1.compute()))
     # Series + DataFrame
     with pytest.warns(None):
+        # RuntimeWarning from pandas on comparing int and str
         assert_eq(ddf1.a.append(ddf2.compute()), ddf1.a.compute().append(ddf2.compute()))
         assert_eq(ddf2.a.append(ddf1.compute()), ddf2.a.compute().append(ddf1.compute()))
 
@@ -1141,6 +1144,7 @@ def test_append2():
     assert_eq(ddf3.append(ddf1.compute()), ddf3.compute().append(ddf1.compute()))
     # Series + DataFrame
     with pytest.warns(None):
+        # RuntimeWarning from pandas on comparing int and str
         assert_eq(ddf1.a.append(ddf3.compute()), ddf1.a.compute().append(ddf3.compute()))
         assert_eq(ddf3.b.append(ddf1.compute()), ddf3.b.compute().append(ddf1.compute()))
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -583,6 +583,7 @@ def test_join_by_index_patterns(how, shuffle):
 @pytest.mark.parametrize('how', ['inner', 'outer', 'left', 'right'])
 @pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
 def test_merge_by_multiple_columns(how, shuffle):
+    # warnings here from pandas
     pdf1l = pd.DataFrame({'a': list('abcdefghij'),
                           'b': list('abcdefghij'),
                           'c': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]},
@@ -805,8 +806,9 @@ def test_concat_unknown_divisions():
 
     assert not aa.known_divisions
 
-    assert_eq(pd.concat([a, b], axis=1),
-              dd.concat([aa, bb], axis=1))
+    with pytest.warns(UserWarning):
+        assert_eq(pd.concat([a, b], axis=1),
+                  dd.concat([aa, bb], axis=1))
 
     cc = dd.from_pandas(b, npartitions=1, sort=False)
     with pytest.raises(ValueError):
@@ -820,7 +822,8 @@ def test_concat_unknown_divisions_errors():
     bb = dd.from_pandas(b, npartitions=2, sort=False)
 
     with pytest.raises(ValueError):
-        dd.concat([aa, bb], axis=1).compute()
+        with pytest.warns(UserWarning):
+            dd.concat([aa, bb], axis=1).compute()
 
 
 def test_concat2():
@@ -959,8 +962,10 @@ def test_concat5():
     for case in cases:
         pdcase = [c.compute() for c in case]
 
-        assert_eq(dd.concat(case, interleave_partitions=True),
-                  pd.concat(pdcase))
+        with pytest.warns(None):
+            # some cases will raise warning directly from pandas
+            assert_eq(dd.concat(case, interleave_partitions=True),
+                      pd.concat(pdcase))
 
         assert_eq(dd.concat(case, join='inner', interleave_partitions=True),
                   pd.concat(pdcase, join='inner'))
@@ -1111,29 +1116,33 @@ def test_append2():
     assert_eq(ddf1.append(ddf2), ddf1.compute().append(ddf2.compute()))
     assert_eq(ddf2.append(ddf1), ddf2.compute().append(ddf1.compute()))
     # Series + DataFrame
-    assert_eq(ddf1.a.append(ddf2), ddf1.a.compute().append(ddf2.compute()))
-    assert_eq(ddf2.a.append(ddf1), ddf2.a.compute().append(ddf1.compute()))
+    with pytest.warns(None):
+        assert_eq(ddf1.a.append(ddf2), ddf1.a.compute().append(ddf2.compute()))
+        assert_eq(ddf2.a.append(ddf1), ddf2.a.compute().append(ddf1.compute()))
 
     # different columns
     assert_eq(ddf1.append(ddf3), ddf1.compute().append(ddf3.compute()))
     assert_eq(ddf3.append(ddf1), ddf3.compute().append(ddf1.compute()))
     # Series + DataFrame
-    assert_eq(ddf1.a.append(ddf3), ddf1.a.compute().append(ddf3.compute()))
-    assert_eq(ddf3.b.append(ddf1), ddf3.b.compute().append(ddf1.compute()))
+    with pytest.warns(None):
+        assert_eq(ddf1.a.append(ddf3), ddf1.a.compute().append(ddf3.compute()))
+        assert_eq(ddf3.b.append(ddf1), ddf3.b.compute().append(ddf1.compute()))
 
     # Dask + pandas
     assert_eq(ddf1.append(ddf2.compute()), ddf1.compute().append(ddf2.compute()))
     assert_eq(ddf2.append(ddf1.compute()), ddf2.compute().append(ddf1.compute()))
     # Series + DataFrame
-    assert_eq(ddf1.a.append(ddf2.compute()), ddf1.a.compute().append(ddf2.compute()))
-    assert_eq(ddf2.a.append(ddf1.compute()), ddf2.a.compute().append(ddf1.compute()))
+    with pytest.warns(None):
+        assert_eq(ddf1.a.append(ddf2.compute()), ddf1.a.compute().append(ddf2.compute()))
+        assert_eq(ddf2.a.append(ddf1.compute()), ddf2.a.compute().append(ddf1.compute()))
 
     # different columns
     assert_eq(ddf1.append(ddf3.compute()), ddf1.compute().append(ddf3.compute()))
     assert_eq(ddf3.append(ddf1.compute()), ddf3.compute().append(ddf1.compute()))
     # Series + DataFrame
-    assert_eq(ddf1.a.append(ddf3.compute()), ddf1.a.compute().append(ddf3.compute()))
-    assert_eq(ddf3.b.append(ddf1.compute()), ddf3.b.compute().append(ddf1.compute()))
+    with pytest.warns(None):
+        assert_eq(ddf1.a.append(ddf3.compute()), ddf1.a.compute().append(ddf3.compute()))
+        assert_eq(ddf3.b.append(ddf1.compute()), ddf3.b.compute().append(ddf1.compute()))
 
 
 def test_append_categorical():

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -95,29 +95,30 @@ def mad(x):
 
 def rolling_functions_tests(p, d):
     # Old-fashioned rolling API
-    assert_eq(pd.rolling_count(p, 3), dd.rolling_count(d, 3))
-    assert_eq(pd.rolling_sum(p, 3), dd.rolling_sum(d, 3))
-    assert_eq(pd.rolling_mean(p, 3), dd.rolling_mean(d, 3))
-    assert_eq(pd.rolling_median(p, 3), dd.rolling_median(d, 3))
-    assert_eq(pd.rolling_min(p, 3), dd.rolling_min(d, 3))
-    assert_eq(pd.rolling_max(p, 3), dd.rolling_max(d, 3))
-    assert_eq(pd.rolling_std(p, 3), dd.rolling_std(d, 3))
-    assert_eq(pd.rolling_var(p, 3), dd.rolling_var(d, 3))
-    # see note around test_rolling_dataframe for logic concerning precision
-    assert_eq(pd.rolling_skew(p, 3),
-              dd.rolling_skew(d, 3), check_less_precise=True)
-    assert_eq(pd.rolling_kurt(p, 3),
-              dd.rolling_kurt(d, 3), check_less_precise=True)
-    assert_eq(pd.rolling_quantile(p, 3, 0.5), dd.rolling_quantile(d, 3, 0.5))
-    assert_eq(pd.rolling_apply(p, 3, mad), dd.rolling_apply(d, 3, mad))
-    assert_eq(pd.rolling_window(p, 3, win_type='boxcar'),
-              dd.rolling_window(d, 3, win_type='boxcar'))
-    # Test with edge-case window sizes
-    assert_eq(pd.rolling_sum(p, 0), dd.rolling_sum(d, 0))
-    assert_eq(pd.rolling_sum(p, 1), dd.rolling_sum(d, 1))
-    # Test with kwargs
-    assert_eq(pd.rolling_sum(p, 3, min_periods=3),
-              dd.rolling_sum(d, 3, min_periods=3))
+    with pytest.warns(FutureWarning):
+        assert_eq(pd.rolling_count(p, 3), dd.rolling_count(d, 3))
+        assert_eq(pd.rolling_sum(p, 3), dd.rolling_sum(d, 3))
+        assert_eq(pd.rolling_mean(p, 3), dd.rolling_mean(d, 3))
+        assert_eq(pd.rolling_median(p, 3), dd.rolling_median(d, 3))
+        assert_eq(pd.rolling_min(p, 3), dd.rolling_min(d, 3))
+        assert_eq(pd.rolling_max(p, 3), dd.rolling_max(d, 3))
+        assert_eq(pd.rolling_std(p, 3), dd.rolling_std(d, 3))
+        assert_eq(pd.rolling_var(p, 3), dd.rolling_var(d, 3))
+        # see note around test_rolling_dataframe for logic concerning precision
+        assert_eq(pd.rolling_skew(p, 3),
+                  dd.rolling_skew(d, 3), check_less_precise=True)
+        assert_eq(pd.rolling_kurt(p, 3),
+                  dd.rolling_kurt(d, 3), check_less_precise=True)
+        assert_eq(pd.rolling_quantile(p, 3, 0.5), dd.rolling_quantile(d, 3, 0.5))
+        assert_eq(pd.rolling_apply(p, 3, mad), dd.rolling_apply(d, 3, mad))
+        assert_eq(pd.rolling_window(p, 3, win_type='boxcar'),
+                  dd.rolling_window(d, 3, win_type='boxcar'))
+        # Test with edge-case window sizes
+        assert_eq(pd.rolling_sum(p, 0), dd.rolling_sum(d, 0))
+        assert_eq(pd.rolling_sum(p, 1), dd.rolling_sum(d, 1))
+        # Test with kwargs
+        assert_eq(pd.rolling_sum(p, 3, min_periods=3),
+                  dd.rolling_sum(d, 3, min_periods=3))
 
 
 def test_rolling_functions_series():

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -30,31 +30,34 @@ def test_ufunc(ufunc):
     ds = dd.from_pandas(s, 3)
 
     # applying Dask ufunc doesn't trigger computation
-    assert isinstance(dafunc(ds), dd.Series)
-    assert_eq(dafunc(ds), npfunc(s))
+    with pytest.warns(None):
+        # Some cause warnings (arcsine)
+        assert isinstance(dafunc(ds), dd.Series)
+        assert_eq(dafunc(ds), npfunc(s))
 
-    # applying NumPy ufunc triggers computation
-    assert isinstance(npfunc(ds), pd.Series)
-    assert_eq(npfunc(ds), npfunc(s))
+        # applying NumPy ufunc triggers computation
+        assert isinstance(npfunc(ds), pd.Series)
+        assert_eq(npfunc(ds), npfunc(s))
 
-    # applying Dask ufunc to normal Series triggers computation
-    assert isinstance(dafunc(s), pd.Series)
-    assert_eq(dafunc(s), npfunc(s))
+        # applying Dask ufunc to normal Series triggers computation
+        assert isinstance(dafunc(s), pd.Series)
+        assert_eq(dafunc(s), npfunc(s))
 
     s = pd.Series(np.abs(np.random.randn(100)))
     ds = dd.from_pandas(s, 3)
 
-    # applying Dask ufunc doesn't trigger computation
-    assert isinstance(dafunc(ds), dd.Series)
-    assert_eq(dafunc(ds), npfunc(s))
+    with pytest.warns(None):
+        # applying Dask ufunc doesn't trigger computation
+        assert isinstance(dafunc(ds), dd.Series)
+        assert_eq(dafunc(ds), npfunc(s))
 
-    # applying NumPy ufunc triggers computation
-    assert isinstance(npfunc(ds), pd.Series)
-    assert_eq(npfunc(ds), npfunc(s))
+        # applying NumPy ufunc triggers computation
+        assert isinstance(npfunc(ds), pd.Series)
+        assert_eq(npfunc(ds), npfunc(s))
 
-    # applying Dask ufunc to normal Series triggers computation
-    assert isinstance(dafunc(s), pd.Series)
-    assert_eq(dafunc(s), npfunc(s))
+        # applying Dask ufunc to normal Series triggers computation
+        assert isinstance(dafunc(s), pd.Series)
+        assert_eq(dafunc(s), npfunc(s))
 
     # DataFrame
     df = pd.DataFrame({'A': np.random.randint(1, 100, size=20),
@@ -62,32 +65,36 @@ def test_ufunc(ufunc):
                        'C': np.abs(np.random.randn(20))})
     ddf = dd.from_pandas(df, 3)
 
-    # applying Dask ufunc doesn't trigger computation
-    assert isinstance(dafunc(ddf), dd.DataFrame)
-    assert_eq(dafunc(ddf), npfunc(df))
+    with pytest.warns(None):
+        # applying Dask ufunc doesn't trigger computation
+        assert isinstance(dafunc(ddf), dd.DataFrame)
+        assert_eq(dafunc(ddf), npfunc(df))
 
-    # applying NumPy ufunc triggers computation
-    assert isinstance(npfunc(ddf), pd.DataFrame)
-    assert_eq(npfunc(ddf), npfunc(df))
+        # applying NumPy ufunc triggers computation
+        assert isinstance(npfunc(ddf), pd.DataFrame)
+        assert_eq(npfunc(ddf), npfunc(df))
 
-    # applying Dask ufunc to normal Dataframe triggers computation
-    assert isinstance(dafunc(df), pd.DataFrame)
-    assert_eq(dafunc(df), npfunc(df))
+        # applying Dask ufunc to normal Dataframe triggers computation
+        assert isinstance(dafunc(df), pd.DataFrame)
+        assert_eq(dafunc(df), npfunc(df))
 
     # Index
     if ufunc in ('logical_not', 'signbit', 'isnan', 'isinf', 'isfinite'):
         return
 
-    assert isinstance(dafunc(ddf.index), dd.Index)
-    assert_eq(dafunc(ddf.index), npfunc(df.index))
+    with pytest.warns(None):
+        assert isinstance(dafunc(ddf.index), dd.Index)
+        assert_eq(dafunc(ddf.index), npfunc(df.index))
 
-    # applying NumPy ufunc triggers computation
-    assert isinstance(npfunc(ddf.index), pd.Index)
-    assert_eq(npfunc(ddf.index), npfunc(df.index))
+        # applying NumPy ufunc triggers computation
+        assert isinstance(npfunc(ddf.index), pd.Index)
+        assert_eq(npfunc(ddf.index), npfunc(df.index))
 
     # applying Dask ufunc to normal Series triggers computation
-    assert isinstance(dafunc(df.index), pd.Index)
-    assert_eq(dafunc(df), npfunc(df))
+    with pytest.warns(None):
+        # some (da.log) cause warnings
+        assert isinstance(dafunc(df.index), pd.Index)
+        assert_eq(dafunc(df), npfunc(df))
 
 
 @pytest.mark.parametrize('ufunc', _BASE_UFUNCS)
@@ -101,32 +108,34 @@ def test_ufunc_with_index(ufunc):
     ds = dd.from_pandas(s, 3)
 
     # applying Dask ufunc doesn't trigger computation
-    assert isinstance(dafunc(ds), dd.Series)
-    assert_eq(dafunc(ds), npfunc(s))
+    with pytest.warns(None):
+        assert isinstance(dafunc(ds), dd.Series)
+        assert_eq(dafunc(ds), npfunc(s))
 
-    # applying NumPy ufunc triggers computation
-    assert isinstance(npfunc(ds), pd.Series)
-    assert_eq(npfunc(ds), npfunc(s))
+        # applying NumPy ufunc triggers computation
+        assert isinstance(npfunc(ds), pd.Series)
+        assert_eq(npfunc(ds), npfunc(s))
 
-    # applying Dask ufunc to normal Series triggers computation
-    assert isinstance(dafunc(s), pd.Series)
-    assert_eq(dafunc(s), npfunc(s))
+        # applying Dask ufunc to normal Series triggers computation
+        assert isinstance(dafunc(s), pd.Series)
+        assert_eq(dafunc(s), npfunc(s))
 
     s = pd.Series(np.abs(np.random.randn(20)),
                   index=list('abcdefghijklmnopqrst'))
     ds = dd.from_pandas(s, 3)
 
-    # applying Dask ufunc doesn't trigger computation
-    assert isinstance(dafunc(ds), dd.Series)
-    assert_eq(dafunc(ds), npfunc(s))
+    with pytest.warns(None):
+        # applying Dask ufunc doesn't trigger computation
+        assert isinstance(dafunc(ds), dd.Series)
+        assert_eq(dafunc(ds), npfunc(s))
 
-    # applying NumPy ufunc triggers computation
-    assert isinstance(npfunc(ds), pd.Series)
-    assert_eq(npfunc(ds), npfunc(s))
+        # applying NumPy ufunc triggers computation
+        assert isinstance(npfunc(ds), pd.Series)
+        assert_eq(npfunc(ds), npfunc(s))
 
-    # applying Dask ufunc to normal Series triggers computation
-    assert isinstance(dafunc(s), pd.Series)
-    assert_eq(dafunc(s), npfunc(s))
+        # applying Dask ufunc to normal Series triggers computation
+        assert isinstance(dafunc(s), pd.Series)
+        assert_eq(dafunc(s), npfunc(s))
 
     df = pd.DataFrame({'A': np.random.randint(1, 100, size=20),
                        'B': np.random.randint(1, 100, size=20),
@@ -134,17 +143,18 @@ def test_ufunc_with_index(ufunc):
                       index=list('abcdefghijklmnopqrst'))
     ddf = dd.from_pandas(df, 3)
 
-    # applying Dask ufunc doesn't trigger computation
-    assert isinstance(dafunc(ddf), dd.DataFrame)
-    assert_eq(dafunc(ddf), npfunc(df))
+    with pytest.warns(None):
+        # applying Dask ufunc doesn't trigger computation
+        assert isinstance(dafunc(ddf), dd.DataFrame)
+        assert_eq(dafunc(ddf), npfunc(df))
 
-    # applying NumPy ufunc triggers computation
-    assert isinstance(npfunc(ddf), pd.DataFrame)
-    assert_eq(npfunc(ddf), npfunc(df))
+        # applying NumPy ufunc triggers computation
+        assert isinstance(npfunc(ddf), pd.DataFrame)
+        assert_eq(npfunc(ddf), npfunc(df))
 
-    # applying Dask ufunc to normal DataFrame triggers computation
-    assert isinstance(dafunc(df), pd.DataFrame)
-    assert_eq(dafunc(df), npfunc(df))
+        # applying Dask ufunc to normal DataFrame triggers computation
+        assert isinstance(dafunc(df), pd.DataFrame)
+        assert_eq(dafunc(df), npfunc(df))
 
 
 @pytest.mark.parametrize('ufunc', ['isreal', 'iscomplex', 'real', 'imag',


### PR DESCRIPTION
Catches a handful of warnings from the dask.dataframe test suite. Remaining
warnings fall into a few classes:

1. `ResoucreWarning` from cloudpickle (e.g.
  `dask/dataframe/tests/test_arithmetics_reduction.py::test_frame_series_arithmetic_methods)`
  Not sure what to do here. Probably a legitimate concern of dask's?
2. `RuntimeWarning` from numpy (e.g.
  `dask/dataframe/tests/test_arithmetics_reduction.py::test_reductions[False]`
  I think dask should catch these, (followup PR)
3. `ImportWarning` from dependencies importing C-extensions code? e.g.
  `dask/dataframe/tests/test_categorical.py::test_categorical_set_index[disk]`
  I have a fix for partd (msgpack). Pandas has some too. Still investigating,
  may be a Cython issue
4. `DeprecationWarning` on regexes. e.g.
  `dask/dataframe/tests/test_groupby.py::test_full_groupby_multilevel[grouper4]`
  I think these are all pandas. xref
  https://github.com/pandas-dev/pandas/issues/16481#issuecomment-303836235
5. `RuntimeWarning` from pandas merge, e.g.
  `dask/dataframe/tests/test_multi.py::test_merge_by_multiple_columns[disk-inner]`
  Filing an issue on pandas