### PR TITLE
Explicitly wrap dask filesystems for pyarrow compatibility

### DIFF
--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -524,3 +524,15 @@ class FileSystem(object):
 
     def get_block_locations(self, path):
         return None, None, None
+
+
+def get_pyarrow_filesystem(fs):
+    """Get an equivalent pyarrow filesystem.
+
+    Not for public use, will be removed once a consistent filesystem api
+    is defined."""
+    try:
+        return fs._get_pyarrow_filesystem()
+    except AttributeError:
+        raise NotImplementedError("Using pyarrow with a %r "
+                                  "filesystem object" % type(fs).__name__)

--- a/dask/bytes/local.py
+++ b/dask/bytes/local.py
@@ -70,5 +70,10 @@ class LocalFileSystem(core.FileSystem):
         path = self._trim_filename(path)
         return os.stat(path).st_size
 
+    def _get_pyarrow_filesystem(self):
+        """Get an equivalent pyarrow filesystem"""
+        import pyarrow as pa
+        return pa.filesystem.LocalFileSystem.get_instance()
+
 
 core._filesystems['file'] = LocalFileSystem

--- a/dask/bytes/s3.py
+++ b/dask/bytes/s3.py
@@ -57,5 +57,10 @@ class DaskS3FileSystem(S3FileSystem, core.FileSystem):
         s3_path = self._trim_filename(path)
         return self.info(s3_path)['Size']
 
+    def _get_pyarrow_filesystem(self):
+        """Get an equivalent pyarrow fileystem"""
+        import pyarrow as pa
+        return pa.filesystem.S3FSWrapper(self)
+
 
 core._filesystems['s3'] = DaskS3FileSystem

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -13,7 +13,8 @@ from toolz import concat, valmap, partial
 
 from dask import compute, get, delayed
 from dask.bytes.s3 import DaskS3FileSystem
-from dask.bytes.core import read_bytes, open_files, open_text_files
+from dask.bytes.core import (read_bytes, open_files, open_text_files,
+                             get_pyarrow_filesystem)
 from dask.bytes import core
 
 
@@ -342,3 +343,9 @@ def test_pathlib_s3(s3):
     with pytest.raises(ValueError):
         url = pathlib.Path('s3://bucket/test.accounts.*')
         sample, values = read_bytes(url, blocksize=None)
+
+
+def test_get_pyarrow_fs_s3(s3):
+    pa = pytest.importorskip('pyarrow')
+    fs = DaskS3FileSystem(anon=True)
+    assert isinstance(get_pyarrow_filesystem(fs), pa.filesystem.S3FSWrapper)

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -276,6 +276,7 @@ def _write_metadata(writes, filenames, fmd, path, open_with, sep):
 
 def _read_pyarrow(fs, paths, file_opener, columns=None, filters=None,
                   categories=None, index=None):
+    from ...bytes.core import get_pyarrow_filesystem
     import pyarrow.parquet as pq
 
     if filters is not None:
@@ -287,7 +288,7 @@ def _read_pyarrow(fs, paths, file_opener, columns=None, filters=None,
     if isinstance(columns, tuple):
         columns = list(columns)
 
-    dataset = pq.ParquetDataset(paths, filesystem=fs)
+    dataset = pq.ParquetDataset(paths, filesystem=get_pyarrow_filesystem(fs))
     schema = dataset.schema.to_arrow_schema()
     has_pandas_metadata = schema.metadata is not None and b'pandas' in schema.metadata
     task_name = 'read-parquet-' + tokenize(dataset, columns)


### PR DESCRIPTION
Reading parquet from hdfs now works with the pyarrow engine.

This implements idea 1 in #2880 (ensure dask passes in valid `pyarrow.filesystem.FileSystem` objects). We also add a wrapper for `DaskHDFileSystem` that is compatible with arrow.

Note that while I've tested this locally and things work, there's no testing infrastructure in this repo for testing with hdfs. The hdfs wrapper could be moved to `distributed` (mildly complicated, as we'd need to synchronize changes), or tested there once this is merged here. Not sure.

In the long run I think standardizing the filesystem interfaces is the best fix, so I don't think this functionality will need to be around for long.

~~Fixes # 2801.~~ (edit: no longer a full fix here).
