### PR TITLE
Minor tweaks to `_unique_internal` optional result handling

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -550,10 +550,11 @@ def _unique_internal(ar, indices, counts, return_inverse=False):
         r["inverse"] = np.arange(len(r), dtype=np.int64)
     if return_index or return_counts:
         for i, v in enumerate(r["values"]):
+            m = (ar == v)
             if return_index:
-                indices[ar == v].min(keepdims=True, out=r["indices"][i:i + 1])
+                indices[m].min(keepdims=True, out=r["indices"][i:i + 1])
             if return_counts:
-                counts[ar == v].sum(keepdims=True, out=r["counts"][i:i + 1])
+                counts[m].sum(keepdims=True, out=r["counts"][i:i + 1])
 
     return r
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -548,7 +548,7 @@ def _unique_internal(ar, indices, counts, return_inverse=False):
     r["values"] = u
     if return_inverse:
         r["inverse"] = np.arange(len(r), dtype=np.int64)
-    for i, v in np.ndenumerate(r["values"]):
+    for i, v in enumerate(r["values"]):
         if return_index:
             r["indices"][i] = indices[ar == v].min()
         if return_counts:

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -548,11 +548,12 @@ def _unique_internal(ar, indices, counts, return_inverse=False):
     r["values"] = u
     if return_inverse:
         r["inverse"] = np.arange(len(r), dtype=np.int64)
-    for i, v in enumerate(r["values"]):
-        if return_index:
-            indices[ar == v].min(keepdims=True, out=r["indices"][i:i + 1])
-        if return_counts:
-            counts[ar == v].sum(keepdims=True, out=r["counts"][i:i + 1])
+    if return_index or return_counts:
+        for i, v in enumerate(r["values"]):
+            if return_index:
+                indices[ar == v].min(keepdims=True, out=r["indices"][i:i + 1])
+            if return_counts:
+                counts[ar == v].sum(keepdims=True, out=r["counts"][i:i + 1])
 
     return r
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -550,9 +550,9 @@ def _unique_internal(ar, indices, counts, return_inverse=False):
         r["inverse"] = np.arange(len(r), dtype=np.int64)
     for i, v in enumerate(r["values"]):
         if return_index:
-            r["indices"][i] = indices[ar == v].min()
+            indices[ar == v].min(keepdims=True, out=r["indices"][i:i + 1])
         if return_counts:
-            r["counts"][i] = counts[ar == v].sum()
+            counts[ar == v].sum(keepdims=True, out=r["counts"][i:i + 1])
 
     return r
 


### PR DESCRIPTION
First avoid entering the `for`-loop used to construct `index` and `count` unless we are computing at least one of them. Second reuse the mask for each unique value when computing both `index` and `count`. Third write output to the result array directly.