### PR TITLE
Add apply_over_axes

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -10,7 +10,7 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        vstack, hstack, compress, extract, round, count_nonzero,
                        flatnonzero, nonzero, around, isnull, notnull, isclose,
                        corrcoef, swapaxes, tensordot, transpose, dot,
-                       apply_along_axis, result_type)
+                       apply_along_axis, apply_over_axes, result_type)
 from .reshape import reshape
 from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
         true_divide, floor_divide, negative, power, remainder, mod, conj, exp,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -213,6 +213,34 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     return result
 
 
+@wraps(np.apply_over_axes)
+def apply_over_axes(func, a, axes):
+    # Validate arguments
+    a = asarray(a)
+    try:
+        axes = tuple(axes)
+    except TypeError:
+        axes = (axes,)
+
+    sl = a.ndim * (slice(None),)
+
+    # Compute using `apply_along_axis`.
+    result = a
+    for i in axes:
+        result = apply_along_axis(func, i, result, 0)
+
+        # Restore original dimensionality or error.
+        if result.ndim == (a.ndim - 1):
+            result = result[sl[:i] + (None,)]
+        elif result.ndim != a.ndim:
+            raise ValueError(
+                "func must either preserve dimensionality of the input"
+                " or reduce it by one."
+            )
+
+    return result
+
+
 @wraps(np.ptp)
 def ptp(a, axis=None):
     return a.max(axis=axis) - a.min(axis=axis)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -131,6 +131,37 @@ def test_apply_along_axis(func1d_name, func1d, shape, axis):
         )
 
 
+@pytest.mark.parametrize('func_name, func', [
+    ["sum0", lambda x, axis: x.sum(axis=axis)],
+    ["sum1", lambda x, axis: x.sum(axis=axis, keepdims=True)],
+    [
+        "range", lambda x, axis:
+            np.concatenate(
+                [
+                    x.min(axis=axis, keepdims=True),
+                    x.max(axis=axis, keepdims=True)
+                ],
+                axis=axis
+            )
+    ],
+])
+@pytest.mark.parametrize('shape, axes', [
+    [(10, 15, 20), tuple()],
+    [(10, 15, 20), 0],
+    [(10, 15, 20), (1,)],
+    [(10, 15, 20), (-1, 1)],
+    [(10, 15, 20), (2, 0, 1)],
+])
+def test_apply_over_axes(func_name, func, shape, axes):
+    a = np.random.randint(0, 10, shape)
+    d = da.from_array(a, chunks=(len(shape) * (5,)))
+
+    assert_eq(
+        da.apply_over_axes(func, d, axes),
+        np.apply_over_axes(func, a, axes)
+    )
+
+
 @pytest.mark.parametrize('shape, axis', [
     [(10, 15, 20), None],
     [(10, 15, 20), 0],

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -10,6 +10,7 @@ Top level user functions:
    angle
    any
    apply_along_axis
+   apply_over_axes
    arange
    arccos
    arccosh
@@ -326,6 +327,7 @@ Other functions
 .. autofunction:: angle
 .. autofunction:: any
 .. autofunction:: apply_along_axis
+.. autofunction:: apply_over_axes
 .. autofunction:: arange
 .. autofunction:: arccos
 .. autofunction:: arccosh


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/2390

Implements `apply_over_axes` for Dask Arrays. Includes tests to ensure it can handle a variety of axes arguments, result shapes, and result types like NumPy's implementation. Adds `apply_over_axes` to Dask Array's public API and documents it. This implementation leverages Dask Array's `apply_along_axis` to do the heavy lifting.