### PR TITLE
Add diff

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -5,7 +5,7 @@ from .core import (Array, concatenate, stack, from_array, store, map_blocks,
                    atop, to_hdf5, to_npy_stack, from_npy_stack, from_delayed,
                    asarray, asanyarray, broadcast_to)
 from .routines import (take, choose, argwhere, where, coarsen, insert,
-                       ravel, roll, unique, squeeze, topk,
+                       ravel, roll, unique, squeeze, topk, diff,
                        bincount, digitize, histogram, cov, array, dstack,
                        vstack, hstack, compress, extract, round, count_nonzero,
                        flatnonzero, nonzero, around, isnull, notnull, isclose,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -161,6 +161,28 @@ def dot(a, b):
     return tensordot(a, b, axes=((a.ndim - 1,), (b.ndim - 2,)))
 
 
+@wraps(np.diff)
+def diff(a, n=1, axis=-1):
+    a = asarray(a)
+    n = int(n)
+    axis = int(axis)
+
+    sl_1 = a.ndim * [slice(None)]
+    sl_2 = a.ndim * [slice(None)]
+
+    sl_1[axis] = slice(1, None)
+    sl_2[axis] = slice(None, -1)
+
+    sl_1 = tuple(sl_1)
+    sl_2 = tuple(sl_2)
+
+    r = a
+    for i in range(n):
+        r = r[sl_1] - r[sl_2]
+
+    return r
+
+
 @wraps(np.bincount)
 def bincount(x, weights=None, minlength=None):
     if minlength is None:

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -104,6 +104,24 @@ def test_dot_method():
     assert_eq(a.dot(b), x.dot(y))
 
 
+@pytest.mark.parametrize('shape, axis', [
+    [(10, 15, 20), 0],
+    [(10, 15, 20), 1],
+    [(10, 15, 20), 2],
+    [(10, 15, 20), -1],
+])
+@pytest.mark.parametrize('n', [
+    0,
+    1,
+    2,
+])
+def test_diff(shape, n, axis):
+    x = np.random.randint(0, 10, shape)
+    a = da.from_array(x, chunks=(len(shape) * (5,)))
+
+    assert_eq(da.diff(a, n, axis), np.diff(x, n, axis))
+
+
 def test_topk():
     x = np.array([5, 2, 1, 6])
     d = da.from_array(x, chunks=2)

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -42,6 +42,7 @@ Top level user functions:
    deg2rad
    degrees
    diag
+   diff
    digitize
    dot
    dstack
@@ -327,6 +328,7 @@ Other functions
 .. autofunction:: deg2rad
 .. autofunction:: degrees
 .. autofunction:: diag
+.. autofunction:: diff
 .. autofunction:: digitize
 .. autofunction:: dot
 .. autofunction:: dstack


### PR DESCRIPTION
Implements NumPy's [diff]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.diff.html ) for use with Dask Arrays. Includes tests against the original implementation with a variety of parameters. Also adds the function to the Dask Array API docs.