### PR TITLE
Support automatic chunking in da.indices

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -395,10 +395,7 @@ def indices(dimensions, dtype=int, chunks='auto'):
     """
     dimensions = tuple(dimensions)
     dtype = np.dtype(dtype)
-    if isinstance(chunks, str):
-        chunks = normalize_chunks(chunks, shape=dimensions, dtype=dtype)
-    else:
-        chunks = tuple(chunks)
+    chunks = normalize_chunks(chunks, shape=dimensions, dtype=dtype)
 
     if len(dimensions) != len(chunks):
         raise ValueError("Need same number of chunks as dimensions.")

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -389,7 +389,10 @@ def indices(dimensions, dtype=int, chunks='auto'):
     """
     dimensions = tuple(dimensions)
     dtype = np.dtype(dtype)
-    chunks = tuple(chunks)
+    if isinstance(chunks, str):
+        chunks = normalize_chunks(chunks, shape=dimensions, dtype=dtype)
+    else:
+        chunks = tuple(chunks)
 
     if len(dimensions) != len(chunks):
         raise ValueError("Need same number of chunks as dimensions.")

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -379,9 +379,15 @@ def indices(dimensions, dtype=int, chunks='auto'):
         The shape of the index grid.
     dtype : dtype, optional
         Type to use for the array. Default is ``int``.
-    chunks : sequence of ints
-        The number of samples on each block. Note that the last block will have
-        fewer samples if ``len(array) % chunks != 0``.
+    chunks : sequence of ints, str
+        The size of each block.  Must be one of the following forms:
+
+        -   A blocksize like (500, 1000)
+        -   A size in bytes, like "100 MiB" which will choose a uniform
+            block-like shape
+        -   The word "auto" which acts like the above, but uses a configuration
+            value ``array.chunk-size`` for the chunk size
+        Note that the last block will have fewer samples if ``len(array) % chunks != 0``.
 
     Returns
     -------
@@ -425,6 +431,7 @@ def eye(N, chunks='auto', M=None, k=0, dtype=float):
       Number of rows in the output.
     chunks : int, str
         How to chunk the array. Must be one of the following forms:
+
         -   A blocksize like 1000.
         -   A size in bytes, like "100 MiB" which will choose a uniform
             block-like shape

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -7,6 +7,7 @@ from toolz import concat
 
 import dask
 import dask.array as da
+from dask.array.core import normalize_chunks
 from dask.array.utils import assert_eq, same_keys, AxisError
 
 
@@ -186,11 +187,6 @@ def test_arange_float_step():
     assert_eq(darr, nparr)
 
 
-def test_indices_no_chunks():
-    with pytest.raises(ValueError):
-        da.indices((1,))
-
-
 def test_indices_wrong_chunks():
     with pytest.raises(ValueError):
         da.indices((1,), chunks=tuple())
@@ -200,6 +196,13 @@ def test_indices_dimensions_chunks():
     chunks = ((1, 4, 2, 3), (5, 5))
     darr = da.indices((10, 10), chunks=chunks)
     assert darr.chunks == ((1, 1),) + chunks
+
+    with dask.config.set({'array.chunk-size': '50 MiB'}):
+        shape = (10000, 10000)
+        expected = normalize_chunks('auto', shape=shape, dtype=int)
+        result = da.indices(shape, chunks='auto')
+        actual = result.chunks[1:]
+        assert expected == actual
 
 
 def test_empty_indicies():

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -201,6 +201,7 @@ def test_indices_dimensions_chunks():
         shape = (10000, 10000)
         expected = normalize_chunks('auto', shape=shape, dtype=int)
         result = da.indices(shape, chunks='auto')
+        # indices prepends a dimension
         actual = result.chunks[1:]
         assert expected == actual
 


### PR DESCRIPTION
This PR adds support for automatic chunking in `da.indices` which currently doesn't work (even though `chunks='auto'` is the default value). For example, on the current `master`:

```python
In [1]: import dask.array as da                                                                                             

In [2]: da.indices((5, 7))                                                                                                  
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-71cafe871d05> in <module>
----> 1 da.indices((5, 7))

~/github/dask/dask/dask/array/creation.py in indices(dimensions, dtype, chunks)
    393 
    394     if len(dimensions) != len(chunks):
--> 395         raise ValueError("Need same number of chunks as dimensions.")
    396 
    397     xi = []

ValueError: Need same number of chunks as dimensions.
```

cc @jakirkham 

- [x] Tests added / passed
- [x] Passes `flake8 dask`
