### PR TITLE
Added accessor registration for Series, DataFrame, and Index

### DIFF
--- a/dask/dataframe/_accessor.py
+++ b/dask/dataframe/_accessor.py
@@ -4,7 +4,7 @@ import warnings
 # Ported from pandas
 # https://github.com/pandas-dev/pandas/blob/master/pandas/core/accessor.py
 
-class CachedAccessor:
+class CachedAccessor(object):
     """
     Custom property-like object (descriptor) for caching accessors.
 

--- a/dask/dataframe/_accessor.py
+++ b/dask/dataframe/_accessor.py
@@ -1,0 +1,79 @@
+import warnings
+
+
+# Ported from pandas
+# https://github.com/pandas-dev/pandas/blob/master/pandas/core/accessor.py
+
+class CachedAccessor:
+    """
+    Custom property-like object (descriptor) for caching accessors.
+
+    Parameters
+    ----------
+    name : str
+        The namespace this will be accessed under, e.g. ``df.foo``
+    accessor : cls
+        The class with the extension methods. The class' __init__ method
+        should expect one of a ``Series``, ``DataFrame`` or ``Index`` as
+        the single argument ``data``
+    """
+    def __init__(self, name, accessor):
+        self._name = name
+        self._accessor = accessor
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            # we're accessing the attribute of the class, i.e., Dataset.geo
+            return self._accessor
+        accessor_obj = self._accessor(obj)
+        # Replace the property with the accessor object. Inspired by:
+        # http://www.pydanny.com/cached-property.html
+        # We need to use object.__setattr__ because we overwrite __setattr__ on
+        # NDFrame
+        object.__setattr__(obj, self._name, accessor_obj)
+        return accessor_obj
+
+
+def _register_accessor(name, cls):
+    def decorator(accessor):
+        if hasattr(cls, name):
+            warnings.warn(
+                'registration of accessor {!r} under name {!r} for type '
+                '{!r} is overriding a preexisting attribute with the same '
+                'name.'.format(accessor, name, cls),
+                UserWarning,
+                stacklevel=2)
+        setattr(cls, name, CachedAccessor(name, accessor))
+        cls._accessors.add(name)
+        return accessor
+    return decorator
+
+
+def register_dataframe_accessor(name):
+    """
+    Register a custom accessor on :class:`dask.dataframe.DataFrame`.
+
+    See :func:`pandas.api.extensions.register_dataframe_accessor` for more.
+    """
+    from dask.dataframe import DataFrame
+    return _register_accessor(name, DataFrame)
+
+
+def register_series_accessor(name):
+    """
+    Register a custom accessor on :class:`dask.dataframe.Series`.
+
+    See :func:`pandas.api.extensions.register_series_accessor` for more.
+    """
+    from dask.dataframe import Series
+    return _register_accessor(name, Series)
+
+
+def register_index_accessor(name):
+    """
+    Register a custom accessor on :class:`dask.dataframe.Index`.
+
+    See :func:`pandas.api.extensions.register_index_accessor` for more.
+    """
+    from dask.dataframe import Index
+    return _register_accessor(name, Index)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2003,6 +2003,7 @@ class Series(_Frame):
     _partition_type = pd.Series
     _is_partition_type = staticmethod(is_series_like)
     _token_prefix = 'series-'
+    _accessors = set()
 
     def __array_wrap__(self, array, context=None):
         if isinstance(context, tuple) and len(context) > 0:
@@ -2481,6 +2482,7 @@ class Index(Series):
     _partition_type = pd.Index
     _is_partition_type = staticmethod(is_index_like)
     _token_prefix = 'index-'
+    _accessors = set()
 
     _dt_attributes = {'nanosecond', 'microsecond', 'millisecond', 'dayofyear',
                       'minute', 'hour', 'day', 'dayofweek', 'second', 'week',
@@ -2611,6 +2613,7 @@ class DataFrame(_Frame):
     _partition_type = pd.DataFrame
     _is_partition_type = staticmethod(is_dataframe_like)
     _token_prefix = 'dataframe-'
+    _accessors = set()
 
     def __array_wrap__(self, array, context=None):
         if isinstance(context, tuple) and len(context) > 0:

--- a/dask/dataframe/extensions.py
+++ b/dask/dataframe/extensions.py
@@ -4,6 +4,20 @@ Support for pandas ExtensionArray in dask.dataframe.
 See :ref:`extensionarrays` for more.
 """
 from ..utils import Dispatch
+from ._accessor import (
+    register_dataframe_accessor,
+    register_index_accessor,
+    register_series_accessor
+)
 
 make_array_nonempty = Dispatch("make_array_nonempty")
 make_scalar = Dispatch("make_scalar")
+
+
+__all__ = [
+    'make_array_nonempty',
+    'make_scalar',
+    'register_dataframe_accessor',
+    'register_index_accessor',
+    'register_series_accessor'
+]

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -2,6 +2,8 @@ import contextlib
 
 import pytest
 
+import dask.compatibility
+
 
 pd = pytest.importorskip('pandas')
 import dask.dataframe as dd
@@ -44,6 +46,7 @@ class MyAccessor:
     (dd.DataFrame, dd.extensions.register_dataframe_accessor),
     (dd.Index, dd.extensions.register_index_accessor)
 ])
+@pytest.mark.skipif(dask.compatibility.PY2, reason="Unknown")
 def test_register(obj, registrar):
     with ensure_removed(obj, 'mine'):
         before = set(dir(obj))
@@ -55,6 +58,7 @@ def test_register(obj, registrar):
         assert 'mine' in obj._accessors
 
 
+@pytest.mark.skipif(dask.compatibility.PY2, reason="Unknown")
 def test_accessor_works():
     with ensure_removed(dd.Series, 'mine'):
         dd.extensions.register_series_accessor('mine')(MyAccessor)

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -2,15 +2,9 @@ import contextlib
 
 import pytest
 
-import dask.compatibility
-
 
 pd = pytest.importorskip('pandas')
 import dask.dataframe as dd
-
-
-def test_register_series_accessor():
-    pass
 
 
 @contextlib.contextmanager
@@ -46,7 +40,6 @@ class MyAccessor:
     (dd.DataFrame, dd.extensions.register_dataframe_accessor),
     (dd.Index, dd.extensions.register_index_accessor)
 ])
-@pytest.mark.skipif(dask.compatibility.PY2, reason="Unknown")
 def test_register(obj, registrar):
     with ensure_removed(obj, 'mine'):
         before = set(dir(obj))
@@ -58,7 +51,6 @@ def test_register(obj, registrar):
         assert 'mine' in obj._accessors
 
 
-@pytest.mark.skipif(dask.compatibility.PY2, reason="Unknown")
 def test_accessor_works():
     with ensure_removed(dd.Series, 'mine'):
         dd.extensions.register_series_accessor('mine')(MyAccessor)

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -1,0 +1,68 @@
+import contextlib
+
+import pytest
+
+
+pd = pytest.importorskip('pandas')
+import dask.dataframe as dd
+
+
+def test_register_series_accessor():
+    pass
+
+
+@contextlib.contextmanager
+def ensure_removed(obj, attr):
+    """Ensure that an attribute added to 'obj' during the test is
+    removed when we're done"""
+    try:
+        yield
+    finally:
+        try:
+            delattr(obj, attr)
+        except AttributeError:
+            pass
+        obj._accessors.discard(attr)
+
+
+class MyAccessor:
+
+    def __init__(self, obj):
+        self.obj = obj
+        self.item = 'item'
+
+    @property
+    def prop(self):
+        return self.item
+
+    def method(self):
+        return self.item
+
+
+@pytest.mark.parametrize('obj, registrar', [
+    (dd.Series, dd.extensions.register_series_accessor),
+    (dd.DataFrame, dd.extensions.register_dataframe_accessor),
+    (dd.Index, dd.extensions.register_index_accessor)
+])
+def test_register(obj, registrar):
+    with ensure_removed(obj, 'mine'):
+        before = set(dir(obj))
+        registrar('mine')(MyAccessor)
+        instance = dd.from_pandas(obj._partition_type([]), 2)
+        assert instance.mine.prop == 'item'
+        after = set(dir(obj))
+        assert (before ^ after) == {'mine'}
+        assert 'mine' in obj._accessors
+
+
+def test_accessor_works():
+    with ensure_removed(dd.Series, 'mine'):
+        dd.extensions.register_series_accessor('mine')(MyAccessor)
+
+        a = pd.Series([1, 2])
+        b = dd.from_pandas(a, 2)
+        assert b.mine.obj is b
+
+        assert b.mine.prop == 'item'
+        assert b.mine.method() == 'item'
+

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -65,4 +65,3 @@ def test_accessor_works():
 
         assert b.mine.prop == 'item'
         assert b.mine.method() == 'item'
-

--- a/docs/source/dataframe-extend.rst
+++ b/docs/source/dataframe-extend.rst
@@ -194,7 +194,8 @@ Accessors
 
 Many extension arrays expose their functionality on Series or DataFrame objects
 using accessors. Dask provides decorators to register accessors similar to pandas. See
-http://pandas.pydata.org/pandas-docs/stable/development/extending.html#registering-custom-accessors for more.
+`the pandas documentation on accessors <http://pandas.pydata.org/pandas-docs/stable/development/extending.html#registering-custom-accessors>`_
+for more.
 
 .. currentmodule:: dask.dataframe
 

--- a/docs/source/dataframe-extend.rst
+++ b/docs/source/dataframe-extend.rst
@@ -186,3 +186,18 @@ So you (or your users) can now create and store a dask ``DataFrame`` or
    Dask Name: from_pandas, 3 tasks
 
 Notice the ``decimal`` dtype.
+
+.. _dataframe.accessors:
+
+Accessors
+---------
+
+Many extension arrays expose their functionality on Series or DataFrame objects
+using accessors. Dask provides decorators to register accessors similar to pandas. See
+http://pandas.pydata.org/pandas-docs/stable/development/extending.html#registering-custom-accessors for more.
+
+.. currentmodule:: dask.dataframe
+
+.. autofunction:: dask.dataframe.extensions.register_dataframe_accessor
+.. autofunction:: dask.dataframe.extensions.register_series_accessor
+.. autofunction:: dask.dataframe.extensions.register_index_accessor


### PR DESCRIPTION
This adds accessors for dask.dataframe objects. They mirror the pandas ones.

testing this out in https://github.com/ContinuumIO/cyberpandas/pull/39

Closes #4801