### PR TITLE
Fix perf issue in dd.Series.isin

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -795,13 +795,28 @@ def test_unique():
 
 
 def test_isin():
-    # Series test
-    assert_eq(d.a.isin([0, 1, 2]), full.a.isin([0, 1, 2]))
-    assert_eq(d.a.isin(pd.Series([0, 1, 2])),
-              full.a.isin(pd.Series([0, 1, 2])))
+    f_list = [1, 2, 3]
+    f_series = pd.Series(f_list)
+    f_dict = {'a': [0, 3], 'b': [1, 2]}
+
+    # Series
+    assert_eq(d.a.isin(f_list), full.a.isin(f_list))
+    assert_eq(d.a.isin(f_series), full.a.isin(f_series))
+    with pytest.raises(NotImplementedError):
+        d.a.isin(d.a)
+
+    # Index
+    da.utils.assert_eq(d.index.isin(f_list), full.index.isin(f_list))
+    da.utils.assert_eq(d.index.isin(f_series), full.index.isin(f_series))
+    with pytest.raises(NotImplementedError):
+        d.a.isin(d.a)
 
     # DataFrame test
-    assert_eq(d.isin([0, 1, 2]), full.isin([0, 1, 2]))
+    assert_eq(d.isin(f_list), full.isin(f_list))
+    assert_eq(d.isin(f_dict), full.isin(f_dict))
+    for obj in [d, f_series, full]:
+        with pytest.raises(NotImplementedError):
+            d.isin(obj)
 
 
 def test_len():


### PR DESCRIPTION
Previously this was slow for large lists/large npartitions for two
reasons:

- The `values` object was part of every task in the graph, increasing
the serialization cost between workers, and traversal cost when
evaluating on a worker.
- The `values` object is usually a builtin python collection (usually a
list), which coupled with the above would significantly slow down our
optimization passes as a large list was traversed once for every
partition.

We now wrap `values` in `delayed`, avoiding both of these problems.

Also expanded test coverage for `isin`, explicitly forbidding a few odd
arguments we don't support.

Fixes #4726, #3198.
