### PR TITLE
Show block example

### DIFF
--- a/docs/source/array-stack.rst
+++ b/docs/source/array-stack.rst
@@ -62,9 +62,9 @@ existing dimension
 Block
 -----
 
-We can handle a larger variety of cases with ``da.block``. Basically it allows
-concatenation to applied over multiple dimensions at once. This is useful if
-your chunks tile a space (e.g. small squares from a larger 2-D plane).
+We can handle a larger variety of cases with ``da.block`` as it allows
+concatenation to be applied over multiple dimensions at once. This is useful if
+your chunks tile a space. For example, small squares from a larger 2-D plane.
 
 .. code-block:: python
 

--- a/docs/source/array-stack.rst
+++ b/docs/source/array-stack.rst
@@ -64,7 +64,7 @@ Block
 
 We can handle a larger variety of cases with ``da.block`` as it allows
 concatenation to be applied over multiple dimensions at once. This is useful if
-your chunks tile a space. For example, small squares from a larger 2-D plane.
+your chunks tile a space. For example, small squares tiling a larger 2-D plane.
 
 .. code-block:: python
 

--- a/docs/source/array-stack.rst
+++ b/docs/source/array-stack.rst
@@ -17,18 +17,21 @@ as we go.
 .. code-block:: python
 
    >>> import dask.array as da
-   >>> data = [da.from_array(np.ones((4, 4)), chunks=(2, 2))
-   ...          for i in range(3)]  # A small stack of dask arrays
+
+   >>> arr0 = da.from_array(np.zeros((3, 4)), chunks=(1, 2))
+   >>> arr1 = da.from_array(np.ones((3, 4)), chunks=(1, 2))
+
+   >>> data = [arr0, arr1]
 
    >>> x = da.stack(data, axis=0)
    >>> x.shape
-   (3, 4, 4)
+   (2, 3, 4)
 
    >>> da.stack(data, axis=1).shape
-   (4, 3, 4)
+   (3, 2, 4)
 
    >>> da.stack(data, axis=-1).shape
-   (4, 4, 3)
+   (3, 4, 2)
 
 This creates a new dimension with length equal to the number of slices
 
@@ -43,12 +46,14 @@ existing dimension
    >>> import dask.array as da
    >>> import numpy as np
 
-   >>> data = [da.from_array(np.ones((4, 4)), chunks=(2, 2))
-   ...          for i in range(3)]  # small stack of dask arrays
+   >>> arr0 = da.from_array(np.zeros((3, 4)), chunks=(1, 2))
+   >>> arr1 = da.from_array(np.ones((3, 4)), chunks=(1, 2))
+
+   >>> data = [arr0, arr1]
 
    >>> x = da.concatenate(data, axis=0)
    >>> x.shape
-   (12, 4)
+   (6, 4)
 
    >>> da.concatenate(data, axis=1).shape
-   (4, 12)
+   (3, 8)

--- a/docs/source/array-stack.rst
+++ b/docs/source/array-stack.rst
@@ -64,7 +64,7 @@ Block
 
 We can handle a larger variety of cases with ``da.block`` as it allows
 concatenation to be applied over multiple dimensions at once. This is useful if
-your chunks tile a space. For example, small squares tiling a larger 2-D plane.
+your chunks tile a space, for example if small squares tile a larger 2-D plane.
 
 .. code-block:: python
 

--- a/docs/source/array-stack.rst
+++ b/docs/source/array-stack.rst
@@ -1,12 +1,13 @@
-Stack and Concatenate
-=====================
+Stack, Concatenate, and Block
+=============================
 
 Often we have many arrays stored on disk that we want to stack together and
 think of as one large array.  This is common with geospatial data in which we
 might have many HDF5/NetCDF files on disk, one for every day, but we want to do
 operations that span multiple days.
 
-To solve this problem we use the functions ``da.stack`` and ``da.concatenate``.
+To solve this problem we use the functions ``da.stack``, ``da.concatenate``,
+and ``da.block``.
 
 Stack
 -----
@@ -57,3 +58,27 @@ existing dimension
 
    >>> da.concatenate(data, axis=1).shape
    (3, 8)
+
+Block
+-----
+
+We can handle a larger variety of cases with ``da.block``. Basically it allows
+concatenation to applied over multiple dimensions at once. This is useful if
+your chunks tile a space (e.g. small squares from a larger 2-D plane).
+
+.. code-block:: python
+
+   >>> import dask.array as da
+   >>> import numpy as np
+
+   >>> arr0 = da.from_array(np.zeros((3, 4)), chunks=(1, 2))
+   >>> arr1 = da.from_array(np.ones((3, 4)), chunks=(1, 2))
+
+   >>> data = [
+   ...     [arr0, arr1],
+   ...     [arr1, arr0]
+   ... ]
+
+   >>> x = da.block(data)
+   >>> x.shape
+   (6, 8)


### PR DESCRIPTION
Adds an example of how `block` can be used to join together Dask Arrays along multiple dimensions.