### PR TITLE
Add apply_along_axis

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -10,7 +10,7 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        vstack, hstack, compress, extract, round, count_nonzero,
                        flatnonzero, nonzero, around, isnull, notnull, isclose,
                        corrcoef, swapaxes, tensordot, transpose, dot,
-                       result_type)
+                       apply_along_axis, result_type)
 from .reshape import reshape
 from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
         true_divide, floor_divide, negative, power, remainder, mod, conj, exp,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -184,7 +184,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
 
     # Rechunk so that func1d is applied over the full axis.
     arr = arr.rechunk(
-        axis * (1,) + arr.shape[axis:axis + 1] + (arr.ndim - axis) * (1,)
+        arr.chunks[:axis] + (arr.shape[axis:axis + 1],) + arr.chunks[axis + 1:]
     )
 
     # Map func1d over the data to get the result

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -3,6 +3,7 @@ from __future__ import division, print_function, absolute_import
 import inspect
 import warnings
 from collections import Iterable
+from distutils.version import LooseVersion
 from functools import wraps, partial
 from itertools import product
 from numbers import Integral
@@ -181,6 +182,13 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     # Test out some data with the function.
     test_data = np.ones((1,), dtype=arr.dtype)
     test_result = np.array(func1d(test_data, *args, **kwargs))
+
+    if (LooseVersion(np.__version__) < LooseVersion("1.13.0") and
+            (np.array(test_result.shape) > 1).sum() > 1):
+            raise ValueError(
+                "Only one non-trivial dimension allowed in result. "
+                "Need NumPy 1.13.0+ for this functionality."
+            )
 
     # Rechunk so that func1d is applied over the full axis.
     arr = arr.rechunk(

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -104,6 +104,28 @@ def test_dot_method():
     assert_eq(a.dot(b), x.dot(y))
 
 
+@pytest.mark.parametrize('func1d_name, func1d', [
+    ["ndim", lambda x: x.ndim],
+    ["sum", lambda x: x.sum()],
+    ["range", lambda x: [x.min(), x.max()]],
+    ["range2", lambda x: [[x.min()], [x.max()]]],
+])
+@pytest.mark.parametrize('shape, axis', [
+    [(10, 15, 20), 0],
+    [(10, 15, 20), 1],
+    [(10, 15, 20), 2],
+    [(10, 15, 20), -1],
+])
+def test_apply_along_axis(func1d_name, func1d, shape, axis):
+    a = np.random.randint(0, 10, shape)
+    d = da.from_array(a, chunks=(len(shape) * (5,)))
+
+    assert_eq(
+        da.apply_along_axis(func1d, axis, d),
+        np.apply_along_axis(func1d, axis, a)
+    )
+
+
 @pytest.mark.parametrize('shape, axis', [
     [(10, 15, 20), None],
     [(10, 15, 20), 0],

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -117,6 +117,14 @@ def test_dot_method():
     [(10, 15, 20), -1],
 ])
 def test_apply_along_axis(func1d_name, func1d, shape, axis):
+    if (func1d_name == "range2" and
+            LooseVersion(np.__version__) < LooseVersion("1.13.0")):
+            pytest.skip(
+                "NumPy %s doesn't support multidimensional results with"
+                " `apply_along_axis`. Need NumPy 1.13.0 or greater."
+                "" % np.__version__
+            )
+
     a = np.random.randint(0, 10, shape)
     d = da.from_array(a, chunks=(len(shape) * (5,)))
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -108,7 +108,7 @@ def test_dot_method():
     ["ndim", lambda x: x.ndim],
     ["sum", lambda x: x.sum()],
     ["range", lambda x: [x.min(), x.max()]],
-    ["range2", lambda x: [[x.min()], [x.max()]]],
+    ["range2", lambda x: [[x.min(), x.max()], [x.max(), x.min()]]],
 ])
 @pytest.mark.parametrize('shape, axis', [
     [(10, 15, 20), 0],
@@ -117,21 +117,18 @@ def test_dot_method():
     [(10, 15, 20), -1],
 ])
 def test_apply_along_axis(func1d_name, func1d, shape, axis):
-    if (func1d_name == "range2" and
-            LooseVersion(np.__version__) < LooseVersion("1.13.0")):
-            pytest.skip(
-                "NumPy %s doesn't support multidimensional results with"
-                " `apply_along_axis`. Need NumPy 1.13.0 or greater."
-                "" % np.__version__
-            )
-
     a = np.random.randint(0, 10, shape)
     d = da.from_array(a, chunks=(len(shape) * (5,)))
 
-    assert_eq(
-        da.apply_along_axis(func1d, axis, d),
-        np.apply_along_axis(func1d, axis, a)
-    )
+    if (func1d_name == "range2" and
+            LooseVersion(np.__version__) < LooseVersion("1.13.0")):
+        with pytest.raises(ValueError):
+            da.apply_along_axis(func1d, axis, d)
+    else:
+        assert_eq(
+            da.apply_along_axis(func1d, axis, d),
+            np.apply_along_axis(func1d, axis, a)
+        )
 
 
 @pytest.mark.parametrize('shape, axis', [

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -9,6 +9,7 @@ Top level user functions:
    all
    angle
    any
+   apply_along_axis
    arange
    arccos
    arccosh
@@ -324,6 +325,7 @@ Other functions
 .. autofunction:: all
 .. autofunction:: angle
 .. autofunction:: any
+.. autofunction:: apply_along_axis
 .. autofunction:: arange
 .. autofunction:: arccos
 .. autofunction:: arccosh


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask/dask/issues/2390 ).

Implements `apply_along_axis` for Dask Arrays. Includes tests to ensure it can handle a variety of axes arguments, result shapes, and result types like NumPy's implementation. Adds `apply_along_axis` to Dask Array's public API and documents it.