### PR TITLE
Tweaks to develop.rst from trying to run tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,8 @@ collect_ignore = ['dask/bytes/hdfs3.py',
                   'dask/bytes/pyarrow.py',
                   'dask/bytes/s3.py',
                   'dask/array/ghost.py',
-                  'dask/array/fft.py']
+                  'dask/array/fft.py',
+                  'dask/dask/dataframe/io/io.py']
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,8 @@ collect_ignore = ['dask/bytes/hdfs3.py',
                   'dask/bytes/s3.py',
                   'dask/array/ghost.py',
                   'dask/array/fft.py',
-                  'dask/dask/dataframe/io/io.py']
+                  'dask/dataframe/io/io.py',
+                  'dask/dot.py']
 
 
 def pytest_addoption(parser):

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -97,6 +97,10 @@ For development, Dask uses the following additional dependencies::
 
    pip install pytest moto mock
 
+And the following dependencies are required to get all tests to pass::
+
+   conda install graphviz python-graphviz ipython
+
 
 Run Tests
 ~~~~~~~~~
@@ -118,7 +122,7 @@ language support, testing, documentation, and style.
 Python Versions
 ~~~~~~~~~~~~~~~
 
-Dask supports Python versions 2.7, 3.4, 3.5, and 3.6 in a single codebase.
+Dask supports Python versions 2.7, 3.5, 3.6, and 3.7 in a single codebase.
 Name changes are handled by the :file:`dask/compatibility.py` file.
 
 Test

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -97,10 +97,6 @@ For development, Dask uses the following additional dependencies::
 
    pip install pytest moto mock
 
-And the following dependencies are required to get all tests to pass::
-
-   conda install graphviz python-graphviz ipython
-
 
 Run Tests
 ~~~~~~~~~


### PR DESCRIPTION
Trying to follow the instructions in develop.rst and run all the tests, I get a pytest error unless I also install graphviz, python-graphviz and ipython. Here are some tweaks to the docs for that:

* Mention dependencies needed to get tests to run
* Also tweak "supported Python versions" line (while I'm here)

Otherwise, I get errors like the following during test collection with pytest:

```
__________________________________________________________________ ERROR collecting dask/tests/test_dot.py ___________________________________________________________________
dask/tests/test_dot.py:18: in <module>
    from IPython.display import Image, SVG
E   ModuleNotFoundError: No module named 'IPython'
__________________________________________________________________ ERROR collecting dask/tests/test_dot.py ___________________________________________________________________
ImportError while importing test module '/Users/chrish/Code/dask/dask/tests/test_dot.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
dask/tests/test_dot.py:18: in <module>
    from IPython.display import Image, SVG
E   ModuleNotFoundError: No module named 'IPython'
```
