### PR TITLE
Optionally descend into structures when doing dask.persist

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -513,6 +513,15 @@ def persist(*args, **kwargs):
     When using Dask on a single machine you should ensure that the dataset fits
     entirely within memory.
 
+    Parameters
+    ----------
+    traverse : bool, optional
+        By default dask traverses builtin python collections looking for dask
+        objects passed to ``compute``. For large collections this can be
+        expensive. If none of the arguments contain any dask objects, set
+        ``traverse=False`` to avoid doing this traversal.
+
+
     Examples
     --------
     >>> df = dd.read_csv('/path/to/*.csv')  # doctest: +SKIP
@@ -545,6 +554,12 @@ def persist(*args, **kwargs):
     -------
     New dask collections backed by in-memory data
     """
+    from dask.delayed import delayed
+    traverse = kwargs.pop('traverse', True)
+    if traverse:
+        args = tuple(delayed(a)
+                     if isinstance(a, (list, set, tuple, dict, Iterator))
+                     else a for a in args)
     collections = [a for a in args if is_dask_collection(a)]
     if not collections:
         return args

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -670,6 +670,14 @@ def test_persist_delayed():
     assert x3.compute() == xx.compute()
 
 
+def test_persist_nested():
+    x1 = delayed(1)
+    x2 = delayed(inc)(x1)
+    xx, = persist([x2, 1])
+    assert isinstance(xx[0], Delayed)
+    assert xx[0].compute() == x2.compute()
+
+
 @pytest.mark.skipif('not da or not db')
 def test_persist_array_bag():
     x = da.arange(5, chunks=2) + 1

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -35,6 +35,13 @@ def test_persist(c, s, a, b):
     yield wait(y2)
     assert y2.key in a.data or y2.key in b.data
 
+    y = delayed(inc)(11)
+    out = persist([y, 2])  # needs to descend into list structure
+    y2 = out[0]
+
+    yield wait(y2)
+    assert y2.key in a.data or y2.key in b.data
+
 
 def test_futures_to_delayed_dataframe(loop):
     pd = pytest.importorskip('pandas')


### PR DESCRIPTION
Copies "traverse" option from compute(). Could factor out.

Fixes https://github.com/dask/distributed/issues/1918
