### PR TITLE
Add warning about derived docstrings early in the docstring

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -404,3 +404,18 @@ def test_derived_from():
     assert Bar.f.__doc__.strip().startswith('A super docstring')
     assert "Foo.f" in Bar.f.__doc__
     assert any("inconsistencies" in line for line in Bar.f.__doc__.split('\n')[:7])
+
+    [b_arg] = [line for line in Bar.f.__doc__.split('\n') if 'b:' in line]
+    assert "not supported" in b_arg.lower()
+    assert "dask" in b_arg.lower()
+
+
+@pytest.mark.skipif(PY2, reason="Docstrings not as easy to manipulate in Py2")
+def test_derived_from_dask_dataframe():
+    dd = pytest.importorskip('dask.dataframe')
+
+    assert "inconsistencies" in dd.Series.dropna.__doc__
+
+    [axis_arg] = [line for line in dd.Series.dropna.__doc__.split('\n') if 'axis :' in line]
+    assert "not supported" in axis_arg.lower()
+    assert "dask" in axis_arg.lower()

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -414,8 +414,8 @@ def test_derived_from():
 def test_derived_from_dask_dataframe():
     dd = pytest.importorskip('dask.dataframe')
 
-    assert "inconsistencies" in dd.Series.dropna.__doc__
+    assert "inconsistencies" in dd.DataFrame.dropna.__doc__
 
-    [axis_arg] = [line for line in dd.Series.dropna.__doc__.split('\n') if 'axis :' in line]
+    [axis_arg] = [line for line in dd.DataFrame.dropna.__doc__.split('\n') if 'axis :' in line]
     assert "not supported" in axis_arg.lower()
     assert "dask" in axis_arg.lower()

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -10,7 +10,7 @@ from dask.utils import (takes_multiple_arguments, Dispatch, random_state_data,
                         memory_repr, methodcaller, M, skip_doctest,
                         SerializableLock, funcname, ndeepmap, ensure_dict,
                         extra_titles, asciitable, itemgetter, partial_by_order,
-                        has_keyword)
+                        has_keyword, derived_from)
 from dask.utils_test import inc
 from dask.highlevelgraph import HighLevelGraph
 
@@ -378,3 +378,28 @@ def test_has_keyword():
     bar = functools.partial(foo, a=1)
     assert has_keyword(bar, 'b')
     assert has_keyword(bar, 'c')
+
+
+def test_derived_from():
+    class Foo:
+        def f(a, b):
+            """ A super docstring
+
+            An explanation
+
+            Parameters
+            ----------
+            a: int
+                an explanation of a
+            b: float
+                an explanation of b
+            """
+
+    class Bar:
+        @derived_from(Foo)
+        def f(a, c):
+            pass
+
+    assert Bar.f.__doc__.strip().startswith('A super docstring')
+    assert "Foo.f" in Bar.f.__doc__
+    assert any("inconsistencies" in line for line in Bar.f.__doc__.split('\n')[:7])

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -380,6 +380,7 @@ def test_has_keyword():
     assert has_keyword(bar, 'c')
 
 
+@pytest.mark.skipif(PY2, reason="Docstrings not as easy to manipulate in Py2")
 def test_derived_from():
     class Foo:
         def f(a, b):

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -498,6 +498,25 @@ def derived_from(original_klass, version=None, ua_args=[]):
             if doc is None:
                 doc = ''
 
+            # Insert disclaimer near the top, after the title.
+            if doc:
+                copied = (
+                    "This docstring was copied from %s.%s.%s\n"
+                    "Some inconsistencies with the Dask version may exist. "
+                    % (original_klass.__module__, original_klass.__name__,
+                        method_name)
+                )
+
+                lines = doc.split('\n')
+                empty = 0
+                for i, line in enumerate(lines):
+                    if not line.strip():
+                        empty += 1
+                    if empty == 2:
+                        break
+                lines[i:i+1] = [''] + copied.split('\n') + ['']
+                doc = '\n'.join(lines)
+
             try:
                 method_args = get_named_args(method)
                 original_args = get_named_args(original_method)
@@ -509,9 +528,9 @@ def derived_from(original_klass, version=None, ua_args=[]):
                 not_supported.extend(ua_args)
 
             if len(not_supported) > 0:
-                note = ("\n        Notes\n        -----\n"
-                        "        Dask doesn't support the following argument(s).\n\n")
-                args = ''.join(['        * {0}\n'.format(a) for a in not_supported])
+                note = ("\nNotes\n-----\n"
+                        "Dask doesn't support the following argument(s).\n\n")
+                args = ''.join(['- {0}\n'.format(a) for a in not_supported])
                 doc = doc + note + args
             doc = skip_doctest(doc)
             doc = extra_titles(doc)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -514,7 +514,7 @@ def derived_from(original_klass, version=None, ua_args=[]):
                         empty += 1
                     if empty == 2:
                         break
-                lines[i:i+1] = [''] + copied.split('\n') + ['']
+                lines[i:i + 1] = [''] + copied.split('\n') + ['']
                 doc = '\n'.join(lines)
 
             try:

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -474,6 +474,74 @@ def extra_titles(doc):
     return '\n'.join(lines)
 
 
+def ignore_warning(doc, cls, name):
+    l1 = "This docstring was copied from %s.%s.%s\n" % (cls.__module__, cls.__name__, name)
+    l2 = "Some inconsistencies with the Dask version may exist."
+
+    i = doc.find('\n\n')
+    if i == -1:
+        # No blank lines found
+        # Add our warning to the end with no blank line after
+        doc = '\n\n'.join([doc, '\n\n', l1, l2])
+    else:
+        # Insert our warning
+        head = doc[:i + 2]
+        tail = doc[i + 2:]
+        # Indentation of next line
+        indent = re.match(r'\s*', tail).group(0)
+        # Insert the warning, indented, with a blank line before and after
+        doc = ''.join([
+            head,
+            indent, l1,
+            indent, l2, '\n\n',
+            tail
+        ])
+
+    return doc
+
+
+def unsupported_arguments(doc, args):
+    """ Mark unsupported arguments with a disclaimer """
+    lines = doc.split('\n')
+    for arg in args:
+        subset = [(i, line) for i, line in enumerate(lines) if re.match(r'^\s*' + arg + ' ?:', line)]
+        if len(subset) == 1:
+            [(i, line)] = subset
+            lines[i] = line + "  (Not supported in Dask)"
+    return '\n'.join(lines)
+
+
+def _derived_from(cls, method, ua_args=[]):
+    """ Helper function for derived_from to ease testing """
+    # do not use wraps here, as it hides keyword arguments displayed
+    # in the doc
+    original_method = getattr(cls, method.__name__)
+    doc = original_method.__doc__
+    if doc is None:
+        doc = ''
+
+    # Insert disclaimer that this is a copied docstring
+    if doc:
+        doc = ignore_warning(doc, cls, method.__name__)
+
+    # Mark unsupported arguments
+    try:
+        method_args = get_named_args(method)
+        original_args = get_named_args(original_method)
+        not_supported = [m for m in original_args if m not in method_args]
+    except ValueError:
+        not_supported = []
+    if len(ua_args) > 0:
+        not_supported.extend(ua_args)
+    if len(not_supported) > 0:
+        doc = unsupported_arguments(doc, not_supported)
+
+    doc = skip_doctest(doc)
+    doc = extra_titles(doc)
+
+    return doc
+
+
 def derived_from(original_klass, version=None, ua_args=[]):
     """Decorator to attach original class's docstring to the wrapped method.
 
@@ -488,54 +556,8 @@ def derived_from(original_klass, version=None, ua_args=[]):
         original but not in Dask will automatically be added.
     """
     def wrapper(method):
-        method_name = method.__name__
-
         try:
-            # do not use wraps here, as it hides keyword arguments displayed
-            # in the doc
-            original_method = getattr(original_klass, method_name)
-            doc = original_method.__doc__
-            if doc is None:
-                doc = ''
-
-            # Insert disclaimer near the top, after the title.
-            if doc:
-                copied = (
-                    "This docstring was copied from %s.%s.%s\n"
-                    "Some inconsistencies with the Dask version may exist. "
-                    % (original_klass.__module__, original_klass.__name__,
-                        method_name)
-                )
-
-                lines = doc.split('\n')
-                empty = 0
-                for i, line in enumerate(lines):
-                    if not line.strip():
-                        empty += 1
-                    if empty == 2:
-                        break
-                lines[i:i + 1] = [''] + copied.split('\n') + ['']
-                doc = '\n'.join(lines)
-
-            try:
-                method_args = get_named_args(method)
-                original_args = get_named_args(original_method)
-                not_supported = [m for m in original_args if m not in method_args]
-            except ValueError:
-                not_supported = []
-
-            if len(ua_args) > 0:
-                not_supported.extend(ua_args)
-
-            if len(not_supported) > 0:
-                note = ("\nNotes\n-----\n"
-                        "Dask doesn't support the following argument(s).\n\n")
-                args = ''.join(['- {0}\n'.format(a) for a in not_supported])
-                doc = doc + note + args
-            doc = skip_doctest(doc)
-            doc = extra_titles(doc)
-
-            method.__doc__ = doc
+            method.__doc__ = _derived_from(original_klass, method, ua_args=ua_args)
             return method
 
         except AttributeError:
@@ -543,7 +565,7 @@ def derived_from(original_klass, version=None, ua_args=[]):
 
             @functools.wraps(method)
             def wrapped(*args, **kwargs):
-                msg = "Base package doesn't support '{0}'.".format(method_name)
+                msg = "Base package doesn't support '{0}'.".format(method.__name__)
                 if version is not None:
                     msg2 = " Use {0} {1} or later to use this method."
                     msg += msg2.format(module_name, version)


### PR DESCRIPTION
Previously this was at the end of the docstring,
which many users fail to read.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
