### PR TITLE
Fix typo in `test_store_kwargs`

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1287,7 +1287,7 @@ def test_store_kwargs():
 
     called[0] = False
     at = np.zeros(shape=(10, 10))
-    store([a], [at], get=get_func, return_store=True, foo="test kwarg")
+    store([a], [at], get=get_func, return_stored=True, foo="test kwarg")
     assert called[0]
 
 


### PR DESCRIPTION
Was using `return_store` instead of `return_stored` where the latter is the supported keyword argument.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
