### PR TITLE
Do not raise exception when calling set_index on empty dataframe #2819

### DIFF
--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -307,6 +307,9 @@ def process_val_weights(vals_and_weights, npartitions, dtype_info):
     aren't enough unique values in the column.  Increasing ``upsample``
     keyword argument in ``df.set_index`` may help.
     """
+    if not vals_and_weights:
+        return np.array(None, dtype=np.dtype(None))
+
     vals, weights = vals_and_weights
     vals = np.array(vals)
     weights = np.array(weights)

--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -307,13 +307,18 @@ def process_val_weights(vals_and_weights, npartitions, dtype_info):
     aren't enough unique values in the column.  Increasing ``upsample``
     keyword argument in ``df.set_index`` may help.
     """
+    dtype, info = dtype_info
+
     if not vals_and_weights:
-        return np.array(None, dtype=np.dtype(None))
+        if not (np.can_cast(np.nan, dtype) or np.can_cast(np.datetime64('NaT'), dtype)):
+            # dtype does not support None value so allow it to change
+            dtype = np.dtype(None)
+
+        return np.array(None, dtype=dtype)
 
     vals, weights = vals_and_weights
     vals = np.array(vals)
     weights = np.array(weights)
-    dtype, info = dtype_info
 
     # We want to create exactly `npartition` number of groups of `vals` that
     # are approximately the same weight and non-empty if possible.  We use a

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -64,9 +64,8 @@ def set_index(df, index, npartitions=None, shuffle=None, compute=False,
         divisions, sizes, mins, maxes = base.compute(divisions, sizes, mins, maxes)
         divisions = divisions.tolist()
 
-        empty_partitions_detected = all(pd.isnull(d) for d in divisions)
-
-        if repartition or empty_partitions_detected:
+        empty_dataframe_detected = all(pd.isnull(d) for d in divisions)
+        if repartition or empty_dataframe_detected:
             total = sum(sizes)
             npartitions = max(math.ceil(total / partition_size), 1)
             npartitions = min(npartitions, df.npartitions)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -64,7 +64,7 @@ def set_index(df, index, npartitions=None, shuffle=None, compute=False,
         divisions, sizes, mins, maxes = base.compute(divisions, sizes, mins, maxes)
         divisions = divisions.tolist()
 
-        empty_dataframe_detected = all(pd.isnull(d) for d in divisions)
+        empty_dataframe_detected = pd.isnull(divisions).all()
         if repartition or empty_dataframe_detected:
             total = sum(sizes)
             npartitions = max(math.ceil(total / partition_size), 1)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -64,7 +64,9 @@ def set_index(df, index, npartitions=None, shuffle=None, compute=False,
         divisions, sizes, mins, maxes = base.compute(divisions, sizes, mins, maxes)
         divisions = divisions.tolist()
 
-        if repartition:
+        empty_partitions_detected = all(pd.isnull(d) for d in divisions)
+
+        if repartition or empty_partitions_detected:
             total = sum(sizes)
             npartitions = max(math.ceil(total / partition_size), 1)
             npartitions = min(npartitions, df.npartitions)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -626,10 +626,8 @@ def test_set_index_on_empty():
         df = pd.DataFrame({'x': [converter(x) for x in test_vals]})
         ddf = dd.from_pandas(df, npartitions=1)
         ddf = ddf[ddf.x > df.x.max()]
-        ddf = ddf.set_index('x')
-        assert ddf.index.name == 'x'
-        assert ddf.index.dtype == df.x.dtype
-        assert len(ddf.index.compute()) == 0
+
+        assert assert_eq(ddf.set_index('x'), df[df.x > df.x.max()].set_index('x'))
 
 
 def test_compute_divisions():

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -620,14 +620,24 @@ def test_set_index_empty_partition():
 
 def test_set_index_on_empty():
     test_vals = [1, 2, 3, 4]
-    converters = [int, float, str, lambda x: pd.to_datetime(x, unit='ns')]
+    converters = [
+        int,
+        float,
+        str,
+        lambda x: pd.to_datetime(x, unit='ns'),
+    ]
 
     for converter in converters:
-        df = pd.DataFrame({'x': [converter(x) for x in test_vals]})
-        ddf = dd.from_pandas(df, npartitions=1)
-        ddf = ddf[ddf.x > df.x.max()]
+        df = pd.DataFrame([{'x': converter(x), 'y': x} for x in test_vals])
+        ddf = dd.from_pandas(df, npartitions=4)
 
-        assert assert_eq(ddf.set_index('x'), df[df.x > df.x.max()].set_index('x'))
+        assert ddf.npartitions > 1
+
+        ddf = ddf[ddf.y > df.y.max()].set_index('x')
+        expected_df = df[df.y > df.y.max()].set_index('x')
+
+        assert assert_eq(ddf, expected_df)
+        assert ddf.npartitions == 1
 
 
 def test_compute_divisions():

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -618,6 +618,20 @@ def test_set_index_empty_partition():
         assert assert_eq(ddf.set_index('x'), df.set_index('x'))
 
 
+def test_set_index_on_empty():
+    test_vals = [1, 2, 3, 4]
+    converters = [int, float, str, lambda x: pd.to_datetime(x, unit='ns')]
+
+    for converter in converters:
+        df = pd.DataFrame({'x': [converter(x) for x in test_vals]})
+        ddf = dd.from_pandas(df, npartitions=1)
+        ddf = ddf[ddf.x > df.x.max()]
+        ddf = ddf.set_index('x')
+        assert ddf.index.name == 'x'
+        assert ddf.index.dtype == df.x.dtype
+        assert len(ddf.index.compute()) == 0
+
+
 def test_compute_divisions():
     from dask.dataframe.shuffle import compute_divisions
     df = pd.DataFrame({'x': [1, 2, 3, 4],

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -29,6 +29,8 @@ DataFrame
   defualt for pandas >= 0.21.0 (:pr:`2838`)
 - Fix exception when calling ``DataFrame.set_index`` on text column where one
   of the partitions was empty (:pr:`2831`)
+- Do not raise exception when calling ``DataFrame.set_index`` on empty dataframe
+  (:pr:`2827`)
 
 Bag
 +++


### PR DESCRIPTION
Fix for https://github.com/dask/dask/issues/2819

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
