### PR TITLE
Specify trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: generic
 sudo: false
-os: linux
+dist: trusty
 
 env:
   matrix:


### PR DESCRIPTION
Specify Ubuntu "trusty" image in .travis.yml. For Bokeh, we've noticed that our CI jobs were 30-40% speedier using the this beta image, though we also ran into some ascii encoding issues. 