### PR TITLE
Array.__setitem__ doesn't update the chunksize, resulting in bad graph traversal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.hypothesis
 *.py[cod]
 __pycache__/
 *.egg-info

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1337,9 +1337,6 @@ class Array(DaskMethodsMixin):
             self.dtype = y.dtype
             self.dask = y.dask
             self.name = y.name
-            # In order to figure out what keys to use, __dask_keys__ needs to
-            # know what chunks to expect. The chunks to expect are y.chunks, so
-            # we need to change our chunks.
             self._chunks = y.chunks
             return self
         else:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1337,6 +1337,10 @@ class Array(DaskMethodsMixin):
             self.dtype = y.dtype
             self.dask = y.dask
             self.name = y.name
+            # In order to figure out what keys to use, __dask_keys__ needs to
+            # know what chunks to expect. The chunks to expect are y.chunks, so
+            # we need to change our chunks.
+            self._chunks = y.chunks
             return self
         else:
             raise NotImplementedError("Item assignment with %s not supported"

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -2,7 +2,7 @@ import itertools
 from operator import getitem
 
 import pytest
-from hypothesis import given, strategies as st, example
+from hypothesis import given, strategies as st, example, settings
 from toolz import merge
 
 np = pytest.importorskip('numpy')
@@ -813,7 +813,8 @@ def size_and_chunks(draw, elements=st.integers(min_value=1, max_value=100)):
 
 
 @given(params=size_and_chunks())
-@example(params=(5, 2, 3))
+@settings(max_examples=15)
+@example(params=(2, 2, 1))
 def test_slicing_of_same_size_preserves_shape(params):
     """ Reproducer for https://github.com/dask/dask/issues/3730.
 
@@ -821,6 +822,7 @@ def test_slicing_of_same_size_preserves_shape(params):
     """
     array_size, chunk_size1, chunk_size2 = params
     x = da.zeros(array_size, chunks=chunk_size1)
-    m = da.zeros(array_size, chunks=chunk_size2)
-    x[m > 0] = 1
-    assert x.shape == x.compute().shape
+    mask = da.zeros(array_size, chunks=chunk_size2)
+    x[mask] = 1
+    result = x.compute()
+    assert x.shape == result.shape

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -2,7 +2,6 @@ import itertools
 from operator import getitem
 
 import pytest
-from hypothesis import given, strategies as st, example, settings
 from toolz import merge
 
 np = pytest.importorskip('numpy')
@@ -801,28 +800,13 @@ def test_pathological_unsorted_slicing():
     assert 'out-of-order' in str(info.list[0])
 
 
-@st.composite
-def size_and_chunks(draw, elements=st.integers(min_value=1, max_value=100)):
-    """ Return 3 tuple of (array size, chunk size 1, chunk size 2).
-
-    Chunk sizes are always smaller than array size.
-    """
-    array_size = draw(elements)
-    chunks = st.integers(min_value=1, max_value=array_size)
-    return (array_size, draw(chunks), draw(chunks))
-
-
-@given(params=size_and_chunks())
-@settings(max_examples=15)
-@example(params=(2, 2, 1))
+@pytest.mark.parametrize('params', [(2, 2, 1), (5, 3, 2)])
 def test_setitem_with_different_chunks_preserves_shape(params):
     """ Reproducer for https://github.com/dask/dask/issues/3730.
 
     Mutating based on an array with different chunks can cause new chunks to be
     used.  We need to ensure those new chunk sizes are applied to the mutated
     array, otherwise the array won't generate the correct keys.
-
-    Use property-based testing to generate a variety of values to check.
     """
     array_size, chunk_size1, chunk_size2 = params
     x = da.zeros(array_size, chunks=chunk_size1)

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -815,8 +815,12 @@ def size_and_chunks(draw, elements=st.integers(min_value=1, max_value=100)):
 @given(params=size_and_chunks())
 @settings(max_examples=15)
 @example(params=(2, 2, 1))
-def test_slicing_of_same_size_preserves_shape(params):
+def test_setitem_with_different_chunks_preserves_shape(params):
     """ Reproducer for https://github.com/dask/dask/issues/3730.
+
+    Mutating based on an array with different chunks can cause new chunks to be
+    used.  We need to ensure those new chunk sizes are applied to the mutated
+    array, otherwise the array won't generate the correct keys.
 
     Use property-based testing to generate a variety of values to check.
     """

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(name='dask',
       packages=packages + tests,
       long_description=open('README.rst').read() if exists('README.rst') else '',
       setup_requires=setup_requires,
-      tests_require=['pytest'],
+      tests_require=['pytest', 'hypothesis'],
       extras_require=extras_require,
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(name='dask',
       packages=packages + tests,
       long_description=open('README.rst').read() if exists('README.rst') else '',
       setup_requires=setup_requires,
-      tests_require=['pytest', 'hypothesis'],
+      tests_require=['pytest'],
       extras_require=extras_require,
       zip_safe=False)


### PR DESCRIPTION
Fixes #3730.

Mutation based on another array can result in chunk size changing. Chunk size is basis for deciding what keys to search the graph for. Therefore we need to make sure chunk size is up-to-date.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
