### PR TITLE
Add ability to control number of unique elements in timeseries

### DIFF
--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -46,7 +46,9 @@ def make_timeseries_part(start, end, dtypes, freq, state_data, kwargs):
     state = np.random.RandomState(state_data)
     columns = {}
     for k, dt in dtypes.items():
-        kws = {kk.rsplit('_', 1)[1]: v for kk, v in kwargs.items() if kk.rsplit('_', 1)[0] == k}
+        kws = {kk.rsplit('_', 1)[1]: v
+               for kk, v in kwargs.items()
+               if kk.rsplit('_', 1)[0] == k}
         columns[k] = make[dt](len(index), state, **kws)
     df = pd.DataFrame(columns, index=index, columns=sorted(columns))
     if df.index[-1] == end:
@@ -206,9 +208,11 @@ def daily_stock(symbol, start, stop, freq=pd.Timedelta(seconds=1),
         s = df.iloc[i]
         if s.isnull().any():
             continue
-        part = delayed(generate_day)(s.name, s.loc['Open'], s.loc['High'], s.loc['Low'],
-                                     s.loc['Close'], s.loc['Volume'],
-                                     freq=freq, random_state=seed)
+        part = delayed(generate_day)(
+            s.name, s.loc['Open'], s.loc['High'], s.loc['Low'],
+            s.loc['Close'], s.loc['Volume'],
+            freq=freq, random_state=seed
+        )
         parts.append(part)
         divisions.append(s.name + pd.Timedelta(hours=9))
 

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -15,8 +15,8 @@ def make_float(n, rstate):
     return rstate.rand(n) * 2 - 1
 
 
-def make_int(n, rstate):
-    return rstate.poisson(1000, size=n)
+def make_int(n, rstate, lam=1000):
+    return rstate.poisson(lam, size=n)
 
 
 names = ['Alice', 'Bob', 'Charlie', 'Dan', 'Edith', 'Frank', 'George',
@@ -41,10 +41,13 @@ make = {float: make_float,
         'category': make_categorical}
 
 
-def make_timeseries_part(start, end, dtypes, freq, state_data):
+def make_timeseries_part(start, end, dtypes, freq, state_data, kwargs):
     index = pd.date_range(start=start, end=end, freq=freq, name='timestamp')
     state = np.random.RandomState(state_data)
-    columns = dict((k, make[dt](len(index), state)) for k, dt in dtypes.items())
+    columns = {}
+    for k, dt in dtypes.items():
+        kws = {kk.rsplit('_', 1)[1]: v for kk, v in kwargs.items() if kk.rsplit('_', 1)[0] == k}
+        columns[k] = make[dt](len(index), state, **kws)
     df = pd.DataFrame(columns, index=index, columns=sorted(columns))
     if df.index[-1] == end:
         df = df.iloc[:-1]
@@ -56,7 +59,8 @@ def make_timeseries(start='2000-01-01',
                     dtypes={'name': str, 'id': int, 'x': float, 'y': float},
                     freq='10s',
                     partition_freq='1M',
-                    seed=None):
+                    seed=None,
+                    **kwargs):
     """ Create timeseries dataframe with random data
 
     Parameters
@@ -74,7 +78,12 @@ def make_timeseries(start='2000-01-01',
         String like '1M' or '2Y' to divide the dataframe into partitions
     seed: int (optional)
         Randomstate seed
+    kwargs:
+        Keywords to pass down to individual column creation functions.
+        Keywords should be prefixed by the column name and then an underscore.
 
+    Examples
+    --------
     >>> import dask.dataframe as dd
     >>> df = dd.demo.make_timeseries('2000', '2010',
     ...                              {'value': float, 'name': str, 'id': int},
@@ -93,9 +102,9 @@ def make_timeseries(start='2000-01-01',
     name = 'make-timeseries-' + tokenize(start, end, dtypes, freq,
                                          partition_freq, state_data)
     dsk = {(name, i): (make_timeseries_part, divisions[i], divisions[i + 1],
-                       dtypes, freq, state_data[i])
+                       dtypes, freq, state_data[i], kwargs)
            for i in range(len(divisions) - 1)}
-    head = make_timeseries_part('2000', '2000', dtypes, '1H', state_data[0])
+    head = make_timeseries_part('2000', '2000', dtypes, '1H', state_data[0], kwargs)
     return DataFrame(dsk, name, head, divisions)
 
 

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -2,6 +2,7 @@ import pandas.util.testing as tm
 import pandas as pd
 import pytest
 
+import dask
 import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq
 
@@ -64,3 +65,15 @@ def test_daily_stock():
     assert isinstance(df, dd.DataFrame)
     assert 10 < df.npartitions < 31
     assert_eq(df, df)
+
+
+def test_make_timeseries_keywords():
+    df = dd.demo.make_timeseries('2000', '2001', {'A': int, 'B': int, 'C': str},
+                                 freq='1D', partition_freq='6M', A_lam=1000000, B_lam=2)
+    a_cardinality = df.A.nunique()
+    b_cardinality = df.B.nunique()
+
+    aa, bb = dask.compute(a_cardinality, b_cardinality, scheduler='single-threaded')
+
+    assert 100 < aa <= 10000000
+    assert 1 < bb <= 100

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -77,3 +77,19 @@ def test_make_timeseries_keywords():
 
     assert 100 < aa <= 10000000
     assert 1 < bb <= 100
+
+
+def test_make_timeseries_fancy_keywords():
+    df = dd.demo.make_timeseries(
+        '2000', '2001',
+        {'A_B': int, 'B_': int, 'C': str},
+        freq='1D', partition_freq='6M',
+        A_B_lam=1000000, B__lam=2
+    )
+    a_cardinality = df.A_B.nunique()
+    b_cardinality = df.B_.nunique()
+
+    aa, bb = dask.compute(a_cardinality, b_cardinality, scheduler='single-threaded')
+
+    assert 100 < aa <= 10000000
+    assert 1 < bb <= 100

--- a/dask/datasets.py
+++ b/dask/datasets.py
@@ -12,6 +12,7 @@ def timeseries(
     partition_freq='1d',
     dtypes={'name': str, 'id': int, 'x': float, 'y': float},
     seed=None,
+    **kwargs
 ):
     """ Create timeseries dataframe with random data
 
@@ -30,6 +31,9 @@ def timeseries(
         String like '1M' or '2Y' to divide the dataframe into partitions
     seed : int (optional)
         Randomstate seed
+    kwargs:
+        Keywords to pass down to individual column creation functions.
+        Keywords should be prefixed by the column name and then an underscore.
 
     Examples
     --------
@@ -42,11 +46,17 @@ def timeseries(
     2000-01-01 00:00:02   988    Wendy -0.526331  0.128641
     2000-01-01 00:00:03  1016   Yvonne  0.620456  0.767270
     2000-01-01 00:00:04   998   Ursula  0.684902 -0.463278
+    >>> df = dask.datasets.timeseries(
+    ...     '2000', '2010',
+    ...     freq='2H', partition_freq='1D', seed=1,  # data frequency
+    ...     dtypes={'value': float, 'name': str, 'id': int},  # data types
+    ...     id_lam=1000  # control number of items in id column
+    ... )
     """
     from dask.dataframe.io.demo import make_timeseries
     return make_timeseries(start=start, end=end, freq=freq,
                            partition_freq=partition_freq,
-                           seed=seed, dtypes=dtypes)
+                           seed=seed, dtypes=dtypes, **kwargs)
 
 
 def _generate_mimesis(field, schema_description, records_per_partition, seed):


### PR DESCRIPTION
This is useful when testing join algorithms, sometimes we want different
cardinalities for integer columns.

To generalize this we now allow passing keyword arguments directly to
individual column creation functions using a convention similar to that
used by scikit-learn parameters.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
