### PR TITLE
Use apply_along_axis name in Dask

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -199,6 +199,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     # Adds other axes as needed.
     result = arr.map_blocks(
         _inner_apply_along_axis,
+        token="apply_along_axis",
         dtype=test_result.dtype,
         chunks=(arr.chunks[:axis] + test_result.shape + arr.chunks[axis + 1:]),
         drop_axis=axis,


### PR DESCRIPTION
Tweak to PR ( https://github.com/dask/dask/pull/2698 ).

Previously an internal function was being used to name the `apply_along_axis` operation in the Dask graph. This is a bit confusing and not really what we want the user to see. So instead use `apply_along_axis` as the name in the Dask graph to make things a bit clearer.