### PR TITLE
Make 'default' compression for fastparquet be snappy, if available

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -12,6 +12,7 @@ import pandas as pd
 from ..core import DataFrame, Series
 from ..utils import (clear_known_categories, strip_unknown_categories,
                      UNKNOWN_CATEGORIES)
+from ...bytes.compression import compress
 from ...base import tokenize
 from ...compatibility import PY3, string_types
 from ...delayed import delayed
@@ -888,6 +889,8 @@ def to_parquet(df, path, engine='auto', compression='default', write_index=None,
 
     if compression != 'default':
         kwargs['compression'] = compression
+    elif 'snappy' in compress:
+        kwargs['compression'] = 'snappy'
 
     write = get_engine(engine)['write']
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,6 +20,7 @@ DataFrame
 - Added top level `isna` method for Dask DataFrames (:pr:`3294`) `Christopher Ren`_
 - Fix selection on partition column on ``read_parquet`` for ``engine="pyarrow"`` (:pr:`3207`) `Uwe Korn`_
 - Provide more informative error message for meta= errors (:pr:`3343`) `Matthew Rocklin`_
+- Default compression for parquet now always Snappy, in line with pandas (:pr:3373) `Martin Durant`_
 
 Bag
 +++


### PR DESCRIPTION
Fixes #3288

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
