### PR TITLE
Fix port for bokeh dashboard

### DIFF
--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -29,7 +29,7 @@ among the various worker processes or threads.
    client = Client(processes=False)  # start local workers as threads
 
 If you have `Bokeh <https://bokeh.pydata.org>`_ installed then this starts up a
-diagnostic dashboard at http://localhost:8786 .
+diagnostic dashboard at http://localhost:8787 .
 
 Submit Tasks
 ------------


### PR DESCRIPTION
bokeh dashboard is on http://localhost:8787 rather than http://localhost:8786, as originally stated, at least on my Windows 7 machine.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
