### PR TITLE
Support mixed operations between arrays and dataframes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1104,6 +1104,10 @@ class Array(Base):
     def shape(self):
         return tuple(map(sum, self.chunks))
 
+    @property
+    def _meta(self):
+        return np.empty(shape=(), dtype=self.dtype)
+
     def _get_chunks(self):
         return self._chunks
 
@@ -2936,7 +2940,10 @@ def elemwise(op, *args, **kwargs):
         vals = [np.empty((1,) * max(1, a.ndim), dtype=a.dtype)
                 if not is_scalar_for_elemwise(a) else a
                 for a in args]
-        dt = apply_infer_dtype(op, vals, {}, 'elemwise', suggest_dtype=False)
+        try:
+            dt = apply_infer_dtype(op, vals, {}, 'elemwise', suggest_dtype=False)
+        except Exception:
+            return NotImplemented
         need_enforce_dtype = any(not is_scalar_for_elemwise(a) and a.ndim == 0 for a in args)
 
     name = kwargs.get('name', None) or '%s-%s' % (funcname(op),

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3136,3 +3136,11 @@ def test_empty_chunks_in_array_len():
 
     err_msg = 'len() of unsized object'
     assert err_msg in str(exc_info.value)
+
+
+@pytest.mark.parametrize('dtype', [None, [('a', 'f4'), ('b', object)]])
+def test_meta(dtype):
+    a = da.zeros((1,), chunks=(1,))
+    assert a._meta.dtype == a.dtype
+    assert isinstance(a._meta, np.ndarray)
+    assert a.nbytes < 1000

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -998,17 +998,17 @@ def test_combine():
     first = lambda a, b: a
 
     # DataFrame
-    for da, db, a, b in [(ddf1, ddf2, df1, df2),
-                         (ddf1.A, ddf2.A, df1.A, df2.A),
-                         (ddf1.B, ddf2.B, df1.B, df2.B)]:
+    for dda, ddb, a, b in [(ddf1, ddf2, df1, df2),
+                           (ddf1.A, ddf2.A, df1.A, df2.A),
+                           (ddf1.B, ddf2.B, df1.B, df2.B)]:
         for func, fill_value in [(add, None), (add, 100), (first, None)]:
             sol = a.combine(b, func, fill_value=fill_value)
-            assert_eq(da.combine(db, func, fill_value=fill_value), sol)
-            assert_eq(da.combine(b, func, fill_value=fill_value), sol)
+            assert_eq(dda.combine(ddb, func, fill_value=fill_value), sol)
+            assert_eq(dda.combine(b, func, fill_value=fill_value), sol)
 
     assert_eq(ddf1.combine(ddf2, add, overwrite=False),
               df1.combine(df2, add, overwrite=False))
-    assert da.combine(db, add)._name == da.combine(db, add)._name
+    assert dda.combine(ddb, add)._name == dda.combine(ddb, add)._name
 
 
 def test_combine_first():
@@ -3021,7 +3021,7 @@ def test_mixed_dask_array_operations_errors():
 def test_mixed_dask_array_multi_dimensional():
     df = pd.DataFrame({'x': [1, 2, 3, 4, 5],
                        'y': [5., 6., 7., 8., 9.]},
-                       columns=['x', 'y'])
+                      columns=['x', 'y'])
     ddf = dd.from_pandas(df, npartitions=2)
 
     x = (df.values + 1).astype(float)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2985,3 +2985,18 @@ def test_map_partition_sparse():
         computed = result.compute()
         assert (computed.data == expected.data).all()
         assert (computed.coords == expected.coords).all()
+
+
+def test_mixed_dask_array_operations():
+    df = pd.DataFrame({'x': [1, 2, 3]}, index=[4, 5, 6])
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    assert_eq(df.x + df.x.values,
+              ddf.x + ddf.x.values)
+    assert_eq(df.x.values + df.x,
+              ddf.x.values + ddf.x)
+
+    assert_eq(df.x + df.index.values,
+              ddf.x + ddf.index.values)
+    assert_eq(df.index.values + df.x,
+              ddf.index.values + ddf.x)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,7 @@ DataFrame
 +++++++++
 
 - Add ``dd.tseries.Resampler.agg`` (:pr:`3202`) `Richard Postelnik`_
+- Support operations that mix dataframes and arrays (:pr:`3230`) `Matthew Rocklin`_
 
 Bag
 +++


### PR DESCRIPTION
This allows mixing of Dask array and dataframe objects in element-wise
computations *if* they are well aligned.

    df.x - df.y.values

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
