### PR TITLE
Docs: Update remote-data-services.rst [skip ci]

### DIFF
--- a/docs/source/remote-data-services.rst
+++ b/docs/source/remote-data-services.rst
@@ -1,10 +1,10 @@
 Remote Data
 ===========
 
-Dask can read data from a variety data stores including local file systems,
+Dask can read data from a variety of data stores including local file systems,
 network file systems, cloud object stores, and Hadoop.  Typically this is done
 by prepending a protocol like ``"s3://"`` to paths used in common data access
-functions like ``dd.read_csv``
+functions like ``dd.read_csv``:
 
 .. code-block:: python
 
@@ -27,7 +27,7 @@ codebase:
   using the library s3fs_
 
 - **Google Cloud Storage**: ``gcs://`` or ``gs:`` - Google Cloud Storage, typically used with Google Compute
-  resource, using gcsfs_ (in development)
+  resource using gcsfs_ (in development)
 
 - **HTTP(s)**: ``http://`` or ``https://`` for reading data directly from HTTP web servers
 
@@ -36,7 +36,7 @@ codebase:
 
 When specifying a storage location, a URL should be provided using the general
 form ``protocol://path/to/data``.  If no protocol is provided, the local
-file-system is assumed (same as ``file://``).
+file system is assumed (same as ``file://``).
 
 .. _hdfs3: http://hdfs3.readthedocs.io/
 .. _s3fs: http://s3fs.readthedocs.io/
@@ -50,7 +50,7 @@ Lower-level details on how Dask handles remote data is described in Section
 Optional Parameters
 -------------------
 
-Two methods exist for passing parameters to the backend file-system driver:
+Two methods exist for passing parameters to the backend file system driver:
 extending the URL to include username, password, server, port, etc.; and
 providing ``storage_options``, a dictionary of parameters to pass on. Examples:
 
@@ -61,12 +61,12 @@ providing ``storage_options``, a dictionary of parameters to pass on. Examples:
    df = dd.read_parquet('s3://bucket/path',
                         storage_options={'anon': True, 'use_ssl': False})
 
-Further details on how to provide configuration for each backend
+Further details on how to provide configuration for each back-end
 is listed next.
 
 Each back-end has additional installation requirements and may not be available
 at runtime. The dictionary ``dask.bytes.core._filesystems`` contains the
-currently available file-systems. Some require appropriate imports before use.
+currently available file systems. Some require appropriate imports before use.
 
 The following list gives the protocol shorthands and the back-ends to which
 they refer.
@@ -81,7 +81,7 @@ dictionary will be ignored.
 
 This is the default back-end, and the one used if no protocol is passed at all.
 
-We assume here that each worker has access to the same file-system - either
+We assume here that each worker has access to the same file system - either
 the workers are co-located on the same machine, or a network file system
 is mounted and referenced at the same path location for every worker node.
 
@@ -120,7 +120,7 @@ set ``hdfs_driver`` using ``dask.config.set``:
 
 By default, both libraries attempt to read the default server and port from
 local Hadoop configuration files on each node, so it may be that no
-configuration is required. However, the server, port and user can be passed as
+configuration is required. However, the server, port, and user can be passed as
 part of the url: ``hdfs://user:pass@server:port/path/to/data``.
 
 Extra Configuration for HDFS3
@@ -129,12 +129,12 @@ Extra Configuration for HDFS3
 The following additional options may be passed to the ``hdfs3`` driver via
 ``storage_options``:
 
-    - ``host``, ``port``, ``user``: basic authentication
-    - ``ticket_cache``, ``token``: kerberos authentication
-    - ``pars``: dictionary of further parameters (e.g., for `high availability`_)
+    - ``host``, ``port``, ``user``: Basic authentication
+    - ``ticket_cache``, ``token``: Kerberos authentication
+    - ``pars``: Dictionary of further parameters (e.g., for `high availability`_)
 
-The ``hdfs3`` driver can also be affected by a few environment variables. For
-information on these see the `hdfs3 documentation`_.
+The ``hdfs3`` driver can also be affected by a few environment variables. For more
+information on these, see the `hdfs3 documentation`_.
 
 .. _high availability: http://hdfs3.readthedocs.io/en/latest/hdfs.html#high-availability-mode
 .. _hdfs3 documentation: https://hdfs3.readthedocs.io/en/latest/hdfs.html#defaults
@@ -145,11 +145,11 @@ Extra Configuration for PyArrow
 The following additional options may be passed to the ``pyarrow`` driver via
 ``storage_options``:
 
-    - ``host``, ``port``, ``user``: basic authentication
-    - ``kerb_ticket``: path to kerberos ticket cache
+    - ``host``, ``port``, ``user``: Basic authentication
+    - ``kerb_ticket``: Path to kerberos ticket cache
 
 PyArrow's ``libhdfs`` driver can also be affected by a few environment
-variables. For information on these see the `pyarrow documentation`_.
+variables. For more information on these, see the `pyarrow documentation`_.
 
 .. _pyarrow documentation: https://arrow.apache.org/docs/python/filesystems.html#hadoop-file-system-hdfs
 
@@ -160,15 +160,15 @@ Amazon S3
 Amazon S3 (Simple Storage Service) is a web service offered by Amazon Web
 Services.
 
-The S3 back-end will be available to dask is s3fs is importable when dask is
+The S3 back-end available to Dask is s3fs, and is importable when Dask is
 imported.
 
 Authentication for S3 is provided by the underlying library boto3. As described
-in the `auth docs`_ this could be achieved by placing credentials files in one
+in the `auth docs`_, this could be achieved by placing credentials files in one
 of several locations on each node: ``~/.aws/credentials``, ``~/.aws/config``,
-``/etc/boto.cfg`` and ``~/.boto``. Alternatively, for nodes located
+``/etc/boto.cfg``, and ``~/.boto``. Alternatively, for nodes located
 within Amazon EC2, IAM roles can be set up for each node, and then no further
-configuration is required. The final authentication option, is for user
+configuration is required. The final authentication option for user
 credentials can be passed directly in the URL
 (``s3://keyID:keySecret/bucket/key/name``) or using ``storage_options``. In
 this case, however, the key/secret will be passed to all workers in-the-clear,
@@ -178,25 +178,25 @@ so this method is only recommended on well-secured networks.
 
 The following parameters may be passed to s3fs using ``storage_options``:
 
-    - anon: whether access should be anonymous (default False)
+    - anon: Whether access should be anonymous (default False)
 
-    - key, secret: for user authentication
+    - key, secret: For user authentication
 
-    - token: if authentication has been done with some other S3 client
+    - token: If authentication has been done with some other S3 client
 
-    - use_ssl: whether connections are encrypted and secure (default True)
+    - use_ssl: Whether connections are encrypted and secure (default True)
 
-    - client_kwargs: dict passed to the `boto3 client`_, with keys such
-      as `region_name`, `endpoint_url`
+    - client_kwargs: Dict passed to the `boto3 client`_, with keys such
+      as `region_name` or `endpoint_url`
 
-    - requester_pays: set True if the authenticated user will assume transfer
+    - requester_pays: Set True if the authenticated user will assume transfer
       costs, which is required by some providers of bulk data
 
-    - default_block_size, default_fill_cache: these are not of particular
-      interest to dask users, as they concern the behaviour of the buffer
+    - default_block_size, default_fill_cache: These are not of particular
+      interest to Dask users, as they concern the behaviour of the buffer
       between successive reads
 
-    - kwargs: other parameters are passed to the `boto3 Session`_ object,
+    - kwargs: Other parameters are passed to the `boto3 Session`_ object,
       such as `profile_name`, to pick one of the authentication sections from
       the configuration files referred to above (see `here`_)
 
@@ -211,30 +211,32 @@ Google Cloud Storage
 Google Cloud Storage is a RESTful online file storage web service for storing
 and accessing data on Google's infrastructure.
 
-The GCS backend is identified by the
+The GCS back-end is identified by the
 protocol identifiers ``gcs`` and ``gs``, which are identical in their effect.
 
 Multiple modes of authentication are supported. These options should be
 included in the ``storage_options`` dictionary as ``{'token': ..}`` submitted with your call
-to a storage-based dask function/method. See the `gcsfs`_ documentation for further
+to a storage-based Dask function/method. See the `gcsfs`_ documentation for further
 details.
 
 
 General recommendations for distributed clusters, in order:
+
 - use 'anon' for public data
-- use 'cloud', if this is available
-- use `gcloud`_ to generate a JSON file, and distribute this to all workers, and
-supply the path to the file
+- use 'cloud' if this is available
+- use `gcloud`_ to generate a JSON file, and distribute this to all workers, and 
+  supply the path to the file
+
 - use gcsfs directly with the 'browser' method to generate a token cache file
-(``~/.gcs_tokens``) and distribute this, with method 'cache'.
+  (``~/.gcs_tokens``) and distribute this with method 'cache'
 
 .. _gcloud: https://cloud.google.com/sdk/docs/
 
 The final suggestion may be the fastest and simplest for authenticated access (as
-opposed to anonymous), since it will not require re-authentication; however this method
-is not secure, credentials will be passed directly around the cluster. This is fine if
+opposed to anonymous), since it will not require re-authentication. However, this method
+is not secure since credentials will be passed directly around the cluster. This is fine if
 you are certain that the cluster is itself secured. You need to create a ``GCSFileSystem`` object
-using any method that works for you, and then pass its credentials directly:
+using any method that works for you and then pass its credentials directly:
 
 .. code-block:: python
 
@@ -244,12 +246,14 @@ using any method that works for you, and then pass its credentials directly:
 Azure Datalake
 --------------
 
-*Support for ADL is experimental - use at own risk*
+.. warning::
+
+    Support for ADL is experimental - use at own risk.
 
 Parameters ``tenant_id``, ``client_id``, and ``client_secret`` are required for
 authentication in ``storage_options=``,
-and all other parameters will be passed on to the AzureDLFileSystem_ constructor,
-follow the link for further information. The auth parameters are passed directly to
+and all other parameters will be passed on to the AzureDLFileSystem_ constructor
+(follow the link for further information). The auth parameters are passed directly to
 workers, so this should only be used within a secure cluster.
 
 .. _AzureDLFileSystem: https://azure-datalake-store.readthedocs.io/en/latest/api.html#azure.datalake.store.core.AzureDLFileSystem
@@ -264,10 +268,10 @@ of files can be used.
 
 Server implementations differ in the information they provide - they may or may
 not specify the size of a file via a HEAD request or at the start of a download -
-and some servers may not respect bytes range requests. The HTTPFileSystem therefore
-offers best-effort behaviour: the download is streamed, but if more data is seen
+and some servers may not respect byte range requests. The HTTPFileSystem therefore
+offers best-effort behaviour: the download is streamed but, if more data is seen
 than the configured block-size, an error will be raised. To be able to access such
-data, you must read the whole file in one shot (and it must fit in memory).
+data you must read the whole file in one shot (and it must fit in memory).
 
 Note that, currently, ``http://`` and ``https://`` are treated as separate protocols,
 and cannot be mixed.
@@ -275,12 +279,12 @@ and cannot be mixed.
 Developer API
 -------------
 
-The prototype for any file-system back-end can be found in
+The prototype for any file system back-end can be found in
 ``bytes.local.LocalFileSystem``. Any new implementation should provide the
-same API, and make itself available as a protocol to dask. For example, the
+same API and make itself available as a protocol to Dask. For example, the
 following would register the protocol "myproto", described by the implementation
 class ``MyProtoFileSystem``. URLs of the form ``myproto://`` would thereafter
-be dispatched to the methods of this class.
+be dispatched to the methods of this class:
 
 .. code-block:: python
 


### PR DESCRIPTION
This PR updates `remote-data-services.rst` with several changes:

- punctuation and naming convention corrections
- some words have been sprinkled here and there to improve the readability of some sentences 
- fixes the formatting of a list in the **Google Cloud Storage** section
- and adds a *warning* text block in the **Azure Datalake**  section to better highlight that the feature is experimental.
