### PR TITLE
Dtype rationalisation for sql queries

### DIFF
--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -137,7 +137,7 @@ def read_sql_table(table, uri, index_col, divisions=None, npartitions=None,
             npartitions = round(count * bytes_per_row / bytes_per_chunk) or 1
         if dtype.kind == "M":
             divisions = pd.date_range(
-                start=mini, end=maxi, freq='%.6fS' % (
+                start=mini, end=maxi, freq='%iS' % (
                     (maxi - mini) / npartitions).total_seconds()).tolist()
             divisions[0] = mini
             divisions[-1] = maxi

--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -168,4 +168,4 @@ def _rationalize_sql(q, uri, meta, **kwargs):
     if df.empty:
         return meta
     else:
-        return df.astype(meta.dtypes)
+        return df.astype(meta.dtypes.to_dict())

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -61,8 +61,8 @@ def test_needs_rational(db):
     d = datetime.timedelta(seconds=1)
     df = pd.DataFrame({'a': list('ghjkl'), 'b': [now + i * d for i in range(5)],
                        'c': [True, True, False, True, True]})
-    df = df.append([{'a': 'x', 'b': now + d*1000, 'c': None},
-                    {'a': None, 'b': now + d*1001, 'c': None}])
+    df = df.append([{'a': 'x', 'b': now + d * 1000, 'c': None},
+                    {'a': None, 'b': now + d * 1001, 'c': None}])
     with tmpfile() as f:
         uri = 'sqlite:///%s' % f
         df.to_sql('test', uri, index=False, if_exists='replace')

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -14,6 +14,8 @@ pytest.importorskip('sqlalchemy')
 pytest.importorskip('sqlite3')
 np = pytest.importorskip('numpy')
 
+import dask
+dask.set_options(get=dask.get)
 
 data = """
 name,number,age,negish

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -55,6 +55,46 @@ def test_empty(db):
         assert pd_dataframe.empty is True
 
 
+def test_needs_rational(db):
+    import datetime
+    now = datetime.datetime.now()
+    d = datetime.timedelta(seconds=1)
+    df = pd.DataFrame({'a': list('ghjkl'), 'b': [now + i * d for i in range(5)],
+                       'c': [True, True, False, True, True]})
+    df = df.append([{'a': 'x', 'b': now + d*1000, 'c': None},
+                    {'a': None, 'b': now + d*1001, 'c': None}])
+    with tmpfile() as f:
+        uri = 'sqlite:///%s' % f
+        df.to_sql('test', uri, index=False, if_exists='replace')
+
+        # one partition contains NULL
+        data = read_sql_table('test', uri, npartitions=2, index_col='b')
+        df2 = df.set_index('b')
+        assert_eq(data, df2.astype({'c': bool}))  # bools are coerced
+
+        # one partition contains NULL, but big enough head
+        data = read_sql_table('test', uri, npartitions=2, index_col='b',
+                              head_rows=12)
+        df2 = df.set_index('b')
+        assert_eq(data, df2)
+
+        # empty partitions
+        data = read_sql_table('test', uri, npartitions=20, index_col='b')
+        part = data.get_partition(12).compute()
+        assert part.dtypes.tolist() == ['O', bool]
+        assert part.empty
+        df2 = df.set_index('b')
+        assert_eq(data, df2.astype({'c': bool}))
+
+        # explicit meta
+        data = read_sql_table('test', uri, npartitions=2, index_col='b',
+                              meta=df2[:0])
+        part = data.get_partition(1).compute()
+        assert part.dtypes.tolist() == ['O', 'O']
+        df2 = df.set_index('b')
+        assert_eq(data, df2)
+
+
 def test_simple(db):
     # single chunk
     data = read_sql_table('test', db, npartitions=2, index_col='number'

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -14,8 +14,6 @@ pytest.importorskip('sqlalchemy')
 pytest.importorskip('sqlite3')
 np = pytest.importorskip('numpy')
 
-import dask
-dask.set_options(get=dask.get)
 
 data = """
 name,number,age,negish


### PR DESCRIPTION
Plus a few more options and docs

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
