### PR TITLE
DASK_CONFIG dictates config write location

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -21,6 +21,7 @@ if PY3:
     from queue import Queue, Empty
     from itertools import zip_longest
     from io import StringIO, BytesIO
+    from os import makedirs
     from bz2 import BZ2File
     from gzip import (GzipFile, compress as gzip_compress,
             decompress as gzip_decompress)
@@ -73,6 +74,7 @@ else:
     from itertools import izip_longest as zip_longest, izip as zip
     from StringIO import StringIO
     from io import BytesIO, BufferedIOBase
+    import os
     import bz2
     import gzip
     from urllib2 import urlopen
@@ -87,6 +89,13 @@ else:
     operator_div = operator.div
     FileNotFoundError = IOError
     FileExistsError = OSError
+
+    def makedirs(name, mode=0o777, exist_ok=True):
+        try:
+            os.makedirs(name, mode=mode)
+        except OSError:
+            if not exist_ok or not os.path.isdir(name):
+                raise
 
     def _make_reraise():
         _code = ("def reraise(exc, tb=None):"

--- a/dask/config.py
+++ b/dask/config.py
@@ -22,7 +22,10 @@ paths = [
 ]
 
 if 'DASK_CONFIG' in os.environ:
-    paths.append(os.environ['DASK_CONFIG'])
+    DASK_CONFIG = os.environ['DASK_CONFIG']
+    paths.append(DASK_CONFIG)
+else:
+    DASK_CONFIG = os.path.join(os.path.expanduser('~'), '.config', 'dask')
 
 
 global_config = config = {}
@@ -159,7 +162,7 @@ def collect_env(env=None):
 
 def ensure_file(
         source,
-        destination=os.path.join(os.path.expanduser('~'), '.config', 'dask'),
+        destination=None,
         comment=True):
     """
     Copy file to default location if it does not already exist
@@ -173,13 +176,16 @@ def ensure_file(
 
     Parameters
     ----------
-    source: string, filename
-        source configuration file, typically within a source directory
-    destination: string, filename
-        destination filename, typically ~/.config/dask
-    comment: bool, True by default
-        Whether or not to comment out the config file when copying
+    source : string, filename
+        Source configuration file, typically within a source directory.
+    destination : string, directory or filename
+        Destination directory or filename. Configurable by ``DASK_CONFIG``
+        environment variable, falling back to ~/.config/dask.
+    comment : bool, True by default
+        Whether or not to comment out the config file when copying.
     """
+    if destination is None:
+        destination = DASK_CONFIG
     if not os.path.splitext(destination)[1].strip('.'):
         _, filename = os.path.split(source)
         destination = os.path.join(destination, filename)

--- a/dask/config.py
+++ b/dask/config.py
@@ -22,10 +22,10 @@ paths = [
 ]
 
 if 'DASK_CONFIG' in os.environ:
-    DASK_CONFIG = os.environ['DASK_CONFIG']
-    paths.append(DASK_CONFIG)
+    PATH = os.environ['DASK_CONFIG']
+    paths.append(PATH)
 else:
-    DASK_CONFIG = os.path.join(os.path.expanduser('~'), '.config', 'dask')
+    PATH = os.path.join(os.path.expanduser('~'), '.config', 'dask')
 
 
 global_config = config = {}
@@ -185,7 +185,7 @@ def ensure_file(
         Whether or not to comment out the config file when copying.
     """
     if destination is None:
-        destination = DASK_CONFIG
+        destination = PATH
     if not os.path.splitext(destination)[1].strip('.'):
         _, filename = os.path.split(source)
         destination = os.path.join(destination, filename)

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -229,12 +229,12 @@ def test_ensure_file_defaults_to_DASK_CONFIG_directory(tmpdir):
         yaml.dump(a, f)
 
     destination = os.path.join(str(tmpdir), 'dask')
-    DASK_CONFIG = dask.config.DASK_CONFIG
+    PATH = dask.config.PATH
     try:
-        dask.config.DASK_CONFIG = destination
+        dask.config.PATH = destination
         ensure_file(source=source)
     finally:
-        dask.config.DASK_CONFIG = DASK_CONFIG
+        dask.config.PATH = PATH
 
     assert os.path.isdir(destination)
     [fn] = os.listdir(destination)

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 
+import dask.config
 from dask.config import (update, merge, collect, collect_yaml, collect_env,
                          get, ensure_file, set, config, rename,
                          update_defaults, refresh)
@@ -219,6 +220,25 @@ def test_ensure_file_directory(mkdir):
             assert os.path.isdir(destination)
             [fn] = os.listdir(destination)
             assert os.path.split(fn)[1] == os.path.split(source)[1]
+
+
+def test_ensure_file_defaults_to_DASK_CONFIG_directory(tmpdir):
+    a = {'x': 1, 'y': {'a': 1}}
+    source = os.path.join(str(tmpdir), 'source.yaml')
+    with open(source, 'w') as f:
+        yaml.dump(a, f)
+
+    destination = os.path.join(str(tmpdir), 'dask')
+    DASK_CONFIG = dask.config.DASK_CONFIG
+    try:
+        dask.config.DASK_CONFIG = destination
+        ensure_file(source=source)
+    finally:
+        dask.config.DASK_CONFIG = DASK_CONFIG
+
+    assert os.path.isdir(destination)
+    [fn] = os.listdir(destination)
+    assert os.path.split(fn)[1] == os.path.split(source)[1]
 
 
 def test_rename():

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -143,47 +143,45 @@ def test_get():
         get('y.b', config=d)
 
 
-def test_ensure_file():
+def test_ensure_file(tmpdir):
     a = {'x': 1, 'y': {'a': 1}}
     b = {'x': 123}
 
-    with tmpfile(extension='yaml') as source:
-        with tmpfile(extension='yaml') as destination:
-            with open(source, 'w') as f:
-                yaml.dump(a, f)
+    source = os.path.join(str(tmpdir), 'source.yaml')
+    dest = os.path.join(str(tmpdir), 'dest')
+    destination = os.path.join(dest, 'source.yaml')
 
-            ensure_file(source=source, destination=destination, comment=False)
+    with open(source, 'w') as f:
+        yaml.dump(a, f)
 
-            with open(destination) as f:
-                result = yaml.load(f)
+    ensure_file(source=source, destination=dest, comment=False)
 
-            with open(source) as src:
-                with open(destination) as dst:
-                    assert src.read() == dst.read()
+    with open(destination) as f:
+        result = yaml.load(f)
+    assert result == a
 
-            assert result == a
+    # don't overwrite old config files
+    with open(source, 'w') as f:
+        yaml.dump(b, f)
 
-            # don't overwrite old config files
-            with open(source, 'w') as f:
-                yaml.dump(b, f)
-            ensure_file(source=source, destination=destination, comment=False)
-            with open(destination) as f:
-                result = yaml.load(f)
+    ensure_file(source=source, destination=dest, comment=False)
 
-            assert result == a
+    with open(destination) as f:
+        result = yaml.load(f)
+    assert result == a
 
-            os.remove(destination)
+    os.remove(destination)
 
-            # Write again, now with comments
-            ensure_file(source=source, destination=destination, comment=True)
-            with open(destination) as f:
-                text = f.read()
-            assert '123' in text
+    # Write again, now with comments
+    ensure_file(source=source, destination=dest, comment=True)
 
-            with open(destination) as f:
-                result = yaml.load(f)
+    with open(destination) as f:
+        text = f.read()
+    assert '123' in text
 
-            assert not result
+    with open(destination) as f:
+        result = yaml.load(f)
+    assert not result
 
 
 def test_set():
@@ -207,19 +205,22 @@ def test_set():
 
 
 @pytest.mark.parametrize('mkdir', [True, False])
-def test_ensure_file_directory(mkdir):
+def test_ensure_file_directory(mkdir, tmpdir):
     a = {'x': 1, 'y': {'a': 1}}
-    with tmpfile(extension='yaml') as source:
-        with tmpfile() as destination:
-            if mkdir:
-                os.mkdir(destination)
-            with open(source, 'w') as f:
-                yaml.dump(a, f)
 
-            ensure_file(source=source, destination=destination)
-            assert os.path.isdir(destination)
-            [fn] = os.listdir(destination)
-            assert os.path.split(fn)[1] == os.path.split(source)[1]
+    source = os.path.join(str(tmpdir), 'source.yaml')
+    dest = os.path.join(str(tmpdir), 'dest')
+
+    with open(source, 'w') as f:
+        yaml.dump(a, f)
+
+    if mkdir:
+        os.mkdir(dest)
+
+    ensure_file(source=source, destination=dest)
+
+    assert os.path.isdir(dest)
+    assert os.path.exists(os.path.join(dest, 'source.yaml'))
 
 
 def test_ensure_file_defaults_to_DASK_CONFIG_directory(tmpdir):


### PR DESCRIPTION
Previously existing configuration files could be specified by
`DASK_CONFIG`, but projects like `distributed` would always write the
default configuration file to `~/.config/dask/`. We now make the write
location configurable as well. This is important in environments where
`~/.config` may not exist of be writable.
