### PR TITLE
The order of columns should not matter

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3782,8 +3782,8 @@ def apply_and_enforce(*args, **kwargs):
 
         if is_dataframe_like(df):
             # Need nan_to_num otherwise nan comparison gives False
-            if not np.array_equal(np.nan_to_num(meta.columns),
-                                  np.nan_to_num(df.columns)):
+            if not np.array_equal(np.sort(np.nan_to_num(meta.columns)),
+                                  np.sort(np.nan_to_num(df.columns))):
                 raise ValueError("The columns in the computed data do not match"
                                  " the columns in the provided metadata")
             else:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2038,7 +2038,10 @@ def test_to_dask_array(as_frame, lengths):
 
 def test_apply():
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
-    ddf = dd.from_pandas(df, npartitions=2)
+
+    # Also tests for unordered columns, but with same content
+    ddf = pd.DataFrame({'y': [10, 20, 30, 40], 'x': [1, 2, 3, 4], })
+    ddf = dd.from_pandas(ddf, npartitions=2)
 
     func = lambda row: row['x'] + row['y']
     assert_eq(ddf.x.apply(lambda x: x + 1, meta=("x", int)),

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -657,12 +657,13 @@ def _check_dask(dsk, check_names=True, check_dtypes=True, result=None):
 
 
 def _maybe_sort(a):
-    # sort by value, then index
+    # sort column names, then by value, then index
     try:
         if isinstance(a, pd.DataFrame):
             if set(a.index.names) & set(a.columns):
                 a.index.names = ['-overlapped-index-name-%d' % i
                                  for i in range(len(a.index.names))]
+            a.sort_index(1, inplace=True)
             a = a.sort_values(by=a.columns.tolist())
         else:
             a = a.sort_values()


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

While comparing the columns of meta df and computed df in apply function, the order should not matter. So both are sorted before comparison.
Currently:
```
df = pd.DataFrame({"a":["hello world","hola mi amigo"]})
ddf = dd.from_pandas(df, npartitions=1)
a = ddf.a.str.split(" ")
words = set()
for i,v in a.iteritems():
    words.update(v)
aa = a.apply(lambda x: pd.Series(x).value_counts(), meta={w: int for w in words})
aa = aa.fillna(0)
aa.compute()
```
produces `ValueError: The columns in the computed data do not match the columns in the provided metadata`
whereas with this change in effect,

|amigo | hello | hola | mi | world
|-- | -- | -- | -- | --
|0.0 | 1.0 | 0.0 | 0.0 | 1.0
|1.0| 0.0 | 1.0 | 1.0 | 0.0

which is expected.

