### PR TITLE
Adds path-like support to to_hdf

### DIFF
--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -66,8 +66,10 @@ def to_hdf(
 
     Parameters
     ----------
-    path : string
-        Path to a target filename.  May contain a ``*`` to denote many filenames
+    path : string, pathlib.Path
+        Path to a target filename. Supports strings, ``pathlib.Path``, or any
+        object implementing the ``__fspath__`` protocol. May contain a ``*`` to
+        denote many filenames.
     key : string
         Datapath within the files.  May contain a ``*`` to denote many locations
     name_function : function
@@ -138,11 +140,13 @@ def to_hdf(
     single_file = True
     single_node = True
 
+    path = stringify_path(path)
+
     # if path is string, format using i_name
     if isinstance(path, str):
         if path.count("*") + key.count("*") > 1:
             raise ValueError(
-                "A maximum of one asterisk is accepted in file " "path and dataset key"
+                "A maximum of one asterisk is accepted in file path and dataset key"
             )
 
         fmt_obj = lambda path, i_name: path.replace("*", i_name)
@@ -151,7 +155,7 @@ def to_hdf(
             single_file = False
     else:
         if key.count("*") > 1:
-            raise ValueError("A maximum of one asterisk is accepted in " "dataset key")
+            raise ValueError("A maximum of one asterisk is accepted in dataset key")
 
         fmt_obj = lambda path, _: path
 

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -784,17 +784,31 @@ def test_hdf_file_list():
             tm.assert_frame_equal(res.compute(), df)
 
 
-def test_hdf_pattern_pathlike():
+def test_read_hdf_pattern_pathlike():
     pytest.importorskip("tables")
     df = pd.DataFrame(
         {"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]}, index=[1.0, 2.0, 3.0, 4.0]
     )
 
-    with tmpdir() as tdir:
-        df.to_hdf(os.path.join(tdir, "test.h5"), "dataframe", format="table")
-        path = pathlib.Path(tdir) / "test.h5"
+    with tmpfile("h5") as fn:
+        path = pathlib.Path(fn)
+        df.to_hdf(path, "dataframe", format="table")
         res = dd.read_hdf(path, "dataframe")
         assert_eq(res, df)
+
+
+def test_to_hdf_path_pathlike():
+    pytest.importorskip("tables")
+    df = pd.DataFrame(
+        {"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]}, index=[1.0, 2.0, 3.0, 4.0]
+    )
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    with tmpfile("h5") as fn:
+        path = pathlib.Path(fn)
+        ddf.to_hdf(path, "/data")
+        res = pd.read_hdf(path, "/data")
+        assert_eq(res, ddf)
 
 
 def test_read_hdf_doesnt_segfault():


### PR DESCRIPTION
Small follow-up to #3335. This PR adds support for path-like objects (e.g. `pathlib.Path`) to `to_hdf`. 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
