### PR TITLE
config: Allow updates from arbitrary Mappings

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -68,10 +68,10 @@ def update(old, new, priority='new'):
     dask.config.merge
     """
     for k, v in new.items():
-        if k not in old and type(v) is dict:
+        if k not in old and isinstance(v, Mapping):
             old[k] = {}
 
-        if type(v) is dict:
+        if isinstance(v, Mapping):
             if old[k] is None:
                 old[k] = {}
             update(old[k], v, priority=priority)

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -1,5 +1,6 @@
 import yaml
 import os
+from collections import OrderedDict
 
 import pytest
 
@@ -13,7 +14,7 @@ from dask.utils import tmpfile
 
 def test_update():
     a = {'x': 1, 'y': {'a': 1}}
-    b = {'x': 2, 'z': 3, 'y': {'b': 2}}
+    b = {'x': 2, 'z': 3, 'y': OrderedDict({'b': 2})}
     update(b, a)
     assert b == {'x': 1, 'y': {'a': 1, 'b': 2}, 'z': 3}
 


### PR DESCRIPTION
`dask.config.update(old, new)` does not work properly unless `type(new) is dict`.  That means that subclasses such as `OrderedDict` don't work as expected.

This tiny PR fixes that.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
