### PR TITLE
Warn if partitions overlap in compute_divisions

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import math
 from operator import getitem
 import uuid
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -537,7 +538,7 @@ def compute_divisions(df, **kwargs):
                          mins, maxes)
 
     if any(a >= b for a, b in zip(maxes[:1], mins[1:])):
-        raise ValueError("Partitions must not overlap.")
+        warnings.warn("Partition indices have overlap.")
 
     divisions = tuple(mins) + (list(maxes)[-1],)
     return divisions

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -536,5 +536,8 @@ def compute_divisions(df, **kwargs):
         raise ValueError("Partitions must be sorted ascending with the index",
                          mins, maxes)
 
+    if any(a >= b for a, b in zip(maxes[:1], mins[1:])):
+        raise ValueError("Partitions must not overlap.")
+
     divisions = tuple(mins) + (list(maxes)[-1],)
     return divisions

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -670,7 +670,7 @@ def test_set_index_on_empty():
 def test_compute_divisions():
     from dask.dataframe.shuffle import compute_divisions
     df = pd.DataFrame({'x': [1, 2, 3, 4],
-                       'y': [10, 20, 30, 40],
+                       'y': [10, 20, 20, 40],
                        'z': [4, 3, 2, 1]},
                       index=[1, 3, 10, 20])
     a = dd.from_pandas(df, 2, sort=False)
@@ -682,6 +682,11 @@ def test_compute_divisions():
 
     assert_eq(a, b, check_divisions=False)
     assert b.known_divisions
+
+    c = dd.from_pandas(df.set_index('y'), 2, sort=False)
+    # Partitions must not overlap
+    with pytest.raises(ValueError):
+        compute_divisions(c)
 
 
 def test_temporary_directory(tmpdir):

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -602,7 +602,7 @@ def test_set_index_sorted_true():
     with pytest.raises(ValueError):
         a.set_index(a.z, sorted=True)
 
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         a.set_index(a.y, sorted=True)
 
 
@@ -687,8 +687,8 @@ def test_compute_divisions():
     assert b.known_divisions
 
     c = dd.from_pandas(df.set_index('y'), 2, sort=False)
-    # Partitions must not overlap
-    with pytest.raises(ValueError):
+    # Partitions overlap warning
+    with pytest.warns(UserWarning):
         compute_divisions(c)
 
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -582,7 +582,7 @@ def test_set_index_raises_error_on_bad_input():
 
 def test_set_index_sorted_true():
     df = pd.DataFrame({'x': [1, 2, 3, 4],
-                       'y': [10, 20, 30, 40],
+                       'y': [10, 20, 20, 40],
                        'z': [4, 3, 2, 1]})
     a = dd.from_pandas(df, 2, sort=False)
     assert not a.known_divisions
@@ -601,6 +601,9 @@ def test_set_index_sorted_true():
 
     with pytest.raises(ValueError):
         a.set_index(a.z, sorted=True)
+
+    with pytest.raises(ValueError):
+        a.set_index(a.y, sorted=True)
 
 
 def test_set_index_sorted_single_partition():


### PR DESCRIPTION
This is my suggestion from #4591. Let me know if you think this is worth adding.