### PR TITLE
Specify to_parquet keys explicitly to ensure ordering

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1040,12 +1040,13 @@ def test_setect_partitioned_column(tmpdir, engine):
     df_partitioned[df_partitioned.fake_categorical1 == 'A'].compute()
 
 
-def test_order():
+@pytest.mark.parametrize('npartitions', [17, 20])  # even and unevenly divides
+def test_order(npartitions):
     from dask.order import order
     df = dd.demo.make_timeseries('2000-01-01', '2000-01-05',
                                  freq='10s', partition_freq='1d',
                                  dtypes={'x': float})
-    x = df.repartition(npartitions=df.npartitions * 3).to_parquet('foo.parquet', compute=False)
+    x = df.repartition(npartitions=npartitions).to_parquet('foo.parquet', compute=False)
     o = order(x.dask)
     dependencies, dependents = dask.core.get_deps(x.dask)
     deps = dependencies[x.key]


### PR DESCRIPTION
Previously we used delayed functions here, which don't order things in
an obvious way.  Our task ordering heuristics use keys as tie-breakers
so they were performing sub-optimally when writing parquet data to disk

In the future, when convenient, we should endeavor to make our keys look
like the following:

    ('name-hash', int)

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
