### PR TITLE
Re-enable multifield copy->view change

### DIFF
--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -334,15 +334,14 @@ if LooseVersion(np.__version__) < '1.15.0':
         return arr[_make_along_axis_idx(arr_shape, indices, axis)]
 
 
-def _make_sliced_dtype(dtype, index):
-    if LooseVersion(np.__version__) == LooseVersion("1.14.0"):
-        return _make_sliced_dtype_np_ge_14(dtype, index)
-    else:
-        return _make_sliced_dtype_np_lt_14(dtype, index)
-
-
-def _make_sliced_dtype_np_ge_14(dtype, index):
-    # For https://github.com/numpy/numpy/pull/6053, NumPy >= 1.14
+def _make_sliced_dtype_np_ge_16(dtype, index):
+    # This was briefly added in 1.14.0
+    # https://github.com/numpy/numpy/pull/6053, NumPy >= 1.14
+    # which was then reverted in 1.14.1 with
+    # https://github.com/numpy/numpy/pull/10411
+    # And then was finally released with
+    # https://github.com/numpy/numpy/pull/12447
+    # in version 1.16.0
     new = {
         'names': index,
         'formats': [dtype.fields[name][0] for name in index],
@@ -356,6 +355,13 @@ def _make_sliced_dtype_np_lt_14(dtype, index):
     # For numpy < 1.14
     dt = np.dtype([(name, dtype[name]) for name in index])
     return dt
+
+
+if LooseVersion(np.__version__) >= LooseVersion("1.16.0") or \
+   LooseVersion(np.__version__) == LooseVersion("1.14.0"):
+    _make_sliced_dtype = _make_sliced_dtype_np_ge_16
+else:
+    _make_sliced_dtype = _make_sliced_dtype_np_lt_14
 
 
 class _Recurser(object):


### PR DESCRIPTION
Numpy attempted to release a feature in 1.14.0, but rolled it
back because it caused too many problems. After fixing issues, they
rereleased it in 1.16.0.

This also makes a minor enhancement to determines which numpy function
should be used at import time instead of run time.

- [X] Tests added / passed
7 tests failed with numpy 1.16. They pass with this patch
- [X] Passes `flake8 dask`
- Closes https://github.com/dask/dask/pull/4357

cc @hmaarrfk