### PR TITLE
Dask array slicing with boolean arrays

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -846,8 +846,10 @@ def slice_with_dask_array(x, index):
 
     if any(isinstance(ind, Array) and ind.dtype == bool and ind.ndim != 1
             for ind in index):
-        raise NotImplementedError("Slicing with dask.array only permitted for "
-                                  "dimension 1 and dimension n")
+        raise NotImplementedError("Slicing with dask.array only permitted when "
+                                  "the indexer has only one dimension or when "
+                                  "it has the same dimension as the sliced "
+                                  "array")
     indexes = [ind
                if isinstance(ind, Array) and ind.dtype == bool
                else slice(None)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2350,6 +2350,19 @@ def test_index_array_with_array_2d():
             sorted(dx[dx > 6].compute().tolist()))
 
 
+@pytest.mark.xfail(reason='Chunking does not align well')
+def test_index_array_with_array_3d_2d():
+    x = np.arange(4**3).reshape((4, 4, 4))
+    dx = da.from_array(x, chunks=(2, 2, 2))
+
+    ind = np.random.random((4, 4)) > 0.5
+    ind = np.arange(4 ** 2).reshape((4, 4)) % 2 == 0
+    dind = da.from_array(ind, (2, 2))
+
+    assert_eq(x[ind], dx[dind])
+    assert_eq(x[:, ind], dx[:, dind])
+
+
 def test_setitem_1d():
     x = np.arange(10)
     dx = da.from_array(x.copy(), chunks=(5,))

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -516,15 +516,14 @@ def test_index_with_dask_array():
         assert_eq(x[x_index], d[index])
 
 
-@pytest.mark.xfail
 def test_index_with_dask_array_2():
-    x = np.random.random((10, 10, 10, 10))
+    x = np.random.random((10, 10, 10))
     ind = np.random.random(10) > 0.5
 
-    d = da.from_array(x, chunks=(2, 3, 4, 5))
+    d = da.from_array(x, chunks=(3, 4, 5))
     dind = da.from_array(ind, chunks=4)
 
-    index = [slice(1, 9, 1), 4, slice(None)]
+    index = [slice(1, 9, 1), slice(None)]
 
     for i in range(x.ndim):
         index2 = index[:]

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -6,6 +6,7 @@ from toolz import merge
 
 np = pytest.importorskip('numpy')
 
+import dask
 import dask.array as da
 from dask.array.slicing import (_sanitize_index_element, _slice_1d,
                                 new_blockdim, sanitize_index, slice_array,
@@ -505,10 +506,14 @@ def test_oob_check():
         x[0, 0]
 
 
-def test_index_with_dask_array_errors():
-    x = da.ones((5, 5), chunks=2)
-    with pytest.raises(NotImplementedError):
-        x[0, x > 10]
+def test_index_with_dask_array():
+    x = np.arange(36).reshape((6, 6))
+    d = da.from_array(x, chunks=(3, 3))
+    ind = np.asarray([True, True, False, True, False, False], dtype=bool)
+    ind = da.from_array(ind, chunks=2)
+    for index in [ind, (slice(1, 9, 2), ind), (ind, slice(2, 8, 1))]:
+        x_index = dask.compute(index)[0]
+        assert_eq(x[x_index], d[index])
 
 
 @pytest.mark.xfail

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -517,6 +517,26 @@ def test_index_with_dask_array():
 
 
 @pytest.mark.xfail
+def test_index_with_dask_array_2():
+    x = np.random.random((10, 10, 10, 10))
+    ind = np.random.random(10) > 0.5
+
+    d = da.from_array(x, chunks=(2, 3, 4, 5))
+    dind = da.from_array(ind, chunks=4)
+
+    index = [slice(1, 9, 1), 4, slice(None)]
+
+    for i in range(x.ndim):
+        index2 = index[:]
+        index2.insert(i, dind)
+
+        index3 = index[:]
+        index3.insert(i, ind)
+
+        assert_eq(x[tuple(index3)], d[tuple(index2)])
+
+
+@pytest.mark.xfail
 def test_cull():
     x = da.ones(1000, chunks=(10,))
 


### PR DESCRIPTION
Currently we support this:

    x[y > 0]

But not this

    x[:, y> 0]

This PR attempts to fix this, but currently fails.  

see #2651 and #2430 

cc @TomAugspurger 