### PR TITLE
Note squeeze's optional axis arg in the changelog

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -34,6 +34,7 @@ Array
 
 - Add ``broadcast_arrays`` for Dask Arrays (:pr:`3217`) `John A Kirkham`_
 - Add ``bitwise_*`` ufuncs (:pr:`3219`) `John A Kirkham`_
+- Add optional ``axis`` argument to ``squeeze`` (:pr:`3261`) `John A Kirkham`_
 - Validate inputs to atop (:pr:`3307`) `Matthew Rocklin`_
 - Avoid calls to astype in concatenate if all parts have the same dtype (:pr:`3301`) `Martin Durant`_
 


### PR DESCRIPTION
Mentions that the Dask Array `squeeze` method now takes the optional `axis` argument should users wish to squeeze out specific axis/axes. Useful for duck typing.

xref: https://github.com/dask/dask/pull/3261