### PR TITLE
Add draft of Array._repr_html_

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1049,7 +1049,7 @@ class Array(DaskMethodsMixin):
             '  <tbody>',
             '    <tr><th> Bytes </th><td> %s </td> <td> %s </td></tr>' % (nbytes, cbytes),
             '    <tr><th> Shape </th><td> %s </td> <td> %s </td></tr>' % (str(self.shape), str(self.chunksize)),
-            '    <tr><th> Count </th><td> %d Tasks </td><td> %d chunks </td></tr>' % (
+            '    <tr><th> Count </th><td> %d Tasks </td><td> %d Chunks </td></tr>' % (
                 len(self.__dask_graph__()), self.npartitions),
             '    <tr><th> DType </th><td> %s </td><td></td></tr>' % self.dtype,
             '  </tbody>',

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1013,9 +1013,11 @@ class Array(DaskMethodsMixin):
                 (name, self.shape, self.dtype, chunksize))
 
     def _repr_html_(self):
-        from .svg import svg
         table = self._repr_html_table()
-        grid = svg(self.chunks)
+        try:
+            grid = self.to_svg(size=config.get('array.svg.size', 120))
+        except NotImplementedError:
+            grid = ""
 
         both = [
             '<table>',
@@ -1114,6 +1116,26 @@ class Array(DaskMethodsMixin):
             r = r[0]
 
         return r
+
+    def to_svg(self, size=500):
+        """ Convert chunks from Dask Array into an SVG Image
+
+        Parameters
+        ----------
+        chunks: tuple
+        size: int
+            Rough size of the image
+
+        Examples
+        --------
+        >>> x.to_svg(size=500)  # doctest: +SKIP
+
+        Returns
+        -------
+        text: An svg string depicting the array as a grid of chunks
+        """
+        from .svg import svg
+        return svg(self.chunks, size=size)
 
     def to_hdf5(self, filename, datapath, **kwargs):
         """ Store array in HDF5 file

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1034,18 +1034,24 @@ class Array(DaskMethodsMixin):
         return '\n'.join(both)
 
     def _repr_html_table(self):
+        if not math.isnan(self.nbytes):
+            nbytes = format_bytes(self.nbytes)
+            cbytes = format_bytes(np.prod(self.chunksize) * self.dtype.itemsize)
+        else:
+            nbytes = 'unknown'
+            cbytes = 'unknown'
+
         table = [
             '<table>'
             '  <thead>'
-            '    <tr><th> Dask Array </th><td> %s </td></tr>' % (self.name[:14] + '...' if len(self.name) > 14 else ''),
+            '    <tr><td> </td><th> Array </th><th> Chunk </th></tr>',
             '  </thead>',
             '  <tbody>',
-            '    <tr><th> Bytes </th><td> %s </td></tr>' % format_bytes(self.nbytes),
-            '    <tr><th> DType </th><td> %s </td></tr>' % self.dtype,
-            '    <tr><th> Shape </th><td> %s </td></tr>' % str(self.shape),
-            '    <tr><th> Chunk Shape </th><td> %s </td></tr>' % str(self.chunksize),
-            '    <tr><th> # Chunks </th><td> %s &rarr; %s </td></tr>' % (self.numblocks, self.npartitions),
-            '    <tr><th> # Tasks </th><td> %d </td></tr>' % len(self.__dask_graph__()),
+            '    <tr><th> Bytes </th><td> %s </td> <td> %s </td></tr>' % (nbytes, cbytes),
+            '    <tr><th> Shape </th><td> %s </td> <td> %s </td></tr>' % (str(self.shape), str(self.chunksize)),
+            '    <tr><th> Count </th><td> %d Tasks </td><td> %d chunks </td></tr>' % (
+                len(self.__dask_graph__()), self.npartitions),
+            '    <tr><th> DType </th><td> %s </td><td></td></tr>' % self.dtype,
             '  </tbody>',
             '</table>'
         ]

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4051,7 +4051,7 @@ def svg_2d(chunks, max_size=(500, 300), min_size=30):
     if y[-1] < min_size:
         y = y * min_size / y[-1]
 
-    header = '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:2" >\n' % (x[-1] + 50, y[-1] + 50)
+    header = '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n' % (x[-1] + 50, y[-1] + 50)
 
     footer = '\n</svg>'
 
@@ -4059,6 +4059,11 @@ def svg_2d(chunks, max_size=(500, 300), min_size=30):
               for yy in y]
     v_lines = ['  <line x1="%d" y1="%d" x2="%d" y2="%d" />' % (xx, 0, xx, y[-1])
               for xx in x]
+
+    h_lines[0] = h_lines[0].replace(' /', 'style="stroke-width:2" /')
+    h_lines[-1] = h_lines[-1].replace(' /', 'style="stroke-width:2" /')
+    v_lines[0] = v_lines[0].replace(' /', 'style="stroke-width:2" /')
+    v_lines[-1] = v_lines[-1].replace(' /', 'style="stroke-width:2" /')
 
     rect = [
         '  <rect x="0" y="0" width="%d" height="%d" style="fill:#ECB172A0;stroke-width:0"/>' % (x[-1], y[-1])

--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -13,6 +13,9 @@ def svg(chunks, **kwargs):
         return ""
 
 
+text_style = 'font-size="1.0rem" font-weight=100 text-anchor="middle"'
+
+
 def svg_2d(chunks, offset=(0, 0), skew=(0, 0)):
     shape = tuple(map(sum, chunks))
     sizes = draw_sizes(shape)
@@ -35,10 +38,10 @@ def svg_2d(chunks, offset=(0, 0), skew=(0, 0)):
     text = [
         "",
         "  <!-- Text -->",
-        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle">%d</text>'
-        % (max_x / 2, max_y + 20, shape[1]),
-        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle" transform="rotate(%d,%f,%f)">%d</text>'
-        % (max_x + 20, max_y / 2, rotate, max_x + 20, max_y / 2, shape[0]),
+        '  <text x="%f" y="%f" %s >%d</text>'
+        % (max_x / 2, max_y + 20, text_style, shape[1]),
+        '  <text x="%f" y="%f" %s transform="rotate(%d,%f,%f)">%d</text>'
+        % (max_x + 20, max_y / 2, text_style, rotate, max_x + 20, max_y / 2, shape[0]),
     ]
 
     return header + "\n".join(lines + text) + footer
@@ -72,21 +75,23 @@ def svg_3d(chunks):
     text = [
         "",
         "  <!-- Text -->",
-        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle">%d</text>'
-        % ((min_z + max_z) / 2, max_y + 20, shape[2]),
-        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle" transform="rotate(%d,%f,%f)">%d</text>'
+        '  <text x="%f" y="%f" %s >%d</text>'
+        % ((min_z + max_z) / 2, max_y + 20, text_style, shape[2]),
+        '  <text x="%f" y="%f" %s transform="rotate(%d,%f,%f)">%d</text>'
         % (
             max_z + 20,
             (min_y + max_y) / 2,
+            text_style,
             rotate,
             max_z + 20,
             (min_y + max_y) / 2,
             shape[1],
         ),
-        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle" transform="rotate(45,%f,%f)">%d</text>'
+        '  <text x="%f" y="%f" %s transform="rotate(45,%f,%f)">%d</text>'
         % (
             (mnx + mxx) / 2 - 10,
             mxy - (mxx - mnx) / 2 + 20,
+            text_style,
             (mnx + mxx) / 2 - 10,
             mxy - (mxx - mnx) / 2 + 20,
             shape[0],

--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -172,25 +172,12 @@ def grid_points(chunks, sizes):
     return points
 
 
-def draw_sizes(shape, max_size=400):
-    """
-
-    Examples
-    --------
-    >>> draw_sizes((10, 10), max_size=100)
-    (100, 100)
-    >>> draw_sizes((1000,), max_size=100)
-    (100,)
-    >>> draw_sizes((1000, 1), max_size=100)
-    (100,, 10)
-    >>> draw_sizes((1000000, 1000, 1), max_size=100)
-    (100, 2, 1)
-    """
+def draw_sizes(shape, max_size=120):
+    """ Get size in pixels for all dimensions """
     mx = max(shape)
-    size = 200
     ratios = [mx / d for d in shape]
     ratios = [ratio_response(r) for r in ratios]
-    return tuple(size / r for r in ratios)
+    return tuple(max_size/ r for r in ratios)
 
 
 def ratio_response(x):

--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -1,0 +1,125 @@
+import numpy as np
+import math
+
+def svg(chunks, **kwargs):
+    if len(chunks) == 1:
+        return svg_1d(chunks, **kwargs)
+    elif len(chunks) == 2:
+        return svg_2d(chunks, **kwargs)
+    else:
+        # TODO
+        return ''
+
+def svg_2d(chunks, offset=(0, 0), skew=(0, 0)):
+    y, x = grid_points(chunks)
+    shape = tuple(map(sum, chunks))
+
+    lines, (max_x, max_y) = svg_grid(x, y, shape, offset=offset, skew=skew)
+
+    header = '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n' % (max_x + 50, max_y + 50)
+
+    footer = '\n</svg>'
+
+    return header + '\n'.join(lines) + footer
+
+
+def svg_lines(x1, y1, x2, y2):
+    n = len(x1)
+    lines = ['  <line x1="%d" y1="%d" x2="%d" y2="%d" />' % (x1[i], y1[i], x2[i], y2[i])
+               for i in range(n)]
+
+    lines[0] = lines[0].replace(' /', ' style="stroke-width:2" /')
+    lines[-1] = lines[-1].replace(' /', ' style="stroke-width:2" /')
+    return lines
+
+
+def svg_grid(x, y, shape, offset=(0, 0), skew=(0, 0)):
+    """ Create lines of SVG text that show a grid
+
+    Parameters
+    ----------
+    x: numpy.ndarray
+    y: numpy.ndarray
+    shape: tuple
+    offset: tuple
+        translational displacement of the grid in SVG coordinates
+    skew: tuple
+    """
+    x1 = np.zeros_like(y) + skew[1] * y + offset[0]
+    y1 = y + skew[0] * x + offset[1]
+    x2 = np.full_like(y, x[-1]) + skew[1] * y + offset[0]
+    y2 = y + skew[0] * x + offset[1]
+
+    max_x = max(x1.max(), x2.max())
+    max_y = max(y1.max(), y2.max())
+
+    h_lines = ["<!-- Horizontal lines -->"] + svg_lines(x1, y1, x2, y2)
+
+    x1 = x + offset[0]
+    y1 = np.zeros_like(x) + offset[1]
+    x2 = x + offset[0]
+    y2 = np.full_like(x, y[-1]) + offset[1]
+
+    y1 += x[-1] * skew[0]
+    x2 += y[-1] * skew[1]
+
+    max_x = max(max_x, x1.max(), x2.max())
+    max_y = max(max_y, y1.max(), y2.max())
+
+    v_lines = ["<!-- Vertical lines -->"] + svg_lines(x1, y1, x2, y2)
+
+    rect = [
+            '  <polygon points="%f,%f %f,%f %f,%f %f,%f" style="fill:#ECB172A0;stroke-width:0"/>' % (
+            x1[0], y1[0], x1[0], y1[-1], x2[-1], y2[-1], x2[0], y1[0])
+    ]
+
+    text = [
+        '',
+        '<!-- Text -->',
+        '<text x="%f" y="%f" font-size="1.4rem" text-anchor="middle">%d</text>' % (x[-1] / 2, y[-1] + 20, shape[1]),
+        '<text x="%f" y="%f" font-size="1.4rem" text-anchor="middle" transform="rotate(-90 %f,%f)">%d</text>' % (
+            x[-1] + 20, y[-1] / 2, x[-1] + 20, y[-1] / 2, shape[0]),
+    ]
+
+    return h_lines + v_lines + rect + text, (max_x, max_y)
+
+
+
+def svg_1d(chunks, **kwargs):
+    return svg_2d(((1,),) + chunks, **kwargs)
+
+
+def grid_points(chunks):
+    cumchunks = [np.cumsum((0,) + c) for c in chunks]
+    sizes = draw_sizes(tuple(map(sum, chunks)))
+    points = [x * size / x[-1] for x, size in zip(cumchunks, sizes)]
+    return points
+
+
+def draw_sizes(shape, max_size=400):
+    """
+
+    Examples
+    --------
+    >>> draw_sizes((10, 10), max_size=100)
+    (100, 100)
+    >>> draw_sizes((1000,), max_size=100)
+    (100,)
+    >>> draw_sizes((1000, 1), max_size=100)
+    (100,, 10)
+    >>> draw_sizes((1000000, 1000, 1), max_size=100)
+    (100, 2, 1)
+    """
+    mx = max(shape)
+    size = math.log(mx) * 40
+    ratios = [d / mx for d in shape]
+    ratios = [max(1/10, r) for r in ratios]
+    return tuple(size * r for r in ratios)
+
+
+class HTML:
+    def __init__(self, text):
+        self.text = text
+
+    def _repr_html_(self):
+        return self.text

--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 import math
 

--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -218,6 +218,8 @@ def svg_grid(x, y, offset=(0, 0), skew=(0, 0)):
     v_lines = ["", "  <!-- Vertical lines -->"] + svg_lines(x1, y1, x2, y2)
 
     rect = [
+        "",
+        "  <!-- Colored Rectangle -->",
         '  <polygon points="%f,%f %f,%f %f,%f %f,%f" style="fill:#ECB172A0;stroke-width:0"/>'
         % (x1[0], y1[0], x1[-1], y1[-1], x2[-1], y2[-1], x2[0], y2[0])
     ]

--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -1,6 +1,7 @@
 import numpy as np
 import math
 
+
 def svg(chunks, **kwargs):
     if len(chunks) == 1:
         return svg_1d(chunks, **kwargs)
@@ -9,17 +10,22 @@ def svg(chunks, **kwargs):
     elif len(chunks) == 3:
         return svg_3d(chunks, **kwargs)
     else:
-        return ''
+        return ""
+
 
 def svg_2d(chunks, offset=(0, 0), skew=(0, 0)):
     shape = tuple(map(sum, chunks))
     sizes = draw_sizes(shape)
     y, x = grid_points(chunks, sizes)
 
-    lines, (min_x, max_x, min_y, max_y) = svg_grid(x, y, shape, offset=offset, skew=skew)
+    lines, (min_x, max_x, min_y, max_y) = svg_grid(
+        x, y, shape, offset=offset, skew=skew
+    )
     header = '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n' % (
-        max_x + 50, max_y + 50)
-    footer = '\n</svg>'
+        max_x + 50,
+        max_y + 50,
+    )
+    footer = "\n</svg>"
 
     if shape[0] >= 100:
         rotate = -90
@@ -27,15 +33,15 @@ def svg_2d(chunks, offset=(0, 0), skew=(0, 0)):
         rotate = 0
 
     text = [
-        '',
-        '  <!-- Text -->',
-        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle">%d</text>' % (max_x / 2, max_y + 20, shape[1]),
-        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle" transform="rotate(%d,%f,%f)">%d</text>' % (
-            max_x + 20, max_y / 2, rotate, max_x + 20, max_y / 2, shape[0]),
+        "",
+        "  <!-- Text -->",
+        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle">%d</text>'
+        % (max_x / 2, max_y + 20, shape[1]),
+        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle" transform="rotate(%d,%f,%f)">%d</text>'
+        % (max_x + 20, max_y / 2, rotate, max_x + 20, max_y / 2, shape[0]),
     ]
 
-
-    return header + '\n'.join(lines + text) + footer
+    return header + "\n".join(lines + text) + footer
 
 
 def svg_3d(chunks):
@@ -43,12 +49,20 @@ def svg_3d(chunks):
     sizes = draw_sizes(shape)
     x, y, z = grid_points(chunks, sizes)
 
-    xy, (mnx, mxx, mny, mxy) = svg_grid(x / 1.7, y, (shape[0], shape[1]), offset=(10, 0), skew=(1, 0))
-    zx, (_, _, _, max_x) = svg_grid(z, x / 1.7, (shape[2], shape[0]), offset=(10, 0), skew=(0, 1))
-    zy, (min_z, max_z, min_y, max_y) = svg_grid(z, y, (shape[2], shape[1]), offset=(max_x + 10, max_x), skew=(0, 0))
+    xy, (mnx, mxx, mny, mxy) = svg_grid(
+        x / 1.7, y, (shape[0], shape[1]), offset=(10, 0), skew=(1, 0)
+    )
+    zx, (_, _, _, max_x) = svg_grid(
+        z, x / 1.7, (shape[2], shape[0]), offset=(10, 0), skew=(0, 1)
+    )
+    zy, (min_z, max_z, min_y, max_y) = svg_grid(
+        z, y, (shape[2], shape[1]), offset=(max_x + 10, max_x), skew=(0, 0)
+    )
     header = '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n' % (
-        max_z + 50, max_y + 50)
-    footer = '\n</svg>'
+        max_z + 50,
+        max_y + 50,
+    )
+    footer = "\n</svg>"
 
     if shape[1] >= 100:
         rotate = -90
@@ -56,25 +70,41 @@ def svg_3d(chunks):
         rotate = 0
 
     text = [
-        '',
-        '  <!-- Text -->',
-        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle">%d</text>' % ((min_z + max_z) / 2, max_y + 20, shape[2]),
-        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle" transform="rotate(%d,%f,%f)">%d</text>' % (
-            max_z + 20, (min_y + max_y) / 2, rotate, max_z + 20, (min_y + max_y) / 2, shape[1]),
-        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle" transform="rotate(45,%f,%f)">%d</text>' % (
-            (mnx + mxx) / 2 - 10, mxy - (mxx - mnx) / 2 + 20, (mnx + mxx) / 2 - 10, mxy - (mxx - mnx) / 2 + 20, shape[0]),
+        "",
+        "  <!-- Text -->",
+        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle">%d</text>'
+        % ((min_z + max_z) / 2, max_y + 20, shape[2]),
+        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle" transform="rotate(%d,%f,%f)">%d</text>'
+        % (
+            max_z + 20,
+            (min_y + max_y) / 2,
+            rotate,
+            max_z + 20,
+            (min_y + max_y) / 2,
+            shape[1],
+        ),
+        '  <text x="%f" y="%f" font-size="1.4rem" text-anchor="middle" transform="rotate(45,%f,%f)">%d</text>'
+        % (
+            (mnx + mxx) / 2 - 10,
+            mxy - (mxx - mnx) / 2 + 20,
+            (mnx + mxx) / 2 - 10,
+            mxy - (mxx - mnx) / 2 + 20,
+            shape[0],
+        ),
     ]
 
-    return header + '\n'.join(xy + zx + zy + text) + footer
+    return header + "\n".join(xy + zx + zy + text) + footer
 
 
 def svg_lines(x1, y1, x2, y2):
     n = len(x1)
-    lines = ['  <line x1="%d" y1="%d" x2="%d" y2="%d" />' % (x1[i], y1[i], x2[i], y2[i])
-               for i in range(n)]
+    lines = [
+        '  <line x1="%d" y1="%d" x2="%d" y2="%d" />' % (x1[i], y1[i], x2[i], y2[i])
+        for i in range(n)
+    ]
 
-    lines[0] = lines[0].replace(' /', ' style="stroke-width:2" /')
-    lines[-1] = lines[-1].replace(' /', ' style="stroke-width:2" /')
+    lines[0] = lines[0].replace(" /", ' style="stroke-width:2" /')
+    lines[-1] = lines[-1].replace(" /", ' style="stroke-width:2" /')
     return lines
 
 
@@ -125,11 +155,11 @@ def svg_grid(x, y, shape, offset=(0, 0), skew=(0, 0)):
     v_lines = ["", "  <!-- Vertical lines -->"] + svg_lines(x1, y1, x2, y2)
 
     rect = [
-            '  <polygon points="%f,%f %f,%f %f,%f %f,%f" style="fill:#ECB172A0;stroke-width:0"/>' % (
-            x1[0], y1[0], x1[-1], y1[-1], x2[-1], y2[-1], x2[0], y2[0])
+        '  <polygon points="%f,%f %f,%f %f,%f %f,%f" style="fill:#ECB172A0;stroke-width:0"/>'
+        % (x1[0], y1[0], x1[-1], y1[-1], x2[-1], y2[-1], x2[0], y2[0])
     ]
 
-    return h_lines + v_lines + rect , (min_x, max_x, min_y, max_y)
+    return h_lines + v_lines + rect, (min_x, max_x, min_y, max_y)
 
 
 def svg_1d(chunks, **kwargs):
@@ -178,11 +208,3 @@ def ratio_response(x):
         return math.log(x + 12.4)  # f(e) == e
     else:
         return math.log(100 + 12.4)
-
-
-class HTML:
-    def __init__(self, text):
-        self.text = text
-
-    def _repr_html_(self):
-        return self.text

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3824,22 +3824,3 @@ def test_auto_chunks_h5py():
             with dask.config.set({'array.chunk-size': '1 MiB'}):
                 x = da.from_array(d)
                 assert x.chunks == ((256, 256, 256, 232), (512, 488))
-
-
-def test_draw_grid_points():
-    x = da.ones((100, 100), chunks=(10, 10))
-    x, y = grid_points(x.chunks)
-    assert (x == y).all()  # respects symmetry
-
-    x = da.ones((10, 50), chunks=(10, 10))
-    x, y = grid_points(x.chunks)
-    assert len(x) == 2
-    assert len(y) == 5   # happy to draw modest grids explicitly
-    assert y[-1] > x[-1]  # larger axes should be larger
-
-    x = da.ones((10, 10000), chunks=(10, 100))
-    x, y = grid_points(x.chunks)
-    assert len(x) == 2
-    assert 5 <= len(y) < 30  # not too many lines
-    assert y[-1] > x[-1]  # still a difference
-    assert y[-1] < x[-1] * 20  # but not beyond perception

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1271,7 +1271,8 @@ def test_repr():
 
 
 def test_repr_html():
-    x = da.ones((10000, 10000))
+    x = da.ones((10000, 5000))
+    x = da.ones((3000, 10000), chunks=(1000, 1000))
     text = x._repr_html_()
     assert 'MB' in text or 'MiB' in text
     assert str(x.shape) in text
@@ -3817,3 +3818,22 @@ def test_auto_chunks_h5py():
             with dask.config.set({'array.chunk-size': '1 MiB'}):
                 x = da.from_array(d)
                 assert x.chunks == ((256, 256, 256, 232), (512, 488))
+
+
+def test_draw_grid_points():
+    x = da.ones((100, 100), chunks=(10, 10))
+    x, y = grid_points(x.chunks)
+    assert (x == y).all()  # respects symmetry
+
+    x = da.ones((10, 50), chunks=(10, 10))
+    x, y = grid_points(x.chunks)
+    assert len(x) == 2
+    assert len(y) == 5   # happy to draw modest grids explicitly
+    assert y[-1] > x[-1]  # larger axes should be larger
+
+    x = da.ones((10, 10000), chunks=(10, 100))
+    x, y = grid_points(x.chunks)
+    assert len(x) == 2
+    assert 5 <= len(y) < 30  # not too many lines
+    assert y[-1] > x[-1]  # still a difference
+    assert y[-1] < x[-1] * 20  # but not beyond perception

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -12,7 +12,6 @@ import operator
 from operator import add, sub, getitem
 from threading import Lock
 import warnings
-import xml.etree.ElementTree
 
 from toolz import merge, countby, concat
 from toolz.curried import identity
@@ -1268,25 +1267,6 @@ def test_repr():
     assert str(d.dtype) in repr(d)
     d = da.ones((4000, 4), chunks=(4, 2))
     assert len(str(d)) < 1000
-
-
-def test_repr_html():
-    x = da.ones((10000, 5000))
-    x = da.ones((3000, 10000), chunks=(1000, 1000))
-    text = x._repr_html_()
-
-    assert 'MB' in text or 'MiB' in text
-    assert str(x.shape) in text
-    assert str(x.dtype) in text
-    assert 'ones' in text
-
-    cleaned = text.replace('&rarr;', '')  # xml doesn't like righarrow character
-    assert xml.etree.ElementTree.fromstring(cleaned) is not None  # parses cleanly
-
-    x = da.ones((3000, 10000, 50), chunks=(1000, 1000, 10))
-    text = x._repr_html_()
-    cleaned = text.replace('&rarr;', '')  # xml doesn't like righarrow character
-    assert xml.etree.ElementTree.fromstring(cleaned) is not None  # parses cleanly
 
 
 def test_slicing_with_ellipsis():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1274,11 +1274,17 @@ def test_repr_html():
     x = da.ones((10000, 5000))
     x = da.ones((3000, 10000), chunks=(1000, 1000))
     text = x._repr_html_()
+
     assert 'MB' in text or 'MiB' in text
     assert str(x.shape) in text
     assert str(x.dtype) in text
     assert 'ones' in text
 
+    cleaned = text.replace('&rarr;', '')  # xml doesn't like righarrow character
+    assert xml.etree.ElementTree.fromstring(cleaned) is not None  # parses cleanly
+
+    x = da.ones((3000, 10000, 50), chunks=(1000, 1000, 10))
+    text = x._repr_html_()
     cleaned = text.replace('&rarr;', '')  # xml doesn't like righarrow character
     assert xml.etree.ElementTree.fromstring(cleaned) is not None  # parses cleanly
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -12,6 +12,7 @@ import operator
 from operator import add, sub, getitem
 from threading import Lock
 import warnings
+import xml.etree.ElementTree
 
 from toolz import merge, countby, concat
 from toolz.curried import identity
@@ -1267,6 +1268,18 @@ def test_repr():
     assert str(d.dtype) in repr(d)
     d = da.ones((4000, 4), chunks=(4, 2))
     assert len(str(d)) < 1000
+
+
+def test_repr_html():
+    x = da.ones((10000, 10000))
+    text = x._repr_html_()
+    assert 'MB' in text or 'MiB' in text
+    assert str(x.shape) in text
+    assert str(x.dtype) in text
+    assert 'ones' in text
+
+    cleaned = text.replace('&rarr;', '')  # xml doesn't like righarrow character
+    assert xml.etree.ElementTree.fromstring(cleaned) is not None  # parses cleanly
 
 
 def test_slicing_with_ellipsis():

--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -13,6 +13,10 @@ def test_basic():
     parses(da.ones(10).to_svg())
     parses(da.ones((10, 10)).to_svg())
     parses(da.ones((10, 10, 10)).to_svg())
+    parses(da.ones((10, 10, 10, 10)).to_svg())
+    parses(da.ones((10, 10, 10, 10, 10)).to_svg())
+    parses(da.ones((10, 10, 10, 10, 10, 10)).to_svg())
+    parses(da.ones((10, 10, 10, 10, 10, 10, 10)).to_svg())
 
 
 def test_repr_html():
@@ -26,9 +30,6 @@ def test_repr_html():
 def test_errors():
     with pytest.raises(NotImplementedError):
         assert da.ones(10)[:0].to_svg()
-
-    with pytest.raises(NotImplementedError):
-        assert da.ones((10, 10, 10, 10)).to_svg()
 
     with pytest.raises(NotImplementedError):
         x = da.ones(10)
@@ -62,3 +63,8 @@ def test_draw_sizes():
     assert b > c
     assert a < b * 5
     assert b < c * 5
+
+
+def test_3d():
+    text = da.ones((10, 10, 10, 10, 10)).to_svg()
+    assert text.count("<svg" ) == 1

--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -1,0 +1,64 @@
+import dask.array as da
+from dask.array.svg import draw_sizes
+import xml.etree.ElementTree
+import pytest
+
+
+def parses(text):
+    cleaned = text.replace('&rarr;', '')  # xml doesn't like righarrow character
+    assert xml.etree.ElementTree.fromstring(cleaned) is not None  # parses cleanly
+
+
+def test_basic():
+    parses(da.ones(10).to_svg())
+    parses(da.ones((10, 10)).to_svg())
+    parses(da.ones((10, 10, 10)).to_svg())
+
+
+def test_repr_html():
+    assert da.ones(10)[:0]._repr_html_()
+    assert da.ones(10)._repr_html_()
+    assert da.ones((10, 10))._repr_html_()
+    assert da.ones((10, 10, 10))._repr_html_()
+    assert da.ones((10, 10, 10, 10))._repr_html_()
+
+
+def test_errors():
+    with pytest.raises(NotImplementedError):
+        assert da.ones(10)[:0].to_svg()
+
+    with pytest.raises(NotImplementedError):
+        assert da.ones((10, 10, 10, 10)).to_svg()
+
+    with pytest.raises(NotImplementedError):
+        x = da.ones(10)
+        x = x[x > 5]
+        x.to_svg()
+
+
+def test_repr_html():
+    x = da.ones((10000, 5000))
+    x = da.ones((3000, 10000), chunks=(1000, 1000))
+    text = x._repr_html_()
+
+    assert 'MB' in text or 'MiB' in text
+    assert str(x.shape) in text
+    assert str(x.dtype) in text
+    assert 'ones' in text
+
+    parses(text)
+
+    x = da.ones((3000, 10000, 50), chunks=(1000, 1000, 10))
+    parses(x._repr_html_())
+
+
+def test_draw_sizes():
+    assert draw_sizes((10, 10), size=100) == (100, 100)  # respect symmetry
+    assert draw_sizes((10, 10), size=200) == (200, 200)  # respect size keyword
+    assert draw_sizes((10, 5), size=100) == (100, 50)  # respect small ratios
+
+    a, b, c = draw_sizes((1000, 100, 10))
+    assert a > b
+    assert b > c
+    assert a < b * 5
+    assert b < c * 5

--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -45,7 +45,6 @@ def test_repr_html():
     assert 'MB' in text or 'MiB' in text
     assert str(x.shape) in text
     assert str(x.dtype) in text
-    assert 'ones' in text
 
     parses(text)
 

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -1,1 +1,5 @@
 temporary-directory: null     # Directory for local disk like /tmp, /scratch, or /local
+
+array:
+  svg:
+    size: 120  # pixels


### PR DESCRIPTION
This provides more information about Dask arrays as an HTML repr

Currently it includes a table of information (bytes, shape, dtype, ...)
A visual representation of the grid in 1d or 2d (working on 3d next)

A rendered result is availble here https://nbviewer.jupyter.org/urls/gist.githubusercontent.com/mrocklin/0df34e9d609f38a2bf3df9311909bb2c/raw/7ab5513cc1c6740ca8b2f4785ecd7d3a3869012c/dask-array-repr.ipynb

<img width="816" alt="Screen Shot 2019-05-11 at 11 08 53 AM" src="https://user-images.githubusercontent.com/306380/57572245-4428c500-73dd-11e9-9d72-ed889ad82a80.png">


### TODO
-  3d
-  handle greater dimensions by having a few grids displayed .  So for example 4d would be a 3d grid followed by a 1d grid
-  Improve styling and placement of grid (visual design help most welcome)
-  Figure out better heuristics on how to handle many chunks or high degrees of asymmetry

cc @shoyer @birdsarah @rabernat @jhamman 

My hope is that with changes like these (I plan to do something similar for high level graphs) we can improve users' literacy and ability to reason about their computations.