### PR TITLE
Add dtype= parameter to da.random.randint

### DIFF
--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -331,8 +331,8 @@ class RandomState(object):
         return self._wrap('power', a, size=size, chunks=chunks)
 
     @doc_wraps(np.random.RandomState.randint)
-    def randint(self, low, high=None, size=None, chunks="auto"):
-        return self._wrap('randint', low, high, size=size, chunks=chunks)
+    def randint(self, low, high=None, size=None, chunks="auto", dtype='l'):
+        return self._wrap('randint', low, high, size=size, chunks=chunks, dtype=dtype)
 
     @doc_wraps(np.random.RandomState.random_integers)
     def random_integers(self, low, high=None, size=None, chunks="auto"):

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -323,3 +323,5 @@ def test_auto_chunks():
 def test_randint_dtype():
     x = da.random.randint(0, 255, size=10, dtype='uint8')
     assert_eq(x, x)
+    assert x.dtype == 'uint8'
+    assert x.compute().dtype == 'uint8'

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -318,3 +318,8 @@ def test_auto_chunks():
     with dask.config.set({'array.chunk-size': '50 MiB'}):
         x = da.random.random((10000, 10000))
         assert 4 < x.npartitions < 32
+
+
+def test_randint_dtype():
+    x = da.random.randint(0, 255, size=10, dtype='uint8')
+    assert_eq(x, x)


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/4579
Supercedes https://github.com/dask/dask/pull/4607

Also checked to see if there were any other cases of dtype being
supported with

```
import numpy

for func in dir(np.random):
    if 'dtype=' in (getattr(np.random, func).__doc__ or ''):
        print(func)
```

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
