### PR TITLE
Avoid itertools.repeat in map_partitions

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1956,7 +1956,7 @@ def map_partitions(func, *args, **kwargs):
             args2.append((itertools.repeat, a.key))
             dependencies.append(a)
         else:
-            args2.append((itertools.repeat, a))
+            args2.append(a)
 
     bag_kwargs = {}
     other_kwargs = {}

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1953,7 +1953,7 @@ def map_partitions(func, *args, **kwargs):
             bags.append(a)
             args2.append(a)
         elif isinstance(a, (Item, Delayed)):
-            args2.append((itertools.repeat, a.key))
+            args2.append(a.key)
             dependencies.append(a)
         else:
             args2.append(a)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1315,3 +1315,5 @@ def test_map_partitions_arg():
 
     assert_eq(mybag.map_partitions(append_str, "foo"),
               ['afoo', 'bfoo', 'cfoo'])
+    assert_eq(mybag.map_partitions(append_str, dask.delayed("foo")),
+              ['afoo', 'bfoo', 'cfoo'])

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1305,3 +1305,12 @@ def test_bag_paths():
     assert b.to_textfiles('foo*') == ['foo0', 'foo1']
     os.remove('foo0')
     os.remove('foo1')
+
+def test_map_partitions_arg():
+    def append_str(partition, s):
+        return [x + s for x in partition]
+
+    mybag = db.from_sequence(["a", "b", "c"])
+
+    assert_eq(mybag.map_partitions(append_str, "foo"),
+              ['afoo', 'bfoo', 'cfoo'])

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1306,6 +1306,7 @@ def test_bag_paths():
     os.remove('foo0')
     os.remove('foo1')
 
+
 def test_map_partitions_arg():
     def append_str(partition, s):
         return [x + s for x in partition]


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/4446

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
