### PR TITLE
Fix nonesense parquet column

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -196,6 +196,7 @@ def _read_fastparquet(fs, fs_token, paths, columns=None, filters=None,
                                   "that do not contain a global '_metadata' file")
 
     check_column_names(pf.columns, categories)
+    check_column_names(pf.columns + list(pf.cats or []), columns)
     if isinstance(columns, tuple):
         # ensure they tokenize the same
         columns = list(columns)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -264,6 +264,20 @@ def test_columns_index(tmpdir, write_engine, read_engine):
 
 
 @write_read_engines_xfail
+def test_nonsense_column(tmpdir, write_engine, read_engine):
+    fn = str(tmpdir)
+    ddf.to_parquet(fn, engine=write_engine)
+    with pytest.raises((ValueError, KeyError)):
+        # fastparquet fails early, pyarrow only on compute
+        dd.read_parquet(fn, columns=['nonesense'], engine=read_engine
+                        ).compute()
+    with pytest.raises((Exception, KeyError)):
+        # fastparquet fails early, pyarrow only on compute
+        dd.read_parquet(fn, columns=['nonesense'] + list(ddf.columns),
+                        engine=read_engine).compute()
+
+
+@write_read_engines_xfail
 def test_columns_no_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=write_engine)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

Probably a regression from fb2c6c7

Fixes dask/fastparquet#376 (not a fp bug)