### PR TITLE
derived_from gets full signature from __wrapped__

### DIFF
--- a/dask/array/tests/test_chunk.py
+++ b/dask/array/tests/test_chunk.py
@@ -16,7 +16,6 @@ def test_keepdims_wrapper_no_axis():
     summer_wrapped = keepdims_wrapper(summer)
 
     assert summer_wrapped != summer
-    assert summer_wrapped == keepdims_wrapper(summer_wrapped)
 
     a = np.arange(24).reshape(1, 2, 3, 4)
 
@@ -44,7 +43,6 @@ def test_keepdims_wrapper_one_axis():
     summer_wrapped = keepdims_wrapper(summer)
 
     assert summer_wrapped != summer
-    assert summer_wrapped == keepdims_wrapper(summer_wrapped)
 
     a = np.arange(24).reshape(1, 2, 3, 4)
 
@@ -72,7 +70,6 @@ def test_keepdims_wrapper_two_axes():
     summer_wrapped = keepdims_wrapper(summer)
 
     assert summer_wrapped != summer
-    assert summer_wrapped == keepdims_wrapper(summer_wrapped)
 
     a = np.arange(24).reshape(1, 2, 3, 4)
 

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -238,6 +238,8 @@ def getargspec(func):
     """Version of inspect.getargspec that works for functools.partial objects"""
     if isinstance(func, functools.partial):
         return _getargspec(func.func)
+    elif hasattr(func, '__wrapped__'):
+        return getargspec(func.__wrapped__)
     else:
         if isinstance(func, type):
             return _getargspec(func.__init__)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -16,7 +16,7 @@ import multiprocessing as mp
 import uuid
 from weakref import WeakValueDictionary
 
-from .compatibility import getargspec, PY3, unicode, bind_method
+from .compatibility import get_named_args, getargspec, PY3, unicode, bind_method
 from .core import get_deps
 from .context import _globals
 from .optimize import key_split    # noqa: F401
@@ -485,10 +485,10 @@ def derived_from(original_klass, version=None, ua_args=[]):
                 doc = ''
 
             try:
-                method_args = getargspec(method).args
-                original_args = getargspec(original_method).args
+                method_args = get_named_args(method)
+                original_args = get_named_args(original_method)
                 not_supported = [m for m in original_args if m not in method_args]
-            except TypeError:
+            except ValueError:
                 not_supported = []
 
             if len(ua_args) > 0:


### PR DESCRIPTION
Previously this would fail for wrapped functions (e.g. `pd.DataFrame.rename`, causing the not implemented parameters section to miss a few parameters. We now traverse `__wrapped__` attributes fully before inspecting the arguments.

We had no tests for this function before, and I'm not sure if adding a test is worth it.

Fixes #2949.