### PR TITLE
Handle missing `matmul` on Python 3.4

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -13,7 +13,7 @@ except ImportError:
 from . import config, threaded
 from .base import is_dask_collection, dont_optimize, DaskMethodsMixin
 from .base import tokenize as _tokenize
-from .compatibility import apply, PY3
+from .compatibility import apply
 from .core import quote
 from .context import globalmethod
 from .utils import funcname, methodcaller, OperatorMethodMixin
@@ -526,8 +526,10 @@ for op in [operator.abs, operator.neg, operator.pos, operator.invert,
     Delayed._bind_operator(op)
 
 
-if PY3:
+try:
     Delayed._bind_operator(operator.matmul)
+except AttributeError:
+    pass
 
 
 def single_key(seq):

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -13,6 +13,11 @@ from dask.compatibility import PY2, PY3
 from dask.delayed import delayed, to_task_dask, Delayed
 from dask.utils_test import inc
 
+try:
+    from operator import matmul
+except ImportError:
+    matmul = None
+
 
 class Tuple(object):
     __dask_scheduler__ = staticmethod(dask.threaded.get)
@@ -102,7 +107,8 @@ def test_operators():
     assert (a >> 1).compute() == 5
     assert (a > 2).compute()
     assert (a ** 2).compute() == 100
-    if PY3:
+
+    if matmul:
         class dummy:
             def __matmul__(self, other):
                 return 4


### PR DESCRIPTION
As `matmul` was added in Python 3.5 and we still support Python 3.4, we can't get away with just adding this on Python 3 only as it will fail on Python 3.4. To fix this, simply try to add `matmul` support everywhere and skip it if `matmul` is not an operator.

- [x] Tests added / passed
- [x] Passes `flake8 dask`

ref: https://travis-ci.org/dask/dask/jobs/398614096