### PR TITLE
TST: Remove invalid pad tests

### DIFF
--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -612,15 +612,6 @@ skip_stat_length = pytest.mark.xfail(_numpy_117, reason="numpy-14061", strict=Tr
         ((10, 11), (4, 5), 0, "reflect", {}),
         ((10, 11), (4, 5), 0, "symmetric", {}),
         ((10, 11), (4, 5), 0, "wrap", {}),
-        pytest.param(
-            (10, 11), (4, 5), 0, "maximum", {"stat_length": 0}, marks=skip_stat_length
-        ),
-        pytest.param(
-            (10, 11), (4, 5), 0, "mean", {"stat_length": 0}, marks=skip_stat_length
-        ),
-        pytest.param(
-            (10, 11), (4, 5), 0, "minimum", {"stat_length": 0}, marks=skip_stat_length
-        ),
     ],
 )
 def test_pad_0_width(shape, chunks, pad_width, mode, kwargs):


### PR DESCRIPTION
From https://github.com/numpy/numpy/issues/14061, the understanding
is that the old behavior was not valid. This raises on NumPy 1.17+.
