### PR TITLE
Better error message for read_csv

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -8,7 +8,7 @@ from dask.sharedict import ShareDict
 from dask.utils import (takes_multiple_arguments, Dispatch, random_state_data,
                         memory_repr, methodcaller, M, skip_doctest,
                         SerializableLock, funcname, ndeepmap, ensure_dict,
-                        package_of, extra_titles)
+                        package_of, extra_titles, asciitable)
 from dask.utils_test import inc
 
 
@@ -168,6 +168,22 @@ def test_extra_titles():
     """
 
     assert extra_titles(example) == expected
+
+
+def test_asciitable():
+    res = asciitable(['fruit', 'color'],
+                     [('apple', 'red'),
+                      ('banana', 'yellow'),
+                      ('tomato', 'red'),
+                      ('pear', 'green')])
+    assert res == ('+--------+--------+\n'
+                   '| fruit  | color  |\n'
+                   '+--------+--------+\n'
+                   '| apple  | red    |\n'
+                   '| banana | yellow |\n'
+                   '| tomato | red    |\n'
+                   '| pear   | green  |\n'
+                   '+--------+--------+')
 
 
 def test_SerializableLock():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -634,6 +634,28 @@ def memory_repr(num):
         num /= 1024.0
 
 
+def asciitable(columns, rows):
+    """Formats an ascii table for given columns and rows.
+
+    Parameters
+    ----------
+    columns : list
+        The column names
+    rows : list of tuples
+        The rows in the table. Each tuple must be the same length as
+        ``columns``.
+    """
+    rows = [tuple(str(i) for i in r) for r in rows]
+    columns = tuple(str(i) for i in columns)
+    widths = tuple(max(max(map(len, x)), len(c))
+                   for x, c in zip(zip(*rows), columns))
+    row_template = ('|' + (' %%-%ds |' * len(columns))) % widths
+    header = row_template % tuple(columns)
+    bar = '+%s+' % '+'.join('-' * (w + 2) for w in widths)
+    data = '\n'.join(row_template % r for r in rows)
+    return '\n'.join([bar, header, bar, data, bar])
+
+
 def put_lines(buf, lines):
     if any(not isinstance(x, unicode) for x in lines):
         lines = [unicode(x) for x in lines]


### PR DESCRIPTION
Previously we'd provide a good error message only if the inferred dtypes
mismatched on `int->float` conversions. We now provide a nice error
message in all cases, including the following information:
- *All* mismatched columns, formatted nicely
- Suggested dtype dictionary to use
- If applicable, also suggest using `assume_missing=True`