### PR TITLE
Fix nonempty_index for CategoricalIndex

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -230,8 +230,9 @@ def test_meta_nonempty_index():
     assert res.names == idx.names
 
     levels = [pd.Int64Index([1], name='a'),
-              pd.CategoricalIndex(data=['b'], categories=['b'], name='b')]
-    idx = pd.MultiIndex(levels=levels, labels=[[0], [0]], names=['a', 'b'])
+              pd.CategoricalIndex(data=['b'], categories=['b'], name='b'),
+              pd.TimedeltaIndex([np.timedelta64(1, 'D')], name='timedelta')]
+    idx = pd.MultiIndex(levels=levels, labels=[[0], [0], [0]], names=['a', 'b', 'timedelta'])
     res = meta_nonempty(idx)
     assert type(res) is pd.MultiIndex
     for idx1, idx2 in zip(idx.levels, res.levels):

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -229,6 +229,16 @@ def test_meta_nonempty_index():
         assert idx1.name == idx2.name
     assert res.names == idx.names
 
+    levels = [pd.Int64Index([1], name='a'),
+              pd.CategoricalIndex(data=['b'], categories=['b'], name='b')]
+    idx = pd.MultiIndex(levels=levels, labels=[[0], [0]], names=['a', 'b'])
+    res = meta_nonempty(idx)
+    assert type(res) is pd.MultiIndex
+    for idx1, idx2 in zip(idx.levels, res.levels):
+        assert type(idx1) is type(idx2)
+        assert idx1.name == idx2.name
+    assert res.names == idx.names
+
 
 @pytest.mark.skipif(PANDAS_VERSION < '0.20.0',
                     reason="Pandas < 0.20.0 doesn't support UInt64Index")

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -330,26 +330,20 @@ def _nonempty_index(idx):
                               name=idx.name)
     elif typ is pd.TimedeltaIndex:
         start = np.timedelta64(1, 'D')
-        data = [start, start] if idx.freq is None else None
+        data = [start, start + 1] if idx.freq is None else None
         return pd.TimedeltaIndex(data, start=start, periods=2, freq=idx.freq,
                                  name=idx.name)
     elif typ is pd.CategoricalIndex:
-        if len(idx.categories):
-            data = [idx.categories[0]] * 2
-            cats = idx.categories
-        else:
+        if len(idx.categories) == 0:
             data = _nonempty_index(idx.categories)
             cats = None
+        else:
+            data = _nonempty_index(_nonempty_index(idx.categories))
+            cats = idx.categories
         return pd.CategoricalIndex(data, categories=cats,
                                    ordered=idx.ordered, name=idx.name)
     elif typ is pd.MultiIndex:
-        levels = []
-        for i in idx.levels:
-            lvl = _nonempty_index(i)
-            if isinstance(lvl, pd.CategoricalIndex):
-                lvl = lvl.drop_duplicates()
-            levels.append(lvl)
-
+        levels = [_nonempty_index(l) for l in idx.levels]
         labels = [[0, 0] for i in idx.levels]
         return pd.MultiIndex(levels=levels, labels=labels, names=idx.names)
     raise TypeError("Don't know how to handle index of "

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -343,7 +343,13 @@ def _nonempty_index(idx):
         return pd.CategoricalIndex(data, categories=cats,
                                    ordered=idx.ordered, name=idx.name)
     elif typ is pd.MultiIndex:
-        levels = [_nonempty_index(i) for i in idx.levels]
+        levels = []
+        for i in idx.levels:
+            lvl = _nonempty_index(i)
+            if isinstance(lvl, pd.CategoricalIndex):
+                lvl = lvl.drop_duplicates()
+            levels.append(lvl)
+
         labels = [[0, 0] for i in idx.levels]
         return pd.MultiIndex(levels=levels, labels=labels, names=idx.names)
     raise TypeError("Don't know how to handle index of "


### PR DESCRIPTION
The `MultiIndex` raises a `ValueError` in case the data of the `CategoricalIndex` is not unique (pandas master)

`ValueError: Level values must be unique: ['b', 'b'] on level 1`

- [x] Tests added
- [x] Tests passed
- [x] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API