### PR TITLE
Re-add the ghost import to da __init__

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -58,6 +58,10 @@ try:
                            triu, tril, fromfunction, tile, repeat, pad)
     from .gufunc import apply_gufunc, gufunc, as_gufunc
     from .utils import assert_eq
+
+    # TODO: remove this after the deprecation cycle of ghost is complete
+    from . import ghost
+
 except ImportError as e:
     msg = ("Dask array requirements are not installed.\n\n"
            "Please either conda or pip install as follows:\n\n"


### PR DESCRIPTION
Needed for libraries that implicitly assumed `da.ghost` namespace was
automatically imported.

See #3830.