### PR TITLE
df.query works with kwargs

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2519,19 +2519,7 @@ class DataFrame(_Frame):
         --------
         pandas.DataFrame.query
         """
-        name = 'query-%s' % tokenize(self, expr)
-        if kwargs:
-            name = name + '--' + tokenize(kwargs)
-            dsk = dict(((name, i), (apply, M.query,
-                                    ((self._name, i), (expr,), kwargs)))
-                       for i in range(self.npartitions))
-        else:
-            dsk = dict(((name, i), (M.query, (self._name, i), expr))
-                       for i in range(self.npartitions))
-
-        meta = self._meta.query(expr, **kwargs)
-        return new_dd_object(merge(dsk, self.dask), name,
-                             meta, self.divisions)
+        return self.map_partitions(M.query, expr, **kwargs)
 
     @derived_from(pd.DataFrame)
     def eval(self, expr, inplace=None, **kwargs):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -10,7 +10,7 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.base import compute_as_if_collection
-from dask.utils import ignoring, put_lines
+from dask.utils import put_lines
 
 from dask.dataframe.core import repartition_divisions, aca, _concat, Scalar
 from dask.dataframe import methods
@@ -1504,29 +1504,34 @@ def test_empty_max():
 
 
 def test_query():
+    pytest.importorskip('numexpr')
+
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})
-    a = dd.from_pandas(df, npartitions=2)
-    q = a.query('x**2 > y')
-    with ignoring(ImportError):
-        assert_eq(q, df.query('x**2 > y'))
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert_eq(ddf.query('x**2 > y'),
+              df.query('x**2 > y'))
+    assert_eq(ddf.query('x**2 > @value', local_dict={'value': 4}),
+              df.query('x**2 > @value', local_dict={'value': 4}))
 
 
 def test_eval():
+    pytest.importorskip('numexpr')
+
     p = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})
     d = dd.from_pandas(p, npartitions=2)
-    with ignoring(ImportError):
-        assert_eq(p.eval('x + y'), d.eval('x + y'))
-        assert_eq(p.eval('z = x + y', inplace=False),
-                  d.eval('z = x + y', inplace=False))
-        with pytest.raises(NotImplementedError):
-            d.eval('z = x + y', inplace=True)
 
-        # catch FutureWarning from pandas about assignment in eval
-        with pytest.warns(None):
-            if PANDAS_VERSION < '0.21.0':
-                if p.eval('z = x + y', inplace=None) is None:
-                    with pytest.raises(NotImplementedError):
-                        d.eval('z = x + y', inplace=None)
+    assert_eq(p.eval('x + y'), d.eval('x + y'))
+    assert_eq(p.eval('z = x + y', inplace=False),
+              d.eval('z = x + y', inplace=False))
+    with pytest.raises(NotImplementedError):
+        d.eval('z = x + y', inplace=True)
+
+    # catch FutureWarning from pandas about assignment in eval
+    with pytest.warns(None):
+        if PANDAS_VERSION < '0.21.0':
+            if p.eval('z = x + y', inplace=None) is None:
+                with pytest.raises(NotImplementedError):
+                    d.eval('z = x + y', inplace=None)
 
 
 @pytest.mark.parametrize('include, exclude', [


### PR DESCRIPTION
Previously this would error out. Also simplified the implementation and
cleaned up the tests for both query and eval.

Fixes #3093.
