### PR TITLE
Docs: Update futures.rst [skip ci]

### DIFF
--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -10,7 +10,7 @@ over time.
 
 These features depend on the second generation task scheduler found in
 `dask.distributed <https://distributed.dask.org/en/latest>`_ (which,
-despite its name, runs very well on a single machine.)
+despite its name, runs very well on a single machine).
 
 .. currentmodule:: distributed
 
@@ -476,7 +476,7 @@ themselves on remote clients if necessary:
 
 
 Queues can also send small pieces of information, anything that is msgpack
-encodable (ints, strings, bools, lists, dicts, etc.)  This can be useful to
+encodable (ints, strings, bools, lists, dicts, etc.).  This can be useful to
 send back small scores or administrative messages:
 
 .. code-block:: python
@@ -491,7 +491,7 @@ send back small scores or administrative messages:
 
 Queues are mediated by the central scheduler, and so they are not ideal for
 sending large amounts of data (everything you send will be routed through a
-central point.)  They are well suited to move around small bits of metadata, or
+central point).  They are well suited to move around small bits of metadata, or
 futures.  These futures may point to much larger pieces of data safely:
 
 .. code-block:: python

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -722,14 +722,6 @@ All operations that require talking to the remote worker are awaitable:
 
        n = await counter.n  # attribute access also must be awaited
 
-Usually Dask computations are composed of tasks that build off of each other in
-a pure functional way.  **They're centrally manathat are managed by the central
-scheduler and
-
-Because tasks are assumed to
-be pure (they don't change their inputs) and are known and coordinated by the
-central scheduler they are safe and**
-
 
 API
 ---

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -3,14 +3,14 @@ Futures
 
 Dask supports a real-time task framework that extends Python's
 `concurrent.futures <https://docs.python.org/3/library/concurrent.futures.html>`_
-interface.  This interface is good for arbitrary task scheduling, like
+interface.  This interface is good for arbitrary task scheduling like
 :doc:`dask.delayed <delayed>`, but is immediate rather than lazy, which
 provides some more flexibility in situations where the computations may evolve
 over time.
 
 These features depend on the second generation task scheduler found in
 `dask.distributed <https://distributed.dask.org/en/latest>`_ (which,
-despite its name, runs very well on a single machine).
+despite its name, runs very well on a single machine.)
 
 .. currentmodule:: distributed
 
@@ -18,7 +18,7 @@ Start Dask Client
 -----------------
 
 You must start a ``Client`` to use the futures interface.  This tracks state
-among the various worker processes or threads.
+among the various worker processes or threads:
 
 .. code-block:: python
 
@@ -28,7 +28,7 @@ among the various worker processes or threads.
    # or
    client = Client(processes=False)  # start local workers as threads
 
-If you have `Bokeh <https://bokeh.pydata.org>`_ installed then this starts up a
+If you have `Bokeh <https://bokeh.pydata.org>`_ installed, then this starts up a
 diagnostic dashboard at http://localhost:8787 .
 
 Submit Tasks
@@ -39,7 +39,7 @@ Submit Tasks
    Client.map
    Future.result
 
-Then you can submit individual tasks using the ``submit`` method.
+You can submit individual tasks using the ``submit`` method:
 
 .. code-block:: python
 
@@ -52,7 +52,7 @@ Then you can submit individual tasks using the ``submit`` method.
    a = client.submit(inc, 10)  # calls inc(10) in background thread or process
    b = client.submit(inc, 20)  # calls inc(20) in background thread or process
 
-Submit returns a ``Future``, which refers to a remote result.  This result may
+``submit`` returns a ``Future``, which refers to a remote result.  This result may
 not yet be completed:
 
 .. code-block:: python
@@ -61,7 +61,7 @@ not yet be completed:
    <Future: status: pending, key: inc-b8aaf26b99466a7a1980efa1ade6701d>
 
 Eventually it will complete.  The result stays in the remote
-thread/process/worker until you ask for it back explicitly.
+thread/process/worker until you ask for it back explicitly:
 
 .. code-block:: python
 
@@ -72,24 +72,24 @@ thread/process/worker until you ask for it back explicitly.
    11
 
 You can pass futures as inputs to submit.  Dask automatically handles dependency
-tracking; once all input futures have completed they will be moved onto a
+tracking; once all input futures have completed, they will be moved onto a
 single worker (if necessary), and then the computation that depends on them
 will be started.  You do not need to wait for inputs to finish before
-submitting a new task; Dask will handle this automatically.
+submitting a new task; Dask will handle this automatically:
 
 .. code-block:: python
 
    c = client.submit(add, a, b)  # calls add on the results of a and b
 
-Similar to Python's ``map`` you can use ``Client.map`` to call the same
+Similar to Python's ``map``, you can use ``Client.map`` to call the same
 function and many inputs:
 
 .. code-block:: python
 
    futures = client.map(inc, range(1000))
 
-However note that each task comes with about 1ms of overhead.  If you want to
-map a function over a large number of inputs then you might consider
+However, note that each task comes with about 1ms of overhead.  If you want to
+map a function over a large number of inputs, then you might consider
 :doc:`dask.bag <bag>` or :doc:`dask.dataframe <dataframe>` instead.
 
 Move Data
@@ -100,9 +100,9 @@ Move Data
    Client.gather
    Client.scatter
 
-Given any future you can call the ``.result`` method to gather the result.
+Given any future, you can call the ``.result`` method to gather the result.
 This will block until the future is done computing and then transfer the result
-back to your local process if necessary.
+back to your local process if necessary:
 
 .. code-block:: python
 
@@ -111,14 +111,14 @@ back to your local process if necessary.
 
 You can gather many results concurrently using the ``Client.gather`` method.
 This can be more efficient than calling ``.result()`` on each future
-sequentially.
+sequentially:
 
 .. code-block:: python
 
    >>> # results = [future.result() for future in futures]
    >>> results = client.gather(futures)  # this can be faster
 
-If you have important local data that you want to include in your computation
+If you have important local data that you want to include in your computation,
 you can either include it as a normal input to a submit or map call:
 
 .. code-block:: python
@@ -162,24 +162,24 @@ References, Cancellation, and Exceptions
    Client.cancel
 
 Dask will only compute and hold onto results for which there are active
-futures.  In this way your local variables define what is active in Dask.  When
+futures.  In this way, your local variables define what is active in Dask.  When
 a future is garbage collected by your local Python session, Dask will feel free
 to delete that data or stop ongoing computations that were trying to produce
-it.
+it:
 
 .. code-block:: python
 
    >>> del future  # deletes remote data once future is garbage collected
 
 You can also explicitly cancel a task using the ``Future.cancel`` or
-``Client.cancel`` methods.
+``Client.cancel`` methods:
 
 .. code-block:: python
 
    >>> future.cancel()  # deletes data even if other futures point to it
 
 If a future fails, then Dask will raise the remote exceptions and tracebacks if
-you try to get the result.
+you try to get the result:
 
 .. code-block:: python
 
@@ -240,8 +240,8 @@ You can also iterate over the futures as they complete using the
       if y > best:
           best = y
 
-For greater efficiency you can also ask ``as_completed`` to gather the results
-in the background.
+For greater efficiency, you can also ask ``as_completed`` to gather the results
+in the background:
 
 .. code-block:: python
 
@@ -249,7 +249,7 @@ in the background.
        # y = future.result()  # don't need this
       ...
 
-Or collect futures all futures in batches that had arrived since the last iteration
+Or collect all futures in batches that had arrived since the last iteration:
 
 .. code-block:: python
 
@@ -257,7 +257,8 @@ Or collect futures all futures in batches that had arrived since the last iterat
       for future, result in batch:
           ...
 
-Additionally, for iterative algorithms you can add more futures into the ``as_completed`` iterator *during* iteration.
+Additionally, for iterative algorithms, you can add more futures into the 
+``as_completed`` iterator *during* iteration:
 
 .. code-block:: python
 
@@ -277,7 +278,7 @@ Fire and Forget
    fire_and_forget
 
 Sometimes we don't care about gathering the result of a task, and only care
-about side effects that it might have, like writing a result to a file.
+about side effects that it might have like writing a result to a file:
 
 .. code-block:: python
 
@@ -296,7 +297,7 @@ using the ``fire_and_forget`` function:
 
    >>> fire_and_forget(c)
 
-This is particularly useful when a future may go out of scope, for example as
+This is particularly useful when a future may go out of scope, for example, as
 part of a function:
 
 .. code-block:: python
@@ -324,7 +325,7 @@ Submit Tasks from Tasks
 *This is an advanced feature and is rarely necessary in the common case.*
 
 Tasks can launch other tasks by getting their own client.  This enables complex
-and highly dynamic workloads.
+and highly dynamic workloads:
 
 .. code-block:: python
 
@@ -359,7 +360,7 @@ sockets or physical sensors:
        fire_and_forget(client.submit(monitor))
 
 However, each running task takes up a single thread, and so if you launch many
-tasks that launch other tasks then it is possible to deadlock the system if you
+tasks that launch other tasks, then it is possible to deadlock the system if you
 are not careful.  You can call the ``secede`` function from within a task to
 have it remove itself from the dedicated thread pool into an administrative
 thread that does not take up a slot within the Dask worker:
@@ -379,7 +380,8 @@ thread that does not take up a slot within the Dask worker:
 If you intend to do more work in the same thread after waiting on client work,
 you may want to explicitly block until the thread is able to *rejoin* the
 thread pool.  This allows some control over the number of threads that are
-created and stops too many threads from being active at once, over-saturating your hardware.
+created and stops too many threads from being active at once, over-saturating 
+your hardware:
 
 .. code-block:: python
 
@@ -395,8 +397,8 @@ created and stops too many threads from being active at once, over-saturating yo
       return result
 
 
-Alternatively, you can just use the normal ``dask.compute`` function *within* a
-task.  This will automatically call ``secede`` and ``rejoin`` appropriately.
+Alternatively, you can just use the normal ``compute`` function *within* a
+task.  This will automatically call ``secede`` and ``rejoin`` appropriately:
 
 .. code-block:: python
 
@@ -448,7 +450,7 @@ Queues
 
 Dask queues follow the API for the standard Python Queue, but now move futures
 or small messages between clients.  Queues serialize sensibly and reconnect
-themselves on remote clients if necessary.
+themselves on remote clients if necessary:
 
 .. code-block:: python
 
@@ -474,7 +476,7 @@ themselves on remote clients if necessary.
 
 
 Queues can also send small pieces of information, anything that is msgpack
-encodable (ints, strings, bools, lists, dicts, etc..).  This can be useful to
+encodable (ints, strings, bools, lists, dicts, etc.)  This can be useful to
 send back small scores or administrative messages:
 
 .. code-block:: python
@@ -489,8 +491,8 @@ send back small scores or administrative messages:
 
 Queues are mediated by the central scheduler, and so they are not ideal for
 sending large amounts of data (everything you send will be routed through a
-central point).  They are well suited to move around small bits of metadata, or
-futures.  These futures may point to much larger pieces of data safely.
+central point.)  They are well suited to move around small bits of metadata, or
+futures.  These futures may point to much larger pieces of data safely:
 
 .. code-block:: python
 
@@ -506,7 +508,7 @@ futures.  These futures may point to much larger pieces of data safely.
    # Or use futures for metadata
    >>> q.put({'status': 'OK', 'stage=': 1234})
 
-If you're looking to move large amounts of data between workers then you might
+If you're looking to move large amounts of data between workers, then you might
 also want to consider the Pub/Sub system described a few sections below.
 
 Global Variables
@@ -516,8 +518,8 @@ Global Variables
    Variable
 
 Variables are like Queues in that they communicate futures and small data
-between clients.  However variables hold only a single value.  You can get or
-set that value at any time.
+between clients.  However, variables hold only a single value.  You can get or
+set that value at any time:
 
 .. code-block:: python
 
@@ -527,10 +529,10 @@ set that value at any time.
    >>> var.get()
    False
 
-This is often used to signal stopping criteria or current parameters, etc.
+This is often used to signal stopping criteria or current parameters
 between clients.
 
-If you want to share large pieces of information then scatter the data first
+If you want to share large pieces of information, then scatter the data first:
 
 .. code-block:: python
 
@@ -558,9 +560,9 @@ they work across the cluster:
            # access protected resource
 
 You can manage several locks at the same time.  Lock can either be given a
-consistent name, or you can pass the lock object around itself.
+consistent name or you can pass the lock object around itself.
 
-Using a consistent name is convenient when you want to lock some known named resource.
+Using a consistent name is convenient when you want to lock some known named resource:
 
 .. code-block:: python
 
@@ -573,7 +575,8 @@ Using a consistent name is convenient when you want to lock some known named res
 
    futures = client.map(load, filenames)
 
-Passing around a lock works as well, and is easier when you want to create short-term locks for a particular situation.
+Passing around a lock works as well and is easier when you want to create short-term 
+locks for a particular situation:
 
 .. code-block:: python
 
@@ -607,20 +610,20 @@ providing an additional channel of communication between ongoing tasks.
 Actors
 ------
 
-.. note: This is an advanced feature and is rarely necessary in the common case.
-.. note: This is an experimental feature and is subject to change without notice
+.. note:: This is an advanced feature and is rarely necessary in the common case.
+.. note:: This is an experimental feature and is subject to change without notice.
 
 Actors allow workers to manage rapidly changing state without coordinating with
 the central scheduler.  This has the advantage of reducing latency
 (worker-to-worker roundtrip latency is around 1ms), reducing pressure on the
-centralized scheduler (workers can coordinate actors entirely among each other)
+centralized scheduler (workers can coordinate actors entirely among each other),
 and also enabling workflows that require stateful or in-place memory
 manipulation.
 
 However, these benefits come at a cost.  The scheduler is unaware of actors and
 so they don't benefit from diagnostics, load balancing, or resilience.  Once an
 actor is running on a worker it is forever tied to that worker.  If that worker
-becomes overburdened or dies then there is not opportunity to recover the
+becomes overburdened or dies, then there is no opportunity to recover the
 workload.
 
 *Because Actors avoid the central scheduler they can be high-performing, but not resilient.*
@@ -629,7 +632,7 @@ Example: Counter
 ~~~~~~~~~~~~~~~~
 
 An actor is a class containing both state and methods that is submitted to a
-worker.
+worker:
 
 .. code-block:: python
 
@@ -706,7 +709,7 @@ Example: Parameter Server
 Asynchronous Operation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-All operations that require talking to the remote worker are awaitable
+All operations that require talking to the remote worker are awaitable:
 
 .. code-block:: python
 
@@ -719,16 +722,13 @@ All operations that require talking to the remote worker are awaitable
 
        n = await counter.n  # attribute access also must be awaited
 
-
-
-
 Usually Dask computations are composed of tasks that build off of each other in
-a pure functional way.  They're centrally manathat are managed by the central
+a pure functional way.  **They're centrally manathat are managed by the central
 scheduler and
 
 Because tasks are assumed to
 be pure (they don't change their inputs) and are known and coordinated by the
-central scheduler they are safe and
+central scheduler they are safe and**
 
 
 API

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -52,7 +52,7 @@ You can submit individual tasks using the ``submit`` method:
    a = client.submit(inc, 10)  # calls inc(10) in background thread or process
    b = client.submit(inc, 20)  # calls inc(20) in background thread or process
 
-``submit`` returns a ``Future``, which refers to a remote result.  This result may
+The ``submit`` function returns a ``Future``, which refers to a remote result.  This result may
 not yet be completed:
 
 .. code-block:: python


### PR DESCRIPTION
This PR updates `futures.rst` with some punctuation and typo corrections. However, I've found a couple of issues that may need some special oversight.

Two important notes:

- In the **Actors** section, some note commands were either not properly defined or were hidden on purpose, but I couldn't tell which one was it. If it was the later, then I need to revert the changes I made in order to hide the note messages.
- The last two sentences in the **Asynchronous Operation** subsection of the **Actors** section require a re-write (I've highlighted the sentence using **  **). I'm not sure if they are supposed to be a single sentence or not, but it seems like someone forgot about them when doing some refactoring. Someone should take a look at them to fix this issue.