### PR TITLE
Fix array random API examples

### DIFF
--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -10,14 +10,14 @@ from .core import (normalize_chunks, Array, slices_from_chunks, asarray,
                    broadcast_shapes, broadcast_to)
 from .. import sharedict
 from ..base import tokenize
-from ..utils import ignoring, random_state_data
+from ..utils import ignoring, random_state_data, skip_doctest
 
 
 def doc_wraps(func):
     """ Copy docstring from one function to another """
     def _(func2):
         if func.__doc__ is not None:
-            func2.__doc__ = func.__doc__.replace('>>>', '>>').replace('...', '..')
+            func2.__doc__ = skip_doctest(func.__doc__)
         return func2
     return _
 

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -104,6 +104,7 @@ def test_unique_names():
 def test_docs():
     assert 'exponential' in exponential.__doc__
     assert 'exponential' in exponential.__name__
+    assert "# doctest: +SKIP" in normal.__doc__
 
 
 def test_can_make_really_big_random_array():


### PR DESCRIPTION
This PR fixes the docstring examples not rendering correctly in the array API docs. 

I saw that all the `RandomState` methods in `dask.array.random` (e.g. `binomial`, `gamma`, etc.) have issues with their docstring examples not being rendered as code blocks in the array API docs. It looks like `doc_wraps`

https://github.com/dask/dask/blob/cfd0f7c223722bff489b8cb9ccb5e8f918a7f913/dask/array/random.py#L16-L22

is being used to copy `numpy.random.RandomState` docstrings to the corresponding dask function. 

But the `replace('>>>', '>>').replace('...', '..')` in `doc_wraps` is causing the docstring examples to be mangled in the dask API docs. After doing some `git blame` digging, it appears the `replace`s were added to avoid docstring testing. I've replaced this with the `skip_doctest` function in `dask.utils`.


- [x] Tests added / passed
- [x] Passes `flake8 dask`
