### PR TITLE
Preserve singleton chunks in fftshift/ifftshift

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -267,6 +267,9 @@ def _fftshift_helper(x, axes=None, inverse=False):
 
         y = _concatenate([y[r], y[l]], axis=i)
 
+        if len(x.chunks[i]) == 1:
+            y = y.rechunk({i: x.chunks[i]})
+
     return y
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,7 @@ Array
 - Support N-D arrays with ``matmul`` (:pr:`2909`) `John A Kirkham`_
 - Add ``vdot`` (:pr:`2910`) `John A Kirkham`_
 - Add ``meshgrid`` (:pr:`2938`) `John A Kirkham`_
+- Preserve singleton chunks in ``fftshift``/``ifftshift`` (:pr:`2733`) `John A Kirkham`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2725

To ensure that `fftshift` and `ifftshift` provide the same chunking as the input array that they are provided, call `rechunk` on each axis that we have to reorder. Given that we are doing nothing more than restructuring the data (not computing anything on it) and we merely wish to restore the original chunks, rechunking should be pretty reasonable here. Included some tests to ensure the chunking is kept the same.

cc @woozey