### PR TITLE
Add optional SciPy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extras_require = {
                 'partd >= 0.3.8', 'cloudpickle >= 0.2.1'],
   'distributed': ['distributed >= 1.21'],
   'delayed': ['toolz >= 0.7.3'],
+  'scipy': ['scipy >= 0.16.0'],
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/3287

Some functionality like Dask Array's `LinearOperator` support depend on SciPy. This adds SciPy as an optional requirement. As the last version this was [tested on was SciPy 0.16.0]( https://travis-ci.org/dask/dask/jobs/124625465#L329 ) (by inspecting the CI logs that added this feature ( https://github.com/dask/dask/pull/1107 )), set that as the minimum SciPy requirement. Can always be bumped if other constraints come into play.