### PR TITLE
Validate inputs to atop

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2312,6 +2312,11 @@ def atop(func, out_ind, *args, **kwargs):
         chunkss[k] = (v,)
     arginds = list(zip(arrays, args[1::2]))
 
+    for arg, ind in arginds:
+        if hasattr(arg, 'ndim') and hasattr(ind, '__len__') and arg.ndim != len(ind):
+            raise ValueError("Index string %s does not match array dimension %d"
+                             % (ind, arg.ndim))
+
     numblocks = {a.name: a.numblocks for a, ind in arginds if ind is not None}
     argindsstr = list(concat([(a if ind is None else a.name, ind) for a, ind in arginds]))
     # Finish up the name

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2661,6 +2661,15 @@ def test_atop_chunks():
     assert_eq(y, np.ones((20, 10)))
 
 
+def test_atop_raises_on_incorrect_indices():
+    x = da.arange(5, chunks=3)
+    with pytest.raises(ValueError) as info:
+        da.atop(lambda x: x, 'ii', x, 'ii', dtype=int)
+
+    assert 'ii' in str(info.value)
+    assert '1' in str(info.value)
+
+
 def test_from_delayed():
     v = delayed(np.ones)((5, 3))
     x = from_delayed(v, shape=(5, 3), dtype=np.ones(0).dtype)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Array
 
 - Add `broadcast_arrays` for Dask Arrays (:pr:`3217`) `John A Kirkham`_
 - Add `bitwise_*` ufuncs (:pr:`3219`) `John A Kirkham`_
+- Validate inputs to atop (:pr:`3307`) `Matthew Rocklin`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
This checks that the lengths of the index strings given to atop match
the dimension of the arrays.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
