### PR TITLE
Allows for read_hdf to accept an iterable of files

### DIFF
--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -339,7 +339,9 @@ def read_hdf(pattern, key, start=0, stop=None, columns=None,
 
     Parameters
     ----------
-    pattern : pattern (string), or buffer to read from. Can contain wildcards
+    pattern : string, list
+        File pattern (string), buffer to read from, or list of file
+        paths. Can contain wildcards.
     key : group identifier in the store. Can contain wildcards
     start : optional, integer (defaults to 0), row number to start at
     stop : optional, integer (defaults to None, the last row), row number to
@@ -377,6 +379,8 @@ def read_hdf(pattern, key, start=0, stop=None, columns=None,
 
     >>> dd.read_hdf('myfile.*.hdf5', '/x')  # doctest: +SKIP
 
+    >>> dd.read_hdf(['myfile.1.hdf5', 'myfile.2.hdf5'], '/x')  # doctest: +SKIP
+
     Load multiple datasets
 
     >>> dd.read_hdf('myfile.1.hdf5', '/*')  # doctest: +SKIP
@@ -385,7 +389,10 @@ def read_hdf(pattern, key, start=0, stop=None, columns=None,
         lock = get_scheduler_lock()
 
     key = key if key.startswith('/') else '/' + key
-    paths = sorted(glob(pattern))
+    if isinstance(pattern, str):
+        paths = sorted(glob(pattern))
+    else:
+        paths = pattern
     if (start != 0 or stop is not None) and len(paths) > 1:
         raise NotImplementedError(read_hdf_error_msg)
     if chunksize <= 0:

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -495,6 +495,21 @@ def test_hdf_globbing():
             tm.assert_frame_equal(res.compute(), pd.concat([df] * 3))
 
 
+def test_hdf_file_list():
+    pytest.importorskip('tables')
+    df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
+                       'y': [1, 2, 3, 4]}, index=[1., 2., 3., 4.])
+
+    with tmpdir() as tdir:
+        df.iloc[:2].to_hdf(os.path.join(tdir, 'one.h5'), 'dataframe', format='table')
+        df.iloc[2:].to_hdf(os.path.join(tdir, 'two.h5'), 'dataframe', format='table')
+
+        with dask.set_options(get=dask.get):
+            input_files = [os.path.join(tdir, 'one.h5'), os.path.join(tdir, 'two.h5')]
+            res = dd.read_hdf(input_files, 'dataframe')
+            tm.assert_frame_equal(res.compute(), df)
+
+
 def test_read_hdf_doesnt_segfault():
     pytest.importorskip('tables')
     with tmpfile('h5') as fn:


### PR DESCRIPTION
Addressed issue #1948. Now `dask.dataframe.read_hdf` can also accept a list (or any iterable) of file paths as an input.  