### PR TITLE
Drop s3fs requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require = {
   'bag': ['cloudpickle >= 0.2.1', 'toolz >= 0.7.3', 'partd >= 0.3.8'],
   'dataframe': ['numpy', 'pandas >= 0.19.0', 'toolz >= 0.7.3',
                 'partd >= 0.3.8', 'cloudpickle >= 0.2.1'],
-  'distributed': ['distributed >= 1.16', 's3fs >= 0.0.8'],
+  'distributed': ['distributed >= 1.16'],
   'delayed': ['toolz >= 0.7.3'],
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
Seems like `s3fs` is or can be optional as one can certainly run a `distributed` cluster without using S3. Looking at `distributed`, it appears to have dropped any requirement on `s3fs` at all. Also any import in `dask` of `s3fs` is guarded against in case `s3fs` is not present. As there are fallbacks that are commonly used when S3 is not used, it seems reasonable to drop `s3fs` as a required dependency of the `distributed` backend. Though maybe `s3fs` should live under a different extra install option.