### PR TITLE
Catch distributed SyntaxError in tests

### DIFF
--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -16,7 +16,7 @@ try:
     import distributed
     from distributed import Client
     from distributed.utils_test import cluster, loop  # noqa: F401
-except ImportError:
+except (ImportError, SyntaxError):
     distributed = None
 
 try:


### PR DESCRIPTION
Currently our Python 2 build on Travis is failing (e.g. https://travis-ci.org/dask/dask/jobs/536088021#L1794-L1811) due to a `SyntaxError` being raised from recent Python 3-only additions to `distributed` (https://github.com/dask/distributed/pull/2675). This PR catches the corresponding `SyntaxError` to skip tests on Python 2 instead of failing. Alternative solutions from others are also welcome. 

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
