### PR TITLE
Add ptp

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -5,7 +5,7 @@ from .core import (Array, concatenate, stack, from_array, store, map_blocks,
                    atop, to_hdf5, to_npy_stack, from_npy_stack, from_delayed,
                    asarray, asanyarray, broadcast_to)
 from .routines import (take, choose, argwhere, where, coarsen, insert,
-                       ravel, roll, unique, squeeze, topk, diff, ediff1d,
+                       ravel, roll, unique, squeeze, topk, ptp, diff, ediff1d,
                        bincount, digitize, histogram, cov, array, dstack,
                        vstack, hstack, compress, extract, round, count_nonzero,
                        flatnonzero, nonzero, around, isnull, notnull, isclose,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -160,6 +160,11 @@ def dot(a, b):
     return tensordot(a, b, axes=((a.ndim - 1,), (b.ndim - 2,)))
 
 
+@wraps(np.ptp)
+def ptp(a, axis=None):
+    return a.max(axis=axis) - a.min(axis=axis)
+
+
 @wraps(np.diff)
 def diff(a, n=1, axis=-1):
     a = asarray(a)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -105,6 +105,20 @@ def test_dot_method():
 
 
 @pytest.mark.parametrize('shape, axis', [
+    [(10, 15, 20), None],
+    [(10, 15, 20), 0],
+    [(10, 15, 20), 1],
+    [(10, 15, 20), 2],
+    [(10, 15, 20), -1],
+])
+def test_ptp(shape, axis):
+    a = np.random.randint(0, 10, shape)
+    d = da.from_array(a, chunks=(len(shape) * (5,)))
+
+    assert_eq(da.ptp(d, axis), np.ptp(a, axis))
+
+
+@pytest.mark.parametrize('shape, axis', [
     [(10, 15, 20), 0],
     [(10, 15, 20), 1],
     [(10, 15, 20), 2],

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -113,6 +113,7 @@ Top level user functions:
    ones_like
    percentile
    prod
+   ptp
    rad2deg
    radians
    ravel
@@ -427,6 +428,7 @@ Other functions
 .. autofunction:: ones_like
 .. autofunction:: percentile
 .. autofunction:: prod
+.. autofunction:: ptp
 .. autofunction:: rad2deg
 .. autofunction:: radians
 .. autofunction:: ravel


### PR DESCRIPTION
Fix #2687

Adds a Dask Array implementation of [`ptp`]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.ptp.html ). Simply takes the difference between the `max` and the `min` of the Dask Array. Also supports an optional `axis` argument. In the default case acts on the flattened array. Documents the function and provides some tests to make sure it behaves ok. Skips implementing the `out` argument as it's unclear what value this provides for Dask Arrays.