### PR TITLE
Remove support for numpy < 1.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
 
     - env:
       - PYTHON=3.4
-      - NUMPY=1.10.4
+      - NUMPY=1.12.1
       - PANDAS=0.19.1
       - *test_and_lint
       - *no_coverage
@@ -45,7 +45,7 @@ jobs:
 
     - env:
       - PYTHON=3.5
-      - NUMPY=1.12.1
+      - NUMPY=1.11.0
       - PANDAS=0.19.2
       - *test_and_lint
       - *no_coverage

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -61,15 +61,14 @@ nanargmax = keepdims_wrapper(np.nanargmax)
 any = keepdims_wrapper(np.any)
 all = keepdims_wrapper(np.all)
 nansum = keepdims_wrapper(np.nansum)
+nanprod = keepdims_wrapper(np.nanprod)
 
 try:
-    from numpy import nanprod, nancumprod, nancumsum
+    from numpy import nancumprod, nancumsum
 except ImportError:  # pragma: no cover
-    nanprod = npcompat.nanprod
     nancumprod = npcompat.nancumprod
     nancumsum = npcompat.nancumsum
 
-nanprod = keepdims_wrapper(nanprod)
 nancumprod = keepdims_wrapper(nancumprod)
 nancumsum = keepdims_wrapper(nancumsum)
 

--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -10,8 +10,8 @@ from .core import (concatenate_lookup, tensordot_lookup, map_blocks,
                    asanyarray, atop)
 
 
-if LooseVersion(np.__version__) < '1.11.0':
-    raise ImportError("dask.array.ma requires numpy >= 1.11.0")
+if LooseVersion(np.__version__) < '1.11.2':
+    raise ImportError("dask.array.ma requires numpy >= 1.11.2")
 
 
 @normalize_token.register(np.ma.masked_array)

--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -2,28 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 from distutils.version import LooseVersion
 
-from ..compatibility import builtins
 import numpy as np
 import warnings
-
-try:
-    isclose = np.isclose
-except AttributeError:
-    def isclose(*args, **kwargs):
-        raise RuntimeError("You need numpy version 1.7 or greater to use "
-                           "isclose.")
-
-try:
-    full = np.full
-except AttributeError:
-    def full(shape, fill_value, dtype=None, order=None):
-        """Our implementation of numpy.full because your numpy is old."""
-        if order is not None:
-            raise NotImplementedError("`order` kwarg is not supported upgrade "
-                                      "to Numpy 1.8 or greater for support.")
-        return np.multiply(fill_value, np.ones(shape, dtype=dtype),
-                           dtype=dtype)
-
 
 # Taken from scikit-learn:
 # https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/fixes.py#L84
@@ -54,79 +34,12 @@ except TypeError:
                                                     np.ma.core._DomainSafeDivide(),
                                                     0, 1)
 
-# functions copied from numpy
-try:
-    from numpy import broadcast_to, nanprod, nancumsum, nancumprod
-except ImportError:  # pragma: no cover
-    # these functions should arrive in numpy v1.10 to v1.12.  Until then,
-    # they are duplicated here
+if LooseVersion(np.__version__) < '1.12.0':
+    # These functions were added in numpy 1.12.0. For previous versions they
+    # are duplicated here
 
     # See https://github.com/numpy/numpy/blob/master/LICENSE.txt
     # or NUMPY_LICENSE.txt within this directory
-    def _maybe_view_as_subclass(original_array, new_array):
-        if type(original_array) is not type(new_array):
-            # if input was an ndarray subclass and subclasses were OK,
-            # then view the result as that subclass.
-            new_array = new_array.view(type=type(original_array))
-            # Since we have done something akin to a view from original_array, we
-            # should let the subclass finalize (if it has it implemented, i.e., is
-            # not None).
-            if new_array.__array_finalize__:
-                new_array.__array_finalize__(original_array)
-        return new_array
-
-    def _broadcast_to(array, shape, subok, readonly):
-        shape = tuple(shape) if np.iterable(shape) else (shape,)
-        array = np.array(array, copy=False, subok=subok)
-        if not shape and array.shape:
-            raise ValueError('cannot broadcast a non-scalar to a scalar array')
-        if builtins.any(size < 0 for size in shape):
-            raise ValueError('all elements of broadcast shape must be non-'
-                             'negative')
-        broadcast = np.nditer(
-            (array,), flags=['multi_index', 'zerosize_ok', 'refs_ok'],
-            op_flags=['readonly'], itershape=shape, order='C').itviews[0]
-        result = _maybe_view_as_subclass(array, broadcast)
-        if not readonly and array.flags.writeable:
-            result.flags.writeable = True
-        return result
-
-    def broadcast_to(array, shape, subok=False):
-        """Broadcast an array to a new shape.
-
-        Parameters
-        ----------
-        array : array_like
-            The array to broadcast.
-        shape : tuple
-            The shape of the desired array.
-        subok : bool, optional
-            If True, then sub-classes will be passed-through, otherwise
-            the returned array will be forced to be a base-class array (default).
-
-        Returns
-        -------
-        broadcast : array
-            A readonly view on the original array with the given shape. It is
-            typically not contiguous. Furthermore, more than one element of a
-            broadcasted array may refer to a single memory location.
-
-        Raises
-        ------
-        ValueError
-            If the array is not compatible with the new shape according to NumPy's
-            broadcasting rules.
-
-        Examples
-        --------
-        >>> x = np.array([1, 2, 3])
-        >>> np.broadcast_to(x, (3, 3))  # doctest: +SKIP
-        array([[1, 2, 3],
-               [1, 2, 3],
-               [1, 2, 3]])
-        """
-        return _broadcast_to(array, shape, subok=subok, readonly=True)
-
     def _replace_nan(a, val):
         """
         If `a` is of inexact type, make a copy of `a`, replace NaNs with
@@ -167,75 +80,6 @@ except ImportError:  # pragma: no cover
         mask = np.isnan(a)
         np.copyto(a, val, where=mask)
         return a, mask
-
-    def nanprod(a, axis=None, dtype=None, out=None, keepdims=0):
-        """
-        Return the product of array elements over a given axis treating Not a
-        Numbers (NaNs) as zero.
-
-        One is returned for slices that are all-NaN or empty.
-
-        .. versionadded:: 1.10.0
-
-        Parameters
-        ----------
-        a : array_like
-            Array containing numbers whose sum is desired. If `a` is not an
-            array, a conversion is attempted.
-        axis : int, optional
-            Axis along which the product is computed. The default is to compute
-            the product of the flattened array.
-        dtype : data-type, optional
-            The type of the returned array and of the accumulator in which the
-            elements are summed.  By default, the dtype of `a` is used.  An
-            exception is when `a` has an integer type with less precision than
-            the platform (u)intp. In that case, the default will be either
-            (u)int32 or (u)int64 depending on whether the platform is 32 or 64
-            bits. For inexact inputs, dtype must be inexact.
-        out : ndarray, optional
-            Alternate output array in which to place the result.  The default
-            is ``None``. If provided, it must have the same shape as the
-            expected output, but the type will be cast if necessary.  See
-            `doc.ufuncs` for details. The casting of NaN to integer can yield
-            unexpected results.
-        keepdims : bool, optional
-            If True, the axes which are reduced are left in the result as
-            dimensions with size one. With this option, the result will
-            broadcast correctly against the original `arr`.
-
-        Returns
-        -------
-        y : ndarray or numpy scalar
-
-        See Also
-        --------
-        :func:`numpy.prod` : Product across array propagating NaNs.
-        isnan : Show which elements are NaN.
-
-        Notes
-        -----
-        Numpy integer arithmetic is modular. If the size of a product exceeds
-        the size of an integer accumulator, its value will wrap around and the
-        result will be incorrect. Specifying ``dtype=double`` can alleviate
-        that problem.
-
-        Examples
-        --------
-        >>> np.nanprod(1)
-        1
-        >>> np.nanprod([1])
-        1
-        >>> np.nanprod([1, np.nan])
-        1.0
-        >>> a = np.array([[1, 2], [3, np.nan]])
-        >>> np.nanprod(a)
-        6.0
-        >>> np.nanprod(a, axis=0)
-        array([ 3.,  2.])
-
-        """
-        a, mask = _replace_nan(a, 1)
-        return np.prod(a, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
 
     def nancumsum(a, axis=None, dtype=None, out=None):
         """

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -14,7 +14,7 @@ from toolz import concat, sliding_window, interleave
 from .. import sharedict
 from ..core import flatten
 from ..base import tokenize
-from . import numpy_compat, chunk
+from . import chunk
 from .creation import arange
 from .utils import safe_wraps
 from .wrap import ones
@@ -995,9 +995,9 @@ def notnull(values):
     return ~isnull(values)
 
 
-@wraps(numpy_compat.isclose)
+@wraps(np.isclose)
 def isclose(arr1, arr2, rtol=1e-5, atol=1e-8, equal_nan=False):
-    func = partial(numpy_compat.isclose, rtol=rtol, atol=atol, equal_nan=equal_nan)
+    func = partial(np.isclose, rtol=rtol, atol=atol, equal_nan=equal_nan)
     return elemwise(func, arr1, arr2, dtype='bool')
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -286,8 +286,6 @@ def test_stack_promote_type():
     assert_eq(res, np.stack([i, f]))
 
 
-@pytest.mark.skipif(LooseVersion(np.__version__) < '1.10.0',
-                    reason="NumPy doesn't yet support stack")
 def test_stack_rechunk():
     x = da.random.random(10, chunks=5)
     y = da.random.random(10, chunks=4)

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -500,10 +500,6 @@ def test_norm_1dim(shape, chunks, axis, norm, keepdims):
 
     a_r = np.linalg.norm(a, ord=norm, axis=axis, keepdims=keepdims)
     d_r = da.linalg.norm(d, ord=norm, axis=axis, keepdims=keepdims)
-
-    # Fix a type mismatch on NumPy 1.10.
-    a_r = a_r.astype(float)
-
     assert_eq(a_r, d_r)
 
 

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -1,20 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
-pytest.importorskip('numpy')
+np = pytest.importorskip('numpy')
 
 import dask.array as da
 from dask.array.utils import assert_eq as _assert_eq, same_keys
 from dask.core import get_deps
 from dask.context import set_options
-
-import numpy as np
-# temporary until numpy functions migrated
-try:
-    from numpy import nanprod
-except ImportError:  # pragma: no cover
-    import dask.array.numpy_compat as npcompat
-    nanprod = npcompat.nanprod
 
 
 def assert_eq(a, b):
@@ -56,7 +48,7 @@ def test_reductions_1D(dtype):
     reduction_1d_test(da.all, a, np.all, x, False)
 
     reduction_1d_test(da.nansum, a, np.nansum, x)
-    reduction_1d_test(da.nanprod, a, nanprod, x)
+    reduction_1d_test(da.nanprod, a, np.nanprod, x)
     reduction_1d_test(da.nanmean, a, np.mean, x)
     reduction_1d_test(da.nanvar, a, np.var, x)
     reduction_1d_test(da.nanstd, a, np.std, x)
@@ -127,7 +119,7 @@ def test_reductions_2D(dtype):
     reduction_2d_test(da.all, a, np.all, x, False)
 
     reduction_2d_test(da.nansum, a, np.nansum, x)
-    reduction_2d_test(da.nanprod, a, nanprod, x)
+    reduction_2d_test(da.nanprod, a, np.nanprod, x)
     reduction_2d_test(da.nanmean, a, np.mean, x)
     reduction_2d_test(da.nanvar, a, np.nanvar, x, False)  # Difference in dtype algo
     reduction_2d_test(da.nanstd, a, np.nanstd, x, False)  # Difference in dtype algo
@@ -207,7 +199,7 @@ def test_reductions_2D_nans():
     reduction_2d_test(da.all, a, np.all, x, False, False)
 
     reduction_2d_test(da.nansum, a, np.nansum, x, False, False)
-    reduction_2d_test(da.nanprod, a, nanprod, x, False, False)
+    reduction_2d_test(da.nanprod, a, np.nanprod, x, False, False)
     reduction_2d_test(da.nanmean, a, np.nanmean, x, False, False)
     with pytest.warns(None):  # division by 0 warning
         reduction_2d_test(da.nanvar, a, np.nanvar, x, False, False)
@@ -287,7 +279,7 @@ def test_nan():
     assert_eq(np.nanstd(x, axis=0), da.nanstd(d, axis=0))
     assert_eq(np.nanargmin(x, axis=0), da.nanargmin(d, axis=0))
     assert_eq(np.nanargmax(x, axis=0), da.nanargmax(d, axis=0))
-    assert_eq(nanprod(x), da.nanprod(d))
+    assert_eq(np.nanprod(x), da.nanprod(d))
 
 
 @pytest.mark.skipif(np.__version__ < '1.13.0', reason='nanmax/nanmin for object dtype')

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -469,8 +469,6 @@ def test_bincount_raises_informative_error_on_missing_minlength_kwarg():
         assert False
 
 
-@pytest.mark.skipif(LooseVersion(np.__version__) < '1.10.0',
-                    reason="NumPy doesn't yet support nd digitize")
 def test_digitize():
     x = np.array([2, 4, 5, 6, 1])
     bins = np.array([1, 2, 3, 4, 5])

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -9,7 +9,7 @@ from dask.array.utils import assert_eq
 
 sparse = pytest.importorskip('sparse')
 
-if LooseVersion(np.__version__) < '1.11.0':
+if LooseVersion(np.__version__) < '1.11.2':
     pytestmark = pytest.mark.skip
 
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from distutils.version import LooseVersion
 import difflib
 import functools
 import math
@@ -14,23 +13,9 @@ from ..local import get_sync
 from ..sharedict import ShareDict
 
 
-if LooseVersion(np.__version__) >= '1.10.0':
-    _allclose = np.allclose
-else:
-    def _allclose(a, b, **kwargs):
-        if kwargs.pop('equal_nan', False):
-            a_nans = np.isnan(a)
-            b_nans = np.isnan(b)
-            if not (a_nans == b_nans).all():
-                return False
-            a = a[~a_nans]
-            b = b[~b_nans]
-        return np.allclose(a, b, **kwargs)
-
-
 def allclose(a, b, equal_nan=False, **kwargs):
     if getattr(a, 'dtype', None) != 'O':
-        return _allclose(a, b, equal_nan=equal_nan, **kwargs)
+        return np.allclose(a, b, equal_nan=equal_nan, **kwargs)
     if equal_nan:
         return (a.shape == b.shape and
                 all(np.isnan(b) if np.isnan(a) else a == b

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -12,7 +12,6 @@ except ImportError:
 
 from ..base import tokenize
 from .core import Array, normalize_chunks
-from .numpy_compat import full
 
 
 def wrap_func_shape_as_first_arg(func, *args, **kwargs):
@@ -68,4 +67,4 @@ w = wrap(wrap_func_shape_as_first_arg)
 ones = w(np.ones, dtype='f8')
 zeros = w(np.zeros, dtype='f8')
 empty = w(np.empty, dtype='f8')
-full = w(full)
+full = w(np.full)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,6 +1,7 @@
 import sys
-from operator import add
+from distutils.version import LooseVersion
 from itertools import product
+from operator import add
 
 import pandas as pd
 import pandas.util.testing as tm
@@ -331,24 +332,25 @@ def test_cumulative():
     assert_eq(ddf.cummin(axis=1), df.cummin(axis=1))
     assert_eq(ddf.cummax(axis=1), df.cummax(axis=1))
 
-    # testing out parameter
-    np.cumsum(ddf, out=ddf_out)
-    assert_eq(ddf_out, df.cumsum())
-    np.cumprod(ddf, out=ddf_out)
-    assert_eq(ddf_out, df.cumprod())
-    ddf.cummin(out=ddf_out)
-    assert_eq(ddf_out, df.cummin())
-    ddf.cummax(out=ddf_out)
-    assert_eq(ddf_out, df.cummax())
+    # testing out parameter if out parameter supported
+    if LooseVersion(np.__version__) >= '1.13.0':
+        np.cumsum(ddf, out=ddf_out)
+        assert_eq(ddf_out, df.cumsum())
+        np.cumprod(ddf, out=ddf_out)
+        assert_eq(ddf_out, df.cumprod())
+        ddf.cummin(out=ddf_out)
+        assert_eq(ddf_out, df.cummin())
+        ddf.cummax(out=ddf_out)
+        assert_eq(ddf_out, df.cummax())
 
-    np.cumsum(ddf, out=ddf_out, axis=1)
-    assert_eq(ddf_out, df.cumsum(axis=1))
-    np.cumprod(ddf, out=ddf_out, axis=1)
-    assert_eq(ddf_out, df.cumprod(axis=1))
-    ddf.cummin(out=ddf_out, axis=1)
-    assert_eq(ddf_out, df.cummin(axis=1))
-    ddf.cummax(out=ddf_out, axis=1)
-    assert_eq(ddf_out, df.cummax(axis=1))
+        np.cumsum(ddf, out=ddf_out, axis=1)
+        assert_eq(ddf_out, df.cumsum(axis=1))
+        np.cumprod(ddf, out=ddf_out, axis=1)
+        assert_eq(ddf_out, df.cumprod(axis=1))
+        ddf.cummin(out=ddf_out, axis=1)
+        assert_eq(ddf_out, df.cummin(axis=1))
+        ddf.cummax(out=ddf_out, axis=1)
+        assert_eq(ddf_out, df.cummax(axis=1))
 
     assert_eq(ddf.a.cumsum(), df.a.cumsum())
     assert_eq(ddf.a.cumprod(), df.a.cumprod())

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ import versioneer
 # NOTE: These are tested in `continuous_integration/travis/test_imports.sh` If
 # you modify these, make sure to change the corresponding line there.
 extras_require = {
-  'array': ['numpy >= 1.10.4', 'toolz >= 0.7.3'],
+  'array': ['numpy >= 1.11.0', 'toolz >= 0.7.3'],
   'bag': ['cloudpickle >= 0.2.1', 'toolz >= 0.7.3', 'partd >= 0.3.8'],
-  'dataframe': ['numpy >= 1.10.4', 'pandas >= 0.19.0', 'toolz >= 0.7.3',
+  'dataframe': ['numpy >= 1.11.0', 'pandas >= 0.19.0', 'toolz >= 0.7.3',
                 'partd >= 0.3.8', 'cloudpickle >= 0.2.1'],
   'distributed': ['distributed >= 1.21'],
   'delayed': ['toolz >= 0.7.3'],


### PR DESCRIPTION
Downstream libraries have bumped the minimum numpy version they support, and we should too.

Fixes #3427.
