### PR TITLE
Expose literal and quote

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .core import istask
+from .core import istask, literal, quote
 from .context import set_options
 from .local import get_sync as get
 try:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -16,12 +16,16 @@ Note that the individual APIs have their own separate API pages available here:
 .. autosummary::
    compute
    is_dask_collection
+   literal
    optimize
    persist
+   quote
    visualize
 
 .. autofunction:: compute
 .. autofunction:: is_dask_collection
+.. autofunction:: literal
 .. autofunction:: optimize
 .. autofunction:: persist
+.. autofunction:: quote
 .. autofunction:: visualize

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -28,6 +28,7 @@ Core
 ++++
 
 - Fixed bug when using unexpected but hashable types for keys (:pr:`3238`) `Daniel Collins`_
+- Add ``literal`` and ``quote`` to the public API (:pr:`3275`) `John A Kirkham`_
 
 
 0.17.1 / 2018-02-22


### PR DESCRIPTION
Includes `literal` and `quote` in the public API following discussion in [this SO question]( https://stackoverflow.com/q/49238644/3877089 ).

cc @mrocklin