### PR TITLE
Updated doc for the new scheduler keyword

### DIFF
--- a/docs/source/scheduler-overview.rst
+++ b/docs/source/scheduler-overview.rst
@@ -55,7 +55,7 @@ of the collection:
 
 The compute method takes a number of keywords:
 
-- ``get``: a scheduler ``get`` function, overrides the default for the collection
+- ``scheduler``: a scheduler ``get`` function or the name of the desired scheduler like ``threads`` or ``processes``. Overrides the default for the collection.
 - ``**kwargs``: extra keywords to pass on to the scheduler ``get`` function.
 
 See also: :ref:`configuring-schedulers`.

--- a/docs/source/scheduler-overview.rst
+++ b/docs/source/scheduler-overview.rst
@@ -55,7 +55,7 @@ of the collection:
 
 The compute method takes a number of keywords:
 
-- ``scheduler``: a scheduler ``get`` function or the name of the desired scheduler like ``threads`` or ``processes``. Overrides the default for the collection.
+- ``scheduler``: the name of the desired scheduler like ``"threads"``, ``"processes"``, or ``"single-threaded"`, a ``get`` function, or a ``dask.distributed.Client`` object.  Overrides the default for the collection.
 - ``**kwargs``: extra keywords to pass on to the scheduler ``get`` function.
 
 See also: :ref:`configuring-schedulers`.


### PR DESCRIPTION
This part of the doc was missed on the update from the `get` to the `scheduler` keyword.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
