### PR TITLE
Close resource profiler process on __exit__

### DIFF
--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -83,15 +83,20 @@ def test_resource_profiler():
     assert len(results) > 0
     assert all(isinstance(i, tuple) and len(i) == 3 for i in results)
 
+    # Tracker stopped on exit
+    assert not rprof._is_running()
+
     rprof.clear()
     assert rprof.results == []
 
+    # Close is idempotent
     rprof.close()
-    assert not rprof._tracker.is_alive()
+    assert not rprof._is_running()
 
-    with pytest.raises(AssertionError):
-        with rprof:
-            get(dsk, 'e')
+    # Restarts tracker if already closed
+    with rprof:
+        get(dsk2, 'c')
+    assert len(rprof.results) > 0
 
 
 @pytest.mark.skipif("not psutil")
@@ -114,7 +119,7 @@ def test_resource_profiler_multiple_gets():
     assert all(isinstance(i, tuple) and len(i) == 3 for i in results)
 
     rprof.close()
-    assert not rprof._tracker.is_alive()
+    assert not rprof._is_running()
 
 
 def test_cache_profiler():


### PR DESCRIPTION
Previously ``ResourceProfiler`` would start a tracker process on
`__init__`, which would then persist until `.close()` was called (or the
profiler was garbage collected). This led to processes unintentionally
persisting longer than intended by users.

Now we close the tracker process on context exit, and restart it if it's
closed on enter. When registered globally (not in a context manager) the
process persists until `close` is explictly called, as it was before.

All user code should continue to work the same, and the cost of
restarting the process should be minimal compared to the cost of the
computations being profiled.

Fixes #2869.