### PR TITLE
Use `cloudpickle` to load instead of `pickle`

### DIFF
--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -30,7 +30,7 @@ def _dumps(x):
     return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
 
 
-_loads = pickle.loads
+_loads = cloudpickle.loads
 
 
 def _process_get_id():


### PR DESCRIPTION
Appears that `_loads` (the `loads` default in `multiprocessing`) was set to `pickle.loads` instead of `cloudpickle.loads`. This in spite of the fact that commit ( 4322feffa4aa9e982e7563ff4f337d5d02feb568 ), which added this states intent was to use `cloudpickle` instead of `dill`.

xref: https://github.com/dask/dask/pull/865