### PR TITLE
[array.linalg.qr] added sfqr (short-and-fat) as a counterpart to tsqr…

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -505,8 +505,6 @@ def triu(m, k=0):
     """
     if m.ndim != 2:
         raise ValueError('input must be 2 dimensional')
-    if m.shape[0] != m.shape[1]:
-        raise NotImplementedError('input must be a square matrix')
     if m.chunks[0][0] != m.chunks[1][0]:
         msg = ('chunks must be a square. '
                'Use .rechunk method to change the size of chunks.')
@@ -555,8 +553,6 @@ def tril(m, k=0):
     """
     if m.ndim != 2:
         raise ValueError('input must be 2 dimensional')
-    if m.shape[0] != m.shape[1]:
-        raise NotImplementedError('input must be a square matrix')
     if not len(set(m.chunks[0] + m.chunks[1])) == 1:
         msg = ('All chunks must be a square matrix to perform lu decomposition. '
                'Use .rechunk method to change the size of chunks.')

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -158,10 +158,14 @@ def tsqr(data, name=None, compute_svd=False):
 
     if not compute_svd:
         qq, rr = np.linalg.qr(np.ones(shape=(1, 1), dtype=data.dtype))
+        q_shape = data.shape if data.shape[0] >= data.shape[1] else (data.shape[0], data.shape[0])
+        q_chunks = data.chunks if data.shape[0] >= data.shape[1] else (data.chunks[0], data.chunks[0])
+        r_shape = (n, n) if data.shape[0] >= data.shape[1] else data.shape
+        r_chunks = (n, n) if data.shape[0] >= data.shape[1] else data.chunks
         q = Array(dsk, name_q_st3,
-                  shape=data.shape, chunks=data.chunks, dtype=qq.dtype)
+                  shape=q_shape, chunks=q_chunks, dtype=qq.dtype)
         r = Array(dsk, name_r_st2,
-                  shape=(n, n), chunks=(n, n), dtype=rr.dtype)
+                  shape=r_shape, chunks=r_chunks, dtype=rr.dtype)
         return q, r
     else:
         # In-core SVD computation
@@ -425,7 +429,8 @@ def qr(a, name=None):
     dask.array.linalg.sfqr: Implementation for short-and-fat arrays
     """
 
-    if len(a.chunks[1]) == 1:
+    # if len(a.chunks[1]) == 1 and a.shape[0] >= a.shape[1]:
+    if len(a.chunks[1]) == 1: # and a.shape[0] >= a.shape[1]:
         return tsqr(a, name)
     elif len(a.chunks[0]) == 1:
         return sfqr(a, name)

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -430,7 +430,7 @@ def qr(a, name=None):
     elif len(a.chunks[0]) == 1:
         return sfqr(a, name)
     else:
-        raise NotImplemented(
+        raise NotImplementedError(
             "qr currently supports only tall-and-skinny (single column chunk/block; see tsqr)\n"
             "and short-and-fat (single row chunk/block; see sfqr) matrices\n\n"
             "Consider use of the rechunk method. For example,\n\n"

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -161,11 +161,10 @@ def tsqr(data, name=None, compute_svd=False):
         q_shape = data.shape if data.shape[0] >= data.shape[1] else (data.shape[0], data.shape[0])
         q_chunks = data.chunks if data.shape[0] >= data.shape[1] else (data.chunks[0], data.chunks[0])
         r_shape = (n, n) if data.shape[0] >= data.shape[1] else data.shape
-        r_chunks = (n, n) if data.shape[0] >= data.shape[1] else data.chunks
         q = Array(dsk, name_q_st3,
                   shape=q_shape, chunks=q_chunks, dtype=qq.dtype)
         r = Array(dsk, name_r_st2,
-                  shape=r_shape, chunks=r_chunks, dtype=rr.dtype)
+                  shape=r_shape, chunks=n, dtype=rr.dtype)
         return q, r
     else:
         # In-core SVD computation

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -47,18 +47,16 @@ def tsqr(data, name=None, compute_svd=False):
 
     Parameters
     ----------
-
     data: Array
     compute_svd: bool
         Whether to compute the SVD rather than the QR decomposition
 
     See Also
     --------
-
     dask.array.linalg.qr - Powered by this algorithm
     dask.array.linalg.svd - Powered by this algorithm
+    dask.array.linalg.sfqr - Variant for short-and-fat arrays
     """
-
     if not (data.ndim == 2 and                    # Is a matrix
             len(data.chunks[1]) == 1):         # Only one column block
         raise ValueError(
@@ -218,15 +216,13 @@ def sfqr(data, name=None):
 
     Parameters
     ----------
-
     data: Array
 
     See Also
     --------
-
-    dask.array.linalg.qr - Supported by this
+    dask.array.linalg.qr - Main user API that uses this function
+    dask.array.linalg.tsqr - Variant for tall-and-skinny case
     """
-
     nr, nc = len(data.chunks[0]), len(data.chunks[1])
     cr, cc = data.chunks[0][0], data.chunks[1][0]
 
@@ -425,8 +421,8 @@ def qr(a, name=None):
     --------
 
     np.linalg.qr : Equivalent NumPy Operation
-    dask.array.linalg.tsqr: Actual implementation for len(a.chunks[1]) == 1 (with citation)
-    dask.array.linalg.sfqr: Actual implementation for len(a.chunks[0]) == 1
+    dask.array.linalg.tsqr: Implementation for tall-and-skinny arrays
+    dask.array.linalg.sfqr: Implementation for short-and-fat arrays
     """
 
     if len(a.chunks[1]) == 1:
@@ -464,7 +460,7 @@ def svd(a, name=None):
     --------
 
     np.linalg.svd : Equivalent NumPy Operation
-    dask.array.linalg.tsqr: Actual implementation with citation
+    dask.array.linalg.tsqr: Implementation for tall-and-skinny arrays
     """
     return tsqr(a, name, compute_svd=True)
 

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -429,8 +429,7 @@ def qr(a, name=None):
     dask.array.linalg.sfqr: Implementation for short-and-fat arrays
     """
 
-    # if len(a.chunks[1]) == 1 and a.shape[0] >= a.shape[1]:
-    if len(a.chunks[1]) == 1: # and a.shape[0] >= a.shape[1]:
+    if len(a.chunks[1]) == 1 and len(a.chunks[0]) > 1:
         return tsqr(a, name)
     elif len(a.chunks[0]) == 1:
         return sfqr(a, name)

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -10,7 +10,7 @@ import toolz
 from ..base import tokenize
 from ..compatibility import apply
 from .. import sharedict
-from .core import top, dotmany, Array
+from .core import top, dotmany, Array, concatenate
 from .creation import eye
 from .random import RandomState
 
@@ -62,7 +62,7 @@ def tsqr(data, name=None, compute_svd=False):
     if not (data.ndim == 2 and                    # Is a matrix
             len(data.chunks[1]) == 1):         # Only one column block
         raise ValueError(
-            "Input must have the following properties:\n"
+            "[tsqr] Input must have the following properties:\n"
             "  1. Have two dimensions\n"
             "  2. Have only one column of blocks")
 
@@ -201,6 +201,96 @@ def tsqr(data, name=None, compute_svd=False):
         return u, s, v
 
 
+def sfqr(data, name=None):
+    """ Direct Short-and-Fat QR
+
+    Currently, this is a quick hack for non-tall-and-skinny matrices which
+    are one chunk tall and (unless they are one chunk wide) have chunks
+    that are wider than they are tall
+
+    Q [R_1 R_2 ...] = [A_1 A_2 ...]
+
+    it computes the factorization Q R_1 = A_1, then computes the other
+    R_k's in parallel.
+
+    Parameters
+    ----------
+
+    data: Array
+
+    See Also
+    --------
+
+    dask.array.linalg.qr - Supported by this
+    """
+
+    nr, nc = len(data.chunks[0]), len(data.chunks[1])
+    cr, cc = data.chunks[0][0], data.chunks[1][0]
+
+    if not ((data.ndim == 2) and  # Is a matrix
+            (nr == 1) and         # Has exactly one block row
+            ((cr <= cc) or        # Chunking dimension on rows is at least that on cols or...
+             (nc == 1))):         # ... only one block col
+        raise ValueError(
+            "[sfqr] Input must have the following properties:\n"
+            "  1. Have two dimensions\n"
+            "  2. Have only one row of blocks\n"
+            "  3. Either one column of blocks or chunking dimension on rows is at most that on cols"
+        )
+
+    prefix = name or 'sfqr-' + tokenize(data)
+    prefix += '_'
+
+    m, n = data.shape
+
+    qq, rr = np.linalg.qr(np.ones(shape=(1, 1), dtype=data.dtype))
+
+    dsk = sharedict.ShareDict()
+    dsk.update(data.dask)
+
+    # data = A = [A_1 A_rest]
+    name_A_1 = prefix + 'A_1'
+    name_A_rest = prefix + 'A_rest'
+    dsk.update_with_key({
+        (name_A_1, 0, 0): (data.name, 0, 0)
+    }, key=name_A_1)
+    dsk.update_with_key({
+        (name_A_rest, 0, idx): (data.name, 0, 1 + idx)
+        for idx in range(nc - 1)
+    }, key=name_A_rest)
+
+    # Q R_1 = A_1
+    name_Q_R1 = prefix + 'Q_R_1'
+    name_Q = prefix + 'Q'
+    name_R_1 = prefix + 'R_1'
+    dsk.update_with_key({
+        (name_Q_R1, 0, 0): (np.linalg.qr, (name_A_1, 0, 0))
+    }, key=name_Q_R1)
+    dsk.update_with_key({
+        (name_Q, 0, 0): (operator.getitem, (name_Q_R1, 0, 0), 0)
+    }, key=name_Q)
+    dsk.update_with_key({
+        (name_R_1, 0, 0): (operator.getitem, (name_Q_R1, 0, 0), 1),
+    }, key=name_R_1)
+
+    Q = Array(dsk, name_Q,
+              shape=(m, min(m, n)), chunks=(m, min(m, n)), dtype=qq.dtype)
+    R_1 = Array(dsk, name_R_1,
+                shape=(min(m, n), cc), chunks=(cr, cc), dtype=rr.dtype)
+
+    # R = [R_1 Q'A_rest]
+    Rs = [R_1]
+
+    if nc > 1:
+        A_rest = Array(dsk, name_A_rest,
+                       shape=(min(m, n), n - cc), chunks=(cr, cc), dtype=rr.dtype)
+        Rs.append(Q.T.dot(A_rest))
+
+    R = concatenate(Rs, axis=1)
+
+    return Q, R
+
+
 def compression_level(n, q, oversampling=10, min_subspace_size=20):
     """ Compression level to use in svd_compressed
 
@@ -327,9 +417,10 @@ def qr(a, name=None):
     --------
 
     np.linalg.qr : Equivalent NumPy Operation
-    dask.array.linalg.tsqr: Actual implementation with citation
+    dask.array.linalg.tsqr: Actual implementation for len(a.chunks[1]) == 1 (with citation)
+    dask.array.linalg.sfqr: Actual implementation otherwise
     """
-    return tsqr(a, name)
+    return tsqr(a, name) if len(a.chunks[1]) == 1 else sfqr(a, name)
 
 
 def svd(a, name=None):

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -282,9 +282,12 @@ def test_tril_triu_errors():
     dA = da.from_array(A, chunks=(5, 5, 5))
     pytest.raises(ValueError, lambda: da.triu(dA))
 
+
+def test_tril_triu_non_square_arrays():
     A = np.random.randint(0, 11, (30, 35))
     dA = da.from_array(A, chunks=(5, 5))
-    pytest.raises(NotImplementedError, lambda: da.triu(dA))
+    assert_eq(da.triu(dA), np.triu(A))
+    assert_eq(da.tril(dA), np.tril(A))
 
 
 def test_eye():

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -18,8 +18,6 @@ def test_tsqr_regular_blocks():
     data = da.from_array(mat, chunks=(10, n), name='A')
 
     q, r = tsqr(data)
-    q = np.array(q)
-    r = np.array(r)
 
     assert_eq(mat, np.dot(q, r))  # accuracy check
     assert_eq(np.eye(n, n), np.dot(q.T, q))  # q must be orthonormal
@@ -33,54 +31,29 @@ def test_tsqr_irregular_blocks():
     mat2 = mat[1:, :]
 
     q, r = tsqr(data)
-    q = np.array(q)
-    r = np.array(r)
 
     assert_eq(mat2, np.dot(q, r))  # accuracy check
     assert_eq(np.eye(n, n), np.dot(q.T, q))  # q must be orthonormal
     assert_eq(r, np.triu(r))  # r must be upper triangular
 
 
-def test_sfqr_regular_blocks():
-    m, n = 10, 40
+@pytest.mark.parametrize('m_n_chunks', [
+    (10, 40, (10, 10)),  # regular blocks
+    (10, 40, (10, 15)),  # irregular blocks
+    (10, 40, ((10), (15, 5, 5, 8, 7))),  # non-uniform chunks (why?)
+    (10, 5, 10),         # thin
+])
+def test_sfqr(m_n_chunks):
+    m, n, chunks = m_n_chunks
     mat = np.random.rand(m, n)
-    data = da.from_array(mat, chunks=(10, 10), name='A')
+    data = da.from_array(mat, chunks=chunks, name='A')
 
     q, r = sfqr(data)
-    q = np.array(q)
-    r = np.array(r)
+
+    m_qtq = min(m, n)
 
     assert_eq(mat, np.dot(q, r))  # accuracy check
-    assert_eq(np.eye(m, m), np.dot(q.T, q))  # q must be orthonormal
-    assert_eq(r, np.triu(r))  # r must be upper triangular
-
-
-def test_sfqr_thin():
-    m, n = 10,5
-    mat = np.random.rand(m, n)
-    data = da.from_array(mat, chunks=(10, 5), name='A')
-
-    q, r = sfqr(data)
-    q = np.array(q)
-    r = np.array(r)
-
-    assert_eq(mat, np.dot(q, r))  # accuracy check
-    assert_eq(np.eye(n, n), np.dot(q.T, q))  # q must be orthonormal
-    assert_eq(r, np.triu(r))  # r must be upper triangular
-
-
-def test_sfqr_irregular_blocks():
-    m, n = 10, 40
-    mat = np.random.rand(m, n)
-    data = da.from_array(mat, chunks=(10, 10), name='A')[1:]
-    mat2 = mat[1:, :]
-
-    q, r = sfqr(data)
-    q = np.array(q)
-    r = np.array(r)
-
-    assert_eq(mat2, np.dot(q, r))  # accuracy check
-    assert_eq(np.eye(m - 1, m - 1), np.dot(q.T, q))  # q must be orthonormal
+    assert_eq(np.eye(m_qtq, m_qtq), np.dot(q.T, q))  # q must be orthonormal
     assert_eq(r, np.triu(r))  # r must be upper triangular
 
 

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -28,10 +28,16 @@ from dask.array.utils import assert_eq, same_keys
 def test_tsqr(m, n, chunks, error_type):
     mat = np.random.rand(m, n)
     data = da.from_array(mat, chunks=chunks, name='A')
-    m_qtq = min(m, n)
+    m_q = m
+    n_q = min(m, n)
+    m_r = n_q
+    n_r = n
+    m_qtq = n_q
 
     if error_type is None:
         q, r = tsqr(data)
+        assert_eq((m_q, n_q), q.shape)  # shape check
+        assert_eq((m_r, n_r), r.shape)  # shape check
         assert_eq(mat, da.dot(q, r))  # accuracy check
         assert_eq(np.eye(m_qtq, m_qtq), da.dot(q.T, q))  # q must be orthonormal
         assert_eq(r, da.triu(r.rechunk(r.shape[0])))  # r must be upper triangular
@@ -56,10 +62,16 @@ def test_tsqr(m, n, chunks, error_type):
 def test_sfqr(m, n, chunks, error_type):
     mat = np.random.rand(m, n)
     data = da.from_array(mat, chunks=chunks, name='A')
-    m_qtq = min(m, n)
+    m_q = m
+    n_q = min(m, n)
+    m_r = n_q
+    n_r = n
+    m_qtq = n_q
 
     if error_type is None:
         q, r = sfqr(data)
+        assert_eq((m_q, n_q), q.shape)  # shape check
+        assert_eq((m_r, n_r), r.shape)  # shape check
         assert_eq(mat, da.dot(q, r))  # accuracy check
         assert_eq(np.eye(m_qtq, m_qtq), da.dot(q.T, q))  # q must be orthonormal
         assert_eq(r, da.triu(r.rechunk(r.shape[0])))  # r must be upper triangular
@@ -84,10 +96,16 @@ def test_sfqr(m, n, chunks, error_type):
 def test_qr(m, n, chunks, error_type):
     mat = np.random.rand(m, n)
     data = da.from_array(mat, chunks=chunks, name='A')
-    m_qtq = min(m, n)
+    m_q = m
+    n_q = min(m, n)
+    m_r = n_q
+    n_r = n
+    m_qtq = n_q
 
     if error_type is None:
         q, r = qr(data)
+        assert_eq((m_q, n_q), q.shape)  # shape check
+        assert_eq((m_r, n_r), r.shape)  # shape check
         assert_eq(mat, da.dot(q, r))  # accuracy check
         assert_eq(np.eye(m_qtq, m_qtq), da.dot(q.T, q))  # q must be orthonormal
         assert_eq(r, da.triu(r.rechunk(r.shape[0])))  # r must be upper triangular

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -12,7 +12,7 @@ from dask.array.linalg import tsqr, sfqr, svd_compressed, qr, svd
 from dask.array.utils import assert_eq, same_keys
 
 
-@pytest.mark.parametrize('m_n_chunks_err', [
+@pytest.mark.parametrize('m,n,chunks,error_type', [
     (20, 10, 10, None),        # tall-skinny regular blocks
     (20, 10, (3, 10), None),   # tall-skinny regular fat layers
     (20, 10, (3, 10), None),   # tall-skinny irregular fat layers
@@ -25,8 +25,7 @@ from dask.array.utils import assert_eq, same_keys
     (10, 40, ((10), (15, 5, 5, 8, 7)), ValueError),  # short-fat non-uniform chunks (why?)
     (20, 20, 10, ValueError),  # 2x2 regular blocks
 ])
-def test_tsqr(m_n_chunks_err):
-    m, n, chunks, error_type = m_n_chunks_err
+def test_tsqr(m, n, chunks, error_type):
     mat = np.random.rand(m, n)
     data = da.from_array(mat, chunks=chunks, name='A')
     m_qtq = min(m, n)
@@ -41,7 +40,7 @@ def test_tsqr(m_n_chunks_err):
             q, r = tsqr(data)
 
 
-@pytest.mark.parametrize('m_n_chunks_err', [
+@pytest.mark.parametrize('m,n,chunks,error_type', [
     (20, 10, 10, ValueError),        # tall-skinny regular blocks
     (20, 10, (3, 10), ValueError),   # tall-skinny regular fat layers
     (20, 10, (3, 10), ValueError),   # tall-skinny irregular fat layers
@@ -54,8 +53,7 @@ def test_tsqr(m_n_chunks_err):
     (10, 40, ((10), (15, 5, 5, 8, 7)), None),  # short-fat non-uniform chunks (why?)
     (20, 20, 10, ValueError),  # 2x2 regular blocks
 ])
-def test_sfqr(m_n_chunks_err):
-    m, n, chunks, error_type = m_n_chunks_err
+def test_sfqr(m, n, chunks, error_type):
     mat = np.random.rand(m, n)
     data = da.from_array(mat, chunks=chunks, name='A')
     m_qtq = min(m, n)
@@ -70,7 +68,7 @@ def test_sfqr(m_n_chunks_err):
             q, r = sfqr(data)
 
 
-@pytest.mark.parametrize('m_n_chunks_err', [
+@pytest.mark.parametrize('m,n,chunks,error_type', [
     (20, 10, 10, None),        # tall-skinny regular blocks
     (20, 10, (3, 10), None),   # tall-skinny regular fat layers
     (20, 10, (3, 10), None),   # tall-skinny irregular fat layers
@@ -83,8 +81,7 @@ def test_sfqr(m_n_chunks_err):
     (10, 40, ((10), (15, 5, 5, 8, 7)), None),  # short-fat non-uniform chunks (why?)
     (20, 20, 10, NotImplementedError),  # 2x2 regular blocks
 ])
-def test_qr(m_n_chunks_err):
-    m, n, chunks, error_type = m_n_chunks_err
+def test_qr(m, n, chunks, error_type):
     mat = np.random.rand(m, n)
     data = da.from_array(mat, chunks=chunks, name='A')
     m_qtq = min(m, n)

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -219,6 +219,7 @@ Linear Algebra
    linalg.solve_triangular
    linalg.svd
    linalg.svd_compressed
+   linalg.sfqr
    linalg.tsqr
 
 Masked Arrays


### PR DESCRIPTION
… (tall-and-skinny) to extend the applicability of qr; most "big data" cases using QR decompositions would probably be either short-and-fat or tall-and-skinny  #diversity

 - [X] 3 tests added based on those for `tsqr`
 - [X] flake8 passed