### PR TITLE
BUG: do not raise IndexError for identity slice in array.vindex

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1342,8 +1342,14 @@ class Array(DaskMethodsMixin):
                 "vindex does not support indexing with None (np.newaxis), "
                 "got {}".format(key))
         if all(isinstance(k, slice) for k in key):
+            slices = (k.indices(num_dim) for k, num_dim in zip(key, self.shape))
+            identity = all(slice_ == (0, num_dim, 1)
+                           for slice_, num_dim in zip(slices, self.shape))
+            if identity:
+                return self
             raise IndexError(
-                "vindex requires at least one non-slice to vectorize over. "
+                "vindex requires at least one non-slice to vectorize over "
+                "when the slices are not over the entire array (i.e, x[:]). "
                 "Use normal slicing instead when only using slices. Got: {}"
                 .format(key))
         return _vindex(self, *key)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1343,9 +1343,9 @@ class Array(DaskMethodsMixin):
                 "got {}".format(key))
         if all(isinstance(k, slice) for k in key):
             slices = (k.indices(num_dim) for k, num_dim in zip(key, self.shape))
-            identity = all(slice_ == (0, num_dim, 1)
-                           for slice_, num_dim in zip(slices, self.shape))
-            if identity:
+            identity_slices = ((0, num_in_dim, 1)   # i.e, x[:]
+                               for num_in_dim in self.shape)
+            if all(slice_ == identity for slice_, identity in zip(slices, identity_slices)):
                 return self
             raise IndexError(
                 "vindex requires at least one non-slice to vectorize over "

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1342,10 +1342,8 @@ class Array(DaskMethodsMixin):
                 "vindex does not support indexing with None (np.newaxis), "
                 "got {}".format(key))
         if all(isinstance(k, slice) for k in key):
-            slices = (k.indices(num_dim) for k, num_dim in zip(key, self.shape))
-            identity_slices = ((0, num_in_dim, 1)   # i.e, x[:]
-                               for num_in_dim in self.shape)
-            if all(slice_ == identity for slice_, identity in zip(slices, identity_slices)):
+            if all(k.indices(d) == slice(0, d).indices(d)
+                   for k, d in zip(key, self.shape)):
                 return self
             raise IndexError(
                 "vindex requires at least one non-slice to vectorize over "

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2340,12 +2340,14 @@ def test_vindex_identity():
 
     x = rng.random(a, chunks=a // 2)
     assert x is x.vindex[:]
+    assert x is x.vindex[:a]
     pytest.raises(IndexError, lambda: x.vindex[:a - 1])
     pytest.raises(IndexError, lambda: x.vindex[1:])
     pytest.raises(IndexError, lambda: x.vindex[0:a:2])
 
     x = rng.random((a, b), chunks=(a // 2, b // 2))
     assert x is x.vindex[:, :]
+    assert x is x.vindex[:a, :b]
     pytest.raises(IndexError, lambda: x.vindex[:, :b - 1])
     pytest.raises(IndexError, lambda: x.vindex[:, 1:])
     pytest.raises(IndexError, lambda: x.vindex[:, 0:b:2])

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2317,7 +2317,6 @@ def test_vindex_negative():
 def test_vindex_errors():
     d = da.ones((5, 5, 5), chunks=(3, 3, 3))
     pytest.raises(IndexError, lambda: d.vindex[np.newaxis])
-    pytest.raises(IndexError, lambda: d.vindex[:5])
     pytest.raises(IndexError, lambda: d.vindex[[1, 2], [1, 2, 3]])
     pytest.raises(IndexError, lambda: d.vindex[[True] * 5])
     pytest.raises(IndexError, lambda: d.vindex[[0], [5]])
@@ -2333,6 +2332,23 @@ def test_vindex_merge():
     assert (_vindex_merge(locations, values) == np.array([[40, 50, 60],
                                                           [1, 2, 3],
                                                           [10, 20, 30]])).all()
+
+
+def test_vindex_identity():
+    rng = da.random.RandomState(42)
+    a, b = 10, 20
+
+    x = rng.random(a, chunks=a // 2)
+    assert x is x.vindex[:]
+    pytest.raises(IndexError, lambda: x.vindex[:a - 1])
+    pytest.raises(IndexError, lambda: x.vindex[1:])
+    pytest.raises(IndexError, lambda: x.vindex[0:a:2])
+
+    x = rng.random((a, b), chunks=(a // 2, b // 2))
+    assert x is x.vindex[:, :]
+    pytest.raises(IndexError, lambda: x.vindex[:, :b - 1])
+    pytest.raises(IndexError, lambda: x.vindex[:, 1:])
+    pytest.raises(IndexError, lambda: x.vindex[:, 0:b:2])
 
 
 def test_empty_array():


### PR DESCRIPTION
This closes #3211. This PR ensures that `x is x.vindex[:]` for a Dask array `x`. This works for any identity indexing slice, not only 1D (e.g., `x[:, :]` or `x[:, :, :]`).

- [x] Tests added: `test_vindex_identity`.
    * This performs makes several assertions for two dimensions. I deliberately left this expanded for readability. 
    * I test the edge cases: off by one (`x[:n - 1]` or `x[1:]`) and slices with a stride of 2 (`x[0:n:2]`).
- [x] Passes `flake8 dask` (well, warns on a bunch but not on this diff).