### PR TITLE
Avoid list index error in repartition_freq

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3714,10 +3714,13 @@ def repartition_freq(df, freq=None):
     divisions = pd.DatetimeIndex(start=df.divisions[0].ceil(freq),
                                  end=df.divisions[-1],
                                  freq=freq).tolist()
-    if divisions[-1] != df.divisions[-1]:
-        divisions.append(df.divisions[-1])
-    if divisions[0] != df.divisions[0]:
-        divisions = [df.divisions[0]] + divisions
+    if not len(divisions):
+        divisions = [df.divisions[0], df.divisions[-1]];
+    else:
+        if divisions[-1] != df.divisions[-1]:
+            divisions.append(df.divisions[-1])
+        if divisions[0] != df.divisions[0]:
+            divisions = [df.divisions[0]] + divisions
 
     return df.repartition(divisions=divisions)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3715,7 +3715,7 @@ def repartition_freq(df, freq=None):
                                  end=df.divisions[-1],
                                  freq=freq).tolist()
     if not len(divisions):
-        divisions = [df.divisions[0], df.divisions[-1]];
+        divisions = [df.divisions[0], df.divisions[-1]]
     else:
         if divisions[-1] != df.divisions[-1]:
             divisions.append(df.divisions[-1])

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1191,9 +1191,9 @@ def test_repartition_object_index():
 
 @pytest.mark.slow
 @pytest.mark.parametrize('npartitions', [1, 20, 243])
-@pytest.mark.parametrize('freq', ['1D', '7D', '28h'])
-@pytest.mark.parametrize('end', ['2000-04-15', '2000-04-15 12:37:01'])
-@pytest.mark.parametrize('start', ['2000-01-01', '2000-01-01 12:30:00'])
+@pytest.mark.parametrize('freq', ['1D', '7D', '28h', '1h'])
+@pytest.mark.parametrize('end', ['2000-04-15', '2000-04-15 12:37:01', '2000-01-01 12:37:00'])
+@pytest.mark.parametrize('start', ['2000-01-01', '2000-01-01 12:30:00', '2000-01-01 12:30:00'])
 def test_repartition_freq(npartitions, freq, start, end):
     start = pd.Timestamp(start)
     end = pd.Timestamp(end)


### PR DESCRIPTION
avoid list index error if old divisions result in only one new division

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
