### PR TITLE
Add quotes to pip install in dev guide 

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -88,7 +88,7 @@ environment on your computer to compile them when installing with ``pip``::
 Install Dask and dependencies::
 
    cd dask
-   pip install -e .[complete]
+   pip install -e ".[complete]"
 
 For development, Dask uses the following additional dependencies::
 


### PR DESCRIPTION
The current development guidelines has

```terminal
pip install -e .[complete]
```

which works with some shells (e.g. bash) but can fail with other shells (e.g. zsh) that use square brackets for pattern matching. This PR adds quotes

```terminal
pip install -e ".[complete]"
```

to the development guidelines to avoid this issue. 
