### PR TITLE
Skip days in daily_stock that have nan values

### DIFF
--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -190,6 +190,8 @@ def daily_stock(symbol, start, stop, freq=pd.Timedelta(seconds=1),
     divisions = []
     for i, seed in zip(range(len(df)), seeds):
         s = df.iloc[i]
+        if s.isnull().any():
+            continue
         part = delayed(generate_day)(s.name, s.loc['Open'], s.loc['High'], s.loc['Low'],
                                      s.loc['Close'], s.loc['Volume'],
                                      freq=freq, random_state=seed)


### PR DESCRIPTION
Some of the data sources fail to include complete data for some days.
We just skip those days.

I apologize for the lack of tests on this.  The support in
pandas_datareader is currently broken in a few ways that makes testing
this difficult.