### PR TITLE
Ensure scalar arrays are not rendered to SVG

### DIFF
--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -24,6 +24,8 @@ def svg(chunks, size=200, **kwargs):
         raise NotImplementedError("Can't generate SVG with unknown chunk sizes")
     if not all(shape):
         raise NotImplementedError("Can't generate SVG with 0 dimensions")
+    if len(chunks) == 0:
+        raise NotImplementedError("Can't generate SVG with 0 dimensions")
     if len(chunks) == 1:
         return svg_1d(chunks, size=size, **kwargs)
     elif len(chunks) == 2:

--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -23,7 +23,7 @@ def svg(chunks, size=200, **kwargs):
     if np.isnan(shape).any():  # don't support unknown sizes
         raise NotImplementedError("Can't generate SVG with unknown chunk sizes")
     if not all(shape):
-        raise NotImplementedError("Can't generate SVG with 0 dimensions")
+        raise NotImplementedError("Can't generate SVG with 0-length dimensions")
     if len(chunks) == 0:
         raise NotImplementedError("Can't generate SVG with 0 dimensions")
     if len(chunks) == 1:

--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -29,9 +29,15 @@ def test_repr_html():
 
 
 def test_errors():
+    # scalars
     with pytest.raises(NotImplementedError):
-        assert da.ones(10)[:0].to_svg()
+        da.ones([]).to_svg()
 
+    # empty one-dim arrays
+    with pytest.raises(NotImplementedError):
+        da.ones(10)[:0].to_svg()
+
+    # unknown shape
     with pytest.raises(NotImplementedError):
         x = da.ones(10)
         x = x[x > 5]

--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -32,13 +32,12 @@ def test_errors():
     # empty arrays
     with pytest.raises(NotImplementedError) as excpt:
         da.ones([]).to_svg()
-    assert "0 dimenstions" in str(excpt.value)
+    assert "0 dimensions" in str(excpt.value)
 
     # Scalars
     with pytest.raises(NotImplementedError) as excpt:
         da.asarray(1).to_svg()
-    assert "0 dimenstions" in str(excpt.value)
-
+    assert "0 dimensions" in str(excpt.value)
 
     # 0-length dims arrays
     with pytest.raises(NotImplementedError) as excpt:

--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -10,6 +10,7 @@ def parses(text):
 
 
 def test_basic():
+    parses(da.ones([]).to_svg())
     parses(da.ones(10).to_svg())
     parses(da.ones((10, 10)).to_svg())
     parses(da.ones((10, 10, 10)).to_svg())

--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -10,7 +10,6 @@ def parses(text):
 
 
 def test_basic():
-    parses(da.ones([]).to_svg())
     parses(da.ones(10).to_svg())
     parses(da.ones((10, 10)).to_svg())
     parses(da.ones((10, 10, 10)).to_svg())
@@ -21,6 +20,7 @@ def test_basic():
 
 
 def test_repr_html():
+    assert da.ones([])._repr_html_()
     assert da.ones(10)[:0]._repr_html_()
     assert da.ones(10)._repr_html_()
     assert da.ones((10, 10))._repr_html_()

--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -29,12 +29,18 @@ def test_repr_html():
 
 
 def test_errors():
-    # scalars
+    # empty arrays
     with pytest.raises(NotImplementedError) as excpt:
         da.ones([]).to_svg()
     assert "0 dimenstions" in str(excpt.value)
 
-    # empty one-dim arrays
+    # Scalars
+    with pytest.raises(NotImplementedError) as excpt:
+        da.asarray(1).to_svg()
+    assert "0 dimenstions" in str(excpt.value)
+
+
+    # 0-length dims arrays
     with pytest.raises(NotImplementedError) as excpt:
         da.ones(10)[:0].to_svg()
     assert "0-length dimensions" in str(excpt.value)

--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -30,18 +30,21 @@ def test_repr_html():
 
 def test_errors():
     # scalars
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError) as excpt:
         da.ones([]).to_svg()
+    assert "0 dimenstions" in str(excpt.value)
 
     # empty one-dim arrays
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError) as excpt:
         da.ones(10)[:0].to_svg()
+    assert "0-length dimensions" in str(excpt.value)
 
-    # unknown shape
-    with pytest.raises(NotImplementedError):
+    # unknown chunk sizes
+    with pytest.raises(NotImplementedError) as excpt:
         x = da.ones(10)
         x = x[x > 5]
         x.to_svg()
+    assert "unknown chunk sizes" in str(excpt.value)
 
 
 def test_repr_html():


### PR DESCRIPTION
Creating the SVG for scalar Dask arrays currently fails.

This adds a `NotImplementedError` for scalars, adds a test ensuring the error is raised, and ensures the HTML repr is succeeding.