### PR TITLE
Register assertion rewriting

### DIFF
--- a/dask/array/conftest.py
+++ b/dask/array/conftest.py
@@ -1,6 +1,10 @@
 import os
 
+import pytest
+
 
 def pytest_ignore_collect(path, config):
     if os.path.split(str(path))[1].startswith("fft.py"):
         return True
+
+pytest.register_assert_rewrite('dask.array.utils')


### PR DESCRIPTION
Thoughts on this? May make debugging a bit easier, as a small comparison:

```
...
        if str(adt) != str(bdt):
            diff = difflib.ndiff(str(adt).splitlines(), str(bdt).splitlines())
            raise AssertionError('string repr are different' + os.linesep +
                                 os.linesep.join(diff))

        try:
>           assert a.shape == b.shape
E           AssertionError

dask/array/utils.py:99: AssertionError
```

vs.

```
...
        if str(adt) != str(bdt):
            diff = difflib.ndiff(str(adt).splitlines(), str(bdt).splitlines())
            raise AssertionError('string repr are different' + os.linesep +
                                 os.linesep.join(diff))

        try:
>           assert a.shape == b.shape
E           assert (4, 3) == (3, 4)
E             At index 0 diff: 4 != 3
E             Use -v to get the full diff

dask/array/utils.py:99: AssertionError
```

For arrays, it's a bit more (too?) verbose:

```
        try:
            assert a.shape == b.shape
>           assert allclose(a, b, **kwargs)
E           assert False
E            +  where False = allclose(array([[ 0.,  0.,  0.],\n       [ 0.,  0.,  0.],\n       [ 0.,  0.,  0.],\n       [ 0.,  0.,  0.]]), array([[ 1.,  1.,  1.],\n       [ 1.,  1.,  1.],\n       [ 1.,  1.,  1.],\n       [ 1.,  1.,  1.]]), **{})

dask/array/utils.py:100: AssertionError
```

although if I change `assert_eq` to use `numpy.testing.assert_allclose`, the output looks like:

```python
E           AssertionError:
E           Not equal to tolerance rtol=1e-07, atol=0
E
E           (mismatch 100.0%)
E            x: array([[ 0.,  0.,  0.],
E                  [ 0.,  0.,  0.],
E                  [ 0.,  0.,  0.],
E                  [ 0.,  0.,  0.]])
E            y: array([[ 1.,  1.,  1.],
E                  [ 1.,  1.,  1.],
E                  [ 1.,  1.,  1.],
E                  [ 1.,  1.,  1.]])

```