### PR TITLE
Add dask.config.update_defaults function

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -27,6 +27,9 @@ if 'DASK_CONFIG' in os.environ:
 global_config = config = {}
 
 
+defaults = []
+
+
 def update(old, new, priority='new'):
     """ Update a nested dictionary with values from another
 
@@ -275,17 +278,35 @@ def collect(paths=paths, env=None):
     return merge(*configs)
 
 
-def refresh(config=config, **kwargs):
+def refresh(config=config, defaults=defaults, **kwargs):
     """
     Update configuration by re-reading yaml files and env variables
 
     This mutates the global dask.config.config, or the config parameter if
     passed in.
 
+    This goes through the following stages:
+
+    1.  Clearing out all old configuration
+    2.  Updating from the stored defaults from downstream libraries
+        (see update_defaults)
+    3.  Updating from yaml files and environment variables
+
+    Note that some functionality only checks configuration once at startup and
+    may not change behavior, even if configuration changes.  It is recommended
+    to restart your python process if convenient to ensure that new
+    configuration changes take place.
+
     See Also
     --------
     dask.config.collect: for parameters
+    dask.config.update_defaults
     """
+    config.clear()
+
+    for d in defaults:
+        update(config, d, priority='old')
+
     update(config, collect(**kwargs))
 
 
@@ -341,6 +362,19 @@ def rename(aliases, config=config):
         del config[k]  # TODO: support nested keys
 
     set(new, config=config)
+
+
+def update_defaults(new, config=config, defaults=defaults):
+    """ Add a new set of defaults to the configuration
+
+    It does two things:
+
+    1.  Add the defaults to a global collection to be used by refresh later
+    2.  Updates the global config with the new configuration
+        prioritizing older values over newer ones
+    """
+    defaults.append(new)
+    update(config, new, priority='old')
 
 
 refresh()

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -4,7 +4,8 @@ import os
 import pytest
 
 from dask.config import (update, merge, collect_yaml, collect_env, get,
-                         ensure_file, set, config, rename)
+                         ensure_file, set, config, rename, update_defaults,
+                         refresh)
 from dask.utils import tmpfile
 
 
@@ -193,3 +194,17 @@ def test_rename():
     config = {'foo-bar': 123}
     rename(aliases, config=config)
     assert config == {'foo': {'bar': 123}}
+
+
+def test_refresh():
+    defaults = []
+    config = {}
+
+    update_defaults({'a': 1}, config=config, defaults=defaults)
+    assert config == {'a': 1}
+
+    refresh(paths=[], env={'DASK_B': '2'}, config=config, defaults=defaults)
+    assert config == {'a': 1, 'b': 2}
+
+    refresh(paths=[], env={'DASK_C': '3'}, config=config, defaults=defaults)
+    assert config == {'a': 1, 'c': 3}

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -252,6 +252,7 @@ Downstream Libraries
 .. autosummary::
    dask.config.ensure_file
    dask.config.update
+   dask.config.update_defaults
 
 Downstream Dask libraries often follow a standard convention to use the central
 Dask configuration.  This section provides recommendations for integration,
@@ -296,7 +297,7 @@ Downstream projects typically follow the following convention:
        with open(fn) as f:
            defaults = yaml.load(f)
 
-       dask.config.update(dask.config.config, defaults, priority='old')
+       dask.config.update_defaults(defaults)
 
 4.  Within that same config.py file, copy the ``'foo.yaml'`` file to the user's
     configuration directory if it doesn't already exist.
@@ -321,7 +322,7 @@ Downstream projects typically follow the following convention:
 
        from . import config
 
-5.  Within ``dask_foo`` code, use the ``dask.config.get`` function to access
+6.  Within ``dask_foo`` code, use the ``dask.config.get`` function to access
     configuration values
 
     .. code-block:: python
@@ -330,6 +331,22 @@ Downstream projects typically follow the following convention:
 
        def process(fn, color=dask.config.get('foo.color')):
            ...
+
+7.  You may also want to ensure that your yaml configuration files are included
+    in your package.  This can be accomplished by including the following line
+    in your MANIFEST.in::
+
+       recursive-include <PACKAGE_NAME> *.yaml
+
+    and the following in your setup.py ``setup`` call
+
+    .. code-block:: python
+
+        from setuptools import setup
+
+        setup(...,
+              include_package_data=True,
+              ...)
 
 This process keeps configuration in a central place, but also keeps it safe
 within namespaces.  It places config files in an easy to access location


### PR DESCRIPTION
This provides a uniform way for downstream library to register their
default values.

Previously our recommendation was for downstream libraries to update the
global configuraiton directly.  This had issues when the global config
would be reset, for example when refreshing the configuration.  Now we
remember these default values in a list of dicts and store them for
future use.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
