### PR TITLE
Docs: Update api.rst [skip ci]

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,8 +3,8 @@ API
 
 Dask APIs generally follow from upstream APIs:
 
--  The :doc:`Dask Array API <array-api>` follows the Numpy API
--  The :doc:`Dask Dataframe API <dataframe-api>` follows the Pandas API
+-  The :doc:`Dask Array API <array-api>` follows the NumPy API
+-  The :doc:`Dask DataFrame API <dataframe-api>` follows the Pandas API
 -  The `Dask-ML API <https://ml.dask.org/modules/api.html>`_ follows the Scikit-Learn API and other related machine learning libraries
 -  The :doc:`Dask Bag API <bag-api>` follows the map/filter/groupby/reduce API common in PySpark, PyToolz, and the Python standard library
 -  The :doc:`Dask Delayed API <delayed-api>` wraps general Python code
@@ -26,7 +26,7 @@ These more general Dask functions are described below:
 These functions work with any scheduler.  More advanced operations are
 available when using the newer scheduler and starting a
 :obj:`dask.distributed.Client` (which, despite its name, runs nicely on a
-single machine).  This API provides the ability to submit, cancel, and track
+single machine.)  This API provides the ability to submit, cancel, and track
 work asynchronously, and includes many functions for complex inter-task
 workflows.  These are not necessary for normal operation, but can be useful for
 real-time or advanced operation.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -26,7 +26,7 @@ These more general Dask functions are described below:
 These functions work with any scheduler.  More advanced operations are
 available when using the newer scheduler and starting a
 :obj:`dask.distributed.Client` (which, despite its name, runs nicely on a
-single machine.)  This API provides the ability to submit, cancel, and track
+single machine).  This API provides the ability to submit, cancel, and track
 work asynchronously, and includes many functions for complex inter-task
 workflows.  These are not necessary for normal operation, but can be useful for
 real-time or advanced operation.


### PR DESCRIPTION
This PR updates `api.rst` with a couple corrections to punctuation and naming conventions (simple stuff)

