### PR TITLE
[WIP] Atop fusion

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -400,7 +400,7 @@ def top(func, output, out_indices, *arrind_pairs, **kwargs):
     # {i: 0, j: 0}, {i: 0, j: 1}, ...
     keydicts = [dict(zip(out_indices, tup)) for tup in keytups]
 
-    # {j: [1, 2, 3], ...}  For j a dummy index of dimension 3
+    # {j: [0, 1, 2], ...}  For j a dummy index of dimension 3
     dummies = dict((i, list(range(dims[i]))) for i in dummy_indices)
 
     # Create argument lists
@@ -2021,6 +2021,8 @@ def unify_chunks(*args, **kwargs):
     ----------
     *args: sequence of Array, index pairs
         Sequence like (x, 'ij', y, 'jk', z, 'i')
+    rechunk : bool, optional
+        If True, returns rechunked arrays as well. Default is True.
 
     Examples
     --------
@@ -2050,16 +2052,22 @@ def unify_chunks(*args, **kwargs):
     """
     args = [asarray(a) if i % 2 == 0 else a for i, a in enumerate(args)]
     warn = kwargs.get('warn', True)
+    rechunk = kwargs.get('rechunk', True)
     arginds = list(partition(2, args)) # [x, ij, y, jk] -> [(x, ij), (y, jk)]
     arrays, inds = zip(*arginds)
     if all(ind == inds[0] for ind in inds) and all(a.chunks == arrays[0].chunks for a in arrays):
-        return dict(zip(inds[0], arrays[0].chunks)), arrays
+        chunks = dict(zip(inds[0], arrays[0].chunks))
+        return (chunks, arrays) if rechunk else chunks
 
     nameinds = [(a.name, i) for a, i in arginds]
     blockdim_dict = dict((a.name, a.chunks) for a, _ in arginds)
 
     chunkss = broadcast_dimensions(nameinds, blockdim_dict,
                                    consolidate=common_blockdim)
+
+    if not rechunk:
+        return chunkss
+
     max_parts = max(arg.npartitions for arg in args[::2])
     nparts = np.prod(list(map(len, chunkss.values())))
 
@@ -2079,7 +2087,170 @@ def unify_chunks(*args, **kwargs):
     return chunkss, arrays
 
 
+class ATopCall(object):
+    __slots__ = '_key', '_ops', '_args'
+
+    def __init__(self, key, ops, args):
+        self._key = key
+        self._ops = ops
+        self._args = args
+
+    def __repr__(self):
+        return 'atop_call'
+
+    def __call__(self, *args):
+        assert len(args) == len(self._args)
+        dsk = dict(zip(self._args, args))
+        dsk.update(self._ops)
+        return core.get(dsk, self._key, recursive=True)
+
+
+def extract_atop_tuple(x):
+    if isinstance(x, ATopArray):
+        return x._atop
+    elif isinstance(x, Array):
+        name = x.name
+        inds = tuple(range(x.ndim))
+        return ((name, inds), {}, {(name, inds)}, {name: x.copy()})
+    else:
+        raise TypeError("Unknown type")
+
+
 def atop(func, out_ind, *args, **kwargs):
+    out = kwargs.pop('name', None)      # May be None at this point
+    token = kwargs.pop('token', None)
+    dtype = kwargs.pop('dtype', None)
+    adjust_chunks = kwargs.pop('adjust_chunks', None)
+    new_axes = kwargs.get('new_axes', {})
+
+    if dtype is None:
+        raise ValueError("Must specify dtype of output array")
+
+    # [x, ij, y, jk] -> [(x, ij), (y, jk)]
+    arginds = list(partition(2, args))
+    # {i, j, k}
+    all_indices = set(concat(pluck(1, arginds)))
+    # indices present in args but not in out
+    dummy_indices = all_indices - set(out_ind)
+
+    # Can't delay with dummy indices
+    if dummy_indices:
+        return _atop(func, out_ind, *args, **kwargs)
+
+    chunkss = unify_chunks(*args, rechunk=False)
+    for k, v in new_axes.items():
+        chunkss[k] = (v,)
+
+    chunks = [chunkss[i] for i in out_ind]
+    if adjust_chunks:
+        for i, ind in enumerate(out_ind):
+            if ind in adjust_chunks:
+                ac = adjust_chunks[ind]
+                if callable(ac):
+                    chunks[i] = tuple(map(ac, chunks[i]))
+                elif isinstance(ac, int):
+                    chunks[i] = (ac,) * len(chunks[i])
+                elif isinstance(ac, (tuple, list)):
+                    chunks[i] = tuple(ac)
+                else:
+                    raise NotImplementedError(
+                        "adjust_chunks values must be callable, int, or tuple")
+    chunks = tuple(chunks)
+
+    # Remap generic indices to tuples of ints for consistency
+    ind_map = {i: n for n, i in enumerate(out_ind)}
+    arginds2 = [(a, tuple(ind_map[i] for i in ind)) for a, ind in arginds]
+
+    argindsstr = list(concat([(a.name, ind) for a, ind in arginds2]))
+    # Finish up the name
+    if not out:
+        out = '%s-%s' % (token or funcname(func).strip('_'),
+                         tokenize(func, out_ind, argindsstr, dtype, **kwargs))
+
+    out_ind = tuple(ind_map[i] for i in out_ind)
+    atops = [(extract_atop_tuple(a), i) for a, i in arginds2]
+    atop_tuple = build_op(func, (out, out_ind), atops, kwargs)
+
+    return ATopArray(atop_tuple, chunks, dtype=dtype)
+
+
+def build_op(func, out, args, kwargs):
+    ops = {}
+    dsks = {}
+    args_set = set()
+    func_args = []
+
+    for arg, call_inds in args:
+        (a_name, a_inds), a_ops, a_args, a_dsks = arg
+
+        if call_inds != a_inds:
+            remap = dict(zip(a_inds, call_inds))
+            rename = {}
+
+            for (name, inds) in a_args.union(a_ops):
+                inds2 = tuple(remap[i] for i in inds)
+                if inds2 != inds:
+                    rename[(name, inds)] = (name, inds2)
+
+            if rename:
+                a_ops = {rename.get(k, k): _atop_subs(v, rename)
+                         for k, v in a_ops.items()}
+
+            args_set.update(rename.get(k, k) for k in a_args)
+            func_args.append((a_name, call_inds))
+        else:
+            args_set.update(a_args)
+            func_args.append((a_name, a_inds))
+
+        ops.update(a_ops)
+        dsks.update(a_dsks)
+
+    if kwargs:
+        ops[out] = (apply, func, func_args, kwargs)
+    else:
+        ops[out] = (func,) + tuple(func_args)
+
+    return (out, ops, args_set, dsks)
+
+
+def _atop_subs(task, lk):
+    if isinstance(task, tuple):
+        if len(task) == 2 and type(task[0]) is str and task in lk:
+            return lk[task]
+        return tuple(_atop_subs(i, lk) for i in task)
+    return task
+
+
+class ATopArray(Array):
+    def __new__(cls, atop_tuple, chunks, dtype):
+        self = super(Array, cls).__new__(cls)
+        self._atop = atop_tuple
+        self._chunks = chunks
+        self._cached_keys = None
+        self.dtype = np.dtype(dtype)
+
+        for plugin in _globals.get('array_plugins', ()):
+            result = plugin(self)
+            if result is not None:
+                self = result
+
+        return self
+
+    @property
+    def name(self):
+        return self._atop[0][0]
+
+    @property
+    def dask(self):
+        outind, ops, args, dsks = self._atop
+        args = sorted(args)
+        arginds = list(concat([(dsks[a[0]], a[1]) for a in args]))
+        func = ATopCall(outind, ops, args)
+        return _atop(func, outind[1], *arginds, name=self.name,
+                    dtype=self.dtype).dask
+
+
+def _atop(func, out_ind, *args, **kwargs):
     """ Tensor operation: Generalized inner and outer products
 
     A broad class of blocked algorithms and patterns can be specified with a

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -29,11 +29,10 @@ from dask.array import chunk
 from dask.array.core import (getem, getter, top, dotmany, concatenate3,
                              broadcast_dimensions, Array, stack, concatenate,
                              from_array, elemwise, broadcast_shapes,
-                             partial_by_order, broadcast_to,
-                             blockdims_from_blockshape, store, optimize,
-                             from_func, normalize_chunks, broadcast_chunks,
-                             atop, from_delayed, concatenate_axes,
-                             common_blockdim)
+                             broadcast_to, blockdims_from_blockshape, store,
+                             optimize, from_func, normalize_chunks,
+                             broadcast_chunks, atop, from_delayed,
+                             concatenate_axes, common_blockdim)
 from dask.array.utils import assert_eq, same_keys
 
 # temporary until numpy functions migrated
@@ -397,10 +396,6 @@ def test_elemwise_on_scalars():
     a = from_array(x, chunks=(5,))
     assert len(a._keys()) == 3
     assert_eq(a, x)
-
-
-def test_partial_by_order():
-    assert partial_by_order(5, function=add, other=[(1, 20)]) == 25
 
 
 def test_elemwise_with_ndarrays():

--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -1,0 +1,20 @@
+import dask.array as da
+
+
+def test_linear():
+    x = da.ones(100, chunks=(10,))
+    assert len(x.dask) == 10
+
+    assert len((x + 1).dask) <= 20
+    assert len((x + 1 + 1 + 1 + 1).dask) <= 20
+    assert len((x + x + 1).dask) <= 20
+    assert len((x + 1).sum().dask) < 25
+    assert len(((x + x) + (x + 1) + (x + 2)).dask) <= 20
+
+
+def test_transpose():
+    x = da.ones((100, 100), chunks=(50, 50))
+
+    y = x + 1
+    z = y + y.T
+    assert len(z.dask) <= len(x.dask) * 2

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -81,10 +81,9 @@ else:
     operator_div = operator.div
     FileNotFoundError = IOError
 
-    eval(compile("""
-        def exec_(codestr, glbls):
-            exec codestr in glbls
-            """, "<_exec>", "exec"))
+    eval(compile(("def exec_(codestr, glbls):\n"
+                  "    exec codestr in glbls\n"),
+                 "<_exec>", "exec"))
 
     def _make_reraise():
         _code = ("def reraise(exc, tb=None):"

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -59,6 +59,9 @@ if PY3:
             raise exc.with_traceback(tb)
         raise exc
 
+    def exec_(codestr, glbls):
+        exec(codestr, glbls)
+
 else:
     import __builtin__ as builtins
     from Queue import Queue, Empty
@@ -77,6 +80,11 @@ else:
     reduce = reduce
     operator_div = operator.div
     FileNotFoundError = IOError
+
+    eval(compile("""
+        def exec_(codestr, glbls):
+            exec codestr in glbls
+            """, "<_exec>", "exec"))
 
     def _make_reraise():
         _code = ("def reraise(exc, tb=None):"

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -18,12 +18,10 @@ except ImportError:
 
 from .. import array as da
 from .. import core
-from ..array.core import partial_by_order
 from .. import threaded
 from ..compatibility import apply, operator_div, bind_method, PY3
-from ..utils import (random_state_data,
-                     pseudorandom, derived_from, funcname, memory_repr,
-                     put_lines, M, key_split)
+from ..utils import (random_state_data, pseudorandom, derived_from, funcname,
+                     memory_repr, put_lines, M, key_split, partial_by_order)
 from ..base import Base, tokenize, normalize_token
 from . import methods
 from .accessor import DatetimeAccessor, StringAccessor


### PR DESCRIPTION
Very very rough, just getting this up for discussion.

This implements fusion at graph build time for subsequent tensor operations (calls to `atop`). This can help reduce the graph size, reduce the overhead of graph building, and reduce unnecessary communication. We take the following approach.

- When possible, calls to `atop` return an `ATopArray` (a subclass of `Array`) that encodes the desired tensor operation without actually building the graph.
- When `ATopArray`s are passed to further calls to `atop`, their operations are extracted and fused into the subsequent `atop` output.
- When the `ATopArray.dask` property is requested, a single call to `atop` the encodes all the included operations is made. This could be cached (isn't currently).

`atop` operations are fuseable iff there are no "dummy indices". Note that no library code uses these, but there are tests for them and external users may be using them.

Todo:
- [ ] reorganize to not be a big mess
- [ ] tests tests tests
- [ ] fix `ATopArray` to work with mutable operations
- [x] improve runtime task interpreter
- [ ] figure out answers to the questions below

Fixes #2538 