### PR TITLE
Allow sample to be False when reading CSV from a remote URL.

### DIFF
--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -48,7 +48,7 @@ def read_bytes(urlpath, delimiter=None, not_zero=False, blocksize="128 MiB",
         Chunk size in bytes, defaults to "128 MiB"
     compression : string or None
         String like 'gzip' or 'xz'.  Must support efficient random access.
-    sample : int or string
+    sample : int, string, or boolean
         Whether or not to return a header sample.
         Values can be ``False`` for "no sample requested"
         Or an integer or string value like ``2**20`` or ``"1 MiB"``

--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -112,7 +112,7 @@ class HTTPFile(object):
                                   **self.kwargs)
         except ValueError:
             # No size information - only allow read() and no seek()
-            self.size = None
+            self.size = None  # pragma: no cover
         except requests.HTTPError as err:
             # If we got an HTTP error, it may be due to HEAD being unsupported,
             # or it may be due to server/permissions/not-found errors. In the former
@@ -120,7 +120,7 @@ class HTTPFile(object):
             code = err.response.status_code
             if code >= 500 or code in (401, 403, 404):
                 raise err
-            self.size = None
+            self.size = None  # pragma: no cover
 
         self.cache = None
         self.closed = False

--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -110,7 +110,7 @@ class HTTPFile(object):
         try:
             self.size = file_size(url, self.session, allow_redirects=True,
                                   **self.kwargs)
-        except ValueError:
+        except (ValueError, requests.HTTPError):
             # No size information - only allow read() and no seek()
             self.size = None
         self.cache = None

--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -110,9 +110,18 @@ class HTTPFile(object):
         try:
             self.size = file_size(url, self.session, allow_redirects=True,
                                   **self.kwargs)
-        except (ValueError, requests.HTTPError):
+        except ValueError:
             # No size information - only allow read() and no seek()
             self.size = None
+        except requests.HTTPError as err:
+            # If we got an HTTP error, it may be due to HEAD being unsupported,
+            # or it may be due to server/permissions/not-found errors. In the former
+            # case we disable read() and seek(), in the latter we re-raise.
+            code = err.response.status_code
+            if code >= 500 or code in (401, 403, 404):
+                raise err
+            self.size = None
+
         self.cache = None
         self.closed = False
         self.start = None

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -158,6 +158,12 @@ def test_parse_sample_bytes():
         assert len(sample) == 40
 
 
+def test_read_bytes_no_sample():
+    with filetexts(files, mode='b'):
+        sample, _ = read_bytes('.test.accounts.1.json', sample=False)
+        assert sample is False
+
+
 def test_read_bytes_blocksize_none():
     with filetexts(files, mode='b'):
         sample, values = read_bytes('.test.accounts.*', blocksize=None)

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -332,7 +332,7 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
     if compression not in seekable_files and compression not in cfiles:
         raise NotImplementedError("Compression format %s not installed" %
                                   compression)
-    if blocksize and blocksize < sample and lastskiprow != 0:
+    if blocksize and sample and blocksize < sample and lastskiprow != 0:
         warn("Unexpected behavior can result from passing skiprows when\n"
              "blocksize is smaller than sample size.\n"
              "Setting ``sample=blocksize``")
@@ -356,6 +356,10 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
 
     if not isinstance(values[0], (tuple, list)):
         values = [values]
+    # If we have not sampled, then use the first row of the first values
+    # as a representative sample.
+    if b_sample is False and len(values[0]):
+        b_sample = values[0][0].compute()
 
     # Get header row, and check that sample is long enough. If the file
     # contains a header row, we need at least 2 nonempty rows + the number of

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -371,7 +371,7 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
     # If the last partition is empty, don't count it
     nparts = 0 if not parts else len(parts) - int(not parts[-1])
 
-    if nparts < lastskiprow + need and len(b_sample) >= sample:
+    if sample is not False and nparts < lastskiprow + need and len(b_sample) >= sample:
         raise ValueError("Sample is not large enough to include at least one "
                          "row of data. Please increase the number of bytes "
                          "in `sample` in the call to `read_csv`/`read_table`")

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -621,6 +621,12 @@ def test_empty_csv_file():
         assert list(df.columns) == ['a', 'b']
 
 
+def test_read_csv_no_sample():
+    with filetexts(csv_files, mode='b') as fn:
+        df = dd.read_csv(fn, sample=False)
+        assert list(df.columns) == ['name', 'amount', 'id']
+
+
 def test_read_csv_sensitive_to_enforce():
     with filetexts(csv_files, mode='b'):
         a = dd.read_csv('2014-01-*.csv', enforce=True)


### PR DESCRIPTION
This allows `blocksize=None`, `sample=False` to be passed into `dd.read_csv`, which allows the user to load a CSV from a remote URL in one go. This is useful if the remote doesn't support HEAD or range requests.

Fixes #4633 

- [ ] Tests added / passed
- [x] Passes `flake8 dask`
