### PR TITLE
Add a chunksize convenience property

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1154,7 +1154,7 @@ class Array(DaskMethodsMixin):
     def shape(self):
         return tuple(map(sum, self.chunks))
     
-    @proprty
+    @property
     def chunksize(self):
         return tuple(c[0] for c in self.chunks)
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1153,6 +1153,10 @@ class Array(DaskMethodsMixin):
     @property
     def shape(self):
         return tuple(map(sum, self.chunks))
+    
+    @proprty
+    def chunksize(self):
+        return tuple(c[0] for c in self.chunks)
 
     @property
     def _meta(self):
@@ -1212,7 +1216,7 @@ class Array(DaskMethodsMixin):
         >>> da.ones((10, 10), chunks=(5, 5), dtype='i4')
         dask.array<..., shape=(10, 10), dtype=int32, chunksize=(5, 5)>
         """
-        chunksize = str(tuple(c[0] for c in self.chunks))
+        chunksize = str(self.chunksize)
         name = self.name.rsplit('-', 1)[0]
         return ("dask.array<%s, shape=%s, dtype=%s, chunksize=%s>" %
                 (name, self.shape, self.dtype, chunksize))

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1153,7 +1153,7 @@ class Array(DaskMethodsMixin):
     @property
     def shape(self):
         return tuple(map(sum, self.chunks))
-    
+
     @property
     def chunksize(self):
         return tuple(c[0] for c in self.chunks)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1156,7 +1156,7 @@ class Array(DaskMethodsMixin):
 
     @property
     def chunksize(self):
-        return tuple(c[0] for c in self.chunks)
+        return tuple(max(c) for c in self.chunks)
 
     @property
     def _meta(self):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -254,6 +254,7 @@ def test_stack():
 
     assert s.shape == (3, 4, 6)
     assert s.chunks == ((1, 1, 1), (2, 2), (3, 3))
+    assert s.chunksize == (1, 2, 3)
     assert s.dask[(s.name, 0, 1, 0)] == (getitem, ('A', 1, 0),
                                          (None, colon, colon))
     assert s.dask[(s.name, 2, 1, 0)] == (getitem, ('C', 1, 0),
@@ -263,6 +264,7 @@ def test_stack():
     s2 = stack([a, b, c], axis=1)
     assert s2.shape == (4, 3, 6)
     assert s2.chunks == ((2, 2), (1, 1, 1), (3, 3))
+    assert s2.chunksize == (2, 1, 3)
     assert s2.dask[(s2.name, 0, 1, 0)] == (getitem, ('B', 0, 0),
                                            (colon, None, colon))
     assert s2.dask[(s2.name, 1, 1, 0)] == (getitem, ('B', 1, 0),
@@ -272,6 +274,7 @@ def test_stack():
     s2 = stack([a, b, c], axis=2)
     assert s2.shape == (4, 6, 3)
     assert s2.chunks == ((2, 2), (3, 3), (1, 1, 1))
+    assert s2.chunksize == (2, 3, 1)
     assert s2.dask[(s2.name, 0, 1, 0)] == (getitem, ('A', 0, 1),
                                            (colon, colon, None))
     assert s2.dask[(s2.name, 1, 1, 2)] == (getitem, ('C', 1, 1),


### PR DESCRIPTION
I found myself needing to get the chunksize for a dask array. It is presented in the `_repr_` but not in a programmatic way. I ended up writing the same list comprehension that the `_repr_` does, which feels wasteful.

This PR moves the comprehension from the `_repr_` into a property and then uses it. This means I can use `mydaskarray.chunksize` in my own code.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
