### PR TITLE
Docs: Drop support for Python 2.7

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -118,7 +118,7 @@ language support, testing, documentation, and style.
 Python Versions
 ~~~~~~~~~~~~~~~
 
-Dask supports Python versions 2.7, 3.5, 3.6, and 3.7 in a single codebase.
+Dask supports Python versions 3.5, 3.6, and 3.7.
 Name changes are handled by the :file:`dask/compatibility.py` file.
 
 Test


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

Follow on from https://github.com/dask/dask/pull/4919.

Removed "in a single codebase" as that's no longer remarkable in a Python 3-only codebase.
