### PR TITLE
Allow arg reductions on unknown chunks on different axes

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -617,7 +617,7 @@ def arg_reduction(x, chunk, combine, agg, axis=None, split_every=None, out=None)
         raise TypeError("axis must be either `None` or int, "
                         "got '{0}'".format(axis))
 
-    if np.isnan(list(concat(x.chunks))).any():
+    if np.isnan([c for i, cc in enumerate(x.chunks) if i in axis for c in cc]).any():
         raise ValueError(
             "Arg-reductions do not work with arrays that have "
             "unknown chunksizes.  At some point in your computation "

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -185,14 +185,24 @@ def test_nanarg_reductions(dfunc, func):
 
 @pytest.mark.parametrize('func', ['argmax', 'nanargmax'])
 def test_arg_reductions_unknown_chunksize(func):
-    x = np.arange(10)
-    d = da.from_array(x, chunks=5)
-    d = d[d > 1]
+    x = da.arange(10, chunks=5)
+    x = x[x > 1]
 
     with pytest.raises(ValueError) as info:
-        getattr(da, func)(d)
+        getattr(da, func)(x)
 
     assert "unknown chunksize" in str(info.value)
+
+
+@pytest.mark.parametrize('func', ['argmax', 'nanargmax'])
+def test_arg_reductions_unknown_chunksize_2d(func):
+    x = da.ones((10, 10), chunks=(5, 5))
+    x = x[x[0, :] > 0, :]  # unknown chunks in first dimension only
+
+    with pytest.raises(ValueError) as info:
+        getattr(da, func)(x, axis=0)
+
+    getattr(da, func)(x, axis=1).compute()
 
 
 def test_reductions_2D_nans():


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
