### PR TITLE
Fixes bug, where size of dimensions would not always be checked 

### DIFF
--- a/dask/array/gufunc.py
+++ b/dask/array/gufunc.py
@@ -199,18 +199,18 @@ def apply_gufunc(func, signature, *args, **kwargs):
             _chunksizes.append(chunksize)
             chunksizess[dim] = _chunksizes
     ### Assert correct partitioning, for case:
-    if not allow_rechunk:
-        for dim, sizes in dimsizess.items():
-            ### Check that the arrays have same length for same dimensions or dimension `1`
-            if set(sizes).union({1}) != {1, max(sizes)}:
-                raise ValueError("Dimension `'{}'` with different lengths in arrays".format(dim))
+    for dim, sizes in dimsizess.items():
+        #### Check that the arrays have same length for same dimensions or dimension `1`
+        if set(sizes).union({1}) != {1, max(sizes)}:
+            raise ValueError("Dimension `'{}'` with different lengths in arrays".format(dim))
+        if not allow_rechunk:
             chunksizes = chunksizess[dim]
-            ### Check if core dimensions consist of only one chunk
+            #### Check if core dimensions consist of only one chunk
             if (dim in core_shapes) and (chunksizes[0] < core_shapes[dim]):
                 raise ValueError("Core dimension `'{}'` consists of multiple chunks. To fix, rechunk into a single \
 chunk along this dimension or set `allow_rechunk=True`, but beware that this may increase memory usage \
 significantly.".format(dim))
-            ### Check if loop dimensions consist of same chunksizes, when they have sizes > 1
+            #### Check if loop dimensions consist of same chunksizes, when they have sizes > 1
             relevant_chunksizes = list(unique(c for s, c in zip(sizes, chunksizes) if s > 1))
             if len(relevant_chunksizes) > 1:
                 raise ValueError("Dimension `'{}'` with different chunksize present".format(dim))

--- a/dask/array/tests/test_gufunc.py
+++ b/dask/array/tests/test_gufunc.py
@@ -260,3 +260,15 @@ def test_apply_gufunc_broadcasting_loopdims():
     assert x.compute().shape == (20, 10, 30)
     assert y.compute().shape == (20, 10, 30)
     assert z.compute().shape == (20, 10, 30)
+
+
+def test_apply_gufunc_check_same_dimsizes():
+    def foo(x, y):
+        return x + y
+
+    a = da.random.normal(size=(3,), chunks=(2,))
+    b = da.random.normal(size=(4,), chunks=(2,))
+
+    with assert_raises(ValueError) as excinfo:
+        apply_gufunc(foo, "(),()->()", a, b, output_dtypes=float, allow_rechunk=True)
+    assert "different lengths in arrays" in str(excinfo.value)


### PR DESCRIPTION
Minor follow up on PR #3109, because it contains a bug, where size of same dimensions would not always be checked and adds test for it.

The bug is, that it only checks for `allow_rechunk=True`, but size of dimensions should be checked always.

- [x] Tests added / passed
- [x] Passes `flake8 dask`