### PR TITLE
allow custom shape and/or label in to_graphviz()

### DIFF
--- a/dask/dot.py
+++ b/dask/dot.py
@@ -125,23 +125,29 @@ def to_graphviz(dsk, data_attributes=None, function_attributes=None,
         k_name = name(k)
         if k_name not in seen:
             seen.add(k_name)
-            g.node(k_name, label=label(k, cache=cache), shape='box',
-                   **data_attributes.get(k, {}))
+            attrs = data_attributes.get(k, {})
+            attrs.setdefault('label', label(k, cache=cache))
+            attrs.setdefault('shape', 'box')
+            g.node(k_name, **attrs)
 
         if istask(v):
             func_name = name((k, 'function'))
             if func_name not in seen:
                 seen.add(func_name)
-                g.node(func_name, label=task_label(v), shape='circle',
-                       **function_attributes.get(k, {}))
+                attrs = function_attributes.get(k, {})
+                attrs.setdefault('label', task_label(v))
+                attrs.setdefault('shape', 'circle')
+                g.node(func_name, **attrs)
             g.edge(func_name, k_name)
 
             for dep in get_dependencies(dsk, k):
                 dep_name = name(dep)
                 if dep_name not in seen:
                     seen.add(dep_name)
-                    g.node(dep_name, label=label(dep, cache=cache), shape='box',
-                           **data_attributes.get(dep, {}))
+                    attrs = data_attributes.get(dep, {})
+                    attrs.setdefault('label', label(dep, cache=cache))
+                    attrs.setdefault('shape', 'box')
+                    g.node(dep_name, **attrs)
                 g.edge(dep_name, func_name)
         elif ishashable(v) and v in dsk:
             g.edge(name(v), k_name)

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -19,13 +19,19 @@ from IPython.display import Image, SVG
 
 
 # Since graphviz doesn't store a graph, we need to parse the output
-label_re = re.compile('.*\[label=(.*?) shape=.*\]')
+label_re = re.compile('.*\[label=(.*?) shape=(.*?)\]')
 
 
 def get_label(line):
     m = label_re.match(line)
     if m:
         return m.group(1)
+
+
+def get_shape(line):
+    m = label_re.match(line)
+    if m:
+        return m.group(2)
 
 
 dsk = {'a': 1,
@@ -73,6 +79,22 @@ def test_to_graphviz():
     funcs = set(('add', 'sum', 'neg'))
     assert set(labels).difference(dsk) == funcs
     assert set(labels).difference(funcs) == set(dsk)
+    shapes = list(filter(None, map(get_shape, g.body)))
+    assert set(shapes) == set(('box', 'circle'))
+
+
+def test_to_graphviz_custom():
+    g = to_graphviz(
+        dsk,
+        data_attributes={'a': {'shape': 'square'}},
+        function_attributes={'c': {'label': 'neg_c', 'shape': 'ellipse'}},
+    )
+    labels = list(filter(None, map(get_label, g.body)))
+    funcs = set(('add', 'sum', 'neg', 'neg_c'))
+    assert set(labels).difference(dsk) == funcs
+    assert set(labels).difference(funcs) == set(dsk)
+    shapes = list(filter(None, map(get_shape, g.body)))
+    assert set(shapes) == set(('box', 'circle', 'square', 'ellipse'))
 
 
 def test_to_graphviz_attributes():


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API

This extends the `data_attributes` and `function_attributes` arguments to support `shape` and `label`.   Without this change, to_graphviz fails with `TypeError: node() got multiple values for keyword argument 'shape'`.  I don't think these arguments are currently documented so I'm not sure whether new documentation is needed.