### PR TITLE
consider uint types as numerical in check_meta

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -287,7 +287,8 @@ def test_check_meta():
                        'b': [True, False, True],
                        'c': [1, 2.5, 3.5],
                        'd': [1, 2, 3],
-                       'e': pd.Categorical(['x', 'y', 'z'])})
+                       'e': pd.Categorical(['x', 'y', 'z']),
+                       'f': pd.Series([1, 2, 3], dtype=np.uint64)})
     meta = df.iloc[:0]
 
     # DataFrame metadata passthrough if correct
@@ -297,7 +298,10 @@ def test_check_meta():
     assert check_meta(e, meta.e) is e
     # numeric_equal means floats and ints are equivalent
     d = df.d
+    f = df.f
     assert check_meta(d, meta.d.astype('f8'), numeric_equal=True) is d
+    assert check_meta(f, meta.f.astype('f8'), numeric_equal=True) is f
+    assert check_meta(f, meta.f.astype('i8'), numeric_equal=True) is f
 
     # Series metadata error
     with pytest.raises(ValueError) as err:

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -531,7 +531,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
         to panda's implicit conversion of integer to floating upon encountering
         missingness, which is hard to infer statically.
     """
-    eq_types = {'i', 'f'} if numeric_equal else {}
+    eq_types = {'i', 'f', 'u'} if numeric_equal else set()
 
     def equal_dtypes(a, b):
         if is_categorical_dtype(a) != is_categorical_dtype(b):


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `flake8 dask`
