### PR TITLE
Allow loading of parquet files which have multi-index

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -234,6 +234,8 @@ def _read_fastparquet(fs, fs_token, paths, columns=None, filters=None,
         index_names, column_names, storage_name_mapping, column_index_names = (
             _parse_pandas_metadata(json.loads(pandas_md[0]))
         )
+        column_names = [n for n in index_names
+                        if n != (index or "")] + column_names
     else:
         raise ValueError("File has multiple entries for 'pandas' metadata")
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -945,6 +945,7 @@ def test_writing_parquet_with_unknown_kwargs(tmpdir, engine):
 
 
 def test_user_index(tmpdir):
+    check_fastparquet()
     engine = 'fastparquet'
     fn = os.path.join(str(tmpdir), 'data.parq')
     df = pd.DataFrame(np.random.randn(10, 2), columns=['a', 'b'],

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -942,3 +942,29 @@ def test_writing_parquet_with_unknown_kwargs(tmpdir, engine):
 
     with pytest.raises(TypeError):
         ddf.to_parquet(fn,  engine=engine, unknown_key='unknown_value')
+
+
+def test_user_index(tmpdir):
+    engine = 'fastparquet'
+    fn = os.path.join(str(tmpdir), 'data.parq')
+    df = pd.DataFrame(np.random.randn(10, 2), columns=['a', 'b'],
+                      index=pd.MultiIndex.from_arrays(
+                          [np.arange(10), np.arange(10) + 1],
+                          names=['x0', 'x1']))
+    df.to_parquet(fn, write_index=True, engine='fastparquet')
+
+    with pytest.raises(Exception):
+        # You get ValueError in fastparquet, NotImplementedError in pyarrow
+        dd.read_parquet(fn, engine=engine)
+
+    d = dd.read_parquet(fn, index=False, engine=engine)
+    assert d.columns.tolist() == ['x0', 'x1', 'a', 'b']
+    assert_eq(d, df.reset_index())
+
+    d = dd.read_parquet(fn, index=['a'], engine=engine)
+    assert d.columns.tolist() == ['x0', 'x1', 'b']
+    assert_eq(d, df.reset_index().set_index('a'))
+
+    d = dd.read_parquet(fn, index=['x0'], engine=engine)
+    assert d.columns.tolist() == ['x1', 'a', 'b']
+    assert_eq(d, df.reset_index().set_index('x0'))


### PR DESCRIPTION
Requires the user to specify which index then want (including False
for no index), and rest of index columns then appear as ordinary
columns.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
