### PR TITLE
[WIP] Ensure _rename is robust to inconsistent column orderings between columns and dataframe

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3556,8 +3556,7 @@ def _rename(columns, df):
             # if target is identical, rename is not necessary
             return df
         # deep=False doesn't doesn't copy any data/indices, so this is cheap
-        df = df.copy(deep=False)
-        df.columns = columns
+        df = df[columns].copy(deep=False)
         return df
     elif isinstance(df, (pd.Series, pd.Index)):
         if isinstance(columns, (pd.Series, pd.Index)):

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -514,6 +514,25 @@ def test_from_delayed():
     assert str(e.value).startswith('Metadata mismatch found in `from_delayed`')
 
 
+def test_from_delayed_misordered_meta():
+    df = pd.DataFrame(
+        columns=['(1)', '(2)', 'date', 'ent', 'val'],
+        data=[range(i * 5, i * 5 + 5) for i in range(3)],
+        index=range(3)
+    )
+
+    # meta with different order for columns
+    misordered_meta = pd.DataFrame(
+        columns=['date', 'ent', 'val', '(1)', '(2)'],
+        data=[range(5)]
+    )
+
+    ddf = dd.from_delayed([delayed(lambda: df)()], meta=misordered_meta)
+
+    assert_eq(ddf, ddf.reset_index(drop=True), check_names=False,
+              check_like=True)
+
+
 def test_from_delayed_sorted():
     a = pd.DataFrame({'x': [1, 2]}, index=[1, 10])
     b = pd.DataFrame({'x': [4, 1]}, index=[100, 200])


### PR DESCRIPTION
- [ x] Tests added / passed
- [ x] Passes `flake8 dask`

Related to #3390 