### PR TITLE
Fix dimension chunking in indices

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -377,7 +377,7 @@ def indices(dimensions, dtype=int, chunks=None):
 
     xi = []
     for i in range(len(dimensions)):
-        xi.append(arange(dimensions[i], dtype=dtype, chunks=chunks[i]))
+        xi.append(arange(dimensions[i], dtype=dtype, chunks=(chunks[i],)))
 
     grid = []
     if np.prod(dimensions):

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -153,6 +153,10 @@ def test_indices_wrong_chunks():
     with pytest.raises(ValueError):
         da.indices((1,), chunks=tuple())
 
+def test_indices_dimensions_chunks():
+    chunks = ((1,4,2,3), (5,5))
+    darr = da.indices((10, 10), chunks=chunks)
+    assert darr.chunks == ((1,1),) + chunks
 
 def test_empty_indicies():
     darr = da.indices(tuple(), chunks=tuple())

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -153,10 +153,12 @@ def test_indices_wrong_chunks():
     with pytest.raises(ValueError):
         da.indices((1,), chunks=tuple())
 
+
 def test_indices_dimensions_chunks():
     chunks = ((1,4,2,3), (5,5))
     darr = da.indices((10, 10), chunks=chunks)
     assert darr.chunks == ((1,1),) + chunks
+
 
 def test_empty_indicies():
     darr = da.indices(tuple(), chunks=tuple())

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 Array
 +++++
 
-- Corrected dimension chunking in indices (:issue:`3166`) `Simon Perkins`_
+- Corrected dimension chunking in indices (:issue:`3166`, :pr:`3167`) `Simon Perkins`_
 
 DataFrame
 +++++++++

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 Array
 +++++
 
+- Corrected dimension chunking in indices (:issue:`3166`) `Simon Perkins`_
 
 DataFrame
 +++++++++
@@ -973,3 +974,4 @@ Other
 .. _`Nir`: https://github.com/nirizr
 .. _`Keisuke Fujii`: https://github.com/fujiisoup
 .. _`Roman Yurchak`: https://github.com/rth
+.. _`Simon Perkins`: https://github.com/sjperkins


### PR DESCRIPTION
chunk nesting for each dimension was incorrectly specified.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
