### PR TITLE
Add from_block_function to array API

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -55,7 +55,7 @@ try:
     from ..base import compute
     from .optimization import optimize
     from .creation import (arange, linspace, meshgrid, indices, diag, eye,
-                           triu, tril, fromfunction, tile, repeat, pad)
+                           triu, tril, from_block_function, fromfunction, tile, repeat, pad)
     from .gufunc import apply_gufunc, gufunc, as_gufunc
     from .utils import assert_eq
 

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -56,7 +56,8 @@ try:
     from .optimization import optimize
     from .creation import (arange, linspace, meshgrid, indices, diag, eye,
                            triu, tril, from_block_function, fromfunction,
-                           tile, repeat, pad, diagonal)
+                           tile, repeat, pad, diagonal,
+                           FromBlockFunctionInfo)
     from .gufunc import apply_gufunc, gufunc, as_gufunc
     from .utils import assert_eq
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -10,6 +10,7 @@ from toolz import accumulate, sliding_window
 
 from ..highlevelgraph import HighLevelGraph
 from ..base import tokenize
+from ..core import quote
 from ..compatibility import Sequence
 from ..utils import funcname
 from . import chunk
@@ -246,17 +247,17 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, chunks='auto',
         return Array(dsk, name, chunks, dtype=dtype)
 
 
-def _call_from_block_function(func, shape, num_chunks, chunk_location, array_location, func_kwargs):
+def _call_from_block_function(func, shape, num_chunks, chunk_location, array_location, func_args, func_kwargs):
     block_info = {
         'shape': shape,
         'num-chunks': num_chunks,
         'chunk-location': chunk_location,
         'array-location': list(array_location)
     }
-    return func(block_info, **func_kwargs)
+    return func(block_info, *func_args, **func_kwargs)
 
 
-def from_block_function(func, shape, chunks='auto', dtype=None, name=None, **kwargs):
+def from_block_function(func, *args, **kwargs):
     """
     Create an array from a function that builds individual blocks.
 
@@ -279,7 +280,10 @@ def from_block_function(func, shape, chunks='auto', dtype=None, name=None, **kwa
     ----------
     func : callable
         Function to produce every block in the array
-    shape : Tuple[int]
+    *args :
+        Other positional arguments to pass to function. Values must be constants
+        (not dask.arrays).
+    shape : Tuple[int], optional
         Shape of the resulting array.
     chunks : tuple, optional
         Chunk shape of resulting blocks. If not provided, a chunking scheme
@@ -308,7 +312,7 @@ def from_block_function(func, shape, chunks='auto', dtype=None, name=None, **kwa
     ...         return np.eye(r1 - r0, c1 - c0)
     ...     else:
     ...         return np.zeros((r1 - r0, c1 - c0))
-    >>> from_block_function(eye_chunk, (4, 4), chunks=2, dtype=float)
+    >>> from_block_function(eye_chunk, shape=(4, 4), chunks=2, dtype=float)
     dask.array<eye_chunk, shape=(4, 4), dtype=float64, chunksize=(2, 2)>
     >>> _.compute()
     array([[1., 0., 0., 0.],
@@ -317,19 +321,25 @@ def from_block_function(func, shape, chunks='auto', dtype=None, name=None, **kwa
            [0., 0., 0., 1.]])
     """
 
-    name = '%s-%s' % (name or funcname(func), tokenize(func, shape, dtype, chunks))
+    shape = kwargs.pop('shape', None)
+    chunks = kwargs.pop('chunks', 'auto')
+    dtype = kwargs.pop('dtype', None)
+    name = kwargs.pop('name', None)
+    name = '%s-%s' % (name or funcname(func), tokenize(func, shape, dtype, chunks, args, kwargs))
 
     if dtype is None:
+        chunks = normalize_chunks(chunks, shape)
         dummy_block_info = {
             'shape': shape,
             'num-chunks': shape,
             'chunk-location': (0,) * len(shape),
             'array-location': [(0, 1)] * len(shape)
         }
-        dtype = apply_infer_dtype(func, [dummy_block_info], kwargs, 'from_block_function')
+        dtype = apply_infer_dtype(func, (dummy_block_info,) + args, kwargs, 'from_block_function')
+    else:
+        chunks = normalize_chunks(chunks, shape, dtype=dtype)
 
-    chunks = normalize_chunks(chunks, shape, dtype=dtype)
-    # Allow for shape=None when chunks are already in normalized form
+    # Allow user to omit shape when chunks are given in normalized form
     shape = tuple(sum(bd) for bd in chunks)
 
     keys = list(product([name], *[range(len(bd)) for bd in chunks]))
@@ -337,7 +347,8 @@ def from_block_function(func, shape, chunks='auto', dtype=None, name=None, **kwa
     locdims = [list(zip(a[:-1], a[1:])) for a in aggdims]
     locations = list(product(*locdims))
     num_chunks = tuple(len(bd) for bd in chunks)
-    dsk = {key: (_call_from_block_function, func, shape, num_chunks, key[1:], location, kwargs)
+    args = quote(args)
+    dsk = {key: (_call_from_block_function, func, shape, num_chunks, key[1:], location, args, kwargs)
            for key, location in zip(keys, locations)}
     return Array(dsk, name, chunks, dtype=dtype)
 
@@ -507,14 +518,14 @@ def indices(dimensions, dtype=int, chunks='auto'):
     return grid
 
 
-def _eye_chunk(block_info, k, out_dtype):
+def _eye_chunk(block_info, k, dtype):
     location = block_info['array-location']
     r0, r1 = location[0]
     c0, c1 = location[1]
     if c0 - r1 < k < c1 - r0:
-        return np.eye(r1 - r0, c1 - c0, k - (c0 - r0), out_dtype)
+        return np.eye(r1 - r0, c1 - c0, k - (c0 - r0), dtype)
     else:
-        return np.zeros((r1 - r0, c1 - c0), out_dtype)
+        return np.zeros((r1 - r0, c1 - c0), dtype)
 
 
 def eye(N, chunks, M=None, k=0, dtype=float):
@@ -556,8 +567,7 @@ def eye(N, chunks, M=None, k=0, dtype=float):
         hchunks.append(M % chunks)
 
     return from_block_function(
-        _eye_chunk, shape=(N, M), chunks=(chunks, chunks), dtype=dtype, name='eye',
-        k=k, out_dtype=dtype)
+        _eye_chunk, k, dtype, chunks=(vchunks, hchunks), dtype=dtype, name='eye')
 
 
 @wraps(np.diag)
@@ -696,7 +706,7 @@ def tril(m, k=0):
     return Array(graph, name, shape=m.shape, chunks=m.chunks, dtype=m.dtype)
 
 
-def _np_fromfunction(block_info, user_dtype, user_func, user_kwargs):
+def _np_fromfunction(block_info, dtype, user_func, user_kwargs):
     def offset_func(*args, **kwargs):
         args2 = list(map(add, args, offset))
         return user_func(*args2, **kwargs)
@@ -704,7 +714,7 @@ def _np_fromfunction(block_info, user_dtype, user_func, user_kwargs):
     location = block_info['array-location']
     offset = [loc[0] for loc in location]
     shape = [loc[1] - loc[0] for loc in location]
-    return np.fromfunction(offset_func, shape, dtype=user_dtype, **user_kwargs)
+    return np.fromfunction(offset_func, shape, dtype=dtype, **user_kwargs)
 
 
 @wraps(np.fromfunction)
@@ -712,8 +722,8 @@ def fromfunction(func, chunks='auto', shape=None, dtype=None, **kwargs):
     dtype = dtype or float
 
     return from_block_function(
-        _np_fromfunction, shape=shape, chunks=chunks, dtype=dtype, name='fromfunction',
-        user_dtype=dtype, user_func=func, user_kwargs=kwargs)
+        _np_fromfunction, dtype, func, kwargs,
+        shape=shape, chunks=chunks, dtype=dtype, name='fromfunction')
 
 
 @wraps(np.repeat)

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -301,14 +301,14 @@ def from_block_function(func, shape, chunks='auto', dtype=None, name=None, **kwa
     arrays with the ones on the main diagonal.
 
     >>> def eye_chunk(block_info):
-            location = block_info['array-location']
-            r0, r1 = location[0]
-            c0, c1 = location[1]
-            if r0 == c0:
-                return np.eye(r1 - r0, c1 - c0)
-            else:
-                return np.zeros((r1 - r0, c1 - c0))
-    >>> from_block_function(eye_chunk, (4, 4), chunks=2, dtype=float).compute()
+    ...     location = block_info['array-location']
+    ...     r0, r1 = location[0]
+    ...     c0, c1 = location[1]
+    ...     if r0 == c0:
+    ...         return np.eye(r1 - r0, c1 - c0)
+    ...     else:
+    ...         return np.zeros((r1 - r0, c1 - c0))
+    >>> from_block_function(eye_chunk, (4, 4), chunks=2, dtype=float)
     dask.array<eye_chunk, shape=(4, 4), dtype=float64, chunksize=(2, 2)>
     >>> _.compute()
     array([[1., 0., 0., 0.],

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -251,7 +251,7 @@ def _call_from_block_function(func, shape, num_chunks, chunk_location, array_loc
         'shape': shape,
         'num-chunks': num_chunks,
         'chunk-location': chunk_location,
-        'array-location': array_location
+        'array-location': list(array_location)
     }
     return func(block_info, **func_kwargs)
 
@@ -326,16 +326,17 @@ def from_block_function(func, shape, chunks='auto', dtype=None, name=None, **kwa
             'chunk-location': (0,) * len(shape),
             'array-location': [(0, 1)] * len(shape)
         }
-        dtype = apply_infer_dtype(func, [dummy_block_info], {}, 'from_block_function')
+        dtype = apply_infer_dtype(func, [dummy_block_info], kwargs, 'from_block_function')
 
     chunks = normalize_chunks(chunks, shape, dtype=dtype)
-    shape = [sum(bd) for bd in chunks]
+    # Allow for shape=None when chunks are already in normalized form
+    shape = tuple(sum(bd) for bd in chunks)
 
     keys = list(product([name], *[range(len(bd)) for bd in chunks]))
     aggdims = [list(accumulate(add, (0,) + bd)) for bd in chunks]
     locdims = [list(zip(a[:-1], a[1:])) for a in aggdims]
     locations = list(product(*locdims))
-    num_chunks = [len(bd) for bd in chunks]
+    num_chunks = tuple(len(bd) for bd in chunks)
     dsk = {key: (_call_from_block_function, func, shape, num_chunks, key[1:], location, kwargs)
            for key, location in zip(keys, locations)}
     return Array(dsk, name, chunks, dtype=dtype)

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -113,8 +113,10 @@ def test_from_block_function(dtype):
     num_chunks = (2, 2)
     calls = []
     lock = threading.Lock()
-    a = da.from_block_function(_from_block_function_callback, shape, chunks, dtype=dtype,
-                               calls=calls, lock=lock)
+    # Passes calls via *args and lock via **kwargs to test both
+    a = da.from_block_function(_from_block_function_callback, calls,
+                               shape=shape, chunks=chunks, dtype=dtype,
+                               lock=lock)
     expected = np.array([[0, 1, 2, 3], [1000, 1001, 1002, 1003], [2000, 2001, 2002, 2003]])
     assert_eq(a, expected)
 

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -80,6 +80,7 @@ Top level user functions:
    fmin
    fmod
    frexp
+   from_block_function
    fromfunction
    frompyfunc
    full
@@ -445,6 +446,7 @@ Other functions
 .. autofunction:: fmin
 .. autofunction:: fmod
 .. autofunction:: frexp
+.. autofunction:: from_block_function
 .. autofunction:: fromfunction
 .. autofunction:: frompyfunc
 .. autofunction:: full


### PR DESCRIPTION
This makes it easier to construct an array from scratch given code that
builds a single block. It's used to simplify `da.eye` and
`da.fromfunction`, and could probably be used in some other places as
well.

Interface-wise, it's somewhat like `map_blocks` but with zero input
arrays. The callback function is given a `block_info` with the same
information as in `map_blocks`, although without the outer layer of
indexing since there is only one output, and as a positional argument
since there are no other positional arguments.

This is still a work in progress, and in particular needs unit tests.
I'm also not sure that kwargs are being handled ideally; it's based off
`fromfunction`, but I see that `map_blocks` and `blockwise` do much more
complicated things with kwargs e.g. to escape strings that could be
misinterpreted as keys.

- [X] Tests added / passed
- [X] Passes `flake8 dask`
- [ ] User documentation updated
