### PR TITLE
Reduce test memory usage

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2477,23 +2477,21 @@ def test_broadcast_against_zero_shape():
               np.ones((5, 5))[:, :0] + 0.1)
 
 
-def test_fast_from_array():
-    x = np.zeros(10000000)
-    start = time.time()
-    da.from_array(x, chunks=x.shape[0] / 10, name='x')
-    end = time.time()
-    assert end - start < 0.100
-
-
-def test_random_from_array():
-    x = np.zeros(500000000)
-    start = time.time()
-    y = da.from_array(x, chunks=x.shape[0] / 10, name=False)
-    end = time.time()
-    assert end - start < 0.400
-
-    y2 = da.from_array(x, chunks=x.shape[0] / 10, name=False)
-    assert y.name != y2.name
+def test_from_array_name():
+    x = np.array([1, 2, 3, 4, 5])
+    chunks = x.shape
+    # Default is tokenize the array
+    dx = da.from_array(x, chunks=chunks)
+    hashed_name = dx.name
+    assert da.from_array(x, chunks=chunks).name == hashed_name
+    # Specify name directly
+    assert da.from_array(x, chunks=chunks, name='x').name == 'x'
+    # False gives a random name
+    dx2 = da.from_array(x, chunks=chunks, name=False)
+    dx3 = da.from_array(x, chunks=chunks, name=False)
+    assert dx2.name != hashed_name
+    assert dx3.name != hashed_name
+    assert dx2.name != dx3.name
 
 
 def test_concatenate_errs():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1910,7 +1910,7 @@ def test_cov_corr_meta():
 
 @pytest.mark.slow
 def test_cov_corr_stable():
-    df = pd.DataFrame(np.random.random((20000000, 2)) * 2 - 1, columns=['a', 'b'])
+    df = pd.DataFrame(np.random.uniform(-1, 1, (20000000, 2)), columns=['a', 'b'])
     ddf = dd.from_pandas(df, npartitions=50)
     assert_eq(ddf.cov(split_every=8), df.cov())
     assert_eq(ddf.corr(split_every=8), df.corr())


### PR DESCRIPTION
There were a few tests that allocated large arrays. This is an attempt to minimize the cases where those are necessary.

- Fixes #2761.
- This and #2738 together reduce our test memory usage by a fair bit, fixes #2671.


