### PR TITLE
Add units to docstrings for partition sizing

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1092,7 +1092,7 @@ class Bag(Base):
         npartitions: int
             If using the disk-based shuffle, the number of output partitions
         blocksize: int
-            If using the disk-based shuffle, the size of shuffle blocks
+            If using the disk-based shuffle, the size of shuffle blocks (bytes)
         max_branch: int
             If using the task-based shuffle, the amount of splitting each
             partition undergoes.  Increase this for fewer copies but more

--- a/dask/bag/text.py
+++ b/dask/bag/text.py
@@ -25,7 +25,7 @@ def read_text(urlpath, blocksize=None, compression='infer',
         Absolute or relative filepath, URL (may include protocols like
         ``s3://``), globstring, or a list of beforementioned strings.
     blocksize: None or int
-        Size to cut up larger files.  Streams by default.
+        Size (in bytes) to cut up larger files.  Streams by default.
     compression: string
         Compression format like 'gzip' or 'xz'.  Defaults to 'infer'
     encoding: string

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -112,7 +112,7 @@ def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
     not_zero: bool
         Force seek of start-of-file delimiter, discarding header.
     blocksize: int (=128MB)
-        Chunk size
+        Chunk size in bytes
     compression: string or None
         String like 'gzip' or 'xz'.  Must support efficient random access.
     sample: bool or int

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -122,7 +122,7 @@ def from_pandas(data, npartitions=None, chunksize=None, sort=True, name=None):
         the size and index of the dataframe, the output may have fewer
         partitions than requested.
     chunksize : int, optional
-        The size of the partitions of the index.
+        The number of rows per index partition to use.
     sort: bool
         Sort input first to obtain cleanly divided partitions or don't sort and
         don't get cleanly divided partitions
@@ -209,7 +209,7 @@ def from_bcolz(x, chunksize=None, categorize=True, index=None, lock=lock,
     ----------
     x : bcolz.ctable
     chunksize : int, optional
-        The size of blocks to pull out from ctable.
+        The size(rows) of blocks to pull out from ctable.
     categorize : bool, defaults to True
         Automatically categorize all string dtypes
     index : string, optional


### PR DESCRIPTION
I added a few units to various docstrings to just clarify things. If anyone can see any I missed please point them out. I also was a little unsure on the units for the from_bcolz function, it seems to be rows but there might be a better description.