### PR TITLE
dask.array: Allow shape to be a numpy array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2116,6 +2116,8 @@ def normalize_chunks(chunks, shape=None, limit=None, dtype=None,
         chunks = (chunks,) * len(shape)
     if isinstance(chunks, dict):
         chunks = tuple(chunks.get(i, None) for i in range(len(shape)))
+    if isinstance(chunks, np.ndarray):
+        chunks = chunks.tolist()
     if not chunks and shape and all(s == 0 for s in shape):
         chunks = ((0,),) * len(shape)
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -57,7 +57,8 @@ def empty_like(a, dtype=None, chunks=None):
 
     a = asarray(a)
     return empty(
-        a.shape, dtype=(dtype or a.dtype), chunks=(chunks or a.chunks)
+        a.shape, dtype=(dtype or a.dtype),
+        chunks=(chunks if chunks is not None else a.chunks)
     )
 
 
@@ -92,7 +93,8 @@ def ones_like(a, dtype=None, chunks=None):
 
     a = asarray(a)
     return ones(
-        a.shape, dtype=(dtype or a.dtype), chunks=(chunks or a.chunks)
+        a.shape, dtype=(dtype or a.dtype),
+        chunks=(chunks if chunks is not None else a.chunks)
     )
 
 
@@ -127,7 +129,8 @@ def zeros_like(a, dtype=None, chunks=None):
 
     a = asarray(a)
     return zeros(
-        a.shape, dtype=(dtype or a.dtype), chunks=(chunks or a.chunks)
+        a.shape, dtype=(dtype or a.dtype),
+        chunks=(chunks if chunks is not None else a.chunks)
     )
 
 
@@ -169,7 +172,7 @@ def full_like(a, fill_value, dtype=None, chunks=None):
         a.shape,
         fill_value,
         dtype=(dtype or a.dtype),
-        chunks=(chunks or a.chunks)
+        chunks=(chunks if chunks is not None else a.chunks)
     )
 
 

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -18,6 +18,7 @@ from dask.array.utils import assert_eq, same_keys
     ]
 )
 @pytest.mark.parametrize("cast_shape", [tuple, list, np.asarray])
+@pytest.mark.parametrize("cast_chunks", [tuple, list, np.asarray])
 @pytest.mark.parametrize(
     "shape, chunks", [
         ((10, 10), (4, 4))
@@ -28,10 +29,11 @@ from dask.array.utils import assert_eq, same_keys
         "i4",
     ]
 )
-def test_arr_like(funcname, shape, cast_shape, dtype, chunks):
+def test_arr_like(funcname, shape, cast_shape, dtype, cast_chunks, chunks):
     np_func = getattr(np, funcname)
     da_func = getattr(da, funcname)
     shape = cast_shape(shape)
+    chunks = cast_chunks(chunks)
 
     if "full" in funcname:
         old_np_func = np_func

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -11,15 +11,16 @@ from dask.array.utils import assert_eq, same_keys
 
 @pytest.mark.parametrize(
     "funcname", [
-        "empty_like",
-        "ones_like",
-        "zeros_like",
-        "full_like",
+        "empty_like", "empty",
+        "ones_like", "ones",
+        "zeros_like", "zeros",
+        "full_like", "full",
     ]
 )
+@pytest.mark.parametrize("cast_shape", [tuple, list, np.asarray])
 @pytest.mark.parametrize(
     "shape, chunks", [
-        ((10, 10), (4, 4)),
+        ((10, 10), (4, 4))
     ]
 )
 @pytest.mark.parametrize(
@@ -27,11 +28,12 @@ from dask.array.utils import assert_eq, same_keys
         "i4",
     ]
 )
-def test_arr_like(funcname, shape, dtype, chunks):
+def test_arr_like(funcname, shape, cast_shape, dtype, chunks):
     np_func = getattr(np, funcname)
     da_func = getattr(da, funcname)
+    shape = cast_shape(shape)
 
-    if funcname == "full_like":
+    if "full" in funcname:
         old_np_func = np_func
         old_da_func = da_func
 
@@ -40,15 +42,19 @@ def test_arr_like(funcname, shape, dtype, chunks):
 
     dtype = np.dtype(dtype)
 
-    a = np.random.randint(0, 10, shape).astype(dtype)
+    if "like" in funcname:
+        a = np.random.randint(0, 10, shape).astype(dtype)
 
-    np_r = np_func(a)
-    da_r = da_func(a, chunks=chunks)
+        np_r = np_func(a)
+        da_r = da_func(a, chunks=chunks)
+    else:
+        np_r = np_func(shape, dtype=dtype)
+        da_r = da_func(shape, dtype=dtype, chunks=chunks)
 
     assert np_r.shape == da_r.shape
     assert np_r.dtype == da_r.dtype
 
-    if funcname != "empty_like":
+    if "empty" not in funcname:
         assert (np_r == np.asarray(da_r)).all()
 
 

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -24,6 +24,9 @@ def wrap_func_shape_as_first_arg(func, *args, **kwargs):
     else:
         shape = kwargs.pop('shape')
 
+    if isinstance(shape, np.ndarray):
+        shape = shape.tolist()
+
     if not isinstance(shape, (tuple, list)):
         shape = (shape,)
 


### PR DESCRIPTION
Fixes #3710

~~Still needs tests. Where should put them? I feel like I can parameterize an existing test, but I couldn't find the appropriate one.~~

- [x] Tests added / passed
- [x] Passes `flake8 dask`
