### PR TITLE
Don't add disclaimer to ill-formed docstrings

### DIFF
--- a/dask/utils.py
+++ b/dask/utils.py
@@ -479,11 +479,7 @@ def ignore_warning(doc, cls, name):
     l2 = "Some inconsistencies with the Dask version may exist."
 
     i = doc.find('\n\n')
-    if i == -1:
-        # No blank lines found
-        # Add our warning to the end with no blank line after
-        doc = '\n\n'.join([doc, '\n\n', l1, l2])
-    else:
+    if i != -1:
         # Insert our warning
         head = doc[:i + 2]
         tail = doc[i + 2:]


### PR DESCRIPTION
Previously this added a disclaimer to the end of docstrings that didn't
have a blank line.  Unfortunately we didn't handle indentation well,
which caused docstrings both to look odd, and to crash sphinx in a
non-informative way.  For now lets just punt on adding the disclaimer to
these docstrings.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
