### PR TITLE
Optimize out reify calls in to_delayed

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1700,8 +1700,9 @@ class Array(Base):
         dask.array.from_delayed
         """
         from ..delayed import Delayed
-        return np.array(ndeepmap(self.ndim, lambda k: Delayed(k, self.dask), self._keys()),
-                        dtype=object)
+        dsk = self._optimize(self.dask, self._keys())
+        L = ndeepmap(self.ndim, lambda k: Delayed(k, dsk), self._keys())
+        return np.array(L, dtype=object)
 
     @wraps(np.repeat)
     def repeat(self, repeats, axis=None):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2228,6 +2228,13 @@ def test_to_delayed():
     assert a.compute() == s
 
 
+def test_to_delayed_optimizes():
+    x = da.ones((4, 4), chunks=(2, 2))
+    y = x[1:][1:][1:][:, 1:][:, 1:][:, 1:]
+    d = y.to_delayed().flatten().tolist()[0]
+    assert len([k for k in d.dask if k[0].startswith('getitem')]) == 1
+
+
 def test_cumulative():
     x = da.arange(20, chunks=5)
     assert_eq(x.cumsum(axis=0), np.arange(20).cumsum())

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -982,6 +982,23 @@ def test_to_delayed():
     assert t.compute() == 21
 
 
+def test_to_delayed_optimizes():
+    b = db.from_sequence([1, 2, 3, 4, 5, 6], npartitions=1)
+    b2 = b.map(inc).map(inc).map(inc)
+
+    [d] = b2.to_delayed()
+    text = str(dict(d.dask))
+    assert text.count('reify') == 1
+
+    d = b2.sum().to_delayed()
+    text = str(dict(d.dask))
+    assert text.count('reify') == 0
+
+    [d] = b2.to_textfiles('foo.txt', compute=False)
+    text = str(dict(d.dask))
+    assert text.count('reify') <= 1
+
+
 def test_from_delayed():
     from dask.delayed import delayed
     a, b, c = delayed([1, 2, 3]), delayed([4, 5, 6]), delayed([7, 8, 9])

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -996,7 +996,7 @@ def test_to_delayed_optimizes():
 
     [d] = b2.to_textfiles('foo.txt', compute=False)
     text = str(dict(d.dask))
-    assert text.count('reify') <= 1
+    assert text.count('reify') <= 0
 
 
 def test_from_delayed():

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3798,7 +3798,8 @@ def to_delayed(df):
     >>> partitions = df.to_delayed()  # doctest: +SKIP
     """
     from ..delayed import Delayed
-    return [Delayed(k, df.dask) for k in df._keys()]
+    dsk = df._optimize(df.dask, df._keys())
+    return [Delayed(k, dsk) for k in df._keys()]
 
 
 @wraps(pd.to_datetime)

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -530,3 +530,12 @@ def test_to_delayed():
     assert isinstance(b, Delayed)
 
     assert_eq(a.compute(), df.iloc[:2])
+
+
+def test_to_delayed_optimizes():
+    df = pd.DataFrame({'x': list(range(20))})
+    ddf = dd.from_pandas(df, npartitions=20)
+    x = (ddf + 1).loc[:2]
+
+    d = x.to_delayed()[0]
+    assert len(d.dask) < 20


### PR DESCRIPTION
This has two major changes:

1.  The lazify optimization traverses down lists.  This is important
    after changes in https://github.com/dask/dask/pull/2339
2.  Call optimize when we convert from bags to delayed objects

See https://github.com/dask/dask/issues/2423