### PR TITLE
Support broadcasting 0-length dimensions

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2497,8 +2497,8 @@ def broadcast_shapes(*shapes):
         return shapes[0]
     out = []
     for sizes in zip_longest(*map(reversed, shapes), fillvalue=-1):
-        dim = max(sizes)
-        if any(i != -1 and i != 1 and i != dim and not np.isnan(i) for i in sizes):
+        dim = 0 if 0 in sizes else max(sizes)
+        if any(i != -1 and i != 0 and i != 1 and i != dim and not np.isnan(i) for i in sizes):
             raise ValueError("operands could not be broadcast together with "
                              "shapes {0}".format(' '.join(map(str, shapes))))
         out.append(dim)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2498,7 +2498,7 @@ def broadcast_shapes(*shapes):
     out = []
     for sizes in zip_longest(*map(reversed, shapes), fillvalue=-1):
         dim = 0 if 0 in sizes else max(sizes)
-        if any(i != -1 and i != 0 and i != 1 and i != dim and not np.isnan(i) for i in sizes):
+        if any(i not in [-1, 0, 1, dim] and not np.isnan(i) for i in sizes):
             raise ValueError("operands could not be broadcast together with "
                              "shapes {0}".format(' '.join(map(str, shapes))))
         out.append(dim)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -608,6 +608,28 @@ def test_broadcast_to_scalar():
         assert_eq(a, d)
 
 
+@pytest.mark.parametrize('u_shape, v_shape', [
+    [tuple(), (2, 3)],
+    [(1,), (2, 3)],
+    [(1, 1), (2, 3)],
+    [(0, 3), (1, 3)],
+    [(2, 0), (2, 1)],
+    [(1, 0), (2, 1)],
+    [(0, 1), (1, 3)],
+])
+def test_broadcast_operator(u_shape, v_shape):
+    u = np.random.random(u_shape)
+    v = np.random.random(v_shape)
+
+    d_u = from_array(u, chunks=1)
+    d_v = from_array(v, chunks=1)
+
+    w = u * v
+    d_w = d_u * d_v
+
+    assert_eq(w, d_w)
+
+
 @pytest.mark.parametrize('original_shape,new_shape,chunks', [
     ((10,), (10,), (3, 3, 4)),
     ((10,), (10, 1, 1), 5),

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -407,6 +407,7 @@ def test_binops():
 
 
 def test_broadcast_shapes():
+    assert (0, 5) == broadcast_shapes((0, 1), (1, 5))
     assert (3, 4, 5) == broadcast_shapes((3, 4, 5), (4, 1), ())
     assert (3, 4) == broadcast_shapes((3, 1), (1, 4), (4,))
     assert (5, 6, 7, 3, 4) == broadcast_shapes((3, 1), (), (5, 6, 7, 1, 4))
@@ -574,7 +575,7 @@ def test_broadcast_to():
     x = np.random.randint(10, size=(5, 1, 6))
     a = from_array(x, chunks=(3, 1, 3))
 
-    for shape in [a.shape, (5, 4, 6), (2, 5, 1, 6), (3, 4, 5, 4, 6)]:
+    for shape in [a.shape, (5, 0, 6), (5, 4, 6), (2, 5, 1, 6), (3, 4, 5, 4, 6)]:
         xb = chunk.broadcast_to(x, shape)
         ab = broadcast_to(a, shape)
 
@@ -590,7 +591,7 @@ def test_broadcast_to():
 def test_broadcast_to_array():
     x = np.random.randint(10, size=(5, 1, 6))
 
-    for shape in [(5, 4, 6), (2, 5, 1, 6), (3, 4, 5, 4, 6)]:
+    for shape in [(5, 0, 6), (5, 4, 6), (2, 5, 1, 6), (3, 4, 5, 4, 6)]:
         a = np.broadcast_to(x, shape)
         d = broadcast_to(x, shape)
 
@@ -600,7 +601,7 @@ def test_broadcast_to_array():
 def test_broadcast_to_scalar():
     x = 5
 
-    for shape in [tuple(), (2, 3), (5, 4, 6), (2, 5, 1, 6), (3, 4, 5, 4, 6)]:
+    for shape in [tuple(), (0,), (2, 3), (5, 4, 6), (2, 5, 1, 6), (3, 4, 5, 4, 6)]:
         a = np.broadcast_to(x, shape)
         d = broadcast_to(x, shape)
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ Array
 - Remove ``random.different_seeds`` from Dask Array API docs (:pr:`2772`)
 - Deprecate ``vnorm`` in favor of ``dask.array.linalg.norm`` (:pr:`2773`)
 - Reimplement ``unique`` to be lazy (:pr:`2775`)
+- Support broadcasting of Dask Arrays with 0-length dimensions (:pr:`2784`)
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2780

Allows 0-length dimensions to be broadcasted and forces the broadcasted shape to 0 along those dimensions. Provides some tests for broadcasting arrays with 0-length dimensions.