### PR TITLE
Bump version to 0.15.3

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+0.15.3 / 2017-09-04
+-------------------
+
+Array
++++++
+
+-  Added `*_like` array creation functions (:pr:`2640`)
+-  Added support for masked arrays (:pr:`2301`)
+
+DataFrame
++++++++++
+
+-  Added user defined aggregations (:pr:`2344`)
+
 0.15.2 / 2017-08-25
 -------------------
 


### PR DESCRIPTION
We need this for Iris, as we can't test against the new masked-array function without a distinct version for conda to grab onto.