### PR TITLE
Docs: Fix missing space in ssh.rst [skip ci]

### DIFF
--- a/docs/source/setup/ssh.rst
+++ b/docs/source/setup/ssh.rst
@@ -39,7 +39,7 @@ flags to adjust how many dask-worker process are run on each host
 
 Options:
 
-..note:: 
+.. note::
 
    This table may grow out of date, you should check ``dask-ssh --help`` to get an up-to-date listing of all options.
 


### PR DESCRIPTION
This PR fixes a missing space in `ssh.rst` w.r.t. the `note` text highlight box.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
