### PR TITLE
Style sphinx table of contents

### DIFF
--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -1,3 +1,57 @@
 @import url("theme.css");
 
-a.internal em {font-style: normal}
+.wy-menu-vertical li ul li a,
+.wy-menu-vertical li.current a,
+.wy-menu-vertical a {
+  color: #ECB172;
+}
+
+.wy-menu-vertical li.toctree-l2.current>a:hover,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l3>a:hover,
+.wy-menu-vertical li.toctree-l3.current li.toctree-l4>a:hover,
+.wy-menu-vertical li.current a:hover {
+  background: #404040;
+  color: #ECB172;
+}
+
+.wy-menu-vertical a:hover {
+  background: #303030;
+}
+
+.wy-side-nav-search>a img.logo,
+.wy-side-nav-search .wy-dropdown>a img.logo {
+  width: 10rem
+}
+
+.wy-side-nav-search {
+  background-color: black;
+}
+
+.wy-side-nav-search>div.version {
+  display: none;
+}
+
+.wy-menu-vertical header,
+.wy-menu-vertical p.caption {
+  color: #D67548;
+}
+
+.wy-menu-vertical li.on a,
+.wy-menu-vertical li.current>a {
+  background: #303030;
+  border-top: none;
+  border-bottom: none;
+}
+
+
+.wy-menu-vertical ul,
+.wy-side-scroll {
+  background-color: #101010;
+}
+
+.wy-menu-vertical li.toctree-l2.current>a,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l3>a,
+.wy-menu-vertical li.toctree-l3.current li.toctree-l4>a,
+.wy-menu-vertical li ul {
+  background-color: #303030;
+}

--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -55,3 +55,17 @@
 .wy-menu-vertical li ul {
   background-color: #303030;
 }
+
+/* Mobile */
+
+.wy-nav-top {
+  background: black;
+}
+
+.wy-nav-top a {
+  color: #ECB172;
+}
+
+.wy-nav-top i {
+  color: #ECB172;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ master_doc = 'docs'
 html_extra_path = ['index.html']
 
 # General information about the project.
-project = u'dask'
+project = u'Dask'
 copyright = u'2014-2018, Anaconda, Inc. and contributors'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -242,8 +242,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('docs', 'dask', u'dask Documentation',
-   u'Dask Development Team', 'dask', 'One line description of project.',
+  ('docs', 'Dask', u'dask Documentation',
+   u'Dask Development Team', 'Dask', 'One line description of project.',
    'Miscellaneous'),
 ]
 
@@ -260,7 +260,7 @@ texinfo_documents = [
 # -- Options for Epub output ---------------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u'dask'
+epub_title = u'Dask'
 epub_author = u'Dask Development Team'
 epub_publisher = u'Anaconda Inc'
 epub_copyright = u'2014-2018, Anaconda, Inc. and contributors'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,7 +108,9 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+    'logo_only': True
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -122,7 +124,8 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+html_logo = "images/dask_horizontal_white_no_pad.svg"
+
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32


### PR DESCRIPTION
This adds an orange-black styling to the table of contents side-bar
in the documentation.

It also uses the Dask logo in the upper left

![image](https://user-images.githubusercontent.com/306380/38139048-c3ff8b74-33fb-11e8-8d44-a01c5b0d8227.png)

cc @shoyer I think you mentioned this