### PR TITLE
Adding support of non-numeric data to describe() (#4401)

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1626,7 +1626,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
 
         colname = data._meta.name if isinstance(data._meta, pd.Series) else None
 
-        name = 'describe-numeric--' + tokenize(data, split_every)
+        name = 'describe-numeric--' + tokenize(num, split_every)
         layer = {(name, 0): (methods.describe_numeric_aggregate, stats_names, colname, is_timedelta_column)}
         graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
         meta = num._meta.describe()

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1546,7 +1546,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
                  exclude=None):
 
         if self._meta.ndim == 1:
-            return self._describe_1d(self)
+            return self._describe_1d(self, split_every, percentiles, percentiles_method)
         elif (include is None) and (exclude is None):
             data = self._meta.select_dtypes(include=[np.number, np.timedelta64])
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1536,34 +1536,127 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
                 return DataFrame(graph, keyname, meta, quantiles[0].divisions)
 
     @derived_from(pd.DataFrame)
-    def describe(self, split_every=False, percentiles=None, percentiles_method='default'):
-        """Currently, only numeric describe is supported """
-        num = self._get_numeric_data()
-        if self.ndim == 2 and len(num.columns) == 0:
-            raise ValueError("DataFrame contains only non-numeric data.")
-        elif self.ndim == 1 and self.dtype == 'object':
-            raise ValueError("Cannot compute ``describe`` on object dtype.")
-        if percentiles is None:
-            percentiles = [0.25, 0.5, 0.75]
+    def describe(self,
+                 split_every=False,
+                 percentiles=None,
+                 percentiles_method='default',
+                 include=None,
+                 exclude=None):
+
+        from pandas.api.types import is_bool_dtype, is_timedelta64_dtype, \
+            is_numeric_dtype, is_datetime64_any_dtype
+
+        def describe_numeric(data, split_every=False, percentiles=None,
+                             percentiles_method='default', is_timedelta_column=False):
+
+            num = data._get_numeric_data()
+
+            if data.ndim == 2 and len(num.columns) == 0:
+                raise ValueError("DataFrame contains only non-numeric data.")
+            elif data.ndim == 1 and data.dtype == 'object':
+                raise ValueError("Cannot compute ``describe`` on object dtype.")
+            if percentiles is None:
+                percentiles = [0.25, 0.5, 0.75]
+            else:
+                # always include the the 50%tle to calculate the median
+                # unique removes duplicates and sorts quantiles
+                percentiles = np.array(percentiles)
+                percentiles = np.append(percentiles, 0.5)
+                percentiles = np.unique(percentiles)
+                percentiles = list(percentiles)
+            stats = [num.count(split_every=split_every),
+                     num.mean(split_every=split_every),
+                     num.std(split_every=split_every),
+                     num.min(split_every=split_every),
+                     num.quantile(percentiles, method=percentiles_method),
+                     num.max(split_every=split_every)]
+            stats_names = [(s._name, 0) for s in stats]
+
+            colname = data._meta.name if isinstance(data._meta, pd.Series) else None
+
+            name = 'describe-numeric--' + tokenize(data, split_every)
+            layer = {(name, 0): (methods.describe_numeric_aggregate, stats_names, colname, is_timedelta_column)}
+            graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
+            meta = num._meta.describe()
+            return new_dd_object(graph, name, meta, divisions=[None, None])
+
+        def describe_categorical_1d(data, split_every=False):
+            vcounts = data.value_counts(split_every)
+            count_nonzero = vcounts[vcounts != 0]
+            count_unique = count_nonzero.size
+
+            stats = [
+                # nunique
+                count_unique,
+                # count
+                data.count(split_every=split_every),
+                # most common value
+                vcounts.head(1, compute=False)
+            ]
+
+            if is_datetime64_any_dtype(data._meta):
+                min_ts = data.dropna().astype('i8').min(split_every=split_every)
+                max_ts = data.dropna().astype('i8').max(split_every=split_every)
+                stats += [min_ts, max_ts]
+
+            stats_names = [(s._name, 0) for s in stats]
+            colname = data._meta.name
+
+            name = 'describe-categorical-1d--' + tokenize(data, split_every)
+            layer = {(name, 0): (methods.describe_categorical_aggregate, stats_names, colname)}
+            graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
+            meta = data._meta.describe()
+            return new_dd_object(graph, name, meta, divisions=[None, None])
+
+        def describe_1d(data):
+            if is_bool_dtype(data._meta):
+                return describe_categorical_1d(data, split_every=split_every)
+            elif is_numeric_dtype(data._meta):
+                return describe_numeric(
+                    data,
+                    split_every=split_every,
+                    percentiles=percentiles,
+                    percentiles_method=percentiles_method)
+            elif is_timedelta64_dtype(data._meta):
+                return describe_numeric(
+                    data.dropna().astype('i8'),
+                    split_every=split_every,
+                    percentiles=percentiles,
+                    percentiles_method=percentiles_method,
+                    is_timedelta_column=True)
+            else:
+                return describe_categorical_1d(data, split_every=split_every)
+
+        if self._meta.ndim == 1:
+            return describe_1d(self)
+        elif (include is None) and (exclude is None):
+            data = self._meta.select_dtypes(include=[np.number, np.timedelta64])
+
+            # when some numerics/timedeltas are found, by default keep them
+            if len(data.columns) == 0:
+                chosen_columns = self._meta.columns
+            else:
+                # check if there are timedelta columns
+                timedeltas = self._meta.select_dtypes(include=[np.timedelta64])
+                if len(timedeltas.columns) == 0:
+                    return describe_numeric(self, split_every, percentiles, percentiles_method)
+                else:
+                    chosen_columns = data.columns
+        elif include == 'all':
+            if exclude is not None:
+                msg = "exclude must be None when include is 'all'"
+                raise ValueError(msg)
+            chosen_columns = self._meta.columns
         else:
-            # always include the the 50%tle to calculate the median
-            # unique removes duplicates and sorts quantiles
-            percentiles = np.array(percentiles)
-            percentiles = np.append(percentiles, 0.5)
-            percentiles = np.unique(percentiles)
-            percentiles = list(percentiles)
-        stats = [num.count(split_every=split_every),
-                 num.mean(split_every=split_every),
-                 num.std(split_every=split_every),
-                 num.min(split_every=split_every),
-                 num.quantile(percentiles, method=percentiles_method),
-                 num.max(split_every=split_every)]
+            chosen_columns = self._meta.select_dtypes(include=include, exclude=exclude)
+
+        stats = [describe_1d(self[col_idx]) for col_idx in chosen_columns]
         stats_names = [(s._name, 0) for s in stats]
 
         name = 'describe--' + tokenize(self, split_every)
         layer = {(name, 0): (methods.describe_aggregate, stats_names)}
         graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
-        meta = num._meta.describe()
+        meta = self._meta.describe(include=include, exclude=exclude)
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
     def _cum_agg(self, op_name, chunk, aggregate, axis, skipna=True,

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -163,6 +163,8 @@ def describe_numeric_aggregate(stats, name=None, is_timedelta_col=False):
     part1 = typ([count, mean, std, min],
                 index=['count', 'mean', 'std', 'min'])
     q.index = ['{0:g}%'.format(l * 100) for l in q.index.tolist()]
+    if isinstance(q, pd.Series) and typ == pd.DataFrame:
+        q = q.to_frame()
     part3 = typ([max], index=['max'])
 
     result = pd.concat([part1, q, part3], **concat_kwargs)

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -144,7 +144,7 @@ def describe_aggregate(values):
             if name not in names:
                 names.append(name)
 
-    return pd.concat(values, join_axes=pd.Index([names]), axis=1)
+    return pd.concat(values, join_axes=[pd.Index(names)], axis=1)
 
 
 def describe_numeric_aggregate(stats, name=None, is_timedelta_col=False):
@@ -175,7 +175,7 @@ def describe_numeric_aggregate(stats, name=None, is_timedelta_col=False):
     return result
 
 
-def describe_categorical_aggregate(stats, name):
+def describe_nonnumeric_aggregate(stats, name):
     args_len = len(stats)
 
     is_datetime_column = args_len == 5
@@ -190,7 +190,7 @@ def describe_categorical_aggregate(stats, name):
 
     # input was empty dataframe/series
     if len(top_freq) == 0:
-        return pd.Series([0, 0], index=['count','unique'], name=name)
+        return pd.Series([0, 0], index=['count', 'unique'], name=name)
 
     top = top_freq.index[0]
     freq = top_freq.iloc[0]

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -351,17 +351,14 @@ def test_describe(include, exclude, percentiles, subset):
     desc_ddf = ddf.describe(include=include, exclude=exclude, percentiles=percentiles)
     desc_df = df.describe(include=include, exclude=exclude, percentiles=percentiles)
 
-    # Assert
     # TODO: for timedelta columns there's overflow in var function, see #4233
-    # causing std to be nan, workaround this allowing AssertionError on std sell
+    # causing std to be nan, workaround this by dropping timedelta column before assertion
     if 'f' in desc_ddf._meta:
-        with pytest.raises(AssertionError) as info:
-            assert_eq(desc_ddf, desc_df)
-            msg = "DataFrame.iloc[:, 2] are different"
-            assert msg in str(info.value)
-    else:
-        # Assert
-        assert_eq(desc_ddf, desc_df)
+        desc_df = desc_df.drop('f', axis=1)
+        desc_ddf = desc_ddf.drop('f', axis=1)
+
+    # Assert
+    assert_eq(desc_ddf, desc_df)
 
     # Check series
     if subset is None:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -384,8 +384,8 @@ def test_describe_empty_tdigest():
 
     df_none = pd.DataFrame({"A": [None, None]})
     ddf_none = dd.from_pandas(pd.DataFrame({"A": [None, None]}), 2)
-    df_len0 = pd.DataFrame({"A": [], "B":[]})
-    ddf_len0 = dd.from_pandas(pd.DataFrame({"A": [], "B":[]}), 2)
+    df_len0 = pd.DataFrame({"A": []})
+    ddf_len0 = dd.from_pandas(df_len0, 2)
     ddf_nocols = dd.from_pandas(pd.DataFrame({}), 2)
 
     assert_eq(df_none.describe(), ddf_none.describe(percentiles_method='tdigest').compute())

--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -124,7 +124,8 @@ class ProgressBar(Callback):
             return
         ndone = len(s['finished'])
         ntasks = sum(len(s[k]) for k in ['ready', 'waiting', 'running']) + ndone
-        self._draw_bar(ndone / ntasks if ntasks else 0, elapsed)
+        if ndone < ntasks:
+            self._draw_bar(ndone / ntasks if ntasks else 0, elapsed)
 
     def _draw_bar(self, frac, elapsed):
         bar = '#' * int(self._width * frac)


### PR DESCRIPTION
#4401 

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`

This PR adds handling of non-numeric dtypes in describe().