### PR TITLE
Read csv names

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -313,7 +313,8 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
     # contains a header row, we need at least 2 nonempty rows + the number of
     # rows to skip.
     skiprows = kwargs.get('skiprows', 0)
-    header = kwargs.get('header', 'infer')
+    names = kwargs.get('names', None)
+    header = kwargs.get('header', 'infer' if names is None else None)
     need = 1 if header is None else 2
     parts = b_sample.split(b_lineterminator, skiprows + need)
     # If the last partition is empty, don't count it

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -925,6 +925,7 @@ def test_error_if_sample_is_too_small():
         assert_eq(dd.read_csv(fn, sample=sample, header=None, skiprows=3),
                   pd.read_csv(fn, header=None, skiprows=3))
 
+
 def test_read_csv_names_not_none():
     text = ('Alice,100\n'
             'Bob,-200\n'
@@ -938,6 +939,7 @@ def test_read_csv_names_not_none():
         df = pd.read_csv(fn, names=names)
         ddf.index = range(len(ddf.index))
         assert_eq(df, ddf)
+
 
 ############
 #  to_csv  #

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -925,6 +925,19 @@ def test_error_if_sample_is_too_small():
         assert_eq(dd.read_csv(fn, sample=sample, header=None, skiprows=3),
                   pd.read_csv(fn, header=None, skiprows=3))
 
+def test_read_csv_names_not_none():
+    text = ('Alice,100\n'
+            'Bob,-200\n'
+            'Charlie,300\n'
+            'Dennis,400\n'
+            'Edith,-500\n'
+            'Frank,600\n')
+    names = ['name', 'amount']
+    with filetext(text) as fn:
+        ddf = dd.read_csv(fn, names=names, blocksize=16).compute()
+        df = pd.read_csv(fn, names=names)
+        ddf.index = range(len(ddf.index))
+        assert_eq(df, ddf)
 
 ############
 #  to_csv  #

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -935,10 +935,9 @@ def test_read_csv_names_not_none():
             'Frank,600\n')
     names = ['name', 'amount']
     with filetext(text) as fn:
-        ddf = dd.read_csv(fn, names=names, blocksize=16).compute()
+        ddf = dd.read_csv(fn, names=names, blocksize=16)
         df = pd.read_csv(fn, names=names)
-        ddf.index = range(len(ddf.index))
-        assert_eq(df, ddf)
+        assert_eq(df, ddf, check_index=False)
 
 
 ############

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,7 @@ bounds indexes (:pr:`2967`) `Stephan Hoyer`_
 DataFrame
 +++++++++
 
+- Fixed ``dd.read_csv`` when ``names`` is given but ``header`` is not set to ``None`` (:issue:`2976`) `Martijn Arts`_
 - Fixed ``dd.read_csv`` so that passing instances of ``CategoricalDtype`` in ``dtype`` will result in known categoricals (:pr:`2997`) `Tom Augspurger`_
 - Prevent ``bool()`` coercion from calling compute (:pr:`2958`) `Albert DeFusco`_
 - ``DataFrame.read_sql()`` (:pr:`2928`) to an empty database tables returns an empty dask dataframe `Apostolos Vlachopoulos`_
@@ -883,3 +884,4 @@ Other
 .. _`Stephan Hoyer`: https://github.com/shoyer
 .. _`Albert DeFusco`: https://github.com/AlbertDeFusco
 .. _`Markus Gonser`: https://github.com/magonser
+.. _`Martijn Arts`: https://github.com/mfaafm


### PR DESCRIPTION
This fixes the issue #2976, where dd.read_csv reads the first line of the file in every partition when `names` is given but `header` is not set to `None`.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
