### PR TITLE
add support in read_csv for parameter skiprows to not only be int or list (like in pandas)

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -300,11 +300,15 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
                          "`dd.{0}`. To achieve the same behavior, it's "
                          "recommended to use `dd.{0}(...)."
                          "head(n=nrows)`".format(reader_name))
-    if isinstance(kwargs.get('skiprows'), list):
+    if isinstance(kwargs.get('skiprows'), int):
+        skiprows = lastskiprow = firstrow = kwargs.get('skiprows')
+    elif kwargs.get('skiprows') is None:
+        skiprows = lastskiprow = firstrow = 0
+    elif not callable(kwargs.get('skiprows')):
         # When skiprows is a list, we expect more than max(skiprows) to
         # be included in the sample. This means that [0,2] will work well,
         # but [0, 440] might not work.
-        skiprows = kwargs.get('skiprows')
+        skiprows = set(kwargs.get('skiprows'))
         lastskiprow = max(skiprows)
         # find the firstrow that is not skipped, for use as header
         firstrow = min(set(range(len(skiprows) + 1)) - set(skiprows))

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -304,7 +304,7 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
         skiprows = lastskiprow = firstrow = kwargs.get('skiprows')
     elif kwargs.get('skiprows') is None:
         skiprows = lastskiprow = firstrow = 0
-    elif not callable(kwargs.get('skiprows')):
+    else:
         # When skiprows is a list, we expect more than max(skiprows) to
         # be included in the sample. This means that [0,2] will work well,
         # but [0, 440] might not work.
@@ -312,8 +312,6 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
         lastskiprow = max(skiprows)
         # find the firstrow that is not skipped, for use as header
         firstrow = min(set(range(len(skiprows) + 1)) - set(skiprows))
-    else:
-        skiprows = lastskiprow = firstrow = kwargs.get('skiprows', 0)
     if isinstance(kwargs.get('header'), list):
         raise TypeError("List of header rows not supported for "
                         "dd.{0}".format(reader_name))

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -431,6 +431,14 @@ def test_read_csv_index():
         assert_eq(result, expected)
 
 
+def test_read_csv_skiprows_range():
+    with filetext(csv_text) as fn:
+        f = dd.read_csv(fn, skiprows=range(5))
+        result = f.compute(scheduler='sync')
+        expected = pd.read_csv(fn, skiprows=range(5))
+        assert_eq(result, expected)
+
+
 def test_usecols():
     with filetext(timeseries) as fn:
         df = dd.read_csv(fn, blocksize=30, usecols=['High', 'Low'])

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -434,7 +434,7 @@ def test_read_csv_index():
 def test_read_csv_skiprows_range():
     with filetext(csv_text) as fn:
         f = dd.read_csv(fn, skiprows=range(5))
-        result = f.compute(scheduler='sync')
+        result = f
         expected = pd.read_csv(fn, skiprows=range(5))
         assert_eq(result, expected)
 


### PR DESCRIPTION
- The dask.dataframe.read_csv function now mimics more the behavior of
the pandas read_csv function
- The pandas read_csv function allows the
skiprows parameter to be of type range or set
- Also case when not assigning skiprows is now explicit

Test it out for yourself:
import dask.dataframe as dd
import pandas as pd
df = pd.read_csv("file.csv", skiprows=range(18)) # this works anyway
df = dd.read_csv("file.csv", skiprows=range(18)) # this works only after fix

- [x] Tests added / passed
- [x] Passes `flake8 dask`
