### PR TITLE
Fix Typo on hpc example. (missing `=` in kwarg).

### DIFF
--- a/docs/source/setup/hpc.rst
+++ b/docs/source/setup/hpc.rst
@@ -37,7 +37,7 @@ They provide interfaces that look like the following:
    from dask_jobqueue import PBSCluster
 
    cluster = PBSCluster(cores=36,
-                        memory"100GB",
+                        memory="100GB",
                         project='P48500028',
                         queue='premium',
                         walltime='02:00:00')


### PR DESCRIPTION
- [ ] Tests added / passed ... no
- [ ] Passes `flake8 dask` ... no
