### PR TITLE
dask.array.bincount() - calculate "minlength" keyword argument if not specified

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -541,12 +541,11 @@ def bincount(x, weights=None, minlength=None):
 
     # Call np.bincount on each block, possibly with weights
     name = 'bincount-' + token
-    if weights is not None:
-        for i, _ in enumerate(x.__dask_keys__()):
+    for i, _ in enumerate(x.__dask_keys__()):
+        if weights is not None:
             dsk[(name, i)] = (np.bincount, (x.name, i), (weights.name, i), ('minlength-' + token, 0))
             dtype = np.bincount([1], weights=[1]).dtype
-    else:
-        for i, _ in enumerate(x.__dask_keys__()):
+        else:
             dsk[(name, i)] = (np.bincount, (x.name, i), None, ('minlength-' + token, 0))
             dtype = np.bincount([]).dtype
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -525,13 +525,13 @@ def gradient(f, *varargs, **kwargs):
 
 
 @wraps(np.bincount)
-def bincount(x, weights=None, minlength=None):
+def bincount(x, weights=None, minlength=0):
     assert x.ndim == 1
     if weights is not None:
         assert weights.chunks == x.chunks
 
     token = tokenize(x, weights, minlength)
-    if minlength is not None:
+    if minlength != 0:
         dsk = {('minlength-' + token, 0): minlength}
     else:
         dsk = {('max-' + token, i): (np.amax, (x.name, i))

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -559,8 +559,7 @@ def bincount(x, weights=None, minlength=None):
     graph = HighLevelGraph.from_collections(
         name, dsk, dependencies=[x] if weights is None else [x, weights])
 
-    chunksize = Array(graph, 'minlength-' + token, ((0,),), dtype)
-    chunks = ((chunksize,),)
+    chunks = ((np.nan,),)
 
     return Array(graph, name, chunks, dtype)
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -556,8 +556,8 @@ def bincount(x, weights=None, minlength=None):
 
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[x] if weights is None else [x, weights])
 
-    minlength = Array(graph, 'minlength-' + token, ((0,),), dtype)
-    chunks = ((minlength,),)
+    chunksize = Array(graph, 'minlength-' + token, ((0,),), dtype)
+    chunks = ((chunksize,),)
 
     return Array(graph, name, chunks, dtype)
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -556,8 +556,8 @@ def bincount(x, weights=None, minlength=None):
     name = 'bincount-sum-' + token
     dsk[(name, 0)] = (np.sum, bincount_list, 0)
 
-    graph = HighLevelGraph.from_collections(name, dsk,
-        dependencies=[x] if weights is None else [x, weights])
+    graph = HighLevelGraph.from_collections(
+        name, dsk, dependencies=[x] if weights is None else [x, weights])
 
     chunksize = Array(graph, 'minlength-' + token, ((0,),), dtype)
     chunks = ((chunksize,),)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -543,10 +543,12 @@ def bincount(x, weights=None, minlength=None):
     name = 'bincount-' + token
     for i, _ in enumerate(x.__dask_keys__()):
         if weights is not None:
-            dsk[(name, i)] = (np.bincount, (x.name, i), (weights.name, i), ('minlength-' + token, 0))
+            dsk[(name, i)] = (np.bincount, (x.name, i), (weights.name, i),
+                              ('minlength-' + token, 0))
             dtype = np.bincount([1], weights=[1]).dtype
         else:
-            dsk[(name, i)] = (np.bincount, (x.name, i), None, ('minlength-' + token, 0))
+            dsk[(name, i)] = (np.bincount, (x.name, i), None,
+                              ('minlength-' + token, 0))
             dtype = np.bincount([]).dtype
 
     # Sum up all of the intermediate bincounts per block
@@ -554,7 +556,8 @@ def bincount(x, weights=None, minlength=None):
     name = 'bincount-sum-' + token
     dsk[(name, 0)] = (np.sum, bincount_list, 0)
 
-    graph = HighLevelGraph.from_collections(name, dsk, dependencies=[x] if weights is None else [x, weights])
+    graph = HighLevelGraph.from_collections(name, dsk,
+        dependencies=[x] if weights is None else [x, weights])
 
     chunksize = Array(graph, 'minlength-' + token, ((0,),), dtype)
     chunks = ((chunksize,),)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -506,15 +506,13 @@ def test_bincount_with_weights():
     assert same_keys(da.bincount(d, weights=dweights, minlength=6), e)
 
 
-def test_bincount_raises_informative_error_on_missing_minlength_kwarg():
-    x = np.array([2, 1, 5, 2, 1])
+def test_bincount_unspecified_minlength():
+    x = np.array([1, 1, 3, 7, 0])
     d = da.from_array(x, chunks=2)
-    try:
-        da.bincount(d)
-    except Exception as e:
-        assert 'minlength' in str(e)
-    else:
-        assert False
+    e = da.bincount(d)
+    assert len(e) == 8
+    assert_eq(e, np.bincount(x))
+    assert same_keys(da.bincount(d), e)
 
 
 def test_digitize():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -510,7 +510,6 @@ def test_bincount_unspecified_minlength():
     x = np.array([1, 1, 3, 7, 0])
     d = da.from_array(x, chunks=2)
     e = da.bincount(d)
-    assert len(e) == 8
     assert_eq(e, np.bincount(x))
     assert same_keys(da.bincount(d), e)
 


### PR DESCRIPTION
Automatic calculation of the `minlength` keyword argument if not specified in the call to `dask.array.bincount()`.

Closes https://github.com/dask/dask/issues/4556

This PR:
* calculates what `minlength` should be if the keyword argument is not specified in the call to `da.bincount()`
* uses a NaN chunksize for the output since that's what @jakirkham suggested, but if we don't like that, we could go back to to the solution I was trying out in [this commit](https://github.com/GenevieveBuckley/dask/commit/80d67349b5ef0b878161df00d6777f6f6dce217a). Comments?

If you pass in an obviously unsuitable value for `minlength` you'll still see a broadcast error when you try to compute, the same as before.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
