### PR TITLE
Add fsspec to HDFS CI build

### DIFF
--- a/continuous_integration/hdfs/install.sh
+++ b/continuous_integration/hdfs/install.sh
@@ -1,6 +1,6 @@
 set -xe
 
-docker exec -it $CONTAINER_ID conda install -y -q dask hdfs3 pyarrow -c twosigma -c conda-forge
+docker exec -it $CONTAINER_ID conda install -y -q dask fsspec hdfs3 pyarrow -c twosigma -c conda-forge
 docker exec -it $CONTAINER_ID pip install -e .
 
 set +xe


### PR DESCRIPTION
Currently, the HDFS build is failing on Travis due to the recent addition of `fsspec` as a dependency (ref https://travis-ci.org/dask/dask/jobs/561785392#L685-L702)