### PR TITLE
Support Zarr Arrays in `to_zarr`/`from_zarr`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2273,6 +2273,10 @@ def to_zarr(arr, url, component=None, storage_options=None,
 
     if isinstance(url, zarr.Array):
         z = url
+        if (isinstance(z.store, (dict, zarr.DictStore)) and
+                'distributed' in config.get('scheduler', '')):
+            raise RuntimeError('Cannot store into in memory Zarr Array using '
+                               'the Distributed Scheduler.')
         arr = arr.rechunk(z.chunks)
         return store(arr, z, lock=False, compute=compute,
                      return_stored=return_stored)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3364,6 +3364,17 @@ def test_zarr_roundtrip():
         assert a2.chunks == a.chunks
 
 
+def test_zarr_existing_array():
+    zarr = pytest.importorskip('zarr')
+    c = (1, 1)
+    a = da.ones((3, 3), chunks=c)
+    z = zarr.zeros_like(a, chunks=c)
+    a.to_zarr(z)
+    a2 = da.from_zarr(z)
+    assert_eq(a, a2)
+    assert a2.chunks == a.chunks
+
+
 def test_read_zarr_chunks():
     pytest.importorskip('zarr')
     a = da.zeros((9, ), chunks=(3, ))

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -163,3 +163,15 @@ def test_zarr_distributed_roundtrip(loop):
                 a2 = da.from_zarr(d)
                 assert_eq(a, a2)
                 assert a2.chunks == a.chunks
+
+
+def test_zarr_in_memory_distributed_err(loop):
+    da = pytest.importorskip('dask.array')
+    zarr = pytest.importorskip('zarr')
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            with pytest.raises(RuntimeError):
+                c = (1, 1)
+                a = da.ones((3, 3), chunks=c)
+                z = zarr.zeros_like(a, chunks=c)
+                a.to_zarr(z)

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -169,7 +169,8 @@ def test_zarr_in_memory_distributed_err(loop):
     da = pytest.importorskip('dask.array')
     zarr = pytest.importorskip('zarr')
     with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
+        with Client(s['address'], loop=loop,
+                    client_kwargs={'set_as_default': True}) as c:
             with pytest.raises(RuntimeError):
                 c = (1, 1)
                 a = da.ones((3, 3), chunks=c)

--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -270,6 +270,13 @@ or to save to a particular bucket on S3:
    >>> arr.to_zarr('s3://mybucket/output.zarr', storage_option={'key': 'mykey',
                    'secret': 'mysecret'})
 
+or your own custom zarr Array:
+
+.. code-block:: Python
+
+   >>> z = zarr.create((10,), dtype=float, store=zarr.ZipStore("output.zarr"))
+   >>> arr.to_zarr(z)
+
 To retrieve those data, you would do ``da.read_zarr`` with exactly the same arguments. The
 chunking of the resultant dask.Array is defined by how the files were saved, unless
 otherwise specified.


### PR DESCRIPTION
Supports Zarr Arrays as arguments of `to_zarr`/`from_zarr`. Thus allowing in memory Zarr Arrays to be used.

- [x] Tests added / passed
- [x] Passes `flake8 dask`