### PR TITLE
Raise error when replace=False in da.choice

### DIFF
--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -172,9 +172,6 @@ class RandomState(object):
     with ignoring(AttributeError):
         @doc_wraps(np.random.RandomState.choice)
         def choice(self, a, size=None, replace=True, p=None, chunks=None):
-            if not replace:
-                raise NotImplementedError('replace=False is not currently '
-                                          'supported for dask.array.choice')
             dsks = []
             # Normalize and validate `a`
             if isinstance(a, Integral):
@@ -220,6 +217,11 @@ class RandomState(object):
                 size = (size,)
 
             chunks = normalize_chunks(chunks, size, dtype=np.float64)
+            if not replace and len(chunks[0]) > 1:
+                    err_msg = ('replace=False is not currently supported for '
+                               'dask.array.choice with multi-chunk output '
+                               'arrays')
+                    raise NotImplementedError(err_msg)
             sizes = list(product(*chunks))
             state_data = random_state_data(len(sizes), self._numpy_state)
 

--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -172,6 +172,9 @@ class RandomState(object):
     with ignoring(AttributeError):
         @doc_wraps(np.random.RandomState.choice)
         def choice(self, a, size=None, replace=True, p=None, chunks=None):
+            if not replace:
+                raise NotImplementedError('replace=False is not currently '
+                                          'supported for dask.array.choice')
             dsks = []
             # Normalize and validate `a`
             if isinstance(a, Integral):

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -271,6 +271,11 @@ def test_choice():
     with pytest.raises(NotImplementedError):
         da.random.choice(da_a, size=size, chunks=chunks, replace=False)
 
+    # Want to make sure replace=False works for a single-partition output array
+    x = da.random.choice(da_a, size=da_a.shape[0], chunks=-1, replace=False)
+    res = x.compute()
+    assert len(res) == len(np.unique(res))
+
 
 def test_create_with_auto_dimensions():
     with dask.config.set({'array.chunk-size': '128MiB'}):

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -268,6 +268,9 @@ def test_choice():
         with pytest.raises(ValueError):
             da.random.choice(a, size=size, chunks=chunks, p=p)
 
+    with pytest.raises(NotImplementedError):
+        da.random.choice(da_a, size=size, chunks=chunks, replace=False)
+
 
 def test_create_with_auto_dimensions():
     with dask.config.set({'array.chunk-size': '128MiB'}):


### PR DESCRIPTION
In the current implementation of `dask.array.choice`, a random sample _from the entire dask array_ is sampled for each chunk in the output dask array. These random samples are then merged together to form the returned dask array. This means that when `replace=False` you won't choose the same sample for a given chunk, but different chunks can sample the same items from the full dask array. For example, 

```python
import dask.array as da
import numpy as np

a = da.arange(10, chunks=3)
for replace in [True, False]:
    c = da.random.choice(a, size=a.shape[0], replace=replace, chunks=3)
    print('replace: {}'.format(replace))
    print('c.compute() = {}'.format(c.compute()))
```

outputs something like 

```
replace: True
c.compute() = [3 3 7 0 4 5 7 9 5 8]
replace: False
c.compute() = [4 0 7 3 2 9 5 1 7 1]
```

We can see there are repeats when `replace=True` (as expected), but there are also repeats when `replace=False` (unexpected). 

I'll keep thinking about how to re-work the `da.choice` implementation to support `replace=False`. In the meantime, this PR adds a check for `replace=False` and raises a `NotImplementedError` accordingly. 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
