### PR TITLE
Fix relative path parsing on windows when using fastparquet

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -368,7 +368,7 @@ def _read_pf_simple(fs, path, base, index_names, all_columns, is_series,
     """Read dataset with fastparquet using ParquetFile machinery"""
     from fastparquet import ParquetFile
     pf = ParquetFile(path, open_with=fs.open)
-    relpath = path.replace(base, '').lstrip('/')
+    relpath = os.path.split(path)[-1]
     for rg in pf.row_groups:
         for ch in rg.columns:
             ch.file_path = relpath

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -343,8 +343,9 @@ def _read_fp_multifile(fs, fs_token, paths, columns=None,
                        categories=None, index=None):
     """Read dataset with fastparquet by assuming metadata from first file"""
     from fastparquet import ParquetFile
-    from fastparquet.util import analyse_paths, get_file_scheme
+    from fastparquet.util import analyse_paths, get_file_scheme, join_path
     base, fns = analyse_paths(paths)
+    parsed_paths = [join_path(p) for p in paths]
     scheme = get_file_scheme(fns)
     pf = ParquetFile(paths[0], open_with=fs.open)
     pf.file_scheme = scheme
@@ -358,7 +359,7 @@ def _read_fp_multifile(fs, fs_token, paths, columns=None,
                        index_names, all_columns, out_type == Series,
                        categories, pf.cats,
                        pf.file_scheme, storage_name_mapping)
-           for i, path in enumerate(paths)}
+           for i, path in enumerate(parsed_paths)}
     divisions = (None, ) * (len(paths) + 1)
     return out_type(dsk, name, meta, divisions)
 
@@ -368,7 +369,7 @@ def _read_pf_simple(fs, path, base, index_names, all_columns, is_series,
     """Read dataset with fastparquet using ParquetFile machinery"""
     from fastparquet import ParquetFile
     pf = ParquetFile(path, open_with=fs.open)
-    relpath = os.path.split(path)[-1]
+    relpath = path.replace(base, '').lstrip('/')
     for rg in pf.row_groups:
         for ch in rg.columns:
             ch.file_path = relpath


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

Some tests in `dataframe/io/tests/test_parquet.py` were failing on Windows on my local set up due to a file path issue. 

Here's an example of the fail:

```
C:\development\dask>py.test dask\dataframe\io\tests\test_parquet.py --pdb
=========================================================================================================== test session starts ============================================================================================================
platform win32 -- Python 3.6.6, pytest-4.1.1, py-1.7.0, pluggy-0.8.1
rootdir: C:\development\dask, inifile: setup.cfg
collected 156 items

dask\dataframe\io\tests\test_parquet.py ..x...x.....xx..s.F
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

tmpdir = local('C:\\Users\\Janne\\AppData\\Local\\Temp\\pytest-of-janne.vuorela\\pytest-18\\test_read_glob_pyarrow_fastpar0'), write_engine = 'pyarrow', read_engine = 'fastparquet'

    @write_read_engines()
    def test_read_glob(tmpdir, write_engine, read_engine):
        if write_engine == read_engine == 'fastparquet' and os.name == 'nt':
            # fastparquet or dask is not normalizing filepaths correctly on
            # windows.
            pytest.skip("filepath bug.")
        fn = str(tmpdir)
        ddf.to_parquet(fn, engine=write_engine)
        if os.path.exists(os.path.join(fn, '_metadata')):
            os.unlink(os.path.join(fn, '_metadata'))

        files = os.listdir(fn)
        assert '_metadata' not in files

        # Infer divisions for engines/versions that support it

        ddf2 = dd.read_parquet(os.path.join(fn, '*.parquet'), engine=read_engine,
                               infer_divisions=should_check_divs(write_engine) and should_check_divs(read_engine))
        assert_eq(ddf, ddf2, check_divisions=should_check_divs(write_engine) and should_check_divs(read_engine))

        # No divisions
        ddf2_no_divs = dd.read_parquet(os.path.join(fn, '*.parquet'),
                                       engine=read_engine, infer_divisions=False)
>       assert_eq(ddf.clear_divisions(), ddf2_no_divs, check_divisions=True)

dask\dataframe\io\tests\test_parquet.py:200:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
dask\dataframe\utils.py:686: in assert_eq
    b = _check_dask(b, check_names=check_names, check_dtypes=check_dtypes)
dask\dataframe\utils.py:615: in _check_dask
    result = dsk.compute(scheduler='sync')
dask\base.py:156: in compute
    (result,) = compute(self, traverse=False, **kwargs)
dask\base.py:398: in compute
    results = schedule(dsk, keys, **kwargs)
dask\local.py:500: in get_sync
    return get_async(apply_sync, 1, dsk, keys, **kwargs)
dask\local.py:446: in get_async
    fire_task()
dask\local.py:442: in fire_task
    callback=queue.put)
dask\local.py:489: in apply_sync
    res = func(*args, **kwds)
dask\local.py:235: in execute_task
    result = pack_exception(e, dumps)
dask\local.py:230: in execute_task
    result = _execute_task(task, data)
dask\core.py:119: in _execute_task
    return func(*args2)
dask\dataframe\io\parquet.py:378: in _read_pf_simple
    df = pf.to_pandas(all_columns, categories, index=index_names)
..\fastparquet\fastparquet\api.py:439: in to_pandas
    assign=parts)
..\fastparquet\fastparquet\api.py:242: in read_row_group_file
    assign=assign, scheme=self.file_scheme)
..\fastparquet\fastparquet\core.py:302: in read_row_group_file
    with open(fn, mode='rb') as f:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <dask.bytes.local.LocalFileSystem object at 0x00000233F9D3D908>
path = 'C:/Users/Janne/AppData/Local/Temp/pytest-of-janne.vuorela/pytest-18/test_read_glob_pyarrow_fastpar0/C:/Users/Janne/AppData/Local/Temp/pytest-of-janne.vuorela/pytest-18/test_read_glob_pyarrow_fastpar0/part.0.parquet', mode = 'rb'
kwargs = {}

    def open(self, path, mode='rb', **kwargs):
        """Make a file-like object

        Parameters
        ----------
        mode: string
            normally "rb", "wb" or "ab" or other.
        kwargs: key-value
            Any other parameters, such as buffer size. May be better to set
            these on the filesystem instance, to apply to all files created by
            it. Not used for local.
        """
>       return open(self._normalize_path(path), mode=mode)
E       OSError: [Errno 22] Invalid argument: 'C:\\Users\\Janne\\AppData\\Local\\Temp\\pytest-of-janne.vuorela\\pytest-18\\test_read_glob_pyarrow_fastpar0\\C:\\Users\\Janne\\AppData\\Local\\Temp\\pytest-of-janne.vuorela\\pytest-18\\test_read_glob_pyarrow_fastpar0\\part.0.parquet'

dask\bytes\local.py:58: OSError
```