### PR TITLE
Trim no expand

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -184,15 +184,14 @@ def trim(x, axes=None, boundary=None, block_info=None):
             boundary = dict(zip(range(len(x.ndim)), boundary))
 
         trim_front = [
-            False if (chunk_location == 0 and bdy == 'none') else True
-            for bdy, chunk_location in zip(
-                boundary, block_info[0]['chunk-location'])]
-        trim_back = [
-            False if (chunk_location != chunks-1 and bdy == 'none') else True
-            for bdy, chunks, chunk_location in zip(
-                boundary,
-                block_info[0]['num-chunks'],
+            False if (chunk_location == 0 and boundary[i] == 'none') else True
+            for i, chunk_location in enumerate(
                 block_info[0]['chunk-location'])]
+        trim_back = [
+            False if (chunk_location == chunks-1 and boundary[i] == 'none') else True
+            for i, (chunks, chunk_location) in enumerate(zip(
+                block_info[0]['num-chunks'],
+                block_info[0]['chunk-location']))]
     else:
         trim_front = [True] * len(axes)
         trim_back = [True] * len(axes)

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -194,8 +194,8 @@ def trim(x, axes=None, boundary=None, block_info=None):
             for i, (chunk_location, t) in enumerate(
                 zip(block_info[0]['chunk-location'], trim_front)))
         trim_back = (
-            None if (chunk_location == chunks-1
-                  and boundary.get(i, 'none') == 'none') else t
+            None if (chunk_location == chunks-1 and
+                     boundary.get(i, 'none') == 'none') else t
             for i, (chunks, chunk_location, t) in enumerate(zip(
                 block_info[0]['num-chunks'],
                 block_info[0]['chunk-location'],

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -184,11 +184,11 @@ def trim(x, axes=None, boundary=None, block_info=None):
             boundary = dict(zip(range(len(x.ndim)), boundary))
 
         trim_front = [
-            False if (chunk_location == 0 and boundary[i] == 'none') else True
+            False if (chunk_location == 0 and boundary.get(i, 'none') == 'none') else True
             for i, chunk_location in enumerate(
                 block_info[0]['chunk-location'])]
         trim_back = [
-            False if (chunk_location == chunks-1 and boundary[i] == 'none') else True
+            False if (chunk_location == chunks-1 and boundary.get(i, 'none') == 'none') else True
             for i, (chunks, chunk_location) in enumerate(zip(
                 block_info[0]['num-chunks'],
                 block_info[0]['chunk-location']))]

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -175,7 +175,7 @@ def trim_internal(x, axes, boundary=None):
 
     olist = []
     for i, bd in enumerate(x.chunks):
-        bdy = boundary2[i] if i in boundary2.keys() else None
+        bdy = boundary2.get(i, None)
         ilist = []
         for j, d in enumerate(bd):
             if bdy != 'none':

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -175,7 +175,7 @@ def trim_internal(x, axes, boundary=None):
 
     olist = []
     for i, bd in enumerate(x.chunks):
-        bdy = boundary2.get(i, None)
+        bdy = boundary2.get(i, 'none')
         ilist = []
         for j, d in enumerate(bd):
             if bdy != 'none':

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -175,13 +175,18 @@ def trim_internal(x, axes, boundary=None):
 
     olist = []
     for i, bd in enumerate(x.chunks):
+        bdy = boundary2[i] if i in boundary2.keys() else None
         ilist = []
-        for d in bd:
-            ilist.append(d - axes.get(i, 0) * 2)
+        for j, d in enumerate(bd):
+            if bdy != 'none':
+                d = d - axes.get(i, 0) * 2
+            else:
+                d = d - axes.get(i, 0) if j != 0 else d
+                d = d - axes.get(i, 0) if j != len(bd) - 1 else d
+            ilist.append(d)
         olist.append(tuple(ilist))
 
     chunks = tuple(olist)
-
     return map_blocks(partial(chunk.trim, axes=axes, boundary=boundary2),
                       x, chunks=chunks, dtype=x.dtype)
 

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -11,9 +11,6 @@ from dask.array.overlap import (fractional_slice, getitem, trim_internal,
 from dask.array.utils import assert_eq, same_keys
 
 
-parametrize = pytest.mark.parametrize
-
-
 def test_fractional_slice():
     assert (fractional_slice(('x', 4.9), {0: 2}) ==
             (getitem, ('x', 5), (slice(0, 2), )))
@@ -420,19 +417,22 @@ def test_overlap_few_dimensions():
     assert len(c.dask) < 10 * len(a.dask)
 
 
-@parametrize('boundary', ['reflect', 'periodic', 'nearest', 'none'])
-def test_trim_boundry_is_dict(boundary):
-    a = da.from_array(np.arange(24).reshape(4, 6), chunks=(2, 3))
-    a_overlaped = da.overlap.overlap(a, 2,
+@pytest.mark.parametrize('boundary',
+                         ['reflect', 'periodic', 'nearest', 'none'])
+def test_trim_boundry(boundary):
+    x = da.from_array(np.arange(24).reshape(4, 6), chunks=(2, 3))
+    x_overlaped = da.overlap.overlap(x, 2,
                                      boundary={0: 'reflect', 1: boundary})
-    a_trimmed = da.overlap.trim(a_overlaped, 2,
+    x_trimmed = da.overlap.trim(x_overlaped, 2,
                                 boundary={0: 'reflect', 1: boundary})
-    assert np.all(a == a_trimmed)
+    assert np.all(x == x_trimmed)
 
+    x_overlaped = da.overlap.overlap(x, 2,
+                                     boundary={1: boundary})
+    x_trimmed = da.overlap.trim(x_overlaped, 2,
+                                boundary={1: boundary})
+    assert np.all(x == x_trimmed)
 
-@parametrize('boundary', ['reflect', 'periodic', 'nearest', 'none'])
-def test_trim_boundry_is_string(boundary):
-    a = da.from_array(np.arange(24).reshape(4, 6), chunks=(2, 3))
-    a_overlaped = da.overlap.overlap(a, 2, boundary=boundary)
-    a_trimmed = da.overlap.trim(a_overlaped, 2, boundary=boundary)
-    assert np.all(a == a_trimmed)
+    x_overlaped = da.overlap.overlap(x, 2, boundary=boundary)
+    x_trimmed = da.overlap.trim(x_overlaped, 2, boundary=boundary)
+    assert np.all(x == x_trimmed)

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -11,6 +11,9 @@ from dask.array.overlap import (fractional_slice, getitem, trim_internal,
 from dask.array.utils import assert_eq, same_keys
 
 
+parametrize = pytest.mark.parametrize
+
+
 def test_fractional_slice():
     assert (fractional_slice(('x', 4.9), {0: 2}) ==
             (getitem, ('x', 5), (slice(0, 2), )))
@@ -415,3 +418,21 @@ def test_overlap_few_dimensions():
     assert len(a.dask) < len(c.dask)
 
     assert len(c.dask) < 10 * len(a.dask)
+
+
+@parametrize('boundary', ['reflect', 'periodic', 'nearest', 'none'])
+def test_trim_boundry_is_dict(boundary):
+    a = da.from_array(np.arange(24).reshape(4, 6), chunks=(2, 3))
+    a_overlaped = da.overlap.overlap(a, 2,
+                                     boundary={0: 'reflect', 1: boundary})
+    a_trimmed = da.overlap.trim(a, 2,
+                                boundary={0: 'reflect', 1: boundary})
+    assert np.all(a == a_trimmed)
+
+
+@parametrize('boundary', ['reflect', 'periodic', 'nearest', 'none'])
+def test_trim_boundry_is_string(boundary):
+    a = da.from_array(np.arange(24).reshape(4, 6), chunks=(2, 3))
+    a_overlaped = da.overlap.overlap(a, 2, boundary=boundary)
+    a_trimmed = da.overlap.trim(a, 2, boundary=boundary)
+    assert np.all(a == a_trimmed)

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -425,7 +425,7 @@ def test_trim_boundry_is_dict(boundary):
     a = da.from_array(np.arange(24).reshape(4, 6), chunks=(2, 3))
     a_overlaped = da.overlap.overlap(a, 2,
                                      boundary={0: 'reflect', 1: boundary})
-    a_trimmed = da.overlap.trim(a, 2,
+    a_trimmed = da.overlap.trim(a_overlaped, 2,
                                 boundary={0: 'reflect', 1: boundary})
     assert np.all(a == a_trimmed)
 
@@ -434,5 +434,5 @@ def test_trim_boundry_is_dict(boundary):
 def test_trim_boundry_is_string(boundary):
     a = da.from_array(np.arange(24).reshape(4, 6), chunks=(2, 3))
     a_overlaped = da.overlap.overlap(a, 2, boundary=boundary)
-    a_trimmed = da.overlap.trim(a, 2, boundary=boundary)
+    a_trimmed = da.overlap.trim(a_overlaped, 2, boundary=boundary)
     assert np.all(a == a_trimmed)


### PR DESCRIPTION
Fixes #3947 

Pushes the trimming logic for the boundary conditions into `chunk.trim` allowing trim to be performed in an efficient manner even in the case where the boundary is `'none'` (string 'none')

It should give more optimal performance from trim in the case where the boundary condition is string `'none'` as it avoids calls to concatenate.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
