### PR TITLE
Add support for rolling operations with larger window that partition size in DataFrames with Time-based index (#4248)

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1215,9 +1215,10 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         ----------
         window : int, str, offset
            Size of the moving window. This is the number of observations used
-           for calculating the statistic. The window size must not be so large
-           as to span more than one adjacent partition. If using an offset
-           or offset alias like '5D', the data must have a ``DatetimeIndex``
+           for calculating the statistic. When not using a ``DatetimeIndex``,
+           the window size must not be so large as to span more than one
+           adjacent partition. If using an offset or offset alias like '5D',
+           the data must have a ``DatetimeIndex``
 
            .. versionchanged:: 0.15.0
 

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -127,13 +127,13 @@ def map_overlap(func, df, before, after, *args, **kwargs):
                     first = first - deltas[j]
                     j = j - 1
 
-                dsk.update({(name_a, i): (_multi_tail_timedelta, [(df_name, k) for k in range(j, i + 1)],
+                dsk.update({(name_a, i): (_tail_timedelta, [(df_name, k) for k in range(j, i + 1)],
                                           (df_name, i + 1), before)})
 
             prevs = [None] + [(name_a, i) for i in range(df.npartitions - 1)]
 
         else:
-            dsk.update({(name_a, i): (_tail_timedelta, (df_name, i), (df_name, i + 1), before)
+            dsk.update({(name_a, i): (_tail_timedelta, [(df_name, i)], (df_name, i + 1), before)
                         for i in range(df.npartitions - 1)})
             prevs = [None] + [(name_a, i) for i in range(df.npartitions - 1)]
     else:
@@ -180,7 +180,7 @@ def _head_timedelta(current, next_, after):
     return next_[next_.index < (current.index.max() + after)]
 
 
-def _multi_tail_timedelta(prevs, current, before):
+def _tail_timedelta(prevs, current, before):
     """Return the concatenated rows of each dataframe in ``prevs`` whose
     index is after the first observation in ``current`` - ``before``.
 
@@ -196,23 +196,6 @@ def _multi_tail_timedelta(prevs, current, before):
     """
     selected = pd.concat([prev[prev.index > (current.index.min() - before)] for prev in prevs])
     return selected
-
-
-def _tail_timedelta(prev, current, before):
-    """Return rows of ``prev`` whose index is after the first
-    observation in ``current`` - ``before``.
-
-    Parameters
-    ----------
-    current : DataFrame
-    prev : DataFrame
-    before : timedelta
-
-    Returns
-    -------
-    overlapped : DataFrame
-    """
-    return prev[prev.index > (current.index.min() - before)]
 
 
 def pandas_rolling_method(df, rolling_kwargs, name, *args, **kwargs):

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -27,7 +27,6 @@ def overlap_chunk(func, prev_part, current_part, next_part, before, after,
     if next_part is not None and isinstance(after, Integral):
         if next_part.shape[0] != after:
             raise NotImplementedError(msg)
-    # We validate that the window isn't too large for tiemdeltas in map_overlap
 
     parts = [p for p in (prev_part, current_part, next_part) if p is not None]
     combined = pd.concat(parts)
@@ -95,10 +94,6 @@ def map_overlap(func, df, before, after, *args, **kwargs):
 
     dsk = {}
 
-    # Have to do the checks for too large windows in the time-delta case
-    # here instead of in `overlap_chunk`, since we can't rely on fix-frequency
-    # index
-
     timedelta_partition_message = (
         "Partition size is less than specified window. "
         "Try using ``df.repartition`` to increase the partition size"
@@ -110,12 +105,42 @@ def map_overlap(func, df, before, after, *args, **kwargs):
         prevs = [None] + [(name_a, i) for i in range(df.npartitions - 1)]
     elif isinstance(before, datetime.timedelta):
         # Assumes monotonic (increasing?) index
-        deltas = pd.Series(df.divisions).diff().iloc[1:-1]
+        divs = pd.Series(df.divisions)
+        deltas = divs.diff().iloc[1:-1]
+
+        # In the first case window-size is larger than at least one partition, thus it is
+        # necessary to calculate how many partitions must be used for each rolling task.
+        # Otherwise, these calculations can be skipped (faster)
+
         if (before > deltas).any():
-            raise ValueError(timedelta_partition_message)
-        dsk.update({(name_a, i): (_tail_timedelta, (df_name, i), (df_name, i + 1), before)
-                    for i in range(df.npartitions - 1)})
-        prevs = [None] + [(name_a, i) for i in range(df.npartitions - 1)]
+            pt_z = divs[0]
+            for i in range(df.npartitions-1):
+                # Select all indexes of relevant partitions between the current partition and
+                # the partition with the highest division outside the rolling window (before)
+                pt_i = divs[i+1]
+
+                # lower-bound the search to the first division
+                lb = max(pt_i - before, pt_z)
+
+                first, j = divs[i], i
+                while first > lb and j > 0:
+                    first = first - deltas[j]
+                    j = j - 1
+
+                # TODO: delete after discussion
+                # Simpler approach, however much slower due to the implicit loc call
+                # particularly for large divisions tables
+                #j = divs[divs<=lb].idxmax()
+
+                dsk.update({(name_a, i): (_multi_tail_timedelta, [(df_name, k) for k in range(j, i+1)],
+                                          (df_name, i + 1), before)})
+
+            prevs = [None] + [(name_a, i) for i in range(df.npartitions - 1)]
+
+        else:
+            dsk.update({(name_a, i): (_tail_timedelta, (df_name, i), (df_name, i + 1), before)
+                        for i in range(df.npartitions - 1)})
+            prevs = [None] + [(name_a, i) for i in range(df.npartitions - 1)]
     else:
         prevs = [None] * df.npartitions
 
@@ -160,6 +185,24 @@ def _head_timedelta(current, next_, after):
     return next_[next_.index < (current.index.max() + after)]
 
 
+def _multi_tail_timedelta(prevs, current, before):
+    """Return the concatenated rows of each dataframe in ``prevs`` whose
+    index is after the first observation in ``current`` - ``before``.
+
+    Parameters
+    ----------
+    current : DataFrame
+    prevs : list of DataFrame objects
+    before : timedelta
+
+    Returns
+    -------
+    overlapped : DataFrame
+    """
+    selected = pd.concat([prev[prev.index > (current.index.min() - before)] for prev in prevs])
+    return selected
+
+
 def _tail_timedelta(prev, current, before):
     """Return rows of ``prev`` whose index is after the first
     observation in ``current`` - ``before``.
@@ -167,7 +210,7 @@ def _tail_timedelta(prev, current, before):
     Parameters
     ----------
     current : DataFrame
-    next_ : DataFrame
+    prev : DataFrame
     before : timedelta
 
     Returns

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -127,11 +127,6 @@ def map_overlap(func, df, before, after, *args, **kwargs):
                     first = first - deltas[j]
                     j = j - 1
 
-                # TODO: delete after discussion
-                # Simpler approach, however much slower due to the implicit loc call
-                # particularly for large divisions tables
-                #j = divs[divs<=lb].idxmax()
-
                 dsk.update({(name_a, i): (_multi_tail_timedelta, [(df_name, k) for k in range(j, i + 1)],
                                           (df_name, i + 1), before)})
 

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -114,10 +114,10 @@ def map_overlap(func, df, before, after, *args, **kwargs):
 
         if (before > deltas).any():
             pt_z = divs[0]
-            for i in range(df.npartitions-1):
+            for i in range(df.npartitions - 1):
                 # Select all indexes of relevant partitions between the current partition and
                 # the partition with the highest division outside the rolling window (before)
-                pt_i = divs[i+1]
+                pt_i = divs[i + 1]
 
                 # lower-bound the search to the first division
                 lb = max(pt_i - before, pt_z)
@@ -132,7 +132,7 @@ def map_overlap(func, df, before, after, *args, **kwargs):
                 # particularly for large divisions tables
                 #j = divs[divs<=lb].idxmax()
 
-                dsk.update({(name_a, i): (_multi_tail_timedelta, [(df_name, k) for k in range(j, i+1)],
+                dsk.update({(name_a, i): (_multi_tail_timedelta, [(df_name, k) for k in range(j, i + 1)],
                                           (df_name, i + 1), before)})
 
             prevs = [None] + [(name_a, i) for i in range(df.npartitions - 1)]


### PR DESCRIPTION
As of the current dask version, it is not currently possible to do any operations that depend on map_partitions for which the window size specified is larger than any partition. However, in the cases that we know the divisions for the dataframe, it is possible to calculate the necessary previous partitions that need to be set as dependency for each operation mapped for a certain partition

The pull-request is marked as WIP for two reasons:
- There is an implementation detail that is explained as a commentary, which can be simplified significantly at the cost of speed for large partition tables
- There is no implementation for forward partition checks (but should be easy to extend). Are these needed for this kind of indexes?

- [x] Tests added / passed
- [x] Passes `flake8 dask`
