### PR TITLE
Defer order/casting einsum parameters to NumPy implementation

### DIFF
--- a/dask/array/einsumfuncs.py
+++ b/dask/array/einsumfuncs.py
@@ -194,14 +194,9 @@ def parse_einsum_input(operands):
 
 @derived_from(np)
 def einsum(*operands, **kwargs):
-    casting = kwargs.pop('casting', 'safe')
     dtype = kwargs.pop('dtype', None)
     optimize = kwargs.pop('optimize', False)
-    order = kwargs.pop('order', 'K')
     split_every = kwargs.pop('split_every', None)
-    if kwargs:
-        raise TypeError("einsum() got unexpected keyword "
-                        "argument(s) %s" % ",".join(kwargs))
 
     einsum_dtype = dtype
 
@@ -237,8 +232,8 @@ def einsum(*operands, **kwargs):
                        adjust_chunks={ind: 1 for ind in contract_inds}, dtype=dtype,
                        # np.einsum parameters
                        subscripts=subscripts, kernel_dtype=einsum_dtype,
-                       ncontract_inds=ncontract_inds, order=order,
-                       casting=casting, optimize=optimize)
+                       ncontract_inds=ncontract_inds,
+                       optimize=optimize, **kwargs)
 
     # Now reduce over any extra contraction dimensions
     if ncontract_inds > 0:

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1529,7 +1529,7 @@ def test_einsum_split_every(split_every):
 def test_einsum_invalid_args():
     _, da_inputs = _numpy_and_dask_inputs('a')
     with pytest.raises(TypeError):
-        da.einsum('a', *da_inputs, foo=1, bar=2)
+        da.einsum('a', *da_inputs, foo=1, bar=2).compute()
 
 
 def test_einsum_broadcasting_contraction():


### PR DESCRIPTION
This is one of requirements to fix #4898, together with https://github.com/cupy/cupy/pull/2249 and NumPy `_implementation` attribute from https://github.com/numpy/numpy/pull/13627.

Thanks @mrocklin for the guidelines on deferring non-Dask specific `kwargs` to the backend library (NumPy, CuPy, etc.).

A test for this already exists https://github.com/dask/dask/blob/4d3a48ee6d5e2b63fef1b0e6740b6478261cdaea/dask/array/tests/test_cupy.py#L60

cc @jakirkham 