### PR TITLE
Dask Collection Interface

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1030,7 +1030,7 @@ class Array(Base):
 
     __dask_optimize__ = globalmethod(optimize, key='array_optimize',
                                      falsey=dont_optimize)
-    __dask_default_get__ = staticmethod(threaded.get)
+    __dask_scheduler__ = staticmethod(threaded.get)
 
     def __dask_postcompute__(self):
         return finalize, ()

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -427,14 +427,14 @@ def diag(v):
                         "got {0}".format(type(v)))
     if v.ndim != 1:
         if v.chunks[0] == v.chunks[1]:
-            dsk = dict(((name, i), (np.diag, row[i])) for (i, row)
-                       in enumerate(v._keys()))
+            dsk = {(name, i): (np.diag, row[i])
+                   for i, row in enumerate(v.__dask_keys__())}
             return Array(sharedict.merge(v.dask, (name, dsk)), name, (v.chunks[0],), dtype=v.dtype)
         else:
             raise NotImplementedError("Extracting diagonals from non-square "
                                       "chunked arrays")
     chunks_1d = v.chunks[0]
-    blocks = v._keys()
+    blocks = v.__dask_keys__()
     dsk = {}
     for i, m in enumerate(chunks_1d):
         for j, n in enumerate(chunks_1d):

--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -100,8 +100,8 @@ def ghost_internal(x, axes):
     """
     dims = list(map(len, x.chunks))
     expand_key2 = partial(expand_key, dims=dims)
-    interior_keys = pipe(x._keys(), flatten, map(expand_key2), map(flatten),
-                         concat, list)
+    interior_keys = pipe(x.__dask_keys__(), flatten, map(expand_key2),
+                         map(flatten), concat, list)
 
     token = tokenize(x, axes)
     name = 'ghost-' + token

--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -5,17 +5,15 @@ from operator import getitem
 import numpy as np
 
 from .core import getter, getter_nofancy, getter_inline
-from ..context import defer_to_globals
 from ..compatibility import zip_longest
 from ..core import flatten, reverse_dict
-from ..optimize import cull, fuse, inline_functions, dont_optimize
+from ..optimize import cull, fuse, inline_functions
 from ..utils import ensure_dict
 
 
 GETTERS = (getter, getter_nofancy, getter_inline, getitem)
 
 
-@defer_to_globals('array_optimize', falsey=dont_optimize)
 def optimize(dsk, keys, fuse_keys=None, fast_functions=None,
              inline_functions_fast_functions=(getter_inline,), rename_fused_keys=True,
              **kwargs):

--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -42,7 +42,7 @@ def percentile(a, q, interpolation='linear'):
     token = tokenize(a, list(q), interpolation)
     name = 'percentile_chunk-' + token
     dsk = dict(((name, i), (_percentile, (key), q, interpolation))
-               for i, key in enumerate(a._keys()))
+               for i, key in enumerate(a.__dask_keys__()))
 
     name2 = 'percentile-' + token
     dsk2 = {(name2, 0): (merge_percentiles, q, [q] * len(a.chunks[0]),

--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -170,7 +170,7 @@ def reshape(x, shape):
     name = 'reshape-' + tokenize(x, shape)
 
     if x.npartitions == 1:
-        key = next(flatten(x._keys()))
+        key = next(flatten(x.__dask_keys__()))
         dsk = {(name,) + (0,) * len(shape): (M.reshape, key, shape)}
         chunks = tuple((d,) for d in shape)
         return Array(sharedict.merge((name, dsk), x.dask), name, chunks,

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -178,7 +178,7 @@ def test_dont_fuse_numpy_arrays():
     for chunks in [(5,), (10,)]:
         y = da.from_array(x, chunks=(10,))
 
-        dsk = y._optimize(y.dask, y._keys())
+        dsk = y.__dask_optimize__(y.dask, y.__dask_keys__())
         assert sum(isinstance(v, np.ndarray) for v in dsk.values()) == 1
 
 
@@ -186,7 +186,7 @@ def test_minimize_data_transfer():
     x = np.ones(100)
     y = da.from_array(x, chunks=25)
     z = y + 1
-    dsk = z._optimize(z.dask, z._keys())
+    dsk = z.__dask_optimize__(z.dask, z.__dask_keys__())
 
     keys = list(dsk)
     results = dask.get(dsk, keys)
@@ -226,7 +226,7 @@ def test_fuse_getter_with_asarray(chunks):
     x = np.ones(10) * 1234567890
     y = da.ones(10, chunks=chunks)
     z = x + y
-    dsk = z._optimize(z.dask, z._keys())
+    dsk = z.__dask_optimize__(z.dask, z.__dask_keys__())
     assert any(v is x for v in dsk.values())
     for v in dsk.values():
         s = str(v)
@@ -246,10 +246,10 @@ def test_turn_off_fusion():
     x = da.ones(10, chunks=(5,))
     y = da.sum(x + 1 + 2 + 3)
 
-    a = y._optimize(y.dask, y._keys())
+    a = y.__dask_optimize__(y.dask, y.__dask_keys__())
 
     with dask.set_options(fuse_ave_width=0):
-        b = y._optimize(y.dask, y._keys())
+        b = y.__dask_optimize__(y.dask, y.__dask_keys__())
 
-    assert dask.get(a, y._keys()) == dask.get(b, y._keys())
+    assert dask.get(a, y.__dask_keys__()) == dask.get(b, y.__dask_keys__())
     assert len(a) < len(b)

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -114,7 +114,7 @@ def test_reductions_2D(dtype):
     a = da.from_array(x, chunks=(4, 4))
 
     b = a.sum(keepdims=True)
-    assert b._keys() == [[(b.name, 0, 0)]]
+    assert b.__dask_keys__() == [[(b.name, 0, 0)]]
 
     reduction_2d_test(da.sum, a, np.sum, x)
     reduction_2d_test(da.prod, a, np.prod, x)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -182,7 +182,7 @@ def to_textfiles(b, path, name_function=None, compression='infer',
     out = [Delayed(w.key, dsk2) for w in writes]
 
     if compute:
-        get = get or _globals.get('get', None) or Bag.__dask_default_get__
+        get = get or _globals.get('get', None) or Bag.__dask_scheduler__
         delayed(out).compute(get=get)
         return names
     else:
@@ -285,7 +285,7 @@ class Item(Base):
 
     __dask_optimize__ = globalmethod(optimize, key='bag_optimize',
                                      falsey=dont_optimize)
-    __dask_default_get__ = staticmethod(mpget)
+    __dask_scheduler__ = staticmethod(mpget)
 
     def __dask_postcompute__(self):
         return finalize_item, ()
@@ -378,7 +378,7 @@ class Bag(Base):
 
     __dask_optimize__ = globalmethod(optimize, key='bag_optimize',
                                      falsey=dont_optimize)
-    __dask_default_get__ = staticmethod(mpget)
+    __dask_scheduler__ = staticmethod(mpget)
 
     def __dask_postcompute__(self):
         return finalize, ()

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -28,14 +28,14 @@ except ImportError:
     from toolz import (frequencies, merge_with, join, reduceby,
                        count, pluck, groupby, topk)
 
-from ..base import Base, normalize_token, tokenize
+from ..base import Base, tokenize, dont_optimize, is_dask_collection
 from ..bytes.core import write_bytes
 from ..compatibility import apply, urlopen
-from ..context import _globals, defer_to_globals
+from ..context import _globals, globalmethod
 from ..core import quote, istask, get_dependencies, reverse_dict
 from ..delayed import Delayed
 from ..multiprocessing import get as mpget
-from ..optimize import fuse, cull, inline, dont_optimize
+from ..optimize import fuse, cull, inline
 from ..utils import (system_encoding, takes_multiple_arguments, funcname,
                      digit, insert, ensure_dict)
 
@@ -106,7 +106,6 @@ def inline_singleton_lists(dsk, dependencies=None):
     return dsk
 
 
-@defer_to_globals('bag_optimize', falsey=dont_optimize)
 def optimize(dsk, keys, fuse_keys=None, rename_fused_keys=True, **kwargs):
     """ Optimize a dask from a dask.bag """
     dsk2, dependencies = cull(dsk, keys)
@@ -179,11 +178,11 @@ def to_textfiles(b, path, name_function=None, compression='infer',
 
     # Use Bag optimizations on these delayed objects
     dsk = ensure_dict(delayed(writes).dask)
-    dsk2 = Bag._optimize(dsk, [w.key for w in writes])
+    dsk2 = Bag.__dask_optimize__(dsk, [w.key for w in writes])
     out = [Delayed(w.key, dsk2) for w in writes]
 
     if compute:
-        get = get or _globals.get('get', None) or Bag._default_get
+        get = get or _globals.get('get', None) or Bag.__dask_default_get__
         delayed(out).compute(get=get)
         return names
     else:
@@ -270,9 +269,29 @@ def robust_wraps(wrapper):
 
 
 class Item(Base):
-    _optimize = staticmethod(optimize)
-    _default_get = staticmethod(mpget)
-    _finalize = staticmethod(finalize_item)
+    def __init__(self, dsk, key):
+        self.dask = dsk
+        self.key = key
+        self.name = key
+
+    def __dask_graph__(self):
+        return self.dask
+
+    def __dask_keys__(self):
+        return [self.key]
+
+    def __dask_tokenize__(self):
+        return self.key
+
+    __dask_optimize__ = globalmethod(optimize, key='bag_optimize',
+                                     falsey=dont_optimize)
+    __dask_default_get__ = staticmethod(mpget)
+
+    def __dask_postcompute__(self):
+        return finalize_item, ()
+
+    def __dask_postpersist__(self):
+        return Item, (self.key,)
 
     @staticmethod
     def from_delayed(value):
@@ -286,11 +305,6 @@ class Item(Base):
         assert isinstance(value, Delayed)
         return Item(ensure_dict(value.dask), value.key)
 
-    def __init__(self, dsk, key):
-        self.dask = dsk
-        self.key = key
-        self.name = key
-
     @property
     def _args(self):
         return (self.dask, self.key)
@@ -300,9 +314,6 @@ class Item(Base):
 
     def __setstate__(self, state):
         self.dask, self.key = state
-
-    def _keys(self):
-        return [self.key]
 
     def apply(self, func):
         name = 'apply-{0}-{1}'.format(funcname(func), tokenize(self, func))
@@ -317,7 +328,8 @@ class Item(Base):
         Returns a single value.
         """
         from dask.delayed import Delayed
-        dsk = self._optimize(self.dask, [self.key])
+        dsk = self.__dask_optimize__(self.__dask_graph__(),
+                                     self.__dask_keys__())
         return Delayed(self.key, dsk)
 
 
@@ -350,14 +362,29 @@ class Bag(Base):
     >>> int(b.fold(lambda x, y: x + y))  # doctest: +SKIP
     30
     """
-    _optimize = staticmethod(optimize)
-    _default_get = staticmethod(mpget)
-    _finalize = staticmethod(finalize)
-
     def __init__(self, dsk, name, npartitions):
         self.dask = dsk
         self.name = name
         self.npartitions = npartitions
+
+    def __dask_graph__(self):
+        return self.dask
+
+    def __dask_keys__(self):
+        return [(self.name, i) for i in range(self.npartitions)]
+
+    def __dask_tokenize__(self):
+        return self.name
+
+    __dask_optimize__ = globalmethod(optimize, key='bag_optimize',
+                                     falsey=dont_optimize)
+    __dask_default_get__ = staticmethod(mpget)
+
+    def __dask_postcompute__(self):
+        return finalize, ()
+
+    def __dask_postpersist__(self):
+        return type(self), (self.name, self.npartitions)
 
     def __str__(self):
         name = self.name if len(self.name) < 10 else self.name[:7] + '...'
@@ -1070,9 +1097,6 @@ class Bag(Base):
         else:
             return b
 
-    def _keys(self):
-        return [(self.name, i) for i in range(self.npartitions)]
-
     def flatten(self):
         """ Concatenate nested lists into one long list
 
@@ -1205,12 +1229,11 @@ class Bag(Base):
         cols = list(meta.columns)
         dtypes = meta.dtypes.to_dict()
         name = 'to_dataframe-' + tokenize(self, cols, dtypes)
-        dsk = {(name, i): (to_dataframe, (self.name, i), cols, dtypes)
-               for i in range(self.npartitions)}
-
+        dsk = self.__dask_optimize__(self.dask, self.__dask_keys__())
+        dsk.update({(name, i): (to_dataframe, (self.name, i), cols, dtypes)
+                    for i in range(self.npartitions)})
         divisions = [None] * (self.npartitions + 1)
-        return dd.DataFrame(merge(optimize(self.dask, self._keys()), dsk),
-                            name, meta, divisions)
+        return dd.DataFrame(dsk, name, meta, divisions)
 
     def to_delayed(self):
         """ Convert bag to list of dask Delayed
@@ -1218,8 +1241,9 @@ class Bag(Base):
         Returns list of Delayed, one per partition.
         """
         from dask.delayed import Delayed
-        dsk = self._optimize(self.dask, self._keys())
-        return [Delayed(k, dsk) for k in self._keys()]
+        keys = self.__dask_keys__()
+        dsk = self.__dask_optimize__(self.__dask_graph__(), keys)
+        return [Delayed(k, dsk) for k in keys]
 
     def repartition(self, npartitions):
         """ Coalesce bag into fewer partitions
@@ -1309,10 +1333,6 @@ def accumulate_part(binop, seq, initial, is_first=False):
     if is_first:
         return res, res[-1] if res else [], initial
     return res[1:], res[-1]
-
-
-normalize_token.register(Item, lambda a: a.key)
-normalize_token.register(Bag, lambda a: a.name)
 
 
 def partition(grouper, sequence, npartitions, p, nelements=2**20):
@@ -1428,8 +1448,8 @@ def concat(bags):
     """
     name = 'concat-' + tokenize(*bags)
     counter = itertools.count(0)
-    dsk = dict(((name, next(counter)), key)
-               for bag in bags for key in sorted(bag._keys()))
+    dsk = {(name, next(counter)): key
+           for bag in bags for key in bag.__dask_keys__()}
     return Bag(merge(dsk, *[b.dask for b in bags]), name, len(dsk))
 
 
@@ -1632,7 +1652,7 @@ def unpack_scalar_dask_kwargs(kwargs):
         if isinstance(v, (Delayed, Item)):
             dsk.update(ensure_dict(v.dask))
             kwargs2[k] = v.key
-        elif isinstance(v, Base):
+        elif is_dask_collection(v):
             raise NotImplementedError("dask.bag doesn't support kwargs of "
                                       "type %s" % type(v).__name__)
         else:
@@ -1802,7 +1822,7 @@ def map_partitions(func, *args, **kwargs):
                 dsk.update(ensure_dict(a.dask))
                 if isinstance(a, Bag):
                     bags.append(a)
-            elif isinstance(a, Base):
+            elif is_dask_collection(a):
                 raise NotImplementedError("dask.bag doesn't support args of "
                                           "type %s" % type(a).__name__)
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -45,7 +45,7 @@ def test_Bag():
 
 
 def test_keys():
-    assert sorted(b._keys()) == sorted(dsk.keys())
+    assert b.__dask_keys__() == sorted(dsk.keys())
 
 
 def test_bag_map():
@@ -1042,7 +1042,7 @@ def test_repartition(nin, nout):
 
     assert c.npartitions == nout
     assert b.compute(get=dask.get) == c.compute(get=dask.get)
-    results = dask.get(c.dask, c._keys())
+    results = dask.get(c.dask, c.__dask_keys__())
     assert all(results)
 
 
@@ -1078,7 +1078,7 @@ def test_accumulate():
 def test_groupby_tasks():
     b = db.from_sequence(range(160), npartitions=4)
     out = b.groupby(lambda x: x % 10, max_branch=4, method='tasks')
-    partitions = dask.get(out.dask, out._keys())
+    partitions = dask.get(out.dask, out.__dask_keys__())
 
     for a in partitions:
         for b in partitions:
@@ -1088,7 +1088,7 @@ def test_groupby_tasks():
     b = db.from_sequence(range(1000), npartitions=100)
     out = b.groupby(lambda x: x % 123, method='tasks')
     assert len(out.dask) < 100**2
-    partitions = dask.get(out.dask, out._keys())
+    partitions = dask.get(out.dask, out.__dask_keys__())
 
     for a in partitions:
         for b in partitions:
@@ -1097,7 +1097,7 @@ def test_groupby_tasks():
 
     b = db.from_sequence(range(10000), npartitions=345)
     out = b.groupby(lambda x: x % 2834, max_branch=24, method='tasks')
-    partitions = dask.get(out.dask, out._keys())
+    partitions = dask.get(out.dask, out.__dask_keys__())
 
     for a in partitions:
         for b in partitions:
@@ -1216,11 +1216,12 @@ def test_optimize_fuse_keys():
     y = x.map(inc)
     z = y.map(inc)
 
-    dsk = z._optimize(z.dask, z._keys())
+    dsk = z.__dask_optimize__(z.dask, z.__dask_keys__())
     assert not set(y.dask) & set(dsk)
 
-    dsk = z._optimize(z.dask, z._keys(), fuse_keys=y._keys())
-    assert all(k in dsk for k in y._keys())
+    dsk = z.__dask_optimize__(z.dask, z.__dask_keys__(),
+                              fuse_keys=y.__dask_keys__())
+    assert all(k in dsk for k in y.__dask_keys__())
 
 
 def test_reductions_are_lazy():

--- a/dask/base.py
+++ b/dask/base.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+from abc import ABCMeta
 from collections import OrderedDict, Iterator
-import copy
 from functools import partial
 from hashlib import md5
 import inspect
@@ -9,32 +9,42 @@ import pickle
 import os
 import threading
 import uuid
+import warnings
 
 from toolz import merge, groupby, curry, identity
 from toolz.functoolz import Compose
 
-from . import sharedict
-from .compatibility import bind_method, long, unicode, PY3
+from .compatibility import long, unicode
 from .context import _globals
 from .core import flatten
 from .hashing import hash_buffer_hex
 from .utils import Dispatch, ensure_dict
-from .sharedict import ShareDict
 
-__all__ = ("Base", "compute", "normalize_token", "tokenize", "visualize")
+
+__all__ = ("DaskMethodsMixin",
+           "is_dask_collection",
+           "compute", "persist", "visualize",
+           "tokenize", "normalize_token")
 
 
 thread_state = threading.local()
 
 
-class Base(object):
-    """Base class for dask collections"""
+def is_dask_collection(x):
+    """Returns ``True`` if ``x`` is a dask collection"""
+    try:
+        return x.__dask_graph__() is not None
+    except AttributeError:
+        return False
+
+
+class DaskMethodsMixin(object):
+    """A mixin adding standard dask collection methods"""
     __slots__ = ()
 
     def visualize(self, filename='mydask', format=None, optimize_graph=False,
                   **kwargs):
-        """
-        Render the computation of this object's task graph using graphviz.
+        """Render the computation of this object's task graph using graphviz.
 
         Requires ``graphviz`` to be installed.
 
@@ -57,7 +67,7 @@ class Base(object):
         result : IPython.diplay.Image, IPython.display.SVG, or None
             See dask.dot.dot_graph for more information.
 
-        See also
+        See Also
         --------
         dask.base.visualize
         dask.dot.dot_graph
@@ -72,15 +82,37 @@ class Base(object):
                          optimize_graph=optimize_graph, **kwargs)
 
     def persist(self, **kwargs):
-        """ Persist this dask collection into memory
+        """Persist this dask collection into memory
 
-        See ``dask.base.persist`` for full docstring
+        This turns a lazy Dask collection into a Dask collection with the same
+        metadata, but now with the results fully computed or actively computing
+        in the background.
+
+        Parameters
+        ----------
+        get : callable, optional
+            A scheduler ``get`` function to use. If not provided, the default
+            is to check the global settings first, and then fall back to
+            the collection defaults.
+        optimize_graph : bool, optional
+            If True [default], the graph is optimized before computation.
+            Otherwise the graph is run as is. This can be useful for debugging.
+        **kwargs
+            Extra keywords to forward to the scheduler ``get`` function.
+
+        Returns
+        -------
+        New dask collections backed by in-memory data
+
+        See Also
+        --------
+        dask.base.persist
         """
         (result,) = persist(self, **kwargs)
         return result
 
     def compute(self, **kwargs):
-        """ Compute this dask collection
+        """Compute this dask collection
 
         This turns a lazy Dask collection into its in-memory equivalent.
         For example a Dask.array turns into a NumPy array and a Dask.dataframe
@@ -98,49 +130,138 @@ class Base(object):
             Otherwise the graph is run as is. This can be useful for debugging.
         kwargs
             Extra keywords to forward to the scheduler ``get`` function.
+
+        See Also
+        --------
+        dask.base.compute
         """
         (result,) = compute(self, traverse=False, **kwargs)
         return result
 
-    @classmethod
-    def _get(cls, dsk, keys, get=None, **kwargs):
-        get = get or _globals['get'] or cls._default_get
-        dsk2 = optimization_function(cls)(ensure_dict(dsk), keys, **kwargs)
-        return get(dsk2, keys, **kwargs)
+
+def call_finalize(finalize, args, results):
+    return finalize(results, *args)
+
+
+def add_ABCMeta(cls):
+    """Use the metaclass ABCMeta for this class"""
+    return ABCMeta(cls.__name__, cls.__bases__, cls.__dict__.copy())
+
+
+# TODO: this class is deprecated and should be removed in a future release.
+@add_ABCMeta
+class Base(DaskMethodsMixin):
+    """DEPRECATED. The recommended way to create a custom dask object now is to
+    implement the dask collection interface (see the docs), and optionally
+    subclass from ``DaskMethodsMixin`` if desired.
+
+    See http://dask.pydata.org/en/latest/custom-collections.html for more
+    information"""
+    __slots__ = ()
 
     @classmethod
-    def _bind_operator(cls, op):
-        """ bind operator to this class """
-        name = op.__name__
+    def __subclasshook__(cls, other):
+        if cls is Base:
+            warnings.warn("DeprecationWarning: `dask.base.Base` is deprecated. "
+                          "To check if an object is a dask collection use "
+                          "dask.base.is_dask_collection.\n\nSee http://dask."
+                          "pydata.org/en/latest/custom-collections.html "
+                          " for more information")
+        return NotImplemented
 
-        if name.endswith('_'):
-            # for and_ and or_
-            name = name[:-1]
-        elif name == 'inv':
-            name = 'invert'
+    def __dask_graph__(self):
+        # We issue a deprecation warning for the whole class here, as any
+        # non-instance check usage will end up calling `__dask_graph__`.
+        warnings.warn("DeprecationWarning: `dask.base.Base` is deprecated. "
+                      "To create a custom dask object implement the dask "
+                      "collection interface, and optionally subclass from "
+                      "``DaskMethodsMixin`` if desired.\n\nSee http://dask."
+                      "pydata.org/en/latest/custom-collections.html "
+                      " for more information")
+        return self.dask
 
-        meth = '__{0}__'.format(name)
+    def _keys(self):
+        warnings.warn("DeprecationWarning: the `_keys` method is deprecated, "
+                      "use `__dask_keys__` instead")
+        return self.__dask_keys__()
 
-        if name in ('abs', 'invert', 'neg', 'pos'):
-            bind_method(cls, meth, cls._get_unary_operator(op))
+    @property
+    def _finalize(self):
+        warnings.warn("DeprecationWarning: the `_finalize` method is "
+                      "deprecated, use `__dask_postcompute__` instead")
+        f, args = self.__dask_postcompute__()
+        return partial(call_finalize, f, args) if args else f
+
+    @classmethod
+    def _optimize(cls, *args, **kwargs):
+        warnings.warn("DeprecationWarning: the `_optimize` method is "
+                      "deprecated, use `__dask_optimize__` instead")
+        return cls.__dask_optimize__(*args, **kwargs)
+
+    @classmethod
+    def _get(cls, dsk, keys, **kwargs):
+        warnings.warn("DeprecationWarning: the `_get` method is "
+                      "deprecated, use ``dask.base.compute_as_if_collection`` "
+                      "instead")
+        return compute_as_if_collection(cls, dsk, keys, **kwargs)
+
+
+def compute_as_if_collection(cls, dsk, keys, get=None, **kwargs):
+    """Compute a graph as if it were of type cls.
+
+    Allows for applying the same optimizations and default scheduler."""
+    get = get or _globals['get'] or cls.__dask_default_get__
+    dsk2 = optimization_function(cls)(ensure_dict(dsk), keys, **kwargs)
+    return get(dsk2, keys, **kwargs)
+
+
+def dont_optimize(dsk, keys, **kwargs):
+    return dsk
+
+
+def optimization_function(x):
+    return getattr(x, '__dask_optimize__', dont_optimize)
+
+
+def collections_to_dsk(collections, optimize_graph=True, **kwargs):
+    """
+    Convert many collections into a single dask graph, after optimization
+    """
+    optimizations = (kwargs.pop('optimizations', None) or
+                     _globals.get('optimizations', []))
+
+    if optimize_graph:
+        groups = groupby(optimization_function, collections)
+        groups = {opt: _extract_graph_and_keys(val)
+                  for opt, val in groups.items()}
+
+        for opt in optimizations:
+            groups = {k: (opt(dsk, keys), keys)
+                      for k, (dsk, keys) in groups.items()}
+
+        dsk = merge(*(opt(dsk, keys, **kwargs)
+                      for opt, (dsk, keys) in groups.items()))
+    else:
+        dsk, _ = _extract_graph_and_keys(collections)
+
+    return dsk
+
+
+def _extract_graph_and_keys(vals):
+    """Given a list of dask vals, return a single graph and a list of keys such
+    that ``get(dsk, keys)`` is equivalent to ``[v.compute() v in vals]``."""
+    dsk = {}
+    keys = []
+    for v in vals:
+        d = v.__dask_graph__()
+        if hasattr(d, 'dicts'):
+            for dd in d.dicts.values():
+                dsk.update(dd)
         else:
-            bind_method(cls, meth, cls._get_binary_operator(op))
+            dsk.update(d)
+        keys.append(v.__dask_keys__())
 
-            if name in ('eq', 'gt', 'ge', 'lt', 'le', 'ne', 'getitem'):
-                return
-
-            rmeth = '__r{0}__'.format(name)
-            bind_method(cls, rmeth, cls._get_binary_operator(op, inv=True))
-
-    @classmethod
-    def _get_unary_operator(cls, op):
-        """ Must return a method used by unary operator """
-        raise NotImplementedError
-
-    @classmethod
-    def _get_binary_operator(cls, op, inv=False):
-        """ Must return a method used by binary operator """
-        raise NotImplementedError
+    return dsk, keys
 
 
 def compute(*args, **kwargs):
@@ -190,7 +311,7 @@ def compute(*args, **kwargs):
                      else a for a in args)
 
     optimize_graph = kwargs.pop('optimize_graph', True)
-    variables = [a for a in args if isinstance(a, Base)]
+    variables = [a for a in args if is_dask_collection(a)]
     if not variables:
         return args
 
@@ -201,21 +322,21 @@ def compute(*args, **kwargs):
         get = get_worker().client.get
 
     if not get:
-        get = variables[0]._default_get
-        if not all(a._default_get == get for a in variables):
+        get = variables[0].__dask_default_get__
+        if not all(a.__dask_default_get__ == get for a in variables):
             raise ValueError("Compute called on multiple collections with "
                              "differing default schedulers. Please specify a "
                              "scheduler `get` function using either "
                              "the `get` kwarg or globally with `set_options`.")
 
     dsk = collections_to_dsk(variables, optimize_graph, **kwargs)
-    keys = [var._keys() for var in variables]
+    keys = [var.__dask_keys__() for var in variables]
+    postcomputes = [a.__dask_postcompute__() if is_dask_collection(a)
+                    else (None, a) for a in args]
     results = get(dsk, keys, **kwargs)
-
     results_iter = iter(results)
-    return tuple(a if not isinstance(a, Base)
-                 else a._finalize(next(results_iter))
-                 for a in args)
+    return tuple(a if f is None else f(next(results_iter), *a)
+                 for f, a in postcomputes)
 
 
 def visualize(*args, **kwargs):
@@ -246,7 +367,7 @@ def visualize(*args, **kwargs):
     result : IPython.diplay.Image, IPython.display.SVG, or None
         See dask.dot.dot_graph for more information.
 
-    See also
+    See Also
     --------
     dask.dot.dot_graph
 
@@ -256,20 +377,186 @@ def visualize(*args, **kwargs):
 
     http://dask.pydata.org/en/latest/optimize.html
     """
+    from dask.dot import dot_graph
 
-    dsks = [arg for arg in args if isinstance(arg, dict)]
-    args = [arg for arg in args if isinstance(arg, Base)]
     filename = kwargs.pop('filename', 'mydask')
     optimize_graph = kwargs.pop('optimize_graph', False)
-    from dask.dot import dot_graph
-    if optimize_graph:
-        dsks.extend([optimization_function(arg)(ensure_dict(arg.dask), arg._keys())
-                     for arg in args])
-    else:
-        dsks.extend([arg.dask for arg in args])
-    dsk = merge(dsks)
+
+    dsks = [arg for arg in args if isinstance(arg, dict)]
+    args = [arg for arg in args if is_dask_collection(arg)]
+
+    dsk = collections_to_dsk(args, optimize_graph=optimize_graph)
+    for d in dsks:
+        dsk.update(d)
 
     return dot_graph(dsk, filename=filename, **kwargs)
+
+
+def persist(*args, **kwargs):
+    """ Persist multiple Dask collections into memory
+
+    This turns lazy Dask collections into Dask collections with the same
+    metadata, but now with their results fully computed or actively computing
+    in the background.
+
+    For example a lazy dask.array built up from many lazy calls will now be a
+    dask.array of the same shape, dtype, chunks, etc., but now with all of
+    those previously lazy tasks either computed in memory as many small NumPy
+    arrays (in the single-machine case) or asynchronously running in the
+    background on a cluster (in the distributed case).
+
+    This function operates differently if a ``dask.distributed.Client`` exists
+    and is connected to a distributed scheduler.  In this case this function
+    will return as soon as the task graph has been submitted to the cluster,
+    but before the computations have completed.  Computations will continue
+    asynchronously in the background.  When using this function with the single
+    machine scheduler it blocks until the computations have finished.
+
+    When using Dask on a single machine you should ensure that the dataset fits
+    entirely within memory.
+
+    Examples
+    --------
+    >>> df = dd.read_csv('/path/to/*.csv')  # doctest: +SKIP
+    >>> df = df[df.name == 'Alice']  # doctest: +SKIP
+    >>> df['in-debt'] = df.balance < 0  # doctest: +SKIP
+    >>> df = df.persist()  # triggers computation  # doctest: +SKIP
+
+    >>> df.value().min()  # future computations are now fast  # doctest: +SKIP
+    -10
+    >>> df.value().max()  # doctest: +SKIP
+    100
+
+    >>> from dask import persist  # use persist function on multiple collections
+    >>> a, b = persist(a, b)  # doctest: +SKIP
+
+    Parameters
+    ----------
+    *args: Dask collections
+    get : callable, optional
+        A scheduler ``get`` function to use. If not provided, the default
+        is to check the global settings first, and then fall back to
+        the collection defaults.
+    optimize_graph : bool, optional
+        If True [default], the graph is optimized before computation.
+        Otherwise the graph is run as is. This can be useful for debugging.
+    **kwargs
+        Extra keywords to forward to the scheduler ``get`` function.
+
+    Returns
+    -------
+    New dask collections backed by in-memory data
+    """
+    collections = [a for a in args if is_dask_collection(a)]
+    if not collections:
+        return args
+
+    get = kwargs.pop('get', None) or _globals['get']
+
+    if get is None and getattr(thread_state, 'key', False):
+        from distributed.worker import get_worker
+        get = get_worker().client.get
+
+    if inspect.ismethod(get):
+        try:
+            from distributed.client import default_client
+        except ImportError:
+            pass
+        else:
+            try:
+                client = default_client()
+            except ValueError:
+                pass
+            else:
+                if client.get == _globals['get']:
+                    collections = client.persist(collections, **kwargs)
+                    if isinstance(collections, list):  # distributed is inconsistent here
+                        collections = tuple(collections)
+                    else:
+                        collections = (collections,)
+                    results_iter = iter(collections)
+                    return tuple(a if not is_dask_collection(a)
+                                 else next(results_iter)
+                                 for a in args)
+
+    optimize_graph = kwargs.pop('optimize_graph', True)
+
+    if not get:
+        get = collections[0].__dask_default_get__
+        if not all(a.__dask_default_get__ == get for a in collections):
+            raise ValueError("Compute called on multiple collections with "
+                             "differing default schedulers. Please specify a "
+                             "scheduler `get` function using either "
+                             "the `get` kwarg or globally with `set_options`.")
+
+    dsk = collections_to_dsk(collections, optimize_graph, **kwargs)
+
+    keys, postpersists = [], []
+    for a in args:
+        if is_dask_collection(a):
+            a_keys = list(flatten(a.__dask_keys__()))
+            rebuild, state = a.__dask_postpersist__()
+            keys.extend(a_keys)
+            postpersists.append((rebuild, a_keys, state))
+        else:
+            postpersists.append((None, None, a))
+
+    results = get(dsk, keys, **kwargs)
+    d = dict(zip(keys, results))
+    return tuple(s if r is None else r({k: d[k] for k in ks}, *s)
+                 for r, ks, s in postpersists)
+
+
+############
+# Tokenize #
+############
+
+def tokenize(*args, **kwargs):
+    """ Deterministic token
+
+    >>> tokenize([1, 2, '3'])
+    '7d6a880cd9ec03506eee6973ff551339'
+
+    >>> tokenize('Hello') == tokenize('Hello')
+    True
+    """
+    if kwargs:
+        args = args + (kwargs,)
+    return md5(str(tuple(map(normalize_token, args))).encode()).hexdigest()
+
+
+normalize_token = Dispatch()
+normalize_token.register((int, long, float, str, unicode, bytes, type(None),
+                          type, slice, complex, type(Ellipsis)),
+                         identity)
+
+
+@normalize_token.register(dict)
+def normalize_dict(d):
+    return normalize_token(sorted(d.items(), key=str))
+
+
+@normalize_token.register(OrderedDict)
+def normalize_ordered_dict(d):
+    return type(d).__name__, normalize_token(list(d.items()))
+
+
+@normalize_token.register(set)
+def normalize_set(s):
+    return normalize_token(sorted(s, key=str))
+
+
+@normalize_token.register((tuple, list))
+def normalize_seq(seq):
+    return type(seq).__name__, list(map(normalize_token, seq))
+
+
+@normalize_token.register(object)
+def normalize_object(o):
+    method = getattr(o, '__dask_tokenize__', None)
+    if method is not None:
+        return method()
+    return normalize_function(o) if callable(o) else uuid.uuid4().hex
 
 
 function_cache = {}
@@ -314,45 +601,6 @@ def _normalize_function(func):
             return cloudpickle.dumps(func, protocol=0)
         except Exception:
             return str(func)
-
-
-normalize_token = Dispatch()
-normalize_token.register((int, long, float, str, unicode, bytes, type(None),
-                          type, slice, complex, type(Ellipsis)),
-                         identity)
-
-
-@normalize_token.register(dict)
-def normalize_dict(d):
-    return normalize_token(sorted(d.items(), key=str))
-
-
-@normalize_token.register(OrderedDict)
-def normalize_ordered_dict(d):
-    return type(d).__name__, normalize_token(list(d.items()))
-
-
-@normalize_token.register(set)
-def normalize_set(s):
-    return normalize_token(sorted(s, key=str))
-
-
-@normalize_token.register((tuple, list))
-def normalize_seq(seq):
-    return type(seq).__name__, list(map(normalize_token, seq))
-
-
-@normalize_token.register(object)
-def normalize_object(o):
-    if callable(o):
-        return normalize_function(o)
-    else:
-        return uuid.uuid4().hex
-
-
-@normalize_token.register(Base)
-def normalize_base(b):
-    return type(b).__name__, b.key
 
 
 @normalize_token.register_lazy("pandas")
@@ -422,195 +670,3 @@ def register_numpy():
                 return 'np.' + name
         except AttributeError:
             return normalize_function(x)
-
-
-def tokenize(*args, **kwargs):
-    """ Deterministic token
-
-    >>> tokenize([1, 2, '3'])
-    '7d6a880cd9ec03506eee6973ff551339'
-
-    >>> tokenize('Hello') == tokenize('Hello')
-    True
-    """
-    if kwargs:
-        args = args + (kwargs,)
-    return md5(str(tuple(map(normalize_token, args))).encode()).hexdigest()
-
-
-def dont_optimize(dsk, keys):
-    return dsk
-
-
-def optimization_function(obj):
-    if isinstance(obj, type):
-        cls = obj
-    else:
-        cls = type(obj)
-    name = cls.__name__.lower() + '_optimize' # dask.set_options(array_optimize=foo)
-    if name in _globals:
-        return _globals[name] or dont_optimize
-    try:
-        return cls._optimize
-    except AttributeError:
-        return dont_optimize
-
-
-def collections_to_dsk(collections, optimize_graph=True, **kwargs):
-    """
-    Convert many collections into a single dask graph, after optimization
-    """
-    optimizations = (kwargs.pop('optimizations', None) or
-                     _globals.get('optimizations', []))
-    if optimize_graph:
-        groups = groupby(optimization_function, collections)
-        groups = {opt: _extract_graph_and_keys(val)
-                  for opt, val in groups.items()}
-        for opt in optimizations:
-            groups = {k: [opt(ensure_dict(dsk), keys), keys]
-                      for k, (dsk, keys) in groups.items()}
-        dsk = merge([opt(dsk, keys, **kwargs)
-                     for opt, (dsk, keys) in groups.items()])
-    else:
-        dsk = ensure_dict(sharedict.merge(*[c.dask for c in collections]))
-
-    return dsk
-
-
-def _extract_graph_and_keys(vals):
-    """Given a list of dask vals, return a single graph and a list of keys such
-    that ``get(dsk, keys)`` is equivalent to ``[v.compute() v in vals]``."""
-    dsk = {}
-    keys = []
-    for v in vals:
-        d = v.dask
-        if type(d) is ShareDict:
-            for dd in d.dicts.values():
-                dsk.update(dd)
-        else:
-            dsk.update(v.dask)
-        keys.append(v._keys())
-
-    return dsk, keys
-
-
-def redict_collection(c, dsk):
-    cc = copy.copy(c)
-    cc.dask = dsk
-    return cc
-
-
-def persist(*args, **kwargs):
-    """ Persist multiple Dask collections into memory
-
-    This turns lazy Dask collections into Dask collections with the same
-    metadata, but now with their results fully computed or actively computing
-    in the background.
-
-    For example a lazy dask.array built up from many lazy calls will now be a
-    dask.array of the same shape, dtype, chunks, etc., but now with all of
-    those previously lazy tasks either computed in memory as many small NumPy
-    arrays (in the single-machine case) or asynchronously running in the
-    background on a cluster (in the distributed case).
-
-    This function operates differently if a ``dask.distributed.Client`` exists
-    and is connected to a distributed scheduler.  In this case this function
-    will return as soon as the task graph has been submitted to the cluster,
-    but before the computations have completed.  Computations will continue
-    asynchronously in the background.  When using this function with the single
-    machine scheduler it blocks until the computations have finished.
-
-    When using Dask on a single machine you should ensure that the dataset fits
-    entirely within memory.
-
-    Examples
-    --------
-    >>> df = dd.read_csv('/path/to/*.csv')  # doctest: +SKIP
-    >>> df = df[df.name == 'Alice']  # doctest: +SKIP
-    >>> df['in-debt'] = df.balance < 0  # doctest: +SKIP
-    >>> df = df.persist()  # triggers computation  # doctest: +SKIP
-
-    >>> df.value().min()  # future computations are now fast  # doctest: +SKIP
-    -10
-    >>> df.value().max()  # doctest: +SKIP
-    100
-
-    >>> from dask import persist  # use persist function on multiple collections
-    >>> a, b = persist(a, b)  # doctest: +SKIP
-
-    Parameters
-    ----------
-    *args: Dask collections
-    get : callable, optional
-        A scheduler ``get`` function to use. If not provided, the default
-        is to check the global settings first, and then fall back to
-        the collection defaults.
-    optimize_graph : bool, optional
-        If True [default], the graph is optimized before computation.
-        Otherwise the graph is run as is. This can be useful for debugging.
-    **kwargs
-        Extra keywords to forward to the scheduler ``get`` function.
-
-    Returns
-    -------
-    New dask collections backed by in-memory data
-    """
-    collections = [a for a in args if isinstance(a, Base)]
-    if not collections:
-        return args
-
-    get = kwargs.pop('get', None) or _globals['get']
-
-    if get is None and getattr(thread_state, 'key', False):
-        from distributed.worker import get_worker
-        get = get_worker().client.get
-
-    if inspect.ismethod(get):
-        try:
-            from distributed.client import default_client
-        except ImportError:
-            pass
-        else:
-            try:
-                client = default_client()
-            except ValueError:
-                pass
-            else:
-                if client.get == _globals['get']:
-                    collections = client.persist(collections, **kwargs)
-                    if isinstance(collections, list):  # distributed is inconsistent here
-                        collections = tuple(collections)
-                    else:
-                        collections = (collections,)
-                    results_iter = iter(collections)
-                    return tuple(a if not isinstance(a, Base)
-                                 else next(results_iter)
-                                 for a in args)
-
-    optimize_graph = kwargs.pop('optimize_graph', True)
-
-    if not get:
-        get = collections[0]._default_get
-        if not all(a._default_get == get for a in collections):
-            raise ValueError("Compute called on multiple collections with "
-                             "differing default schedulers. Please specify a "
-                             "scheduler `get` function using either "
-                             "the `get` kwarg or globally with `set_options`.")
-
-    dsk = collections_to_dsk(collections, optimize_graph, **kwargs)
-    keys = list(flatten([var._keys() for var in collections]))
-    results = get(dsk, keys, **kwargs)
-
-    d = dict(zip(keys, results))
-
-    result = [redict_collection(c, {k: d[k]
-                                    for k in flatten(c._keys())})
-              for c in collections]
-    results_iter = iter(result)
-    return tuple(a if not isinstance(a, Base)
-                 else next(results_iter)
-                 for a in args)
-
-
-if PY3:
-    Base.persist.__doc__ = persist.__doc__

--- a/dask/base.py
+++ b/dask/base.py
@@ -210,7 +210,7 @@ def compute_as_if_collection(cls, dsk, keys, get=None, **kwargs):
     """Compute a graph as if it were of type cls.
 
     Allows for applying the same optimizations and default scheduler."""
-    get = get or _globals['get'] or cls.__dask_default_get__
+    get = get or _globals['get'] or cls.__dask_scheduler__
     dsk2 = optimization_function(cls)(ensure_dict(dsk), keys, **kwargs)
     return get(dsk2, keys, **kwargs)
 
@@ -322,8 +322,8 @@ def compute(*args, **kwargs):
         get = get_worker().client.get
 
     if not get:
-        get = variables[0].__dask_default_get__
-        if not all(a.__dask_default_get__ == get for a in variables):
+        get = variables[0].__dask_scheduler__
+        if not all(a.__dask_scheduler__ == get for a in variables):
             raise ValueError("Compute called on multiple collections with "
                              "differing default schedulers. Please specify a "
                              "scheduler `get` function using either "
@@ -482,8 +482,8 @@ def persist(*args, **kwargs):
     optimize_graph = kwargs.pop('optimize_graph', True)
 
     if not get:
-        get = collections[0].__dask_default_get__
-        if not all(a.__dask_default_get__ == get for a in collections):
+        get = collections[0].__dask_scheduler__
+        if not all(a.__dask_scheduler__ == get for a in collections):
             raise ValueError("Compute called on multiple collections with "
                              "differing default schedulers. Please specify a "
                              "scheduler `get` function using either "

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -3,14 +3,14 @@ from __future__ import print_function, division, absolute_import
 import io
 import os
 
-from toolz import merge, partial
+from toolz import merge
 from warnings import warn
 
 from .compression import seekable_files, files as compress_files
 from .utils import (SeekableFile, read_block, infer_compression,
                     infer_storage_options, build_name_function)
 from ..compatibility import PY2, unicode
-from ..base import tokenize, normalize_token
+from ..base import tokenize
 from ..delayed import delayed
 from ..utils import import_required, ensure_bytes, ensure_unicode, is_integer
 
@@ -266,10 +266,9 @@ class OpenFileCreator(object):
         return OpenFile(self.fs.open, path, self.compression, mode,
                         self.text, self.encoding, self.errors)
 
-
-@partial(normalize_token.register, OpenFileCreator)
-def normalize_OpenFileCreator(ofc):
-    return ofc.compression, ofc.text, ofc.encoding, ofc.protocol, ofc.storage_options
+    def __dask_tokenize__(self):
+        return (self.compression, self.text, self.encoding,
+                self.protocol, self.storage_options)
 
 
 class OpenFile(object):

--- a/dask/context.py
+++ b/dask/context.py
@@ -3,8 +3,8 @@ Control global computation context
 """
 from __future__ import absolute_import, division, print_function
 
+from functools import partial
 from collections import defaultdict
-import functools
 
 _globals = defaultdict(lambda: None)
 _globals['callbacks'] = set()
@@ -43,45 +43,55 @@ class set_options(object):
         _globals.update(self.old)
 
 
-def defer_to_globals(name, falsey=None):
+def globalmethod(default=None, key=None, falsey=None):
     """ Allow function to be taken over by globals
 
-    This modifies a function so that occurrences of it may be taken over by
-    functions registered in the global options.  It is commonly used as a
-    decorator.
+    This modifies a method so that occurrences of it may be taken over by
+    functions registered in the global options. Can be used as a decorator or a
+    function.
 
     Parameters
     ----------
-    name: str
-        name under which we register this function in the global parameters
-    falsey: callable, None, optional
-        A function to use if the option is falsey
+    default : callable
+        The default callable to use.
+    key : str
+        Key under which we register this function in the global parameters
+    falsey : callable, None, optional
+        A function to use if the option is falsey. If not provided, the default
+        is used instead.
 
     Examples
     --------
-
     >>> import dask
-    >>> @defer_to_globals('foo')
-    ... def f():
-    ...     return 1
-
-    >>> f()
+    >>> class Foo(object):
+    ...     @globalmethod(key='bar', falsey=lambda: 3)
+    ...     def bar():
+    ...         return 1
+    >>> f = Foo()
+    >>> f.bar()
     1
-
-    >>> with dask.set_options(foo=lambda: 2):
-    ...     print(f())
+    >>> with dask.set_options(bar=lambda: 2):
+    ...     print(f.bar())
     2
+    >>> with dask.set_options(bar=False):
+    ...     print(f.bar())
+    3
     """
-    def _(func):
-        @functools.wraps(func)
-        def f(*args, **kwargs):
-            if name in _globals:
-                if _globals[name]:
-                    return _globals[name](*args, **kwargs)
-                elif falsey:
-                    return falsey(*args, **kwargs)
-            else:
-                return func(*args, **kwargs)
+    if default is None:
+        return partial(globalmethod, key=key, falsey=falsey)
+    return GlobalMethod(default=default, key=key, falsey=falsey)
 
-        return f
-    return _
+
+class GlobalMethod(object):
+    def __init__(self, default, key, falsey=None):
+        self._default = default
+        self._key = key
+        self._falsey = falsey
+
+    def __get__(self, instance, owner=None):
+        if self._key in _globals:
+            if _globals[self._key]:
+                return _globals[self._key]
+            elif self._falsey is not None:
+                return self._falsey
+        return self._default

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -111,7 +111,7 @@ class Scalar(Base, OperatorMethodMixin):
 
     __dask_optimize__ = globalmethod(optimize, key='dataframe_optimize',
                                      falsey=dont_optimize)
-    __dask_default_get__ = staticmethod(threaded.get)
+    __dask_scheduler__ = staticmethod(threaded.get)
 
     def __dask_postcompute__(self):
         return first, ()
@@ -252,7 +252,7 @@ class _Frame(Base, OperatorMethodMixin):
 
     __dask_optimize__ = globalmethod(optimize, key='dataframe_optimize',
                                      falsey=dont_optimize)
-    __dask_default_get__ = staticmethod(threaded.get)
+    __dask_scheduler__ = staticmethod(threaded.get)
 
     def __dask_postcompute__(self):
         return finalize, ()

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -12,7 +12,7 @@ from toolz import merge
 from .io import _link
 from ..core import DataFrame, new_dd_object
 from ... import multiprocessing
-from ...base import tokenize
+from ...base import tokenize, compute_as_if_collection
 from ...bytes.utils import build_name_function
 from ...compatibility import PY3
 from ...context import _globals
@@ -216,7 +216,7 @@ def to_hdf(df, path, key, mode='a', append=False, get=None,
         keys = [(name, i) for i in range(df.npartitions)]
 
     if compute:
-        DataFrame._get(dsk, keys, get=get, **dask_kwargs)
+        compute_as_if_collection(DataFrame, dsk, keys, get=get, **dask_kwargs)
         return filenames
     else:
         return delayed([Delayed(k, dsk) for k in keys])

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -390,7 +390,7 @@ def from_dask_array(x, columns=None):
         divisions[-1] -= 1
 
     dsk = {}
-    for i, (chunk, ind) in enumerate(zip(x._keys(), index)):
+    for i, (chunk, ind) in enumerate(zip(x.__dask_keys__(), index)):
         if x.ndim == 2:
             chunk = chunk[0]
         if isinstance(meta, pd.Series):
@@ -435,8 +435,8 @@ def to_bag(df, index=False):
         raise TypeError("df must be either DataFrame or Series")
     name = 'to_bag-' + tokenize(df, index)
     dsk = dict(((name, i), (_df_to_bag, block, index))
-               for (i, block) in enumerate(df._keys()))
-    dsk.update(df._optimize(df.dask, df._keys()))
+               for (i, block) in enumerate(df.__dask_keys__()))
+    dsk.update(df.__dask_optimize__(df.__dask_graph__(), df.__dask_keys__()))
     return Bag(dsk, name, df.npartitions)
 
 
@@ -462,7 +462,7 @@ def to_records(df):
         raise TypeError("df must be either DataFrame or Series")
     name = 'to-records-' + tokenize(df)
     dsk = {(name, i): (M.to_records, key)
-           for (i, key) in enumerate(df._keys())}
+           for (i, key) in enumerate(df.__dask_keys__())}
     x = df._meta.to_records()
     chunks = ((np.nan,) * df.npartitions,)
     return Array(merge(df.dask, dsk), name, chunks, x.dtype)

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -15,6 +15,7 @@ import pandas.util.testing as tm
 
 import dask
 import dask.dataframe as dd
+from dask.base import compute_as_if_collection
 from dask.dataframe.io.csv import (text_blocks_to_pandas, pandas_read_text,
                                    auto_blocksize)
 from dask.dataframe.utils import assert_eq, has_known_categories, PANDAS_VERSION
@@ -279,7 +280,9 @@ def test_read_csv_index():
         result = f.compute(get=dask.get)
         assert result.index.name == 'amount'
 
-        blocks = dd.DataFrame._get(f.dask, f._keys(), get=dask.get)
+        blocks = compute_as_if_collection(dd.DataFrame, f.dask,
+                                          f.__dask_keys__(),
+                                          get=dask.get)
         for i, block in enumerate(blocks):
             if i < len(f.divisions) - 2:
                 assert (block.index < f.divisions[i + 1]).all()

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -150,7 +150,7 @@ def test_optimize(fn, c):
     assert_eq(df[c], ddf[c])
     x = ddf[c]
 
-    dsk = x._optimize(x.dask, x._keys())
+    dsk = x.__dask_optimize__(x.dask, x.__dask_keys__())
     assert len(dsk) == x.npartitions
     assert all(v[4] == c for v in dsk.values())
 

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -297,10 +297,9 @@ def single_partition_join(left, right, **kwargs):
     meta = pd.merge(left._meta_nonempty, right._meta_nonempty, **kwargs)
     name = 'merge-' + tokenize(left, right, **kwargs)
     if left.npartitions == 1:
-        left_key = first(left._keys())
-        dsk = dict(((name, i), (apply, pd.merge, [left_key, right_key],
-                                kwargs))
-                   for i, right_key in enumerate(right._keys()))
+        left_key = first(left.__dask_keys__())
+        dsk = {(name, i): (apply, pd.merge, [left_key, right_key], kwargs)
+               for i, right_key in enumerate(right.__dask_keys__())}
 
         if kwargs.get('right_index'):
             divisions = right.divisions
@@ -308,10 +307,9 @@ def single_partition_join(left, right, **kwargs):
             divisions = [None for _ in right.divisions]
 
     elif right.npartitions == 1:
-        right_key = first(right._keys())
-        dsk = dict(((name, i), (apply, pd.merge, [left_key, right_key],
-                                kwargs))
-                   for i, left_key in enumerate(left._keys()))
+        right_key = first(right.__dask_keys__())
+        dsk = {(name, i): (apply, pd.merge, [left_key, right_key], kwargs)
+               for i, left_key in enumerate(left.__dask_keys__())}
 
         if kwargs.get('left_index'):
             divisions = left.divisions
@@ -470,7 +468,7 @@ def stack_partitions(dfs, divisions, join='outer'):
         except (ValueError, TypeError):
             match = False
 
-        for key in df._keys():
+        for key in df.__dask_keys__():
             if match:
                 dsk[(name, i)] = key
             else:

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -1,27 +1,25 @@
 """ Dataframe optimizations """
 from __future__ import absolute_import, division, print_function
 
-from .io import dataframe_from_ctable
-from ..optimize import cull, fuse_getitem, fuse, dont_optimize
-from ..context import _globals, defer_to_globals
+from ..optimize import cull, fuse_getitem, fuse
+from ..context import _globals
 from .. import core
 
 try:
     import fastparquet  # noqa: F401
 except ImportError:
-    _read_parquet_row_group = False
-else:
-    from .io.parquet import _read_parquet_row_group
+    fastparquet = False
 
 
-@defer_to_globals('dataframe_optimize', falsey=dont_optimize)
 def optimize(dsk, keys, **kwargs):
+    from .io import dataframe_from_ctable
     if isinstance(keys, list):
         dsk, dependencies = cull(dsk, list(core.flatten(keys)))
     else:
         dsk, dependencies = cull(dsk, [keys])
     dsk = fuse_getitem(dsk, dataframe_from_ctable, 3)
-    if _read_parquet_row_group:
+    if fastparquet:
+        from .io.parquet import _read_parquet_row_group
         dsk = fuse_getitem(dsk, _read_parquet_row_group, 4)
     dsk, dependencies = fuse(dsk, keys, dependencies=dependencies,
                              ave_width=_globals.get('fuse_ave_width', 0))

--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -431,7 +431,7 @@ def partition_quantiles(df, npartitions, upsample=1.0, random_state=None):
         random_state = hash(token) % np.iinfo(np.int32).max
     state_data = random_state_data(df.npartitions, random_state)
 
-    df_keys = df._keys()
+    df_keys = df.__dask_keys__()
 
     name0 = 're-quantiles-0-' + token
     dtype_dsk = {(name0, 0): (dtype_info, df_keys[0])}

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -135,7 +135,7 @@ def map_overlap(func, df, before, after, *args, **kwargs):
     else:
         nexts = [None] * df.npartitions
 
-    for i, (prev, current, next) in enumerate(zip(prevs, df._keys(), nexts)):
+    for i, (prev, current, next) in enumerate(zip(prevs, df.__dask_keys__(), nexts)):
         dsk[(name, i)] = (overlap_chunk, func, prev, current, next, before,
                           after, args, kwargs)
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -14,7 +14,7 @@ from .hashing import hash_pandas_object
 from .utils import PANDAS_VERSION
 
 from .. import base
-from ..base import tokenize, compute
+from ..base import tokenize, compute, compute_as_if_collection
 from ..context import _globals
 from ..delayed import delayed
 from ..sizeof import sizeof
@@ -266,12 +266,12 @@ def rearrange_by_column_disk(df, column, npartitions=None, compute=False):
     # Partition data on disk
     name = 'shuffle-partition-' + always_new_token
     dsk2 = {(name, i): (shuffle_group_3, key, column, npartitions, p)
-            for i, key in enumerate(df._keys())}
+            for i, key in enumerate(df.__dask_keys__())}
 
     dsk = merge(df.dask, dsk1, dsk2)
     if compute:
         keys = [p, sorted(dsk2)]
-        pp, values = (_globals.get('get') or DataFrame._get)(dsk, keys)
+        pp, values = compute_as_if_collection(DataFrame, dsk, keys)
         dsk1 = {p: pp}
         dsk = dict(zip(sorted(dsk2), values))
 
@@ -354,7 +354,7 @@ def rearrange_by_column_tasks(df, column, max_branch=32, npartitions=None):
         parts = [i % df.npartitions for i in range(npartitions)]
         token = tokenize(df2, npartitions)
         dsk = {('repartition-group-' + token, i): (shuffle_group_2, k, column)
-               for i, k in enumerate(df2._keys())}
+               for i, k in enumerate(df2.__dask_keys__())}
         for p in range(npartitions):
             dsk[('repartition-get-' + token, p)] = \
                 (shuffle_group_get, ('repartition-group-' + token, parts[p]), p)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -962,7 +962,7 @@ def test_hash_groupby_aggregate(npartitions, split_every, split_out):
     result = ddf.groupby('x').y.var(split_every=split_every,
                                     split_out=split_out)
 
-    dsk = result._optimize(result.dask, result._keys())
+    dsk = result.__dask_optimize__(result.dask, result.__dask_keys__())
     from dask.core import get_deps
     dependencies, dependents = get_deps(dsk)
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pandas.util.testing as tm
 
 from dask.local import get_sync
+from dask.base import compute_as_if_collection
 from dask.dataframe.core import _Frame
 from dask.dataframe.methods import concat
 from dask.dataframe.multi import (align_partitions, merge_indexed_dataframes,
@@ -1030,7 +1031,9 @@ def test_concat_categorical(known, cat_index, divisions):
         res = dd.concat(ddfs, join=join, interleave_partitions=divisions)
         assert_eq(res, sol)
         if known:
-            for p in [i.iloc[:0] for i in res._get(res.dask, res._keys())]:
+            parts = compute_as_if_collection(dd.DataFrame, res.dask,
+                                             res.__dask_keys__())
+            for p in [i.iloc[:0] for i in parts]:
                 res._meta == p  # will error if schemas don't align
         assert not cat_index or has_known_categories(res.index) == known
         return res

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -3,7 +3,7 @@ from operator import getitem
 from toolz import merge
 
 import dask
-from dask.dataframe.optimize import dataframe_from_ctable
+from dask.dataframe.io import dataframe_from_ctable
 import dask.dataframe as dd
 import pandas as pd
 
@@ -43,9 +43,9 @@ def test_fuse_ave_width():
     s = ((df.x + 1) + (df.x + 2))
 
     with dask.set_options(fuse_ave_width=4):
-        a = s._optimize(s.dask, s._keys())
+        a = s.__dask_optimize__(s.dask, s.__dask_keys__())
 
-    b = s._optimize(s.dask, s._keys())
+    b = s.__dask_optimize__(s.dask, s.__dask_keys__())
 
     assert len(a) < len(b)
     assert len(a) <= 15

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -112,7 +112,7 @@ class Resampler(object):
         # Repartition divs into bins. These won't match labels after mapping
         partitioned = self.obj.repartition(newdivs, force=True)
 
-        keys = partitioned._keys()
+        keys = partitioned.__dask_keys__()
         dsk = partitioned.dask
 
         args = zip(keys, outdivs, outdivs[1:], ['left'] * (len(keys) - 1) + [None])

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -619,7 +619,7 @@ def assert_divisions(ddf):
         return (x if isinstance(x, pd.Index)
                 else x.index.get_level_values(0))
 
-    results = get_sync(ddf.dask, ddf._keys())
+    results = get_sync(ddf.dask, ddf.__dask_keys__())
     for i, df in enumerate(results[:-1]):
         if len(df):
             assert index(df).min() >= ddf.divisions[i]

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -363,7 +363,7 @@ class Delayed(Base, OperatorMethodMixin):
     def __dask_tokenize__(self):
         return self.key
 
-    __dask_default_get__ = staticmethod(threaded.get)
+    __dask_scheduler__ = staticmethod(threaded.get)
     __dask_optimize__ = globalmethod(dont_optimize, key='delayed_optimize')
 
     def __dask_postcompute__(self):

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -9,12 +9,13 @@ try:
 except ImportError:
     from toolz import curry, first, pluck
 
-from . import base, threaded
+from . import threaded
+from .base import Base, is_dask_collection, dont_optimize
+from .base import tokenize as _tokenize
 from .compatibility import apply
 from .core import quote
-from .context import _globals, defer_to_globals
-from .optimize import dont_optimize
-from .utils import concrete, funcname, methodcaller, ensure_dict
+from .context import _globals, globalmethod
+from .utils import funcname, methodcaller, OperatorMethodMixin
 from . import sharedict
 
 __all__ = ['Delayed', 'delayed']
@@ -65,11 +66,13 @@ def to_task_dask(expr):
     if isinstance(expr, Delayed):
         return expr.key, expr.dask
 
-    if isinstance(expr, base.Base):
+    if is_dask_collection(expr):
         name = 'finalize-' + tokenize(expr, pure=True)
-        keys = expr._keys()
-        dsk = expr._optimize(ensure_dict(expr.dask), keys)
-        dsk[name] = (expr._finalize, (concrete, keys))
+        keys = expr.__dask_keys__()
+        opt = getattr(expr, '__dask_optimize__', dont_optimize)
+        finalize, args = expr.__dask_postcompute__()
+        dsk = {name: (finalize, keys) + args}
+        dsk.update(opt(expr.__dask_graph__(), keys))
         return name, dsk
 
     if isinstance(expr, Iterator):
@@ -111,7 +114,7 @@ def tokenize(*args, **kwargs):
         pure = _globals.get('delayed_pure', False)
 
     if pure:
-        return base.tokenize(*args, **kwargs)
+        return _tokenize(*args, **kwargs)
     else:
         return str(uuid.uuid4())
 
@@ -301,7 +304,7 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
     if isinstance(obj, Delayed):
         return obj
 
-    if isinstance(obj, base.Base) or traverse:
+    if is_dask_collection(obj) or traverse:
         task, dsk = to_task_dask(obj)
     else:
         task = quote(obj)
@@ -333,18 +336,16 @@ def right(method):
     return _inner
 
 
-optimize = defer_to_globals('delayed_optimize', falsey=dont_optimize)(dont_optimize)
+def rebuild(dsk, key, length):
+    return Delayed(key, dsk, length)
 
 
-class Delayed(base.Base):
+class Delayed(Base, OperatorMethodMixin):
     """Represents a value to be computed by dask.
 
     Equivalent to the output from a single key in a dask graph.
     """
     __slots__ = ('_key', 'dask', '_length')
-    _finalize = staticmethod(first)
-    _default_get = staticmethod(threaded.get)
-    _optimize = staticmethod(optimize)
 
     def __init__(self, key, dsk, length=None):
         self._key = key
@@ -352,6 +353,24 @@ class Delayed(base.Base):
             dsk = sharedict.merge(*dsk)
         self.dask = dsk
         self._length = length
+
+    def __dask_graph__(self):
+        return self.dask
+
+    def __dask_keys__(self):
+        return [self.key]
+
+    def __dask_tokenize__(self):
+        return self.key
+
+    __dask_default_get__ = staticmethod(threaded.get)
+    __dask_optimize__ = globalmethod(dont_optimize, key='delayed_optimize')
+
+    def __dask_postcompute__(self):
+        return first, ()
+
+    def __dask_postpersist__(self):
+        return rebuild, (self._key, getattr(self, '_length', None))
 
     def __getstate__(self):
         return tuple(getattr(self, i) for i in self.__slots__)
@@ -363,9 +382,6 @@ class Delayed(base.Base):
     @property
     def key(self):
         return self._key
-
-    def _keys(self):
-        return [self.key]
 
     def __repr__(self):
         return "Delayed({0})".format(repr(self.key))
@@ -500,6 +516,3 @@ for op in [operator.abs, operator.neg, operator.pos, operator.invert,
            operator.eq, operator.ge, operator.gt, operator.ne, operator.le,
            operator.lt, operator.getitem]:
     Delayed._bind_operator(op)
-
-
-base.normalize_token.register(Delayed, lambda a: a.key)

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -5,11 +5,10 @@ import re
 from operator import getitem
 
 from .compatibility import unicode
-
 from .context import _globals
-from .core import add, inc  # noqa: F401
 from .core import (istask, get_dependencies, subs, toposort, flatten,
                    reverse_dict, ishashable)
+from .utils_test import add, inc  # noqa: F401
 
 
 def cull(dsk, keys):
@@ -807,7 +806,3 @@ def key_split(s):
             return result
     except Exception:
         return 'Other'
-
-
-def dont_optimize(dsk, keys, **kwargs):
-    return dsk

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -5,11 +5,13 @@ import pytest
 from operator import add, mul
 import subprocess
 import sys
+from toolz import merge
 
 import dask
 from dask import delayed
 from dask.base import (compute, tokenize, normalize_token, normalize_function,
-                       visualize, persist, function_cache)
+                       visualize, persist, function_cache, is_dask_collection,
+                       DaskMethodsMixin)
 from dask.delayed import Delayed
 from dask.utils import tmpdir, tmpfile, ignoring
 from dask.utils_test import inc, dec
@@ -207,6 +209,25 @@ def test_tokenize_same_repr():
     assert tokenize(Foo(1)) != tokenize(Foo(2))
 
 
+def test_tokenize_method():
+    class Foo(object):
+        def __init__(self, x):
+            self.x = x
+
+        def __dask_tokenize__(self):
+            return self.x
+
+    a, b = Foo(1), Foo(2)
+    assert tokenize(a) == tokenize(a)
+    assert tokenize(a) != tokenize(b)
+
+    # dispatch takes precedence
+    before = tokenize(a)
+    normalize_token.register(Foo, lambda self: self.x + 1)
+    after = tokenize(a)
+    assert before != after
+
+
 @pytest.mark.skipif('not np')
 def test_tokenize_sequences():
     assert tokenize([1]) != tokenize([2])
@@ -248,6 +269,91 @@ def test_tokenize_object_array_with_nans():
                                [], (), {}, None, str, int])
 def test_tokenize_base_types(x):
     assert tokenize(x) == tokenize(x), x
+
+
+def test_is_dask_collection():
+    class DummyCollection(object):
+        def __init__(self, dsk=None):
+            self.dask = dsk
+
+        def __dask_graph__(self):
+            return self.dask
+
+    x = delayed(1) + 2
+    assert is_dask_collection(x)
+    assert not is_dask_collection(2)
+    assert is_dask_collection(DummyCollection({}))
+    assert not is_dask_collection(DummyCollection())
+
+
+class Tuple(DaskMethodsMixin):
+    __slots__ = ('_dask', '_keys')
+    __dask_default_get__ = staticmethod(dask.threaded.get)
+
+    def __init__(self, dsk, keys):
+        self._dask = dsk
+        self._keys = keys
+
+    def __add__(self, other):
+        if isinstance(other, Tuple):
+            return Tuple(merge(self._dask, other._dask),
+                         self._keys + other._keys)
+        return NotImplemented
+
+    def __dask_graph__(self):
+        return self._dask
+
+    def __dask_keys__(self):
+        return self._keys
+
+    def __dask_tokenize__(self):
+        return self._keys
+
+    def __dask_postcompute__(self):
+        return tuple, ()
+
+    def __dask_postpersist__(self):
+        return Tuple, (self._keys,)
+
+
+def test_custom_collection():
+    dsk = {'a': 1, 'b': 2}
+    dsk2 = {'c': (add, 'a', 'b'),
+            'd': (add, 'c', 1)}
+    dsk2.update(dsk)
+    dsk3 = {'e': (add, 'a', 4),
+            'f': (inc, 'e')}
+    dsk3.update(dsk)
+
+    x = Tuple(dsk, ['a', 'b'])
+    y = Tuple(dsk2, ['c', 'd'])
+    z = Tuple(dsk3, ['e', 'f'])
+
+    # __slots__ defined on base mixin class propogates
+    with pytest.raises(AttributeError):
+        x.foo = 1
+
+    # is_dask_collection
+    assert is_dask_collection(x)
+
+    # tokenize
+    assert tokenize(x) == tokenize(x)
+    assert tokenize(x) != tokenize(y)
+
+    # compute
+    assert x.compute() == (1, 2)
+    assert dask.compute(x, [y, z]) == ((1, 2), [(3, 4), (5, 6)])
+    t = x + y + z
+    assert t.compute() == (1, 2, 3, 4, 5, 6)
+
+    # persist
+    t2 = t.persist()
+    assert isinstance(t2, Tuple)
+    assert t2._dask == dict(zip('abcdef', range(1, 7)))
+    assert t2.compute() == (1, 2, 3, 4, 5, 6)
+    x2, y2, z2 = dask.persist(x, y, z)
+    t3 = x2 + y2 + z2
+    assert t2._dask == t3._dask
 
 
 @pytest.mark.skipif('not db')
@@ -369,12 +475,19 @@ def test_visualize():
         x = da.arange(5, chunks=2)
         x.visualize(filename=os.path.join(d, 'mydask'))
         assert os.path.exists(os.path.join(d, 'mydask.png'))
+
         x.visualize(filename=os.path.join(d, 'mydask.pdf'))
         assert os.path.exists(os.path.join(d, 'mydask.pdf'))
+
         visualize(x, 1, 2, filename=os.path.join(d, 'mydask.png'))
         assert os.path.exists(os.path.join(d, 'mydask.png'))
+
         dsk = {'a': 1, 'b': (add, 'a', 2), 'c': (mul, 'a', 1)}
         visualize(x, dsk, filename=os.path.join(d, 'mydask.png'))
+        assert os.path.exists(os.path.join(d, 'mydask.png'))
+
+        x = Tuple(dsk, ['a', 'b', 'c'])
+        visualize(x, filename=os.path.join(d, 'mydask.png'))
         assert os.path.exists(os.path.join(d, 'mydask.png'))
 
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -288,7 +288,7 @@ def test_is_dask_collection():
 
 class Tuple(DaskMethodsMixin):
     __slots__ = ('_dask', '_keys')
-    __dask_default_get__ = staticmethod(dask.threaded.get)
+    __dask_scheduler__ = staticmethod(dask.threaded.get)
 
     def __init__(self, dsk, keys):
         self._dask = dsk

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -14,7 +14,7 @@ from dask.utils_test import inc
 
 
 class Tuple(object):
-    __dask_default_get__ = staticmethod(dask.threaded.get)
+    __dask_scheduler__ = staticmethod(dask.threaded.get)
 
     def __init__(self, dsk, keys):
         self._dask = dsk

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -6,10 +6,31 @@ from random import random
 from toolz import identity, partial, merge
 import pytest
 
+import dask
 from dask import set_options, compute
 from dask.compatibility import PY2, PY3
 from dask.delayed import delayed, to_task_dask, Delayed
 from dask.utils_test import inc
+
+
+class Tuple(object):
+    __dask_default_get__ = staticmethod(dask.threaded.get)
+
+    def __init__(self, dsk, keys):
+        self._dask = dsk
+        self._keys = keys
+
+    def __dask_tokenize__(self):
+        return self._keys
+
+    def __dask_graph__(self):
+        return self._dask
+
+    def __dask_keys__(self):
+        return self._keys
+
+    def __dask_postcompute__(self):
+        return tuple, ()
 
 
 def test_to_task_dask():
@@ -44,6 +65,14 @@ def test_to_task_dask():
     task, dask = to_task_dask(MyClass())
     assert type(task) is MyClass
     assert dict(dask) == {}
+
+    # Custom dask objects
+    x = Tuple({'a': 1, 'b': 2, 'c': (add, 'a', 'b')}, ['a', 'b', 'c'])
+    task, dask = to_task_dask(x)
+    assert task in dask
+    f = dask.pop(task)
+    assert f == (tuple, ['a', 'b', 'c'])
+    assert dask == x._dask
 
 
 def test_delayed():
@@ -91,12 +120,11 @@ def test_attributes():
     assert (a.real + a.imag).compute() == 3
 
 
-def test_method_getattr_optimize():
+def test_method_getattr_call_same_task():
     a = delayed([1, 2, 3])
     o = a.index(1)
-    dsk = o._optimize(o.dask, o._keys())
     # Don't getattr the method, then call in separate task
-    assert getattr not in set(v[0] for v in dsk.values())
+    assert getattr not in set(v[0] for v in o.__dask_graph__().values())
 
 
 def test_delayed_errors():
@@ -307,6 +335,15 @@ def test_kwargs():
     assert dmysum(1, 2, c=c, four=dmysum(2, 3)).key != ten.key
     assert dmysum(1, 2, c=c, four=4).key != ten.key
     assert dmysum(1, 2, c=c, four=4).key != dmysum(2, 2, c=c, four=4).key
+
+
+def test_custom_delayed():
+    x = Tuple({'a': 1, 'b': 2, 'c': (add, 'a', 'b')}, ['a', 'b', 'c'])
+    x2 = delayed(add, pure=True)(x, (4, 5, 6))
+    n = delayed(len, pure=True)(x)
+    assert delayed(len, pure=True)(x).key == n.key
+    assert x2.compute() == (1, 2, 3, 4, 5, 6)
+    assert compute(n, x2, x) == (3, (1, 2, 3, 4, 5, 6), (1, 2, 3))
 
 
 def test_array_delayed():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -799,7 +799,7 @@ class SerializableLock(object):
 def effective_get(get=None, collection=None):
     """Get the effective get method used in a given situation"""
     return (get or _globals.get('get') or
-            getattr(collection, '__dask_default_get__', None))
+            getattr(collection, '__dask_scheduler__', None))
 
 
 def get_scheduler_lock(get=None, collection=None):

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -17,7 +17,7 @@ import multiprocessing as mp
 import uuid
 from weakref import WeakValueDictionary
 
-from .compatibility import getargspec, PY3, unicode, urlsplit
+from .compatibility import getargspec, PY3, unicode, urlsplit, bind_method
 from .core import get_deps
 from .context import _globals
 from .optimize import key_split    # noqa: F401
@@ -798,8 +798,8 @@ class SerializableLock(object):
 
 def effective_get(get=None, collection=None):
     """Get the effective get method used in a given situation"""
-    collection_get = collection._default_get if collection is not None else None
-    return get or _globals.get('get') or collection_get
+    return (get or _globals.get('get') or
+            getattr(collection, '__dask_default_get__', None))
 
 
 def get_scheduler_lock(get=None, collection=None):
@@ -822,6 +822,44 @@ def ensure_dict(d):
             result.update(dd)
         return result
     return dict(d)
+
+
+class OperatorMethodMixin(object):
+    """A mixin for dynamically implementing operators"""
+
+    @classmethod
+    def _bind_operator(cls, op):
+        """ bind operator to this class """
+        name = op.__name__
+
+        if name.endswith('_'):
+            # for and_ and or_
+            name = name[:-1]
+        elif name == 'inv':
+            name = 'invert'
+
+        meth = '__{0}__'.format(name)
+
+        if name in ('abs', 'invert', 'neg', 'pos'):
+            bind_method(cls, meth, cls._get_unary_operator(op))
+        else:
+            bind_method(cls, meth, cls._get_binary_operator(op))
+
+            if name in ('eq', 'gt', 'ge', 'lt', 'le', 'ne', 'getitem'):
+                return
+
+            rmeth = '__r{0}__'.format(name)
+            bind_method(cls, rmeth, cls._get_binary_operator(op, inv=True))
+
+    @classmethod
+    def _get_unary_operator(cls, op):
+        """ Must return a method used by unary operator """
+        raise NotImplementedError
+
+    @classmethod
+    def _get_binary_operator(cls, op, inv=False):
+        """ Must return a method used by binary operator """
+        raise NotImplementedError
 
 
 # XXX: Kept to keep old versions of distributed/dask in sync. After

--- a/docs/source/custom-collections.rst
+++ b/docs/source/custom-collections.rst
@@ -96,7 +96,7 @@ interface is used inside dask.
         The optimized dask graph.
 
 
-.. staticmethod:: __dask_default_get__(dsk, keys, \*\*kwargs)
+.. staticmethod:: __dask_scheduler__(dsk, keys, \*\*kwargs)
 
     The default scheduler ``get`` to use for this object.
 
@@ -105,7 +105,7 @@ interface is used inside dask.
     >>> import dask.threaded
     >>> class MyCollection(object):
     ...     # Use the threaded scheduler by default
-    ...     __dask_default_get__ = staticmethod(dask.threaded.get)
+    ...     __dask_scheduler__ = staticmethod(dask.threaded.get)
 
 
 .. method:: __dask_postcompute__(self)
@@ -208,7 +208,7 @@ The operation of ``compute`` can be broken into three stages:
    - If a ``get`` function is specified directly as a keyword, use that.
    - Otherwise, if a global scheduler is set, use that.
    - Otherwise fall back to the default scheduler for the given collections.
-     Note that if all collections don't share the same ``__dask_default_get__``
+     Note that if all collections don't share the same ``__dask_scheduler__``
      then an error will be raised.
 
    Once the appropriate scheduler ``get`` function is determined, it's called
@@ -427,7 +427,7 @@ elements of ``dask.delayed``.
             return dsk2
 
         # Use the threaded scheduler by default.
-        __dask_default_get__ = staticmethod(dask.threaded.get)
+        __dask_scheduler__ = staticmethod(dask.threaded.get)
 
         def __dask_postcompute__(self):
             # We want to return the results as a tuple, so our finalize

--- a/docs/source/custom-collections.rst
+++ b/docs/source/custom-collections.rst
@@ -1,0 +1,581 @@
+Custom Collections
+==================
+
+For many problems the built-in dask collections (``dask.array``,
+``dask.dataframe``, ``dask.bag``, and ``dask.delayed``) are sufficient. For
+cases where they aren't it's possible to create your own dask collections. Here
+we describe the required methods to fullfill the dask collection interface.
+
+.. warning:: The custom collection API is experimental and subject to change
+             without going through a deprecation cycle.
+
+.. note:: This is considered an advanced feature. For most cases the built-in
+          collections are probably sufficient.
+
+Before reading this you should read and underestand:
+
+- :doc:`overview <graphs>`
+- :doc:`graph specification <spec>`
+- :doc:`custom graphs <custom-graphs>`
+
+**Contents**
+
+- :ref:`Description of the dask collection interface <collection-interface>`
+- :ref:`How this interface is used to implement the core dask
+  methods <core-method-internals>`
+- :ref:`How to add the core methods to your class <adding-methods-to-class>`
+- :ref:`example-dask-collection`
+- :ref:`How to check if something is a dask collection <is-dask-collection>`
+- :ref:`How to make tokenize work with your collection <deterministic-hashing>`
+
+
+.. _collection-interface:
+
+The Dask Collection Interface
+-----------------------------
+
+To create your own dask collection, you need to fullfill the following
+interface. Note that there is no required base class.
+
+It's recommended to also read :ref:`core-method-internals` to see how this
+interface is used inside dask.
+
+
+.. method:: __dask_graph__(self)
+
+    The dask graph.
+
+    Returns
+    -------
+    dsk : MutableMapping, None
+        The dask graph. If ``None``, this instance will not be interpreted as a
+        dask collection, and none of the remaining interface methods will be
+        called.
+
+
+.. method:: __dask_keys__(self)
+
+    The output keys for the dask graph.
+
+    Returns
+    -------
+    keys : list
+        A possibly nested list of keys that represent the outputs of the graph.
+        After computation, the results will be returned in the same layout,
+        with the keys replaced with their corresponding outputs.
+
+
+.. staticmethod:: __dask_optimize__(dsk, keys, \*\*kwargs)
+
+    Given a graph and keys, return a new optimized graph.
+
+    This method can be either a ``staticmethod`` or a ``classmethod``, but not
+    an instancemethod.
+
+    Note that graphs and keys are merged before calling ``__dask_optimize__``;
+    as such the graph and keys passed to this method may represent more than
+    one collection sharing the same optimize method.
+
+    If not implemented, defaults to returning the graph unchanged.
+
+    Parameters
+    ----------
+    dsk : MutableMapping
+        The merged graphs from all collections sharing the same
+        ``__dask_optimize__`` method.
+    keys : list
+        A list of the outputs from ``__dask_keys__`` from all collections
+        sharing the same ``__dask_optimize__`` method.
+    \*\*kwargs
+        Extra keyword arguments forwarded from the call to ``compute`` or
+        ``persist``. Can be used or ignored as needed.
+
+    Returns
+    -------
+    optimized_dsk : MutableMapping
+        The optimized dask graph.
+
+
+.. staticmethod:: __dask_default_get__(dsk, keys, \*\*kwargs)
+
+    The default scheduler ``get`` to use for this object.
+
+    Usually attached to the class as a staticmethod, e.g.
+
+    >>> import dask.threaded
+    >>> class MyCollection(object):
+    ...     # Use the threaded scheduler by default
+    ...     __dask_default_get__ = staticmethod(dask.threaded.get)
+
+
+.. method:: __dask_postcompute__(self)
+
+    Return the finalizer and (optional) extra arguments to convert the computed
+    results into their in-memory representation.
+
+    Used to implement ``dask.compute``.
+
+    Returns
+    -------
+    finalize : callable
+        A function with the signature ``finalize(results, *extra_args)``.
+        Called with the computed results in the same structure as the
+        corresponding keys from ``__dask_keys__``, as well as any extra
+        arguments as specified in ``extra_args``.  Should perform any necessary
+        finalization before returning the corresponding in-memory collection
+        from ``compute``. For example, the ``finalize`` function for
+        ``dask.array.Array`` concatenates all the individual array chunks into
+        one large numpy array, which is then the result of ``compute``.
+    extra_args : tuple
+        Any extra arguments to pass to ``finalize`` after ``results``. If no
+        extra arguments should be an empty tuple.
+
+
+.. method:: __dask_postpersist__(self)
+
+    Return the rebuilder and (optional) extra arguments to rebuild an equivalent
+    dask collection from a persisted graph.
+
+    Used to implement ``dask.persist``.
+
+    Returns
+    -------
+    rebuild : callable
+        A function with the signature ``rebuild(dsk, *extra_args)``. Called
+        with a persisted graph containing only the keys and results from
+        ``__dask_keys__``, as well as any extra arguments as specified in
+        ``extra_args``. Should return an equivalent dask collection with the
+        same keys as ``self``, but with the results already computed. For
+        example, the ``rebuild`` function for ``dask.array.Array`` is just the
+        ``__init__`` method called with the new graph but the same metadata.
+    extra_args : tuple
+        Any extra arguments to pass to ``rebuild`` after ``dsk``. If no extra
+        arguments should be an empty tuple.
+
+
+.. note:: It's also recommended to define ``__dask_tokenize__``,
+          see :ref:`deterministic-hashing`.
+
+
+.. _core-method-internals:
+
+Internals of the Core Dask Methods
+----------------------------------
+
+Dask has a few *core* functions (and corresponding methods) that implement
+common operations:
+
+- ``compute``: convert one or more dask collections into their in-memory
+  counterparts
+- ``persist``: convert one or more dask collections into equivalent dask
+  collections with their results already computed and cached in memory.
+- ``visualize``: given one or more dask collections, draw out the graph that
+  would be passed to the scheduler during a call to ``compute`` or ``persist``
+
+Here we briefly describe the internals of these functions to illustrate how
+they relate to the above interface.
+
+Compute
+~~~~~~~
+
+The operation of ``compute`` can be broken into three stages:
+
+1. **Graph Merging & Optimization**
+
+   First the individual collections are converted to a single large graph and
+   nested list of keys. How this happens depends on the value of the
+   ``optimize_graph`` keyword, which each function takes:
+
+   - If ``optimize_graph`` is ``True`` (default) then the collections are first
+     grouped by their ``__dask_optimize__`` methods. All collections with the
+     same ``__dask_optimize__`` method have their graphs merged and keys
+     concatenated, and then a single call to each respective
+     ``__dask_optimize__`` is made with the merged graphs and keys. The
+     resulting graphs are then merged.
+
+   - If ``optimize_graph`` is ``False`` then all the graphs are merged and all
+     the keys concatenated.
+
+   After this stage there is a single large graph and nested list of keys which
+   represents all the collections.
+
+2. **Computation**
+
+   After the graphs are merged and any optimizations performed, the resulting
+   large graph and nested list of keys are passed on to the scheduler. The
+   scheduler to use is chosen as follows:
+
+   - If a ``get`` function is specified directly as a keyword, use that.
+   - Otherwise, if a global scheduler is set, use that.
+   - Otherwise fall back to the default scheduler for the given collections.
+     Note that if all collections don't share the same ``__dask_default_get__``
+     then an error will be raised.
+
+   Once the appropriate scheduler ``get`` function is determined, it's called
+   with the merged graph, keys, and extra keyword arguments. After this stage
+   ``results`` is a nested list of values. The structure of this list mirrors
+   that of ``keys``, with each key substituted with its corresponding result.
+
+3. **Postcompute**
+
+   After the results are generated the output values of ``compute`` need to be
+   built. This is what the ``__dask_postcompute__`` method is for.
+   ``__dask_postcompute__`` returns two things:
+
+   - A ``finalize`` function, which takes in the results for the corresponding
+     keys
+   - A tuple of extra arguments to pass to ``finalize`` after the results
+
+   To build the outputs, the list of collections and results is iterated over,
+   and the finalizer for each collection is called on its respective results.
+
+In pseudocode this process looks like:
+
+.. code:: python
+
+    def compute(*collections, **kwargs):
+        # 1. Graph Merging & Optimization
+        # -------------------------------
+        if kwargs.pop('optimize_graph', True):
+            # If optimization is turned on, group the collections by
+            # optimization method, and apply each method only once to the merged
+            # sub-graphs.
+            optimization_groups = groupby_optimization_methods(collections)
+            graphs = []
+            for optimize_method, cols in optimization_groups:
+                # Merge the graphs and keys for the subset of collections that
+                # share this optimization method
+                sub_graph = merge_graphs([x.__dask_graph__() for x in cols])
+                sub_keys = [x.__dask_keys__() for x in cols]
+                # kwargs are forwarded to ``__dask_optimize__`` from compute
+                optimized_graph = optimize_method(sub_graph, sub_keys, **kwargs)
+                graphs.append(optimized_graph)
+            graph = merge_graphs(graphs)
+        else:
+            graph = merge_graphs([x.__dask_graph__() for x in collections])
+        # Keys are always the same
+        keys = [x.__dask_keys__() for x in collections]
+
+        # 2. Computation
+        # --------------
+        # Determine appropriate get function based on collections, global
+        # settings, and keyword arguments
+        get = determine_get_function(collections, **kwargs)
+        # Pass the merged graph, keys, and kwargs to ``get``
+        results = get(graph, keys, **kwargs)
+
+        # 3. Postcompute
+        # --------------
+        output = []
+        # Iterate over the results and collections
+        for res, collection in zip(results, collections):
+            finalize, extra_args = collection.__dask_postcompute__()
+            out = finalize(res, **extra_args)
+            output.append(out)
+
+        # `dask.compute` always returns tuples
+        return tuple(output)
+
+
+Persist
+~~~~~~~
+
+Persist is very similar to ``compute``, except for how the return values are
+created. It too has three stages:
+
+1. **Graph Merging & Optimization**
+
+   Same as in ``compute``.
+
+2. **Computation**
+
+   Same as in ``compute``, except in the case of the distributed scheduler,
+   where the values in ``results`` are futures instead of values.
+
+3. **Postpersist**
+
+   Similar to ``__dask_postcompute__``, ``__dask_postpersist__`` is used to
+   rebuild values in a call to ``persist``. ``__dask_postpersist__`` returns
+   two things:
+
+   - A ``rebuild`` function, which takes in a persisted graph. The keys of
+     this graph are the same as ``__dask_keys__`` for the corresponding
+     collection, and the values are computed results (for the single machine
+     scheduler) or futures (for the distributed scheduler).
+   - A tuple of extra arguments to pass to ``rebuild`` after the graph
+
+   To build the outputs of ``persist``, the list of collections and results is
+   iterated over, and the rebuilder for each collection is called on the graph
+   for its respective results.
+
+In pseudocode this looks like:
+
+.. code:: python
+
+    def persist(*collections, **kwargs):
+        # 1. Graph Merging & Optimization
+        # -------------------------------
+        # **Same as in compute**
+        graph = ...
+        keys = ...
+
+        # 2. Computation
+        # --------------
+        # **Same as in compute**
+        results = ...
+
+        # 3. Postpersist
+        # --------------
+        output = []
+        # Iterate over the results and collections
+        for res, collection in zip(results, collections):
+            # res has the same structure as keys
+            keys = collection.__dask_keys__()
+            # Get the computed graph for this collection.
+            # Here flatten converts a nested list into a single list
+            graph = {k: r for (k, r) in zip(flatten(keys), flatten(res))}
+
+            # Rebuild the output dask collection with the computed graph
+            rebuild, extra_args = collection.__dask_postpersist__()
+            out = rebuild(graph, *extra_args)
+
+            output.append(out)
+
+        # dask.persist always returns tuples
+        return tuple(output)
+
+Visualize
+~~~~~~~~~
+
+Visualize is the simplest of the 3 core methods. It only has two stages:
+
+1. **Graph Merging & Optimization**
+
+   Same as in ``compute``
+
+2. **Graph Drawing**
+
+   The resulting merged graph is drawn using ``graphviz`` and output to the
+   specified file.
+
+In pseudocode this looks like:
+
+.. code:: python
+
+    def visualize(*collections, **kwargs):
+        # 1. Graph Merging & Optimization
+        # -------------------------------
+        # **Same as in compute**
+        graph = ...
+        keys = ...
+
+        # 2. Graph Drawing
+        # ----------------
+        # Draw the graph with graphviz's `dot` tool and return the result.
+        return dot_graph(graph, **kwargs)
+
+
+.. _adding-methods-to-class:
+
+Adding the Core Dask Methods to Your Class
+------------------------------------------
+
+Defining the above interface will allow your object to used by the core dask
+functions (``dask.compute``, ``dask.persist``, ``dask.visualize``, etc...). To
+add corresponding method versions of these subclass from
+``dask.base.DaskMethodsMixin``, which adds implementations of ``compute``,
+``persist``, and ``visualize`` based on the interface above.
+
+
+.. _example-dask-collection:
+
+Example Dask Collection
+-----------------------
+
+Here we create a dask collection representing a tuple. Every element in the
+tuple is represented as a task in the graph. Note that this is for illustration
+purposes only - the same user experience could be done using normal tuples with
+elements of ``dask.delayed``.
+
+.. code:: python
+
+    # Saved as dask_tuple.py
+    from dask.base import DaskMethodsMixin
+    from dask.optimize import cull
+
+    # We subclass from DaskMethodsMixin to add common dask methods to our
+    # class. This is nice but not necessary for creating a dask collection.
+    class Tuple(DaskMethodsMixin):
+        def __init__(self, dsk, keys):
+            # The init method takes in a dask graph and a set of keys to use
+            # as outputs.
+            self._dsk = dsk
+            self._keys = keys
+
+        def __dask_graph__(self):
+            return self._dsk
+
+        def __dask_keys__(self):
+            return self._keys
+
+        @staticmethod
+        def __dask_optimize__(dsk, keys, **kwargs):
+            # We cull unnecessary tasks here. Note that this isn't necessary,
+            # dask will do this automatically, this just shows one optimization
+            # you could do.
+            dsk2, _ = cull(dsk, keys)
+            return dsk2
+
+        # Use the threaded scheduler by default.
+        __dask_default_get__ = staticmethod(dask.threaded.get)
+
+        def __dask_postcompute__(self):
+            # We want to return the results as a tuple, so our finalize
+            # function is `tuple`. There are no extra arguments, so we also
+            # return an empty tuple.
+            return tuple, ()
+
+        def __dask_postpersist__(self):
+            # Since our __init__ takes a graph as its first argument, our
+            # rebuild function can just be the class itself. For extra
+            # arguments we also return a tuple containing just the keys.
+            return Tuple, (self._keys,)
+
+        def __dask_tokenize__(self):
+            # For tokenize to work we want to return a value that fully
+            # represents this object. In this case it's the list of keys
+            # to be computed.
+            return tuple(self._keys)
+
+Demonstrating this class:
+
+.. code:: python
+
+    >>> from dask_tuple import Tuple
+    >>> from operator import add, mul
+
+    # Define a dask graph
+    >>> dsk = {'a': 1,
+    ...        'b': 2,
+    ...        'c': (add, 'a', 'b'),
+    ...        'd': (mul, 'b', 2),
+    ...        'e': (add, 'b', 'c')}
+
+    # The output keys for this graph
+    >>> keys = ['b', 'c', 'd', 'e']
+
+    >>> x = Tuple(dsk, keys)
+
+    # Compute turns Tuple into a tuple
+    >>> x.compute()
+    (2, 3, 4, 5)
+
+    # Persist turns Tuple into a Tuple, with each task already computed
+    >>> x2 = x.persist()
+    >>> isinstance(x2, Tuple)
+    True
+    >>> x2.__dask_graph__()
+    {'b': 2,
+     'c': 3,
+     'd': 4,
+     'e': 5}
+    >>> x2.compute()
+    (2, 3, 4, 5)
+
+
+.. _is-dask-collection:
+
+Checking if an object is a dask collection
+------------------------------------------
+
+To check if an object is a dask collection, use
+``dask.base.is_dask_collection``:
+
+.. code:: python
+
+    >>> from dask.base import is_dask_collection
+    >>> from dask import delayed
+
+    >>> x = delayed(sum)([1, 2, 3])
+    >>> is_dask_collection(x)
+    True
+    >>> is_dask_collection(1)
+    False
+
+
+.. _deterministic-hashing:
+
+Implementing Deterministic Hashing
+----------------------------------
+
+Dask implements its own deterministic hash function to generate keys based on
+the value of arguments. This function is available as ``dask.base.tokenize``.
+Many common types already have implementations of ``tokenize``, which can be
+found in ``dask/base.py``.
+
+When creating your own custom classes you may need to register a ``tokenize``
+implementation. There are two ways to do this:
+
+.. note:: Both dask collections and normal python objects can have
+          implementations of ``tokenize`` using either of the methods
+          described below.
+
+1. The ``__dask_tokenize__`` method
+
+   Where possible, it's recommended to define the ``__dask_tokenize__`` method.
+   This method takes no arguments and should return a value fully
+   representative of the object.
+
+2. Register a function with ``dask.base.normalize_token``
+
+   If defining a method on the class isn't possible, you can register a tokenize
+   function with the ``normalize_token`` dispatch. The function should have the
+   same signature as described above.
+
+In both cases the implementation should be the same, only the location of the
+definition is different.
+
+Example
+~~~~~~~
+
+.. code:: python
+
+    >>> from dask.base import tokenize, normalize_token
+
+    # Define a tokenize implementation using a method.
+    >>> class Foo(object):
+    ...     def __init__(self, a, b):
+    ...         self.a = a
+    ...         self.b = b
+    ...
+    ...     def __dask_tokenize__(self):
+    ...         # This tuple fully represents self
+    ...         return (Foo, self.a, self.b)
+
+    >>> x = Foo(1, 2)
+    >>> tokenize(x)
+    '5988362b6e07087db2bc8e7c1c8cc560'
+    >>> tokenize(x) == tokenize(x)  # token is deterministic
+    True
+
+    # Register an implementation with normalize_token
+    >>> class Bar(object):
+    ...     def __init__(self, x, y):
+    ...         self.x = x
+    ...         self.y = y
+
+    >>> @normalize_token.register(Bar)
+    ... def tokenize_bar(x):
+    ...     return (Bar, x.x, x.x)
+
+    >>> y = Bar(1, 2)
+    >>> tokenize(y)
+    '5a7e9c3645aa44cf13d021c14452152e'
+    >>> tokenize(y) == tokenize(y)
+    True
+    >>> tokenize(y) == tokenize(x)  # tokens for different objects aren't equal
+    False
+
+
+For more examples please see ``dask/base.py`` or any of the built-in dask
+collections.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -244,6 +244,7 @@ often a better choice.  If you are a *core developer*, then you should start her
 * :doc:`caching`
 * :doc:`bytes`
 * :doc:`remote-data-services`
+* :doc:`custom-collections`
 * :doc:`cite`
 
 .. toctree::
@@ -261,6 +262,7 @@ often a better choice.  If you are a *core developer*, then you should start her
    caching.rst
    bytes.rst
    remote-data-services.rst
+   custom-collections.rst
    cite.rst
    funding.rst
 


### PR DESCRIPTION
This adds a standard protocol for the dask collections implemented via a set of methods (and no required base class). The methods are similar to the existing non-public api, but not exactly the same. I recommend the new doc page (`docs/source/custom-collections.rst`) as a starting point.

Supersedes #1068.