### PR TITLE
Use meta in stack

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3693,7 +3693,7 @@ def stack(seq, axis=0):
     seq = [x.astype(meta.dtype) for x in seq]
 
     n = len(seq)
-    ndim = len(seq[0].shape)
+    ndim = meta.ndim - 1
     if axis < 0:
         axis = ndim + axis + 1
     if axis > ndim:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3710,8 +3710,8 @@ def stack(seq, axis=0):
     uc_args = list(concat((x, ind) for x in seq))
     _, seq = unify_chunks(*uc_args)
 
-    dt = reduce(np.promote_types, [a.dtype for a in seq])
-    seq = [x.astype(dt) for x in seq]
+    meta = np.stack([meta_from_array(a) for a in seq], axis=axis)
+    seq = [x.astype(meta.dtype) for x in seq]
 
     assert len(set(a.chunks for a in seq)) == 1  # same chunks
     chunks = (seq[0].chunks[:axis] + ((1,) * n,) + seq[0].chunks[axis:])
@@ -3729,7 +3729,7 @@ def stack(seq, axis=0):
     layer = dict(zip(keys, values))
     graph = HighLevelGraph.from_collections(name, layer, dependencies=seq)
 
-    return Array(graph, name, chunks, dtype=dt)
+    return Array(graph, name, chunks, meta=meta)
 
 
 def concatenate3(arrays):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3696,10 +3696,6 @@ def stack(seq, axis=0):
     ndim = meta.ndim - 1
     if axis < 0:
         axis = ndim + axis + 1
-    if axis > ndim:
-        raise ValueError("Axis must not be greater than number of dimensions"
-                         "\nData has %d dimensions, but got axis=%d" %
-                         (ndim, axis))
     if not all(x.shape == seq[0].shape for x in seq):
         idx = np.where(np.asanyarray([x.shape for x in seq]) != seq[0].shape)[0]
         raise ValueError("Stacked arrays must have the same shape. "

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3684,6 +3684,8 @@ def stack(seq, axis=0):
     --------
     concatenate
     """
+    seq = [asarray(a) for a in seq]
+
     if not seq:
         raise ValueError("Need array(s) to stack")
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3689,6 +3689,9 @@ def stack(seq, axis=0):
     if not seq:
         raise ValueError("Need array(s) to stack")
 
+    meta = np.stack([meta_from_array(a) for a in seq], axis=axis)
+    seq = [x.astype(meta.dtype) for x in seq]
+
     n = len(seq)
     ndim = len(seq[0].shape)
     if axis < 0:
@@ -3709,9 +3712,6 @@ def stack(seq, axis=0):
     ind = list(range(ndim))
     uc_args = list(concat((x, ind) for x in seq))
     _, seq = unify_chunks(*uc_args)
-
-    meta = np.stack([meta_from_array(a) for a in seq], axis=axis)
-    seq = [x.astype(meta.dtype) for x in seq]
 
     assert len(set(a.chunks for a in seq)) == 1  # same chunks
     chunks = (seq[0].chunks[:axis] + ((1,) * n,) + seq[0].chunks[axis:])

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -158,6 +158,7 @@ def test_metadata():
     assert isinstance((y - z)._meta, sparse.COO)
     if IS_NEP18_ACTIVE:
         assert isinstance(np.concatenate([y, y])._meta, sparse.COO)
+        assert isinstance(np.stack([y, y])._meta, sparse.COO)
 
 
 def test_html_repr():


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/4929

Rewrites `da.stack` to use `_meta`. Borrows from PR ( https://github.com/dask/dask/pull/4925 ) and PR ( https://github.com/dask/dask/pull/4937 ).

cc @pentschev

- [x] Tests added / passed
- [x] Passes `flake8 dask`