### PR TITLE
Optionally return stored data after storing

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -940,13 +940,12 @@ def store(sources, targets, lock=True, regions=None, compute=True, keep=False, *
             store_dlyds = persist(*store_dlyds)
             store_dsks_mrg = sharedict.merge(*[e.dask for e in store_dlyds])
 
+        load_dsks_mrg = sharedict.merge(store_dsks_mrg, *load_dsks)
+
         results = []
-        for each_load_name, each_load_dsk in zip(load_names, load_dsks):
+        for each_load_name in load_names:
             results.append(Array(
-                sharedict.merge(
-                    (each_load_name, each_load_dsk),
-                    store_dsks_mrg,
-                ),
+                load_dsks_mrg,
                 each_load_name,
                 src.chunks,
                 src.dtype

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -907,12 +907,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         except AttributeError:
             each_tgt_dsk = {}
 
-        src = Array(
-            sources_dsk,
-            src.name,
-            src.chunks,
-            src.dtype
-        )
+        src = Array(sources_dsk, src.name, src.chunks, src.dtype)
 
         each_store_dsk = insert_to_ooc(
             src, tgt, lock=lock, region=reg, return_stored=return_stored

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -32,7 +32,8 @@ import numpy as np
 from . import chunk
 from .numpy_compat import _make_sliced_dtype
 from .slicing import slice_array, replace_ellipsis
-from ..base import Base, tokenize, dont_optimize, compute_as_if_collection
+from ..base import (Base, tokenize, dont_optimize, compute_as_if_collection,
+                    persist)
 from ..context import _globals, globalmethod
 from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      is_integer, IndexCallable, funcname, derived_from,
@@ -936,7 +937,6 @@ def store(sources, targets, lock=True, regions=None, compute=True,
     result = None
     if return_stored:
         if compute:
-            from ..base import persist
             store_dlyds = [Delayed(k, store_dsks_mrg) for k in store_keys]
             store_dlyds = persist(*store_dlyds)
             store_dsks_mrg = sharedict.merge(*[e.dask for e in store_dlyds])

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2769,12 +2769,7 @@ def retrieve_from_ooc(keys, dsk):
     load_dsk = dict()
     for each_key in keys:
         load_key = ('load-%s' % each_key[0],) + each_key[1:]
-        # Reuse the arguments from `store_chunk` in `load_chunk`. Knowing that
-        # `dsk[each_key]` has the format below, we need to make a small change.
-        # `(store_chunk, t, out, slc, lock, region, return_stored)`
-        # Namely drop the first 3 arguments as they are the function and two
-        # arrays that were already used up by `store_chunk`. In their place use
-        # `load_chunk` and the result from `store_chunk` (i.e. `each_key`).
+        # Reuse the result and arguments from `store_chunk` in `load_chunk`.
         load_dsk[load_key] = (load_chunk, each_key,) + dsk[each_key][3:-1]
 
     return load_dsk

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -933,6 +933,7 @@ def store(sources, targets, lock=True, regions=None, compute=True, keep=False, *
         store_dsks, tgt_dsks, [sources_dsk]
     ))
 
+    result = None
     if keep:
         if compute:
             from ..base import persist
@@ -942,26 +943,26 @@ def store(sources, targets, lock=True, regions=None, compute=True, keep=False, *
 
         load_dsks_mrg = sharedict.merge(store_dsks_mrg, *load_dsks)
 
-        results = []
+        result = []
         for each_load_name in load_names:
-            results.append(Array(
+            result.append(Array(
                 load_dsks_mrg,
                 each_load_name,
                 src.chunks,
                 src.dtype
             ))
-        results = tuple(results)
-
-        return results
+        result = tuple(result)
     else:
         name = 'store-' + tokenize(*store_keys)
         dsk = sharedict.merge({name: store_keys}, store_dsks_mrg)
-        result = Delayed(name, dsk)
+        dlyd = Delayed(name, dsk)
 
         if compute:
-            result.compute()
+            dlyd.compute()
         else:
-            return result
+            result = dlyd
+
+    return result
 
 
 def blockdims_from_blockshape(shape, chunks):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -937,15 +937,9 @@ def store(sources, targets, lock=True, regions=None, compute=True,
 
         load_dsks_mrg = sharedict.merge(store_dsks_mrg, *load_dsks)
 
-        result = []
-        for each_load_name in load_names:
-            result.append(Array(
-                load_dsks_mrg,
-                each_load_name,
-                src.chunks,
-                src.dtype
-            ))
-        result = tuple(result)
+        result = tuple(
+            Array(load_dsks_mrg, n, src.chunks, src.dtype) for n in load_names
+        )
 
         return result
     else:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2769,6 +2769,12 @@ def retrieve_from_ooc(keys, dsk):
     load_dsk = dict()
     for each_key in keys:
         load_key = ('load-%s' % each_key[0],) + each_key[1:]
+        # Reuse the arguments from `store_chunk` in `load_chunk`. Knowing that
+        # `dsk[each_key]` has the format below, we need to make a small change.
+        # `(store_chunk, t, out, slc, lock, region, return_stored)`
+        # Namely drop the first 3 arguments as they are the function and two
+        # arrays that were already used up by `store_chunk`. In their place use
+        # `load_chunk` and the result from `store_chunk` (i.e. `each_key`).
         load_dsk[load_key] = (load_chunk, each_key,) + dsk[each_key][3:-1]
 
     return load_dsk

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -913,6 +913,10 @@ def store(sources, targets, lock=True, regions=None, compute=True, keep=False, *
             store_dlyds.append(Delayed(each_store_key, each_store_dsk_mrg))
 
     if keep:
+        if compute:
+            from ..base import persist
+            store_dlyds = persist(*store_dlyds)
+
         store_dsk = sharedict.merge(*[e.dask for e in store_dlyds])
 
         results = []

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -929,7 +929,6 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         store_dsks, tgt_dsks, [sources_dsk]
     ))
 
-    result = None
     if return_stored:
         if compute:
             store_dlyds = [Delayed(k, store_dsks_mrg) for k in store_keys]
@@ -947,17 +946,18 @@ def store(sources, targets, lock=True, regions=None, compute=True,
                 src.dtype
             ))
         result = tuple(result)
+
+        return result
     else:
         name = 'store-' + tokenize(*store_keys)
         dsk = sharedict.merge({name: store_keys}, store_dsks_mrg)
-        dlyd = Delayed(name, dsk)
+        result = Delayed(name, dsk)
 
         if compute:
-            dlyd.compute()
+            result.compute()
+            return None
         else:
-            result = dlyd
-
-    return result
+            return result
 
 
 def blockdims_from_blockshape(shape, chunks):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -39,7 +39,7 @@ from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      SerializableLock, ensure_dict, Dispatch)
 from ..compatibility import unicode, long, getargspec, zip_longest, apply
 from ..core import quote
-from ..delayed import to_task_dask
+from ..delayed import Delayed, to_task_dask
 from .. import threaded, core
 from .. import sharedict
 from ..sharedict import ShareDict
@@ -862,7 +862,6 @@ def store(sources, targets, lock=True, regions=None, compute=True,
 
     >>> store([x, y, z], [dset1, dset2, dset3])  # doctest: +SKIP
     """
-    from ..delayed import Delayed
 
     if isinstance(sources, Array):
         sources = [sources]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1224,7 +1224,7 @@ def test_store_delayed_target():
     assert_eq(bt, b)
 
     # test keeping result
-    st = store([a, b], [atd, btd], keep=True, compute=False)
+    st = store([a, b], [atd, btd], return_stored=True, compute=False)
     st = dask.compute(*st)
 
     at = targs['at']
@@ -1280,7 +1280,9 @@ def test_store_regions():
     # Single region (keep result):
     at = np.zeros(shape=(8, 4, 6))
     bt = np.zeros(shape=(8, 4, 6))
-    v = store([a, b], [at, bt], regions=region, compute=False, keep=True)
+    v = store(
+        [a, b], [at, bt], regions=region, compute=False, return_stored=True
+    )
     assert isinstance(v, tuple)
     assert all([isinstance(e, da.Array) for e in v])
     assert (at == 0).all() and (bt[region] == 0).all()
@@ -1314,7 +1316,12 @@ def test_store_regions():
     # Multiple regions (keep result):
     at = np.zeros(shape=(8, 4, 6))
     bt = np.zeros(shape=(8, 4, 6))
-    v = store([a, b], [at, bt], regions=[region, region], compute=False, keep=True)
+    v = store(
+        [a, b], [at, bt],
+        regions=[region, region],
+        compute=False,
+        return_stored=True
+    )
     assert isinstance(v, tuple)
     assert all([isinstance(e, da.Array) for e in v])
     assert (at == 0).all() and (bt[region] == 0).all()
@@ -1351,7 +1358,7 @@ def test_store_compute_false():
     at = np.zeros(shape=(4, 4))
     bt = np.zeros(shape=(4, 4))
 
-    dat, dbt = store([a, b], [at, bt], compute=False, keep=True)
+    dat, dbt = store([a, b], [at, bt], compute=False, return_stored=True)
     assert isinstance(dat, Array) and isinstance(dbt, Array)
     assert (at == 0).all() and (bt == 0).all()
     assert (dat.compute() == at).all() and (dbt.compute() == bt).all()

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -19,7 +19,7 @@ from toolz.curried import identity
 import dask
 import dask.array as da
 from dask.base import tokenize, compute_as_if_collection
-from dask.delayed import delayed
+from dask.delayed import Delayed, delayed
 from dask.local import get_sync
 from dask.utils import ignoring, tmpfile, tmpdir
 from dask.utils_test import inc
@@ -1213,11 +1213,12 @@ def test_store_delayed_target():
     atd = delayed(make_target)('at')
     btd = delayed(make_target)('bt')
 
-    store([a, b], [atd, btd])
+    st = store([a, b], [atd, btd])
 
     at = targs['at']
     bt = targs['bt']
 
+    assert st is None
     assert_eq(at, a)
     assert_eq(bt, b)
 
@@ -1233,7 +1234,8 @@ def test_store():
     at = np.empty(shape=(4, 4))
     bt = np.empty(shape=(4, 4))
 
-    store([a, b], [at, bt])
+    st = store([a, b], [at, bt])
+    assert st is None
     assert (at == 2).all()
     assert (bt == 3).all()
 
@@ -1252,8 +1254,9 @@ def test_store_regions():
     at = np.zeros(shape=(8, 4, 6))
     bt = np.zeros(shape=(8, 4, 6))
     v = store([a, b], [at, bt], regions=region, compute=False)
+    assert isinstance(v, Delayed)
     assert (at == 0).all() and (bt[region] == 0).all()
-    v.compute()
+    assert all([ev is None for ev in v.compute()])
     assert (at[region] == 2).all() and (bt[region] == 3).all()
     assert not (bt == 3).all() and not ( bt == 0 ).all()
     assert not (at == 2).all() and not ( at == 0 ).all()
@@ -1262,8 +1265,9 @@ def test_store_regions():
     at = np.zeros(shape=(8, 4, 6))
     bt = np.zeros(shape=(8, 4, 6))
     v = store([a, b], [at, bt], regions=[region, region], compute=False)
+    assert isinstance(v, Delayed)
     assert (at == 0).all() and (bt[region] == 0).all()
-    v.compute()
+    assert all([ev is None for ev in v.compute()])
     assert (at[region] == 2).all() and (bt[region] == 3).all()
     assert not (bt == 3).all() and not ( bt == 0 ).all()
     assert not (at == 2).all() and not ( at == 0 ).all()
@@ -1277,8 +1281,9 @@ def test_store_compute_false():
     bt = np.zeros(shape=(4, 4))
 
     v = store([a, b], [at, bt], compute=False)
+    assert isinstance(v, Delayed)
     assert (at == 0).all() and (bt == 0).all()
-    v.compute()
+    assert all([ev is None for ev in v.compute()])
     assert (at == 2).all() and (bt == 3).all()
 
 
@@ -1320,6 +1325,7 @@ def test_store_locks():
 
     lock = Lock()
     v = store([a, b], [at, bt], compute=False, lock=lock)
+    assert isinstance(v, Delayed)
     dsk = v.dask
     locks = set(vv for v in dsk.values() for vv in v if isinstance(vv, _Lock))
     assert locks == set([lock])
@@ -1328,16 +1334,18 @@ def test_store_locks():
     at = NonthreadSafeStore()
     v = store([a, b], [at, at], lock=lock,
               get=dask.threaded.get, num_workers=10)
+    assert v is None
 
     # Don't assume thread safety by default
     at = NonthreadSafeStore()
-    store(a, at, get=dask.threaded.get, num_workers=10)
-    a.store(at, get=dask.threaded.get, num_workers=10)
+    assert store(a, at, get=dask.threaded.get, num_workers=10) is None
+    assert a.store(at, get=dask.threaded.get, num_workers=10) is None
 
     # Ensure locks can be removed
     at = ThreadSafeStore()
     for i in range(10):
-        a.store(at, lock=False, get=dask.threaded.get, num_workers=10)
+        st = a.store(at, lock=False, get=dask.threaded.get, num_workers=10)
+        assert st is None
         if at.max_concurrent_uses > 1:
             break
         if i == 9:
@@ -1350,7 +1358,8 @@ def test_store_multiprocessing_lock():
     a = d + 1
 
     at = np.zeros(shape=(10, 10))
-    a.store(at, get=dask.multiprocessing.get, num_workers=10)
+    st = a.store(at, get=dask.multiprocessing.get, num_workers=10)
+    assert st is None
 
 
 def test_to_hdf5():


### PR DESCRIPTION
Related to issue ( https://github.com/dask/dask/issues/2156 )

Adds an argument Dask Array's `store`, called `keep`. When set, `keep` will return the stored result(s). The behavior of `keep` differs a little depending on whether `compute` is set. If `compute` is `False`, Dask Arrays corresponding to the stored values are returned, which can be chained into other computations, persisted, etc. If `compute` is `True`, then it is like calling `compute` on Dask Arrays that would have been returned if `keep` was `False`.