### PR TITLE
Don't cull in local scheduler, do cull in delayed

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -16,6 +16,7 @@ from .base import tokenize as _tokenize
 from .compatibility import apply
 from .core import quote
 from .context import globalmethod
+from .optimization import cull
 from .utils import funcname, methodcaller, OperatorMethodMixin
 from . import sharedict
 
@@ -339,6 +340,11 @@ def right(method):
     return _inner
 
 
+def optimize(dsk, keys, **kwargs):
+    dsk2, _ = cull(dsk, keys)
+    return dsk2
+
+
 def rebuild(dsk, key, length):
     return Delayed(key, dsk, length)
 
@@ -367,7 +373,7 @@ class Delayed(DaskMethodsMixin, OperatorMethodMixin):
         return self.key
 
     __dask_scheduler__ = staticmethod(threaded.get)
-    __dask_optimize__ = globalmethod(dont_optimize, key='delayed_optimize')
+    __dask_optimize__ = globalmethod(optimize, key='delayed_optimize')
 
     def __dask_postcompute__(self):
         return single_key, ()

--- a/dask/local.py
+++ b/dask/local.py
@@ -115,7 +115,6 @@ from .core import (istask, flatten, reverse_dict, get_dependencies, ishashable,
 from . import config
 from .order import order
 from .callbacks import unpack_callbacks, local_callbacks
-from .optimization import cull
 from .utils_test import add, inc  # noqa: F401
 
 
@@ -453,8 +452,6 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
                 if cb[0]:
                     cb[0](dsk)
                 started_cbs.append(cb)
-
-            dsk, dependencies = cull(dsk, list(results))
 
             keyorder = order(dsk)
 

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -164,6 +164,15 @@ def test_common_subexpressions():
     assert len(res.dask) == 3
 
 
+def test_delayed_optimize():
+    x = Delayed('b', {'a': 1,
+                      'b': (inc, 'a'),
+                      'c': (inc, 'b')})
+    (x2,) = dask.optimize(x)
+    # Delayed's __dask_optimize__ culls out 'c'
+    assert sorted(x2.dask.keys()) == ['a', 'b']
+
+
 def test_lists():
     a = delayed(1)
     b = delayed(2)


### PR DESCRIPTION
- Removes culling from the local scheduler. This was (usually)
unnecessary, as all the collections (except delayed) culled by default.
- Adds culling to ``dask.delayed``

Fixes #3735.
