### PR TITLE
Metadata inference doesn't special case series

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -519,6 +519,22 @@ def test_map_partitions_keeps_kwargs_in_dict():
     assert a.x.map_partitions(f, x=5)._name != a.x.map_partitions(f, x=6)._name
 
 
+def test_metadata_inference_single_partition_aligned_args():
+    # https://github.com/dask/dask/issues/3034
+    # Previously broadcastable series functionality broke this
+
+    df = pd.DataFrame({'x': [1, 2, 3, 4, 5]})
+    ddf = dd.from_pandas(df, npartitions=1)
+
+    def check(df, df_x):
+        assert len(df) == len(df_x)
+        assert len(df) > 0
+        return df
+
+    res = dd.map_partitions(check, ddf, ddf.x)
+    assert_eq(res, ddf)
+
+
 def test_drop_duplicates():
     res = d.drop_duplicates()
     res2 = d.drop_duplicates(split_every=2)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -34,6 +34,7 @@ DataFrame
 - Fixed ``dd.concat`` losing the index dtype when the data contained a categorical (:issue:`2932`) `Tom Augspurger`_
 - ``DataFrame.merge()`` (:pr:`2960`) now supports merging on a combination of columns and the index `Jon Mease`_
 - Removed the deprecated ``dd.rolling*`` methods, in preperation for their removal in the next pandas release (:pr:`2995`) `Tom Augspurger`_
+- Fix metadata inference bug in which single-partition series were mistakenly special cased (:pr:`3035`) `Jim Crist`
 
 
 Core


### PR DESCRIPTION
Previously 1 partition series were special cased during metadata
inference to support broadcastable series. This was a bad check, and
leads to misaligned arguments during any metadata inference check with a
single partition series.

This PR removes this behavior, and instead special cases inference in
`elemwise` following the `is_broadcastable` logic already implemented
there.

Fixes #3034.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
