### PR TITLE
Remove numpy warning in moment calculation

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -4,7 +4,6 @@ import operator
 from functools import partial, wraps
 from itertools import product, repeat
 from math import factorial, log, ceil
-import warnings
 
 import numpy as np
 from numbers import Integral, Number
@@ -467,7 +466,7 @@ def moment_chunk(A, order=2, sum=chunk.sum, numel=numel, dtype='f8', meta=False,
 
     n = n.astype(np.int64)
     total = sum(A, dtype=dtype, **kwargs)
-    with warnings.catch_warnings(record=True):
+    with np.errstate(divide='ignore', invalid='ignore'):
         u = total / n
     xs = [sum((A - u)**i, dtype=dtype, **kwargs) for i in range(2, order + 1)]
     M = np.stack(xs, axis=-1)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -4,6 +4,7 @@ import operator
 from functools import partial, wraps
 from itertools import product, repeat
 from math import factorial, log, ceil
+import warnings
 
 import numpy as np
 from numbers import Integral, Number
@@ -466,7 +467,8 @@ def moment_chunk(A, order=2, sum=chunk.sum, numel=numel, dtype='f8', meta=False,
 
     n = n.astype(np.int64)
     total = sum(A, dtype=dtype, **kwargs)
-    u = total / n
+    with warnings.catch_warnings(record=True):
+        u = total / n
     xs = [sum((A - u)**i, dtype=dtype, **kwargs) for i in range(2, order + 1)]
     M = np.stack(xs, axis=-1)
     return {'total': total, 'n': n, 'M': M}

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3880,3 +3880,12 @@ def test_auto_chunks_h5py():
             with dask.config.set({'array.chunk-size': '1 MiB'}):
                 x = da.from_array(d)
                 assert x.chunks == ((256, 256, 256, 232), (512, 488))
+
+
+def test_no_warnings_from_blockwise():
+    x = da.ones((15, 15), chunks=(5, 5))
+
+    with warnings.catch_warnings(record=True) as record:
+        (x.dot(x.T + 1) - x.mean(axis=0)).std()
+
+    assert not record

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3885,7 +3885,7 @@ def test_auto_chunks_h5py():
 def test_no_warnings_from_blockwise():
     x = da.ones((15, 15), chunks=(5, 5))
 
-    with warnings.catch_warnings(record=True) as record:
+    with pytest.warns(None) as record:
         (x.dot(x.T + 1) - x.mean(axis=0)).std()
 
     assert not record


### PR DESCRIPTION
Previously we would divide by 0 in meta calculations for dask array
moments, which would raise a Numpy RuntimeWarning to users.

Now we avoid that situation, though we may also want to investigate a
more thorough solution.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
