### PR TITLE
COMPAT: Pandas 0.22.0 astype for categorical dtypes

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -206,14 +206,13 @@ def text_blocks_to_pandas(reader, block_lists, header, head, kwargs,
             specified_dtypes.get(k).categories is not None
         ]
         unknown_categoricals = categoricals.difference(known_categoricals)
-    elif isinstance(specified_dtypes, CategoricalDtype):
-        if _HAS_CDT and isinstance(specified_dtypes, CategoricalDtype):
-            if specified_dtypes.categories is None:
-                known_categoricals = []
-                unknown_categoricals = categoricals
-            else:
-                known_categoricals = categoricals
-                unknown_categoricals = []
+    elif _HAS_CDT and isinstance(specified_dtypes, CategoricalDtype):
+        if specified_dtypes.categories is None:
+            known_categoricals = []
+            unknown_categoricals = categoricals
+        else:
+            known_categoricals = categoricals
+            unknown_categoricals = []
     else:
         known_categoricals = []
         unknown_categoricals = categoricals

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -218,9 +218,8 @@ def text_blocks_to_pandas(reader, block_lists, header, head, kwargs,
         unknown_categoricals = categoricals
 
     # Fixup the dtypes
-    for k in dtypes:
-        if k in unknown_categoricals:
-            dtypes[k] = 'category'
+    for k in unknown_categoricals:
+        dtypes[k] = 'category'
 
     columns = list(head.columns)
     delayed_pandas_read_text = delayed(pandas_read_text)

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -198,24 +198,21 @@ def text_blocks_to_pandas(reader, block_lists, header, head, kwargs,
     # 2. contain 'category' for data inferred types
     categoricals = head.select_dtypes(include=['category']).columns
 
-    if isinstance(specified_dtypes, collections.Mapping):
-        known_categoricals = [
-            k for k in categoricals
-            if _HAS_CDT and
-            isinstance(specified_dtypes.get(k), CategoricalDtype) and
-            specified_dtypes.get(k).categories is not None
-        ]
-        unknown_categoricals = categoricals.difference(known_categoricals)
-    elif _HAS_CDT and isinstance(specified_dtypes, CategoricalDtype):
-        if specified_dtypes.categories is None:
-            known_categoricals = []
-            unknown_categoricals = categoricals
-        else:
-            known_categoricals = categoricals
-            unknown_categoricals = []
-    else:
-        known_categoricals = []
-        unknown_categoricals = categoricals
+    known_categoricals = []
+    unknown_categoricals = categoricals
+
+    if _HAS_CDT:
+        if isinstance(specified_dtypes, collections.Mapping):
+            known_categoricals = [
+                k for k in categoricals
+                if isinstance(specified_dtypes.get(k), CategoricalDtype) and
+                specified_dtypes.get(k).categories is not None
+            ]
+            unknown_categoricals = categoricals.difference(known_categoricals)
+        elif isinstance(specified_dtypes, CategoricalDtype):
+            if specified_dtypes.categories is None:
+                known_categoricals = []
+                unknown_categoricals = categoricals
 
     # Fixup the dtypes
     for k in unknown_categoricals:

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -384,7 +384,7 @@ def test_categorical_dtypes():
                 ['apple', 'banana', 'orange', 'pear'])
 
 
-@pytest.mark.skipif(PANDAS_VERSION < '0.20.0',
+@pytest.mark.skipif(PANDAS_VERSION < '0.21.0',
                     reason="Uses CategoricalDtype")
 def test_categorical_ordered():
     text1 = normalize_text("""

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -431,9 +431,12 @@ def test_categorical_known():
 
         assert_eq(result, expected)
 
-        # Specify "uknown" categories
+        # Specify "unknown" categories
         result = dd.read_csv("foo.*.csv",
                              dtype=pd.api.types.CategoricalDtype())
+        assert result.A.cat.known is False
+
+        result = dd.read_csv("foo.*.csv", dtype="category")
         assert result.A.cat.known is False
 
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -386,36 +386,55 @@ def test_categorical_dtypes():
 
 @pytest.mark.skipif(PANDAS_VERSION < '0.21.0',
                     reason="Uses CategoricalDtype")
-def test_categorical_ordered():
+def test_categorical_known():
     text1 = normalize_text("""
-    A
-    a
-    b
-    a
+    A,B
+    a,a
+    b,b
+    a,a
     """)
     text2 = normalize_text("""
-    A
-    a
-    b
-    c
+    A,B
+    a,a
+    b,b
+    c,c
     """)
     dtype = pd.api.types.CategoricalDtype(['a', 'b', 'c'])
     with filetexts({"foo.1.csv": text1, "foo.2.csv": text2}):
-        result = dd.read_csv("foo.*.csv", dtype={"A": 'category'})
+        result = dd.read_csv("foo.*.csv", dtype={"A": 'category',
+                                                 "B": 'category'})
+        assert result.A.cat.known is False
+        assert result.B.cat.known is False
         expected = pd.DataFrame({
             "A": pd.Categorical(['a', 'b', 'a', 'a', 'b', 'c'],
+                                categories=dtype.categories),
+            "B": pd.Categorical(['a', 'b', 'a', 'a', 'b', 'c'],
                                 categories=dtype.categories)},
                                 index=[0, 1, 2, 0, 1, 2])
         assert_eq(result, expected)
 
-        result = dd.read_csv("foo.*.csv", dtype=dtype)
+        # Specify a dtype
+        result = dd.read_csv("foo.*.csv", dtype={'A': dtype, 'B': 'category'})
+        assert result.A.cat.known is True
+        assert result.B.cat.known is False
+        tm.assert_index_equal(result.A.cat.categories, dtype.categories)
+        assert result.A.cat.ordered is False
         assert_eq(result, expected)
 
         # ordered
         dtype = pd.api.types.CategoricalDtype(['a', 'b', 'c'], ordered=True)
-        result = dd.read_csv("foo.*.csv", dtype=dtype)
+        result = dd.read_csv("foo.*.csv", dtype={'A': dtype, 'B': 'category'})
         expected['A'] = expected['A'].cat.as_ordered()
+        assert result.A.cat.known is True
+        assert result.B.cat.known is False
+        assert result.A.cat.ordered is True
+
         assert_eq(result, expected)
+
+        # Specify "uknown" categories
+        result = dd.read_csv("foo.*.csv",
+                             dtype=pd.api.types.CategoricalDtype())
+        assert result.A.cat.known is False
 
 
 @pytest.mark.slow

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,7 @@ bounds indexes (:pr:`2967`) `Stephan Hoyer`_
 DataFrame
 +++++++++
 
+- Compatability with pandas 0.22.0 (:issue:`2996`) `Tom Augspurger`_
 - Prevent ``bool()`` coercion from calling compute (:pr:`2958`) `Albert DeFusco`_
 - ``DataFrame.read_sql()`` (:pr:`2928`) to an empty database tables returns an empty dask dataframe `Apostolos Vlachopoulos`_
 - Fixed ``dd.concat`` losing the index dtype when the data contained a categorical (:issue:`2932`) `Tom Augspurger`_

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,7 @@ bounds indexes (:pr:`2967`) `Stephan Hoyer`_
 DataFrame
 +++++++++
 
+- Fixed ``dd.read_csv`` so that passing instances of ``CategoricalDtype`` in ``dtype`` will result in known categoricals (:pr:`2996`) `Tom Augspurger`_
 - Compatability with pandas 0.22.0 (:issue:`2996`) `Tom Augspurger`_
 - Prevent ``bool()`` coercion from calling compute (:pr:`2958`) `Albert DeFusco`_
 - ``DataFrame.read_sql()`` (:pr:`2928`) to an empty database tables returns an empty dask dataframe `Apostolos Vlachopoulos`_

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,8 +24,7 @@ bounds indexes (:pr:`2967`) `Stephan Hoyer`_
 DataFrame
 +++++++++
 
-- Fixed ``dd.read_csv`` so that passing instances of ``CategoricalDtype`` in ``dtype`` will result in known categoricals (:pr:`2996`) `Tom Augspurger`_
-- Compatability with pandas 0.22.0 (:issue:`2996`) `Tom Augspurger`_
+- Fixed ``dd.read_csv`` so that passing instances of ``CategoricalDtype`` in ``dtype`` will result in known categoricals (:pr:`2997`) `Tom Augspurger`_
 - Prevent ``bool()`` coercion from calling compute (:pr:`2958`) `Albert DeFusco`_
 - ``DataFrame.read_sql()`` (:pr:`2928`) to an empty database tables returns an empty dask dataframe `Apostolos Vlachopoulos`_
 - Fixed ``dd.concat`` losing the index dtype when the data contained a categorical (:issue:`2932`) `Tom Augspurger`_

--- a/docs/source/dataframe-design.rst
+++ b/docs/source/dataframe-design.rst
@@ -144,6 +144,16 @@ dtype as ``'category'``:
 
 .. _`categorical data`: http://pandas.pydata.org/pandas-docs/stable/categorical.html
 
+With pandas 0.21.0 and up, ``dd.read_csv`` and ``dd.read_table`` can read
+data directly into *known* categoricals by specifying instances of
+``pd.api.types.CategoricalDtype``:
+
+.. code-block:: python
+
+    >>> dtype = {'col': pd.api.types.CategoricalDtype(['a', 'b', 'c'])}
+    >>> ddf = dd.read_csv(..., dtype=dtype)
+
+
 Partitions
 ----------
 


### PR DESCRIPTION
Change in https://github.com/pandas-dev/pandas/pull/18710 caused a dask failure
when reading CSV files, as our `.astype` relied on the old (broken) behavior.

Closes https://github.com/dask/dask/issues/2996
