### PR TITLE
DOC: Update module reference to dask.array.gufunc (skip-ci)

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -338,7 +338,7 @@ Create and Store Arrays
 Generalized Ufuncs
 ~~~~~~~~~~~~~~~~~~
 
-.. currentmodule:: dask.array
+.. currentmodule:: dask.array.gufunc
 
 .. autosummary::
    apply_gufunc


### PR DESCRIPTION
- Changed `currentmodule` from `dask.array` to `dask.array.gufunc` in `array-api.rst`, which generates working autosummary link, as in `array-gufunc.rst`.

Fixes #3687.

Docs only
