### PR TITLE
Explain why `test_distributed` is skipped

### DIFF
--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -305,7 +305,8 @@ def test_glob(hdfs):
             {basedir + p for p in ['/a', '/a1', '/a2', '/a3', '/b1', '/c', '/c2']})
 
 
-@pytest.mark.skipif(not distributed)  # noqa: F811
+@pytest.mark.skipif(not distributed,                                    # noqa: F811
+                    reason="Skipped as distributed is not installed.")  # noqa: F811
 def test_distributed(hdfs, loop):     # noqa: F811
     dd = pytest.importorskip('dask.dataframe')
 


### PR DESCRIPTION
Appears `pytest` will error a test if it is skipped without a reason now. This adds a reason explaining that this test won't be run if `distributed` is not installed.

ref: https://travis-ci.org/dask/dask/jobs/392193127#L1379-L1390
xref: https://github.com/dask/dask/pull/3609

- [x] Tests added / passed
- [x] Passes `flake8 dask`
