### PR TITLE
Optional axis argument for cumulative functions

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -619,7 +619,7 @@ nanargmin = make_arg_reduction(chunk.nanmin, _nanargmin, True)
 nanargmax = make_arg_reduction(chunk.nanmax, _nanargmax, True)
 
 
-def cumreduction(func, binop, ident, x, axis, dtype=None, out=None):
+def cumreduction(func, binop, ident, x, axis=None, dtype=None, out=None):
     """ Generic function for cumulative reduction
 
     Parameters
@@ -643,6 +643,9 @@ def cumreduction(func, binop, ident, x, axis, dtype=None, out=None):
     cumsum
     cumprod
     """
+    if axis is None:
+        x = x.flatten()
+        axis = 0
     if dtype is None:
         dtype = func(np.empty((0,), dtype=x.dtype)).dtype
     assert isinstance(axis, int)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -696,12 +696,12 @@ def _cumprod_merge(a, b):
 
 
 @wraps(np.cumsum)
-def cumsum(x, axis, dtype=None, out=None):
+def cumsum(x, axis=None, dtype=None, out=None):
     return cumreduction(np.cumsum, _cumsum_merge, 0, x, axis, dtype, out=out)
 
 
 @wraps(np.cumprod)
-def cumprod(x, axis, dtype=None, out=None):
+def cumprod(x, axis=None, dtype=None, out=None):
     return cumreduction(np.cumprod, _cumprod_merge, 1, x, axis, dtype, out=out)
 
 

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -387,6 +387,22 @@ def test_array_reduction_out(func):
     assert_eq(x, func(np.ones((10, 10)), axis=0))
 
 
+@pytest.mark.parametrize("func", ["cumsum", "cumprod"])
+@pytest.mark.parametrize("axis", [None, 0, 1, -1])
+def test_array_cumreduction_axis(func, axis):
+    np_func = getattr(np, func)
+    da_func = getattr(da, func)
+
+    s = (10, 11, 12)
+    a = np.arange(np.prod(s)).reshape(s)
+    d = da.from_array(a, chunks=(4, 5, 6))
+
+    a_r = np_func(a, axis=axis)
+    d_r = da_func(d, axis=axis)
+
+    assert_eq(a_r, d_r)
+
+
 @pytest.mark.parametrize('func', [np.cumsum, np.cumprod])
 def test_array_cumreduction_out(func):
     x = da.ones((10, 10), chunks=(4, 4))


### PR DESCRIPTION
Make the `axis` argument to cumulative functions optional inline with what NumPy does. Also provide tests to ensure that this and various other `axis` arguments behave correctly on slightly more interesting data.