### PR TITLE
3982 to parquet reorg

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1131,11 +1131,6 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         from .io import to_hdf
         return to_hdf(self, path_or_buf, key, mode, append, **kwargs)
 
-    def to_parquet(self, path, *args, **kwargs):
-        """ See dd.to_parquet docstring for more information """
-        from .io import to_parquet
-        return to_parquet(self, path, *args, **kwargs)
-
     def to_csv(self, filename, **kwargs):
         """ See dd.to_csv docstring for more information """
         from .io import to_csv
@@ -2793,6 +2788,11 @@ class DataFrame(_Frame):
         """
         from .io import to_bag
         return to_bag(self, index)
+
+    def to_parquet(self, path, *args, **kwargs):
+        """ See dd.to_parquet docstring for more information """
+        from .io import to_parquet
+        return to_parquet(self, path, *args, **kwargs)
 
     @derived_from(pd.DataFrame)
     def to_string(self, max_rows=5):

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -84,6 +84,7 @@ Dataframe
     DataFrame.to_delayed
     DataFrame.to_hdf
     DataFrame.to_json
+    DataFrame.to_parquet
     DataFrame.to_records
     DataFrame.truediv
     DataFrame.values
@@ -197,7 +198,6 @@ Series
    Series.to_delayed
    Series.to_frame
    Series.to_hdf
-   Series.to_parquet
    Series.to_string
    Series.to_timestamp
    Series.truediv


### PR DESCRIPTION
Per suggestion of issue #3982, I have moved the to_parquet method to the DataFrame only. I appreciate any guidance and feedback that can be provided if need be. Thank you.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
