### PR TITLE
Array optimizations don't elide some getter calls

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -11,7 +11,12 @@ from ..optimize import cull, fuse, inline_functions
 from ..utils import ensure_dict
 
 
+# All get* functions the optimizations know about
 GETTERS = (getter, getter_nofancy, getter_inline, getitem)
+# These get* functions aren't ever completely removed from the graph,
+# even if the index should be a no-op by numpy semantics. Some array-like's
+# don't completely follow semantics, making indexing always necessary.
+GETNOREMOVE = (getter, getter_nofancy)
 
 
 def optimize(dsk, keys, fuse_keys=None, fast_functions=None,
@@ -136,8 +141,8 @@ def optimize_slices(dsk):
                 a, a_index, a_lock = b, c_index, b_lock
                 a_asarray |= b_asarray
 
-            # Skip the get call if no asarray call, no lock, and nothing to do
-            if ((not a_asarray and not a_lock) and
+            # Skip the get call if not from from_array and nothing to do
+            if (get not in GETNOREMOVE and
                 ((type(a_index) is slice and not a_index.start and
                   a_index.stop is None and a_index.step is None) or
                  (type(a_index) is tuple and

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1407,6 +1407,30 @@ def test_from_array_with_lock():
     assert_eq(e + f, x + x)
 
 
+class MyArray(object):
+    def __init__(self, x):
+        self.x = x
+        self.dtype = x.dtype
+        self.shape = x.shape
+
+    def __getitem__(self, i):
+        return self.x[i]
+
+
+def test_from_array_tasks_always_call_getter():
+    x1 = np.arange(25).reshape((5, 5))
+    x2 = np.array([[1]])
+    x3 = np.array(1)[()]
+
+    dx1a = da.from_array(MyArray(x1), chunks=(5, 5), asarray=False)
+    dx1b = da.from_array(MyArray(x1), chunks=x1.shape, asarray=False)
+    dx2 = da.from_array(MyArray(x2), chunks=1, asarray=False)
+    dx3 = da.from_array(MyArray(x3), chunks=1, asarray=False)
+
+    for res, sol in [(dx1a, x1), (dx1b, x1), (dx2, x2), (dx3, x3)]:
+        assert_eq(res, sol)
+
+
 def test_from_array_no_asarray():
 
     def assert_chunks_are_of_type(x, cls):


### PR DESCRIPTION
Previously all no-op indexing operations were fully removed in the
optimization passes. This was fine for array-like's that follow numpy's
semantics, but not all objects fully follow these semantics.

Since chunks always should follow numpy slicing conventions, the only
thing we need to worry about is original backend storage (in calls to
`from_array`). We fix the optimization passes to never fully remove
slices if the indexing operation originated in `from_array`.

Fixes #2823.