### PR TITLE
Drop outdated `numpy_compat` functions

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -67,8 +67,6 @@ all = np.all
 nansum = np.nansum
 nanprod = np.nanprod
 
-from numpy import nancumprod, nancumsum
-
 nanmin = np.nanmin
 nanmax = np.nanmax
 mean = np.mean

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -67,11 +67,7 @@ all = np.all
 nansum = np.nansum
 nanprod = np.nanprod
 
-try:
-    from numpy import nancumprod, nancumsum
-except ImportError:  # pragma: no cover
-    nancumprod = npcompat.nancumprod
-    nancumsum = npcompat.nancumsum
+from numpy import nancumprod, nancumsum
 
 nanmin = np.nanmin
 nanmax = np.nanmax

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -67,6 +67,9 @@ all = np.all
 nansum = np.nansum
 nanprod = np.nanprod
 
+nancumprod = np.nancumprod
+nancumsum = np.nancumsum
+
 nanmin = np.nanmin
 nanmax = np.nanmax
 mean = np.mean

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -34,7 +34,6 @@ from dask.array.core import (getem, getter, dotmany, concatenate3,
 from dask.blockwise import (make_blockwise_graph as top, broadcast_dimensions)
 from dask.array.utils import assert_eq, same_keys
 
-# temporary until numpy functions migrated
 from numpy import nancumsum, nancumprod
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -35,12 +35,7 @@ from dask.blockwise import (make_blockwise_graph as top, broadcast_dimensions)
 from dask.array.utils import assert_eq, same_keys
 
 # temporary until numpy functions migrated
-try:
-    from numpy import nancumsum, nancumprod
-except ImportError:  # pragma: no cover
-    import dask.array.numpy_compat as npcompat
-    nancumsum = npcompat.nancumsum
-    nancumprod = npcompat.nancumprod
+from numpy import nancumsum, nancumprod
 
 
 def test_getem():


### PR DESCRIPTION
These functions (`nancumsum` and `nancumprod`) have been removed as part of bumping the NumPy requirement to 1.13.0. So drop these fallback imports as these functions don't exist any more.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
