### PR TITLE
Fix handling of non-iterable non-string keys for task graphs

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -303,16 +303,18 @@ def subs(task, key, val):
             arg = subs(arg, key, val)
         elif type_arg is list:
             arg = [subs(x, key, val) for x in arg]
-        elif type_arg.__name__ == "ndarray" and type(key).__name__ == "ndarray":
-            # Can't do a simple equality check, since this may trigger
-            # a FutureWarning from NumPy about array equality
-            # https://github.com/dask/dask/pull/2457
-            if len(arg) == len(key) and all(type(aa) == type(bb) and aa == bb
-                                            for aa, bb in zip(arg, key)):
-                arg = val
         elif type_arg is type(key):
-            if arg == key:
-                arg = val
+            try:
+                # Can't do a simple equality check, since this may trigger
+                # a FutureWarning from NumPy about array equality
+                # https://github.com/dask/dask/pull/2457
+                if len(arg) == len(key) and all(type(aa) == type(bb) and aa == bb
+                                                for aa, bb in zip(arg, key)):
+                    arg = val
+
+            except TypeError:
+                if arg == key:
+                    arg = val
         newargs.append(arg)
     return task[:1] + tuple(newargs)
 

--- a/dask/core.py
+++ b/dask/core.py
@@ -303,7 +303,7 @@ def subs(task, key, val):
             arg = subs(arg, key, val)
         elif type_arg is list:
             arg = [subs(x, key, val) for x in arg]
-        elif type_arg.__name__ == "ndarray":
+        elif type_arg.__name__ == "ndarray" and type(key).__name__ == "ndarray":
             # Can't do a simple equality check, since this may trigger
             # a FutureWarning from NumPy about array equality
             # https://github.com/dask/dask/pull/2457

--- a/dask/core.py
+++ b/dask/core.py
@@ -313,6 +313,7 @@ def subs(task, key, val):
                     arg = val
 
             except (TypeError, AttributeError):
+                # Handle keys which are not sized (len() fails), but are hashable
                 if arg == key:
                     arg = val
         newargs.append(arg)

--- a/dask/core.py
+++ b/dask/core.py
@@ -312,7 +312,7 @@ def subs(task, key, val):
                                                 for aa, bb in zip(arg, key)):
                     arg = val
 
-            except TypeError:
+            except (TypeError, AttributeError):
                 if arg == key:
                     arg = val
         newargs.append(arg)

--- a/dask/core.py
+++ b/dask/core.py
@@ -303,12 +303,15 @@ def subs(task, key, val):
             arg = subs(arg, key, val)
         elif type_arg is list:
             arg = [subs(x, key, val) for x in arg]
-        elif type_arg is type(key):
+        elif type_arg.__name__ == "ndarray":
             # Can't do a simple equality check, since this may trigger
             # a FutureWarning from NumPy about array equality
             # https://github.com/dask/dask/pull/2457
             if len(arg) == len(key) and all(type(aa) == type(bb) and aa == bb
                                             for aa, bb in zip(arg, key)):
+                arg = val
+        elif type_arg is type(key):
+            if arg == key:
                 arg = val
         newargs.append(arg)
     return task[:1] + tuple(newargs)
@@ -365,7 +368,7 @@ def _toposort(dsk, keys=None, returncycle=False, dependencies=None):
                         if returncycle:
                             return cycle
                         else:
-                            cycle = '->'.join(cycle)
+                            cycle = '->'.join(str(x) for x in cycle)
                             raise RuntimeError('Cycle detected in Dask: %s' % cycle)
                     next_nodes.append(nxt)
 

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -221,6 +221,20 @@ def test_subs_with_surprisingly_friendly_eq():
         assert subs(df, 'x', 1) is df
 
 
+def test_subs_unexpected_hashable_key():
+    class UnexpectedButHashable:
+        def __init__(self):
+            self.name = "a"
+
+        def __hash__(self):
+            return hash(self.name)
+
+        def __eq__(self, other):
+            return isinstance(other, UnexpectedButHashable)
+
+    assert subs((id, UnexpectedButHashable()), UnexpectedButHashable(), 1) == (id, 1)
+
+
 def test_quote():
     literals = [[1, 2, 3], (add, 1, 2),
                 [1, [2, 3]], (add, 1, (add, 2, 3))]

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1027,3 +1027,4 @@ Other
 .. _`Max Epstein`: https://github.com/MaxPowerWasTaken
 .. _`Simon Perkins`: https://github.com/sjperkins
 .. _`Richard Postelnik`: https://github.com/postelrich
+.. _`Daniel Collins`: https://github.com/dancollins34

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -42,6 +42,8 @@ Bag
 Core
 ++++
 
+- Fixed bug when using unexpected but hashable types for keys (:pr:`3238`) `Daniel Collins`_
+
 
 0.17.1 / 2018-02-22
 -------------------


### PR DESCRIPTION
The first issue on lines 306-317 in subs is fixing the assumption that if type_arg is type(key) then arg is an ndarray, when it can actually be any non-core python type at this point in the branching.  It adds a fallback to check simple equality in case the arg is not sized or is not iterable.

The second issue is where '->'.join(cycle) will fail (in trying to create an error message) if the elements of cycle cannot be added to strings.  This is resolved by calling str(x) on each before joining.

- [Y] Tests added / passed - added test_core.py:test_subs_unexpected_hashable_key, passes all existing tests
- [N] Passes `flake8 dask` - Passes for my code, errors elsewhere
- [?] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API - Not sure what changes need to be made