### PR TITLE
Optimize scalar condition in where

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2721,7 +2721,23 @@ See the following documentation page for details:
 def where(condition, x=None, y=None):
     if x is None or y is None:
         raise TypeError(where_error_message)
-    return choose(condition, [y, x])
+
+    x = asarray(x)
+    y = asarray(y)
+
+    shape = broadcast_shapes(x.shape, y.shape)
+    dtype = np.promote_types(x.dtype, y.dtype)
+
+    x = broadcast_to(x, shape).astype(dtype)
+    y = broadcast_to(y, shape).astype(dtype)
+
+    if isinstance(condition, (bool, np.bool8)):
+        if condition:
+            return x
+        else:
+            return y
+    else:
+        return choose(condition, [y, x])
 
 
 @wraps(chunk.coarsen)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -679,6 +679,23 @@ def test_where():
             assert_eq(w1, w2)
 
 
+def test_where_bool_optimization():
+    x = np.random.randint(10, size=(15, 16))
+    d = from_array(x, chunks=(4, 5))
+    y = np.random.randint(10, size=(15, 16))
+    e = from_array(y, chunks=(4, 5))
+
+    for c in [True, False, np.True_, np.False_]:
+        w1 = where(c, d, e)
+        w2 = np.where(c, x, y)
+
+        assert_eq(w1, w2)
+
+        ex_w1 = d if c else e
+
+        assert w1 is ex_w1
+
+
 def test_where_has_informative_error():
     x = da.ones(5, chunks=3)
     try:


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2407

If the `condition` provided to `da.where` is a simple `bool` or `np.bool8` value, optimize out the call to `where` and simply return, which of the two arrays was selected.

As `da.where` and `np.where` also handle things like broadcasting and type promotion, these things need to be handled as well. However broadcasting and type promotion are also designed to be optimized out if they are no-ops. So in the ideal case one could merely get back one of the Dask Arrays they provided with no change.

Include a test that verifies `da.where` is optimized out for Boolean values.