### PR TITLE
Docs: Update cheatsheet.rst [skip ci]

### DIFF
--- a/docs/source/cheatsheet.rst
+++ b/docs/source/cheatsheet.rst
@@ -1,6 +1,6 @@
 Dask Cheat Sheet
 ================
 
-The 300KB pdf :download:`dask cheat sheet <daskcheatsheet.pdf>`
-is a single page summary about using dask.
+The 300KB pdf :download:`Dask cheat sheet <daskcheatsheet.pdf>`
+is a single page summary about using Dask.
 It is commonly distributed at conferences and trade shows.


### PR DESCRIPTION
This PR updates `cheatsheet.rst` with a couple of naming convention corrections.

