### PR TITLE
[MRG] add support for duplicate column names

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3124,8 +3124,8 @@ class DataFrame(_Frame):
     def _repr_data(self):
         meta = self._meta
         index = self._repr_divisions
-        values = {c: _repr_data_series(meta[c], index) for c in meta.columns}
-        return pd.DataFrame(values, columns=meta.columns)
+        series_list = [_repr_data_series(s, index=index) for _, s in meta.iteritems()]
+        return pd.concat(series_list, axis=1)
 
     _HTML_FMT = """<div><strong>Dask DataFrame Structure:</strong></div>
 {data}

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -3,6 +3,8 @@ import pandas as pd
 from textwrap import dedent
 
 import dask.dataframe as dd
+import dask.array as da
+import numpy as np
 from dask.dataframe.utils import PANDAS_VERSION
 
 if PANDAS_VERSION >= '0.21.0':
@@ -487,3 +489,9 @@ def test_categorical_format():
            "dtype: category\n"
            "Dask Name: from_pandas, 1 tasks")
     assert repr(unknown) == exp
+
+
+def test_duplicate_columns_repr():
+    arr = da.from_array(np.arange(10).reshape(5, 2), chunks=(5, 2))
+    frame = dd.from_dask_array(arr, columns=['a', 'a'])
+    repr(frame)


### PR DESCRIPTION
Fixes #4079

- modifies _repr_data to use a list of series instead of a dict
- adds a test that tries to print with duplicate column names

- [X] Tests added / passed
- [X] Passes `flake8 dask`

