### PR TITLE
Support N-D arrays with matmul

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1485,28 +1485,12 @@ class Array(Base):
         return elemwise(operator.xor, other, self)
 
     def __matmul__(self, other):
-        from .routines import tensordot
-        other = asanyarray(other)
-        if other.ndim > 2:
-            msg = ('The matrix multiplication operator (@) is not yet '
-                   'implemented for higher-dimensional Dask arrays. Try '
-                   '`dask.array.tensordot` and see the discussion at '
-                   'https://github.com/dask/dask/pull/2349 for details.')
-            raise NotImplementedError(msg)
-        return tensordot(self, other, axes=((self.ndim - 1,),
-                                            (other.ndim - 2,)))
+        from .routines import matmul
+        return matmul(self, other)
 
     def __rmatmul__(self, other):
-        from .routines import tensordot
-        other = asanyarray(other)
-        if self.ndim > 2:
-            msg = ('The matrix multiplication operator (@) is not yet '
-                   'implemented for higher-dimensional Dask arrays. Try '
-                   '`dask.array.tensordot` and see the discussion at '
-                   'https://github.com/dask/dask/pull/2349 for details.')
-            raise NotImplementedError(msg)
-        return tensordot(other, self, axes=((other.ndim - 1,),
-                                            (self.ndim - 2,)))
+        from .routines import matmul
+        return matmul(other, self)
 
     @derived_from(np.ndarray)
     def any(self, axis=None, keepdims=False, split_every=None, out=None):

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -216,10 +216,16 @@ def _inner_apply_along_axis(arr,
 def matmul(a, b):
     a = asanyarray(a)
     b = asanyarray(b)
-    try:
-        return a.__matmul__(b)
-    except Exception:
-        return b.__rmatmul__(a)
+
+    if b.ndim > 2:
+        msg = ('The matrix multiplication operator (@) is not yet '
+               'implemented for higher-dimensional Dask arrays. Try '
+               '`dask.array.tensordot` and see the discussion at '
+               'https://github.com/dask/dask/pull/2349 for details.')
+        raise NotImplementedError(msg)
+
+    return tensordot(a, b, axes=((a.ndim - 1,),
+                                 (b.ndim - 2,)))
 
 
 @wraps(np.apply_along_axis)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -540,9 +540,7 @@ def test_matmul():
     assert_eq(operator.matmul(x, list_vec), operator.matmul(a, list_vec))
     z = np.random.random((5, 5, 5))
     c = from_array(z, chunks=(1, 5, 1))
-    with pytest.raises(NotImplementedError):
-        operator.matmul(a, z)
-
+    assert_eq(operator.matmul(a, z), operator.matmul(x, c))
     assert_eq(operator.matmul(z, a), operator.matmul(c, x))
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Array
 +++++
 
 - Add ``matmul`` (:pr:`2904`) `John A Kirkham`_
+- Support N-D arrays with ``matmul`` (:pr:`2909`) `John A Kirkham`_
 - Add ``vdot`` (:pr:`2910`) `John A Kirkham`_
 
 DataFrame


### PR DESCRIPTION
In PR ( https://github.com/dask/dask/pull/2349 ), where `matmul` support in the form of the `__matmul__` and `__rmatmul__` was added, we decided to forego supporting arbitrary N-D arrays in favor of just supporting 1-D and 2-D arrays, which were clearer to implement. This was done by leveraging `tensordot`, which had equivalent behavior for these cases, and raising for any N > 2.

The PR here rewrites the `matmul` implementation to support `matmul`'s full behavior for arbitrary N. This includes raising for scalars, broadcasting 1-D arrays (and reducing the singleton dimensions introduced with them), and broadcasting when dimensionality is mismatched between the two arrays. The computation itself is carried out by using `atop` to apply NumPy's `matmul` over the two arrays. Now that a `matmul` function is present thanks to PR ( https://github.com/dask/dask/pull/2904 ), this work is done in that function and the methods `__matmul__` and `__rmatmul__` merely dispatch to it. Includes a large variety of tests to exercise various arrays of different dimensions to make sure they are handled the same with Dask as in NumPy. Entry included in the changelog for this addition.