### PR TITLE
Issue 3937

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -391,7 +391,7 @@ def _slice_1d(dim_shape, lengths, index):
             ind = index - chunk_boundaries[i - 1]
         else:
             ind = index
-        return {i: ind}
+        return {int(i): int(ind)}
 
     assert isinstance(index, slice)
 

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -273,3 +273,15 @@ def test_turn_off_fusion():
 
     assert dask.get(a, y.__dask_keys__()) == dask.get(b, y.__dask_keys__())
     assert len(a) < len(b)
+
+def test_gh3937():
+    """ This will produce Integral type indices that are not ints (np.int64) """
+    data_size = 3322683
+    chunk_size = 2**20
+
+    old_data = da.from_array(np.random.random((data_size,)), (chunk_size,))
+    old_data = da.concatenate((old_data, [old_data[-1]]))
+
+    old_data = old_data.rechunk((chunk_size,))
+    old_data = da.coarsen(np.sum, old_data, {0: 2})
+    old_data.compute()

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -275,13 +275,11 @@ def test_turn_off_fusion():
     assert len(a) < len(b)
 
 def test_gh3937():
-    """ This will produce Integral type indices that are not ints (np.int64) """
-    data_size = 3322683
-    chunk_size = 2**20
-
-    old_data = da.from_array(np.random.random((data_size,)), (chunk_size,))
-    old_data = da.concatenate((old_data, [old_data[-1]]))
-
-    old_data = old_data.rechunk((chunk_size,))
-    old_data = da.coarsen(np.sum, old_data, {0: 2})
-    old_data.compute()
+    x = da.from_array([1, 2, 3.], (2,))
+    x = da.concatenate((x, [x[-1]]))
+    y = x.rechunk((2,))
+    # This will produce Integral type indices that are not ints (np.int64), failing
+    # the optimizer
+    y = da.coarsen(np.sum, y, {0: 2})
+    # How to trigger the optimizer explicitly?
+    y.compute()

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -274,7 +274,9 @@ def test_turn_off_fusion():
     assert dask.get(a, y.__dask_keys__()) == dask.get(b, y.__dask_keys__())
     assert len(a) < len(b)
 
+
 def test_gh3937():
+    # test for github issue #3937
     x = da.from_array([1, 2, 3.], (2,))
     x = da.concatenate((x, [x[-1]]))
     y = x.rechunk((2,))


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

This PR fixes #3937. It contains two patches:

1. Uses Integral for integral type checks in array/optimize.py
2. Ensure the use of numpy in array/slice.py is hidden by casting result to an int.

Either fixes the original issue.

The use of isinstance(x, int) may cause problems in other places if a Integral (e.g. numpy.int64) is somehow passed into dask internals. I recommend changing all of them to isinstance(x, Integral), but there may be other concerns (e.g. sticking to primitive python types and always cast them before going down to internals can be desirable).

Here is a list of them:

```
(base) [yfeng1@waterfall dask]$ grep isinstance `find dask -name '*.py'` |grep int
dask/array/tests/test_array_core.py:    assert isinstance(x.size, int)
dask/array/tests/test_array_core.py:    assert all(isinstance(s, int) for s in d.shape)
dask/array/tests/test_overlap.py:    assert isinstance(fs[1][1], int)
dask/array/tests/test_overlap.py:    assert all(isinstance(k[2], int) for k in a.dask)
dask/array/tests/test_overlap.py:    assert all(isinstance(k[1], int) for k in b.dask)
dask/array/chunk.py:    if isinstance(axes, int):
dask/array/core.py:                   for x in b if not isinstance(x, (int, long)))
dask/array/core.py:                elif isinstance(adjust_chunks[ind], int):
dask/array/core.py:    points = [p if isinstance(p, slice) else list(p) for p in points]
dask/array/creation.py:    if not isinstance(chunks, int):
dask/array/einsumfuncs.py:                elif isinstance(s, int):
dask/array/einsumfuncs.py:                elif isinstance(s, int):
dask/array/rechunk.py:            all(isinstance(x, int) or math.isnan(x)
dask/array/reductions.py:    if isinstance(axis, int):
dask/array/reductions.py:    elif isinstance(split_every, int):
dask/array/reductions.py:    if not isinstance(order, int) or order < 0:
dask/array/reductions.py:    elif isinstance(axis, int):
dask/array/reductions.py:    assert isinstance(axis, int)
dask/array/routines.py:    if isinstance(left_axes, int):
dask/array/routines.py:    if isinstance(right_axes, int):
dask/array/slicing.py:        n = sum(isinstance(ind, int) for ind in index[:x])
dask/bag/tests/test_bag.py:        y = repeat(y) if isinstance(y, int) else y
dask/dataframe/tests/test_csv.py:    assert isinstance(auto_blocksize(3000, 15), int)
dask/dataframe/tests/test_csv.py:    assert isinstance(blocksize, int)
dask/dataframe/tests/test_utils_dataframe.py:    assert isinstance(meta, np.int64)
dask/dataframe/io/tests/test_csv.py:    assert isinstance(auto_blocksize(3000, 15), int)
dask/dataframe/io/tests/test_csv.py:    assert isinstance(blocksize, int)
dask/dataframe/categorical.py:    elif not isinstance(split_every, int) or split_every < 2:
dask/dataframe/core.py:        if isinstance(window, int):
dask/dataframe/core.py:            if not isinstance(min_periods, int):
dask/dataframe/core.py:        if not isinstance(periods, int):
dask/dataframe/core.py:        if not isinstance(periods, int):
dask/dataframe/core.py:        if not isinstance(lag, int):
dask/dataframe/core.py:    elif split_every < 2 or not isinstance(split_every, int):
dask/dataframe/core.py:    elif split_every < 2 or not isinstance(split_every, int):
dask/dataframe/rolling.py:    if prev_part is not None and isinstance(before, int):
dask/dataframe/rolling.py:    if next_part is not None and isinstance(after, int):
dask/dataframe/rolling.py:        if not (isinstance(before, int) and before >= 0 and
dask/dataframe/rolling.py:                isinstance(after, int) and after >= 0):
dask/dataframe/rolling.py:    if before and isinstance(before, int):
dask/dataframe/rolling.py:    if after and isinstance(after, int):
dask/dataframe/rolling.py:                (isinstance(self.window, int) and self.window <= 1) or
dask/tests/test_sizeof.py:    assert isinstance(sizeof(df), int)
dask/tests/test_sizeof.py:    assert isinstance(sizeof(df.x), int)
dask/tests/test_sizeof.py:    assert isinstance(sizeof(df.index), int)
```