### PR TITLE
[WIP] Fix collections.abc deprecation warnings in Python 3.7.0

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -1,14 +1,13 @@
 """ A set of NumPy functions to apply per chunk """
 from __future__ import absolute_import, division, print_function
 
-from collections import Container, Iterable, Sequence
 from functools import wraps
 
 from toolz import concat
 import numpy as np
 from . import numpy_compat as npcompat
 
-from ..compatibility import getargspec
+from ..compatibility import getargspec, Container, Iterable, Sequence
 from ..core import flatten
 from ..utils import ignoring
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from bisect import bisect
-from collections import Iterator
 from functools import partial, wraps
 from itertools import product
 import math
@@ -40,7 +39,7 @@ from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      SerializableLock, ensure_dict, Dispatch, factors,
                      parse_bytes, has_keyword)
 from ..compatibility import (unicode, long, zip_longest, apply,
-                             Iterable, Mapping)
+                             Iterable, Iterator, Mapping)
 from ..core import quote
 from ..delayed import Delayed, to_task_dask
 from .. import threaded, core

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from bisect import bisect
-from collections import Iterable, Mapping
 from collections import Iterator
 from functools import partial, wraps
 from itertools import product
@@ -40,7 +39,8 @@ from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      is_integer, IndexCallable, funcname, derived_from,
                      SerializableLock, ensure_dict, Dispatch, factors,
                      parse_bytes, has_keyword)
-from ..compatibility import unicode, long, zip_longest, apply
+from ..compatibility import (unicode, long, zip_longest, apply,
+                             Iterable, Mapping)
 from ..core import quote
 from ..delayed import Delayed, to_task_dask
 from .. import threaded, core

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Sequence
 from functools import partial, wraps
 from itertools import product
 from operator import add
@@ -11,6 +10,7 @@ from toolz import accumulate, sliding_window
 
 from .. import sharedict
 from ..base import tokenize
+from ..compatibility import Sequence
 from ..utils import ignoring
 from . import chunk
 from .core import (Array, asarray, normalize_chunks,

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-import collections
+from ..compatibility import Sequence
 from functools import wraps
 import inspect
 
@@ -257,7 +257,7 @@ def rfftfreq(n, d=1.0, chunks=None):
 def _fftshift_helper(x, axes=None, inverse=False):
     if axes is None:
         axes = list(range(x.ndim))
-    elif not isinstance(axes, collections.Sequence):
+    elif not isinstance(axes, Sequence):
         axes = (axes,)
 
     y = x

--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from functools import wraps
-from collections import Iterator
 from numbers import Number
 
 import numpy as np
@@ -10,6 +9,7 @@ from toolz import merge, merge_sorted
 from .core import Array
 from ..base import tokenize
 from .. import sharedict
+from ..compatibility import Iterator
 
 
 @wraps(np.percentile)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -3,7 +3,6 @@ from __future__ import division, print_function, absolute_import
 import inspect
 import math
 import warnings
-from collections import Iterable
 from distutils.version import LooseVersion
 from functools import wraps, partial
 from numbers import Number, Real, Integral
@@ -12,6 +11,7 @@ import numpy as np
 from toolz import concat, merge, sliding_window, interleave
 
 from .. import sharedict
+from ..compatibility import Iterable
 from ..core import flatten
 from ..base import tokenize
 from ..utils import funcname

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -5,7 +5,7 @@ import itertools
 import math
 import uuid
 import warnings
-from collections import Iterable, Iterator, defaultdict
+from collections import defaultdict
 from distutils.version import LooseVersion
 from functools import wraps, partial
 from operator import getitem
@@ -30,7 +30,7 @@ except ImportError:
 from .. import config
 from ..base import tokenize, dont_optimize, is_dask_collection, DaskMethodsMixin
 from ..bytes import open_files
-from ..compatibility import apply, urlopen
+from ..compatibility import apply, urlopen, Iterable, Iterator
 from ..context import globalmethod
 from ..core import quote, istask, get_dependencies, reverse_dict
 from ..delayed import Delayed

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -5,7 +5,6 @@ import pytest
 import math
 import os
 import random
-from collections import Iterator
 from itertools import repeat
 
 import partd
@@ -17,7 +16,7 @@ from dask.bag.core import (Bag, lazify, lazify_task, map, collect,
                            reduceby, reify, partition, inline_singleton_lists,
                            optimize, from_delayed)
 from dask.bag.utils import assert_eq
-from dask.compatibility import BZ2File, GzipFile, PY2
+from dask.compatibility import BZ2File, GzipFile, PY2, Iterator
 from dask.delayed import Delayed
 from dask.utils import filetexts, tmpfile, tmpdir
 from dask.utils_test import inc, add

--- a/dask/base.py
+++ b/dask/base.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import OrderedDict, Iterator
+from collections import OrderedDict
 from functools import partial
 from hashlib import md5
 from operator import getitem
@@ -14,7 +14,7 @@ import warnings
 from toolz import merge, groupby, curry, identity
 from toolz.functoolz import Compose
 
-from .compatibility import long, unicode
+from .compatibility import long, unicode, Iterator
 from .context import thread_state
 from .core import flatten, quote, get as simple_get
 from .hashing import hash_buffer_hex

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -16,6 +16,48 @@ class LZMAFile:
                             "To use, install lzmaffi or backports.lzma.")
 LZMA_AVAILABLE = False
 
+
+# From 3.8, Collections Abstract Base Classes will be visible only
+# from collections.abc.
+try:
+    from collections.abc import (
+        Container,
+        Hashable,
+        Iterable,
+        Iterator,
+        Sized,
+        Callable,
+        Sequence,
+        MutableSequence,
+        Set,
+        MutableSet,
+        Mapping,
+        MutableMapping,
+        MappingView,
+        ItemsView,
+        KeysView,
+        ValuesView,
+    )
+except ImportError:
+    from collections import (
+        Container,
+        Hashable,
+        Iterable,
+        Iterator,
+        Sized,
+        Callable,
+        Sequence,
+        MutableSequence,
+        Set,
+        MutableSet,
+        Mapping,
+        MutableMapping,
+        MappingView,
+        ItemsView,
+        KeysView,
+        ValuesView,
+    )
+
 if PY3:
     import copyreg
     import builtins

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterator
 from functools import wraps, partial
 import operator
 from operator import getitem
@@ -22,7 +21,7 @@ from .. import core
 
 from ..utils import partial_by_order
 from .. import threaded
-from ..compatibility import apply, operator_div, bind_method, string_types
+from ..compatibility import apply, operator_div, bind_method, string_types, Iterator
 from ..context import globalmethod
 from ..utils import (random_state_data, pseudorandom, derived_from, funcname,
                      memory_repr, put_lines, M, key_split, OperatorMethodMixin,

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 from io import BytesIO
 from warnings import warn, catch_warnings, simplefilter
-import collections
 
 try:
     import psutil
@@ -19,7 +18,7 @@ except ImportError:
 
 from ...bytes import read_bytes, open_files
 from ...bytes.compression import seekable_files, files as cfiles
-from ...compatibility import PY2, PY3
+from ...compatibility import PY2, PY3, Mapping
 from ...delayed import delayed
 from ...utils import asciitable
 
@@ -197,7 +196,7 @@ def text_blocks_to_pandas(reader, block_lists, header, head, kwargs,
     unknown_categoricals = categoricals
 
     if _HAS_CDT:
-        if isinstance(specified_dtypes, collections.Mapping):
+        if isinstance(specified_dtypes, Mapping):
             known_categoricals = [
                 k for k in categoricals
                 if isinstance(specified_dtypes.get(k), CategoricalDtype) and

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -4,7 +4,6 @@ import re
 import textwrap
 from distutils.version import LooseVersion
 
-from collections import Iterator
 import sys
 import traceback
 from contextlib import contextmanager
@@ -19,7 +18,7 @@ except ImportError:
     # pandas < 0.19.2
     from pandas.core.common import is_datetime64tz_dtype
 
-from ..compatibility import PY2
+from ..compatibility import PY2, Iterator
 from ..core import get_deps
 from ..local import get_sync
 from ..utils import asciitable, is_arraylike

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterator
 import operator
 import types
 import uuid
@@ -13,7 +12,7 @@ except ImportError:
 from . import config, threaded
 from .base import is_dask_collection, dont_optimize, DaskMethodsMixin
 from .base import tokenize as _tokenize
-from .compatibility import apply
+from .compatibility import apply, Iterator
 from .core import quote
 from .context import globalmethod
 from .optimization import cull

--- a/dask/sharedict.py
+++ b/dask/sharedict.py
@@ -1,5 +1,6 @@
 from toolz import concat, unique, count
-from collections import Mapping
+
+from .compatibility import Mapping
 
 
 class ShareDict(Mapping):

--- a/dask/store/core.py
+++ b/dask/store/core.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import defaultdict, MutableMapping
+from collections import defaultdict
 from operator import getitem
 from datetime import datetime
 from time import time
 
+from ..compatibility import MutableMapping
 from ..core import istask, ishashable
 from ..utils_test import add  # noqa: F401
 

--- a/dask/tests/test_sharedict.py
+++ b/dask/tests/test_sharedict.py
@@ -1,8 +1,7 @@
-from collections import Mapping
-
 import pytest
 from toolz import merge
 
+from dask.compatibility import Mapping
 from dask.sharedict import ShareDict
 
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -8,7 +8,6 @@ import sys
 import tempfile
 import re
 from errno import ENOENT
-from collections import Iterator
 from contextlib import contextmanager
 from importlib import import_module
 from numbers import Integral
@@ -18,7 +17,8 @@ import uuid
 import warnings
 from weakref import WeakValueDictionary
 
-from .compatibility import get_named_args, getargspec, PY3, unicode, bind_method
+from .compatibility import (get_named_args, getargspec, PY3, unicode,
+                            bind_method, Iterator)
 from .core import get_deps
 from .optimization import key_split    # noqa: F401
 

--- a/docs/source/scripts/scheduling.py
+++ b/docs/source/scripts/scheduling.py
@@ -2,8 +2,8 @@ from toolz import merge
 from time import time
 import dask
 from dask import threaded, multiprocessing, local
+from dask.compatibility import Iterator
 from random import randint
-from collections import Iterator
 import matplotlib.pyplot as plt
 
 


### PR DESCRIPTION
Since Python 3.3, the abstract base classes for collections
were extracted into the collections.abc submodule.

This fixes #3875 by adding the deprecated imports into the compatibility.py
This should remove any eventual deprecation warnings related to collections.abc
and prepare at least this part of Dask for the future versions of Python.

See also:
https://docs.python.org/3.7/library/collections.html

- [x] Tests passed (no extra tests added)
- [x] Passes `flake8 dask`
