### PR TITLE
Support categories= argument for pyarrow

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -518,8 +518,10 @@ def _read_pyarrow(fs, fs_token, paths, columns=None, filters=None,
     if filters is not None:
         raise NotImplementedError("Predicate pushdown not implemented")
 
-    if categories is not None:
-        raise NotImplementedError("Categorical reads not yet implemented")
+    if isinstance(categories, string_types):
+        categories = [categories]
+    else:
+        categories = list(categories)
 
     if isinstance(columns, tuple):
         columns = list(columns)
@@ -553,7 +555,7 @@ def _read_pyarrow(fs, fs_token, paths, columns=None, filters=None,
 
     all_columns = index_names + column_names
 
-    dtypes = _get_pyarrow_dtypes(schema)
+    dtypes = _get_pyarrow_dtypes(schema, categories)
     dtypes = {storage_name_mapping.get(k, k): v for k, v in dtypes.items()}
 
     meta = _meta_from_dtypes(all_columns, dtypes, index_names, column_index_names)
@@ -573,7 +575,8 @@ def _read_pyarrow(fs, fs_token, paths, columns=None, filters=None,
                              column_names,
                              index_names,
                              out_type == Series,
-                             dataset.partitions)
+                             dataset.partitions,
+                             categories)
             for i, piece in enumerate(dataset.pieces)
         }
     else:
@@ -583,24 +586,28 @@ def _read_pyarrow(fs, fs_token, paths, columns=None, filters=None,
     return out_type(task_plan, task_name, meta, divisions)
 
 
-def _get_pyarrow_dtypes(schema):
+def _get_pyarrow_dtypes(schema, categories):
     dtypes = {}
     for i in range(len(schema)):
         field = schema[i]
         numpy_dtype = field.type.to_pandas_dtype()
         dtypes[field.name] = numpy_dtype
 
+    if categories:
+        for cat in categories:
+            dtypes[cat] = "category"
+
     return dtypes
 
 
 def _read_pyarrow_parquet_piece(fs, piece, columns, index_cols, is_series,
-                                partitions):
+                                partitions, categories):
     with fs.open(piece.path, mode='rb') as f:
         table = piece.read(columns=index_cols + columns,
                            partitions=partitions,
                            use_pandas_metadata=True,
                            file=f)
-    df = table.to_pandas()
+    df = table.to_pandas(categories=categories)
     has_index = not isinstance(df.index, pd.RangeIndex)
 
     if not has_index and index_cols:

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -889,7 +889,7 @@ def test_pyarrow_raises_filters_categoricals(tmpdir):
 
     df.to_parquet(tmp, write_index=False, engine="pyarrow")
 
-    with pytest.raises(NotImplementedError) as m:
+    with pytest.raises(NotImplementedError):
         dd.read_parquet(tmp, engine="pyarrow", filters=["A>1"])
 
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -892,11 +892,6 @@ def test_pyarrow_raises_filters_categoricals(tmpdir):
     with pytest.raises(NotImplementedError) as m:
         dd.read_parquet(tmp, engine="pyarrow", filters=["A>1"])
 
-    with pytest.raises(NotImplementedError) as m:
-        dd.read_parquet(tmp, engine="pyarrow", categories=['A'])
-
-    assert m.match("Categorical reads not yet ")
-
 
 def test_read_no_metadata(tmpdir, engine):
     # use pyarrow.parquet to create a parquet file without

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -37,7 +37,7 @@ DataFrame
 +++++++++
 
 - Bugfix to allow column assignment of pandas datetimes(:pr:`3164`) `Max Epstein`_
-
+- Support specifying categorical columns on ``read_parquet`` with ``categories=[…]`` for ``engine="pyarrow"`` (:pr:`3177`) `Uwe Korn`_
 
 Bag
 +++

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ DataFrame
 +++++++++
 
 -  Fixed bug in shuffle due to aggressive truncation (:pr:`3201`) `Matthew Rocklin`_
+- Support specifying categorical columns on ``read_parquet`` with ``categories=[…]`` for ``engine="pyarrow"`` (:pr:`3177`) `Uwe Korn`_
 
 
 Bag
@@ -37,7 +38,6 @@ DataFrame
 +++++++++
 
 - Bugfix to allow column assignment of pandas datetimes(:pr:`3164`) `Max Epstein`_
-- Support specifying categorical columns on ``read_parquet`` with ``categories=[…]`` for ``engine="pyarrow"`` (:pr:`3177`) `Uwe Korn`_
 
 Bag
 +++


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API

Depends on https://github.com/apache/arrow/pull/1620 (should be part of the upcoming 0.9 release)

`fastparquet` -> `pyarrow` roundtrip fails due to https://github.com/dask/fastparquet/issues/305