### PR TITLE
Raise an error on the use of the get= keyword and set_options

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -51,7 +51,6 @@ try:
     from .wrap import ones, zeros, empty, full
     from .creation import ones_like, zeros_like, empty_like, full_like
     from .rechunk import rechunk
-    from ..context import set_options
     from ..base import compute
     from .optimization import optimize
     from .creation import (arange, linspace, meshgrid, indices, diag, eye,

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1261,17 +1261,17 @@ def test_store_kwargs():
 
     called[0] = False
     at = np.zeros(shape=(10, 10))
-    store([a], [at], get=get_func, foo="test kwarg")
+    store([a], [at], scheduler=get_func, foo="test kwarg")
     assert called[0]
 
     called[0] = False
     at = np.zeros(shape=(10, 10))
-    a.store(at, get=get_func, foo="test kwarg")
+    a.store(at, scheduler=get_func, foo="test kwarg")
     assert called[0]
 
     called[0] = False
     at = np.zeros(shape=(10, 10))
-    store([a], [at], get=get_func, return_stored=True, foo="test kwarg")
+    store([a], [at], scheduler=get_func, return_stored=True, foo="test kwarg")
     assert called[0]
 
 

--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -7,7 +7,6 @@ try:
     from .text import read_text
     from .utils import assert_eq
     from .avro import read_avro
-    from ..context import set_options
     from ..base import compute
 except ImportError as e:
     msg = ("Dask bag requirements are not installed.\n\n"

--- a/dask/base.py
+++ b/dask/base.py
@@ -883,7 +883,7 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
             raise ValueError("Compute called on multiple collections with "
                              "differing default schedulers. Please specify a "
                              "scheduler=` parameter explicitly in compute or "
-                             "globally with `set_options`.")
+                             "globally with `dask.config.set`.")
         return get
 
     return None

--- a/dask/base.py
+++ b/dask/base.py
@@ -9,7 +9,6 @@ import pickle
 import os
 import threading
 import uuid
-import warnings
 
 from toolz import merge, groupby, curry, identity
 from toolz.functoolz import Compose
@@ -157,11 +156,11 @@ class DaskMethodsMixin(object):
         return result
 
 
-def compute_as_if_collection(cls, dsk, keys, get=None, scheduler=None, **kwargs):
+def compute_as_if_collection(cls, dsk, keys, scheduler=None, get=None, **kwargs):
     """Compute a graph as if it were of type cls.
 
     Allows for applying the same optimizations and default scheduler."""
-    schedule = get_scheduler(get=get, scheduler=scheduler, cls=cls)
+    schedule = get_scheduler(scheduler=scheduler, cls=cls, get=get)
     dsk2 = optimization_function(cls)(ensure_dict(dsk), keys, **kwargs)
     return schedule(dsk2, keys, **kwargs)
 
@@ -383,9 +382,9 @@ def compute(*args, **kwargs):
     if not collections:
         return args
 
-    schedule = get_scheduler(get=kwargs.pop('get', None),
-                             scheduler=kwargs.pop('scheduler', None),
-                             collections=collections)
+    schedule = get_scheduler(scheduler=kwargs.pop('scheduler', None),
+                             collections=collections,
+                             get=kwargs.pop('get', None))
 
     dsk = collections_to_dsk(collections, optimize_graph, **kwargs)
     keys = [x.__dask_keys__() for x in collections]
@@ -544,8 +543,7 @@ def persist(*args, **kwargs):
     if not collections:
         return args
 
-    schedule = get_scheduler(get=kwargs.pop('get', None),
-                             scheduler=kwargs.pop('scheduler', None),
+    schedule = get_scheduler(scheduler=kwargs.pop('scheduler', None),
                              collections=collections)
 
     if inspect.ismethod(schedule):
@@ -814,22 +812,24 @@ else:
     })
 
 
-_warnned_on_get = [False]
+get_err_msg = """
+The get= keyword has been removed.
 
+Please use the scheduler= keyword instead with the name of
+the desired scheduler like 'threads' or 'processes'
 
-def warn_on_get(get):
-    if _warnned_on_get[0]:
-        return
-    else:
-        if get in named_schedulers.values():
-            _warnned_on_get[0] = True
-            warnings.warn(
-                "The get= keyword has been deprecated. "
-                "Please use the scheduler= keyword instead with the name of "
-                "the desired scheduler like 'threads' or 'processes'\n"
-                "    x.compute(scheduler='threads') \n"
-                "or with a function that takes the graph and keys\n"
-                "    x.compute(scheduler=my_scheduler_function)")
+    x.compute(scheduler='single-threaded')
+    x.compute(scheduler='threads')
+    x.compute(scheduler='processes')
+
+or with a function that takes the graph and keys
+
+    x.compute(scheduler=my_scheduler_function)
+
+or with a Dask client
+
+    x.compute(scheduler=client)
+""".strip()
 
 
 def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
@@ -837,19 +837,15 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
 
     There are various ways to specify the scheduler to use:
 
-    1.  Passing in get= parameters (deprecated)
-    2.  Passing in scheduler= parameters
-    3.  Passing these into global confiuration
-    4.  Using defaults of a dask collection
+    1.  Passing in scheduler= parameters
+    2.  Passing these into global confiuration
+    3.  Using defaults of a dask collection
 
     This function centralizes the logic to determine the right scheduler to use
     from those many options
     """
-    if get is not None:
-        if scheduler is not None:
-            raise ValueError("Both get= and scheduler= provided.  Choose one")
-        warn_on_get(get)
-        return get
+    if get:
+        raise TypeError(get_err_msg)
 
     if scheduler is not None:
         if callable(scheduler):
@@ -870,8 +866,7 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
         return get_scheduler(scheduler=config.get('scheduler', None))
 
     if config.get('get', None):
-        warn_on_get(config.get('get', None))
-        return config.get('get', None)
+        raise ValueError(get_err_msg)
 
     if getattr(thread_state, 'key', False):
         from distributed.worker import get_worker

--- a/dask/context.py
+++ b/dask/context.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function
 
 import threading
 from functools import partial
-import warnings
 from . import config
 
 _globals = config.config
@@ -14,16 +13,14 @@ _globals = config.config
 thread_state = threading.local()
 
 
-_warned_set_options = [False]
-
-
 def set_options(*args, **kwargs):
     """ Deprecated: see dask.config.set instead """
-    if not _warned_set_options[0]:
-        warnings.warn("The dask.set_options function has been deprecated. "
-                      "Please use dask.config.set instead")
-        _warned_set_options[0] = True
-    return config.set(*args, **kwargs)
+    raise TypeError("The dask.set_options function has been deprecated.\n"
+                    "Please use dask.config.set instead\n\n"
+                    "  Before: with dask.set_options(foo='bar'):\n"
+                    "              ...\n"
+                    "  After:  with dask.config.set(foo='bar'):\n"
+                    "              ...")
 
 
 def globalmethod(default=None, key=None, falsey=None):
@@ -53,10 +50,10 @@ def globalmethod(default=None, key=None, falsey=None):
     >>> f = Foo()
     >>> f.bar()
     1
-    >>> with dask.set_options(bar=lambda: 2):
+    >>> with dask.config.set(bar=lambda: 2):
     ...     print(f.bar())
     2
-    >>> with dask.set_options(bar=False):
+    >>> with dask.config.set(bar=False):
     ...     print(f.bar())
     3
     """

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -499,7 +499,7 @@ def _write_csv(df, fil, **kwargs):
 
 
 def to_csv(df, filename, name_function=None, compression=None, compute=True,
-           get=None, scheduler=None, storage_options=None, **kwargs):
+           scheduler=None, storage_options=None, **kwargs):
     """
     Store Dask DataFrame to CSV files
 
@@ -633,7 +633,7 @@ def to_csv(df, filename, name_function=None, compression=None, compute=True,
               for d, f in zip(df.to_delayed(), files)]
 
     if compute:
-        delayed(values).compute(get=get, scheduler=scheduler)
+        delayed(values).compute(scheduler=scheduler)
         return [f.path for f in files]
     else:
         return values

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -34,7 +34,7 @@ def _pd_to_hdf(pd_to_hdf, lock, args, kwargs=None):
     return None
 
 
-def to_hdf(df, path, key, mode='a', append=False, get=None, scheduler=None,
+def to_hdf(df, path, key, mode='a', append=False, scheduler=None,
            name_function=None, compute=True, lock=None, dask_kwargs={},
            **kwargs):
     """ Store Dask Dataframe to Hierarchical Data Format (HDF) files
@@ -73,6 +73,8 @@ def to_hdf(df, path, key, mode='a', append=False, get=None, scheduler=None,
         will be used depending on your scheduler if a lock is required. See
         dask.utils.get_scheduler_lock for more information about lock
         selection.
+    scheduler : string
+        The scheduler to use, like "threads" or "processes"
     **other:
         See pandas.to_hdf for more information
 
@@ -165,15 +167,13 @@ def to_hdf(df, path, key, mode='a', append=False, get=None, scheduler=None,
 
     # If user did not specify scheduler and write is sequential default to the
     # sequential scheduler. otherwise let the _get method choose the scheduler
-    if (get is None and
-            not config.get('get', None) and
-            scheduler is None and
+    if (scheduler is None and
             not config.get('scheduler', None) and
             single_node and single_file):
         scheduler = 'single-threaded'
 
     # handle lock default based on whether we're writing to a single entity
-    _actual_get = get_scheduler(get=get, collections=[df], scheduler=scheduler)
+    _actual_get = get_scheduler(collections=[df], scheduler=scheduler)
     if lock is None:
         if not single_node:
             lock = True
@@ -184,7 +184,7 @@ def to_hdf(df, path, key, mode='a', append=False, get=None, scheduler=None,
         else:
             lock = False
     if lock:
-        lock = get_scheduler_lock(get, df, scheduler=scheduler)
+        lock = get_scheduler_lock(df, scheduler=scheduler)
 
     kwargs.update({'format': 'table', 'mode': mode, 'append': append})
 
@@ -223,7 +223,7 @@ def to_hdf(df, path, key, mode='a', append=False, get=None, scheduler=None,
         keys = [(name, i) for i in range(df.npartitions)]
 
     if compute:
-        compute_as_if_collection(DataFrame, dsk, keys, get=get,
+        compute_as_if_collection(DataFrame, dsk, keys,
                                  scheduler=scheduler, **dask_kwargs)
         return filenames
     else:

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1169,7 +1169,7 @@ def test_to_csv_with_get():
     ddf = dd.from_pandas(df, npartitions=2)
 
     with tmpdir() as dn:
-        ddf.to_csv(dn, index=False, get=my_get)
+        ddf.to_csv(dn, index=False, scheduler=my_get)
         assert flag[0]
         result = dd.read_csv(os.path.join(dn, '*')).compute().reset_index(drop=True)
         assert_eq(result, df)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -5,7 +5,6 @@ import pytest
 from operator import add, mul
 import subprocess
 import sys
-import warnings
 
 from toolz import merge
 
@@ -834,20 +833,17 @@ def test_scheduler_keyword():
 
         with dask.config.set(scheduler='foo'):
             assert x.compute(scheduler='threads') == 2
-
-        with pytest.raises(ValueError):
-            x.compute(get=dask.threaded.get, scheduler='foo')
     finally:
         del named_schedulers['foo']
 
 
-def test_warn_get_keyword():
+def test_raise_get_keyword():
     x = delayed(inc)(1)
 
-    with warnings.catch_warnings(record=True) as record:
+    with pytest.raises(TypeError) as info:
         x.compute(get=dask.get)
 
-    assert 'scheduler=' in str(record[0].message)
+    assert 'scheduler=' in str(info.value)
 
 
 def test_get_scheduler():

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -5,7 +5,6 @@ import pytest
 from operator import add, mul
 import subprocess
 import sys
-import warnings
 import time
 
 from toolz import merge

--- a/dask/tests/test_context.py
+++ b/dask/tests/test_context.py
@@ -1,4 +1,4 @@
-from dask.context import set_options, _globals, globalmethod
+from dask.context import globalmethod
 import dask.array as da
 import dask
 
@@ -15,25 +15,13 @@ def test_with_get():
     assert x.sum().compute() == 10
     assert var[0] == 0
 
-    with set_options(get=myget):
+    with dask.config.set(scheduler=myget):
         assert x.sum().compute() == 10
     assert var[0] == 1
 
     # Make sure we've cleaned up
     assert x.sum().compute() == 10
     assert var[0] == 1
-
-
-def test_set_options_context_manger():
-    with set_options(foo='bar'):
-        assert _globals['foo'] == 'bar'
-    assert _globals.get('foo', None) is None
-
-    try:
-        set_options(foo='baz')
-        assert _globals['foo'] == 'baz'
-    finally:
-        del _globals['foo']
 
 
 def foo():

--- a/dask/tests/test_context.py
+++ b/dask/tests/test_context.py
@@ -45,16 +45,16 @@ def test_globalmethod():
 
     assert x.f() == 1
 
-    with dask.set_options(f=lambda: 2):
+    with dask.config.set(f=lambda: 2):
         assert x.f() == 2
 
-    with dask.set_options(f=foo):
+    with dask.config.set(f=foo):
         assert x.f is foo
         assert x.f() == 'foo'
 
     assert x.g is foo
     assert x.g() == 'foo'
 
-    with dask.set_options(g=False):
+    with dask.config.set(g=False):
         assert x.g is bar
         assert x.g() == 'bar'

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -8,7 +8,7 @@ from toolz import identity, partial, merge
 import pytest
 
 import dask
-from dask import set_options, compute
+from dask import compute
 from dask.compatibility import PY2, PY3
 from dask.delayed import delayed, to_task_dask, Delayed
 from dask.utils_test import inc
@@ -275,37 +275,37 @@ def test_pure_global_setting():
     # delayed functions
     func = delayed(add)
 
-    with set_options(delayed_pure=True):
+    with dask.config.set(delayed_pure=True):
         assert func(1, 2).key == func(1, 2).key
 
-    with set_options(delayed_pure=False):
+    with dask.config.set(delayed_pure=False):
         assert func(1, 2).key != func(1, 2).key
 
     func = delayed(add, pure=True)
-    with set_options(delayed_pure=False):
+    with dask.config.set(delayed_pure=False):
         assert func(1, 2).key == func(1, 2).key
 
     # delayed objects
     assert delayed(1).key != delayed(1).key
-    with set_options(delayed_pure=True):
+    with dask.config.set(delayed_pure=True):
         assert delayed(1).key == delayed(1).key
 
-    with set_options(delayed_pure=False):
+    with dask.config.set(delayed_pure=False):
         assert delayed(1, pure=True).key == delayed(1, pure=True).key
 
     # delayed methods
     data = delayed([1, 2, 3])
     assert data.index(1).key != data.index(1).key
 
-    with set_options(delayed_pure=True):
+    with dask.config.set(delayed_pure=True):
         assert data.index(1).key == data.index(1).key
         assert data.index(1, pure=False).key != data.index(1, pure=False).key
 
-    with set_options(delayed_pure=False):
+    with dask.config.set(delayed_pure=False):
         assert data.index(1, pure=True).key == data.index(1, pure=True).key
 
     # magic methods always pure
-    with set_options(delayed_pure=False):
+    with dask.config.set(delayed_pure=False):
         assert data.index.key == data.index.key
         element = data[0]
         assert (element + element).key == (element + element).key

--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -7,7 +7,7 @@ from time import time, sleep
 
 import pytest
 
-from dask.context import set_options
+import dask
 from dask.compatibility import PY2
 from dask.threaded import get
 from dask.utils_test import inc, add
@@ -40,7 +40,7 @@ def test_exceptions_rise_to_top():
 
 def test_reuse_pool():
     pool = ThreadPool()
-    with set_options(pool=pool):
+    with dask.config.set(pool=pool):
         assert get({'x': (inc, 1)}, 'x') == 2
         assert get({'x': (inc, 1)}, 'x') == 2
 

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -5,13 +5,12 @@ import pickle
 import numpy as np
 import pytest
 
-import dask
 from dask.sharedict import ShareDict
 from dask.utils import (takes_multiple_arguments, Dispatch, random_state_data,
                         memory_repr, methodcaller, M, skip_doctest,
                         SerializableLock, funcname, ndeepmap, ensure_dict,
                         extra_titles, asciitable, itemgetter, partial_by_order,
-                        effective_get, has_keyword)
+                        has_keyword)
 from dask.utils_test import inc
 
 
@@ -341,18 +340,6 @@ def test_itemgetter():
 
 def test_partial_by_order():
     assert partial_by_order(5, function=operator.add, other=[(1, 20)]) == 25
-
-
-def test_effective_get():
-    da = pytest.importorskip('dask.array')
-    x = da.arange(10, chunks=(5,))
-
-    with pytest.warns(Warning) as record:
-        assert effective_get(collection=x) is dask.threaded.get
-        assert effective_get(get=dask.threaded.get) is dask.threaded.get
-
-    assert any('dask.base.get_scheduler' in str(warning)
-               for warning in record.list)
 
 
 def test_has_keyword():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -13,7 +13,6 @@ from importlib import import_module
 from numbers import Integral
 from threading import Lock
 import uuid
-import warnings
 from weakref import WeakValueDictionary
 
 from .compatibility import (get_named_args, getargspec, PY3, unicode,
@@ -806,13 +805,12 @@ class SerializableLock(object):
     __repr__ = __str__
 
 
-def get_scheduler_lock(get=None, collection=None, scheduler=None):
+def get_scheduler_lock(collection=None, scheduler=None):
     """Get an instance of the appropriate lock for a certain situation based on
        scheduler used."""
     from . import multiprocessing
     from .base import get_scheduler
-    actual_get = get_scheduler(get=get,
-                               collections=[collection],
+    actual_get = get_scheduler(collections=[collection],
                                scheduler=scheduler)
 
     if actual_get == multiprocessing.get:
@@ -1014,14 +1012,6 @@ byte_sizes = {
 byte_sizes = {k.lower(): v for k, v in byte_sizes.items()}
 byte_sizes.update({k[0]: v for k, v in byte_sizes.items() if k and 'i' not in k})
 byte_sizes.update({k[:-1]: v for k, v in byte_sizes.items() if k and 'i' in k})
-
-
-def effective_get(get=None, collection=None):
-    """ Deprecated: see dask.base.get_scheduler """
-    warnings.warn("Deprecated, see dask.base.get_scheduler instead")
-
-    from dask.base import get_scheduler
-    return get_scheduler(get=get, collections=[collection])
 
 
 def has_keyword(func, keyword):


### PR DESCRIPTION
Previously we used to warn if the user used the `get=` keyword or used `dask.set_options`

Now we raise an informative TypeError pointing to the `scheduler=` keyword and `dask.config.set` functions respectively.

cc @jcrist @shoyer 
