### PR TITLE
Follow-up for atleast_nd

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -18,7 +18,7 @@ from ..base import tokenize
 from . import numpy_compat, chunk
 
 from .core import (Array, map_blocks, elemwise, from_array, asarray,
-                   concatenate, stack, atop, broadcast_shapes,
+                   asanyarray, concatenate, stack, atop, broadcast_shapes,
                    is_scalar_for_elemwise, broadcast_to, tensordot_lookup)
 
 
@@ -41,7 +41,7 @@ def result_type(*args):
 def atleast_3d(*arys):
     new_arys = []
     for x in arys:
-        x = asarray(x)
+        x = asanyarray(x)
         if x.ndim == 0:
             x = x[None, None, None]
         elif x.ndim == 1:
@@ -61,7 +61,7 @@ def atleast_3d(*arys):
 def atleast_2d(*arys):
     new_arys = []
     for x in arys:
-        x = asarray(x)
+        x = asanyarray(x)
         if x.ndim == 0:
             x = x[None, None]
         elif x.ndim == 1:
@@ -79,7 +79,7 @@ def atleast_2d(*arys):
 def atleast_1d(*arys):
     new_arys = []
     for x in arys:
-        x = asarray(x)
+        x = asanyarray(x)
         if x.ndim == 0:
             x = x[None]
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -82,6 +82,9 @@ def test_atleast_nd_one_arg(funcname, shape, chunks):
     ((4, 6, 8, 10), (2, 3, 4, 5)),
 ])
 def test_atleast_nd_two_args(funcname, shape1, chunks1, shape2, chunks2):
+    if len(shape1) > len(shape2):
+        pytest.skip("The reverse order case is already tested.")
+
     np_a_1 = np.random.random(shape1)
     da_a_1 = da.from_array(np_a_1, chunks=chunks1)
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -27,8 +27,22 @@ def test_array():
     "atleast_2d",
     "atleast_3d",
 ])
+def test_atleast_nd_no_args(funcname):
+    np_func = getattr(np, funcname)
+    da_func = getattr(da, funcname)
+
+    np_r_n = np_func()
+    da_r_n = da_func()
+
+    assert np_r_n == da_r_n
+
+
+@pytest.mark.parametrize("funcname", [
+    "atleast_1d",
+    "atleast_2d",
+    "atleast_3d",
+])
 @pytest.mark.parametrize("num_arrs", [
-    0,
     1,
     2
 ])

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -42,9 +42,30 @@ def test_atleast_nd_no_args(funcname):
     "atleast_2d",
     "atleast_3d",
 ])
-@pytest.mark.parametrize("num_arrs", [
-    1,
-    2
+@pytest.mark.parametrize("shape, chunks", [
+    (tuple(), tuple()),
+    ((4,), (2,)),
+    ((4, 6), (2, 3)),
+    ((4, 6, 8), (2, 3, 4)),
+    ((4, 6, 8, 10), (2, 3, 4, 5)),
+])
+def test_atleast_nd_one_arg(funcname, shape, chunks):
+    np_a = np.random.random(shape)
+    da_a = da.from_array(np_a, chunks=chunks)
+
+    np_func = getattr(np, funcname)
+    da_func = getattr(da, funcname)
+
+    np_r = np_func(np_a)
+    da_r = da_func(da_a)
+
+    assert_eq(np_r, da_r)
+
+
+@pytest.mark.parametrize("funcname", [
+    "atleast_1d",
+    "atleast_2d",
+    "atleast_3d",
 ])
 @pytest.mark.parametrize("shape, chunks", [
     (tuple(), tuple()),
@@ -53,7 +74,9 @@ def test_atleast_nd_no_args(funcname):
     ((4, 6, 8), (2, 3, 4)),
     ((4, 6, 8, 10), (2, 3, 4, 5)),
 ])
-def test_atleast_nd(funcname, num_arrs, shape, chunks):
+def test_atleast_nd_two_args(funcname, shape, chunks):
+    num_arrs = 2
+
     np_a = np.random.random(shape)
     da_a = da.from_array(np_a, chunks=chunks)
 
@@ -66,14 +89,7 @@ def test_atleast_nd(funcname, num_arrs, shape, chunks):
     np_r_n = np_func(*np_a_n)
     da_r_n = da_func(*da_a_n)
 
-    if num_arrs != 1:
-        assert type(np_r_n) is type(da_r_n)
-    else:
-        assert type(np_r_n) is np.ndarray
-        assert type(da_r_n) is da.Array
-
-        np_r_n = [np_r_n]
-        da_r_n = [da_r_n]
+    assert type(np_r_n) is type(da_r_n)
 
     assert len(np_r_n) == len(da_r_n)
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -67,21 +67,29 @@ def test_atleast_nd_one_arg(funcname, shape, chunks):
     "atleast_2d",
     "atleast_3d",
 ])
-@pytest.mark.parametrize("shape, chunks", [
+@pytest.mark.parametrize("shape1, chunks1", [
     (tuple(), tuple()),
     ((4,), (2,)),
     ((4, 6), (2, 3)),
     ((4, 6, 8), (2, 3, 4)),
     ((4, 6, 8, 10), (2, 3, 4, 5)),
 ])
-def test_atleast_nd_two_args(funcname, shape, chunks):
-    num_arrs = 2
+@pytest.mark.parametrize("shape2, chunks2", [
+    (tuple(), tuple()),
+    ((4,), (2,)),
+    ((4, 6), (2, 3)),
+    ((4, 6, 8), (2, 3, 4)),
+    ((4, 6, 8, 10), (2, 3, 4, 5)),
+])
+def test_atleast_nd_two_args(funcname, shape1, chunks1, shape2, chunks2):
+    np_a_1 = np.random.random(shape1)
+    da_a_1 = da.from_array(np_a_1, chunks=chunks1)
 
-    np_a = np.random.random(shape)
-    da_a = da.from_array(np_a, chunks=chunks)
+    np_a_2 = np.random.random(shape2)
+    da_a_2 = da.from_array(np_a_2, chunks=chunks2)
 
-    np_a_n = num_arrs * [np_a]
-    da_a_n = num_arrs * [da_a]
+    np_a_n = [np_a_1, np_a_2]
+    da_a_n = [da_a_1, da_a_2]
 
     np_func = getattr(np, funcname)
     da_func = getattr(da, funcname)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1,5 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
+import itertools
+
 import pytest
 from distutils.version import LooseVersion
 
@@ -67,29 +69,24 @@ def test_atleast_nd_one_arg(funcname, shape, chunks):
     "atleast_2d",
     "atleast_3d",
 ])
-@pytest.mark.parametrize("shape1, chunks1", [
-    (tuple(), tuple()),
-    ((4,), (2,)),
-    ((4, 6), (2, 3)),
-    ((4, 6, 8), (2, 3, 4)),
-    ((4, 6, 8, 10), (2, 3, 4, 5)),
-])
-@pytest.mark.parametrize("shape2, chunks2", [
-    (tuple(), tuple()),
-    ((4,), (2,)),
-    ((4, 6), (2, 3)),
-    ((4, 6, 8), (2, 3, 4)),
-    ((4, 6, 8, 10), (2, 3, 4, 5)),
-])
-def test_atleast_nd_two_args(funcname, shape1, chunks1, shape2, chunks2):
-    if len(shape1) > len(shape2):
-        pytest.skip("The reverse order case is already tested.")
-
+@pytest.mark.parametrize("shape1, shape2", list(
+    itertools.combinations_with_replacement(
+        [
+            tuple(),
+            (4,),
+            (4, 6),
+            (4, 6, 8),
+            (4, 6, 8, 10),
+        ],
+        2
+    )
+))
+def test_atleast_nd_two_args(funcname, shape1, shape2):
     np_a_1 = np.random.random(shape1)
-    da_a_1 = da.from_array(np_a_1, chunks=chunks1)
+    da_a_1 = da.from_array(np_a_1, chunks=tuple(c // 2 for c in shape1))
 
     np_a_2 = np.random.random(shape2)
-    da_a_2 = da.from_array(np_a_2, chunks=chunks2)
+    da_a_2 = da.from_array(np_a_2, chunks=tuple(c // 2 for c in shape2))
 
     np_a_n = [np_a_1, np_a_2]
     da_a_n = [da_a_1, da_a_2]


### PR DESCRIPTION
Follow-up on PR ( https://github.com/dask/dask/pull/2760 )

Changes made to the `atleast_nd` functions and their tests:

* Makes use of `asanyarray`.
* Simplifies testing of the no argument case.
* Breaks out testing of the one argument case (drops NumPy `assert`).
* Handles two potentially different sized arrays for in two argument case.