### PR TITLE
Adjusts codecov's target/threshold, disable patch

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,8 +8,11 @@ coverage:
   range: 90..100
 
   status:
-    project: yes
-    patch: yes
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+    patch: no
     changes: no
 
 comment: off


### PR DESCRIPTION
Solves #4670.

@mrocklin, @jrbourbeau I set target to 90% (we currently meet > 91%) and threshold to 1%. Let me know if you think they're reasonable. I know we don't want to enforce coverage for now, but if it drops by more than 1%, it seems a good idea that we are alerted about that.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
