### PR TITLE
Update docs to use `from_zarr`

### DIFF
--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -275,7 +275,7 @@ or your own custom zarr Array:
    >>> z = zarr.create((10,), dtype=float, store=zarr.ZipStore("output.zarr"))
    >>> arr.to_zarr(z)
 
-To retrieve those data, you would do ``da.read_zarr`` with exactly the same arguments. The
+To retrieve those data, you would do ``da.from_zarr`` with exactly the same arguments. The
 chunking of the resultant Dask array is defined by how the files were saved, unless
 otherwise specified.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -552,7 +552,7 @@ Core
 Array
 +++++
 
-- Add to/read_zarr for Zarr-format datasets and arrays (:pr:`3460`) `Martin Durant`_
+- Add to/from_zarr for Zarr-format datasets and arrays (:pr:`3460`) `Martin Durant`_
 - Experimental addition of generalized ufunc support, ``apply_gufunc``, ``gufunc``, and
   ``as_gufunc`` (:pr:`3109`) (:pr:`3526`) (:pr:`3539`) `Markus Gonser`_
 - Avoid unnecessary rechunking tasks (:pr:`3529`) `Matthew Rocklin`_


### PR DESCRIPTION
In a few places the command `read_zarr` was referenced. It was likely intended that this should be `from_zarr`, which is the included function. This PR changes the former to the latter for clarity.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
