### PR TITLE
Assume the current python executable is the one we should spawn.

### DIFF
--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import requests
 import subprocess
+import sys
 import time
 
 from dask.bytes.core import open_files
@@ -19,9 +20,9 @@ def dir_server():
                 f.write(b'a' * 10000)
 
         if PY2:
-            cmd = ['python', '-m', 'SimpleHTTPServer', '8999']
+            cmd = [sys.executable, '-m', 'SimpleHTTPServer', '8999']
         else:
-            cmd = ['python', '-m', 'http.server', '8999']
+            cmd = [sys.executable, '-m', 'http.server', '8999']
         p = subprocess.Popen(cmd, cwd=d)
         timeout = 10
         while True:


### PR DESCRIPTION
On Debian the Python executable is named python3, so the test fails
because it tries to run the Python 2 interpreter.

Using sys.executable should be the safest option as the test server
will be launched using the same interpreter that the test suite is
running under.

- [X] Tests added / passed (Tests pass with default Debian python interpreter.
- [X] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
     Not documented as there should be no visible change to anyone but people using system Python 3 interpreters on systems following the Python installation conventions for Unix like systems.

Improves #3449 