### PR TITLE
Include computed collection within sharedict in delayed

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3356,3 +3356,10 @@ def test_no_warnings_on_metadata():
         da.arccos(x)
 
     assert not record
+
+
+def test_delayed_array_key_hygeine():
+    a = da.zeros((1,), chunks=(1,))
+    d = delayed(identity)(a)
+    b = da.from_delayed(d, shape=a.shape, dtype=a.dtype)
+    assert_eq(a, b)

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -5,9 +5,9 @@ import operator
 import uuid
 
 try:
-    from cytoolz import curry, first
+    from cytoolz import curry, first, pluck
 except ImportError:
-    from toolz import curry, first
+    from toolz import curry, first, pluck
 
 from . import base, threaded
 from .compatibility import apply
@@ -435,14 +435,17 @@ def call_function(func, func_token, args, kwargs, pure=None, nout=None):
         name = dask_key_name
 
     dsk = sharedict.ShareDict()
-    args, dasks = unzip(map(to_task_dask, args), 2)
-    for arg, d in zip(args, dasks):
+    args_dasks = list(map(to_task_dask, args))
+    for arg, d in args_dasks:
         if isinstance(d, sharedict.ShareDict):
             dsk.update_with_key(d)
         elif isinstance(arg, str):
             dsk.update_with_key(d, key=arg)
         else:
             dsk.update(d)
+
+    args = tuple(pluck(0, args_dasks))
+
     if kwargs:
         dask_kwargs, dsk2 = to_task_dask(kwargs)
         dsk.update(dsk2)


### PR DESCRIPTION
When delayed is given a collection it optimizes and finalizes the
collection's graph before adding it into its own graph.  Because delayed
uses a sharedict it gives this new subgraph a name.  Previously we did
not provide a good name for graphs in this case and instead relied on
the id number of the dict.  Now we watch for this case more carefully.