### PR TITLE
Callbacks unregister properly in nested contexts

### DIFF
--- a/dask/callbacks.py
+++ b/dask/callbacks.py
@@ -136,4 +136,5 @@ class add_callbacks(object):
         return
 
     def __exit__(self, type, value, traceback):
-        _globals['callbacks'] = self.old
+        _globals['callbacks'].clear()
+        _globals['callbacks'].update(self.old)

--- a/dask/callbacks.py
+++ b/dask/callbacks.py
@@ -128,13 +128,13 @@ class add_callbacks(object):
     >>> with add_callbacks(callbacks):    # doctest: +SKIP
     ...     res.compute()
     """
-    def __init__(self, *args):
-        self.old = _globals['callbacks'].copy()
-        _globals['callbacks'].update([normalize_callback(a) for a in args])
+    def __init__(self, *callbacks):
+        self.callbacks = [normalize_callback(c) for c in callbacks]
+        _globals['callbacks'].update(self.callbacks)
 
     def __enter__(self):
         return
 
     def __exit__(self, type, value, traceback):
-        _globals['callbacks'].clear()
-        _globals['callbacks'].update(self.old)
+        for c in self.callbacks:
+            _globals['callbacks'].discard(c)

--- a/dask/tests/test_callbacks.py
+++ b/dask/tests/test_callbacks.py
@@ -103,3 +103,14 @@ def test_nested_schedulers():
     assert outer_callback.dsk == outer_dsk
     assert inner_callback.dsk == inner_dsk
     assert not _globals['callbacks']
+
+
+def test_add_remove_mutates_not_replaces():
+    g = _globals.copy()
+
+    assert not g['callbacks']
+
+    with Callback():
+        pass
+
+    assert not g['callbacks']


### PR DESCRIPTION
Previously unregistering callbacks would replace the existing set of
callbacks. Now we mutate that set in place to reset it (matching the
behavior of `set_options`). Fixes a leaking `ResourceProfiler` in the
distributed test suite.

Fixes https://github.com/dask/distributed/issues/1597.