### PR TITLE
Merge dtype warning

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -329,17 +329,24 @@ def warn_dtype_mismatch(left, right, left_on, right_on):
     """ Checks for merge column dtype mismatches and throws a warning (#4574)
     """
 
-    dtype_mism = {(lo, ro): (left.dtypes[lo], right.dtypes[ro])
-                  for lo, ro in zip(left_on, right_on)
-                  if not left.dtypes[lo] is right.dtypes[ro]}
+    if not isinstance(left_on, list):
+        left_on = [left_on]
+    if not isinstance(right_on, list):
+        right_on = [right_on]
 
-    if dtype_mism:
-        col_str = '\n'.join('{}: {}'.format(cols, dtypes)
-                            for cols, dtypes in dtype_mism.items())
+    if (all(col in left.columns for col in left_on) and
+            all(col in right.columns for col in right_on)):
+        dtype_mism = {(lo, ro): (left.dtypes[lo], right.dtypes[ro])
+                      for lo, ro in zip(left_on, right_on)
+                      if not left.dtypes[lo] is right.dtypes[ro]}
 
-        warnings.warn(('Merging dataframes with merge column data '
-                       'type mismatches: \n{}\nCast dtypes explicitly to '
-                       'avoid unexpected results.').format(col_str))
+        if dtype_mism:
+            col_str = '\n'.join('{}: {}'.format(cols, dtypes)
+                                for cols, dtypes in dtype_mism.items())
+
+            warnings.warn(('Merging dataframes with merge column data '
+                           'type mismatches: \n{}\nCast dtypes explicitly to '
+                           'avoid unexpected results.').format(col_str))
 
 
 @wraps(pd.merge)

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -330,8 +330,8 @@ def warn_dtype_mismatch(left, right, left_on, right_on):
     """
 
     dtype_mism = {(lo, ro): (left.dtypes[lo], right.dtypes[ro])
-              for lo, ro in zip(left_on, right_on)
-              if not left.dtypes[lo] is right.dtypes[ro]}
+                  for lo, ro in zip(left_on, right_on)
+                  if not left.dtypes[lo] is right.dtypes[ro]}
 
     if dtype_mism:
         col_str = '\n'.join('{}: {}'.format(cols, dtypes)

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -69,7 +69,8 @@ from .core import (_Frame, DataFrame, Series, map_partitions, Index,
 from .io import from_pandas
 from . import methods
 from .shuffle import shuffle, rearrange_by_divisions
-from .utils import strip_unknown_categories, is_dataframe_like, is_series_like
+from .utils import (strip_unknown_categories, is_dataframe_like,
+                    is_series_like, asciitable)
 
 
 def align_partitions(*dfs):
@@ -336,17 +337,17 @@ def warn_dtype_mismatch(left, right, left_on, right_on):
 
     if (all(col in left.columns for col in left_on) and
             all(col in right.columns for col in right_on)):
-        dtype_mism = {(lo, ro): (left.dtypes[lo], right.dtypes[ro])
+        dtype_mism = [((lo, ro), left.dtypes[lo], right.dtypes[ro])
                       for lo, ro in zip(left_on, right_on)
-                      if not left.dtypes[lo] is right.dtypes[ro]}
+                      if not left.dtypes[lo] is right.dtypes[ro]]
 
         if dtype_mism:
-            col_str = '\n'.join('{}: {}'.format(cols, dtypes)
-                                for cols, dtypes in dtype_mism.items())
+            col_tb = asciitable(('Merge columns', 'left dtype', 'right dtype'),
+                                dtype_mism)
 
             warnings.warn(('Merging dataframes with merge column data '
                            'type mismatches: \n{}\nCast dtypes explicitly to '
-                           'avoid unexpected results.').format(col_str))
+                           'avoid unexpected results.').format(col_tb))
 
 
 @wraps(pd.merge)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -346,6 +346,42 @@ def test_concat_different_dtypes(join):
 
 
 @pytest.mark.parametrize('how', ['inner', 'outer', 'left', 'right'])
+@pytest.mark.parametrize('on_index', [True, False])
+def test_merge_columns_dtypes(how, on_index):
+    # tests results of merges with merge columns having different dtypes;
+    # asserts that either the merge was successful or the corresponding warning is raised
+    # addresses issue #4574
+
+    df1 = pd.DataFrame({"A": list(np.arange(5).astype(float)) * 2,
+                        "B": list(np.arange(5)) * 2})
+    df2 = pd.DataFrame({"A": np.arange(5), "B": np.arange(5)})
+
+    a = dd.from_pandas(df1, 2)  # merge column "A" is float
+    b = dd.from_pandas(df2, 2)  # merge column "A" is int
+
+    on = ["A"]
+    left_index = right_index = on_index
+
+    if on_index:
+        a = a.set_index("A")
+        b = b.set_index("A")
+        on = None
+
+    with pytest.warns(None) as record:
+        result = dd.merge(a, b, on=on, how=how,
+                          left_index=left_index, right_index=right_index)
+
+    warned = any('merge column data type mismatches' in str(r) for r in record)
+
+    # result type depends on merge operation -> convert to pandas
+    result = result if isinstance(result, pd.DataFrame) else result.compute()
+
+    has_nans = result.isna().values.any()
+
+    assert (has_nans and warned) or not has_nans
+
+
+@pytest.mark.parametrize('how', ['inner', 'outer', 'left', 'right'])
 @pytest.mark.parametrize('shuffle', ['disk', 'tasks'])
 def test_merge(how, shuffle):
     A = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': [1, 1, 2, 2, 3, 4]})

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -423,6 +423,7 @@ def test_derived_from():
 @pytest.mark.skipif(PY2, reason="Docstrings not as easy to manipulate in Py2")
 def test_derived_from_func():
     import builtins
+
     @derived_from(builtins)
     def sum():
         "extra docstring"


### PR DESCRIPTION
Warning in case of merge column dtype mismatches; this addresses issue #4574.
The added `test_merge_columns_dtypes` function performs various merges and checks that they either produce the expected DataFrames or throw the warning.

- [x] Tests added / passed
- [x] Passes `flake8 dask`
