### PR TITLE
DataFrame: index_bounds instead of divisions for better partition start/stop bounds

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1310,8 +1310,8 @@ class Bag(Base):
         dsk = self.__dask_optimize__(self.dask, self.__dask_keys__())
         dsk.update({(name, i): (to_dataframe, (self.name, i), cols, dtypes)
                     for i in range(self.npartitions)})
-        divisions = [None] * (self.npartitions + 1)
-        return dd.DataFrame(dsk, name, meta, divisions)
+        index_bounds = dd.IndexBounds((None,) * self.npartitions)
+        return dd.DataFrame(dsk, name, meta, index_bounds)
 
     def to_delayed(self, optimize_graph=True):
         """Convert into a list of ``dask.delayed`` objects, one per partition.

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -271,7 +271,7 @@ def test_parquet(s3, engine):
     assert 'part.0.parquet' in files
 
     df2 = dd.read_parquet(url, index='foo', engine=engine)
-    assert len(df2.divisions) > 1
+    assert len(df2.index_bounds) > 0
 
     pd.util.testing.assert_frame_equal(data, df2.compute())
 

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import print_function, division, absolute_import
 
 from .core import (DataFrame, Series, Index, _Frame, map_partitions,
-                   repartition, to_delayed, to_datetime, to_timedelta)
+                   repartition, to_delayed, to_datetime, to_timedelta,
+                   IndexBounds,
+                   )
 from .groupby import Aggregation
 from .io import (from_array, from_pandas, from_bcolz,
                  from_dask_array, read_hdf, read_sql_table,

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -742,11 +742,11 @@ class _GroupBy(object):
 
         if isinstance(self.index, list):
             do_index_partition_align = all(
-                item.divisions == df.divisions if isinstance(item, Series) else True
+                item.index_bounds == df.index_bounds if isinstance(item, Series) else True
                 for item in self.index
             )
         elif isinstance(self.index, Series):
-            do_index_partition_align = df.divisions == self.index.divisions
+            do_index_partition_align = df.index_bounds == self.index.index_bounds
         else:
             do_index_partition_align = True
 
@@ -864,7 +864,7 @@ class _GroupBy(object):
                                index, 0 if columns is None else columns,
                                aggregate, initial)
         return new_dd_object(merge(dask, cumpart_ext.dask, cumlast.dask),
-                             name, chunk(self._meta), self.obj.divisions)
+                             name, chunk(self._meta), self.obj.index_bounds)
 
     @derived_from(pd.core.groupby.GroupBy)
     def cumsum(self, axis=0):
@@ -1075,7 +1075,7 @@ class _GroupBy(object):
                                       "is currently not supported")
 
         df = self.obj
-        should_shuffle = not (df.known_divisions and
+        should_shuffle = not (df.known_bounds and
                               df._contains_index_name(self.index))
 
         if should_shuffle:

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -298,10 +298,10 @@ def test_read_csv_index():
                                           f.__dask_keys__(),
                                           get=dask.get)
         for i, block in enumerate(blocks):
-            if i < len(f.divisions) - 2:
-                assert (block.index < f.divisions[i + 1]).all()
-            if i > 0:
-                assert (block.index >= f.divisions[i]).all()
+            assert (block.index >= f.index_bounds[i].start).all()
+            assert (block.index <= f.index_bounds[i].stop).all()
+            if i < len(f.index_bounds) - 1:
+                assert (block.index < f.index_bounds[i + 1].start).all()
 
         expected = pd.read_csv(fn).set_index('amount')
         assert_eq(result, expected)

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -10,8 +10,8 @@ def test_make_timeseries():
     df = dd.demo.make_timeseries('2000', '2015', {'A': float, 'B': int, 'C': str},
                                  freq='2D', partition_freq='6M')
 
-    assert df.divisions[0] == pd.Timestamp('2000-01-31', freq='6M')
-    assert df.divisions[-1] == pd.Timestamp('2014-07-31', freq='6M')
+    assert df.index_bounds[0].start == pd.Timestamp('2000-01-31', freq='6M')
+    assert df.index_bounds[-1].stop == pd.Timestamp('2014-07-31', freq='6M')
     tm.assert_index_equal(df.columns, pd.Index(['A', 'B', 'C']))
     assert df['A'].head().dtype == float
     assert df['B'].head().dtype == int

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -442,7 +442,7 @@ def test_read_hdf_multiple():
         a.to_hdf(fn, '/data*')
         r = dd.read_hdf(fn, '/data*', sorted_index=True)
         assert a.npartitions == r.npartitions
-        assert a.divisions == r.divisions
+        assert a.index_bounds == r.index_bounds
         assert_eq(a, r)
 
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -107,7 +107,7 @@ def test_local(tmpdir, write_engine, read_engine):
 
     df2 = dd.read_parquet(tmp, index=False, engine=read_engine)
 
-    assert len(df2.divisions) > 1
+    assert len(df2.index_bounds) > 0
 
     out = df2.compute(get=dask.get).reset_index()
 

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -107,7 +107,7 @@ def test_simple(db):
 def test_npartitions(db):
     data = read_sql_table('test', db, columns=list(df.columns), npartitions=2,
                           index_col='number')
-    assert len(data.divisions) == 3
+    assert len(data.index_bounds) == 2
     assert (data.name.compute() == df.name).all()
     data = read_sql_table('test', db, columns=['name'], npartitions=6,
                           index_col="number")
@@ -157,7 +157,7 @@ def test_datetimes():
         df.to_sql('test', uri, index=False, if_exists='replace')
         data = read_sql_table('test', uri, npartitions=2, index_col='b')
         assert data.index.dtype.kind == "M"
-        assert data.divisions[0] == df.b.min()
+        assert data.index_bounds[0].start == df.b.min()
         df2 = df.set_index('b')
         assert_eq(data.map_partitions(lambda x: x.sort_index()),
                   df2.sort_index())
@@ -169,7 +169,7 @@ def test_with_func(db):
 
     # function for the index, get all columns
     data = read_sql_table('test', db, npartitions=2, index_col=index)
-    assert data.divisions[0] == 0
+    assert data.index_bounds[0].start == 0
     part = data.get_partition(0).compute()
     assert (part.index == 0).all()
 

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -137,7 +137,7 @@ def map_overlap(func, df, before, after, *args, **kwargs):
         dsk[(name, i)] = (overlap_chunk, func, prev, current, next, before,
                           after, args, kwargs)
 
-    return df._constructor(dsk, name, meta, df.divisions)
+    return df._constructor(dsk, name, meta, df.index_bounds)
 
 
 def _head_timedelta(current, next_, after):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3114,3 +3114,15 @@ def test_meta_raises():
         ddf.a + ddf.c
 
     assert "meta=" not in str(info.value)
+
+
+def test_part_concat():
+
+    # Should be able to get a partition(s) and stitch back together w/o
+    # breaking divisions
+    df = pd.DataFrame({"a": range(10)})
+    ddf = dd.from_pandas(df, npartitions=3)
+    assert_eq(
+        dd.concat([ddf.get_partition(i) for i in range(ddf.npartitions)]),
+        df
+    )

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -219,8 +219,8 @@ def test_dataframe_format_unknown_divisions():
                        'B': list('ABCDEFGH'),
                        'C': pd.Categorical(list('AAABBBCC'))})
     ddf = dd.from_pandas(df, 3)
-    ddf = ddf.clear_divisions()
-    assert not ddf.known_divisions
+    ddf = ddf.clear_index_bounds()
+    assert not ddf.known_bounds
 
     exp = ("Dask DataFrame Structure:\n"
            "                   A       B                C\n"

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1254,7 +1254,7 @@ def test_groupby_column_and_index_apply(group_args, apply_func):
     assert_eq(expected, result, check_divisions=False)
 
     # Check that partitioning is preserved
-    assert ddf.divisions == result.divisions
+    assert ddf.index_bounds == result.index_bounds
 
     # Check that no shuffling occurred.
     # The groupby operation should add only 1 task per partition
@@ -1265,7 +1265,7 @@ def test_groupby_column_and_index_apply(group_args, apply_func):
     assert_eq(expected, result, check_divisions=False)
 
     # Check that divisions were preserved (all None in this case)
-    assert ddf_no_divs.divisions == result.divisions
+    assert ddf_no_divs.index_bounds == result.index_bounds
 
     # Crude check to see if shuffling was performed.
     # The groupby operation should add only more than 1 task per partition

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -84,7 +84,7 @@ def _resample_bin_and_out_divs(divisions, rule, closed='left', label='left'):
 
 class Resampler(object):
     def __init__(self, obj, rule, **kwargs):
-        if not obj.known_divisions:
+        if not obj.known_bounds:
             msg = ("Can only resample dataframes with known divisions\n"
                    "See dask.pydata.org/en/latest/dataframe-design.html#partitions\n"
                    "for more information.")

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -32,10 +32,10 @@ def test_series_resample(obj, method, npartitions, freq, closed, label):
     expected = resample(ps, freq, how=method, closed=closed, label=label)
     assert_eq(result, expected, check_dtype=False)
 
-    divisions = result.divisions
+    bounds = result.index_bounds
 
-    assert expected.index[0] == divisions[0]
-    assert expected.index[-1] == divisions[-1]
+    assert expected.index[0] == bounds[0].start
+    assert expected.index[-1] == bounds[-1].stop
 
 
 def test_resample_agg():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -618,7 +618,7 @@ def assert_divisions(ddf):
         return
     if not hasattr(ddf, 'index'):
         return
-    if not ddf.known_divisions:
+    if not ddf.known_bounds:
         return
 
     def index(x):

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -9,7 +9,9 @@ from dask.sharedict import ShareDict
 from dask.utils import (takes_multiple_arguments, Dispatch, random_state_data,
                         memory_repr, methodcaller, M, skip_doctest,
                         SerializableLock, funcname, ndeepmap, ensure_dict,
-                        extra_titles, asciitable, itemgetter, partial_by_order)
+                        extra_titles, asciitable, itemgetter, partial_by_order,
+                        Interval,
+                        )
 from dask.utils_test import inc
 
 
@@ -316,3 +318,73 @@ def test_itemgetter():
 
 def test_partial_by_order():
     assert partial_by_order(5, function=operator.add, other=[(1, 20)]) == 25
+
+
+def test_intervals():
+    inc = Interval.inclusive(5, 10)
+    ex = Interval.exclusive(5, 10)
+    base_tests = [
+        (4, False),
+        (5, True),
+        (7, True),
+        (15, False),
+    ]
+    for test, expected in base_tests + [(10, True)]:
+        assert (test in inc) is expected
+
+    for test, expected in base_tests + [(10, False)]:
+        assert (test in ex) is expected
+
+    assert not inc.strict_lt(ex)
+
+    assert not Interval.inclusive(5, 10).strict_lt(Interval.inclusive(10, 15))
+    assert Interval.exclusive(5, 10).strict_lt(Interval.inclusive(10, 15))
+
+    # Range containment tests
+    assert Interval.inclusive(5, 10) in Interval.inclusive(0, 10)
+    assert Interval.exclusive(5, 10) in Interval.inclusive(5, 10)
+    assert Interval.exclusive(5, 10) in Interval.exclusive(0, 10)
+    assert not Interval.inclusive(5, 10) in Interval.exclusive(5, 10)
+
+    assert not Interval.inclusive(5, 10) in Interval.exclusive(0, 10)
+
+    assert not Interval.inclusive(0, 10) in Interval.inclusive(3, 7)
+
+    # Logic tests
+    assert not (inc & ex).closed
+    assert (Interval(5, 10, 1) & Interval(7, 11, 0)) == Interval.inclusive(7, 10)
+    assert (Interval(5, 10, 0) & Interval(7, 11, 1)) == Interval.exclusive(7, 10)
+    assert (Interval(5, 10, 1) & Interval(7, 9, 0)) == Interval.exclusive(7, 9)
+    assert not (Interval.inclusive(5, 10) & Interval.inclusive(10, 11)).empty()
+    assert (Interval.exclusive(5, 10) & Interval.inclusive(10, 11)).empty()
+    assert 10 in (Interval.inclusive(5, 10) & Interval.inclusive(10, 11))
+    assert (Interval.inclusive(5, 10) & Interval.inclusive(20, 30)).empty()
+
+    assert Interval.inclusive(5, 10).overlaps(Interval.inclusive(7, 10))
+    assert Interval.inclusive(5, 10).overlaps(Interval.inclusive(10, 10))
+    assert not Interval.exclusive(5, 10).overlaps(Interval.inclusive(10, 10))
+    assert not Interval.exclusive(5, 10).overlaps(Interval.inclusive(12, 12))
+
+    # Comparison tests
+    assert Interval.exclusive(0, 1) < Interval.inclusive(0, 1)
+    assert Interval.inclusive(0, 1) < Interval.exclusive(0, 2)
+    expected_order = [
+        Interval.exclusive(5, 10),
+        Interval.exclusive(7, 15),
+        9,
+        Interval.exclusive(10, 20),
+        Interval.inclusive(10, 20),
+        Interval.exclusive(12, 15),
+    ]
+    s = list(sorted(reversed(expected_order)))
+    assert expected_order == s
+
+    # Splitting
+    assert (Interval.exclusive(0, 5).split(3)) == (Interval.exclusive(0, 3), Interval.exclusive(3, 5))
+    assert (Interval.inclusive(0, 5).split(3)) == (Interval.exclusive(0, 3), Interval.inclusive(3, 5), )
+    assert (Interval.exclusive(0, 5).split(0)) == (Interval.exclusive(0, 5), )
+    assert (Interval.inclusive(0, 5).split(5)) == (Interval.inclusive(0, 5), )
+
+    for interval, split in [(Interval.inclusive(0, 1), -1), (Interval.exclusive(0, 1), 1)]:
+        with pytest.raises(ValueError):
+            interval.split(split)

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -321,8 +321,12 @@ def test_partial_by_order():
 
 
 def test_intervals():
-    inc = Interval.inclusive(5, 10)
-    ex = Interval.exclusive(5, 10)
+
+    # Shortcuts
+    inclusive = Interval.inclusive
+    exclusive = Interval.exclusive
+    inc = inclusive(5, 10)
+    ex = exclusive(5, 10)
     base_tests = [
         (4, False),
         (5, True),
@@ -337,54 +341,54 @@ def test_intervals():
 
     assert not inc.strict_lt(ex)
 
-    assert not Interval.inclusive(5, 10).strict_lt(Interval.inclusive(10, 15))
-    assert Interval.exclusive(5, 10).strict_lt(Interval.inclusive(10, 15))
+    assert not inclusive(5, 10).strict_lt(inclusive(10, 15))
+    assert exclusive(5, 10).strict_lt(inclusive(10, 15))
 
     # Range containment tests
-    assert Interval.inclusive(5, 10) in Interval.inclusive(0, 10)
-    assert Interval.exclusive(5, 10) in Interval.inclusive(5, 10)
-    assert Interval.exclusive(5, 10) in Interval.exclusive(0, 10)
-    assert not Interval.inclusive(5, 10) in Interval.exclusive(5, 10)
+    assert inclusive(5, 10) in inclusive(0, 10)
+    assert exclusive(5, 10) in inclusive(5, 10)
+    assert exclusive(5, 10) in exclusive(0, 10)
+    assert not inclusive(5, 10) in exclusive(5, 10)
 
-    assert not Interval.inclusive(5, 10) in Interval.exclusive(0, 10)
+    assert not inclusive(5, 10) in exclusive(0, 10)
 
-    assert not Interval.inclusive(0, 10) in Interval.inclusive(3, 7)
+    assert not inclusive(0, 10) in inclusive(3, 7)
 
     # Logic tests
     assert not (inc & ex).closed
-    assert (Interval(5, 10, 1) & Interval(7, 11, 0)) == Interval.inclusive(7, 10)
-    assert (Interval(5, 10, 0) & Interval(7, 11, 1)) == Interval.exclusive(7, 10)
-    assert (Interval(5, 10, 1) & Interval(7, 9, 0)) == Interval.exclusive(7, 9)
-    assert not (Interval.inclusive(5, 10) & Interval.inclusive(10, 11)).empty()
-    assert (Interval.exclusive(5, 10) & Interval.inclusive(10, 11)).empty()
-    assert 10 in (Interval.inclusive(5, 10) & Interval.inclusive(10, 11))
-    assert (Interval.inclusive(5, 10) & Interval.inclusive(20, 30)).empty()
+    assert (inclusive(5, 10) & exclusive(7, 11)) == inclusive(7, 10)
+    assert (exclusive(5, 10) & inclusive(7, 11)) == exclusive(7, 10)
+    assert (inclusive(5, 10) & exclusive(7, 9)) == exclusive(7, 9)
+    assert not (inclusive(5, 10) & inclusive(10, 11)).empty()
+    assert (exclusive(5, 10) & inclusive(10, 11)).empty()
+    assert 10 in (inclusive(5, 10) & inclusive(10, 11))
+    assert (inclusive(5, 10) & inclusive(20, 30)).empty()
 
-    assert Interval.inclusive(5, 10).overlaps(Interval.inclusive(7, 10))
-    assert Interval.inclusive(5, 10).overlaps(Interval.inclusive(10, 10))
-    assert not Interval.exclusive(5, 10).overlaps(Interval.inclusive(10, 10))
-    assert not Interval.exclusive(5, 10).overlaps(Interval.inclusive(12, 12))
+    assert inclusive(5, 10).overlaps(inclusive(7, 10))
+    assert inclusive(5, 10).overlaps(inclusive(10, 10))
+    assert not exclusive(5, 10).overlaps(inclusive(10, 10))
+    assert not exclusive(5, 10).overlaps(inclusive(12, 12))
 
     # Comparison tests
-    assert Interval.exclusive(0, 1) < Interval.inclusive(0, 1)
-    assert Interval.inclusive(0, 1) < Interval.exclusive(0, 2)
+    assert exclusive(0, 1) < inclusive(0, 1)
+    assert inclusive(0, 1) < exclusive(0, 2)
     expected_order = [
-        Interval.exclusive(5, 10),
-        Interval.exclusive(7, 15),
+        exclusive(5, 10),
+        exclusive(7, 15),
         9,
-        Interval.exclusive(10, 20),
-        Interval.inclusive(10, 20),
-        Interval.exclusive(12, 15),
+        exclusive(10, 20),
+        inclusive(10, 20),
+        exclusive(12, 15),
     ]
     s = list(sorted(reversed(expected_order)))
     assert expected_order == s
 
     # Splitting
-    assert (Interval.exclusive(0, 5).split(3)) == (Interval.exclusive(0, 3), Interval.exclusive(3, 5))
-    assert (Interval.inclusive(0, 5).split(3)) == (Interval.exclusive(0, 3), Interval.inclusive(3, 5), )
-    assert (Interval.exclusive(0, 5).split(0)) == (Interval.exclusive(0, 5), )
-    assert (Interval.inclusive(0, 5).split(5)) == (Interval.inclusive(0, 5), )
+    assert (exclusive(0, 5).split(3)) == (exclusive(0, 3), exclusive(3, 5))
+    assert (inclusive(0, 5).split(3)) == (exclusive(0, 3), inclusive(3, 5))
+    assert (exclusive(0, 5).split(0)) == (exclusive(0, 5), )
+    assert (inclusive(0, 5).split(5)) == (inclusive(0, 5), )
 
-    for interval, split in [(Interval.inclusive(0, 1), -1), (Interval.exclusive(0, 1), 1)]:
+    for interval, split in [(inclusive(0, 1), -1), (exclusive(0, 1), 1)]:
         with pytest.raises(ValueError):
             interval.split(split)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -910,13 +910,19 @@ class Interval(namedtuple('RawInterval', ['start', 'lopen', 'stop', 'rclosed']))
     part of the interval < a value, or all?  Stict tests for nonoverlapping
     comparisons are provided as separate methods (eg :meth:`self.strict_lt`).
 
-    :param start: smallest value in the interval (inclusive)
 
-    :param bool lopen: if the start value is open/exclusive start value
+    Parameters
+    ----------
 
-    :param stop: largest value in the interval
-
-    :param bool rclosed: if ```True```, the stop value is inclusive (a closed
+    start:
+        smallest value in the interval (inclusive).  May be any object that
+        supports comparisons like '<'
+    lopen: bool
+        if the start value is open/exclusive start value
+    stop:
+        largest value in the interval
+    rclosed: bool
+        if ```True```, the stop value is inclusive (a closed
         range).  Otherwise, the stop value is an open/exclusive max value and
         is not included in the interval
 
@@ -1008,6 +1014,9 @@ class Interval(namedtuple('RawInterval', ['start', 'lopen', 'stop', 'rclosed']))
         return self > other or self.start == other
 
     def __eq__(self, other):
+        if other is None:
+            return False
+
         if isinstance(other, Interval):
             return tuple(self) == tuple(other)
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -948,7 +948,7 @@ class Interval(namedtuple('RawInterval', ['start', 'lopen', 'stop', 'rclosed']))
     def _common_str(self, start, stop):
         return "{}{}{}, {}{}".format(
             self.__class__.__name__,
-            {False: '[', True: ')'}[self.lopen],
+            {False: '[', True: '('}[self.lopen],
             start,
             stop,
             {False: ')', True: ']'}[self.rclosed]


### PR DESCRIPTION
This is an implementation which should improve dask DataFrames (and Series) by granting them knowledge of the full index ranges within each partition, rather than how divisions act at the moment.

Divisions, as implemented, are problematic because they a) do not tell the maximum value w/in any given partition (just a less than bound) and b) are confusing and inconsistent since they do try to capture that value for the last partition only.  This implementation solves that by storing a start, stop boundary (as well as whether it is inclusive or exclusive) for each partition.  In all cases where a DF is created within the standard library (parquet, hdf, from_pandas, ... except maybe sql?) this information is already available without additional computation.

It is an implementation of #3384 (and inadvertently solves #3411 as it gives a cleaner way of slicing... and can be further improved)

Tests all seem to be passing (which weren't failing before, eg FFT) though many skip for me (hdfs, ...) so I would like to know if there are remaining issues.

I believe it is fully backwards compatible but will allow for a path to deprecate the use of `.divisions` as we see fit... the `IndexBounds` instance contains more information than divisions and therefore should always be able to recreate the previous behavior.

There are a number of functions that may be improved still w/ the greater amount of information which I did not touch much, such as the repartitioning utilities.  I have marked some with `# TODO`.

I have not yet done much documentation etc... can spend more time if this PR is desirable.  Since this is a rather large change (though most is refactoring) I would appreciate solid feedback before investing more time.

