### PR TITLE
Don't use type when getting accessor in dataframes

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -44,7 +44,7 @@ class Accessor(object):
         meta = self._series._meta
         if hasattr(meta, 'to_series'):  # is index-like
             meta = meta.to_series()
-        return getattr(type(meta), self._accessor_name)
+        return getattr(meta, self._accessor_name)
 
     @staticmethod
     def _delegate_property(obj, accessor, attr):

--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -87,10 +87,10 @@ class Accessor(object):
 
     def __getattr__(self, key):
         if key in self._delegates:
-            if isinstance(getattr(self._accessor, key), property):
-                return self._property_map(key)
-            else:
+            if callable(getattr(self._accessor, key)):
                 return partial(self._function_map, key)
+            else:
+                return self._property_map(key)
         else:
             raise AttributeError(key)
 


### PR DESCRIPTION
In Pandas this is an object on the type, however in other systems (notably
cudf) this is a property, which is hard to introspect.

It looks like we only use this to detect if a method exists rather than for
actual computation, so this should be low-impact

- [ ] Tests added / passed
- [ ] Passes `flake8 dask`
