### PR TITLE
Remove explicit pandas checks and provide cudf lazy registration

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -247,6 +247,15 @@ else:
 concat_dispatch = Dispatch('concat')
 
 
+@concat_dispatch.register_lazy('cudf')
+def register_cudf():
+    import cudf
+    concat_dispatch.register(
+        (cudf.DataFrame, cudf.Series, cudf.Index),
+        cudf.concat
+    )
+
+
 def concat(dfs, axis=0, join='outer', uniform=False, filter_warning=True):
     """Concatenate, handling some edge cases:
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -4,7 +4,9 @@ import pandas.util.testing as tm
 import dask.dataframe as dd
 from dask.dataframe.utils import (shard_df_on_index, meta_nonempty, make_meta,
                                   raise_on_meta_error, check_meta,
-                                  UNKNOWN_CATEGORIES, PANDAS_VERSION)
+                                  UNKNOWN_CATEGORIES, PANDAS_VERSION,
+                                  is_dataframe_like, is_series_like,
+                                  is_index_like)
 
 import pytest
 
@@ -328,3 +330,18 @@ def test_check_meta():
         '| e      | category | -        |\n'
         '+--------+----------+----------+')
     assert str(err.value) == exp
+
+
+def test_is_dataframe_like():
+    df = pd.DataFrame({'x': [1, 2, 3]})
+    assert is_dataframe_like(df)
+    assert not is_dataframe_like(df.x)
+    assert not is_dataframe_like(df.index)
+
+    assert not is_series_like(df)
+    assert is_series_like(df.x)
+    assert not is_series_like(df.index)
+
+    assert not is_index_like(df)
+    assert not is_index_like(df.x)
+    assert is_index_like(df.index)

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -345,3 +345,6 @@ def test_is_dataframe_like():
     assert not is_index_like(df)
     assert not is_index_like(df.x)
     assert is_index_like(df.index)
+
+    ddf = dd.from_pandas(df, npartitions=1)
+    assert is_dataframe_like(ddf)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -18,6 +18,7 @@ except ImportError:
     # pandas < 0.19.2
     from pandas.core.common import is_datetime64tz_dtype
 
+from ..base import is_dask_collection
 from ..compatibility import PY2, Iterator, Mapping
 from ..core import get_deps
 from ..local import get_sync
@@ -450,14 +451,17 @@ def _nonempty_series(s, idx=None):
 
 
 def is_dataframe_like(df):
+    """ Looks like a Pandas DataFrame """
     return set(dir(df)) > {'dtypes', 'columns', 'groupby', 'head'}
 
 
 def is_series_like(s):
+    """ Looks like a Pandas Series """
     return set(dir(s)) > {'name', 'dtype', 'groupby', 'head'}
 
 
 def is_index_like(s):
+    """ Looks like a Pandas Index """
     attrs = set(dir(s))
     return attrs > {'name', 'dtype'} and 'head' not in attrs
 
@@ -498,7 +502,8 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
             return a == b
         return (a.kind in eq_types and b.kind in eq_types) or (a == b)
 
-    if not (is_dataframe_like(meta) or is_series_like(meta) or is_index_like(meta)):
+    if (not (is_dataframe_like(meta) or is_series_like(meta) or is_index_like(meta))
+            or is_dask_collection(meta)):
         raise TypeError("Expected partition to be DataFrame, Series, or "
                         "Index, got `%s`" % type(meta).__name__)
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -449,6 +449,19 @@ def _nonempty_series(s, idx=None):
     return pd.Series(data, name=s.name, index=idx)
 
 
+def is_dataframe_like(df):
+    return set(dir(df)) > {'dtypes', 'columns', 'groupby', 'head'}
+
+
+def is_series_like(s):
+    return set(dir(s)) > {'name', 'dtype', 'groupby', 'head'}
+
+
+def is_index_like(s):
+    attrs = set(dir(s))
+    return attrs > {'name', 'dtype'} and 'head' not in attrs
+
+
 def check_meta(x, meta, funcname=None, numeric_equal=True):
     """Check that the dask metadata matches the result.
 
@@ -485,13 +498,9 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
             return a == b
         return (a.kind in eq_types and b.kind in eq_types) or (a == b)
 
-    from .core import parallel_types
-    if not isinstance(meta, parallel_types()):
+    if not (is_dataframe_like(meta) or is_series_like(meta) or is_index_like(meta)):
         raise TypeError("Expected partition to be DataFrame, Series, or "
                         "Index, got `%s`" % type(meta).__name__)
-
-    def is_dataframe_like(df):
-        return all(hasattr(df, attr) for attr in ['dtypes', 'columns', 'groupby', 'head'])
 
     if type(x) != type(meta):
         errmsg = ("Expected partition of type `%s` but got "


### PR DESCRIPTION
- [ ] Tests added / passed  # I'm not planning to do this for the cudf work.  It will be tested downstream
- [x] Passes `flake8 dask`

It would be good to get some other less-biased dev to ok the introduction of `cudf` here