### PR TITLE
Add documentation entry for dask.array.ma.average

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -237,6 +237,7 @@ Masked Arrays
 ~~~~~~~~~~~~~
 
 .. autosummary::
+   ma.average
    ma.filled
    ma.fix_invalid
    ma.getdata
@@ -574,6 +575,7 @@ Other functions
 .. autofunction:: tsqr
 
 .. currentmodule:: dask.array.ma
+.. autofunction:: average
 .. autofunction:: filled
 .. autofunction:: fix_invalid
 .. autofunction:: getdata


### PR DESCRIPTION
This pull request adds a documentation entry for `dask.array.ma.average`. This function has been around since version 1.1.0, but is still missing from the documentation. 

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
