### PR TITLE
Fix slow single threaded action on isin

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2133,7 +2133,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
 
     @derived_from(pd.Series)
     def isin(self, values):
-        return elemwise(M.isin, self, list(values))
+        return elemwise(M.isin, self, list(values), meta=pd.Series(dtype=bool))
 
     @insert_meta_param_description(pad=12)
     @derived_from(pd.Series)
@@ -3401,7 +3401,7 @@ def elemwise(op, *args, **kwargs):
         Function to apply across input dataframes
     *args: DataFrames, Series, Scalars, Arrays,
         The arguments of the operation
-    **kwrags: scalars
+    **kwargs: scalars
     meta: pd.DataFrame, pd.Series (optional)
         Valid metadata for the operation.  Will evaluate on a small piece of
         data if not provided.


### PR DESCRIPTION
Fixes #3198 

Works for me, I don't know how to write a test for this, but the fix works great and makes sense as isin will always return a bool.

I didn't touch the DataFrame version as I don't have a test for that and I'm not sure it's actually implemented even though there's a method for it.