### PR TITLE
Allow naive concatenation of sorted dataframes

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1692,7 +1692,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         return self.map_partitions(M.astype, dtype=dtype, meta=meta)
 
     @derived_from(pd.Series)
-    def append(self, other):
+    def append(self, other, interleave_partitions=False):
         # because DataFrame.append will override the method,
         # wrap by pd.Series.append docstring
         from .multi import concat
@@ -1701,7 +1701,8 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
             msg = "append doesn't support list or dict input"
             raise NotImplementedError(msg)
 
-        return concat([self, other], join='outer', interleave_partitions=False)
+        return concat([self, other], join='outer',
+                      interleave_partitions=interleave_partitions)
 
     @derived_from(pd.DataFrame)
     def align(self, other, join='outer', axis=None, fill_value=None):
@@ -2991,14 +2992,15 @@ class DataFrame(_Frame):
                      npartitions=npartitions, shuffle=shuffle)
 
     @derived_from(pd.DataFrame)
-    def append(self, other):
+    def append(self, other, interleave_partitions=False):
         if isinstance(other, Series):
             msg = ('Unable to appending dd.Series to dd.DataFrame.'
                    'Use pd.Series to append as row.')
             raise ValueError(msg)
         elif is_series_like(other):
             other = other.to_frame().T
-        return super(DataFrame, self).append(other)
+        return super(DataFrame, self).append(
+            other, interleave_partitions=interleave_partitions)
 
     @derived_from(pd.DataFrame)
     def iterrows(self):

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -503,7 +503,6 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
 
     Parameters
     ----------
-
     dfs : list
         List of dask.DataFrames to be concatenated
     axis : {0, 1, 'index', 'columns'}, default 0
@@ -524,7 +523,6 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
 
     Examples
     --------
-
     If all divisions are known and ordered, divisions are kept.
 
     >>> a                                               # doctest: +SKIP
@@ -611,9 +609,8 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
             elif interleave_partitions:
                 return concat_indexed_dataframes(dfs, join=join)
             else:
-                raise ValueError('All inputs have known divisions which '
-                                 'cannot be concatenated in order. Specify '
-                                 'interleave_partitions=True to ignore order')
+                divisions = [None] * (sum([df.npartitions for df in dfs]) + 1)
+                return stack_partitions(dfs, divisions, join=join)
         else:
             divisions = [None] * (sum([df.npartitions for df in dfs]) + 1)
             return stack_partitions(dfs, divisions, join=join)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1019,10 +1019,6 @@ def test_concat4_interleave_partitions():
     for case in cases:
         pdcase = [c.compute() for c in case]
 
-        with pytest.raises(ValueError) as err:
-            dd.concat(case)
-        assert msg in str(err.value)
-
         assert_eq(dd.concat(case, interleave_partitions=True),
                   pd.concat(pdcase, **concat_kwargs))
         assert_eq(dd.concat(case, join='inner', interleave_partitions=True),
@@ -1223,13 +1219,6 @@ def test_append():
     check_with_warning(ddf, df3, df, df3)
     check_with_warning(ddf.a, df3.b, df.a, df3.b)
 
-    df4 = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6],
-                        'b': [1, 2, 3, 4, 5, 6]},
-                       index=[4, 5, 6, 7, 8, 9])
-    ddf4 = dd.from_pandas(df4, 2)
-    with pytest.raises(ValueError):
-        ddf.append(ddf4)
-
 
 @pytest.mark.filterwarnings("ignore")
 def test_append2():
@@ -1322,6 +1311,15 @@ def test_append_categorical():
         res = ddf1.index.append(ddf2.index)
         assert_eq(res, df1.index.append(df2.index))
         assert has_known_categories(res) == known
+
+
+def test_append_lose_divisions():
+    df = pd.DataFrame({'x': [1, 2, 3, 4]}, index=[1, 2, 3, 4])
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    ddf2 = ddf.append(ddf)
+    df2 = df.append(df)
+    assert_eq(ddf2, df2)
 
 
 def test_singleton_divisions():


### PR DESCRIPTION
Previously we would raise a somewhat confusing error when a user tried
to concatenate dataframes that were sorted, pointing them towards
`interleave_partitions=True`.  Now we allow this behavior without
complaint, producing an unsorted dataframe.

This stops guiding users towards correct behavior, but also reduces the
confusion for novice users.

Fixes https://github.com/dask/dask/issues/4693

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
