### PR TITLE
Switch `_` -> `-` config normalization to `-` -> `_`

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -105,7 +105,7 @@ def merge(*dicts):
 
 
 def normalize_key(key):
-    """ Replaces underscores with hyphens in string keys
+    """ Replaces hyphens with underscores in string keys
 
     Parameters
     ----------
@@ -113,12 +113,12 @@ def normalize_key(key):
         Key to assign.
     """
     if isinstance(key, string_types):
-        key = key.replace('_', '-')
+        key = key.replace('-', '_')
     return key
 
 
 def normalize_nested_keys(config):
-    """ Replaces underscores with hyphens for keys for a nested Mapping
+    """ Replaces hyphens with underscores for keys for a nested Mapping
 
     Examples
     --------
@@ -184,7 +184,7 @@ def collect_env(env=None):
 
     -  Lower-cases the key text
     -  Treats ``__`` (double-underscore) as nested access
-    -  Replaces ``_`` (underscore) with a hyphen.
+    -  Replaces ``-`` with ``_`` (underscore)
     -  Calls ``ast.literal_eval`` on the value
     """
     if env is None:

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -134,7 +134,7 @@ def test_env():
            }
 
     expected = {
-        'a-b': 123,
+        'a_b': 123,
         'c': True,
         'd': 'hello',
         'e': {'x': 123, 'y': 456},
@@ -305,8 +305,8 @@ def test_ensure_file_defaults_to_DASK_CONFIG_directory(tmpdir):
 
 
 def test_rename():
-    aliases = {'foo-bar': 'foo.bar'}
-    config = {'foo-bar': 123}
+    aliases = {'foo_bar': 'foo.bar'}
+    config = {'foo_bar': 123}
     rename(aliases, config=config)
     assert config == {'foo': {'bar': 123}}
 
@@ -344,8 +344,8 @@ def test_expand_environment_variables(inp, out):
 
 
 @pytest.mark.parametrize('inp,out', [
-    ('custom_key', 'custom-key'),
-    ('custom-key', 'custom-key'),
+    ('custom-key', 'custom_key'),
+    ('custom_key', 'custom_key'),
     (1, 1),
     (2.3, 2.3)
 ])
@@ -354,13 +354,13 @@ def test_normalize_key(inp, out):
 
 
 def test_normalize_nested_keys():
-    config = {'key_1': 1,
-              'key_2': {'nested_key_1': 2},
-              'key_3': 3
+    config = {'key-1': 1,
+              'key-2': {'nested-key-1': 2},
+              'key-3': 3
               }
-    expected = {'key-1': 1,
-                'key-2': {'nested-key-1': 2},
-                'key-3': 3
+    expected = {'key_1': 1,
+                'key_2': {'nested_key_1': 2},
+                'key_3': 3
                 }
     assert normalize_nested_keys(config) == expected
 
@@ -384,3 +384,14 @@ def test_get_set_roundtrip(key):
 
 def test_merge_None_to_dict():
     assert dask.config.merge({'a': None, 'c': 0}, {'a': {'b': 1}}) == {'a': {'b': 1}, 'c': 0}
+
+
+def test_load_keys_with_underscores(tmpdir):
+    environ = {'ARROW_LIBHDFS_DIR': '/some/path'}
+    config = {'yarn': {'worker': {'env': environ}}}
+    path = str(tmpdir.join('config.yaml'))
+    with open(path, mode='w') as f:
+        yaml.dump(config, f)
+
+    config = merge(*collect_yaml(paths=[str(tmpdir)]))
+    assert get('yarn.worker.env', config=config) == environ

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -127,7 +127,7 @@ resulting in configuration values like the following:
 
 Dask searches for all environment variables that start with ``DASK_``, then
 transforms keys by converting to lower case, changing double-underscores to
-nested structures, and changing single underscores to hyphens.
+nested structures, and changing hyphens to single underscores.
 
 Dask tries to parse all values with `ast.literal_eval
 <https://docs.python.org/3/library/ast.html#ast.literal_eval>`_, letting users


### PR DESCRIPTION
Previously we'd normalize all key names in `dask.config` to hyphenated
names, replacing all underscores with hyphens. This causes problems with
keys that should be taken as literal values (e.g. environment variables
in an `env` key). We really should only normalize key names that are
explicitly declared (some kind of schema), but for now we just swap the
normlalized form since underscores are more common for environment
variables.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`

Fixes #4366.