### PR TITLE
Add allow_unknown_chunksizes to hstack and vstack

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -104,17 +104,17 @@ def vstack(tup):
 
 
 @wraps(np.hstack)
-def hstack(tup):
+def hstack(tup, allow_unknown_chunksizes=False):
     if all(x.ndim == 1 for x in tup):
-        return concatenate(tup, axis=0)
+        return concatenate(tup, axis=0, allow_unknown_chunksizes=allow_unknown_chunksizes)
     else:
-        return concatenate(tup, axis=1)
+        return concatenate(tup, axis=1, allow_unknown_chunksizes=allow_unknown_chunksizes)
 
 
 @wraps(np.dstack)
-def dstack(tup):
+def dstack(tup, allow_unknown_chunksizes=False):
     tup = tuple(atleast_3d(x) for x in tup)
-    return concatenate(tup, axis=2)
+    return concatenate(tup, axis=2, allow_unknown_chunksizes=allow_unknown_chunksizes)
 
 
 @wraps(np.swapaxes)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -98,9 +98,9 @@ def atleast_1d(*arys):
 
 
 @wraps(np.vstack)
-def vstack(tup):
+def vstack(tup, allow_unknown_chunksizes=False):
     tup = tuple(atleast_2d(x) for x in tup)
-    return concatenate(tup, axis=0)
+    return concatenate(tup, axis=0, allow_unknown_chunksizes=allow_unknown_chunksizes)
 
 
 @wraps(np.hstack)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -881,7 +881,7 @@ def test_dstack():
     assert_eq(np.dstack((x, y)), da.dstack((a, b)))
 
 
-@pytest.mark.parametrize('np_func,dsk_func, nan_chunk', [
+@pytest.mark.parametrize('np_func,dsk_func,nan_chunk', [
     (np.hstack, da.hstack, 0),
     (np.dstack, da.dstack, 1),
     (np.vstack, da.vstack, 2),

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -898,7 +898,7 @@ def test_stack_unknown_chunk_sizes(np_func, dsk_func, nan_chunk):
     with pytest.raises(ValueError):
         dsk_func((x, x))
 
-    np_stacked = np_func((y,y))
+    np_stacked = np_func((y, y))
     dsk_stacked = dsk_func((x, x), allow_unknown_chunksizes=True)
     assert_eq(np_stacked, dsk_stacked)
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -881,6 +881,21 @@ def test_dstack():
     assert_eq(np.dstack((x, y)), da.dstack((a, b)))
 
 
+@pytest.mark.parametrize('np_func, dsk_func', [
+    (np.vstack, da.vstack),
+    (np.hstack, da.hstack),
+    (np.dstack, da.dstack)
+])
+def test_stack_unknown_chunk_sizes(np_func, dsk_func):
+    x = da.ones((10, 10, 10), chunks=(1, 1, 1), dtype=np.int)
+    x._chunks = ((np.nan,) * 10, (1,)*10, (1,)*10)
+    y = np.ones((10, 10, 10), dtype=np.int)
+
+    np_stacked = np_func((y,y))
+    dsk_stacked = dsk_func((x, x), allow_unknown_chunksizes=True)
+    assert_eq(np_stacked, dsk_stacked)
+
+
 def test_take():
     x = np.arange(400).reshape((20, 20))
     a = da.from_array(x, chunks=(5, 5))

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -887,12 +887,12 @@ def test_dstack():
     (np.vstack, da.vstack, 2),
 ])
 def test_stack_unknown_chunk_sizes(np_func, dsk_func, nan_chunk):
-    s = (100, 100, 100)
-    x = da.ones(s, chunks=(10, 10, 10), dtype=np.int)
-    y = np.ones(s, dtype=np.int)
+    shape = (100, 100, 100)
+    x = da.ones(shape, chunks=(50, 50, 50))
+    y = np.ones(shape)
 
     tmp = list(x._chunks)
-    tmp[nan_chunk] = (np.nan,) * 10
+    tmp[nan_chunk] = (np.nan,) * 2
     x._chunks = tuple(tmp)
 
     with pytest.raises(ValueError):

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -881,14 +881,14 @@ def test_dstack():
     assert_eq(np.dstack((x, y)), da.dstack((a, b)))
 
 
-@pytest.mark.parametrize('np_func, dsk_func', [
+@pytest.mark.parametrize('np_func,dsk_func', [
     (np.vstack, da.vstack),
     (np.hstack, da.hstack),
     (np.dstack, da.dstack)
 ])
 def test_stack_unknown_chunk_sizes(np_func, dsk_func):
     x = da.ones((10, 10, 10), chunks=(1, 1, 1), dtype=np.int)
-    x._chunks = ((np.nan,) * 10, (1,)*10, (1,)*10)
+    x._chunks = ((np.nan,) * 10, (1,) * 10, (1,) * 10)
     y = np.ones((10, 10, 10), dtype=np.int)
 
     np_stacked = np_func((y,y))


### PR DESCRIPTION
Adds allow_unknown_chunksizes parameter to hstack and vstack as discussed in: https://github.com/dask/dask-ml/pull/437

- [ ] Tests added / passed
- [x] Passes `flake8 dask`
