### PR TITLE
Support changing colormap with string like visualize(cmap='RdBu')

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -457,12 +457,15 @@ def visualize(*args, **kwargs):
 
     if color == 'order':
         from .order import order
+        import matplotlib.pyplot as plt
         o = order(dsk)
         try:
             cmap = kwargs.pop('cmap')
         except KeyError:
+            cmap = plt.cm.RdBu
+        if isinstance(cmap, str):
             import matplotlib.pyplot as plt
-            cmap = plt.cm.viridis
+            cmap = getattr(plt.cm, cmap)
         mx = max(o.values()) + 1
         colors = {k: _colorize(cmap(v / mx, bytes=True)) for k, v in o.items()}
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -554,7 +554,7 @@ def test_visualize_order():
     pytest.importorskip('matplotlib')
     x = da.arange(5, chunks=2)
     with tmpfile(extension='dot') as fn:
-        x.visualize(color='order', filename=fn)
+        x.visualize(color='order', filename=fn, cmap='RdBu')
         with open(fn) as f:
             text = f.read()
         assert 'color="#' in text

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -28,7 +28,7 @@ Core
 
 - Change default task ordering to prefer nodes with few dependents and then
   many downstream dependencies (:pr:`3056`) `Matthew Rocklin`_
-- Add color= option to visualize to color by task order (:pr:`3057`) `Matthew Rocklin`_
+- Add color= option to visualize to color by task order (:pr:`3057`) (:pr:`3122`) `Matthew Rocklin`_
 - Deprecate ``dask.bytes.open_text_files`` (:pr:`3077`) `Jim Crist`_
 - Remove short-circuit hdfs reads handling due to maintenance costs. May be
   re-added in a more robust manner later (:pr:`3079`) `Jim Crist`_


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
