### PR TITLE
fix another unicode/mixed-type edge case in normalize_array

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -729,12 +729,13 @@ def register_numpy():
                     x.shape, x.strides, offset)
         if x.dtype.hasobject:
             try:
-                # string fast-path
-                data = hash_buffer_hex('-'.join(x.flat).encode(encoding='utf-8', errors='surrogatepass'))
-            except UnicodeDecodeError:
-                # bytes fast-path
-                data = hash_buffer_hex(b'-'.join(x.flat))
-            except TypeError:
+                try:
+                    # string fast-path
+                    data = hash_buffer_hex('-'.join(x.flat).encode(encoding='utf-8', errors='surrogatepass'))
+                except UnicodeDecodeError:
+                    # bytes fast-path
+                    data = hash_buffer_hex(b'-'.join(x.flat))
+            except (TypeError, UnicodeDecodeError):
                 # object data w/o fast-path, use fast cPickle
                 try:
                     data = hash_buffer_hex(cPickle.dumps(x, cPickle.HIGHEST_PROTOCOL))

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -215,6 +215,12 @@ def test_tokenize_pandas_invalid_unicode():
 
 
 @pytest.mark.skipif('not pd')
+def test_tokenize_pandas_mixed_unicode_bytes():
+    df = pd.DataFrame({u'ö'.encode('utf8'): [1, 2, 3], u'ö': [u'ö', u'ö'.encode('utf8'), None]}, index=[1, 2, 3])
+    tokenize(df)
+
+
+@pytest.mark.skipif('not pd')
 def test_tokenize_pandas_no_pickle():
     class NoPickle(object):
         # pickling not supported because it is a local class


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `flake8 dask`

I initially thought that I've fixed #2713 in #4312, but I just hit an edge case that I wasn't aware of. This PR fixes that one as well and adds a regression test. Sure, the data types are weird here (bytes and unicode objects mixed), but at least dask shouldn't crash in that case.