### PR TITLE
Allow using both sorted_index and chunksize in read_hdf (#3401)

### DIFF
--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -266,18 +266,16 @@ def _read_single_hdf(path, key, start=0, stop=None, columns=None,
                 else:
                     stops.append(stop)
                 if sorted_index:
-                    if chunksize is not None:
-                        division = [storer.read_column('index', start=start, stop=start + 1)[0]
-                                    for start in range(0, storer.nrows, chunksize)]
-                        division_end = storer.read_column('index',
-                                                          start=storer.nrows - 1,
-                                                          stop=storer.nrows)[0]
-                        divisions += division + [division_end]
-                    else:
-                        division_start = storer.read_column('index', start=0, stop=1)[0]
-                        division_end = storer.read_column('index', start=storer.nrows - 1,
-                                                          stop=storer.nrows)[0]
-                        divisions.append([division_start, division_end])
+                    division = [storer.read_column('index', start=start, stop=start + 1)[0]
+                                for start in range(0, storer.nrows, chunksize)]
+                    division_end = storer.read_column('index',
+                                                      start=storer.nrows - 1,
+                                                      stop=storer.nrows)[0]
+
+                    division.append(division_end)
+                    divisions.append(division)
+
+                    print(divisions)
                 else:
                     divisions.append(None)
 

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -243,7 +243,7 @@ def _read_single_hdf(path, key, start=0, stop=None, columns=None,
     Read a single hdf file into a dask.dataframe. Used for each file in
     read_hdf.
     """
-    def get_keys_stops_divisions(path, key, stop, sorted_index):
+    def get_keys_stops_divisions(path, key, stop, sorted_index, chunksize):
         """
         Get the "keys" or group identifiers which match the given key, which
         can contain wildcards. This uses the hdf file identified by the
@@ -266,12 +266,16 @@ def _read_single_hdf(path, key, start=0, stop=None, columns=None,
                 else:
                     stops.append(stop)
                 if sorted_index:
-                    division_start = storer.read_column('index', start=0, stop=1)[0]
-                    division_end = storer.read_column('index', start=storer.nrows - 1,
+                    division = [storer.read_column('index', start=start, stop=start + 1)[0]
+                                for start in range(0, storer.nrows, chunksize)]
+                    division_end = storer.read_column('index',
+                                                      start=storer.nrows - 1,
                                                       stop=storer.nrows)[0]
-                    divisions.append([division_start, division_end])
+
+                    divisions += division + [division_end]
                 else:
                     divisions.append(None)
+
         return keys, stops, divisions
 
     def one_path_one_key(path, key, start, stop, columns, chunksize, division, lock):
@@ -314,7 +318,7 @@ def _read_single_hdf(path, key, start=0, stop=None, columns=None,
 
         return new_dd_object(dsk, name, empty, divisions)
 
-    keys, stops, divisions = get_keys_stops_divisions(path, key, stop, sorted_index)
+    keys, stops, divisions = get_keys_stops_divisions(path, key, stop, sorted_index, chunksize)
     if (start != 0 or stop is not None) and len(keys) > 1:
         raise NotImplementedError(read_hdf_error_msg)
     from ..multi import concat

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -266,13 +266,18 @@ def _read_single_hdf(path, key, start=0, stop=None, columns=None,
                 else:
                     stops.append(stop)
                 if sorted_index:
-                    division = [storer.read_column('index', start=start, stop=start + 1)[0]
-                                for start in range(0, storer.nrows, chunksize)]
-                    division_end = storer.read_column('index',
-                                                      start=storer.nrows - 1,
-                                                      stop=storer.nrows)[0]
-
-                    divisions += division + [division_end]
+                    if chunksize is not None:
+                        division = [storer.read_column('index', start=start, stop=start + 1)[0]
+                                    for start in range(0, storer.nrows, chunksize)]
+                        division_end = storer.read_column('index',
+                                                          start=storer.nrows - 1,
+                                                          stop=storer.nrows)[0]
+                        divisions += division + [division_end]
+                    else:
+                        division_start = storer.read_column('index', start=0, stop=1)[0]
+                        division_end = storer.read_column('index', start=storer.nrows - 1,
+                                                          stop=storer.nrows)[0]
+                        divisions.append([division_start, division_end])
                 else:
                     divisions.append(None)
 

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -415,6 +415,14 @@ def test_read_hdf(data, compare):
         assert (sorted(dd.read_hdf(fn, '/data', mode='r').dask) ==
                 sorted(dd.read_hdf(fn, '/data', mode='r').dask))
 
+    with tmpfile('h5') as fn:
+        sorted_data = data.sort_index()
+        sorted_data.to_hdf(fn, '/data', format='table')
+        a = dd.read_hdf(fn, '/data', chunksize=2, sorted_index=True, mode='r')
+        assert a.npartitions == 2
+
+        compare(a.compute(), sorted_data)
+
 
 def test_read_hdf_multiply_open():
     """Test that we can read from a file that's already opened elsewhere in


### PR DESCRIPTION
Solve #3401 issue.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
- [ ] Fully documented, including `docs/source/changelog.rst` for all changes
      and one of the `docs/source/*-api.rst` files for new API
