### PR TITLE
fix for `dask.array.linalg.tsqr` fails tests (intermittently) with arrays of uncertain dimensions

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -33,6 +33,20 @@ def _nanmin(m, n):
     return k_1 if np.isnan(k_0) else k_0
 
 
+def _wrapped_qr(a):
+    """
+    A wrapper for np.linalg.qr that handles arrays with 0 rows
+
+    Notes: Created for tsqr so as to manage cases with uncertain
+    array dimensions. In particular, the case where arrays have
+    (uncertain) chunks with 0 rows.
+    """
+    if a.shape[0] == 0:
+        return np.zeros((0, 0)), np.zeros((0, a.shape[1]))
+    else:
+        return np.linalg.qr(a)
+
+
 def tsqr(data, compute_svd=False, _max_vchunk_size=None):
     """ Direct Tall-and-Skinny QR algorithm
 
@@ -108,7 +122,7 @@ def tsqr(data, compute_svd=False, _max_vchunk_size=None):
 
     # Block qr
     name_qr_st1 = 'qr' + token
-    dsk_qr_st1 = top(np.linalg.qr, name_qr_st1, 'ij', data.name, 'ij',
+    dsk_qr_st1 = top(_wrapped_qr, name_qr_st1, 'ij', data.name, 'ij',
                      numblocks={data.name: numblocks})
     dsk.update_with_key(dsk_qr_st1, key=name_qr_st1)
 

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -41,6 +41,7 @@ def _wrapped_qr(a):
     array dimensions. In particular, the case where arrays have
     (uncertain) chunks with 0 rows.
     """
+    # workaround may be removed when numpy stops rejecting edge cases
     if a.shape[0] == 0:
         return np.zeros((0, 0)), np.zeros((0, a.shape[1]))
     else:

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -190,7 +190,15 @@ ALPHABET = alphabet.upper()
 def _tensordot(a, b, axes):
     x = max([a, b], key=lambda x: x.__array_priority__)
     tensordot = tensordot_lookup.dispatch(type(x))
-    x = tensordot(a, b, axes=axes)
+
+    a_dims = np.array([a.shape[i] for i in axes[0]])
+    b_dims = np.array([b.shape[i] for i in axes[1]])
+    if len(a_dims) > 0 and (a_dims == b_dims).all() and a_dims.min() == 0:
+        x = np.zeros(tuple([s for i, s in enumerate(a.shape) if i not in axes[0]] +
+                           [s for i, s in enumerate(b.shape) if i not in axes[1]]))
+    else:
+        x = tensordot(a, b, axes=axes)
+
     ind = [slice(None, None)] * x.ndim
     for a in sorted(axes[0]):
         ind.insert(a, None)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -191,6 +191,7 @@ def _tensordot(a, b, axes):
     x = max([a, b], key=lambda x: x.__array_priority__)
     tensordot = tensordot_lookup.dispatch(type(x))
 
+    # workaround may be removed when numpy version (currently 1.13.0) is bumped
     a_dims = np.array([a.shape[i] for i in axes[0]])
     b_dims = np.array([b.shape[i] for i in axes[1]])
     if len(a_dims) > 0 and (a_dims == b_dims).all() and a_dims.min() == 0:


### PR DESCRIPTION
Fix for issue https://github.com/dask/dask/issues/3659 where `dask.array.linalg.tsqr` fails tests with uncertain dimensions (after suitably many runs; test is stochastic)

Cause: uncertain dimensions mean the possibility of chunks with zero height, which `np.linalg.qr` does not accept

Fix: a wrapper function for `np.linalg.qr` was written to handle the case

- [X] Failing tests pass
- [X] Passes `flake8 dask`
