### PR TITLE
fix #4278

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -51,7 +51,7 @@ conda install -q -c conda-forge \
     partd \
     psutil \
     pytables \
-    "pytest<=3.10" \
+    pytest \
     requests \
     scikit-image \
     scikit-learn \

--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -41,10 +41,10 @@ basedir = '/tmp/test-dask'
 
 
 # This fixture checks for a minimum pyarrow version
-@pytest.fixture(params=[pytest.mark.skipif(not hdfs3, 'hdfs3',
-                                           reason='hdfs3 not found'),
-                        pytest.mark.skipif(not PYARROW_DRIVER, 'pyarrow',
-                                           reason='required pyarrow version not found')])
+@pytest.fixture(params=[
+    pytest.param('hdfs3', marks=pytest.mark.skipif(not hdfs3, reason='hdfs3 not found')),
+    pytest.param('pyarrow', marks=pytest.mark.skipif(not PYARROW_DRIVER,
+                                                     reason='required pyarrow version not found'))])
 def hdfs(request):
     if request.param == 'hdfs3':
         hdfs = hdfs3.HDFileSystem(host='localhost', port=8020)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -52,10 +52,9 @@ df = pd.DataFrame({'x': [i * 7 % 5 for i in range(nrows)],  # Not sorted
 ddf = dd.from_pandas(df, npartitions=npartitions)
 
 
-@pytest.fixture(params=[pytest.mark.skipif(not fastparquet, 'fastparquet',
-                                           reason='fastparquet not found'),
-                        pytest.mark.skipif(not pq, 'pyarrow',
-                                           reason='pyarrow not found')])
+@pytest.fixture(params=[
+    pytest.param('fastparquet', marks=pytest.mark.skipif(not fastparquet, reason='fastparquet not found')),
+    pytest.param('pyarrow', marks=pytest.mark.skipif(not pq, reason='pyarrow not found'))])
 def engine(request):
     return request.param
 
@@ -709,8 +708,9 @@ def test_read_parquet_custom_columns(tmpdir, engine):
     (pd.DataFrame({'x': pd.Categorical([1, 2, 1])}), {}, {'categories': ['x']}),
     (pd.DataFrame({'x': list(map(pd.Timestamp, [3000, 2000, 1000]))}), {}, {}),
     (pd.DataFrame({'x': [3000, 2000, 1000]}).astype('M8[ns]'), {}, {}),
-    pytest.mark.xfail((pd.DataFrame({'x': [3, 2, 1]}).astype('M8[ns]'), {}, {}),
-                      reason="Parquet doesn't support nanosecond precision"),
+    pytest.param(pd.DataFrame({'x': [3, 2, 1]}).astype('M8[ns]'), {}, {},
+                 marks=pytest.mark.xfail(
+                     reason="Parquet doesn't support nanosecond precision")),
     (pd.DataFrame({'x': [3, 2, 1]}).astype('M8[us]'), {}, {}),
     (pd.DataFrame({'x': [3, 2, 1]}).astype('M8[ms]'), {}, {}),
     (pd.DataFrame({'x': [3, 2, 1]}).astype('uint16'), {}, {}),

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -174,7 +174,8 @@ def test_full_groupby_apply_multiarg():
     lambda df: ['a', 'b'],
     lambda df: df['a'],
     lambda df: [df['a'], df['b']],
-    pytest.mark.xfail(reason="not yet supported")(lambda df: [df['a'] > 2, df['b'] > 1])
+    pytest.param(lambda df: [df['a'] > 2, df['b'] > 1], marks=pytest.mark.xfail(
+        reason="not yet supported"))
 ])
 @pytest.mark.parametrize('reverse', [True, False])
 def test_full_groupby_multilevel(grouper, reverse):
@@ -654,7 +655,7 @@ def test_apply_shuffle():
     lambda df: df['AA'],
     lambda df: [df['AA'], df['AB']],
     lambda df: df['AA'] + 1,
-    pytest.mark.xfail("NotImplemented")(lambda df: [df['AA'] + 1, df['AB'] + 1]),
+    pytest.param(lambda df: [df['AA'] + 1, df['AB'] + 1], marks=pytest.mark.xfail("NotImplemented"))
 ])
 def test_apply_shuffle_multilevel(grouper):
     pdf = pd.DataFrame({'AB': [1, 2, 3, 4] * 5,
@@ -962,7 +963,8 @@ def test_series_aggregations_multilevel(grouper, agg_func):
     lambda df: df['a'] > 2,
     lambda df: [df['a'], df['b']],
     lambda df: [df['a'] > 2],
-    pytest.mark.xfail(reason="index dtype does not coincide: boolean != empty")(lambda df: [df['a'] > 2, df['b'] > 1])
+    pytest.param(lambda df: [df['a'] > 2, df['b'] > 1], marks=pytest.mark.xfail(
+        reason="index dtype does not coincide: boolean != empty"))
 ])
 @pytest.mark.parametrize('group_and_slice', [
     lambda df, grouper: df.groupby(grouper(df)),

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -153,7 +153,7 @@ def test_partitioning_index_categorical_on_values():
     assert (res == res2).all()
 
 
-@pytest.mark.parametrize('npartitions', [1, 4, 7, pytest.mark.slow(23)])
+@pytest.mark.parametrize('npartitions', [1, 4, 7, pytest.param(23, marks=pytest.mark.slow)])
 def test_set_index_tasks(npartitions):
     df = pd.DataFrame({'x': np.random.random(100),
                        'y': np.random.random(100) // 0.2},

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -109,7 +109,7 @@ def test_aliases():
 
 @pytest.mark.parametrize('format,typ', [
     ('png', Image),
-    pytest.mark.xfail(('jpeg', Image), reason='jpeg not always supported in dot'),
+    pytest.param('jpeg', Image, marks=pytest.mark.xfail(reason='jpeg not always supported in dot')),
     ('dot', type(None)),
     ('pdf', type(None)),
     ('svg', SVG),
@@ -133,7 +133,7 @@ def test_dot_graph(tmpdir, format, typ):
 
 @pytest.mark.parametrize('format,typ', [
     ('png', Image),
-    pytest.mark.xfail(('jpeg', Image), reason='jpeg not always supported in dot'),
+    pytest.param('jpeg', Image, marks=pytest.mark.xfail(reason='jpeg not always supported in dot')),
     ('dot', type(None)),
     ('pdf', type(None)),
     ('svg', SVG),


### PR DESCRIPTION
I made it possible to run a test with pytest==4.0.1(this version is latest now.)

related issue: #4278 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
