### PR TITLE
Use mask selection in compress

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1003,10 +1003,9 @@ def compress(condition, a, axis=None):
     axis = validate_axis(axis, a.ndim)
 
     # Treat `condition` as filled with `False` (if it is too short)
-    if len(condition) < a.shape[axis]:
-        a = a[tuple(slice(None, len(condition))
-                    if i == axis else slice(None)
-                    for i in range(a.ndim))]
+    a = a[tuple(slice(None, len(condition))
+                if i == axis else slice(None)
+                for i in range(a.ndim))]
 
     # Use `condition` to select along 1 dimension
     slc = ((slice(None),) * axis + (condition, ) +

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1008,18 +1008,10 @@ def compress(condition, a, axis=None):
                     if i == axis else slice(None)
                     for i in range(a.ndim))]
 
-    if isinstance(condition, Array):
-        inds = tuple(range(a.ndim))
-        out = blockwise(np.compress, inds, condition, (inds[axis],), a, inds,
-                        axis=axis, dtype=a.dtype)
-        out._chunks = tuple((np.NaN,) * len(c) if i == axis else c
-                            for i, c in enumerate(out.chunks))
-        return out
-    else:
-        # Optimized case when condition is known
-        slc = ((slice(None),) * axis + (condition, ) +
-               (slice(None),) * (a.ndim - axis - 1))
-        return a[slc]
+    # Use `condition` to select along 1 dimension
+    slc = ((slice(None),) * axis + (condition, ) +
+           (slice(None),) * (a.ndim - axis - 1))
+    return a[slc]
 
 
 @wraps(np.extract)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -994,13 +994,13 @@ def compress(condition, a, axis=None):
     condition = asarray(condition).astype(bool)
     a = asarray(a)
 
+    if condition.ndim != 1:
+        raise ValueError("Condition must be one dimensional")
+
     if axis is None:
         a = a.ravel()
         axis = 0
     axis = validate_axis(axis, a.ndim)
-
-    if condition.ndim != 1:
-        raise ValueError("Condition must be one dimensional")
 
     # Treat `condition` as filled with `False` (if it is too short)
     if len(condition) < a.shape[axis]:

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -999,9 +999,6 @@ def compress(condition, a, axis=None):
         axis = 0
     axis = validate_axis(axis, a.ndim)
 
-    # Only coerce non-lazy values to numpy arrays
-    if not isinstance(condition, Array):
-        condition = np.array(condition, dtype=bool)
     if condition.ndim != 1:
         raise ValueError("Condition must be one dimensional")
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1002,11 +1002,13 @@ def compress(condition, a, axis=None):
     if condition.ndim != 1:
         raise ValueError("Condition must be one dimensional")
 
+    # Treat `condition` as filled with `False` (if it is too short)
+    if len(condition) < a.shape[axis]:
+        a = a[tuple(slice(None, len(condition))
+                    if i == axis else slice(None)
+                    for i in range(a.ndim))]
+
     if isinstance(condition, Array):
-        if len(condition) < a.shape[axis]:
-            a = a[tuple(slice(None, len(condition))
-                        if i == axis else slice(None)
-                        for i in range(a.ndim))]
         inds = tuple(range(a.ndim))
         out = blockwise(np.compress, inds, condition, (inds[axis],), a, inds,
                         axis=axis, dtype=a.dtype)
@@ -1015,10 +1017,6 @@ def compress(condition, a, axis=None):
         return out
     else:
         # Optimized case when condition is known
-        if len(condition) < a.shape[axis]:
-            condition = condition.copy()
-            condition.resize(a.shape[axis])
-
         slc = ((slice(None),) * axis + (condition, ) +
                (slice(None),) * (a.ndim - axis - 1))
         return a[slc]

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -991,6 +991,9 @@ def squeeze(a, axis=None):
 
 @wraps(np.compress)
 def compress(condition, a, axis=None):
+    condition = asarray(condition).astype(bool)
+    a = asarray(a)
+
     if axis is None:
         a = a.ravel()
         axis = 0

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1008,9 +1008,11 @@ def compress(condition, a, axis=None):
                 for i in range(a.ndim))]
 
     # Use `condition` to select along 1 dimension
-    slc = ((slice(None),) * axis + (condition, ) +
-           (slice(None),) * (a.ndim - axis - 1))
-    return a[slc]
+    a = a[tuple(condition
+                if i == axis else slice(None)
+                for i in range(a.ndim))]
+
+    return a
 
 
 @wraps(np.extract)


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/4497

Rewrites `compress` to leverage mask selection in its implementation. This simplifies the code a bit as it benefits from existing mask selection support for Dask Arrays ( https://github.com/dask/dask/pull/2658 ), which works just as well for NumPy arrays or other similar arrays.

cc @pentschev @mrocklin

- [x] Tests added / passed
- [x] Passes `flake8 dask`
