### PR TITLE
Updated diagnostic bokeh test for compatibility with bokeh>=1.1.0

### DIFF
--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -299,7 +299,10 @@ def test_plot_multiple():
             get(dsk2, 'c')
     p = visualize([prof, rprof], label_size=50,
                   title="Not the default", show=False, save=False)
-    if LooseVersion(bokeh.__version__) >= '0.12.0':
+    bokeh_version = LooseVersion(bokeh.__version__)
+    if bokeh_version >= '1.1.0':
+        figures = [r[0] for r in p.children[1].children]
+    elif bokeh_version >= '0.12.0':
         figures = [r.children[0] for r in p.children[1].children]
     else:
         figures = [r[0] for r in p.children]


### PR DESCRIPTION
Fixes regression in profiler tests with bokeh >=1.1.0 due to a change in the way grids of plots are represented. Also checked that the plot still displays as expected:

![Screen Shot 2019-04-09 at 7 26 17 PM](https://user-images.githubusercontent.com/1550771/55825189-5fae6080-5afd-11e9-83fa-99b7477dda5f.png)

- [x] Tests added / passed
- [x] Passes `flake8 dask`
