### PR TITLE
Series rename

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1742,6 +1742,13 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
                                           task=len(self.dask))
 
     @derived_from(pd.Series)
+    def rename(self, index=None, inplace=False):
+        if not inplace:
+            self = self.copy()
+        self.name = index
+        return self
+
+    @derived_from(pd.Series)
     def round(self, decimals=0):
         return elemwise(M.round, self, decimals)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -249,24 +249,29 @@ def test_rename_series_method():
     s = pd.Series(['a', 'b', 'c', 'd', 'e', 'f', 'g'], name='x')
     ds = dd.from_pandas(s, 2)
 
-    res = ds.rename(lambda x: x ** 2)
-    assert_eq(res, s.rename(lambda x: x ** 2))
-    assert res.known_divisions
+    for is_sorted in [True, False]:
+        res = ds.rename(lambda x: x ** 2, sorted_index=is_sorted)
+        assert_eq(res, s.rename(lambda x: x ** 2))
+        assert res.known_divisions == is_sorted
 
-    res = ds.rename(s)
-    assert_eq(res, s.rename(s))
-    assert res.known_divisions
+        res = ds.rename(s, sorted_index=is_sorted)
+        assert_eq(res, s.rename(s))
+        assert res.known_divisions == is_sorted
+
+    with pytest.raises(ValueError):
+        ds.rename(lambda x: -x, sorted_index=True)
+    assert_eq(ds.rename(lambda x: -x), s.rename(lambda x: -x))
 
     res = ds.rename(ds)
     assert_eq(res, s.rename(s))
     assert not res.known_divisions
 
     ds2 = ds.clear_divisions()
-    res = ds2.rename(lambda x: x**2)
+    res = ds2.rename(lambda x: x**2, sorted_index=True)
     assert_eq(res, s.rename(lambda x: x**2))
     assert not res.known_divisions
 
-    res = ds.rename(lambda x: x**2, inplace=True)
+    res = ds.rename(lambda x: x**2, inplace=True, sorted_index=True)
     assert res is ds
     s.rename(lambda x: x**2, inplace=True)
     assert_eq(ds, s)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -231,6 +231,20 @@ def test_rename_series():
     assert_eq(dind, ind)
 
 
+def test_rename_series_method():
+    s = pd.Series([1, 2, 3, 4, 5, 6, 7], name='x')
+    ds = dd.from_pandas(s, 2)
+
+    assert_eq(ds.rename('y'), s.rename('y'))
+    assert ds.name == 'x'  # no mutation
+    assert_eq(ds.rename(), s.rename())
+
+    ds.rename('z', inplace=True)
+    s.rename('z', inplace=True)
+    assert ds.name == 'z'
+    assert_eq(ds, s)
+
+
 def test_describe():
     # prepare test case which approx quantiles will be the same as actuals
     s = pd.Series(list(range(20)) * 4)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -232,6 +232,7 @@ def test_rename_series():
 
 
 def test_rename_series_method():
+    # Series name
     s = pd.Series([1, 2, 3, 4, 5, 6, 7], name='x')
     ds = dd.from_pandas(s, 2)
 
@@ -242,6 +243,32 @@ def test_rename_series_method():
     ds.rename('z', inplace=True)
     s.rename('z', inplace=True)
     assert ds.name == 'z'
+    assert_eq(ds, s)
+
+    # Series index
+    s = pd.Series(['a', 'b', 'c', 'd', 'e', 'f', 'g'], name='x')
+    ds = dd.from_pandas(s, 2)
+
+    res = ds.rename(lambda x: x ** 2)
+    assert_eq(res, s.rename(lambda x: x ** 2))
+    assert res.known_divisions
+
+    res = ds.rename(s)
+    assert_eq(res, s.rename(s))
+    assert res.known_divisions
+
+    res = ds.rename(ds)
+    assert_eq(res, s.rename(s))
+    assert not res.known_divisions
+
+    ds2 = ds.clear_divisions()
+    res = ds2.rename(lambda x: x**2)
+    assert_eq(res, s.rename(lambda x: x**2))
+    assert not res.known_divisions
+
+    res = ds.rename(lambda x: x**2, inplace=True)
+    assert res is ds
+    s.rename(lambda x: x**2, inplace=True)
     assert_eq(ds, s)
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -32,6 +32,7 @@ DataFrame
 - Compatability for reading Parquet files written by PyArrow 0.8.0 (:pr:`2973`) `Tom Augspurger`_
 - Correctly handle the column name (`df.columns.name`) when reading in ``dd.read_parquet`` (:pr:2973`) `Tom Augspurger`_
 - Fixed ``dd.concat`` losing the index dtype when the data contained a categorical (:issue:`2932`) `Tom Augspurger`_
+- Add ``dd.Series.rename`` (:pr:`3027`) `Jim Crist`_
 - ``DataFrame.merge()`` (:pr:`2960`) now supports merging on a combination of columns and the index `Jon Mease`_
 
 

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -169,6 +169,7 @@ Series
    Series.rdiv
    Series.reduction
    Series.repartition
+   Series.rename
    Series.resample
    Series.reset_index
    Series.rolling


### PR DESCRIPTION
Fixes #2927.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
