### PR TITLE
fix(repartition_size) Don't coerce split_mem_usages to int

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5393,7 +5393,7 @@ def repartition_size(df, size):
         split_mem_usages = []
         for n, usage in zip(nsplits, mem_usages):
             split_mem_usages.extend([usage / n] * n)
-        mem_usages = pd.Series(split_mem_usages, dtype=mem_usages.dtype)
+        mem_usages = pd.Series(split_mem_usages)
 
     # 2. now that all partitions are less than size, concat them up to size
     assert np.all(mem_usages <= size)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1725,7 +1725,7 @@ def test_repartition_npartitions(use_index, n, k, dtype, transform):
 
 @pytest.mark.parametrize("use_index", [True, False])
 @pytest.mark.parametrize("n", [2, 5])
-@pytest.mark.parametrize("partition_size", ["1kiB"])
+@pytest.mark.parametrize("partition_size", ["1kiB", 379])
 @pytest.mark.parametrize("transform", [lambda df: df, lambda df: df.x])
 def test_repartition_partition_size(use_index, n, partition_size, transform):
     df = pd.DataFrame(


### PR DESCRIPTION
Small fix for the newly added repartition_size. The previous tests didn't catch it because the number of splits based on the tested repartition size happened to divide exactly the memory usages.