### PR TITLE
Update doc building

### DIFF
--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -11,13 +11,13 @@ from dask.array.utils import assert_eq
 
 def test_ufunc_meta():
     assert da.log.__name__ == 'log'
-    assert da.log.__doc__.replace('    # doctest: +SKIP', '') == np.log.__doc__
+    assert da.log.__doc__.replace('  # doctest: +SKIP', '') == np.log.__doc__
 
     assert da.modf.__name__ == 'modf'
-    assert da.modf.__doc__.replace('    # doctest: +SKIP', '') == np.modf.__doc__
+    assert da.modf.__doc__.replace('  # doctest: +SKIP', '') == np.modf.__doc__
 
     assert da.frexp.__name__ == 'frexp'
-    assert da.frexp.__doc__.replace('    # doctest: +SKIP', '') == np.frexp.__doc__
+    assert da.frexp.__doc__.replace('  # doctest: +SKIP', '') == np.frexp.__doc__
 
 
 def test_ufunc():

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -8,7 +8,7 @@ from dask.sharedict import ShareDict
 from dask.utils import (takes_multiple_arguments, Dispatch, random_state_data,
                         memory_repr, methodcaller, M, skip_doctest,
                         SerializableLock, funcname, ndeepmap, ensure_dict,
-                        package_of)
+                        package_of, extra_titles)
 from dask.utils_test import inc
 
 
@@ -130,12 +130,44 @@ def test_skip_doctest():
 >>> xxx"""
 
     res = skip_doctest(example)
-    assert res == """>>> xxx    # doctest: +SKIP
+    assert res == """>>> xxx  # doctest: +SKIP
 >>>
 >>> # comment
->>> xxx    # doctest: +SKIP"""
+>>> xxx  # doctest: +SKIP"""
 
     assert skip_doctest(None) == ''
+
+
+def test_extra_titles():
+    example = """
+
+    Notes
+    -----
+    hello
+
+    Foo
+    ---
+
+    Notes
+    -----
+    bar
+    """
+
+    expected = """
+
+    Notes
+    -----
+    hello
+
+    Foo
+    ---
+
+    Extra Notes
+    -----------
+    bar
+    """
+
+    assert extra_titles(example) == expected
 
 
 def test_SerializableLock():

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
-numpydoc
+numpydoc==0.6
 sphinx
 sphinx_rtd_theme
 toolz

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -506,7 +506,7 @@ API
    wait
 
 .. autofunction:: as_completed
-.. autofucntion:: fire_and_forget
+.. autofunction:: fire_and_forget
 .. autofunction:: get_client
 .. autofunction:: secede
 .. autofunction:: wait

--- a/docs/source/scheduler-choice.rst
+++ b/docs/source/scheduler-choice.rst
@@ -75,13 +75,13 @@ reasons:
 
 1.  The multiprocessing scheduler brings intermediate values back to the main
     process before sending them out again for new tasks.  For embarrassingly
-    parallel workloads, such as are common in dask.bag_, this is rarely a
-    problem because repeated tasks are fused together and outputs are typically
-    small, like counts, sums, or filenames to which we have written results.
-    However for more complex workloads like a blocked matrix multiply this can
-    be troublesome.  The distributed scheduler is sophisticated enough to track
-    which data is in which process and so can avoid costly interprocess
-    communication.
+    parallel workloads, such as are common in :doc:`dask.bag <bag>`, this is
+    rarely a problem because repeated tasks are fused together and outputs are
+    typically small, like counts, sums, or filenames to which we have written
+    results.  However for more complex workloads like a blocked matrix multiply
+    this can be troublesome.  The distributed scheduler is sophisticated enough
+    to track which data is in which process and so can avoid costly
+    interprocess communication.
 2.  The distributed scheduler supports a set of rich real-time diagnostics
     which can help provide feedback and diagnose performance issues.
 3.  The distributed scheduler supports a larger API, including asynchronous


### PR DESCRIPTION
1.  We avoid numpydoc 0.7, which is particularly strict about extra sections
2.  We fix our docstrings to avoid duplicate section titles
3.  We fix a few links within prose docs
4.  Fix a spelling mistake

Even though we fixed the duplicate section titles the full class docstring
seems to get everything, causing more issues.  I'm just going to pin to 0.6 for
now.  It looks like they're releasing 0.8 rather soon, so I suspect that 0.7
had known issues.