### PR TITLE
Catch warning from numpy in subs

### DIFF
--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -578,6 +578,15 @@ def test_slicing_none_int_ellipses(a, b, c, d):
 """
 
 
+def test_slicing_integer_no_warnings():
+    # https://github.com/dask/dask/pull/2457/
+    X = da.random.random((100, 2), (2, 2))
+    idx = np.array([0, 0, 1, 1])
+    with pytest.warns(None) as rec:
+        X[idx].compute()
+    assert len(rec) == 0
+
+
 @pytest.mark.slow
 def test_slicing_none_int_ellipes():
     shape = (2, 3, 5, 7, 11)

--- a/dask/core.py
+++ b/dask/core.py
@@ -303,8 +303,13 @@ def subs(task, key, val):
             arg = subs(arg, key, val)
         elif type_arg is list:
             arg = [subs(x, key, val) for x in arg]
-        elif type_arg is type(key) and arg == key:
-            arg = val
+        elif type_arg is type(key):
+            # Can't do a simple equality check, since this may trigger
+            # a FutureWarning from NumPy about array equality
+            # https://github.com/dask/dask/pull/2457
+            if len(arg) == len(key) and all(type(aa) == type(bb) and aa == bb
+                                            for aa, bb in zip(arg, key)):
+                arg = val
         newargs.append(arg)
     return task[:1] + tuple(newargs)
 


### PR DESCRIPTION
When slicing a dask.array with an array of integers, an operation in `subs`
would emit a FutureWarning from NumPy.

```python
>>> import dask.array as da; import numpy as np
>>> X = da.random.random((100, 2), (2, 2))
>>> idx = np.array([0, 0, 1, 1])
>>> X[idx].compute()
```

```pytb
(Pdb++) pp arg
(array([0, 0, 1, 1]), slice(None, None, None))
(Pdb++) pp key
('da.random.random_sample-95ef33cc2e3f5ffd6248bd70b54d75ec', 0, 0)
(Pdb++) arg == key
/Users/taugspurger/Envs/dask-dev/lib/python3.6/site-packages/dask/dask/core.py:1: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  from __future__ import absolute_import, division, print_function
False
```

So we're doing `np.array([0, 0, 1, 1]) == 'a string'`. At the moment this
returns ``False``, but in the future it will be `array([False, False, False,
False])`, which means the tuple comparison will fail with a `ValueError` (I think).

This prepares for that eventuality, while catching the warning today.