### PR TITLE
Set name=False in array foo_like functions

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3006,7 +3006,7 @@ def retrieve_from_ooc(keys, dsk_pre, dsk_post=None):
     return load_dsk
 
 
-def asarray(a):
+def asarray(a, **kwargs):
     """Convert the input to a dask array.
 
     Parameters
@@ -3046,7 +3046,7 @@ def asarray(a):
         return a.to_dask_array()
     elif not isinstance(getattr(a, 'shape', None), Iterable):
         a = np.asarray(a)
-    return from_array(a, chunks=a.shape, getitem=getter_inline)
+    return from_array(a, chunks=a.shape, getitem=getter_inline, **kwargs)
 
 
 def asanyarray(a):

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -54,7 +54,7 @@ def empty_like(a, dtype=None, chunks=None):
     the functions that do set the array values.
     """
 
-    a = asarray(a)
+    a = asarray(a, name=False)
     return empty(
         a.shape, dtype=(dtype or a.dtype),
         chunks=(chunks if chunks is not None else a.chunks)
@@ -90,7 +90,7 @@ def ones_like(a, dtype=None, chunks=None):
     empty : Return a new uninitialized array.
     """
 
-    a = asarray(a)
+    a = asarray(a, name=False)
     return ones(
         a.shape, dtype=(dtype or a.dtype),
         chunks=(chunks if chunks is not None else a.chunks)
@@ -126,7 +126,7 @@ def zeros_like(a, dtype=None, chunks=None):
     empty : Return a new uninitialized array.
     """
 
-    a = asarray(a)
+    a = asarray(a, name=False)
     return zeros(
         a.shape, dtype=(dtype or a.dtype),
         chunks=(chunks if chunks is not None else a.chunks)
@@ -166,7 +166,7 @@ def full_like(a, fill_value, dtype=None, chunks=None):
     full : Fill a new array.
     """
 
-    a = asarray(a)
+    a = asarray(a, name=False)
     return full(
         a.shape,
         fill_value,


### PR DESCRIPTION
This avoids tokenization when passed numpy arrays

Fixes https://github.com/dask/dask/issues/3946

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
