### PR TITLE
Make distributed tests optional again.

### DIFF
--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1018,7 +1018,3 @@ def test_num_workers_config(scheduler):
     workers = {i.worker_id for i in prof.results}
 
     assert len(workers) == num_workers
-
-
-if sys.version_info >= (3, 5):
-    from dask.tests.py3_test_await import *  # noqa F401

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -2,6 +2,7 @@ import pytest
 
 distributed = pytest.importorskip("distributed")
 
+import sys
 from functools import partial
 from operator import add
 from tornado import gen
@@ -194,3 +195,7 @@ def test_scheduler_equals_client(loop):
             assert client.run_on_scheduler(
                 lambda dask_scheduler: dask_scheduler.story(x.key)
             )
+
+
+if sys.version_info >= (3, 5):
+    from dask.tests.py3_test_await import *  # noqa F401


### PR DESCRIPTION
These `await` tests were added in a way that was not skipped if `distributed` was not available.

- [x] Tests added / passed
- [?] Passes `black dask` / `flake8 dask`
