### PR TITLE
Minor optimizations to Dask Array's store

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -889,7 +889,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
     sources_dsk = sharedict.merge(*[e.__dask_graph__() for e in sources])
     sources_dsk = Array.__dask_optimize__(
         sources_dsk,
-        [e.__dask_keys__() for e in sources]
+        list(core.flatten([e.__dask_keys__() for e in sources]))
     )
 
     tgt_dsks = []

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2702,12 +2702,14 @@ def insert_to_ooc(arr, out, lock=True, region=None, return_stored=False):
         lock = Lock()
 
     slices = slices_from_chunks(arr.chunks)
+    if region:
+        slices = [fuse_slice(region, slc) for slc in slices]
 
     name = 'store-%s' % arr.name
     dsk = dict()
     for t, slc in zip(core.flatten(arr.__dask_keys__()), slices):
         store_key = (name,) + t[1:]
-        dsk[store_key] = (store_chunk, t, out, slc, lock, region, return_stored)
+        dsk[store_key] = (store_chunk, t, out, slc, lock, None, return_stored)
 
     return dsk
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -18,12 +18,12 @@ import uuid
 import warnings
 
 try:
-    from cytoolz import (partition, concat, concatv, join, first,
+    from cytoolz import (partition, concat, join, first,
                          groupby, valmap, accumulate, assoc)
     from cytoolz.curried import filter, pluck
 
 except ImportError:
-    from toolz import (partition, concat, concatv, join, first,
+    from toolz import (partition, concat, join, first,
                        groupby, valmap, accumulate, assoc)
     from toolz.curried import filter, pluck
 from toolz import pipe, map, reduce
@@ -931,9 +931,8 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         store_keys.extend(each_store_dsk.keys())
         store_dsks.append(each_store_dsk)
 
-    store_dsks_mrg = sharedict.merge(*concatv(
-        store_dsks, [targets_dsk], [sources_dsk]
-    ))
+    store_dsks_mrg = sharedict.merge(*store_dsks)
+    store_dsks_mrg = sharedict.merge(store_dsks_mrg, targets_dsk, sources_dsk)
 
     if return_stored:
         if compute:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -832,7 +832,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
     ----------
 
     sources: Array or iterable of Arrays
-    targets: array-like or iterable of array-likes
+    targets: array-like or Delayed or iterable of array-likes and/or Delayeds
         These should support setitem syntax ``target[10:20] = ...``
     lock: boolean or threading.Lock, optional
         Whether or not to lock the data stores while storing.

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2775,7 +2775,7 @@ def retrieve_from_ooc(keys, dsk):
     for each_key in keys:
         load_key = ('load-%s' % each_key[0],) + each_key[1:]
         # Reuse the result and arguments from `store_chunk` in `load_chunk`.
-        load_dsk[load_key] = (load_chunk, each_key,) + dsk[each_key][3:-1]
+        load_dsk[load_key] = (load_chunk, each_key) + dsk[each_key][3:-1]
 
     return load_dsk
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2718,17 +2718,17 @@ def insert_to_ooc(arr, out, lock=True, region=None,
         slices = [fuse_slice(region, slc) for slc in slices]
 
     name = 'store-%s' % arr.name
-    sto_chunk = store_chunk
+    func = store_chunk
     args = ()
     if return_stored and load_stored:
         name = 'load-store-%s' % arr.name
-        sto_chunk = load_store_chunk
+        func = load_store_chunk
         args = (load_stored,)
 
     dsk = dict()
     for t, slc in zip(core.flatten(arr.__dask_keys__()), slices):
         store_key = (name,) + t[1:]
-        dsk[store_key] = (sto_chunk, t, out, slc, lock, return_stored) + args
+        dsk[store_key] = (func, t, out, slc, lock, return_stored) + args
 
     return dsk
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2746,7 +2746,7 @@ def load_chunk(x, index, lock):
     return result
 
 
-def retrieve_from_ooc(keys, dsk):
+def retrieve_from_ooc(keys, dsk_pre, dsk_post=None):
     """
     Creates a Dask graph for loading stored ``keys`` from ``dsk``.
 
@@ -2754,8 +2754,10 @@ def retrieve_from_ooc(keys, dsk):
     ----------
     keys: Sequence
         A sequence containing Dask graph keys to load
-    dsk: Mapping
-        A Dask graph corresponding to a Dask Array
+    dsk_pre: Mapping
+        A Dask graph corresponding to a Dask Array before computation
+    dsk_post: Mapping, optional
+        A Dask graph corresponding to a Dask Array after computation
 
     Examples
     --------
@@ -2766,11 +2768,14 @@ def retrieve_from_ooc(keys, dsk):
     >>> retrieve_from_ooc(g.keys(), g)  # doctest: +SKIP
     """
 
+    if not dsk_post:
+        dsk_post = {k: k for k in keys}
+
     load_dsk = dict()
-    for each_key in keys:
-        load_key = ('load-%s' % each_key[0],) + each_key[1:]
+    for k in keys:
+        load_key = ('load-%s' % k[0],) + k[1:]
         # Reuse the result and arguments from `store_chunk` in `load_chunk`.
-        load_dsk[load_key] = (load_chunk, each_key) + dsk[each_key][3:-1]
+        load_dsk[load_key] = (load_chunk, dsk_post[k]) + dsk_pre[k][3:-1]
 
     return load_dsk
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2725,10 +2725,10 @@ def insert_to_ooc(arr, out, lock=True, region=None,
         func = load_store_chunk
         args = (load_stored,)
 
-    dsk = dict()
-    for t, slc in zip(core.flatten(arr.__dask_keys__()), slices):
-        store_key = (name,) + t[1:]
-        dsk[store_key] = (func, t, out, slc, lock, return_stored) + args
+    dsk = {
+        (name,) + t[1:]: (func, t, out, slc, lock, return_stored) + args
+        for t, slc in zip(core.flatten(arr.__dask_keys__()), slices)
+    }
 
     return dsk
 
@@ -2758,11 +2758,10 @@ def retrieve_from_ooc(keys, dsk_pre, dsk_post=None):
     if not dsk_post:
         dsk_post = {k: k for k in keys}
 
-    load_dsk = dict()
-    for k in keys:
-        load_key = ('load-%s' % k[0],) + k[1:]
-        # Reuse the result and arguments from `store_chunk` in `load_chunk`.
-        load_dsk[load_key] = (load_chunk, dsk_post[k]) + dsk_pre[k][3:-1]
+    load_dsk = {
+        ('load-' + k[0],) + k[1:]: (load_chunk, dsk_post[k]) + dsk_pre[k][3:-1]
+        for k in keys
+    }
 
     return load_dsk
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1226,7 +1226,13 @@ def test_store_delayed_target():
     # test keeping result
     for st_compute in [False, True]:
         targs.clear()
+
         st = store([a, b], [atd, btd], return_stored=True, compute=st_compute)
+        if st_compute:
+            assert all(
+                not any(dask.core.get_deps(e.dask)[0].values()) for e in st
+            )
+
         st = dask.compute(*st)
 
         at = targs['at']
@@ -1301,7 +1307,11 @@ def test_store_regions():
         )
         assert isinstance(v, tuple)
         assert all([isinstance(e, da.Array) for e in v])
-        if not st_compute:
+        if st_compute:
+            assert all(
+                not any(dask.core.get_deps(e.dask)[0].values()) for e in v
+            )
+        else:
             assert (at == 0).all() and (bt[region] == 0).all()
 
         ar, br = v
@@ -1329,7 +1339,11 @@ def test_store_regions():
         )
         assert isinstance(v, tuple)
         assert all([isinstance(e, da.Array) for e in v])
-        if not st_compute:
+        if st_compute:
+            assert all(
+                not any(dask.core.get_deps(e.dask)[0].values()) for e in v
+            )
+        else:
             assert (at == 0).all() and (bt[region] == 0).all()
 
         ar, br = v

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,7 @@ Array
 +++++
 
 - Corrected dimension chunking in indices (:issue:`3166`, :pr:`3167`) `Simon Perkins`_
+- Inline ``store_chunk`` calls for ``store``'s ``return_stored`` option (:pr:`3153`) `John A Kirkham`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Performs some optimizations for `Delayed` targets. Namely skips collecting empty dictionaries if no `Delayed` target is present. Also optimized the `Delayed` target portion of the Dask as this was not being done before (already done as part of the Dask Array optimizations). In cases not using `Delayed` targets, this should be a no-op.

If `return_stored` and `compute` are both `True`, builds the `load_chunk` Dask after calling `persist` on the `store_chunk` Dask. This comes with the nice benefit of inlining results from `persist` directly into the `load_chunk` Dask. Thus simplifying the graph used for the Dask Arrays constructed in this case. Also simplifies the `for`-loop over sources and targets.

In the case of `return_stored=True` and `compute=False`, fuses the `store_chunk` and `load_chunk` calls into one `load_store_chunk` function per @jcrist's [suggestion]( https://github.com/dask/dask/pull/3082#issuecomment-360571394 ). This allows the lock (if any) to be held for the duration of both the store and load steps. Thus this should avoid contention between store and load steps on chunks.

Merges Dasks corresponding to chunks of particular types (e.g. `Delayed` targets, `store_chunk` calls, `load_chunk` calls) in a few cases before merging with other Dask types.

Also simplifies `store_chunk` and `load_chunk` by running `fuse_slice` for the provided `region` before constructing the Dask. This simplifies the logic in these functions and avoids the overhead (however small) of offloading this work to these functions.

Admittedly of the optimizations done here, similar optimizations are performed when submitting Dask Arrays for computation. However as `store` represents a final step in many ways, it seems reasonable to perform some of these optimizations here before returning to the user.