### PR TITLE
Support `traverse` keyword in persist/optimize

### DIFF
--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -693,6 +693,22 @@ def test_persist_literals():
     assert persist(1, 2, 3) == (1, 2, 3)
 
 
+def test_persist_nested():
+    a = delayed(1) + 5
+    b = a + 1
+    c = a + 2
+    result = persist({'a': a, 'b': [1, 2, b]}, (c, 2))
+    assert isinstance(result[0]['a'], Delayed)
+    assert isinstance(result[0]['b'][2], Delayed)
+    assert isinstance(result[1][0], Delayed)
+    assert compute(*result) == ({'a': 6, 'b': [1, 2, 7]}, (8, 2))
+
+    res = persist([a, b], c, traverse=False)
+    assert res[0][0] is a
+    assert res[0][1] is b
+    assert res[1].compute() == 8
+
+
 def test_persist_delayed():
     x1 = delayed(1)
     x2 = delayed(inc)(x1)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -351,7 +351,7 @@ def test_unpack_collections():
         return (a, b,               # Top-level collections
                 {'a': a,            # dict
                  a: b,              # collections as keys
-                 'b': [1, 2, b],    # list
+                 'b': [1, 2, [b]],  # list
                  'c': 10,           # other builtins pass through unchanged
                  'd': (c, 2),       # tuple
                  'e': {a, 2, 3}},   # set

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -32,7 +32,7 @@ Bag
 Core
 ++++
 
--
+- Support traversing collections in persist, visualize, and optimize (:pr:`3410`) `Jim Crist`_
 
 
 0.17.2 / 2018-03-21


### PR DESCRIPTION
Adds support for `traverse` keyword to `persist`/`optimize`, and changes how this is implemented for `compute`.

The general gist is that we wrap all collection transforms in `unpack`/`repack` calls. The pattern is:

```
collections, repack = unpack(*args)  # extract all collections from arguments
results = transform(collections)     # do something with the collections
return repack(results)               # repackage the results in python collections
```

Supersedes #3404, fixes dask/distributed#1918.