### PR TITLE
Move arg-reductions unknown chunksizes check

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -8,7 +8,7 @@ from math import factorial, log, ceil
 import numpy as np
 from numbers import Integral
 
-from toolz import compose, partition_all, get, accumulate, pluck, concat
+from toolz import compose, partition_all, get, accumulate, pluck
 
 from . import chunk
 from .core import _concatenate2, Array, atop, handle_out
@@ -551,6 +551,12 @@ def arg_chunk(func, argfunc, x, axis, offset_info):
     arg = argfunc(x, axis=arg_axis, keepdims=True)
     if arg_axis is None:
         offset, total_shape = offset_info
+        if np.isnan(total_shape).any():
+            raise ValueError(
+                "Arg-reductions do not work with arrays that have "
+                "unknown chunksizes.  At some point in your computation "
+                "this array lost chunking information"
+            )
         ind = np.unravel_index(arg.ravel()[0], x.shape)
         total_ind = tuple(o + i for (o, i) in zip(offset, ind))
         arg[:] = np.ravel_multi_index(total_ind, total_shape)
@@ -616,13 +622,6 @@ def arg_reduction(x, chunk, combine, agg, axis=None, split_every=None, out=None)
     else:
         raise TypeError("axis must be either `None` or int, "
                         "got '{0}'".format(axis))
-
-    if np.isnan(list(concat(x.chunks))).any():
-        raise ValueError(
-            "Arg-reductions do not work with arrays that have "
-            "unknown chunksizes.  At some point in your computation "
-            "this array lost chunking information"
-        )
 
     # Map chunk across all blocks
     name = 'arg-reduce-{0}'.format(tokenize(axis, x, chunk,

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -190,7 +190,7 @@ def test_arg_reductions_unknown_chunksize(func):
     d = d[d > 1]
 
     with pytest.raises(ValueError) as info:
-        getattr(da, func)(d)
+        getattr(da, func)(d).compute()
 
     assert "unknown chunksize" in str(info.value)
 


### PR DESCRIPTION
This PR moves the unknown chunksizes check added in #4128 from `arg_reduction` (when the corresponding dask graph is being built) to `arg_chunk` (when a computation is being performed on array chunks). 

It appears there are valid use cases that are being disallowed due to the changes made in #4128, ref https://github.com/dask/dask-ml/pull/418. 

The changes made in this PR will still raise the more informative error message added in #4128, but at compute time rather than at dask graph construction time. 

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
