### PR TITLE
Add flip, flipud, and fliplr

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -11,7 +11,8 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        flatnonzero, nonzero, around, isnull, notnull, isclose,
                        allclose, corrcoef, swapaxes, tensordot, transpose, dot,
                        vdot, matmul, apply_along_axis, apply_over_axes,
-                       result_type, atleast_1d, atleast_2d, atleast_3d)
+                       result_type, atleast_1d, atleast_2d, atleast_3d,
+                       flip, flipud, fliplr)
 from .reshape import reshape
 from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
         true_divide, floor_divide, negative, power, remainder, mod, conj, exp,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -174,6 +174,11 @@ def flipud(m):
     return flip(m, 0)
 
 
+@wraps(np.fliplr)
+def fliplr(m):
+    return flip(m, 1)
+
+
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 ALPHABET = alphabet.upper()
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -141,6 +141,34 @@ def transpose(a, axes=None):
                 dtype=a.dtype, axes=axes)
 
 
+def flip(m, axis):
+    """
+    Reverse element order along axis.
+
+    Parameters
+    ----------
+    axis : int
+        Axis to reverse element order of.
+
+    Returns
+    -------
+    reversed array : ndarray
+    """
+
+    m = asanyarray(m)
+
+    sl = m.ndim * [slice(None)]
+    try:
+        sl[axis] = slice(None, None, -1)
+    except IndexError:
+        raise ValueError(
+            "`axis` of %s invalid for %s-D array" % (str(axis), str(m.ndim))
+        )
+    sl = tuple(sl)
+
+    return m[sl]
+
+
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 ALPHABET = alphabet.upper()
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -169,6 +169,11 @@ def flip(m, axis):
     return m[sl]
 
 
+@wraps(np.flipud)
+def flipud(m):
+    return flip(m, 0)
+
+
 alphabet = 'abcdefghijklmnopqrstuvwxyz'
 ALPHABET = alphabet.upper()
 

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -63,6 +63,9 @@ Top level user functions:
    fabs
    fix
    flatnonzero
+   flip
+   flipud
+   fliplr
    floor
    fmax
    fmin
@@ -389,6 +392,9 @@ Other functions
 .. autofunction:: fabs
 .. autofunction:: fix
 .. autofunction:: flatnonzero
+.. autofunction:: flip
+.. autofunction:: flipud
+.. autofunction:: fliplr
 .. autofunction:: floor
 .. autofunction:: fmax
 .. autofunction:: fmin

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ Array
 - Add ``vdot`` (:pr:`2910`) `John A Kirkham`_
 - Add ``meshgrid`` (:pr:`2938`) `John A Kirkham`_
 - Preserve singleton chunks in ``fftshift``/``ifftshift`` (:pr:`2733`) `John A Kirkham`_
+- Add ``flip``, ``flipud``, ``fliplr`` (:pr:`2954`) `John A Kirkham`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Provides Dask Array implementations of `flip`, `flipud`, and `fliplr`. Documents them in Dask Array's API docs. Also tests them against their NumPy equivalents. Notes the addition in the changelog.