### PR TITLE
Move hdfs integration and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ log
 *.swp
 *.swo
 .cache/
+hdfs-initialized-indicator

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ install:
   - if [[ $TEST == 'true' ]]; then source continuous_integration/travis/install.sh; fi
 
 script:
-  - if [[ $TEST_HDFS == 'true' ]]; then docker exec -it $CONTAINER_ID py.test dask/bytes/tests/test_hdfs.py -vv; fi
+  - if [[ $TEST_HDFS == 'true' ]]; then source continuous_integration/hdfs/run_tests.sh; fi
   - if [[ $TEST == 'true' ]]; then source continuous_integration/travis/run_tests.sh; fi
   - if [[ $LINT == 'true' ]]; then flake8 dask; fi
   - if [[ $TEST_IMPORTS == 'true' ]]; then source continuous_integration/travis/test_imports.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: trusty
 os: linux
 
 _base_envs:
+  - &test_and_lint TEST='true' LINT='true'
   - &coverage COVERAGE='true' PARALLEL='false'
   - &no_coverage COVERAGE='false' PARALLEL='true'
   - &optimize PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
@@ -18,6 +19,7 @@ jobs:
       - PYTHON=2.7
       - NUMPY=1.12.1
       - PANDAS=0.19.2
+      - *test_and_lint
       - *coverage
       - *no_optimize
       - *no_imports
@@ -26,6 +28,7 @@ jobs:
       - PYTHON=2.7
       - NUMPY=1.13.0
       - PANDAS=0.20.2
+      - *test_and_lint
       - *no_coverage
       - *optimize
       - *no_imports
@@ -34,6 +37,7 @@ jobs:
       - PYTHON=3.4
       - NUMPY=1.10.4
       - PANDAS=0.19.1
+      - *test_and_lint
       - *no_coverage
       - *optimize
       - *no_imports
@@ -43,6 +47,7 @@ jobs:
       - PYTHON=3.5
       - NUMPY=1.12.1
       - PANDAS=0.19.2
+      - *test_and_lint
       - *no_coverage
       - *no_optimize
       - *no_imports
@@ -52,6 +57,7 @@ jobs:
       - UPSTREAM_DEV=1  # Install nightly versions of NumPy, pandas, pyarrow
       - NUMPY=1.13.0    # these are overridden later
       - PANDAS=0.20.3
+      - *test_and_lint
       - *no_coverage
       - *no_optimize
       - *imports
@@ -60,16 +66,31 @@ jobs:
       if: type != pull_request
       os: osx
 
+    - env:
+      - TEST_HDFS='true'
+      if: (type != pull_request) OR (branch =~ __TEST_HDFS__)  # Skip on PRS unless the branch contains __TEST_HDFS__
+      sudo: true
+      services:
+        - docker
+      before_install:
+        - source continuous_integration/hdfs/startup_hdfs.sh
+
   allow_failures:
     - os: osx
 
 
 install:
-  - source continuous_integration/travis/install.sh
+  - |
+    if [[ $TEST_HDFS == 'true' ]]; then
+      docker exec -it $CONTAINER_ID conda install -y -q dask hdfs3 pyarrow -c conda-forge
+      docker exec -it $CONTAINER_ID python setup.py install
+    fi;
+  - if [[ $TEST == 'true' ]]; then source continuous_integration/travis/install.sh; fi
 
 script:
-  - source continuous_integration/travis/run_tests.sh
-  - flake8 dask
+  - if [[ $TEST_HDFS == 'true' ]]; then docker exec -it $CONTAINER_ID py.test dask/bytes/tests/test_hdfs.py -vv; fi
+  - if [[ $TEST == 'true' ]]; then source continuous_integration/travis/run_tests.sh; fi
+  - if [[ $LINT == 'true' ]]; then flake8 dask; fi
   - if [[ $TEST_IMPORTS == 'true' ]]; then source continuous_integration/travis/test_imports.sh; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,11 +80,7 @@ jobs:
 
 
 install:
-  - |
-    if [[ $TEST_HDFS == 'true' ]]; then
-      docker exec -it $CONTAINER_ID conda install -y -q dask hdfs3 pyarrow -c conda-forge
-      docker exec -it $CONTAINER_ID python setup.py install
-    fi;
+  - if [[ $TEST_HDFS == 'true' ]]; then source continuous_integration/hdfs/install.sh; fi
   - if [[ $TEST == 'true' ]]; then source continuous_integration/travis/install.sh; fi
 
 script:

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,12 @@
+import os
 import pytest
+
+# Files to skip doctests in
+SKIP_DOCTESTS = ['dask/bytes/hdfs.py',
+                 'dask/array/fft.py']
+
+curdir = os.path.dirname(__file__)
+skip_doctests = {os.path.join(curdir, p) for p in SKIP_DOCTESTS}
 
 
 def pytest_addoption(parser):
@@ -11,5 +19,5 @@ def pytest_runtest_setup(item):
 
 
 def pytest_ignore_collect(path, config):
-    if 'run_test.py' in str(path):
-        return True
+    path = str(path)
+    return 'run_test.py' in path or path in skip_doctests

--- a/continuous_integration/hdfs/Dockerfile
+++ b/continuous_integration/hdfs/Dockerfile
@@ -32,6 +32,9 @@ RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -
 
 ENV PATH /opt/conda/bin:$PATH
 
+# Notifies the dask tests to run
+ENV DASK_RUN_HDFS_TESTS true
+
 EXPOSE 8020 50070
 
 VOLUME /working

--- a/continuous_integration/hdfs/Dockerfile
+++ b/continuous_integration/hdfs/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:trusty
+
+RUN apt-get update && \
+    apt-get install -y -q curl bzip2 git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install CDH5 in a single node: Pseudo Distributed
+# Docs: http://www.cloudera.com/content/www/en-us/documentation/enterprise/latest/topics/cdh_qs_yarn_pseudo.html
+ADD docker-files/cloudera.pref /etc/apt/preferences.d/cloudera.pref
+RUN curl -s http://archive.cloudera.com/cdh5/ubuntu/trusty/amd64/cdh/archive.key | apt-key add - && \
+    echo 'deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/trusty/amd64/cdh trusty-cdh5 contrib' > /etc/apt/sources.list.d/cloudera.list && \
+    echo 'deb-src http://archive.cloudera.com/cdh5/ubuntu/trusty/amd64/cdh trusty-cdh5 contrib' >> /etc/apt/sources.list.d/cloudera.list && \
+    apt-get update && \
+    apt-get install -y -q openjdk-7-jre-headless hadoop-conf-pseudo && \
+    sudo -u hdfs hdfs namenode -format -force && \
+    for x in `cd /etc/init.d ; ls hadoop-hdfs-*` ; do sudo service $x start ; done && \
+    bash /usr/lib/hadoop/libexec/init-hdfs.sh && \
+    rm -rf /var/lib/apt/lists/*
+
+# Needed for hdfs3
+ENV LIBHDFS3_CONF /etc/hadoop/conf/hdfs-site.xml
+
+# Install conda & build conda environments:
+# py35 is root environment
+# py27 gets own environment
+RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh && \
+    /bin/bash /tmp/miniconda.sh -b -p /opt/conda && \
+    rm /tmp/miniconda.sh && \
+    /opt/conda/bin/conda install -y -q libhdfs3 pytest flake8 -c conda-forge && \
+    /opt/conda/bin/conda create -y -n py27 python=2.7 && \
+    /opt/conda/bin/conda install -y -q -n py27 libhdfs3 pytest -c conda-forge
+
+ENV PATH /opt/conda/bin:$PATH
+
+EXPOSE 8020 50070
+
+VOLUME /working
+WORKDIR /working
+
+ADD docker-files/start.sh /tmp/start.sh
+CMD ["bash", "/tmp/start.sh", "-d"]

--- a/continuous_integration/hdfs/README.md
+++ b/continuous_integration/hdfs/README.md
@@ -1,4 +1,19 @@
-# Setting up hdfs testing using docker
+## HDFS testing on Travis CI
+
+Dask & HDFS testing relies on a docker container. The tests are setup to run on
+Travis CI, but only under the following conditions:
+
+- Merges to master
+- PRs where the branch name contains the string `"__TEST_HDFS__"`
+
+If you make a PR changing HDFS functionality it'd be good to have the HDFS
+tests run, please add `"__TEST_HDFS__"` to the end of your branch name.
+
+If you've already made a PR (and thus can't change the branch name), you can
+temporarily comment out the `if:` configuration in the `.travis.yml` for the
+HDFS tests.
+
+## Setting up HDFS testing locally using Docker
 
 Assumes docker is already installed and the docker-daemon is running.
 
@@ -20,6 +35,12 @@ docker build -t daskdev/dask-hdfs-testing continuous_integration/hdfs/
 source continuous_integration/hdfs/startup_hdfs.sh
 ```
 
+- Install dependencies and dask on the container
+
+```bash
+source continuous_integration/hdfs/install.sh
+```
+
 - Start a bash session in the running container:
 
 ```bash
@@ -30,10 +51,9 @@ export CONTAINER_ID=$(docker ps -l -q)
 docker exec -it $CONTAINER_ID bash
 ```
 
-- Install the library and run the tests
+- Run the tests
 
 ```bash
-python setup.py install
 # Test just the hdfs tests
 py.test dask/bytes/tests/test_hdfs.py -s -vv
 ```

--- a/continuous_integration/hdfs/README.md
+++ b/continuous_integration/hdfs/README.md
@@ -41,7 +41,14 @@ source continuous_integration/hdfs/startup_hdfs.sh
 source continuous_integration/hdfs/install.sh
 ```
 
-- Start a bash session in the running container:
+- Run the tests
+
+```bash
+source continuous_integration/hdfs/run_tests.sh
+```
+
+- Alternatively, you can start a terminal on the container and run the tests
+  manually. This can be nicer for debugging:
 
 ```bash
 # CONTAINER_ID should be defined from above, but if it isn't you can get it from
@@ -49,11 +56,7 @@ export CONTAINER_ID=$(docker ps -l -q)
 
 # Start the bash session
 docker exec -it $CONTAINER_ID bash
-```
 
-- Run the tests
-
-```bash
 # Test just the hdfs tests
 py.test dask/bytes/tests/test_hdfs.py -s -vv
 ```

--- a/continuous_integration/hdfs/README.md
+++ b/continuous_integration/hdfs/README.md
@@ -1,0 +1,39 @@
+# Setting up hdfs testing using docker
+
+Assumes docker is already installed and the docker-daemon is running.
+
+From the root directory in the repo:
+
+- First get the docker container:
+
+```bash
+# Either pull it from docker hub
+docker pull daskdev/dask-hdfs-testing
+
+# Or build it locally
+docker build -t daskdev/dask-hdfs-testing continuous_integration/hdfs/
+```
+
+- Start the container and wait for it to be ready:
+
+```bash
+source continuous_integration/hdfs/startup_hdfs.sh
+```
+
+- Start a bash session in the running container:
+
+```bash
+# CONTAINER_ID should be defined from above, but if it isn't you can get it from
+export CONTAINER_ID=$(docker ps -l -q)
+
+# Start the bash session
+docker exec -it $CONTAINER_ID bash
+```
+
+- Install the library and run the tests
+
+```bash
+python setup.py install
+# Test just the hdfs tests
+py.test dask/bytes/tests/test_hdfs.py -s -vv
+```

--- a/continuous_integration/hdfs/docker-files/cloudera.pref
+++ b/continuous_integration/hdfs/docker-files/cloudera.pref
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=Cloudera, l=Cloudera
+Pin-Priority: 501

--- a/continuous_integration/hdfs/docker-files/start.sh
+++ b/continuous_integration/hdfs/docker-files/start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Start HDFS
+sudo service hadoop-hdfs-namenode start
+sudo service hadoop-hdfs-datanode start
+
+echo "HDFS Started"
+
+if [[ $1 == "-d" ]]; then
+    # Running as a daemon, indicate to host that hdfs is started
+    touch /working/hdfs-initialized-indicator
+    sleep infinity
+fi
+
+if [[ $1 == "-bash" ]]; then
+    /bin/bash
+fi

--- a/continuous_integration/hdfs/install.sh
+++ b/continuous_integration/hdfs/install.sh
@@ -1,0 +1,2 @@
+docker exec -it $CONTAINER_ID conda install -y -q dask hdfs3 pyarrow -c conda-forge
+docker exec -it $CONTAINER_ID python setup.py install

--- a/continuous_integration/hdfs/install.sh
+++ b/continuous_integration/hdfs/install.sh
@@ -1,2 +1,2 @@
 docker exec -it $CONTAINER_ID conda install -y -q dask hdfs3 pyarrow -c conda-forge
-docker exec -it $CONTAINER_ID python setup.py install
+docker exec -it $CONTAINER_ID pip install -e .

--- a/continuous_integration/hdfs/run_tests.sh
+++ b/continuous_integration/hdfs/run_tests.sh
@@ -1,0 +1,1 @@
+docker exec -it $CONTAINER_ID py.test dask/bytes/tests/test_hdfs.py -vv

--- a/continuous_integration/hdfs/startup_hdfs.sh
+++ b/continuous_integration/hdfs/startup_hdfs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+HOSTDIR=$(pwd)
+INIT_MARKER=$HOSTDIR/hdfs-initialized-indicator
+
+# Remove initialization marker
+rm -f $INIT_MARKER
+
+# Start the hdfs service
+echo "Starting Docker Container..."
+CONTAINER_ID=$(docker run -d -p 8020:8020 -p 50070:50070 -v $(pwd):/working daskdev/dask-hdfs-testing)
+export CONTAINER_ID
+
+# Error immediately if this fails
+if [ $? -ne 0 ]; then
+    echo "Failed starting HDFS container"
+    exit 1
+fi
+echo "DONE"
+
+# Wait for initialization
+CHECK_RUNNING="docker top $CONTAINER_ID"
+while [[ $($CHECK_RUNNING) ]] && [[ ! -f $INIT_MARKER ]]
+do
+    sleep 1
+done
+
+# Error out if the container failed starting
+if [[ ! $($CHECK_RUNNING) ]]; then
+    echo "HDFS startup failed! Logs follow"
+    echo "-------------------------------------------------"
+    docker logs $CONTAINER_ID
+    echo "-------------------------------------------------"
+    exit 1
+fi
+
+echo "Started HDFS container: $CONTAINER_ID"

--- a/continuous_integration/hdfs/startup_hdfs.sh
+++ b/continuous_integration/hdfs/startup_hdfs.sh
@@ -8,7 +8,7 @@ rm -f $INIT_MARKER
 
 # Start the hdfs service
 echo "Starting Docker Container..."
-CONTAINER_ID=$(docker run -d -p 8020:8020 -p 50070:50070 -v $(pwd):/working daskdev/dask-hdfs-testing)
+CONTAINER_ID=$(docker run -d -v $(pwd):/working daskdev/dask-hdfs-testing)
 export CONTAINER_ID
 
 # Error immediately if this fails

--- a/dask/array/conftest.py
+++ b/dask/array/conftest.py
@@ -1,6 +1,0 @@
-import os
-
-
-def pytest_ignore_collect(path, config):
-    if os.path.split(str(path))[1].startswith("fft.py"):
-        return True

--- a/dask/bytes/__init__.py
+++ b/dask/bytes/__init__.py
@@ -4,6 +4,3 @@ from ..utils import ignoring
 from .core import read_bytes, open_files, open_text_files
 
 from . import local
-
-with ignoring(ImportError, SyntaxError):
-    from . import s3

--- a/dask/bytes/_pyarrow.py
+++ b/dask/bytes/_pyarrow.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+import pyarrow as pa
+
+
+class HDFS3Wrapper(pa.filesystem.DaskFileSystem):
+    """Pyarrow compatibility wrapper class"""
+    def isdir(self, path):
+        return self.fs.isdir(path)
+
+    def isfile(self, path):
+        return self.fs.isfile(path)

--- a/dask/bytes/conftest.py
+++ b/dask/bytes/conftest.py
@@ -1,5 +1,0 @@
-import os
-
-def pytest_ignore_collect(path, config):
-    if os.path.split(str(path))[1].startswith("hdfs.py"):
-        return True

--- a/dask/bytes/conftest.py
+++ b/dask/bytes/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+def pytest_ignore_collect(path, config):
+    if os.path.split(str(path))[1].startswith("hdfs.py"):
+        return True

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 import io
 import os
-from distutils.version import LooseVersion
 from warnings import warn
 
 from toolz import merge
@@ -471,6 +470,7 @@ def get_fs(protocol, storage_options=None):
                         "    conda install s3fs -c conda-forge\n"
                         "    or\n"
                         "    pip install s3fs")
+        import dask.bytes.s3  # noqa, register the s3 backend
 
     elif protocol in ('gs', 'gcs'):
         import_required('gcsfs',
@@ -480,12 +480,10 @@ def get_fs(protocol, storage_options=None):
                         "    pip install gcsfs")
 
     elif protocol == 'hdfs':
-        msg = ("Need to install `hdfs3 > 0.2.0` for HDFS support\n"
-               "    conda install hdfs3 -c conda-forge")
-        hdfs3 = import_required('hdfs3', msg)
-        if not LooseVersion(hdfs3.__version__) > '0.2.0':
-            raise RuntimeError(msg)
-        import hdfs3.dask  # register dask filesystem
+        import_required('hdfs3',
+                        "Need to install `hdfs3` library for hdfs support\n"
+                        "    conda install s3fs -c conda-forge")
+        import dask.bytes.hdfs  # noqa, register the hdfs3 backend
 
     if protocol in _filesystems:
         cls = _filesystems[protocol]

--- a/dask/bytes/hdfs.py
+++ b/dask/bytes/hdfs.py
@@ -1,0 +1,26 @@
+from __future__ import print_function, division, absolute_import
+
+from ..base import tokenize
+from .core import _filesystems
+
+from hdfs3.core import HDFileSystem
+
+
+class DaskHDFS3FileSystem(HDFileSystem):
+    sep = '/'
+
+    def mkdirs(self, path):
+        return super(DaskHDFS3FileSystem, self).makedirs(path)
+
+    def ukey(self, path):
+        return tokenize(path, self.info(path)['last_mod'])
+
+    def size(self, path):
+        return self.info(path)['size']
+
+    def _get_pyarrow_filesystem(self):
+        from ._pyarrow import HDFS3Wrapper
+        return HDFS3Wrapper(self)
+
+
+_filesystems['hdfs'] = DaskHDFS3FileSystem

--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -1,24 +1,12 @@
 from __future__ import print_function, division, absolute_import
 
-import json
 import os
-import sys
-from contextlib import contextmanager
 
 import pytest
 
-if not os.environ.get('DASK_RUN_HDFS_TESTS', ''):
-    pytestmark = pytest.mark.skip(reason="HDFS tests not configured to run")
-
 hdfs3 = pytest.importorskip('hdfs3')
-pytest.importorskip('distributed')
 
-from distributed import Client
-from distributed.client import wait, Future
-from distributed.utils import get_ip
-from distributed.utils_test import gen_cluster, loop
 from toolz import concat
-from tornado import gen
 
 import dask
 from dask import delayed
@@ -27,312 +15,150 @@ from dask.bytes.hdfs import DaskHDFS3FileSystem
 from dask.compatibility import unicode
 
 
-loop = loop  # squash flake8 errors
+if not os.environ.get('DASK_RUN_HDFS_TESTS', ''):
+    pytestmark = pytest.mark.skip(reason="HDFS tests not configured to run")
 
-ip = get_ip()
+
+basedir = '/tmp/test-dask'
 
 
-@contextmanager
-def make_hdfs():
-    basedir = '/tmp/test-dask'
+@pytest.fixture
+def hdfs():
     hdfs = hdfs3.HDFileSystem(host='localhost', port=8020)
     if hdfs.exists(basedir):
         hdfs.rm(basedir)
     hdfs.mkdir(basedir)
 
-    try:
-        yield hdfs, basedir
-    finally:
-        if hdfs.exists(basedir):
-            hdfs.rm(basedir)
+    yield hdfs
+
+    if hdfs.exists(basedir):
+        hdfs.rm(basedir)
 
 
-def cluster(*args, **kwargs):
-    from distributed.utils_test import cluster
-    if sys.version_info.major < 3 and not sys.platform.startswith('win'):
-        pytest.skip("hdfs3 is not fork safe, test can hang on Python 2")
-    return cluster(*args, **kwargs)
+def test_read_bytes(hdfs):
+    nfiles = 10
 
+    data = b'a' * int(1e3)
 
-@gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
-def test_read_bytes(c, s, a, b):
-    with make_hdfs() as (hdfs, basedir):
-        data = b'a' * int(1e8)
-        fn = '%s/file' % basedir
-
+    for fn in ['%s/file.%d' % (basedir, i) for i in range(nfiles)]:
         with hdfs.open(fn, 'wb', replication=1) as f:
             f.write(data)
 
-        sample, values = read_bytes('hdfs://' + fn)
-        assert sample[:5] == b'aaaaa'
-
-        futures = c.compute(values[0])
-        results = yield c._gather(futures)
-        assert b''.join(results) == data
+    sample, values = read_bytes('hdfs://%s/file.*' % basedir)
+    (results,) = dask.compute(values)
+    assert [b''.join(r) for r in results] == nfiles * [data]
 
 
-@pytest.mark.parametrize('nworkers', [1, 3])
-def test_read_bytes_sync(loop, nworkers):
-    with cluster(nworkers=nworkers) as (s, workers):
-        with make_hdfs() as (hdfs, basedir):
-            data = b'a' * int(1e3)
+def test_read_bytes_URL(hdfs):
+    nfiles = 10
+    data = b'a' * int(1e3)
 
-            for fn in ['%s/file.%d' % (basedir, i) for i in range(100)]:
-                with hdfs.open(fn, 'wb', replication=1) as f:
-                    f.write(data)
+    for fn in ['%s/file.%d' % (basedir, i) for i in range(nfiles)]:
+        with hdfs.open(fn, 'wb', replication=1) as f:
+            f.write(data)
 
-            with Client(s['address'], loop=loop):
-                sample, values = read_bytes('hdfs://%s/file.*' % basedir)
-                results = delayed(values).compute()
-                assert [b''.join(r) for r in results] == 100 * [data]
+    path = 'hdfs://localhost:8020%s/file.*' % basedir
+    sample, values = read_bytes(path)
+    (results,) = dask.compute(values)
+    assert [b''.join(r) for r in results] == nfiles * [data]
 
 
-def test_read_bytes_sync_URL(loop, nworkers=1):
-    with cluster(nworkers=nworkers) as (s, workers):
-        with make_hdfs() as (hdfs, basedir):
-            data = b'a' * int(1e3)
+def test_read_bytes_big_file(hdfs):
+    fn = '%s/file' % basedir
 
-            for fn in ['%s/file.%d' % (basedir, i) for i in range(100)]:
-                with hdfs.open(fn, 'wb', replication=1) as f:
-                    f.write(data)
+    # Write 100 MB file
+    nblocks = int(1e3)
+    blocksize = int(1e5)
+    data = b'a' * blocksize
+    with hdfs.open(fn, 'wb', replication=1) as f:
+        for i in range(nblocks):
+            f.write(data)
 
-            with Client(s['address'], loop=loop):
-                path = 'hdfs://localhost:8020%s/file.*' % basedir
-                sample, values = read_bytes(path)
-                results = delayed(values).compute()
-                assert [b''.join(r) for r in results] == 100 * [data]
+    sample, values = read_bytes('hdfs://' + fn, blocksize=blocksize)
+    assert sample[:5] == b'aaaaa'
+    assert len(values[0]) == nblocks
 
-
-@gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
-def test_deterministic_key_names(e, s, a, b):
-    with make_hdfs() as (hdfs, basedir):
-        data = b'abc\n' * int(1e3)
-        fn = '%s/file' % basedir
-
-        with hdfs.open(fn, 'wb', replication=1) as fil:
-            fil.write(data)
-
-        _, x = read_bytes('hdfs://%s/*' % basedir, delimiter=b'\n')
-        _, y = read_bytes('hdfs://%s/*' % basedir, delimiter=b'\n')
-        _, z = read_bytes('hdfs://%s/*' % basedir, delimiter=b'c')
-
-        assert [f.key for f in concat(x)] == [f.key for f in concat(y)]
-        assert [f.key for f in concat(x)] != [f.key for f in concat(z)]
+    (results,) = dask.compute(values[0])
+    assert sum(map(len, results)) == nblocks * blocksize
+    for r in results:
+        assert set(r.decode('utf-8')) == {'a'}
 
 
-@gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
-def test_write_bytes(c, s, a, b):
-    with make_hdfs() as (hdfs, basedir):
-        hdfs.mkdir('%s/data/' % basedir)
-        data = [b'123', b'456', b'789']
-        remote_data = yield c._scatter(data)
+def test_deterministic_key_names(hdfs):
+    data = b'abc\n' * int(1e3)
+    fn = '%s/file' % basedir
 
-        futures = c.compute(write_bytes(remote_data,
-                                        'hdfs://%s/data/file.*.dat' % basedir))
-        yield wait(futures)
+    with hdfs.open(fn, 'wb', replication=1) as fil:
+        fil.write(data)
 
-        yield futures[0]
+    _, x = read_bytes('hdfs://%s/*' % basedir, delimiter=b'\n')
+    _, y = read_bytes('hdfs://%s/*' % basedir, delimiter=b'\n')
+    _, z = read_bytes('hdfs://%s/*' % basedir, delimiter=b'c')
 
-        assert len(hdfs.ls('%s/data/' % basedir)) == 3
-        with hdfs.open('%s/data/file.1.dat' % basedir) as f:
-            assert f.read() == b'456'
-
-        hdfs.mkdir('%s/data2/' % basedir)
-        futures = c.compute(write_bytes(remote_data,
-                                        'hdfs://%s/data2/' % basedir))
-        yield wait(futures)
-
-        assert len(hdfs.ls('%s/data2/' % basedir)) == 3
+    assert [f.key for f in concat(x)] == [f.key for f in concat(y)]
+    assert [f.key for f in concat(x)] != [f.key for f in concat(z)]
 
 
-@gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
-def test_write_bytes_2(c, s, a, b):
-    with make_hdfs() as (hdfs, basedir):
-        path = 'hdfs://%s/' % basedir
-        data = [b'test data %i' % i for i in range(5)]
-        values = [delayed(d) for d in data]
-        out = write_bytes(values, path)
-        futures = c.compute(out)
-        results = yield c._gather(futures)
-        assert len(hdfs.ls(basedir)) == 5
+def test_write_bytes(hdfs):
+    path = 'hdfs://%s/' % basedir
+    data = [b'test data %i' % i for i in range(5)]
+    values = write_bytes([delayed(d) for d in data], path)
+    dask.compute(values)
+    assert len(hdfs.ls(basedir)) == 5
 
-        sample, vals = read_bytes('hdfs://%s/*.part' % basedir)
-        futures = c.compute(list(concat(vals)))
-        results = yield c._gather(futures)
-        assert data == results
+    sample, vals = read_bytes('hdfs://%s/*.part' % basedir)
+    (results,) = dask.compute(list(concat(vals)))
+    assert data == results
 
 
-def test_read_csv_sync(loop):
-    dd = pytest.importorskip('dask.dataframe')
-    import pandas as pd
-
-    with cluster(nworkers=3) as (s, [a, b, c]):
-        with make_hdfs() as (hdfs, basedir):
-            with hdfs.open('%s/1.csv' % basedir, 'wb') as f:
-                f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
-
-            with hdfs.open('%s/2.csv' % basedir, 'wb') as f:
-                f.write(b'name,amount,id\nCharlie,300,3\nDennis,400,4')
-
-            with Client(s['address'], loop=loop) as e:
-                values = dd.read_csv('hdfs://%s/*.csv' % basedir,
-                                     lineterminator='\n',
-                                     collection=False, header=0)
-                futures = e.compute(values)
-                assert all(isinstance(f, Future) for f in futures)
-                L = e.gather(futures)
-                assert isinstance(L[0], pd.DataFrame)
-                assert list(L[0].columns) == ['name', 'amount', 'id']
-
-                df = dd.read_csv('hdfs://%s/*.csv' % basedir,
-                                 lineterminator='\n',
-                                 collection=True, header=0)
-                assert isinstance(df, dd.DataFrame)
-                assert list(df.head().iloc[0]) == ['Alice', 100, 1]
-
-
-def test_read_csv_sync_compute(loop):
+def test_read_csv(hdfs):
     dd = pytest.importorskip('dask.dataframe')
 
-    with cluster(nworkers=1) as (s, [a]):
-        with make_hdfs() as (hdfs, basedir):
-            with hdfs.open('%s/1.csv' % basedir, 'wb') as f:
-                f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
+    with hdfs.open('%s/1.csv' % basedir, 'wb') as f:
+        f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
 
-            with hdfs.open('%s/2.csv' % basedir, 'wb') as f:
-                f.write(b'name,amount,id\nCharlie,300,3\nDennis,400,4')
+    with hdfs.open('%s/2.csv' % basedir, 'wb') as f:
+        f.write(b'name,amount,id\nCharlie,300,3\nDennis,400,4')
 
-            with Client(s['address'], loop=loop) as e:
-                df = dd.read_csv('hdfs://%s/*.csv' % basedir, collection=True)
-                assert df.amount.sum().compute(get=e.get) == 1000
+    df = dd.read_csv('hdfs://%s/*.csv' % basedir)
+    assert isinstance(df, dd.DataFrame)
+    assert df.id.sum() == 1 + 2 + 3 + 4
 
 
-@gen_cluster([(ip, 1), (ip, 1)], timeout=60, client=True)
-def test_read_csv(e, s, a, b):
-    dd = pytest.importorskip('dask.dataframe')
-
-    with make_hdfs() as (hdfs, basedir):
-        with hdfs.open('%s/1.csv' % basedir, 'wb') as f:
-            f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
-
-        with hdfs.open('%s/2.csv' % basedir, 'wb') as f:
-            f.write(b'name,amount,id\nCharlie,300,3\nDennis,400,4')
-
-        df = dd.read_csv('hdfs://%s/*.csv' % basedir, lineterminator='\n')
-        result = e.compute(df.id.sum(), sync=False)
-        result = yield result
-        assert result == 1 + 2 + 3 + 4
-
-
-@gen_cluster([(ip, 1), (ip, 1)], timeout=60, client=True)
-def test_read_csv_with_names(e, s, a, b):
-    dd = pytest.importorskip('dask.dataframe')
-
-    with make_hdfs() as (hdfs, basedir):
-        with hdfs.open('%s/1.csv' % basedir, 'wb') as f:
-            f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
-
-        df = dd.read_csv('hdfs://%s/*.csv' % basedir,
-                         names=['amount', 'name'],
-                         lineterminator='\n')
-        assert list(df.columns) == ['amount', 'name']
-
-
-@gen_cluster([(ip, 1), (ip, 1)], timeout=60, client=True)
-def test_read_csv_lazy(e, s, a, b):
-    dd = pytest.importorskip('dask.dataframe')
-
-    with make_hdfs() as (hdfs, basedir):
-        with hdfs.open('%s/1.csv' % basedir, 'wb') as f:
-            f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
-
-        with hdfs.open('%s/2.csv' % basedir, 'wb') as f:
-            f.write(b'name,amount,id\nCharlie,300,3\nDennis,400,4')
-
-        df = dd.read_csv('hdfs://%s/*.csv' % basedir, lineterminator='\n')
-        yield gen.sleep(0.5)
-        assert not s.tasks
-
-        result = yield e.compute(df.id.sum(), sync=False)
-        assert result == 1 + 2 + 3 + 4
-
-
-@gen_cluster([(ip, 1), (ip, 1)], timeout=60, client=True)
-def test_read_text(c, s, a, b):
+def test_read_text(hdfs):
     db = pytest.importorskip('dask.bag')
 
-    with make_hdfs() as (hdfs, basedir):
-        with hdfs.open('%s/text.1.txt' % basedir, 'wb') as f:
-            f.write('Alice 100\nBob 200\nCharlie 300'.encode())
+    with hdfs.open('%s/text.1.txt' % basedir, 'wb') as f:
+        f.write('Alice 100\nBob 200\nCharlie 300'.encode())
 
-        with hdfs.open('%s/text.2.txt' % basedir, 'wb') as f:
-            f.write('Dan 400\nEdith 500\nFrank 600'.encode())
+    with hdfs.open('%s/text.2.txt' % basedir, 'wb') as f:
+        f.write('Dan 400\nEdith 500\nFrank 600'.encode())
 
-        with hdfs.open('%s/other.txt' % basedir, 'wb') as f:
-            f.write('a b\nc d'.encode())
+    b = db.read_text('hdfs://%s/text.*.txt' % basedir)
+    result = b.str.strip().str.split().map(len).compute()
+    assert result == [2, 2, 2, 2, 2, 2]
 
-        b = db.read_text('hdfs://%s/text.*.txt' % basedir)
-        yield gen.sleep(0.5)
-        assert not s.tasks
+    with hdfs.open('%s/other.txt' % basedir, 'wb') as f:
+        f.write('a b\nc d'.encode())
 
-        b.compute(get=dask.get)
-
-        coll = b.str.strip().str.split().map(len)
-
-        future = c.compute(coll)
-        yield gen.sleep(0.5)
-        result = yield future
-        assert result == [2, 2, 2, 2, 2, 2]
-
-        b = db.read_text('hdfs://%s/other.txt' % basedir)
-        b = c.persist(b)
-        future = c.compute(b.str.split().flatten())
-        result = yield future
-        assert result == ['a', 'b', 'c', 'd']
+    b = db.read_text('hdfs://%s/other.txt' % basedir)
+    result = b.str.split().flatten().compute()
+    assert result == ['a', 'b', 'c', 'd']
 
 
-@gen_cluster([(ip, 1)], timeout=60, client=True)
-def test_read_text_json_endline(e, s, a):
-    db = pytest.importorskip('dask.bag')
-
-    with make_hdfs() as (hdfs, basedir):
-        with hdfs.open('%s/text.1.txt' % basedir, 'wb') as f:
-            f.write(b'{"x": 1}\n{"x": 2}\n')
-
-        b = db.read_text('hdfs://%s/text.1.txt' % basedir).map(json.loads)
-        result = yield e.compute(b)
-
-        assert result == [{"x": 1}, {"x": 2}]
-
-
-@gen_cluster([(ip, 1), (ip, 1)], timeout=60, client=True)
-def test_read_text_unicode(e, s, a, b):
+def test_read_text_unicode(hdfs):
     db = pytest.importorskip('dask.bag')
 
     data = b'abcd\xc3\xa9'
-    with make_hdfs() as (hdfs, basedir):
-        fn = '%s/data.txt' % basedir
-        with hdfs.open(fn, 'wb') as f:
-            f.write(b'\n'.join([data, data]))
+    fn = '%s/data.txt' % basedir
+    with hdfs.open(fn, 'wb') as f:
+        f.write(b'\n'.join([data, data]))
 
-        f = db.read_text('hdfs://' + fn, collection=False)
-        result = yield e.compute(f[0])
-        assert len(result) == 2
-        assert list(map(unicode.strip, result)) == [data.decode('utf-8')] * 2
-        assert len(result[0].strip()) == 5
-
-
-def test_read_text_sync(loop):
-    db = pytest.importorskip('dask.bag')
-
-    with make_hdfs() as (hdfs, basedir):
-        with hdfs.open('%s/data.txt' % basedir, 'wb') as f:
-            f.write(b'hello\nworld')
-
-        with cluster(nworkers=3) as (s, [a, b, c]):
-            with Client(s['address'], loop=loop):
-                b = db.read_text('hdfs://%s/*.txt' % basedir)
-                assert list(b.str.strip().str.upper()) == ['HELLO', 'WORLD']
+    f = db.read_text('hdfs://' + fn, collection=False)
+    result = f[0].compute()
+    assert len(result) == 2
+    assert list(map(unicode.strip, result)) == [data.decode('utf-8')] * 2
+    assert len(result[0].strip()) == 5
 
 
 def test_pyarrow_compat():
@@ -342,23 +168,20 @@ def test_pyarrow_compat():
     assert isinstance(pa_hdfs, pa.filesystem.FileSystem)
 
 
-def test_parquet_pyarrow(loop):
+def test_parquet_pyarrow(hdfs):
     pytest.importorskip('pyarrow')
     dd = pytest.importorskip('dask.dataframe')
     import pandas as pd
     import numpy as np
 
-    with make_hdfs() as (hdfs, basedir):
-        fn = '%s/test.parquet' % basedir
-        hdfs_fn = 'hdfs://%s' % fn
-        df = pd.DataFrame(np.random.normal(size=(1000, 4)),
-                          columns=list('abcd'))
-        ddf = dd.from_pandas(df, npartitions=4)
+    fn = '%s/test.parquet' % basedir
+    hdfs_fn = 'hdfs://%s' % fn
+    df = pd.DataFrame(np.random.normal(size=(1000, 4)),
+                      columns=list('abcd'))
+    ddf = dd.from_pandas(df, npartitions=4)
 
-        with cluster(nworkers=1) as (s, [a]):
-            with Client(s['address'], loop=loop):
-                ddf.to_parquet(hdfs_fn, engine='pyarrow')
-                assert len(hdfs.ls(fn))  # Files are written
+    ddf.to_parquet(hdfs_fn, engine='pyarrow')
+    assert len(hdfs.ls(fn))  # Files are written
 
-                ddf2 = dd.read_parquet(hdfs_fn, engine='pyarrow')
-                assert len(ddf2) == 1000  # smoke test on read
+    ddf2 = dd.read_parquet(hdfs_fn, engine='pyarrow')
+    assert len(ddf2) == 1000  # smoke test on read

--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -1,0 +1,364 @@
+from __future__ import print_function, division, absolute_import
+
+import json
+import os
+import sys
+from contextlib import contextmanager
+
+import pytest
+
+if not os.environ.get('DASK_RUN_HDFS_TESTS', ''):
+    pytestmark = pytest.mark.skip(reason="HDFS tests not configured to run")
+
+hdfs3 = pytest.importorskip('hdfs3')
+pytest.importorskip('distributed')
+
+from distributed import Client
+from distributed.client import wait, Future
+from distributed.utils import get_ip
+from distributed.utils_test import gen_cluster, loop
+from toolz import concat
+from tornado import gen
+
+import dask
+from dask import delayed
+from dask.bytes.core import read_bytes, write_bytes
+from dask.bytes.hdfs import DaskHDFS3FileSystem
+from dask.compatibility import unicode
+
+
+loop = loop  # squash flake8 errors
+
+ip = get_ip()
+
+
+@contextmanager
+def make_hdfs():
+    basedir = '/tmp/test-dask'
+    hdfs = hdfs3.HDFileSystem(host='localhost', port=8020)
+    if hdfs.exists(basedir):
+        hdfs.rm(basedir)
+    hdfs.mkdir(basedir)
+
+    try:
+        yield hdfs, basedir
+    finally:
+        if hdfs.exists(basedir):
+            hdfs.rm(basedir)
+
+
+def cluster(*args, **kwargs):
+    from distributed.utils_test import cluster
+    if sys.version_info.major < 3 and not sys.platform.startswith('win'):
+        pytest.skip("hdfs3 is not fork safe, test can hang on Python 2")
+    return cluster(*args, **kwargs)
+
+
+@gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
+def test_read_bytes(c, s, a, b):
+    with make_hdfs() as (hdfs, basedir):
+        data = b'a' * int(1e8)
+        fn = '%s/file' % basedir
+
+        with hdfs.open(fn, 'wb', replication=1) as f:
+            f.write(data)
+
+        sample, values = read_bytes('hdfs://' + fn)
+        assert sample[:5] == b'aaaaa'
+
+        futures = c.compute(values[0])
+        results = yield c._gather(futures)
+        assert b''.join(results) == data
+
+
+@pytest.mark.parametrize('nworkers', [1, 3])
+def test_read_bytes_sync(loop, nworkers):
+    with cluster(nworkers=nworkers) as (s, workers):
+        with make_hdfs() as (hdfs, basedir):
+            data = b'a' * int(1e3)
+
+            for fn in ['%s/file.%d' % (basedir, i) for i in range(100)]:
+                with hdfs.open(fn, 'wb', replication=1) as f:
+                    f.write(data)
+
+            with Client(s['address'], loop=loop):
+                sample, values = read_bytes('hdfs://%s/file.*' % basedir)
+                results = delayed(values).compute()
+                assert [b''.join(r) for r in results] == 100 * [data]
+
+
+def test_read_bytes_sync_URL(loop, nworkers=1):
+    with cluster(nworkers=nworkers) as (s, workers):
+        with make_hdfs() as (hdfs, basedir):
+            data = b'a' * int(1e3)
+
+            for fn in ['%s/file.%d' % (basedir, i) for i in range(100)]:
+                with hdfs.open(fn, 'wb', replication=1) as f:
+                    f.write(data)
+
+            with Client(s['address'], loop=loop):
+                path = 'hdfs://localhost:8020%s/file.*' % basedir
+                sample, values = read_bytes(path)
+                results = delayed(values).compute()
+                assert [b''.join(r) for r in results] == 100 * [data]
+
+
+@gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
+def test_deterministic_key_names(e, s, a, b):
+    with make_hdfs() as (hdfs, basedir):
+        data = b'abc\n' * int(1e3)
+        fn = '%s/file' % basedir
+
+        with hdfs.open(fn, 'wb', replication=1) as fil:
+            fil.write(data)
+
+        _, x = read_bytes('hdfs://%s/*' % basedir, delimiter=b'\n')
+        _, y = read_bytes('hdfs://%s/*' % basedir, delimiter=b'\n')
+        _, z = read_bytes('hdfs://%s/*' % basedir, delimiter=b'c')
+
+        assert [f.key for f in concat(x)] == [f.key for f in concat(y)]
+        assert [f.key for f in concat(x)] != [f.key for f in concat(z)]
+
+
+@gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
+def test_write_bytes(c, s, a, b):
+    with make_hdfs() as (hdfs, basedir):
+        hdfs.mkdir('%s/data/' % basedir)
+        data = [b'123', b'456', b'789']
+        remote_data = yield c._scatter(data)
+
+        futures = c.compute(write_bytes(remote_data,
+                                        'hdfs://%s/data/file.*.dat' % basedir))
+        yield wait(futures)
+
+        yield futures[0]
+
+        assert len(hdfs.ls('%s/data/' % basedir)) == 3
+        with hdfs.open('%s/data/file.1.dat' % basedir) as f:
+            assert f.read() == b'456'
+
+        hdfs.mkdir('%s/data2/' % basedir)
+        futures = c.compute(write_bytes(remote_data,
+                                        'hdfs://%s/data2/' % basedir))
+        yield wait(futures)
+
+        assert len(hdfs.ls('%s/data2/' % basedir)) == 3
+
+
+@gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
+def test_write_bytes_2(c, s, a, b):
+    with make_hdfs() as (hdfs, basedir):
+        path = 'hdfs://%s/' % basedir
+        data = [b'test data %i' % i for i in range(5)]
+        values = [delayed(d) for d in data]
+        out = write_bytes(values, path)
+        futures = c.compute(out)
+        results = yield c._gather(futures)
+        assert len(hdfs.ls(basedir)) == 5
+
+        sample, vals = read_bytes('hdfs://%s/*.part' % basedir)
+        futures = c.compute(list(concat(vals)))
+        results = yield c._gather(futures)
+        assert data == results
+
+
+def test_read_csv_sync(loop):
+    dd = pytest.importorskip('dask.dataframe')
+    import pandas as pd
+
+    with cluster(nworkers=3) as (s, [a, b, c]):
+        with make_hdfs() as (hdfs, basedir):
+            with hdfs.open('%s/1.csv' % basedir, 'wb') as f:
+                f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
+
+            with hdfs.open('%s/2.csv' % basedir, 'wb') as f:
+                f.write(b'name,amount,id\nCharlie,300,3\nDennis,400,4')
+
+            with Client(s['address'], loop=loop) as e:
+                values = dd.read_csv('hdfs://%s/*.csv' % basedir,
+                                     lineterminator='\n',
+                                     collection=False, header=0)
+                futures = e.compute(values)
+                assert all(isinstance(f, Future) for f in futures)
+                L = e.gather(futures)
+                assert isinstance(L[0], pd.DataFrame)
+                assert list(L[0].columns) == ['name', 'amount', 'id']
+
+                df = dd.read_csv('hdfs://%s/*.csv' % basedir,
+                                 lineterminator='\n',
+                                 collection=True, header=0)
+                assert isinstance(df, dd.DataFrame)
+                assert list(df.head().iloc[0]) == ['Alice', 100, 1]
+
+
+def test_read_csv_sync_compute(loop):
+    dd = pytest.importorskip('dask.dataframe')
+
+    with cluster(nworkers=1) as (s, [a]):
+        with make_hdfs() as (hdfs, basedir):
+            with hdfs.open('%s/1.csv' % basedir, 'wb') as f:
+                f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
+
+            with hdfs.open('%s/2.csv' % basedir, 'wb') as f:
+                f.write(b'name,amount,id\nCharlie,300,3\nDennis,400,4')
+
+            with Client(s['address'], loop=loop) as e:
+                df = dd.read_csv('hdfs://%s/*.csv' % basedir, collection=True)
+                assert df.amount.sum().compute(get=e.get) == 1000
+
+
+@gen_cluster([(ip, 1), (ip, 1)], timeout=60, client=True)
+def test_read_csv(e, s, a, b):
+    dd = pytest.importorskip('dask.dataframe')
+
+    with make_hdfs() as (hdfs, basedir):
+        with hdfs.open('%s/1.csv' % basedir, 'wb') as f:
+            f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
+
+        with hdfs.open('%s/2.csv' % basedir, 'wb') as f:
+            f.write(b'name,amount,id\nCharlie,300,3\nDennis,400,4')
+
+        df = dd.read_csv('hdfs://%s/*.csv' % basedir, lineterminator='\n')
+        result = e.compute(df.id.sum(), sync=False)
+        result = yield result
+        assert result == 1 + 2 + 3 + 4
+
+
+@gen_cluster([(ip, 1), (ip, 1)], timeout=60, client=True)
+def test_read_csv_with_names(e, s, a, b):
+    dd = pytest.importorskip('dask.dataframe')
+
+    with make_hdfs() as (hdfs, basedir):
+        with hdfs.open('%s/1.csv' % basedir, 'wb') as f:
+            f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
+
+        df = dd.read_csv('hdfs://%s/*.csv' % basedir,
+                         names=['amount', 'name'],
+                         lineterminator='\n')
+        assert list(df.columns) == ['amount', 'name']
+
+
+@gen_cluster([(ip, 1), (ip, 1)], timeout=60, client=True)
+def test_read_csv_lazy(e, s, a, b):
+    dd = pytest.importorskip('dask.dataframe')
+
+    with make_hdfs() as (hdfs, basedir):
+        with hdfs.open('%s/1.csv' % basedir, 'wb') as f:
+            f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
+
+        with hdfs.open('%s/2.csv' % basedir, 'wb') as f:
+            f.write(b'name,amount,id\nCharlie,300,3\nDennis,400,4')
+
+        df = dd.read_csv('hdfs://%s/*.csv' % basedir, lineterminator='\n')
+        yield gen.sleep(0.5)
+        assert not s.tasks
+
+        result = yield e.compute(df.id.sum(), sync=False)
+        assert result == 1 + 2 + 3 + 4
+
+
+@gen_cluster([(ip, 1), (ip, 1)], timeout=60, client=True)
+def test_read_text(c, s, a, b):
+    db = pytest.importorskip('dask.bag')
+
+    with make_hdfs() as (hdfs, basedir):
+        with hdfs.open('%s/text.1.txt' % basedir, 'wb') as f:
+            f.write('Alice 100\nBob 200\nCharlie 300'.encode())
+
+        with hdfs.open('%s/text.2.txt' % basedir, 'wb') as f:
+            f.write('Dan 400\nEdith 500\nFrank 600'.encode())
+
+        with hdfs.open('%s/other.txt' % basedir, 'wb') as f:
+            f.write('a b\nc d'.encode())
+
+        b = db.read_text('hdfs://%s/text.*.txt' % basedir)
+        yield gen.sleep(0.5)
+        assert not s.tasks
+
+        b.compute(get=dask.get)
+
+        coll = b.str.strip().str.split().map(len)
+
+        future = c.compute(coll)
+        yield gen.sleep(0.5)
+        result = yield future
+        assert result == [2, 2, 2, 2, 2, 2]
+
+        b = db.read_text('hdfs://%s/other.txt' % basedir)
+        b = c.persist(b)
+        future = c.compute(b.str.split().flatten())
+        result = yield future
+        assert result == ['a', 'b', 'c', 'd']
+
+
+@gen_cluster([(ip, 1)], timeout=60, client=True)
+def test_read_text_json_endline(e, s, a):
+    db = pytest.importorskip('dask.bag')
+
+    with make_hdfs() as (hdfs, basedir):
+        with hdfs.open('%s/text.1.txt' % basedir, 'wb') as f:
+            f.write(b'{"x": 1}\n{"x": 2}\n')
+
+        b = db.read_text('hdfs://%s/text.1.txt' % basedir).map(json.loads)
+        result = yield e.compute(b)
+
+        assert result == [{"x": 1}, {"x": 2}]
+
+
+@gen_cluster([(ip, 1), (ip, 1)], timeout=60, client=True)
+def test_read_text_unicode(e, s, a, b):
+    db = pytest.importorskip('dask.bag')
+
+    data = b'abcd\xc3\xa9'
+    with make_hdfs() as (hdfs, basedir):
+        fn = '%s/data.txt' % basedir
+        with hdfs.open(fn, 'wb') as f:
+            f.write(b'\n'.join([data, data]))
+
+        f = db.read_text('hdfs://' + fn, collection=False)
+        result = yield e.compute(f[0])
+        assert len(result) == 2
+        assert list(map(unicode.strip, result)) == [data.decode('utf-8')] * 2
+        assert len(result[0].strip()) == 5
+
+
+def test_read_text_sync(loop):
+    db = pytest.importorskip('dask.bag')
+
+    with make_hdfs() as (hdfs, basedir):
+        with hdfs.open('%s/data.txt' % basedir, 'wb') as f:
+            f.write(b'hello\nworld')
+
+        with cluster(nworkers=3) as (s, [a, b, c]):
+            with Client(s['address'], loop=loop):
+                b = db.read_text('hdfs://%s/*.txt' % basedir)
+                assert list(b.str.strip().str.upper()) == ['HELLO', 'WORLD']
+
+
+def test_pyarrow_compat():
+    pa = pytest.importorskip('pyarrow')
+    dhdfs = DaskHDFS3FileSystem()
+    pa_hdfs = dhdfs._get_pyarrow_filesystem()
+    assert isinstance(pa_hdfs, pa.filesystem.FileSystem)
+
+
+def test_parquet_pyarrow(loop):
+    pytest.importorskip('pyarrow')
+    dd = pytest.importorskip('dask.dataframe')
+    import pandas as pd
+    import numpy as np
+
+    with make_hdfs() as (hdfs, basedir):
+        fn = '%s/test.parquet' % basedir
+        hdfs_fn = 'hdfs://%s' % fn
+        df = pd.DataFrame(np.random.normal(size=(1000, 4)),
+                          columns=list('abcd'))
+        ddf = dd.from_pandas(df, npartitions=4)
+
+        with cluster(nworkers=1) as (s, [a]):
+            with Client(s['address'], loop=loop):
+                ddf.to_parquet(hdfs_fn, engine='pyarrow')
+                assert len(hdfs.ls(fn))  # Files are written
+
+                ddf2 = dd.read_parquet(hdfs_fn, engine='pyarrow')
+                assert len(ddf2) == 1000  # smoke test on read


### PR DESCRIPTION
This moves the hdfs integration and tests out of hdfs3 and into dask. See https://github.com/dask/hdfs3/pull/148#issuecomment-358817007 for background. In short, due to multiple hdfs backends and the importance of hdfs, it makes more sense for these tests to be in the main dask repo where they'll get more attention.

Since we expect this code to rarely change, the tests are only run:
- On merges to master
- When a PR *branch* name contains the string `"__TEST_HDFS__"`

This allows individual PRs to trigger the tests as needed (see e.g. this PR)

A summary of this PR:
- Moves the dask hdfs filesystem and tests to this repo
- Cleans up the previous tests which relied on distributed. We no longer need to explicitly test with distributed since any specific distributed integration was removed in #3079.
- Adds hdfs test integration files (docker)
- Tweaks travis build to build hdfs tests under the conditions specified above
