### PR TITLE
Ensure list passed to `pd.DataFrame`

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1989,5 +1989,9 @@ def split(seq, n):
 
 def to_dataframe(seq, columns, dtypes):
     import pandas as pd
-    res = pd.DataFrame(reify(seq), columns=list(columns))
+    seq = reify(seq)
+    # pd.DataFrame expects lists, only copy if necessary
+    if not isinstance(seq, list):
+        seq = list(seq)
+    res = pd.DataFrame(seq, columns=list(columns))
     return res.astype(dtypes, copy=False)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -823,12 +823,13 @@ def test_to_dataframe():
     dd.utils.assert_eq(df, sol, check_index=False)
     check_parts(df, sol)
 
-    # Works with iterators
-    b = db.from_sequence(range(100), npartitions=5).map_partitions(iter)
+    # Works with iterators and tuples
     sol = pd.DataFrame({'a': range(100)})
-    df = b.to_dataframe(columns=sol)
-    dd.utils.assert_eq(df, sol, check_index=False)
-    check_parts(df, sol)
+    b = db.from_sequence(range(100), npartitions=5)
+    for f in [iter, tuple]:
+        df = b.map_partitions(f).to_dataframe(columns=sol)
+        dd.utils.assert_eq(df, sol, check_index=False)
+        check_parts(df, sol)
 
 
 ext_open = [('gz', GzipFile), ('', open)]


### PR DESCRIPTION
Previously this could have been a tuple. Fixes #2474.