### PR TITLE
Link PR for "Allow tuples as sharedict keys"

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,7 +23,7 @@ Bag
 Core
 ++++
 
--  Allow tuples as sharedict keys
+-  Allow tuples as sharedict keys (:pr:`2763`)
 
 0.15.4 / 2017-10-06
 -------------------


### PR DESCRIPTION
Make sure the link to the PR shows up in the changelog.

xref: https://github.com/dask/dask/pull/2763