### PR TITLE
Allow dataframe.loc with numpy array

### DIFF
--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -59,13 +59,13 @@ class _LocIndexer(object):
 
             if isinstance(iindexer, slice):
                 return self._loc_slice(iindexer, cindexer)
-            elif isinstance(iindexer, list) or isinstance(iindexer, np.ndarray):
+            elif isinstance(iindexer, (list, np.ndarray)):
                 return self._loc_list(iindexer, cindexer)
             else:
                 # element should raise KeyError
                 return self._loc_element(iindexer, cindexer)
         else:
-            if isinstance(iindexer, list) or isinstance(iindexer, np.ndarray):
+            if isinstance(iindexer, (list, np.ndarray)):
                 # applying map_pattition to each partitions
                 # results in duplicated NaN rows
                 msg = 'Cannot index with list against unknown division'
@@ -124,7 +124,7 @@ class _LocIndexer(object):
                              meta=meta, divisions=[iindexer, iindexer])
 
     def _get_partitions(self, keys):
-        if isinstance(keys, list) or isinstance(keys, np.ndarray):
+        if isinstance(keys, (list, np.ndarray)):
             return _partitions_of_index_values(self.obj.divisions, keys)
         else:
             # element

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -94,18 +94,22 @@ class _LocIndexer(object):
     def _loc_list(self, iindexer, cindexer):
         name = 'loc-%s' % tokenize(iindexer, self.obj)
         parts = self._get_partitions(iindexer)
-        dsk = {}
-
-        divisions = []
-        items = sorted(parts.items())
-        for i, (div, indexer) in enumerate(items):
-            dsk[name, i] = (methods.loc, (self._name, div),
-                            indexer, cindexer)
-            # append minimum value as division
-            divisions.append(sorted(indexer)[0])
-        # append maximum value of the last division
-        divisions.append(sorted(items[-1][1])[-1])
         meta = self._make_meta(iindexer, cindexer)
+
+        if len(iindexer):
+            dsk = {}
+            divisions = []
+            items = sorted(parts.items())
+            for i, (div, indexer) in enumerate(items):
+                dsk[name, i] = (methods.loc, (self._name, div),
+                                indexer, cindexer)
+                # append minimum value as division
+                divisions.append(sorted(indexer)[0])
+            # append maximum value of the last division
+            divisions.append(sorted(items[-1][1])[-1])
+        else:
+            divisions = [None, None]
+            dsk = {(name, 0): meta.head(0)}
         return new_dd_object(merge(self.obj.dask, dsk), name,
                              meta=meta, divisions=divisions)
 

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -59,13 +59,13 @@ class _LocIndexer(object):
 
             if isinstance(iindexer, slice):
                 return self._loc_slice(iindexer, cindexer)
-            elif isinstance(iindexer, list):
+            elif isinstance(iindexer, list) or isinstance(iindexer, np.ndarray):
                 return self._loc_list(iindexer, cindexer)
             else:
                 # element should raise KeyError
                 return self._loc_element(iindexer, cindexer)
         else:
-            if isinstance(iindexer, list):
+            if isinstance(iindexer, list) or isinstance(iindexer, np.ndarray):
                 # applying map_pattition to each partitions
                 # results in duplicated NaN rows
                 msg = 'Cannot index with list against unknown division'
@@ -124,7 +124,7 @@ class _LocIndexer(object):
                              meta=meta, divisions=[iindexer, iindexer])
 
     def _get_partitions(self, keys):
-        if isinstance(keys, list):
+        if isinstance(keys, list) or isinstance(keys, np.ndarray):
             return _partitions_of_index_values(self.obj.divisions, keys)
         else:
             # element

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -34,6 +34,8 @@ def test_loc():
     assert_eq(d.loc[3:], full.loc[3:])
     assert_eq(d.loc[[5]], full.loc[[5]])
     assert_eq(d.loc[[3, 4, 1, 8]], full.loc[[3, 4, 1, 8]])
+    assert_eq(d.loc[[3, 4, 1, 9]], full.loc[[3, 4, 1, 9]])
+    assert_eq(d.loc[np.array([3, 4, 1, 9])], full.loc[np.array([3, 4, 1, 9])])
 
     assert_eq(d.a.loc[5], full.a.loc[5:5])
     assert_eq(d.a.loc[3:8], full.a.loc[3:8])
@@ -41,6 +43,8 @@ def test_loc():
     assert_eq(d.a.loc[3:], full.a.loc[3:])
     assert_eq(d.a.loc[[5]], full.a.loc[[5]])
     assert_eq(d.a.loc[[3, 4, 1, 8]], full.a.loc[[3, 4, 1, 8]])
+    assert_eq(d.a.loc[[3, 4, 1, 9]], full.a.loc[[3, 4, 1, 9]])
+    assert_eq(d.a.loc[np.array([3, 4, 1, 9])], full.a.loc[np.array([3, 4, 1, 9])])
 
     pytest.raises(KeyError, lambda: d.loc[1000])
     assert_eq(d.loc[1000:], full.loc[1000:])

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -45,6 +45,8 @@ def test_loc():
     assert_eq(d.a.loc[[3, 4, 1, 8]], full.a.loc[[3, 4, 1, 8]])
     assert_eq(d.a.loc[[3, 4, 1, 9]], full.a.loc[[3, 4, 1, 9]])
     assert_eq(d.a.loc[np.array([3, 4, 1, 9])], full.a.loc[np.array([3, 4, 1, 9])])
+    assert_eq(d.a.loc[[]], full.a.loc[[]])
+    assert_eq(d.a.loc[np.array([])], full.a.loc[np.array([])])
 
     pytest.raises(KeyError, lambda: d.loc[1000])
     assert_eq(d.loc[1000:], full.loc[1000:])


### PR DESCRIPTION
In native pandas, `df.loc[np.array([1,2,3])]` is valid, but it does not work in dask. This PR implements the simple improvement with tests.