### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,16 +34,6 @@ jobs:
       - *no_imports
 
     - env:
-      - PYTHON=3.4
-      - NUMPY=1.11.3
-      - PANDAS=0.19.1
-      - *test_and_lint
-      - *no_coverage
-      - *optimize
-      - *no_imports
-      if: type != pull_request
-
-    - env:
       - PYTHON=3.5
       - NUMPY=1.11.1
       - PANDAS=0.19.2

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -19,6 +19,7 @@ from toolz.curried import identity
 import dask
 import dask.array as da
 from dask.base import tokenize, compute_as_if_collection
+from dask.compatibility import PY2
 from dask.delayed import Delayed, delayed
 from dask.utils import ignoring, tmpfile, tmpdir, key_split
 from dask.utils_test import inc, dec
@@ -2052,7 +2053,7 @@ def test_from_array_ndarray_getitem():
 
 @pytest.mark.parametrize(
     'x', [[1, 2], (1, 2), memoryview(b'abc')] +
-    ([buffer(b'abc')] if sys.version_info[0] == 2 else []))  # noqa: F821
+    ([buffer(b'abc')] if PY2 else []))  # noqa: F821
 def test_from_array_list(x):
     """Lists, tuples, and memoryviews are automatically converted to ndarray
     """
@@ -2069,7 +2070,7 @@ def test_from_array_list(x):
 
 @pytest.mark.parametrize(
     'type_', [t for t in np.ScalarType if t not in [memoryview] +
-              ([buffer] if sys.version_info[0] == 2 else [])])  # noqa: F821
+              ([buffer] if PY2 else [])])  # noqa: F821
 def test_from_array_scalar(type_):
     """Python and numpy scalars are automatically converted to ndarray
     """

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -3,7 +3,6 @@ from __future__ import division, print_function, absolute_import
 import itertools
 from numbers import Number
 import textwrap
-import sys
 
 import pytest
 from distutils.version import LooseVersion
@@ -11,6 +10,7 @@ from distutils.version import LooseVersion
 np = pytest.importorskip('numpy')
 
 import dask.array as da
+from dask.compatibility import PY2
 from dask.utils import ignoring
 from dask.array.utils import assert_eq, same_keys
 from dask.array.einsumfuncs import einsum_can_optimize
@@ -265,7 +265,7 @@ def test_tensordot():
                      da.tensordot(a, b, axes=(1, 0)))
 
     # Increasing number of chunks warning
-    with pytest.warns(None if sys.version_info[0] == 2 else da.PerformanceWarning):
+    with pytest.warns(None if PY2 else da.PerformanceWarning):
         assert not same_keys(da.tensordot(a, b, axes=0),
                              da.tensordot(a, b, axes=1))
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -5,7 +5,6 @@ import pytest
 import math
 import os
 import random
-import sys
 from collections import Iterator
 from itertools import repeat
 
@@ -843,7 +842,6 @@ def test_to_textfiles_name_function_preserves_order():
         assert seq == out
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3,3), reason="Python3.3 uses pytest2.7.2, w/o warns method")
 def test_to_textfiles_name_function_warn():
     seq = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p']
     a = db.from_sequence(seq, npartitions=16)

--- a/dask/bytes/compression.py
+++ b/dask/bytes/compression.py
@@ -1,12 +1,11 @@
 from __future__ import print_function, division, absolute_import
 
 import bz2
-import sys
 import zlib
 
 from toolz import identity
 
-from ..compatibility import gzip_compress, gzip_decompress, GzipFile
+from ..compatibility import gzip_compress, gzip_decompress, GzipFile, PY2
 from ..utils import ignoring
 
 
@@ -61,7 +60,7 @@ with ignoring(ImportError):
 #     seekable_files['xz'] = lzmaffi.LZMAFile
 
 
-if sys.version_info[0] >= 3:
+if not PY2:
     import bz2
     files['bz2'] = bz2.BZ2File
 

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -17,6 +17,7 @@ class LZMAFile:
 LZMA_AVAILABLE = False
 
 if PY3:
+    import copyreg
     import builtins
     from queue import Queue, Empty
     from itertools import zip_longest
@@ -70,6 +71,7 @@ if PY3:
 
 else:
     import __builtin__ as builtins
+    import copy_reg as copyreg
     from Queue import Queue, Empty
     from itertools import izip_longest as zip_longest, izip as zip
     from StringIO import StringIO

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 
-import sys
 import os
 import dask
 import pytest
@@ -358,8 +357,6 @@ def test_to_hdf_kwargs():
         tm.assert_frame_equal(df, df2)
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 3),
-                    reason="Python3.3 uses pytest2.7.2, w/o warns method")
 def test_to_fmt_warns():
     pytest.importorskip('tables')
     df16 = pd.DataFrame({'x': ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,4 +1,3 @@
-import sys
 import textwrap
 from distutils.version import LooseVersion
 from itertools import product
@@ -13,6 +12,7 @@ import dask
 import dask.array as da
 import dask.dataframe as dd
 from dask.base import compute_as_if_collection
+from dask.compatibility import PY2
 from dask.utils import put_lines, M
 
 from dask.dataframe.core import repartition_divisions, aca, _concat, Scalar
@@ -92,8 +92,6 @@ def test_head_npartitions():
         d.head(2, npartitions=5)
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 3),
-                    reason="Python3.3 uses pytest2.7.2, w/o warns method")
 def test_head_npartitions_warn():
     with pytest.warns(None):
         d.head(100)
@@ -1969,7 +1967,7 @@ def test_apply():
         ddf.apply(lambda xy: xy, axis='index')
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 0),
+@pytest.mark.skipif(PY2,
                     reason="Global filter is applied by another library, and "
                            "not reset properly.")
 def test_apply_warns():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -19,6 +19,7 @@ except ImportError:
     # pandas < 0.19.2
     from pandas.core.common import is_datetime64tz_dtype
 
+from ..compatibility import PY2
 from ..core import get_deps
 from ..local import get_sync
 from ..utils import asciitable, is_arraylike
@@ -661,7 +662,7 @@ def assert_sane_keynames(ddf):
         assert isinstance(k, (str, bytes))
         assert len(k) < 100
         assert ' ' not in k
-        if sys.version_info[0] >= 3:
+        if not PY2:
             assert k.split('-')[0].isidentifier()
 
 

--- a/dask/hashing.py
+++ b/dask/hashing.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import binascii
 import hashlib
-import sys
+
+from .compatibility import PY2
 
 
 hashers = []  # In decreasing performance order
@@ -28,7 +29,7 @@ else:
             Produce a 16-bytes hash of *buf* using CityHash.
             """
             h = cityhash.CityHash128(buf)
-            if sys.version_info >= (3,):
+            if not PY2:
                 return h.to_bytes(16, 'little')
             else:
                 return binascii.a2b_hex('%032x' % h)
@@ -99,4 +100,4 @@ def hash_buffer_hex(buf, hasher=None):
     """
     h = hash_buffer(buf, hasher)
     s = binascii.b2a_hex(h)
-    return s.decode() if sys.version_info >= (3,) else s
+    return s.decode() if not PY2 else s

--- a/dask/local.py
+++ b/dask/local.py
@@ -107,9 +107,8 @@ See the function ``inline_functions`` for more information.
 from __future__ import absolute_import, division, print_function
 
 import os
-import sys
 
-from .compatibility import Queue, Empty, reraise
+from .compatibility import Queue, Empty, reraise, PY2
 from .core import (istask, flatten, reverse_dict, get_dependencies, ishashable,
                    has_tasks)
 from . import config
@@ -119,7 +118,7 @@ from .optimization import cull
 from .utils_test import add, inc  # noqa: F401
 
 
-if sys.version_info.major < 3:
+if PY2:
     # Due to a bug in python 2.7 Queue.get, if a timeout isn't specified then
     # `Queue.get` can't be interrupted. A workaround is to specify an extremely
     # long timeout, which then allows it to be interrupted.

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -5,17 +5,12 @@ import traceback
 import pickle
 import sys
 
-from . import config
-from .local import get_async  # TODO: get better get
-from .optimization import fuse, cull
-
 import cloudpickle
 
-
-if sys.version_info.major < 3:
-    import copy_reg as copyreg
-else:
-    import copyreg
+from . import config
+from .compatibility import copyreg
+from .local import get_async  # TODO: get better get
+from .optimization import fuse, cull
 
 
 def _reduce_method_descriptor(m):

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -18,7 +18,7 @@ from dask.base import (compute, tokenize, normalize_token, normalize_function,
 from dask.delayed import Delayed
 from dask.utils import tmpdir, tmpfile, ignoring
 from dask.utils_test import inc, dec
-from dask.compatibility import long, unicode
+from dask.compatibility import long, unicode, PY2
 
 
 def import_or_none(path):
@@ -118,7 +118,7 @@ def test_tokenize_numpy_array_on_object_dtype():
             tokenize(np.array(['a', None, 'aaa'], dtype=object)))
     assert (tokenize(np.array([(1, 'a'), (1, None), (1, 'aaa')], dtype=object)) ==
             tokenize(np.array([(1, 'a'), (1, None), (1, 'aaa')], dtype=object)))
-    if sys.version_info[0] == 2:
+    if PY2:
         assert (tokenize(np.array([unicode("Rebeca Alón", encoding="utf-8")], dtype=object)) ==
                 tokenize(np.array([unicode("Rebeca Alón", encoding="utf-8")], dtype=object)))
 


### PR DESCRIPTION
Removes support for Python 3.4.

- Drop 3.4 from travis ci
- Remove branches in our code for no longer supported python versions
- Cleans up handling of python versions throughout the code to rely on `dask.compatibility.PY2`/`dask.compatibility.PY3` throughout. This makes it easier to grep for these branches in the future instead of the various `sys.version_info` things.

Fixes #3797.
Fixes #2626.