### PR TITLE
Add outer for Dask Arrays

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -11,7 +11,7 @@ from .routines import (take, choose, argwhere, where, coarsen, insert,
                        dstack, vstack, hstack, compress, extract, round,
                        count_nonzero, flatnonzero, nonzero, around, isin,
                        isnull, notnull, isclose, allclose, corrcoef, swapaxes,
-                       tensordot, transpose, dot, vdot, matmul,
+                       tensordot, transpose, dot, vdot, matmul, outer,
                        apply_along_axis, apply_over_axes, result_type,
                        atleast_1d, atleast_2d, atleast_3d, piecewise, flip,
                        flipud, fliplr, einsum, average)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -283,6 +283,16 @@ def matmul(a, b):
     return out
 
 
+@wraps(np.outer)
+def outer(a, b):
+    a = a.flatten()
+    b = b.flatten()
+
+    dtype = np.outer(a.dtype.type(), b.dtype.type()).dtype
+
+    return atop(np.outer, "ij", a, "i", b, "j", dtype=dtype)
+
+
 def _inner_apply_along_axis(arr,
                             func1d,
                             func1d_axis,

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -314,6 +314,23 @@ def test_vdot(shape, chunks):
     assert_eq(da.vdot(a, b), da.vdot(b, a).conj())
 
 
+@pytest.mark.parametrize('shape1, shape2', [
+    ((20,), (6,)),
+    ((4, 5,), (2, 3)),
+])
+def test_inner(shape1, shape2):
+    np.random.random(1337)
+
+    x = 2 * np.random.random(shape1) - 1
+    y = 2 * np.random.random(shape2) - 1
+
+    a = da.from_array(x, chunks=3)
+    b = da.from_array(y, chunks=3)
+
+    assert_eq(np.outer(x, y), da.outer(a, b))
+    assert_eq(np.outer(y, x), da.outer(b, a))
+
+
 @pytest.mark.parametrize('func1d_name, func1d', [
     ["ndim", lambda x: x.ndim],
     ["sum", lambda x: x.sum()],

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -141,6 +141,7 @@ Top level user functions:
    notnull
    ones
    ones_like
+   outer
    pad
    percentile
    piecewise
@@ -499,6 +500,7 @@ Other functions
 .. autofunction:: notnull
 .. autofunction:: ones
 .. autofunction:: ones_like
+.. autofunction:: outer
 .. autofunction:: pad
 .. autofunction:: percentile
 .. autofunction:: piecewise


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/3656

Adds an implementation of NumPy's `outer` for Dask Arrays. Includes tests and API documentation.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
