### PR TITLE
Making skiprows accept lists

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -330,7 +330,7 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
     if blocksize and blocksize < sample and lastskiprow != 0:
         warn("Unexpected behavior can result from passing skiprows when\n"
              "blocksize is smaller than sample size.\n"
-             "Setting ``sample=blocksize")
+             "Setting ``sample=blocksize``")
         sample = blocksize
     b_lineterminator = lineterminator.encode()
     b_out = read_bytes(urlpath, delimiter=b_lineterminator,

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -301,8 +301,15 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
                          "recommended to use `dd.{0}(...)."
                          "head(n=nrows)`".format(reader_name))
     if isinstance(kwargs.get('skiprows'), list):
-        raise TypeError("List of skiprows not supported for "
-                        "dd.{0}".format(reader_name))
+        # When skiprows is a list, we expect more than max(skiprows) to
+        # be included in the sample. This means that [0,2] will work well,
+        # but [0, 440] might not work.
+        skiprows = kwargs.get('skiprows')
+        lastskiprow = max(skiprows)
+        # find the firstrow that is not skipped, for use as header
+        firstrow = min(set(range(len(skiprows) + 1)) - set(skiprows))
+    else:
+        skiprows = lastskiprow = firstrow = kwargs.get('skiprows', 0)
     if isinstance(kwargs.get('header'), list):
         raise TypeError("List of header rows not supported for "
                         "dd.{0}".format(reader_name))
@@ -344,20 +351,19 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
     # Get header row, and check that sample is long enough. If the file
     # contains a header row, we need at least 2 nonempty rows + the number of
     # rows to skip.
-    skiprows = kwargs.get('skiprows', 0)
     names = kwargs.get('names', None)
     header = kwargs.get('header', 'infer' if names is None else None)
     need = 1 if header is None else 2
-    parts = b_sample.split(b_lineterminator, skiprows + need)
+    parts = b_sample.split(b_lineterminator, lastskiprow + need)
     # If the last partition is empty, don't count it
     nparts = 0 if not parts else len(parts) - int(not parts[-1])
 
-    if nparts < skiprows + need and len(b_sample) >= sample:
+    if nparts < lastskiprow + need and len(b_sample) >= sample:
         raise ValueError("Sample is not large enough to include at least one "
                          "row of data. Please increase the number of bytes "
                          "in `sample` in the call to `read_csv`/`read_table`")
 
-    header = b'' if header is None else parts[skiprows] + b_lineterminator
+    header = b'' if header is None else parts[firstrow] + b_lineterminator
 
     # Use sample to infer dtypes and check for presense of include_path_column
     head = reader(BytesIO(b_sample), **kwargs)

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -327,7 +327,11 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
     if compression not in seekable_files and compression not in cfiles:
         raise NotImplementedError("Compression format %s not installed" %
                                   compression)
-
+    if blocksize and blocksize < sample and lastskiprow != 0:
+        warn("Unexpected behavior can result from passing skiprows when\n"
+             "blocksize is smaller than sample size.\n"
+             "Setting ``sample=blocksize")
+        sample = blocksize
     b_lineterminator = lineterminator.encode()
     b_out = read_bytes(urlpath, delimiter=b_lineterminator,
                        blocksize=blocksize,

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -289,7 +289,6 @@ def test_read_csv_large_skiprows(dd_read, pd_read, text, skip):
                          [(dd.read_csv, pd.read_csv, csv_text, 7),
                           (dd.read_table, pd.read_table, tsv_text, [1, 12])])
 def test_read_csv_skiprows_only_in_first_partition(dd_read, pd_read, text, skip):
-    # If sample is larger than the first partition this behavior is expected
     names = ['name', 'amount']
     with filetext(text) as fn:
         with pytest.warns(UserWarning) as w:
@@ -299,10 +298,10 @@ def test_read_csv_skiprows_only_in_first_partition(dd_read, pd_read, text, skip)
             msg = str(w[0].message)
             assert 'sample=blocksize' in msg
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning):
+            # if new sample does not contain all the skiprows, raise error
             with pytest.raises(ValueError):
-                actual = dd_read(fn, blocksize=30, skiprows=skip, names=names).compute()
-                assert actual.shape != pd_read(fn, skiprows=skip, names=names).shape
+                dd_read(fn, blocksize=30, skiprows=skip, names=names)
 
 
 @pytest.mark.parametrize('dd_read,pd_read,files',

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -220,7 +220,8 @@ def test_skiprows_as_list(dd_read, pd_read, files, units):
     files = {name: (comment_header + b'\n' +
                     content.replace(b'\n', b'\n' + units, 1)) for name, content in files.items()}
     n_comment_lines = len(comment_header.splitlines())
-    skip = [*range( n_comment_lines),  n_comment_lines + 1]
+    skip = list(range( n_comment_lines))
+    skip.append(n_comment_lines + 1)
     with filetexts(files, mode='b'):
         df = dd_read('2014-01-*.csv', skiprows=skip)
         expected_df = pd.concat([pd_read(n, skiprows=skip) for n in sorted(files)])


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

This PR adds the ability to pass lists of `skiprows` to `dask.dataframe.read_csv`. I think this feature is especially useful for cases where there is a row of units or type under the header row (that is where I encountered the need). 