### PR TITLE
Pad result from _colorize

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -412,7 +412,7 @@ def visualize(*args, **kwargs):
         except KeyError:
             import matplotlib.pyplot as plt
             cmap = plt.cm.viridis
-        mx = max(o.values())
+        mx = max(o.values()) + 1
         colors = {k: _colorize(cmap(v / mx, bytes=True)) for k, v in o.items()}
 
         kwargs['function_attributes'] = {k: {'color': v, 'label': str(o[k])}
@@ -742,7 +742,11 @@ def _colorize(t):
     --------
     >>> _colorize((255, 255, 255))
     '#FFFFFF'
+    >>> _colorize((0, 32, 128))
+    '#002080'
     """
     t = t[:3]
     i = sum(v * 256 ** (len(t) - i - 1) for i, v in enumerate(t))
-    return "#" + hex(int(i))[2:].upper()
+    h = hex(int(i))[2:].upper()
+    h = '0' * (6 - len(h)) + h
+    return "#" + h


### PR DESCRIPTION
Previously colorize would return results like `#FFFFF` (five Fs) rather than
the result left-padded to six characters `#0FFFFF`.  This provides a fix.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
