### PR TITLE
Normalize reversed slices in dask array

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -728,6 +728,8 @@ def normalize_slice(idx, dim):
                 stop = None
             if step == 1:
                 step = None
+            if stop is not None and start is not None and stop < start:
+                stop = start
         elif step < 0:
             if start >= dim - 1:
                 start = None

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3593,3 +3593,10 @@ def test_atop_large_inputs_delayed():
     d = atop(lambda x, y: x + y, 'i', a, 'i', y=b, dtype=a.dtype)
     assert any(b is v for v in d.dask.values())
     assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
+
+
+def test_slice_reversed():
+    x = da.ones(10, chunks=-1)
+    y = x[6:3]
+
+    assert_eq(y, np.ones(0))


### PR DESCRIPTION
Fixes #2994

- [x] Tests added / passed
- [x] Passes `flake8 dask`
