### PR TITLE
fix of minor typos in landing page index.html

### DIFF
--- a/docs/source/index.html
+++ b/docs/source/index.html
@@ -125,9 +125,9 @@
         <div class="row featurette">
           <div class="col-md-7">
             <h2 class="featurette-heading">Familiar for Python users</h2>
-            <h2 class="featurette-subheading"> and easy to get started</h2>
-            <p class="lead">Dask uses existing Python APIs and data structures to make it easy to switch between Numpy, Pandas, Scikit-learn to their Dask-powered equivalents. </>
-            <p class="lead"> You don't have to completely rewrite your code or retrain to scale up.</p>
+            <h2 class="featurette-subheading">and easy to get started</h2>
+            <p class="lead">Dask uses existing Python APIs and data structures to make it easy to switch between Numpy, Pandas, Scikit-learn to their Dask-powered equivalents.</>
+            <p class="lead">You don't have to completely rewrite your code or retrain to scale up.</p>
             <a class="btn btn-secondary" href="api.html" role="button">Learn About Dask APIs &raquo;</a>
           </div>
 
@@ -155,11 +155,11 @@ lr.fit(train, test)</code></pre>
 
         <div class="row featurette">
           <div class="col-md-7 order-md-1">
-            <h2 class="featurette-heading">Scale up to clusters </h2>
+            <h2 class="featurette-heading">Scale up to clusters</h2>
             <h2 class="featurette-subheading">or just use it on your laptop</h2>
             <p class="lead">Dask's schedulers scale to thousand-node clusters and its algorithms have been tested on some of the largest supercomputers in the world.</p>
 
-            <p class="lead">But you don't need a massive cluster to get started.  Dask ships with schedulers designed for use on personal machines.  Many people use Dask today to scale computations on their laptop, using multiple cores for computation and their disk for excess storage.</p>
+            <p class="lead">But you don't need a massive cluster to get started. Dask ships with schedulers designed for use on personal machines. Many people use Dask today to scale computations on their laptop, using multiple cores for computation and their disk for excess storage.</p>
             <a class="btn btn-secondary" href="scheduling.html" role="button">Learn About Dask Schedulers &raquo;</a>
           </div>
           <div class="col-md-5 order-md-2" style="padding: 6rem 0rem;">
@@ -175,7 +175,7 @@ lr.fit(train, test)</code></pre>
             <h2 class="featurette-heading">Customizable</h2>
             <h2 class="featurette-subheading">Enabling you to parallelize internal systems</h2>
             <p class="lead">Not all computations fit into a big dataframe.</p>
-            <p class="lead">Dask exposes lower-level APIs letting you build custom systems for in-house applications.  This helps open source leaders parallelize their own packages and helps business leaders scale custom business logic.</p>
+            <p class="lead">Dask exposes lower-level APIs letting you build custom systems for in-house applications. This helps open source leaders parallelize their own packages and helps business leaders scale custom business logic.</p>
           </div>
 
           <div class="col-md-5 p-lg-1 mx-auto my-5">

--- a/docs/source/index.html
+++ b/docs/source/index.html
@@ -90,7 +90,7 @@
           <div class="col-lg-4">
             <h2 class="mt-3">Numpy</h2>
             <img src="_images/dask-array-black-text.svg" class="top-image">
-            <p>Dask arrays scale Numpy workflows, enabling multi-dimensional data analysis in earth science, satellite imagery, genomics, biomedical applications, and machine learning algorithms</p>
+            <p>Dask arrays scale Numpy workflows, enabling multi-dimensional data analysis in earth science, satellite imagery, genomics, biomedical applications, and machine learning algorithms.</p>
             <p>
               <a class="btn btn-outline-secondary" href="array.html" role="button">Learn More &raquo;</a>
               <a class="btn btn-secondary" href="https://mybinder.org/v2/gh/dask/dask-examples/master?filepath=array.ipynb" role="button">Try Now &raquo;</a>
@@ -109,7 +109,7 @@
             <!-- <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/32/Rosenbrock_function.svg/300px-Rosenbrock_function.svg.png" class="top-image"> -->
             <h2 class="mt-3">Scikit-Learn</h2>
             <img src="https://www.inria.fr/var/inria/storage/images/medias/saclay/actualites-images/saclay_scikit_learn_classification_398x195/841331-1-fre-FR/saclay_scikit_learn_classification_398x195.jpg" class="top-image">
-            <p>Dask-ML scales machine learning APIs like Scikit-Learn and XGBoost to enable scalable training and prediction on large models and large datasets</p>
+            <p>Dask-ML scales machine learning APIs like Scikit-Learn and XGBoost to enable scalable training and prediction on large models and large datasets.</p>
             <p>
               <a class="btn btn-outline-secondary" href="https://dask-ml.readthedocs.org/en/latest/" role="button">Learn More &raquo;</a>
               <a class="btn btn-secondary" href="https://mybinder.org/v2/gh/dask/dask-examples/master?filepath=machine-learning.ipynb" role="button">Try Now &raquo;</a>
@@ -127,7 +127,7 @@
             <h2 class="featurette-heading">Familiar for Python users</h2>
             <h2 class="featurette-subheading"> and easy to get started</h2>
             <p class="lead">Dask uses existing Python APIs and data structures to make it easy to switch between Numpy, Pandas, Scikit-learn to their Dask-powered equivalents. </>
-            <p class="lead"> You don't have to completely rewrite your code or retrain to scale up</p>
+            <p class="lead"> You don't have to completely rewrite your code or retrain to scale up.</p>
             <a class="btn btn-secondary" href="api.html" role="button">Learn About Dask APIs &raquo;</a>
           </div>
 
@@ -174,8 +174,8 @@ lr.fit(train, test)</code></pre>
           <div class="col-md-7">
             <h2 class="featurette-heading">Customizable</h2>
             <h2 class="featurette-subheading">Enabling you to parallelize internal systems</h2>
-            <p class="lead">Not all computations fit into a big dataframe</p>
-            <p class="lead">Dask exposes lower-level APIs letting you build custom systems for in-house applications.  This helps open source leaders parallelize their own packages and helps business leaders scale custom business logic</p>
+            <p class="lead">Not all computations fit into a big dataframe.</p>
+            <p class="lead">Dask exposes lower-level APIs letting you build custom systems for in-house applications.  This helps open source leaders parallelize their own packages and helps business leaders scale custom business logic.</p>
           </div>
 
           <div class="col-md-5 p-lg-1 mx-auto my-5">
@@ -196,7 +196,7 @@ lr.fit(train, test)</code></pre>
 
         <div class="container supporters">
           <h2>Supported By</h2>
-          <p>Dask receives generous support from the following institutions, either through direct funding, or by employing core developers<p>
+          <p>Dask receives generous support from the following institutions, either through direct funding, or by employing core developers.<p>
           <div class="row">
             <div class="col supporter">
               <a href="https://anaconda.com"><img src="https://www.anaconda.com/wp-content/themes/anaconda/images/logo-dark.png"></a>


### PR DESCRIPTION
Just added some missing full stops in landing page.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
