### PR TITLE
Include filename in read_csv

### DIFF
--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -52,9 +52,7 @@ def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
         used as sample size, otherwise the default sample size is 10kB.
     include_path : bool
         Whether or not to include the path with the bytes representing a particular file.
-        If True ``blocks`` is a tuple where the first item is a list of paths and the second
-        is a list of lists of ``dask.Delayed`` where each delayed object computes to a
-        block of bytes from that file.
+        Default is False.
     **kwargs : dict
         Extra options that make sense to a particular storage connection, e.g.
         host, port, username, password, etc.
@@ -63,7 +61,7 @@ def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
     --------
     >>> sample, blocks = read_bytes('2015-*-*.csv', delimiter=b'\\n')  # doctest: +SKIP
     >>> sample, blocks = read_bytes('s3://bucket/2015-*-*.csv', delimiter=b'\\n')  # doctest: +SKIP
-    >>> sample, (paths, blocks) = read_bytes('2015-*-*.csv', include_path=True)  # doctest: +SKIP
+    >>> sample, paths, blocks = read_bytes('2015-*-*.csv', include_path=True)  # doctest: +SKIP
 
     Returns
     -------
@@ -72,6 +70,10 @@ def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
     blocks : list of lists of ``dask.Delayed``
         Each list corresponds to a file, and each delayed object computes to a
         block of bytes from that file.
+    paths : list of strings, only included if include_path is True
+        List of same length as blocks, where each item is the path to the file
+        represented in the corresponding block.
+
     """
     fs, fs_token, paths = get_fs_token_paths(urlpath, mode='rb',
                                              storage_options=kwargs)
@@ -122,7 +124,7 @@ def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize=2**27,
             nbytes = 10000 if sample is True else sample
             sample = read_block(f, 0, nbytes, delimiter)
     if include_path:
-        return sample, (paths, out)
+        return sample, out, paths
     return sample, out
 
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -162,7 +162,7 @@ def test_read_bytes_blocksize_float():
 def test_read_bytes_include_path():
     with filetexts(files, mode='b'):
         sample, values = read_bytes('.test.accounts.*', include_path=True)
-        assert {path.split('/')[-1] for path, _ in values} == set(files.keys())
+        assert {os.path.split(path)[1] for path, _ in values} == set(files.keys())
 
 
 def test_with_urls():

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -161,7 +161,7 @@ def test_read_bytes_blocksize_float():
 
 def test_read_bytes_include_path():
     with filetexts(files, mode='b'):
-        sample, (paths, values) = read_bytes('.test.accounts.*', include_path=True)
+        _, _, paths = read_bytes('.test.accounts.*', include_path=True)
         assert {os.path.split(path)[1] for path in paths} == set(files.keys())
 
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -159,6 +159,12 @@ def test_read_bytes_blocksize_float():
             read_bytes('.test.account*', blocksize=5.5)
 
 
+def test_read_bytes_include_path():
+    with filetexts(files, mode='b'):
+        sample, values = read_bytes('.test.accounts.*', include_path=True)
+        assert {path.split('/')[-1] for path, _ in values} == set(files.keys())
+
+
 def test_with_urls():
     with filetexts(files, mode='b'):
         # OS-independent file:// URI with glob *

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -161,8 +161,8 @@ def test_read_bytes_blocksize_float():
 
 def test_read_bytes_include_path():
     with filetexts(files, mode='b'):
-        sample, values = read_bytes('.test.accounts.*', include_path=True)
-        assert {os.path.split(path)[1] for path, _ in values} == set(files.keys())
+        sample, (paths, values) = read_bytes('.test.accounts.*', include_path=True)
+        assert {os.path.split(path)[1] for path in paths} == set(files.keys())
 
 
 def test_with_urls():

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -51,7 +51,7 @@ def pandas_read_text(reader, b, header, kwargs, dtypes=None, columns=None,
         A dictionary of keyword arguments to be passed to ``reader``
     dtypes : dict
         DTypes to assign to columns
-    path: tuple
+    path : tuple
         A tuple containing path column name, path to file, and all paths.
 
     See Also

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -361,7 +361,7 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
 
     # Use sample to infer dtypes and check for presense of include_path_column
     head = reader(BytesIO(b_sample), **kwargs)
-    if include_path_column in head.columns:
+    if include_path_column and (include_path_column in head.columns):
         raise KeyError("Files already contain the column name: %s, so the "
                        "path column cannot use this name. Please set "
                        "`include_path_column` to a unique name."

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -187,7 +187,7 @@ def text_blocks_to_pandas(reader, block_lists, header, head, kwargs,
     kwargs : dict
         Keyword arguments to pass down to ``reader``
     collection: boolean, optional (defaults to True)
-    path: tuple, optional
+    path : tuple, optional
         A tuple containing column name for path and list of all paths
 
     Returns
@@ -322,19 +322,20 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
                                   compression)
 
     b_lineterminator = lineterminator.encode()
-    b_sample, values = read_bytes(urlpath, delimiter=b_lineterminator,
-                                  blocksize=blocksize,
-                                  sample=sample,
-                                  compression=compression,
-                                  include_path=include_path_column,
-                                  **(storage_options or {}))
+    b_out = read_bytes(urlpath, delimiter=b_lineterminator,
+                       blocksize=blocksize,
+                       sample=sample,
+                       compression=compression,
+                       include_path=include_path_column,
+                       **(storage_options or {}))
 
     if include_path_column:
-        paths, values = values
+        b_sample, values, paths = b_out
         if path_converter:
             paths = [path_converter(path) for path in paths]
         path = (include_path_column, paths)
     else:
+        b_sample, values = b_out
         path = None
 
     if not isinstance(values[0], (tuple, list)):
@@ -427,7 +428,7 @@ assume_missing : bool, optional
 storage_options : dict, optional
     Extra options that make sense for a particular storage connection, e.g.
     host, port, username, password, etc.
-include_path_column: bool or str, optional
+include_path_column : bool or str, optional
     Whether or not to include the path to each particular file. If True a new
     column is added to the dataframe called ``path``. If str, sets new column
     name. Default is False.

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -362,10 +362,10 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
     # Use sample to infer dtypes and check for presense of include_path_column
     head = reader(BytesIO(b_sample), **kwargs)
     if include_path_column and (include_path_column in head.columns):
-        raise KeyError("Files already contain the column name: %s, so the "
-                       "path column cannot use this name. Please set "
-                       "`include_path_column` to a unique name."
-                       % include_path_column)
+        raise ValueError("Files already contain the column name: %s, so the "
+                         "path column cannot use this name. Please set "
+                         "`include_path_column` to a unique name."
+                         % include_path_column)
 
     specified_dtypes = kwargs.get('dtype', {})
     if specified_dtypes is None:

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -345,8 +345,13 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
 
     header = b'' if header is None else parts[skiprows] + b_lineterminator
 
-    # Use sample to infer dtypes
+    # Use sample to infer dtypes and check for presense of include_path_col
     head = reader(BytesIO(b_sample), **kwargs)
+    if include_path_col in head.columns:
+        raise KeyError("Files already contain the column name: %s, so the "
+                       "path column cannot use this name. Please set "
+                       "`include_path_col` to a unique name."
+                       % include_path_col)
 
     specified_dtypes = kwargs.get('dtype', {})
     if specified_dtypes is None:

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -29,6 +29,10 @@ def normalize_text(s):
     return '\n'.join(map(str.strip, s.strip().split('\n')))
 
 
+def parse_filename(path):
+    return os.path.split(path)[1]
+
+
 csv_text = """
 name,amount
 Alice,100
@@ -289,9 +293,9 @@ def test_read_csv_files_list(dd_read, pd_read, files):
                           (dd.read_table, tsv_files)])
 def test_read_csv_include_path_col(dd_read, files):
     with filetexts(files, mode='b'):
-        df = dd_read('2014-01-*.csv', include_path_col=True)
-        filenames = df.path.map(lambda x: x.split('/')[-1]).compute()
-        set(filenames) == set(files.keys())
+        df = dd_read('2014-01-*.csv', include_path_col=True,
+                     converters={'path': parse_filename})
+        set(df.compute().path) == set(files.keys())
 
 
 @pytest.mark.parametrize('dd_read,files',
@@ -299,9 +303,9 @@ def test_read_csv_include_path_col(dd_read, files):
                           (dd.read_table, tsv_files)])
 def test_read_csv_include_path_col_as_str(dd_read, files):
     with filetexts(files, mode='b'):
-        df = dd_read('2014-01-*.csv', include_path_col='file_path')
-        filenames = df.file_path.map(lambda x: x.split('/')[-1]).compute()
-        set(filenames) == set(files.keys())
+        df = dd_read('2014-01-*.csv', include_path_col='filename',
+                     converters={'filename': parse_filename})
+        set(df.compute().filename) == set(files.keys())
 
 
 # After this point, we test just using read_csv, as all functionality

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -330,7 +330,7 @@ def test_read_csv_include_path_column_is_dtype_category(dd_read, files):
     with filetexts(files, mode='b'):
         df = dd_read('2014-01-*.csv', include_path_column=True)
         assert df.path.dtype == 'category'
-        assert not has_known_categories(df.path)
+        assert has_known_categories(df.path)
 
         dfs = dd_read('2014-01-*.csv', include_path_column=True, collection=False)
         result = dfs[0].compute()

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -319,7 +319,7 @@ def test_read_csv_include_path_column_as_str(dd_read, files):
                           (dd.read_table, tsv_files)])
 def test_read_csv_include_path_column_with_duplicate_name(dd_read, files):
     with filetexts(files, mode='b'):
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             dd_read('2014-01-*.csv', include_path_column='name')
 
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -284,6 +284,26 @@ def test_read_csv_files_list(dd_read, pd_read, files):
             dd_read([])
 
 
+@pytest.mark.parametrize('dd_read,files',
+                         [(dd.read_csv, csv_files),
+                          (dd.read_table, tsv_files)])
+def test_read_csv_include_path_col(dd_read, files):
+    with filetexts(files, mode='b'):
+        df = dd_read('2014-01-*.csv', include_path_col=True)
+        filenames = df.path.map(lambda x: x.split('/')[-1]).compute()
+        set(filenames) == set(files.keys())
+
+
+@pytest.mark.parametrize('dd_read,files',
+                         [(dd.read_csv, csv_files),
+                          (dd.read_table, tsv_files)])
+def test_read_csv_include_path_col_as_str(dd_read, files):
+    with filetexts(files, mode='b'):
+        df = dd_read('2014-01-*.csv', include_path_col='file_path')
+        filenames = df.file_path.map(lambda x: x.split('/')[-1]).compute()
+        set(filenames) == set(files.keys())
+
+
 # After this point, we test just using read_csv, as all functionality
 # for both is implemented using the same code.
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -308,6 +308,15 @@ def test_read_csv_include_path_col_as_str(dd_read, files):
         set(df.compute().filename) == set(files.keys())
 
 
+@pytest.mark.parametrize('dd_read,files',
+                         [(dd.read_csv, csv_files),
+                          (dd.read_table, tsv_files)])
+def test_read_csv_include_path_col_with_duplicate_name(dd_read, files):
+    with filetexts(files, mode='b'):
+        with pytest.raises(KeyError):
+            dd_read('2014-01-*.csv', include_path_col='name')
+
+
 # After this point, we test just using read_csv, as all functionality
 # for both is implemented using the same code.
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -291,9 +291,9 @@ def test_read_csv_files_list(dd_read, pd_read, files):
 @pytest.mark.parametrize('dd_read,files',
                          [(dd.read_csv, csv_files),
                           (dd.read_table, tsv_files)])
-def test_read_csv_include_path_col(dd_read, files):
+def test_read_csv_include_path_column(dd_read, files):
     with filetexts(files, mode='b'):
-        df = dd_read('2014-01-*.csv', include_path_col=True,
+        df = dd_read('2014-01-*.csv', include_path_column=True,
                      converters={'path': parse_filename})
         set(df.compute().path) == set(files.keys())
 
@@ -301,9 +301,9 @@ def test_read_csv_include_path_col(dd_read, files):
 @pytest.mark.parametrize('dd_read,files',
                          [(dd.read_csv, csv_files),
                           (dd.read_table, tsv_files)])
-def test_read_csv_include_path_col_as_str(dd_read, files):
+def test_read_csv_include_path_column_as_str(dd_read, files):
     with filetexts(files, mode='b'):
-        df = dd_read('2014-01-*.csv', include_path_col='filename',
+        df = dd_read('2014-01-*.csv', include_path_column='filename',
                      converters={'filename': parse_filename})
         set(df.compute().filename) == set(files.keys())
 
@@ -311,10 +311,10 @@ def test_read_csv_include_path_col_as_str(dd_read, files):
 @pytest.mark.parametrize('dd_read,files',
                          [(dd.read_csv, csv_files),
                           (dd.read_table, tsv_files)])
-def test_read_csv_include_path_col_with_duplicate_name(dd_read, files):
+def test_read_csv_include_path_column_with_duplicate_name(dd_read, files):
     with filetexts(files, mode='b'):
         with pytest.raises(KeyError):
-            dd_read('2014-01-*.csv', include_path_col='name')
+            dd_read('2014-01-*.csv', include_path_column='name')
 
 
 # After this point, we test just using read_csv, as all functionality


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [x] Closes #2802

Adding a kwarg `include_path_col` to `read_csv`:

```python
df = dd.read_csv('data*.csv', include_path_col=True)
```

This kwarg can be a bool or a string indicating the name of the column in the resulting dataframe

```python
df = dd.read_csv('data*.csv', include_path_col='name_of_path_col')
```

Example using data1.csv and data2.csv from docs: 

<img width="998" alt="screen shot 2018-08-27 at 4 48 30 pm" src="https://user-images.githubusercontent.com/4806877/44685264-12bbc500-aa19-11e8-9afb-5e01f14a0bb4.png">

In this PR I return the same paths that we pass to `pd.read_csv`. That seemed like the safest/easiest option, but I'm open to suggestions for other approaches. 
