### PR TITLE
Add allclose

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -9,7 +9,7 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        bincount, digitize, histogram, cov, array, dstack,
                        vstack, hstack, compress, extract, round, count_nonzero,
                        flatnonzero, nonzero, around, isnull, notnull, isclose,
-                       corrcoef, swapaxes, tensordot, transpose, dot,
+                       allclose, corrcoef, swapaxes, tensordot, transpose, dot,
                        apply_along_axis, apply_over_axes, result_type,
                        atleast_1d, atleast_2d, atleast_3d)
 from .reshape import reshape

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -728,6 +728,11 @@ def isclose(arr1, arr2, rtol=1e-5, atol=1e-8, equal_nan=False):
     return elemwise(func, arr1, arr2, dtype='bool')
 
 
+@wraps(np.allclose)
+def allclose(arr1, arr2, rtol=1e-5, atol=1e-8, equal_nan=False):
+    return isclose(arr1, arr2, rtol=rtol, atol=atol, equal_nan=equal_nan).all()
+
+
 def variadic_choose(a, *choices):
     return np.choose(a, choices)
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -660,6 +660,19 @@ def test_isclose():
               np.isclose(x, y, equal_nan=True))
 
 
+def test_allclose():
+    n_a = np.array([0, np.nan, 1, 1.5])
+    n_b = np.array([1e-9, np.nan, 1, 2])
+
+    d_a = da.from_array(n_a, chunks=(2,))
+    d_b = da.from_array(n_b, chunks=(2,))
+
+    n_r = np.allclose(n_a, n_b, equal_nan=True)
+    d_r = da.allclose(d_a, d_b, equal_nan=True)
+
+    assert_eq(np.array(n_r)[()], d_r)
+
+
 def test_choose():
     # test choose function
     x = np.random.randint(10, size=(15, 16))

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -7,6 +7,7 @@ Top level user functions:
 
 .. autosummary::
    all
+   allclose
    angle
    any
    apply_along_axis
@@ -327,6 +328,7 @@ Other functions
 .. autofunction:: concatenate
 
 .. autofunction:: all
+.. autofunction:: allclose
 .. autofunction:: angle
 .. autofunction:: any
 .. autofunction:: apply_along_axis

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Array
 +++++
 
 - Add ``atleast_1d``, ``atleast_2d``, and ``atleast_3d`` (:pr:`2760`)
+- Add ``allclose`` (:pr:`2771`)
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2756

Implements the equivalent of NumPy's `allclose` for Dask Arrays and adds it to the public API. Simply leverages Dask Array's `isclose` function and `all` method for the computation. Provides a simple test of Dask Array's `allclose` compared to NumPy. Includes `allclose` in Dask Array's API docs and mentions it in the changelog.