### PR TITLE
Docs: Update single-machine.rst with corrections [skip ci]

### DIFF
--- a/docs/source/setup/single-machine.rst
+++ b/docs/source/setup/single-machine.rst
@@ -9,7 +9,7 @@ use this scheduler. However, you do have a choice between threads and processes:
 1.  **Threads**: Use multiple threads in the same process.  This option is good
     for numeric code that releases the GIL_ (like NumPy, Pandas, Scikit-Learn,
     Numba, ...) because data is free to share.  This is the default scheduler for
-    ``dask.array``, ``dask.dataframe``, and ``dask.delayed``.
+    ``dask.array``, ``dask.dataframe``, and ``dask.delayed``
 
 2.  **Processes**: Send data to separate processes for processing.  This option
     is good when operating on pure Python objects like strings or JSON-like
@@ -17,17 +17,17 @@ use this scheduler. However, you do have a choice between threads and processes:
     on numeric data like Pandas DataFrames or NumPy arrays.  Using processes
     avoids GIL issues, but can also result in a lot of inter-process
     communication, which can be slow.  This is the default scheduler for
-    ``dask.bag``, and it is sometimes useful with ``dask.dataframe``.
+    ``dask.bag``, and it is sometimes useful with ``dask.dataframe``
 
     Note that the ``dask.distributed`` scheduler is often a better choice when
     working with GIL-bound code.  See :doc:`dask.distributed on a single
-    machine <single-distributed>`.
+    machine <single-distributed>`
 
 3.  **Single-threaded**: Execute computations in a single thread.  This option
     provides no parallelism, but is useful when debugging or profiling.
     Turning your parallel execution into a sequential one can be a convenient
     option in many situations where you want to better understand what is going
-    on.
+    on
 
 .. _GIL: https://docs.python.org/3/glossary.html#term-gil
 
@@ -37,9 +37,9 @@ Selecting Threads, Processes, or Single Threaded
 
 Currently, these options are available by selecting different ``get`` functions:
 
--  ``dask.threaded.get``: The threaded scheduler.
--  ``dask.multiprocessing.get``: The multiprocessing scheduler.
--  ``dask.local.get_sync``: The single-threaded scheduler.
+-  ``dask.threaded.get``: The threaded scheduler
+-  ``dask.multiprocessing.get``: The multiprocessing scheduler
+-  ``dask.local.get_sync``: The single-threaded scheduler
 
 You can specify these functions in any of the following ways:
 

--- a/docs/source/setup/single-machine.rst
+++ b/docs/source/setup/single-machine.rst
@@ -67,6 +67,6 @@ You can specify these functions in any of the following ways:
 Use the Distributed Scheduler
 -----------------------------
 
-The newer ``dask.distributed`` scheduler also works well on a single machine and
+Dask's newer distributed scheduler also works well on a single machine and
 offers more features and diagnostics.  See :doc:`this page
 <single-distributed>` for more information.

--- a/docs/source/setup/single-machine.rst
+++ b/docs/source/setup/single-machine.rst
@@ -3,24 +3,24 @@ Single-Machine Scheduler
 
 The default Dask scheduler provides parallelism on a single machine by using
 either threads or processes.  It is the default choice used by Dask because it
-requires no setup.  You don't need to make any choices or set anything up to
-use this scheduler, however you do have a choice between threads and processes:
+requires no setup. You don't need to make any choices or set anything up to
+use this scheduler. However, you do have a choice between threads and processes:
 
 1.  **Threads**: Use multiple threads in the same process.  This option is good
     for numeric code that releases the GIL_ (like NumPy, Pandas, Scikit-Learn,
     Numba, ...) because data is free to share.  This is the default scheduler for
-    ``dask.array``, ``dask.dataframe``, and ``dask.delayed``
+    ``dask.array``, ``dask.dataframe``, and ``dask.delayed``.
 
 2.  **Processes**: Send data to separate processes for processing.  This option
     is good when operating on pure Python objects like strings or JSON-like
-    dictionary data that holds onto the GIL_ but not very good when operating
-    on numeric data like Pandas dataframes or NumPy arrays.  Using processes
-    avoids GIL issues but can also result in a lot of inter-process
+    dictionary data that holds onto the GIL_, but not very good when operating
+    on numeric data like Pandas DataFrames or NumPy arrays.  Using processes
+    avoids GIL issues, but can also result in a lot of inter-process
     communication, which can be slow.  This is the default scheduler for
-    ``dask.bag`` and is sometimes useful with ``dask.dataframe``.
+    ``dask.bag``, and it is sometimes useful with ``dask.dataframe``.
 
-    Note that the dask.distributed scheduler is often a better choice when
-    working with GIL-bound code.  See :doc:`Dask.distributed on a single
+    Note that the ``dask.distributed`` scheduler is often a better choice when
+    working with GIL-bound code.  See :doc:`dask.distributed on a single
     machine <single-distributed>`.
 
 3.  **Single-threaded**: Execute computations in a single thread.  This option
@@ -35,11 +35,11 @@ use this scheduler, however you do have a choice between threads and processes:
 Selecting Threads, Processes, or Single Threaded
 ------------------------------------------------
 
-Currently these options are available by selecting different ``get`` functions:
+Currently, these options are available by selecting different ``get`` functions:
 
--  ``dask.threaded.get``: The threaded scheduler
--  ``dask.multiprocessing.get``: The multiprocessing scheduler
--  ``dask.local.get_sync``: The single-threaded scheduler
+-  ``dask.threaded.get``: The threaded scheduler.
+-  ``dask.multiprocessing.get``: The multiprocessing scheduler.
+-  ``dask.local.get_sync``: The single-threaded scheduler.
 
 You can specify these functions in any of the following ways:
 
@@ -67,6 +67,6 @@ You can specify these functions in any of the following ways:
 Use the Distributed Scheduler
 -----------------------------
 
-The newer dask.distributed scheduler also works well on a single machine and
+The newer ``dask.distributed`` scheduler also works well on a single machine and
 offers more features and diagnostics.  See :doc:`this page
 <single-distributed>` for more information.


### PR DESCRIPTION
This PR updates `single-machine.rst` with some corrections mostly to punctuation and naming conventions. 

I've made a change to the capitalization to the link "**D**ask.distributed on a single machine" to "**d**ask.distributed on a single machine" mainly because, apart from the title of the next section, everywhere else in the documentation it is in lower-case, and since it is referring to a module I assumed it would be best to keep it in lower case as well.

If you agree with this minor circumstance, then I'll make the same change  in the next section in `single-distributed.rst`.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
