### PR TITLE
Remove changelog requirement from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,2 @@
 - [ ] Tests added / passed
 - [ ] Passes `flake8 dask`
-- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
-      and one of the `docs/source/*-api.rst` files for new API


### PR DESCRIPTION
See https://github.com/dask/dask/issues/3447

This should reduce friction for submitting PRs

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
