### PR TITLE
Fix rechunk with chunksize of -1 in a dict

### DIFF
--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -191,6 +191,9 @@ def blockshape_dict_to_tuple(old_chunks, d):
 
     >>> blockshape_dict_to_tuple(((4, 4), (5, 5)), {1: 3})
     ((4, 4), (3, 3, 3, 1))
+    >>> blockshape_dict_to_tuple(((4, 4), (5, 5)), {1: -1})
+    ((4, 4), (10,))
+
     """
     shape = tuple(map(sum, old_chunks))
     new_chunks = list(old_chunks)
@@ -228,15 +231,17 @@ def rechunk(x, chunks, threshold=DEFAULT_THRESHOLD,
     Parameters
     ----------
 
-    x:   dask array
-    chunks:  tuple
-        The new block dimensions to create
+    x: dask array
+        Array to be rechunked.
+    chunks:  int, tuple or dict
+        The new block dimensions to create. -1 indicates the full size of the
+        corresponding dimension.
     threshold: int
-        The graph growth factor under which we don't bother
-        introducing an intermediate step
+        The graph growth factor under which we don't bother introducing an
+        intermediate step.
     block_size_limit: int
         The maximum block size (in bytes) we want to produce during an
-        intermediate step
+        intermediate step.
     """
     threshold = threshold or DEFAULT_THRESHOLD
     block_size_limit = block_size_limit or DEFAULT_BLOCK_SIZE_LIMIT

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -195,8 +195,9 @@ def blockshape_dict_to_tuple(old_chunks, d):
     shape = tuple(map(sum, old_chunks))
     new_chunks = list(old_chunks)
     for k, v in d.items():
-        div = shape[k] // v
-        mod = shape[k] % v
+        if v == -1:
+            v = shape[k]
+        div, mod = divmod(shape[k], v)
         new_chunks[k] = (v,) * div + ((mod,) if mod else ())
     return tuple(new_chunks)
 

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -157,6 +157,10 @@ def test_rechunk_with_dict():
     y = x.rechunk(chunks={0: (12, 12)})
     assert y.chunks == ((12, 12), (8, 8, 8))
 
+    x = da.ones((24, 24), chunks=(4, 8))
+    y = x.rechunk(chunks={0: -1})
+    assert y.chunks == ((24,), (8, 8, 8))
+
 
 def test_rechunk_with_empty_input():
     x = da.ones((24, 24), chunks=(4, 8))

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 Array
 +++++
 
--
+- Fix ``rechunk`` with chunksize of -1 in a dict (:pr:`3469`) `Stephan Hoyer`_
 
 Dataframe
 +++++++++


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

This should fix using a chunk-size of `-1` via xarray's `.chunk()` method (https://github.com/pydata/xarray/issues/2103)