### PR TITLE
Add chunks='auto' to from_array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2091,6 +2091,8 @@ def from_array(x, chunks='auto', name=None, lock=False, asarray=True, fancy=True
             ((1000, 1000, 500), (400, 400)).
         -   A size in bytes, like "100 MiB" which will choose a uniform
             block-like shape
+        -   The word "auto" which acts like the above, but uses a configuration
+            value ``array.chunk-size`` for the chunk size
 
         -1 or None as a blocksize indicate the size of the corresponding
         dimension.
@@ -2133,10 +2135,7 @@ def from_array(x, chunks='auto', name=None, lock=False, asarray=True, fancy=True
     if isinstance(x, (list, tuple, memoryview) + np.ScalarType):
         x = np.array(x)
 
-    if hasattr(x, 'chunks'):
-        previous_chunks = x.chunks
-    else:
-        previous_chunks = None
+    previous_chunks = getattr(x, 'chunks', None)
 
     chunks = normalize_chunks(
         chunks,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2074,7 +2074,7 @@ def round_to(c, s):
         return c // s * s
 
 
-def from_array(x, chunks, name=None, lock=False, asarray=True, fancy=True,
+def from_array(x, chunks='auto', name=None, lock=False, asarray=True, fancy=True,
                getitem=None):
     """ Create dask array from something that looks like an array
 
@@ -2089,6 +2089,8 @@ def from_array(x, chunks, name=None, lock=False, asarray=True, fancy=True,
         -   A blockshape like (1000, 1000).
         -   Explicit sizes of all blocks along all dimensions like
             ((1000, 1000, 500), (400, 400)).
+        -   A size in bytes, like "100 MiB" which will choose a uniform
+            block-like shape
 
         -1 or None as a blocksize indicate the size of the corresponding
         dimension.
@@ -2119,11 +2121,29 @@ def from_array(x, chunks, name=None, lock=False, asarray=True, fancy=True,
     arrays to coordinate around the same lock.
 
     >>> a = da.from_array(x, chunks=(1000, 1000), lock=True)  # doctest: +SKIP
+
+    If your underlying datastore has a ``.chunks`` attribute (as h5py and zarr
+    datasets do) then a multiple of that chunk shape will be used if you
+    do not provide a chunk shape.
+
+    >>> a = da.from_array(x, chunks='auto')  # doctest: +SKIP
+    >>> a = da.from_array(x, chunks='100 MiB')  # doctest: +SKIP
+    >>> a = da.from_array(x)  # doctest: +SKIP
     """
     if isinstance(x, (list, tuple, memoryview) + np.ScalarType):
         x = np.array(x)
 
-    chunks = normalize_chunks(chunks, x.shape, dtype=x.dtype)
+    if hasattr(x, 'chunks'):
+        previous_chunks = x.chunks
+    else:
+        previous_chunks = None
+
+    chunks = normalize_chunks(
+        chunks,
+        x.shape,
+        dtype=x.dtype,
+        previous_chunks=previous_chunks
+    )
     if name in (None, True):
         token = tokenize(x, chunks)
         original_name = 'array-original-' + token


### PR DESCRIPTION
This uses the "auto" chunking in da.from_array

It also uses a ``.chunks`` attribute on the dataset if present,
making the HDF5 and Zarr cases somewhat natural by default.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`

This was developed while writing up array best practices docs.