### PR TITLE
Fixes passing kwargs with unknown keys to Parquet metadata writing fu…

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -223,9 +223,12 @@ def _write_fastparquet(df, path, write_index=None, append=False,
                     'Appended divisions overlapping with the previous ones.\n'
                     'New: {} | Previous: {}'.format(old_end, divisions[0]))
     else:
-        import inspect
         # Get only arguments specified in the function
-        spec = inspect.getfullargspec(fastparquet.writer.make_metadata)
+        try:
+            from inspect import getfullargspec as getargspec
+        except ImportError:
+            from inspect import getargspec
+        spec = getargspec(fastparquet.writer.make_metadata)
         safe_kwargs = {k: v for k, v in kwargs.items() if k in spec.args}
         safe_kwargs['data'] = df._meta
         safe_kwargs['object_encoding'] = object_encoding
@@ -416,10 +419,13 @@ def _write_partition_pyarrow(df, open_with, filename, write_index,
         parquet.write_table(t, fil, **kwargs)
 
     if metadata_path is not None:
-        import inspect
         with open_with(metadata_path, 'wb') as fil:
             # Get only arguments specified in the function
-            spec = inspect.getfullargspec(parquet.write_metadata)
+            try:
+                from inspect import getfullargspec as getargspec
+            except ImportError:
+                from inspect import getargspec
+            spec = getargspec(parquet.write_metadata)
             safe_kwargs = {k: v for k, v in kwargs.items() if k in spec.args}
             safe_kwargs['schema'] = t.schema
             safe_kwargs['where'] = fil

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -175,7 +175,9 @@ def _write_partition_fastparquet(df, fs, path, filename, fmd, compression,
 
 def _write_fastparquet(df, path, write_index=None, append=False,
                        ignore_divisions=False, partition_on=None,
-                       storage_options=None, compression=None, **kwargs):
+                       storage_options=None, compression=None,
+                       has_nulls=True, fixed_text=None,
+                       object_encoding='utf8', times='int64'):
     import fastparquet
 
     fs, paths, open_with = get_fs_paths_myopen(path, None, 'wb',
@@ -183,7 +185,6 @@ def _write_fastparquet(df, path, write_index=None, append=False,
     fs.mkdirs(path)
     sep = fs.sep
 
-    object_encoding = kwargs.pop('object_encoding', 'utf8')
     if object_encoding == 'infer' or (isinstance(object_encoding, dict) and 'infer' in object_encoding.values()):
         raise ValueError('"infer" not allowed as object encoding, '
                          'because this required data in memory.')
@@ -223,18 +224,8 @@ def _write_fastparquet(df, path, write_index=None, append=False,
                     'Appended divisions overlapping with the previous ones.\n'
                     'New: {} | Previous: {}'.format(old_end, divisions[0]))
     else:
-        # Get only arguments specified in the function
-        try:
-            from inspect import getfullargspec as getargspec
-        except ImportError:
-            from inspect import getargspec
-        spec = getargspec(fastparquet.writer.make_metadata)
-        safe_kwargs = {k: v for k, v in kwargs.items() if k in spec.args}
-        safe_kwargs['data'] = df._meta
-        safe_kwargs['object_encoding'] = object_encoding
-        safe_kwargs['index_cols'] = index_cols
-        safe_kwargs['ignore_columns'] = partition_on
-        fmd = fastparquet.writer.make_metadata(**safe_kwargs)
+        fmd = fastparquet.writer.make_metadata(df._meta, has_nulls, partition_on, fixed_text,
+                                               object_encoding, times, index_cols)
         i_offset = 0
 
     filenames = ['part.%i.parquet' % (i + i_offset)
@@ -382,13 +373,22 @@ def _read_pyarrow_parquet_piece(open_file_func, piece, columns, index_cols,
 
 def _write_pyarrow(df, path, write_index=None, append=False,
                    ignore_divisions=False, partition_on=None,
-                   storage_options=None, **kwargs):
+                   storage_options=None,
+                   row_group_size=None, version='1.0',
+                   use_dictionary=True, compression='snappy',
+                   use_deprecated_int96_timestamps=None,
+                   coerce_timestamps=None,
+                   flavor=None, chunk_size=None):
     if append:
         raise NotImplementedError("`append` not implemented for "
                                   "`engine='pyarrow'`")
 
     if partition_on:
-        raise NotImplementedError("`partition_on` not implemented for "
+            raise NotImplementedError("`partition_on` not implemented for "
+                                      "`engine='pyarrow'`")
+
+    if ignore_divisions:
+        raise NotImplementedError("`ignore_divisions` not implemented for "
                                   "`engine='pyarrow'`")
 
     if write_index is None and df.known_divisions:
@@ -401,36 +401,45 @@ def _write_pyarrow(df, path, write_index=None, append=False,
     template = fs.sep.join([path, 'part.%i.parquet'])
 
     write = delayed(_write_partition_pyarrow)
-    first_kwargs = kwargs.copy()
-    first_kwargs['metadata_path'] = fs.sep.join([path, '_common_metadata'])
+    metadata_path = fs.sep.join([path, '_common_metadata'])
     writes = [write(part, open_with, template % i, write_index,
-                    **(kwargs if i else first_kwargs))
+                    (None if i else metadata_path),
+                    row_group_size, version,
+                    use_dictionary, compression,
+                    use_deprecated_int96_timestamps,
+                    coerce_timestamps,
+                    flavor, chunk_size)
               for i, part in enumerate(df.to_delayed())]
     return delayed(writes)
 
 
 def _write_partition_pyarrow(df, open_with, filename, write_index,
-                             metadata_path=None, **kwargs):
+                             metadata_path=None,
+                             row_group_size=None, version='1.0',
+                             use_dictionary=True, compression='snappy',
+                             use_deprecated_int96_timestamps=None,
+                             coerce_timestamps=None,
+                             flavor=None, chunk_size=None):
     import pyarrow as pa
     from pyarrow import parquet
     t = pa.Table.from_pandas(df, preserve_index=write_index)
 
+    # Only kwargs key expected by write_table
+    if not chunk_size:
+        chunk_size = row_group_size
+
     with open_with(filename, 'wb') as fil:
-        parquet.write_table(t, fil, **kwargs)
+        parquet.write_table(t, fil, row_group_size, version,
+                            use_dictionary, compression,
+                            use_deprecated_int96_timestamps,
+                            coerce_timestamps,
+                            flavor, chunk_size=chunk_size)
 
     if metadata_path is not None:
         with open_with(metadata_path, 'wb') as fil:
-            # Get only arguments specified in the function
-            try:
-                from inspect import getfullargspec as getargspec
-            except ImportError:
-                from inspect import getargspec
-            spec = getargspec(parquet.write_metadata)
-            safe_kwargs = {k: v for k, v in kwargs.items() if k in spec.args}
-            safe_kwargs['schema'] = t.schema
-            safe_kwargs['where'] = fil
-            parquet.write_metadata(**safe_kwargs)
-
+            parquet.write_metadata(t.schema, fil, version,
+                                   use_deprecated_int96_timestamps,
+                                   coerce_timestamps)
 
 # ----------------------------------------------------------------------
 # User API

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -615,13 +615,29 @@ def test_writing_parquet_with_compression(tmpdir, compression, engine):
     assert_eq(out, df, check_index=(engine != 'fastparquet'))
 
 
+def test_writing_parquet_with_kwargs(tmpdir, engine):
+    fn = str(tmpdir)
+
+    engine_kwargs = {
+        'pyarrow': {
+            'compression': 'snappy',
+            'coerce_timestamps': None,
+            'use_dictionary': True
+        },
+        'fastparquet': {
+            'compression': 'snappy',
+            'times': 'int64',
+            'fixed_text': None
+        }
+    }
+
+    ddf.to_parquet(fn,  engine=engine, **engine_kwargs[engine])
+    out = dd.read_parquet(fn, engine=engine)
+    assert_eq(out, df, check_index=(engine != 'fastparquet'))
+
+
 def test_writing_parquet_with_unknown_kwargs(tmpdir, engine):
     fn = str(tmpdir)
 
-    df = pd.DataFrame({'x': ['a', 'b', 'c'] * 10,
-                       'y': [1, 2, 3] * 10})
-    ddf = dd.from_pandas(df, npartitions=3)
-
-    ddf.to_parquet(fn,  engine=engine, unknown_key='unknown_value')
-    out = dd.read_parquet(fn, engine=engine)
-    assert_eq(out, df, check_index=(engine != 'fastparquet'))
+    with pytest.raises(TypeError):
+        ddf.to_parquet(fn,  engine=engine, unknown_key='unknown_value')

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -613,3 +613,15 @@ def test_writing_parquet_with_compression(tmpdir, compression, engine):
     ddf.to_parquet(fn, compression=compression, engine=engine)
     out = dd.read_parquet(fn, engine=engine)
     assert_eq(out, df, check_index=(engine != 'fastparquet'))
+
+
+def test_writing_parquet_with_unknown_kwargs(tmpdir, engine):
+    fn = str(tmpdir)
+
+    df = pd.DataFrame({'x': ['a', 'b', 'c'] * 10,
+                       'y': [1, 2, 3] * 10})
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    ddf.to_parquet(fn,  engine=engine, unknown_key='unknown_value')
+    out = dd.read_parquet(fn, engine=engine)
+    assert_eq(out, df, check_index=(engine != 'fastparquet'))

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -622,6 +622,5 @@ def test_writing_parquet_with_unknown_kwargs(tmpdir, engine):
                        'y': [1, 2, 3] * 10})
     ddf = dd.from_pandas(df, npartitions=3)
 
-    ddf.to_parquet(fn,  engine=engine, unknown_key='unknown_value')
-    out = dd.read_parquet(fn, engine=engine)
-    assert_eq(out, df, check_index=(engine != 'fastparquet'))
+    with pytest.raises(TypeError):
+        ddf.to_parquet(fn,  engine=engine, unknown_key='unknown_value')

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -622,5 +622,6 @@ def test_writing_parquet_with_unknown_kwargs(tmpdir, engine):
                        'y': [1, 2, 3] * 10})
     ddf = dd.from_pandas(df, npartitions=3)
 
-    with pytest.raises(TypeError):
-        ddf.to_parquet(fn,  engine=engine, unknown_key='unknown_value')
+    ddf.to_parquet(fn,  engine=engine, unknown_key='unknown_value')
+    out = dd.read_parquet(fn, engine=engine)
+    assert_eq(out, df, check_index=(engine != 'fastparquet'))


### PR DESCRIPTION
Relates to issue #2985. `kwargs` were passed to a functions without `kwargs` support, which caused errors on unknown arguments present in `kwargs`, like `compression` but possibly others. PR adds also a specific test for the issue.
