### PR TITLE
Avoid deprecated message parameter in pytest.raises

### DIFF
--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -534,11 +534,13 @@ def test_to_records_raises():
                       index=pd.Index([1., 2., 3., 4.], name='ind'))
     ddf = dd.from_pandas(df, 2)
 
-    with pytest.raises(ValueError, message="3 != 2"):
+    with pytest.raises(ValueError):
         ddf.to_records(lengths=[2, 2, 2])
+        pytest.fail("3 != 2")
 
-    with pytest.raises(ValueError, message="Unexpected value"):
+    with pytest.raises(ValueError):
         ddf.to_records(lengths=5)
+        pytest.fail("Unexpected value")
 
 
 def test_from_delayed():


### PR DESCRIPTION
This deprecation warning is causing the CI to fail (e.g. https://travis-ci.org/dask/dask/jobs/547365938#L1930-L1947). Handling this deprecation as recommended in https://docs.pytest.org/en/4.6-maintenance/deprecations.html#message-parameter-of-pytest-raises

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
