### PR TITLE
BUG: setitem should update divisions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2144,6 +2144,7 @@ class DataFrame(_Frame):
         self.dask = df.dask
         self._name = df._name
         self._meta = df._meta
+        self.divisions = df.divisions
 
     def __delitem__(self, key):
         result = self.drop([key], axis=1)

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -111,14 +111,15 @@ def rolling_functions_tests(p, d):
                   dd.rolling_kurt(d, 3), check_less_precise=True)
         assert_eq(pd.rolling_quantile(p, 3, 0.5), dd.rolling_quantile(d, 3, 0.5))
         assert_eq(pd.rolling_apply(p, 3, mad), dd.rolling_apply(d, 3, mad))
-        assert_eq(pd.rolling_window(p, 3, win_type='boxcar'),
-                  dd.rolling_window(d, 3, win_type='boxcar'))
         # Test with edge-case window sizes
         assert_eq(pd.rolling_sum(p, 0), dd.rolling_sum(d, 0))
         assert_eq(pd.rolling_sum(p, 1), dd.rolling_sum(d, 1))
         # Test with kwargs
         assert_eq(pd.rolling_sum(p, 3, min_periods=3),
                   dd.rolling_sum(d, 3, min_periods=3))
+        pytest.importorskip("scipy")
+        assert_eq(pd.rolling_window(p, 3, win_type='boxcar'),
+                  dd.rolling_window(d, 3, win_type='boxcar'))
 
 
 def test_rolling_functions_series():

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -521,3 +521,13 @@ def test_array_nondim():
     x = da.ones((100,3), chunks=10)
     y = da.array(x)
     assert isinstance(y, da.Array)
+
+
+def test_setitem_triggering_realign():
+    import pandas as pd
+    import dask.dataframe as dd
+
+    a = dd.from_pandas(pd.DataFrame({"A": range(12)}), npartitions=3)
+    b = dd.from_pandas(pd.Series(range(12), name='B'), npartitions=4)
+    a['C'] = b
+    assert len(a) == 12


### PR DESCRIPTION
The `df` returned by `assign` may contain different divisions that `self` in
DataFrame.__setitem__ which throws off our dataframe structure.

Now we simply copy over `df.divisions` as well.

The test fails on master (`len(a)` was incorrectly 6).