### PR TITLE
local: extend started_cbs AFTER state is initialized

### DIFF
--- a/dask/local.py
+++ b/dask/local.py
@@ -405,14 +405,15 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
         started_cbs = []
         succeeded = False
         try:
+            keyorder = order(dsk)
+
+            state = start_state_from_dask(dsk, cache=cache, sortkey=keyorder.get)
+
+            # extend started_cbs AFTER state is initialized
             for cb in callbacks:
                 if cb[0]:
                     cb[0](dsk)
                 started_cbs.append(cb)
-
-            keyorder = order(dsk)
-
-            state = start_state_from_dask(dsk, cache=cache, sortkey=keyorder.get)
 
             for _, start_state, _, _, _ in callbacks:
                 if start_state:

--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -29,6 +29,23 @@ def test_get_without_computation():
     assert get(dsk, 'x') == 1
 
 
+def test_broken_callback():
+    from dask.callbacks import Callback
+
+    def _f_ok(*args, **kwargs):
+        pass
+
+    def _f_broken(*args, **kwargs):
+        raise ValueError('my_exception')
+
+    dsk = {'x': 1}
+
+    with Callback(start=_f_broken, finish=_f_ok):
+        with Callback(start=_f_ok, finish=_f_ok):
+            with pytest.raises(ValueError, match='my_exception'):
+                get(dsk, 'x')
+
+
 def bad(x):
     raise ValueError()
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

I have observed a case where an exception seems to be raised very early and therefore `state` is not initialized in the finally block, leading to an `UnboundLocalError` and swallowing the original exception (which would have been helpful to have). I think in general, the `state` here should be initialized first, no matter what the root cause of my local problem (which I will report once I have found it).

I don't know if this needs a test or what a good test would be to trigger this issue.