### PR TITLE
Use code generation in atop fusion

### DIFF
--- a/dask/array/top.py
+++ b/dask/array/top.py
@@ -8,7 +8,7 @@ import toolz
 from .. import base, core, sharedict, utils
 from ..compatibility import apply
 from ..delayed import to_task_dask
-from ..optimization import SubgraphCallable
+from ..optimization import CompiledSubgraphCallable
 
 
 def subs(task, substitution):
@@ -149,7 +149,7 @@ class TOP(collections.Mapping):
             return self._cached_dict
         else:
             keys = tuple(map(atop_token, range(len(self.indices))))
-            func = SubgraphCallable(self.dsk, self.output, keys)
+            func = CompiledSubgraphCallable(self.dsk, self.output, keys)
             self._cached_dict = top(
                 func,
                 self.output,

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -111,6 +111,9 @@ if PY3:
             raise exc.with_traceback(tb)
         raise exc
 
+    def exec_(codestr, glbls):
+        exec(codestr, glbls)
+
 else:
     import __builtin__ as builtins
     import copy_reg as copyreg
@@ -150,6 +153,10 @@ else:
 
     reraise = _make_reraise()
     del _make_reraise
+
+    eval(compile(("def exec_(codestr, glbls):\n"
+                  "    exec codestr in glbls\n"),
+                  "<_exec>", "exec"))
 
     def _getargspec(func):
         return inspect.getargspec(func)


### PR DESCRIPTION
Using code generation in atop fusion instead of the default
SubgraphCallable provides noticeable speedups on some problems.

Subgraphs are fused into a single python callable upon creation of the
`SubgraphCallable`. This object is serialized between nodes as a
codestring and namespace, which is much faster than relying on
cloudpickle to do the same. On first call the codestring is exec'd into
a python function.

We still use `SubgraphCallable` for fuse subgraphs, as the non-codegen
version makes sense in that case. The difference is:

- atop fusion generates one callable, and uses it for many tasks
- subgraph fusion generates a new callable for every fused subgraph

In the atop fusion case we can do more work initially, as the cost is
amortized among many tasks.