### PR TITLE
A few test cleanups

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -1,10 +1,10 @@
 # Install conda
 case "$(uname -s)" in
     'Darwin')
-        MINICONDA_FILENAME="Miniconda3-latest-MacOSX-x86_64.sh"
+        MINICONDA_FILENAME="Miniconda3-4.3.21-MacOSX-x86_64.sh"
         ;;
     'Linux')
-        MINICONDA_FILENAME="Miniconda3-latest-Linux-x86_64.sh"
+        MINICONDA_FILENAME="Miniconda3-4.3.21-Linux-x86_64.sh"
         ;;
     *)  ;;
 esac
@@ -43,13 +43,15 @@ conda install -q -c conda-forge \
     ipython \
     partd \
     psutil \
-    pytables \
     "pytest<=3.1.1" \
     scikit-image \
     scikit-learn \
     scipy \
     sqlalchemy \
     toolz
+
+# install pytables from defaults for now
+conda install -q pytables
 
 pip install -q git+https://github.com/dask/partd --upgrade --no-deps
 pip install -q git+https://github.com/dask/zict --upgrade --no-deps
@@ -84,5 +86,5 @@ pip install -q \
 
 # Install dask
 pip install -q --no-deps -e .[complete]
-echo pip freeze
-pip freeze
+echo conda list
+conda list

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -16,6 +16,11 @@ def test_array():
     assert_eq(da.array(d, ndmin=3, dtype='i8'),
               np.array(x, ndmin=3, dtype='i8'))
 
+    # regression #1847 this shall not raise an exception.
+    x = da.ones((100,3), chunks=10)
+    y = da.array(x)
+    assert isinstance(y, da.Array)
+
 
 def test_transpose():
     x = np.arange(240).reshape((4, 6, 10))

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -12,7 +12,6 @@ from dask.array.slicing import (_sanitize_index_element, _slice_1d,
                                 new_blockdim, sanitize_index, slice_array,
                                 take, normalize_index)
 from dask.array.utils import assert_eq, same_keys
-from dask.compatibility import skip
 
 
 def test_slice_1d():
@@ -364,7 +363,7 @@ class ReturnItem(object):
         return key
 
 
-@skip
+@pytest.mark.skip(reason='really long test')
 def test_slicing_exhaustively():
     x = np.random.rand(6, 7, 8)
     a = da.from_array(x, chunks=(3, 3, 3))

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -242,9 +242,6 @@ def getargspec(func):
         else:
             return _getargspec(func)
 
-def skip(func):
-    return
-
 
 def bind_method(cls, name, func):
     """Bind a method to class

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -27,7 +27,8 @@ else:
 
 
 def set_index(df, index, npartitions=None, shuffle=None, compute=False,
-              drop=True, upsample=1.0, divisions=None, **kwargs):
+              drop=True, upsample=1.0, divisions=None,
+              partition_size=128e6, **kwargs):
     """ See _Frame.set_index for docstring """
     if (isinstance(index, Series) and index._name == df.index._name):
         return df
@@ -65,7 +66,7 @@ def set_index(df, index, npartitions=None, shuffle=None, compute=False,
 
         if repartition:
             total = sum(sizes)
-            npartitions = max(math.ceil(total / 128e6), 1)
+            npartitions = max(math.ceil(total / partition_size), 1)
             npartitions = min(npartitions, df.npartitions)
             n = len(divisions)
             try:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2256,6 +2256,13 @@ def test_attribute_assignment():
     assert_eq(ddf, df.assign(y=df.x + df.y))
 
 
+def test_setitem_triggering_realign():
+    a = dd.from_pandas(pd.DataFrame({"A": range(12)}), npartitions=3)
+    b = dd.from_pandas(pd.Series(range(12), name='B'), npartitions=4)
+    a['C'] = b
+    assert len(a) == 12
+
+
 def test_inplace_operators():
     df = pd.DataFrame({'x': [1, 2, 3, 4, 5],
                        'y': [1., 2., 3., 4., 5.]})

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -514,20 +514,3 @@ def test_optimize_None():
 
     with dask.set_options(array_optimize=None, get=my_get):
         y.compute()
-
-
-def test_array_nondim():
-    # regression #1847 this shall not raise an exception.
-    x = da.ones((100,3), chunks=10)
-    y = da.array(x)
-    assert isinstance(y, da.Array)
-
-
-def test_setitem_triggering_realign():
-    import pandas as pd
-    import dask.dataframe as dd
-
-    a = dd.from_pandas(pd.DataFrame({"A": range(12)}), npartitions=3)
-    b = dd.from_pandas(pd.Series(range(12), name='B'), npartitions=4)
-    a['C'] = b
-    assert len(a) == 12


### PR DESCRIPTION
A few small test cleanups found while working on something else.

- Move a few tests out of `test_base` into the appropriate files (not sure how they ended up here)
- Remove `dask.compatibility.skip` in favor of `pytest.mark.skip`