### PR TITLE
Deprecate `open_text_files`

### DIFF
--- a/dask/bag/text.py
+++ b/dask/bag/text.py
@@ -7,7 +7,7 @@ from toolz import concat
 
 from ..utils import system_encoding
 from ..delayed import delayed
-from ..bytes import open_text_files, read_bytes
+from ..bytes import open_files, read_bytes
 from .core import from_delayed
 
 delayed = delayed(pure=True)
@@ -67,9 +67,9 @@ def read_text(urlpath, blocksize=None, compression='infer',
                      for fn in urlpath], [])
     else:
         if blocksize is None:
-            files = open_text_files(urlpath, encoding=encoding, errors=errors,
-                                    compression=compression,
-                                    **(storage_options or {}))
+            files = open_files(urlpath, mode='rt', encoding=encoding,
+                               errors=errors, compression=compression,
+                               **(storage_options or {}))
             blocks = [delayed(list, pure=True)(delayed(file_to_blocks)(file))
                       for file in files]
 

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -285,7 +285,7 @@ class OpenFile(object):
 
 def open_files(urlpath, mode='rb', compression=None, encoding='utf8',
                errors=None, name_function=None, num=1, **kwargs):
-    """ Given path return dask.delayed file-like objects
+    """ Given a path return file-like objects
 
     Parameters
     ----------
@@ -412,6 +412,8 @@ def open_text_files(urlpath, compression=None, mode='rt', encoding='utf8',
                     errors='strict', **kwargs):
     """ Given path return dask.delayed file-like objects in text mode
 
+    This function is deprecated, use ``open_files(path, mode='rt', ...)``.
+
     Parameters
     ----------
     urlpath: string
@@ -434,6 +436,8 @@ def open_text_files(urlpath, compression=None, mode='rt', encoding='utf8',
     -------
     List of ``dask.delayed`` objects that compute to text file-like objects
     """
+    warn("DeprecationWarning: open_text_files is deprecated, use `open_files` "
+         "with mode='rt' or mode='wt'")
     return open_files(urlpath, mode=mode.replace('b', 't'),
                       compression=compression, encoding=encoding,
                       errors=errors, **kwargs)

--- a/docs/source/bytes.rst
+++ b/docs/source/bytes.rst
@@ -12,17 +12,16 @@ users.*
 .. autosummary::
    read_bytes
    open_files
-   open_text_files
 
 These functions are extensible in their output formats (bytes, file objects),
 their input locations (file system, S3, HDFS), line delimiters, and compression
 formats.
 
 These functions provide data as ``dask.delayed`` objects.  These objects either
-point to blocks of bytes (``read_bytes``) or open file objects (``open_files``,
-``open_text_files``).  They can handle different compression formats by
-prepending protocols like ``s3://`` or ``hdfs://``.  They handle compression
-formats listed in the ``dask.bytes.compression`` module.
+point to blocks of bytes (``read_bytes``) or open file objects
+(``open_files``).  They can handle different compression formats by prepending
+protocols like ``s3://`` or ``hdfs://``.  They handle compression formats
+listed in the ``dask.bytes.compression`` module.
 
 These functions are not used for all data sources.  Some data sources like HDF5
 are quite particular and receive custom treatment.
@@ -74,4 +73,3 @@ Functions
 
 .. autofunction:: read_bytes
 .. autofunction:: open_files
-.. autofunction:: open_text_files

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,6 +22,7 @@ Bag
 Core
 ++++
 
+- Deprecate ``dask.bytes.open_text_files`` (:pr:`3077`) `Jim Crist`_
 -  Change default task ordering to prefer nodes with few dependents and then
    many downstream dependencies (:pr:`3056`) `Matthew Rocklin`_
 -  Add color= option to visualize to color by task order (:pr:`3057`) `Matthew Rocklin`_


### PR DESCRIPTION
This method is only a small wrapper around `open_files`, which is unnecessary and confusing.

Also cleans up a few tests, and removes a few duplicate tests.
