### PR TITLE
Handle `return_stored` in `store` method correctly

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1208,7 +1208,12 @@ class Array(Base):
 
     @wraps(store)
     def store(self, target, **kwargs):
-        return store([self], [target], **kwargs)
+        r = store([self], [target], **kwargs)
+
+        if kwargs.get("return_stored", False):
+            r = r[0]
+
+        return r
 
     def to_hdf5(self, filename, datapath, **kwargs):
         """ Store array in HDF5 file

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1513,6 +1513,26 @@ def test_store_locks():
             assert lock.acquire_count == nchunks
 
 
+def test_store_method_return():
+    d = da.ones((10, 10), chunks=(2, 2))
+    a = d + 1
+
+    for compute in [False, True]:
+        for return_stored in [False, True]:
+            at = np.zeros(shape=(10, 10))
+            r = a.store(
+                at, get=dask.threaded.get,
+                compute=compute, return_stored=return_stored
+            )
+
+            if return_stored:
+                assert isinstance(r, Array)
+            elif compute:
+                assert r is None
+            else:
+                assert isinstance(r, Delayed)
+
+
 @pytest.mark.xfail(reason="can't lock with multiprocessing")
 def test_store_multiprocessing_lock():
     d = da.ones((10, 10), chunks=(2, 2))


### PR DESCRIPTION
If `store` is returning the stored array loaded, then strip the length 1 tuple from the result to make it easier to work with. IOW return the Dask Array representing the stored result of the computation.

xref: https://github.com/dask/dask/pull/2980