### PR TITLE
Support arrow in `to_parquet`. Several other parquet cleanups.

### DIFF
--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -282,12 +282,10 @@ def test_read_text_passes_through_options():
         assert df.count().compute(get=get) == 3
 
 
-@pytest.mark.parametrize("engine", ['arrow', 'fastparquet'])
+@pytest.mark.parametrize("engine", ['pyarrow', 'fastparquet'])
 def test_parquet(s3, engine):
     dd = pytest.importorskip('dask.dataframe')
-    pytest.importorskip('fastparquet')
-    if engine == 'arrow':
-        pytest.importorskip('pyarrow')
+    pytest.importorskip(engine)
     import pandas as pd
     import numpy as np
 
@@ -301,7 +299,7 @@ def test_parquet(s3, engine):
                              size=1000).astype("O")},
                         index=pd.Index(np.arange(1000), name='foo'))
     df = dd.from_pandas(data, chunksize=500)
-    df.to_parquet(url, object_encoding='utf8')
+    df.to_parquet(url, engine=engine)
 
     files = [f.split('/')[-1] for f in s3.ls(url)]
     assert '_metadata' in files

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -14,6 +14,9 @@ from ...delayed import delayed
 from ...bytes.core import get_fs_paths_myopen
 
 
+__all__ = ('read_parquet', 'to_parquet')
+
+
 def _meta_from_dtypes(to_read_columns, file_columns, file_dtypes):
     meta = pd.DataFrame({c: pd.Series([], dtype=d)
                         for (c, d) in file_dtypes.items()},

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -222,7 +222,7 @@ def _write_fastparquet(df, path, compression=None, write_index=None,
     else:
         write = delayed(fastparquet.writer.make_part_file)
         writes = [write(open_with(sep.join([path, filename]), 'wb'), partition,
-                        fmd.schema, compression=compression)
+                        fmd.schema, compression=compression, fmd=fmd)
                   for filename, partition in zip(filenames, df.to_delayed())]
 
     return delayed(_write_metadata)(writes, filenames, fmd, path, open_with, sep)

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -250,8 +250,8 @@ def _write_metadata(writes, filenames, fmd, path, open_with, sep):
 # PyArrow interface
 
 
-def _read_pyarrow(fs, paths, file_opener, columns=None, filters=None,
-                  categories=None, index=None):
+def _read_arrow(fs, paths, file_opener, columns=None, filters=None,
+                categories=None, index=None):
     import pyarrow.parquet as api
 
     if filters is not None:
@@ -347,9 +347,9 @@ def _read_arrow_parquet_piece(open_file_func, piece, columns, index_col,
         return df
 
 
-def _write_pyarrow(df, path, write_index=None, append=False,
-                   ignore_divisions=False, partition_on=None,
-                   storage_options=None, **kwargs):
+def _write_arrow(df, path, write_index=None, append=False,
+                 ignore_divisions=False, partition_on=None,
+                 storage_options=None, **kwargs):
     if append:
         raise NotImplementedError("`append` not implemented for "
                                   "`engine='arrow'`")
@@ -445,8 +445,8 @@ def get_engine(engine):
         def normalize_PyArrowParquetDataset(ds):
             return (type(ds), ds.paths)
 
-        _ENGINES['arrow'] = eng = {'read': _read_pyarrow,
-                                   'write': _write_pyarrow}
+        _ENGINES['arrow'] = eng = {'read': _read_arrow,
+                                   'write': _write_arrow}
         return eng
 
     else:

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -275,7 +275,7 @@ def _read_pyarrow(fs, paths, file_opener, columns=None, filters=None,
         index_col = None
     elif index is None and has_pandas_metadata:
         pandas_metadata = json.loads(schema.metadata[b'pandas'].decode('utf8'))
-        index_col = pandas_metadata.get('index_columns', None)
+        index_col = pandas_metadata.get('index_columns')
     else:
         index_col = index
 
@@ -338,9 +338,8 @@ def _read_arrow_parquet_piece(open_file_func, piece, columns, index_col,
                            use_pandas_metadata=True,
                            file=f)
     df = table.to_pandas()
-    if index_col is not None:
-        if not df.index.name == index_col[0]:
-            df = df.set_index(index_col)
+    if df.index.name is None and index_col is not None:
+        df = df.set_index(index_col)
 
     if is_series:
         return df[df.columns[0]]

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -348,8 +348,8 @@ def _read_arrow_parquet_piece(open_file_func, piece, columns, index_cols,
                            use_pandas_metadata=True,
                            file=f)
     df = table.to_pandas()
-    if (index_cols and df.index.name is None and not
-            df.columns.intersection(index_cols).empty):
+    if (index_cols and df.index.name is None and
+            len(df.columns.intersection(index_cols))):
         # Index should be set, but it isn't
         df = df.set_index(index_cols)
     elif not index_cols and df.index.name is not None:

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -11,7 +11,7 @@ import pytest
 import dask
 import dask.multiprocessing
 import dask.dataframe as dd
-from dask.dataframe.utils import assert_eq, PANDAS_VERSION
+from dask.dataframe.utils import assert_eq
 
 try:
     import fastparquet
@@ -202,7 +202,8 @@ def test_optimize(tmpdir, c):
     assert all(v[4] == c for v in dsk.values())
 
 
-@pytest.mark.skipif(PANDAS_VERSION < '0.21.0', reason="no to_parquet method")
+@pytest.mark.skipif(not hasattr(pd.DataFrame, 'to_parquet'),
+                    reason="no to_parquet method")
 @write_read_engines(False)
 def test_roundtrip_from_pandas(tmpdir, write_engine, read_engine):
     fn = str(tmpdir.join('test.parquet'))

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -19,9 +19,9 @@ except ImportError:
     fastparquet = False
 
 try:
-    import pyarrow.parquet as pa_parquet
+    import pyarrow.parquet as pq
 except ImportError:
-    pa_parquet = False
+    pq = False
 
 
 df = pd.DataFrame({'x': [6, 2, 3, 4, 5],
@@ -33,7 +33,7 @@ ddf = dd.from_pandas(df, npartitions=3)
 
 @pytest.fixture(params=[pytest.mark.skipif(not fastparquet, 'fastparquet',
                                            reason='fastparquet not found'),
-                        pytest.mark.skipif(not pa_parquet, 'pyarrow',
+                        pytest.mark.skipif(not pq, 'pyarrow',
                                            reason='pyarrow not found')])
 def engine(request):
     return request.param
@@ -45,7 +45,7 @@ def check_fastparquet():
 
 
 def check_pyarrow():
-    if not pa_parquet:
+    if not pq:
         pytest.skip('pyarrow not found')
 
 
@@ -55,7 +55,7 @@ def write_read_engines(xfail_arrow_to_fastparquet=True):
     else:
         xfail = ()
     ff = () if fastparquet else (pytest.mark.skip(reason='fastparquet not found'),)
-    aa = () if pa_parquet else (pytest.mark.skip(reason='pyarrow not found'),)
+    aa = () if pq else (pytest.mark.skip(reason='pyarrow not found'),)
     engines = [pytest.param('fastparquet', 'fastparquet', marks=ff),
                pytest.param('pyarrow', 'pyarrow', marks=aa),
                pytest.param('fastparquet', 'pyarrow', marks=ff + aa),
@@ -479,7 +479,7 @@ def test_to_parquet_default_writes_nulls(tmpdir):
     ddf = dd.from_pandas(df, npartitions=1)
 
     ddf.to_parquet(fn)
-    table = pa_parquet.read_table(fn)
+    table = pq.read_table(fn)
     assert table[1].null_count == 2
 
 


### PR DESCRIPTION
This started off as a PR to support writing parquet using arrow, but kind of spiraled out in scope as I found bugs in the original implementations. A summary of changes here:

- Support `engine` kwarg in `to_parquet`
- Add support for using `pyarrow` in `to_parquet`
- Switch `'arrow'` to `'pyarrow'` for engine kwarg, deprecating old `'arrow'` name. This matches the pandas interface.
- Refactor how engines were handled, removing top-level imports in `dask.dataframe.io.parquet`
- Fix several bugs in both readers and writers, mostly having to do with how indices were handled
- Expand testing for `pyarrow` and `fastparquet` compatibility
- Allow running the test suite with neither, one, or both of `pyarrow` and `fastparquet` installed

Fixes #2783.
Fixes #2440.