### PR TITLE
Bug issue2928: read sql table fails when reading empty table

### DIFF
--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -3,7 +3,7 @@ import pandas as pd
 import six
 
 from ... import delayed
-from .io import from_delayed
+from .io import from_delayed, from_pandas
 
 
 def read_sql_table(table, uri, index_col, divisions=None, npartitions=None,
@@ -96,6 +96,9 @@ def read_sql_table(table, uri, index_col, divisions=None, npartitions=None,
 
     q = sql.select(columns).limit(5).select_from(table)
     head = pd.read_sql(q, engine, **kwargs)
+
+    if head.empty:
+        return from_pandas(head, npartitions=1)
 
     if divisions is None:
         if limits is None:

--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -98,6 +98,8 @@ def read_sql_table(table, uri, index_col, divisions=None, npartitions=None,
     head = pd.read_sql(q, engine, **kwargs)
 
     if head.empty:
+        name = table.name
+        head = pd.read_sql_table(name, uri, index_col=index_col)
         return from_pandas(head, npartitions=1)
 
     if divisions is None:

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -25,11 +25,6 @@ Garreth,6,20,0
 """
 
 df = pd.read_csv(io.StringIO(data), index_col='number')
-create_empty_table = """ 
-                        CREATE TABLE IF NOT EXISTS empty (
-                            id integer PRIMARY KEY,
-                            name text NOT NULL); 
-                        """
 empty_df = pd.DataFrame({'col1': pd.Series(name='col1', dtype='int64'),
                          'col2': pd.Series(name='col2', dtype='int64')})
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,7 @@ Array
 DataFrame
 +++++++++
 
--
+- ``DataFrame.read_sql()`` (:pr:`2928`) to an empty database tables returns an empty dask dataframe `Apostolos Vlachopoulos`_
 
 
 Core


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
