### PR TITLE
Make load_store_chunk args from store_chunk's args

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2735,9 +2735,9 @@ def insert_to_ooc(arr, out, lock=True, region=None,
     func = store_chunk
     args = ()
     if return_stored and load_stored:
-        name = 'load-store-%s' % arr.name
+        name = 'load-%s' % name
         func = load_store_chunk
-        args = (load_stored,)
+        args = args + (load_stored,)
 
     dsk = {
         (name,) + t[1:]: (func, t, out, slc, lock, return_stored) + args


### PR DESCRIPTION
Reuse the name generated for `load_store_chunk`'s keys based off the keys used for `store_chunk`. Also tack on the arguments used for `load_store_chunk` after those used for `store_chunk`. Should avoid deviations between the two cases as the `load_store_chunk` case is merely an extension of the `store_chunk` case.