### PR TITLE
Add tests for groupby reductions with object dtypes

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -937,7 +937,8 @@ class _GroupBy(object):
     def mean(self, split_every=None, split_out=1):
         s = self.sum(split_every=split_every, split_out=split_out)
         c = self.count(split_every=split_every, split_out=split_out)
-        c = c[s.columns]
+        if is_dataframe_like(s):
+            c = c[s.columns]
         return s / c
 
     @derived_from(pd.core.groupby.GroupBy)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -240,6 +240,7 @@ def _apply_chunk(df, *index, **kwargs):
 def _var_chunk(df, *index):
     if is_series_like(df):
         df = df.to_frame()
+    df = df._get_numeric_data()
     g = _groupby_raise_unaligned(df, by=index)
     x = g.sum()
 
@@ -934,8 +935,10 @@ class _GroupBy(object):
 
     @derived_from(pd.core.groupby.GroupBy)
     def mean(self, split_every=None, split_out=1):
-        return (self.sum(split_every=split_every, split_out=split_out) /
-                self.count(split_every=split_every, split_out=split_out))
+        s = self.sum(split_every=split_every, split_out=split_out)
+        c = self.count(split_every=split_every, split_out=split_out)
+        c = c[s.columns]
+        return s / c
 
     @derived_from(pd.core.groupby.GroupBy)
     def size(self, split_every=None, split_out=1):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3410,3 +3410,22 @@ def test_meta_error_message():
     assert 'Series' in str(info.value)
     assert 'DataFrame' in str(info.value)
     assert 'pandas' in str(info.value)
+
+
+@pytest.mark.parametrize('func', [
+    lambda x: x.std(),
+    lambda x: x.groupby('x').std(),
+    lambda x: x.groupby('x').var(),
+    lambda x: x.groupby('x').mean(),
+    lambda x: x.groupby('x').sum(),
+    lambda x: x.groupby('x').z.std(),
+])
+def test_std_object_dtype(func):
+    df = pd.DataFrame({
+        'x': [1, 2, 1],
+        'y': ['a', 'b', 'c'],
+        'z': [11., 22., 33.],
+    })
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    assert_eq(func(df), func(ddf))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3410,22 +3410,3 @@ def test_meta_error_message():
     assert 'Series' in str(info.value)
     assert 'DataFrame' in str(info.value)
     assert 'pandas' in str(info.value)
-
-
-@pytest.mark.parametrize('func', [
-    lambda x: x.std(),
-    lambda x: x.groupby('x').std(),
-    lambda x: x.groupby('x').var(),
-    lambda x: x.groupby('x').mean(),
-    lambda x: x.groupby('x').sum(),
-    lambda x: x.groupby('x').z.std(),
-])
-def test_std_object_dtype(func):
-    df = pd.DataFrame({
-        'x': [1, 2, 1],
-        'y': ['a', 'b', 'c'],
-        'z': [11., 22., 33.],
-    })
-    ddf = dd.from_pandas(df, npartitions=2)
-
-    assert_eq(func(df), func(ddf))

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1516,3 +1516,22 @@ def test_groupby_select_column_agg():
     actual = ddf.groupby('A')['B'].agg('var')
     expected = pdf.groupby('A')['B'].agg('var')
     assert_eq(actual, expected)
+
+
+@pytest.mark.parametrize('func', [
+    lambda x: x.std(),
+    lambda x: x.groupby('x').std(),
+    lambda x: x.groupby('x').var(),
+    lambda x: x.groupby('x').mean(),
+    lambda x: x.groupby('x').sum(),
+    lambda x: x.groupby('x').z.std(),
+])
+def test_std_object_dtype(func):
+    df = pd.DataFrame({
+        'x': [1, 2, 1],
+        'y': ['a', 'b', 'c'],
+        'z': [11., 22., 33.],
+    })
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    assert_eq(func(df), func(ddf))


### PR DESCRIPTION
Fixes #4534

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`