### PR TITLE
Modify mean chunk functions to return dicts rather than arrays

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -347,11 +347,10 @@ def mean_combine(pairs, sum=chunk.sum, numel=numel, dtype='f8', axis=None, **kwa
 def mean_agg(pairs, dtype='f8', axis=None, **kwargs):
     ns = deepmap(lambda pair: pair['n'], pairs)
     totals = deepmap(lambda pair: pair['total'], pairs)
-    n = _concatenate2(ns, axes=axis).sum(axis=axis, **kwargs)
-    total = _concatenate2(totals, axes=axis).sum(axis=axis, **kwargs)
+    n = _concatenate2(ns, axes=axis).sum(axis=axis, dtype=dtype, **kwargs)
+    total = _concatenate2(totals, axes=axis).sum(axis=axis, dtype=dtype, **kwargs)
 
-    return divide(total.sum(dtype=dtype, **kwargs),
-                  n.sum(dtype=dtype, **kwargs), dtype=dtype)
+    return divide(total, n, dtype=dtype)
 
 
 @wraps(chunk.mean)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -22,7 +22,7 @@ from .numpy_compat import ma_divide, divide as np_divide
 from ..compatibility import getargspec, builtins
 from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
-from ..utils import ignoring, funcname, Dispatch
+from ..utils import ignoring, funcname, Dispatch, deepmap
 from .. import config
 
 # Generic functions to support chunks of different types
@@ -331,26 +331,27 @@ def nannumel(x, **kwargs):
 def mean_chunk(x, sum=chunk.sum, numel=numel, dtype='f8', **kwargs):
     n = numel(x, dtype=dtype, **kwargs)
     total = sum(x, dtype=dtype, **kwargs)
-    empty = empty_lookup.dispatch(type(n))
-    result = empty(n.shape, dtype=[('total', total.dtype), ('n', n.dtype)])
-    result['n'] = n
-    result['total'] = total
-    return result
+    return {'n': n, 'total': total}
 
 
-def mean_combine(pair, sum=chunk.sum, numel=numel, dtype='f8', **kwargs):
-    n = sum(pair['n'], **kwargs)
-    total = sum(pair['total'], **kwargs)
-    empty = empty_lookup.dispatch(type(n))
-    result = empty(n.shape, dtype=pair.dtype)
-    result['n'] = n
-    result['total'] = total
-    return result
+def mean_combine(pairs, sum=chunk.sum, numel=numel, dtype='f8', axis=None, **kwargs):
+    if not isinstance(pairs, list):
+        pairs = [pairs]
+    ns = deepmap(lambda pair: pair['n'], pairs)
+    totals = deepmap(lambda pair: pair['total'], pairs)
+    n = _concatenate2(ns, axes=axis).sum(axis=axis, **kwargs)
+    total = _concatenate2(totals, axes=axis).sum(axis=axis, **kwargs)
+    return {'n': n, 'total': total}
 
 
-def mean_agg(pair, dtype='f8', **kwargs):
-    return divide(pair['total'].sum(dtype=dtype, **kwargs),
-                  pair['n'].sum(dtype=dtype, **kwargs), dtype=dtype)
+def mean_agg(pairs, dtype='f8', axis=None, **kwargs):
+    ns = deepmap(lambda pair: pair['n'], pairs)
+    totals = deepmap(lambda pair: pair['total'], pairs)
+    n = _concatenate2(ns, axes=axis).sum(axis=axis, **kwargs)
+    total = _concatenate2(totals, axes=axis).sum(axis=axis, **kwargs)
+
+    return divide(total.sum(dtype=dtype, **kwargs),
+                  n.sum(dtype=dtype, **kwargs), dtype=dtype)
 
 
 @wraps(chunk.mean)
@@ -361,7 +362,7 @@ def mean(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None):
         dt = getattr(np.mean(np.empty(shape=(1,), dtype=a.dtype)), 'dtype', object)
     return reduction(a, mean_chunk, mean_agg, axis=axis, keepdims=keepdims,
                      dtype=dt, split_every=split_every, combine=mean_combine,
-                     out=out)
+                     out=out, concatenate=False)
 
 
 def nanmean(a, axis=None, dtype=None, keepdims=False, split_every=None,
@@ -373,6 +374,7 @@ def nanmean(a, axis=None, dtype=None, keepdims=False, split_every=None,
     return reduction(a, partial(mean_chunk, sum=chunk.nansum, numel=nannumel),
                      mean_agg, axis=axis, keepdims=keepdims, dtype=dt,
                      split_every=split_every, out=out,
+                     concatenate=False,
                      combine=partial(mean_combine, sum=chunk.nansum, numel=nannumel))
 
 


### PR DESCRIPTION
These functions return two array chunks each:

1.  The sum of the array
2.  The counts of the array

We need to return these as a single intermediate value.

Previously we did this by constructing an empty numpy array and then
assigning into it.  This doesn't work as well with numpy-like arrays
like cupy and sparse.

Now we return a dict containing two arrays.  This is nice in a few ways,
but does mean that we need to replicate the `concatenate=`
functionality within our chunk aggregation and combine functions, which
can be tricky.  This commit fails to do it correctly, but may be a good
start.

This is also somewhat suboptimal in a distributed setting because we no longer get special-cased handling of numpy arrays like we used to.  The scheduler will probably miscount the number of bytes that these objects hold and will probably not use ideal serialization and compression.  I *think* that this is probably ok because they're likely to be small, but it's worth pointing out.

After this we would like to implement the same fix for other functions,
notably the `moment_*` functions in this same reductions.py file.

Fixes https://github.com/dask/dask/issues/4481

Help or ideas with this would be welcome.  cc @pentschev @jakirkham 

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
