### PR TITLE
Update sizeof definitions

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -8,7 +8,8 @@ try:  # PyPy does not support sys.getsizeof
     sys.getsizeof(1)
     getsizeof = sys.getsizeof
 except (AttributeError, TypeError):  # Monkey patch
-    getsizeof = lambda x: 100
+    def getsizeof(x):
+        return 100
 
 
 sizeof = Dispatch(name='sizeof')
@@ -39,29 +40,39 @@ def register_numpy():
 @sizeof.register_lazy("pandas")
 def register_pandas():
     import pandas as pd
+    import numpy as np
+
+    def object_size(x):
+        if not len(x):
+            return 0
+        sample = np.random.choice(x, size=20, replace=True)
+        sample = list(map(sizeof, sample))
+        return sum(sample) / 20 * len(x)
 
     @sizeof.register(pd.DataFrame)
     def sizeof_pandas_dataframe(df):
-        p = int(df.memory_usage(index=True).sum())
-        obj = int((df.dtypes == object).sum() * len(df) * 100)
-        if df.index.dtype == object:
-            obj += len(df) * 100
-        return int(p + obj) + 1000
+        p = sizeof(df.index)
+        for name, col in df.iteritems():
+            p += col.memory_usage(index=False)
+            if col.dtype == object:
+                p += object_size(col._values)
+        return int(p) + 1000
 
     @sizeof.register(pd.Series)
     def sizeof_pandas_series(s):
         p = int(s.memory_usage(index=True))
         if s.dtype == object:
-            p += len(s) * 100
+            p += object_size(s._values)
         if s.index.dtype == object:
-            p += len(s) * 100
+            p += object_size(s.index)
         return int(p) + 1000
 
     @sizeof.register(pd.Index)
     def sizeof_pandas_index(i):
         p = int(i.memory_usage())
-        obj = len(i) * 100 if i.dtype == object else 0
-        return int(p + obj) + 1000
+        if i.dtype == object:
+            p += object_size(i)
+        return int(p) + 1000
 
 
 @sizeof.register_lazy("scipy")

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -22,7 +22,7 @@ def test_containers():
 
 def test_numpy():
     np = pytest.importorskip('numpy')
-    assert sizeof(np.empty(1000, dtype='f8')) == 8000
+    assert 8000 <= sizeof(np.empty(1000, dtype='f8')) <= 9000
     dt = np.dtype('f8')
     assert sizeof(dt) == sys.getsizeof(dt)
 
@@ -43,6 +43,13 @@ def test_pandas():
     assert isinstance(sizeof(df.index), int)
 
 
+def test_pandas_repeated_column():
+    pd = pytest.importorskip('pandas')
+    df = pd.DataFrame({'x': [1, 2, 3]})
+
+    assert sizeof(df[['x', 'x', 'x']]) > sizeof(df)
+
+
 def test_sparse_matrix():
     sparse = pytest.importorskip('scipy.sparse')
     sp = sparse.eye(10)
@@ -54,3 +61,33 @@ def test_sparse_matrix():
     assert sizeof(sp.tocsr()) >= 232
     assert sizeof(sp.todok()) >= 192
     assert sizeof(sp.tolil()) >= 204
+
+
+def test_serires_object_dtype():
+    pd = pytest.importorskip('pandas')
+    s = pd.Series(['a'] * 1000)
+    assert sizeof('a') * 1000 < sizeof(s) < 2 * sizeof('a') * 1000
+
+    s = pd.Series(['a' * 1000] * 1000)
+    assert sizeof(s) > 1000000
+
+
+def test_dataframe_object_dtype():
+    pd = pytest.importorskip('pandas')
+    df = pd.DataFrame({'x': ['a'] * 1000})
+    assert sizeof('a') * 1000 < sizeof(df) < 2 * sizeof('a') * 1000
+
+    s = pd.Series(['a' * 1000] * 1000)
+    assert sizeof(s) > 1000000
+
+
+def test_empty():
+    pd = pytest.importorskip('pandas')
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': ['a' * 100, 'b' * 100, 'c' * 100]},
+                      index=[10, 20, 30])
+    empty = df.head(0)
+
+    assert sizeof(empty) > 0
+    assert sizeof(empty.x) > 0
+    assert sizeof(empty.y) > 0
+    assert sizeof(empty.index) > 0


### PR DESCRIPTION
Previously we had two independent implementations in dask/dask and
dask/distributed that had diverged.  This brings them back in sync.

We'll remove the version in dask/distributed shortly to avoid this from
happening again.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
