### PR TITLE
Check object for name/dtype attributes rather than type

### DIFF
--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -514,8 +514,8 @@ def is_dataframe_like(df):
     """ Looks like a Pandas DataFrame """
     typ = type(df)
     return (all(hasattr(typ, name)
-                for name in ('dtypes', 'groupby', 'head', 'merge', 'mean'))
-            and not
+                for name in ('groupby', 'head', 'merge', 'mean')) and
+            all(hasattr(df, name) for name in ('dtypes',)) and not
             any(hasattr(typ, name)
                 for name in ('value_counts', 'dtype')))
 
@@ -523,15 +523,15 @@ def is_dataframe_like(df):
 def is_series_like(s):
     """ Looks like a Pandas Series """
     typ = type(s)
-    return (all(hasattr(typ, name)
-                for name in ('name', 'dtype', 'groupby', 'head', 'mean'))
-            and 'index' not in typ.__name__.lower())
+    return (all(hasattr(typ, name) for name in ('groupby', 'head', 'mean')) and
+            all(hasattr(s, name) for name in ('dtype', 'name')) and
+            'index' not in typ.__name__.lower())
 
 
 def is_index_like(s):
     """ Looks like a Pandas Index """
     typ = type(s)
-    return (all(hasattr(typ, name) for name in ('name', 'dtype'))
+    return (all(hasattr(s, name) for name in ('name', 'dtype'))
             and 'index' in typ.__name__.lower())
 
 


### PR DESCRIPTION
This is to help cudf, which handles things like Series.name as an
attribute rather than as a computed property.  This seems reasonable
generally.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
