### PR TITLE
WIP: Make bzip2 compressed files seekable

### DIFF
--- a/dask/bytes/compression.py
+++ b/dask/bytes/compression.py
@@ -23,6 +23,7 @@ decompress = {'gzip': gzip_decompress,
               'bz2': bz2.decompress,
               None: identity}
 files = {'gzip': lambda f, **kwargs: GzipFile(fileobj=f, **kwargs),
+         'bz2': lambda f, **kwargs: bz2.BZ2File(fileobj=f, **kwargs),
          None: noop_file}
 seekable_files = {None: noop_file,
                   'bz2': bz2.BZ2File}

--- a/dask/bytes/compression.py
+++ b/dask/bytes/compression.py
@@ -24,7 +24,8 @@ decompress = {'gzip': gzip_decompress,
               None: identity}
 files = {'gzip': lambda f, **kwargs: GzipFile(fileobj=f, **kwargs),
          None: noop_file}
-seekable_files = {None: noop_file}
+seekable_files = {None: noop_file,
+                  'bz2': bz2.BZ2File}
 
 
 with ignoring(ImportError):

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -41,7 +41,7 @@ Core
 ++++
 
 - Improve 32-bit compatibility (:pr:`2937`) `Matthew Rocklin`_
-
+- Support seekable reads of bzip2 compressed files (:pr:`3040`) `Uwe Korn`_
 
 0.16.0 / 2017-11-17
 -------------------


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
