### PR TITLE
Fix column choice when passing list of files to fastparquet

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -181,7 +181,7 @@ def _read_fastparquet(fs, fs_token, paths, columns=None, filters=None,
     if isinstance(paths, fastparquet.api.ParquetFile):
         pf = paths
     elif len(paths) > 1:
-        if infer_divisions is not True:
+        if infer_divisions is not False:
             # this scans all the files, allowing index/divisions and filtering
             pf = fastparquet.ParquetFile(paths, open_with=fs.open, sep=fs.sep)
         else:

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -178,15 +178,15 @@ def _read_fastparquet(fs, fs_token, paths, columns=None, filters=None,
                       categories=None, index=None, infer_divisions=None):
     import fastparquet
 
-    if isinstance(paths,fastparquet.api.ParquetFile):
+    if isinstance(paths, fastparquet.api.ParquetFile):
         pf = paths
     elif len(paths) > 1:
-        if infer_divisions:
+        if infer_divisions is not True:
             # this scans all the files, allowing index/divisions and filtering
             pf = fastparquet.ParquetFile(paths, open_with=fs.open, sep=fs.sep)
         else:
-            return _read_fp_multifile(fs, fs_token, paths, columns=None,
-                                      categories=None, index=None)
+            return _read_fp_multifile(fs, fs_token, paths, columns=columns,
+                                      categories=categories, index=index)
     else:
         try:
             pf = fastparquet.ParquetFile(paths[0] + fs.sep + '_metadata',

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -668,6 +668,7 @@ def test_ordering(tmpdir, write_engine, read_engine):
 
 
 def test_read_parquet_custom_columns(tmpdir, engine):
+    import glob
     tmp = str(tmpdir)
     data = pd.DataFrame({'i32': np.arange(1000, dtype=np.int32),
                          'f': np.arange(1000, dtype=np.float64)})
@@ -680,6 +681,15 @@ def test_read_parquet_custom_columns(tmpdir, engine):
                           infer_divisions=should_check_divs(engine))
     assert_eq(df[['i32', 'f']], df2,
               check_index=False, check_divisions=should_check_divs(engine))
+
+    import glob
+    fns = glob.glob(os.path.join(tmp, '*.parquet'))
+    df2 = dd.read_parquet(fns,
+                          columns=['i32'],
+                          engine=engine).compute()
+    df2.sort_values('i32', inplace=True)
+    assert_eq(df[['i32']], df2,
+              check_index=False, check_divisions=False)
 
     df3 = dd.read_parquet(tmp,
                           columns=['f', 'i32'],


### PR DESCRIPTION
Came up while testing Intake stuff

- [x] Tests added / passed
- [x] Passes `flake8 dask`
