### PR TITLE
Docs: Update diagnostics-local.rst [skip ci]

### DIFF
--- a/docs/source/diagnostics-local.rst
+++ b/docs/source/diagnostics-local.rst
@@ -12,8 +12,7 @@ This page describes the following few built-in options:
 3.  ResourceProfiler
 4.  CacheProfiler
 
-
-This page then provides instructions on how to build your own custom diagnostic.
+Furthermore, this page then provides instructions on how to build your own custom diagnostic.
 
 .. currentmodule:: dask.diagnostics
 
@@ -26,7 +25,7 @@ Progress Bar
 
 The ``ProgressBar`` class builds on the scheduler callbacks described above to
 display a progress bar in the terminal or notebook during computation. This can
-be a nice feedback during long running graph execution. It can be used as a
+give a nice feedback during long running graph execution. It can be used as a
 context manager around calls to ``get`` or ``compute`` to profile the
 computation:
 
@@ -40,7 +39,7 @@ computation:
     ...     out = res.compute()
     [########################################] | 100% Completed | 17.1 s
 
-Or registered globally using the ``register`` method.
+or registered globally using the ``register`` method:
 
 .. code-block:: python
 
@@ -64,10 +63,10 @@ Profiler
    Profiler
 
 Dask provides a few tools for profiling execution. As with the ``ProgressBar``,
-they each can be used as context managers, or registered globally.
+they each can be used as context managers or registered globally.
 
-The ``Profiler`` class is used to profile dask execution at the task level.
-During execution it records the following information for each task:
+The ``Profiler`` class is used to profile Dask's execution at the task level.
+During execution, it records the following information for each task:
 
 1. Key
 2. Task
@@ -82,16 +81,16 @@ ResourceProfiler
 .. autosummary::
    ResourceProfiler
 
-The ``ResourceProfiler`` class is used to profile dask execution at the
-resource level. During execution it records the following information
-for each timestep
+The ``ResourceProfiler`` class is used to profile Dask's execution at the
+resource level. During execution, it records the following information
+for each timestep:
 
 1. Time in seconds since the epoch
 2. Memory usage in MB
 3. % CPU usage
 
 The default timestep is 1 second, but can be set manually using the ``dt``
-keyword.
+keyword:
 
 .. code-block:: python
 
@@ -105,8 +104,8 @@ CacheProfiler
 .. autosummary::
    CacheProfiler
 
-The ``CacheProfiler`` class is used to profile dask execution at the scheduler
-cache level. During execution it records the following information for each
+The ``CacheProfiler`` class is used to profile Dask's execution at the scheduler
+cache level. During execution, it records the following information for each
 task:
 
 1. Key
@@ -115,7 +114,7 @@ task:
 4. Cache entry time in seconds since the epoch
 5. Cache exit time in seconds since the epoch
 
-Where the size metric is the output of a function called on the result of each
+Here the size metric is the output of a function called on the result of each
 task. The default metric is to count each task (``metric`` is 1 for all tasks).
 Other functions may be used as a metric instead through the ``metric`` keyword.
 For example, the ``nbytes`` function found in ``cachey`` can be used to measure
@@ -132,7 +131,7 @@ Example
 -------
 
 As an example to demonstrate using the diagnostics, we'll profile some linear
-algebra done with ``dask.array``. We'll create a random array, take its QR
+algebra done with Dask Array. We'll create a random array, take its QR
 decomposition, and then reconstruct the initial array by multiplying the Q and
 R components together. Note that since the profilers (and all diagnostics) are
 just context managers, multiple profilers can be used in a with block:
@@ -148,7 +147,6 @@ just context managers, multiple profilers can be used in a with block:
     >>> with Profiler() as prof, ResourceProfiler(dt=0.25) as rprof,
     ...         CacheProfiler() as cprof:
     ...     out = a2.compute()
-
 
 The results of each profiler are stored in their ``results`` attribute as a
 list of ``namedtuple`` objects:
@@ -172,7 +170,7 @@ list of ``namedtuple`` objects:
               cache_time=1454368444.49662,
               free_time=1454368446.769452)
 
-These can be analyzed separately, or viewed in a bokeh plot using the provided
+These can be analyzed separately or viewed in a bokeh plot using the provided
 ``visualize`` method on each profiler:
 
 .. code-block:: python
@@ -187,7 +185,7 @@ These can be analyzed separately, or viewed in a bokeh plot using the provided
             width="650" height="300" style="border:none"></iframe>
 
 To view multiple profilers at the same time, the ``dask.diagnostics.visualize``
-function can be used. This takes a list of profilers, and creates a vertical
+function can be used. This takes a list of profilers and creates a vertical
 stack of plots aligned along the x-axis:
 
 .. code-block:: python
@@ -205,18 +203,18 @@ stack of plots aligned along the x-axis:
 
 Looking at the above figure, from top to bottom:
 
-1. The results from the ``Profiler`` object. This shows the execution time for
+1. The results from the ``Profiler`` object: This shows the execution time for
    each task as a rectangle, organized along the y-axis by worker (in this case
-   threads). Similar tasks are grouped by color, and by hovering over each task
+   threads). Similar tasks are grouped by color and, by hovering over each task,
    one can see the key and task that each block represents.
 
-2. The results from the ``ResourceProfiler`` object. This shows two lines, one
+2. The results from the ``ResourceProfiler`` object: This shows two lines, one
    for total CPU percentage used by all the workers, and one for total memory
    usage.
 
-3. The results from the ``CacheProfiler`` object. This shows a line for each
+3. The results from the ``CacheProfiler`` object: This shows a line for each
    task group, plotting the sum of the current ``metric`` in the cache against
-   time. In this case it's the default metric (count), and the lines represent
+   time. In this case it's the default metric (count) and the lines represent
    the number of each object in the cache at time. Note that the grouping and
    coloring is the same as for the ``Profiler`` plot, and that the task
    represented by each line can be found by hovering over the line.
@@ -224,14 +222,14 @@ Looking at the above figure, from top to bottom:
 From these plots we can see that the initial tasks (calls to
 ``numpy.random.random`` and ``numpy.linalg.qr`` for each chunk) are run
 concurrently, but only use slightly more than 100\% CPU. This is because the
-call to ``numpy.linalg.qr`` currently doesn't release the global interpreter
-lock, so those calls can't truly be done in parallel. Next, there's a reduction
+call to ``numpy.linalg.qr`` currently doesn't release the Global Interpreter
+Lock (GIL), so those calls can't truly be done in parallel. Next, there's a reduction
 step where all the blocks are combined. This requires all the results from the
 first step to be held in memory, as shown by the increased number of results in
 the cache, and increase in memory usage. Immediately after this task ends, the
 number of elements in the cache decreases, showing that they were only needed
 for this step. Finally, there's an interleaved set of calls to ``dot`` and
-``sum``. Looking at the CPU plot shows that these run both concurrently and in
+``sum``. Looking at the CPU plot, it shows that these run both concurrently and in
 parallel, as the CPU percentage spikes up to around 350\%.
 
 
@@ -246,35 +244,25 @@ accept five callbacks, allowing for inspection of scheduler execution.
 
 The callbacks are:
 
-1. ``start(dsk)``
+1. ``start(dsk)``: Run at the beginning of execution, right before the 
+state is initialized.  Receives the Dask graph
 
-   Run at the beginning of execution, right before the state is initialized.
-   Receives the dask graph.
+2. ``start_state(dsk, state)``: Run at the beginning of execution, right 
+after the state is initialized.  Receives the Dask graph and scheduler state
 
-2. ``start_state(dsk, state)``
+3. ``pretask(key, dsk, state)``: Run every time a new task is started. 
+Receives the key of the task to be run, the Dask graph, and the scheduler state
 
-   Run at the beginning of execution, right after the state is initialized.
-   Receives the dask graph and scheduler state.
+4. ``posttask(key, result, dsk, state, id)``: Run every time a task is finished. 
+Receives the key of the task that just completed, the result, the Dask graph, 
+the scheduler state, and the id of the worker that ran the task
 
-3. ``pretask(key, dsk, state)``
-
-   Run every time a new task is started. Receives the key of the task to be
-   run, the dask graph, and the scheduler state.
-
-4. ``posttask(key, result, dsk, state, id)``
-
-   Run every time a task is finished. Receives the key of the task that just
-   completed, the result, the dask graph, the scheduler state, and the id of
-   the worker that ran the task.
-
-5. ``finish(dsk, state, errored)``
-
-   Run at the end of execution, right before the result is returned. Receives
-   the dask graph, the scheduler state, and a boolean indicating whether or not
-   the exit was due to an error.
+5. ``finish(dsk, state, errored)``: Run at the end of execution, right before the 
+result is returned. Receives the Dask graph, the scheduler state, and a boolean 
+indicating whether or not the exit was due to an error
 
 Custom diagnostics can be created either by instantiating the ``Callback``
-class with the some of above methods as keywords or by subclassing the
+class with the some of the above methods as keywords or by subclassing the
 ``Callback`` class.
 Here we create a class that prints the name of every key as it's computed:
 


### PR DESCRIPTION
This PR updates `diagnostics-local.rst` with some corrections to punctuation, naming conventions and other improvements to clarity of sentences. Furthermore, a refactor of the last list has been done in order to match the rest of the documentation's style.

