### PR TITLE
Remove verbose flag from pytest setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ test = pytest
 markers:
   skip_if_np_ge_114: Skip a test when NumPy is older than 1.14
   skip_if_np_lt_114: Skip a test when NumPy is at least 1.14
-addopts = -rsx -v --durations=10
+addopts = -rsx --durations=10
 # minversion = 3.2
 # filterwarnings =
 #     error


### PR DESCRIPTION
This was added accidentlly as we copied over the setup.cfg settings from
dask-ml.  Unfortunately this makes testing logs long enough that they don't fit
in Travis-CI easily.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
