### PR TITLE
Update the pytest version for TravisCI

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -51,7 +51,7 @@ conda install -q -c conda-forge \
     partd \
     psutil \
     pytables \
-    "pytest<=3.1.1" \
+    "pytest<=3.10" \
     requests \
     scikit-image \
     scikit-learn \


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `flake8 dask`

Just update the pytest version to `3.10`. All tests passed with py36 on my laptop.