### PR TITLE
mean of sparse array: AxisError: axis 0 is out of bounds for array of dimension 0

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -231,7 +231,7 @@ def nanmax(a, axis=None, keepdims=False, split_every=None, out=None):
 
 def numel(x, **kwargs):
     """ A reduction to count the number of elements """
-    return chunk.sum(np.ones_like(x), **kwargs)
+    return chunk.sum(np.ones(x.shape, dtype='u8'), **kwargs)
 
 
 def nannumel(x, **kwargs):
@@ -242,6 +242,8 @@ def nannumel(x, **kwargs):
 def mean_chunk(x, sum=chunk.sum, numel=numel, dtype='f8', **kwargs):
     n = numel(x, dtype=dtype, **kwargs)
     total = sum(x, dtype=dtype, **kwargs)
+    if hasattr(total, 'todense'):
+        total = total.todense()
     empty = empty_lookup.dispatch(type(n))
     result = empty(n.shape, dtype=[('total', total.dtype), ('n', n.dtype)])
     result['n'] = n

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -32,6 +32,7 @@ functions = [
     lambda x: da.tensordot(x, np.ones(x.shape[:2]), axes=[(0, 1), (0, 1)]),
     lambda x: x.sum(axis=0),
     lambda x: x.max(axis=0),
+    lambda x: x.mean(axis=0),
     lambda x: x.sum(axis=(1, 2)),
     lambda x: x.astype(np.complex128),
     lambda x: x.map_blocks(lambda x: x * 2),


### PR DESCRIPTION
`s.mean(axis=0).compute()` triggers the following uncaught exception:

```
________________________________________________________________________________________________ test_basic[func18] ________________________________________________________________________________________________

func = <function <lambda> at 0x7eff69e3ee18>

    @pytest.mark.parametrize('func', functions)
    def test_basic(func):
        x = da.random.random((2, 3, 4), chunks=(1, 2, 2))
        x[x < 0.8] = 0
    
        y = x.map_blocks(sparse.COO.from_numpy)
    
        xx = func(x)
        yy = func(y)
    
>       assert_eq(xx, yy)

func       = <function <lambda> at 0x7eff69e3ee18>
x          = dask.array<where, shape=(2, 3, 4), dtype=float64, chunksize=(1, 2, 2)>
xx         = dask.array<mean_agg-aggregate, shape=(3, 4), dtype=float64, chunksize=(2, 2)>
y          = dask.array<from_numpy, shape=(2, 3, 4), dtype=float64, chunksize=(1, 2, 2)>
yy         = dask.array<mean_agg-aggregate, shape=(3, 4), dtype=float64, chunksize=(2, 2)>

dask/array/tests/test_sparse.py:58: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
dask/array/utils.py:83: in assert_eq
    b = b.compute(get=get_sync)
dask/base.py:138: in compute
    (result,) = compute(self, traverse=False, **kwargs)
dask/base.py:336: in compute
    results = get(dsk, keys, **kwargs)
dask/local.py:562: in get_sync
    return get_async(apply_sync, 1, dsk, keys, **kwargs)
dask/local.py:529: in get_async
    fire_task()
dask/local.py:504: in fire_task
    callback=queue.put)
dask/local.py:551: in apply_sync
    res = func(*args, **kwds)
dask/local.py:295: in execute_task
    result = pack_exception(e, dumps)
dask/local.py:290: in execute_task
    result = _execute_task(task, data)
dask/local.py:271: in _execute_task
    return func(*args2)
dask/compatibility.py:47: in apply
    return func(*args, **kwargs)
dask/array/reductions.py:243: in mean_chunk
    n = numel(x, dtype=dtype, **kwargs)
dask/array/reductions.py:234: in numel
    return chunk.sum(np.ones_like(x), **kwargs)
../../.virtualenvs/py36/lib/python3.6/site-packages/numpy/core/fromnumeric.py:1834: in sum
    out=out, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

a = array(1, dtype=object), axis = (0,), dtype = dtype('float64'), out = None, keepdims = True

    def _sum(a, axis=None, dtype=None, out=None, keepdims=False):
>       return umr_sum(a, axis, dtype, out, keepdims)
E       numpy.core._internal.AxisError: axis 0 is out of bounds for array of dimension 0

a          = array(1, dtype=object)
axis       = (0,)
dtype      = dtype('float64')
keepdims   = True
out        = None
```

This PR adds a non-regression test along with a naive fix that calls `todense()` on each chunk during the reduction. This is probably sub-optimal from a performance point of view but I am not sure which kwargs should be supported in `numel` besides `axis`.

I will add a entry to the changelog if we agree on the correct fix.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API

