### PR TITLE
Add broadcast_arrays

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import, division, print_function
 from ..utils import ignoring
 from .core import (Array, block, concatenate, stack, from_array, store,
                    map_blocks, atop, to_hdf5, to_npy_stack, from_npy_stack,
-                   from_delayed, asarray, asanyarray, broadcast_to)
+                   from_delayed, asarray, asanyarray,
+                   broadcast_arrays, broadcast_to)
 from .routines import (take, choose, argwhere, where, coarsen, insert,
                        ravel, roll, unique, squeeze, topk, ptp, diff, ediff1d,
                        bincount, digitize, histogram, cov, array, dstack,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3091,6 +3091,24 @@ def broadcast_to(x, shape, chunks=None):
                  dtype=x.dtype)
 
 
+@wraps(np.broadcast_arrays)
+def broadcast_arrays(*args, **kwargs):
+    subok = bool(kwargs.pop("subok", False))
+
+    to_array = asanyarray if subok else asarray
+    args = tuple(to_array(e) for e in args)
+
+    if kwargs:
+        raise TypeError("unsupported keyword argument(s) provided")
+
+    shape = broadcast_shapes(*(e.shape for e in args))
+    chunks = broadcast_chunks(*(e.chunks for e in args))
+
+    result = [broadcast_to(e, shape=shape, chunks=chunks) for e in args]
+
+    return result
+
+
 def offset_func(func, offset, *args):
     """  Offsets inputs by offset
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -14,7 +14,7 @@ from ..utils import ignoring
 from . import chunk
 from .core import (Array, asarray, normalize_chunks,
                    stack, concatenate,
-                   broadcast_to)
+                   broadcast_arrays)
 from .wrap import empty, ones, zeros, full
 
 
@@ -316,26 +316,22 @@ def meshgrid(*xi, **kwargs):
 
     xi = [asarray(e) for e in xi]
     xi = [e.flatten() for e in xi]
-    dimensions = [xi[i].size for i in range(len(xi))]
-    chunks = [xi[i].chunks[0] for i in range(len(xi))]
 
     if indexing == "xy" and len(xi) > 1:
         xi[0], xi[1] = xi[1], xi[0]
-        dimensions[0], dimensions[1] = dimensions[1], dimensions[0]
-        chunks[0], chunks[1] = chunks[1], chunks[0]
 
     grid = []
     for i in range(len(xi)):
-        s = len(dimensions) * [None]
+        s = len(xi) * [None]
         s[i] = slice(None)
         s = tuple(s)
 
         r = xi[i][s]
 
-        if not sparse:
-            r = broadcast_to(r, shape=dimensions, chunks=chunks)
-
         grid.append(r)
+
+    if not sparse:
+        grid = broadcast_arrays(*grid)
 
     if indexing == "xy" and len(xi) > 1:
         grid[0], grid[1] = grid[1], grid[0]

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -12,7 +12,9 @@ from .. import sharedict
 from ..base import tokenize
 from ..utils import ignoring
 from . import chunk
-from .core import Array, asarray, normalize_chunks, stack, concatenate, broadcast_to
+from .core import (Array, asarray, normalize_chunks,
+                   stack, concatenate,
+                   broadcast_to)
 from .wrap import empty, ones, zeros, full
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -910,6 +910,30 @@ def test_broadcast_to_chunks():
         broadcast_to(a, (5, 2, 6), chunks=((3, 2), (3,), (3, 3)))
 
 
+def test_broadcast_arrays():
+    # Calling `broadcast_arrays` with no arguments only works in NumPy 1.13.0+.
+    if LooseVersion(np.__version__) >= LooseVersion("1.13.0"):
+        assert np.broadcast_arrays() == da.broadcast_arrays()
+
+    a = np.arange(4)
+    d_a = da.from_array(a, chunks=tuple(s // 2 for s in a.shape))
+
+    a_0 = np.arange(4)[None, :]
+    a_1 = np.arange(4)[:, None]
+
+    d_a_0 = d_a[None, :]
+    d_a_1 = d_a[:, None]
+
+    a_r = np.broadcast_arrays(a_0, a_1)
+    d_r = da.broadcast_arrays(d_a_0, d_a_1)
+
+    assert isinstance(d_r, list)
+    assert len(a_r) == len(d_r)
+
+    for e_a_r, e_d_r in zip(a_r, d_r):
+        assert_eq(e_a_r, e_d_r)
+
+
 @pytest.mark.parametrize('u_shape, v_shape', [
     [tuple(), (2, 3)],
     [(1,), (2, 3)],

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -36,6 +36,7 @@ Top level user functions:
    bitwise_or
    bitwise_xor
    block
+   broadcast_arrays
    broadcast_to
    coarsen
    ceil
@@ -371,6 +372,7 @@ Other functions
 .. autofunction:: bitwise_or
 .. autofunction:: bitwise_xor
 .. autofunction:: block
+.. autofunction:: broadcast_arrays
 .. autofunction:: broadcast_to
 .. autofunction:: coarsen
 .. autofunction:: ceil

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -25,6 +25,7 @@ Core
 Array
 +++++
 
+- Add `broadcast_arrays` for Dask Arrays (:pr:`3217`) `John A Kirkham`_
 - Add `bitwise_*` ufuncs (:pr:`3219`) `John A Kirkham`_
 
 DataFrame


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/3209
Requires https://github.com/dask/dask/pull/3218 (for the no argument case)

Implements `broadcast_arrays` for Dask Arrays.