### PR TITLE
Add argwhere, *nonzero, where (cond)

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -6,8 +6,8 @@ from .core import (Array, stack, concatenate, take, tensordot, transpose,
         roll, fromfunction, unique, store, squeeze, topk, bincount, tile,
         digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
-        from_delayed, round, swapaxes, repeat, flatnonzero, nonzero,
-        asarray, asanyarray)
+        from_delayed, round, swapaxes, repeat, count_nonzero, flatnonzero,
+        nonzero, asarray, asanyarray)
 from .core import (around, isnull, notnull, isclose, eye, triu,
                    tril, diag, corrcoef)
 from .reshape import reshape

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 from ..utils import ignoring
 from .core import (Array, stack, concatenate, take, tensordot, transpose,
-        from_array, choose, where, coarsen, insert, broadcast_to, ravel,
-        roll, fromfunction, unique, store, squeeze, topk, bincount, tile,
-        digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
+        from_array, choose, argwhere, where, coarsen, insert, broadcast_to,
+        ravel, roll, fromfunction, unique, store, squeeze, topk, bincount,
+        tile, digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
         extract, from_delayed, round, swapaxes, repeat, count_nonzero,
         flatnonzero, nonzero, asarray, asanyarray)

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -6,7 +6,8 @@ from .core import (Array, stack, concatenate, take, tensordot, transpose,
         roll, fromfunction, unique, store, squeeze, topk, bincount, tile,
         digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
-        from_delayed, round, swapaxes, repeat, nonzero, asarray, asanyarray)
+        from_delayed, round, swapaxes, repeat, flatnonzero, nonzero,
+        asarray, asanyarray)
 from .core import (around, isnull, notnull, isclose, eye, triu,
                    tril, diag, corrcoef)
 from .reshape import reshape

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -6,7 +6,7 @@ from .core import (Array, stack, concatenate, take, tensordot, transpose,
         roll, fromfunction, unique, store, squeeze, topk, bincount, tile,
         digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
-        from_delayed, round, swapaxes, repeat, asarray, asanyarray)
+        from_delayed, round, swapaxes, repeat, nonzero, asarray, asanyarray)
 from .core import (around, isnull, notnull, isclose, eye, triu,
                    tril, diag, corrcoef)
 from .reshape import reshape

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2843,6 +2843,12 @@ def isnonzero(a):
     if issubclass(a.dtype.type, Number):
         return (a != 0)
     if issubclass(a.dtype.type, (np.bytes_, np.unicode_)):
+        ######################################################
+        # Treats empty or whitespace only strings as False.  #
+        # This behavior mimics NumPy's own behavior.         #
+        #                                                    #
+        # xref: https://github.com/numpy/numpy/issues/9462   #
+        ######################################################
         np_isnonzero = np.vectorize(lambda v: bool(v.strip()), otypes=[bool])
         return a.map_blocks(np_isnonzero, dtype=bool)
     else:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2876,7 +2876,7 @@ def where(condition, x=None, y=None):
 
 @wraps(np.count_nonzero)
 def count_nonzero(a, axis=None):
-    return (a != 0).sum(axis=axis)
+    return (a != 0).astype(np.int64).sum(axis=axis)
 
 
 @wraps(np.flatnonzero)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2838,6 +2838,20 @@ See the following documentation page for details:
 """.strip()
 
 
+@wraps(np.argwhere)
+def argwhere(a):
+    from .creation import indices
+
+    nz = (a != 0).flatten()
+
+    ind = indices(a.shape, dtype=np.int64, chunks=a.chunks)
+    ind = ind.reshape((a.ndim, -1))
+    ind = compress(nz, ind, axis=1)
+    ind = ind.T
+
+    return ind
+
+
 @wraps(np.where)
 def where(condition, x=None, y=None):
     if (x is None) != (y is None):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2855,6 +2855,11 @@ def where(condition, x=None, y=None):
         return choose(condition, [y, x])
 
 
+@wraps(np.flatnonzero)
+def flatnonzero(a):
+    return a.ravel().nonzero()[0]
+
+
 @wraps(np.nonzero)
 def nonzero(a):
     from .creation import indices

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2838,23 +2838,23 @@ See the following documentation page for details:
 """.strip()
 
 
-def _isnonzero_str(v):
-    return bool(v.strip())
+def _isnonzero_vec(v):
+    return bool(np.count_nonzero(v))
 
 
-_isnonzero_str = np.vectorize(_isnonzero_str, otypes=[bool])
+_isnonzero_vec = np.vectorize(_isnonzero_vec, otypes=[bool])
 
 
 def isnonzero(a):
     a = asarray(a)
     if issubclass(a.dtype.type, (np.bytes_, np.unicode_)):
         ######################################################
-        # Treats empty or whitespace only strings as False.  #
-        # This behavior mimics NumPy's own behavior.         #
+        # Handle special cases where conversion to bool does #
+        # not work correctly.                                #
         #                                                    #
-        # xref: https://github.com/numpy/numpy/issues/9462   #
+        # xref: https://github.com/numpy/numpy/issues/9479   #
         ######################################################
-        return a.map_blocks(_isnonzero_str, dtype=bool)
+        return a.map_blocks(_isnonzero_vec, dtype=bool)
     else:
         return a.astype(bool)
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2845,7 +2845,7 @@ def argwhere(a):
     nz = (a != 0).flatten()
 
     ind = indices(a.shape, dtype=np.int64, chunks=a.chunks)
-    ind = ind.reshape((a.ndim, -1)).T
+    ind = stack([ind[i].ravel() for i in range(len(ind))], axis=1)
     ind = compress(nz, ind, axis=0)
 
     return ind

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2845,9 +2845,8 @@ def argwhere(a):
     nz = (a != 0).flatten()
 
     ind = indices(a.shape, dtype=np.int64, chunks=a.chunks)
-    ind = ind.reshape((a.ndim, -1))
-    ind = compress(nz, ind, axis=1)
-    ind = ind.T
+    ind = ind.reshape((a.ndim, -1)).T
+    ind = compress(nz, ind, axis=0)
 
     return ind
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2886,7 +2886,8 @@ def flatnonzero(a):
 
 @wraps(np.nonzero)
 def nonzero(a):
-    return tuple(argwhere(a).T)
+    ind = argwhere(a)
+    return tuple(ind[:, i] for i in range(ind.shape[1]))
 
 
 @wraps(chunk.coarsen)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2857,7 +2857,8 @@ def argwhere(a):
     nz = isnonzero(a).flatten()
 
     ind = indices(a.shape, dtype=np.int64, chunks=a.chunks)
-    ind = stack([ind[i].ravel() for i in range(len(ind))], axis=1)
+    if ind.ndim > 1:
+        ind = stack([ind[i].ravel() for i in range(len(ind))], axis=1)
     ind = compress(nz, ind, axis=0)
 
     return ind
@@ -2899,7 +2900,10 @@ def flatnonzero(a):
 @wraps(np.nonzero)
 def nonzero(a):
     ind = argwhere(a)
-    return tuple(ind[:, i] for i in range(ind.shape[1]))
+    if ind.ndim > 1:
+        return tuple(ind[:, i] for i in range(ind.shape[1]))
+    else:
+        return (ind,)
 
 
 @wraps(chunk.coarsen)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2895,7 +2895,7 @@ def nonzero(a):
     ind = indices(a.shape, dtype=np.int64, chunks=a.chunks)
     ind = ind.reshape((a.ndim, -1))
 
-    return tuple(compress(nz, ind[i], axis=0) for i in range(a.ndim))
+    return tuple(compress(nz, ind[i]) for i in range(a.ndim))
 
 
 @wraps(chunk.coarsen)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1768,6 +1768,10 @@ class Array(Base):
     def repeat(self, repeats, axis=None):
         return repeat(self, repeats, axis=axis)
 
+    @wraps(np.nonzero)
+    def nonzero(self):
+        return nonzero(self)
+
 
 def ensure_int(f):
     i = int(f)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2887,15 +2887,7 @@ def flatnonzero(a):
 
 @wraps(np.nonzero)
 def nonzero(a):
-    from .creation import indices
-
-    nz = (a != 0).flatten()
-
-    ind = indices(a.shape, dtype=np.int64, chunks=a.chunks)
-    ind = ind.reshape((a.ndim, -1))
-    ind = compress(nz, ind, axis=1)
-
-    return tuple(ind)
+    return tuple(argwhere(a).T)
 
 
 @wraps(chunk.coarsen)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2881,7 +2881,7 @@ def where(condition, x=None, y=None):
     if (x is None) != (y is None):
         raise ValueError("either both or neither of x and y should be given")
     if (x is None) and (y is None):
-        return condition.nonzero()
+        return nonzero(condition)
 
     x = asarray(x)
     y = asarray(y)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2870,7 +2870,8 @@ def nonzero(a):
     from .creation import indices
 
     nz = (a != 0).flatten()
-    ind = indices(a.shape, chunks=a.chunks).reshape((a.ndim, -1))
+    ind = indices(a.shape, dtype=np.int64, chunks=a.chunks)
+    ind = ind.reshape((a.ndim, -1))
 
     return tuple(compress(nz, ind[i], axis=0) for i in range(a.ndim))
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2851,6 +2851,16 @@ def where(condition, x=None, y=None):
         return choose(condition, [y, x])
 
 
+@wraps(np.nonzero)
+def nonzero(a):
+    from .creation import indices
+
+    nz = (a != 0).flatten()
+    ind = indices(a.shape, chunks=a.chunks).reshape((a.ndim, -1))
+
+    return tuple(compress(nz, ind[i], axis=0) for i in range(a.ndim))
+
+
 @wraps(chunk.coarsen)
 def coarsen(reduction, x, axes, trim_excess=False):
     if (not trim_excess and

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2847,7 +2847,10 @@ _isnonzero_vec = np.vectorize(_isnonzero_vec, otypes=[bool])
 
 def isnonzero(a):
     a = asarray(a)
-    if issubclass(a.dtype.type, (np.bytes_, np.unicode_)):
+
+    try:
+        np.zeros(tuple(), dtype=a.dtype).astype(bool)
+    except ValueError:
         ######################################################
         # Handle special cases where conversion to bool does #
         # not work correctly.                                #

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2892,10 +2892,12 @@ def nonzero(a):
     from .creation import indices
 
     nz = (a != 0).flatten()
+
     ind = indices(a.shape, dtype=np.int64, chunks=a.chunks)
     ind = ind.reshape((a.ndim, -1))
+    ind = compress(nz, ind, axis=1)
 
-    return tuple(compress(nz, ind[i]) for i in range(a.ndim))
+    return tuple(ind)
 
 
 @wraps(chunk.coarsen)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2881,7 +2881,7 @@ def count_nonzero(a, axis=None):
 
 @wraps(np.flatnonzero)
 def flatnonzero(a):
-    return a.ravel().nonzero()[0]
+    return argwhere(a.ravel())[:, 0]
 
 
 @wraps(np.nonzero)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2842,6 +2842,9 @@ def _isnonzero_str(v):
     return bool(v.strip())
 
 
+_isnonzero_str = np.vectorize(_isnonzero_str, otypes=[bool])
+
+
 def isnonzero(a):
     a = asarray(a)
     if issubclass(a.dtype.type, (np.bytes_, np.unicode_)):
@@ -2851,8 +2854,7 @@ def isnonzero(a):
         #                                                    #
         # xref: https://github.com/numpy/numpy/issues/9462   #
         ######################################################
-        np_isnonzero = np.vectorize(_isnonzero_str, otypes=[bool])
-        return a.map_blocks(np_isnonzero, dtype=bool)
+        return a.map_blocks(_isnonzero_str, dtype=bool)
     else:
         return a.astype(bool)
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2855,6 +2855,11 @@ def where(condition, x=None, y=None):
         return choose(condition, [y, x])
 
 
+@wraps(np.count_nonzero)
+def count_nonzero(a, axis=None):
+    return (a != 0).sum(axis=axis)
+
+
 @wraps(np.flatnonzero)
 def flatnonzero(a):
     return a.ravel().nonzero()[0]

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2846,8 +2846,6 @@ _isnonzero_vec = np.vectorize(_isnonzero_vec, otypes=[bool])
 
 
 def isnonzero(a):
-    a = asarray(a)
-
     try:
         np.zeros(tuple(), dtype=a.dtype).astype(bool)
     except ValueError:
@@ -2865,6 +2863,8 @@ def isnonzero(a):
 @wraps(np.argwhere)
 def argwhere(a):
     from .creation import indices
+
+    a = asarray(a)
 
     nz = isnonzero(a).flatten()
 
@@ -2901,12 +2901,12 @@ def where(condition, x=None, y=None):
 
 @wraps(np.count_nonzero)
 def count_nonzero(a, axis=None):
-    return isnonzero(a).astype(np.int64).sum(axis=axis)
+    return isnonzero(asarray(a)).astype(np.int64).sum(axis=axis)
 
 
 @wraps(np.flatnonzero)
 def flatnonzero(a):
-    return argwhere(a.ravel())[:, 0]
+    return argwhere(asarray(a).ravel())[:, 0]
 
 
 @wraps(np.nonzero)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2840,8 +2840,6 @@ See the following documentation page for details:
 
 def isnonzero(a):
     a = asarray(a)
-    if issubclass(a.dtype.type, Number):
-        return (a != 0)
     if issubclass(a.dtype.type, (np.bytes_, np.unicode_)):
         ######################################################
         # Treats empty or whitespace only strings as False.  #
@@ -2852,8 +2850,7 @@ def isnonzero(a):
         np_isnonzero = np.vectorize(lambda v: bool(v.strip()), otypes=[bool])
         return a.map_blocks(np_isnonzero, dtype=bool)
     else:
-        np_isnonzero = np.vectorize(lambda v: bool(v), otypes=[bool])
-        return a.map_blocks(np_isnonzero, dtype=bool)
+        return a.astype(bool)
 
 
 @wraps(np.argwhere)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2838,6 +2838,10 @@ See the following documentation page for details:
 """.strip()
 
 
+def _isnonzero_str(v):
+    return bool(v.strip())
+
+
 def isnonzero(a):
     a = asarray(a)
     if issubclass(a.dtype.type, (np.bytes_, np.unicode_)):
@@ -2847,7 +2851,7 @@ def isnonzero(a):
         #                                                    #
         # xref: https://github.com/numpy/numpy/issues/9462   #
         ######################################################
-        np_isnonzero = np.vectorize(lambda v: bool(v.strip()), otypes=[bool])
+        np_isnonzero = np.vectorize(_isnonzero_str, otypes=[bool])
         return a.map_blocks(np_isnonzero, dtype=bool)
     else:
         return a.astype(bool)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2829,24 +2829,6 @@ def choose(a, choices):
     return elemwise(variadic_choose, a, *choices)
 
 
-where_error_message = """
-The dask.array version of where only handles the three argument case.
-
-    da.where(x > 0, x, 0)
-
-and not the single argument case
-
-    da.where(x > 0)
-
-This is because dask.array operations must be able to infer the shape of their
-outputs prior to execution.  The number of positive elements of x requires
-execution.  See the ``np.where`` docstring for examples and the following link
-for a more thorough explanation:
-
-    http://dask.pydata.org/en/latest/array-overview.html#construct
-""".strip()
-
-
 chunks_none_error_message = """
 You must specify a chunks= keyword argument.
 This specifies the chunksize of your array blocks.
@@ -2858,8 +2840,10 @@ See the following documentation page for details:
 
 @wraps(np.where)
 def where(condition, x=None, y=None):
-    if x is None or y is None:
-        raise TypeError(where_error_message)
+    if (x is None) != (y is None):
+        raise ValueError("either both or neither of x and y should be given")
+    if (x is None) and (y is None):
+        return condition.nonzero()
 
     x = asarray(x)
     y = asarray(y)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -29,8 +29,8 @@ from dask.array.core import (getem, getter, top, dotmany,
                              concatenate3, broadcast_dimensions, Array, stack,
                              concatenate, from_array, take, elemwise, isnull,
                              notnull, broadcast_shapes, partial_by_order,
-                             tensordot, choose, where, flatnonzero, nonzero,
-                             coarsen, insert, broadcast_to, fromfunction,
+                             tensordot, choose, where, coarsen, insert,
+                             broadcast_to, fromfunction,
                              blockdims_from_blockshape, store, optimize,
                              from_func, normalize_chunks, broadcast_chunks,
                              atop, from_delayed, concatenate_axes,
@@ -797,7 +797,7 @@ def test_flatnonzero():
     d = from_array(x, chunks=(4, 5))
 
     x_fnz = np.flatnonzero(x)
-    d_fnz = flatnonzero(d)
+    d_fnz = da.flatnonzero(d)
 
     assert_eq(d_fnz, x_fnz)
 
@@ -807,7 +807,7 @@ def test_nonzero():
     d = from_array(x, chunks=(4, 5))
 
     x_nz = np.nonzero(x)
-    d_nz = nonzero(d)
+    d_nz = da.nonzero(d)
 
     assert isinstance(d_nz, type(x_nz))
     assert len(d_nz) == len(x_nz)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -812,11 +812,6 @@ def test_count_nonzero():
                     reason="NumPy's count_nonzero doesn't yet support axis")
 @pytest.mark.parametrize('axis', [None, 0, (1,), (0, 1)])
 def test_count_nonzero_axis(axis):
-    if (LooseVersion(np.__version__) < LooseVersion("1.12.0")):
-        pytest.skip(
-            "NumPy %s doesn't support multiple axes with `roll`."
-            " Need NumPy 1.12.0 or greater." % np.__version__
-        )
     for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)
         d = from_array(x, chunks=chunks)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -789,7 +789,7 @@ def test_count_nonzero(axis):
     x = np.random.randint(10, size=(15, 16))
     d = from_array(x, chunks=(4, 5))
 
-    assert_eq(da.count_nonzero(d, axis), da.count_nonzero(x, axis))
+    assert_eq(da.count_nonzero(d, axis), np.count_nonzero(x, axis))
 
 
 def test_flatnonzero():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -786,16 +786,17 @@ def test_where_incorrect_args():
 
 @pytest.mark.parametrize('axis', [None, 0, (1,), (0, 1)])
 def test_count_nonzero(axis):
-    x = np.random.randint(10, size=(15, 16))
-    d = from_array(x, chunks=(4, 5))
+    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+        x = np.random.randint(10, size=shape)
+        d = from_array(x, chunks=chunks)
 
-    x_c = np.count_nonzero(x, axis)
-    d_c = da.count_nonzero(d, axis)
+        x_c = np.count_nonzero(x, axis)
+        d_c = da.count_nonzero(d, axis)
 
-    if d_c.shape == tuple():
-        assert x_c == d_c.compute()
-    else:
-        assert_eq(x_c, d_c)
+        if d_c.shape == tuple():
+            assert x_c == d_c.compute()
+        else:
+            assert_eq(x_c, d_c)
 
 
 def test_flatnonzero():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -747,12 +747,19 @@ def test_where_bool_optimization():
         assert w1 is ex_w1
 
 
-def test_where_has_informative_error():
-    x = da.ones(5, chunks=3)
-    try:
-        da.where(x > 0)
-    except Exception as e:
-        assert 'dask' in str(e)
+def test_where_nonzero():
+    x = np.random.randint(10, size=(15, 16))
+    x[5, 5] = x[4, 4] = 0 # Ensure some false elements
+    d = from_array(x, chunks=(4, 5))
+
+    x_w = np.where(x)
+    d_w = where(d)
+
+    assert isinstance(d_w, type(x_w))
+    assert len(d_w) == len(x_w)
+
+    for i in range(len(x_w)):
+        assert_eq(d_w[i], x_w[i])
 
 
 @pytest.mark.parametrize('axis', [None, 0, (1,), (0, 1)])

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -789,7 +789,10 @@ def test_count_nonzero(axis):
     x = np.random.randint(10, size=(15, 16))
     d = from_array(x, chunks=(4, 5))
 
-    assert_eq(da.count_nonzero(d, axis), np.count_nonzero(x, axis))
+    x_c = np.count_nonzero(x, axis)
+    d_c = da.count_nonzero(d, axis)
+
+    assert_eq(x_c, d_c)
 
 
 def test_flatnonzero():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -762,6 +762,17 @@ def test_where_nonzero():
         assert_eq(d_w[i], x_w[i])
 
 
+def test_where_incorrect_args():
+    a = da.ones(5, chunks=3)
+
+    for kwd in ["x", "y"]:
+        kwargs = {kwd: a}
+        try:
+            da.where(a > 0, **kwargs)
+        except ValueError as e:
+            assert 'either both or neither of x and y should be given' in str(e)
+
+
 @pytest.mark.parametrize('axis', [None, 0, (1,), (0, 1)])
 def test_count_nonzero(axis):
     x = np.random.randint(10, size=(15, 16))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -710,14 +710,14 @@ def test_choose():
 
 
 def test_argwhere():
-    x = np.random.randint(10, size=(15, 16))
-    x[5, 5] = x[4, 4] = 0 # Ensure some false elements
-    d = from_array(x, chunks=(4, 5))
+    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+        x = np.random.randint(10, size=shape)
+        d = from_array(x, chunks=chunks)
 
-    x_nz = np.argwhere(x)
-    d_nz = da.argwhere(d)
+        x_nz = np.argwhere(x)
+        d_nz = da.argwhere(d)
 
-    assert_eq(d_nz, x_nz)
+        assert_eq(d_nz, x_nz)
 
 
 def test_where():
@@ -759,18 +759,18 @@ def test_where_bool_optimization():
 
 
 def test_where_nonzero():
-    x = np.random.randint(10, size=(15, 16))
-    x[5, 5] = x[4, 4] = 0 # Ensure some false elements
-    d = from_array(x, chunks=(4, 5))
+    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+        x = np.random.randint(10, size=shape)
+        d = from_array(x, chunks=chunks)
 
-    x_w = np.where(x)
-    d_w = where(d)
+        x_w = np.where(x)
+        d_w = where(d)
 
-    assert isinstance(d_w, type(x_w))
-    assert len(d_w) == len(x_w)
+        assert isinstance(d_w, type(x_w))
+        assert len(d_w) == len(x_w)
 
-    for i in range(len(x_w)):
-        assert_eq(d_w[i], x_w[i])
+        for i in range(len(x_w)):
+            assert_eq(d_w[i], x_w[i])
 
 
 def test_where_incorrect_args():
@@ -793,41 +793,44 @@ def test_count_nonzero(axis):
 
 
 def test_flatnonzero():
-    x = np.random.randint(10, size=(15, 16))
-    d = from_array(x, chunks=(4, 5))
+    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+        x = np.random.randint(10, size=shape)
+        d = from_array(x, chunks=chunks)
 
-    x_fnz = np.flatnonzero(x)
-    d_fnz = da.flatnonzero(d)
+        x_fnz = np.flatnonzero(x)
+        d_fnz = da.flatnonzero(d)
 
-    assert_eq(d_fnz, x_fnz)
+        assert_eq(d_fnz, x_fnz)
 
 
 def test_nonzero():
-    x = np.random.randint(10, size=(15, 16))
-    d = from_array(x, chunks=(4, 5))
+    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+        x = np.random.randint(10, size=shape)
+        d = from_array(x, chunks=chunks)
 
-    x_nz = np.nonzero(x)
-    d_nz = da.nonzero(d)
+        x_nz = np.nonzero(x)
+        d_nz = da.nonzero(d)
 
-    assert isinstance(d_nz, type(x_nz))
-    assert len(d_nz) == len(x_nz)
+        assert isinstance(d_nz, type(x_nz))
+        assert len(d_nz) == len(x_nz)
 
-    for i in range(len(x_nz)):
-        assert_eq(d_nz[i], x_nz[i])
+        for i in range(len(x_nz)):
+            assert_eq(d_nz[i], x_nz[i])
 
 
 def test_nonzero_method():
-    x = np.random.randint(10, size=(15, 16))
-    d = from_array(x, chunks=(4, 5))
+    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+        x = np.random.randint(10, size=shape)
+        d = from_array(x, chunks=chunks)
 
-    x_nz = x.nonzero()
-    d_nz = d.nonzero()
+        x_nz = x.nonzero()
+        d_nz = d.nonzero()
 
-    assert isinstance(d_nz, type(x_nz))
-    assert len(d_nz) == len(x_nz)
+        assert isinstance(d_nz, type(x_nz))
+        assert len(d_nz) == len(x_nz)
 
-    for i in range(len(x_nz)):
-        assert_eq(d_nz[i], x_nz[i])
+        for i in range(len(x_nz)):
+            assert_eq(d_nz[i], x_nz[i])
 
 
 def test_coarsen():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -710,7 +710,7 @@ def test_choose():
 
 
 def test_argwhere():
-    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+    for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)
         d = from_array(x, chunks=chunks)
 
@@ -769,7 +769,7 @@ def test_where_bool_optimization():
 
 
 def test_where_nonzero():
-    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+    for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)
         d = from_array(x, chunks=chunks)
 
@@ -795,7 +795,7 @@ def test_where_incorrect_args():
 
 
 def test_count_nonzero():
-    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+    for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)
         d = from_array(x, chunks=chunks)
 
@@ -817,7 +817,7 @@ def test_count_nonzero_axis(axis):
             "NumPy %s doesn't support multiple axes with `roll`."
             " Need NumPy 1.12.0 or greater." % np.__version__
         )
-    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+    for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)
         d = from_array(x, chunks=chunks)
 
@@ -875,7 +875,7 @@ def test_count_nonzero_str():
 
 
 def test_flatnonzero():
-    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+    for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)
         d = from_array(x, chunks=chunks)
 
@@ -886,7 +886,7 @@ def test_flatnonzero():
 
 
 def test_nonzero():
-    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+    for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)
         d = from_array(x, chunks=chunks)
 
@@ -915,7 +915,7 @@ def test_nonzero_str():
 
 
 def test_nonzero_method():
-    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+    for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)
         d = from_array(x, chunks=chunks)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -817,7 +817,7 @@ def test_count_nonzero_axis(axis):
             "NumPy %s doesn't support multiple axes with `roll`."
             " Need NumPy 1.12.0 or greater." % np.__version__
         )
-    for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)
         d = from_array(x, chunks=chunks)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -709,6 +709,17 @@ def test_choose():
     assert_eq(choose(d > 5, [-d, d]), np.choose(x > 5, [-x, x]))
 
 
+def test_argwhere():
+    x = np.random.randint(10, size=(15, 16))
+    x[5, 5] = x[4, 4] = 0 # Ensure some false elements
+    d = from_array(x, chunks=(4, 5))
+
+    x_nz = np.argwhere(x)
+    d_nz = da.argwhere(d)
+
+    assert_eq(d_nz, x_nz)
+
+
 def test_where():
     x = np.random.randint(10, size=(15, 16))
     x[5, 5] = x[4, 4] = 0 # Ensure some false elements

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -856,7 +856,12 @@ def test_count_nonzero_obj_axis(axis):
     if d_c.shape == tuple():
         assert x_c == d_c.compute()
     else:
-        assert_eq(x_c, d_c)
+        #######################################################
+        # Workaround oddness with Windows and object arrays.  #
+        #                                                     #
+        # xref: https://github.com/numpy/numpy/issues/9468    #
+        #######################################################
+        assert_eq(x_c.astype(np.int64), d_c)
 
 
 def test_count_nonzero_str():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -783,10 +783,8 @@ def test_nonzero():
     assert isinstance(d_nz, type(x_nz))
     assert len(d_nz) == len(x_nz)
 
-    x_nza = np.stack(x_nz)
-    d_nza = da.stack(d_nz)
-
-    assert_eq(d_nza, x_nza)
+    for i in range(len(x_nz)):
+        assert_eq(d_nz[i], x_nz[i])
 
 
 def test_nonzero_method():
@@ -799,10 +797,8 @@ def test_nonzero_method():
     assert isinstance(d_nz, type(x_nz))
     assert len(d_nz) == len(x_nz)
 
-    x_nza = np.stack(x_nz)
-    d_nza = da.stack(d_nz)
-
-    assert_eq(d_nza, x_nza)
+    for i in range(len(x_nz)):
+        assert_eq(d_nz[i], x_nz[i])
 
 
 def test_coarsen():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -794,8 +794,29 @@ def test_where_incorrect_args():
             assert 'either both or neither of x and y should be given' in str(e)
 
 
+def test_count_nonzero():
+    for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+        x = np.random.randint(10, size=shape)
+        d = from_array(x, chunks=chunks)
+
+        x_c = np.count_nonzero(x)
+        d_c = da.count_nonzero(d)
+
+        if d_c.shape == tuple():
+            assert x_c == d_c.compute()
+        else:
+            assert_eq(x_c, d_c)
+
+
+@pytest.mark.skipif(LooseVersion(np.__version__) < '1.12.0',
+                    reason="NumPy's count_nonzero doesn't yet support axis")
 @pytest.mark.parametrize('axis', [None, 0, (1,), (0, 1)])
-def test_count_nonzero(axis):
+def test_count_nonzero_axis(axis):
+    if (LooseVersion(np.__version__) < LooseVersion("1.12.0")):
+        pytest.skip(
+            "NumPy %s doesn't support multiple axes with `roll`."
+            " Need NumPy 1.12.0 or greater." % np.__version__
+        )
     for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)
         d = from_array(x, chunks=chunks)
@@ -809,8 +830,23 @@ def test_count_nonzero(axis):
             assert_eq(x_c, d_c)
 
 
+def test_count_nonzero_obj():
+    x = np.random.randint(10, size=(15, 16)).astype(object)
+    d = from_array(x, chunks=(4, 5))
+
+    x_c = np.count_nonzero(x)
+    d_c = da.count_nonzero(d)
+
+    if d_c.shape == tuple():
+        assert x_c == d_c.compute()
+    else:
+        assert_eq(x_c, d_c)
+
+
+@pytest.mark.skipif(LooseVersion(np.__version__) < '1.12.0',
+                    reason="NumPy's count_nonzero doesn't yet support axis")
 @pytest.mark.parametrize('axis', [None, 0, (1,), (0, 1)])
-def test_count_nonzero_obj(axis):
+def test_count_nonzero_obj_axis(axis):
     x = np.random.randint(10, size=(15, 16)).astype(object)
     d = from_array(x, chunks=(4, 5))
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -727,6 +727,14 @@ def test_where_has_informative_error():
         assert 'dask' in str(e)
 
 
+@pytest.mark.parametrize('axis', [None, 0, (1,), (0, 1)])
+def test_count_nonzero(axis):
+    x = np.random.randint(10, size=(15, 16))
+    d = from_array(x, chunks=(4, 5))
+
+    assert_eq(da.count_nonzero(d, axis), da.count_nonzero(x, axis))
+
+
 def test_flatnonzero():
     x = np.random.randint(10, size=(15, 16))
     d = from_array(x, chunks=(4, 5))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -29,8 +29,8 @@ from dask.array.core import (getem, getter, top, dotmany,
                              concatenate3, broadcast_dimensions, Array, stack,
                              concatenate, from_array, take, elemwise, isnull,
                              notnull, broadcast_shapes, partial_by_order,
-                             tensordot, choose, where, nonzero, coarsen,
-                             insert, broadcast_to, fromfunction,
+                             tensordot, choose, where, flatnonzero, nonzero,
+                             coarsen, insert, broadcast_to, fromfunction,
                              blockdims_from_blockshape, store, optimize,
                              from_func, normalize_chunks, broadcast_chunks,
                              atop, from_delayed, concatenate_axes,
@@ -725,6 +725,16 @@ def test_where_has_informative_error():
         da.where(x > 0)
     except Exception as e:
         assert 'dask' in str(e)
+
+
+def test_flatnonzero():
+    x = np.random.randint(10, size=(15, 16))
+    d = from_array(x, chunks=(4, 5))
+
+    x_fnz = np.flatnonzero(x)
+    d_fnz = flatnonzero(d)
+
+    assert_eq(d_fnz, x_fnz)
 
 
 def test_nonzero():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -720,6 +720,16 @@ def test_argwhere():
         assert_eq(d_nz, x_nz)
 
 
+def test_argwhere_obj():
+    x = np.random.randint(10, size=(15, 16)).astype(object)
+    d = from_array(x, chunks=(4, 5))
+
+    x_nz = np.argwhere(x)
+    d_nz = da.argwhere(d)
+
+    assert_eq(d_nz, x_nz)
+
+
 def test_where():
     x = np.random.randint(10, size=(15, 16))
     x[5, 5] = x[4, 4] = 0 # Ensure some false elements
@@ -799,6 +809,30 @@ def test_count_nonzero(axis):
             assert_eq(x_c, d_c)
 
 
+@pytest.mark.parametrize('axis', [None, 0, (1,), (0, 1)])
+def test_count_nonzero_obj(axis):
+    x = np.random.randint(10, size=(15, 16)).astype(object)
+    d = from_array(x, chunks=(4, 5))
+
+    x_c = np.count_nonzero(x, axis)
+    d_c = da.count_nonzero(d, axis)
+
+    if d_c.shape == tuple():
+        assert x_c == d_c.compute()
+    else:
+        assert_eq(x_c, d_c)
+
+
+def test_count_nonzero_str():
+    x = np.array(list("Hello world"))
+    d = from_array(x, chunks=(4,))
+
+    x_c = np.count_nonzero(x)
+    d_c = da.count_nonzero(d)
+
+    assert x_c == d_c.compute()
+
+
 def test_flatnonzero():
     for shape, chunks in [((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)
@@ -823,6 +857,20 @@ def test_nonzero():
 
         for i in range(len(x_nz)):
             assert_eq(d_nz[i], x_nz[i])
+
+
+def test_nonzero_str():
+    x = np.array(list("Hello world"))
+    d = from_array(x, chunks=(4,))
+
+    x_nz = np.nonzero(x)
+    d_nz = da.nonzero(d)
+
+    assert isinstance(d_nz, type(x_nz))
+    assert len(d_nz) == len(x_nz)
+
+    for i in range(len(x_nz)):
+        assert_eq(d_nz[i], x_nz[i])
 
 
 def test_nonzero_method():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -29,8 +29,8 @@ from dask.array.core import (getem, getter, top, dotmany,
                              concatenate3, broadcast_dimensions, Array, stack,
                              concatenate, from_array, take, elemwise, isnull,
                              notnull, broadcast_shapes, partial_by_order,
-                             tensordot, choose, where, coarsen, insert,
-                             broadcast_to, fromfunction,
+                             tensordot, choose, where, nonzero, coarsen,
+                             insert, broadcast_to, fromfunction,
                              blockdims_from_blockshape, store, optimize,
                              from_func, normalize_chunks, broadcast_chunks,
                              atop, from_delayed, concatenate_axes,
@@ -725,6 +725,38 @@ def test_where_has_informative_error():
         da.where(x > 0)
     except Exception as e:
         assert 'dask' in str(e)
+
+
+def test_nonzero():
+    x = np.random.randint(10, size=(15, 16))
+    d = from_array(x, chunks=(4, 5))
+
+    x_nz = np.nonzero(x)
+    d_nz = nonzero(d)
+
+    assert isinstance(d_nz, type(x_nz))
+    assert len(d_nz) == len(x_nz)
+
+    x_nza = np.stack(x_nz)
+    d_nza = da.stack(d_nz)
+
+    assert_eq(d_nza, x_nza)
+
+
+def test_nonzero_method():
+    x = np.random.randint(10, size=(15, 16))
+    d = from_array(x, chunks=(4, 5))
+
+    x_nz = x.nonzero()
+    d_nz = d.nonzero()
+
+    assert isinstance(d_nz, type(x_nz))
+    assert len(d_nz) == len(x_nz)
+
+    x_nza = np.stack(x_nz)
+    d_nza = da.stack(d_nz)
+
+    assert_eq(d_nza, x_nza)
 
 
 def test_coarsen():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -792,7 +792,10 @@ def test_count_nonzero(axis):
     x_c = np.count_nonzero(x, axis)
     d_c = da.count_nonzero(d, axis)
 
-    assert_eq(x_c, d_c)
+    if d_c.shape == tuple():
+        assert x_c == d_c.compute()
+    else:
+        assert_eq(x_c, d_c)
 
 
 def test_flatnonzero():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -730,6 +730,16 @@ def test_argwhere_obj():
     assert_eq(d_nz, x_nz)
 
 
+def test_argwhere_str():
+    x = np.array(list("Hello world"))
+    d = from_array(x, chunks=(4,))
+
+    x_nz = np.argwhere(x)
+    d_nz = da.argwhere(d)
+
+    assert_eq(d_nz, x_nz)
+
+
 def test_where():
     x = np.random.randint(10, size=(15, 16))
     x[5, 5] = x[4, 4] = 0 # Ensure some false elements
@@ -893,20 +903,6 @@ def test_nonzero():
 
         for i in range(len(x_nz)):
             assert_eq(d_nz[i], x_nz[i])
-
-
-def test_nonzero_str():
-    x = np.array(list("Hello world"))
-    d = from_array(x, chunks=(4,))
-
-    x_nz = np.nonzero(x)
-    d_nz = da.nonzero(d)
-
-    assert isinstance(d_nz, type(x_nz))
-    assert len(d_nz) == len(x_nz)
-
-    for i in range(len(x_nz)):
-        assert_eq(d_nz[i], x_nz[i])
 
 
 def test_nonzero_method():

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -100,6 +100,7 @@ Top level user functions:
    nansum
    nanvar
    nextafter
+   nonzero
    notnull
    ones
    percentile
@@ -380,6 +381,7 @@ Other functions
 .. autofunction:: nansum
 .. autofunction:: nanvar
 .. autofunction:: nextafter
+.. autofunction:: nonzero
 .. autofunction:: notnull
 .. autofunction:: ones
 .. autofunction:: percentile

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -34,6 +34,7 @@ Top level user functions:
    corrcoef
    cos
    cosh
+   count_nonzero
    cov
    cumprod
    cumsum
@@ -316,6 +317,7 @@ Other functions
 .. autofunction:: corrcoef
 .. autofunction:: cos
 .. autofunction:: cosh
+.. autofunction:: count_nonzero
 .. autofunction:: cov
 .. autofunction:: cumprod
 .. autofunction:: cumsum

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -19,6 +19,7 @@ Top level user functions:
    arctanh
    argmax
    argmin
+   argwhere
    around
    array
    bincount
@@ -302,6 +303,7 @@ Other functions
 .. autofunction:: arctanh
 .. autofunction:: argmax
 .. autofunction:: argmin
+.. autofunction:: argwhere
 .. autofunction:: around
 .. autofunction:: array
 .. autofunction:: bincount

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -49,6 +49,7 @@ Top level user functions:
    eye
    fabs
    fix
+   flatnonzero
    floor
    fmax
    fmin
@@ -330,6 +331,7 @@ Other functions
 .. autofunction:: eye
 .. autofunction:: fabs
 .. autofunction:: fix
+.. autofunction:: flatnonzero
 .. autofunction:: floor
 .. autofunction:: fmax
 .. autofunction:: fmin


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/1076

Provides a basic implementation of NumPy's [`argwhere`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.argwhere.html ) for Dask Arrays. Makes use of `compress` to make it work. Leverages this implementation of `argwhere` to make an implementation of NumPy's [`nonzero`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.nonzero.html ) for Dask Arrays. Also builds on top of this to provide [`flatnonzero`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.flatnonzero.html ). Independently also adds [`count_nonzero`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.count_nonzero.html ). Finally adds support for `where` when only the condition is provided by using `nonzero` in this case. All of these implementations are made to be lazy and use unknown dimension lengths as needed.

cc @shoyer @mrocklin