### PR TITLE
Add dataframe to/from json

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -6,7 +6,7 @@ from .groupby import Aggregation
 from .io import (from_array, from_pandas, from_bcolz,
                  from_dask_array, read_hdf, read_sql_table,
                  from_delayed, read_csv, to_csv, read_table,
-                 demo, to_hdf, to_records, to_bag)
+                 demo, to_hdf, to_records, to_bag, read_json, to_json)
 from .optimize import optimize
 from .multi import merge, concat
 from . import rolling

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1075,6 +1075,11 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         from .io import to_csv
         return to_csv(self, filename, **kwargs)
 
+    def to_json(self, filename, *args, **kwargs):
+        """ See dd.to_json docstring for more information """
+        from .io import to_json
+        return to_json(self, filename, *args, **kwargs)
+
     def to_delayed(self, optimize_graph=True):
         """Convert into a list of ``dask.delayed`` objects, one per partition.
 

--- a/dask/dataframe/io/__init__.py
+++ b/dask/dataframe/io/__init__.py
@@ -6,6 +6,7 @@ from .io import (from_array, from_bcolz, from_array, from_bcolz,
 from .csv import read_csv, to_csv, read_table
 from .hdf import read_hdf, to_hdf
 from .sql import read_sql_table
+from .json import read_json, to_json
 from . import demo
 try:
     from .parquet import read_parquet, to_parquet

--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import io
 import pandas as pd
 from dask.bytes import open_files, read_bytes
@@ -35,7 +37,6 @@ def to_json(df, url_path, orient='records', lines=True, storage_options=None,
         If true, immediately executes. If False, returns a set of delayed
         objects, which can be computed at a later time.
     """
-    import dask.dataframe as dd
     kwargs['orient'] = orient
     kwargs['lines'] = lines and orient == 'records'
     outfiles = open_files(

--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -130,8 +130,8 @@ def read_json(url_path, orient='records', lines=True, storage_options=None,
         chunks = list(dask.core.flatten(chunks))
         first = read_json_chunk(first, encoding, errors, kwargs)
         parts = [dask.delayed(read_json_chunk)(
-            chunk, encoding, errors, kwargs, meta=first[:0])
-                 for chunk in chunks]
+            chunk, encoding, errors, kwargs, meta=first[:0]
+        ) for chunk in chunks]
 
     else:
         files = open_files(url_path, 'rt', encoding=encoding, errors=errors,

--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -1,0 +1,118 @@
+import io
+import pandas as pd
+from dask.bytes import open_files, read_bytes
+from dask import delayed
+import dask.dataframe as dd
+import dask
+from ...core import flatten
+
+
+def to_json(df, url_path, orient='records', lines=True, storage_options=None,
+            compute=True, **kwargs):
+    """Write dataframe into JSON text files
+
+    This utilises ``pandas.DataFrame.to_json()``, and most parameters are
+    passed through - see its docstring.
+
+    Differences: orient is 'records' by default, with lines=True; this
+    produces the kind of JSON output that is most common in big-data
+    applications, and which can be chunked when reading (see ``read_json()``).
+
+    Parameters
+    ----------
+    df: dask.DataFrame
+        Data to save
+    url_path: str, list of str
+        Location to write to. If a string, and there are more than one
+        partitions in df, should include a glob character to expand into a
+        set of file names, or provide a ``name_function=`` parameter.
+        Supports protocol specifications such as ``"s3://"``.
+    encoding, errors:
+        The text encoding to implement, e.g., "utf-8" and how to respond
+        to errors in the conversion (see ``str.encode()``).
+    orient, lines, kwargs
+        passed to pandas
+    storage_options: dict
+        Passed to backend file-system implementation
+    compute: bool
+        If true, immediately executes. If False, returns a set of delayed
+        objects, which can be computed at a later time.
+    """
+    kwargs['orient'] = orient
+    kwargs['lines'] = lines
+    outfiles = open_files(
+        url_path, 'wt', encoding=kwargs.pop('encoding', 'utf-8'),
+        errors=kwargs.pop('errors', 'strict'),
+        name_function=kwargs.pop('name_funciton', None),
+        num=df.npartitions,
+        **(storage_options or {})
+    )
+    parts = [delayed(_part_to_file)(d, outfile, kwargs)
+             for outfile, d in zip(outfiles, df.to_delayed())]
+    if compute:
+        return dask.compute(parts)
+    else:
+        return parts
+
+
+def _part_to_file(df, openfile, kwargs):
+    with openfile as f:
+        df.to_json(f, **kwargs)
+
+
+def read_json(url_path, orient='records', lines=True, storage_options=None,
+              blocksize=2**27, **kwargs):
+    """Create a dataframe from a set of JSON files
+
+    This utilises ``pandas.read_json()``, and most parameters are
+    passed through - see its docstring.
+
+    Differences: orient is 'records' by default, with lines=True; this
+    is apropriate for "JSON-lines" data, the kind of JSON output that is most
+    common in big-data scenarios, and which can be chunked when reading
+    (see ``read_json()``). All other options require blocksize=None, i.e.,
+    one partition per input file.
+
+
+    Parameters
+    ----------
+    url_path: str, list of str
+        Location to read from. If a string, can include a glob character to
+        find a set of file names.
+        Supports protocol specifications such as ``"s3://"``.
+    encoding, errors:
+        The text encoding to implement, e.g., "utf-8" and how to respond
+        to errors in the conversion (see ``str.encode()``).
+    orient, lines, kwargs
+        passed to pandas
+    storage_options: dict
+        Passed to backend file-system implementation
+    """
+    if blocksize and (orient != 'records' or not lines):
+        raise ValueError("JSON file chunking only allowed for JSON-lines"
+                         "input (orient='records', lines=True).")
+    encoding = kwargs.pop('encoding', 'utf-8')
+    errors = kwargs.pop('errors', 'strict')
+    storage_options = storage_options or {}
+    if blocksize:
+        _, chunks = read_bytes(url_path, b'\n', blocksize, sample=False,
+                               **storage_options)
+        parts = [delayed(_chunk_to_partition)(chunk, encoding, errors, kwargs)
+                 for chunk in flatten(chunks)]
+    else:
+        files = open_files(url_path, 'rt', encoding=encoding, errors=errors,
+                           **storage_options)
+        parts = [delayed(_file_to_partition)(f, orient, lines, kwargs)
+                 for f in files]
+    return dd.from_delayed(parts)
+
+
+def _chunk_to_partition(chunk, encoding, errors, kwargs):
+    s = io.StringIO(chunk.decode(encoding, errors))
+    s.seek(0)
+    return pd.read_json(s, orient='records', lines=True, **kwargs)
+
+
+def _file_to_partition(f, orient, lines, kwargs):
+    with f as f:
+        return pd.read_json(f, orient=orient, lines=lines, **kwargs)

--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -1,10 +1,7 @@
 import io
 import pandas as pd
 from dask.bytes import open_files, read_bytes
-from dask import delayed
-import dask.dataframe as dd
 import dask
-from ...core import flatten
 
 
 def to_json(df, url_path, orient='records', lines=True, storage_options=None,
@@ -38,8 +35,9 @@ def to_json(df, url_path, orient='records', lines=True, storage_options=None,
         If true, immediately executes. If False, returns a set of delayed
         objects, which can be computed at a later time.
     """
+    import dask.dataframe as dd
     kwargs['orient'] = orient
-    kwargs['lines'] = lines
+    kwargs['lines'] = lines and orient == 'records'
     outfiles = open_files(
         url_path, 'wt', encoding=kwargs.pop('encoding', 'utf-8'),
         errors=kwargs.pop('errors', 'strict'),
@@ -47,7 +45,7 @@ def to_json(df, url_path, orient='records', lines=True, storage_options=None,
         num=df.npartitions,
         **(storage_options or {})
     )
-    parts = [delayed(_part_to_file)(d, outfile, kwargs)
+    parts = [dask.delayed(write_json_partition)(d, outfile, kwargs)
              for outfile, d in zip(outfiles, df.to_delayed())]
     if compute:
         return dask.compute(parts)
@@ -55,23 +53,23 @@ def to_json(df, url_path, orient='records', lines=True, storage_options=None,
         return parts
 
 
-def _part_to_file(df, openfile, kwargs):
+def write_json_partition(df, openfile, kwargs):
     with openfile as f:
         df.to_json(f, **kwargs)
 
 
 def read_json(url_path, orient='records', lines=True, storage_options=None,
-              blocksize=2**27, **kwargs):
+              blocksize=None, **kwargs):
     """Create a dataframe from a set of JSON files
 
     This utilises ``pandas.read_json()``, and most parameters are
     passed through - see its docstring.
 
     Differences: orient is 'records' by default, with lines=True; this
-    is apropriate for "JSON-lines" data, the kind of JSON output that is most
-    common in big-data scenarios, and which can be chunked when reading
-    (see ``read_json()``). All other options require blocksize=None, i.e.,
-    one partition per input file.
+    is apropriate for line-delimited "JSON-lines" data, the kind of JSON output
+    that is most common in big-data scenarios, and which can be chunked when
+    reading (see ``read_json()``). All other options require blocksize=None,
+    i.e., one partition per input file.
 
 
     Parameters
@@ -87,32 +85,60 @@ def read_json(url_path, orient='records', lines=True, storage_options=None,
         passed to pandas
     storage_options: dict
         Passed to backend file-system implementation
+    blocksize: None or int
+        If None, files are not blocked, and you get one partition per input
+        file. If int, which can only be used for line-delimited JSON files,
+        each partition will be approximately this size in bytes, to the nearest
+        newline character.
+
+    Returns
+    -------
+    dask.DataFrame
+
+    Examples
+    --------
+    Load single file
+
+    >>> dd.read_json('myfile.1.json')  # doctest: +SKIP
+
+    Load multiple files
+
+    >>> dd.read_json('myfile.*.json')  # doctest: +SKIP
+
+    >>> dd.read_json(['myfile.1.json', 'myfile.2.json'])  # doctest: +SKIP
+
+    Load large line-delimited JSON files using partitions of approx
+    256MB size
+
+    >> dd.read_json('data/file*.csv', blocksize=2**28)
     """
+    import dask.dataframe as dd
     if blocksize and (orient != 'records' or not lines):
         raise ValueError("JSON file chunking only allowed for JSON-lines"
                          "input (orient='records', lines=True).")
     encoding = kwargs.pop('encoding', 'utf-8')
+    lines = lines and orient == 'records'
     errors = kwargs.pop('errors', 'strict')
     storage_options = storage_options or {}
     if blocksize:
-        _, chunks = read_bytes(url_path, b'\n', blocksize, sample=False,
-                               **storage_options)
-        parts = [delayed(_chunk_to_partition)(chunk, encoding, errors, kwargs)
-                 for chunk in flatten(chunks)]
+        _, chunks = read_bytes(url_path, b'\n', blocksize=blocksize,
+                               sample=False, **storage_options)
+        parts = [dask.delayed(read_json_chunk)(chunk, encoding, errors, kwargs)
+                 for chunk in dask.core.flatten(chunks)]
     else:
         files = open_files(url_path, 'rt', encoding=encoding, errors=errors,
                            **storage_options)
-        parts = [delayed(_file_to_partition)(f, orient, lines, kwargs)
+        parts = [dask.delayed(read_json_file)(f, orient, lines, kwargs)
                  for f in files]
     return dd.from_delayed(parts)
 
 
-def _chunk_to_partition(chunk, encoding, errors, kwargs):
+def read_json_chunk(chunk, encoding, errors, kwargs):
     s = io.StringIO(chunk.decode(encoding, errors))
     s.seek(0)
     return pd.read_json(s, orient='records', lines=True, **kwargs)
 
 
-def _file_to_partition(f, orient, lines, kwargs):
+def read_json_file(f, orient, lines, kwargs):
     with f as f:
         return pd.read_json(f, orient=orient, lines=lines, **kwargs)

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -2,7 +2,6 @@ import os
 import pandas as pd
 import pytest
 
-import dask
 import dask.dataframe as dd
 from dask.utils import tmpfile, tmpdir
 from dask.dataframe.utils import assert_eq

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -46,10 +46,11 @@ def test_read_json_error():
             dd.read_json(f, orient='split', blocksize=1)
 
 
-def test_read_chunked():
+@pytest.mark.parametrize('block', [5, 15, 33, 200, 90000])
+def test_read_chunked(block):
     with tmpdir() as path:
         fn = os.path.join(path, '1.json')
         df.to_json(fn, orient='records', lines=True)
-        d = dd.read_json(fn, blocksize=33)
-        assert d.npartitions > 1
+        d = dd.read_json(fn, blocksize=block, sample=10)
+        assert (d.npartitions > 1) or (block > 50)
         assert_eq(d, df, check_index=False)

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -41,6 +41,8 @@ def test_write_json_basic(orient):
 
 def test_read_json_error():
     with tmpfile('json') as f:
+        with pytest.raises(ValueError):
+            df.to_json(f, orient='split', lines=True)
         df.to_json(f, orient='split', lines=False)
         with pytest.raises(ValueError):
             dd.read_json(f, orient='split', blocksize=1)

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -1,0 +1,56 @@
+import os
+import pandas as pd
+import pytest
+
+import dask
+import dask.dataframe as dd
+from dask.utils import tmpfile, tmpdir
+from dask.dataframe.utils import assert_eq
+
+
+df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
+                   'y': [1, 2, 3, 4]})
+
+
+@pytest.mark.parametrize('orient', ['split', 'records', 'index', 'columns',
+                                    'values'])
+def test_read_json_basic(orient):
+    with tmpfile('json') as f:
+        df.to_json(f, orient=orient, lines=False)
+        actual = dd.read_json(f, orient=orient, lines=False)
+        actual_pd = pd.read_json(f, orient=orient, lines=False)
+
+        out = actual.compute()
+        assert_eq(out, actual_pd)
+        if orient == 'values':
+            out.columns = list(df.columns)
+        assert_eq(out, df)
+
+
+@pytest.mark.parametrize('orient', ['split', 'records', 'index', 'columns',
+                                    'values'])
+def test_write_json_basic(orient):
+    with tmpdir() as path:
+        fn = os.path.join(path, '1.json')
+        df.to_json(fn, orient=orient, lines=False)
+        actual = dd.read_json(fn, orient=orient, lines=False)
+        out = actual.compute()
+        if orient == 'values':
+            out.columns = list(df.columns)
+        assert_eq(out, df)
+
+
+def test_read_json_error():
+    with tmpfile('json') as f:
+        df.to_json(f, orient='split', lines=False)
+        with pytest.raises(ValueError):
+            dd.read_json(f, orient='split', blocksize=1)
+
+
+def test_read_chunked():
+    with tmpdir() as path:
+        fn = os.path.join(path, '1.json')
+        df.to_json(fn, orient='records', lines=True)
+        d = dd.read_json(fn, blocksize=33)
+        assert d.npartitions > 1
+        assert_eq(d, df, check_index=False)

--- a/dask/dataframe/io/utils.py
+++ b/dask/dataframe/io/utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import pandas as pd
 import json
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,8 @@ Array
 Dataframe
 +++++++++
 
+- Add to/read_json (:pr:`3494`) `Martin Durant`_
+
 Bag
 +++
 

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -79,6 +79,7 @@ Dataframe
     DataFrame.to_csv
     DataFrame.to_delayed
     DataFrame.to_hdf
+    DataFrame.to_json
     DataFrame.to_records
     DataFrame.truediv
     DataFrame.values
@@ -281,6 +282,7 @@ Create DataFrames
    read_table
    read_parquet
    read_hdf
+   read_json
    read_orc
    read_sql_table
    from_array


### PR DESCRIPTION
Posting early to see if there are any comments on the approach. There are other formats that are relatively easy for pandas, unsure if we want to support them all here. There is an argument to attempt to match as much as we can of the pandas API.

Fixes https://github.com/dask/dask/issues/3491

cc @j-bennet