### PR TITLE
Support case in get_scheduler with no inputs

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -837,6 +837,18 @@ def warn_on_get(get):
 
 
 def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
+    """ Get scheduler function
+
+    There are various ways to specify the scheduler to use:
+
+    1.  Passing in get= parameters (deprecated)
+    2.  Passing in scheduler= parameters
+    3.  Passing these into global confiuration
+    4.  Using defaults of a dask collection
+
+    This function centralizes the logic to determine the right scheduler to use
+    from those many options
+    """
     if get is not None:
         if scheduler is not None:
             raise ValueError("Both get= and scheduler= provided.  Choose one")
@@ -868,7 +880,8 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
     if cls is not None:
         return cls.__dask_scheduler__
 
-    collections = [c for c in collections if c is not None]
+    if collections:
+        collections = [c for c in collections if c is not None]
     if collections:
         get = collections[0].__dask_scheduler__
         if not all(c.__dask_scheduler__ == get for c in collections):

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -14,7 +14,7 @@ from dask import delayed
 from dask.base import (compute, tokenize, normalize_token, normalize_function,
                        visualize, persist, function_cache, is_dask_collection,
                        DaskMethodsMixin, optimize, unpack_collections,
-                       named_schedulers)
+                       named_schedulers, get_scheduler)
 from dask.delayed import Delayed
 from dask.utils import tmpdir, tmpfile, ignoring
 from dask.utils_test import inc, dec
@@ -857,3 +857,12 @@ def test_warn_get_keyword():
         x.compute(get=dask.get)
 
     assert 'scheduler=' in str(record[0].message)
+
+
+def test_get_scheduler():
+    assert get_scheduler() is None
+    assert get_scheduler(scheduler='threads') is dask.threaded.get
+    assert get_scheduler(scheduler='sync') is dask.local.get_sync
+    with dask.set_options(scheduler='threads'):
+        assert get_scheduler(scheduler='threads') is dask.threaded.get
+    assert get_scheduler() is None


### PR DESCRIPTION
Previously this failed on a check on collections

- [x] Tests added / passed
- [x] Passes `flake8 dask`
