### PR TITLE
fix HDFS in dask

### DIFF
--- a/continuous_integration/hdfs/Dockerfile
+++ b/continuous_integration/hdfs/Dockerfile
@@ -17,18 +17,12 @@ RUN curl -s https://archive.cloudera.com/cdh5/ubuntu/xenial/amd64/cdh/archive.ke
     bash /usr/lib/hadoop/libexec/init-hdfs.sh && \
     rm -rf /var/lib/apt/lists/*
 
-# Needed for hdfs3
-ENV LIBHDFS3_CONF /etc/hadoop/conf/hdfs-site.xml
-
 # Install conda & build conda environments:
-# py35 is root environment
-# py27 gets own environment
+# py37 is root environment
 RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh && \
     /bin/bash /tmp/miniconda.sh -b -p /opt/conda && \
     rm /tmp/miniconda.sh && \
-    /opt/conda/bin/conda install -y -q libhdfs3 pytest flake8 black -c conda-forge && \
-    /opt/conda/bin/conda create -y -n py27 python=2.7 && \
-    /opt/conda/bin/conda install -y -q -n py27 libhdfs3 pytest -c conda-forge
+    /opt/conda/bin/conda install -y -q pytest flake8 black -c conda-forge
 
 ENV PATH /opt/conda/bin:$PATH
 

--- a/continuous_integration/hdfs/install.sh
+++ b/continuous_integration/hdfs/install.sh
@@ -1,6 +1,6 @@
 set -xe
 
-docker exec -it $CONTAINER_ID conda install -y -q dask hdfs3 pyarrow -c twosigma -c conda-forge
+docker exec -it $CONTAINER_ID conda install -y -q dask pyarrow fsspec -c conda-forge
 docker exec -it $CONTAINER_ID pip install -e .
 
 set +xe

--- a/dask/bytes/tests/test_compression.py
+++ b/dask/bytes/tests/test_compression.py
@@ -10,6 +10,8 @@ from ..utils import compress
 def test_files(fmt, File):
     if fmt == "zip" and sys.version_info.minor == 5:
         pytest.skip("zipfile is read-only on py35")
+    if fmt not in compr:
+        pytest.skip('compression function not provided')
     if fmt is None:
         return
     data = b"1234" * 1000

--- a/dask/bytes/tests/test_compression.py
+++ b/dask/bytes/tests/test_compression.py
@@ -11,7 +11,7 @@ def test_files(fmt, File):
     if fmt == "zip" and sys.version_info.minor == 5:
         pytest.skip("zipfile is read-only on py35")
     if fmt not in compress:
-        pytest.skip('compression function not provided')
+        pytest.skip("compression function not provided")
     if fmt is None:
         return
     data = b"1234" * 1000

--- a/dask/bytes/tests/test_compression.py
+++ b/dask/bytes/tests/test_compression.py
@@ -10,7 +10,7 @@ from ..utils import compress
 def test_files(fmt, File):
     if fmt == "zip" and sys.version_info.minor == 5:
         pytest.skip("zipfile is read-only on py35")
-    if fmt not in compr:
+    if fmt not in compress:
         pytest.skip('compression function not provided')
     if fmt is None:
         return

--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -222,7 +222,7 @@ def test_glob(hdfs):
         basedir + "/c/d": ([], ["x3"]),
     }
 
-    hdfs, _, _ = get_fs_token_paths('hdfs:///')
+    hdfs, _, _ = get_fs_token_paths("hdfs:///")
     hdfs.makedirs(basedir + "/c/d")
     hdfs.makedirs(basedir + "/c2/d/")
     for fn in (
@@ -237,9 +237,7 @@ def test_glob(hdfs):
         basedir + p for p in ["/a", "/a1", "/a2", "/a3"]
     }
 
-    assert set(hdfs.glob(basedir + "/c/*")) == {
-        basedir + p for p in ["/c/x1", "/c/x2"]
-    }
+    assert set(hdfs.glob(basedir + "/c/*")) == {basedir + p for p in ["/c/x1", "/c/x2"]}
 
     assert set(hdfs.glob(basedir + "/*/x*")) == {
         basedir + p for p in ["/c/x1", "/c/x2", "/c2/x1", "/c2/x2"]

--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -2,14 +2,13 @@ from __future__ import print_function, division, absolute_import
 
 import os
 import posixpath
-from distutils.version import LooseVersion
 
 import pytest
 from toolz import concat
 
 import dask
 from dask.bytes.core import read_bytes, open_files, get_fs_token_paths
-from dask.compatibility import unicode, PY2
+from dask.compatibility import unicode
 
 
 try:
@@ -18,8 +17,6 @@ try:
     from distributed.utils_test import cluster, loop  # noqa: F401
 except (ImportError, SyntaxError):
     distributed = None
-
-hdfs3 = None
 
 try:
     import pyarrow

--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -8,7 +8,7 @@ import pytest
 from toolz import concat
 
 import dask
-from dask.bytes.core import read_bytes, open_files
+from dask.bytes.core import read_bytes, open_files, get_fs_token_paths
 from dask.compatibility import unicode, PY2
 
 
@@ -19,18 +19,11 @@ try:
 except (ImportError, SyntaxError):
     distributed = None
 
-try:
-    import hdfs3
-except ImportError:
-    hdfs3 = None
+hdfs3 = None
 
 try:
     import pyarrow
-    from dask.bytes.pyarrow import _MIN_PYARROW_VERSION_SUPPORTED
-
-    PYARROW_DRIVER = LooseVersion(pyarrow.__version__) >= _MIN_PYARROW_VERSION_SUPPORTED
 except ImportError:
-    PYARROW_DRIVER = False
     pyarrow = None
 
 
@@ -41,32 +34,15 @@ if not os.environ.get("DASK_RUN_HDFS_TESTS", ""):
 basedir = "/tmp/test-dask"
 
 
-# This fixture checks for a minimum pyarrow version
-@pytest.fixture(
-    params=[
-        pytest.param(
-            "hdfs3", marks=pytest.mark.skipif(not hdfs3, reason="hdfs3 not found")
-        ),
-        pytest.param(
-            "pyarrow",
-            marks=pytest.mark.skipif(
-                not PYARROW_DRIVER, reason="required pyarrow version not found"
-            ),
-        ),
-    ]
-)
+@pytest.fixture
 def hdfs(request):
-    if request.param == "hdfs3":
-        hdfs = hdfs3.HDFileSystem(host="localhost", port=8020)
-    else:
-        hdfs = pyarrow.hdfs.connect(host="localhost", port=8020)
+    hdfs = pyarrow.hdfs.connect(host="localhost", port=8020)
 
     if hdfs.exists(basedir):
         hdfs.rm(basedir, recursive=True)
     hdfs.mkdir(basedir)
 
-    with dask.config.set(hdfs_driver=request.param):
-        yield hdfs
+    yield hdfs
 
     if hdfs.exists(basedir):
         hdfs.rm(basedir, recursive=True)
@@ -74,7 +50,6 @@ def hdfs(request):
 
 # This mark doesn't check the minimum pyarrow version.
 require_pyarrow = pytest.mark.skipif(not pyarrow, reason="pyarrow not installed")
-require_hdfs3 = pytest.mark.skipif(not hdfs3, reason="hdfs3 not installed")
 
 
 def test_read_bytes(hdfs):
@@ -174,13 +149,6 @@ def test_read_csv(hdfs):
     assert df.id.sum().compute() == 1 + 2 + 3 + 4
 
 
-@pytest.mark.skipif(
-    PY2,
-    reason=(
-        "pyarrow's hdfs isn't fork-safe, requires "
-        "multiprocessing `spawn` start method"
-    ),
-)
 def test_read_text(hdfs):
     db = pytest.importorskip("dask.bag")
     import multiprocessing as mp
@@ -226,19 +194,7 @@ def test_read_text_unicode(hdfs):
 
 
 @require_pyarrow
-@require_hdfs3
-def test_pyarrow_compat():
-    from dask.bytes.hdfs3 import HDFS3HadoopFileSystem
-
-    dhdfs = HDFS3HadoopFileSystem()
-    pa_hdfs = dhdfs._get_pyarrow_filesystem()
-    assert isinstance(pa_hdfs, pyarrow.filesystem.FileSystem)
-
-
-@require_pyarrow
 def test_parquet_pyarrow(hdfs):
-    if LooseVersion(pyarrow.__version__) == "0.13.0":
-        pytest.skip("pyarrow 0.13.0 not supported for parquet")
     dd = pytest.importorskip("dask.dataframe")
     import pandas as pd
     import numpy as np
@@ -258,14 +214,6 @@ def test_parquet_pyarrow(hdfs):
 
 
 def test_glob(hdfs):
-    if type(hdfs).__module__.startswith("hdfs3"):
-        from dask.bytes.hdfs3 import HDFS3HadoopFileSystem
-
-        hdfs = HDFS3HadoopFileSystem.from_hdfs3(hdfs)
-    else:
-        from dask.bytes.pyarrow import PyArrowHadoopFileSystem
-
-        hdfs = PyArrowHadoopFileSystem.from_pyarrow(hdfs)
 
     tree = {
         basedir: (["c", "c2"], ["a", "a1", "a2", "a3", "b1"]),
@@ -274,8 +222,9 @@ def test_glob(hdfs):
         basedir + "/c/d": ([], ["x3"]),
     }
 
-    hdfs.mkdirs(basedir + "/c/d/")
-    hdfs.mkdirs(basedir + "/c2/d/")
+    hdfs, _, _ = get_fs_token_paths('hdfs:///')
+    hdfs.makedirs(basedir + "/c/d")
+    hdfs.makedirs(basedir + "/c2/d/")
     for fn in (
         posixpath.join(dirname, f)
         for (dirname, (_, fils)) in tree.items()
@@ -289,7 +238,7 @@ def test_glob(hdfs):
     }
 
     assert set(hdfs.glob(basedir + "/c/*")) == {
-        basedir + p for p in ["/c/x1", "/c/x2", "/c/d"]
+        basedir + p for p in ["/c/x1", "/c/x2"]
     }
 
     assert set(hdfs.glob(basedir + "/*/x*")) == {
@@ -299,18 +248,14 @@ def test_glob(hdfs):
         basedir + p for p in ["/c/x1", "/c2/x1"]
     }
 
-    assert hdfs.glob(basedir + "/c") == [basedir + "/c"]
-    assert hdfs.glob(basedir + "/c/") == [basedir + "/c/"]
-    assert hdfs.glob(basedir + "/a") == [basedir + "/a"]
-
-    assert hdfs.glob("/this-path-doesnt-exist") == []
-    assert hdfs.glob(basedir + "/missing/") == []
-    assert hdfs.glob(basedir + "/missing/x1") == []
+    assert hdfs.find("/this-path-doesnt-exist") == []
+    assert hdfs.find(basedir + "/missing/") == []
+    assert hdfs.find(basedir + "/missing/x1") == []
     assert hdfs.glob(basedir + "/missing/*") == []
     assert hdfs.glob(basedir + "/*/missing") == []
 
     assert set(hdfs.glob(basedir + "/*")) == {
-        basedir + p for p in ["/a", "/a1", "/a2", "/a3", "/b1", "/c", "/c2"]
+        basedir + p for p in ["/a", "/a1", "/a2", "/a3", "/b1"]
     }
 
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -272,7 +272,7 @@ def test_compression(fmt, blocksize):
     if fmt == "zip" and sys.version_info.minor == 5:
         pytest.skip("zipfile is read-only on py35")
     if fmt not in compress:
-        pytest.skip('compression function not provided')
+        pytest.skip("compression function not provided")
     files2 = valmap(compress[fmt], files)
     with filetexts(files2, mode="b"):
         if fmt and blocksize:
@@ -325,7 +325,7 @@ def test_open_files_compression(mode, fmt):
     if fmt == "zip" and sys.version_info.minor == 5:
         pytest.skip("zipfile is read-only on py35")
     if fmt not in compress:
-        pytest.skip('compression function not provided')
+        pytest.skip("compression function not provided")
     files2 = valmap(compress[fmt], files)
     with filetexts(files2, mode="b"):
         myfiles = open_files(".test.accounts.*", mode=mode, compression=fmt)

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -271,6 +271,8 @@ fmt_bs = [(fmt, None) for fmt in compr] + [(fmt, 10) for fmt in compr]
 def test_compression(fmt, blocksize):
     if fmt == "zip" and sys.version_info.minor == 5:
         pytest.skip("zipfile is read-only on py35")
+    if fmt not in compress:
+        pytest.skip('compression function not provided')
     files2 = valmap(compress[fmt], files)
     with filetexts(files2, mode="b"):
         if fmt and blocksize:
@@ -322,7 +324,7 @@ def test_open_files_text_mode(encoding):
 def test_open_files_compression(mode, fmt):
     if fmt == "zip" and sys.version_info.minor == 5:
         pytest.skip("zipfile is read-only on py35")
-    if fmt not in compr:
+    if fmt not in compress:
         pytest.skip('compression function not provided')
     files2 = valmap(compress[fmt], files)
     with filetexts(files2, mode="b"):

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -322,6 +322,8 @@ def test_open_files_text_mode(encoding):
 def test_open_files_compression(mode, fmt):
     if fmt == "zip" and sys.version_info.minor == 5:
         pytest.skip("zipfile is read-only on py35")
+    if fmt not in compr:
+        pytest.skip('compression function not provided')
     files2 = valmap(compress[fmt], files)
     with filetexts(files2, mode="b"):
         myfiles = open_files(".test.accounts.*", mode=mode, compression=fmt)

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -339,7 +339,7 @@ def test_compression(s3, fmt, blocksize):
     if fmt == "zip" and sys.version_info.minor == 5:
         pytest.skip("zipfile is read-only on py35")
     if fmt not in compress:
-        pytest.skip('compression function not provided')
+        pytest.skip("compression function not provided")
     s3._cache.clear()
     with s3_context("compress", valmap(compress[fmt], files)):
         if fmt and blocksize:

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -338,6 +338,8 @@ def test_read_bytes_delimited(s3, blocksize):
 def test_compression(s3, fmt, blocksize):
     if fmt == "zip" and sys.version_info.minor == 5:
         pytest.skip("zipfile is read-only on py35")
+    if fmt not in compr:
+        pytest.skip('compression function not provided')
     s3._cache.clear()
     with s3_context("compress", valmap(compress[fmt], files)):
         if fmt and blocksize:

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -338,7 +338,7 @@ def test_read_bytes_delimited(s3, blocksize):
 def test_compression(s3, fmt, blocksize):
     if fmt == "zip" and sys.version_info.minor == 5:
         pytest.skip("zipfile is read-only on py35")
-    if fmt not in compr:
+    if fmt not in compress:
         pytest.skip('compression function not provided')
     s3._cache.clear()
     with s3_context("compress", valmap(compress[fmt], files)):


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Needs docs update to remove references to hdfs3, which is no longer supported. May provide that in separate PR together with general remote bytes docs update, nearer to release time.