### PR TITLE
Add user survey link to docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,6 +49,14 @@ html_extra_path = ['index.html']
 project = u'Dask'
 copyright = u'2014-2018, Anaconda, Inc. and contributors'
 
+rst_prolog = """
+
+.. note::
+
+    Help inform future development and improve the Dask community experience -
+    take the `2019 Dask User Survey <https://t.co/OGrIjTLC2G>`_
+"""
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,14 +49,6 @@ html_extra_path = ['index.html']
 project = u'Dask'
 copyright = u'2014-2018, Anaconda, Inc. and contributors'
 
-rst_prolog = """
-
-.. note::
-
-    Help inform future development and improve the Dask community experience -
-    take the `2019 Dask User Survey <https://t.co/OGrIjTLC2G>`_
-"""
-
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,3 +1,8 @@
+.. note::
+
+    Help inform future development and improve the Dask community experience -
+    take the `2019 Dask User Survey <https://t.co/OGrIjTLC2G>`_
+
 ====
 Dask
 ====


### PR DESCRIPTION
This PR adds a link to the user survey to our documentation (analogous to https://github.com/dask/dask.github.io/pull/12). Currently this PR adds a note to the top of each page, like so:

<img width="1440" alt="Screen Shot 2019-06-29 at 8 39 00 PM" src="https://user-images.githubusercontent.com/11656932/60391220-e0527c80-9aae-11e9-8e7a-4d03ef312a11.png">

Is this something we want to add temporarily to bring attention to the survey? Is adding it to every page overkill (e.g. should we just add a link to `index.rst`)?
