### PR TITLE
Support `return_*` arguments with `unique`

### DIFF
--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -472,16 +472,33 @@ def test_round():
     assert_eq(d.round(2), da.round(d, 2))
 
 
-def test_unique():
+@pytest.mark.parametrize("return_index", [False, True])
+@pytest.mark.parametrize("return_inverse", [False, True])
+@pytest.mark.parametrize("return_counts", [False, True])
+def test_unique(return_index, return_inverse, return_counts):
+    kwargs = dict(
+        return_index=return_index,
+        return_inverse=return_inverse,
+        return_counts=return_counts
+    )
+
     a = np.array([1, 2, 4, 4, 5, 2])
     d = da.from_array(a, chunks=(3,))
 
-    r_a = np.unique(a)
-    r_d = da.unique(d)
+    r_a = np.unique(a, **kwargs)
+    r_d = da.unique(d, **kwargs)
 
-    assert isinstance(r_d, da.Array)
+    if not any([return_index, return_inverse, return_counts]):
+        assert isinstance(r_a, np.ndarray)
+        assert isinstance(r_d, da.Array)
 
-    assert_eq(r_d, r_a)
+        r_a = (r_a,)
+        r_d = (r_d,)
+
+    assert len(r_a) == len(r_d)
+
+    for e_r_a, e_r_d in zip(r_a, r_d):
+        assert_eq(e_r_d, e_r_a)
 
 
 def _maybe_len(l):

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,7 @@ Array
 - Reimplement ``unique`` to be lazy (:pr:`2775`)
 - Support broadcasting of Dask Arrays with 0-length dimensions (:pr:`2784`)
 - Add ``asarray`` and ``asanyarray`` to Dask Array API docs (:pr:`2787`)
+- Support ``unique``'s ``return_*`` arguments (:pr:`2779`)
 
 DataFrame
 +++++++++


### PR DESCRIPTION
~~Requires PR ( https://github.com/dask/dask/pull/2775 ).~~ (already merged)
~~Requires PR ( https://github.com/dask/dask/pull/2784 ) (for the empty array case with `return_inverse=True`).~~ (already merged)
Closes https://github.com/dask/dask/pull/2639

Adds support for `return_index`, `return_inverse`, and `return_counts` with `unique`. This builds off of the lazy `unique` implementation in PR ( https://github.com/dask/dask/pull/2775 ). All of these when computed are done so lazily. As support for these parameters requires returning multiple arrays, which doesn't seem to be supported for things like `atop`, this implementation leverages structured arrays to workaround this constraint. This way the structured array holds each of the different results under a different record, which can easily be selected out on the other end. To handle these formatting issues and combining results from different blocks, an internal unique function is introduced, which uses NumPy's `unique` under the hood. Provides a simple test against NumPy's `unique` with similar arguments. Also adds a note to the changelog about this addition.