### PR TITLE
Add frompyfunc

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -24,7 +24,7 @@ from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
         fmax, fmin, isreal, iscomplex, isfinite, isinf, isnan, signbit,
         copysign, nextafter, spacing, ldexp, fmod, floor, ceil, trunc, degrees,
         radians, rint, fix, angle, real, imag, clip, fabs, sign, absolute,
-        i0, sinc, nan_to_num, frexp, modf, divide)
+        i0, sinc, nan_to_num, frexp, modf, divide, frompyfunc)
 try:
     from .ufunc import float_power
 except ImportError:

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -1,12 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
+import pickle
 from functools import partial
+from operator import add
 
 import pytest
 np = pytest.importorskip('numpy')
 
 import dask.array as da
+from dask.array.ufunc import da_frompyfunc
 from dask.array.utils import assert_eq
+from dask.base import tokenize
 
 
 def test_ufunc_meta():
@@ -261,6 +265,56 @@ def test_angle():
     assert_eq(da.angle(dacomp, deg=True), np.angle(comp, deg=True))
     assert isinstance(da.angle(comp), np.ndarray)
     assert_eq(da.angle(comp), np.angle(comp))
+
+
+def test_frompyfunc():
+    myadd = da.frompyfunc(add, 2, 1)
+    np_myadd = np.frompyfunc(add, 2, 1)
+
+    x = np.random.normal(0, 10, size=(10, 10))
+    dx = da.from_array(x, chunks=(3, 4))
+    y = np.random.normal(0, 10, size=10)
+    dy = da.from_array(y, chunks=2)
+
+    assert_eq(myadd(dx, dy), np_myadd(x, y))
+    assert_eq(myadd.outer(dx, dy), np_myadd.outer(x, y))
+
+    with pytest.raises(NotImplementedError):
+        da.frompyfunc(lambda x, y: (x + y, x - y), 2, 2)
+
+
+def test_frompyfunc_wrapper():
+    f = da_frompyfunc(add, 2, 1)
+    np_f = np.frompyfunc(add, 2, 1)
+    x = np.array([1, 2, 3])
+
+    # Callable
+    np.testing.assert_equal(f(x, 1), np_f(x, 1))
+
+    # picklable
+    f2 = pickle.loads(pickle.dumps(f))
+    np.testing.assert_equal(f2(x, 1), np_f(x, 1))
+
+    # Attributes
+    assert f.ntypes == np_f.ntypes
+    with pytest.raises(AttributeError):
+        f.not_an_attribute
+
+    # Tab completion
+    assert 'ntypes' in dir(f)
+
+    # Methods
+    np.testing.assert_equal(f.outer(x, x), np_f.outer(x, x))
+
+    # funcname
+    assert f.__name__ == 'frompyfunc-add'
+
+    # repr
+    assert repr(f) == "da.frompyfunc<add, 2, 1>"
+
+    # tokenize
+    assert (tokenize(da_frompyfunc(add, 2, 1)) ==
+            tokenize(da_frompyfunc(add, 2, 1)))
 
 
 @pytest.mark.skipif(np.__version__ < '1.13.0', reason='array_ufunc not present')

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -72,8 +72,9 @@ class da_frompyfunc(object):
 
     def __dir__(self):
         o = set(dir(type(self)))
+        o.update(self.__dict__)
         o.update(dir(self._ufunc))
-        return o
+        return list(o)
 
 
 @wraps(np.frompyfunc)

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -73,6 +73,7 @@ Top level user functions:
    fmod
    frexp
    fromfunction
+   frompyfunc
    full
    full_like
    histogram
@@ -403,6 +404,7 @@ Other functions
 .. autofunction:: fmod
 .. autofunction:: frexp
 .. autofunction:: fromfunction
+.. autofunction:: frompyfunc
 .. autofunction:: full
 .. autofunction:: full_like
 .. autofunction:: histogram

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,7 @@ bounds indexes (:pr:`2967`) `Stephan Hoyer`_
 - Add ``float_power`` ufunc (:pr:`2962`) (:pr:`2969`) `John A Kirkham`_
 - Compatability for changes to structured arrays in the upcoming NumPy 1.14 release (:pr:`2964`) `Tom Augspurger`_
 - Add ``block`` (:pr:`2650`) `John A Kirkham`_
+- Add ``frompyfunc`` (:pr:`3030`) `Jim Crist`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Add support for frompyfunc to dask.array.

Fixes #2956.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
