### PR TITLE
Avoid calling pd.Timedelta in repartition(freq=)

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3798,19 +3798,20 @@ def repartition_divisions(a, b, name, out1, out2, force=False):
 
 def repartition_freq(df, freq=None):
     """ Repartition a timeseries dataframe by a new frequency """
-    freq = pd.Timedelta(freq)
     if not isinstance(df.divisions[0], pd.Timestamp):
         raise TypeError("Can only repartition on frequency for timeseries")
-    divisions = pd.DatetimeIndex(start=df.divisions[0].ceil(freq),
+    try:
+        start = df.divisions[0].ceil(freq)
+    except ValueError:
+        start = df.divisions[0]
+    divisions = pd.DatetimeIndex(start=start,
                                  end=df.divisions[-1],
                                  freq=freq).tolist()
     if not len(divisions):
         divisions = [df.divisions[0], df.divisions[-1]]
     else:
-        if divisions[-1] != df.divisions[-1]:
-            divisions.append(df.divisions[-1])
-        if divisions[0] != df.divisions[0]:
-            divisions = [df.divisions[0]] + divisions
+        divisions[0] = df.divisions[0]
+        divisions[-1] = df.divisions[-1]
 
     return df.repartition(divisions=divisions)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3810,8 +3810,10 @@ def repartition_freq(df, freq=None):
     if not len(divisions):
         divisions = [df.divisions[0], df.divisions[-1]]
     else:
-        divisions[0] = df.divisions[0]
-        divisions[-1] = df.divisions[-1]
+        if divisions[-1] != df.divisions[-1]:
+            divisions.append(df.divisions[-1])
+        if divisions[0] != df.divisions[0]:
+            divisions = [df.divisions[0]] + divisions
 
     return df.repartition(divisions=divisions)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1291,9 +1291,9 @@ def test_repartition_freq_errors():
 
 
 def test_repartition_freq_month():
-    ts=pd.date_range("2015-01-01 00:00", " 2015-05-01 23:50", freq="10min")
+    ts = pd.date_range("2015-01-01 00:00", " 2015-05-01 23:50", freq="10min")
     df = pd.DataFrame(np.random.randint(0,100,size=(len(ts),4)),
-            columns=list('ABCD'), index=ts)
+                      columns=list('ABCD'), index=ts)
     ddf = dd.from_pandas(df,npartitions=1).repartition(freq='1M')
 
     assert_eq(df, ddf)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1290,6 +1290,16 @@ def test_repartition_freq_errors():
     assert 'timeseries' in str(info.value)
 
 
+def test_repartition_freq_month():
+    ts=pd.date_range("2015-01-01 00:00", " 2015-05-01 23:50", freq="10min")
+    df = pd.DataFrame(np.random.randint(0,100,size=(len(ts),4)),
+            columns=list('ABCD'), index=ts)
+    ddf = dd.from_pandas(df,npartitions=1).repartition(freq='1M')
+
+    assert_eq(df, ddf)
+    assert 2 < ddf.npartitions <= 6
+
+
 def test_embarrassingly_parallel_operations():
     df = pd.DataFrame({'x': [1, 2, 3, 4, None, 6], 'y': list('abdabd')},
                       index=[10, 20, 30, 40, 50, 60])

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,7 @@ Array
 DataFrame
 +++++++++
 
+-  Support month timedeltas in repartition(freq=...) (:pr:`3110`) `Matthew Rocklin`_
 
 Bag
 +++


### PR DESCRIPTION
It turns out that 1m and 1M both convert to minutes, causing some
frustration.

See https://stackoverflow.com/questions/48467042/dask-dataframes-time-series-partitions

We don't actually need the call to pd.Timedelta.
Everything works fine regardless.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
