### PR TITLE
DataFrame.itertuples accepts index, name kwargs

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2990,10 +2990,10 @@ class DataFrame(_Frame):
                 yield row
 
     @derived_from(pd.DataFrame)
-    def itertuples(self, **kwargs):
+    def itertuples(self, index=True, name='Pandas'):
         for i in range(self.npartitions):
             df = self.get_partition(i).compute()
-            for row in df.itertuples(**kwargs):
+            for row in df.itertuples(index=index, name=name):
                 yield row
 
     @classmethod

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2990,10 +2990,10 @@ class DataFrame(_Frame):
                 yield row
 
     @derived_from(pd.DataFrame)
-    def itertuples(self):
+    def itertuples(self, **kwargs):
         for i in range(self.npartitions):
             df = self.get_partition(i).compute()
-            for row in df.itertuples():
+            for row in df.itertuples(**kwargs):
                 yield row
 
     @classmethod

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2423,6 +2423,22 @@ def test_dataframe_itertuples():
         assert a == b
 
 
+def test_dataframe_itertuples_with_index_false():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    for (a, b) in zip(df.itertuples(index=False), ddf.itertuples(index=False)):
+        assert a == b
+
+
+def test_dataframe_itertuples_with_name_none():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    for (a, b) in zip(df.itertuples(name=None), ddf.itertuples(name=None)):
+        assert a == b
+
+
 def test_astype():
     df = pd.DataFrame({'x': [1, 2, 3, None], 'y': [10, 20, 30, 40]},
                       index=[10, 20, 30, 40])

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2437,6 +2437,7 @@ def test_dataframe_itertuples_with_name_none():
 
     for (a, b) in zip(df.itertuples(name=None), ddf.itertuples(name=None)):
         assert a == b
+        assert type(a) is type(b)
 
 
 def test_astype():


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

The dask documentation http://docs.dask.org/en/latest/dataframe-api.html#dask.dataframe.DataFrame.itertuples suggests that `DataFrame.itertuples` accepts kwargs `index` and `name` like pandas dataframes. 

This PR makes one small change to add this functionality, and adds the appropriate tests. 