### PR TITLE
Ensure trivial padding returns the original array

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -1002,14 +1002,15 @@ def pad_stats(array, pad_width, mode, *args):
         pad_chunks = tuple(pad_chunks)
 
         result_idx = array[select]
-        if mode == "maximum":
-            result_idx = result_idx.max(axis=axes, keepdims=True)
-        elif mode == "mean":
-            result_idx = result_idx.mean(axis=axes, keepdims=True)
-        elif mode == "minimum":
-            result_idx = result_idx.min(axis=axes, keepdims=True)
+        if axes:
+            if mode == "maximum":
+                result_idx = result_idx.max(axis=axes, keepdims=True)
+            elif mode == "mean":
+                result_idx = result_idx.mean(axis=axes, keepdims=True)
+            elif mode == "minimum":
+                result_idx = result_idx.min(axis=axes, keepdims=True)
 
-        result_idx = broadcast_to(result_idx, pad_shape, chunks=pad_chunks)
+            result_idx = broadcast_to(result_idx, pad_shape, chunks=pad_chunks)
 
         result[idx] = result_idx
 

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -565,6 +565,26 @@ def test_tile_array_reps(shape, chunks, reps):
 
 
 @pytest.mark.parametrize('shape, chunks, pad_width, mode, kwargs', [
+    ((10, 11), (4, 5), 0, 'constant', {'constant_values': 2}),
+    ((10, 11), (4, 5), 0, 'edge', {}),
+    ((10, 11), (4, 5), 0, 'linear_ramp', {'end_values': 2}),
+    ((10, 11), (4, 5), 0, 'reflect', {}),
+    ((10, 11), (4, 5), 0, 'symmetric', {}),
+    ((10, 11), (4, 5), 0, 'wrap', {}),
+])
+def test_pad_0_width(shape, chunks, pad_width, mode, kwargs):
+    np_a = np.random.random(shape)
+    da_a = da.from_array(np_a, chunks=chunks)
+
+    np_r = np.pad(np_a, pad_width, mode, **kwargs)
+    da_r = da.pad(da_a, pad_width, mode, **kwargs)
+
+    assert da_r is da_a
+
+    assert_eq(np_r, da_r)
+
+
+@pytest.mark.parametrize('shape, chunks, pad_width, mode, kwargs', [
     ((10,), (3,), 1, 'constant', {}),
     ((10,), (3,), 2, 'constant', {'constant_values': -1}),
     ((10,), (3,), ((2, 3)), 'constant', {'constant_values': (-1, -2)}),

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -571,6 +571,9 @@ def test_tile_array_reps(shape, chunks, reps):
     ((10, 11), (4, 5), 0, 'reflect', {}),
     ((10, 11), (4, 5), 0, 'symmetric', {}),
     ((10, 11), (4, 5), 0, 'wrap', {}),
+    ((10, 11), (4, 5), 0, 'maximum', {'stat_length': 0}),
+    ((10, 11), (4, 5), 0, 'mean', {'stat_length': 0}),
+    ((10, 11), (4, 5), 0, 'minimum', {'stat_length': 0}),
 ])
 def test_pad_0_width(shape, chunks, pad_width, mode, kwargs):
     np_a = np.random.random(shape)


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/4982 (by adding a test)

The `da.pad` function handles padding of the ends by using `da.concatenate` to join the edges with the original array. Thus if the arrays to pad were trivial in size, they would be joined as well. However this results in some unnecessary changes to the graph.

The `da.concatenate` function has since been rewritten to drop arrays of trivial length from the result. Thus `da.pad` benefits from this behavior and will also exclude arrays of trivial length. Though this was not tested previously. So here we include a test to ensure `da.pad` doesn't change the array when trivial padding occurs.

cc @michaeldoron59 @jrbourbeau

- [x] Tests added / passed
- [x] Passes `flake8 dask`