### PR TITLE
Implement .blocks accessor

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1389,6 +1389,8 @@ class Array(DaskMethodsMixin):
             index = (index,)
         if sum(isinstance(ind, (np.ndarray, list)) for ind in index) > 1:
             raise ValueError("Can only slice with a single list")
+        if any(ind is None for ind in index):
+            raise ValueError("Slicing with np.newaxis or None is not supported")
         index = normalize_index(index, self.numblocks)
         index = tuple(slice(k, k + 1) if isinstance(k, Number) else k
                       for k in index)
@@ -1414,6 +1416,12 @@ class Array(DaskMethodsMixin):
         Numpy-style slicing but now rather than slice elements of the array you
         slice along blocks so, for example, ``x.blocks[0, ::2]`` produces a new
         dask array with every other block in the first row of blocks.
+
+        You can index blocks in any way that could index a numpy array of shape
+        equal to the number of blocks in each dimension, (available as
+        array.numblocks).  The dimension of the output array will be the same
+        as the dimension of this array, even if integer indices are passed.
+        This does not support slicing with ``np.newaxis`` or multiple lists.
 
         Examples
         --------

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1407,6 +1407,11 @@ class Array(DaskMethodsMixin):
     def blocks(self):
         """ Slice an array by blocks
 
+        This allows blockwise slicing of a Dask array.  You can perform normal
+        Numpy-style slicing but now rather than slice elements of the array you
+        slice along blocks so, for example, ``x.blocks[0, ::2]`` produces a new
+        dask array with every other block in the first row of blocks.
+
         Examples
         --------
         >>> import dask.array as da
@@ -1419,6 +1424,10 @@ class Array(DaskMethodsMixin):
         array([0, 1, 4, 5, 8, 9])
         >>> x.blocks[[-1, 0]].compute()
         array([8, 9, 0, 1])
+
+        Returns
+        -------
+        A Dask array
         """
         return IndexCallable(self._blocks)
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1387,10 +1387,13 @@ class Array(DaskMethodsMixin):
         from .slicing import normalize_index
         if not isinstance(index, tuple):
             index = (index,)
+        if sum(isinstance(ind, (np.ndarray, list)) for ind in index) > 1:
+            raise ValueError("Can only slice with a single list")
         index = normalize_index(index, self.numblocks)
         index = tuple(slice(k, k + 1) if isinstance(k, Number) else k
                       for k in index)
-        name = 'getitem-' + tokenize(self, index)
+
+        name = 'blocks-' + tokenize(self, index)
 
         new_keys = np.array(self.__dask_keys__(), dtype=object)[index]
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3531,6 +3531,7 @@ def test_blocks_indexer():
     assert_eq(x.blocks[-1], x[-2:])
     assert_eq(x.blocks[:3], x[:6])
     assert_eq(x.blocks[[0, 1, 2]], x[:6])
+    assert_eq(x.blocks[[3, 0, 2]], np.array([6, 7, 0, 1, 4, 5]))
 
     x = da.random.random((20, 20), chunks=(4, 5))
     assert_eq(x.blocks[0], x[:4])

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3546,5 +3546,11 @@ def test_blocks_indexer():
         x.blocks[[0, 1], [0, 1]]
     with pytest.raises(ValueError):
         x.blocks[np.array([0, 1]), [0, 1]]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as info:
         x.blocks[np.array([0, 1]), np.array([0, 1])]
+    assert "list" in str(info.value)
+    with pytest.raises(ValueError) as info:
+        x.blocks[None, :, :]
+    assert "newaxis" in str(info.value) and "not supported" in str(info.value)
+    with pytest.raises(IndexError) as info:
+        x.blocks[100, 100]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3539,3 +3539,11 @@ def test_blocks_indexer():
 
     x = da.ones((40, 40, 40), chunks=(10, 10, 10))
     assert_eq(x.blocks[0, :, 0], np.ones((10, 40, 10)))
+
+    x = da.ones((2, 2), chunks=1)
+    with pytest.raises(ValueError):
+        x.blocks[[0, 1], [0, 1]]
+    with pytest.raises(ValueError):
+        x.blocks[np.array([0, 1]), [0, 1]]
+    with pytest.raises(ValueError):
+        x.blocks[np.array([0, 1]), np.array([0, 1])]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3536,3 +3536,6 @@ def test_blocks_indexer():
     assert_eq(x.blocks[0], x[:4])
     assert_eq(x.blocks[0, :3], x[:4, :15])
     assert_eq(x.blocks[:, :3], x[:, :15])
+
+    x = da.ones((40, 40, 40), chunks=(10, 10, 10))
+    assert_eq(x.blocks[0, :, 0], np.ones((10, 40, 10)))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3520,3 +3520,19 @@ def test_zarr_nocompute():
         a2 = da.from_zarr(d)
         assert_eq(a, a2)
         assert a2.chunks == a.chunks
+
+
+def test_blocks_indexer():
+    x = da.arange(10, chunks=2)
+
+    assert isinstance(x.blocks[0], da.Array)
+
+    assert_eq(x.blocks[0], x[:2])
+    assert_eq(x.blocks[-1], x[-2:])
+    assert_eq(x.blocks[:3], x[:6])
+    assert_eq(x.blocks[[0, 1, 2]], x[:6])
+
+    x = da.random.random((20, 20), chunks=(4, 5))
+    assert_eq(x.blocks[0], x[:4])
+    assert_eq(x.blocks[0, :3], x[:4, :15])
+    assert_eq(x.blocks[:, :3], x[:, :15])


### PR DESCRIPTION
```python
>>> import dask.array as da
>>> x = da.arange(10, chunks=2)
>>> x.blocks[0].compute()
array([0, 1])
>>> x.blocks[:3].compute()
array([0, 1, 2, 3, 4, 5])
>>> x.blocks[::2].compute()
array([0, 1, 4, 5, 8, 9])
>>> x.blocks[[-1, 0]].compute()
array([8, 9, 0, 1])
```

Fixes #3684
Fixes #3274

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`

cc @stuartarchibald and @jakirkham and @shoyer 
