### PR TITLE
Support map_overlap on unspecified axes in depth and boundary

### DIFF
--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -361,7 +361,7 @@ def add_dummy_padding(x, depth, boundary):
     array([..., 0, 1, 2, 3, 4, 5, ...])
     """
     for k, v in boundary.items():
-        d = depth[k]
+        d = depth.get(k, 0)
         if v == 'none' and d > 0:
             empty_shape = list(x.shape)
             empty_shape[k] = d

--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -465,4 +465,5 @@ def coerce_boundary(ndim, boundary):
         boundary = (boundary,) * ndim
     if isinstance(boundary, tuple):
         boundary = dict(zip(range(ndim), boundary))
+
     return boundary

--- a/dask/array/tests/test_ghost.py
+++ b/dask/array/tests/test_ghost.py
@@ -195,8 +195,11 @@ def test_map_overlap():
     exp1 = d.map_overlap(lambda x: x + x.size, depth=1, dtype=d.dtype)
     exp2 = d.map_overlap(lambda x: x + x.size, depth={0: 1, 1: 1},
                          boundary={0: 'reflect', 1: 'none'}, dtype=d.dtype)
+    exp3 = d.map_overlap(lambda x: x + x.size, depth={1: 1},
+                         boundary={1: 'reflect'}, dtype=d.dtype)
     assert_eq(exp1, x + 16)
     assert_eq(exp2, x + 12)
+    assert_eq(exp3, x + 8)
 
 
 @pytest.mark.parametrize("boundary", [

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,7 @@ Array
 - The ``topk`` API has changed from topk(k, array) to the more conventional topk(array, k).
   The legacy API still works but is now deprecated. (:pr:`2965`) `Guido Imperiale`_
 - New function ``argtopk`` for Dask Arrays (:pr:`3396`) `Guido Imperiale`_
+- Fix handling partial depth and boundary in ``map_overlap`` (:pr:`3445`) `John A Kirkham`_
 
 DataFrame
 +++++++++


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/3444

Implements support in `map_overlap` for `depth` and `boundary` to leave out dimensions that are trivial (i.e. `0` or `none` respectively).

<hr>

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API