### PR TITLE
MAINT: Re-factor dask.array.core.normalize_chunks to be exposed by da…

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -5,7 +5,8 @@ try:
     from .core import (Array, block, concatenate, stack, from_array, store,
                        map_blocks, atop, to_hdf5, to_npy_stack, from_npy_stack,
                        from_delayed, asarray, asanyarray, PerformanceWarning,
-                       broadcast_arrays, broadcast_to, from_zarr, to_zarr)
+                       broadcast_arrays, broadcast_to, from_zarr, to_zarr,
+                       normalize_chunks)
     from .routines import (take, choose, argwhere, where, coarsen, insert,
                            ravel, roll, unique, squeeze, ptp, diff, ediff1d,
                            gradient, bincount, digitize, histogram, cov, array,


### PR DESCRIPTION
Small tweak to expose `dask.array.core.normalize_chunks()` at the level of `dask.array`. This is based on feedback from pydata/xarray#2255.

I didn't yet re-factor any internal package imports; those are still all importing from `dask.array.core`, but happy to do so if someone can help point out where appropriate.

- [ ] Tests added / passed
- [x] Passes `flake8 dask`