### PR TITLE
Update groupby-apply doc with warning

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -182,7 +182,7 @@ class Aggregation(object):
     what operation to do on each chunk of data, how to combine those chunks of
     data together, and then how to finalize the result.
 
-    See :ref:`dataframe.groupby.aggregation` for more.
+    See :ref:`dataframe.groupby.aggregate` for more.
 
     Parameters
     ----------
@@ -1112,17 +1112,17 @@ class _GroupBy(object):
         1.  The user should provide output metadata.
         2.  If the grouper does not align with the index then this causes a full
             shuffle.  The order of rows within each group may not be preserved.
-        3.  Dask's GroupBy.apply is not appropriate for functions reductions.
-            For custom reductions, use :class:`dask.dataframe.Aggregation`.
+        3.  Dask's GroupBy.apply is not appropriate for aggregations. For custom
+            aggregations, use :class:`dask.dataframe.groupby.Aggregation`.
 
         .. warning::
 
            Pandas' groupby-apply can be used to to apply arbitrary functions,
            including aggregations that result in one row per group. Dask's
-           groupby-apply will apply `func` once to each partition-group pair,
-           so when `func` is a reduction you'll end up with one row per
+           groupby-apply will apply ``func`` once to each partition-group pair,
+           so when ``func`` is a reduction you'll end up with one row per
            partition-group pair. To apply a custom aggregation with Dask,
-           use :class:`dask.dataframe.Aggregation`.
+           use :class:`dask.dataframe.groupby.Aggregation`.
 
         Parameters
         ----------

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -182,6 +182,8 @@ class Aggregation(object):
     what operation to do on each chunk of data, how to combine those chunks of
     data together, and then how to finalize the result.
 
+    See :ref:`dataframe.groupby.aggregation` for more.
+
     Parameters
     ----------
     name : str
@@ -1110,6 +1112,17 @@ class _GroupBy(object):
         1.  The user should provide output metadata.
         2.  If the grouper does not align with the index then this causes a full
             shuffle.  The order of rows within each group may not be preserved.
+        3.  Dask's GroupBy.apply is not appropriate for functions reductions.
+            For custom reductions, use :class:`dask.dataframe.Aggregation`.
+
+        .. warning::
+
+           Pandas' groupby-apply can be used to to apply arbitrary functions,
+           including aggregations that result in one row per group. Dask's
+           groupby-apply will apply `func` once to each partition-group pair,
+           so when `func` is a reduction you'll end up with one row per
+           partition-group pair. To apply a custom aggregation with Dask,
+           use :class:`dask.dataframe.Aggregation`.
 
         Parameters
         ----------

--- a/docs/source/dataframe-groupby.rst
+++ b/docs/source/dataframe-groupby.rst
@@ -123,6 +123,8 @@ can be used to select either on-disk or task-based shuffling:
     df.set_index(column, shuffle='tasks')
 
 
+.. _dataframe.groupby.aggregate:
+
 Aggregate
 =========
 
@@ -167,3 +169,46 @@ A mean function can be implemented as:
         lambda count, sum: sum / count,
     )
     df.groupby('g').agg(custom_mean)
+
+
+For example, let's compute the group-wise extent (maximum - minimum)
+for a DataFrame.
+
+.. code-block:: python
+
+   >>> import string
+   >>> import pandas as pd
+   >>> import dask.dataframe as dd
+   >>> import numpy as np
+
+   >>> df = pd.DataFrame({
+   ...   'a': ['a', 'b', 'a', 'a', 'b'],
+   ...   'b': [0, 1, 0, 2, 5],
+   >>> })
+   >>> ddf = dd.from_pandas(df, 2)
+
+We define the building blocks to find the maximum and minimum of each chunk, and then
+the maximum and minimum over all the chunks. We finalize by taking the difference between
+the Series with the maxima and minima
+
+.. code-block:: python
+
+   >>> def chunk(grouped):
+   ...     return grouped.max(), grouped.min()
+
+   >>> def agg(chunk_maxes, chunk_mins):
+   ...     return chunk_maxes.max(), chunk_mins.min()
+
+   >>> def finalize(maxima, minima):
+   ...     return maxima - minima
+
+Finally, we create and use the aggregation
+
+.. code-block:: python
+
+   >>> extent = dd.Aggregation('extent', chunk, agg, finalize=finalize)
+   >>> ddf.groupby('a').agg(extent).compute()
+      b
+   a
+   a  2
+   b  4

--- a/docs/source/dataframe-groupby.rst
+++ b/docs/source/dataframe-groupby.rst
@@ -176,11 +176,6 @@ for a DataFrame.
 
 .. code-block:: python
 
-   >>> import string
-   >>> import pandas as pd
-   >>> import dask.dataframe as dd
-   >>> import numpy as np
-
    >>> df = pd.DataFrame({
    ...   'a': ['a', 'b', 'a', 'a', 'b'],
    ...   'b': [0, 1, 0, 2, 5],


### PR DESCRIPTION
Note the difference to pandas's groupby-apply when the applied
function is an aggregation. We steer users towards dd.Aggregation
when the function reduces.

Closes https://github.com/dask/dask/issues/4372

For now, this is documentation only. I don't see an easy way to reliably detect that the user is doing an aggregation.
