### PR TITLE
Use correct dtype when test concatenation.

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -363,7 +363,7 @@ def test_concatenate():
 
 
 @pytest.mark.parametrize('dtypes', [(('>f8', '>f8'), '>f8'),
-                                    (('<f4', '<f8'), '<f8')])
+                                    (('<f4', '<f8'), '=f8')])
 def test_concatenate_types(dtypes):
     dts_in, dt_out = dtypes
     arrs = [np.zeros(4, dtype=dt) for dt in dts_in]


### PR DESCRIPTION
When all dtypes are the same, dask returns the same dtype. When they are not all the same, then it defers to `np.promote_dtypes`. This function always returns native byteorder, so fix the test.

Fixes #3811.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
