### PR TITLE
Centralize configuration

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from . import config
 from .core import istask
 from .context import set_options
 from .local import get_sync as get

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -39,6 +39,7 @@ if PY3:
     from urllib.request import urlopen
     from urllib.parse import urlparse, urlsplit, quote, unquote
     FileNotFoundError = FileNotFoundError
+    FileExistsError = FileExistsError
     unicode = str
     string_types = (str,)
     long = int
@@ -85,6 +86,7 @@ else:
     reduce = reduce
     operator_div = operator.div
     FileNotFoundError = IOError
+    FileExistsError = OSError
 
     def _make_reraise():
         _code = ("def reraise(exc, tb=None):"

--- a/dask/config.py
+++ b/dask/config.py
@@ -147,7 +147,7 @@ def collect_env(env=os.environ):
     return result
 
 
-def ensure_config_file(
+def ensure_file(
         source,
         destination=os.path.join(os.path.expanduser('~'), '.config', 'dask'),
         comment=True):
@@ -260,7 +260,6 @@ def collect(paths=paths, env=os.environ):
     --------
     dask.config.refresh: collect configuration and update into primary config
     """
-    This returns
     configs = []
 
     if yaml:
@@ -274,6 +273,9 @@ def collect(paths=paths, env=os.environ):
 def refresh(config=config, **kwargs):
     """
     Update configuration by re-reading yaml files and env variables
+
+    This mutates the global dask.config.config, or the config parameter if
+    passed in.
 
     See Also
     --------

--- a/dask/config.py
+++ b/dask/config.py
@@ -231,12 +231,13 @@ def get(key, default=no_default, config=config):
 
 
 @contextmanager
-def set_config(arg=None, config=config, **kwargs):
+def set(arg=None, config=config, **kwargs):
     """ Temporarily set configuration values within a context manager
 
     Examples
     --------
-    >>> with set_config({'foo': 123}):
+    >>> import dask
+    >>> with dask.config.set({'foo': 123}):
     ...     pass
     """
     if arg and not kwargs:

--- a/dask/config.py
+++ b/dask/config.py
@@ -7,6 +7,9 @@ import sys
 from .compatibility import FileExistsError
 
 
+no_default = '__no_default__'
+
+
 config_paths = [
     '/etc/dask',
     os.path.join(sys.prefix, 'etc', 'dask'),
@@ -192,3 +195,34 @@ except ImportError:
 configs.append(collect_env())
 
 config = merge(*configs)
+
+
+def get(key, default=no_default, config=config):
+    """
+    Get elements from global config
+
+    Use '.' for nested access
+
+    Examples
+    --------
+    >>> from dask import config
+    >>> config.get('foo')
+    {'x': 1, 'y': 2}
+
+    >>> config.get('foo.x')
+    1
+
+    >>> config.get('foo.x.y', default=123)
+    123
+    """
+    keys = key.split('.')
+    result = config
+    for k in keys:
+        try:
+            result = result[k]
+        except (TypeError, IndexError, KeyError):
+            if default is not no_default:
+                return default
+            else:
+                raise
+    return result

--- a/dask/config.py
+++ b/dask/config.py
@@ -240,8 +240,9 @@ configs = []
 try:
     import yaml
 except ImportError:
-    pass
-else:
+    yaml == None
+
+if yaml:
     configs.extend(collect_yaml())
 
 configs.append(collect_env())

--- a/dask/config.py
+++ b/dask/config.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
 import ast
-from contextlib import contextmanager
 import copy
 import os
 import sys
@@ -264,3 +263,22 @@ class set(object):
     def __exit__(self, type, value, traceback):
         self.config.clear()
         self.config.update(self.old)
+
+
+def rename(aliases, config=config):
+    """ Rename old keys to new keys
+
+    This helps migrate older configuration versions over time
+    """
+    old = list()
+    new = dict()
+    for o, n in aliases.items():
+        value = get(o, None, config=config)
+        if value is not None:
+            old.append(o)
+            new[n] = value
+
+    for k in old:
+        del config[k]  # TODO: support nested keys
+
+    set(new, config=config)

--- a/dask/config.py
+++ b/dask/config.py
@@ -240,7 +240,7 @@ configs = []
 try:
     import yaml
 except ImportError:
-    yaml == None
+    yaml = None
 
 if yaml:
     configs.extend(collect_yaml())

--- a/dask/config.py
+++ b/dask/config.py
@@ -173,7 +173,7 @@ def ensure_config_file(
             lines = ['#' + line if line else line for line in lines]
 
         with open(tmp, 'w') as f:
-            f.write(os.linesep.join(lines))
+            f.write(''.join(lines))
 
         try:
             os.rename(tmp, destination)

--- a/dask/config.py
+++ b/dask/config.py
@@ -154,18 +154,23 @@ def ensure_config_file(
     comment: bool, True by default
         Whether or not to comment out the config file when copying
     """
+    if not os.path.exists(os.path.dirname(destination)):
+        os.makedirs(os.path.dirname(destination), exists_ok=True)
+
+    if os.path.isdir(destination):
+        _, filename = os.path.split(source)
+        destination = os.path.join(destination, filename)
+
     if not os.path.exists(destination):
-        if not os.path.exists(os.path.dirname(destination)):
-            os.makedirs(os.path.dirname(destination), exists_ok=True)
         # Atomically create destination.  Parallel testing discovered
         # a race condition where a process can be busy creating the
         # destination while another process reads an empty config file.
         tmp = '%s.tmp.%d' % (destination, os.getpid())
         with open(source) as f:
-            if comment:
-                lines = ['#' + line if line else line for line in f]
-            else:
-                lines = list(f)
+            lines = list(f)
+
+        if comment:
+            lines = ['#' + line if line else line for line in lines]
 
         with open(tmp, 'w') as f:
             f.write(os.linesep.join(lines))

--- a/dask/config.py
+++ b/dask/config.py
@@ -120,7 +120,7 @@ def collect_yaml(paths=paths):
     return configs
 
 
-def collect_env(env=os.environ):
+def collect_env(env=None):
     """ Collect config from environment variables
 
     This grabs environment variables of the form "DASK_FOO__BAR_BAZ=123" and
@@ -132,6 +132,8 @@ def collect_env(env=os.environ):
     -  Replaces ``_`` (underscore) with a hyphen.
     -  Calls ``ast.literal_eval`` on the value
     """
+    if env is None:
+        env = os.environ
     d = {}
     for name, value in env.items():
         if name.startswith('DASK_'):
@@ -240,7 +242,7 @@ class set(object):
         self.config.update(self.old)
 
 
-def collect(paths=paths, env=os.environ):
+def collect(paths=paths, env=None):
     """
     Collect configuration from paths and environment variables
 
@@ -260,6 +262,8 @@ def collect(paths=paths, env=os.environ):
     --------
     dask.config.refresh: collect configuration and update into primary config
     """
+    if os is None:
+        env = os.environ
     configs = []
 
     if yaml:

--- a/dask/config.py
+++ b/dask/config.py
@@ -136,7 +136,8 @@ def ensure_config_file(
         source,
         destination=os.path.join(os.path.expanduser('~'), '.config', 'dask'),
         comment=True):
-    """ Copy file to default location if it does not already exist
+    """
+    Copy file to default location if it does not already exist
 
     This tries to move a default configuration file to a default location if
     if does not already exist.  It also comments out that file by default.
@@ -154,12 +155,12 @@ def ensure_config_file(
     comment: bool, True by default
         Whether or not to comment out the config file when copying
     """
-    if not os.path.exists(os.path.dirname(destination)):
-        os.makedirs(os.path.dirname(destination), exists_ok=True)
-
-    if os.path.isdir(destination):
+    if not os.path.splitext(destination)[1].strip('.'):
         _, filename = os.path.split(source)
         destination = os.path.join(destination, filename)
+
+    if not os.path.exists(os.path.dirname(destination)):
+        os.makedirs(os.path.dirname(destination))
 
     if not os.path.exists(destination):
         # Atomically create destination.  Parallel testing discovered
@@ -170,7 +171,10 @@ def ensure_config_file(
             lines = list(f)
 
         if comment:
-            lines = ['#' + line if line else line for line in lines]
+            lines = ['# ' + line
+                     if line.strip() and not line.startswith('#')
+                     else line
+                     for line in lines]
 
         with open(tmp, 'w') as f:
             f.write(''.join(lines))

--- a/dask/config.py
+++ b/dask/config.py
@@ -1,0 +1,194 @@
+from __future__ import print_function, division, absolute_import
+
+from contextlib import contextmanager
+import os
+import sys
+
+from .compatibility import FileExistsError
+
+
+config_paths = [
+    '/etc/dask',
+    os.path.join(sys.prefix, 'etc', 'dask'),
+    os.path.join(os.path.expanduser('~'), '.config', 'dask'),
+    os.path.join(os.path.expanduser('~'), '.dask')
+]
+
+if 'DASK_CONFIG' in os.environ:
+    config_paths.append(os.environ['DASK_CONFIG'])
+
+
+def update(old, new):
+    """ Update a nested dictionary with values from another
+
+    This is like dict.update except that it smoothly merges nested values
+
+    This operates in-place and modifies old
+
+    Example
+    -------
+    >>> a = {'x': 1, 'y': {'a': 2}}
+    >>> b = {'y': {'b': 3}}
+    >>> update(a, b)
+    {'x': 1, 'y': {'a': 2, 'b': 3}}
+
+    See Also
+    --------
+    merge
+    """
+    for k, v in new.items():
+        if k not in old and type(v) is dict:
+            old[k] = {}
+
+        if type(v) is dict:
+            update(old[k], v)
+        else:
+            old[k] = v
+    return old
+
+
+def merge(*dicts):
+    """ Update a sequence of nested dictionaries
+
+    This prefers the values in the latter dictionaries to those in the former
+
+    Example
+    -------
+    >>> a = {'x': 1, 'y': {'a': 2}}
+    >>> b = {'y': {'b': 3}}
+    >>> merge(a, b)
+    {'x': 1, 'y': {'a': 2, 'b': 3}}
+
+    See Also
+    --------
+    update
+    """
+    result = {}
+    for d in dicts:
+        update(result, d)
+    return result
+
+
+def collect_yaml(paths=config_paths):
+    """ Collect configuration from yaml files
+
+    This searches through ``config_paths``, expands to find all yaml or json
+    files, and then parses each file.
+    """
+    # Find all paths
+    file_paths = []
+    for path in paths:
+        if os.path.exists(path):
+            if os.path.isdir(path):
+                file_paths.extend(sorted([
+                    p for p in os.listdir(path)
+                    if os.splitext(p)[1].lower() in ('json', 'yaml', 'yml')
+                ]))
+            else:
+                file_paths.append(path)
+
+    configs = []
+
+    # Parse yaml files
+    for path in file_paths:
+        with open(path) as f:
+            data = yaml.load(f.read() or {})
+            configs.append(data)
+
+    return configs
+
+
+def collect_env():
+    """ Collect config from environment variables
+
+    This grabs environment variables of the form "DASK_FOO_BAR=123"
+    and turns these into config variables of the form ``{"foo-bar": 123}``
+    """
+    env = {}
+    for name, value in os.environ.items():
+        if name.startswith('DASK_'):
+            varname = name[5:].lower().replace('_', '-')
+            env[varname] = _parse_env_value(value)
+
+    return env
+
+
+def _parse_env_value(value):
+    """ Convert a string to an integer, float or boolean (in that order) if possible. """
+    bools = {
+        'true': True,
+        'false': False
+    }
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return bools.get(value.lower(), value)
+
+
+def ensure_config_file(
+        source,
+        destination=os.path.join(os.path.expanduser('~'), '.config', 'dask')):
+    """ Copy file to default location if it does not already exist
+
+    This tries to move a default configuration files to a default location if
+    if does not already exist.
+
+    This is to be used by downstream modules (like dask.distributed) that may
+    have default configuration files that they wish to include in the default
+    configuration path.
+    """
+    if not os.path.exists(destination):
+        import shutil
+        if not os.path.exists(os.path.dirname(destination)):
+            try:
+                os.mkdir(os.path.dirname(destination))
+            except FileExistsError:
+                pass
+        # Atomically create destination.  Parallel testing discovered
+        # a race condition where a process can be busy creating the
+        # destination while another process reads an empty config file.
+        tmp = '%s.tmp.%d' % (destination, os.getpid())
+        shutil.copy(source, tmp)
+        try:
+            os.rename(tmp, destination)
+        except OSError:
+            os.remove(tmp)
+
+
+@contextmanager
+def set_config(arg=None, **kwargs):
+    if arg and not kwargs:
+        kwargs = arg
+    old = {}
+    for key in kwargs:
+        if key in config:
+            old[key] = config[key]
+
+    for key, value in kwargs.items():
+        config[key] = value
+
+    try:
+        yield
+    finally:
+        for key in kwargs:
+            if key in old:
+                config[key] = old[key]
+            else:
+                del config[key]
+
+
+configs = []
+
+try:
+    import yaml
+except ImportError:
+    configs.extend(collect_yaml())
+
+configs.append(collect_env())
+
+config = merge(*configs)

--- a/dask/config.py
+++ b/dask/config.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import ast
 from contextlib import contextmanager
+import copy
 import os
 import sys
 
@@ -232,10 +233,7 @@ def set_config(arg=None, config=config, **kwargs):
     if arg and not kwargs:
         kwargs = arg
 
-    old = {}
-    for key in kwargs:
-        if key in config:
-            old[key] = get(key)
+    old = copy.deepcopy(config)
 
     def assign(keys, value, d):
         key = keys[0]
@@ -252,8 +250,5 @@ def set_config(arg=None, config=config, **kwargs):
     try:
         yield
     finally:
-        for key in kwargs:
-            if key in old:
-                assign(key.split('.'), old[key], config)
-            else:
-                del config[key]
+        config.clear()
+        config.update(old)

--- a/dask/config.py
+++ b/dask/config.py
@@ -37,12 +37,12 @@ def update(old, new, priority='new'):
     -------
     >>> a = {'x': 1, 'y': {'a': 2}}
     >>> b = {'x': 2, 'y': {'b': 3}}
-    >>> update(a, b)
+    >>> update(a, b)  # doctest: +SKIP
     {'x': 2, 'y': {'a': 2, 'b': 3}}
 
     >>> a = {'x': 1, 'y': {'a': 2}}
     >>> b = {'x': 2, 'y': {'b': 3}}
-    >>> update(a, b, priority='old')
+    >>> update(a, b, priority='old')  # doctest: +SKIP
     {'x': 1, 'y': {'a': 2, 'b': 3}}
 
     See Also
@@ -71,7 +71,7 @@ def merge(*dicts):
     -------
     >>> a = {'x': 1, 'y': {'a': 2}}
     >>> b = {'y': {'b': 3}}
-    >>> merge(a, b)
+    >>> merge(a, b)  # doctest: +SKIP
     {'x': 1, 'y': {'a': 2, 'b': 3}}
 
     See Also

--- a/dask/config.py
+++ b/dask/config.py
@@ -33,8 +33,8 @@ def update(old, new, priority='new'):
         If new (default) then the new dictionary has preference.
         Otherwise the old dictionary does.
 
-    Example
-    -------
+    Examples
+    --------
     >>> a = {'x': 1, 'y': {'a': 2}}
     >>> b = {'x': 2, 'y': {'b': 3}}
     >>> update(a, b)  # doctest: +SKIP
@@ -47,7 +47,7 @@ def update(old, new, priority='new'):
 
     See Also
     --------
-    merge
+    dask.config.merge
     """
     for k, v in new.items():
         if k not in old and type(v) is dict:
@@ -67,8 +67,8 @@ def merge(*dicts):
 
     This prefers the values in the latter dictionaries to those in the former
 
-    Example
-    -------
+    Examples
+    --------
     >>> a = {'x': 1, 'y': {'a': 2}}
     >>> b = {'y': {'b': 3}}
     >>> merge(a, b)  # doctest: +SKIP
@@ -76,7 +76,7 @@ def merge(*dicts):
 
     See Also
     --------
-    update
+    dask.config.update
     """
     result = {}
     for d in dicts:
@@ -201,6 +201,10 @@ class set(object):
     >>> import dask
     >>> with dask.config.set({'foo': 123}):
     ...     pass
+
+    See Also
+    --------
+    dask.config.get
     """
     def __init__(self, arg=None, config=None, **kwargs):
         if config is None:
@@ -263,6 +267,10 @@ def get(key, default=no_default, config=config):
 
     >>> config.get('foo.x.y', default=123)  # doctest: +SKIP
     123
+
+    See Also
+    --------
+    dask.config.set
     """
     keys = key.split('.')
     result = config

--- a/dask/config.py
+++ b/dask/config.py
@@ -97,7 +97,7 @@ def collect_yaml(paths=config_paths):
             if os.path.isdir(path):
                 file_paths.extend(sorted([
                     p for p in os.listdir(path)
-                    if os.splitext(p)[1].lower() in ('json', 'yaml', 'yml')
+                    if os.path.splitext(p)[1].lower() in ('json', 'yaml', 'yml')
                 ]))
             else:
                 file_paths.append(path)
@@ -125,7 +125,7 @@ def collect_env():
             varname = name[5:].lower().replace('_', '-')
             try:
                 env[varname] = ast.literal_eval(value)
-            except ValueError:
+            except (SyntaxError, ValueError):
                 env[varname] = value
 
     return env
@@ -211,6 +211,8 @@ configs = []
 try:
     import yaml
 except ImportError:
+    pass
+else:
     configs.extend(collect_yaml())
 
 configs.append(collect_env())

--- a/dask/config.py
+++ b/dask/config.py
@@ -20,18 +20,29 @@ if 'DASK_CONFIG' in os.environ:
     config_paths.append(os.environ['DASK_CONFIG'])
 
 
-def update(old, new):
+def update(old, new, priority='new'):
     """ Update a nested dictionary with values from another
 
     This is like dict.update except that it smoothly merges nested values
 
     This operates in-place and modifies old
 
+    Parameters
+    ----------
+    priority: string {'old', 'new'}
+        If new (default) then the new dictionary has preference.
+        Otherwise the old dictionary does.
+
     Example
     -------
     >>> a = {'x': 1, 'y': {'a': 2}}
-    >>> b = {'y': {'b': 3}}
+    >>> b = {'x': 2, 'y': {'b': 3}}
     >>> update(a, b)
+    {'x': 2, 'y': {'a': 2, 'b': 3}}
+
+    >>> a = {'x': 1, 'y': {'a': 2}}
+    >>> b = {'x': 2, 'y': {'b': 3}}
+    >>> update(a, b, priority='old')
     {'x': 1, 'y': {'a': 2, 'b': 3}}
 
     See Also
@@ -43,9 +54,11 @@ def update(old, new):
             old[k] = {}
 
         if type(v) is dict:
-            update(old[k], v)
+            update(old[k], v, priority=priority)
         else:
-            old[k] = v
+            if priority == 'new' or k not in old:
+                old[k] = v
+
     return old
 
 
@@ -196,13 +209,13 @@ def get(key, default=no_default, config=config):
     Examples
     --------
     >>> from dask import config
-    >>> config.get('foo')
+    >>> config.get('foo')  # doctest: +SKIP
     {'x': 1, 'y': 2}
 
-    >>> config.get('foo.x')
+    >>> config.get('foo.x')  # doctest: +SKIP
     1
 
-    >>> config.get('foo.x.y', default=123)
+    >>> config.get('foo.x.y', default=123)  # doctest: +SKIP
     123
     """
     keys = key.split('.')

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -1,0 +1,58 @@
+from dask.utils import tmpfile
+from dask.config import merge, collect_yaml, collect_env
+import yaml
+import os
+
+
+def test_merge():
+    a = {'x': 1, 'y': {'a': 1}}
+    b = {'x': 2, 'z': 3, 'y': {'b': 2}}
+
+    expected = {
+        'x': 2,
+        'y': {'a': 1, 'b': 2},
+        'z': 3
+    }
+
+    c = merge(a, b)
+    assert c == expected
+
+
+def test_collect():
+    a = {'x': 1, 'y': {'a': 1}}
+    b = {'x': 2, 'z': 3, 'y': {'b': 2}}
+
+    expected = {
+        'x': 2,
+        'y': {'a': 1, 'b': 2},
+        'z': 3,
+    }
+
+    with tmpfile(extension='yaml') as fn1:
+        with tmpfile(extension='yaml') as fn2:
+            a = {'x': 1, 'y': {'a': 1}}
+            b = {'x': 2, 'z': 3, 'y': {'b': 2}}
+            with open(fn1, 'w') as f:
+                yaml.dump(a, f)
+            with open(fn2, 'w') as f:
+                yaml.dump(b, f)
+
+            config = merge(*collect_yaml(paths=[fn1, fn2]))
+            assert config == expected
+
+
+def test_env():
+    os.environ['DASK_A_B'] = '123'
+    os.environ['DASK_C'] = 'True'
+    os.environ['DASK_D'] = 'hello'
+    try:
+        env = collect_env()
+        assert env == {
+            'a-b': 123,
+            'c': True,
+            'd': 'hello'
+        }
+    finally:
+        del os.environ['DASK_A_B']
+        del os.environ['DASK_C']
+        del os.environ['DASK_D']

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -143,11 +143,13 @@ def test_set_config():
         assert config['abc'] == {'x': 1, 'y': 2, 'z': {'a': 3}}
 
 
-def test_ensure_config_file_directory():
+@pytest.mark.parametrize('mkdir', [True, False])
+def test_ensure_config_file_directory(mkdir):
     a = {'x': 1, 'y': {'a': 1}}
     with tmpfile(extension='yaml') as source:
         with tmpfile() as destination:
-            os.mkdir(destination)
+            if mkdir:
+                os.mkdir(destination)
             with open(source, 'w') as f:
                 yaml.dump(a, f)
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -137,3 +137,17 @@ def test_set_config():
 
     with set_config({'abc.x': 1, 'abc.y': 2, 'abc.z.a': 3}):
         assert config['abc'] == {'x': 1, 'y': 2, 'z': {'a': 3}}
+
+
+def test_ensure_config_file_directory():
+    a = {'x': 1, 'y': {'a': 1}}
+    with tmpfile(extension='yaml') as source:
+        with tmpfile() as destination:
+            os.mkdir(destination)
+            with open(source, 'w') as f:
+                yaml.dump(a, f)
+
+            ensure_config_file(source=source, destination=destination)
+            assert os.path.isdir(destination)
+            [fn] = os.listdir(destination)
+            assert os.path.split(fn)[1] == os.path.split(source)[1]

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -58,20 +58,26 @@ def test_collect():
 
 
 def test_env():
-    os.environ['DASK_A_B'] = '123'
-    os.environ['DASK_C'] = 'True'
-    os.environ['DASK_D'] = 'hello'
-    try:
-        env = collect_env()
-        assert env == {
-            'a-b': 123,
-            'c': True,
-            'd': 'hello'
-        }
-    finally:
-        del os.environ['DASK_A_B']
-        del os.environ['DASK_C']
-        del os.environ['DASK_D']
+    env = {'DASK_A_B': '123',
+           'DASK_C': 'True',
+           'DASK_D': 'hello',
+           'DASK_E__X': '123',
+           'DASK_E__Y': '456',
+           'DASK_F': '[1, 2, "3"]',
+           'DASK_G': '/not/parsable/as/literal',
+           'FOO': 'not included',
+           }
+
+    expected = {
+        'a-b': 123,
+        'c': True,
+        'd': 'hello',
+        'e': {'x': 123, 'y': 456},
+        'f': [1, 2, "3"],
+        'g': '/not/parsable/as/literal',
+    }
+
+    assert collect_env(env) == expected
 
 
 def test_get():

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -98,6 +98,10 @@ def test_ensure_config_file():
             with open(destination) as f:
                 result = yaml.load(f)
 
+            with open(source) as src:
+                with open(destination) as dst:
+                    assert src.read() == dst.read()
+
             assert result == a
 
             # don't overwrite old config files

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from dask.config import (update, merge, collect_yaml, collect_env, get,
-                         ensure_config_file, set, config, rename)
+                         ensure_file, set, config, rename)
 from dask.utils import tmpfile
 
 
@@ -90,7 +90,7 @@ def test_get():
         get('y.b', config=d)
 
 
-def test_ensure_config_file():
+def test_ensure_file():
     a = {'x': 1, 'y': {'a': 1}}
     b = {'x': 123}
 
@@ -99,7 +99,7 @@ def test_ensure_config_file():
             with open(source, 'w') as f:
                 yaml.dump(a, f)
 
-            ensure_config_file(source=source, destination=destination, comment=False)
+            ensure_file(source=source, destination=destination, comment=False)
 
             with open(destination) as f:
                 result = yaml.load(f)
@@ -113,7 +113,7 @@ def test_ensure_config_file():
             # don't overwrite old config files
             with open(source, 'w') as f:
                 yaml.dump(b, f)
-            ensure_config_file(source=source, destination=destination, comment=False)
+            ensure_file(source=source, destination=destination, comment=False)
             with open(destination) as f:
                 result = yaml.load(f)
 
@@ -122,7 +122,7 @@ def test_ensure_config_file():
             os.remove(destination)
 
             # Write again, now with comments
-            ensure_config_file(source=source, destination=destination, comment=True)
+            ensure_file(source=source, destination=destination, comment=True)
             with open(destination) as f:
                 text = f.read()
             assert '123' in text
@@ -154,7 +154,7 @@ def test_set():
 
 
 @pytest.mark.parametrize('mkdir', [True, False])
-def test_ensure_config_file_directory(mkdir):
+def test_ensure_file_directory(mkdir):
     a = {'x': 1, 'y': {'a': 1}}
     with tmpfile(extension='yaml') as source:
         with tmpfile() as destination:
@@ -163,7 +163,7 @@ def test_ensure_config_file_directory(mkdir):
             with open(source, 'w') as f:
                 yaml.dump(a, f)
 
-            ensure_config_file(source=source, destination=destination)
+            ensure_file(source=source, destination=destination)
             assert os.path.isdir(destination)
             [fn] = os.listdir(destination)
             assert os.path.split(fn)[1] == os.path.split(source)[1]

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -1,7 +1,10 @@
-from dask.utils import tmpfile
-from dask.config import merge, collect_yaml, collect_env
 import yaml
 import os
+
+import pytest
+
+from dask.config import merge, collect_yaml, collect_env, get
+from dask.utils import tmpfile
 
 
 def test_merge():
@@ -56,3 +59,13 @@ def test_env():
         del os.environ['DASK_A_B']
         del os.environ['DASK_C']
         del os.environ['DASK_D']
+
+
+def test_get():
+    d = {'x': 1, 'y': {'a': 2}}
+
+    assert get('x', config=d) == 1
+    assert get('y.a', config=d) == 2
+    assert get('y.b', 123, config=d) == 123
+    with pytest.raises(KeyError):
+        get('y.b', config=d)

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -142,6 +142,10 @@ def test_set():
     with set({'abc.x': 1, 'abc.y': 2, 'abc.z.a': 3}):
         assert config['abc'] == {'x': 1, 'y': 2, 'z': {'a': 3}}
 
+    d = {}
+    set({'abc.x': 123}, config=d)
+    assert d['abc']['x'] == 123
+
 
 @pytest.mark.parametrize('mkdir', [True, False])
 def test_ensure_config_file_directory(mkdir):

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -3,8 +3,21 @@ import os
 
 import pytest
 
-from dask.config import merge, collect_yaml, collect_env, get
+from dask.config import update, merge, collect_yaml, collect_env, get
 from dask.utils import tmpfile
+
+
+def test_update():
+    a = {'x': 1, 'y': {'a': 1}}
+    b = {'x': 2, 'z': 3, 'y': {'b': 2}}
+    update(b, a)
+    assert b == {'x': 1, 'y': {'a': 1, 'b': 2}, 'z': 3}
+
+    a = {'x': 1, 'y': {'a': 1}}
+    b = {'x': 2, 'z': 3, 'y': {'a': 3, 'b': 2}}
+    update(b, a, priority='old')
+    assert b == {'x': 2, 'y': {'a': 3, 'b': 2}, 'z': 3}
+
 
 
 def test_merge():

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from dask.config import (update, merge, collect_yaml, collect_env, get,
-                         ensure_config_file, set, config)
+                         ensure_config_file, set, config, rename)
 from dask.utils import tmpfile
 
 
@@ -161,3 +161,10 @@ def test_ensure_config_file_directory(mkdir):
             assert os.path.isdir(destination)
             [fn] = os.listdir(destination)
             assert os.path.split(fn)[1] == os.path.split(source)[1]
+
+
+def test_rename():
+    aliases = {'foo-bar': 'foo.bar'}
+    config = {'foo-bar': 123}
+    rename(aliases, config=config)
+    assert config == {'foo': {'bar': 123}}

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from dask.config import (update, merge, collect_yaml, collect_env, get,
-                         ensure_config_file, set_config, config)
+                         ensure_config_file, set, config)
 from dask.utils import tmpfile
 
 
@@ -127,19 +127,19 @@ def test_ensure_config_file():
             assert not result
 
 
-def test_set_config():
-    with set_config(abc=123):
+def test_set():
+    with set(abc=123):
         assert config['abc'] == 123
-        with set_config(abc=456):
+        with set(abc=456):
             assert config['abc'] == 456
         assert config['abc'] == 123
 
     assert 'abc' not in config
 
-    with set_config({'abc': 123}):
+    with set({'abc': 123}):
         assert config['abc'] == 123
 
-    with set_config({'abc.x': 1, 'abc.y': 2, 'abc.z.a': 3}):
+    with set({'abc.x': 1, 'abc.y': 2, 'abc.z.a': 3}):
         assert config['abc'] == {'x': 1, 'y': 2, 'z': {'a': 3}}
 
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from dask.config import (update, merge, collect_yaml, collect_env, get,
-        ensure_config_file)
+                         ensure_config_file, set_config, config)
 from dask.utils import tmpfile
 
 
@@ -18,7 +18,6 @@ def test_update():
     b = {'x': 2, 'z': 3, 'y': {'a': 3, 'b': 2}}
     update(b, a, priority='old')
     assert b == {'x': 2, 'y': {'a': 3, 'b': 2}, 'z': 3}
-
 
 
 def test_merge():
@@ -122,3 +121,19 @@ def test_ensure_config_file():
                 result = yaml.load(f)
 
             assert not result
+
+
+def test_set_config():
+    with set_config(abc=123):
+        assert config['abc'] == 123
+        with set_config(abc=456):
+            assert config['abc'] == 456
+        assert config['abc'] == 123
+
+    assert 'abc' not in config
+
+    with set_config({'abc': 123}):
+        assert config['abc'] == 123
+
+    with set_config({'abc.x': 1, 'abc.y': 2, 'abc.z.a': 3}):
+        assert config['abc'] == {'x': 1, 'y': 2, 'z': {'a': 3}}

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -2,14 +2,14 @@ Configuration
 =============
 
 Taking full advantage of Dask sometimes requires user configuration.
-This might be to control logging, specify cluster configuration, provide
-credentials for security, or any of several other options that arise in
+This might be to control logging verbosity, specify cluster configuration,
+provide credentials for security, or any of several other options that arise in
 production.
 
 Configuration is specified in one of the following ways:
 
 1.  YAML files in ``~/.config/dask/`` or ``/etc/dask/``
-2.  Environment variables like ``DASK_WORK_STEALING=True``
+2.  Environment variables like ``DASK_SCHEDULER__WORK_STEALING=True``
 3.  Default settings within sub-libraries
 
 This combination makes it easy to specify configuration in a variety of
@@ -20,10 +20,10 @@ docker images.
 Access Configuration
 --------------------
 
-.. currentmodule:: dask.config
+.. currentmodule:: dask
 
 .. autosummary::
-   get
+   dask.config.get
 
 Configuration is usually read by using the ``dask.config`` module, either with
 the ``config`` dictionary or the ``get`` function:
@@ -31,19 +31,23 @@ the ``config`` dictionary or the ``get`` function:
 .. code-block:: python
 
    >>> import dask
+   >>> import dask.distributed  # populate config with distributed defaults
    >>> dask.config.config
    {
-    'logging': {
-      'distributed': 'info',
-      'bokeh': 'critical',
-      'tornado': 'critical',
-      },
-    'work-stealing': True,
-    'log-format': '%(name)s - %(levelname)s - %(message)s'
+     'logging': {
+       'distributed': 'info',
+       'bokeh': 'critical',
+       'tornado': 'critical',
+     }
+     'admin': {
+       'log-format': '%(name)s - %(levelname)s - %(message)s'
+     }
    }
 
-   >>> dask.config.get('work-stealing')
-   True
+   >>> dask.config.get('logging')
+   {'distributed': 'info',
+    'bokeh': 'critical',
+    'tornado': 'critical'}
 
    >>> dask.config.get('logging.bokeh')  # use `.` for nested access
    'critical'
@@ -52,20 +56,24 @@ You may wish to inspect the ``dask.config.config`` dictionary to get a sense
 for what configuration is being used by your current system.
 
 
-Specify with YAML files
------------------------
+Specify Configuration
+---------------------
 
-Dask checks the following locations for configuration files:
+YAML files
+~~~~~~~~~~
 
-1.  ``~/.config/dask``
-3.  the ``{sys.executable}/etc/dask`` directory local to the Python executable
-4.  The root ``/etc/dask/`` directory
+It is common to specify configuration in YAML files any of a few possible
+locations:
 
-Within each of these directories it collects *all* YAML files and merges them
-together, preferring values according to the ordering in the list above (top
-takes precedence over bottom).  Additionally you can specify a path with the
-``DASK_CONFIG`` environment variable, that takes precedence at the top of the
-list above.
+1.  The ``~/.config/dask`` directory in the user's home directory
+2.  The ``{sys.executable}/etc/dask`` directory local to the Python executable
+3.  The root ``/etc/dask/`` directory
+
+Dask searches for *all* YAML files within each of these directories and merges
+them together, preferring configuration files closer to the user over system
+configuration files (preference follows the order in the list above).
+Additionally users can specify a path with the ``DASK_CONFIG`` environment
+variable, that takes precedence at the top of the list above.
 
 The contents of these YAML files are merged together, allowing different
 dask subprojects like ``dask-kubernetes`` or ``dask-ml`` to manage configuration
@@ -75,51 +83,119 @@ files separately, but have them merge into the same global configuration.
 config files.  This is deprecated and will soon be removed.*
 
 
-Specify with Environment Variables
-----------------------------------
+Environment Variables
+~~~~~~~~~~~~~~~~~~~~~
 
 You can also specify configuration values with environment variables like
 the following:
 
 .. code-block:: bash
 
-   export DASK_FOO_BAR=True
+   export DASK_SCHEDULER__WORK_STEALING=True
+   export DASK_SCHEDULER__ALLOWED_FAILURES=5
 
 resulting in configuration values like the following:
 
 .. code-block:: python
 
-   {'foo-bar': True}
+   {'scheduler': {'work-stealing': True, 'allowed-failures': 5}}
 
 Dask searches for all environment variables that start with ``DASK_``, then
-transforms keys by converting to lower case and changing underscores to
-hyphens.  Dask tries to parse all values with ``ast.literal_eval``, letting
-users pass numeric and boolean values (such as ``True`` in the example above)
-as well as lists, dictionaries, and so on with normal Python syntax.
+transforms keys by converting to lower case, changing double-underscores to
+nested structures, and changing single underscores to hyphens.
+
+Dask tries to parse all values with `ast.literal_eval
+<https://docs.python.org/3/library/ast.html#ast.literal_eval>`_, letting users
+pass numeric and boolean values (such as ``True`` in the example above) as well
+as lists, dictionaries, and so on with normal Python syntax.
 
 Environment variables take precedence over configuration values found in YAML
 files.
 
 
-Specify within Python
----------------------
+Defaults
+~~~~~~~~
+
+Additionally, individual subprojects may add their own default values when they
+are imported.  These are always added with lower priority than the YAML files
+or environment variables mentioned above
+
+.. code-block:: python
+
+   >>> import dask.config
+   >>> dask.config.config  # no configuration by default
+   {}
+
+   >>> import dask.distributed
+   >>> dask.config.config  # New values have been added
+   {'scheduler': ...,
+    'worker': ...,
+    'tls': ...}
+
+
+Directly within Python
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
-   set
+   dask.config.set
 
 Configuration is stored within a normal Python dictionary in
 ``dask.config.config`` and can be modified using normal Python operations.
 
 Additionally, you can temporarily set a configuration value using the
-``dask.config.set`` context manager.
+``dask.config.set`` function.  This function accepts a dictionary as an input
+and interprets ``"."`` as nested access
 
 .. code-block:: python
 
-   with dask.config.set({'work-stealing': False}):
+   >>> dask.config.set({'scheduler.work-stealing': True})
+
+This function can also be used as a context manager for consistent cleanup.
+
+.. code-block:: python
+
+   with dask.config.set({'scheduler.work-stealing': True}):
        ...
+
+
+Updating and Merging Configuration
+----------------------------------
+
+.. autosummary::
+   dask.config.merge
+   dask.config.update
+
+As described above, configuration can come from many places, including several
+YAML files, environment variables, and project defaults.  Each of these
+provides a configuration that is possibly nested like the following:
+
+.. code-block:: python
+
+   x = {'a': 0, 'c': {'d': 4}}
+   y = {'a': 1, 'b': 2, 'c': {'e': 5}}
+
+Dask will merge these configurations respecting nested data structures, and
+respecting order.
+
+.. code-block:: python
+
+   >>> dask.config.merge(x, y)
+   {'a': 1, 'b': 2, 'c': {'d': 4, 'e': 5}}
+
+You can also use the ``update`` function to update the existing configuration
+in place with a new configuration.  This can be done with priority being given
+to either config.  This is often used to update the global configuration in
+``dask.config.config``
+
+.. code-block:: python
+
+   dask.config.update(dask.config, new, priority='new')  # Give priority to new values
+   dask.config.update(dask.config, new, priority='old')  # Give priority to old values
 
 API
 ---
 
-.. autofunction:: get
-.. autofunction:: set
+.. autofunction:: dask.config.get
+.. autofunction:: dask.config.set
+.. autofunction:: dask.config.merge
+.. autofunction:: dask.config.update

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -73,7 +73,7 @@ the following:
 
 .. code-block:: bash
 
-   export DASK_FOO_BAR=true
+   export DASK_FOO_BAR=True
 
 resulting in configuration values like the following:
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -66,7 +66,7 @@ It is common to specify configuration in YAML files any of a few possible
 locations:
 
 1.  The ``~/.config/dask`` directory in the user's home directory
-2.  The ``{sys.executable}/etc/dask`` directory local to the Python executable
+2.  The ``{sys.prefix}/etc/dask`` directory local to Python
 3.  The root ``/etc/dask/`` directory
 
 Dask searches for *all* YAML files within each of these directories and merges

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,0 +1,108 @@
+Configuration
+=============
+
+Taking full advantage of Dask sometimes requires user configuration.
+This might be to control logging, specify cluster configuration, provide
+credentials for security, or any of several other options that arise in
+production.
+
+Configuration is usually specified either with YAML files in specific
+directories, like ``~/.config/dask/*.yaml``, or with environment variables like
+``DASK_WORK_STEALING=true``.  This combination makes it easy to specify
+configuration in a variety of settings.
+
+
+Access Configuration
+--------------------
+
+.. currentmodule:: dask.config
+
+.. autosummary::
+   get
+
+Configuration is usually read by using the ``dask.config`` module, either with
+the ``config`` dictionary or the ``get`` function
+
+.. code-block:: python
+
+   >>> from dask import config
+   >>> config.config
+   {
+    'logging': {
+      'distributed': 'info',
+      'bokeh': 'critical',
+      'tornado': 'critical',
+      },
+    'work-stealing': True,
+    'log-format': '%(name)s - %(levelname)s - %(message)s'
+   }
+
+   >>> config.get('logging.bokeh')
+   'critical'
+
+You may wish to inspect the ``dask.config.config`` dictionary to get a sense
+for what configuration is being used by your current system.
+
+
+Specify with YAML files
+-----------------------
+
+Dask checks the following locations for configuration files:
+
+1.  ``~/.config/dask``
+2.  ``~/.dask/`` (deprecated)
+3.  the ``/etc/dask`` directory local to the Python executable
+4.  The root ``/etc/dask/`` directory
+
+Within each of these directories it collects *all* YAML files and merges them
+together, preferring values according to the ordering in the list above (top
+takes precedence over bottom).  Additionally you can specify a path with the
+``DASK_CONFIG`` environment variable, that takes precedence at the top of the
+list above.
+
+The contents of these YAML files are merged together, allowing different
+dask subprojects like ``dask-kubernetes`` or ``dask-ml`` to manage configuration
+files separately, but have them merge into the same global configuration.
+
+
+Specify with Environment Variables
+----------------------------------
+
+You can also specify configuration values with environment variables like
+the following:
+
+.. code-block:: bash
+
+   export DASK_FOO_BAR=true
+
+resulting in configuration values like the following:
+
+.. code-block:: python
+
+   {'foo-bar': True}
+
+Dask searches for all environment variables that start with ``DASK_``, then
+transforms them by converting to lower case and changing underscores to
+hyphens.  Dask also parses numeric and boolean values if possible.
+
+Environment variables take precedence over configuration values found in YAML
+files.
+
+
+Specify within Python
+---------------------
+
+.. autosummary::
+   set_config
+
+Configuration is stored within a normal Python dictionary in
+``dask.config.config`` and can be modified using normal Python operations.
+
+Additionally, you can temporarily set a configuration value using the
+``set_config`` context manager.
+
+API
+---
+
+.. autofunction:: get
+.. autofunction:: set_config

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -9,7 +9,7 @@ production.
 Configuration is specified in one of the following ways:
 
 1.  YAML files in ``~/.config/dask/`` or ``/etc/dask/``
-2.  Environment variables like ``DASK_SCHEDULER__WORK_STEALING=True``
+2.  Environment variables like ``DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING=True``
 3.  Default settings within sub-libraries
 
 This combination makes it easy to specify configuration in a variety of
@@ -106,14 +106,19 @@ the following:
 
 .. code-block:: bash
 
-   export DASK_SCHEDULER__WORK_STEALING=True
-   export DASK_SCHEDULER__ALLOWED_FAILURES=5
+   export DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING=True
+   export DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES=5
 
 resulting in configuration values like the following:
 
 .. code-block:: python
 
-   {'scheduler': {'work-stealing': True, 'allowed-failures': 5}}
+   {'distributed':
+     {'scheduler':
+       {'work-stealing': True,
+        'allowed-failures': 5}
+     }
+   }
 
 Dask searches for all environment variables that start with ``DASK_``, then
 transforms keys by converting to lower case, changing double-underscores to

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -105,21 +105,21 @@ Specify within Python
 ---------------------
 
 .. autosummary::
-   set_config
+   set
 
 Configuration is stored within a normal Python dictionary in
 ``dask.config.config`` and can be modified using normal Python operations.
 
 Additionally, you can temporarily set a configuration value using the
-``set_config`` context manager.
+``dask.config.set`` context manager.
 
 .. code-block:: python
 
-   with dask.config.set_config({'work-stealing': False}):
+   with dask.config.set({'work-stealing': False}):
        ...
 
 API
 ---
 
 .. autofunction:: get
-.. autofunction:: set_config
+.. autofunction:: set

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -62,8 +62,23 @@ Specify Configuration
 YAML files
 ~~~~~~~~~~
 
-It is common to specify configuration in YAML files any of a few possible
-locations:
+You can specify configuration values in YAML files like the following:
+
+.. code-block:: yaml
+
+   logging:
+     distributed: info
+     bokeh: critical
+     tornado: critical
+
+   scheduler:
+     work-stealing: True
+     allowed-failures: 5
+
+    admin:
+      log-format: '%(name)s - %(levelname)s - %(message)s'
+
+These files can live in any of the following locations:
 
 1.  The ``~/.config/dask`` directory in the user's home directory
 2.  The ``{sys.prefix}/etc/dask`` directory local to Python

--- a/docs/source/docs.rst
+++ b/docs/source/docs.rst
@@ -245,6 +245,7 @@ often a better choice.  If you are a *core developer*, then you should start her
 
 * :doc:`develop`
 * :doc:`changelog`
+* :doc:`configuration`
 * :doc:`presentations`
 * :doc:`cheatsheet`
 * :doc:`spark`
@@ -262,6 +263,7 @@ often a better choice.  If you are a *core developer*, then you should start her
 
    develop.rst
    changelog.rst
+   configuration.rst
    presentations.rst
    cheatsheet.rst
    spark.rst


### PR DESCRIPTION
This creates a dask.config module to serve as central repository for all configuration in Dask and Dask sub-projects.  It includes utilities to find config files (in yaml format), parse environment variables, establish standardized locations for those files, and migrate configurations over time.

Fixes https://github.com/dask/dask/issues/3367

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
