### PR TITLE
Add ediff1d

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -5,7 +5,7 @@ from .core import (Array, concatenate, stack, from_array, store, map_blocks,
                    atop, to_hdf5, to_npy_stack, from_npy_stack, from_delayed,
                    asarray, asanyarray, broadcast_to)
 from .routines import (take, choose, argwhere, where, coarsen, insert,
-                       ravel, roll, unique, squeeze, topk, diff,
+                       ravel, roll, unique, squeeze, topk, diff, ediff1d,
                        bincount, digitize, histogram, cov, array, dstack,
                        vstack, hstack, compress, extract, round, count_nonzero,
                        flatnonzero, nonzero, around, isnull, notnull, isclose,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -187,20 +187,15 @@ def diff(a, n=1, axis=-1):
 def ediff1d(ary, to_end=None, to_begin=None):
     ary = asarray(ary)
 
-    if to_end is None:
-        to_end = np.array([], dtype=ary.dtype)
-    if to_begin is None:
-        to_begin = np.array([], dtype=ary.dtype)
+    aryf = ary.flatten()
+    r = aryf[1:] - aryf[:-1]
 
-    to_end = asarray(to_end)
-    to_begin = asarray(to_begin)
-
-    ary = ary.flatten()
-    to_end = to_end.flatten()
-    to_begin = to_begin.flatten()
-
-    r = diff(ary)
-    r = concatenate([to_begin, r, to_end])
+    r = [r]
+    if to_begin is not None:
+        r = [asarray(to_begin).flatten()] + r
+    if to_end is not None:
+        r = r + [asarray(to_end).flatten()]
+    r = concatenate(r)
 
     return r
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -183,6 +183,28 @@ def diff(a, n=1, axis=-1):
     return r
 
 
+@wraps(np.ediff1d)
+def ediff1d(ary, to_end=None, to_begin=None):
+    ary = asarray(ary)
+
+    if to_end is None:
+        to_end = np.array([], dtype=ary.dtype)
+    if to_begin is None:
+        to_begin = np.array([], dtype=ary.dtype)
+
+    to_end = asarray(to_end)
+    to_begin = asarray(to_begin)
+
+    ary = ary.flatten()
+    to_end = to_end.flatten()
+    to_begin = to_begin.flatten()
+
+    r = diff(ary)
+    r = concatenate([to_begin, r, to_end])
+
+    return r
+
+
 @wraps(np.bincount)
 def bincount(x, weights=None, minlength=None):
     if minlength is None:

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -122,6 +122,22 @@ def test_diff(shape, n, axis):
     assert_eq(da.diff(a, n, axis), np.diff(x, n, axis))
 
 
+@pytest.mark.parametrize('shape', [
+    (10,),
+    (10, 15),
+])
+@pytest.mark.parametrize('to_end, to_begin', [
+    [None, None],
+    [0, 0],
+    [[1, 2], [3, 4]],
+])
+def test_ediff1d(shape, to_end, to_begin):
+    x = np.random.randint(0, 10, shape)
+    a = da.from_array(x, chunks=(len(shape) * (5,)))
+
+    assert_eq(da.ediff1d(a, to_end, to_begin), np.ediff1d(x, to_end, to_begin))
+
+
 def test_topk():
     x = np.array([5, 2, 1, 6])
     d = da.from_array(x, chunks=2)

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -46,6 +46,7 @@ Top level user functions:
    digitize
    dot
    dstack
+   ediff1d
    empty
    exp
    expm1
@@ -332,6 +333,7 @@ Other functions
 .. autofunction:: digitize
 .. autofunction:: dot
 .. autofunction:: dstack
+.. autofunction:: ediff1d
 .. autofunction:: empty
 .. autofunction:: exp
 .. autofunction:: expm1


### PR DESCRIPTION
Implements NumPy's [ediff1d]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.ediff1d.html ) for use with Dask Arrays. Includes tests against the original implementation with a variety of parameters. Also adds the function to the Dask Array API docs.