### PR TITLE
Consolidate changelog for 0.15.4

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,13 +7,10 @@ Changelog
 Array
 +++++
 
--  Indexing with np.int (:pr:`2718`)
--  Rechunking with zero dimensions (:pr:`2747`)
--  Support -1 as an alias for "size of the dimension" in ``chunks``.
--  Call mkdir in array.to_npy_stack (:pr:`2709`)
 -  Support indexing in arrays with np.int (fixes regression) (:pr:`2719`)
 -  Handle zero dimension with rechunking (:pr:`2747`)
--  Support -1 as an alias for dimension size in chunks (:pr:`2749`)
+-  Support -1 as an alias for "size of the dimension" in ``chunks`` (:pr:`2749`)
+-  Call mkdir in array.to_npy_stack (:pr:`2709`)
 
 
 DataFrame
@@ -22,7 +19,6 @@ DataFrame
 -  Added the `.str` accessor to Categoricals with string categories (:pr:`2743`)
 -  Support int96 (spark) datetimes in parquet writer (:pr:`2711`)
 -  Pass on file scheme to fastparquet (:pr:`2714`)
--  Add .str accessor for categorical with object dtype (:pr:`2743`)
 -  Support Pandas 0.21 (:pr:`2737`)
 
 


### PR DESCRIPTION
Drops some duplicate entries in the changelog for the 0.15.4 release.