### PR TITLE
Add chunks to dask.array.broadcast_to

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1804,7 +1804,7 @@ def normalize_chunks(chunks, shape=None):
     >>> normalize_chunks((2, 2), shape=(5, 6))
     ((2, 2, 1), (2, 2, 2))
 
-    >>> normalize_chunks(((2, 2, 1), (2, 2, 2)), shape=(4, 6))  # Idempotent
+    >>> normalize_chunks(((2, 2, 1), (2, 2, 2)), shape=(5, 6))  # Idempotent
     ((2, 2, 1), (2, 2, 2))
 
     >>> normalize_chunks([[2, 2], [3, 3]])  # Cleans up lists to tuples

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -608,6 +608,27 @@ def test_broadcast_to_scalar():
         assert_eq(a, d)
 
 
+def test_broadcast_to_chunks():
+    x = np.random.randint(10, size=(5, 1, 6))
+    a = from_array(x, chunks=(3, 1, 3))
+
+    for shape, chunks, expected_chunks in [
+            ((5, 3, 6), (3, -1, 3), ((3, 2), (3,), (3, 3))),
+            ((5, 3, 6), (3, 1, 3), ((3, 2), (1, 1, 1,), (3, 3))),
+            ((2, 5, 3, 6), (1, 3, 1, 3), ((1, 1), (3, 2), (1, 1, 1,), (3, 3)))]:
+        xb = chunk.broadcast_to(x, shape)
+        ab = broadcast_to(a, shape, chunks=chunks)
+        assert_eq(xb, ab)
+        assert ab.chunks == expected_chunks
+
+    with pytest.raises(ValueError):
+        broadcast_to(a, a.shape, chunks=((2, 3), (1,), (3, 3)))
+    with pytest.raises(ValueError):
+        broadcast_to(a, a.shape, chunks=((3, 2), (3,), (3, 3)))
+    with pytest.raises(ValueError):
+        broadcast_to(a, (5, 2, 6), chunks=((3, 2), (3,), (3, 3)))
+
+
 @pytest.mark.parametrize('u_shape, v_shape', [
     [tuple(), (2, 3)],
     [(1,), (2, 3)],

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Array
 - Add ``matmul`` (:pr:`2904`) `John A Kirkham`_
 - Support N-D arrays with ``matmul`` (:pr:`2909`) `John A Kirkham`_
 - Add ``vdot`` (:pr:`2910`) `John A Kirkham`_
+- Explicit ``chunks`` argument for ``broadcast_to`` (:pr:`2943`) `Stephan Hoyer`_
 
 DataFrame
 +++++++++
@@ -864,3 +865,4 @@ Other
 .. _`@fjetter`: https://github.com/fjetter
 .. _`@Ced4`: https://github.com/Ced4
 .. _`Ian Hopkinson`: https://https://github.com/IanHopkinson
+.. _`Stephan Hoyer`: https://github.com/shoyer


### PR DESCRIPTION
This allows for directly producing output arrays with proper chunking for broadcasting, instead of relying on rechunking afterwards. As mentioned by @magonser in https://github.com/dask/dask/issues/2057#issuecomment-333332368 the later can be slower, because broadcast arrays get fully loaded into memory by indexing.

On one toy benchmark, I see an improvement from 6.5 to 4.0 seconds:
```
In [12]: x = da.ones((1, 1000,), chunks=10)

In [13]: y = da.ones((1000, 1), chunks=10)

In [14]: z = x + y
/Users/shoyer/dev/dask/dask/array/core.py:2113: UserWarning: Increasing number of chunks by factor of 100
  (nparts / max_parts))

In [15]: %timeit z.compute()
1 loop, best of 3: 1.3 s per loop

In [16]: z = da.broadcast_to(x, (1000, 1000)) + da.broadcast_to(y, (1000, 1000))
/Users/shoyer/dev/dask/dask/array/core.py:2113: UserWarning: Increasing number of chunks by factor of 100
  (nparts / max_parts))

In [17]: %timeit z.compute()
1 loop, best of 3: 6.55 s per loop

In [18]: z = da.broadcast_to(x, (1000, 1000), 10) + da.broadcast_to(y, (1000, 1000), 10)

In [19]: %timeit z.compute()
1 loop, best of 3: 3.97 s per loop
```

This isn't as much as a I hoped, but it's something. Maybe there are other cases where it makes more of a difference.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
