### PR TITLE
Dask.config set and get normalize underscores and hyphens

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -119,7 +119,7 @@ def normalize_nested_keys(config):
     Examples
     --------
     >>> a = {'x': 1, 'y_1': {'a_2': 2}}
-    >>> normalize_nested_keys(a)  # doctest: +SKIP
+    >>> normalize_nested_keys(a)
     {'x': 1, 'y-1': {'a-2': 2}}
     """
     config_norm = {}

--- a/dask/config.py
+++ b/dask/config.py
@@ -225,6 +225,17 @@ def ensure_file(
         pass
 
 
+def normalize_key(key):
+    """ Replaces single underscores with hyphens
+
+    Parameters
+    ----------
+    key : string
+        Key to assign.
+    """
+    return key.replace('_', '-')
+
+
 class set(object):
     """ Temporarily set configuration values within a context manager
 
@@ -285,7 +296,7 @@ class set(object):
         path: List[str]
             Used internally to hold the path of old values
         """
-        key = keys[0].replace('_', '-')
+        key = normalize_key(keys[0])
         if len(keys) == 1:
             if old is not None:
                 path_key = tuple(path + [key])
@@ -392,7 +403,7 @@ def get(key, default=no_default, config=config):
     keys = key.split('.')
     result = config
     for k in keys:
-        k = k.replace('_', '-')
+        k = normalize_key(k)
         try:
             result = result[k]
         except (TypeError, IndexError, KeyError):

--- a/dask/config.py
+++ b/dask/config.py
@@ -285,16 +285,16 @@ class set(object):
         path: List[str]
             Used internally to hold the path of old values
         """
+        key = keys[0].replace('_', '-')
         if len(keys) == 1:
             if old is not None:
-                path_key = tuple(path + [keys[0]])
-                if keys[0] in d:
-                    old[path_key] = d[keys[0]]
+                path_key = tuple(path + [key])
+                if key in d:
+                    old[path_key] = d[key]
                 else:
                     old[path_key] = '--delete--'
-            d[keys[0]] = value
+            d[key] = value
         else:
-            key = keys[0]
             if key not in d:
                 d[key] = {}
                 if old is not None:
@@ -392,6 +392,7 @@ def get(key, default=no_default, config=config):
     keys = key.split('.')
     result = config
     for k in keys:
+        k = k.replace('_', '-')
         try:
             result = result[k]
         except (TypeError, IndexError, KeyError):

--- a/dask/config.py
+++ b/dask/config.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     yaml = None
 
-from .compatibility import makedirs, builtins, Mapping
+from .compatibility import makedirs, builtins, Mapping, string_types
 
 
 no_default = '__no_default__'
@@ -103,14 +103,16 @@ def merge(*dicts):
 
 
 def normalize_key(key):
-    """ Replaces underscores with hyphens
+    """ Replaces underscores with hyphens in string keys
 
     Parameters
     ----------
-    key : string
+    key : string, int, or float
         Key to assign.
     """
-    return key.replace('_', '-')
+    if isinstance(key, string_types):
+        key = key.replace('_', '-')
+    return key
 
 
 def normalize_nested_keys(config):

--- a/dask/config.py
+++ b/dask/config.py
@@ -102,6 +102,17 @@ def merge(*dicts):
     return result
 
 
+def normalize_key(key):
+    """ Replaces underscores with hyphens
+
+    Parameters
+    ----------
+    key : string
+        Key to assign.
+    """
+    return key.replace('_', '-')
+
+
 def normalize_nested_keys(config):
     """ Replaces underscores with hyphens for keys for a nested Mapping
 
@@ -244,17 +255,6 @@ def ensure_file(
                 os.remove(tmp)
     except OSError:
         pass
-
-
-def normalize_key(key):
-    """ Replaces underscores with hyphens
-
-    Parameters
-    ----------
-    key : string
-        Key to assign.
-    """
-    return key.replace('_', '-')
 
 
 class set(object):

--- a/dask/context.py
+++ b/dask/context.py
@@ -65,7 +65,7 @@ def globalmethod(default=None, key=None, falsey=None):
 class GlobalMethod(object):
     def __init__(self, default, key, falsey=None):
         self._default = default
-        self._key = key
+        self._key = config.normalize_key(key)
         self._falsey = falsey
 
     def __get__(self, instance, owner=None):

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -885,23 +885,3 @@ def test_num_workers_config(scheduler):
     workers = {i.worker_id for i in prof.results}
 
     assert len(workers) == num_workers
-
-
-@pytest.mark.parametrize('scheduler', ['threads', 'processes'])
-def test_num_workers_env_var(monkeypatch, scheduler):
-    num_workers = 3
-    monkeypatch.setenv('DASK_NUM_WORKERS', num_workers)
-    dask.config.refresh()
-
-    @delayed
-    def f(x):
-        time.sleep(0.5)
-        return x
-
-    a = [f(i) for i in range(5)]
-    with Profiler() as prof:
-        a = compute(*a, scheduler=scheduler)
-
-    workers = {i.worker_id for i in prof.results}
-
-    assert len(workers) == num_workers

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -885,3 +885,23 @@ def test_num_workers_config(scheduler):
     workers = {i.worker_id for i in prof.results}
 
     assert len(workers) == num_workers
+
+
+@pytest.mark.parametrize('scheduler', ['threads', 'processes'])
+def test_num_workers_env_var(monkeypatch, scheduler):
+    num_workers = 3
+    monkeypatch.setenv('DASK_NUM_WORKERS', num_workers)
+    dask.config.refresh()
+
+    @delayed
+    def f(x):
+        time.sleep(0.5)
+        return x
+
+    a = [f(i) for i in range(5)]
+    with Profiler() as prof:
+        a = compute(*a, scheduler=scheduler)
+
+    workers = {i.worker_id for i in prof.results}
+
+    assert len(workers) == num_workers

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -320,21 +320,15 @@ def test_normalize_nested_keys():
 def test_env_var_normalization(monkeypatch):
     value = 3
     monkeypatch.setenv('DASK_A_B', value)
-    dask.config.refresh()
-
-    assert get('a_b') == value
-    assert get('a-b') == value
-
-    # Maks sure to remove this test key from config
-    dask.config.config.pop('a-b')
+    d = {}
+    dask.config.refresh(config=d)
+    assert get('a_b', config=d) == value
+    assert get('a-b', config=d) == value
 
 
 @pytest.mark.parametrize('key', ['custom_key', 'custom-key'])
 def test_get_set_roundtrip(key):
     value = 123
-    dask.config.set({key: value})
-    assert dask.config.get('custom_key') == value
-    assert dask.config.get('custom-key') == value
-
-    # Maks sure to remove this test key from config
-    dask.config.config.pop(normalize_key(key))
+    with dask.config.set({key: value}):
+        assert dask.config.get('custom_key') == value
+        assert dask.config.get('custom-key') == value

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -300,9 +300,14 @@ def test_expand_environment_variables(inp, out):
         del os.environ['FOO']
 
 
-@pytest.mark.parametrize('key', ['custom_key', 'custom-key'])
-def test_normalize_key(key):
-    assert normalize_key(key) == 'custom-key'
+@pytest.mark.parametrize('inp,out', [
+    ('custom_key', 'custom-key'),
+    ('custom-key', 'custom-key'),
+    (1, 1),
+    (2.3, 2.3)
+])
+def test_normalize_key(inp, out):
+    assert normalize_key(inp) == out
 
 
 def test_normalize_nested_keys():

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -6,7 +6,8 @@ import pytest
 import dask.config
 from dask.config import (update, merge, collect, collect_yaml, collect_env,
                          get, ensure_file, set, config, rename,
-                         update_defaults, refresh, expand_environment_variables)
+                         update_defaults, refresh, expand_environment_variables,
+                         normalize_nested_keys)
 from dask.utils import tmpfile
 
 
@@ -297,3 +298,15 @@ def test_expand_environment_variables(inp, out):
         assert expand_environment_variables(inp) == out
     finally:
         del os.environ['FOO']
+
+
+def test_normalize_nested_keys():
+    config = {'key_1': 1,
+              'key_2': {'nested_key_1': 2},
+              'key_3': 3
+              }
+    expected = {'key-1': 1,
+                'key-2': {'nested-key-1': 2},
+                'key-3': 3
+                }
+    assert normalize_nested_keys(config) == expected

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -55,6 +55,10 @@ the ``config`` dictionary or the ``get`` function:
 You may wish to inspect the ``dask.config.config`` dictionary to get a sense
 for what configuration is being used by your current system.
 
+Note that the ``get`` function treats underscores and hyphens identically.
+For example, ``dask.config.get('num_workers')`` is equivalent to
+``dask.config.get('num-workers')``.
+
 
 Specify Configuration
 ---------------------
@@ -177,6 +181,10 @@ This function can also be used as a context manager for consistent cleanup.
 
    with dask.config.set({'scheduler.work-stealing': True}):
        ...
+
+Note that the ``set`` function treats underscores and hyphens identically.
+For example, ``dask.config.set({'scheduler.work-stealing': True})`` is
+equivalent to ``dask.config.set({'scheduler.work_stealing': True})``.
 
 
 Updating Configuration


### PR DESCRIPTION
This PR updates `dask.config.get` and `dask.config.set` to both replace single underscores with hyphens. The motivation for this is to avoid a mis-match between configuration variables in Python with underscores, e.g., 

```python
with dask.config.set(num_workers=5):
    ...
```
 
and environment variables, e.g. `DASK_NUM_WORKERS`, which already replace `'_'` with `'-'`.

Fixes #4141

- [x] Tests added / passed
- [x] Passes `flake8 dask`
