### PR TITLE
Pull num_workers from config.get

### DIFF
--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -160,6 +160,7 @@ def get(dsk, keys, num_workers=None, func_loads=None, func_dumps=None,
         If True [default], `fuse` is applied to the graph before computation.
     """
     pool = config.get('pool', None)
+    num_workers = num_workers or config.get('num_workers', None)
     if pool is None:
         context = get_context()
         pool = context.Pool(num_workers,

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -876,7 +876,7 @@ def test_callable_scheduler():
 @pytest.mark.parametrize('scheduler', ['threads', 'processes'])
 def test_num_workers_config(num_workers, scheduler):
     # Regression test for issue #4082
-    a = da.random.randint(0, 100, size=200, chunks=5)
+    a = da.random.randint(0, 10, size=400, chunks=2)
 
     with dask.config.set(num_workers=num_workers), Profiler() as prof:
         a.compute(scheduler=scheduler)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -19,6 +19,7 @@ from dask.delayed import Delayed
 from dask.utils import tmpdir, tmpfile, ignoring
 from dask.utils_test import inc, dec
 from dask.compatibility import long, unicode, PY2
+from dask.diagnostics import Profiler
 
 
 def import_or_none(path):
@@ -868,3 +869,18 @@ def test_callable_scheduler():
 
     assert delayed(lambda: 1)().compute(scheduler=get) == 1
     assert called[0]
+
+
+@pytest.mark.skipif('not da')
+@pytest.mark.parametrize('num_workers', range(1, 4))
+@pytest.mark.parametrize('scheduler', ['threads', 'processes'])
+def test_num_workers_config(num_workers, scheduler):
+    # Regression test for issue #4082
+    a = da.random.randint(0, 100, size=200, chunks=5)
+
+    with dask.config.set(num_workers=num_workers), Profiler() as prof:
+        a.compute(scheduler=scheduler)
+
+    workers = {i.worker_id for i in prof.results}
+
+    assert len(workers) == num_workers

--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -56,6 +56,7 @@ def get(dsk, result, cache=None, num_workers=None, **kwargs):
     """
     global default_pool
     pool = config.get('pool', None)
+    num_workers = num_workers or config.get('num_workers', None)
     thread = current_thread()
 
     with pools_lock:


### PR DESCRIPTION
This PR attempts to pull `num_workers` for the multi-threading and multi-processing schedulers from `config.get` if not specified directly to the corresponding scheduler `get` function. 

Fixes #4082

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
