### PR TITLE
Linalg.norm ndim along axis partial fix

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -1081,15 +1081,15 @@ def lstsq(a, b):
 
 @wraps(np.linalg.norm)
 def norm(x, ord=None, axis=None, keepdims=False):
-    if x.ndim > 2:
-        raise ValueError("Improper number of dimensions to norm.")
-
     if axis is None:
         axis = tuple(range(x.ndim))
     elif isinstance(axis, Number):
         axis = (int(axis),)
     else:
         axis = tuple(axis)
+
+    if len(axis) > 2:
+        raise ValueError("Improper number of dimensions to norm.")
 
     if ord == "fro":
         ord = None
@@ -1111,26 +1111,34 @@ def norm(x, ord=None, axis=None, keepdims=False):
         if len(axis) == 1:
             r = r.max(axis=axis, keepdims=keepdims)
         else:
-            r = r.sum(axis=axis[1], keepdims=keepdims).max(keepdims=keepdims)
+            r = r.sum(axis=axis[1], keepdims=True).max(axis=axis[0], keepdims=True)
+            if keepdims is False:
+                r = r.squeeze(axis=axis)
     elif ord == -np.inf:
         r = abs(r)
         if len(axis) == 1:
             r = r.min(axis=axis, keepdims=keepdims)
         else:
-            r = r.sum(axis=axis[1], keepdims=keepdims).min(keepdims=keepdims)
+            r = r.sum(axis=axis[1], keepdims=True).min(axis=axis[0], keepdims=True)
+            if keepdims is False:
+                r = r.squeeze(axis=axis)
     elif ord == 0:
         if len(axis) == 2:
             raise ValueError("Invalid norm order for matrices.")
 
-        r = (r != 0).astype(r.dtype).sum(axis=0, keepdims=keepdims)
+        r = (r != 0).astype(r.dtype).sum(axis=axis, keepdims=keepdims)
     elif ord == 1:
         r = abs(r)
         if len(axis) == 1:
             r = r.sum(axis=axis, keepdims=keepdims)
         else:
-            r = r.sum(axis=axis[0], keepdims=keepdims).max(keepdims=keepdims)
+            r = r.sum(axis=axis[0], keepdims=True).max(axis=axis[1], keepdims=True)
+            if keepdims is False:
+                r = r.squeeze(axis=axis)
     elif len(axis) == 2 and ord == -1:
-        r = abs(r).sum(axis=axis[0], keepdims=keepdims).min(keepdims=keepdims)
+        r = abs(r).sum(axis=axis[0], keepdims=True).min(axis=axis[1], keepdims=True)
+        if keepdims is False:
+            r = r.squeeze(axis=axis)
     elif len(axis) == 2 and ord == 2:
         r = svd(x)[1][None].max(keepdims=keepdims)
     elif len(axis) == 2 and ord == -2:

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -111,7 +111,7 @@ def tsqr(data, compute_svd=False, _max_vchunk_size=None):
             "  2. Have only one column of blocks\n\n"
             "Note: This function (tsqr) supports QR decomposition in the case of\n"
             "tall-and-skinny matrices (single column chunk/block; see qr)"
-            "shape: {}, chunks: {}".format(data.shape, data.chunks)
+            "Current shape: {},\nCurrent chunksize: {}".format(data.shape, data.chunksize)
         )
 
     token = '-' + tokenize(data, compute_svd)

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -111,6 +111,7 @@ def tsqr(data, compute_svd=False, _max_vchunk_size=None):
             "  2. Have only one column of blocks\n\n"
             "Note: This function (tsqr) supports QR decomposition in the case of\n"
             "tall-and-skinny matrices (single column chunk/block; see qr)"
+            "shape: {}, chunks: {}".format(data.shape, data.chunks)
         )
 
     token = '-' + tokenize(data, compute_svd)
@@ -1104,6 +1105,8 @@ def norm(x, ord=None, axis=None, keepdims=False):
     elif ord == "nuc":
         if len(axis) == 1:
             raise ValueError("Invalid norm order for vectors.")
+        if x.ndim > 2:
+            raise NotImplementedError("SVD based norm not implemented for ndim > 2")
 
         r = svd(x)[1][None].sum(keepdims=keepdims)
     elif ord == np.inf:
@@ -1140,8 +1143,12 @@ def norm(x, ord=None, axis=None, keepdims=False):
         if keepdims is False:
             r = r.squeeze(axis=axis)
     elif len(axis) == 2 and ord == 2:
+        if x.ndim > 2:
+            raise NotImplementedError("SVD based norm not implemented for ndim > 2")
         r = svd(x)[1][None].max(keepdims=keepdims)
     elif len(axis) == 2 and ord == -2:
+        if x.ndim > 2:
+            raise NotImplementedError("SVD based norm not implemented for ndim > 2")
         r = svd(x)[1][None].min(keepdims=keepdims)
     else:
         if len(axis) == 2:

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -659,10 +659,6 @@ def test_no_chunks_svd():
     [(5,), (2,), 0],
     [(5,), (2,), (0,)],
     [(5, 6), (2, 2), None],
-    [(5, 6), (2, 2), 0],
-    [(5, 6), (2, 2), 1],
-    [(5, 6), (2, 2), (0, 1)],
-    [(5, 6), (2, 2), (1, 0)],
 ])
 @pytest.mark.parametrize("norm", [
     None,
@@ -683,6 +679,39 @@ def test_norm_any_ndim(shape, chunks, axis, norm, keepdims):
     d_r = da.linalg.norm(d, ord=norm, axis=axis, keepdims=keepdims)
 
     assert_eq(a_r, d_r)
+
+
+@pytest.mark.parametrize("shape, chunks", [
+    [(5,), (2,)],
+    [(5, 6), (2, 2)],
+    [(4, 5, 6), (2, 2, 2)],
+    [(4, 5, 6, 7), (2, 2, 2, 2)],
+    [(4, 5, 6, 7, 3), (2, 2, 2, 2, 2)],
+])
+@pytest.mark.parametrize("norm", [
+    None,
+    1,
+    -1,
+    np.inf,
+    -np.inf,
+])
+@pytest.mark.parametrize("keepdims", [
+    False,
+    True,
+])
+def test_norm_any_slice(shape, chunks, norm, keepdims):
+    a = np.random.random(shape)
+    d = da.from_array(a, chunks=chunks)
+
+    for firstaxis in range(len(shape)):
+        for secondaxis in range(len(shape)):
+            if firstaxis != secondaxis:
+                axis = (firstaxis, secondaxis)
+            else:
+                axis = firstaxis
+            a_r = np.linalg.norm(a, ord=norm, axis=axis, keepdims=keepdims)
+            d_r = da.linalg.norm(d, ord=norm, axis=axis, keepdims=keepdims)
+            assert_eq(a_r, d_r)
 
 
 @pytest.mark.parametrize("shape, chunks, axis", [
@@ -713,6 +742,8 @@ def test_norm_1dim(shape, chunks, axis, norm, keepdims):
     [(5, 6), (2, 2), None],
     [(5, 6), (2, 2), (0, 1)],
     [(5, 6), (2, 2), (1, 0)],
+    [(4, 5, 6, 7), (2, 2, 2, 2), (1,2)],
+    [(4, 5, 6, 7), (2, 2, 2, 2), (-1,-2)],
 ])
 @pytest.mark.parametrize("norm", [
     "fro",
@@ -730,7 +761,7 @@ def test_norm_2dim(shape, chunks, axis, norm, keepdims):
 
     # Need one chunk on last dimension for svd.
     if norm == "nuc" or norm == 2 or norm == -2:
-        d = d.rechunk((d.chunks[0], d.shape[1]))
+        d = d.rechunk({axis[-1]: -1})
 
     a_r = np.linalg.norm(a, ord=norm, axis=axis, keepdims=keepdims)
     d_r = da.linalg.norm(d, ord=norm, axis=axis, keepdims=keepdims)

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -683,10 +683,10 @@ def test_norm_any_ndim(shape, chunks, axis, norm, keepdims):
 
 @pytest.mark.parametrize("shape, chunks", [
     [(5,), (2,)],
-    [(5, 6), (2, 2)],
-    [(4, 5, 6), (2, 2, 2)],
-    [(4, 5, 6, 7), (2, 2, 2, 2)],
-    [(4, 5, 6, 7, 3), (2, 2, 2, 2, 2)],
+    [(5, 3), (2, 2)],
+    [(4, 5, 3), (2, 2, 2)],
+    [(4, 5, 2, 3), (2, 2, 2, 2)],
+    [(2, 5, 2, 4, 3), (2, 2, 2, 2, 2)],
 ])
 @pytest.mark.parametrize("norm", [
     None,
@@ -769,8 +769,8 @@ def test_norm_2dim(shape, chunks, axis, norm, keepdims):
 
 
 @pytest.mark.parametrize("shape, chunks, axis", [
-    [(4, 5, 6, 7), (2, 2, 2, 2), (1,2)],
-    [(4, 5, 6, 7), (2, 2, 2, 2), (-1,-2)],
+    [(3, 2, 4), (2, 2, 2), (1, 2)],
+    [(2, 3, 4, 5), (2, 2, 2, 2), (-1, -2)],
 ])
 @pytest.mark.parametrize("norm", [
     "nuc",

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -760,8 +760,7 @@ def test_norm_2dim(shape, chunks, axis, norm, keepdims):
 
     # Need one chunk on last dimension for svd.
     if norm == "nuc" or norm == 2 or norm == -2:
-        rechunkaxis = -1
-        d = d.rechunk({rechunkaxis: -1})
+        d = d.rechunk({-1: -1})
 
     a_r = np.linalg.norm(a, ord=norm, axis=axis, keepdims=keepdims)
     d_r = da.linalg.norm(d, ord=norm, axis=axis, keepdims=keepdims)

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -681,6 +681,7 @@ def test_norm_any_ndim(shape, chunks, axis, norm, keepdims):
     assert_eq(a_r, d_r)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("shape, chunks", [
     [(5,), (2,)],
     [(5, 3), (2, 2)],


### PR DESCRIPTION
This is a partial fix for #3895, working towards feature parity with numpy's `linalg.norm`. 
For the implementation of SVD based norms along arbitrary axis the `tsqr` algorithm could be extended, or some clever choice of rechunk/map_blocks should be made, both of which I feel not confident to be able to fix at this point in time, as such the code will throw `NotImplementedErrors` for now in these cases.

I feel however that the extension of functionality for arrays of vectors and arrays of matrices for non-SVD based norms makes it still worth it to merge. If we merge, I will create a new issue for the SVD based norms.

Feedback is welcome as always.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
