### PR TITLE
Add atleast_nd functions

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -10,7 +10,8 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        vstack, hstack, compress, extract, round, count_nonzero,
                        flatnonzero, nonzero, around, isnull, notnull, isclose,
                        corrcoef, swapaxes, tensordot, transpose, dot,
-                       apply_along_axis, apply_over_axes, result_type)
+                       apply_along_axis, apply_over_axes, result_type,
+                       atleast_1d, atleast_2d, atleast_3d)
 from .reshape import reshape
 from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
         true_divide, floor_divide, negative, power, remainder, mod, conj, exp,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -40,23 +40,22 @@ def result_type(*args):
 @wraps(np.atleast_3d)
 def atleast_3d(x):
     if x.ndim == 0:
-        return x[None, None, None]
+        x = x[None, None, None]
     elif x.ndim == 1:
-        return x[None, :, None]
+        x = x[None, :, None]
     elif x.ndim == 2:
-        return x[:, :, None]
-    elif x.ndim > 2:
-        return x
+        x = x[:, :, None]
 
+    return x
 
 @wraps(np.atleast_2d)
 def atleast_2d(x):
     if x.ndim == 0:
-        return x[None, None]
+        x = x[None, None]
     elif x.ndim == 1:
-        return x[None, :]
-    elif x.ndim > 1:
-        return x
+        x = x[None, :]
+
+    return x
 
 
 @wraps(np.atleast_1d)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -38,14 +38,14 @@ def result_type(*args):
 
 
 def atleast_3d(x):
-    if x.ndim == 1:
+    if x.ndim == 0:
+        return x[None, None, None]
+    elif x.ndim == 1:
         return x[None, :, None]
     elif x.ndim == 2:
         return x[:, :, None]
     elif x.ndim > 2:
         return x
-    else:
-        raise NotImplementedError()
 
 
 def atleast_2d(x):

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -57,6 +57,13 @@ def atleast_2d(x):
         raise NotImplementedError()
 
 
+def atleast_1d(x):
+    if x.ndim == 0:
+        x = x[None]
+
+    return x
+
+
 @wraps(np.vstack)
 def vstack(tup):
     tup = tuple(atleast_2d(x) for x in tup)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -41,6 +41,7 @@ def result_type(*args):
 def atleast_3d(*arys):
     new_arys = []
     for x in arys:
+        x = asarray(x)
         if x.ndim == 0:
             x = x[None, None, None]
         elif x.ndim == 1:
@@ -60,6 +61,7 @@ def atleast_3d(*arys):
 def atleast_2d(*arys):
     new_arys = []
     for x in arys:
+        x = asarray(x)
         if x.ndim == 0:
             x = x[None, None]
         elif x.ndim == 1:
@@ -77,6 +79,7 @@ def atleast_2d(*arys):
 def atleast_1d(*arys):
     new_arys = []
     for x in arys:
+        x = asarray(x)
         if x.ndim == 0:
             x = x[None]
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -49,12 +49,12 @@ def atleast_3d(x):
 
 
 def atleast_2d(x):
-    if x.ndim == 1:
+    if x.ndim == 0:
+        return x[None, None]
+    elif x.ndim == 1:
         return x[None, :]
     elif x.ndim > 1:
         return x
-    else:
-        raise NotImplementedError()
 
 
 def atleast_1d(x):

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -38,32 +38,54 @@ def result_type(*args):
 
 
 @wraps(np.atleast_3d)
-def atleast_3d(x):
-    if x.ndim == 0:
-        x = x[None, None, None]
-    elif x.ndim == 1:
-        x = x[None, :, None]
-    elif x.ndim == 2:
-        x = x[:, :, None]
+def atleast_3d(*arys):
+    new_arys = []
+    for x in arys:
+        if x.ndim == 0:
+            x = x[None, None, None]
+        elif x.ndim == 1:
+            x = x[None, :, None]
+        elif x.ndim == 2:
+            x = x[:, :, None]
 
-    return x
+        new_arys.append(x)
+
+    if len(new_arys) == 1:
+        return new_arys[0]
+    else:
+        return new_arys
+
 
 @wraps(np.atleast_2d)
-def atleast_2d(x):
-    if x.ndim == 0:
-        x = x[None, None]
-    elif x.ndim == 1:
-        x = x[None, :]
+def atleast_2d(*arys):
+    new_arys = []
+    for x in arys:
+        if x.ndim == 0:
+            x = x[None, None]
+        elif x.ndim == 1:
+            x = x[None, :]
 
-    return x
+        new_arys.append(x)
+
+    if len(new_arys) == 1:
+        return new_arys[0]
+    else:
+        return new_arys
 
 
 @wraps(np.atleast_1d)
-def atleast_1d(x):
-    if x.ndim == 0:
-        x = x[None]
+def atleast_1d(*arys):
+    new_arys = []
+    for x in arys:
+        if x.ndim == 0:
+            x = x[None]
 
-    return x
+        new_arys.append(x)
+
+    if len(new_arys) == 1:
+        return new_arys[0]
+    else:
+        return new_arys
 
 
 @wraps(np.vstack)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -37,6 +37,7 @@ def result_type(*args):
     return np.result_type(*args)
 
 
+@wraps(np.atleast_3d)
 def atleast_3d(x):
     if x.ndim == 0:
         return x[None, None, None]
@@ -48,6 +49,7 @@ def atleast_3d(x):
         return x
 
 
+@wraps(np.atleast_2d)
 def atleast_2d(x):
     if x.ndim == 0:
         return x[None, None]
@@ -57,6 +59,7 @@ def atleast_2d(x):
         return x
 
 
+@wraps(np.atleast_1d)
 def atleast_1d(x):
     if x.ndim == 0:
         x = x[None]

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -27,6 +27,11 @@ def test_array():
     "atleast_2d",
     "atleast_3d",
 ])
+@pytest.mark.parametrize("num_arrs", [
+    0,
+    1,
+    2
+])
 @pytest.mark.parametrize("shape, chunks", [
     (tuple(), tuple()),
     ((4,), (2,)),
@@ -34,17 +39,32 @@ def test_array():
     ((4, 6, 8), (2, 3, 4)),
     ((4, 6, 8, 10), (2, 3, 4, 5)),
 ])
-def test_atleast_nd(funcname, shape, chunks):
+def test_atleast_nd(funcname, num_arrs, shape, chunks):
     np_a = np.random.random(shape)
     da_a = da.from_array(np_a, chunks=chunks)
+
+    np_a_n = num_arrs * [np_a]
+    da_a_n = num_arrs * [da_a]
 
     np_func = getattr(np, funcname)
     da_func = getattr(da, funcname)
 
-    np_r = np_func(np_a)
-    da_r = da_func(da_a)
+    np_r_n = np_func(*np_a_n)
+    da_r_n = da_func(*da_a_n)
 
-    assert_eq(np_r, da_r)
+    if num_arrs != 1:
+        assert type(np_r_n) is type(da_r_n)
+    else:
+        assert type(np_r_n) is np.ndarray
+        assert type(da_r_n) is da.Array
+
+        np_r_n = [np_r_n]
+        da_r_n = [da_r_n]
+
+    assert len(np_r_n) == len(da_r_n)
+
+    for np_r, da_r in zip(np_r_n, da_r_n):
+        assert_eq(np_r, da_r)
 
 
 def test_transpose():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -22,6 +22,31 @@ def test_array():
     assert isinstance(y, da.Array)
 
 
+@pytest.mark.parametrize("funcname", [
+    "atleast_1d",
+    "atleast_2d",
+    "atleast_3d",
+])
+@pytest.mark.parametrize("shape, chunks", [
+    (tuple(), tuple()),
+    ((4,), (2,)),
+    ((4, 6), (2, 3)),
+    ((4, 6, 8), (2, 3, 4)),
+    ((4, 6, 8, 10), (2, 3, 4, 5)),
+])
+def test_atleast_nd(funcname, shape, chunks):
+    np_a = np.random.random(shape)
+    da_a = da.from_array(np_a, chunks=chunks)
+
+    np_func = getattr(np, funcname)
+    da_func = getattr(da, funcname)
+
+    np_r = np_func(np_a)
+    da_r = da_func(da_a)
+
+    assert_eq(np_r, da_r)
+
+
 def test_transpose():
     x = np.arange(240).reshape((4, 6, 10))
     d = da.from_array(x, (2, 3, 4))

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -24,6 +24,9 @@ Top level user functions:
    argwhere
    around
    array
+   atleast_1d
+   atleast_2d
+   atleast_3d
    bincount
    broadcast_to
    coarsen
@@ -341,6 +344,9 @@ Other functions
 .. autofunction:: argwhere
 .. autofunction:: around
 .. autofunction:: array
+.. autofunction:: atleast_1d
+.. autofunction:: atleast_2d
+.. autofunction:: atleast_3d
 .. autofunction:: bincount
 .. autofunction:: broadcast_to
 .. autofunction:: coarsen

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,7 +7,7 @@ X.Y.Z / YYYY-MM-DD
 Array
 +++++
 
--
+- Add ``atleast_1d``, ``atleast_2d``, and ``atleast_3d`` (:pr:`2760`)
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2753

Exposes the `atleast_2d` and `atleast_3d` functions that were already present as part of Dask Array's public API. Also adds support for the 0-D case and multiple arrays to both of them. Adds `atleast_1d` as well. Provides tests to compare all of these functions to the NumPy equivalents. Includes them in the API docs. Makes a changelog entry for this addition.