### PR TITLE
Add norm

### DIFF
--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -501,6 +501,9 @@ def test_norm_1dim(shape, chunks, axis, norm, keepdims):
     a_r = np.linalg.norm(a, ord=norm, axis=axis, keepdims=keepdims)
     d_r = da.linalg.norm(d, ord=norm, axis=axis, keepdims=keepdims)
 
+    # Fix a type mismatch on NumPy 1.10.
+    a_r = a_r.astype(float)
+
     assert_eq(a_r, d_r)
 
 


### PR DESCRIPTION
Adds a Dask Array implementation of [`numpy.linalg.norm`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.norm.html ).