### PR TITLE
Remove nans from divisions when shuffling

### DIFF
--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -618,3 +618,19 @@ def test_temporary_directory():
         ddf2 = ddf.set_index('x', shuffle='disk')
         ddf2.compute()
         assert any(fn.endswith('.partd') for fn in os.listdir(os.getcwd()))
+
+
+def test_empty_partitions():
+    # See https://github.com/dask/dask/issues/2408
+    df = pd.DataFrame({'a': list(range(10))})
+    df['b'] = df['a'] % 3;
+    df['c'] = df['b'].astype(str)
+
+    ddf = dd.from_pandas(df, npartitions=3)
+    ddf = ddf.set_index('b')
+    ddf = ddf.repartition(npartitions=3)
+    ddf.get_partition(0).compute()
+    assert_eq(ddf, df.set_index('b'))
+
+    ddf = ddf.set_index('c')
+    assert_eq(ddf, df.set_index('b').set_index('c'))

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -623,7 +623,7 @@ def test_temporary_directory():
 def test_empty_partitions():
     # See https://github.com/dask/dask/issues/2408
     df = pd.DataFrame({'a': list(range(10))})
-    df['b'] = df['a'] % 3;
+    df['b'] = df['a'] % 3
     df['c'] = df['b'].astype(str)
 
     ddf = dd.from_pandas(df, npartitions=3)


### PR DESCRIPTION
When shuffling we first check to see if the column is already sorted, in which
case we can be much much faster.  To do this we compute the minimum and maximum
value of the column in every partition.  If there is an empty partition then
this can cause a problem, because the min/max value will be nan.

Now we remove these nans before proceeding

Fixes https://github.com/dask/dask/issues/2408