### PR TITLE
A few dataframe metadata fixes

### DIFF
--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -240,6 +240,8 @@ def test_pyarrow_compat():
 
 @require_pyarrow
 def test_parquet_pyarrow(hdfs):
+    if LooseVersion(pyarrow.__version__) == '0.13.0':
+        pytest.skip('pyarrow 0.13.0 not supported for parquet')
     dd = pytest.importorskip('dask.dataframe')
     import pandas as pd
     import numpy as np

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -4,6 +4,7 @@ import io
 import sys
 import os
 from contextlib import contextmanager
+from distutils.version import LooseVersion
 
 import pytest
 import numpy as np
@@ -353,7 +354,9 @@ def test_read_text_passes_through_options():
 @pytest.mark.parametrize("engine", ['pyarrow', 'fastparquet'])
 def test_parquet(s3, engine):
     dd = pytest.importorskip('dask.dataframe')
-    pytest.importorskip(engine)
+    lib = pytest.importorskip(engine)
+    if engine == 'pyarrow' and LooseVersion(lib.__version__) == '0.13.0':
+        pytest.skip('pyarrow 0.13.0 not supported for parquet')
     import pandas as pd
     import numpy as np
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3789,7 +3789,9 @@ def map_partitions(func, *args, **kwargs):
     meta_index = getattr(make_meta(dfs[0]), 'index', None) if dfs else None
 
     if meta is no_default:
-        meta = _emulate(func, *args, udf=True, **kwargs2)
+        # Use non-normalized kwargs here, as we want the real values (not
+        # delayed values)
+        meta = _emulate(func, *args, udf=True, **kwargs)
     else:
         meta = make_meta(meta, index=meta_index)
 

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -1063,7 +1063,7 @@ def get_engine(engine):
         if pa_version < '0.8.0':
             raise RuntimeError("PyArrow version >= 0.8.0 required")
         elif pa_version == '0.13.0':
-            raise RuntimeError("PyArrow versino 0.13.0 isn't supported, please "
+            raise RuntimeError("PyArrow version 0.13.0 isn't supported, please "
                                "upgrade or downgrade")
 
         _ENGINES['pyarrow'] = eng = {'read': _read_pyarrow,

--- a/dask/dataframe/io/parquet.py
+++ b/dask/dataframe/io/parquet.py
@@ -1059,8 +1059,12 @@ def get_engine(engine):
     elif engine == 'pyarrow':
         pa = import_required('pyarrow', "`pyarrow` not installed")
 
-        if LooseVersion(pa.__version__) < '0.8.0':
+        pa_version = LooseVersion(pa.__version__)
+        if pa_version < '0.8.0':
             raise RuntimeError("PyArrow version >= 0.8.0 required")
+        elif pa_version == '0.13.0':
+            raise RuntimeError("PyArrow versino 0.13.0 isn't supported, please "
+                               "upgrade or downgrade")
 
         _ENGINES['pyarrow'] = eng = {'read': _read_pyarrow,
                                      'write': _write_pyarrow}

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -21,17 +21,43 @@ try:
 except ImportError:
     fastparquet = False
 
+
+try:
+    import pyarrow as pa
+    pa_version = LooseVersion(pa.__version__)
+    check_pa_divs = pa_version >= '0.9.0'
+except ImportError:
+    pa_version = None
+    check_pa_divs = False
+
+
 try:
     import pyarrow.parquet as pq
 except ImportError:
     pq = False
 
 
-try:
-    import pyarrow as pa
-    check_pa_divs = pa.__version__ >= LooseVersion('0.9.0')
-except ImportError:
-    check_pa_divs = False
+SKIP_FASTPARQUET = not fastparquet
+SKIP_FASTPARQUET_REASON = 'fastparquet not found'
+FASTPARQUET_MARK = pytest.mark.skipif(SKIP_FASTPARQUET, reason=SKIP_FASTPARQUET_REASON)
+
+if pa_version == '0.13.0':
+    SKIP_PYARROW = True
+    SKIP_PYARROW_REASON = 'pyarrow 0.13.0 not supported'
+else:
+    SKIP_PYARROW = not pq
+    SKIP_PYARROW_REASON = 'pyarrow not found'
+PYARROW_MARK = pytest.mark.skipif(SKIP_PYARROW, reason=SKIP_PYARROW_REASON)
+
+
+def check_fastparquet():
+    if SKIP_FASTPARQUET:
+        pytest.skip(SKIP_FASTPARQUET_REASON)
+
+
+def check_pyarrow():
+    if SKIP_PYARROW:
+        pytest.skip(SKIP_PYARROW_REASON)
 
 
 def should_check_divs(engine):
@@ -53,20 +79,10 @@ ddf = dd.from_pandas(df, npartitions=npartitions)
 
 
 @pytest.fixture(params=[
-    pytest.param('fastparquet', marks=pytest.mark.skipif(not fastparquet, reason='fastparquet not found')),
-    pytest.param('pyarrow', marks=pytest.mark.skipif(not pq, reason='pyarrow not found'))])
+    pytest.param('fastparquet', marks=FASTPARQUET_MARK),
+    pytest.param('pyarrow', marks=PYARROW_MARK)])
 def engine(request):
     return request.param
-
-
-def check_fastparquet():
-    if not fastparquet:
-        pytest.skip('fastparquet not found')
-
-
-def check_pyarrow():
-    if not pq:
-        pytest.skip('pyarrow not found')
 
 
 def write_read_engines(**kwargs):
@@ -78,9 +94,10 @@ def write_read_engines(**kwargs):
     marks = {(w, r): [] for w in backends for r in backends}
 
     # Skip if uninstalled
-    for name, exists in [('fastparquet', fastparquet), ('pyarrow', pq)]:
-        val = pytest.mark.skip(reason='%s not found' % name)
-        if not exists:
+    for name, skip, reason in [('fastparquet', SKIP_FASTPARQUET, SKIP_FASTPARQUET_REASON),
+                               ('pyarrow', SKIP_PYARROW, SKIP_PYARROW_REASON)]:
+        if skip:
+            val = pytest.mark.skip(reason=reason)
             for k in marks:
                 if name in k:
                     marks[k].append(val)
@@ -1177,8 +1194,7 @@ def test_parse_pandas_metadata_null_index():
 def test_read_no_metadata(tmpdir, engine):
     # use pyarrow.parquet to create a parquet file without
     # pandas metadata
-    pa = pytest.importorskip("pyarrow")
-    import pyarrow.parquet as pq
+    check_pyarrow()
     tmp = str(tmpdir) + "table.parq"
 
     table = pa.Table.from_arrays([pa.array([1, 2, 3]),
@@ -1342,7 +1358,7 @@ def test_with_tz(tmpdir, engine):
 
 def test_arrow_partitioning(tmpdir):
     # Issue #3518
-    pytest.importorskip('pyarrow')
+    check_pyarrow()
     path = str(tmpdir)
     data = {
         'p': np.repeat(np.arange(3), 2).astype(np.int8),
@@ -1369,7 +1385,7 @@ def test_informative_error_messages():
 
 
 def test_append_cat_fp(tmpdir):
-    pytest.importorskip('fastparquet')
+    check_fastparquet()
     path = str(tmpdir)
     # https://github.com/dask/dask/issues/4120
     df = pd.DataFrame({"x": ["a", "a", "b", "a", "b"]})
@@ -1386,13 +1402,13 @@ def test_append_cat_fp(tmpdir):
 
 def test_passing_parquetfile(tmpdir):
     import shutil
-    fp = pytest.importorskip('fastparquet')
+    check_fastparquet()
     path = str(tmpdir)
     df = pd.DataFrame({"x": [1, 3, 2, 4]})
     ddf = dd.from_pandas(df, npartitions=1)
 
     dd.to_parquet(ddf, path)
-    pf = fp.ParquetFile(path)
+    pf = fastparquet.ParquetFile(path)
     shutil.rmtree(path)
 
     # should pass, because no need to re-read metadata

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -24,10 +24,8 @@ except ImportError:
 
 try:
     import pyarrow as pa
-    pa_version = LooseVersion(pa.__version__)
-    check_pa_divs = pa_version >= '0.9.0'
+    check_pa_divs = pa.__version__ >= LooseVersion('0.9.0')
 except ImportError:
-    pa_version = None
     check_pa_divs = False
 
 
@@ -41,7 +39,7 @@ SKIP_FASTPARQUET = not fastparquet
 SKIP_FASTPARQUET_REASON = 'fastparquet not found'
 FASTPARQUET_MARK = pytest.mark.skipif(SKIP_FASTPARQUET, reason=SKIP_FASTPARQUET_REASON)
 
-if pa_version == '0.13.0':
+if pq and pa.__version__ == LooseVersion('0.13.0'):
     SKIP_PYARROW = True
     SKIP_PYARROW_REASON = 'pyarrow 0.13.0 not supported'
 else:

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -70,7 +70,6 @@ from .io import from_pandas
 from . import methods
 from .shuffle import shuffle, rearrange_by_divisions
 from .utils import strip_unknown_categories
-from ..utils import M
 
 
 def align_partitions(*dfs):
@@ -203,6 +202,17 @@ def require(divisions, parts, required=None):
 required = {'left': [0], 'right': [1], 'inner': [0, 1], 'outer': []}
 
 
+def merge_chunk(lhs, *args, **kwargs):
+    empty_index_dtype = kwargs.pop('empty_index_dtype', None)
+    out = lhs.merge(*args, **kwargs)
+    # Workaround pandas bug where if the output result of a merge operation is
+    # an empty dataframe, the output index is `int64` in all cases, regardless
+    # of input dtypes.
+    if len(out) == 0 and empty_index_dtype is not None:
+        out.index = out.index.astype(empty_index_dtype)
+    return out
+
+
 def merge_indexed_dataframes(lhs, rhs, left_index=True, right_index=True, **kwargs):
     """ Join two partitioned dataframes along their index """
     how = kwargs.get('how', 'left')
@@ -214,11 +224,12 @@ def merge_indexed_dataframes(lhs, rhs, left_index=True, right_index=True, **kwar
 
     name = 'join-indexed-' + tokenize(lhs, rhs, **kwargs)
 
+    meta = lhs._meta_nonempty.merge(rhs._meta_nonempty, **kwargs)
+    kwargs['empty_index_dtype'] = meta.index.dtype
+
     dsk = dict()
     for i, (a, b) in enumerate(parts):
-        dsk[(name, i)] = (apply, M.merge, [a, b], kwargs)
-
-    meta = lhs._meta_nonempty.merge(rhs._meta_nonempty, **kwargs)
+        dsk[(name, i)] = (apply, merge_chunk, [a, b], kwargs)
 
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[lhs, rhs])
     return new_dd_object(graph, name, meta, divisions)
@@ -270,7 +281,8 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
     token = tokenize(lhs2, rhs2, npartitions, shuffle, **kwargs)
     name = 'hash-join-' + token
 
-    dsk = {(name, i): (apply, M.merge, [(lhs2._name, i), (rhs2._name, i)], kwargs)
+    kwargs['empty_index_dtype'] = meta.index.dtype
+    dsk = {(name, i): (apply, merge_chunk, [(lhs2._name, i), (rhs2._name, i)], kwargs)
            for i in range(npartitions)}
 
     divisions = [None] * (npartitions + 1)
@@ -283,10 +295,11 @@ def single_partition_join(left, right, **kwargs):
     # new index will not necessarily correspond the current divisions
 
     meta = left._meta_nonempty.merge(right._meta_nonempty, **kwargs)
+    kwargs['empty_index_dtype'] = meta.index.dtype
     name = 'merge-' + tokenize(left, right, **kwargs)
     if left.npartitions == 1 and kwargs['how'] in ('inner', 'right'):
         left_key = first(left.__dask_keys__())
-        dsk = {(name, i): (apply, M.merge, [left_key, right_key], kwargs)
+        dsk = {(name, i): (apply, merge_chunk, [left_key, right_key], kwargs)
                for i, right_key in enumerate(right.__dask_keys__())}
 
         if kwargs.get('right_index') or right._contains_index_name(
@@ -297,7 +310,7 @@ def single_partition_join(left, right, **kwargs):
 
     elif right.npartitions == 1 and kwargs['how'] in ('inner', 'left'):
         right_key = first(right.__dask_keys__())
-        dsk = {(name, i): (apply, M.merge, [left_key, right_key], kwargs)
+        dsk = {(name, i): (apply, merge_chunk, [left_key, right_key], kwargs)
                for i, left_key in enumerate(left.__dask_keys__())}
 
         if kwargs.get('left_index') or left._contains_index_name(
@@ -393,10 +406,11 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
             left = rearrange_by_divisions(left, left_on, right.divisions,
                                           max_branch, shuffle=shuffle)
             right = right.clear_divisions()
-        return map_partitions(M.merge, left, right, meta=meta, how=how, on=on,
-                              left_on=left_on, right_on=right_on,
+        return map_partitions(merge_chunk, left, right, meta=meta, how=how,
+                              on=on, left_on=left_on, right_on=right_on,
                               left_index=left_index, right_index=right_index,
-                              suffixes=suffixes, indicator=indicator)
+                              suffixes=suffixes, indicator=indicator,
+                              empty_index_dtype=meta.index.dtype)
     # Catch all hash join
     else:
         return hash_join(left, left.index if left_index else left_on,

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -964,46 +964,54 @@ def test_index():
 
 
 def test_assign():
-    d_unknown = dd.from_pandas(full, npartitions=3, sort=False)
-    assert not d_unknown.known_divisions
-    res = d.assign(c=1,
-                   d='string',
-                   e=d.a.sum(),
-                   f=d.a + d.b,
-                   g=lambda x: x.a + x.b,
-                   dt=pd.Timestamp(2018, 2, 13))
-    res_unknown = d_unknown.assign(c=1,
-                                   d='string',
-                                   e=d_unknown.a.sum(),
-                                   f=d_unknown.a + d_unknown.b,
-                                   g=lambda x: x.a + x.b,
-                                   dt=pd.Timestamp(2018, 2, 13))
-    sol = full.assign(c=1,
-                      d='string',
-                      e=full.a.sum(),
-                      f=full.a + full.b,
-                      g=lambda x: x.a + x.b,
-                      dt=pd.Timestamp(2018, 2, 13))
+    df = pd.DataFrame({'a': range(8),
+                       'b': [float(i) for i in range(10, 18)]},
+                      index=pd.Index(list('abcdefgh')))
+    ddf = dd.from_pandas(df, npartitions=3)
+    ddf_unknown = dd.from_pandas(df, npartitions=3, sort=False)
+    assert not ddf_unknown.known_divisions
+
+    res = ddf.assign(c=1,
+                     d='string',
+                     e=ddf.a.sum(),
+                     f=ddf.a + ddf.b,
+                     g=lambda x: x.a + x.b,
+                     dt=pd.Timestamp(2018, 2, 13))
+    res_unknown = ddf_unknown.assign(c=1,
+                                     d='string',
+                                     e=ddf_unknown.a.sum(),
+                                     f=ddf_unknown.a + ddf_unknown.b,
+                                     g=lambda x: x.a + x.b,
+                                     dt=pd.Timestamp(2018, 2, 13))
+    sol = df.assign(c=1,
+                    d='string',
+                    e=df.a.sum(),
+                    f=df.a + df.b,
+                    g=lambda x: x.a + x.b,
+                    dt=pd.Timestamp(2018, 2, 13))
     assert_eq(res, sol)
     assert_eq(res_unknown, sol)
 
-    res = d.assign(c=full.a + 1)
-    assert_eq(res, full.assign(c=full.a + 1))
+    res = ddf.assign(c=df.a + 1)
+    assert_eq(res, df.assign(c=df.a + 1))
+
+    res = ddf.assign(c=ddf.index)
+    assert_eq(res, df.assign(c=df.index))
 
     # divisions unknown won't work with pandas
     with pytest.raises(ValueError):
-        d_unknown.assign(c=full.a + 1)
+        ddf_unknown.assign(c=df.a + 1)
 
     # unsupported type
     with pytest.raises(TypeError):
-        d.assign(c=list(range(9)))
+        ddf.assign(c=list(range(9)))
 
     # Fails when assigning known divisions to unknown divisions
     with pytest.raises(ValueError):
-        d_unknown.assign(foo=d.a)
+        ddf_unknown.assign(foo=ddf.a)
     # Fails when assigning unknown divisions to known divisions
     with pytest.raises(ValueError):
-        d.assign(foo=d_unknown.a)
+        ddf.assign(foo=ddf_unknown.a)
 
 
 def test_assign_callable():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -150,25 +150,38 @@ def test_full_groupby_apply_multiarg():
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        for c_lazy, d_lazy in [(c_scalar, d_scalar),
-                               (c_delayed, d_delayed)]:
-            assert_eq(df.groupby('a').apply(func, c, d=d),
-                      ddf.groupby('a').apply(func, c, d=d_lazy))
+        assert_eq(df.groupby('a').apply(func, c, d=d),
+                  ddf.groupby('a').apply(func, c, d=d_scalar))
 
-            assert_eq(df.groupby('a').apply(func, c),
-                      ddf.groupby('a').apply(func, c))
+        assert_eq(df.groupby('a').apply(func, c),
+                  ddf.groupby('a').apply(func, c))
 
-            assert_eq(df.groupby('a').apply(func, c, d=d),
-                      ddf.groupby('a').apply(func, c, d=d))
+        assert_eq(df.groupby('a').apply(func, c, d=d),
+                  ddf.groupby('a').apply(func, c, d=d))
 
-            assert_eq(df.groupby('a').apply(func, c),
-                      ddf.groupby('a').apply(func, c_lazy), check_dtype=False)
+        assert_eq(df.groupby('a').apply(func, c),
+                  ddf.groupby('a').apply(func, c_scalar), check_dtype=False)
 
-            assert_eq(df.groupby('a').apply(func, c),
-                      ddf.groupby('a').apply(func, c_lazy, meta=meta))
+        assert_eq(df.groupby('a').apply(func, c),
+                  ddf.groupby('a').apply(func, c_scalar, meta=meta))
 
-            assert_eq(df.groupby('a').apply(func, c, d=d),
-                      ddf.groupby('a').apply(func, c, d=d_lazy, meta=meta))
+        assert_eq(df.groupby('a').apply(func, c, d=d),
+                  ddf.groupby('a').apply(func, c, d=d_scalar, meta=meta))
+
+    # Delayed arguments work, but only if metadata is provided
+    with pytest.raises(ValueError) as exc:
+        ddf.groupby('a').apply(func, c, d=d_delayed)
+    assert 'dask.delayed' in str(exc.value) and 'meta'in str(exc.value)
+
+    with pytest.raises(ValueError) as exc:
+        ddf.groupby('a').apply(func, c_delayed, d=d)
+    assert 'dask.delayed' in str(exc.value) and 'meta'in str(exc.value)
+
+    assert_eq(df.groupby('a').apply(func, c),
+              ddf.groupby('a').apply(func, c_delayed, meta=meta))
+
+    assert_eq(df.groupby('a').apply(func, c, d=d),
+              ddf.groupby('a').apply(func, c, d=d_delayed, meta=meta))
 
 
 @pytest.mark.parametrize('grouper', [

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -436,6 +436,14 @@ def test_merge_by_index_patterns(how, shuffle):
                           'd': [5, 4, 3, 2]},
                          index=list('fghi'))
 
+    def pd_merge(left, right, **kwargs):
+        # Workaround pandas bug where output dtype of empty index will be int64
+        # even if input was object.
+        out = pd.merge(left, right, **kwargs)
+        if len(out) == 0:
+            return out.set_index(out.index.astype(left.index.dtype))
+        return out
+
     for pdl, pdr in [(pdf1l, pdf1r), (pdf2l, pdf2r), (pdf3l, pdf3r),
                      (pdf4l, pdf4r), (pdf5l, pdf5r), (pdf6l, pdf6r),
                      (pdf7l, pdf7r)]:
@@ -449,22 +457,22 @@ def test_merge_by_index_patterns(how, shuffle):
 
             assert_eq(dd.merge(ddl, ddr, how=how, left_index=True,
                                right_index=True, shuffle=shuffle),
-                      pd.merge(pdl, pdr, how=how, left_index=True,
+                      pd_merge(pdl, pdr, how=how, left_index=True,
                                right_index=True))
             assert_eq(dd.merge(ddr, ddl, how=how, left_index=True,
                                right_index=True, shuffle=shuffle),
-                      pd.merge(pdr, pdl, how=how, left_index=True,
+                      pd_merge(pdr, pdl, how=how, left_index=True,
                                right_index=True))
 
             assert_eq(dd.merge(ddl, ddr, how=how, left_index=True,
                                right_index=True, shuffle=shuffle,
                                indicator=True),
-                      pd.merge(pdl, pdr, how=how, left_index=True,
+                      pd_merge(pdl, pdr, how=how, left_index=True,
                                right_index=True, indicator=True))
             assert_eq(dd.merge(ddr, ddl, how=how, left_index=True,
                                right_index=True, shuffle=shuffle,
                                indicator=True),
-                      pd.merge(pdr, pdl, how=how, left_index=True,
+                      pd_merge(pdr, pdl, how=how, left_index=True,
                                right_index=True, indicator=True))
 
             assert_eq(ddr.merge(ddl, how=how, left_index=True,


### PR DESCRIPTION
Due to a bug in `dd.utils.assert_eq`, we weren't properly testing that index metadata was correct. This fixes that, as well as issues this turned up.

- Use `_meta_nonempty` in assign
- Use `_meta_nonempty` in groupby aggregations
- Error nicely when trying to infer metadata from a `dask.delayed`
object (which we can't do since it could be any dtype).
- Fix `dd.utils.assert_eq` to properly compare index dtypes

Fixes #2564.
