### PR TITLE
Ignore non-readable config files

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -168,7 +168,7 @@ def collect_yaml(paths=paths):
                 data = yaml.load(f.read()) or {}
                 data = normalize_nested_keys(data)
                 configs.append(data)
-        except OSError:
+        except (OSError, IOError):
             # Ignore permission errors
             pass
 

--- a/dask/config.py
+++ b/dask/config.py
@@ -147,11 +147,15 @@ def collect_yaml(paths=paths):
     for path in paths:
         if os.path.exists(path):
             if os.path.isdir(path):
-                file_paths.extend(sorted([
-                    os.path.join(path, p)
-                    for p in os.listdir(path)
-                    if os.path.splitext(p)[1].lower() in ('.json', '.yaml', '.yml')
-                ]))
+                try:
+                    file_paths.extend(sorted([
+                        os.path.join(path, p)
+                        for p in os.listdir(path)
+                        if os.path.splitext(p)[1].lower() in ('.json', '.yaml', '.yml')
+                    ]))
+                except OSError:
+                    # Ignore permission errors
+                    pass
             else:
                 file_paths.append(path)
 
@@ -159,10 +163,14 @@ def collect_yaml(paths=paths):
 
     # Parse yaml files
     for path in file_paths:
-        with open(path) as f:
-            data = yaml.load(f.read()) or {}
-            data = normalize_nested_keys(data)
-            configs.append(data)
+        try:
+            with open(path) as f:
+                data = yaml.load(f.read()) or {}
+                data = normalize_nested_keys(data)
+                configs.append(data)
+        except OSError:
+            # Ignore permission errors
+            pass
 
     return configs
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -1,6 +1,8 @@
 import yaml
 import os
+import stat
 from collections import OrderedDict
+from contextlib import contextmanager
 
 import pytest
 
@@ -77,6 +79,43 @@ def test_collect_yaml_dir():
             yaml.dump(b, f)
 
         config = merge(*collect_yaml(paths=[dirname]))
+        assert config == expected
+
+
+@contextmanager
+def no_read_permissions(path):
+    perm_orig = stat.S_IMODE(os.stat(path).st_mode)
+    perm_new = perm_orig ^ stat.S_IREAD
+    try:
+        os.chmod(path, perm_new)
+        yield
+    finally:
+        os.chmod(path, perm_orig)
+
+
+@pytest.mark.parametrize('kind', ['directory', 'file'])
+def test_collect_yaml_permission_errors(tmpdir, kind):
+    a = {'x': 1, 'y': 2}
+    b = {'y': 3, 'z': 4}
+
+    dir_path = str(tmpdir)
+    a_path = os.path.join(dir_path, 'a.yaml')
+    b_path = os.path.join(dir_path, 'b.yaml')
+
+    with open(a_path, mode='w') as f:
+        yaml.dump(a, f)
+    with open(b_path, mode='w') as f:
+        yaml.dump(b, f)
+
+    if kind == 'directory':
+        cant_read = dir_path
+        expected = {}
+    else:
+        cant_read = a_path
+        expected = b
+
+    with no_read_permissions(cant_read):
+        config = merge(*collect_yaml(paths=[dir_path]))
         assert config == expected
 
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -1,6 +1,7 @@
 import yaml
 import os
 import stat
+import sys
 from collections import OrderedDict
 from contextlib import contextmanager
 
@@ -93,6 +94,8 @@ def no_read_permissions(path):
         os.chmod(path, perm_orig)
 
 
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason="Can't make writeonly file on windows")
 @pytest.mark.parametrize('kind', ['directory', 'file'])
 def test_collect_yaml_permission_errors(tmpdir, kind):
     a = {'x': 1, 'y': 2}


### PR DESCRIPTION
In some setups configuration directories/files may exist but may not be
readable by a user. This used to cause an error on startup, now we
ignore these errors (mirroring the behavior other tools like git).