### PR TITLE
Add basic infrastructure for cupy

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -61,6 +61,14 @@ concatenate_lookup.register((object, np.ndarray), np.concatenate)
 tensordot_lookup.register((object, np.ndarray), np.tensordot)
 
 
+@tensordot_lookup.register_lazy('cupy')
+@concatenate_lookup.register_lazy('cupy')
+def register_sparse():
+    import cupy
+    concatenate_lookup.register(cupy.ndarray, cupy.concatenate)
+    tensordot_lookup.register(cupy.ndarray, cupy.tensordot)
+
+
 @tensordot_lookup.register_lazy('sparse')
 @concatenate_lookup.register_lazy('sparse')
 def register_sparse():

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -1,0 +1,59 @@
+import random
+from distutils.version import LooseVersion
+
+import numpy as np
+import pytest
+
+import dask.array as da
+from dask.array.utils import assert_eq
+
+cupy = pytest.importorskip('cupy')
+
+
+functions = [
+    lambda x: x,
+    pytest.mark.xfail(lambda x: da.expm1(x), reason="cupy doesn't support expm1"),
+    lambda x: 2 * x,
+    lambda x: x / 2,
+    lambda x: x**2,
+    lambda x: x + x,
+    lambda x: x * x,
+    lambda x: x[0],
+    lambda x: x[:, 1],
+    lambda x: x[:1, None, 1:3],
+    lambda x: x.T,
+    lambda x: da.transpose(x, (1, 2, 0)),
+    lambda x: x.sum(),
+    pytest.mark.xfail(lambda x: x.dot(np.arange(x.shape[-1])), reason='cupy.dot(numpy) fails'),
+    pytest.mark.xfail(lambda x: x.dot(np.eye(x.shape[-1])), reason='cupy.dot(numpy) fails'),
+    pytest.mark.xfail(lambda x: da.tensordot(x, np.ones(x.shape[:2]), axes=[(0, 1), (0, 1)]),
+                      reason='cupy.dot(numpy) fails'),
+    lambda x: x.sum(axis=0),
+    lambda x: x.max(axis=0),
+    lambda x: x.sum(axis=(1, 2)),
+    lambda x: x.astype(np.complex128),
+    lambda x: x.map_blocks(lambda x: x * 2),
+    pytest.mark.xfail(lambda x: x.round(1), reason="cupy doesn't support round"),
+    lambda x: x.reshape((x.shape[0] * x.shape[1], x.shape[2])),
+    lambda x: abs(x),
+    lambda x: x > 0.5,
+    lambda x: x.rechunk((4, 4, 4)),
+    lambda x: x.rechunk((2, 2, 1)),
+]
+
+
+@pytest.mark.parametrize('func', functions)
+def test_basic(func):
+    c = cupy.random.random((2, 3, 4))
+    n = c.get()
+    dc = da.from_array(c, chunks=(1, 2, 2), asarray=False)
+    dn = da.from_array(n, chunks=(1, 2, 2))
+
+    ddc = func(dc)
+    ddn = func(dn)
+
+    assert_eq(ddc, ddn)
+
+    if ddc.shape:
+        result = ddc.compute(scheduler='single-threaded')
+        assert isinstance(result, cupy.ndarray)

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -12,7 +12,7 @@ cupy = pytest.importorskip('cupy')
 
 functions = [
     lambda x: x,
-    pytest.mark.xfail(lambda x: da.expm1(x), reason="cupy doesn't support expm1"),
+    pytest.mark.xfail(lambda x: da.expm1(x), reason="expm1 isn't a proper ufunc"),
     lambda x: 2 * x,
     lambda x: x / 2,
     lambda x: x**2,

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -21,7 +21,15 @@ except AttributeError:
         AxisError = type(e)
 
 
+def normalize_to_array(x):
+    if 'cupy' in str(type(x)):
+        return x.get()
+    else:
+        return x
+
 def allclose(a, b, equal_nan=False, **kwargs):
+    a = normalize_to_array(a)
+    b = normalize_to_array(b)
     if getattr(a, 'dtype', None) != 'O':
         return np.allclose(a, b, equal_nan=equal_nan, **kwargs)
     if equal_nan:


### PR DESCRIPTION
This applies dispatch functions for the cupy library for GPU arrays.
We then copy some of the sparse test suite to see what works and what doesn't.
Currently this has some hacky bits to handle assert_eq that will have to be
cleaned up.

I also ran into issues when using normal threads, and things are generally pretty slow, so I wouldn't look at this as any more than an experiment for now.

work in progress



- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
