### PR TITLE
4809 fix extra cr

### DIFF
--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -162,15 +162,18 @@ class OpenFile(object):
         The encoding to use if opened in text mode.
     errors : str or None, optional
         How to handle encoding errors if opened in text mode.
+    newline : None, '', '\n', '\r', or '\r\n'.
+        Passed to TextIOWrapper in text mode
     """
     def __init__(self, fs, path, mode='rb', compression=None, encoding=None,
-                 errors=None):
+                 errors=None, newline=None):
         self.fs = fs
         self.path = path
         self.mode = mode
         self.compression = get_compression(path, compression)
         self.encoding = encoding
         self.errors = errors
+        self.newline = newline
         self.fobjects = []
 
     def __reduce__(self):
@@ -191,7 +194,7 @@ class OpenFile(object):
 
         if 't' in self.mode:
             f = io.TextIOWrapper(f, encoding=self.encoding,
-                                 errors=self.errors)
+                                 errors=self.errors, newline=self.newline)
             fobjects.append(f)
 
         self.fobjects = fobjects
@@ -208,7 +211,8 @@ class OpenFile(object):
 
 
 def open_files(urlpath, mode='rb', compression=None, encoding='utf8',
-               errors=None, name_function=None, num=1, **kwargs):
+               errors=None, name_function=None, num=1, newline=None,
+               **kwargs):
     """ Given a path or paths, return a list of ``OpenFile`` objects.
 
     Parameters
@@ -232,6 +236,8 @@ def open_files(urlpath, mode='rb', compression=None, encoding='utf8',
     num : int [1]
         if writing mode, number of files we expect to create (passed to
         name+function)
+    newline : None, '', '\n', '\r', or '\r\n'.
+        Passed to TextIOWrapper in text mode
     **kwargs : dict
         Extra options that make sense to a particular storage connection, e.g.
         host, port, username, password, etc.
@@ -250,7 +256,7 @@ def open_files(urlpath, mode='rb', compression=None, encoding='utf8',
                                              storage_options=kwargs)
 
     return [OpenFile(fs, path, mode=mode, compression=compression,
-                     encoding=encoding, errors=errors)
+                     encoding=encoding, errors=errors, newline=newline)
             for path in paths]
 
 

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -162,7 +162,7 @@ class OpenFile(object):
         The encoding to use if opened in text mode.
     errors : str or None, optional
         How to handle encoding errors if opened in text mode.
-    newline : None, '', '\n', '\r', or '\r\n'.
+    newline : {None, '', '\n', '\r', '\r\n'}
         Passed to TextIOWrapper in text mode
     """
     def __init__(self, fs, path, mode='rb', compression=None, encoding=None,
@@ -236,7 +236,7 @@ def open_files(urlpath, mode='rb', compression=None, encoding='utf8',
     num : int [1]
         if writing mode, number of files we expect to create (passed to
         name+function)
-    newline : None, '', '\n', '\r', or '\r\n'.
+    newline : {None, '', '\n', '\r', '\r\n'}
         Passed to TextIOWrapper in text mode
     **kwargs : dict
         Extra options that make sense to a particular storage connection, e.g.

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -628,7 +628,8 @@ def to_csv(df, filename, name_function=None, compression=None, compute=True,
 
     files = open_files(filename, compression=compression, mode=mode,
                        encoding=encoding, name_function=name_function,
-                       num=df.npartitions, **(storage_options or {}))
+                       num=df.npartitions, newline='',
+                       **(storage_options or {}))
 
     to_csv_chunk = delayed(_write_csv, pure=False)
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1275,3 +1275,21 @@ def test_to_csv_header(header, header_first_partition_only, expected_first, expe
             line = fp.readline()
             assert line == expected_next
         os.remove(filename)
+
+def test_to_csv_line_ending():
+    df = pd.DataFrame({'x': [0]})
+    ddf = dd.from_pandas(df, npartitions=1)
+    expected = {b'0\r\n', b'0\n'} # either/or
+    # For comparison...
+    # unexpected = {b'0\r\r\n'}
+    # This test addresses GH4809, and checks that only (at most) one
+    #  '\r' character is written per line when writing to csv.
+    #  In case it's correct (on UNIX) to have no '\r' at all, this test
+    #  considers either '\r\n' or '\n' as appropriate line endings,
+    #  but not '\r\r\n'.
+    with tmpdir() as dn:
+        ddf.to_csv(os.path.join(dn, 'foo*.csv'), header=False, index=False)
+        filename = os.path.join(dn, 'foo0.csv')
+        with open(filename, 'rb') as f:
+            raw = f.read()
+    assert raw in expected

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1276,6 +1276,7 @@ def test_to_csv_header(header, header_first_partition_only, expected_first, expe
             assert line == expected_next
         os.remove(filename)
 
+
 def test_to_csv_line_ending():
     df = pd.DataFrame({'x': [0]})
     ddf = dd.from_pandas(df, npartitions=1)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `flake8 dask`

Fixes #4809.

Includes the following new test, which demonstrates the issue, and did, indeed, fail prior to the fix here.

```python
def test_to_csv_line_ending():
    df = pd.DataFrame({'x': [0]})
    ddf = dd.from_pandas(df, npartitions=1)
    expected = {b'0\r\n', b'0\n'} # either/or
    # For comparison...
    # unexpected = {b'0\r\r\n'}
    # This test addresses GH4809, and checks that only (at most) one
    #  '\r' character is written per line when writing to csv.
    #  In case it's correct (on UNIX) to have no '\r' at all, this test
    #  considers either '\r\n' or '\n' as appropriate line endings,
    #  but not '\r\r\n'.
    with tmpdir() as dn:
        ddf.to_csv(os.path.join(dn, 'foo*.csv'), header=False, index=False)
        filename = os.path.join(dn, 'foo0.csv')
        with open(filename, 'rb') as f:
            raw = f.read()
    assert raw in expected
```