### PR TITLE
Remove "da.random" from random array keys

### DIFF
--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -124,7 +124,7 @@ class RandomState(object):
         sizes = list(product(*chunks))
         state_data = random_state_data(len(sizes), self._numpy_state)
         token = tokenize(state_data, size, chunks, args, kwargs)
-        name = 'da.random.{0}-{1}'.format(func.__name__, token)
+        name = '{0}-{1}'.format(func.__name__, token)
 
         keys = product([name], *([range(len(bd)) for bd in chunks] +
                                  [[0]] * len(extra_chunks)))

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -280,5 +280,5 @@ def test_create_with_auto_dimensions():
 def test_names():
     name = da.random.normal(0, 1, size=(1000,), chunks=(500,)).name
 
-    assert 'normal' in name
+    assert name.startswith('normal')
     assert len(key_split(name)) < 10

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import dask
 import dask.array as da
+from dask.utils import key_split
 from dask.array.core import Array
 from dask.array.random import random, exponential, normal
 from dask.array.utils import assert_eq
@@ -274,3 +275,10 @@ def test_create_with_auto_dimensions():
 
         y = da.random.random((10000, 10000), chunks="auto")
         assert y.chunks == ((2500,) * 4, (2500,) * 4)
+
+
+def test_names():
+    name = da.random.normal(0, 1, size=(1000,), chunks=(500,)).name
+
+    assert 'normal' in name
+    assert len(key_split(name)) < 10


### PR DESCRIPTION
We tend not to preface keys with the module name.
The long names also make diangostics slightly less pleasant.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
