### PR TITLE
Proposal: traverse numpy array of objects

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -260,11 +260,17 @@ def unpack_collections(*args, **kwargs):
         if not traverse:
             tsk = quote(expr)
         else:
+            import numpy as np
             # Treat iterators like lists
             typ = list if isinstance(expr, Iterator) else type(expr)
 
             if typ in (list, tuple, set):
                 tsk = (typ, [_unpack(i) for i in expr])
+            elif typ is np.ndarray:
+                if expr.dtype == np.dtype('O'):
+                    tsk = (np.asarray, _unpack(expr.tolist()))
+                else:
+                    return expr
             elif typ is dict:
                 tsk = (dict, [[_unpack(k), _unpack(v)]
                               for k, v in expr.items()])

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -86,6 +86,12 @@ def to_task_dask(expr):
         # Ensure output type matches input type
         return (args, dsk) if typ is list else ((typ, args), dsk)
 
+    import numpy as np
+    if typ is np.ndarray:
+        if expr.dtype == np.dtype('O'):
+            args, dsk = to_task_dask(expr.tolist())
+            return ((np.asarray, args), dsk)
+
     if typ is dict:
         args, dsk = to_task_dask([[k, v] for k, v in expr.items()])
         return (dict, args), dsk


### PR DESCRIPTION
When traversing dask collections, this will look for numpy arrays. If it finds any, and they are arrays of objects, it calls `tolist` and gives `np.asarray` as the function to reconstruct the array from the list.

[notebook example](https://gist.github.com/hmaarrfk/f14d3560666bc6626a741a9e4d01d4bb)

This fixes  #3692

Would something like this be ok?

If something like this is OK, some more work would need to be done to:
1. Remove the hard dependency on numpy.
   * How should I do this? With try statements?
2. Can this work for subclasses of numpy arrays or other array like objects? I would need a pointer on how to make that work. Maybe with introspection?
3. Of course tests need to be added.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
