### PR TITLE
Enhance `dask.array.broadcast arrays`

### DIFF
--- a/dask/array/broadcast_arrays.py
+++ b/dask/array/broadcast_arrays.py
@@ -1,0 +1,312 @@
+from __future__ import absolute_import, division, print_function
+
+import re
+from functools import partial
+from itertools import count
+from operator import itemgetter
+import numpy as np
+try:
+    from cytoolz import concat, groupby, valmap, unique, compose
+except ImportError:
+    from toolz import concat, groupby, valmap, unique, compose
+
+from .core import asarray, asanyarray, broadcast_to
+
+
+_DIMENSION_NAME = r'\w+'
+_DIMENSION_LIST = '(?:{0:}(?:,{0:})*,?)?'.format(_DIMENSION_NAME)
+_ARGUMENT = r'\({}\)'.format(_DIMENSION_LIST)
+_ARGUMENTS = '(?:{0:}(?:,{0:})*,?)?'.format(_ARGUMENT)
+_SIGNATURE = '^{0:}->{1:}$'.format(_ARGUMENTS, _ARGUMENTS)
+
+
+def _parse_signature(signature):
+    """
+    Parse string signatures for broadcast arrays.
+
+    Arguments
+    ---------
+    signature : String
+
+    Returns
+    -------
+    Tuple of input and output core dimensions parsed from the signature, each
+    of the form List[Tuple[str, ...]]. 
+    """
+    signature = signature.replace(' ', '')
+    signature = signature if '->' in signature else signature + '->'
+    if not re.match(_SIGNATURE, signature):
+        raise ValueError(
+            'not a valid signature: {}'.format(signature))
+    in_txt, out_txt = signature.split('->')
+    ins = [tuple(re.findall(_DIMENSION_NAME, arg))
+           for arg in re.findall(_ARGUMENT, in_txt)]
+    outs = [tuple(re.findall(_DIMENSION_NAME, arg))
+            for arg in re.findall(_ARGUMENT, out_txt)]
+    return ins, outs
+
+
+def _where(seq, elem):
+    """
+    Returns first occurrence of ``elem`` in ``seq``
+    or ``None``, if ``elem`` is not found
+    """
+    try:
+        return [i for i, e in enumerate(seq) if e == elem][0]
+    except IndexError:
+        return None
+
+
+def _inverse(seq):
+    """
+    Returns the inverse of a sequence of int. 
+    ``None`` is ignored.
+
+    Examples
+    --------
+    >>> _inverse([0, 1])
+    [0, 1]
+    >>> _inverse([2, 1])
+    [None, 1, 0]
+    >>> _inverse([None, 1, 0])
+    [2, 1] 
+    """
+    if not seq:
+        return []
+    n = max(filter(lambda e: e is not None, seq))
+    return [_where(seq, i) for i in range(n+1)]
+
+
+def _argsort(list_):
+    """
+    Simple argsort in pure python
+    """
+    return sorted(range(len(list_)), key=list_.__getitem__)
+
+
+def broadcast_arrays(*args, **kwargs):
+    """
+    Broadcasts arrays against each other.
+
+
+    Parameters
+    ----------
+    *args: Arrays
+        Arrays to be broadcast against each other.
+
+    signature: Optional; String, Iterable of Iterable, or None
+        Specifies loop and core dimensions within each array, where only loop
+        dimensions are broadcast. E.g. ``"(i,K),(j)->(K),()"`` is the signature
+        for two arrays, where the first array has ``"K"`` as core dimension and
+        the two loop dimensions are ``"i"`` and ``"j"``. Specification of core
+        dimensions could also be omitted, e.g. ``"(i),(j)"``. Then only loop
+        dimensions could be specified and the signature is left aligned,
+        meaning trailing array dimensions are considered core dimensions.
+
+        Dimension sizes for same loop dimensions must match or be of length
+        ``1``. Dimension sizes of same core dimensions must match.
+
+        Chunk sizes for same loop or core dimensions must be same,
+        except where a loop dimension is sparse and of length ``1``.
+
+        Order of loop dimensions is in order of their appearance.
+        Core dimensions are put to the end in the specified order.
+
+        Defaults to ``None``.
+
+        Note: while the syntax is similar to numpy generalized 
+        ufuncs [2]_, its meaning here is different. 
+       
+    sparse: Optional; Bool
+        Specifies if a broadcast should be sparse, i.e. new broadcast
+        dimensions are of length 1. If not sparse existing sparse
+        dimensions are broadcast to their full size (as stated by
+        the other passed arguments). Defaults to ``False``.
+    
+    subok: Bool
+
+
+    Returns
+    -------
+     : Arrays
+        Broadcast arrays
+
+
+    Examples
+    --------
+    >>> a = np.random.randn(3, 1)
+    >>> b = np.random.randn(1, 4)
+    >>> A, B = broadcast_arrays(a, b)
+    >>> A.shape, B.shape
+    (3, 4), (3, 4)
+
+
+    >>> a = np.random.randn(3)
+    >>> b = np.random.randn(4)
+    >>> A, B = broadcast_arrays(a, b, signature="(i),(j)")
+    >>> A.shape, B.shape
+    (3, 4), (3, 4)
+
+
+    >>> a = np.random.randn(3)
+    >>> b = np.random.randn(4)
+    >>> A, B = broadcast_arrays(a, b, signature="(i),(j)", sparse=True)
+    >>> A.shape, B.shape
+    (3, 1), (1, 4)
+
+
+    >>> x = da.random.normal(size=(2, 4, 5), chunks=(1, 3, 4))
+    >>> y = da.random.normal(size=(6, 2, 8, 7), chunks=(2, 1, 5, 6))
+    >>> X, Y = broadcast_arrays(x, y, signature="(L1,K2,K1),(K3,L1,L2,K4)->(K1,K2),(K3,K4)", sparse=True)
+    >>> X.shape, Y.shape
+    (2, 1, 5, 4), (2, 8, 6, 7)
+
+
+    References
+    ----------
+    .. [1] http://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
+
+
+    """
+    signature = kwargs.pop('signature', None)
+    sparse = kwargs.pop('sparse', False)
+    subok = bool(kwargs.pop('subok', False))
+    if kwargs:
+        raise TypeError("Unsupported keyword argument(s) provided")
+    
+    # Input processing
+    to_array = asanyarray if subok else asarray
+    args = tuple(to_array(e) for e in args)
+    nargs = len(args)
+    shapes = [e.shape for e in args]
+    chunkss = [tuple(i[0] for i in e.chunks) for e in args]
+    ndimss = [len(s) for s in shapes]
+
+    # Parse signature
+    if isinstance(signature, str):
+        lhs_dimss, rhs_dimss = _parse_signature(signature)
+    elif isinstance(signature, tuple):
+        lhs_dimss, rhs_dimss = signature
+    elif isinstance(signature, list):
+        lhs_dimss = signature
+        rhs_dimss = []
+    elif signature is None:
+        # Inject default behavior for signature
+        lhs_dimss = [tuple(reversed(range(n))) for n in ndimss]
+        rhs_dimss = []
+    else:
+        raise ValueError("``signature`` is invalid")
+    rhs_dimss = rhs_dimss if rhs_dimss else [tuple()]*nargs
+    lhs_dimss = lhs_dimss if lhs_dimss else [tuple(reversed(range(n - len(rhs_dims)))) for n, rhs_dims in zip(ndimss, rhs_dimss)]
+
+    # Check consistency of passed arguments
+    if len(lhs_dimss) != len(args):
+        raise ValueError("``signature`` does not match number of input arrays")
+    if len(rhs_dimss) != len(args):
+        raise ValueError("``signature`` does not match number of input arrays on right hand side")
+
+    # Check consistency of passed dimensions
+    for idx, ndims, lhs_dims, rhs_dims in zip(count(1), ndimss, lhs_dimss, rhs_dimss):
+        if (len(set(lhs_dims)) != len(lhs_dims)) or \
+           (len(set(rhs_dims)) != len(rhs_dims)):
+            raise ValueError("Repeated dimension name for array #{} in signature".format(idx))
+        if len(lhs_dims) > ndims:
+            raise ValueError("Too many dimension(s) for input array #{} in signature given".format(idx))
+    
+    # Construct complete dimension names of passed arrays
+    in_dimss = []
+    auto_core_dimss = []
+    for idx, ndims, lhs_dims, rhs_dims in  zip(count(), ndimss, lhs_dimss, rhs_dimss):
+        in_dims = list(lhs_dims)
+        auto_core_dims = tuple()
+        ndiff = ndims - len(in_dims)
+        assert ndiff >= 0  # Should not occur
+        if ndiff == 0:
+            # Mode 1) LHS provided all dimension names
+            pass
+        elif len(rhs_dims) == 0:
+            # Mode 2) No RHS, we automatically create dimension names for them and consider them core dims, i.e.
+            # unique from dimensions at same positions in other passed arrays
+            auto_core_dims = tuple('__broadcast_arrays_coredim_{}_{}'.format(idx, j) for j in range(ndiff))
+            in_dims.extend(auto_core_dims)
+        else:
+            # Mode 3) We can attach the missing dim names from RHS if they won't lead to repeated
+            # dimensions names
+            in_dims.extend(rhs_dims[-ndiff:])
+            if len(in_dims) != ndims:
+                raise ValueError("Signature for array #{} cannot be created easily - please clarify dimensions".format(idx))
+        in_dimss.append(in_dims)
+        auto_core_dimss.append(auto_core_dims)
+        # Check consistency of in_dimss construction
+        if len(set(in_dims)) != len(in_dims):
+            raise ValueError("Repeated dimension name for array #{} in signature".format(idx))
+
+    # Check that the arrays have same length for same dimensions or dimension `1`
+    _temp = groupby(0, concat(zip(ad, s) for ad, s in zip(in_dimss, shapes)))
+    dimsizess = valmap(compose(set, partial(map, itemgetter(1))), _temp)
+    for dim, sizes in dimsizess.items():
+        if sizes.union({1}) != {1, max(sizes)}:
+            raise ValueError("Dimension ``{}`` with different lengths in arrays".format(dim))
+    dimsizes = valmap(max, dimsizess)
+
+    # Check if arrays have same chunk size for the same dimension
+    _temp = groupby(0, concat(zip(ad, s, c) for ad, s, c in zip(lhs_dimss, shapes, chunkss)))
+    dimchunksizess = valmap(compose(set,
+                                    partial(map, itemgetter(1)),
+                                    partial(filter, lambda e: e != (1, 1)),
+                                    partial(map, lambda tpl: tpl[1:])),
+                            _temp)
+    for dim, dimchunksizes in dimchunksizess.items():
+        if len(dimchunksizes) > 1:
+            raise ValueError('Dimension ``{}`` with different chunksize present'.format(dim))
+    dimchunksizes = valmap(max, dimchunksizess)
+
+    # Find loop dims and union of all loop dims in order of appearance
+    auto_loop_dimss = [tuple(i for i in id_ if i not in rd)
+                          for id_, rd in zip(lhs_dimss, rhs_dimss)]
+
+    # According to https://docs.scipy.org/doc/numpy-1.14.0/user/basics.broadcasting.html automatic broadcasting
+    # is right aligned. Therefore to determine the correct order of dim names for auto broadcasting, we sort the
+    # arrays from many loop dims to few loop dims and then then order of total loop dims will be in order of
+    # their appearance
+    _auto_loop_dimss_sorted = sorted(auto_loop_dimss, key=len, reverse=True)
+    auto_total_loop_dims = tuple(unique(concat(_auto_loop_dimss_sorted)))
+
+    out_dimss = [auto_total_loop_dims
+                  + rd
+                  + acd   #??+ tuple(r for r in rd if r not in id_)
+                  for id_, rd, acd in zip(in_dimss, rhs_dimss, auto_core_dimss)]
+
+    # Find order of transposition for each array and perform transformations
+    new_args = []
+    for arg, out_dims, in_dims, shape, chunks in zip(args, out_dimss, in_dimss, shapes, chunkss):
+
+        # Find new position of given dimension and maybe indicate dimensions which have to be created
+        in2out_poss = []
+        for idx, out_dim in enumerate(out_dims):
+            oidx = _where(in_dims, out_dim)
+            if oidx is None:
+                oidx = -idx-1
+            in2out_poss.append(oidx)  # Insert new dim if not present
+        # Determine order for later transposition
+        _temp = _argsort(in2out_poss)
+        transpose_idcs = _inverse(_temp)
+        sorted_in2out_poss = sorted(in2out_poss)
+
+        # Determine the new shape size by pre-pending newly created dimensions
+        if sparse is True:
+            new_shape = tuple(1 for i in in2out_poss if i < 0) + shape
+        else:
+            new_shape = tuple(dimsizes[out_dims[-i-1]] for i in sorted_in2out_poss if i < 0) \
+                      + tuple(dimsizes[in_dims[i]] for i in sorted_in2out_poss if i >= 0) # Also need to extend size `1` sparse dimensions in this case
+
+        # Chunks can be original size, in case of `sparse=True` it will be cut back to `1` by new_shape
+        new_chunks = tuple(dimchunksizes[out_dims[-i-1]] for i in sorted_in2out_poss if i < 0) + chunks
+
+        # Apply old `dask.array.broadcast_to` and `transpose`
+        new_arg = broadcast_to(arg, shape=new_shape, chunks=new_chunks)
+        new_arg = new_arg.transpose(transpose_idcs)
+
+        new_args.append(new_arg)
+    
+    return new_args

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -31,7 +31,7 @@ from dask.array.core import (getem, getter, top, dotmany, concatenate3,
                              broadcast_to, blockdims_from_blockshape, store,
                              optimize, from_func, normalize_chunks,
                              broadcast_chunks, atop, from_delayed,
-                             concatenate_axes, common_blockdim)
+                             concatenate_axes, common_blockdim, broadcast_arrays)
 from dask.array.utils import assert_eq, same_keys
 
 # temporary until numpy functions migrated
@@ -928,7 +928,7 @@ def test_broadcast_to_chunks():
 def test_broadcast_arrays():
     # Calling `broadcast_arrays` with no arguments only works in NumPy 1.13.0+.
     if LooseVersion(np.__version__) >= LooseVersion("1.13.0"):
-        assert np.broadcast_arrays() == da.broadcast_arrays()
+        assert np.broadcast_arrays() == broadcast_arrays()
 
     a = np.arange(4)
     d_a = da.from_array(a, chunks=tuple(s // 2 for s in a.shape))
@@ -940,7 +940,7 @@ def test_broadcast_arrays():
     d_a_1 = d_a[:, None]
 
     a_r = np.broadcast_arrays(a_0, a_1)
-    d_r = da.broadcast_arrays(d_a_0, d_a_1)
+    d_r = broadcast_arrays(d_a_0, d_a_1)
 
     assert isinstance(d_r, list)
     assert len(a_r) == len(d_r)

--- a/dask/array/tests/test_broadcast_arrays.py
+++ b/dask/array/tests/test_broadcast_arrays.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
-from pytest import raises as assert_raises
 from numpy.testing import assert_array_equal, assert_equal
 import dask.array as da
 import numpy as np
@@ -15,8 +14,8 @@ from dask.array.broadcast_arrays import _parse_signature, broadcast_arrays
 def test__where():
     assert _where([], 1) is None
     assert _where([0, 2], 1) is None
-    assert _where([0, 2], 2) == 1 
-    assert _where([0, 2, None], None) == 2 
+    assert _where([0, 2], 2) == 1
+    assert _where([0, 2, None], None) == 2
 
 
 def test__inverse():
@@ -112,11 +111,9 @@ def test_broadcast_arrays_05():
 
 
 # 1) Broadcast two scalars each with distinct loop dims against each other
-@pytest.mark.parametrize("signature", [
-                                       "(i),(j)",
+@pytest.mark.parametrize("signature", ["(i),(j)",
                                        "(i),(j)->(),()",
-                                       "(i),(j)->(i,j),(i,j)"
-                                      ])
+                                       "(i),(j)->(i,j),(i,j)"])
 def test_broadcast_arrays_scalar_distinct_loop_dims(signature):
     a = np.random.randn(3)
     b = np.random.randn(4,)
@@ -126,12 +123,10 @@ def test_broadcast_arrays_scalar_distinct_loop_dims(signature):
 
 
 # 2) Broadcast two vectors each with distinct loop dims against each other
-@pytest.mark.parametrize("signature", [
-                                       "(i),(j)",
+@pytest.mark.parametrize("signature", ["(i),(j)",
                                        "(i),(j)->(U),(V)",  # Advanced usage, maybe not recommended
                                        "(i,U),(j,V)->(U),(V)",
-                                       "(i,U),(j,V)->(i,j,U),(i,j,V)"
-                                       ])
+                                       "(i,U),(j,V)->(i,j,U),(i,j,V)"])
 def test_broadcast_arrays_vectors_distinct_loop_dims(signature):
     a = np.random.randn(3, 5)
     b = np.random.randn(4, 6)
@@ -141,13 +136,11 @@ def test_broadcast_arrays_vectors_distinct_loop_dims(signature):
 
 
 # 3) Broadcast two scaVars with same loop dim against each other
-@pytest.mark.parametrize("signature", [
-                                       None,
+@pytest.mark.parametrize("signature", [None,
                                        "(i),(i)",
                                        "->(),()",
                                        "(i),(i)->(),()",
-                                       "(i),(i)->(i),(i)",
-                                       ])
+                                       "(i),(i)->(i),(i)"])
 def test_broadcast_arrays_scaVars_same_loop_dims(signature):
     a = np.random.randn(3)
     b = np.random.randn(3)
@@ -157,13 +150,11 @@ def test_broadcast_arrays_scaVars_same_loop_dims(signature):
 
 
 # 4) Broadcast two vectors each with same loop dim against each other
-@pytest.mark.parametrize("signature", [
-                                       "(i),(i)",
+@pytest.mark.parametrize("signature", ["(i),(i)",
                                        "->(U),(V)",
                                        "(i),(i)->(U),(V)",  # Advanced usage, maybe not recommended
                                        "(i,U),(i,V)->(U),(V)",
-                                       "(i,U),(i,V)->(i,U),(i,V)"
-                                       ])
+                                       "(i,U),(i,V)->(i,U),(i,V)"])
 def test_broadcast_arrays_vectors_same_loop_dims(signature):
     a = np.random.randn(3, 5)
     b = np.random.randn(3, 6)
@@ -173,13 +164,11 @@ def test_broadcast_arrays_vectors_same_loop_dims(signature):
 
 
 # 5a) Broadcast two vectors each with partially same loop dim against each other no proposed loop dim order
-@pytest.mark.parametrize("signature", [
-                                       "(j),(i,j)",
+@pytest.mark.parametrize("signature", ["(j),(i,j)",
                                        "->(U),(V)",
                                        "(j),(i,j)->(U),(V)",  # Advanced usage, maybe not recommended
                                        "(j,U),(i,j,V)->(U),(V)",
-                                       "(j,U),(i,j,V)->(i,j,U),(i,j,V)"
-                                       ])
+                                       "(j,U),(i,j,V)->(i,j,U),(i,j,V)"])
 def test_broadcast_arrays_vectors_mixed_loop_dims(signature):
     a = np.random.randn(4, 5)
     b = np.random.randn(3, 4, 6)
@@ -189,12 +178,10 @@ def test_broadcast_arrays_vectors_mixed_loop_dims(signature):
 
 
 # 5b) Broadcast two vectors each with partially same loop dim against each other no proposed loop dim order
-@pytest.mark.parametrize("signature", [
-                                       "(i),(i,j)",
+@pytest.mark.parametrize("signature", ["(i),(i,j)",
                                        "(i),(i,j)->(U),(V)",  # Advanced usage, maybe not recommended
                                        "(i,U),(i,j,V)->(U),(V)",
-                                       "(i,U),(i,j,V)->(i,j,U),(i,j,V)"
-                                      ])
+                                       "(i,U),(i,j,V)->(i,j,U),(i,j,V)"])
 def test_broadcast_arrays_vectors_mixed_loop_dims_02(signature):
     a = np.random.randn(3, 5)
     b = np.random.randn(3, 4, 6)

--- a/dask/array/tests/test_broadcast_arrays.py
+++ b/dask/array/tests/test_broadcast_arrays.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from distutils.version import LooseVersion
 import pytest
 from numpy.testing import assert_array_equal, assert_equal
 import dask.array as da
@@ -36,9 +37,9 @@ def test__parse_signature():
 
 # Test from `dask.array.tests.test_array_core.py`
 def test_broadcast_arrays():
-    # # Calling `broadcast_arrays` with no arguments only works in NumPy 1.13.0+.
-    # if LooseVersion(np.__version__) >= LooseVersion("1.13.0"):
-    #     assert np.broadcast_arrays() == da.broadcast_arrays()
+    # Calling `broadcast_arrays` with no arguments only works in NumPy 1.13.0+.
+    if LooseVersion(np.__version__) >= LooseVersion("1.13.0"):
+        assert np.broadcast_arrays() == broadcast_arrays()
 
     a = np.arange(4)
     d_a = da.from_array(a, chunks=tuple(s // 2 for s in a.shape))

--- a/dask/array/tests/test_broadcast_arrays.py
+++ b/dask/array/tests/test_broadcast_arrays.py
@@ -1,0 +1,199 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+from pytest import raises as assert_raises
+from numpy.testing import assert_array_equal, assert_equal
+import dask.array as da
+import numpy as np
+from dask.array.utils import assert_eq
+
+
+from dask.array.broadcast_arrays import _where, _inverse
+from dask.array.broadcast_arrays import _parse_signature, broadcast_arrays
+
+
+def test__where():
+    assert _where([], 1) is None
+    assert _where([0, 2], 1) is None
+    assert _where([0, 2], 2) == 1 
+    assert _where([0, 2, None], None) == 2 
+
+
+def test__inverse():
+    assert _inverse([0]) == [0]
+    assert _inverse([0, 1]) == [0, 1]
+    assert _inverse([2, 1]) == [None, 1, 0]
+    assert _inverse([None, 1, 0]) == [2, 1]
+
+
+def test__parse_signature():
+    assert_equal(_parse_signature(''), ([], []))
+    assert_equal(_parse_signature('()'), ([tuple()], []))
+    assert_equal(_parse_signature('()->()'), ([tuple()], [tuple()]))
+    assert_equal(_parse_signature('->()'), ([], [tuple()]))
+    assert_equal(_parse_signature('(i,k)->(j)'), ([('i', 'k')], [('j',)]))
+    assert_equal(_parse_signature('(i,k),(j)->(k),()'), ([('i', 'k'),('j',)], [('k',), tuple()]))
+
+
+# Test from `dask.array.tests.test_array_core.py`
+def test_broadcast_arrays():
+    # # Calling `broadcast_arrays` with no arguments only works in NumPy 1.13.0+.
+    # if LooseVersion(np.__version__) >= LooseVersion("1.13.0"):
+    #     assert np.broadcast_arrays() == da.broadcast_arrays()
+
+    a = np.arange(4)
+    d_a = da.from_array(a, chunks=tuple(s // 2 for s in a.shape))
+
+    a_0 = np.arange(4)[None, :]
+    a_1 = np.arange(4)[:, None]
+
+    d_a_0 = d_a[None, :]
+    d_a_1 = d_a[:, None]
+
+    a_r = np.broadcast_arrays(a_0, a_1)
+    d_r = broadcast_arrays(d_a_0, d_a_1)
+
+    assert isinstance(d_r, list)
+    assert len(a_r) == len(d_r)
+
+    for e_a_r, e_d_r in zip(a_r, d_r):
+        assert_eq(e_a_r, e_d_r)
+
+
+@pytest.mark.parametrize("sparse", [True, False])
+def test_broadcast_arrays_00(sparse):
+    x = np.array([1, 2, 3])
+    y = np.array([10, 20])
+    X, Y = np.meshgrid(x, y, indexing="ij", sparse=sparse)
+    Z = X + Y
+    DX, DY = broadcast_arrays(x, y, signature="(a),(b)", sparse=sparse)
+    DZ = DX + DY
+    assert_array_equal(Z, DZ.compute())
+
+
+def test_broadcast_arrays_01():
+    x = da.random.normal(size=(3, 1), chunks=(2, 3))
+    y = da.random.normal(size=(1, 4), chunks=(2, 3))
+    X, Y = broadcast_arrays(x, y, signature="(i,j),(i,j)", sparse=False)
+    Z = X + Y
+    assert Z.shape == (3, 4)
+
+
+def test_broadcast_arrays_02():
+    a = np.random.randn(3, 1)
+    b = np.random.randn(4,)
+    A, B = broadcast_arrays(a, b, sparse=False)
+    assert A.shape == (3, 4)
+    assert B.shape == (3, 4)
+
+
+def test_broadcast_arrays_03():
+    x = da.random.normal(size=(2, 4, 5), chunks=(1, 3, 4))
+    y = da.random.normal(size=(6, 2, 8, 7), chunks=(2, 1, 5, 6))
+    X, Y = broadcast_arrays(x, y, signature="(L1,K2,K1),(K3,L1,L2,K4)->(K1,K2),(K3,K4)", sparse=False)
+    assert X.shape[:2] == (2, 8)
+    assert Y.shape[:2] == (2, 8)
+    assert X.shape[2:] == (5, 4)
+    assert Y.shape[2:] == (6, 7)
+
+
+def test_broadcast_arrays_04():
+    x = da.random.normal(size=(2, 8, 4, 5), chunks=(1, 5, 3, 4))
+    y = da.random.normal(size=(6, 8, 2, 7), chunks=(2, 5, 1, 6))
+    X, Y = broadcast_arrays(x, y, signature="(L1,L2,K2,K1),(K3,L2,L1,K4)->(K1,K2),(K3,K4)", sparse=False)
+    assert X.shape[:2] == (2, 8)
+    assert Y.shape[:2] == (2, 8)
+    assert X.shape[2:] == (5, 4)
+    assert Y.shape[2:] == (6, 7)
+
+
+# 1) Broadcast two scalars each with distinct loop dims against each other
+@pytest.mark.parametrize("signature", [
+                                       "(i),(j)",
+                                       "(i),(j)->(),()",
+                                       "(i),(j)->(i,j),(i,j)"
+                                      ])
+def test_broadcast_arrays_scalar_distinct_loop_dims(signature):
+    a = np.random.randn(3)
+    b = np.random.randn(4,)
+    A, B = broadcast_arrays(a, b, signature=signature, sparse=False)
+    assert A.shape == (3, 4)
+    assert B.shape == (3, 4)
+
+
+# 2) Broadcast two vectors each with distinct loop dims against each other
+@pytest.mark.parametrize("signature", [
+                                       "(i),(j)",
+                                       "(i),(j)->(k),(l)",  # Advanced usage, maybe not recommended
+                                       "(i,k),(j,l)->(k),(l)",
+                                       "(i,k),(j,l)->(i,j,k),(i,j,l)"
+                                       ])
+def test_broadcast_arrays_vectors_distinct_loop_dims(signature):
+    a = np.random.randn(3, 5)
+    b = np.random.randn(4, 6)
+    A, B = broadcast_arrays(a, b, signature=signature, sparse=False)
+    assert A.shape == (3, 4, 5)
+    assert B.shape == (3, 4, 6)
+
+
+# 3) Broadcast two scalars with same loop dim against each other
+@pytest.mark.parametrize("signature", [
+                                       None,
+                                       "(i),(i)",
+                                       "->(),()",
+                                       "(i),(i)->(),()",
+                                       "(i),(i)->(i),(i)",
+                                       ])
+def test_broadcast_arrays_scalars_same_loop_dims(signature):
+    a = np.random.randn(3)
+    b = np.random.randn(3)
+    A, B = broadcast_arrays(a, b, signature=signature, sparse=False)
+    assert A.shape == (3,)
+    assert B.shape == (3,)
+
+
+# 4) Broadcast two vectors each with same loop dim against each other
+@pytest.mark.parametrize("signature", [
+                                       "(i),(i)",
+                                       "->(k),(l)",
+                                       "(i),(i)->(k),(l)",  # Advanced usage, maybe not recommended
+                                       "(i,k),(i,l)->(k),(l)",
+                                       "(i,k),(i,l)->(i,k),(i,l)"
+                                       ])
+def test_broadcast_arrays_vectors_same_loop_dims(signature):
+    a = np.random.randn(3, 5)
+    b = np.random.randn(3, 6)
+    A, B = broadcast_arrays(a, b, signature=signature, sparse=False)
+    assert A.shape == (3, 5)
+    assert B.shape == (3, 6)
+
+
+# 5a) Broadcast two vectors each with partially same loop dim against each other no proposed loop dim order
+@pytest.mark.parametrize("signature", [
+                                       "(j),(i,j)",
+                                       "->(k),(l)",
+                                       "(j),(i,j)->(k),(l)",  # Advanced usage, maybe not recommended
+                                       "(j,k),(i,j,l)->(k),(l)",
+                                       "(j,k),(i,j,l)->(i,j,k),(i,j,l)"
+                                       ])
+def test_broadcast_arrays_vectors_mixed_loop_dims(signature):
+    a = np.random.randn(4, 5)
+    b = np.random.randn(3, 4, 6)
+    A, B = broadcast_arrays(a, b, signature=signature, sparse=False)
+    assert A.shape == (3, 4, 5)
+    assert B.shape == (3, 4, 6)
+
+
+# 5b) Broadcast two vectors each with partially same loop dim against each other no proposed loop dim order
+@pytest.mark.parametrize("signature", [
+                                       "(i),(i,j)",
+                                       "(i),(i,j)->(k),(l)",  # Advanced usage, maybe not recommended
+                                       "(i,k),(i,j,l)->(k),(l)",
+                                       "(i,k),(i,j,l)->(i,j,k),(i,j,l)"
+                                      ])
+def test_broadcast_arrays_vectors_mixed_loop_dims_02(signature):
+    a = np.random.randn(3, 5)
+    b = np.random.randn(3, 4, 6)
+    A, B = broadcast_arrays(a, b, signature=signature, sparse=False)
+    assert A.shape == (3, 4, 5)
+    assert B.shape == (3, 4, 6)

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -651,6 +651,10 @@ Other functions
 .. autofunction:: atop
 .. autofunction:: top
 
+.. currentmodule:: dask.array.broadcast_arrays
+
+.. autofunction:: broadcast_arrays
+
 .. currentmodule:: dask.array
 
 Array Methods

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,7 @@ Array
 +++++
 
 - Fix ``rechunk`` with chunksize of -1 in a dict (:pr:`3469`) `Stephan Hoyer`_
+- Enhance ``broadcast_arrays`` by ``signature`` argument to exclude core dims from broadcast and ``sparse`` argument as in ``numpy.meshgrid`` (:pr:`XXXX`) `Markus Gonser`_
 
 Dataframe
 +++++++++

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,7 +9,7 @@ Array
 +++++
 
 - Fix ``rechunk`` with chunksize of -1 in a dict (:pr:`3469`) `Stephan Hoyer`_
-- Enhance ``broadcast_arrays`` by ``signature`` argument to exclude core dims from broadcast and ``sparse`` argument as in ``numpy.meshgrid`` (:pr:`XXXX`) `Markus Gonser`_
+- Enhance ``broadcast_arrays`` by ``signature`` argument to exclude core dims from broadcast and ``sparse`` argument as in ``numpy.meshgrid`` (:pr:`3486`) `Markus Gonser`_
 
 Dataframe
 +++++++++


### PR DESCRIPTION
Thi PR suggest a way to enhance `broadcast_arrays` by an `signature` argument to exclude core dims from broadcast and a `sparse` argument, like in `numpy.meshgrid`. 

While the standard behavior stays the same as in `numpy.broadcast_arrays`, the added functionality is beyond numpys implementation and this function might need a different name.

I've kept the new proposal still in extra module `dask.array.broadcast arrays` instead of overwriting `broadcast_array` inside `dask.array.core`.

- [x] Tests added / passed
- [x] Passes `flake8 dask`