### PR TITLE
ENH: Index in dd.from_dask_array

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -355,7 +355,7 @@ def from_dask_array(x, columns=None, index=None):
     index : dask.dataframe.Index, optional
         An optional *dask* Index to use for the output Series or DataFrame.
 
-        The defualt output index depends on whether `x` has any unknown
+        The default output index depends on whether `x` has any unknown
         chunks. If there are any unknown chunks, the output has ``None``
         for all the divisions (one per chunk). If all the chunks are known,
         a default index with known divsions is created.

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -14,7 +14,7 @@ from ...compatibility import unicode, PY3
 from ... import array as da
 from ...delayed import delayed
 
-from ..core import DataFrame, Series, new_dd_object
+from ..core import DataFrame, Series, Index, new_dd_object
 from ..shuffle import set_partition
 from ..utils import insert_meta_param_description, check_meta, make_meta
 
@@ -342,16 +342,27 @@ def dataframe_from_ctable(x, slc, columns=None, categories=None, lock=lock):
     return result
 
 
-def from_dask_array(x, columns=None):
+def from_dask_array(x, columns=None, index=None):
     """ Create a Dask DataFrame from a Dask Array.
 
     Converts a 2d array into a DataFrame and a 1d array into a Series.
 
     Parameters
     ----------
-    x: da.Array
-    columns: list or string
+    x : da.Array
+    columns : list or string
         list of column names if DataFrame, single string if Series
+    index : dask.dataframe.Index, optional
+        An optional *dask* Index to use for the output Series or DataFrame.
+
+        The defualt output index depends on whether `x` has any unknown
+        chunks. If there are any unknown chunks, the output has ``None``
+        for all the divisions (one per chunk). If all the chunks are known,
+        a default index with known divsions is created.
+
+        Specifying `index` can be useful if you're conforming a Dask Array
+        to an existing dask Series or DataFrame, and you would like the
+        indices to match.
 
     Examples
     --------
@@ -378,7 +389,22 @@ def from_dask_array(x, columns=None):
         x = x.rechunk({1: x.shape[1]})
 
     name = 'from-dask-array' + tokenize(x, columns)
-    if np.isnan(sum(x.shape)):
+    to_merge = []
+
+    if index is not None:
+        if not isinstance(index, Index):
+            raise ValueError("'index' must be an instance of dask.dataframe.Index")
+        if index.npartitions != x.numblocks[0]:
+            msg = (
+                "'index' must have the same number of blocks as 'x'. "
+                "({} != {})".format(index.npartitions, x.numblocks[0])
+            )
+            raise ValueError(msg)
+        divisions = index.divisions
+        to_merge.append(ensure_dict(index.dask))
+        index = index.__dask_keys__()
+
+    elif np.isnan(sum(x.shape)):
         divisions = [None] * (len(x.chunks[0]) + 1)
         index = [None] * len(x.chunks[0])
     else:
@@ -398,7 +424,8 @@ def from_dask_array(x, columns=None):
         else:
             dsk[name, i] = (pd.DataFrame, chunk, ind, meta.columns)
 
-    return new_dd_object(merge(ensure_dict(x.dask), dsk), name, meta, divisions)
+    to_merge.extend([ensure_dict(x.dask), dsk])
+    return new_dd_object(merge(*to_merge), name, meta, divisions)
 
 
 def _link(token, result):

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -351,6 +351,31 @@ def test_Series_from_dask_array():
     assert_eq(ser, ser2)
 
 
+@pytest.mark.parametrize('as_frame', [True, False])
+def test_from_dask_array_index(as_frame):
+    s = dd.from_pandas(pd.Series(range(10), index=list('abcdefghij')),
+                       npartitions=3)
+    if as_frame:
+        s = s.to_frame()
+    result = dd.from_dask_array(s.values, index=s.index)
+    assert_eq(s, result)
+
+
+def test_from_dask_array_index_raises():
+    x = da.random.uniform(size=(10,), chunks=(5,))
+    with pytest.raises(ValueError) as m:
+        dd.from_dask_array(x, index=pd.Index(np.arange(10)))
+    assert m.match("must be an instance")
+
+    a = dd.from_pandas(pd.Series(range(12)), npartitions=2)
+    b = dd.from_pandas(pd.Series(range(12)), npartitions=4)
+    with pytest.raises(ValueError) as m:
+        dd.from_dask_array(a.values, index=b.index)
+
+    assert m.match("must have the same number")
+    assert m.match("4 != 2")
+
+
 def test_from_dask_array_compat_numpy_array():
     x = da.ones((3, 3, 3), chunks=2)
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,7 +13,7 @@ Array
 Dataframe
 +++++++++
 
--
+- Added an `index` parameter to :meth:`dask.dataframe.from_dask_array` for creating a dask DataFrame from a dask Array with a given index.
 
 Core
 ++++


### PR DESCRIPTION
This is necessary to properly support https://github.com/dask/dask-ml/issues/362

```python
In [8]: s = dd.from_pandas(pd.Series(range(10), index=list('abcdefghij')), 2)

In [9]: r = dd.from_dask_array(s.values, index=s.index)

In [10]: r
Out[10]:
Dask Series Structure:
npartitions=2
a    int64
f      ...
j      ...
dtype: int64
Dask Name: from-dask, 8 tasks

In [11]: r.compute()
Out[11]:
a    0
b    1
c    2
d    3
e    4
f    5
g    6
h    7
i    8
j    9
dtype: int64
```