### PR TITLE
Quickfix missing import fastpaquet in parquet.py

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -471,6 +471,7 @@ def _write_metadata(writes, filenames, fmd, path, metadata_fn, myopen, sep):
     --------
     to_parquet
     """
+    import fastparquet
     for fn, rg in zip(filenames, writes):
         if rg is not None:
             if isinstance(rg, list):


### PR DESCRIPTION
When trying to run `df.to_parquet('dask_dataframe.parquet')` from a clean install via `pip install dask[dataframe]`. It reports

```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-16-d56cfa626383> in <module>()
      7 
      8 os.chdir('/home/atom/alp/code/scripts')
----> 9 df_with_lakes.to_parquet('lasers_in_lakes.parquet')

~/miniconda3/lib/python3.6/site-packages/dask/dataframe/core.py in to_parquet(self, path, *args, **kwargs)
    955         """ See dd.to_parquet docstring for more information """
    956         from .io import to_parquet
--> 957         return to_parquet(path, self, *args, **kwargs)
    958 
    959     def to_csv(self, filename, **kwargs):

~/miniconda3/lib/python3.6/site-packages/dask/dataframe/io/parquet.py in to_parquet(path, df, compression, write_index, has_nulls, fixed_text, object_encoding, storage_options, append, ignore_divisions, partition_on, compute, times)
    367     read_parquet: Read parquet data to dask.dataframe
    368     """
--> 369     import fastparquet
    370     partition_on = partition_on or []
    371 

ModuleNotFoundError: No module named 'fastparquet'

```
So I did `pip install fastparquet`, and then it reports:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-17-d56cfa626383> in <module>()
      7 
      8 os.chdir('/home/atom/alp/code/scripts')
----> 9 df_with_lakes.to_parquet('lasers_in_lakes.parquet')

~/miniconda3/lib/python3.6/site-packages/dask/dataframe/core.py in to_parquet(self, path, *args, **kwargs)
    955         """ See dd.to_parquet docstring for more information """
    956         from .io import to_parquet
--> 957         return to_parquet(path, self, *args, **kwargs)
    958 
    959     def to_csv(self, filename, **kwargs):

~/miniconda3/lib/python3.6/site-packages/dask/dataframe/io/parquet.py in to_parquet(path, df, compression, write_index, has_nulls, fixed_text, object_encoding, storage_options, append, ignore_divisions, partition_on, compute, times)
    451     if compute:
    452         writes = delayed(writes).compute()
--> 453         _write_metadata(writes, filenames, fmd, path, metadata_fn, myopen, sep)
    454     else:
    455         out = delayed(_write_metadata)(writes, filenames, fmd, path, metadata_fn,

~/miniconda3/lib/python3.6/site-packages/dask/dataframe/io/parquet.py in _write_metadata(writes, filenames, fmd, path, metadata_fn, myopen, sep)
    475                 fmd.row_groups.append(rg)
    476 
--> 477     fastparquet.writer.write_common_metadata(metadata_fn, fmd, open_with=myopen,
    478                                              no_row_groups=False)
    479 

AttributeError: 'bool' object has no attribute 'writer'
```

I fixed it with a simple one-liner `import fastparquet` in [parquet.py](https://github.com/dask/dask/blob/9e9fa10ef11bfe86a52214d8a2cda19508a4ee37/dask/dataframe/io/parquet.py#L467-L488). The 'bool' object probably refers to this [section](https://github.com/dask/dask/blob/9e9fa10ef11bfe86a52214d8a2cda19508a4ee37/dask/dataframe/io/parquet.py#L13-L22), where fastparquet is returned as `False`? I feel as though the library imports aren't handled particularly well in this file...

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
