### PR TITLE
WIP - Micro-optimize optimizations

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1766,7 +1766,7 @@ class Array(Base):
         dask.array.from_delayed
         """
         from ..delayed import Delayed
-        dsk = self._optimize(self.dask, self._keys())
+        dsk, _ = self._optimize(self.dask, self._keys())
         L = ndeepmap(self.ndim, lambda k: Delayed(k, dsk), self._keys())
         return np.array(L, dtype=object)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1790,7 +1790,7 @@ def test_optimize():
     x = np.arange(5).astype('f4')
     a = da.from_array(x, chunks=(2,))
     expr = a[1:4] + 1
-    result = optimize(expr.dask, expr._keys())
+    result, _ = optimize(expr.dask, expr._keys())
     assert isinstance(result, dict)
     assert all(key in result for key in expr._keys())
 
@@ -2951,10 +2951,10 @@ def test_optimize_fuse_keys():
     y = x + 1
     z = y + 1
 
-    dsk = z._optimize(z.dask, z._keys())
+    dsk, _ = z._optimize(z.dask, z._keys())
     assert not set(y.dask) & set(dsk)
 
-    dsk = z._optimize(z.dask, z._keys(), fuse_keys=y._keys())
+    dsk, _ = z._optimize(z.dask, z._keys(), fuse_keys=y._keys())
     assert all(k in dsk for k in y._keys())
 
 

--- a/dask/array/tests/test_ghost.py
+++ b/dask/array/tests/test_ghost.py
@@ -8,7 +8,7 @@ import dask.array as da
 from dask.array.ghost import (fractional_slice, getitem, trim_internal,
                               ghost_internal, nearest, constant, boundaries,
                               reflect, periodic, ghost)
-from dask.core import get
+from dask import get
 from dask.array.utils import assert_eq
 
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -485,18 +485,18 @@ def test_inline_singleton_lists():
     inp = {'b': (list, 'a'),
            'c': (f, 'b', 1)}
     out = {'c': (f, (list, 'a'), 1)}
-    assert inline_singleton_lists(inp) == out
+    assert inline_singleton_lists(inp)[0] == out
 
     out = {'c': (f, 'a', 1)}
-    assert optimize(inp, ['c'], rename_fused_keys=False) == out
+    assert optimize(inp, ['c'], rename_fused_keys=False)[0] == out
 
     inp = {'b': (list, 'a'),
            'c': (f, 'b', 1),
            'd': (f, 'b', 2)}
-    assert inline_singleton_lists(inp) == inp
+    assert inline_singleton_lists(inp)[0] == inp
 
     inp = {'b': (4, 5)} # doesn't inline constants
-    assert inline_singleton_lists(inp) == inp
+    assert inline_singleton_lists(inp)[0] == inp
 
 
 def test_take():
@@ -1199,10 +1199,10 @@ def test_optimize_fuse_keys():
     y = x.map(inc)
     z = y.map(inc)
 
-    dsk = z._optimize(z.dask, z._keys())
+    dsk, _ = z._optimize(z.dask, z._keys())
     assert not set(y.dask) & set(dsk)
 
-    dsk = z._optimize(z.dask, z._keys(), fuse_keys=y._keys())
+    dsk, _ = z._optimize(z.dask, z._keys(), fuse_keys=y._keys())
     assert all(k in dsk for k in y._keys())
 
 

--- a/dask/core.py
+++ b/dask/core.py
@@ -4,6 +4,8 @@ from itertools import chain
 
 from .utils_test import add, inc  # noqa: F401
 
+no_default = '--no-default--'
+
 
 def ishashable(x):
     """ Is x hashable?
@@ -156,7 +158,7 @@ def get(d, x, recursive=False, **kwargs):
     raise KeyError("{0} is not a key in the graph".format(x))
 
 
-def get_dependencies(dsk, key=None, task=None, as_list=False):
+def get_dependencies(dsk, key=None, task=no_default, as_list=False):
     """ Get the immediate tasks on which this task depends
 
     Examples
@@ -187,7 +189,7 @@ def get_dependencies(dsk, key=None, task=None, as_list=False):
     """
     if key is not None:
         arg = dsk[key]
-    elif task is not None:
+    elif task is not no_default:
         arg = task
     else:
         raise ValueError("Provide either key or task")

--- a/dask/core.py
+++ b/dask/core.py
@@ -134,7 +134,7 @@ def _get_recursive(d, x):
         return x
 
 
-def get(d, x, recursive=False):
+def get(d, x, recursive=False, **kwargs):
     """ Get value from Dask
 
     Examples

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3830,7 +3830,7 @@ def to_delayed(df):
     >>> partitions = df.to_delayed()  # doctest: +SKIP
     """
     from ..delayed import Delayed
-    dsk = df._optimize(df.dask, df._keys())
+    dsk, _ = df._optimize(df.dask, df._keys())
     return [Delayed(k, dsk) for k in df._keys()]
 
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -436,7 +436,7 @@ def to_bag(df, index=False):
     name = 'to_bag-' + tokenize(df, index)
     dsk = dict(((name, i), (_df_to_bag, block, index))
                for (i, block) in enumerate(df._keys()))
-    dsk.update(df._optimize(df.dask, df._keys()))
+    dsk.update(df._optimize(df.dask, df._keys())[0])
     return Bag(dsk, name, df.npartitions)
 
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -150,7 +150,7 @@ def test_optimize(fn, c):
     assert_eq(df[c], ddf[c])
     x = ddf[c]
 
-    dsk = x._optimize(x.dask, x._keys())
+    dsk, _ = x._optimize(x.dask, x._keys())
     assert len(dsk) == x.npartitions
     assert all(v[4] == c for v in dsk.values())
 

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -25,5 +25,5 @@ def optimize(dsk, keys, **kwargs):
         dsk = fuse_getitem(dsk, _read_parquet_row_group, 4)
     dsk, dependencies = fuse(dsk, keys, dependencies=dependencies,
                              ave_width=_globals.get('fuse_ave_width', 0))
-    dsk, _ = cull(dsk, keys)
-    return dsk
+    dsk, dependencies = cull(dsk, keys)
+    return dsk, dependencies

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2471,7 +2471,7 @@ def test_hash_split_unique(npartitions, split_every, split_out):
 
     dropped = ds.unique(split_every=split_every, split_out=split_out)
 
-    dsk = dropped._optimize(dropped.dask, dropped._keys())
+    dsk, _ = dropped._optimize(dropped.dask, dropped._keys())
     from dask.core import get_deps
     dependencies, dependents = get_deps(dsk)
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -960,7 +960,7 @@ def test_hash_groupby_aggregate(npartitions, split_every, split_out):
     result = ddf.groupby('x').y.var(split_every=split_every,
                                     split_out=split_out)
 
-    dsk = result._optimize(result.dask, result._keys())
+    dsk, _ = result._optimize(result.dask, result._keys())
     from dask.core import get_deps
     dependencies, dependents = get_deps(dsk)
 

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -32,7 +32,7 @@ def test_column_optimizations_with_bcolz_and_rewrite():
                                     bc, slice(0, 2), ['a', 'b'], {}))
                         for i in [1, 2, 3])
 
-        result = dd.optimize(dsk2, [('y', i) for i in [1, 2, 3]])
+        result, _ = dd.optimize(dsk2, [('y', i) for i in [1, 2, 3]])
         assert result == expected
 
 
@@ -43,9 +43,9 @@ def test_fuse_ave_width():
     s = ((df.x + 1) + (df.x + 2))
 
     with dask.set_options(fuse_ave_width=4):
-        a = s._optimize(s.dask, s._keys())
+        a, _ = s._optimize(s.dask, s._keys())
 
-    b = s._optimize(s.dask, s._keys())
+    b, _ = s._optimize(s.dask, s._keys())
 
     assert len(a) < len(b)
     assert len(a) <= 15

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -68,7 +68,7 @@ def to_task_dask(expr):
     if isinstance(expr, base.Base):
         name = 'finalize-' + tokenize(expr, pure=True)
         keys = expr._keys()
-        dsk = expr._optimize(ensure_dict(expr.dask), keys)
+        dsk, _ = expr._optimize(ensure_dict(expr.dask), keys)
         dsk[name] = (expr._finalize, (concrete, keys))
         return name, dsk
 

--- a/dask/local.py
+++ b/dask/local.py
@@ -269,18 +269,20 @@ def _execute_task(arg, cache, dsk=None):
     >>> _execute_task('foo', cache)  # Passes through on non-keys
     'foo'
     """
-    if isinstance(arg, list):
+    typ = type(arg)
+    if typ is list:
         return [_execute_task(a, cache) for a in arg]
-    elif istask(arg):
+    elif typ is tuple and arg and callable(arg[0]):
         func, args = arg[0], arg[1:]
         args2 = [_execute_task(a, cache) for a in args]
         return func(*args2)
-    elif not ishashable(arg):
-        return arg
-    elif arg in cache:
-        return cache[arg]
     else:
-        return arg
+        try:
+            return cache[arg]
+        except TypeError:
+            return arg
+        except KeyError:
+            return arg
 
 
 def execute_task(key, task_info, dumps, loads, get_id, pack_exception):

--- a/dask/local.py
+++ b/dask/local.py
@@ -481,6 +481,8 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
 
             if should_cull:
                 dsk, dependencies = cull(dsk, list(results))
+
+            if dependencies and isinstance(next(iter(dependencies.values())), list):
                 dependencies = {k: set(v) for k, v in dependencies.items()}
 
             keyorder = order(dsk, dependencies=dependencies)
@@ -521,6 +523,8 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
 
             # Main loop, wait on tasks to finish, insert new ones
             while state['waiting'] or state['ready'] or state['running']:
+                if not state['running'] and not queue.qsize():
+                    import pdb; pdb.set_trace()
                 key, res_info, failed = queue_get(queue)
                 if failed:
                     exc, tb = loads(res_info)

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -126,7 +126,7 @@ def pack_exception(e, dumps):
 
 
 def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
-        optimize_graph=True, **kwargs):
+        optimize_graph=True, dependencies=None, **kwargs):
     """ Multiprocessed get function appropriate for Bags
 
     Parameters
@@ -157,7 +157,7 @@ def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
     # Optimize Dask
     dsk2, dependencies = cull(dsk, keys)
     if optimize_graph:
-        dsk3, dependencies = fuse(dsk2, keys, dependencies)
+        dsk3, dependencies = fuse(dsk2, keys, dependencies=dependencies)
     else:
         dsk3 = dsk2
 
@@ -174,7 +174,8 @@ def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
         result = get_async(pool.apply_async, len(pool._pool), dsk3, keys,
                            get_id=_process_get_id, dumps=dumps, loads=loads,
                            pack_exception=pack_exception,
-                           raise_exception=reraise, **kwargs)
+                           raise_exception=reraise, dependencies=dependencies,
+                           **kwargs)
     finally:
         if cleanup:
             pool.close()

--- a/dask/order.py
+++ b/dask/order.py
@@ -73,8 +73,11 @@ def order(dsk, dependencies=None):
     >>> order(dsk)
     {'a': 2, 'c': 1, 'b': 3, 'd': 0}
     """
-    if dependencies is None:
+    if not dependencies:
         dependencies = {k: get_dependencies(dsk, k) for k in dsk}
+    elif isinstance(next(iter(dependencies.values())), list):
+        dependencies = {k: set(v) for k, v in dependencies.items()}
+
     dependents = reverse_dict(dependencies)
 
     ndeps = ndependents(dependencies, dependents)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -508,7 +508,7 @@ def test_optimize_None():
     x = da.ones(10, chunks=(5,))
     y = x[:9][1:8][::2] + 1  # normally these slices would be fused
 
-    def my_get(dsk, keys):
+    def my_get(dsk, keys, **kwargs):
         assert dsk == dict(y.dask)  # but they aren't
         return dask.get(dsk, keys)
 

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -93,7 +93,7 @@ def test_attributes():
 def test_method_getattr_optimize():
     a = delayed([1, 2, 3])
     o = a.index(1)
-    dsk = o._optimize(o.dask, o._keys())
+    dsk, _ = o._optimize(o.dask, o._keys())
     # Don't getattr the method, then call in separate task
     assert getattr not in set(v[0] for v in dsk.values())
 

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -272,7 +272,7 @@ def test_inline_functions():
            d: (double, y),
            x: 1, y: 1}
 
-    result = inline_functions(dsk, [], fast_functions=set([inc]))
+    result, _ = inline_functions(dsk, [], fast_functions=set([inc]))
     expected = {'out': (add, (inc, x), d),
                 d: (double, y),
                 x: 1, y: 1}
@@ -284,14 +284,14 @@ def test_inline_ignores_curries_and_partials():
            'a': (partial(add, 1), 'x'),
            'b': (inc, 'a')}
 
-    result = inline_functions(dsk, [], fast_functions=set([add]))
+    result, _ = inline_functions(dsk, [], fast_functions=set([add]))
     assert result['b'] == (inc, dsk['a'])
     assert 'a' not in result
 
 
 def test_inline_doesnt_shrink_fast_functions_at_top():
     dsk = {'x': (inc, 'y'), 'y': 1}
-    result = inline_functions(dsk, [], fast_functions=set([inc]))
+    result, _ = inline_functions(dsk, [], fast_functions=set([inc]))
     assert result == dsk
 
 
@@ -304,15 +304,15 @@ def test_inline_traverses_lists():
     expected = {'out': (sum, [(inc, x), d]),
                 d: (double, y),
                 x: 1, y: 1}
-    result = inline_functions(dsk, [], fast_functions=set([inc]))
+    result, _ = inline_functions(dsk, [], fast_functions=set([inc]))
     assert result == expected
 
 
 def test_inline_functions_protects_output_keys():
     dsk = {'x': (inc, 1), 'y': (double, 'x')}
-    assert inline_functions(dsk, [], [inc]) == {'y': (double, (inc, 1))}
-    assert inline_functions(dsk, ['x'], [inc]) == {'y': (double, 'x'),
-                                                   'x': (inc, 1)}
+    assert inline_functions(dsk, [], [inc])[0] == {'y': (double, (inc, 1))}
+    assert inline_functions(dsk, ['x'], [inc])[0] == {'y': (double, 'x'),
+                                                      'x': (inc, 1)}
 
 
 def test_functions_of():


### PR DESCRIPTION
This is an effort to reduce overhead in graph optimization.  There are a few changes:

1.  We add dependencies to the output of optimizations.  In the future (perhaps this PR) we may want to extend this to a general blob of state that passes through optimizations.
2.  We micro-optimize fire_task

### TODO

- [ ] Fix failing tests from dependencies pass through
- [ ] generalize dependencies pass through to generally passing through state, so that we can, for example, also pass through dependents in the future
- [ ] merge passes through order.py into fewer passes if possible