### PR TITLE
Add meshgrid

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -42,5 +42,5 @@ from .rechunk import rechunk
 from ..context import set_options
 from ..base import compute
 from .optimization import optimize
-from .creation import (arange, linspace, indices, diag, eye, triu, tril,
-                       fromfunction, tile, repeat)
+from .creation import (arange, linspace, meshgrid, indices, diag, eye,
+                       triu, tril, fromfunction, tile, repeat)

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -373,20 +373,13 @@ def indices(dimensions, dtype=int, chunks=None):
     if len(dimensions) != len(chunks):
         raise ValueError("Need same number of chunks as dimensions.")
 
+    xi = []
+    for i in range(len(dimensions)):
+        xi.append(arange(dimensions[i], dtype=dtype, chunks=chunks[i]))
+
     grid = []
     if np.prod(dimensions):
-        for i in range(len(dimensions)):
-            s = len(dimensions) * [None]
-            s[i] = slice(None)
-            s = tuple(s)
-
-            r = arange(dimensions[i], dtype=dtype, chunks=chunks[i])
-            r = r[s]
-
-            for j in chain(range(i), range(i + 1, len(dimensions))):
-                r = r.repeat(dimensions[j], axis=j)
-
-            grid.append(r)
+        grid = meshgrid(*xi, indexing="ij")
 
     if grid:
         grid = stack(grid)

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -198,6 +198,39 @@ def test_indicies():
     assert_eq(darr, nparr)
 
 
+@pytest.mark.parametrize("shapes", [
+    [()],
+    [(0,)],
+    [(2,), (3,)],
+    [(2,), (3,), (4,)],
+    [(2,), (3,), (4,), (5,)],
+    [(2, 3), (4,)],
+])
+@pytest.mark.parametrize("indexing", [
+    "ij",
+    "xy",
+])
+@pytest.mark.parametrize("sparse", [
+    False,
+    True,
+])
+def test_meshgrid(shapes, indexing, sparse):
+    xi_a = []
+    xi_d = []
+    for each_shape in shapes:
+        xi_a.append(np.random.random(each_shape))
+        xi_d.append(da.from_array(xi_a[-1], chunks=1))
+
+    r_a = np.meshgrid(*xi_a, indexing=indexing, sparse=sparse)
+    r_d = da.meshgrid(*xi_d, indexing=indexing, sparse=sparse)
+
+    assert isinstance(r_d, list)
+    assert len(r_a) == len(r_d)
+
+    for e_r_a, e_r_d in zip(r_a, r_d):
+        assert_eq(e_r_a, e_r_d)
+
+
 def test_tril_triu():
     A = np.random.randn(20, 20)
     for chk in [5, 4]:

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -101,6 +101,7 @@ Top level user functions:
    max
    maximum
    mean
+   meshgrid
    min
    minimum
    modf
@@ -425,6 +426,7 @@ Other functions
 .. autofunction:: max
 .. autofunction:: maximum
 .. autofunction:: mean
+.. autofunction:: meshgrid
 .. autofunction:: min
 .. autofunction:: minimum
 .. autofunction:: modf

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Array
 - Add ``matmul`` (:pr:`2904`) `John A Kirkham`_
 - Support N-D arrays with ``matmul`` (:pr:`2909`) `John A Kirkham`_
 - Add ``vdot`` (:pr:`2910`) `John A Kirkham`_
+- Add ``meshgrid`` (:pr:`2938`) `John A Kirkham`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2057

Implements `meshgrid` for Dask Arrays. Supports all keyword arguments (except `copy`). Tests the implementation against NumPy's. Adds `meshgrid` to Dask Array's public API and documents it. Includes a changelog entry for the addition. Also rewrites `indices` to use `meshgrid` internally (simplifying the code).