### PR TITLE
Add sizeof support for cupy.ndarray

### DIFF
--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import dask.array as da
+from dask.sizeof import sizeof
 from dask.array.utils import assert_eq
 
 cupy = pytest.importorskip('cupy')
@@ -60,3 +61,10 @@ def test_basic(func):
     if ddc.shape:
         result = ddc.compute(scheduler='single-threaded')
         assert isinstance(result, cupy.ndarray)
+
+
+@pytest.mark.parametrize('dtype', ['f4', 'f8'])
+def test_sizeof(dtype):
+    c = cupy.random.random((2, 3, 4), dtype=dtype)
+
+    assert sizeof(c) == c.nbytes

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -28,6 +28,15 @@ def sizeof_python_collection(seq):
     return getsizeof(seq) + sum(map(sizeof, seq))
 
 
+@sizeof.register_lazy("cupy")
+def register_cupy():
+    import cupy
+
+    @sizeof.register(cupy.ndarray)
+    def sizeof_cupy_ndarray(x):
+        return int(x.nbytes)
+
+
 @sizeof.register_lazy("numpy")
 def register_numpy():
     import numpy as np


### PR DESCRIPTION
@mrocklin we need this to properly calculate size of `cupy.ndarray`s to spill their memory to host/disk.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
