### PR TITLE
Change numpy versioning in make_sliced_dtype

### DIFF
--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -364,7 +364,7 @@ except ImportError:  # pragma: no cover
 
 
 def _make_sliced_dtype(dtype, index):
-    if LooseVersion(np.__version__) >= LooseVersion("1.14.0"):
+    if LooseVersion(np.__version__) == LooseVersion("1.14.0"):
         return _make_sliced_dtype_np_ge_14(dtype, index)
     else:
         return _make_sliced_dtype_np_lt_14(dtype, index)

--- a/dask/array/tests/test_numpy_compat.py
+++ b/dask/array/tests/test_numpy_compat.py
@@ -1,18 +1,9 @@
-from distutils.version import LooseVersion
-
 import pytest
 import numpy as np
 
 import dask.array as da
 from dask.array.numpy_compat import _make_sliced_dtype
 from dask.array.utils import assert_eq
-
-NP_LE_114 = LooseVersion(np.__version__) <= LooseVersion("1.14")
-
-skip_if_np_ge_114 = pytest.mark.skipif(NP_LE_114,
-                                       reason="NumPy is older than '1.14'.")
-skip_if_np_lt_114 = pytest.mark.skipif(not NP_LE_114,
-                                       reason="NumPy is at least '1.14'.")
 
 
 @pytest.fixture(params=[
@@ -32,7 +23,6 @@ def index(request):
     return request.param
 
 
-@skip_if_np_ge_114
 def test_basic():
     # sanity check
     dtype = [('a', 'f8'), ('b', 'f8'), ('c', 'f8')]
@@ -41,23 +31,6 @@ def test_basic():
     result = dx[['a', 'b']]
     expected = x[['a', 'b']]
     assert_eq(result, expected)
-
-    expected_dtype = np.dtype({'names': ['a', 'b'],
-                               'formats': ['<f8', '<f8'],
-                               'offsets': [0, 8], 'itemsize': 24})
-    assert result.dtype == expected_dtype
-
-
-@skip_if_np_lt_114
-def test_basic_old():
-    dtype = [('a', 'f8'), ('b', 'f8'), ('c', 'f8')]
-    x = np.ones((5, 3), dtype=dtype)
-    dx = da.ones((5, 3), dtype=dtype, chunks=3)
-    result = dx[['a', 'b']]
-    expected = x[['a', 'b']]
-    assert_eq(result, expected)
-
-    assert result.dtype == dtype[:2]
 
 
 def test_slice_dtype(dtype, index):

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Array
 
 - Corrected dimension chunking in indices (:issue:`3166`, :pr:`3167`) `Simon Perkins`_
 - Inline ``store_chunk`` calls for ``store``'s ``return_stored`` option (:pr:`3153`) `John A Kirkham`_
+- Compatibility with struct dtypes for NumPy 1.14.1 release (:pr:`3187`) `Matthew Rocklin`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
It looks like numpy reverted a change in how it handles struct dtypes.

This also simplifies a test to only test against numpy behavior,
rather than explicitly test different outcomes for different versions.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
