### PR TITLE
Add back dask.utils.effective_get

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -5,11 +5,13 @@ import pickle
 import numpy as np
 import pytest
 
+import dask
 from dask.sharedict import ShareDict
 from dask.utils import (takes_multiple_arguments, Dispatch, random_state_data,
                         memory_repr, methodcaller, M, skip_doctest,
                         SerializableLock, funcname, ndeepmap, ensure_dict,
-                        extra_titles, asciitable, itemgetter, partial_by_order)
+                        extra_titles, asciitable, itemgetter, partial_by_order,
+                        effective_get)
 from dask.utils_test import inc
 
 
@@ -316,3 +318,15 @@ def test_itemgetter():
 
 def test_partial_by_order():
     assert partial_by_order(5, function=operator.add, other=[(1, 20)]) == 25
+
+
+def test_effective_get():
+    da = pytest.importorskip('dask.array')
+    x = da.arange(10, chunks=(5,))
+
+    with pytest.warns(Warning) as record:
+        assert effective_get(collection=x) is dask.threaded.get
+        assert effective_get(get=dask.threaded.get) is dask.threaded.get
+
+    assert any('dask.base.get_scheduler' in str(warning)
+               for warning in record.list)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -15,6 +15,7 @@ from numbers import Integral
 from threading import Lock
 import multiprocessing as mp
 import uuid
+import warnings
 from weakref import WeakValueDictionary
 
 from .compatibility import get_named_args, getargspec, PY3, unicode, bind_method
@@ -1002,3 +1003,11 @@ byte_sizes = {
 byte_sizes = {k.lower(): v for k, v in byte_sizes.items()}
 byte_sizes.update({k[0]: v for k, v in byte_sizes.items() if k and 'i' not in k})
 byte_sizes.update({k[:-1]: v for k, v in byte_sizes.items() if k and 'i' in k})
+
+
+def effective_get(get=None, collection=None):
+    """ Deprecated: see dask.base.get_scheduler """
+    warnings.warn("Deprecated, see dask.base.get_scheduler instead")
+
+    from dask.base import get_scheduler
+    return get_scheduler(get=get, collections=[collection])


### PR DESCRIPTION
This was removed in 0.18.0, which broke some XArray work.
See the following issues:

- https://github.com/pydata/xarray/issues/2238
- https://github.com/dask/dask/issues/3638

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
