### PR TITLE
Add constrains on HEAD when getting size of HTTP files

### DIFF
--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -294,8 +294,17 @@ class HTTPFile(object):
 
 
 def file_size(url, session, **kwargs):
-    """Call HEAD on the server to get file size"""
-    r = session.head(url, **kwargs)
+    """Call HEAD on the server to get file size
+
+    Default operation is to explicitly allow redirects and use encoding
+    'identity' (no compression) to get the true size of the target.
+    """
+    kwargs = kwargs.copy()
+    ar = kwargs.pop('allow_redirects', True)
+    head = kwargs.get('headers', {})
+    if 'Accept-Encoding' not in head:
+        head['Accept-Encoding'] = 'identity'
+    r = session.head(url, allow_redirects=ar, **kwargs)
     r.raise_for_status()
     if 'Content-Length' in r.headers:
         return int(r.headers['Content-Length'])


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
