### PR TITLE
Use NumPy 1.11 with Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
 
     - env:
       - PYTHON=3.4
-      - NUMPY=1.12.1
+      - NUMPY=1.11.3
       - PANDAS=0.19.1
       - *test_and_lint
       - *no_coverage


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/3475

Appears that Pandas 0.19 and NumPy 1.12 conflict due to the Conda package for Pandas' version constraints (particularly for Python 3.4). So try downgrading the NumPy version used in this CI matrix to fix this issue.

Note: Pushed the branch to the Dask main repo as this CI matrix element is skipped otherwise. Want to see if this fixes the issue before it's merged.