### PR TITLE
Register `long`s with an identity normalization.

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -13,7 +13,7 @@ from toolz import merge, groupby, curry, identity
 from toolz.functoolz import Compose
 
 from . import sharedict
-from .compatibility import bind_method, unicode, PY3
+from .compatibility import bind_method, long, unicode, PY3
 from .context import _globals
 from .core import flatten
 from .hashing import hash_buffer_hex
@@ -305,8 +305,8 @@ def _normalize_function(func):
 
 
 normalize_token = Dispatch()
-normalize_token.register((int, float, str, unicode, bytes, type(None), type,
-                          slice, complex),
+normalize_token.register((int, long, float, str, unicode, bytes, type(None),
+                          type, slice, complex),
                          identity)
 
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -13,7 +13,7 @@ from dask.base import (compute, tokenize, normalize_token, normalize_function,
 from dask.delayed import Delayed
 from dask.utils import tmpdir, tmpfile, ignoring
 from dask.utils_test import inc, dec
-from dask.compatibility import unicode
+from dask.compatibility import long, unicode
 
 
 def import_or_none(path):
@@ -167,7 +167,7 @@ def test_tokenize_numpy_ufunc_consistent():
 
 
 def test_normalize_base():
-    for i in [1, 1.1, '1', slice(1, 2, 3)]:
+    for i in [1, long(1), 1.1, '1', slice(1, 2, 3)]:
         assert normalize_token(i) is i
 
 


### PR DESCRIPTION
Bottleneck 1.2.1 changed some things to produce `long` instead of `int`. This type was not registered with a normalization, and so it walked the MRO to `object` normalization, which produces a new UUID every time. This breaks `test_deterministic_reduction_names`.

Fixes #2421.