### PR TITLE
Ignore numpy warnings when calculating dtypes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -491,7 +491,8 @@ def apply_infer_dtype(func, args, kwargs, funcname, suggest_dtype=True):
     args = [np.ones((1,) * x.ndim, dtype=x.dtype)
             if isinstance(x, Array) else x for x in args]
     try:
-        o = func(*args, **kwargs)
+        with np.errstate(all='ignore'):
+            o = func(*args, **kwargs)
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         tb = ''.join(traceback.format_tb(exc_traceback))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3022,3 +3022,11 @@ def test_constructor_plugin():
 
     assert isinstance(y, np.ndarray)
     assert len(L) == 2
+
+
+def test_no_warnings_on_metadata():
+    x = da.ones(5, chunks=3)
+    with warnings.catch_warnings(record=True) as record:
+        da.arccos(x)
+
+    assert not record


### PR DESCRIPTION
See https://github.com/dask/dask/issues/2381#issuecomment-305189209