### PR TITLE
Cleanup insert_to_ooc

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2569,6 +2569,30 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
 
 
 def insert_to_ooc(arr, out, lock=True, region=None):
+    """
+    Creates a Dask graph for storing chunks from ``arr`` in ``out``.
+
+    Parameters
+    ----------
+    arr: da.Array
+        A dask array
+    out: array-like
+        Where to store results too.
+    lock: Lock-like or bool, optional
+        Whether to lock or with what (default is ``True``,
+        which means a ``threading.Lock`` instance).
+    region: slice-like, optional
+        Where in ``out`` to store ``arr``'s results
+        (default is ``None``, meaning all of ``out``).
+
+    Examples
+    --------
+
+    >>> d = da.ones((5, 6), chunks=(2, 3))
+    >>> a = np.empty(d.shape)
+    >>> insert_to_ooc(d, a)
+    """
+
     if lock is True:
         lock = Lock()
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2569,6 +2569,30 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
 
 
 def store_chunk(x, out, index, lock, region):
+    """
+    A function inserted in a Dask graph for storing a chunk.
+
+    Parameters
+    ----------
+    x: array-like
+        An array (potentially a NumPy one)
+    out: array-like
+        Where to store results too.
+    index: slice-like
+        Where to store result from ``x`` in ``out``.
+    lock: Lock-like or False
+        Lock to use before writing to ``out``.
+    region: slice-like or None
+        Where relative to ``out`` to store ``x``.
+
+    Examples
+    --------
+
+    >>> a = np.ones((5, 6))
+    >>> b = np.empty(a.shape)
+    >>> store_chunk(a, b, (slice(None), slice(None)), False, None)
+    """
+
     subindex = index
     if region is not None:
         subindex = fuse_slice(region, index)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2627,10 +2627,10 @@ def insert_to_ooc(arr, out, lock=True, region=None):
 
     Examples
     --------
-
+    >>> import dask.array as da
     >>> d = da.ones((5, 6), chunks=(2, 3))
     >>> a = np.empty(d.shape)
-    >>> insert_to_ooc(d, a)
+    >>> insert_to_ooc(d, a)  # doctest: +SKIP
     """
 
     if lock is True:


### PR DESCRIPTION
Breaks out the `store` closure from `insert_to_ooc` as `insert_to_ooc_store`. Adds docstrings with basic examples to both `insert_to_ooc` and `insert_to_ooc_store`.