### PR TITLE
Add unravel_index

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -10,12 +10,12 @@ try:
                            ravel, roll, unique, squeeze, ptp, diff, ediff1d,
                            gradient, bincount, digitize, histogram, cov, array,
                            dstack, vstack, hstack, compress, extract, round,
-                           count_nonzero, flatnonzero, nonzero, around, isin,
-                           isnull, notnull, isclose, allclose, corrcoef, swapaxes,
-                           tensordot, transpose, dot, vdot, matmul, outer,
-                           apply_along_axis, apply_over_axes, result_type,
-                           atleast_1d, atleast_2d, atleast_3d, piecewise, flip,
-                           flipud, fliplr, einsum, average)
+                           count_nonzero, flatnonzero, nonzero, unravel_index,
+                           around, isin, isnull, notnull, isclose, allclose,
+                           corrcoef, swapaxes, tensordot, transpose, dot, vdot,
+                           matmul, outer, apply_along_axis, apply_over_axes,
+                           result_type, atleast_1d, atleast_2d, atleast_3d,
+                           piecewise, flip, flipud, fliplr, einsum, average)
     from .reshape import reshape
     from .ufunc import (add, subtract, multiply, divide, logaddexp, logaddexp2,
             true_divide, floor_divide, negative, power, remainder, mod, conj, exp,

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1256,6 +1256,42 @@ def test_nonzero_method():
             assert_eq(d_nz[i], x_nz[i])
 
 
+@pytest.mark.skipif(
+    LooseVersion(np.__version__) < LooseVersion("1.14.0"),
+    reason="NumPy 1.14.0+ needed for `unravel_index` to take an empty shape."
+)
+def test_unravel_index_empty():
+    shape = tuple()
+    findices = np.array(0, dtype=int)
+    d_findices = da.from_array(findices, chunks=1)
+
+    indices = np.unravel_index(findices, shape)
+    d_indices = da.unravel_index(d_findices, shape)
+
+    assert isinstance(d_indices, type(indices))
+    assert len(d_indices) == len(indices) == 0
+
+
+def test_unravel_index():
+    for nindices, shape, order in [(0, (15,), 'C'),
+                                   (1, (15,), 'C'),
+                                   (3, (15,), 'C'),
+                                   (3, (15,), 'F'),
+                                   (2, (15, 16), 'C'),
+                                   (2, (15, 16), 'F')]:
+        findices = np.random.randint(np.prod(shape, dtype=int), size=nindices)
+        d_findices = da.from_array(findices, chunks=1)
+
+        indices = np.unravel_index(findices, shape, order)
+        d_indices = da.unravel_index(d_findices, shape, order)
+
+        assert isinstance(d_indices, type(indices))
+        assert len(d_indices) == len(indices)
+
+        for i in range(len(indices)):
+            assert_eq(d_indices[i], indices[i])
+
+
 def test_coarsen():
     x = np.random.randint(10, size=(24, 24))
     d = da.from_array(x, chunks=(4, 8))

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1279,6 +1279,9 @@ def test_unravel_index():
                                    (3, (15,), 'F'),
                                    (2, (15, 16), 'C'),
                                    (2, (15, 16), 'F')]:
+        arr = np.random.random(shape)
+        darr = da.from_array(arr, chunks=1)
+
         findices = np.random.randint(np.prod(shape, dtype=int), size=nindices)
         d_findices = da.from_array(findices, chunks=1)
 
@@ -1290,6 +1293,8 @@ def test_unravel_index():
 
         for i in range(len(indices)):
             assert_eq(d_indices[i], indices[i])
+
+        assert_eq(darr.vindex[d_indices], arr[indices])
 
 
 def test_coarsen():

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -180,6 +180,7 @@ Top level user functions:
    triu
    trunc
    unique
+   unravel_index
    var
    vdot
    vstack
@@ -539,6 +540,7 @@ Other functions
 .. autofunction:: triu
 .. autofunction:: trunc
 .. autofunction:: unique
+.. autofunction:: unravel_index
 .. autofunction:: var
 .. autofunction:: vdot
 .. autofunction:: vstack


### PR DESCRIPTION
Partially addresses ( https://github.com/dask/dask/issues/2557 ).

Implements NumPy's [unravel_index]( https://docs.scipy.org/doc/numpy/reference/generated/numpy.unravel_index.html ) for Dask Arrays.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
