### PR TITLE
Consolidate changelog entries

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,24 +1,6 @@
 Changelog
 =========
 
-0.17.X / 2018-02-DD
--------------------
-
-Array
-+++++
-
-DataFrame
-+++++++++
-
-- Add ``dd.tseries.Resampler.agg`` (:pr:`3202`) `Richard Postelnik`_
-- Support operations that mix dataframes and arrays (:pr:`3230`) `Matthew Rocklin`_
-
-Bag
-+++
-
-Core
-++++
-
 
 0.XX.X / 2018-MM-DD
 -------------------
@@ -34,6 +16,8 @@ DataFrame
 
 -  Fixed bug in shuffle due to aggressive truncation (:pr:`3201`) `Matthew Rocklin`_
 - Support specifying categorical columns on ``read_parquet`` with ``categories=[…]`` for ``engine="pyarrow"`` (:pr:`3177`) `Uwe Korn`_
+- Add ``dd.tseries.Resampler.agg`` (:pr:`3202`) `Richard Postelnik`_
+- Support operations that mix dataframes and arrays (:pr:`3230`) `Matthew Rocklin`_
 
 
 Bag


### PR DESCRIPTION
Somehow we wound up with two development release sections. This merges them back together.