### PR TITLE
Fix bug in pyarrow and hdfs

### DIFF
--- a/dask/bytes/pyarrow.py
+++ b/dask/bytes/pyarrow.py
@@ -32,7 +32,7 @@ class PyArrowHadoopFileSystem(object):
     sep = "/"
 
     def __init__(self, **kwargs):
-        self.fs = pa.hdfs.HadoopFileSystem(update_hdfs_options(**kwargs))
+        self.fs = pa.hdfs.HadoopFileSystem(update_hdfs_options(kwargs))
 
     @classmethod
     def from_pyarrow(cls, fs):


### PR DESCRIPTION
Small change to fix error in pyarrow + hdfs. 

dd.read_parquet("hdfs://some-hdfs-hostname/" + filename)

would raise TypeError: update_hdfs_options() got an unexpected keyword argument 'host'

- [ ] Tests added / passed
- [x] Passes `flake8 dask`
