### PR TITLE
Pyarrow's get_metadata no longer requires open_file_func argument

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -700,9 +700,8 @@ def _read_pyarrow(fs, fs_token, paths, columns=None, filters=None,
     # Find non-empty pieces
     non_empty_pieces = []
     # Determine valid pieces
-    _open = lambda fn: pq.ParquetFile(fs.open(fn, mode='rb'))
     for piece in dataset.pieces:
-        pf = piece.get_metadata(_open)
+        pf = piece.get_metadata()
         # non_empty_pieces.append(piece)
         if pf.num_row_groups > 0:
             non_empty_pieces.append(piece)
@@ -838,7 +837,7 @@ def _get_pyarrow_divisions(pa_pieces, divisions_name, pa_schema, infer_divisions
         # Initialize index of divisions column within the row groups.
         # To be computed during while processing the first piece below
         for piece in pa_pieces:
-            pf = piece.get_metadata(pq.ParquetFile)
+            pf = piece.get_metadata()
             rg = pf.row_group(0)
 
             # Compute division column index

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -812,7 +812,6 @@ def _get_pyarrow_divisions(pa_pieces, divisions_name, pa_schema, infer_divisions
     """
     # Local imports
     import pyarrow as pa
-    import pyarrow.parquet as pq
 
     if infer_divisions is True and pa.__version__ < LooseVersion('0.9.0'):
         raise NotImplementedError('infer_divisions=True requires pyarrow >=0.9.0')


### PR DESCRIPTION
The following arrow [commit](https://github.com/apache/arrow/commit/f2fb02b82b60ba9a90c8bad6e5b11e37fc3ea9d3#diff-211255c3faff2b62de57e1dca9f60e13) has broken the dask [integration test](https://travis-ci.org/kszucs/crossbow/builds/505712978#L5878). It is going to be shipped in the 0.13 release.

cc @wesm 

- [x] Tests added / passed
- [x] Passes `flake8 dask`

To test check this PR out locally, then:

```
$ git clone https://github.com/apache/arrow
$ cd arrow
$ docker-compose build cpp
$ docker-compose build python
$ docker-compose build dask-integration
$ docker-compose run -v /local/path/to/dask:/dask dask-integration bash

# pip install -e dask
# arrow/ci/docker_build_cpp.sh && \
  arrow/ci/docker_build_python.sh && \
  arrow/integration/dask/runtest.sh
```
