### PR TITLE
Calling np.dtype on a delayed object works

### DIFF
--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -168,6 +168,7 @@ def test_np_dtype_of_delayed():
     x = delayed(1)
     with pytest.raises(TypeError):
         np.dtype(x)
+    assert delayed(np.array([1], dtype='f8')).dtype.compute() == np.dtype('f8')
 
 
 def test_delayed_errors():

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -161,6 +161,15 @@ def test_method_getattr_call_same_task():
     assert getattr not in set(v[0] for v in o.__dask_graph__().values())
 
 
+def test_np_dtype_of_delayed():
+    # This used to result in a segfault due to recursion, see
+    # https://github.com/dask/dask/pull/4374#issuecomment-454381465
+    np = pytest.importorskip('numpy')
+    x = delayed(1)
+    with pytest.raises(TypeError):
+        np.dtype(x)
+
+
 def test_delayed_errors():
     a = delayed([1, 2, 3])
     # Immutable


### PR DESCRIPTION
Calling `np.dtype(dask.delayed(...))` used to result in a segfault, as
numpy recursively tries to get `dtype` from the object. This is likely a
bug in numpy. For now, we can do a dumb check for if `x.dtype.dtype` is
called (which shouldn't ever show up in real code).

See https://github.com/dask/dask/pull/4374#issuecomment-454381465.
