### PR TITLE
Move CLI API docs to relavant pages

### DIFF
--- a/docs/source/setup/cli.rst
+++ b/docs/source/setup/cli.rst
@@ -67,11 +67,8 @@ generally useful to users.  The diagnostic server on the scheduler is
 particularly valuable, and is served on port ``8787`` by default (configurable
 with the ``--bokeh-port`` keyword).
 
-.. note::
-
-    For more information about relevant ports, please take a look at the help
-    pages with ``dask-scheduler --help`` and ``dask-worker --help``
-
+For more information about relevant ports, please take a look at the available
+:ref:`command line options <worker-scheduler-cli-options>`.
 
 Automated Tools
 ---------------
@@ -82,6 +79,8 @@ SGE/SLURM/Torque or Yarn/Mesos.  Additionally, cluster SSH tools exist to send
 the same commands to many machines.  We recommend searching online for "cluster
 ssh" or "cssh".
 
+
+.. _worker-scheduler-cli-options:
 
 CLI Options
 -----------

--- a/docs/source/setup/cli.rst
+++ b/docs/source/setup/cli.rst
@@ -83,13 +83,14 @@ the same commands to many machines.  We recommend searching online for "cluster
 ssh" or "cssh".
 
 
-API
----
+CLI Options
+-----------
 
-.. warning::
+.. note::
 
    The command line documentation here may differ depending on your installed
-   version. We recommend referring to the output of ``<command> --help``.
+   version. We recommend referring to the output of ``dask-scheduler --help``
+   and ``dask-worker --help``.
 
 .. click:: distributed.cli.dask_scheduler:main
    :prog: dask-scheduler
@@ -97,16 +98,4 @@ API
 
 .. click:: distributed.cli.dask_worker:main
    :prog: dask-worker
-   :show-nested:
-
-.. click:: distributed.cli.dask_ssh:main
-   :prog: dask-ssh
-   :show-nested:
-
-.. click:: distributed.cli.dask_submit:main
-   :prog: dask-submit
-   :show-nested:
-
-.. click:: distributed.cli.dask_remote:main
-   :prog: dask-remote
    :show-nested:

--- a/docs/source/setup/ssh.rst
+++ b/docs/source/setup/ssh.rst
@@ -29,49 +29,11 @@ The ``dask-ssh`` utility depends on the ``paramiko``::
 CLI Options
 ----------- 
 
-Launch a distributed cluster over SSH. A ``dask-scheduler`` process will run
-on the first host specified in [HOSTNAMES] or in the hostfile (unless
-``--scheduler`` is specified explicitly). One or more ``dask-worker`` processes
-will be run on each host in [HOSTNAMES] or in the hostfile. Use command line
-flags to adjust how many dask-worker process are run on each host
-(``--nprocs``) and how many cpus are used by each dask-worker process
-(``--nthreads``).
-
-Options:
-
 .. note::
 
-   This table may grow out of date, you should check ``dask-ssh --help`` to get an up-to-date listing of all options.
+   The command line documentation here may differ depending on your installed
+   version. We recommend referring to the output of ``dask-ssh --help``.
 
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| Option             | TYPE    | Description                                                                                                    |
-+====================+=========+================================================================================================================+
-| --scheduler        | TEXT    | Specify scheduler node.  Defaults to first address                                                             |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --scheduler-port   | INTEGER | Specify scheduler port number.  Defaults to port 8786                                                          |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --nthreads         | INTEGER | Number of threads per worker process. Defaults to number of cores divided by the number of processes per host  |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --nprocs           | INTEGER | Number of worker processes per host. Defaults to one                                                           |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --hostfile         | PATH    | Textfile with hostnames/IP addresses                                                                           |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --ssh-username     | TEXT    | Username to use when establishing SSH connections                                                              |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --ssh-port         | INTEGER | Port to use for SSH connections                                                                                |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --ssh-private-key  | TEXT    | Private key file to use for SSH connections                                                                    |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --log-directory    | PATH    | Directory to use on all cluster nodes for the output of dask-scheduler and dask-worker commands                |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --remote-python    | TEXT    | Path to Python on remote nodes                                                                                 |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --memory-limit     | TEXT    | Bytes of memory that the worker can use. This can be an integer (bytes), float(fraction of total system memory)|
-|                    |         | string (like 5GB or 5000M), 'auto', or zero for no memory management                                           |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --worker-port      | INTEGER | Serving computation port, defaults to random                                                                   |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --nanny-port       | INTEGER | Serving nanny port, defaults to random                                                                         |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
-| --nohost           |         | Do not pass the hostname to the worker                                                                         |
-+--------------------+---------+----------------------------------------------------------------------------------------------------------------+
+.. click:: distributed.cli.dask_ssh:main
+   :prog: dask-ssh
+   :show-nested:


### PR DESCRIPTION
Currently the auto-generated CLI API docs are all centrally located at https://docs.dask.org/en/latest/setup/cli.html#api, even though that page only discusses the `dask-scheduler` and `dask-worker` commands. This PR moves the CLI API docs for individual commands to the corresponding documentation page that discusses the command. I.e. 

- `dask-scheduler` & `dask-worker` stay in `docs/source/setup/cli.rst`
- `dask-ssh` moves to `docs/source/setup/ssh.rst`
- `dask-submit` & `dask-remote` move to `distributed/docs/source/submitting-applications.rst` (see https://github.com/dask/distributed/pull/2794) 