### PR TITLE
Replace dask.set_options with dask.config.set

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -32,9 +32,10 @@ import numpy as np
 from . import chunk
 from .numpy_compat import _make_sliced_dtype
 from .slicing import slice_array, replace_ellipsis
+from .. import config
 from ..base import (DaskMethodsMixin, tokenize, dont_optimize,
                     compute_as_if_collection, persist, is_dask_collection)
-from ..context import _globals, globalmethod
+from ..context import globalmethod
 from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      is_integer, IndexCallable, funcname, derived_from,
                      SerializableLock, ensure_dict, Dispatch)
@@ -1041,7 +1042,7 @@ class Array(DaskMethodsMixin):
             raise ValueError("You must specify the dtype of the array")
         self.dtype = np.dtype(dtype)
 
-        for plugin in _globals.get('array_plugins', ()):
+        for plugin in config.get('array_plugins', ()):
             result = plugin(self)
             if result is not None:
                 self = result

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -18,9 +18,8 @@ from .wrap import zeros, ones
 from .numpy_compat import ma_divide, divide as np_divide
 from ..compatibility import getargspec, builtins
 from ..base import tokenize
-from ..context import _globals
 from ..utils import ignoring, funcname, Dispatch
-from .. import sharedict
+from .. import config, sharedict
 
 
 # Generic functions to support chunks of different types
@@ -76,7 +75,7 @@ def _tree_reduce(x, aggregate, axis, keepdims, dtype, split_every=None,
     Lower level, users should use ``reduction`` or ``arg_reduction`` directly.
     """
     # Normalize split_every
-    split_every = split_every or _globals.get('split_every', 4)
+    split_every = split_every or config.get('split_every', 4)
     if isinstance(split_every, dict):
         split_every = dict((k, split_every.get(k, 2)) for k in axis)
     elif isinstance(split_every, int):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1216,7 +1216,7 @@ def test_blockdims_from_blockshape():
 def test_coerce():
     d0 = da.from_array(np.array(1), chunks=(1,))
     d1 = da.from_array(np.array([1]), chunks=(1,))
-    with dask.set_options(scheduler='sync'):
+    with dask.config.set(scheduler='sync'):
         for d in d0, d1:
             assert bool(d) is True
             assert int(d) == 1
@@ -3187,13 +3187,13 @@ def test_elemwise_with_lists(chunks, other):
 def test_constructor_plugin():
     L = []
     L2 = []
-    with dask.set_options(array_plugins=[L.append, L2.append]):
+    with dask.config.set(array_plugins=[L.append, L2.append]):
         x = da.ones(10, chunks=5)
         y = x + 1
 
     assert L == L2 == [x, y]
 
-    with dask.set_options(array_plugins=[lambda x: x.compute()]):
+    with dask.config.set(array_plugins=[lambda x: x.compute()]):
         x = da.ones(10, chunks=5)
         y = x + 1
 

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -268,7 +268,7 @@ def test_turn_off_fusion():
 
     a = y.__dask_optimize__(y.dask, y.__dask_keys__())
 
-    with dask.set_options(fuse_ave_width=0):
+    with dask.config.set(fuse_ave_width=0):
         b = y.__dask_optimize__(y.dask, y.__dask_keys__())
 
     assert dask.get(a, y.__dask_keys__()) == dask.get(b, y.__dask_keys__())

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -27,10 +27,11 @@ except ImportError:
     from toolz import (frequencies, merge_with, join, reduceby,
                        count, pluck, groupby, topk)
 
+from .. import config
 from ..base import tokenize, dont_optimize, is_dask_collection, DaskMethodsMixin
 from ..bytes import open_files
 from ..compatibility import apply, urlopen
-from ..context import _globals, globalmethod
+from ..context import globalmethod
 from ..core import quote, istask, get_dependencies, reverse_dict
 from ..delayed import Delayed
 from ..multiprocessing import get as mpget
@@ -1226,9 +1227,9 @@ class Bag(DaskMethodsMixin):
         if method is not None:
             raise Exception("The method= keyword has been moved to shuffle=")
         if shuffle is None:
-            shuffle = _globals.get('shuffle')
+            shuffle = config.get('shuffle', None)
         if shuffle is None:
-            if 'distributed' in _globals.get('scheduler', ''):
+            if 'distributed' in config.get('scheduler', ''):
                 shuffle = 'tasks'
             else:
                 shuffle = 'disk'
@@ -2022,7 +2023,7 @@ def groupby_disk(b, grouper, npartitions=None, blocksize=2**20):
 
     import partd
     p = ('partd-' + token,)
-    dirname = _globals.get('temporary_directory', None)
+    dirname = config.get('temporary_directory', None)
     if dirname:
         file = (apply, partd.File, (), {'dir': dirname})
     else:

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -549,7 +549,7 @@ def test_take_npartitions():
 def test_take_npartitions_warn():
     # Use single-threaded scheduler so warnings are properly captured in the
     # same process
-    with dask.set_options(scheduler='sync'):
+    with dask.config.set(scheduler='sync'):
         with pytest.warns(UserWarning):
             b.take(100)
 
@@ -1288,7 +1288,7 @@ def test_repeated_groupby():
 def test_temporary_directory(tmpdir):
     b = db.range(10, npartitions=4)
 
-    with dask.set_options(temporary_directory=str(tmpdir)):
+    with dask.config.set(temporary_directory=str(tmpdir)):
         b2 = b.groupby(lambda x: x % 2)
         b2.compute()
         assert any(fn.endswith('.partd') for fn in os.listdir(str(tmpdir)))

--- a/dask/base.py
+++ b/dask/base.py
@@ -15,11 +15,11 @@ from toolz import merge, groupby, curry, identity
 from toolz.functoolz import Compose
 
 from .compatibility import long, unicode
-from .context import _globals, thread_state
+from .context import thread_state
 from .core import flatten, quote
 from .hashing import hash_buffer_hex
 from .utils import Dispatch, ensure_dict
-from . import threaded, local
+from . import config, local, threaded
 
 
 __all__ = ("DaskMethodsMixin",
@@ -179,7 +179,7 @@ def collections_to_dsk(collections, optimize_graph=True, **kwargs):
     Convert many collections into a single dask graph, after optimization
     """
     optimizations = (kwargs.pop('optimizations', None) or
-                     _globals.get('optimizations', []))
+                     config.get('optimizations', []))
 
     if optimize_graph:
         groups = groupby(optimization_function, collections)
@@ -866,12 +866,12 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
         # else:  # try to connect to remote scheduler with this name
         #     return get_client(scheduler).get
 
-    if _globals.get('scheduler'):
-        return get_scheduler(scheduler=_globals['scheduler'])
+    if config.get('scheduler', None):
+        return get_scheduler(scheduler=config.get('scheduler', None))
 
-    if _globals.get('get'):
-        warn_on_get(_globals['get'])
-        return _globals['get']
+    if config.get('get', None):
+        warn_on_get(config.get('get', None))
+        return config.get('get', None)
 
     if getattr(thread_state, 'key', False):
         from distributed.worker import get_worker

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -11,8 +11,8 @@ from .compression import seekable_files, files as compress_files
 from .utils import (SeekableFile, read_block, infer_compression,
                     infer_storage_options, build_name_function,
                     update_storage_options)
+from .. import config
 from ..compatibility import unicode
-from ..context import _globals
 from ..base import tokenize
 from ..delayed import delayed
 from ..utils import import_required, is_integer
@@ -447,7 +447,7 @@ def get_fs(protocol, storage_options=None):
         cls = _filesystems[protocol]
 
     elif protocol == 'hdfs':
-        cls = get_hdfs_driver(_globals.get("hdfs_driver", "auto"))
+        cls = get_hdfs_driver(config.get("hdfs_driver", "auto"))
 
     elif protocol in ['http', 'https']:
         import_required('requests',

--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -47,7 +47,7 @@ def hdfs(request):
         hdfs.rm(basedir, recursive=True)
     hdfs.mkdir(basedir)
 
-    with dask.set_options(hdfs_driver=request.param):
+    with dask.config.set(hdfs_driver=request.param):
         yield hdfs
 
     if hdfs.exists(basedir):
@@ -68,14 +68,14 @@ def test_fs_driver_backends():
     fs1, token1 = get_fs('hdfs')
     assert isinstance(fs1, HDFS3HadoopFileSystem)
 
-    with dask.set_options(hdfs_driver='pyarrow'):
+    with dask.config.set(hdfs_driver='pyarrow'):
         fs2, token2 = get_fs('hdfs')
     assert isinstance(fs2, PyArrowHadoopFileSystem)
 
     assert token1 != token2
 
     with pytest.raises(ValueError):
-        with dask.set_options(hdfs_driver='not-a-valid-driver'):
+        with dask.config.set(hdfs_driver='not-a-valid-driver'):
             get_fs('hdfs')
 
 
@@ -193,13 +193,13 @@ def test_read_text(hdfs):
         f.write('a b\nc d'.encode())
 
     b = db.read_text('hdfs://%s/text.*.txt' % basedir)
-    with dask.set_options(pool=pool):
+    with dask.config.set(pool=pool):
         result = b.str.strip().str.split().map(len).compute()
 
     assert result == [2, 2, 2, 2, 2, 2]
 
     b = db.read_text('hdfs://%s/other.txt' % basedir)
-    with dask.set_options(pool=pool):
+    with dask.config.set(pool=pool):
         result = b.str.split().flatten().compute()
 
     assert result == ['a', 'b', 'c', 'd']

--- a/dask/context.py
+++ b/dask/context.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 
 import threading
 from functools import partial
+import warnings
 from . import config
 
 _globals = config.config
@@ -12,7 +13,17 @@ _globals = config.config
 
 thread_state = threading.local()
 
-set_options = config.set
+
+_warned_set_options = [False]
+
+
+def set_options(*args, **kwargs):
+    """ Deprecated: see dask.config.set instead """
+    if not _warned_set_options[0]:
+        warnings.warn("The dask.set_options function has been deprecated. "
+                      "Please use dask.config.set instead")
+        _warned_set_options[0] = True
+    return config.set(*args, **kwargs)
 
 
 def globalmethod(default=None, key=None, falsey=None):

--- a/dask/context.py
+++ b/dask/context.py
@@ -6,45 +6,14 @@ from __future__ import absolute_import, division, print_function
 import threading
 from functools import partial
 from collections import defaultdict
+from . import config
 
-_globals = defaultdict(lambda: None)
-_globals['callbacks'] = set()
+_globals = config.config
 
 
 thread_state = threading.local()
 
-
-class set_options(object):
-    """ Set global state within controlled context
-
-    This lets you specify various global settings in a tightly controlled
-    ``with`` block.
-
-    Valid keyword arguments currently include the following::
-
-        get - the scheduler to use
-        pool - a thread or process pool
-        cache - Cache to use for intermediate results
-        func_loads/func_dumps - loads/dumps functions for serialization of data
-            likely to contain functions.  Defaults to
-            cloudpickle.loads/cloudpickle.dumps
-        optimizations - List of additional optimizations to run
-
-    Examples
-    --------
-    >>> with set_options(scheduler='single-threaded'):  # doctest: +SKIP
-    ...     x = np.array(x)  # uses single-threaded scheduler internally
-    """
-    def __init__(self, **kwargs):
-        self.old = _globals.copy()
-        _globals.update(kwargs)
-
-    def __enter__(self):
-        return
-
-    def __exit__(self, type, value, traceback):
-        _globals.clear()
-        _globals.update(self.old)
+set_options = config.set
 
 
 def globalmethod(default=None, key=None, falsey=None):

--- a/dask/context.py
+++ b/dask/context.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function
 
 import threading
 from functools import partial
-from collections import defaultdict
 from . import config
 
 _globals = config.config

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -12,11 +12,10 @@ from toolz import merge
 from .io import _link
 from ...base import get_scheduler
 from ..core import DataFrame, new_dd_object
-from ... import multiprocessing
+from ... import config, multiprocessing
 from ...base import tokenize, compute_as_if_collection
 from ...bytes.utils import build_name_function
 from ...compatibility import PY3
-from ...context import _globals
 from ...delayed import Delayed, delayed
 from ...utils import get_scheduler_lock
 
@@ -163,9 +162,9 @@ def to_hdf(df, path, key, mode='a', append=False, get=None, scheduler=None,
     # If user did not specify scheduler and write is sequential default to the
     # sequential scheduler. otherwise let the _get method choose the scheduler
     if (get is None and
-            'get' not in _globals and
+            not config.get('get', None) and
             scheduler is None and
-            'scheduler' not in _globals and
+            not config.get('scheduler', None) and
             single_node and single_file):
         scheduler = 'single-threaded'
 

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -482,7 +482,7 @@ def test_hdf_globbing():
         df.to_hdf(os.path.join(tdir, 'two.h5'), '/bar/data', format='table')
         df.to_hdf(os.path.join(tdir, 'two.h5'), '/foo/data', format='table')
 
-        with dask.set_options(scheduler='sync'):
+        with dask.config.set(scheduler='sync'):
             res = dd.read_hdf(os.path.join(tdir, 'one.h5'), '/*/data',
                               chunksize=2)
             assert res.npartitions == 2
@@ -516,7 +516,7 @@ def test_hdf_file_list():
         df.iloc[:2].to_hdf(os.path.join(tdir, 'one.h5'), 'dataframe', format='table')
         df.iloc[2:].to_hdf(os.path.join(tdir, 'two.h5'), 'dataframe', format='table')
 
-        with dask.set_options(scheduler='sync'):
+        with dask.config.set(scheduler='sync'):
             input_files = [os.path.join(tdir, 'one.h5'), os.path.join(tdir, 'two.h5')]
             res = dd.read_hdf(input_files, 'dataframe')
             tm.assert_frame_equal(res.compute(), df)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1185,7 +1185,7 @@ def test_writing_parquet_with_kwargs(tmpdir, engine):
     assert_eq(out, ddf, check_index=(engine != 'fastparquet'), check_divisions=should_check_divs(engine))
 
     # Avoid race condition in pyarrow 0.8.0 on writing partitioned datasets
-    with dask.set_options(scheduler='sync'):
+    with dask.config.set(scheduler='sync'):
         ddf.to_parquet(path2, engine=engine, partition_on=['a'],
                        **engine_kwargs[engine])
     out = dd.read_parquet(path2, engine=engine).compute()

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -2,8 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 from ..optimization import cull, fuse_getitem, fuse
-from ..context import _globals
-from .. import core
+from .. import config, core
 
 try:
     import fastparquet  # noqa: F401
@@ -22,6 +21,6 @@ def optimize(dsk, keys, **kwargs):
         from .io.parquet import _read_parquet_row_group
         dsk = fuse_getitem(dsk, _read_parquet_row_group, 4)
     dsk, dependencies = fuse(dsk, keys, dependencies=dependencies,
-                             ave_width=_globals.get('fuse_ave_width', 0))
+                             ave_width=config.get('fuse_ave_width', 0))
     dsk, _ = cull(dsk, keys)
     return dsk

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -13,9 +13,8 @@ from .core import DataFrame, Series, _Frame, _concat, map_partitions
 from .hashing import hash_pandas_object
 from .utils import PANDAS_VERSION
 
-from .. import base
+from .. import base, config
 from ..base import tokenize, compute, compute_as_if_collection
-from ..context import _globals
 from ..delayed import delayed
 from ..sizeof import sizeof
 from ..utils import digit, insert, M
@@ -229,7 +228,7 @@ def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None)
 
 def rearrange_by_column(df, col, npartitions=None, max_branch=None,
                         shuffle=None, compute=None):
-    shuffle = shuffle or _globals.get('shuffle', 'disk')
+    shuffle = shuffle or config.get('shuffle', 'disk')
     if shuffle == 'disk':
         return rearrange_by_column_disk(df, col, npartitions, compute=compute)
     elif shuffle == 'tasks':
@@ -242,7 +241,7 @@ class maybe_buffered_partd(object):
     """If serialized, will return non-buffered partd. Otherwise returns a
     buffered partd"""
     def __init__(self, buffer=True, tempdir=None):
-        self.tempdir = tempdir or _globals.get('temporary_directory')
+        self.tempdir = tempdir or config.get('temporary_directory')
         self.buffer = buffer
 
     def __reduce__(self):

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -241,7 +241,7 @@ class maybe_buffered_partd(object):
     """If serialized, will return non-buffered partd. Otherwise returns a
     buffered partd"""
     def __init__(self, buffer=True, tempdir=None):
-        self.tempdir = tempdir or config.get('temporary_directory')
+        self.tempdir = tempdir or config.get('temporary_directory', None)
         self.buffer = buffer
 
     def __reduce__(self):

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -205,7 +205,7 @@ def test_categorical_set_index(shuffle):
     df['y'] = pd.Categorical(df['y'], categories=['a', 'b', 'c'], ordered=True)
     a = dd.from_pandas(df, npartitions=2)
 
-    with dask.set_options(scheduler='sync', shuffle=shuffle):
+    with dask.config.set(scheduler='sync', shuffle=shuffle):
         b = a.set_index('y', npartitions=a.npartitions)
         d1, d2 = b.get_partition(0), b.get_partition(1)
         assert list(d1.index.compute()) == ['a']

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -215,7 +215,7 @@ def test_groupby_on_index(scheduler):
     def func2(df):
         return df[['b']] - df[['b']].mean()
 
-    with dask.set_options(scheduler=scheduler):
+    with dask.config.set(scheduler=scheduler):
         with pytest.warns(None):
             assert_eq(ddf.groupby('a').apply(func),
                       pdf.groupby('a').apply(func))
@@ -689,7 +689,7 @@ def test_groupby_apply_tasks():
     df['B'] = df.B // 0.1
     ddf = dd.from_pandas(df, npartitions=10)
 
-    with dask.set_options(shuffle='tasks'):
+    with dask.config.set(shuffle='tasks'):
         for ind in [lambda x: 'A', lambda x: x.A]:
             a = df.groupby(ind(df)).apply(len)
             with pytest.warns(UserWarning):
@@ -708,7 +708,7 @@ def test_groupby_multiprocessing():
     df = pd.DataFrame({'A': [1, 2, 3, 4, 5],
                        'B': ['1','1','a','a','a']})
     ddf = dd.from_pandas(df, npartitions=3)
-    with dask.set_options(scheduler='processes'):
+    with dask.config.set(scheduler='processes'):
         assert_eq(ddf.groupby('B').apply(lambda x: x, meta={"A": int,
                                                             "B": object}),
                   df.groupby('B').apply(lambda x: x))

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -42,7 +42,7 @@ def test_fuse_ave_width():
 
     s = ((df.x + 1) + (df.x + 2))
 
-    with dask.set_options(fuse_ave_width=4):
+    with dask.config.set(fuse_ave_width=4):
         a = s.__dask_optimize__(s.dask, s.__dask_keys__())
 
     b = s.__dask_optimize__(s.dask, s.__dask_keys__())

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -288,7 +288,7 @@ def test_set_index_with_explicit_divisions():
     def throw(*args, **kwargs):
         raise Exception()
 
-    with dask.set_options(get=throw):
+    with dask.config.set(get=throw):
         ddf2 = ddf.set_index('x', divisions=[1, 3, 5])
     assert ddf2.divisions == (1, 3, 5)
 
@@ -341,11 +341,11 @@ def test_set_index_divisions_sorted():
     def throw(*args, **kwargs):
         raise Exception("Shouldn't have computed")
 
-    with dask.set_options(get=throw):
+    with dask.config.set(get=throw):
         res = ddf.set_index('x', divisions=[10, 13, 16, 18], sorted=True)
     assert_eq(res, df.set_index('x'))
 
-    with dask.set_options(get=throw):
+    with dask.config.set(get=throw):
         res = ddf.set_index('y', divisions=['a', 'b', 'd', 'e'], sorted=True)
     assert_eq(res, df.set_index('y'))
 
@@ -664,7 +664,7 @@ def test_temporary_directory(tmpdir):
                        'z': np.random.random(100)})
     ddf = dd.from_pandas(df, npartitions=10, name='x', sort=False)
 
-    with dask.set_options(temporary_directory=str(tmpdir),
+    with dask.config.set(temporary_directory=str(tmpdir),
                           scheduler='processes'):
         ddf2 = ddf.set_index('x', shuffle='disk')
         ddf2.compute()
@@ -721,7 +721,7 @@ def test_gh_2730():
     dd_left = dd.from_pandas(small, npartitions=3)
     dd_right = dd.from_pandas(large, npartitions=257)
 
-    with dask.set_options(shuffle='tasks', scheduler='sync'):
+    with dask.config.set(shuffle='tasks', scheduler='sync'):
         dd_merged = dd_left.merge(dd_right, how='inner', on='KEY')
         result = dd_merged.compute()
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -665,7 +665,7 @@ def test_temporary_directory(tmpdir):
     ddf = dd.from_pandas(df, npartitions=10, name='x', sort=False)
 
     with dask.config.set(temporary_directory=str(tmpdir),
-                          scheduler='processes'):
+                         scheduler='processes'):
         ddf2 = ddf.set_index('x', shuffle='disk')
         ddf2.compute()
         assert any(fn.endswith('.partd') for fn in os.listdir(str(tmpdir)))

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -9,12 +9,12 @@ try:
 except ImportError:
     from toolz import curry, pluck
 
-from . import threaded
+from . import config, threaded
 from .base import is_dask_collection, dont_optimize, DaskMethodsMixin
 from .base import tokenize as _tokenize
 from .compatibility import apply
 from .core import quote
-from .context import _globals, globalmethod
+from .context import globalmethod
 from .utils import funcname, methodcaller, OperatorMethodMixin
 from . import sharedict
 
@@ -111,7 +111,7 @@ def tokenize(*args, **kwargs):
     """
     pure = kwargs.pop('pure', None)
     if pure is None:
-        pure = _globals.get('delayed_pure', False)
+        pure = config.get('delayed_pure', False)
 
     if pure:
         return _tokenize(*args, **kwargs)

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -208,10 +208,10 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
     >>> @delayed
     ... def mul(a, b):
     ...     return a * b
-    >>> with dask.set_options(delayed_pure=True):
+    >>> with dask.config.set(delayed_pure=True):
     ...     print(mul(1, 2).key == mul(1, 2).key)
     True
-    >>> with dask.set_options(delayed_pure=False):
+    >>> with dask.config.set(delayed_pure=False):
     ...     print(mul(1, 2).key == mul(1, 2).key)
     False
 
@@ -299,7 +299,7 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
 
     >>> a.count(2, dask_key_name="count_2")
     Delayed('count_2')
-    >>> with dask.set_options(delayed_pure=True):
+    >>> with dask.config.set(delayed_pure=True):
     ...     print(a.count(2).key == a.count(2).key)
     True
     """

--- a/dask/diagnostics/tests/test_progress.py
+++ b/dask/diagnostics/tests/test_progress.py
@@ -2,11 +2,11 @@ from operator import add, mul
 
 import pytest
 
+from dask.callbacks import Callback
 from dask.local import get_sync
 from dask.diagnostics import ProgressBar
 from dask.diagnostics.progress import format_time
 from dask.threaded import get as get_threaded
-from dask.context import _globals
 
 
 dsk = {'a': 1,
@@ -65,16 +65,16 @@ def test_register(capsys):
         p = ProgressBar()
         p.register()
 
-        assert _globals['callbacks']
+        assert Callback.active
 
         get_threaded(dsk, 'e')
         check_bar_completed(capsys)
 
         p.unregister()
 
-        assert not _globals['callbacks']
+        assert not Callback.active
     finally:
-        _globals['callbacks'].clear()
+        Callback.active.clear()
 
 
 def test_no_tasks(capsys):

--- a/dask/local.py
+++ b/dask/local.py
@@ -120,7 +120,7 @@ import sys
 from .compatibility import Queue, Empty, reraise
 from .core import (istask, flatten, reverse_dict, get_dependencies, ishashable,
                    has_tasks)
-from .context import _globals
+from . import config
 from .order import order
 from .callbacks import unpack_callbacks, local_callbacks
 from .optimization import cull
@@ -184,7 +184,7 @@ def start_state_from_dask(dsk, cache=None, sortkey=None):
     if sortkey is None:
         sortkey = order(dsk).get
     if cache is None:
-        cache = _globals['cache']
+        cache = config.get('cache', None)
     if cache is None:
         cache = dict()
     data_keys = set()
@@ -481,7 +481,7 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
                     start_state(dsk, state)
 
             if rerun_exceptions_locally is None:
-                rerun_exceptions_locally = _globals.get('rerun_exceptions_locally', False)
+                rerun_exceptions_locally = config.get('rerun_exceptions_locally', False)
 
             if state['waiting'] and not state['ready']:
                 raise ValueError("Found no accessible jobs in dask")

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -5,8 +5,8 @@ import traceback
 import pickle
 import sys
 
+from . import config
 from .local import get_async  # TODO: get better get
-from .context import _globals
 from .optimization import fuse, cull
 
 import cloudpickle
@@ -146,7 +146,7 @@ def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
     optimize_graph : bool
         If True [default], `fuse` is applied to the graph before computation.
     """
-    pool = _globals['pool']
+    pool = config.get('pool', None)
     if pool is None:
         pool = multiprocessing.Pool(num_workers,
                                     initializer=initialize_worker_process)
@@ -163,8 +163,8 @@ def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
 
     # We specify marshalling functions in order to catch serialization
     # errors and report them to the user.
-    loads = func_loads or _globals.get('func_loads') or _loads
-    dumps = func_dumps or _globals.get('func_dumps') or _dumps
+    loads = func_loads or config.get('func_loads', None) or _loads
+    dumps = func_dumps or config.get('func_dumps', None) or _dumps
 
     # Note former versions used a multiprocessing Manager to share
     # a Queue between parent and workers, but this is fragile on Windows

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -4,8 +4,8 @@ import math
 import re
 from operator import getitem
 
+from . import config
 from .compatibility import unicode
-from .context import _globals
 from .core import (istask, get_dependencies, subs, toposort, flatten,
                    reverse_dict, ishashable)
 from .utils_test import add, inc  # noqa: F401
@@ -505,25 +505,25 @@ def fuse(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
 
     # Assign reasonable, not too restrictive defaults
     if ave_width is None:
-        if _globals.get('fuse_ave_width') is None:
+        if config.get('fuse_ave_width', None) is None:
             ave_width = 1
         else:
-            ave_width = _globals['fuse_ave_width']
+            ave_width = config.get('fuse_ave_width', None)
 
     if max_height is None:
-        if _globals.get('fuse_max_height') is None:
+        if config.get('fuse_max_height', None) is None:
             max_height = len(dsk)
         else:
-            max_height = _globals['fuse_max_height']
+            max_height = config.get('fuse_max_height', None)
 
     max_depth_new_edges = (
         max_depth_new_edges or
-        _globals.get('fuse_max_depth_new_edges') or
+        config.get('fuse_max_depth_new_edges', None) or
         ave_width + 1.5
     )
     max_width = (
         max_width or
-        _globals.get('fuse_max_width') or
+        config.get('fuse_max_width', None) or
         1.5 + ave_width * math.log(ave_width + 1)
     )
 
@@ -531,7 +531,7 @@ def fuse(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
         return dsk, dependencies
 
     if rename_keys is None:
-        rename_keys = _globals.get('fuse_rename_keys', True)
+        rename_keys = config.get('fuse_rename_keys', True)
     if rename_keys is True:
         key_renamer = default_fused_keys_renamer
     elif rename_keys is False:

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -636,7 +636,7 @@ def test_optimizations_keyword():
     x = dask.delayed(inc)(1)
     assert x.compute() == 2
 
-    with dask.set_options(optimizations=[inc_to_dec]):
+    with dask.config.set(optimizations=[inc_to_dec]):
         assert x.compute() == 0
 
     assert x.compute() == 2
@@ -665,7 +665,7 @@ def test_optimize():
     assert dask.compute(x3, y3, z3) == sols
 
     # Optimize respects global optimizations as well
-    with dask.set_options(optimizations=[inc_to_dec]):
+    with dask.config.set(optimizations=[inc_to_dec]):
         x4, y4, z4 = optimize(x, y, z)
     for a, b in zip([x3, y3, z3], [x4, y4, z4]):
         assert dict(a.dask) == dict(b.dask)
@@ -799,14 +799,14 @@ def test_optimize_globals():
 
     assert_eq(x + 1, np.ones(10) + 1)
 
-    with dask.set_options(array_optimize=optimize_double):
+    with dask.config.set(array_optimize=optimize_double):
         assert_eq(x + 1, (np.ones(10) * 2 + 1) * 2)
 
     assert_eq(x + 1, np.ones(10) + 1)
 
     b = db.range(10, npartitions=2)
 
-    with dask.set_options(array_optimize=optimize_double):
+    with dask.config.set(array_optimize=optimize_double):
         xx, bb = dask.compute(x + 1, b.map(inc), scheduler='single-threaded')
         assert_eq(xx, (np.ones(10) * 2 + 1) * 2)
 
@@ -821,7 +821,7 @@ def test_optimize_None():
         assert dsk == dict(y.dask)  # but they aren't
         return dask.get(dsk, keys)
 
-    with dask.set_options(array_optimize=None, get=my_get):
+    with dask.config.set(array_optimize=None, get=my_get):
         y.compute()
 
 
@@ -837,11 +837,11 @@ def test_scheduler_keyword():
         assert x.compute() == 2
         assert x.compute(scheduler='foo') == 123
 
-        with dask.set_options(scheduler='foo'):
+        with dask.config.set(scheduler='foo'):
             assert x.compute() == 123
         assert x.compute() == 2
 
-        with dask.set_options(scheduler='foo'):
+        with dask.config.set(scheduler='foo'):
             assert x.compute(scheduler='threads') == 2
 
         with pytest.raises(ValueError):
@@ -863,6 +863,6 @@ def test_get_scheduler():
     assert get_scheduler() is None
     assert get_scheduler(scheduler='threads') is dask.threaded.get
     assert get_scheduler(scheduler='sync') is dask.local.get_sync
-    with dask.set_options(scheduler='threads'):
+    with dask.config.set(scheduler='threads'):
         assert get_scheduler(scheduler='threads') is dask.threaded.get
     assert get_scheduler() is None

--- a/dask/tests/test_cache.py
+++ b/dask/tests/test_cache.py
@@ -1,8 +1,8 @@
+from dask.callbacks import Callback
 from dask.cache import Cache
 from dask.local import get_sync
 from dask.threaded import get
 from operator import add
-from dask.context import _globals
 from time import sleep
 import pytest
 
@@ -38,7 +38,7 @@ def test_cache():
 
     assert flag == [2]  # no x present
 
-    assert not _globals['callbacks']
+    assert not Callback.active
 
 
 def test_cache_with_number():

--- a/dask/tests/test_callbacks.py
+++ b/dask/tests/test_callbacks.py
@@ -1,5 +1,4 @@
 from dask.local import get_sync
-from dask.context import _globals
 from dask.threaded import get as get_threaded
 from dask.callbacks import Callback
 from dask.utils_test import add
@@ -88,7 +87,7 @@ def test_nested_schedulers():
                  'y': (add, 'x', 3)}
 
     def nested_call(x):
-        assert not _globals['callbacks']
+        assert not Callback.active
         with inner_callback:
             return get_threaded(inner_dsk, 'y') + x
 
@@ -99,18 +98,16 @@ def test_nested_schedulers():
     with outer_callback:
         get_threaded(outer_dsk, 'b')
 
-    assert not _globals['callbacks']
+    assert not Callback.active
     assert outer_callback.dsk == outer_dsk
     assert inner_callback.dsk == inner_dsk
-    assert not _globals['callbacks']
+    assert not Callback.active
 
 
 def test_add_remove_mutates_not_replaces():
-    g = _globals.copy()
-
-    assert not g['callbacks']
+    assert not Callback.active
 
     with Callback():
-        pass
+        assert Callback.active
 
-    assert not g['callbacks']
+    assert not Callback.active

--- a/dask/tests/test_context.py
+++ b/dask/tests/test_context.py
@@ -27,7 +27,7 @@ def test_with_get():
 def test_set_options_context_manger():
     with set_options(foo='bar'):
         assert _globals['foo'] == 'bar'
-    assert _globals['foo'] is None
+    assert _globals.get('foo', None) is None
 
     try:
         set_options(foo='baz')

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -97,7 +97,7 @@ def test_futures_to_delayed_array(loop):
 
 @gen_cluster(client=True)
 def test_local_get_with_distributed_active(c, s, a, b):
-    with dask.set_options(scheduler='sync'):
+    with dask.config.set(scheduler='sync'):
         x = delayed(inc)(1).persist()
     yield gen.sleep(0.01)
     assert not s.tasks # scheduler hasn't done anything

--- a/dask/tests/test_local.py
+++ b/dask/tests/test_local.py
@@ -112,7 +112,7 @@ def test_cache_options():
         assert 'y' in cache
         return x + 1
 
-    with dask.set_options(cache=cache):
+    with dask.config.set(cache=cache):
         get_sync({'x': (inc2, 'y'), 'y': 1}, 'x')
 
 

--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -11,8 +11,8 @@ from multiprocessing.pool import ThreadPool
 import threading
 from threading import current_thread, Lock
 
+from . import config
 from .local import get_async
-from .context import _globals
 from .utils_test import inc, add  # noqa: F401
 
 
@@ -55,7 +55,7 @@ def get(dsk, result, cache=None, num_workers=None, **kwargs):
     (4, 2)
     """
     global default_pool
-    pool = _globals['pool']
+    pool = config.get('pool', None)
     thread = current_thread()
 
     with pools_lock:

--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -385,7 +385,7 @@ all dask.arrays to the global ``array_plugins=`` value:
    >>> def f(x):
    ...     print(x.nbytes)
 
-   >>> with dask.set_options(array_plugins=[f]):
+   >>> with dask.config.set(array_plugins=[f]):
    ...     x = da.ones((10, 1), chunks=(5, 1))
    ...     y = x.dot(x.T)
    80
@@ -409,7 +409,7 @@ hidden by Dask's lazy semantics.
 
 .. code-block:: python
 
-   >>> with dask.set_options(array_plugins=[lambda x: x.compute()]):
+   >>> with dask.config.set(array_plugins=[lambda x: x.compute()]):
    ...     x = da.arange(5, chunks=2)
 
    >>> x  # this was automatically converted into a numpy array
@@ -428,7 +428,7 @@ We may wish to warn users if they are creating chunks that are too large
        if any(nb > 1e9 for nb in nbytes):
            warnings.warn("Array contains very large chunks")
 
-   with dask.set_options(array_plugins=[warn_on_large_chunks]):
+   with dask.config.set(array_plugins=[warn_on_large_chunks]):
        ...
 
 Combine
@@ -439,5 +439,5 @@ other, chaining results through them.
 
 .. code-block:: python
 
-   with dask.set_options(array_plugins=[warn_on_large_chunks, lambda x: x.compute()]):
+   with dask.config.set(array_plugins=[warn_on_large_chunks, lambda x: x.compute()]):
        ...

--- a/docs/source/optimize.rst
+++ b/docs/source/optimize.rst
@@ -304,7 +304,7 @@ you prefer and it will be used instead of the default scheme.
 
 .. code-block:: python
 
-   with dask.set_options(array_optimize=my_optimize_function):
+   with dask.config.set(array_optimize=my_optimize_function):
        x, y = dask.compute(x, y)
 
 You can register separate optimization functions for different collections, or
@@ -313,9 +313,9 @@ be optimized.
 
 .. code-block:: python
 
-   with dask.set_options(array_optimize=my_optimize_function,
-                         dataframe_optimize=None,
-                         delayed_optimize=my_other_optimize_function):
+   with dask.config.set(array_optimize=my_optimize_function,
+                        dataframe_optimize=None,
+                        delayed_optimize=my_other_optimize_function):
        ...
 
 You need not specify all collections.  Collections will default to their

--- a/docs/source/remote-data-services.rst
+++ b/docs/source/remote-data-services.rst
@@ -99,7 +99,7 @@ Spark.
 
 HDFS support can be provided by either hdfs3_ or pyarrow_, defaulting to the
 first library installed in that order. To explicitly set which library to use,
-set ``hdfs_driver`` using ``dask.set_options``:
+set ``hdfs_driver`` using ``dask.config.set``:
 
 .. code-block:: python
 
@@ -107,15 +107,15 @@ set ``hdfs_driver`` using ``dask.set_options``:
     dd.read_csv('hdfs:///path/to/*.csv')
 
    # Use hdfs3 for HDFS I/O
-   with dask.set_options(hdfs_driver='hdfs3'):
+   with dask.config.set(hdfs_driver='hdfs3'):
        dd.read_csv('hdfs:///path/to/*.csv')
 
    # Use pyarrow for HDFS I/O
-   with dask.set_options(hdfs_driver='pyarrow'):
+   with dask.config.set(hdfs_driver='pyarrow'):
        dd.read_csv('hdfs:///path/to/*.csv')
 
    # Set pyarrow as the global hdfs driver
-   dask.set_options(hdfs_driver='pyarrow')
+   dask.config.set(hdfs_driver='pyarrow')
 
 
 By default, both libraries attempt to read the default server and port from

--- a/docs/source/scheduler-overview.rst
+++ b/docs/source/scheduler-overview.rst
@@ -111,17 +111,17 @@ may want to use a different scheduler. There are two ways to do this.
 
         >>> x.sum().compute(scheduler='processes')
 
-2. Using ``dask.set_options``. This can be used either as a context manager, or to
+2. Using ``dask.config.set``. This can be used either as a context manager, or to
    set the scheduler globally:
 
     .. code-block:: python
 
         # As a context manager
-        >>> with dask.set_options(scheduler='processes'):
+        >>> with dask.config.set(scheduler='processes'):
         ...     x.sum().compute()
 
         # Set globally
-        >>> dask.set_options(scheduler='processes')
+        >>> dask.config.set(scheduler='processes')
         >>> x.sum().compute()
 
 
@@ -137,12 +137,12 @@ calling ``compute``:
     >>> x.compute(num_workers=4)
 
 Alternatively, the multiprocessing and threaded schedulers will check for a
-global pool set with ``dask.set_options``:
+global pool set with ``dask.config.set``:
 
 .. code-block:: python
 
     >>> from multiprocessing.pool import ThreadPool
-    >>> with dask.set_options(pool=ThreadPool(4)):
+    >>> with dask.config.set(pool=ThreadPool(4)):
     ...     x.compute()
 
 For more information on the individual options for each scheduler, see the
@@ -160,7 +160,7 @@ well with ``pdb``:
 
 .. code-block:: python
 
-    >>> dask.set_options(scheduler='single-threaded')
+    >>> dask.config.set(scheduler='single-threaded')
     >>> x.sum().compute()    # This computation runs serially instead of in parallel
 
 

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -39,7 +39,7 @@ Local Threads
 .. code-block:: python
 
    import dask
-   dask.set_options(scheduler='threads')  # overwrite default with threaded scheduler
+   dask.config.set(scheduler='threads')  # overwrite default with threaded scheduler
 
 The threaded scheduler executes computations with a local ``multiprocessing.pool.ThreadPool``.
 It is lightweight and requires no setup.
@@ -68,7 +68,7 @@ we encourage readers to continue reading after this section*
 .. code-block:: python
 
    import dask.multiprocessing
-   dask.set_options(scheduler='processes')  # overwrite default with multiprocessing scheduler
+   dask.config.set(scheduler='processes')  # overwrite default with multiprocessing scheduler
 
 
 The multiprocessing scheduler executes computations with a local ``multiprocessing.Pool``.
@@ -108,7 +108,7 @@ Single Thread
 .. code-block:: python
 
    import dask
-   dask.set_options(scheduler='synchronous')  # overwrite default with single-threaded scheduler
+   dask.config.set(scheduler='synchronous')  # overwrite default with single-threaded scheduler
 
 The single-threaded synchronous scheduler executes all computations in the local thread,
 with no parallelism at all.
@@ -159,12 +159,12 @@ We recommend referring to the :doc:`setup documentation <setup>` for more inform
 Configuration
 -------------
 
-You can configure the global default scheduler by using the ``dask.set_options(scheduler...)`` command.
+You can configure the global default scheduler by using the ``dask.config.set(scheduler...)`` command.
 This can be done globally,
 
 .. code-block:: python
 
-   dask.set_options(scheduler='threads')
+   dask.config.set(scheduler='threads')
 
    x.compute()
 
@@ -172,7 +172,7 @@ or as a context manager
 
 .. code-block:: python
 
-   with dask.set_options(scheduler='threads'):
+   with dask.config.set(scheduler='threads'):
        x.compute()
 
 or within a single compute call
@@ -188,8 +188,8 @@ or specify the desired number of workers.
 .. code-block:: python
 
    from multiprocessing.pool import ThreadPool
-   with dask.set_options(pool=ThreadPool(4)):
+   with dask.config.set(pool=ThreadPool(4)):
        ...
 
-   with dask.set_options(num_workers=4):
+   with dask.config.set(num_workers=4):
        ...

--- a/docs/source/setup/single-machine.rst
+++ b/docs/source/setup/single-machine.rst
@@ -53,7 +53,7 @@ You can specify these functions in any of the following ways:
 
     .. code-block:: python
 
-       with dask.set_options(scheduler='threads'):
+       with dask.config.set(scheduler='threads'):
            x.compute()
            y.compute()
 
@@ -61,7 +61,7 @@ You can specify these functions in any of the following ways:
 
     .. code-block:: python
 
-       dask.set_options(scheduler='threads')
+       dask.config.set(scheduler='threads')
 
 
 Use the Distributed Scheduler

--- a/docs/source/shared.rst
+++ b/docs/source/shared.rst
@@ -84,11 +84,11 @@ mediated by using a global or contextual pool:
 
    >>> from multiprocessing.pool import ThreadPool
    >>> pool = ThreadPool()
-   >>> da.set_options(pool=pool)  # set global threadpool
+   >>> dask.config.set(pool=pool)  # set global threadpool
 
    or
 
-   >>> with set_options(pool=pool)  # use threadpool throughout with block
+   >>> with dask.config.set(pool=pool)  # use threadpool throughout with block
    ...     ...
 
 We now measure scaling the number of tasks and scaling the density of the


### PR DESCRIPTION
Previously we had two ways to set global configuration/state

1.  dask.set_options(...) which used dask.context._globals
2.  dask.config.set(...) which used dask.config.config

These are now backed by the same data structure, held in
dask.config.config.  For backwards compatibility they both still work
as before (mostly), though we'll be recommending dask.config.set
in the future.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
