### PR TITLE
Adds quotes to source pip install

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -63,7 +63,7 @@ To install dask from source, clone the repository from `github
 
 or use ``pip`` locally if you want to install all dependencies as well::
 
-    pip install -e .[complete]
+    pip install -e ".[complete]"
 
 You can view the list of all dependencies within the ``extras_require`` field
 of ``setup.py``.


### PR DESCRIPTION
This PR adds quotes to the `pip install` from the "Install from Source" section of the docs
