### PR TITLE
Replace get= with scheduler= keyword

### DIFF
--- a/dask/array/tests/test_ghost.py
+++ b/dask/array/tests/test_ghost.py
@@ -8,7 +8,6 @@ import dask.array as da
 from dask.array.ghost import (fractional_slice, getitem, trim_internal,
                               ghost_internal, nearest, constant, boundaries,
                               reflect, periodic, ghost)
-from dask.core import get
 from dask.array.utils import assert_eq, same_keys
 
 
@@ -31,7 +30,7 @@ def test_ghost_internal():
     d = da.from_array(x, chunks=(4, 4))
 
     g = ghost_internal(d, {0: 2, 1: 1})
-    result = g.compute(get=get)
+    result = g.compute(scheduler='sync')
     assert g.chunks == ((6, 6), (5, 5))
 
     expected = np.array([

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -7,7 +7,6 @@ import dask.array as da
 from dask.array.core import Array
 from dask.array.random import random, exponential, normal
 from dask.array.utils import assert_eq
-from dask.multiprocessing import get as mpget
 from dask.multiprocessing import _dumps, _loads
 
 
@@ -27,7 +26,7 @@ def test_concurrency():
 
     state = da.random.RandomState(5)
     y = state.normal(10, 1, size=10, chunks=2)
-    assert (x.compute(get=mpget) == y.compute(get=mpget)).all()
+    assert (x.compute(scheduler='processes') == y.compute(scheduler='processes')).all()
 
 
 def test_doc_randomstate():

--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -4,7 +4,6 @@ pytest.importorskip('numpy')
 from dask.array.wrap import ones
 import dask.array as da
 import numpy as np
-import dask
 
 
 def test_ones():
@@ -35,7 +34,7 @@ def test_full():
     a = da.full((3, 3), 100, chunks=(2, 2), dtype='i8')
 
     assert (a.compute() == 100).all()
-    assert a.dtype == a.compute(get=dask.get).dtype == 'i8'
+    assert a.dtype == a.compute(scheduler='sync').dtype == 'i8'
 
 
 def test_can_make_really_big_array_of_ones():

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -9,7 +9,6 @@ import numpy as np
 from toolz import frequencies, concat
 
 from .core import Array
-from ..local import get_sync
 from ..sharedict import ShareDict
 
 
@@ -63,7 +62,7 @@ def assert_eq(a, b, check_shape=True, **kwargs):
         assert a.dtype is not None
         adt = a.dtype
         _check_dsk(a.dask)
-        a = a.compute(get=get_sync)
+        a = a.compute(scheduler='sync')
         if hasattr(a, 'todense'):
             a = a.todense()
         if not hasattr(a, 'dtype'):
@@ -81,7 +80,7 @@ def assert_eq(a, b, check_shape=True, **kwargs):
         assert b.dtype is not None
         bdt = b.dtype
         _check_dsk(b.dask)
-        b = b.compute(get=get_sync)
+        b = b.compute(scheduler='sync')
         if not hasattr(b, 'dtype'):
             b = np.array(b, dtype='O')
         if hasattr(b, 'todense'):

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -134,8 +134,8 @@ def _to_textfiles_chunk(data, lazy_file):
 
 
 def to_textfiles(b, path, name_function=None, compression='infer',
-                 encoding=system_encoding, compute=True, get=None,
-                 storage_options=None):
+                 encoding=system_encoding, compute=True, storage_options=None,
+                 **kwargs):
     """ Write dask Bag to disk, one filename per partition, one line per element.
 
     **Paths**: This will create one file for each partition in your bag. You
@@ -200,7 +200,7 @@ def to_textfiles(b, path, name_function=None, compression='infer',
     out = type(b)(merge(dsk, b.dask), name, b.npartitions)
 
     if compute:
-        out.compute(get=get)
+        out.compute(**kwargs)
         return [f.path for f in files]
     else:
         return out.to_delayed()
@@ -691,10 +691,10 @@ class Bag(DaskMethodsMixin):
 
     @wraps(to_textfiles)
     def to_textfiles(self, path, name_function=None, compression='infer',
-                     encoding=system_encoding, compute=True, get=None,
-                     storage_options=None):
+                     encoding=system_encoding, compute=True,
+                     storage_options=None, **kwargs):
         return to_textfiles(self, path, name_function, compression, encoding,
-                            compute, get=get, storage_options=storage_options)
+                            compute, storage_options=storage_options, **kwargs)
 
     def fold(self, binop, combine=None, initial=no_default, split_every=None):
         """ Parallelizable reduction

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -34,9 +34,9 @@ b = Bag(dsk, 'x', 3)
 
 def assert_eq(a, b):
     if hasattr(a, 'compute'):
-        a = a.compute(get=dask.local.get_sync)
+        a = a.compute(scheduler='sync')
     if hasattr(b, 'compute'):
-        b = b.compute(get=dask.local.get_sync)
+        b = b.compute(scheduler='sync')
 
     assert a == b
 
@@ -138,7 +138,7 @@ def test_map_method():
     def vararg_inc(*args):
         return inc(*args)
 
-    assert b.map(vararg_inc).compute(get=dask.get) == list(map(inc, x))
+    assert_eq(b.map(vararg_inc), list(map(inc, x)))
 
 
 def test_starmap():
@@ -236,8 +236,7 @@ def test_fold():
     assert set(d.fold(lambda a, b: ''.join([a, b]), initial='').compute()) == set('hello')
 
     e = db.from_sequence([[1], [2], [3]], npartitions=2)
-    with dask.set_options(get=dask.get):
-        assert set(e.fold(add, initial=[]).compute()) == set([1, 2, 3])
+    assert set(e.fold(add, initial=[]).compute(scheduler='sync')) == set([1, 2, 3])
 
 
 def test_distinct():
@@ -264,7 +263,7 @@ def test_frequencies():
     assert dict(d) == dict(zip(range(10), [1] * 10))
     bag = db.from_sequence([0, 0, 0, 0], npartitions=4)
     bag2 = bag.filter(None).frequencies(split_every=2)
-    assert dict(bag2.compute(get=dask.get)) == {}
+    assert_eq(bag2, [])
 
 
 def test_topk():
@@ -338,9 +337,9 @@ def test_tree_reductions():
 def test_aggregation(npartitions):
     L = list(range(15))
     b = db.range(15, npartitions=npartitions)
-    assert b.mean().compute(get=dask.get) == sum(L) / len(L)
-    assert b.sum().compute(get=dask.get) == sum(L)
-    assert b.count().compute(get=dask.get) == len(L)
+    assert_eq(b.mean(), sum(L) / len(L))
+    assert_eq(b.sum(), sum(L))
+    assert_eq(b.count(), len(L))
 
 
 @pytest.mark.parametrize('npartitions', [1, 10])
@@ -348,17 +347,18 @@ def test_non_splittable_reductions(npartitions):
     np = pytest.importorskip('numpy')
     data = list(range(100))
     c = db.from_sequence(data, npartitions=npartitions)
-    assert c.mean().compute() == np.mean(data)
-    assert c.std().compute(get=dask.get) == np.std(data)
+
+    assert_eq(c.mean(), np.mean(data))
+    assert_eq(c.std(), np.std(data))
 
 
 def test_std():
-    assert b.std().compute(get=dask.get) == math.sqrt(2.0)
+    assert_eq(b.std(), math.sqrt(2.0))
     assert float(b.std()) == math.sqrt(2.0)
 
 
 def test_var():
-    assert b.var().compute(get=dask.get) == 2.0
+    assert_eq(b.var(), 2.0)
     assert float(b.var()) == 2.0
 
 
@@ -549,7 +549,7 @@ def test_take_npartitions():
 def test_take_npartitions_warn():
     # Use single-threaded scheduler so warnings are properly captured in the
     # same process
-    with dask.set_options(get=dask.get):
+    with dask.set_options(scheduler='sync'):
         with pytest.warns(UserWarning):
             b.take(100)
 
@@ -830,7 +830,7 @@ def test_to_textfiles(ext, myopen):
     b = db.from_sequence(['abc', '123', 'xyz'], npartitions=2)
     with tmpdir() as dir:
         c = b.to_textfiles(os.path.join(dir, '*.' + ext), compute=False)
-        dask.compute(*c, get=dask.get)
+        dask.compute(*c, scheduler='sync')
         assert os.path.exists(os.path.join(dir, '1.' + ext))
 
         f = myopen(os.path.join(dir, '1.' + ext), 'rb')
@@ -1049,7 +1049,7 @@ def test_from_delayed_iterator():
         bag.count(),
         bag.pluck('operations').count(),
         bag.pluck('operations').flatten().count(),
-        get=dask.get,
+        scheduler='sync',
     ) == (25, 25, 50)
 
 
@@ -1077,7 +1077,7 @@ def test_repartition(nin, nout):
     c = b.repartition(npartitions=nout)
 
     assert c.npartitions == nout
-    assert b.compute(get=dask.get) == c.compute(get=dask.get)
+    assert_eq(b, c)
     results = dask.get(c.dask, c.__dask_keys__())
     assert all(results)
 
@@ -1158,14 +1158,14 @@ def test_groupby_tasks_names():
 def test_groupby_tasks_2(size, npartitions, groups):
     func = lambda x: x % groups
     b = db.range(size, npartitions=npartitions).groupby(func, method='tasks')
-    result = b.compute(get=dask.get)
+    result = b.compute(scheduler='sync')
     assert dict(result) == groupby(func, range(size))
 
 
 def test_groupby_tasks_3():
     func = lambda x: x % 10
     b = db.range(20, npartitions=5).groupby(func, method='tasks', max_branch=2)
-    result = b.compute(get=dask.get)
+    result = b.compute(scheduler='sync')
     assert dict(result) == groupby(func, range(20))
     # assert b.npartitions == 5
 
@@ -1179,19 +1179,19 @@ def test_to_textfiles_empty_partitions():
 
 def test_reduction_empty():
     b = db.from_sequence(range(10), npartitions=100)
-    assert b.filter(lambda x: x % 2 == 0).max().compute(get=dask.get) == 8
-    assert b.filter(lambda x: x % 2 == 0).min().compute(get=dask.get) == 0
+    assert_eq(b.filter(lambda x: x % 2 == 0).max(), 8)
+    assert_eq(b.filter(lambda x: x % 2 == 0).min(), 0)
 
 
 @pytest.mark.parametrize('npartitions', [1, 2, 4])
 def test_reduction_empty_aggregate(npartitions):
     b = db.from_sequence([0, 0, 0, 1], npartitions=npartitions).filter(None)
-    assert b.min(split_every=2).compute(get=dask.get) == 1
-    vals = db.compute(b.min(split_every=2), b.max(split_every=2), get=dask.get)
+    assert_eq(b.min(split_every=2), 1)
+    vals = db.compute(b.min(split_every=2), b.max(split_every=2), scheduler='sync')
     assert vals == (1, 1)
     with pytest.raises(ValueError):
         b = db.from_sequence([0, 0, 0, 0], npartitions=npartitions)
-        b.filter(None).min(split_every=2).compute(get=dask.get)
+        b.filter(None).min(split_every=2).compute(scheduler='sync')
 
 
 class StrictReal(int):
@@ -1206,7 +1206,7 @@ class StrictReal(int):
 
 def test_reduction_with_non_comparable_objects():
     b = db.from_sequence([StrictReal(x) for x in range(10)], partition_size=2)
-    assert b.fold(max, max).compute(get=dask.get) == StrictReal(9)
+    assert_eq(b.fold(max, max), StrictReal(9))
 
 
 def test_reduction_with_sparse_matrices():
@@ -1216,7 +1216,7 @@ def test_reduction_with_sparse_matrices():
     def sp_reduce(a, b):
         return sp.vstack([a, b])
 
-    assert b.fold(sp_reduce, sp_reduce).compute(get=dask.get).shape == (4, 1)
+    assert b.fold(sp_reduce, sp_reduce).compute(scheduler='sync').shape == (4, 1)
 
 
 def test_empty():
@@ -1237,14 +1237,14 @@ def test_bag_picklable():
 
 def test_msgpack_unicode():
     b = db.from_sequence([{"a": 1}]).groupby("a")
-    result = b.compute(get=dask.get)
+    result = b.compute(scheduler='sync')
     assert dict(result) == {1: [{'a': 1}]}
 
 
 def test_bag_with_single_callable():
     f = lambda: None
     b = db.from_sequence([f])
-    assert list(b.compute(get=dask.get)) == [f]
+    assert_eq(b, [f])
 
 
 def test_optimize_fuse_keys():
@@ -1276,7 +1276,7 @@ def test_reductions_are_lazy():
 
     res = b.reduction(func, sum)
 
-    assert res.compute(get=dask.get) == sum(range(10))
+    assert_eq(res, sum(range(10)))
 
 
 def test_repeated_groupby():
@@ -1296,10 +1296,10 @@ def test_temporary_directory(tmpdir):
 
 def test_empty_bag():
     b = db.from_sequence([])
-    assert b.map(inc).all().compute(get=dask.get)
-    assert not b.map(inc).any().compute(get=dask.get)
-    assert not b.map(inc).sum().compute(get=dask.get)
-    assert not b.map(inc).count().compute(get=dask.get)
+    assert_eq(b.map(inc).all(), True)
+    assert_eq(b.map(inc).any(), False)
+    assert_eq(b.map(inc).sum(), False)
+    assert_eq(b.map(inc).count(), False)
 
 
 def test_bag_paths():

--- a/dask/bag/tests/test_text.py
+++ b/dask/bag/tests/test_text.py
@@ -3,12 +3,12 @@ from __future__ import print_function, division, absolute_import
 import pytest
 from toolz import partial
 
-from dask import compute, get
+from dask import compute
 from dask.utils import filetexts
 from dask.bytes import compression
 from dask.bag.text import read_text
 
-compute = partial(compute, get=get)
+compute = partial(compute, scheduler='sync')
 
 
 files = {'.test.accounts.1.json':  ('{"amount": 100, "name": "Alice"}\n'
@@ -58,5 +58,5 @@ def test_errors():
             read_text('.test.foo', encoding='ascii').compute()
 
         result = read_text('.test.foo', encoding='ascii', errors='ignore')
-        result = result.compute(get=get)
+        result = result.compute(scheduler='sync')
         assert result == ['Jos\n', 'Alice']

--- a/dask/base.py
+++ b/dask/base.py
@@ -107,7 +107,7 @@ class DaskMethodsMixin(object):
 
         Parameters
         ----------
-        scheduler: string, optional
+        scheduler : string, optional
             Which scheduler to use like "threads", "synchronous" or "processes".
             If not provided, the default is to check the global settings first,
             and then fall back to the collection defaults.
@@ -138,7 +138,7 @@ class DaskMethodsMixin(object):
 
         Parameters
         ----------
-        scheduler: string, optional
+        scheduler : string, optional
             Which scheduler to use like "threads", "synchronous" or "processes".
             If not provided, the default is to check the global settings first,
             and then fall back to the collection defaults.
@@ -358,7 +358,7 @@ def compute(*args, **kwargs):
         objects passed to ``compute``. For large collections this can be
         expensive. If none of the arguments contain any dask objects, set
         ``traverse=False`` to avoid doing this traversal.
-    scheduler: string, optional
+    scheduler : string, optional
         Which scheduler to use like "threads", "synchronous" or "processes".
         If not provided, the default is to check the global settings first,
         and then fall back to the collection defaults.
@@ -524,7 +524,7 @@ def persist(*args, **kwargs):
     Parameters
     ----------
     *args: Dask collections
-    scheduler: string, optional
+    scheduler : string, optional
         Which scheduler to use like "threads", "synchronous" or "processes".
         If not provided, the default is to check the global settings first,
         and then fall back to the collection defaults.
@@ -806,7 +806,7 @@ named_schedulers = {
     'synchronous': local.get_sync,
     'single-threaded': local.get_sync,
     'threads': threaded.get,
-    'threaded': threaded.get,
+    'threading': threaded.get,
 }
 
 try:

--- a/dask/base.py
+++ b/dask/base.py
@@ -9,6 +9,7 @@ import pickle
 import os
 import threading
 import uuid
+import warnings
 
 from toolz import merge, groupby, curry, identity
 from toolz.functoolz import Compose
@@ -824,6 +825,10 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
     if get is not None:
         if scheduler is not None:
             raise ValueError("Both get= and scheduler= provided.  Choose one")
+        warnings.warn("The get= keyword has been deprecated. "
+                      "Please use the scheduler= keyword instead with the "
+                      "name of the desired scheduler "
+                      "like 'threads' or 'processes'")
         return get
 
     if scheduler is not None:

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -8,7 +8,7 @@ import sys
 import pytest
 from toolz import concat, valmap, partial
 
-from dask import compute, get
+from dask import compute
 from dask.compatibility import FileNotFoundError, unicode
 from dask.utils import filetexts
 from dask.bytes import compression
@@ -17,7 +17,7 @@ from dask.bytes.core import (read_bytes, open_files, FileSystem,
                              get_pyarrow_filesystem, logical_size,
                              get_fs_token_paths)
 
-compute = partial(compute, get=get)
+compute = partial(compute, scheduler='sync')
 
 files = {'.test.accounts.1.json': (b'{"amount": 100, "name": "Alice"}\n'
                                    b'{"amount": 200, "name": "Bob"}\n'

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -12,13 +12,13 @@ httpretty = pytest.importorskip('httpretty')
 
 from toolz import concat, valmap, partial
 
-from dask import compute, get
+from dask import compute
 from dask.bytes.s3 import DaskS3FileSystem
 from dask.bytes.core import read_bytes, open_files, get_pyarrow_filesystem
 from dask.bytes.compression import compress, files as compress_files, seekable_files
 
 
-compute = partial(compute, get=get)
+compute = partial(compute, scheduler='sync')
 
 
 test_bucket_name = 'test'
@@ -244,7 +244,7 @@ def test_read_text_passes_through_options():
     db = pytest.importorskip('dask.bag')
     with s3_context('csv', {'a.csv': b'a,b\n1,2\n3,4'}) as s3:
         df = db.read_text('s3://csv/*.csv', storage_options={'s3': s3})
-        assert df.count().compute(get=get) == 3
+        assert df.count().compute(scheduler='sync') == 3
 
 
 @pytest.mark.parametrize("engine", ['pyarrow', 'fastparquet'])

--- a/dask/context.py
+++ b/dask/context.py
@@ -32,8 +32,8 @@ class set_options(object):
 
     Examples
     --------
-    >>> with set_options(get=dask.get):  # doctest: +SKIP
-    ...     x = np.array(x)  # uses dask.get internally
+    >>> with set_options(scheduler='single-threaded'):  # doctest: +SKIP
+    ...     x = np.array(x)  # uses single-threaded scheduler internally
     """
     def __init__(self, **kwargs):
         self.old = _globals.copy()

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1056,10 +1056,10 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         return new_dd_object(merge(self.dask, dsk), name,
                              self._meta, self.divisions)
 
-    def to_hdf(self, path_or_buf, key, mode='a', append=False, get=None, **kwargs):
+    def to_hdf(self, path_or_buf, key, mode='a', append=False, **kwargs):
         """ See dd.to_hdf docstring for more information """
         from .io import to_hdf
-        return to_hdf(self, path_or_buf, key, mode, append, get=get, **kwargs)
+        return to_hdf(self, path_or_buf, key, mode, append, **kwargs)
 
     def to_parquet(self, path, *args, **kwargs):
         """ See dd.to_parquet docstring for more information """

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -440,7 +440,7 @@ def _to_csv_chunk(df, fil, **kwargs):
 
 
 def to_csv(df, filename, name_function=None, compression=None, compute=True,
-           get=None, storage_options=None, **kwargs):
+           get=None, scheduler=None, storage_options=None, **kwargs):
     """
     Store Dask DataFrame to CSV files
 
@@ -574,7 +574,7 @@ def to_csv(df, filename, name_function=None, compression=None, compute=True,
               for d, f in zip(df.to_delayed(), files)]
 
     if compute:
-        delayed(values).compute(get=get)
+        delayed(values).compute(get=get, scheduler=scheduler)
         return [f.path for f in files]
     else:
         return values

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -10,6 +10,7 @@ import pandas as pd
 from toolz import merge
 
 from .io import _link
+from ...base import get_scheduler
 from ..core import DataFrame, new_dd_object
 from ... import multiprocessing
 from ...base import tokenize, compute_as_if_collection
@@ -17,8 +18,7 @@ from ...bytes.utils import build_name_function
 from ...compatibility import PY3
 from ...context import _globals
 from ...delayed import Delayed, delayed
-from ...local import get_sync
-from ...utils import effective_get, get_scheduler_lock
+from ...utils import get_scheduler_lock
 
 
 def _pd_to_hdf(pd_to_hdf, lock, args, kwargs=None):
@@ -35,7 +35,7 @@ def _pd_to_hdf(pd_to_hdf, lock, args, kwargs=None):
     return None
 
 
-def to_hdf(df, path, key, mode='a', append=False, get=None,
+def to_hdf(df, path, key, mode='a', append=False, get=None, scheduler=None,
            name_function=None, compute=True, lock=None, dask_kwargs={},
            **kwargs):
     """ Store Dask Dataframe to Hierarchical Data Format (HDF) files
@@ -93,7 +93,7 @@ def to_hdf(df, path, key, mode='a', append=False, get=None,
 
     Save data to multiple files, using the multiprocessing scheduler:
 
-    >>> df.to_hdf('output-*.hdf', '/data', get=dask.multiprocessing.get) # doctest: +SKIP
+    >>> df.to_hdf('output-*.hdf', '/data', scheduler='processes') # doctest: +SKIP
 
     Specify custom naming scheme.  This writes files as
     '2000-01-01.hdf', '2000-01-02.hdf', '2000-01-03.hdf', etc..
@@ -162,11 +162,15 @@ def to_hdf(df, path, key, mode='a', append=False, get=None,
 
     # If user did not specify scheduler and write is sequential default to the
     # sequential scheduler. otherwise let the _get method choose the scheduler
-    if get is None and 'get' not in _globals and single_node and single_file:
-        get = get_sync
+    if (get is None and
+            'get' not in _globals and
+            scheduler is None and
+            'scheduler' not in _globals and
+            single_node and single_file):
+        scheduler = 'single-threaded'
 
     # handle lock default based on whether we're writing to a single entity
-    _actual_get = effective_get(get, df)
+    _actual_get = get_scheduler(get=get, collections=[df], scheduler=scheduler)
     if lock is None:
         if not single_node:
             lock = True
@@ -177,7 +181,7 @@ def to_hdf(df, path, key, mode='a', append=False, get=None,
         else:
             lock = False
     if lock:
-        lock = get_scheduler_lock(get, df)
+        lock = get_scheduler_lock(get, df, scheduler=scheduler)
 
     kwargs.update({'format': 'table', 'mode': mode, 'append': append})
 
@@ -216,7 +220,8 @@ def to_hdf(df, path, key, mode='a', append=False, get=None,
         keys = [(name, i) for i in range(df.npartitions)]
 
     if compute:
-        compute_as_if_collection(DataFrame, dsk, keys, get=get, **dask_kwargs)
+        compute_as_if_collection(DataFrame, dsk, keys, get=get,
+                                 scheduler=scheduler, **dask_kwargs)
         return filenames
     else:
         return delayed([Delayed(k, dsk) for k in keys])

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -313,11 +313,9 @@ def test_to_hdf_exceptions():
                 a.to_hdf(hdf, '/data_*_*')
 
 
-@pytest.mark.parametrize('get', [dask.get,
-                                 dask.threaded.get,
-                                 dask.multiprocessing.get])
+@pytest.mark.parametrize('scheduler', ['sync', 'threads', 'processes'])
 @pytest.mark.parametrize('npartitions', [1, 4, 10])
-def test_to_hdf_schedulers(get, npartitions):
+def test_to_hdf_schedulers(scheduler, npartitions):
     pytest.importorskip('tables')
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'],
                        'y': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]},
@@ -326,20 +324,20 @@ def test_to_hdf_schedulers(get, npartitions):
 
     # test single file single node
     with tmpfile('h5') as fn:
-        a.to_hdf(fn, '/data', get=get)
+        a.to_hdf(fn, '/data', scheduler=scheduler)
         out = pd.read_hdf(fn, '/data')
         assert_eq(df, out)
 
     # test multiple files single node
     with tmpdir() as dn:
         fn = os.path.join(dn, 'data_*.h5')
-        a.to_hdf(fn, '/data', get=get)
+        a.to_hdf(fn, '/data', scheduler=scheduler)
         out = dd.read_hdf(fn, '/data')
         assert_eq(df, out)
 
     # test single file multiple nodes
     with tmpfile('h5') as fn:
-        a.to_hdf(fn, '/data*', get=get)
+        a.to_hdf(fn, '/data*', scheduler=scheduler)
         out = dd.read_hdf(fn, '/data*')
         assert_eq(df, out)
 
@@ -476,7 +474,7 @@ def test_hdf_globbing():
         df.to_hdf(os.path.join(tdir, 'two.h5'), '/bar/data', format='table')
         df.to_hdf(os.path.join(tdir, 'two.h5'), '/foo/data', format='table')
 
-        with dask.set_options(get=dask.get):
+        with dask.set_options(scheduler='sync'):
             res = dd.read_hdf(os.path.join(tdir, 'one.h5'), '/*/data',
                               chunksize=2)
             assert res.npartitions == 2
@@ -510,7 +508,7 @@ def test_hdf_file_list():
         df.iloc[:2].to_hdf(os.path.join(tdir, 'one.h5'), 'dataframe', format='table')
         df.iloc[2:].to_hdf(os.path.join(tdir, 'two.h5'), 'dataframe', format='table')
 
-        with dask.set_options(get=dask.get):
+        with dask.set_options(scheduler='sync'):
             input_files = [os.path.join(tdir, 'one.h5'), os.path.join(tdir, 'two.h5')]
             res = dd.read_hdf(input_files, 'dataframe')
             tm.assert_frame_equal(res.compute(), df)

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -12,7 +12,6 @@ from dask.dataframe.io.io import _meta_from_array
 from dask.delayed import Delayed, delayed
 
 from dask.utils import tmpfile
-from dask.local import get_sync
 
 from dask.dataframe.utils import assert_eq, is_categorical_dtype
 
@@ -126,11 +125,11 @@ def test_from_bcolz_multiple_threads():
         d = dd.from_bcolz(t, chunksize=2)
         assert d.npartitions == 2
         assert is_categorical_dtype(d.dtypes['a'])
-        assert list(d.x.compute(get=get_sync)) == [1, 2, 3]
-        assert list(d.a.compute(get=get_sync)) == ['a', 'b', 'a']
+        assert list(d.x.compute(scheduler='sync')) == [1, 2, 3]
+        assert list(d.a.compute(scheduler='sync')) == ['a', 'b', 'a']
 
         d = dd.from_bcolz(t, chunksize=2, index='x')
-        L = list(d.index.compute(get=get_sync))
+        L = list(d.index.compute(scheduler='sync'))
         assert L == [1, 2, 3] or L == [1, 3, 2]
 
         # Names
@@ -150,13 +149,13 @@ def test_from_bcolz():
     d = dd.from_bcolz(t, chunksize=2)
     assert d.npartitions == 2
     assert is_categorical_dtype(d.dtypes['a'])
-    assert list(d.x.compute(get=get_sync)) == [1, 2, 3]
-    assert list(d.a.compute(get=get_sync)) == ['a', 'b', 'a']
-    L = list(d.index.compute(get=get_sync))
+    assert list(d.x.compute(scheduler='sync')) == [1, 2, 3]
+    assert list(d.a.compute(scheduler='sync')) == ['a', 'b', 'a']
+    L = list(d.index.compute(scheduler='sync'))
     assert L == [0, 1, 2]
 
     d = dd.from_bcolz(t, chunksize=2, index='x')
-    L = list(d.index.compute(get=get_sync))
+    L = list(d.index.compute(scheduler='sync'))
     assert L == [1, 2, 3] or L == [1, 3, 2]
 
     # Names
@@ -324,7 +323,7 @@ def test_DataFrame_from_dask_array():
     assert isinstance(df, dd.DataFrame)
     tm.assert_index_equal(df.columns, pd.Index(['a', 'b', 'c']))
     assert list(df.divisions) == [0, 4, 8, 9]
-    assert (df.compute(get=get_sync).values == x.compute(get=get_sync)).all()
+    assert (df.compute(scheduler='sync').values == x.compute(scheduler='sync')).all()
 
     # dd.from_array should re-route to from_dask_array
     df2 = dd.from_array(x, columns=['a', 'b', 'c'])
@@ -340,7 +339,7 @@ def test_Series_from_dask_array():
     assert isinstance(ser, dd.Series)
     assert ser.name == 'a'
     assert list(ser.divisions) == [0, 4, 8, 9]
-    assert (ser.compute(get=get_sync).values == x.compute(get=get_sync)).all()
+    assert (ser.compute(scheduler='sync').values == x.compute(scheduler='sync')).all()
 
     ser = dd.from_dask_array(x)
     assert isinstance(ser, dd.Series)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -129,7 +129,7 @@ def test_local(tmpdir, write_engine, read_engine):
 
     assert len(df2.divisions) > 1
 
-    out = df2.compute(get=dask.get).reset_index()
+    out = df2.compute(scheduler='sync').reset_index()
 
     for column in df.columns:
         assert (data[column] == out[column]).all()
@@ -819,8 +819,8 @@ def test_filters(tmpdir):
     assert len(ddf2) > 0
 
 
-@pytest.mark.parametrize('get', [dask.threaded.get, dask.multiprocessing.get])
-def test_to_parquet_lazy(tmpdir, get, engine):
+@pytest.mark.parametrize('scheduler', ['threads', 'processes'])
+def test_to_parquet_lazy(tmpdir, scheduler, engine):
     tmpdir = str(tmpdir)
     df = pd.DataFrame({'a': [1, 2, 3, 4],
                        'b': [1., 2., 3., 4.]})
@@ -829,7 +829,7 @@ def test_to_parquet_lazy(tmpdir, get, engine):
     value = ddf.to_parquet(tmpdir, compute=False, engine=engine)
 
     assert hasattr(value, 'dask')
-    value.compute(get=get)
+    value.compute(scheduler=scheduler)
     assert os.path.exists(tmpdir)
 
     ddf2 = dd.read_parquet(tmpdir, engine=engine, infer_divisions=should_check_divs(engine))
@@ -1185,7 +1185,7 @@ def test_writing_parquet_with_kwargs(tmpdir, engine):
     assert_eq(out, ddf, check_index=(engine != 'fastparquet'), check_divisions=should_check_divs(engine))
 
     # Avoid race condition in pyarrow 0.8.0 on writing partitioned datasets
-    with dask.set_options(get=dask.get):
+    with dask.set_options(scheduler='sync'):
         ddf.to_parquet(path2, engine=engine, partition_on=['a'],
                        **engine_kwargs[engine])
     out = dd.read_parquet(path2, engine=engine).compute()

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -205,7 +205,7 @@ def test_categorical_set_index(shuffle):
     df['y'] = pd.Categorical(df['y'], categories=['a', 'b', 'c'], ordered=True)
     a = dd.from_pandas(df, npartitions=2)
 
-    with dask.set_options(get=dask.get, shuffle=shuffle):
+    with dask.set_options(scheduler='sync', shuffle=shuffle):
         b = a.set_index('y', npartitions=a.npartitions)
         d1, d2 = b.get_partition(0), b.get_partition(1)
         assert list(d1.index.compute()) == ['a']

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -956,7 +956,7 @@ def test_unknown_divisions():
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]})}
     meta = make_meta({'a': 'i8', 'b': 'i8'})
     d = dd.DataFrame(dsk, 'x', meta, [None, None, None, None])
-    full = d.compute(get=dask.get)
+    full = d.compute(scheduler='sync')
 
     assert_eq(d.a.sum(), full.a.sum())
     assert_eq(d.a + d.b + 1, full.a + full.b + 1)
@@ -2730,7 +2730,7 @@ def test_hash_split_unique(npartitions, split_every, split_out):
 
     assert len([k for k, v in dependencies.items() if not v]) == npartitions
     assert dropped.npartitions == (split_out or 1)
-    assert sorted(dropped.compute(get=dask.get)) == sorted(s.unique())
+    assert sorted(dropped.compute(scheduler='sync')) == sorted(s.unique())
 
 
 @pytest.mark.parametrize('split_every', [None, 2])

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -198,8 +198,8 @@ def test_groupby_dir():
     assert 'b c d e' not in dir(g)
 
 
-@pytest.mark.parametrize('get', [dask.get, dask.threaded.get])
-def test_groupby_on_index(get):
+@pytest.mark.parametrize('scheduler', ['sync', 'threads'])
+def test_groupby_on_index(scheduler):
     pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
                         'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
                        index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
@@ -215,7 +215,7 @@ def test_groupby_on_index(get):
     def func2(df):
         return df[['b']] - df[['b']].mean()
 
-    with dask.set_options(get=get):
+    with dask.set_options(scheduler=scheduler):
         with pytest.warns(None):
             assert_eq(ddf.groupby('a').apply(func),
                       pdf.groupby('a').apply(func))
@@ -705,11 +705,10 @@ def test_groupby_apply_tasks():
 
 
 def test_groupby_multiprocessing():
-    from dask.multiprocessing import get
     df = pd.DataFrame({'A': [1, 2, 3, 4, 5],
                        'B': ['1','1','a','a','a']})
     ddf = dd.from_pandas(df, npartitions=3)
-    with dask.set_options(get=get):
+    with dask.set_options(scheduler='processes'):
         assert_eq(ddf.groupby('B').apply(lambda x: x, meta={"A": int,
                                                             "B": object}),
                   df.groupby('B').apply(lambda x: x))

--- a/dask/dataframe/tests/test_hyperloglog.py
+++ b/dask/dataframe/tests/test_hyperloglog.py
@@ -1,5 +1,4 @@
 
-import dask
 import dask.dataframe as dd
 
 import pandas as pd
@@ -49,7 +48,7 @@ rs = np.random.RandomState(96)
 def test_basic(df, npartitions):
     ddf = dd.from_pandas(df, npartitions=npartitions)
 
-    approx = ddf.nunique_approx().compute(get=dask.local.get_sync)
+    approx = ddf.nunique_approx().compute(scheduler='sync')
     exact = len(df.drop_duplicates())
     assert abs(approx - exact) <= 2 or abs(approx - exact) / exact < 0.05
 
@@ -60,7 +59,7 @@ def test_split_every(split_every, npartitions):
     df = pd.Series([1, 2, 3] * 1000)
     ddf = dd.from_pandas(df, npartitions=npartitions)
 
-    approx = ddf.nunique_approx(split_every=split_every).compute(get=dask.local.get_sync)
+    approx = ddf.nunique_approx(split_every=split_every).compute(scheduler='sync')
     exact = len(df.drop_duplicates())
     assert abs(approx - exact) <= 2 or abs(approx - exact) / exact < 0.05
 

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -4,7 +4,6 @@ import numpy as np
 
 import pytest
 
-import dask
 import dask.dataframe as dd
 
 from dask.dataframe.indexing import _coerce_loc_index
@@ -62,7 +61,7 @@ def test_loc_non_informative_index():
     ddf.divisions = (None,) * 3
     assert not ddf.known_divisions
 
-    ddf.loc[20:30].compute(get=dask.get)
+    ddf.loc[20:30].compute(scheduler='sync')
 
     assert_eq(ddf.loc[20:30], df.loc[20:30])
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -3,7 +3,6 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 
-from dask.local import get_sync
 from dask.base import compute_as_if_collection
 from dask.dataframe.core import _Frame
 from dask.dataframe.methods import concat
@@ -190,11 +189,11 @@ def test_merge_indexed_dataframe_to_indexed_dataframe():
 
 def list_eq(aa, bb):
     if isinstance(aa, dd.DataFrame):
-        a = aa.compute(get=get_sync)
+        a = aa.compute(scheduler='sync')
     else:
         a = aa
     if isinstance(bb, dd.DataFrame):
-        b = bb.compute(get=get_sync)
+        b = bb.compute(scheduler='sync')
     else:
         b = bb
     tm.assert_index_equal(a.columns, b.columns)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -507,7 +507,7 @@ def _check_dask(dsk, check_names=True, check_dtypes=True, result=None):
     import dask.dataframe as dd
     if hasattr(dsk, 'dask'):
         if result is None:
-            result = dsk.compute(get=get_sync)
+            result = dsk.compute(scheduler='sync')
         if isinstance(dsk, dd.Index):
             assert isinstance(result, pd.Index), type(result)
             assert isinstance(dsk._meta, pd.Index), type(dsk._meta)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -11,7 +11,8 @@ import dask
 from dask import delayed
 from dask.base import (compute, tokenize, normalize_token, normalize_function,
                        visualize, persist, function_cache, is_dask_collection,
-                       DaskMethodsMixin, optimize, unpack_collections)
+                       DaskMethodsMixin, optimize, unpack_collections,
+                       named_schedulers)
 from dask.delayed import Delayed
 from dask.utils import tmpdir, tmpfile, ignoring
 from dask.utils_test import inc, dec
@@ -470,13 +471,13 @@ def test_compute_no_opt():
     # Check that with the kwarg, the optimization doesn't happen
     keys = []
     with Callback(pretask=lambda key, *args: keys.append(key)):
-        o.compute(get=dask.get, optimize_graph=False)
+        o.compute(scheduler='single-threaded', optimize_graph=False)
     assert len([k for k in keys if '-mul-' in k[0]]) == 4
     assert len([k for k in keys if '-add-' in k[0]]) == 4
     # Check that without the kwarg, the optimization does happen
     keys = []
     with Callback(pretask=lambda key, *args: keys.append(key)):
-        o.compute(get=dask.get)
+        o.compute(scheduler='single-threaded')
     # Names of fused tasks have been merged, and the original key is an alias.
     # Otherwise, the lengths below would be 4 and 0.
     assert len([k for k in keys if '-mul-' in k[0]]) == 8
@@ -537,7 +538,7 @@ def test_compute_array_bag():
 
     pytest.raises(ValueError, lambda: compute(x, b))
 
-    xx, bb = compute(x, b, get=dask.get)
+    xx, bb = compute(x, b, scheduler='single-threaded')
     assert np.allclose(xx, np.arange(5))
     assert bb == [1, 2, 3]
 
@@ -762,7 +763,7 @@ def test_persist_array_bag():
     with pytest.raises(ValueError):
         persist(x, b)
 
-    xx, bb = persist(x, b, get=dask.get)
+    xx, bb = persist(x, b, scheduler='single-threaded')
 
     assert isinstance(xx, da.Array)
     assert isinstance(bb, db.Bag)
@@ -804,7 +805,7 @@ def test_optimize_globals():
     b = db.range(10, npartitions=2)
 
     with dask.set_options(array_optimize=optimize_double):
-        xx, bb = dask.compute(x + 1, b.map(inc), get=dask.get)
+        xx, bb = dask.compute(x + 1, b.map(inc), scheduler='single-threaded')
         assert_eq(xx, (np.ones(10) * 2 + 1) * 2)
 
 
@@ -820,3 +821,28 @@ def test_optimize_None():
 
     with dask.set_options(array_optimize=None, get=my_get):
         y.compute()
+
+
+def test_scheduler_keyword():
+    def schedule(dsk, keys, **kwargs):
+        return [[123]]
+
+    named_schedulers['foo'] = schedule
+
+    x = delayed(inc)(1)
+
+    try:
+        assert x.compute() == 2
+        assert x.compute(scheduler='foo') == 123
+
+        with dask.set_options(scheduler='foo'):
+            assert x.compute() == 123
+        assert x.compute() == 2
+
+        with dask.set_options(scheduler='foo'):
+            assert x.compute(scheduler='threads') == 2
+
+        with pytest.raises(ValueError):
+            x.compute(get=dask.threaded.get, scheduler='foo')
+    finally:
+        del named_schedulers['foo']

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -5,6 +5,8 @@ import pytest
 from operator import add, mul
 import subprocess
 import sys
+import warnings
+
 from toolz import merge
 
 import dask
@@ -846,3 +848,12 @@ def test_scheduler_keyword():
             x.compute(get=dask.threaded.get, scheduler='foo')
     finally:
         del named_schedulers['foo']
+
+
+def test_warn_get_keyword():
+    x = delayed(inc)(1)
+
+    with warnings.catch_warnings(record=True) as record:
+        x.compute(get=dask.get)
+
+    assert 'scheduler=' in str(record[0].message)

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -97,12 +97,12 @@ def test_futures_to_delayed_array(loop):
 
 @gen_cluster(client=True)
 def test_local_get_with_distributed_active(c, s, a, b):
-    with dask.set_options(get=dask.get):
+    with dask.set_options(scheduler='sync'):
         x = delayed(inc)(1).persist()
     yield gen.sleep(0.01)
     assert not s.tasks # scheduler hasn't done anything
 
-    y = delayed(inc)(2).persist(get=dask.get)
+    y = delayed(inc)(2).persist(scheduler='sync')
     yield gen.sleep(0.01)
     assert not s.tasks # scheduler hasn't done anything
 
@@ -147,4 +147,4 @@ def test_futures_in_graph(loop):
             xxyy2 = c.persist(xxyy)
             xxyy3 = delayed(add)(xxyy2, 10)
 
-            assert xxyy3.compute(get=c.get) == ((1 + 1) + (2 + 2)) + 10
+            assert xxyy3.compute(scheduler='dask.distributed') == ((1 + 1) + (2 + 2)) + 10

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -126,7 +126,7 @@ def test_random_seeds(random):
         return tuple(random.randint(0, 10000) for i in range(5))
 
     N = 10
-    with set_options(get=get):
+    with set_options(scheduler='processes'):
         results, = compute([delayed(f, pure=False)() for i in range(N)])
 
     assert len(set(results)) == N

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -19,7 +19,6 @@ from weakref import WeakValueDictionary
 
 from .compatibility import get_named_args, getargspec, PY3, unicode, bind_method
 from .core import get_deps
-from .context import _globals
 from .optimization import key_split    # noqa: F401
 
 
@@ -799,20 +798,18 @@ class SerializableLock(object):
     __repr__ = __str__
 
 
-def effective_get(get=None, collection=None):
-    """Get the effective get method used in a given situation"""
-    return (get or _globals.get('get') or
-            getattr(collection, '__dask_scheduler__', None))
-
-
-def get_scheduler_lock(get=None, collection=None):
+def get_scheduler_lock(get=None, collection=None, scheduler=None):
     """Get an instance of the appropriate lock for a certain situation based on
        scheduler used."""
     from . import multiprocessing
-    actual_get = effective_get(get, collection)
+    from .base import get_scheduler
+    actual_get = get_scheduler(get=get,
+                               collections=[collection],
+                               scheduler=scheduler)
 
     if actual_get == multiprocessing.get:
         return mp.Manager().Lock()
+
     return SerializableLock()
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -42,6 +42,7 @@ Core
 ++++
 
 - Support traversing collections in persist, visualize, and optimize (:pr:`3410`) `Jim Crist`_
+- Add schedule= keyword, replace get= (:pr:`3448`) `Matthew Rocklin`_
 
 
 0.17.2 / 2018-03-21

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -42,7 +42,7 @@ Core
 ++++
 
 - Support traversing collections in persist, visualize, and optimize (:pr:`3410`) `Jim Crist`_
-- Add schedule= keyword, replace get= (:pr:`3448`) `Matthew Rocklin`_
+- Add schedule= keyword to compute and persist.  This replaces common use of the get= keyword (:pr:`3448`) `Matthew Rocklin`_
 
 
 0.17.2 / 2018-03-21

--- a/docs/source/dataframe-groupby.rst
+++ b/docs/source/dataframe-groupby.rst
@@ -89,15 +89,11 @@ Selecting methods
 Dask will use on-disk shuffling by default but will switch to task-based
 distributed shuffling if the default scheduler is set to use a
 ``dask.distributed.Client`` such as would be the case if the user sets the
-Client as default using one of the following two options:
+Client as default:
 
 .. code-block:: python
 
     client = Client('scheduler:8786', set_as_default=True)
-
-    or
-
-    dask.set_options(get=client.get)
 
 Alternatively, if you prefer to avoid defaults, you can specify a ``method=``
 keyword argument to ``groupby`` or ``set_index``

--- a/docs/source/scheduler-overview.rst
+++ b/docs/source/scheduler-overview.rst
@@ -109,7 +109,7 @@ may want to use a different scheduler. There are two ways to do this.
 
     .. code-block:: python
 
-        >>> x.sum().compute(get=dask.multiprocessing.get)
+        >>> x.sum().compute(scheduler='processes')
 
 2. Using ``dask.set_options``. This can be used either as a context manager, or to
    set the scheduler globally:
@@ -117,11 +117,11 @@ may want to use a different scheduler. There are two ways to do this.
     .. code-block:: python
 
         # As a context manager
-        >>> with dask.set_options(get=dask.multiprocessing.get):
+        >>> with dask.set_options(scheduler='processes'):
         ...     x.sum().compute()
 
         # Set globally
-        >>> dask.set_options(get=dask.multiprocessing.get)
+        >>> dask.set_options(scheduler='processes')
         >>> x.sum().compute()
 
 
@@ -160,7 +160,7 @@ well with ``pdb``:
 
 .. code-block:: python
 
-    >>> dask.set_options(get=dask.get)
+    >>> dask.set_options(scheduler='single-threaded')
     >>> x.sum().compute()    # This computation runs serially instead of in parallel
 
 

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -39,7 +39,7 @@ Local Threads
 .. code-block:: python
 
    import dask
-   dask.set_options(get=dask.threaded.get)  # overwrite default with threaded scheduler
+   dask.set_options(scheduler='threads')  # overwrite default with threaded scheduler
 
 The threaded scheduler executes computations with a local ``multiprocessing.pool.ThreadPool``.
 It is lightweight and requires no setup.
@@ -68,7 +68,7 @@ we encourage readers to continue reading after this section*
 .. code-block:: python
 
    import dask.multiprocessing
-   dask.set_options(get=dask.multiprocessing.get)  # overwrite default with multiprocessing scheduler
+   dask.set_options(scheduler='processes')  # overwrite default with multiprocessing scheduler
 
 
 The multiprocessing scheduler executes computations with a local ``multiprocessing.Pool``.
@@ -108,7 +108,7 @@ Single Thread
 .. code-block:: python
 
    import dask
-   dask.set_options(get=dask.local.get_sync)  # overwrite default with single-threaded scheduler
+   dask.set_options(scheduler='synchronous')  # overwrite default with single-threaded scheduler
 
 The single-threaded synchronous scheduler executes all computations in the local thread,
 with no parallelism at all.
@@ -159,12 +159,12 @@ We recommend referring to the :doc:`setup documentation <setup>` for more inform
 Configuration
 -------------
 
-You can configure the global default scheduler by using the ``dask.set_options(get=...)`` command.
+You can configure the global default scheduler by using the ``dask.set_options(scheduler...)`` command.
 This can be done globally,
 
 .. code-block:: python
 
-   dask.set_options(get=dask.threaded.get)
+   dask.set_options(scheduler='threads')
 
    x.compute()
 
@@ -172,14 +172,14 @@ or as a context manager
 
 .. code-block:: python
 
-   with dask.set_options(get=dask.threaded.get):
+   with dask.set_options(scheduler='threads'):
        x.compute()
 
 or within a single compute call
 
 .. code-block:: python
 
-   x.compute(get=dask.threaded.get)
+   x.compute(scheduler='threads')
 
 Additionally some of the scheduler support other keyword arguments.
 For example the Pool-based single-machine scheduler allow you to provide custom pools,

--- a/docs/source/setup/single-machine.rst
+++ b/docs/source/setup/single-machine.rst
@@ -47,13 +47,13 @@ You can specify these functions in any of the following ways:
 
     .. code-block:: python
 
-       x.compute(get=dask.threaded.get)
+       x.compute(scheduler='threads')
 
 -   With a context manager
 
     .. code-block:: python
 
-       with dask.set_options(get=dask.threaded.get):
+       with dask.set_options(scheduler='threads'):
            x.compute()
            y.compute()
 
@@ -61,7 +61,7 @@ You can specify these functions in any of the following ways:
 
     .. code-block:: python
 
-       dask.set_options(get=dask.threaded.get)
+       dask.set_options(scheduler='threads')
 
 
 Use the Distributed Scheduler

--- a/docs/source/use-cases.rst
+++ b/docs/source/use-cases.rst
@@ -213,7 +213,7 @@ parallelize and load balance the work.
 .. code-block:: python
 
    import dask.threaded
-   results = compute(*values, get=dask.threaded.get)
+   results = compute(*values, scheduler='threads')
 
 **Multiple Processes**:
 
@@ -221,7 +221,7 @@ parallelize and load balance the work.
 
 
    import dask.multiprocessing
-   results = compute(*values, get=dask.multiprocessing.get)
+   results = compute(*values, scheduler='processes')
 
 **Distributed Cluster**:
 
@@ -230,7 +230,7 @@ parallelize and load balance the work.
 
    from dask.distributed import Client
    client = Client("cluster-address:8786")
-   results = compute(*values, get=client.get)
+   results = compute(*values, scheduler='distributed')
 
 
 Complex dependencies


### PR DESCRIPTION
This adds a new scheduler= keyword to compute and persist functions,
replacing the non-intuitive get= keyword, enabling users to specify different
schedulers with names like the following:

```python
x.compute(get=dask.threaded.get)  # Before
x.compute(scheduler='threads')    # After
```

The common schedulers are stored in a dictionary in dask/base.py
and dask.distributed is handled specially to avoid importing by default

This also changes docstrings and documentation.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
