### PR TITLE
Boolean coercion of Arrays and DataFrames

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1181,19 +1181,33 @@ class Array(Base):
         from ..dataframe import from_dask_array
         return from_dask_array(self, columns=columns)
 
-    def __int__(self):
-        return int(self.compute())
-
     def __bool__(self):
-        return bool(self.compute())
+        if self.size > 1:
+            raise ValueError("The truth value of a {0} is ambiguous. "
+                             "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
+                             .format(self.__class__.__name__))
+        else:
+            return bool(self.compute())
 
     __nonzero__ = __bool__  # python 2
 
+    def _scalarfunc(self, func):
+        if self.size > 1:
+            raise TypeError("Only length-1 arrays can be converted "
+                            "to Python scalars")
+        else:
+            return func(self.compute())
+
+    def __int__(self):
+        return self._scalarfunc(int)
+
+    __long__ = __int__  # python 2
+
     def __float__(self):
-        return float(self.compute())
+        return self._scalarfunc(float)
 
     def __complex__(self):
-        return complex(self.compute())
+        return self._scalarfunc(complex)
 
     def __setitem__(self, key, value):
         from .routines import where

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1184,19 +1184,19 @@ class Array(Base):
     def __bool__(self):
         if self.size > 1:
             raise ValueError("The truth value of a {0} is ambiguous. "
-                             "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
+                             "Use a.any() or a.all()."
                              .format(self.__class__.__name__))
         else:
             return bool(self.compute())
 
     __nonzero__ = __bool__  # python 2
 
-    def _scalarfunc(self, func):
+    def _scalarfunc(self, cast_type):
         if self.size > 1:
             raise TypeError("Only length-1 arrays can be converted "
                             "to Python scalars")
         else:
-            return func(self.compute())
+            return cast_type(self.compute())
 
     def __int__(self):
         return self._scalarfunc(int)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -884,10 +884,8 @@ def test_coerce():
 
     a2 = np.arange(2)
     d2 = da.from_array(a2, chunks=(2,))
-    with pytest.raises(TypeError):
-        int(d2)
-        float(d2)
-        complex(d2)
+    for func in (int, float, complex):
+        pytest.raises(TypeError, lambda :func(d2))
 
 
 def test_bool():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -877,10 +877,10 @@ def test_coerce():
     d1 = da.from_array(np.array([1]), chunks=(1,))
     with dask.set_options(get=dask.get):
         for d in d0, d1:
-            assert bool(d) == True
+            assert bool(d) is True
             assert int(d) == 1
             assert float(d) == 1.0
-            assert complex(d) == (1+0j)
+            assert complex(d) == complex(1)
 
     a2 = np.arange(2)
     d2 = da.from_array(a2, chunks=(2,))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -873,12 +873,29 @@ def test_blockdims_from_blockshape():
 
 
 def test_coerce():
-    d = da.from_array(np.array([1]), chunks=(1,))
+    d0 = da.from_array(np.array(1), chunks=(1,))
+    d1 = da.from_array(np.array([1]), chunks=(1,))
     with dask.set_options(get=dask.get):
-        assert bool(d)
-        assert int(d)
-        assert float(d)
-        assert complex(d)
+        for d in d0, d1:
+            assert bool(d) == True
+            assert int(d) == 1
+            assert float(d) == 1.0
+            assert complex(d) == (1+0j)
+
+    a2 = np.arange(2)
+    d2 = da.from_array(a2, chunks=(2,))
+    with pytest.raises(TypeError):
+        int(d2)
+        float(d2)
+        complex(d2)
+
+
+def test_bool():
+    arr = np.arange(100).reshape((10,10))
+    darr = da.from_array(arr, chunks=(10,10))
+    with pytest.raises(ValueError):
+        bool(darr)
+        bool(darr == darr)
 
 
 def test_store_delayed_target():

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -412,15 +412,15 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
 
     def __bool__(self):
         raise ValueError("The truth value of a {0} is ambiguous. "
-                         "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
+                         "Use a.any() or a.all()."
                          .format(self.__class__.__name__))
 
     __nonzero__ = __bool__  # python 2
 
-    def _scalarfunc(self, func):
+    def _scalarfunc(self, cast_type):
         def wrapper():
             raise TypeError("cannot convert the series to "
-                            "{0}".format(str(func)))
+                            "{0}".format(str(cast_type)))
 
         return wrapper
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -410,6 +410,31 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         return self.reduction(len, np.sum, token='len', meta=int,
                               split_every=False).compute()
 
+    def __bool__(self):
+        raise ValueError("The truth value of a {0} is ambiguous. "
+                         "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
+                         .format(self.__class__.__name__))
+
+    __nonzero__ = __bool__  # python 2
+
+    def _scalarfunc(self, func):
+        def wrapper():
+            raise TypeError("cannot convert the series to "
+                            "{0}".format(str(converter)))
+
+        return wrapper
+
+    def __float__(self):
+        return self._scalarfunc(float)
+
+    def __int__(self):
+        return self._scalarfunc(int)
+
+    __long__ = __int__  # python 2
+
+    def __complex__(self):
+        return self._scalarfunc(complex)
+
     @insert_meta_param_description(pad=12)
     def map_partitions(self, func, *args, **kwargs):
         """ Apply Python function on each DataFrame partition.

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -420,7 +420,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
     def _scalarfunc(self, func):
         def wrapper():
             raise TypeError("cannot convert the series to "
-                            "{0}".format(str(converter)))
+                            "{0}".format(str(func)))
 
         return wrapper
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2819,8 +2819,7 @@ def test_coerce():
 def test_bool():
     df = pd.DataFrame(np.arange(100).reshape((10,10)))
     ddf = dd.from_pandas(df, npartitions=2)
-    with pytest.raises(ValueError):
-        bool(ddf)
-        bool(ddf[0])
-        bool(ddf == ddf)
-        bool(ddf[0] == ddf[0])
+    conditions = [ddf, ddf[0], ddf == ddf, ddf[0] == ddf[0]]
+    for cond in conditions:
+        with pytest.raises(ValueError):
+            bool(cond)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2806,3 +2806,21 @@ def test_sample_empty_partitions():
     # smoke test sample on empty partitions
     res = ddf2.compute()
     assert res.dtypes.equals(ddf2.dtypes)
+
+
+def test_coerce():
+    df = pd.DataFrame(np.arange(100).reshape((10,10)))
+    ddf = dd.from_pandas(df, npartitions=2)
+    funcs = (int, float, complex)
+    for d,t in product(funcs,(ddf, ddf[0])):
+        pytest.raises(TypeError, lambda: t(d))
+
+
+def test_bool():
+    df = pd.DataFrame(np.arange(100).reshape((10,10)))
+    ddf = dd.from_pandas(df, npartitions=2)
+    with pytest.raises(ValueError):
+        bool(ddf)
+        bool(ddf[0])
+        bool(ddf == ddf)
+        bool(ddf[0] == ddf[0])

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 Array
 +++++
 
+- Prevent ``bool()`` coercion from calling compute (:pr:`2958`) `Albert DeFusco`_
 - Add ``matmul`` (:pr:`2904`) `John A Kirkham`_
 - Support N-D arrays with ``matmul`` (:pr:`2909`) `John A Kirkham`_
 - Add ``vdot`` (:pr:`2910`) `John A Kirkham`_
@@ -16,7 +17,7 @@ Array
 DataFrame
 +++++++++
 
--
+- Prevent ``bool()`` coercion from calling compute (:pr:`2958`) `Albert DeFusco`_
 
 
 Core
@@ -866,3 +867,4 @@ Other
 .. _`@fjetter`: https://github.com/fjetter
 .. _`@Ced4`: https://github.com/Ced4
 .. _`Ian Hopkinson`: https://https://github.com/IanHopkinson
+.. _`Albert DeFusco`: https://github.com/AlbertDeFusco


### PR DESCRIPTION
This addresses issue #2948.

Behavior of `bool()` and `if cond:` now matches NumPy and Pandas. Most importantly, if `bool(array-like)` is called a ValueError is returned stating that the truth value is ambiguous.

- Added tests for Series, DataFrame, array
- Passes flake8
- Test suite passes
