### PR TITLE
Support literals in top and atop

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -29,11 +29,10 @@ from dask.array import chunk
 from dask.array.core import (getem, getter, top, dotmany, concatenate3,
                              broadcast_dimensions, Array, stack, concatenate,
                              from_array, elemwise, broadcast_shapes,
-                             partial_by_order, broadcast_to,
-                             blockdims_from_blockshape, store, optimize,
-                             from_func, normalize_chunks, broadcast_chunks,
-                             atop, from_delayed, concatenate_axes,
-                             common_blockdim)
+                             broadcast_to, blockdims_from_blockshape, store,
+                             optimize, from_func, normalize_chunks,
+                             broadcast_chunks, atop, from_delayed,
+                             concatenate_axes, common_blockdim)
 from dask.array.utils import assert_eq, same_keys
 
 # temporary until numpy functions migrated
@@ -428,10 +427,6 @@ def test_elemwise_on_scalars():
     assert result.compute().dtype == np.int64
     assert (x.sum() * y).dtype == np.int32
     assert_eq((x.sum() * y).astype(np.int64), result)
-
-
-def test_partial_by_order():
-    assert partial_by_order(5, function=add, other=[(1, 20)]) == 25
 
 
 def test_elemwise_with_ndarrays():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -92,6 +92,26 @@ def test_top_supports_broadcasting_rules():
          ('z', 1, 1): (add, ('x', 0, 1), ('y', 1, 0))}
 
 
+def test_top_literals():
+    assert top(add, 'z', 'ij', 'x', 'ij', 123, None, numblocks={'x': (2, 2)}) == \
+        {('z', 0, 0): (add, ('x', 0, 0), 123),
+         ('z', 0, 1): (add, ('x', 0, 1), 123),
+         ('z', 1, 0): (add, ('x', 1, 0), 123),
+         ('z', 1, 1): (add, ('x', 1, 1), 123)}
+
+
+def test_atop_literals():
+    x = da.ones((10, 10), chunks=(5, 5))
+    z = atop(add, 'ij', x, 'ij', 100, None, dtype=x.dtype)
+    assert_eq(z, x + 100)
+
+    z = atop(lambda x, y, z: x * y + z, 'ij', 2, None,  x, 'ij', 100, None, dtype=x.dtype)
+    assert_eq(z, 2 * x + 100)
+
+    z = atop(getitem, 'ij', x, 'ij', slice(None), None, dtype=x.dtype)
+    assert_eq(z, x)
+
+
 def test_concatenate3_on_scalars():
     assert_eq(concatenate3([1, 2]), np.array([1, 2]))
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -18,7 +18,7 @@ except ImportError:
 
 from .. import array as da
 from .. import core
-from ..array.core import partial_by_order
+from ..utils import partial_by_order
 from .. import threaded
 from ..compatibility import apply, operator_div, bind_method, PY3
 from ..utils import (random_state_data,

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -1,5 +1,6 @@
-import pickle
 import functools
+import operator
+import pickle
 
 import numpy as np
 import pytest
@@ -8,7 +9,7 @@ from dask.sharedict import ShareDict
 from dask.utils import (takes_multiple_arguments, Dispatch, random_state_data,
                         memory_repr, methodcaller, M, skip_doctest,
                         SerializableLock, funcname, ndeepmap, ensure_dict,
-                        extra_titles, asciitable, itemgetter)
+                        extra_titles, asciitable, itemgetter, partial_by_order)
 from dask.utils_test import inc
 
 
@@ -311,3 +312,7 @@ def test_itemgetter():
     g2 = pickle.loads(pickle.dumps(g))
     assert g2(data) == 2
     assert g2.index == 1
+
+
+def test_partial_by_order():
+    assert partial_by_order(5, function=operator.add, other=[(1, 20)]) == 25

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -899,3 +899,18 @@ def infer_storage_options(urlpath, inherit_storage_options=None):
         inferred_storage_options.update(inherit_storage_options)
 
     return inferred_storage_options
+
+
+def partial_by_order(*args, **kwargs):
+    """
+
+    >>> from operator import add
+    >>> partial_by_order(5, function=add, other=[(1, 10)])
+    15
+    """
+    function = kwargs.pop('function')
+    other = kwargs.pop('other')
+    args2 = list(args)
+    for i, arg in other:
+        args2.insert(i, arg)
+    return function(*args2, **kwargs)


### PR DESCRIPTION
We use a special index value of `None` to imply that a value should be treated as a literal.


```python
>>> top(add, 'z', 'i', 'x', 'i', 100, None,  numblocks={'x': (2,)})  # doctest: +SKIP
{('z', 0): (add, ('x', 0), 100),
 ('z', 1): (add, ('x', 1), 100)}
```