### PR TITLE
Raise TypeError if dask array is given as shape for da.ones, zeros, empty or full

### DIFF
--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -24,6 +24,10 @@ def wrap_func_shape_as_first_arg(func, *args, **kwargs):
     else:
         shape = kwargs.pop('shape')
 
+    if isinstance(shape, Array):
+        raise TypeError('Dask array input not supported. '
+                        'Please use tuple, list, or a 1D numpy array instead.')
+
     if isinstance(shape, np.ndarray):
         shape = shape.tolist()
 


### PR DESCRIPTION
Raise a TypeError if dask array is given as shape for dask array ones(), zeros(), empty() or full()

Closes https://github.com/dask/dask/issues/4691

- [x] Tests passed
- [x] Passes `flake8 dask`
