### PR TITLE
Adds synchronous scheduler syntax to debugging docs

### DIFF
--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -54,6 +54,28 @@ faithfully in your local thread, allowing you to use normal tools like ``pdb``,
 all of your normal Python debugging tricks in Dask computations, as long as you
 don't need parallelism.
 
+This single-threaded scheduler can be used by setting
+``scheduler='synchronous'`` in a compute call
+
+.. code-block:: python
+
+    >>> x.compute(scheduler='synchronous')
+
+set globally using ``dask.config.set``
+
+.. code-block:: python
+
+    >>> dask.config.set(scheduler='synchronous')
+
+or as a context manager
+
+.. code-block:: python
+
+    >>> with dask.config.set(scheduler='synchronous'):
+    ...     x.compute()
+
+
+
 This only works for single-machine schedulers.  It does not work with
 dask.distributed unless you are comfortable using the Tornado API (look at the
 `testing infrastructure
@@ -76,7 +98,7 @@ keyword.
 
 .. code-block:: python
 
-   x.compute(rerun_exceptions_locally=True)
+   >>> x.compute(rerun_exceptions_locally=True)
 
 On the distributed scheduler use the ``recreate_error_locally`` method on
 anything that contains ``Futures`` :

--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -54,27 +54,15 @@ faithfully in your local thread, allowing you to use normal tools like ``pdb``,
 all of your normal Python debugging tricks in Dask computations, as long as you
 don't need parallelism.
 
-This single-threaded scheduler can be used by setting
-``scheduler='synchronous'`` in a compute call
+The single-threaded scheduler can be used, for example, by setting
+``scheduler='single-threaded'`` in a compute call
 
 .. code-block:: python
 
-    >>> x.compute(scheduler='synchronous')
+    >>> x.compute(scheduler='single-threaded')
 
-set globally using ``dask.config.set``
-
-.. code-block:: python
-
-    >>> dask.config.set(scheduler='synchronous')
-
-or as a context manager
-
-.. code-block:: python
-
-    >>> with dask.config.set(scheduler='synchronous'):
-    ...     x.compute()
-
-
+For more ways to configure schedulers, see the :ref:`scheduler configuration
+documentation <scheduling-configuration>`.
 
 This only works for single-machine schedulers.  It does not work with
 dask.distributed unless you are comfortable using the Tornado API (look at the

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -155,6 +155,7 @@ You can also run Dask on a distributed cluster.
 There are a variety of ways to set this up depending on your cluster.
 We recommend referring to the :doc:`setup documentation <setup>` for more information.
 
+.. _scheduling-configuration:
 
 Configuration
 -------------


### PR DESCRIPTION
Adds syntax for how to use single-threaded scheduler to debugging docs

See https://github.com/dask/dask/issues/3442#issuecomment-386308258

- [x] Tests added / passed
- [x] Passes `flake8 dask`
