### PR TITLE
Remove `random.different_seeds` from API docs

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -227,7 +227,6 @@ Random
    random.beta
    random.binomial
    random.chisquare
-   random.different_seeds
    random.exponential
    random.f
    random.gamma

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Array
 +++++
 
 - Add ``atleast_1d``, ``atleast_2d``, and ``atleast_3d`` (:pr:`2760`)
+- Remove ``random.different_seeds`` from Dask Array API docs (:pr:`2772`)
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2724

Seems that `random.different_seeds` is not available in the API. So shouldn't be listed in the Dask Array API docs. Thanks @maxgamurar for raising this.

cc @TomAugspurger