### PR TITLE
DOC: DataFrame→Array conversion and unknown chunks

### DIFF
--- a/docs/source/array-chunks.rst
+++ b/docs/source/array-chunks.rst
@@ -77,25 +77,17 @@ result in an error.
    >>> x[100]
    ValueError: Array chunk sizes unknown
 
-This happens frequently when converting a Dask DataFrame to a Dask Array. One
-method for that conversion is
+This also happens when creating a Dask array from a Dask DataFrame:
 
 .. code-block:: python
 
    >>> ddf = dask.dataframe.from_pandas(...)
-   >>> ddf.values
+   >>> ddf.to_dask_array()
    ... dask.array<values, shape=(nan, 2), dtype=float64, chunksize=(nan, 2)>
 
-This is the simplest method to get a Dask Array, but the ``nan`` in ``ddf.values.chunks`` can lead to some indexing errors.
-
-This is most easily resolved with the ``to_dask_array`` method:
-
-   >>> ddf.to_dask_array(lengths=True)
-   ... dask.array<array, shape=(100, 1), dtype=float64, chunksize=(50, 1)>
-
-Specifying ``lengths=True`` immediately computes the chunk sizes. This enables
-downstream computations that rely on having known chunk sizes.
-
+For details on how to avoid unknown chunk sizes, look at how to create a Dask
+array from a Dask DataFrame in the :doc:`documentation on Dask array creation
+<array-creation>`.
 
 Chunks Examples
 ---------------

--- a/docs/source/array-chunks.rst
+++ b/docs/source/array-chunks.rst
@@ -77,6 +77,22 @@ result in an error.
    >>> x[100]
    ValueError: Array chunk sizes unknown
 
+This happens frequently when converting a Dask DataFrame to a Dask Array. One
+method for that conversion is
+
+.. code-block:: python
+
+   >>> ddf = dask.dataframe.from_pandas(...)
+   >>> ddf.values
+   ... dask.array<values, shape=(nan, 2), dtype=float64, chunksize=(nan, 2)>
+
+This is the simplest method to get a Dask Array, but the ``nan`` in ``ddf.values.chunks`` can lead to some indexing errors.
+
+This is most easily resolved with the ``to_dask_array`` method:
+
+   >>> ddf.to_dask_array(lengths=True)
+   ... dask.array<array, shape=(100, 1), dtype=float64, chunksize=(50, 1)>
+
 
 Chunks Examples
 ---------------

--- a/docs/source/array-chunks.rst
+++ b/docs/source/array-chunks.rst
@@ -77,7 +77,7 @@ result in an error.
    >>> x[100]
    ValueError: Array chunk sizes unknown
 
-This also happens when creating a Dask array from a Dask DataFrame:
+This can also happen when creating a Dask array from a Dask DataFrame:
 
 .. code-block:: python
 

--- a/docs/source/array-chunks.rst
+++ b/docs/source/array-chunks.rst
@@ -93,6 +93,9 @@ This is most easily resolved with the ``to_dask_array`` method:
    >>> ddf.to_dask_array(lengths=True)
    ... dask.array<array, shape=(100, 1), dtype=float64, chunksize=(50, 1)>
 
+Specifying ``lengths=True`` immediately computes the chunk sizes. This enables
+downstream computations that rely on having known chunk sizes.
+
 
 Chunks Examples
 ---------------

--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -147,7 +147,7 @@ Specifying ``lengths=True`` triggers immediate computation of the chunk sizes.
 This enables downstream computations that rely on having known chunk sizes
 (e.g., slicing).
 
-``to_records`` also returns a Dask Array but does not compute the shape
+The Dask DataFrame ``to_records`` method also returns a Dask Array, but does not compute the shape
 information:
 
    >>> df.to_records()

--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -115,7 +115,7 @@ See :doc:`documentation on using dask.delayed with collections<delayed-collectio
 From Dask DataFrame
 -------------------
 
-At the most basic level, Dask DataFrames have a ``to_dask_array`` method:
+There are several ways to create a Dask array from a Dask DataFrame. Dask DataFrames have a ``to_dask_array`` method:
 
 .. code-block:: python
 

--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -115,17 +115,43 @@ See :doc:`documentation on using dask.delayed with collections<delayed-collectio
 From Dask DataFrame
 -------------------
 
-You can create Dask arrays from Dask DataFrames using the ``.values`` attribute
-or the ``.to_records()`` method:
+At the most basic level, Dask DataFrames have a ``to_dask_array`` method:
 
 .. code-block:: python
 
-   >>> x = df.values
-   >>> x = df.to_records()
+   >>> df = dask.dataframes.from_pandas(...)
+   >>> df.to_dask_array()
+   dask.array<values, shape=(nan, 3), dtype=float64, chunksize=(nan, 3)>
 
-However, these arrays do not have known chunk sizes (dask.dataframe does not
-track the number of rows in each partition), and so some operations like slicing
-will not operate correctly.
+This mirrors the `to_numpy
+<https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_numpy.html>`_
+function in Pandas. The ``values`` attribute is also supported:
+
+.. code-block:: python
+
+   >>> df.values
+   dask.array<values, shape=(nan, 3), dtype=float64, chunksize=(nan, 3)>
+
+However, these arrays do not have known chunk sizes because dask.dataframe does
+not track the number of rows in each partition. This means that some operations
+like slicing will not operate correctly.
+
+The chunk sizes can be computed:
+
+.. code-block:: python
+
+   >>> df.to_dask_array(lengths=True)
+   dask.array<array, shape=(100, 3), dtype=float64, chunksize=(50, 3)>
+
+Specifying ``lengths=True`` triggers immediate computation of the chunk sizes.
+This enables downstream computations that rely on having known chunk sizes
+(e.g., slicing).
+
+``to_records`` also returns a Dask Array but does not compute the shape
+information:
+
+   >>> df.to_records()
+   dask.array<to_records, shape=(nan,), dtype=(numpy.record, [('index', '<i8'), ('x', '<f8'), ('y', '<f8'), ('z', '<f8')]), chunksize=(nan,)>
 
 If you have a function that converts a Pandas DataFrame into a NumPy array,
 then calling ``map_partitions`` with that function on a Dask DataFrame will
@@ -133,7 +159,8 @@ produce a Dask array:
 
 .. code-block:: python
 
-   >>> x = df.map_partitions(np.asarray)
+   >>> df.map_partitions(np.asarray)
+   dask.array<asarray, shape=(nan, 3), dtype=float64, chunksize=(nan, 3)>
 
 
 Interactions with NumPy arrays


### PR DESCRIPTION
**What does this PR implement?**
This PR provides documentation for converting converting a Dask DataFrame to a Dask Array and computing `chunks` in the process (so `chunks` is not `nan`).

**Reference issues/PRs**
* "I had to pass lengths to `to_dask_array` which I didn't realize existed."—https://github.com/dask/dask/issues/3293#issuecomment-461545055
* https://github.com/dask/dask-ml/issues/465, "How to chunk a Dask Array with unknown chunks"
