### PR TITLE
Align auto chunks to provided chunks, rather than shape

### DIFF
--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -617,7 +617,7 @@ def test_rechunk_avoid_needless_chunking():
     (100, 1, 10, (10,) * 10),
     (100, 50, 10, (10,) * 10),
     (100, 100, 10, (10,) * 10),
-    (20, 7, 10, (10, 10)),
+    (20, 7, 10, (7, 7, 6)),
     (20, (1, 1, 1, 1, 6, 2, 1, 7), 5, (5, 5, 5, 5)),
 ])
 def test_rechunk_auto_1d(shape, chunks, bs, expected):


### PR DESCRIPTION
Previously we used to align "auto" chunks to the shape, even if the old chunks
are not well aligned to the shape.  Now we align to the previous chunking if it
was consistent.

Here is an example that would change:

```python
import dask
import dask.array as da

x = da.ones(3000, chunks=512).astype('u1')

with dask.config.set({'array.chunk-size': '1kiB'}):
    y = x.rechunk('auto')

>>> y.chunks            # Previously
((1000, 1000, 1000),)
>>> y.chunks            # New
((1024, 1024, 952),)
```

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
