### PR TITLE
Docs: Update `scheduling.rst` [skip ci]

### DIFF
--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -2,16 +2,15 @@ Scheduling
 ==========
 
 All of the large-scale Dask collections like
-:doc:`Dask Array <array>`, :doc:`Dask dataframe <dataframe>`, and :doc:`Dask bag <bag>`
+:doc:`Dask Array <array>`, :doc:`Dask DataFrame <dataframe>`, and :doc:`Dask Bag <bag>`
 and the fine-grained APIs like :doc:`delayed <delayed>` and :doc:`futures <futures>`
-generate task graphs where each node in the graph is a normal Python function,
+generate task graphs where each node in the graph is a normal Python function
 and edges between nodes are normal Python objects
-that are created by one task as ouptuts and used as inputs in another task.
-After Dask generates these task graphs it needs to execute them on parallel hardware.
+that are created by one task as outputs and used as inputs in another task.
+After Dask generates these task graphs, it needs to execute them on parallel hardware.
 This is the job of a *task scheduler*.
-Different task schedulers exist.
-Each will consume a task graph and compute the same result,
-but with different performance characteristics.
+Different task schedulers exist, and each will consume a task graph and compute the 
+same result, but with different performance characteristics.
 
 .. image:: images/collections-schedulers.png
    :alt: Dask collections and schedulers
@@ -20,13 +19,13 @@ but with different performance characteristics.
 
 Dask has two families of task schedulers:
 
-1.  **Single machine scheduler**: This scheduler provides basic features on a
+1.  **Single machine scheduler**: this scheduler provides basic features on a
     local process or thread pool.  This scheduler was made first and is the
-    default.  It is simple and cheap to use.  It can only be used on a single
-    machine and does not scale.
-2.  **Distributed scheduler**: This scheduler is more sophisticated, offers
+    default.  It is simple and cheap to use, altough it can only be used on 
+    a single machine and does not scale
+2.  **Distributed scheduler**: this scheduler is more sophisticated, offers
     more features, but also requires a bit more effort to set up.  It can
-    run locally or distributed across a cluster.
+    run locally or distributed across a cluster
 
 For different computations you may find better performance with particular scheduler settings.
 This document helps you understand how to choose between and configure different schedulers,
@@ -43,17 +42,17 @@ Local Threads
 
 The threaded scheduler executes computations with a local ``multiprocessing.pool.ThreadPool``.
 It is lightweight and requires no setup.
-It introduces very little task overhead, around 50us per task,
-and because everything occurs in the same process,
+It introduces very little task overhead (around 50us per task)
+and, because everything occurs in the same process,
 it incurs no costs to transfer data between tasks.
-However due to Python's Global Interpreter Lock (GIL),
+However, due to Python's Global Interpreter Lock (GIL),
 this scheduler only provides parallelism when your computation is dominated by non-Python code,
-such as is the case when operating on numeric data in NumPy arrays, Pandas dataframes,
+such as is the case when operating on numeric data in NumPy arrays, Pandas DataFrames,
 or using any of the other C/C++/Cython based projects in the ecosystem.
 
 The threaded scheduler is the default choice for
-:doc:`dask array <array>`, :doc:`dask dataframe <dataframe>`, and :doc:`dask delayed <delayed>`.
-However if your computation is dominated by processing pure Python objects
+:doc:`Dask Array <array>`, :doc:`Dask DataFrame <dataframe>`, and :doc:`Dask Delayed <delayed>`.
+However, if your computation is dominated by processing pure Python objects
 like strings, dicts, or lists,
 then you may want to try one of the process-based schedulers below
 (we currently recommend the distributed scheduler on a local machine).
@@ -62,8 +61,10 @@ then you may want to try one of the process-based schedulers below
 Local Processes
 ---------------
 
-*Note: the distributed scheduler described a couple sections below is often a better choice today.
-we encourage readers to continue reading after this section*
+.. note:: 
+
+   The distributed scheduler described a couple sections below is often a better choice today. 
+   We encourage readers to continue reading after this section.
 
 .. code-block:: python
 
@@ -76,18 +77,18 @@ It is lightweight to use and requires no setup.
 Every task and all of its dependencies are shipped to a local process,
 executed, and then their result is shipped back to the main process.
 This means that it is able to bypass issues with the GIL and provide parallelism
-even on computations are are dominated by Pure Python code,
+even on computations that are dominated by pure Python code,
 such as those that process strings, dicts, and lists.
 
-However moving data to remote processes and back can introduce performance penalties,
+However, moving data to remote processes and back can introduce performance penalties,
 particularly when the data being transferred between processes is large.
 The multiprocessing scheduler is an excellent choice when workflows are relatively linear,
-and so do not involve significant inter-task data transfer,
-and when inputs and outputs are both small, like filenames and counts.
+and so does not involve significant inter-task data transfer
+as well as when inputs and outputs are both small, like filenames and counts.
 
 This is common in basic data ingestion workloads,
-such as those are common in :doc:`dask bag <bag>`,
-where the multiprocessing scheduler is the default.
+such as those are common in :doc:`Dask Bag <bag>`,
+where the multiprocessing scheduler is the default:
 
 .. code-block:: python
 
@@ -110,16 +111,16 @@ Single Thread
    import dask
    dask.config.set(scheduler='synchronous')  # overwrite default with single-threaded scheduler
 
-The single-threaded synchronous scheduler executes all computations in the local thread,
+The single-threaded synchronous scheduler executes all computations in the local thread
 with no parallelism at all.
 This is particularly valuable for debugging and profiling,
 which are more difficult when using threads or processes.
 
-For example, when using IPython or Jupyter notebooks the ``%debug``, ``%pdb``, or ``%prun`` magics
-will not work well when using the parallel dask schedulers;
-they were not designed to be used in a parallel computing context.
-However if you run into an exception and want to step into the debugger
-you may wish to rerun your computation under the single-threaded scheduler,
+For example, when using IPython or Jupyter notebooks, the ``%debug``, ``%pdb``, or ``%prun`` magics
+will not work well when using the parallel Dask schedulers 
+(they were not designed to be used in a parallel computing context).
+However, if you run into an exception and want to step into the debugger,
+you may wish to rerun your computation under the single-threaded scheduler
 where these tools will function properly.
 
 
@@ -133,8 +134,8 @@ Dask Distributed (local)
    # or
    client = Client(processes=False)
 
-The dask.distributed scheduler can either be :doc:`setup on a cluster <setup>`
-or run locally on a personal machine.  Despite having the name "distributed"
+The Dask distributed scheduler can either be :doc:`setup on a cluster <setup>`
+or run locally on a personal machine.  Despite having the name "distributed",
 it is often pragmatic on local machines for a few reasons:
 
 1.  It provides access to asynchronous API, notably :doc:`Futures <futures>`
@@ -142,9 +143,9 @@ it is often pragmatic on local machines for a few reasons:
     performance and progress
 3.  It handles data locality with more sophistication, and so can be more
     efficient than the multiprocessing scheduler on workloads that require
-    multiple processes.
+    multiple processes
 
-You can read more about using the dask.distributed scheduler on a single machine in
+You can read more about using the Dask distributed scheduler on a single machine in
 :doc:`these docs <setup/single-distributed>`.
 
 
@@ -161,7 +162,7 @@ Configuration
 -------------
 
 You can configure the global default scheduler by using the ``dask.config.set(scheduler...)`` command.
-This can be done globally,
+This can be done globally:
 
 .. code-block:: python
 
@@ -169,22 +170,22 @@ This can be done globally,
 
    x.compute()
 
-or as a context manager
+or as a context manager:
 
 .. code-block:: python
 
    with dask.config.set(scheduler='threads'):
        x.compute()
 
-or within a single compute call
+or within a single compute call:
 
 .. code-block:: python
 
    x.compute(scheduler='threads')
 
 Additionally some of the scheduler support other keyword arguments.
-For example the Pool-based single-machine scheduler allow you to provide custom pools,
-or specify the desired number of workers.
+For example, the pool-based single-machine scheduler allows you to provide custom pools
+or specify the desired number of workers:
 
 .. code-block:: python
 


### PR DESCRIPTION
This PR updates `scheduling.rst` with some punctuation, naming conventions and typo corrections (a couple). Also, a few connecting words were sprinkled here and there to improve clarity of some sentences.

