### PR TITLE
Enable/Fix test_select_partitioned_column for pyarrow 0.9.0

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -693,6 +693,7 @@ def _write_partition_pyarrow(df, path, fs, filename, write_index,
 
     if partition_on:
         parquet.write_to_dataset(t, path, partition_cols=partition_on,
+                                 preserve_index=write_index,
                                  filesystem=fs, **kwargs)
     else:
         with fs.open(filename, 'wb') as fil:

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1050,9 +1050,12 @@ def test_writing_parquet_with_unknown_kwargs(tmpdir, engine):
         ddf.to_parquet(fn,  engine=engine, unknown_key='unknown_value')
 
 
-def test_setect_partitioned_column(tmpdir, engine):
+def test_select_partitioned_column(tmpdir, engine):
     if engine == 'pyarrow':
-        pytest.xfail()
+        import pyarrow as pa
+        if pa.__version__ < LooseVersion('0.9.0'):
+            pytest.skip("pyarrow<0.9.0 did not support this")
+
     fn = str(tmpdir)
     size = 20
     d = {'signal1': np.random.normal(0, 0.3, size=size).cumsum() + 50,

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,7 +13,7 @@ Array
 DataFrame
 +++++++++
 
--
+- Fix selection on partition column on ``read_parquet`` for ``engine="pyarrow"`` (:pr:`3207`) `Uwe Korn`_
 
 Bag
 +++


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
