### PR TITLE
Docs: Update kubernetes.rst [skip ci]

### DIFF
--- a/docs/source/setup/kubernetes.rst
+++ b/docs/source/setup/kubernetes.rst
@@ -9,12 +9,12 @@ Kubernetes
    Native <kubernetes-native.rst>
 
 Kubernetes_ is a popular system for deploying distributed applications on clusters,
-particularly in the cloud.
-You can use Kubernetes to launch Dask workers in the following two ways:
+particularly in the cloud.  You can use Kubernetes to launch Dask workers in the 
+following two ways:
 
 1.  **Helm**:
     You can launch a Dask scheduler, several workers, and an optional Jupyter Notebook server
-    on a Kubernetes easily using Helm_.
+    on a Kubernetes easily using Helm_
 
     .. code-block:: bash
 
@@ -24,17 +24,19 @@ You can use Kubernetes to launch Dask workers in the following two ways:
     This is a good choice if you want to do the following:
 
     1.  Run a managed Dask cluster for a long period of time
-    2.  Also deploy a Jupyter server from which to run code,
+    2.  Also deploy a Jupyter server from which to run code
     3.  Share the same Dask cluster between many automated services
     4.  Try out Dask for the first time on a cloud-based system
         like Amazon, Google, or Microsoft Azure
         (see also our :doc:`Cloud documentation <cloud>`)
-
-    See :doc:`Dask and Helm documentation <kubernetes-helm>` for more information.
+    
+    .. note::
+    
+      For more information, see :doc:`Dask and Helm documentation <kubernetes-helm>`.
 
 2.  **Native**:
     You can quickly deploy Dask workers on Kubernetes
-    from within a Python script or interactive session using Dask-Kubernetes_.
+    from within a Python script or interactive session using Dask-Kubernetes_
 
     .. code-block:: python
 
@@ -53,7 +55,9 @@ You can use Kubernetes to launch Dask workers in the following two ways:
         rather than depend on a centralized system
     3.  Quickly adapt Dask cluster size to the current workload
 
-    See Dask-Kubernetes_ documentation for more information.
+    .. note::
+    
+      For more information, see Dask-Kubernetes_ documentation.
 
 You may also want to see the documentation on using
 :doc:`Dask with Docker containers <docker>`


### PR DESCRIPTION
This PR updates `kubernetes.rst` with minor corrections and highlights two paragraphs that each point to documentation. The previous format was somewhat clunky near two sections, and the highlights seemed reasonable and not too distracting for this particular case.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
