### PR TITLE
WIP: Add extract

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -6,7 +6,7 @@ from .core import (Array, stack, concatenate, take, tensordot, transpose,
         roll, fromfunction, unique, store, squeeze, topk, bincount, tile,
         digitize, histogram, map_blocks, atop, to_hdf5, dot, cov, array,
         dstack, vstack, hstack, to_npy_stack, from_npy_stack, compress,
-        from_delayed, round, swapaxes, repeat, asarray, asanyarray)
+        extract, from_delayed, round, swapaxes, repeat, asarray, asanyarray)
 from .core import (around, isnull, notnull, isclose, eye, triu,
                    tril, diag, corrcoef)
 from .reshape import reshape

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2449,6 +2449,24 @@ def take(a, indices, axis=0):
         return a[(slice(None),) * axis + (indices,)]
 
 
+@wraps(np.extract)
+def extract(condition, a):
+    from .wrap import zeros
+
+    a = asarray(a).ravel()
+    condition = asarray(condition).ravel()
+
+    condition = condition.astype(bool)
+
+    if len(condition) < len(a):
+        condition_xtr = zeros(a.shape, dtype=bool, chunks=a.chunks)
+        condition_xtr = condition_xtr[len(condition):]
+        condition = concatenate([condition, condition_xtr])
+
+    condition = np.array(condition)
+    return a[condition]
+
+
 @wraps(np.compress)
 def compress(condition, a, axis=None):
     if axis is None:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -428,6 +428,21 @@ def test_take():
     assert same_keys(take(a, [3, 4, 5], axis=-1), take(a, [3, 4, 5], axis=-1))
 
 
+def test_extract():
+    x = np.arange(25).reshape((5, 5))
+    a = from_array(x, chunks=(2, 2))
+
+    assert_eq(np.extract([True, False, True, False, True], x),
+              da.extract([True, False, True, False, True], a))
+    assert_eq(np.extract([True, False], x),
+              da.extract([True, False], a))
+    assert_eq(np.extract((a.size + 1) * [False], x),
+              da.extract((a.size + 1) * [False], a))
+
+    with pytest.raises(IndexError):
+        da.extract((a.size + 1) * [True], x)
+
+
 def test_compress():
     x = np.arange(25).reshape((5, 5))
     a = from_array(x, chunks=(2, 2))

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -46,6 +46,7 @@ Top level user functions:
    empty
    exp
    expm1
+   extract
    eye
    fabs
    fix
@@ -326,6 +327,7 @@ Other functions
 .. autofunction:: empty
 .. autofunction:: exp
 .. autofunction:: expm1
+.. autofunction:: extract
 .. autofunction:: eye
 .. autofunction:: fabs
 .. autofunction:: fix


### PR DESCRIPTION
Related to issue ( https://github.com/dask/dask/issues/2540 ).

Implements the equivalent of NumPy's [`extract`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.extract.html ) function for use with Dask Arrays. This is not totally lazy yet. However it should hopefully be easier to make this lazy and thus reimplement [`compress`]( http://dask.pydata.org/en/latest/array-api.html#dask.array.compress ) on top of this Dask Array `extract` implementation.