### PR TITLE
Remove deprecated `Base` class

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -32,8 +32,8 @@ import numpy as np
 from . import chunk
 from .numpy_compat import _make_sliced_dtype
 from .slicing import slice_array, replace_ellipsis
-from ..base import (Base, tokenize, dont_optimize, compute_as_if_collection,
-                    persist, is_dask_collection)
+from ..base import (DaskMethodsMixin, tokenize, dont_optimize,
+                    compute_as_if_collection, persist, is_dask_collection)
 from ..context import _globals, globalmethod
 from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      is_integer, IndexCallable, funcname, derived_from,
@@ -999,7 +999,7 @@ See the following documentation page for details:
 """.strip()
 
 
-class Array(Base):
+class Array(DaskMethodsMixin):
     """ Parallel Dask Array
 
     A parallel nd-array comprised of many numpy arrays arranged in a grid.

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -28,7 +28,7 @@ from ..utils import (random_state_data, pseudorandom, derived_from, funcname,
                      memory_repr, put_lines, M, key_split, OperatorMethodMixin,
                      is_arraylike)
 from ..array import Array
-from ..base import Base, tokenize, dont_optimize, is_dask_collection
+from ..base import DaskMethodsMixin, tokenize, dont_optimize, is_dask_collection
 from ..delayed import Delayed, to_task_dask
 
 from . import methods
@@ -106,7 +106,7 @@ def finalize(results):
     return _concat(results)
 
 
-class Scalar(Base, OperatorMethodMixin):
+class Scalar(DaskMethodsMixin, OperatorMethodMixin):
     """ A Dask object to represent a pandas scalar"""
     def __init__(self, dsk, name, meta, divisions=None):
         # divisions is ignored, only present to be compatible with other
@@ -247,7 +247,7 @@ def _scalar_binary(op, self, other, inv=False):
         return Scalar(dsk, name, meta)
 
 
-class _Frame(Base, OperatorMethodMixin):
+class _Frame(DaskMethodsMixin, OperatorMethodMixin):
     """ Superclass for DataFrame and Series
 
     Parameters

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -10,7 +10,7 @@ except ImportError:
     from toolz import curry, pluck
 
 from . import threaded
-from .base import Base, is_dask_collection, dont_optimize
+from .base import is_dask_collection, dont_optimize, DaskMethodsMixin
 from .base import tokenize as _tokenize
 from .compatibility import apply
 from .core import quote
@@ -342,7 +342,7 @@ def rebuild(dsk, key, length):
     return Delayed(key, dsk, length)
 
 
-class Delayed(Base, OperatorMethodMixin):
+class Delayed(DaskMethodsMixin, OperatorMethodMixin):
     """Represents a value to be computed by dask.
 
     Equivalent to the output from a single key in a dask graph.


### PR DESCRIPTION
This was deprecated in 0.16.0. Since we've already had a major release since then, remove the deprecation.
