### PR TITLE
Fixed typo in doc strings of read_sql_table method

### DIFF
--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -73,7 +73,7 @@ def read_sql_table(table, uri, index_col, divisions=None, npartitions=None,
 
     Examples
     --------
-    >>> df = dd.read_sql('accounts', 'sqlite:///path/to/bank.db',
+    >>> df = dd.read_sql_table('accounts', 'sqlite:///path/to/bank.db',
     ...                  npartitions=10, index_col='id')  # doctest: +SKIP
     """
     import sqlalchemy as sa


### PR DESCRIPTION
Since this is an example for read_sql_table, "dd.read_sql" should be "dd.read_sql_table"

(Is "read_sql" an alias method for read_sql_table? If so, please ignore and close this pull request, I am new to Dask and just found an odd thing when I reading docs.)

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
