### PR TITLE
Mark the HDFS test as a known failure

### DIFF
--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -238,6 +238,9 @@ def test_pyarrow_compat():
     assert isinstance(pa_hdfs, pyarrow.filesystem.FileSystem)
 
 
+@pytest.mark.skip(
+    reason='hdfs3 fails. See https://github.com/dask/dask/issues/3345.'
+)
 @require_pyarrow
 def test_parquet_pyarrow(hdfs):
     dd = pytest.importorskip('dask.dataframe')


### PR DESCRIPTION
As this test has been failing for some time and creates unnecessary noise on `master`, just mark it as a known fail. If it gets fixed, we can always move it back.

xref: https://github.com/dask/dask/issues/3345