### PR TITLE
Add http -> https redirect to docs

### DIFF
--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -1,0 +1,3 @@
+if (location.protocol == 'http:') {
+ location.href = 'https:' + window.location.href.substring(window.location.protocol.length);
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -358,3 +358,4 @@ def copy_legacy_redirects(app, docname):
 
 def setup(app):
     app.connect('build-finished', copy_legacy_redirects)
+    app.add_javascript('custom.js')


### PR DESCRIPTION
This PR adds custom javascript as proposed in https://github.com/dask/dask/issues/4270#issuecomment-494133259 to perform `'http:'` -> `'https:'` redirects for docs.dask.org

Fixes #4270