### PR TITLE
Note `where`-style selection of Dask Arrays works

### DIFF
--- a/docs/source/array-slicing.rst
+++ b/docs/source/array-slicing.rst
@@ -7,10 +7,10 @@ supports the following:
 *  Slicing by integers and slices ``x[0, :5]``
 *  Slicing by lists/arrays of integers  ``x[[1, 2, 4]]``
 *  Slicing by lists/arrays of booleans ``x[[False, True, True, False, True]]``
+*  Slicing one ``dask.array`` with another ``x[x > 0]``
 
 It does not currently support the following:
 
-*  Slicing one ``dask.array`` with another ``x[x > 0]``
 *  Slicing with lists in multiple axes  ``x[[1, 2, 3], [3, 2, 1]]``
 
 Both of these are straightforward to add though.  If you have a use case then


### PR DESCRIPTION
The docs still noted that selection by a conditional Dask Array does not work. However this case actually does work with Dask Arrays. So move this to the supported cases.

xref: https://github.com/dask/dask/pull/2539