### PR TITLE
Docs: Update dataframe-groupby.rst [skip ci]

### DIFF
--- a/docs/source/dataframe-groupby.rst
+++ b/docs/source/dataframe-groupby.rst
@@ -5,7 +5,7 @@ Shuffling for GroupBy and Join
 
 Operations like ``groupby``, ``join``, and ``set_index`` have special
 performance considerations that are different from normal Pandas due to the
-parallel, larger-than-memory, and distributed nature of dask.dataframe.
+parallel, larger-than-memory, and distributed nature of Dask DataFrame.
 
 Easy Case
 ---------
@@ -15,16 +15,16 @@ To start off, common groupby operations like
 var, count, nunique`` are all quite fast and efficient, even if partitions are
 not cleanly divided with known divisions.  This is the common case.
 
-Additionally, if divisions are known then applying an arbitrary function to
+Additionally, if divisions are known, then applying an arbitrary function to
 groups is efficient when the grouping columns include the index.
 
-Joins are also quite fast when joining a Dask dataframe to a Pandas dataframe
-or when joining two Dask dataframes along their index.  No special
+Joins are also quite fast when joining a Dask DataFrame to a Pandas DataFrame
+or when joining two Dask DataFrames along their index.  No special
 considerations need to be made when operating in these common cases.
 
-So if you're doing common groupby and join operations then you can stop reading
-this.  Everything will scale nicely.  Fortunately this is true most of the
-time.
+So, if you're doing common groupby and join operations, then you can stop reading
+this.  Everything will scale nicely.  Fortunately, this is true most of the
+time:
 
 .. code-block:: python
 
@@ -40,7 +40,7 @@ Difficult Cases
 In some cases, such as when applying an arbitrary function to groups (when not
 grouping on index with known divisions), when joining along non-index columns,
 or when explicitly setting an unsorted column to be the index, we may need to
-trigger a full dataset shuffle
+trigger a full dataset shuffle:
 
 .. code-block:: python
 
@@ -49,10 +49,10 @@ trigger a full dataset shuffle
    >>> df.set_index(column)                          # Requires shuffle
 
 A shuffle is necessary when we need to re-sort our data along a new index.  For
-example if we have banking records that are organized by time and we now want
-to organize them by user ID then we'll need to move a lot of data around.  In
-Pandas all of this data fit in memory, so this operation was easy.  Now that we
-don't assume that all data fits in memory we must be a bit more careful.
+example, if we have banking records that are organized by time and we now want
+to organize them by user ID, then we'll need to move a lot of data around.  In
+Pandas all of this data fits in memory, so this operation was easy.  Now that we
+don't assume that all data fits in memory, we must be a bit more careful.
 
 Re-sorting the data can be avoided by restricting yourself to the easy cases
 mentioned above.
@@ -61,12 +61,13 @@ Shuffle Methods
 ---------------
 
 There are currently two strategies to shuffle data depending on whether you are
-on a single machine or on a distributed cluster.
+on a single machine or on a distributed cluster: shuffle on disk and shuffle 
+over the network.
 
 Shuffle on Disk
 ```````````````
 
-When operating on larger-than-memory data on a single machine we shuffle by
+When operating on larger-than-memory data on a single machine, we shuffle by
 dumping intermediate results to disk.  This is done using the partd_ project
 for on-disk shuffles.
 
@@ -75,8 +76,8 @@ for on-disk shuffles.
 Shuffle over the Network
 ````````````````````````
 
-When operating on a distributed cluster the Dask workers may not have access to
-a shared hard drive.  In this case we shuffle data by breaking input partitions
+When operating on a distributed cluster, the Dask workers may not have access to
+a shared hard drive.  In this case, we shuffle data by breaking input partitions
 into many pieces based on where they will end up and moving these pieces
 throughout the network.  This prolific expansion of intermediate partitions
 can stress the task scheduler.  To manage for many-partitioned datasets we
@@ -86,9 +87,9 @@ effect of shuffling to something closer to ``n log(n)`` with ``log(n)`` copies.
 Selecting methods
 `````````````````
 
-Dask will use on-disk shuffling by default but will switch to task-based
+Dask will use on-disk shuffling by default, but will switch to task-based
 distributed shuffling if the default scheduler is set to use a
-``dask.distributed.Client`` such as would be the case if the user sets the
+``dask.distributed.Client``, such as would be the case if the user sets the
 Client as default:
 
 .. code-block:: python
@@ -97,7 +98,7 @@ Client as default:
 
 Alternatively, if you prefer to avoid defaults, you can configure the global
 shuffling method by using the ``dask.config.set(shuffle=...)`` command.
-This can be done globally,
+This can be done globally:
 
 .. code-block:: python
 
@@ -105,7 +106,7 @@ This can be done globally,
 
     df.groupby(...).apply(...)
 
-or as a context manager
+or as a context manager:
 
 .. code-block:: python
 
@@ -114,7 +115,7 @@ or as a context manager
 
 
 In addition, ``set_index`` also accepts a ``shuffle`` keyword argument that
-can be used to select either on-disk or task-based shuffling
+can be used to select either on-disk or task-based shuffling:
 
 .. code-block:: python
 
@@ -125,15 +126,15 @@ can be used to select either on-disk or task-based shuffling
 Aggregate
 =========
 
-Dask support Pandas' ``aggregate`` syntax to run multiple reductions on the
-same groups. Common reductions, such as ``max``, ``sum``, ``mean`` are directly
-supported:
+Dask supports Pandas' ``aggregate`` syntax to run multiple reductions on the
+same groups.  Common reductions such as ``max``, ``sum``, and ``mean`` are 
+directly supported:
 
 .. code-block:: python
 
     >>> df.groupby(columns).aggregate(['sum', 'mean', 'max', 'min'])
 
-Dask also supports user defined reductions. To ensure proper performance, the
+Dask also supports user defined reductions.  To ensure proper performance, the
 reduction has to be formulated in terms of three independent steps. The
 ``chunk`` step is applied to each partition independently and reduces the data
 within a partition. The ``aggregate`` combines the within partition results.
@@ -142,7 +143,7 @@ The optional ``finalize`` step combines the results returned from the
 recognize the reduction, it has to be passed as an instance of
 ``dask.dataframe.Aggregation``.
 
-For example, ``sum`` could be implemented as
+For example, ``sum`` could be implemented as:
 
 .. code-block:: python
 
@@ -150,12 +151,12 @@ For example, ``sum`` could be implemented as
     df.groupby('g').agg(custom_sum)
 
 The name argument should be different from existing reductions to avoid data
-corruption. The arguments to each function are pre-grouped series objects,
+corruption.  The arguments to each function are pre-grouped series objects,
 similar to ``df.groupby('g')['value']``.
 
 Many reductions can only be implemented with multiple temporaries. To implement
 these reductions, the steps should return tuples and expect multiple arguments.
-A mean function can be implemented as
+A mean function can be implemented as:
 
 .. code-block:: python
 


### PR DESCRIPTION
This PR updates `dataframe-groupby.rst` with a few corrections to grammar, punctuation and naming conventions (nothing major)