### PR TITLE
Add core dask config file to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include setup.py
 include README.rst
 include LICENSE.txt
 include MANIFEST.in
+include dask/dask.yaml
 
 include versioneer.py
 include dask/_version.py

--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,5 @@ setup(name='dask',
       setup_requires=setup_requires,
       tests_require=['pytest'],
       extras_require=extras_require,
+      include_package_data=True,
       zip_safe=False)


### PR DESCRIPTION
Noticed CI failures in `distributed` (ref https://travis-ci.org/dask/distributed/jobs/529018634) that I think is related to the new `dask/dask.yaml` config file (added in #4774). 

I suspect `dask/dask.yaml` should be included in `MANIFEST.in` and we should have `include_package_data=True` in `setup.py`. This way `dask/dask.yaml` will be [included as a data file](https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files) when dask is installed. 

cc @mrocklin  