### PR TITLE
Fix memory formatting in kubernetes-helm documentation

### DIFF
--- a/docs/source/setup/kubernetes-helm.rst
+++ b/docs/source/setup/kubernetes-helm.rst
@@ -149,10 +149,10 @@ environments should be matched).
      resources:
        limits:
          cpu: 2
-         memory: 7.5 GiB
+         memory: 7.5G
        requests:
          cpu: 2
-         memory: 7.5 GiB
+         memory: 7.5G
      env:
        - name: EXTRA_CONDA_PACKAGES
          value: numba xarray -c conda-forge


### PR DESCRIPTION
Resolves #3372. This PR makes a small change to how the memory requirements are formatted in `kubernetes-helm.rst`. 

cc @mrocklin @jacobtomlinson