### PR TITLE
Fix the average function when there is a masked array

### DIFF
--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -8,6 +8,7 @@ import numpy as np
 from ..base import normalize_token
 from .core import (concatenate_lookup, tensordot_lookup, map_blocks,
                    asanyarray, atop)
+from .routines import _average
 
 
 if LooseVersion(np.__version__) < '1.11.2':
@@ -249,3 +250,8 @@ def set_fill_value(a, fill_value):
     res = a.map_blocks(_set_fill_value, fill_value)
     a.dask = res.dask
     a.name = res.name
+
+
+@wraps(np.ma.average)
+def average(a, axis=None, weights=None, returned=False):
+    return _average(a, axis, weights, returned, is_masked=True)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -20,6 +20,7 @@ from .creation import arange, diag, empty, indices
 from .utils import safe_wraps, validate_axis
 from .wrap import ones
 from .ufunc import multiply, sqrt
+from .ma import getmaskarray
 
 from .core import (Array, map_blocks, elemwise, from_array, asarray,
                    asanyarray, concatenate, stack, atop, broadcast_shapes,
@@ -1326,7 +1327,8 @@ def average(a, axis=None, weights=None, returned=False):
             # setup wgt to broadcast along axis
             wgt = broadcast_to(wgt, (a.ndim - 1) * (1,) + wgt.shape)
             wgt = wgt.swapaxes(-1, axis)
-
+        # if there is a masked array
+        wgt = wgt * (~getmaskarray(a))
         scl = wgt.sum(axis=axis, dtype=result_dtype)
         avg = multiply(a, wgt, dtype=result_dtype).sum(axis) / scl
 

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -331,3 +331,20 @@ def test_set_fill_value():
 
     with pytest.raises(ValueError):
         da.ma.set_fill_value(dmx, dx)
+
+
+def test_average_weights_with_masked_array():
+    mask = np.array([[True, False],
+                     [True, True],
+                     [False, True]])
+    data = np.arange(6).reshape((3, 2))
+    a = np.ma.array(data, mask=mask)
+    d_a = da.ma.masked_array(data=data, mask=mask, chunks=2)
+
+    weights = np.array([0.25, 0.75])
+    d_weights = da.from_array(weights, chunks=2)
+
+    np_avg = np.ma.average(a, weights=weights, axis=1)
+    da_avg = da.ma.average(d_a, weights=d_weights, axis=1)
+
+    assert_eq(np_avg, da_avg)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1607,23 +1607,6 @@ def test_average_weights():
     assert_eq(np_avg, da_avg)
 
 
-def test_average_weights_with_masked_array():
-    mask = np.array([[True, False],
-                     [True, True],
-                     [False, True]])
-    data = np.arange(6).reshape((3, 2))
-    a = np.ma.array(data, mask=mask)
-    d_a = da.ma.masked_array(data=data, mask=mask, chunks=2)
-
-    weights = np.array([0.25, 0.75])
-    d_weights = da.from_array(weights, chunks=2)
-
-    np_avg = np.ma.average(a, weights=weights, axis=1)
-    da_avg = da.average(d_a, weights=d_weights, axis=1)
-
-    assert_eq(np_avg, da_avg)
-
-
 def test_average_raises():
     d_a = da.arange(11, chunks=2)
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1607,6 +1607,23 @@ def test_average_weights():
     assert_eq(np_avg, da_avg)
 
 
+def test_average_weights_with_masked_array():
+    mask = np.array([[True, False],
+                     [True, True],
+                     [False, True]])
+    data = np.arange(6).reshape((3, 2))
+    a = np.ma.array(data, mask=mask)
+    d_a = da.ma.masked_array(data=data, mask=mask, chunks=2)
+
+    weights = np.array([0.25, 0.75])
+    d_weights = da.from_array(weights, chunks=2)
+
+    np_avg = np.ma.average(a, weights=weights, axis=1)
+    da_avg = da.average(d_a, weights=d_weights, axis=1)
+
+    assert_eq(np_avg, da_avg)
+
+
 def test_average_raises():
     d_a = da.arange(11, chunks=2)
 


### PR DESCRIPTION
The Dask average function does not take into account the masked when the sum of weights is computed.

Add a unit test dedicated to this issue.

- [X] Tests added / passed
- [X] Passes `flake8 dask`

close #3846 