### PR TITLE
parquet append=True allowed to create new dataset

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -399,7 +399,12 @@ def _write_fastparquet(df, fs, fs_token, path, write_index=None, append=False,
         index_cols = []
 
     if append:
-        pf = fastparquet.api.ParquetFile(path, open_with=fs.open, sep=sep)
+        try:
+            pf = fastparquet.api.ParquetFile(path, open_with=fs.open, sep=sep)
+        except (IOError, ValueError):
+            # append for create
+            append = False
+    if append:
         if pf.file_scheme not in ['hive', 'empty', 'flat']:
             raise ValueError('Requested file scheme is hive, '
                              'but existing file scheme is not.')

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -287,6 +287,27 @@ def test_append(tmpdir, engine):
     assert_eq(df, ddf3)
 
 
+def test_append_create(tmpdir):
+    """Test that appended parquet equal to the original one."""
+    check_fastparquet()
+    tmp = str(tmpdir)
+    df = pd.DataFrame({'i32': np.arange(1000, dtype=np.int32),
+                       'i64': np.arange(1000, dtype=np.int64),
+                       'f': np.arange(1000, dtype=np.float64),
+                       'bhello': np.random.choice(['hello', 'yo', 'people'],
+                                                  size=1000).astype("O")})
+    df.index.name = 'index'
+
+    half = len(df) // 2
+    ddf1 = dd.from_pandas(df.iloc[:half], chunksize=100)
+    ddf2 = dd.from_pandas(df.iloc[half:], chunksize=100)
+    ddf1.to_parquet(tmp, append=True)
+    ddf2.to_parquet(tmp, append=True)
+
+    ddf3 = dd.read_parquet(tmp, engine='fastparquet')
+    assert_eq(df, ddf3)
+
+
 def test_append_with_partition(tmpdir):
     check_fastparquet()
     tmp = str(tmpdir)


### PR DESCRIPTION
(fastparquet only)

Fixes #3008

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
