### PR TITLE
Fixes for SerializableLock

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -5,6 +5,7 @@ import pickle
 import numpy as np
 import pytest
 
+from dask.compatibility import PY2
 from dask.utils import (takes_multiple_arguments, Dispatch, random_state_data,
                         memory_repr, methodcaller, M, skip_doctest,
                         SerializableLock, funcname, ndeepmap, ensure_dict,
@@ -263,6 +264,7 @@ def test_SerializableLock_locked():
         assert a.locked()
 
 
+@pytest.mark.skipif(PY2, reason="no blocking= keyword in Python 2")
 def test_SerializableLock_acquire_blocking():
     a = SerializableLock('a')
     assert a.acquire(blocking=True)

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -260,8 +260,10 @@ def test_SerializableLock_name_collision():
 
 def test_SerializableLock_locked():
     a = SerializableLock('a')
+    assert not a.locked()
     with a:
         assert a.locked()
+    assert not a.locked()
 
 
 @pytest.mark.skipif(PY2, reason="no blocking= keyword in Python 2")

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -257,6 +257,19 @@ def test_SerializableLock_name_collision():
     assert d.lock not in (a.lock, b.lock, c.lock)
 
 
+def test_SerializableLock_locked():
+    a = SerializableLock('a')
+    with a:
+        assert a.locked()
+
+
+def test_SerializableLock_acquire_blocking():
+    a = SerializableLock('a')
+    assert a.acquire(blocking=True)
+    assert not a.acquire(blocking=False)
+    a.release()
+
+
 def test_funcname():
     def foo(a, b, c):
         pass

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -777,11 +777,11 @@ class SerializableLock(object):
             self.lock = Lock()
             SerializableLock._locks[self.token] = self.lock
 
-    def acquire(self, *args):
-        return self.lock.acquire(*args)
+    def acquire(self, *args, **kwargs):
+        return self.lock.acquire(*args, **kwargs)
 
-    def release(self, *args):
-        return self.lock.release(*args)
+    def release(self, *args, **kwargs):
+        return self.lock.release(*args, **kwargs)
 
     def __enter__(self):
         self.lock.__enter__()
@@ -789,9 +789,8 @@ class SerializableLock(object):
     def __exit__(self, *args):
         self.lock.__exit__(*args)
 
-    @property
     def locked(self):
-        return self.locked
+        return self.lock.locked()
 
     def __getstate__(self):
         return self.token


### PR DESCRIPTION
locked() should be a method (this version was both broken and untested).

acquire() now supports keyword arguments, e.g., lock.acquire(blocking=True).

- [x] Tests added / passed
- [x] Passes `flake8 dask`
