### PR TITLE
Fix array histogram range error when array has nans

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -627,17 +627,17 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
     name = 'histogram-sum-' + token
 
     # Map the histogram to all bins
-    def block_hist(x, weights=None):
+    def block_hist(x, range=None, weights=None):
         return np.histogram(x, bins, range=range, weights=weights)[0][np.newaxis]
 
     if weights is None:
-        dsk = {(name, i, 0): (block_hist, k)
+        dsk = {(name, i, 0): (block_hist, k, range)
                for i, k in enumerate(flatten(a.__dask_keys__()))}
         dtype = np.histogram([])[0].dtype
     else:
         a_keys = flatten(a.__dask_keys__())
         w_keys = flatten(weights.__dask_keys__())
-        dsk = {(name, i, 0): (block_hist, k, w)
+        dsk = {(name, i, 0): (block_hist, k, range, w)
                for i, (k, w) in enumerate(zip(a_keys, w_keys))}
         dtype = weights.dtype
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -628,7 +628,7 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
 
     # Map the histogram to all bins
     def block_hist(x, weights=None):
-        return np.histogram(x, bins, weights=weights)[0][np.newaxis]
+        return np.histogram(x, bins, range=range, weights=weights)[0][np.newaxis]
 
     if weights is None:
         dsk = {(name, i, 0): (block_hist, k)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -552,6 +552,15 @@ def test_histogram_alternative_bins_range():
     assert_eq(b1, b2)
 
 
+def test_histogram_bins_range_with_nan_array():
+    # Regression test for issue #3977
+    v = da.from_array(np.array([-2, np.nan, 2]), chunks=1)
+    (a1, b1) = da.histogram(v, bins=10, range=(-3, 3))
+    (a2, b2) = np.histogram(v, bins=10, range=(-3, 3))
+    assert_eq(a1, a2)
+    assert_eq(b1, b2)
+
+
 def test_histogram_return_type():
     v = da.random.random(100, chunks=10)
     bins = np.arange(0, 1.01, 0.01)


### PR DESCRIPTION
Fixes #3977. This PR adds the `range` parameter to the `np.histogram` call that is used in `da.histogram`. 

Note that there were improvements made to `np.histogram` in the 1.15.0 NumPy release. So the error reported in #3977 only occurs for NumPy versions < 1.15.0. Either way, this PR provides a fix that is valid for all NumPy versions.  

- [x] Tests added / passed
- [x] Passes `flake8 dask`
