### PR TITLE
Improve support for dd.read_parquet with multi-indices

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -163,32 +163,25 @@ def test_read_list(tmpdir, write_engine, read_engine):
 
 
 @write_read_engines_xfail
-def test_auto_add_index(tmpdir, write_engine, read_engine):
+def test_columns_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=write_engine)
-    ddf2 = dd.read_parquet(fn, columns=['x'], index='myindex', engine=read_engine)
-    assert_eq(df[['x']], ddf2)
+    df2 = df.reset_index()
+
+    assert_eq(dd.read_parquet(fn, columns=[], engine=read_engine), df[[]])
+    assert_eq(dd.read_parquet(fn, columns=['x'], engine=read_engine), df[['x']])
+    assert_eq(dd.read_parquet(fn, index='myindex', columns=['x'], engine=read_engine), df[['x']])
+    assert_eq(dd.read_parquet(fn, index='myindex', columns=['x', 'y'], engine=read_engine), df)
+
+    assert_eq(dd.read_parquet(fn, index=False, engine=read_engine),
+              df2, check_index=False)
+    assert_eq(dd.read_parquet(fn, index=False, columns=['x', 'y'], engine=read_engine),
+              df, check_index=False)
+    assert_eq(dd.read_parquet(fn, index=False, columns=['myindex', 'x'], engine=read_engine),
+              df2[['myindex', 'x']], check_index=False)
 
 
-@write_read_engines_xfail
-def test_index_column_false_index(tmpdir, write_engine, read_engine):
-    fn = str(tmpdir)
-    ddf.to_parquet(fn, engine=write_engine)
-    ddf2 = dd.read_parquet(fn, columns=['myindex'], index=False, engine=read_engine)
-    assert_eq(pd.DataFrame(df.index), ddf2, check_index=False)
-
-
-@pytest.mark.parametrize("columns", [['myindex'], []])
-@pytest.mark.parametrize("index", ['myindex', None])
-@write_read_engines_xfail
-def test_columns_index(tmpdir, write_engine, read_engine, columns, index):
-    fn = str(tmpdir)
-    ddf.to_parquet(fn, engine=write_engine)
-    ddf2 = dd.read_parquet(fn, columns=columns, index=index, engine=read_engine)
-    assert_eq(df[[]], ddf2)
-
-
-def test_index_with_multi_index(tmpdir, engine):
+def test_columns_index_with_multi_index(tmpdir, engine):
     fn = os.path.join(str(tmpdir), 'test.parquet')
     index = pd.MultiIndex.from_arrays([np.arange(10), np.arange(10) + 1],
                                       names=['x0', 'x1'])
@@ -205,13 +198,17 @@ def test_index_with_multi_index(tmpdir, engine):
         import pyarrow as pa
         pq.write_table(pa.Table.from_pandas(df), fn)
 
+        # Pyarrow supports multi-index reads
         ddf = dd.read_parquet(fn, engine=engine)
         assert_eq(ddf, df)
 
-        d = dd.read_parquet(fn, columns=['x0', 'a'], engine=engine)
-        assert_eq(d, df[['a']])
+        d = dd.read_parquet(fn, columns='a', engine=engine)
+        assert_eq(d, df['a'])
 
-    # DataFrame output
+        d = dd.read_parquet(fn, index=['a', 'b'], columns=['x0', 'x1'], engine=engine)
+        assert_eq(d, df2.set_index(['a', 'b'])[['x0', 'x1']])
+
+    # Just index
     d = dd.read_parquet(fn, index=False, engine=engine)
     assert_eq(d, df2)
 
@@ -221,25 +218,31 @@ def test_index_with_multi_index(tmpdir, engine):
     d = dd.read_parquet(fn, index=['x0'], engine=engine)
     assert_eq(d, df2.set_index('x0')[['a', 'b']])
 
-    # Set columns explictly
+    # Just columns
+    d = dd.read_parquet(fn, columns=['x0', 'a'], engine=engine)
+    assert_eq(d, df2.set_index('x1')[['x0', 'a']])
+
+    # Both index and columns
     d = dd.read_parquet(fn, index=False, columns=['x0', 'b'], engine=engine)
     assert_eq(d, df2[['x0', 'b']])
 
-    d = dd.read_parquet(fn, index=['a'], columns=['x0', 'a'], engine=engine)
-    assert_eq(d, df2.set_index('a')[['x0']])
+    for index in ['x1', 'b']:
+        d = dd.read_parquet(fn, index=index, columns=['x0', 'a'], engine=engine)
+        assert_eq(d, df2.set_index(index)[['x0', 'a']])
 
-    d = dd.read_parquet(fn, index=['x0'], columns=['x0', 'a'], engine=engine)
-    assert_eq(d, df2.set_index('x0')[['a']])
+    # Columns and index intersect
+    for index in ['a', 'x0']:
+        with pytest.raises(ValueError):
+            d = dd.read_parquet(fn, index=index, columns=['x0', 'a'], engine=engine)
 
     # Series output
-    for index in [False, 'a']:
-        for column in ['b', 'x0']:
-            d = dd.read_parquet(fn, index=index, columns=column, engine=engine)
-            sol = df2.set_index(index)[column] if index else df2[column]
-            assert_eq(d, sol)
-
-    with pytest.raises(ValueError):
-        dd.read_parquet(fn, columns='x0', engine=engine)
+    for ind, col, sol_df in [(None, 'x0', df2.set_index('x1')),
+                             (False, 'b', df2),
+                             (False, 'x0', df2),
+                             ('a', 'x0', df2.set_index('a')),
+                             ('a', 'b', df2.set_index('a'))]:
+        d = dd.read_parquet(fn, index=ind, columns=col, engine=engine)
+        assert_eq(d, sol_df[col])
 
 
 @write_read_engines_xfail

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -25,6 +25,8 @@ DataFrame
 - Deprecates the ``dd.to_delayed`` *function* in favor of the existing method
   (:pr:`3126`) `Jim Crist`_
 - Return dask.arrays from df.map_partitions calls when the UDF returns a numpy array (:pr:`3147`) `Matthew Rocklin`_
+- Change handling of ``columns`` and ``index`` in ``dd.read_parquet`` to be more
+  consistent, especially in handling of multi-indices (:pr:`3149`) `Jim Crist`_
 
 Bag
 +++
@@ -945,3 +947,4 @@ Other
 .. _`Jon Mease`: https://github.com/jmmease
 .. _`Xander Johnson`: https://github.com/metasyn
 .. _`Nir`: https://github.com/nirizr
+.. _`Keisuke Fujii`: https://github.com/fujiisoup


### PR DESCRIPTION
Be more robust in interpreting `index=..., columns=...` when dealing with a parquet file with a multi-index.

Fixes #3104, supersedes #3132.
