### PR TITLE
ENH: DataFrame.iloc

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -932,18 +932,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         from .indexing import _LocIndexer
         return _LocIndexer(self)
 
-    @property
-    def iloc(self):
-        """Purely integer-location based indexing for selection by position.
-
-        Only indexing the column positions is supported.
-        See :ref:`dataframe.indexing` for more.
-        """
-        from .indexing import _iLocIndexer
-        return _iLocIndexer(self)
-
-    # NOTE: `iloc` is not implemented because of performance concerns.
-    # see https://github.com/dask/dask/pull/507
+    # Note: iloc is implemented only on DataFrame
 
     def repartition(self, divisions=None, npartitions=None, freq=None, force=False):
         """ Repartition dataframe along new divisions
@@ -2370,6 +2359,22 @@ class DataFrame(_Frame):
         self._meta = renamed._meta
         self._name = renamed._name
         self.dask.update(renamed.dask)
+
+    @property
+    def iloc(self):
+        """Purely integer-location based indexing for selection by position.
+
+        Only indexing the column positions is supported. Trying to select
+        row positions will raise a ValueError.
+
+        See :ref:`dataframe.indexing` for more.
+
+        Examples
+        --------
+        >>> df.iloc[:, [2, 0, 1]]  # doctest: +SKIP
+        """
+        from .indexing import _iLocIndexer
+        return _iLocIndexer(self)
 
     def __getitem__(self, key):
         name = 'getitem-%s' % tokenize(self, key)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -932,6 +932,16 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         from .indexing import _LocIndexer
         return _LocIndexer(self)
 
+    @property
+    def iloc(self):
+        """Purely integer-location based indexing for selection by position.
+
+        Only indexing the column positions is supported.
+        See :ref:`dataframe.indexing` for more.
+        """
+        from .indexing import _iLocIndexer
+        return _iLocIndexer(self)
+
     # NOTE: `iloc` is not implemented because of performance concerns.
     # see https://github.com/dask/dask/pull/507
 

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -13,15 +13,17 @@ from . import methods
 from ..base import tokenize
 
 
-class _LocIndexer(object):
-    """ Helper class for the .loc accessor """
-
+class _IndexerBase(object):
     def __init__(self, obj):
         self.obj = obj
 
     @property
     def _name(self):
         return self.obj._name
+
+    @property
+    def _meta_indexer(self):
+        raise NotImplementedError
 
     def _make_meta(self, iindexer, cindexer):
         """
@@ -30,7 +32,52 @@ class _LocIndexer(object):
         if cindexer is None:
             return self.obj
         else:
-            return self.obj._meta.loc[:, cindexer]
+            return self._meta_indexer[:, cindexer]
+
+
+class _iLocIndexer(_IndexerBase):
+
+    @property
+    def _meta_indexer(self):
+        return self.obj._meta.iloc
+
+    def __getitem__(self, key):
+
+        if self.obj.ndim == 1:
+            if key != slice(None):
+                raise ValueError("'Series.iloc' only supports 'slice(None)'.")
+            return self.obj
+
+        # dataframe
+        msg = ("'DataFrame.iloc' does not support slicing rows. "
+               "The indexer must be a 2-tuple whose first item is "
+               "'slice(None)'.")
+        if not isinstance(key, tuple):
+            raise ValueError(msg)
+
+        if len(key) != 2:
+            raise ValueError(msg)
+
+        iindexer, cindexer = key
+
+        if iindexer != slice(None):
+            raise ValueError(msg)
+
+        return self._iloc(iindexer, cindexer)
+
+    def _iloc(self, iindexer, cindexer):
+        assert iindexer == slice(None)
+        meta = self._make_meta( iindexer, cindexer)
+
+        return self.obj.map_partitions(methods.iloc, cindexer, meta=meta)
+
+
+class _LocIndexer(_IndexerBase):
+    """ Helper class for the .loc accessor """
+
+    @property
+    def _meta_indexer(self):
+        return self.obj._meta.loc
 
     def __getitem__(self, key):
 

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -43,15 +43,9 @@ class _iLocIndexer(_IndexerBase):
 
     def __getitem__(self, key):
 
-        if self.obj.ndim == 1:
-            if key != slice(None):
-                raise ValueError("'Series.iloc' only supports 'slice(None)'.")
-            return self.obj
-
         # dataframe
-        msg = ("'DataFrame.iloc' does not support slicing rows. "
-               "The indexer must be a 2-tuple whose first item is "
-               "'slice(None)'.")
+        msg = ("'DataFrame.iloc' only supports selecting columns. "
+               "It must be used like 'df.iloc[:, column_indexer]'.")
         if not isinstance(key, tuple):
             raise ValueError(msg)
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -32,7 +32,6 @@ def iloc(df, cindexer=None):
     return df.iloc[:, cindexer]
 
 
-
 def try_loc(df, iindexer, cindexer=None):
     """
     .loc for unknown divisions

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -28,6 +28,9 @@ def loc(df, iindexer, cindexer=None):
         return df.loc[iindexer, cindexer]
 
 
+def iloc(df, cindexer=None):
+    return df.iloc[:, cindexer]
+
 def try_loc(df, iindexer, cindexer=None):
     """
     .loc for unknown divisions

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -31,6 +31,8 @@ def loc(df, iindexer, cindexer=None):
 def iloc(df, cindexer=None):
     return df.iloc[:, cindexer]
 
+
+
 def try_loc(df, iindexer, cindexer=None):
     """
     .loc for unknown divisions

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -414,9 +414,8 @@ def test_iloc(indexer):
 def test_iloc_series():
     s = pd.Series([1, 2, 3])
     ds = dd.from_pandas(s, 2)
-
-    result = ds.iloc[:]
-    assert_eq(result, s)
+    with pytest.raises(AttributeError):
+        ds.iloc[:]
 
 
 def test_iloc_raises():

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -392,3 +392,45 @@ def test_to_series():
     ddf = dd.from_pandas(df, 10)
 
     assert_eq(df.index.to_series(), ddf.index.to_series())
+
+
+@pytest.mark.parametrize('indexer', [
+    0,
+    [0],
+    [0, 1],
+    [1, 0],
+    [False, True, True]
+])
+def test_iloc(indexer):
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
+    ddf = dd.from_pandas(df, 2)
+
+    result = ddf.iloc[:, indexer]
+    expected = df.iloc[:, indexer]
+
+    assert_eq(result, expected)
+
+
+def test_iloc_series():
+    s = pd.Series([1, 2, 3])
+    ds = dd.from_pandas(s, 2)
+
+    result = ds.iloc[:]
+    assert_eq(result, s)
+
+
+def test_iloc_raises():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
+    ddf = dd.from_pandas(df, 2)
+
+    with pytest.raises(ValueError):
+        ddf.iloc[[0, 1], :]
+
+    with pytest.raises(ValueError):
+        ddf.iloc[[0, 1], [0, 1]]
+
+    with pytest.raises(ValueError):
+        ddf.iloc[[0, 1], [0, 1], [1, 2]]
+        
+    with pytest.raises(IndexError):
+        ddf.iloc[:, [5, 6]]

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -428,9 +428,8 @@ def test_iloc_raises():
 
     with pytest.raises(ValueError):
         ddf.iloc[[0, 1], [0, 1]]
-
-    with pytest.raises(ValueError):
+with pytest.raises(ValueError):
         ddf.iloc[[0, 1], [0, 1], [1, 2]]
-        
+
     with pytest.raises(IndexError):
         ddf.iloc[:, [5, 6]]

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -428,7 +428,8 @@ def test_iloc_raises():
 
     with pytest.raises(ValueError):
         ddf.iloc[[0, 1], [0, 1]]
-with pytest.raises(ValueError):
+
+    with pytest.raises(ValueError):
         ddf.iloc[[0, 1], [0, 1], [1, 2]]
 
     with pytest.raises(IndexError):

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -35,6 +35,7 @@ Dataframe
     DataFrame.get_partition
     DataFrame.groupby
     DataFrame.head
+    DataFrame.iloc
     DataFrame.index
     DataFrame.isna
     DataFrame.isnull

--- a/docs/source/dataframe-design.rst
+++ b/docs/source/dataframe-design.rst
@@ -1,3 +1,5 @@
+.. _dataframe.design:
+
 Internal Design
 ===============
 

--- a/docs/source/dataframe-indexing.rst
+++ b/docs/source/dataframe-indexing.rst
@@ -1,0 +1,129 @@
+.. _dataframe.indexing:
+
+Indexing into Dask DataFrames
+=============================
+
+Dask DataFrame supports some of pandas' indexing behavior.
+
+.. currentmodule:: dask.dataframe
+
+.. autosummary::
+
+   DataFrame.iloc
+   DataFrame.loc
+
+Label-based Indexing
+--------------------
+
+Just like pandas, Dask DataFrame supports label-based indexing with the ``.loc``
+accessor for selecting rows or columns, and ``__getitem__`` (square brackets)
+for selecting just columns.
+
+.. note::
+
+   To select rows, the DataFrame's divisions must be known (see
+   :ref:`dataframe.design` and :ref:`dataframe.performance`) for more.
+
+.. code-block:: python
+
+   >>> import dask.dataframe as dd
+   >>> import pandas as pd
+   >>> df = pd.DataFrame({"A": [1, 2, 3], "B": [3, 4, 5]},
+   ...                   index=['a', 'b', 'c'])
+   >>> ddf = dd.from_pandas(df, npartitions=2)
+   >>> ddf
+   Dask DataFrame Structure:
+                      A      B
+   npartitions=1
+   a              int64  int64
+   c                ...    ...
+   Dask Name: from_pandas, 1 tasks
+
+Selecting columns:
+
+.. code-block:: python
+
+   >>> ddf[['B', 'A']]
+   Dask DataFrame Structure:
+                      B      A
+   npartitions=1
+   a              int64  int64
+   c                ...    ...
+   Dask Name: getitem, 2 tasks
+
+
+Selecting a single column reduces to a Dask Series:
+
+.. code-block:: python
+
+   >>> ddf['A']
+   Dask Series Structure:
+   npartitions=1
+   a    int64
+   c      ...
+   Name: A, dtype: int64
+   Dask Name: getitem, 2 tasks
+
+Slicing rows and (optionally) columns with ``.loc``:
+
+.. code-block:: python
+
+   >>> ddf.loc[['b', 'c'], ['A']]
+   Dask DataFrame Structure:
+                      A
+   npartitions=1
+   b              int64
+   c                ...
+   Dask Name: loc, 2 tasks
+
+Dask DataFrame supports pandas' `partial-string indexing <https://pandas.pydata.org/pandas-docs/stable/timeseries.html#partial-string-indexing>`_:
+
+.. code-block:: python
+
+   >>> ts = dd.demo.make_timeseries()
+   >>> ts
+   Dask DataFrame Structure:
+                      id    name        x        y
+   npartitions=11
+   2000-01-31      int64  object  float64  float64
+   2000-02-29        ...     ...      ...      ...
+   ...               ...     ...      ...      ...
+   2000-11-30        ...     ...      ...      ...
+   2000-12-31        ...     ...      ...      ...
+   Dask Name: make-timeseries, 11 tasks
+
+   >>> ts.loc['2000-02-12']
+   Dask DataFrame Structure:
+                                     id    name        x        y
+   npartitions=1
+   2000-02-12 00:00:00.000000000  int64  object  float64  float64
+   2000-02-12 23:59:59.999999999    ...     ...      ...      ...
+   Dask Name: loc, 12 tasks
+
+
+Positional Indexing
+-------------------
+
+Dask DataFrame does not track the length of partitions, making positional
+indexing with ``.iloc`` inefficient for selecting rows. :meth:`DataFrame.iloc`
+only supports indexers where the row indexer is ``slice(None)`` (which ``:`` is
+a shorthand for.)
+
+.. code-block:: python
+
+   >>> ddf.iloc[:, [1, 0]]
+   Dask DataFrame Structure:
+                      B      A
+   npartitions=1
+   a              int64  int64
+   c                ...    ...
+   Dask Name: iloc, 2 tasks
+
+Trying to select specific rows with ``iloc`` will raise an exception:
+
+.. code-block:: python
+
+   >>> ddf.iloc[[0, 2], [1]]
+   Traceback (most recent call last)
+     File "<stdin>", line 1, in <module>
+   ValueError: 'DataFrame.iloc' does not support slicing rows. The indexer must be a 2-tuple whose first item is 'slice(None)'.

--- a/docs/source/dataframe-performance.rst
+++ b/docs/source/dataframe-performance.rst
@@ -1,3 +1,5 @@
+.. _dataframe.performance:
+
 Dask DataFrame Performance Tips
 ===============================
 

--- a/docs/source/dataframe.rst
+++ b/docs/source/dataframe.rst
@@ -10,6 +10,7 @@ Dataframe
    dataframe-performance.rst
    dataframe-design.rst
    dataframe-groupby.rst
+   dataframe-indexing.rst
 
 A Dask DataFrame is a large parallel dataframe composed of many smaller Pandas
 dataframes, split along the index.  These pandas dataframes may live on disk


### PR DESCRIPTION
Implements Series/DataFrame.iloc with the requirement that the row-indexer must be `:`.

Also adds a new docs section on indexing.

Alternative to https://github.com/dask/dask/pull/507.