### PR TITLE
Test that dask collections can hold scipy.sparse arrays

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3574,3 +3574,14 @@ def test_blocks_indexer():
     assert "newaxis" in str(info.value) and "not supported" in str(info.value)
     with pytest.raises(IndexError) as info:
         x.blocks[100, 100]
+
+
+def test_dask_array_holds_scipy_sparse_containers():
+    sparse = pytest.importorskip('scipy.sparse')
+    x = da.random.random((1000, 10), chunks=(100, 10))
+    x[x < 0.9] = 0
+    y = x.map_blocks(sparse.csr_matrix)
+
+    vs = y.to_delayed().flatten().tolist()
+    values = dask.compute(*vs, scheduler='single-threaded')
+    assert all(isinstance(v, sparse.csr_matrix) for v in values)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -892,7 +892,7 @@ def is_arraylike(x):
     >>> is_arraylike('cat')
     False
     """
-    return (hasattr(x, '__array__') and
+    return (# hasattr(x, '__array__') and
             hasattr(x, 'shape') and x.shape and
             hasattr(x, 'dtype'))
 


### PR DESCRIPTION
They can't do much with them because they don't support the ndarray
interface, but it's useful for dask-ml work that we can produce them and
then hand them off to dask.delayed or da.map_blocks workflows

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
