### PR TITLE
Add bag.read_avro

### DIFF
--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -6,6 +6,7 @@ try:
                        bag_zip as zip, bag_map as map)
     from .text import read_text
     from .utils import assert_eq
+    from .avro import read_avro
     from ..context import set_options
     from ..base import compute
 except ImportError as e:

--- a/dask/bag/avro.py
+++ b/dask/bag/avro.py
@@ -1,0 +1,126 @@
+import copy
+import io
+
+MAGIC = b'Obj\x01'
+SYNC_SIZE = 16
+
+
+def read_long(fo):
+    """variable-length, zig-zag encoding."""
+    c = fo.read(1)
+    b = ord(c)
+    n = b & 0x7F
+    shift = 7
+    while (b & 0x80) != 0:
+        b = ord(fo.read(1))
+        n |= (b & 0x7F) << shift
+        shift += 7
+    return (n >> 1) ^ -(n & 1)
+
+
+def read_bytes(fo):
+    """a long followed by that many bytes of data."""
+    size = read_long(fo)
+    return fo.read(size)
+
+
+def read_header(fo):
+    """Extract an avro file's header
+
+    fo: file-like
+        This should be in bytes mode, e.g., io.BytesIO
+
+    Returns dict representing the header
+
+    Parameters
+    ----------
+    fo: file-like
+    """
+    assert fo.read(len(MAGIC)) == MAGIC, 'Magic avro bytes missing'
+    meta = {}
+    out = {'meta': meta}
+    while True:
+        n_keys = read_long(fo)
+        if n_keys == 0:
+            break
+        for i in range(n_keys):
+            # ignore dtype mapping for bag version
+            read_bytes(fo)  # schema keys
+            read_bytes(fo)  # schema values
+    out['sync'] = fo.read(SYNC_SIZE)
+    out['header_size'] = fo.tell()
+    fo.seek(0)
+    out['head_bytes'] = fo.read(out['header_size'])
+    return out
+
+
+def read_avro(urlpath, blocksize=100000000, storage_options=None):
+    """Read set of avro files
+
+    Use this with arbitrary nested avro schemas. Please refer to the
+    fastavro documentation for its capabilities:
+    https://github.com/fastavro/fastavro
+
+    Parameters
+    ----------
+    urlpath: string or list
+        Absolute or relative filepath, URL (may include protocols like
+        ``s3://``), or globstring pointing to data.
+    blocksize: int or None
+        Size of chunks in bytes. If None, there will be no chunking and each
+        file will become one partition.
+    storage_options: dict or None
+        passed to backend file-system
+    """
+    from dask.utils import import_required
+    from dask import delayed
+    from dask.bytes.core import open_files, read_bytes
+    from dask.bag import from_delayed
+    import_required('fastavro',
+                    "fastavro is a required dependency for using "
+                    "bag.read_avro().")
+
+    storage_options = storage_options or {}
+    files = open_files(urlpath, **storage_options)
+    with copy.copy(files[0]) as f:
+        # we assume the same header for all files
+        head = read_header(f)
+    if blocksize is not None:
+        _, chunks = read_bytes(urlpath, sample=False, blocksize=blocksize,
+                               delimiter=head['sync'], include_path=False,
+                               **storage_options)
+        dread = delayed(read_chunk)
+        bits = []
+        need_heads = [len(chu) > 1 for chu in chunks]
+        if any(need_heads):
+            # any file with more than one chunk will have a different marker
+            dhead = delayed(lambda i: read_header(io.BytesIO(i)))
+            heads = {i: (dhead(chu[0]) if (len(chu) > 1 and i > 0) else None)
+                     for i, chu in enumerate(chunks)}
+        for i, chu in enumerate(chunks):
+            if len(chu) > 1 and i > 0:
+                head = heads[i]
+            bits.extend([dread(ch, head) for ch in chu])
+        return from_delayed(bits)
+    else:
+        files = open_files(urlpath, **storage_options)
+        dread = delayed(read_file)
+        chunks = [dread(fo) for fo in files]
+        return from_delayed(chunks)
+
+
+def read_chunk(chunk, head):
+    """Get rows from raw bytes block"""
+    import fastavro
+    head_bytes = head['head_bytes']
+    if not chunk.startswith(MAGIC):
+        chunk = head_bytes + chunk
+    i = io.BytesIO(chunk)
+    return list(fastavro.iter_avro(i))
+
+
+def read_file(fo):
+    """Get rows from file-like"""
+    import fastavro
+    with fo as f:
+        return list(fastavro.iter_avro(f))

--- a/dask/bag/tests/test_avro.py
+++ b/dask/bag/tests/test_avro.py
@@ -1,0 +1,58 @@
+import os
+import pytest
+import random
+import dask.bag as db
+fastavro = pytest.importorskip('fastavro')
+
+expected = [{'name': random.choice(['fred', 'wilma', 'barney', 'betty']),
+             'number': random.randint(0, 100)} for _ in range(1000)]
+schema = {
+    'doc': 'Descr',
+    'name': 'Random',
+    'namespace': 'test',
+    'type': 'record',
+    'fields': [
+        {'name': 'name', 'type': 'string'},
+        {'name': 'number', 'type': 'int'},
+    ],
+}
+import dask
+dask.set_options(scheduler='sync')
+
+def test_onefile_oneblock(tmpdir):
+    fn = os.path.join(tmpdir, 'one.avro')
+    with open(fn, 'wb') as f:
+        fastavro.writer(f, records=expected, schema=schema)
+    b = db.read_avro(fn, blocksize=None)
+    assert b.npartitions == 1
+    assert b.compute() == expected
+
+
+def test_twofile_oneblock(tmpdir):
+    fn1 = os.path.join(tmpdir, 'one.avro')
+    fn2 = os.path.join(tmpdir, 'two.avro')
+    with open(fn1, 'wb') as f:
+        fastavro.writer(f, records=expected[:500], schema=schema)
+    with open(fn2, 'wb') as f:
+        fastavro.writer(f, records=expected[500:], schema=schema)
+    b = db.read_avro(os.path.join(tmpdir, '*.avro'), blocksize=None)
+    assert b.npartitions == 2
+    assert b.compute() == expected
+
+
+def test_twofile_multiblock(tmpdir):
+    fn1 = os.path.join(tmpdir, 'one.avro')
+    fn2 = os.path.join(tmpdir, 'two.avro')
+    with open(fn1, 'wb') as f:
+        fastavro.writer(f, records=expected[:500], schema=schema,
+                        sync_interval=100)
+    with open(fn2, 'wb') as f:
+        fastavro.writer(f, records=expected[500:], schema=schema,
+                        sync_interval=100)
+    b = db.read_avro(os.path.join(tmpdir, '*.avro'), blocksize=None)
+    assert b.npartitions == 2
+    assert b.compute() == expected
+
+    b = db.read_avro(os.path.join(tmpdir, '*.avro'), blocksize=1000)
+    assert b.npartitions > 2
+    assert b.compute() == expected


### PR DESCRIPTION
Involves a little copying of code from uavro, but stands alone.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
