### PR TITLE
Don't reread metadata when passing ParquetFile to read_parquet

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -1137,6 +1137,7 @@ def read_parquet(path, columns=None, filters=None, categories=None, index=None,
             mode='rb',
             storage_options=storage_options
         )
+        paths = path
     else:
         read = get_engine(engine)['read']
         fs, fs_token, paths = get_fs_token_paths(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1361,3 +1361,18 @@ def test_append_cat_fp(tmpdir):
     dd.to_parquet(ddf, path, append=True, ignore_divisions=True)
     d = dd.read_parquet(path).compute()
     assert d['x'].tolist() == ["a", "a", "b", "a", "b"] * 2
+
+
+def test_passing_parquetfile(tmpdir):
+    import shutil
+    fp = pytest.importorskip('fastparquet')
+    path = str(tmpdir)
+    df = pd.DataFrame({"x": [1, 3, 2, 4]})
+    ddf = dd.from_pandas(df, npartitions=1)
+
+    dd.to_parquet(ddf, path)
+    pf = fp.ParquetFile(path)
+    shutil.rmtree(tmpdir)
+
+    # should pass, because no need to re-read metadata
+    dd.read_parquet(pf)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1372,7 +1372,7 @@ def test_passing_parquetfile(tmpdir):
 
     dd.to_parquet(ddf, path)
     pf = fp.ParquetFile(path)
-    shutil.rmtree(tmpdir)
+    shutil.rmtree(path)
 
     # should pass, because no need to re-read metadata
     dd.read_parquet(pf)


### PR DESCRIPTION
Can confirm that the test fails without this change and passes with it.

Fixes #4243

- [x] Tests added / passed
- [x] Passes `flake8 dask`
