### PR TITLE
Adds endpoint and retstep support for linspace

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -191,13 +191,9 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, chunks=None,
     endpoint : bool, optional
         If True, ``stop`` is the last sample. Otherwise, it is not included.
         Default is True.
-
-        .. versionadded:: 0.18.2
     retstep : bool, optional
         If True, return (samples, step), where step is the spacing between
         samples. Default is False.
-
-        .. versionadded:: 0.18.2
     chunks :  int
         The number of samples on each block. Note that the last block will have
         fewer samples if `num % blocksize != 0`
@@ -238,7 +234,8 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, chunks=None,
     for i, bs in enumerate(chunks[0]):
         bs_space = bs - 1 if endpoint else bs
         blockstop = blockstart + (bs_space * step)
-        task = (partial(np.linspace, endpoint=endpoint, dtype=dtype), blockstart, blockstop, bs)
+        task = (partial(np.linspace, endpoint=endpoint, dtype=dtype),
+                blockstart, blockstop, bs)
         blockstart = blockstart + (step * bs)
         dsk[(name, i)] = task
 

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -52,26 +52,32 @@ def test_arr_like(funcname, shape, dtype, chunks):
         assert (np_r == np.asarray(da_r)).all()
 
 
-def test_linspace():
-    darr = da.linspace(6, 49, chunks=5)
-    nparr = np.linspace(6, 49)
+@pytest.mark.parametrize("endpoint", [True, False])
+def test_linspace(endpoint):
+    darr = da.linspace(6, 49, endpoint=endpoint, chunks=5)
+    nparr = np.linspace(6, 49, endpoint=endpoint)
     assert_eq(darr, nparr)
 
-    darr = da.linspace(1.4, 4.9, chunks=5, num=13)
-    nparr = np.linspace(1.4, 4.9, num=13)
+    darr = da.linspace(1.4, 4.9, endpoint=endpoint, chunks=5, num=13)
+    nparr = np.linspace(1.4, 4.9, endpoint=endpoint, num=13)
     assert_eq(darr, nparr)
 
-    darr = da.linspace(6, 49, chunks=5, dtype=float)
-    nparr = np.linspace(6, 49, dtype=float)
+    darr = da.linspace(6, 49, endpoint=endpoint, chunks=5, dtype=float)
+    nparr = np.linspace(6, 49, endpoint=endpoint, dtype=float)
     assert_eq(darr, nparr)
 
-    darr = da.linspace(1.4, 4.9, chunks=5, num=13, dtype=int)
-    nparr = np.linspace(1.4, 4.9, num=13, dtype=int)
+    darr, dstep = da.linspace(6, 49, endpoint=endpoint, chunks=5, retstep=True)
+    nparr, npstep = np.linspace(6, 49, endpoint=endpoint, retstep=True)
+    assert np.allclose(dstep, npstep)
     assert_eq(darr, nparr)
-    assert (sorted(da.linspace(1.4, 4.9, chunks=5, num=13).dask) ==
-            sorted(da.linspace(1.4, 4.9, chunks=5, num=13).dask))
-    assert (sorted(da.linspace(6, 49, chunks=5, dtype=float).dask) ==
-            sorted(da.linspace(6, 49, chunks=5, dtype=float).dask))
+
+    darr = da.linspace(1.4, 4.9, endpoint=endpoint, chunks=5, num=13, dtype=int)
+    nparr = np.linspace(1.4, 4.9, num=13, endpoint=endpoint, dtype=int)
+    assert_eq(darr, nparr)
+    assert (sorted(da.linspace(1.4, 4.9, endpoint=endpoint, chunks=5, num=13).dask) ==
+            sorted(da.linspace(1.4, 4.9, endpoint=endpoint, chunks=5, num=13).dask))
+    assert (sorted(da.linspace(6, 49, endpoint=endpoint, chunks=5, dtype=float).dask) ==
+            sorted(da.linspace(6, 49, endpoint=endpoint, chunks=5, dtype=float).dask))
 
 
 def test_arange():


### PR DESCRIPTION
This PR adds support for the `endpoint` and `retstep` keyword arguments to `da.linspace`. Fixes #3673.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
