### PR TITLE
Use read_parquet(..., engine='pyarrow')

### DIFF
--- a/docs/source/dataframe-performance.rst
+++ b/docs/source/dataframe-performance.rst
@@ -209,7 +209,7 @@ format for Python.
 .. code-block:: python
 
    df1 = dd.read_parquet('path/to/my-results/', engine='fastparquet')
-   df2 = dd.read_parquet('path/to/my-results/', engine='arrow')
+   df2 = dd.read_parquet('path/to/my-results/', engine='pyarrow')
 
 These libraries be installed using
 


### PR DESCRIPTION
According to the source

dask/dataframe/io/parquet.py:755: UserWarning: parquet with `engine='arrow'` is deprecated, use `engine='pyarrow'` instead

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
