### PR TITLE
To make tokenize threadsafe we add a lock around clearing the cache

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -652,18 +652,6 @@ def test_matmul():
     assert_eq(operator.matmul(z, a), operator.matmul(c, x))
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5),
-                    reason="Matrix multiplication operator only after Py3.5")
-@pytest.mark.skipif(np.__version__ == '1.13.0',
-                    reason="https://github.com/numpy/numpy/issues/9028")
-def test_matmul_raises():
-    x = np.random.random((5, 5))
-    z = np.random.random((5, 5, 5))
-    c = from_array(z, chunks=(1, 5, 1))
-    with pytest.raises(NotImplementedError):
-        operator.matmul(x, c)
-
-
 def test_T():
     x = np.arange(400).reshape((20, 20))
     a = from_array(x, chunks=(5, 5))


### PR DESCRIPTION
This was showing up in complex multi-threaded dask/distributed workloads.

cc @jcrist 