### PR TITLE
Add support for UInt64Index

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -3,7 +3,8 @@ import pandas as pd
 import pandas.util.testing as tm
 import dask.dataframe as dd
 from dask.dataframe.utils import (shard_df_on_index, meta_nonempty, make_meta,
-                                  raise_on_meta_error, UNKNOWN_CATEGORIES)
+                                  raise_on_meta_error, UNKNOWN_CATEGORIES,
+                                  PANDAS_VERSION)
 
 import pytest
 
@@ -226,6 +227,15 @@ def test_meta_nonempty_index():
         assert type(idx1) is type(idx2)
         assert idx1.name == idx2.name
     assert res.names == idx.names
+
+
+@pytest.mark.skipif(PANDAS_VERSION < '0.20.0',
+                    reason="Pandas < 0.20.0 doesn't support UInt64Index")
+def test_meta_nonempty_uint64index():
+    idx = pd.UInt64Index([1], name='foo')
+    res = meta_nonempty(idx)
+    assert type(res) is pd.UInt64Index
+    assert res.name == idx.name
 
 
 def test_meta_nonempty_scalar():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -294,11 +294,17 @@ def make_meta(x, index=None):
     raise TypeError("Don't know how to create metadata from {0}".format(x))
 
 
+if PANDAS_VERSION >= "0.20.0":
+    _numeric_index_types = (pd.Int64Index, pd.Float64Index, pd.UInt64Index)
+else:
+    _numeric_index_types = (pd.Int64Index, pd.Float64Index)
+
+
 def _nonempty_index(idx):
     typ = type(idx)
     if typ is pd.RangeIndex:
         return pd.RangeIndex(2, name=idx.name)
-    elif typ in (pd.Int64Index, pd.Float64Index):
+    elif typ in _numeric_index_types:
         return typ([1, 2], name=idx.name)
     elif typ is pd.Index:
         return pd.Index(['a', 'b'], name=idx.name)


### PR DESCRIPTION
`UInt64Index` was added in pandas 0.20.0. This adds support for metadata inference for it.

Fixes #2405