### PR TITLE
Remove `get_block_locations` handling

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,6 +27,8 @@ Core
 -  Change default task ordering to prefer nodes with few dependents and then
    many downstream dependencies (:pr:`3056`) `Matthew Rocklin`_
 -  Add color= option to visualize to color by task order (:pr:`3057`) `Matthew Rocklin`_
+- Remove short-circuit hdfs reads handling due to maintenance costs. May be
+  re-added in a more robust manner later (:pr:`3079`) `Jim Crist`_
 
 
 0.16.1 / 2018-01-09


### PR DESCRIPTION
This was used for short circuit reads from hdfs using libhdfs3, but has
the following problems:

- `hdfs3` specific, other hdfs libraries currently don't expose this
feature. This would be less of an issue if `hdfs3` was a full featured
hdfs library, but due to its lack of handling various security features
other libraries (e.g. `libhdfs`) may be preferable instead (for now).
- This feature complicated testing and code, relying on tests in the
`hdfs3` library that have now started failing (due to lack of being
run).
- The feature wasn't fully thought out in a generic way. If we re-add it
later, we can think about how this might expand to other hdfs clients
(or other potential backends).

This optimization also only comes into play if:
- You have short-circuit reads enabled
- The data you want to read is on the same nodes you're computing on
- The data you want to read is evenly distributed among those nodes
- The scheduler decides it makes sense to read from those nodes instead
of moving the computation elsewhere.