### PR TITLE
Ensures pandas_datareader dependencies are installated on CI

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -89,8 +89,7 @@ fi
 
 pip install --quiet --upgrade --no-deps \
     cachey \
-    graphviz \
-    pandas_datareader
+    graphviz
 
 pip install --quiet --upgrade \
     cityhash \
@@ -98,7 +97,8 @@ pip install --quiet --upgrade \
     mmh3 \
     pytest-xdist \
     xxhash \
-    moto
+    moto \
+    pandas_datareader
 
 if [[ ${UPSTREAM_DEV} ]]; then
     echo "Installing PyArrow dev"


### PR DESCRIPTION
Fixes #4986.

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
