### PR TITLE
Use funcname in dask/array/wrapped.py

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -20,7 +20,7 @@ import dask
 import dask.array as da
 from dask.base import tokenize, compute_as_if_collection
 from dask.delayed import Delayed, delayed
-from dask.utils import ignoring, tmpfile, tmpdir
+from dask.utils import ignoring, tmpfile, tmpdir, key_split
 from dask.utils_test import inc, dec
 
 from dask.array import chunk
@@ -1197,7 +1197,7 @@ def test_from_function_requires_block_args():
 
 def test_repr():
     d = da.ones((4, 4), chunks=(2, 2))
-    assert d.name[:5] in repr(d)
+    assert key_split(d.name) in repr(d)
     assert str(d.shape) in repr(d)
     assert str(d.dtype) in repr(d)
     d = da.ones((4000, 4), chunks=(4, 2))
@@ -2840,7 +2840,6 @@ def test_map_blocks_name():
 
 def test_from_array_names():
     pytest.importorskip('distributed')
-    from distributed.utils import key_split
 
     x = np.ones(10)
     d = da.from_array(x, chunks=2)

--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -11,6 +11,8 @@ def test_ones():
     x = np.array(a)
     assert (x == np.ones((10, 10), 'i4')).all()
 
+    assert a.name.startswith('ones-')
+
 
 def test_size_as_list():
     a = ones([10, 10], dtype='i4', chunks=(4, 4))
@@ -35,6 +37,8 @@ def test_full():
 
     assert (a.compute() == 100).all()
     assert a.dtype == a.compute(scheduler='sync').dtype == 'i8'
+
+    assert a.name.startswith('full-')
 
 
 def test_can_make_really_big_array_of_ones():

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -11,6 +11,7 @@ except ImportError:
     from toolz import curry
 
 from ..base import tokenize
+from ..utils import funcname
 from .core import Array, normalize_chunks
 
 
@@ -36,7 +37,7 @@ def wrap_func_shape_as_first_arg(func, *args, **kwargs):
     chunks = normalize_chunks(chunks, shape, dtype=dtype)
     name = kwargs.pop('name', None)
 
-    name = name or 'wrapped-' + tokenize(func, shape, chunks, dtype, args, kwargs)
+    name = name or funcname(func) + '-' + tokenize(func, shape, chunks, dtype, args, kwargs)
 
     keys = product([name], *[range(len(bd)) for bd in chunks])
     shapes = product(*chunks)


### PR DESCRIPTION
Previously arrays like ones and zeroes had the non-informative name
'wrapped'

- [x] Tests added / passed
- [x] Passes `flake8 dask`
