### PR TITLE
Consistent use of ordering by task name

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -99,16 +99,17 @@ def order(dsk, dependencies=None):
     waiting = {k: set(v) for k, v in dependencies.items()}
 
     def dependencies_key(x):
-        return total_dependencies.get(x, 0), StrComparable(x)
+        return total_dependencies.get(x, 0), ReverseStrComparable(x)
 
     def dependents_key(x):
-        return total_dependents.get(x, 0), StrComparable(x)
+        return (total_dependents.get(x, 0),
+                StrComparable(x))
 
     result = dict()
     i = 0
 
     stack = [k for k, v in dependents.items() if not v]
-    stack = sorted(stack, key=total_dependencies.get)
+    stack = sorted(stack, key=dependencies_key)
 
     while stack:
         item = stack.pop()
@@ -214,3 +215,21 @@ class StrComparable(object):
             return self.obj < other.obj
         except Exception:
             return str(self.obj) < str(other.obj)
+
+
+class ReverseStrComparable(object):
+    """ Wrap object so that it defaults to string comparison
+
+    Used when sorting in reverse direction.  See StrComparable for normal
+    documentation.
+    """
+    __slots__ = ('obj',)
+
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __lt__(self, other):
+        try:
+            return self.obj > other.obj
+        except Exception:
+            return str(self.obj) > str(other.obj)

--- a/dask/tests/test_local.py
+++ b/dask/tests/test_local.py
@@ -176,4 +176,4 @@ def test_ordering():
 
     get_sync(dsk, 'y')
 
-    assert L == sorted(L, reverse=True)
+    assert L == sorted(L)

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -146,8 +146,10 @@ def test_avoid_upwards_branching_complex(abcde):
            (a, 2): (f, (a, 3)),
            (a, 3): (f, (b, 1), (c, 1)),
            (b, 1): (f, (b, 2)),
+           (b, 2): (f,),
            (c, 1): (f, (c, 2)),
            (c, 2): (f, (c, 3)),
+           (c, 3): (f,),
            (d, 1): (f, (c, 1)),
            (d, 2): (f, (d, 1)),
            (d, 3): (f, (d, 1)),
@@ -238,8 +240,11 @@ def test_gh_3055():
 
     dsk = dict(w.__dask_graph__())
     o = order(dsk)
+    # from dask import visualize
+    # visualize(dsk, color='order', filename='dask.pdf', node_attr={'penwidth': '6'})
     L = [o[k] for k in w.__dask_keys__()]
-    assert sorted(L) == L
+    assert sum(x < len(L) / 2) > len(L) / 3  # some complete quickly
+    assert sorted(L) == L  # operate in order
 
 
 def test_type_comparisions_ok(abcde):
@@ -353,7 +358,7 @@ def test_local_parents_of_reduction(abcde):
     assert log == expected
 
 
-def test_nearest_neightbor(abcde):
+def test_nearest_neighbor(abcde):
     """
 
     a1  a2  a3  a4  a5  a6  a7
@@ -379,7 +384,8 @@ def test_nearest_neightbor(abcde):
            a7: (f, b3)}
 
     o = order(dsk)
-    from dask import visualize
-    visualize(dsk, color='order', filename='dask.png', node_attr={'penwidth': '6'})
+    # from dask import visualize
+    # visualize(dsk, color='order', filename='dask.png', node_attr={'penwidth': '6'})
 
-    assert {o[b1], o[b2], o[b3]} == {0, 5, 8}
+    assert {o[b1], o[b2], o[b3]} == {0, 1, 5}
+    assert o[min([b1, b2, b3])] == 0

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -240,8 +240,6 @@ def test_gh_3055():
 
     dsk = dict(w.__dask_graph__())
     o = order(dsk)
-    # from dask import visualize
-    # visualize(dsk, color='order', filename='dask.pdf', node_attr={'penwidth': '6'})
     L = [o[k] for k in w.__dask_keys__()]
     assert sum(x < len(o) / 2 for x in L) > len(L) / 3  # some complete quickly
     assert sorted(L) == L  # operate in order

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -28,6 +28,7 @@ Core
 ++++
 
 - Fixed bug when using unexpected but hashable types for keys (:pr:`3238`) `Daniel Collins`_
+- Fix bug in task ordering so that we break ties consistently with the key name (:pr:`3271`) `Matthew Rocklin`_
 
 
 0.17.1 / 2018-02-22


### PR DESCRIPTION
![dask](https://user-images.githubusercontent.com/306380/37259149-2d3bf412-2559-11e8-8f01-563dac607a40.png)

We break ties in task ordering by using the task key itself.  Previously we did this inconsistently due to using `sorted(reverse=True/False)` in different situations.  This cause inconsistent ordrering in general and pathological ordering in some situations (like nearest neighbor computations).

We now use two different comparators for string comparison.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
