### PR TITLE
Fix CI and add set -e

### DIFF
--- a/continuous_integration/travis/run_tests.sh
+++ b/continuous_integration/travis/run_tests.sh
@@ -16,3 +16,5 @@ else
     echo "py.test dask --runslow $XTRATESTARGS"
     py.test dask --runslow $XTRATESTARGS
 fi
+
+set +e

--- a/continuous_integration/travis/run_tests.sh
+++ b/continuous_integration/travis/run_tests.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -e
+
 # Need to make test order deterministic when parallelizing tests, hence PYTHONHASHSEED
 # (see https://github.com/pytest-dev/pytest-xdist/issues/63)
 if [[ $PARALLEL == 'true' ]]; then
@@ -13,7 +16,3 @@ else
     echo "py.test dask --runslow $XTRATESTARGS"
     py.test dask --runslow $XTRATESTARGS
 fi
-
-# This needs to be enabled to test __array_function__ protocol with
-# NumPy v1.16.x, enabled by default starting in v1.17
-export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1


### PR DESCRIPTION
This PR removes `export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1` in `continuous_integration/travis/run_tests.sh` which was causing Travis CI builds to pass regardless if there were failed tests. For reference, see https://github.com/dask/dask/pull/4525#issuecomment-473416578 and the comment that follows. 

Also added `set -e` to fail immediately. 

cc @mrocklin @pentschev 
