### PR TITLE
Add more helpful error when len is called on arrays with empty chunks. Fixes 3058.

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1111,10 +1111,8 @@ class Array(Base):
     chunks = property(_get_chunks, _set_chunks, "chunks property")
 
     def __len__(self):
-        if len(self.chunks) == 0:
-            raise ValueError("Can not get length if chunks are empty. "
-                             "Please initalize with chunks or use"
-                             " rechunk method to set if needed.")
+        if not self.chunks:
+            raise TypeError("len() of unsized object")
         return sum(self.chunks[0])
 
     def __array_ufunc__(self, numpy_ufunc, method, *inputs, **kwargs):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1111,6 +1111,10 @@ class Array(Base):
     chunks = property(_get_chunks, _set_chunks, "chunks property")
 
     def __len__(self):
+        if len(self.chunks) == 0:
+            raise ValueError("Can not get length if chunks are empty. "
+                             "Please initalize with chunks or use"
+                             " rechunk method to set if needed.")
         return sum(self.chunks[0])
 
     def __array_ufunc__(self, numpy_ufunc, method, *inputs, **kwargs):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3035,11 +3035,9 @@ def test_delayed_array_key_hygeine():
 
 
 def test_empty_chunks_in_array_len():
-    da = pytest.importorskip('dask.array')
-
     x = da.ones((), chunks=())
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(TypeError) as exc_info:
         len(x)
 
-    err_msg = 'Can not get length if chunks are empty'
+    err_msg = 'len() of unsized object'
     assert err_msg in str(exc_info.value)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3032,3 +3032,14 @@ def test_delayed_array_key_hygeine():
     d = delayed(identity)(a)
     b = da.from_delayed(d, shape=a.shape, dtype=a.dtype)
     assert_eq(a, b)
+
+
+def test_empty_chunks_in_array_len():
+    da = pytest.importorskip('dask.array')
+
+    x = da.ones((), chunks=())
+    with pytest.raises(ValueError) as exc_info:
+        len(x)
+
+    err_msg = 'Can not get length if chunks are empty'
+    assert err_msg in str(exc_info.value)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 
 Array
 +++++
-
+- Update error handling when len is called with empty chunks (:issue:`3058`) `Xander Johnson`_
 
 DataFrame
 +++++++++
@@ -918,3 +918,4 @@ Other
 .. _`Markus Gonser`: https://github.com/magonser
 .. _`Martijn Arts`: https://github.com/mfaafm
 .. _`Jon Mease`: https://github.com/jmmease
+.. _`Xander Johnson`: https://github.com/metasyn


### PR DESCRIPTION
Fixes #3058

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
