### PR TITLE
aggregate function for rolling objects

### DIFF
--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -306,6 +306,13 @@ class Rolling(object):
         return self._call_method('apply', func, args=args,
                                  kwargs=kwargs, **kwds)
 
+    @derived_from(pd_Rolling)
+    def aggregate(self, func, args=(), kwargs={}, **kwds):
+        return self._call_method('agg', func, args=args,
+                                 kwargs=kwargs, **kwds)
+
+    agg = aggregate
+
     def __repr__(self):
 
         def order(item):

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -278,17 +278,17 @@ def test_rolling_agg():
     expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
     expected.columns = pd.MultiIndex.from_product([['A', 'B'], ['mean',
                                                                 'std']])
-    tm.assert_frame_equal(result, expected)
+    assert_eq(result, expected)
 
     result = r.aggregate({'A': np.mean, 'B': np.std}).compute()
 
     expected = pd.concat([a_mean, b_std], axis=1)
-    tm.assert_frame_equal(result, expected, check_like=True)
+    assert_eq(result, expected, check_like=True)
 
     result = r.aggregate({'A': ['mean', 'std']}).compute()
     expected = pd.concat([a_mean, a_std], axis=1)
     expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'), ('A', 'std')])
-    tm.assert_frame_equal(result, expected)
+    assert_eq(result, expected)
 
     with catch_warnings(record=True):
         result = r.aggregate({'A': {'mean': 'mean', 'sum': 'sum'}}).compute()
@@ -296,7 +296,7 @@ def test_rolling_agg():
     expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
                                                   ('A', 'sum')])
 
-    tm.assert_frame_equal(result, expected, check_like=True)
+    assert_eq(result, expected, check_like=True)
 
     with catch_warnings(record=True):
         result = r.aggregate({'A': {'mean': 'mean',
@@ -306,14 +306,14 @@ def test_rolling_agg():
     expected = pd.concat([a_mean, a_sum, b_mean, b_sum], axis=1)
     exp_cols = [('A', 'mean'), ('A', 'sum'), ('B', 'mean2'), ('B', 'sum2')]
     expected.columns = pd.MultiIndex.from_tuples(exp_cols)
-    tm.assert_frame_equal(result, expected, check_like=True)
+    assert_eq(result, expected, check_like=True)
 
     result = r.aggregate({'A': ['mean', 'std'], 'B': ['mean', 'std']}).compute()
     expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
 
     exp_cols = [('A', 'mean'), ('A', 'std'), ('B', 'mean'), ('B', 'std')]
     expected.columns = pd.MultiIndex.from_tuples(exp_cols)
-    tm.assert_frame_equal(result, expected, check_like=True)
+    assert_eq(result, expected, check_like=True)
 
 
 def test_rolling_agg_aggregate():
@@ -330,7 +330,7 @@ def test_rolling_agg_aggregate():
     result = r.agg([np.mean, np.std]).compute()
     expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
     expected.columns = pd.MultiIndex.from_product([['A', 'B'], ['mean', 'std']])
-    tm.assert_frame_equal(result, expected)
+    assert_eq(result, expected)
 
 
 def test_rolling_agg_apply():
@@ -350,7 +350,7 @@ def test_rolling_agg_apply():
     rcustom = r.apply(lambda x: np.std(x, ddof=1), **kwargs).compute()
 
     expected = pd.concat([a_sum, rcustom['B']], axis=1)
-    tm.assert_frame_equal(result, expected, check_like=True)
+    assert_eq(result, expected, check_like=True)
 
 
 def test_rolling_agg_consistency():
@@ -389,4 +389,4 @@ def test_agg_nested_dicts():
         result = r.agg({'A': {'ra': ['mean', 'std']},
                         'B': {'rb': ['mean', 'std']}}).compute()
 
-    tm.assert_frame_equal(result, expected, check_like=True)
+    assert_eq(result, expected, check_like=True)

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -6,7 +6,6 @@ from warnings import catch_warnings
 import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq, PANDAS_VERSION
 import pandas.util.testing as tm
-from pandas.core.base import SpecificationError
 
 N = 40
 df = pd.DataFrame({'a': np.random.randn(N).cumsum(),

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import pytest
 import numpy as np
-from warnings import catch_warnings
 
 import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq, PANDAS_VERSION

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -274,24 +274,24 @@ def test_rolling_agg():
     b_std = r_std['B']
     b_sum = r_sum['B']
 
-    result = r.aggregate([np.mean, np.std]).compute()
+    result = r.aggregate([np.mean, np.std])
     expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
     expected.columns = pd.MultiIndex.from_product([['A', 'B'], ['mean',
                                                                 'std']])
     assert_eq(result, expected)
 
-    result = r.aggregate({'A': np.mean, 'B': np.std}).compute()
+    result = r.aggregate({'A': np.mean, 'B': np.std})
 
     expected = pd.concat([a_mean, b_std], axis=1)
     assert_eq(result, expected, check_like=True)
 
-    result = r.aggregate({'A': ['mean', 'std']}).compute()
+    result = r.aggregate({'A': ['mean', 'std']})
     expected = pd.concat([a_mean, a_std], axis=1)
     expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'), ('A', 'std')])
     assert_eq(result, expected)
 
     with catch_warnings(record=True):
-        result = r.aggregate({'A': {'mean': 'mean', 'sum': 'sum'}}).compute()
+        result = r.aggregate({'A': {'mean': 'mean', 'sum': 'sum'}})
     expected = pd.concat([a_mean, a_sum], axis=1)
     expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
                                                   ('A', 'sum')])
@@ -302,13 +302,13 @@ def test_rolling_agg():
         result = r.aggregate({'A': {'mean': 'mean',
                                     'sum': 'sum'},
                               'B': {'mean2': 'mean',
-                                    'sum2': 'sum'}}).compute()
+                                    'sum2': 'sum'}})
     expected = pd.concat([a_mean, a_sum, b_mean, b_sum], axis=1)
     exp_cols = [('A', 'mean'), ('A', 'sum'), ('B', 'mean2'), ('B', 'sum2')]
     expected.columns = pd.MultiIndex.from_tuples(exp_cols)
     assert_eq(result, expected, check_like=True)
 
-    result = r.aggregate({'A': ['mean', 'std'], 'B': ['mean', 'std']}).compute()
+    result = r.aggregate({'A': ['mean', 'std'], 'B': ['mean', 'std']})
     expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
 
     exp_cols = [('A', 'mean'), ('A', 'std'), ('B', 'mean'), ('B', 'std')]
@@ -327,7 +327,7 @@ def test_rolling_agg_aggregate():
     b_mean = r_mean['B']
     b_std = r_std['B']
 
-    result = r.agg([np.mean, np.std]).compute()
+    result = r.agg([np.mean, np.std])
     expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
     expected.columns = pd.MultiIndex.from_product([['A', 'B'], ['mean', 'std']])
     assert_eq(result, expected)
@@ -346,7 +346,7 @@ def test_rolling_agg_apply():
     r_sum = r.sum().compute()
     a_sum = r_sum['A']
 
-    result = r.agg({'A': np.sum, 'B': lambda x: np.std(x, ddof=1)}).compute()
+    result = r.agg({'A': np.sum, 'B': lambda x: np.std(x, ddof=1)})
     rcustom = r.apply(lambda x: np.std(x, ddof=1), **kwargs).compute()
 
     expected = pd.concat([a_sum, rcustom['B']], axis=1)
@@ -387,6 +387,6 @@ def test_agg_nested_dicts():
 
     with catch_warnings(record=True):
         result = r.agg({'A': {'ra': ['mean', 'std']},
-                        'B': {'rb': ['mean', 'std']}}).compute()
+                        'B': {'rb': ['mean', 'std']}})
 
     assert_eq(result, expected, check_like=True)

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -390,13 +390,3 @@ def test_agg_nested_dicts():
                         'B': {'rb': ['mean', 'std']}}).compute()
 
     tm.assert_frame_equal(result, expected, check_like=True)
-
-    with catch_warnings(record=True):
-        result = r.agg({'A': {'ra': ['mean', 'std']},
-                        'B': {'rb': ['mean', 'std']}}).compute()
-    expected.columns = pd.MultiIndex.from_tuples([('A', 'ra', 'mean'),
-                                                  ('A', 'ra', 'std'),
-                                                  ('B', 'rb', 'mean'),
-                                                  ('B', 'rb', 'std')])
-
-    tm.assert_frame_equal(result, expected, check_like=True)


### PR DESCRIPTION
Basic aggregate / agg function for rolling objects.
Usage example : 
```
import pandas as pd
import numpy as np
import dask.dataframe as dd
import datetime
from pandas.tseries.offsets import Day

time_range = pd.date_range(datetime.datetime(2016, 1, 1), datetime.datetime(2017, 1, 1), freq='D')

data = pd.DataFrame({'time': time_range,
                     'value': np.random.random(len(time_range))})
data = data.set_index('time')
data_dd = dd.from_pandas(data, npartitions=1)

result = data_dd.rolling(Day(10)).agg({'value': ['min', 'max', 'mean']}).compute()
```

Does **not** support the `ddf.groupby().rolling()...` paradigm.

- [ x] Tests added / passed
- [ x] Passes `flake8 dask`
