### PR TITLE
Fix indices error message

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -171,7 +171,7 @@ def indices(dimensions, dtype=int, chunks=None):
     chunks = tuple(chunks)
 
     if len(dimensions) != len(chunks):
-        raise ValueError("Need one more chunk than dimensions.")
+        raise ValueError("Need same number of chunks as dimensions.")
 
     grid = []
     if np.prod(dimensions):


### PR DESCRIPTION
The error message didn't make sense given the condition used. So this corrects the error message to be more inline with the requirement missed.