### PR TITLE
Fix cumulative functions on tables with more than 1 partition (#5024)

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5237,7 +5237,7 @@ def _take_last(a, skipna=True):
         # in each column
         if is_dataframe_like(a):
             # create Series from appropriate backend dataframe library
-            series_typ = type(a.loc[0:1, a.columns[0]])
+            series_typ = type(a.iloc[0:1, 0])
             if a.empty:
                 return series_typ([])
             return series_typ(

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -468,8 +468,9 @@ def test_describe_for_possibly_unsorted_q():
 
 
 def test_cumulative():
-    df = pd.DataFrame(np.random.randn(100, 5), columns=list("abcde"))
-    df_out = pd.DataFrame(np.random.randn(100, 5), columns=list("abcde"))
+    index = ["row{:03d}".format(i) for i in range(100)]
+    df = pd.DataFrame(np.random.randn(100, 5), columns=list("abcde"), index=index)
+    df_out = pd.DataFrame(np.random.randn(100, 5), columns=list("abcde"), index=index)
 
     ddf = dd.from_pandas(df, 5)
     ddf_out = dd.from_pandas(df_out, 5)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
