### PR TITLE
Add key argument to Bag.distinct

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -826,7 +826,7 @@ class Bag(DaskMethodsMixin):
         ----------
         key: {callable,str}
             Defines uniqueness of items in bag by calling ``key`` on each item.
-            If a string is passed `key` is considered to be `lambda x: x[key]`.
+            If a string is passed ``key`` is considered to be ``lambda x: x[key]``.
 
         Examples
         --------

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -823,9 +823,19 @@ class Bag(DaskMethodsMixin):
 
         Unordered without repeats.
 
+        Parameters
+        ----------
+        key: callable
+            Defines uniqueness such as in `toolz.unique`
+
+        Examples
+        --------
         >>> b = from_sequence(['Alice', 'Bob', 'Alice'])
         >>> sorted(b.distinct())
         ['Alice', 'Bob']
+        >>> b = from_sequence([{'name': 'Alice'}, {'name': 'Bob'}, {'name': 'Alice'}])
+        >>> sorted(b.distinct(key=lambda x: x['name']))
+        [{'name': 'Alice'}, {'name': 'Bob'}]
         """
         key = key if callable(key) else toolz.curried.get(key)
         perpartition = lambda seq: list(toolz.unique(seq, key=key))

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -825,8 +825,9 @@ class Bag(DaskMethodsMixin):
 
         Parameters
         ----------
-        key: callable
-            Defines uniqueness such as in `toolz.unique`
+        key: {callable,str}
+            Defines uniqueness of items in bag by calling `key` on each item.
+            If a string is passed `key` is considered to be `lambda x: x[key]`.
 
         Examples
         --------
@@ -835,6 +836,8 @@ class Bag(DaskMethodsMixin):
         ['Alice', 'Bob']
         >>> b = from_sequence([{'name': 'Alice'}, {'name': 'Bob'}, {'name': 'Alice'}])
         >>> b.distinct(key=lambda x: x['name']).compute()
+        [{'name': 'Alice'}, {'name': 'Bob'}]
+        >>> b.distinct(key='name').compute()
         [{'name': 'Alice'}, {'name': 'Bob'}]
         """
         key = key if callable(key) else toolz.curried.get(key)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -14,7 +14,6 @@ from random import Random
 from toolz import (merge, take, reduce, valmap, map, partition_all, filter,
                    remove, compose, curry, first, second, accumulate, peek)
 from toolz.compatibility import iteritems, zip
-import toolz.curried
 import toolz
 _implement_accumulate = LooseVersion(toolz.__version__) > '0.7.4'
 try:

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -834,7 +834,7 @@ class Bag(DaskMethodsMixin):
         >>> sorted(b.distinct())
         ['Alice', 'Bob']
         >>> b = from_sequence([{'name': 'Alice'}, {'name': 'Bob'}, {'name': 'Alice'}])
-        >>> b.distinct(key=lambda x: x['name'])
+        >>> b.distinct(key=lambda x: x['name']).compute()
         [{'name': 'Alice'}, {'name': 'Bob'}]
         """
         key = key if callable(key) else toolz.curried.get(key)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -825,7 +825,7 @@ class Bag(DaskMethodsMixin):
         Parameters
         ----------
         key: {callable,str}
-            Defines uniqueness of items in bag by calling `key` on each item.
+            Defines uniqueness of items in bag by calling ``key`` on each item.
             If a string is passed `key` is considered to be `lambda x: x[key]`.
 
         Examples

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -838,7 +838,7 @@ class Bag(DaskMethodsMixin):
         [{'name': 'Alice'}, {'name': 'Bob'}]
         """
         key = key if callable(key) else toolz.curried.get(key)
-        perpartition = lambda seq: list(toolz.unique(seq, key=key))
+        perpartition = toolz.compose(list, toolz.curried.unique(key=key))
         aggregate = merge_distinct(key=key)
         return self.reduction(perpartition,
                               aggregate,

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -834,7 +834,7 @@ class Bag(DaskMethodsMixin):
         >>> sorted(b.distinct())
         ['Alice', 'Bob']
         >>> b = from_sequence([{'name': 'Alice'}, {'name': 'Bob'}, {'name': 'Alice'}])
-        >>> sorted(b.distinct(key=lambda x: x['name']))
+        >>> b.distinct(key=lambda x: x['name'])
         [{'name': 'Alice'}, {'name': 'Bob'}]
         """
         key = key if callable(key) else toolz.curried.get(key)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -232,8 +232,8 @@ def test_distinct_with_key():
     expected = [{'a': 0}, {'a': 1}]
     key = 'a'
     key_func = lambda x: x[key]
-    assert bag.distinct(key_func).compute() == expected
-    assert bag.distinct(key).compute() == expected
+    assert_eq(bag.distinct(key_func), expected)
+    assert_eq(bag.distinct(key), expected)
 
 
 def test_merge_distinct():


### PR DESCRIPTION
- [ ] Tests added / passed
- [x] Passes `flake8 dask`

closes #2493 

A few things to discuss:

1. Should we change the implementation to use `fold` instead of `reduction`?
2. Is it ok to default `key` to `toolz.identity` instead of `None` + conditional logic?