### PR TITLE
Fix divisions when joining two single-partition dataframes

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -284,7 +284,7 @@ def single_partition_join(left, right, **kwargs):
 
     meta = left._meta_nonempty.merge(right._meta_nonempty, **kwargs)
     name = 'merge-' + tokenize(left, right, **kwargs)
-    if left.npartitions == 1:
+    if left.npartitions == 1 and kwargs['how'] in ('inner', 'right'):
         left_key = first(left.__dask_keys__())
         dsk = {(name, i): (apply, M.merge, [left_key, right_key], kwargs)
                for i, right_key in enumerate(right.__dask_keys__())}
@@ -295,7 +295,7 @@ def single_partition_join(left, right, **kwargs):
         else:
             divisions = [None for _ in right.divisions]
 
-    elif right.npartitions == 1:
+    elif right.npartitions == 1 and kwargs['how'] in ('inner', 'left'):
         right_key = first(right.__dask_keys__())
         dsk = {(name, i): (apply, M.merge, [left_key, right_key], kwargs)
                for i, left_key in enumerate(left.__dask_keys__())}

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -305,6 +305,8 @@ def single_partition_join(left, right, **kwargs):
             divisions = left.divisions
         else:
             divisions = [None for _ in left.divisions]
+    else:
+        raise NotImplementedError("single_partition_join has no fallback for invalid calls")
 
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[left, right])
     return new_dd_object(graph, name, meta, divisions)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -199,7 +199,6 @@ def list_eq(aa, bb):
     else:
         b = bb
     tm.assert_index_equal(a.columns, b.columns)
-    # tm.assert_index_equal(a.index, b.index)  # Shouldn't this be a requirement?
 
     if isinstance(a, pd.DataFrame):
         av = a.sort_values(list(a.columns)).values

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -192,12 +192,18 @@ def test_merge_indexed_dataframe_to_indexed_dataframe():
 def list_eq(aa, bb):
     if isinstance(aa, dd.DataFrame):
         a = aa.compute(scheduler='sync')
+        a_index = aa.index.compute(scheduler='sync')
     else:
         a = aa
+        a_index = aa.index
     if isinstance(bb, dd.DataFrame):
         b = bb.compute(scheduler='sync')
+        b_index = bb.index.compute(scheduler='sync')
     else:
         b = bb
+        b_index = bb.index
+
+    tm.assert_numpy_array_equal(a_index.values, b_index.values)
     tm.assert_index_equal(a.columns, b.columns)
 
     if isinstance(a, pd.DataFrame):
@@ -367,7 +373,11 @@ def test_merge(how, shuffle):
                      suffixes=('1', '2'), shuffle=shuffle),
             pd.merge(A, B, left_on='x', right_index=True, how=how,
                      suffixes=('1', '2')))
-
+    # print("  --  ")
+    # print(dd.merge(a, b, left_on='x', right_index=True, how=how,
+    #                  suffixes=('1', '2'), shuffle=shuffle).index.compute())
+    # print(pd.merge(A, B, left_on='x', right_index=True, how=how,
+    #          suffixes=('1', '2')).index)
     # pandas result looks buggy
     # list_eq(dd.merge(a, B, left_index=True, right_on='y'),
     #         pd.merge(A, B, left_index=True, right_on='y'))

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -194,13 +194,12 @@ def list_eq(aa, bb):
         a = aa.compute(scheduler='sync')
     else:
         a = aa
-
     if isinstance(bb, dd.DataFrame):
         b = bb.compute(scheduler='sync')
     else:
         b = bb
-
     tm.assert_index_equal(a.columns, b.columns)
+    # tm.assert_index_equal(a.index, b.index)  # Shouldn't this be a requirement?
 
     if isinstance(a, pd.DataFrame):
         av = a.sort_values(list(a.columns)).values
@@ -369,11 +368,7 @@ def test_merge(how, shuffle):
                      suffixes=('1', '2'), shuffle=shuffle),
             pd.merge(A, B, left_on='x', right_index=True, how=how,
                      suffixes=('1', '2')))
-    # print("  --  ")
-    # print(dd.merge(a, b, left_on='x', right_index=True, how=how,
-    #                  suffixes=('1', '2'), shuffle=shuffle).index.compute())
-    # print(pd.merge(A, B, left_on='x', right_index=True, how=how,
-    #          suffixes=('1', '2')).index)
+
     # pandas result looks buggy
     # list_eq(dd.merge(a, B, left_index=True, right_on='y'),
     #         pd.merge(A, B, left_index=True, right_on='y'))


### PR DESCRIPTION
There was an error where if `npartition=1` for both `left` and `right` on a merge, then the check inside of `single_partition_join` would short to using the `right` divisions, even if it was supposed to be `left` table's divisions that are used.

- [x] Tests added / passed
- [x] Passes `flake8 dask`

Note: the test I added first validated the bug (on previous code), and then was resolved with the fix in `single_partition_join`

This answers the bug identified in https://github.com/dask/dask/issues/4617