### PR TITLE
Add `meta` kwarg to `Bag.to_dataframe`

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1144,9 +1144,9 @@ class Bag(Base):
             Column names to use. If the passed data do not have names
             associated with them, this argument provides names for the columns.
             Otherwise this argument indicates the order of the columns in the
-            result (any names not found in the data will become all-NA columns).
-            Note that if ``meta`` is provided the columns will be taken from
-            ``meta`` instead and this parameter will be ignored.
+            result (any names not found in the data will become all-NA
+            columns).  Note that if ``meta`` is provided, column names will be
+            taken from there and this parameter is invalid.
 
         Examples
         --------
@@ -1173,6 +1173,8 @@ class Bag(Base):
             else:
                 head = self.take(1)[0]
                 meta = pd.DataFrame([head], columns=columns)
+        elif columns is not None:
+            raise ValueError("Can't specify both `meta` and `columns`")
         else:
             meta = dd.utils.make_meta(meta)
         # Serializing the columns and dtypes is much smaller than serializing

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1119,7 +1119,7 @@ class Bag(Base):
             msg = "Shuffle method must be 'disk' or 'tasks'"
             raise NotImplementedError(msg)
 
-    def to_dataframe(self, columns=None):
+    def to_dataframe(self, meta=None, columns=None):
         """ Create Dask Dataframe from a Dask Bag
 
         Bag should contain tuples, dict records, or scalars.
@@ -1129,15 +1129,24 @@ class Bag(Base):
 
         Parameters
         ----------
-        columns : pandas.DataFrame or list, optional
-            If a ``pandas.DataFrame``, it should mirror the column names and
-            dtypes of the output dataframe. If a list, it provides the desired
-            column names. If not provided or a list, a single element from
-            the first partition will be computed, triggering a potentially
-            expensive call to ``compute``. Providing a list is only useful for
-            selecting subset of columns, to avoid an internal compute call you
-            must provide a ``pandas.DataFrame`` as dask requires dtype knowledge
-            ahead of time.
+        meta : pd.DataFrame, dict, iterable, optional
+            An empty ``pd.DataFrame`` that matches the dtypes and column names
+            of the output. This metadata is necessary for many algorithms in
+            dask dataframe to work.  For ease of use, some alternative inputs
+            are also available. Instead of a ``DataFrame``, a ``dict`` of
+            ``{name: dtype}`` or iterable of ``(name, dtype)`` can be provided.
+            If not provided or a list, a single element from the first
+            partition will be computed, triggering a potentially expensive call
+            to ``compute``. This may lead to unexpected results, so providing
+            ``meta`` is recommended. For more information, see
+            ``dask.dataframe.utils.make_meta``.
+        columns : sequence, optional
+            Column names to use. If the passed data do not have names
+            associated with them, this argument provides names for the columns.
+            Otherwise this argument indicates the order of the columns in the
+            result (any names not found in the data will become all-NA columns).
+            Note that if ``meta`` is provided the columns will be taken from
+            ``meta`` instead and this parameter will be ignored.
 
         Examples
         --------
@@ -1156,11 +1165,16 @@ class Bag(Base):
         """
         import pandas as pd
         import dask.dataframe as dd
-        if isinstance(columns, pd.DataFrame):
-            meta = columns
+        if meta is None:
+            if isinstance(columns, pd.DataFrame):
+                warn("Passing metadata to `columns` is deprecated. Please "
+                     "use the `meta` keyword instead.")
+                meta = columns
+            else:
+                head = self.take(1)[0]
+                meta = pd.DataFrame([head], columns=columns)
         else:
-            head = self.take(1)[0]
-            meta = pd.DataFrame([head], columns=columns)
+            meta = dd.utils.make_meta(meta)
         # Serializing the columns and dtypes is much smaller than serializing
         # the empty frame
         cols = list(meta.columns)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -803,6 +803,9 @@ def test_to_dataframe():
     df = b.to_dataframe(columns=['a', 'b'])
     dd.utils.assert_eq(df, sol, check_index=False)
     check_parts(df, sol)
+    df = b.to_dataframe(meta=[('a', 'i8'), ('b', 'i8')])
+    dd.utils.assert_eq(df, sol, check_index=False)
+    check_parts(df, sol)
 
     # Elements are dictionaries
     b = b.map(lambda x: dict(zip(['a', 'b'], x)))
@@ -812,14 +815,15 @@ def test_to_dataframe():
     assert df._name == b.to_dataframe()._name
 
     # With metadata specified
-    df = b.to_dataframe(columns=sol)
-    dd.utils.assert_eq(df, sol, check_index=False)
-    check_parts(df, sol)
+    for meta in [sol, [('a', 'i8'), ('b', 'i8')]]:
+        df = b.to_dataframe(meta=meta)
+        dd.utils.assert_eq(df, sol, check_index=False)
+        check_parts(df, sol)
 
     # Single column
     b = b.pluck('a')
     sol = sol[['a']]
-    df = b.to_dataframe(columns=sol)
+    df = b.to_dataframe(meta=sol)
     dd.utils.assert_eq(df, sol, check_index=False)
     check_parts(df, sol)
 
@@ -827,7 +831,7 @@ def test_to_dataframe():
     sol = pd.DataFrame({'a': range(100)})
     b = db.from_sequence(range(100), npartitions=5)
     for f in [iter, tuple]:
-        df = b.map_partitions(f).to_dataframe(columns=sol)
+        df = b.map_partitions(f).to_dataframe(meta=sol)
         dd.utils.assert_eq(df, sol, check_index=False)
         check_parts(df, sol)
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -820,6 +820,10 @@ def test_to_dataframe():
         dd.utils.assert_eq(df, sol, check_index=False)
         check_parts(df, sol)
 
+    # Error to specify both columns and meta
+    with pytest.raises(ValueError):
+        b.to_dataframe(columns=['a', 'b'], meta=sol)
+
     # Single column
     b = b.pluck('a')
     sol = sol[['a']]


### PR DESCRIPTION
Allows passing in a metadata specification instead of a DataFrame. Also
deprecate the overloading of the `columns` kwarg. This now has the
following behavior:

- If `meta` is specified, ignore columns.
- If `meta` not specified, infer metadata using `columns` (if provided).

Fixes #2480.