### PR TITLE
Fuse linear chains of subgraphs

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -111,6 +111,9 @@ if PY3:
             raise exc.with_traceback(tb)
         raise exc
 
+    def exec_(codestr, glbls):
+        exec(codestr, glbls)
+
 else:
     import __builtin__ as builtins
     import copy_reg as copyreg
@@ -150,6 +153,10 @@ else:
 
     reraise = _make_reraise()
     del _make_reraise
+
+    eval(compile(("def exec_(codestr, glbls):\n"
+                  "    exec codestr in glbls\n"),
+                  "<_exec>", "exec"))
 
     def _getargspec(func):
         return inspect.getargspec(func)

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -1,7 +1,7 @@
 """ Dataframe optimizations """
 from __future__ import absolute_import, division, print_function
 
-from ..optimization import cull, fuse_getitem, fuse
+from ..optimization import cull, fuse_getitem, fuse, fuse_subgraphs
 from .. import config, core
 
 try:
@@ -22,5 +22,7 @@ def optimize(dsk, keys, **kwargs):
         dsk = fuse_getitem(dsk, _read_parquet_row_group, 4)
     dsk, dependencies = fuse(dsk, keys, dependencies=dependencies,
                              ave_width=config.get('fuse_ave_width', 0))
+    if config.get('fuse_subgraphs', False):
+        dsk, dependencies = fuse_subgraphs(dsk, keys, dependencies=dependencies)
     dsk, _ = cull(dsk, keys)
     return dsk

--- a/dask/tests/test_optimization.py
+++ b/dask/tests/test_optimization.py
@@ -1093,20 +1093,11 @@ def test_SubgraphCallable():
     f = SubgraphCallable(dsk, 'h', ['in1', 'in2'], name='test')
     assert f.name == 'test'
     assert repr(f) == 'test'
-    nglobals = len(f.namespace)
-    glbls = list(f.namespace.values())
-    assert dontcall not in glbls
-    assert apply not in glbls
-    assert non_hashable in glbls
 
     dsk2 = dsk.copy()
     dsk2.update({'in1': 1, 'in2': 2})
     assert f(1, 2) == get_sync(cull(dsk2, ['h'])[0], ['h'])[0]
     assert f(1, 2) == f(1, 2)
 
-    assert len(f.namespace) == nglobals
     f2 = pickle.loads(pickle.dumps(f))
     assert f2(1, 2) == f(1, 2)
-    assert f2.name == f.name
-    assert f2.code == f.code
-    assert f2.namespace == f.namespace


### PR DESCRIPTION
Adds `fuse_subgraphs`, a function to fuse linear chains of non-fusable-with-fuse subgraphs together into a single task. The intention is that this is called somewhere in ``__dask_optimize__`` after ``fuse``.

It's currently a separate function because some collections (e.g. fusing getitem in dask array) have addtional steps after ``fuse`` that require access to the graph, and tasks wrapped in ``SubgraphCallable`` wouldn't be available to those optimization routines.

Fixes #3807.

Todo:
- [ ] Add tests