### PR TITLE
Fix naming bug of cumulative aggregations

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1360,28 +1360,28 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
 
         return new_dd_object(dsk, name, num._meta, divisions=[None, None])
 
-    def _cum_agg(self, token, chunk, aggregate, axis, skipna=True,
+    def _cum_agg(self, op_name, chunk, aggregate, axis, skipna=True,
                  chunk_kwargs=None):
         """ Wrapper for cumulative operation """
 
         axis = self._validate_axis(axis)
 
         if axis == 1:
-            name = '{0}{1}(axis=1)'.format(self._token_prefix, token)
+            name = '{0}{1}(axis=1)'.format(self._token_prefix, op_name)
             return self.map_partitions(chunk, token=name, **chunk_kwargs)
         else:
             # cumulate each partitions
-            name1 = '{0}{1}-map'.format(self._token_prefix, token)
+            name1 = '{0}{1}-map'.format(self._token_prefix, op_name)
             cumpart = map_partitions(chunk, self, token=name1, meta=self,
                                      **chunk_kwargs)
 
-            name2 = '{0}{1}-take-last'.format(self._token_prefix, token)
+            name2 = '{0}{1}-take-last'.format(self._token_prefix, op_name)
             cumlast = map_partitions(_take_last, cumpart, skipna,
                                      meta=pd.Series([]), token=name2)
 
             suffix = tokenize(self)
-            name = '{0}{1}-{2}'.format(self._token_prefix, token, suffix)
-            cname = '{0}{1}-cum-last-{2}'.format(self._token_prefix, token,
+            name = '{0}{1}-{2}'.format(self._token_prefix, op_name, suffix)
+            cname = '{0}{1}-cum-last-{2}'.format(self._token_prefix, op_name,
                                                  suffix)
 
             # aggregate cumulated partisions and its previous last element

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1379,8 +1379,10 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
             cumlast = map_partitions(_take_last, cumpart, skipna,
                                      meta=pd.Series([]), token=name2)
 
-            name = '{0}{1}'.format(self._token_prefix, token)
-            cname = '{0}{1}-cum-last'.format(self._token_prefix, token)
+            suffix = tokenize(self)
+            name = '{0}{1}-{2}'.format(self._token_prefix, token, suffix)
+            cname = '{0}{1}-cum-last-{2}'.format(self._token_prefix, token,
+                                                 suffix)
 
             # aggregate cumulated partisions and its previous last element
             dask = {}

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2823,3 +2823,18 @@ def test_bool():
     for cond in conditions:
         with pytest.raises(ValueError):
             bool(cond)
+
+
+def test_cumulative_multiple_columns():
+    # GH 3037
+    df = pd.DataFrame(np.random.randn(100, 5), columns=list('abcde'))
+    ddf = dd.from_pandas(df, 5)
+
+    for d in [ddf, df]:
+        for c in df.columns:
+            d[c + 'cs'] = d[c].cumsum()
+            d[c + 'cmin'] = d[c].cummin()
+            d[c + 'cmax'] = d[c].cummax()
+            d[c + 'cp'] = d[c].cumprod()
+
+    assert_eq(ddf, df)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -26,6 +26,7 @@ bounds indexes (:pr:`2967`) `Stephan Hoyer`_
 DataFrame
 +++++++++
 
+- Fixed naming bug in cumulative aggregations (:issue:`3037`) `Martijn Arts`_
 - Fixed ``dd.read_csv`` when ``names`` is given but ``header`` is not set to ``None`` (:issue:`2976`) `Martijn Arts`_
 - Fixed ``dd.read_csv`` so that passing instances of ``CategoricalDtype`` in ``dtype`` will result in known categoricals (:pr:`2997`) `Tom Augspurger`_
 - Prevent ``bool()`` coercion from calling compute (:pr:`2958`) `Albert DeFusco`_


### PR DESCRIPTION
Fixes #3037.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
