### PR TITLE
[REVIEW] Generalizing has_known_categories

### DIFF
--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -107,10 +107,7 @@ def get_dummies(
     """
     if PANDAS_VERSION >= "0.23.0":
         # dtype added to pandas
-        if len(kwargs) == 0:
-            kwargs = {"dtype": dtype}
-        else:
-            kwargs["dtype"] = dtype
+        kwargs["dtype"] = dtype
     elif dtype != np.uint8:
         # User specified something other than the default.
         raise ValueError(

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -7,7 +7,7 @@ from .core import Series, DataFrame, map_partitions, apply_concat_apply
 from . import methods
 from .utils import is_categorical_dtype, is_scalar, has_known_categories, PANDAS_VERSION
 from ..utils import M
-
+import sys
 
 ###############################################################
 # Dummies
@@ -163,33 +163,21 @@ def get_dummies(
 
     # We explicitly create `meta` on `data._meta` (the empty version) to
     # work around https://github.com/pandas-dev/pandas/issues/21993
-    if isinstance(data._meta, (pd.Series, pd.Index, pd.DataFrame)):
-        meta = pd.get_dummies(
-            data._meta,
-            prefix=prefix,
-            prefix_sep=prefix_sep,
-            dummy_na=dummy_na,
-            columns=columns,
-            sparse=sparse,
-            drop_first=drop_first,
-            **kwargs
-        )
-        method_cache = pd
-    else:
-        meta = M.get_dummies(
-            data._meta,
-            prefix=prefix,
-            prefix_sep=prefix_sep,
-            dummy_na=dummy_na,
-            columns=columns,
-            sparse=sparse,
-            drop_first=drop_first,
-            **kwargs
-        )
-        method_cache = M
+    package_name = data._meta.__class__.__module__.split(".")[0]
+    dummies = sys.modules[package_name].get_dummies
+    meta = dummies(
+        data._meta,
+        prefix=prefix,
+        prefix_sep=prefix_sep,
+        dummy_na=dummy_na,
+        columns=columns,
+        sparse=sparse,
+        drop_first=drop_first,
+        **kwargs
+    )
 
     return map_partitions(
-        method_cache.get_dummies,
+        dummies,
         data,
         prefix=prefix,
         prefix_sep=prefix_sep,

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -203,7 +203,7 @@ def has_known_categories(x):
     x = getattr(x, "_meta", x)
     if is_series_like(x):
         return UNKNOWN_CATEGORIES not in x.cat.categories
-    elif is_index_like(x) and hasattr(x, "cat"):
+    elif is_index_like(x) and hasattr(x, "categories"):
         return UNKNOWN_CATEGORIES not in x.categories
     raise TypeError("Expected Series or CategoricalIndex")
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -201,9 +201,9 @@ def has_known_categories(x):
     x : Series or CategoricalIndex
     """
     x = getattr(x, "_meta", x)
-    if isinstance(x, pd.Series):
+    if is_series_like(x):
         return UNKNOWN_CATEGORIES not in x.cat.categories
-    elif isinstance(x, pd.CategoricalIndex):
+    elif is_index_like(x) and hasattr(x, "cat"):
         return UNKNOWN_CATEGORIES not in x.categories
     raise TypeError("Expected Series or CategoricalIndex")
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

This is related to : comment @beckernick  mentioned here: https://github.com/dask/dask/issues/4885#issuecomment-499121110

We will have to generalize `has_known_categories` for non-pandas objects to stop failing here.