### PR TITLE
Always start with empty http buffer, not None

### DIFF
--- a/dask/bytes/http.py
+++ b/dask/bytes/http.py
@@ -122,7 +122,7 @@ class HTTPFile(object):
                 raise err
             self.size = None  # pragma: no cover
 
-        self.cache = None
+        self.cache = b''
         self.closed = False
         self.start = None
         self.end = None


### PR DESCRIPTION
Fixes #4672

- [x] Tests added / passed
- [x] Passes `flake8 dask`
