### PR TITLE
Adds index to unsupprted argument for DataFrame.rename

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2565,7 +2565,7 @@ class DataFrame(_Frame):
         df2 = self._meta.assign(**_extract_meta(kwargs))
         return elemwise(methods.assign, self, *pairs, meta=df2)
 
-    @derived_from(pd.DataFrame)
+    @derived_from(pd.DataFrame, ua_args=['index'])
     def rename(self, index=None, columns=None):
         if index is not None:
             raise ValueError("Cannot rename index.")

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,7 @@ Dataframe
 +++++++++
 
 - Add to/read_json (:pr:`3494`) `Martin Durant`_
+- Adds ``index`` to unsupported arguments for ``DataFrame.rename`` method (:pr:`3522`) `James Bourbeau`_
 
 Bag
 +++


### PR DESCRIPTION
This PR adds `index` the to unsupported argument list for `DataFrame.rename` method. Closes #3504. 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
