### PR TITLE
Implement Dask Array's unique to be lazy

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -14,12 +14,14 @@ from toolz import concat, sliding_window, interleave
 
 from .. import sharedict
 from ..core import flatten
-from ..base import tokenize, compute_as_if_collection
+from ..base import tokenize
+from ..delayed import delayed
 from . import numpy_compat, chunk
 
 from .core import (Array, map_blocks, elemwise, from_array, asarray,
-                   asanyarray, concatenate, stack, atop, broadcast_shapes,
-                   is_scalar_for_elemwise, broadcast_to, tensordot_lookup)
+                   from_delayed, asanyarray, concatenate, stack, atop,
+                   broadcast_shapes, is_scalar_for_elemwise, broadcast_to,
+                   tensordot_lookup)
 
 
 @wraps(np.array)
@@ -530,11 +532,14 @@ def round(a, decimals=0):
 
 @wraps(np.unique)
 def unique(x):
-    name = 'unique-' + x.name
-    dsk = {(name, i): (np.unique, key) for i, key in enumerate(x.__dask_keys__())}
-    parts = compute_as_if_collection(Array, sharedict.merge((name, dsk), x.dask),
-                                     list(dsk.keys()))
-    return np.unique(np.concatenate(parts))
+    x = x.ravel()
+
+    out = atop(np.unique, "i", x, "i", dtype=x.dtype)
+    out._chunks = tuple((np.nan,) * len(c) for c in out.chunks)
+
+    out = from_delayed(delayed(np.unique)(out), (np.nan,), x.dtype)
+
+    return out
 
 
 @wraps(np.roll)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -473,9 +473,15 @@ def test_round():
 
 
 def test_unique():
-    x = np.array([1, 2, 4, 4, 5, 2])
-    d = da.from_array(x, chunks=(3,))
-    assert_eq(da.unique(d), np.unique(x))
+    a = np.array([1, 2, 4, 4, 5, 2])
+    d = da.from_array(a, chunks=(3,))
+
+    r_a = np.unique(a)
+    r_d = da.unique(d)
+
+    assert isinstance(r_d, da.Array)
+
+    assert_eq(r_d, r_a)
 
 
 def _maybe_len(l):

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -240,7 +240,7 @@ def from_bcolz(x, chunksize=None, categorize=True, index=None, lock=lock,
                     np.issubdtype(x.dtype[name], np.unicode_) or
                     np.issubdtype(x.dtype[name], np.object_)):
                 a = da.from_array(x[name], chunks=(chunksize * len(x.names),))
-                categories[name] = da.unique(a)
+                categories[name] = da.unique(a).compute()
 
     columns = tuple(x.dtype.names)
     divisions = tuple(range(0, len(x), chunksize))

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,7 @@ Array
 - Add ``allclose`` (:pr:`2771`)
 - Remove ``random.different_seeds`` from Dask Array API docs (:pr:`2772`)
 - Deprecate ``vnorm`` in favor of ``dask.array.linalg.norm`` (:pr:`2773`)
+- Reimplement ``unique`` to be lazy (:pr:`2775`)
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2566

Previously Dask Array's `unique` would compute the result when called. Given Dask's typically lazy nature, this was a bit surprising for users. However for a while the needed features for a lazy `unique` implementation (e.g. unknown shapes) simply did not exist. Now that it looks like the needed features are available, rewrite `unique` to be lazy to more closely match the behavior of other functions in Dask.
