### PR TITLE
very minor change: clearer exception message when using index or index_col in read_csv

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -289,8 +289,8 @@ def read_pandas(reader, urlpath, blocksize=AUTO_BLOCKSIZE, collection=True,
     if include_path_column and isinstance(include_path_column, bool):
         include_path_column = 'path'
     if 'index' in kwargs or 'index_col' in kwargs:
-        raise ValueError("Keyword 'index' not supported "
-                         "dd.{0}(...).set_index('my-index') "
+        raise ValueError("Keywords 'index' and 'index_col' not supported. "
+                         "Use dd.{0}(...).set_index('my-index') "
                          "instead".format(reader_name))
     for kw in ['iterator', 'chunksize']:
         if kw in kwargs:


### PR DESCRIPTION
Using `dask.dataframe.read_csv` with either `index` or `index_col` keyword produces the same message: `ValueError: Keyword 'index' not supported dd.read_csv(...).set_index('my-index') instead`. This just changes it to `ValueError: Keywords 'index' and 'index_col' are not supported. Use dd.read_csv(...).set_index('my-index') instead`. 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
