### PR TITLE
Fix failing hdfs test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ jobs:
 
     - env:
       - TEST_HDFS='true'
-      if: type != pull_request OR head_branch =~ __TEST_HDFS__  # Skip on PRS unless the branch contains __TEST_HDFS__
+      if: type != pull_request OR commit_message =~ test-hdfs  # Skip on PRS unless the commit message contains "test-hdfs"
       sudo: true
       services:
         - docker

--- a/continuous_integration/hdfs/README.md
+++ b/continuous_integration/hdfs/README.md
@@ -4,14 +4,10 @@ Dask & HDFS testing relies on a docker container. The tests are setup to run on
 Travis CI, but only under the following conditions:
 
 - Merges to master
-- PRs where the branch name contains the string `"__TEST_HDFS__"`
+- PRs where the commit message contains the string `"test-hdfs"`
 
 If you make a PR changing HDFS functionality it'd be good to have the HDFS
-tests run, please add `"__TEST_HDFS__"` to the end of your branch name.
-
-If you've already made a PR (and thus can't change the branch name), you can
-temporarily comment out the `if:` configuration in the `.travis.yml` for the
-HDFS tests.
+tests run, please add `"test-hdfs"` to your commit message.
 
 ## Setting up HDFS testing locally using Docker
 

--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -238,9 +238,6 @@ def test_pyarrow_compat():
     assert isinstance(pa_hdfs, pyarrow.filesystem.FileSystem)
 
 
-@pytest.mark.skip(
-    reason='hdfs3 fails. See https://github.com/dask/dask/issues/3345.'
-)
 @require_pyarrow
 def test_parquet_pyarrow(hdfs):
     dd = pytest.importorskip('dask.dataframe')


### PR DESCRIPTION
- Remove skip for `test_parquet_pyarrow`, as this tests now passes
- Update to use new travis ci conditionals for optionally testing hdfs functionality. When this was originally added you could only conditionally run on branch name - now you can conditionally run on commit message string (which is nicer and easier to use). New behavior is documented in the hdfs CI readme.

Fixes #3345 
Supersedes #3483