### PR TITLE
Add missing initialization to CacheProfiler

### DIFF
--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -230,7 +230,7 @@ class _Tracker(Process):
                 break
             elif msg == 'collect':
                 ps = self._update_pids(pid)
-                while not self.child_conn.poll():
+                while not data or not self.child_conn.poll():
                     tic = default_timer()
                     mem = cpu = 0
                     for p in ps:

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -305,6 +305,7 @@ class CacheProfiler(Callback):
     """
 
     def __init__(self, metric=None, metric_name=None):
+        self.clear()
         self._metric = metric if metric else lambda value: 1
         if metric_name:
             self._metric_name = metric_name

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -28,7 +28,7 @@ dsk = {'a': 1,
        'd': (mul, 'a', 'b'),
        'e': (mul, 'c', 'd')}
 
-dsk2 = {'a': 1, 'b': 2, 'c': (lambda a, b: sleep(1.0) or (a + b), 'a', 'b')}
+dsk2 = {'a': 1, 'b': 2, 'c': (lambda a, b: sleep(0.1) or (a + b), 'a', 'b')}
 
 
 def test_profiler():


### PR DESCRIPTION
This fixes using CacheProfiler.register (previously it would only work
if explicitly cleared or used through the context manager protocol).