### PR TITLE
Improvements to dask.array.where

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -511,6 +511,12 @@ def apply_infer_dtype(func, args, kwargs, funcname, suggest_dtype=True):
     return o.dtype
 
 
+@wraps(np.result_type)
+def result_type(*args):
+    args = [a if is_scalar_for_elemwise(a) else a.dtype for a in args]
+    return np.result_type(*args)
+
+
 def map_blocks(func, *args, **kwargs):
     """ Map a function across all blocks of a dask array.
 
@@ -2834,11 +2840,7 @@ def where(condition, x=None, y=None):
         raise TypeError(where_error_message)
 
     if np.isscalar(condition):
-        # Match the dtype inference logic from elemwise
-        vals = [np.empty((1,) * a.ndim, dtype=a.dtype)
-                if not is_scalar_for_elemwise(a) else a
-                for a in (x, y)]
-        dtype = apply_infer_dtype(np.where, [condition] + vals, {}, 'where', suggest_dtype=False)
+        dtype = result_type(x, y)
         x = asarray(x)
         y = asarray(y)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -685,7 +685,7 @@ def test_choose():
 
 
 def test_where():
-    x = np.random.randint(10, size=(15, 16))
+    x = np.random.randint(10, size=(15, 14))
     x[5, 5] = x[4, 4] = 0 # Ensure some false elements
     d = from_array(x, chunks=(4, 5))
     y = np.random.randint(10, size=15).astype(np.uint8)
@@ -695,14 +695,30 @@ def test_where():
                    (d, x),
                    (1, 1),
                    (0, 0),
+                   (5, 5),
                    (True, True),
                    (np.True_, np.True_),
                    (False, False),
                    (np.False_, np.False_)]:
-        for b1, b2 in [(0, 0), (-e[:, None], -y[:, None])]:
+        for b1, b2 in [(0, 0), (-e[:, None], -y[:, None]), (e[:14], y[:14])]:
             w1 = where(c1, d, b1)
             w2 = np.where(c2, x, b2)
             assert_eq(w1, w2)
+
+
+def test_where_scalar_dtype():
+    x = np.int32(3)
+    y1 = np.array([4, 5, 6], dtype=np.int16)
+    c1 = np.array([1, 0, 1])
+    y2 = from_array(y1, chunks=2)
+    c2 = from_array(c1, chunks=2)
+    w1 = np.where(c1, x, y1)
+    w2 = where(c2, x, y2)
+    assert_eq(w1, w2)
+    # Test again for the bool optimization
+    w3 = np.where(True, x, y1)
+    w4 = where(True, x, y1)
+    assert_eq(w3, w4)
 
 
 def test_where_bool_optimization():


### PR DESCRIPTION
This improves the dtype handling so that it follows elemwise behaviour
when either x or y is a scalar. For example:
```python
da.where(True, 1.0, da.ones(5, chunks=5, dtype=np.float32))
```
will now have type `np.float32` instead of `np.float64`. A unit test has
been added to check this.

The shape broadcasting is now only done in the scalar-condition path,
leaving it up to `elemwise` for the general case. This gives a simpler
graph when broadcasting is non-trivial, since the old code would have to
rechunk the broadcast array.

Finally, the general path is done via np.where instead of np.choose,
since a benchmark showed it to be faster (1.9s vs 3.6s on my machine for
the code below):
```python
from __future__ import print_function, division
import dask.array as da
import numpy as np
import time

def timer(name, func, passes=5):
    func()
    start = time.time()
    for i in range(passes):
        func()
    end = time.time()
    print(name, (end - start) / passes)

a = da.zeros(100000000, chunks=10000000)
b = da.ones(100000000, chunks=10000000)
c = da.random.randint(0, 2, 100000000, chunks=10000000)

timer('da.where', lambda: da.where(c, a, b).compute())
timer('np.where', lambda: da.core.elemwise(np.where, c, a, b).compute())
```