### PR TITLE
topk overhaul and argtopk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.egg-info
+dask-worker-space/
 docs/build
 build/
 dist/

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -6,7 +6,7 @@ from .core import (Array, block, concatenate, stack, from_array, store,
                    from_delayed, asarray, asanyarray,
                    broadcast_arrays, broadcast_to)
 from .routines import (take, choose, argwhere, where, coarsen, insert,
-                       ravel, roll, unique, squeeze, topk, ptp, diff, ediff1d,
+                       ravel, roll, unique, squeeze, ptp, diff, ediff1d,
                        bincount, digitize, histogram, cov, array, dstack,
                        vstack, hstack, compress, extract, round, count_nonzero,
                        flatnonzero, nonzero, around, isin, isnull, notnull,
@@ -37,7 +37,8 @@ from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
                          argmin, argmax,
                          nansum, nanmean, nanstd, nanvar, nanmin,
                          nanmax, nanargmin, nanargmax,
-                         cumsum, cumprod)
+                         cumsum, cumprod,
+                         topk, argtopk)
 from .percentile import percentile
 with ignoring(ImportError):
     from .reductions import nanprod, nancumprod, nancumsum

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -187,18 +187,17 @@ def topk(a, k, axis, keepdims):
     if abs(k) >= a.shape[axis]:
         return a
     a = np.partition(a, -k, axis=axis)
-    # a = a[-k:] if k>0 else a[:-k], on arbitrary axis
-    a = a[[
+    # return a[-k:] if k>0 else a[:-k], on arbitrary axis
+    return a[[
         (slice(-k, None) if k > 0 else slice(None, -k))
         if i == axis else slice(None)
         for i in range(a.ndim)
     ]]
-    return a
 
 
 def topk_postprocess(a, k, axis):
     """Kernel of topk and argtopk.
-    Post-processes the outpout of topk, sorting the results internally.
+    Post-processes the output of topk, sorting the results internally.
     """
     a = np.sort(a, axis=axis)
     if k > 0:

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -215,7 +215,7 @@ def argtopk_preprocess(a, idx):
     Preprocess data, by putting it together with its indexes in a recarray
     """
     # np.core.records.fromarrays won't work if a and idx don't have the same shape
-    res = np.recarray(a.shape, dtype=[('values', a.dtype), ('idx', int)])
+    res = np.recarray(a.shape, dtype=[('values', a.dtype), ('idx', idx.dtype)])
     res.values = a
     res.idx = idx
     return res

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -174,18 +174,50 @@ try:
     from numpy import broadcast_to
 except ImportError:  # pragma: no cover
     broadcast_to = npcompat.broadcast_to
-
-
-def topk(k, x):
-    """ Top k elements of an array
-
-    >>> topk(2, np.array([5, 1, 3, 6]))
-    array([6, 5])
+def topk(a, k, axis, keepdims):
+    """Kernel of topk and argtopk.
+    Extract the k largest elements from a on the given axis.
+    If k is negative, extract the -k smallest elements instead.
+    Note that, unlike in the parent function, the returned elements
+    are not sorted internally.
     """
-    # http://stackoverflow.com/a/23734295/616616 by larsmans
-    k = np.minimum(k, len(x))
-    ind = np.argpartition(x, -k)[-k:]
-    return np.sort(x[ind])[::-1]
+    axis = axis[0]
+    if abs(k) >= a.shape[axis]:
+        return a
+    a = np.partition(a, -k, axis=axis)
+    # a = a[-k:] if k>0 else a[:-k], on arbitrary axis
+    a = a[[
+        (slice(-k, None) if k > 0 else slice(None, -k))
+        if i == axis else slice(None)
+        for i in range(a.ndim)
+    ]]
+    return a
+
+
+def topk_postproc(a, k, axis):
+    """Kernel of topk and argtopk.
+    Post-processes the outpout of topk, sorting the results internally.
+    """
+    if axis < 0:
+        axis += a.ndim
+    a = np.sort(a, axis=axis)
+    if k > 0:
+        # a = a[::-1] on arbitrary axis
+        a = a[[
+            slice(None, None, -1) if i == axis else slice(None)
+            for i in range(a.ndim)
+        ]]
+    return a
+
+
+def argtopk_preproc(a, idx):
+    """Kernel of argtopk.
+    Preprocess data, by putting it together with its indexes in a recarray
+    """
+    res = np.recarray(a.shape, dtype=[('values', a.dtype), ('idx', int)])
+    res.values = a
+    res.idx = idx
+    return res
 
 
 def arange(start, stop, step, length, dtype):

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -174,6 +174,8 @@ try:
     from numpy import broadcast_to
 except ImportError:  # pragma: no cover
     broadcast_to = npcompat.broadcast_to
+
+
 def topk(a, k, axis, keepdims):
     """Kernel of topk and argtopk.
     Extract the k largest elements from a on the given axis.

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -196,12 +196,10 @@ def topk(a, k, axis, keepdims):
     return a
 
 
-def topk_postproc(a, k, axis):
+def topk_postprocess(a, k, axis):
     """Kernel of topk and argtopk.
     Post-processes the outpout of topk, sorting the results internally.
     """
-    if axis < 0:
-        axis += a.ndim
     a = np.sort(a, axis=axis)
     if k > 0:
         # a = a[::-1] on arbitrary axis
@@ -212,10 +210,11 @@ def topk_postproc(a, k, axis):
     return a
 
 
-def argtopk_preproc(a, idx):
+def argtopk_preprocess(a, idx):
     """Kernel of argtopk.
     Preprocess data, by putting it together with its indexes in a recarray
     """
+    # np.core.records.fromarrays won't work if a and idx don't have the same shape
     res = np.recarray(a.shape, dtype=[('values', a.dtype), ('idx', int)])
     res.values = a
     res.idx = idx

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1409,7 +1409,7 @@ class Array(Base):
         return topk(self, k, axis=axis, split_every=split_every)
 
     def argtopk(self, k, axis=-1, split_every=None):
-        """The indexes of the top k elements of an array.
+        """The indices of the top k elements of an array.
 
         See ``da.argtopk`` for docstring"""
         from .reductions import argtopk

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1401,12 +1401,19 @@ class Array(Base):
             shape = shape[0]
         return reshape(self, shape)
 
-    def topk(self, k):
+    def topk(self, k, axis=-1, split_every=None):
         """The top k elements of an array.
 
         See ``da.topk`` for docstring"""
-        from .routines import topk
-        return topk(k, self)
+        from .reductions import topk
+        return topk(self, k, axis=axis, split_every=split_every)
+
+    def argtopk(self, k, axis=-1, split_every=None):
+        """The indexes of the top k elements of an array.
+
+        See ``da.argtopk`` for docstring"""
+        from .reductions import argtopk
+        return argtopk(self, k, axis=axis, split_every=split_every)
 
     def astype(self, dtype, **kwargs):
         """Copy of the array, cast to a specified type.

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -745,7 +745,7 @@ def topk(a, k, axis=-1, split_every=None):
     array([1, 3])
     """
     if isinstance(a, int) and isinstance(k, Array):
-        warnings.warn("DeprecationWarning: topk(k, x) has been replaced with topk(a, k)")
+        warnings.warn("DeprecationWarning: topk(k, a) has been replaced with topk(a, k)")
         a, k = k, a
 
     axis = validate_axis(a.ndim, axis)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -789,4 +789,4 @@ def argtopk(a, k, axis=-1, split_every=None):
     res = topk(a_rec, k, axis=axis, split_every=split_every)
 
     # Discard values
-    return res.map_blocks(operator.getitem, 'idx', dtype=int)
+    return res['idx']

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -12,6 +12,7 @@ from toolz import compose, partition_all, get, accumulate, pluck
 
 from . import chunk
 from .core import _concatenate2, Array, atop, lol_tuples, handle_out
+from .creation import arange
 from .ufunc import sqrt
 from .wrap import zeros, ones
 from .numpy_compat import ma_divide, divide as np_divide
@@ -722,3 +723,68 @@ def validate_axis(ndim, axis):
         return axis + ndim
     else:
         return axis
+
+
+def topk(a, k, axis=-1, split_every=None):
+    """Extract the k largest elements from a on the given axis,
+    and return them sorted from largest to smallest.
+    If k is negative, extract the -k smallest elements instead,
+    and return them sorted from smallest to largest.
+
+    This assumes that ``k`` is small.  All results will be returned in a single
+    chunk along the given axis.
+
+    Examples
+    --------
+    >>> x = np.array([5, 1, 3, 6])
+    >>> d = from_array(x, chunks=2)
+    >>> d.topk(2).compute()
+    array([6, 5])
+    >>> d.topk(-2).compute()
+    array([1, 3])
+    """
+    if isinstance(a, int) and isinstance(k, Array):
+        warnings.warn("DeprecationWarning: topk(k, x) has been replaced with topk(a, k)")
+        a, k = k, a
+
+    kernel = partial(chunk.topk, k=k)
+    res = reduction(a, kernel, kernel, axis=axis, keepdims=True,
+                    dtype=a.dtype, split_every=split_every)
+    # reduction(keepdims=True) sets shape[axis] to 1. Fix it.
+    chunks = list(res.chunks)
+    chunks[axis] = (abs(k), )
+    res = Array(res.dask, res.name, chunks, res.dtype)
+
+    # Sort result internally
+    return res.map_blocks(chunk.topk_postproc, k=k, axis=axis, dtype=a.dtype)
+
+
+def argtopk(a, k, axis=-1, split_every=None):
+    """Extract the indexes of the k largest elements from a on the given axis,
+    and return them sorted from largest to smallest.
+    If k is negative, extract the indexes of the -k smallest elements instead,
+    and return them sorted from smallest to largest.
+
+    This assumes that ``k`` is small.  All results will be returned in a single
+    chunk along the given axis.
+
+    Examples
+    --------
+    >>> x = np.array([5, 1, 3, 6])
+    >>> d = from_array(x, chunks=2)
+    >>> d.argtopk(2).compute()
+    array([3, 0])
+    >>> d.argtopk(-2).compute()
+    array([1, 2])
+    """
+    # Convert a to a recarray that contains its index
+    if axis < 0:
+        axis += a.ndim
+    idx = arange(a.shape[axis], chunks=a.chunks[axis])
+    idx = idx[tuple(slice(None) if i == axis else np.newaxis for i in range(a.ndim))]
+    a_rec = a.map_blocks(chunk.argtopk_preproc, idx, dtype=[('values', a.dtype), ('idx', int)])
+
+    res = topk(a_rec, k, axis=axis, split_every=split_every)
+
+    # Discard values
+    return res.map_blocks(operator.getitem, 'idx', dtype=int)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -736,8 +736,9 @@ def topk(a, k, axis=-1, split_every=None):
 
     Examples
     --------
+    >>> import dask.array as da
     >>> x = np.array([5, 1, 3, 6])
-    >>> d = from_array(x, chunks=2)
+    >>> d = da.from_array(x, chunks=2)
     >>> d.topk(2).compute()
     array([6, 5])
     >>> d.topk(-2).compute()
@@ -770,8 +771,9 @@ def argtopk(a, k, axis=-1, split_every=None):
 
     Examples
     --------
+    >>> import dask.array as da
     >>> x = np.array([5, 1, 3, 6])
-    >>> d = from_array(x, chunks=2)
+    >>> d = da.from_array(x, chunks=2)
     >>> d.argtopk(2).compute()
     array([3, 0])
     >>> d.argtopk(-2).compute()

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -784,7 +784,7 @@ def argtopk(a, k, axis=-1, split_every=None):
     axis = validate_axis(a.ndim, axis)
 
     # Convert a to a recarray that contains its index
-    idx = arange(a.shape[axis], chunks=a.chunks[axis])
+    idx = arange(a.shape[axis], chunks=a.chunks[axis], dtype=np.int64)
     idx = idx[tuple(slice(None) if i == axis else np.newaxis for i in range(a.ndim))]
     a_rec = a.map_blocks(chunk.argtopk_preprocess, idx,
                          dtype=[('a', a.dtype), ('idx', idx.dtype)])

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -6,7 +6,6 @@ from collections import Iterable
 from distutils.version import LooseVersion
 from functools import wraps, partial
 from numbers import Integral
-from operator import getitem
 
 import numpy as np
 from toolz import concat, sliding_window, interleave

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -878,38 +878,6 @@ def squeeze(a, axis=None):
     return a[sl]
 
 
-def topk(k, x):
-    """ The top k elements of an array
-
-    Returns the k greatest elements of the array in sorted order.  Only works
-    on arrays of a single dimension.
-
-    This assumes that ``k`` is small.  All results will be returned in a single
-    chunk.
-
-    Examples
-    --------
-
-    >>> x = np.array([5, 1, 3, 6])
-    >>> d = from_array(x, chunks=2)
-    >>> d.topk(2).compute()
-    array([6, 5])
-    """
-    if x.ndim != 1:
-        raise ValueError("Topk only works on arrays of one dimension")
-
-    token = tokenize(k, x)
-    name = 'chunk.topk-' + token
-    dsk = {(name, i): (chunk.topk, k, key)
-           for i, key in enumerate(x.__dask_keys__())}
-    name2 = 'topk-' + token
-    dsk[(name2, 0)] = (getitem, (np.sort, (np.concatenate, list(dsk))),
-                       slice(-1, -k - 1, -1))
-    chunks = ((k,),)
-
-    return Array(sharedict.merge((name2, dsk), x.dask), name2, chunks, dtype=x.dtype)
-
-
 @wraps(np.compress)
 def compress(condition, a, axis=None):
     if axis is None:

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -424,7 +424,12 @@ def test_array_cumreduction_out(func):
     assert_eq(x, func(np.ones((10, 10)), axis=0))
 
 
-def test_topk_argtopk():
+@pytest.mark.parametrize('npfunc,daskfunc', [
+    (np.sort, da.topk),
+    (np.argsort, da.argtopk),
+])
+@pytest.mark.parametrize('split_every', [None, 2])
+def test_topk_argtopk1(npfunc, daskfunc, split_every):
     # Test data
     k = 5
     a = da.random.random(1000, chunks=250)
@@ -432,44 +437,50 @@ def test_topk_argtopk():
     c = da.from_array(np.array([(1, 'Hello'), (2, 'World')], dtype=[('foo', int), ('bar', '<U5')]),
                       chunks=1)
 
+    # 1-dimensional arrays
+    # top 5 elements, sorted descending
+    assert_eq(npfunc(a)[-k:][::-1],
+              daskfunc(a, k, split_every=split_every))
+    # bottom 5 elements, sorted ascending
+    assert_eq(npfunc(a)[:k],
+              daskfunc(a, -k, split_every=split_every))
+
+    # n-dimensional arrays
+    # also testing when k > chunk
+    # top 5 elements, sorted descending
+    assert_eq(npfunc(b, axis=0)[-k:, :, :][::-1, :, :],
+              daskfunc(b, k, axis=0, split_every=split_every))
+    assert_eq(npfunc(b, axis=1)[:, -k:, :][:, ::-1, :],
+              daskfunc(b, k, axis=1, split_every=split_every))
+    assert_eq(npfunc(b, axis=-1)[:, :, -k:][:, :, ::-1],
+              daskfunc(b, k, axis=-1, split_every=split_every))
+    with pytest.raises(ValueError):
+        daskfunc(b, k, axis=3, split_every=split_every)
+
+    # bottom 5 elements, sorted ascending
+    assert_eq(npfunc(b, axis=0)[:k, :, :],
+              daskfunc(b, -k, axis=0, split_every=split_every))
+    assert_eq(npfunc(b, axis=1)[:, :k, :],
+              daskfunc(b, -k, axis=1, split_every=split_every))
+    assert_eq(npfunc(b, axis=-1)[:, :, :k],
+              daskfunc(b, -k, axis=-1, split_every=split_every))
+    with pytest.raises(ValueError):
+        daskfunc(b, -k, axis=3, split_every=split_every)
+
+    # structured arrays
+    assert_eq(npfunc(c, axis=0)[-1:][::-1],
+              daskfunc(c, 1, split_every=split_every))
+    assert_eq(npfunc(c, axis=0)[:1],
+              daskfunc(c, -1, split_every=split_every))
+
+
+def test_topk_argtopk2():
+    a = da.random.random((10, 20, 30), chunks=(4, 8, 8))
+
     # Support for deprecated API for topk
     with pytest.warns(UserWarning):
-        assert_eq(da.topk(a, k), da.topk(k, a))
+        assert_eq(da.topk(a, 5), da.topk(5, a))
 
     # As Array methods
-    assert_eq(b.topk(k, axis=1, split_every=2), da.topk(b, k, axis=1, split_every=2))
-    assert_eq(b.argtopk(k, axis=1, split_every=2), da.argtopk(b, k, axis=1, split_every=2))
-
-    for npf, daskf in ((np.sort, da.topk), (np.argsort, da.argtopk)):
-        for se in (None, 2):
-            # 1-dimensional arrays
-            # top 5 elements, sorted descending
-            assert_eq(npf(a)[-k:][::-1], daskf(a, k, split_every=se))
-            # bottom 5 elements, sorted ascending
-            assert_eq(npf(a)[:k], daskf(a, -k, split_every=se))
-
-            # n-dimensional arrays
-            # also testing when k > chunk
-            # top 5 elements, sorted descending
-            assert_eq(npf(b, axis=0)[-k:, :, :][::-1, :, :],
-                      daskf(b, k, axis=0, split_every=se))
-            assert_eq(npf(b, axis=1)[:, -k:, :][:, ::-1, :],
-                      daskf(b, k, axis=1, split_every=se))
-            assert_eq(npf(b, axis=-1)[:, :, -k:][:, :, ::-1],
-                      daskf(b, k, axis=-1, split_every=se))
-            with pytest.raises(ValueError):
-                daskf(b, k, axis=3, split_every=se)
-
-            # bottom 5 elements, sorted ascending
-            assert_eq(npf(b, axis=0)[:k, :, :],
-                      daskf(b, -k, axis=0, split_every=se))
-            assert_eq(npf(b, axis=1)[:, :k, :],
-                      daskf(b, -k, axis=1, split_every=se))
-            assert_eq(npf(b, axis=-1)[:, :, :k],
-                      daskf(b, -k, axis=-1, split_every=se))
-            with pytest.raises(ValueError):
-                daskf(b, -k, axis=3, split_every=se)
-
-            # structured arrays
-            assert_eq(npf(c, axis=0)[-1:][::-1], daskf(c, 1, split_every=se))
-            assert_eq(npf(c, axis=0)[:1], daskf(c, -1, split_every=se))
+    assert_eq(a.topk(5, axis=1, split_every=2), da.topk(a, 5, axis=1, split_every=2))
+    assert_eq(a.argtopk(5, axis=1, split_every=2), da.argtopk(a, 5, axis=1, split_every=2))

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -430,7 +430,7 @@ def test_topk_argtopk():
     a = da.random.random(1000, chunks=250)
     b = da.random.random((10, 20, 30), chunks=(4, 8, 8))
     c = da.from_array(np.array([(1, 'Hello'), (2, 'World')], dtype=[('foo', int), ('bar', '<U5')]),
-                   chunks=1)
+                      chunks=1)
 
     # Support for deprecated API for topk
     np.testing.assert_array_equal(da.topk(a, 5), da.topk(5, a))

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -422,3 +422,45 @@ def test_array_cumreduction_out(func):
     x = da.ones((10, 10), chunks=(4, 4))
     func(x, axis=0, out=x)
     assert_eq(x, func(np.ones((10, 10)), axis=0))
+
+
+def test_topk_argtopk():
+    # Test data
+    k = 5
+    a = da.random.random(1000, chunks=250)
+    b = da.random.random((10, 20, 30), chunks=(4, 8, 8))
+    c = da.from_array(np.array([(1, 'Hello'), (2, 'World')], dtype=[('foo', int), ('bar', '<U5')]),
+                   chunks=1)
+
+    # Support for deprecated API for topk
+    np.testing.assert_array_equal(da.topk(a, 5), da.topk(5, a))
+
+    # As Array methods
+    a.topk(5)
+    np.testing.assert_array_equal(da.topk(a, 5), da.topk(5, a))
+
+    for npf, daskf in ((np.sort, da.topk), (np.argsort, da.argtopk)):
+        for se in (None, 2):
+            # 1-dimensional arrays
+            np.testing.assert_array_equal(npf(a)[-k:][::-1], daskf(a, k, split_every=se))
+            np.testing.assert_array_equal(npf(a)[:k], daskf(a, -k, split_every=se))
+
+            # n-dimensional arrays
+            # also testing when k > chunk
+            np.testing.assert_array_equal(npf(b, axis=0)[-k:, :, :][::-1, :, :],
+                                          daskf(b, k, axis=0, split_every=se))
+            np.testing.assert_array_equal(npf(b, axis=1)[:, -k:, :][:, ::-1, :],
+                                          daskf(b, k, axis=1, split_every=se))
+            np.testing.assert_array_equal(npf(b, axis=2)[:, :, -k:][:, :, ::-1],
+                                          daskf(b, k, axis=2, split_every=se))
+
+            np.testing.assert_array_equal(npf(b, axis=0)[:k, :, :],
+                                          daskf(b, -k, axis=0, split_every=se))
+            np.testing.assert_array_equal(npf(b, axis=1)[:, :k, :],
+                                          daskf(b, -k, axis=1, split_every=se))
+            np.testing.assert_array_equal(npf(b, axis=2)[:, :, :k],
+                                          daskf(b, -k, axis=2, split_every=se))
+
+            # structured arrays
+            np.testing.assert_array_equal(npf(c, axis=0)[-1:][::-1], daskf(c, 1, split_every=se))
+            np.testing.assert_array_equal(npf(c, axis=0)[:1], daskf(c, -1, split_every=se))

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -418,27 +418,6 @@ def test_ediff1d(shape, to_end, to_begin):
     assert_eq(da.ediff1d(a, to_end, to_begin), np.ediff1d(x, to_end, to_begin))
 
 
-def test_topk():
-    x = np.array([5, 2, 1, 6])
-    d = da.from_array(x, chunks=2)
-
-    e = da.topk(2, d)
-
-    assert e.chunks == ((2,),)
-    assert_eq(e, np.sort(x)[-1:-3:-1])
-    assert same_keys(da.topk(2, d), e)
-
-
-def test_topk_k_bigger_than_chunk():
-    x = np.array([5, 2, 1, 6])
-    d = da.from_array(x, chunks=2)
-
-    e = da.topk(3, d)
-
-    assert e.chunks == ((3,),)
-    assert_eq(e, np.array([6, 5, 2]))
-
-
 def test_bincount():
     x = np.array([2, 1, 5, 2, 1])
     d = da.from_array(x, chunks=2)

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -22,6 +22,7 @@ Top level user functions:
    arctanh
    argmax
    argmin
+   argtopk
    argwhere
    around
    array
@@ -340,7 +341,6 @@ Other functions
 .. autofunction:: from_array
 .. autofunction:: from_delayed
 .. autofunction:: store
-.. autofunction:: topk
 .. autofunction:: coarsen
 .. autofunction:: stack
 .. autofunction:: concatenate
@@ -361,6 +361,7 @@ Other functions
 .. autofunction:: arctanh
 .. autofunction:: argmax
 .. autofunction:: argmin
+.. autofunction:: argtopk
 .. autofunction:: argwhere
 .. autofunction:: around
 .. autofunction:: array

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,12 @@ Array
 - Add ``piecewise`` for Dask Arrays (:pr:`3350`) `John A Kirkham`_
 - Fix handling of ``nan`` in ``broadcast_shapes`` (:pr:`3356`) `John A Kirkham`_
 - Add ``isin`` for dask arrays (:pr:`3363`). `Stephan Hoyer`_
+- Overhauled ``topk`` for Dask Arrays: faster algorithm, particularly for large k's; added support
+  for multiple axes, recursive aggregation, and an option to pick the bottom k elements instead.
+  (:pr:`3395`) `Guido Imperiale`_
+- The ``topk`` API has changed from topk(k, array) to the more conventional topk(array, k).
+  The legacy API still works but is now deprecated. (:pr:`2965`) `Guido Imperiale`_
+- New function ``argtopk`` for Dask Arrays (:pr:`3396`) `Guido Imperiale`_
 
 DataFrame
 +++++++++
@@ -1023,6 +1029,7 @@ Other
 - There is also a gitter chat room and a stackoverflow tag
 
 
+.. _`Guido Imperiale`: https://github.com/crusaderky
 .. _`John A Kirkham`: https://github.com/jakirkham
 .. _`Matthew Rocklin`: https://github.com/mrocklin
 .. _`Jim Crist`: https://github.com/jcrist


### PR DESCRIPTION
topk changes:
+ change API from topk(k, a) to topk(a, k) (closes #2965)
+ add support for multiple axis
+ add support for recursive aggregation (closes #3395)
+ avoid needless internal sorting in intermediate passages
+ new function argtopk (partially resolves #3396)