### PR TITLE
Docs: Update user-interfaces.rest [skip ci]

### DIFF
--- a/docs/source/user-interfaces.rst
+++ b/docs/source/user-interfaces.rst
@@ -3,13 +3,13 @@ User Interfaces
 
 Dask supports several user interfaces:
 
--  High Level
+-  High-Level
     -  :doc:`Arrays <array>`: parallel Numpy
     -  :doc:`Bags <bag>`: parallel lists
-    -  :doc:`Dataframes <dataframe>`: parallel Pandas
+    -  :doc:`DataFrames <dataframe>`: parallel Pandas
     -  `Machine Learning <https://ml.dask.org>`_ : parallel Scikit-Learn
     -  Others from external projects, like `XArray <https://xarray.pydata.org>`_
--  Low Level
+-  Low-Level
     -  :doc:`Delayed <delayed>`: parallel function evaluation
     -  :doc:`Futures <futures>`: real-time parallel function evaluation
 
@@ -18,19 +18,19 @@ machinery, and so has the same scaling, diagnostics, resilience, and so on, but
 each provides a different set of parallel algorithms and programming style.
 
 This document helps you to decide which user interface best suits your needs,
-and gives some general information that applies to all of the interfaces.
-The pages linked to above give more information about each interface in greater
+and gives some general information that applies to all interfaces.
+The pages linked above give more information about each interface in greater
 depth.
 
-High Level Collections
+High-Level Collections
 ----------------------
 
 Many people who start using Dask are explicitly looking for a scalable version of
-Numpy, Pandas, or Scikit-Learn.  For these situations the starting point within
-Dask is usually fairly clear.  If you want scalable Numpy, they start with Dask
-array; if you want scalable Pandas, they start with Dask dataframe, and so on.
+Numpy, Pandas, or Scikit-Learn.  For these situations, the starting point within
+Dask is usually fairly clear.  If you want scalable Numpy arrays, then start with Dask
+array; if you want scalable Pandas DataFrames, then start with Dask DataFrame, and so on.
 
-These high-level interfaces copy the standard interface with slight variation.
+These high-level interfaces copy the standard interface with slight variations.
 These interfaces automatically parallelize over larger datasets for you for a
 large subset of the API from the original project.
 
@@ -43,7 +43,7 @@ large subset of the API from the original project.
 
    y = x + x.T - x.mean(axis=0)  # Use normal syntax for high level algorithms
 
-   # Dataframes
+   # DataFrames
    import dask.dataframe as dd
    df = dd.read_csv('2018-*-*.csv', parse_dates='timestamp',  # normal Pandas code
                     blocksize=64000000)  # break text into 64MB chunks
@@ -57,17 +57,17 @@ large subset of the API from the original project.
              .map(lambda d: d['balance'])
              .sum())
 
-It is important to remember that while APIs may be similar some differences do
+It is important to remember that, while APIs may be similar, some differences do
 exist.  Additionally, the performance of some algorithms may differ from their
 in-memory counterparts due to the advantages and disadvantages of parallel
 programming.  Some thought and attention is still required when using Dask.
 
 
-Low Level Interfaces
+Low-Level Interfaces
 --------------------
 
-Often when parallelizing existing code bases or building custom algorithms you
-run into code that is parallelizable, but isn't just a big dataframe or array.
+Often when parallelizing existing code bases or building custom algorithms, you
+run into code that is parallelizable, but isn't just a big DataFrame or array.
 Consider the for-loopy code below:
 
 .. code-block:: python
@@ -83,9 +83,9 @@ Consider the for-loopy code below:
 
 There is potential parallelism in this code (the many calls to ``f`` and ``g``
 can be done in parallel), but it's not clear how to rewrite it into a big
-array or dataframe so that it can use a higher-level API.  Even if you could
+array or DataFrame so that it can use a higher-level API.  Even if you could
 rewrite it into one of these paradigms, it's not clear that this would be a
-good idea.   Much of the meaning would likely be lost in translation, and this
+good idea.  Much of the meaning would likely be lost in translation, and this
 process would become much more difficult for more complex systems.
 
 Instead, Dask's lower-level APIs let you write parallel code one function call
@@ -109,15 +109,15 @@ into a lazily constructed task graph:
    results = dask.compute(*lazy_results)  # compute all in parallel
 
 
-Combining High and Low Level
-----------------------------
+Combining High- and Low-Level Interfaces
+----------------------------------------
 
-It is common to combine high and low level interfaces.
-For example you might use Dask array/bag/dataframe to load in data and do
+It is common to combine high- and low-level interfaces.
+For example, you might use Dask array/bag/dataframe to load in data and do
 initial pre-processing, then switch to Dask delayed for a custom algorithm that
 is specific to your domain, then switch back to Dask array/dataframe to clean
-up and store results.  Understanding both sets of user interfaces and how
-to switch between them can be a productive combination.
+up and store results.  Understanding both sets of user interfaces, and how
+to switch between them, can be a productive combination.
 
 .. code-block:: python
 
@@ -126,14 +126,14 @@ to switch between them can be a productive combination.
 
    # Manipulate delayed values arbitrarily as you like
 
-   # Convert many delayed Pandas dataframes back to a single Dask dataframe
+   # Convert many delayed Pandas DataFrames back to a single Dask DataFrame
    df = dd.from_delayed(delayed_values)
 
 
 Laziness and Computing
 ----------------------
 
-Most Dask user interfaces are *lazy* meaning that they do not evaluate until
+Most Dask user interfaces are *lazy*, meaning that they do not evaluate until
 you explicitly ask for a result using the ``compute`` method:
 
 .. code-block:: python
@@ -154,9 +154,9 @@ efficient:
    min, max = dask.compute(y.min(), y.max())
 
 Note that the ``compute()`` function returns in-memory results.  It converts
-Dask dataframes to Pandas dataframes, Dask arrays to Numpy arrays, and Dask
+Dask DataFrames to Pandas DataFrames, Dask arrays to Numpy arrays, and Dask
 bags to lists.  *You should only call compute on results that will fit
-comfortably in memory*.  If your result does not fit in memory then you might
+comfortably in memory*.  If your result does not fit in memory, then you might
 consider writing it to disk instead.
 
 .. code-block:: python
@@ -170,10 +170,10 @@ consider writing it to disk instead.
 Persist into Distributed Memory
 -------------------------------
 
-Alternatively, if you are on a cluster then you may want to trigger a
+Alternatively, if you are on a cluster, then you may want to trigger a
 computation and store the results in distributed memory.  In this case you do
 not want to call ``compute``, which would create a single Pandas, Numpy, or
-List result, but instead you want to call ``persist``, which returns a new Dask
+list result. Instead, you want to call ``persist``, which returns a new Dask
 object that points to actively computing, or already computed results spread
 around your cluster's memory.
 
@@ -186,7 +186,7 @@ around your cluster's memory.
    y = y.persist()
 
 This is common to see after data loading an preprocessing steps, but before
-rapid iteration, exploration, or complex algorithms.  For example we might read
+rapid iteration, exploration, or complex algorithms.  For example, we might read
 in a lot of data, filter down to a more manageable subset, and then persist
 data into memory so that we can iterate quickly.
 
@@ -206,14 +206,14 @@ data into memory so that we can iterate quickly.
 Lazy vs Immediate
 -----------------
 
-As mentioned above, most Dask workloads are lazy, that is they don't start any
-work, until you explicitly trigger them with a call to ``compute()``.
-However sometimes you *do* want to submit work as quickly as possible, track it
+As mentioned above, most Dask workloads are lazy, that is, they don't start any
+work until you explicitly trigger them with a call to ``compute()``.
+However, sometimes you *do* want to submit work as quickly as possible, track it
 over time, submit new work or cancel work depending on partial results, and so
 on.  This can be useful when tracking or responding to real-time events,
 handling streaming data, or when building complex and adaptive algorithms.
 
-For these situations people typically turn to the :doc:`futures interface
+For these situations, people typically turn to the :doc:`futures interface
 <futures>` which is a low-level interface like Dask delayed, but operates
 immediately rather than lazily.
 
@@ -285,7 +285,7 @@ There are established ways to combine the interfaces above:
        df = dd.from_delayed(delayeds)
        df = dd.from_delayed(futures)
 
-3.  The ``Client.compute`` method converts Delayed objects into Futures.
+3.  The ``Client.compute`` method converts Delayed objects into Futures
 
     .. code-block:: python
 
@@ -301,7 +301,7 @@ There are established ways to combine the interfaces above:
        df = df.persist()  # start computation in the background
        futures = futures_of(df)
 
-4.  The Dask.delayed object converts Futures into delayed objects.
+5.  The Dask.delayed object converts Futures into delayed objects
 
     .. code-block:: python
 
@@ -311,12 +311,12 @@ The approaches above should suffice to convert any interface into any other.
 We often see some anti-patterns that do not work as well:
 
 1.  Calling low-level APIs (delayed or futures) on high-level objects (like
-    Dask arrays or dataframes) This downgrades those objects to their Numpy or
+    Dask arrays or DataFrames). This downgrades those objects to their Numpy or
     Pandas equivalents, which may not be desired.
     Often people are looking for APIs like ``dask.array.map_blocks`` or
-    ``dask.dataframe.map_partitions`` instead.
+    ``dask.dataframe.map_partitions`` instead
 2.  Calling ``compute()`` on Future objects.
-    Often people want the ``.result()`` method instead.
+    Often people want the ``.result()`` method instead
 3.  Calling Numpy/Pandas functions on high-level Dask objects or
     high-level Dask functions on Numpy/Pandas objects
 
@@ -334,10 +334,9 @@ below:
 -  High Level
     -  :doc:`Arrays <array>`: parallel Numpy
     -  :doc:`Bags <bag>`: parallel lists
-    -  :doc:`Dataframes <dataframe>`: parallel Pandas
+    -  :doc:`DataFrames <dataframe>`: parallel Pandas
     -  `Machine Learning <https://ml.dask.org>`_ : parallel Scikit-Learn
     -  Others from external projects, like `XArray <https://xarray.pydata.org>`_
 -  Low Level
     -  :doc:`Delayed <delayed>`: parallel function evaluation
     -  :doc:`Futures <futures>`: real-time parallel function evaluation
-


### PR DESCRIPTION
This PR updates `user-interfaces.rst` with some corrections to sentences,  header titles, lists, and punctuation. 

Nothing major, but there are some changes here and there across the file.
