### PR TITLE
Adds comma to flake8 section in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ ignore =
     # Comparing types instead of isinstance
     E721,
     # Assigning lambda expression
-    E731
+    E731,
     # Ambiguous variable names
     E741
 max-line-length = 120


### PR DESCRIPTION
Adds comma to flake8 section in setup.cfg

https://github.com/dask/dask/blob/6de346b35512cf3592a00499419009cb706981b1/setup.cfg#L19-L22

This was causing `flake8 dask` to raise `E731 do not assign a lambda expression, use a def` messages when run on my local copy of dask. 
