### PR TITLE
Move `thread_state` out of the top namespace

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     pass
 try:
-    from .base import visualize, compute, persist, thread_state, is_dask_collection
+    from .base import visualize, compute, persist, is_dask_collection
 except ImportError:
     pass
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -15,7 +15,7 @@ from toolz import merge, groupby, curry, identity
 from toolz.functoolz import Compose
 
 from .compatibility import long, unicode
-from .context import _globals
+from .context import _globals, thread_state
 from .core import flatten
 from .hashing import hash_buffer_hex
 from .utils import Dispatch, ensure_dict
@@ -25,9 +25,6 @@ __all__ = ("DaskMethodsMixin",
            "is_dask_collection",
            "compute", "persist", "visualize",
            "tokenize", "normalize_token")
-
-
-thread_state = threading.local()
 
 
 def is_dask_collection(x):

--- a/dask/context.py
+++ b/dask/context.py
@@ -3,11 +3,15 @@ Control global computation context
 """
 from __future__ import absolute_import, division, print_function
 
+import threading
 from functools import partial
 from collections import defaultdict
 
 _globals = defaultdict(lambda: None)
 _globals['callbacks'] = set()
+
+
+thread_state = threading.local()
 
 
 class set_options(object):


### PR DESCRIPTION
This was added here, but isn't useful for most users. Move to `dask.context` as discussed in https://github.com/dask/dask/pull/2762#discussion_r144630254.
