### PR TITLE
Fixes Series comparison to NumPy scalars

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -344,8 +344,11 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
     def __array_ufunc__(self, numpy_ufunc, method, *inputs, **kwargs):
         out = kwargs.get('out', ())
         for x in inputs + out:
-            if not isinstance(x, (Number, Scalar, _Frame, Array,
-                                  pd.DataFrame, pd.Series, pd.Index)):
+            # Want to check for 0-dimensional arrays
+            if isinstance(x, np.ndarray) and x.shape == ():
+                continue
+            elif not isinstance(x, (Number, Scalar, _Frame, Array,
+                                    pd.DataFrame, pd.Series, pd.Index)):
                 return NotImplemented
 
         if method == '__call__':

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1754,7 +1754,10 @@ class Series(_Frame):
 
     def __array_wrap__(self, array, context=None):
         if isinstance(context, tuple) and len(context) > 0:
-            index = context[1][0].index
+            if isinstance(context[1][0], np.ndarray) and context[1][0].shape == ():
+                index = None
+            else:
+                index = context[1][0].index
 
         return pd.Series(array, index=index, name=self.name)
 
@@ -2314,7 +2317,10 @@ class DataFrame(_Frame):
 
     def __array_wrap__(self, array, context=None):
         if isinstance(context, tuple) and len(context) > 0:
-            index = context[1][0].index
+            if isinstance(context[1][0], np.ndarray) and context[1][0].shape == ():
+                index = None
+            else:
+                index = context[1][0].index
 
         return pd.DataFrame(array, index=index, columns=self.columns)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -344,7 +344,8 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
     def __array_ufunc__(self, numpy_ufunc, method, *inputs, **kwargs):
         out = kwargs.get('out', ())
         for x in inputs + out:
-            # Want to check for 0-dimensional arrays
+            # ufuncs work with 0-dimensional NumPy ndarrays
+            # so we don't want to raise NotImplemented
             if isinstance(x, np.ndarray) and x.shape == ():
                 continue
             elif not isinstance(x, (Number, Scalar, _Frame, Array,

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -374,3 +374,19 @@ def test_ufunc_with_reduction(redfunc, ufunc, pandas):
     with pytest.warns(None):
         assert isinstance(np_redfunc(dask), (dd.DataFrame, dd.Series, dd.core.Scalar))
         assert_eq(np_redfunc(np_ufunc(dask)), np_redfunc(np_ufunc(pandas)))
+
+
+@pytest.mark.parametrize('ufunc', ['greater', 'greater_equal', 'less', 'less_equal'])
+@pytest.mark.parametrize('pandas',
+                         [pd.Series(np.random.randint(1, 100, size=100)),
+                          pd.DataFrame({'A': np.random.randint(1, 100, size=20),
+                                        'B': np.random.randint(1, 100, size=20),
+                                        'C': np.abs(np.random.randn(20))})])
+@pytest.mark.parametrize('scalar', [15, 16.4, np.int64(15), np.float64(16.4)])
+def test_ufunc_numpy_scalar(ufunc, pandas, scalar):
+    # Regression test for issue #3392
+    dafunc = getattr(da, ufunc)
+    npfunc = getattr(np, ufunc)
+
+    dask = dd.from_pandas(pandas, 3)
+    assert_eq(dafunc(scalar, dask), npfunc(scalar, pandas))

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -376,17 +376,16 @@ def test_ufunc_with_reduction(redfunc, ufunc, pandas):
         assert_eq(np_redfunc(np_ufunc(dask)), np_redfunc(np_ufunc(pandas)))
 
 
-@pytest.mark.parametrize('ufunc', ['greater', 'greater_equal', 'less', 'less_equal'])
 @pytest.mark.parametrize('pandas',
                          [pd.Series(np.random.randint(1, 100, size=100)),
                           pd.DataFrame({'A': np.random.randint(1, 100, size=20),
                                         'B': np.random.randint(1, 100, size=20),
                                         'C': np.abs(np.random.randn(20))})])
 @pytest.mark.parametrize('scalar', [15, 16.4, np.int64(15), np.float64(16.4)])
-def test_ufunc_numpy_scalar(ufunc, pandas, scalar):
+def test_ufunc_numpy_scalar_comparison(pandas, scalar):
     # Regression test for issue #3392
-    dafunc = getattr(da, ufunc)
-    npfunc = getattr(np, ufunc)
 
-    dask = dd.from_pandas(pandas, 3)
-    assert_eq(dafunc(scalar, dask), npfunc(scalar, pandas))
+    dask_compare = scalar >= dd.from_pandas(pandas, npartitions=3)
+    pandas_compare = scalar >= pandas
+
+    assert_eq(dask_compare, pandas_compare)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -32,6 +32,7 @@ DataFrame
 - Provide more informative error message for meta= errors (:pr:`3343`) `Matthew Rocklin`_
 - add orc reader (:pr:`3284`) `Martin Durant`_
 - Default compression for parquet now always Snappy, in line with pandas (:pr:`3373`) `Martin Durant`_
+- Fixed bug in Dask DataFrame and Series comparisons with NumPy scalars (:pr:`3436`) `James Bourbeau`_
 
 Bag
 +++


### PR DESCRIPTION
Fixes #3392. This PR fixes Series comparison to NumPy scalars, which currently fail.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
