### PR TITLE
Test `unique`'s inverse mapping's shape

### DIFF
--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -497,6 +497,10 @@ def test_unique_kwargs(return_index, return_inverse, return_counts):
 
     assert len(r_a) == len(r_d)
 
+    if return_inverse:
+        i = 1 + int(return_index)
+        assert (d.size,) == r_d[i].shape
+
     for e_r_a, e_r_d in zip(r_a, r_d):
         assert_eq(e_r_d, e_r_a)
 
@@ -527,6 +531,8 @@ def test_unique_rand(seed, low, high, shape, chunks):
     r_d = da.unique(d, **kwargs)
 
     assert len(r_a) == len(r_d)
+
+    assert (d.size,) == r_d[2].shape
 
     for e_r_a, e_r_d in zip(r_a, r_d):
         assert_eq(e_r_d, e_r_a)


### PR DESCRIPTION
The inverse mapping from `unique` should have a known shape. Also that shape should be identical to that of the original array (provided to `unique`) flattened. This makes the inverse mapping different from the other results that `unique` provides that have an unknown shape. Namely because the inverse mapping's shape is known a priori as it is not a function of the original array's contents (though the contents of the inverse mapping are). Therefore this tweaks `unique`'s tests to ensure that the shape of the inverse mapping is being checked against the original data's size.