### PR TITLE
WIP: Optimize `_unique_internal`'s optional result handling

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -550,11 +550,18 @@ def _unique_internal(ar, indices, counts, return_inverse=False):
         r["inverse"] = np.arange(len(r), dtype=np.int64)
     if return_index or return_counts:
         m_ar = (r["values"][:, None] == ar[None, :])
-        for i, m in enumerate(m_ar):
-            if return_index:
-                indices[m].min(keepdims=True, out=r["indices"][i:i + 1])
-            if return_counts:
-                counts[m].sum(keepdims=True, out=r["counts"][i:i + 1])
+        if return_index:
+            np.where(
+                m_ar,
+                indices[None, :],
+                np.iinfo(r.dtype["indices"]).max
+            ).min(axis=1, out=r["indices"])
+        if return_counts:
+            np.where(
+                m_ar,
+                counts[None, :],
+                0
+            ).sum(axis=1, out=r["counts"])
 
     return r
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -549,8 +549,8 @@ def _unique_internal(ar, indices, counts, return_inverse=False):
     if return_inverse:
         r["inverse"] = np.arange(len(r), dtype=np.int64)
     if return_index or return_counts:
-        for i, v in enumerate(r["values"]):
-            m = (ar == v)
+        m_ar = (r["values"][:, None] == ar[None, :])
+        for i, m in enumerate(m_ar):
             if return_index:
                 indices[m].min(keepdims=True, out=r["indices"][i:i + 1])
             if return_counts:


### PR DESCRIPTION
Vectorizes away a `for`-loop in `_unique_internal` that was used to compute the optional results, `indices` and `counts`. Does this by leveraging NumPy's `where` to fill in non-relevant data from the `indices` and `counts` provided as input. Then reduces these down before storing the result.