### PR TITLE
Docs: Update configuration.rst [skip ci]

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -92,11 +92,11 @@ These files can live in any of the following locations:
 Dask searches for *all* YAML files within each of these directories and merges
 them together, preferring configuration files closer to the user over system
 configuration files (preference follows the order in the list above).
-Additionally users can specify a path with the ``DASK_CONFIG`` environment
-variable, that takes precedence at the top of the list above.
+Additionally, users can specify a path with the ``DASK_CONFIG`` environment
+variable, which takes precedence at the top of the list above.
 
 The contents of these YAML files are merged together, allowing different
-dask subprojects like ``dask-kubernetes`` or ``dask-ml`` to manage configuration
+Dask subprojects like ``dask-kubernetes`` or ``dask-ml`` to manage configuration
 files separately, but have them merge into the same global configuration.
 
 *Note: for historical reasons we also look in the ``~/.dask`` directory for
@@ -143,7 +143,7 @@ Defaults
 
 Additionally, individual subprojects may add their own default values when they
 are imported.  These are always added with lower priority than the YAML files
-or environment variables mentioned above
+or environment variables mentioned above:
 
 .. code-block:: python
 
@@ -169,13 +169,13 @@ Configuration is stored within a normal Python dictionary in
 
 Additionally, you can temporarily set a configuration value using the
 ``dask.config.set`` function.  This function accepts a dictionary as an input
-and interprets ``"."`` as nested access
+and interprets ``"."`` as nested access:
 
 .. code-block:: python
 
    >>> dask.config.set({'scheduler.work-stealing': True})
 
-This function can also be used as a context manager for consistent cleanup.
+This function can also be used as a context manager for consistent cleanup:
 
 .. code-block:: python
 
@@ -208,7 +208,7 @@ provides a configuration that is possibly nested like the following:
    y = {'a': 1, 'b': 2, 'c': {'e': 5}}
 
 Dask will merge these configurations respecting nested data structures, and
-respecting order.
+respecting order:
 
 .. code-block:: python
 
@@ -218,7 +218,7 @@ respecting order.
 You can also use the ``update`` function to update the existing configuration
 in place with a new configuration.  This can be done with priority being given
 to either config.  This is often used to update the global configuration in
-``dask.config.config``
+``dask.config.config``:
 
 .. code-block:: python
 
@@ -226,7 +226,7 @@ to either config.  This is often used to update the global configuration in
    dask.config.update(dask.config, new, priority='old')  # Give priority to old values
 
 Sometimes it is useful to expand environment variables stored within a
-configuration. This can be done with the ``expand_environment_variables``
+configuration.  This can be done with the ``expand_environment_variables``
 function:
 
 .. code-block:: python
@@ -240,9 +240,9 @@ Refreshing Configuration
    dask.config.collect
    dask.config.refresh
 
-If you change your environment variables or YAML files Dask will not
+If you change your environment variables or YAML files, Dask will not
 immediately see the changes.  Instead, you can call ``refresh`` to go through
-the configuration collection process and update the default configuration.
+the configuration collection process and update the default configuration:
 
 .. code-block:: python
 
@@ -257,7 +257,7 @@ the configuration collection process and update the default configuration.
 
 This function uses ``dask.config.collect``, which returns the configuration
 without modifying the global configuration.  You might use this to determine
-the configuration of particular paths not yet on the config path.
+the configuration of particular paths not yet on the config path:
 
 .. code-block:: python
 
@@ -273,7 +273,7 @@ Downstream Libraries
    dask.config.update_defaults
 
 Downstream Dask libraries often follow a standard convention to use the central
-Dask configuration.  This section provides recommendations for integration,
+Dask configuration.  This section provides recommendations for integration
 using a fictional project, ``dask-foo``, as an example.
 
 Downstream projects typically follow the following convention:
@@ -287,7 +287,7 @@ Downstream projects typically follow the following convention:
        dask_foo/core.py
        dask_foo/foo.yaml  # <---
 
-2.  Place configuration in that file within a namespace for the project
+2.  Place configuration in that file within a namespace for the project:
 
     .. code-block:: yaml
 
@@ -300,7 +300,7 @@ Downstream projects typically follow the following convention:
            b: 2
 
 3.  Within a config.py file (or anywhere) load that default config file and
-    update it into the global configuration
+    update it into the global configuration:
 
     .. code-block:: python
 
@@ -332,7 +332,7 @@ Downstream projects typically follow the following convention:
     The user can investigate ``~/.config/dask/*.yaml`` to see all of the
     commented out configuration files to which they have access.
 
-5.  Ensure that this file is run on import by including it in ``__init__.py``
+5.  Ensure that this file is run on import by including it in ``__init__.py``:
 
     .. code-block:: python
 
@@ -341,7 +341,7 @@ Downstream projects typically follow the following convention:
        from . import config
 
 6.  Within ``dask_foo`` code, use the ``dask.config.get`` function to access
-    configuration values
+    configuration values:
 
     .. code-block:: python
 
@@ -356,7 +356,7 @@ Downstream projects typically follow the following convention:
 
        recursive-include <PACKAGE_NAME> *.yaml
 
-    and the following in your setup.py ``setup`` call
+    and the following in your setup.py ``setup`` call:
 
     .. code-block:: python
 
@@ -367,8 +367,8 @@ Downstream projects typically follow the following convention:
               ...)
 
 This process keeps configuration in a central place, but also keeps it safe
-within namespaces.  It places config files in an easy to access location
-,``~/.config/dask/\*.yaml`` by default so that users can easily discover what
+within namespaces.  It places config files in an easy to access location 
+by default (``~/.config/dask/\*.yaml``), so that users can easily discover what
 they can change, but maintains the actual defaults within the source code, so
 that they more closely track changes in the library.
 


### PR DESCRIPTION
This PR updates `configuration.rst` with some punctuation improvements and naming convention corrections. Additionally, a fix to a highlighted string is applied, and also it is slightly reordered in the sentence to improve its reading flow (at least for me it looks slightly better formatted this way).
