### PR TITLE
Rechunk rfftfreq/fftfreq if needed

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -228,9 +228,9 @@ def _fftfreq_helper(n, d=1.0, chunks=None, real=False):
     s = n // 2 + 1 if real else n
     t = l - s
 
-    chunks = _normalize_chunks(chunks, (s,))[0] + (t,)
+    chunks = _normalize_chunks(chunks, (s,))
 
-    r = _linspace(0, 1, l, chunks=chunks)
+    r = _linspace(0, 1, l, chunks=(chunks[0] + (t,),))
 
     if real:
         n_2 = n // 2 + 1

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -239,6 +239,9 @@ def _fftfreq_helper(n, d=1.0, chunks=None, real=False):
         n_2 = (n + 1) // 2
         r = _concatenate([r[:n_2], r[n_2:-1] - 1])
 
+    if r.chunks != chunks:
+        r = r.rechunk(chunks)
+
     r /= d
 
     return r

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -9,6 +9,10 @@ import dask.array.fft
 from dask.array.fft import fft_wrap
 from dask.array.utils import assert_eq
 
+from dask.array.core import (
+    normalize_chunks as _normalize_chunks,
+)
+
 
 def same_keys(a, b):
     def key(k):
@@ -202,7 +206,13 @@ def test_wrap_fftns(modname, funcname, dtype):
 @pytest.mark.parametrize("c", [lambda m: m, lambda m: (1, m - 1)])
 def test_fftfreq(n, d, c):
     c = c(n)
-    assert_eq(da.fft.fftfreq(n, d, chunks=c), np.fft.fftfreq(n, d))
+
+    r1 = np.fft.fftfreq(n, d)
+    r2 = da.fft.fftfreq(n, d, chunks=c)
+
+    assert _normalize_chunks(c, r2.shape) == r2.chunks
+
+    assert_eq(r1, r2)
 
 
 @pytest.mark.parametrize("n", [1, 2, 3, 6, 7])
@@ -210,9 +220,13 @@ def test_fftfreq(n, d, c):
 @pytest.mark.parametrize("c", [lambda m: m // 2 + 1, lambda m: (1, m // 2)])
 def test_rfftfreq(n, d, c):
     c = c(n)
-    assert_eq(
-        da.fft.rfftfreq(n, d, chunks=c), np.fft.rfftfreq(n, d)
-    )
+
+    r1 = np.fft.rfftfreq(n, d)
+    r2 = da.fft.rfftfreq(n, d, chunks=c)
+
+    assert _normalize_chunks(c, r2.shape) == r2.chunks
+
+    assert_eq(r1, r2)
 
 
 @pytest.mark.parametrize("funcname", ["fftshift", "ifftshift"])


### PR DESCRIPTION
Checks to see if `fftfreq`/`rfftfreq` have the right chunking. If the chunking does not match, rechunk the array to match the expected chunking. At least one scenario where this is needed is when the Dask array has a chunk split due to slicing. Also includes some tests to make sure the user provided chunking is matched by the resulting array.