### PR TITLE
correct quantile to handle unsorted quantiles

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3946,11 +3946,13 @@ def quantile(df, q):
     q : list/array of floats
         Iterable of numbers ranging from 0 to 100 for the desired quantiles
     """
-    # current implementation needs q to be sorted, sort to make sure
-    q = np.asanyarray(q)
-    if q.ndim > 0:
-        q = np.sort(q, kind='mergesort')
-        
+    # current implementation needs q to be sorted so 
+    # sort if array-like, otherwise leave it alone
+    q_ndarray = np.array(q)
+    if q_ndarray.ndim > 0:
+        q_ndarray.sort(kind='mergesort')
+        q = q_ndarray
+
     assert isinstance(df, Series)
     from dask.array.percentile import _percentile, merge_percentiles
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3946,6 +3946,11 @@ def quantile(df, q):
     q : list/array of floats
         Iterable of numbers ranging from 0 to 100 for the desired quantiles
     """
+    # current implementation needs qs to be sorted, sort in-place to make sure
+    q = np.asanyarray(q)
+    if q.ndim > 0:
+        q.sort(kind='mergesort')
+        
     assert isinstance(df, Series)
     from dask.array.percentile import _percentile, merge_percentiles
 
@@ -3967,9 +3972,7 @@ def quantile(df, q):
 
     # pandas uses quantile in [0, 1]
     # numpy / everyone else uses [0, 100]
-    # current implementation needs qs to be sorted, sort in-place to make sure
     qs = np.asarray(q) * 100
-    qs.sort(kind='mergesort')
     token = tokenize(df, qs)
 
     if len(qs) == 0:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3967,7 +3967,9 @@ def quantile(df, q):
 
     # pandas uses quantile in [0, 1]
     # numpy / everyone else uses [0, 100]
+    # current implementation needs qs to be sorted, sort in-place to make sure
     qs = np.asarray(q) * 100
+    qs.sort(kind='mergesort')
     token = tokenize(df, qs)
 
     if len(qs) == 0:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3946,7 +3946,7 @@ def quantile(df, q):
     q : list/array of floats
         Iterable of numbers ranging from 0 to 100 for the desired quantiles
     """
-    # current implementation needs q to be sorted so 
+    # current implementation needs q to be sorted so
     # sort if array-like, otherwise leave it alone
     q_ndarray = np.array(q)
     if q_ndarray.ndim > 0:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3946,10 +3946,10 @@ def quantile(df, q):
     q : list/array of floats
         Iterable of numbers ranging from 0 to 100 for the desired quantiles
     """
-    # current implementation needs qs to be sorted, sort in-place to make sure
+    # current implementation needs q to be sorted, sort to make sure
     q = np.asanyarray(q)
     if q.ndim > 0:
-        q.sort(kind='mergesort')
+        q = np.sort(q, kind='mergesort')
         
     assert isinstance(df, Series)
     from dask.array.percentile import _percentile, merge_percentiles

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -896,6 +896,23 @@ def test_dataframe_quantile():
     assert_eq(ddf.quantile(axis=1), df.quantile(axis=1))
     pytest.raises(ValueError, lambda: ddf.quantile([0.25, 0.75], axis=1))
 
+    
+def test_quantile_for_possibly_unsorted_q():
+    '''check that quantile is giving correct answers even when quantile parameter, q, may be unsorted.
+    
+    See https://github.com/dask/dask/issues/4642.
+    '''
+    # prepare test case where percentiles should equal values
+    A = da.arange(0, 101)
+    ds = dd.from_dask_array(A)
+    
+    for q in [[0.25, 0.50, 0.75], [0.25, 0.50, 0.75, 0.99], [0.75, 0.5, 0.25],
+             [0.25, 0.99, 0.75, 0.50]]:
+        r = ds.quantile(q).compute()
+        assert_eq(r.loc[0.25], 25.0)
+        assert_eq(r.loc[0.50], 50.0)
+        assert_eq(r.loc[0.75], 75.0)
+        
 
 def test_index():
     assert_eq(d.index, full.index)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -896,23 +896,29 @@ def test_dataframe_quantile():
     assert_eq(ddf.quantile(axis=1), df.quantile(axis=1))
     pytest.raises(ValueError, lambda: ddf.quantile([0.25, 0.75], axis=1))
 
-    
+
 def test_quantile_for_possibly_unsorted_q():
     '''check that quantile is giving correct answers even when quantile parameter, q, may be unsorted.
-    
+
     See https://github.com/dask/dask/issues/4642.
     '''
     # prepare test case where percentiles should equal values
     A = da.arange(0, 101)
     ds = dd.from_dask_array(A)
-    
+
     for q in [[0.25, 0.50, 0.75], [0.25, 0.50, 0.75, 0.99], [0.75, 0.5, 0.25],
-             [0.25, 0.99, 0.75, 0.50]]:
+              [0.25, 0.99, 0.75, 0.50]]:
         r = ds.quantile(q).compute()
         assert_eq(r.loc[0.25], 25.0)
         assert_eq(r.loc[0.50], 50.0)
         assert_eq(r.loc[0.75], 75.0)
-        
+
+    r = ds.quantile([0.25]).compute()
+    assert_eq(r.loc[0.25], 25.0)
+
+    r = ds.quantile(0.25).compute()
+    assert_eq(r, 25.0)
+
 
 def test_index():
     assert_eq(d.index, full.index)


### PR DESCRIPTION
Currently dask.dataframe.core.quantile(df, q) can silently give incorrect results when the list of quantiles, q, is not sorted. For instance quantile(dask.array.arange(100), [0.75, 0.50, 0.25]) gives incorrect results. This patch uses numpy's mergesort to ensure that the quantiles are sorted. Note that with the patch behavior still differs from that in pandas.DataFrame.quantile() where quantiles are calculated correctly while preserving order. While this patch does not duplicate the behavior of pandas because it does not preserve the order of the quantiles, it does at least avoids the silent errors.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
