### PR TITLE
Fix failing parquet test

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -617,7 +617,7 @@ def test_roundtrip_from_pandas(tmpdir, write_engine, read_engine):
     fn = str(tmpdir.join("test.parquet"))
     dfp = df.copy()
     dfp.index.name = "index"
-    dfp.to_parquet(fn, index=True, engine=write_engine)
+    dfp.to_parquet(fn, engine=write_engine)
     ddf = dd.read_parquet(fn, index="index", engine=read_engine)
     assert_eq(dfp, ddf)
 


### PR DESCRIPTION
This PR removes explicitly setting `index=True` when calling pandas `to_parquet` in `test_roundtrip_from_pandas`. The `index=` parameter was added to `to_parquet` in pandas version 0.24.0, leading to test failures on the CI when tested against older (yet still supported) versions of pandas (ref https://travis-ci.org/dask/dask/jobs/554929402#L1107-L1139). 

This issue wasn't caught before because the CI had pyarrow 0.13.0 installed and skipped the test. With the new release of pyarrow 0.14.0, this test is no longer skipped and the test failure showed up. 

Fixes #5073

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
