### PR TITLE
Fix OMP_NUM_THREADS code block in array best practices

### DIFF
--- a/docs/source/array-best-practices.rst
+++ b/docs/source/array-best-practices.rst
@@ -75,7 +75,7 @@ to be told to use only one thread explicitly.  You can do this with the
 following environment variables (using bash ``export`` command below, but this
 may vary depending on your operating system).
 
-.. code-block::
+.. code-block:: bash
 
    export OMP_NUM_THREADS=1
    export MKL_NUM_THREADS=1


### PR DESCRIPTION
Currently the 

```bash
export OMP_NUM_THREADS=1
export MKL_NUM_THREADS=1
export OPENBLAS_NUM_THREADS=1
```

code block in the "Avoid Oversubscribing Threads" section of the array best practices documentation isn't being rendered. Specifying `bash` as the language fixed the issue locally. 