### PR TITLE
Use da.from_array(..., asarray=False) if input follows NEP-18

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2599,8 +2599,9 @@ def from_array(
         pass in True to have dask.array create one for you.
     asarray : bool, optional
         If True then call np.asarray on chunks to convert them to numpy arrays.
-        Set to False to pass passed chunks through unchanged.  This defaults to
-        True, unless the input has the ``__array_function__`` method defined.
+        If False then chunks are passed through unchanged.
+        If None (default) then we use True if the ``__array_function__`` method
+        is undefined.
     fancy : bool, optional
         If ``x`` doesn't support fancy indexing (e.g. indexing with lists or
         arrays) then set to False. Default is True.

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -177,8 +177,8 @@ def test_unregistered_func(func):
         def __init__(self, arr):
             self.arr = arr
 
-        def __array__(self, **kwargs):
-            return np.asarray(self.arr, **kwargs)
+        def __array__(self, *args, **kwargs):
+            return np.asarray(self.arr, *args, **kwargs)
 
         def __array_function__(self, f, t, arrs, kw):
             arrs = tuple(

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -192,3 +192,12 @@ def test_from_delayed_meta():
     x = da.from_delayed(d, shape=(3, 3), meta=sparse.COO.from_numpy(np.eye(1)))
     assert isinstance(x._meta, sparse.COO)
     assert_eq(x, x)
+
+
+def test_from_array():
+    x = sparse.COO.from_numpy(np.eye(10))
+    d = da.from_array(x, chunks=(5, 5))
+
+    assert isinstance(d._meta, sparse.COO)
+    assert_eq(d, d)
+    assert isinstance(d.compute(), sparse.COO)


### PR DESCRIPTION
Previously we called `np.asarray` on each chunk in `da.from_array`.
This can be troublesome if we have arrays like `cupy` or `sparse` that
are capable of performing computations on their own.

Now we look for an `__array_function__` method on the input as a signal
that it can handle numpy-like functions.  If it has this method then we
don't call `np.asarray`

cc @shoyer @pentschev @hameerabbasi 