### PR TITLE
Docs: Update docker.rst [skip ci]

### DIFF
--- a/docs/source/setup/docker.rst
+++ b/docs/source/setup/docker.rst
@@ -41,7 +41,7 @@ Extensibility
 
 Users can mildly customize the software environment by populating the
 environment variables ``EXTRA_APT_PACKAGES``, ``EXTRA_CONDA_PACKAGES``, and
-``EXTRA_PIP_PACKAGES``.  If these environmet variables are set, they will
+``EXTRA_PIP_PACKAGES``.  If these environment variables are set, they will
 trigger calls to the following respectively::
 
    apt-get install $EXTRA_APT_PACKAGES

--- a/docs/source/setup/docker.rst
+++ b/docs/source/setup/docker.rst
@@ -11,12 +11,12 @@ a Debian image.
 These images are large, around 1GB.
 
 -   ``daskdev/dask``: This a normal debian + miniconda image with the full Dask
-     conda package (including the distributed scheduler), Numpy, and Pandas.
-     This image is about 1GB in size.
+    conda package (including the distributed scheduler), Numpy, and Pandas.
+    This image is about 1GB in size.
 
 -   ``daskdev/dask-notebook``: This is based on the
     `Jupyter base-notebook image <https://hub.docker.com/r/jupyter/base-notebook/>`_
-    and so is appropriate for use both normally as a Jupyter server, and also as
+    and so it is suitable for use both normally as a Jupyter server, and also as
     part of a JupyterHub deployment.  It also includes a matching Dask software
     environment described above.  This image is about 2GB in size.
 
@@ -41,7 +41,7 @@ Extensibility
 
 Users can mildly customize the software environment by populating the
 environment variables ``EXTRA_APT_PACKAGES``, ``EXTRA_CONDA_PACKAGES``, and
-``EXTRA_PIP_PACKAGES``.  If these environmet variables are set they will
+``EXTRA_PIP_PACKAGES``.  If these environmet variables are set, they will
 trigger calls to the following respectively::
 
    apt-get install $EXTRA_APT_PACKAGES
@@ -52,11 +52,11 @@ Note that using these can significantly delay the container from starting,
 especially when using ``apt``, or ``conda`` (``pip`` is relatively fast).
 
 Remember that it is important for software versions to match between Dask
-workers and Dask clients.  As a result it is often useful to include the same
+workers and Dask clients.  As a result, it is often useful to include the same
 extra packages in both Jupyter and Worker images.
 
 Source
 ------
 
-Docker files are maintained at https://github.com/dask/dask-docker .
+Docker files are maintained at https://github.com/dask/dask-docker.
 This repository also includes a docker-compose configuration.


### PR DESCRIPTION
This PR updates `docker.rst` with some minor corrections and fixes an indentation mistake in the first bullet point (`daskdev/dask`).

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
