### PR TITLE
Further relax Array meta checks for Xarray

### DIFF
--- a/dask/array/blockwise.py
+++ b/dask/array/blockwise.py
@@ -12,12 +12,10 @@ from ..blockwise import blockwise as core_blockwise
 
 
 def blockwise_meta(func, dtype, *args, **kwargs):
+    from .utils import meta_from_array
     arrays = args[::2]
-    ndims = [a.ndim if hasattr(a, 'ndim') else 0 for a in arrays]
-    args_meta = [arg._meta if hasattr(arg, '_meta') else
-                 arg[tuple(slice(0, 0, None) for _ in range(nd))] if nd > 0 else arg
-                 for arg, nd in zip(arrays, ndims)]
-    kwargs_meta = {k: v._meta if hasattr(v, '_meta') else v for k, v in kwargs.items()}
+    args_meta = list(map(meta_from_array, arrays))
+    kwargs_meta = {k: meta_from_array(v) for k, v in kwargs.items()}
 
     # TODO: look for alternative to this, causes issues when using map_blocks()
     # with np.vectorize, such as dask.array.routines._isnonzero_vec().

--- a/dask/array/tests/test_array_utils.py
+++ b/dask/array/tests/test_array_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import dask.array as da
 from dask.array.utils import meta_from_array
 
 asarrays = [np.asarray]
@@ -20,6 +21,9 @@ except ImportError:
 
 @pytest.mark.parametrize("asarray", asarrays)
 def test_meta_from_array(asarray):
+    x = np.array(1)
+    assert meta_from_array(x, ndim=1).shape == (0,)
+
     x = np.ones((1, 2, 3), dtype='float32')
     x = asarray(x)
 
@@ -30,3 +34,10 @@ def test_meta_from_array(asarray):
     assert meta_from_array(x, ndim=2).shape == (0, 0)
     assert meta_from_array(x, ndim=4).shape == (0, 0, 0, 0)
     assert meta_from_array(x, dtype="float64").dtype == "float64"
+
+    x = da.ones((1,))
+    assert isinstance(meta_from_array(x), np.ndarray)
+
+    assert meta_from_array(123) == 123
+    assert meta_from_array('foo') == 'foo'
+    assert meta_from_array(np.dtype('float32')) == np.dtype('float32')

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -41,16 +41,19 @@ def meta_from_array(x, ndim=None, dtype=None):
     -------
     array-like
     """
+    # x._meta must be a Dask Array, some libraries (e.g. zarr) implement a
+    # _meta attribute that are incompatible with Dask Array._meta
+    if hasattr(x, '_meta') and isinstance(x, Array):
+        x = x._meta
+
+    if not hasattr(x, 'shape') or not hasattr(x, 'dtype'):
+        return x
+
     if isinstance(x, list) or isinstance(x, tuple):
         ndims = [0 if isinstance(a, numbers.Number)
                  else a.ndim if hasattr(a, 'ndim') else len(a) for a in x]
         a = [a if nd == 0 else meta_from_array(a, nd) for a, nd in zip(x, ndims)]
         return a if isinstance(x, list) else tuple(x)
-
-    # x._meta must be a Dask Array, some libraries (e.g. zarr) implement a
-    # _meta attribute that are incompatible with Dask Array._meta
-    if hasattr(x, '_meta') and isinstance(x, Array):
-        x = x._meta
 
     if ndim is None:
         ndim = x.ndim


### PR DESCRIPTION
Our checks in slicing were causing issues for Xarray, which has some
unslicable array types.  Additionally, this centralizes a bit of logic
from blockwise into meta_from_array

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`

See https://github.com/pydata/xarray/issues/3009

cc @pentschev @max-sixty 
