### PR TITLE
Bugfix: Filesystem object not passed to pyarrow reader

### DIFF
--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -282,9 +282,17 @@ def test_read_text_passes_through_options():
         assert df.count().compute(get=get) == 3
 
 
-def test_parquet(s3):
+@pytest.mark.parametrize("engine", [
+    'auto',
+    'pyarrow',
+    'fastparquet'
+])
+def test_parquet(s3, engine):
     dd = pytest.importorskip('dask.dataframe')
-    pytest.importorskip('fastparquet')
+    if engine is not 'auto':
+        pytest.importorskip(engine)
+    else:
+        pytest.importorskip('fastparquet')
     from dask.dataframe.io.parquet import to_parquet, read_parquet
 
     import pandas as pd
@@ -306,7 +314,7 @@ def test_parquet(s3):
     assert '_metadata' in files
     assert 'part.0.parquet' in files
 
-    df2 = read_parquet(url, index='foo')
+    df2 = read_parquet(url, index='foo', engine=engine)
     assert len(df2.divisions) > 1
 
     pd.util.testing.assert_frame_equal(data, df2.compute())

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -282,15 +282,12 @@ def test_read_text_passes_through_options():
         assert df.count().compute(get=get) == 3
 
 
-@pytest.mark.parametrize("import_name,engine", [
-    ('pyarrow', 'arrow'),
-    ('fastparquet', 'fastparquet'),
-])
-def test_parquet(s3, import_name, engine):
+@pytest.mark.parametrize("engine", ['arrow', 'fastparquet'])
+def test_parquet(s3, engine):
     dd = pytest.importorskip('dask.dataframe')
-    pytest.importorskip(import_name)
-    from dask.dataframe.io.parquet import to_parquet, read_parquet
-
+    pytest.importorskip('fastparquet')
+    if engine == 'arrow':
+        pytest.importorskip('pyarrow')
     import pandas as pd
     import numpy as np
 
@@ -304,13 +301,13 @@ def test_parquet(s3, import_name, engine):
                              size=1000).astype("O")},
                         index=pd.Index(np.arange(1000), name='foo'))
     df = dd.from_pandas(data, chunksize=500)
-    to_parquet(df, url, object_encoding='utf8')
+    df.to_parquet(url, object_encoding='utf8')
 
     files = [f.split('/')[-1] for f in s3.ls(url)]
     assert '_metadata' in files
     assert 'part.0.parquet' in files
 
-    df2 = read_parquet(url, index='foo', engine=engine)
+    df2 = dd.read_parquet(url, index='foo', engine=engine)
     assert len(df2.divisions) > 1
 
     pd.util.testing.assert_frame_equal(data, df2.compute())
@@ -319,7 +316,6 @@ def test_parquet(s3, import_name, engine):
 def test_parquet_wstoragepars(s3):
     dd = pytest.importorskip('dask.dataframe')
     pytest.importorskip('fastparquet')
-    from dask.dataframe.io.parquet import to_parquet, read_parquet
 
     import pandas as pd
     import numpy as np
@@ -328,14 +324,14 @@ def test_parquet_wstoragepars(s3):
 
     data = pd.DataFrame({'i32': np.array([0, 5, 2, 5])})
     df = dd.from_pandas(data, chunksize=500)
-    to_parquet(df, url, write_index=False)
+    df.to_parquet(url, write_index=False)
 
-    read_parquet(url, storage_options={'default_fill_cache': False})
+    dd.read_parquet(url, storage_options={'default_fill_cache': False})
     assert s3.current().default_fill_cache is False
-    read_parquet(url, storage_options={'default_fill_cache': True})
+    dd.read_parquet(url, storage_options={'default_fill_cache': True})
     assert s3.current().default_fill_cache is True
 
-    read_parquet(url, storage_options={'default_block_size': 2**20})
+    dd.read_parquet(url, storage_options={'default_block_size': 2**20})
     assert s3.current().default_block_size == 2**20
     with s3.current().open(url + '/_metadata') as f:
         assert f.blocksize == 2**20

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -282,17 +282,13 @@ def test_read_text_passes_through_options():
         assert df.count().compute(get=get) == 3
 
 
-@pytest.mark.parametrize("engine", [
-    'auto',
-    'pyarrow',
-    'fastparquet'
+@pytest.mark.parametrize("import_name,engine", [
+    ('pyarrow', 'arrow'),
+    ('fastparquet', 'fastparquet'),
 ])
-def test_parquet(s3, engine):
+def test_parquet(s3, import_name, engine):
     dd = pytest.importorskip('dask.dataframe')
-    if engine is not 'auto':
-        pytest.importorskip(engine)
-    else:
-        pytest.importorskip('fastparquet')
+    pytest.importorskip(import_name)
     from dask.dataframe.io.parquet import to_parquet, read_parquet
 
     import pandas as pd

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -172,7 +172,10 @@ def _read_pyarrow(fs, paths, file_opener, columns=None, filters=None,
     if isinstance(columns, tuple):
         columns = list(columns)
 
-    dataset = api.ParquetDataset(paths)
+    dataset = api.ParquetDataset(
+        path_or_paths=paths,
+        filesystem=fs
+    )
     schema = dataset.schema.to_arrow_schema()
     has_pandas_metadata = schema.metadata is not None and b'pandas' in schema.metadata
     task_name = 'read-parquet-' + tokenize(dataset, columns)


### PR DESCRIPTION
This fixes a bug where the FileSystem object is not properly passed to the `read_parquet` method.

I had to add additional methods to the `LocalFileSystem` class since `pyarrow` expects a broader interface. These adaptations should eventually also be included in s3fs to support `pyarrow` reads from s3.