### PR TITLE
Fix env None check

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -271,7 +271,7 @@ def collect(paths=paths, env=None):
     --------
     dask.config.refresh: collect configuration and update into primary config
     """
-    if os is None:
+    if env is None:
         env = os.environ
     configs = []
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -123,6 +123,15 @@ def test_collect():
             assert config == expected
 
 
+def test_collect_env_none():
+    os.environ['DASK_FOO'] = 'bar'
+    try:
+        config = collect([])
+        assert config == {'foo': 'bar'}
+    finally:
+        del os.environ['DASK_FOO']
+
+
 def test_get():
     d = {'x': 1, 'y': {'a': 2}}
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -3,9 +3,9 @@ import os
 
 import pytest
 
-from dask.config import (update, merge, collect_yaml, collect_env, get,
-                         ensure_file, set, config, rename, update_defaults,
-                         refresh)
+from dask.config import (update, merge, collect, collect_yaml, collect_env,
+                         get, ensure_file, set, config, rename,
+                         update_defaults, refresh)
 from dask.utils import tmpfile
 
 
@@ -98,6 +98,29 @@ def test_env():
     }
 
     assert collect_env(env) == expected
+
+
+def test_collect():
+    a = {'x': 1, 'y': {'a': 1}}
+    b = {'x': 2, 'z': 3, 'y': {'b': 2}}
+    env = {'DASK_W': 4}
+
+    expected = {
+        'w': 4,
+        'x': 2,
+        'y': {'a': 1, 'b': 2},
+        'z': 3,
+    }
+
+    with tmpfile(extension='yaml') as fn1:
+        with tmpfile(extension='yaml') as fn2:
+            with open(fn1, 'w') as f:
+                yaml.dump(a, f)
+            with open(fn2, 'w') as f:
+                yaml.dump(b, f)
+
+            config = collect([fn1, fn2], env=env)
+            assert config == expected
 
 
 def test_get():


### PR DESCRIPTION
I think the `if os is None` check is invalid, changing it to `if env is None`.

- [x] Tests added / passed
- [x] Passes `flake8 dask`


