### PR TITLE
improve output dtype and shape inference in apply_along_axis

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2018,7 +2018,7 @@ def normalize_chunks(chunks, shape=None, limit=None, dtype=None,
     """ Normalize chunks to tuple of tuples
 
     This takes in a variety of input types and information and produces a full
-    tuple-of-tuples result for chunks, sutiable to be passed to Array or
+    tuple-of-tuples result for chunks, suitable to be passed to Array or
     rechunk or any other operation that creates a Dask array.
 
     Parameters

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3734,7 +3734,7 @@ def stack(seq, axis=0):
     """
     Stack arrays along a new axis
 
-    Given a sequence of dask Arrays form a new dask Array by stacking them
+    Given a sequence of dask arrays, form a new dask array by stacking them
     along a new dimension (axis=0 by default)
 
     Examples

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -317,11 +317,11 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     arr = asarray(arr)
 
     # Validate and normalize axis.
-    axlen = arr.shape[axis]
+    arr.shape[axis]
     axis = len(arr.shape[:axis])
 
     # Test out some data with the function.
-    test_data = np.ones((axlen,), dtype=arr.dtype)
+    test_data = np.ones((1,), dtype=arr.dtype)
     test_result = np.array(func1d(test_data, *args, **kwargs))
 
     if (LooseVersion(np.__version__) < LooseVersion("1.13.0") and

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -317,11 +317,11 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     arr = asarray(arr)
 
     # Validate and normalize axis.
-    arr.shape[axis]
+    axlen = arr.shape[axis]
     axis = len(arr.shape[:axis])
 
     # Test out some data with the function.
-    test_data = np.ones((1,), dtype=arr.dtype)
+    test_data = np.ones((axlen,), dtype=arr.dtype)
     test_result = np.array(func1d(test_data, *args, **kwargs))
 
     if (LooseVersion(np.__version__) < LooseVersion("1.13.0") and


### PR DESCRIPTION
closes #3727 

I got some test failures in `irfft2` and `irfftn` due to floating-point dtype mismatches between the dask fft and the numpy fft, but I can't see how they are related to my changes...

- [ ] Tests added / passed
- [x] Passes `flake8 dask`
