### PR TITLE
Move local `indices` import to global import

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -16,7 +16,7 @@ from ..core import flatten
 from ..base import tokenize
 from ..utils import funcname
 from . import chunk
-from .creation import arange, empty
+from .creation import arange, empty, indices
 from .utils import safe_wraps, validate_axis
 from .wrap import ones
 from .ufunc import multiply
@@ -1123,8 +1123,6 @@ def isnonzero(a):
 
 @wraps(np.argwhere)
 def argwhere(a):
-    from .creation import indices
-
     a = asarray(a)
 
     nz = isnonzero(a).flatten()


### PR DESCRIPTION
This import of `indices` in `argwhere` is likely a holdover from when `argwhere` was defined in `dask.array.core`. As `argwhere` has since been moved to `dask.array.routines`, importing `indices` globally is not an issue. So go ahead and switch this import to a global import as that is preferred.