### PR TITLE
Sort by grouper values prior to calling groupby-apply

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -141,6 +141,7 @@ def _groupby_raise_unaligned(df, **kwargs):
 def _groupby_slice_apply(df, grouper, key, func):
     # No need to use raise if unaligned here - this is only called after
     # shuffling, which makes everything aligned already
+    df = df.sort_values(grouper)
     g = df.groupby(grouper)
     if key:
         g = g[key]

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -141,13 +141,6 @@ def _groupby_raise_unaligned(df, **kwargs):
 def _groupby_slice_apply(df, grouper, key, func):
     # No need to use raise if unaligned here - this is only called after
     # shuffling, which makes everything aligned already
-    if isinstance(grouper, (pd.DataFrame, pd.Series, pd.Index)):
-        grouper = grouper.sort_values()
-    else:
-        try:
-            df = df.sort_values(grouper)
-        except KeyError:  # this fails when the grouper includes the index
-            pass
     g = df.groupby(grouper)
     if key:
         g = g[key]

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -141,7 +141,13 @@ def _groupby_raise_unaligned(df, **kwargs):
 def _groupby_slice_apply(df, grouper, key, func):
     # No need to use raise if unaligned here - this is only called after
     # shuffling, which makes everything aligned already
-    df = df.sort_values(grouper)
+    if isinstance(grouper, (pd.DataFrame, pd.Series, pd.Index)):
+        grouper = grouper.sort_values()
+    else:
+        try:
+            df = df.sort_values(grouper)
+        except KeyError:  # this fails when the grouper includes the index
+            pass
     g = df.groupby(grouper)
     if key:
         g = g[key]

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -120,11 +120,15 @@ def test_full_groupby():
     lambda df: [df['a'], df['b']],
     pytest.mark.xfail(reason="not yet supported")(lambda df: [df['a'] > 2, df['b'] > 1])
 ])
-def test_full_groupby_multilevel(grouper):
+@pytest.mark.parametrize('reverse', [True, False])
+def test_full_groupby_multilevel(grouper, reverse):
+    index = [0, 1, 3, 5, 6, 8, 9, 9, 9]
+    if reverse:
+        index = index[::-1]
     df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
                        'd': [1, 2, 3, 4, 5, 6, 7, 8, 9],
                        'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-                      index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
+                      index=index)
     ddf = dd.from_pandas(df, npartitions=3)
 
     def func(df):
@@ -133,9 +137,9 @@ def test_full_groupby_multilevel(grouper):
 
     # last one causes a DeprcationWarning from pandas.
     # See https://github.com/pandas-dev/pandas/issues/16481
+    meta = {"a": int, "d": int, "b": float}
     assert_eq(df.groupby(grouper(df)).apply(func),
-              ddf.groupby(grouper(ddf)).apply(func, meta={"a": int, "d": int,
-                                                          "b": float}))
+              ddf.groupby(grouper(ddf)).apply(func, meta=meta))
 
 
 def test_groupby_dir():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -106,11 +106,10 @@ def test_full_groupby():
     assert 'b' in dir(df.groupby('a'))
 
     def func(df):
-        df['b'] = df.b - df.b.mean()
-        return df
+        return df.assign(b=df.b - df.b.mean())
 
     assert_eq(df.groupby('a').apply(func),
-              ddf.groupby('a').apply(func, meta={"a": int, "b": float}))
+              ddf.groupby('a').apply(func))
 
 
 @pytest.mark.parametrize('grouper', [
@@ -132,14 +131,12 @@ def test_full_groupby_multilevel(grouper, reverse):
     ddf = dd.from_pandas(df, npartitions=3)
 
     def func(df):
-        df['b'] = df.b - df.b.mean()
-        return df
+        return df.assign(b=df.b - df.b.mean())
 
     # last one causes a DeprcationWarning from pandas.
     # See https://github.com/pandas-dev/pandas/issues/16481
-    meta = {"a": int, "d": int, "b": float}
     assert_eq(df.groupby(grouper(df)).apply(func),
-              ddf.groupby(grouper(ddf)).apply(func, meta=meta))
+              ddf.groupby(grouper(ddf)).apply(func))
 
 
 def test_groupby_dir():

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,7 @@ DataFrame
 +++++++++
 
 -  Support month timedeltas in repartition(freq=...) (:pr:`3110`) `Matthew Rocklin`_
+-  Sort grouper values prior to groupby-apply (:pr:`3118`) `Matthew Rocklin`_
 
 Bag
 +++

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,7 +18,7 @@ DataFrame
 +++++++++
 
 -  Support month timedeltas in repartition(freq=...) (:pr:`3110`) `Matthew Rocklin`_
--  Sort grouper values prior to groupby-apply (:pr:`3118`) `Matthew Rocklin`_
+-  Avoid mutation in dataframe groupby tests (:pr:`3118`) `Matthew Rocklin`_
 
 Bag
 +++


### PR DESCRIPTION
Otherwise we run afoul of a reindex operation when we have multiple
repeated index values

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
