### PR TITLE
Reset requests after using moto

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -81,7 +81,7 @@ pip install --upgrade \
     mmh3 \
     pytest-xdist \
     xxhash
-pip install git+https://github.com/spulec/moto  # includes fix for requests
+pip install --upgrade git+https://github.com/spulec/moto  # includes fix for requests
 
 if [[ ${UPSTREAM_DEV} ]]; then
     echo "Installing PyArrow dev"

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -78,10 +78,10 @@ pip install --upgrade --no-deps \
 pip install --upgrade \
     cityhash \
     flake8 \
-    moto \
     mmh3 \
     pytest-xdist \
     xxhash
+pip install git+https://github.com/spulec/moto  # includes fix for requests
 
 if [[ ${UPSTREAM_DEV} ]]; then
     echo "Installing PyArrow dev"

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -80,8 +80,8 @@ pip install --upgrade \
     flake8 \
     mmh3 \
     pytest-xdist \
-    xxhash
-pip install --upgrade git+https://github.com/spulec/moto  # includes fix for requests
+    xxhash \
+    moto
 
 if [[ ${UPSTREAM_DEV} ]]; then
     echo "Installing PyArrow dev"

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -8,6 +8,7 @@ import pytest
 s3fs = pytest.importorskip('s3fs')
 boto3 = pytest.importorskip('boto3')
 moto = pytest.importorskip('moto')
+httpretty = pytest.importorskip('httpretty')
 
 from toolz import concat, valmap, partial
 
@@ -35,12 +36,16 @@ files = {'test/accounts.1.json':  (b'{"amount": 100, "name": "Alice"}\n'
 def s3():
     # writable local S3 system
     import moto
-    with moto.mock_s3():
-        client = boto3.client('s3')
-        client.create_bucket(Bucket=test_bucket_name, ACL='public-read-write')
-        for f, data in files.items():
-            client.put_object(Bucket=test_bucket_name, Key=f, Body=data)
-        yield s3fs.S3FileSystem(anon=True)
+    try:
+        with moto.mock_s3():
+            client = boto3.client('s3')
+            client.create_bucket(Bucket=test_bucket_name, ACL='public-read-write')
+            for f, data in files.items():
+                client.put_object(Bucket=test_bucket_name, Key=f, Body=data)
+            yield s3fs.S3FileSystem(anon=True)
+    finally:
+        httpretty.HTTPretty.disable()
+        httpretty.HTTPretty.reset()
 
 
 @contextmanager
@@ -59,7 +64,11 @@ def s3_context(bucket, files):
             client.delete_object(Bucket=bucket, Key=f, Body=data)
         except Exception:
             pass
-    m.stop()
+        finally:
+            m.stop()
+            httpretty = pytest.importorskip('httpretty')
+            httpretty.HTTPretty.disable()
+            httpretty.HTTPretty.reset()
 
 
 def test_get_s3():

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -34,6 +34,7 @@ files = {'test/accounts.1.json':  (b'{"amount": 100, "name": "Alice"}\n'
 @pytest.yield_fixture
 def s3():
     # writable local S3 system
+    import moto
     with moto.mock_s3():
         client = boto3.client('s3')
         client.create_bucket(Bucket=test_bucket_name, ACL='public-read-write')

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -17,6 +17,9 @@ columns = ['time', 'date']
 
 @pytest.mark.network
 def test_orc_with_backend():
+    httpretty = pytest.importorskip('httpretty')
+    httpretty.HTTPretty.disable()
+    httpretty.HTTPretty.reset()
     d = read_orc(url)
     assert set(d.columns) == {'time', 'date'}  # order is not guranteed
     assert len(d) == 70000
@@ -25,6 +28,9 @@ def test_orc_with_backend():
 @pytest.fixture(scope='module')
 def orc_files():
     requests = pytest.importorskip('requests')
+    httpretty = pytest.importorskip('httpretty')
+    httpretty.HTTPretty.disable()
+    httpretty.HTTPretty.reset()
     data = requests.get(url).content
     d = tempfile.mkdtemp()
     files = [os.path.join(d, fn) for fn in ['test1.orc', 'test2.orc']]

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -6,7 +6,6 @@ import tempfile
 from dask.dataframe import read_orc
 from dask.dataframe.utils import assert_eq
 import dask.dataframe as dd
-from dask.compatibility import PY2
 
 pytest.importorskip('pyarrow.orc')
 url = ('https://www.googleapis.com/download/storage/v1/b/anaconda-public-data/o'

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -16,9 +16,6 @@ columns = ['time', 'date']
 
 @pytest.mark.network
 def test_orc_with_backend():
-    httpretty = pytest.importorskip('httpretty')
-    httpretty.HTTPretty.disable()
-    httpretty.HTTPretty.reset()
     d = read_orc(url)
     assert set(d.columns) == {'time', 'date'}  # order is not guranteed
     assert len(d) == 70000
@@ -27,9 +24,6 @@ def test_orc_with_backend():
 @pytest.fixture(scope='module')
 def orc_files():
     requests = pytest.importorskip('requests')
-    httpretty = pytest.importorskip('httpretty')
-    httpretty.HTTPretty.disable()
-    httpretty.HTTPretty.reset()
     data = requests.get(url).content
     d = tempfile.mkdtemp()
     files = [os.path.join(d, fn) for fn in ['test1.orc', 'test2.orc']]

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -15,7 +15,6 @@ url = ('https://www.googleapis.com/download/storage/v1/b/anaconda-public-data/o'
 columns = ['time', 'date']
 
 
-@pytest.mark.skipif(PY2, reason='moto and requests confusion')
 @pytest.mark.network
 def test_orc_with_backend():
     d = read_orc(url)
@@ -38,7 +37,6 @@ def orc_files():
         shutil.rmtree(d, ignore_errors=True)
 
 
-@pytest.mark.skipif(PY2, reason='moto and requests confusion')
 def test_orc_single(orc_files):
     fn = orc_files[0]
     d = read_orc(fn)
@@ -51,7 +49,6 @@ def test_orc_single(orc_files):
     assert 'nonexist' in str(e)
 
 
-@pytest.mark.skipif(PY2, reason='moto and requests confusion')
 def test_orc_multiple(orc_files):
     d = read_orc(orc_files[0])
     d2 = read_orc(orc_files)


### PR DESCRIPTION
https://github.com/spulec/moto/pull/1553 fixed the bad interaction between
moto and requests. We now use master downstream of that, which means that
ORC py2 tests can be re-enabled

Fixes https://github.com/dask/dask/issues/3379  (probably)