### PR TITLE
Parallel variance computation for dataframes

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -6,7 +6,7 @@ from itertools import product, repeat
 from math import factorial, log, ceil
 
 import numpy as np
-from numbers import Integral
+from numbers import Integral, Number
 
 from toolz import compose, partition_all, get, accumulate, pluck
 
@@ -461,10 +461,11 @@ def moment_agg(pairs, order=2, ddof=0, dtype='f8', sum=np.sum, axis=None, **kwar
     denominator = n.sum(axis=axis, **kwargs) - ddof
 
     # taking care of the edge case with empty or all-nans array with ddof > 0
-    if isinstance(denominator, np.ndarray):
+    if isinstance(denominator, Number):
+        if denominator < 0:
+            denominator = np.nan
+    else:
         denominator[denominator < 0] = np.nan
-    elif denominator < 0:
-        denominator = np.nan
 
     return divide(M, denominator, dtype=dtype)
 

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -457,7 +457,16 @@ def moment_agg(pairs, order=2, ddof=0, dtype='f8', sum=np.sum, axis=None, **kwar
     inner_term = divide(totals, ns, dtype=dtype) - mu
 
     M = _moment_helper(Ms, ns, inner_term, order, sum, axis, kwargs)
-    return divide(M, n.sum(axis=axis, **kwargs) - ddof, dtype=dtype)
+
+    denominator = n.sum(axis=axis, **kwargs) - ddof
+
+    # taking care of the edge case with empty or all-nans array with ddof > 0
+    if isinstance(denominator, np.ndarray):
+        denominator[denominator < 0] = np.nan
+    elif denominator < 0:
+        denominator = np.nan
+
+    return divide(M, denominator, dtype=dtype)
 
 
 def moment(a, order, axis=None, dtype=None, keepdims=False, ddof=0,

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1463,18 +1463,19 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
         else:
             num = self._get_numeric_data()
             values_dtype = num.values.dtype
+            array_values = num.values
 
             if not np.issubdtype(values_dtype, np.number):
-                num.values.dtype = 'f8'
+                array_values = num.values.astype('f8')
 
             if skipna or skipna is None:
-                array_var = da.nanvar(num.values, axis=0, ddof=ddof, split_every=split_every)
+                array_var = da.nanvar(array_values, axis=0, ddof=ddof, split_every=split_every)
             else:
-                array_var = da.var(num.values, axis=0, ddof=ddof, split_every=split_every)
+                array_var = da.var(array_values, axis=0, ddof=ddof, split_every=split_every)
 
-            name = self._token_prefix + 'var--' + tokenize(num, split_every)
+            name = self._token_prefix + 'var-' + tokenize(num, split_every)
 
-            cols = num._meta.columns if isinstance(num._meta, pd.DataFrame) else None
+            cols = num._meta.columns if is_dataframe_like(num) else None
             array_var_name = (array_var._name,) + (0,) * len(num._meta_nonempty.values.var(axis=0).shape)
 
             layer = {(name, 0): (methods.wrap_var_reduction, array_var_name, cols)}

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1475,7 +1475,7 @@ Dask Name: {name}, {task} tasks""".format(klass=self.__class__.__name__,
             name = self._token_prefix + 'var--' + tokenize(num, split_every)
 
             cols = num._meta.columns if isinstance(num._meta, pd.DataFrame) else None
-            array_var_name = (array_var._name,) + (0,) * len(num._meta.values.var(axis=0).shape)
+            array_var_name = (array_var._name,) + (0,) * len(num._meta_nonempty.values.var(axis=0).shape)
 
             layer = {(name, 0): (methods.wrap_var_reduction, array_var_name, cols)}
             graph = HighLevelGraph.from_collections(name, layer, dependencies=[array_var])

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -122,7 +122,7 @@ def mean_aggregate(s, n):
 
 
 def wrap_var_reduction(array_var, index):
-    if isinstance(array_var, np.ndarray):
+    if isinstance(array_var, np.ndarray) or isinstance(array_var, list):
         return pd.Series(array_var, index=index)
 
     return array_var

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -128,6 +128,12 @@ def wrap_var_reduction(array_var, index):
     return array_var
 
 
+def var_mixed_concat(numeric_var, timedelta_var, columns):
+    vars = pd.concat([numeric_var, timedelta_var])
+
+    return vars.reindex(index=columns)
+
+
 def describe_aggregate(values):
     assert len(values) > 0
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -121,16 +121,11 @@ def mean_aggregate(s, n):
         return np.float64(np.nan)
 
 
-def var_aggregate(x2, x, n, ddof):
-    try:
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter('always')
-            result = (x2 / n) - (x / n)**2
-        if ddof != 0:
-            result = result * n / (n - ddof)
-        return result
-    except ZeroDivisionError:
-        return np.float64(np.nan)
+def wrap_var_reduction(array_var, index):
+    if isinstance(array_var, np.ndarray):
+        return pd.Series(array_var, index=index)
+
+    return array_var
 
 
 def describe_aggregate(values):

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -609,21 +609,17 @@ def test_frame_series_arithmetic_methods():
 def test_reductions(split_every):
     dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3],
                                    'b': [4, 5, 6],
-                                   'c': [True, True, False],
-                                   'd': [np.timedelta64(3, 'D'), np.timedelta64(1, 'D'), np.timedelta64(5, 'D')]
-                                   },
+                                   'c': [True, True, False]},
                                   index=[0, 1, 3]),
            ('x', 1): pd.DataFrame({'a': [4, 5, 6],
                                    'b': [3, 2, 1],
-                                   'c': [False, False, False],
-                                   'd': [np.timedelta64(3, 'D'), np.timedelta64(1, 'D'), np.timedelta64(5, 'D')]},
+                                   'c': [False, False, False]},
                                   index=[5, 6, 8]),
            ('x', 2): pd.DataFrame({'a': [13094304034, 3489385935, 100006774],
                                    'b': [0, 0, 0],
-                                   'c': [True, True, True],
-                                   'd': [np.timedelta64(3, 'D'), np.timedelta64(1, 'D'), np.timedelta64(5, 'D')]},
+                                   'c': [True, True, True]},
                                   index=[9, 9, 9])}
-    meta = make_meta({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
+    meta = make_meta({'a': 'i8', 'b': 'i8', 'c': 'bool'}, index=pd.Index([], 'i8'))
     ddf1 = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
@@ -637,8 +633,9 @@ def test_reductions(split_every):
     bools = pd.Series([True, False, True, False, True], dtype=bool)
     boolds = dd.from_pandas(bools, 2)
 
-    for dds, pds in [(ddf1.b, pdf1.b),
-                     (ddf1.a, pdf1.a),
+    for dds, pds in [(ddf1.a, pdf1.a),
+                     (ddf1.b, pdf1.b),
+                     (ddf1.c, pdf1.c),
                      (ddf1['a'], pdf1['a']),
                      (ddf1['b'], pdf1['b']),
                      (nands1, nans1),
@@ -712,6 +709,23 @@ def test_reductions(split_every):
     assert_eq(ddf1.index.min(split_every=split_every), pdf1.index.min())
     assert_eq(ddf1.index.max(split_every=split_every), pdf1.index.max())
     assert_eq(ddf1.index.count(split_every=split_every), pd.notnull(pdf1.index).sum())
+
+
+@pytest.mark.parametrize('split_every', [False, 2])
+def test_reductions_timedelta(split_every):
+    ds = pd.Series(pd.to_timedelta([2, 3, 4, np.nan, 5]))
+    dds = dd.from_pandas(ds, 2)
+
+    with pytest.warns(None):
+        # runtime warnings; https://github.com/dask/dask/issues/2381
+        assert_eq(dds.var(split_every=split_every), ds.var())
+
+    assert_eq(dds.var(ddof=0, split_every=split_every), ds.var(ddof=0))
+
+    assert_eq(dds.sum(split_every=split_every), ds.sum())
+    assert_eq(dds.min(split_every=split_every), ds.min())
+    assert_eq(dds.max(split_every=split_every), ds.max())
+    assert_eq(dds.count(split_every=split_every), ds.count())
 
 
 @pytest.mark.parametrize('frame,axis,out',
@@ -896,10 +910,9 @@ def test_reductions_non_numeric_dtypes():
     assert_eq(dds.max(), pds.max())
     assert_eq(dds.count(), pds.count())
 
-    # ToDo: pandas supports timedelta std, otherwise dask raises:
-    # incompatible type for a datetime/timedelta operation [__pow__]
+    # ToDo: pandas supports timedelta std, dask returns float64
     # assert_eq(dds.std(), pds.std())
-    # assert_eq(dds.var(), pds.var())
+    assert_eq(dds.var(), pds.var())
 
     # ToDo: pandas supports timedelta std, otherwise dask raises:
     # TypeError: unsupported operand type(s) for *: 'float' and 'Timedelta'
@@ -1011,27 +1024,33 @@ def test_reductions_frame_dtypes():
     df = pd.DataFrame({'int': [1, 2, 3, 4, 5, 6, 7, 8],
                        'float': [1., 2., 3., 4., np.nan, 6., 7., 8.],
                        'dt': [pd.NaT] + [datetime(2011, i, 1) for i in range(1, 8)],
-                       'str': list('abcdefgh')})
+                       'str': list('abcdefgh'),
+                       'timedelta': pd.to_timedelta([1, 2, 3, 4, 5, 6, 7, 8]),
+                       'bool': [True, False] * 4
+                       })
 
     if HAS_INT_NA:
         df['intna'] = pd.array([1, 2, 3, 4, None, 6, 7, 8], dtype=pd.Int64Dtype())
 
     ddf = dd.from_pandas(df, 3)
+
+    # TODO: std and mean do not support timedelta dtype
+    df_no_timedelta = df.drop('timedelta', axis=1, inplace=False)
+    ddf_no_timedelta = dd.from_pandas(df_no_timedelta, 3)
+
     assert_eq(df.sum(), ddf.sum())
     assert_eq(df.prod(), ddf.prod())
     assert_eq(df.min(), ddf.min())
     assert_eq(df.max(), ddf.max())
     assert_eq(df.count(), ddf.count())
-    assert_eq(df.std(), ddf.std())
+    assert_eq(df_no_timedelta.std(), ddf_no_timedelta.std())
     assert_eq(df.var(), ddf.var())
     assert_eq(df.sem(), ddf.sem())
-    assert_eq(df.std(ddof=0), ddf.std(ddof=0))
+    assert_eq(df_no_timedelta.std(ddof=0), ddf_no_timedelta.std(ddof=0))
     assert_eq(df.var(ddof=0), ddf.var(ddof=0))
     assert_eq(df.sem(ddof=0), ddf.sem(ddof=0))
 
-    result = ddf.mean()
-    expected = df.mean()
-    assert_eq(expected, result)
+    assert_eq(df_no_timedelta.mean(), ddf_no_timedelta.mean())
 
     assert_eq(df._get_numeric_data(), ddf._get_numeric_data())
 

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -607,11 +607,21 @@ def test_frame_series_arithmetic_methods():
 
 @pytest.mark.parametrize('split_every', [False, 2])
 def test_reductions(split_every):
-    dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]},
+    dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3],
+                                   'b': [4, 5, 6],
+                                   'c': [True, True, False],
+                                   'd': [np.timedelta64(3, 'D'), np.timedelta64(1, 'D'), np.timedelta64(5, 'D')]
+                                   },
                                   index=[0, 1, 3]),
-           ('x', 1): pd.DataFrame({'a': [4, 5, 6], 'b': [3, 2, 1]},
+           ('x', 1): pd.DataFrame({'a': [4, 5, 6],
+                                   'b': [3, 2, 1],
+                                   'c': [False, False, False],
+                                   'd': [np.timedelta64(3, 'D'), np.timedelta64(1, 'D'), np.timedelta64(5, 'D')]},
                                   index=[5, 6, 8]),
-           ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]},
+           ('x', 2): pd.DataFrame({'a': [13094304034, 3489385935, 100006774],
+                                   'b': [0, 0, 0],
+                                   'c': [True, True, True],
+                                   'd': [np.timedelta64(3, 'D'), np.timedelta64(1, 'D'), np.timedelta64(5, 'D')]},
                                   index=[9, 9, 9])}
     meta = make_meta({'a': 'i8', 'b': 'i8'}, index=pd.Index([], 'i8'))
     ddf1 = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
@@ -627,9 +637,13 @@ def test_reductions(split_every):
     bools = pd.Series([True, False, True, False, True], dtype=bool)
     boolds = dd.from_pandas(bools, 2)
 
-    for dds, pds in [(ddf1.b, pdf1.b), (ddf1.a, pdf1.a),
-                     (ddf1['a'], pdf1['a']), (ddf1['b'], pdf1['b']),
-                     (nands1, nans1), (nands2, nans2), (nands3, nans3),
+    for dds, pds in [(ddf1.b, pdf1.b),
+                     (ddf1.a, pdf1.a),
+                     (ddf1['a'], pdf1['a']),
+                     (ddf1['b'], pdf1['b']),
+                     (nands1, nans1),
+                     (nands2, nans2),
+                     (nands3, nans3),
                      (boolds, bools)]:
         assert isinstance(dds, dd.Series)
         assert isinstance(pds, pd.Series)
@@ -639,6 +653,7 @@ def test_reductions(split_every):
         assert_eq(dds.min(split_every=split_every), pds.min())
         assert_eq(dds.max(split_every=split_every), pds.max())
         assert_eq(dds.count(split_every=split_every), pds.count())
+
         with pytest.warns(None):
             # runtime warnings; https://github.com/dask/dask/issues/2381
             assert_eq(dds.std(split_every=split_every), pds.std())
@@ -648,6 +663,7 @@ def test_reductions(split_every):
         with pytest.warns(None):
             # runtime warnings; https://github.com/dask/dask/issues/2381
             assert_eq(dds.sem(split_every=split_every), pds.sem())
+
         assert_eq(dds.std(ddof=0, split_every=split_every), pds.std(ddof=0))
         assert_eq(dds.var(ddof=0, split_every=split_every), pds.var(ddof=0))
         assert_eq(dds.sem(ddof=0, split_every=split_every), pds.sem(ddof=0))
@@ -951,13 +967,22 @@ def test_reductions_frame(split_every):
     assert_dask_graph(ddf1.min(split_every=split_every), 'dataframe-min')
     assert_dask_graph(ddf1.max(split_every=split_every), 'dataframe-max')
     assert_dask_graph(ddf1.count(split_every=split_every), 'dataframe-count')
-    # std, var, sem, and mean consist of sum and count operations
-    assert_dask_graph(ddf1.std(split_every=split_every), 'dataframe-sum')
-    assert_dask_graph(ddf1.std(split_every=split_every), 'dataframe-count')
-    assert_dask_graph(ddf1.var(split_every=split_every), 'dataframe-sum')
-    assert_dask_graph(ddf1.var(split_every=split_every), 'dataframe-count')
-    assert_dask_graph(ddf1.sem(split_every=split_every), 'dataframe-sum')
-    assert_dask_graph(ddf1.sem(split_every=split_every), 'dataframe-count')
+
+    # std, var, sem, and mean consist of moment_* operations
+    assert_dask_graph(ddf1.std(split_every=split_every), 'dataframe-var')
+    assert_dask_graph(ddf1.std(split_every=split_every), 'moment_chunk')
+    assert_dask_graph(ddf1.std(split_every=split_every), 'moment_agg')
+    assert_dask_graph(ddf1.std(split_every=split_every), 'values')
+
+    assert_dask_graph(ddf1.var(split_every=split_every), 'moment_chunk')
+    assert_dask_graph(ddf1.var(split_every=split_every), 'moment_agg')
+    assert_dask_graph(ddf1.var(split_every=split_every), 'values')
+
+    assert_dask_graph(ddf1.sem(split_every=split_every), 'dataframe-var')
+    assert_dask_graph(ddf1.sem(split_every=split_every), 'moment_chunk')
+    assert_dask_graph(ddf1.sem(split_every=split_every), 'moment_agg')
+    assert_dask_graph(ddf1.sem(split_every=split_every), 'values')
+
     assert_dask_graph(ddf1.mean(split_every=split_every), 'dataframe-sum')
     assert_dask_graph(ddf1.mean(split_every=split_every), 'dataframe-count')
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -351,12 +351,6 @@ def test_describe(include, exclude, percentiles, subset):
     desc_ddf = ddf.describe(include=include, exclude=exclude, percentiles=percentiles)
     desc_df = df.describe(include=include, exclude=exclude, percentiles=percentiles)
 
-    # TODO: for timedelta columns there's overflow in var function, see #4233
-    # causing std to be nan, workaround this by dropping timedelta column before assertion
-    if 'f' in desc_ddf._meta:
-        desc_df = desc_df.drop('f', axis=1)
-        desc_ddf = desc_ddf.drop('f', axis=1)
-
     # Assert
     assert_eq(desc_ddf, desc_df)
 


### PR DESCRIPTION
Fixes #4233

- [x] Tests added / passed
- [x] Passes `flake8 dask`

Re-using array variance computation logic in dataframe.