### PR TITLE
Introduced parameter for output stream for progress bar

### DIFF
--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -75,7 +75,7 @@ class ProgressBar(Callback):
 
     def __init__(self, minimum=0, width=40, dt=0.1, out=None):
         if out is None:
-            out=sys.stdout
+            out = sys.stdout
         self._minimum = minimum
         self._width = width
         self._dt = dt

--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -73,7 +73,9 @@ class ProgressBar(Callback):
     [########################################] | 100% Completed | 10.4 s
     """
 
-    def __init__(self, minimum=0, width=40, dt=0.1, out=sys.stdout):
+    def __init__(self, minimum=0, width=40, dt=0.1, out=None):
+        if out is None:
+            out=sys.stdout
         self._minimum = minimum
         self._width = width
         self._dt = dt

--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -73,10 +73,11 @@ class ProgressBar(Callback):
     [########################################] | 100% Completed | 10.4 s
     """
 
-    def __init__(self, minimum=0, width=40, dt=0.1):
+    def __init__(self, minimum=0, width=40, dt=0.1, out=sys.stdout):
         self._minimum = minimum
         self._width = width
         self._dt = dt
+        self._file = out
         self.last_duration = 0
 
     def _start(self, dsk):
@@ -90,7 +91,7 @@ class ProgressBar(Callback):
 
     def _pretask(self, key, dsk, state):
         self._state = state
-        sys.stdout.flush()
+        self._file.flush()
 
     def _finish(self, dsk, state, errored):
         self._running = False
@@ -103,8 +104,8 @@ class ProgressBar(Callback):
             self._draw_bar(1, elapsed)
         else:
             self._update_bar(elapsed)
-        sys.stdout.write('\n')
-        sys.stdout.flush()
+        self._file.write('\n')
+        self._file.flush()
 
     def _timer_func(self):
         """Background thread for updating the progress bar"""
@@ -130,5 +131,5 @@ class ProgressBar(Callback):
         msg = '\r[{0:<{1}}] | {2}% Completed | {3}'.format(bar, self._width,
                                                            percent, elapsed)
         with ignoring(ValueError):
-            sys.stdout.write(msg)
-            sys.stdout.flush()
+            self._file.write(msg)
+            self._file.flush()


### PR DESCRIPTION
Using stderr instead of stdout for progress bars can be desirable, see
hyperspy/hyperspy#1842. This change allows users to specify the stream to use
and allows to easily change the default behavior.