### PR TITLE
Updates read_hdf docstring

### DIFF
--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -354,9 +354,7 @@ def read_hdf(pattern, key, start=0, stop=None, columns=None,
         index (default is False).
     lock : boolean, optional
         Option to use a lock to prevent concurrency issues (default is True).
-    mode : {'a', 'r', 'r+'}, default 'a'
-        Mode to use when opening the hdf file(s)
-        
+    mode : {'a', 'r', 'r+'}, default 'a'. Mode to use when opening file(s).
         'r'
             Read-only; no data can be modified.
         'a'

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -355,6 +355,8 @@ def read_hdf(pattern, key, start=0, stop=None, columns=None,
     lock : boolean, optional
         Option to use a lock to prevent concurrency issues (default is True).
     mode : {'a', 'r', 'r+'}, default 'a'
+        Mode to use when opening the hdf file(s)
+        
         'r'
             Read-only; no data can be modified.
         'a'

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -348,15 +348,15 @@ def read_hdf(pattern, key, start=0, stop=None, columns=None,
         A list of columns that if not None, will limit the return
         columns (default is None)
     chunksize : positive integer, optional
-        Maximal number of rows per partition (default is 1000000)
+        Maximal number of rows per partition (default is 1000000).
+    sorted_index : boolean, optional
+        Option to specify whether or not the input hdf files have a sorted
+        index (default is False).
     lock : boolean, optional
         Option to use a lock to prevent concurrency issues (default is True).
-    mode : {'a', 'w', 'r', 'r+'}, default 'a'
+    mode : {'a', 'r', 'r+'}, default 'a'
         'r'
             Read-only; no data can be modified.
-        'w'
-            Write; a new file is created (an existing file with the same
-            name would be deleted).
         'a'
             Append; an existing file is opened for reading and writing,
             and if the file does not exist it is created.

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -344,10 +344,24 @@ def read_hdf(pattern, key, start=0, stop=None, columns=None,
     start : optional, integer (defaults to 0), row number to start at
     stop : optional, integer (defaults to None, the last row), row number to
         stop at
-    columns : optional, a list of columns that if not None, will limit the
-        return columns
-    chunksize : optional, positive integer
-        maximal number of rows per partition
+    columns : list of columns, optional
+        A list of columns that if not None, will limit the return
+        columns (default is None)
+    chunksize : positive integer, optional
+        Maximal number of rows per partition (default is 1000000)
+    lock : boolean, optional
+        Option to use a lock to prevent concurrency issues (default is True).
+    mode : {'a', 'w', 'r', 'r+'}, default 'a'
+        'r'
+            Read-only; no data can be modified.
+        'w'
+            Write; a new file is created (an existing file with the same
+            name would be deleted).
+        'a'
+            Append; an existing file is opened for reading and writing,
+            and if the file does not exist it is created.
+        'r+'
+            It is similar to 'a', but the file must already exist.
 
     Returns
     -------

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -199,6 +199,10 @@ docstrings with pytest as follows::
 
    py.test dask --doctest-modules
 
+Docstring testing requires graphviz to be installed. This can be done via::
+
+   conda install -y graphviz
+
 
 Style
 ~~~~~


### PR DESCRIPTION
I noticed that the `dask.dataframe.read_hdf` docstring didn't have anything for the `lock` or `mode` parameters. This PR simply adds those parameters to the docstring. 


I also came across a problem when locally running docstring tests (via `py.test dask --doctest-modules`) I got the following `RuntimeError` related to not having `graphviz` installed

![image](https://user-images.githubusercontent.com/11656932/28182681-85692802-67d2-11e7-92db-67e1f8d71d7e.png)

I found this error could be resolved with a simple `conda install -y graphviz`. So I've also added this command to the Docstrings section of the Development Guidelines.