### PR TITLE
Add matmul function

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -10,7 +10,7 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        vstack, hstack, compress, extract, round, count_nonzero,
                        flatnonzero, nonzero, around, isnull, notnull, isclose,
                        allclose, corrcoef, swapaxes, tensordot, transpose, dot,
-                       apply_along_axis, apply_over_axes, result_type,
+                       matmul, apply_along_axis, apply_over_axes, result_type,
                        atleast_1d, atleast_2d, atleast_3d)
 from .reshape import reshape
 from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -207,6 +207,16 @@ def _inner_apply_along_axis(arr,
     )
 
 
+@wraps(np.matmul)
+def matmul(a, b):
+    a = asanyarray(a)
+    b = asanyarray(b)
+    try:
+        return a.__matmul__(b)
+    except Exception:
+        return b.__rmatmul__(a)
+
+
 @wraps(np.apply_along_axis)
 def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     arr = asarray(arr)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -148,6 +148,29 @@ def test_swapaxes():
     assert d.swapaxes(0, 1).name != d.swapaxes(1, 0).name
 
 
+def test_matmul():
+    x = np.random.random((5, 5))
+    y = np.random.random((5, 2))
+
+    a = da.from_array(x, chunks=(1, 5))
+    b = da.from_array(y, chunks=(5, 1))
+
+    assert_eq(np.matmul(x, y), da.matmul(a, b))
+    assert_eq(np.matmul(a, y), da.matmul(x, b))
+    assert_eq(np.matmul(x, b), da.matmul(a, y))
+
+    list_vec = list(range(1, 6))
+    assert_eq(np.matmul(x, list_vec), da.matmul(a, list_vec))
+    assert_eq(np.matmul(list_vec, y), da.matmul(list_vec, b))
+
+    z = np.random.random((5, 5, 5))
+    c = da.from_array(z, chunks=(1, 5, 1))
+    with pytest.raises(NotImplementedError):
+        da.matmul(a, z)
+
+    assert_eq(np.matmul(z, x), da.matmul(c, a))
+
+
 def test_tensordot():
     x = np.arange(400).reshape((20, 20))
     a = da.from_array(x, chunks=(5, 4))

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -97,6 +97,7 @@ Top level user functions:
    logical_or
    logical_xor
    map_blocks
+   matmul
    max
    maximum
    mean
@@ -419,6 +420,7 @@ Other functions
 .. autofunction:: logical_not
 .. autofunction:: logical_or
 .. autofunction:: logical_xor
+.. autofunction:: matmul
 .. autofunction:: max
 .. autofunction:: maximum
 .. autofunction:: mean

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 Array
 +++++
 
--
+- Add ``matmul`` (:pr:`2904`) `John A Kirkham`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Provides a `matmul` function akin to that of [NumPy's `matmul` function]( https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html ), which is exported to the public API. Also tests and documents this function. Simply reuses the methods for now.

~~TODO: Needs a changelog entry.~~