### PR TITLE
Added `percentiles` options for `dask.dataframe.describe` method

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1458,19 +1458,22 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
                 return DataFrame(dask, keyname, meta, quantiles[0].divisions)
 
     @derived_from(pd.DataFrame)
-    def describe(self, split_every=False):
+    def describe(self, split_every=False, percentiles=None):
         # currently, only numeric describe is supported
         num = self._get_numeric_data()
         if self.ndim == 2 and len(num.columns) == 0:
             raise ValueError("DataFrame contains only non-numeric data.")
         elif self.ndim == 1 and self.dtype == 'object':
             raise ValueError("Cannot compute ``describe`` on object dtype.")
-
+        if percentiles is None:
+            percentiles = [0.25, 0.5, 0.75]
+        else:
+            percentiles = list(set(sorted(percentiles + [0.5])))
         stats = [num.count(split_every=split_every),
                  num.mean(split_every=split_every),
                  num.std(split_every=split_every),
                  num.min(split_every=split_every),
-                 num.quantile([0.25, 0.5, 0.75]),
+                 num.quantile(percentiles),
                  num.max(split_every=split_every)]
         stats_names = [(s._name, 0) for s in stats]
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -121,7 +121,7 @@ def describe_aggregate(values):
     typ = pd.DataFrame if isinstance(count, pd.Series) else pd.Series
     part1 = typ([count, mean, std, min],
                 index=['count', 'mean', 'std', 'min'])
-    q.index = ['{0:g}%'.format(l*100) for l in q.index.tolist()]
+    q.index = ['{0:g}%'.format(l * 100) for l in q.index.tolist()]
     part3 = typ([max], index=['max'])
     return pd.concat([part1, q, part3])
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -121,7 +121,7 @@ def describe_aggregate(values):
     typ = pd.DataFrame if isinstance(count, pd.Series) else pd.Series
     part1 = typ([count, mean, std, min],
                 index=['count', 'mean', 'std', 'min'])
-    q.index = ['25%', '50%', '75%']
+    q.index = ['{0:g}%'.format(l*100) for l in q.index.tolist()]
     part3 = typ([max], index=['max'])
     return pd.concat([part1, q, part3])
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -288,6 +288,9 @@ def test_describe():
 
     assert_eq(s.describe(), ds.describe())
     assert_eq(df.describe(), ddf.describe())
+    test_quantiles = [0.25, 0.75]
+    assert_eq(df.describe(percentiles=test_quantiles),
+              ddf.describe(percentiles=test_quantiles))
     assert_eq(s.describe(), ds.describe(split_every=2))
     assert_eq(df.describe(), ddf.describe(split_every=2))
 


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `flake8 dask`


This PR adds the `percentiles=[...]` as found in the upstream pandas's `describe` function. Testing cases added.