### PR TITLE
Add a better error message when cloudpickle is missing

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -863,6 +863,8 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
         elif scheduler.lower() in ('dask.distributed', 'distributed'):
             from distributed.worker import get_client
             return get_client().get
+        elif scheduler.lower() in ['processes', 'multiprocessing']:
+            raise ValueError("Please install cloudpickle to use the '%s' scheduler." % scheduler)
         else:
             raise ValueError("Expected one of [distributed, %s]" % ', '.join(sorted(named_schedulers)))
         # else:  # try to connect to remote scheduler with this name


### PR DESCRIPTION
Fixes: https://github.com/dask/dask/issues/4341
```
ValueError: Please install cloudpickle to use the 'processes' scheduler.
```

- [ ] Tests added / passed
- [x] Passes `flake8 dask`

I'm not too familiar with the test, and it seems that all the dependencies are installed automatically so it is difficult to test this case.


