### PR TITLE
Fix CuPy tests or properly marks as xfail

### DIFF
--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -9,7 +9,7 @@ cupy = pytest.importorskip('cupy')
 
 functions = [
     lambda x: x,
-    pytest.mark.xfail(lambda x: da.expm1(x), reason="expm1 isn't a proper ufunc"),
+    lambda x: da.expm1(x),
     lambda x: 2 * x,
     lambda x: x / 2,
     lambda x: x**2,
@@ -21,22 +21,27 @@ functions = [
     lambda x: x.T,
     lambda x: da.transpose(x, (1, 2, 0)),
     lambda x: x.sum(),
-    pytest.mark.xfail(lambda x: x.dot(np.arange(x.shape[-1])), reason='cupy.dot(numpy) fails'),
-    pytest.mark.xfail(lambda x: x.dot(np.eye(x.shape[-1])), reason='cupy.dot(numpy) fails'),
-    pytest.mark.xfail(lambda x: da.tensordot(x, np.ones(x.shape[:2]), axes=[(0, 1), (0, 1)]),
-                      reason='cupy.dot(numpy) fails'),
+    pytest.param(lambda x: x.dot(np.arange(x.shape[-1])),
+                 marks=pytest.mark.xfail(reason='cupy.dot(numpy) fails')),
+    pytest.param(lambda x: x.dot(np.eye(x.shape[-1])),
+                 marks=pytest.mark.xfail(reason='cupy.dot(numpy) fails')),
+    pytest.param(lambda x: da.tensordot(x, np.ones(x.shape[:2]), axes=[(0, 1), (0, 1)]),
+                 marks=pytest.mark.xfail(reason='cupy.dot(numpy) fails')),
     lambda x: x.sum(axis=0),
     lambda x: x.max(axis=0),
     lambda x: x.sum(axis=(1, 2)),
     lambda x: x.astype(np.complex128),
     lambda x: x.map_blocks(lambda x: x * 2),
-    pytest.mark.xfail(lambda x: x.round(1), reason="cupy doesn't support round"),
+    pytest.param(lambda x: x.round(1),
+                 marks=pytest.mark.xfail(reason="cupy doesn't support round")),
     lambda x: x.reshape((x.shape[0] * x.shape[1], x.shape[2])),
     lambda x: abs(x),
     lambda x: x > 0.5,
     lambda x: x.rechunk((4, 4, 4)),
     lambda x: x.rechunk((2, 2, 1)),
-    lambda x: da.einsum("ijk,ijk", x, x)
+    pytest.param(lambda x: da.einsum("ijk,ijk", x, x),
+                 marks=pytest.mark.xfail(reason=
+                     'depends on resolution of https://github.com/numpy/numpy/issues/12974'))
 ]
 
 

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -40,8 +40,8 @@ functions = [
     lambda x: x.rechunk((4, 4, 4)),
     lambda x: x.rechunk((2, 2, 1)),
     pytest.param(lambda x: da.einsum("ijk,ijk", x, x),
-                 marks=pytest.mark.xfail(reason=
-                     'depends on resolution of https://github.com/numpy/numpy/issues/12974'))
+                 marks=pytest.mark.xfail(
+                     reason='depends on resolution of https://github.com/numpy/numpy/issues/12974'))
 ]
 
 


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
