### PR TITLE
Adds `invert`

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -23,7 +23,7 @@ try:
             sin, cos, tan, arcsin, arccos, arctan, arctan2, hypot, sinh, cosh,
             tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg, greater,
             greater_equal, less, less_equal, not_equal, equal, maximum,
-            bitwise_and, bitwise_or, bitwise_xor, bitwise_not, minimum,
+            bitwise_and, bitwise_or, bitwise_xor, bitwise_not, invert, minimum,
             logical_and, logical_or, logical_xor, logical_not, fmax, fmin,
             isreal, iscomplex, isfinite, isinf, isneginf, isposinf, isnan, signbit,
             copysign, nextafter, spacing, ldexp, fmod, floor, ceil, trunc, degrees,

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -56,7 +56,7 @@ except AttributeError:
 unary_ufuncs = ['absolute', 'arccos', 'arccosh', 'arcsin', 'arcsinh', 'arctan',
                 'arctanh', 'bitwise_not', 'cbrt', 'ceil', 'conj', 'cos',
                 'cosh', 'deg2rad', 'degrees', 'exp', 'exp2', 'expm1', 'fabs',
-                'fix', 'floor', 'i0', 'isfinite', 'isinf', 'isnan', 'log',
+                'fix', 'floor', 'i0', 'invert','isfinite', 'isinf', 'isnan', 'log',
                 'log10', 'log1p', 'log2', 'logical_not', 'nan_to_num',
                 'negative', 'rad2deg', 'radians', 'reciprocal', 'rint', 'sign',
                 'signbit', 'sin', 'sinc', 'sinh', 'spacing', 'sqrt', 'square',

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -229,6 +229,7 @@ bitwise_and = ufunc(np.bitwise_and)
 bitwise_or = ufunc(np.bitwise_or)
 bitwise_xor = ufunc(np.bitwise_xor)
 bitwise_not = ufunc(np.bitwise_not)
+invert = bitwise_not
 
 # floating functions
 isfinite = ufunc(np.isfinite)

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -91,6 +91,7 @@ Top level user functions:
    imag
    indices
    insert
+   invert
    isclose
    iscomplex
    isfinite


### PR DESCRIPTION
Provides the equivalent to NumPy's [invert](https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.invert.html) function for Dask Arrays. This will close https://github.com/dask/dask/issues/2916.

## Example 

```python
In [1]: import dask.array as da

In [2]: import numpy as np

In [3]: arr =  np.array([13], dtype=np.uint8)

In [4]: np.invert(arr)
Out[4]: array([242], dtype=uint8)

In [5]: darr = da.from_array(arr, chunks=1)

In [6]: da.invert(darr).compute()
Out[6]: array([242], dtype=uint8)

In [7]: # Same way numpy's bitwise_not is an alias for invert

In [8]: np.bitwise_not is np.invert
Out[8]: True

In [9]: # Dask's bitwise_not is an alias for invert, and vice versa

In [10]: da.bitwise_not is da.invert
Out[10]: True

In [11]: # Boolean arrays are accepted

In [12]: b_arr = np.array([True, False])

In [13]: np.invert(b_arr)
Out[13]: array([False,  True])

In [14]: da.invert(da.from_array(b_arr, chunks=1))
Out[14]: dask.array<invert, shape=(2,), dtype=bool, chunksize=(1,)>

In [15]: da.invert(da.from_array(b_arr, chunks=1)).compute()
Out[15]: array([False,  True])
```
- [x] Tests added / passed
- [ ] Passes `flake8 dask`

