### PR TITLE
Support unknown dims in ravel no-op case

### DIFF
--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -155,6 +155,10 @@ def reshape(x, shape):
     if len(known_sizes) < len(shape):
         if len(known_sizes) - len(shape) > 1:
             raise ValueError('can only specify one unknown dimension')
+        # Fastpath for x.reshape(-1) on 1D arrays, allows unknown shape in x
+        # for this case only.
+        if len(shape) == 1 and x.ndim == 1:
+            return x
         missing_size = sanitize_index(x.size / reduce(mul, known_sizes, 1))
         shape = tuple(missing_size if s == -1 else s for s in shape)
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -807,6 +807,15 @@ def test_ravel():
     assert_eq(np.ravel(x), da.ravel(a))
 
 
+def test_ravel_1D_no_op():
+    x = np.random.randint(10, size=100)
+    dx = da.from_array(x, chunks=10)
+    # known dims
+    assert_eq(dx.ravel(), x.ravel())
+    # Unknown dims
+    assert_eq(dx[dx > 2].ravel(), x[x > 2].ravel())
+
+
 @pytest.mark.parametrize('is_func', [True, False])
 @pytest.mark.parametrize('axis', [None, 0, -1, (0, -1)])
 def test_squeeze(is_func, axis):


### PR DESCRIPTION
For the case of a 1-D `x`, `x.ravel()` (and `x.reshape(-1)`) should work
regardless if `x` has known dimensions. Note that other cases of
reshaping with unknown dimensions are not necessarily safe, so for now
only this simple case is supported.