### PR TITLE
API: Add `.str` accessor for Categorical with object dtype

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -5,6 +5,7 @@ import pandas as pd
 from toolz import partial
 
 from ..utils import derived_from
+from .utils import is_categorical_dtype
 
 
 def maybe_wrap_pandas(obj, x):
@@ -109,7 +110,9 @@ class StringAccessor(Accessor):
     _not_implemented = {'get_dummies'}
 
     def _validate(self, series):
-        if not series.dtype == 'object':
+        if not (series.dtype == 'object' or (
+                is_categorical_dtype(series) and
+                series.cat.categories.dtype == 'object')):
             raise AttributeError("Can only use .str accessor with object dtype")
 
     @derived_from(pd.core.strings.StringMethods)

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -342,3 +342,16 @@ class TestCategoricalAccessor:
         res = db.compute()
         tm.assert_index_equal(db.cat.categories, get_cat(res).categories)
         assert_array_index_eq(db.cat.codes, get_cat(res).codes)
+
+    def test_categorical_string_ops(self):
+        a = pd.Series(['a', 'a', 'b'], dtype='category')
+        da = dd.from_pandas(a, 2)
+        result = da.str.upper()
+        expected = a.str.upper()
+        assert_eq(result, expected)
+
+    def test_categorical_non_string_raises(self):
+        a = pd.Series([1, 2, 3], dtype='category')
+        da = dd.from_pandas(a, 2)
+        with pytest.raises(AttributeError):
+            da.str.upper()

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,7 +13,7 @@ Array
 DataFrame
 +++++++++
 
--
+- Added the `.str` accessor to Categoricals with string categories (:pr:`2743`)
 
 
 Bag


### PR DESCRIPTION
Closes #2740 