### PR TITLE
Document Dask Array's `nan_to_num` in public API

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -134,6 +134,7 @@ Top level user functions:
    nanstd
    nansum
    nanvar
+   nan_to_num
    nextafter
    nonzero
    notnull
@@ -489,6 +490,7 @@ Other functions
 .. autofunction:: nanstd
 .. autofunction:: nansum
 .. autofunction:: nanvar
+.. autofunction:: nan_to_num
 .. autofunction:: nextafter
 .. autofunction:: nonzero
 .. autofunction:: notnull


### PR DESCRIPTION
Appears that we wrapped NumPy's `nan_to_num` function for use with Dask Arrays, but it didn't make it into the docs. This adds `nan_to_num` to Dask Array's API docs.