### PR TITLE
Fix `invert` docstring

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -457,6 +457,7 @@ Other functions
 .. autofunction:: imag
 .. autofunction:: indices
 .. autofunction:: insert
+.. autofunction:: invert
 .. autofunction:: isclose
 .. autofunction:: iscomplex
 .. autofunction:: isfinite


### PR DESCRIPTION
Docstring wasn't properly generated in https://github.com/dask/dask/pull/4127. This fixes it. 
- [x] Tests added / passed
- [ ] Passes `flake8 dask`
