### PR TITLE
Remove outdated requirement from repartition docstring

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -939,8 +939,8 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
             List of partitions to be used. If specified npartitions will be
             ignored.
         npartitions : int, optional
-            Number of partitions of output, must be less than npartitions of
-            input. Only used if divisions isn't specified.
+            Number of partitions of output. Only used if divisions isn't
+            specified.
         freq : str, pd.Timedelta
             A period on which to partition timeseries data like ``'7D'`` or
             ``'12h'`` or ``pd.Timedelta(hours=12)``.  Assumes a datetime index.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,7 +23,7 @@ DataFrame
 +++++++++
 
 
-- Allow `t` as shorthand for `table` in `to_hdf` for pandas compatibility `Jörg Dietrich`_
+- Allow `t` as shorthand for `table` in `to_hdf` for pandas compatibility (:pr:`3330`) `Jörg Dietrich`_
 - Added top level `isna` method for Dask DataFrames (:pr:`3294`) `Christopher Ren`_
 - Fix selection on partition column on ``read_parquet`` for ``engine="pyarrow"`` (:pr:`3207`) `Uwe Korn`_
 - Added DataFrame.squeeze method (:pr:`3366`) `Christopher Ren`_
@@ -32,6 +32,7 @@ DataFrame
 - Provide more informative error message for meta= errors (:pr:`3343`) `Matthew Rocklin`_
 - add orc reader (:pr:`3284`) `Martin Durant`_
 - Default compression for parquet now always Snappy, in line with pandas (:pr:`3373`) `Martin Durant`_
+- Remove outdated requirement from repartition docstring (:pr:`3440`) `Jörg Dietrich`_
 
 Bag
 +++


### PR DESCRIPTION
Fixes #3439 

- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
