### PR TITLE
Full traversal in dask.order

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -87,6 +87,10 @@ def order(dsk, dependencies=None):
     """
     if dependencies is None:
         dependencies = {k: get_dependencies(dsk, k) for k in dsk}
+
+    for k, deps in dependencies.items():
+        deps.discard(k)
+
     dependents = reverse_dict(dependencies)
 
     total_dependencies = ndependencies(dependencies, dependents)

--- a/dask/order.py
+++ b/dask/order.py
@@ -133,7 +133,6 @@ def ndependents(dependencies, dependents):
 
     Examples
     --------
-
     >>> dsk = {'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b')}
     >>> dependencies, dependents = get_deps(dsk)
 
@@ -161,7 +160,6 @@ def ndependencies(dependencies, dependents):
 
     Examples
     --------
-
     >>> dsk = {'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b')}
     >>> dependencies, dependents = get_deps(dsk)
     >>> sorted(ndependencies(dependencies, dependents).items())
@@ -178,73 +176,3 @@ def ndependencies(dependencies, dependents):
             if num_needed[parent] == 0:
                 current.add(parent)
     return result
-
-
-def dfs(dependencies, dependents, key=lambda x: x):
-    """ Depth First Search of dask graph
-
-    This traverses from root/output nodes down to leaf/input nodes in a depth
-    first manner.  At each node it traverses down its immediate children by the
-    order determined by maximizing the key function.
-
-    As inputs it takes dependencies and dependents as can be computed from
-    ``get_deps(dsk)``.
-
-    Examples
-    --------
-    >>> dsk = {'a': 1, 'b': 2, 'c': (inc, 'a'), 'd': (add, 'b', 'c')}
-    >>> dependencies, dependents = get_deps(dsk)
-
-    >>> sorted(dfs(dependencies, dependents).items())
-    [('a', 3), ('b', 1), ('c', 2), ('d', 0)]
-    """
-    result = dict()
-    i = 0
-
-    roots = [k for k, v in dependents.items() if not v]
-    stack = sorted(roots, key=key, reverse=True)
-    seen = set()
-
-    while stack:
-        item = stack.pop()
-        if item in seen:
-            continue
-        seen.add(item)
-
-        result[item] = i
-        deps = dependencies[item]
-        if deps:
-            deps = deps - seen
-            deps = sorted(deps, key=key, reverse=True)
-            stack.extend(deps)
-        i += 1
-
-    return result
-
-
-class StrComparable(object):
-    """ Wrap object so that it defaults to string comparison
-
-    When comparing two objects of different types Python fails
-
-    >>> 'a' < 1  # doctest: +SKIP
-    Traceback (most recent call last):
-        ...
-    TypeError: '<' not supported between instances of 'str' and 'int'
-
-    This class wraps the object so that, when this would occur it instead
-    compares the string representation
-
-    >>> StrComparable('a') < StrComparable(1)
-    False
-    """
-    __slots__ = ('obj',)
-
-    def __init__(self, obj):
-        self.obj = obj
-
-    def __lt__(self, other):
-        try:
-            return self.obj < other.obj
-        except Exception:
-            return str(self.obj) < str(other.obj)

--- a/dask/order.py
+++ b/dask/order.py
@@ -65,26 +65,63 @@ from .utils_test import add, inc  # noqa: F401
 def order(dsk, dependencies=None):
     """ Order nodes in dask graph
 
-    The ordering will be a topological sort but will also tend to produce
-    computations that have a small memory footprint.
+    This produces an ordering over our tasks that we use to break ties when
+    executing.  We do this ahead of time to reduce a bit of stress on the
+    scheduler and also to assist in static analysis.
+
+    This currently traverses the graph as a single-threaded scheduler would
+    traverse it.  It breaks ties in the following ways:
+
+    1.  Start from roots nodes that have the largest subgraphs
+    2.  When a node has dependencies that are not yet computed prefer
+        dependencies with large subtrees  (start hard things first)
+    2.  When we reach a node that can be computed we then traverse up and
+        prefer dependents that have small super-trees (few total dependents)
+        (finish existing work quickly)
 
     Examples
     --------
     >>> dsk = {'a': 1, 'b': 2, 'c': (inc, 'a'), 'd': (add, 'b', 'c')}
     >>> order(dsk)
-    {'a': 2, 'c': 1, 'b': 3, 'd': 0}
+    {'a': 0, 'c': 1, 'b': 2, 'd': 3}
     """
     if dependencies is None:
         dependencies = {k: get_dependencies(dsk, k) for k in dsk}
     dependents = reverse_dict(dependencies)
 
-    ndepts = {k: len(dependents[k]) for k in dependents}
-    ndepends = ndependencies(dependencies, dependents)
+    total_dependencies = ndependencies(dependencies, dependents)
+    total_dependents = ndependents(dependencies, dependents)
 
-    def key(x):
-        return StrComparable((ndepts[x], -ndepends.get(x, 0), x))
+    waiting = {k: set(v) for k, v in dependencies.items()}
 
-    return dfs(dependencies, dependents, key=key)
+    result = dict()
+    i = 0
+
+    stack = [k for k, v in dependents.items() if not v]
+    stack = sorted(stack, key=total_dependencies.get)
+
+    while stack:
+        item = stack.pop()
+
+        if item in result:
+            continue
+
+        if waiting[item]:
+            stack.append(item)
+            stack.extend(sorted(waiting[item],
+                                key=total_dependencies.get))
+            continue
+
+        result[item] = i
+        i += 1
+
+        for dep in dependents[item]:
+            waiting[dep].discard(item)
+
+        deps = [d for d in dependents[item] if d not in result]
+        stack.extend(sorted(deps, key=total_dependents.get, reverse=True))
+
+    return result
 
 
 def ndependents(dependencies, dependents):

--- a/dask/tests/test_local.py
+++ b/dask/tests/test_local.py
@@ -176,4 +176,4 @@ def test_ordering():
 
     get_sync(dsk, 'y')
 
-    assert L == sorted(L)
+    assert L == sorted(L, reverse=True)

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -251,3 +251,23 @@ def test_type_comparisions_ok(abcde):
     a, b, c, d, e = abcde
     dsk = {a: 1, (a, 1): 2, (a, b, 1): 3}
     order(dsk)  # this doesn't err
+
+
+def test_prefer_short_dependents(abcde):
+    """
+
+         a
+         |
+      d  b  e
+       \ | /
+         c
+
+    Prefer to finish d and e before starting b.  That way c can be released
+    during the long computations.
+    """
+    a, b, c, d, e = abcde
+    dsk = {c: (f,), d: (f, c), e: (f, c), b: (f, c), a: (f, b)}
+
+    o = order(dsk)
+    assert o[d] < o[b]
+    assert o[e] < o[b]

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -239,7 +239,7 @@ def test_gh_3055():
     dsk = dict(w.__dask_graph__())
     o = order(dsk)
     L = [o[k] for k in w.__dask_keys__()]
-    assert sorted(L) == L[::-1] or sorted(L) == L
+    assert sorted(L) == L
 
 
 def test_type_comparisions_ok(abcde):

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import pytest
-
 
 def inc(x):
     return x + 1
@@ -112,25 +110,6 @@ class GetFunctionTestMixin(object):
         d = {'x%d' % (i + 1): (inc, 'x%d' % i) for i in range(10000)}
         d['x0'] = 0
         assert self.get(d, 'x10000') == 10000
-
-    @pytest.mark.skip(reason="We are no longer robust to graph cycles")
-    def test_robust_to_cycles(self):
-        d = {'x%d' % (i + 1): (inc, 'x%d' % i) for i in range(10000)}
-        d['x0'] = 0
-        d['x5000'] = (inc, 'x5001')
-
-        try:
-            self.get(d, 'x10000')
-        except (RuntimeError, ValueError) as e:
-            if isinstance(e, RuntimeError):
-                assert str(e) == 'Cycle detected in Dask: x5001->x5000->x5001'
-            elif isinstance(e, ValueError):
-                assert str(e).startswith('Found no accessible jobs in dask')
-        else:
-            msg = 'dask with infinite cycle should have raised an exception.'
-            assert False, msg
-
-        assert self.get(d, 'x4999') == 4999
 
     def test_with_sharedict(self):
         from .sharedict import ShareDict

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import pytest
+
 
 def inc(x):
     return x + 1
@@ -107,10 +109,14 @@ class GetFunctionTestMixin(object):
         assert self.get(d, 'z') == 4
 
     def test_get_stack_limit(self):
-        d = dict(('x%d' % (i + 1), (inc, 'x%d' % i)) for i in range(10000))
+        d = {'x%d' % (i + 1): (inc, 'x%d' % i) for i in range(10000)}
         d['x0'] = 0
         assert self.get(d, 'x10000') == 10000
-        # introduce cycle
+
+    @pytest.mark.skip(reason="We are no longer robust to graph cycles")
+    def test_robust_to_cycles(self):
+        d = {'x%d' % (i + 1): (inc, 'x%d' % i) for i in range(10000)}
+        d['x0'] = 0
         d['x5000'] = (inc, 'x5001')
 
         try:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -38,6 +38,7 @@ Core
 - Add ``dask.base.optimize`` for optimizing multiple collections without
   computing. (:pr:`3071`) `Jim Crist`_
 - Rename ``dask.optimize`` module to ``dask.optimization`` (:pr:`3071`) `Jim Crist`_
+- Change task ordering to do a full traversal (:pr:`3066`) `Matthew Rocklin`_
 
 
 0.16.1 / 2018-01-09


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
