### PR TITLE
Fixes for pyarrow 0.10.0 release

### DIFF
--- a/dask/dataframe/io/orc.py
+++ b/dask/dataframe/io/orc.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
+from distutils.version import LooseVersion
+
+from .utils import _get_pyarrow_dtypes, _meta_from_dtypes
 from ..core import DataFrame
 from ...base import tokenize
 from ...bytes.core import get_fs_token_paths
 from ...utils import import_required
-from .utils import _get_pyarrow_dtypes, _meta_from_dtypes
 
 __all__ = ('read_orc',)
 
@@ -40,6 +42,16 @@ def read_orc(path, columns=None, storage_options=None):
     ...                  'master/examples/demo-11-zlib.orc')  # doctest: +SKIP
     """
     orc = import_required('pyarrow.orc', 'Please install pyarrow >= 0.9.0')
+    import pyarrow as pa
+
+    if LooseVersion(pa.__version__) == '0.10.0':
+        raise RuntimeError("Due to a bug in pyarrow 0.10.0, the ORC reader is "
+                           "unavailable. Please either downgrade pyarrow to "
+                           "0.9.0, or use pyarrow the master branch (in which "
+                           "this issue is fixed).\n\n"
+                           "For more information see: "
+                           "https://issues.apache.org/jira/browse/ARROW-3009")
+
     storage_options = storage_options or {}
     fs, fs_token, paths = get_fs_token_paths(path, mode='rb',
                                              storage_options=storage_options)

--- a/dask/dataframe/io/orc.py
+++ b/dask/dataframe/io/orc.py
@@ -47,7 +47,7 @@ def read_orc(path, columns=None, storage_options=None):
     if LooseVersion(pa.__version__) == '0.10.0':
         raise RuntimeError("Due to a bug in pyarrow 0.10.0, the ORC reader is "
                            "unavailable. Please either downgrade pyarrow to "
-                           "0.9.0, or use pyarrow the master branch (in which "
+                           "0.9.0, or use the pyarrow master branch (in which "
                            "this issue is fixed).\n\n"
                            "For more information see: "
                            "https://issues.apache.org/jira/browse/ARROW-3009")

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -1,13 +1,24 @@
 import os
-import pytest
 import shutil
 import tempfile
+from distutils.version import LooseVersion
+
+import pytest
 
 from dask.dataframe import read_orc
 from dask.dataframe.utils import assert_eq
 import dask.dataframe as dd
 
 pytest.importorskip('pyarrow.orc')
+
+# Skip for broken ORC reader
+import pyarrow as pa
+pytestmark = pytest.mark.skipif(
+    LooseVersion(pa.__version__) == '0.10.0',
+    reason=("PyArrow 0.10.0 release broke the ORC reader, see "
+            "https://issues.apache.org/jira/browse/ARROW-3009"))
+
+
 url = ('https://www.googleapis.com/download/storage/v1/b/anaconda-public-data/o'
        '/orc%2FTestOrcFile.testDate1900.orc?generation=1522611448751555&alt='
        'media')


### PR DESCRIPTION
- Error nicely if pyarrow version has broken ORC reader
- Skip ORC tests for bad pyarrow versions
- Use `is_timestamp` instead of `TimestampType`
- Remove support for pyarrow versions < 0.8.0 (which are missing `is_timestamp`, and are rather old anyway.