### PR TITLE
Call mkdir from correct namespace in array.to_npy_stack.

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3177,7 +3177,7 @@ def to_npy_stack(dirname, x, axis=0):
     xx = x.rechunk(chunks)
 
     if not os.path.exists(dirname):
-        os.path.mkdir(dirname)
+        os.mkdir(dirname)
 
     meta = {'chunks': chunks, 'dtype': x.dtype, 'axis': axis}
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1709,11 +1709,12 @@ def test_to_npy_stack():
     d = da.from_array(x, chunks=(2, 4, 4))
 
     with tmpdir() as dirname:
-        da.to_npy_stack(dirname+'/test', d, axis=0)
-        assert os.path.exists(os.path.join(dirname, '0.npy'))
-        assert (np.load(os.path.join(dirname, '1.npy')) == x[2:4]).all()
+        stackdir = os.path.join(dirname, 'test')
+        da.to_npy_stack(stackdir, d, axis=0)
+        assert os.path.exists(os.path.join(stackdir, '0.npy'))
+        assert (np.load(os.path.join(stackdir, '1.npy')) == x[2:4]).all()
 
-        e = da.from_npy_stack(dirname)
+        e = da.from_npy_stack(stackdir)
         assert_eq(d, e)
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1709,7 +1709,7 @@ def test_to_npy_stack():
     d = da.from_array(x, chunks=(2, 4, 4))
 
     with tmpdir() as dirname:
-        da.to_npy_stack(dirname, d, axis=0)
+        da.to_npy_stack(dirname+'/test', d, axis=0)
         assert os.path.exists(os.path.join(dirname, '0.npy'))
         assert (np.load(os.path.join(dirname, '1.npy')) == x[2:4]).all()
 


### PR DESCRIPTION
Correctly call mkdir from the os namespace, not the os.path namespace.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
