### PR TITLE
ufunc: avoid __array_wrap__ in favor of __array_function__

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ jobs:
       - *no_coverage
       - *no_optimize
       - *imports
+      - *array_function
 
     - env: &py37_dev
       - UPSTREAM_DEV=1  # Install nightly versions of NumPy, pandas, pyarrow

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -60,14 +60,18 @@ def test_array_notimpl_function_dask(func):
 
 
 @pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
-def test_array_function_sparse_transpose():
+@pytest.mark.parametrize('func', [
+    lambda x: np.real(x),
+    lambda x: np.imag(x),
+    lambda x: np.transpose(x)])
+def test_array_function_sparse(func):
     sparse = pytest.importorskip('sparse')
     x = da.random.random((500, 500), chunks=(100, 100))
     x[x < 0.9] = 0
 
     y = x.map_blocks(sparse.COO)
 
-    assert_eq(np.transpose(x), np.transpose(y))
+    assert_eq(func(x), func(y))
 
 
 @pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -41,7 +41,17 @@ functions = [
     lambda x: x.rechunk((2, 2, 1)),
     pytest.param(lambda x: da.einsum("ijk,ijk", x, x),
                  marks=pytest.mark.xfail(
-                     reason='depends on resolution of https://github.com/numpy/numpy/issues/12974'))
+                     reason='depends on resolution of https://github.com/numpy/numpy/issues/12974')),
+    lambda x: np.isreal(x),
+    lambda x: np.iscomplex(x),
+    lambda x: np.isneginf(x),
+    lambda x: np.isposinf(x),
+    lambda x: np.real(x),
+    lambda x: np.imag(x),
+    lambda x: np.fix(x),
+    lambda x: np.i0(x.reshape((24,))),
+    lambda x: np.sinc(x),
+    lambda x: np.nan_to_num(x),
 ]
 
 

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -55,8 +55,6 @@ functions = [
     lambda x: x.rechunk((2, 2, 1)),
     lambda x: np.isneginf(x),
     lambda x: np.isposinf(x),
-    lambda x: np.real(x),
-    lambda x: np.imag(x),
 ]
 
 

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -53,6 +53,10 @@ functions = [
     lambda x: x > 0.5,
     lambda x: x.rechunk((4, 4, 4)),
     lambda x: x.rechunk((2, 2, 1)),
+    lambda x: np.isneginf(x),
+    lambda x: np.isposinf(x),
+    lambda x: np.real(x),
+    lambda x: np.imag(x),
 ]
 
 

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -7,6 +7,7 @@ import numpy as np
 from toolz import curry
 
 from .core import Array, elemwise, blockwise, apply_infer_dtype, asarray
+from .utils import IS_NEP18_ACTIVE
 from ..base import is_dask_collection, normalize_function
 from .. import core
 from ..highlevelgraph import HighLevelGraph
@@ -29,7 +30,7 @@ def wrap_elemwise(numpy_ufunc, array_wrap=False):
     def wrapped(*args, **kwargs):
         dsk = [arg for arg in args if hasattr(arg, '_elemwise')]
         if len(dsk) > 0:
-            if array_wrap:
+            if array_wrap and not IS_NEP18_ACTIVE:
                 return dsk[0]._elemwise(__array_wrap__, numpy_ufunc,
                                         *args, **kwargs)
             else:
@@ -268,8 +269,8 @@ absolute = ufunc(np.absolute)
 clip = wrap_elemwise(np.clip)
 isreal = wrap_elemwise(np.isreal, array_wrap=True)
 iscomplex = wrap_elemwise(np.iscomplex, array_wrap=True)
-isneginf = wrap_elemwise(np.isneginf, array_wrap=True)
-isposinf = wrap_elemwise(np.isposinf, array_wrap=True)
+isneginf = partial(wrap_elemwise(np.equal, array_wrap=True), -np.inf)
+isposinf = partial(wrap_elemwise(np.equal, array_wrap=True), np.inf)
 real = wrap_elemwise(np.real, array_wrap=True)
 imag = wrap_elemwise(np.imag, array_wrap=True)
 fix = wrap_elemwise(np.fix, array_wrap=True)

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -12,9 +12,10 @@ from .. import core
 from ..highlevelgraph import HighLevelGraph
 from ..utils import skip_doctest, funcname
 try:
-    from ..dataframe import core as ddcore
+    from ..dataframe.utils import is_dataframe_like
 except ImportError:
-    pass
+    def is_dataframe_like(df):
+        return False
 
 
 def __array_wrap__(numpy_ufunc, x, *args, **kwargs):
@@ -33,12 +34,8 @@ def wrap_elemwise(numpy_ufunc, array_wrap=False):
     def wrapped(*args, **kwargs):
         dsk = [arg for arg in args if hasattr(arg, '_elemwise')]
         if len(dsk) > 0:
-            try:
-                is_dataframe = isinstance(dsk[0], ddcore._Frame)
-            except NameError:
-                is_dataframe = False
             if (array_wrap and
-                    (is_dataframe or not IS_NEP18_ACTIVE)):
+                    (is_dataframe_like(dsk[0]) or not IS_NEP18_ACTIVE)):
                 return dsk[0]._elemwise(__array_wrap__, numpy_ufunc,
                                         *args, **kwargs)
             else:

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -10,12 +10,8 @@ from .utils import IS_NEP18_ACTIVE
 from ..base import is_dask_collection, normalize_function
 from .. import core
 from ..highlevelgraph import HighLevelGraph
-from ..utils import skip_doctest, funcname
-try:
-    from ..dataframe.utils import is_dataframe_like
-except ImportError:
-    def is_dataframe_like(df):
-        return False
+from ..utils import (skip_doctest, funcname,
+                     is_dataframe_like, is_series_like, is_index_like)
 
 
 def __array_wrap__(numpy_ufunc, x, *args, **kwargs):
@@ -34,8 +30,10 @@ def wrap_elemwise(numpy_ufunc, array_wrap=False):
     def wrapped(*args, **kwargs):
         dsk = [arg for arg in args if hasattr(arg, '_elemwise')]
         if len(dsk) > 0:
+            is_dataframe = (is_dataframe_like(dsk[0]) or is_series_like(dsk[0]) or
+                            is_index_like(dsk[0]))
             if (array_wrap and
-                    (is_dataframe_like(dsk[0]) or not IS_NEP18_ACTIVE)):
+                    (is_dataframe or not IS_NEP18_ACTIVE)):
                 return dsk[0]._elemwise(__array_wrap__, numpy_ufunc,
                                         *args, **kwargs)
             else:

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 from operator import getitem
 from functools import partial, wraps
@@ -12,6 +11,7 @@ from ..base import is_dask_collection, normalize_function
 from .. import core
 from ..highlevelgraph import HighLevelGraph
 from ..utils import skip_doctest, funcname
+from ..dataframe import core as ddcore
 
 
 def __array_wrap__(numpy_ufunc, x, *args, **kwargs):
@@ -30,7 +30,8 @@ def wrap_elemwise(numpy_ufunc, array_wrap=False):
     def wrapped(*args, **kwargs):
         dsk = [arg for arg in args if hasattr(arg, '_elemwise')]
         if len(dsk) > 0:
-            if array_wrap and not IS_NEP18_ACTIVE:
+            if (array_wrap and (isinstance(dsk[0], ddcore._Frame)
+                                or not IS_NEP18_ACTIVE)):
                 return dsk[0]._elemwise(__array_wrap__, numpy_ufunc,
                                         *args, **kwargs)
             else:
@@ -224,6 +225,8 @@ less = ufunc(np.less)
 less_equal = ufunc(np.less_equal)
 not_equal = ufunc(np.not_equal)
 equal = ufunc(np.equal)
+isneginf = partial(equal, -np.inf)
+isposinf = partial(equal, np.inf)
 logical_and = ufunc(np.logical_and)
 logical_or = ufunc(np.logical_or)
 logical_xor = ufunc(np.logical_xor)
@@ -269,8 +272,6 @@ absolute = ufunc(np.absolute)
 clip = wrap_elemwise(np.clip)
 isreal = wrap_elemwise(np.isreal, array_wrap=True)
 iscomplex = wrap_elemwise(np.iscomplex, array_wrap=True)
-isneginf = partial(wrap_elemwise(np.equal, array_wrap=True), -np.inf)
-isposinf = partial(wrap_elemwise(np.equal, array_wrap=True), np.inf)
 real = wrap_elemwise(np.real, array_wrap=True)
 imag = wrap_elemwise(np.imag, array_wrap=True)
 fix = wrap_elemwise(np.fix, array_wrap=True)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -33,6 +33,9 @@ from ..compatibility import PY2, Iterator, Mapping
 from ..core import get_deps
 from ..local import get_sync
 from ..utils import asciitable, is_arraylike, Dispatch
+from ..utils import is_dataframe_like as dask_is_dataframe_like
+from ..utils import is_series_like as dask_is_series_like
+from ..utils import is_index_like as dask_is_index_like
 
 
 PANDAS_VERSION = LooseVersion(pd.__version__)
@@ -511,28 +514,15 @@ def _nonempty_series(s, idx=None):
 
 
 def is_dataframe_like(df):
-    """ Looks like a Pandas DataFrame """
-    typ = type(df)
-    return (all(hasattr(typ, name)
-                for name in ('groupby', 'head', 'merge', 'mean')) and
-            all(hasattr(df, name) for name in ('dtypes',)) and not
-            any(hasattr(typ, name)
-                for name in ('value_counts', 'dtype')))
+    return dask_is_dataframe_like(df)
 
 
 def is_series_like(s):
-    """ Looks like a Pandas Series """
-    typ = type(s)
-    return (all(hasattr(typ, name) for name in ('groupby', 'head', 'mean')) and
-            all(hasattr(s, name) for name in ('dtype', 'name')) and
-            'index' not in typ.__name__.lower())
+    return dask_is_series_like(s)
 
 
 def is_index_like(s):
-    """ Looks like a Pandas Index """
-    typ = type(s)
-    return (all(hasattr(s, name) for name in ('name', 'dtype'))
-            and 'index' in typ.__name__.lower())
+    return dask_is_index_like(s)
 
 
 def check_meta(x, meta, funcname=None, numeric_equal=True):

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -931,6 +931,31 @@ def is_arraylike(x):
     )
 
 
+def is_dataframe_like(df):
+    """ Looks like a Pandas DataFrame """
+    typ = type(df)
+    return (all(hasattr(typ, name)
+                for name in ('groupby', 'head', 'merge', 'mean')) and
+            all(hasattr(df, name) for name in ('dtypes',)) and not
+            any(hasattr(typ, name)
+                for name in ('value_counts', 'dtype')))
+
+
+def is_series_like(s):
+    """ Looks like a Pandas Series """
+    typ = type(s)
+    return (all(hasattr(typ, name) for name in ('groupby', 'head', 'mean')) and
+            all(hasattr(s, name) for name in ('dtype', 'name')) and
+            'index' not in typ.__name__.lower())
+
+
+def is_index_like(s):
+    """ Looks like a Pandas Index """
+    typ = type(s)
+    return (all(hasattr(s, name) for name in ('name', 'dtype'))
+            and 'index' in typ.__name__.lower())
+
+
 def natural_sort_key(s):
     """
     Sorting `key` function for performing a natural sort on a collection of


### PR DESCRIPTION
Solves #4496.

@jakirkham as per our conversation yesterday, I think this is a good solution for #4496, this way we push NEP-18 compatibility forward and avoid the need for changes on NumPy side, or any other libraries.

@mrocklin FYI

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
