### PR TITLE
TST: Remove pytest.raises.match for back-compat.

### DIFF
--- a/dask/array/tests/test_stats.py
+++ b/dask/array/tests/test_stats.py
@@ -132,4 +132,4 @@ def test_skew_raises():
     with pytest.raises(ValueError) as rec:
         dask.array.stats.skewtest(a)
 
-    assert rec.match("7 samples")
+    assert "7 samples" in str(rec)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -259,11 +259,11 @@ def test_describe_empty():
     ddf = dd.from_pandas(pd.DataFrame({"A": ['a', 'b']}), 2)
     with pytest.raises(ValueError) as rec:
         ddf.describe()
-    assert rec.match('DataFrame contains only non-numeric data.')
+    assert 'DataFrame contains only non-numeric data.' in str(rec)
 
     with pytest.raises(ValueError) as rec:
         ddf.A.describe()
-    assert rec.match('Cannot compute ``describe`` on object dtype.')
+    assert 'Cannot compute ``describe`` on object dtype.' in str(rec)
 
 
 def test_cumulative():


### PR DESCRIPTION
As I noted on gitter, dask tests are odd in that they check for Python 3.3 in order to provide compatibility with dask 2.7.2, but then they use `pytest.raises.match`, which came out in pytest 3.0. This PR removes the latter in order to support (at least) pytest 2.9.2, which is what's in Fedora at the moment.