### PR TITLE
Rename bag.concat to bag.flatten

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1055,7 +1055,9 @@ class Bag(Base):
                    for i in range(self.npartitions))
         return type(self)(merge(self.dask, dsk), name, self.npartitions)
 
-    concat = flatten
+    def concat(self):
+        warn("Deprecated.  Use the .flatten method instead")
+        return self.flatten()
 
     def __iter__(self):
         return iter(self.compute())

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1040,20 +1040,22 @@ class Bag(Base):
     def _keys(self):
         return [(self.name, i) for i in range(self.npartitions)]
 
-    def concat(self):
+    def flatten(self):
         """ Concatenate nested lists into one long list
 
         >>> b = from_sequence([[1], [2, 3]])
         >>> list(b)
         [[1], [2, 3]]
 
-        >>> list(b.concat())
+        >>> list(b.flatten())
         [1, 2, 3]
         """
-        name = 'concat-' + tokenize(self)
+        name = 'flatten-' + tokenize(self)
         dsk = dict(((name, i), (list, (toolz.concat, (self.name, i))))
                    for i in range(self.npartitions))
         return type(self)(merge(self.dask, dsk), name, self.npartitions)
+
+    concat = flatten
 
     def __iter__(self):
         return iter(self.compute())

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -736,13 +736,14 @@ def test_concat():
     b = db.from_sequence([4, 5, 6])
     c = db.concat([a, b])
     assert list(c) == [1, 2, 3, 4, 5, 6]
-
     assert c.name == db.concat([a, b]).name
-    assert b.concat().name != a.concat().name
-    assert b.concat().name == b.concat().name
 
-    b = db.from_sequence([1, 2, 3]).map(lambda x: x * [1, 2, 3])
-    assert list(b.concat()) == [1, 2, 3] * sum([1, 2, 3])
+
+def test_flatten():
+    b = db.from_sequence([[1], [2, 3]])
+    assert list(b.flatten()) == [1, 2, 3]
+    assert list(b.flatten()) == list(b.concat())
+    assert b.flatten().name == b.flatten().name
 
 
 def test_concat_after_map():

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1007,7 +1007,7 @@ def test_from_delayed_iterator():
     assert db.compute(
         bag.count(),
         bag.pluck('operations').count(),
-        bag.pluck('operations').concat().count(),
+        bag.pluck('operations').flatten().count(),
         get=dask.get,
     ) == (25, 25, 50)
 

--- a/docs/source/bag-api.rst
+++ b/docs/source/bag-api.rst
@@ -10,10 +10,10 @@ Top level user functions:
     Bag.all
     Bag.any
     Bag.compute
-    Bag.concat
     Bag.count
     Bag.distinct
     Bag.filter
+    Bag.flatten
     Bag.fold
     Bag.foldby
     Bag.frequencies


### PR DESCRIPTION
Concat is the name we use from toolz.  However flatten may be more clear.
Additionally db.concat does something totally different.