### PR TITLE
Remove resize tool from bokeh plots

### DIFF
--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -236,7 +236,7 @@ def plot_tasks(results, dsk, palette='Viridis', label_size=60, **kwargs):
     tz = import_required('toolz', _TOOLZ_MISSING_MSG)
 
     defaults = dict(title="Profile Results",
-                    tools="hover,save,reset,resize,xwheel_zoom,xpan",
+                    tools="hover,save,reset,xwheel_zoom,xpan",
                     plot_width=800, plot_height=300)
     defaults.update((k, v) for (k, v) in kwargs.items() if k in
                     _get_figure_keywords())
@@ -316,7 +316,7 @@ def plot_resources(results, palette='Viridis', **kwargs):
     from bokeh.models import LinearAxis, Range1d
 
     defaults = dict(title="Profile Results",
-                    tools="save,reset,resize,xwheel_zoom,xpan",
+                    tools="save,reset,xwheel_zoom,xpan",
                     plot_width=800, plot_height=300)
     defaults.update((k, v) for (k, v) in kwargs.items() if k in
                     _get_figure_keywords())
@@ -373,7 +373,7 @@ def plot_cache(results, dsk, start_time, metric_name, palette='Viridis',
     tz = import_required('toolz', _TOOLZ_MISSING_MSG)
 
     defaults = dict(title="Profile Results",
-                    tools="hover,save,reset,resize,wheel_zoom,xpan",
+                    tools="hover,save,reset,wheel_zoom,xpan",
                     plot_width=800, plot_height=300)
     defaults.update((k, v) for (k, v) in kwargs.items() if k in
                     _get_figure_keywords())

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -224,7 +224,10 @@ def test_profiler_plot():
     assert check_title(p, "Not the default")
     # Test empty, checking for errors
     prof.clear()
-    prof.visualize(show=False, save=False)
+    with pytest.warns(None) as record:
+        prof.visualize(show=False, save=False)
+
+    assert len(record) == 0
 
 
 @pytest.mark.skipif("not bokeh")
@@ -244,7 +247,11 @@ def test_resource_profiler_plot():
     assert check_title(p, "Not the default")
     # Test empty, checking for errors
     rprof.clear()
-    rprof.visualize(show=False, save=False)
+
+    with pytest.warns(None) as record:
+        rprof.visualize(show=False, save=False)
+
+    assert len(record) == 0
 
 
 @pytest.mark.skipif("not bokeh")
@@ -264,7 +271,10 @@ def test_cache_profiler_plot():
     assert p.axis[1].axis_label == 'Cache Size (non-standard)'
     # Test empty, checking for errors
     cprof.clear()
-    cprof.visualize(show=False, save=False)
+    with pytest.warns(None) as record:
+        cprof.visualize(show=False, save=False)
+
+    assert len(record) == 0
 
 
 @pytest.mark.skipif("not bokeh")


### PR DESCRIPTION
This was removed in 0.12.7 and now results in warnings

cc @jcrist for quick review