### PR TITLE
Fix import for broadcast_to.

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -16,7 +16,7 @@ from numbers import Integral
 try:
     from numpy import broadcast_to
 except ImportError:  # pragma: no cover
-    broadcast_to = npcompat.broadcast_to
+    from ..core import broadcast_to
 
 try:
     from numpy import take_along_axis

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -14,11 +14,6 @@ from ..utils import ignoring
 from numbers import Integral
 
 try:
-    from numpy import broadcast_to
-except ImportError:  # pragma: no cover
-    from ..core import broadcast_to
-
-try:
     from numpy import take_along_axis
 except ImportError:  # pragma: no cover
     take_along_axis = npcompat.take_along_axis
@@ -231,7 +226,7 @@ def argtopk(a_plus_idx, k, axis, keepdims):
     if isinstance(a_plus_idx, list):
         a_plus_idx = list(flatten(a_plus_idx))
         a = np.concatenate([ai for ai, _ in a_plus_idx], axis)
-        idx = np.concatenate([broadcast_to(idxi, ai.shape)
+        idx = np.concatenate([np.broadcast_to(idxi, ai.shape)
                               for ai, idxi in a_plus_idx], axis)
     else:
         a, idx = a_plus_idx

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3354,7 +3354,7 @@ def broadcast_to(x, shape, chunks=None):
                           for bd, i in zip(x.chunks, new_index[ndim_new:]))
         old_key = (x.name,) + old_index
         new_key = (name,) + new_index
-        dsk[new_key] = (chunk.broadcast_to, old_key, quote(chunk_shape))
+        dsk[new_key] = (np.broadcast_to, old_key, quote(chunk_shape))
 
     return Array(sharedict.merge((name, dsk), x.dask, dependencies={name: {x.name}}),
                  name, chunks, dtype=x.dtype)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -870,7 +870,7 @@ def test_broadcast_to():
     a = from_array(x, chunks=(3, 1, 3))
 
     for shape in [a.shape, (5, 0, 6), (5, 4, 6), (2, 5, 1, 6), (3, 4, 5, 4, 6)]:
-        xb = chunk.broadcast_to(x, shape)
+        xb = np.broadcast_to(x, shape)
         ab = broadcast_to(a, shape)
 
         assert_eq(xb, ab)
@@ -910,7 +910,7 @@ def test_broadcast_to_chunks():
             ((5, 3, 6), (3, -1, 3), ((3, 2), (3,), (3, 3))),
             ((5, 3, 6), (3, 1, 3), ((3, 2), (1, 1, 1,), (3, 3))),
             ((2, 5, 3, 6), (1, 3, 1, 3), ((1, 1), (3, 2), (1, 1, 1,), (3, 3)))]:
-        xb = chunk.broadcast_to(x, shape)
+        xb = np.broadcast_to(x, shape)
         ab = broadcast_to(a, shape, chunks=chunks)
         assert_eq(xb, ab)
         assert ab.chunks == expected_chunks

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -24,8 +24,6 @@ from dask.delayed import Delayed, delayed
 from dask.utils import ignoring, tmpfile, tmpdir, key_split
 from dask.utils_test import inc, dec
 
-from dask.array import chunk
-
 from dask.array.core import (getem, getter, top, dotmany, concatenate3,
                              broadcast_dimensions, Array, stack, concatenate,
                              from_array, broadcast_shapes,


### PR DESCRIPTION
The import fails when it's not imported from numpy.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
