### PR TITLE
Groupby Covariance/Correlation

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -411,7 +411,8 @@ def _cov_agg(_t, levels, ddof):
                 pass
 
     for level in range(len(result.columns.levels)):
-        result.columns.set_levels(col_mapping.keys(), level=level, inplace=True)
+        keys = list(col_mapping.keys())
+        result.columns.set_levels(keys, level=level, inplace=True)
 
     result.index.set_names(idx_mapping, inplace=True)
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1144,11 +1144,11 @@ class _GroupBy(object):
     def cov(self, ddof=1, split_every=None, split_out=1):
         """Groupby covariance is accomplished by
 
-        1. computing intermediate values for sum, count, and the product of
-        all columns: a b c -> a*a, a*b, b*b, b*c, c*c.
+        1. Computing intermediate values for sum, count, and the product of
+           all columns: a b c -> a*a, a*b, b*b, b*c, c*c.
 
         2. The values are then aggregated and the final covariance value is calculated:
-        cov(X,Y) = X*Y - Xbar * Ybar
+           cov(X,Y) = X*Y - Xbar * Ybar
         """
 
         levels = _determine_levels(self.index)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -360,10 +360,9 @@ def _cov_agg(_t, levels, ddof):
     muls = []
     ns = []
 
-    if is_series_like(_t):
-        t = _t.to_list() # concat from combiner
-    else:
-        t = _t
+    # sometime we get a series back from concat combiner
+    t = list(_t)
+
     cols = t[0][0].columns
     for x, mul, n in t:
         xs.append(x)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -346,7 +346,9 @@ def _cov_chunk(df, *index):
 
     # mapping columns to str(numerical) values allows us to easily handle
     # arbitrary column names (numbers, string, empty strings)
-    col_mapping = dict(zip(list(df.columns.values), map(str, range(len(df.columns)))))
+    col_mapping = collections.OrderedDict()
+    for i, c in enumerate(df.columns):
+        col_mapping[c] = str(i)
     df = df.rename(columns=col_mapping)
     cols = df._get_numeric_data().columns
 
@@ -410,13 +412,13 @@ def _cov_agg(_t, levels, ddof):
                 # when slicing the col_map will not have the index
                 pass
 
+    keys = list(col_mapping.keys())
     for level in range(len(result.columns.levels)):
-        keys = list(col_mapping.keys())
         result.columns.set_levels(keys, level=level, inplace=True)
 
     result.index.set_names(idx_mapping, inplace=True)
 
-    # stacking leads to a sorted index
+    # stacking can lead to a sorted index
     s_result = result.stack(dropna=False)
     assert is_dataframe_like(s_result)
     return s_result

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1098,7 +1098,7 @@ class _GroupBy(object):
         levels = _determine_levels(self.index)
 
         if self._slice:
-            sliced_plus = self._slice + list(self.index)
+            sliced_plus = list(self._slice) + list(self.index)
             self.obj = self.obj[sliced_plus]
 
         result = aca([self.obj, self.index] if not isinstance(self.index, list) else [self.obj] + self.index,

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -359,11 +359,11 @@ def _cov_agg(t, levels, ddof):
         muls.append(mul)
         ns.append(n)
 
-    x_sums = pd.concat(xs).groupby(level=levels, sort=False).sum()
-    x_muls = pd.concat(muls).groupby(level=levels, sort=False).sum()
-    x_ns = pd.concat(ns).groupby(level=levels).sum()
+    total_sums = concat(xs).groupby(level=levels, sort=False).sum()
+    total_muls = concat(muls).groupby(level=levels, sort=False).sum()
+    total_counts = concat(ns).groupby(level=levels).sum()
     result = (
-        pd.concat([x_sums, x_muls, x_ns], axis=1)
+        concat([total_sums, total_muls, total_counts], axis=1)
         .groupby(level=0)
         .apply(_cov_finalizer, cols=cols)
     )

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -8,25 +8,13 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from .core import (
-    DataFrame,
-    Series,
-    aca,
-    map_partitions,
-    new_dd_object,
-    no_default,
-    split_out_on_index,
-    _extract_meta,
-)
+from .core import (DataFrame, Series, aca, map_partitions,
+                   new_dd_object, no_default, split_out_on_index,
+                   _extract_meta)
 from .methods import drop_columns, concat
 from .shuffle import shuffle
-from .utils import (
-    make_meta,
-    insert_meta_param_description,
-    raise_on_meta_error,
-    is_series_like,
-    is_dataframe_like,
-)
+from .utils import (make_meta, insert_meta_param_description,
+                    raise_on_meta_error, is_series_like, is_dataframe_like)
 from ..base import tokenize
 from ..utils import derived_from, M, funcname, itemgetter
 from ..highlevelgraph import HighLevelGraph
@@ -65,7 +53,6 @@ from .. import compatibility
 #
 # #############################################
 
-
 def _determine_levels(index):
     """Determine the correct levels argument to groupby.
     """
@@ -84,18 +71,13 @@ def _normalize_index(df, index):
     elif isinstance(index, list):
         return [_normalize_index(df, col) for col in index]
 
-    elif (
-        is_series_like(index)
-        and index.name in df.columns
-        and index._name == df[index.name]._name
-    ):
+    elif (is_series_like(index) and index.name in df.columns and
+          index._name == df[index.name]._name):
         return index.name
 
-    elif (
-        isinstance(index, DataFrame)
-        and set(index.columns).issubset(df.columns)
-        and index._name == df[index.columns]._name
-    ):
+    elif (isinstance(index, DataFrame) and
+          set(index.columns).issubset(df.columns) and
+          index._name == df[index.columns]._name):
         return list(index.columns)
 
     else:
@@ -107,7 +89,7 @@ def _maybe_slice(grouped, columns):
     Slice columns if grouped is pd.DataFrameGroupBy
     """
     # FIXME: update with better groupby object detection (i.e.: ngroups, get_group)
-    if "groupby" in type(grouped).__name__.lower():
+    if 'groupby' in type(grouped).__name__.lower():
         if columns is not None:
             if isinstance(columns, (tuple, list, set, pd.Index)):
                 columns = list(columns)
@@ -134,26 +116,24 @@ def _groupby_raise_unaligned(df, **kwargs):
     unaligned key is generally a bad idea, we just error loudly in dask.
 
     For more information see pandas GH issue #15244 and Dask GH issue #1876."""
-    by = kwargs.get("by", None)
+    by = kwargs.get('by', None)
     if by is not None and not _is_aligned(df, by):
-        msg = (
-            "Grouping by an unaligned index is unsafe and unsupported.\n"
-            "This can be caused by filtering only one of the object or\n"
-            "grouping key. For example, the following works in pandas,\n"
-            "but not in dask:\n"
-            "\n"
-            "df[df.foo < 0].groupby(df.bar)\n"
-            "\n"
-            "This can be avoided by either filtering beforehand, or\n"
-            "passing in the name of the column instead:\n"
-            "\n"
-            "df2 = df[df.foo < 0]\n"
-            "df2.groupby(df2.bar)\n"
-            "# or\n"
-            "df[df.foo < 0].groupby('bar')\n"
-            "\n"
-            "For more information see dask GH issue #1876."
-        )
+        msg = ("Grouping by an unaligned index is unsafe and unsupported.\n"
+               "This can be caused by filtering only one of the object or\n"
+               "grouping key. For example, the following works in pandas,\n"
+               "but not in dask:\n"
+               "\n"
+               "df[df.foo < 0].groupby(df.bar)\n"
+               "\n"
+               "This can be avoided by either filtering beforehand, or\n"
+               "passing in the name of the column instead:\n"
+               "\n"
+               "df2 = df[df.foo < 0]\n"
+               "df2.groupby(df2.bar)\n"
+               "# or\n"
+               "df[df.foo < 0].groupby('bar')\n"
+               "\n"
+               "For more information see dask GH issue #1876.")
         raise ValueError(msg)
     elif by is not None and len(by):
         # since we're coming through apply, `by` will be a tuple.
@@ -166,7 +146,7 @@ def _groupby_raise_unaligned(df, **kwargs):
 def _groupby_slice_apply(df, grouper, key, func, *args, **kwargs):
     # No need to use raise if unaligned here - this is only called after
     # shuffling, which makes everything aligned already
-    group_keys = kwargs.pop("group_keys", True)
+    group_keys = kwargs.pop('group_keys', True)
     g = df.groupby(grouper, group_keys=group_keys)
     if key:
         g = g[key]
@@ -194,7 +174,6 @@ def _groupby_get_group(df, by_key, get_key, columns):
 ###############################################################
 # Aggregation
 ###############################################################
-
 
 class Aggregation(object):
     """User defined groupby-aggregation.
@@ -248,7 +227,6 @@ class Aggregation(object):
     Though of course, both of these are built-in and so you don't need to
     implement them yourself.
     """
-
     def __init__(self, name, chunk, agg, finalize=None):
         self.chunk = chunk
         self.agg = agg
@@ -261,8 +239,8 @@ def _groupby_aggregate(df, aggfunc=None, levels=None):
 
 
 def _apply_chunk(df, *index, **kwargs):
-    func = kwargs.pop("chunk")
-    columns = kwargs.pop("columns")
+    func = kwargs.pop('chunk')
+    columns = kwargs.pop('columns')
 
     g = _groupby_raise_unaligned(df, by=index)
 
@@ -284,11 +262,11 @@ def _var_chunk(df, *index):
     g = _groupby_raise_unaligned(df, by=index)
     x = g.sum()
 
-    n = g[x.columns].count().rename(columns=lambda c: c + "-count")
+    n = g[x.columns].count().rename(columns=lambda c: c + '-count')
 
     df[cols] = df[cols] ** 2
     g2 = _groupby_raise_unaligned(df, by=index)
-    x2 = g2.sum().rename(columns=lambda c: c + "-x2")
+    x2 = g2.sum().rename(columns=lambda c: c + '-x2')
 
     x2.index = x.index
     return concat([x, x2, n], axis=1)
@@ -301,13 +279,13 @@ def _var_combine(g, levels):
 def _var_agg(g, levels, ddof):
     g = g.groupby(level=levels, sort=False).sum()
     nc = len(g.columns)
-    x = g[g.columns[: nc // 3]]
-    x2 = g[g.columns[nc // 3 : 2 * nc // 3]].rename(columns=lambda c: c[:-3])
-    n = g[g.columns[-nc // 3 :]].rename(columns=lambda c: c[:-6])
+    x = g[g.columns[:nc // 3]]
+    x2 = g[g.columns[nc // 3:2 * nc // 3]].rename(columns=lambda c: c[:-3])
+    n = g[g.columns[-nc // 3:]].rename(columns=lambda c: c[:-6])
 
     # TODO: replace with _finalize_var?
     result = x2 - x ** 2 / n
-    div = n - ddof
+    div = (n - ddof)
     div[div < 0] = 0
     result /= div
     result[(n - ddof) == 0] = np.nan
@@ -398,10 +376,9 @@ def _cov_agg(t, levels, ddof):
 # nunique
 ###############################################################
 
-
 def _nunique_df_chunk(df, *index, **kwargs):
-    levels = kwargs.pop("levels")
-    name = kwargs.pop("name")
+    levels = kwargs.pop('levels')
+    name = kwargs.pop('name')
 
     g = _groupby_raise_unaligned(df, by=index)
     if len(df) > 0:
@@ -409,9 +386,9 @@ def _nunique_df_chunk(df, *index, **kwargs):
         # we set the index here to force a possibly duplicate index
         # for our reduce step
         if isinstance(levels, list):
-            grouped.index = pd.MultiIndex.from_arrays(
-                [grouped.index.get_level_values(level=level) for level in levels]
-            )
+            grouped.index = pd.MultiIndex.from_arrays([
+                grouped.index.get_level_values(level=level) for level in levels
+            ])
         else:
             grouped.index = grouped.index.get_level_values(level=levels)
     else:
@@ -432,12 +409,13 @@ def _drop_duplicates_rename(df):
 
 
 def _nunique_df_combine(df, levels):
-    result = df.groupby(level=levels, sort=False).apply(_drop_duplicates_rename)
+    result = df.groupby(level=levels,
+                        sort=False).apply(_drop_duplicates_rename)
 
     if isinstance(levels, list):
-        result.index = pd.MultiIndex.from_arrays(
-            [result.index.get_level_values(level=level) for level in levels]
-        )
+        result.index = pd.MultiIndex.from_arrays([
+            result.index.get_level_values(level=level) for level in levels
+        ])
     else:
         result.index = result.index.get_level_values(level=levels)
 
@@ -471,7 +449,7 @@ def _nunique_series_chunk(df, *index, **_ignored_):
 #
 ###############################################################
 def _make_agg_id(func, column):
-    return "{!s}-{!s}-{}".format(func, column, tokenize(func, column))
+    return '{!s}-{!s}-{}'.format(func, column, tokenize(func, column))
 
 
 def _normalize_spec(spec, non_group_columns):
@@ -532,27 +510,22 @@ def _normalize_spec(spec, non_group_columns):
     if isinstance(spec, dict):
         for input_column, subspec in spec.items():
             if isinstance(subspec, dict):
-                res.extend(
-                    ((input_column, result_column), func, input_column)
-                    for result_column, func in subspec.items()
-                )
+                res.extend(((input_column, result_column), func, input_column)
+                           for result_column, func in subspec.items())
 
             else:
                 if not isinstance(subspec, list):
                     subspec = [subspec]
 
-                res.extend(
-                    ((input_column, funcname(func)), func, input_column)
-                    for func in subspec
-                )
+                res.extend(((input_column, funcname(func)), func, input_column)
+                           for func in subspec)
 
     else:
         raise ValueError("unsupported agg spec of type {}".format(type(spec)))
 
     compounds = (list, tuple, dict)
-    use_flat_columns = not any(
-        isinstance(subspec, compounds) for subspec in spec.values()
-    )
+    use_flat_columns = not any(isinstance(subspec, compounds)
+                               for subspec in spec.values())
 
     if use_flat_columns:
         res = [(input_col, func, input_col) for (_, func, input_col) in res]
@@ -583,7 +556,7 @@ def _build_agg_args(spec):
         applied after the ``agg_funcs``. They are used to create final results
         from intermediate representations.
     """
-    known_np_funcs = {np.min: "min", np.max: "max"}
+    known_np_funcs = {np.min: 'min', np.max: 'max'}
 
     # check that there are no name conflicts for a single input column
     by_name = {}
@@ -593,7 +566,7 @@ def _build_agg_args(spec):
 
     for funcs in by_name.values():
         if len(funcs) != 1:
-            raise ValueError("conflicting aggregation functions: {}".format(funcs))
+            raise ValueError('conflicting aggregation functions: {}'.format(funcs))
 
     chunks = {}
     aggs = {}
@@ -606,10 +579,10 @@ def _build_agg_args(spec):
         impls = _build_agg_args_single(result_column, func, input_column)
 
         # overwrite existing result-columns, generate intermediates only once
-        chunks.update((spec[0], spec) for spec in impls["chunk_funcs"])
-        aggs.update((spec[0], spec) for spec in impls["aggregate_funcs"])
+        chunks.update((spec[0], spec) for spec in impls['chunk_funcs'])
+        aggs.update((spec[0], spec) for spec in impls['aggregate_funcs'])
 
-        finalizers.append(impls["finalizer"])
+        finalizers.append(impls['finalizer'])
 
     chunks = sorted(chunks.values())
     aggs = sorted(aggs.values())
@@ -619,28 +592,27 @@ def _build_agg_args(spec):
 
 def _build_agg_args_single(result_column, func, input_column):
     simple_impl = {
-        "sum": (M.sum, M.sum),
-        "min": (M.min, M.min),
-        "max": (M.max, M.max),
-        "count": (M.count, M.sum),
-        "size": (M.size, M.sum),
-        "first": (M.first, M.first),
-        "last": (M.last, M.last),
-        "prod": (M.prod, M.prod),
+        'sum': (M.sum, M.sum),
+        'min': (M.min, M.min),
+        'max': (M.max, M.max),
+        'count': (M.count, M.sum),
+        'size': (M.size, M.sum),
+        'first': (M.first, M.first),
+        'last': (M.last, M.last),
+        'prod': (M.prod, M.prod)
     }
 
     if func in simple_impl.keys():
-        return _build_agg_args_simple(
-            result_column, func, input_column, simple_impl[func]
-        )
+        return _build_agg_args_simple(result_column, func, input_column,
+                                      simple_impl[func])
 
-    elif func == "var":
+    elif func == 'var':
         return _build_agg_args_var(result_column, func, input_column)
 
-    elif func == "std":
+    elif func == 'std':
         return _build_agg_args_std(result_column, func, input_column)
 
-    elif func == "mean":
+    elif func == 'mean':
         return _build_agg_args_mean(result_column, func, input_column)
 
     elif isinstance(func, Aggregation):
@@ -655,74 +627,64 @@ def _build_agg_args_simple(result_column, func, input_column, impl_pair):
     chunk_impl, agg_impl = impl_pair
 
     return dict(
-        chunk_funcs=[
-            (
-                intermediate,
-                _apply_func_to_column,
-                dict(column=input_column, func=chunk_impl),
-            )
-        ],
-        aggregate_funcs=[
-            (
-                intermediate,
-                _apply_func_to_column,
-                dict(column=intermediate, func=agg_impl),
-            )
-        ],
+        chunk_funcs=[(intermediate, _apply_func_to_column,
+                     dict(column=input_column, func=chunk_impl))],
+        aggregate_funcs=[(intermediate, _apply_func_to_column,
+                         dict(column=intermediate, func=agg_impl))],
         finalizer=(result_column, itemgetter(intermediate), dict()),
     )
 
 
 def _build_agg_args_var(result_column, func, input_column):
-    int_sum = _make_agg_id("sum", input_column)
-    int_sum2 = _make_agg_id("sum2", input_column)
-    int_count = _make_agg_id("count", input_column)
+    int_sum = _make_agg_id('sum', input_column)
+    int_sum2 = _make_agg_id('sum2', input_column)
+    int_count = _make_agg_id('count', input_column)
 
     return dict(
         chunk_funcs=[
-            (int_sum, _apply_func_to_column, dict(column=input_column, func=M.sum)),
-            (int_count, _apply_func_to_column, dict(column=input_column, func=M.count)),
-            (int_sum2, _compute_sum_of_squares, dict(column=input_column)),
+            (int_sum, _apply_func_to_column,
+             dict(column=input_column, func=M.sum)),
+            (int_count, _apply_func_to_column,
+             dict(column=input_column, func=M.count)),
+            (int_sum2, _compute_sum_of_squares,
+             dict(column=input_column)),
         ],
         aggregate_funcs=[
             (col, _apply_func_to_column, dict(column=col, func=M.sum))
             for col in (int_sum, int_count, int_sum2)
         ],
-        finalizer=(
-            result_column,
-            _finalize_var,
-            dict(sum_column=int_sum, count_column=int_count, sum2_column=int_sum2),
-        ),
+        finalizer=(result_column, _finalize_var,
+                   dict(sum_column=int_sum, count_column=int_count,
+                        sum2_column=int_sum2)),
     )
 
 
 def _build_agg_args_std(result_column, func, input_column):
     impls = _build_agg_args_var(result_column, func, input_column)
 
-    result_column, _, kwargs = impls["finalizer"]
-    impls["finalizer"] = (result_column, _finalize_std, kwargs)
+    result_column, _, kwargs = impls['finalizer']
+    impls['finalizer'] = (result_column, _finalize_std, kwargs)
 
     return impls
 
 
 def _build_agg_args_mean(result_column, func, input_column):
-    int_sum = _make_agg_id("sum", input_column)
-    int_count = _make_agg_id("count", input_column)
+    int_sum = _make_agg_id('sum', input_column)
+    int_count = _make_agg_id('count', input_column)
 
     return dict(
         chunk_funcs=[
-            (int_sum, _apply_func_to_column, dict(column=input_column, func=M.sum)),
-            (int_count, _apply_func_to_column, dict(column=input_column, func=M.count)),
+            (int_sum, _apply_func_to_column,
+             dict(column=input_column, func=M.sum)),
+            (int_count, _apply_func_to_column,
+             dict(column=input_column, func=M.count)),
         ],
         aggregate_funcs=[
             (col, _apply_func_to_column, dict(column=col, func=M.sum))
             for col in (int_sum, int_count)
         ],
-        finalizer=(
-            result_column,
-            _finalize_mean,
-            dict(sum_column=int_sum, count_column=int_count),
-        ),
+        finalizer=(result_column, _finalize_mean,
+                   dict(sum_column=int_sum, count_column=int_count)),
     )
 
 
@@ -734,19 +696,19 @@ def _build_agg_args_custom(result_column, func, input_column):
 
     else:
         finalizer = (
-            result_column,
-            _apply_func_to_columns,
-            dict(func=func.finalize, prefix=col),
+            result_column, _apply_func_to_columns,
+            dict(func=func.finalize, prefix=col)
         )
 
     return dict(
         chunk_funcs=[
-            (col, _apply_func_to_column, dict(func=func.chunk, column=input_column))
+            (col, _apply_func_to_column,
+             dict(func=func.chunk, column=input_column))
         ],
         aggregate_funcs=[
             (col, _apply_func_to_columns, dict(func=func.agg, prefix=col))
         ],
-        finalizer=finalizer,
+        finalizer=finalizer
     )
 
 
@@ -779,7 +741,7 @@ def _groupby_apply_funcs(df, *index, **kwargs):
         # We want multiple keys
         kwargs.update(by=list(index))
 
-    funcs = kwargs.pop("funcs")
+    funcs = kwargs.pop('funcs')
     grouped = _groupby_raise_unaligned(df, **kwargs)
 
     result = collections.OrderedDict()
@@ -788,7 +750,7 @@ def _groupby_apply_funcs(df, *index, **kwargs):
 
         if isinstance(r, tuple):
             for idx, s in enumerate(r):
-                result["{}-{}".format(result_column, idx)] = s
+                result['{}-{}'.format(result_column, idx)] = s
 
         else:
             result[result_column] = r
@@ -847,7 +809,7 @@ def _finalize_var(df, count_column, sum_column, sum2_column, ddof=1):
     x2 = df[sum2_column]
 
     result = x2 - x ** 2 / n
-    div = n - ddof
+    div = (n - ddof)
     div[div < 0] = 0
     result /= div
     result[(n - ddof) == 0] = np.nan
@@ -868,11 +830,8 @@ def _cum_agg_aligned(part, cum_last, index, columns, func, initial):
 
 def _cum_agg_filled(a, b, func, initial):
     union = a.index.union(b.index)
-    return func(
-        a.reindex(union, fill_value=initial),
-        b.reindex(union, fill_value=initial),
-        fill_value=initial,
-    )
+    return func(a.reindex(union, fill_value=initial),
+                b.reindex(union, fill_value=initial), fill_value=initial)
 
 
 def _cumcount_aggregate(a, b, fill_value=None):
@@ -894,7 +853,6 @@ class _GroupBy(object):
     group_keys: bool
         Passed to pandas.DataFrame.groupby()
     """
-
     def __init__(self, df, by=None, slice=None, group_keys=True):
 
         assert isinstance(df, (DataFrame, Series))
@@ -914,18 +872,14 @@ class _GroupBy(object):
             do_index_partition_align = True
 
         if not do_index_partition_align:
-            raise NotImplementedError(
-                "The grouped object and index of the "
-                "groupby must have the same divisions."
-            )
+            raise NotImplementedError("The grouped object and index of the "
+                                      "groupby must have the same divisions.")
 
         # slicing key applied to _GroupBy instance
         self._slice = slice
 
         if isinstance(self.index, list):
-            index_meta = [
-                item._meta if isinstance(item, Series) else item for item in self.index
-            ]
+            index_meta = [item._meta if isinstance(item, Series) else item for item in self.index]
 
         elif isinstance(self.index, Series):
             index_meta = self.index._meta
@@ -943,10 +897,7 @@ class _GroupBy(object):
         sample = self.obj._meta_nonempty
 
         if isinstance(self.index, list):
-            index_meta = [
-                item._meta_nonempty if isinstance(item, Series) else item
-                for item in self.index
-            ]
+            index_meta = [item._meta_nonempty if isinstance(item, Series) else item for item in self.index]
 
         elif isinstance(self.index, Series):
             index_meta = self.index._meta_nonempty
@@ -957,7 +908,8 @@ class _GroupBy(object):
         grouped = sample.groupby(index_meta, group_keys=self.group_keys)
         return _maybe_slice(grouped, self._slice)
 
-    def _aca_agg(self, token, func, aggfunc=None, split_every=None, split_out=1):
+    def _aca_agg(self, token, func, aggfunc=None, split_every=None,
+                 split_out=1):
         if aggfunc is None:
             aggfunc = func
 
@@ -967,20 +919,13 @@ class _GroupBy(object):
         token = self._token_prefix + token
         levels = _determine_levels(self.index)
 
-        return aca(
-            [self.obj, self.index]
-            if not isinstance(self.index, list)
-            else [self.obj] + self.index,
-            chunk=_apply_chunk,
-            chunk_kwargs=dict(chunk=func, columns=columns),
-            aggregate=_groupby_aggregate,
-            meta=meta,
-            token=token,
-            split_every=split_every,
-            aggregate_kwargs=dict(aggfunc=aggfunc, levels=levels),
-            split_out=split_out,
-            split_out_setup=split_out_on_index,
-        )
+        return aca([self.obj, self.index] if not isinstance(self.index, list) else [self.obj] + self.index,
+                   chunk=_apply_chunk,
+                   chunk_kwargs=dict(chunk=func, columns=columns),
+                   aggregate=_groupby_aggregate,
+                   meta=meta, token=token, split_every=split_every,
+                   aggregate_kwargs=dict(aggfunc=aggfunc, levels=levels),
+                   split_out=split_out, split_out_setup=split_out_on_index)
 
     def _cum_agg(self, token, chunk, aggregate, initial):
         """ Wrapper for cumulative groupby operation """
@@ -989,53 +934,42 @@ class _GroupBy(object):
         index = self.index if isinstance(self.index, list) else [self.index]
 
         name = self._token_prefix + token
-        name_part = name + "-map"
-        name_last = name + "-take-last"
-        name_cum = name + "-cum-last"
+        name_part = name + '-map'
+        name_last = name + '-take-last'
+        name_cum = name + '-cum-last'
 
         # cumulate each partitions
-        cumpart_raw = map_partitions(
-            _apply_chunk,
-            self.obj,
-            *index,
-            chunk=chunk,
-            columns=columns,
-            token=name_part,
-            meta=meta
-        )
+        cumpart_raw = map_partitions(_apply_chunk, self.obj, *index,
+                                     chunk=chunk,
+                                     columns=columns,
+                                     token=name_part,
+                                     meta=meta)
 
-        cumpart_raw_frame = (
-            cumpart_raw.to_frame() if is_series_like(meta) else cumpart_raw
-        )
+        cumpart_raw_frame = (cumpart_raw.to_frame()
+                             if is_series_like(meta)
+                             else cumpart_raw)
 
         cumpart_ext = cumpart_raw_frame.assign(
-            **{
-                i: self.obj[i]
-                if np.isscalar(i) and i in self.obj.columns
-                else self.obj.index
-                for i in index
-            }
-        )
+            **{i: self.obj[i]
+               if np.isscalar(i) and i in self.obj.columns
+               else self.obj.index
+               for i in index})
 
         # Use pd.Grouper objects to specify that we are grouping by columns.
         # Otherwise, pandas will throw an ambiguity warning if the
         # DataFrame's index (self.obj.index) was included in the grouping
         # specification (self.index). See pandas #14432
         index_groupers = [pd.Grouper(key=ind) for ind in index]
-        cumlast = map_partitions(
-            _apply_chunk,
-            cumpart_ext,
-            *index_groupers,
-            columns=0 if columns is None else columns,
-            chunk=M.last,
-            meta=meta,
-            token=name_last
-        )
+        cumlast = map_partitions(_apply_chunk, cumpart_ext, *index_groupers,
+                                 columns=0 if columns is None else columns,
+                                 chunk=M.last,
+                                 meta=meta,
+                                 token=name_last)
 
         # aggregate cumulated partitions and its previous last element
         _hash = tokenize(self, token, chunk, aggregate, initial)
-        name += "-" + _hash
-        name_cum += "-" + _hash
+        name += '-' + _hash
+        name_cum += '-' + _hash
         dask = {}
         dask[(name, 0)] = (cumpart_raw._name, 0)
 
@@ -1045,25 +979,15 @@ class _GroupBy(object):
                 dask[(name_cum, i)] = (cumlast._name, i - 1)
             else:
                 # aggregate with previous cumulation results
-                dask[(name_cum, i)] = (
-                    _cum_agg_filled,
-                    (name_cum, i - 1),
-                    (cumlast._name, i - 1),
-                    aggregate,
-                    initial,
-                )
-            dask[(name, i)] = (
-                _cum_agg_aligned,
-                (cumpart_ext._name, i),
-                (name_cum, i),
-                index,
-                0 if columns is None else columns,
-                aggregate,
-                initial,
-            )
-        graph = HighLevelGraph.from_collections(
-            name, dask, dependencies=[cumpart_raw, cumpart_ext, cumlast]
-        )
+                dask[(name_cum, i)] = (_cum_agg_filled,
+                                       (name_cum, i - 1),
+                                       (cumlast._name, i - 1),
+                                       aggregate, initial)
+            dask[(name, i)] = (_cum_agg_aligned,
+                               (cumpart_ext._name, i), (name_cum, i),
+                               index, 0 if columns is None else columns,
+                               aggregate, initial)
+        graph = HighLevelGraph.from_collections(name, dask, dependencies=[cumpart_raw, cumpart_ext, cumlast])
         return new_dd_object(graph, name, chunk(self._meta), self.obj.divisions)
 
     @derived_from(pd.core.groupby.GroupBy)
@@ -1071,62 +995,63 @@ class _GroupBy(object):
         if axis:
             return self.obj.cumsum(axis=axis)
         else:
-            return self._cum_agg("cumsum", chunk=M.cumsum, aggregate=M.add, initial=0)
+            return self._cum_agg('cumsum',
+                                 chunk=M.cumsum,
+                                 aggregate=M.add,
+                                 initial=0)
 
     @derived_from(pd.core.groupby.GroupBy)
     def cumprod(self, axis=0):
         if axis:
             return self.obj.cumprod(axis=axis)
         else:
-            return self._cum_agg("cumprod", chunk=M.cumprod, aggregate=M.mul, initial=1)
+            return self._cum_agg('cumprod',
+                                 chunk=M.cumprod,
+                                 aggregate=M.mul,
+                                 initial=1)
 
     @derived_from(pd.core.groupby.GroupBy)
     def cumcount(self, axis=None):
-        return self._cum_agg(
-            "cumcount", chunk=M.cumcount, aggregate=_cumcount_aggregate, initial=-1
-        )
+        return self._cum_agg('cumcount',
+                             chunk=M.cumcount,
+                             aggregate=_cumcount_aggregate,
+                             initial=-1)
 
     @derived_from(pd.core.groupby.GroupBy)
     def sum(self, split_every=None, split_out=1, min_count=None):
-        result = self._aca_agg(
-            token="sum", func=M.sum, split_every=split_every, split_out=split_out
-        )
+        result = self._aca_agg(token='sum', func=M.sum, split_every=split_every,
+                               split_out=split_out)
         if min_count:
-            return result.where(self.count() >= min_count, other=np.NaN)
+            return result.where(self.count() >= min_count,
+                                other=np.NaN)
         else:
             return result
 
     @derived_from(pd.core.groupby.GroupBy)
     def prod(self, split_every=None, split_out=1, min_count=None):
-        result = self._aca_agg(
-            token="prod", func=M.prod, split_every=split_every, split_out=split_out
-        )
+        result = self._aca_agg(token='prod', func=M.prod, split_every=split_every,
+                               split_out=split_out)
         if min_count:
-            return result.where(self.count() >= min_count, other=np.NaN)
+            return result.where(self.count() >= min_count,
+                                other=np.NaN)
         else:
             return result
 
     @derived_from(pd.core.groupby.GroupBy)
     def min(self, split_every=None, split_out=1):
-        return self._aca_agg(
-            token="min", func=M.min, split_every=split_every, split_out=split_out
-        )
+        return self._aca_agg(token='min', func=M.min, split_every=split_every,
+                             split_out=split_out)
 
     @derived_from(pd.core.groupby.GroupBy)
     def max(self, split_every=None, split_out=1):
-        return self._aca_agg(
-            token="max", func=M.max, split_every=split_every, split_out=split_out
-        )
+        return self._aca_agg(token='max', func=M.max, split_every=split_every,
+                             split_out=split_out)
 
     @derived_from(pd.core.groupby.GroupBy)
     def count(self, split_every=None, split_out=1):
-        return self._aca_agg(
-            token="count",
-            func=M.count,
-            aggfunc=M.sum,
-            split_every=split_every,
-            split_out=split_out,
-        )
+        return self._aca_agg(token='count', func=M.count,
+                             aggfunc=M.sum, split_every=split_every,
+                             split_out=split_out)
 
     @derived_from(pd.core.groupby.GroupBy)
     def mean(self, split_every=None, split_out=1):
@@ -1138,31 +1063,20 @@ class _GroupBy(object):
 
     @derived_from(pd.core.groupby.GroupBy)
     def size(self, split_every=None, split_out=1):
-        return self._aca_agg(
-            token="size",
-            func=M.size,
-            aggfunc=M.sum,
-            split_every=split_every,
-            split_out=split_out,
-        )
+        return self._aca_agg(token='size', func=M.size, aggfunc=M.sum,
+                             split_every=split_every, split_out=split_out)
 
     @derived_from(pd.core.groupby.GroupBy)
     def var(self, ddof=1, split_every=None, split_out=1):
         levels = _determine_levels(self.index)
-        result = aca(
-            [self.obj, self.index]
-            if not isinstance(self.index, list)
-            else [self.obj] + self.index,
-            chunk=_var_chunk,
-            aggregate=_var_agg,
-            combine=_var_combine,
-            token=self._token_prefix + "var",
-            aggregate_kwargs={"ddof": ddof, "levels": levels},
-            combine_kwargs={"levels": levels},
-            split_every=split_every,
-            split_out=split_out,
-            split_out_setup=split_out_on_index,
-        )
+        result = aca([self.obj, self.index] if not isinstance(self.index, list) else [self.obj] + self.index,
+                     chunk=_var_chunk,
+                     aggregate=_var_agg, combine=_var_combine,
+                     token=self._token_prefix + 'var',
+                     aggregate_kwargs={'ddof': ddof, 'levels': levels},
+                     combine_kwargs={'levels': levels},
+                     split_every=split_every, split_out=split_out,
+                     split_out_setup=split_out_on_index)
 
         if isinstance(self.obj, Series):
             result = result[result.columns[0]]
@@ -1177,6 +1091,7 @@ class _GroupBy(object):
         result = map_partitions(np.sqrt, v, meta=v)
         return result
 
+    @derived_from(pd.DataFrame)
     def cov(self, ddof=1, split_every=None, split_out=1):
         levels = _determine_levels(self.index)
         result = aca(
@@ -1203,34 +1118,25 @@ class _GroupBy(object):
 
     @derived_from(pd.core.groupby.GroupBy)
     def first(self, split_every=None, split_out=1):
-        return self._aca_agg(
-            token="first", func=M.first, split_every=split_every, split_out=split_out
-        )
+        return self._aca_agg(token='first', func=M.first, split_every=split_every,
+                             split_out=split_out)
 
     @derived_from(pd.core.groupby.GroupBy)
     def last(self, split_every=None, split_out=1):
-        return self._aca_agg(
-            token="last", func=M.last, split_every=split_every, split_out=split_out
-        )
+        return self._aca_agg(token='last', func=M.last, split_every=split_every,
+                             split_out=split_out)
 
     @derived_from(pd.core.groupby.GroupBy)
     def get_group(self, key):
-        token = self._token_prefix + "get_group"
+        token = self._token_prefix + 'get_group'
 
         meta = self._meta.obj
         if is_dataframe_like(meta) and self._slice is not None:
             meta = meta[self._slice]
         columns = meta.columns if is_dataframe_like(meta) else meta.name
 
-        return map_partitions(
-            _groupby_get_group,
-            self.obj,
-            self.index,
-            key,
-            columns,
-            meta=meta,
-            token=token,
-        )
+        return map_partitions(_groupby_get_group, self.obj, self.index, key,
+                              columns, meta=meta, token=token)
 
     def aggregate(self, arg, split_every, split_out=1):
         if isinstance(self.obj, DataFrame):
@@ -1238,9 +1144,8 @@ class _GroupBy(object):
                 group_columns = {self.index}
 
             elif isinstance(self.index, list):
-                group_columns = {
-                    i for i in self.index if isinstance(i, tuple) or np.isscalar(i)
-                }
+                group_columns = {i for i in self.index
+                                 if isinstance(i, tuple) or np.isscalar(i)}
 
             else:
                 group_columns = set()
@@ -1254,9 +1159,8 @@ class _GroupBy(object):
             else:
                 # NOTE: this step relies on the index normalization to replace
                 #       series with their name in an index.
-                non_group_columns = [
-                    col for col in self.obj.columns if col not in group_columns
-                ]
+                non_group_columns = [col for col in self.obj.columns
+                                     if col not in group_columns]
 
             spec = _normalize_spec(arg, non_group_columns)
 
@@ -1266,17 +1170,13 @@ class _GroupBy(object):
                 # None is used to denote the series itself. This pseudo column is
                 # removed from the result columns before passing the spec along.
                 spec = _normalize_spec({None: arg}, [])
-                spec = [
-                    (result_column, func, input_column)
-                    for ((_, result_column), func, input_column) in spec
-                ]
+                spec = [(result_column, func, input_column)
+                        for ((_, result_column), func, input_column) in spec]
 
             else:
                 spec = _normalize_spec({None: arg}, [])
-                spec = [
-                    (self.obj.name, func, input_column)
-                    for (_, func, input_column) in spec
-                ]
+                spec = [(self.obj.name, func, input_column)
+                        for (_, func, input_column) in spec]
 
         else:
             raise ValueError("aggregate on unknown object {}".format(self.obj))
@@ -1294,21 +1194,19 @@ class _GroupBy(object):
         else:
             chunk_args = [self.obj] + self.index
 
-        return aca(
-            chunk_args,
-            chunk=_groupby_apply_funcs,
-            chunk_kwargs=dict(funcs=chunk_funcs),
-            combine=_groupby_apply_funcs,
-            combine_kwargs=dict(funcs=aggregate_funcs, level=levels),
-            aggregate=_agg_finalize,
-            aggregate_kwargs=dict(
-                aggregate_funcs=aggregate_funcs, finalize_funcs=finalizers, level=levels
-            ),
-            token="aggregate",
-            split_every=split_every,
-            split_out=split_out,
-            split_out_setup=split_out_on_index,
-        )
+        return aca(chunk_args,
+                   chunk=_groupby_apply_funcs,
+                   chunk_kwargs=dict(funcs=chunk_funcs),
+                   combine=_groupby_apply_funcs,
+                   combine_kwargs=dict(funcs=aggregate_funcs, level=levels),
+                   aggregate=_agg_finalize,
+                   aggregate_kwargs=dict(
+                       aggregate_funcs=aggregate_funcs,
+                       finalize_funcs=finalizers,
+                       level=levels,
+                   ),
+                   token='aggregate', split_every=split_every,
+                   split_out=split_out, split_out_setup=split_out_on_index)
 
     @insert_meta_param_description(pad=12)
     def apply(self, func, *args, **kwargs):
@@ -1343,51 +1241,43 @@ class _GroupBy(object):
         -------
         applied : Series or DataFrame depending on columns keyword
         """
-        meta = kwargs.get("meta", no_default)
+        meta = kwargs.get('meta', no_default)
 
         if meta is no_default:
-            with raise_on_meta_error(
-                "groupby.apply({0})".format(funcname(func)), udf=True
-            ):
+            with raise_on_meta_error("groupby.apply({0})".format(funcname(func)), udf=True):
                 meta_args, meta_kwargs = _extract_meta((args, kwargs), nonempty=True)
                 meta = self._meta_nonempty.apply(func, *meta_args, **meta_kwargs)
 
-            msg = (
-                "`meta` is not specified, inferred from partial data. "
-                "Please provide `meta` if the result is unexpected.\n"
-                "  Before: .apply(func)\n"
-                "  After:  .apply(func, meta={'x': 'f8', 'y': 'f8'}) for dataframe result\n"
-                "  or:     .apply(func, meta=('x', 'f8'))            for series result"
-            )
+            msg = ("`meta` is not specified, inferred from partial data. "
+                   "Please provide `meta` if the result is unexpected.\n"
+                   "  Before: .apply(func)\n"
+                   "  After:  .apply(func, meta={'x': 'f8', 'y': 'f8'}) for dataframe result\n"
+                   "  or:     .apply(func, meta=('x', 'f8'))            for series result")
             warnings.warn(msg, stacklevel=2)
 
         meta = make_meta(meta)
 
         # Validate self.index
-        if isinstance(self.index, list) and any(
-            isinstance(item, Series) for item in self.index
-        ):
-            raise NotImplementedError(
-                "groupby-apply with a multiple Series " "is currently not supported"
-            )
+        if (isinstance(self.index, list) and
+                any(isinstance(item, Series) for item in self.index)):
+            raise NotImplementedError("groupby-apply with a multiple Series "
+                                      "is currently not supported")
 
         df = self.obj
-        should_shuffle = not (
-            df.known_divisions and df._contains_index_name(self.index)
-        )
+        should_shuffle = not (df.known_divisions and
+                              df._contains_index_name(self.index))
 
         if should_shuffle:
             if isinstance(self.obj, Series):
                 # Temporarily convert series to dataframe for shuffle
-                df = df.to_frame("__series__")
+                df = df.to_frame('__series__')
                 convert_back_to_series = True
             else:
                 convert_back_to_series = False
 
             if isinstance(self.index, DataFrame):  # add index columns to dataframe
-                df2 = df.assign(
-                    **{"_index_" + c: self.index[c] for c in self.index.columns}
-                )
+                df2 = df.assign(**{'_index_' + c: self.index[c]
+                                   for c in self.index.columns})
                 index = self.index
             elif isinstance(self.index, Series):
                 df2 = df.assign(_index=self.index)
@@ -1400,50 +1290,43 @@ class _GroupBy(object):
 
             if isinstance(self.index, DataFrame):
                 # extract index from dataframe
-                cols = ["_index_" + c for c in self.index.columns]
+                cols = ['_index_' + c for c in self.index.columns]
                 index2 = df3[cols]
                 if is_dataframe_like(meta):
                     df4 = df3.map_partitions(drop_columns, cols, meta.columns.dtype)
                 else:
                     df4 = df3.drop(cols, axis=1)
             elif isinstance(self.index, Series):
-                index2 = df3["_index"]
+                index2 = df3['_index']
                 index2.name = self.index.name
                 if is_dataframe_like(meta):
-                    df4 = df3.map_partitions(drop_columns, "_index", meta.columns.dtype)
+                    df4 = df3.map_partitions(drop_columns, '_index',
+                                             meta.columns.dtype)
                 else:
-                    df4 = df3.drop("_index", axis=1)
+                    df4 = df3.drop('_index', axis=1)
             else:
                 df4 = df3
                 index2 = self.index
 
             if convert_back_to_series:
-                df4 = df4["__series__"].rename(self.obj.name)
+                df4 = df4['__series__'].rename(self.obj.name)
 
         else:
             df4 = df
             index2 = self.index
 
         # Perform embarrassingly parallel groupby-apply
-        kwargs["meta"] = meta
-        df5 = map_partitions(
-            _groupby_slice_apply,
-            df4,
-            index2,
-            self._slice,
-            func,
-            token=funcname(func),
-            *args,
-            group_keys=self.group_keys,
-            **kwargs
-        )
+        kwargs['meta'] = meta
+        df5 = map_partitions(_groupby_slice_apply, df4, index2,
+                             self._slice, func, token=funcname(func), *args, group_keys=self.group_keys,
+                             **kwargs)
 
         return df5
 
 
 class DataFrameGroupBy(_GroupBy):
 
-    _token_prefix = "dataframe-groupby-"
+    _token_prefix = 'dataframe-groupby-'
 
     def __getitem__(self, key):
         if isinstance(key, list):
@@ -1456,13 +1339,9 @@ class DataFrameGroupBy(_GroupBy):
         return g
 
     def __dir__(self):
-        return sorted(
-            set(
-                dir(type(self))
-                + list(self.__dict__)
-                + list(filter(compatibility.isidentifier, self.obj.columns))
-            )
-        )
+        return sorted(set(dir(type(self)) + list(self.__dict__) +
+                      list(filter(compatibility.isidentifier,
+                                  self.obj.columns))))
 
     def __getattr__(self, key):
         try:
@@ -1472,12 +1351,10 @@ class DataFrameGroupBy(_GroupBy):
 
     @derived_from(pd.core.groupby.DataFrameGroupBy)
     def aggregate(self, arg, split_every=None, split_out=1):
-        if arg == "size":
+        if arg == 'size':
             return self.size()
 
-        return super(DataFrameGroupBy, self).aggregate(
-            arg, split_every=split_every, split_out=split_out
-        )
+        return super(DataFrameGroupBy, self).aggregate(arg, split_every=split_every, split_out=split_out)
 
     @derived_from(pd.core.groupby.DataFrameGroupBy)
     def agg(self, arg, split_every=None, split_out=1):
@@ -1486,7 +1363,7 @@ class DataFrameGroupBy(_GroupBy):
 
 class SeriesGroupBy(_GroupBy):
 
-    _token_prefix = "series-groupby-"
+    _token_prefix = 'series-groupby-'
 
     def __init__(self, df, by=None, slice=None, **kwargs):
         # for any non series object, raise pandas-compat error message
@@ -1498,7 +1375,8 @@ class SeriesGroupBy(_GroupBy):
                 if len(by) == 0:
                     raise ValueError("No group keys passed!")
 
-                non_series_items = [item for item in by if not isinstance(item, Series)]
+                non_series_items = [item for item in by
+                                    if not isinstance(item, Series)]
                 # raise error from pandas, if applicable
                 df._meta.groupby(non_series_items)
             else:
@@ -1517,27 +1395,20 @@ class SeriesGroupBy(_GroupBy):
         else:
             chunk = _nunique_series_chunk
 
-        return aca(
-            [self.obj, self.index]
-            if not isinstance(self.index, list)
-            else [self.obj] + self.index,
-            chunk=chunk,
-            aggregate=_nunique_df_aggregate,
-            combine=_nunique_df_combine,
-            token="series-groupby-nunique",
-            chunk_kwargs={"levels": levels, "name": name},
-            aggregate_kwargs={"levels": levels, "name": name},
-            combine_kwargs={"levels": levels},
-            split_every=split_every,
-            split_out=split_out,
-            split_out_setup=split_out_on_index,
-        )
+        return aca([self.obj, self.index] if not isinstance(self.index, list) else [self.obj] + self.index,
+                   chunk=chunk,
+                   aggregate=_nunique_df_aggregate,
+                   combine=_nunique_df_combine,
+                   token='series-groupby-nunique',
+                   chunk_kwargs={'levels': levels, 'name': name},
+                   aggregate_kwargs={'levels': levels, 'name': name},
+                   combine_kwargs={'levels': levels},
+                   split_every=split_every, split_out=split_out,
+                   split_out_setup=split_out_on_index)
 
     @derived_from(pd.core.groupby.SeriesGroupBy)
     def aggregate(self, arg, split_every=None, split_out=1):
-        result = super(SeriesGroupBy, self).aggregate(
-            arg, split_every=split_every, split_out=split_out
-        )
+        result = super(SeriesGroupBy, self).aggregate(arg, split_every=split_every, split_out=split_out)
         if self._slice:
             result = result[self._slice]
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -326,7 +326,7 @@ def _cov_finalizer(df, cols):
 
 
 def mul_cols(df, cols):
-    _df = pd.DataFrame()
+    _df = type(df)()
     for i, j in it.combinations_with_replacement(df[cols].columns, 2):
         col = "%s%s" % (i, j)
         _df[col] = df[i] * df[j]

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -8,13 +8,25 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from .core import (DataFrame, Series, aca, map_partitions,
-                   new_dd_object, no_default, split_out_on_index,
-                   _extract_meta)
+from .core import (
+    DataFrame,
+    Series,
+    aca,
+    map_partitions,
+    new_dd_object,
+    no_default,
+    split_out_on_index,
+    _extract_meta,
+)
 from .methods import drop_columns, concat
 from .shuffle import shuffle
-from .utils import (make_meta, insert_meta_param_description,
-                    raise_on_meta_error, is_series_like, is_dataframe_like)
+from .utils import (
+    make_meta,
+    insert_meta_param_description,
+    raise_on_meta_error,
+    is_series_like,
+    is_dataframe_like,
+)
 from ..base import tokenize
 from ..utils import derived_from, M, funcname, itemgetter
 from ..highlevelgraph import HighLevelGraph
@@ -53,6 +65,7 @@ from .. import compatibility
 #
 # #############################################
 
+
 def _determine_levels(index):
     """Determine the correct levels argument to groupby.
     """
@@ -71,13 +84,18 @@ def _normalize_index(df, index):
     elif isinstance(index, list):
         return [_normalize_index(df, col) for col in index]
 
-    elif (is_series_like(index) and index.name in df.columns and
-          index._name == df[index.name]._name):
+    elif (
+        is_series_like(index)
+        and index.name in df.columns
+        and index._name == df[index.name]._name
+    ):
         return index.name
 
-    elif (isinstance(index, DataFrame) and
-          set(index.columns).issubset(df.columns) and
-          index._name == df[index.columns]._name):
+    elif (
+        isinstance(index, DataFrame)
+        and set(index.columns).issubset(df.columns)
+        and index._name == df[index.columns]._name
+    ):
         return list(index.columns)
 
     else:
@@ -89,7 +107,7 @@ def _maybe_slice(grouped, columns):
     Slice columns if grouped is pd.DataFrameGroupBy
     """
     # FIXME: update with better groupby object detection (i.e.: ngroups, get_group)
-    if 'groupby' in type(grouped).__name__.lower():
+    if "groupby" in type(grouped).__name__.lower():
         if columns is not None:
             if isinstance(columns, (tuple, list, set, pd.Index)):
                 columns = list(columns)
@@ -116,24 +134,26 @@ def _groupby_raise_unaligned(df, **kwargs):
     unaligned key is generally a bad idea, we just error loudly in dask.
 
     For more information see pandas GH issue #15244 and Dask GH issue #1876."""
-    by = kwargs.get('by', None)
+    by = kwargs.get("by", None)
     if by is not None and not _is_aligned(df, by):
-        msg = ("Grouping by an unaligned index is unsafe and unsupported.\n"
-               "This can be caused by filtering only one of the object or\n"
-               "grouping key. For example, the following works in pandas,\n"
-               "but not in dask:\n"
-               "\n"
-               "df[df.foo < 0].groupby(df.bar)\n"
-               "\n"
-               "This can be avoided by either filtering beforehand, or\n"
-               "passing in the name of the column instead:\n"
-               "\n"
-               "df2 = df[df.foo < 0]\n"
-               "df2.groupby(df2.bar)\n"
-               "# or\n"
-               "df[df.foo < 0].groupby('bar')\n"
-               "\n"
-               "For more information see dask GH issue #1876.")
+        msg = (
+            "Grouping by an unaligned index is unsafe and unsupported.\n"
+            "This can be caused by filtering only one of the object or\n"
+            "grouping key. For example, the following works in pandas,\n"
+            "but not in dask:\n"
+            "\n"
+            "df[df.foo < 0].groupby(df.bar)\n"
+            "\n"
+            "This can be avoided by either filtering beforehand, or\n"
+            "passing in the name of the column instead:\n"
+            "\n"
+            "df2 = df[df.foo < 0]\n"
+            "df2.groupby(df2.bar)\n"
+            "# or\n"
+            "df[df.foo < 0].groupby('bar')\n"
+            "\n"
+            "For more information see dask GH issue #1876."
+        )
         raise ValueError(msg)
     elif by is not None and len(by):
         # since we're coming through apply, `by` will be a tuple.
@@ -146,7 +166,7 @@ def _groupby_raise_unaligned(df, **kwargs):
 def _groupby_slice_apply(df, grouper, key, func, *args, **kwargs):
     # No need to use raise if unaligned here - this is only called after
     # shuffling, which makes everything aligned already
-    group_keys = kwargs.pop('group_keys', True)
+    group_keys = kwargs.pop("group_keys", True)
     g = df.groupby(grouper, group_keys=group_keys)
     if key:
         g = g[key]
@@ -174,6 +194,7 @@ def _groupby_get_group(df, by_key, get_key, columns):
 ###############################################################
 # Aggregation
 ###############################################################
+
 
 class Aggregation(object):
     """User defined groupby-aggregation.
@@ -227,6 +248,7 @@ class Aggregation(object):
     Though of course, both of these are built-in and so you don't need to
     implement them yourself.
     """
+
     def __init__(self, name, chunk, agg, finalize=None):
         self.chunk = chunk
         self.agg = agg
@@ -239,8 +261,8 @@ def _groupby_aggregate(df, aggfunc=None, levels=None):
 
 
 def _apply_chunk(df, *index, **kwargs):
-    func = kwargs.pop('chunk')
-    columns = kwargs.pop('columns')
+    func = kwargs.pop("chunk")
+    columns = kwargs.pop("columns")
 
     g = _groupby_raise_unaligned(df, by=index)
 
@@ -262,11 +284,11 @@ def _var_chunk(df, *index):
     g = _groupby_raise_unaligned(df, by=index)
     x = g.sum()
 
-    n = g[x.columns].count().rename(columns=lambda c: c + '-count')
+    n = g[x.columns].count().rename(columns=lambda c: c + "-count")
 
     df[cols] = df[cols] ** 2
     g2 = _groupby_raise_unaligned(df, by=index)
-    x2 = g2.sum().rename(columns=lambda c: c + '-x2')
+    x2 = g2.sum().rename(columns=lambda c: c + "-x2")
 
     x2.index = x.index
     return concat([x, x2, n], axis=1)
@@ -279,13 +301,13 @@ def _var_combine(g, levels):
 def _var_agg(g, levels, ddof):
     g = g.groupby(level=levels, sort=False).sum()
     nc = len(g.columns)
-    x = g[g.columns[:nc // 3]]
-    x2 = g[g.columns[nc // 3:2 * nc // 3]].rename(columns=lambda c: c[:-3])
-    n = g[g.columns[-nc // 3:]].rename(columns=lambda c: c[:-6])
+    x = g[g.columns[: nc // 3]]
+    x2 = g[g.columns[nc // 3 : 2 * nc // 3]].rename(columns=lambda c: c[:-3])
+    n = g[g.columns[-nc // 3 :]].rename(columns=lambda c: c[:-6])
 
     # TODO: replace with _finalize_var?
     result = x2 - x ** 2 / n
-    div = (n - ddof)
+    div = n - ddof
     div[div < 0] = 0
     result /= div
     result[(n - ddof) == 0] = np.nan
@@ -293,13 +315,93 @@ def _var_agg(g, levels, ddof):
     return result
 
 
+def _cov_combine(g, levels):
+    return g
+
+
+def _cov_finalizer(df, cols):
+    vals = []
+    num_elements = len(list(it.product(cols, repeat=2)))
+    num_cols = len(cols)
+    vals = np.zeros(num_elements)
+    col_idx_mapping = dict(zip(cols, range(len(cols))))
+    for i, j in it.combinations_with_replacement(df[cols].columns, 2):
+        x = col_idx_mapping[i]
+        y = col_idx_mapping[j]
+        idx = x + num_cols * y
+        mul_col = "%s%s" % (i, j)
+        ni = df["%s-count" % i]
+        nj = df["%s-count" % j]
+
+        n = np.sqrt(ni * nj)
+        div = n - 1
+        div[div < 0] = 0
+
+        val = (df[mul_col] - df[i] * df[j] / n).values[0] / div
+        vals[idx] = val
+        if i != j:
+            idx = num_cols * x + y
+            vals[idx] = val
+    level_1 = cols
+    index = pd.MultiIndex.from_product([level_1, level_1])
+    return pd.Series(vals, index=index)
+
+
+def mul_cols(df, cols):
+    _df = pd.DataFrame()
+    for i, j in it.combinations_with_replacement(df[cols].columns, 2):
+        col = "%s%s" % (i, j)
+        _df[col] = df[i] * df[j]
+    return _df
+
+
+def _cov_chunk(df, *index):
+    if is_series_like(df):
+        df = df.to_frame()
+
+    df = df.copy()
+    cols = df._get_numeric_data().columns
+    cols = cols.drop(*index)
+
+    g = _groupby_raise_unaligned(df, by=index)
+    x = g.sum()
+    mul = g.apply(mul_cols, cols=cols).reset_index(level=1, drop=True)
+    n = g[x.columns].count().rename(columns=lambda c: c + "-count")
+
+    return (x, mul, n)
+
+
+def _cov_agg(t, levels, ddof):
+    xs = []
+    muls = []
+    ns = []
+    cols = t[0][0].columns
+    for x, mul, n in t:
+        xs.append(x)
+        muls.append(mul)
+        ns.append(n)
+
+    x_sums = pd.concat(xs).groupby(level=levels, sort=False).sum()
+    x_muls = pd.concat(muls).groupby(level=levels, sort=False).sum()
+    x_ns = pd.concat(ns).groupby(level=levels).sum()
+    result = (
+        pd.concat([x_sums, x_muls, x_ns], axis=1)
+        .groupby(level=0)
+        .apply(_cov_finalizer, cols=cols)
+    )
+    s_result = result.stack()
+    assert is_dataframe_like(s_result)
+    return s_result
+
+
 ###############################################################
 # nunique
 ###############################################################
 
+
 def _nunique_df_chunk(df, *index, **kwargs):
-    levels = kwargs.pop('levels')
-    name = kwargs.pop('name')
+    levels = kwargs.pop("levels")
+    name = kwargs.pop("name")
 
     g = _groupby_raise_unaligned(df, by=index)
     if len(df) > 0:
@@ -307,9 +409,9 @@ def _nunique_df_chunk(df, *index, **kwargs):
         # we set the index here to force a possibly duplicate index
         # for our reduce step
         if isinstance(levels, list):
-            grouped.index = pd.MultiIndex.from_arrays([
-                grouped.index.get_level_values(level=level) for level in levels
-            ])
+            grouped.index = pd.MultiIndex.from_arrays(
+                [grouped.index.get_level_values(level=level) for level in levels]
+            )
         else:
             grouped.index = grouped.index.get_level_values(level=levels)
     else:
@@ -330,13 +432,12 @@ def _drop_duplicates_rename(df):
 
 
 def _nunique_df_combine(df, levels):
-    result = df.groupby(level=levels,
-                        sort=False).apply(_drop_duplicates_rename)
+    result = df.groupby(level=levels, sort=False).apply(_drop_duplicates_rename)
 
     if isinstance(levels, list):
-        result.index = pd.MultiIndex.from_arrays([
-            result.index.get_level_values(level=level) for level in levels
-        ])
+        result.index = pd.MultiIndex.from_arrays(
+            [result.index.get_level_values(level=level) for level in levels]
+        )
     else:
         result.index = result.index.get_level_values(level=levels)
 
@@ -370,7 +471,7 @@ def _nunique_series_chunk(df, *index, **_ignored_):
 #
 ###############################################################
 def _make_agg_id(func, column):
-    return '{!s}-{!s}-{}'.format(func, column, tokenize(func, column))
+    return "{!s}-{!s}-{}".format(func, column, tokenize(func, column))
 
 
 def _normalize_spec(spec, non_group_columns):
@@ -431,22 +532,27 @@ def _normalize_spec(spec, non_group_columns):
     if isinstance(spec, dict):
         for input_column, subspec in spec.items():
             if isinstance(subspec, dict):
-                res.extend(((input_column, result_column), func, input_column)
-                           for result_column, func in subspec.items())
+                res.extend(
+                    ((input_column, result_column), func, input_column)
+                    for result_column, func in subspec.items()
+                )
 
             else:
                 if not isinstance(subspec, list):
                     subspec = [subspec]
 
-                res.extend(((input_column, funcname(func)), func, input_column)
-                           for func in subspec)
+                res.extend(
+                    ((input_column, funcname(func)), func, input_column)
+                    for func in subspec
+                )
 
     else:
         raise ValueError("unsupported agg spec of type {}".format(type(spec)))
 
     compounds = (list, tuple, dict)
-    use_flat_columns = not any(isinstance(subspec, compounds)
-                               for subspec in spec.values())
+    use_flat_columns = not any(
+        isinstance(subspec, compounds) for subspec in spec.values()
+    )
 
     if use_flat_columns:
         res = [(input_col, func, input_col) for (_, func, input_col) in res]
@@ -477,7 +583,7 @@ def _build_agg_args(spec):
         applied after the ``agg_funcs``. They are used to create final results
         from intermediate representations.
     """
-    known_np_funcs = {np.min: 'min', np.max: 'max'}
+    known_np_funcs = {np.min: "min", np.max: "max"}
 
     # check that there are no name conflicts for a single input column
     by_name = {}
@@ -487,7 +593,7 @@ def _build_agg_args(spec):
 
     for funcs in by_name.values():
         if len(funcs) != 1:
-            raise ValueError('conflicting aggregation functions: {}'.format(funcs))
+            raise ValueError("conflicting aggregation functions: {}".format(funcs))
 
     chunks = {}
     aggs = {}
@@ -500,10 +606,10 @@ def _build_agg_args(spec):
         impls = _build_agg_args_single(result_column, func, input_column)
 
         # overwrite existing result-columns, generate intermediates only once
-        chunks.update((spec[0], spec) for spec in impls['chunk_funcs'])
-        aggs.update((spec[0], spec) for spec in impls['aggregate_funcs'])
+        chunks.update((spec[0], spec) for spec in impls["chunk_funcs"])
+        aggs.update((spec[0], spec) for spec in impls["aggregate_funcs"])
 
-        finalizers.append(impls['finalizer'])
+        finalizers.append(impls["finalizer"])
 
     chunks = sorted(chunks.values())
     aggs = sorted(aggs.values())
@@ -513,27 +619,28 @@ def _build_agg_args(spec):
 
 def _build_agg_args_single(result_column, func, input_column):
     simple_impl = {
-        'sum': (M.sum, M.sum),
-        'min': (M.min, M.min),
-        'max': (M.max, M.max),
-        'count': (M.count, M.sum),
-        'size': (M.size, M.sum),
-        'first': (M.first, M.first),
-        'last': (M.last, M.last),
-        'prod': (M.prod, M.prod)
+        "sum": (M.sum, M.sum),
+        "min": (M.min, M.min),
+        "max": (M.max, M.max),
+        "count": (M.count, M.sum),
+        "size": (M.size, M.sum),
+        "first": (M.first, M.first),
+        "last": (M.last, M.last),
+        "prod": (M.prod, M.prod),
     }
 
     if func in simple_impl.keys():
-        return _build_agg_args_simple(result_column, func, input_column,
-                                      simple_impl[func])
+        return _build_agg_args_simple(
+            result_column, func, input_column, simple_impl[func]
+        )
 
-    elif func == 'var':
+    elif func == "var":
         return _build_agg_args_var(result_column, func, input_column)
 
-    elif func == 'std':
+    elif func == "std":
         return _build_agg_args_std(result_column, func, input_column)
 
-    elif func == 'mean':
+    elif func == "mean":
         return _build_agg_args_mean(result_column, func, input_column)
 
     elif isinstance(func, Aggregation):
@@ -548,64 +655,74 @@ def _build_agg_args_simple(result_column, func, input_column, impl_pair):
     chunk_impl, agg_impl = impl_pair
 
     return dict(
-        chunk_funcs=[(intermediate, _apply_func_to_column,
-                     dict(column=input_column, func=chunk_impl))],
-        aggregate_funcs=[(intermediate, _apply_func_to_column,
-                         dict(column=intermediate, func=agg_impl))],
+        chunk_funcs=[
+            (
+                intermediate,
+                _apply_func_to_column,
+                dict(column=input_column, func=chunk_impl),
+            )
+        ],
+        aggregate_funcs=[
+            (
+                intermediate,
+                _apply_func_to_column,
+                dict(column=intermediate, func=agg_impl),
+            )
+        ],
         finalizer=(result_column, itemgetter(intermediate), dict()),
     )
 
 
 def _build_agg_args_var(result_column, func, input_column):
-    int_sum = _make_agg_id('sum', input_column)
-    int_sum2 = _make_agg_id('sum2', input_column)
-    int_count = _make_agg_id('count', input_column)
+    int_sum = _make_agg_id("sum", input_column)
+    int_sum2 = _make_agg_id("sum2", input_column)
+    int_count = _make_agg_id("count", input_column)
 
     return dict(
         chunk_funcs=[
-            (int_sum, _apply_func_to_column,
-             dict(column=input_column, func=M.sum)),
-            (int_count, _apply_func_to_column,
-             dict(column=input_column, func=M.count)),
-            (int_sum2, _compute_sum_of_squares,
-             dict(column=input_column)),
+            (int_sum, _apply_func_to_column, dict(column=input_column, func=M.sum)),
+            (int_count, _apply_func_to_column, dict(column=input_column, func=M.count)),
+            (int_sum2, _compute_sum_of_squares, dict(column=input_column)),
         ],
         aggregate_funcs=[
             (col, _apply_func_to_column, dict(column=col, func=M.sum))
             for col in (int_sum, int_count, int_sum2)
         ],
-        finalizer=(result_column, _finalize_var,
-                   dict(sum_column=int_sum, count_column=int_count,
-                        sum2_column=int_sum2)),
+        finalizer=(
+            result_column,
+            _finalize_var,
+            dict(sum_column=int_sum, count_column=int_count, sum2_column=int_sum2),
+        ),
     )
 
 
 def _build_agg_args_std(result_column, func, input_column):
     impls = _build_agg_args_var(result_column, func, input_column)
 
-    result_column, _, kwargs = impls['finalizer']
-    impls['finalizer'] = (result_column, _finalize_std, kwargs)
+    result_column, _, kwargs = impls["finalizer"]
+    impls["finalizer"] = (result_column, _finalize_std, kwargs)
 
     return impls
 
 
 def _build_agg_args_mean(result_column, func, input_column):
-    int_sum = _make_agg_id('sum', input_column)
-    int_count = _make_agg_id('count', input_column)
+    int_sum = _make_agg_id("sum", input_column)
+    int_count = _make_agg_id("count", input_column)
 
     return dict(
         chunk_funcs=[
-            (int_sum, _apply_func_to_column,
-             dict(column=input_column, func=M.sum)),
-            (int_count, _apply_func_to_column,
-             dict(column=input_column, func=M.count)),
+            (int_sum, _apply_func_to_column, dict(column=input_column, func=M.sum)),
+            (int_count, _apply_func_to_column, dict(column=input_column, func=M.count)),
         ],
         aggregate_funcs=[
             (col, _apply_func_to_column, dict(column=col, func=M.sum))
             for col in (int_sum, int_count)
         ],
-        finalizer=(result_column, _finalize_mean,
-                   dict(sum_column=int_sum, count_column=int_count)),
+        finalizer=(
+            result_column,
+            _finalize_mean,
+            dict(sum_column=int_sum, count_column=int_count),
+        ),
     )
 
 
@@ -617,19 +734,19 @@ def _build_agg_args_custom(result_column, func, input_column):
 
     else:
         finalizer = (
-            result_column, _apply_func_to_columns,
-            dict(func=func.finalize, prefix=col)
+            result_column,
+            _apply_func_to_columns,
+            dict(func=func.finalize, prefix=col),
         )
 
     return dict(
         chunk_funcs=[
-            (col, _apply_func_to_column,
-             dict(func=func.chunk, column=input_column))
+            (col, _apply_func_to_column, dict(func=func.chunk, column=input_column))
         ],
         aggregate_funcs=[
             (col, _apply_func_to_columns, dict(func=func.agg, prefix=col))
         ],
-        finalizer=finalizer
+        finalizer=finalizer,
     )
 
 
@@ -662,7 +779,7 @@ def _groupby_apply_funcs(df, *index, **kwargs):
         # We want multiple keys
         kwargs.update(by=list(index))
 
-    funcs = kwargs.pop('funcs')
+    funcs = kwargs.pop("funcs")
     grouped = _groupby_raise_unaligned(df, **kwargs)
 
     result = collections.OrderedDict()
@@ -671,7 +788,7 @@ def _groupby_apply_funcs(df, *index, **kwargs):
 
         if isinstance(r, tuple):
             for idx, s in enumerate(r):
-                result['{}-{}'.format(result_column, idx)] = s
+                result["{}-{}".format(result_column, idx)] = s
 
         else:
             result[result_column] = r
@@ -730,7 +847,7 @@ def _finalize_var(df, count_column, sum_column, sum2_column, ddof=1):
     x2 = df[sum2_column]
 
     result = x2 - x ** 2 / n
-    div = (n - ddof)
+    div = n - ddof
     div[div < 0] = 0
     result /= div
     result[(n - ddof) == 0] = np.nan
@@ -751,8 +868,11 @@ def _cum_agg_aligned(part, cum_last, index, columns, func, initial):
 
 def _cum_agg_filled(a, b, func, initial):
     union = a.index.union(b.index)
-    return func(a.reindex(union, fill_value=initial),
-                b.reindex(union, fill_value=initial), fill_value=initial)
+    return func(
+        a.reindex(union, fill_value=initial),
+        b.reindex(union, fill_value=initial),
+        fill_value=initial,
+    )
 
 
 def _cumcount_aggregate(a, b, fill_value=None):
@@ -774,6 +894,7 @@ class _GroupBy(object):
     group_keys: bool
         Passed to pandas.DataFrame.groupby()
     """
+
     def __init__(self, df, by=None, slice=None, group_keys=True):
 
         assert isinstance(df, (DataFrame, Series))
@@ -793,14 +914,18 @@ class _GroupBy(object):
             do_index_partition_align = True
 
         if not do_index_partition_align:
-            raise NotImplementedError("The grouped object and index of the "
-                                      "groupby must have the same divisions.")
+            raise NotImplementedError(
+                "The grouped object and index of the "
+                "groupby must have the same divisions."
+            )
 
         # slicing key applied to _GroupBy instance
         self._slice = slice
 
         if isinstance(self.index, list):
-            index_meta = [item._meta if isinstance(item, Series) else item for item in self.index]
+            index_meta = [
+                item._meta if isinstance(item, Series) else item for item in self.index
+            ]
 
         elif isinstance(self.index, Series):
             index_meta = self.index._meta
@@ -818,7 +943,10 @@ class _GroupBy(object):
         sample = self.obj._meta_nonempty
 
         if isinstance(self.index, list):
-            index_meta = [item._meta_nonempty if isinstance(item, Series) else item for item in self.index]
+            index_meta = [
+                item._meta_nonempty if isinstance(item, Series) else item
+                for item in self.index
+            ]
 
         elif isinstance(self.index, Series):
             index_meta = self.index._meta_nonempty
@@ -829,8 +957,7 @@ class _GroupBy(object):
         grouped = sample.groupby(index_meta, group_keys=self.group_keys)
         return _maybe_slice(grouped, self._slice)
 
-    def _aca_agg(self, token, func, aggfunc=None, split_every=None,
-                 split_out=1):
+    def _aca_agg(self, token, func, aggfunc=None, split_every=None, split_out=1):
         if aggfunc is None:
             aggfunc = func
 
@@ -840,13 +967,20 @@ class _GroupBy(object):
         token = self._token_prefix + token
         levels = _determine_levels(self.index)
 
-        return aca([self.obj, self.index] if not isinstance(self.index, list) else [self.obj] + self.index,
-                   chunk=_apply_chunk,
-                   chunk_kwargs=dict(chunk=func, columns=columns),
-                   aggregate=_groupby_aggregate,
-                   meta=meta, token=token, split_every=split_every,
-                   aggregate_kwargs=dict(aggfunc=aggfunc, levels=levels),
-                   split_out=split_out, split_out_setup=split_out_on_index)
+        return aca(
+            [self.obj, self.index]
+            if not isinstance(self.index, list)
+            else [self.obj] + self.index,
+            chunk=_apply_chunk,
+            chunk_kwargs=dict(chunk=func, columns=columns),
+            aggregate=_groupby_aggregate,
+            meta=meta,
+            token=token,
+            split_every=split_every,
+            aggregate_kwargs=dict(aggfunc=aggfunc, levels=levels),
+            split_out=split_out,
+            split_out_setup=split_out_on_index,
+        )
 
     def _cum_agg(self, token, chunk, aggregate, initial):
         """ Wrapper for cumulative groupby operation """
@@ -855,42 +989,53 @@ class _GroupBy(object):
         index = self.index if isinstance(self.index, list) else [self.index]
 
         name = self._token_prefix + token
-        name_part = name + '-map'
-        name_last = name + '-take-last'
-        name_cum = name + '-cum-last'
+        name_part = name + "-map"
+        name_last = name + "-take-last"
+        name_cum = name + "-cum-last"
 
         # cumulate each partitions
-        cumpart_raw = map_partitions(_apply_chunk, self.obj, *index,
-                                     chunk=chunk,
-                                     columns=columns,
-                                     token=name_part,
-                                     meta=meta)
+        cumpart_raw = map_partitions(
+            _apply_chunk,
+            self.obj,
+            *index,
+            chunk=chunk,
+            columns=columns,
+            token=name_part,
+            meta=meta
+        )
 
-        cumpart_raw_frame = (cumpart_raw.to_frame()
-                             if is_series_like(meta)
-                             else cumpart_raw)
+        cumpart_raw_frame = (
+            cumpart_raw.to_frame() if is_series_like(meta) else cumpart_raw
+        )
 
         cumpart_ext = cumpart_raw_frame.assign(
-            **{i: self.obj[i]
-               if np.isscalar(i) and i in self.obj.columns
-               else self.obj.index
-               for i in index})
+            **{
+                i: self.obj[i]
+                if np.isscalar(i) and i in self.obj.columns
+                else self.obj.index
+                for i in index
+            }
+        )
 
         # Use pd.Grouper objects to specify that we are grouping by columns.
         # Otherwise, pandas will throw an ambiguity warning if the
         # DataFrame's index (self.obj.index) was included in the grouping
         # specification (self.index). See pandas #14432
         index_groupers = [pd.Grouper(key=ind) for ind in index]
-        cumlast = map_partitions(_apply_chunk, cumpart_ext, *index_groupers,
-                                 columns=0 if columns is None else columns,
-                                 chunk=M.last,
-                                 meta=meta,
-                                 token=name_last)
+        cumlast = map_partitions(
+            _apply_chunk,
+            cumpart_ext,
+            *index_groupers,
+            columns=0 if columns is None else columns,
+            chunk=M.last,
+            meta=meta,
+            token=name_last
+        )
 
         # aggregate cumulated partitions and its previous last element
         _hash = tokenize(self, token, chunk, aggregate, initial)
-        name += '-' + _hash
-        name_cum += '-' + _hash
+        name += "-" + _hash
+        name_cum += "-" + _hash
         dask = {}
         dask[(name, 0)] = (cumpart_raw._name, 0)
 
@@ -900,15 +1045,25 @@ class _GroupBy(object):
                 dask[(name_cum, i)] = (cumlast._name, i - 1)
             else:
                 # aggregate with previous cumulation results
-                dask[(name_cum, i)] = (_cum_agg_filled,
-                                       (name_cum, i - 1),
-                                       (cumlast._name, i - 1),
-                                       aggregate, initial)
-            dask[(name, i)] = (_cum_agg_aligned,
-                               (cumpart_ext._name, i), (name_cum, i),
-                               index, 0 if columns is None else columns,
-                               aggregate, initial)
-        graph = HighLevelGraph.from_collections(name, dask, dependencies=[cumpart_raw, cumpart_ext, cumlast])
+                dask[(name_cum, i)] = (
+                    _cum_agg_filled,
+                    (name_cum, i - 1),
+                    (cumlast._name, i - 1),
+                    aggregate,
+                    initial,
+                )
+            dask[(name, i)] = (
+                _cum_agg_aligned,
+                (cumpart_ext._name, i),
+                (name_cum, i),
+                index,
+                0 if columns is None else columns,
+                aggregate,
+                initial,
+            )
+        graph = HighLevelGraph.from_collections(
+            name, dask, dependencies=[cumpart_raw, cumpart_ext, cumlast]
+        )
         return new_dd_object(graph, name, chunk(self._meta), self.obj.divisions)
 
     @derived_from(pd.core.groupby.GroupBy)
@@ -916,63 +1071,62 @@ class _GroupBy(object):
         if axis:
             return self.obj.cumsum(axis=axis)
         else:
-            return self._cum_agg('cumsum',
-                                 chunk=M.cumsum,
-                                 aggregate=M.add,
-                                 initial=0)
+            return self._cum_agg("cumsum", chunk=M.cumsum, aggregate=M.add, initial=0)
 
     @derived_from(pd.core.groupby.GroupBy)
     def cumprod(self, axis=0):
         if axis:
             return self.obj.cumprod(axis=axis)
         else:
-            return self._cum_agg('cumprod',
-                                 chunk=M.cumprod,
-                                 aggregate=M.mul,
-                                 initial=1)
+            return self._cum_agg("cumprod", chunk=M.cumprod, aggregate=M.mul, initial=1)
 
     @derived_from(pd.core.groupby.GroupBy)
     def cumcount(self, axis=None):
-        return self._cum_agg('cumcount',
-                             chunk=M.cumcount,
-                             aggregate=_cumcount_aggregate,
-                             initial=-1)
+        return self._cum_agg(
+            "cumcount", chunk=M.cumcount, aggregate=_cumcount_aggregate, initial=-1
+        )
 
     @derived_from(pd.core.groupby.GroupBy)
     def sum(self, split_every=None, split_out=1, min_count=None):
-        result = self._aca_agg(token='sum', func=M.sum, split_every=split_every,
-                               split_out=split_out)
+        result = self._aca_agg(
+            token="sum", func=M.sum, split_every=split_every, split_out=split_out
+        )
         if min_count:
-            return result.where(self.count() >= min_count,
-                                other=np.NaN)
+            return result.where(self.count() >= min_count, other=np.NaN)
         else:
             return result
 
     @derived_from(pd.core.groupby.GroupBy)
     def prod(self, split_every=None, split_out=1, min_count=None):
-        result = self._aca_agg(token='prod', func=M.prod, split_every=split_every,
-                               split_out=split_out)
+        result = self._aca_agg(
+            token="prod", func=M.prod, split_every=split_every, split_out=split_out
+        )
         if min_count:
-            return result.where(self.count() >= min_count,
-                                other=np.NaN)
+            return result.where(self.count() >= min_count, other=np.NaN)
         else:
             return result
 
     @derived_from(pd.core.groupby.GroupBy)
     def min(self, split_every=None, split_out=1):
-        return self._aca_agg(token='min', func=M.min, split_every=split_every,
-                             split_out=split_out)
+        return self._aca_agg(
+            token="min", func=M.min, split_every=split_every, split_out=split_out
+        )
 
     @derived_from(pd.core.groupby.GroupBy)
     def max(self, split_every=None, split_out=1):
-        return self._aca_agg(token='max', func=M.max, split_every=split_every,
-                             split_out=split_out)
+        return self._aca_agg(
+            token="max", func=M.max, split_every=split_every, split_out=split_out
+        )
 
     @derived_from(pd.core.groupby.GroupBy)
     def count(self, split_every=None, split_out=1):
-        return self._aca_agg(token='count', func=M.count,
-                             aggfunc=M.sum, split_every=split_every,
-                             split_out=split_out)
+        return self._aca_agg(
+            token="count",
+            func=M.count,
+            aggfunc=M.sum,
+            split_every=split_every,
+            split_out=split_out,
+        )
 
     @derived_from(pd.core.groupby.GroupBy)
     def mean(self, split_every=None, split_out=1):
@@ -984,20 +1138,31 @@ class _GroupBy(object):
 
     @derived_from(pd.core.groupby.GroupBy)
     def size(self, split_every=None, split_out=1):
-        return self._aca_agg(token='size', func=M.size, aggfunc=M.sum,
-                             split_every=split_every, split_out=split_out)
+        return self._aca_agg(
+            token="size",
+            func=M.size,
+            aggfunc=M.sum,
+            split_every=split_every,
+            split_out=split_out,
+        )
 
     @derived_from(pd.core.groupby.GroupBy)
     def var(self, ddof=1, split_every=None, split_out=1):
         levels = _determine_levels(self.index)
-        result = aca([self.obj, self.index] if not isinstance(self.index, list) else [self.obj] + self.index,
-                     chunk=_var_chunk,
-                     aggregate=_var_agg, combine=_var_combine,
-                     token=self._token_prefix + 'var',
-                     aggregate_kwargs={'ddof': ddof, 'levels': levels},
-                     combine_kwargs={'levels': levels},
-                     split_every=split_every, split_out=split_out,
-                     split_out_setup=split_out_on_index)
+        result = aca(
+            [self.obj, self.index]
+            if not isinstance(self.index, list)
+            else [self.obj] + self.index,
+            chunk=_var_chunk,
+            aggregate=_var_agg,
+            combine=_var_combine,
+            token=self._token_prefix + "var",
+            aggregate_kwargs={"ddof": ddof, "levels": levels},
+            combine_kwargs={"levels": levels},
+            split_every=split_every,
+            split_out=split_out,
+            split_out_setup=split_out_on_index,
+        )
 
         if isinstance(self.obj, Series):
             result = result[result.columns[0]]
@@ -1012,27 +1177,60 @@ class _GroupBy(object):
         result = map_partitions(np.sqrt, v, meta=v)
         return result
 
+    def cov(self, ddof=1, split_every=None, split_out=1):
+        levels = _determine_levels(self.index)
+        result = aca(
+            [self.obj, self.index]
+            if not isinstance(self.index, list)
+            else [self.obj] + self.index,
+            chunk=_cov_chunk,
+            aggregate=_cov_agg,
+            combine=_cov_combine,
+            token=self._token_prefix + "cov",
+            aggregate_kwargs={"ddof": ddof, "levels": levels},
+            combine_kwargs={"levels": levels},
+            split_every=split_every,
+            split_out=split_out,
+            split_out_setup=split_out_on_index,
+        )
+
+        if isinstance(self.obj, Series):
+            result = result[result.columns[0]]
+        if self._slice:
+            result = result[self._slice]
+
+        return result
+
     @derived_from(pd.core.groupby.GroupBy)
     def first(self, split_every=None, split_out=1):
-        return self._aca_agg(token='first', func=M.first, split_every=split_every,
-                             split_out=split_out)
+        return self._aca_agg(
+            token="first", func=M.first, split_every=split_every, split_out=split_out
+        )
 
     @derived_from(pd.core.groupby.GroupBy)
     def last(self, split_every=None, split_out=1):
-        return self._aca_agg(token='last', func=M.last, split_every=split_every,
-                             split_out=split_out)
+        return self._aca_agg(
+            token="last", func=M.last, split_every=split_every, split_out=split_out
+        )
 
     @derived_from(pd.core.groupby.GroupBy)
     def get_group(self, key):
-        token = self._token_prefix + 'get_group'
+        token = self._token_prefix + "get_group"
 
         meta = self._meta.obj
         if is_dataframe_like(meta) and self._slice is not None:
             meta = meta[self._slice]
         columns = meta.columns if is_dataframe_like(meta) else meta.name
 
-        return map_partitions(_groupby_get_group, self.obj, self.index, key,
-                              columns, meta=meta, token=token)
+        return map_partitions(
+            _groupby_get_group,
+            self.obj,
+            self.index,
+            key,
+            columns,
+            meta=meta,
+            token=token,
+        )
 
     def aggregate(self, arg, split_every, split_out=1):
         if isinstance(self.obj, DataFrame):
@@ -1040,8 +1238,9 @@ class _GroupBy(object):
                 group_columns = {self.index}
 
             elif isinstance(self.index, list):
-                group_columns = {i for i in self.index
-                                 if isinstance(i, tuple) or np.isscalar(i)}
+                group_columns = {
+                    i for i in self.index if isinstance(i, tuple) or np.isscalar(i)
+                }
 
             else:
                 group_columns = set()
@@ -1055,8 +1254,9 @@ class _GroupBy(object):
             else:
                 # NOTE: this step relies on the index normalization to replace
                 #       series with their name in an index.
-                non_group_columns = [col for col in self.obj.columns
-                                     if col not in group_columns]
+                non_group_columns = [
+                    col for col in self.obj.columns if col not in group_columns
+                ]
 
             spec = _normalize_spec(arg, non_group_columns)
 
@@ -1066,13 +1266,17 @@ class _GroupBy(object):
                 # None is used to denote the series itself. This pseudo column is
                 # removed from the result columns before passing the spec along.
                 spec = _normalize_spec({None: arg}, [])
-                spec = [(result_column, func, input_column)
-                        for ((_, result_column), func, input_column) in spec]
+                spec = [
+                    (result_column, func, input_column)
+                    for ((_, result_column), func, input_column) in spec
+                ]
 
             else:
                 spec = _normalize_spec({None: arg}, [])
-                spec = [(self.obj.name, func, input_column)
-                        for (_, func, input_column) in spec]
+                spec = [
+                    (self.obj.name, func, input_column)
+                    for (_, func, input_column) in spec
+                ]
 
         else:
             raise ValueError("aggregate on unknown object {}".format(self.obj))
@@ -1090,19 +1294,21 @@ class _GroupBy(object):
         else:
             chunk_args = [self.obj] + self.index
 
-        return aca(chunk_args,
-                   chunk=_groupby_apply_funcs,
-                   chunk_kwargs=dict(funcs=chunk_funcs),
-                   combine=_groupby_apply_funcs,
-                   combine_kwargs=dict(funcs=aggregate_funcs, level=levels),
-                   aggregate=_agg_finalize,
-                   aggregate_kwargs=dict(
-                       aggregate_funcs=aggregate_funcs,
-                       finalize_funcs=finalizers,
-                       level=levels,
-                   ),
-                   token='aggregate', split_every=split_every,
-                   split_out=split_out, split_out_setup=split_out_on_index)
+        return aca(
+            chunk_args,
+            chunk=_groupby_apply_funcs,
+            chunk_kwargs=dict(funcs=chunk_funcs),
+            combine=_groupby_apply_funcs,
+            combine_kwargs=dict(funcs=aggregate_funcs, level=levels),
+            aggregate=_agg_finalize,
+            aggregate_kwargs=dict(
+                aggregate_funcs=aggregate_funcs, finalize_funcs=finalizers, level=levels
+            ),
+            token="aggregate",
+            split_every=split_every,
+            split_out=split_out,
+            split_out_setup=split_out_on_index,
+        )
 
     @insert_meta_param_description(pad=12)
     def apply(self, func, *args, **kwargs):
@@ -1137,43 +1343,51 @@ class _GroupBy(object):
         -------
         applied : Series or DataFrame depending on columns keyword
         """
-        meta = kwargs.get('meta', no_default)
+        meta = kwargs.get("meta", no_default)
 
         if meta is no_default:
-            with raise_on_meta_error("groupby.apply({0})".format(funcname(func)), udf=True):
+            with raise_on_meta_error(
+                "groupby.apply({0})".format(funcname(func)), udf=True
+            ):
                 meta_args, meta_kwargs = _extract_meta((args, kwargs), nonempty=True)
                 meta = self._meta_nonempty.apply(func, *meta_args, **meta_kwargs)
 
-            msg = ("`meta` is not specified, inferred from partial data. "
-                   "Please provide `meta` if the result is unexpected.\n"
-                   "  Before: .apply(func)\n"
-                   "  After:  .apply(func, meta={'x': 'f8', 'y': 'f8'}) for dataframe result\n"
-                   "  or:     .apply(func, meta=('x', 'f8'))            for series result")
+            msg = (
+                "`meta` is not specified, inferred from partial data. "
+                "Please provide `meta` if the result is unexpected.\n"
+                "  Before: .apply(func)\n"
+                "  After:  .apply(func, meta={'x': 'f8', 'y': 'f8'}) for dataframe result\n"
+                "  or:     .apply(func, meta=('x', 'f8'))            for series result"
+            )
             warnings.warn(msg, stacklevel=2)
 
         meta = make_meta(meta)
 
         # Validate self.index
-        if (isinstance(self.index, list) and
-                any(isinstance(item, Series) for item in self.index)):
-            raise NotImplementedError("groupby-apply with a multiple Series "
-                                      "is currently not supported")
+        if isinstance(self.index, list) and any(
+            isinstance(item, Series) for item in self.index
+        ):
+            raise NotImplementedError(
+                "groupby-apply with a multiple Series " "is currently not supported"
+            )
 
         df = self.obj
-        should_shuffle = not (df.known_divisions and
-                              df._contains_index_name(self.index))
+        should_shuffle = not (
+            df.known_divisions and df._contains_index_name(self.index)
+        )
 
         if should_shuffle:
             if isinstance(self.obj, Series):
                 # Temporarily convert series to dataframe for shuffle
-                df = df.to_frame('__series__')
+                df = df.to_frame("__series__")
                 convert_back_to_series = True
             else:
                 convert_back_to_series = False
 
             if isinstance(self.index, DataFrame):  # add index columns to dataframe
-                df2 = df.assign(**{'_index_' + c: self.index[c]
-                                   for c in self.index.columns})
+                df2 = df.assign(
+                    **{"_index_" + c: self.index[c] for c in self.index.columns}
+                )
                 index = self.index
             elif isinstance(self.index, Series):
                 df2 = df.assign(_index=self.index)
@@ -1186,43 +1400,50 @@ class _GroupBy(object):
 
             if isinstance(self.index, DataFrame):
                 # extract index from dataframe
-                cols = ['_index_' + c for c in self.index.columns]
+                cols = ["_index_" + c for c in self.index.columns]
                 index2 = df3[cols]
                 if is_dataframe_like(meta):
                     df4 = df3.map_partitions(drop_columns, cols, meta.columns.dtype)
                 else:
                     df4 = df3.drop(cols, axis=1)
             elif isinstance(self.index, Series):
-                index2 = df3['_index']
+                index2 = df3["_index"]
                 index2.name = self.index.name
                 if is_dataframe_like(meta):
-                    df4 = df3.map_partitions(drop_columns, '_index',
-                                             meta.columns.dtype)
+                    df4 = df3.map_partitions(drop_columns, "_index", meta.columns.dtype)
                 else:
-                    df4 = df3.drop('_index', axis=1)
+                    df4 = df3.drop("_index", axis=1)
             else:
                 df4 = df3
                 index2 = self.index
 
             if convert_back_to_series:
-                df4 = df4['__series__'].rename(self.obj.name)
+                df4 = df4["__series__"].rename(self.obj.name)
 
         else:
             df4 = df
             index2 = self.index
 
         # Perform embarrassingly parallel groupby-apply
-        kwargs['meta'] = meta
-        df5 = map_partitions(_groupby_slice_apply, df4, index2,
-                             self._slice, func, token=funcname(func), *args, group_keys=self.group_keys,
-                             **kwargs)
+        kwargs["meta"] = meta
+        df5 = map_partitions(
+            _groupby_slice_apply,
+            df4,
+            index2,
+            self._slice,
+            func,
+            token=funcname(func),
+            *args,
+            group_keys=self.group_keys,
+            **kwargs
+        )
 
         return df5
 
 
 class DataFrameGroupBy(_GroupBy):
 
-    _token_prefix = 'dataframe-groupby-'
+    _token_prefix = "dataframe-groupby-"
 
     def __getitem__(self, key):
         if isinstance(key, list):
@@ -1235,9 +1456,13 @@ class DataFrameGroupBy(_GroupBy):
         return g
 
     def __dir__(self):
-        return sorted(set(dir(type(self)) + list(self.__dict__) +
-                      list(filter(compatibility.isidentifier,
-                                  self.obj.columns))))
+        return sorted(
+            set(
+                dir(type(self))
+                + list(self.__dict__)
+                + list(filter(compatibility.isidentifier, self.obj.columns))
+            )
+        )
 
     def __getattr__(self, key):
         try:
@@ -1247,10 +1472,12 @@ class DataFrameGroupBy(_GroupBy):
 
     @derived_from(pd.core.groupby.DataFrameGroupBy)
     def aggregate(self, arg, split_every=None, split_out=1):
-        if arg == 'size':
+        if arg == "size":
             return self.size()
 
-        return super(DataFrameGroupBy, self).aggregate(arg, split_every=split_every, split_out=split_out)
+        return super(DataFrameGroupBy, self).aggregate(
+            arg, split_every=split_every, split_out=split_out
+        )
 
     @derived_from(pd.core.groupby.DataFrameGroupBy)
     def agg(self, arg, split_every=None, split_out=1):
@@ -1259,7 +1486,7 @@ class DataFrameGroupBy(_GroupBy):
 
 class SeriesGroupBy(_GroupBy):
 
-    _token_prefix = 'series-groupby-'
+    _token_prefix = "series-groupby-"
 
     def __init__(self, df, by=None, slice=None, **kwargs):
         # for any non series object, raise pandas-compat error message
@@ -1271,8 +1498,7 @@ class SeriesGroupBy(_GroupBy):
                 if len(by) == 0:
                     raise ValueError("No group keys passed!")
 
-                non_series_items = [item for item in by
-                                    if not isinstance(item, Series)]
+                non_series_items = [item for item in by if not isinstance(item, Series)]
                 # raise error from pandas, if applicable
                 df._meta.groupby(non_series_items)
             else:
@@ -1291,20 +1517,27 @@ class SeriesGroupBy(_GroupBy):
         else:
             chunk = _nunique_series_chunk
 
-        return aca([self.obj, self.index] if not isinstance(self.index, list) else [self.obj] + self.index,
-                   chunk=chunk,
-                   aggregate=_nunique_df_aggregate,
-                   combine=_nunique_df_combine,
-                   token='series-groupby-nunique',
-                   chunk_kwargs={'levels': levels, 'name': name},
-                   aggregate_kwargs={'levels': levels, 'name': name},
-                   combine_kwargs={'levels': levels},
-                   split_every=split_every, split_out=split_out,
-                   split_out_setup=split_out_on_index)
+        return aca(
+            [self.obj, self.index]
+            if not isinstance(self.index, list)
+            else [self.obj] + self.index,
+            chunk=chunk,
+            aggregate=_nunique_df_aggregate,
+            combine=_nunique_df_combine,
+            token="series-groupby-nunique",
+            chunk_kwargs={"levels": levels, "name": name},
+            aggregate_kwargs={"levels": levels, "name": name},
+            combine_kwargs={"levels": levels},
+            split_every=split_every,
+            split_out=split_out,
+            split_out_setup=split_out_on_index,
+        )
 
     @derived_from(pd.core.groupby.SeriesGroupBy)
     def aggregate(self, arg, split_every=None, split_out=1):
-        result = super(SeriesGroupBy, self).aggregate(arg, split_every=split_every, split_out=split_out)
+        result = super(SeriesGroupBy, self).aggregate(
+            arg, split_every=split_every, split_out=split_out
+        )
         if self._slice:
             result = result[self._slice]
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -15,6 +15,7 @@ from dask.dataframe.utils import (
 
 AGG_FUNCS = ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'cov', 'nunique', 'first', 'last', 'prod']
 
+
 @pytest.fixture(params=AGG_FUNCS)
 def agg_func(request):
     """
@@ -979,11 +980,10 @@ def test_dataframe_aggregations_multilevel(grouper, agg_func):
 
     ddf = dd.from_pandas(pdf, npartitions=10)
 
-
     # covariance only works with N+1 columns
     if agg_func != 'cov':
         assert_eq(call(pdf.groupby(grouper(pdf))['c'], agg_func),
-                call(ddf.groupby(grouper(ddf))['c'], agg_func, split_every=2))
+                  call(ddf.groupby(grouper(ddf))['c'], agg_func, split_every=2))
 
     # not supported by pandas
     if agg_func != 'nunique':
@@ -998,7 +998,7 @@ def test_dataframe_aggregations_multilevel(grouper, agg_func):
             assert_eq(df, call(ddf.groupby(grouper(ddf)), agg_func, split_every=2))
         else:
             assert_eq(call(pdf.groupby(grouper(pdf)), agg_func),
-                    call(ddf.groupby(grouper(ddf)), agg_func, split_every=2))
+                      call(ddf.groupby(grouper(ddf)), agg_func, split_every=2))
 
 
 @pytest.mark.parametrize('grouper', [
@@ -1014,6 +1014,10 @@ def test_series_aggregations_multilevel(grouper, agg_func):
 
     def call(g, m, **kwargs):
         return getattr(g, m)(**kwargs)
+
+    # covariance is not a series aggregation
+    if agg_func == 'cov':
+        return
 
     pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
                         'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -991,7 +991,7 @@ def test_dataframe_aggregations_multilevel(grouper, agg_func):
                   call(ddf.groupby(grouper(ddf))[['c', 'd']], agg_func, split_every=2))
 
         assert_eq(call(pdf.groupby(grouper(pdf)), agg_func),
-                    call(ddf.groupby(grouper(ddf)), agg_func, split_every=2))
+                  call(ddf.groupby(grouper(ddf)), agg_func, split_every=2))
 
 
 @pytest.mark.parametrize('grouper', [
@@ -1630,6 +1630,7 @@ def test_groupby_group_keys():
 
     expected = pdf.groupby('a', group_keys=False).apply(func)
     assert_eq(expected, ddf.groupby('a', group_keys=False).apply(func, meta=expected))
+
 
 @pytest.mark.parametrize('columns', [
                          ['a', 'b', 'c'],

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1640,7 +1640,6 @@ def test_groupby_group_keys():
 def test_groupby_cov(columns):
     rows = 20
     cols = 3
-    np.random.seed(11)
     data = np.random.randn(rows, cols)
     df = pd.DataFrame(data, columns=columns)
     df["key"] = np.random.randint(0, cols, size=rows)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -283,7 +283,7 @@ def test_groupby_multilevel_getitem(grouper, agg_func):
     pandas_group = grouper(df)
 
     # covariance only works with N+1 columns
-    if not isinstance(pandas_group, pd.core.groupby.generic.DataFrameGroupBy):
+    if isinstance(pandas_group, pd.core.groupby.SeriesGroupBy) and agg_func == 'cov':
         return
 
     dask_agg = getattr(dask_group, agg_func)
@@ -993,7 +993,7 @@ def test_dataframe_aggregations_multilevel(grouper, agg_func):
         if agg_func == 'cov':
             # stacking in covariance leads to a sorted index:
             df = call(pdf.groupby(grouper(pdf)), agg_func).sort_index()
-            cols = sorted(df.columns.to_list())
+            cols = sorted(list(df.columns))
             df = df[cols]
             assert_eq(df, call(ddf.groupby(grouper(ddf)), agg_func, split_every=2))
         else:

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -282,6 +282,10 @@ def test_groupby_multilevel_getitem(grouper, agg_func):
     dask_group = grouper(ddf)
     pandas_group = grouper(df)
 
+    # covariance only works with N+1 columns
+    if not isinstance(pandas_group, pd.core.groupby.generic.DataFrameGroupBy):
+        return
+
     dask_agg = getattr(dask_group, agg_func)
     pandas_agg = getattr(pandas_group, agg_func)
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -13,7 +13,7 @@ from dask.dataframe.utils import (
     assert_eq, assert_dask_graph, assert_max_deps, PANDAS_VERSION,
 )
 
-AGG_FUNCS = ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'nunique', 'first', 'last', 'prod']
+AGG_FUNCS = ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'cov', 'nunique', 'first', 'last', 'prod']
 
 
 @pytest.fixture(params=AGG_FUNCS)
@@ -270,7 +270,6 @@ def test_groupby_on_index(scheduler):
                           lambda df: df.groupby(['a', 'b', 'c'])])
 def test_groupby_multilevel_getitem(grouper, agg_func):
     # nunique is not implemented for DataFrameGroupBy
-    breakpoint()
     if agg_func == 'nunique':
         return
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -10,26 +10,10 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.dataframe.utils import (
-    assert_eq,
-    assert_dask_graph,
-    assert_max_deps,
-    PANDAS_VERSION,
+    assert_eq, assert_dask_graph, assert_max_deps, PANDAS_VERSION,
 )
 
-AGG_FUNCS = [
-    "sum",
-    "mean",
-    "min",
-    "max",
-    "count",
-    "size",
-    "std",
-    "var",
-    "nunique",
-    "first",
-    "last",
-    "prod",
-]
+AGG_FUNCS = ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'nunique', 'first', 'last', 'prod']
 
 
 @pytest.fixture(params=AGG_FUNCS)
@@ -41,42 +25,43 @@ def agg_func(request):
 
 
 def groupby_internal_repr():
-    pdf = pd.DataFrame({"x": [1, 2, 3, 4, 6, 7, 8, 9, 10], "y": list("abcbabbcda")})
+    pdf = pd.DataFrame({'x': [1, 2, 3, 4, 6, 7, 8, 9, 10],
+                        'y': list('abcbabbcda')})
     ddf = dd.from_pandas(pdf, 3)
 
-    gp = pdf.groupby("y")
-    dp = ddf.groupby("y")
+    gp = pdf.groupby('y')
+    dp = ddf.groupby('y')
     assert isinstance(dp, dd.groupby.DataFrameGroupBy)
     assert isinstance(dp._meta, pd.core.groupby.DataFrameGroupBy)
     assert isinstance(dp.obj, dd.DataFrame)
     assert_eq(dp.obj, gp.obj)
 
-    gp = pdf.groupby("y")["x"]
-    dp = ddf.groupby("y")["x"]
+    gp = pdf.groupby('y')['x']
+    dp = ddf.groupby('y')['x']
     assert isinstance(dp, dd.groupby.SeriesGroupBy)
     assert isinstance(dp._meta, pd.core.groupby.SeriesGroupBy)
     # slicing should not affect to internal
     assert isinstance(dp.obj, dd.Series)
     assert_eq(dp.obj, gp.obj)
 
-    gp = pdf.groupby("y")[["x"]]
-    dp = ddf.groupby("y")[["x"]]
+    gp = pdf.groupby('y')[['x']]
+    dp = ddf.groupby('y')[['x']]
     assert isinstance(dp, dd.groupby.DataFrameGroupBy)
     assert isinstance(dp._meta, pd.core.groupby.DataFrameGroupBy)
     # slicing should not affect to internal
     assert isinstance(dp.obj, dd.DataFrame)
     assert_eq(dp.obj, gp.obj)
 
-    gp = pdf.groupby(pdf.y)["x"]
-    dp = ddf.groupby(ddf.y)["x"]
+    gp = pdf.groupby(pdf.y)['x']
+    dp = ddf.groupby(ddf.y)['x']
     assert isinstance(dp, dd.groupby.SeriesGroupBy)
     assert isinstance(dp._meta, pd.core.groupby.SeriesGroupBy)
     # slicing should not affect to internal
     assert isinstance(dp.obj, dd.Series)
     assert_eq(dp.obj, gp.obj)
 
-    gp = pdf.groupby(pdf.y)[["x"]]
-    dp = ddf.groupby(ddf.y)[["x"]]
+    gp = pdf.groupby(pdf.y)[['x']]
+    dp = ddf.groupby(ddf.y)[['x']]
     assert isinstance(dp, dd.groupby.DataFrameGroupBy)
     assert isinstance(dp._meta, pd.core.groupby.DataFrameGroupBy)
     # slicing should not affect to internal
@@ -85,68 +70,69 @@ def groupby_internal_repr():
 
 
 def groupby_error():
-    pdf = pd.DataFrame({"x": [1, 2, 3, 4, 6, 7, 8, 9, 10], "y": list("abcbabbcda")})
+    pdf = pd.DataFrame({'x': [1, 2, 3, 4, 6, 7, 8, 9, 10],
+                        'y': list('abcbabbcda')})
     ddf = dd.from_pandas(pdf, 3)
 
     with pytest.raises(KeyError):
-        ddf.groupby("A")
+        ddf.groupby('A')
 
     with pytest.raises(KeyError):
-        ddf.groupby(["x", "A"])
+        ddf.groupby(['x', 'A'])
 
-    dp = ddf.groupby("y")
+    dp = ddf.groupby('y')
 
-    msg = "Column not found: "
+    msg = 'Column not found: '
     with pytest.raises(KeyError) as err:
-        dp["A"]
+        dp['A']
     assert msg in str(err.value)
 
     with pytest.raises(KeyError) as err:
-        dp[["x", "A"]]
+        dp[['x', 'A']]
     assert msg in str(err.value)
 
 
 def groupby_internal_head():
-    pdf = pd.DataFrame(
-        {"A": [1, 2] * 10, "B": np.random.randn(20), "C": np.random.randn(20)}
-    )
+    pdf = pd.DataFrame({'A': [1, 2] * 10,
+                        'B': np.random.randn(20),
+                        'C': np.random.randn(20)})
     ddf = dd.from_pandas(pdf, 3)
 
-    assert_eq(ddf.groupby("A")._head().sum(), pdf.head().groupby("A").sum())
+    assert_eq(ddf.groupby('A')._head().sum(),
+              pdf.head().groupby('A').sum())
 
-    assert_eq(ddf.groupby(ddf["A"])._head().sum(), pdf.head().groupby(pdf["A"]).sum())
+    assert_eq(ddf.groupby(ddf['A'])._head().sum(),
+              pdf.head().groupby(pdf['A']).sum())
 
-    assert_eq(
-        ddf.groupby(ddf["A"] + 1)._head().sum(), pdf.head().groupby(pdf["A"] + 1).sum()
-    )
+    assert_eq(ddf.groupby(ddf['A'] + 1)._head().sum(),
+              pdf.head().groupby(pdf['A'] + 1).sum())
 
 
 def test_full_groupby():
-    df = pd.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-        index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
-    )
+    df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                       'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
+                      index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
     ddf = dd.from_pandas(df, npartitions=3)
 
-    pytest.raises(KeyError, lambda: ddf.groupby("does_not_exist"))
-    pytest.raises(AttributeError, lambda: ddf.groupby("a").does_not_exist)
-    assert "b" in dir(ddf.groupby("a"))
+    pytest.raises(KeyError, lambda: ddf.groupby('does_not_exist'))
+    pytest.raises(AttributeError, lambda: ddf.groupby('a').does_not_exist)
+    assert 'b' in dir(ddf.groupby('a'))
 
     def func(df):
         return df.assign(b=df.b - df.b.mean())
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        assert ddf.groupby("a").apply(func)._name.startswith("func")
+        warnings.simplefilter('ignore')
+        assert ddf.groupby('a').apply(func)._name.startswith('func')
 
-        assert_eq(df.groupby("a").apply(func), ddf.groupby("a").apply(func))
+        assert_eq(df.groupby('a').apply(func),
+                  ddf.groupby('a').apply(func))
 
 
 def test_full_groupby_apply_multiarg():
-    df = pd.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-        index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
-    )
+    df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                       'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
+                      index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
     ddf = dd.from_pandas(df, npartitions=3)
 
     def func(df, c, d=3):
@@ -160,83 +146,61 @@ def test_full_groupby_apply_multiarg():
     c_delayed = dask.delayed(lambda: c)()
     d_delayed = dask.delayed(lambda: d)()
 
-    meta = df.groupby("a").apply(func, c)
+    meta = df.groupby('a').apply(func, c)
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        assert_eq(
-            df.groupby("a").apply(func, c, d=d),
-            ddf.groupby("a").apply(func, c, d=d_scalar),
-        )
+        warnings.simplefilter('ignore')
+        assert_eq(df.groupby('a').apply(func, c, d=d),
+                  ddf.groupby('a').apply(func, c, d=d_scalar))
 
-        assert_eq(df.groupby("a").apply(func, c), ddf.groupby("a").apply(func, c))
+        assert_eq(df.groupby('a').apply(func, c),
+                  ddf.groupby('a').apply(func, c))
 
-        assert_eq(
-            df.groupby("a").apply(func, c, d=d), ddf.groupby("a").apply(func, c, d=d)
-        )
+        assert_eq(df.groupby('a').apply(func, c, d=d),
+                  ddf.groupby('a').apply(func, c, d=d))
 
-        assert_eq(
-            df.groupby("a").apply(func, c),
-            ddf.groupby("a").apply(func, c_scalar),
-            check_dtype=False,
-        )
+        assert_eq(df.groupby('a').apply(func, c),
+                  ddf.groupby('a').apply(func, c_scalar), check_dtype=False)
 
-        assert_eq(
-            df.groupby("a").apply(func, c),
-            ddf.groupby("a").apply(func, c_scalar, meta=meta),
-        )
+        assert_eq(df.groupby('a').apply(func, c),
+                  ddf.groupby('a').apply(func, c_scalar, meta=meta))
 
-        assert_eq(
-            df.groupby("a").apply(func, c, d=d),
-            ddf.groupby("a").apply(func, c, d=d_scalar, meta=meta),
-        )
+        assert_eq(df.groupby('a').apply(func, c, d=d),
+                  ddf.groupby('a').apply(func, c, d=d_scalar, meta=meta))
 
     # Delayed arguments work, but only if metadata is provided
     with pytest.raises(ValueError) as exc:
-        ddf.groupby("a").apply(func, c, d=d_delayed)
-    assert "dask.delayed" in str(exc.value) and "meta" in str(exc.value)
+        ddf.groupby('a').apply(func, c, d=d_delayed)
+    assert 'dask.delayed' in str(exc.value) and 'meta'in str(exc.value)
 
     with pytest.raises(ValueError) as exc:
-        ddf.groupby("a").apply(func, c_delayed, d=d)
-    assert "dask.delayed" in str(exc.value) and "meta" in str(exc.value)
+        ddf.groupby('a').apply(func, c_delayed, d=d)
+    assert 'dask.delayed' in str(exc.value) and 'meta'in str(exc.value)
 
-    assert_eq(
-        df.groupby("a").apply(func, c),
-        ddf.groupby("a").apply(func, c_delayed, meta=meta),
-    )
+    assert_eq(df.groupby('a').apply(func, c),
+              ddf.groupby('a').apply(func, c_delayed, meta=meta))
 
-    assert_eq(
-        df.groupby("a").apply(func, c, d=d),
-        ddf.groupby("a").apply(func, c, d=d_delayed, meta=meta),
-    )
+    assert_eq(df.groupby('a').apply(func, c, d=d),
+              ddf.groupby('a').apply(func, c, d=d_delayed, meta=meta))
 
 
-@pytest.mark.parametrize(
-    "grouper",
-    [
-        lambda df: ["a"],
-        lambda df: ["a", "b"],
-        lambda df: df["a"],
-        lambda df: [df["a"], df["b"]],
-        pytest.param(
-            lambda df: [df["a"] > 2, df["b"] > 1],
-            marks=pytest.mark.xfail(reason="not yet supported"),
-        ),
-    ],
-)
-@pytest.mark.parametrize("reverse", [True, False])
+@pytest.mark.parametrize('grouper', [
+    lambda df: ['a'],
+    lambda df: ['a', 'b'],
+    lambda df: df['a'],
+    lambda df: [df['a'], df['b']],
+    pytest.param(lambda df: [df['a'] > 2, df['b'] > 1], marks=pytest.mark.xfail(
+        reason="not yet supported"))
+])
+@pytest.mark.parametrize('reverse', [True, False])
 def test_full_groupby_multilevel(grouper, reverse):
     index = [0, 1, 3, 5, 6, 8, 9, 9, 9]
     if reverse:
         index = index[::-1]
-    df = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5, 6, 7, 8, 9],
-            "d": [1, 2, 3, 4, 5, 6, 7, 8, 9],
-            "b": [4, 5, 6, 3, 2, 1, 0, 0, 0],
-        },
-        index=index,
-    )
+    df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                       'd': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                       'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
+                      index=index)
     ddf = dd.from_pandas(df, npartitions=3)
 
     def func(df):
@@ -245,91 +209,75 @@ def test_full_groupby_multilevel(grouper, reverse):
     # last one causes a DeprcationWarning from pandas.
     # See https://github.com/pandas-dev/pandas/issues/16481
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        assert_eq(
-            df.groupby(grouper(df)).apply(func), ddf.groupby(grouper(ddf)).apply(func)
-        )
+        warnings.simplefilter('ignore')
+        assert_eq(df.groupby(grouper(df)).apply(func),
+                  ddf.groupby(grouper(ddf)).apply(func))
 
 
 def test_groupby_dir():
-    df = pd.DataFrame({"a": range(10), "b c d e": range(10)})
+    df = pd.DataFrame({'a': range(10), 'b c d e': range(10)})
     ddf = dd.from_pandas(df, npartitions=2)
-    g = ddf.groupby("a")
-    assert "a" in dir(g)
-    assert "b c d e" not in dir(g)
+    g = ddf.groupby('a')
+    assert 'a' in dir(g)
+    assert 'b c d e' not in dir(g)
 
 
-@pytest.mark.parametrize("scheduler", ["sync", "threads"])
+@pytest.mark.parametrize('scheduler', ['sync', 'threads'])
 def test_groupby_on_index(scheduler):
-    pdf = pd.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-        index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
-    )
+    pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                        'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
+                       index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
     ddf = dd.from_pandas(pdf, npartitions=3)
 
-    ddf2 = ddf.set_index("a")
-    pdf2 = pdf.set_index("a")
-    assert_eq(ddf.groupby("a").b.mean(), ddf2.groupby(ddf2.index).b.mean())
+    ddf2 = ddf.set_index('a')
+    pdf2 = pdf.set_index('a')
+    assert_eq(ddf.groupby('a').b.mean(), ddf2.groupby(ddf2.index).b.mean())
 
     def func(df):
         return df.assign(b=df.b - df.b.mean())
 
     def func2(df):
-        return df[["b"]] - df[["b"]].mean()
+        return df[['b']] - df[['b']].mean()
 
     def func3(df):
         return df.mean()
 
     with dask.config.set(scheduler=scheduler):
         with pytest.warns(None):
-            assert_eq(ddf.groupby("a").apply(func), pdf.groupby("a").apply(func))
+            assert_eq(ddf.groupby('a').apply(func),
+                      pdf.groupby('a').apply(func))
 
-            assert_eq(
-                ddf.groupby("a").apply(func).set_index("a"),
-                pdf.groupby("a").apply(func).set_index("a"),
-            )
+            assert_eq(ddf.groupby('a').apply(func).set_index('a'),
+                      pdf.groupby('a').apply(func).set_index('a'))
 
-            assert_eq(
-                pdf2.groupby(pdf2.index).apply(func2),
-                ddf2.groupby(ddf2.index).apply(func2),
-            )
+            assert_eq(pdf2.groupby(pdf2.index).apply(func2),
+                      ddf2.groupby(ddf2.index).apply(func2))
 
-            assert_eq(
-                ddf2.b.groupby("a").apply(func3), pdf2.b.groupby("a").apply(func3)
-            )
+            assert_eq(ddf2.b.groupby('a').apply(func3),
+                      pdf2.b.groupby('a').apply(func3))
 
-            assert_eq(
-                ddf2.b.groupby(ddf2.index).apply(func3),
-                pdf2.b.groupby(pdf2.index).apply(func3),
-            )
+            assert_eq(ddf2.b.groupby(ddf2.index).apply(func3),
+                      pdf2.b.groupby(pdf2.index).apply(func3))
 
 
-@pytest.mark.parametrize(
-    "grouper",
-    [
-        lambda df: df.groupby("a")["b"],
-        lambda df: df.groupby(["a", "b"]),
-        lambda df: df.groupby(["a", "b"])["c"],
-        lambda df: df.groupby(df["a"])[["b", "c"]],
-        lambda df: df.groupby("a")[["b", "c"]],
-        lambda df: df.groupby("a")[["b"]],
-        lambda df: df.groupby(["a", "b", "c"]),
-    ],
-)
+@pytest.mark.parametrize('grouper',
+                         [lambda df: df.groupby('a')['b'],
+                          lambda df: df.groupby(['a', 'b']),
+                          lambda df: df.groupby(['a', 'b'])['c'],
+                          lambda df: df.groupby(df['a'])[['b', 'c']],
+                          lambda df: df.groupby('a')[['b', 'c']],
+                          lambda df: df.groupby('a')[['b']],
+                          lambda df: df.groupby(['a', 'b', 'c'])])
 def test_groupby_multilevel_getitem(grouper, agg_func):
     # nunique is not implemented for DataFrameGroupBy
     breakpoint()
-    if agg_func == "nunique":
+    if agg_func == 'nunique':
         return
 
-    df = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 1, 2, 3],
-            "b": [1, 2, 1, 4, 2, 1],
-            "c": [1, 3, 2, 1, 1, 2],
-            "d": [1, 2, 1, 1, 2, 2],
-        }
-    )
+    df = pd.DataFrame({'a': [1, 2, 3, 1, 2, 3],
+                       'b': [1, 2, 1, 4, 2, 1],
+                       'c': [1, 3, 2, 1, 1, 2],
+                       'd': [1, 2, 1, 1, 2, 2]})
     ddf = dd.from_pandas(df, 2)
 
     dask_group = grouper(ddf)
@@ -341,47 +289,45 @@ def test_groupby_multilevel_getitem(grouper, agg_func):
     assert isinstance(dask_group, dd.groupby._GroupBy)
     assert isinstance(pandas_group, pd.core.groupby.GroupBy)
 
-    if agg_func == "mean":
+    if agg_func == 'mean':
         assert_eq(dask_agg(), pandas_agg().astype(float))
     else:
         assert_eq(dask_agg(), pandas_agg())
 
 
 def test_groupby_multilevel_agg():
-    df = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 1, 2, 3],
-            "b": [1, 2, 1, 4, 2, 1],
-            "c": [1, 3, 2, 1, 1, 2],
-            "d": [1, 2, 1, 1, 2, 2],
-        }
-    )
+    df = pd.DataFrame({'a': [1, 2, 3, 1, 2, 3],
+                       'b': [1, 2, 1, 4, 2, 1],
+                       'c': [1, 3, 2, 1, 1, 2],
+                       'd': [1, 2, 1, 1, 2, 2]})
     ddf = dd.from_pandas(df, 2)
 
-    sol = df.groupby(["a"]).mean()
-    res = ddf.groupby(["a"]).mean()
+    sol = df.groupby(['a']).mean()
+    res = ddf.groupby(['a']).mean()
     assert_eq(res, sol)
 
-    sol = df.groupby(["a", "c"]).mean()
-    res = ddf.groupby(["a", "c"]).mean()
+    sol = df.groupby(['a', 'c']).mean()
+    res = ddf.groupby(['a', 'c']).mean()
     assert_eq(res, sol)
 
-    sol = df.groupby([df["a"], df["c"]]).mean()
-    res = ddf.groupby([ddf["a"], ddf["c"]]).mean()
+    sol = df.groupby([df['a'], df['c']]).mean()
+    res = ddf.groupby([ddf['a'], ddf['c']]).mean()
     assert_eq(res, sol)
 
 
 def test_groupby_get_group():
-    dsk = {
-        ("x", 0): pd.DataFrame({"a": [1, 2, 6], "b": [4, 2, 7]}, index=[0, 1, 3]),
-        ("x", 1): pd.DataFrame({"a": [4, 2, 6], "b": [3, 3, 1]}, index=[5, 6, 8]),
-        ("x", 2): pd.DataFrame({"a": [4, 3, 7], "b": [1, 1, 3]}, index=[9, 9, 9]),
-    }
-    meta = dsk[("x", 0)]
-    d = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
+    dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 6], 'b': [4, 2, 7]},
+                                  index=[0, 1, 3]),
+           ('x', 1): pd.DataFrame({'a': [4, 2, 6], 'b': [3, 3, 1]},
+                                  index=[5, 6, 8]),
+           ('x', 2): pd.DataFrame({'a': [4, 3, 7], 'b': [1, 1, 3]},
+                                  index=[9, 9, 9])}
+    meta = dsk[('x', 0)]
+    d = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
     full = d.compute()
 
-    for ddkey, pdkey in [("b", "b"), (d.b, full.b), (d.b + 1, full.b + 1)]:
+    for ddkey, pdkey in [('b', 'b'), (d.b, full.b),
+                         (d.b + 1, full.b + 1)]:
         ddgrouped = d.groupby(ddkey)
         pdgrouped = full.groupby(pdkey)
         # DataFrame
@@ -393,30 +339,30 @@ def test_groupby_get_group():
 
 
 def test_dataframe_groupby_nunique():
-    strings = list("aaabbccccdddeee")
+    strings = list('aaabbccccdddeee')
     data = np.random.randn(len(strings))
     ps = pd.DataFrame(dict(strings=strings, data=data))
     s = dd.from_pandas(ps, npartitions=3)
-    expected = ps.groupby("strings")["data"].nunique()
-    assert_eq(s.groupby("strings")["data"].nunique(), expected)
+    expected = ps.groupby('strings')['data'].nunique()
+    assert_eq(s.groupby('strings')['data'].nunique(), expected)
 
 
 def test_dataframe_groupby_nunique_across_group_same_value():
-    strings = list("aaabbccccdddeee")
-    data = list(map(int, "123111223323412"))
+    strings = list('aaabbccccdddeee')
+    data = list(map(int, '123111223323412'))
     ps = pd.DataFrame(dict(strings=strings, data=data))
     s = dd.from_pandas(ps, npartitions=3)
-    expected = ps.groupby("strings")["data"].nunique()
-    assert_eq(s.groupby("strings")["data"].nunique(), expected)
+    expected = ps.groupby('strings')['data'].nunique()
+    assert_eq(s.groupby('strings')['data'].nunique(), expected)
 
 
 def test_series_groupby_propagates_names():
-    df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
     ddf = dd.from_pandas(df, 2)
-    func = lambda df: df["y"].sum()
+    func = lambda df: df['y'].sum()
     with pytest.warns(UserWarning):  # meta inference
-        result = ddf.groupby("x").apply(func)
-    expected = df.groupby("x").apply(func)
+        result = ddf.groupby('x').apply(func)
+    expected = df.groupby('x').apply(func)
     assert_eq(result, expected)
 
 
@@ -459,9 +405,9 @@ def test_series_groupby_errors():
         ss.groupby(sss)
 
     with pytest.raises(KeyError):
-        s.groupby("x")  # pandas
+        s.groupby('x')  # pandas
     with pytest.raises(KeyError):
-        ss.groupby("x")  # dask should raise the same error
+        ss.groupby('x')  # dask should raise the same error
 
 
 def test_groupby_index_array():
@@ -469,42 +415,36 @@ def test_groupby_index_array():
     ddf = dd.from_pandas(df, npartitions=2)
 
     # first select column, then group
-    assert_eq(
-        df.A.groupby(df.index.month).nunique(),
-        ddf.A.groupby(ddf.index.month).nunique(),
-        check_names=False,
-    )
+    assert_eq(df.A.groupby(df.index.month).nunique(),
+              ddf.A.groupby(ddf.index.month).nunique(), check_names=False)
 
     # first group, then select column
-    assert_eq(
-        df.groupby(df.index.month).A.nunique(),
-        ddf.groupby(ddf.index.month).A.nunique(),
-        check_names=False,
-    )
+    assert_eq(df.groupby(df.index.month).A.nunique(),
+              ddf.groupby(ddf.index.month).A.nunique(), check_names=False)
 
 
 def test_groupby_set_index():
     df = tm.makeTimeDataFrame()
     ddf = dd.from_pandas(df, npartitions=2)
-    pytest.raises(TypeError, lambda: ddf.groupby(df.index.month, as_index=False))
+    pytest.raises(TypeError,
+                  lambda: ddf.groupby(df.index.month, as_index=False))
 
 
-@pytest.mark.parametrize("empty", [True, False])
+@pytest.mark.parametrize('empty', [True, False])
 def test_split_apply_combine_on_series(empty):
     if empty:
-        pdf = pd.DataFrame({"a": [1.0], "b": [1.0]}, index=[0]).iloc[:0]
+        pdf = pd.DataFrame({'a': [1.], 'b': [1.]}, index=[0]).iloc[:0]
         # There's a bug in pandas where df.groupby(...).var(ddof=0) results in
         # no columns. Just skip these checks for now.
         ddofs = []
     else:
         ddofs = [0, 1, 2]
-        pdf = pd.DataFrame(
-            {"a": [1, 2, 6, 4, 4, 6, 4, 3, 7], "b": [4, 2, 7, 3, 3, 1, 1, 1, 2]},
-            index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
-        )
+        pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7],
+                            'b': [4, 2, 7, 3, 3, 1, 1, 1, 2]},
+                           index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
     ddf = dd.from_pandas(pdf, npartitions=3)
 
-    for ddkey, pdkey in [("b", "b"), (ddf.b, pdf.b), (ddf.b + 1, pdf.b + 1)]:
+    for ddkey, pdkey in [('b', 'b'), (ddf.b, pdf.b), (ddf.b + 1, pdf.b + 1)]:
         assert_eq(ddf.groupby(ddkey).a.min(), pdf.groupby(pdkey).a.min())
         assert_eq(ddf.groupby(ddkey).a.max(), pdf.groupby(pdkey).a.max())
         assert_eq(ddf.groupby(ddkey).a.count(), pdf.groupby(pdkey).a.count())
@@ -514,9 +454,12 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddkey).a.first(), pdf.groupby(pdkey).a.first())
         assert_eq(ddf.groupby(ddkey).a.last(), pdf.groupby(pdkey).a.last())
         for ddof in ddofs:
-            assert_eq(ddf.groupby(ddkey).a.var(ddof), pdf.groupby(pdkey).a.var(ddof))
-            assert_eq(ddf.groupby(ddkey).a.std(ddof), pdf.groupby(pdkey).a.std(ddof))
-            assert_eq(ddf.groupby(ddkey).a.cov(ddof), pdf.groupby(pdkey).a.cov(ddof))
+            assert_eq(ddf.groupby(ddkey).a.var(ddof),
+                      pdf.groupby(pdkey).a.var(ddof))
+            assert_eq(ddf.groupby(ddkey).a.std(ddof),
+                      pdf.groupby(pdkey).a.std(ddof))
+            assert_eq(ddf.groupby(ddkey).a.cov(ddof),
+                      pdf.groupby(pdkey).a.cov(ddof))
 
         assert_eq(ddf.groupby(ddkey).sum(), pdf.groupby(pdkey).sum())
         assert_eq(ddf.groupby(ddkey).min(), pdf.groupby(pdkey).min())
@@ -529,53 +472,28 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddkey).prod(), pdf.groupby(pdkey).prod())
 
         for ddof in ddofs:
-            assert_eq(
-                ddf.groupby(ddkey).var(ddof),
-                pdf.groupby(pdkey).var(ddof),
-                check_dtype=False,
-            )
-            assert_eq(
-                ddf.groupby(ddkey).std(ddof),
-                pdf.groupby(pdkey).std(ddof),
-                check_dtype=False,
-            )
+            assert_eq(ddf.groupby(ddkey).var(ddof),
+                      pdf.groupby(pdkey).var(ddof), check_dtype=False)
+            assert_eq(ddf.groupby(ddkey).std(ddof),
+                      pdf.groupby(pdkey).std(ddof), check_dtype=False)
 
     for ddkey, pdkey in [(ddf.b, pdf.b), (ddf.b + 1, pdf.b + 1)]:
-        assert_eq(
-            ddf.a.groupby(ddkey).sum(), pdf.a.groupby(pdkey).sum(), check_names=False
-        )
-        assert_eq(
-            ddf.a.groupby(ddkey).max(), pdf.a.groupby(pdkey).max(), check_names=False
-        )
-        assert_eq(
-            ddf.a.groupby(ddkey).count(),
-            pdf.a.groupby(pdkey).count(),
-            check_names=False,
-        )
-        assert_eq(
-            ddf.a.groupby(ddkey).mean(), pdf.a.groupby(pdkey).mean(), check_names=False
-        )
-        assert_eq(
-            ddf.a.groupby(ddkey).nunique(),
-            pdf.a.groupby(pdkey).nunique(),
-            check_names=False,
-        )
-        assert_eq(
-            ddf.a.groupby(ddkey).first(),
-            pdf.a.groupby(pdkey).first(),
-            check_names=False,
-        )
-        assert_eq(
-            ddf.a.groupby(ddkey).last(), pdf.a.groupby(pdkey).last(), check_names=False
-        )
-        assert_eq(
-            ddf.a.groupby(ddkey).prod(), pdf.a.groupby(pdkey).prod(), check_names=False
-        )
+        assert_eq(ddf.a.groupby(ddkey).sum(), pdf.a.groupby(pdkey).sum(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).max(), pdf.a.groupby(pdkey).max(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).count(), pdf.a.groupby(pdkey).count(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).mean(), pdf.a.groupby(pdkey).mean(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).nunique(), pdf.a.groupby(pdkey).nunique(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).first(), pdf.a.groupby(pdkey).first(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).last(), pdf.a.groupby(pdkey).last(), check_names=False)
+        assert_eq(ddf.a.groupby(ddkey).prod(), pdf.a.groupby(pdkey).prod(), check_names=False)
 
         for ddof in ddofs:
-            assert_eq(ddf.a.groupby(ddkey).var(ddof), pdf.a.groupby(pdkey).var(ddof))
-            assert_eq(ddf.a.groupby(ddkey).std(ddof), pdf.a.groupby(pdkey).std(ddof))
-            assert_eq(ddf.a.groupby(ddkey).cov(ddof), pdf.a.groupby(pdkey).cov(ddof))
+            assert_eq(ddf.a.groupby(ddkey).var(ddof),
+                      pdf.a.groupby(pdkey).var(ddof))
+            assert_eq(ddf.a.groupby(ddkey).std(ddof),
+                      pdf.a.groupby(pdkey).std(ddof))
+            assert_eq(ddf.a.groupby(ddkey).cov(ddof),
+                      pdf.a.groupby(pdkey).cov(ddof))
 
     for i in [0, 4, 7]:
         assert_eq(ddf.groupby(ddf.b > i).a.sum(), pdf.groupby(pdf.b > i).a.sum())
@@ -583,9 +501,7 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddf.b > i).a.max(), pdf.groupby(pdf.b > i).a.max())
         assert_eq(ddf.groupby(ddf.b > i).a.count(), pdf.groupby(pdf.b > i).a.count())
         assert_eq(ddf.groupby(ddf.b > i).a.mean(), pdf.groupby(pdf.b > i).a.mean())
-        assert_eq(
-            ddf.groupby(ddf.b > i).a.nunique(), pdf.groupby(pdf.b > i).a.nunique()
-        )
+        assert_eq(ddf.groupby(ddf.b > i).a.nunique(), pdf.groupby(pdf.b > i).a.nunique())
         assert_eq(ddf.groupby(ddf.b > i).a.size(), pdf.groupby(pdf.b > i).a.size())
         assert_eq(ddf.groupby(ddf.b > i).a.first(), pdf.groupby(pdf.b > i).a.first())
         assert_eq(ddf.groupby(ddf.b > i).a.last(), pdf.groupby(pdf.b > i).a.last())
@@ -596,9 +512,7 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddf.a > i).b.max(), pdf.groupby(pdf.a > i).b.max())
         assert_eq(ddf.groupby(ddf.a > i).b.count(), pdf.groupby(pdf.a > i).b.count())
         assert_eq(ddf.groupby(ddf.a > i).b.mean(), pdf.groupby(pdf.a > i).b.mean())
-        assert_eq(
-            ddf.groupby(ddf.a > i).b.nunique(), pdf.groupby(pdf.a > i).b.nunique()
-        )
+        assert_eq(ddf.groupby(ddf.a > i).b.nunique(), pdf.groupby(pdf.a > i).b.nunique())
         assert_eq(ddf.groupby(ddf.b > i).b.size(), pdf.groupby(pdf.b > i).b.size())
         assert_eq(ddf.groupby(ddf.b > i).b.first(), pdf.groupby(pdf.b > i).b.first())
         assert_eq(ddf.groupby(ddf.b > i).b.last(), pdf.groupby(pdf.b > i).b.last())
@@ -625,16 +539,11 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddf.a > i).prod(), pdf.groupby(pdf.a > i).prod())
 
         for ddof in ddofs:
-            assert_eq(
-                ddf.groupby(ddf.b > i).std(ddof), pdf.groupby(pdf.b > i).std(ddof)
-            )
+            assert_eq(ddf.groupby(ddf.b > i).std(ddof),
+                      pdf.groupby(pdf.b > i).std(ddof))
 
-    for ddkey, pdkey in [
-        ("a", "a"),
-        (ddf.a, pdf.a),
-        (ddf.a + 1, pdf.a + 1),
-        (ddf.a > 3, pdf.a > 3),
-    ]:
+    for ddkey, pdkey in [('a', 'a'), (ddf.a, pdf.a),
+                         (ddf.a + 1, pdf.a + 1), (ddf.a > 3, pdf.a > 3)]:
         assert_eq(ddf.groupby(ddkey).b.sum(), pdf.groupby(pdkey).b.sum())
         assert_eq(ddf.groupby(ddkey).b.min(), pdf.groupby(pdkey).b.min())
         assert_eq(ddf.groupby(ddkey).b.max(), pdf.groupby(pdkey).b.max())
@@ -657,56 +566,54 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddkey).prod(), pdf.groupby(pdkey).prod())
 
         for ddof in ddofs:
-            assert_eq(ddf.groupby(ddkey).b.std(ddof), pdf.groupby(pdkey).b.std(ddof))
+            assert_eq(ddf.groupby(ddkey).b.std(ddof),
+                      pdf.groupby(pdkey).b.std(ddof))
 
-    assert sorted(ddf.groupby("b").a.sum().dask) == sorted(
-        ddf.groupby("b").a.sum().dask
-    )
-    assert sorted(ddf.groupby(ddf.a > 3).b.mean().dask) == sorted(
-        ddf.groupby(ddf.a > 3).b.mean().dask
-    )
+    assert (sorted(ddf.groupby('b').a.sum().dask) ==
+            sorted(ddf.groupby('b').a.sum().dask))
+    assert (sorted(ddf.groupby(ddf.a > 3).b.mean().dask) ==
+            sorted(ddf.groupby(ddf.a > 3).b.mean().dask))
 
     # test raises with incorrect key
-    pytest.raises(KeyError, lambda: ddf.groupby("x"))
-    pytest.raises(KeyError, lambda: ddf.groupby(["a", "x"]))
-    pytest.raises(KeyError, lambda: ddf.groupby("a")["x"])
-    pytest.raises(KeyError, lambda: ddf.groupby("a")["b", "x"])
-    pytest.raises(KeyError, lambda: ddf.groupby("a")[["b", "x"]])
+    pytest.raises(KeyError, lambda: ddf.groupby('x'))
+    pytest.raises(KeyError, lambda: ddf.groupby(['a', 'x']))
+    pytest.raises(KeyError, lambda: ddf.groupby('a')['x'])
+    pytest.raises(KeyError, lambda: ddf.groupby('a')['b', 'x'])
+    pytest.raises(KeyError, lambda: ddf.groupby('a')[['b', 'x']])
 
     # test graph node labels
-    assert_dask_graph(ddf.groupby("b").a.sum(), "series-groupby-sum")
-    assert_dask_graph(ddf.groupby("b").a.min(), "series-groupby-min")
-    assert_dask_graph(ddf.groupby("b").a.max(), "series-groupby-max")
-    assert_dask_graph(ddf.groupby("b").a.count(), "series-groupby-count")
-    assert_dask_graph(ddf.groupby("b").a.var(), "series-groupby-var")
-    assert_dask_graph(ddf.groupby("b").a.cov(), "series-groupby-cov")
-    assert_dask_graph(ddf.groupby("b").a.first(), "series-groupby-first")
-    assert_dask_graph(ddf.groupby("b").a.last(), "series-groupby-last")
-    assert_dask_graph(ddf.groupby("b").a.prod(), "series-groupby-prod")
+    assert_dask_graph(ddf.groupby('b').a.sum(), 'series-groupby-sum')
+    assert_dask_graph(ddf.groupby('b').a.min(), 'series-groupby-min')
+    assert_dask_graph(ddf.groupby('b').a.max(), 'series-groupby-max')
+    assert_dask_graph(ddf.groupby('b').a.count(), 'series-groupby-count')
+    assert_dask_graph(ddf.groupby('b').a.var(), 'series-groupby-var')
+    assert_dask_graph(ddf.groupby('b').a.cov(), 'series-groupby-cov')
+    assert_dask_graph(ddf.groupby('b').a.first(), 'series-groupby-first')
+    assert_dask_graph(ddf.groupby('b').a.last(), 'series-groupby-last')
+    assert_dask_graph(ddf.groupby('b').a.prod(), 'series-groupby-prod')
     # mean consists from sum and count operations
-    assert_dask_graph(ddf.groupby("b").a.mean(), "series-groupby-sum")
-    assert_dask_graph(ddf.groupby("b").a.mean(), "series-groupby-count")
-    assert_dask_graph(ddf.groupby("b").a.nunique(), "series-groupby-nunique")
-    assert_dask_graph(ddf.groupby("b").a.size(), "series-groupby-size")
+    assert_dask_graph(ddf.groupby('b').a.mean(), 'series-groupby-sum')
+    assert_dask_graph(ddf.groupby('b').a.mean(), 'series-groupby-count')
+    assert_dask_graph(ddf.groupby('b').a.nunique(), 'series-groupby-nunique')
+    assert_dask_graph(ddf.groupby('b').a.size(), 'series-groupby-size')
 
-    assert_dask_graph(ddf.groupby("b").sum(), "dataframe-groupby-sum")
-    assert_dask_graph(ddf.groupby("b").min(), "dataframe-groupby-min")
-    assert_dask_graph(ddf.groupby("b").max(), "dataframe-groupby-max")
-    assert_dask_graph(ddf.groupby("b").count(), "dataframe-groupby-count")
-    assert_dask_graph(ddf.groupby("b").first(), "dataframe-groupby-first")
-    assert_dask_graph(ddf.groupby("b").last(), "dataframe-groupby-last")
-    assert_dask_graph(ddf.groupby("b").prod(), "dataframe-groupby-prod")
+    assert_dask_graph(ddf.groupby('b').sum(), 'dataframe-groupby-sum')
+    assert_dask_graph(ddf.groupby('b').min(), 'dataframe-groupby-min')
+    assert_dask_graph(ddf.groupby('b').max(), 'dataframe-groupby-max')
+    assert_dask_graph(ddf.groupby('b').count(), 'dataframe-groupby-count')
+    assert_dask_graph(ddf.groupby('b').first(), 'dataframe-groupby-first')
+    assert_dask_graph(ddf.groupby('b').last(), 'dataframe-groupby-last')
+    assert_dask_graph(ddf.groupby('b').prod(), 'dataframe-groupby-prod')
     # mean consists from sum and count operations
-    assert_dask_graph(ddf.groupby("b").mean(), "dataframe-groupby-sum")
-    assert_dask_graph(ddf.groupby("b").mean(), "dataframe-groupby-count")
-    assert_dask_graph(ddf.groupby("b").size(), "dataframe-groupby-size")
+    assert_dask_graph(ddf.groupby('b').mean(), 'dataframe-groupby-sum')
+    assert_dask_graph(ddf.groupby('b').mean(), 'dataframe-groupby-count')
+    assert_dask_graph(ddf.groupby('b').size(), 'dataframe-groupby-size')
 
 
-@pytest.mark.parametrize("keyword", ["split_every", "split_out"])
+@pytest.mark.parametrize('keyword', ['split_every', 'split_out'])
 def test_groupby_reduction_split(keyword):
-    pdf = pd.DataFrame(
-        {"a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 100, "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100}
-    )
+    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 100,
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100})
     ddf = dd.from_pandas(pdf, npartitions=15)
 
     def call(g, m, **kwargs):
@@ -715,29 +622,29 @@ def test_groupby_reduction_split(keyword):
     # DataFrame
     for m in AGG_FUNCS:
         # nunique is not implemented for DataFrameGroupBy
-        if m == "nunique":
+        if m == 'nunique':
             continue
-        res = call(ddf.groupby("b"), m, **{keyword: 2})
-        sol = call(pdf.groupby("b"), m)
+        res = call(ddf.groupby('b'), m, **{keyword: 2})
+        sol = call(pdf.groupby('b'), m)
         assert_eq(res, sol)
-        assert call(ddf.groupby("b"), m)._name != res._name
+        assert call(ddf.groupby('b'), m)._name != res._name
 
-    res = call(ddf.groupby("b"), "var", ddof=2, **{keyword: 2})
-    sol = call(pdf.groupby("b"), "var", ddof=2)
+    res = call(ddf.groupby('b'), 'var', ddof=2, **{keyword: 2})
+    sol = call(pdf.groupby('b'), 'var', ddof=2)
     assert_eq(res, sol)
-    assert call(ddf.groupby("b"), "var", ddof=2)._name != res._name
+    assert call(ddf.groupby('b'), 'var', ddof=2)._name != res._name
 
     # Series, post select
     for m in AGG_FUNCS:
-        res = call(ddf.groupby("b").a, m, **{keyword: 2})
-        sol = call(pdf.groupby("b").a, m)
+        res = call(ddf.groupby('b').a, m, **{keyword: 2})
+        sol = call(pdf.groupby('b').a, m)
         assert_eq(res, sol)
-        assert call(ddf.groupby("b").a, m)._name != res._name
+        assert call(ddf.groupby('b').a, m)._name != res._name
 
-    res = call(ddf.groupby("b").a, "var", ddof=2, **{keyword: 2})
-    sol = call(pdf.groupby("b").a, "var", ddof=2)
+    res = call(ddf.groupby('b').a, 'var', ddof=2, **{keyword: 2})
+    sol = call(pdf.groupby('b').a, 'var', ddof=2)
     assert_eq(res, sol)
-    assert call(ddf.groupby("b").a, "var", ddof=2)._name != res._name
+    assert call(ddf.groupby('b').a, 'var', ddof=2)._name != res._name
 
     # Series, pre select
     for m in AGG_FUNCS:
@@ -748,305 +655,231 @@ def test_groupby_reduction_split(keyword):
         assert_eq(res, sol, check_names=False)
         assert call(ddf.a.groupby(ddf.b), m)._name != res._name
 
-    res = call(ddf.a.groupby(ddf.b), "var", ddof=2, **{keyword: 2})
-    sol = call(pdf.a.groupby(pdf.b), "var", ddof=2)
+    res = call(ddf.a.groupby(ddf.b), 'var', ddof=2, **{keyword: 2})
+    sol = call(pdf.a.groupby(pdf.b), 'var', ddof=2)
     assert_eq(res, sol)
-    assert call(ddf.a.groupby(ddf.b), "var", ddof=2)._name != res._name
+    assert call(ddf.a.groupby(ddf.b), 'var', ddof=2)._name != res._name
 
 
 def test_apply_shuffle():
-    pdf = pd.DataFrame(
-        {
-            "A": [1, 2, 3, 4] * 5,
-            "B": np.random.randn(20),
-            "C": np.random.randn(20),
-            "D": np.random.randn(20),
-        }
-    )
+    pdf = pd.DataFrame({'A': [1, 2, 3, 4] * 5,
+                        'B': np.random.randn(20),
+                        'C': np.random.randn(20),
+                        'D': np.random.randn(20)})
     ddf = dd.from_pandas(pdf, 3)
 
     with pytest.warns(UserWarning):  # meta inference
-        assert_eq(
-            ddf.groupby("A").apply(lambda x: x.sum()),
-            pdf.groupby("A").apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby('A').apply(lambda x: x.sum()),
+                  pdf.groupby('A').apply(lambda x: x.sum()))
 
-        assert_eq(
-            ddf.groupby(ddf["A"]).apply(lambda x: x.sum()),
-            pdf.groupby(pdf["A"]).apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby(ddf['A']).apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A']).apply(lambda x: x.sum()))
 
-        assert_eq(
-            ddf.groupby(ddf["A"] + 1).apply(lambda x: x.sum()),
-            pdf.groupby(pdf["A"] + 1).apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby(ddf['A'] + 1).apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A'] + 1).apply(lambda x: x.sum()))
 
         # SeriesGroupBy
-        assert_eq(
-            ddf.groupby("A")["B"].apply(lambda x: x.sum()),
-            pdf.groupby("A")["B"].apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby('A')['B'].apply(lambda x: x.sum()),
+                  pdf.groupby('A')['B'].apply(lambda x: x.sum()))
 
-        assert_eq(
-            ddf.groupby(ddf["A"])["B"].apply(lambda x: x.sum()),
-            pdf.groupby(pdf["A"])["B"].apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby(ddf['A'])['B'].apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A'])['B'].apply(lambda x: x.sum()))
 
-        assert_eq(
-            ddf.groupby(ddf["A"] + 1)["B"].apply(lambda x: x.sum()),
-            pdf.groupby(pdf["A"] + 1)["B"].apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby(ddf['A'] + 1)['B'].apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A'] + 1)['B'].apply(lambda x: x.sum()))
 
         # Series.groupby
-        assert_eq(
-            ddf.B.groupby(ddf["A"]).apply(lambda x: x.sum()),
-            pdf.B.groupby(pdf["A"]).apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.B.groupby(ddf['A']).apply(lambda x: x.sum()),
+                  pdf.B.groupby(pdf['A']).apply(lambda x: x.sum()))
 
-        assert_eq(
-            ddf.B.groupby(ddf["A"] + 1).apply(lambda x: x.sum()),
-            pdf.B.groupby(pdf["A"] + 1).apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.B.groupby(ddf['A'] + 1).apply(lambda x: x.sum()),
+                  pdf.B.groupby(pdf['A'] + 1).apply(lambda x: x.sum()))
 
         # DataFrameGroupBy with column slice
-        assert_eq(
-            ddf.groupby("A")[["B", "C"]].apply(lambda x: x.sum()),
-            pdf.groupby("A")[["B", "C"]].apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby('A')[['B', 'C']].apply(lambda x: x.sum()),
+                  pdf.groupby('A')[['B', 'C']].apply(lambda x: x.sum()))
 
-        assert_eq(
-            ddf.groupby(ddf["A"])[["B", "C"]].apply(lambda x: x.sum()),
-            pdf.groupby(pdf["A"])[["B", "C"]].apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby(ddf['A'])[['B', 'C']].apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A'])[['B', 'C']].apply(lambda x: x.sum()))
 
-        assert_eq(
-            ddf.groupby(ddf["A"] + 1)[["B", "C"]].apply(lambda x: x.sum()),
-            pdf.groupby(pdf["A"] + 1)[["B", "C"]].apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby(ddf['A'] + 1)[['B', 'C']].apply(lambda x: x.sum()),
+                  pdf.groupby(pdf['A'] + 1)[['B', 'C']].apply(lambda x: x.sum()))
 
 
-@pytest.mark.parametrize(
-    "grouper",
-    [
-        lambda df: "AA",
-        lambda df: ["AA", "AB"],
-        lambda df: df["AA"],
-        lambda df: [df["AA"], df["AB"]],
-        lambda df: df["AA"] + 1,
-        pytest.param(
-            lambda df: [df["AA"] + 1, df["AB"] + 1],
-            marks=pytest.mark.xfail("NotImplemented"),
-        ),
-    ],
-)
+@pytest.mark.parametrize('grouper', [
+    lambda df: 'AA',
+    lambda df: ['AA', 'AB'],
+    lambda df: df['AA'],
+    lambda df: [df['AA'], df['AB']],
+    lambda df: df['AA'] + 1,
+    pytest.param(lambda df: [df['AA'] + 1, df['AB'] + 1], marks=pytest.mark.xfail("NotImplemented"))
+])
 def test_apply_shuffle_multilevel(grouper):
-    pdf = pd.DataFrame(
-        {
-            "AB": [1, 2, 3, 4] * 5,
-            "AA": [1, 2, 3, 4] * 5,
-            "B": np.random.randn(20),
-            "C": np.random.randn(20),
-            "D": np.random.randn(20),
-        }
-    )
+    pdf = pd.DataFrame({'AB': [1, 2, 3, 4] * 5,
+                        'AA': [1, 2, 3, 4] * 5,
+                        'B': np.random.randn(20),
+                        'C': np.random.randn(20),
+                        'D': np.random.randn(20)})
     ddf = dd.from_pandas(pdf, 3)
 
     with pytest.warns(UserWarning):
         # DataFrameGroupBy
-        assert_eq(
-            ddf.groupby(grouper(ddf)).apply(lambda x: x.sum()),
-            pdf.groupby(grouper(pdf)).apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby(grouper(ddf)).apply(lambda x: x.sum()),
+                  pdf.groupby(grouper(pdf)).apply(lambda x: x.sum()))
 
         # SeriesGroupBy
-        assert_eq(
-            ddf.groupby(grouper(ddf))["B"].apply(lambda x: x.sum()),
-            pdf.groupby(grouper(pdf))["B"].apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby(grouper(ddf))['B'].apply(lambda x: x.sum()),
+                  pdf.groupby(grouper(pdf))['B'].apply(lambda x: x.sum()))
 
         # DataFrameGroupBy with column slice
-        assert_eq(
-            ddf.groupby(grouper(ddf))[["B", "C"]].apply(lambda x: x.sum()),
-            pdf.groupby(grouper(pdf))[["B", "C"]].apply(lambda x: x.sum()),
-        )
+        assert_eq(ddf.groupby(grouper(ddf))[['B', 'C']].apply(lambda x: x.sum()),
+                  pdf.groupby(grouper(pdf))[['B', 'C']].apply(lambda x: x.sum()))
 
 
 def test_numeric_column_names():
     # df.groupby(0)[df.columns] fails if all columns are numbers (pandas bug)
     # This ensures that we cast all column iterables to list beforehand.
-    df = pd.DataFrame({0: [0, 1, 0, 1], 1: [1, 2, 3, 4], 2: [0, 1, 0, 1]})
+    df = pd.DataFrame({0: [0, 1, 0, 1],
+                       1: [1, 2, 3, 4],
+                       2: [0, 1, 0, 1], })
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf.groupby(0).sum(), df.groupby(0).sum())
     assert_eq(ddf.groupby([0, 2]).sum(), df.groupby([0, 2]).sum())
-    assert_eq(
-        ddf.groupby(0).apply(lambda x: x, meta={0: int, 1: int, 2: int}),
-        df.groupby(0).apply(lambda x: x),
-    )
+    assert_eq(ddf.groupby(0).apply(lambda x: x, meta={0: int, 1: int, 2: int}),
+              df.groupby(0).apply(lambda x: x))
 
 
 def test_groupby_apply_tasks():
     df = pd.util.testing.makeTimeDataFrame()
-    df["A"] = df.A // 0.1
-    df["B"] = df.B // 0.1
+    df['A'] = df.A // 0.1
+    df['B'] = df.B // 0.1
     ddf = dd.from_pandas(df, npartitions=10)
 
-    with dask.config.set(shuffle="tasks"):
-        for ind in [lambda x: "A", lambda x: x.A]:
+    with dask.config.set(shuffle='tasks'):
+        for ind in [lambda x: 'A', lambda x: x.A]:
             a = df.groupby(ind(df)).apply(len)
             with pytest.warns(UserWarning):
                 b = ddf.groupby(ind(ddf)).apply(len)
             assert_eq(a, b.compute())
-            assert not any("partd" in k[0] for k in b.dask)
+            assert not any('partd' in k[0] for k in b.dask)
 
             a = df.groupby(ind(df)).B.apply(len)
             with pytest.warns(UserWarning):
                 b = ddf.groupby(ind(ddf)).B.apply(len)
             assert_eq(a, b.compute())
-            assert not any("partd" in k[0] for k in b.dask)
+            assert not any('partd' in k[0] for k in b.dask)
 
 
 def test_groupby_multiprocessing():
-    df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": ["1", "1", "a", "a", "a"]})
+    df = pd.DataFrame({'A': [1, 2, 3, 4, 5],
+                       'B': ['1', '1', 'a', 'a', 'a']})
     ddf = dd.from_pandas(df, npartitions=3)
-    with dask.config.set(scheduler="processes"):
-        assert_eq(
-            ddf.groupby("B").apply(lambda x: x, meta={"A": int, "B": object}),
-            df.groupby("B").apply(lambda x: x),
-        )
+    with dask.config.set(scheduler='processes'):
+        assert_eq(ddf.groupby('B').apply(lambda x: x, meta={"A": int,
+                                                            "B": object}),
+                  df.groupby('B').apply(lambda x: x))
 
 
 def test_groupby_normalize_index():
-    full = pd.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-        index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
-    )
+    full = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                         'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
+                        index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
     d = dd.from_pandas(full, npartitions=3)
 
-    assert d.groupby("a").index == "a"
-    assert d.groupby(d["a"]).index == "a"
-    assert d.groupby(d["a"] > 2).index._name == (d["a"] > 2)._name
-    assert d.groupby(["a", "b"]).index == ["a", "b"]
+    assert d.groupby('a').index == 'a'
+    assert d.groupby(d['a']).index == 'a'
+    assert d.groupby(d['a'] > 2).index._name == (d['a'] > 2)._name
+    assert d.groupby(['a', 'b']).index == ['a', 'b']
 
-    assert d.groupby([d["a"], d["b"]]).index == ["a", "b"]
-    assert d.groupby([d["a"], "b"]).index == ["a", "b"]
+    assert d.groupby([d['a'], d['b']]).index == ['a', 'b']
+    assert d.groupby([d['a'], 'b']).index == ['a', 'b']
 
 
-@pytest.mark.parametrize(
-    "spec",
-    [
-        {"b": {"c": "mean"}, "c": {"a": "max", "b": "min"}},
-        {"b": "mean", "c": ["min", "max"]},
-        {"b": np.sum, "c": ["min", np.max, np.std, np.var]},
-        [
-            "sum",
-            "mean",
-            "min",
-            "max",
-            "count",
-            "size",
-            "std",
-            "var",
-            "first",
-            "last",
-            "prod",
-        ],
-        "var",
-        {"b": "mean", "c": "first", "d": "last", "a": ["first", "last"]},
-        {"b": {"c": "mean"}, "c": {"a": "first", "b": "last"}},
-    ],
-)
-@pytest.mark.parametrize("split_every", [False, None])
-@pytest.mark.parametrize(
-    "grouper",
-    [
-        lambda df: "a",
-        lambda df: ["a", "d"],
-        lambda df: [df["a"], df["d"]],
-        lambda df: df["a"],
-        lambda df: df["a"] > 2,
-    ],
-)
+@pytest.mark.parametrize('spec', [
+    {'b': {'c': 'mean'}, 'c': {'a': 'max', 'b': 'min'}},
+    {'b': 'mean', 'c': ['min', 'max']},
+    {'b': np.sum, 'c': ['min', np.max, np.std, np.var]},
+    ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'first', 'last', 'prod'],
+    'var',
+    {'b': 'mean', 'c': 'first', 'd': 'last', 'a': ['first', 'last']},
+    {'b': {'c': 'mean'}, 'c': {'a': 'first', 'b': 'last'}},
+])
+@pytest.mark.parametrize('split_every', [False, None])
+@pytest.mark.parametrize('grouper', [
+    lambda df: 'a',
+    lambda df: ['a', 'd'],
+    lambda df: [df['a'], df['d']],
+    lambda df: df['a'],
+    lambda df: df['a'] > 2,
+])
 def test_aggregate__examples(spec, split_every, grouper):
-    pdf = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 1, 1, 2, 4, 3, 7] * 10,
-            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-            "d": [3, 2, 1, 3, 2, 1, 2, 6, 4] * 10,
-        },
-        columns=["c", "b", "a", "d"],
-    )
+    pdf = pd.DataFrame({'a': [1, 2, 3, 1, 1, 2, 4, 3, 7] * 10,
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
+                        'd': [3, 2, 1, 3, 2, 1, 2, 6, 4] * 10},
+                       columns=['c', 'b', 'a', 'd'])
     ddf = dd.from_pandas(pdf, npartitions=10)
 
     # Warning from pandas deprecation .agg(dict[dict])
     # it's from pandas, so no reason to assert the deprecation warning,
     # but we should still test it for now
     with pytest.warns(None):
-        assert_eq(
-            pdf.groupby(grouper(pdf)).agg(spec),
-            ddf.groupby(grouper(ddf)).agg(spec, split_every=split_every),
-        )
+        assert_eq(pdf.groupby(grouper(pdf)).agg(spec),
+                  ddf.groupby(grouper(ddf)).agg(spec, split_every=split_every))
 
 
-@pytest.mark.parametrize(
-    "spec",
-    [
-        {"b": "sum", "c": "min", "d": "max"},
-        ["sum"],
-        ["sum", "mean", "min", "max", "count", "size", "std", "var", "first", "last"],
-        "sum",
-        "size",
-    ],
-)
-@pytest.mark.parametrize("split_every", [False, None])
-@pytest.mark.parametrize(
-    "grouper",
-    [lambda df: [df["a"], df["d"]], lambda df: df["a"], lambda df: df["a"] > 2],
-)
+@pytest.mark.parametrize('spec', [
+    {'b': 'sum', 'c': 'min', 'd': 'max'},
+    ['sum'],
+    ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'first', 'last'],
+    'sum', 'size',
+])
+@pytest.mark.parametrize('split_every', [False, None])
+@pytest.mark.parametrize('grouper', [
+    lambda df: [df['a'], df['d']],
+    lambda df: df['a'],
+    lambda df: df['a'] > 2,
+])
 def test_series_aggregate__examples(spec, split_every, grouper):
-    pdf = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 1, 1, 2, 4, 3, 7] * 10,
-            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-            "d": [3, 2, 1, 3, 2, 1, 2, 6, 4] * 10,
-        },
-        columns=["c", "b", "a", "d"],
-    )
-    ps = pdf["c"]
+    pdf = pd.DataFrame({'a': [1, 2, 3, 1, 1, 2, 4, 3, 7] * 10,
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
+                        'd': [3, 2, 1, 3, 2, 1, 2, 6, 4] * 10},
+                       columns=['c', 'b', 'a', 'd'])
+    ps = pdf['c']
 
     ddf = dd.from_pandas(pdf, npartitions=10)
-    ds = ddf["c"]
+    ds = ddf['c']
     # Warning from pandas deprecation .agg(dict[dict])
     # it's from pandas, so no reason to assert the deprecation warning,
     # but we should still test it for now
     with pytest.warns(None):
-        assert_eq(
-            ps.groupby(grouper(pdf)).agg(spec),
-            ds.groupby(grouper(ddf)).agg(spec, split_every=split_every),
-        )
+        assert_eq(ps.groupby(grouper(pdf)).agg(spec),
+                  ds.groupby(grouper(ddf)).agg(spec, split_every=split_every))
 
 
 def test_aggregate__single_element_groups(agg_func):
     spec = agg_func
 
     # nunique is not supported in specs
-    if spec == "nunique":
+    if spec == 'nunique':
         return
 
-    pdf = pd.DataFrame(
-        {"a": [1, 1, 3, 3], "b": [4, 4, 16, 16], "c": [1, 1, 4, 4], "d": [1, 1, 3, 3]},
-        columns=["c", "b", "a", "d"],
-    )
+    pdf = pd.DataFrame({'a': [1, 1, 3, 3],
+                        'b': [4, 4, 16, 16],
+                        'c': [1, 1, 4, 4],
+                        'd': [1, 1, 3, 3]},
+                       columns=['c', 'b', 'a', 'd'])
     ddf = dd.from_pandas(pdf, npartitions=3)
 
-    expected = pdf.groupby(["a", "d"]).agg(spec)
+    expected = pdf.groupby(['a', 'd']).agg(spec)
 
     # NOTE: for std the result is not recast ot the original dtype
-    if spec in {"mean", "var"}:
+    if spec in {'mean', 'var'}:
         expected = expected.astype(float)
 
-    assert_eq(expected, ddf.groupby(["a", "d"]).agg(spec))
+    assert_eq(expected,
+              ddf.groupby(['a', 'd']).agg(spec))
 
 
 def test_aggregate_build_agg_args__reuse_of_intermediates():
@@ -1056,18 +889,19 @@ def test_aggregate_build_agg_args__reuse_of_intermediates():
     """
     from dask.dataframe.groupby import _build_agg_args
 
-    no_mean_spec = [("foo", "sum", "input"), ("bar", "count", "input")]
+    no_mean_spec = [
+        ('foo', 'sum', 'input'),
+        ('bar', 'count', 'input'),
+    ]
 
     with_mean_spec = [
-        ("foo", "sum", "input"),
-        ("bar", "count", "input"),
-        ("baz", "mean", "input"),
+        ('foo', 'sum', 'input'),
+        ('bar', 'count', 'input'),
+        ('baz', 'mean', 'input'),
     ]
 
     no_mean_chunks, no_mean_aggs, no_mean_finalizers = _build_agg_args(no_mean_spec)
-    with_mean_chunks, with_mean_aggs, with_mean_finalizers = _build_agg_args(
-        with_mean_spec
-    )
+    with_mean_chunks, with_mean_aggs, with_mean_finalizers = _build_agg_args(with_mean_spec)
 
     assert len(no_mean_chunks) == len(with_mean_chunks)
     assert len(no_mean_aggs) == len(with_mean_aggs)
@@ -1077,55 +911,31 @@ def test_aggregate_build_agg_args__reuse_of_intermediates():
 
 
 def test_aggregate__dask():
-    dask_holder = collections.namedtuple("dask_holder", ["dask"])
-    get_agg_dask = lambda obj: dask_holder(
-        {k: v for (k, v) in obj.dask.items() if k[0].startswith("aggregate")}
-    )
+    dask_holder = collections.namedtuple('dask_holder', ['dask'])
+    get_agg_dask = lambda obj: dask_holder({
+        k: v for (k, v) in obj.dask.items() if k[0].startswith('aggregate')
+    })
 
     specs = [
-        {"b": {"c": "mean"}, "c": {"a": "max", "b": "min"}},
-        {"b": "mean", "c": ["min", "max"]},
-        [
-            "sum",
-            "mean",
-            "min",
-            "max",
-            "count",
-            "size",
-            "std",
-            "var",
-            "first",
-            "last",
-            "prod",
-        ],
-        "sum",
-        "mean",
-        "min",
-        "max",
-        "count",
-        "std",
-        "var",
-        "first",
-        "last",
-        "prod"
+        {'b': {'c': 'mean'}, 'c': {'a': 'max', 'b': 'min'}},
+        {'b': 'mean', 'c': ['min', 'max']},
+        ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'first', 'last', 'prod'],
+        'sum', 'mean', 'min', 'max', 'count', 'std', 'var', 'first', 'last', 'prod'
+
         # NOTE: the 'size' spec is special since it bypasses aggregate
         # 'size'
     ]
 
-    pdf = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 1, 1, 2, 4, 3, 7] * 100,
-            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100,
-            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 100,
-            "d": [3, 2, 1, 3, 2, 1, 2, 6, 4] * 100,
-        },
-        columns=["c", "b", "a", "d"],
-    )
+    pdf = pd.DataFrame({'a': [1, 2, 3, 1, 1, 2, 4, 3, 7] * 100,
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100,
+                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 100,
+                        'd': [3, 2, 1, 3, 2, 1, 2, 6, 4] * 100},
+                       columns=['c', 'b', 'a', 'd'])
     ddf = dd.from_pandas(pdf, npartitions=100)
 
     for spec in specs:
-        result1 = ddf.groupby(["a", "b"]).agg(spec, split_every=2)
-        result2 = ddf.groupby(["a", "b"]).agg(spec, split_every=2)
+        result1 = ddf.groupby(['a', 'b']).agg(spec, split_every=2)
+        result2 = ddf.groupby(['a', 'b']).agg(spec, split_every=2)
 
         agg_dask1 = get_agg_dask(result1)
         agg_dask2 = get_agg_dask(result2)
@@ -1139,63 +949,47 @@ def test_aggregate__dask():
 
         # the length of the dask does not depend on the passed spec
         for other_spec in specs:
-            other = ddf.groupby(["a", "b"]).agg(other_spec, split_every=2)
+            other = ddf.groupby(['a', 'b']).agg(other_spec, split_every=2)
             assert len(other.dask) == len(result1.dask)
             assert len(other.dask) == len(result2.dask)
 
 
-@pytest.mark.parametrize(
-    "grouper",
-    [
-        lambda df: ["a"],
-        lambda df: ["a", "b"],
-        lambda df: df["a"],
-        lambda df: [df["a"], df["b"]],
-        lambda df: [df["a"] > 2, df["b"] > 1],
-    ],
-)
+@pytest.mark.parametrize('grouper', [
+    lambda df: ['a'],
+    lambda df: ['a', 'b'],
+    lambda df: df['a'],
+    lambda df: [df['a'], df['b']],
+    lambda df: [df['a'] > 2, df['b'] > 1]
+])
 def test_dataframe_aggregations_multilevel(grouper, agg_func):
     def call(g, m, **kwargs):
         return getattr(g, m)(**kwargs)
 
-    pdf = pd.DataFrame(
-        {
-            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
-            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-            "d": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-        },
-        columns=["c", "b", "a", "d"],
-    )
+    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+                        'd': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
+                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10},
+                       columns=['c', 'b', 'a', 'd'])
 
     ddf = dd.from_pandas(pdf, npartitions=10)
 
-    assert_eq(
-        call(pdf.groupby(grouper(pdf))["c"], agg_func),
-        call(ddf.groupby(grouper(ddf))["c"], agg_func, split_every=2),
-    )
+    assert_eq(call(pdf.groupby(grouper(pdf))['c'], agg_func),
+              call(ddf.groupby(grouper(ddf))['c'], agg_func, split_every=2))
 
     # not supported by pandas
-    if agg_func != "nunique":
-        assert_eq(
-            call(pdf.groupby(grouper(pdf))[["c", "d"]], agg_func),
-            call(ddf.groupby(grouper(ddf))[["c", "d"]], agg_func, split_every=2),
-        )
+    if agg_func != 'nunique':
+        assert_eq(call(pdf.groupby(grouper(pdf))[['c', 'd']], agg_func),
+                  call(ddf.groupby(grouper(ddf))[['c', 'd']], agg_func, split_every=2))
 
-        assert_eq(
-            call(pdf.groupby(grouper(pdf)), agg_func),
-            call(ddf.groupby(grouper(ddf)), agg_func, split_every=2),
-        )
+        assert_eq(call(pdf.groupby(grouper(pdf)), agg_func),
+                  call(ddf.groupby(grouper(ddf)), agg_func, split_every=2))
 
 
-@pytest.mark.parametrize(
-    "grouper",
-    [
-        lambda df: df["a"],
-        lambda df: [df["a"], df["b"]],
-        lambda df: [df["a"] > 2, df["b"] > 1],
-    ],
-)
+@pytest.mark.parametrize('grouper', [
+    lambda df: df['a'],
+    lambda df: [df['a'], df['b']],
+    lambda df: [df['a'] > 2, df['b'] > 1]
+])
 def test_series_aggregations_multilevel(grouper, agg_func):
     """
     similar to ``test_dataframe_aggregations_multilevel``, but series do not
@@ -1205,58 +999,38 @@ def test_series_aggregations_multilevel(grouper, agg_func):
     def call(g, m, **kwargs):
         return getattr(g, m)(**kwargs)
 
-    pdf = pd.DataFrame(
-        {
-            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
-            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-        },
-        columns=["c", "b", "a"],
-    )
+    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10},
+                       columns=['c', 'b', 'a'])
 
     ddf = dd.from_pandas(pdf, npartitions=10)
 
-    assert_eq(
-        call(pdf["c"].groupby(grouper(pdf)), agg_func),
-        call(ddf["c"].groupby(grouper(ddf)), agg_func, split_every=2),
-        # for pandas ~ 0.18, the name is not not properly propagated for
-        # the mean aggregation
-        check_names=(agg_func not in {"mean", "nunique"}),
-    )
+    assert_eq(call(pdf['c'].groupby(grouper(pdf)), agg_func),
+              call(ddf['c'].groupby(grouper(ddf)), agg_func, split_every=2),
+              # for pandas ~ 0.18, the name is not not properly propagated for
+              # the mean aggregation
+              check_names=(agg_func not in {'mean', 'nunique'}))
 
 
-@pytest.mark.parametrize(
-    "grouper",
-    [
-        lambda df: df["a"],
-        lambda df: df["a"] > 2,
-        lambda df: [df["a"], df["b"]],
-        lambda df: [df["a"] > 2],
-        pytest.param(
-            lambda df: [df["a"] > 2, df["b"] > 1],
-            marks=pytest.mark.xfail(
-                reason="index dtype does not coincide: boolean != empty"
-            ),
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "group_and_slice",
-    [
-        lambda df, grouper: df.groupby(grouper(df)),
-        lambda df, grouper: df["c"].groupby(grouper(df)),
-        lambda df, grouper: df.groupby(grouper(df))["c"],
-    ],
-)
+@pytest.mark.parametrize('grouper', [
+    lambda df: df['a'],
+    lambda df: df['a'] > 2,
+    lambda df: [df['a'], df['b']],
+    lambda df: [df['a'] > 2],
+    pytest.param(lambda df: [df['a'] > 2, df['b'] > 1], marks=pytest.mark.xfail(
+        reason="index dtype does not coincide: boolean != empty"))
+])
+@pytest.mark.parametrize('group_and_slice', [
+    lambda df, grouper: df.groupby(grouper(df)),
+    lambda df, grouper: df['c'].groupby(grouper(df)),
+    lambda df, grouper: df.groupby(grouper(df))['c'],
+])
 def test_groupby_meta_content(group_and_slice, grouper):
-    pdf = pd.DataFrame(
-        {
-            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
-            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-        },
-        columns=["c", "b", "a"],
-    )
+    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10},
+                       columns=['c', 'b', 'a'])
 
     ddf = dd.from_pandas(pdf, npartitions=10)
 
@@ -1269,51 +1043,43 @@ def test_groupby_meta_content(group_and_slice, grouper):
 
 
 def test_groupy_non_aligned_index():
-    pdf = pd.DataFrame(
-        {
-            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
-            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-        },
-        columns=["c", "b", "a"],
-    )
+    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
+                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10},
+                       columns=['c', 'b', 'a'])
 
     ddf3 = dd.from_pandas(pdf, npartitions=3)
     ddf7 = dd.from_pandas(pdf, npartitions=7)
 
     # working examples
-    ddf3.groupby(["a", "b"])
-    ddf3.groupby([ddf3["a"], ddf3["b"]])
+    ddf3.groupby(['a', 'b'])
+    ddf3.groupby([ddf3['a'], ddf3['b']])
 
     # misaligned divisions
     with pytest.raises(NotImplementedError):
-        ddf3.groupby(ddf7["a"])
+        ddf3.groupby(ddf7['a'])
 
     with pytest.raises(NotImplementedError):
-        ddf3.groupby([ddf7["a"], ddf7["b"]])
+        ddf3.groupby([ddf7['a'], ddf7['b']])
 
     with pytest.raises(NotImplementedError):
-        ddf3.groupby([ddf7["a"], ddf3["b"]])
+        ddf3.groupby([ddf7['a'], ddf3['b']])
 
     with pytest.raises(NotImplementedError):
-        ddf3.groupby([ddf3["a"], ddf7["b"]])
+        ddf3.groupby([ddf3['a'], ddf7['b']])
 
     with pytest.raises(NotImplementedError):
-        ddf3.groupby([ddf7["a"], "b"])
+        ddf3.groupby([ddf7['a'], 'b'])
 
 
 def test_groupy_series_wrong_grouper():
-    df = pd.DataFrame(
-        {
-            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
-            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-        },
-        columns=["c", "b", "a"],
-    )
+    df = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
+                       'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+                       'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10},
+                      columns=['c', 'b', 'a'])
 
     df = dd.from_pandas(df, npartitions=3)
-    s = df["a"]
+    s = df['a']
 
     # working index values
     s.groupby(s)
@@ -1321,10 +1087,10 @@ def test_groupy_series_wrong_grouper():
 
     # non working index values
     with pytest.raises(KeyError):
-        s.groupby("foo")
+        s.groupby('foo')
 
     with pytest.raises(KeyError):
-        s.groupby([s, "foo"])
+        s.groupby([s, 'foo'])
 
     with pytest.raises(ValueError):
         s.groupby(df)
@@ -1333,89 +1099,87 @@ def test_groupy_series_wrong_grouper():
         s.groupby([s, df])
 
 
-@pytest.mark.parametrize("npartitions", [1, 4, 20])
-@pytest.mark.parametrize("split_every", [2, 5])
-@pytest.mark.parametrize("split_out", [None, 1, 5, 20])
+@pytest.mark.parametrize('npartitions', [1, 4, 20])
+@pytest.mark.parametrize('split_every', [2, 5])
+@pytest.mark.parametrize('split_out', [None, 1, 5, 20])
 def test_hash_groupby_aggregate(npartitions, split_every, split_out):
-    df = pd.DataFrame({"x": np.arange(100) % 10, "y": np.ones(100)})
+    df = pd.DataFrame({'x': np.arange(100) % 10,
+                       'y': np.ones(100)})
     ddf = dd.from_pandas(df, npartitions)
 
-    result = ddf.groupby("x").y.var(split_every=split_every, split_out=split_out)
+    result = ddf.groupby('x').y.var(split_every=split_every,
+                                    split_out=split_out)
 
     dsk = result.__dask_optimize__(result.dask, result.__dask_keys__())
     from dask.core import get_deps
-
     dependencies, dependents = get_deps(dsk)
 
     assert result.npartitions == (split_out or 1)
     assert len([k for k, v in dependencies.items() if not v]) == npartitions
 
-    assert_eq(result, df.groupby("x").y.var())
+    assert_eq(result, df.groupby('x').y.var())
 
 
 def test_split_out_multi_column_groupby():
-    df = pd.DataFrame(
-        {"x": np.arange(100) % 10, "y": np.ones(100), "z": [1, 2, 3, 4, 5] * 20}
-    )
+    df = pd.DataFrame({'x': np.arange(100) % 10,
+                       'y': np.ones(100),
+                       'z': [1, 2, 3, 4, 5] * 20})
 
     ddf = dd.from_pandas(df, npartitions=10)
 
-    result = ddf.groupby(["x", "y"]).z.mean(split_out=4)
-    expected = df.groupby(["x", "y"]).z.mean()
+    result = ddf.groupby(['x', 'y']).z.mean(split_out=4)
+    expected = df.groupby(['x', 'y']).z.mean()
 
     assert_eq(result, expected, check_dtype=False)
 
 
 def test_groupby_split_out_num():
     # GH 1841
-    ddf = dd.from_pandas(
-        pd.DataFrame({"A": [1, 1, 2, 2], "B": [1, 2, 3, 4]}), npartitions=2
-    )
-    assert ddf.groupby("A").sum().npartitions == 1
-    assert ddf.groupby("A").sum(split_out=2).npartitions == 2
-    assert ddf.groupby("A").sum(split_out=3).npartitions == 3
+    ddf = dd.from_pandas(pd.DataFrame({'A': [1, 1, 2, 2],
+                                       'B': [1, 2, 3, 4]}),
+                         npartitions=2)
+    assert ddf.groupby('A').sum().npartitions == 1
+    assert ddf.groupby('A').sum(split_out=2).npartitions == 2
+    assert ddf.groupby('A').sum(split_out=3).npartitions == 3
 
     with pytest.raises(TypeError):
         # groupby doesn't adcept split_out
-        ddf.groupby("A", split_out=2)
+        ddf.groupby('A', split_out=2)
 
 
 def test_groupby_not_supported():
-    ddf = dd.from_pandas(
-        pd.DataFrame({"A": [1, 1, 2, 2], "B": [1, 2, 3, 4]}), npartitions=2
-    )
+    ddf = dd.from_pandas(pd.DataFrame({'A': [1, 1, 2, 2],
+                                       'B': [1, 2, 3, 4]}),
+                         npartitions=2)
     with pytest.raises(TypeError):
-        ddf.groupby("A", axis=1)
+        ddf.groupby('A', axis=1)
     with pytest.raises(TypeError):
-        ddf.groupby("A", level=1)
+        ddf.groupby('A', level=1)
     with pytest.raises(TypeError):
-        ddf.groupby("A", as_index=False)
+        ddf.groupby('A', as_index=False)
     with pytest.raises(TypeError):
-        ddf.groupby("A", sort=False)
+        ddf.groupby('A', sort=False)
     with pytest.raises(TypeError):
-        ddf.groupby("A", squeeze=True)
+        ddf.groupby('A', squeeze=True)
 
 
 def test_groupby_numeric_column():
-    df = pd.DataFrame({"A": ["foo", "foo", "bar"], 0: [1, 2, 3]})
+    df = pd.DataFrame({'A': ['foo', 'foo', 'bar'], 0: [1, 2, 3]})
     ddf = dd.from_pandas(df, npartitions=3)
 
-    assert_eq(ddf.groupby(ddf.A)[0].sum(), df.groupby(df.A)[0].sum())
+    assert_eq(ddf.groupby(ddf.A)[0].sum(),
+              df.groupby(df.A)[0].sum())
 
 
-@pytest.mark.parametrize("sel", ["c", "d", ["c", "d"]])
-@pytest.mark.parametrize("key", ["a", ["a", "b"]])
-@pytest.mark.parametrize("func", ["cumsum", "cumprod", "cumcount"])
+@pytest.mark.parametrize('sel', ['c', 'd', ['c', 'd']])
+@pytest.mark.parametrize('key', ['a', ['a', 'b']])
+@pytest.mark.parametrize('func', ['cumsum', 'cumprod', 'cumcount'])
 def test_cumulative(func, key, sel):
-    df = pd.DataFrame(
-        {
-            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 6,
-            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 6,
-            "c": np.random.randn(54),
-            "d": np.random.randn(54),
-        },
-        columns=["a", "b", "c", "d"],
-    )
+    df = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 6,
+                       'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 6,
+                       'c': np.random.randn(54),
+                       'd': np.random.randn(54)},
+                      columns=['a', 'b', 'c', 'd'])
     df.iloc[[-18, -12, -6], -1] = np.nan
     ddf = dd.from_pandas(df, npartitions=10)
 
@@ -1423,30 +1187,21 @@ def test_cumulative(func, key, sel):
     assert_eq(getattr(g, func)(), getattr(dg, func)())
 
 
-@pytest.mark.parametrize("func", ["cumsum", "cumprod"])
+@pytest.mark.parametrize('func', ['cumsum', 'cumprod'])
 def test_cumulative_axis1(func):
-    df = pd.DataFrame(
-        {
-            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 2,
-            "b": np.random.randn(18),
-            "c": np.random.randn(18),
-        }
-    )
+    df = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 2,
+                       'b': np.random.randn(18),
+                       'c': np.random.randn(18)})
     df.iloc[-6, -1] = np.nan
     ddf = dd.from_pandas(df, npartitions=4)
-    assert_eq(
-        getattr(df.groupby("a"), func)(axis=1), getattr(ddf.groupby("a"), func)(axis=1)
-    )
+    assert_eq(getattr(df.groupby('a'), func)(axis=1),
+              getattr(ddf.groupby('a'), func)(axis=1))
 
 
 def test_groupby_unaligned_index():
-    df = pd.DataFrame(
-        {
-            "a": np.random.randint(0, 10, 50),
-            "b": np.random.randn(50),
-            "c": np.random.randn(50),
-        }
-    )
+    df = pd.DataFrame({'a': np.random.randint(0, 10, 50),
+                       'b': np.random.randn(50),
+                       'c': np.random.randn(50)})
     ddf = dd.from_pandas(df, npartitions=5)
     filtered = df[df.b < 0.5]
     dfiltered = ddf[ddf.b < 0.5]
@@ -1454,16 +1209,14 @@ def test_groupby_unaligned_index():
     ddf_group = dfiltered.groupby(ddf.a)
     ds_group = dfiltered.b.groupby(ddf.a)
 
-    bad = [
-        ddf_group.mean(),
-        ddf_group.var(),
-        ddf_group.b.nunique(),
-        ddf_group.get_group(0),
-        ds_group.mean(),
-        ds_group.var(),
-        ds_group.nunique(),
-        ds_group.get_group(0),
-    ]
+    bad = [ddf_group.mean(),
+           ddf_group.var(),
+           ddf_group.b.nunique(),
+           ddf_group.get_group(0),
+           ds_group.mean(),
+           ds_group.var(),
+           ds_group.nunique(),
+           ds_group.get_group(0)]
 
     for obj in bad:
         with pytest.raises(ValueError):
@@ -1473,10 +1226,8 @@ def test_groupby_unaligned_index():
         return x + 1
 
     df_group = filtered.groupby(df.a)
-    good = [
-        (ddf_group.apply(add1, meta=ddf), df_group.apply(add1)),
-        (ddf_group.b.apply(add1, meta=ddf.b), df_group.b.apply(add1)),
-    ]
+    good = [(ddf_group.apply(add1, meta=ddf), df_group.apply(add1)),
+            (ddf_group.b.apply(add1, meta=ddf.b), df_group.b.apply(add1))]
 
     for (res, sol) in good:
         assert_eq(res, sol)
@@ -1487,20 +1238,19 @@ def test_groupby_dataframe_cum_caching():
 
     Relates to #3756.
     """
-    df = pd.DataFrame(
-        dict(a=list("aabbcc")), index=pd.date_range(start="20100101", periods=6)
-    )
-    df["ones"] = 1
-    df["twos"] = 2
+    df = pd.DataFrame(dict(a=list('aabbcc')),
+                      index=pd.date_range(start='20100101', periods=6))
+    df['ones'] = 1
+    df['twos'] = 2
 
     ddf = dd.from_pandas(df, npartitions=3)
 
-    ops = ["cumsum", "cumprod"]
+    ops = ['cumsum', 'cumprod']
 
     for op in ops:
-        ddf0 = getattr(ddf.groupby(["a"]), op)()
-        ddf1 = ddf.rename(columns={"ones": "foo", "twos": "bar"})
-        ddf1 = getattr(ddf1.groupby(["a"]), op)()
+        ddf0 = getattr(ddf.groupby(['a']), op)()
+        ddf1 = ddf.rename(columns={'ones': 'foo', 'twos': 'bar'})
+        ddf1 = getattr(ddf1.groupby(['a']), op)()
 
         # _a and _b dataframe should be equal
         res0_a, res1_a = dask.compute(ddf0, ddf1)
@@ -1515,21 +1265,20 @@ def test_groupby_series_cum_caching():
 
     Relates to #3755
     """
-    df = pd.DataFrame(
-        dict(a=list("aabbcc")), index=pd.date_range(start="20100101", periods=6)
-    )
-    df["ones"] = 1
-    df["twos"] = 2
+    df = pd.DataFrame(dict(a=list('aabbcc')),
+                      index=pd.date_range(start='20100101', periods=6))
+    df['ones'] = 1
+    df['twos'] = 2
 
-    ops = ["cumsum", "cumprod"]
+    ops = ['cumsum', 'cumprod']
     for op in ops:
         ddf = dd.from_pandas(df, npartitions=3)
-        dcum = ddf.groupby(["a"])
-        res0_a, res1_a = dask.compute(
-            getattr(dcum["ones"], op)(), getattr(dcum["twos"], op)()
-        )
-        cum = df.groupby(["a"])
-        res0_b, res1_b = (getattr(cum["ones"], op)(), getattr(cum["twos"], op)())
+        dcum = ddf.groupby(['a'])
+        res0_a, res1_a = dask.compute(getattr(dcum['ones'], op)(),
+                                      getattr(dcum['twos'], op)())
+        cum = df.groupby(['a'])
+        res0_b, res1_b = (getattr(cum['ones'], op)(),
+                          getattr(cum['twos'], op)())
 
         assert res0_a.equals(res0_b)
         assert res1_a.equals(res1_b)
@@ -1538,63 +1287,47 @@ def test_groupby_series_cum_caching():
 def test_groupby_slice_agg_reduces():
     d = pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, 5]})
     a = dd.from_pandas(d, npartitions=2)
-    result = a.groupby("a")["b"].agg(["min", "max"])
-    expected = d.groupby("a")["b"].agg(["min", "max"])
+    result = a.groupby("a")["b"].agg(['min', 'max'])
+    expected = d.groupby("a")['b'].agg(['min', 'max'])
     assert_eq(result, expected)
 
 
 def test_groupby_agg_grouper_single():
     # https://github.com/dask/dask/issues/2255
-    d = pd.DataFrame({"a": [1, 2, 3, 4]})
+    d = pd.DataFrame({'a': [1, 2, 3, 4]})
     a = dd.from_pandas(d, npartitions=2)
 
-    result = a.groupby("a")["a"].agg(["min", "max"])
-    expected = d.groupby("a")["a"].agg(["min", "max"])
+    result = a.groupby('a')['a'].agg(['min', 'max'])
+    expected = d.groupby('a')['a'].agg(['min', 'max'])
     assert_eq(result, expected)
 
 
-@pytest.mark.parametrize("slice_", ["a", ["a"], ["a", "b"], ["b"]])
+@pytest.mark.parametrize('slice_', [
+    'a', ['a'], ['a', 'b'], ['b'],
+])
 def test_groupby_agg_grouper_multiple(slice_):
     # https://github.com/dask/dask/issues/2255
-    d = pd.DataFrame({"a": [1, 2, 3, 4], "b": [1, 2, 3, 4]})
+    d = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [1, 2, 3, 4]})
     a = dd.from_pandas(d, npartitions=2)
 
-    result = a.groupby("a")[slice_].agg(["min", "max"])
-    expected = d.groupby("a")[slice_].agg(["min", "max"])
+    result = a.groupby('a')[slice_].agg(['min', 'max'])
+    expected = d.groupby('a')[slice_].agg(['min', 'max'])
     assert_eq(result, expected)
 
 
-@pytest.mark.parametrize(
-    "agg_func",
-    [
-        "cumprod",
-        "cumcount",
-        "cumsum",
-        "var",
-        "sum",
-        "mean",
-        "count",
-        "size",
-        "std",
-        "min",
-        "max",
-        "first",
-        "last",
-        "prod",
-    ],
-)
+@pytest.mark.parametrize('agg_func', [
+    'cumprod', 'cumcount', 'cumsum', 'var', 'sum', 'mean', 'count', 'size',
+    'std', 'min', 'max', 'first', 'last', 'prod'
+])
 def test_groupby_column_and_index_agg_funcs(agg_func):
     def call(g, m, **kwargs):
         return getattr(g, m)(**kwargs)
 
-    df = pd.DataFrame(
-        {
-            "idx": [1, 1, 1, 2, 2, 2],
-            "a": [1, 2, 1, 2, 1, 2],
-            "b": np.arange(6),
-            "c": [1, 1, 1, 2, 2, 2],
-        }
-    ).set_index("idx")
+    df = pd.DataFrame({'idx': [1, 1, 1, 2, 2, 2],
+                       'a': [1, 2, 1, 2, 1, 2],
+                       'b': np.arange(6),
+                       'c': [1, 1, 1, 2, 2, 2]}
+                      ).set_index('idx')
 
     ddf = dd.from_pandas(df, npartitions=df.index.nunique())
     ddf_no_divs = dd.from_pandas(df, npartitions=df.index.nunique(), sort=False)
@@ -1602,69 +1335,70 @@ def test_groupby_column_and_index_agg_funcs(agg_func):
     # Index and then column
 
     # Compute expected result
-    expected = call(df.groupby(["idx", "a"]), agg_func)
-    if agg_func in {"mean", "var"}:
+    expected = call(df.groupby(['idx', 'a']), agg_func)
+    if agg_func in {'mean', 'var'}:
         expected = expected.astype(float)
 
-    result = call(ddf.groupby(["idx", "a"]), agg_func)
+    result = call(ddf.groupby(['idx', 'a']), agg_func)
     assert_eq(expected, result)
 
-    result = call(ddf_no_divs.groupby(["idx", "a"]), agg_func)
+    result = call(ddf_no_divs.groupby(['idx', 'a']), agg_func)
     assert_eq(expected, result)
 
     # apply-combine-apply aggregation functions
-    aca_agg = {"sum", "mean", "var", "size", "std", "count", "first", "last", "prod"}
+    aca_agg = {'sum', 'mean', 'var', 'size', 'std', 'count', 'first', 'last', 'prod'}
 
     # Test aggregate strings
     if agg_func in aca_agg:
-        result = ddf_no_divs.groupby(["idx", "a"]).agg(agg_func)
+        result = ddf_no_divs.groupby(['idx', 'a']).agg(agg_func)
         assert_eq(expected, result)
 
     # Column and then index
 
     # Compute expected result
-    expected = call(df.groupby(["a", "idx"]), agg_func)
-    if agg_func in {"mean", "var"}:
+    expected = call(df.groupby(['a', 'idx']), agg_func)
+    if agg_func in {'mean', 'var'}:
         expected = expected.astype(float)
 
-    result = call(ddf.groupby(["a", "idx"]), agg_func)
+    result = call(ddf.groupby(['a', 'idx']), agg_func)
     assert_eq(expected, result)
 
-    result = call(ddf_no_divs.groupby(["a", "idx"]), agg_func)
+    result = call(ddf_no_divs.groupby(['a', 'idx']), agg_func)
     assert_eq(expected, result)
 
     # Test aggregate strings
     if agg_func in aca_agg:
-        result = ddf_no_divs.groupby(["a", "idx"]).agg(agg_func)
+        result = ddf_no_divs.groupby(['a', 'idx']).agg(agg_func)
         assert_eq(expected, result)
 
     # Index only
 
     # Compute expected result
-    expected = call(df.groupby("idx"), agg_func)
-    if agg_func in {"mean", "var"}:
+    expected = call(df.groupby('idx'), agg_func)
+    if agg_func in {'mean', 'var'}:
         expected = expected.astype(float)
 
-    result = call(ddf.groupby("idx"), agg_func)
+    result = call(ddf.groupby('idx'), agg_func)
     assert_eq(expected, result)
 
-    result = call(ddf_no_divs.groupby("idx"), agg_func)
+    result = call(ddf_no_divs.groupby('idx'), agg_func)
     assert_eq(expected, result)
 
     # Test aggregate strings
     if agg_func in aca_agg:
-        result = ddf_no_divs.groupby("idx").agg(agg_func)
+        result = ddf_no_divs.groupby('idx').agg(agg_func)
         assert_eq(expected, result)
 
 
-@pytest.mark.parametrize("group_args", [["idx", "a"], ["a", "idx"], ["idx"], "idx"])
 @pytest.mark.parametrize(
-    "apply_func", [np.min, np.mean, lambda s: np.max(s) - np.mean(s)]
-)
+    'group_args', [['idx', 'a'], ['a', 'idx'], ['idx'], 'idx'])
+@pytest.mark.parametrize(
+    'apply_func', [np.min, np.mean, lambda s: np.max(s) - np.mean(s)])
 def test_groupby_column_and_index_apply(group_args, apply_func):
-    df = pd.DataFrame(
-        {"idx": [1, 1, 1, 2, 2, 2], "a": [1, 2, 1, 2, 1, 2], "b": np.arange(6)}
-    ).set_index("idx")
+    df = pd.DataFrame({'idx': [1, 1, 1, 2, 2, 2],
+                       'a': [1, 2, 1, 2, 1, 2],
+                       'b': np.arange(6)}
+                      ).set_index('idx')
 
     ddf = dd.from_pandas(df, npartitions=df.index.nunique())
     ddf_no_divs = dd.from_pandas(df, npartitions=df.index.nunique(), sort=False)
@@ -1673,7 +1407,7 @@ def test_groupby_column_and_index_apply(group_args, apply_func):
     expected = df.groupby(group_args).apply(apply_func)
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+        warnings.simplefilter('ignore')
 
         # Compute on dask DataFrame with divisions (no shuffling)
         result = ddf.groupby(group_args).apply(apply_func)
@@ -1699,71 +1433,65 @@ def test_groupby_column_and_index_apply(group_args, apply_func):
 
 
 custom_mean = dd.Aggregation(
-    "mean",
+    'mean',
     lambda s: (s.count(), s.sum()),
     lambda s0, s1: (s0.sum(), s1.sum()),
     lambda s0, s1: s1 / s0,
 )
 
-custom_sum = dd.Aggregation("sum", lambda s: s.sum(), lambda s0: s0.sum())
+custom_sum = dd.Aggregation('sum', lambda s: s.sum(), lambda s0: s0.sum())
 
 
-@pytest.mark.parametrize(
-    "pandas_spec, dask_spec, check_dtype",
-    [
-        ({"b": "mean"}, {"b": custom_mean}, False),
-        ({"b": "sum"}, {"b": custom_sum}, True),
-        (["mean", "sum"], [custom_mean, custom_sum], False),
-        ({"b": ["mean", "sum"]}, {"b": [custom_mean, custom_sum]}, False),
-    ],
-)
+@pytest.mark.parametrize('pandas_spec, dask_spec, check_dtype', [
+    ({'b': 'mean'}, {'b': custom_mean}, False),
+    ({'b': 'sum'}, {'b': custom_sum}, True),
+    (['mean', 'sum'], [custom_mean, custom_sum], False),
+    ({'b': ['mean', 'sum']}, {'b': [custom_mean, custom_sum]}, False),
+])
 def test_dataframe_groupby_agg_custom_sum(pandas_spec, dask_spec, check_dtype):
-    df = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3})
+    df = pd.DataFrame({'g': [0, 0, 1] * 3, 'b': [1, 2, 3] * 3})
     ddf = dd.from_pandas(df, npartitions=2)
 
-    expected = df.groupby("g").aggregate(pandas_spec)
-    result = ddf.groupby("g").aggregate(dask_spec)
+    expected = df.groupby('g').aggregate(pandas_spec)
+    result = ddf.groupby('g').aggregate(dask_spec)
 
     assert_eq(result, expected, check_dtype=check_dtype)
 
 
-@pytest.mark.parametrize(
-    "pandas_spec, dask_spec",
-    [
-        ("mean", custom_mean),
-        (["mean"], [custom_mean]),
-        (["mean", "sum"], [custom_mean, custom_sum]),
-    ],
-)
+@pytest.mark.parametrize('pandas_spec, dask_spec', [
+    ('mean', custom_mean),
+    (['mean'], [custom_mean]),
+    (['mean', 'sum'], [custom_mean, custom_sum]),
+])
 def test_series_groupby_agg_custom_mean(pandas_spec, dask_spec):
-    d = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3})
+    d = pd.DataFrame({'g': [0, 0, 1] * 3, 'b': [1, 2, 3] * 3})
     a = dd.from_pandas(d, npartitions=2)
 
-    expected = d["b"].groupby(d["g"]).aggregate(pandas_spec)
-    result = a["b"].groupby(a["g"]).aggregate(dask_spec)
+    expected = d['b'].groupby(d['g']).aggregate(pandas_spec)
+    result = a['b'].groupby(a['g']).aggregate(dask_spec)
 
     assert_eq(result, expected, check_dtype=False)
 
 
 def test_groupby_agg_custom__name_clash_with_internal_same_column():
     """for a single input column only unique names are allowed"""
-    d = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3})
+    d = pd.DataFrame({'g': [0, 0, 1] * 3, 'b': [1, 2, 3] * 3})
     a = dd.from_pandas(d, npartitions=2)
 
-    agg_func = dd.Aggregation("sum", lambda s: s.sum(), lambda s0: s0.sum())
+    agg_func = dd.Aggregation('sum', lambda s: s.sum(), lambda s0: s0.sum())
 
     with pytest.raises(ValueError):
-        a.groupby("g").aggregate({"b": [agg_func, "sum"]})
+        a.groupby('g').aggregate({'b': [agg_func, 'sum']})
 
 
 def test_groupby_agg_custom__name_clash_with_internal_different_column():
     """custom aggregation functions can share the name of a builtin function"""
-    d = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3, "c": [4, 5, 6] * 3})
+    d = pd.DataFrame({'g': [0, 0, 1] * 3, 'b': [1, 2, 3] * 3, 'c': [4, 5, 6] * 3})
     a = dd.from_pandas(d, npartitions=2)
 
     # NOTE: this function is purposefully misnamed
     agg_func = dd.Aggregation(
-        "sum",
+        'sum',
         lambda s: (s.count(), s.sum()),
         lambda s0, s1: (s0.sum(), s1.sum()),
         lambda s0, s1: s1 / s0,
@@ -1771,8 +1499,8 @@ def test_groupby_agg_custom__name_clash_with_internal_different_column():
 
     # NOTE: the name of agg-func is suppressed in the output,
     # since only a single agg func per column was specified
-    result = a.groupby("g").aggregate({"b": agg_func, "c": "sum"})
-    expected = d.groupby("g").aggregate({"b": "mean", "c": "sum"})
+    result = a.groupby('g').aggregate({'b': agg_func, 'c': 'sum'})
+    expected = d.groupby('g').aggregate({'b': 'mean', 'c': 'sum'})
 
     assert_eq(result, expected, check_dtype=False)
 
@@ -1784,7 +1512,7 @@ def test_groupby_agg_custom__mode():
         def impl(s):
             res, = s.iloc[0]
 
-            for (i,) in s.iloc[1:]:
+            for i, in s.iloc[1:]:
                 res = res.add(i, fill_value=0)
 
             return [res]
@@ -1792,56 +1520,52 @@ def test_groupby_agg_custom__mode():
         return s.apply(impl)
 
     agg_func = dd.Aggregation(
-        "custom_mode",
+        'custom_mode',
         lambda s: s.apply(lambda s: [s.value_counts()]),
         agg_mode,
         lambda s: s.map(lambda i: i[0].idxmax()),
     )
 
-    d = pd.DataFrame(
-        {
-            "g0": [0, 0, 0, 1, 1] * 3,
-            "g1": [0, 0, 0, 1, 1] * 3,
-            "cc": [4, 5, 4, 6, 6] * 3,
-        }
-    )
+    d = pd.DataFrame({
+        'g0': [0, 0, 0, 1, 1] * 3,
+        'g1': [0, 0, 0, 1, 1] * 3,
+        'cc': [4, 5, 4, 6, 6] * 3,
+    })
     a = dd.from_pandas(d, npartitions=5)
 
-    actual = a["cc"].groupby([a["g0"], a["g1"]]).agg(agg_func)
+    actual = a['cc'].groupby([a['g0'], a['g1']]).agg(agg_func)
 
     # cheat to get the correct index
-    expected = pd.DataFrame({"g0": [0, 1], "g1": [0, 1], "cc": [4, 6]})
-    expected = expected["cc"].groupby([expected["g0"], expected["g1"]]).agg("sum")
+    expected = pd.DataFrame({'g0': [0, 1], 'g1': [0, 1], 'cc': [4, 6]})
+    expected = expected['cc'].groupby([expected['g0'], expected['g1']]).agg('sum')
 
     assert_eq(actual, expected)
 
 
 def test_groupby_select_column_agg():
-    pdf = pd.DataFrame(
-        {
-            "A": [1, 2, 3, 1, 2, 3, 1, 2, 4],
-            "B": [-0.776, -0.4, -0.873, 0.054, 1.419, -0.948, -0.967, -1.714, -0.666],
-        }
-    )
+    pdf = pd.DataFrame({'A': [1, 2, 3, 1, 2, 3, 1, 2, 4],
+                        'B': [-0.776, -0.4, -0.873, 0.054, 1.419, -0.948,
+                              -0.967, -1.714, -0.666]})
     ddf = dd.from_pandas(pdf, npartitions=4)
-    actual = ddf.groupby("A")["B"].agg("var")
-    expected = pdf.groupby("A")["B"].agg("var")
+    actual = ddf.groupby('A')['B'].agg('var')
+    expected = pdf.groupby('A')['B'].agg('var')
     assert_eq(actual, expected)
 
 
-@pytest.mark.parametrize(
-    "func",
-    [
-        lambda x: x.std(),
-        lambda x: x.groupby("x").std(),
-        lambda x: x.groupby("x").var(),
-        lambda x: x.groupby("x").mean(),
-        lambda x: x.groupby("x").sum(),
-        lambda x: x.groupby("x").z.std(),
-    ],
-)
+@pytest.mark.parametrize('func', [
+    lambda x: x.std(),
+    lambda x: x.groupby('x').std(),
+    lambda x: x.groupby('x').var(),
+    lambda x: x.groupby('x').mean(),
+    lambda x: x.groupby('x').sum(),
+    lambda x: x.groupby('x').z.std(),
+])
 def test_std_object_dtype(func):
-    df = pd.DataFrame({"x": [1, 2, 1], "y": ["a", "b", "c"], "z": [11.0, 22.0, 33.0]})
+    df = pd.DataFrame({
+        'x': [1, 2, 1],
+        'y': ['a', 'b', 'c'],
+        'z': [11., 22., 33.],
+    })
     ddf = dd.from_pandas(df, npartitions=2)
 
     assert_eq(func(df), func(ddf))
@@ -1849,58 +1573,50 @@ def test_std_object_dtype(func):
 
 def test_timeseries():
     df = dask.datasets.timeseries().partitions[:2]
-    assert_eq(df.groupby("name").std(), df.groupby("name").std())
+    assert_eq(df.groupby('name').std(),
+              df.groupby('name').std())
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < "0.22.0",
-    reason="Parameter min_count not implemented in "
-    "DataFrame.groupby().sum() and DataFrame.groupby().prod()",
-)
-@pytest.mark.parametrize("min_count", [0, 1, 2, 3])
+@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
+                    reason="Parameter min_count not implemented in "
+                           "DataFrame.groupby().sum() and DataFrame.groupby().prod()")
+@pytest.mark.parametrize('min_count', [0, 1, 2, 3])
 def test_with_min_count(min_count):
-    dfs = [
-        pd.DataFrame(
-            {
-                "group": ["A", "A", "B"],
-                "val1": [np.nan, 2, 3],
-                "val2": [np.nan, 5, 6],
-                "val3": [5, 4, 9],
-            }
-        ),
-        pd.DataFrame(
-            {
-                "group": ["A", "A", "B"],
-                "val1": [2, np.nan, np.nan],
-                "val2": [np.nan, 5, 6],
-                "val3": [5, 4, 9],
-            }
-        ),
-    ]
+    dfs = [pd.DataFrame({
+                        'group':['A', 'A', 'B'],
+                        'val1':[np.nan, 2, 3],
+                        'val2':[np.nan, 5, 6],
+                        'val3':[5, 4, 9]
+                        }),
+           pd.DataFrame({
+                        'group':['A', 'A', 'B'],
+                        'val1':[2, np.nan, np.nan],
+                        'val2':[np.nan, 5, 6],
+                        'val3':[5, 4, 9]
+                        })]
     ddfs = [dd.from_pandas(df, npartitions=4) for df in dfs]
 
     for df, ddf in zip(dfs, ddfs):
-        assert_eq(
-            df.groupby("group").sum(min_count=min_count),
-            ddf.groupby("group").sum(min_count=min_count),
-        )
-        assert_eq(
-            df.groupby("group").prod(min_count=min_count),
-            ddf.groupby("group").prod(min_count=min_count),
-        )
+        assert_eq(df.groupby('group').sum(min_count=min_count),
+                  ddf.groupby('group').sum(min_count=min_count))
+        assert_eq(df.groupby('group').prod(min_count=min_count),
+                  ddf.groupby('group').prod(min_count=min_count))
 
 
 def test_groupby_group_keys():
-    df = pd.DataFrame({"a": [1, 2, 2, 3], "b": [2, 3, 4, 5]})
-    ddf = dd.from_pandas(df, npartitions=2).set_index("a")
-    pdf = df.set_index("a")
+    df = pd.DataFrame({
+        'a': [1, 2, 2, 3],
+        'b': [2, 3, 4, 5],
+    })
+    ddf = dd.from_pandas(df, npartitions=2).set_index('a')
+    pdf = df.set_index('a')
 
     func = lambda g: g.copy()
-    expected = pdf.groupby("a").apply(func)
-    assert_eq(expected, ddf.groupby("a").apply(func, meta=expected))
+    expected = pdf.groupby('a').apply(func)
+    assert_eq(expected, ddf.groupby('a').apply(func, meta=expected))
 
-    expected = pdf.groupby("a", group_keys=False).apply(func)
-    assert_eq(expected, ddf.groupby("a", group_keys=False).apply(func, meta=expected))
+    expected = pdf.groupby('a', group_keys=False).apply(func)
+    assert_eq(expected, ddf.groupby('a', group_keys=False).apply(func, meta=expected))
 
 
 def test_groupby_cov():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -10,10 +10,26 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.dataframe.utils import (
-    assert_eq, assert_dask_graph, assert_max_deps, PANDAS_VERSION,
+    assert_eq,
+    assert_dask_graph,
+    assert_max_deps,
+    PANDAS_VERSION,
 )
 
-AGG_FUNCS = ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'nunique', 'first', 'last', 'prod']
+AGG_FUNCS = [
+    "sum",
+    "mean",
+    "min",
+    "max",
+    "count",
+    "size",
+    "std",
+    "var",
+    "nunique",
+    "first",
+    "last",
+    "prod",
+]
 
 
 @pytest.fixture(params=AGG_FUNCS)
@@ -25,43 +41,42 @@ def agg_func(request):
 
 
 def groupby_internal_repr():
-    pdf = pd.DataFrame({'x': [1, 2, 3, 4, 6, 7, 8, 9, 10],
-                        'y': list('abcbabbcda')})
+    pdf = pd.DataFrame({"x": [1, 2, 3, 4, 6, 7, 8, 9, 10], "y": list("abcbabbcda")})
     ddf = dd.from_pandas(pdf, 3)
 
-    gp = pdf.groupby('y')
-    dp = ddf.groupby('y')
+    gp = pdf.groupby("y")
+    dp = ddf.groupby("y")
     assert isinstance(dp, dd.groupby.DataFrameGroupBy)
     assert isinstance(dp._meta, pd.core.groupby.DataFrameGroupBy)
     assert isinstance(dp.obj, dd.DataFrame)
     assert_eq(dp.obj, gp.obj)
 
-    gp = pdf.groupby('y')['x']
-    dp = ddf.groupby('y')['x']
+    gp = pdf.groupby("y")["x"]
+    dp = ddf.groupby("y")["x"]
     assert isinstance(dp, dd.groupby.SeriesGroupBy)
     assert isinstance(dp._meta, pd.core.groupby.SeriesGroupBy)
     # slicing should not affect to internal
     assert isinstance(dp.obj, dd.Series)
     assert_eq(dp.obj, gp.obj)
 
-    gp = pdf.groupby('y')[['x']]
-    dp = ddf.groupby('y')[['x']]
+    gp = pdf.groupby("y")[["x"]]
+    dp = ddf.groupby("y")[["x"]]
     assert isinstance(dp, dd.groupby.DataFrameGroupBy)
     assert isinstance(dp._meta, pd.core.groupby.DataFrameGroupBy)
     # slicing should not affect to internal
     assert isinstance(dp.obj, dd.DataFrame)
     assert_eq(dp.obj, gp.obj)
 
-    gp = pdf.groupby(pdf.y)['x']
-    dp = ddf.groupby(ddf.y)['x']
+    gp = pdf.groupby(pdf.y)["x"]
+    dp = ddf.groupby(ddf.y)["x"]
     assert isinstance(dp, dd.groupby.SeriesGroupBy)
     assert isinstance(dp._meta, pd.core.groupby.SeriesGroupBy)
     # slicing should not affect to internal
     assert isinstance(dp.obj, dd.Series)
     assert_eq(dp.obj, gp.obj)
 
-    gp = pdf.groupby(pdf.y)[['x']]
-    dp = ddf.groupby(ddf.y)[['x']]
+    gp = pdf.groupby(pdf.y)[["x"]]
+    dp = ddf.groupby(ddf.y)[["x"]]
     assert isinstance(dp, dd.groupby.DataFrameGroupBy)
     assert isinstance(dp._meta, pd.core.groupby.DataFrameGroupBy)
     # slicing should not affect to internal
@@ -70,69 +85,68 @@ def groupby_internal_repr():
 
 
 def groupby_error():
-    pdf = pd.DataFrame({'x': [1, 2, 3, 4, 6, 7, 8, 9, 10],
-                        'y': list('abcbabbcda')})
+    pdf = pd.DataFrame({"x": [1, 2, 3, 4, 6, 7, 8, 9, 10], "y": list("abcbabbcda")})
     ddf = dd.from_pandas(pdf, 3)
 
     with pytest.raises(KeyError):
-        ddf.groupby('A')
+        ddf.groupby("A")
 
     with pytest.raises(KeyError):
-        ddf.groupby(['x', 'A'])
+        ddf.groupby(["x", "A"])
 
-    dp = ddf.groupby('y')
+    dp = ddf.groupby("y")
 
-    msg = 'Column not found: '
+    msg = "Column not found: "
     with pytest.raises(KeyError) as err:
-        dp['A']
+        dp["A"]
     assert msg in str(err.value)
 
     with pytest.raises(KeyError) as err:
-        dp[['x', 'A']]
+        dp[["x", "A"]]
     assert msg in str(err.value)
 
 
 def groupby_internal_head():
-    pdf = pd.DataFrame({'A': [1, 2] * 10,
-                        'B': np.random.randn(20),
-                        'C': np.random.randn(20)})
+    pdf = pd.DataFrame(
+        {"A": [1, 2] * 10, "B": np.random.randn(20), "C": np.random.randn(20)}
+    )
     ddf = dd.from_pandas(pdf, 3)
 
-    assert_eq(ddf.groupby('A')._head().sum(),
-              pdf.head().groupby('A').sum())
+    assert_eq(ddf.groupby("A")._head().sum(), pdf.head().groupby("A").sum())
 
-    assert_eq(ddf.groupby(ddf['A'])._head().sum(),
-              pdf.head().groupby(pdf['A']).sum())
+    assert_eq(ddf.groupby(ddf["A"])._head().sum(), pdf.head().groupby(pdf["A"]).sum())
 
-    assert_eq(ddf.groupby(ddf['A'] + 1)._head().sum(),
-              pdf.head().groupby(pdf['A'] + 1).sum())
+    assert_eq(
+        ddf.groupby(ddf["A"] + 1)._head().sum(), pdf.head().groupby(pdf["A"] + 1).sum()
+    )
 
 
 def test_full_groupby():
-    df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
-                       'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-                      index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
+    df = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
+        index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
+    )
     ddf = dd.from_pandas(df, npartitions=3)
 
-    pytest.raises(KeyError, lambda: ddf.groupby('does_not_exist'))
-    pytest.raises(AttributeError, lambda: ddf.groupby('a').does_not_exist)
-    assert 'b' in dir(ddf.groupby('a'))
+    pytest.raises(KeyError, lambda: ddf.groupby("does_not_exist"))
+    pytest.raises(AttributeError, lambda: ddf.groupby("a").does_not_exist)
+    assert "b" in dir(ddf.groupby("a"))
 
     def func(df):
         return df.assign(b=df.b - df.b.mean())
 
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        assert ddf.groupby('a').apply(func)._name.startswith('func')
+        warnings.simplefilter("ignore")
+        assert ddf.groupby("a").apply(func)._name.startswith("func")
 
-        assert_eq(df.groupby('a').apply(func),
-                  ddf.groupby('a').apply(func))
+        assert_eq(df.groupby("a").apply(func), ddf.groupby("a").apply(func))
 
 
 def test_full_groupby_apply_multiarg():
-    df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
-                       'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-                      index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
+    df = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
+        index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
+    )
     ddf = dd.from_pandas(df, npartitions=3)
 
     def func(df, c, d=3):
@@ -146,61 +160,83 @@ def test_full_groupby_apply_multiarg():
     c_delayed = dask.delayed(lambda: c)()
     d_delayed = dask.delayed(lambda: d)()
 
-    meta = df.groupby('a').apply(func, c)
+    meta = df.groupby("a").apply(func, c)
 
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        assert_eq(df.groupby('a').apply(func, c, d=d),
-                  ddf.groupby('a').apply(func, c, d=d_scalar))
+        warnings.simplefilter("ignore")
+        assert_eq(
+            df.groupby("a").apply(func, c, d=d),
+            ddf.groupby("a").apply(func, c, d=d_scalar),
+        )
 
-        assert_eq(df.groupby('a').apply(func, c),
-                  ddf.groupby('a').apply(func, c))
+        assert_eq(df.groupby("a").apply(func, c), ddf.groupby("a").apply(func, c))
 
-        assert_eq(df.groupby('a').apply(func, c, d=d),
-                  ddf.groupby('a').apply(func, c, d=d))
+        assert_eq(
+            df.groupby("a").apply(func, c, d=d), ddf.groupby("a").apply(func, c, d=d)
+        )
 
-        assert_eq(df.groupby('a').apply(func, c),
-                  ddf.groupby('a').apply(func, c_scalar), check_dtype=False)
+        assert_eq(
+            df.groupby("a").apply(func, c),
+            ddf.groupby("a").apply(func, c_scalar),
+            check_dtype=False,
+        )
 
-        assert_eq(df.groupby('a').apply(func, c),
-                  ddf.groupby('a').apply(func, c_scalar, meta=meta))
+        assert_eq(
+            df.groupby("a").apply(func, c),
+            ddf.groupby("a").apply(func, c_scalar, meta=meta),
+        )
 
-        assert_eq(df.groupby('a').apply(func, c, d=d),
-                  ddf.groupby('a').apply(func, c, d=d_scalar, meta=meta))
+        assert_eq(
+            df.groupby("a").apply(func, c, d=d),
+            ddf.groupby("a").apply(func, c, d=d_scalar, meta=meta),
+        )
 
     # Delayed arguments work, but only if metadata is provided
     with pytest.raises(ValueError) as exc:
-        ddf.groupby('a').apply(func, c, d=d_delayed)
-    assert 'dask.delayed' in str(exc.value) and 'meta'in str(exc.value)
+        ddf.groupby("a").apply(func, c, d=d_delayed)
+    assert "dask.delayed" in str(exc.value) and "meta" in str(exc.value)
 
     with pytest.raises(ValueError) as exc:
-        ddf.groupby('a').apply(func, c_delayed, d=d)
-    assert 'dask.delayed' in str(exc.value) and 'meta'in str(exc.value)
+        ddf.groupby("a").apply(func, c_delayed, d=d)
+    assert "dask.delayed" in str(exc.value) and "meta" in str(exc.value)
 
-    assert_eq(df.groupby('a').apply(func, c),
-              ddf.groupby('a').apply(func, c_delayed, meta=meta))
+    assert_eq(
+        df.groupby("a").apply(func, c),
+        ddf.groupby("a").apply(func, c_delayed, meta=meta),
+    )
 
-    assert_eq(df.groupby('a').apply(func, c, d=d),
-              ddf.groupby('a').apply(func, c, d=d_delayed, meta=meta))
+    assert_eq(
+        df.groupby("a").apply(func, c, d=d),
+        ddf.groupby("a").apply(func, c, d=d_delayed, meta=meta),
+    )
 
 
-@pytest.mark.parametrize('grouper', [
-    lambda df: ['a'],
-    lambda df: ['a', 'b'],
-    lambda df: df['a'],
-    lambda df: [df['a'], df['b']],
-    pytest.param(lambda df: [df['a'] > 2, df['b'] > 1], marks=pytest.mark.xfail(
-        reason="not yet supported"))
-])
-@pytest.mark.parametrize('reverse', [True, False])
+@pytest.mark.parametrize(
+    "grouper",
+    [
+        lambda df: ["a"],
+        lambda df: ["a", "b"],
+        lambda df: df["a"],
+        lambda df: [df["a"], df["b"]],
+        pytest.param(
+            lambda df: [df["a"] > 2, df["b"] > 1],
+            marks=pytest.mark.xfail(reason="not yet supported"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("reverse", [True, False])
 def test_full_groupby_multilevel(grouper, reverse):
     index = [0, 1, 3, 5, 6, 8, 9, 9, 9]
     if reverse:
         index = index[::-1]
-    df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
-                       'd': [1, 2, 3, 4, 5, 6, 7, 8, 9],
-                       'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-                      index=index)
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "d": [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "b": [4, 5, 6, 3, 2, 1, 0, 0, 0],
+        },
+        index=index,
+    )
     ddf = dd.from_pandas(df, npartitions=3)
 
     def func(df):
@@ -209,74 +245,91 @@ def test_full_groupby_multilevel(grouper, reverse):
     # last one causes a DeprcationWarning from pandas.
     # See https://github.com/pandas-dev/pandas/issues/16481
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        assert_eq(df.groupby(grouper(df)).apply(func),
-                  ddf.groupby(grouper(ddf)).apply(func))
+        warnings.simplefilter("ignore")
+        assert_eq(
+            df.groupby(grouper(df)).apply(func), ddf.groupby(grouper(ddf)).apply(func)
+        )
 
 
 def test_groupby_dir():
-    df = pd.DataFrame({'a': range(10), 'b c d e': range(10)})
+    df = pd.DataFrame({"a": range(10), "b c d e": range(10)})
     ddf = dd.from_pandas(df, npartitions=2)
-    g = ddf.groupby('a')
-    assert 'a' in dir(g)
-    assert 'b c d e' not in dir(g)
+    g = ddf.groupby("a")
+    assert "a" in dir(g)
+    assert "b c d e" not in dir(g)
 
 
-@pytest.mark.parametrize('scheduler', ['sync', 'threads'])
+@pytest.mark.parametrize("scheduler", ["sync", "threads"])
 def test_groupby_on_index(scheduler):
-    pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
-                        'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-                       index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
+    pdf = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
+        index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
+    )
     ddf = dd.from_pandas(pdf, npartitions=3)
 
-    ddf2 = ddf.set_index('a')
-    pdf2 = pdf.set_index('a')
-    assert_eq(ddf.groupby('a').b.mean(), ddf2.groupby(ddf2.index).b.mean())
+    ddf2 = ddf.set_index("a")
+    pdf2 = pdf.set_index("a")
+    assert_eq(ddf.groupby("a").b.mean(), ddf2.groupby(ddf2.index).b.mean())
 
     def func(df):
         return df.assign(b=df.b - df.b.mean())
 
     def func2(df):
-        return df[['b']] - df[['b']].mean()
+        return df[["b"]] - df[["b"]].mean()
 
     def func3(df):
         return df.mean()
 
     with dask.config.set(scheduler=scheduler):
         with pytest.warns(None):
-            assert_eq(ddf.groupby('a').apply(func),
-                      pdf.groupby('a').apply(func))
+            assert_eq(ddf.groupby("a").apply(func), pdf.groupby("a").apply(func))
 
-            assert_eq(ddf.groupby('a').apply(func).set_index('a'),
-                      pdf.groupby('a').apply(func).set_index('a'))
+            assert_eq(
+                ddf.groupby("a").apply(func).set_index("a"),
+                pdf.groupby("a").apply(func).set_index("a"),
+            )
 
-            assert_eq(pdf2.groupby(pdf2.index).apply(func2),
-                      ddf2.groupby(ddf2.index).apply(func2))
+            assert_eq(
+                pdf2.groupby(pdf2.index).apply(func2),
+                ddf2.groupby(ddf2.index).apply(func2),
+            )
 
-            assert_eq(ddf2.b.groupby('a').apply(func3),
-                      pdf2.b.groupby('a').apply(func3))
+            assert_eq(
+                ddf2.b.groupby("a").apply(func3), pdf2.b.groupby("a").apply(func3)
+            )
 
-            assert_eq(ddf2.b.groupby(ddf2.index).apply(func3),
-                      pdf2.b.groupby(pdf2.index).apply(func3))
+            assert_eq(
+                ddf2.b.groupby(ddf2.index).apply(func3),
+                pdf2.b.groupby(pdf2.index).apply(func3),
+            )
 
 
-@pytest.mark.parametrize('grouper',
-                         [lambda df: df.groupby('a')['b'],
-                          lambda df: df.groupby(['a', 'b']),
-                          lambda df: df.groupby(['a', 'b'])['c'],
-                          lambda df: df.groupby(df['a'])[['b', 'c']],
-                          lambda df: df.groupby('a')[['b', 'c']],
-                          lambda df: df.groupby('a')[['b']],
-                          lambda df: df.groupby(['a', 'b', 'c'])])
+@pytest.mark.parametrize(
+    "grouper",
+    [
+        lambda df: df.groupby("a")["b"],
+        lambda df: df.groupby(["a", "b"]),
+        lambda df: df.groupby(["a", "b"])["c"],
+        lambda df: df.groupby(df["a"])[["b", "c"]],
+        lambda df: df.groupby("a")[["b", "c"]],
+        lambda df: df.groupby("a")[["b"]],
+        lambda df: df.groupby(["a", "b", "c"]),
+    ],
+)
 def test_groupby_multilevel_getitem(grouper, agg_func):
     # nunique is not implemented for DataFrameGroupBy
-    if agg_func == 'nunique':
+    breakpoint()
+    if agg_func == "nunique":
         return
 
-    df = pd.DataFrame({'a': [1, 2, 3, 1, 2, 3],
-                       'b': [1, 2, 1, 4, 2, 1],
-                       'c': [1, 3, 2, 1, 1, 2],
-                       'd': [1, 2, 1, 1, 2, 2]})
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 1, 2, 3],
+            "b": [1, 2, 1, 4, 2, 1],
+            "c": [1, 3, 2, 1, 1, 2],
+            "d": [1, 2, 1, 1, 2, 2],
+        }
+    )
     ddf = dd.from_pandas(df, 2)
 
     dask_group = grouper(ddf)
@@ -288,45 +341,47 @@ def test_groupby_multilevel_getitem(grouper, agg_func):
     assert isinstance(dask_group, dd.groupby._GroupBy)
     assert isinstance(pandas_group, pd.core.groupby.GroupBy)
 
-    if agg_func == 'mean':
+    if agg_func == "mean":
         assert_eq(dask_agg(), pandas_agg().astype(float))
     else:
         assert_eq(dask_agg(), pandas_agg())
 
 
 def test_groupby_multilevel_agg():
-    df = pd.DataFrame({'a': [1, 2, 3, 1, 2, 3],
-                       'b': [1, 2, 1, 4, 2, 1],
-                       'c': [1, 3, 2, 1, 1, 2],
-                       'd': [1, 2, 1, 1, 2, 2]})
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 1, 2, 3],
+            "b": [1, 2, 1, 4, 2, 1],
+            "c": [1, 3, 2, 1, 1, 2],
+            "d": [1, 2, 1, 1, 2, 2],
+        }
+    )
     ddf = dd.from_pandas(df, 2)
 
-    sol = df.groupby(['a']).mean()
-    res = ddf.groupby(['a']).mean()
+    sol = df.groupby(["a"]).mean()
+    res = ddf.groupby(["a"]).mean()
     assert_eq(res, sol)
 
-    sol = df.groupby(['a', 'c']).mean()
-    res = ddf.groupby(['a', 'c']).mean()
+    sol = df.groupby(["a", "c"]).mean()
+    res = ddf.groupby(["a", "c"]).mean()
     assert_eq(res, sol)
 
-    sol = df.groupby([df['a'], df['c']]).mean()
-    res = ddf.groupby([ddf['a'], ddf['c']]).mean()
+    sol = df.groupby([df["a"], df["c"]]).mean()
+    res = ddf.groupby([ddf["a"], ddf["c"]]).mean()
     assert_eq(res, sol)
 
 
 def test_groupby_get_group():
-    dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 6], 'b': [4, 2, 7]},
-                                  index=[0, 1, 3]),
-           ('x', 1): pd.DataFrame({'a': [4, 2, 6], 'b': [3, 3, 1]},
-                                  index=[5, 6, 8]),
-           ('x', 2): pd.DataFrame({'a': [4, 3, 7], 'b': [1, 1, 3]},
-                                  index=[9, 9, 9])}
-    meta = dsk[('x', 0)]
-    d = dd.DataFrame(dsk, 'x', meta, [0, 4, 9, 9])
+    dsk = {
+        ("x", 0): pd.DataFrame({"a": [1, 2, 6], "b": [4, 2, 7]}, index=[0, 1, 3]),
+        ("x", 1): pd.DataFrame({"a": [4, 2, 6], "b": [3, 3, 1]}, index=[5, 6, 8]),
+        ("x", 2): pd.DataFrame({"a": [4, 3, 7], "b": [1, 1, 3]}, index=[9, 9, 9]),
+    }
+    meta = dsk[("x", 0)]
+    d = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
     full = d.compute()
 
-    for ddkey, pdkey in [('b', 'b'), (d.b, full.b),
-                         (d.b + 1, full.b + 1)]:
+    for ddkey, pdkey in [("b", "b"), (d.b, full.b), (d.b + 1, full.b + 1)]:
         ddgrouped = d.groupby(ddkey)
         pdgrouped = full.groupby(pdkey)
         # DataFrame
@@ -338,30 +393,30 @@ def test_groupby_get_group():
 
 
 def test_dataframe_groupby_nunique():
-    strings = list('aaabbccccdddeee')
+    strings = list("aaabbccccdddeee")
     data = np.random.randn(len(strings))
     ps = pd.DataFrame(dict(strings=strings, data=data))
     s = dd.from_pandas(ps, npartitions=3)
-    expected = ps.groupby('strings')['data'].nunique()
-    assert_eq(s.groupby('strings')['data'].nunique(), expected)
+    expected = ps.groupby("strings")["data"].nunique()
+    assert_eq(s.groupby("strings")["data"].nunique(), expected)
 
 
 def test_dataframe_groupby_nunique_across_group_same_value():
-    strings = list('aaabbccccdddeee')
-    data = list(map(int, '123111223323412'))
+    strings = list("aaabbccccdddeee")
+    data = list(map(int, "123111223323412"))
     ps = pd.DataFrame(dict(strings=strings, data=data))
     s = dd.from_pandas(ps, npartitions=3)
-    expected = ps.groupby('strings')['data'].nunique()
-    assert_eq(s.groupby('strings')['data'].nunique(), expected)
+    expected = ps.groupby("strings")["data"].nunique()
+    assert_eq(s.groupby("strings")["data"].nunique(), expected)
 
 
 def test_series_groupby_propagates_names():
-    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
     ddf = dd.from_pandas(df, 2)
-    func = lambda df: df['y'].sum()
+    func = lambda df: df["y"].sum()
     with pytest.warns(UserWarning):  # meta inference
-        result = ddf.groupby('x').apply(func)
-    expected = df.groupby('x').apply(func)
+        result = ddf.groupby("x").apply(func)
+    expected = df.groupby("x").apply(func)
     assert_eq(result, expected)
 
 
@@ -404,9 +459,9 @@ def test_series_groupby_errors():
         ss.groupby(sss)
 
     with pytest.raises(KeyError):
-        s.groupby('x')  # pandas
+        s.groupby("x")  # pandas
     with pytest.raises(KeyError):
-        ss.groupby('x')  # dask should raise the same error
+        ss.groupby("x")  # dask should raise the same error
 
 
 def test_groupby_index_array():
@@ -414,36 +469,42 @@ def test_groupby_index_array():
     ddf = dd.from_pandas(df, npartitions=2)
 
     # first select column, then group
-    assert_eq(df.A.groupby(df.index.month).nunique(),
-              ddf.A.groupby(ddf.index.month).nunique(), check_names=False)
+    assert_eq(
+        df.A.groupby(df.index.month).nunique(),
+        ddf.A.groupby(ddf.index.month).nunique(),
+        check_names=False,
+    )
 
     # first group, then select column
-    assert_eq(df.groupby(df.index.month).A.nunique(),
-              ddf.groupby(ddf.index.month).A.nunique(), check_names=False)
+    assert_eq(
+        df.groupby(df.index.month).A.nunique(),
+        ddf.groupby(ddf.index.month).A.nunique(),
+        check_names=False,
+    )
 
 
 def test_groupby_set_index():
     df = tm.makeTimeDataFrame()
     ddf = dd.from_pandas(df, npartitions=2)
-    pytest.raises(TypeError,
-                  lambda: ddf.groupby(df.index.month, as_index=False))
+    pytest.raises(TypeError, lambda: ddf.groupby(df.index.month, as_index=False))
 
 
-@pytest.mark.parametrize('empty', [True, False])
+@pytest.mark.parametrize("empty", [True, False])
 def test_split_apply_combine_on_series(empty):
     if empty:
-        pdf = pd.DataFrame({'a': [1.], 'b': [1.]}, index=[0]).iloc[:0]
+        pdf = pd.DataFrame({"a": [1.0], "b": [1.0]}, index=[0]).iloc[:0]
         # There's a bug in pandas where df.groupby(...).var(ddof=0) results in
         # no columns. Just skip these checks for now.
         ddofs = []
     else:
         ddofs = [0, 1, 2]
-        pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7],
-                            'b': [4, 2, 7, 3, 3, 1, 1, 1, 2]},
-                           index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
+        pdf = pd.DataFrame(
+            {"a": [1, 2, 6, 4, 4, 6, 4, 3, 7], "b": [4, 2, 7, 3, 3, 1, 1, 1, 2]},
+            index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
+        )
     ddf = dd.from_pandas(pdf, npartitions=3)
 
-    for ddkey, pdkey in [('b', 'b'), (ddf.b, pdf.b), (ddf.b + 1, pdf.b + 1)]:
+    for ddkey, pdkey in [("b", "b"), (ddf.b, pdf.b), (ddf.b + 1, pdf.b + 1)]:
         assert_eq(ddf.groupby(ddkey).a.min(), pdf.groupby(pdkey).a.min())
         assert_eq(ddf.groupby(ddkey).a.max(), pdf.groupby(pdkey).a.max())
         assert_eq(ddf.groupby(ddkey).a.count(), pdf.groupby(pdkey).a.count())
@@ -453,10 +514,9 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddkey).a.first(), pdf.groupby(pdkey).a.first())
         assert_eq(ddf.groupby(ddkey).a.last(), pdf.groupby(pdkey).a.last())
         for ddof in ddofs:
-            assert_eq(ddf.groupby(ddkey).a.var(ddof),
-                      pdf.groupby(pdkey).a.var(ddof))
-            assert_eq(ddf.groupby(ddkey).a.std(ddof),
-                      pdf.groupby(pdkey).a.std(ddof))
+            assert_eq(ddf.groupby(ddkey).a.var(ddof), pdf.groupby(pdkey).a.var(ddof))
+            assert_eq(ddf.groupby(ddkey).a.std(ddof), pdf.groupby(pdkey).a.std(ddof))
+            assert_eq(ddf.groupby(ddkey).a.cov(ddof), pdf.groupby(pdkey).a.cov(ddof))
 
         assert_eq(ddf.groupby(ddkey).sum(), pdf.groupby(pdkey).sum())
         assert_eq(ddf.groupby(ddkey).min(), pdf.groupby(pdkey).min())
@@ -469,26 +529,53 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddkey).prod(), pdf.groupby(pdkey).prod())
 
         for ddof in ddofs:
-            assert_eq(ddf.groupby(ddkey).var(ddof),
-                      pdf.groupby(pdkey).var(ddof), check_dtype=False)
-            assert_eq(ddf.groupby(ddkey).std(ddof),
-                      pdf.groupby(pdkey).std(ddof), check_dtype=False)
+            assert_eq(
+                ddf.groupby(ddkey).var(ddof),
+                pdf.groupby(pdkey).var(ddof),
+                check_dtype=False,
+            )
+            assert_eq(
+                ddf.groupby(ddkey).std(ddof),
+                pdf.groupby(pdkey).std(ddof),
+                check_dtype=False,
+            )
 
     for ddkey, pdkey in [(ddf.b, pdf.b), (ddf.b + 1, pdf.b + 1)]:
-        assert_eq(ddf.a.groupby(ddkey).sum(), pdf.a.groupby(pdkey).sum(), check_names=False)
-        assert_eq(ddf.a.groupby(ddkey).max(), pdf.a.groupby(pdkey).max(), check_names=False)
-        assert_eq(ddf.a.groupby(ddkey).count(), pdf.a.groupby(pdkey).count(), check_names=False)
-        assert_eq(ddf.a.groupby(ddkey).mean(), pdf.a.groupby(pdkey).mean(), check_names=False)
-        assert_eq(ddf.a.groupby(ddkey).nunique(), pdf.a.groupby(pdkey).nunique(), check_names=False)
-        assert_eq(ddf.a.groupby(ddkey).first(), pdf.a.groupby(pdkey).first(), check_names=False)
-        assert_eq(ddf.a.groupby(ddkey).last(), pdf.a.groupby(pdkey).last(), check_names=False)
-        assert_eq(ddf.a.groupby(ddkey).prod(), pdf.a.groupby(pdkey).prod(), check_names=False)
+        assert_eq(
+            ddf.a.groupby(ddkey).sum(), pdf.a.groupby(pdkey).sum(), check_names=False
+        )
+        assert_eq(
+            ddf.a.groupby(ddkey).max(), pdf.a.groupby(pdkey).max(), check_names=False
+        )
+        assert_eq(
+            ddf.a.groupby(ddkey).count(),
+            pdf.a.groupby(pdkey).count(),
+            check_names=False,
+        )
+        assert_eq(
+            ddf.a.groupby(ddkey).mean(), pdf.a.groupby(pdkey).mean(), check_names=False
+        )
+        assert_eq(
+            ddf.a.groupby(ddkey).nunique(),
+            pdf.a.groupby(pdkey).nunique(),
+            check_names=False,
+        )
+        assert_eq(
+            ddf.a.groupby(ddkey).first(),
+            pdf.a.groupby(pdkey).first(),
+            check_names=False,
+        )
+        assert_eq(
+            ddf.a.groupby(ddkey).last(), pdf.a.groupby(pdkey).last(), check_names=False
+        )
+        assert_eq(
+            ddf.a.groupby(ddkey).prod(), pdf.a.groupby(pdkey).prod(), check_names=False
+        )
 
         for ddof in ddofs:
-            assert_eq(ddf.a.groupby(ddkey).var(ddof),
-                      pdf.a.groupby(pdkey).var(ddof))
-            assert_eq(ddf.a.groupby(ddkey).std(ddof),
-                      pdf.a.groupby(pdkey).std(ddof))
+            assert_eq(ddf.a.groupby(ddkey).var(ddof), pdf.a.groupby(pdkey).var(ddof))
+            assert_eq(ddf.a.groupby(ddkey).std(ddof), pdf.a.groupby(pdkey).std(ddof))
+            assert_eq(ddf.a.groupby(ddkey).cov(ddof), pdf.a.groupby(pdkey).cov(ddof))
 
     for i in [0, 4, 7]:
         assert_eq(ddf.groupby(ddf.b > i).a.sum(), pdf.groupby(pdf.b > i).a.sum())
@@ -496,7 +583,9 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddf.b > i).a.max(), pdf.groupby(pdf.b > i).a.max())
         assert_eq(ddf.groupby(ddf.b > i).a.count(), pdf.groupby(pdf.b > i).a.count())
         assert_eq(ddf.groupby(ddf.b > i).a.mean(), pdf.groupby(pdf.b > i).a.mean())
-        assert_eq(ddf.groupby(ddf.b > i).a.nunique(), pdf.groupby(pdf.b > i).a.nunique())
+        assert_eq(
+            ddf.groupby(ddf.b > i).a.nunique(), pdf.groupby(pdf.b > i).a.nunique()
+        )
         assert_eq(ddf.groupby(ddf.b > i).a.size(), pdf.groupby(pdf.b > i).a.size())
         assert_eq(ddf.groupby(ddf.b > i).a.first(), pdf.groupby(pdf.b > i).a.first())
         assert_eq(ddf.groupby(ddf.b > i).a.last(), pdf.groupby(pdf.b > i).a.last())
@@ -507,7 +596,9 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddf.a > i).b.max(), pdf.groupby(pdf.a > i).b.max())
         assert_eq(ddf.groupby(ddf.a > i).b.count(), pdf.groupby(pdf.a > i).b.count())
         assert_eq(ddf.groupby(ddf.a > i).b.mean(), pdf.groupby(pdf.a > i).b.mean())
-        assert_eq(ddf.groupby(ddf.a > i).b.nunique(), pdf.groupby(pdf.a > i).b.nunique())
+        assert_eq(
+            ddf.groupby(ddf.a > i).b.nunique(), pdf.groupby(pdf.a > i).b.nunique()
+        )
         assert_eq(ddf.groupby(ddf.b > i).b.size(), pdf.groupby(pdf.b > i).b.size())
         assert_eq(ddf.groupby(ddf.b > i).b.first(), pdf.groupby(pdf.b > i).b.first())
         assert_eq(ddf.groupby(ddf.b > i).b.last(), pdf.groupby(pdf.b > i).b.last())
@@ -534,11 +625,16 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddf.a > i).prod(), pdf.groupby(pdf.a > i).prod())
 
         for ddof in ddofs:
-            assert_eq(ddf.groupby(ddf.b > i).std(ddof),
-                      pdf.groupby(pdf.b > i).std(ddof))
+            assert_eq(
+                ddf.groupby(ddf.b > i).std(ddof), pdf.groupby(pdf.b > i).std(ddof)
+            )
 
-    for ddkey, pdkey in [('a', 'a'), (ddf.a, pdf.a),
-                         (ddf.a + 1, pdf.a + 1), (ddf.a > 3, pdf.a > 3)]:
+    for ddkey, pdkey in [
+        ("a", "a"),
+        (ddf.a, pdf.a),
+        (ddf.a + 1, pdf.a + 1),
+        (ddf.a > 3, pdf.a > 3),
+    ]:
         assert_eq(ddf.groupby(ddkey).b.sum(), pdf.groupby(pdkey).b.sum())
         assert_eq(ddf.groupby(ddkey).b.min(), pdf.groupby(pdkey).b.min())
         assert_eq(ddf.groupby(ddkey).b.max(), pdf.groupby(pdkey).b.max())
@@ -561,53 +657,56 @@ def test_split_apply_combine_on_series(empty):
         assert_eq(ddf.groupby(ddkey).prod(), pdf.groupby(pdkey).prod())
 
         for ddof in ddofs:
-            assert_eq(ddf.groupby(ddkey).b.std(ddof),
-                      pdf.groupby(pdkey).b.std(ddof))
+            assert_eq(ddf.groupby(ddkey).b.std(ddof), pdf.groupby(pdkey).b.std(ddof))
 
-    assert (sorted(ddf.groupby('b').a.sum().dask) ==
-            sorted(ddf.groupby('b').a.sum().dask))
-    assert (sorted(ddf.groupby(ddf.a > 3).b.mean().dask) ==
-            sorted(ddf.groupby(ddf.a > 3).b.mean().dask))
+    assert sorted(ddf.groupby("b").a.sum().dask) == sorted(
+        ddf.groupby("b").a.sum().dask
+    )
+    assert sorted(ddf.groupby(ddf.a > 3).b.mean().dask) == sorted(
+        ddf.groupby(ddf.a > 3).b.mean().dask
+    )
 
     # test raises with incorrect key
-    pytest.raises(KeyError, lambda: ddf.groupby('x'))
-    pytest.raises(KeyError, lambda: ddf.groupby(['a', 'x']))
-    pytest.raises(KeyError, lambda: ddf.groupby('a')['x'])
-    pytest.raises(KeyError, lambda: ddf.groupby('a')['b', 'x'])
-    pytest.raises(KeyError, lambda: ddf.groupby('a')[['b', 'x']])
+    pytest.raises(KeyError, lambda: ddf.groupby("x"))
+    pytest.raises(KeyError, lambda: ddf.groupby(["a", "x"]))
+    pytest.raises(KeyError, lambda: ddf.groupby("a")["x"])
+    pytest.raises(KeyError, lambda: ddf.groupby("a")["b", "x"])
+    pytest.raises(KeyError, lambda: ddf.groupby("a")[["b", "x"]])
 
     # test graph node labels
-    assert_dask_graph(ddf.groupby('b').a.sum(), 'series-groupby-sum')
-    assert_dask_graph(ddf.groupby('b').a.min(), 'series-groupby-min')
-    assert_dask_graph(ddf.groupby('b').a.max(), 'series-groupby-max')
-    assert_dask_graph(ddf.groupby('b').a.count(), 'series-groupby-count')
-    assert_dask_graph(ddf.groupby('b').a.var(), 'series-groupby-var')
-    assert_dask_graph(ddf.groupby('b').a.first(), 'series-groupby-first')
-    assert_dask_graph(ddf.groupby('b').a.last(), 'series-groupby-last')
-    assert_dask_graph(ddf.groupby('b').a.prod(), 'series-groupby-prod')
+    assert_dask_graph(ddf.groupby("b").a.sum(), "series-groupby-sum")
+    assert_dask_graph(ddf.groupby("b").a.min(), "series-groupby-min")
+    assert_dask_graph(ddf.groupby("b").a.max(), "series-groupby-max")
+    assert_dask_graph(ddf.groupby("b").a.count(), "series-groupby-count")
+    assert_dask_graph(ddf.groupby("b").a.var(), "series-groupby-var")
+    assert_dask_graph(ddf.groupby("b").a.cov(), "series-groupby-cov")
+    assert_dask_graph(ddf.groupby("b").a.first(), "series-groupby-first")
+    assert_dask_graph(ddf.groupby("b").a.last(), "series-groupby-last")
+    assert_dask_graph(ddf.groupby("b").a.prod(), "series-groupby-prod")
     # mean consists from sum and count operations
-    assert_dask_graph(ddf.groupby('b').a.mean(), 'series-groupby-sum')
-    assert_dask_graph(ddf.groupby('b').a.mean(), 'series-groupby-count')
-    assert_dask_graph(ddf.groupby('b').a.nunique(), 'series-groupby-nunique')
-    assert_dask_graph(ddf.groupby('b').a.size(), 'series-groupby-size')
+    assert_dask_graph(ddf.groupby("b").a.mean(), "series-groupby-sum")
+    assert_dask_graph(ddf.groupby("b").a.mean(), "series-groupby-count")
+    assert_dask_graph(ddf.groupby("b").a.nunique(), "series-groupby-nunique")
+    assert_dask_graph(ddf.groupby("b").a.size(), "series-groupby-size")
 
-    assert_dask_graph(ddf.groupby('b').sum(), 'dataframe-groupby-sum')
-    assert_dask_graph(ddf.groupby('b').min(), 'dataframe-groupby-min')
-    assert_dask_graph(ddf.groupby('b').max(), 'dataframe-groupby-max')
-    assert_dask_graph(ddf.groupby('b').count(), 'dataframe-groupby-count')
-    assert_dask_graph(ddf.groupby('b').first(), 'dataframe-groupby-first')
-    assert_dask_graph(ddf.groupby('b').last(), 'dataframe-groupby-last')
-    assert_dask_graph(ddf.groupby('b').prod(), 'dataframe-groupby-prod')
+    assert_dask_graph(ddf.groupby("b").sum(), "dataframe-groupby-sum")
+    assert_dask_graph(ddf.groupby("b").min(), "dataframe-groupby-min")
+    assert_dask_graph(ddf.groupby("b").max(), "dataframe-groupby-max")
+    assert_dask_graph(ddf.groupby("b").count(), "dataframe-groupby-count")
+    assert_dask_graph(ddf.groupby("b").first(), "dataframe-groupby-first")
+    assert_dask_graph(ddf.groupby("b").last(), "dataframe-groupby-last")
+    assert_dask_graph(ddf.groupby("b").prod(), "dataframe-groupby-prod")
     # mean consists from sum and count operations
-    assert_dask_graph(ddf.groupby('b').mean(), 'dataframe-groupby-sum')
-    assert_dask_graph(ddf.groupby('b').mean(), 'dataframe-groupby-count')
-    assert_dask_graph(ddf.groupby('b').size(), 'dataframe-groupby-size')
+    assert_dask_graph(ddf.groupby("b").mean(), "dataframe-groupby-sum")
+    assert_dask_graph(ddf.groupby("b").mean(), "dataframe-groupby-count")
+    assert_dask_graph(ddf.groupby("b").size(), "dataframe-groupby-size")
 
 
-@pytest.mark.parametrize('keyword', ['split_every', 'split_out'])
+@pytest.mark.parametrize("keyword", ["split_every", "split_out"])
 def test_groupby_reduction_split(keyword):
-    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 100,
-                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100})
+    pdf = pd.DataFrame(
+        {"a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 100, "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100}
+    )
     ddf = dd.from_pandas(pdf, npartitions=15)
 
     def call(g, m, **kwargs):
@@ -616,29 +715,29 @@ def test_groupby_reduction_split(keyword):
     # DataFrame
     for m in AGG_FUNCS:
         # nunique is not implemented for DataFrameGroupBy
-        if m == 'nunique':
+        if m == "nunique":
             continue
-        res = call(ddf.groupby('b'), m, **{keyword: 2})
-        sol = call(pdf.groupby('b'), m)
+        res = call(ddf.groupby("b"), m, **{keyword: 2})
+        sol = call(pdf.groupby("b"), m)
         assert_eq(res, sol)
-        assert call(ddf.groupby('b'), m)._name != res._name
+        assert call(ddf.groupby("b"), m)._name != res._name
 
-    res = call(ddf.groupby('b'), 'var', ddof=2, **{keyword: 2})
-    sol = call(pdf.groupby('b'), 'var', ddof=2)
+    res = call(ddf.groupby("b"), "var", ddof=2, **{keyword: 2})
+    sol = call(pdf.groupby("b"), "var", ddof=2)
     assert_eq(res, sol)
-    assert call(ddf.groupby('b'), 'var', ddof=2)._name != res._name
+    assert call(ddf.groupby("b"), "var", ddof=2)._name != res._name
 
     # Series, post select
     for m in AGG_FUNCS:
-        res = call(ddf.groupby('b').a, m, **{keyword: 2})
-        sol = call(pdf.groupby('b').a, m)
+        res = call(ddf.groupby("b").a, m, **{keyword: 2})
+        sol = call(pdf.groupby("b").a, m)
         assert_eq(res, sol)
-        assert call(ddf.groupby('b').a, m)._name != res._name
+        assert call(ddf.groupby("b").a, m)._name != res._name
 
-    res = call(ddf.groupby('b').a, 'var', ddof=2, **{keyword: 2})
-    sol = call(pdf.groupby('b').a, 'var', ddof=2)
+    res = call(ddf.groupby("b").a, "var", ddof=2, **{keyword: 2})
+    sol = call(pdf.groupby("b").a, "var", ddof=2)
     assert_eq(res, sol)
-    assert call(ddf.groupby('b').a, 'var', ddof=2)._name != res._name
+    assert call(ddf.groupby("b").a, "var", ddof=2)._name != res._name
 
     # Series, pre select
     for m in AGG_FUNCS:
@@ -649,231 +748,305 @@ def test_groupby_reduction_split(keyword):
         assert_eq(res, sol, check_names=False)
         assert call(ddf.a.groupby(ddf.b), m)._name != res._name
 
-    res = call(ddf.a.groupby(ddf.b), 'var', ddof=2, **{keyword: 2})
-    sol = call(pdf.a.groupby(pdf.b), 'var', ddof=2)
+    res = call(ddf.a.groupby(ddf.b), "var", ddof=2, **{keyword: 2})
+    sol = call(pdf.a.groupby(pdf.b), "var", ddof=2)
     assert_eq(res, sol)
-    assert call(ddf.a.groupby(ddf.b), 'var', ddof=2)._name != res._name
+    assert call(ddf.a.groupby(ddf.b), "var", ddof=2)._name != res._name
 
 
 def test_apply_shuffle():
-    pdf = pd.DataFrame({'A': [1, 2, 3, 4] * 5,
-                        'B': np.random.randn(20),
-                        'C': np.random.randn(20),
-                        'D': np.random.randn(20)})
+    pdf = pd.DataFrame(
+        {
+            "A": [1, 2, 3, 4] * 5,
+            "B": np.random.randn(20),
+            "C": np.random.randn(20),
+            "D": np.random.randn(20),
+        }
+    )
     ddf = dd.from_pandas(pdf, 3)
 
     with pytest.warns(UserWarning):  # meta inference
-        assert_eq(ddf.groupby('A').apply(lambda x: x.sum()),
-                  pdf.groupby('A').apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby("A").apply(lambda x: x.sum()),
+            pdf.groupby("A").apply(lambda x: x.sum()),
+        )
 
-        assert_eq(ddf.groupby(ddf['A']).apply(lambda x: x.sum()),
-                  pdf.groupby(pdf['A']).apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby(ddf["A"]).apply(lambda x: x.sum()),
+            pdf.groupby(pdf["A"]).apply(lambda x: x.sum()),
+        )
 
-        assert_eq(ddf.groupby(ddf['A'] + 1).apply(lambda x: x.sum()),
-                  pdf.groupby(pdf['A'] + 1).apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby(ddf["A"] + 1).apply(lambda x: x.sum()),
+            pdf.groupby(pdf["A"] + 1).apply(lambda x: x.sum()),
+        )
 
         # SeriesGroupBy
-        assert_eq(ddf.groupby('A')['B'].apply(lambda x: x.sum()),
-                  pdf.groupby('A')['B'].apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby("A")["B"].apply(lambda x: x.sum()),
+            pdf.groupby("A")["B"].apply(lambda x: x.sum()),
+        )
 
-        assert_eq(ddf.groupby(ddf['A'])['B'].apply(lambda x: x.sum()),
-                  pdf.groupby(pdf['A'])['B'].apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby(ddf["A"])["B"].apply(lambda x: x.sum()),
+            pdf.groupby(pdf["A"])["B"].apply(lambda x: x.sum()),
+        )
 
-        assert_eq(ddf.groupby(ddf['A'] + 1)['B'].apply(lambda x: x.sum()),
-                  pdf.groupby(pdf['A'] + 1)['B'].apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby(ddf["A"] + 1)["B"].apply(lambda x: x.sum()),
+            pdf.groupby(pdf["A"] + 1)["B"].apply(lambda x: x.sum()),
+        )
 
         # Series.groupby
-        assert_eq(ddf.B.groupby(ddf['A']).apply(lambda x: x.sum()),
-                  pdf.B.groupby(pdf['A']).apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.B.groupby(ddf["A"]).apply(lambda x: x.sum()),
+            pdf.B.groupby(pdf["A"]).apply(lambda x: x.sum()),
+        )
 
-        assert_eq(ddf.B.groupby(ddf['A'] + 1).apply(lambda x: x.sum()),
-                  pdf.B.groupby(pdf['A'] + 1).apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.B.groupby(ddf["A"] + 1).apply(lambda x: x.sum()),
+            pdf.B.groupby(pdf["A"] + 1).apply(lambda x: x.sum()),
+        )
 
         # DataFrameGroupBy with column slice
-        assert_eq(ddf.groupby('A')[['B', 'C']].apply(lambda x: x.sum()),
-                  pdf.groupby('A')[['B', 'C']].apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby("A")[["B", "C"]].apply(lambda x: x.sum()),
+            pdf.groupby("A")[["B", "C"]].apply(lambda x: x.sum()),
+        )
 
-        assert_eq(ddf.groupby(ddf['A'])[['B', 'C']].apply(lambda x: x.sum()),
-                  pdf.groupby(pdf['A'])[['B', 'C']].apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby(ddf["A"])[["B", "C"]].apply(lambda x: x.sum()),
+            pdf.groupby(pdf["A"])[["B", "C"]].apply(lambda x: x.sum()),
+        )
 
-        assert_eq(ddf.groupby(ddf['A'] + 1)[['B', 'C']].apply(lambda x: x.sum()),
-                  pdf.groupby(pdf['A'] + 1)[['B', 'C']].apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby(ddf["A"] + 1)[["B", "C"]].apply(lambda x: x.sum()),
+            pdf.groupby(pdf["A"] + 1)[["B", "C"]].apply(lambda x: x.sum()),
+        )
 
 
-@pytest.mark.parametrize('grouper', [
-    lambda df: 'AA',
-    lambda df: ['AA', 'AB'],
-    lambda df: df['AA'],
-    lambda df: [df['AA'], df['AB']],
-    lambda df: df['AA'] + 1,
-    pytest.param(lambda df: [df['AA'] + 1, df['AB'] + 1], marks=pytest.mark.xfail("NotImplemented"))
-])
+@pytest.mark.parametrize(
+    "grouper",
+    [
+        lambda df: "AA",
+        lambda df: ["AA", "AB"],
+        lambda df: df["AA"],
+        lambda df: [df["AA"], df["AB"]],
+        lambda df: df["AA"] + 1,
+        pytest.param(
+            lambda df: [df["AA"] + 1, df["AB"] + 1],
+            marks=pytest.mark.xfail("NotImplemented"),
+        ),
+    ],
+)
 def test_apply_shuffle_multilevel(grouper):
-    pdf = pd.DataFrame({'AB': [1, 2, 3, 4] * 5,
-                        'AA': [1, 2, 3, 4] * 5,
-                        'B': np.random.randn(20),
-                        'C': np.random.randn(20),
-                        'D': np.random.randn(20)})
+    pdf = pd.DataFrame(
+        {
+            "AB": [1, 2, 3, 4] * 5,
+            "AA": [1, 2, 3, 4] * 5,
+            "B": np.random.randn(20),
+            "C": np.random.randn(20),
+            "D": np.random.randn(20),
+        }
+    )
     ddf = dd.from_pandas(pdf, 3)
 
     with pytest.warns(UserWarning):
         # DataFrameGroupBy
-        assert_eq(ddf.groupby(grouper(ddf)).apply(lambda x: x.sum()),
-                  pdf.groupby(grouper(pdf)).apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby(grouper(ddf)).apply(lambda x: x.sum()),
+            pdf.groupby(grouper(pdf)).apply(lambda x: x.sum()),
+        )
 
         # SeriesGroupBy
-        assert_eq(ddf.groupby(grouper(ddf))['B'].apply(lambda x: x.sum()),
-                  pdf.groupby(grouper(pdf))['B'].apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby(grouper(ddf))["B"].apply(lambda x: x.sum()),
+            pdf.groupby(grouper(pdf))["B"].apply(lambda x: x.sum()),
+        )
 
         # DataFrameGroupBy with column slice
-        assert_eq(ddf.groupby(grouper(ddf))[['B', 'C']].apply(lambda x: x.sum()),
-                  pdf.groupby(grouper(pdf))[['B', 'C']].apply(lambda x: x.sum()))
+        assert_eq(
+            ddf.groupby(grouper(ddf))[["B", "C"]].apply(lambda x: x.sum()),
+            pdf.groupby(grouper(pdf))[["B", "C"]].apply(lambda x: x.sum()),
+        )
 
 
 def test_numeric_column_names():
     # df.groupby(0)[df.columns] fails if all columns are numbers (pandas bug)
     # This ensures that we cast all column iterables to list beforehand.
-    df = pd.DataFrame({0: [0, 1, 0, 1],
-                       1: [1, 2, 3, 4],
-                       2: [0, 1, 0, 1], })
+    df = pd.DataFrame({0: [0, 1, 0, 1], 1: [1, 2, 3, 4], 2: [0, 1, 0, 1]})
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf.groupby(0).sum(), df.groupby(0).sum())
     assert_eq(ddf.groupby([0, 2]).sum(), df.groupby([0, 2]).sum())
-    assert_eq(ddf.groupby(0).apply(lambda x: x, meta={0: int, 1: int, 2: int}),
-              df.groupby(0).apply(lambda x: x))
+    assert_eq(
+        ddf.groupby(0).apply(lambda x: x, meta={0: int, 1: int, 2: int}),
+        df.groupby(0).apply(lambda x: x),
+    )
 
 
 def test_groupby_apply_tasks():
     df = pd.util.testing.makeTimeDataFrame()
-    df['A'] = df.A // 0.1
-    df['B'] = df.B // 0.1
+    df["A"] = df.A // 0.1
+    df["B"] = df.B // 0.1
     ddf = dd.from_pandas(df, npartitions=10)
 
-    with dask.config.set(shuffle='tasks'):
-        for ind in [lambda x: 'A', lambda x: x.A]:
+    with dask.config.set(shuffle="tasks"):
+        for ind in [lambda x: "A", lambda x: x.A]:
             a = df.groupby(ind(df)).apply(len)
             with pytest.warns(UserWarning):
                 b = ddf.groupby(ind(ddf)).apply(len)
             assert_eq(a, b.compute())
-            assert not any('partd' in k[0] for k in b.dask)
+            assert not any("partd" in k[0] for k in b.dask)
 
             a = df.groupby(ind(df)).B.apply(len)
             with pytest.warns(UserWarning):
                 b = ddf.groupby(ind(ddf)).B.apply(len)
             assert_eq(a, b.compute())
-            assert not any('partd' in k[0] for k in b.dask)
+            assert not any("partd" in k[0] for k in b.dask)
 
 
 def test_groupby_multiprocessing():
-    df = pd.DataFrame({'A': [1, 2, 3, 4, 5],
-                       'B': ['1', '1', 'a', 'a', 'a']})
+    df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": ["1", "1", "a", "a", "a"]})
     ddf = dd.from_pandas(df, npartitions=3)
-    with dask.config.set(scheduler='processes'):
-        assert_eq(ddf.groupby('B').apply(lambda x: x, meta={"A": int,
-                                                            "B": object}),
-                  df.groupby('B').apply(lambda x: x))
+    with dask.config.set(scheduler="processes"):
+        assert_eq(
+            ddf.groupby("B").apply(lambda x: x, meta={"A": int, "B": object}),
+            df.groupby("B").apply(lambda x: x),
+        )
 
 
 def test_groupby_normalize_index():
-    full = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
-                         'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-                        index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
+    full = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
+        index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
+    )
     d = dd.from_pandas(full, npartitions=3)
 
-    assert d.groupby('a').index == 'a'
-    assert d.groupby(d['a']).index == 'a'
-    assert d.groupby(d['a'] > 2).index._name == (d['a'] > 2)._name
-    assert d.groupby(['a', 'b']).index == ['a', 'b']
+    assert d.groupby("a").index == "a"
+    assert d.groupby(d["a"]).index == "a"
+    assert d.groupby(d["a"] > 2).index._name == (d["a"] > 2)._name
+    assert d.groupby(["a", "b"]).index == ["a", "b"]
 
-    assert d.groupby([d['a'], d['b']]).index == ['a', 'b']
-    assert d.groupby([d['a'], 'b']).index == ['a', 'b']
+    assert d.groupby([d["a"], d["b"]]).index == ["a", "b"]
+    assert d.groupby([d["a"], "b"]).index == ["a", "b"]
 
 
-@pytest.mark.parametrize('spec', [
-    {'b': {'c': 'mean'}, 'c': {'a': 'max', 'b': 'min'}},
-    {'b': 'mean', 'c': ['min', 'max']},
-    {'b': np.sum, 'c': ['min', np.max, np.std, np.var]},
-    ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'first', 'last', 'prod'],
-    'var',
-    {'b': 'mean', 'c': 'first', 'd': 'last', 'a': ['first', 'last']},
-    {'b': {'c': 'mean'}, 'c': {'a': 'first', 'b': 'last'}},
-])
-@pytest.mark.parametrize('split_every', [False, None])
-@pytest.mark.parametrize('grouper', [
-    lambda df: 'a',
-    lambda df: ['a', 'd'],
-    lambda df: [df['a'], df['d']],
-    lambda df: df['a'],
-    lambda df: df['a'] > 2,
-])
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"b": {"c": "mean"}, "c": {"a": "max", "b": "min"}},
+        {"b": "mean", "c": ["min", "max"]},
+        {"b": np.sum, "c": ["min", np.max, np.std, np.var]},
+        [
+            "sum",
+            "mean",
+            "min",
+            "max",
+            "count",
+            "size",
+            "std",
+            "var",
+            "first",
+            "last",
+            "prod",
+        ],
+        "var",
+        {"b": "mean", "c": "first", "d": "last", "a": ["first", "last"]},
+        {"b": {"c": "mean"}, "c": {"a": "first", "b": "last"}},
+    ],
+)
+@pytest.mark.parametrize("split_every", [False, None])
+@pytest.mark.parametrize(
+    "grouper",
+    [
+        lambda df: "a",
+        lambda df: ["a", "d"],
+        lambda df: [df["a"], df["d"]],
+        lambda df: df["a"],
+        lambda df: df["a"] > 2,
+    ],
+)
 def test_aggregate__examples(spec, split_every, grouper):
-    pdf = pd.DataFrame({'a': [1, 2, 3, 1, 1, 2, 4, 3, 7] * 10,
-                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-                        'd': [3, 2, 1, 3, 2, 1, 2, 6, 4] * 10},
-                       columns=['c', 'b', 'a', 'd'])
+    pdf = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 1, 1, 2, 4, 3, 7] * 10,
+            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
+            "d": [3, 2, 1, 3, 2, 1, 2, 6, 4] * 10,
+        },
+        columns=["c", "b", "a", "d"],
+    )
     ddf = dd.from_pandas(pdf, npartitions=10)
 
     # Warning from pandas deprecation .agg(dict[dict])
     # it's from pandas, so no reason to assert the deprecation warning,
     # but we should still test it for now
     with pytest.warns(None):
-        assert_eq(pdf.groupby(grouper(pdf)).agg(spec),
-                  ddf.groupby(grouper(ddf)).agg(spec, split_every=split_every))
+        assert_eq(
+            pdf.groupby(grouper(pdf)).agg(spec),
+            ddf.groupby(grouper(ddf)).agg(spec, split_every=split_every),
+        )
 
 
-@pytest.mark.parametrize('spec', [
-    {'b': 'sum', 'c': 'min', 'd': 'max'},
-    ['sum'],
-    ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'first', 'last'],
-    'sum', 'size',
-])
-@pytest.mark.parametrize('split_every', [False, None])
-@pytest.mark.parametrize('grouper', [
-    lambda df: [df['a'], df['d']],
-    lambda df: df['a'],
-    lambda df: df['a'] > 2,
-])
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"b": "sum", "c": "min", "d": "max"},
+        ["sum"],
+        ["sum", "mean", "min", "max", "count", "size", "std", "var", "first", "last"],
+        "sum",
+        "size",
+    ],
+)
+@pytest.mark.parametrize("split_every", [False, None])
+@pytest.mark.parametrize(
+    "grouper",
+    [lambda df: [df["a"], df["d"]], lambda df: df["a"], lambda df: df["a"] > 2],
+)
 def test_series_aggregate__examples(spec, split_every, grouper):
-    pdf = pd.DataFrame({'a': [1, 2, 3, 1, 1, 2, 4, 3, 7] * 10,
-                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-                        'd': [3, 2, 1, 3, 2, 1, 2, 6, 4] * 10},
-                       columns=['c', 'b', 'a', 'd'])
-    ps = pdf['c']
+    pdf = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 1, 1, 2, 4, 3, 7] * 10,
+            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
+            "d": [3, 2, 1, 3, 2, 1, 2, 6, 4] * 10,
+        },
+        columns=["c", "b", "a", "d"],
+    )
+    ps = pdf["c"]
 
     ddf = dd.from_pandas(pdf, npartitions=10)
-    ds = ddf['c']
+    ds = ddf["c"]
     # Warning from pandas deprecation .agg(dict[dict])
     # it's from pandas, so no reason to assert the deprecation warning,
     # but we should still test it for now
     with pytest.warns(None):
-        assert_eq(ps.groupby(grouper(pdf)).agg(spec),
-                  ds.groupby(grouper(ddf)).agg(spec, split_every=split_every))
+        assert_eq(
+            ps.groupby(grouper(pdf)).agg(spec),
+            ds.groupby(grouper(ddf)).agg(spec, split_every=split_every),
+        )
 
 
 def test_aggregate__single_element_groups(agg_func):
     spec = agg_func
 
     # nunique is not supported in specs
-    if spec == 'nunique':
+    if spec == "nunique":
         return
 
-    pdf = pd.DataFrame({'a': [1, 1, 3, 3],
-                        'b': [4, 4, 16, 16],
-                        'c': [1, 1, 4, 4],
-                        'd': [1, 1, 3, 3]},
-                       columns=['c', 'b', 'a', 'd'])
+    pdf = pd.DataFrame(
+        {"a": [1, 1, 3, 3], "b": [4, 4, 16, 16], "c": [1, 1, 4, 4], "d": [1, 1, 3, 3]},
+        columns=["c", "b", "a", "d"],
+    )
     ddf = dd.from_pandas(pdf, npartitions=3)
 
-    expected = pdf.groupby(['a', 'd']).agg(spec)
+    expected = pdf.groupby(["a", "d"]).agg(spec)
 
     # NOTE: for std the result is not recast ot the original dtype
-    if spec in {'mean', 'var'}:
+    if spec in {"mean", "var"}:
         expected = expected.astype(float)
 
-    assert_eq(expected,
-              ddf.groupby(['a', 'd']).agg(spec))
+    assert_eq(expected, ddf.groupby(["a", "d"]).agg(spec))
 
 
 def test_aggregate_build_agg_args__reuse_of_intermediates():
@@ -883,19 +1056,18 @@ def test_aggregate_build_agg_args__reuse_of_intermediates():
     """
     from dask.dataframe.groupby import _build_agg_args
 
-    no_mean_spec = [
-        ('foo', 'sum', 'input'),
-        ('bar', 'count', 'input'),
-    ]
+    no_mean_spec = [("foo", "sum", "input"), ("bar", "count", "input")]
 
     with_mean_spec = [
-        ('foo', 'sum', 'input'),
-        ('bar', 'count', 'input'),
-        ('baz', 'mean', 'input'),
+        ("foo", "sum", "input"),
+        ("bar", "count", "input"),
+        ("baz", "mean", "input"),
     ]
 
     no_mean_chunks, no_mean_aggs, no_mean_finalizers = _build_agg_args(no_mean_spec)
-    with_mean_chunks, with_mean_aggs, with_mean_finalizers = _build_agg_args(with_mean_spec)
+    with_mean_chunks, with_mean_aggs, with_mean_finalizers = _build_agg_args(
+        with_mean_spec
+    )
 
     assert len(no_mean_chunks) == len(with_mean_chunks)
     assert len(no_mean_aggs) == len(with_mean_aggs)
@@ -905,31 +1077,55 @@ def test_aggregate_build_agg_args__reuse_of_intermediates():
 
 
 def test_aggregate__dask():
-    dask_holder = collections.namedtuple('dask_holder', ['dask'])
-    get_agg_dask = lambda obj: dask_holder({
-        k: v for (k, v) in obj.dask.items() if k[0].startswith('aggregate')
-    })
+    dask_holder = collections.namedtuple("dask_holder", ["dask"])
+    get_agg_dask = lambda obj: dask_holder(
+        {k: v for (k, v) in obj.dask.items() if k[0].startswith("aggregate")}
+    )
 
     specs = [
-        {'b': {'c': 'mean'}, 'c': {'a': 'max', 'b': 'min'}},
-        {'b': 'mean', 'c': ['min', 'max']},
-        ['sum', 'mean', 'min', 'max', 'count', 'size', 'std', 'var', 'first', 'last', 'prod'],
-        'sum', 'mean', 'min', 'max', 'count', 'std', 'var', 'first', 'last', 'prod'
-
+        {"b": {"c": "mean"}, "c": {"a": "max", "b": "min"}},
+        {"b": "mean", "c": ["min", "max"]},
+        [
+            "sum",
+            "mean",
+            "min",
+            "max",
+            "count",
+            "size",
+            "std",
+            "var",
+            "first",
+            "last",
+            "prod",
+        ],
+        "sum",
+        "mean",
+        "min",
+        "max",
+        "count",
+        "std",
+        "var",
+        "first",
+        "last",
+        "prod"
         # NOTE: the 'size' spec is special since it bypasses aggregate
         # 'size'
     ]
 
-    pdf = pd.DataFrame({'a': [1, 2, 3, 1, 1, 2, 4, 3, 7] * 100,
-                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100,
-                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 100,
-                        'd': [3, 2, 1, 3, 2, 1, 2, 6, 4] * 100},
-                       columns=['c', 'b', 'a', 'd'])
+    pdf = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 1, 1, 2, 4, 3, 7] * 100,
+            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100,
+            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 100,
+            "d": [3, 2, 1, 3, 2, 1, 2, 6, 4] * 100,
+        },
+        columns=["c", "b", "a", "d"],
+    )
     ddf = dd.from_pandas(pdf, npartitions=100)
 
     for spec in specs:
-        result1 = ddf.groupby(['a', 'b']).agg(spec, split_every=2)
-        result2 = ddf.groupby(['a', 'b']).agg(spec, split_every=2)
+        result1 = ddf.groupby(["a", "b"]).agg(spec, split_every=2)
+        result2 = ddf.groupby(["a", "b"]).agg(spec, split_every=2)
 
         agg_dask1 = get_agg_dask(result1)
         agg_dask2 = get_agg_dask(result2)
@@ -943,47 +1139,63 @@ def test_aggregate__dask():
 
         # the length of the dask does not depend on the passed spec
         for other_spec in specs:
-            other = ddf.groupby(['a', 'b']).agg(other_spec, split_every=2)
+            other = ddf.groupby(["a", "b"]).agg(other_spec, split_every=2)
             assert len(other.dask) == len(result1.dask)
             assert len(other.dask) == len(result2.dask)
 
 
-@pytest.mark.parametrize('grouper', [
-    lambda df: ['a'],
-    lambda df: ['a', 'b'],
-    lambda df: df['a'],
-    lambda df: [df['a'], df['b']],
-    lambda df: [df['a'] > 2, df['b'] > 1]
-])
+@pytest.mark.parametrize(
+    "grouper",
+    [
+        lambda df: ["a"],
+        lambda df: ["a", "b"],
+        lambda df: df["a"],
+        lambda df: [df["a"], df["b"]],
+        lambda df: [df["a"] > 2, df["b"] > 1],
+    ],
+)
 def test_dataframe_aggregations_multilevel(grouper, agg_func):
     def call(g, m, **kwargs):
         return getattr(g, m)(**kwargs)
 
-    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
-                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-                        'd': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10},
-                       columns=['c', 'b', 'a', 'd'])
+    pdf = pd.DataFrame(
+        {
+            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
+            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+            "d": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
+            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
+        },
+        columns=["c", "b", "a", "d"],
+    )
 
     ddf = dd.from_pandas(pdf, npartitions=10)
 
-    assert_eq(call(pdf.groupby(grouper(pdf))['c'], agg_func),
-              call(ddf.groupby(grouper(ddf))['c'], agg_func, split_every=2))
+    assert_eq(
+        call(pdf.groupby(grouper(pdf))["c"], agg_func),
+        call(ddf.groupby(grouper(ddf))["c"], agg_func, split_every=2),
+    )
 
     # not supported by pandas
-    if agg_func != 'nunique':
-        assert_eq(call(pdf.groupby(grouper(pdf))[['c', 'd']], agg_func),
-                  call(ddf.groupby(grouper(ddf))[['c', 'd']], agg_func, split_every=2))
+    if agg_func != "nunique":
+        assert_eq(
+            call(pdf.groupby(grouper(pdf))[["c", "d"]], agg_func),
+            call(ddf.groupby(grouper(ddf))[["c", "d"]], agg_func, split_every=2),
+        )
 
-        assert_eq(call(pdf.groupby(grouper(pdf)), agg_func),
-                  call(ddf.groupby(grouper(ddf)), agg_func, split_every=2))
+        assert_eq(
+            call(pdf.groupby(grouper(pdf)), agg_func),
+            call(ddf.groupby(grouper(ddf)), agg_func, split_every=2),
+        )
 
 
-@pytest.mark.parametrize('grouper', [
-    lambda df: df['a'],
-    lambda df: [df['a'], df['b']],
-    lambda df: [df['a'] > 2, df['b'] > 1]
-])
+@pytest.mark.parametrize(
+    "grouper",
+    [
+        lambda df: df["a"],
+        lambda df: [df["a"], df["b"]],
+        lambda df: [df["a"] > 2, df["b"] > 1],
+    ],
+)
 def test_series_aggregations_multilevel(grouper, agg_func):
     """
     similar to ``test_dataframe_aggregations_multilevel``, but series do not
@@ -993,38 +1205,58 @@ def test_series_aggregations_multilevel(grouper, agg_func):
     def call(g, m, **kwargs):
         return getattr(g, m)(**kwargs)
 
-    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
-                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10},
-                       columns=['c', 'b', 'a'])
+    pdf = pd.DataFrame(
+        {
+            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
+            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
+        },
+        columns=["c", "b", "a"],
+    )
 
     ddf = dd.from_pandas(pdf, npartitions=10)
 
-    assert_eq(call(pdf['c'].groupby(grouper(pdf)), agg_func),
-              call(ddf['c'].groupby(grouper(ddf)), agg_func, split_every=2),
-              # for pandas ~ 0.18, the name is not not properly propagated for
-              # the mean aggregation
-              check_names=(agg_func not in {'mean', 'nunique'}))
+    assert_eq(
+        call(pdf["c"].groupby(grouper(pdf)), agg_func),
+        call(ddf["c"].groupby(grouper(ddf)), agg_func, split_every=2),
+        # for pandas ~ 0.18, the name is not not properly propagated for
+        # the mean aggregation
+        check_names=(agg_func not in {"mean", "nunique"}),
+    )
 
 
-@pytest.mark.parametrize('grouper', [
-    lambda df: df['a'],
-    lambda df: df['a'] > 2,
-    lambda df: [df['a'], df['b']],
-    lambda df: [df['a'] > 2],
-    pytest.param(lambda df: [df['a'] > 2, df['b'] > 1], marks=pytest.mark.xfail(
-        reason="index dtype does not coincide: boolean != empty"))
-])
-@pytest.mark.parametrize('group_and_slice', [
-    lambda df, grouper: df.groupby(grouper(df)),
-    lambda df, grouper: df['c'].groupby(grouper(df)),
-    lambda df, grouper: df.groupby(grouper(df))['c'],
-])
+@pytest.mark.parametrize(
+    "grouper",
+    [
+        lambda df: df["a"],
+        lambda df: df["a"] > 2,
+        lambda df: [df["a"], df["b"]],
+        lambda df: [df["a"] > 2],
+        pytest.param(
+            lambda df: [df["a"] > 2, df["b"] > 1],
+            marks=pytest.mark.xfail(
+                reason="index dtype does not coincide: boolean != empty"
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "group_and_slice",
+    [
+        lambda df, grouper: df.groupby(grouper(df)),
+        lambda df, grouper: df["c"].groupby(grouper(df)),
+        lambda df, grouper: df.groupby(grouper(df))["c"],
+    ],
+)
 def test_groupby_meta_content(group_and_slice, grouper):
-    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
-                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10},
-                       columns=['c', 'b', 'a'])
+    pdf = pd.DataFrame(
+        {
+            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
+            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
+        },
+        columns=["c", "b", "a"],
+    )
 
     ddf = dd.from_pandas(pdf, npartitions=10)
 
@@ -1037,43 +1269,51 @@ def test_groupby_meta_content(group_and_slice, grouper):
 
 
 def test_groupy_non_aligned_index():
-    pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
-                        'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-                        'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10},
-                       columns=['c', 'b', 'a'])
+    pdf = pd.DataFrame(
+        {
+            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
+            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
+        },
+        columns=["c", "b", "a"],
+    )
 
     ddf3 = dd.from_pandas(pdf, npartitions=3)
     ddf7 = dd.from_pandas(pdf, npartitions=7)
 
     # working examples
-    ddf3.groupby(['a', 'b'])
-    ddf3.groupby([ddf3['a'], ddf3['b']])
+    ddf3.groupby(["a", "b"])
+    ddf3.groupby([ddf3["a"], ddf3["b"]])
 
     # misaligned divisions
     with pytest.raises(NotImplementedError):
-        ddf3.groupby(ddf7['a'])
+        ddf3.groupby(ddf7["a"])
 
     with pytest.raises(NotImplementedError):
-        ddf3.groupby([ddf7['a'], ddf7['b']])
+        ddf3.groupby([ddf7["a"], ddf7["b"]])
 
     with pytest.raises(NotImplementedError):
-        ddf3.groupby([ddf7['a'], ddf3['b']])
+        ddf3.groupby([ddf7["a"], ddf3["b"]])
 
     with pytest.raises(NotImplementedError):
-        ddf3.groupby([ddf3['a'], ddf7['b']])
+        ddf3.groupby([ddf3["a"], ddf7["b"]])
 
     with pytest.raises(NotImplementedError):
-        ddf3.groupby([ddf7['a'], 'b'])
+        ddf3.groupby([ddf7["a"], "b"])
 
 
 def test_groupy_series_wrong_grouper():
-    df = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
-                       'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-                       'c': [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10},
-                      columns=['c', 'b', 'a'])
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
+            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
+            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
+        },
+        columns=["c", "b", "a"],
+    )
 
     df = dd.from_pandas(df, npartitions=3)
-    s = df['a']
+    s = df["a"]
 
     # working index values
     s.groupby(s)
@@ -1081,10 +1321,10 @@ def test_groupy_series_wrong_grouper():
 
     # non working index values
     with pytest.raises(KeyError):
-        s.groupby('foo')
+        s.groupby("foo")
 
     with pytest.raises(KeyError):
-        s.groupby([s, 'foo'])
+        s.groupby([s, "foo"])
 
     with pytest.raises(ValueError):
         s.groupby(df)
@@ -1093,87 +1333,89 @@ def test_groupy_series_wrong_grouper():
         s.groupby([s, df])
 
 
-@pytest.mark.parametrize('npartitions', [1, 4, 20])
-@pytest.mark.parametrize('split_every', [2, 5])
-@pytest.mark.parametrize('split_out', [None, 1, 5, 20])
+@pytest.mark.parametrize("npartitions", [1, 4, 20])
+@pytest.mark.parametrize("split_every", [2, 5])
+@pytest.mark.parametrize("split_out", [None, 1, 5, 20])
 def test_hash_groupby_aggregate(npartitions, split_every, split_out):
-    df = pd.DataFrame({'x': np.arange(100) % 10,
-                       'y': np.ones(100)})
+    df = pd.DataFrame({"x": np.arange(100) % 10, "y": np.ones(100)})
     ddf = dd.from_pandas(df, npartitions)
 
-    result = ddf.groupby('x').y.var(split_every=split_every,
-                                    split_out=split_out)
+    result = ddf.groupby("x").y.var(split_every=split_every, split_out=split_out)
 
     dsk = result.__dask_optimize__(result.dask, result.__dask_keys__())
     from dask.core import get_deps
+
     dependencies, dependents = get_deps(dsk)
 
     assert result.npartitions == (split_out or 1)
     assert len([k for k, v in dependencies.items() if not v]) == npartitions
 
-    assert_eq(result, df.groupby('x').y.var())
+    assert_eq(result, df.groupby("x").y.var())
 
 
 def test_split_out_multi_column_groupby():
-    df = pd.DataFrame({'x': np.arange(100) % 10,
-                       'y': np.ones(100),
-                       'z': [1, 2, 3, 4, 5] * 20})
+    df = pd.DataFrame(
+        {"x": np.arange(100) % 10, "y": np.ones(100), "z": [1, 2, 3, 4, 5] * 20}
+    )
 
     ddf = dd.from_pandas(df, npartitions=10)
 
-    result = ddf.groupby(['x', 'y']).z.mean(split_out=4)
-    expected = df.groupby(['x', 'y']).z.mean()
+    result = ddf.groupby(["x", "y"]).z.mean(split_out=4)
+    expected = df.groupby(["x", "y"]).z.mean()
 
     assert_eq(result, expected, check_dtype=False)
 
 
 def test_groupby_split_out_num():
     # GH 1841
-    ddf = dd.from_pandas(pd.DataFrame({'A': [1, 1, 2, 2],
-                                       'B': [1, 2, 3, 4]}),
-                         npartitions=2)
-    assert ddf.groupby('A').sum().npartitions == 1
-    assert ddf.groupby('A').sum(split_out=2).npartitions == 2
-    assert ddf.groupby('A').sum(split_out=3).npartitions == 3
+    ddf = dd.from_pandas(
+        pd.DataFrame({"A": [1, 1, 2, 2], "B": [1, 2, 3, 4]}), npartitions=2
+    )
+    assert ddf.groupby("A").sum().npartitions == 1
+    assert ddf.groupby("A").sum(split_out=2).npartitions == 2
+    assert ddf.groupby("A").sum(split_out=3).npartitions == 3
 
     with pytest.raises(TypeError):
         # groupby doesn't adcept split_out
-        ddf.groupby('A', split_out=2)
+        ddf.groupby("A", split_out=2)
 
 
 def test_groupby_not_supported():
-    ddf = dd.from_pandas(pd.DataFrame({'A': [1, 1, 2, 2],
-                                       'B': [1, 2, 3, 4]}),
-                         npartitions=2)
+    ddf = dd.from_pandas(
+        pd.DataFrame({"A": [1, 1, 2, 2], "B": [1, 2, 3, 4]}), npartitions=2
+    )
     with pytest.raises(TypeError):
-        ddf.groupby('A', axis=1)
+        ddf.groupby("A", axis=1)
     with pytest.raises(TypeError):
-        ddf.groupby('A', level=1)
+        ddf.groupby("A", level=1)
     with pytest.raises(TypeError):
-        ddf.groupby('A', as_index=False)
+        ddf.groupby("A", as_index=False)
     with pytest.raises(TypeError):
-        ddf.groupby('A', sort=False)
+        ddf.groupby("A", sort=False)
     with pytest.raises(TypeError):
-        ddf.groupby('A', squeeze=True)
+        ddf.groupby("A", squeeze=True)
 
 
 def test_groupby_numeric_column():
-    df = pd.DataFrame({'A': ['foo', 'foo', 'bar'], 0: [1, 2, 3]})
+    df = pd.DataFrame({"A": ["foo", "foo", "bar"], 0: [1, 2, 3]})
     ddf = dd.from_pandas(df, npartitions=3)
 
-    assert_eq(ddf.groupby(ddf.A)[0].sum(),
-              df.groupby(df.A)[0].sum())
+    assert_eq(ddf.groupby(ddf.A)[0].sum(), df.groupby(df.A)[0].sum())
 
 
-@pytest.mark.parametrize('sel', ['c', 'd', ['c', 'd']])
-@pytest.mark.parametrize('key', ['a', ['a', 'b']])
-@pytest.mark.parametrize('func', ['cumsum', 'cumprod', 'cumcount'])
+@pytest.mark.parametrize("sel", ["c", "d", ["c", "d"]])
+@pytest.mark.parametrize("key", ["a", ["a", "b"]])
+@pytest.mark.parametrize("func", ["cumsum", "cumprod", "cumcount"])
 def test_cumulative(func, key, sel):
-    df = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 6,
-                       'b': [4, 2, 7, 3, 3, 1, 1, 1, 2] * 6,
-                       'c': np.random.randn(54),
-                       'd': np.random.randn(54)},
-                      columns=['a', 'b', 'c', 'd'])
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 6,
+            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 6,
+            "c": np.random.randn(54),
+            "d": np.random.randn(54),
+        },
+        columns=["a", "b", "c", "d"],
+    )
     df.iloc[[-18, -12, -6], -1] = np.nan
     ddf = dd.from_pandas(df, npartitions=10)
 
@@ -1181,21 +1423,30 @@ def test_cumulative(func, key, sel):
     assert_eq(getattr(g, func)(), getattr(dg, func)())
 
 
-@pytest.mark.parametrize('func', ['cumsum', 'cumprod'])
+@pytest.mark.parametrize("func", ["cumsum", "cumprod"])
 def test_cumulative_axis1(func):
-    df = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7] * 2,
-                       'b': np.random.randn(18),
-                       'c': np.random.randn(18)})
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 2,
+            "b": np.random.randn(18),
+            "c": np.random.randn(18),
+        }
+    )
     df.iloc[-6, -1] = np.nan
     ddf = dd.from_pandas(df, npartitions=4)
-    assert_eq(getattr(df.groupby('a'), func)(axis=1),
-              getattr(ddf.groupby('a'), func)(axis=1))
+    assert_eq(
+        getattr(df.groupby("a"), func)(axis=1), getattr(ddf.groupby("a"), func)(axis=1)
+    )
 
 
 def test_groupby_unaligned_index():
-    df = pd.DataFrame({'a': np.random.randint(0, 10, 50),
-                       'b': np.random.randn(50),
-                       'c': np.random.randn(50)})
+    df = pd.DataFrame(
+        {
+            "a": np.random.randint(0, 10, 50),
+            "b": np.random.randn(50),
+            "c": np.random.randn(50),
+        }
+    )
     ddf = dd.from_pandas(df, npartitions=5)
     filtered = df[df.b < 0.5]
     dfiltered = ddf[ddf.b < 0.5]
@@ -1203,14 +1454,16 @@ def test_groupby_unaligned_index():
     ddf_group = dfiltered.groupby(ddf.a)
     ds_group = dfiltered.b.groupby(ddf.a)
 
-    bad = [ddf_group.mean(),
-           ddf_group.var(),
-           ddf_group.b.nunique(),
-           ddf_group.get_group(0),
-           ds_group.mean(),
-           ds_group.var(),
-           ds_group.nunique(),
-           ds_group.get_group(0)]
+    bad = [
+        ddf_group.mean(),
+        ddf_group.var(),
+        ddf_group.b.nunique(),
+        ddf_group.get_group(0),
+        ds_group.mean(),
+        ds_group.var(),
+        ds_group.nunique(),
+        ds_group.get_group(0),
+    ]
 
     for obj in bad:
         with pytest.raises(ValueError):
@@ -1220,8 +1473,10 @@ def test_groupby_unaligned_index():
         return x + 1
 
     df_group = filtered.groupby(df.a)
-    good = [(ddf_group.apply(add1, meta=ddf), df_group.apply(add1)),
-            (ddf_group.b.apply(add1, meta=ddf.b), df_group.b.apply(add1))]
+    good = [
+        (ddf_group.apply(add1, meta=ddf), df_group.apply(add1)),
+        (ddf_group.b.apply(add1, meta=ddf.b), df_group.b.apply(add1)),
+    ]
 
     for (res, sol) in good:
         assert_eq(res, sol)
@@ -1232,19 +1487,20 @@ def test_groupby_dataframe_cum_caching():
 
     Relates to #3756.
     """
-    df = pd.DataFrame(dict(a=list('aabbcc')),
-                      index=pd.date_range(start='20100101', periods=6))
-    df['ones'] = 1
-    df['twos'] = 2
+    df = pd.DataFrame(
+        dict(a=list("aabbcc")), index=pd.date_range(start="20100101", periods=6)
+    )
+    df["ones"] = 1
+    df["twos"] = 2
 
     ddf = dd.from_pandas(df, npartitions=3)
 
-    ops = ['cumsum', 'cumprod']
+    ops = ["cumsum", "cumprod"]
 
     for op in ops:
-        ddf0 = getattr(ddf.groupby(['a']), op)()
-        ddf1 = ddf.rename(columns={'ones': 'foo', 'twos': 'bar'})
-        ddf1 = getattr(ddf1.groupby(['a']), op)()
+        ddf0 = getattr(ddf.groupby(["a"]), op)()
+        ddf1 = ddf.rename(columns={"ones": "foo", "twos": "bar"})
+        ddf1 = getattr(ddf1.groupby(["a"]), op)()
 
         # _a and _b dataframe should be equal
         res0_a, res1_a = dask.compute(ddf0, ddf1)
@@ -1259,20 +1515,21 @@ def test_groupby_series_cum_caching():
 
     Relates to #3755
     """
-    df = pd.DataFrame(dict(a=list('aabbcc')),
-                      index=pd.date_range(start='20100101', periods=6))
-    df['ones'] = 1
-    df['twos'] = 2
+    df = pd.DataFrame(
+        dict(a=list("aabbcc")), index=pd.date_range(start="20100101", periods=6)
+    )
+    df["ones"] = 1
+    df["twos"] = 2
 
-    ops = ['cumsum', 'cumprod']
+    ops = ["cumsum", "cumprod"]
     for op in ops:
         ddf = dd.from_pandas(df, npartitions=3)
-        dcum = ddf.groupby(['a'])
-        res0_a, res1_a = dask.compute(getattr(dcum['ones'], op)(),
-                                      getattr(dcum['twos'], op)())
-        cum = df.groupby(['a'])
-        res0_b, res1_b = (getattr(cum['ones'], op)(),
-                          getattr(cum['twos'], op)())
+        dcum = ddf.groupby(["a"])
+        res0_a, res1_a = dask.compute(
+            getattr(dcum["ones"], op)(), getattr(dcum["twos"], op)()
+        )
+        cum = df.groupby(["a"])
+        res0_b, res1_b = (getattr(cum["ones"], op)(), getattr(cum["twos"], op)())
 
         assert res0_a.equals(res0_b)
         assert res1_a.equals(res1_b)
@@ -1281,47 +1538,63 @@ def test_groupby_series_cum_caching():
 def test_groupby_slice_agg_reduces():
     d = pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, 5]})
     a = dd.from_pandas(d, npartitions=2)
-    result = a.groupby("a")["b"].agg(['min', 'max'])
-    expected = d.groupby("a")['b'].agg(['min', 'max'])
+    result = a.groupby("a")["b"].agg(["min", "max"])
+    expected = d.groupby("a")["b"].agg(["min", "max"])
     assert_eq(result, expected)
 
 
 def test_groupby_agg_grouper_single():
     # https://github.com/dask/dask/issues/2255
-    d = pd.DataFrame({'a': [1, 2, 3, 4]})
+    d = pd.DataFrame({"a": [1, 2, 3, 4]})
     a = dd.from_pandas(d, npartitions=2)
 
-    result = a.groupby('a')['a'].agg(['min', 'max'])
-    expected = d.groupby('a')['a'].agg(['min', 'max'])
+    result = a.groupby("a")["a"].agg(["min", "max"])
+    expected = d.groupby("a")["a"].agg(["min", "max"])
     assert_eq(result, expected)
 
 
-@pytest.mark.parametrize('slice_', [
-    'a', ['a'], ['a', 'b'], ['b'],
-])
+@pytest.mark.parametrize("slice_", ["a", ["a"], ["a", "b"], ["b"]])
 def test_groupby_agg_grouper_multiple(slice_):
     # https://github.com/dask/dask/issues/2255
-    d = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [1, 2, 3, 4]})
+    d = pd.DataFrame({"a": [1, 2, 3, 4], "b": [1, 2, 3, 4]})
     a = dd.from_pandas(d, npartitions=2)
 
-    result = a.groupby('a')[slice_].agg(['min', 'max'])
-    expected = d.groupby('a')[slice_].agg(['min', 'max'])
+    result = a.groupby("a")[slice_].agg(["min", "max"])
+    expected = d.groupby("a")[slice_].agg(["min", "max"])
     assert_eq(result, expected)
 
 
-@pytest.mark.parametrize('agg_func', [
-    'cumprod', 'cumcount', 'cumsum', 'var', 'sum', 'mean', 'count', 'size',
-    'std', 'min', 'max', 'first', 'last', 'prod'
-])
+@pytest.mark.parametrize(
+    "agg_func",
+    [
+        "cumprod",
+        "cumcount",
+        "cumsum",
+        "var",
+        "sum",
+        "mean",
+        "count",
+        "size",
+        "std",
+        "min",
+        "max",
+        "first",
+        "last",
+        "prod",
+    ],
+)
 def test_groupby_column_and_index_agg_funcs(agg_func):
     def call(g, m, **kwargs):
         return getattr(g, m)(**kwargs)
 
-    df = pd.DataFrame({'idx': [1, 1, 1, 2, 2, 2],
-                       'a': [1, 2, 1, 2, 1, 2],
-                       'b': np.arange(6),
-                       'c': [1, 1, 1, 2, 2, 2]}
-                      ).set_index('idx')
+    df = pd.DataFrame(
+        {
+            "idx": [1, 1, 1, 2, 2, 2],
+            "a": [1, 2, 1, 2, 1, 2],
+            "b": np.arange(6),
+            "c": [1, 1, 1, 2, 2, 2],
+        }
+    ).set_index("idx")
 
     ddf = dd.from_pandas(df, npartitions=df.index.nunique())
     ddf_no_divs = dd.from_pandas(df, npartitions=df.index.nunique(), sort=False)
@@ -1329,70 +1602,69 @@ def test_groupby_column_and_index_agg_funcs(agg_func):
     # Index and then column
 
     # Compute expected result
-    expected = call(df.groupby(['idx', 'a']), agg_func)
-    if agg_func in {'mean', 'var'}:
+    expected = call(df.groupby(["idx", "a"]), agg_func)
+    if agg_func in {"mean", "var"}:
         expected = expected.astype(float)
 
-    result = call(ddf.groupby(['idx', 'a']), agg_func)
+    result = call(ddf.groupby(["idx", "a"]), agg_func)
     assert_eq(expected, result)
 
-    result = call(ddf_no_divs.groupby(['idx', 'a']), agg_func)
+    result = call(ddf_no_divs.groupby(["idx", "a"]), agg_func)
     assert_eq(expected, result)
 
     # apply-combine-apply aggregation functions
-    aca_agg = {'sum', 'mean', 'var', 'size', 'std', 'count', 'first', 'last', 'prod'}
+    aca_agg = {"sum", "mean", "var", "size", "std", "count", "first", "last", "prod"}
 
     # Test aggregate strings
     if agg_func in aca_agg:
-        result = ddf_no_divs.groupby(['idx', 'a']).agg(agg_func)
+        result = ddf_no_divs.groupby(["idx", "a"]).agg(agg_func)
         assert_eq(expected, result)
 
     # Column and then index
 
     # Compute expected result
-    expected = call(df.groupby(['a', 'idx']), agg_func)
-    if agg_func in {'mean', 'var'}:
+    expected = call(df.groupby(["a", "idx"]), agg_func)
+    if agg_func in {"mean", "var"}:
         expected = expected.astype(float)
 
-    result = call(ddf.groupby(['a', 'idx']), agg_func)
+    result = call(ddf.groupby(["a", "idx"]), agg_func)
     assert_eq(expected, result)
 
-    result = call(ddf_no_divs.groupby(['a', 'idx']), agg_func)
+    result = call(ddf_no_divs.groupby(["a", "idx"]), agg_func)
     assert_eq(expected, result)
 
     # Test aggregate strings
     if agg_func in aca_agg:
-        result = ddf_no_divs.groupby(['a', 'idx']).agg(agg_func)
+        result = ddf_no_divs.groupby(["a", "idx"]).agg(agg_func)
         assert_eq(expected, result)
 
     # Index only
 
     # Compute expected result
-    expected = call(df.groupby('idx'), agg_func)
-    if agg_func in {'mean', 'var'}:
+    expected = call(df.groupby("idx"), agg_func)
+    if agg_func in {"mean", "var"}:
         expected = expected.astype(float)
 
-    result = call(ddf.groupby('idx'), agg_func)
+    result = call(ddf.groupby("idx"), agg_func)
     assert_eq(expected, result)
 
-    result = call(ddf_no_divs.groupby('idx'), agg_func)
+    result = call(ddf_no_divs.groupby("idx"), agg_func)
     assert_eq(expected, result)
 
     # Test aggregate strings
     if agg_func in aca_agg:
-        result = ddf_no_divs.groupby('idx').agg(agg_func)
+        result = ddf_no_divs.groupby("idx").agg(agg_func)
         assert_eq(expected, result)
 
 
+@pytest.mark.parametrize("group_args", [["idx", "a"], ["a", "idx"], ["idx"], "idx"])
 @pytest.mark.parametrize(
-    'group_args', [['idx', 'a'], ['a', 'idx'], ['idx'], 'idx'])
-@pytest.mark.parametrize(
-    'apply_func', [np.min, np.mean, lambda s: np.max(s) - np.mean(s)])
+    "apply_func", [np.min, np.mean, lambda s: np.max(s) - np.mean(s)]
+)
 def test_groupby_column_and_index_apply(group_args, apply_func):
-    df = pd.DataFrame({'idx': [1, 1, 1, 2, 2, 2],
-                       'a': [1, 2, 1, 2, 1, 2],
-                       'b': np.arange(6)}
-                      ).set_index('idx')
+    df = pd.DataFrame(
+        {"idx": [1, 1, 1, 2, 2, 2], "a": [1, 2, 1, 2, 1, 2], "b": np.arange(6)}
+    ).set_index("idx")
 
     ddf = dd.from_pandas(df, npartitions=df.index.nunique())
     ddf_no_divs = dd.from_pandas(df, npartitions=df.index.nunique(), sort=False)
@@ -1401,7 +1673,7 @@ def test_groupby_column_and_index_apply(group_args, apply_func):
     expected = df.groupby(group_args).apply(apply_func)
 
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
+        warnings.simplefilter("ignore")
 
         # Compute on dask DataFrame with divisions (no shuffling)
         result = ddf.groupby(group_args).apply(apply_func)
@@ -1427,65 +1699,71 @@ def test_groupby_column_and_index_apply(group_args, apply_func):
 
 
 custom_mean = dd.Aggregation(
-    'mean',
+    "mean",
     lambda s: (s.count(), s.sum()),
     lambda s0, s1: (s0.sum(), s1.sum()),
     lambda s0, s1: s1 / s0,
 )
 
-custom_sum = dd.Aggregation('sum', lambda s: s.sum(), lambda s0: s0.sum())
+custom_sum = dd.Aggregation("sum", lambda s: s.sum(), lambda s0: s0.sum())
 
 
-@pytest.mark.parametrize('pandas_spec, dask_spec, check_dtype', [
-    ({'b': 'mean'}, {'b': custom_mean}, False),
-    ({'b': 'sum'}, {'b': custom_sum}, True),
-    (['mean', 'sum'], [custom_mean, custom_sum], False),
-    ({'b': ['mean', 'sum']}, {'b': [custom_mean, custom_sum]}, False),
-])
+@pytest.mark.parametrize(
+    "pandas_spec, dask_spec, check_dtype",
+    [
+        ({"b": "mean"}, {"b": custom_mean}, False),
+        ({"b": "sum"}, {"b": custom_sum}, True),
+        (["mean", "sum"], [custom_mean, custom_sum], False),
+        ({"b": ["mean", "sum"]}, {"b": [custom_mean, custom_sum]}, False),
+    ],
+)
 def test_dataframe_groupby_agg_custom_sum(pandas_spec, dask_spec, check_dtype):
-    df = pd.DataFrame({'g': [0, 0, 1] * 3, 'b': [1, 2, 3] * 3})
+    df = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3})
     ddf = dd.from_pandas(df, npartitions=2)
 
-    expected = df.groupby('g').aggregate(pandas_spec)
-    result = ddf.groupby('g').aggregate(dask_spec)
+    expected = df.groupby("g").aggregate(pandas_spec)
+    result = ddf.groupby("g").aggregate(dask_spec)
 
     assert_eq(result, expected, check_dtype=check_dtype)
 
 
-@pytest.mark.parametrize('pandas_spec, dask_spec', [
-    ('mean', custom_mean),
-    (['mean'], [custom_mean]),
-    (['mean', 'sum'], [custom_mean, custom_sum]),
-])
+@pytest.mark.parametrize(
+    "pandas_spec, dask_spec",
+    [
+        ("mean", custom_mean),
+        (["mean"], [custom_mean]),
+        (["mean", "sum"], [custom_mean, custom_sum]),
+    ],
+)
 def test_series_groupby_agg_custom_mean(pandas_spec, dask_spec):
-    d = pd.DataFrame({'g': [0, 0, 1] * 3, 'b': [1, 2, 3] * 3})
+    d = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3})
     a = dd.from_pandas(d, npartitions=2)
 
-    expected = d['b'].groupby(d['g']).aggregate(pandas_spec)
-    result = a['b'].groupby(a['g']).aggregate(dask_spec)
+    expected = d["b"].groupby(d["g"]).aggregate(pandas_spec)
+    result = a["b"].groupby(a["g"]).aggregate(dask_spec)
 
     assert_eq(result, expected, check_dtype=False)
 
 
 def test_groupby_agg_custom__name_clash_with_internal_same_column():
     """for a single input column only unique names are allowed"""
-    d = pd.DataFrame({'g': [0, 0, 1] * 3, 'b': [1, 2, 3] * 3})
+    d = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3})
     a = dd.from_pandas(d, npartitions=2)
 
-    agg_func = dd.Aggregation('sum', lambda s: s.sum(), lambda s0: s0.sum())
+    agg_func = dd.Aggregation("sum", lambda s: s.sum(), lambda s0: s0.sum())
 
     with pytest.raises(ValueError):
-        a.groupby('g').aggregate({'b': [agg_func, 'sum']})
+        a.groupby("g").aggregate({"b": [agg_func, "sum"]})
 
 
 def test_groupby_agg_custom__name_clash_with_internal_different_column():
     """custom aggregation functions can share the name of a builtin function"""
-    d = pd.DataFrame({'g': [0, 0, 1] * 3, 'b': [1, 2, 3] * 3, 'c': [4, 5, 6] * 3})
+    d = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3, "c": [4, 5, 6] * 3})
     a = dd.from_pandas(d, npartitions=2)
 
     # NOTE: this function is purposefully misnamed
     agg_func = dd.Aggregation(
-        'sum',
+        "sum",
         lambda s: (s.count(), s.sum()),
         lambda s0, s1: (s0.sum(), s1.sum()),
         lambda s0, s1: s1 / s0,
@@ -1493,8 +1771,8 @@ def test_groupby_agg_custom__name_clash_with_internal_different_column():
 
     # NOTE: the name of agg-func is suppressed in the output,
     # since only a single agg func per column was specified
-    result = a.groupby('g').aggregate({'b': agg_func, 'c': 'sum'})
-    expected = d.groupby('g').aggregate({'b': 'mean', 'c': 'sum'})
+    result = a.groupby("g").aggregate({"b": agg_func, "c": "sum"})
+    expected = d.groupby("g").aggregate({"b": "mean", "c": "sum"})
 
     assert_eq(result, expected, check_dtype=False)
 
@@ -1506,7 +1784,7 @@ def test_groupby_agg_custom__mode():
         def impl(s):
             res, = s.iloc[0]
 
-            for i, in s.iloc[1:]:
+            for (i,) in s.iloc[1:]:
                 res = res.add(i, fill_value=0)
 
             return [res]
@@ -1514,52 +1792,56 @@ def test_groupby_agg_custom__mode():
         return s.apply(impl)
 
     agg_func = dd.Aggregation(
-        'custom_mode',
+        "custom_mode",
         lambda s: s.apply(lambda s: [s.value_counts()]),
         agg_mode,
         lambda s: s.map(lambda i: i[0].idxmax()),
     )
 
-    d = pd.DataFrame({
-        'g0': [0, 0, 0, 1, 1] * 3,
-        'g1': [0, 0, 0, 1, 1] * 3,
-        'cc': [4, 5, 4, 6, 6] * 3,
-    })
+    d = pd.DataFrame(
+        {
+            "g0": [0, 0, 0, 1, 1] * 3,
+            "g1": [0, 0, 0, 1, 1] * 3,
+            "cc": [4, 5, 4, 6, 6] * 3,
+        }
+    )
     a = dd.from_pandas(d, npartitions=5)
 
-    actual = a['cc'].groupby([a['g0'], a['g1']]).agg(agg_func)
+    actual = a["cc"].groupby([a["g0"], a["g1"]]).agg(agg_func)
 
     # cheat to get the correct index
-    expected = pd.DataFrame({'g0': [0, 1], 'g1': [0, 1], 'cc': [4, 6]})
-    expected = expected['cc'].groupby([expected['g0'], expected['g1']]).agg('sum')
+    expected = pd.DataFrame({"g0": [0, 1], "g1": [0, 1], "cc": [4, 6]})
+    expected = expected["cc"].groupby([expected["g0"], expected["g1"]]).agg("sum")
 
     assert_eq(actual, expected)
 
 
 def test_groupby_select_column_agg():
-    pdf = pd.DataFrame({'A': [1, 2, 3, 1, 2, 3, 1, 2, 4],
-                        'B': [-0.776, -0.4, -0.873, 0.054, 1.419, -0.948,
-                              -0.967, -1.714, -0.666]})
+    pdf = pd.DataFrame(
+        {
+            "A": [1, 2, 3, 1, 2, 3, 1, 2, 4],
+            "B": [-0.776, -0.4, -0.873, 0.054, 1.419, -0.948, -0.967, -1.714, -0.666],
+        }
+    )
     ddf = dd.from_pandas(pdf, npartitions=4)
-    actual = ddf.groupby('A')['B'].agg('var')
-    expected = pdf.groupby('A')['B'].agg('var')
+    actual = ddf.groupby("A")["B"].agg("var")
+    expected = pdf.groupby("A")["B"].agg("var")
     assert_eq(actual, expected)
 
 
-@pytest.mark.parametrize('func', [
-    lambda x: x.std(),
-    lambda x: x.groupby('x').std(),
-    lambda x: x.groupby('x').var(),
-    lambda x: x.groupby('x').mean(),
-    lambda x: x.groupby('x').sum(),
-    lambda x: x.groupby('x').z.std(),
-])
+@pytest.mark.parametrize(
+    "func",
+    [
+        lambda x: x.std(),
+        lambda x: x.groupby("x").std(),
+        lambda x: x.groupby("x").var(),
+        lambda x: x.groupby("x").mean(),
+        lambda x: x.groupby("x").sum(),
+        lambda x: x.groupby("x").z.std(),
+    ],
+)
 def test_std_object_dtype(func):
-    df = pd.DataFrame({
-        'x': [1, 2, 1],
-        'y': ['a', 'b', 'c'],
-        'z': [11., 22., 33.],
-    })
+    df = pd.DataFrame({"x": [1, 2, 1], "y": ["a", "b", "c"], "z": [11.0, 22.0, 33.0]})
     ddf = dd.from_pandas(df, npartitions=2)
 
     assert_eq(func(df), func(ddf))
@@ -1567,47 +1849,69 @@ def test_std_object_dtype(func):
 
 def test_timeseries():
     df = dask.datasets.timeseries().partitions[:2]
-    assert_eq(df.groupby('name').std(),
-              df.groupby('name').std())
+    assert_eq(df.groupby("name").std(), df.groupby("name").std())
 
 
-@pytest.mark.skipif(PANDAS_VERSION < '0.22.0',
-                    reason="Parameter min_count not implemented in "
-                           "DataFrame.groupby().sum() and DataFrame.groupby().prod()")
-@pytest.mark.parametrize('min_count', [0, 1, 2, 3])
+@pytest.mark.skipif(
+    PANDAS_VERSION < "0.22.0",
+    reason="Parameter min_count not implemented in "
+    "DataFrame.groupby().sum() and DataFrame.groupby().prod()",
+)
+@pytest.mark.parametrize("min_count", [0, 1, 2, 3])
 def test_with_min_count(min_count):
-    dfs = [pd.DataFrame({
-                        'group':['A', 'A', 'B'],
-                        'val1':[np.nan, 2, 3],
-                        'val2':[np.nan, 5, 6],
-                        'val3':[5, 4, 9]
-                        }),
-           pd.DataFrame({
-                        'group':['A', 'A', 'B'],
-                        'val1':[2, np.nan, np.nan],
-                        'val2':[np.nan, 5, 6],
-                        'val3':[5, 4, 9]
-                        })]
+    dfs = [
+        pd.DataFrame(
+            {
+                "group": ["A", "A", "B"],
+                "val1": [np.nan, 2, 3],
+                "val2": [np.nan, 5, 6],
+                "val3": [5, 4, 9],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "group": ["A", "A", "B"],
+                "val1": [2, np.nan, np.nan],
+                "val2": [np.nan, 5, 6],
+                "val3": [5, 4, 9],
+            }
+        ),
+    ]
     ddfs = [dd.from_pandas(df, npartitions=4) for df in dfs]
 
     for df, ddf in zip(dfs, ddfs):
-        assert_eq(df.groupby('group').sum(min_count=min_count),
-                  ddf.groupby('group').sum(min_count=min_count))
-        assert_eq(df.groupby('group').prod(min_count=min_count),
-                  ddf.groupby('group').prod(min_count=min_count))
+        assert_eq(
+            df.groupby("group").sum(min_count=min_count),
+            ddf.groupby("group").sum(min_count=min_count),
+        )
+        assert_eq(
+            df.groupby("group").prod(min_count=min_count),
+            ddf.groupby("group").prod(min_count=min_count),
+        )
 
 
 def test_groupby_group_keys():
-    df = pd.DataFrame({
-        'a': [1, 2, 2, 3],
-        'b': [2, 3, 4, 5],
-    })
-    ddf = dd.from_pandas(df, npartitions=2).set_index('a')
-    pdf = df.set_index('a')
+    df = pd.DataFrame({"a": [1, 2, 2, 3], "b": [2, 3, 4, 5]})
+    ddf = dd.from_pandas(df, npartitions=2).set_index("a")
+    pdf = df.set_index("a")
 
     func = lambda g: g.copy()
-    expected = pdf.groupby('a').apply(func)
-    assert_eq(expected, ddf.groupby('a').apply(func, meta=expected))
+    expected = pdf.groupby("a").apply(func)
+    assert_eq(expected, ddf.groupby("a").apply(func, meta=expected))
 
-    expected = pdf.groupby('a', group_keys=False).apply(func)
-    assert_eq(expected, ddf.groupby('a', group_keys=False).apply(func, meta=expected))
+    expected = pdf.groupby("a", group_keys=False).apply(func)
+    assert_eq(expected, ddf.groupby("a", group_keys=False).apply(func, meta=expected))
+
+
+def test_groupby_cov():
+    rows = 20
+    cols = 3
+    np.random.seed(11)
+    data = np.random.randn(rows, cols)
+    df = pd.DataFrame(data, columns=list("abc"))
+    df["key"] = np.random.randint(0, cols, size=rows)
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    expected = df.groupby("key").cov()
+    result = ddf.groupby("key").cov()
+    assert_eq(expected, result)

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -232,6 +232,7 @@ Groupby Operations
    DataFrameGroupBy.std
    DataFrameGroupBy.sum
    DataFrameGroupBy.var
+   DataFrameGroupBy.cov
    DataFrameGroupBy.first
    DataFrameGroupBy.last
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

This PR will close https://github.com/dask/dask/issues/4828 .  The algorithm follows a similar path as `variance` in each block we calculate means, sums, and counts and aggregate all the results at the end to call

> cov(x, y) = (x_i `*` x_j - x_mu `*` y_mu) 