### PR TITLE
ENH:  Support merging Dask DataFrames on a combination of columns and index levels (GH2950)

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -53,13 +53,6 @@ conda install -q -c conda-forge \
     sqlalchemy \
     toolz
 
-if [[ ${UPSTREAM_DEV} ]]; then
-    echo "Installing NumPy and Pandas dev"
-    conda uninstall -y --force numpy pandas
-    PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
-    pip install -q --pre --no-deps --upgrade --timeout=60 -f $PRE_WHEELS numpy pandas
-fi;
-
 # install pytables from defaults for now
 conda install -q pytables
 
@@ -91,6 +84,13 @@ pip install -q --upgrade \
     mmh3 \
     pytest-xdist \
     xxhash
+
+if [[ ${UPSTREAM_DEV} ]]; then
+    echo "Installing NumPy and Pandas dev"
+    conda uninstall -y --force numpy pandas
+    PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
+    pip install -q --pre --no-deps --upgrade --timeout=60 -f $PRE_WHEELS numpy pandas
+fi;
 
 # Install dask
 pip install -q --no-deps -e .[complete]

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2821,7 +2821,7 @@ class DataFrame(_Frame):
                             if isinstance(columns_or_index, list)
                             else [columns_or_index])
 
-        column_names = [n for n in columns_or_index if self._is_column_label(n)]
+        column_names = [n for n in columns_or_index if self._is_column_label_reference(n)]
 
         selected_df = self[column_names]
         if self._contains_index_name(columns_or_index):
@@ -2830,34 +2830,38 @@ class DataFrame(_Frame):
 
         return selected_df
 
-    def _is_column_label(self, c):
+    def _is_column_label_reference(self, key):
         """
-        Test whether a value matches the label of a column in the DataFrame
-        """
-        return (not is_dask_collection(c) and
-                (np.isscalar(c) or isinstance(c, tuple)) and
-                c in self.columns)
+        Test whether a key is a column label reference
 
-    def _is_index_label(self, i):
+        To be considered a column label reference, `key` must match the name of at
+        least one column.
         """
-        Test whether a value matches the label of the index of the DataFrame
+        return (not is_dask_collection(key) and
+                (np.isscalar(key) or isinstance(key, tuple)) and
+                key in self.columns)
+
+    def _is_index_level_reference(self, key):
+        """
+        Test whether a key is an index level reference
+
+        To be considered an index level reference, `key` must match the index name
+        and must NOT match the name of any column.
         """
         return (self.index.name is not None and
-                not is_dask_collection(i) and
-                (np.isscalar(i) or isinstance(i, tuple)) and
-                i == self.index.name)
+                not is_dask_collection(key) and
+                (np.isscalar(key) or isinstance(key, tuple)) and
+                key == self.index.name and
+                key not in self.columns)
 
     def _contains_index_name(self, columns_or_index):
         """
-        Test whether the input contains the label of the index of the DataFrame
+        Test whether the input contains a reference to the index of the DataFrame
         """
         if isinstance(columns_or_index, list):
-            return (any(self._is_index_label(n) and
-                        not self._is_column_label(n)
-                        for n in columns_or_index))
+            return any(self._is_index_level_reference(n) for n in columns_or_index)
         else:
-            return (self._is_index_label(columns_or_index) and
-                    not self._is_column_label(columns_or_index))
+            return self._is_index_level_reference(columns_or_index)
 
 
 # bind operators

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -203,7 +203,8 @@ required = {'left': [0], 'right': [1], 'inner': [0, 1], 'outer': []}
 
 
 def merge_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix='',
-                             indicator=False):
+                             indicator=False, left_on=None, right_on=None,
+                             left_index=True, right_index=True):
     """ Join two partitioned dataframes along their index """
 
     (lhs, rhs), divisions, parts = align_partitions(lhs, rhs)
@@ -213,7 +214,8 @@ def merge_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix='',
     right_empty = rhs._meta
 
     name = 'join-indexed-' + tokenize(lhs, rhs, how, lsuffix, rsuffix,
-                                      indicator)
+                                      indicator, left_on, right_on,
+                                      left_index, right_index)
 
     dsk = dict()
     for i, (a, b) in enumerate(parts):
@@ -222,12 +224,14 @@ def merge_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix='',
         if b is None and how in ('left', 'outer'):
             b = right_empty
 
-        dsk[(name, i)] = (methods.merge, a, b, how, None, None, True, True,
+        dsk[(name, i)] = (methods.merge, a, b, how, left_on, right_on,
+                          left_index, right_index,
                           indicator, (lsuffix, rsuffix), left_empty,
                           right_empty)
 
     meta = pd.merge(lhs._meta_nonempty, rhs._meta_nonempty, how=how,
-                    left_index=True, right_index=True,
+                    left_index=left_index, right_index=right_index,
+                    left_on=left_on, right_on=right_on,
                     suffixes=(lsuffix, rsuffix), indicator=indicator)
     return new_dd_object(toolz.merge(lhs.dask, rhs.dask, dsk),
                          name, meta, divisions)
@@ -301,7 +305,8 @@ def single_partition_join(left, right, **kwargs):
         dsk = {(name, i): (apply, pd.merge, [left_key, right_key], kwargs)
                for i, right_key in enumerate(right.__dask_keys__())}
 
-        if kwargs.get('right_index'):
+        if kwargs.get('right_index') or right._contains_index_name(
+                kwargs.get('right_on')):
             divisions = right.divisions
         else:
             divisions = [None for _ in right.divisions]
@@ -311,7 +316,8 @@ def single_partition_join(left, right, **kwargs):
         dsk = {(name, i): (apply, pd.merge, [left_key, right_key], kwargs)
                for i, left_key in enumerate(left.__dask_keys__())}
 
-        if kwargs.get('left_index'):
+        if kwargs.get('left_index') or left._contains_index_name(
+                kwargs.get('left_on')):
             divisions = left.divisions
         else:
             divisions = [None for _ in left.divisions]
@@ -360,14 +366,22 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
         right = from_pandas(right, npartitions=1)  # turn into DataFrame
 
     # Both sides are now dd.DataFrame or dd.Series objects
+    merge_indexed_left = (left_index or left._contains_index_name(
+        left_on)) and left.known_divisions
+
+    merge_indexed_right = (right_index or right._contains_index_name(
+        right_on)) and right.known_divisions
 
     # Both sides indexed
-    if (left_index and left.known_divisions and
-            right_index and right.known_divisions):  # Do indexed join
+    if merge_indexed_left and merge_indexed_right:  # Do indexed join
         return merge_indexed_dataframes(left, right, how=how,
                                         lsuffix=suffixes[0],
                                         rsuffix=suffixes[1],
-                                        indicator=indicator)
+                                        indicator=indicator,
+                                        left_on=left_on,
+                                        right_on=right_on,
+                                        left_index=left_index,
+                                        right_index=right_index)
 
     # Single partition on one side
     elif (left.npartitions == 1 and how in ('inner', 'right') or
@@ -386,11 +400,11 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
                         left_on=left_on, right_on=right_on,
                         left_index=left_index, right_index=right_index,
                         suffixes=suffixes, indicator=indicator)
-        if left_index and left.known_divisions:
+        if merge_indexed_left and left.known_divisions:
             right = rearrange_by_divisions(right, right_on, left.divisions,
                                            max_branch, shuffle=shuffle)
             left = left.clear_divisions()
-        elif right_index and right.known_divisions:
+        elif merge_indexed_right and right.known_divisions:
             left = rearrange_by_divisions(left, left_on, right.divisions,
                                           max_branch, shuffle=shuffle)
             right = right.clear_divisions()

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -202,7 +202,7 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32,
     shuffle_tasks
     """
     if not isinstance(index, _Frame):
-        index = df[index]
+        index = df._select_columns_or_index(index)
     partitions = index.map_partitions(partitioning_index,
                                       npartitions=npartitions or df.npartitions,
                                       meta=pd.Series([0]))

--- a/dask/dataframe/tests/test_merge_column_and_index.py
+++ b/dask/dataframe/tests/test_merge_column_and_index.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from dask.dataframe.utils import assert_eq
+from dask.dataframe.utils import assert_eq, PANDAS_VERSION
 
 
 # Fixtures
@@ -72,6 +72,8 @@ def on(request):
 
 # Tests
 # =====
+@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+                    reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 def test_merge_known_to_known(df_left, df_right, ddf_left, ddf_right, on, how):
     # Compute expected
     expected = df_left.merge(df_right, on=on, how=how)
@@ -84,6 +86,8 @@ def test_merge_known_to_known(df_left, df_right, ddf_left, ddf_right, on, how):
     assert_eq(result.divisions, (1, 2, 3, 4))
 
 
+@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+                    reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 @pytest.mark.parametrize('how', ['inner', 'left'])
 def test_merge_known_to_single(df_left, df_right, ddf_left, ddf_right_single, on, how):
     # Compute expected
@@ -97,6 +101,8 @@ def test_merge_known_to_single(df_left, df_right, ddf_left, ddf_right_single, on
     assert_eq(result.divisions, ddf_left.divisions)
 
 
+@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+                    reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 @pytest.mark.parametrize('how', ['inner', 'right'])
 def test_merge_single_to_known(df_left, df_right, ddf_left_single, ddf_right, on, how):
     # Compute expected
@@ -110,6 +116,8 @@ def test_merge_single_to_known(df_left, df_right, ddf_left_single, ddf_right, on
     assert_eq(result.divisions, ddf_right.divisions)
 
 
+@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+                    reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 def test_merge_known_to_unknown(df_left, df_right, ddf_left, ddf_right_unknown, on, how):
     # Compute expected
     expected = df_left.merge(df_right, on=on, how=how)
@@ -120,6 +128,8 @@ def test_merge_known_to_unknown(df_left, df_right, ddf_left, ddf_right_unknown, 
     assert_eq(result.divisions, (None, None, None))
 
 
+@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+                    reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 def test_merge_unknown_to_known(df_left, df_right, ddf_left_unknown, ddf_right, on, how):
     # Compute expected
     expected = df_left.merge(df_right, on=on, how=how)
@@ -132,6 +142,8 @@ def test_merge_unknown_to_known(df_left, df_right, ddf_left_unknown, ddf_right, 
     assert_eq(result.divisions, (None, None, None))
 
 
+@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+                    reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 def test_merge_unknown_to_unknown(df_left, df_right, ddf_left_unknown, ddf_right_unknown, on, how):
     # Compute expected
     expected = df_left.merge(df_right, on=on, how=how)

--- a/dask/dataframe/tests/test_merge_column_and_index.py
+++ b/dask/dataframe/tests/test_merge_column_and_index.py
@@ -84,6 +84,7 @@ def test_merge_known_to_known(df_left, df_right, ddf_left, ddf_right, on, how):
     # Assertions
     assert_eq(result, expected)
     assert_eq(result.divisions, (1, 2, 3, 4))
+    assert len(result.__dask_graph__()) <= 20
 
 
 @pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
@@ -99,6 +100,7 @@ def test_merge_known_to_single(df_left, df_right, ddf_left, ddf_right_single, on
     # Assertions
     assert_eq(result, expected)
     assert_eq(result.divisions, ddf_left.divisions)
+    assert len(result.__dask_graph__()) <= 5
 
 
 @pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
@@ -114,6 +116,7 @@ def test_merge_single_to_known(df_left, df_right, ddf_left_single, ddf_right, on
     # Assertions
     assert_eq(result, expected)
     assert_eq(result.divisions, ddf_right.divisions)
+    assert len(result.__dask_graph__()) <= 5
 
 
 @pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
@@ -126,6 +129,7 @@ def test_merge_known_to_unknown(df_left, df_right, ddf_left, ddf_right_unknown, 
     result = ddf_left.merge(ddf_right_unknown, on=on, how=how)
     assert_eq(result, expected)
     assert_eq(result.divisions, (None, None, None))
+    assert len(result.__dask_graph__()) >= 40
 
 
 @pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
@@ -140,6 +144,7 @@ def test_merge_unknown_to_known(df_left, df_right, ddf_left_unknown, ddf_right, 
     # Assertions
     assert_eq(result, expected)
     assert_eq(result.divisions, (None, None, None))
+    assert len(result.__dask_graph__()) >= 40
 
 
 @pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
@@ -152,3 +157,4 @@ def test_merge_unknown_to_unknown(df_left, df_right, ddf_left_unknown, ddf_right
     result = ddf_left_unknown.merge(ddf_right_unknown, on=on, how=how)
     assert_eq(result, expected)
     assert_eq(result.divisions, (None, None, None))
+    assert len(result.__dask_graph__()) >= 40

--- a/dask/dataframe/tests/test_merge_column_and_index.py
+++ b/dask/dataframe/tests/test_merge_column_and_index.py
@@ -1,0 +1,142 @@
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+import pytest
+
+from dask.dataframe.utils import assert_eq
+
+
+# Fixtures
+# ========
+@pytest.fixture
+def df_left():
+    return pd.DataFrame(dict(
+        idx=[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4],
+        k=[1, 2, 3, 1, 2, 3, 4, 1, 2, 1, 2],
+        v1=np.linspace(0, 1, 11)
+    )).set_index(['idx'])
+
+
+@pytest.fixture
+def df_right():
+    return pd.DataFrame(dict(
+        idx=[1, 1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3],
+        k=[1, 2, 2, 3, 3, 4, 2, 3, 1, 1, 2, 3],
+        v2=np.linspace(10, 11, 12)
+    )).set_index(['idx'])
+
+
+@pytest.fixture
+def ddf_left(df_left):
+    return dd.repartition(df_left, [1, 3, 4])
+
+
+@pytest.fixture
+def ddf_left_unknown(ddf_left):
+    return ddf_left.clear_divisions()
+
+
+@pytest.fixture
+def ddf_left_single(df_left):
+    return dd.from_pandas(df_left, npartitions=1, sort=False)
+
+
+@pytest.fixture
+def ddf_right(df_right):
+    return dd.repartition(df_right, [1, 2, 4])
+
+
+@pytest.fixture
+def ddf_right_unknown(ddf_right):
+    return ddf_right.clear_divisions()
+
+
+@pytest.fixture
+def ddf_right_single(df_right):
+    return dd.from_pandas(df_right, npartitions=1, sort=False)
+
+
+@pytest.fixture(params=['inner', 'left', 'right', 'outer'])
+def how(request):
+    return request.param
+
+
+@pytest.fixture(params=[
+    'idx',
+    ['idx'],
+    ['idx', 'k'],
+    ['k', 'idx']])
+def on(request):
+    return request.param
+
+
+# Tests
+# =====
+def test_merge_known_to_known(df_left, df_right, ddf_left, ddf_right, on, how):
+    # Compute expected
+    expected = df_left.merge(df_right, on=on, how=how)
+
+    # Perform merge
+    result = ddf_left.merge(ddf_right, on=on, how=how)
+
+    # Assertions
+    assert_eq(result, expected)
+    assert_eq(result.divisions, (1, 2, 3, 4))
+
+
+@pytest.mark.parametrize('how', ['inner', 'left'])
+def test_merge_known_to_single(df_left, df_right, ddf_left, ddf_right_single, on, how):
+    # Compute expected
+    expected = df_left.merge(df_right, on=on, how=how)
+
+    # Perform merge
+    result = ddf_left.merge(ddf_right_single, on=on, how=how)
+
+    # Assertions
+    assert_eq(result, expected)
+    assert_eq(result.divisions, ddf_left.divisions)
+
+
+@pytest.mark.parametrize('how', ['inner', 'right'])
+def test_merge_single_to_known(df_left, df_right, ddf_left_single, ddf_right, on, how):
+    # Compute expected
+    expected = df_left.merge(df_right, on=on, how=how)
+
+    # Perform merge
+    result = ddf_left_single.merge(ddf_right, on=on, how=how)
+
+    # Assertions
+    assert_eq(result, expected)
+    assert_eq(result.divisions, ddf_right.divisions)
+
+
+def test_merge_known_to_unknown(df_left, df_right, ddf_left, ddf_right_unknown, on, how):
+    # Compute expected
+    expected = df_left.merge(df_right, on=on, how=how)
+
+    # Perform merge
+    result = ddf_left.merge(ddf_right_unknown, on=on, how=how)
+    assert_eq(result, expected)
+    assert_eq(result.divisions, (None, None, None))
+
+
+def test_merge_unknown_to_known(df_left, df_right, ddf_left_unknown, ddf_right, on, how):
+    # Compute expected
+    expected = df_left.merge(df_right, on=on, how=how)
+
+    # Perform merge
+    result = ddf_left_unknown.merge(ddf_right, on=on, how=how)
+
+    # Assertions
+    assert_eq(result, expected)
+    assert_eq(result.divisions, (None, None, None))
+
+
+def test_merge_unknown_to_unknown(df_left, df_right, ddf_left_unknown, ddf_right_unknown, on, how):
+    # Compute expected
+    expected = df_left.merge(df_right, on=on, how=how)
+
+    # Merge unknown to unknown
+    result = ddf_left_unknown.merge(ddf_right_unknown, on=on, how=how)
+    assert_eq(result, expected)
+    assert_eq(result.divisions, (None, None, None))

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,7 +17,7 @@ DataFrame
 +++++++++
 
 - ``DataFrame.read_sql()`` (:pr:`2928`) to an empty database tables returns an empty dask dataframe `Apostolos Vlachopoulos`_
-
+- ``DataFrame.merge()`` (:pr:`2960`) now supports merging on a combination of columns and the index `Jon Mease`_
 
 Core
 ++++

--- a/docs/source/dataframe-groupby.rst
+++ b/docs/source/dataframe-groupby.rst
@@ -31,6 +31,8 @@ time.
    >>> df.groupby(columns).known_reduction()             # Fast and common case
    >>> df.groupby(columns_with_index).apply(user_fn)     # Fast and common case
    >>> dask_df.join(pandas_df, on=column)                # Fast and common case
+   >>> lhs.join(rhs)                                     # Fast and common case
+   >>> lhs.merge(rhs, on=columns_with_index)             # Fast and common case
 
 Difficult Cases
 ---------------
@@ -43,7 +45,7 @@ trigger a full dataset shuffle
 .. code-block:: python
 
    >>> df.groupby(columns_no_index).apply(user_fn)   # Requires shuffle
-   >>> lhs.join(rhs, on=column)                      # Requires shuffle
+   >>> lhs.join(rhs, on=columns_no_index)            # Requires shuffle
    >>> df.set_index(column)                          # Requires shuffle
 
 A shuffle is necessary when we need to re-sort our data along a new index.  For

--- a/docs/source/dataframe-overview.rst
+++ b/docs/source/dataframe-overview.rst
@@ -113,6 +113,8 @@ The following class of computations works well:
     *  value_counts:  ``df.x.value_counts()``
     *  Drop duplicates:  ``df.x.drop_duplicates()``
     *  Join on index:  ``dd.merge(df1, df2, left_index=True, right_index=True)``
+       or ``dd.merge(df1, df2, on=['idx', 'x'])`` where ``idx`` is the index
+       name for both ``df1`` and ``df2``
     *  Join with Pandas DataFrames: ``dd.merge(df1, df2, on='id')``
     *  Elementwise operations with different partitions / divisions: ``df1.x + df2.y``
     *  Datetime resampling: ``df.resample(...)``


### PR DESCRIPTION
This PR implements the changes proposed in #2950: Support for merging DataFrames on a combination of columns and the index. The corresponding feature was added to pandas for inclusion in 0.22.0 (pandas-dev/pandas#17484).

- [x] Closes #2950 
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Documented in `dataframe-groupby.rst` and `dataframe-overview.rst`
- [x] Changelog update
- [x] Merge in PR #2964 after it lands to fix tests against numpy dev
