### PR TITLE
Adds asarray and asanyarray to the dask.array public API

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2441,7 +2441,9 @@ def asarray(a):
     """
     if isinstance(a, Array):
         return a
-    if not isinstance(getattr(a, 'shape', None), Iterable):
+    if isinstance(a, (list, tuple)) and any(isinstance(i, Array) for i in a):
+        a = stack(a)
+    elif not isinstance(getattr(a, 'shape', None), Iterable):
         a = np.asarray(a)
     return from_array(a, chunks=a.shape, getitem=getter_inline)
 
@@ -2475,7 +2477,9 @@ def asanyarray(a):
     """
     if isinstance(a, Array):
         return a
-    if not isinstance(getattr(a, 'shape', None), Iterable):
+    if isinstance(a, (list, tuple)) and any(isinstance(i, Array) for i in a):
+        a = stack(a)
+    elif not isinstance(getattr(a, 'shape', None), Iterable):
         a = np.asanyarray(a)
     return from_array(a, chunks=a.shape, getitem=getter_inline,
                       asarray=False)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2415,13 +2415,29 @@ def insert_to_ooc(out, arr, lock=True, region=None):
 
 
 def asarray(array):
-    """Coerce argument into a dask array
+    """Coerce array-like object into a dask array.
+
+    Parameters
+    ----------
+    array : array-like
+        Input to be coerced into a dask array.
+
+    Returns
+    -------
+    dask array
 
     Examples
     --------
+    >>> import dask.array as da
+    >>> import numpy as np
     >>> x = np.arange(3)
-    >>> asarray(x)
+    >>> da.asarray(x)
     dask.array<array, shape=(3,), dtype=int64, chunksize=(3,)>
+
+    >>> y = [[1, 2, 3], [4, 5, 6]]
+    >>> da.asarray(y)
+    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3)>
+
     """
     if isinstance(array, Array):
         return array

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2446,22 +2446,38 @@ def asarray(a):
     return from_array(a, chunks=a.shape, getitem=getter_inline)
 
 
-def asanyarray(array):
-    """Coerce argument into a dask array.
+def asanyarray(a):
+    """Convert the input to a dask array.
 
-    Subclasses of `np.ndarray` will be passed through as chunks unchanged.
+    Subclasses of ``np.ndarray`` will be passed through as chunks unchanged.
+
+    Parameters
+    ----------
+    a : array-like
+        Input data, in any form that can be converted to a dask array.
+
+    Returns
+    -------
+    out : dask array
+        Dask array interpretation of a.
 
     Examples
     --------
+    >>> import dask.array as da
+    >>> import numpy as np
     >>> x = np.arange(3)
-    >>> asanyarray(x)
+    >>> da.asanyarray(x)
     dask.array<array, shape=(3,), dtype=int64, chunksize=(3,)>
+
+    >>> y = [[1, 2, 3], [4, 5, 6]]
+    >>> da.asanyarray(y)
+    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3)>
     """
-    if isinstance(array, Array):
-        return array
-    if not isinstance(getattr(array, 'shape', None), Iterable):
-        array = np.asanyarray(array)
-    return from_array(array, chunks=array.shape, getitem=getter_inline,
+    if isinstance(a, Array):
+        return a
+    if not isinstance(getattr(a, 'shape', None), Iterable):
+        a = np.asanyarray(a)
+    return from_array(a, chunks=a.shape, getitem=getter_inline,
                       asarray=False)
 
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2414,17 +2414,18 @@ def insert_to_ooc(out, arr, lock=True, region=None):
     return dsk
 
 
-def asarray(array):
-    """Coerce array-like object into a dask array.
+def asarray(a):
+    """Convert the input to a dask array.
 
     Parameters
     ----------
-    array : array-like
-        Input to be coerced into a dask array.
+    a : array-like
+        Input data, in any form that can be converted to a dask array.
 
     Returns
     -------
-    dask array
+    out : dask array
+        Dask array interpretation of a.
 
     Examples
     --------
@@ -2437,13 +2438,12 @@ def asarray(array):
     >>> y = [[1, 2, 3], [4, 5, 6]]
     >>> da.asarray(y)
     dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3)>
-
     """
-    if isinstance(array, Array):
-        return array
-    if not isinstance(getattr(array, 'shape', None), Iterable):
-        array = np.asarray(array)
-    return from_array(array, chunks=array.shape, getitem=getter_inline)
+    if isinstance(a, Array):
+        return a
+    if not isinstance(getattr(a, 'shape', None), Iterable):
+        a = np.asarray(a)
+    return from_array(a, chunks=a.shape, getitem=getter_inline)
 
 
 def asanyarray(array):

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -25,6 +25,7 @@ Top level user functions:
    argwhere
    around
    array
+   asanyarray
    asarray
    atleast_1d
    atleast_2d
@@ -346,6 +347,7 @@ Other functions
 .. autofunction:: argwhere
 .. autofunction:: around
 .. autofunction:: array
+.. autofunction:: asanyarray
 .. autofunction:: asarray
 .. autofunction:: atleast_1d
 .. autofunction:: atleast_2d

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -25,6 +25,7 @@ Top level user functions:
    argwhere
    around
    array
+   asarray
    atleast_1d
    atleast_2d
    atleast_3d
@@ -345,6 +346,7 @@ Other functions
 .. autofunction:: argwhere
 .. autofunction:: around
 .. autofunction:: array
+.. autofunction:: asarray
 .. autofunction:: atleast_1d
 .. autofunction:: atleast_2d
 .. autofunction:: atleast_3d

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ Array
 - Deprecate ``vnorm`` in favor of ``dask.array.linalg.norm`` (:pr:`2773`)
 - Reimplement ``unique`` to be lazy (:pr:`2775`)
 - Support broadcasting of Dask Arrays with 0-length dimensions (:pr:`2784`)
+- Add ``asarray`` and ``asanyarray`` to Dask Array API docs (:pr:`2787`)
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Fixes #2723. This PR adds `asarray` and `asanyarray` to the `dask.array` public API. 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
