### PR TITLE
Document norm in Dask Array API

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -177,6 +177,7 @@ Linear Algebra
    linalg.inv
    linalg.lstsq
    linalg.lu
+   linalg.norm
    linalg.qr
    linalg.solve
    linalg.solve_triangular
@@ -435,6 +436,7 @@ Other functions
 .. autofunction:: inv
 .. autofunction:: lstsq
 .. autofunction:: lu
+.. autofunction:: norm
 .. autofunction:: qr
 .. autofunction:: solve
 .. autofunction:: solve_triangular


### PR DESCRIPTION
Makes sure that norm shows up in Dask Array's API.