### PR TITLE
Add concurrent.futures documentation

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -4,3 +4,4 @@ sphinx_rtd_theme
 toolz
 cloudpickle
 pandas>=0.19.0
+distributed

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -433,10 +433,64 @@ If you want to share large pieces of information then scatter the data first
 API
 ---
 
+**Client**
+
+.. autosummary::
+   Client
+   Client.cancel
+   Client.compute
+   Client.gather
+   Client.get
+   Client.get_dataset
+   Client.get_executor
+   Client.has_what
+   Client.list_datasets
+   Client.map
+   Client.ncores
+   Client.persist
+   Client.publish_dataset
+   Client.rebalance
+   Client.replicate
+   Client.restart
+   Client.run
+   Client.run_on_scheduler
+   Client.scatter
+   Client.shutdown
+   Client.scheduler_info
+   Client.shutdown
+   Client.start_ipython_workers
+   Client.start_ipython_scheduler
+   Client.submit
+   Client.unpublish_dataset
+   Client.upload_file
+   Client.who_has
+
+**Future**
+
+.. autosummary::
+   Future
+   Future.add_done_callback
+   Future.cancel
+   Future.cancelled
+   Future.done
+   Future.exception
+   Future.result
+   Future.traceback
+
+**Functions**
+
+.. autosummary::
+   as_completed
+   fire_and_forget
+   get_client
+   secede
+   wait
+
 .. autofunction:: as_completed
 .. autofucntion:: fire_and_forget
 .. autofunction:: get_client
 .. autofunction:: secede
+.. autofunction:: wait
 
 .. autoclass:: Client
    :members:

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -39,7 +39,7 @@ Submit Tasks
    Client.map
    Future.result
 
-Then can submit individual tasks using the ``submit`` method.
+Then you can submit individual tasks using the ``submit`` method.
 
 .. code-block:: python
 
@@ -71,17 +71,18 @@ thread/process/worker until you ask for it back explicitly.
    >>> a.result()  # blocks until task completes and data arrives
    11
 
-You can pass futures as inputs to submit.  Dask will handle dependency
-tracking, and so will wait until all inputs have completed, and then will move
-all inputs to a single worker if necessary, and then start the computation.
-You do not need to wait for inputs to finish before submitting a new task; Dask
-will handle this automatically.
+You can pass futures as inputs to submit.  Dask automatically handles dependency
+tracking; once all input futures have completed they will be moved onto a
+single worker (if necessary), and then the computation that depends on them
+will be started.  You do not need to wait for inputs to finish before
+submitting a new task; Dask will handle this automatically.
 
 .. code-block:: python
 
    c = client.submit(add, a, b)  # calls add on the results of a and b
 
-You can use ``map`` to call ``submit`` on the same function and many inputs:
+Similar to Python's ``map`` you can use ``Client.map`` to call the same
+function and many inputs:
 
 .. code-block:: python
 
@@ -126,7 +127,7 @@ you can either include it as a normal input to a submit or map call:
    >>> future = client.submit(my_function, df)
 
 Or you can ``scatter`` it explicitly.  Scattering moves your data to a worker
-and gives you back a future pointing to that data:
+and returns a future pointing to that data:
 
 .. code-block:: python
 
@@ -137,12 +138,12 @@ and gives you back a future pointing to that data:
    >>> future = client.submit(my_function, remote_df)
 
 Both of these accomplish the same result, but using scatter can sometimes be
-faster, especially if you are using processes or distributed workers (where
-data transfer is necessary) and you want to use ``df`` in many computations.
-Scattering the data beforehand avoids excessive data movement.
+faster.  This is especially true if you use processes or distributed workers
+(where data transfer is necessary) and you want to use ``df`` in many
+computations.  Scattering the data beforehand avoids excessive data movement.
 
-Scattering lists scatters all elements individually.  Dask will spread these
-elements evenly throughout workers in a round-robin fashion:
+Calling scatter on a list scatters all elements individually.  Dask will spread
+these elements evenly throughout workers in a round-robin fashion:
 
 .. code-block:: python
 
@@ -161,14 +162,14 @@ References, Cancellation, and Exceptions
    Client.cancel
 
 Dask will only compute and hold onto results for which there are active
-futures.  In this way your local variables define what is active in Dask.  If
-you delete the last future to a piece of remote data then Dask will feel free
+futures.  In this way your local variables define what is active in Dask.  When
+a future is garbage collected by your local Python session, Dask will feel free
 to delete that data or stop ongoing computations that were trying to produce
 it.
 
 .. code-block:: python
 
-   >>> del future  # deletes remote data if no other futures point to it
+   >>> del future  # deletes remote data once future is garbage collected
 
 You can also explicitly cancel a task using the ``Future.cancel`` or
 ``Client.cancel`` methods.
@@ -218,7 +219,7 @@ You can wait on a future or collection of futures using the ``wait`` function:
 
 .. code-block:: python
 
-   from dask.distributed import wait, as_completed
+   from dask.distributed import wait
 
    >>> wait(futures)
 
@@ -228,6 +229,8 @@ You can also iterate over the futures as they complete using the
 ``as_completed`` function:
 
 .. code-block:: python
+
+   from dask.distributed import as_completed
 
    futures = client.map(score, x_values)
 
@@ -379,8 +382,8 @@ Coordinate Data Between Clients
 
 In the section above we saw that you could have multiple clients running at the
 same time, each of which generated and manipulated futures.  These clients can
-coordinate with each other using Dask ``Queues`` and ``Variables``, which can
-communicate futures or small bits of data between clients sensibly.
+coordinate with each other using Dask ``Queue`` and ``Variable`` objects, which
+can communicate futures or small bits of data between clients sensibly.
 
 Dask queues follow the API for the standard Python Queue, but now move futures
 or small messages between clients.  Queues serialize sensibly and reconnect

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -1,0 +1,452 @@
+Futures
+=======
+
+Dask supports a real-time task framework that extends Python's
+`concurrent.futures <https://docs.python.org/3/library/concurrent.futures.html>`_
+interface.  This interface is good for arbitrary task scheduling, like
+:doc:`dask.delayed <delayed>`, but is immediate rather than lazy, which
+provides some more flexibility in situations where the computations may evolve
+over time.
+
+These features depend on the second generation task scheduler found in
+`dask.distributed <https://distributed.readthedocs.org/en/latest>`_ (which,
+despite its name, runs very well on a single machine).
+
+Basics
+------
+
+.. currentmodule:: distributed
+
+.. autosummary::
+   Client.submit
+   Client.map
+   Future.result
+
+You must start a ``Client`` to use the futures interface:
+Then can submit individual tasks using the ``submit`` method.
+
+.. code-block:: python
+
+   def inc(x):
+       return x + 1
+
+   def add(x, y):
+       return x + y
+
+   client = Client()  # start local workers
+   a = client.submit(inc, 10)  # calls inc(10) in background thread or process
+   b = client.submit(inc, 20)  # calls inc(20) in background thread or process
+
+Submit returns a ``Future``, which refers to a remote result.  This result may
+not yet be completed:
+
+.. code-block:: python
+
+   >>> a
+   <Future: status: pending, key: inc-b8aaf26b99466a7a1980efa1ade6701d>
+
+Eventually it will complete.  The result stays in the remote
+thread/process/worker until you ask for it back explicitly.
+
+.. code-block:: python
+
+   >>> a
+   <Future: status: finished, type: int, key: inc-b8aaf26b99466a7a1980efa1ade6701d>
+
+   >>> a.result()  # blocks until task completes and data arrives
+   11
+
+You can pass futures as inputs to submit.  Dask will handle dependency
+tracking, and so will wait until all inputs have completed, and then will move
+all inputs to a single worker if necessary, and then start the computation.
+You do not need to wait for inputs to finish before submitting a new task; Dask
+will handle this automatically.
+
+.. code-block:: python
+
+   c = client.submit(add, a, b)  # calls add on the results of a and b
+
+You can use ``map`` to call ``submit`` on the same function and many inputs:
+
+.. code-block:: python
+
+   futures = client.map(inc, range(1000))
+
+However note that each task comes with about 1ms of overhead.  If you want to
+map a function over a large number of inputs then you might consider
+:doc:`dask.bag <bag>` or :doc:`dask.dataframe <dataframe>` instead.
+
+Move Data
+---------
+
+.. autosummary::
+   Future.result
+   Client.gather
+   Client.scatter
+
+Given any future you can call the ``.result`` method to gather the result.
+This will block until the future is done computing and then transfer the result
+back to your local process if necessary.
+
+.. code-block:: python
+
+   >>> c.result()
+   32
+
+You can gather many results concurrently using the ``Client.gather`` method.
+This can be more efficient than calling ``.result()`` on each future
+sequentially.
+
+.. code-block:: python
+
+   >>> # results = [future.result() for future in futures]
+   >>> results = client.gather(futures)  # this can be faster
+
+If you have important local data that you want to include in your computation
+you can either include it as a normal input to a submit or map call:
+
+.. code-block:: python
+
+   >>> df = pd.read_csv('training-data.csv')
+   >>> future = client.submit(my_function, df)
+
+Or you can ``scatter`` it explicitly.  Scattering moves your data to a worker
+and gives you back a future pointing to that data:
+
+.. code-block:: python
+
+   >>> remote_df = client.scatter(df)
+   >>> remote_df
+   <Future: status: finished, type: DataFrame, key: bbd0ca93589c56ea14af49cba470006e>
+
+   >>> future = client.submit(my_function, remote_df)
+
+Both of these accomplish the same result, but using scatter can sometimes be
+faster, especially if you are using processes or distributed workers (where
+data transfer is necessary) and you want to use ``df`` in many computations.
+Scattering the data beforehand avoids excessive data movement.
+
+Scattering lists scatters all elements individually.  Dask will spread these
+elements evenly throughout workers in a round-robin fashion:
+
+.. code-block:: python
+
+   >>> client.scatter([1, 2, 3])
+   [<Future: status: finished, type: int, key: c0a8a20f903a4915b94db8de3ea63195>,
+    <Future: status: finished, type: int, key: 58e78e1b34eb49a68c65b54815d1b158>,
+    <Future: status: finished, type: int, key: d3395e15f605bc35ab1bac6341a285e2>]
+
+References, Cancellation, and Exceptions
+----------------------------------------
+
+.. autosummary::
+   Future.cancel
+   Future.exception
+   Future.traceback
+   Client.cancel
+
+Dask will only compute and hold onto results for which there are active
+futures.  In this way your local variables define what is active in Dask.  If
+you delete the last future to a piece of remote data then Dask will feel free
+to delete that data or stop ongoing computations that were trying to produce
+it.
+
+.. code-block:: python
+
+   >>> del future  # deletes remote data if no other futures point to it
+
+You can also explicitly cancel a task using the ``Future.cancel`` or
+``Client.cancel`` methods.
+
+.. code-block:: python
+
+   >>> future.cancel()  # deletes data even if other futures point to it
+
+If a future fails, then Dask will raise the remote exceptions and tracebacks if
+you try to get the result.
+
+.. code-block:: python
+
+   def div(x, y):
+       return x / y
+
+   >>> a = client.submit(div, 1, 0)  # 1 / 0 raises a ZeroDivisionError
+   >>> a
+   <Future: status: error, key: div-3601743182196fb56339e584a2bf1039>
+
+   >>> a.result()
+         1 def div(x, y):
+   ----> 2     return x / y
+
+   ZeroDivisionError: division by zero
+
+All futures that depend on an erred future also err with the same exception:
+
+.. code-block:: python
+
+   >>> b = client.submit(inc, a)
+   >>> b
+   <Future: status: error, key: inc-15e2e4450a0227fa38ede4d6b1a952db>
+
+You can collect the exception or traceback explicitly with the
+``Future.exception`` or ``Future.traceback`` methods.
+
+
+Waiting on Futures
+------------------
+
+.. autosummary::
+   as_completed
+   wait
+
+You can wait on a future or collection of futures using the ``wait`` function:
+
+.. code-block:: python
+
+   >>> wait(futures)
+
+This blocks until all futures are finished or have erred.
+
+You can also iterate over the futures as they complete using the
+``as_completed`` function:
+
+.. code-block:: python
+
+   futures = client.map(score, x_values)
+
+   best = -1
+   for future in as_completed(futures):
+      y = future.result()
+      if y > best:
+          best = y
+
+For greater efficiency you can also ask ``as_completed`` to gather the results
+in the background.
+
+.. code-block:: python
+
+   for future in as_completed(futures, results=True):
+      ...
+
+Or collect futures all futures in batches that had arrived since the last iteration
+
+.. code-block:: python
+
+   for batch in as_completed(futures, results=True).batches():
+      for future in batch:
+          ...
+
+
+Additionally, for iterative algorithms you can add more futures into the ``as_completed`` iterator
+
+.. code-block:: python
+
+   seq = as_completed(futures)
+
+   for future in seq:
+       y = future.result()
+       if condition(y):
+           new_future = client.submit(...)
+           seq.add(new_future)  # add back into the loop
+
+
+Fire and Forget
+---------------
+
+.. autosummary::
+   fire_and_forget
+
+Sometimes we don't care about gathering the result of a task, and only care
+about side effects that it might have, like writing a result to a file.
+
+.. code-block:: python
+
+   >>> a = client.submit(load, filename)
+   >>> b = client.submit(process, a)
+   >>> c = client.submit(write, c, out_filename)
+
+As noted above, Dask will stop work that doesn't have any active futures.  It
+thinks that because no one has a pointer to this data that no one cares.  You
+can tell Dask to compute a task anyway, even if there are no active futures,
+using the ``fire_and_forget`` function:
+
+.. code-block:: python
+
+   >>> fire_and_forget(c)
+
+This is particularly useful when a future may go out of scope, for example as
+part of a function:
+
+.. code-block:: python
+
+    def process(filename):
+        out_filename = 'out-' + filename
+        a = client.submit(load, filename)
+        b = client.submit(process, a)
+        c = client.submit(write, c, out_filename)
+        fire_and_forget(c)
+        return  # here we lose the reference to c, but that's now ok
+
+    for filename in filenames:
+        process(filename)
+
+
+Submit Tasks from Tasks
+-----------------------
+
+.. autosummary::
+   get_client
+   secede
+
+Tasks can launch other tasks by getting their own client.  This enables complex
+and highly dynamic workloads.
+
+.. code-block:: python
+
+   from dask.distributed import get_client
+
+   def my_function(x):
+       ...
+
+       # Get locally created client
+       client = get_client()
+
+       # Do normal client operations, asking cluster for computation
+       a = client.submit(...)
+       b = client.submit(...)
+       a, b = client.gather([a, b])
+
+       return a + b
+
+It also allows you to set up long running tasks that watch other resources like
+sockets or physical sensors:
+
+.. code-block:: python
+
+   def monitor(device):
+      client = get_client()
+      while True:
+          data = device.read_data()
+          future = client.submit(process, data)
+          fire_and_forget(future)
+
+   for device in devices:
+       fire_and_forget(client.submit(monitor))
+
+However, each running task takes up a single thread, and so if you launch many
+tasks that launch other tasks then it is possible to deadlock the system if you
+are not careful.  You can call the ``secede`` function from within a task to
+have it remove itself from the dedicated thread pool into an administrative
+thread that does not take up a slot within the Dask worker:
+
+.. code-block:: python
+
+   from dask.distributed import get_client, secede
+
+   def monitor(device):
+      client = get_client()
+      secede()
+      while True:
+          data = device.read_data()
+          future = client.submit(process, data)
+          fire_and_forget(future)
+
+
+Coordinate Data Between Clients
+-------------------------------
+
+.. autosummary::
+   Queue
+   Variable
+
+In the section above we saw that you could have multiple clients running at the
+same time, each of which generated and manipulated futures.  These clients can
+coordinate with each other using Dask ``Queues`` and ``Variables``, which can
+communicate futures or small bits of data between clients sensibly.
+
+Dask queues follow the API for the standard Python Queue, but now move futures
+or small messages between clients.  Queues serialize sensibly and reconnect
+themselves on remote clients if necessary.
+
+.. code-block:: python
+
+   from dask.distributed import Queue
+
+   def load_and_submit(filename):
+       data = load(filename)
+       client = get_client()
+       future = client.submit(process, data)
+       queue.put(future)
+
+   client = Client()
+
+   queue = Queue()
+
+   for filename in filenames:
+       future = client.submit(load_and_submit, filename)
+       fire_and_forget(filename)
+
+   while True:
+       future = queue.get()
+       print(future.result())
+
+
+Queues can also send small pieces of information, anything that is msgpack
+encodable (ints, strings, bools, lists, dicts, etc..).  This can be useful to
+send back small scores or administrative messages:
+
+.. code-block:: python
+
+   def func(x):
+       try:
+          ...
+       except Exception as e:
+           error_queue.put(str(e))
+
+   error_queue = Queue()
+
+Variables are like Queues in that they communicate futures and small data
+between clients.  However variables hold only a single value.  You can get or
+set that value at any time.
+
+.. code-block:: python
+
+   >>> var = Variable('stopping-criterion')
+   >>> var.set(False)
+
+   >>> var.get()
+   False
+
+This is often used to signal stopping criteria or current parameters, etc.
+between clients.
+
+If you want to share large pieces of information then scatter the data first
+
+.. code-block:: python
+
+   >>> parameters = np.array(...)
+   >>> future = client.scatter(parameters)
+   >>> var.set(future)
+
+
+
+API
+---
+
+.. autofunction:: as_completed
+.. autofucntion:: fire_and_forget
+.. autofunction:: get_client
+.. autofunction:: secede
+
+.. autoclass:: Client
+   :members:
+
+.. autoclass:: Future
+   :members:
+
+
+.. autoclass:: Queue
+   :members:
+
+.. autoclass:: Variable
+   :members:

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -12,17 +12,33 @@ These features depend on the second generation task scheduler found in
 `dask.distributed <https://distributed.readthedocs.org/en/latest>`_ (which,
 despite its name, runs very well on a single machine).
 
-Basics
-------
-
 .. currentmodule:: distributed
+
+Start Dask Client
+-----------------
+
+You must start a ``Client`` to use the futures interface.  This tracks state
+among the various worker processes or threads.
+
+.. code-block:: python
+
+   from dask.distributed import Client
+
+   client = Client()  # start local workers as processes
+   # or
+   client = Client(processes=False)  # start local workers as threads
+
+If you have `Bokeh <https://bokeh.pydata.org>`_ installed then this starts up a
+diagnostic dashboard at http://localhost:8786 .
+
+Submit Tasks
+------------
 
 .. autosummary::
    Client.submit
    Client.map
    Future.result
 
-You must start a ``Client`` to use the futures interface:
 Then can submit individual tasks using the ``submit`` method.
 
 .. code-block:: python
@@ -33,7 +49,6 @@ Then can submit individual tasks using the ``submit`` method.
    def add(x, y):
        return x + y
 
-   client = Client()  # start local workers
    a = client.submit(inc, 10)  # calls inc(10) in background thread or process
    b = client.submit(inc, 20)  # calls inc(20) in background thread or process
 
@@ -203,6 +218,8 @@ You can wait on a future or collection of futures using the ``wait`` function:
 
 .. code-block:: python
 
+   from dask.distributed import wait, as_completed
+
    >>> wait(futures)
 
 This blocks until all futures are finished or have erred.
@@ -235,7 +252,6 @@ Or collect futures all futures in batches that had arrived since the last iterat
    for batch in as_completed(futures, results=True).batches():
       for future in batch:
           ...
-
 
 Additionally, for iterative algorithms you can add more futures into the ``as_completed`` iterator
 
@@ -271,6 +287,8 @@ can tell Dask to compute a task anyway, even if there are no active futures,
 using the ``fire_and_forget`` function:
 
 .. code-block:: python
+
+   from dask.distributed import fire_and_forget
 
    >>> fire_and_forget(c)
 
@@ -427,8 +445,6 @@ If you want to share large pieces of information then scatter the data first
    >>> parameters = np.array(...)
    >>> future = client.scatter(parameters)
    >>> var.set(future)
-
-
 
 API
 ---

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,7 +41,7 @@ on Dask's distributed scheduler,
 Familiar user interface
 -----------------------
 
-**Dask DataFrame** mimics Pandas
+**Dask DataFrame** mimics Pandas - :doc:`documentation <dataframe>`
 
 .. code-block:: python
 
@@ -49,7 +49,7 @@ Familiar user interface
     df = pd.read_csv('2015-01-01.csv')      df = dd.read_csv('2015-*-*.csv')
     df.groupby(df.user_id).value.mean()     df.groupby(df.user_id).value.mean().compute()
 
-**Dask Array** mimics NumPy
+**Dask Array** mimics NumPy - :doc:`documentation <array>`
 
 .. code-block:: python
 
@@ -59,7 +59,7 @@ Familiar user interface
                                                               chunks=(1000, 1000))
    x - x.mean(axis=1)                       x - x.mean(axis=1).compute()
 
-**Dask Bag** mimics iterators, Toolz, and PySpark
+**Dask Bag** mimics iterators, Toolz, and PySpark - :doc:`documentation <bag>`
 
 .. code-block:: python
 
@@ -67,7 +67,7 @@ Familiar user interface
    b = db.read_text('2015-*-*.json.gz').map(json.loads)
    b.pluck('name').frequencies().topk(10, lambda pair: pair[1]).compute()
 
-**Dask Delayed** mimics for loops and wraps custom code
+**Dask Delayed** mimics for loops and wraps custom code - :doc:`documentation <delayed>`
 
 .. code-block:: python
 
@@ -81,7 +81,7 @@ Familiar user interface
    result.compute()
 
 The **concurrent.futures** interface provides general submission of custom
-tasks:
+tasks: - :doc:`documentation <futures>`
 
 .. code-block:: python
 
@@ -156,6 +156,7 @@ then you should start here.
 * :doc:`bag`
 * :doc:`dataframe`
 * :doc:`delayed`
+* :doc:`futures`
 
 .. toctree::
    :maxdepth: 1
@@ -166,6 +167,7 @@ then you should start here.
    bag.rst
    dataframe.rst
    delayed.rst
+   futures.rst
    machine-learning.rst
 
 **Scheduling**


### PR DESCRIPTION
This adds a documentation page for the concurrent.futures-style task API added in the dask.distributed scheduler to the dask/dask docs.  This seems simpler than pointing people to the dask/distributed docs, which I think it would be good to diminish in prominence for users (it's somewhat confusing to split documentation). 

However, this does add more complexity to the doc building process, which now needs both dask/dask and dask/distributed