### PR TITLE
Fixes example code block in dataframe.Series.map_overlap

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -657,8 +657,9 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         3  3.0  1.0
         4  4.0  1.0
 
-        If you have a ``DatetimeIndex``, you can use a `timedelta` for time-
+        If you have a ``DatetimeIndex``, you can use a ``pd.Timedelta`` for time-
         based windows.
+
         >>> ts = pd.Series(range(10), index=pd.date_range('2017', periods=10))
         >>> dts = dd.from_pandas(ts, npartitions=2)
         >>> dts.map_overlap(lambda df: df.rolling('2D').sum(),


### PR DESCRIPTION
Ran into a minor formatting issue in the "Examples" section of the `dataframe.Series.map_overlap` docstring. Looks like an extra space was missing that caused an example to be rendered incorrectly

<img width="1241" alt="screen shot 2018-04-19 at 3 31 56 pm" src="https://user-images.githubusercontent.com/11656932/39016941-85a6cf08-43e7-11e8-8993-45a751b5c992.png">

This PR just adds an extra space, so the example is rendered as a code block

<img width="1252" alt="screen shot 2018-04-19 at 3 32 32 pm" src="https://user-images.githubusercontent.com/11656932/39016965-97ef3b6e-43e7-11e8-8783-f28b6839581e.png">

