### PR TITLE
Tokenize scipy sparse arrays and np.matrix

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -633,7 +633,6 @@ def register_pandas():
 def register_numpy():
     import numpy as np
 
-    @normalize_token.register(np.ndarray)
     def normalize_array(x):
         if not x.shape:
             return (str(x), x.dtype)
@@ -658,6 +657,11 @@ def register_numpy():
                 data = hash_buffer_hex(x.copy().ravel(order='K').view('i1'))
         return (data, x.dtype, x.shape, x.strides)
 
+    @normalize_token.register(np.matrix)
+    def normalize_matrix(x):
+        return type(x).__name__, normalize_array(x.view(type=np.ndarray))
+
+    normalize_token.register(np.ndarray, normalize_array)
     normalize_token.register(np.dtype, repr)
     normalize_token.register(np.generic, repr)
 
@@ -669,3 +673,26 @@ def register_numpy():
                 return 'np.' + name
         except AttributeError:
             return normalize_function(x)
+
+
+@normalize_token.register_lazy("scipy")
+def register_scipy():
+    import scipy.sparse as sp
+
+    def normalize_sparse_matrix(x, attrs):
+        return type(x).__name__, normalize_seq((normalize_token(getattr(x, key))
+                                                for key in attrs))
+
+    for cls, attrs in [(sp.dia_matrix, ('data', 'offsets', 'shape')),
+                       (sp.bsr_matrix, ('data', 'indices', 'indptr',
+                                        'blocksize', 'shape')),
+                       (sp.coo_matrix, ('data', 'row', 'col', 'shape')),
+                       (sp.csr_matrix, ('data', 'indices', 'indptr', 'shape')),
+                       (sp.csc_matrix, ('data', 'indices', 'indptr', 'shape')),
+                       (sp.lil_matrix, ('data', 'rows', 'shape'))]:
+        normalize_token.register(cls,
+                                 partial(normalize_sparse_matrix, attrs=attrs))
+
+    @normalize_token.register(sp.dok_matrix)
+    def normalize_dok_matrix(x):
+        return type(x).__name__, normalize_token(sorted(x.items()))

--- a/dask/base.py
+++ b/dask/base.py
@@ -633,6 +633,7 @@ def register_pandas():
 def register_numpy():
     import numpy as np
 
+    @normalize_token.register(np.ndarray)
     def normalize_array(x):
         if not x.shape:
             return (str(x), x.dtype)
@@ -661,7 +662,6 @@ def register_numpy():
     def normalize_matrix(x):
         return type(x).__name__, normalize_array(x.view(type=np.ndarray))
 
-    normalize_token.register(np.ndarray, normalize_array)
     normalize_token.register(np.dtype, repr)
     normalize_token.register(np.generic, repr)
 


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/3054

This PR adds tokenization for scipy sparse arrays. Because a sum of such array along one of the dimensions produces a `np.matrix`, this PR also adds tokenization for the latter class.

cc @jcrist 