### PR TITLE
Simplify construction of store graph

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -904,7 +904,9 @@ def store(sources, targets, lock=True, regions=None, compute=True,
             targets_keys.extend(e.__dask_keys__())
             targets_dsk.append(e.__dask_graph__())
         elif is_dask_collection(e):
-            raise TypeError("Targets must be either Delayed objects or array-likes")
+            raise TypeError(
+                "Targets must be either Delayed objects or array-likes"
+            )
         else:
             targets2.append(e)
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -917,7 +917,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
     load_stored = (return_stored and not compute)
     store_dsk = sharedict.merge(*[
         insert_to_ooc(s, t, lock, r, return_stored, load_stored)
-        for t, s, r in zip(targets2, sources2, regions)
+        for s, t, r in zip(sources2, targets2, regions)
     ])
     store_keys = list(store_dsk.keys())
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -893,6 +893,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
         sources_dsk,
         list(core.flatten([e.__dask_keys__() for e in sources]))
     )
+    sources2 = [Array(sources_dsk, e.name, e.chunks, e.dtype) for e in sources]
 
     # Optimize all targets together
     targets2 = []
@@ -917,9 +918,7 @@ def store(sources, targets, lock=True, regions=None, compute=True,
 
     store_keys = []
     store_dsk = []
-    for tgt, src, reg in zip(targets2, sources, regions):
-        src = Array(sources_dsk, src.name, src.chunks, src.dtype)
-
+    for tgt, src, reg in zip(targets2, sources2, regions):
         each_store_dsk = insert_to_ooc(
             src, tgt, lock=lock, region=reg,
             return_stored=return_stored, load_stored=load_stored


### PR DESCRIPTION
In `dask.array.store`, simplify the construction of the Dask store graph by making use of comprehensions. Makes the code a little cleaner and more readable. May also improve speed as well.