### PR TITLE
WIP: Aggregation methods for object-type array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -61,6 +61,20 @@ def register_sparse():
     tensordot_lookup.register(sparse.COO, sparse.tensordot)
 
 
+concatenate_lookup = Dispatch('concatenate')
+tensordot_lookup = Dispatch('tensordot')
+concatenate_lookup.register((object, np.ndarray), np.concatenate)
+tensordot_lookup.register((object, np.ndarray), np.tensordot)
+
+
+@tensordot_lookup.register_lazy('sparse')
+@concatenate_lookup.register_lazy('sparse')
+def register_sparse():
+    import sparse
+    concatenate_lookup.register(sparse.COO, sparse.concatenate)
+    tensordot_lookup.register(sparse.COO, sparse.tensordot)
+
+
 def getter(a, b, asarray=True, lock=None):
     if isinstance(b, tuple) and any(x is None for x in b):
         b2 = tuple(x for x in b if x is not None)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -61,20 +61,6 @@ def register_sparse():
     tensordot_lookup.register(sparse.COO, sparse.tensordot)
 
 
-concatenate_lookup = Dispatch('concatenate')
-tensordot_lookup = Dispatch('tensordot')
-concatenate_lookup.register((object, np.ndarray), np.concatenate)
-tensordot_lookup.register((object, np.ndarray), np.tensordot)
-
-
-@tensordot_lookup.register_lazy('sparse')
-@concatenate_lookup.register_lazy('sparse')
-def register_sparse():
-    import sparse
-    concatenate_lookup.register(sparse.COO, sparse.concatenate)
-    tensordot_lookup.register(sparse.COO, sparse.tensordot)
-
-
 def getter(a, b, asarray=True, lock=None):
     if isinstance(b, tuple) and any(x is None for x in b):
         b2 = tuple(x for x in b if x is not None)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import warnings
-
 from functools import partial, wraps
 from itertools import product, repeat
 from math import factorial, log, ceil
@@ -442,12 +440,6 @@ def vnorm(a, ord=None, axis=None, dtype=None, keepdims=False, split_every=None,
 
     See np.linalg.norm
     """
-
-    warnings.warn(
-        "DeprecationWarning: Please use `dask.array.linalg.norm` instead.",
-        UserWarning
-    )
-
     if ord is None or ord == 'fro':
         ord = 2
     if ord == np.inf:

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 from functools import partial, wraps
 from itertools import product, repeat
 from math import factorial, log, ceil
@@ -440,6 +442,12 @@ def vnorm(a, ord=None, axis=None, dtype=None, keepdims=False, split_every=None,
 
     See np.linalg.norm
     """
+
+    warnings.warn(
+        "DeprecationWarning: Please use `dask.array.linalg.norm` instead.",
+        UserWarning
+    )
+
     if ord is None or ord == 'fro':
         ord = 2
     if ord == np.inf:

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -143,7 +143,7 @@ def sum(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None):
     if dtype is not None:
         dt = dtype
     else:
-        dt = np.empty((1,), dtype=a.dtype).sum().dtype
+        dt = np.empty((1,), dtype=a.dtype).sum(keepdims=True).dtype
     return reduction(a, chunk.sum, chunk.sum, axis=axis, keepdims=keepdims,
                      dtype=dt, split_every=split_every, out=out)
 
@@ -153,7 +153,7 @@ def prod(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None):
     if dtype is not None:
         dt = dtype
     else:
-        dt = np.empty((1,), dtype=a.dtype).prod().dtype
+        dt = np.empty((1,), dtype=a.dtype).prod(keepdims=True).dtype
     return reduction(a, chunk.prod, chunk.prod, axis=axis, keepdims=keepdims,
                      dtype=dt, split_every=split_every, out=out)
 
@@ -187,7 +187,7 @@ def nansum(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None)
     if dtype is not None:
         dt = dtype
     else:
-        dt = chunk.nansum(np.empty((1,), dtype=a.dtype)).dtype
+        dt = getattr(chunk.nansum(np.empty((1,), dtype=a.dtype)), 'dtype', object)
     return reduction(a, chunk.nansum, chunk.sum, axis=axis, keepdims=keepdims,
                      dtype=dt, split_every=split_every, out=out)
 
@@ -199,7 +199,7 @@ with ignoring(AttributeError):
         if dtype is not None:
             dt = dtype
         else:
-            dt = chunk.nanprod(np.empty((1,), dtype=a.dtype)).dtype
+            dt = getattr(chunk.nansum(np.empty((1,), dtype=a.dtype)), 'dtype', object)
         return reduction(a, chunk.nanprod, chunk.prod, axis=axis,
                          keepdims=keepdims, dtype=dt, split_every=split_every,
                          out=out)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -269,7 +269,7 @@ def mean(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None):
     if dtype is not None:
         dt = dtype
     else:
-        dt = np.mean(np.empty(shape=(1,), dtype=a.dtype)).dtype
+        dt = getattr(np.mean(np.empty(shape=(1,), dtype=a.dtype)), 'dtype', object)
     return reduction(a, mean_chunk, mean_agg, axis=axis, keepdims=keepdims,
                      dtype=dt, split_every=split_every, combine=mean_combine,
                      out=out)
@@ -280,7 +280,7 @@ def nanmean(a, axis=None, dtype=None, keepdims=False, split_every=None,
     if dtype is not None:
         dt = dtype
     else:
-        dt = np.mean(np.empty(shape=(1,), dtype=a.dtype)).dtype
+        dt = getattr(np.mean(np.empty(shape=(1,), dtype=a.dtype)), 'dtype', object)
     return reduction(a, partial(mean_chunk, sum=chunk.nansum, numel=nannumel),
                      mean_agg, axis=axis, keepdims=keepdims, dtype=dt,
                      split_every=split_every, out=out,
@@ -377,7 +377,7 @@ def moment(a, order, axis=None, dtype=None, keepdims=False, ddof=0,
     if dtype is not None:
         dt = dtype
     else:
-        dt = np.var(np.ones(shape=(1,), dtype=a.dtype)).dtype
+        dt = getattr(np.var(np.ones(shape=(1,), dtype=a.dtype)), 'dtype', object)
     return reduction(a, partial(moment_chunk, order=order),
                      partial(moment_agg, order=order, ddof=ddof),
                      axis=axis, keepdims=keepdims,
@@ -391,7 +391,7 @@ def var(a, axis=None, dtype=None, keepdims=False, ddof=0, split_every=None,
     if dtype is not None:
         dt = dtype
     else:
-        dt = np.var(np.ones(shape=(1,), dtype=a.dtype)).dtype
+        dt = getattr(np.var(np.ones(shape=(1,), dtype=a.dtype)), 'dtype', object)
     return reduction(a, moment_chunk, partial(moment_agg, ddof=ddof), axis=axis,
                      keepdims=keepdims, dtype=dt, split_every=split_every,
                      combine=moment_combine, name='var', out=out)
@@ -402,7 +402,7 @@ def nanvar(a, axis=None, dtype=None, keepdims=False, ddof=0, split_every=None,
     if dtype is not None:
         dt = dtype
     else:
-        dt = np.var(np.ones(shape=(1,), dtype=a.dtype)).dtype
+        dt = getattr(np.var(np.ones(shape=(1,), dtype=a.dtype)), 'dtype', object)
     return reduction(a, partial(moment_chunk, sum=chunk.nansum, numel=nannumel),
                      partial(moment_agg, sum=np.nansum, ddof=ddof), axis=axis,
                      keepdims=keepdims, dtype=dt, split_every=split_every,
@@ -655,7 +655,7 @@ def cumreduction(func, binop, ident, x, axis=None, dtype=None, out=None):
         x = x.flatten()
         axis = 0
     if dtype is None:
-        dtype = func(np.empty((0,), dtype=x.dtype)).dtype
+        dtype = getattr(func(np.empty((0,), dtype=x.dtype)), 'dtype', object)
     assert isinstance(axis, int)
     axis = validate_axis(x.ndim, axis)
 

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -143,7 +143,7 @@ def sum(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None):
     if dtype is not None:
         dt = dtype
     else:
-        dt = np.empty((1,), dtype=a.dtype).sum(keepdims=True).dtype
+        dt = getattr(np.empty((1,), dtype=a.dtype).sum(), 'dtype', object)
     return reduction(a, chunk.sum, chunk.sum, axis=axis, keepdims=keepdims,
                      dtype=dt, split_every=split_every, out=out)
 
@@ -153,7 +153,7 @@ def prod(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None):
     if dtype is not None:
         dt = dtype
     else:
-        dt = np.empty((1,), dtype=a.dtype).prod(keepdims=True).dtype
+        dt = getattr(np.empty((1,), dtype=a.dtype).prod(), 'dtype', object)
     return reduction(a, chunk.prod, chunk.prod, axis=axis, keepdims=keepdims,
                      dtype=dt, split_every=split_every, out=out)
 

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -17,28 +17,8 @@ except ImportError:  # pragma: no cover
     nanprod = npcompat.nanprod
 
 
-def assert_eq(a, b, check_dtype=False):
-    _assert_eq(a, b, equal_nan=True, check_dtype=False)
-
-
-def assert_nan_eq(a, b):
-    """ Similar to assert_eq but accept nan value """
-    if hasattr(a, 'compute'):
-        a = a.compute()
-    if hasattr(b, 'compute'):
-        b = b.compute()
-
-    assert type(a) == type(b)
-    a = np.array(a)
-    b = np.array(b)
-    assert a.shape == b.shape
-
-    nanidx = a != b
-    assert np.isnan(a[nanidx].astype(float)).all()
-    assert np.isnan(b[nanidx].astype(float)).all()
-    a[nanidx] = 0.0
-    b[nanidx] = 0.0
-    assert_eq(a, b)
+def assert_eq(a, b):
+    _assert_eq(a, b, equal_nan=True)
 
 
 def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True, split_every=True):
@@ -319,9 +299,9 @@ def test_nan_object(func):
                   [9, 10, 11, 12]]).astype(object)
     d = da.from_array(x, chunks=(2, 2))
 
-    assert_eq(getattr(np, func)(x, axis=0), getattr(da, func)(d, axis=0), check_dtype=False)
-    assert_eq(getattr(np, func)(x, axis=1), getattr(da, func)(d, axis=1), check_dtype=False)
-    assert_eq(getattr(np, func)(x), getattr(da, func)(d), check_dtype=False)
+    assert_eq(getattr(np, func)(x, axis=0), getattr(da, func)(d, axis=0))
+    assert_eq(getattr(np, func)(x, axis=1), getattr(da, func)(d, axis=1))
+    assert_eq(getattr(np, func)(x), getattr(da, func)(d))
 
 
 def test_0d_array():

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -134,7 +134,7 @@ def test_reductions_2D(dtype):
     a = da.from_array(x, chunks=(4, 4))
 
     b = a.sum(keepdims=True)
-    assert b.__dask_keys__() == [[(b.name, 0, 0)]]
+    assert b._keys() == [[(b.name, 0, 0)]]
 
     reduction_2d_test(da.sum, a, np.sum, x)
     reduction_2d_test(da.prod, a, np.prod, x)

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -25,10 +25,13 @@ def assert_nan_eq(a, b):
     """ Similar to assert_eq but accept nan value """
     if hasattr(a, 'compute'):
         a = a.compute()
-    a = np.array(a)
     if hasattr(b, 'compute'):
         b = b.compute()
+
+    assert type(a) == type(b)
+    a = np.array(a)
     b = np.array(b)
+    assert a.shape == b.shape
 
     nanidx = a != b
     assert np.isnan(a[nanidx].astype(float)).all()

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -17,8 +17,8 @@ except ImportError:  # pragma: no cover
     nanprod = npcompat.nanprod
 
 
-def assert_eq(a, b):
-    _assert_eq(a, b, equal_nan=True)
+def assert_eq(a, b, check_dtype=False):
+    _assert_eq(a, b, equal_nan=True, check_dtype=False)
 
 
 def assert_nan_eq(a, b):
@@ -319,9 +319,9 @@ def test_nan_object(func):
                   [9, 10, 11, 12]]).astype(object)
     d = da.from_array(x, chunks=(2, 2))
 
-    assert_nan_eq(getattr(np, func)(x, axis=0), getattr(da, func)(d, axis=0))
-    assert_nan_eq(getattr(np, func)(x, axis=1), getattr(da, func)(d, axis=1))
-    assert_nan_eq(getattr(np, func)(x), getattr(da, func)(d))
+    assert_eq(getattr(np, func)(x, axis=0), getattr(da, func)(d, axis=0), check_dtype=False)
+    assert_eq(getattr(np, func)(x, axis=1), getattr(da, func)(d, axis=1), check_dtype=False)
+    assert_eq(getattr(np, func)(x), getattr(da, func)(d), check_dtype=False)
 
 
 def test_0d_array():

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -290,6 +290,19 @@ def test_nan():
     assert_eq(nanprod(x), da.nanprod(d))
 
 
+@pytest.mark.parametrize('func', ['nansum', 'sum', 'nanmin', 'min',
+                                  'nanmax', 'max'])
+def test_nan_object(func):
+    x = np.array([[1, np.nan, 3, 4],
+                  [5, 6, 7, np.nan],
+                  [9, 10, 11, 12]]).astype(object)
+    d = da.from_array(x, chunks=(2, 2))
+
+    assert_eq(getattr(np, func)(x), getattr(da, func)(d))
+    assert_eq(getattr(np, func)(x, axis=0), getattr(da, func)(d, axis=0))
+    assert_eq(getattr(np, func)(x, axis=1), getattr(da, func)(d, axis=1))
+
+
 def test_0d_array():
     x = da.mean(da.ones(4, chunks=4), axis=0).compute()
     y = np.mean(np.ones(4))

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -134,7 +134,7 @@ def test_reductions_2D(dtype):
     a = da.from_array(x, chunks=(4, 4))
 
     b = a.sum(keepdims=True)
-    assert b._keys() == [[(b.name, 0, 0)]]
+    assert b.__dask_keys__() == [[(b.name, 0, 0)]]
 
     reduction_2d_test(da.sum, a, np.sum, x)
     reduction_2d_test(da.prod, a, np.prod, x)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 Array
 +++++
 
+- Added a support object-type arrays for nansum, nanmin, and nanmax (:issue:`3133`) `Keisuke Fujii`_
 - Update error handling when len is called with empty chunks (:issue:`3058`) `Xander Johnson`_
 - Fixes a metadata bug with ``store``'s ``return_stored`` option (:pr:`3064`) `John A Kirkham`_
 - Fix a bug in ``optimization.fuse_slice`` to properly handle when first input is ``None`` (:pr:`3076`) `James Bourbeau`_


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API

This fixes #3133.
As the current `assert_eq` looks unable to take care 
+ `nan`-included arrays
+ scalar
I added `assert_nan_eq` function in test_reductions.py, but there should be better ways to do this.

I appreciate any suggestions.

