### PR TITLE
Support concat for categorical MultiIndex

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -206,6 +206,14 @@ def pivot_count(df, index, columns, values):
 # concat
 # ---------------------------------
 
+if PANDAS_VERSION < '0.20.0':
+    def _get_level_values(x, n):
+        return x.get_level_values(n)
+else:
+    def _get_level_values(x, n):
+        return x._get_level_values(n)
+
+
 def concat(dfs, axis=0, join='outer', uniform=False):
     """Concatenate, handling some edge cases:
 
@@ -237,7 +245,7 @@ def concat(dfs, axis=0, join='outer', uniform=False):
             first, rest = dfs[0], dfs[1:]
             if all((isinstance(o, pd.MultiIndex) and o.nlevels >= first.nlevels)
                     for o in rest):
-                arrays = [concat([i._get_level_values(n) for i in dfs])
+                arrays = [concat([_get_level_values(i, n) for i in dfs])
                           for n in range(first.nlevels)]
                 return pd.MultiIndex.from_arrays(arrays, names=first.names)
 

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -49,6 +49,8 @@ for df in frames:
                              y=df.y.cat.set_categories(list('abc'))))
 frames3 = [i.set_index(i.y) for i in frames]
 frames4 = [i.set_index(i.y) for i in frames2]
+frames5 = [i.set_index([i.y, i.x]) for i in frames]
+frames6 = [i.set_index([i.y, i.x]) for i in frames2]
 
 
 def test_concat_unions_categoricals():
@@ -77,6 +79,13 @@ def test_concat_unions_categoricals():
     # Non-categorical Series, Categorical Index
     tm.assert_series_equal(_concat([i.x for i in frames3]),
                            pd.concat([i.x for i in frames4]))
+
+    # MultiIndex with Categorical Index
+    tm.assert_index_equal(_concat([i.index for i in frames5]),
+                          pd.concat([i for i in frames6]).index)
+
+    # DataFrame, MultiIndex with CategoricalIndex
+    tm.assert_frame_equal(_concat(frames5), pd.concat(frames6))
 
 
 def test_unknown_categoricals():


### PR DESCRIPTION
Previously we supported concatenating pandas objects with differing categorical indices. This extends that to support concatenating multi-indices with differing categorical indices. Fixes #2510.