### PR TITLE
first/last aggregations for DataFrame-/SeriesGroupBy

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -486,6 +486,8 @@ def _build_agg_args_single(result_column, func, input_column):
         'max': (M.max, M.max),
         'count': (M.count, M.sum),
         'size': (M.size, M.sum),
+        'first': (M.first, M.first),
+        'last': (M.last, M.last)
     }
 
     if func in simple_impl.keys():
@@ -948,6 +950,16 @@ class _GroupBy(object):
         v = self.var(ddof, split_every=split_every, split_out=split_out)
         result = map_partitions(np.sqrt, v, meta=v)
         return result
+
+    @derived_from(pd.core.groupby.GroupBy)
+    def first(self, split_every=None, split_out=1):
+        return self._aca_agg(token='first', func=M.first, split_every=split_every,
+                             split_out=split_out)
+
+    @derived_from(pd.core.groupby.GroupBy)
+    def last(self, split_every=None, split_out=1):
+        return self._aca_agg(token='last', func=M.last, split_every=split_every,
+                             split_out=split_out)
 
     @derived_from(pd.core.groupby.GroupBy)
     def get_group(self, key):

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -228,13 +228,13 @@ def test_groupby_on_index(get):
 
 
 @pytest.mark.parametrize('grouper',
-                         [lambda ddf, df: (ddf.groupby('a')['b'], df.groupby('a')['b']),
-                          lambda ddf, df: (ddf.groupby(['a', 'b']), df.groupby(['a', 'b'])),
-                          lambda ddf, df: (ddf.groupby(['a', 'b'])['c'], df.groupby(['a', 'b'])['c']),
-                          lambda ddf, df: (ddf.groupby(ddf['a'])[['b', 'c']], df.groupby(df['a'])[['b', 'c']]),
-                          lambda ddf, df: (ddf.groupby('a')[['b', 'c']], df.groupby('a')[['b', 'c']]),
-                          lambda ddf, df: (ddf.groupby('a')[['b']], df.groupby('a')[['b']]),
-                          lambda ddf, df: (ddf.groupby(['a', 'b', 'c']), df.groupby(['a', 'b', 'c']))])
+                         [lambda df: df.groupby('a')['b'],
+                          lambda df: df.groupby(['a', 'b']),
+                          lambda df: df.groupby(['a', 'b'])['c'],
+                          lambda df: df.groupby(df['a'])[['b', 'c']],
+                          lambda df: df.groupby('a')[['b', 'c']],
+                          lambda df: df.groupby('a')[['b']],
+                          lambda df: df.groupby(['a', 'b', 'c'])])
 def test_groupby_multilevel_getitem(grouper, agg_func):
     # nunique is not implemented for DataFrameGroupBy
     if agg_func == 'nunique':
@@ -246,7 +246,8 @@ def test_groupby_multilevel_getitem(grouper, agg_func):
                        'd': [1, 2, 1, 1, 2, 2]})
     ddf = dd.from_pandas(df, 2)
 
-    dask_group, pandas_group = grouper(ddf, df)
+    dask_group = grouper(ddf)
+    pandas_group = grouper(df)
 
     dask_agg = getattr(dask_group, agg_func)
     pandas_agg = getattr(pandas_group, agg_func)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -11,6 +11,17 @@ import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq, assert_dask_graph, assert_max_deps, PANDAS_VERSION
 
 
+AGG_FUNCS = ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'nunique', 'first', 'last']
+
+
+@pytest.fixture(params=AGG_FUNCS)
+def agg_func(request):
+    """
+    Aggregations supported for groups
+    """
+    return request.param
+
+
 def groupby_internal_repr():
     pdf = pd.DataFrame({'x': [1, 2, 3, 4, 6, 7, 8, 9, 10],
                         'y': list('abcbabbcda')})
@@ -216,29 +227,37 @@ def test_groupby_on_index(get):
                       ddf2.groupby(ddf2.index).apply(func2))
 
 
-def test_groupby_multilevel_getitem():
+@pytest.mark.parametrize('grouper',
+                         [lambda ddf, df: (ddf.groupby('a')['b'], df.groupby('a')['b']),
+                          lambda ddf, df: (ddf.groupby(['a', 'b']), df.groupby(['a', 'b'])),
+                          lambda ddf, df: (ddf.groupby(['a', 'b'])['c'], df.groupby(['a', 'b'])['c']),
+                          lambda ddf, df: (ddf.groupby(ddf['a'])[['b', 'c']], df.groupby(df['a'])[['b', 'c']]),
+                          lambda ddf, df: (ddf.groupby('a')[['b', 'c']], df.groupby('a')[['b', 'c']]),
+                          lambda ddf, df: (ddf.groupby('a')[['b']], df.groupby('a')[['b']]),
+                          lambda ddf, df: (ddf.groupby(['a', 'b', 'c']), df.groupby(['a', 'b', 'c']))])
+def test_groupby_multilevel_getitem(grouper, agg_func):
+    # nunique is not implemented for DataFrameGroupBy
+    if agg_func == 'nunique':
+        return
+
     df = pd.DataFrame({'a': [1, 2, 3, 1, 2, 3],
                        'b': [1, 2, 1, 4, 2, 1],
                        'c': [1, 3, 2, 1, 1, 2],
                        'd': [1, 2, 1, 1, 2, 2]})
     ddf = dd.from_pandas(df, 2)
 
-    cases = [(ddf.groupby('a')['b'], df.groupby('a')['b']),
-             (ddf.groupby(['a', 'b']), df.groupby(['a', 'b'])),
-             (ddf.groupby(['a', 'b'])['c'], df.groupby(['a', 'b'])['c']),
-             (ddf.groupby(ddf['a'])[['b', 'c']], df.groupby(df['a'])[['b', 'c']]),
-             (ddf.groupby('a')[['b', 'c']], df.groupby('a')[['b', 'c']]),
-             (ddf.groupby('a')[['b']], df.groupby('a')[['b']]),
-             (ddf.groupby(['a', 'b', 'c']), df.groupby(['a', 'b', 'c']))]
+    dask_group, pandas_group = grouper(ddf, df)
 
-    for d, p in cases:
-        assert isinstance(d, dd.groupby._GroupBy)
-        assert isinstance(p, pd.core.groupby.GroupBy)
-        assert_eq(d.sum(), p.sum())
-        assert_eq(d.min(), p.min())
-        assert_eq(d.max(), p.max())
-        assert_eq(d.count(), p.count())
-        assert_eq(d.mean(), p.mean().astype(float))
+    dask_agg = getattr(dask_group, agg_func)
+    pandas_agg = getattr(pandas_group, agg_func)
+
+    assert isinstance(dask_group, dd.groupby._GroupBy)
+    assert isinstance(pandas_group, pd.core.groupby.GroupBy)
+
+    if agg_func == 'mean':
+        assert_eq(dask_agg(), pandas_agg().astype(float))
+    else:
+        assert_eq(dask_agg(), pandas_agg())
 
 
 def test_groupby_multilevel_agg():
@@ -328,6 +347,8 @@ def test_series_groupby():
         assert_eq(dg.min(), pdg.min())
         assert_eq(dg.max(), pdg.max())
         assert_eq(dg.size(), pdg.size())
+        assert_eq(dg.first(), pdg.first())
+        assert_eq(dg.last(), pdg.last())
 
 
 def test_series_groupby_errors():
@@ -385,6 +406,8 @@ def test_split_apply_combine_on_series():
         assert_eq(ddf.groupby(ddkey).a.mean(), pdf.groupby(pdkey).a.mean())
         assert_eq(ddf.groupby(ddkey).a.nunique(), pdf.groupby(pdkey).a.nunique())
         assert_eq(ddf.groupby(ddkey).a.size(), pdf.groupby(pdkey).a.size())
+        assert_eq(ddf.groupby(ddkey).a.first(), pdf.groupby(pdkey).a.first())
+        assert_eq(ddf.groupby(ddkey).a.last(), pdf.groupby(pdkey).a.last())
         for ddof in [0, 1, 2]:
             assert_eq(ddf.groupby(ddkey).a.var(ddof),
                       pdf.groupby(pdkey).a.var(ddof))
@@ -397,6 +420,9 @@ def test_split_apply_combine_on_series():
         assert_eq(ddf.groupby(ddkey).count(), pdf.groupby(pdkey).count())
         assert_eq(ddf.groupby(ddkey).mean(), pdf.groupby(pdkey).mean())
         assert_eq(ddf.groupby(ddkey).size(), pdf.groupby(pdkey).size())
+        assert_eq(ddf.groupby(ddkey).first(), pdf.groupby(pdkey).first())
+        assert_eq(ddf.groupby(ddkey).last(), pdf.groupby(pdkey).last())
+
         for ddof in [0, 1, 2]:
             assert_eq(ddf.groupby(ddkey).var(ddof),
                       pdf.groupby(pdkey).var(ddof), check_dtype=False)
@@ -409,6 +435,9 @@ def test_split_apply_combine_on_series():
         assert_eq(ddf.a.groupby(ddkey).count(), pdf.a.groupby(pdkey).count(), check_names=False)
         assert_eq(ddf.a.groupby(ddkey).mean(), pdf.a.groupby(pdkey).mean(), check_names=False)
         assert_eq(ddf.a.groupby(ddkey).nunique(), pdf.a.groupby(pdkey).nunique(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).first(), pdf.a.groupby(pdkey).first(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).last(), pdf.a.groupby(pdkey).last(), check_names=False)
+
         for ddof in [0, 1, 2]:
             assert_eq(ddf.a.groupby(ddkey).var(ddof),
                       pdf.a.groupby(pdkey).var(ddof))
@@ -423,6 +452,8 @@ def test_split_apply_combine_on_series():
         assert_eq(ddf.groupby(ddf.b > i).a.mean(), pdf.groupby(pdf.b > i).a.mean())
         assert_eq(ddf.groupby(ddf.b > i).a.nunique(), pdf.groupby(pdf.b > i).a.nunique())
         assert_eq(ddf.groupby(ddf.b > i).a.size(), pdf.groupby(pdf.b > i).a.size())
+        assert_eq(ddf.groupby(ddf.b > i).a.first(), pdf.groupby(pdf.b > i).a.first())
+        assert_eq(ddf.groupby(ddf.b > i).a.last(), pdf.groupby(pdf.b > i).a.last())
 
         assert_eq(ddf.groupby(ddf.a > i).b.sum(), pdf.groupby(pdf.a > i).b.sum())
         assert_eq(ddf.groupby(ddf.a > i).b.min(), pdf.groupby(pdf.a > i).b.min())
@@ -431,6 +462,8 @@ def test_split_apply_combine_on_series():
         assert_eq(ddf.groupby(ddf.a > i).b.mean(), pdf.groupby(pdf.a > i).b.mean())
         assert_eq(ddf.groupby(ddf.a > i).b.nunique(), pdf.groupby(pdf.a > i).b.nunique())
         assert_eq(ddf.groupby(ddf.b > i).b.size(), pdf.groupby(pdf.b > i).b.size())
+        assert_eq(ddf.groupby(ddf.b > i).b.first(), pdf.groupby(pdf.b > i).b.first())
+        assert_eq(ddf.groupby(ddf.b > i).b.last(), pdf.groupby(pdf.b > i).b.last())
 
         assert_eq(ddf.groupby(ddf.b > i).sum(), pdf.groupby(pdf.b > i).sum())
         assert_eq(ddf.groupby(ddf.b > i).min(), pdf.groupby(pdf.b > i).min())
@@ -438,6 +471,8 @@ def test_split_apply_combine_on_series():
         assert_eq(ddf.groupby(ddf.b > i).count(), pdf.groupby(pdf.b > i).count())
         assert_eq(ddf.groupby(ddf.b > i).mean(), pdf.groupby(pdf.b > i).mean())
         assert_eq(ddf.groupby(ddf.b > i).size(), pdf.groupby(pdf.b > i).size())
+        assert_eq(ddf.groupby(ddf.b > i).first(), pdf.groupby(pdf.b > i).first())
+        assert_eq(ddf.groupby(ddf.b > i).last(), pdf.groupby(pdf.b > i).last())
 
         assert_eq(ddf.groupby(ddf.a > i).sum(), pdf.groupby(pdf.a > i).sum())
         assert_eq(ddf.groupby(ddf.a > i).min(), pdf.groupby(pdf.a > i).min())
@@ -445,6 +480,8 @@ def test_split_apply_combine_on_series():
         assert_eq(ddf.groupby(ddf.a > i).count(), pdf.groupby(pdf.a > i).count())
         assert_eq(ddf.groupby(ddf.a > i).mean(), pdf.groupby(pdf.a > i).mean())
         assert_eq(ddf.groupby(ddf.a > i).size(), pdf.groupby(pdf.a > i).size())
+        assert_eq(ddf.groupby(ddf.a > i).first(), pdf.groupby(pdf.a > i).first())
+        assert_eq(ddf.groupby(ddf.a > i).last(), pdf.groupby(pdf.a > i).last())
 
         for ddof in [0, 1, 2]:
             assert_eq(ddf.groupby(ddf.b > i).std(ddof),
@@ -459,6 +496,8 @@ def test_split_apply_combine_on_series():
         assert_eq(ddf.groupby(ddkey).b.mean(), pdf.groupby(pdkey).b.mean())
         assert_eq(ddf.groupby(ddkey).b.nunique(), pdf.groupby(pdkey).b.nunique())
         assert_eq(ddf.groupby(ddkey).b.size(), pdf.groupby(pdkey).b.size())
+        assert_eq(ddf.groupby(ddkey).b.first(), pdf.groupby(pdkey).b.first())
+        assert_eq(ddf.groupby(ddkey).last(), pdf.groupby(pdkey).last())
 
         assert_eq(ddf.groupby(ddkey).sum(), pdf.groupby(pdkey).sum())
         assert_eq(ddf.groupby(ddkey).min(), pdf.groupby(pdkey).min())
@@ -466,6 +505,8 @@ def test_split_apply_combine_on_series():
         assert_eq(ddf.groupby(ddkey).count(), pdf.groupby(pdkey).count())
         assert_eq(ddf.groupby(ddkey).mean(), pdf.groupby(pdkey).mean().astype(float))
         assert_eq(ddf.groupby(ddkey).size(), pdf.groupby(pdkey).size())
+        assert_eq(ddf.groupby(ddkey).first(), pdf.groupby(pdkey).first())
+        assert_eq(ddf.groupby(ddkey).last(), pdf.groupby(pdkey).last())
 
         for ddof in [0, 1, 2]:
             assert_eq(ddf.groupby(ddkey).b.std(ddof),
@@ -489,6 +530,8 @@ def test_split_apply_combine_on_series():
     assert_dask_graph(ddf.groupby('b').a.max(), 'series-groupby-max')
     assert_dask_graph(ddf.groupby('b').a.count(), 'series-groupby-count')
     assert_dask_graph(ddf.groupby('b').a.var(), 'series-groupby-var')
+    assert_dask_graph(ddf.groupby('b').a.first(), 'series-groupby-first')
+    assert_dask_graph(ddf.groupby('b').a.last(), 'series-groupby-last')
     # mean consists from sum and count operations
     assert_dask_graph(ddf.groupby('b').a.mean(), 'series-groupby-sum')
     assert_dask_graph(ddf.groupby('b').a.mean(), 'series-groupby-count')
@@ -499,6 +542,8 @@ def test_split_apply_combine_on_series():
     assert_dask_graph(ddf.groupby('b').min(), 'dataframe-groupby-min')
     assert_dask_graph(ddf.groupby('b').max(), 'dataframe-groupby-max')
     assert_dask_graph(ddf.groupby('b').count(), 'dataframe-groupby-count')
+    assert_dask_graph(ddf.groupby('b').first(), 'dataframe-groupby-first')
+    assert_dask_graph(ddf.groupby('b').last(), 'dataframe-groupby-last')
     # mean consists from sum and count operations
     assert_dask_graph(ddf.groupby('b').mean(), 'dataframe-groupby-sum')
     assert_dask_graph(ddf.groupby('b').mean(), 'dataframe-groupby-count')
@@ -515,7 +560,10 @@ def test_groupby_reduction_split(keyword):
         return getattr(g, m)(**kwargs)
 
     # DataFrame
-    for m in ['sum', 'min', 'max', 'count', 'mean', 'size', 'var', 'std']:
+    for m in AGG_FUNCS:
+        # nunique is not implemented for DataFrameGroupBy
+        if m == 'nunique':
+            continue
         res = call(ddf.groupby('b'), m, **{keyword: 2})
         sol = call(pdf.groupby('b'), m)
         assert_eq(res, sol)
@@ -527,8 +575,7 @@ def test_groupby_reduction_split(keyword):
     assert call(ddf.groupby('b'), 'var', ddof=2)._name != res._name
 
     # Series, post select
-    for m in ['sum', 'min', 'max', 'count', 'mean', 'nunique', 'size',
-              'var', 'std']:
+    for m in AGG_FUNCS:
         res = call(ddf.groupby('b').a, m, **{keyword: 2})
         sol = call(pdf.groupby('b').a, m)
         assert_eq(res, sol)
@@ -540,8 +587,7 @@ def test_groupby_reduction_split(keyword):
     assert call(ddf.groupby('b').a, 'var', ddof=2)._name != res._name
 
     # Series, pre select
-    for m in ['sum', 'min', 'max', 'count', 'mean', 'nunique', 'size',
-              'var', 'std']:
+    for m in AGG_FUNCS:
         res = call(ddf.a.groupby(ddf.b), m, **{keyword: 2})
         sol = call(pdf.a.groupby(pdf.b), m)
         # There's a bug in pandas 0.18.0 with `pdf.a.groupby(pdf.b).count()`
@@ -687,8 +733,10 @@ def test_groupby_normalize_index():
     {'b': {'c': 'mean'}, 'c': {'a': 'max', 'b': 'min'}},
     {'b': 'mean', 'c': ['min', 'max']},
     {'b': np.sum, 'c': ['min', np.max, np.std, np.var]},
-    ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var'],
+    ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'first', 'last'],
     'var',
+    {'b':'mean', 'c': 'first', 'd': 'last', 'a': ['first', 'last']},
+    {'b': {'c': 'mean'}, 'c':{'a': 'first', 'b': 'last'}},
 ])
 @pytest.mark.parametrize('split_every', [False, None])
 @pytest.mark.parametrize('grouper', [
@@ -717,7 +765,7 @@ def test_aggregate__examples(spec, split_every, grouper):
 @pytest.mark.parametrize('spec', [
     {'b': 'sum', 'c': 'min', 'd': 'max'},
     ['sum'],
-    ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var'],
+    ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'first', 'last'],
     'sum', 'size',
 ])
 @pytest.mark.parametrize('split_every', [False, None])
@@ -746,10 +794,13 @@ def test_series_aggregate__examples(spec, split_every, grouper):
                   check_names=(spec != 'size'))
 
 
-@pytest.mark.parametrize('spec', [
-    'sum', 'min', 'max', 'count', 'size', 'std', 'var', 'mean',
-])
-def test_aggregate__single_element_groups(spec):
+def test_aggregate__single_element_groups(agg_func):
+    spec = agg_func
+
+    # nunique is not supported in specs
+    if spec == 'nunique':
+        return
+
     pdf = pd.DataFrame({'a': [1, 1, 3, 3],
                         'b': [4, 4, 16, 16],
                         'c': [1, 1, 4, 4],
@@ -804,8 +855,8 @@ def test_aggregate__dask():
     specs = [
         {'b': {'c': 'mean'}, 'c': {'a': 'max', 'b': 'min'}},
         {'b': 'mean', 'c': ['min', 'max']},
-        ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var'],
-        'sum', 'mean', 'min', 'max', 'count', 'std', 'var',
+        ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'first', 'last'],
+        'sum', 'mean', 'min', 'max', 'count', 'std', 'var', 'first', 'last'
 
         # NOTE: the 'size' spec is special since it bypasses aggregate
         # 'size'
@@ -839,9 +890,6 @@ def test_aggregate__dask():
             assert len(other.dask) == len(result2.dask)
 
 
-@pytest.mark.parametrize('agg_func', [
-    'sum', 'var', 'mean', 'count', 'size', 'std', 'nunique', 'min', 'max'
-])
 @pytest.mark.parametrize('grouper', [
     lambda df: ['a'],
     lambda df: ['a', 'b'],
@@ -873,9 +921,6 @@ def test_dataframe_aggregations_multilevel(grouper, agg_func):
                   call(ddf.groupby(grouper(ddf)), agg_func, split_every=2))
 
 
-@pytest.mark.parametrize('agg_func', [
-    'sum', 'var', 'mean', 'count', 'size', 'std', 'min', 'max', 'nunique',
-])
 @pytest.mark.parametrize('grouper', [
     lambda df: df['a'],
     lambda df: [df['a'], df['b']],
@@ -1160,7 +1205,7 @@ def test_groupby_agg_grouper_multiple(slice_):
                            "(pandas-dev/pandas#16859)")
 @pytest.mark.parametrize('agg_func', [
     'cumprod', 'cumcount', 'cumsum', 'var', 'sum', 'mean', 'count', 'size',
-    'std', 'min', 'max',
+    'std', 'min', 'max', 'first', 'last'
 ])
 def test_groupby_column_and_index_agg_funcs(agg_func):
 
@@ -1189,10 +1234,13 @@ def test_groupby_column_and_index_agg_funcs(agg_func):
     result = call(ddf_no_divs.groupby(['idx', 'a']), agg_func)
     assert_eq(expected, result)
 
+    # apply-combine-apply aggregation functions
+    aca_agg = {'sum', 'mean', 'var', 'size', 'std', 'count', 'first', 'last'}
+
     # Test aggregate strings
-    if agg_func in {'sum', 'mean', 'var', 'size', 'std', 'count'}:
-            result = ddf_no_divs.groupby(['idx', 'a']).agg(agg_func)
-            assert_eq(expected, result)
+    if agg_func in aca_agg:
+        result = ddf_no_divs.groupby(['idx', 'a']).agg(agg_func)
+        assert_eq(expected, result)
 
     # Column and then index
 
@@ -1208,9 +1256,9 @@ def test_groupby_column_and_index_agg_funcs(agg_func):
     assert_eq(expected, result)
 
     # Test aggregate strings
-    if agg_func in {'sum', 'mean', 'var', 'size', 'std', 'count'}:
-            result = ddf_no_divs.groupby(['a', 'idx']).agg(agg_func)
-            assert_eq(expected, result)
+    if agg_func in aca_agg:
+        result = ddf_no_divs.groupby(['a', 'idx']).agg(agg_func)
+        assert_eq(expected, result)
 
     # Index only
 
@@ -1226,7 +1274,7 @@ def test_groupby_column_and_index_agg_funcs(agg_func):
     assert_eq(expected, result)
 
     # Test aggregate strings
-    if agg_func in {'sum', 'mean', 'var', 'size', 'std', 'count'}:
+    if agg_func in aca_agg:
         result = ddf_no_divs.groupby('idx').agg(agg_func)
         assert_eq(expected, result)
 

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -222,6 +222,8 @@ Groupby Operations
    DataFrameGroupBy.std
    DataFrameGroupBy.sum
    DataFrameGroupBy.var
+   DataFrameGroupBy.first
+   DataFrameGroupBy.last
 
 .. autosummary::
    SeriesGroupBy.aggregate
@@ -239,6 +241,8 @@ Groupby Operations
    SeriesGroupBy.std
    SeriesGroupBy.sum
    SeriesGroupBy.var
+   SeriesGroupBy.first
+   SeriesGroupBy.last
 
 Rolling Operations
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
```python
In [1]: import pandas as pd, dask.dataframe as dd
In [2]: df = pd.DataFrame({'F': list('abcdef'),
                           'B': [4, 5, 4, 5, 5, 4],
                           'C': [7, 8, 9, 4, 2, 3],
                           'D': [1, 3, 5, 7, 1, 0],
                           'E': [5, 3, 6, 9, 2, 4],
                           'A': list('aaabbb')})
In [3]: ddf = dd.from_pandas(df, npartitions=3)
In [4]: ddf.groupby(by='A').agg({'B': 'mean', 'C': 'mean', 'D': 'first', 'E': 'last'}).compute()
Out[4]:
          B    C  D  E
A
a  4.333333  8.0  1  6
b  4.666667  3.0  7  4
In [5]: ddf.groupby(by='A')['D', 'E'].first().compute()
Out[5]:
   D  E
A
a  1  5
b  7  9
In [6]: ddf.groupby(by='A')['D', 'E'].last().compute()
Out[6]:
   D  E
A
a  5  6
b  0  4
```

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API

xref #3206