### PR TITLE
da.repeat works with negative axis

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3955,6 +3955,11 @@ def repeat(a, repeats, axis=None):
     if not isinstance(repeats, Integral):
         raise NotImplementedError("Only integer valued repeats supported")
 
+    if -a.ndim <= axis < 0:
+        axis += a.ndim
+    elif not 0 <= axis <= a.ndim - 1:
+        raise ValueError("axis(=%d) out of bounds" % axis)
+
     if repeats == 1:
         return a
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2764,7 +2764,7 @@ def test_repeat():
     d = da.from_array(x, chunks=(4, 5, 3))
 
     repeats = [1, 2, 5]
-    axes = [0, 1, 2]
+    axes = [-3, -2, -1, 0, 1, 2]
 
     for r in repeats:
         for a in axes:
@@ -2780,6 +2780,10 @@ def test_repeat():
 
     with pytest.raises(NotImplementedError):
         da.repeat(d, 2)
+
+    for invalid_axis in [3, -4]:
+        with pytest.raises(ValueError):
+            da.repeat(d, 2, axis=invalid_axis)
 
     x = np.arange(5)
     d = da.arange(5, chunks=(2,))


### PR DESCRIPTION
Previously this would fail with a confusing error message.

Fixes #2531.