### PR TITLE
Adds choose method to dask.array.Array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1307,9 +1307,9 @@ class Array(Base):
 
     flatten = ravel
 
-    @wraps(np.ndarray.choose)
+    @derived_from(np.ndarray)
     def choose(self, choices):
-        return elemwise(variadic_choose, self, *choices)
+        return choose(self, choices)
 
     @wraps(np.reshape)
     def reshape(self, *shape):
@@ -2842,7 +2842,7 @@ def variadic_choose(a, *choices):
 
 @wraps(np.choose)
 def choose(a, choices):
-    return a.choose(choices)
+    return elemwise(variadic_choose, a, *choices)
 
 
 chunks_none_error_message = """

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1307,7 +1307,7 @@ class Array(Base):
 
     flatten = ravel
 
-    @wraps(np.choose)
+    @wraps(np.ndarray.choose)
     def choose(self, choices):
         return elemwise(variadic_choose, self, *choices)
 
@@ -2842,7 +2842,7 @@ def variadic_choose(a, *choices):
 
 @wraps(np.choose)
 def choose(a, choices):
-    return elemwise(variadic_choose, a, *choices)
+    return a.choose(choices)
 
 
 chunks_none_error_message = """

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1307,6 +1307,10 @@ class Array(Base):
 
     flatten = ravel
 
+    @wraps(np.choose)
+    def choose(self, choices):
+        return elemwise(variadic_choose, self, *choices)
+
     @wraps(np.reshape)
     def reshape(self, *shape):
         from .reshape import reshape

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -715,6 +715,12 @@ def test_choose():
     assert_eq(choose(d > 5, [0, d]), np.choose(x > 5, [0, x]))
     assert_eq(choose(d > 5, [-d, d]), np.choose(x > 5, [-x, x]))
 
+    # test choose method
+    index_dask = d > 5
+    index_numpy = d > 5
+    assert_eq(index_dask.choose([0, d]), index_numpy.choose([0, x]))
+    assert_eq(index_dask.choose([-d, d]), index_numpy.choose([-x, x]))
+
 
 def test_argwhere():
     for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -709,6 +709,7 @@ def test_norm():
 
 
 def test_choose():
+    # test choose function
     x = np.random.randint(10, size=(15, 16))
     d = from_array(x, chunks=(4, 5))
 
@@ -717,7 +718,7 @@ def test_choose():
 
     # test choose method
     index_dask = d > 5
-    index_numpy = d > 5
+    index_numpy = x > 5
     assert_eq(index_dask.choose([0, d]), index_numpy.choose([0, x]))
     assert_eq(index_dask.choose([-d, d]), index_numpy.choose([-x, x]))
 


### PR DESCRIPTION
Fixes issue #2569. As mentioned in the issue, a `dask.array.choose` function already exists. This PR copies the `dask.array.choose` functionality into a `choose` method for `dask.array.Array` objects. 