### PR TITLE
Support for map_blocks with no array arguments

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -573,15 +573,15 @@ def map_blocks(func, *args, **kwargs):
             if new_axis:
                 # anything using the keys in dsk is incorrect, as the
                 # original array doesn't have values for `new_axis`.
-                old_k = tuple(x for i, x in enumerate(k) if i not in new_axis)
+                old_k = tuple(x for i, x in enumerate(k[1:]) if i not in new_axis)
             else:
-                old_k = k
+                old_k = k[1:]
 
             info = {i: {'shape': shapes[i],
                         'num-chunks': num_chunks[i],
                         'array-location': [(starts[i][ij][j], starts[i][ij][j + 1])
-                                           for ij, j in enumerate(old_k[1:])],
-                        'chunk-location': old_k[1:]}
+                                           for ij, j in enumerate(old_k)],
+                        'chunk-location': old_k}
                     for i in shapes}
             info[None] = {'shape': out.shape,
                           'num-chunks': out.numblocks,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -417,14 +417,17 @@ def map_blocks(func, *args, **kwargs):
      None: {'shape': (1000,),
             'num-chunks': (10,),
             'chunk-location': (4,),
-            array-location: [(400, 500)]}}
+            'array-location': [(400, 500)],
+            'chunk-shape': (100,),
+            'dtype': dtype('float64')}}
 
     For each argument and keyword arguments that are dask arrays (the positions
     of which are the first index), you will receive the shape of the full
     array, the number of chunks of the full array in each dimension, the chunk
     location (for example the fourth chunk over in the first dimension), and
     the array location (for example the slice corresponding to ``40:50``). The
-    same information is provided for the output, with the key ``None``.
+    same information is provided for the output, with the key ``None``, plus
+    the shape and dtype that should be returned.
 
     These features can be combined to synthesize an array from scratch, for
     example:
@@ -584,7 +587,10 @@ def map_blocks(func, *args, **kwargs):
                           'num-chunks': out.numblocks,
                           'array-location': [(out_starts[ij][j], out_starts[ij][j + 1])
                                              for ij, j in enumerate(k[1:])],
-                          'chunk-location': k[1:]}
+                          'chunk-location': k[1:],
+                          'chunk-shape': tuple(out.chunks[ij][j]
+                                               for ij, j in enumerate(k[1:])),
+                          'dtype': dtype}
 
             v = copy.copy(v)  # Need to copy and unpack subgraph callable
             v.dsk = copy.copy(v.dsk)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1210,6 +1210,16 @@ def test_map_blocks_dtype_inference():
     assert 'RuntimeError' in msg
 
 
+def test_map_blocks_no_array_args():
+    def func(dtype, block_info=None):
+        loc = block_info[None]['array-location']
+        return np.arange(loc[0][0], loc[0][1], dtype=dtype)
+
+    x = da.map_blocks(func, np.float32, new_axis=[0], chunks=((5, 3),), dtype=np.float32)
+    assert x.chunks == ((5, 3),)
+    assert_eq(x, np.arange(8, dtype=np.float32))
+
+
 def test_repr():
     d = da.ones((4, 4), chunks=(2, 2))
     assert key_split(d.name) in repr(d)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1210,12 +1210,18 @@ def test_map_blocks_dtype_inference():
     assert 'RuntimeError' in msg
 
 
+def test_map_blocks_infer_newaxis():
+    x = da.ones((5, 3), chunks=(2, 2))
+    y = da.map_blocks(lambda x: x[None], x, chunks=((1,), (2, 2, 1), (2, 1)))
+    assert_eq(y, da.ones((1, 5, 3)))
+
+
 def test_map_blocks_no_array_args():
     def func(dtype, block_info=None):
         loc = block_info[None]['array-location']
         return np.arange(loc[0][0], loc[0][1], dtype=dtype)
 
-    x = da.map_blocks(func, np.float32, new_axis=[0], chunks=((5, 3),), dtype=np.float32)
+    x = da.map_blocks(func, np.float32, chunks=((5, 3),), dtype=np.float32)
     assert x.chunks == ((5, 3),)
     assert_eq(x, np.arange(8, dtype=np.float32))
 
@@ -2622,7 +2628,7 @@ def test_map_blocks_with_changed_dimension():
 
     # Provided chunks have wrong shape
     with pytest.raises(ValueError):
-        d.map_blocks(lambda b: b.sum(axis=0), chunks=(7, 4), drop_axis=0)
+        d.map_blocks(lambda b: b.sum(axis=0), chunks=(), drop_axis=0)
 
     with pytest.raises(ValueError):
         d.map_blocks(lambda b: b.sum(axis=0), chunks=((4, 4, 4),), drop_axis=0)

--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -290,6 +290,34 @@ def test_blockwise_stacked_new_axes_same_dim(concatenate):
     assert_eq(c, np.ones((5, 7)))
 
 
+def test_blockwise_new_axes_chunked():
+    def f(x):
+        return x[None, :] * 2
+
+    x = da.arange(0, 6, 1, chunks=2, dtype=np.int32)
+    y = da.blockwise(f, 'qa', x, 'a', new_axes={'q': (1, 1)}, dtype=x.dtype)
+    assert y.chunks == ((1, 1), (2, 2, 2))
+    assert_eq(y, np.array([[0, 2, 4, 6, 8, 10], [0, 2, 4, 6, 8, 10]], np.int32))
+
+
+def test_blockwise_no_args():
+    def f():
+        return np.ones((2, 3), np.float32)
+
+    x = da.blockwise(f, 'ab', new_axes={'a': 2, 'b': (3, 3)}, dtype=np.float32)
+    assert x.chunks == ((2,), (3, 3))
+    assert_eq(x, np.ones((2, 6), np.float32))
+
+
+def test_blockwise_no_array_args():
+    def f(dtype):
+        return np.ones((2, 3), dtype)
+
+    x = da.blockwise(f, 'ab', np.float32, None, new_axes={'a': 2, 'b': (3, 3)}, dtype=np.float32)
+    assert x.chunks == ((2,), (3, 3))
+    assert_eq(x, np.ones((2, 6), np.float32))
+
+
 def test_blockwise_kwargs():
     def f(a, b=0):
         return a + b

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -315,8 +315,8 @@ def make_blockwise_graph(func, output, out_indices, *arrind_pairs, **kwargs):
 
     # Dictionary mapping {i: 3, j: 4, ...} for i, j, ... the dimensions
     dims = broadcast_dimensions(argpairs, numblocks)
-    for k in new_axes:
-        dims[k] = 1
+    for k, v in new_axes.items():
+        dims[k] = len(v) if isinstance(v, tuple) else 1
 
     # (0, 0), (0, 1), (0, 2), (1, 0), ...
     keytups = list(itertools.product(*[range(dims[i]) for i in out_indices]))


### PR DESCRIPTION
This comprises multiple pieces:
- Make `unify_chunks` work correctly when given only constants
- If there are no arguments, consider the output to be zero-dimensional
  prior to application of `new_axis`.
- Allow blockwise to take a list of chunk sizes in `new_axes` instead of
  just a length.
- Add an entry to `block_info` to describe the output.

- [X] Tests added / passed
- [X] Passes `flake8 dask`
