### PR TITLE
Avoid asarray and lock arguments for from_array(getitem)

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -183,7 +183,7 @@ def getem(arr, chunks, getitem=getter, shape=None, out_name=None, lock=False,
     keys = list(product([out_name], *[range(len(bds)) for bds in chunks]))
     slices = slices_from_chunks(chunks)
 
-    if getitem != operator.getitem and (not asarray or lock):
+    if getitem is not operator.getitem and (not asarray or lock):
         values = [(getitem, arr, x, asarray, lock) for x in slices]
     else:
         # Common case, drop extra parameters

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -183,7 +183,7 @@ def getem(arr, chunks, getitem=getter, shape=None, out_name=None, lock=False,
     keys = list(product([out_name], *[range(len(bds)) for bds in chunks]))
     slices = slices_from_chunks(chunks)
 
-    if not asarray or lock:
+    if getitem != operator.getitem and (not asarray or lock):
         values = [(getitem, arr, x, asarray, lock) for x in slices]
     else:
         # Common case, drop extra parameters
@@ -2389,7 +2389,7 @@ def from_array(x, chunks, name=None, lock=False, asarray=True, fancy=True,
         dsk = {(name, ) + (0, ) * x.ndim: x}
     else:
         if getitem is None:
-            if type(x) is np.ndarray:
+            if type(x) is np.ndarray and not lock:
                 # simpler and cleaner, but missing all the nuances of getter
                 getitem = operator.getitem
             elif fancy:

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -820,3 +820,13 @@ def test_setitem_with_different_chunks_preserves_shape(params):
 def test_gh3579():
     assert_eq(np.arange(10)[0::-1], da.arange(10, chunks=3)[0::-1])
     assert_eq(np.arange(10)[::-1], da.arange(10, chunks=3)[::-1])
+
+
+@pytest.mark.parametrize('lock', [True, False])
+@pytest.mark.parametrize('asarray', [True, False])
+@pytest.mark.parametrize('fancy', [True, False])
+def test_gh4043(lock, asarray, fancy):
+    a1 = da.from_array(np.zeros(3,), chunks=1, asarray=asarray, lock=lock, fancy=fancy)
+    a2 = da.from_array(np.ones(3,), chunks=1, asarray=asarray, lock=lock, fancy=fancy)
+    al = da.stack([a1, a2])
+    assert_eq(al, al)


### PR DESCRIPTION
Fixes #4043

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
