### PR TITLE
 Changes `dask.array.meshgrid` to use `broadcast_to` internally (#2981)

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from functools import partial, wraps
-from itertools import chain, product
+from itertools import product
 from operator import add
 from numbers import Integral
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -312,6 +312,7 @@ def meshgrid(*xi, **kwargs):
     if indexing not in ("ij", "xy"):
         raise ValueError("`indexing` must be `'ij'` or `'xy'`")
 
+    xi = [asarray(e) for e in xi]
     xi = [e.flatten() for e in xi]
     dimensions = [xi[i].size for i in range(len(xi))]
     chunks = [xi[i].chunks[0] for i in range(len(xi))]

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -12,7 +12,7 @@ from .. import sharedict
 from ..base import tokenize
 from ..utils import ignoring
 from . import chunk
-from .core import Array, asarray, normalize_chunks, stack, concatenate
+from .core import Array, asarray, normalize_chunks, stack, concatenate, broadcast_to
 from .wrap import empty, ones, zeros, full
 
 
@@ -314,10 +314,12 @@ def meshgrid(*xi, **kwargs):
 
     xi = [e.flatten() for e in xi]
     dimensions = [xi[i].size for i in range(len(xi))]
+    chunks = [xi[i].chunks[0] for i in range(len(xi))]
 
     if indexing == "xy" and len(xi) > 1:
         xi[0], xi[1] = xi[1], xi[0]
         dimensions[0], dimensions[1] = dimensions[1], dimensions[0]
+        chunks[0], chunks[1] = chunks[1], chunks[0]
 
     grid = []
     for i in range(len(xi)):
@@ -328,8 +330,7 @@ def meshgrid(*xi, **kwargs):
         r = xi[i][s]
 
         if not sparse:
-            for j in chain(range(i), range(i + 1, len(dimensions))):
-                r = r.repeat(dimensions[j], axis=j)
+            r = broadcast_to(r, shape=dimensions, chunks=chunks)
 
         grid.append(r)
 

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -198,7 +198,7 @@ def test_indicies():
     assert_eq(darr, nparr)
 
 
-@pytest.mark.parametrize("shapes,chunks", [
+@pytest.mark.parametrize("shapes, chunks", [
     ([()], [()]),
     ([(0,)], [(0,)]),
     ([(2,), (3,)], [(1,), (2,)]),

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -248,10 +248,10 @@ def test_meshgrid_inputcoercion():
     a = [1, 2, 3]
     b = np.array([4, 5, 6, 7])
     x, y = np.meshgrid(a, b, indexing='ij')
-    z = x*y
+    z = x * y
 
     x_d, y_d = da.meshgrid(a, b, indexing='ij')
-    z_d = x_d*y_d
+    z_d = x_d * y_d
 
     assert z_d.shape == (len(a), len(b))
     assert_eq(z, z_d)

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -239,8 +239,6 @@ def test_meshgrid(shapes, chunks, indexing, sparse):
     for e_r_a, e_r_d, i in zip(r_a, r_d, do):
         assert_eq(e_r_a, e_r_d)
         if sparse:
-            print("3", e_r_d, e_r_d.chunks)
-            print("4", e_r_d.chunks[i], xi_dc[i])
             assert e_r_d.chunks[i] == xi_dc[i]
         else:
             assert e_r_d.chunks == xi_dc

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -244,6 +244,19 @@ def test_meshgrid(shapes, chunks, indexing, sparse):
             assert e_r_d.chunks == xi_dc
 
 
+def test_meshgrid_inputcoercion():
+    a = [1, 2, 3]
+    b = np.array([4, 5, 6, 7])
+    x, y = np.meshgrid(a, b, indexing='ij')
+    z = x*y
+
+    x_d, y_d = da.meshgrid(a, b, indexing='ij')
+    z_d = x_d*y_d
+
+    assert z_d.shape == (len(a), len(b))
+    assert_eq(z, z_d)
+
+
 def test_tril_triu():
     A = np.random.randn(20, 20)
     for chk in [5, 4]:

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -198,13 +198,13 @@ def test_indicies():
     assert_eq(darr, nparr)
 
 
-@pytest.mark.parametrize("shapes", [
-    [()],
-    [(0,)],
-    [(2,), (3,)],
-    [(2,), (3,), (4,)],
-    [(2,), (3,), (4,), (5,)],
-    [(2, 3), (4,)],
+@pytest.mark.parametrize("shapes,chunks", [
+    ([()], [()]),
+    ([(0,)], [(0,)]),
+    ([(2,), (3,)], [(1,), (2,)]),
+    ([(2,), (3,), (4,)], [(1,), (2,), (3,)]),
+    ([(2,), (3,), (4,), (5,)], [(1,), (2,), (3,), (4,)]),
+    ([(2, 3), (4,)], [(1, 2), (3,)]),
 ])
 @pytest.mark.parametrize("indexing", [
     "ij",
@@ -214,12 +214,21 @@ def test_indicies():
     False,
     True,
 ])
-def test_meshgrid(shapes, indexing, sparse):
+def test_meshgrid(shapes, chunks, indexing, sparse):
     xi_a = []
     xi_d = []
-    for each_shape in shapes:
+    xi_dc = []
+    for each_shape, each_chunk in zip(shapes, chunks):
         xi_a.append(np.random.random(each_shape))
-        xi_d.append(da.from_array(xi_a[-1], chunks=1))
+        xi_d_e = da.from_array(xi_a[-1], chunks=each_chunk)
+        xi_d.append(xi_d_e)
+        xi_d_ef = xi_d_e.flatten()
+        xi_dc.append(xi_d_ef.chunks[0])
+    do = list(range(len(xi_dc)))
+    if indexing == "xy" and len(xi_dc) > 1:
+        do[0], do[1] = do[1], do[0]
+        xi_dc[0], xi_dc[1] = xi_dc[1], xi_dc[0]
+    xi_dc = tuple(xi_dc)
 
     r_a = np.meshgrid(*xi_a, indexing=indexing, sparse=sparse)
     r_d = da.meshgrid(*xi_d, indexing=indexing, sparse=sparse)
@@ -227,8 +236,14 @@ def test_meshgrid(shapes, indexing, sparse):
     assert isinstance(r_d, list)
     assert len(r_a) == len(r_d)
 
-    for e_r_a, e_r_d in zip(r_a, r_d):
+    for e_r_a, e_r_d, i in zip(r_a, r_d, do):
         assert_eq(e_r_a, e_r_d)
+        if sparse:
+            print("3", e_r_d, e_r_d.chunks)
+            print("4", e_r_d.chunks[i], xi_dc[i])
+            assert e_r_d.chunks[i] == xi_dc[i]
+        else:
+            assert e_r_d.chunks == xi_dc
 
 
 def test_tril_triu():

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,7 +12,7 @@ Array
 - Support N-D arrays with ``matmul`` (:pr:`2909`) `John A Kirkham`_
 - Add ``vdot`` (:pr:`2910`) `John A Kirkham`_
 - Explicit ``chunks`` argument for ``broadcast_to`` (:pr:`2943`) `Stephan Hoyer`_
-- Add ``meshgrid`` (:pr:`2938`) `John A Kirkham`_ and (:pr:``) `Markus Gonser`_
+- Add ``meshgrid`` (:pr:`2938`) `John A Kirkham`_ and (:pr:`3001`) `Markus Gonser`_
 - Preserve singleton chunks in ``fftshift``/``ifftshift`` (:pr:`2733`) `John A Kirkham`_
 - Fix handling of negative indexes in ``vindex`` and raise errors for out of
 bounds indexes (:pr:`2967`) `Stephan Hoyer`_

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,7 +12,7 @@ Array
 - Support N-D arrays with ``matmul`` (:pr:`2909`) `John A Kirkham`_
 - Add ``vdot`` (:pr:`2910`) `John A Kirkham`_
 - Explicit ``chunks`` argument for ``broadcast_to`` (:pr:`2943`) `Stephan Hoyer`_
-- Add ``meshgrid`` (:pr:`2938`) `John A Kirkham`_
+- Add ``meshgrid`` (:pr:`2938`) `John A Kirkham`_ and (:pr:``) `Markus Gonser`_
 - Preserve singleton chunks in ``fftshift``/``ifftshift`` (:pr:`2733`) `John A Kirkham`_
 - Fix handling of negative indexes in ``vindex`` and raise errors for out of
 bounds indexes (:pr:`2967`) `Stephan Hoyer`_
@@ -878,3 +878,4 @@ Other
 .. _`Ian Hopkinson`: https://https://github.com/IanHopkinson
 .. _`Stephan Hoyer`: https://github.com/shoyer
 .. _`Albert DeFusco`: https://github.com/AlbertDeFusco
+.. _`Markus Gonser`: https://github.com/magonser


### PR DESCRIPTION
PR for Issue #2981. Changes `dask.array.meshgrid` to use `broadcast_to` internally. 