### PR TITLE
Do no attemp to compute divisions on empty dataframe.

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -106,6 +106,12 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
                        categories, pf.schema, pf.cats, pf.dtypes)
            for i, rg in enumerate(rgs)}
 
+    if not dsk:
+        # empty dataframe
+        dsk = {(name, 0): meta}
+        divisions = (None, None)
+        return out_type(dsk, name, meta, divisions)
+
     if index_col:
         minmax = fastparquet.api.sorted_partitioned_columns(pf)
         if index_col in minmax:
@@ -120,11 +126,6 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
 
     if isinstance(divisions[0], np.datetime64):
         divisions = [pd.Timestamp(d) for d in divisions]
-
-    if not dsk:
-        # empty dataframe
-        dsk = {(name, 0): meta}
-        divisions = (None, None)
 
     return out_type(dsk, name, meta, divisions)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -75,6 +75,16 @@ def test_index(fn):
     assert_eq(df, ddf)
 
 
+def test_empty_index():
+    with tmpdir() as tmp:
+        df = pd.DataFrame(columns=['a', 'b'])
+        df.set_index('a', inplace=True, drop=True)
+        ddf = dd.from_pandas(df, npartitions=2)
+        ddf.to_parquet(tmp, write_index=True)
+        read_df = dd.read_parquet(tmp)
+        assert read_df.index.name == 'a'
+
+
 def test_glob(fn):
     os.unlink(os.path.join(fn, '_metadata'))
     files = os.listdir(fn)


### PR DESCRIPTION
This fixes reading the empty df w schema from parquet file.