### PR TITLE
memmapped numpy arrays on different part of same file bug

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -747,6 +747,8 @@ def register_numpy():
             if hasattr(x.base, 'ctypes'):
                 offset = (x.ctypes.get_as_parameter().value -
                           x.base.ctypes.get_as_parameter().value)
+            elif hasattr(x, 'offset'):
+                offset = getattr(x, 'offset')
             else:
                 offset = 0  # root memmap's have mmap object as base
             return (x.filename, os.path.getmtime(x.filename), x.dtype,

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -124,6 +124,19 @@ def test_tokenize_numpy_array_on_object_dtype():
         assert (tokenize(np.array([unicode("Rebeca Alón", encoding="utf-8")], dtype=object)) ==
                 tokenize(np.array([unicode("Rebeca Alón", encoding="utf-8")], dtype=object)))
 
+@pytest.mark.skipif('not np')
+def test_tokenize_numpy_memmap_offset(tmpdir):
+    #Test two different memmaps into the same numpy file
+    fn = str(tmpdir.join("demo_data"))
+
+    with open(fn, 'wb') as f:
+        f.write(b'ashekwicht')
+
+    with open(fn, 'rb') as f:
+        mmap1 = np.memmap(f, dtype=np.uint8, mode='r', offset=0, shape=5)
+        mmap2 = np.memmap(f, dtype=np.uint8, mode='r', offset=5, shape=5)
+
+        assert(tokenize(mmap1) != tokenize(mmap2))
 
 @pytest.mark.skipif('not np')
 def test_tokenize_numpy_memmap():
@@ -138,16 +151,6 @@ def test_tokenize_numpy_memmap():
         z = tokenize(np.load(fn, mmap_mode='r'))
 
     assert y != z
-
-    #Test two different memmaps into the same numpy file
-    file = open('demo_data', 'wb')
-    file.write(b'ashekwicht')
-    file.close()
-    file = open('demo_data', 'rb')
-    mmap1 = np.memmap(file, dtype=np.uint8, mode='r', offset=0, shape=5)
-    mmap2 = np.memmap(file, dtype=np.uint8, mode='r', offset=5, shape=5)
-    assert(tokenize(mmap1) != tokenize(mmap2))
-    os.remove('demo_data')
 
     with tmpfile('.npy') as fn:
         x = np.random.normal(size=(10, 10))

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -139,6 +139,16 @@ def test_tokenize_numpy_memmap():
 
     assert y != z
 
+    #Test two different memmaps into the same numpy file
+    file = open('demo_data', 'wb')
+    file.write(b'ashekwicht')
+    file.close()
+    file = open('demo_data', 'rb')
+    mmap1 = np.memmap(file, dtype=np.uint8, mode='r', offset=0, shape=5)
+    mmap2 = np.memmap(file, dtype=np.uint8, mode='r', offset=5, shape=5)
+    assert(tokenize(mmap1) != tokenize(mmap2))
+    os.remove('demo_data')
+
     with tmpfile('.npy') as fn:
         x = np.random.normal(size=(10, 10))
         np.save(fn, x)


### PR DESCRIPTION
Fix for #4920 

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
