### PR TITLE
Indexing with an unsigned integer array

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -62,7 +62,7 @@ def sanitize_index(ind):
             # If a 1-element tuple, unwrap the element
             nonzero = nonzero[0]
         return np.asanyarray(nonzero)
-    elif index_array.dtype.kind in {'u', 'i'}:
+    elif np.issubdtype(index_array.dtype, np.integer):
         return index_array
     elif np.issubdtype(index_array.dtype, float):
         int_index = index_array.astype(np.intp)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -62,7 +62,7 @@ def sanitize_index(ind):
             # If a 1-element tuple, unwrap the element
             nonzero = nonzero[0]
         return np.asanyarray(nonzero)
-    elif np.issubdtype(index_array.dtype, int):
+    elif index_array.dtype.kind in {'u', 'i'}:
         return index_array
     elif np.issubdtype(index_array.dtype, float):
         int_index = index_array.astype(np.intp)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1611,6 +1611,16 @@ def test_slice_with_floats():
         d[[1, 1.5]]
 
 
+def test_slice_with_uint():
+    d = da.ones((5,), chunks=(3,))
+    assert_eq(d[np.array([0])],
+              d[np.array([0], dtype='uint64')])
+    assert_eq(d[np.array([0])],
+              d[np.array([0], dtype='uint32')])
+    assert_eq(d[np.array([0])],
+              d[np.array([0], dtype='uint16')])
+
+
 def test_vindex_basic():
     x = np.arange(56).reshape((7, 8))
     d = da.from_array(x, chunks=(3, 4))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1612,13 +1612,11 @@ def test_slice_with_floats():
 
 
 def test_slice_with_uint():
-    d = da.ones((5,), chunks=(3,))
-    assert_eq(d[np.array([0])],
-              d[np.array([0], dtype='uint64')])
-    assert_eq(d[np.array([0])],
-              d[np.array([0], dtype='uint32')])
-    assert_eq(d[np.array([0])],
-              d[np.array([0], dtype='uint16')])
+    x = np.arange(10)
+    dx = da.from_array(x, chunks=5)
+    inds = np.array([0, 3, 6], dtype='u8')
+    assert_eq(dx[inds], x[inds])
+    assert_eq(dx[inds.astype('u4')], x[inds.astype('u4')])
 
 
 def test_vindex_basic():


### PR DESCRIPTION
Fixes #2646

Now support indexing `dask.array` by an unsigned-integer array.