### PR TITLE
Support 0 or 1 args in broadcast_shapes and broadcast_chunks

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -799,7 +799,9 @@ def broadcast_chunks(*chunkss):
         ...
     ValueError: Chunks do not align: [(10, 10, 10), (3, 3)]
     """
-    if len(chunkss) == 1:
+    if not chunkss:
+        return ()
+    elif len(chunkss) == 1:
         return chunkss[0]
     n = max(map(len, chunkss))
     chunkss2 = [((1,),) * (n - len(c)) + c for c in chunkss]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -686,6 +686,7 @@ def test_binops():
 
 
 def test_broadcast_shapes():
+    assert (2, 5) == broadcast_shapes((2, 5))
     assert (0, 5) == broadcast_shapes((0, 1), (1, 5))
     assert (3, 4, 5) == broadcast_shapes((3, 4, 5), (4, 1), ())
     assert (3, 4) == broadcast_shapes((3, 1), (1, 4), (4,))
@@ -2356,6 +2357,8 @@ def test_map_blocks_with_changed_dimension():
 
 
 def test_broadcast_chunks():
+    assert broadcast_chunks(((2, 3),)) == ((2, 3),)
+
     assert broadcast_chunks(((5, 5),), ((5, 5),)) == ((5, 5),)
 
     a = ((10, 10, 10), (5, 5),)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -686,6 +686,7 @@ def test_binops():
 
 
 def test_broadcast_shapes():
+    assert () == broadcast_shapes()
     assert (2, 5) == broadcast_shapes((2, 5))
     assert (0, 5) == broadcast_shapes((0, 1), (1, 5))
     assert (3, 4, 5) == broadcast_shapes((3, 4, 5), (4, 1), ())
@@ -2357,6 +2358,8 @@ def test_map_blocks_with_changed_dimension():
 
 
 def test_broadcast_chunks():
+    assert broadcast_chunks() == ()
+
     assert broadcast_chunks(((2, 3),)) == ((2, 3),)
 
     assert broadcast_chunks(((5, 5),), ((5, 5),)) == ((5, 5),)


### PR DESCRIPTION
In `broadcast_shapes` both of these cases were supported, but didn't find test cases for either. In `broadcast_chunks` the single argument case was supported, but the no argument case failed. Also `broadcast_chunks` didn't appear to have tests for the single or no argument cases.

Hence this fixes `broadcast_chunks` to work in the no argument case. Also adds test cases for `broadcast_shapes` and `broadcast_chunks` when provided no arguments or a single argument.