### PR TITLE
Addressing timestamp and preserve_index changes in pyarrow

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -615,10 +615,11 @@ def test_optimize(tmpdir, c):
 @write_read_engines()
 def test_roundtrip_from_pandas(tmpdir, write_engine, read_engine):
     fn = str(tmpdir.join("test.parquet"))
-    df.index.name = "index"
-    df.to_parquet(fn, index=True, engine=write_engine)
+    dfp = df.copy()
+    dfp.index.name = "index"
+    dfp.to_parquet(fn, index=True, engine=write_engine)
     ddf = dd.read_parquet(fn, index="index", engine=read_engine)
-    assert_eq(df, ddf)
+    assert_eq(dfp, ddf)
 
 
 @write_read_engines_xfail

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -616,9 +616,9 @@ def test_optimize(tmpdir, c):
 def test_roundtrip_from_pandas(tmpdir, write_engine, read_engine):
     fn = str(tmpdir.join("test.parquet"))
     df = pd.DataFrame({"x": [1, 2, 3]})
-    df.to_parquet(fn, engine=write_engine)
+    df.to_parquet(fn, index=True, engine=write_engine)
     ddf = dd.read_parquet(fn, engine=read_engine)
-    assert_eq(df, ddf)
+    assert_eq(df, ddf, check_index=False)
 
 
 @write_read_engines_xfail

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -615,10 +615,10 @@ def test_optimize(tmpdir, c):
 @write_read_engines()
 def test_roundtrip_from_pandas(tmpdir, write_engine, read_engine):
     fn = str(tmpdir.join("test.parquet"))
-    df = pd.DataFrame({"x": [1, 2, 3]})
+    df.index.name = 'index'
     df.to_parquet(fn, index=True, engine=write_engine)
-    ddf = dd.read_parquet(fn, engine=read_engine)
-    assert_eq(df, ddf, check_index=False)
+    ddf = dd.read_parquet(fn, index='index', engine=read_engine)
+    assert_eq(df, ddf)
 
 
 @write_read_engines_xfail

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -615,9 +615,9 @@ def test_optimize(tmpdir, c):
 @write_read_engines()
 def test_roundtrip_from_pandas(tmpdir, write_engine, read_engine):
     fn = str(tmpdir.join("test.parquet"))
-    df.index.name = 'index'
+    df.index.name = "index"
     df.to_parquet(fn, index=True, engine=write_engine)
-    ddf = dd.read_parquet(fn, index='index', engine=read_engine)
+    ddf = dd.read_parquet(fn, index="index", engine=read_engine)
     assert_eq(df, ddf)
 
 


### PR DESCRIPTION
This PR is in response to an issue raised in [arrow/PR#4718 - ARROW-5730](https://github.com/apache/arrow/pull/4718).  Adding minor changes to `test_roundtrip_from_pandas` to accound for changes in in pyarrow index-preservation.  Also skipping timestamp conversion for newest version of pyarrow.

- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
