### PR TITLE
Raise informative error on arg-reduction on unknown chunksize

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -8,7 +8,7 @@ from math import factorial, log, ceil
 import numpy as np
 from numbers import Integral
 
-from toolz import compose, partition_all, get, accumulate, pluck
+from toolz import compose, partition_all, get, accumulate, pluck, concat
 
 from . import chunk
 from .core import _concatenate2, Array, atop, handle_out
@@ -616,6 +616,13 @@ def arg_reduction(x, chunk, combine, agg, axis=None, split_every=None, out=None)
     else:
         raise TypeError("axis must be either `None` or int, "
                         "got '{0}'".format(axis))
+
+    if np.isnan(list(concat(x.chunks))).any():
+        raise ValueError(
+            "Arg-reductions do not work with arrays that have "
+            "unknown chunksizes.  At some point in your computation "
+            "this array lost chunking information"
+        )
 
     # Map chunk across all blocks
     name = 'arg-reduce-{0}'.format(tokenize(axis, x, chunk,

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -183,6 +183,18 @@ def test_nanarg_reductions(dfunc, func):
             dfunc(a).compute()
 
 
+@pytest.mark.parametrize('func', ['argmax', 'nanargmax'])
+def test_arg_reductions_unknown_chunksize(func):
+    x = np.arange(10)
+    d = da.from_array(x, chunks=5)
+    d = d[d > 1]
+
+    with pytest.raises(ValueError) as info:
+        getattr(da, func)(d)
+
+    assert "unknown chunksize" in str(info.value)
+
+
 def test_reductions_2D_nans():
     # chunks are a mix of some/all/no NaNs
     x = np.full((4, 4), np.nan)


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/3108

- [x] Tests added / passed
- [x] Passes `flake8 dask`
