### PR TITLE
Fix bug introduced by #4438

### DIFF
--- a/dask/bytes/pyarrow.py
+++ b/dask/bytes/pyarrow.py
@@ -32,7 +32,7 @@ class PyArrowHadoopFileSystem(object):
     sep = "/"
 
     def __init__(self, **kwargs):
-        self.fs = pa.hdfs.HadoopFileSystem(update_hdfs_options(**kwargs))
+        self.fs = pa.hdfs.HadoopFileSystem(update_hdfs_options(kwargs))
 
     @classmethod
     def from_pyarrow(cls, fs):


### PR DESCRIPTION
Pass kwargs as dict without splicing.

Seems like I made a mistake in https://github.com/dask/dask/pull/4438 %( 

Does travis run hdfs related tests? 

- [ ] Tests added / passed
- [v] Passes `flake8 dask`
