### PR TITLE
Test `broadcast_chunks` handles `nan` correctly

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2465,6 +2465,21 @@ def test_broadcast_chunks():
     b = ((1,), (5, 5),)
     assert broadcast_chunks(a, b) == a
 
+    a = ((1,), (np.nan, np.nan, np.nan),)
+    b = ((3, 3), (1,),)
+    r = broadcast_chunks(a, b)
+    assert r[0] == b[0] and np.allclose(r[1], a[1], equal_nan=True)
+
+    a = ((3, 3), (1,),)
+    b = ((1,), (np.nan, np.nan, np.nan),)
+    r = broadcast_chunks(a, b)
+    assert r[0] == a[0] and np.allclose(r[1], b[1], equal_nan=True)
+
+    a = ((3, 3,), (5, 5),)
+    b = ((1,), (np.nan, np.nan, np.nan),)
+    with pytest.raises(ValueError):
+        broadcast_chunks(a, b)
+
 
 def test_chunks_error():
     x = np.ones((10, 10))


### PR DESCRIPTION
Related to issue ( https://github.com/dask/dask/issues/3355 )

Add some tests for `nan` lengths in chunks passed to `broadcast_chunks`. The behavior already appears to be correct, but was untested. So this should help ensure it doesn't regress.
