### PR TITLE
Adds condition to dask.array.percentile to handle scalar percentile

### DIFF
--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from functools import wraps
 from collections import Iterator
+from numbers import Number
 
 import numpy as np
 from toolz import merge, merge_sorted
@@ -38,7 +39,7 @@ def percentile(a, q, interpolation='linear'):
     if not a.ndim == 1:
         raise NotImplementedError(
             "Percentiles only implemented for 1-d arrays")
-    if isinstance(q, (int, float)):
+    if isinstance(q, Number):
         q = [q]
     q = np.array(q)
     token = tokenize(a, list(q), interpolation)

--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -38,6 +38,8 @@ def percentile(a, q, interpolation='linear'):
     if not a.ndim == 1:
         raise NotImplementedError(
             "Percentiles only implemented for 1-d arrays")
+    if isinstance(q, (int, float)):
+        q = [q]
     q = np.array(q)
     token = tokenize(a, list(q), interpolation)
     name = 'percentile_chunk-' + token

--- a/dask/array/tests/test_percentiles.py
+++ b/dask/array/tests/test_percentiles.py
@@ -55,6 +55,6 @@ def test_percentiles_with_empty_arrays():
 
 def test_percentiles_with_scaler_percentile():
     # Regression test to ensure da.percentile works with scalar percentiles
-    # See #3020 
+    # See #3020
     d = da.ones((16,), chunks=(4,))
     assert_eq(da.percentile(d, 50), np.array([1], dtype=d.dtype))

--- a/dask/array/tests/test_percentiles.py
+++ b/dask/array/tests/test_percentiles.py
@@ -51,3 +51,10 @@ def test_percentile_with_categoricals():
 def test_percentiles_with_empty_arrays():
     x = da.ones(10, chunks=((5, 0, 5),))
     assert_eq(da.percentile(x, [10, 50, 90]), np.array([1, 1, 1], dtype=x.dtype))
+
+
+def test_percentiles_with_scaler_percentile():
+    # Regression test to ensure da.percentile works with scalar percentiles
+    # See #3020 
+    d = da.ones((16,), chunks=(4,))
+    assert_eq(da.percentile(d, 50), np.array([1], dtype=d.dtype))

--- a/dask/array/tests/test_percentiles.py
+++ b/dask/array/tests/test_percentiles.py
@@ -53,8 +53,9 @@ def test_percentiles_with_empty_arrays():
     assert_eq(da.percentile(x, [10, 50, 90]), np.array([1, 1, 1], dtype=x.dtype))
 
 
-def test_percentiles_with_scaler_percentile():
+@pytest.mark.parametrize('q', [5, 5.0, np.int64(5), np.float64(5)])
+def test_percentiles_with_scaler_percentile(q):
     # Regression test to ensure da.percentile works with scalar percentiles
     # See #3020
     d = da.ones((16,), chunks=(4,))
-    assert_eq(da.percentile(d, 50), np.array([1], dtype=d.dtype))
+    assert_eq(da.percentile(d, q), np.array([1], dtype=d.dtype))

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 Array
 +++++
 
+- Fix handling of scalar percentile values in ``percentile`` (:pr:`3021`) `James Bourbeau`_
 - Prevent ``bool()`` coercion from calling compute (:pr:`2958`) `Albert DeFusco`_
 - Add ``matmul`` (:pr:`2904`) `John A Kirkham`_
 - Support N-D arrays with ``matmul`` (:pr:`2909`) `John A Kirkham`_


### PR DESCRIPTION
Fixes #3020. Currently `dask.array.percentile` throws an error when scalar percentiles are used. 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
