### PR TITLE
Add set of tasks that should not be added to stack in order

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -106,6 +106,7 @@ def order(dsk, dependencies=None):
                 StrComparable(x))
 
     result = dict()
+    seen = set()  # tasks that should not be added again to the stack
     i = 0
 
     stack = [k for k, v in dependents.items() if not v]
@@ -123,6 +124,7 @@ def order(dsk, dependencies=None):
         deps = waiting[item]
         if deps:
             stack.append(item)
+            seen.add(item)
             if len(deps) < 1000:
                 deps = sorted(deps, key=dependencies_key)
             stack.extend(deps)
@@ -134,7 +136,8 @@ def order(dsk, dependencies=None):
         for dep in dependents[item]:
             waiting[dep].discard(item)
 
-        deps = [d for d in dependents[item] if d not in result]
+        deps = [d for d in dependents[item]
+                if d not in result and not (d in seen and waiting[d])]
         if len(deps) < 1000:
             deps = sorted(deps, key=dependents_key, reverse=True)
         stack.extend(deps)


### PR DESCRIPTION
Previously we would re-add a task to the stack many times if it had many dependencies.  
We now maintain a set of tasks that should not be re-added and check it.  
This results in a significant reduction of costs in order in cases where a single output has
many input dependencies.

Real-world cause is here: https://github.com/pangeo-data/pangeo/issues/150#issuecomment-374330750

I don't know of a nice way to test this.  This is one of those situations where having benchmarks directly within the repository would be convenient.

- [ ] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
