### PR TITLE
catch IOError in ensure_file

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -252,7 +252,7 @@ def ensure_file(
                 os.rename(tmp, destination)
             except OSError:
                 os.remove(tmp)
-    except OSError:
+    except (IOError, OSError):
         pass
 
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

I didn't bother with a test and can mock something if necessary. Ran into this with a read only file system when grabbing the new version.