### PR TITLE
Don't render None for unknown divisions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -303,8 +303,7 @@ class _Frame(Base):
             divisions = pd.Index(self.divisions, name=name)
         else:
             # avoid to be converted to NaN
-            divisions = pd.Index(['None'] * (self.npartitions + 1),
-                                 name=name)
+            divisions = pd.Index([''] * (self.npartitions + 1), name=name)
         return divisions
 
     def __repr__(self):

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -209,20 +209,20 @@ def test_dataframe_format_unknown_divisions():
     exp = ("Dask DataFrame Structure:\n"
            "                   A       B                C\n"
            "npartitions=3                                \n"
-           "None           int64  object  category[known]\n"
-           "None             ...     ...              ...\n"
-           "None             ...     ...              ...\n"
-           "None             ...     ...              ...\n"
+           "               int64  object  category[known]\n"
+           "                 ...     ...              ...\n"
+           "                 ...     ...              ...\n"
+           "                 ...     ...              ...\n"
            "Dask Name: from_pandas, 3 tasks")
     assert repr(ddf) == exp
     assert str(ddf) == exp
 
     exp = ("                   A       B                C\n"
            "npartitions=3                                \n"
-           "None           int64  object  category[known]\n"
-           "None             ...     ...              ...\n"
-           "None             ...     ...              ...\n"
-           "None             ...     ...              ...")
+           "               int64  object  category[known]\n"
+           "                 ...     ...              ...\n"
+           "                 ...     ...              ...\n"
+           "                 ...     ...              ...")
     assert ddf.to_string() == exp
 
     exp_table = """<table border="1" class="dataframe">
@@ -242,25 +242,25 @@ def test_dataframe_format_unknown_divisions():
   </thead>
   <tbody>
     <tr>
-      <th>None</th>
+      <th></th>
       <td>int64</td>
       <td>object</td>
       <td>category[known]</td>
     </tr>
     <tr>
-      <th>None</th>
+      <th></th>
       <td>...</td>
       <td>...</td>
       <td>...</td>
     </tr>
     <tr>
-      <th>None</th>
+      <th></th>
       <td>...</td>
       <td>...</td>
       <td>...</td>
     </tr>
     <tr>
-      <th>None</th>
+      <th></th>
       <td>...</td>
       <td>...</td>
       <td>...</td>


### PR DESCRIPTION
Previously when a user repr'ed a dataframe with unknown divisions they
would see "None" in the divisions column.  This was confusing because
users thought that their index was full of None values, rather than
simply being unknown.

Now we just don't render anything when the divisions are uknown.