### PR TITLE
When reading multiple paths, expand globs.

### DIFF
--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -279,6 +279,9 @@ def expand_paths_if_needed(paths, mode, num, fs, name_function):
     :return: list of paths
     """
     expanded_paths = []
+    paths = list(paths)
+    if 'w' in mode and sum([1 for p in paths if '*' in p]) > 1:
+        raise ValueError("When writing data, only one filename mask can be specified.")
     for curr_path in paths:
         if '*' in curr_path:
             if 'w' in mode:

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -267,12 +267,12 @@ def expand_paths_if_needed(paths, mode, num, fs, name_function):
     """Expand paths if they have a ``*`` in them.
 
     :param paths: list of paths
-    mode : str, optional
+    mode : str
         Mode in which to open files.
-    num : int, optional
+    num : int
         If opening in writing mode, number of files we expect to create.
     fs : filesystem object
-    name_function : callable, optional
+    name_function : callable
         If opening in writing mode, this callable is used to generate path
         names. Names are generated for each partition by
         ``urlpath.replace('*', name_function(partition_index))``.

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -294,9 +294,16 @@ def get_fs_token_paths(urlpath, mode='rb', num=1, name_function=None,
             raise ValueError("When specifying a list of paths, all paths must "
                              "share the same protocol and options")
         update_storage_options(options, storage_options)
-        paths = list(paths)
-
         fs, fs_token = get_fs(protocol, options)
+        expanded_paths = []
+        for curr_path in paths:
+            if 'w' in mode:
+                expanded_paths.extend(_expand_paths(curr_path, name_function, num))
+            elif '*' in curr_path:
+                expanded_paths.extend(fs.glob(curr_path))
+            else:
+                expanded_paths.append(curr_path)
+        paths = sorted(expanded_paths)
 
     elif isinstance(urlpath, (str, unicode)) or hasattr(urlpath, 'name'):
         urlpath, protocol, options = infer_options(urlpath)

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -29,6 +29,12 @@ files = {'.test.accounts.1.json': (b'{"amount": 100, "name": "Alice"}\n'
                                    b'{"amount": 800, "name": "Dennis"}\n')}
 
 
+csv_files = {'.test.fakedata.1.csv': (b'a,b\n'
+                                      b'1,2\n'),
+             '.test.fakedata.2.csv': (b'a,b\n'
+                                      b'3,4\n')}
+
+
 try:
     # used only in test_with_urls - may be more generally useful
     import pathlib
@@ -84,6 +90,16 @@ def test_urlpath_inference_errors():
     with pytest.raises(TypeError):
         get_fs_token_paths({'sets/are.csv', 'unordered/so/they.csv',
                             'should/not/be.csv' 'allowed.csv'})
+
+
+def test_urlpath_can_expand():
+    """Make sure * is expanded in file paths."""
+    with filetexts(csv_files, mode='b'):
+        _, _, paths = get_fs_token_paths('.*.csv')
+        assert len(paths) == 2
+
+        _, _, paths = get_fs_token_paths(['.*.csv'])
+        assert len(paths) == 2
 
 
 def test_read_bytes():

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -108,8 +108,9 @@ def test_urlpath_expand_write():
     assert paths == ['prefix-0.csv', 'prefix-1.csv']
     _, _, paths = get_fs_token_paths(['prefix-*.csv'], mode='wb', num=2)
     assert paths == ['prefix-0.csv', 'prefix-1.csv']
-    _, _, paths = get_fs_token_paths(['prefix1-*.csv', 'prefix2-*.csv'], mode='wb', num=2)
-    assert paths == ['prefix1-0.csv', 'prefix1-1.csv']
+    # we can read with multiple masks, but not write
+    with pytest.raises(ValueError):
+        _, _, paths = get_fs_token_paths(['prefix1-*.csv', 'prefix2-*.csv'], mode='wb', num=2)
 
 
 def test_read_bytes():

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -92,14 +92,24 @@ def test_urlpath_inference_errors():
                             'should/not/be.csv' 'allowed.csv'})
 
 
-def test_urlpath_can_expand():
-    """Make sure * is expanded in file paths."""
+def test_urlpath_expand_read():
+    """Make sure * is expanded in file paths when reading."""
+    # when reading, globs should be expanded to read files by mask
     with filetexts(csv_files, mode='b'):
         _, _, paths = get_fs_token_paths('.*.csv')
         assert len(paths) == 2
-
         _, _, paths = get_fs_token_paths(['.*.csv'])
         assert len(paths) == 2
+
+
+def test_urlpath_expand_write():
+    """Make sure * is expanded in file paths when writing."""
+    _, _, paths = get_fs_token_paths('prefix-*.csv', mode='wb', num=2)
+    assert paths == ['prefix-0.csv', 'prefix-1.csv']
+    _, _, paths = get_fs_token_paths(['prefix-*.csv'], mode='wb', num=2)
+    assert paths == ['prefix-0.csv', 'prefix-1.csv']
+    _, _, paths = get_fs_token_paths(['prefix1-*.csv', 'prefix2-*.csv'], mode='wb', num=2)
+    assert paths == ['prefix1-0.csv', 'prefix1-1.csv']
 
 
 def test_read_bytes():


### PR DESCRIPTION
I had an exception when reading `csv` and providing a list of glob masks. It looks like globs are expanded when one path is provided, but not when a list of paths is provided:

```
In [3]: df = dd.read_csv(base_path + '*.csv')

In [4]: df = dd.read_csv([base_path + '*.csv'])
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-4-ea5547b4df7e> in <module>()
----> 1 df = dd.read_csv([base_path + '*.csv'])

~/.pyenv/versions/3.6.5/envs/shareupd/lib/python3.6/site-packages/dask/dataframe/io/csv.py in read(urlpath, blocksize, collection, lineterminator, compression, sample, enforce, assume_missing, storage_options, **kwargs)
    424                            enforce=enforce, assume_missing=assume_missing,
    425                            storage_options=storage_options,
--> 426                            **kwargs)
    427     read.__doc__ = READ_DOC_TEMPLATE.format(reader=reader_name,
    428                                             file_type=file_type)

~/.pyenv/versions/3.6.5/envs/shareupd/lib/python3.6/site-packages/dask/dataframe/io/csv.py in read_pandas(reader, urlpath, blocksize, collection, lineterminator, compression, sample, enforce, assume_missing, storage_options, **kwargs)
    300                                   sample=sample,
    301                                   compression=compression,
--> 302                                   **(storage_options or {}))
    303
    304     if not isinstance(values[0], (tuple, list)):

~/.pyenv/versions/3.6.5/envs/shareupd/lib/python3.6/site-packages/dask/bytes/core.py in read_bytes(urlpath, delimiter, not_zero, blocksize, sample, compression, **kwargs)
     87         for path in paths:
     88             try:
---> 89                 size = logical_size(fs, path, compression)
     90             except ValueError:
     91                 raise ValueError("Cannot do chunked reads on files compressed "

~/.pyenv/versions/3.6.5/envs/shareupd/lib/python3.6/site-packages/dask/bytes/core.py in logical_size(fs, path, compression)
    509
    510     if compression is None:
--> 511         return fs.size(path)
    512     elif compression in seekable_files:
    513         with OpenFile(fs, path, compression=compression) as f:

~/.pyenv/versions/3.6.5/envs/shareupd/lib/python3.6/site-packages/dask/bytes/local.py in size(self, path)
     65     def size(self, path):
     66         """Size in bytes of the file at path"""
---> 67         return os.stat(self._normalize_path(path)).st_size
     68
     69     def _get_pyarrow_filesystem(self):

FileNotFoundError: [Errno 2] No such file or directory: '/Users/irina/repos/data/shares_updater/csv/2018-07-02/apikey=foo.com/*.csv'
```

This fixes the problem.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
