### PR TITLE
Pass on file_scheme to fastparquet

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -103,7 +103,8 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
 
     dsk = {(name, i): (_read_parquet_row_group, myopen, pf.row_group_filename(rg),
                        index_col, all_columns, rg, out_type == Series,
-                       categories, pf.schema, pf.cats, pf.dtypes)
+                       categories, pf.schema, pf.cats, pf.dtypes,
+                       pf.file_scheme)
            for i, rg in enumerate(rgs)}
 
     if not dsk:
@@ -131,7 +132,7 @@ def _read_fastparquet(fs, paths, myopen, columns=None, filters=None,
 
 
 def _read_parquet_row_group(open, fn, index, columns, rg, series, categories,
-                            schema, cs, dt, *args):
+                            schema, cs, dt, scheme, *args):
     if not isinstance(columns, (tuple, list)):
         columns = (columns,)
         series = True
@@ -139,7 +140,7 @@ def _read_parquet_row_group(open, fn, index, columns, rg, series, categories,
         columns = columns + type(columns)([index])
     df, views = _pre_allocate(rg.num_rows, columns, categories, index, cs, dt)
     read_row_group_file(fn, rg, columns, categories, schema, cs,
-                        open=open, assign=views)
+                        open=open, assign=views, scheme=scheme)
 
     if series:
         return df[df.columns[0]]

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -532,7 +532,7 @@ def test_drill_scheme(fn):
     fastparquet.write(files[1], df2)
 
     df = dd.read_parquet(files)
-    assert 'dir0' in df
+    assert 'dir0' in df.columns
     out = df.compute()
     assert 'dir0' in out
     assert (np.unique(out.dir0) == ['test_data1', 'test_data2']).all()

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -513,3 +513,25 @@ def test_timestamp96(fn):
     assert pf._schema[1].type == fastparquet.parquet_thrift.Type.INT96
     out = dd.read_parquet(fn).compute()
     assert_eq(out, df)
+
+
+def test_drill_scheme(fn):
+    N = 5
+    df1 = pd.DataFrame({c: np.random.random(N)
+                        for i, c in enumerate(['a', 'b', 'c'])})
+    df2 = pd.DataFrame({c: np.random.random(N)
+                        for i, c in enumerate(['a', 'b', 'c'])})
+    files = []
+    for d in ['test_data1', 'test_data2']:
+        dn = os.path.join(fn, d)
+        if not os.path.exists(dn):
+            os.mkdir(dn)
+        files.append(os.path.join(dn, 'data1.parq'))
+
+    fastparquet.write(files[0], df1)
+    fastparquet.write(files[1], df2)
+
+    df = dd.read_parquet(files)
+    out = df.compute()
+    assert 'dir0' in out
+    assert (np.unique(out.dir0) == ['test_data1', 'test_data2']).all()

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -532,6 +532,7 @@ def test_drill_scheme(fn):
     fastparquet.write(files[1], df2)
 
     df = dd.read_parquet(files)
+    assert 'dir0' in df
     out = df.compute()
     assert 'dir0' in out
     assert (np.unique(out.dir0) == ['test_data1', 'test_data2']).all()


### PR DESCRIPTION
- [x ] Tests added / passed
- [x ] Passes `flake8 dask`
- [x ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API (none needed - bug fix)

Fixes https://github.com/dask/fastparquet/issues/221