### PR TITLE
Update references to the nonexistent scheduler module to using the local module

### DIFF
--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -1,7 +1,7 @@
 """
 A threaded shared-memory scheduler
 
-See scheduler.py
+See local.py
 """
 from __future__ import absolute_import, division, print_function
 

--- a/docs/source/scheduling-policy.rst
+++ b/docs/source/scheduling-policy.rst
@@ -4,7 +4,7 @@ Scheduling in Depth
 *Note: this technical document is not optimized for user readability.*
 
 The default shared memory scheduler used by most dask collections lives in
-``dask/scheduler.py``. This scheduler dynamically schedules tasks to new
+``dask/local.py``. This scheduler dynamically schedules tasks to new
 workers as they become available.  It operates in a shared memory environment
 without consideration to data locality, all workers have access to all data
 equally.
@@ -48,11 +48,11 @@ on to the next.  This encourages our workers to complete blocks/subtrees of our
 graph before moving on to new blocks/subtrees.
 
 And so to encourage this "depth first behavior" we do a depth first search and
-number all nodes according to their number in the depth first search (DFS) 
-traversal.  We use this number to break ties when adding tasks on to the stack.  
-Please note that while we spoke of optimizing the many-distinct-subtree case 
-above this choice is entirely local and applies quite generally beyond this 
-case.  Anything that behaves even remotely like the many-distinct-subtree case 
+number all nodes according to their number in the depth first search (DFS)
+traversal.  We use this number to break ties when adding tasks on to the stack.
+Please note that while we spoke of optimizing the many-distinct-subtree case
+above this choice is entirely local and applies quite generally beyond this
+case.  Anything that behaves even remotely like the many-distinct-subtree case
 will benefit accordingly, and this case is quite common in normal workloads.
 
 And yet we have glossed over another tie breaker. Performing the depth

--- a/docs/source/scripts/scheduling.py
+++ b/docs/source/scripts/scheduling.py
@@ -1,7 +1,7 @@
 from toolz import merge
 from time import time
 import dask
-from dask import threaded, multiprocessing, scheduler
+from dask import threaded, multiprocessing, local
 from random import randint
 from collections import Iterator
 import matplotlib.pyplot as plt
@@ -43,7 +43,7 @@ import numpy as np
 
 x = np.logspace(0, 4, 10)
 trivial_results = dict()
-for get in [dask.get, threaded.get, scheduler.get_sync, multiprocessing.get]:
+for get in [dask.get, threaded.get, local.get_sync, multiprocessing.get]:
     y = list()
     for n in x:
         dsk, keys = trivial(int(n), 5)
@@ -80,7 +80,7 @@ plt.savefig('images/scaling-nodes.png')
 
 x = np.linspace(1, 100, 10)
 crosstalk_results = dict()
-for get in [threaded.get, scheduler.get_sync]:
+for get in [threaded.get, local.get_sync]:
     y = list()
     for n in x:
         dsk, keys = crosstalk(1000, 5, int(n))


### PR DESCRIPTION
There are a number of references to the `scheduler` module which doesn't exist. Looking at commit 0108940387a8d17034a7fbad0558d7e3672243d9 it seems to indicate `local` is the correct package. My guess is `scheduler` is a WIP name that didn't all get updated before that commit was merged?

My editor also removed a bunch of trailing whitespaces - since dask follows flake8 I didn't revert them but let me know if they should be left there or be updated in a different commit.

- [x] Passes `flake8 dask`
