### PR TITLE
Move local imports in `corrcoef` to global imports

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -16,10 +16,10 @@ from ..core import flatten
 from ..base import tokenize
 from ..utils import funcname
 from . import chunk
-from .creation import arange, empty
+from .creation import arange, diag, empty
 from .utils import safe_wraps, validate_axis
 from .wrap import ones
-from .ufunc import multiply
+from .ufunc import multiply, sqrt
 
 from .core import (Array, map_blocks, elemwise, from_array, asarray,
                    asanyarray, concatenate, stack, atop, broadcast_shapes,
@@ -715,10 +715,6 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
 
 @wraps(np.corrcoef)
 def corrcoef(x, y=None, rowvar=1):
-
-    from .ufunc import sqrt
-    from .creation import diag
-
     c = cov(x, y, rowvar)
     if c.shape == ():
         return c / c


### PR DESCRIPTION
These imports of `sqrt` and `diag` in `corrcoef` are likely holdovers from when `corrcoef` was defined in `dask.array.core`. As `corrcoef` has since been moved to `dask.array.routines`, importing `sqrt` and `diag` globally is not an issue. So go ahead and switch these imports to global imports as that is preferred.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`