### PR TITLE
Adds support for subsetting DataFrames with pandas Index/Series and numpy ndarrays

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2359,7 +2359,7 @@ class DataFrame(_Frame):
         elif isinstance(key, slice):
             return self.loc[key]
 
-        if isinstance(key, (list, pd.Index)):
+        if isinstance(key, (pd.Series, np.ndarray, pd.Index, list)):
             # error is raised from pandas
             meta = self._meta[_extract_meta(key)]
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2359,7 +2359,7 @@ class DataFrame(_Frame):
         elif isinstance(key, slice):
             return self.loc[key]
 
-        if isinstance(key, list):
+        if isinstance(key, (list, pd.Index)):
             # error is raised from pandas
             meta = self._meta[_extract_meta(key)]
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2621,6 +2621,14 @@ def test_getitem_string_subclass():
     assert_eq(df[column_1], ddf[column_1])
 
 
+def test_getitem_index():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
+    ddf = dd.from_pandas(df, 2)
+    index = pd.Index(['C', 'A', 'B'])
+
+    assert_eq(df[index], ddf[index])
+
+
 def test_diff():
     df = pd.DataFrame(np.random.randn(100, 5), columns=list('abcde'))
     ddf = dd.from_pandas(df, 5)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2621,12 +2621,13 @@ def test_getitem_string_subclass():
     assert_eq(df[column_1], ddf[column_1])
 
 
-def test_getitem_index():
-    df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
+@pytest.mark.parametrize('col_type', [list, np.array, pd.Series, pd.Index])
+def test_getitem_column_types(col_type):
+    df = pd.DataFrame({'A': [1, 2], 'B': [3, 4], 'C': [5, 6]})
     ddf = dd.from_pandas(df, 2)
-    index = pd.Index(['C', 'A', 'B'])
+    cols = col_type(['C', 'A', 'B'])
 
-    assert_eq(df[index], ddf[index])
+    assert_eq(df[cols], ddf[cols])
 
 
 def test_diff():

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,7 @@ Dataframe
 
 - Add to/read_json (:pr:`3494`) `Martin Durant`_
 - Adds ``index`` to unsupported arguments for ``DataFrame.rename`` method (:pr:`3522`) `James Bourbeau`_
+- Adds support to subset Dask DataFrame columns using ``pandas.Index`` objects (:pr:`3536`) `James Bourbeau`_
 
 Bag
 +++

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,7 +15,7 @@ Dataframe
 
 - Add to/read_json (:pr:`3494`) `Martin Durant`_
 - Adds ``index`` to unsupported arguments for ``DataFrame.rename`` method (:pr:`3522`) `James Bourbeau`_
-- Adds support to subset Dask DataFrame columns using ``pandas.Index`` objects (:pr:`3536`) `James Bourbeau`_
+- Adds support to subset Dask DataFrame columns using ``numpy.ndarray``, ``pandas.Series``, and ``pandas.Index`` objects (:pr:`3536`) `James Bourbeau`_
 
 Bag
 +++


### PR DESCRIPTION
Adds support for subsetting DataFrame columns with `pd.Index` objects. Closes #2832. 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
