### PR TITLE
Improve performance of bag.read_text on small files

### DIFF
--- a/dask/bag/tests/test_text.py
+++ b/dask/bag/tests/test_text.py
@@ -52,6 +52,18 @@ def test_read_text(fmt, bs, encoding):
         assert ''.join(line for block in L for line in block) == expected
 
 
+def test_files_per_partition():
+    files3 = {'{:02}.txt'.format(n): 'line from {:02}' for n in range(20)}
+    with filetexts(files3):
+        b = read_text('*.txt', files_per_partition=10)
+
+        l = len(b.take(100, npartitions=1))
+        assert l == 10, "10 files should be grouped into one partition"
+
+        assert b.count().compute() == 20, "All 20 lines should be read"
+    pass
+
+
 def test_errors():
     with filetexts({'.test.foo': b'Jos\xe9\nAlice'}, mode='b'):
         with pytest.raises(UnicodeDecodeError):

--- a/dask/bag/tests/test_text.py
+++ b/dask/bag/tests/test_text.py
@@ -61,7 +61,6 @@ def test_files_per_partition():
         assert l == 10, "10 files should be grouped into one partition"
 
         assert b.count().compute() == 20, "All 20 lines should be read"
-    pass
 
 
 def test_errors():

--- a/dask/bag/text.py
+++ b/dask/bag/text.py
@@ -77,6 +77,9 @@ def read_text(urlpath, blocksize=None, compression='infer',
                 blocks.append(delayed(list)(delayed(files_to_blocks)(block_files)))
 
     else:
+        if files_per_partition is not None:
+            raise ValueError('Only one of blocksize or files_per_partition can be set')
+
         _, blocks = read_bytes(urlpath, delimiter=linedelimiter.encode(),
                                blocksize=blocksize, sample=False,
                                compression=compression,
@@ -99,9 +102,7 @@ def file_to_blocks(lazy_file):
 
 
 def files_to_blocks(lazy_files):
-    for file in lazy_files:
-        for line in file_to_blocks(file):
-            yield line
+    return concat(file_to_blocks(f) for f in lazy_files)
 
 
 def decode(block, encoding, errors):


### PR DESCRIPTION
Adding a new optional parameter to `bag.read_text()`, called `files_per_partition`, gives users the option to group files into fewer partitions than one per file. This can dramatically improve performance on large numbers of small files by reducing the complexity of the graph and increasing the duration of read partition operations.

Fixes #4012 

- [ x ] Tests added / passed
- [ x ] Passes `flake8 dask`
