### PR TITLE
Ci fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ ignore =
     E721,
     # Assigning lambda expression
     E731
+    # Ambiguous variable names
+    E741
 max-line-length = 120
 
 [versioneer]


### PR DESCRIPTION
This is for compatibility with the [new flake8 release](http://flake8.pycqa.org/en/latest/release-notes/3.5.0.html#new-dependency-information), which checks for ambiguous identifiers.

I've updated the code to not use these variable names. I could also update the config to ignore that check. Either works for me.