### PR TITLE
Adjust concatenate size 0 array case for meta

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2953,6 +2953,8 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
     --------
     stack
     """
+    from . import wrap
+
     seq = [asarray(a) for a in seq]
 
     if not seq:
@@ -2982,7 +2984,11 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
 
     n = len(seq)
     if n == 0:
-        return from_array(np.empty(shape=shape, dtype=meta.dtype))
+        try:
+            return wrap.empty_like(meta, shape=shape, chunks=shape,
+                                   dtype=meta.dtype)
+        except TypeError:
+            return wrap.empty(shape, chunks=shape, dtype=meta.dtype)
     elif n == 1:
         return seq[0]
 

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -158,6 +158,7 @@ def test_metadata():
     assert isinstance((y - z)._meta, sparse.COO)
     if IS_NEP18_ACTIVE:
         assert isinstance(np.concatenate([y, y])._meta, sparse.COO)
+        assert isinstance(np.concatenate([y, y[:0], y])._meta, sparse.COO)
 
 
 def test_html_repr():


### PR DESCRIPTION
Instead of hand rolling our own Dask Array creation call, dispatch to the existing ones in `wrap`. Also leverage meta to create an array of the expected type instead of using a NumPy array using `empty_like` (when `empty_like` supports this).

cc @pentschev

- [x] Tests added / passed
- [x] Passes `flake8 dask`