### PR TITLE
Install pyarrow fastparquet for Appveyor

### DIFF
--- a/continuous_integration/appveyor/setup_conda_environment.cmd
+++ b/continuous_integration/appveyor/setup_conda_environment.cmd
@@ -27,7 +27,7 @@ echo pandas %PANDAS% >> %CONDA_PREFIX%\conda-meta\pinned
 
 @rem Install optional dependencies for tests
 %CONDA_INSTALL% numpy pandas cloudpickle distributed
-%CONDA_INSTALL% bcolz bokeh h5py ipython lz4 psutil pytables s3fs scipy
+%CONDA_INSTALL% bcolz bokeh h5py ipython lz4 psutil pytables s3fs scipy pyarrow fastparquet
 
 %PIP_INSTALL% git+https://github.com/dask/partd --upgrade
 %PIP_INSTALL% git+https://github.com/dask/cachey --upgrade


### PR DESCRIPTION
To correct https://ci.appveyor.com/project/daskdev/dask/builds/21288395
```
SKIP [1] dask\dataframe\io\tests\test_parquet.py:112: fastparquet not found
SKIP [3] dask\dataframe\io\tests\test_parquet.py:112: pyarrow not found
SKIP [1] dask\dataframe\io\tests\test_parquet.py:137: fastparquet not found
SKIP [3] dask\dataframe\io\tests\test_parquet.py:137: pyarrow not found
SKIP [2] dask\dataframe\io\tests\test_parquet.py:163: fastparquet not found
SKIP [6] dask\dataframe\io\tests\test_parquet.py:163: pyarrow not found
```