### PR TITLE
Avoid optimization on sharedicts without dependencies

### DIFF
--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -380,3 +380,28 @@ def test_namedtuple(tup):
                 dtype=A.dtype)
 
     assert_eq(A, B)
+
+
+def test_gh_4176():
+    def foo(A):
+        return A[None, ...]
+
+    A = da.ones(shape=(10, 20, 4), chunks=(2, 5, 4))
+
+    name = 'D'
+
+    dsk = da.core.top(
+        foo, name, ("nsrc", "ntime", "nbl", "npol"),
+        A.name, ("ntime", "nbl", "npol"),
+        new_axes={"nsrc": 1},
+        numblocks={a.name: a.numblocks for a in (A,)}
+    )
+
+    array_dsk = dask.sharedict.ShareDict()
+    array_dsk.update(dsk)
+    array_dsk.update(A.__dask_graph__())
+
+    chunks = ((1,),) + A.chunks
+
+    D = da.Array(array_dsk, name, chunks, dtype=A.dtype)
+    D.sum(axis=0).compute()

--- a/dask/array/top.py
+++ b/dask/array/top.py
@@ -591,7 +591,8 @@ def optimize_atop(full_graph, keys=()):
             deps = set(top_layers)
             while deps:  # we gather as many sub-layers as we can
                 dep = deps.pop()
-                if (isinstance(layers[dep], TOP) and
+                if (dep in layers and
+                        isinstance(layers[dep], TOP) and
                         not (dep != layer and dep in keep) and  # output layer
                         layers[dep].concatenate == layers[layer].concatenate):  # punt on mixed concatenate
                     top_layers.add(dep)


### PR DESCRIPTION
When users construct Sharedicts manually they may not provide
dependencies.  If so, we should just avoid optimizing gracefully.

Fixes #4176

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
