### PR TITLE
BUG: Fixed partial string indexing with no freq

### DIFF
--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -244,6 +244,20 @@ def test_loc_on_pandas_datetimes():
     assert_eq(a.loc['2014': '2015'], a.loc['2014': '2015'])
 
 
+def test_loc_datetime_no_freq():
+    # https://github.com/dask/dask/issues/2389
+
+    datetime_index = pd.date_range('2016-01-01', '2016-01-31', freq='12h')
+    datetime_index.freq = None  # FORGET FREQUENCY
+    df = pd.DataFrame({'num': range(len(datetime_index))}, index=datetime_index)
+
+    ddf = dd.from_pandas(df, npartitions=1)
+    slice_ = slice('2016-01-03', '2016-01-05')
+    result = ddf.loc[slice_, :]
+    expected = df.loc[slice_, :]
+    assert_eq(result, expected)
+
+
 def test_coerce_loc_index():
     for t in [pd.Timestamp, np.datetime64]:
         assert isinstance(_coerce_loc_index([t('2014')], '2014'), t)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -304,7 +304,12 @@ def _nonempty_index(idx):
         return pd.Index(['a', 'b'], name=idx.name)
     elif typ is pd.DatetimeIndex:
         start = '1970-01-01'
-        data = [start, start] if idx.freq is None else None
+        # Need a non-monotonic decreasing index to avoid issues with
+        # partial string indexing see https://github.com/dask/dask/issues/2389
+        # and https://github.com/pandas-dev/pandas/issues/16515
+        # This doesn't mean `_meta_nonempty` should ever rely on
+        # `self.monotonic_increasing` or `self.monotonic_decreasing`
+        data = [start, '1970-01-02'] if idx.freq is None else None
         return pd.DatetimeIndex(data, start=start, periods=2, freq=idx.freq,
                                 tz=idx.tz, name=idx.name)
     elif typ is pd.PeriodIndex:


### PR DESCRIPTION
Worked around an edge case in pandas datetime indexing by changing the data in
_meta_nonempty.index so that the index no longer looks monotonically decreasing.

Closes https://github.com/dask/dask/issues/2389