### PR TITLE
CLN: Remove redundant code, fix typos

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -75,7 +75,6 @@ def hold_keys(dsk, dependencies):
                         # linear chain
                         if new_task[0] in GETTERS or new_task in dsk:
                             dep = new_dep
-                            task = new_task
                         else:
                             break
                 except (IndexError, TypeError):
@@ -243,7 +242,6 @@ def fuse_slice(a, b):
                 stop = min(a.stop, stop)
             else:
                 stop = a.stop
-            stop = stop
         step = a.step * b.step
         if step == 1:
             step = None

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -187,7 +187,6 @@ fmod = ufunc(np.fmod)
 floor = ufunc(np.floor)
 ceil = ufunc(np.ceil)
 trunc = ufunc(np.trunc)
-divide = ufunc(np.divide)
 
 # more math routines, from this page:
 # http://docs.scipy.org/doc/numpy/reference/routines.math.html

--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -115,7 +115,6 @@ def categorize(df, columns=None, index=None, split_every=None, **kwargs):
 
     prefix = 'get-categories-agg-' + token
     k = df.npartitions
-    b = a
     depth = 0
     while k > split_every:
         b = prefix + str(depth)

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -155,10 +155,10 @@ def _read_pyarrow(fs, paths, file_opener, columns=None, filters=None,
     api = pyarrow_parquet
 
     if filters is not None:
-        raise NotImplemented("Predicate pushdown not implemented")
+        raise NotImplementedError("Predicate pushdown not implemented")
 
     if categories is not None:
-        raise NotImplemented("Categorical reads not yet implemented")
+        raise NotImplementedError("Categorical reads not yet implemented")
 
     if isinstance(columns, tuple):
         columns = list(columns)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -211,7 +211,6 @@ def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None)
     df2 = df.assign(_partitions=partitions)
     df3 = rearrange_by_column(df2, '_partitions', max_branch=max_branch,
                               npartitions=len(divisions) - 1, shuffle=shuffle)
-    df4 = df3.drop('_partitions', axis=1)
     df4 = df3.map_partitions(drop_columns, '_partitions', df.columns.dtype)
     return df4
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -596,9 +596,8 @@ def assert_dask_graph(dask, label):
             k = k[0]
         if k.startswith(label):
             return True
-    else:
-        msg = "given dask graph doesn't contan label: {0}"
-        raise AssertionError(msg.format(label))
+    raise AssertionError("given dask graph doesn't contain label: {label}"
+                         .format(label=label))
 
 
 def assert_divisions(ddf):

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -219,7 +219,6 @@ class _Tracker(Process):
 
     def run(self):
         pid = current_process()
-        ps = self._update_pids(pid)
         data = []
         while True:
             try:

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -594,12 +594,11 @@ def fuse(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
                     parent = child
                     child = children_stack[-1]
                     children = reducible & deps[child]
-                else:
-                    children_stack_pop()
-                    # This is a leaf node in the reduction region
-                    # key, task, fused_keys, height, width, number of nodes, fudge, set of edges
-                    info_stack_append((child, rv[child], None if key_renamer is None else [child],
-                                       1, 1, 1, 0, deps[child] - reducible))
+                children_stack_pop()
+                # This is a leaf node in the reduction region
+                # key, task, fused_keys, height, width, number of nodes, fudge, set of edges
+                info_stack_append((child, rv[child], None if key_renamer is None else [child],
+                                   1, 1, 1, 0, deps[child] - reducible))
             else:
                 children_stack_pop()
                 # Calculate metrics and fuse as appropriate


### PR DESCRIPTION
Removed some redundant code:
- variables that get reassigned before being used
- unnecessary `else` clauses

Fixed some typos:
- `NotImplemented`  -> `NotImplementedError` when raising
- minor typo in an error message

Made some code comments to further explain these changes for easier review.