### PR TITLE
correct to_parquet example in docs

### DIFF
--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -1203,7 +1203,7 @@ def to_parquet(df, path, engine='auto', compression='default', write_index=None,
     Examples
     --------
     >>> df = dd.read_csv(...)  # doctest: +SKIP
-    >>> to_parquet('/path/to/output/', df, compression='snappy')  # doctest: +SKIP
+    >>> dd.to_parquet(df, '/path/to/output/', compression='snappy')  # doctest: +SKIP
 
     See Also
     --------


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `flake8 dask`

I've updated the example in the `to_parquet` to be correct. Also, seems to be getting skipped in doctesting - should I remove skip comments?
