### PR TITLE
Try to add `float_power` ufunc

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -15,16 +15,21 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        flip, flipud, fliplr)
 from .reshape import reshape
 from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
-        true_divide, floor_divide, negative, power, float_power, remainder,
-        mod, conj, exp, exp2, log, log2, log10, log1p, expm1, sqrt, square,
-        cbrt, reciprocal, sin, cos, tan, arcsin, arccos, arctan, arctan2,
-        hypot, sinh, cosh, tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg,
-        greater, greater_equal, less, less_equal, not_equal, equal,
-        logical_and, logical_or, logical_xor, logical_not, maximum, minimum,
+        true_divide, floor_divide, negative, power, remainder, mod, conj, exp,
+        exp2, log, log2, log10, log1p, expm1, sqrt, square, cbrt, reciprocal,
+        sin, cos, tan, arcsin, arccos, arctan, arctan2, hypot, sinh, cosh,
+        tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg, greater,
+        greater_equal, less, less_equal, not_equal, equal, logical_and,
+        logical_or, logical_xor, logical_not, maximum, minimum,
         fmax, fmin, isreal, iscomplex, isfinite, isinf, isnan, signbit,
         copysign, nextafter, spacing, ldexp, fmod, floor, ceil, trunc, degrees,
         radians, rint, fix, angle, real, imag, clip, fabs, sign, absolute,
         i0, sinc, nan_to_num, frexp, modf, divide)
+try:
+    from .ufunc import float_power
+except ImportError:
+    # Absent for NumPy versions prior to 1.12.
+    pass
 from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
                          moment,
                          argmin, argmax,

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -38,8 +38,15 @@ binary_ufuncs = ['add', 'arctan2', 'copysign', 'divide', 'equal',
                  'greater_equal', 'hypot', 'ldexp', 'less', 'less_equal',
                  'logaddexp', 'logaddexp2', 'logical_and', 'logical_or',
                  'logical_xor', 'maximum', 'minimum', 'mod', 'multiply',
-                 'nextafter', 'not_equal', 'power', 'float_power', 'remainder',
-                 'subtract', 'true_divide']
+                 'nextafter', 'not_equal', 'power', 'remainder', 'subtract',
+                 'true_divide']
+
+try:
+    da.float_power
+    binary_ufuncs += ['float_power']
+except AttributeError:
+    # Absent for NumPy versions prior to 1.12.
+    pass
 
 unary_ufuncs = ['absolute', 'arccos', 'arccosh', 'arcsin', 'arcsinh', 'arctan',
                 'arctanh', 'cbrt', 'ceil', 'conj', 'cos', 'cosh', 'deg2rad',

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -122,7 +122,11 @@ true_divide = ufunc(np.true_divide)
 floor_divide = ufunc(np.floor_divide)
 negative = ufunc(np.negative)
 power = ufunc(np.power)
-float_power = ufunc(np.float_power)
+try:
+    float_power = ufunc(np.float_power)
+except AttributeError:
+    # Absent for NumPy versions prior to 1.12.
+    pass
 remainder = ufunc(np.remainder)
 mod = ufunc(np.mod)
 # fmod: see below

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,7 @@ Array
 - Add ``meshgrid`` (:pr:`2938`) `John A Kirkham`_
 - Preserve singleton chunks in ``fftshift``/``ifftshift`` (:pr:`2733`) `John A Kirkham`_
 - Add ``flip``, ``flipud``, ``fliplr`` (:pr:`2954`) `John A Kirkham`_
-- Add ``float_power`` ufunc (:pr:`2962`) `John A Kirkham`_
+- Add ``float_power`` ufunc (:pr:`2962`) (:pr:`2969`) `John A Kirkham`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Follow-up to PR ( https://github.com/dask/dask/pull/2962 ).

In some older versions of NumPy, it appears that `float_power` is not present. This tries to wrap `float_power` if present and ignores it if not.