### PR TITLE
Fix ORC tests for pyarrow 0.12.0

### DIFF
--- a/dask/dataframe/io/orc.py
+++ b/dask/dataframe/io/orc.py
@@ -14,9 +14,14 @@ __all__ = ('read_orc',)
 def _read_orc_stripe(fs, path, stripe, columns=None):
     """Pull out specific data from specific part of ORC file"""
     orc = import_required('pyarrow.orc', 'Please install pyarrow >= 0.9.0')
+    import pyarrow as pa
     with fs.open(path, 'rb') as f:
         o = orc.ORCFile(f)
-        return o.read_stripe(stripe, columns).to_pandas()
+        table = o.read_stripe(stripe, columns)
+    if pa.__version__ < LooseVersion('0.11.0'):
+        return table.to_pandas()
+    else:
+        return table.to_pandas(date_as_object=False)
 
 
 def read_orc(path, columns=None, storage_options=None):

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -907,8 +907,10 @@ def _read_pyarrow_parquet_piece(fs, piece, columns, index_cols, is_series,
         df = table.to_pandas()
         for cat in categories:
             df[cat] = df[cat].astype('category')
-    else:
+    elif pa.__version__ < LooseVersion('0.11.0'):
         df = table.to_pandas(categories=categories)
+    else:
+        df = table.to_pandas(categories=categories, date_as_object=False)
     has_index = not isinstance(df.index, pd.RangeIndex)
 
     if not has_index and index_cols:


### PR DESCRIPTION
Explicitly set `date_as_object=False` for all versions of pyarrow where
this keyword is present. The default value was changed in pyarrow 0.12.0
to True.
