### PR TITLE
Add fill_value support for series comparisons

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2186,11 +2186,12 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
     def _bind_comparison_method(cls, name, comparison):
         """ bind comparison method like DataFrame.add to this class """
 
-        def meth(self, other, level=None, axis=0):
+        def meth(self, other, level=None, fill_value=None, axis=0):
             if level is not None:
                 raise NotImplementedError('level must be None')
             axis = self._validate_axis(axis)
-            return elemwise(comparison, self, other, axis=axis)
+            op = partial(comparison, fill_value=fill_value)
+            return elemwise(op, self, other, axis=axis)
 
         meth.__doc__ = comparison.__doc__
         bind_method(cls, name, meth)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2170,7 +2170,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
 
     @classmethod
     def _bind_operator_method(cls, name, op):
-        """ bind operator method like DataFrame.add to this class """
+        """ bind operator method like Series.add to this class """
 
         def meth(self, other, level=None, fill_value=None, axis=0):
             if level is not None:
@@ -2184,7 +2184,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
 
     @classmethod
     def _bind_comparison_method(cls, name, comparison):
-        """ bind comparison method like DataFrame.add to this class """
+        """ bind comparison method like Series.eq to this class """
 
         def meth(self, other, level=None, fill_value=None, axis=0):
             if level is not None:
@@ -2918,7 +2918,7 @@ class DataFrame(_Frame):
 
     @classmethod
     def _bind_comparison_method(cls, name, comparison):
-        """ bind comparison method like DataFrame.add to this class """
+        """ bind comparison method like DataFrame.eq to this class """
 
         def meth(self, other, axis='columns', level=None):
             if level is not None:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2190,8 +2190,11 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
             if level is not None:
                 raise NotImplementedError('level must be None')
             axis = self._validate_axis(axis)
-            op = partial(comparison, fill_value=fill_value)
-            return elemwise(op, self, other, axis=axis)
+            if fill_value is None:
+                return elemwise(comparison, self, other, axis=axis)
+            else:
+                op = partial(comparison, fill_value=fill_value)
+                return elemwise(op, self, other, axis=axis)
 
         meth.__doc__ = comparison.__doc__
         bind_method(cls, name, meth)

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1075,11 +1075,11 @@ def test_reductions_frame_nan(split_every):
 @pytest.mark.parametrize('comparison', ['lt', 'gt', 'le', 'ge', 'ne', 'eq'])
 def test_series_comparison_nan(comparison):
     s = pd.Series([1, 2, 3, 4, 5, 6, 7])
-    s_nan = pd.Series([1, 2, 3, np.nan, 5, 6, 7])
+    s_nan = pd.Series([1, -1, 8, np.nan, 5, 6, 2.4])
     ds = dd.from_pandas(s, 3)
     ds_nan = dd.from_pandas(s_nan, 3)
 
-    fill_value = 4
+    fill_value = 7
     comparison_pd = getattr(s, comparison)
     comparison_dd = getattr(ds, comparison)
     assert_eq(comparison_dd(ds_nan, fill_value=fill_value),

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1070,3 +1070,17 @@ def test_reductions_frame_nan(split_every):
                   ddf.sem(axis=1, skipna=False, ddof=0, split_every=split_every))
         assert_eq(df.mean(axis=1, skipna=False),
                   ddf.mean(axis=1, skipna=False, split_every=split_every))
+
+
+@pytest.mark.parametrize('comparison', ['lt', 'gt', 'le', 'ge', 'ne', 'eq'])
+def test_series_comparison_nan(comparison):
+    s = pd.Series([1, 2, 3, 4, 5, 6, 7])
+    s_nan = pd.Series([1, 2, 3, np.nan, 5, 6, 7])
+    ds = dd.from_pandas(s, 3)
+    ds_nan = dd.from_pandas(s_nan, 3)
+
+    fill_value = 4
+    comparison_pd = getattr(s, comparison)
+    comparison_dd = getattr(ds, comparison)
+    assert_eq(comparison_dd(ds_nan, fill_value=fill_value),
+              comparison_pd(s_nan, fill_value=fill_value))


### PR DESCRIPTION
This PR adds support for `fill_value` for dask Series comparison methods

Fixes #4249

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
