### PR TITLE
Add average function to dask array

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -14,7 +14,7 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        tensordot, transpose, dot, vdot, matmul,
                        apply_along_axis, apply_over_axes, result_type,
                        atleast_1d, atleast_2d, atleast_3d, piecewise, flip,
-                       flipud, fliplr, einsum)
+                       flipud, fliplr, einsum, average)
 from .reshape import reshape
 from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
         true_divide, floor_divide, negative, power, remainder, mod, conj, exp,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1266,10 +1266,6 @@ def average(a, axis=None, weights=None, returned=False):
             wgt = wgt.swapaxes(-1, axis)
 
         scl = wgt.sum(axis=axis, dtype=result_dtype)
-        if (scl == 0.0).any():
-            raise ZeroDivisionError(
-                "Weights sum to zero, can't be normalized")
-
         avg = multiply(a, wgt, dtype=result_dtype).sum(axis) / scl
 
     if returned:

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -19,6 +19,7 @@ from . import chunk
 from .creation import arange
 from .utils import safe_wraps
 from .wrap import ones
+from .ufunc import multiply
 
 from .core import (Array, map_blocks, elemwise, from_array, asarray,
                    asanyarray, concatenate, stack, atop, broadcast_shapes,
@@ -1227,3 +1228,53 @@ def insert(arr, obj, values, axis):
     interleaved = list(interleave([split_arr, split_values]))
     interleaved = [i for i in interleaved if i.nbytes]
     return concatenate(interleaved, axis=axis)
+
+
+@wraps(np.average)
+def average(a, axis=None, weights=None, returned=False):
+    # This was minimally modified from numpy.average
+    # See numpy license at https://github.com/numpy/numpy/blob/master/LICENSE.txt
+    # or NUMPY_LICENSE.txt within this directory
+    a = asanyarray(a)
+
+    if weights is None:
+        avg = a.mean(axis)
+        scl = avg.dtype.type(a.size / avg.size)
+    else:
+        wgt = asanyarray(weights)
+
+        if issubclass(a.dtype.type, (np.integer, np.bool_)):
+            result_dtype = result_type(a.dtype, wgt.dtype, 'f8')
+        else:
+            result_dtype = result_type(a.dtype, wgt.dtype)
+
+        # Sanity checks
+        if a.shape != wgt.shape:
+            if axis is None:
+                raise TypeError(
+                    "Axis must be specified when shapes of a and weights "
+                    "differ.")
+            if wgt.ndim != 1:
+                raise TypeError(
+                    "1D weights expected when shapes of a and weights differ.")
+            if wgt.shape[0] != a.shape[axis]:
+                raise ValueError(
+                    "Length of weights not compatible with specified axis.")
+
+            # setup wgt to broadcast along axis
+            wgt = broadcast_to(wgt, (a.ndim - 1) * (1,) + wgt.shape)
+            wgt = wgt.swapaxes(-1, axis)
+
+        scl = wgt.sum(axis=axis, dtype=result_dtype)
+        if (scl == 0.0).any():
+            raise ZeroDivisionError(
+                "Weights sum to zero, can't be normalized")
+
+        avg = multiply(a, wgt, dtype=result_dtype).sum(axis) / scl
+
+    if returned:
+        if scl.shape != avg.shape:
+            scl = broadcast_to(scl, avg.shape).copy()
+        return avg, scl
+    else:
+        return avg

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1480,3 +1480,39 @@ def test_einsum_broadcasting_contraction3():
     np_res = np.einsum('ajk,kbl,jl,ab->ab', a, b, c, d)
     da_res = da.einsum('ajk,kbl,jl,ab->ab', d_a, d_b, d_c, d_d)
     assert_eq(np_res, da_res)
+
+
+@pytest.mark.parametrize('a', [np.arange(11),
+                               np.arange(6).reshape((3,2))
+                               ])
+@pytest.mark.parametrize('returned', [True, False])
+def test_average(a, returned):
+    d_a = da.from_array(a, chunks=2)
+
+    np_avg = np.average(a, returned=returned)
+    da_avg = da.average(d_a, returned=returned)
+
+    assert_eq(np_avg, da_avg)
+
+
+def test_average_weights():
+    a = np.arange(6).reshape((3,2))
+    d_a = da.from_array(a, chunks=2)
+
+    weights = np.array([0.25, 0.75])
+    d_weights = da.from_array(weights, chunks=2)
+
+    np_avg = np.average(a, weights=weights, axis=1)
+    da_avg = da.average(d_a, weights=d_weights, axis=1)
+
+    assert_eq(np_avg, da_avg)
+
+
+def test_average_raises():
+    d_a = da.arange(11, chunks=2)
+
+    with pytest.raises(TypeError):
+        da.average(d_a, weights=[1, 2, 3])
+
+    with pytest.raises(ZeroDivisionError):
+        da.average(d_a, weights=da.zeros_like(d_a))

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1514,5 +1514,5 @@ def test_average_raises():
     with pytest.raises(TypeError):
         da.average(d_a, weights=[1, 2, 3])
 
-    with pytest.raises(ZeroDivisionError):
-        da.average(d_a, weights=da.zeros_like(d_a))
+    with pytest.warns(RuntimeWarning):
+        da.average(d_a, weights=da.zeros_like(d_a)).compute()

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -31,6 +31,7 @@ Top level user functions:
    atleast_1d
    atleast_2d
    atleast_3d
+   average
    bincount
    bitwise_and
    bitwise_not
@@ -390,6 +391,7 @@ Other functions
 .. autofunction:: atleast_1d
 .. autofunction:: atleast_2d
 .. autofunction:: atleast_3d
+.. autofunction:: average
 .. autofunction:: bincount
 .. autofunction:: bitwise_and
 .. autofunction:: bitwise_not


### PR DESCRIPTION
This PR adds an `average` function to dask array that corresponds to the [numpy average function](https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.average.html).

- [x] Tests added / passed
- [x] Passes `flake8 dask`
