### PR TITLE
Adjustments to insert_to_ooc

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2588,8 +2588,10 @@ def insert_to_ooc(arr, out, lock=True, region=None):
     slices = slices_from_chunks(arr.chunks)
 
     name = 'store-%s' % arr.name
-    dsk = {(name,) + t[1:]: (store, t, out, slc, lock, region)
-           for t, slc in zip(core.flatten(arr.__dask_keys__()), slices)}
+    dsk = dict()
+    for t, slc in zip(core.flatten(arr.__dask_keys__()), slices):
+        store_key = (name,) + t[1:]
+        dsk[store_key] = (store, t, out, slc, lock, region)
 
     return dsk
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2571,13 +2571,14 @@ def insert_to_ooc(arr, out, lock=True, region=None):
         lock = Lock()
 
     def store(x, out, index, lock, region):
+        subindex = index
+        if region is not None:
+            subindex = fuse_slice(region, index)
+
         if lock:
             lock.acquire()
         try:
-            if region is None:
-                out[index] = np.asanyarray(x)
-            else:
-                out[fuse_slice(region, index)] = np.asanyarray(x)
+            out[subindex] = np.asanyarray(x)
         finally:
             if lock:
                 lock.release()


### PR DESCRIPTION
Pulls some changes out of PR ( https://github.com/dask/dask/pull/2980 ). 

Makes some adjustments to the `insert_to_ooc` function in `dask.array.core`. Namely determines the `subindex` to write into before acquiring the `lock`. Also converts the generator expression at the end into a `for`-loop.