### PR TITLE
Add has_parallel_type

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -14,7 +14,7 @@ from ...compatibility import unicode, PY3
 from ... import array as da
 from ...delayed import delayed
 
-from ..core import DataFrame, Series, Index, new_dd_object, parallel_types
+from ..core import DataFrame, Series, Index, new_dd_object, has_parallel_type
 from ..shuffle import set_partition
 from ..utils import insert_meta_param_description, check_meta, make_meta
 
@@ -165,7 +165,7 @@ def from_pandas(data, npartitions=None, chunksize=None, sort=True, name=None):
     if isinstance(getattr(data, 'index', None), pd.MultiIndex):
         raise NotImplementedError("Dask does not support MultiIndex Dataframes.")
 
-    if not isinstance(data, parallel_types()):
+    if not has_parallel_type(data):
         raise TypeError("Input must be a pandas DataFrame or Series")
 
     if ((npartitions is None) == (chunksize is None)):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -16,7 +16,8 @@ from dask.base import compute_as_if_collection
 from dask.compatibility import PY2
 from dask.utils import put_lines, M
 
-from dask.dataframe.core import repartition_divisions, aca, _concat, Scalar
+from dask.dataframe.core import (repartition_divisions, aca, _concat, Scalar,
+                                 has_parallel_type)
 from dask.dataframe import methods
 from dask.dataframe.utils import (assert_eq, make_meta, assert_max_deps,
                                   PANDAS_VERSION)
@@ -3364,3 +3365,9 @@ def test_scalar_with_array():
 
     da.utils.assert_eq(df.x.values + df.x.mean(),
                        ddf.x.values + ddf.x.mean())
+
+
+def test_has_parallel_type():
+    assert has_parallel_type(pd.DataFrame())
+    assert has_parallel_type(pd.Series())
+    assert not has_parallel_type(123)


### PR DESCRIPTION
This is a bit nicer than `isinstance(obj, parallel_types())` because it
works also with lazily registered types.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
