### PR TITLE
Squash a few warnings in dask.array

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -195,3 +195,12 @@ def arange(start, stop, step, length, dtype):
 
 def astype(x, astype_dtype=None, **kwargs):
     return x.astype(astype_dtype, **kwargs)
+
+
+def view(x, dtype, order='C'):
+    if order == 'C':
+        x = np.ascontiguousarray(x)
+        return x.view(dtype)
+    else:
+        x = np.asfortranarray(x)
+        return x.T.view(dtype).T

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1750,20 +1750,16 @@ class Array(Base):
         mult = self.dtype.itemsize / dtype.itemsize
 
         if order == 'C':
-            ascontiguousarray = np.ascontiguousarray
             chunks = self.chunks[:-1] + (tuple(ensure_int(c * mult)
                                          for c in self.chunks[-1]),)
         elif order == 'F':
-            ascontiguousarray = np.asfortranarray
             chunks = ((tuple(ensure_int(c * mult) for c in self.chunks[0]), ) +
                       self.chunks[1:])
         else:
             raise ValueError("Order must be one of 'C' or 'F'")
 
-        out = elemwise(ascontiguousarray, self, dtype=self.dtype)
-        out = elemwise(np.ndarray.view, out, dtype, dtype=dtype)
-        out._chunks = chunks
-        return out
+        return self.map_blocks(chunk.view, dtype, order=order,
+                               dtype=dtype, chunks=chunks)
 
     @derived_from(np.ndarray)
     def swapaxes(self, axis1, axis2):

--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -188,7 +188,7 @@ class RandomState(object):
                     raise ValueError("a must be one dimensional")
                 len_a = len(a)
                 dsks.append(a.dask)
-                a = a._keys()[0]
+                a = a.__dask_keys__()[0]
 
             # Normalize and validate `p`
             if p is not None:
@@ -208,7 +208,7 @@ class RandomState(object):
                     raise ValueError("a and p must have the same size")
 
                 dsks.append(p.dask)
-                p = p._keys()[0]
+                p = p.__dask_keys__()[0]
 
             if size is None:
                 size = ()

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -391,7 +391,7 @@ def find_merge_rechunk(old_chunks, new_chunks, block_size_limit):
         bse = block_size_effect[k]
         if bse == 1:
             bse = 1 + 1e-9
-        return np.log(gse) / np.log(bse)
+        return (np.log(gse) / np.log(bse)) if bse > 0 else 0
 
     sorted_candidates = sorted(merge_candidates, key=key)
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -536,7 +536,7 @@ def unique(x):
     out._chunks = tuple((np.nan,) * len(c) for c in out.chunks)
 
     name = 'unique-aggregate-' + out.name
-    dsk = {(name, 0): (np.unique, (np.concatenate, out._keys()))}
+    dsk = {(name, 0): (np.unique, (np.concatenate, out.__dask_keys__()))}
     out = Array(
         sharedict.merge((name, dsk), out.dask), name, ((np.nan,),), out.dtype
     )

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -771,7 +771,8 @@ def normalize_index(idx, shape):
             none_shape.append(None)
 
     for i, d in zip(idx, none_shape):
-        check_index(i, d)
+        if d is not None:
+            check_index(i, d)
     idx = tuple(map(sanitize_index, idx))
     idx = tuple(map(normalize_slice, idx, none_shape))
     idx = posify_index(none_shape, idx)
@@ -808,7 +809,10 @@ def check_index(ind, dimension):
 
     >>> check_index(slice(0, 3), 5)
     """
-    if isinstance(ind, (list, np.ndarray)):
+    # unknown dimension, assumed to be in bounds
+    if np.isnan(dimension):
+        return
+    elif isinstance(ind, (list, np.ndarray)):
         x = np.asanyarray(ind)
         if (x >= dimension).any() or (x < -dimension).any():
             raise IndexError("Index out of bounds %s" % dimension)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -558,17 +558,19 @@ def test_norm():
     a = a + (a.max() - a) * 1j
     b = from_array(a, chunks=(5, 5))
 
-    assert_eq(b.vnorm(), np.linalg.norm(a))
-    assert_eq(b.vnorm(ord=1), np.linalg.norm(a.flatten(), ord=1))
-    assert_eq(b.vnorm(ord=4, axis=0), np.linalg.norm(a, ord=4, axis=0))
-    assert b.vnorm(ord=4, axis=0, keepdims=True).ndim == b.ndim
-    split_every = {0: 3, 1: 3}
-    assert_eq(b.vnorm(ord=1, axis=0, split_every=split_every),
-              np.linalg.norm(a, ord=1, axis=0))
-    assert_eq(b.vnorm(ord=np.inf, axis=0, split_every=split_every),
-              np.linalg.norm(a, ord=np.inf, axis=0))
-    assert_eq(b.vnorm(ord=np.inf, split_every=split_every),
-              np.linalg.norm(a.flatten(), ord=np.inf))
+    # TODO: Deprecated method, remove test when method removed
+    with pytest.warns(UserWarning):
+        assert_eq(b.vnorm(), np.linalg.norm(a))
+        assert_eq(b.vnorm(ord=1), np.linalg.norm(a.flatten(), ord=1))
+        assert_eq(b.vnorm(ord=4, axis=0), np.linalg.norm(a, ord=4, axis=0))
+        assert b.vnorm(ord=4, axis=0, keepdims=True).ndim == b.ndim
+        split_every = {0: 3, 1: 3}
+        assert_eq(b.vnorm(ord=1, axis=0, split_every=split_every),
+                  np.linalg.norm(a, ord=1, axis=0))
+        assert_eq(b.vnorm(ord=np.inf, axis=0, split_every=split_every),
+                  np.linalg.norm(a, ord=np.inf, axis=0))
+        assert_eq(b.vnorm(ord=np.inf, split_every=split_every),
+                  np.linalg.norm(a.flatten(), ord=np.inf))
 
 
 def test_broadcast_to():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1788,9 +1788,8 @@ def test_view():
 def test_view_fortran():
     x = np.asfortranarray(np.arange(64).reshape((8, 8)))
     d = da.from_array(x, chunks=(2, 3))
-    # TODO: DeprecationWarning: Changing the shape of non-C contiguous array by
-    assert_eq(x.view('i4'), d.view('i4', order='F'))
-    assert_eq(x.view('i2'), d.view('i2', order='F'))
+    assert_eq(x.T.view('i4').T, d.view('i4', order='F'))
+    assert_eq(x.T.view('i2').T, d.view('i2', order='F'))
 
 
 def test_h5py_tokenize():


### PR DESCRIPTION
Fixes a few warnings in `dask.array`. Some of these were simple, and some required a bit more extensive changes in the code. Each commit fixes a separate source of warnings:

- A few calls to the deprecated `_keys` method
- Deprecation warning in `view` with fortran order
- Divide by zero warning in rechunk
- nan encountered in slicing internals
- Deprecation warning for `Array.norm`
