### PR TITLE
Require NumPy 1.10.4+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ import versioneer
 # NOTE: These are tested in `continuous_integration/travis/test_imports.sh` If
 # you modify these, make sure to change the corresponding line there.
 extras_require = {
-  'array': ['numpy', 'toolz >= 0.7.3'],
+  'array': ['numpy >= 1.10.4', 'toolz >= 0.7.3'],
   'bag': ['cloudpickle >= 0.2.1', 'toolz >= 0.7.3', 'partd >= 0.3.8'],
-  'dataframe': ['numpy', 'pandas >= 0.19.0', 'toolz >= 0.7.3',
+  'dataframe': ['numpy >= 1.10.4', 'pandas >= 0.19.0', 'toolz >= 0.7.3',
                 'partd >= 0.3.8', 'cloudpickle >= 0.2.1'],
   'distributed': ['distributed >= 1.21'],
   'delayed': ['toolz >= 0.7.3'],


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/2796

As NumPy 1.10.4+ is the oldest version of NumPy that we test against, set that as the lower bound for Dask's optional NumPy requirement. Also some things that Dask is doing internally assume NumPy 1.10 at a minimum (e.g. wrapping `cbrt`).