### PR TITLE
Support compress with axis as None

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2452,7 +2452,8 @@ def take(a, indices, axis=0):
 @wraps(np.compress)
 def compress(condition, a, axis=None):
     if axis is None:
-        raise NotImplementedError("Must select axis for compression")
+        a = a.ravel()
+        axis = 0
     if not -a.ndim <= axis < a.ndim:
         raise ValueError('axis=(%s) out of bounds' % axis)
     if axis < 0:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -432,15 +432,17 @@ def test_compress():
     x = np.arange(25).reshape((5, 5))
     a = from_array(x, chunks=(2, 2))
 
+    assert_eq(np.compress([True, False, True, False, True], x),
+              da.compress([True, False, True, False, True], a))
     assert_eq(np.compress([True, False, True, False, True], x, axis=0),
               da.compress([True, False, True, False, True], a, axis=0))
     assert_eq(np.compress([True, False, True, False, True], x, axis=1),
               da.compress([True, False, True, False, True], a, axis=1))
+    assert_eq(np.compress([True, False], x),
+              da.compress([True, False], a))
     assert_eq(np.compress([True, False], x, axis=1),
               da.compress([True, False], a, axis=1))
 
-    with pytest.raises(NotImplementedError):
-        da.compress([True, False], a)
     with pytest.raises(ValueError):
         da.compress([True, False], a, axis=100)
     with pytest.raises(ValueError):


### PR DESCRIPTION
According to NumPy's documentation, when [`compress`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.compress.html ) gets `axis` as `None`, it simply flattens the array and applies the same operation on it. Given this, it appears to be a simple matter to transform this case into an already supported case for `compress`; namely, a flattened array where `axis` is `0` instead. The tests are updated to reflect this change and a few test cases are included as well.