### PR TITLE
Add recompute= keyword to svd_compressed for lower-memory use

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -675,9 +675,6 @@ def compression_matrix(data, q, n_power_iter=0, seed=None, recompute=False):
             wait(tmp)
         mat_h = data.dot(tmp)
     q, _ = tsqr(mat_h)
-    if recompute:
-        q = q.persist()
-        wait(q)
     return q.T
 
 
@@ -726,6 +723,9 @@ def svd_compressed(a, k, n_power_iter=0, seed=None, recompute=False):
     comp = compression_matrix(
         a, k, n_power_iter=n_power_iter, seed=seed, recompute=recompute
     )
+    if recompute:
+        comp = comp.persist()
+        wait(comp)
     a_compressed = comp.dot(a)
     v, s, u = tsqr(a_compressed.T, compute_svd=True)
     u = comp.T.dot(u)

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -626,7 +626,7 @@ def compression_level(n, q, oversampling=10, min_subspace_size=20):
     return min(max(min_subspace_size, q + oversampling), n)
 
 
-def compression_matrix(data, q, n_power_iter=0, seed=None, recompute=False):
+def compression_matrix(data, q, n_power_iter=0, seed=None, compute=False):
     """ Randomly sample matrix to find most active subspace
 
     This compression matrix returned by this algorithm can be used to
@@ -642,10 +642,10 @@ def compression_matrix(data, q, n_power_iter=0, seed=None, recompute=False):
     n_power_iter: int
         number of power iterations, useful when the singular values of
         the input matrix decay very slowly.
-    recompute : bool
+    compute : bool
         Whether or not to compute data at each stage during computation.
         Recomputing the input while performing several passes reduces memory
-        pressure, but means that we have to recompute the input multiple times.
+        pressure, but means that we have to compute the input multiple times.
         This is a good choice if the data is larger than memory and cheap to
         recreate.
 
@@ -669,11 +669,11 @@ def compression_matrix(data, q, n_power_iter=0, seed=None, recompute=False):
     )
     mat_h = data.dot(omega)
     for j in range(n_power_iter):
-        if recompute:
+        if compute:
             mat_h = mat_h.persist()
             wait(mat_h)
         tmp = data.T.dot(mat_h)
-        if recompute:
+        if compute:
             tmp = tmp.persist()
             wait(tmp)
         mat_h = data.dot(tmp)
@@ -681,7 +681,7 @@ def compression_matrix(data, q, n_power_iter=0, seed=None, recompute=False):
     return q.T
 
 
-def svd_compressed(a, k, n_power_iter=0, seed=None, recompute=False):
+def svd_compressed(a, k, n_power_iter=0, seed=None, compute=False):
     """ Randomly compressed rank-k thin Singular Value Decomposition.
 
     This computes the approximate singular value decomposition of a large
@@ -699,10 +699,10 @@ def svd_compressed(a, k, n_power_iter=0, seed=None, recompute=False):
         Number of power iterations, useful when the singular values
         decay slowly. Error decreases exponentially as n_power_iter
         increases. In practice, set n_power_iter <= 4.
-    recompute : bool
+    compute : bool
         Should we compute data at each stage during computation?
         Recomputing reduces memory pressure, but means that we have to
-        recompute the input multiple times.
+        compute the input multiple times.
 
     Examples
     --------
@@ -724,9 +724,9 @@ def svd_compressed(a, k, n_power_iter=0, seed=None, recompute=False):
     https://arxiv.org/abs/0909.4061
     """
     comp = compression_matrix(
-        a, k, n_power_iter=n_power_iter, seed=seed, recompute=recompute
+        a, k, n_power_iter=n_power_iter, seed=seed, compute=compute
     )
-    if recompute:
+    if compute:
         comp = comp.persist()
         wait(comp)
     a_compressed = comp.dot(a)

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -660,7 +660,10 @@ def compression_matrix(data, q, n_power_iter=0, seed=None, recompute=False):
     """
     n = data.shape[1]
     comp_level = compression_level(n, q)
-    state = RandomState(seed)
+    if isinstance(seed, RandomState):
+        state = seed
+    else:
+        state = RandomState(seed)
     omega = state.standard_normal(
         size=(n, comp_level), chunks=(data.chunks[1], (comp_level,))
     )

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -643,7 +643,7 @@ def compression_matrix(data, q, n_power_iter=0, seed=None, compute=False):
         number of power iterations, useful when the singular values of
         the input matrix decay very slowly.
     compute : bool
-        Whether or not to compute data at each stage during computation.
+        Whether or not to compute data at each use.
         Recomputing the input while performing several passes reduces memory
         pressure, but means that we have to compute the input multiple times.
         This is a good choice if the data is larger than memory and cheap to
@@ -700,9 +700,11 @@ def svd_compressed(a, k, n_power_iter=0, seed=None, compute=False):
         decay slowly. Error decreases exponentially as n_power_iter
         increases. In practice, set n_power_iter <= 4.
     compute : bool
-        Should we compute data at each stage during computation?
-        Recomputing reduces memory pressure, but means that we have to
-        compute the input multiple times.
+        Whether or not to compute data at each use.
+        Recomputing the input while performing several passes reduces memory
+        pressure, but means that we have to compute the input multiple times.
+        This is a good choice if the data is larger than memory and cheap to
+        recreate.
 
     Examples
     --------

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -910,3 +910,13 @@ def test_norm_implemented_errors(shape, chunks, axis, norm, keepdims):
     if len(shape) > 2 and len(axis) == 2:
         with pytest.raises(NotImplementedError):
             da.linalg.norm(d, ord=norm, axis=axis, keepdims=keepdims)
+
+
+def test_biggish_svd():
+    x = da.ones((100, 100), chunks=(10, 10))
+    u, s, v = da.linalg.svd_compressed(x, k=2, n_power_iter=0, recompute=True, seed=123)
+    uu, ss, vv = da.linalg.svd_compressed(x, k=2, n_power_iter=0, seed=123)
+
+    assert len(v.dask) < len(vv.dask)
+
+    assert_eq(v, vv)

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -912,7 +912,7 @@ def test_norm_implemented_errors(shape, chunks, axis, norm, keepdims):
             da.linalg.norm(d, ord=norm, axis=axis, keepdims=keepdims)
 
 
-def test_biggish_svd():
+def test_svd_compressed_recompute():
     x = da.ones((100, 100), chunks=(10, 10))
     u, s, v = da.linalg.svd_compressed(x, k=2, n_power_iter=0, recompute=True, seed=123)
     uu, ss, vv = da.linalg.svd_compressed(x, k=2, n_power_iter=0, seed=123)

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -912,9 +912,9 @@ def test_norm_implemented_errors(shape, chunks, axis, norm, keepdims):
             da.linalg.norm(d, ord=norm, axis=axis, keepdims=keepdims)
 
 
-def test_svd_compressed_recompute():
+def test_svd_compressed_compute():
     x = da.ones((100, 100), chunks=(10, 10))
-    u, s, v = da.linalg.svd_compressed(x, k=2, n_power_iter=0, recompute=True, seed=123)
+    u, s, v = da.linalg.svd_compressed(x, k=2, n_power_iter=0, compute=True, seed=123)
     uu, ss, vv = da.linalg.svd_compressed(x, k=2, n_power_iter=0, seed=123)
 
     assert len(v.dask) < len(vv.dask)

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -389,16 +389,3 @@ def test_double_dependencies():
     X = da.dot(X, X.T)
 
     assert_eq(X.compute(optimize_graph=False), X)
-
-
-def test_dot_fuses():
-    from dask.blockwise import optimize_blockwise
-
-    x = da.ones((200, 10), chunks=(100, 10))
-    y = da.ones((10, 10), chunks=(10, 10))
-
-    z = x.dot(y)
-
-    optimize_blockwise(z.dask)
-    breakpoint()
-    1 + 1

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -389,3 +389,16 @@ def test_double_dependencies():
     X = da.dot(X, X.T)
 
     assert_eq(X.compute(optimize_graph=False), X)
+
+
+def test_dot_fuses():
+    from dask.blockwise import optimize_blockwise
+
+    x = da.ones((200, 10), chunks=(100, 10))
+    y = da.ones((10, 10), chunks=(10, 10))
+
+    z = x.dot(y)
+
+    optimize_blockwise(z.dask)
+    breakpoint()
+    1 + 1

--- a/dask/base.py
+++ b/dask/base.py
@@ -1011,3 +1011,18 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
         return get
 
     return None
+
+
+def wait(x, timeout=None, return_when="ALL_COMPLETED"):
+    """ Wait until computation has finished
+
+    This is a compatibility alias for ``dask.distributed.wait``.
+    If it is applied onto Dask collections without Dask Futures or if Dask
+    distributed is not installed then it is a no-op
+    """
+    try:
+        from distributed import wait
+
+        return wait(x, timeout=timeout, return_when=return_when)
+    except (ImportError, ValueError):
+        return x


### PR DESCRIPTION
The svd_compressed algorithm needs to use the input array a few times
Often, this array is too large to fit into memory, and so it is better
to recompute it.  This PR adds a keyword, ``recompute=``, which
optionally triggers this behavior.  It is turned off by default.

We also fix up the docstring a bit and one of the keys in the high level
graph.

This also introduces a dask.distributed agnostic wait function to wait
on persisted data if we're using the distributed scheduler, but to do
nothing otherwise.

With this change we're able to compute arbitrarily large svd
computations in low memory.

cc @alimanfoo 