### PR TITLE
[REVIEW] Initial version of non-groupby _take_last

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4204,9 +4204,8 @@ def _take_last(a, skipna=True):
         Whether to exclude NaN
 
     """
-
     def _last_valid(s):
-        for i in range(1, min(10, len(s))):
+        for i in range(1, min(10, len(s)+1)):
             val = s.iloc[-i]
             if not pd.isnull(val):
                 return val
@@ -4222,7 +4221,9 @@ def _take_last(a, skipna=True):
         # take last valid value excluding NaN, NaN location may be different
         # in each column
         if is_dataframe_like(a):
-            return pd.Series({col: _last_valid(a[col]) for col in a.columns}, index=a.columns)
+            # create Series of appropriate backend dataframe library
+            series_typ = type(a.iloc[0])
+            return series_typ({col: _last_valid(a[col]) for col in a.columns}, index=a.columns)
         else:
             return _last_valid(a)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4221,9 +4221,12 @@ def _take_last(a, skipna=True):
         # take last valid value excluding NaN, NaN location may be different
         # in each column
         if is_dataframe_like(a):
-            # create Series of appropriate backend dataframe library
-            series_typ = type(a.iloc[0])
-            return series_typ({col: _last_valid(a[col]) for col in a.columns}, index=a.columns)
+            # create Series from appropriate backend dataframe library
+            series_typ = type(a.loc[0:1, a.columns[0]])
+            if a.empty:
+                return series_typ([])
+            return series_typ({col: _last_valid(a[col]) for col in a.columns},
+                              index=a.columns)
         else:
             return _last_valid(a)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4222,7 +4222,7 @@ def _take_last(a, skipna=True):
         # take last valid value excluding NaN, NaN location may be different
         # in each column
         if is_dataframe_like(a):
-            return pd.Series({col: _last_valid(a[col]) for col in a.columns}, columns=a.columns)
+            return pd.Series({col: _last_valid(a[col]) for col in a.columns}, index=a.columns)
         else:
             return _last_valid(a)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4205,10 +4205,10 @@ def _take_last(a, skipna=True):
 
     """
 
-    def _collect_series_last_valid(s):
+    def _last_valid(s):
         size = len(s)
-        for i in range(size - 1, max(size - 11, 0) - 1, -1):
-            val = s.iloc[i]
+        for i in range(1, min(10, size)):
+            val = s.iloc[-i]
             if not pd.isnull(val):
                 return val
         else:
@@ -4217,24 +4217,15 @@ def _take_last(a, skipna=True):
                 return nonnull.iloc[-1]
         return None
 
-    def _collect_frame_last_valid(frame):
-        last_valid_rows = {}
-        for col in a.columns:
-            last_val = _collect_series_last_valid(a[col])
-            last_valid_rows[col] = last_val
-        return last_valid_rows
-
     if skipna is False:
         return a.iloc[-1]
     else:
         # take last valid value excluding NaN, NaN location may be different
         # in each column
         if is_dataframe_like(a):
-            last_valid_rows = _collect_frame_last_valid(a)
-            return pd.Series(last_valid_rows, index=a.columns)
+            return pd.Series({col: _last_valid(a[col]) for col in a.columns}, columns=a.columns)
         else:
-            last_valid = _collect_series_last_valid(a)
-            return last_valid
+            return _last_valid(a)
 
 
 def check_divisions(divisions):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4205,7 +4205,7 @@ def _take_last(a, skipna=True):
 
     """
     def _last_valid(s):
-        for i in range(1, min(10, len(s)+1)):
+        for i in range(1, min(10, len(s) + 1)):
             val = s.iloc[-i]
             if not pd.isnull(val):
                 return val

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4206,8 +4206,7 @@ def _take_last(a, skipna=True):
     """
 
     def _last_valid(s):
-        size = len(s)
-        for i in range(1, min(10, size)):
+        for i in range(1, min(10, len(s))):
             val = s.iloc[-i]
             if not pd.isnull(val):
                 return val

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -405,6 +405,25 @@ def test_cumulative():
     assert_eq(df.cumprod(axis=1, skipna=False), ddf.cumprod(axis=1, skipna=False))
 
 
+@pytest.mark.parametrize(
+    'func',
+    [M.cumsum,
+     M.cumprod,
+     pytest.param(M.cummin, marks=[pytest.mark.xfail(
+         reason='ValueError: Can only compare identically-labeled Series objects')]),
+     pytest.param(M.cummax, marks=[pytest.mark.xfail(
+         reason='ValueError: Can only compare identically-labeled Series objects')])]
+)
+def test_cumulative_empty_partitions(func):
+    df = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6, 7, 8]})
+    ddf = dd.from_pandas(df, npartitions=4)
+    assert_eq(func(df[df.x < 5]), func(ddf[ddf.x < 5]))
+
+    df = pd.DataFrame({'x': [1, 2, 3, 4, None, 5, 6, None, 7, 8]})
+    ddf = dd.from_pandas(df, npartitions=5)
+    assert_eq(func(df[df.x < 5]), func(ddf[ddf.x < 5]))
+
+
 def test_dropna():
     df = pd.DataFrame({'x': [np.nan, 2, 3, 4, np.nan, 6],
                        'y': [1, 2, np.nan, 4, np.nan, np.nan],


### PR DESCRIPTION
**Summary of Changes**
- Refactors `_take_last` to remove the `groupby.last()` usage
    - Uses a two-tiered approach to find the last valid value in order to maintain speed. New approach is significantly faster than the groupby.last() approach for large data sizes and comparable at smaller sizes.
- Replaces explicit pandas references with a check for whether the object is dataframe-like and uses the appropriate Series constructor based on the types.

- [x] Existing tests passed
- [ ] Added and passed test for empty partitions scenario
- [x] Passes `flake8 dask`

This closes #4732 and will also close #4743.