### PR TITLE
Raise more informative error for histogram bins and range

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -599,9 +599,9 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
     array([5000, 5000])
     """
     if not np.iterable(bins) and (range is None or bins is None):
-        raise ValueError('dask.array.histogram requires either an iterable '
-                         'specifying the bins or the number of bins and a '
-                         'range to be defined.')
+        raise ValueError('dask.array.histogram requires either specifying '
+                         'bins as an iterable or specifying both a range and '
+                         'the number of bins')
 
     if weights is not None and weights.chunks != a.chunks:
         raise ValueError('Input array and weights must have the same '

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -598,9 +598,10 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
     >>> h.compute()
     array([5000, 5000])
     """
-    if bins is None or (range is None and bins is None):
-        raise ValueError('dask.array.histogram requires either bins '
-                         'or bins and range to be defined.')
+    if not np.iterable(bins) and (range is None or bins is None):
+        raise ValueError('dask.array.histogram requires either an iterable '
+                         'specifying the bins or the number of bins and a '
+                         'range to be defined.')
 
     if weights is not None and weights.chunks != a.chunks:
         raise ValueError('Input array and weights must have the same '

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -601,6 +601,20 @@ def test_histogram_extra_args_and_shapes():
                   da.histogram(v, bins=bins, weights=w, density=True)[0])
 
 
+@pytest.mark.parametrize("bins, hist_range", [
+    (None, None),
+    (10, None),
+    (None, (1, 10)),
+])
+def test_histogram_bin_range_raises(bins, hist_range):
+    data = da.random.random(10, chunks=2)
+    with pytest.raises(ValueError) as info:
+        da.histogram(data, bins=bins, range=hist_range)
+    err_msg = str(info.value)
+    assert 'bins' in err_msg
+    assert 'range' in err_msg
+
+
 def test_cov():
     x = np.arange(56).reshape((7, 8))
     d = da.from_array(x, chunks=(4, 4))


### PR DESCRIPTION
This PR updates the validation check for `bins` and `range` in `dask.array.histogram` to raise a more informative error message when the number of `bins` is specified without a `range` argument. 

Current error message raised:
```python
TypeError: 'NoneType' object is not iterable
```

Updated error message:
```python
ValueError: dask.array.histogram requires either an iterable 
specifying the bins or the number of bins and a range to be defined.
```

Closes #4428

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
