### PR TITLE
Deprecate vnorm

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 from functools import partial, wraps
 from itertools import product, repeat
 from math import factorial, log, ceil
@@ -440,6 +442,12 @@ def vnorm(a, ord=None, axis=None, dtype=None, keepdims=False, split_every=None,
 
     See np.linalg.norm
     """
+
+    warnings.warn(
+        "DeprecationWarning: Please use `dask.array.linalg.norm` instead.",
+        UserWarning
+    )
+
     if ord is None or ord == 'fro':
         ord = 2
     if ord == np.inf:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Array
 - Add ``atleast_1d``, ``atleast_2d``, and ``atleast_3d`` (:pr:`2760`)
 - Add ``allclose`` (:pr:`2771`)
 - Remove ``random.different_seeds`` from Dask Array API docs (:pr:`2772`)
+- Deprecate ``vnorm`` in favor of ``dask.array.linalg.norm`` (:pr:`2773`)
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2606

At this point, users can get the same functionality from `dask.array.linalg`'s `norm`. Since the latter matches a name from NumPy and `vnorm` does not, it makes more sense to deprecate `vnorm` and direct users to `norm`.