### PR TITLE
Fix bug in HTTPFile._fetch_range with headers (#4479)

### DIFF
--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -244,7 +244,7 @@ class HTTPFile(object):
         requested, an exception is raised.
         """
         kwargs = self.kwargs.copy()
-        headers = self.kwargs.pop('headers', {})
+        headers = kwargs.pop('headers', {})
         headers['Range'] = 'bytes=%i-%i' % (start, end - 1)
         r = self.session.get(self.url, headers=headers, stream=True, **kwargs)
         r.raise_for_status()

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -47,6 +47,17 @@ def test_simple(dir_server):
     assert data == open(os.path.join(dir_server, fn), 'rb').read()
 
 
+def test_fetch_range_with_headers(dir_server):
+    # https://github.com/dask/dask/issues/4479
+    root = 'http://localhost:8999/'
+    fn = files[0]
+    headers = {'Date': 'Wed, 21 Oct 2015 07:28:00 GMT'}
+    f = open_files(root + fn, headers=headers)[0]
+    with f as f:
+        data = f.read(length=1) + f.read(length=-1)
+    assert data == open(os.path.join(dir_server, fn), 'rb').read()
+
+
 @pytest.mark.parametrize('block_size', [None, 99999])
 def test_ops(dir_server, block_size):
     root = 'http://localhost:8999/'


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`
