### PR TITLE
Fixes slicing list/array issue

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -220,7 +220,7 @@ def fuse_slice(a, b):
     None
     """
     # None only works if the second side is a full slice
-    if a is None and b == slice(None, None):
+    if a is None and isinstance(b, slice) and b == slice(None, None):
         return None
 
     # Replace None with 0 and one in start and step

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -139,6 +139,8 @@ def test_fuse_slice():
 
     with pytest.raises(NotImplementedError):
         fuse_slice(slice(10, 15, 2), -1)
+    with pytest.raises(NotImplementedError):
+        fuse_slice(None, np.array([0, 0]))
 
 
 def test_fuse_slice_with_lists():

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -139,6 +139,7 @@ def test_fuse_slice():
 
     with pytest.raises(NotImplementedError):
         fuse_slice(slice(10, 15, 2), -1)
+    # Regression test for #3076
     with pytest.raises(NotImplementedError):
         fuse_slice(None, np.array([0, 0]))
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Array
 
 - Update error handling when len is called with empty chunks (:issue:`3058`) `Xander Johnson`_
 - Fixes a metadata bug with ``store``'s ``return_stored`` option (:pr:`3064`) `John A Kirkham`_
+- Fix a bug in ``optimization.fuse_slice`` to properly handle when first input is ``None`` (:pr:`3076`) `James Bourbeau`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Fixes #3049. 

It looks like the error in #3049 is caused by the `b == slice(None, None)` comparison in `fuse_slice` when `b` is an `np.ndarray`

https://github.com/dask/dask/blob/b7be7d8007ed7c2b425b5998b85dde60d82052c5/dask/array/optimization.py#L222-L223

This PR adds an additional `instance(b, slice)` check to ensure that `b` is indeed a `slice`.

```python
# None only works if the second side is a full slice
if a is None and isinstance(b, slice) and b == slice(None, None):
```

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
