### PR TITLE
Text and fix when appending categoricals with fastparquet

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -583,7 +583,9 @@ def _write_fastparquet(df, fs, fs_token, path, write_index=None, append=False,
             raise ValueError('Appended columns not the same.\n'
                              'Previous: {} | New: {}'
                              .format(pf.columns, list(df.columns)))
-        elif set(pf.dtypes[c] for c in pf.columns) != set(df[pf.columns].dtypes):
+        elif (pd.Series(pf.dtypes).loc[pf.columns] != df[pf.columns].dtypes).any():
+            import pdb
+            pdb.set_trace()
             raise ValueError('Appended dtypes differ.\n{}'
                              .format(set(pf.dtypes.items()) ^
                                      set(df.dtypes.iteritems())))

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1345,3 +1345,19 @@ def test_informative_error_messages():
     assert 'foo' in str(info.value)
     assert 'arrow' in str(info.value)
     assert 'fastparquet' in str(info.value)
+
+
+def test_append_cat_fp(tmpdir):
+    pytest.importorskip('fastparquet')
+    path = str(tmpdir)
+    # https://github.com/dask/dask/issues/4120
+    df = pd.DataFrame({"x": ["a", "a", "b", "a", "b"]})
+    df["x"] = df["x"].astype("category")
+    ddf = dd.from_pandas(df, npartitions=1)
+
+    dd.to_parquet(ddf, path)
+
+    # this fails:
+    dd.to_parquet(ddf, path, append=True, ignore_divisions=True)
+    d = dd.read_parquet(path).compute()
+    assert d['x'].tolist() == ["a", "a", "b", "a", "b"] * 2


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
