### PR TITLE
Support setting the index

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3812,7 +3812,7 @@ def map_partitions(func, *args, **kwargs):
     if transform_divisions and isinstance(dfs[0], Index) and len(dfs) == 1:
         try:
             divisions = func(
-                *[pd.Index(arg.divisions) if arg is dfs[0] else arg for arg in args],
+                *[pd.Index(a.divisions) if a is dfs[0] else a for a in args],
                 **kwargs
             )
             if isinstance(divisions, pd.Index):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -390,13 +390,8 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
 
     @index.setter
     def index(self, value):
-        def f(df, ind):
-            df = df.copy()
-            df.index = ind
-            return df
-
         self.divisions = value.divisions
-        result = map_partitions(f, self, value)
+        result = map_partitions(methods.assign_index, self, value)
         self.dask = result.dask
         self._name = result._name
         self._meta = result._meta
@@ -3341,7 +3336,6 @@ for op in [operator.abs, operator.add, operator.and_, operator_div,
            operator.ne, operator.neg, operator.or_, operator.pow,
            operator.sub, operator.truediv, operator.floordiv, operator.xor]:
     _Frame._bind_operator(op)
-    Index._bind_operator(op)
     Scalar._bind_operator(op)
 
 for name in ['add', 'sub', 'mul', 'div',

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3387,6 +3387,7 @@ def elemwise(op, *args, **kwargs):
     """
     meta = kwargs.pop('meta', no_default)
     out = kwargs.pop('out', None)
+    transform_divisions = kwargs.pop('transform_divisions', False)
 
     _name = funcname(op) + '-' + tokenize(op, *args, **kwargs)
 
@@ -3412,7 +3413,7 @@ def elemwise(op, *args, **kwargs):
             dasks[i] = a
 
     divisions = dfs[0].divisions
-    if isinstance(dfs[0], Index) and len(dfs) == 1:
+    if transform_divisions and isinstance(dfs[0], Index) and len(dfs) == 1:
         try:
             divisions = op(
                 *[pd.Index(arg.divisions) if arg is dfs[0] else arg for arg in args],
@@ -3733,6 +3734,7 @@ def map_partitions(func, *args, **kwargs):
     """
     meta = kwargs.pop('meta', no_default)
     name = kwargs.pop('token', None)
+    transform_divisions = kwargs.pop('transform_divisions', False)
 
     # Normalize keyword arguments
     kwargs2 = {k: normalize_arg(v) for k, v in kwargs.items()}
@@ -3802,7 +3804,7 @@ def map_partitions(func, *args, **kwargs):
     )
 
     divisions = dfs[0].divisions
-    if isinstance(dfs[0], Index) and len(dfs) == 1:
+    if transform_divisions and isinstance(dfs[0], Index) and len(dfs) == 1:
         try:
             divisions = func(
                 *[pd.Index(arg.divisions) if arg is dfs[0] else arg for arg in args],

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3387,7 +3387,7 @@ def elemwise(op, *args, **kwargs):
     """
     meta = kwargs.pop('meta', no_default)
     out = kwargs.pop('out', None)
-    transform_divisions = kwargs.pop('transform_divisions', False)
+    transform_divisions = kwargs.pop('transform_divisions', True)
 
     _name = funcname(op) + '-' + tokenize(op, *args, **kwargs)
 
@@ -3734,7 +3734,7 @@ def map_partitions(func, *args, **kwargs):
     """
     meta = kwargs.pop('meta', no_default)
     name = kwargs.pop('token', None)
-    transform_divisions = kwargs.pop('transform_divisions', False)
+    transform_divisions = kwargs.pop('transform_divisions', True)
 
     # Normalize keyword arguments
     kwargs2 = {k: normalize_arg(v) for k, v in kwargs.items()}

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3383,6 +3383,11 @@ def elemwise(op, *args, **kwargs):
     meta: pd.DataFrame, pd.Series (optional)
         Valid metadata for the operation.  Will evaluate on a small piece of
         data if not provided.
+    transform_divisions: boolean
+        If the input is a ``dask.dataframe.Index`` we normally will also apply
+        the function onto the divisions and apply those transformed divisions
+        to the output.  You can pass ``transform_divisions=False`` to override
+        this behavior
 
     Examples
     --------

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -761,11 +761,11 @@ class _GroupBy(object):
 
         if isinstance(self.index, list):
             do_index_partition_align = all(
-                item.divisions == df.divisions if isinstance(item, Series) else True
+                item.npartitions == df.npartitions if isinstance(item, Series) else True
                 for item in self.index
             )
         elif isinstance(self.index, Series):
-            do_index_partition_align = df.divisions == self.index.divisions
+            do_index_partition_align = df.npartitions == self.index.npartitions
         else:
             do_index_partition_align = True
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -383,3 +383,9 @@ def concat_pandas(dfs, axis=0, join='outer', uniform=False, filter_warning=True)
     if ind is not None:
         out.index = ind
     return out
+
+
+def assign_index(df, ind):
+    df = df.copy()
+    df.index = ind
+    return df

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -211,7 +211,8 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32,
 
     partitions = index.map_partitions(partitioning_index,
                                       npartitions=npartitions or df.npartitions,
-                                      meta=pd.Series([0]))
+                                      meta=pd.Series([0]),
+                                      transform_divisions=False)
     df2 = df.assign(_partitions=partitions)
     df2._meta.index.name = df._meta.index.name
     df3 = rearrange_by_column(df2, '_partitions', npartitions=npartitions,

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -266,9 +266,10 @@ def get_cat(x):
     return x if isinstance(x, pd.CategoricalIndex) else x.cat
 
 
-def assert_array_index_eq(left, right):
+def assert_array_index_eq(left, right, check_divisions=False):
     """left and right are equal, treating index and array as equivalent"""
-    assert_eq(left, pd.Index(right) if isinstance(right, np.ndarray) else right)
+    assert_eq(left, pd.Index(right) if isinstance(right, np.ndarray) else
+            right, check_divisions=check_divisions)
 
 
 def test_return_type_known_categories():
@@ -291,7 +292,7 @@ class TestCategoricalAccessor:
         s, ds = series
         expected = getattr(get_cat(s), prop)
         result = getattr(get_cat(ds), prop)
-        compare(result, expected)
+        compare(result, expected, check_divisions=False)
 
     @pytest.mark.parametrize('series', cat_series)
     @pytest.mark.parametrize('method, kwargs', [
@@ -312,9 +313,11 @@ class TestCategoricalAccessor:
         s, ds = series
         expected = op(get_cat(s))
         result = op(get_cat(ds))
-        assert_eq(result, expected)
-        assert_eq(get_cat(result._meta).categories, get_cat(expected).categories)
-        assert_eq(get_cat(result._meta).ordered, get_cat(expected).ordered)
+        assert_eq(result, expected, check_divisions=False)
+        assert_eq(get_cat(result._meta).categories,
+                get_cat(expected).categories, check_divisions=False)
+        assert_eq(get_cat(result._meta).ordered, get_cat(expected).ordered,
+                check_divisions=False)
 
     def test_categorical_empty(self):
         # GH 1705

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -269,7 +269,7 @@ def get_cat(x):
 def assert_array_index_eq(left, right, check_divisions=False):
     """left and right are equal, treating index and array as equivalent"""
     assert_eq(left, pd.Index(right) if isinstance(right, np.ndarray) else
-            right, check_divisions=check_divisions)
+              right, check_divisions=check_divisions)
 
 
 def test_return_type_known_categories():
@@ -315,9 +315,9 @@ class TestCategoricalAccessor:
         result = op(get_cat(ds))
         assert_eq(result, expected, check_divisions=False)
         assert_eq(get_cat(result._meta).categories,
-                get_cat(expected).categories, check_divisions=False)
+                  get_cat(expected).categories, check_divisions=False)
         assert_eq(get_cat(result._meta).ordered, get_cat(expected).ordered,
-                check_divisions=False)
+                  check_divisions=False)
 
     def test_categorical_empty(self):
         # GH 1705

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3410,3 +3410,27 @@ def test_meta_error_message():
     assert 'Series' in str(info.value)
     assert 'DataFrame' in str(info.value)
     assert 'pandas' in str(info.value)
+
+
+def test_assign_index():
+    df = pd.DataFrame({'x': [1, 2, 3, 4, 5]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    ddf_copy = ddf.copy()
+
+    ddf.index = ddf.index * 10
+
+    expected = df.copy()
+    expected.index = expected.index * 10
+
+    assert_eq(ddf, expected)
+    assert_eq(ddf_copy, df)
+
+
+def test_index_divisions():
+    df = pd.DataFrame({'x': [1, 2, 3, 4, 5]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    assert_eq(ddf.index + 1, df.index + 1)
+    assert_eq(10 * ddf.index, 10 * df.index)
+    assert_eq(-ddf.index, -df.index)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -376,8 +376,9 @@ def test_series_groupby_errors():
         ss.groupby([])  # dask should raise the same error
     assert msg in str(err.value)
 
-    sss = dd.from_pandas(s, npartitions=3)
-    pytest.raises(NotImplementedError, lambda: ss.groupby(sss))
+    sss = dd.from_pandas(s, npartitions=5)
+    with pytest.raises(NotImplementedError):
+        ss.groupby(sss)
 
     with pytest.raises(KeyError):
         s.groupby('x')  # pandas

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -38,7 +38,6 @@ _BASE_UFUNCS = ['conj', 'exp', 'log', 'log2', 'log10', 'log1p',
                                       index=list('abcdefghijklmnopqrst'))])
 @pytest.mark.parametrize('ufunc', _BASE_UFUNCS)
 def test_ufunc(pandas_input, ufunc):
-
     dafunc = getattr(da, ufunc)
     npfunc = getattr(np, ufunc)
 

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -70,7 +70,8 @@ def test_ufunc(pandas_input, ufunc):
 
     with pytest.warns(None):
         assert isinstance(dafunc(dask_input.index), dd.Index)
-        assert_eq(dafunc(dask_input.index), npfunc(pandas_input.index))
+        assert_eq(dafunc(dask_input.index), npfunc(pandas_input.index),
+                  check_divisions=ufunc != 'spacing')
 
         # applying NumPy ufunc is lazy
         if isinstance(npfunc, np.ufunc) and np.__version__ >= '1.13.0':
@@ -78,7 +79,8 @@ def test_ufunc(pandas_input, ufunc):
         else:
             assert isinstance(npfunc(dask_input.index), pd.Index)
 
-        assert_eq(npfunc(dask_input.index), npfunc(dask_input.index))
+        assert_eq(npfunc(dask_input.index), npfunc(dask_input.index),
+                  check_divisions=ufunc != 'spacing')
 
     # applying Dask ufunc to normal Series triggers computation
     with pytest.warns(None):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import math
+import numbers
 import re
 import textwrap
 from distutils.version import LooseVersion
@@ -822,9 +823,13 @@ def valid_divisions(divisions):
     """
     if not isinstance(divisions, (tuple, list)):
         return False
-    for i in range(len(divisions) - 2):
-        if divisions[i] >= divisions[i + 1] or math.isnan(divisions[i]):
+
+    for i, x in enumerate(divisions[:-2]):
+        if x >= divisions[i + 1]:
             return False
+        if isinstance(x, numbers.Number) and math.isnan(x):
+            return False
+
     if divisions[-2] > divisions[-1]:
         return False
     return True

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -816,7 +816,11 @@ def valid_divisions(divisions):
     False
     >>> valid_divisions([0, 1, 1])
     True
+    >>> valid_divisions(123)
+    False
     """
+    if not isinstance(divisions, (tuple, list)):
+        return False
     for i in range(len(divisions) - 1):
         if divisions[i] >= divisions[i + 1]:
             return False

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import math
 import re
 import textwrap
 from distutils.version import LooseVersion
@@ -821,8 +822,8 @@ def valid_divisions(divisions):
     """
     if not isinstance(divisions, (tuple, list)):
         return False
-    for i in range(len(divisions) - 1):
-        if divisions[i] >= divisions[i + 1]:
+    for i in range(len(divisions) - 2):
+        if divisions[i] >= divisions[i + 1] or math.isnan(divisions[i]):
             return False
     if divisions[-2] > divisions[-1]:
         return False

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -801,3 +801,25 @@ def assert_max_deps(x, n, eq=True):
         assert max(map(len, dependencies.values())) == n
     else:
         assert max(map(len, dependencies.values())) <= n
+
+
+def valid_divisions(divisions):
+    """ Are the provided divisions valid?
+
+    Examples
+    --------
+    >>> valid_divisions([1, 2, 3])
+    True
+    >>> valid_divisions([3, 2, 1])
+    False
+    >>> valid_divisions([1, 1, 1])
+    False
+    >>> valid_divisions([0, 1, 1])
+    True
+    """
+    for i in range(len(divisions) - 1):
+        if divisions[i] >= divisions[i + 1]:
+            return False
+    if divisions[-2] > divisions[-1]:
+        return False
+    return True

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -728,9 +728,7 @@ def assert_dask_graph(dask, label):
 def assert_divisions(ddf):
     if not hasattr(ddf, 'divisions'):
         return
-    if not hasattr(ddf, 'index'):
-        return
-    if not ddf.known_divisions:
+    if not getattr(ddf, 'known_divisions', False):
         return
 
     def index(x):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -820,6 +820,8 @@ def valid_divisions(divisions):
     True
     >>> valid_divisions(123)
     False
+    >>> valid_divisions([0, float('nan'), 1])
+    False
     """
     if not isinstance(divisions, (tuple, list)):
         return False
@@ -830,6 +832,11 @@ def valid_divisions(divisions):
         if isinstance(x, numbers.Number) and math.isnan(x):
             return False
 
+    for x in divisions[-2:]:
+        if isinstance(x, numbers.Number) and math.isnan(x):
+            return False
+
     if divisions[-2] > divisions[-1]:
         return False
+
     return True


### PR DESCRIPTION
This PR does two things:

-  When we manipulate the index, change the divisions accordingly.  So for example `df.index * 10` has its divisions also multiplied by 10
-  Allow assignment of the index

(I'm happy to separate these changes if desired for review purposes)

The first change is more complex, and has some negative effects for situations like the following:

    df.groupby(df.index.dt.day)

Because now the grouper and the dataframe do not have matching divisions and so we'll either try to align them or raise an error (which is what happens today).  It's not clear what correct behavior is here.  This PR relaxes the check for aligned divisions to only ask that they have the same number of partitions, not that their division values are equivalent.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
