### PR TITLE
Add HTTPFileSystem

### DIFF
--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -449,6 +449,15 @@ def get_fs(protocol, storage_options=None):
     elif protocol == 'hdfs':
         cls = get_hdfs_driver(_globals.get("hdfs_driver", "auto"))
 
+    elif protocol in ['http', 'https']:
+        import_required('requests',
+                        "Need to install `requests` for HTTP support\n"
+                        "   conda install requests\n"
+                        "    or\n"
+                        "   pip install requests")
+        import dask.bytes.http  # noqa, registers HTTP backend
+        cls = _filesystems[protocol]
+
     else:
         raise ValueError("Unknown protocol %s" % protocol)
 

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -289,7 +289,9 @@ def get_fs_token_paths(urlpath, mode='rb', num=1, name_function=None,
         paths, protocols, options_list = zip(*map(infer_options, urlpath))
         protocol = protocols[0]
         options = options_list[0]
-        if not (all(p == protocol for p in protocols) and
+        if all(p in ['http', 'https'] for p in protocols):
+            pass
+        elif not (all(p == protocol for p in protocols) and
                 all(o == options for o in options_list)):
             raise ValueError("When specifying a list of paths, all paths must "
                              "share the same protocol and options")

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -289,9 +289,7 @@ def get_fs_token_paths(urlpath, mode='rb', num=1, name_function=None,
         paths, protocols, options_list = zip(*map(infer_options, urlpath))
         protocol = protocols[0]
         options = options_list[0]
-        if all(p in ['http', 'https'] for p in protocols):
-            pass
-        elif not (all(p == protocol for p in protocols) and
+        if not (all(p == protocol for p in protocols) and
                 all(o == options for o in options_list)):
             raise ValueError("When specifying a list of paths, all paths must "
                              "share the same protocol and options")

--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -1,0 +1,239 @@
+from __future__ import print_function, division, absolute_import
+
+from glob import glob
+import os
+import requests
+
+from . import core
+from ..base import tokenize
+
+DEFAULT_BLOCK_SIZE = 5 * 2 ** 20
+
+
+class HTTPFileSystem(core.FileSystem):
+    """
+    Simple File-System for fetching data via HTTP(S)
+
+    Unlike other file-systems, HTTP is limited in that it does not provide glob
+    or write capability. Furthermore, no read-ahead is presently
+    """
+    sep = '/'
+
+    def __init__(self, root='', **storage_options):
+        """
+        Parameters
+        ----------
+        storage_options: key-value
+            May be credentials, e.g., `{'auth': ('username', 'pword')}` or any
+            other parameters for requests
+        """
+        self.block_size = storage_options.pop('block_size', DEFAULT_BLOCK_SIZE)
+        self.kwargs = storage_options
+        self.session = requests.Session()
+        self.root = root
+
+    @classmethod
+    def http(cls, **storage_options):
+        root = 'http://' + storage_options.pop('host')
+        return cls(root=root, **storage_options)
+
+    @classmethod
+    def https(cls, **storage_options):
+        root = 'https://' + storage_options.pop('host')
+        return cls(root=root, **storage_options)
+
+    def glob(self, path):
+        """For a template path, return matching files"""
+        raise NotImplementedError
+
+    def mkdirs(self, path):
+        """Make any intermediate directories to make path writable"""
+        raise NotImplementedError
+
+    def open(self, path, mode='rb', block_size=None, **kwargs):
+        """Make a file-like object
+
+        Parameters
+        ----------
+        path: str
+            Full URL with protocol
+        mode: string
+            must be "rb"
+        kwargs: key-value
+            Any other parameters, passed to requests calls
+        """
+        if mode != 'rb':
+            raise NotImplementedError
+        block_size = block_size if block_size is not None else self.block_size
+        return HTTPFile(self.root + path, self.session, block_size,
+                        **self.kwargs)
+
+    def ukey(self, path):
+        """Unique identifier, so we can tell if a file changed"""
+        # Could do HEAD here?
+        return tokenize(self.root + path)
+
+    def size(self, path):
+        """Size in bytes of the file at path"""
+        return file_size(path, session=self.session, **self.kwargs)
+
+
+core._filesystems['http'] = HTTPFileSystem.http
+core._filesystems['https'] = HTTPFileSystem.https
+
+
+class HTTPFile(object):
+    """
+    A file-like object pointing to a remove HTTP(S) resource.
+
+    Supports only reading, with read-ahead of a predermined block-size.
+
+    Parameters
+    ----------
+    url: str
+        Full URL of the remote resource, including the protocol
+    session: requests.Session or None
+        All calls will be made within this session, to avoid restarting
+        connections where the server allows this
+    block_size: int or None
+        The amount of read-ahead to do, in bytes. Default is 5MB, or the value
+        configured for the FileSystem creating this file
+    kwargs: all other key-values are passed to reqeuests calls.
+    """
+
+    def __init__(self, url, session=None, block_size=None, **kwargs):
+        self.url = url
+        self.kwargs = kwargs
+        self.loc = 0
+        self.session = session if session is not None else requests.Session()
+        self.blocksize = (block_size if block_size is not None
+                          else DEFAULT_BLOCK_SIZE)
+        self.size = file_size(url, self.session, **self.kwargs)
+        self.cache = None
+        self.start = None
+        self.end = None
+
+    def seek(self, where, whence=0):
+        """Set file position
+
+        Parameters
+        ----------
+        where: int
+            Location to set
+        whence: int (default 0)
+            If zero, set from start of file (value should be positive); if 1,
+            set relative to current position; if 2, set relative to end of file
+            (value shoulf be negative)
+
+        Returns the position.
+        """
+        if whence == 0:
+            nloc = where
+        elif whence == 1:
+            nloc += where
+        elif whence == 2:
+            nloc = self.size + where
+        else:
+            raise ValueError('Whence must be in [1, 2, 3], but got %s' % whence)
+        if nloc < 0:
+            raise ValueError('Seek before start of file')
+        self.loc = nloc
+        return nloc
+
+    def tell(self):
+        """Get current file byte position"""
+        return self.loc
+
+    def read(self, length=-1):
+        """Read bytes from file
+
+        Parameters
+        ----------
+        length: int
+            Read up to this many bytes. If negative, read all content to end of
+            file.
+        """
+        if length < 0 or self.loc + length > self.size:
+            end = self.size
+        else:
+            end = self.loc + length
+        self. _fetch(self.loc, end)
+        data = self.cache[self.loc - self.start:end - self.loc]
+        self.loc = end
+        return data
+
+    def _fetch(self, start, end):
+        """Set new bounds for data cache and fetch data, if required"""
+        if self.start is None and self.end is None:
+            # First read
+            self.start = start
+            self.end = end + self.blocksize
+            self.cache = self._fetch_range(start, self.end)
+        if start < self.start:
+            if self.end - end > self.blocksize:
+                self.start = start
+                self.end = end + self.blocksize
+                self.cache = self._fetch_range(self.start, self.end)
+            else:
+                new = self._fetch_range(start, self.start)
+                self.start = start
+                self.cache = new + self.cache
+        if end > self.end:
+            if self.end > self.size:
+                return
+            if end - self.end > self.blocksize:
+                self.start = start
+                self.end = end + self.blocksize
+                self.cache = self._fetch_range(self.start, self.end)
+            else:
+                new = self._fetch_range(self.end, end + self.blocksize)
+                self.end = end + self.blocksize
+                self.cache = self.cache + new
+
+    def _fetch_range(self, start, end):
+        """Download a block of data"""
+        kwargs = self.kwargs.copy()
+        headers = self.kwargs.pop('headers', {})
+        headers['Range'] = 'bytes=%i-%i' % (start, end + 1)
+        r = self.session.get(self.url, headers=headers, **kwargs)
+        if r.ok:
+            return r.content
+        else:
+            r.raise_for_status()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def __iter__(self):
+        # no text lines here, use TextIOWrapper
+        raise NotImplementedError
+
+    def write(self):
+        raise NotImplementedError
+
+    def close(self):
+        self.loc = 0
+        self.cache = None
+        self.start = None
+        self.end = None
+
+    def seekable(self):
+        return True
+
+    def writable(self):
+        return False
+
+    def readable(self):
+        return True
+
+
+def file_size(url, session, **kwargs):
+    """Call HEAD on the server to get file size"""
+    r = session.head(url, **kwargs)
+    if 'Content-Length' in r.headers:
+        return int(r.headers['Content-Length'])
+    else:
+        raise ValueError("Server did not supply size of %s" % url)

--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -78,7 +78,7 @@ class HTTPFileSystem(core.FileSystem):
     def ukey(self, path):
         """Unique identifier, so we can tell if a file changed"""
         # Could do HEAD here?
-        return tokenize(self._make_url(url))
+        return tokenize(self._make_url(path))
 
     def size(self, path):
         """Size in bytes of the file at path"""

--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -1,7 +1,5 @@
 from __future__ import print_function, division, absolute_import
 
-from glob import glob
-import os
 import requests
 
 from . import core
@@ -35,11 +33,15 @@ class HTTPFileSystem(core.FileSystem):
     @classmethod
     def http(cls, **storage_options):
         root = 'http://' + storage_options.pop('host')
+        if 'port' in storage_options:
+            root += ':%i' % storage_options.pop('port')
         return cls(root=root, **storage_options)
 
     @classmethod
     def https(cls, **storage_options):
         root = 'https://' + storage_options.pop('host')
+        if 'port' in storage_options:
+            root += ':%i' % storage_options.pop('port')
         return cls(root=root, **storage_options)
 
     def glob(self, path):

--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -228,7 +228,7 @@ class HTTPFile(object):
                 return r.content
             else:
                 raise ValueError('Got more bytes (%i) than requested (%i)' % (
-                    cl, end-start))
+                    cl, end - start))
         cl = 0
         out = []
         for chunk in r.iter_content(chunk_size=2 ** 20):

--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import requests
+import uuid
 
 from . import core
 from ..base import tokenize
@@ -13,7 +14,7 @@ class HTTPFileSystem(core.FileSystem):
     Simple File-System for fetching data via HTTP(S)
 
     Unlike other file-systems, HTTP is limited in that it does not provide glob
-    or write capability. Furthermore, no read-ahead is presently
+    or write capability.
     """
     sep = '/'
 
@@ -55,9 +56,8 @@ class HTTPFileSystem(core.FileSystem):
         return HTTPFile(url, self.session, block_size, **self.kwargs)
 
     def ukey(self, url):
-        """Unique identifier, so we can tell if a file changed"""
-        # Could do HEAD here?
-        return tokenize(url)
+        """Unique identifier, implied file might have changed every time"""
+        return uuid.uuid1().hex
 
     def size(self, url):
         """Size in bytes of the file at path"""
@@ -70,7 +70,7 @@ core._filesystems['https'] = HTTPFileSystem
 
 class HTTPFile(object):
     """
-    A file-like object pointing to a remove HTTP(S) resource.
+    A file-like object pointing to a remove HTTP(S) resource
 
     Supports only reading, with read-ahead of a predermined block-size.
 

--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -4,7 +4,6 @@ import requests
 import uuid
 
 from . import core
-from ..base import tokenize
 
 DEFAULT_BLOCK_SIZE = 5 * 2 ** 20
 

--- a/dask/bytes/tests/test_bytes_utils.py
+++ b/dask/bytes/tests/test_bytes_utils.py
@@ -91,7 +91,8 @@ def test_infer_storage_options():
     assert so.pop('username') == 'User-name'
     assert so.pop('host') == 'Node-name.com'
 
-    assert infer_storage_options('http://127.0.0.1:8080/test.csv')['host'] == '127.0.0.1'
+    u = 'http://127.0.0.1:8080/test.csv'
+    assert infer_storage_options(u) == {'protocol': 'http', 'path': u}
 
     # For s3 and gcs the netloc is actually the bucket name, so we want to
     # include it in the path. Test that:

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -1,0 +1,39 @@
+import os
+import pytest
+import requests
+import subprocess
+import time
+
+from dask.bytes.core import open_files
+from dask.compatibility import PY2
+
+
+@pytest.fixture
+def server():
+    if PY2:
+        cmd = ['python', '-m', 'SimpleHTTPServer', '8999']
+    else:
+        cmd = ['python', '-m', 'http.server', '8999']
+    p = subprocess.Popen(cmd)
+    timeout = 10
+    while True:
+        try:
+            requests.get('http://localhost:8999')
+            break
+        except requests.exceptions.ConnectionError:
+            time.sleep(0.1)
+            timeout -= 0.1
+            if timeout < 0:
+                raise RuntimeError('Server did not appear')
+    yield
+    p.terminate()
+
+
+def test_simple(server):
+    root = 'http://localhost:8999/'
+    files = [f for f in os.listdir('.') if os.path.isfile(f)]
+    fn = files[0]
+    f = open_files(root + fn)[0]
+    with f as f:
+        data = f.read()
+    assert data == open(fn, 'rb').read()

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -65,7 +65,7 @@ def test_errors(server):
         with f:
             pass
     root = 'http://localhost:8999/'
-    files = [f for f in os.listdir('.') if os.path.isfile(f)]
+    files = [fn for fn in os.listdir('.') if os.path.isfile(fn)]
     fn = files[0]
     f = open_files(root + fn, mode='wb')[0]
     with pytest.raises(NotImplementedError):
@@ -92,9 +92,9 @@ def test_parquet():
     dd = pytest.importorskip('dask.dataframe')
     pytest.importorskip('fastparquet')  # no pyarrow compatability FS yet
     df = dd.read_parquet([
-                        'https://github.com/Parquet/parquet-compatibility/raw/'
-                        'master/parquet-testdata/impala/1.1.1-NONE/'
-                        'nation.impala.parquet']).compute()
+        'https://github.com/Parquet/parquet-compatibility/raw/'
+        'master/parquet-testdata/impala/1.1.1-NONE/'
+        'nation.impala.parquet']).compute()
     assert df.n_nationkey.tolist() == list(range(25))
     assert df.columns.tolist() == ['n_nationkey', 'n_name', 'n_regionkey',
                                    'n_comment']
@@ -107,4 +107,4 @@ def test_bag():
     urls = ['http://anaconda.com', 'http://en.wikipedia.org']
     b = db.read_text(urls)
     assert b.npartitions == 2
-    bc = b.compute()
+    b.compute()

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -8,7 +8,7 @@ from dask.bytes.core import open_files
 from dask.compatibility import PY2
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def server():
     if PY2:
         cmd = ['python', '-m', 'SimpleHTTPServer', '8999']
@@ -37,3 +37,56 @@ def test_simple(server):
     with f as f:
         data = f.read()
     assert data == open(fn, 'rb').read()
+
+
+def test_ops(server):
+    root = 'http://localhost:8999/'
+    files = [f for f in os.listdir('.') if os.path.isfile(f)]
+    fn = files[0]
+    f = open_files(root + fn)[0]
+    data = open(fn, 'rb').read()
+    with f as f:
+        assert f.read(10) == data[:10]
+        f.seek(0)
+        assert f.read(10) == data[:10]
+        assert f.read(10) == data[10:20]
+        f.seek(-10, 2)
+        assert f.read() == data[-10:]
+
+    f = open_files(root + fn, block_size=2)[0]
+    with f as f:
+        with pytest.raises(RuntimeError):
+            # this happens because the simple HTTP server does not respect Range
+            assert f.read(10) == data[:10]
+
+
+def test_errors(server):
+    f = open_files('http://localhost:8999/doesnotexist')[0]
+    with pytest.raises(requests.exceptions.RequestException):
+        with f:
+            pass
+    f = open_files('http://nohost/')[0]
+    with pytest.raises(requests.exceptions.RequestException):
+        with f:
+            pass
+    root = 'http://localhost:8999/'
+    files = [f for f in os.listdir('.') if os.path.isfile(f)]
+    fn = files[0]
+    f = open_files(root + fn, mode='wb')[0]
+    with pytest.raises(NotImplementedError):
+        with f as f:
+            pass
+    f = open_files(root + fn)[0]
+    with f as f:
+        with pytest.raises(ValueError):
+            f.seek(-1)
+
+
+def test_files(server):
+    root = 'http://localhost:8999/'
+    files = [f for f in os.listdir('.') if os.path.isfile(f)]
+    fn = files[0:2]
+    fs = open_files([root + f for f in fn])
+    for f, f2 in zip(fs, fn):
+        with f as f:
+            assert f.read() == open(f2, 'rb').read()

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -16,7 +16,7 @@ def dir_server():
     with tmpdir() as d:
         for fn in files:
             with open(os.path.join(d, fn), 'wb') as f:
-                f.write(b'a'*10000)
+                f.write(b'a' * 10000)
 
         if PY2:
             cmd = ['python', '-m', 'SimpleHTTPServer', '8999']

--- a/dask/bytes/utils.py
+++ b/dask/bytes/utils.py
@@ -51,6 +51,10 @@ def infer_storage_options(urlpath, inherit_storage_options=None):
         if windows_path:
             path = '%s:%s' % windows_path.groups()
 
+    if protocol in ['http', 'https']:
+        # for HTTP, we don't want to parse, as requests will anyway
+        return {'protocol': protocol, 'path': urlpath}
+
     options = {
         'protocol': protocol,
         'path': path,

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,7 @@ Bag
 Core
 ++++
 
+- New file-system for HTTP(S), allowing direct loading from specific URLs (:pr:`3160`) `Martin Durant`_
 
 0.17.0 / 2018-02-09
 -------------------

--- a/docs/source/remote-data-services.rst
+++ b/docs/source/remote-data-services.rst
@@ -224,6 +224,23 @@ Possible additional storage options:
       a JSON file created by gcloud.
 
 
+HTTP
+----
+
+Direct file-like access to arbitrary URLs is available over HTTP and HTTPS. However,
+there is no such thing as ``glob`` functionality over HTTP, so only explicit lists
+of files can be used.
+
+Server implementations differ in the information they provide - they may or may
+not specify the size of a file via a HEAD request or at the start of a download -
+and some servers may not respect bytes range requests. The HTTPFileSystem therefore
+offers best-effort behaviour: the download is streamed, but if more data is seen
+than the configured block-size, an error will be raised. To be able to access such
+data, you must read the whole file in one shot (and it must fit in memory).
+
+Note that, currently, ``http://`` and ``https://`` are treated as separate protocols,
+and cannot be mixed.
+
 Developer API
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API

Fixes #3158

Posted for comments: is this a reasonable way to go about things?

I would need to do add to the set of imports in dask.bytes.core.get_fs; this only requires requests.

Testing will need to set up an actual simple HTTP server.