### PR TITLE
Fix header level of section in changelog

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,7 +23,7 @@ DataFrame
 -  Pass username as 'user' when using pyarrow (:pr:`4438`) `Roma Sokolov`_
 
 Delayed
--------
++++++++
 
 -  Fix DelayedAttr return value (:pr:`4440`) `Matthew Rocklin`_
 


### PR DESCRIPTION
A section called "Delayed" under 1.1.1 was at the same header level as
versions.