### PR TITLE
Don't error if writing parquet with no data

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -121,6 +121,11 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
     if isinstance(divisions[0], np.datetime64):
         divisions = [pd.Timestamp(d) for d in divisions]
 
+    if not dsk:
+        # empty dataframe
+        dsk = {(name, 0): meta}
+        divisions = (None, None)
+
     return out_type(dsk, name, meta, divisions)
 
 
@@ -455,8 +460,6 @@ def _write_metadata(writes, filenames, fmd, path, metadata_fn, myopen, sep):
                     chunk.file_path = fn
                 fmd.row_groups.append(rg)
 
-    if len(fmd.row_groups) == 0:
-        raise ValueError("All partitions were empty")
     fastparquet.writer.write_common_metadata(metadata_fn, fmd, open_with=myopen,
                                              no_row_groups=False)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -471,4 +471,4 @@ def test_empty(fn):
     assert '_metadata' in files
     out = dd.read_parquet(fn).compute()
     assert len(out) == 0
-    assert list(out.columns) == ['a', 'b']
+    assert_eq(out, df)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -374,10 +374,6 @@ def test_empty_partition(fn):
     assert_eq(ddf2.compute(), ddf3.compute(), check_names=False,
               check_index=False)
 
-    ddf2 = ddf[ddf.a <= -5]
-    with pytest.raises(ValueError):
-        ddf2.to_parquet(fn)
-
 
 def test_timestamp_index():
     with tmpfile() as fn:
@@ -465,3 +461,14 @@ def test_to_parquet_lazy(tmpdir, get):
     ddf2 = dd.read_parquet(tmpdir)
 
     assert_eq(ddf, ddf2)
+
+
+def test_empty(fn):
+    df = pd.DataFrame({'a': ['a', 'b', 'b'], 'b': [4, 5, 6]})[0:0]
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf.to_parquet(fn, write_index=False)
+    files = os.listdir(fn)
+    assert '_metadata' in files
+    out = dd.read_parquet(fn).compute()
+    assert len(out) == 0
+    assert list(out.columns) == ['a', 'b']


### PR DESCRIPTION
Fixes #2433 

Also, allow reading where there is no data: produces empty dataframe.

I'm not certain about the corner cases below - since this is already a fix for a corner case.

Warning: partition_on does not mix with writing empty dataframe, since
there is nothing to base directory names on; should this still error?

Warning: writing empty dataframe will still produce data files for each
part (if not using partition_on), but each file will contain no rows.
This can be fixed on the fastparquet side, but it's not immediately
obvious what the behaviour should be.