### PR TITLE
Add piecewise to Dask Array

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -13,7 +13,7 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        allclose, corrcoef, swapaxes, tensordot, transpose, dot,
                        vdot, matmul, apply_along_axis, apply_over_axes,
                        result_type, atleast_1d, atleast_2d, atleast_3d,
-                       flip, flipud, fliplr)
+                       piecewise, flip, flipud, fliplr)
 from .reshape import reshape
 from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
         true_divide, floor_divide, negative, power, remainder, mod, conj, exp,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1065,6 +1065,24 @@ def nonzero(a):
         return (ind,)
 
 
+def _int_piecewise(x, *condlist, **kwargs):
+    return np.piecewise(
+        x, list(condlist), kwargs["funclist"],
+        *kwargs["func_args"], **kwargs["func_kw"]
+    )
+
+
+@wraps(np.piecewise)
+def piecewise(x, condlist, funclist, *args, **kw):
+    return map_blocks(
+        _int_piecewise,
+        x, *condlist,
+        dtype=x.dtype,
+        token="piecewise",
+        funclist=funclist, func_args=args, func_kw=kw
+    )
+
+
 @wraps(chunk.coarsen)
 def coarsen(reduction, x, axes, trim_excess=False):
     if (not trim_excess and

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -889,6 +889,31 @@ def test_choose():
     assert_eq(index_dask.choose([-d, d]), index_numpy.choose([-x, x]))
 
 
+def test_piecewise():
+    x = np.random.randint(10, size=(15, 16))
+    d = da.from_array(x, chunks=(4, 5))
+
+    assert_eq(
+        np.piecewise(x, [x < 5, x >= 5], [lambda e, v, k: e + 1, 5], 1, k=2),
+        da.piecewise(d, [d < 5, d >= 5], [lambda e, v, k: e + 1, 5], 1, k=2)
+    )
+
+    assert_eq(
+        np.piecewise(
+            x,
+            [x > 2, x <= 5],
+            [lambda e, v, k: e + 1, lambda e, v, k: v * e, lambda e, v, k: 0],
+            1, k=2
+        ),
+        da.piecewise(
+            d,
+            [d > 5, d <= 5],
+            [lambda e, v, k: e + 1, lambda e, v, k: v * e, lambda e, v, k: 0],
+            1, k=2
+        )
+    )
+
+
 def test_argwhere():
     for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -133,6 +133,7 @@ Top level user functions:
    ones
    ones_like
    percentile
+   piecewise
    prod
    ptp
    rad2deg
@@ -468,6 +469,7 @@ Other functions
 .. autofunction:: ones
 .. autofunction:: ones_like
 .. autofunction:: percentile
+.. autofunction:: piecewise
 .. autofunction:: prod
 .. autofunction:: ptp
 .. autofunction:: rad2deg

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 Array
 +++++
 
--
+- Add ``piecewise`` for Dask Arrays (:pr:`3350`) `John A Kirkham`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Adds a Dask Array implementation of NumPy's [`piecewise`]( https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.piecewise.html ) function.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
