### PR TITLE
Preserve DataFrame divisions when reading from parquet using pyarrow

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -940,7 +940,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
     fs, fs_token, paths = get_fs_token_paths(path, mode='rb',
                                              storage_options=storage_options)
 
-    if isinstance(path, str) and len(paths) > 1:
+    if isinstance(path, string_types) and len(paths) > 1:
         # Sort paths naturally if multiple paths resulted from a single
         # specification (by '*' globbing)
         paths = sorted(paths, key=natural_sort_key)

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -600,6 +600,13 @@ def _read_pyarrow(fs, fs_token, paths, columns=None, filters=None,
     meta = _meta_from_dtypes(all_columns, dtypes, index_names, column_index_names)
     meta = clear_known_categories(meta, cols=categories)
 
+    # Handle converting divisions to timestamps
+    if divisions[0] is not None and meta.index.dtype.kind == 'M':
+        # Why is this factor of 1000 needed???
+        datetimes = [np.array([d*1000]).astype(meta.index.dtype)[0]
+                     for d in divisions]
+        divisions = [pd.Timestamp(dt) for dt in datetimes]
+
     if out_type == Series:
         assert len(meta.columns) == 1
         meta = meta[meta.columns[0]]

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -5,6 +5,7 @@ import copy
 import json
 import warnings
 import distutils
+from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -353,7 +354,6 @@ def _write_partition_fastparquet(df, fs, path, filename, fmd, compression,
                                  partition_on):
     from fastparquet.writer import partition_on_columns, make_part_file
     import fastparquet
-    from distutils.version import LooseVersion
     # Fastparquet mutates this in a non-threadsafe manner. For now we just copy
     # it before forwarding to fastparquet.
     fmd = copy.copy(fmd)
@@ -517,7 +517,7 @@ def _read_pyarrow(fs, fs_token, paths, columns=None, filters=None,
         storage_name_mapping = {k: k for k in column_names}
         column_index_names = [None]
 
-    if pa.__version__ < distutils.version.LooseVersion('0.8.0'):
+    if pa.__version__ < LooseVersion('0.8.0'):
         # the pyarrow 0.7.0 *reader* expects the storage names for index names
         # that are None.
         if any(x is None for x in index_names):
@@ -651,7 +651,7 @@ def _get_pyarrow_divisions(pa_pieces, divisions_name, pa_schema, infer_divisions
     import pyarrow as pa
     import pyarrow.parquet as pq
 
-    if infer_divisions is True and pa.__version__ < distutils.version.LooseVersion('0.9.0'):
+    if infer_divisions is True and pa.__version__ < LooseVersion('0.9.0'):
         raise NotImplementedError('infer_divisions=True requires pyarrow >=0.9.0')
 
     # Check whether divisions_name is in the schema
@@ -738,7 +738,7 @@ def _read_pyarrow_parquet_piece(fs, piece, columns, index_cols, is_series,
                            use_pandas_metadata=True,
                            file=f)
 
-    if pa.__version__ < distutils.version.LooseVersion('0.9.0'):
+    if pa.__version__ < LooseVersion('0.9.0'):
         df = table.to_pandas()
         for cat in categories:
             df[cat] = df[cat].astype('category')

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -670,6 +670,9 @@ def _get_pyarrow_divisions(pa_pieces, divisions_name, pa_schema, infer_divisions
     import pyarrow as pa
     import pyarrow.parquet as pq
 
+    if infer_divisions is True and pa.__version__ < distutils.version.LooseVersion('0.9.0'):
+        raise NotImplementedError('infer_divisions=True requires pyarrow >=0.9.0')
+
     # Check whether divisions_name is in the schema
     # Note: get_field_index returns -1 if not found, but it does not accept None
     if infer_divisions is True:

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -680,7 +680,7 @@ def _get_pyarrow_divisions(pa_pieces, divisions_name, pa_schema):
 
             # Handle encoding of bytes string
             if index_field.type == pa.string():
-                # Is this always true? Is the string encoding specified in the parquet metadata somewhere?
+                # Parquet strings are always encoded as utf-8
                 encoding = 'utf-8'
                 divisions = [d.decode(encoding).strip() for d in divisions]
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -673,21 +673,18 @@ def _get_pyarrow_divisions(pa_pieces, divisions_name, pa_schema, infer_divisions
 
         # Initialize index of divisions column within the row groups.
         # To be computed during while processing the first piece below
-        divisions_col_index = None
-
         for piece in pa_pieces:
             pf = piece.get_metadata(pq.ParquetFile)
             rg = pf.row_group(0)
 
-            # Compute division column index if needed
-            if divisions_col_index is None:
-                rg_paths = [rg.column(i).path_in_schema for i in range(rg.num_columns)]
-                try:
-                    divisions_col_index = rg_paths.index(divisions_name)
-                except ValueError:
-                    # Divisions not valid
-                    min_maxs = None
-                    break
+            # Compute division column index
+            rg_paths = [rg.column(i).path_in_schema for i in range(rg.num_columns)]
+            try:
+                divisions_col_index = rg_paths.index(divisions_name)
+            except ValueError:
+                # Divisions not valid
+                min_maxs = None
+                break
 
             col_meta = rg.column(divisions_col_index)
             stats = col_meta.statistics

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -5,6 +5,7 @@ import copy
 import json
 import warnings
 import distutils
+import os
 from distutils.version import LooseVersion
 
 import numpy as np
@@ -190,7 +191,7 @@ def _read_fastparquet(fs, fs_token, paths, columns=None, filters=None,
             pf = fastparquet.ParquetFile(paths[0], open_with=fs.open, sep=fs.sep)
 
     # Validate infer_divisions
-    if not pf.fn.endswith('/_metadata') and infer_divisions is True:
+    if os.path.split(pf.fn)[-1] != '_metadata' and infer_divisions is True:
         raise NotImplementedError("infer_divisions=True is not supported by the fastparquet engine for datasets "
                                   "that do not contain a global '_metadata' file")
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -4,7 +4,6 @@ import re
 import copy
 import json
 import warnings
-import distutils
 import os
 from distutils.version import LooseVersion
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -531,9 +531,18 @@ def _read_pyarrow(fs, fs_token, paths, columns=None, filters=None,
 
     # Determine divisions
     if len(index_names) == 1:
-        divisions_name = index_names[0]
+
+        # Look up storage name of the single index column
+        divisions_names = [storage_name for storage_name, name in storage_name_mapping.items()
+                           if index_names[0] == name]
+
+        if divisions_names:
+            divisions_name = divisions_names[0]
+        else:
+            divisions_name = None
     else:
         divisions_name = None
+
     divisions = _get_pyarrow_divisions(non_empty_pieces, divisions_name, schema)
 
     # Build task

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -677,6 +677,13 @@ def _get_pyarrow_divisions(pa_pieces, divisions_name, pa_schema):
                 divisions_ns = [_to_ns(d, time_unit) for d in
                                 divisions]
                 divisions = [pd.Timestamp(ns) for ns in divisions_ns]
+
+            # Handle encoding of bytes string
+            if index_field.type == pa.string():
+                # Is this always true? Is the string encoding specified in the parquet metadata somewhere?
+                encoding = 'utf-8'
+                divisions = [d.decode(encoding).strip() for d in divisions]
+
         else:
             divisions = (None,) * (len(pa_pieces) + 1)
     elif pa_pieces:

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -20,7 +20,7 @@ from ...compatibility import PY3, string_types
 from ...delayed import delayed
 from ...bytes.core import get_fs_token_paths
 from ...bytes.utils import infer_storage_options
-from ...utils import import_required, nat_sort_key
+from ...utils import import_required, natural_sort_key
 from .utils import _get_pyarrow_dtypes, _meta_from_dtypes
 
 __all__ = ('read_parquet', 'to_parquet')
@@ -547,7 +547,7 @@ def _read_pyarrow(fs, fs_token, paths, columns=None, filters=None,
     # the order of the resulting pieces unmodified
     if len(paths) == 1 and len(dataset.pieces) > 1:
         non_empty_pieces = sorted(
-            non_empty_pieces, key=lambda piece: nat_sort_key(piece.path))
+            non_empty_pieces, key=lambda piece: natural_sort_key(piece.path))
 
     # Determine divisions
     if len(index_names) == 1:
@@ -944,7 +944,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
     if isinstance(path, str) and len(paths) > 1:
         # Sort paths naturally if multiple paths resulted from a single
         # specification (by '*' globbing)
-        paths = sorted(paths, key=nat_sort_key)
+        paths = sorted(paths, key=natural_sort_key)
 
     return read(fs, fs_token, paths, columns=columns, filters=filters,
                 categories=categories, index=index, infer_divisions=infer_divisions)

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -614,17 +614,11 @@ def _to_ns(val, unit):
     int
         Time val in nanoseconds
     """
-    if unit == 's':
-        factor = int(1e9)
-    elif unit == 'ms':
-        factor = int(1e6)
-    elif unit == 'us':
-        factor = int(1e3)
-    elif unit == 'ns':
-        factor = 1
-    else:
-        raise ValueError("Unsupported time unit '{unit}'"
-                         .format(unit=unit))
+    factors = {'s': int(1e9), 'ms': int(1e6), 'us': int(1e3), 'ns': 1}
+    try:
+        factor = factors.get(unit)
+    except KeyError:
+        raise ValueError("Unsupported time unit '{unit}'".format(unit=unit))
 
     return val * factor
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -14,7 +14,7 @@ import dask.multiprocessing
 import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq
 from dask.dataframe.io.parquet import _parse_pandas_metadata
-from dask.utils import nat_sort_key
+from dask.utils import natural_sort_key
 
 try:
     import fastparquet
@@ -204,7 +204,7 @@ def test_read_list(tmpdir, write_engine, read_engine):
     files = sorted([os.path.join(tmpdir, f)
                    for f in os.listdir(tmpdir)
                    if not f.endswith('_metadata')],
-                   key=nat_sort_key)
+                   key=natural_sort_key)
 
     # Infer divisions for engines/versions that support it
     ddf2 = dd.read_parquet(files, engine=read_engine,

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -781,7 +781,7 @@ def test_parquet_select_cats(tmpdir):
     xfail_fastparquet_pyarrow="fastparquet gh#251"
 )
 def test_columns_name(tmpdir, write_engine, read_engine):
-    if write_engine == read_engine == 'fastparquet':
+    if write_engine == 'fastparquet':
         pytest.skip('Fastparquet does not write column_indexes')
 
     if write_engine == 'pyarrow':

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -34,7 +34,7 @@ except ImportError:
     check_pa_divs = False
 
 
-def check_divs(engine):
+def should_check_divs(engine):
     if engine == 'fastparquet':
         return True
     elif engine == 'pyarrow' and check_pa_divs:
@@ -141,8 +141,8 @@ def test_index(tmpdir, write_engine, read_engine):
     ddf.to_parquet(fn, engine=write_engine)
 
     # Infer divisions for engines/versions that support it
-    ddf2 = dd.read_parquet(fn, engine=read_engine, infer_divisions=check_divs(read_engine))
-    assert_eq(ddf, ddf2, check_divisions=check_divs(read_engine))
+    ddf2 = dd.read_parquet(fn, engine=read_engine, infer_divisions=should_check_divs(read_engine))
+    assert_eq(ddf, ddf2, check_divisions=should_check_divs(read_engine))
 
     # infer_divisions False
     ddf2_no_divs = dd.read_parquet(fn, engine=read_engine, infer_divisions=False)
@@ -188,8 +188,8 @@ def test_read_glob(tmpdir, write_engine, read_engine):
     # Infer divisions for engines/versions that support it
 
     ddf2 = dd.read_parquet(os.path.join(fn, '*'), engine=read_engine,
-                           infer_divisions=check_divs(write_engine) and check_divs(read_engine))
-    assert_eq(ddf, ddf2, check_divisions=check_divs(write_engine) and check_divs(read_engine))
+                           infer_divisions=should_check_divs(write_engine) and should_check_divs(read_engine))
+    assert_eq(ddf, ddf2, check_divisions=should_check_divs(write_engine) and should_check_divs(read_engine))
 
     # No divisions
     ddf2_no_divs = dd.read_parquet(os.path.join(fn, '*'), engine=read_engine, infer_divisions=False)
@@ -207,8 +207,8 @@ def test_read_list(tmpdir, write_engine, read_engine):
 
     # Infer divisions for engines/versions that support it
     ddf2 = dd.read_parquet(files, engine=read_engine,
-                           infer_divisions=check_divs(write_engine) and check_divs(read_engine))
-    assert_eq(ddf, ddf2, check_divisions=check_divs(write_engine) and check_divs(read_engine))
+                           infer_divisions=should_check_divs(write_engine) and should_check_divs(read_engine))
+    assert_eq(ddf, ddf2, check_divisions=should_check_divs(write_engine) and should_check_divs(read_engine))
 
     # No divisions
     ddf2_no_divs = dd.read_parquet(files, engine=read_engine, infer_divisions=False)
@@ -224,8 +224,8 @@ def test_columns_index(tmpdir, write_engine, read_engine):
     # ----------
     # ### Emtpy columns ###
     # With divisions if supported
-    assert_eq(dd.read_parquet(fn, columns=[], engine=read_engine, infer_divisions=check_divs(read_engine)),
-              ddf[[]], check_divisions=check_divs(read_engine))
+    assert_eq(dd.read_parquet(fn, columns=[], engine=read_engine, infer_divisions=should_check_divs(read_engine)),
+              ddf[[]], check_divisions=should_check_divs(read_engine))
 
     # No divisions
     assert_eq(dd.read_parquet(fn, columns=[], engine=read_engine, infer_divisions=False),
@@ -233,8 +233,8 @@ def test_columns_index(tmpdir, write_engine, read_engine):
 
     # ### Single column, auto select index ###
     # With divisions if supported
-    assert_eq(dd.read_parquet(fn, columns=['x'], engine=read_engine, infer_divisions=check_divs(read_engine)),
-              ddf[['x']], check_divisions=check_divs(read_engine))
+    assert_eq(dd.read_parquet(fn, columns=['x'], engine=read_engine, infer_divisions=should_check_divs(read_engine)),
+              ddf[['x']], check_divisions=should_check_divs(read_engine))
 
     # No divisions
     assert_eq(dd.read_parquet(fn, columns=['x'], engine=read_engine, infer_divisions=False),
@@ -243,8 +243,8 @@ def test_columns_index(tmpdir, write_engine, read_engine):
     # ### Single column, specify index ###
     # With divisions if supported
     assert_eq(dd.read_parquet(fn, index='myindex', columns=['x'], engine=read_engine,
-                              infer_divisions=check_divs(read_engine)),
-              ddf[['x']], check_divisions=check_divs(read_engine))
+                              infer_divisions=should_check_divs(read_engine)),
+              ddf[['x']], check_divisions=should_check_divs(read_engine))
 
     # No divisions
     assert_eq(dd.read_parquet(fn, index='myindex', columns=['x'], engine=read_engine,
@@ -254,8 +254,8 @@ def test_columns_index(tmpdir, write_engine, read_engine):
     # ### Two columns, specify index ###
     # With divisions if supported
     assert_eq(dd.read_parquet(fn, index='myindex', columns=['x', 'y'], engine=read_engine,
-                              infer_divisions=check_divs(read_engine)),
-              ddf, check_divisions=check_divs(read_engine))
+                              infer_divisions=should_check_divs(read_engine)),
+              ddf, check_divisions=should_check_divs(read_engine))
 
     # No divisions
     assert_eq(dd.read_parquet(fn, index='myindex', columns=['x', 'y'], engine=read_engine,
@@ -395,11 +395,11 @@ def test_no_index(tmpdir, write_engine, read_engine):
 def test_read_series(tmpdir, engine):
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=engine)
-    ddf2 = dd.read_parquet(fn, columns=['x'], engine=engine, infer_divisions=check_divs(engine))
-    assert_eq(ddf[['x']], ddf2, check_divisions=check_divs(engine))
+    ddf2 = dd.read_parquet(fn, columns=['x'], engine=engine, infer_divisions=should_check_divs(engine))
+    assert_eq(ddf[['x']], ddf2, check_divisions=should_check_divs(engine))
 
-    ddf2 = dd.read_parquet(fn, columns='x', index='myindex', engine=engine, infer_divisions=check_divs(engine))
-    assert_eq(ddf.x, ddf2, check_divisions=check_divs(engine))
+    ddf2 = dd.read_parquet(fn, columns='x', index='myindex', engine=engine, infer_divisions=should_check_divs(engine))
+    assert_eq(ddf.x, ddf2, check_divisions=should_check_divs(engine))
 
 
 def test_names(tmpdir, engine):
@@ -661,16 +661,16 @@ def test_read_parquet_custom_columns(tmpdir, engine):
     df2 = dd.read_parquet(tmp,
                           columns=['i32', 'f'],
                           engine=engine,
-                          infer_divisions=check_divs(engine))
+                          infer_divisions=should_check_divs(engine))
     assert_eq(df[['i32', 'f']], df2,
-              check_index=False, check_divisions=check_divs(engine))
+              check_index=False, check_divisions=should_check_divs(engine))
 
     df3 = dd.read_parquet(tmp,
                           columns=['f', 'i32'],
                           engine=engine,
-                          infer_divisions=check_divs(engine))
+                          infer_divisions=should_check_divs(engine))
     assert_eq(df[['f', 'i32']], df3,
-              check_index=False, check_divisions=check_divs(engine))
+              check_index=False, check_divisions=should_check_divs(engine))
 
 
 @pytest.mark.parametrize('df,write_kwargs,read_kwargs', [
@@ -756,8 +756,8 @@ def test_timestamp_index(tmpdir, engine):
     df.index.name = 'foo'
     ddf = dd.from_pandas(df, npartitions=5)
     ddf.to_parquet(fn, engine=engine)
-    ddf2 = dd.read_parquet(fn, engine=engine, infer_divisions=check_divs(engine))
-    assert_eq(ddf, ddf2, check_divisions=check_divs(engine))
+    ddf2 = dd.read_parquet(fn, engine=engine, infer_divisions=should_check_divs(engine))
+    assert_eq(ddf, ddf2, check_divisions=should_check_divs(engine))
 
 
 def test_to_parquet_default_writes_nulls(tmpdir):
@@ -832,9 +832,9 @@ def test_to_parquet_lazy(tmpdir, get, engine):
     value.compute(get=get)
     assert os.path.exists(tmpdir)
 
-    ddf2 = dd.read_parquet(tmpdir, engine=engine, infer_divisions=check_divs(engine))
+    ddf2 = dd.read_parquet(tmpdir, engine=engine, infer_divisions=should_check_divs(engine))
 
-    assert_eq(ddf, ddf2, check_divisions=check_divs(engine))
+    assert_eq(ddf, ddf2, check_divisions=should_check_divs(engine))
 
 
 def test_timestamp96(tmpdir):
@@ -934,8 +934,8 @@ def test_writing_parquet_with_compression(tmpdir, compression, engine):
         pf = fastparquet.ParquetFile(fn)
         assert pf.row_groups[0].columns[0].meta_data.codec == 1
 
-    out = dd.read_parquet(fn, engine=engine, infer_divisions=check_divs(engine))
-    assert_eq(out, ddf, check_index=(engine != 'fastparquet'), check_divisions=check_divs(engine))
+    out = dd.read_parquet(fn, engine=engine, infer_divisions=should_check_divs(engine))
+    assert_eq(out, ddf, check_index=(engine != 'fastparquet'), check_divisions=should_check_divs(engine))
 
 
 @pytest.fixture(params=[
@@ -1181,8 +1181,8 @@ def test_writing_parquet_with_kwargs(tmpdir, engine):
     }
 
     ddf.to_parquet(path1,  engine=engine, **engine_kwargs[engine])
-    out = dd.read_parquet(path1, engine=engine, infer_divisions=check_divs(engine))
-    assert_eq(out, ddf, check_index=(engine != 'fastparquet'), check_divisions=check_divs(engine))
+    out = dd.read_parquet(path1, engine=engine, infer_divisions=should_check_divs(engine))
+    assert_eq(out, ddf, check_index=(engine != 'fastparquet'), check_divisions=should_check_divs(engine))
 
     # Avoid race condition in pyarrow 0.8.0 on writing partitioned datasets
     with dask.set_options(get=dask.get):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -822,9 +822,6 @@ def test_filters(tmpdir):
 
 @pytest.mark.parametrize('get', [dask.threaded.get, dask.multiprocessing.get])
 def test_to_parquet_lazy(tmpdir, get, engine):
-    check_fastparquet()
-    check_pyarrow()
-
     tmpdir = str(tmpdir)
     df = pd.DataFrame({'a': [1, 2, 3, 4],
                        'b': [1., 2., 3., 4.]})

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -24,7 +24,6 @@ except ImportError:
 try:
     import pyarrow.parquet as pq
 except ImportError:
-    check_pa_divs = False
     pq = False
 
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -44,10 +44,10 @@ def should_check_divs(engine):
 
 nrows = 40
 npartitions = 15
-df = pd.DataFrame({'x': [i*7 % 5 for i in range(nrows)],  # Not sorted
-                   'y': [i*2.5 for i in range(nrows)]  # Sorted
+df = pd.DataFrame({'x': [i * 7 % 5 for i in range(nrows)],  # Not sorted
+                   'y': [i * 2.5 for i in range(nrows)]  # Sorted
                    },
-                  index=pd.Index([10*i for i in range(nrows)], name='myindex'))
+                  index=pd.Index([10 * i for i in range(nrows)], name='myindex'))
 
 ddf = dd.from_pandas(df, npartitions=npartitions)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -157,6 +157,7 @@ def test_index(tmpdir, write_engine, read_engine):
         # the dataset, which could be expensive
         assert_eq(ddf.clear_divisions(), ddf2_default, check_divisions=True)
 
+
 @pytest.mark.parametrize('index', [False, True])
 @write_read_engines_xfail
 def test_empty(tmpdir, write_engine, read_engine, index):

--- a/dask/dataframe/io/utils.py
+++ b/dask/dataframe/io/utils.py
@@ -1,12 +1,28 @@
 import pandas as pd
+import json
 
 
 def _get_pyarrow_dtypes(schema, categories):
     """Convert a pyarrow.Schema object to pandas dtype dict"""
+
+    # Check for pandas metadata
+    has_pandas_metadata = schema.metadata is not None and b'pandas' in schema.metadata
+    if has_pandas_metadata:
+        pandas_metadata = json.loads(schema.metadata[b'pandas'].decode('utf8'))
+        pandas_metadata_dtypes = {c['name']: c['numpy_type'] for c in pandas_metadata.get('columns', [])}
+    else:
+        pandas_metadata_dtypes = {}
+
     dtypes = {}
     for i in range(len(schema)):
         field = schema[i]
-        numpy_dtype = field.type.to_pandas_dtype()
+
+        # Get numpy_dtype from pandas metadata if available
+        if field.name in pandas_metadata_dtypes:
+            numpy_dtype = pandas_metadata_dtypes[field.name]
+        else:
+            numpy_dtype = field.type.to_pandas_dtype()
+
         dtypes[field.name] = numpy_dtype
 
     if categories:

--- a/dask/dataframe/io/utils.py
+++ b/dask/dataframe/io/utils.py
@@ -9,7 +9,8 @@ def _get_pyarrow_dtypes(schema, categories):
     has_pandas_metadata = schema.metadata is not None and b'pandas' in schema.metadata
     if has_pandas_metadata:
         pandas_metadata = json.loads(schema.metadata[b'pandas'].decode('utf8'))
-        pandas_metadata_dtypes = {c['name']: c['numpy_type'] for c in pandas_metadata.get('columns', [])}
+        pandas_metadata_dtypes = {c.get('field_name', c.get('name', None)): c['numpy_type']
+                                  for c in pandas_metadata.get('columns', [])}
     else:
         pandas_metadata_dtypes = {}
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import sys
 import tempfile
+import re
 from errno import ENOENT
 from collections import Iterator
 from contextlib import contextmanager
@@ -896,3 +897,31 @@ def is_arraylike(x):
     return (hasattr(x, '__array__') and
             hasattr(x, 'shape') and x.shape and
             hasattr(x, 'dtype'))
+
+
+def nat_sort_key(s):
+    """
+    Sorting `key` function for performing a natural sort on a collection of
+    strings
+
+    Parameters
+    ----------
+    s : str
+        A string that is an element of the collection being sorted
+
+    Returns
+    -------
+    tuple[str or int]
+        Tuple of the parts of the input string where each part is either a
+        string or an integer
+
+    Examples
+    --------
+    >>> a = ['f0', 'f1', 'f2', 'f8', 'f9', 'f10', 'f11', 'f19', 'f20', 'f21']
+    >>> sorted(a)
+        ['f0', 'f1', 'f10', 'f11', 'f19', 'f2', 'f20', 'f21', 'f8', 'f9']
+    >>> sorted(a, key=nat_sort_key)
+        ['f0', 'f1', 'f2', 'f8', 'f9', 'f10', 'f11', 'f19', 'f20', 'f21']
+    """
+    return [int(part) if part.isdigit() else part
+            for part in re.split('(\d+)', s)]

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -921,9 +921,9 @@ def natural_sort_key(s):
     --------
     >>> a = ['f0', 'f1', 'f2', 'f8', 'f9', 'f10', 'f11', 'f19', 'f20', 'f21']
     >>> sorted(a)
-        ['f0', 'f1', 'f10', 'f11', 'f19', 'f2', 'f20', 'f21', 'f8', 'f9']
+    ['f0', 'f1', 'f10', 'f11', 'f19', 'f2', 'f20', 'f21', 'f8', 'f9']
     >>> sorted(a, key=natural_sort_key)
-        ['f0', 'f1', 'f2', 'f8', 'f9', 'f10', 'f11', 'f19', 'f20', 'f21']
+    ['f0', 'f1', 'f2', 'f8', 'f9', 'f10', 'f11', 'f19', 'f20', 'f21']
     """
     return [int(part) if part.isdigit() else part
             for part in re.split('(\d+)', s)]

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -899,10 +899,12 @@ def is_arraylike(x):
             hasattr(x, 'dtype'))
 
 
-def nat_sort_key(s):
+def natural_sort_key(s):
     """
     Sorting `key` function for performing a natural sort on a collection of
     strings
+    
+    See https://en.wikipedia.org/wiki/Natural_sort_order
 
     Parameters
     ----------
@@ -920,7 +922,7 @@ def nat_sort_key(s):
     >>> a = ['f0', 'f1', 'f2', 'f8', 'f9', 'f10', 'f11', 'f19', 'f20', 'f21']
     >>> sorted(a)
         ['f0', 'f1', 'f10', 'f11', 'f19', 'f2', 'f20', 'f21', 'f8', 'f9']
-    >>> sorted(a, key=nat_sort_key)
+    >>> sorted(a, key=natural_sort_key)
         ['f0', 'f1', 'f2', 'f8', 'f9', 'f10', 'f11', 'f19', 'f20', 'f21']
     """
     return [int(part) if part.isdigit() else part

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -903,7 +903,7 @@ def natural_sort_key(s):
     """
     Sorting `key` function for performing a natural sort on a collection of
     strings
-    
+
     See https://en.wikipedia.org/wiki/Natural_sort_order
 
     Parameters

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,6 +19,8 @@ DataFrame
 - Allow `t` as shorthand for `table` in `to_hdf` for pandas compatibility `Jörg Dietrich`_
 - Added top level `isna` method for Dask DataFrames (:pr:`3294`) `Christopher Ren`_
 - Fix selection on partition column on ``read_parquet`` for ``engine="pyarrow"`` (:pr:`3207`) `Uwe Korn`_
+- Added `infer_divisions` option to ``read_parquet`` to specify whether read engines should compute divisions (:pr:`3387`) `Jon Mease`_
+- Added support for inferring division for ``engine="pyarrow"`` (:pr:`3387`) `Jon Mease`_
 - Provide more informative error message for meta= errors (:pr:`3343`) `Matthew Rocklin`_
 - add orc reader (:pr:3284) `Martin Durant`_
 - Default compression for parquet now always Snappy, in line with pandas (:pr:3373) `Martin Durant`_


### PR DESCRIPTION
Implementation of #3383.

I updated a bunch of tests in `test_parquet.py` to check the `read_parquet` dask DataFrame against the expected dask DataFrame, rather than the expected pandas DataFrame. I only `check_divisions` when the reader is `fastparquet` or `pyarrow >= '0.9.0'`.  This has the added benefit of checking the `read_parquet` divisions logic for the fastparquet path, which I don't think was really verified previously.

I added a bit of logic to `_read_pyarrow` to use pyarrow's column metadata stats to compute the min/max of each row group and the use these pairs to build the divisions. It's rough, but it works in many cases.

I ran into a handful of tangentially related issues during a couple of hours of working through the failing tests.  I'm not sure if I'll be able to see this through the the finish, but I wanted to at least share my progress.

@jcrist Is this division calculation logic the kind of approach you had in mind in #3383?
@mrocklin Does this division calculation logic give you pause performance-wise?

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Changelog
