### PR TITLE
allow column assignment of pandas datetime to dask dataframe

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2488,7 +2488,7 @@ class DataFrame(_Frame):
     def assign(self, **kwargs):
         for k, v in kwargs.items():
             if not (isinstance(v, (Series, Scalar, pd.Series)) or
-                    callable(v) or np.isscalar(v)):
+                    callable(v) or pd.api.types.is_scalar(v)):
                 raise TypeError("Column assignment doesn't support type "
                                 "{0}".format(type(v).__name__))
         pairs = list(sum(kwargs.items(), ()))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -825,19 +825,19 @@ def test_assign():
                    e=d.a.sum(),
                    f=d.a + d.b,
                    g=lambda x: x.a + x.b,
-                   dt = pd.datetime(2018, 2, 13))
+                   dt=pd.datetime(2018, 2, 13))
     res_unknown = d_unknown.assign(c=1,
                                    d='string',
                                    e=d_unknown.a.sum(),
                                    f=d_unknown.a + d_unknown.b,
-                                   g=lambda x: x.a + x.b, 
-                                   dt = pd.datetime(2018, 2, 13))
+                                   g=lambda x: x.a + x.b,
+                                   dt=pd.datetime(2018, 2, 13))
     sol = full.assign(c=1,
                       d='string',
                       e=full.a.sum(),
                       f=full.a + full.b,
                       g=lambda x: x.a + x.b,
-                      dt = pd.datetime(2018, 2, 13))
+                      dt=pd.datetime(2018, 2, 13))
     assert_eq(res, sol)
     assert_eq(res_unknown, sol)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -824,17 +824,20 @@ def test_assign():
                    d='string',
                    e=d.a.sum(),
                    f=d.a + d.b,
-                   g=lambda x: x.a + x.b)
+                   g=lambda x: x.a + x.b,
+                   dt = pd.datetime(2018, 2, 13))
     res_unknown = d_unknown.assign(c=1,
                                    d='string',
                                    e=d_unknown.a.sum(),
                                    f=d_unknown.a + d_unknown.b,
-                                   g=lambda x: x.a + x.b)
+                                   g=lambda x: x.a + x.b, 
+                                   dt = pd.datetime(2018, 2, 13))
     sol = full.assign(c=1,
                       d='string',
                       e=full.a.sum(),
                       f=full.a + full.b,
-                      g=lambda x: x.a + x.b)
+                      g=lambda x: x.a + x.b,
+                      dt = pd.datetime(2018, 2, 13))
     assert_eq(res, sol)
     assert_eq(res_unknown, sol)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -825,19 +825,19 @@ def test_assign():
                    e=d.a.sum(),
                    f=d.a + d.b,
                    g=lambda x: x.a + x.b,
-                   dt=pd.datetime(2018, 2, 13))
+                   dt=pd.Timestamp(2018, 2, 13))
     res_unknown = d_unknown.assign(c=1,
                                    d='string',
                                    e=d_unknown.a.sum(),
                                    f=d_unknown.a + d_unknown.b,
                                    g=lambda x: x.a + x.b,
-                                   dt=pd.datetime(2018, 2, 13))
+                                   dt=pd.Timestamp(2018, 2, 13))
     sol = full.assign(c=1,
                       d='string',
                       e=full.a.sum(),
                       f=full.a + full.b,
                       g=lambda x: x.a + x.b,
-                      dt=pd.datetime(2018, 2, 13))
+                      dt=pd.Timestamp(2018, 2, 13))
     assert_eq(res, sol)
     assert_eq(res_unknown, sol)
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,7 +11,7 @@ Array
 
 DataFrame
 +++++++++
-- Bugfix to allow column assignment of pandas datetimes(:pr:`3164`)`Max Epstein`_
+- Bugfix to allow column assignment of pandas datetimes(:pr:`3164`) `Max Epstein`_
 
 
 Bag

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -37,7 +37,7 @@ Array
 
 DataFrame
 +++++++++
-
+- Bugfix to allow column assignment of pandas datetimes
 - Support month timedeltas in repartition(freq=...) (:pr:`3110`) `Matthew Rocklin`_
 - Avoid mutation in dataframe groupby tests (:pr:`3118`) `Matthew Rocklin`_
 - ``read_csv``, ``read_table``, and ``read_parquet`` accept iterables of paths

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,7 @@ Array
 
 DataFrame
 +++++++++
+- Bugfix to allow column assignment of pandas datetimes(:pr:`3164`)`Max Epstein`_
 
 
 Bag
@@ -37,7 +38,6 @@ Array
 
 DataFrame
 +++++++++
-- Bugfix to allow column assignment of pandas datetimes
 - Support month timedeltas in repartition(freq=...) (:pr:`3110`) `Matthew Rocklin`_
 - Avoid mutation in dataframe groupby tests (:pr:`3118`) `Matthew Rocklin`_
 - ``read_csv``, ``read_table``, and ``read_parquet`` accept iterables of paths
@@ -973,3 +973,4 @@ Other
 .. _`Nir`: https://github.com/nirizr
 .. _`Keisuke Fujii`: https://github.com/fujiisoup
 .. _`Roman Yurchak`: https://github.com/rth
+.. _`Max Epstein`: https://github.com/MaxPowerWasTaken


### PR DESCRIPTION
- no Tests added, datetime case added to `test_assign` in `dask/dataframe/tests/test_dataframe.py`
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API

... For issue https://github.com/dask/dask/issues/3159

On testing, I didn't find a test for the `assign` function in `dask/tests/` to add a usecase for. Would you like me to add a datetime usecase for. Should I add a new test? If so, the new test would be a test of `assign` right?

I ran `py.test dask/dataframe` before and after making the change, and got the same results each time (1659 passed, 319 skipped, 9 xfailed, 107 warnings) on my system.

Please let me know if there's anything I should change/improve.