### PR TITLE
Support indexing with np.int

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -751,7 +751,7 @@ def normalize_index(idx, shape):
     idx = replace_ellipsis(len(shape), idx)
     n_sliced_dims = 0
     for i in idx:
-        if hasattr(i, 'ndim'):
+        if hasattr(i, 'ndim') and i.ndim >= 1:
             n_sliced_dims += i.ndim
         elif i is None:
             continue

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1626,12 +1626,26 @@ def test_slice_with_floats():
         d[[1, 1.5]]
 
 
-def test_slice_with_uint():
+def test_slice_with_integer_types():
     x = np.arange(10)
     dx = da.from_array(x, chunks=5)
     inds = np.array([0, 3, 6], dtype='u8')
     assert_eq(dx[inds], x[inds])
     assert_eq(dx[inds.astype('u4')], x[inds.astype('u4')])
+
+    inds = np.array([0, 3, 6], dtype=np.int64)
+    assert_eq(dx[inds], x[inds])
+    assert_eq(dx[inds.astype('u4')], x[inds.astype('u4')])
+
+
+def test_index_with_integer_types():
+    x = np.arange(10)
+    dx = da.from_array(x, chunks=5)
+    inds = int(3)
+    assert_eq(dx[inds], x[inds])
+
+    inds = np.int64(3)
+    assert_eq(dx[inds], x[inds])
 
 
 def test_vindex_basic():

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 Array
 +++++
 
--
+-  Indexing with np.int (:pr:`2718`)
 
 
 DataFrame


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API

Fixes #2718