### PR TITLE
Prevent astype in array.concatenate if all parts have same dtype

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2611,8 +2611,12 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
 
     cum_dims = [0] + list(accumulate(add, [len(a.chunks[axis]) for a in seq]))
 
-    dt = reduce(np.promote_types, [a.dtype for a in seq])
-    seq = [x.astype(dt) for x in seq]
+    seq_dtypes = [a.dtype for a in seq]
+    if len(set(seq_dtypes)) > 1:
+        dt = reduce(np.promote_types, seq_dtypes)
+        seq = [x.astype(dt) for x in seq]
+    else:
+        dt = seq_dtypes[0]
 
     names = [a.name for a in seq]
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -335,6 +335,17 @@ def test_concatenate():
     pytest.raises(ValueError, lambda: concatenate([a, b, c], axis=2))
 
 
+@pytest.mark.parametrize('dtypes', [(('>f8', '>f8'), '>f8'),
+                                    (('<f4', '<f8'), '<f8')])
+def test_concatenate_types(dtypes):
+    dts_in, dt_out = dtypes
+    arrs = [np.zeros(4, dtype=dt) for dt in dts_in]
+    darrs = [from_array(arr, chunks=(2,)) for arr in arrs]
+
+    x = concatenate(darrs, axis=0)
+    assert x.dtype == dt_out
+
+
 def test_concatenate_unknown_axes():
     dd = pytest.importorskip('dask.dataframe')
     pd = pytest.importorskip('pandas')


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API

Fixes #3248