### PR TITLE
Numpy 1104 compat fix

### DIFF
--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -310,11 +310,11 @@ def process_val_weights(vals_and_weights, npartitions, dtype_info):
     dtype, info = dtype_info
 
     if not vals_and_weights:
-        if not (np.can_cast(np.nan, dtype) or np.can_cast(np.datetime64('NaT'), dtype)):
+        try:
+            return np.array(None, dtype=dtype)
+        except Exception:
             # dtype does not support None value so allow it to change
-            dtype = np.dtype(None)
-
-        return np.array(None, dtype=dtype)
+            return np.array(None, dtype=np.float_)
 
     vals, weights = vals_and_weights
     vals = np.array(vals)


### PR DESCRIPTION
This was failing, as numpy 1.10.4 checks for `'NaT'` casting failed. Rewritten to just try to create a missing value, and fallback to `NaN`.

Fixes #2861.
