### PR TITLE
Fix pd.MultiIndex size estimate

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -89,7 +89,7 @@ def register_pandas():
         p = int(sum(object_size(l) for l in i.levels))
         for c in i.codes if hasattr(i, "codes") else i.labels:
             p += c.nbytes
-        return int(p) + 1000
+        return int(p)
 
 
 @sizeof.register_lazy("scipy")

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -84,6 +84,13 @@ def register_pandas():
             p += object_size(i)
         return int(p) + 1000
 
+    @sizeof.register(pd.MultiIndex)
+    def sizeof_pandas_multiindex(i):
+        p = int(sum(object_size(l) for l in i.levels))
+        for c in i.codes if hasattr(i, "codes") else i.labels:
+            p += c.nbytes
+        return int(p) + 1000
+
 
 @sizeof.register_lazy("scipy")
 def register_spmatrix():

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -89,7 +89,7 @@ def register_pandas():
         p = int(sum(object_size(l) for l in i.levels))
         for c in i.codes if hasattr(i, "codes") else i.labels:
             p += c.nbytes
-        return int(p)
+        return int(p) + 1000
 
 
 @sizeof.register_lazy("scipy")

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -37,10 +37,12 @@ def test_pandas():
     assert sizeof(df.x) >= sizeof(df.index)
     assert sizeof(df.y) >= 100 * 3
     assert sizeof(df.index) >= 20
+    assert sizeof(df.set_index(["x", "y"].index)) < 1800
 
     assert isinstance(sizeof(df), int)
     assert isinstance(sizeof(df.x), int)
     assert isinstance(sizeof(df.index), int)
+    assert isinstance(sizeof(df.set_index(["x", "y"]).index), int)
 
 
 def test_pandas_repeated_column():

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -46,8 +46,9 @@ def test_pandas():
 def test_pandas_multiindex():
     pd = pytest.importorskip("pandas")
     index = pd.MultiIndex.from_product([range(5), ["a", "b", "c", "d", "e"]])
+    actual_size = sys.getsizeof(index) + 1000  # adjust for serialization overhead
 
-    assert 0.5 * sys.getsizeof(index) < sizeof(index) < 2 * sys.getsizeof(index)
+    assert 0.5 * actual_size < sizeof(index) < 2 * actual_size
     assert isinstance(sizeof(index), int)
 
 

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -37,12 +37,18 @@ def test_pandas():
     assert sizeof(df.x) >= sizeof(df.index)
     assert sizeof(df.y) >= 100 * 3
     assert sizeof(df.index) >= 20
-    assert sizeof(df.set_index(["x", "y"].index)) < 1800
 
     assert isinstance(sizeof(df), int)
     assert isinstance(sizeof(df.x), int)
     assert isinstance(sizeof(df.index), int)
-    assert isinstance(sizeof(df.set_index(["x", "y"]).index), int)
+
+
+def test_pandas_multiindex():
+    pd = pytest.importorskip("pandas")
+    index = pd.MultiIndex.from_product([range(5), ["a", "b", "c", "d", "e"]])
+
+    assert 0.5 * sys.getsizeof(index) < sizeof(index) < 2 * sys.getsizeof(index)
+    assert isinstance(sizeof(index), int)
 
 
 def test_pandas_repeated_column():


### PR DESCRIPTION
Fixes #5002.

Couple of new values with the above test setup:
Actual 3.4e6, old dask 308e6, new dask 3.34e6 (100 x 10000)
Actual 75e6, old dask 1525e6, new dask 57e6 (5 x 1000000)

Still not perfect but definitely an improvement :)


- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`