### PR TITLE
Add a paragraph on Dask-Yarn in the cloud docs

### DIFF
--- a/docs/source/setup/cloud.rst
+++ b/docs/source/setup/cloud.rst
@@ -1,13 +1,21 @@
 Cloud Deployments
 =================
 
-To get started running Dask on common Cloud providers like Amazon, 
+To get started running Dask on common Cloud providers like Amazon,
 Google, or Microsoft, we currently recommend deploying
 :doc:`Dask with Kubernetes and Helm <kubernetes-helm>`.
 
 All three major cloud vendors now provide managed Kubernetes services.
 This allows us to reliably provide the same experience across all clouds,
 and ensures that solutions for any one provider remain up-to-date.
+
+Alternatively, if you are deploying on a cloud-hosted Hadoop cluster like
+`Amazon EMR <https://aws.amazon.com/emr/>`_ or `Google Cloud DataProc
+<https://cloud.google.com/dataproc/>`_, you will want to use `Dask-Yarn
+<https://yarn.dask.org/>`_. Documentation on deploying on Amazon EMR
+specifically can be found `here
+<https://yarn.dask.org/en/latest/aws-emr.html>`_, the process is similar for
+Google Cloud DataProc.
 
 Data Access
 -----------


### PR DESCRIPTION
Some users want to deploy on cloud-hosted hadoop clusters, we add a paragraph to the cloud deployment docs linking to the yarn deployment docs, and specifically the EMR example.

Fixes #4220.
