### PR TITLE
Implement min_count for the DataFrame methods sum and prod

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1302,14 +1302,26 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
                                    split_every=split_every, out=out)
 
     @derived_from(pd.DataFrame)
-    def sum(self, axis=None, skipna=True, split_every=False, dtype=None, out=None):
-        return self._reduction_agg('sum', axis=axis, skipna=skipna,
-                                   split_every=split_every, out=out)
+    def sum(self, axis=None, skipna=True, split_every=False, dtype=None,
+            out=None, min_count=None):
+        result = self._reduction_agg('sum', axis=axis, skipna=skipna,
+                                     split_every=split_every, out=out)
+        if min_count:
+            return result.where(self.notnull().sum(axis=axis) >= min_count,
+                                other=np.NaN)
+        else:
+            return result
 
     @derived_from(pd.DataFrame)
-    def prod(self, axis=None, skipna=True, split_every=False, dtype=None, out=None):
-        return self._reduction_agg('prod', axis=axis, skipna=skipna,
-                                   split_every=split_every, out=out)
+    def prod(self, axis=None, skipna=True, split_every=False, dtype=None,
+             out=None, min_count=None):
+        result = self._reduction_agg('prod', axis=axis, skipna=skipna,
+                                     split_every=split_every, out=out)
+        if min_count:
+            return result.where(self.notnull().sum(axis=axis) >= min_count,
+                                other=np.NaN)
+        else:
+            return result
 
     @derived_from(pd.DataFrame)
     def max(self, axis=None, skipna=True, split_every=False, out=None):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -998,7 +998,7 @@ def test_sum_with_min_count():
         for axis in axes:
             for min_count in [0, 1, 2, 3]:
                 assert_eq(df.sum(min_count=min_count, axis=axis),
-                          ddf.sum(min_count=min_count, axis=axis).compute())
+                          ddf.sum(min_count=min_count, axis=axis))
 
 
 @pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
@@ -1018,7 +1018,7 @@ def test_prod_with_min_count():
         for axis in axes:
             for min_count in [0, 1, 2, 3]:
                 assert_eq(df.prod(min_count=min_count, axis=axis),
-                          ddf.prod(min_count=min_count, axis=axis).compute())
+                          ddf.prod(min_count=min_count, axis=axis))
 
 
 @pytest.mark.parametrize('join', ['inner', 'outer', 'left', 'right'])

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1001,6 +1001,26 @@ def test_sum_with_min_count():
                           ddf.sum(min_count=min_count, axis=axis).compute())
 
 
+@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+                    reason="Parameter min_count not implemented in "
+                           "DataFrame.prod()")
+def test_prod_with_min_count():
+    dfs = [pd.DataFrame([[None, 2, 3],
+                         [None, 5, 6],
+                         [5, 4, 9]]),
+           pd.DataFrame([[2, None, None],
+                         [None, 5, 6],
+                         [5, 4, 9]])]
+    ddfs = [dd.from_pandas(df, npartitions=4) for df in dfs]
+    axes = [0, 1]
+
+    for df, ddf in zip(dfs, ddfs):
+        for axis in axes:
+            for min_count in [0, 1, 2, 3]:
+                assert_eq(df.prod(min_count=min_count, axis=axis),
+                          ddf.prod(min_count=min_count, axis=axis).compute())
+
+
 @pytest.mark.parametrize('join', ['inner', 'outer', 'left', 'right'])
 def test_align(join):
     df1a = pd.DataFrame({'A': np.random.randn(10),

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -981,6 +981,23 @@ def test_unknown_divisions():
     assert_eq(d.a + d.b + 1, full.a + full.b + 1)
 
 
+def test_sum_with_min_count():
+    dfs = [pd.DataFrame([[None, 2, 3],
+                         [None, 5, 6],
+                         [5, 4, 9]]),
+           pd.DataFrame([[2, None, None],
+                         [None, 5, 6],
+                         [5, 4, 9]])]
+    ddfs = [dd.from_pandas(df, npartitions=4) for df in dfs]
+    axes = [0, 1]
+
+    for df, ddf in zip(dfs, ddfs):
+        for axis in axes:
+            for min_count in [0, 1, 2, 3]:
+                assert_eq(df.sum(min_count=min_count, axis=axis),
+                          ddf.sum(min_count=min_count, axis=axis).compute())
+
+
 @pytest.mark.parametrize('join', ['inner', 'outer', 'left', 'right'])
 def test_align(join):
     df1a = pd.DataFrame({'A': np.random.randn(10),

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -983,8 +983,8 @@ def test_unknown_divisions():
 
 @pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
                     reason="Parameter min_count not implemented in "
-                           "DataFrame.sum()")
-def test_sum_with_min_count():
+                           "DataFrame.sum() and DataFrame.prod()")
+def test_with_min_count():
     dfs = [pd.DataFrame([[None, 2, 3],
                          [None, 5, 6],
                          [5, 4, 9]]),
@@ -999,24 +999,6 @@ def test_sum_with_min_count():
             for min_count in [0, 1, 2, 3]:
                 assert_eq(df.sum(min_count=min_count, axis=axis),
                           ddf.sum(min_count=min_count, axis=axis))
-
-
-@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
-                    reason="Parameter min_count not implemented in "
-                           "DataFrame.prod()")
-def test_prod_with_min_count():
-    dfs = [pd.DataFrame([[None, 2, 3],
-                         [None, 5, 6],
-                         [5, 4, 9]]),
-           pd.DataFrame([[2, None, None],
-                         [None, 5, 6],
-                         [5, 4, 9]])]
-    ddfs = [dd.from_pandas(df, npartitions=4) for df in dfs]
-    axes = [0, 1]
-
-    for df, ddf in zip(dfs, ddfs):
-        for axis in axes:
-            for min_count in [0, 1, 2, 3]:
                 assert_eq(df.prod(min_count=min_count, axis=axis),
                           ddf.prod(min_count=min_count, axis=axis))
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -981,6 +981,9 @@ def test_unknown_divisions():
     assert_eq(d.a + d.b + 1, full.a + full.b + 1)
 
 
+@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+                    reason="Parameter min_count not implemented in "
+                           "DataFrame.sum()")
 def test_sum_with_min_count():
     dfs = [pd.DataFrame([[None, 2, 3],
                          [None, 5, 6],


### PR DESCRIPTION
As mentioned in #3981 dask DataFrames do not support the relatively new ``min_count`` parameter on the methods ``sum`` and ``prod``. I've tried to address that with this pull request.

- [x] Tests passed
- [x] Tests added
- [x] Passes `flake8 dask`