### PR TITLE
Minor meta construction cleanup in concatenate

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2985,9 +2985,7 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
         raise ValueError("Need array(s) to concatenate")
 
     from .utils import meta_from_array
-    metas = [s._meta for s in seq]
-    metas = [meta_from_array(m, m.ndim) for m in metas]
-    meta = np.concatenate(metas)
+    meta = np.concatenate([meta_from_array(s, s.ndim) for s in seq])
 
     # Promote types to match meta
     seq = [a.astype(meta.dtype) for a in seq]


### PR DESCRIPTION
@jakirkham I just noticed we could simplify the meta construction in `concatenate` a little further, so decided to push this quick PR.