### PR TITLE
Remove `fastparquet` package before pip installing

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -62,6 +62,7 @@ pip install --upgrade --no-deps git+https://github.com/dask/s3fs
 
 if [[ $PYTHONOPTIMIZE != '2' ]] && [[ $NUMPY > '1.11.0' ]] && [[ $NUMPY < '1.14.0' ]]; then
     conda install -q -c conda-forge fastparquet python-snappy
+    conda remove --force fastparquet
     pip install --no-deps git+https://github.com/dask/fastparquet
 fi
 


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/3084

Recent versions of `pip` have gotten a bit smarter about detecting a package is already installed instead of simply overwriting. This is actually a good thing for the majority of use cases. However it means that we have to adjust our logic for installing the development version `fastparquet`. Though it is probably for the best so that we don't accidentally have stray files floating around from a previous install. To adapt to this new behavior from `pip`, we forcible remove `fastparquet` after installing it (we only wanted to ensure the bulk of its dependencies were present anyways) with `conda`. Then the `pip` install can proceed without issues.