### PR TITLE
[REVIEW] Remove pandas dependency of cummin_aggregate and cummax_aggregate

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -7,7 +7,7 @@ import pandas as pd
 from pandas.api.types import is_categorical_dtype, union_categoricals
 from toolz import partition
 
-from .utils import PANDAS_VERSION, is_series_like
+from .utils import PANDAS_VERSION, is_series_like, is_dataframe_like
 from ..utils import Dispatch
 
 if PANDAS_VERSION >= '0.23':
@@ -145,14 +145,14 @@ def describe_aggregate(values):
 
 
 def cummin_aggregate(x, y):
-    if isinstance(x, (pd.Series, pd.DataFrame)):
+    if is_series_like(x) or is_dataframe_like(x):
         return x.where((x < y) | x.isnull(), y, axis=x.ndim - 1)
     else:       # scalar
         return x if x < y else y
 
 
 def cummax_aggregate(x, y):
-    if isinstance(x, (pd.Series, pd.DataFrame)):
+    if is_series_like(x) or is_dataframe_like(x):
         return x.where((x > y) | x.isnull(), y, axis=x.ndim - 1)
     else:       # scalar
         return x if x > y else y


### PR DESCRIPTION
**Summary of Changes**
- This PR removes the pandas Series and DataFrame dependency of `cummin_aggregate` and `cummax_aggregate` in favor of checking for series/dataframe like-ness, allowing potential non-pandas backends like cuDF to be used.

- [X] Tests passed (none added)
- [x] Passes `flake8 dask`

This closes #4747 