### PR TITLE
Removes "incubating" from Apache Impala reference

### DIFF
--- a/docs/source/dataframe-performance.rst
+++ b/docs/source/dataframe-performance.rst
@@ -194,7 +194,7 @@ instead.  `Apache Parquet <http://parquet.apache.org/>`_ is a columnar binary
 format that is easy to split into multiple files (easier for parallel loading)
 and is generally much simpler to deal with than HDF5 (from the library's
 perspective).  It is also a common format used by other big data systems like
-`Apache Spark <http://spark.apache.org/>`_ and `Apache Impala (incubating)
+`Apache Spark <http://spark.apache.org/>`_ and `Apache Impala
 <http://impala.apache.org/>`_ and so is useful to interchange with other
 systems.
 


### PR DESCRIPTION
Fixes #3272. This PR removes the incubating reference to Apache Impala in the docs. 

- [ ] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
