### PR TITLE
Cleanup for GH2950

### DIFF
--- a/dask/dataframe/tests/test_merge_column_and_index.py
+++ b/dask/dataframe/tests/test_merge_column_and_index.py
@@ -90,7 +90,7 @@ def on(request):
 
 # Tests
 # =====
-@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+@pytest.mark.skipif(PANDAS_VERSION < '0.23.0',
                     reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 def test_merge_known_to_known(df_left, df_right, ddf_left, ddf_right, on, how):
     # Compute expected
@@ -105,7 +105,7 @@ def test_merge_known_to_known(df_left, df_right, ddf_left, ddf_right, on, how):
     assert len(result.__dask_graph__()) < 80
 
 
-@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+@pytest.mark.skipif(PANDAS_VERSION < '0.23.0',
                     reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 @pytest.mark.parametrize('how', ['inner', 'left'])
 def test_merge_known_to_single(df_left, df_right, ddf_left, ddf_right_single, on, how):
@@ -121,7 +121,7 @@ def test_merge_known_to_single(df_left, df_right, ddf_left, ddf_right_single, on
     assert len(result.__dask_graph__()) < 30
 
 
-@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+@pytest.mark.skipif(PANDAS_VERSION < '0.23.0',
                     reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 @pytest.mark.parametrize('how', ['inner', 'right'])
 def test_merge_single_to_known(df_left, df_right, ddf_left_single, ddf_right, on, how):
@@ -137,7 +137,7 @@ def test_merge_single_to_known(df_left, df_right, ddf_left_single, ddf_right, on
     assert len(result.__dask_graph__()) < 30
 
 
-@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+@pytest.mark.skipif(PANDAS_VERSION < '0.23.0',
                     reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 def test_merge_known_to_unknown(df_left, df_right, ddf_left, ddf_right_unknown, on, how):
     # Compute expected
@@ -152,7 +152,7 @@ def test_merge_known_to_unknown(df_left, df_right, ddf_left, ddf_right_unknown, 
     assert len(result.__dask_graph__()) >= 400
 
 
-@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+@pytest.mark.skipif(PANDAS_VERSION < '0.23.0',
                     reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 def test_merge_unknown_to_known(df_left, df_right, ddf_left_unknown, ddf_right, on, how):
     # Compute expected
@@ -167,7 +167,7 @@ def test_merge_unknown_to_known(df_left, df_right, ddf_left_unknown, ddf_right, 
     assert len(result.__dask_graph__()) > 400
 
 
-@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+@pytest.mark.skipif(PANDAS_VERSION < '0.23.0',
                     reason="Need pandas col+index merge support (pandas-dev/pandas#14355)")
 def test_merge_unknown_to_unknown(df_left, df_right, ddf_left_unknown, ddf_right_unknown, on, how):
     # Compute expected

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -35,7 +35,7 @@ DataFrame
 - Correctly handle the column name (`df.columns.name`) when reading in ``dd.read_parquet`` (:pr:2973`) `Tom Augspurger`_
 - Fixed ``dd.concat`` losing the index dtype when the data contained a categorical (:issue:`2932`) `Tom Augspurger`_
 - Add ``dd.Series.rename`` (:pr:`3027`) `Jim Crist`_
-- ``DataFrame.merge()`` (:pr:`2960`) now supports merging on a combination of columns and the index `Jon Mease`_
+- ``DataFrame.merge()`` now supports merging on a combination of columns and the index (:pr:`2960`) `Jon Mease`_
 - Removed the deprecated ``dd.rolling*`` methods, in preperation for their removal in the next pandas release (:pr:`2995`) `Tom Augspurger`_
 - Fix metadata inference bug in which single-partition series were mistakenly special cased (:pr:`3035`) `Jim Crist`_
 - Add support for ``Series.str.cat`` (:pr:`3028`) `Jim Crist`_
@@ -893,3 +893,4 @@ Other
 .. _`Albert DeFusco`: https://github.com/AlbertDeFusco
 .. _`Markus Gonser`: https://github.com/magonser
 .. _`Martijn Arts`: https://github.com/mfaafm
+.. _`Jon Mease`: https://github.com/jmmease


### PR DESCRIPTION
Fixed a couple of small issues I noticed in the changes for #2950 
- [x] The `pytest.mark.skipif` constraints need to change from pandas 0.22 to 0.23 since pandas 0.22 became 0.23 after this PR was merged. See pandas-dev/pandas#17484
- [x] Fixed the author reference to myself in the changelog
