### PR TITLE
Make da.RandomState extensible to other modules

### DIFF
--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -31,25 +31,37 @@ class RandomState(object):
     ``np.random.RandomState`` except that all functions also take a ``chunks=``
     keyword argument.
 
+    Parameters
+    ----------
+    seed: Number
+        Object to pass to RandomState to serve as deterministic seed
+    RandomState: Callable[seed] -> RandomState
+        A callable that, when provided with a ``seed`` keyword provides an
+        object that operates identically to ``np.random.RandomState`` (the
+        default).  This might also be a function that returns a
+        ``randomgen.RandomState``, ``mkl_random``, or
+        ``cupy.random.RandomState`` object.
+
     Examples
     --------
-
     >>> import dask.array as da
     >>> state = da.random.RandomState(1234)  # a seed
     >>> x = state.normal(10, 0.1, size=3, chunks=(2,))
     >>> x.compute()
     array([10.01867852, 10.04812289,  9.89649746])
 
-    See Also:
-        np.random.RandomState
+    See Also
+    --------
+    np.random.RandomState
     """
-    def __init__(self, seed=None):
-        self._numpy_state = np.random.RandomState(seed)
+    def __init__(self, seed=None, RandomState=np.random.RandomState):
+        self._numpy_state = RandomState(seed)
+        self._RandomState = RandomState
 
     def seed(self, seed=None):
         self._numpy_state.seed(seed)
 
-    def _wrap(self, func, *args, **kwargs):
+    def _wrap(self, funcname, *args, **kwargs):
         """ Wrap numpy random function to produce dask.array random function
 
         extra_chunks should be a chunks tuple to append to the end of chunks
@@ -118,19 +130,19 @@ class RandomState(object):
 
         # Get dtype
         small_kwargs['size'] = (0,)
-        dtype = func(np.random.RandomState(), *small_args,
-                     **small_kwargs).dtype
+        func = getattr(np.random.RandomState(), funcname)
+        dtype = func(*small_args, **small_kwargs).dtype
 
         sizes = list(product(*chunks))
-        state_data = random_state_data(len(sizes), self._numpy_state)
-        token = tokenize(state_data, size, chunks, args, kwargs)
-        name = '{0}-{1}'.format(func.__name__, token)
+        seeds = random_state_data(len(sizes), self._numpy_state)
+        token = tokenize(seeds, size, chunks, args, kwargs)
+        name = '{0}-{1}'.format(funcname, token)
 
         keys = product([name], *([range(len(bd)) for bd in chunks] +
                                  [[0]] * len(extra_chunks)))
         blocks = product(*[range(len(bd)) for bd in chunks])
         vals = []
-        for state, size, slc, block in zip(state_data, sizes, slices, blocks):
+        for seed, size, slc, block in zip(seeds, sizes, slices, blocks):
             arg = []
             for i, ar in enumerate(args):
                 if i not in lookup:
@@ -149,25 +161,22 @@ class RandomState(object):
                         kwrg[k] = (lookup[k], ) + block
                     else:   # np.ndarray
                         kwrg[k] = (getitem, lookup[k], slc)
-            vals.append((_apply_random, func.__name__, state, size, arg, kwrg))
+            vals.append((_apply_random, self._RandomState, funcname, seed, size, arg, kwrg))
         dsk.update(dict(zip(keys, vals)))
         dsk = sharedict.merge((name, dsk), *dsks)
         return Array(dsk, name, chunks + extra_chunks, dtype=dtype)
 
     @doc_wraps(np.random.RandomState.beta)
     def beta(self, a, b, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.beta, a, b,
-                          size=size, chunks=chunks)
+        return self._wrap('beta', a, b, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.binomial)
     def binomial(self, n, p, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.binomial, n, p,
-                          size=size, chunks=chunks)
+        return self._wrap('binomial', n, p, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.chisquare)
     def chisquare(self, df, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.chisquare, df,
-                          size=size, chunks=chunks)
+        return self._wrap('chisquare', df, size=size, chunks=chunks)
 
     with ignoring(AttributeError):
         @doc_wraps(np.random.RandomState.choice)
@@ -239,178 +248,143 @@ class RandomState(object):
 
     @doc_wraps(np.random.RandomState.exponential)
     def exponential(self, scale=1.0, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.exponential, scale,
-                          size=size, chunks=chunks)
+        return self._wrap('exponential', scale, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.f)
     def f(self, dfnum, dfden, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.f, dfnum, dfden,
-                          size=size, chunks=chunks)
+        return self._wrap('f', dfnum, dfden, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.gamma)
     def gamma(self, shape, scale=1.0, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.gamma, shape, scale,
-                          size=size, chunks=chunks)
+        return self._wrap('gamma', shape, scale, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.geometric)
     def geometric(self, p, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.geometric, p,
-                          size=size, chunks=chunks)
+        return self._wrap('geometric', p, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.gumbel)
     def gumbel(self, loc=0.0, scale=1.0, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.gumbel, loc, scale,
-                          size=size, chunks=chunks)
+        return self._wrap('gumbel', loc, scale, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.hypergeometric)
     def hypergeometric(self, ngood, nbad, nsample, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.hypergeometric,
-                          ngood, nbad, nsample,
+        return self._wrap('hypergeometric', ngood, nbad, nsample,
                           size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.laplace)
     def laplace(self, loc=0.0, scale=1.0, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.laplace, loc, scale,
-                          size=size, chunks=chunks)
+        return self._wrap('laplace', loc, scale, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.logistic)
     def logistic(self, loc=0.0, scale=1.0, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.logistic, loc, scale,
-                          size=size, chunks=chunks)
+        return self._wrap('logistic', loc, scale, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.lognormal)
     def lognormal(self, mean=0.0, sigma=1.0, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.lognormal, mean, sigma,
-                          size=size, chunks=chunks)
+        return self._wrap('lognormal', mean, sigma, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.logseries)
     def logseries(self, p, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.logseries, p,
-                          size=size, chunks=chunks)
+        return self._wrap('logseries', p, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.multinomial)
     def multinomial(self, n, pvals, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.multinomial, n, pvals,
-                          size=size, chunks=chunks,
+        return self._wrap('multinomial', n, pvals, size=size, chunks=chunks,
                           extra_chunks=((len(pvals),),))
 
     @doc_wraps(np.random.RandomState.negative_binomial)
     def negative_binomial(self, n, p, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.negative_binomial, n, p,
-                          size=size, chunks=chunks)
+        return self._wrap('negative_binomial', n, p, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.noncentral_chisquare)
     def noncentral_chisquare(self, df, nonc, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.noncentral_chisquare, df, nonc,
-                          size=size, chunks=chunks)
+        return self._wrap('noncentral_chisquare', df, nonc, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.noncentral_f)
     def noncentral_f(self, dfnum, dfden, nonc,  size=None, chunks=None):
-        return self._wrap(np.random.RandomState.noncentral_f,
-                          dfnum, dfden, nonc,
-                          size=size, chunks=chunks)
+        return self._wrap('noncentral_f', dfnum, dfden, nonc, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.normal)
     def normal(self, loc=0.0, scale=1.0, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.normal, loc, scale,
-                          size=size, chunks=chunks)
+        return self._wrap('normal', loc, scale, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.pareto)
     def pareto(self, a, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.pareto, a,
-                          size=size, chunks=chunks)
+        return self._wrap('pareto', a, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.poisson)
     def poisson(self, lam=1.0, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.poisson, lam,
-                          size=size, chunks=chunks)
+        return self._wrap('poisson', lam, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.power)
     def power(self, a, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.power, a,
-                          size=size, chunks=chunks)
+        return self._wrap('power', a, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.randint)
     def randint(self, low, high=None, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.randint, low, high,
-                          size=size, chunks=chunks)
+        return self._wrap('randint', low, high, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.random_integers)
     def random_integers(self, low, high=None, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.random_integers, low, high,
-                          size=size, chunks=chunks)
+        return self._wrap('random_integers', low, high, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.random_sample)
     def random_sample(self, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.random_sample,
-                          size=size, chunks=chunks)
+        return self._wrap('random_sample', size=size, chunks=chunks)
 
     random = random_sample
 
     @doc_wraps(np.random.RandomState.rayleigh)
     def rayleigh(self, scale=1.0, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.rayleigh, scale,
-                          size=size, chunks=chunks)
+        return self._wrap('rayleigh', scale, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.standard_cauchy)
     def standard_cauchy(self, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.standard_cauchy,
-                          size=size, chunks=chunks)
+        return self._wrap('standard_cauchy', size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.standard_exponential)
     def standard_exponential(self, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.standard_exponential,
-                          size=size, chunks=chunks)
+        return self._wrap('standard_exponential', size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.standard_gamma)
     def standard_gamma(self, shape, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.standard_gamma, shape,
-                          size=size, chunks=chunks)
+        return self._wrap('standard_gamma', shape, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.standard_normal)
     def standard_normal(self, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.standard_normal,
-                          size=size, chunks=chunks)
+        return self._wrap('standard_normal', size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.standard_t)
     def standard_t(self, df, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.standard_t, df,
-                          size=size, chunks=chunks)
+        return self._wrap('standard_t', df, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.tomaxint)
     def tomaxint(self, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.tomaxint,
-                          size=size, chunks=chunks)
+        return self._wrap('tomaxint', size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.triangular)
     def triangular(self, left, mode, right, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.triangular, left, mode, right,
-                          size=size, chunks=chunks)
+        return self._wrap('triangular', left, mode, right, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.uniform)
     def uniform(self, low=0.0, high=1.0, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.uniform, low, high,
-                          size=size, chunks=chunks)
+        return self._wrap('uniform', low, high, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.vonmises)
     def vonmises(self, mu, kappa, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.vonmises, mu, kappa,
-                          size=size, chunks=chunks)
+        return self._wrap('vonmises', mu, kappa, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.wald)
     def wald(self, mean, scale, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.wald, mean, scale,
-                          size=size, chunks=chunks)
+        return self._wrap('wald', mean, scale, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.weibull)
     def weibull(self, a, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.weibull, a,
-                          size=size, chunks=chunks)
+        return self._wrap('weibull', a, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.zipf)
     def zipf(self, a, size=None, chunks=None):
-        return self._wrap(np.random.RandomState.zipf, a,
-                          size=size, chunks=chunks)
+        return self._wrap('zipf', a, size=size, chunks=chunks)
 
 
 def _choice(state_data, a, size, replace, p):
@@ -418,10 +392,10 @@ def _choice(state_data, a, size, replace, p):
     return state.choice(a, size=size, replace=replace, p=p)
 
 
-def _apply_random(func, state_data, size, args, kwargs):
+def _apply_random(RandomState, funcname, state_data, size, args, kwargs):
     """Apply RandomState method with seed"""
-    state = np.random.RandomState(state_data)
-    func = getattr(state, func)
+    state = RandomState(state_data)
+    func = getattr(state, funcname)
     return func(*args, size=size, **kwargs)
 
 

--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -54,8 +54,8 @@ class RandomState(object):
     --------
     np.random.RandomState
     """
-    def __init__(self, seed=None, RandomState=np.random.RandomState):
-        self._numpy_state = RandomState(seed)
+    def __init__(self, seed=None, RandomState=None):
+        self._numpy_state = np.random.RandomState(seed)
         self._RandomState = RandomState
 
     def seed(self, seed=None):
@@ -394,6 +394,8 @@ def _choice(state_data, a, size, replace, p):
 
 def _apply_random(RandomState, funcname, state_data, size, args, kwargs):
     """Apply RandomState method with seed"""
+    if RandomState is None:
+        RandomState = np.random.RandomState
     state = RandomState(state_data)
     func = getattr(state, funcname)
     return func(*args, size=size, **kwargs)

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -291,3 +291,24 @@ def test_names():
 
     assert name.startswith('normal')
     assert len(key_split(name)) < 10
+
+
+def test_external_randomstate_class():
+    randomgen = pytest.importorskip('randomgen')
+
+    rs = da.random.RandomState(RandomState=lambda seed: randomgen.RandomGenerator(randomgen.DSFMT(seed)))
+    x = rs.normal(0, 1, size=(10), chunks=(5,))
+    assert_eq(x, x)
+
+    rs = da.random.RandomState(
+        RandomState=lambda seed: randomgen.RandomGenerator(randomgen.DSFMT(seed)),
+        seed=123
+    )
+    a = rs.normal(0, 1, size=(10), chunks=(5,))
+    rs = da.random.RandomState(
+        RandomState=lambda seed: randomgen.RandomGenerator(randomgen.DSFMT(seed)),
+        seed=123
+    )
+    b = rs.normal(0, 1, size=(10), chunks=(5,))
+    assert a.name == b.name
+    assert_eq(a, b)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -268,7 +268,7 @@ def random_state_data(n, random_state=None):
     """
     import numpy as np
 
-    if not isinstance(random_state, np.random.RandomState):
+    if not all(hasattr(random_state, attr) for attr in ['normal', 'beta', 'bytes', 'uniform']):
         random_state = np.random.RandomState(random_state)
 
     random_data = random_state.bytes(624 * n * 4)  # `n * 624` 32-bit integers


### PR DESCRIPTION
This enables other libraries like cupy or randomgen to compose their
random modules with dask array.

Fixes https://github.com/dask/dask/issues/3993

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
