### PR TITLE
Provide parameter to dask.array.gufunc to fix output dtype bug in np.vectorize

### DIFF
--- a/dask/array/tests/test_gufunc.py
+++ b/dask/array/tests/test_gufunc.py
@@ -561,9 +561,18 @@ def run_mangled_output_dtype_test(reassign_vectorize_dtypes=None):
                       vectorize=True,
                       reassign_vectorize_dtypes=reassign_vectorize_dtypes)
 
-    x = np.array(['12', '23'], dtype=o_dtype)
+    x = np.array([['11', '12'], ['21', '22']], dtype=o_dtype)
     y = f(da.array(x)).compute()
-    np.testing.assert_array_equal(x, y)
+
+    np.testing.assert_array_equal(y, x)
+
+    # Check consistent with numpy.  This is not the same as testing the
+    # correctness of numpy.
+    g = np.vectorize(identity, otypes=(o_dtype,), signature="()->()")
+    if reassign_vectorize_dtypes is not True:
+        np.testing.assert_array_equal(g(x), y)
+    else:
+        assert not np.array_equal(g(x), y)
 
 
 def test_unicode_dtypes_in_gufunc_with_fix_true():

--- a/dask/array/tests/test_gufunc.py
+++ b/dask/array/tests/test_gufunc.py
@@ -541,3 +541,53 @@ def test_apply_gufunc_via_numba_02():
     y = mysum(a, axis=0, keepdims=True, allow_rechunk=True)
 
     assert_eq(x, y)
+
+
+def run_mangled_dtype_test(reassign_vectorize_dtypes=None):
+
+    def io_mapping():
+        # Create strings with sizes {8, 9, 10, 11}.  NOTE: '10' and '11' are
+        # 2-character strings.  If numpy changes the dtype to shorter strings
+        # (which it currently does, the output strings will be truncated to be
+        # 1 character in length.  This is bad and the behavior we want to
+        # correct.
+
+        output_dtype = "U2"  # Output SHOULD support length-2 strings.
+        sizes = np.arange(8, 12)
+        str_tpe = "U" + str(np.max(sizes))
+        inp = np.array(["-" * n for n in sizes], dtype=str_tpe).reshape(2, 2)
+        output = sizes.astype(output_dtype).reshape(2, 2)
+        return np.dtype(output_dtype), inp, output
+
+    output_dtypes, npa, expected_output = io_mapping()
+
+    if reassign_vectorize_dtypes is None:
+        str_len = da.gufunc(lambda x: len(str(x)),
+                            output_dtypes=output_dtypes,
+                            signature="()->()",
+                            vectorize=True)
+    else:
+        str_len = da.gufunc(lambda x: len(str(x)),
+                            output_dtypes=output_dtypes,
+                            signature="()->()",
+                            vectorize=True,
+
+                            # This assignment is what is under test.
+                            reassign_vectorize_dtypes=reassign_vectorize_dtypes)
+
+    out = str_len(da.array(npa)).compute()
+    np.testing.assert_array_equal(expected_output, out)
+
+
+def test_unicode_dtypes_in_gufunc_with_fix_true():
+    run_mangled_dtype_test(reassign_vectorize_dtypes=True)
+
+
+def test_unicode_dtypes_in_gufunc_with_fix_omitted():
+    with pytest.raises(AssertionError):
+        run_mangled_dtype_test()
+
+
+def test_unicode_dtypes_in_gufunc_with_fix_false():
+    with pytest.raises(AssertionError):
+        run_mangled_dtype_test(reassign_vectorize_dtypes=False)


### PR DESCRIPTION
`np.vectorize` can mangle the desired dtypes that are passed to it when creating a vectorized wrapper of a function.  This can be fixed by reassigning the output dtypes passed to `np.vectorize` to the wrapped function returned by `np.vectorize`.  

Because `apply_gufunc` calls `np.vectorize` inside its body, this fix cannot be applied in the dask gufunc case.  To overcome this, a Boolean keyword argument `reassign_vectorize_dtypes` is introduced that when provided and true, causes then reassignment of the output dtypes to the function wrapped by `np.vectorize`.  This provides enough power to fix the issue while not changing the default behavior.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`