### PR TITLE
compress: Partially handle condition as Dask array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2451,6 +2451,8 @@ def take(a, indices, axis=0):
 
 @wraps(np.compress)
 def compress(condition, a, axis=None):
+    from .wrap import zeros
+
     if axis is None:
         raise NotImplementedError("Must select axis for compression")
     if not -a.ndim <= axis < a.ndim:
@@ -2458,13 +2460,15 @@ def compress(condition, a, axis=None):
     if axis < 0:
         axis += a.ndim
 
-    condition = np.array(condition, dtype=bool)
+    condition = asarray(condition).astype(bool)
     if condition.ndim != 1:
         raise ValueError("Condition must be one dimensional")
     if len(condition) < a.shape[axis]:
-        condition = condition.copy()
-        condition.resize(a.shape[axis])
+        condition_xtr = zeros(a.shape[axis], dtype=bool, chunks=a.chunks[axis])
+        condition_xtr = condition_xtr[len(condition):]
+        condition = concatenate([condition, condition_xtr])
 
+    condition = np.array(condition)
     slc = ((slice(None),) * axis + (condition, ) +
            (slice(None),) * (a.ndim - axis - 1))
     return a[slc]


### PR DESCRIPTION
Works towards resolving issue ( https://github.com/dask/dask/issues/2540 ).

To prep for making `compress` a lazy function, handle the `condition` array argument as a Dask Array as long as possible. Unfortunately it still needs to be converted to a NumPy Array to create the needed slice to apply to the input array `a`. However this little rewrite should make it easier to focus on just getting that portion of code into Dask Arrays instead of NumPy Arrays.