### PR TITLE
Support da.asanyarray on dask dataframes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3076,7 +3076,9 @@ def asanyarray(a):
     """
     if isinstance(a, Array):
         return a
-    if isinstance(a, (list, tuple)) and any(isinstance(i, Array) for i in a):
+    elif hasattr(a, 'to_dask_array'):
+        return a.to_dask_array()
+    elif isinstance(a, (list, tuple)) and any(isinstance(i, Array) for i in a):
         a = stack(a)
     elif not isinstance(getattr(a, 'shape', None), Iterable):
         a = np.asanyarray(a)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2139,6 +2139,26 @@ def test_asanyarray():
     assert da.asanyarray(dx) is dx
 
 
+def test_asanyarray_dataframe():
+    pd = pytest.importorskip('pandas')
+    dd = pytest.importorskip('dask.dataframe')
+
+    df = pd.DataFrame({'x': [1, 2, 3]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    x = np.asanyarray(df)
+    dx = da.asanyarray(ddf)
+    assert isinstance(dx, da.Array)
+
+    assert_eq(x, dx)
+
+    x = np.asanyarray(df.x)
+    dx = da.asanyarray(ddf.x)
+    assert isinstance(dx, da.Array)
+
+    assert_eq(x, dx)
+
+
 def test_from_func():
     x = np.arange(10)
     f = lambda n: n * x


### PR DESCRIPTION
This made operations like dask-ml `pipeline.score` work on dataframes (for whatever default scoring method I was using).