### PR TITLE
Avoid importing skimage on AttributeError

### DIFF
--- a/dask/array/image.py
+++ b/dask/array/image.py
@@ -5,7 +5,7 @@ import os
 
 try:
     from skimage.io import imread as sk_imread
-except ImportError:
+except (AttributeError, ImportError):
     pass
 
 from .core import Array


### PR DESCRIPTION
When running Python in optimized mode it strips docstrings.
This causes and error in Pillow:

    dask/array/image.py:7: in <module>
	from skimage.io import imread as sk_imread
    ../../../miniconda/envs/test-environment/lib/python2.7/site-packages/skimage/io/__init__.py:7: in <module>
	from .manage_plugins import *
    ../../../miniconda/envs/test-environment/lib/python2.7/site-packages/skimage/io/manage_plugins.py:28: in <module>
	from .collection import imread_collection_wrapper
    ../../../miniconda/envs/test-environment/lib/python2.7/site-packages/skimage/io/collection.py:12: in <module>
	from PIL import Image
    ../../../miniconda/envs/test-environment/lib/python2.7/site-packages/PIL/__init__.py:27: in <module>
	__doc__ = __doc__.format(__version__)  # include version in docstring
    E   AttributeError: 'NoneType' object has no attribute 'format'

We now gracefully avoid this import

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
