### PR TITLE
Loading of partitioned parquet should result in known categories

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -309,7 +309,7 @@ def _read_fastparquet(fs, fs_token, paths, columns=None, filters=None,
         if catcol in meta.columns:
             meta[catcol] = meta[catcol].cat.set_categories(pf.cats[catcol])
         if meta.index.name == catcol:
-            meta.index = meta.index.cat.set_categories(pf.cats[catcol])
+            meta.index = meta.index.set_categories(pf.cats[catcol])
 
     if not dsk:
         # empty dataframe

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -309,6 +309,8 @@ def _read_fastparquet(fs, fs_token, paths, columns=None, filters=None,
                        categories, pf.schema, pf.cats, pf.dtypes,
                        pf.file_scheme, storage_name_mapping)
            for i, rg in enumerate(rgs)}
+    for catcol in pf.cats:
+        meta[catcol] = meta[catcol].cat.set_categories(pf.cats[catcol])
 
     if not dsk:
         # empty dataframe

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -416,6 +416,9 @@ def test_partition_on_cats(tmpdir):
     df = dd.read_parquet(tmp, columns=['a', 'c'], engine='fastparquet')
     assert set(df.c.cat.categories) == {'x', 'y', 'z'}
     assert 'b' not in df.columns
+    df = dd.read_parquet(tmp, index='c', engine='fastparquet')
+    assert set(df.index.categories) == {'x', 'y', 'z'}
+    assert 'c' not in df.columns
 
 
 def test_append_wo_index(tmpdir):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -398,6 +398,26 @@ def test_append_with_partition(tmpdir):
               check_index=False)
 
 
+def test_partition_on_cats(tmpdir):
+    check_fastparquet()
+    tmp = str(tmpdir)
+    d = pd.DataFrame({'a': np.random.rand(50),
+                      'b': np.random.choice(['x', 'y', 'z'], size=50),
+                      'c': np.random.choice(['x', 'y', 'z'], size=50)})
+    d = dd.from_pandas(d, 2)
+    d.to_parquet(tmp, partition_on=['b'], engine='fastparquet')
+    df = dd.read_parquet(tmp, engine='fastparquet')
+    assert set(df.b.cat.categories) == {'x', 'y', 'z'}
+
+    d.to_parquet(tmp, partition_on=['b', 'c'], engine='fastparquet')
+    df = dd.read_parquet(tmp, engine='fastparquet')
+    assert set(df.b.cat.categories) == {'x', 'y', 'z'}
+    assert set(df.c.cat.categories) == {'x', 'y', 'z'}
+    df = dd.read_parquet(tmp, columns=['a', 'c'], engine='fastparquet')
+    assert set(df.c.cat.categories) == {'x', 'y', 'z'}
+    assert 'b' not in df.columns
+
+
 def test_append_wo_index(tmpdir):
     """Test append with write_index=False."""
     check_fastparquet()

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -419,6 +419,9 @@ def test_partition_on_cats(tmpdir):
     df = dd.read_parquet(tmp, index='c', engine='fastparquet')
     assert set(df.index.categories) == {'x', 'y', 'z'}
     assert 'c' not in df.columns
+    # series
+    df = dd.read_parquet(tmp, columns='b', engine='fastparquet')
+    assert set(df.cat.categories) == {'x', 'y', 'z'}
 
 
 def test_append_wo_index(tmpdir):


### PR DESCRIPTION
Fix for the fastparquet side

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
