### PR TITLE
Adds isin method to dask.dataframe.DataFrame

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1393,6 +1393,10 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         return self.map_partitions(M.isnull)
 
     @derived_from(pd.DataFrame)
+    def isin(self, values):
+        return elemwise(M.isin, self, list(values))
+
+    @derived_from(pd.DataFrame)
     def astype(self, dtype):
         meta = self._meta.astype(dtype)
         meta = clear_known_categories(meta)
@@ -1764,8 +1768,8 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
                    split_every=split_every, n=n)
 
     @derived_from(pd.Series)
-    def isin(self, other):
-        return elemwise(M.isin, self, list(other))
+    def isin(self, values):
+        return elemwise(M.isin, self, list(values))
 
     @insert_meta_param_description(pad=12)
     @derived_from(pd.Series)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -626,9 +626,13 @@ def test_unique():
 
 
 def test_isin():
+    # Series test
     assert_eq(d.a.isin([0, 1, 2]), full.a.isin([0, 1, 2]))
     assert_eq(d.a.isin(pd.Series([0, 1, 2])),
               full.a.isin(pd.Series([0, 1, 2])))
+
+    # DataFrame test
+    assert_eq(d.isin([0, 1, 2]), full.isin([0, 1, 2]))
 
 
 def test_len():


### PR DESCRIPTION
Fixes issue #2071. This PR adds an `isin` method to `dask.dataframe.DataFrame` (which is already implemented in `dask.dataframe.Series`). Also, the API documentation is updated accordingly through use of the `derived_from` decorator in `dask.utils`. 