### PR TITLE
Ensure result computing dask.array.isnull() always gives a numpy array

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1038,10 +1038,16 @@ def around(x, decimals=0):
     return map_blocks(partial(np.around, decimals=decimals), x, dtype=x.dtype)
 
 
+def _asarray_isnull(values):
+    import pandas as pd
+    return np.asarray(pd.isnull(values))
+
+
 def isnull(values):
     """ pandas.isnull for dask arrays """
-    import pandas as pd
-    return elemwise(pd.isnull, values, dtype='bool')
+    # eagerly raise ImportError, if pandas isn't available
+    import pandas as pd  # noqa
+    return elemwise(_asarray_isnull, values, dtype='bool')
 
 
 def notnull(values):

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -935,6 +935,14 @@ def test_isnull():
         assert_eq(da.notnull(a), ~np.isnan(x))
 
 
+def test_isnull_result_is_an_array():
+    # regression test for https://github.com/dask/dask/issues/3822
+    arr = da.from_array(np.arange(3, dtype=np.int64), chunks=-1)
+    with ignoring(ImportError):
+        result = da.isnull(arr[0]).compute()
+        assert type(result) is np.ndarray
+
+
 def test_isclose():
     x = np.array([0, np.nan, 1, 1.5])
     y = np.array([1e-9, np.nan, 1, 2])


### PR DESCRIPTION
pandas.isnull() will return Python booleans when given Python scalars as inputs,
which can break things in strange ways, e.g., as manifested in #3822.

I still don't know exactly what went wrong there, but this fixes it.

- [x] Tests added / passed
- [ ] Passes `flake8 dask`
