### PR TITLE
Measure sizeof pandas objects more accurately with deep=True

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -42,26 +42,18 @@ def register_pandas():
 
     @sizeof.register(pd.DataFrame)
     def sizeof_pandas_dataframe(df):
-        p = int(df.memory_usage(index=True).sum())
-        obj = int((df.dtypes == object).sum() * len(df) * 100)
-        if df.index.dtype == object:
-            obj += len(df) * 100
-        return int(p + obj) + 1000
+        p = int(df.memory_usage(index=True, deep=True).sum())
+        return p + 1000
 
     @sizeof.register(pd.Series)
     def sizeof_pandas_series(s):
-        p = int(s.memory_usage(index=True))
-        if s.dtype == object:
-            p += len(s) * 100
-        if s.index.dtype == object:
-            p += len(s) * 100
-        return int(p) + 1000
+        p = int(s.memory_usage(index=True, deep=True))
+        return p + 1000
 
     @sizeof.register(pd.Index)
     def sizeof_pandas_index(i):
-        p = int(i.memory_usage())
-        obj = len(i) * 100 if i.dtype == object else 0
-        return int(p + obj) + 1000
+        p = int(i.memory_usage(deep=True))
+        return p + 1000
 
 
 @sizeof.register_lazy("scipy")


### PR DESCRIPTION
This is a small PR that measures the memory usage of pandas objects more accurately by replacing the current heuristic with `memory_usage(deep=True)`. Should allow the scheduler to make better decisions on when to spill to disk.

Note that `memory_usage(deep=True)` only goes down one level. E.g., the memory usage of a list of strings in a DataFrame would still not be computed accurately.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
