### PR TITLE
Added index column name after resample (issue #3827)

### DIFF
--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -38,7 +38,8 @@ def _resample_series(series, start, end, reindex_closed, rule,
                      resample_kwargs, how, fill_value, how_args, how_kwargs):
     out = getattr(series.resample(rule, **resample_kwargs), how)(*how_args, **how_kwargs)
     return out.reindex(pd.date_range(start, end, freq=rule,
-                                     closed=reindex_closed),
+                                     closed=reindex_closed,
+                                     name=out.index.name),
                        fill_value=fill_value)
 
 

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -77,3 +77,19 @@ def test_unknown_divisions_error():
         assert False
     except ValueError as e:
         assert 'divisions' in str(e)
+
+
+def test_resample_index_name():
+    import numpy as np
+    from datetime import datetime, timedelta
+
+    date_today = datetime.now()
+    days = pd.date_range(date_today, date_today + timedelta(20), freq='D')
+    data = np.random.randint(1, high=100, size=len(days))
+
+    df = pd.DataFrame({'date': days, 'values': data})
+    df = df.set_index('date')
+
+    ddf = dd.from_pandas(df, npartitions=4)
+
+    assert ddf.resample('D').mean().head().index.name == "date"


### PR DESCRIPTION
This fixes #3827 
Fixes #3660 

I added the test mentioned in the issue in dask/dataframe/tseries/tests/test_resample.py

- [x] Tests added / passed
- [x] Passes `flake8 dask`
