### PR TITLE
Remove bare `except:` blocks and test that none exist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install: source continuous_integration/travis/install.sh
 script:
   - source continuous_integration/travis/run_tests.sh
   - flake8 dask
-  - pycodestyle --select=E722 --exclude=tests dask  # check for bare `except:` blocks
+  - pycodestyle --select=E722 dask  # check for bare `except:` blocks
   - if [[ $TEST_IMPORTS == 'true' ]]; then source continuous_integration/travis/test_imports.sh; fi
 after_success: source continuous_integration/travis/after_success.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install: source continuous_integration/travis/install.sh
 script:
   - source continuous_integration/travis/run_tests.sh
   - flake8 dask
+  - pycodestyle --select=E722 --exclude=tests dask  # check for bare `except:` blocks
   - if [[ $TEST_IMPORTS == 'true' ]]; then source continuous_integration/travis/test_imports.sh; fi
 after_success: source continuous_integration/travis/after_success.sh
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -79,7 +79,8 @@ pip install -q \
     mmh3 \
     pandas_datareader \
     pytest-xdist \
-    xxhash
+    xxhash \
+    pycodestyle
 
 # Install dask
 pip install -q --no-deps -e .[complete]

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -654,7 +654,7 @@ def map_blocks(func, *args, **kwargs):
         spec = getargspec(func)
         block_id = ('block_id' in spec.args or
                     'block_id' in getattr(spec, 'kwonly_args', ()))
-    except:
+    except Exception:
         block_id = False
 
     if block_id:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -731,7 +731,7 @@ def map_blocks(func, *args, **kwargs):
         else:
             try:
                 chunks2 = list(broadcast_chunks(*[a.chunks for a in arrs]))
-            except:
+            except Exception:
                 raise ValueError("Arrays in `map_blocks` don't align, can't "
                                  "infer output chunks. Please provide "
                                  "`chunks` kwarg.")

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -24,7 +24,7 @@ try:
     if LooseVersion(cytoolz.__version__) > '0.7.3':
         from cytoolz import accumulate  # noqa: F811
         _implement_accumulate = True
-except:
+except ImportError:
     from toolz import (frequencies, merge_with, join, reduceby,
                        count, pluck, groupby, topk)
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -300,12 +300,12 @@ def _normalize_function(func):
             result = pickle.dumps(func, protocol=0)
             if b'__main__' not in result:  # abort on dynamic functions
                 return result
-        except:
+        except Exception:
             pass
         try:
             import cloudpickle
             return cloudpickle.dumps(func, protocol=0)
-        except:
+        except Exception:
             return str(func)
 
 
@@ -413,7 +413,7 @@ def register_numpy():
             name = x.__name__
             if getattr(np, name) is x:
                 return 'np.' + name
-        except:
+        except AttributeError:
             return normalize_function(x)
 
 

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -57,7 +57,7 @@ def s3_context(bucket, files):
     for f, data in files.items():
         try:
             client.delete_object(Bucket=bucket, Key=f, Body=data)
-        except:
+        except Exception:
             pass
     m.stop()
 

--- a/dask/core.py
+++ b/dask/core.py
@@ -53,7 +53,7 @@ def has_tasks(dsk, x):
     try:
         if x in dsk:
             return True
-    except:
+    except Exception:
         pass
     if isinstance(x, list):
         for i in x:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -51,7 +51,7 @@ def _concat(args):
     if not isinstance(args[0], (pd.DataFrame, pd.Series, pd.Index)):
         try:
             return pd.Series(args)
-        except:
+        except Exception:
             return args
     # We filter out empty partitions here because pandas frequently has
     # inconsistent dtypes in results between empty and non-empty frames.

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -18,13 +18,13 @@ try:
     from fastparquet.api import _pre_allocate
     from fastparquet.util import check_column_names
     default_encoding = parquet_thrift.Encoding.PLAIN
-except:
+except ImportError:
     fastparquet = False
     default_encoding = None
 
 try:
     import pyarrow.parquet as pyarrow_parquet
-except:
+except ImportError:
     pyarrow_parquet = False
 
 
@@ -54,7 +54,7 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
             pf = fastparquet.ParquetFile(paths[0] + fs.sep + '_metadata',
                                          open_with=myopen,
                                          sep=fs.sep)
-        except:
+        except Exception:
             pf = fastparquet.ParquetFile(paths[0], open_with=myopen, sep=fs.sep)
 
     check_column_names(pf.columns, categories)

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -253,7 +253,7 @@ def concat(dfs, axis=0, join='outer', uniform=False):
             new_tuples = np.concatenate(to_concat)
             try:
                 return pd.MultiIndex.from_tuples(new_tuples, names=first.names)
-            except:
+            except Exception:
                 return pd.Index(new_tuples)
         return dfs[0].append(dfs[1:])
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -285,7 +285,7 @@ def make_meta(x, index=None):
         try:
             dtype = np.dtype(x)
             return _scalar_from_dtype(dtype)
-        except:
+        except Exception:
             # Continue on to next check
             pass
 

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -11,11 +11,11 @@ import pytest
 
 try:
     import bokeh
-except:
+except ImportError:
     bokeh = None
 try:
     import psutil
-except:
+except ImportError:
     psutil = None
 
 

--- a/dask/rewrite.py
+++ b/dask/rewrite.py
@@ -406,7 +406,7 @@ def _match(S, N):
             # Backtrack here
             (S, N, matches) = stack.pop()
             restore_state_flag = True
-        except:
+        except Exception:
             return
 
 

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -194,7 +194,7 @@ def test_subs_no_key_data_eq():
 def test_subs_with_unfriendly_eq():
     try:
         import numpy as np
-    except:
+    except ImportError:
         return
     else:
         task = (np.sum, np.array([1, 2]))
@@ -214,7 +214,7 @@ def test_subs_with_unfriendly_eq():
 def test_subs_with_surprisingly_friendly_eq():
     try:
         import pandas as pd
-    except:
+    except: ImportError
         return
     else:
         df = pd.DataFrame()

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -214,7 +214,7 @@ def test_subs_with_unfriendly_eq():
 def test_subs_with_surprisingly_friendly_eq():
     try:
         import pandas as pd
-    except: ImportError
+    except ImportError:
         return
     else:
         df = pd.DataFrame()

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -335,12 +335,12 @@ def takes_multiple_arguments(func, varargs=True):
 
     try:
         spec = getargspec(func)
-    except:
+    except Exception:
         return False
 
     try:
         is_constructor = spec.args[0] == 'self' and isinstance(func, type)
-    except:
+    except Exception:
         is_constructor = False
 
     if varargs and spec.varargs:
@@ -545,7 +545,7 @@ def funcname(func):
         if name == '<lambda>':
             return 'lambda'
         return name
-    except:
+    except AttributeError:
         return str(func)
 
 


### PR DESCRIPTION
If a bare except is desired, do `except: # noqa: E722`.

`pycodestyle` is used, because this is a recent feature not yet available in `pep8` or `flake8` utilities.

I was mostly lazy and used `Exception` rather than more specific exceptions, but this is still better than bare `except:`.