### PR TITLE
Replace token= keyword with name= in map_blocks

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1304,7 +1304,6 @@ class Array(DaskMethodsMixin):
         if (isinstance(index, (str, unicode)) or
                 (isinstance(index, list) and index and
                  all(isinstance(i, (str, unicode)) for i in index))):
-            out = 'getitem-' + tokenize(self, index)
             if isinstance(index, (str, unicode)):
                 dt = self.dtype[index]
             else:
@@ -1313,10 +1312,12 @@ class Array(DaskMethodsMixin):
             if dt.shape:
                 new_axis = list(range(self.ndim, self.ndim + len(dt.shape)))
                 chunks = self.chunks + tuple((i,) for i in dt.shape)
-                return self.map_blocks(getitem, index, dtype=dt.base, name=out,
-                                       chunks=chunks, new_axis=new_axis)
+                return self.map_blocks(getitem, index, dtype=dt.base,
+                                       name='getitem', chunks=chunks,
+                                       new_axis=new_axis)
             else:
-                return self.map_blocks(getitem, index, dtype=dt, name=out)
+                return self.map_blocks(getitem, index, dtype=dt,
+                                       name='getitem')
 
         if not isinstance(index, tuple):
             index = (index,)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -659,7 +659,7 @@ def map_blocks(func, *args, **kwargs):
     You may specify the key name prefix of the resulting task in the graph with
     the optional ``token`` keyword argument.
 
-    >>> x.map_blocks(lambda x: x + 1, token='increment')  # doctest: +SKIP
+    >>> x.map_blocks(lambda x: x + 1, name='increment')  # doctest: +SKIP
     dask.array<increment, shape=(100,), dtype=int64, chunksize=(10,)>
     """
     if not callable(func):
@@ -669,9 +669,11 @@ def map_blocks(func, *args, **kwargs):
         raise TypeError(msg % type(func).__name__)
     name = kwargs.pop('name', None)
     token = kwargs.pop('token', None)
-    if not name:
-        name = '%s-%s' % (token or funcname(func),
-                          tokenize(token or func, args, **kwargs))
+    if token:
+        warnings.warn("The token= keyword to map_blocks has been moved to name=")
+        name = token
+
+    name = '%s-%s' % (name or funcname(func), tokenize(func, *args, **kwargs))
     dtype = kwargs.pop('dtype', None)
     chunks = kwargs.pop('chunks', None)
     drop_axis = kwargs.pop('drop_axis', [])

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1313,11 +1313,9 @@ class Array(DaskMethodsMixin):
                 new_axis = list(range(self.ndim, self.ndim + len(dt.shape)))
                 chunks = self.chunks + tuple((i,) for i in dt.shape)
                 return self.map_blocks(getitem, index, dtype=dt.base,
-                                       name='getitem', chunks=chunks,
-                                       new_axis=new_axis)
+                                       chunks=chunks, new_axis=new_axis)
             else:
-                return self.map_blocks(getitem, index, dtype=dt,
-                                       name='getitem')
+                return self.map_blocks(getitem, index, dtype=dt)
 
         if not isinstance(index, tuple):
             index = (index,)
@@ -1466,7 +1464,6 @@ class Array(DaskMethodsMixin):
             raise TypeError("astype does not take the following keyword "
                             "arguments: {0!s}".format(list(extra)))
         casting = kwargs.get('casting', 'unsafe')
-        copy = kwargs.get('copy', True)
         dtype = np.dtype(dtype)
         if self.dtype == dtype:
             return self
@@ -1474,8 +1471,7 @@ class Array(DaskMethodsMixin):
             raise TypeError("Cannot cast array from {0!r} to {1!r}"
                             " according to the rule "
                             "{2!r}".format(self.dtype, dtype, casting))
-        name = 'astype-' + tokenize(self, dtype, casting, copy)
-        return self.map_blocks(chunk.astype, dtype=dtype, name=name,
+        return self.map_blocks(chunk.astype, dtype=dtype,
                                astype_dtype=dtype, **kwargs)
 
     def __abs__(self):

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -14,6 +14,7 @@ from toolz import concat, merge, sliding_window, interleave
 from .. import sharedict
 from ..core import flatten
 from ..base import tokenize
+from ..utils import funcname
 from . import chunk
 from .creation import arange
 from .utils import safe_wraps
@@ -319,7 +320,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     # Adds other axes as needed.
     result = arr.map_blocks(
         _inner_apply_along_axis,
-        token="apply_along_axis",
+        name=funcname(func1d) + '-along-axis',
         dtype=test_result.dtype,
         chunks=(arr.chunks[:axis] + test_result.shape + arr.chunks[axis + 1:]),
         drop_axis=axis,
@@ -1138,7 +1139,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
         _int_piecewise,
         x, *condlist,
         dtype=x.dtype,
-        token="piecewise",
+        name="piecewise",
         funclist=funclist, func_args=args, func_kw=kw
     )
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -21,7 +21,7 @@ import dask.array as da
 from dask.base import tokenize, compute_as_if_collection
 from dask.delayed import Delayed, delayed
 from dask.utils import ignoring, tmpfile, tmpdir
-from dask.utils_test import inc
+from dask.utils_test import inc, dec
 
 from dask.array import chunk
 
@@ -1097,11 +1097,9 @@ def test_map_blocks():
     assert_eq(e, x + 1)
 
     e = d.map_blocks(inc, name='increment')
-    assert e.name == 'increment'
+    assert e.name.startswith('increment-')
 
-    e = d.map_blocks(inc, token='increment')
-    assert e.name != 'increment'
-    assert e.name.startswith('increment')
+    assert d.map_blocks(inc, name='foo').name != d.map_blocks(dec, name='foo').name
 
     d = from_array(x, chunks=(10, 10))
     e = d.map_blocks(lambda x: x[::2, ::2], chunks=(5, 5), dtype=d.dtype)


### PR DESCRIPTION
Behavior here was reversed from normal dask.array conventions.
This does an abrupt change of the name= semantics and issues a warning
when users use token=, pointing them to name=

See https://github.com/dask/dask/issues/3226#issuecomment-396419864

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
