### PR TITLE
Slice array with smaller mask

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3213,12 +3213,28 @@ def from_npy_stack(dirname, mmap_mode='r'):
 
 
 def slice_with_dask_array(x, index):
-    y = elemwise(getitem, x, index, dtype=x.dtype)
+    token = 'getitem'
+    name = token + tokenize(x, index)
 
-    name = 'getitem-' + tokenize(x, index)
+    if index.ndim < x.ndim:
+        x = x.reshape((-1,) + x.shape[index.ndim:])
+        index = index.flatten()
 
-    dsk = {(name, i): k
-           for i, k in enumerate(core.flatten(y._keys()))}
-    chunks = ((np.nan,) * y.npartitions,)
+        inds = tuple(range(x.ndim))
+        y = atop(np.compress,
+                 inds,
+                 index, (0,),
+                 x, inds,
+                 axis=0,
+                 token=token, dtype=x.dtype)
+        y._chunks = (len(y._chunks[0]) * (np.NaN,),) + y._chunks[1:]
 
-    return Array(sharedict.merge(y.dask, (name, dsk)), name, chunks, x.dtype)
+        return y
+    else:
+        y = elemwise(getitem, x, index, dtype=x.dtype)
+
+        dsk = {(name, i): k
+               for i, k in enumerate(core.flatten(y._keys()))}
+        chunks = ((np.nan,) * y.npartitions,)
+
+        return Array(sharedict.merge(y.dask, (name, dsk)), name, chunks, x.dtype)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2324,6 +2324,19 @@ def test_index_array_with_array_1d():
         dx[dy > 5]
 
 
+def test_index_array_2d_with_array_1d():
+    x = np.arange(24).reshape((4, 6))
+    dx = da.from_array(x, chunks=(2, 2))
+
+    print(sorted(x[x[:, 0] % 2 == 0].tolist()))
+    print(sorted(dx[dx[:, 0] % 2 == 0].compute().tolist()))
+
+    assert (sorted(x[x[:, 0] % 2 == 0].tolist()) ==
+            sorted(dx[dx[:, 0] % 2 == 0].compute().tolist()))
+    assert (sorted(x[x[:, 0] > 6].tolist()) ==
+            sorted(dx[dx[:, 0] > 6].compute().tolist()))
+
+
 def test_index_array_with_array_2d():
     x = np.arange(24).reshape((4, 6))
     dx = da.from_array(x, chunks=(2, 2))


### PR DESCRIPTION
Allows a Dask Array to be sliced with a boolean Dask Array that is smaller than the array it is slicing. This constitutes a very small, but useful step towards resolving issue ( https://github.com/dask/dask/issues/2651 ).