### PR TITLE
Adding missing `

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -147,7 +147,7 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
         into ``nout`` objects, allowing for unpacking of results. By default
         iteration over ``Delayed`` objects will error. Note, that ``nout=1``
         expects ``obj``, to return a tuple of length 1, and consequently for
-        `nout=0``, ``obj`` should return an empty tuple.
+        ``nout=0``, ``obj`` should return an empty tuple.
     traverse : bool, optional
         By default dask traverses builtin python collections looking for dask
         objects passed to ``delayed``. For large collections this can be


### PR DESCRIPTION
I found this while reading the online docs which indeed incorrectly
render that word.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
