### PR TITLE
Optimize out broadcast_to on unchanged shape

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2811,6 +2811,10 @@ def insert(arr, obj, values, axis):
 @wraps(chunk.broadcast_to)
 def broadcast_to(x, shape):
     shape = tuple(shape)
+
+    if x.shape == shape:
+        return x
+
     ndim_new = len(shape) - x.ndim
     if ndim_new < 0 or any(new != old
                            for new, old in zip(shape[ndim_new:], x.shape)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -732,9 +732,14 @@ def test_broadcast_to():
     x = np.random.randint(10, size=(5, 1, 6))
     a = from_array(x, chunks=(3, 1, 3))
 
-    for shape in [(5, 4, 6), (2, 5, 1, 6), (3, 4, 5, 4, 6)]:
-        assert_eq(chunk.broadcast_to(x, shape),
-                  broadcast_to(a, shape))
+    for shape in [a.shape, (5, 4, 6), (2, 5, 1, 6), (3, 4, 5, 4, 6)]:
+        xb = chunk.broadcast_to(x, shape)
+        ab = broadcast_to(a, shape)
+
+        assert_eq(xb, ab)
+
+        if a.shape == ab.shape:
+            assert a is ab
 
     pytest.raises(ValueError, lambda: broadcast_to(a, (2, 1, 6)))
     pytest.raises(ValueError, lambda: broadcast_to(a, (3,)))


### PR DESCRIPTION
If `broadcast_to` is called on a Dask Array that already has the desired shape, simply return the Dask Array unaltered. A test for this behavior is also included.