### PR TITLE
Give informative meta= warning

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4751,7 +4751,7 @@ def meta_warning(df):
            "It is possible that Dask will guess incorrectly.\n"
            "To provide an explicit output types or to silence this message, "
            "please provide the `meta=` keyword, as described in the map or "
-           "apply function that you are using..")
+           "apply function that you are using.")
     if meta_str:
         msg += ("\n"
                 "  Before: .apply(func)\n"

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2117,6 +2117,12 @@ def test_apply_warns():
         ddf.apply(func, axis=1, meta=(None, int))
     assert len(w) == 0
 
+    with pytest.warns(UserWarning) as w:
+        ddf.apply(lambda x: x, axis=1)
+    assert len(w) == 1
+    assert "'x'" in str(w[0].message)
+    assert "int64" in str(w[0].message)
+
 
 def test_applymap():
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})


### PR DESCRIPTION
Often users get hung up on how exactly to create meta= objects when
using UDF functions like map/apply/...

They don't need to, we can figure it out for them, but sometimes they
like to silence these warnings.  Now we provide the correct result in
the warning message itself.

Originally raised in https://stackoverflow.com/questions/55363496/dask-dataframe-defining-meta-for-date-diff-in-groubpy

Example
-------

```python
In [1]: import dask

In [2]: df = dask.datasets.timeseries()

In [3]: df.apply(lambda x: x, axis=1)
/Users/mrocklin/workspace/dask/dask/dataframe/core.py:3144: UserWarning:
You did not provide metadata, so Dask is running your function on a small dataset to guess output types. It is possible that Dask will guess incorrectly.
To provide an explicit output types or to silence this message, please provide the `meta=` keyword, as described in the map or apply function that you are using..
  Before: .apply(func)
  After:  .apply(func, meta={'id': 'int64', 'name': 'object', 'x': 'float64', 'y': 'float64'})

  warnings.warn(meta_warning(meta))
Out[3]:
Dask DataFrame Structure:
                   id    name        x        y
npartitions=30
2000-01-01      int64  object  float64  float64
2000-01-02        ...     ...      ...      ...
...               ...     ...      ...      ...
2000-01-30        ...     ...      ...      ...
2000-01-31        ...     ...      ...      ...
Dask Name: apply, 60 tasks
```

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
