### PR TITLE
Fix travis parquet test issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,7 @@ jobs:
       - NUMPY=1.14.0
       - PANDAS=0.22.0
       - *test_and_lint
-      - COVERAGE='false'
-      - PARALLEL='false'
+      - *no_coverage
       - *no_optimize
       - *imports
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -54,27 +54,27 @@ conda install -q -c conda-forge \
     sqlalchemy \
     toolz
 
-pip install -q --upgrade --no-deps git+https://github.com/dask/partd
-pip install -q --upgrade --no-deps git+https://github.com/dask/zict
-pip install -q --upgrade --no-deps git+https://github.com/dask/distributed
-pip install -q --upgrade --no-deps git+https://github.com/mrocklin/sparse
-pip install -q --upgrade --no-deps git+https://github.com/dask/s3fs
+pip install --upgrade --no-deps git+https://github.com/dask/partd
+pip install --upgrade --no-deps git+https://github.com/dask/zict
+pip install --upgrade --no-deps git+https://github.com/dask/distributed
+pip install --upgrade --no-deps git+https://github.com/mrocklin/sparse
+pip install --upgrade --no-deps git+https://github.com/dask/s3fs
 
 if [[ $PYTHONOPTIMIZE != '2' ]] && [[ $NUMPY > '1.11.0' ]] && [[ $NUMPY < '1.14.0' ]]; then
     conda install -q -c conda-forge fastparquet python-snappy
-    pip install -q --no-deps git+https://github.com/dask/fastparquet
+    pip install --no-deps git+https://github.com/dask/fastparquet
 fi
 
 if [[ $PYTHON == '2.7' ]]; then
-    pip install -q --no-deps backports.lzma mock
+    pip install --no-deps backports.lzma mock
 fi
 
-pip install -q --upgrade --no-deps \
+pip install --upgrade --no-deps \
     cachey \
     graphviz \
     pandas_datareader
 
-pip install -q --upgrade \
+pip install --upgrade \
     cityhash \
     flake8 \
     moto \
@@ -101,11 +101,11 @@ if [[ ${UPSTREAM_DEV} ]]; then
     echo "Installing NumPy and Pandas dev"
     conda uninstall -y --force numpy pandas
     PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
-    pip install -q --pre --no-deps --upgrade --timeout=60 -f $PRE_WHEELS numpy pandas
+    pip install --pre --no-deps --upgrade --timeout=60 -f $PRE_WHEELS numpy pandas
 fi;
 
 
 # Install dask
-pip install -q --no-deps -e .[complete]
+pip install --no-deps -e .[complete]
 echo conda list
 conda list

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -59,7 +59,7 @@ def write_read_engines(**kwargs):
     marks = {(w, r): [] for w in backends for r in backends}
 
     # Skip if uninstalled
-    for name, exists in zip(backends, [pq, fastparquet]):
+    for name, exists in [('fastparquet', fastparquet), ('pyarrow', pq)]:
         val = pytest.mark.skip(reason='%s not found' % name)
         if not exists:
             for k in marks:


### PR DESCRIPTION
- Fixes non-deterministic parquet test failure when fastparquet/pyarrow isn't installed. This was due to accidentally iterating over a set instead of a list and assuming ordering. This led to the skip flags being incorrect *sometimes*.
- Removes `-q` flag on pip installs on travis, which should make debugging these issues easier in the future.
