### PR TITLE
Avoid groupby.agg(callable) in groupby-var

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -242,8 +242,14 @@ def _var_chunk(df, *index):
         df = df.to_frame()
     g = _groupby_raise_unaligned(df, by=index)
     x = g.sum()
-    x2 = g.agg(lambda x: (x**2).sum()).rename(columns=lambda c: c + '-x2')
+
     n = g.count().rename(columns=lambda c: c + '-count')
+
+    df2 = df ** 2
+    g2 = _groupby_raise_unaligned(df2, by=index)
+    x2 = g2.sum().rename(columns=lambda c: c + '-x2')
+
+    x2.index = x.index
     return pd.concat([x, x2, n], axis=1)
 
 


### PR DESCRIPTION
This has two benefits

1.  It's much faster the following benchmark shows a 5x improvement
2.  It doesn't require the pandas-like container to implement
    groupby.agg(callable), which helps cudf

Benchmark
---------

I get five-ish seconds for this on master
And less than one second on this branch

```
from time import time
import dask
df = dask.datasets.timeseries(dtypes={'id': int, 'data': float}).persist()

start = time()
for i in range(3):
    df.groupby('id').data.std().compute()
stop = time()

print(stop - start)`
```

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`

cc @thomcom @TomAugspurger 