### PR TITLE
Remove spurious keys from map_overlap graph

### DIFF
--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -112,8 +112,9 @@ def ghost_internal(x, axes):
         if k != frac_slice:
             interior_slices[k] = frac_slice
 
-        ghost_blocks[(name,) + k[1:]] = (concatenate3,
-                                         (concrete, expand_key2(k)))
+        else:
+            ghost_blocks[(name,) + k[1:]] = (concatenate3,
+                                             (concrete, expand_key2(k)))
 
     chunks = []
     for i, bds in enumerate(x.chunks):

--- a/dask/array/tests/test_ghost.py
+++ b/dask/array/tests/test_ghost.py
@@ -362,3 +362,13 @@ def test_none_boundaries():
          [33, 33,  8,  9, 10, 11, 33, 33],
          [33, 33, 12, 13, 14, 15, 33, 33]])
     assert_eq(exp, res)
+
+
+def test_ghost_small():
+    x = da.ones((10, 10), chunks=(5, 5))
+
+    y = x.map_overlap(lambda x: x, depth=1)
+    assert len(y.dask) < 200
+
+    y = x.map_overlap(lambda x: x, depth=1, boundary='none')
+    assert len(y.dask) < 100


### PR DESCRIPTION
Previously we included a large number of spurious keys in the graph.

These were innocuous and were culled away at computation time but did
significantly increase graph generation time.

cc @martindurant @stefanv @emmanuelle