### PR TITLE
Add support for cupy.einsum

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -10,7 +10,6 @@ from . import numpy_compat as npcompat
 from ..compatibility import Container, Iterable, Sequence
 from ..core import flatten
 from ..utils import ignoring
-from . import core
 
 from numbers import Integral
 
@@ -276,18 +275,6 @@ def view(x, dtype, order='C'):
     else:
         x = np.asfortranarray(x)
         return x.T.view(dtype).T
-
-
-def einsum(*operands, **kwargs):
-    subscripts = kwargs.pop('subscripts')
-    ncontract_inds = kwargs.pop('ncontract_inds')
-    dtype = kwargs.pop('kernel_dtype')
-    einsum = core.einsum_lookup.dispatch(type(operands[0]))
-    chunk = einsum(subscripts, *operands, dtype=dtype, **kwargs)
-
-    # Avoid concatenate=True in blockwise by adding 1's
-    # for the contracted dimensions
-    return chunk.reshape(chunk.shape + (1,) * ncontract_inds)
 
 
 def slice_with_int_dask_array(x, idx, offset, x_size, axis):

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -10,6 +10,7 @@ from . import numpy_compat as npcompat
 from ..compatibility import Container, Iterable, Sequence
 from ..core import flatten
 from ..utils import ignoring
+from . import core
 
 from numbers import Integral
 
@@ -281,7 +282,8 @@ def einsum(*operands, **kwargs):
     subscripts = kwargs.pop('subscripts')
     ncontract_inds = kwargs.pop('ncontract_inds')
     dtype = kwargs.pop('kernel_dtype')
-    chunk = np.einsum(subscripts, *operands, dtype=dtype, **kwargs)
+    einsum = core.einsum_lookup.dispatch(type(operands[0]))
+    chunk = einsum(subscripts, *operands, dtype=dtype, **kwargs)
 
     # Avoid concatenate=True in blockwise by adding 1's
     # for the contracted dimensions

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -57,16 +57,24 @@ config.update_defaults({'array': {
 
 concatenate_lookup = Dispatch('concatenate')
 tensordot_lookup = Dispatch('tensordot')
+einsum_lookup = Dispatch('einsum')
 concatenate_lookup.register((object, np.ndarray), np.concatenate)
 tensordot_lookup.register((object, np.ndarray), np.tensordot)
+einsum_lookup.register((object, np.ndarray), np.einsum)
 
 
 @tensordot_lookup.register_lazy('cupy')
 @concatenate_lookup.register_lazy('cupy')
+@einsum_lookup.register_lazy('cupy')
 def register_cupy():
     import cupy
     concatenate_lookup.register(cupy.ndarray, cupy.concatenate)
     tensordot_lookup.register(cupy.ndarray, cupy.tensordot)
+
+    @einsum_lookup.register(cupy.ndarray)
+    def _cupy_einsum(*args, order='K', casting='safe', **kwargs):
+        # NB: cupy does not accept `order` or `casting` kwargs - ignore
+        return cupy.einsum(*args, **kwargs)
 
 
 @tensordot_lookup.register_lazy('sparse')

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -72,8 +72,10 @@ def register_cupy():
     tensordot_lookup.register(cupy.ndarray, cupy.tensordot)
 
     @einsum_lookup.register(cupy.ndarray)
-    def _cupy_einsum(*args, order='K', casting='safe', **kwargs):
+    def _cupy_einsum(*args, **kwargs):
         # NB: cupy does not accept `order` or `casting` kwargs - ignore
+        kwargs.pop('casting', None)
+        kwargs.pop('order', None)
         return cupy.einsum(*args, **kwargs)
 
 

--- a/dask/array/einsumfuncs.py
+++ b/dask/array/einsumfuncs.py
@@ -6,11 +6,22 @@ from functools import wraps
 import numpy as np
 from numpy.compat import basestring
 
-from .core import blockwise, asarray
-from . import chunk
+from .core import blockwise, asarray, einsum_lookup
 
 einsum_symbols = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 einsum_symbols_set = set(einsum_symbols)
+
+
+def chunk_einsum(*operands, **kwargs):
+    subscripts = kwargs.pop('subscripts')
+    ncontract_inds = kwargs.pop('ncontract_inds')
+    dtype = kwargs.pop('kernel_dtype')
+    einsum = einsum_lookup.dispatch(type(operands[0]))
+    chunk = einsum(subscripts, *operands, dtype=dtype, **kwargs)
+
+    # Avoid concatenate=True in blockwise by adding 1's
+    # for the contracted dimensions
+    return chunk.reshape(chunk.shape + (1,) * ncontract_inds)
 
 
 # This function duplicates numpy's _parse_einsum_input() function
@@ -230,7 +241,7 @@ def einsum(*operands, **kwargs):
 
     # Introduce the contracted indices into the blockwise product
     # so that we get numpy arrays, not lists
-    result = blockwise(chunk.einsum, tuple(outputs) + tuple(contract_inds),
+    result = blockwise(chunk_einsum, tuple(outputs) + tuple(contract_inds),
                        *(a for ap in zip(ops, inputs) for a in ap),
                        # blockwise parameters
                        adjust_chunks={ind: 1 for ind in contract_inds}, dtype=dtype,

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -36,6 +36,7 @@ functions = [
     lambda x: x > 0.5,
     lambda x: x.rechunk((4, 4, 4)),
     lambda x: x.rechunk((2, 2, 1)),
+    lambda x: da.einsum("ijk,ijk", x, x)
 ]
 
 


### PR DESCRIPTION
This just adds an ``einsum_lookup`` dispatcher and registers ``cupy.einsum``.

- [x] Tests added / passed
- [x] Passes `flake8 dask`

It was a simple addition so I haven't raised an issue first, but I do have a few questions:
- [ ] Presumably ``__array_function__`` will eventually/soon replace this mechanism? Is this an OK stop-gap in the meantime?
- [ ] I'm silently ignoring the ``casting`` and ``order`` kwargs as these are not supported by ``cupy`` (but always passed by ``dask``). Could possibly warn here if anything but the defaults are supplied.
- [ ] I'm just dispatching on the first array argument of ``einsum`` - should this be a more involved ``type`` check of all array arguments? For info, if a mix of ``numpy/cupy``arrays are supplied ``cupy.einsum`` itself returns a ``cupy`` array.

---

Just for context, the motivation for this is performing very large, parallelized, GPU tensor network contractions using [``quimb``](https://quimb.readthedocs.io/en/latest/tensor-basics.html) and [``opt_einsum``](https://optimized-einsum.readthedocs.io/en/latest/) (which needs mostly ``tensordot`` but also sometimes ``einsum``). The speedups so far are pretty tasty! Though I expect considerations of which dimensions to chunk (https://github.com/dask/dask/issues/2225) might make it even better.