### PR TITLE
Avoid recursion in dask.core.get

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -77,74 +77,55 @@ def preorder_traversal(task):
             yield item
 
 
-def _get_nonrecursive(d, x, maxdepth=1000):
-    # Non-recursive. DAG property is checked upon reaching maxdepth.
-    _list = lambda *args: list(args)
-
-    # We construct a nested hierarchy of tuples to mimic the execution stack
-    # of frames that Python would maintain for a recursive implementation.
-    # A frame is associated with a single task from a Dask.
-    # A frame tuple has three elements:
-    #    1) The function for the task.
-    #    2) The arguments for the task (typically keys in the Dask).
-    #       Arguments are stored in reverse order, and elements are popped
-    #       as they are evaluated.
-    #    3) The calculated results of the arguments from (2).
-    stack = [(lambda x: x, [x], [])]
-    while True:
-        func, args, results = stack[-1]
-        if not args:
-            val = func(*results)
-            if len(stack) == 1:
-                return val
-            stack.pop()
-            stack[-1][2].append(val)
-            continue
-        elif maxdepth and len(stack) > maxdepth:
-            cycle = getcycle(d, x)
-            if cycle:
-                cycle = '->'.join(cycle)
-                raise RuntimeError('Cycle detected in Dask: %s' % cycle)
-            maxdepth = None
-
-        key = args.pop()
-        if isinstance(key, list):
-            stack.append((_list, list(key[::-1]), []))
-            continue
-        elif ishashable(key) and key in d:
-            args.append(d[key])
-            continue
-        elif istask(key):
-            stack.append((key[0], list(key[:0:-1]), []))
-        else:
-            results.append(key)
-
-
-def _get_recursive(dsk, x, cache):
-    # recursive, no cycle detection
-    if isinstance(x, list):
-        return [_get_recursive(dsk, k, cache) for k in x]
-
-    hashable = ishashable(x)
-    if hashable and x in cache:
-        return cache[x]
-    elif hashable and x in dsk:
-        res = cache[x] = _get_recursive(dsk, dsk[x], cache)
-        return res
-    elif type(x) is tuple and x and callable(x[0]):  # istask
-        func, args = x[0], x[1:]
-        args2 = [_get_recursive(dsk, k, cache) for k in args]
-        return func(*args2)
-    return x
-
-
 def lists_to_tuples(res, keys):
     if isinstance(keys, list):
         return tuple(lists_to_tuples(r, k) for r, k in zip(res, keys))
     return res
 
 
-def get(d, x, recursive=False, cache=None):
+def _execute_task(arg, cache, dsk=None):
+    """ Do the actual work of collecting data and executing a function
+
+    Examples
+    --------
+
+    >>> cache = {'x': 1, 'y': 2}
+
+    Compute tasks against a cache
+    >>> _execute_task((add, 'x', 1), cache)  # Compute task in naive manner
+    2
+    >>> _execute_task((add, (inc, 'x'), 1), cache)  # Support nested computation
+    3
+
+    Also grab data from cache
+    >>> _execute_task('x', cache)
+    1
+
+    Support nested lists
+    >>> list(_execute_task(['x', 'y'], cache))
+    [1, 2]
+
+    >>> list(map(list, _execute_task([['x', 'y'], ['y', 'x']], cache)))
+    [[1, 2], [2, 1]]
+
+    >>> _execute_task('foo', cache)  # Passes through on non-keys
+    'foo'
+    """
+    if isinstance(arg, list):
+        return [_execute_task(a, cache) for a in arg]
+    elif istask(arg):
+        func, args = arg[0], arg[1:]
+        args2 = [_execute_task(a, cache) for a in args]
+        return func(*args2)
+    elif not ishashable(arg):
+        return arg
+    elif arg in cache:
+        return cache[arg]
+    else:
+        return arg
+
+
+def get(dsk, out, cache=None):
     """ Get value from Dask
 
     Examples
@@ -158,18 +139,19 @@ def get(d, x, recursive=False, cache=None):
     >>> get(d, 'y')
     2
     """
-    for k in (flatten(x) if isinstance(x, list) else [x]):
-        if k not in d:
+    for k in (flatten(out) if isinstance(out, list) else [out]):
+        if k not in dsk:
             raise KeyError("{0} is not a key in the graph".format(k))
-    if recursive:
-        res = _get_recursive(d, x, cache or {})
-    else:
-        if cache is not None:
-            raise ValueError("Cache not supported")
-        res = _get_nonrecursive(d, x)
-    if isinstance(x, list):
-        return lists_to_tuples(res, x)
-    return res
+    if cache is None:
+        cache = {}
+    for key in toposort(dsk):
+        task = dsk[key]
+        result = _execute_task(task, cache)
+        cache[key] = result
+    result = _execute_task(out, cache)
+    if isinstance(out, list):
+        result = lists_to_tuples(result, out)
+    return result
 
 
 def get_dependencies(dsk, key=None, task=None, as_list=False):

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -4,10 +4,10 @@ import math
 import re
 from operator import getitem
 
-from . import config
+from . import config, core
 from .compatibility import unicode
 from .core import (istask, get_dependencies, subs, toposort,
-                   flatten, reverse_dict, ishashable, _get_recursive)
+                   flatten, reverse_dict, ishashable)
 from .utils_test import add, inc  # noqa: F401
 
 
@@ -938,8 +938,8 @@ class SubgraphCallable(object):
         if not len(args) == len(self.inkeys):
             raise ValueError("Expected %d args, got %d"
                              % (len(self.inkeys), len(args)))
-        return _get_recursive(self.dsk, self.outkey,
-                              dict(zip(self.inkeys, args)))
+        return core.get(self.dsk, self.outkey,
+                        dict(zip(self.inkeys, args)))
 
     def __reduce__(self):
         return (SubgraphCallable,

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -916,7 +916,7 @@ class SubgraphCallable(object):
     __slots__ = ('dsk', 'outkey', 'inkeys', 'name')
 
     def __init__(self, dsk, outkey, inkeys, name='subgraph_callable'):
-        self.dsk = dsk
+        self.dsk, _ = cull(dsk, outkey)
         self.outkey = outkey
         self.inkeys = inkeys
         self.name = name

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -916,7 +916,7 @@ class SubgraphCallable(object):
     __slots__ = ('dsk', 'outkey', 'inkeys', 'name')
 
     def __init__(self, dsk, outkey, inkeys, name='subgraph_callable'):
-        self.dsk, _ = cull(dsk, outkey)
+        self.dsk = dsk
         self.outkey = outkey
         self.inkeys = inkeys
         self.name = name

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -56,14 +56,6 @@ class TestGet(GetFunctionTestMixin):
     get = staticmethod(core.get)
 
 
-class TestRecursiveGet(GetFunctionTestMixin):
-    get = staticmethod(lambda d, k: core.get(d, k, recursive=True))
-
-    def test_get_stack_limit(self):
-        # will blow stack in recursive mode
-        pass
-
-
 def test_GetFunctionTestMixin_class():
     class TestCustomGetFail(GetFunctionTestMixin):
         get = staticmethod(lambda x, y: 1)

--- a/dask/tests/test_optimization.py
+++ b/dask/tests/test_optimization.py
@@ -1089,10 +1089,6 @@ def test_fuse_reductions_multiple_input():
     })
 
 
-def dontcall(x):
-    raise ValueError("shouldn't be called")
-
-
 def func_with_kwargs(a, b, c=2):
     return a + b + c
 
@@ -1108,7 +1104,6 @@ def test_SubgraphCallable():
            'd': (inc, 'a'),
            'e': (add, 'c', 'd'),
            'f': ['a', 2, 'b', (add, 'b', (sum, non_hashable))],
-           'g': (dontcall, 'in1'),
            'h': (add, (sum, 'f'), (sum, ['a', 'b']))}
 
     f = SubgraphCallable(dsk, 'h', ['in1', 'in2'], name='test')


### PR DESCRIPTION
Instead we use a topological sort

This cleans up tracebacks and profiling a bit when we have large complex
tasks or graphs (as we sometimes do when fusing many sequential tasks
together)

- [x] Tests added / passed
- [x] Passes `flake8 dask`

cc @jcrist (no rush)