### PR TITLE
Docs: Update high-level-graphs.rst [skip ci]

### DIFF
--- a/docs/source/high-level-graphs.rst
+++ b/docs/source/high-level-graphs.rst
@@ -11,11 +11,10 @@ how to work with these in more detail.
 Motivation and Example
 ----------------------
 
-In full generality, Dask schedulers expect arbitrary task graphs, where each
-node is a single Python function call, and each edge is a dependency between
+In full generality, Dask schedulers expect arbitrary task graphs where each
+node is a single Python function call and each edge is a dependency between
 two function calls.  These are usually stored in flat dictionaries.  Here is
-some simple dask dataframe code and the task graph that it might generate:
-
+some simple Dask DataFrame code and the task graph that it might generate:
 
 .. code-block:: python
 
@@ -45,7 +44,7 @@ some simple dask dataframe code and the task graph that it might generate:
 The task graph is a dictionary that stores every Pandas-level function call
 necessary to compute the final result.  We can see that there is some structure
 to this dictionary if we separate out the tasks that were associated to each
-high-level Dask DataFrame operation.
+high-level Dask DataFrame operation:
 
 .. code-block:: python
 
@@ -71,9 +70,9 @@ high-level Dask DataFrame operation.
 
 By understanding this high-level structure we are able to understand our task
 graphs more easily (this is more important for larger datasets when there are
-thousands of tasks per layer) and do perform high-level optimizations.  For
-example in the case above we may want to automatically rewrite our code to
-filter our datasets before adding 100
+thousands of tasks per layer) and how to perform high-level optimizations.  For
+example, in the case above we may want to automatically rewrite our code to
+filter our datasets before adding 100:
 
 .. code-block:: python
 
@@ -88,7 +87,7 @@ filter our datasets before adding 100
     df = df + 100
 
 Dask's high level graphs help us to explicitly encode this structure by storing
-our task graphs in layers, with dependencies between layers.
+our task graphs in layers with dependencies between layers:
 
 .. code-block:: python
 
@@ -124,7 +123,7 @@ our task graphs in layers, with dependencies between layers.
     'filter': {'add'}
    }
 
-While the dataframe points to the output layers on which it depends directly
+While the DataFrame points to the output layers on which it depends directly:
 
 .. code-block:: python
 
@@ -136,7 +135,7 @@ HighLevelGraphs
 ---------------
 
 The :obj:`HighLevelGraph` object is a ``Mapping`` object composed of other
-sub-``Mappings``, along with a high-level dependency mapping between them.
+sub-``Mappings``, along with a high-level dependency mapping between them:
 
 .. code-block:: python
 
@@ -144,8 +143,8 @@ sub-``Mappings``, along with a high-level dependency mapping between them.
        layers: Dict[str, Mapping]
        dependencies: Dict[str, Set[str]]
 
-You can construct a HighLevelGraph explicilty by providing both to the
-constructor.
+You can construct a HighLevelGraph explicitly by providing both to the
+constructor:
 
 .. code-block:: python
 
@@ -173,7 +172,7 @@ constructor.
    graph = HighLevelGraph(layers, dependencies)
 
 This object satisfies the ``Mapping`` interface, and so operates as a normal
-Python dictionary that is the semantic merger of the underlying layers
+Python dictionary that is the semantic merger of the underlying layers:
 
 .. code-block:: python
 


### PR DESCRIPTION
This PR updates `high-level-graphs.rst` with some punctuation and naming convention corrections, plus a couple typos
