### PR TITLE
Pass `store`'s `kwargs` to `compute` call

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -933,7 +933,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         load_store_dsk = store_dsk
         if compute:
             store_dlyds = [Delayed(k, store_dsk) for k in store_keys]
-            store_dlyds = persist(*store_dlyds)
+            store_dlyds = persist(*store_dlyds, **kwargs)
             store_dsk_2 = sharedict.merge(*[e.dask for e in store_dlyds])
 
             load_store_dsk = retrieve_from_ooc(
@@ -952,7 +952,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         result = Delayed(name, dsk)
 
         if compute:
-            result.compute()
+            result.compute(**kwargs)
             return None
         else:
             return result

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1222,6 +1222,34 @@ def test_bool():
         bool(darr == darr)
 
 
+def test_store_kwargs():
+    d = da.ones((10, 10), chunks=(2, 2))
+    a = d + 1
+
+    called = [False]
+
+    def get_func(*args, **kwargs):
+        assert kwargs.pop("foo") == "test kwarg"
+        r = dask.get(*args, **kwargs)
+        called[0] = True
+        return r
+
+    called[0] = False
+    at = np.zeros(shape=(10, 10))
+    store([a], [at], get=get_func, foo="test kwarg")
+    assert called[0]
+
+    called[0] = False
+    at = np.zeros(shape=(10, 10))
+    a.store(at, get=get_func, foo="test kwarg")
+    assert called[0]
+
+    called[0] = False
+    at = np.zeros(shape=(10, 10))
+    store([a], [at], get=get_func, return_store=True, foo="test kwarg")
+    assert called[0]
+
+
 def test_store_delayed_target():
     from dask.delayed import delayed
     d = da.ones((4, 4), chunks=(2, 2))


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/3299
Related https://github.com/dask/dask/pull/2980

Appears the `kwargs` intended for the `compute` call in Dask Array's `store` were getting dropped after a recent rewrite. This corrects it so that `kwargs` are passed to the `compute` call.

cc @mrocklin @rabernat
