### PR TITLE
Mod before truncate in shufle_group

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -283,11 +283,12 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
                      how, npartitions, suffixes, shuffle, indicator)
     name = 'hash-join-' + token
 
-    dsk = dict(((name, i), (methods.merge, (lhs2._name, i), (rhs2._name, i),
-                            how, left_on, right_on,
-                            left_index, right_index, indicator,
-                            suffixes, lhs._meta, rhs._meta))
-               for i in range(npartitions))
+    dsk = {(name, i): (methods.merge,
+                       (lhs2._name, i), (rhs2._name, i),
+                       how, left_on, right_on,
+                       left_index, right_index, indicator,
+                       suffixes, lhs._meta, rhs._meta)
+           for i in range(npartitions)}
 
     divisions = [None] * (npartitions + 1)
     return new_dd_object(toolz.merge(lhs2.dask, rhs2.dask, dsk),

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -460,8 +460,7 @@ def shuffle_group(df, col, stage, k, npartitions):
     npartitions, k, stage = [np.array(x, dtype=np.min_scalar_type(x))[()]
                              for x in [npartitions, k, stage]]
 
-    c = np.mod(c, npartitions).astype(typ)
-    c = np.mod(c, npartitions, out=c)
+    c = np.mod(c, npartitions).astype(typ, copy=False)
     c = np.floor_divide(c, k ** stage, out=c)
     c = np.mod(c, k, out=c)
 
@@ -470,9 +469,7 @@ def shuffle_group(df, col, stage, k, npartitions):
     locations = locations.cumsum()
     parts = [df2.iloc[a:b] for a, b in zip(locations[:-1], locations[1:])]
 
-    result = dict(zip(range(k), parts))
-
-    return result
+    return dict(zip(range(k), parts))
 
 
 def shuffle_group_3(df, col, npartitions, p):

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -203,6 +203,7 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32,
     """
     if not isinstance(index, _Frame):
         index = df._select_columns_or_index(index)
+
     partitions = index.map_partitions(partitioning_index,
                                       npartitions=npartitions or df.npartitions,
                                       meta=pd.Series([0]))
@@ -363,6 +364,7 @@ def rearrange_by_column_tasks(df, column, max_branch=32, npartitions=None):
     if npartitions is not None and npartitions != df.npartitions:
         parts = [i % df.npartitions for i in range(npartitions)]
         token = tokenize(df2, npartitions)
+
         dsk = {('repartition-group-' + token, i): (shuffle_group_2, k, column)
                for i, k in enumerate(df2.__dask_keys__())}
         for p in range(npartitions):
@@ -442,6 +444,11 @@ def shuffle_group_get(g_head, i):
 
 
 def shuffle_group(df, col, stage, k, npartitions):
+    """ Splits dataframe into groups
+
+    The group is determined by their final partition, and which stage we are in
+    in the shuffle
+    """
     if col == '_partitions':
         ind = df[col]
     else:
@@ -449,11 +456,11 @@ def shuffle_group(df, col, stage, k, npartitions):
 
     c = ind._values
     typ = np.min_scalar_type(npartitions * 2)
-    c = c.astype(typ)
 
     npartitions, k, stage = [np.array(x, dtype=np.min_scalar_type(x))[()]
                              for x in [npartitions, k, stage]]
 
+    c = np.mod(c, npartitions).astype(typ)
     c = np.mod(c, npartitions, out=c)
     c = np.floor_divide(c, k ** stage, out=c)
     c = np.mod(c, k, out=c)
@@ -463,7 +470,9 @@ def shuffle_group(df, col, stage, k, npartitions):
     locations = locations.cumsum()
     parts = [df2.iloc[a:b] for a, b in zip(locations[:-1], locations[1:])]
 
-    return dict(zip(range(k), parts))
+    result = dict(zip(range(k), parts))
+
+    return result
 
 
 def shuffle_group_3(df, col, npartitions, p):

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,27 @@ Changelog
 =========
 
 
+0.XX.X / 2018-MM-DD
+-------------------
+
+Array
++++++
+
+
+DataFrame
++++++++++
+
+-  Fixed bug in shuffle due to aggressive truncation (:pr:`3201`) `Matthew Rocklin`_
+
+
+Bag
++++
+
+
+Core
+++++
+
+
 0.17.1 / 2018-02-22
 -------------------
 


### PR DESCRIPTION
Fixes #2730

This caused some rows to be missed during task-based shuffles

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
