### PR TITLE
Fix arg reduction tokens

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -943,7 +943,7 @@ def pad_udf(array, pad_width, mode, **kwargs):
 
         result = result.map_blocks(
             wrapped_pad_func,
-            token="pad",
+            name="pad",
             dtype=result.dtype,
             pad_func=mode,
             iaxis_pad_width=pad_width[d],

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -614,8 +614,8 @@ def arg_reduction(x, chunk, combine, agg, axis=None, split_every=None, out=None)
                         "got '{0}'".format(axis))
 
     # Map chunk across all blocks
-    name = 'arg-reduce-chunk-axis={0}-{1}'.format(axis, tokenize(x, chunk, 
-                                                                 combine, split_every, 
+    name = 'arg-reduce-chunk-axis={0}-{1}'.format(axis, tokenize(x, chunk,
+                                                                 combine, split_every,
                                                                  out))
     old = x.name
     keys = list(product(*map(range, x.numblocks)))
@@ -717,7 +717,7 @@ def cumreduction(func, binop, ident, x, axis=None, dtype=None, out=None):
     m = x.map_blocks(func, axis=axis, dtype=dtype)
 
     name = '{0}-axis={1}-{2}'.format(func.__name__, axis, tokenize(func, x, dtype,
-                                                               dtype, out))
+                                                                   dtype, out))
     n = x.numblocks[axis]
     full = slice(None, None, None)
     slc = (full,) * axis + (slice(-1, None),) + (full,) * (x.ndim - axis - 1)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -614,7 +614,9 @@ def arg_reduction(x, chunk, combine, agg, axis=None, split_every=None, out=None)
                         "got '{0}'".format(axis))
 
     # Map chunk across all blocks
-    name = 'arg-reduce-chunk-{0}'.format(tokenize(chunk, axis))
+    name = 'arg-reduce-chunk-axis={0}-{1}'.format(axis, tokenize(x, chunk, 
+                                                                 combine, split_every, 
+                                                                 out))
     old = x.name
     keys = list(product(*map(range, x.numblocks)))
     offsets = list(product(*(accumulate(operator.add, bd[:-1], 0)
@@ -714,7 +716,8 @@ def cumreduction(func, binop, ident, x, axis=None, dtype=None, out=None):
 
     m = x.map_blocks(func, axis=axis, dtype=dtype)
 
-    name = '%s-axis=%d-%s' % (func.__name__, axis, tokenize(x, dtype))
+    name = '{0}-axis={1}-{2}'.format(func.__name__, axis, tokenize(func, x, dtype,
+                                                               dtype, out))
     n = x.numblocks[axis]
     full = slice(None, None, None)
     slc = (full,) * axis + (slice(-1, None),) + (full,) * (x.ndim - axis - 1)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -614,9 +614,8 @@ def arg_reduction(x, chunk, combine, agg, axis=None, split_every=None, out=None)
                         "got '{0}'".format(axis))
 
     # Map chunk across all blocks
-    name = 'arg-reduce-chunk-axis={0}-{1}'.format(axis, tokenize(x, chunk,
-                                                                 combine, split_every,
-                                                                 out))
+    name = 'arg-reduce-{0}'.format(tokenize(axis, x, chunk,
+                                            combine, split_every))
     old = x.name
     keys = list(product(*map(range, x.numblocks)))
     offsets = list(product(*(accumulate(operator.add, bd[:-1], 0)
@@ -716,8 +715,8 @@ def cumreduction(func, binop, ident, x, axis=None, dtype=None, out=None):
 
     m = x.map_blocks(func, axis=axis, dtype=dtype)
 
-    name = '{0}-axis={1}-{2}'.format(func.__name__, axis, tokenize(func, x, dtype,
-                                                                   dtype, out))
+    name = '{0}-{1}'.format(func.__name__, tokenize(func, axis, binop,
+                                                    ident, x, dtype))
     n = x.numblocks[axis]
     full = slice(None, None, None)
     slc = (full,) * axis + (slice(-1, None),) + (full,) * (x.ndim - axis - 1)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -69,7 +69,7 @@ def sanitize_index(ind):
         return np.asanyarray(nonzero)
     elif np.issubdtype(index_array.dtype, np.integer):
         return index_array
-    elif np.issubdtype(index_array.dtype, float):
+    elif np.issubdtype(index_array.dtype, np.floating):
         int_index = index_array.astype(np.intp)
         if np.allclose(index_array, int_index):
             return int_index

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -489,13 +489,12 @@ def test_topk_argtopk3():
               da.argtopk(a, 5, axis=1, split_every=2))
 
 
-@pytest.mark.parametrize('func', [da.cumsum, da.cumprod, 
-                                  da.argmin, da.argmax, 
+@pytest.mark.parametrize('func', [da.cumsum, da.cumprod,
+                                  da.argmin, da.argmax,
                                   da.min, da.max,
                                   da.nansum, da.nanmax])
 def test_regres_3940(func):
     a = da.ones((5,2), chunks=(2,2))
-    assert func(a).name != func(a+1).name
+    assert func(a).name != func(a + 1).name
     assert func(a, axis=0).name != func(a).name
     assert func(a, axis=0).name != func(a, axis=1).name
-    

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -6,8 +6,7 @@ np = pytest.importorskip('numpy')
 import dask.array as da
 from dask.array.utils import assert_eq as _assert_eq, same_keys
 from dask.core import get_deps
-from dask.context import set_options
-
+import dask.config as config
 
 def assert_eq(a, b):
     _assert_eq(a, b, equal_nan=True)
@@ -139,7 +138,7 @@ def test_arg_reductions(dfunc, func):
     assert_eq(dfunc(a, 0), func(x, 0))
     assert_eq(dfunc(a, 1), func(x, 1))
     assert_eq(dfunc(a, 2), func(x, 2))
-    with set_options(split_every=2):
+    with config.set(split_every=2):
         assert_eq(dfunc(a), func(x))
         assert_eq(dfunc(a, 0), func(x, 0))
         assert_eq(dfunc(a, 1), func(x, 1))
@@ -368,7 +367,7 @@ def test_tree_reduce_depth():
 
 def test_tree_reduce_set_options():
     x = da.from_array(np.arange(242).reshape((11, 22)), chunks=(3, 4))
-    with set_options(split_every={0: 2, 1: 3}):
+    with config.set(split_every={0: 2, 1: 3}):
         assert_max_deps(x.sum(), 2 * 3)
         assert_max_deps(x.sum(axis=0), 2)
 

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -8,6 +8,7 @@ from dask.array.utils import assert_eq as _assert_eq, same_keys
 from dask.core import get_deps
 import dask.config as config
 
+
 def assert_eq(a, b):
     _assert_eq(a, b, equal_nan=True)
 

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -487,3 +487,15 @@ def test_topk_argtopk3():
               da.topk(a, 5, axis=1, split_every=2))
     assert_eq(a.argtopk(5, axis=1, split_every=2),
               da.argtopk(a, 5, axis=1, split_every=2))
+
+
+@pytest.mark.parametrize('func', [da.cumsum, da.cumprod, 
+                                  da.argmin, da.argmax, 
+                                  da.min, da.max,
+                                  da.nansum, da.nanmax])
+def test_regres_3940(func):
+    a = da.ones((5,2), chunks=(2,2))
+    assert func(a).name != func(a+1).name
+    assert func(a, axis=0).name != func(a).name
+    assert func(a, axis=0).name != func(a, axis=1).name
+    


### PR DESCRIPTION
Fixes #3940, I hope we can still include this one for the bugfix release #3951.
Also en passant fixed some FutureWarnings from numpy and dask, as they were cluttering the test output :')

- [x] Tests passed
- [x] Passes `flake8 dask`
