### PR TITLE
Support delayed and single-partition bags in Bag.join

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,10 +19,10 @@ DataFrame
 - Add ``dd.tseries.Resampler.agg`` (:pr:`3202`) `Richard Postelnik`_
 - Support operations that mix dataframes and arrays (:pr:`3230`) `Matthew Rocklin`_
 
-
 Bag
 +++
 
+- Support joining against single-partitioned bags and delayed objects (:pr:`3254`) `Matthew Rocklin`_
 
 Core
 ++++


### PR DESCRIPTION
This can significantly improve performance when joining against larger
collections due to serialization overhead on the distributed scheduler.

There is still more work to do here for multi-partition joins.

Experiments also show that GC is having a profound effect on performance
here.

Fixes #3252 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
