### PR TITLE
Support for callables in df.assign

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2307,7 +2307,7 @@ class DataFrame(_Frame):
     def assign(self, **kwargs):
         for k, v in kwargs.items():
             if not (isinstance(v, (Series, Scalar, pd.Series)) or
-                    np.isscalar(v)):
+                    callable(v) or np.isscalar(v)):
                 raise TypeError("Column assignment doesn't support type "
                                 "{0}".format(type(v).__name__))
         pairs = list(sum(kwargs.items(), ()))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -745,15 +745,18 @@ def test_assign():
     res = d.assign(c=1,
                    d='string',
                    e=d.a.sum(),
-                   f=d.a + d.b)
+                   f=d.a + d.b,
+                   g=lambda x: x.a + x.b)
     res_unknown = d_unknown.assign(c=1,
                                    d='string',
                                    e=d_unknown.a.sum(),
-                                   f=d_unknown.a + d_unknown.b)
+                                   f=d_unknown.a + d_unknown.b,
+                                   g=lambda x: x.a + x.b)
     sol = full.assign(c=1,
                       d='string',
                       e=full.a.sum(),
-                      f=full.a + full.b)
+                      f=full.a + full.b,
+                      g=lambda x: x.a + x.b)
     assert_eq(res, sol)
     assert_eq(res_unknown, sol)
 


### PR DESCRIPTION
Add support for callables in `df.assign`. Fixes #2509.