### PR TITLE
Play nicer with ndarray subclasses

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -6,7 +6,7 @@ from .core import (Array, stack, concatenate, take, tensordot, transpose,
         roll, fromfunction, unique, store, squeeze, topk, bincount, tile,
         digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
-        from_delayed, round, swapaxes, repeat, asarray)
+        from_delayed, round, swapaxes, repeat, asarray, asanyarray)
 from .core import (around, isnull, notnull, isclose, eye, triu,
                    tril, diag, corrcoef)
 from .reshape import reshape

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -45,23 +45,18 @@ from .. import sharedict
 from ..sharedict import ShareDict
 
 
-def getarray(a, b, lock=None):
-    """ Mimics getitem but includes call to np.asarray
-
-    >>> getarray([1, 2, 3, 4, 5], slice(1, 4))
-    array([2, 3, 4])
-    """
+def getter(a, b, subok=False, lock=None):
     if isinstance(b, tuple) and any(x is None for x in b):
         b2 = tuple(x for x in b if x is not None)
         b3 = tuple(None if x is None else slice(None, None)
                    for x in b if not isinstance(x, (int, long)))
-        return getarray(a, b2, lock)[b3]
+        return getter(a, b2, subok=subok, lock=lock)[b3]
 
     if lock:
         lock.acquire()
     try:
         c = a[b]
-        if type(c) != np.ndarray:
+        if not subok:
             c = np.asarray(c)
     finally:
         if lock:
@@ -69,17 +64,17 @@ def getarray(a, b, lock=None):
     return c
 
 
-def getarray_nofancy(a, b, lock=None):
-    """ A simple wrapper around ``getarray``.
+def getter_nofancy(a, b, subok=False, lock=None):
+    """ A simple wrapper around ``getter``.
 
     Used to indicate to the optimization passes that the backend doesn't
     support fancy indexing.
     """
-    return getarray(a, b, lock=lock)
+    return getter(a, b, subok=subok, lock=lock)
 
 
-def getarray_inline(a, b, lock=None):
-    """ A getarray function that optimizations feel comfortable inlining
+def getter_inline(a, b, subok=False, lock=None):
+    """ A getter function that optimizations feel comfortable inlining
 
     Slicing operations with this function may be inlined into a graph, such as
     in the following rewrite
@@ -97,7 +92,7 @@ def getarray_inline(a, b, lock=None):
 
     This inlining can be relevant to operations when running off of disk.
     """
-    return getarray(a, b, lock=lock)
+    return getter(a, b, subok=subok, lock=lock)
 
 
 from .optimization import optimize, fuse_slice
@@ -121,20 +116,21 @@ def slices_from_chunks(chunks):
             for start, shape in zip(starts, shapes)]
 
 
-def getem(arr, chunks, getitem=getarray, shape=None, out_name=None, lock=False):
+def getem(arr, chunks, getitem=getter, shape=None, out_name=None, lock=False,
+          subok=False):
     """ Dask getting various chunks from an array-like
 
     >>> getem('X', chunks=(2, 3), shape=(4, 6))  # doctest: +SKIP
-    {('X', 0, 0): (getarray, 'X', (slice(0, 2), slice(0, 3))),
-     ('X', 1, 0): (getarray, 'X', (slice(2, 4), slice(0, 3))),
-     ('X', 1, 1): (getarray, 'X', (slice(2, 4), slice(3, 6))),
-     ('X', 0, 1): (getarray, 'X', (slice(0, 2), slice(3, 6)))}
+    {('X', 0, 0): (getter, 'X', (slice(0, 2), slice(0, 3))),
+     ('X', 1, 0): (getter, 'X', (slice(2, 4), slice(0, 3))),
+     ('X', 1, 1): (getter, 'X', (slice(2, 4), slice(3, 6))),
+     ('X', 0, 1): (getter, 'X', (slice(0, 2), slice(3, 6)))}
 
     >>> getem('X', chunks=((2, 2), (3, 3)))  # doctest: +SKIP
-    {('X', 0, 0): (getarray, 'X', (slice(0, 2), slice(0, 3))),
-     ('X', 1, 0): (getarray, 'X', (slice(2, 4), slice(0, 3))),
-     ('X', 1, 1): (getarray, 'X', (slice(2, 4), slice(3, 6))),
-     ('X', 0, 1): (getarray, 'X', (slice(0, 2), slice(3, 6)))}
+    {('X', 0, 0): (getter, 'X', (slice(0, 2), slice(0, 3))),
+     ('X', 1, 0): (getter, 'X', (slice(2, 4), slice(0, 3))),
+     ('X', 1, 1): (getter, 'X', (slice(2, 4), slice(3, 6))),
+     ('X', 0, 1): (getter, 'X', (slice(0, 2), slice(3, 6)))}
     """
     out_name = out_name or arr
     chunks = normalize_chunks(chunks, shape)
@@ -142,9 +138,10 @@ def getem(arr, chunks, getitem=getarray, shape=None, out_name=None, lock=False):
     keys = list(product([out_name], *[range(len(bds)) for bds in chunks]))
     slices = slices_from_chunks(chunks)
 
-    if lock:
-        values = [(getitem, arr, x, lock) for x in slices]
+    if subok or lock:
+        values = [(getitem, arr, x, subok, lock) for x in slices]
     else:
+        # Common case, drop extra parameters
         values = [(getitem, arr, x) for x in slices]
 
     return dict(zip(keys, values))
@@ -1831,7 +1828,8 @@ def normalize_chunks(chunks, shape=None):
     return tuple(tuple(int(x) if not math.isnan(x) else x for x in c) for c in chunks)
 
 
-def from_array(x, chunks, name=None, lock=False, fancy=True, getitem=None):
+def from_array(x, chunks, name=None, lock=False, subok=False, fancy=True,
+               getitem=None):
     """ Create dask array from something that looks like an array
 
     Input must have a ``.shape`` and support numpy-style slicing.
@@ -1851,6 +1849,10 @@ def from_array(x, chunks, name=None, lock=False, fancy=True, getitem=None):
     lock : bool or Lock, optional
         If ``x`` doesn't support concurrent reads then provide a lock here, or
         pass in True to have dask.array create one for you.
+    subok : bool, optional
+        If True, then ``ndarray`` sub-classes will be passed-through unchanged,
+        otherwise the array chunks will be converted to instances of
+        ``ndarray`` (default).
     fancy : bool, optional
         If ``x`` doesn't support fancy indexing (e.g. indexing with lists or
         arrays) then set to False. Default is True.
@@ -1887,12 +1889,14 @@ def from_array(x, chunks, name=None, lock=False, fancy=True, getitem=None):
         lock = SerializableLock()
 
     if getitem is None:
-        if fancy:
-            getitem = getarray
-        else:
-            getitem = getarray_nofancy
-    dsk = getem(original_name, chunks, getitem, out_name=name, lock=lock)
+        getitem = getter if fancy else getter_nofancy
+    elif subok or lock:
+        raise ValueError("Can't specify lock/subok and custom getitem")
+
+    dsk = getem(original_name, chunks, getitem=getitem, shape=x.shape,
+                out_name=name, lock=lock, subok=subok)
     dsk[original_name] = x
+
     return Array(dsk, name, chunks, dtype=x.dtype)
 
 
@@ -2589,7 +2593,7 @@ def asarray(array):
     if not isinstance(getattr(array, 'shape', None), Iterable):
         array = np.asarray(array)
     dsk = {(name,) + (0,) * len(array.shape):
-           (getarray_inline, name) + ((slice(None, None),) * len(array.shape),),
+           (getter_inline, name) + ((slice(None, None),) * len(array.shape),),
            name: array}
     chunks = tuple((d,) for d in array.shape)
     return Array(dsk, name, chunks, dtype=array.dtype)

--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -4,7 +4,7 @@ from operator import getitem
 
 import numpy as np
 
-from .core import getarray, getarray_nofancy, getarray_inline
+from .core import getter, getter_nofancy, getter_inline
 from ..context import defer_to_globals
 from ..compatibility import zip_longest
 from ..core import flatten, reverse_dict
@@ -12,9 +12,12 @@ from ..optimize import cull, fuse, inline_functions, dont_optimize
 from ..utils import ensure_dict
 
 
+GETTERS = (getter, getter_nofancy, getter_inline, getitem)
+
+
 @defer_to_globals('array_optimize', falsey=dont_optimize)
 def optimize(dsk, keys, fuse_keys=None, fast_functions=None,
-             inline_functions_fast_functions=(getarray_inline,), rename_fused_keys=True,
+             inline_functions_fast_functions=(getter_inline,), rename_fused_keys=True,
              **kwargs):
     """ Optimize dask for array computation
 
@@ -48,12 +51,11 @@ def hold_keys(dsk, dependencies):
     We don't want to fuse data present in the graph because it is easier to
     serialize as a raw value.
 
-    We don't want to fuse chains after getitem/getarrays because we want to
+    We don't want to fuse chains after getitem/GETTERS because we want to
     move around only small pieces of data, rather than the underlying arrays.
     """
     dependents = reverse_dict(dependencies)
     data = {k for k, v in dsk.items() if type(v) not in (tuple, str)}
-    getters = (getarray, getarray_nofancy, getarray_inline, getitem)
 
     hold_keys = list(data)
     for dat in data:
@@ -64,14 +66,14 @@ def hold_keys(dsk, dependencies):
             # when there's either more than one dependent, or the dependent is
             # no longer a get* function or an alias. We then add the final
             # key to the list of keys not to fuse.
-            if type(task) is tuple and task and task[0] in getters:
+            if type(task) is tuple and task and task[0] in GETTERS:
                 try:
                     while len(dependents[dep]) == 1:
                         new_dep = next(iter(dependents[dep]))
                         new_task = dsk[new_dep]
                         # If the task is a get* or an alias, continue up the
                         # linear chain
-                        if new_task[0] in getters or new_task in dsk:
+                        if new_task[0] in GETTERS or new_task in dsk:
                             dep = new_dep
                             task = new_task
                         else:
@@ -92,20 +94,25 @@ def optimize_slices(dsk):
         fuse_slice_dict
     """
     fancy_ind_types = (list, np.ndarray)
-    getters = (getarray_nofancy, getarray, getitem, getarray_inline)
     dsk = dsk.copy()
     for k, v in dsk.items():
-        if type(v) is tuple and v[0] in getters and len(v) == 3:
-            f, a, a_index = v
-            a_lock = None
-            getter = f
-            while type(a) is tuple and a[0] in getters and len(a) in (3, 4):
+        if type(v) is tuple and v[0] in GETTERS and len(v) in (3, 5):
+            if len(v) == 3:
+                get, a, a_index = v
+                # getter defaults to subok=False, getitem is semantically True
+                a_subok = get is getitem
+                a_lock = None
+            else:
+                get, a, a_index, a_subok, a_lock = v
+            while type(a) is tuple and a[0] in GETTERS and len(a) in (3, 5):
                 if len(a) == 3:
                     f2, b, b_index = a
+                    b_subok = f2 is getitem
                     b_lock = None
                 else:
-                    f2, b, b_index, b_lock = a
-                if a_lock is not None and a_lock is not b_lock:
+                    f2, b, b_index, b_subok, b_lock = a
+
+                if a_lock and a_lock is not b_lock:
                     break
                 if (type(a_index) is tuple) != (type(b_index) is tuple):
                     break
@@ -114,35 +121,41 @@ def optimize_slices(dsk):
                     if (len(a_index) != len(b_index) and
                             any(i is None for i in indices)):
                         break
-                    if (f2 is getarray_nofancy and
+                    if (f2 is getter_nofancy and
                             any(isinstance(i, fancy_ind_types) for i in indices)):
                         break
-                elif (f2 is getarray_nofancy and
+                elif (f2 is getter_nofancy and
                         (type(a_index) in fancy_ind_types or
                          type(b_index) in fancy_ind_types)):
                     break
                 try:
                     c_index = fuse_slice(b_index, a_index)
                     # rely on fact that nested gets never decrease in
-                    # strictness e.g. `(getarray, (getitem, ...))` never
+                    # strictness e.g. `(getter_nofancy, (getter, ...))` never
                     # happens
-                    getter = f2
-                    if getter is getarray_inline:
-                        getter = getarray
+                    get = getter if f2 is getter_inline else f2
                 except NotImplementedError:
                     break
                 a, a_index, a_lock = b, c_index, b_lock
-            if (getter is getitem and
+                a_subok &= b_subok
+
+            # Skip the get call if no asarray call, no lock, and nothing to do
+            if ((a_subok and not a_lock) and
                 ((type(a_index) is slice and not a_index.start and
                   a_index.stop is None and a_index.step is None) or
                  (type(a_index) is tuple and
                   all(type(s) is slice and not s.start and s.stop is None and
                       s.step is None for s in a_index)))):
                 dsk[k] = a
-            elif a_lock is None:
-                dsk[k] = (getter, a, a_index)
+            elif get is getitem or not (a_subok or a_lock):
+                # default settings are fine, drop the extra parameters Since we
+                # always fallback to inner `get` functions, `get is getitem`
+                # can only occur if all gets are getitem, meaning all
+                # parameters must be getitem defaults.
+                dsk[k] = (get, a, a_index)
             else:
-                dsk[k] = (getter, a, a_index, a_lock)
+                dsk[k] = (get, a, a_index, a_subok, a_lock)
+
     return dsk
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1627,7 +1627,7 @@ def test_slicing_with_non_ndarrays():
 
 def test_getter():
     assert type(getter(np.matrix([[1]]), 0)) is np.ndarray
-    assert type(getter(np.matrix([[1]]), 0, subok=True)) is np.matrix
+    assert type(getter(np.matrix([[1]]), 0, asarray=False)) is np.matrix
     assert_eq(getter([1, 2, 3, 4, 5], slice(1, 4)), np.array([2, 3, 4]))
 
     assert_eq(getter(np.arange(5), (None, slice(None, None))),
@@ -1682,7 +1682,7 @@ def test_from_array_with_lock():
     assert_eq(e + f, x + x)
 
 
-def test_from_array_subok():
+def test_from_array_no_asarray():
 
     def assert_chunks_are_of_type(x, cls):
         chunks = x._get(x.dask, x._keys())
@@ -1691,8 +1691,8 @@ def test_from_array_subok():
 
     x = np.matrix(np.arange(100).reshape((10, 10)))
 
-    for subok, cls in [(False, np.ndarray), (True, np.matrix)]:
-        dx = da.from_array(x, chunks=(5, 5), subok=subok)
+    for asarray, cls in [(True, np.ndarray), (False, np.matrix)]:
+        dx = da.from_array(x, chunks=(5, 5), asarray=asarray)
         assert_chunks_are_of_type(dx, cls)
         assert_chunks_are_of_type(dx[0:5], cls)
         assert_chunks_are_of_type(dx[0:5][:, 0], cls)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -25,7 +25,7 @@ from dask.utils import ignoring, tmpfile, tmpdir
 from dask.utils_test import inc
 
 from dask.array import chunk
-from dask.array.core import (getem, getarray, top, dotmany,
+from dask.array.core import (getem, getter, top, dotmany,
                              concatenate3, broadcast_dimensions, Array, stack,
                              concatenate, from_array, take, elemwise, isnull,
                              notnull, broadcast_shapes, partial_by_order,
@@ -56,10 +56,10 @@ def same_keys(a, b):
 
 
 def test_getem():
-    sol = {('X', 0, 0): (getarray, 'X', (slice(0, 2), slice(0, 3))),
-           ('X', 1, 0): (getarray, 'X', (slice(2, 4), slice(0, 3))),
-           ('X', 1, 1): (getarray, 'X', (slice(2, 4), slice(3, 6))),
-           ('X', 0, 1): (getarray, 'X', (slice(0, 2), slice(3, 6)))}
+    sol = {('X', 0, 0): (getter, 'X', (slice(0, 2), slice(0, 3))),
+           ('X', 1, 0): (getter, 'X', (slice(2, 4), slice(0, 3))),
+           ('X', 1, 1): (getter, 'X', (slice(2, 4), slice(3, 6))),
+           ('X', 0, 1): (getter, 'X', (slice(0, 2), slice(3, 6)))}
     assert getem('X', (2, 3), shape=(4, 6)) == sol
 
 
@@ -1625,11 +1625,12 @@ def test_slicing_with_non_ndarrays():
     assert_eq((x + 1).sum(), (np.arange(10, dtype=x.dtype) + 1).sum())
 
 
-def test_getarray():
-    assert type(getarray(np.matrix([[1]]), 0)) == np.ndarray
-    assert_eq(getarray([1, 2, 3, 4, 5], slice(1, 4)), np.array([2, 3, 4]))
+def test_getter():
+    assert type(getter(np.matrix([[1]]), 0)) is np.ndarray
+    assert type(getter(np.matrix([[1]]), 0, subok=True)) is np.matrix
+    assert_eq(getter([1, 2, 3, 4, 5], slice(1, 4)), np.array([2, 3, 4]))
 
-    assert_eq(getarray(np.arange(5), (None, slice(None, None))),
+    assert_eq(getter(np.arange(5), (None, slice(None, None))),
               np.arange(5)[None, :])
 
 
@@ -1669,8 +1670,8 @@ def test_from_array_with_lock():
 
     tasks = [v for k, v in d.dask.items() if k[0] == d.name]
 
-    assert hasattr(tasks[0][3], 'acquire')
-    assert len(set(task[3] for task in tasks)) == 1
+    assert hasattr(tasks[0][4], 'acquire')
+    assert len(set(task[4] for task in tasks)) == 1
 
     assert_eq(d, x)
 
@@ -1681,15 +1682,20 @@ def test_from_array_with_lock():
     assert_eq(e + f, x + x)
 
 
-def test_from_array_slicing_results_in_ndarray():
+def test_from_array_subok():
+
+    def assert_chunks_are_of_type(x, cls):
+        chunks = x._get(x.dask, x._keys())
+        for c in concat(chunks):
+            assert type(c) is cls
+
     x = np.matrix(np.arange(100).reshape((10, 10)))
-    dx = da.from_array(x, chunks=(5, 5))
-    s1 = dx[0:5]
-    assert type(dx[0:5].compute()) == np.ndarray
-    s2 = s1[0:3]
-    assert type(s2.compute()) == np.ndarray
-    s3 = s2[:, 0]
-    assert type(s3.compute()) == np.ndarray
+
+    for subok, cls in [(False, np.ndarray), (True, np.matrix)]:
+        dx = da.from_array(x, chunks=(5, 5), subok=subok)
+        assert_chunks_are_of_type(dx, cls)
+        assert_chunks_are_of_type(dx[0:5], cls)
+        assert_chunks_are_of_type(dx[0:5][:, 0], cls)
 
 
 def test_from_array_getitem():
@@ -1705,6 +1711,9 @@ def test_from_array_getitem():
             assert v[0] is my_getitem
 
     assert_eq(x, y)
+
+    with pytest.raises(ValueError):
+        da.from_array(x, chunks=(5,), getitem=my_getitem, lock=True)
 
 
 def test_asarray():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1712,9 +1712,6 @@ def test_from_array_getitem():
 
     assert_eq(x, y)
 
-    with pytest.raises(ValueError):
-        da.from_array(x, chunks=(5,), getitem=my_getitem, lock=True)
-
 
 def test_asarray():
     assert_eq(da.asarray([1, 2, 3]), np.asarray([1, 2, 3]))
@@ -1732,6 +1729,14 @@ def test_asarray_h5py():
             x = da.asarray(d)
             assert d in x.dask.values()
             assert not any(isinstance(v, np.ndarray) for v in x.dask.values())
+
+
+def test_asanyarray():
+    x = np.matrix([1, 2, 3])
+    dx = da.asanyarray(x)
+    assert dx.numblocks == (1, 1)
+    assert isinstance(dx._get(dx.dask, dx._keys())[0][0], np.matrix)
+    assert da.asanyarray(dx) is dx
 
 
 def test_from_func():

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -55,15 +55,15 @@ def test_fuse_getitem():
                (slice(5, 10), slice(10, 20))),
               (getitem, 'x', (slice(1005, 1010), slice(10, 20)))),
 
-             ((getter, (getter, 'x', slice(1000, 2000), True, False), slice(15, 20)),
+             ((getter, (getter, 'x', slice(1000, 2000), False, False), slice(15, 20)),
               (getter, 'x', slice(1015, 1020))),
 
-             ((getter, (getter, 'x', slice(1000, 2000)), slice(15, 20), True, False),
+             ((getter, (getter, 'x', slice(1000, 2000)), slice(15, 20), False, False),
               (getter, 'x', slice(1015, 1020))),
 
-             ((getter, (getter_nofancy, 'x', slice(1000, 2000), True, False),
-               slice(15, 20), True, False),
-              (getter_nofancy, 'x', slice(1015, 1020), True, False)),
+             ((getter, (getter_nofancy, 'x', slice(1000, 2000), False, False),
+               slice(15, 20), False, False),
+              (getter_nofancy, 'x', slice(1015, 1020), False, False)),
              ]
 
     for inp, expected in pairs:
@@ -75,19 +75,19 @@ def test_fuse_getitem_lock():
     lock1 = SerializableLock()
     lock2 = SerializableLock()
 
-    pairs = [((getter, (getter, 'x', slice(1000, 2000), False, lock1), slice(15, 20)),
-              (getter, 'x', slice(1015, 1020), False, lock1)),
+    pairs = [((getter, (getter, 'x', slice(1000, 2000), True, lock1), slice(15, 20)),
+              (getter, 'x', slice(1015, 1020), True, lock1)),
 
-             ((getitem, (getter, 'x', (slice(1000, 2000), slice(100, 200)), False, lock1),
+             ((getitem, (getter, 'x', (slice(1000, 2000), slice(100, 200)), True, lock1),
                         (slice(15, 20), slice(50, 60))),
-              (getter, 'x', (slice(1015, 1020), slice(150, 160)), False, lock1)),
+              (getter, 'x', (slice(1015, 1020), slice(150, 160)), True, lock1)),
 
-             ((getitem, (getter_nofancy, 'x', (slice(1000, 2000), slice(100, 200)), False, lock1),
+             ((getitem, (getter_nofancy, 'x', (slice(1000, 2000), slice(100, 200)), True, lock1),
                         (slice(15, 20), slice(50, 60))),
-              (getter_nofancy, 'x', (slice(1015, 1020), slice(150, 160)), False, lock1)),
+              (getter_nofancy, 'x', (slice(1015, 1020), slice(150, 160)), True, lock1)),
 
-             ((getter, (getter, 'x', slice(1000, 2000), False, lock1), slice(15, 20), False, lock2),
-              (getter, (getter, 'x', slice(1000, 2000), False, lock1), slice(15, 20), False, lock2))]
+             ((getter, (getter, 'x', slice(1000, 2000), True, lock1), slice(15, 20), True, lock2),
+              (getter, (getter, 'x', slice(1000, 2000), True, lock1), slice(15, 20), True, lock2))]
 
     for inp, expected in pairs:
         result = optimize_slices({'y': inp})


### PR DESCRIPTION
Two changes:

- Add `subok` kwarg to `da.from_array`.

Mirrors the `subok` kwarg in `np.array`. If True, array-like's will be passed through as chunks unchanged. Default is False. This allows avoiding the `np.asarray` call, making it easier to work with non numpy arrays as chunks.

To make this work we change `getarray` to a more generic `getter` function and add a `subok` parameter. Alternatively we could have kept the same format and created more getter functions, but this would have led to an explosion of functions for all the different combinations
(which seemed less maintainable).

- Add `da.asanyarray`

Similar to `da.asarray`, except avoids the call to `np.asarray`.