### PR TITLE
Doc: Replace from_avro with read_avro in documents (#4283)

### DIFF
--- a/docs/source/bag-api.rst
+++ b/docs/source/bag-api.rst
@@ -50,7 +50,7 @@ Create Bags
    from_delayed
    read_text
    from_url
-   from_avro
+   read_avro
    range
 
 Top-level functions

--- a/docs/source/bag-creation.rst
+++ b/docs/source/bag-creation.rst
@@ -70,7 +70,7 @@ attached directly to bags with ``.str.methodname``:
    >>> b = db.read_text('myfile.*.csv').str.strip().str.split(',')
 
 
-``db.from_avro``
+``db.read_avro``
 ----------------
 
 Dask Bag can read binary files in the `Avro`_ format if `fastavro`_ is installed.


### PR DESCRIPTION
closes #4283
This replaces from_avro with read_avro in bag-api.rst and bag-creation.rst.