### PR TITLE
Fix slicing of big arrays (#3619)

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -372,7 +372,7 @@ def _slice_1d(dim_shape, lengths, index):
     >>> _slice_1d(100, [20, 20, 20, 20, 20], slice(100, -12, -3))
     {4: slice(-1, -12, -3)}
     """
-    chunk_boundaries = np.cumsum(lengths)
+    chunk_boundaries = np.cumsum(lengths, dtype=np.int64)
 
     if isinstance(index, Integral):
         # use right-side search to be consistent with previous result

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -130,6 +130,16 @@ def test_slice_1d():
     result = _slice_1d(104, [20, 23, 27, 13, 21], slice(100, 27, -3))
     assert expected == result
 
+    # x=range(1000000000000)
+    # x[1000:]
+    expected = {0: slice(1000, 1000000000, 1)}
+    expected.update({ii: slice(None, None, None) for ii in range(1, 1000)})
+    # This array is large
+    result = _slice_1d(1000000000000,
+                       [1000000000] * 1000,
+                       slice(1000, None, None))
+    assert expected == result
+
 
 def test_slice_singleton_value_on_boundary():
     assert _slice_1d(15, [5, 5, 5], 10) == {2: 0}


### PR DESCRIPTION
As discussed in #3619 this fixes issues with slicing of large arrays.

I kept using `np.int64` instead of using `np.uint64` because some other tests failed due to some negative values.

I have also added a test for a slightly modified version of the example of the issue as a test.