### PR TITLE
Rewrite fftfreq to use map_blocks, simplify rfftfreq

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -12,11 +12,8 @@ try:
 except ImportError:
     scipy = None
 
-from .creation import linspace as _linspace
-from .core import (
-    concatenate as _concatenate,
-    normalize_chunks as _normalize_chunks,
-)
+from .core import concatenate as _concatenate
+from .creation import arange as _arange
 
 
 chunk_error = ("Dask array only supports taking an FFT along an axis that \n"
@@ -221,40 +218,36 @@ hfft = fft_wrap(np.fft.hfft, dtype=np.float_)
 ihfft = fft_wrap(np.fft.ihfft, dtype=np.complex_)
 
 
-def _fftfreq_helper(n, d=1.0, chunks=None, real=False):
-    n = int(n)
-
-    l = n + 1
-    s = n // 2 + 1 if real else n
-    t = l - s
-
-    chunks = _normalize_chunks(chunks, (s,))
-
-    r = _linspace(0, 1, l, chunks=(chunks[0] + (t,),))
-
-    if real:
-        n_2 = n // 2 + 1
-        r = r[:n_2]
-    else:
-        n_2 = (n + 1) // 2
-        r = _concatenate([r[:n_2], r[n_2:-1] - 1])
-
-    if r.chunks != chunks:
-        r = r.rechunk(chunks)
-
-    r /= d
-
+def _fftfreq_block(i, n, d):
+    r = i.copy()
+    r[i >= (n + 1) // 2] -= n
+    r /= n * d
     return r
 
 
 @wraps(np.fft.fftfreq)
 def fftfreq(n, d=1.0, chunks=None):
-    return _fftfreq_helper(n, d=d, chunks=chunks, real=False)
+    n = int(n)
+    d = float(d)
+
+    r = _arange(n, dtype=float, chunks=chunks)
+
+    return r.map_blocks(_fftfreq_block, dtype=float, n=n, d=d)
 
 
 @wraps(np.fft.rfftfreq)
 def rfftfreq(n, d=1.0, chunks=None):
-    return _fftfreq_helper(n, d=d, chunks=chunks, real=True)
+    n = int(n)
+    d = float(d)
+
+    def _rfftfreq_block(i, n, d):
+        r = i.copy()
+        r /= n * d
+        return r
+
+    r = _arange(n // 2 + 1, dtype=float, chunks=chunks)
+
+    return r.map_blocks(_rfftfreq_block, dtype=float, n=n, d=d)
 
 
 def _fftshift_helper(x, axes=None, inverse=False):

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -240,14 +240,10 @@ def rfftfreq(n, d=1.0, chunks=None):
     n = int(n)
     d = float(d)
 
-    def _rfftfreq_block(i, n, d):
-        r = i.copy()
-        r /= n * d
-        return r
-
     r = _arange(n // 2 + 1, dtype=float, chunks=chunks)
+    r /= n * d
 
-    return r.map_blocks(_rfftfreq_block, dtype=float, n=n, d=d)
+    return r
 
 
 def _fftshift_helper(x, axes=None, inverse=False):


### PR DESCRIPTION
In order to clean up and simplify the `fftfreq` and `rfftfreq` functions a bit, split them up and rewrote them in terms of `map_blocks` on a Python function to create the resultant Dask Array. This removes many of the odd distinctions that occurred by trying to combine the real and complex cases. Also it avoids the need to perform weird chunk manipulation either at array creation or subsequently (including the call to `rechunk`). Not only are these functions simpler and easier to reason about, but it appears they are a bit faster than the original implementations.