### PR TITLE
Issue 3937 follow up, int type checks.

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -11,6 +11,8 @@ from ..compatibility import getargspec, Container, Iterable, Sequence
 from ..core import flatten
 from ..utils import ignoring
 
+from numbers import Integral
+
 try:
     from numpy import broadcast_to
 except ImportError:  # pragma: no cover
@@ -171,7 +173,7 @@ def trim(x, axes=None):
     array([[ 7,  8,  9, 10],
            [13, 14, 15, 16]])
     """
-    if isinstance(axes, int):
+    if isinstance(axes, Integral):
         axes = [axes] * x.ndim
     if isinstance(axes, dict):
         axes = [axes.get(i, 0) for i in range(x.ndim)]

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -38,7 +38,7 @@ from ..utils import (homogeneous_deepmap, ndeepmap, ignoring, concrete,
                      is_integer, IndexCallable, funcname, derived_from,
                      SerializableLock, ensure_dict, Dispatch, factors,
                      parse_bytes, has_keyword, M)
-from ..compatibility import (unicode, long, zip_longest, apply,
+from ..compatibility import (unicode, zip_longest, apply,
                              Iterable, Iterator, Mapping)
 from ..core import quote
 from ..delayed import Delayed, to_task_dask

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4,7 +4,7 @@ from bisect import bisect
 from functools import partial, wraps
 from itertools import product
 import math
-from numbers import Number
+from numbers import Number, Integral
 import operator
 from operator import add, getitem, mul
 import os
@@ -93,7 +93,7 @@ def getter(a, b, asarray=True, lock=None):
     if isinstance(b, tuple) and any(x is None for x in b):
         b2 = tuple(x for x in b if x is not None)
         b3 = tuple(None if x is None else slice(None, None)
-                   for x in b if not isinstance(x, (int, long)))
+                   for x in b if not isinstance(x, Integral))
         return getter(a, b2, asarray=asarray, lock=lock)[b3]
 
     if lock:
@@ -2834,7 +2834,7 @@ def atop(func, out_ind, *args, **kwargs):
             if ind in adjust_chunks:
                 if callable(adjust_chunks[ind]):
                     chunks[i] = tuple(map(adjust_chunks[ind], chunks[i]))
-                elif isinstance(adjust_chunks[ind], int):
+                elif isinstance(adjust_chunks[ind], Integral):
                     chunks[i] = tuple(adjust_chunks[ind] for _ in chunks[i])
                 elif isinstance(adjust_chunks[ind], (tuple, list)):
                     chunks[i] = tuple(adjust_chunks[ind])

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -18,7 +18,6 @@ from .core import (Array, asarray, normalize_chunks,
                    broadcast_to, broadcast_arrays)
 from .wrap import empty, ones, zeros, full
 
-
 def empty_like(a, dtype=None, chunks=None):
     """
     Return a new array with the same shape and type as a given array.
@@ -442,7 +441,7 @@ def eye(N, chunks, M=None, k=0, dtype=float):
       An array where all elements are equal to zero, except for the `k`-th
       diagonal, whose values are equal to one.
     """
-    if not isinstance(chunks, int):
+    if not isinstance(chunks, Integral):
         raise ValueError('chunks must be an int')
 
     token = tokenize(N, chunk, M, k, dtype)

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -18,6 +18,7 @@ from .core import (Array, asarray, normalize_chunks,
                    broadcast_to, broadcast_arrays)
 from .wrap import empty, ones, zeros, full
 
+
 def empty_like(a, dtype=None, chunks=None):
     """
     Return a new array with the same shape and type as a given array.

--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -10,6 +10,7 @@ from ..core import flatten, reverse_dict
 from ..optimization import cull, fuse, inline_functions
 from ..utils import ensure_dict
 
+from numbers import Integral
 
 # All get* functions the optimizations know about
 GETTERS = (getter, getter_nofancy, getter_inline, getitem)
@@ -184,7 +185,7 @@ def check_for_nonfusible_fancy_indexing(fancy, normal):
     # x[:, [1, 2], :][0, :, :] -> x[0, [1, 2], :] or
     # x[0, :, :][:, [1, 2], :] -> x[0, [1, 2], :]
     for f, n in zip_longest(fancy, normal, fillvalue=slice(None)):
-        if type(f) is not list and isinstance(n, int):
+        if type(f) is not list and isinstance(n, Integral):
             raise NotImplementedError("Can't handle normal indexing with "
                                       "integers and fancy indexing if the "
                                       "integers and fancy indices don't "
@@ -229,7 +230,7 @@ def fuse_slice(a, b):
     if isinstance(b, slice):
         b = normalize_slice(b)
 
-    if isinstance(a, slice) and isinstance(b, int):
+    if isinstance(a, slice) and isinstance(b, Integral):
         if b < 0:
             raise NotImplementedError()
         return a.start + b * a.step
@@ -252,7 +253,7 @@ def fuse_slice(a, b):
 
     if isinstance(b, list):
         return [fuse_slice(a, bb) for bb in b]
-    if isinstance(a, list) and isinstance(b, (int, slice)):
+    if isinstance(a, list) and isinstance(b, (Integral, slice)):
         return a[b]
 
     if isinstance(a, tuple) and not isinstance(b, tuple):
@@ -276,7 +277,7 @@ def fuse_slice(a, b):
         result = list()
         for i in range(len(a)):
             #  axis ceased to exist  or we're out of b
-            if isinstance(a[i], int) or j == len(b):
+            if isinstance(a[i], Integral) or j == len(b):
                 result.append(a[i])
                 continue
             while b[j] is None:  # insert any Nones on the rhs

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -6,6 +6,8 @@ from itertools import product, repeat
 from math import factorial, log, ceil
 
 import numpy as np
+from numbers import Integral
+
 from toolz import compose, partition_all, get, accumulate, pluck
 
 from . import chunk
@@ -19,7 +21,6 @@ from ..compatibility import getargspec, builtins
 from ..base import tokenize
 from ..utils import ignoring, funcname, Dispatch
 from .. import config, sharedict
-
 
 # Generic functions to support chunks of different types
 empty_lookup = Dispatch('empty')
@@ -124,7 +125,7 @@ def reduction(x, chunk, aggregate, axis=None, keepdims=False, dtype=None,
     """
     if axis is None:
         axis = tuple(range(x.ndim))
-    if isinstance(axis, int):
+    if isinstance(axis, Integral):
         axis = (axis,)
     axis = validate_axis(axis, x.ndim)
 
@@ -159,7 +160,7 @@ def _tree_reduce(x, aggregate, axis, keepdims, dtype, split_every=None,
     split_every = split_every or config.get('split_every', 4)
     if isinstance(split_every, dict):
         split_every = dict((k, split_every.get(k, 2)) for k in axis)
-    elif isinstance(split_every, int):
+    elif isinstance(split_every, Integral):
         n = builtins.max(int(split_every ** (1 / (len(axis) or 1))), 2)
         split_every = dict.fromkeys(axis, n)
     else:
@@ -446,7 +447,7 @@ def moment_agg(data, order=2, ddof=0, dtype='f8', sum=np.sum, **kwargs):
 
 def moment(a, order, axis=None, dtype=None, keepdims=False, ddof=0,
            split_every=None, out=None):
-    if not isinstance(order, int) or order < 0:
+    if not isinstance(order, Integral) or order < 0:
         raise ValueError("Order must be an integer >= 0")
 
     if order < 2:
@@ -605,7 +606,7 @@ def arg_reduction(x, chunk, combine, agg, axis=None, split_every=None, out=None)
     if axis is None:
         axis = tuple(range(x.ndim))
         ravel = True
-    elif isinstance(axis, int):
+    elif isinstance(axis, Integral):
         axis = validate_axis(axis, x.ndim)
         axis = (axis,)
         ravel = x.ndim == 1
@@ -709,7 +710,7 @@ def cumreduction(func, binop, ident, x, axis=None, dtype=None, out=None):
         axis = 0
     if dtype is None:
         dtype = getattr(func(np.empty((0,), dtype=x.dtype)), 'dtype', object)
-    assert isinstance(axis, int)
+    assert isinstance(axis, Integral)
     axis = validate_axis(axis, x.ndim)
 
     m = x.map_blocks(func, axis=axis, dtype=dtype)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -215,9 +215,9 @@ def tensordot(lhs, rhs, axes=2):
         left_axes = tuple(range(lhs.ndim - 1, lhs.ndim - axes - 1, -1))
         right_axes = tuple(range(0, axes))
 
-    if isinstance(left_axes, int):
+    if isinstance(left_axes, Integral):
         left_axes = (left_axes,)
-    if isinstance(right_axes, int):
+    if isinstance(right_axes, Integral):
         right_axes = (right_axes,)
     if isinstance(left_axes, list):
         left_axes = tuple(left_axes)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -172,7 +172,7 @@ def slice_with_newaxes(out_name, in_name, blockdims, index):
     where_none = [i for i, ind in enumerate(index) if ind is None]
     where_none_orig = list(where_none)
     for i, x in enumerate(where_none):
-        n = sum(isinstance(ind, int) for ind in index[:x])
+        n = sum(isinstance(ind, Integral) for ind in index[:x])
         if n:
             where_none[i] -= n
 

--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from collections import defaultdict
 import pandas as pd
 from toolz import partition_all
+from numbers import Integral
 
 from ..base import tokenize, compute_as_if_collection
 from .accessor import Accessor
@@ -105,7 +106,7 @@ def categorize(df, columns=None, index=None, split_every=None, **kwargs):
         split_every = 16
     elif split_every is False:
         split_every = df.npartitions
-    elif not isinstance(split_every, int) or split_every < 2:
+    elif not isinstance(split_every, Integral) or split_every < 2:
         raise ValueError("split_every must be an integer >= 2")
 
     token = tokenize(df, columns, index, split_every)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -10,7 +10,7 @@ import warnings
 from toolz import merge, first, unique, partition_all, remove
 import pandas as pd
 import numpy as np
-from numbers import Number
+from numbers import Number, Integral
 
 try:
     from chest import Chest as Cache
@@ -1218,12 +1218,12 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         """
         from dask.dataframe.rolling import Rolling
 
-        if isinstance(window, int):
+        if isinstance(window, Integral):
             if window < 0:
                 raise ValueError('window must be >= 0')
 
         if min_periods is not None:
-            if not isinstance(min_periods, int):
+            if not isinstance(min_periods, Integral):
                 raise ValueError('min_periods must be an integer')
             if min_periods < 0:
                 raise ValueError('min_periods must be >= 0')
@@ -1234,7 +1234,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
     @derived_from(pd.DataFrame)
     def diff(self, periods=1, axis=0):
         axis = self._validate_axis(axis)
-        if not isinstance(periods, int):
+        if not isinstance(periods, Integral):
             raise TypeError("periods must be an integer")
 
         if axis == 1:
@@ -1248,7 +1248,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
     @derived_from(pd.DataFrame)
     def shift(self, periods=1, freq=None, axis=0):
         axis = self._validate_axis(axis)
-        if not isinstance(periods, int):
+        if not isinstance(periods, Integral):
             raise TypeError("periods must be an integer")
 
         if axis == 1:
@@ -2279,7 +2279,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
 
     @derived_from(pd.Series)
     def autocorr(self, lag=1, split_every=False):
-        if not isinstance(lag, int):
+        if not isinstance(lag, Integral):
             raise TypeError("lag must be an integer")
         return self.corr(self if lag == 0 else self.shift(lag),
                          split_every=split_every)
@@ -3480,7 +3480,7 @@ def apply_concat_apply(args, chunk=None, aggregate=None, combine=None,
         split_every = 8
     elif split_every is False:
         split_every = npartitions
-    elif split_every < 2 or not isinstance(split_every, int):
+    elif split_every < 2 or not isinstance(split_every, Integral):
         raise ValueError("split_every must be an integer >= 2")
 
     token_key = tokenize(token or (chunk, aggregate), meta, args,
@@ -3831,7 +3831,7 @@ def cov_corr(df, min_periods=None, corr=False, scalar=False, split_every=False):
 
     if split_every is False:
         split_every = df.npartitions
-    elif split_every < 2 or not isinstance(split_every, int):
+    elif split_every < 2 or not isinstance(split_every, Integral):
         raise ValueError("split_every must be an integer >= 2")
 
     df = df._get_numeric_data()

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -4,6 +4,7 @@ import datetime
 
 import pandas as pd
 from pandas.core.window import Rolling as pd_Rolling
+from numbers import Integral
 
 from ..base import tokenize
 from ..utils import M, funcname, derived_from
@@ -18,11 +19,11 @@ def overlap_chunk(func, prev_part, current_part, next_part, before, after,
            "window size. Try using ``df.repartition`` "
            "to increase the partition size.")
 
-    if prev_part is not None and isinstance(before, int):
+    if prev_part is not None and isinstance(before, Integral):
         if prev_part.shape[0] != before:
             raise NotImplementedError(msg)
 
-    if next_part is not None and isinstance(after, int):
+    if next_part is not None and isinstance(after, Integral):
         if next_part.shape[0] != after:
             raise NotImplementedError(msg)
     # We validate that the window isn't too large for tiemdeltas in map_overlap
@@ -69,8 +70,8 @@ def map_overlap(func, df, before, after, *args, **kwargs):
             raise TypeError("Must have a `DatetimeIndex` when using string offset "
                             "for `before` and `after`")
     else:
-        if not (isinstance(before, int) and before >= 0 and
-                isinstance(after, int) and after >= 0):
+        if not (isinstance(before, Integral) and before >= 0 and
+                isinstance(after, Integral) and after >= 0):
             raise ValueError("before and after must be positive integers")
 
     if 'token' in kwargs:
@@ -102,7 +103,7 @@ def map_overlap(func, df, before, after, *args, **kwargs):
         "Try using ``df.repartition`` to increase the partition size"
     )
 
-    if before and isinstance(before, int):
+    if before and isinstance(before, Integral):
         dsk.update({(name_a, i): (M.tail, (df_name, i), before)
                     for i in range(df.npartitions - 1)})
         prevs = [None] + [(name_a, i) for i in range(df.npartitions - 1)]
@@ -117,7 +118,7 @@ def map_overlap(func, df, before, after, *args, **kwargs):
     else:
         prevs = [None] * df.npartitions
 
-    if after and isinstance(after, int):
+    if after and isinstance(after, Integral):
         dsk.update({(name_b, i): (M.head, (df_name, i), after)
                     for i in range(1, df.npartitions)})
         nexts = [(name_b, i) for i in range(1, df.npartitions)] + [None]
@@ -219,7 +220,7 @@ class Rolling(object):
         or multiple (False).
         """
         return (self.axis in (1, 'columns') or
-                (isinstance(self.window, int) and self.window <= 1) or
+                (isinstance(self.window, Integral) and self.window <= 1) or
                 self.obj.npartitions == 1)
 
     def _call_method(self, method_name, *args, **kwargs):


### PR DESCRIPTION
This PR trades most isinstance(..., int) to isinstance(..., Integral) in the internals of dask.

I noticed in many places isinstance(..., Number) is used where integers are expected.

Each of the changes in this PR may need to be carefully think through. Or maybe we shall just merge it and identify new test cases as the downstream are affected. The current tests all should pass.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`

