### PR TITLE
Preserve NumPy condition in da.asarray to preserve output shape

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -14,7 +14,7 @@ from ..compatibility import Iterable
 from ..core import flatten
 from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
-from ..utils import funcname, derived_from
+from ..utils import funcname, derived_from, is_arraylike
 from . import chunk
 from .creation import arange, diag, empty, indices
 from .utils import safe_wraps, validate_axis, meta_from_array, zeros_like_safe
@@ -1003,8 +1003,8 @@ def squeeze(a, axis=None):
 @derived_from(np)
 def compress(condition, a, axis=None):
 
-    if not isinstance(condition, np.ndarray):
-        # Allow `condition` to be a numpy array, otherwise ensure `condition`
+    if not is_arraylike(condition):
+        # Allow `condition` to be anything array-like, otherwise ensure `condition`
         # is a dask array.
         condition = asarray(condition)
     condition = condition.astype(bool)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1005,8 +1005,8 @@ def compress(condition, a, axis=None):
 
     if not is_arraylike(condition):
         # Allow `condition` to be anything array-like, otherwise ensure `condition`
-        # is a dask array.
-        condition = asarray(condition)
+        # is a numpy array.
+        condition = np.asarray(condition)
     condition = condition.astype(bool)
     a = asarray(a)
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1002,7 +1002,12 @@ def squeeze(a, axis=None):
 
 @derived_from(np)
 def compress(condition, a, axis=None):
-    condition = asarray(condition).astype(bool)
+
+    if not isinstance(condition, np.ndarray):
+        # Allow `condition` to be a numpy array, otherwise ensure `condition`
+        # is a dask array.
+        condition = asarray(condition)
+    condition = condition.astype(bool)
     a = asarray(a)
 
     if condition.ndim != 1:

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -956,9 +956,9 @@ def test_compress():
                 axis = axis or 0
                 assert np.isnan(res.shape[axis]).all()
                 assert np.isnan(res.chunks[axis]).all()
-            elif isinstance(dc, np.ndarray):
-                # If condition is a numpy array then we expect the shape of the
-                # compressed axis to be a number, i.e., not nan.
+            else:
+                # If condition is a not a dask array then we expect the shape of the
+                # compressed axis to be known, i.e., not nan.
                 axis = axis or 0
                 assert np.count_nonzero(dc) == res.shape[axis]
                 assert not np.isnan(res.chunks[axis]).any()

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -950,8 +950,18 @@ def test_compress():
             res = da.compress(dc, a, axis=axis)
             assert_eq(np.compress(c, x, axis=axis), res)
             if isinstance(dc, da.Array):
+                # If condition is a dask array then we expect the shape of the
+                # compressed array to be nan, because we won't know that until
+                # the result is computed.
                 axis = axis or 0
+                assert np.isnan(res.shape[axis]).all()
                 assert np.isnan(res.chunks[axis]).all()
+            elif isinstance(dc, np.ndarray):
+                # If condition is a numpy array then we expect the shape of the
+                # compressed axis to be a number, i.e., not nan.
+                axis = axis or 0
+                assert np.count_nonzero(dc) == res.shape[axis]
+                assert not np.isnan(res.chunks[axis]).any()
 
     with pytest.raises(ValueError):
         da.compress([True, False], a, axis=100)


### PR DESCRIPTION
This PR resolves #4940 by allowing the `condition` argument to be a numpy array and leaving it as such.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
