### PR TITLE
Document instructions for minmal dask-core install

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,15 +12,19 @@ Conda
 
 Dask is installed by default in `Anaconda <https://www.anaconda.com/download/>`_::
 
-You can update Dask using `conda <https://www.anaconda.com/download/>`_::
+You can update Dask using the `conda <https://www.anaconda.com/download/>`_: command:
 
-    conda install dask
+*   ``conda install dask``               : Installs dask from the default channel (recommended)
+*   ``conda install -c conda-forge dask``: Installs dask from `conda-forge <https://conda-forge.github.io/>`_.
 
-This installs Dask and all common dependencies, including Pandas and NumPy.
+This installs Dask and **all** common dependencies, including Pandas and NumPy.
 
-Dask packages are maintained both on the default channel and on and
-`conda-forge <https://conda-forge.github.io/>`_.
+Optionally, you can obtain a no frills dask installation using:
 
+*   ``conda install dask-core``                : Installs dask-core from the default channel (recommended)
+*   ``conda install -c conda-forge dask-core`` : Installs dask-core from `conda-forge <https://conda-forge.github.io/>`_.
+    
+This will install a minimal set of dependencies required to run dask, similar to (but not exactly the same as) ``pip install dask`` below. See https://github.com/conda-forge/dask-feedstock/issues/22 for more information on the large number of dependencies `conda install dask` would pull.
 
 Pip
 ---

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -14,17 +14,17 @@ Dask is installed by default in `Anaconda <https://www.anaconda.com/download/>`_
 
 You can update Dask using the `conda <https://www.anaconda.com/download/>`_: command:
 
-*   ``conda install dask``               : Installs dask from the default channel (recommended)
-*   ``conda install -c conda-forge dask``: Installs dask from `conda-forge <https://conda-forge.github.io/>`_.
+   ``conda install dask``
 
 This installs Dask and **all** common dependencies, including Pandas and NumPy.
 
-Optionally, you can obtain a no frills dask installation using:
+Dask packages are maintained both on the default channel and on `conda-forge <https://conda-forge.github.io/>`_.
 
-*   ``conda install dask-core``                : Installs dask-core from the default channel (recommended)
-*   ``conda install -c conda-forge dask-core`` : Installs dask-core from `conda-forge <https://conda-forge.github.io/>`_.
+Optionally, you can obtain a minimal dask installation using:
+
+   ``conda install dask-core``
     
-This will install a minimal set of dependencies required to run dask, similar to (but not exactly the same as) ``pip install dask`` below. See https://github.com/conda-forge/dask-feedstock/issues/22 for more information on the large number of dependencies `conda install dask` would pull.
+This will install a very minimal set of dependencies required to run dask, similar to (but not exactly the same as) ``pip install dask`` below.
 
 Pip
 ---

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,19 +12,19 @@ Conda
 
 Dask is installed by default in `Anaconda <https://www.anaconda.com/download/>`_::
 
-You can update Dask using the `conda <https://www.anaconda.com/download/>`_: command:
+You can update Dask using the `conda <https://www.anaconda.com/download/>`_ command::
 
-   ``conda install dask``
+   conda install dask
 
 This installs Dask and **all** common dependencies, including Pandas and NumPy.
 
 Dask packages are maintained both on the default channel and on `conda-forge <https://conda-forge.github.io/>`_.
 
-Optionally, you can obtain a minimal dask installation using:
+Optionally, you can obtain a minimal dask installation using the following command::
 
-   ``conda install dask-core``
+   conda install dask-core
     
-This will install a very minimal set of dependencies required to run dask, similar to (but not exactly the same as) ``pip install dask`` below.
+This will install a minimal set of dependencies required to run dask, similar to (but not exactly the same as) ``pip install dask`` below.
 
 Pip
 ---


### PR DESCRIPTION
This pull request's core purpose is to add in instructions for installing dask-core which has less dependency bloat than the default `conda install dask`. A use-case for example is  for developers building docker images that don't want a overly huge image size (see e.g. [here](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#avoid-installing-unnecessary-packages)), or for those who would like to manage the optional dependencies themselves.

Aware of https://github.com/dask/dask/pull/2336 which removes confusion of two channels (default and conda-forge), but seeing as dask-core downloads overwhelming come from the conda-forge channel (>30k vs < 100 see https://anaconda.org/search?q=dask-core), I thought I'd add back in the instructions for conda-forge, but add in 'recommended' in brackets next to default channel so that new users won't be too confused. Open to recommendations on what's better.

External references:
https://pypi.python.org/pypi/dask
https://github.com/conda/conda/pull/4982 (note new optional dependency functionality from conda 4.4.0 onwards)
https://github.com/conda-forge/dask-feedstock/issues/22

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
