### PR TITLE
Fixing returning type in categorical.as_known 

### DIFF
--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -184,7 +184,7 @@ class CategoricalAccessor(Accessor):
             Keywords to pass on to the call to `compute`.
         """
         if self.known:
-            return self
+            return self._series
         categories = self._property_map('categories').unique().compute(**kwargs)
         return self.set_categories(categories.values)
 

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -271,7 +271,6 @@ def assert_array_index_eq(left, right):
     assert_eq(left, pd.Index(right) if isinstance(right, np.ndarray) else right)
 
 def test_return_type_known_categories():
-        #need to understand properly and do the test.
         df = pd.DataFrame({"A":['a','b','c']})
         df['A'] = df['A'].astype('category')
         dask_df = dd.from_pandas(df,2)

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -270,13 +270,14 @@ def assert_array_index_eq(left, right):
     """left and right are equal, treating index and array as equivalent"""
     assert_eq(left, pd.Index(right) if isinstance(right, np.ndarray) else right)
 
+
 def test_return_type_known_categories():
-        df = pd.DataFrame({"A":['a','b','c']})
-        df['A'] = df['A'].astype('category')
-        dask_df = dd.from_pandas(df,2)
-        ret_type = dask_df.A.cat.as_known()
-        assert isinstance(ret_type, dd.core.Series)
-        
+    df = pd.DataFrame({"A": ['a', 'b', 'c']})
+    df['A'] = df['A'].astype('category')
+    dask_df = dd.from_pandas(df, 2)
+    ret_type = dask_df.A.cat.as_known()
+    assert isinstance(ret_type, dd.core.Series)
+
 
 class TestCategoricalAccessor:
 

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -270,6 +270,14 @@ def assert_array_index_eq(left, right):
     """left and right are equal, treating index and array as equivalent"""
     assert_eq(left, pd.Index(right) if isinstance(right, np.ndarray) else right)
 
+def test_return_type_known_categories():
+        #need to understand properly and do the test.
+        df = pd.DataFrame({"A":['a','b','c']})
+        df['A'] = df['A'].astype('category')
+        dask_df = dd.from_pandas(df,2)
+        ret_type = dask_df.A.cat.as_known()
+        assert isinstance(ret_type, dd.core.Series)
+        
 
 class TestCategoricalAccessor:
 


### PR DESCRIPTION
Executed: `py.test dask/dataframe --verbose`

2733 passed, 299 skipped, 9 xfailed, 773 warnings in 352.25 second

Fixing the issue #3784.