### PR TITLE
Correct internal dimension of Dask's SVD

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -163,6 +163,12 @@ def tsqr(data, name=None, compute_svd=False):
                   shape=(n, n), chunks=(n, n), dtype=rr.dtype)
         return q, r
     else:
+        k = np.nanmin([m, n])
+
+        # Force to int if a nan was present.
+        if not np.isnan(k):
+            k = int(k)
+
         # In-core SVD computation
         name_svd_st2 = prefix + 'SVD_st2'
         dsk_svd_st2 = top(np.linalg.svd, name_svd_st2, 'ij', name_r_st2, 'ij',
@@ -193,9 +199,9 @@ def tsqr(data, name=None, compute_svd=False):
 
         uu, ss, vv = np.linalg.svd(np.ones(shape=(1, 1), dtype=data.dtype))
 
-        u = Array(dsk, name_u_st4, shape=data.shape, chunks=data.chunks,
+        u = Array(dsk, name_u_st4, shape=(m, k), chunks=(data.chunks[0], (k,)),
                   dtype=uu.dtype)
-        s = Array(dsk, name_s_st2, shape=(n,), chunks=((n,),), dtype=ss.dtype)
+        s = Array(dsk, name_s_st2, shape=(k,), chunks=((k,),), dtype=ss.dtype)
         v = Array(dsk, name_v_st2, shape=(n, n), chunks=((n,), (n,)),
                   dtype=vv.dtype)
         return u, s, v

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -97,6 +97,23 @@ def test_linalg_consistent_names():
     assert same_keys(v1, v2)
 
 
+@pytest.mark.parametrize("m,n", [
+    (10, 20),
+    (15, 15),
+    (20, 10),
+])
+def test_dask_svd_self_consistent(m, n):
+    a = np.random.rand(m, n)
+    d_a = da.from_array(a, chunks=(3, n), name='A')
+
+    d_u, d_s, d_vt = da.linalg.svd(d_a)
+    u, s, vt = da.compute(d_u, d_s, d_vt)
+
+    for d_e, e in zip([d_u, d_s, d_vt], [u, s, vt]):
+        assert d_e.shape == e.shape
+        assert d_e.dtype == e.dtype
+
+
 @pytest.mark.slow
 def test_svd_compressed():
     m, n = 2000, 250


### PR DESCRIPTION
Previously the Dask Array SVD code had assumed the shared dimension would be equal to the column in the Dask Array matrix always. However the shared dimension in SVD is whichever is shortest (row or column) of the provided matrix. Computing the results actually provides NumPy Arrays of the expected shape. Meaning that the chunking is merely being misreported when constructing the Dask Arrays from the Dask graph. Hence this fixes how the shapes and chunks of the resulting Dask Arrays are determined.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
