### PR TITLE
Support complex data with vnorm

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -433,9 +433,6 @@ def vnorm(a, ord=None, axis=None, dtype=None, keepdims=False, split_every=None,
     elif ord == 1:
         return sum(abs(a), axis=axis, dtype=dtype, keepdims=keepdims,
                    split_every=split_every, out=out)
-    elif ord % 2 == 0:
-        return sum(a ** ord, axis=axis, dtype=dtype, keepdims=keepdims,
-                   split_every=split_every, out=out) ** (1. / ord)
     else:
         return sum(abs(a) ** ord, axis=axis, dtype=dtype, keepdims=keepdims,
                    split_every=split_every, out=out) ** (1. / ord)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -538,6 +538,7 @@ def test_T():
 
 def test_norm():
     a = np.arange(200, dtype='f8').reshape((20, 10))
+    a = a + (a.max() - a) * 1j
     b = from_array(a, chunks=(5, 5))
 
     assert_eq(b.vnorm(), np.linalg.norm(a))


### PR DESCRIPTION
Currently `vnorm` has an optimization for `ord` that is a multiple of `2`. This optimization is fine for non-`complex` data. However if the data is `complex`, then this optimization yields an incorrect result. Included is a test that demonstrates this issue and a fix.