### PR TITLE
Add zarr to CI environment

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -61,7 +61,8 @@ conda install -q -c conda-forge \
     scikit-learn \
     scipy \
     sqlalchemy \
-    toolz
+    toolz \
+    zarr
 
 pip install --upgrade --no-deps locket git+https://github.com/dask/partd
 pip install --upgrade --no-deps git+https://github.com/dask/zict

--- a/continuous_integration/travis/run_tests.sh
+++ b/continuous_integration/travis/run_tests.sh
@@ -13,7 +13,3 @@ else
     echo "py.test dask --runslow $XTRATESTARGS"
     py.test dask --runslow $XTRATESTARGS
 fi
-
-# This needs to be enabled to test __array_function__ protocol with
-# NumPy v1.16.x, enabled by default starting in v1.17
-export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3452,7 +3452,7 @@ def test_zarr_return_stored(compute):
         a = da.zeros((3, 3), chunks=(1, 1))
         a2 = a.to_zarr(d, compute=compute, return_stored=True)
         assert isinstance(a2, Array)
-        assert_eq(a, a2)
+        assert_eq(a, a2, check_graph=False)
         assert a2.chunks == a.chunks
 
 


### PR DESCRIPTION
This PR adds `zarr` to the CI test environment. Right now all `zarr`-related tests are being skipped (see for example https://travis-ci.org/dask/dask/jobs/507332049#L2190-L2193).

While running tests with `zarr` installed locally, `dask/array/tests/test_array_core.py::test_zarr_return_stored[False]` fails. 

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
