### PR TITLE
Add `*_like` array creation functions

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -34,6 +34,7 @@ with ignoring(ImportError):
     from .reductions import nanprod, nancumprod, nancumsum
 from . import random, linalg, ghost, learn, fft
 from .wrap import ones, zeros, empty, full
+from .creation import ones_like, zeros_like, empty_like, full_like
 from .rechunk import rechunk
 from ..context import set_options
 from ..base import compute

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -12,8 +12,162 @@ from .. import sharedict
 from ..base import tokenize
 from ..utils import ignoring
 from . import chunk
-from .core import Array, normalize_chunks, stack, concatenate
-from .wrap import empty
+from .core import Array, asarray, normalize_chunks, stack, concatenate
+from .wrap import empty, ones, zeros, full
+
+
+def empty_like(a, dtype=None, chunks=None):
+    """
+    Return a new array with the same shape and type as a given array.
+
+    Parameters
+    ----------
+    a : array_like
+        The shape and data-type of `a` define these same attributes of the
+        returned array.
+    dtype : data-type, optional
+        Overrides the data type of the result.
+    chunks : sequence of ints
+        The number of samples on each block. Note that the last block will have
+        fewer samples if ``len(array) % chunks != 0``.
+
+    Returns
+    -------
+    out : ndarray
+        Array of uninitialized (arbitrary) data with the same
+        shape and type as `a`.
+
+    See Also
+    --------
+    ones_like : Return an array of ones with shape and type of input.
+    zeros_like : Return an array of zeros with shape and type of input.
+    empty : Return a new uninitialized array.
+    ones : Return a new array setting values to one.
+    zeros : Return a new array setting values to zero.
+
+    Notes
+    -----
+    This function does *not* initialize the returned array; to do that use
+    `zeros_like` or `ones_like` instead.  It may be marginally faster than
+    the functions that do set the array values.
+    """
+
+    a = asarray(a)
+    return empty(
+        a.shape, dtype=(dtype or a.dtype), chunks=(chunks or a.chunks)
+    )
+
+
+def ones_like(a, dtype=None, chunks=None):
+    """
+    Return an array of ones with the same shape and type as a given array.
+
+    Parameters
+    ----------
+    a : array_like
+        The shape and data-type of `a` define these same attributes of
+        the returned array.
+    dtype : data-type, optional
+        Overrides the data type of the result.
+    chunks : sequence of ints
+        The number of samples on each block. Note that the last block will have
+        fewer samples if ``len(array) % chunks != 0``.
+
+    Returns
+    -------
+    out : ndarray
+        Array of ones with the same shape and type as `a`.
+
+    See Also
+    --------
+    zeros_like : Return an array of zeros with shape and type of input.
+    empty_like : Return an empty array with shape and type of input.
+    zeros : Return a new array setting values to zero.
+    ones : Return a new array setting values to one.
+    empty : Return a new uninitialized array.
+    """
+
+    a = asarray(a)
+    return ones(
+        a.shape, dtype=(dtype or a.dtype), chunks=(chunks or a.chunks)
+    )
+
+
+def zeros_like(a, dtype=None, chunks=None):
+    """
+    Return an array of zeros with the same shape and type as a given array.
+
+    Parameters
+    ----------
+    a : array_like
+        The shape and data-type of `a` define these same attributes of
+        the returned array.
+    dtype : data-type, optional
+        Overrides the data type of the result.
+    chunks : sequence of ints
+        The number of samples on each block. Note that the last block will have
+        fewer samples if ``len(array) % chunks != 0``.
+
+    Returns
+    -------
+    out : ndarray
+        Array of zeros with the same shape and type as `a`.
+
+    See Also
+    --------
+    ones_like : Return an array of ones with shape and type of input.
+    empty_like : Return an empty array with shape and type of input.
+    zeros : Return a new array setting values to zero.
+    ones : Return a new array setting values to one.
+    empty : Return a new uninitialized array.
+    """
+
+    a = asarray(a)
+    return zeros(
+        a.shape, dtype=(dtype or a.dtype), chunks=(chunks or a.chunks)
+    )
+
+
+def full_like(a, fill_value, dtype=None, chunks=None):
+    """
+    Return a full array with the same shape and type as a given array.
+
+    Parameters
+    ----------
+    a : array_like
+        The shape and data-type of `a` define these same attributes of
+        the returned array.
+    fill_value : scalar
+        Fill value.
+    dtype : data-type, optional
+        Overrides the data type of the result.
+    chunks : sequence of ints
+        The number of samples on each block. Note that the last block will have
+        fewer samples if ``len(array) % chunks != 0``.
+
+    Returns
+    -------
+    out : ndarray
+        Array of `fill_value` with the same shape and type as `a`.
+
+    See Also
+    --------
+    zeros_like : Return an array of zeros with shape and type of input.
+    ones_like : Return an array of ones with shape and type of input.
+    empty_like : Return an empty array with shape and type of input.
+    zeros : Return a new array setting values to zero.
+    ones : Return a new array setting values to one.
+    empty : Return a new uninitialized array.
+    full : Fill a new array.
+    """
+
+    a = asarray(a)
+    return full(
+        a.shape,
+        fill_value,
+        dtype=(dtype or a.dtype),
+        chunks=(chunks or a.chunks)
+    )
 
 
 def linspace(start, stop, num=50, chunks=None, dtype=None):

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -48,6 +48,7 @@ Top level user functions:
    dstack
    ediff1d
    empty
+   empty_like
    exp
    expm1
    eye
@@ -61,6 +62,7 @@ Top level user functions:
    frexp
    fromfunction
    full
+   full_like
    histogram
    hstack
    hypot
@@ -108,6 +110,7 @@ Top level user functions:
    nonzero
    notnull
    ones
+   ones_like
    percentile
    prod
    rad2deg
@@ -147,6 +150,7 @@ Top level user functions:
    vstack
    where
    zeros
+   zeros_like
 
 Fast Fourier Transforms
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -336,6 +340,7 @@ Other functions
 .. autofunction:: dstack
 .. autofunction:: ediff1d
 .. autofunction:: empty
+.. autofunction:: empty_like
 .. autofunction:: exp
 .. autofunction:: expm1
 .. autofunction:: eye
@@ -349,6 +354,7 @@ Other functions
 .. autofunction:: frexp
 .. autofunction:: fromfunction
 .. autofunction:: full
+.. autofunction:: full_like
 .. autofunction:: histogram
 .. autofunction:: hstack
 .. autofunction:: hypot
@@ -396,6 +402,7 @@ Other functions
 .. autofunction:: nonzero
 .. autofunction:: notnull
 .. autofunction:: ones
+.. autofunction:: ones_like
 .. autofunction:: percentile
 .. autofunction:: prod
 .. autofunction:: rad2deg
@@ -435,6 +442,7 @@ Other functions
 .. autofunction:: vstack
 .. autofunction:: where
 .. autofunction:: zeros
+.. autofunction:: zeros_like
 
 .. currentmodule:: dask.array.linalg
 


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2637

Provides Dask Array equivalents of common NumPy `*_like` functions [`empty_like`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.empty_like.html ), [`ones_like`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.ones_like.html ), [`zeros_like`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.zeros_like.html ), and [`full_like`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.full_like.html ).