### PR TITLE
Note `da.pad` can be used with `map_overlap`

### DIFF
--- a/docs/source/array-ghost.rst
+++ b/docs/source/array-ghost.rst
@@ -101,8 +101,8 @@ So an example boundary kind argument might look like the following
     1: 'reflect',
     2: np.nan}
 
-Alternatively you can use functions like ``da.fromfunction`` and
-``da.concatenate`` to pad arbitrarily.
+Alternatively you can use :py:func:`dask.array.pad` for other types of
+paddings.
 
 
 Map a function across blocks


### PR DESCRIPTION
Originally users were on their own for more complex paddings of boundaries. So the recommendation here provided users a way to address those needs. However now that Dask Array has a `pad` implementation that mimics NumPy with a wide range of paddings supported. It should be preferred when possible.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
