### PR TITLE
Allow the CI dev build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,13 +55,13 @@ jobs:
       - *no_coverage
       - *no_optimize
       - *imports
+      if: type != pull_request
 
     - env: *py36_env
       if: type != pull_request
       os: osx
 
   allow_failures:
-    - env: *py36_env
     - os: osx
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ jobs:
 
     - env:
       - PYTHON=3.6
-      - NUMPY=1.13.0
-      - PANDAS=0.20.3
+      - NUMPY=1.14.0
+      - PANDAS=0.22.0
       - *no_coverage
       - *no_optimize
       - *imports

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
       - *no_optimize
       - *no_imports
 
-    - env:
+    - env: &py36_env
       - PYTHON=3.6
       - NUMPY=1.14.0
       - PANDAS=0.22.0
@@ -64,7 +64,7 @@ jobs:
       - *imports
       if: type != pull_request
 
-    - env: *py36_dev
+    - env: *py36_env
       if: type != pull_request
       os: osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ jobs:
       os: osx
 
   allow_failures:
+    - env: *py36_env
     - os: osx
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
     - env: &py36_env
       - PYTHON=3.6
       - NUMPY=1.14.0
-      - PANDAS=0.20.3
+      - PANDAS=0.22.0
       - *test_and_lint
       - *no_coverage
       - *no_optimize

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ jobs:
       os: osx
 
   allow_failures:
+    - env: *py36_env
     - os: osx
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
       - PYTHON=3.6
       - NUMPY=1.14.0
       - PANDAS=0.22.0
+      - *test_and_lint
       - *no_coverage
       - *no_optimize
       - *imports

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
       - NUMPY=1.14.0
       - PANDAS=0.22.0
       - *test_and_lint
-      - *no_coverage
+      - *coverage
       - *no_optimize
       - *imports
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,8 @@ jobs:
       - NUMPY=1.14.0
       - PANDAS=0.22.0
       - *test_and_lint
-      - *coverage
+      - COVERAGE='false'
+      - PARALLEL='false'
       - *no_optimize
       - *imports
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,15 @@ jobs:
       - *no_optimize
       - *no_imports
 
-    - env: &py36_env
+    - env:
       - PYTHON=3.6
+      - NUMPY=1.13.0
+      - PANDAS=0.20.3
+      - *no_coverage
+      - *no_optimize
+      - *imports
+
+    - env: &py36_dev
       - UPSTREAM_DEV=1  # Install nightly versions of NumPy, pandas, pyarrow
       - NUMPY=1.13.0    # these are overridden later
       - PANDAS=0.20.3
@@ -57,12 +64,12 @@ jobs:
       - *imports
       if: type != pull_request
 
-    - env: *py36_env
+    - env: *py36_dev
       if: type != pull_request
       os: osx
 
   allow_failures:
-    - env: *py36_env
+    - env: *py36_dev
     - os: osx
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
     - env: &py36_env
       - PYTHON=3.6
       - NUMPY=1.14.0
-      - PANDAS=0.22.0
+      - PANDAS=0.20.3
       - *test_and_lint
       - *no_coverage
       - *no_optimize

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -46,15 +46,13 @@ conda install -q -c conda-forge \
     ipython \
     partd \
     psutil \
+    pytables \
     "pytest<=3.1.1" \
     scikit-image \
     scikit-learn \
     scipy \
     sqlalchemy \
     toolz
-
-# install pytables from defaults for now
-conda install -q pytables
 
 pip install -q --upgrade --no-deps git+https://github.com/dask/partd
 pip install -q --upgrade --no-deps git+https://github.com/dask/zict

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -62,7 +62,7 @@ pip install -q --upgrade --no-deps git+https://github.com/dask/distributed
 pip install -q --upgrade --no-deps git+https://github.com/mrocklin/sparse
 pip install -q --upgrade --no-deps git+https://github.com/dask/s3fs
 
-if [[ $PYTHONOPTIMIZE != '2' ]] && [[ $NUMPY > '1.11.0' ]]; then
+if [[ $PYTHONOPTIMIZE != '2' ]] && [[ $NUMPY > '1.11.0' ]] && [[ $NUMPY < '1.14.0' ]]; then
     conda install -q -c conda-forge fastparquet python-snappy
     pip install -q --no-deps git+https://github.com/dask/fastparquet
 fi


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/3043
Partially addresses https://github.com/dask/dask/issues/2744

As dev libraries tend to breaking things rather frequently, simply mark this build as an allowed failure. This doesn't mean that we don't care about fixing issues with dev libraries. Simply that we don't expect every change to take that into account. Leaving it in the matrix for those interested in fixing it to have an easier time doing so.