### PR TITLE
Update setup.py to include "install_requires"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(name='dask',
       packages=packages + tests,
       long_description=(open('README.rst').read() if exists('README.rst')
                         else ''),
+      install_requires=extras_require['dataframe'],
       extras_require=extras_require,
       zip_safe=False)


### PR DESCRIPTION
I tried the Installation through 

$ pip install dask

and it does not install any dependencies.

Note: it is possible that the author intended to add

> install_requires=extras_require['complete']
instead of

> install_requires=extras_require['dataframe'],