### PR TITLE
RFC: Add TileDB backend

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -62,6 +62,7 @@ conda install -q -c conda-forge \
     scipy \
     sqlalchemy \
     toolz \
+    tiledb-py \
     zarr
 
 pip install --upgrade codecov

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -7,6 +7,7 @@ try:
                        map_blocks, to_hdf5, to_npy_stack, from_npy_stack,
                        from_delayed, asarray, asanyarray, PerformanceWarning,
                        broadcast_arrays, broadcast_to, from_zarr, to_zarr)
+    from .tiledb_io import from_tiledb, to_tiledb
     from .routines import (take, choose, argwhere, where, coarsen, insert,
                            ravel, roll, unique, squeeze, ptp, diff, ediff1d,
                            gradient, bincount, digitize, histogram, cov, array,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -48,7 +48,6 @@ from .numpy_compat import _Recurser, _make_sliced_dtype
 from .slicing import slice_array, replace_ellipsis
 from .blockwise import blockwise
 
-
 config.update_defaults({'array': {
     'chunk-size': '128MiB',
     'rechunk-threshold': 4
@@ -1778,6 +1777,16 @@ class Array(DaskMethodsMixin):
         See function ``to_zarr()`` for parameters.
         """
         return to_zarr(self, *args, **kwargs)
+
+    def to_tiledb(self, uri, *args, **kwargs):
+        """Save array to the TileDB storage manager
+
+        See function ``to_tiledb()`` for argument documentation.
+
+        See https://docs.tiledb.io for details about the format and engine.
+        """
+        from .tiledb_io import to_tiledb
+        return to_tiledb(self, uri, *args, **kwargs)
 
 
 def ensure_int(f):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3537,6 +3537,75 @@ def test_zarr_nocompute():
         assert a2.chunks == a.chunks
 
 
+@pytest.mark.skipif(sys.version_info[0:2] == (3,5),
+                    reason="Skipping TileDB with python 3.5 because the tiledb-py "
+                           "conda-forge package is too old, and is not updatable.")
+def test_tiledb_roundtrip():
+    tiledb = pytest.importorskip('tiledb')
+    # 1) load with default chunking
+    # 2) load from existing tiledb.DenseArray
+    # 3) write to existing tiledb.DenseArray
+    a = da.random.random((3,3))
+    with tmpdir() as uri:
+        da.to_tiledb(a, uri)
+        tdb = da.from_tiledb(uri)
+
+        assert_eq(a, tdb)
+        assert a.chunks == tdb.chunks
+
+        # from tiledb.array
+        with tiledb.open(uri) as t:
+            tdb2 = da.from_tiledb(t)
+            assert_eq(a, tdb2)
+
+    with tmpdir() as uri2:
+        with tiledb.empty_like(uri2, a) as t:
+            a.to_tiledb(t)
+            assert_eq(da.from_tiledb(uri2), a)
+
+    # specific chunking
+    with tmpdir() as uri:
+        a = da.random.random((3,3), chunks=(1,1))
+        a.to_tiledb(uri)
+        tdb = da.from_tiledb(uri)
+
+        assert_eq(a, tdb)
+        assert a.chunks == tdb.chunks
+
+
+@pytest.mark.skipif(sys.version_info[0:2] == (3,5),
+                    reason="Skipping TileDB with python 3.5 because the tiledb-py "
+                           "conda-forge package is too old, and is not updatable.")
+def test_tiledb_multiattr():
+    tiledb = pytest.importorskip('tiledb')
+    dom = tiledb.Domain(
+        tiledb.Dim("x", (0,1000), tile=100),
+        tiledb.Dim("y", (0,1000), tile=100))
+    schema = tiledb.ArraySchema(
+        attrs=(tiledb.Attr("attr1"),
+               tiledb.Attr("attr2")),
+        domain=dom)
+
+    with tmpdir() as uri:
+        tiledb.DenseArray.create(uri, schema)
+        tdb = tiledb.DenseArray(uri, 'w')
+
+        ar1 = np.random.randn(*tdb.schema.shape)
+        ar2 = np.random.randn(*tdb.schema.shape)
+
+        tdb[:] = {'attr1': ar1,
+                  'attr2': ar2}
+        tdb = tiledb.DenseArray(uri, 'r')
+
+        # basic round-trip from dask.array
+        d = da.from_tiledb(uri, attribute='attr2')
+        assert_eq(d, ar2)
+
+        # smoke-test computation directly on the TileDB view
+        d = da.from_tiledb(uri, attribute='attr2')
+        assert_eq(np.mean(ar2), d.mean().compute(scheduler='threads'))
+
+
 def test_blocks_indexer():
     x = da.arange(10, chunks=2)
 

--- a/dask/array/tiledb_io.py
+++ b/dask/array/tiledb_io.py
@@ -19,6 +19,12 @@ def from_tiledb(uri, attribute=None, chunks=None,
     attribute: str or None
         Attribute selection (single-attribute view on multi-attribute array)
 
+
+    Returns
+    -------
+
+    A Dask Array
+
     Examples
     --------
 
@@ -80,18 +86,24 @@ def to_tiledb(darray, uri, compute=True, return_stored=False,
         A dask array to write.
     uri:
         Any supported TileDB storage location.
-    storage_options:
+    storage_options: dict
         Dict containing any configuration options for the TileDB backend.
         see https://docs.tiledb.io/en/stable/tutorials/config.html
     compute, return_stored: see ``store()``
-    :return:
-        None
 
-    Note on chunking/tiling:
-        TileDB only supports regularly-chunked arrays.
-        TileDB `tile extents`_ correspond to form 2 of the dask
-        `chunk specification`_, and the conversion is
-        done automatically for supported arrays.
+    Returns
+    -------
+
+    None
+        Unless ``return_stored`` is set to ``True`` (``False`` by default)
+
+    Notes
+    -----
+
+    TileDB only supports regularly-chunked arrays.
+    TileDB `tile extents`_ correspond to form 2 of the dask
+    `chunk specification`_, and the conversion is
+    done automatically for supported arrays.
 
     Examples
     --------

--- a/dask/array/tiledb_io.py
+++ b/dask/array/tiledb_io.py
@@ -1,0 +1,142 @@
+from . import core
+
+
+def _tiledb_to_chunks(tiledb_array):
+    schema = tiledb_array.schema
+    return list(schema.domain.dim(i).tile for i in range(schema.ndim))
+
+
+def from_tiledb(uri, attribute=None, chunks=None,
+                storage_options=None, **kwargs):
+    """Load array from the TileDB storage format
+
+    See https://docs.tiledb.io for more information about TileDB.
+
+    Parameters
+    ----------
+    uri: TileDB array or str
+        Location to save the data
+    attribute: str or None
+        Attribute selection (single-attribute view on multi-attribute array)
+
+    Examples
+    --------
+
+    >>> # create a tiledb array
+    >>> import tiledb, numpy as np, tempfile  # doctest: +SKIP
+    >>> uri = tempfile.NamedTemporaryFile().name  # doctest: +SKIP
+    >>> tiledb.from_numpy(uri, np.arange(0,9).reshape(3,3))  # doctest: +SKIP
+    <tiledb.libtiledb.DenseArray object at 0x...>
+    >>> # read back the array
+    >>> import dask.array as da  # doctest: +SKIP
+    >>> tdb_ar = da.from_tiledb(uri)  # doctest: +SKIP
+    >>> tdb_ar.shape  # doctest: +SKIP
+    (3, 3)
+    >>> tdb_ar.mean().compute()  # doctest: +SKIP
+    4.0
+    """
+    import tiledb
+    tiledb_config = storage_options or dict()
+    key = tiledb_config.pop('key', None)
+
+    if isinstance(uri, tiledb.Array):
+        tdb = uri
+    else:
+        tdb = tiledb.open(uri, attr=attribute, config=tiledb_config, key=key)
+
+    if tdb.schema.sparse:
+        raise ValueError("Sparse TileDB arrays are not supported")
+
+    if not attribute:
+        if tdb.schema.nattr > 1:
+            raise TypeError("keyword 'attribute' must be provided"
+                            "when loading a multi-attribute TileDB array")
+        else:
+            attribute = tdb.schema.attr(0).name
+
+    if tdb.iswritable:
+        raise ValueError("TileDB array must be open for reading")
+
+    chunks = chunks or _tiledb_to_chunks(tdb)
+
+    assert(len(chunks) == tdb.schema.ndim)
+
+    return core.from_array(tdb, chunks, name='tiledb-%s' % uri)
+
+
+def to_tiledb(darray, uri, compute=True, return_stored=False,
+              storage_options=None, **kwargs):
+    """Save array to the TileDB storage format
+
+    Save 'array' using the TileDB storage manager, to any TileDB-supported URI,
+    including local disk, S3, or HDFS.
+
+    See https://docs.tiledb.io for more information about TileDB.
+
+    Parameters
+    ----------
+
+    darray: dask.array
+        A dask array to write.
+    uri:
+        Any supported TileDB storage location.
+    storage_options:
+        Dict containing any configuration options for the TileDB backend.
+        see https://docs.tiledb.io/en/stable/tutorials/config.html
+    compute, return_stored: see ``store()``
+    :return:
+        None
+
+    Note on chunking/tiling:
+        TileDB only supports regularly-chunked arrays.
+        TileDB `tile extents`_ correspond to form 2 of the dask
+        `chunk specification`_, and the conversion is
+        done automatically for supported arrays.
+
+    Examples
+    --------
+
+    >>> import dask.array as da, tempfile  # doctest: +SKIP
+    >>> uri = tempfile.NamedTemporaryFile().name   # doctest: +SKIP
+    >>> data = da.random.random(5,5)  # doctest: +SKIP
+    >>> da.to_tiledb(data, uri)  # doctest: +SKIP
+    >>> import tiledb  # doctest: +SKIP
+    >>> tdb_ar = tiledb.open(uri)  # doctest: +SKIP
+    >>> all(tdb_ar == data)  # doctest: +SKIP
+    True
+
+    .. _chunk specification: https://docs.tiledb.io/en/stable/tutorials/tiling-dense.html
+    .. _tile extents: http://docs.dask.org/en/latest/array-chunks.html
+    """
+    import tiledb
+
+    tiledb_config = storage_options or dict()
+    # encryption key, if any
+    key = tiledb_config.pop('key', None)
+
+    if not core._check_regular_chunks(darray.chunks):
+        raise ValueError('Attempt to save array to TileDB with irregular '
+                         'chunking, please call `arr.rechunk(...)` first.')
+
+    if isinstance(uri, str):
+        chunks = [c[0] for c in darray.chunks]
+        key = kwargs.pop('key', None)
+        # create a suitable, empty, writable TileDB array
+        tdb = tiledb.empty_like(uri, darray, tile=chunks, config=tiledb_config, key=key, **kwargs)
+    elif isinstance(uri, tiledb.Array):
+        tdb = uri
+        # sanity checks
+        if not ((darray.shape == tdb.shape) and
+                (darray.dtype == tdb.dtype) and
+                (darray.ndim == tdb.ndim)):
+            raise ValueError("Target TileDB array layout is not compatible with "
+                             "source array")
+    else:
+        raise ValueError("'uri' must be string pointing to supported TileDB store location "
+                         "or an open, writable TileDB array.")
+
+    if not (tdb.isopen and tdb.iswritable):
+        raise ValueError("Target TileDB array is not open and writable.")
+
+    return darray.store(tdb, lock=False, compute=compute,
+                        return_stored=return_stored)

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 numpydoc==0.8
 sphinx
-dask_sphinx_theme>=1.1.0
+  #dask_sphinx_theme>=1.1.0
 toolz
 cloudpickle
 pandas>=0.19.0

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -335,10 +335,12 @@ Create and Store Arrays
    from_delayed
    from_npy_stack
    from_zarr
+   from_tiledb
    store
    to_hdf5
    to_zarr
    to_npy_stack
+   to_tiledb
 
 Generalized Ufuncs
 ~~~~~~~~~~~~~~~~~~
@@ -601,10 +603,12 @@ Other functions
 .. autofunction:: from_delayed
 .. autofunction:: from_npy_stack
 .. autofunction:: from_zarr
+.. autofunction:: from_tiledb
 .. autofunction:: store
 .. autofunction:: to_hdf5
 .. autofunction:: to_zarr
 .. autofunction:: to_npy_stack
+.. autofunction:: to_tiledb
 
 .. currentmodule:: dask.array.fft
 

--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -327,6 +327,31 @@ chunking of the resultant Dask array is defined by how the files were saved, unl
 otherwise specified.
 
 
+TileDB
+------
+
+`TileDB <https://docs.tiledb.io>`_  is a binary array format and storage manager with
+tunable chunking, layout, and compression options. The TileDB storage manager library
+includes support for scalable storage backends such as S3 API compatible object stores
+and HDFS, with automatic scaling, and supports multi-threaded and multi-process
+reads (consistent) and writes (eventually-consistent).
+
+To save data to a local TileDB array:
+
+.. code-block:: Python
+
+  >>> arr.to_tiledb('output.tdb')
+
+or to save to a bucket on S3:
+
+  >>> arr.to_tiledb('s3://mybucket/output.tdb',
+                    storage_options={'vfs.s3.aws_access_key_id': 'mykey',
+                                     'vfs.s3.aws_secret_access_key': 'mysecret'})
+
+Files may be retrieved by running `da.from_tiledb` with the same URI, and any
+necessary arguments.
+
+
 Plugins
 =======
 


### PR DESCRIPTION
This is a request-for-comment and WIP PR to propose adding TileDB integration to Dask, as suggested by several dask users [in this pangeo thread](https://github.com/pangeo-data/pangeo/issues/120) (cc @rabernat, @martindurant)

Status
- [x] Tests added / passed
- [x] Passes `flake8 dask`
- [ ] I will do a TileDB-Py point release on conda+pip to include anything else needed upon review here.

Proposed API additions
- `dask.array.to_tiledb` and `dask.array.from_tiledb`

Background

[TileDB](https://tiledb.io) is an open source, multi-dimensional array management system which provides:

- storage for dense and sparse array data with support for fast updates, compression, and encryption.
- a storage engine written in C++ for efficient queries and provides native a C/C++ API for portability.
- open spec on disk format
- multi-language support: Python, R, Go, and Java bindings
- Conda packages for the TileDB core and python bindings
- storage backends for S3 and HDFS
- the concurrency and consistency model is: consistent reads via timestamped snapshots, and eventually-consistent writes.  Supports concurrent multiple readers and multiple writers.  Supports multithreaded parallel IO from a single python process.

