### PR TITLE
Check metadata in `dd.from_delayed`

### DIFF
--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -513,6 +513,10 @@ def test_from_delayed():
     with pytest.raises(ValueError):
         dd.from_delayed(dfs, meta=meta, divisions=[0, 1, 3, 6])
 
+    with pytest.raises(ValueError) as e:
+        dd.from_delayed(dfs, meta=meta.a).compute()
+    assert str(e.value).startswith('Metadata mismatch found in `from_delayed`')
+
 
 def test_from_delayed_sorted():
     a = pd.DataFrame({'x': [1, 2]}, index=[1, 10])

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -3,8 +3,8 @@ import pandas as pd
 import pandas.util.testing as tm
 import dask.dataframe as dd
 from dask.dataframe.utils import (shard_df_on_index, meta_nonempty, make_meta,
-                                  raise_on_meta_error, UNKNOWN_CATEGORIES,
-                                  PANDAS_VERSION)
+                                  raise_on_meta_error, check_meta,
+                                  UNKNOWN_CATEGORIES, PANDAS_VERSION)
 
 import pytest
 
@@ -265,3 +265,50 @@ def test_raise_on_meta_error():
         assert 'RuntimeError' in e.args[0]
     else:
         assert False, "should have errored"
+
+
+def test_check_meta():
+    df = pd.DataFrame({'a': ['x', 'y', 'z'],
+                       'b': [True, False, True],
+                       'c': [1, 2.5, 3.5],
+                       'd': [1, 2, 3],
+                       'e': pd.Categorical(['x', 'y', 'z'])})
+    meta = df.iloc[:0]
+
+    # DataFrame metadata passthrough if correct
+    assert check_meta(df, meta) is df
+    # Series metadata passthrough if correct
+    e = df.e
+    assert check_meta(e, meta.e) is e
+    # numeric_equal means floats and ints are equivalent
+    d = df.d
+    assert check_meta(d, meta.d.astype('f8'), numeric_equal=True) is d
+
+    # Series metadata error
+    with pytest.raises(ValueError) as err:
+        check_meta(d, meta.d.astype('f8'), numeric_equal=False)
+    assert str(err.value) == ('Metadata mismatch found.\n'
+                              '\n'
+                              'Partition type: `Series`\n'
+                              '+----------+---------+\n'
+                              '|          | dtype   |\n'
+                              '+----------+---------+\n'
+                              '| Found    | int64   |\n'
+                              '| Expected | float64 |\n'
+                              '+----------+---------+')
+
+    # DataFrame metadata error
+    meta2 = meta.astype({'a': 'category', 'd': 'f8'})[['a', 'b', 'c', 'd']]
+    df2 = df[['a', 'b', 'd', 'e']]
+    with pytest.raises(ValueError) as err:
+        check_meta(df2, meta2, funcname='from_delayed')
+    assert str(err.value) == ('Metadata mismatch found in `from_delayed`.\n'
+                              '\n'
+                              'Partition type: `DataFrame`\n'
+                              '+--------+----------+----------+\n'
+                              '| Column | Found    | Expected |\n'
+                              '+--------+----------+----------+\n'
+                              '| a      | object   | category |\n'
+                              '| c      | -        | float64  |\n'
+                              '| e      | category | -        |\n'
+                              '+--------+----------+----------+')


### PR DESCRIPTION
Previously if you specified the wrong metadata in `dd.from_delayed`
you'd get a nonintuitive error message. We fix this by creating a
function to check metadata inline, and raise a nice error message when
incorrect metadata is found. We apply this to `from_delayed` only for
now.