### PR TITLE
Automatically wrap large arguments with dask.delayed in map_blocks/partitions

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2856,7 +2856,7 @@ def atop(func, out_ind, *args, **kwargs):
                              % (ind, arg.ndim))
 
     numblocks = {a.name: a.numblocks for a, ind in arginds if ind is not None}
-    argindsstr = list(concat([(delayed(a) if sizeof(a) > 1e6 else a
+    argindsstr = list(concat([((delayed(a) if sizeof(a) > 1e6 else a)
                                if ind is None else a.name, ind)
                               for a, ind in arginds]))
     # Finish up the name

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -614,7 +614,7 @@ def map_blocks(func, *args, **kwargs):
     ----------
     func : callable
         Function to apply to every block in the array.
-    args : dask arrays or constants
+    args : dask arrays or other objects
     dtype : np.dtype, optional
         The ``dtype`` of the output array. It is recommended to provide this.
         If not provided, will be inferred by applying the function to a small

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3656,6 +3656,20 @@ def test_map_blocks_large_inputs_delayed():
     c = a.map_blocks(add, b)
     assert b in c.dask.values()
     assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
+
     d = a.map_blocks(lambda x, y: x + y, y=b)
+    assert b in d.dask.values()
+    assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
+
+
+def test_atop_large_inputs_delayed():
+    a = da.ones(10, chunks=(5,))
+    b = np.ones(1000000)
+
+    c = atop(add, 'i', a, 'i', b, None, dtype=a.dtype)
+    assert b in c.dask.values()
+    assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
+
+    d = atop(lambda x, y: x + y, 'i', a, 'i', y=b, dtype=a.dtype)
     assert b in d.dask.values()
     assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3654,11 +3654,11 @@ def test_map_blocks_large_inputs_delayed():
     b = np.ones(1000000)
 
     c = a.map_blocks(add, b)
-    assert b in c.dask.values()
+    assert any(b is v for v in c.dask.values())
     assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
 
     d = a.map_blocks(lambda x, y: x + y, y=b)
-    assert b in d.dask.values()
+    assert any(b is v for v in d.dask.values())
     assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
 
 
@@ -3667,9 +3667,9 @@ def test_atop_large_inputs_delayed():
     b = np.ones(1000000)
 
     c = atop(add, 'i', a, 'i', b, None, dtype=a.dtype)
-    assert b in c.dask.values()
+    assert any(b is v for v in c.dask.values())
     assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
 
     d = atop(lambda x, y: x + y, 'i', a, 'i', y=b, dtype=a.dtype)
-    assert b in d.dask.values()
+    assert any(b is v for v in d.dask.values())
     assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3647,3 +3647,15 @@ def test_3851():
 def test_3925():
     x = da.from_array(np.array(['a', 'b', 'c'], dtype=object), chunks=-1)
     assert (x[0] == x[0]).compute(scheduler='sync')
+
+
+def test_map_blocks_large_inputs_delayed():
+    a = da.ones(10, chunks=(5,))
+    b = np.ones(1000000)
+
+    c = a.map_blocks(add, b)
+    assert b in c.dask.values()
+    assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
+    d = a.map_blocks(lambda x, y: x + y, y=b)
+    assert b in d.dask.values()
+    assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3604,7 +3604,7 @@ def map_partitions(func, *args, **kwargs):
     if meta is not no_default:
         meta = make_meta(meta)
 
-    kwargs2 = {k: delayed(v) if sizeof(v) > 1e6 else v
+    kwargs2 = {k: delayed(v) if not is_dask_collection(v) and sizeof(v) > 1e6 else v
                for k, v in kwargs.items()}
 
     assert callable(func)


### PR DESCRIPTION
This avoids having many copies of an object in the graph, one in each task.

We should also do this in atop and in dd.map_partitions

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
