### PR TITLE
Remove `expand` parameter from df.str.split

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -69,7 +69,10 @@ class Accessor(object):
         return set(dir(self._accessor)).difference(self._not_implemented)
 
     def __dir__(self):
-        return self._delegates.union(dir(type(self)) + list(self.__dict__))
+        o = self._delegates
+        o.update(self.__dict__)
+        o.update(dir(type(self)))
+        return list(o)
 
     def __getattr__(self, key):
         if key in self._delegates:

--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 from toolz import partial
 
+from ..utils import derived_from
+
 
 def maybe_wrap_pandas(obj, x):
     if isinstance(x, np.ndarray):
@@ -100,3 +102,7 @@ class StringAccessor(Accessor):
     def _validate(self, series):
         if not series.dtype == 'object':
             raise AttributeError("Can only use .str accessor with object dtype")
+
+    @derived_from(pd.core.strings.StringMethods)
+    def split(self, pat=None, n=-1):
+        return self._function_map('split', pat=pat, n=n)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1348,6 +1348,10 @@ def test_str_accessor():
     assert 'str' not in dir(a.y)
     assert not hasattr(a.y, 'str')
 
+    # not implemented methods don't show up
+    assert 'get_dummies' not in dir(a.x.str)
+    assert not hasattr(a.x.str, 'get_dummies')
+
     assert 'upper' in dir(a.x.str)
     assert_eq(a.x.str.upper(), df.x.str.upper())
     assert set(a.x.str.upper().dask) == set(a.x.str.upper().dask)


### PR DESCRIPTION
We can't support this, since we don't know how many elements there will
be in the split result.

Fixes #2592.