### PR TITLE
Fix link to 'map_blocks' function in array api docs

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -114,7 +114,7 @@ Top level user functions:
    logical_not
    logical_or
    logical_xor
-   map_blocks
+   ~core.map_blocks
    map_overlap
    matmul
    max
@@ -145,7 +145,7 @@ Top level user functions:
    outer
    pad
    percentile
-   PerformanceWarning
+   ~core.PerformanceWarning
    piecewise
    prod
    ptp


### PR DESCRIPTION
This is a doc-only update. I use the `map_blocks` function a lot and finally got annoyed enough of the autosummary link at the top of the page not mapping to the function that I fixed it. I also fixed the `PerformanceWarning` link. However, there are other functions/methods that aren't linked to, but I had trouble figuring out the proper solution. I'll create a separate issue for those in a bit.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
