### PR TITLE
Treat None as missing in config when updating

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -72,6 +72,8 @@ def update(old, new, priority='new'):
             old[k] = {}
 
         if type(v) is dict:
+            if old[k] is None:
+                old[k] = {}
             update(old[k], v, priority=priority)
         else:
             if priority == 'new' or k not in old:

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -337,3 +337,7 @@ def test_get_set_roundtrip(key):
     with dask.config.set({key: value}):
         assert dask.config.get('custom_key') == value
         assert dask.config.get('custom-key') == value
+
+
+def test_merge_None_to_dict():
+    assert dask.config.merge({'a': None, 'c': 0}, {'a': {'b': 1}}) == {'a': {'b': 1}, 'c': 0}


### PR DESCRIPTION
Sometimes users provide None/null in configuration to indicate that they
don't have a value.

Previously this would break when we went to merge configurations.

Now we accept merging a dict into None, replacing the None value rather than
erring.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`


cc @djhoese @ian-r-rose