### PR TITLE
Docs: Update spark.rst [skip ci]

### DIFF
--- a/docs/source/spark.rst
+++ b/docs/source/spark.rst
@@ -14,7 +14,7 @@ Summary
 -------
 
 Generally Dask is smaller and lighter weight than Spark.  This means that it
-has fewer features and instead is intended to be used in conjunction with other
+has fewer features and, instead, is intended to be used in conjunction with other
 libraries, particularly those in the numeric Python ecosystem.  It couples with
 other libraries like Pandas or Scikit-Learn to achieve high-level
 functionality.
@@ -39,7 +39,7 @@ functionality.
     - Spark is more focused on traditional business intelligence
       operations like SQL and lightweight machine learning.
     - Dask is applied more generally both to business intelligence
-      applications, as well as a number of scientific and custom situations
+      applications, as well as a number of scientific and custom situations.
 - Internal Design
     - Spark's internal model is higher level, providing good high level
       optimizations on uniformly applied computations, but lacking flexibility
@@ -50,14 +50,14 @@ functionality.
       build more complex bespoke systems.  It is fundamentally based on generic
       task scheduling.
 - Scale
-    - Spark scales from a single node to thousand-node clusters
-    - Dask scales from a single node to thousand-node clusters
+    - Spark scales from a single node to thousand-node clusters.
+    - Dask scales from a single node to thousand-node clusters.
 - APIs
-    - Dataframes
-        - Spark dataframe has its own API and memory model.  It also
+    - DataFrames
+        - Spark DataFrame has its own API and memory model.  It also
           implements a large subset of the SQL language.  Spark includes a
           high-level query optimizer for complex queries.
-        - Dask.dataframe reuses the Pandas API and memory model.  It implements
+        - Dask DataFrame reuses the Pandas API and memory model.  It implements
           neither SQL nor a query optimizer.  It is able to do random access,
           efficient time series operations, and other Pandas-style indexed
           operations.
@@ -73,7 +73,7 @@ functionality.
           `dask-ml`_ project for integrations.
     - Arrays
         - Spark does not include support for multi-dimensional arrays natively
-          (this would be challenging given their computation model) although
+          (this would be challenging given their computation model), although
           some support for two-dimensional matrices may be found in MLLib.
           People may also want to look at the `Thunder
           <https://github.com/thunder-project/thunder>`_ project, which
@@ -83,13 +83,13 @@ functionality.
     - Streaming
         - Spark's support for streaming data is first-class and integrates well
           into their other APIs.  It follows a mini-batch approach.  This
-          provides decent performance on large uniform streaming operations
+          provides decent performance on large uniform streaming operations.
         - Dask provides a :doc:`real-time futures interface <futures>` that is
           lower-level than Spark streaming.  This enables more creative and
           complex use-cases, but requires more work than Spark streaming.
     - Graphs / complex networks
-        - Spark provides GraphX, a library for graph processing
-        - Dask provides no such library
+        - Spark provides GraphX, a library for graph processing.
+        - Dask provides no such library.
     - Custom parallelism
         - Spark generally expects users to compose computations out of their
           high-level primitives (map, reduce, groupby, join, ...).  It is also
@@ -139,15 +139,15 @@ This many-little-tasks state is only available internally to the Spark
 scheduler.
 
 Dask graphs skip this high-level representation and go directly to the
-many-little-tasks stage.  As such one ``map`` operation on a dask collection
-will immediately generate and add possibly thousands of tiny tasks to the dask
+many-little-tasks stage.  As such, one ``map`` operation on a Dask collection
+will immediately generate and add possibly thousands of tiny tasks to the Dask
 graph.
 
 This difference in the scale of the underlying graph has implications on the
 kinds of analysis and optimizations one can do and also on the generality that
 one exposes to users.  Dask is unable to perform some optimizations that Spark
 can because Dask schedulers do not have a top-down picture of the computation
-they were asked to perform.  However, dask is able to easily represent far more
+they were asked to perform.  However, Dask is able to easily represent far more
 `complex algorithms`_ and expose the creation of these algorithms to normal users.
 
 
@@ -155,16 +155,16 @@ Conclusion
 ----------
 
 Spark is mature and all-inclusive.  If you want a single project that does
-everything and you're already on Big Data hardware then Spark is a safe bet,
+everything and you're already on Big Data hardware, then Spark is a safe bet,
 especially if your use cases are typical ETL + SQL and you're already using
 Scala.
 
 Dask is lighter weight and is easier to integrate into existing code and hardware.
 If your problems vary beyond typical ETL + SQL and you want to add flexible
-parallelism to existing solutions then dask may be a good fit, especially if
+parallelism to existing solutions, then Dask may be a good fit, especially if
 you are already using Python and associated libraries like NumPy and Pandas.
 
-If you are looking to manage a terabyte or less of tabular CSV or JSON data
+If you are looking to manage a terabyte or less of tabular CSV or JSON data,
 then you should forget both Spark and Dask and use Postgres_ or MongoDB_.
 
 


### PR DESCRIPTION
This PR updates `spark.rst` with some punctuation improvements and naming convention corrections (simple stuff)
