### PR TITLE
ENH: Support 3rd-party ExtensionArrays

### DIFF
--- a/dask/dataframe/extensions.py
+++ b/dask/dataframe/extensions.py
@@ -1,0 +1,8 @@
+"""
+Support for pandas ExtensionArray in dask.dataframe.
+
+See :ref:`extensionarrays` for more.
+"""
+from ..utils import Dispatch
+
+make_array_nonempty = Dispatch("make_array_nonempty")

--- a/dask/dataframe/tests/test_extensions.py
+++ b/dask/dataframe/tests/test_extensions.py
@@ -2,19 +2,22 @@ from decimal import Decimal
 import pytest
 
 import dask.dataframe as dd
-from dask.dataframe.utils import assert_eq
+from dask.dataframe.utils import assert_eq, PANDAS_VERSION
 
-pd = pytest.importorskip("pandas", minversion="0.24.0rc1")
+pd = pytest.importorskip("pandas", minversion="0.23.4")
 
-
-from pandas.tests.extension.decimal import DecimalArray, DecimalDtype
+from pandas.tests.extension.decimal.array import DecimalArray, DecimalDtype
 from dask.dataframe.extensions import make_array_nonempty
 
 
 @make_array_nonempty.register(DecimalDtype)
 def _(dtype):
+    kwargs = {}
+    if PANDAS_VERSION >= "0.24.0rc1":
+        kwargs['dtype'] = dtype
+
     return DecimalArray._from_sequence([Decimal('0'), Decimal('NaN')],
-                                       dtype=dtype)
+                                       **kwargs)
 
 
 def test_register_extension_type():

--- a/dask/dataframe/tests/test_extensions.py
+++ b/dask/dataframe/tests/test_extensions.py
@@ -1,0 +1,28 @@
+from decimal import Decimal
+import pytest
+
+import dask.dataframe as dd
+from dask.dataframe.utils import assert_eq
+
+pd = pytest.importorskip("pandas", minversion="0.24.0rc1")
+
+
+from pandas.tests.extension.decimal import DecimalArray, DecimalDtype
+from dask.dataframe.extensions import make_array_nonempty
+
+
+@make_array_nonempty.register(DecimalDtype)
+def _(dtype):
+    return DecimalArray._from_sequence([Decimal('0'), Decimal('NaN')],
+                                       dtype=dtype)
+
+
+def test_register_extension_type():
+    arr = DecimalArray._from_sequence([Decimal('1.0')] * 10)
+    ser = pd.Series(arr)
+    dser = dd.from_pandas(ser, 2)
+    assert_eq(ser, dser)
+
+    df = pd.DataFrame({"A": ser})
+    ddf = dd.from_pandas(df, 2)
+    assert_eq(df, ddf)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -18,6 +18,7 @@ except ImportError:
     # pandas < 0.19.2
     from pandas.core.common import is_datetime64tz_dtype
 
+from .extensions import make_array_nonempty
 from ..base import is_dask_collection
 from ..compatibility import PY2, Iterator, Mapping
 from ..core import get_deps
@@ -443,6 +444,8 @@ def _nonempty_series(s, idx=None):
             cats = None
         data = pd.Categorical(data, categories=cats,
                               ordered=s.cat.ordered)
+    elif type(dtype) in make_array_nonempty._lookup:
+        data = make_array_nonempty(dtype)
     else:
         entry = _scalar_from_dtype(dtype)
         data = np.array([entry, entry], dtype=dtype)


### PR DESCRIPTION
This adds (basic) support for 3rd party ExtensionArrays in `dask.dataframe`.

The initial failures stemmed from note being able to create a `_meta_nonempty` for these dtypes. Rather than trying to guess, we request that authors register their extension dtypes with dask.dataframe.

It gets the bare minimum working. It's likely that we'll uncover additional issues, but I haven't thought much about how to test this more thoroughly. This is tested using the `DecimalDtype`, which isn't part of pandas public API (it's just a "3rd-party" extension array that's only meant for testing pandas extension array interface).

Closes https://github.com/dask/dask/issues/3240