### PR TITLE
Use travis conditional builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 os: linux
 
 _base_envs:
-  - &coverage COVERAGE='true' PARALLEL='true'
+  - &coverage COVERAGE='true' PARALLEL='false'
   - &no_coverage COVERAGE='false' PARALLEL='true'
   - &optimize PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
   - &no_optimize XTRATESTARGS=
@@ -37,7 +37,7 @@ jobs:
       - *no_coverage
       - *optimize
       - *no_imports
-      if: branch = master
+      if: type != pull_request
 
     - env:
       - PYTHON=3.5
@@ -56,7 +56,7 @@ jobs:
       - *imports
 
     - env: *py36_env
-      if: branch = master
+      if: type != pull_request
       os: osx
 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,40 @@
 language: generic
 sudo: false
 dist: trusty
+os: linux
 
-env:
-  matrix:
-    - PYTHON=2.7 NUMPY=1.12.1 PANDAS=0.19.2 COVERAGE='true' PARALLEL='false' TEST_IMPORTS='false' XTRATESTARGS=
-    - PYTHON=2.7 NUMPY=1.13.0 PANDAS=0.20.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='false' PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
-    - PYTHON=3.4 NUMPY=1.10.4 PANDAS=0.19.1 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='false' PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
-    - PYTHON=3.5 NUMPY=1.12.1 PANDAS=0.19.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='false' XTRATESTARGS=
-    - PYTHON=3.6 NUMPY=1.13.0 PANDAS=0.20.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='true' XTRATESTARGS=
-
-matrix:
+jobs:
   fast_finish: true
   include:
-  - os: osx
-    env: PYTHON=3.6 NUMPY=1.12.1 PANDAS=0.19.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='true' XTRATESTARGS=
-  # Together with fast_finish, allow build to be marked successful before the OS X job finishes
-  allow_failures:
-  - os: osx
-    # This needs to be the exact same line as above
-    env: PYTHON=3.6 NUMPY=1.12.1 PANDAS=0.19.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='true' XTRATESTARGS=
+      - env: PYTHON=2.7 NUMPY=1.12.1 PANDAS=0.19.2 COVERAGE='true' PARALLEL='false' TEST_IMPORTS='false' XTRATESTARGS=
 
-install: source continuous_integration/travis/install.sh
+      - env: PYTHON=2.7 NUMPY=1.13.0 PANDAS=0.20.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='false' PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
+
+      - env: PYTHON=3.4 NUMPY=1.10.4 PANDAS=0.19.1 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='false' PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
+        if: branch = master
+
+      - env: PYTHON=3.5 NUMPY=1.12.1 PANDAS=0.19.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='false' XTRATESTARGS=
+
+      - env: PYTHON=3.6 NUMPY=1.13.0 PANDAS=0.20.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='true' XTRATESTARGS=
+
+      - env: PYTHON=3.6 NUMPY=1.13.0 PANDAS=0.20.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='true' XTRATESTARGS=
+        if: branch = master
+        os: osx
+
+  allow_failures:
+    - os: osx
+
+install:
+  - source continuous_integration/travis/install.sh
+
 script:
   - source continuous_integration/travis/run_tests.sh
   - flake8 dask
   - pycodestyle --select=E722 dask  # check for bare `except:` blocks
   - if [[ $TEST_IMPORTS == 'true' ]]; then source continuous_integration/travis/test_imports.sh; fi
-after_success: source continuous_integration/travis/after_success.sh
+
+after_success:
+  - source continuous_integration/travis/after_success.sh
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,65 @@ sudo: false
 dist: trusty
 os: linux
 
+_base_envs:
+  - &coverage COVERAGE='true' PARALLEL='true'
+  - &no_coverage COVERAGE='false' PARALLEL='true'
+  - &optimize PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
+  - &no_optimize XTRATESTARGS=
+  - &imports TEST_IMPORTS='true'
+  - &no_imports TEST_IMPORTS='false'
+
 jobs:
   fast_finish: true
   include:
-      - env: PYTHON=2.7 NUMPY=1.12.1 PANDAS=0.19.2 COVERAGE='true' PARALLEL='false' TEST_IMPORTS='false' XTRATESTARGS=
+    - env:
+      - PYTHON=2.7
+      - NUMPY=1.12.1
+      - PANDAS=0.19.2
+      - *coverage
+      - *no_optimize
+      - *no_imports
 
-      - env: PYTHON=2.7 NUMPY=1.13.0 PANDAS=0.20.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='false' PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
+    - env:
+      - PYTHON=2.7
+      - NUMPY=1.13.0
+      - PANDAS=0.20.2
+      - *no_coverage
+      - *optimize
+      - *no_imports
 
-      - env: PYTHON=3.4 NUMPY=1.10.4 PANDAS=0.19.1 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='false' PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
-        if: branch = master
+    - env:
+      - PYTHON=3.4
+      - NUMPY=1.10.4
+      - PANDAS=0.19.1
+      - *no_coverage
+      - *optimize
+      - *no_imports
+      if: branch = master
 
-      - env: PYTHON=3.5 NUMPY=1.12.1 PANDAS=0.19.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='false' XTRATESTARGS=
+    - env:
+      - PYTHON=3.5
+      - NUMPY=1.12.1
+      - PANDAS=0.19.2
+      - *no_coverage
+      - *no_optimize
+      - *no_imports
 
-      - env: PYTHON=3.6 NUMPY=1.13.0 PANDAS=0.20.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='true' XTRATESTARGS=
+    - env: &py36_env
+      - PYTHON=3.6
+      - NUMPY=1.13.0
+      - PANDAS=0.20.2
+      - *no_coverage
+      - *no_optimize
+      - *imports
 
-      - env: PYTHON=3.6 NUMPY=1.13.0 PANDAS=0.20.2 COVERAGE='false' PARALLEL='true' TEST_IMPORTS='true' XTRATESTARGS=
-        if: branch = master
-        os: osx
+    - env: *py36_env
+      if: branch = master
+      os: osx
 
   allow_failures:
     - os: osx
+
 
 install:
   - source continuous_integration/travis/install.sh


### PR DESCRIPTION
Attempt to speed up travis builds by only running certain builds on merge to master.

This only runs tests on 3.4 and osx when committing to master.

Also clean up the environment descriptions to use references, making the configuration a bit easier to read.