### PR TITLE
Docs: Update spec.rst [skip ci]

### DIFF
--- a/docs/source/spec.rst
+++ b/docs/source/spec.rst
@@ -10,7 +10,7 @@ values.
 Definitions
 -----------
 
-A **dask graph** is a dictionary mapping **keys** to **computations**:
+A **Dask graph** is a dictionary mapping **keys** to **computations**:
 
 .. code-block:: python
 
@@ -28,7 +28,7 @@ A **key** is any hashable value that is not a **task**:
    ('x', 2, 3)
 
 A **task** is a tuple with a callable first element.  Tasks represent atomic
-units of work meant to be run by a single worker. Example: 
+units of work meant to be run by a single worker.  Example: 
 
 .. code-block:: python
 
@@ -40,7 +40,7 @@ function. An *argument* may be any valid **computation**.
 
 A **computation** may be one of the following:
 
-1.  Any **key** present in the dask graph like ``'x'``
+1.  Any **key** present in the Dask graph like ``'x'``
 2.  Any other value like ``1``, to be interpreted literally
 3.  A **task** like ``(inc, 'x')`` (see below)
 4.  A list of **computations**, like ``[1, 'x', (inc, 'x')]``
@@ -66,7 +66,7 @@ What functions should expect
 ----------------------------
 
 In cases like ``(add, 'x', 'y')``, functions like ``add`` receive concrete
-values instead of keys.  A dask scheduler replaces keys (like ``'x'`` and ``'y'``) with
+values instead of keys.  A Dask scheduler replaces keys (like ``'x'`` and ``'y'``) with
 their computed values (like ``1``, and ``2``) *before* calling the ``add`` function.
 
 
@@ -76,7 +76,7 @@ Entry Point - The ``get`` function
 The ``get`` function serves as entry point to computation for all
 :doc:`schedulers <scheduler-overview>`.  This function gets the value
 associated to the given key.  That key may refer to stored data, as is the case
-with ``'x'``, or a task as is the case with ``'z'``.  In the latter case,
+with ``'x'``, or to a task, as is the case with ``'z'``.  In the latter case,
 ``get`` should perform all necessary computation to retrieve the computed
 value.
 
@@ -104,7 +104,7 @@ value.
    >>> get(dsk, 'w')
    6
 
-Additionally if given a ``list``, get should simultaneously acquire values for
+Additionally, if given a ``list``, get should simultaneously acquire values for
 multiple keys:
 
 .. code-block:: python
@@ -112,7 +112,7 @@ multiple keys:
    >>> get(dsk, ['x', 'y', 'z'])
    [1, 2, 3]
 
-Because we accept lists of keys as keys, we support nested lists.
+Because we accept lists of keys as keys, we support nested lists:
 
 .. code-block:: python
 
@@ -126,7 +126,7 @@ computing, using caches, and so on.
 Why use tuples
 --------------
 
-With ``(add, 'x', 'y')`` we wish to encode "the result of calling ``add`` on
+With ``(add, 'x', 'y')``, we wish to encode the result of calling ``add`` on
 the values corresponding to the keys ``'x'`` and ``'y'``.
 
 We intend the following meaning:
@@ -135,7 +135,7 @@ We intend the following meaning:
 
    add('x', 'y')  # after x and y have been replaced
 
-But this will err because Python executes the function immediately,
+But this will err because Python executes the function immediately
 before we know values for ``'x'`` and ``'y'``.
 
 We delay the execution by moving the opening parenthesis one term to the left,


### PR DESCRIPTION
This PR updates `spec.rst` with minor corrections to punctuation and naming convention.
