### PR TITLE
Read methods/functions accept iterables of paths

### DIFF
--- a/dask/bag/tests/test_text.py
+++ b/dask/bag/tests/test_text.py
@@ -41,6 +41,11 @@ def test_read_text(fmt, bs, encoding):
         L, = compute(b)
         assert ''.join(L) == expected
 
+        b = read_text(sorted(files), compression=fmt, blocksize=bs,
+                      encoding=encoding)
+        L, = compute(b)
+        assert ''.join(L) == expected
+
         blocks = read_text('.test.accounts.*.json', compression=fmt, blocksize=bs,
                            encoding=encoding, collection=False)
         L = compute(*blocks)

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -366,9 +366,11 @@ for :func:`pandas.{reader}` for more information on available keyword arguments.
 
 Parameters
 ----------
-urlpath : string
-    Absolute or relative filepath, URL (may include protocols like
-    ``s3://``), or globstring for {file_type} files.
+urlpath : string or list
+    Absolute or relative filepath(s). Prefix with a protocol like ``s3://``
+    to read from alternative filesystems. To read from multiple files you
+    can pass a globstring or a list of paths, with the caveat that they
+    must all have the same protocol.
 blocksize : int or None, optional
     Number of bytes by which to cut up larger files. Default value is
     computed based on available physical memory and the number of cores.

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -718,9 +718,12 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
 
     Parameters
     ----------
-    path : string
-        Source directory for data. May be a glob string.
-        Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
+    path : string or list
+        Source directory for data, or path(s) to individual parquet files.
+        Prefix with a protocol like ``s3://`` to read from alternative
+        filesystems. To read from multiple files you can pass a globstring or a
+        list of paths, with the caveat that they must all have the same
+        protocol.
     columns: list or None
         List of column names to load
     filters: list

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -270,6 +270,20 @@ def test_read_csv_files(dd_read, pd_read, files):
         assert_eq(df, expected2, check_dtype=False)
 
 
+@pytest.mark.parametrize('dd_read,pd_read,files',
+                         [(dd.read_csv, pd.read_csv, csv_files),
+                          (dd.read_table, pd.read_table, tsv_files)])
+def test_read_csv_files_list(dd_read, pd_read, files):
+    with filetexts(files, mode='b'):
+        subset = sorted(files)[:2]  # Just first 2
+        sol = pd.concat([pd_read(BytesIO(files[k])) for k in subset])
+        res = dd_read(subset)
+        assert_eq(res, sol, check_dtype=False)
+
+        with pytest.raises(ValueError):
+            dd_read([])
+
+
 # After this point, we test just using read_csv, as all functionality
 # for both is implemented using the same code.
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -151,6 +151,17 @@ def test_read_glob(tmpdir, write_engine, read_engine):
     assert_eq(df, ddf2)
 
 
+@write_read_engines()
+def test_read_list(tmpdir, write_engine, read_engine):
+    tmpdir = str(tmpdir)
+    ddf.to_parquet(tmpdir, engine=write_engine)
+    files = sorted(os.path.join(tmpdir, f)
+                   for f in os.listdir(tmpdir)
+                   if not f.endswith('_metadata'))
+    ddf2 = dd.read_parquet(files, engine=read_engine)
+    assert_eq(df, ddf2)
+
+
 @write_read_engines_xfail
 def test_auto_add_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,8 +17,10 @@ Array
 DataFrame
 +++++++++
 
--  Support month timedeltas in repartition(freq=...) (:pr:`3110`) `Matthew Rocklin`_
--  Avoid mutation in dataframe groupby tests (:pr:`3118`) `Matthew Rocklin`_
+- Support month timedeltas in repartition(freq=...) (:pr:`3110`) `Matthew Rocklin`_
+- Avoid mutation in dataframe groupby tests (:pr:`3118`) `Matthew Rocklin`_
+- ``read_csv``, ``read_table``, and ``read_parquet`` accept iterables of paths
+  (:pr:`3124`) `Jim Crist`_
 
 Bag
 +++


### PR DESCRIPTION
Allows passing iterables of paths to `dd.read_csv`/`dd.read_table`/`dd.read_parquet`/`db.read_text`. Fixes #1948.