### PR TITLE
Replace cudf-specific code with dask-cudf import

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -12,28 +12,4 @@ from .core import get_parallel_type, meta_nonempty, make_meta
 @meta_nonempty.register_lazy('cudf')
 @make_meta.register_lazy('cudf')
 def _register_cudf():
-    import cudf
     import dask_cudf
-    get_parallel_type.register(cudf.DataFrame, lambda _: dask_cudf.DataFrame)
-    get_parallel_type.register(cudf.Series, lambda _: dask_cudf.Series)
-    get_parallel_type.register(cudf.Index, lambda _: dask_cudf.Index)
-
-    @meta_nonempty.register((cudf.DataFrame, cudf.Series, cudf.Index))
-    def _(x):
-        y = meta_nonempty(x.to_pandas())  # TODO: add iloc[:5]
-        return cudf.from_pandas(y)
-
-    @make_meta.register((cudf.Series, cudf.DataFrame))
-    def _(x):
-        return x.head(0)
-
-    @make_meta.register(cudf.Index)
-    def _(x):
-        return x[:0]
-
-    @concat_dispatch.register((cudf.DataFrame, cudf.Series, cudf.Index))
-    def _(dfs, axis=0, join='outer', uniform=False, filter_warning=True):
-        assert axis == 0
-        assert join == 'outer'
-        assert filter_warning is True
-        return cudf.concat(dfs)

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -12,4 +12,4 @@ from .core import get_parallel_type, meta_nonempty, make_meta
 @meta_nonempty.register_lazy('cudf')
 @make_meta.register_lazy('cudf')
 def _register_cudf():
-    import dask_cudf
+    import dask_cudf  # noqa: F401

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -31,7 +31,9 @@ def _register_cudf():
     def _(x):
         return x[:0]
 
-    concat_dispatch.register(
-        (cudf.DataFrame, cudf.Series, cudf.Index),
-        cudf.concat
-    )
+    @concat_dispatch.register((cudf.DataFrame, cudf.Series, cudf.Index))
+    def _(dfs, axis=0, join='outer', uniform=False, filter_warning=True):
+        assert axis == 0
+        assert join == 'outer'
+        assert filter_warning is True
+        return cudf.concat(dfs)


### PR DESCRIPTION
I'm a little concerned about the current practice of my futzing with cudf code in the dask.dataframe codebase.  I'm not yet sure how best to handle this.  In the meantime here is a tiny change.