### PR TITLE
Use recursive glob in LocalFileSystem

### DIFF
--- a/dask/bytes/local.py
+++ b/dask/bytes/local.py
@@ -33,7 +33,10 @@ class LocalFileSystem(object):
 
     def glob(self, path):
         """For a template path, return matching files"""
-        return sorted(glob(self._normalize_path(path)))
+        try:
+            return sorted(glob(self._normalize_path(path), recursive=True))
+        except TypeError:  # recursive kwarg is new in Python 3.5
+            return sorted(glob(self._normalize_path(path)))
 
     def mkdirs(self, path):
         """Make any intermediate directories to make path writable"""

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -31,7 +31,9 @@ files = {'.test.accounts.1.json': (b'{"amount": 100, "name": "Alice"}\n'
 csv_files = {'.test.fakedata.1.csv': (b'a,b\n'
                                       b'1,2\n'),
              '.test.fakedata.2.csv': (b'a,b\n'
-                                      b'3,4\n')}
+                                      b'3,4\n'),
+             'subdir/.test.fakedata.2.csv': (b'a,b\n'
+                                             b'5,6\n')}
 
 
 try:
@@ -99,6 +101,15 @@ def test_urlpath_expand_read():
         assert len(paths) == 2
         _, _, paths = get_fs_token_paths(['.*.csv'])
         assert len(paths) == 2
+
+
+@pytest.mark.skipif(sys.version_info < (3, 5),
+                    reason="Recursive glob is new in Python 3.5")
+def test_recursive_glob_expand():
+    """Make sure * is expanded in file paths when reading."""
+    with filetexts(csv_files, mode='b'):
+        _, _, paths = get_fs_token_paths('**/.*.csv')
+        assert len(paths) == 3
 
 
 def test_urlpath_expand_write():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -196,6 +196,10 @@ def filetexts(d, open=open, mode='t', use_tmpdir=True):
     """
     with (tmp_cwd() if use_tmpdir else noop_context()):
         for filename, text in d.items():
+            try:
+                os.makedirs(os.path.dirname(filename))
+            except OSError:
+                pass
             f = open(filename, 'w' + mode)
             try:
                 f.write(text)


### PR DESCRIPTION
Currently using a wildcard like `dd.read_csv(dir/**/*.csv)` works with a remote path (at least for GCS) but not locally. That functionality is quite useful so it seems nice to have locally in case where it's possible, which it is for the std lib `glob` in 3.5+.