### PR TITLE
Add fix for  DataFrame.__setitem__ for index. This fixes #3818

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2490,9 +2490,14 @@ class DataFrame(_Frame):
         raise NotImplementedError(key)
 
     def __setitem__(self, key, value):
-        if isinstance(key, (tuple, list)):
+        if isinstance(key, (tuple, list)) and isinstance(value, DataFrame):
             df = self.assign(**{k: value[c]
                                 for k, c in zip(key, value.columns)})
+
+        elif isinstance(key, pd.Index) and not isinstance(value, DataFrame):
+            key = list(key)
+            df = self.assign(**{k: value
+                                for k in key})
         else:
             df = self.assign(**{key: value})
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2496,8 +2496,7 @@ class DataFrame(_Frame):
 
         elif isinstance(key, pd.Index) and not isinstance(value, DataFrame):
             key = list(key)
-            df = self.assign(**{k: value
-                                for k in key})
+            df = self.assign(**{k: value for k in key})
         else:
             df = self.assign(**{key: value})
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3324,7 +3324,7 @@ def test_partitions_indexer():
 
 def test_setitem():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
-    ddf = dd.from_pandas(df, 2)
+    ddf = dd.from_pandas(df.copy(), 2)
     df[df.columns] = 1
     ddf[ddf.columns] = 1
     assert_eq(df, ddf)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3320,3 +3320,11 @@ def test_partitions_indexer():
     assert ddf.x.partitions[:3].npartitions == 3
 
     assert ddf.x.partitions[::2].compute().tolist() == [0, 1, 4, 5, 8, 9]
+
+
+def test_setitem():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+    ddf = dd.from_pandas(df, 2)
+    df[df.columns] = 1
+    ddf[ddf.columns] = 1
+    assert_eq(df, ddf)


### PR DESCRIPTION
This addresses #3818 

```python
In [1]: import pandas as pd

In [2]: import dask.dataframe as dd

In [3]: df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})

In [4]: ddf = dd.from_pandas(df, 2)

In [5]: df
Out[5]:
   A  B
0  1  3
1  2  4

In [6]: ddf.compute()
Out[6]:
   A  B
0  1  3
1  2  4

In [7]: df[df.columns] = 1

In [8]: df
Out[8]:
   A  B
0  1  1
1  1  1

In [9]: ddf[ddf.columns] = 1

In [10]: ddf.compute()
Out[10]:
   A  B
0  1  1
1  1  1
```
- [x] Tests added / passed
- [ ] Passes `flake8 dask`
