### PR TITLE
Issue/kwargs

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -113,12 +113,12 @@ def _execute_task(arg, cache, dsk=None):
     """
     if isinstance(arg, list):
         return [_execute_task(a, cache) for a in arg]
-    elif isinstance(arg, dict):
-        return {k: _execute_task(v, cache) for k, v in arg.items()}
     elif istask(arg):
         func, args = arg[0], arg[1:]
         args2 = [_execute_task(a, cache) for a in args]
         return func(*args2)
+    elif isinstance(arg, dict):
+        return {k: _execute_task(v, cache) for k, v in arg.items()}
     elif not ishashable(arg):
         return arg
     elif arg in cache:

--- a/dask/core.py
+++ b/dask/core.py
@@ -113,6 +113,8 @@ def _execute_task(arg, cache, dsk=None):
     """
     if isinstance(arg, list):
         return [_execute_task(a, cache) for a in arg]
+    elif isinstance(arg, dict):
+        return {k: _execute_task(v, cache) for k, v in arg.items()}
     elif istask(arg):
         func, args = arg[0], arg[1:]
         args2 = [_execute_task(a, cache) for a in args]

--- a/dask/tests/test_apply_kwargs.py
+++ b/dask/tests/test_apply_kwargs.py
@@ -1,0 +1,70 @@
+import dask
+from dask.compatibility import apply
+from dask import multiprocessing
+from dask import threaded
+from dask.distributed import Client
+import pytest
+
+def mult(*args, x, y=100):
+    return x * y
+
+@pytest.fixture(params=['distributed', 'multiprocessing', 'threaded', 'single-threaded'])
+def scheduler(request):
+    return request.param
+
+def test_apply_kwargs(scheduler):
+    """Test that kwargs can be passed where values are the results of other tasks if apply is used"""
+    dsk = {
+            'a': 10,
+            'b': 100,
+            'c': (apply, mult, [], {'x': 'a'}),
+    }
+
+    if scheduler == 'single-threaded':
+        get = dask.get
+        res = dict(zip(dsk.keys(), get(dsk, keys=list(dsk.keys()))))
+    elif scheduler == 'threaded':
+        get  = threaded.get
+        res = dict(zip(dsk.keys(), get(dsk, list(dsk.keys()))))
+    elif scheduler == 'multiprocessing':
+        get  = multiprocessing.get
+        res = dict(zip(dsk.keys(), get(dsk, keys=list(dsk.keys()))))
+    elif scheduler == 'distributed':
+        client = Client()
+        get = client.get
+        res = dict(zip(dsk.keys(), get(dsk, keys=list(dsk.keys()))))
+
+
+    assert 'a' in res
+    assert 'c' in res
+    assert res['b'] == 100
+    assert res['c'] == 1000
+
+
+def test_apply_kwargs_to_func_node(scheduler):
+    """Test that schedulers handle kwargs when a node is passed as function to apply"""
+    dsk = {
+            'a': 10,
+            'b': mult,
+            'c': (apply, 'b', [], {'x': 10}),
+    }
+
+    if scheduler == 'single-threaded':
+        get = dask.get
+        res = dict(zip(dsk.keys(), get(dsk, keys=list(dsk.keys()))))
+    elif scheduler == 'threaded':
+        get  = threaded.get
+        res = dict(zip(dsk.keys(), get(dsk, list(dsk.keys()))))
+    elif scheduler == 'multiprocessing':
+        get  = multiprocessing.get
+        res = dict(zip(dsk.keys(), get(dsk, keys=list(dsk.keys()))))
+    elif scheduler == 'distributed':
+        client = Client()
+        get = client.get
+        res = dict(zip(dsk.keys(), get(dsk, keys=list(dsk.keys()))))
+
+    assert 'a' in res
+    assert 'c' in res
+    assert res['b'] == mult
+    assert res['c'] == 1000
+


### PR DESCRIPTION
I added dict as arg type to core._execute_task. This allows compatibility.apply to accept kwargs where values are results of dependencies

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
