### PR TITLE
Clear `_cached_keys` on name change in dask.array

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -209,6 +209,13 @@ def test_keys():
     dx = Array(dsk, 'x', chunks=(10, 10), shape=(50, 60), dtype='f8')
     assert dx._keys() == [[(dx.name, i, j) for j in range(6)]
                           for i in range(5)]
+    # Cache works
+    assert dx._keys() is dx._keys()
+    # Test mutating names clears key cache
+    dx.dask = {('y', i, j): () for i in range(5) for j in range(6)}
+    dx.name = 'y'
+    assert dx._keys() == [[(dx.name, i, j) for j in range(6)]
+                          for i in range(5)]
     d = Array({}, 'x', (), shape=(), dtype='f8')
     assert d._keys() == [('x',)]
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -26,6 +26,7 @@ __all__ = ("Base", "compute", "normalize_token", "tokenize", "visualize")
 
 class Base(object):
     """Base class for dask collections"""
+    __slots__ = ()
 
     def visualize(self, filename='mydask', format=None, optimize_graph=False,
                   **kwargs):


### PR DESCRIPTION
Previously a `_cached_keys` attribute was added to `dask.array` to store
the result of the `_keys` method for fast recompute. Later, mutating the
`name`/`dask` attributes of a `dask.array` was supported. Unfortunately,
mutating these attributes wouldn't clear the cache, which would lead to
hard to find bugs.

To fix this, we do the following:

- Make `Base` define `__slots__`, so that the `__slots__` attribute of
  `Array` is respected. Before the `__slots__` on `Array` were ignored,
  making `_cached_keys` an unexpected source of state (wasn't declared,
  and the declaration was thought to be respected)

- Make `name` a property, and clear the cache when set

- Add a test for the cache behavior.