### PR TITLE
Don't check for memory leaks in distributed tests

### DIFF
--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -1,12 +1,19 @@
 import pytest
 distributed = pytest.importorskip('distributed')
 
+from functools import partial
+import inspect
 from tornado import gen
 
 import dask
 from dask import persist, delayed
-from distributed.client import _wait, Client
+from distributed.client import wait, Client
 from distributed.utils_test import gen_cluster, inc, cluster, loop  # flake8: noqa
+
+
+if 'should_check_state' in inspect.getargspec(gen_cluster).args:
+    gen_cluster = partial(gen_cluster, should_check_state=False)
+    cluster = partial(cluster, should_check_state=False)
 
 
 def test_can_import_client():
@@ -18,13 +25,13 @@ def test_persist(c, s, a, b):
     x = delayed(inc)(1)
     x2, = persist(x)
 
-    yield _wait(x2)
+    yield wait(x2)
     assert x2.key in a.data or x2.key in b.data
 
     y = delayed(inc)(10)
     y2, one = persist(y, 1)
 
-    yield _wait(y2)
+    yield wait(y2)
     assert y2.key in a.data or y2.key in b.data
 
 


### PR DESCRIPTION
The dask/dask test suite fails this for now