### PR TITLE
fixes dd.read_json to infer file compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ _base_envs:
   - &test_and_lint TEST='true' LINT='true'
   - &coverage COVERAGE='true' PARALLEL='false'
   - &no_coverage COVERAGE='false' PARALLEL='true'
-  - &optimize PYTHONOPTIMIZE=2 XTRATESTARGS='--ignore=dask/diagnostics --ignore=dask/bytes/tests/test_http.py'
+  - &optimize PYTHONOPTIMIZE=2 XTRATESTARGS='--ignore=dask/diagnostics'
   - &no_optimize XTRATESTARGS=
   - &imports TEST_IMPORTS='true'
   - &no_imports TEST_IMPORTS='false'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ _base_envs:
   - &test_and_lint TEST='true' LINT='true'
   - &coverage COVERAGE='true' PARALLEL='false'
   - &no_coverage COVERAGE='false' PARALLEL='true'
-  - &optimize PYTHONOPTIMIZE=2 XTRATESTARGS=--ignore=dask/diagnostics
+  - &optimize PYTHONOPTIMIZE=2 XTRATESTARGS='--ignore=dask/diagnostics --ignore=dask/bytes/tests/test_http.py'
   - &no_optimize XTRATESTARGS=
   - &imports TEST_IMPORTS='true'
   - &no_imports TEST_IMPORTS='false'

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -105,6 +105,11 @@ if [[ ${UPSTREAM_DEV} ]]; then
     pip install --pre --no-deps --upgrade --timeout=60 -f $PRE_WHEELS numpy pandas
 fi;
 
+# quick fix for a bug in requests==2.19.0 that makes it not work with PYTHONOPTIMIZE=2
+if [[ $PYTHONOPTIMIZE = '2' ]]; then
+    echo "Forcing requests==2.18.4"
+    pip install requests==2.18.4
+fi;
 
 # Install dask
 pip install --no-deps -e .[complete]

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import requests
 import subprocess
 import sys
 import time
@@ -10,6 +9,7 @@ from dask.compatibility import PY2
 from dask.utils import tmpdir
 
 files = ['a', 'b']
+requests = pytest.importorskip('requests')
 
 
 @pytest.fixture(scope='module')

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -11,7 +11,7 @@ from dask.utils import tmpfile, tmpdir
 
 df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
                    'y': [1, 2, 3, 4]})
-ddf = dd.from_pandas(df, npartitions=1)
+ddf = dd.from_pandas(df, npartitions=2)
 
 
 @pytest.mark.parametrize('orient', ['split', 'records', 'index', 'columns',

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -73,12 +73,7 @@ def test_json_compressed(compression):
 
 def test_read_json_inferred_compression():
     with tmpdir() as path:
-        fn = os.path.join(path, 'test.json')
-        # pandas < 0.21.0 doesn't support compression in to_json
-        # so do it manually here to allow testing for all versions
-        df.to_json(fn, orient='records', lines=True)
-        with open(fn, 'rb') as f_in:
-            with gzip.open(fn + '.gz', 'wb') as f_out:
-                shutil.copyfileobj(f_in, f_out)
-        actual = dd.read_json(fn + '.gz')
+        fn = os.path.join(path, '*.json.gz')
+        dd.to_json(ddf, fn, compression='gzip')
+        actual = dd.read_json(fn)
         assert_eq(df, actual.compute(), check_index=False)

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -1,8 +1,6 @@
-import gzip
 import os
 import pandas as pd
 import pytest
-import shutil
 
 import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -16,6 +16,7 @@ columns = ['time', 'date']
 
 @pytest.mark.network
 def test_orc_with_backend():
+    pytest.importorskip('requests')
     d = read_orc(url)
     assert set(d.columns) == {'time', 'date'}  # order is not guranteed
     assert len(d) == 70000


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `flake8 dask`

This PR is a fix for https://github.com/dask/dask/issues/3593

I added a test, all of the json tests pass but I'm getting a stack overflow error on dask/dataframe/io/tests/test_hdf.py so I can't actually verify that the rest are still working... This PR shouldn't have an impact on anything else though.