### PR TITLE
Compute dtypes at runtime for fft

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -168,8 +168,8 @@ def fft_wrap(fft_func, kind=None, dtype=None):
 
         _dtype = dtype
         if _dtype is None:
-            _dtype = fft_func(np.ones(len(axes) * (8,),
-                                      dtype=a.dtype)).dtype
+            sample = np.ones(a.ndim * (8,), dtype=a.dtype)
+            _dtype = fft_func(sample).dtype
 
         for each_axis in axes:
             if len(a.chunks[each_axis]) != 1:
@@ -210,20 +210,20 @@ def fft_wrap(fft_func, kind=None, dtype=None):
     return func
 
 
-fft = fft_wrap(np.fft.fft, dtype=np.complex_)
-fft2 = fft_wrap(np.fft.fft2, dtype=np.complex_)
-fftn = fft_wrap(np.fft.fftn, dtype=np.complex_)
-ifft = fft_wrap(np.fft.ifft, dtype=np.complex_)
-ifft2 = fft_wrap(np.fft.ifft2, dtype=np.complex_)
-ifftn = fft_wrap(np.fft.ifftn, dtype=np.complex_)
-rfft = fft_wrap(np.fft.rfft, dtype=np.complex_)
-rfft2 = fft_wrap(np.fft.rfft2, dtype=np.complex_)
-rfftn = fft_wrap(np.fft.rfftn, dtype=np.complex_)
-irfft = fft_wrap(np.fft.irfft, dtype=np.float_)
-irfft2 = fft_wrap(np.fft.irfft2, dtype=np.float_)
-irfftn = fft_wrap(np.fft.irfftn, dtype=np.float_)
-hfft = fft_wrap(np.fft.hfft, dtype=np.float_)
-ihfft = fft_wrap(np.fft.ihfft, dtype=np.complex_)
+fft = fft_wrap(np.fft.fft)
+fft2 = fft_wrap(np.fft.fft2)
+fftn = fft_wrap(np.fft.fftn)
+ifft = fft_wrap(np.fft.ifft)
+ifft2 = fft_wrap(np.fft.ifft2)
+ifftn = fft_wrap(np.fft.ifftn)
+rfft = fft_wrap(np.fft.rfft)
+rfft2 = fft_wrap(np.fft.rfft2)
+rfftn = fft_wrap(np.fft.rfftn)
+irfft = fft_wrap(np.fft.irfft)
+irfft2 = fft_wrap(np.fft.irfft2)
+irfftn = fft_wrap(np.fft.irfftn)
+hfft = fft_wrap(np.fft.hfft)
+ihfft = fft_wrap(np.fft.ihfft)
 
 
 def _fftfreq_block(i, n, d):


### PR DESCRIPTION
It looks like MKL's fft algorithm now supports smaller dtypes,
like float32 and complex64.  This removes our default dtypes to that
we determine dtype with a small computation

cc @jakirkham 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
