### PR TITLE
CI environment overhaul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
       - PYTHON=3.6
       - NUMPY=1.15.1
       - PANDAS=0.23.4
+      - ENV_FILE=continuous_integration/travis/travis-36.yaml
       - *test_and_lint
       - *coverage
       - *no_optimize
@@ -40,6 +41,7 @@ jobs:
       - PYTHON=3.7
       - NUMPY=1.16.2
       - PANDAS>=0.24.1
+      - ENV_FILE=continuous_integration/travis/travis-37.yaml
       - *test_and_lint
       - *no_coverage
       - *no_optimize
@@ -48,8 +50,8 @@ jobs:
 
     - env: &py37_dev
       - UPSTREAM_DEV=1  # Install nightly versions of NumPy, pandas, pyarrow
-      - NUMPY=1.16.2    # these are overridden later
-      - PANDAS>=0.24.2
+      - ENV_FILE=continuous_integration/travis/travis-37-dev.yaml
+      - *test_and_lint
       - *test_and_lint
       - *no_coverage
       - *no_optimize

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ jobs:
       - PYTHON=3.5
       - NUMPY=1.13.0
       - PANDAS=0.21.1
+      - ENV_FILE=continuous_integration/travis/travis-35.yaml
       - *test
       - *no_coverage
       - *no_optimize

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ jobs:
       - UPSTREAM_DEV=1  # Install nightly versions of NumPy, pandas, pyarrow
       - ENV_FILE=continuous_integration/travis/travis-37-dev.yaml
       - *test_and_lint
-      - *test_and_lint
       - *no_coverage
       - *no_optimize
       - *no_imports

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ jobs:
   fast_finish: true
   include:
     - env:
-      - PYTHON=3.5
-      - NUMPY=1.13.0
-      - PANDAS=0.21.1
       - ENV_FILE=continuous_integration/travis/travis-35.yaml
       - *test
       - *no_coverage
@@ -28,9 +25,6 @@ jobs:
       - *no_imports
 
     - env: &py36_env
-      - PYTHON=3.6
-      - NUMPY=1.15.1
-      - PANDAS=0.23.4
       - ENV_FILE=continuous_integration/travis/travis-36.yaml
       - *test_and_lint
       - *coverage
@@ -38,9 +32,6 @@ jobs:
       - *imports
 
     - env: &py37_env
-      - PYTHON=3.7
-      - NUMPY=1.16.2
-      - PANDAS>=0.24.1
       - ENV_FILE=continuous_integration/travis/travis-37.yaml
       - *test_and_lint
       - *no_coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
     - PYTHON: "3.6"
       ARCH: "64"
       CONDA_ENV: testenv
+      ENV_FILE: continuous_integration/appveyor/environment.yaml
 
 init:
   # Use AppVeyor's provided Miniconda: https://www.appveyor.com/docs/installed-software#python

--- a/continuous_integration/appveyor/environment.yaml
+++ b/continuous_integration/appveyor/environment.yaml
@@ -1,0 +1,31 @@
+# This job includes coverage
+name: testenv
+channels:
+  - conda-forge
+dependencies:
+  # required dependencies
+  - python=3.6.*
+  - numpy>=1.13.0
+  - pandas>=0.21.0
+  - pytest
+  - cloudpickle
+  - distributed
+  - bcolz
+  - bokeh
+  - h5py
+  - ipython
+  - lz4
+  - psutil
+  - pytables
+  - s3fs
+  - scipy
+  - fastparquet
+  - python-snappy
+  - zarr
+  - crick
+  - pip
+  - partd
+  - cachey
+  - sparse
+  - blosc
+  - moto

--- a/continuous_integration/appveyor/environment.yaml
+++ b/continuous_integration/appveyor/environment.yaml
@@ -9,6 +9,7 @@ dependencies:
   - pytest
   - cloudpickle
   - distributed
+  - toolz
   - bcolz
   - bokeh
   - h5py

--- a/continuous_integration/appveyor/environment.yaml
+++ b/continuous_integration/appveyor/environment.yaml
@@ -1,4 +1,3 @@
-# This job includes coverage
 name: testenv
 channels:
   - conda-forge

--- a/continuous_integration/appveyor/run_tests.cmd
+++ b/continuous_integration/appveyor/run_tests.cmd
@@ -2,10 +2,7 @@ call activate %CONDA_ENV%
 
 @echo on
 
-set PYTHONFAULTHANDLER=1
-
-@rem `--capture=sys` avoids clobbering faulthandler tracebacks on crash
-set PYTEST=py.test --capture=sys
+set PYTEST=pytest
 
 @rem %PYTEST% -v --runslow dask\dataframe\tests\test_groupby.py
 %PYTEST% dask

--- a/continuous_integration/appveyor/setup_conda_environment.cmd
+++ b/continuous_integration/appveyor/setup_conda_environment.cmd
@@ -6,8 +6,6 @@ set PIP_INSTALL=pip install -q
 
 @echo on
 
-@rem Deactivate any environment
-call deactivate
 @rem Display root environment (for debugging)
 conda list
 @rem Clean up any left-over from a previous build
@@ -15,7 +13,7 @@ conda remove --all -q -y -n %CONDA_ENV%
 
 @rem Create test environment
 @rem (note: no cytoolz as it seems to prevent faulthandler tracebacks on crash)
-conda env create -n %CONDA_ENV% -q -f %CONDA_FILE%
+conda env create -n %CONDA_ENV% -q -f %ENV_FILE%
 
 call activate %CONDA_ENV%
 

--- a/continuous_integration/appveyor/setup_conda_environment.cmd
+++ b/continuous_integration/appveyor/setup_conda_environment.cmd
@@ -15,19 +15,9 @@ conda remove --all -q -y -n %CONDA_ENV%
 
 @rem Create test environment
 @rem (note: no cytoolz as it seems to prevent faulthandler tracebacks on crash)
-conda create -n %CONDA_ENV% -q -y python=%PYTHON% pytest toolz
+conda env create -n %CONDA_ENV% -q -f %CONDA_FILE%
 
 call activate %CONDA_ENV%
-
-@rem Install optional dependencies for tests
-%CONDA_INSTALL% -c conda-forge "numpy>=1.13" "pandas>=0.21.0" cloudpickle distributed bcolz bokeh h5py ipython lz4 psutil pytables s3fs scipy fastparquet python-snappy zarr crick
-
-%PIP_INSTALL% --no-deps --upgrade locket git+https://github.com/dask/partd
-%PIP_INSTALL% --no-deps --upgrade heapdict git+https://github.com/dask/cachey
-%PIP_INSTALL%           --upgrade git+https://github.com/dask/distributed
-%PIP_INSTALL% --no-deps           git+https://github.com/pydata/sparse
-%PIP_INSTALL% --no-deps --upgrade blosc --upgrade
-%PIP_INSTALL% --no-deps moto Jinja2 boto boto3 botocore cryptography requests xmltodict six werkzeug PyYAML pytz python-dateutil python-jose mock docker jsondiff==1.1.2 aws-xray-sdk responses idna cfn-lint
 
 @rem Display final environment (for reproducing)
 %CONDA% list

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -75,6 +75,8 @@ pip install --quiet --upgrade --no-deps git+https://github.com/dask/distributed
 if [[ $PYTHON != '3.5' ]]; then
     # s3fs supports 3.6+
     pip install --quiet --upgrade --no-deps git+https://github.com/dask/s3fs
+else
+    pip install --quite --upgrade s3fs
 fi
 
 if [[ $PYTHONOPTIMIZE != '2' ]] && [[ $NUMPY > '1.11.0' ]] && [[ $NUMPY < '1.14.0' ]]; then

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -20,7 +20,7 @@ export BOTO_CONFIG=/dev/null
 conda config --set always_yes yes --set changeps1 no --set remote_max_retries 10
 
 # Create conda environment
-conda create -q -n test-environment python=$PYTHON
+conda env create -q -n test-environment -f $ENV_FILE python=$PYTHON
 source activate test-environment
 
 # Pin matrix items
@@ -76,7 +76,7 @@ if [[ $PYTHON != '3.5' ]]; then
     # s3fs supports 3.6+
     pip install --quiet --upgrade --no-deps git+https://github.com/dask/s3fs
 else
-    pip install --quite --upgrade s3fs
+    pip install --quiet --upgrade s3fs
 fi
 
 if [[ $PYTHONOPTIMIZE != '2' ]] && [[ $NUMPY > '1.11.0' ]] && [[ $NUMPY < '1.14.0' ]]; then

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -21,7 +21,7 @@ export BOTO_CONFIG=/dev/null
 conda config --set always_yes yes --set changeps1 no --set remote_max_retries 10
 
 # Create conda environment
-conda env create -q -n test-environment -f $ENV_FILE python=$PYTHON
+conda env create -q -n test-environment -f $ENV_FILE
 source activate test-environment
 
 # We don't have a conda-forge package for cityhash
@@ -38,6 +38,7 @@ if [[ ${UPSTREAM_DEV} ]]; then
         pandas
     pip install \
         --no-deps
+        --upgrade \
         locket \
         git+https://github.com/pydata/sparse \
         git+https://github.com/dask/s3fs \

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -13,6 +13,7 @@ case "$(uname -s)" in
 esac
 
 
+# Install miniconda
 wget https://repo.continuum.io/miniconda/$MINICONDA_FILENAME -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
@@ -23,110 +24,22 @@ conda config --set always_yes yes --set changeps1 no --set remote_max_retries 10
 conda env create -q -n test-environment -f $ENV_FILE python=$PYTHON
 source activate test-environment
 
-# Pin matrix items
-# Please see PR ( https://github.com/dask/dask/pull/2185 ) for details.
-touch $CONDA_PREFIX/conda-meta/pinned
-if ! [[ ${UPSTREAM_DEV} ]]; then
-    echo "Pinning NumPy $NUMPY, pandas $PANDAS"
-    echo "numpy $NUMPY" >> $CONDA_PREFIX/conda-meta/pinned
-    echo "pandas $PANDAS" >> $CONDA_PREFIX/conda-meta/pinned
-fi;
-
-# Install dependencies.
-conda install -q -c conda-forge \
-    numpy \
-    pandas \
-    bcolz \
-    blosc \
-    bokeh \
-    boto3 \
-    botocore \
-    httpretty \
-    chest \
-    cloudpickle \
-    coverage \
-    crick \
-    cytoolz \
-    distributed \
-    graphviz \
-    h5py \
-    ipython \
-    lz4 \
-    numba \
-    partd \
-    psutil \
-    pytables \
-    pytest \
-    requests \
-    scikit-image \
-    scikit-learn \
-    scipy \
-    sqlalchemy \
-    toolz \
-    tiledb-py \
-    zarr
-
-pip install --quiet --upgrade codecov
-
-pip install --quiet --upgrade --no-deps locket git+https://github.com/dask/partd
-pip install --quiet --upgrade --no-deps git+https://github.com/dask/zict
-pip install --quiet --upgrade --no-deps git+https://github.com/dask/distributed
-
-if [[ $PYTHON != '3.5' ]]; then
-    # s3fs supports 3.6+
-    pip install --quiet --upgrade --no-deps git+https://github.com/dask/s3fs
-else
-    pip install --quiet --upgrade s3fs
-fi
-
-if [[ $PYTHONOPTIMIZE != '2' ]] && [[ $NUMPY > '1.11.0' ]] && [[ $NUMPY < '1.14.0' ]]; then
-    conda install -q -c conda-forge fastparquet python-snappy cython
-    conda remove --force fastparquet
-    pip install --quiet --no-deps git+https://github.com/dask/fastparquet
-fi
-
-if [[ $NUMPY > '1.13.0' ]]; then
-    if [[ ${UPSTREAM_DEV} ]]; then
-        pip install --quiet --upgrade git+https://github.com/pydata/sparse
-    else
-        pip install --quiet sparse
-    fi
-fi
-
-pip install --quiet --upgrade --no-deps \
-    cachey \
-    graphviz
-
-pip install --quiet --upgrade \
-    cityhash \
-    mmh3 \
-    pytest-xdist \
-    xxhash \
-    moto \
-    pandas_datareader
-
 if [[ ${UPSTREAM_DEV} ]]; then
-    echo "Installing PyArrow dev"
-    conda install -q -c twosigma \
-          arrow-cpp \
-          parquet-cpp \
-          pyarrow
-else
-    echo "Installing PyArrow"
-    conda install -q -c conda-forge \
-          arrow-cpp \
-          parquet-cpp \
-          pyarrow
-
-fi;
-
-if [[ ${UPSTREAM_DEV} ]]; then
-    echo "Installing NumPy and Pandas dev"
-    conda uninstall -y --force numpy pandas
-    PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
-    pip install --quiet --pre --no-deps --upgrade --timeout=60 -f $PRE_WHEELS numpy pandas
-fi;
-
+    conda uninstall --force numpy pandas
+    pip install -f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com \
+        -- no-deps \
+        --pre \
+        numpy \
+        pandas
+    pip install \
+        --no-deps
+        locket \
+        git+https://github.com/pydata/sparse \
+        git+https://github.com/dask/s3fs \
+        git+https://github.com/dask/partd \
+        git+https://github.com/dask/zict \
+        git+https://github.com/dask/distributed
+fi
 
 # Install dask
 pip install --quiet --no-deps -e .[complete]

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -24,10 +24,15 @@ conda config --set always_yes yes --set changeps1 no --set remote_max_retries 10
 conda env create -q -n test-environment -f $ENV_FILE python=$PYTHON
 source activate test-environment
 
+# We don't have a conda-forge package for cityhash
+# We don't include it in the conda environment.yaml, since that may
+# make things harder for contributors that don't have a C++ compiler
+pip install --no-deps cityhash
+
 if [[ ${UPSTREAM_DEV} ]]; then
     conda uninstall --force numpy pandas
     pip install -f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com \
-        -- no-deps \
+        --no-deps \
         --pre \
         numpy \
         pandas

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -71,7 +71,11 @@ pip install --quiet --upgrade codecov
 pip install --quiet --upgrade --no-deps locket git+https://github.com/dask/partd
 pip install --quiet --upgrade --no-deps git+https://github.com/dask/zict
 pip install --quiet --upgrade --no-deps git+https://github.com/dask/distributed
-pip install --quiet --upgrade --no-deps git+https://github.com/dask/s3fs
+
+if [[ $PYTHON != '3.5' ]]; then
+    # s3fs supports 3.6+
+    pip install --quiet --upgrade --no-deps git+https://github.com/dask/s3fs
+fi
 
 if [[ $PYTHONOPTIMIZE != '2' ]] && [[ $NUMPY > '1.11.0' ]] && [[ $NUMPY < '1.14.0' ]]; then
     conda install -q -c conda-forge fastparquet python-snappy cython

--- a/continuous_integration/travis/travis-35.yaml
+++ b/continuous_integration/travis/travis-35.yaml
@@ -1,0 +1,54 @@
+# This file intends to test the oldest supported versions
+# of dependencies
+name: pandas-dev
+channels:
+  - conda-forge
+dependencies:
+  # required dependencies
+  - python=3.5.*
+  - numpy=1.13.*
+  - pandas=0.21.*
+  # test dependencies
+  - pytest
+  - pytest-xdist
+  - moto
+  - coverage
+  - fastparquet
+  - h5py
+  - pytables
+  - zarr
+  - tiledb-py
+  - sqlalchemy
+  # other -- IO
+  - bcolz
+  - blosc
+  - s3fs
+  - boto3
+  - botocore
+  - bokeh
+  - httpretty
+  - chest
+  - cloudpickle
+  - crick
+  - cytoolz
+  - distributed==2.0.1
+  - graphviz
+  - ipython
+  - lz4
+  - numba
+  - partd
+  - psutil
+  - requests
+  - scikit-image
+  - scikit-learn
+  - scipy
+  - toolz
+  - python-snappy
+  - sparse
+  - cachey
+  - python-graphviz
+  - pip
+  - pip:
+      - cityhash
+      - mmh3
+      - xxhash

--- a/continuous_integration/travis/travis-35.yaml
+++ b/continuous_integration/travis/travis-35.yaml
@@ -1,6 +1,6 @@
 # This file intends to test the oldest supported versions
 # of dependencies
-name: pandas-dev
+name: test-environment
 channels:
   - conda-forge
 dependencies:
@@ -12,13 +12,13 @@ dependencies:
   - pytest
   - pytest-xdist
   - moto
-  - coverage
   - fastparquet
   - h5py
   - pytables
   - zarr
   - tiledb-py
   - sqlalchemy
+  - pyarrow
   # other -- IO
   - bcolz
   - blosc
@@ -47,6 +47,7 @@ dependencies:
   - sparse
   - cachey
   - python-graphviz
+  - pandas-datareader
   - pip
   - pip:
       - cityhash

--- a/continuous_integration/travis/travis-36.yaml
+++ b/continuous_integration/travis/travis-36.yaml
@@ -51,8 +51,6 @@ dependencies:
   - cachey
   - python-graphviz
   - pandas-datareader
+  - mmh3
+  - xxhash
   - pip
-  - pip:
-      - cityhash
-      - mmh3
-      - xxhash

--- a/continuous_integration/travis/travis-36.yaml
+++ b/continuous_integration/travis/travis-36.yaml
@@ -1,0 +1,56 @@
+# This job includes coverage
+name: test-environment
+channels:
+  - conda-forge
+dependencies:
+  # required dependencies
+  - python=3.6.*
+  - numpy=1.15.*
+  - pandas=0.23.*
+  # test dependencies
+  - pytest
+  - pytest-xdist
+  - moto
+  - coverage
+  - codecov
+  - fastparquet
+  - h5py
+  - pytables
+  - zarr
+  - tiledb-py
+  - sqlalchemy
+  - pyarrow
+  # other -- IO
+  - bcolz
+  - blosc
+  - s3fs
+  - boto3
+  - botocore
+  - bokeh
+  - httpretty
+  - chest
+  - cloudpickle
+  - crick
+  - cytoolz
+  - distributed==2.0.1
+  - graphviz
+  - ipython
+  - lz4
+  - numba
+  - partd
+  - psutil
+  - requests
+  - scikit-image
+  - scikit-learn
+  - scipy
+  - toolz
+  - python-snappy
+  - sparse
+  - cachey
+  - python-graphviz
+  - pandas-datareader
+  - pip
+  - pip:
+      - cityhash
+      - mmh3
+      - xxhash

--- a/continuous_integration/travis/travis-36.yaml
+++ b/continuous_integration/travis/travis-36.yaml
@@ -13,7 +13,9 @@ dependencies:
   - moto
   - coverage
   - codecov
-  - fastparquet
+  # Issue with conda package for NumPy 1.15?
+  # See fastparquet-444
+  # - fastparquet
   - h5py
   - pytables
   - zarr

--- a/continuous_integration/travis/travis-37-dev.yaml
+++ b/continuous_integration/travis/travis-37-dev.yaml
@@ -1,0 +1,53 @@
+# This job tests against upstream dev
+name: test-environment
+channels:
+  - conda-forge
+dependencies:
+  # required dependencies
+  - python=3.7.*
+  # For the dependencies. These will be re-installed later.
+  - numpy
+  - pandas
+  # test dependencies
+  - pytest
+  - pytest-xdist
+  - moto
+  - fastparquet
+  - h5py
+  - pytables
+  - zarr
+  - tiledb-py
+  - sqlalchemy
+  - pyarrow
+  # other -- IO
+  - bcolz
+  - blosc
+  - s3fs
+  - boto3
+  - botocore
+  - bokeh
+  - httpretty
+  - chest
+  - cloudpickle
+  - crick
+  - cytoolz
+  - distributed==2.0.1
+  - graphviz
+  - ipython
+  - lz4
+  - numba
+  - partd
+  - psutil
+  - requests
+  - scikit-image
+  - scikit-learn
+  - scipy
+  - toolz
+  - python-snappy
+  - cachey
+  - python-graphviz
+  - pip
+  - pip:
+      - cityhash
+      - mmh3
+      - xxhash

--- a/continuous_integration/travis/travis-37.yaml
+++ b/continuous_integration/travis/travis-37.yaml
@@ -1,0 +1,53 @@
+name: test-environment
+channels:
+  - conda-forge
+dependencies:
+  # required dependencies
+  - python=3.7.*
+  - numpy=1.16.*
+  - pandas=0.24.*
+  # test dependencies
+  - pytest
+  - pytest-xdist
+  - moto
+  - fastparquet
+  - h5py
+  - pytables
+  - zarr
+  - tiledb-py
+  - sqlalchemy
+  - pyarrow
+  # other -- IO
+  - bcolz
+  - blosc
+  - s3fs
+  - boto3
+  - botocore
+  - bokeh
+  - httpretty
+  - chest
+  - cloudpickle
+  - crick
+  - cytoolz
+  - distributed==2.0.1
+  - graphviz
+  - ipython
+  - lz4
+  - numba
+  - partd
+  - psutil
+  - requests
+  - scikit-image
+  - scikit-learn
+  - scipy
+  - toolz
+  - python-snappy
+  - sparse
+  - cachey
+  - python-graphviz
+  - pandas-datareader
+  - pip
+  - pip:
+      - cityhash
+      - mmh3
+      - xxhash

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -148,11 +148,9 @@ def test_open_glob(dir_server):
 
 
 @pytest.mark.network
+@pytest.mark.xfail(reason="https://github.com/dask/dask/issues/5042", strict=False)
 def test_parquet():
-    from distutils.version import LooseVersion
-
-    if LooseVersion(requests.__version__) < LooseVersion("2.21.0"):
-        pytest.skip()
+    pytest.importorskip("requests", minversion="2.21.0")
     dd = pytest.importorskip("dask.dataframe")
     pytest.importorskip("fastparquet")  # no pyarrow compatability FS yet
     df = dd.read_parquet(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1076,7 +1076,7 @@ def test_filters(tmpdir, write_engine, read_engine):
 
 
 def test_divisions_read_with_filters(tmpdir):
-    check_fastparquet()
+    pytest.importorskip("fastparquet", minversion="0.3.1")
     tmpdir = str(tmpdir)
     # generate dataframe
     size = 100
@@ -1101,7 +1101,7 @@ def test_divisions_read_with_filters(tmpdir):
 
 
 def test_divisions_are_known_read_with_filters(tmpdir):
-    check_fastparquet()
+    pytest.importorskip("fastparquet", minversion="0.3.1")
     tmpdir = str(tmpdir)
     # generate dataframe
     df = pd.DataFrame(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1042,6 +1042,8 @@ def test_partition_on(tmpdir, write_engine, read_engine):
 
 @write_read_engines_xfail
 def test_filters(tmpdir, write_engine, read_engine):
+    if write_engine == "fastparquet" or read_engine == "fastparquet":
+        pytest.importorskip("fastparquet", minversion="0.3.1")
     fn = str(tmpdir)
 
     df = pd.DataFrame({"at": ["ab", "aa", "ba", "da", "bb"]})


### PR DESCRIPTION
Updates how we install our environment. The goal is to end up with as few subsequent `pip install`  operations as possible. That's what broke our CI over the weekend.

We specify the environments in a per-job `environment.yaml` file. I tried to capture the following cases

1. "Oldest supported". The oldest python, Numpy, pandas, distributed, etc. I'd like to add fastparquet & arrow. Do we have an official minimum version for those @martindurant?
2. "Upstream dev". Upstream versions of pandas, numpy, etc. I'm going to go through the current failures today. I'm hoping to find a better solution to being notified about failures here, since the current system (us checking manually) isn't ideal.

---

Test changes

We should have a few new skips. Some of the fastparquet tests were being skipped, since (IIUC) we previously only tested against fastparquet master.