### PR TITLE
Normalize `meta` on call to `dd.from_delayed`

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -16,7 +16,7 @@ from ...delayed import delayed
 
 from ..core import DataFrame, Series, new_dd_object
 from ..shuffle import set_partition
-from ..utils import insert_meta_param_description, check_meta
+from ..utils import insert_meta_param_description, check_meta, make_meta
 
 from ...utils import M, ensure_dict
 
@@ -502,10 +502,7 @@ def from_delayed(dfs, meta=None, divisions=None, prefix='from-delayed'):
 
     if meta is None:
         meta = dfs[0].compute()
-    if isinstance(meta, (str, pd.Series)):
-        Frame = Series
-    else:
-        Frame = DataFrame
+    meta = make_meta(meta)
 
     name = prefix + '-' + tokenize(*dfs)
     dsk = merge(df.dask for df in dfs)
@@ -519,7 +516,7 @@ def from_delayed(dfs, meta=None, divisions=None, prefix='from-delayed'):
         if len(divs) != len(dfs) + 1:
             raise ValueError("divisions should be a tuple of len(dfs) + 1")
 
-    df = Frame(dsk, name, meta, divs)
+    df = new_dd_object(dsk, name, meta, divs)
 
     if divisions == 'sorted':
         from ..shuffle import compute_divisions

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -510,6 +510,10 @@ def test_from_delayed():
         assert list(s.map_partitions(my_len).compute()) == [1, 2, 3, 4]
         assert ddf.known_divisions == (divisions is not None)
 
+    meta2 = [(c, 'f8') for c in df.columns]
+    assert_eq(dd.from_delayed(dfs, meta=meta2), df)
+    assert_eq(dd.from_delayed([d.a for d in dfs], meta=('a', 'f8')), df.a)
+
     with pytest.raises(ValueError):
         dd.from_delayed(dfs, meta=meta, divisions=[0, 1, 3, 6])
 


### PR DESCRIPTION
Previously this would let non-normalized metadata sneak through, which
would lead to failures on computation.

Fixes #2587.