### PR TITLE
Add doc note bag.map_partition callback should expect generators

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -616,12 +616,10 @@ class Bag(Base):
         Parameters
         ----------
         func : callable
-            ``func`` will be called for every partition.
-            ``func`` should expect every ``Bag``, ``Item`` and ``Delayed``
-            object as either an ``Iterator`` or ``Iterable``, depending on the
-            preceding tasks in the task graph. As this is an implementation
-            detail, type of object is not gurenteed to be consistent between
-            versions).
+            The function to be called on every partition.
+            This function should expect an ``Iterator`` or ``Iterable`` for
+            every partition and should return an ``Iterator`` or ``Iterable``
+            in return.
         *args, **kwargs : Bag, Item, Delayed, or object
             Arguments and keyword arguments to pass to ``func``.
             Partitions from this bag will be the first argument, and these will

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -616,6 +616,12 @@ class Bag(Base):
         Parameters
         ----------
         func : callable
+            ``func`` will be called for every partition.
+            ``func`` should expect every ``Bag``, ``Item`` and ``Delayed``
+            object as either an ``Iterator`` or ``Iterable``, depending on the
+            preceding tasks in the task graph. As this is an implementation
+            detail, type of object is not gurenteed to be consistent between
+            versions).
         *args, **kwargs : Bag, Item, Delayed, or object
             Arguments and keyword arguments to pass to ``func``.
             Partitions from this bag will be the first argument, and these will

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -28,6 +28,7 @@ DataFrame
 Bag
 +++
 
+- Document ``bag.map_paritions`` function may recieve either a list or generator.
 
 Core
 ++++

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -28,7 +28,7 @@ DataFrame
 Bag
 +++
 
-- Document ``bag.map_paritions`` function may recieve either a list or generator.
+- Document ``bag.map_paritions`` function may recieve either a list or generator. (:pr:`3150`) `Nir`_
 
 Core
 ++++
@@ -943,3 +943,4 @@ Other
 .. _`Martijn Arts`: https://github.com/mfaafm
 .. _`Jon Mease`: https://github.com/jmmease
 .. _`Xander Johnson`: https://github.com/metasyn
+.. _`Nir`: https://github.com/nirizr


### PR DESCRIPTION
Specific questions:
* Is this clear enough?
* Can this happen anywhere else?

- [x] Tests added / passed
- [X] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
