### PR TITLE
Add 'threshold' parameter to pd.DataFrame.dropna

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2787,7 +2787,7 @@ class DataFrame(_Frame):
 
     @derived_from(pd.DataFrame)
     def dropna(self, how='any', subset=None, thresh=None):
-        return self.map_partitions(M.dropna, how=how, subset=subset, thresh=None)
+        return self.map_partitions(M.dropna, how=how, subset=subset, thresh=thresh)
 
     @derived_from(pd.DataFrame)
     def clip(self, lower=None, upper=None, out=None):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2786,8 +2786,8 @@ class DataFrame(_Frame):
         return self.map_partitions(M.eval, expr, meta=meta, inplace=inplace, **kwargs)
 
     @derived_from(pd.DataFrame)
-    def dropna(self, how='any', subset=None):
-        return self.map_partitions(M.dropna, how=how, subset=subset)
+    def dropna(self, how='any', subset=None, thresh=None):
+        return self.map_partitions(M.dropna, how=how, subset=subset, thresh=None)
 
     @derived_from(pd.DataFrame)
     def clip(self, lower=None, upper=None, out=None):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -392,7 +392,7 @@ def test_cumulative():
 def test_dropna():
     df = pd.DataFrame({'x': [np.nan, 2, 3, 4, np.nan, 6],
                        'y': [1, 2, np.nan, 4, np.nan, np.nan],
-                       'z': [1, 2, 3, 4, np.nan, np.nan]},
+                       'z': [1, 2, 3, 4, np.nan, 6]},
                       index=[10, 20, 30, 40, 50, 60])
     ddf = dd.from_pandas(df, 3)
 
@@ -406,6 +406,22 @@ def test_dropna():
     assert_eq(ddf.dropna(subset=['y', 'z']), df.dropna(subset=['y', 'z']))
     assert_eq(ddf.dropna(subset=['y', 'z'], how='all'),
               df.dropna(subset=['y', 'z'], how='all'))
+
+    # threshold
+    assert_eq(df.dropna(thresh=None), df.loc[[20, 40]])
+    assert_eq(ddf.dropna(thresh=None), df.dropna(thresh=None))
+
+    assert_eq(df.dropna(thresh=0), df.loc[:])
+    assert_eq(ddf.dropna(thresh=0), df.dropna(thresh=0))
+
+    assert_eq(df.dropna(thresh=1), df.loc[[10, 20, 30, 40, 60]])
+    assert_eq(ddf.dropna(thresh=1), df.dropna(thresh=1))
+
+    assert_eq(df.dropna(thresh=2), df.loc[[10, 20, 30, 40, 60]])
+    assert_eq(ddf.dropna(thresh=2), df.dropna(thresh=2))
+
+    assert_eq(df.dropna(thresh=3), df.loc[[20, 40]])
+    assert_eq(ddf.dropna(thresh=3), df.dropna(thresh=3))
 
 
 @pytest.mark.parametrize('lower, upper', [(2, 5), (2.5, 3.5)])


### PR DESCRIPTION
dask.DataFrame.dropna is missing the [ "thresh" ](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.dropna.html) parameter.

The [dask documentation](http://docs.dask.org/en/latest/dataframe-api.html#dask.dataframe.DataFrame.dropna) includes it in the explanation but it doesn't seem to have been implemented.

As an aside, the docs also mention the "subset" parameter. However, I believe passing this through may cause unexpected behavior with the underlying metadata, we may want to remove it from the documentation.