### PR TITLE
PartD requirement should be 0.3.8.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ import versioneer
 # you modify these, make sure to change the corresponding line there.
 extras_require = {
   'array': ['numpy', 'toolz >= 0.7.3'],
-  'bag': ['cloudpickle >= 0.2.1', 'toolz >= 0.7.3', 'partd >= 0.3.7'],
+  'bag': ['cloudpickle >= 0.2.1', 'toolz >= 0.7.3', 'partd >= 0.3.8'],
   'dataframe': ['numpy', 'pandas >= 0.19.0', 'toolz >= 0.7.3',
-                'partd >= 0.3.7', 'cloudpickle >= 0.2.1'],
+                'partd >= 0.3.8', 'cloudpickle >= 0.2.1'],
   'distributed': ['distributed >= 1.16', 's3fs >= 0.0.8'],
   'delayed': ['toolz >= 0.7.3'],
 }


### PR DESCRIPTION
#2139 states that dask/partd#24 is not required, but without it, tests do not pass. I'm not sure how much code continues to work without the PartD change, but changing the minimum requirement is the simplest thing to do...