### PR TITLE
Fixes a metadata issue with store's return_stored

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -937,9 +937,15 @@ def store(sources, targets, lock=True, regions=None, compute=True,
 
         load_dsks_mrg = sharedict.merge(store_dsks_mrg, *load_dsks)
 
-        result = tuple(
-            Array(load_dsks_mrg, n, src.chunks, src.dtype) for n in load_names
-        )
+        result = []
+        for i, sources_i in enumerate(sources):
+            result.append(Array(
+                load_dsks_mrg,
+                load_names[i],
+                sources_i.chunks,
+                sources_i.dtype
+            ))
+        result = tuple(result)
 
         return result
     else:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -937,15 +937,12 @@ def store(sources, targets, lock=True, regions=None, compute=True,
 
         load_dsks_mrg = sharedict.merge(store_dsks_mrg, *load_dsks)
 
-        result = []
-        for i, sources_i in enumerate(sources):
-            result.append(Array(
-                load_dsks_mrg,
-                load_names[i],
-                sources_i.chunks,
-                sources_i.dtype
-            ))
-        result = tuple(result)
+        result = tuple(
+            Array(load_dsks_mrg, ln, s.chunks, s.dtype)
+            for ln, s in zip(load_names, sources)
+        )
+
+        assert len(result) == len(sources)
 
         return result
     else:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1261,13 +1261,14 @@ def test_store():
 
 
 def test_store_regions():
-    d = da.ones((4, 4, 4), chunks=(2, 2, 2))
+    d = da.ones((4, 4, 4), dtype=int, chunks=(2, 2, 2))
     a, b = d + 1, d + 2
+    a = a[:, 1:, :].astype(float)
 
     region = (slice(None,None,2), slice(None), [1, 2, 4, 5])
 
     # Single region:
-    at = np.zeros(shape=(8, 4, 6))
+    at = np.zeros(shape=(8, 3, 6))
     bt = np.zeros(shape=(8, 4, 6))
     v = store([a, b], [at, bt], regions=region, compute=False)
     assert isinstance(v, Delayed)
@@ -1278,7 +1279,7 @@ def test_store_regions():
     assert not (at == 2).all() and not ( at == 0 ).all()
 
     # Single region (keep result):
-    at = np.zeros(shape=(8, 4, 6))
+    at = np.zeros(shape=(8, 3, 6))
     bt = np.zeros(shape=(8, 4, 6))
     v = store(
         [a, b], [at, bt], regions=region, compute=False, return_stored=True
@@ -1303,7 +1304,7 @@ def test_store_regions():
     assert (ar == 2).all()
 
     # Multiple regions:
-    at = np.zeros(shape=(8, 4, 6))
+    at = np.zeros(shape=(8, 3, 6))
     bt = np.zeros(shape=(8, 4, 6))
     v = store([a, b], [at, bt], regions=[region, region], compute=False)
     assert isinstance(v, Delayed)
@@ -1314,7 +1315,7 @@ def test_store_regions():
     assert not (at == 2).all() and not ( at == 0 ).all()
 
     # Multiple regions (keep result):
-    at = np.zeros(shape=(8, 4, 6))
+    at = np.zeros(shape=(8, 3, 6))
     bt = np.zeros(shape=(8, 4, 6))
     v = store(
         [a, b], [at, bt],

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 Array
 +++++
 
+- Fixes a metadata bug with ``store``'s ``return_stored`` option (:pr:`3064`) `John A Kirkham`_
 
 DataFrame
 +++++++++

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -42,6 +42,7 @@ bounds indexes (:pr:`2967`) `Stephan Hoyer`_
 - Compatability for changes to structured arrays in the upcoming NumPy 1.14 release (:pr:`2964`) `Tom Augspurger`_
 - Add ``block`` (:pr:`2650`) `John A Kirkham`_
 - Add ``frompyfunc`` (:pr:`3030`) `Jim Crist`_
+- Add the ``return_stored`` option to ``store`` for chaining stored results (:pr:`2980`) `John A Kirkham`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Tweaks one of the tests to work with two different arrays (both in shape and type) to demonstrate the bug that was occurring. Then provides a fix to `store` that makes this test pass.