### PR TITLE
Only subs on core collections, not subclasses

### DIFF
--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -1,3 +1,4 @@
+import collections
 from operator import add
 
 import pytest
@@ -361,3 +362,21 @@ def test_svd():
     u, s, v = da.linalg.svd(y)
     z = y + u
     assert_eq(z, z)
+
+
+@pytest.mark.parametrize('tup', [
+    (1, 2),
+    collections.namedtuple('foo', ['a', 'b'])(1, 2),
+])
+def test_namedtuple(tup):
+    A = da.random.random((20, 20), chunks=(10, 10))
+
+    def f(data, x):
+        return data
+
+    B = da.atop(f, ("d1", "d2"),
+                A, ("d1", "d2"),
+                x=tup,
+                dtype=A.dtype)
+
+    assert_eq(A, B)

--- a/dask/array/top.py
+++ b/dask/array/top.py
@@ -18,7 +18,7 @@ def subs(task, substitution):
     """
     if isinstance(task, dict):
         return {k: subs(v, substitution) for k, v in task.items()}
-    if isinstance(task, (tuple, list, set)):
+    if type(task) in (tuple, list, set):
         return type(task)([subs(x, substitution) for x in task])
     try:
         return substitution[task]


### PR DESCRIPTION
This avoids bad behavior with subclasses like namedtuples

Fixes #4158

- [x] Tests added / passed
- [x] Passes `flake8 dask`
