### PR TITLE
Multiprocess friendly to_hdf5

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3356,6 +3356,32 @@ def concatenate_axes(arrays, axes):
     return concatenate3(transposelist(arrays, axes, extradims=extradims))
 
 
+class HDF5Dataset(object):
+    def __init__(self, filename, datasetname, shape, dtype, chunks):
+        self._filename = filename
+        self._datasetname = datasetname
+
+        import h5py
+        with h5py.File(self._filename, "a") as f:
+            f.require_dataset(
+                self._datasetname,
+                shape=shape,
+                dtype=dtype,
+                chunks=chunks,
+                exact=True
+            )
+
+    def __getitem__(self, idx):
+        import h5py
+        with h5py.File(self._filename, "r") as f:
+            return f[self._datasetname][idx]
+
+    def __setitem__(self, idx, val):
+        import h5py
+        with h5py.File(self._filename, "r+") as f:
+            f[self._datasetname][idx] = val
+
+
 def to_hdf5(filename, *args, **kwargs):
     """ Store arrays in HDF5 file
 


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/3074
Fixes https://github.com/dask/dask/issues/2488

An RFC that attempts to implement `to_hdf5` in such a way where it could be used to do writing from the workers to an HDF5 dataset with the caveat that locking must occur. That said, it is much better than the current situation where writing to an HDF5 dataset from multiple processes is simply not possible.

cc @mrocklin @stuartarchibald @martindurant