### PR TITLE
Fix `isin` API documentation

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -429,6 +429,7 @@ Other functions
 .. autofunction:: isclose
 .. autofunction:: iscomplex
 .. autofunction:: isfinite
+.. autofunction:: isin
 .. autofunction:: isinf
 .. autofunction:: isnan
 .. autofunction:: isnull


### PR DESCRIPTION
Forgot to add `isin` with `autofunction` as well. This fixes that issue.

xref: https://github.com/dask/dask/pull/3363

cc @shoyer