### PR TITLE
PyArrow should write _common_metadata instead of _metadata

### DIFF
--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -303,7 +303,7 @@ def test_parquet(s3, engine):
     df.to_parquet(url, engine=engine)
 
     files = [f.split('/')[-1] for f in s3.ls(url)]
-    assert '_metadata' in files
+    assert '_common_metadata' in files
     assert 'part.0.parquet' in files
 
     df2 = dd.read_parquet(url, index='foo', engine=engine)

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -395,7 +395,7 @@ def _write_pyarrow(df, path, write_index=None, append=False,
 
     write = delayed(_write_partition_pyarrow)
     first_kwargs = kwargs.copy()
-    first_kwargs['metadata_path'] = fs.sep.join([path, '_metadata'])
+    first_kwargs['metadata_path'] = fs.sep.join([path, '_common_metadata'])
     writes = [write(part, open_with, template % i, write_index,
                     **(kwargs if i else first_kwargs))
               for i, part in enumerate(df.to_delayed())]

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -77,7 +77,7 @@ def test_local(tmpdir, write_engine, read_engine):
     df.to_parquet(tmp, write_index=False, engine=write_engine)
 
     files = os.listdir(tmp)
-    assert '_metadata' in files
+    assert '_common_metadata' in files
     assert 'part.0.parquet' in files
 
     df2 = dd.read_parquet(tmp, index=False, engine=read_engine)
@@ -116,7 +116,8 @@ def test_empty(tmpdir, write_engine, read_engine, index):
 def test_read_glob(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=write_engine)
-    os.unlink(os.path.join(fn, '_metadata'))
+    if os.path.exists(os.path.join(fn, '_metadata')):
+        os.unlink(os.path.join(fn, '_metadata'))
 
     files = os.listdir(fn)
     assert '_metadata' not in files


### PR DESCRIPTION
_metadata should include the metadata of all RowGroups in the whole
dataset while _common_metadata only describes the schema.

- [x] Tests added / passed
- [x] Passes `flake8 dask`

