### PR TITLE
Raise ValueError if stack is given no arrays

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3684,6 +3684,9 @@ def stack(seq, axis=0):
     --------
     concatenate
     """
+    if not seq:
+        raise ValueError("Need array(s) to stack")
+
     n = len(seq)
     ndim = len(seq[0].shape)
     if axis < 0:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -280,6 +280,7 @@ def test_stack():
                                            (colon, colon, None))
     assert same_keys(s2, stack([a, b, c], axis=2))
 
+    pytest.raises(ValueError, lambda: stack([]))
     pytest.raises(ValueError, lambda: stack([a, b, c], axis=3))
 
     assert set(b.dask.keys()).issubset(s2.dask.keys())


### PR DESCRIPTION
Analog to PR ( https://github.com/dask/dask/pull/4927 ) except for `da.stack`.

- [x] Tests added / passed
- [x] Passes `flake8 dask`