### PR TITLE
Fix documentation requirements

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 numpydoc==0.8
 sphinx
-  #dask_sphinx_theme>=1.1.0
+dask_sphinx_theme>=1.1.0
 toolz
 cloudpickle
 pandas>=0.19.0


### PR DESCRIPTION
The `dask_sphinx_theme` package in `docs/requirements-docs.txt` was commented out in #4679 which is causing the readthedocs build to fail (ref https://readthedocs.org/projects/dask/builds/8949208/). This PR fixes this issue  