### PR TITLE
Allow tokenization on odd characters/bytestrings in numpy arrays

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -111,6 +111,8 @@ if PY3:
             raise exc.with_traceback(tb)
         raise exc
 
+    import pickle as cPickle
+
 else:
     import __builtin__ as builtins
     import copy_reg as copyreg
@@ -301,6 +303,9 @@ else:
     except ImportError:
         # Fallback to top-level definition
         pass
+
+
+    import cPickle
 
 
 def getargspec(func):

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -207,6 +207,23 @@ def test_tokenize_pandas():
     assert tokenize(a) == tokenize(b)
 
 
+@pytest.mark.skipif('not pd')
+def test_tokenize_pandas_invalid_unicode():
+    # see https://github.com/dask/dask/issues/2713
+    df = pd.DataFrame({'x\ud83d': [1, 2, 3], 'y\ud83d': ['4', 'asd\ud83d', None]}, index=[1, 2, 3])
+    tokenize(df)
+
+
+@pytest.mark.skipif('not pd')
+def test_tokenize_pandas_no_pickle():
+    class NoPickle(object):
+        # pickling not supported because it is a local class
+        pass
+
+    df = pd.DataFrame({'x': ['foo', None, NoPickle()]})
+    tokenize(df)
+
+
 def test_tokenize_kwargs():
     assert tokenize(5, x=1) == tokenize(5, x=1)
     assert tokenize(5) != tokenize(5, x=1)
@@ -545,6 +562,25 @@ def test_compute_array_dataframe():
     arr_out, df_out = compute(darr, ddf)
     assert np.allclose(arr_out, arr + 1)
     pd.util.testing.assert_series_equal(df_out, df.a + 2)
+
+
+@pytest.mark.skipif('not dd')
+def test_compute_dataframe_valid_unicode_in_bytes():
+    df = pd.DataFrame(
+        data=np.random.random((3, 1)),
+        columns=[u'ö'.encode('utf8')],
+    )
+    dd.from_pandas(df, npartitions=4)
+
+
+@pytest.mark.skipif('not dd')
+def test_compute_dataframe_invalid_unicode():
+    # see https://github.com/dask/dask/issues/2713
+    df = pd.DataFrame(
+        data=np.random.random((3, 1)),
+        columns=['\ud83d'],
+    )
+    dd.from_pandas(df, npartitions=4)
 
 
 @pytest.mark.skipif('not da or not db')


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

Fixes #2713 
