### PR TITLE
Add support for bag groupby npartitions=1 and shuffle=tasks edge case

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1970,7 +1970,7 @@ def groupby_tasks(b, grouper, hash=hash, max_branch=32):
     max_branch = max_branch or 32
     n = b.npartitions
 
-    stages = int(math.ceil(math.log(n) / math.log(max_branch)))
+    stages = int(math.ceil(math.log(n) / math.log(max_branch))) or 1
     if stages > 1:
         k = int(math.ceil(n ** (1 / stages)))
     else:

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1138,7 +1138,8 @@ def test_groupby_tasks_names():
 
 
 @pytest.mark.parametrize('size,npartitions,groups', [(1000, 20, 100),
-                                                     (12345, 234, 1042)])
+                                                     (12345, 234, 1042),
+                                                     (100, 1, 50)])
 def test_groupby_tasks_2(size, npartitions, groups):
     func = lambda x: x % groups
     b = db.range(size, npartitions=npartitions).groupby(func, shuffle='tasks')


### PR DESCRIPTION
This PR adds support for `bag.groupby` for single-partition bags when `shuffle='tasks'`. Currently, when `npartitions=1`, `stages` in `groupby_tasks` is set to `0`. For this edge case, `stages` should be `1` to properly construct the `groupby` dask graph.

Also added a test for this edge case.

Fixes #3748 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
