### PR TITLE
Tweak apply_along_axis's pre-NumPy 1.13.0 error

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -184,7 +184,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     test_result = np.array(func1d(test_data, *args, **kwargs))
 
     if (LooseVersion(np.__version__) < LooseVersion("1.13.0") and
-            (np.array(test_result.shape) > 1).sum() > 1):
+            (np.array(test_result.shape) > 1).sum(dtype=int) > 1):
             raise ValueError(
                 "Only one non-trivial dimension allowed in result. "
                 "Need NumPy 1.13.0+ for this functionality."

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -186,7 +186,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     if (LooseVersion(np.__version__) < LooseVersion("1.13.0") and
             (np.array(test_result.shape) > 1).sum(dtype=int) > 1):
             raise ValueError(
-                "Only one non-trivial dimension allowed in result. "
+                "No more than one non-trivial dimension allowed in result. "
                 "Need NumPy 1.13.0+ for this functionality."
             )
 


### PR DESCRIPTION
Some small tweaks to PR ( https://github.com/dask/dask/pull/2698 ).

Basically just adjusts an error message that `apply_along_axis` would raise if `func1d` would return a result with dimensionality higher than 1-D while using a NumPy prior to 1.13.0, which would not support such behavior. The tweaks are listed below.

* Ensures that summing of non-trivial axes occurs in an integral type. Promotion to an integral type would happen anyways by default, but it is good to be explicit.
* Changes the error message to specifically disallow more than one non-trivial dimension. Previously this sound like having no non-trivial dimensions (e.g. a scalar) was disallowed.