### PR TITLE
Better error message on import when missing common dependencies

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -60,8 +60,8 @@ try:
     from .utils import assert_eq
 except ImportError as e:
     msg = ("Dask array requirements are not installed.\n\n"
-           "Please either conda or pip install dask[array]:\n\n"
-           "  conda install dask[array]          # either conda install\n"
+           "Please either conda or pip install as follows:\n\n"
+           "  conda install dask                 # either conda install\n"
            "  pip install dask[array] --upgrade  # or pip install")
     e.msg += "\n\n" + msg
     raise e

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -1,59 +1,67 @@
 from __future__ import absolute_import, division, print_function
 
-from ..utils import ignoring
-from .core import (Array, block, concatenate, stack, from_array, store,
-                   map_blocks, atop, to_hdf5, to_npy_stack, from_npy_stack,
-                   from_delayed, asarray, asanyarray, PerformanceWarning,
-                   broadcast_arrays, broadcast_to, from_zarr, to_zarr)
-from .routines import (take, choose, argwhere, where, coarsen, insert,
-                       ravel, roll, unique, squeeze, ptp, diff, ediff1d,
-                       gradient, bincount, digitize, histogram, cov, array,
-                       dstack, vstack, hstack, compress, extract, round,
-                       count_nonzero, flatnonzero, nonzero, around, isin,
-                       isnull, notnull, isclose, allclose, corrcoef, swapaxes,
-                       tensordot, transpose, dot, vdot, matmul, outer,
-                       apply_along_axis, apply_over_axes, result_type,
-                       atleast_1d, atleast_2d, atleast_3d, piecewise, flip,
-                       flipud, fliplr, einsum, average)
-from .reshape import reshape
-from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
-        true_divide, floor_divide, negative, power, remainder, mod, conj, exp,
-        exp2, log, log2, log10, log1p, expm1, sqrt, square, cbrt, reciprocal,
-        sin, cos, tan, arcsin, arccos, arctan, arctan2, hypot, sinh, cosh,
-        tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg, greater,
-        greater_equal, less, less_equal, not_equal, equal, maximum,
-        bitwise_and, bitwise_or, bitwise_xor, bitwise_not, minimum,
-        logical_and, logical_or, logical_xor, logical_not, fmax, fmin,
-        isreal, iscomplex, isfinite, isinf, isneginf, isposinf, isnan, signbit,
-        copysign, nextafter, spacing, ldexp, fmod, floor, ceil, trunc, degrees,
-        radians, rint, fix, angle, real, imag, clip, fabs, sign, absolute,
-        i0, sinc, nan_to_num, frexp, modf, divide, frompyfunc)
 try:
-    from .ufunc import float_power
-except ImportError:
-    # Absent for NumPy versions prior to 1.12.
-    pass
-from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
-                         moment,
-                         argmin, argmax,
-                         nansum, nanmean, nanstd, nanvar, nanmin,
-                         nanmax, nanargmin, nanargmax,
-                         cumsum, cumprod,
-                         topk, argtopk)
-from .percentile import percentile
-with ignoring(ImportError):
-    from .reductions import nanprod, nancumprod, nancumsum
-with ignoring(ImportError):
-    from . import ma
-from . import random, linalg, ghost, fft
-from .ghost import map_overlap
-from .wrap import ones, zeros, empty, full
-from .creation import ones_like, zeros_like, empty_like, full_like
-from .rechunk import rechunk
-from ..context import set_options
-from ..base import compute
-from .optimization import optimize
-from .creation import (arange, linspace, meshgrid, indices, diag, eye,
-                       triu, tril, fromfunction, tile, repeat, pad)
-from .gufunc import apply_gufunc, gufunc, as_gufunc
-from .utils import assert_eq
+    from ..utils import ignoring
+    from .core import (Array, block, concatenate, stack, from_array, store,
+                       map_blocks, atop, to_hdf5, to_npy_stack, from_npy_stack,
+                       from_delayed, asarray, asanyarray, PerformanceWarning,
+                       broadcast_arrays, broadcast_to, from_zarr, to_zarr)
+    from .routines import (take, choose, argwhere, where, coarsen, insert,
+                           ravel, roll, unique, squeeze, ptp, diff, ediff1d,
+                           gradient, bincount, digitize, histogram, cov, array,
+                           dstack, vstack, hstack, compress, extract, round,
+                           count_nonzero, flatnonzero, nonzero, around, isin,
+                           isnull, notnull, isclose, allclose, corrcoef, swapaxes,
+                           tensordot, transpose, dot, vdot, matmul, outer,
+                           apply_along_axis, apply_over_axes, result_type,
+                           atleast_1d, atleast_2d, atleast_3d, piecewise, flip,
+                           flipud, fliplr, einsum, average)
+    from .reshape import reshape
+    from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
+            true_divide, floor_divide, negative, power, remainder, mod, conj, exp,
+            exp2, log, log2, log10, log1p, expm1, sqrt, square, cbrt, reciprocal,
+            sin, cos, tan, arcsin, arccos, arctan, arctan2, hypot, sinh, cosh,
+            tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg, greater,
+            greater_equal, less, less_equal, not_equal, equal, maximum,
+            bitwise_and, bitwise_or, bitwise_xor, bitwise_not, minimum,
+            logical_and, logical_or, logical_xor, logical_not, fmax, fmin,
+            isreal, iscomplex, isfinite, isinf, isneginf, isposinf, isnan, signbit,
+            copysign, nextafter, spacing, ldexp, fmod, floor, ceil, trunc, degrees,
+            radians, rint, fix, angle, real, imag, clip, fabs, sign, absolute,
+            i0, sinc, nan_to_num, frexp, modf, divide, frompyfunc)
+    try:
+        from .ufunc import float_power
+    except ImportError:
+        # Absent for NumPy versions prior to 1.12.
+        pass
+    from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
+                             moment,
+                             argmin, argmax,
+                             nansum, nanmean, nanstd, nanvar, nanmin,
+                             nanmax, nanargmin, nanargmax,
+                             cumsum, cumprod,
+                             topk, argtopk)
+    from .percentile import percentile
+    with ignoring(ImportError):
+        from .reductions import nanprod, nancumprod, nancumsum
+    with ignoring(ImportError):
+        from . import ma
+    from . import random, linalg, ghost, fft
+    from .ghost import map_overlap
+    from .wrap import ones, zeros, empty, full
+    from .creation import ones_like, zeros_like, empty_like, full_like
+    from .rechunk import rechunk
+    from ..context import set_options
+    from ..base import compute
+    from .optimization import optimize
+    from .creation import (arange, linspace, meshgrid, indices, diag, eye,
+                           triu, tril, fromfunction, tile, repeat, pad)
+    from .gufunc import apply_gufunc, gufunc, as_gufunc
+    from .utils import assert_eq
+except ImportError as e:
+    msg = ("Dask array requirements are not installed.\n\n"
+           "Please either conda or pip install dask[array]:\n\n"
+           "  conda install dask[array]          # either conda install\n"
+           "  pip install dask[array] --upgrade  # or pip install")
+    e.msg += "\n\n" + msg
+    raise e

--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -1,9 +1,17 @@
 from __future__ import absolute_import, division, print_function
 
-from .core import (Bag, Item, from_sequence, from_url, to_textfiles, concat,
-                   from_delayed, map_partitions, bag_range as range,
-                   bag_zip as zip, bag_map as map)
-from .text import read_text
-from .utils import assert_eq
-from ..context import set_options
-from ..base import compute
+try:
+    from .core import (Bag, Item, from_sequence, from_url, to_textfiles, concat,
+                       from_delayed, map_partitions, bag_range as range,
+                       bag_zip as zip, bag_map as map)
+    from .text import read_text
+    from .utils import assert_eq
+    from ..context import set_options
+    from ..base import compute
+except ImportError as e:
+    msg = ("Dask bag requirements are not installed.\n\n"
+           "Please either conda or pip install dask[bag]:\n\n"
+           "  conda install dask[bag]          # either conda install\n"
+           "  pip install dask[bag] --upgrade  # or pip install")
+    e.msg += "\n\n" + msg
+    raise e

--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -10,8 +10,8 @@ try:
     from ..base import compute
 except ImportError as e:
     msg = ("Dask bag requirements are not installed.\n\n"
-           "Please either conda or pip install dask[bag]:\n\n"
-           "  conda install dask[bag]          # either conda install\n"
+           "Please either conda or pip install as follows:\n\n"
+           "  conda install dask               # either conda install\n"
            "  pip install dask[bag] --upgrade  # or pip install")
     e.msg += "\n\n" + msg
     raise e

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -1,24 +1,32 @@
 from __future__ import print_function, division, absolute_import
 
-from .core import (DataFrame, Series, Index, _Frame, map_partitions,
-                   repartition, to_delayed, to_datetime, to_timedelta)
-from .groupby import Aggregation
-from .io import (from_array, from_pandas, from_bcolz,
-                 from_dask_array, read_hdf, read_sql_table,
-                 from_delayed, read_csv, to_csv, read_table,
-                 demo, to_hdf, to_records, to_bag, read_json, to_json)
-from .optimize import optimize
-from .multi import merge, concat
-from . import rolling
-from ..base import compute
-from .reshape import get_dummies, pivot_table, melt
-from .utils import assert_eq
-from .io.orc import read_orc
 try:
-    from .io import read_parquet, to_parquet
-except ImportError:
-    pass
-try:
-    from .core import isna
-except ImportError:
-    pass
+    from .core import (DataFrame, Series, Index, _Frame, map_partitions,
+                       repartition, to_delayed, to_datetime, to_timedelta)
+    from .groupby import Aggregation
+    from .io import (from_array, from_pandas, from_bcolz,
+                     from_dask_array, read_hdf, read_sql_table,
+                     from_delayed, read_csv, to_csv, read_table,
+                     demo, to_hdf, to_records, to_bag, read_json, to_json)
+    from .optimize import optimize
+    from .multi import merge, concat
+    from . import rolling
+    from ..base import compute
+    from .reshape import get_dummies, pivot_table, melt
+    from .utils import assert_eq
+    from .io.orc import read_orc
+    try:
+        from .io import read_parquet, to_parquet
+    except ImportError:
+        pass
+    try:
+        from .core import isna
+    except ImportError:
+        pass
+except ImportError as e:
+    msg = ("Dask dataframe requirements are not installed.\n\n"
+           "Please either conda or pip install dask[dataframe]:\n\n"
+           "  conda install dask[dataframe]          # either conda install\n"
+           "  pip install dask[dataframe] --upgrade  # or pip install")
+    e.msg += "\n\n" + msg
+    raise e

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -25,8 +25,8 @@ try:
         pass
 except ImportError as e:
     msg = ("Dask dataframe requirements are not installed.\n\n"
-           "Please either conda or pip install dask[dataframe]:\n\n"
-           "  conda install dask[dataframe]          # either conda install\n"
+           "Please either conda or pip install as follows:\n\n"
+           "  conda install dask                     # either conda install\n"
            "  pip install dask[dataframe] --upgrade  # or pip install")
     e.msg += "\n\n" + msg
     raise e


### PR DESCRIPTION
Implementation draft for #3740. Entering

```bash
python -c "import dask.array"
```

gives

```bash
Traceback (most recent call last):
  File "/Users/horta/code/dask-horta/dask/array/core.py", line 21, in <module>
    from cytoolz import (partition, concat, join, first,
ModuleNotFoundError: No module named 'cytoolz'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/horta/code/dask-horta/dask/array/__init__.py", line 11, in <module>
    raise e
  File "/Users/horta/code/dask-horta/dask/array/__init__.py", line 4, in <module>
    from ._init_impl import *
  File "/Users/horta/code/dask-horta/dask/array/_init_impl.py", line 4, in <module>
    from .core import (Array, block, concatenate, stack, from_array, store,
  File "/Users/horta/code/dask-horta/dask/array/core.py", line 26, in <module>
    from toolz import (partition, concat, join, first,
ModuleNotFoundError: No module named 'toolz'

Dask array requirements are not installed.

Please either conda or pip install dask[array]:

  conda install dask[array]          # either conda install
  pip install dask[array] --upgrade  # or pip install
```

here when `dask[array]` dependencies are not installed. I thought a large try/catch around the imports in `dask/array/__init__.py` would make it harder to read and I wanted to keep `import dask.array` lazy.

Alternatively, the corresponding dependencies could be imported in advance, in the beginning of `dask/array/__init__.py`, but that would make it harder to add or remove common dependencies as it would require to keep `dask/array/__init__.py` in sync.

The `_int_impl.py` solution is quite ugly, though, but I could not come up with anything better. I wonder if there is a common practice for such a case.