### PR TITLE
Pass get functions through scheduler keyword

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -856,6 +856,8 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
     if scheduler is not None:
         if callable(scheduler):
             return scheduler
+        elif "Client" in type(scheduler).__name__ and hasattr(scheduler, 'get'):
+            return scheduler.get
         elif scheduler.lower() in named_schedulers:
             return named_schedulers[scheduler.lower()]
         elif scheduler.lower() in ('dask.distributed', 'distributed'):

--- a/dask/base.py
+++ b/dask/base.py
@@ -825,10 +825,13 @@ def warn_on_get(get):
     else:
         if get in named_schedulers.values():
             _warnned_on_get[0] = True
-            warnings.warn("The get= keyword has been deprecated. "
-                          "Please use the scheduler= keyword instead with the "
-                          "name of the desired scheduler "
-                          "like 'threads' or 'processes'")
+            warnings.warn(
+                "The get= keyword has been deprecated. "
+                "Please use the scheduler= keyword instead with the name of "
+                "the desired scheduler like 'threads' or 'processes'\n"
+                "    x.compute(scheduler='threads') \n"
+                "or with a function that takes the graph and keys\n"
+                "    x.compute(scheduler=my_scheduler_function)")
 
 
 def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
@@ -851,7 +854,9 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
         return get
 
     if scheduler is not None:
-        if scheduler.lower() in named_schedulers:
+        if callable(scheduler):
+            return scheduler
+        elif scheduler.lower() in named_schedulers:
             return named_schedulers[scheduler.lower()]
         elif scheduler.lower() in ('dask.distributed', 'distributed'):
             from distributed.worker import get_client

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -811,7 +811,7 @@ def test_optimize_None():
         assert dsk == dict(y.dask)  # but they aren't
         return dask.get(dsk, keys)
 
-    with dask.config.set(array_optimize=None, get=my_get):
+    with dask.config.set(array_optimize=None, scheduler=my_get):
         y.compute()
 
 
@@ -856,3 +856,14 @@ def test_get_scheduler():
     with dask.config.set(scheduler='threads'):
         assert get_scheduler(scheduler='threads') is dask.threaded.get
     assert get_scheduler() is None
+
+
+def test_callable_scheduler():
+    called = [False]
+
+    def get(dsk, keys, *args, **kwargs):
+        called[0] = True
+        return dask.get(dsk, keys)
+
+    assert delayed(lambda: 1)().compute(scheduler=get) == 1
+    assert called[0]

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -176,3 +176,11 @@ def test_zarr_in_memory_distributed_err(loop):
                 a = da.ones((3, 3), chunks=c)
                 z = zarr.zeros_like(a, chunks=c)
                 a.to_zarr(z)
+
+
+def test_scheduler_equals_client(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as client:
+            x = delayed(lambda: 1)()
+            assert x.compute(scheduler=client) == 1
+            assert client.run_on_scheduler(lambda dask_scheduler: dask_scheduler.story(x.key))


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

You can now do things like `scheduler=dask.threaded.get`

Question: Should I also start to raise a proper error when people use the `get=` keyword?  Currently we warn.