### PR TITLE
Disable locking in to_zarr (needed for using to_zarr in a distributed context)

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2283,7 +2283,8 @@ def to_zarr(arr, url, component=None, storage_options=None,
     chunks = [c[0] for c in arr.chunks]
     z = zarr.create(shape=arr.shape, chunks=chunks, dtype=arr.dtype,
                     store=mapper, path=component, overwrite=overwrite, **kwargs)
-    return store(arr, z, compute=compute, return_stored=return_stored)
+    return store(arr, z, lock=False, compute=compute,
+                 return_stored=return_stored)
 
 
 def _check_regular_chunks(chunkset):

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -9,6 +9,7 @@ from tornado import gen
 import dask
 from dask import persist, delayed, compute
 from dask.delayed import Delayed
+from dask.utils import tmpdir
 from distributed.client import wait, Client
 from distributed.utils_test import gen_cluster, inc, cluster, loop  # flake8: noqa
 
@@ -148,3 +149,17 @@ def test_futures_in_graph(loop):
             xxyy3 = delayed(add)(xxyy2, 10)
 
             assert xxyy3.compute(scheduler='dask.distributed') == ((1 + 1) + (2 + 2)) + 10
+
+
+def test_zarr_distributed_roundtrip(loop):
+    da = pytest.importorskip('dask.array')
+    zarr = pytest.importorskip('zarr')
+    assert_eq = da.utils.assert_eq
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            with tmpdir() as d:
+                a = da.zeros((3, 3), chunks=(1, 1))
+                a.to_zarr(d)
+                a2 = da.from_zarr(d)
+                assert_eq(a, a2)
+                assert a2.chunks == a.chunks


### PR DESCRIPTION
Appears that `to_zarr` was defaulting to `store`'s behavior of using a `threading.Lock` object for each chunk written. As the `threading.Lock` object is not pickleable, this fails when using Distributed. Since we already guarantee the chunks are aligned, just disable any kind of locking in `to_zarr`. Includes a test using a small Distributed cluster that fails without this change and passes with it.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
