### PR TITLE
Remove unnecessary map_partitions in aggregate

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -453,7 +453,7 @@ def _build_agg_args(spec):
 
         impls = _build_agg_args_single(result_column, func, input_column)
 
-        # overwrite existing result-columns, generate intermedates only once
+        # overwrite existing result-columns, generate intermediates only once
         chunks.update((spec[0], spec) for spec in impls['chunk_funcs'])
         aggs.update((spec[0], spec) for spec in impls['aggregate_funcs'])
 
@@ -632,9 +632,13 @@ def _compute_sum_of_squares(grouped, column):
     return base.apply(lambda x: (x ** 2).sum())
 
 
-def _agg_finalize(df, funcs):
+def _agg_finalize(df, aggregate_funcs, finalize_funcs, level):
+    # finish the final aggregation level
+    df = _groupby_apply_funcs(df, funcs=aggregate_funcs, level=level)
+
+    # and finalize the result
     result = collections.OrderedDict()
-    for result_column, func, kwargs in funcs:
+    for result_column, func, kwargs in finalize_funcs:
         result[result_column] = func(df, **kwargs)
 
     return pd.DataFrame(result)
@@ -996,18 +1000,19 @@ class _GroupBy(object):
         else:
             chunk_args = [self.obj] + self.index
 
-        obj = aca(chunk_args,
-                  chunk=_groupby_apply_funcs,
-                  chunk_kwargs=dict(funcs=chunk_funcs),
-                  aggregate=_groupby_apply_funcs,
-                  aggregate_kwargs=dict(funcs=aggregate_funcs, level=levels),
-                  combine=_groupby_apply_funcs,
-                  combine_kwargs=dict(funcs=aggregate_funcs, level=levels),
-                  token='aggregate', split_every=split_every,
-                  split_out=split_out, split_out_setup=split_out_on_index)
-
-        return map_partitions(_agg_finalize, obj, token='aggregate-finalize',
-                              funcs=finalizers)
+        return aca(chunk_args,
+                   chunk=_groupby_apply_funcs,
+                   chunk_kwargs=dict(funcs=chunk_funcs),
+                   combine=_groupby_apply_funcs,
+                   combine_kwargs=dict(funcs=aggregate_funcs, level=levels),
+                   aggregate=_agg_finalize,
+                   aggregate_kwargs=dict(
+                       aggregate_funcs=aggregate_funcs,
+                       finalize_funcs=finalizers,
+                       level=levels,
+                   ),
+                   token='aggregate', split_every=split_every,
+                   split_out=split_out, split_out_setup=split_out_on_index)
 
     @insert_meta_param_description(pad=12)
     def apply(self, func, meta=no_default):

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -714,6 +714,9 @@ class itemgetter(object):
     def __reduce__(self):
         return (itemgetter, (self.index,))
 
+    def __eq__(self, other):
+        return type(self) is type(other) and self.index == other.index
+
 
 class MethodCache(object):
     """Attribute access on this object returns a methodcaller for that


### PR DESCRIPTION
As the title suggests: this pr streamlines the aggregate implementation by merging the finalizer and the last aggregation into a single aggregate function passed to `aca`.  Thereby this pr addresses [the issue](https://github.com/dask/dask/issues/2708) of metadata detection with custom aggregates. 

I changed the core dask object `itemgetter` by adding `__eq__`. This allows to compare dasks that include it in their graph. If preferred, I can also remove the `__eq__` impl and change the test to only compare keys not full items.

As an additional test I added the implementation of a mode function that would fail with the old code.

Locally: 

- [x] Tests added / passed
- [x] Passes `flake8 dask`

No additional docs since no user facing interface changes.