### PR TITLE
Fix set_index(..., sorted=True) overlap issue

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5965,8 +5965,6 @@ def prefix_reduction(f, ddf, identity, **kwargs):
     ddf : dd.DataFrame
     identity : pd.DataFrame
         an identity element of f, that is f(identity, df) = f(df, identity) = df
-    kwargs : ??
-        keyword arguments of f ??
     """
     dsk = dict()
     name = "prefix_reduction-" + tokenize(f, ddf, identity, **kwargs)

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -569,44 +569,6 @@ def merge(
 ###############################################################
 
 
-def fix_overlap(ddf):
-    """ Ensures that ddf.divisions are all distinct and that the upper bound on
-    each partition is exclusive
-    """
-    if not ddf.known_divisions:
-        raise ValueError("Can only fix overlap when divisions are known")
-
-    def body(df, index):
-        return df.drop(index, inplace=True) if index in df else df
-
-    def overlap(df, index):
-        return df.loc[[index]] if index in df else None
-
-    dsk = dict()
-    name = "fix-overlap-" + tokenize(ddf)
-
-    n = len(ddf.divisions) - 1
-    divisions = []
-    for i in range(n):
-        if i > 0 and ddf.divisions[i - 1] == ddf.divisions[i]:
-            frames = dsk[(name, len(divisions) - 1)][1]
-        else:
-            frames = []
-            if i > 0:
-                frames.append((overlap, (ddf._name, i - 1), ddf.divisions[i]))
-            divisions.append(ddf.divisions[i])
-            dsk[(name, len(divisions) - 1)] = (pd.concat, frames)
-
-        if i == n - 1 or ddf.divisions[i + 1] == ddf.divisions[i]:
-            frames.append((ddf._name, i))
-        else:
-            frames.append((body, (ddf._name, i), ddf.divisions[i + 1]))
-    divisions.append(ddf.divisions[-1])
-
-    graph = HighLevelGraph.from_collections(name, dsk, dependencies=[ddf])
-    return new_dd_object(graph, name, ddf._meta, divisions)
-
-
 def most_recent_tail(left, right):
     if right.empty:
         return left
@@ -744,9 +706,6 @@ def _concat_compat(frames, left, right):
 
 
 def merge_asof_indexed(left, right, **kwargs):
-    left = fix_overlap(left)
-    right = fix_overlap(right)
-
     dsk = dict()
     name = "asof-join-indexed-" + tokenize(left, right, **kwargs)
     meta = pd.merge_asof(left._meta_nonempty, right._meta_nonempty, **kwargs)

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -608,16 +608,12 @@ def fix_overlap(ddf):
 
 
 def most_recent_tail(left, right):
-    if left is None or right is None:
-        raise ValueError("dafuq did u do")
     if right.empty:
         return left
     return right.tail(1)
 
 
 def most_recent_tail_summary(left, right, by=None):
-    if left is None or right is None:
-        raise ValueError("dafuq did u do")
     return pd.concat([left, right]).drop_duplicates(subset=by, keep="last")
 
 
@@ -635,16 +631,12 @@ def compute_tails(ddf, by=None):
 
 
 def most_recent_head(left, right):
-    if left is None or right is None:
-        raise ValueError("dafuq did u do")
     if left.empty:
         return right
     return left.head(1)
 
 
 def most_recent_head_summary(left, right, by=None):
-    if left is None or right is None:
-        raise ValueError("dafuq did u do")
     return pd.concat([left, right]).drop_duplicates(subset=by, keep="first")
 
 
@@ -691,9 +683,6 @@ def pair_partitions(L, R):
 
 def merge_asof_padded(left, right, prev=None, next=None, **kwargs):
     """ merge_asof but potentially adding rows to the beginning/end of right """
-    if left is None or right is None:
-        raise ValueError("dafuq did u do")
-
     frames = []
     if prev is not None:
         frames.append(prev)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -667,9 +667,6 @@ def test_set_index_sorted_true():
     with pytest.raises(ValueError):
         a.set_index(a.z, sorted=True)
 
-    with pytest.warns(UserWarning):
-        a.set_index(a.y, sorted=True)
-
 
 def test_set_index_sorted_single_partition():
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [1, 0, 1, 0]})
@@ -738,17 +735,10 @@ def test_compute_divisions():
     a = dd.from_pandas(df, 2, sort=False)
     assert not a.known_divisions
 
-    divisions = compute_divisions(a)
-    b = copy(a)
-    b.divisions = divisions
+    b = compute_divisions(copy(a))
 
     assert_eq(a, b, check_divisions=False)
     assert b.known_divisions
-
-    c = dd.from_pandas(df.set_index("y"), 2, sort=False)
-    # Partitions overlap warning
-    with pytest.warns(UserWarning):
-        compute_divisions(c)
 
 
 def test_temporary_directory(tmpdir):

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -858,3 +858,11 @@ def test_set_index_errors_with_inplace_kwarg():
 
     with pytest.raises(NotImplementedError):
         ddf.set_index("a", inplace=True)
+
+
+def test_set_index_overlap():
+    A = pd.DataFrame({"key": [1, 2, 3, 4, 4, 5, 6, 7], "value": list("abcd" * 2)})
+    a = dd.from_pandas(A, npartitions=2)
+    a = a.set_index("key", sorted=True)
+    b = a.repartition(divisions=a.divisions)
+    assert_eq(a, b)


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

I just moved the fix_overlap created for multi.py into the actual set_index code, removing the possibility of a warning/error. Resolved #4860