### PR TITLE
A few parquet cleanups

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -972,7 +972,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
     def to_parquet(self, path, *args, **kwargs):
         """ See dd.to_parquet docstring for more information """
         from .io import to_parquet
-        return to_parquet(path, self, *args, **kwargs)
+        return to_parquet(self, path, *args, **kwargs)
 
     def to_csv(self, filename, **kwargs):
         """ See dd.to_csv docstring for more information """

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 import json
+import warnings
+
 import numpy as np
 import pandas as pd
 
@@ -328,7 +330,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
                              categories=categories, index=index)
 
 
-def to_parquet(path, df, compression=None, write_index=None, has_nulls=True,
+def to_parquet(df, path, compression=None, write_index=None, has_nulls=True,
                fixed_text=None, object_encoding=None, storage_options=None,
                append=False, ignore_divisions=False, partition_on=None,
                compute=True, times='int64'):
@@ -340,10 +342,10 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=True,
 
     Parameters
     ----------
+    df : Dask.dataframe
     path : string
         Destination directory for data.  Prepend with protocol like ``s3://``
         or ``hdfs://`` for remote data.
-    df : Dask.dataframe
     compression : string or dict
         Either a string like "SNAPPY" or a dictionary mapping column names to
         compressors like ``{"name": "GZIP", "values": "SNAPPY"}``
@@ -399,6 +401,12 @@ def to_parquet(path, df, compression=None, write_index=None, has_nulls=True,
     """
     import fastparquet
     partition_on = partition_on or []
+
+    # TODO: remove once deprecation cycle is finished
+    if isinstance(path, DataFrame):
+        warnings.warn("DeprecationWarning: The order of `df` and `path` in "
+                      "`dd.to_parquet` has switched, please update your code")
+        df, path = path, df
 
     fs, paths, myopen = get_fs_paths_myopen(path, None, 'wb',
                                             **(storage_options or {}))


### PR DESCRIPTION
- Simplify logic in a few places
- Remove unnecessary imports
- Formatting tweaks
- Reorder `df` and `path` arguments in `to_parquet` to be consistent with other output functions. Add a deprecation warning to remain backwards compatible with old methods.
