### PR TITLE
Avoid deepcopy in dask.config.set

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -225,42 +225,6 @@ def ensure_file(
         pass
 
 
-def _assign(keys, value, d, old=None, path=[]):
-    """ Assign value into a nested configuration dictionary
-
-    Optionally record the old values in old
-
-    Parameters
-    ----------
-    keys: Sequence[str]
-        The nested path of keys to assign the value, similar to toolz.put_in
-    value: object
-    d: dict
-        The part of the nested dictionary into which we want to assign the
-        value
-    old: dict, optional
-        If provided this will hold the old values
-    path: List[str]
-        Used internally to hold the path of old values
-    """
-    key = keys[0]
-    if len(keys) == 1:
-        if old is not None:
-            path_key = tuple(path + [keys[0]])
-            if keys[0] in d:
-                old[path_key] = d[keys[0]]
-            else:
-                old[path_key] = '--delete--'
-        d[keys[0]] = value
-    else:
-        if key not in d:
-            d[key] = {}
-            if old is not None:
-                old[tuple(path + [key])] = '--delete--'
-            old = None
-        _assign(keys[1:], value, d[key], path=path + [key], old=old)
-
-
 class set(object):
     """ Temporarily set configuration values within a context manager
 
@@ -283,7 +247,7 @@ class set(object):
             self.old = {}
 
             for key, value in kwargs.items():
-                _assign(key.split('.'), value, config, old=self.old)
+                self._assign(key.split('.'), value, config, old=self.old)
 
     def __enter__(self):
         return self.config
@@ -300,7 +264,43 @@ class set(object):
                 except KeyError:
                     pass
             else:
-                _assign(keys, value, self.config)
+                self._assign(keys, value, self.config)
+
+    @classmethod
+    def _assign(cls, keys, value, d, old=None, path=[]):
+        """ Assign value into a nested configuration dictionary
+
+        Optionally record the old values in old
+
+        Parameters
+        ----------
+        keys: Sequence[str]
+            The nested path of keys to assign the value, similar to toolz.put_in
+        value: object
+        d: dict
+            The part of the nested dictionary into which we want to assign the
+            value
+        old: dict, optional
+            If provided this will hold the old values
+        path: List[str]
+            Used internally to hold the path of old values
+        """
+        if len(keys) == 1:
+            if old is not None:
+                path_key = tuple(path + [keys[0]])
+                if keys[0] in d:
+                    old[path_key] = d[keys[0]]
+                else:
+                    old[path_key] = '--delete--'
+            d[keys[0]] = value
+        else:
+            key = keys[0]
+            if key not in d:
+                d[key] = {}
+                if old is not None:
+                    old[tuple(path + [key])] = '--delete--'
+                old = None
+            cls._assign(keys[1:], value, d[key], path=path + [key], old=old)
 
 
 def collect(paths=paths, env=None):

--- a/dask/config.py
+++ b/dask/config.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
 import ast
-import copy
 import os
 import sys
 import threading
@@ -226,6 +225,42 @@ def ensure_file(
         pass
 
 
+def _assign(keys, value, d, old=None, path=[]):
+    """ Assign value into a nested configuration dictionary
+
+    Optionally record the old values in old
+
+    Parameters
+    ----------
+    keys: Sequence[str]
+        The nested path of keys to assign the value, similar to toolz.put_in
+    value: object
+    d: dict
+        The part of the nested dictionary into which we want to assign the
+        value
+    old: dict, optional
+        If provided this will hold the old values
+    path: List[str]
+        Used internally to hold the path of old values
+    """
+    key = keys[0]
+    if len(keys) == 1:
+        if old is not None:
+            path_key = tuple(path + [keys[0]])
+            if keys[0] in d:
+                old[path_key] = d[keys[0]]
+            else:
+                old[path_key] = '--delete--'
+        d[keys[0]] = value
+    else:
+        if key not in d:
+            d[key] = {}
+            if old is not None:
+                old[tuple(path + [key])] = '--delete--'
+            old = None
+        _assign(keys[1:], value, d[key], path=path + [key], old=old)
+
+
 class set(object):
     """ Temporarily set configuration values within a context manager
 
@@ -245,26 +280,27 @@ class set(object):
 
         with lock:
             self.config = config
-            self.old = copy.deepcopy(config)
-
-            def assign(keys, value, d):
-                key = keys[0]
-                if len(keys) == 1:
-                    d[keys[0]] = value
-                else:
-                    if key not in d:
-                        d[key] = {}
-                    assign(keys[1:], value, d[key])
+            self.old = {}
 
             for key, value in kwargs.items():
-                assign(key.split('.'), value, config)
+                _assign(key.split('.'), value, config, old=self.old)
 
     def __enter__(self):
-        return config
+        return self.config
 
     def __exit__(self, type, value, traceback):
-        self.config.clear()
-        self.config.update(self.old)
+        for keys, value in self.old.items():
+            if value == '--delete--':
+                d = self.config
+                try:
+                    while len(keys) > 1:
+                        d = d[keys[0]]
+                        keys = keys[1:]
+                    del d[keys[0]]
+                except KeyError:
+                    pass
+            else:
+                _assign(keys, value, self.config)
 
 
 def collect(paths=paths, env=None):

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -195,13 +195,31 @@ def test_set():
 
     with set({'abc': 123}):
         assert config['abc'] == 123
+    assert 'abc' not in config
 
     with set({'abc.x': 1, 'abc.y': 2, 'abc.z.a': 3}):
         assert config['abc'] == {'x': 1, 'y': 2, 'z': {'a': 3}}
+    assert 'abc' not in config
 
     d = {}
     set({'abc.x': 123}, config=d)
     assert d['abc']['x'] == 123
+
+
+def test_set_nested():
+    with set({'abc': {'x': 123}}):
+        assert config['abc'] == {'x': 123}
+        with set({'abc.y': 456}):
+            assert config['abc'] == {'x': 123, 'y': 456}
+        assert config['abc'] == {'x': 123}
+    assert 'abc' not in config
+
+
+def test_set_hard_to_copyables():
+    import threading
+    with set(x=threading.Lock()):
+        with set(y=1):
+            pass
 
 
 @pytest.mark.parametrize('mkdir', [True, False])


### PR DESCRIPTION
When using dask.config.set as a context manager we need to be able to
reverse the changes we make.

Before we used to do a `deepcopy` of the previous configuration and
then apply it back when we exited.  This was expensive and broke
whenever the configuration contained anything that wasn't easily
deepcopyable (roughly the same things that aren't pickleable).

Now we record what changes we made, and remove them more surgically.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
