### PR TITLE
Add documentation for dataframe reshape methods

### DIFF
--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -246,8 +246,8 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
     Unpivots a DataFrame from wide format to long format, optionally leaving identifier variables set.
 
     This function is useful to massage a DataFrame into a format where one or more columns are identifier variables
-    (``id_vars``), while all other columns, considered measured variables (``value_vars``), are "unpivoted" to the row axis,
-    leaving just two non-identifier columns, 'variable' and 'value'.
+    (``id_vars``), while all other columns, considered measured variables (``value_vars``), are "unpivoted" to the row
+    axis, leaving just two non-identifier columns, 'variable' and 'value'.
 
     Parameters
     ----------

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -183,6 +183,10 @@ def pivot_table(df, index=None, columns=None,
     Returns
     -------
     table : DataFrame
+
+    See Also
+    --------
+    pandas.pivot_table
     """
 
     if not is_scalar(index) or index is None:

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -186,7 +186,7 @@ def pivot_table(df, index=None, columns=None,
 
     See Also
     --------
-    pandas.pivot_table
+    pandas.DataFrame.pivot_table
     """
 
     if not is_scalar(index) or index is None:
@@ -242,6 +242,38 @@ def pivot_table(df, index=None, columns=None,
 
 def melt(frame, id_vars=None, value_vars=None, var_name=None,
          value_name='value', col_level=None):
+    """
+    Unpivots a DataFrame from wide format to long format, optionally leaving identifier variables set.
+
+    This function is useful to massage a DataFrame into a format where one or more columns are identifier variables
+    (``id_vars``), while all other columns, considered measured variables (``value_vars``), are "unpivoted" to the row axis,
+    leaving just two non-identifier columns, 'variable' and 'value'.
+
+    Parameters
+    ----------
+    frame : DataFrame
+    id_vars : tuple, list, or ndarray, optional
+        Column(s) to use as identifier variables.
+    value_vars : tuple, list, or ndarray, optional
+        Column(s) to unpivot. If not specified, uses all columns that
+        are not set as `id_vars`.
+    var_name : scalar
+        Name to use for the 'variable' column. If None it uses
+        ``frame.columns.name`` or 'variable'.
+    value_name : scalar, default 'value'
+        Name to use for the 'value' column.
+    col_level : int or string, optional
+        If columns are a MultiIndex then use this level to melt.
+
+    Returns
+    -------
+    DataFrame
+        Unpivoted DataFrame.
+
+    See Also
+    --------
+    pandas.DataFrame.melt
+    """
 
     from dask.dataframe.core import no_default
 

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -171,13 +171,13 @@ def pivot_table(df, index=None, columns=None,
 
     Parameters
     ----------
-    data : DataFrame
-    values : scalar
-        column to aggregate
+    df : DataFrame
     index : scalar
         column to be index
     columns : scalar
         column to be columns
+    values : scalar
+        column to aggregate
     aggfunc : {'mean', 'sum', 'count'}, default 'mean'
 
     Returns

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -325,6 +325,17 @@ Covert DataFrames
    to_dask_array
    to_delayed
 
+Reshape DataFrames
+~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: dask.dataframe.reshape
+
+.. autosummary::
+
+   get_dummies
+   pivot_table
+   melt
+
 DataFrame Methods
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -411,3 +411,5 @@ Other functions
 .. currentmodule:: dask.dataframe.reshape
 
 .. autofunction:: get_dummies
+.. autofunction:: pivot_table
+

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -412,4 +412,4 @@ Other functions
 
 .. autofunction:: get_dummies
 .. autofunction:: pivot_table
-
+.. autofunction:: melt

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -407,3 +407,7 @@ Other functions
 
 .. autofunction:: concat
 .. autofunction:: merge
+
+.. currentmodule:: dask.dataframe.reshape
+
+.. autofunction:: get_dummies


### PR DESCRIPTION
Adds some documentation for the DataFrame reshape methods.

Do not have examples for `pivot_table` and `melt`, unless we want to borrow the ones from Pandas.

Reference issue: #4825 