### PR TITLE
WIP: Add rollaxis

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -11,8 +11,8 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        dstack, vstack, hstack, compress, extract, round,
                        count_nonzero, flatnonzero, nonzero, around, isin,
                        isnull, notnull, isclose, allclose, corrcoef, swapaxes,
-                       tensordot, transpose, dot, vdot, matmul, outer,
-                       apply_along_axis, apply_over_axes, result_type,
+                       rollaxis, tensordot, transpose, dot, vdot, matmul,
+                       outer, apply_along_axis, apply_over_axes, result_type,
                        atleast_1d, atleast_2d, atleast_3d, piecewise, flip,
                        flipud, fliplr, einsum, average)
 from .reshape import reshape

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -133,6 +133,20 @@ def swapaxes(a, axis1, axis2):
                 dtype=a.dtype)
 
 
+@wraps(np.rollaxis)
+def rollaxis(a, axis, start=0):
+    a = asanyarray(a)
+
+    new_order = list(range(a.ndim))
+    del new_order[axis]
+    new_order.insert(start, axis)
+    new_order = tuple(new_order)
+
+    result = a.transpose(new_order)
+
+    return result
+
+
 @wraps(np.transpose)
 def transpose(a, axes=None):
     if axes:

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -151,6 +151,23 @@ def test_swapaxes():
     assert d.swapaxes(0, 1).name != d.swapaxes(1, 0).name
 
 
+@pytest.mark.parametrize('shape', [
+    (),
+    (5,),
+    (5, 10, 15, 20),
+])
+def test_rollaxis(shape):
+    a = np.random.randint(0, 10, shape)
+    d = da.from_array(a, chunks=(len(shape) * (5,)))
+
+    for axis in range(-a.ndim, a.ndim):
+        for start in range(-a.ndim, a.ndim):
+            r_a = np.rollaxis(a, axis, start)
+            r_d = da.rollaxis(d, axis, start)
+
+            assert_eq(r_a, r_d)
+
+
 @pytest.mark.parametrize("funcname, kwargs", [
     ("flipud", {}),
     ("fliplr", {}),

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -157,6 +157,7 @@ Top level user functions:
    result_type
    rint
    roll
+   rollaxis
    round
    sign
    signbit
@@ -516,6 +517,7 @@ Other functions
 .. autofunction:: result_type
 .. autofunction:: rint
 .. autofunction:: roll
+.. autofunction:: rollaxis
 .. autofunction:: round
 .. autofunction:: sign
 .. autofunction:: signbit


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask/dask/issues/2559 ).

Implements `rollaxis` for Dask Arrays. Adds `rollaxis` to the public API and documents it. Provides some tests of `rollaxis` from Dask Array compared to NumPy.