### PR TITLE
Avoid auto-updating conda

### DIFF
--- a/continuous_integration/hdfs/install.sh
+++ b/continuous_integration/hdfs/install.sh
@@ -1,2 +1,3 @@
+docker exec -it $CONTAINER_ID conda config --set auto_update_conda false
 docker exec -it $CONTAINER_ID conda install -y -q dask hdfs3 pyarrow -c twosigma -c conda-forge
 docker exec -it $CONTAINER_ID pip install -e .

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -13,7 +13,8 @@ esac
 wget https://repo.continuum.io/miniconda/$MINICONDA_FILENAME -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
-conda config --set always_yes yes --set changeps1 no
+conda config --set always_yes yes \
+             --set changeps1 no
 
 # Create conda environment
 conda create -q -n test-environment python=$PYTHON

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -14,7 +14,8 @@ wget https://repo.continuum.io/miniconda/$MINICONDA_FILENAME -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 conda config --set always_yes yes \
-             --set changeps1 no
+             --set changeps1 no \
+             --set auto_update_conda false
 
 # Create conda environment
 conda create -q -n test-environment python=$PYTHON


### PR DESCRIPTION
Related to https://github.com/dask/dask/issues/3345

Appears that Conda is being auto-updated from 4.3 to 4.5 unintentionally. This blocks Conda from updating itself unless explicitly requested. *May* solve some recent issues seen with the HDFS tests.

Note: Pushed the branch to the Dask main repo as this CI matrix element is skipped otherwise. Want to see if this fixes the issue before it's merged.