### PR TITLE
Inline ``store_chunk`` calls for ``store``'s ``return_stored`` option

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -892,6 +892,10 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         [e.__dask_keys__() for e in sources]
     )
 
+    keep_lock = False
+    if return_stored and not compute:
+        keep_lock = True
+
     tgt_dsks = []
     store_keys = []
     store_dsks = []
@@ -910,7 +914,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         src = Array(sources_dsk, src.name, src.chunks, src.dtype)
 
         each_store_dsk = insert_to_ooc(
-            src, tgt, lock=lock, region=reg,
+            src, tgt, lock=lock, keep_lock=keep_lock, region=reg,
             return_stored=return_stored
         )
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2644,7 +2644,9 @@ def store_chunk(x, out, index, lock, region, return_stored):
 
     >>> a = np.ones((5, 6))
     >>> b = np.empty(a.shape)
-    >>> store_chunk(a, b, (slice(None), slice(None)), False, None, False)
+    >>> store_chunk(
+    ...     a, b, (slice(None), slice(None)), False, None, False
+    ... )
     """
 
     result = None
@@ -2727,7 +2729,9 @@ def load_chunk(x, index, lock, region):
     --------
 
     >>> a = np.ones((5, 6))
-    >>> load_chunk(a, (slice(None), slice(None)), False, None)  # doctest: +SKIP
+    >>> load_chunk(
+    ...     a, (slice(None), slice(None)), False, None
+    ... )  # doctest: +SKIP
     """
 
     result = None

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -897,6 +897,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
     store_dsks = []
     if return_stored:
         load_names = []
+        load_keys = []
         load_dsks = []
     for tgt, src, reg in zip(targets, sources, regions):
         # if out is a delayed object update dictionary accordingly
@@ -913,11 +914,12 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         )
 
         if return_stored:
+            each_load_dsk = retrieve_from_ooc(
+                each_store_dsk.keys(), each_store_dsk
+            )
             load_names.append('load-store-%s' % src.name)
-            load_dsks.append(retrieve_from_ooc(
-                each_store_dsk.keys(),
-                each_store_dsk
-            ))
+            load_keys.extend(each_load_dsk.keys())
+            load_dsks.append(each_load_dsk)
 
         store_keys.extend(each_store_dsk.keys())
         store_dsks.append(each_store_dsk)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -45,6 +45,7 @@ from .. import threaded, core
 from .. import sharedict
 from ..sharedict import ShareDict
 from .numpy_compat import _Recurser
+from ..optimization import cull, inline
 
 
 concatenate_lookup = Dispatch('concatenate')
@@ -941,7 +942,6 @@ def store(sources, targets, lock=True, regions=None, compute=True,
 
         load_dsks_mrg = sharedict.merge(store_dsks_mrg, *load_dsks)
 
-        from ..optimization import cull, inline
         load_dsks_mrg = cull(inline(load_dsks_mrg, store_keys), load_keys)[0]
 
         result = tuple(

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -936,6 +936,9 @@ def store(sources, targets, lock=True, regions=None, compute=True,
 
         load_dsks_mrg = sharedict.merge(store_dsks_mrg, *load_dsks)
 
+        from ..optimization import cull, inline
+        load_dsks_mrg = cull(inline(load_dsks_mrg, store_keys), load_keys)[0]
+
         result = tuple(
             Array(load_dsks_mrg, ln, s.chunks, s.dtype)
             for ln, s in zip(load_names, sources)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -935,6 +935,8 @@ def store(sources, targets, lock=True, regions=None, compute=True,
     tgt_dsks_mrg = sharedict.merge(*tgt_dsks)
     store_dsks_mrg = sharedict.merge(*store_dsks)
 
+    tgt_dsks_mrg = cull(tgt_dsks_mrg, tgt_keys)[0]
+
     store_dsks_mrg = sharedict.merge(
         store_dsks_mrg, tgt_dsks_mrg, sources_dsk
     )

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2727,7 +2727,7 @@ def insert_to_ooc(arr, out, lock=True, keep_lock=False, region=None,
     return dsk
 
 
-def load_chunk(x, index, lock, kept_lock, region):
+def load_store_chunk(x, index, lock, kept_lock, region):
     """
     A function inserted in a Dask graph for loading a chunk.
 
@@ -2748,7 +2748,7 @@ def load_chunk(x, index, lock, kept_lock, region):
     --------
 
     >>> a = np.ones((5, 6))
-    >>> load_chunk(
+    >>> load_store_chunk(
     ...     a, (slice(None), slice(None)), False, False, None
     ... )  # doctest: +SKIP
     """
@@ -2793,8 +2793,8 @@ def retrieve_from_ooc(keys, dsk):
     load_dsk = dict()
     for k in keys:
         load_key = ('load-%s' % k[0],) + k[1:]
-        # Reuse result and arguments from `store_chunk` in `load_chunk`.
-        load_dsk[load_key] = (load_chunk, k,) + dsk[k][3:-1]
+        # Reuse result and arguments from `store_chunk` in `load_store_chunk`.
+        load_dsk[load_key] = (load_store_chunk, k,) + dsk[k][3:-1]
 
     return load_dsk
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -942,13 +942,14 @@ def store(sources, targets, lock=True, regions=None, compute=True,
     )
 
     if return_stored:
+        load_dsks_mrg = sharedict.merge(*load_dsks)
+
         if compute:
             store_dlyds = [Delayed(k, store_dsks_mrg) for k in store_keys]
             store_dlyds = persist(*store_dlyds)
             store_dsks_mrg = sharedict.merge(*[e.dask for e in store_dlyds])
 
-        load_dsks_mrg = sharedict.merge(store_dsks_mrg, *load_dsks)
-
+        load_dsks_mrg = sharedict.merge(load_dsks_mrg, store_dsks_mrg)
         load_dsks_mrg = cull(inline(load_dsks_mrg, store_keys), load_keys)[0]
 
         result = tuple(

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2791,10 +2791,10 @@ def retrieve_from_ooc(keys, dsk):
     """
 
     load_dsk = dict()
-    for each_key in keys:
-        load_key = ('load-%s' % each_key[0],) + each_key[1:]
-        # Reuse the result and arguments from `store_chunk` in `load_chunk`.
-        load_dsk[load_key] = (load_chunk, each_key,) + dsk[each_key][3:-1]
+    for k in keys:
+        load_key = ('load-%s' % k[0],) + k[1:]
+        # Reuse result and arguments from `store_chunk` in `load_chunk`.
+        load_dsk[load_key] = (load_chunk, k,) + dsk[k][3:-1]
 
     return load_dsk
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -18,12 +18,12 @@ import uuid
 import warnings
 
 try:
-    from cytoolz import (partition, concat, concatv, join, first,
+    from cytoolz import (partition, concat, join, first,
                          groupby, valmap, accumulate, assoc)
     from cytoolz.curried import filter, pluck
 
 except ImportError:
-    from toolz import (partition, concat, concatv, join, first,
+    from toolz import (partition, concat, join, first,
                        groupby, valmap, accumulate, assoc)
     from toolz.curried import filter, pluck
 from toolz import pipe, map, reduce
@@ -931,10 +931,11 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         store_dsks.append(each_store_dsk)
 
     tgt_dsks_mrg = sharedict.merge(*tgt_dsks)
+    store_dsks_mrg = sharedict.merge(*store_dsks)
 
-    store_dsks_mrg = sharedict.merge(*concatv(
-        store_dsks, [tgt_dsks_mrg], [sources_dsk]
-    ))
+    store_dsks_mrg = sharedict.merge(
+        store_dsks_mrg, tgt_dsks_mrg, sources_dsk
+    )
 
     if return_stored:
         if compute:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -897,6 +897,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
     if return_stored and not compute:
         keep_lock = True
 
+    tgt_keys = []
     tgt_dsks = []
     store_keys = []
     store_dsks = []
@@ -909,6 +910,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         try:
             tgt_dsks.append(tgt.dask)
             tgt = tgt.key
+            tgt_keys.append(tgt)
         except AttributeError:
             pass
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -930,8 +930,10 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         store_keys.extend(each_store_dsk.keys())
         store_dsks.append(each_store_dsk)
 
+    tgt_dsks_mrg = sharedict.merge(*tgt_dsks)
+
     store_dsks_mrg = sharedict.merge(*concatv(
-        store_dsks, tgt_dsks, [sources_dsk]
+        store_dsks, [tgt_dsks_mrg], [sources_dsk]
     ))
 
     if return_stored:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -901,11 +901,10 @@ def store(sources, targets, lock=True, regions=None, compute=True,
     for tgt, src, reg in zip(targets, sources, regions):
         # if out is a delayed object update dictionary accordingly
         try:
-            each_tgt_dsk = {}
-            each_tgt_dsk.update(tgt.dask)
+            tgt_dsks.append(tgt.dask)
             tgt = tgt.key
         except AttributeError:
-            each_tgt_dsk = {}
+            pass
 
         src = Array(sources_dsk, src.name, src.chunks, src.dtype)
 
@@ -919,8 +918,6 @@ def store(sources, targets, lock=True, regions=None, compute=True,
                 each_store_dsk.keys(),
                 each_store_dsk
             ))
-
-        tgt_dsks.append(each_tgt_dsk)
 
         store_keys.extend(each_store_dsk.keys())
         store_dsks.append(each_store_dsk)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -910,7 +910,8 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         src = Array(sources_dsk, src.name, src.chunks, src.dtype)
 
         each_store_dsk = insert_to_ooc(
-            src, tgt, lock=lock, region=reg, return_stored=return_stored
+            src, tgt, lock=lock, region=reg,
+            return_stored=return_stored
         )
 
         if return_stored:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1224,6 +1224,7 @@ def test_store_delayed_target():
     assert_eq(bt, b)
 
     # test keeping result
+    targs.clear()
     st = store([a, b], [atd, btd], return_stored=True, compute=False)
     st = dask.compute(*st)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1294,7 +1294,8 @@ def test_store_regions():
     at = np.zeros(shape=(8, 3, 6))
     bt = np.zeros(shape=(8, 4, 6))
     v = store(
-        [a, b], [at, bt], regions=region, compute=False, return_stored=True
+        [a, b], [at, bt], regions=region,
+        compute=False, return_stored=True
     )
     assert isinstance(v, tuple)
     assert all([isinstance(e, da.Array) for e in v])

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1224,24 +1224,25 @@ def test_store_delayed_target():
     assert_eq(bt, b)
 
     # test keeping result
-    targs.clear()
-    st = store([a, b], [atd, btd], return_stored=True, compute=False)
-    st = dask.compute(*st)
+    for st_compute in [False, True]:
+        targs.clear()
+        st = store([a, b], [atd, btd], return_stored=True, compute=st_compute)
+        st = dask.compute(*st)
 
-    at = targs['at']
-    bt = targs['bt']
+        at = targs['at']
+        bt = targs['bt']
 
-    assert st is not None
-    assert isinstance(st, tuple)
-    assert all([isinstance(v, np.ndarray) for v in st])
-    assert_eq(at, a)
-    assert_eq(bt, b)
-    assert_eq(st[0], a)
-    assert_eq(st[1], b)
+        assert st is not None
+        assert isinstance(st, tuple)
+        assert all([isinstance(v, np.ndarray) for v in st])
+        assert_eq(at, a)
+        assert_eq(bt, b)
+        assert_eq(st[0], a)
+        assert_eq(st[1], b)
 
-    pytest.raises(ValueError, lambda: store([a], [at, bt]))
-    pytest.raises(ValueError, lambda: store(at, at))
-    pytest.raises(ValueError, lambda: store([at, bt], [at, bt]))
+        pytest.raises(ValueError, lambda: store([a], [at, bt]))
+        pytest.raises(ValueError, lambda: store(at, at))
+        pytest.raises(ValueError, lambda: store([at, bt], [at, bt]))
 
 
 def test_store():
@@ -1291,58 +1292,60 @@ def test_store_regions():
     assert not (at == 2).all() and not ( at == 0 ).all()
 
     # Single region (keep result):
-    at = np.zeros(shape=(8, 3, 6))
-    bt = np.zeros(shape=(8, 4, 6))
-    v = store(
-        [a, b], [at, bt], regions=region,
-        compute=False, return_stored=True
-    )
-    assert isinstance(v, tuple)
-    assert all([isinstance(e, da.Array) for e in v])
-    assert (at == 0).all() and (bt[region] == 0).all()
+    for st_compute in [False, True]:
+        at = np.zeros(shape=(8, 3, 6))
+        bt = np.zeros(shape=(8, 4, 6))
+        v = store(
+            [a, b], [at, bt], regions=region,
+            compute=st_compute, return_stored=True
+        )
+        assert isinstance(v, tuple)
+        assert all([isinstance(e, da.Array) for e in v])
+        if not st_compute:
+            assert (at == 0).all() and (bt[region] == 0).all()
 
-    ar, br = v
-    assert ar.dtype == a.dtype
-    assert br.dtype == b.dtype
-    assert ar.shape == a.shape
-    assert br.shape == b.shape
-    assert ar.chunks == a.chunks
-    assert br.chunks == b.chunks
+        ar, br = v
+        assert ar.dtype == a.dtype
+        assert br.dtype == b.dtype
+        assert ar.shape == a.shape
+        assert br.shape == b.shape
+        assert ar.chunks == a.chunks
+        assert br.chunks == b.chunks
 
-    ar, br = da.compute(ar, br)
-    assert (at[region] == 2).all() and (bt[region] == 3).all()
-    assert not (bt == 3).all() and not ( bt == 0 ).all()
-    assert not (at == 2).all() and not ( at == 0 ).all()
-    assert (br == 3).all()
-    assert (ar == 2).all()
+        ar, br = da.compute(ar, br)
+        assert (at[region] == 2).all() and (bt[region] == 3).all()
+        assert not (bt == 3).all() and not ( bt == 0 ).all()
+        assert not (at == 2).all() and not ( at == 0 ).all()
+        assert (br == 3).all()
+        assert (ar == 2).all()
 
     # Multiple regions (keep result):
-    at = np.zeros(shape=(8, 3, 6))
-    bt = np.zeros(shape=(8, 4, 6))
-    v = store(
-        [a, b], [at, bt],
-        regions=[region, region],
-        compute=False,
-        return_stored=True
-    )
-    assert isinstance(v, tuple)
-    assert all([isinstance(e, da.Array) for e in v])
-    assert (at == 0).all() and (bt[region] == 0).all()
+    for st_compute in [False, True]:
+        at = np.zeros(shape=(8, 3, 6))
+        bt = np.zeros(shape=(8, 4, 6))
+        v = store(
+            [a, b], [at, bt], regions=[region, region],
+            compute=st_compute, return_stored=True
+        )
+        assert isinstance(v, tuple)
+        assert all([isinstance(e, da.Array) for e in v])
+        if not st_compute:
+            assert (at == 0).all() and (bt[region] == 0).all()
 
-    ar, br = v
-    assert ar.dtype == a.dtype
-    assert br.dtype == b.dtype
-    assert ar.shape == a.shape
-    assert br.shape == b.shape
-    assert ar.chunks == a.chunks
-    assert br.chunks == b.chunks
+        ar, br = v
+        assert ar.dtype == a.dtype
+        assert br.dtype == b.dtype
+        assert ar.shape == a.shape
+        assert br.shape == b.shape
+        assert ar.chunks == a.chunks
+        assert br.chunks == b.chunks
 
-    ar, br = da.compute(ar, br)
-    assert (at[region] == 2).all() and (bt[region] == 3).all()
-    assert not (bt == 3).all() and not ( bt == 0 ).all()
-    assert not (at == 2).all() and not ( at == 0 ).all()
-    assert (br == 3).all()
-    assert (ar == 2).all()
+        ar, br = da.compute(ar, br)
+        assert (at[region] == 2).all() and (bt[region] == 3).all()
+        assert not (bt == 3).all() and not ( bt == 0 ).all()
+        assert not (at == 2).all() and not ( at == 0 ).all()
+        assert (br == 3).all()
+        assert (ar == 2).all()
 
 
 def test_store_compute_false():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1279,6 +1279,17 @@ def test_store_regions():
     assert not (bt == 3).all() and not ( bt == 0 ).all()
     assert not (at == 2).all() and not ( at == 0 ).all()
 
+    # Multiple regions:
+    at = np.zeros(shape=(8, 3, 6))
+    bt = np.zeros(shape=(8, 4, 6))
+    v = store([a, b], [at, bt], regions=[region, region], compute=False)
+    assert isinstance(v, Delayed)
+    assert (at == 0).all() and (bt[region] == 0).all()
+    assert all([ev is None for ev in v.compute()])
+    assert (at[region] == 2).all() and (bt[region] == 3).all()
+    assert not (bt == 3).all() and not ( bt == 0 ).all()
+    assert not (at == 2).all() and not ( at == 0 ).all()
+
     # Single region (keep result):
     at = np.zeros(shape=(8, 3, 6))
     bt = np.zeros(shape=(8, 4, 6))
@@ -1303,17 +1314,6 @@ def test_store_regions():
     assert not (at == 2).all() and not ( at == 0 ).all()
     assert (br == 3).all()
     assert (ar == 2).all()
-
-    # Multiple regions:
-    at = np.zeros(shape=(8, 3, 6))
-    bt = np.zeros(shape=(8, 4, 6))
-    v = store([a, b], [at, bt], regions=[region, region], compute=False)
-    assert isinstance(v, Delayed)
-    assert (at == 0).all() and (bt[region] == 0).all()
-    assert all([ev is None for ev in v.compute()])
-    assert (at[region] == 2).all() and (bt[region] == 3).all()
-    assert not (bt == 3).all() and not ( bt == 0 ).all()
-    assert not (at == 2).all() and not ( at == 0 ).all()
 
     # Multiple regions (keep result):
     at = np.zeros(shape=(8, 3, 6))

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Array
 
 - Update error handling when len is called with empty chunks (:issue:`3058`) `Xander Johnson`_
 - Fixes a metadata bug with ``store``'s ``return_stored`` option (:pr:`3064`) `John A Kirkham`_
+- Inline ``store_chunk`` calls for ``store``'s ``return_stored`` option (:pr:`3082`) `John A Kirkham`_
 - Fix a bug in ``optimization.fuse_slice`` to properly handle when first input is ``None`` (:pr:`3076`) `James Bourbeau`_
 
 DataFrame


### PR DESCRIPTION
Inlines `store_chunk` calls inside `load_chunk` calls for `store` in an attempt to join tasks and reuse resources. This is handled slightly differently depending on whether the `store_chunk` tasks are run immediately or delayed.

In the first case where the `store_chunk` tasks are `persist`ed, the `Future`s are placed in the `load_chunk` calls and the graph is shrinked. Typically `distributed` inlines `Futures` when we submit the job amongst other steps. So doing this inlining in advance is fine. If this is run locally, then the results are inlined instead, which is still ok. This also halves the graph size while still containing all the same information.

In the second case where the `store_chunk` calls are delayed, the function is inlined into `load_chunk`. This should ensure that one task runs both functions one after another. Further the lock is held for the duration of both the `store_chunk` and `load_chunk` tasks. This should avoid some contention over the lock and allow running tasks with the lock to complete without getting blocked by other tasks that could have acquired the lock between `store_chunk` and `load_chunk` tasks previously.

More generally this should simplify the Dask graph a bit and improve performance. Given the effect of this inlining on the graph (and existing nomenclature in the code), we rename `load_chunk` to `load_store_chunk`.

Also improves test coverage of the different options for returning results from `store`.