### PR TITLE
Call head before compute in dd.from_delayed

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -525,7 +525,8 @@ def from_delayed(dfs, meta=None, divisions=None, prefix='from-delayed'):
 
     if meta is None:
         meta = dask.delayed(make_meta)(dfs[0]).compute()
-    meta = make_meta(meta)
+    else:
+        meta = make_meta(meta)
 
     name = prefix + '-' + tokenize(*dfs)
     dsk = merge(df.dask for df in dfs)

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -524,7 +524,7 @@ def from_delayed(dfs, meta=None, divisions=None, prefix='from-delayed'):
                             type(df).__name__)
 
     if meta is None:
-        meta = dask.delayed(make_meta)(dfs[0]).compute()
+        meta = delayed(make_meta)(dfs[0]).compute()
     else:
         meta = make_meta(meta)
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -524,7 +524,7 @@ def from_delayed(dfs, meta=None, divisions=None, prefix='from-delayed'):
                             type(df).__name__)
 
     if meta is None:
-        meta = dfs[0].compute()
+        meta = dask.delayed(make_meta)(dfs[0]).compute()
     meta = make_meta(meta)
 
     name = prefix + '-' + tokenize(*dfs)


### PR DESCRIPTION
In from_delayed we need to move a bit of data from a task to the client
process.  Now we make sure only to move a small bit of data instead of
the full chunk.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
