### PR TITLE
Add color= option to visualize that supports coloring by task order

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -56,6 +56,9 @@ class DaskMethodsMixin(object):
         optimize_graph : bool, optional
             If True, the graph is optimized before rendering.  Otherwise,
             the graph is displayed as is. Default is False.
+        color: {None, 'order'}, optional
+            Options to color nodes.  Provide ``cmap=`` keyword for additional
+            colormap
         **kwargs
            Additional keyword arguments to forward to ``to_graphviz``.
 
@@ -361,9 +364,9 @@ def visualize(*args, **kwargs):
     optimize_graph : bool, optional
         If True, the graph is optimized before rendering.  Otherwise,
         the graph is displayed as is. Default is False.
-    color: False
-        Options to color nodes.  Current valid options include ['order']
-        Provide ``cmap=`` keyword for additional colormap
+    color: {None, 'order'}, optional
+        Options to color nodes.  Provide ``cmap=`` keyword for additional
+        colormap
     **kwargs
        Additional keyword arguments to forward to ``to_graphviz``.
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -731,6 +731,15 @@ def register_scipy():
 
 
 def _colorize(t):
+    """ Convert (r, g, b) triple to "#RRGGBB" string
+
+    For use with ``visualize(color=...)``
+
+    Examples
+    --------
+    >>> _colorize((255, 255, 255))
+    '#FFFFFF'
+    """
     t = t[:3]
     i = sum(v * 256 ** (len(t) - i - 1) for i, v in enumerate(t))
-    return "#" + hex(int(i))[2:]
+    return "#" + hex(int(i))[2:].upper()

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -547,6 +547,19 @@ def test_visualize():
         assert os.path.exists(os.path.join(d, 'mydask.png'))
 
 
+@pytest.mark.skipif('not da')
+@pytest.mark.skipif(sys.flags.optimize,
+                    reason="graphviz exception with Python -OO flag")
+def test_visualize_order():
+    pytest.importorskip('matplotlib')
+    x = da.arange(5, chunks=2)
+    with tmpfile(extension='dot') as fn:
+        x.visualize(color='order', filename=fn)
+        with open(fn) as f:
+            text = f.read()
+        assert 'color="#' in text
+
+
 def test_use_cloudpickle_to_tokenize_functions_in__main__():
     import sys
     from textwrap import dedent

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,6 +22,7 @@ Core
 
 -  Change default task ordering to prefer nodes with few dependents and then
    many downstream dependencies (:pr:`3056`) `Matthew Rocklin`_
+-  Add color= option to visualize to color by task order (:pr:`3057`) `Matthew Rocklin`_
 
 
 0.16.1 / 2018-01-09


### PR DESCRIPTION
This is helpful when exploring task priority issues.

Currently this feature feels a bit tacked on.  Suggestions on how to
make this less intrusive would be welcome.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
