### PR TITLE
Fix undefined `meta` for `str.split(expand=False)`

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -147,6 +147,8 @@ class StringAccessor(Accessor):
             else:
                 meta = type(self._series._meta)([" ".join(["a"] * 2 * n)])
                 meta = meta.str.split(n=n, expand=expand, pat=pat)
+        else:
+            meta = (self._series.name, object)
         return self._function_map("split", pat=pat, n=n, expand=expand, meta=meta)
 
     @derived_from(pd.core.strings.StringMethods)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4062,6 +4062,16 @@ def test_map_partitions_delays_lists():
     assert any(str(L) == str(v) for v in out.__dask_graph__().values())
 
 
+def test_str_noexpand():
+    s = pd.Series(["a b c d", "aa bb cc dd", "aaa bbb ccc dddd"], name="foo")
+    ds = dd.from_pandas(s, npartitions=2)
+
+    for n in [1, 2, 3]:
+        assert_eq(s.str.split(n=n, expand=False), ds.str.split(n=n, expand=False))
+
+    assert ds.str.split(n=1, expand=False).name == "foo"
+
+
 def test_str_expand():
     s = pd.Series(["a b c d", "aa bb cc dd", "aaa bbb ccc dddd"])
     ds = dd.from_pandas(s, npartitions=2)


### PR DESCRIPTION
Looks like this got broken in #4744.