### PR TITLE
Provide full type name in check_meta

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2896,7 +2896,7 @@ class DataFrame(_Frame):
                     callable(v) or pd.api.types.is_scalar(v) or
                     is_index_like(v)):
                 raise TypeError("Column assignment doesn't support type "
-                                "{0}".format(type(v).__name__))
+                                "{0}".format(typename(type(v))))
             if callable(v):
                 kwargs[k] = v(self)
 
@@ -3625,7 +3625,8 @@ def handle_out(out, result):
             out.divisions = result.divisions
     elif out is not None:
         msg = ("The out parameter is not fully supported."
-               " Received type %s, expected %s " % ( type(out).__name__, type(result).__name__))
+               " Received type %s, expected %s " % ( typename(type(out)),
+                   typename(type(result))))
         raise NotImplementedError(msg)
     else:
         return result

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3624,9 +3624,11 @@ def handle_out(out, result):
         if not isinstance(out, Scalar):
             out.divisions = result.divisions
     elif out is not None:
-        msg = ("The out parameter is not fully supported."
-               " Received type %s, expected %s " % ( typename(type(out)),
-                   typename(type(result))))
+        msg = (
+            "The out parameter is not fully supported."
+            " Received type %s, expected %s " % (
+                typename(type(out)), typename(type(result)))
+        )
         raise NotImplementedError(msg)
     else:
         return result

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -305,7 +305,7 @@ def test_check_meta():
         check_meta(d, meta.d.astype('f8'), numeric_equal=False)
     assert str(err.value) == ('Metadata mismatch found.\n'
                               '\n'
-                              'Partition type: `Series`\n'
+                              'Partition type: `pandas.core.series.Series`\n'
                               '+----------+---------+\n'
                               '|          | dtype   |\n'
                               '+----------+---------+\n'
@@ -322,7 +322,7 @@ def test_check_meta():
     exp = (
         'Metadata mismatch found in `from_delayed`.\n'
         '\n'
-        'Partition type: `DataFrame`\n'
+        'Partition type: `pandas.core.frame.DataFrame`\n'
         '+--------+----------+----------+\n'
         '| Column | Found    | Expected |\n'
         '+--------+----------+----------+\n'

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -333,6 +333,17 @@ def test_check_meta():
     assert str(err.value) == exp
 
 
+def test_check_meta_typename():
+    df = pd.DataFrame({'x': []})
+    ddf = dd.from_pandas(df, npartitions=1)
+    check_meta(df, df)
+    with pytest.raises(Exception) as info:
+        check_meta(ddf, df)
+
+    assert "dask" in str(info.value)
+    assert "pandas" in str(info.value)
+
+
 def test_is_dataframe_like():
     df = pd.DataFrame({'x': [1, 2, 3]})
     ddf = dd.from_pandas(df, npartitions=1)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -22,7 +22,7 @@ from ..base import is_dask_collection
 from ..compatibility import PY2, Iterator, Mapping
 from ..core import get_deps
 from ..local import get_sync
-from ..utils import asciitable, is_arraylike, Dispatch
+from ..utils import asciitable, is_arraylike, Dispatch, typename
 from ..utils import is_dataframe_like as dask_is_dataframe_like
 from ..utils import is_series_like as dask_is_series_like
 from ..utils import is_index_like as dask_is_index_like
@@ -565,7 +565,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
 
     if type(x) != type(meta):
         errmsg = ("Expected partition of type `%s` but got "
-                  "`%s`" % (type(meta).__name__, type(x).__name__))
+                  "`%s`" % (typename(type(meta)), typename(type(x))))
     elif is_dataframe_like(meta):
         kwargs = dict()
         if PANDAS_VERSION >= '0.23.0':

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -346,8 +346,8 @@ def meta_nonempty_object(x):
     if is_scalar(x):
         return _nonempty_scalar(x)
     else:
-        raise TypeError("Expected Index, Series, DataFrame, or scalar, "
-                        "got {0}".format(type(x).__name__))
+        raise TypeError("Expected Pandas-like Index, Series, DataFrame, or scalar, "
+                        "got {0}".format(typename(type(x))))
 
 
 @meta_nonempty.register(pd.DataFrame)
@@ -414,7 +414,7 @@ def _nonempty_index(idx):
             return pd.MultiIndex(levels=levels, labels=codes, names=idx.names)
 
     raise TypeError("Don't know how to handle index of "
-                    "type {0}".format(type(idx).__name__))
+                    "type {0}".format(typename(type(idx))))
 
 
 _simple_fake_mapping = {
@@ -463,7 +463,7 @@ def _nonempty_scalar(x):
         return make_scalar(dtype)
 
     raise TypeError("Can't handle meta of type "
-                    "'{0}'".format(type(x).__name__))
+                    "'{0}'".format(typename(type(x))))
 
 
 @meta_nonempty.register(pd.Series)
@@ -561,7 +561,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
     if (not (is_dataframe_like(meta) or is_series_like(meta) or is_index_like(meta))
             or is_dask_collection(meta)):
         raise TypeError("Expected partition to be DataFrame, Series, or "
-                        "Index, got `%s`" % type(meta).__name__)
+                        "Index, got `%s`" % typename(type(meta)))
 
     if type(x) != type(meta):
         errmsg = ("Expected partition of type `%s` but got "
@@ -575,7 +575,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
                       if not equal_dtypes(a, b)]
         if bad_dtypes:
             errmsg = ("Partition type: `%s`\n%s" %
-                      (type(meta).__name__,
+                      (typename(type(meta)),
                        asciitable(['Column', 'Found', 'Expected'], bad_dtypes)))
         elif not np.array_equal(np.nan_to_num(meta.columns),
                                 np.nan_to_num(x.columns)):
@@ -589,7 +589,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
         if equal_dtypes(x.dtype, meta.dtype):
             return x
         errmsg = ("Partition type: `%s`\n%s" %
-                  (type(meta).__name__,
+                  (typename(type(meta)),
                    asciitable(['', 'dtype'], [('Found', x.dtype),
                                               ('Expected', meta.dtype)])))
 


### PR DESCRIPTION
Otherwise users get the less-than-helpful error message when they put
dask dataframes in dask dataframes

> Expected DataFrame but got DataFrame

For example https://stackoverflow.com/questions/56174285/forcing-locality-on-dask-dataframe-subsets