### PR TITLE
Skip einsum optimize tests if unsupported in NumPy

### DIFF
--- a/dask/array/einsumfuncs.py
+++ b/dask/array/einsumfuncs.py
@@ -193,7 +193,7 @@ def _einsum_kernel(*operands, **kwargs):
     return chunk.reshape(chunk.shape + (1,) * ncontract_inds)
 
 
-_einsum_can_optimize = LooseVersion(np.__version__) >= LooseVersion("1.12.0")
+einsum_can_optimize = LooseVersion(np.__version__) >= LooseVersion("1.12.0")
 
 
 @wraps(np.einsum)
@@ -212,7 +212,7 @@ def einsum(*operands, **kwargs):
     if optimize is None:
         optimize = False
 
-    if _einsum_can_optimize and optimize is not False:
+    if einsum_can_optimize and optimize is not False:
         # Avoid computation of dask arrays within np.einsum_path
         # by passing in small numpy arrays broadcasted
         # up to the right shape
@@ -234,7 +234,7 @@ def einsum(*operands, **kwargs):
     kwargs['kernel_dtype'] = einsum_dtype
     kwargs['ncontract_inds'] = ncontract_inds
 
-    if _einsum_can_optimize:
+    if einsum_can_optimize:
         kwargs['optimize'] = optimize
 
     # Update kwargs with atop parameters

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -11,6 +11,7 @@ np = pytest.importorskip('numpy')
 import dask.array as da
 from dask.utils import ignoring
 from dask.array.utils import assert_eq, same_keys
+from dask.array.einsumfuncs import einsum_can_optimize
 
 
 def test_array():
@@ -1356,6 +1357,8 @@ def test_einsum(einsum_signature):
               da.einsum(einsum_signature, *da_inputs))
 
 
+@pytest.mark.skipif(not einsum_can_optimize,
+                    reason="np.einsum(optimize) unavailable")
 @pytest.mark.parametrize('optimize_opts', [
     (True, False),
     ('greedy', False),


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
