### PR TITLE
Add traverse support for dataclasses

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -13,7 +13,8 @@ import uuid
 from toolz import merge, groupby, curry, identity
 from toolz.functoolz import Compose
 
-from .compatibility import long, unicode, Iterator
+from .compatibility import apply, long, unicode, Iterator, is_dataclass, \
+    dataclass_fields
 from .context import thread_state
 from .core import flatten, quote, get as simple_get
 from .hashing import hash_buffer_hex
@@ -264,6 +265,10 @@ def unpack_collections(*args, **kwargs):
             elif typ is dict:
                 tsk = (dict, [[_unpack(k), _unpack(v)]
                               for k, v in expr.items()])
+            elif is_dataclass(expr):
+                tsk = (apply, typ, (), (dict,
+                       [[f.name, _unpack(getattr(expr, f.name))] for f in
+                        dataclass_fields(expr)]))
             else:
                 return expr
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -13,8 +13,8 @@ import uuid
 from toolz import merge, groupby, curry, identity
 from toolz.functoolz import Compose
 
-from .compatibility import apply, long, unicode, Iterator, is_dataclass, \
-    dataclass_fields
+from .compatibility import (apply, long, unicode, Iterator, is_dataclass,
+                            dataclass_fields)
 from .context import thread_state
 from .core import flatten, quote, get as simple_get
 from .hashing import hash_buffer_hex

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -307,7 +307,7 @@ def getargspec(func):
     """Version of inspect.getargspec that works with partial and warps."""
     if isinstance(func, functools.partial):
         return getargspec(func.func)
- 
+
     func = getattr(func, '__wrapped__', func)
     if isinstance(func, type):
         return _getargspec(func.__init__)
@@ -337,3 +337,17 @@ def bind_method(cls, name, func):
         setattr(cls, name, types.MethodType(func, None, cls))
     else:
         setattr(cls, name, func)
+
+
+try:
+    from dataclasses import is_dataclass, fields as dataclass_fields, make_dataclass
+
+except ImportError:
+    def is_dataclass(x):
+        return False
+
+    def dataclass_fields(x):
+        return []
+
+    def make_dataclass(*args, **kwargs):
+        raise NotImplemented()

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -340,7 +340,7 @@ def bind_method(cls, name, func):
 
 
 try:
-    from dataclasses import is_dataclass, fields as dataclass_fields, make_dataclass
+    from dataclasses import is_dataclass, fields as dataclass_fields
 
 except ImportError:
     def is_dataclass(x):
@@ -348,6 +348,3 @@ except ImportError:
 
     def dataclass_fields(x):
         return []
-
-    def make_dataclass(*args, **kwargs):
-        raise NotImplemented()

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -18,7 +18,7 @@ from dask.base import (compute, tokenize, normalize_token, normalize_function,
 from dask.delayed import Delayed
 from dask.utils import tmpdir, tmpfile, ignoring
 from dask.utils_test import inc, dec
-from dask.compatibility import long, unicode, PY2, make_dataclass
+from dask.compatibility import long, unicode, PY2
 from dask.diagnostics import Profiler
 
 
@@ -348,10 +348,8 @@ def test_is_dask_collection():
 
 try:
     import dataclasses
-
     # Avoid @dataclass decorator as Python < 3.7 fail to interpret the type hints
-    ADataClass = make_dataclass('ADataClass', [('a', int)])
-
+    ADataClass = dataclasses.make_dataclass('ADataClass', [('a', int)])
 except ImportError:
     dataclasses = None
 

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -9,7 +9,7 @@ import pytest
 
 import dask
 from dask import compute
-from dask.compatibility import PY2, PY3, make_dataclass
+from dask.compatibility import PY2, PY3
 from dask.delayed import delayed, to_task_dask, Delayed
 from dask.utils_test import inc
 
@@ -95,10 +95,10 @@ def test_delayed():
 
 
 def test_delayed_with_dataclass():
-    pytest.importorskip("dataclasses")
+    dataclasses = pytest.importorskip("dataclasses")
 
     # Avoid @dataclass decorator as Python < 3.7 fail to interpret the type hints
-    ADataClass = make_dataclass('ADataClass', [('a', int)])
+    ADataClass = dataclasses.make_dataclass('ADataClass', [('a', int)])
 
     literal = dask.delayed(3)
     with_class = dask.delayed({"a": ADataClass(a=literal)})


### PR DESCRIPTION
`Dataclasses` are not traversed right now. As I see them replacing pure `dicts` in quite some cases I think it would be nice to handle them as well.

No tests yet added, wanted to check first if you guys are interested.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
