### PR TITLE
Include partitions with no width in repartition

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4081,8 +4081,9 @@ def repartition_divisions(a, b, name, out1, out2, force=False):
         else:
             d[(out1, k)] = (methods.boundary_slice, (name, i - 1), low, b[j], False)
             low = b[j]
+            if len(a) == i + 1 or a[i] < a[i + 1]:
+                j += 1
             i += 1
-            j += 1
         c.append(low)
         k += 1
 
@@ -4116,7 +4117,7 @@ def repartition_divisions(a, b, name, out1, out2, force=False):
         while c[i] < b[j]:
             tmp.append((out1, i))
             i += 1
-        if last_elem and c[i] == b[-1] and (b[-1] != b[-2] or j == len(b) - 1) and i < k:
+        while last_elem and c[i] == b[-1] and (b[-1] != b[-2] or j == len(b) - 1) and i < k:
             # append if last split is not included
             tmp.append((out1, i))
             i += 1


### PR DESCRIPTION
Previously when repartitioning a dataframe that had partitions of zero
width like the following:

    >>> df.divisions
    (1, 1, 1)

We would lose information about the earlier partitions.

Fixes https://github.com/dask/dask/issues/3911

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
