### PR TITLE
Optimize concatenate on singleton sequences

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2282,6 +2282,9 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
                "\nData has %d dimensions, but got axis=%d")
         raise ValueError(msg % (ndim, axis))
 
+    if n == 1:
+        return seq[0]
+
     if (not allow_unknown_chunksizes and
         not all(i == axis or all(x.shape[i] == seq[0].shape[i] for x in seq)
                 for i in range(ndim))):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2274,12 +2274,14 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
     """
     n = len(seq)
     ndim = len(seq[0].shape)
+
     if axis < 0:
         axis = ndim + axis
     if axis >= ndim:
         msg = ("Axis must be less than than number of dimensions"
                "\nData has %d dimensions, but got axis=%d")
         raise ValueError(msg % (ndim, axis))
+
     if (not allow_unknown_chunksizes and
         not all(i == axis or all(x.shape[i] == seq[0].shape[i] for x in seq)
                 for i in range(ndim))):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -302,6 +302,13 @@ def test_concatenate():
 
     assert set(b.dask.keys()).issubset(y.dask.keys())
 
+    z = concatenate([a], axis=0)
+
+    assert z.shape == a.shape
+    assert z.chunks == a.chunks
+    assert z.dask == a.dask
+    assert z is a
+
     assert (concatenate([a, b, c], axis=-1).chunks ==
             concatenate([a, b, c], axis=1).chunks)
 


### PR DESCRIPTION
Provides an optimization for `concatenate` on singleton sequences. Namely skips trying to `concatenate` in these cases as the result should be an identity.