### PR TITLE
[WIP]API: Add marker to control alignment in map_partitions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1476,12 +1476,15 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
 
     @derived_from(pd.DataFrame)
     def combine(self, other, func, fill_value=None, overwrite=True):
-        return self.map_partitions(M.combine, other, func,
-                                   fill_value=fill_value, overwrite=overwrite)
+        meta = self._meta
+        return self.map_partitions(M.combine, AlignMe(other), func,
+                                   fill_value=fill_value, overwrite=overwrite,
+                                   meta=meta)
 
     @derived_from(pd.DataFrame)
     def combine_first(self, other):
-        return self.map_partitions(M.combine_first, other)
+        meta = self._meta
+        return self.map_partitions(M.combine_first, AlignMe(other), meta=meta)
 
     @classmethod
     def _bind_operator_method(cls, name, op):
@@ -1856,12 +1859,18 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
 
     @derived_from(pd.Series)
     def combine(self, other, func, fill_value=None):
+        meta = self._meta
+        if isinstance(other, pd.Series):
+            other = AlignMe(other)
         return self.map_partitions(M.combine, other, func,
-                                   fill_value=fill_value)
+                                   fill_value=fill_value,
+                                   meta=meta)
 
     @derived_from(pd.Series)
     def combine_first(self, other):
-        return self.map_partitions(M.combine_first, other)
+        meta = self._meta
+        other = AlignMe(other)
+        return self.map_partitions(M.combine_first, other, meta=meta)
 
     def to_bag(self, index=False):
         """ Craeate a Dask Bag from a Series """
@@ -1887,6 +1896,8 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
                 raise NotImplementedError('level must be None')
             axis = self._validate_axis(axis)
             meta = _emulate(op, self, other, axis=axis, fill_value=fill_value)
+            if axis == 0 and isinstance(other, (pd.Series, pd.DataFrame)):
+                other = AlignMe(other)
             return map_partitions(op, self, other, meta=meta,
                                   axis=axis, fill_value=fill_value)
         meth.__doc__ = op.__doc__
@@ -1900,6 +1911,12 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
             if level is not None:
                 raise NotImplementedError('level must be None')
             axis = self._validate_axis(axis)
+            if axis == 0 and isinstance(other, (pd.Series, pd.DataFrame)):
+                other = AlignMe(other)
+            elif axis == 1 and isinstance(other, pd.DataFrame):
+                # XXX: is this required?
+                other = AlignMe(other)
+
             return elemwise(comparison, self, other, axis=axis)
 
         meth.__doc__ = comparison.__doc__
@@ -2355,10 +2372,13 @@ class DataFrame(_Frame):
                     callable(v) or np.isscalar(v)):
                 raise TypeError("Column assignment doesn't support type "
                                 "{0}".format(type(v).__name__))
+        df2 = self._meta.assign(**_extract_meta(kwargs))
         pairs = list(sum(kwargs.items(), ()))
+        pairs = [AlignMe(x) if isinstance(x, (Series, pd.Series)) else x
+                 for x in pairs]
 
         # Figure out columns of the output
-        df2 = self._meta.assign(**_extract_meta(kwargs))
+
         return elemwise(methods.assign, self, *pairs, meta=df2)
 
     @derived_from(pd.DataFrame)
@@ -2550,15 +2570,13 @@ class DataFrame(_Frame):
                 if isinstance(other, Series):
                     msg = 'Unable to {0} dd.Series with axis=1'.format(name)
                     raise ValueError(msg)
-                elif isinstance(other, pd.Series):
-                    # Special case for pd.Series to avoid unwanted partitioning
-                    # of other. We pass it in as a kwarg to prevent this.
-                    meta = _emulate(op, self, other=other, axis=axis,
-                                    fill_value=fill_value)
-                    return map_partitions(op, self, other=other, meta=meta,
-                                          axis=axis, fill_value=fill_value)
-
             meta = _emulate(op, self, other, axis=axis, fill_value=fill_value)
+
+            if axis == 0 and isinstance(other, (pd.Series, pd.DataFrame)):
+                other = AlignMe(other)
+            elif axis == 1 and isinstance(other, pd.DataFrame):
+                other = AlignMe(other)
+
             return map_partitions(op, self, other, meta=meta,
                                   axis=axis, fill_value=fill_value)
         meth.__doc__ = op.__doc__
@@ -2934,9 +2952,19 @@ def elemwise(op, *args, **kwargs):
 
 def _maybe_from_pandas(dfs):
     from .io import from_pandas
-    dfs = [from_pandas(df, 1) if isinstance(df, (pd.Series, pd.DataFrame))
-           else df for df in dfs]
-    return dfs
+    out = []
+    for df in dfs:
+        if isinstance(df, AlignMe):
+            if isinstance(df.value, _Frame):
+                out.append(df.value)
+            elif isinstance(df.value, (pd.Series, pd.DataFrame)):
+                out.append(from_pandas(df.value, 1))
+            else:
+                raise TypeError("Can't wrap type '{}' in 'AlignMe'".format(
+                    type(df.value)))
+        else:
+            out.append(df)
+    return out
 
 
 def hash_shard(df, nparts, split_out_setup=None, split_out_setup_kwargs=None):
@@ -3163,6 +3191,11 @@ def _emulate(func, *args, **kwargs):
     """
     with raise_on_meta_error(funcname(func)):
         return func(*_extract_meta(args, True), **_extract_meta(kwargs, True))
+
+
+class AlignMe:
+    def __init__(self, value):
+        self.value = value
 
 
 @insert_meta_param_description

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -545,6 +545,8 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
     >>> dd.concat([a, b])                               # doctest: +SKIP
     dd.DataFrame<concat-..., divisions=(None, None, None, None)>
     """
+    from .core import AlignMe
+
     if not isinstance(dfs, list):
         raise TypeError("dfs must be a list of DataFrames/Series objects")
     if len(dfs) == 0:
@@ -560,7 +562,7 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
 
     axis = DataFrame._validate_axis(axis)
     dasks = [df for df in dfs if isinstance(df, _Frame)]
-    dfs = _maybe_from_pandas(dfs)
+    dfs = _maybe_from_pandas([AlignMe(df) for df in dfs])
 
     if axis == 1:
         if all(df.known_divisions for df in dasks):

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1002,3 +1002,13 @@ def test_reductions_frame_nan(split_every):
               ddf.sem(axis=1, skipna=False, ddof=0, split_every=split_every))
     assert_eq(df.mean(axis=1, skipna=False),
               ddf.mean(axis=1, skipna=False, split_every=split_every))
+
+
+def test_binop_no_sort():
+    # https://github.com/dask/dask/issues/2840
+    df = pd.DataFrame(np.random.uniform(size=(5, 11))).rename(columns=str)
+    ddf = dd.from_pandas(df, 2)
+
+    result = ddf / ddf.mean(0).compute()
+    expected = df / df.mean(0)
+    assert_eq(result, expected)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1307,6 +1307,14 @@ def test_ffill_bfill():
     assert_eq(ddf.bfill(axis=1), df.bfill(axis=1))
 
 
+def test_fillna_series_types():
+    # https://github.com/dask/dask/issues/2809
+    df = pd.DataFrame({"A": [1, np.nan, 3], "B": [1, np.nan, 3]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    fill_value = pd.Series([1, 10], index=['A', 'C'])
+    assert_eq(ddf.fillna(fill_value), df.fillna(fill_value))
+
+
 def test_sample():
     df = pd.DataFrame({'x': [1, 2, 3, 4, None, 6], 'y': list('abdabd')},
                       index=[10, 20, 30, 40, 50, 60])


### PR DESCRIPTION
This adds a simple marker for whether a value should be aligned when
passed to map_partitions. I noticed a few issues recently where unexpected
alignment was causing issues, so I wanted to put this out for discussion. I'm
perfectly fine with closing this if we decide it's not worthwhile. I'm really not
sure if it's a good change or not.

The basic issue is that for some calls to `map_partitions`, we want to align and repartition the `Series` or `DataFarme` in `*args`, and sometimes we don't. In general, I don't think we can know ahead of time whether the user wants the arguments to be aligned and repartitioned, so we provide a way for them to specify that. I'm don't like the name `AlignMe`, but haven't thought through alternatives.

I made the alignment opt-in, we could also align by default and provide a way to opt-out.

An alternative PR to this is to simply

- continue to fix internal issues where we have undesirable alignment (#2840, #2809)
- Instruct users to always use keyword arguments when they do not want alignment (#2807)

Even as I write this I'm wondering if we should just do that. Still I'll submit this for consideration.
If we like this, I'll document it and add examples.


Closes https://github.com/dask/dask/issues/2840
Closes https://github.com/dask/dask/issues/2809
Closes https://github.com/dask/dask/issues/2807
