### PR TITLE
[WIP] dd.Index operations yield other Index objects

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2985,3 +2985,17 @@ def test_map_partition_sparse():
         computed = result.compute()
         assert (computed.data == expected.data).all()
         assert (computed.coords == expected.coords).all()
+
+def test_index_operations_yield_indexes():
+    df = pd.DataFrame({'x': [1, 2, 3]}, index=[1, 2, 3])
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert isinstance(ddf.index > 1, dd.Index)
+    assert isinstance(1 < ddf.index, dd.Index)
+    assert isinstance(~(ddf.index > 1), dd.Index)
+
+
+def test_mixed_dask_array_operations():
+    df = pd.DataFrame({'x': [1, 2, 3]}, index=[1, 2, 3])
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert_eq((df.index > 2) | (df.x < 1),
+              (ddf.index > 2) | (ddf.x < 1))


### PR DESCRIPTION
This modifies binary and unary operators on Index objects to always
return other index objects, even though Pandas normally returns np.ndarrays

See https://github.com/dask/dask/issues/3227

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
