### PR TITLE
Allow `utils.derive_from` to accept functions, apply across array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -32,7 +32,7 @@ from ..base import (DaskMethodsMixin, tokenize, dont_optimize,
                     compute_as_if_collection, persist, is_dask_collection)
 from ..blockwise import broadcast_dimensions, subs
 from ..context import globalmethod
-from ..utils import (ndeepmap, ignoring, concrete,
+from ..utils import (ndeepmap, ignoring, concrete, derived_from,
                      is_integer, IndexCallable, funcname, derived_from,
                      SerializableLock, Dispatch, factors,
                      parse_bytes, has_keyword, M, ndimlist)
@@ -3371,7 +3371,7 @@ def broadcast_to(x, shape, chunks=None):
     return Array(graph, name, chunks, dtype=x.dtype)
 
 
-@wraps(np.broadcast_arrays)
+@derived_from(np)
 def broadcast_arrays(*args, **kwargs):
     subok = bool(kwargs.pop("subok", False))
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -17,6 +17,7 @@ from .core import (Array, asarray, normalize_chunks,
                    broadcast_to, broadcast_arrays)
 from .wrap import empty, ones, zeros, full
 from .utils import AxisError
+from ..utils import derived_from
 
 
 def empty_like(a, dtype=None, chunks=None):
@@ -322,7 +323,7 @@ def arange(*args, **kwargs):
     return Array(dsk, name, chunks, dtype=dtype)
 
 
-@wraps(np.meshgrid)
+@derived_from(np)
 def meshgrid(*xi, **kwargs):
     indexing = kwargs.pop("indexing", "xy")
     sparse = bool(kwargs.pop("sparse", False))
@@ -462,7 +463,7 @@ def eye(N, chunks, M=None, k=0, dtype=float):
                  chunks=(chunks, chunks), dtype=dtype)
 
 
-@wraps(np.diag)
+@derived_from(np)
 def diag(v):
     name = 'diag-' + tokenize(v)
     if isinstance(v, np.ndarray):
@@ -502,7 +503,7 @@ def diag(v):
     return Array(graph, name, (chunks_1d, chunks_1d), dtype=v.dtype)
 
 
-@wraps(np.diagonal)
+@derived_from(np)
 def diagonal(a, offset=0, axis1=0, axis2=1):
     name = 'diagonal-' + tokenize(a, offset, axis1, axis2)
 
@@ -673,7 +674,7 @@ def _np_fromfunction(func, shape, dtype, offset, func_kwargs):
     return np.fromfunction(offset_func, shape, dtype=dtype, **func_kwargs)
 
 
-@wraps(np.fromfunction)
+@derived_from(np)
 def fromfunction(func, chunks='auto', shape=None, dtype=None, **kwargs):
     chunks = normalize_chunks(chunks, shape, dtype=dtype)
     name = 'fromfunction-' + tokenize(func, chunks, shape, dtype, kwargs)
@@ -691,7 +692,7 @@ def fromfunction(func, chunks='auto', shape=None, dtype=None, **kwargs):
     return Array(dsk, name, chunks, dtype=dtype)
 
 
-@wraps(np.repeat)
+@derived_from(np)
 def repeat(a, repeats, axis=None):
     if axis is None:
         if a.ndim == 1:
@@ -737,7 +738,7 @@ def repeat(a, repeats, axis=None):
     return concatenate(out, axis=axis)
 
 
-@wraps(np.tile)
+@derived_from(np)
 def tile(A, reps):
     if not isinstance(reps, Integral):
         raise NotImplementedError("Only integer valued `reps` supported.")
@@ -1034,7 +1035,7 @@ def pad_udf(array, pad_width, mode, **kwargs):
     return result
 
 
-@wraps(np.pad)
+@derived_from(np)
 def pad(array, pad_width, mode, **kwargs):
     array = asarray(array)
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from functools import partial, wraps, reduce
+from functools import partial, reduce
 from itertools import product
 from operator import add, getitem
 from numbers import Integral, Number

--- a/dask/array/einsumfuncs.py
+++ b/dask/array/einsumfuncs.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy.compat import basestring
 
 from .core import blockwise, asarray, einsum_lookup
+from ..utils import derived_from
 
 einsum_symbols = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 einsum_symbols_set = set(einsum_symbols)
@@ -193,7 +194,7 @@ def parse_einsum_input(operands):
     return (input_subscripts, output_subscript, operands)
 
 
-@wraps(np.einsum)
+@derived_from(np)
 def einsum(*operands, **kwargs):
     casting = kwargs.pop('casting', 'safe')
     dtype = kwargs.pop('dtype', None)

--- a/dask/array/einsumfuncs.py
+++ b/dask/array/einsumfuncs.py
@@ -1,7 +1,5 @@
 from __future__ import division, print_function, absolute_import
 
-from functools import wraps
-
 import numpy as np
 from numpy.compat import basestring
 

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from ..compatibility import Sequence
-from functools import wraps
 import inspect
 
 import numpy as np

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -14,6 +14,7 @@ except ImportError:
 
 from .core import concatenate as _concatenate
 from .creation import arange as _arange
+from ..utils import derived_from
 
 
 chunk_error = ("Dask array only supports taking an FFT along an axis that \n"
@@ -236,7 +237,7 @@ def _fftfreq_block(i, n, d):
     return r
 
 
-@wraps(np.fft.fftfreq)
+@derived_from(np.fft)
 def fftfreq(n, d=1.0, chunks='auto'):
     n = int(n)
     d = float(d)
@@ -246,7 +247,7 @@ def fftfreq(n, d=1.0, chunks='auto'):
     return r.map_blocks(_fftfreq_block, dtype=float, n=n, d=d)
 
 
-@wraps(np.fft.rfftfreq)
+@derived_from(np.fft)
 def rfftfreq(n, d=1.0, chunks='auto'):
     n = int(n)
     d = float(d)
@@ -284,11 +285,11 @@ def _fftshift_helper(x, axes=None, inverse=False):
     return y
 
 
-@wraps(np.fft.fftshift)
+@derived_from(np.fft)
 def fftshift(x, axes=None):
     return _fftshift_helper(x, axes=axes, inverse=False)
 
 
-@wraps(np.fft.ifftshift)
+@derived_from(np.fft)
 def ifftshift(x, axes=None):
     return _fftshift_helper(x, axes=axes, inverse=True)

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -14,6 +14,7 @@ from ..highlevelgraph import HighLevelGraph
 from .core import dotmany, Array, concatenate
 from .creation import eye
 from .random import RandomState
+from ..utils import derived_from
 
 
 def _cumsum_blocks(it):
@@ -1111,7 +1112,7 @@ def lstsq(a, b):
     return x, residuals, rank, s
 
 
-@wraps(np.linalg.norm)
+@derived_from(np.linalg)
 def norm(x, ord=None, axis=None, keepdims=False):
     if axis is None:
         axis = tuple(range(x.ndim))

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import operator
-from functools import wraps
 from numbers import Number
 
 import numpy as np

--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -138,24 +138,24 @@ def masked_equal(a, value):
     return blockwise(np.ma.masked_equal, inds, a, inds, value, (), dtype=a.dtype)
 
 
-@wraps(np.ma.masked_invalid)
+@derived_from(np.ma)
 def masked_invalid(a):
     return asanyarray(a).map_blocks(np.ma.masked_invalid)
 
 
-@wraps(np.ma.masked_inside)
+@derived_from(np.ma)
 def masked_inside(x, v1, v2):
     x = asanyarray(x)
     return x.map_blocks(np.ma.masked_inside, v1, v2)
 
 
-@wraps(np.ma.masked_outside)
+@derived_from(np.ma)
 def masked_outside(x, v1, v2):
     x = asanyarray(x)
     return x.map_blocks(np.ma.masked_outside, v1, v2)
 
 
-@wraps(np.ma.masked_where)
+@derived_from(np.ma)
 def masked_where(condition, a):
     cshape = getattr(condition, 'shape', ())
     if cshape and cshape != a.shape:
@@ -176,7 +176,7 @@ def masked_where(condition, a):
     )
 
 
-@wraps(np.ma.masked_values)
+@derived_from(np.ma)
 def masked_values(x, value, rtol=1e-05, atol=1e-08, shrink=True):
     x = asanyarray(x)
     if getattr(value, 'shape', ()):
@@ -185,19 +185,19 @@ def masked_values(x, value, rtol=1e-05, atol=1e-08, shrink=True):
                       atol=atol, shrink=shrink)
 
 
-@wraps(np.ma.fix_invalid)
+@derived_from(np.ma)
 def fix_invalid(a, fill_value=None):
     a = asanyarray(a)
     return a.map_blocks(np.ma.fix_invalid, fill_value=fill_value)
 
 
-@wraps(np.ma.getdata)
+@derived_from(np.ma)
 def getdata(a):
     a = asanyarray(a)
     return a.map_blocks(np.ma.getdata)
 
 
-@wraps(np.ma.getmaskarray)
+@derived_from(np.ma)
 def getmaskarray(a):
     a = asanyarray(a)
     return a.map_blocks(np.ma.getmaskarray)
@@ -208,7 +208,7 @@ def _masked_array(data, mask=np.ma.nomask, **kwargs):
     return np.ma.masked_array(data, mask=mask, dtype=dtype, **kwargs)
 
 
-@wraps(np.ma.masked_array)
+@derived_from(np.ma)
 def masked_array(data, mask=np.ma.nomask, fill_value=None,
                  **kwargs):
     data = asanyarray(data)
@@ -244,7 +244,7 @@ def _set_fill_value(x, fill_value):
     return x
 
 
-@wraps(np.ma.set_fill_value)
+@derived_from(np.ma)
 def set_fill_value(a, fill_value):
     a = asanyarray(a)
     if getattr(fill_value, 'shape', ()):
@@ -255,6 +255,6 @@ def set_fill_value(a, fill_value):
     a.name = res.name
 
 
-@wraps(np.ma.average)
+@derived_from(np.ma)
 def average(a, axis=None, weights=None, returned=False):
     return _average(a, axis, weights, returned, is_masked=True)

--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -8,6 +8,7 @@ from ..base import normalize_token
 from .core import (concatenate_lookup, tensordot_lookup, map_blocks,
                    asanyarray, blockwise)
 from .routines import _average
+from ..utils import derived_from
 
 
 @normalize_token.register(np.ma.masked_array)
@@ -101,7 +102,7 @@ def _tensordot(a, b, axes=2):
     return res.reshape(olda + oldb)
 
 
-@wraps(np.ma.filled)
+@derived_from(np.ma)
 def filled(a, fill_value=None):
     a = asanyarray(a)
     return a.map_blocks(np.ma.filled, fill_value=fill_value)
@@ -128,7 +129,7 @@ masked_less_equal = _wrap_masked(np.ma.masked_less_equal)
 masked_not_equal = _wrap_masked(np.ma.masked_not_equal)
 
 
-@wraps(np.ma.masked_equal)
+@derived_from(np.ma)
 def masked_equal(a, value):
     a = asanyarray(a)
     if getattr(value, 'shape', ()):

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -899,7 +899,6 @@ def _isin_kernel(element, test_elements, assume_unique=False):
     return values.reshape(element.shape + (1,) * test_elements.ndim)
 
 
-# not @derived_from, func might not exist
 @safe_wraps(getattr(np, 'isin', None))
 def isin(element, test_elements, assume_unique=False, invert=False):
     element = asarray(element)
@@ -1203,7 +1202,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
     )
 
 
-@wraps(chunk.coarsen)  # this is not a numpy function
+@wraps(chunk.coarsen)
 def coarsen(reduction, x, axes, trim_excess=False):
     if (not trim_excess and
         not all(bd % div == 0 for i, div in axes.items()

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -13,7 +13,7 @@ from ..compatibility import Iterable
 from ..core import flatten
 from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
-from ..utils import funcname
+from ..utils import funcname, derived_from
 from . import chunk
 from .creation import arange, diag, empty, indices
 from .utils import safe_wraps, validate_axis
@@ -27,7 +27,7 @@ from .core import (Array, map_blocks, elemwise, from_array, asarray,
 from .einsumfuncs import einsum  # noqa
 
 
-@wraps(np.array)
+@derived_from(np)
 def array(x, dtype=None, ndmin=None):
     while ndmin is not None and x.ndim < ndmin:
         x = x[None, :]

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -36,13 +36,13 @@ def array(x, dtype=None, ndmin=None):
     return x
 
 
-@wraps(np.result_type)
+@derived_from(np)
 def result_type(*args):
     args = [a if is_scalar_for_elemwise(a) else a.dtype for a in args]
     return np.result_type(*args)
 
 
-@wraps(np.atleast_3d)
+@derived_from(np)
 def atleast_3d(*arys):
     new_arys = []
     for x in arys:
@@ -62,7 +62,7 @@ def atleast_3d(*arys):
         return new_arys
 
 
-@wraps(np.atleast_2d)
+@derived_from(np)
 def atleast_2d(*arys):
     new_arys = []
     for x in arys:
@@ -80,7 +80,7 @@ def atleast_2d(*arys):
         return new_arys
 
 
-@wraps(np.atleast_1d)
+@derived_from(np)
 def atleast_1d(*arys):
     new_arys = []
     for x in arys:
@@ -96,13 +96,13 @@ def atleast_1d(*arys):
         return new_arys
 
 
-@wraps(np.vstack)
+@derived_from(np)
 def vstack(tup, allow_unknown_chunksizes=False):
     tup = tuple(atleast_2d(x) for x in tup)
     return concatenate(tup, axis=0, allow_unknown_chunksizes=allow_unknown_chunksizes)
 
 
-@wraps(np.hstack)
+@derived_from(np)
 def hstack(tup, allow_unknown_chunksizes=False):
     if all(x.ndim == 1 for x in tup):
         return concatenate(tup, axis=0, allow_unknown_chunksizes=allow_unknown_chunksizes)
@@ -110,13 +110,13 @@ def hstack(tup, allow_unknown_chunksizes=False):
         return concatenate(tup, axis=1, allow_unknown_chunksizes=allow_unknown_chunksizes)
 
 
-@wraps(np.dstack)
+@derived_from(np)
 def dstack(tup, allow_unknown_chunksizes=False):
     tup = tuple(atleast_3d(x) for x in tup)
     return concatenate(tup, axis=2, allow_unknown_chunksizes=allow_unknown_chunksizes)
 
 
-@wraps(np.swapaxes)
+@derived_from(np)
 def swapaxes(a, axis1, axis2):
     if axis1 == axis2:
         return a
@@ -131,7 +131,7 @@ def swapaxes(a, axis1, axis2):
     return blockwise(np.swapaxes, out, a, ind, axis1=axis1, axis2=axis2, dtype=a.dtype)
 
 
-@wraps(np.transpose)
+@derived_from(np)
 def transpose(a, axes=None):
     if axes:
         if len(axes) != a.ndim:
@@ -171,12 +171,12 @@ def flip(m, axis):
     return m[sl]
 
 
-@wraps(np.flipud)
+@derived_from(np)
 def flipud(m):
     return flip(m, 0)
 
 
-@wraps(np.fliplr)
+@derived_from(np)
 def fliplr(m):
     return flip(m, 1)
 
@@ -205,7 +205,7 @@ def _tensordot(a, b, axes):
     return x
 
 
-@wraps(np.tensordot)
+@derived_from(np)
 def tensordot(lhs, rhs, axes=2):
     if isinstance(axes, Iterable):
         left_axes, right_axes = axes
@@ -241,17 +241,17 @@ def tensordot(lhs, rhs, axes=2):
     return result
 
 
-@wraps(np.dot)
+@derived_from(np)
 def dot(a, b):
     return tensordot(a, b, axes=((a.ndim - 1,), (b.ndim - 2,)))
 
 
-@wraps(np.vdot)
+@derived_from(np)
 def vdot(a, b):
     return dot(a.conj().ravel(), b.ravel())
 
 
-@safe_wraps(np.matmul)
+@derived_from(np)
 def matmul(a, b):
     a = asanyarray(a)
     b = asanyarray(b)
@@ -290,7 +290,7 @@ def matmul(a, b):
     return out
 
 
-@wraps(np.outer)
+@derived_from(np)
 def outer(a, b):
     a = a.flatten()
     b = b.flatten()
@@ -310,7 +310,7 @@ def _inner_apply_along_axis(arr,
     )
 
 
-@wraps(np.apply_along_axis)
+@derived_from(np)
 def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     arr = asarray(arr)
 
@@ -345,7 +345,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     return result
 
 
-@wraps(np.apply_over_axes)
+@derived_from(np)
 def apply_over_axes(func, a, axes):
     # Validate arguments
     a = asarray(a)
@@ -373,12 +373,12 @@ def apply_over_axes(func, a, axes):
     return result
 
 
-@wraps(np.ptp)
+@derived_from(np)
 def ptp(a, axis=None):
     return a.max(axis=axis) - a.min(axis=axis)
 
 
-@wraps(np.diff)
+@derived_from(np)
 def diff(a, n=1, axis=-1):
     a = asarray(a)
     n = int(n)
@@ -400,7 +400,7 @@ def diff(a, n=1, axis=-1):
     return r
 
 
-@wraps(np.ediff1d)
+@derived_from(np)
 def ediff1d(ary, to_end=None, to_begin=None):
     ary = asarray(ary)
 
@@ -437,7 +437,7 @@ def _gradient_kernel(x, block_id, coord, axis, array_locs, grad_kwargs):
     return grad
 
 
-@wraps(np.gradient)
+@derived_from(np)
 def gradient(f, *varargs, **kwargs):
     f = asarray(f)
 
@@ -523,7 +523,7 @@ def _bincount_sum(bincounts, dtype=int):
     return out
 
 
-@wraps(np.bincount)
+@derived_from(np)
 def bincount(x, weights=None, minlength=0):
     if x.ndim != 1:
         raise ValueError('Input array must be one dimensional. '
@@ -556,7 +556,7 @@ def bincount(x, weights=None, minlength=0):
     return Array(graph, final_name, chunks, dtype)
 
 
-@wraps(np.digitize)
+@derived_from(np)
 def digitize(a, bins, right=False):
     bins = np.asarray(bins)
     dtype = np.digitize([0], bins, right=False).dtype
@@ -664,7 +664,7 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
         return n, bins
 
 
-@wraps(np.cov)
+@derived_from(np)
 def cov(m, y=None, rowvar=1, bias=0, ddof=None):
     # This was copied almost verbatim from np.cov
     # See numpy license at https://github.com/numpy/numpy/blob/master/LICENSE.txt
@@ -713,7 +713,7 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
         return (dot(X, X.T.conj()) / fact).squeeze()
 
 
-@wraps(np.corrcoef)
+@derived_from(np)
 def corrcoef(x, y=None, rowvar=1):
     c = cov(x, y, rowvar)
     if c.shape == ():
@@ -724,7 +724,7 @@ def corrcoef(x, y=None, rowvar=1):
     return (c / sqr_d) / sqr_d.T
 
 
-@wraps(np.round)
+@derived_from(np)
 def round(a, decimals=0):
     return a.map_blocks(np.round, decimals=decimals, dtype=a.dtype)
 
@@ -790,7 +790,7 @@ def _unique_internal(ar, indices, counts, return_inverse=False):
     return r
 
 
-@wraps(np.unique)
+@derived_from(np)
 def unique(ar, return_index=False, return_inverse=False, return_counts=False):
     ar = ar.ravel()
 
@@ -899,6 +899,7 @@ def _isin_kernel(element, test_elements, assume_unique=False):
     return values.reshape(element.shape + (1,) * test_elements.ndim)
 
 
+# not @derived_from, func might not exist
 @safe_wraps(getattr(np, 'isin', None))
 def isin(element, test_elements, assume_unique=False, invert=False):
     element = asarray(element)
@@ -923,7 +924,7 @@ def isin(element, test_elements, assume_unique=False, invert=False):
     return result
 
 
-@wraps(np.roll)
+@derived_from(np)
 def roll(array, shift, axis=None):
     result = array
 
@@ -971,12 +972,12 @@ def roll(array, shift, axis=None):
     return result
 
 
-@wraps(np.ravel)
+@derived_from(np)
 def ravel(array):
     return array.reshape((-1,))
 
 
-@wraps(np.squeeze)
+@derived_from(np)
 def squeeze(a, axis=None):
     if axis is None:
         axis = tuple(i for i, d in enumerate(a.shape) if d == 1)
@@ -993,7 +994,7 @@ def squeeze(a, axis=None):
     return a[sl]
 
 
-@wraps(np.compress)
+@derived_from(np)
 def compress(condition, a, axis=None):
     condition = asarray(condition).astype(bool)
     a = asarray(a)
@@ -1019,14 +1020,14 @@ def compress(condition, a, axis=None):
     return a
 
 
-@wraps(np.extract)
+@derived_from(np)
 def extract(condition, arr):
     condition = asarray(condition).astype(bool)
     arr = asarray(arr)
     return compress(condition.ravel(), arr.ravel())
 
 
-@wraps(np.take)
+@derived_from(np)
 def take(a, indices, axis=0):
     axis = validate_axis(axis, a.ndim)
 
@@ -1045,7 +1046,7 @@ def _take_dask_array_from_numpy(a, indices, axis):
                               dtype=a.dtype)
 
 
-@wraps(np.around)
+@derived_from(np)
 def around(x, decimals=0):
     return map_blocks(partial(np.around, decimals=decimals), x, dtype=x.dtype)
 
@@ -1067,13 +1068,13 @@ def notnull(values):
     return ~isnull(values)
 
 
-@wraps(np.isclose)
+@derived_from(np)
 def isclose(arr1, arr2, rtol=1e-5, atol=1e-8, equal_nan=False):
     func = partial(np.isclose, rtol=rtol, atol=atol, equal_nan=equal_nan)
     return elemwise(func, arr1, arr2, dtype='bool')
 
 
-@wraps(np.allclose)
+@derived_from(np)
 def allclose(arr1, arr2, rtol=1e-5, atol=1e-8, equal_nan=False):
     return isclose(arr1, arr2, rtol=rtol, atol=atol, equal_nan=equal_nan).all()
 
@@ -1082,7 +1083,7 @@ def variadic_choose(a, *choices):
     return np.choose(a, choices)
 
 
-@wraps(np.choose)
+@derived_from(np)
 def choose(a, choices):
     return elemwise(variadic_choose, a, *choices)
 
@@ -1109,7 +1110,7 @@ def isnonzero(a):
         return a.astype(bool)
 
 
-@wraps(np.argwhere)
+@derived_from(np)
 def argwhere(a):
     a = asarray(a)
 
@@ -1123,7 +1124,7 @@ def argwhere(a):
     return ind
 
 
-@wraps(np.where)
+@derived_from(np)
 def where(condition, x=None, y=None):
     if (x is None) != (y is None):
         raise ValueError("either both or neither of x and y should be given")
@@ -1143,17 +1144,17 @@ def where(condition, x=None, y=None):
         return elemwise(np.where, condition, x, y)
 
 
-@wraps(np.count_nonzero)
+@derived_from(np)
 def count_nonzero(a, axis=None):
     return isnonzero(asarray(a)).astype(np.intp).sum(axis=axis)
 
 
-@wraps(np.flatnonzero)
+@derived_from(np)
 def flatnonzero(a):
     return argwhere(asarray(a).ravel())[:, 0]
 
 
-@wraps(np.nonzero)
+@derived_from(np)
 def nonzero(a):
     ind = argwhere(a)
     if ind.ndim > 1:
@@ -1173,7 +1174,7 @@ def _unravel_index_kernel(indices, func_kwargs):
     return np.stack(np.unravel_index(indices, **func_kwargs))
 
 
-@wraps(np.unravel_index)
+@derived_from(np)
 def unravel_index(indices, dims, order='C'):
     if dims and indices.size:
         unraveled_indices = tuple(indices.map_blocks(
@@ -1191,7 +1192,7 @@ def unravel_index(indices, dims, order='C'):
     return unraveled_indices
 
 
-@wraps(np.piecewise)
+@derived_from(np)
 def piecewise(x, condlist, funclist, *args, **kw):
     return map_blocks(
         _int_piecewise,
@@ -1202,7 +1203,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
     )
 
 
-@wraps(chunk.coarsen)
+@wraps(chunk.coarsen)  # this is not a numpy function
 def coarsen(reduction, x, axes, trim_excess=False):
     if (not trim_excess and
         not all(bd % div == 0 for i, div in axes.items()
@@ -1237,7 +1238,7 @@ def split_at_breaks(array, breaks, axis=0):
     return split_array
 
 
-@wraps(np.insert)
+@derived_from(np)
 def insert(arr, obj, values, axis):
     # axis is a required argument here to avoid needing to deal with the numpy
     # default case (which reshapes the array to make it flat)
@@ -1332,6 +1333,6 @@ def _average(a, axis=None, weights=None, returned=False, is_masked=False):
         return avg
 
 
-@wraps(np.average)
+@derived_from(np)
 def average(a, axis=None, weights=None, returned=False):
     return _average(a, axis, weights, returned, is_masked=False)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -26,6 +26,12 @@ def test_array():
     assert isinstance(y, da.Array)
 
 
+def test_derived_docstrings():
+    assert ("This docstring was copied from numpy.array"
+            in da.routines.array.__doc__)
+    assert "Create an array." in da.routines.array.__doc__
+
+
 @pytest.mark.parametrize("funcname", [
     "atleast_1d",
     "atleast_2d",

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -26,6 +26,7 @@ def test_array():
     assert isinstance(y, da.Array)
 
 
+@pytest.mark.skipif(PY2, reason="Docstrings stripped in optimised Py2")
 def test_derived_docstrings():
     assert ("This docstring was copied from numpy.array"
             in da.routines.array.__doc__)

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -1,6 +1,6 @@
 
 from operator import getitem
-from functools import partial, wraps
+from functools import partial
 
 import numpy as np
 from toolz import curry

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -10,7 +10,7 @@ from .utils import IS_NEP18_ACTIVE
 from ..base import is_dask_collection, normalize_function
 from .. import core
 from ..highlevelgraph import HighLevelGraph
-from ..utils import (skip_doctest, funcname,
+from ..utils import (skip_doctest, funcname, derived_from,
                      is_dataframe_like, is_series_like, is_index_like)
 
 
@@ -82,7 +82,7 @@ class da_frompyfunc(object):
         return list(o)
 
 
-@wraps(np.frompyfunc)
+@derived_from(np)
 def frompyfunc(func, nin, nout):
     if nout > 1:
         raise NotImplementedError("frompyfunc with more than one output")

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -104,7 +104,8 @@ if PY3:
         """Get all non ``*args/**kwargs`` arguments for a function"""
         s = inspect.signature(func)
         return [n for n, p in s.parameters.items()
-                if p.kind == p.POSITIONAL_OR_KEYWORD]
+                if p.kind in [p.POSITIONAL_OR_KEYWORD, p.POSITIONAL_ONLY,
+                              p.KEYWORD_ONLY]]
 
     def reraise(exc, tb=None):
         if exc.__traceback__ is not tb:

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -421,6 +421,19 @@ def test_derived_from():
 
 
 @pytest.mark.skipif(PY2, reason="Docstrings not as easy to manipulate in Py2")
+def test_derived_from_func():
+    import builtins
+    @derived_from(builtins)
+    def sum():
+        "extra docstring"
+        pass
+
+    assert "extra docstring\n\n" in sum.__doc__
+    assert "Return the sum of" in sum.__doc__
+    assert "This docstring was copied from builtins.sum" in sum.__doc__
+
+
+@pytest.mark.skipif(PY2, reason="Docstrings not as easy to manipulate in Py2")
 def test_derived_from_dask_dataframe():
     dd = pytest.importorskip('dask.dataframe')
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -477,7 +477,13 @@ def extra_titles(doc):
 
 def ignore_warning(doc, cls, name, extra=""):
     """Expand docstring by adding disclaimer and extra text"""
-    l1 = "This docstring was copied from %s.%s.%s. \n\n" % (cls.__module__, cls.__name__, name)
+    import inspect
+    if inspect.isclass(cls):
+        l1 = "This docstring was copied from %s.%s.%s. \n\n" \
+             "" % (cls.__module__, cls.__name__, name)
+    else:
+        l1 = "This docstring was copied from %s.%s. \n\n" \
+             "" % (cls.__name__, name)
     l2 = "Some inconsistencies with the Dask version may exist."
 
     i = doc.find('\n\n')

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -512,7 +512,8 @@ def unsupported_arguments(doc, args):
     """ Mark unsupported arguments with a disclaimer """
     lines = doc.split('\n')
     for arg in args:
-        subset = [(i, line) for i, line in enumerate(lines) if re.match(r'^\s*' + arg + ' ?:', line)]
+        subset = [(i, line) for i, line in enumerate(lines)
+                  if re.match(r'^\s*' + arg + ' ?:', line)]
         if len(subset) == 1:
             [(i, line)] = subset
             lines[i] = line + "  (Not supported in Dask)"

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -441,7 +441,7 @@ def _skip_doctest(line):
     # NumPy docstring contains cursor and comment only example
     stripped = line.strip()
     if stripped == '>>>' or stripped.startswith('>>> #'):
-        return stripped
+        return line
     elif '>>>' in stripped and '+SKIP' not in stripped:
         if '# doctest:' in line:
             return line + ', +SKIP'


### PR DESCRIPTION
To be applied to numpy top-level functions, as seen throughout the dask.array
package. One test case so far: da.routines.array .

- [x] Tests added / passed
- [x] Passes `flake8 dask`

Fixes #4758