### PR TITLE
Fixup series-groupby-apply

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1845,6 +1845,28 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         """
         return self.map_partitions(methods.values)
 
+    def _is_index_level_reference(self, key):
+        """
+        Test whether a key is an index level reference
+
+        To be considered an index level reference, `key` must match the index name
+        and must NOT match the name of any column (if a dataframe).
+        """
+        return (self.index.name is not None and
+                not is_dask_collection(key) and
+                (np.isscalar(key) or isinstance(key, tuple)) and
+                key == self.index.name and
+                key not in getattr(self, 'columns', ()))
+
+    def _contains_index_name(self, columns_or_index):
+        """
+        Test whether the input contains a reference to the index of the DataFrame/Series
+        """
+        if isinstance(columns_or_index, list):
+            return any(self._is_index_level_reference(n) for n in columns_or_index)
+        else:
+            return self._is_index_level_reference(columns_or_index)
+
 
 def _raise_if_object_series(x, funcname):
     """
@@ -3333,28 +3355,6 @@ class DataFrame(_Frame):
         return (not is_dask_collection(key) and
                 (np.isscalar(key) or isinstance(key, tuple)) and
                 key in self.columns)
-
-    def _is_index_level_reference(self, key):
-        """
-        Test whether a key is an index level reference
-
-        To be considered an index level reference, `key` must match the index name
-        and must NOT match the name of any column.
-        """
-        return (self.index.name is not None and
-                not is_dask_collection(key) and
-                (np.isscalar(key) or isinstance(key, tuple)) and
-                key == self.index.name and
-                key not in self.columns)
-
-    def _contains_index_name(self, columns_or_index):
-        """
-        Test whether the input contains a reference to the index of the DataFrame
-        """
-        if isinstance(columns_or_index, list):
-            return any(self._is_index_level_reference(n) for n in columns_or_index)
-        else:
-            return self._is_index_level_reference(columns_or_index)
 
 
 # bind operators

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -239,6 +239,9 @@ def test_groupby_on_index(scheduler):
     def func2(df):
         return df[['b']] - df[['b']].mean()
 
+    def func3(df):
+        return df.mean()
+
     with dask.config.set(scheduler=scheduler):
         with pytest.warns(None):
             assert_eq(ddf.groupby('a').apply(func),
@@ -249,6 +252,12 @@ def test_groupby_on_index(scheduler):
 
             assert_eq(pdf2.groupby(pdf2.index).apply(func2),
                       ddf2.groupby(ddf2.index).apply(func2))
+
+            assert_eq(ddf2.b.groupby('a').apply(func3),
+                      pdf2.b.groupby('a').apply(func3))
+
+            assert_eq(ddf2.b.groupby(ddf2.index).apply(func3),
+                      pdf2.b.groupby(pdf2.index).apply(func3))
 
 
 @pytest.mark.parametrize('grouper',
@@ -672,6 +681,13 @@ def test_apply_shuffle():
 
         assert_eq(ddf.groupby(ddf['A'] + 1)['B'].apply(lambda x: x.sum()),
                   pdf.groupby(pdf['A'] + 1)['B'].apply(lambda x: x.sum()))
+
+        # Series.groupby
+        assert_eq(ddf.B.groupby(ddf['A']).apply(lambda x: x.sum()),
+                  pdf.B.groupby(pdf['A']).apply(lambda x: x.sum()))
+
+        assert_eq(ddf.B.groupby(ddf['A'] + 1).apply(lambda x: x.sum()),
+                  pdf.B.groupby(pdf['A'] + 1).apply(lambda x: x.sum()))
 
         # DataFrameGroupBy with column slice
         assert_eq(ddf.groupby('A')[['B', 'C']].apply(lambda x: x.sum()),


### PR DESCRIPTION
Previously ``ddf[column].groupby(...).apply()`` would fail. We now
implement and test for grouping on index (no shuffle) and on column(s)
(needs shuffle).

Fixes #4590.
