### PR TITLE
Listing all optional requirements of Dask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+bcolz
+h5py
+matplotlib
+moto
+pandas_datareader
+partd
+pytest
+requests
+s3fs
+six
+sklearn
+snappy
+sparse
+sqlalchemy
+tornado


### PR DESCRIPTION
Includes all requirements of Dask without version constraints to start. Would like to fill these in as well. This should help us better understand what Dask needs for a complete working environment.

Note: Some things like `setuptools` are needed at build time (i.e. to install `dask`) or `versioneer` for updating the vendored versioning code, but are not needed outside of that. So they have been stripped.