### PR TITLE
Use get_worker().client.get if available

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     pass
 try:
-    from .base import visualize, compute, persist
+    from .base import visualize, compute, persist, thread_state
 except ImportError:
     pass
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -193,6 +193,10 @@ def compute(*args, **kwargs):
 
     get = kwargs.pop('get', None) or _globals['get']
 
+    if get is None and _globals.get('distributed_worker'):
+        from distributed.worker import get_worker
+        get = get_worker().client.get
+
     if not get:
         get = variables[0]._default_get
         if not all(a._default_get == get for a in variables):
@@ -553,6 +557,10 @@ def persist(*args, **kwargs):
         return args
 
     get = kwargs.pop('get', None) or _globals['get']
+
+    if get is None and _globals.get('distributed_worker'):
+        from distributed.worker import get_worker
+        get = get_worker().client.get
 
     if inspect.ismethod(get):
         try:

--- a/dask/base.py
+++ b/dask/base.py
@@ -24,6 +24,9 @@ from .sharedict import ShareDict
 __all__ = ("Base", "compute", "normalize_token", "tokenize", "visualize")
 
 
+thread_state = threading.local()
+
+
 class Base(object):
     """Base class for dask collections"""
     __slots__ = ()
@@ -193,7 +196,7 @@ def compute(*args, **kwargs):
 
     get = kwargs.pop('get', None) or _globals['get']
 
-    if get is None and _globals.get('distributed_worker'):
+    if get is None and getattr(thread_state, 'key', False):
         from distributed.worker import get_worker
         get = get_worker().client.get
 
@@ -558,7 +561,7 @@ def persist(*args, **kwargs):
 
     get = kwargs.pop('get', None) or _globals['get']
 
-    if get is None and _globals.get('distributed_worker'):
+    if get is None and getattr(thread_state, 'key', False):
         from distributed.worker import get_worker
         get = get_worker().client.get
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,8 @@ Core
 ++++
 
 -  Allow tuples as sharedict keys (:pr:`2763`)
+-  Calling compute within a dask.distributed task defaults to distributed
+   scheduler (:pr:`2762`)
 
 0.15.4 / 2017-10-06
 -------------------


### PR DESCRIPTION
This makes tasks within workers to default to the distribued
scheduler's get.

Depends on https://github.com/dask/distributed/pull/1465

- [ ] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
