### PR TITLE
Do not except on set_index on text column with empty partitions #2820

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -112,9 +112,11 @@ def remove_nans(divisions):
         if is_float_and_nan(divisions[i]):
             divisions[i] = divisions[i + 1]
 
-    for i in range(1, len(divisions)):
-        if is_float_and_nan(divisions[i]):
-            divisions[i] = divisions[i - 1]
+    for i in range(len(divisions) - 1, -1, -1):
+        if not is_float_and_nan(divisions[i]):
+            for j in range(i + 1, len(divisions)):
+                divisions[j] = divisions[i]
+            break
 
     return divisions
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -109,11 +109,11 @@ def remove_nans(divisions):
     divisions = list(divisions)
 
     for i in range(len(divisions) - 2, -1, -1):
-        if is_float_and_nan(divisions[i]):
+        if pd.isnull(divisions[i]):
             divisions[i] = divisions[i + 1]
 
     for i in range(len(divisions) - 1, -1, -1):
-        if not is_float_and_nan(divisions[i]):
+        if not pd.isnull(divisions[i]):
             for j in range(i + 1, len(divisions)):
                 divisions[j] = divisions[i]
             break
@@ -521,7 +521,3 @@ def compute_divisions(df, **kwargs):
 
     divisions = tuple(mins) + (list(maxes)[-1],)
     return divisions
-
-
-def is_float_and_nan(f):
-    return isinstance(f, float) and math.isnan(f)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -103,12 +103,19 @@ def remove_nans(divisions):
     [1, 1, 2]
     >>> remove_nans((1, np.nan, 2))
     [1, 2, 2]
+    >>> remove_nans((1, 2, np.nan))
+    [1, 2, 2]
     """
     divisions = list(divisions)
+
     for i in range(len(divisions) - 2, -1, -1):
-        d = divisions[i]
-        if isinstance(d, float) and math.isnan(d):
+        if is_float_and_nan(divisions[i]):
             divisions[i] = divisions[i + 1]
+
+    for i in range(1, len(divisions)):
+        if is_float_and_nan(divisions[i]):
+            divisions[i] = divisions[i - 1]
+
     return divisions
 
 
@@ -512,3 +519,7 @@ def compute_divisions(df, **kwargs):
 
     divisions = tuple(mins) + (list(maxes)[-1],)
     return divisions
+
+
+def is_float_and_nan(f):
+    return isinstance(f, float) and math.isnan(f)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -657,6 +657,7 @@ def test_empty_partitions():
 
 def test_remove_nans():
     tests = [
+        ((1, 1, 2), (1, 1, 2)),
         ((np.nan, 1, 2), (1, 1, 2)),
         ((1, np.nan, 2), (1, 2, 2)),
         ((1, 2, np.nan), (1, 2, 2)),

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -16,7 +16,8 @@ from dask.dataframe.shuffle import (shuffle,
                                     partitioning_index,
                                     rearrange_by_column,
                                     rearrange_by_divisions,
-                                    maybe_buffered_partd)
+                                    maybe_buffered_partd,
+                                    remove_nans)
 from dask.dataframe.utils import assert_eq, make_meta
 
 
@@ -596,6 +597,19 @@ def test_set_index_sorted_min_max_same():
     assert df2.divisions == (0, 1, 1)
 
 
+def test_set_index_text_column_empty_partition():
+    df = pd.DataFrame([{'x': str(i), 'y': i} for i in range(3)], columns=['x', 'y'])
+    ddf = dd.concat([
+        dd.from_pandas(df, npartitions=1),
+        dd.from_pandas(df[df.y > df.y.max()], npartitions=1),
+    ])
+
+    assert any(ddf.get_partition(p).compute().empty for p in range(ddf.npartitions))
+
+    ddf = ddf.set_index('x')
+    assert assert_eq(ddf.index.compute(), pd.Index(['0', '1', '2'], dtype='object', name='x'))
+
+
 def test_compute_divisions():
     from dask.dataframe.shuffle import compute_divisions
     df = pd.DataFrame({'x': [1, 2, 3, 4],
@@ -640,3 +654,10 @@ def test_empty_partitions():
 
     ddf = ddf.set_index('c')
     assert_eq(ddf, df.set_index('b').set_index('c'))
+
+
+def test_remove_nans():
+    assert remove_nans((np.nan, 1, 2)) == [1, 1, 2]
+    assert remove_nans((1, np.nan, 2)) == [1, 2, 2]
+    assert remove_nans((1, 2, np.nan)) == [1, 2, 2]
+    assert remove_nans((1, 2, np.nan, np.nan)) == [1, 2, 2, 2]

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -689,5 +689,4 @@ def test_remove_nans():
         for inputs, expected in tests:
             params = [x_val if x is X else conv(x) for x in inputs]
             expected = [conv(x) for x in expected]
-            print(f'{params} : {expected}')
             assert remove_nans(params) == expected

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -665,17 +665,15 @@ def test_empty_partitions():
 
 
 def test_remove_nans():
-    X = object()
-
     tests = [
         ((1, 1, 2), (1, 1, 2)),
-        ((X, 1, 2), (1, 1, 2)),
-        ((1, X, 2), (1, 2, 2)),
-        ((1, 2, X), (1, 2, 2)),
-        ((1, 2, X, X), (1, 2, 2, 2)),
-        ((X, X, 1, 2), (1, 1, 1, 2)),
-        ((1, X, X, 2), (1, 2, 2, 2)),
-        ((X, 1, X, 2, X, 3, X), (1, 1, 2, 2, 3, 3, 3)),
+        ((None, 1, 2), (1, 1, 2)),
+        ((1, None, 2), (1, 2, 2)),
+        ((1, 2, None), (1, 2, 2)),
+        ((1, 2, None, None), (1, 2, 2, 2)),
+        ((None, None, 1, 2), (1, 1, 1, 2)),
+        ((1, None, None, 2), (1, 2, 2, 2)),
+        ((None, 1, None, 2, None, 3, None), (1, 1, 2, 2, 3, 3, 3)),
     ]
 
     converters = [
@@ -685,8 +683,8 @@ def test_remove_nans():
         (lambda x: pd.to_datetime(x, unit='ns'), np.datetime64('NaT')),
     ]
 
-    for conv, x_val in converters:
+    for conv, none_val in converters:
         for inputs, expected in tests:
-            params = [x_val if x is X else conv(x) for x in inputs]
+            params = [none_val if x is None else conv(x) for x in inputs]
             expected = [conv(x) for x in expected]
             assert remove_nans(params) == expected

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,6 +27,8 @@ DataFrame
   series along the columns, matching pandas' behavior (:pr:`2800`)
 - Fixed default inplace parameter for ``DataFrame.eval`` to match the pandas
   defualt for pandas >= 0.21.0 (:pr:`2838`)
+- Fix exception when calling ``DataFrame.set_index`` on text column where one
+  of the partitions was empty (:pr:`2831`)
 
 Bag
 +++


### PR DESCRIPTION
Add second pass to remove_nan to replace nan at end of list and avoid comparing str with nan. Fixes https://github.com/dask/dask/issues/2820

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
