### PR TITLE
Ensure to_zarr with return_stored True returns a Dask Array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2432,8 +2432,8 @@ def to_zarr(arr, url, component=None, storage_options=None,
             raise RuntimeError('Cannot store into in memory Zarr Array using '
                                'the Distributed Scheduler.')
         arr = arr.rechunk(z.chunks)
-        return store(arr, z, lock=False, compute=compute,
-                     return_stored=return_stored)
+        return arr.store(z, lock=False, compute=compute,
+                         return_stored=return_stored)
 
     if not _check_regular_chunks(arr.chunks):
         raise ValueError('Attempt to save array to zarr with irregular '
@@ -2453,8 +2453,8 @@ def to_zarr(arr, url, component=None, storage_options=None,
     chunks = [c[0] for c in arr.chunks]
     z = zarr.create(shape=arr.shape, chunks=chunks, dtype=arr.dtype,
                     store=mapper, path=component, overwrite=overwrite, **kwargs)
-    return store(arr, z, lock=False, compute=compute,
-                 return_stored=return_stored)
+    return arr.store(z, lock=False, compute=compute,
+                     return_stored=return_stored)
 
 
 def _check_regular_chunks(chunkset):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3493,6 +3493,17 @@ def test_zarr_roundtrip():
         assert a2.chunks == a.chunks
 
 
+@pytest.mark.parametrize('compute', [False, True])
+def test_zarr_return_stored(compute):
+    pytest.importorskip('zarr')
+    with tmpdir() as d:
+        a = da.zeros((3, 3), chunks=(1, 1))
+        a2 = a.to_zarr(d, compute=compute, return_stored=True)
+        assert isinstance(a2, Array)
+        assert_eq(a, a2)
+        assert a2.chunks == a.chunks
+
+
 def test_zarr_existing_array():
     zarr = pytest.importorskip('zarr')
     c = (1, 1)


### PR DESCRIPTION
Makes a small change in `to_zarr` to use the Dask Array `store` method (as opposed to the function). When `return_stored=True`, the `store` method makes sure to strip the singleton `tuple` from the result, the `store` function would usually provide. Thus giving the user a Dask Array in these cases. By changing this in `to_zarr`, we extend this behavior there as well. A test of this behavior is also included.

cc @martindurant

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
