### PR TITLE
Point users to Dask-Yarn from spark documentation

### DIFF
--- a/docs/source/spark.rst
+++ b/docs/source/spark.rst
@@ -14,10 +14,9 @@ Summary
 -------
 
 Generally Dask is smaller and lighter weight than Spark.  This means that it
-has fewer features and, instead, is intended to be used in conjunction with other
-libraries, particularly those in the numeric Python ecosystem.  It couples with
-other libraries like Pandas or Scikit-Learn to achieve high-level
-functionality.
+has fewer features and, instead, is used in conjunction with other libraries,
+particularly those in the numeric Python ecosystem.  It couples with libraries
+like Pandas or Scikit-Learn to achieve high-level functionality.
 
 - Language
     - Spark is written in Scala with some support for Python and R.  It
@@ -121,6 +120,27 @@ Reasons you might choose Dask
    computing
 -  You want to interoperate with other technologies and don't mind installing
    multiple packages
+
+
+Reaons to choose both
+---------------------
+
+It is easy to use both Dask and Spark on the same data and on the same cluster.
+
+They can both read and write common formats, like CSV, JSON, ORC, and Parquet,
+making it easy to hand results off between Dask and Spark workflows.
+
+They can both deploy on the same clusters.
+Most clusters are designed to support many different distributed systems at the
+same time, using resource managers like Kubernetes and YARN.  If you already
+have a cluster on which you run Spark workloads, it's likely easy to also run
+Dask workloads on your current infrastructure and vice versa.
+
+In particular, for users coming from traditional Hadoop/Spark clusters (such as
+those sold by Cloudera/Hortonworks) you are likely using the Yarn resource
+manager.  You can deploy Dask on these systems using the `Dask Yarn
+<https://yarn.dask.org>`_ project, as well as other projects, like `JupyterHub
+on Hadoop <https://jcrist.github.io/jupyterhub-on-hadoop/>`_.
 
 
 Developer-Facing Differences

--- a/docs/source/spark.rst
+++ b/docs/source/spark.rst
@@ -137,7 +137,7 @@ have a cluster on which you run Spark workloads, it's likely easy to also run
 Dask workloads on your current infrastructure and vice versa.
 
 In particular, for users coming from traditional Hadoop/Spark clusters (such as
-those sold by Cloudera/Hortonworks) you are likely using the Yarn resource
+those sold by Cloudera/Hortonworks) you are using the Yarn resource
 manager.  You can deploy Dask on these systems using the `Dask Yarn
 <https://yarn.dask.org>`_ project, as well as other projects, like `JupyterHub
 on Hadoop <https://jcrist.github.io/jupyterhub-on-hadoop/>`_.


### PR DESCRIPTION
This page is our most highly trafficked page.
Lets direct traffic to the Dask-Yarn and JupyterHub-on-Hadoop pages from here.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`

cc @jcrist if you wanted to take over here I would welcome that.  I suspect that you can speak to this audience with more authority than I can.