### PR TITLE
Only allocate the result space in `wrapped_pad_func`

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -905,7 +905,7 @@ def pad_stats(array, pad_width, mode, *args):
 
 
 def wrapped_pad_func(array, pad_func, iaxis_pad_width, iaxis, pad_func_kwargs):
-    result = array.copy()
+    result = np.empty_like(array)
     for i in np.ndindex(array.shape[:iaxis] + array.shape[iaxis + 1:]):
         i = i[:iaxis] + (slice(None),) + i[iaxis:]
         result[i] = pad_func(array[i], iaxis_pad_width, iaxis, pad_func_kwargs)


### PR DESCRIPTION
Previously `wrapped_pad_func` was copying the input `array` into `result` and then overwriting it. However the copy shouldn't be needed as it isn't used. Thus this uses `np.empty` to create the NumPy array with correct shape and type instead leaving filling it to the `for`-loop below.

- [x] Tests added / passed
- [x] Passes `flake8 dask`