### PR TITLE
Fix NumPy issubtype deprecation warning

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -69,7 +69,7 @@ def sanitize_index(ind):
         return np.asanyarray(nonzero)
     elif np.issubdtype(index_array.dtype, np.integer):
         return index_array
-    elif np.issubdtype(index_array.dtype, float):
+    elif np.issubdtype(index_array.dtype, np.floating):
         int_index = index_array.astype(np.intp)
         if np.allclose(index_array, int_index):
             return int_index


### PR DESCRIPTION
Change issubdtype(..., float) to issubdtype(..., np.floating) as
recommended by the warning issued by numpy >= 1.14.

- [ ] Tests added / passed
- [X] Passes `flake8 dask`