### PR TITLE
Add vdot

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -10,8 +10,8 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        vstack, hstack, compress, extract, round, count_nonzero,
                        flatnonzero, nonzero, around, isnull, notnull, isclose,
                        allclose, corrcoef, swapaxes, tensordot, transpose, dot,
-                       matmul, apply_along_axis, apply_over_axes, result_type,
-                       atleast_1d, atleast_2d, atleast_3d)
+                       vdot, matmul, apply_along_axis, apply_over_axes,
+                       result_type, atleast_1d, atleast_2d, atleast_3d)
 from .reshape import reshape
 from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
         true_divide, floor_divide, negative, power, remainder, mod, conj, exp,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -197,6 +197,11 @@ def dot(a, b):
     return tensordot(a, b, axes=((a.ndim - 1,), (b.ndim - 2,)))
 
 
+@wraps(np.vdot)
+def vdot(a, b):
+    return dot(a.conj().ravel(), b.ravel())
+
+
 def _inner_apply_along_axis(arr,
                             func1d,
                             func1d_axis,

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -215,6 +215,27 @@ def test_dot_method():
     assert_eq(a.dot(b), x.dot(y))
 
 
+@pytest.mark.parametrize('shape, chunks', [
+    ((20,), (6,)),
+    ((4, 5,), (2, 3)),
+])
+def test_vdot(shape, chunks):
+    np.random.random(1337)
+
+    x = 2 * np.random.random((2,) + shape) - 1
+    x = x[0] + 1j * x[1]
+
+    y = 2 * np.random.random((2,) + shape) - 1
+    y = y[0] + 1j * y[1]
+
+    a = da.from_array(x, chunks=chunks)
+    b = da.from_array(y, chunks=chunks)
+
+    assert_eq(np.vdot(x, y), da.vdot(a, b))
+    assert_eq(np.vdot(y, x), da.vdot(b, a))
+    assert_eq(da.vdot(a, b), da.vdot(b, a).conj())
+
+
 @pytest.mark.parametrize('func1d_name, func1d', [
     ["ndim", lambda x: x.ndim],
     ["sum", lambda x: x.sum()],

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -157,6 +157,7 @@ Top level user functions:
    trunc
    unique
    var
+   vdot
    vnorm
    vstack
    where
@@ -480,6 +481,7 @@ Other functions
 .. autofunction:: trunc
 .. autofunction:: unique
 .. autofunction:: var
+.. autofunction:: vdot
 .. autofunction:: vnorm
 .. autofunction:: vstack
 .. autofunction:: where

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Array
 +++++
 
 - Add ``matmul`` (:pr:`2904`) `John A Kirkham`_
+- Add ``vdot`` (:pr:`2910`) `John A Kirkham`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Provides a Dask Array implementation of `vdot`. Tests it with some basic input data and compares the results to NumPy's `vdot`. Includes it in the public API and adds this to the changelog.