### PR TITLE
Raise ValueError if concatenate is given no arrays

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2980,6 +2980,10 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
     stack
     """
     n = len(seq)
+
+    if n == 0:
+        raise ValueError("Need array(s) to concatenate")
+
     ndim = len(seq[0].shape)
 
     if axis < 0:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -357,6 +357,7 @@ def test_concatenate():
     assert (concatenate([a, b, c], axis=-1).chunks ==
             concatenate([a, b, c], axis=1).chunks)
 
+    pytest.raises(ValueError, lambda: concatenate([]))
     pytest.raises(ValueError, lambda: concatenate([a, b, c], axis=2))
 
 


### PR DESCRIPTION
Matches Dask Array's `concatenate`'s behavior to that of NumPy's by raising a `ValueError` if no arrays are provided to `concatenate`. Includes a test for this exception.

- [x] Tests added / passed
- [x] Passes `flake8 dask`

Note: Pulled out from PR ( https://github.com/dask/dask/pull/4167 ).