### PR TITLE
Tweak piecewise tests

### DIFF
--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -900,6 +900,13 @@ def test_piecewise():
         da.piecewise(d, [d < 5, d >= 5], [lambda e, v, k: e + 1, 5], 1, k=2)
     )
 
+
+def test_piecewise_otherwise():
+    np.random.seed(1337)
+
+    x = np.random.randint(10, size=(15, 16))
+    d = da.from_array(x, chunks=(4, 5))
+
     assert_eq(
         np.piecewise(
             x,

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -890,6 +890,8 @@ def test_choose():
 
 
 def test_piecewise():
+    np.random.seed(1337)
+
     x = np.random.randint(10, size=(15, 16))
     d = da.from_array(x, chunks=(4, 5))
 
@@ -901,13 +903,13 @@ def test_piecewise():
     assert_eq(
         np.piecewise(
             x,
-            [x > 2, x <= 5],
+            [x > 5, x <= 2],
             [lambda e, v, k: e + 1, lambda e, v, k: v * e, lambda e, v, k: 0],
             1, k=2
         ),
         da.piecewise(
             d,
-            [d > 5, d <= 5],
+            [d > 5, d <= 2],
             [lambda e, v, k: e + 1, lambda e, v, k: v * e, lambda e, v, k: 0],
             1, k=2
         )

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import itertools
+import textwrap
 
 import pytest
 from distutils.version import LooseVersion
@@ -901,6 +902,16 @@ def test_piecewise():
     )
 
 
+@pytest.mark.skipif(
+    LooseVersion(np.__version__) < '1.12.0',
+    reason=textwrap.dedent(
+        """\
+            NumPy piecewise mishandles the otherwise condition pre-1.12.0.
+
+            xref: https://github.com/numpy/numpy/issues/5737
+        """
+    )
+)
 def test_piecewise_otherwise():
     np.random.seed(1337)
 


### PR DESCRIPTION
Follow-up to PR ( https://github.com/dask/dask/pull/3350 )

Appears that NumPy pre-1.12 had an issue going back to NumPy 1.9 with `piecewise` where it mishandled the case of an extra condition a.k.a. an otherwise/else case. ( https://github.com/numpy/numpy/issues/5737 ) This caused us a CI failure on Python 3.4 where NumPy 1.10 is being used.

As such, this fixes the issue by skipping that `piecewise` test if the NumPy version is older than 1.12 and cites the issues should anyone get curious.

Also realized the otherwise case was not getting exercised correctly due to the conditions provided. So this fixes that as well.