### PR TITLE
Workaround map_overlap bug in gradient

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -458,7 +458,7 @@ def gradient(f, *varargs, **kwargs):
         f.map_overlap(
             _gradient_kernel,
             dtype=f.dtype,
-            depth={j: 1 if j == ax else 0 for j in range(f.ndim)},
+            depth=1,
             boundary="none",
             grad_varargs=(varargs[i],),
             grad_kwargs=merge(kwargs, {"axis": ax}),

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -449,6 +449,8 @@ def test_gradient(shape, varargs, axis, edge_order):
         for e_r, e_r_a in zip(r, r_a):
             assert_eq(e_r, e_r_a)
 
+        assert_eq(sum(r), sum(r_a))
+
 
 def test_bincount():
     x = np.array([2, 1, 5, 2, 1])


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/3633

Appears there is a bug that `map_overlap` computations can run into when computing different results with different depths using the same input data. ( https://github.com/dask/dask/issues/3634 ) As `gradient` used different `depth`s for different results as overlaps were not needed to be the same for all of them, it ran into this bug, which caused issues combining the results. ( https://github.com/dask/dask/issues/3633 ) To address this latter issue, simply set the `depth` to `1` for all axes. This appears to fix the `gradient` issue. However the `map_overlap` issue is still outstanding. ( https://github.com/dask/dask/issues/3634 )

- [x] Tests added / passed
- [x] Passes `flake8 dask`
