### PR TITLE
Fix DelayedAttr return value

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -614,7 +614,7 @@ class DelayedAttr(Delayed):
         # code). See https://github.com/dask/dask/pull/4374#issuecomment-454381465
         if attr == 'dtype' and self._attr == 'dtype':
             raise AttributeError("Attribute %s not found" % attr)
-        super(DelayedAttr, self).__getattr__(attr)
+        return super(DelayedAttr, self).__getattr__(attr)
 
     @property
     def dask(self):

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -600,3 +600,10 @@ def test_delayed_decorator_on_method():
     # For static methods (and regular functions), the decorated methods should
     # be Delayed objects.
     assert isinstance(A.addstatic, Delayed)
+
+
+def test_attribute_of_attribute():
+    x = delayed(123)
+    assert isinstance(x.a, Delayed)
+    assert isinstance(x.a.b, Delayed)
+    assert isinstance(x.a.b.c, Delayed)


### PR DESCRIPTION
Previously we were missing a return statement

- [x] Tests added / passed
- [x] Passes `flake8 dask`
