### PR TITLE
Increase conda download retries

### DIFF
--- a/continuous_integration/hdfs/install.sh
+++ b/continuous_integration/hdfs/install.sh
@@ -1,2 +1,6 @@
+set -xe
+
 docker exec -it $CONTAINER_ID conda install -y -q dask hdfs3 pyarrow -c twosigma -c conda-forge
 docker exec -it $CONTAINER_ID pip install -e .
+
+set +xe

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -14,7 +14,7 @@ esac
 wget https://repo.continuum.io/miniconda/$MINICONDA_FILENAME -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
-conda config --set always_yes yes --set changeps1 no
+conda config --set always_yes yes --set changeps1 no --set remote_max_retries 10
 
 # Create conda environment
 conda create -q -n test-environment python=$PYTHON

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -1,3 +1,5 @@
+set -xe
+
 #!/usr/bin/env bash
 # Install conda
 case "$(uname -s)" in
@@ -113,3 +115,5 @@ fi;
 pip install --no-deps -e .[complete]
 echo conda list
 conda list
+
+set +xe


### PR DESCRIPTION
We've been seeing an increase in conda download failures on travis lately.

- https://travis-ci.org/dask/dask/jobs/412727337
- https://travis-ci.org/dask/dask/jobs/412754348
- https://travis-ci.org/dask/dask/jobs/412815896

After talking to the conda team, it was suggested to try increasing the value of `remote_max_retries` to 10 to see if that helps (they're not 100% sure why this would be happening).
