### PR TITLE
TST: Don't trigger faulty NumPy lstsq problems.

### DIFF
--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -426,7 +426,9 @@ def test_lstsq(nrow, ncol, chunk):
     A[:, 1] = A[:, 2]
     dA = da.from_array(A, (chunk, ncol))
     db = da.from_array(b, chunk)
-    x, r, rank, s = np.linalg.lstsq(A, b)
+    x, r, rank, s = np.linalg.lstsq(A, b,
+                                    rcond=np.finfo(np.double).eps * max(nrow,
+                                                                        ncol))
     assert rank == ncol - 1
     dx, dr, drank, ds = da.linalg.lstsq(dA, db)
     assert drank.compute() == rank


### PR DESCRIPTION
With `randint` and `seed=1`, the `np.linalg.lstsq` triggers some poor rcond due to numpy/numpy#8740. Since dask does not trigger the same bug itself, change the rcond as in numpy/numpy#9284 to not break.

Interestingly, this is something that I cannot trigger with conda's NumPy (mkl or nomkl), but it is a problem with the packaged NumPy in Fedora. Without this change, the assertion that the rank is one less than the column count fails (as produced by NumPy). Dask's version does not support an alternate `rcond`, and does not appear to trigger any poor conditioning, so it works fine.