### PR TITLE
WIP: Support using `vindex` with Dask Arrays

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3488,8 +3488,15 @@ def _vindex(x, *indexes):
     x = x[nonfancy_indexes]
 
     array_indexes = {}
+    dask_array_indexes = {}
     for i, (ind, size) in enumerate(zip(reduced_indexes, x.shape)):
-        if not isinstance(ind, slice):
+        if isinstance(ind, Array):
+            if ind.dtype.kind == 'b':
+                raise IndexError('vindex does not support indexing with '
+                                 'boolean arrays')
+            ind %= size
+            dask_array_indexes[i] = ind
+        elif not isinstance(ind, slice):
             ind = np.array(ind, copy=True)
             if ind.dtype.kind == 'b':
                 raise IndexError('vindex does not support indexing with '
@@ -3503,6 +3510,9 @@ def _vindex(x, *indexes):
 
     if array_indexes:
         x = _vindex_array(x, array_indexes)
+
+    if dask_array_indexes:
+        x = _vindex_dask_arrays(x, dask_array_indexes)
 
     return x
 
@@ -3585,6 +3595,63 @@ def _vindex_array(x, dict_indexes):
         tuple(map(sum, chunks)), chunks=chunks, dtype=x.dtype, name=out_name
     )
     return result_1d.reshape(broadcast_shape + result_1d.shape[1:])
+
+
+def _vindex_dask_arrays(x, dict_indexes):
+    """Point wise indexing with Dask Arrays"""
+
+    from .creation import arange
+
+    arr_inds = []
+    out_axes = []
+    for i in range(x.ndim):
+        try:
+            ind = dict_indexes[i]
+        except KeyError:
+            arr_inds.append(slice(None))
+            out_axes.append(len(arr_inds))
+        else:
+            arr_inds.append(ind)
+            if 0 not in out_axes:
+                out_axes.append(0)
+    arr_inds = tuple(arr_inds)
+    out_axes = tuple(out_axes)
+
+    x_inds = tuple(
+        arange(s, chunks=c) for s, c in zip(x.shape, x.chunks)
+    )
+
+    idx_vals = atop(
+        _vindex_dask_arrays_chunk,
+        out_axes,
+        x, tuple(range(1, 1 + x.ndim)),
+        *concat([
+            (e_0, (0,), e_i, (i,)) if isinstance(e_0, Array) else
+            (e_0, None, e_i, (i,))
+            for i, (e_0, e_i) in enumerate(zip(arr_inds, x_inds), start=1)
+        ]),
+        dtype=x.dtype,
+        concatenate=True
+    )
+
+    return idx_vals
+
+
+def _vindex_dask_arrays_chunk(xc, *args):
+    inds = args[::2]
+    x_inds = args[1::2]
+
+    xc_inds = []
+    for i, (e_0, e_i) in enumerate(zip(inds, x_inds)):
+        if isinstance(e_0, np.ndarray):
+            xc_inds.append(np.searchsorted(e_i, e_0[e_0 <= e_i[-1]]))
+        else:
+            xc_inds.append(e_0)
+    xc_inds = tuple(xc_inds)
+
+    vals = xc[xc_inds]
+
+    return vals
 
 
 def _get_axis(indexes):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2187,6 +2187,27 @@ def test_point_slicing():
     result = d.vindex[[1, 2, 5, 5], [3, 1, 6, 1]]
     assert_eq(result, x[[1, 2, 5, 5], [3, 1, 6, 1]])
 
+    result = d.vindex[da.asarray([1, 2, 6, 6]), :]
+    assert_eq(result, x[[1, 2, 6, 6], :])
+
+    result = d.vindex[:, da.asarray([1, 2, 7, 7])]
+    assert_eq(result, x[:, [1, 2, 7, 7]])
+
+    result = d.vindex[2, da.asarray([1, 2, 7, 7])]
+    assert_eq(result, x[2, [1, 2, 7, 7]])
+
+    result = d.vindex[:, da.asarray([2, 1, 7, 6])]
+    assert_eq(result, x[:, [2, 1, 7, 6]])
+
+    result = d.vindex[:, da.asarray([2, 1, 7, 7])]
+    assert_eq(result, x[:, [2, 1, 7, 7]])
+
+    result = d.vindex[:, da.from_array(np.array([7, 1, 2, 6]), chunks=2)]
+    assert_eq(result, x[:, [7, 1, 2, 6]])
+
+    result = d.vindex[(d % 3).nonzero()]
+    assert_eq(result, x[(x % 3).nonzero()])
+
     result = d.vindex[[0, 1, 6, 0], [0, 1, 0, 7]]
     assert_eq(result, x[[0, 1, 6, 0], [0, 1, 0, 7]])
     assert same_keys(result, d.vindex[[0, 1, 6, 0], [0, 1, 0, 7]])

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 Array
 +++++
 
+- Support Dask Arrays with `vindex` (:pr:`3210`) `John A Kirkham`_
 - Add ``piecewise`` for Dask Arrays (:pr:`3350`) `John A Kirkham`_
 - Fix handling of ``nan`` in ``broadcast_shapes`` (:pr:`3356`) `John A Kirkham`_
 - Add ``isin`` for dask arrays (:pr:`3363`). `Stephan Hoyer`_


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/3096

Change `vindex` so that it can support using Dask Arrays for indexing. Does this using `atop` to map Dask Array indices to those representing particular values in the chunk. Thus allowing individual values to be pulled from each chunk and combined into the total result. Comes with the added bonus that this will work whether the Dask Arrays providing coordinates have a known length or an unknown length.