### PR TITLE
fuse_subgraphs works without normal fuse

### DIFF
--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -567,7 +567,11 @@ def fuse(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
     reducible = {k for k, vals in rdeps.items() if len(vals) == 1}
     if keys:
         reducible -= keys
-    if not reducible:
+    if (not reducible and
+            (not fuse_subgraphs or not
+             {k for k, vals in rdeps.items() if len(set(vals)) == 1})):
+        # Quick return if there's nothing to do. Only progress if there's tasks
+        # fusible by the main `fuse`, or by `fuse_subgraphs` if enabled.
         return dsk, deps
 
     rv = dsk.copy()

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -568,8 +568,7 @@ def fuse(dsk, keys=None, dependencies=None, ave_width=None, max_width=None,
     if keys:
         reducible -= keys
     if (not reducible and
-            (not fuse_subgraphs or not
-             {k for k, vals in rdeps.items() if len(set(vals)) == 1})):
+            (not fuse_subgraphs or all(len(set(v)) != 1 for v in rdeps.values()))):
         # Quick return if there's nothing to do. Only progress if there's tasks
         # fusible by the main `fuse`, or by `fuse_subgraphs` if enabled.
         return dsk, deps

--- a/dask/tests/test_optimization.py
+++ b/dask/tests/test_optimization.py
@@ -1200,3 +1200,27 @@ def test_fuse_subgraphs():
             'inc-6': (inc, (inc, 'add-2'))
         }))
     assert res in sols
+
+
+def test_fuse_subgraphs_linear_chains_of_duplicate_deps():
+    dsk = {'x-1': 1,
+           'add-1': (add, 'x-1', 'x-1'),
+           'add-2': (add, 'add-1', 'add-1'),
+           'add-3': (add, 'add-2', 'add-2'),
+           'add-4': (add, 'add-3', 'add-3'),
+           'add-5': (add, 'add-4', 'add-4')}
+
+    res = fuse(dsk, 'add-5', fuse_subgraphs=True)
+    sol = with_deps({
+        'add-x-1': (
+            SubgraphCallable({
+                'x-1': 1,
+                'add-1': (add, 'x-1', 'x-1'),
+                'add-2': (add, 'add-1', 'add-1'),
+                'add-3': (add, 'add-2', 'add-2'),
+                'add-4': (add, 'add-3', 'add-3'),
+                'add-5': (add, 'add-4', 'add-4')
+            }, 'add-5', ()),),
+        'add-5': 'add-x-1'
+    })
+    assert res == sol


### PR DESCRIPTION
Previously if `fuse` backed out early, `fuse_subgraphs` would never run.
Now we also check if `fuse_subgraphs` may be useful, and if so don't
backout early.

Fixes #4036.