### PR TITLE
Add einsum autofunction in docs

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -403,6 +403,7 @@ Other functions
 .. autofunction:: ediff1d
 .. autofunction:: empty
 .. autofunction:: empty_like
+.. autofunction:: einsum
 .. autofunction:: exp
 .. autofunction:: expm1
 .. autofunction:: eye


### PR DESCRIPTION
I added `einsum` in the summary but forgot to add the autofunction.

- [ ] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API

