### PR TITLE
Raise descriptive error when boolean-indexing a dask array with NaN chunks

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -962,34 +962,6 @@ def slice_with_int_dask_array_on_axis(x, idx, axis):
     return y
 
 
-def _flat_chunks(c):
-    """
-    Helper function to retrieve all chunks attributes from dask arrays and
-    return them as a flat iterable of chunk sizes from the input dask arrays.
-
-    Parameters
-    ----------
-    c: Either a NumPy array, a dask array or an iterable, from which to
-       retrieve all dask array chunksizes
-
-    Returns
-    -------
-    Chunk sizes from all input dask arrays, as a flat list.
-
-    """
-    if is_dask_collection(c):
-        arrays = (c,)
-    else:
-        try:
-            arrays = filter(lambda x: hasattr(x, 'chunks'), c)
-        except TypeError:
-            arrays = filter(lambda x: hasattr(x, 'chunks'), (c,))
-    all_chunks = []
-    for array in arrays:
-        all_chunks.extend(array.chunks)
-    return list(chain.from_iterable(all_chunks))
-
-
 def slice_with_bool_dask_array(x, index):
     """ Slice x with one or more dask arrays of bools
 

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1012,13 +1012,10 @@ def slice_with_bool_dask_array(x, index):
     """
     from .core import Array, atop, elemwise
 
-    x_chunks = _flat_chunks(x)
-    nan_in_x_chunks = np.isnan(x_chunks).any()
-    index_chunks = _flat_chunks(index)
-    nan_in_index_chunks = np.isnan(index_chunks).any()
-    failure_mode = nan_in_x_chunks and not nan_in_index_chunks
+    nan_shape_dims = [i for i, v in enumerate(x.shape) if np.isnan(v)]
+    dims_to_index = [i for i, idx in enumerate(index) if not isinstance(idx, slice)]
 
-    if failure_mode:
+    if nan_shape_dims == dims_to_index:
         raise NotImplementedError("Slicing an array with unknown chunks with "
                                   "a dask.array of bools is not supported")
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3092,7 +3092,7 @@ def test_index_array_with_array_1d():
 
     dy = da.ones(11, chunks=(3,))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         dx[dy > 5]
 
 

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -8,7 +8,7 @@ np = pytest.importorskip('numpy')
 
 import dask
 import dask.array as da
-from dask.array.slicing import (_flat_chunks, _sanitize_index_element, _slice_1d,
+from dask.array.slicing import (_sanitize_index_element, _slice_1d,
                                 new_blockdim, sanitize_index, slice_array,
                                 take, normalize_index, slicing_plan)
 from dask.array.utils import assert_eq, same_keys
@@ -623,23 +623,6 @@ def test_index_with_int_dask_array_nocompute():
     result = x[idx]
     with pytest.raises(NotImplementedError):
         result.compute()
-
-
-def test_flat_chunks():
-    x = np.arange(10)
-    dx = da.from_array(x, chunks=(5,))
-    dxn = da.from_array(x, chunks=-1)
-    dxn._chunks = ((np.nan, np.nan),)
-    s = slice(None)
-
-    # Check single items.
-    assert _flat_chunks(x) == []
-    assert _flat_chunks(dx) == [5, 5]
-    assert _flat_chunks(s) == []
-
-    # Check combinations.
-    assert _flat_chunks([x, dx, s]) == [5, 5]
-    assert _flat_chunks([dx, dxn]) == [5, 5, np.nan, np.nan]
 
 
 def test_index_with_bool_dask_array():

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -8,7 +8,7 @@ np = pytest.importorskip('numpy')
 
 import dask
 import dask.array as da
-from dask.array.slicing import (_sanitize_index_element, _slice_1d,
+from dask.array.slicing import (_flat_chunks, _sanitize_index_element, _slice_1d,
                                 new_blockdim, sanitize_index, slice_array,
                                 take, normalize_index, slicing_plan)
 from dask.array.utils import assert_eq, same_keys
@@ -623,6 +623,23 @@ def test_index_with_int_dask_array_nocompute():
     result = x[idx]
     with pytest.raises(NotImplementedError):
         result.compute()
+
+
+def test_flat_chunks():
+    x = np.arange(10)
+    dx = da.from_array(x, chunks=(5,))
+    dxn = da.from_array(x, chunks=-1)
+    dxn._chunks = ((np.nan, np.nan),)
+    s = slice(None)
+
+    # Check single items.
+    assert _flat_chunks(x) == []
+    assert _flat_chunks(dx) == [5, 5]
+    assert _flat_chunks(s) == []
+
+    # Check combinations.
+    assert _flat_chunks([x, dx, s]) == [5, 5]
+    assert _flat_chunks([dx, dxn]) == [5, 5, np.nan, np.nan]
 
 
 def test_index_with_bool_dask_array():

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -441,6 +441,15 @@ def test_boolean_numpy_array_slicing():
     assert_eq(da.asarray([0])[ind], np.arange(1)[ind])
 
 
+def test_boolean_slicing_nan_chunks():
+    dx1 = da.from_array(np.arange(20), chunks=4)
+    dx2 = da.from_array(np.arange(10, 30), chunks=4)
+    dx3 = dx1[dx2 > 5]
+    with pytest.raises(NotImplementedError,
+                       message='unknown chunks with a dask.array of bools'):
+        dx3[dx2 > 10]
+
+
 def test_empty_list():
     x = np.ones((5, 5, 5), dtype='i4')
     dx = da.from_array(x, chunks=2)


### PR DESCRIPTION
Raise a descriptive error when trying to perform a boolean indexing operation on a dask array with `NaN` chunks. This produces a more accurate (and relevant?) error than the current situation:

```python
>>> dxn
dask.array<array, shape=(nan,), dtype=int64, chunksize=(nan,)>
>>> dxn[dxn > 5]
```
```python-traceback
ValueError                                Traceback (most recent call last)
...
ValueError: operands could not be broadcast together with shapes (nan,) (6,)
```

Fixes #3824, inasmuch as it improves the error message, as per [the suggestion there](https://github.com/dask/dask/issues/3824#issuecomment-408715809). 

Checklist:
- [x] Tests added / passed (locally)
- [x] Passes `flake8 dask`
