### PR TITLE
Adds number of items parameter to sample method

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1030,12 +1030,15 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
     def bfill(self, axis=None, limit=None):
         return self.fillna(method='bfill', limit=limit, axis=axis)
 
-    def sample(self, frac, replace=False, random_state=None):
+    def sample(self, n=None, frac=None, replace=False, random_state=None):
         """ Random sample of items
 
         Parameters
         ----------
-        frac : float
+        n : int, optional
+            Number of items to return is not supported by dask. Use frac
+            instead.
+        frac : float, optional
             Fraction of axis items to return.
         replace : boolean, optional
             Sample with or without replacement. Default = False.
@@ -1048,6 +1051,17 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         DataFrame.random_split
         pandas.DataFrame.sample
         """
+        if n is not None:
+            msg = ("sample does not support the number of sampled items "
+                   "parameter, 'n'. Please use the 'frac' parameter instead.")
+            if isinstance(n, Number) and 0 <= n <= 1:
+                warnings.warn(msg)
+                frac = n
+            else:
+                raise ValueError(msg)
+
+        if frac is None:
+            raise ValueError("frac must not be None")
 
         if random_state is None:
             random_state = np.random.RandomState()


### PR DESCRIPTION
This PR adds an `n` parameter to the DataFrame `sample` method. `n` isn't supported by dask, but this aligns the dask `sample` function signature more with the pandas `sample` signature. 

In order not to break existing code like `ddf.sample(0.3)`, I've added an additional check so that if `0 <= n <= 1`, then a `UserWarning` is raised and `frac` is replaced with the input value of `n`

<details>
<summary> Example: </summary>

```python
In [1]: import pandas as pd

In [2]: import dask.dataframe as dd

In [3]: df = pd.DataFrame({'x': [1, 2, 3, 4, None, 6], 'y': list('abdabd')},
   ...:                   index=[10, 20, 30, 40, 50, 60])
   ...:

In [4]: a = dd.from_pandas(df, 2)

In [5]: a.sample(0.3)
/Users/jbourbeau/software/dask/dask/dataframe/core.py:1058: UserWarning: sample does not support the number of sampled items parameter, 'n'. Please use the 'frac' parameter instead.
  warnings.warn(msg)
Out[5]:
Dask DataFrame Structure:
                     x       y
npartitions=2
10             float64  object
40                 ...     ...
60                 ...     ...
Dask Name: sample, 4 tasks
```
</details>

<br>

Closes #3574. 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
