### PR TITLE
Mark some parquet tests xfail

### DIFF
--- a/dask/array/tests/test_image.py
+++ b/dask/array/tests/test_image.py
@@ -15,7 +15,7 @@ def random_images(n, shape):
     with tmpdir() as dirname:
         for i in range(n):
             fn = os.path.join(dirname, 'image.%d.png' % i)
-            x = np.random.randint(0, 255, size=shape).astype('i1')
+            x = np.random.randint(0, 255, size=shape).astype('u1')
             imsave(fn, x)
 
         yield os.path.join(dirname, '*.png')
@@ -37,7 +37,7 @@ def test_imread_with_custom_function():
         return np.ones((2, 3, 4), dtype='i1')
     with random_images(4, (5, 6, 3)) as globstring:
         im = da_imread(globstring, imread=imread2)
-        assert (im.compute() == np.ones((4, 2, 3, 4), dtype='i1')).all()
+        assert (im.compute() == np.ones((4, 2, 3, 4), dtype='u1')).all()
 
 
 def test_preprocess():
@@ -46,4 +46,4 @@ def test_preprocess():
         return x[:, :, 0]
     with random_images(4, (2, 3, 4)) as globstring:
         im = da_imread(globstring, preprocess=preprocess)
-        assert (im.compute() == np.ones((4, 2, 3), dtype='i1')).all()
+        assert (im.compute() == np.ones((4, 2, 3), dtype='u1')).all()

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1334,6 +1334,8 @@ def test_select_partitioned_column(tmpdir, engine):
     df_partitioned[df_partitioned.fake_categorical1 == 'A'].compute()
 
 
+@pytest.mark.xfail(
+    reason="Failing with PyArrow 0.13, see https://github.com/dask/dask/issues/4666")
 def test_with_tz(tmpdir, engine):
     if engine == 'pyarrow' and pa.__version__ < LooseVersion('0.11.0'):
         pytest.skip("pyarrow<0.11.0 did not support this")

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -460,6 +460,8 @@ def test_optimize(tmpdir, c):
 
 @pytest.mark.skipif(not hasattr(pd.DataFrame, 'to_parquet'),
                     reason="no to_parquet method")
+@pytest.mark.xfail(
+    reason="Failing with PyArrow 0.13, see https://github.com/dask/dask/issues/4666")
 @write_read_engines()
 def test_roundtrip_from_pandas(tmpdir, write_engine, read_engine):
     fn = str(tmpdir.join('test.parquet'))
@@ -470,6 +472,8 @@ def test_roundtrip_from_pandas(tmpdir, write_engine, read_engine):
 
 
 @write_read_engines_xfail
+@pytest.mark.xfail(
+    reason="Failing with PyArrow 0.13, see https://github.com/dask/dask/issues/4666")
 def test_categorical(tmpdir, write_engine, read_engine):
     tmp = str(tmpdir)
     df = pd.DataFrame({'x': ['a', 'b', 'c'] * 100}, dtype='category')
@@ -677,6 +681,8 @@ def test_ordering(tmpdir, write_engine, read_engine):
     assert_eq(ddf, ddf2, check_divisions=False)
 
 
+@pytest.mark.xfail(
+    reason="Failing with PyArrow 0.13, see https://github.com/dask/dask/issues/4666")
 def test_read_parquet_custom_columns(tmpdir, engine):
     import glob
     tmp = str(tmpdir)
@@ -828,6 +834,8 @@ def test_partition_on(tmpdir, write_engine, read_engine):
 
 
 @write_read_engines_xfail
+@pytest.mark.xfail(
+    reason="Failing with PyArrow 0.13, see https://github.com/dask/dask/issues/4666")
 def test_filters(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
 
@@ -933,6 +941,8 @@ def test_read_from_fastparquet_parquetfile(tmpdir):
 
 
 @pytest.mark.parametrize('scheduler', ['threads', 'processes'])
+@pytest.mark.xfail(
+    reason="Failing with PyArrow 0.13, see https://github.com/dask/dask/issues/4666")
 def test_to_parquet_lazy(tmpdir, scheduler, engine):
     tmpdir = str(tmpdir)
     df = pd.DataFrame({'a': [1, 2, 3, 4],
@@ -1030,6 +1040,8 @@ def test_columns_name(tmpdir, write_engine, read_engine):
 
 
 @pytest.mark.parametrize('compression,', ['default', None, 'gzip', 'snappy'])
+@pytest.mark.xfail(
+    reason="Failing with PyArrow 0.13, see https://github.com/dask/dask/issues/4666")
 def test_writing_parquet_with_compression(tmpdir, compression, engine):
     fn = str(tmpdir)
 
@@ -1336,6 +1348,8 @@ def test_with_tz(tmpdir, engine):
     assert_eq(df, df2, check_divisions=False, check_index=False)
 
 
+@pytest.mark.xfail(
+    reason="Failing with PyArrow 0.13, see https://github.com/dask/dask/issues/4666")
 def test_arrow_partitioning(tmpdir):
     # Issue #3518
     pytest.importorskip('pyarrow')


### PR DESCRIPTION
Marking failing parquet tests xfail, see discussion in #4666.

cc @martindurant @mrocklin 

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
