### PR TITLE
Fix renaming on index to_frame method

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2417,8 +2417,11 @@ class Index(Series):
 
     @derived_from(pd.Index)
     def to_frame(self, name=None):
-        return self.map_partitions(M.to_frame, True, name,
-                                   meta=self._meta.to_frame(True, name))
+        if PANDAS_VERSION < '0.24.0' and name is not None:
+            raise ValueError('renaming index is not supported on this PANDAS version')
+        elif PANDAS_VERSION >= '0.24.0':
+            return self.map_partitions(M.to_frame, True, name,
+                                       meta=self._meta.to_frame(True, name))
 
 
 class DataFrame(_Frame):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2417,11 +2417,16 @@ class Index(Series):
 
     @derived_from(pd.Index)
     def to_frame(self, name=None):
-        if PANDAS_VERSION < '0.24.0' and name is not None:
-            raise ValueError('renaming index is not supported on this PANDAS version')
-        elif PANDAS_VERSION >= '0.24.0':
+        if PANDAS_VERSION >= '0.24.0':
             return self.map_partitions(M.to_frame, True, name,
                                        meta=self._meta.to_frame(True, name))
+        else:
+            if name is not None:
+                raise ValueError("The 'name' keyword was added in pandas 0.24.0. "
+                                 "Your version of pandas is '{}'.".format(PANDAS_VERSION))
+            else:
+                return self.map_partitions(M.to_frame,
+                                           meta=self._meta.to_frame())
 
 
 class DataFrame(_Frame):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2420,6 +2420,9 @@ class Index(Series):
         if PANDAS_VERSION >= '0.24.0':
             return self.map_partitions(M.to_frame, True, name,
                                        meta=self._meta.to_frame(True, name))
+        elif PANDAS_VERSION < '0.21.0':
+            raise NotImplementedError("The 'Index.to_frame' method was added in pandas 0.21.0 "
+                                      "Your version of pandas is '{}'.".format(PANDAS_VERSION))
         else:
             if name is not None:
                 raise ValueError("The 'name' keyword was added in pandas 0.24.0. "

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2416,9 +2416,9 @@ class Index(Series):
                                    meta=self._meta.to_series())
 
     @derived_from(pd.Index)
-    def to_frame(self, index=True, name=None):
-        return self.map_partitions(M.to_frame, index, name,
-                                   meta=self._meta.to_frame(index, name))
+    def to_frame(self, name=None):
+        return self.map_partitions(M.to_frame, True, name,
+                                   meta=self._meta.to_frame(True, name))
 
 
 class DataFrame(_Frame):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2415,11 +2415,14 @@ class Index(Series):
         return self.map_partitions(M.to_series,
                                    meta=self._meta.to_series())
 
-    @derived_from(pd.Index)
-    def to_frame(self, name=None):
+    @derived_from(pd.Index, ua_args=['index'])
+    def to_frame(self, index=True, name=None):
+        if not index:
+            raise NotImplementedError()
+
         if PANDAS_VERSION >= '0.24.0':
-            return self.map_partitions(M.to_frame, True, name,
-                                       meta=self._meta.to_frame(True, name))
+            return self.map_partitions(M.to_frame, index, name,
+                                       meta=self._meta.to_frame(index, name))
         elif PANDAS_VERSION < '0.21.0':
             raise NotImplementedError("The 'Index.to_frame' method was added in pandas 0.21.0 "
                                       "Your version of pandas is '{}'.".format(PANDAS_VERSION))

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2415,6 +2415,11 @@ class Index(Series):
         return self.map_partitions(M.to_series,
                                    meta=self._meta.to_series())
 
+    @derived_from(pd.Index)
+    def to_frame(self, index=True, name=None):
+        return self.map_partitions(M.to_frame, index, name,
+                                   meta=self._meta.to_frame(index, name))
+
 
 class DataFrame(_Frame):
     """

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -410,6 +410,8 @@ def test_to_series():
     assert_eq(df.index.to_series(), ddf.index.to_series())
 
 
+@pytest.mark.skipif(PANDAS_VERSION < '0.21.0',
+                    reason="No index.to_frame method")
 def test_to_frame():
 
     # Test for time index

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -410,6 +410,25 @@ def test_to_series():
     assert_eq(df.index.to_series(), ddf.index.to_series())
 
 
+def test_to_frame():
+
+    # Test for time index
+    df = pd.DataFrame({'A': np.random.randn(100)},
+                      index=pd.date_range('2011-01-01', freq='H', periods=100))
+    ddf = dd.from_pandas(df, 10)
+
+    assert_eq(df.index.to_frame(), ddf.index.to_frame())
+    assert_eq(df.index.to_frame(name='foo'), ddf.index.to_frame(name='foo'))
+
+    # Test for numerical index
+    df = pd.DataFrame({'A': np.random.randn(100)},
+                      index=range(100))
+    ddf = dd.from_pandas(df, 10)
+
+    assert_eq(df.index.to_frame(), ddf.index.to_frame())
+    assert_eq(df.index.to_frame(name='bar'), ddf.index.to_frame(name='bar'))
+
+
 @pytest.mark.parametrize('indexer', [
     0,
     [0],

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -418,7 +418,6 @@ def test_to_frame():
     ddf = dd.from_pandas(df, 10)
 
     assert_eq(df.index.to_frame(), ddf.index.to_frame())
-    assert_eq(df.index.to_frame(name='foo'), ddf.index.to_frame(name='foo'))
 
     # Test for numerical index
     df = pd.DataFrame({'A': np.random.randn(100)},
@@ -426,6 +425,23 @@ def test_to_frame():
     ddf = dd.from_pandas(df, 10)
 
     assert_eq(df.index.to_frame(), ddf.index.to_frame())
+
+
+@pytest.mark.skipif(PANDAS_VERSION < '0.24.0',
+                    reason="No renaming for index")
+def test_to_frame_name():
+    # Test for time index
+    df = pd.DataFrame({'A': np.random.randn(100)},
+                      index=pd.date_range('2011-01-01', freq='H', periods=100))
+    ddf = dd.from_pandas(df, 10)
+
+    assert_eq(df.index.to_frame(name='foo'), ddf.index.to_frame(name='foo'))
+
+    # Test for numerical index
+    df = pd.DataFrame({'A': np.random.randn(100)},
+                      index=range(100))
+    ddf = dd.from_pandas(df, 10)
+
     assert_eq(df.index.to_frame(name='bar'), ddf.index.to_frame(name='bar'))
 
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

Fix issue https://github.com/dask/dask/issues/3564

Finally pandas 0.24 was released and so, the fix for index `to_frame` bug is now patched. However it was not possible to replicate pandas behavior since `map_partitions`  don't have access to global index when `index=False`