### PR TITLE
Bag.to_dataframe works with iterators

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1987,5 +1987,5 @@ def split(seq, n):
 
 def to_dataframe(seq, columns, dtypes):
     import pandas as pd
-    res = pd.DataFrame(seq, columns=list(columns))
+    res = pd.DataFrame(reify(seq), columns=list(columns))
     return res.astype(dtypes, copy=False)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -822,6 +822,13 @@ def test_to_dataframe():
     dd.utils.assert_eq(df, sol, check_index=False)
     check_parts(df, sol)
 
+    # Works with iterators
+    b = db.from_sequence(range(100), npartitions=5).map_partitions(iter)
+    sol = pd.DataFrame({'a': range(100)})
+    df = b.to_dataframe(columns=sol)
+    dd.utils.assert_eq(df, sol, check_index=False)
+    check_parts(df, sol)
+
 
 ext_open = [('gz', GzipFile), ('', open)]
 if not PY2:


### PR DESCRIPTION
Previously this would fail as the `data` argument to `pd.DataFrame` can't be an `Iterator`. We now convert if needed.

Fixes #2460.