### PR TITLE
DOC: Note vindex in slicing

### DIFF
--- a/docs/source/array-slicing.rst
+++ b/docs/source/array-slicing.rst
@@ -13,8 +13,8 @@ It does not currently support the following:
 
 *  Slicing with lists in multiple axes  ``x[[1, 2, 3], [3, 2, 1]]``
 
-Both of these are straightforward to add though.  If you have a use case then
-raise an issue.
+This is straightforward to add though.  If you have a use case then raise an
+issue.
 
 Efficiency
 ----------

--- a/docs/source/array-slicing.rst
+++ b/docs/source/array-slicing.rst
@@ -14,7 +14,8 @@ It does not currently support the following:
 *  Slicing with lists in multiple axes  ``x[[1, 2, 3], [3, 2, 1]]``
 
 This is straightforward to add though.  If you have a use case then raise an
-issue.
+issue. Also users interested in this should take a look at
+:attr:`~dask.array.Array.vindex`.
 
 Efficiency
 ----------


### PR DESCRIPTION
Follow-up to issue ( https://github.com/dask/dask/issues/3096 )

Makes a note of `vindex` next to the unsupported multiple lists of axes use case to catch the eye of users looking for this functionality who may not otherwise be aware of it.

cc @mraspaud @shoyer @mrocklin