### PR TITLE
Remove assertion in HighLevelGraph constructor

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -69,8 +69,6 @@ class HighLevelGraph(Mapping):
         typically used by developers to make new HighLevelGraphs
     """
     def __init__(self, layers, dependencies):
-        for v in layers.values():
-            assert not isinstance(v, HighLevelGraph)
         assert all(layers)
         self.layers = layers
         self.dependencies = dependencies

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -69,10 +69,8 @@ class HighLevelGraph(Mapping):
         typically used by developers to make new HighLevelGraphs
     """
     def __init__(self, layers, dependencies):
-        assert all(layers)
         self.layers = layers
         self.dependencies = dependencies
-        assert set(dependencies) == set(layers)
 
     @property
     def dicts(self):


### PR DESCRIPTION
This was not necessary and causes significant slowdowns in
HighLevelGraph construction.

See https://github.com/dask/distributed/issues/2611

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
