### PR TITLE
Adds string subclass check to dataframe.__getitem__

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -8,7 +8,6 @@ from pprint import pformat
 import warnings
 
 from toolz import merge, first, unique, partition_all, remove
-import six
 import pandas as pd
 import numpy as np
 from numbers import Number
@@ -23,7 +22,7 @@ from .. import core
 
 from ..utils import partial_by_order
 from .. import threaded
-from ..compatibility import apply, operator_div, bind_method
+from ..compatibility import apply, operator_div, bind_method, string_types
 from ..context import globalmethod
 from ..utils import (random_state_data, pseudorandom, derived_from, funcname,
                      memory_repr, put_lines, M, key_split, OperatorMethodMixin,
@@ -2339,7 +2338,7 @@ class DataFrame(_Frame):
 
     def __getitem__(self, key):
         name = 'getitem-%s' % tokenize(self, key)
-        if np.isscalar(key) or isinstance(key, (tuple, six.string_types)):
+        if np.isscalar(key) or isinstance(key, (tuple, string_types)):
 
             if isinstance(self._meta.index, (pd.DatetimeIndex, pd.PeriodIndex)):
                 if key not in self._meta.columns:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -8,6 +8,7 @@ from pprint import pformat
 import warnings
 
 from toolz import merge, first, unique, partition_all, remove
+import six
 import pandas as pd
 import numpy as np
 from numbers import Number
@@ -2338,7 +2339,7 @@ class DataFrame(_Frame):
 
     def __getitem__(self, key):
         name = 'getitem-%s' % tokenize(self, key)
-        if np.isscalar(key) or isinstance(key, tuple):
+        if np.isscalar(key) or isinstance(key, (tuple, six.string_types)):
 
             if isinstance(self._meta.index, (pd.DatetimeIndex, pd.PeriodIndex)):
                 if key not in self._meta.columns:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2600,6 +2600,17 @@ def test_getitem_multilevel():
     assert_eq(pdf[[('A', '0'), ('B', '1')]], ddf[[('A', '0'), ('B', '1')]])
 
 
+def test_getitem_string_subclass():
+    df = pd.DataFrame({'column_1': list(range(10))})
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    class string_subclass(str):
+        pass
+    column_1 = string_subclass('column_1')
+
+    assert_eq(df[column_1], ddf[column_1])
+
+
 def test_diff():
     df = pd.DataFrame(np.random.randn(100, 5), columns=list('abcde'))
     ddf = dd.from_pandas(df, 5)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,7 +13,7 @@ Array
 Dataframe
 +++++++++
 
--
+- Add support for indexing Dask DataFrames with string subclasses (:pr:`3461`) `James Bourbeau`_
 
 Bag
 +++


### PR DESCRIPTION
This PR adds string subclass support to `DataFrame.__getitem__`

Fixes #3297

- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
