### PR TITLE
Add read_function keyword to read_json

### DIFF
--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -76,7 +76,7 @@ def write_json_partition(df, openfile, kwargs):
 @insert_meta_param_description
 def read_json(url_path, orient='records', lines=None, storage_options=None,
               blocksize=None, sample=2**20, encoding='utf-8', errors='strict',
-              compression='infer', meta=None, **kwargs):
+              compression='infer', meta=None, engine=pd.read_json, **kwargs):
     """Create a dataframe from a set of JSON files
 
     This utilises ``pandas.read_json()``, and most parameters are
@@ -114,6 +114,9 @@ def read_json(url_path, orient='records', lines=None, storage_options=None,
         Text conversion, ``see bytes.decode()``
     compression : string or None
         String like 'gzip' or 'xz'.
+    engine : function object, default ``pd.read_json``
+        The underlying function that dask will use to read JSON files. By
+        default, this will be the pandas JSON reader (``pd.read_json``).
     $META
 
     Returns
@@ -153,32 +156,30 @@ def read_json(url_path, orient='records', lines=None, storage_options=None,
                                    **storage_options)
         chunks = list(dask.core.flatten(chunks))
         if meta is None:
-            meta = read_json_chunk(first, encoding, errors, kwargs)
+            meta = read_json_chunk(first, encoding, errors, engine, kwargs)
         meta = make_meta(meta)
         parts = [dask.delayed(read_json_chunk)(
-            chunk, encoding, errors, kwargs, meta=meta
+            chunk, encoding, errors, engine, kwargs, meta=meta
         ) for chunk in chunks]
         return dd.from_delayed(parts, meta=meta)
     else:
         files = open_files(url_path, 'rt', encoding=encoding, errors=errors,
                            compression=compression, **storage_options)
-        parts = [dask.delayed(read_json_file)(f, orient, lines, kwargs)
+        parts = [dask.delayed(read_json_file)(f, orient, lines, engine, kwargs)
                  for f in files]
         return dd.from_delayed(parts, meta=meta)
 
 
-def read_json_chunk(chunk, encoding, errors, kwargs, meta=None):
+def read_json_chunk(chunk, encoding, errors, engine, kwargs, meta=None):
     s = io.StringIO(chunk.decode(encoding, errors))
     s.seek(0)
-    read_function = kwargs.pop('read_function', pd.read_json)
-    df = read_function(s, orient='records', lines=True, **kwargs)
+    df = engine(s, orient='records', lines=True, **kwargs)
     if meta is not None and df.empty:
         return meta
     else:
         return df
 
 
-def read_json_file(f, orient, lines, kwargs):
-    read_function = kwargs.pop('read_function', pd.read_json)
+def read_json_file(f, orient, lines, engine, kwargs):
     with f as f:
-        return read_function(f, orient=orient, lines=lines, **kwargs)
+        return engine(f, orient=orient, lines=lines, **kwargs)

--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -170,7 +170,8 @@ def read_json(url_path, orient='records', lines=None, storage_options=None,
 def read_json_chunk(chunk, encoding, errors, kwargs, meta=None):
     s = io.StringIO(chunk.decode(encoding, errors))
     s.seek(0)
-    df = pd.read_json(s, orient='records', lines=True, **kwargs)
+    read_function = kwargs.pop('read_function', pd.read_json)
+    df = read_function(s, orient='records', lines=True, **kwargs)
     if meta is not None and df.empty:
         return meta
     else:
@@ -178,5 +179,6 @@ def read_json_chunk(chunk, encoding, errors, kwargs, meta=None):
 
 
 def read_json_file(f, orient, lines, kwargs):
+    read_function = kwargs.pop('read_function', pd.read_json)
     with f as f:
-        return pd.read_json(f, orient=orient, lines=lines, **kwargs)
+        return read_function(f, orient=orient, lines=lines, **kwargs)

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -39,9 +39,9 @@ def test_read_json_basic(orient):
             out.columns = list(df.columns)
         assert_eq(out, df)
 
-@pytest.mark.parametrize('orient', ['records', 'index', 'columns', 'values'])
+
 @pytest.mark.parametrize('fkeyword', ['pandas', 'json'])
-def test_read_json_fkeyword(orient, fkeyword):
+def test_read_json_fkeyword(fkeyword):
     def _my_json_reader(*args, **kwargs):
         if fkeyword == 'json':
             if json is None:
@@ -58,9 +58,8 @@ def test_read_json_fkeyword(orient, fkeyword):
 
         out = actual.compute()
         assert_eq(out, actual_pd)
-        if orient == 'values':
-            out.columns = list(df.columns)
         assert_eq(out, df)
+
 
 @pytest.mark.parametrize('orient', ['split', 'records', 'index', 'columns',
                                     'values'])


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `flake8 dask`

This PR allows the pandas `read_json` function to be swapped out for something else (like `cudf.read_json`)