### PR TITLE
Remove unnecessary endianness check in test_concat_datetimeindex

### DIFF
--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1135,7 +1135,7 @@ def test_concat_datetimeindex():
     db3 = dd.from_pandas(b3, 1)
 
     result = concat([b2.iloc[:0], b3.iloc[:0]])
-    assert result.index.dtype == '<M8[ns]'
+    assert result.index.dtype == 'M8[ns]'
 
     result = dd.concat([db2, db3])
     expected = pd.concat([b2, b3])


### PR DESCRIPTION
This fixes the second part of #3811.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
