### PR TITLE
Apply non-fancy indices first in vindex

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3470,15 +3470,26 @@ def _vindex(x, *indexes):
     array([ 0,  9, 48,  7])
     """
     indexes = replace_ellipsis(x.ndim, indexes)
-    partial_slices = {i: ind for i, ind in enumerate(indexes)
-                      if isinstance(ind, slice) and ind != slice(None)}
-    if partial_slices:
-        key = tuple(partial_slices.get(i, slice(None))
-                    for i in range(len(indexes)))
-        x = x[key]
+
+    nonfancy_indexes = []
+    reduced_indexes = []
+    for i, ind in enumerate(indexes):
+        if isinstance(ind, Number):
+            nonfancy_indexes.append(ind)
+        elif isinstance(ind, slice):
+            nonfancy_indexes.append(ind)
+            reduced_indexes.append(slice(None))
+        else:
+            nonfancy_indexes.append(slice(None))
+            reduced_indexes.append(ind)
+
+    nonfancy_indexes = tuple(nonfancy_indexes)
+    reduced_indexes = tuple(reduced_indexes)
+
+    x = x[nonfancy_indexes]
 
     array_indexes = {}
-    for i, (ind, size) in enumerate(zip(indexes, x.shape)):
+    for i, (ind, size) in enumerate(zip(reduced_indexes, x.shape)):
         if not isinstance(ind, slice):
             ind = np.array(ind, copy=True)
             if ind.dtype.kind == 'b':

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3491,41 +3491,49 @@ def _vindex(x, *indexes):
             ind %= size
             array_indexes[i] = ind
 
+    if array_indexes:
+        x = _vindex_array(x, array_indexes)
+
+    return x
+
+
+def _vindex_array(x, dict_indexes):
+    """Point wise indexing with only NumPy Arrays."""
+
     try:
-        broadcast_indexes = np.broadcast_arrays(*array_indexes.values())
+        broadcast_indexes = np.broadcast_arrays(*dict_indexes.values())
     except ValueError:
         # note: error message exactly matches numpy
-        shapes_str = ' '.join(str(a.shape) for a in array_indexes.values())
+        shapes_str = ' '.join(str(a.shape) for a in dict_indexes.values())
         raise IndexError('shape mismatch: indexing arrays could not be '
                          'broadcast together with shapes ' + shapes_str)
     broadcast_shape = broadcast_indexes[0].shape
 
-    lookup = dict(zip(array_indexes, broadcast_indexes))
+    lookup = dict(zip(dict_indexes, broadcast_indexes))
     flat_indexes = [lookup[i].ravel().tolist() if i in lookup else None
-                    for i in range(len(indexes))]
+                    for i in range(x.ndim)]
     flat_indexes.extend([None] * (x.ndim - len(flat_indexes)))
-    result_1d = _vindex_1d(x, *flat_indexes)
-    return result_1d.reshape(broadcast_shape + result_1d.shape[1:])
 
-
-def _vindex_1d(x, *indexes):
-    """Point wise indexing with only 1D lists and full slices."""
-    indexes = [list(index) if index is not None else index for index in indexes]
+    flat_indexes = [
+        list(index) if index is not None else index for index in flat_indexes
+    ]
     bounds = [list(accumulate(add, (0,) + c)) for c in x.chunks]
-    bounds2 = [b for i, b in zip(indexes, bounds) if i is not None]
-    axis = _get_axis(indexes)
-    token = tokenize(x, indexes)
+    bounds2 = [
+        b for i, b in zip(flat_indexes, bounds) if i is not None
+    ]
+    axis = _get_axis(flat_indexes)
+    token = tokenize(x, flat_indexes)
     out_name = 'vindex-merge-' + token
 
     points = list()
-    for i, idx in enumerate(zip(*[i for i in indexes if i is not None])):
+    for i, idx in enumerate(zip(*[i for i in flat_indexes if i is not None])):
         block_idx = [np.searchsorted(b, ind, 'right') - 1
                      for b, ind in zip(bounds2, idx)]
         inblock_idx = [ind - bounds2[k][j]
                        for k, (ind, j) in enumerate(zip(idx, block_idx))]
         points.append((i, tuple(block_idx), tuple(inblock_idx)))
 
-    chunks = [c for i, c in zip(indexes, x.chunks) if i is None]
+    chunks = [c for i, c in zip(flat_indexes, x.chunks) if i is None]
     chunks.insert(0, (len(points),) if points else (0,))
     chunks = tuple(chunks)
 
@@ -3534,9 +3542,11 @@ def _vindex_1d(x, *indexes):
         per_block = dict((k, v) for k, v in per_block.items() if v)
 
         other_blocks = list(product(*[list(range(len(c))) if i is None else [None]
-                                    for i, c in zip(indexes, x.chunks)]))
+                                    for i, c in zip(flat_indexes, x.chunks)]))
 
-        full_slices = [slice(None, None) if i is None else None for i in indexes]
+        full_slices = [
+            slice(None, None) if i is None else None for i in flat_indexes
+        ]
 
         name = 'vindex-slice-' + token
         dsk = dict((keyname(name, i, okey),
@@ -3553,14 +3563,18 @@ def _vindex_1d(x, *indexes):
                     [keyname(name, i, okey) for i in range(len(per_block))]))
                    for okey in other_blocks)
 
-        return Array(sharedict.merge(x.dask, (out_name, dsk)), out_name, chunks,
-                     x.dtype)
+        result_1d = Array(
+            sharedict.merge(x.dask, (out_name, dsk)), out_name, chunks, x.dtype
+        )
+        return result_1d.reshape(broadcast_shape + result_1d.shape[1:])
 
     # output has a zero dimension, just create a new zero-shape array with the
     # same dtype
     from .wrap import empty
-    return empty(tuple(map(sum, chunks)), chunks=chunks, dtype=x.dtype,
-                 name=out_name)
+    result_1d = empty(
+        tuple(map(sum, chunks)), chunks=chunks, dtype=x.dtype, name=out_name
+    )
+    return result_1d.reshape(broadcast_shape + result_1d.shape[1:])
 
 
 def _get_axis(indexes):


### PR DESCRIPTION
Extracts the non-fancy indices and applies them first in `vindex`. This is important as these shrink the shape of the array. Thus it is easier to reason about later steps if we know this has already happened. Further these immediately result in Dask Array chunks being dropped from consideration as only the chunk(s) containing the index or slice are kept. This is a nice property to have before other subselections are applied.