### PR TITLE
Break apart uneven array-of-int slicing to separate chunks

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from ..utils import ignoring
 from .core import (Array, block, concatenate, stack, from_array, store,
                    map_blocks, atop, to_hdf5, to_npy_stack, from_npy_stack,
-                   from_delayed, asarray, asanyarray,
+                   from_delayed, asarray, asanyarray, PerformanceWarning,
                    broadcast_arrays, broadcast_to, from_zarr, to_zarr)
 from .routines import (take, choose, argwhere, where, coarsen, insert,
                        ravel, roll, unique, squeeze, ptp, diff, ediff1d,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2540,7 +2540,7 @@ def unify_chunks(*args, **kwargs):
 
     if warn and nparts and nparts >= max_parts * 10:
         warnings.warn("Increasing number of chunks by factor of %d" %
-                      (nparts / max_parts), PerformanceWarning)
+                      (nparts / max_parts), PerformanceWarning, stacklevel=3)
 
     arrays = []
     for a, i in arginds:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -70,6 +70,10 @@ def register_sparse():
     tensordot_lookup.register(sparse.COO, sparse.tensordot)
 
 
+class PerformanceWarning(Warning):
+    """ A warning given when bad chunking may cause poor performance """
+
+
 def getter(a, b, asarray=True, lock=None):
     if isinstance(b, tuple) and any(x is None for x in b):
         b2 = tuple(x for x in b if x is not None)
@@ -2536,7 +2540,7 @@ def unify_chunks(*args, **kwargs):
 
     if warn and nparts and nparts >= max_parts * 10:
         warnings.warn("Increasing number of chunks by factor of %d" %
-                      (nparts / max_parts))
+                      (nparts / max_parts), PerformanceWarning)
 
     arrays = []
     for a, i in arginds:

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -560,7 +560,8 @@ def take(outname, inname, chunks, index, axis=0):
         factor = math.ceil(len(plan) / len(chunks[axis]))
         from .core import PerformanceWarning
         warnings.warn("Slicing with an out-of-order index is generating %d "
-                      "times more chunks" % factor, PerformanceWarning)
+                      "times more chunks" % factor, PerformanceWarning,
+                      stacklevel=6)
 
     index_lists = [idx for _, idx in plan]
     where_index = [i for i, _ in plan]

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -497,6 +497,20 @@ def issorted(seq):
 
 
 def slicing_plan(chunks, index):
+    """ Construct a plan to slice chunks with the given index
+
+    Parameters
+    ----------
+    chunks : Tuple[int]
+        One dimensions worth of chunking information
+    index : np.ndarray[int]
+        The index passed to slice on that dimension
+
+    Returns
+    -------
+    out : List[Tuple[int, np.ndarray]]
+        A list of chunk/sub-index pairs corresponding to each output chunk
+    """
     index = np.asanyarray(index)
     cum_chunks = np.cumsum(chunks)
 
@@ -515,62 +529,16 @@ def slicing_plan(chunks, index):
     return out
 
 
-def take_sorted(outname, inname, blockdims, index, axis=0):
-    """ Index array with sorted list index
-
-    Forms a dask for the following case
-
-        x[:, [1, 3, 5, 10], ...]
-
-    where the index, ``[1, 3, 5, 10]`` is sorted in non-decreasing order.
-
-    >>> blockdims, dsk = take('y', 'x', [(20, 20, 20, 20)], [1, 3, 5, 47], axis=0)
-    >>> blockdims
-    ((3, 1),)
-    >>> dsk  # doctest: +SKIP
-    {('y', 0): (getitem, ('x', 0), ([1, 3, 5],)),
-     ('y', 1): (getitem, ('x', 2), ([7],))}
-
-    See Also
-    --------
-    take - calls this function
-    """
-    sizes = blockdims[axis]  # the blocksizes on the axis that we care about
-
-    index_lists = partition_by_size(sizes, index)
-    where_index = [i for i, il in enumerate(index_lists) if len(il)]
-    index_lists = [il for il in index_lists if len(il)]
-
-    dims = [range(len(bd)) for bd in blockdims]
-
-    indims = list(dims)
-    indims[axis] = list(range(len(where_index)))
-    keys = list(product([outname], *indims))
-
-    outdims = list(dims)
-    outdims[axis] = where_index
-    slices = [[colon] * len(bd) for bd in blockdims]
-    slices[axis] = index_lists
-    slices = list(product(*slices))
-    inkeys = list(product([inname], *outdims))
-    values = [(getitem, inkey, slc) for inkey, slc in zip(inkeys, slices)]
-
-    blockdims2 = list(blockdims)
-    blockdims2[axis] = tuple(map(len, index_lists))
-
-    return tuple(blockdims2), dict(zip(keys, values))
-
-
-def take(outname, inname, blockdims, index, axis=0):
+def take(outname, inname, chunks, index, axis=0):
     """ Index array with an iterable of index
 
     Handles a single index by a single list
 
     Mimics ``np.take``
 
-    >>> blockdims, dsk = take('y', 'x', [(20, 20, 20, 20)], [5, 1, 47, 3], axis=0)
-    >>> blockdims
-    ((4,),)
+    >>> chunks, dsk = take('y', 'x', [(20, 20, 20, 20)], [5, 1, 47, 3], axis=0)
+    >>> chunks
+    ((2, 1, 1),)
     >>> dsk  # doctest: +SKIP
     {('y', 0): (getitem, (np.concatenate, [(getitem, ('x', 0), ([1, 3, 5],)),
                                            (getitem, ('x', 2), ([7],))],
@@ -579,45 +547,36 @@ def take(outname, inname, blockdims, index, axis=0):
 
     When list is sorted we retain original block structure
 
-    >>> blockdims, dsk = take('y', 'x', [(20, 20, 20, 20)], [1, 3, 5, 47], axis=0)
-    >>> blockdims
+    >>> chunks, dsk = take('y', 'x', [(20, 20, 20, 20)], [1, 3, 5, 47], axis=0)
+    >>> chunks
     ((3, 1),)
     >>> dsk  # doctest: +SKIP
     {('y', 0): (getitem, ('x', 0), ([1, 3, 5],)),
      ('y', 2): (getitem, ('x', 2), ([7],))}
     """
+    plan = slicing_plan(chunks[axis], index)
 
-    index = np.asanyarray(index)
+    index_lists = [idx for _, idx in plan]
+    where_index = [i for i, _ in plan]
 
-    if issorted(index):
-        return take_sorted(outname, inname, blockdims, index, axis)
+    dims = [range(len(bd)) for bd in chunks]
 
-    if isinstance(index, np.ndarray) and index.ndim > 0:
-        sorted_idx = np.sort(index)
-    else:
-        sorted_idx = index
+    indims = list(dims)
+    indims[axis] = list(range(len(where_index)))
+    keys = list(product([outname], *indims))
 
-    n = len(blockdims)
-    sizes = blockdims[axis]  # the blocksizes on the axis that we care about
+    outdims = list(dims)
+    outdims[axis] = where_index
+    slices = [[colon] * len(bd) for bd in chunks]
+    slices[axis] = index_lists
+    slices = list(product(*slices))
+    inkeys = list(product([inname], *outdims))
+    values = [(getitem, inkey, slc) for inkey, slc in zip(inkeys, slices)]
 
-    index_lists = partition_by_size(sizes, sorted_idx)
-
-    dims = [[0] if axis == i else list(range(len(bd)))
-            for i, bd in enumerate(blockdims)]
-    keys = list(product([outname], *dims))
-
-    rev_index = np.searchsorted(sorted_idx, index)
-    vals = [(getitem, (np.concatenate,
-                       [(getitem, ((inname, ) + d[:axis] + (i, ) + d[axis + 1:]),
-                         ((colon, ) * axis + (IL, ) + (colon, ) * (n - axis - 1)))
-                        for i, IL in enumerate(index_lists) if len(IL)], axis),
-             ((colon, ) * axis + (rev_index, ) + (colon, ) * (n - axis - 1)))
-            for d in product(*dims)]
-
-    blockdims2 = list(blockdims)
-    blockdims2[axis] = (len(index), )
-
-    return tuple(blockdims2), dict(zip(keys, vals))
+    chunks2 = list(chunks)
+    chunks2[axis] = tuple(map(len, index_lists))
+    dsk = dict(zip(keys, values))
+    return tuple(chunks2), dsk
 
 
 def posify_index(shape, ind):

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -496,6 +496,25 @@ def issorted(seq):
     return np.all(seq[:-1] <= seq[1:])
 
 
+def slicing_plan(chunks, index):
+    index = np.asanyarray(index)
+    cum_chunks = np.cumsum(chunks)
+
+    chunk_locations = np.searchsorted(cum_chunks, index, side='right')
+    where = np.where(np.diff(chunk_locations))[0] + 1
+    where = np.concatenate([[0], where, [len(chunk_locations)]])
+
+    out = []
+    for i in range(len(where) - 1):
+        sub_index = index[where[i]:where[i + 1]]
+        chunk = chunk_locations[where[i]]
+        if chunk > 0:
+            sub_index = sub_index - cum_chunks[chunk - 1]
+        out.append((chunk, sub_index))
+
+    return out
+
+
 def take_sorted(outname, inname, blockdims, index, axis=0):
     """ Index array with sorted list index
 

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -558,8 +558,9 @@ def take(outname, inname, chunks, index, axis=0):
     plan = slicing_plan(chunks[axis], index)
     if len(plan) >= len(chunks[axis]) * 10:
         factor = math.ceil(len(plan) / len(chunks[axis]))
+        from .core import PerformanceWarning
         warnings.warn("Slicing with an out-of-order index is generating %d "
-                      "times more chunks" % factor)
+                      "times more chunks" % factor, PerformanceWarning)
 
     index_lists = [idx for _, idx in plan]
     where_index = [i for i, _ in plan]

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -4,6 +4,7 @@ from itertools import product
 import math
 from numbers import Integral, Number
 from operator import getitem, itemgetter
+import warnings
 
 import numpy as np
 from toolz import memoize, merge, pluck, concat
@@ -555,6 +556,10 @@ def take(outname, inname, chunks, index, axis=0):
      ('y', 2): (getitem, ('x', 2), ([7],))}
     """
     plan = slicing_plan(chunks[axis], index)
+    if len(plan) >= len(chunks[axis]) * 10:
+        factor = math.ceil(len(plan) / len(chunks[axis]))
+        warnings.warn("Slicing with an out-of-order index is generating %d "
+                      "times more chunks" % factor)
 
     index_lists = [idx for _, idx in plan]
     where_index = [i for i, _ in plan]

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -262,7 +262,7 @@ def test_tensordot():
 
     assert same_keys(da.tensordot(a, b, axes=(1, 0)),
                      da.tensordot(a, b, axes=(1, 0)))
-    with pytest.warns(None):  # Increasing number of chunks warning
+    with pytest.warns(da.PerformanceWarning):  # Increasing number of chunks warning
         assert not same_keys(da.tensordot(a, b, axes=0),
                              da.tensordot(a, b, axes=1))
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -3,6 +3,7 @@ from __future__ import division, print_function, absolute_import
 import itertools
 from numbers import Number
 import textwrap
+import sys
 
 import pytest
 from distutils.version import LooseVersion
@@ -262,7 +263,9 @@ def test_tensordot():
 
     assert same_keys(da.tensordot(a, b, axes=(1, 0)),
                      da.tensordot(a, b, axes=(1, 0)))
-    with pytest.warns(da.PerformanceWarning):  # Increasing number of chunks warning
+
+    # Increasing number of chunks warning
+    with pytest.warns(None if sys.version_info[0] == 2 else da.PerformanceWarning):
         assert not same_keys(da.tensordot(a, b, axes=0),
                              da.tensordot(a, b, axes=1))
 
@@ -718,8 +721,9 @@ def test_isin_rand(seed, low, high, elements_shape, elements_chunks,
     a2 = rng.randint(low, high, size=test_shape) - 5
     d2 = da.from_array(a2, chunks=test_chunks)
 
-    r_a = np.isin(a1, a2, invert=invert)
-    r_d = da.isin(d1, d2, invert=invert)
+    with pytest.warns(None):
+        r_a = np.isin(a1, a2, invert=invert)
+        r_d = da.isin(d1, d2, invert=invert)
     assert_eq(r_a, r_d)
 
 
@@ -1383,8 +1387,9 @@ def test_einsum(einsum_signature):
 
     np_inputs, da_inputs = _numpy_and_dask_inputs(input_sigs)
 
-    assert_eq(np.einsum(einsum_signature, *np_inputs),
-              da.einsum(einsum_signature, *da_inputs))
+    with pytest.warns(None):
+        assert_eq(np.einsum(einsum_signature, *np_inputs),
+                  da.einsum(einsum_signature, *da_inputs))
 
 
 @pytest.mark.skipif(not einsum_can_optimize,

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -251,36 +251,22 @@ def test_slicing_with_newaxis():
 
 def test_take():
     chunks, dsk = take('y', 'x', [(20, 20, 20, 20)], [5, 1, 47, 3], axis=0)
-    expected = {('y', 0): (getitem, (np.concatenate,
-                                     [(getitem, ('x', 0), (np.array([1, 3, 5]),)),
-                                      (getitem, ('x', 2), (np.array([7]),))], 0),
-                           (np.array([2, 0, 3, 1]), ))}
+    expected = {('y', 0): (getitem, ('x', 0), (np.array([5, 1]),)),
+                ('y', 1): (getitem, ('x', 2), (np.array([7]),)),
+                ('y', 2): (getitem, ('x', 0), (np.array([3]),))}
     np.testing.assert_equal(sorted(dsk.items()), sorted(expected.items()))
-    assert chunks == ((4,),)
+    assert chunks == ((2, 1, 1),)
 
     chunks, dsk = take('y', 'x', [(20, 20, 20, 20), (20, 20)], [
                        5, 1, 47, 3], axis=0)
-    expected = {('y', 0, j): (getitem, (np.concatenate,
-                                        [(getitem, ('x', 0, j),
-                                          ([1, 3, 5], slice(None, None, None))),
-                                         (getitem, ('x', 2, j),
-                                          ([7], slice(None, None, None)))], 0),
-                              ([2, 0, 3, 1], slice(None, None, None)))
-                for j in range(2)}
+    expected = {('y', 0, 0): (getitem, ('x', 0, 0), (np.array([5, 1]), slice(None, None, None))),
+                ('y', 0, 1): (getitem, ('x', 0, 1), (np.array([5, 1]), slice(None, None, None))),
+                ('y', 1, 0): (getitem, ('x', 2, 0), (np.array([7]), slice(None, None, None))),
+                ('y', 1, 1): (getitem, ('x', 2, 1), (np.array([7]), slice(None, None, None))),
+                ('y', 2, 0): (getitem, ('x', 0, 0), (np.array([3]), slice(None, None, None))),
+                ('y', 2, 1): (getitem, ('x', 0, 1), (np.array([3]), slice(None, None, None)))}
     np.testing.assert_equal(sorted(dsk.items()), sorted(expected.items()))
-    assert chunks == ((4,), (20, 20))
-
-    chunks, dsk = take('y', 'x', [(20, 20, 20, 20), (20, 20)], [
-                       5, 1, 37, 3], axis=1)
-    expected = {('y', i, 0): (getitem, (np.concatenate,
-                                        [(getitem, ('x', i, 0),
-                                          (slice(None, None, None), [1, 3, 5])),
-                                         (getitem, ('x', i, 1),
-                                          (slice(None, None, None), [17]))], 1),
-                              (slice(None, None, None), [2, 0, 3, 1]))
-                for i in range(4)}
-    np.testing.assert_equal(sorted(dsk.items()), sorted(expected.items()))
-    assert chunks == ((20, 20, 20, 20), (4,))
+    assert chunks == ((2, 1, 1), (20, 20))
 
 
 def test_take_sorted():
@@ -299,20 +285,6 @@ def test_take_sorted():
                           for i in range(4)))
     np.testing.assert_equal(dsk, expected)
     assert chunks == ((20, 20, 20, 20), (3, 1))
-
-
-def test_slice_lists():
-    y, chunks = slice_array('y', 'x', ((3, 3, 3, 1), (3, 3, 3, 1)),
-                            (np.array([2, 1, 9]), slice(None, None, None)))
-    exp = {('y', 0, i): (getitem, (np.concatenate,
-                                   [(getitem, ('x', 0, i),
-                                     ([1, 2], slice(None, None, None))),
-                                    (getitem, ('x', 3, i),
-                                     ([0], slice(None, None, None)))], 0),
-                         ([1, 0, 2], slice(None, None, None)))
-           for i in range(4)}
-    np.testing.assert_equal(y, exp)
-    assert chunks == ((3,), (3, 3, 3, 1))
 
 
 def test_slicing_chunks():
@@ -666,10 +638,10 @@ def test_normalize_index():
 
 def test_take_semi_sorted():
     x = da.ones(10, chunks=(5,))
-    index = np.arange(10) % 5
+    index = np.arange(15) % 10
 
     y = x[index]
-    assert y.chunks == ((5, 5),)
+    assert y.chunks == ((5, 5, 5),)
 
 
 @pytest.mark.parametrize('chunks,index,expected', [

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -672,3 +672,16 @@ def test_slicing_plan(chunks, index, expected):
         assert i == j
         assert len(x) == len(y)
         assert (x == y).all()
+
+
+def test_pathological_unsorted_slicing():
+    x = da.ones(100, chunks=10)
+
+    # [0, 10, 20, ... 90, 1, 11, 21, ... 91, ...]
+    index = np.arange(100).reshape(10, 10).ravel(order='F')
+
+    with pytest.warns(Warning) as info:
+        x[index]
+
+    assert '10' in str(info.list[0])
+    assert 'out-of-order' in str(info.list[0])

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -680,7 +680,7 @@ def test_pathological_unsorted_slicing():
     # [0, 10, 20, ... 90, 1, 11, 21, ... 91, ...]
     index = np.arange(100).reshape(10, 10).ravel(order='F')
 
-    with pytest.warns(Warning) as info:
+    with pytest.warns(da.PerformanceWarning) as info:
         x[index]
 
     assert '10' in str(info.list[0])

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -144,6 +144,7 @@ Top level user functions:
    outer
    pad
    percentile
+   PerformanceWarning
    piecewise
    prod
    ptp


### PR DESCRIPTION
Previously when slicing into a dask array with a list/array of integers we would do one of two things:

### Sorted, respect chunking

If the array was sorted then it would return an array that was chunked similarly to the input

```python
import dask.array as da
x = da.ones((20, 20), chunks=(4, 5))
x.chunks
# ((4, 4, 4, 4, 4), (5, 5, 5, 5))

import numpy as np

x[np.arange(20), :].chunks
# ((4, 4, 4, 4, 4), (5, 5, 5, 5))

x[np.arange(20) // 2, :].chunks
# ((8, 8, 4), (5, 5, 5, 5))
```

### Unsorted, single chunk

However if the index wasn't sorted then it would put everything into one big chunk

```python
index = np.arange(20) % 10
# array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])

x[index, :].chunks
# ((20,), (5, 5, 5, 5))
```

### Now

Now, we pick out different pieces of the index and use them to slice into the dask array.  

```python
x = da.ones((20, 20), chunks=(4, 5))
index = np.arange(20) % 10
# array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])

x[index].chunks
# Before: ((20,), (5, 5, 5, 5))
# Now: ((4, 4, 2, 4, 4, 2), (5, 5, 5, 5))
```

This is good because it allows more granular chunking when slicing with a semi-sorted index, but is bad in that it can easily create very many chunks in pathological situations, like indexing with a random index.

cc @shoyer @rabernat @jakirkham 

Follows on discussion from https://github.com/pydata/xarray/issues/2237