### PR TITLE
Add test for dtype casting

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3629,3 +3629,26 @@ def test_str_expand_more_columns():
     ds = dd.from_pandas(s, npartitions=2)
 
     s.str.split(n=10, expand=True).compute()
+
+
+def test_dtype_cast():
+    df = pd.DataFrame({
+        'A': np.arange(10, dtype=np.int32),
+        'B': np.arange(10, dtype=np.int64),
+        'C': np.arange(10, dtype=np.float32),
+    })
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert ddf.A.dtype == np.int32
+    assert ddf.B.dtype == np.int64
+    assert ddf.C.dtype == np.float32
+
+    col = pd.Series(np.arange(10, dtype=np.float32)) / 2
+    assert col.dtype == np.float32
+
+    ddf = ddf.assign(D=col)
+    assert ddf.D.dtype == np.float32
+    assert ddf.C.dtype == np.float32
+    # fails
+    assert ddf.B.dtype == np.int64
+    # fails
+    assert ddf.A.dtype == np.int32


### PR DESCRIPTION
Fixes #4398

- [x] Tests added / passed
- [x] Passes `flake8 dask`
