### PR TITLE
A mild refactor of `dask.bytes`

### DIFF
--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -872,7 +872,9 @@ def test_to_textfiles_inputs():
         B.to_textfiles(dirname)
         assert os.path.exists(dirname)
         assert os.path.exists(os.path.join(dirname, '0.part'))
-    pytest.raises(ValueError, lambda: B.to_textfiles(5))
+
+    with pytest.raises(TypeError):
+        B.to_textfiles(5)
 
 
 def test_to_textfiles_endlines():

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -637,9 +637,11 @@ def test_from_s3():
     e = db.read_text('s3://tip-data/t*.gz', storage_options=dict(anon=True))
     assert e.take(5) == five_tips
 
-    # test all keys in bucket
-    c = db.read_text('s3://tip-data/*', storage_options=dict(anon=True))
-    assert c.npartitions == 4
+    # test multiple keys in bucket
+    c = db.read_text(['s3://tip-data/tips.gz', 's3://tip-data/tips.json',
+                      's3://tip-data/tips.csv'],
+                     storage_options=dict(anon=True))
+    assert c.npartitions == 3
 
 
 def test_from_sequence():

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -224,7 +224,8 @@ class OpenFile(object):
     Parameters
     ----------
     fs : FileSystem
-        The file system to use for opening the file
+        The file system to use for opening the file. Should match the interface
+        of ``dask.bytes.local.LocalFileSystem``.
     path : str
         Location to open
     mode : str like 'rb', optional
@@ -375,12 +376,12 @@ def get_fs_token_paths(urlpath, mode='rb', num=1, name_function=None,
     """
     if isinstance(urlpath, (list, tuple)):
         if not urlpath:
-            raise ValueError("empty urlpath")
-        paths, protocols, options_itbl = zip(*map(infer_options, urlpath))
+            raise ValueError("empty urlpath sequence")
+        paths, protocols, options_list = zip(*map(infer_options, urlpath))
         protocol = protocols[0]
-        options = options_itbl[0]
+        options = options_list[0]
         if not (all(p == protocol for p in protocols) and
-                all(o == options for o in options_itbl)):
+                all(o == options for o in options_list)):
             raise ValueError("When specifying a list of paths, all paths must "
                              "share the same protocol and options")
         update_storage_options(options, storage_options)
@@ -511,6 +512,8 @@ _filesystems = dict()
 
 
 class FileSystem(object):
+    """Deprecated, do not use. Implement filesystems by matching the interface
+    of `dask.bytes.local.LocalFileSystem` instead of subclassing."""
     pass
 
 

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -397,7 +397,7 @@ def get_fs_token_paths(urlpath, mode='rb', num=1, name_function=None,
         if 'w' in mode:
             paths = _expand_paths(urlpath, name_function, num)
         elif "*" in urlpath:
-            paths = fs.glob(urlpath)
+            paths = sorted(fs.glob(urlpath))
         else:
             paths = [urlpath]
 

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -81,14 +81,17 @@ def write_bytes(data, urlpath, name_function=None, compression=None,
     kwargs: passed to filesystem constructor
     """
     mode = 'wb' if encoding is None else 'wt'
-    fs, _, names, myopen = get_fs_paths_myopen(urlpath, compression, mode,
-                                               name_function=name_function,
-                                               num=len(data), encoding=encoding,
-                                               **kwargs)
 
-    values = [delayed(write_block_to_file, pure=False)(d, myopen(f, mode='wb'))
-              for d, f in zip(data, names)]
-    return values, names
+    files = open_files(urlpath, compression=compression, mode=mode,
+                       encoding=encoding, name_function=name_function,
+                       num=len(data), **kwargs)
+
+    values = [delayed(write_block_to_file, pure=False)(d, f)
+              for d, f in zip(data, files)]
+
+    paths = [f.path for f in files]
+
+    return values, paths
 
 
 def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
@@ -135,9 +138,8 @@ def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
     A sample header and list of ``dask.Delayed`` objects or list of lists of
     delayed objects if ``fn`` is a globstring.
     """
-    fs, fs_token, paths, myopen = get_fs_paths_myopen(urlpath, compression,
-                                                      'rb', None, **kwargs)
-    client = None
+    fs, fs_token, paths = get_fs_paths(urlpath, mode='rb', **kwargs)
+
     if len(paths) == 0:
         raise IOError("%s resolved to no files" % urlpath)
 
@@ -146,22 +148,28 @@ def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
             raise TypeError("blocksize must be an integer")
         blocksize = int(blocksize)
 
-    blocks, lengths, machines = fs.get_block_locations(paths)
-    if blocks:
-        offsets = blocks
+    client = None
+    if hasattr(fs, 'get_block_locations'):
+        offsets, lengths, machines = fs.get_block_locations(paths)
+        try:
+            from distributed.client import default_client
+            client = default_client()
+        except (ImportError, ValueError):  # no distributed client
+            pass
     elif blocksize is None:
         offsets = [[0]] * len(paths)
-        lengths = [[None]] * len(offsets)
-        machines = [[None]] * len(offsets)
+        lengths = [[None]] * len(paths)
+        machines = [None] * len(paths)
     else:
         offsets = []
         lengths = []
         for path in paths:
             try:
-                size = fs.logical_size(path, compression)
-            except KeyError:
-                raise ValueError('Cannot read compressed files (%s) in byte chunks,'
-                                 'use blocksize=None' % infer_compression(urlpath))
+                size = logical_size(fs, path, compression)
+            except ValueError:
+                raise ValueError("Cannot do chunked reads on files compressed "
+                                 "with compression=%r. To read, set "
+                                 "blocksize=None" % get_compression(path, compression))
             off = list(range(0, size, blocksize))
             length = [blocksize] * len(off)
             if not_zero:
@@ -169,92 +177,40 @@ def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
                 length[0] -= 1
             offsets.append(off)
             lengths.append(length)
-        machines = [[None]] * len(offsets)
+        machines = [None] * len(offsets)
+
+    delayed_read = delayed(read_block_from_file)
 
     out = []
     for path, offset, length, machine in zip(paths, offsets, lengths, machines):
         token = tokenize(fs_token, delimiter, path, fs.ukey(path),
                          compression, offset)
         keys = ['read-block-%s-%s' % (o, token) for o in offset]
-        L = [delayed(read_block_from_file)(myopen(path, mode='rb'), o,
-                                           l, delimiter, dask_key_name=key)
-             for (o, key, l) in zip(offset, keys, length)]
-        out.append(L)
-        if machine is not None:  # blocks are in preferred locations
-            if client is None:
-                try:
-                    from distributed.client import default_client
-                    client = default_client()
-                except (ImportError, ValueError):  # no distributed client
-                    client = False
-            if client:
-                restrictions = {key: w for key, w in zip(keys, machine)}
-                client._send_to_scheduler({'op': 'update-graph', 'tasks': {},
-                                           'dependencies': [], 'keys': [],
-                                           'restrictions': restrictions,
-                                           'loose_restrictions': list(restrictions),
-                                           'client': client.id})
+        out.append([delayed_read(OpenFile(fs, path, compression=compression),
+                                 o, l, delimiter, dask_key_name=key)
+                    for o, key, l in zip(offset, keys, length)])
+        if machine is not None and client is not None:
+            # blocks are in preferred locations
+            restrictions = {key: w for key, w in zip(keys, machine)}
+            client._send_to_scheduler({'op': 'update-graph',
+                                       'tasks': {},
+                                       'dependencies': [],
+                                       'keys': [],
+                                       'restrictions': restrictions,
+                                       'loose_restrictions': keys,
+                                       'client': client.id})
 
-    if sample is not True:
-        nbytes = sample
-    else:
-        nbytes = 10000
     if sample:
-        with myopen(paths[0], 'rb') as f:
+        with OpenFile(fs, paths[0], compression=compression) as f:
+            nbytes = 10000 if sample is True else sample
             sample = read_block(f, 0, nbytes, delimiter)
+
     return sample, out
 
 
 def read_block_from_file(lazy_file, off, bs, delimiter):
     with lazy_file as f:
         return read_block(f, off, bs, delimiter)
-
-
-class OpenFileCreator(object):
-    """
-    Produces a function-like instance, which generates open file contexts
-
-    Analyses the passed URL to determine the appropriate backend (local file,
-    s3, etc.), and then acts something like the builtin `open` in
-    with a context, where the further options such as compression are applied
-    to the file to be opened.
-
-    Parameters
-    ----------
-    fs : FileSystem
-        The file system to use for opening the file
-    compression : str or None
-        One of the keys of `compress_files` or None; all files opened will use
-        this compression.
-    text : bool
-        Whether files should be binary or text
-    encoding : str
-        If files are text, the encoding to use
-    errors : str ['strict']
-        How to handle encoding errors for text files
-
-    Examples
-    --------
-    >>> ofc = OpenFileCreator('2015-*-*.csv')  # doctest: +SKIP
-    >>> with ofc('2015-12-10.csv', 'rb') as f: # doctest: +SKIP
-    ...     f.read(10)                         # doctest: +SKIP
-    """
-    def __init__(self, fs, compression=None, text=False, encoding='utf8',
-                 errors=None):
-        self.fs = fs
-        self.compression = compression
-        self.text = text
-        self.encoding = encoding
-        self.errors = errors
-
-    def __call__(self, path, mode='rb'):
-        """Produces `OpenFile` instance"""
-        return OpenFile(self.fs, path, self.compression, mode,
-                        self.text, self.encoding, self.errors)
-
-    def __dask_tokenize__(self):
-        raise NotImplementedError()
-        return self.fs, self.compression, self.text, self.encoding, self.errors
 
 
 class OpenFile(object):
@@ -268,29 +224,32 @@ class OpenFile(object):
     ----------
     fs : FileSystem
         The file system to use for opening the file
-    path: str
+    path : str
         Location to open
-    compression: str or None
-        Compression to apply
-    mode: str like 'rb'
+    mode : str like 'rb', optional
         Mode of the opened file
-    text: bool
+    compression : str or None, optional
+        Compression to apply
+    text : bool, optional
         Whether to wrap the file to be text-like
-    encoding: if using text
-    errors: if using text
+    encoding : str or None, optional
+        The encoding to use if opened in text mode.
+    errors : str or None, optional
+        How to handle encoding errors if opened in text mode.
     """
-    def __init__(self, fs, path, compression, mode, text, encoding,
+    def __init__(self, fs, path, mode='rb', compression=None, encoding=None,
                  errors=None):
         self.fs = fs
         self.path = path
-        self.compression = compression
         self.mode = mode
-        self.text = text
+        self.compression = get_compression(path, compression)
         self.encoding = encoding
         self.errors = errors
-
         self.fobjects = []
-        self.f = None
+
+    def __reduce__(self):
+        return (OpenFile, (self.fs, self.path, self.mode, self.compression,
+                           self.encoding, self.errors))
 
     def __enter__(self):
         mode = self.mode.replace('t', '').replace('b', '') + 'b'
@@ -304,13 +263,12 @@ class OpenFile(object):
             f = compress(f, mode=mode)
             fobjects.append(f)
 
-        if self.text:
+        if 't' in self.mode:
             f = io.TextIOWrapper(f, encoding=self.encoding,
                                  errors=self.errors)
             fobjects.append(f)
 
         self.fobjects = fobjects
-        self.f = f
         return f
 
     def __exit__(self, *args):
@@ -321,10 +279,9 @@ class OpenFile(object):
         for f in reversed(self.fobjects):
             f.close()
         self.fobjects = []
-        self.f = None
 
 
-def open_files(urlpath, compression=None, mode='rb', encoding='utf8',
+def open_files(urlpath, mode='rb', compression=None, encoding='utf8',
                errors=None, name_function=None, num=1, **kwargs):
     """ Given path return dask.delayed file-like objects
 
@@ -333,9 +290,9 @@ def open_files(urlpath, compression=None, mode='rb', encoding='utf8',
     urlpath: string
         Absolute or relative filepath, URL (may include protocols like
         ``s3://``), or globstring pointing to data.
+    mode: 'rb', 'wt', etc.
     compression: string
         Compression to use.  See ``dask.bytes.compression.files`` for options.
-    mode: 'rb', 'wt', etc.
     encoding: str
         For text mode only
     errors: None or str
@@ -360,11 +317,13 @@ def open_files(urlpath, compression=None, mode='rb', encoding='utf8',
     -------
     List of ``dask.delayed`` objects that compute to file-like objects
     """
-    fs, _, paths, myopen = get_fs_paths_myopen(urlpath, compression, mode,
-                                               encoding=encoding, num=num,
-                                               name_function=name_function,
-                                               errors=errors, **kwargs)
-    return [myopen(path, mode) for path in paths]
+    fs, fs_token, paths = get_fs_paths(urlpath, mode, num=num,
+                                       name_function=name_function,
+                                       **kwargs)
+
+    return [OpenFile(fs, path, mode=mode, compression=compression,
+                     encoding=encoding, errors=errors)
+            for path in paths]
 
 
 def get_compression(urlpath, compression):
@@ -400,8 +359,7 @@ def all_equal(seq):
     return all(y == x for y in seq[1:])
 
 
-def get_fs_paths_myopen(urlpath, compression, mode, encoding='utf8',
-                        errors='strict', num=1, name_function=None, **kwargs):
+def get_fs_paths(urlpath, mode='rb', num=1, name_function=None, **kwargs):
     if isinstance(urlpath, (list, tuple)):
         if not urlpath:
             raise ValueError("empty urlpath")
@@ -414,10 +372,6 @@ def get_fs_paths_myopen(urlpath, compression, mode, encoding='utf8',
         update_storage_options(options, kwargs)
         paths = list(paths)
 
-        compressions = [get_compression(p, compression) for p in paths]
-        assert all_equal(compressions)
-        compression = compressions[0]
-
         fs, fs_token = get_fs(protocol, options)
 
     elif isinstance(urlpath, (str, unicode)) or hasattr(urlpath, 'name'):
@@ -425,7 +379,6 @@ def get_fs_paths_myopen(urlpath, compression, mode, encoding='utf8',
         update_storage_options(options, kwargs)
 
         fs, fs_token = get_fs(protocol, options)
-        compression = get_compression(urlpath, compression)
 
         if 'w' in mode:
             paths = _expand_paths(urlpath, name_function, num)
@@ -437,10 +390,7 @@ def get_fs_paths_myopen(urlpath, compression, mode, encoding='utf8',
     else:
         raise TypeError('url type not understood: %s' % urlpath)
 
-    open_with = OpenFileCreator(fs, compression, text='b' not in mode,
-                                encoding=encoding, errors=errors)
-
-    return fs, fs_token, paths, open_with
+    return fs, fs_token, paths
 
 
 def open_text_files(urlpath, compression=None, mode='rt', encoding='utf8',
@@ -469,7 +419,8 @@ def open_text_files(urlpath, compression=None, mode='rt', encoding='utf8',
     -------
     List of ``dask.delayed`` objects that compute to text file-like objects
     """
-    return open_files(urlpath, compression, mode.replace('b', 't'), encoding,
+    return open_files(urlpath, mode=mode.replace('b', 't'),
+                      compression=compression, encoding=encoding,
                       errors=errors, **kwargs)
 
 
@@ -546,26 +497,25 @@ def get_fs(protocol, storage_options=None):
 
 
 _filesystems = dict()
-# see .local.LocalFileSystem for reference implementation
 
 
 class FileSystem(object):
-    def logical_size(self, path, compression):
-        if compression == 'infer':
-            compression = infer_compression(path)
-        if compression is None:
-            return self.size(path)
-        else:
-            with self.open(path, 'rb') as f:
-                f = SeekableFile(f)
-                g = seekable_files[compression](f)
-                g.seek(0, 2)
-                result = g.tell()
-                g.close()
-            return result
+    pass
 
-    def get_block_locations(self, path):
-        return None, None, None
+
+def logical_size(fs, path, compression='infer'):
+    if compression == 'infer':
+        compression = infer_compression(path)
+
+    if compression is None:
+        return fs.size(path)
+    elif compression in seekable_files:
+        with OpenFile(fs, path, compression=compression) as f:
+            f.seek(0, 2)
+            return f.tell()
+    else:
+        raise ValueError("Cannot infer logical size from file compressed with "
+                         "compression=%r" % compression)
 
 
 def get_pyarrow_filesystem(fs):

--- a/dask/bytes/local.py
+++ b/dask/bytes/local.py
@@ -25,19 +25,19 @@ class LocalFileSystem(core.FileSystem):
         """
         self.cwd = os.getcwd()
 
-    def _normpath(self, path):
-        # ensure paths are absolute and normalized
+    def _normalize_path(self, path):
+        """Ensure paths are absolute and normalized"""
         if not os.path.isabs(path):
             return os.path.join(self.cwd, path)
         return os.path.normpath(path)
 
     def glob(self, path):
         """For a template path, return matching files"""
-        return sorted(glob(self._normpath(path)))
+        return sorted(glob(self._normalize_path(path)))
 
     def mkdirs(self, path):
         """Make any intermediate directories to make path writable"""
-        path = self._normpath(path)
+        path = self._normalize_path(path)
         try:
             os.makedirs(path)
         except OSError:
@@ -55,16 +55,16 @@ class LocalFileSystem(core.FileSystem):
             these on the filesystem instance, to apply to all files created by
             it. Not used for local.
         """
-        return open(self._normpath(path), mode=mode)
+        return open(self._normalize_path(path), mode=mode)
 
     def ukey(self, path):
         """Unique identifier, so we can tell if a file changed"""
-        path = self._normpath(path)
+        path = self._normalize_path(path)
         return tokenize(path, os.stat(path).st_mtime)
 
     def size(self, path):
         """Size in bytes of the file at path"""
-        return os.stat(self._normpath(path)).st_size
+        return os.stat(self._normalize_path(path)).st_size
 
     def _get_pyarrow_filesystem(self):
         """Get an equivalent pyarrow filesystem"""

--- a/dask/bytes/local.py
+++ b/dask/bytes/local.py
@@ -4,7 +4,6 @@ from glob import glob
 import os
 
 from . import core
-from .utils import infer_storage_options
 from ..base import tokenize
 
 
@@ -26,20 +25,19 @@ class LocalFileSystem(core.FileSystem):
         """
         self.cwd = os.getcwd()
 
-    def _trim_filename(self, fn):
-        path = infer_storage_options(fn)['path']
+    def _normpath(self, path):
+        # ensure paths are absolute and normalized
         if not os.path.isabs(path):
-            path = os.path.normpath(os.path.join(self.cwd, path))
-        return path
+            return os.path.join(self.cwd, path)
+        return os.path.normpath(path)
 
     def glob(self, path):
         """For a template path, return matching files"""
-        path = self._trim_filename(path)
-        return sorted(glob(path))
+        return sorted(glob(self._normpath(path)))
 
     def mkdirs(self, path):
         """Make any intermediate directories to make path writable"""
-        path = self._trim_filename(path)
+        path = self._normpath(path)
         try:
             os.makedirs(path)
         except OSError:
@@ -57,18 +55,16 @@ class LocalFileSystem(core.FileSystem):
             these on the filesystem instance, to apply to all files created by
             it. Not used for local.
         """
-        path = self._trim_filename(path)
-        return open(path, mode=mode)
+        return open(self._normpath(path), mode=mode)
 
     def ukey(self, path):
         """Unique identifier, so we can tell if a file changed"""
-        path = self._trim_filename(path)
+        path = self._normpath(path)
         return tokenize(path, os.stat(path).st_mtime)
 
     def size(self, path):
         """Size in bytes of the file at path"""
-        path = self._trim_filename(path)
-        return os.stat(path).st_size
+        return os.stat(self._normpath(path)).st_size
 
     def _get_pyarrow_filesystem(self):
         """Get an equivalent pyarrow filesystem"""

--- a/dask/bytes/s3.py
+++ b/dask/bytes/s3.py
@@ -3,7 +3,6 @@ from __future__ import print_function, division, absolute_import
 from s3fs import S3FileSystem
 
 from . import core
-from .utils import infer_storage_options
 
 
 class DaskS3FileSystem(S3FileSystem, core.FileSystem):
@@ -30,32 +29,16 @@ class DaskS3FileSystem(S3FileSystem, core.FileSystem):
             secret = password
         if secret is not None:
             kwargs['secret'] = secret
-        # S3FileSystem.__init__(self, kwargs)  # not sure what do do here
-        S3FileSystem.__init__(self, **kwargs)
-
-    def _trim_filename(self, fn):
-        so = infer_storage_options(fn)
-        return so.get('host', '') + so['path']
-
-    def open(self, path, mode='rb'):
-        s3_path = self._trim_filename(path)
-        f = S3FileSystem.open(self, s3_path, mode=mode)
-        return f
-
-    def glob(self, path):
-        s3_path = self._trim_filename(path)
-        return ['s3://%s' % s for s in S3FileSystem.glob(self, s3_path)]
+        super(DaskS3FileSystem, self).__init__(**kwargs)
 
     def mkdirs(self, path):
         pass  # no need to pre-make paths on S3
 
     def ukey(self, path):
-        s3_path = self._trim_filename(path)
-        return self.info(s3_path)['ETag']
+        return self.info(path)['ETag']
 
     def size(self, path):
-        s3_path = self._trim_filename(path)
-        return self.info(s3_path)['Size']
+        return self.info(path)['Size']
 
     def _get_pyarrow_filesystem(self):
         """Get an equivalent pyarrow fileystem"""

--- a/dask/bytes/tests/test_bytes_utils.py
+++ b/dask/bytes/tests/test_bytes_utils.py
@@ -107,6 +107,10 @@ def test_infer_storage_options():
 
     assert infer_storage_options('http://127.0.0.1:8080/test.csv')['host'] == '127.0.0.1'
 
+    # For s3 and gcs the netloc is actually the bucket name, so we want to
+    # include it in the path. Test that:
+    # - Parsing doesn't lowercase the bucket
+    # - The bucket is included in path
     for protocol in ['s3', 'gcs', 'gs']:
         options = infer_storage_options('%s://Bucket-name.com/test.csv' % protocol)
         assert options['path'] == 'Bucket-name.com/test.csv'

--- a/dask/bytes/tests/test_bytes_utils.py
+++ b/dask/bytes/tests/test_bytes_utils.py
@@ -105,8 +105,11 @@ def test_infer_storage_options():
     assert so.pop('username') == 'User-name'
     assert so.pop('host') == 'Node-name.com'
 
-    assert infer_storage_options('s3://Bucket-name.com/test.csv')['host'] == 'Bucket-name.com'
     assert infer_storage_options('http://127.0.0.1:8080/test.csv')['host'] == '127.0.0.1'
+
+    for protocol in ['s3', 'gcs', 'gs']:
+        options = infer_storage_options('%s://Bucket-name.com/test.csv' % protocol)
+        assert options['path'] == 'Bucket-name.com/test.csv'
 
     with pytest.raises(KeyError):
         infer_storage_options('file:///bucket/file.csv', {'path': 'collide'})

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -53,12 +53,13 @@ def test_urlpath_inference_strips_protocol(tmpdir):
             f.write(b'1,2,3\n' * 10)
 
     # globstring
-    urlpath = to_uri(os.path.join(tmpdir, 'test.')) + '*.csv'
+    protocol = 'file:///' if sys.platform == 'win32' else 'file://'
+    urlpath = protocol + os.path.join(tmpdir, 'test.*.csv')
     _, _, paths2 = get_fs_token_paths(urlpath)
     assert paths2 == paths
 
     # list of paths
-    _, _, paths2 = get_fs_token_paths([to_uri(p) for p in paths])
+    _, _, paths2 = get_fs_token_paths([protocol + p for p in paths])
     assert paths2 == paths
 
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -53,12 +53,12 @@ def test_urlpath_inference_strips_protocol(tmpdir):
             f.write(b'1,2,3\n' * 10)
 
     # globstring
-    urlpath = os.path.join(tmpdir, 'test.*.csv')
-    _, _, paths2 = get_fs_token_paths('file://' + urlpath)
+    urlpath = to_uri(os.path.join(tmpdir, 'test.')) + '*.csv'
+    _, _, paths2 = get_fs_token_paths(urlpath)
     assert paths2 == paths
 
     # list of paths
-    _, _, paths2 = get_fs_token_paths(['file://' + p for p in paths])
+    _, _, paths2 = get_fs_token_paths([to_uri(p) for p in paths])
     assert paths2 == paths
 
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -14,7 +14,8 @@ from dask.utils import filetexts
 from dask.bytes import compression
 from dask.bytes.local import LocalFileSystem
 from dask.bytes.core import (open_text_files, write_bytes, read_bytes,
-                             open_files, FileSystem, get_pyarrow_filesystem)
+                             open_files, FileSystem, get_pyarrow_filesystem,
+                             logical_size)
 
 compute = partial(compute, get=get)
 
@@ -250,7 +251,7 @@ def test_getsize(fmt):
     compress = compression.compress[fmt]
     with filetexts({'.tmp.getsize': compress(b'1234567890')}, mode='b'):
         fs = LocalFileSystem()
-        assert fs.logical_size('.tmp.getsize', fmt) == 10
+        assert logical_size(fs, '.tmp.getsize', fmt) == 10
 
 
 def test_bad_compression():

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -14,8 +14,7 @@ from dask.utils import filetexts
 from dask.bytes import compression
 from dask.bytes.local import LocalFileSystem
 from dask.bytes.core import (open_text_files, write_bytes, read_bytes,
-                             open_files, OpenFileCreator, FileSystem,
-                             get_pyarrow_filesystem)
+                             open_files, FileSystem, get_pyarrow_filesystem)
 
 compute = partial(compute, get=get)
 
@@ -300,7 +299,9 @@ def test_simple_write(tmpdir):
     files = os.listdir(tmpdir)
     assert len(files) == 2
     assert '0.part' in files
-    d = open(os.path.join(tmpdir, files[0]), 'rb').read()
+
+    with open(os.path.join(tmpdir, files[0]), 'rb') as f:
+        d = f.read()
     assert d == b'000'
 
 
@@ -329,24 +330,18 @@ def test_open_files_write(tmpdir):
 
 
 def test_pickability_of_lazy_files(tmpdir):
+    tmpdir = str(tmpdir)
     cloudpickle = pytest.importorskip('cloudpickle')
-    fn = os.path.join(str(tmpdir), 'foo')
-    with open(fn, 'wb') as f:
-        f.write(b'1')
 
-    opener = OpenFileCreator('file://foo.py', open=open)
-    opener2 = cloudpickle.loads(cloudpickle.dumps(opener))
-    assert type(opener2.fs) == type(opener.fs)
+    with filetexts(files, mode='b'):
+        myfiles = open_files('.test.accounts.*')
+        myfiles2 = cloudpickle.loads(cloudpickle.dumps(myfiles))
 
-    lazy_file = opener(fn, mode='rt')
-    lazy_file2 = cloudpickle.loads(cloudpickle.dumps(lazy_file))
-    assert lazy_file.path == lazy_file2.path
-
-    with lazy_file as f:
-        pass
-
-    lazy_file3 = cloudpickle.loads(cloudpickle.dumps(lazy_file))
-    assert lazy_file.path == lazy_file3.path
+        for f, f2 in zip(myfiles, myfiles2):
+            assert f.path == f2.path
+            assert type(f.fs) == type(f2.fs)
+            with f as f_open, f2 as f2_open:
+                assert f_open.read() == f2_open.read()
 
 
 def test_py2_local_bytes(tmpdir):
@@ -354,11 +349,9 @@ def test_py2_local_bytes(tmpdir):
     with gzip.open(fn, mode='wb') as f:
         f.write(b'hello\nworld')
 
-    ofc = OpenFileCreator(fn, text=True, open=open, mode='rt',
-                          compression='gzip', encoding='utf-8')
-    lazy_file = ofc(fn)
+    files = open_files(fn, compression='gzip', mode='rt')
 
-    with lazy_file as f:
+    with files[0] as f:
         assert all(isinstance(line, unicode) for line in f)
 
 
@@ -375,7 +368,9 @@ def test_abs_paths(tmpdir):
 
     fs = LocalFileSystem()
     os.chdir(here)
-    assert fs.open('tmp', 'r').read() == 'hi'
+    with fs.open('tmp', 'r') as f:
+        res = f.read()
+    assert res == 'hi'
 
 
 class UnknownFileSystem(FileSystem):

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -233,12 +233,6 @@ def test_files(s3):
             assert data == files[path]
 
 
-@pytest.mark.parametrize('fmt', list(seekable_files))
-def test_getsize(fmt):
-    with s3_context('compress', {'x': compress[fmt](b'1234567890')}) as s3:
-        assert s3.logical_size('compress/x', fmt) == 10
-
-
 double = lambda x: x * 2
 
 

--- a/dask/bytes/utils.py
+++ b/dask/bytes/utils.py
@@ -51,7 +51,7 @@ def infer_storage_options(urlpath, inherit_storage_options=None):
         if windows_path:
             path = '%s:%s' % windows_path.groups()
 
-    inferred_storage_options = {
+    options = {
         'protocol': protocol,
         'path': path,
     }
@@ -60,27 +60,42 @@ def infer_storage_options(urlpath, inherit_storage_options=None):
         # Parse `hostname` from netloc manually because `parsed_path.hostname`
         # lowercases the hostname which is not always desirable (e.g. in S3):
         # https://github.com/dask/dask/issues/1417
-        inferred_storage_options['host'] = parsed_path.netloc.rsplit('@', 1)[-1].rsplit(':', 1)[0]
+        host = parsed_path.netloc.rsplit('@', 1)[-1].rsplit(':', 1)[0]
+
+        # For gcs and s3 the netloc is actually the bucket name, so we want to
+        # include it in the path. It feels a bit wrong to hardcode this, but
+        # the number of filesystems where this matters is small, so this should
+        # be fine to include:
+        if protocol in ('s3', 'gcs', 'gs'):
+            options['path'] = host + options['path']
+        else:
+            options['host'] = host
+
         if parsed_path.port:
-            inferred_storage_options['port'] = parsed_path.port
+            options['port'] = parsed_path.port
         if parsed_path.username:
-            inferred_storage_options['username'] = parsed_path.username
+            options['username'] = parsed_path.username
         if parsed_path.password:
-            inferred_storage_options['password'] = parsed_path.password
+            options['password'] = parsed_path.password
 
     if parsed_path.query:
-        inferred_storage_options['url_query'] = parsed_path.query
+        options['url_query'] = parsed_path.query
     if parsed_path.fragment:
-        inferred_storage_options['url_fragment'] = parsed_path.fragment
+        options['url_fragment'] = parsed_path.fragment
 
     if inherit_storage_options:
-        if set(inherit_storage_options) & set(inferred_storage_options):
-            raise KeyError("storage options (%r) and path url options (%r) "
-                           "collision is detected"
-                           % (inherit_storage_options, inferred_storage_options))
-        inferred_storage_options.update(inherit_storage_options)
+        update_storage_options(options, inherit_storage_options)
 
-    return inferred_storage_options
+    return options
+
+
+def update_storage_options(options, inherited):
+    collisions = set(options) & set(inherited)
+    if collisions:
+        collisions = '\n'.join('- %r' % k for k in collisions)
+        raise KeyError("Collision between inferred and specified storage "
+                       "options:\n%s")
+    options.update(inherited)
 
 
 if PY2:

--- a/dask/bytes/utils.py
+++ b/dask/bytes/utils.py
@@ -89,7 +89,9 @@ def infer_storage_options(urlpath, inherit_storage_options=None):
     return options
 
 
-def update_storage_options(options, inherited):
+def update_storage_options(options, inherited=None):
+    if not inherited:
+        inherited = {}
     collisions = set(options) & set(inherited)
     if collisions:
         collisions = '\n'.join('- %r' % k for k in collisions)

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -14,7 +14,7 @@ from ..utils import UNKNOWN_CATEGORIES
 from ...base import tokenize, normalize_token
 from ...compatibility import PY3, string_types
 from ...delayed import delayed
-from ...bytes.core import get_fs_paths_myopen
+from ...bytes.core import get_fs_paths
 
 __all__ = ('read_parquet', 'to_parquet')
 
@@ -378,8 +378,7 @@ def _write_fastparquet(df, path, write_index=None, append=False,
                        storage_options=None, compression=None, **kwargs):
     import fastparquet
 
-    fs, fs_token, paths, _ = get_fs_paths_myopen(path, None, 'wb',
-                                                 **(storage_options or {}))
+    fs, fs_token, paths = get_fs_paths(path, 'wb', **(storage_options or {}))
     fs.mkdirs(path)
     sep = fs.sep
 
@@ -609,8 +608,8 @@ def _write_pyarrow(df, path, write_index=None, append=False,
     if write_index is None and df.known_divisions:
         write_index = True
 
-    fs, fs_token, paths, _ = get_fs_paths_myopen(path, None, 'wb',
-                                                 **(storage_options or {}))
+    fs, fs_token, paths = get_fs_paths(path, 'wb', **(storage_options or {}))
+
     fs.mkdirs(path)
 
     template = fs.sep.join([path, 'part.%i.parquet'])
@@ -756,8 +755,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
     --------
     to_parquet
     """
-    fs, fs_token, paths, _ = get_fs_paths_myopen(path, None, 'rb',
-                                                 **(storage_options or {}))
+    fs, fs_token, paths = get_fs_paths(path, 'rb', **(storage_options or {}))
 
     read = get_engine(engine)['read']
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -14,7 +14,7 @@ from ..utils import UNKNOWN_CATEGORIES
 from ...base import tokenize
 from ...compatibility import PY3, string_types
 from ...delayed import delayed
-from ...bytes.core import get_fs_paths
+from ...bytes.core import get_fs_token_paths
 from ...utils import import_required
 
 __all__ = ('read_parquet', 'to_parquet')
@@ -742,7 +742,8 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
     """
     read = get_engine(engine)['read']
 
-    fs, fs_token, paths = get_fs_paths(path, 'rb', **(storage_options or {}))
+    fs, fs_token, paths = get_fs_token_paths(path, mode='rb',
+                                             storage_options=storage_options)
 
     return read(fs, fs_token, paths, columns=columns, filters=filters,
                 categories=categories, index=index)
@@ -818,7 +819,8 @@ def to_parquet(df, path, engine='auto', compression='default', write_index=None,
 
     write = get_engine(engine)['write']
 
-    fs, fs_token, _ = get_fs_paths(path, 'wb', **(storage_options or {}))
+    fs, fs_token, _ = get_fs_token_paths(path, mode='wb',
+                                         storage_options=storage_options)
 
     out = write(df, fs, fs_token, path, write_index=write_index, append=append,
                 ignore_divisions=ignore_divisions, partition_on=partition_on,


### PR DESCRIPTION
This started off as just fixing #2885, but spiraled out as other issues prevented that. There is still more I want to do to cleanup `dask.bytes`, but figured this was self contained enough to submit.

Changes included:
- Filesystems are now passed a full path as if it was a local path, instead of passing path with the protocol/options still included. This removes the need for the `_trim_filename` code littered throughout each dask filesystem library.
- The `OpenFileCreator` class is removed. This merged a few unrelated concepts, and the underlying code ended up being cleaner without it.
- Removes tokenizing of open parquet file objects in favor of explicit token generation from arguments. This is more robust, and removes the need to register a tokenization implementation.
- Removal of any non-standard methods on the filesystem objects. `logical_size` should really be a function, and `get_block_locations` is backend specific so we now check for an implementation before calling it.
- Fixes a bug in the `get_block_locations` handling that resulted in distributed always being tried, even when not using hdfs (resulted in a warning in the tests).
- Squashes a few warnings in our tests that existed before this change.

The remaining changes were mostly to keep token generation consistent throughout, formatting, and docstring cleanups. This has led to a larger diff than I'd like, but the main goal was just point 1 (remove protocol/options from paths passed to filesystems).