### PR TITLE
Dataframe sample method docstring fix

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1037,9 +1037,9 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         ----------
         frac : float
             Fraction of axis items to return.
-        replace: boolean, optional
+        replace : boolean, optional
             Sample with or without replacement. Default = False.
-        random_state: int or ``np.random.RandomState``
+        random_state : int or ``np.random.RandomState``
             If int we create a new RandomState with this as the seed
             Otherwise we draw from the passed RandomState
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1035,7 +1035,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
 
         Parameters
         ----------
-        frac : float, optional
+        frac : float
             Fraction of axis items to return.
         replace: boolean, optional
             Sample with or without replacement. Default = False.


### PR DESCRIPTION
Ran across a minor documentation error. Currently the `frac` parameter for the Dataframe `sample` method is listed as optional. However it's a required positional argument. This PR just removes "optional" from the corresponding docstring. 

- [ ] ~~Tests added / passed~~
- [x] Passes `flake8 dask`
