### PR TITLE
Add schema name in read_sql_table for empty tables

### DIFF
--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -120,7 +120,8 @@ def read_sql_table(table, uri, index_col, divisions=None, npartitions=None,
         if head.empty:
             # no results at all
             name = table.name
-            head = pd.read_sql_table(name, uri, index_col=index_col)
+            schema = table.schema
+            head = pd.read_sql_table(name, uri, schema=schema, index_col=index_col)
             return from_pandas(head, npartitions=1)
 
         bytes_per_row = (head.memory_usage(deep=True, index=True)).sum() / 5

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -55,6 +55,40 @@ def test_empty(db):
         assert pd_dataframe.empty is True
 
 
+@pytest.mark.skip(reason="Requires a postgres server. Sqlite does not support multiple schemas.")
+def test_empty_other_schema():
+    from sqlalchemy import create_engine, MetaData, Table, Column, Integer, event, DDL
+    # Database configurations.
+    pg_user = 'user'
+    pg_pass = 'pass'
+    pg_db = 'db'
+    db_url = 'postgresql://%s:%s@localhost/%s' % (pg_user, pg_pass, pg_db)
+
+    # Create an empty table in a different schema.
+    table_name = 'empty_table'
+    schema_name = 'other_schema'
+    engine = create_engine(db_url)
+    metadata = MetaData()
+    table = Table(table_name, metadata,
+                  Column('id', Integer, primary_key=True),
+                  Column('col2', Integer), schema=schema_name)
+    # Create the schema and the table.
+    event.listen(metadata, 'before_create', DDL("CREATE SCHEMA IF NOT EXISTS %s" % schema_name))
+    metadata.create_all(engine)
+
+    # Read the empty table from the other schema.
+    dask_df = read_sql_table(table.name, db_url, index_col='id', schema=table.schema, npartitions=1)
+
+    # Validate that the retrieved table is empty.
+    assert dask_df.index.name == 'id'
+    assert dask_df.col2.dtype == np.dtype('int64')
+    pd_dataframe = dask_df.compute()
+    assert pd_dataframe.empty is True
+
+    # Drop the schema and the table.
+    engine.execute("DROP SCHEMA IF EXISTS %s CASCADE" % schema_name)
+
+
 def test_needs_rational(db):
     import datetime
     now = datetime.datetime.now()

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -55,7 +55,7 @@ def test_empty(db):
         assert pd_dataframe.empty is True
 
 
-# @pytest.mark.skip(reason="Requires a postgres server. Sqlite does not support multiple schemas.")
+@pytest.mark.skip(reason="Requires a postgres server. Sqlite does not support multiple schemas.")
 def test_empty_other_schema():
     from sqlalchemy import create_engine, MetaData, Table, Column, Integer, event, DDL
     # Database configurations.

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -55,14 +55,16 @@ def test_empty(db):
         assert pd_dataframe.empty is True
 
 
-@pytest.mark.skip(reason="Requires a postgres server. Sqlite does not support multiple schemas.")
+# @pytest.mark.skip(reason="Requires a postgres server. Sqlite does not support multiple schemas.")
 def test_empty_other_schema():
     from sqlalchemy import create_engine, MetaData, Table, Column, Integer, event, DDL
     # Database configurations.
+    pg_host = 'localhost'
+    pg_port = '5432'
     pg_user = 'user'
     pg_pass = 'pass'
     pg_db = 'db'
-    db_url = 'postgresql://%s:%s@localhost/%s' % (pg_user, pg_pass, pg_db)
+    db_url = 'postgresql://%s:%s@%s:%s/%s' % (pg_user, pg_pass, pg_host, pg_port, pg_db)
 
     # Create an empty table in a different schema.
     table_name = 'empty_table'


### PR DESCRIPTION
Builds on #2928 and #2935

* Propagate the schema name from dask to pandas API.

If the empty table is not in the public schema, `pd.read_sql_table` won't be able to read it and would cause a "Table Not Found" error. We need to propagate the schema passed to dask's `read_sql_table` to pandas `read_sql_table`

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
