### PR TITLE
Avoid YAML deprecation

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -6,13 +6,8 @@ import sys
 import threading
 try:
     import yaml
-    from distutils.version import LooseVersion
-    if yaml.__version__ >= LooseVersion('5.1'):
-        yaml_load = yaml.safe_load
-    else:
-        yaml_load = yaml.load
 except ImportError:
-    yaml = yaml_load = None
+    yaml = None
 
 from .compatibility import makedirs, builtins, Mapping, string_types
 
@@ -170,7 +165,7 @@ def collect_yaml(paths=paths):
     for path in file_paths:
         try:
             with open(path) as f:
-                data = yaml_load(f.read()) or {}
+                data = yaml.safe_load(f.read()) or {}
                 data = normalize_nested_keys(data)
                 configs.append(data)
         except (OSError, IOError):

--- a/dask/config.py
+++ b/dask/config.py
@@ -6,8 +6,13 @@ import sys
 import threading
 try:
     import yaml
+    from distutils.version import LooseVersion
+    if yaml.__version__ >= LooseVersion('5.1'):
+        yaml_load = yaml.safe_load
+    else:
+        yaml_load = yaml.load
 except ImportError:
-    yaml = None
+    yaml = yaml_load = None
 
 from .compatibility import makedirs, builtins, Mapping, string_types
 
@@ -165,7 +170,7 @@ def collect_yaml(paths=paths):
     for path in file_paths:
         try:
             with open(path) as f:
-                data = yaml.load(f.read()) or {}
+                data = yaml_load(f.read()) or {}
                 data = normalize_nested_keys(data)
                 configs.append(data)
         except (OSError, IOError):


### PR DESCRIPTION
Fixes #4597

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
