### PR TITLE
Add `optimize_graph` kwarg to `to_delayed` methods

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1833,10 +1833,14 @@ class Array(Base):
         memo[id(self)] = c
         return c
 
-    def to_delayed(self):
-        """ Convert Array into dask Delayed objects
+    def to_delayed(self, optimize_graph=True):
+        """Convert into an array of ``dask.delayed`` objects, one per chunk.
 
-        Returns an array of values, one value per chunk.
+        Parameters
+        ----------
+        optimize_graph : bool, optional
+            If True [default], the graph is optimized before converting into
+            ``dask.delayed`` objects.
 
         See Also
         --------
@@ -1844,7 +1848,9 @@ class Array(Base):
         """
         from ..delayed import Delayed
         keys = self.__dask_keys__()
-        dsk = self.__dask_optimize__(self.__dask_graph__(), keys)
+        dsk = self.__dask_graph__()
+        if optimize_graph:
+            dsk = self.__dask_optimize__(dsk, keys)
         L = ndeepmap(self.ndim, lambda k: Delayed(k, dsk), keys)
         return np.array(L, dtype=object)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2370,11 +2370,19 @@ def test_to_delayed():
     assert a.compute() == s
 
 
-def test_to_delayed_optimizes():
+def test_to_delayed_optimize_graph():
     x = da.ones((4, 4), chunks=(2, 2))
     y = x[1:][1:][1:][:, 1:][:, 1:][:, 1:]
+
+    # optimizations
     d = y.to_delayed().flatten().tolist()[0]
     assert len([k for k in d.dask if k[0].startswith('getitem')]) == 1
+
+    # no optimizations
+    d2 = y.to_delayed(optimize_graph=False).flatten().tolist()[0]
+    assert dict(d2.dask) == dict(y.dask)
+
+    assert (d.compute() == d2.compute()).all()
 
 
 def test_cumulative():

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -528,17 +528,36 @@ def test_from_delayed_sorted():
 def test_to_delayed():
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
     ddf = dd.from_pandas(df, npartitions=2)
+
+    # Frame
     a, b = ddf.to_delayed()
     assert isinstance(a, Delayed)
     assert isinstance(b, Delayed)
-
     assert_eq(a.compute(), df.iloc[:2])
 
+    # Scalar
+    x = ddf.x.sum()
+    dx = x.to_delayed()
+    assert isinstance(dx, Delayed)
+    assert_eq(dx.compute(), x)
 
-def test_to_delayed_optimizes():
+
+def test_to_delayed_optimize_graph():
     df = pd.DataFrame({'x': list(range(20))})
     ddf = dd.from_pandas(df, npartitions=20)
-    x = (ddf + 1).loc[:2]
+    ddf2 = (ddf + 1).loc[:2]
 
-    d = x.to_delayed()[0]
+    # Frame
+    d = ddf2.to_delayed()[0]
     assert len(d.dask) < 20
+    d2 = ddf2.to_delayed(optimize_graph=False)[0]
+    assert sorted(d2.dask) == sorted(ddf2.dask)
+    assert_eq(ddf2.get_partition(0), d.compute())
+    assert_eq(ddf2.get_partition(0), d2.compute())
+
+    # Scalar
+    x = ddf2.x.sum()
+    dx = x.to_delayed()
+    dx2 = x.to_delayed(optimize_graph=False)
+    assert len(dx.dask) < len(dx2.dask)
+    assert_eq(dx.compute(), dx2.compute())

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,8 @@ DataFrame
 - Avoid mutation in dataframe groupby tests (:pr:`3118`) `Matthew Rocklin`_
 - ``read_csv``, ``read_table``, and ``read_parquet`` accept iterables of paths
   (:pr:`3124`) `Jim Crist`_
+- Deprecates the ``dd.to_delayed`` *function* in favor of the existing method
+  (:pr:`3126`) `Jim Crist`_
 
 Bag
 +++
@@ -39,6 +41,8 @@ Core
   computing. (:pr:`3071`) `Jim Crist`_
 - Rename ``dask.optimize`` module to ``dask.optimization`` (:pr:`3071`) `Jim Crist`_
 - Change task ordering to do a full traversal (:pr:`3066`) `Matthew Rocklin`_
+- Adds an ``optimize_graph`` keyword to all ``to_delayed`` methods to allow
+  controlling whether optimizations occur on conversion. (:pr:`3126`) `Jim Crist`_
 
 
 0.16.1 / 2018-01-09

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -292,7 +292,6 @@ Store DataFrames
     to_hdf
     to_records
     to_bag
-    to_delayed
 
 DataFrame Methods
 ~~~~~~~~~~~~~~~~~
@@ -341,7 +340,6 @@ Storage and Conversion
 .. autofunction:: from_bcolz
 .. autofunction:: from_dask_array
 .. autofunction:: from_delayed
-.. autofunction:: to_delayed
 .. autofunction:: to_records
 .. autofunction:: to_csv
 .. autofunction:: to_bag

--- a/docs/source/dataframe-create.rst
+++ b/docs/source/dataframe-create.rst
@@ -39,7 +39,7 @@ Dask Collections:
     from_delayed
     from_dask_array
     dask.bag.core.Bag.to_dataframe
-    to_delayed
+    DataFrame.to_delayed
     to_records
     to_bag
 


### PR DESCRIPTION
Adds an `optimize_graph` kwarg to all `to_delayed` methods indicating whether to optimize the graph before the conversion (default True). Adds tests and docs for this functionality.

Also deprecates the ``dd.to_delayed`` function, as this was inconsistent with other collection's api's.

Fixes #3061.