### PR TITLE
Update use-cases.rst

### DIFF
--- a/docs/source/use-cases.rst
+++ b/docs/source/use-cases.rst
@@ -107,7 +107,7 @@ without significantly changing their code.
    import dask.dataframe as dd
 
    df = dd.read_csv('data/2016-*.*.csv', parse_dates=['timestamp'])
-   df.groupby(df.timestamp.dt.hour).value.mean().compute()
+   df.groupby(df.timestamp.dt.hour).mean().compute()
 
 .. _Pandas: http://pandas.pydata.org/
 
@@ -130,7 +130,7 @@ the analyst is already very comfortable.
 
    import dask.dataframe as dd
    df = dd.read_csv('hdfs://data/2016-*.*.csv', parse_dates=['timestamp'])
-   df.groupby(df.timestamp.dt.hour).value.mean().compute()
+   df.groupby(df.timestamp.dt.hour).mean().compute()
 
 .. _HDFS3: https://hdfs3.readthedocs.io/en/latest/
 


### PR DESCRIPTION
It looks like the *DataFrameGroupBy* object does not have a `value` property:

```
In [80]: df_group = df.groupby(df.times.dt.hour)

In [81]: type(df_group)
Out[81]: dask.dataframe.groupby.DataFrameGroupBy

In [82]: [x for x in dir(df_group) if 'va' in x]
Out[82]: ['var']
```