### PR TITLE
Update URL for joblib to new website hosting their doc

### DIFF
--- a/docs/source/custom-graphs.rst
+++ b/docs/source/custom-graphs.rst
@@ -83,7 +83,7 @@ Dask schedulers differ in the following ways:
 But the other projects offer different advantages and different programming
 paradigms.  One should inspect all such projects before selecting one.
 
-.. _Joblib: https://pythonhosted.org/joblib/parallel.html
+.. _Joblib: https://joblib.readthedocs.io/en/latest/
 .. _Multiprocessing: https://docs.python.org/3/library/multiprocessing.html
 .. _`IPython Parallel`: https://ipyparallel.readthedocs.io/en/latest/
 .. _`Concurrent.futures`: https://docs.python.org/3/library/concurrent.futures.html

--- a/docs/source/use-cases.rst
+++ b/docs/source/use-cases.rst
@@ -402,5 +402,5 @@ cluster resources in response to demand.
 
 .. _`combines dask.distributed with normal Python Queues`: https://distributed.dask.org/en/latest/queues.html
 
-.. _Joblib: https://pythonhosted.org/joblib/parallel.html
+.. _Joblib: https://joblib.readthedocs.io/en/latest/
 .. _dask.distributed: https://distributed.dask.org/en/latest/


### PR DESCRIPTION
The website pythonhosted.org is dead now? Anyways, this is the new location for their doc.