### PR TITLE
COMPAT: Adjust is_dataframe_like

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -376,9 +376,14 @@ def test_check_meta_typename():
     assert "pandas" in str(info.value)
 
 
-def test_is_dataframe_like():
+def test_is_dataframe_like(monkeypatch):
     df = pd.DataFrame({"x": [1, 2, 3]})
     ddf = dd.from_pandas(df, npartitions=1)
+
+    if not hasattr(pd.DataFrame, "value_counts"):
+        # TODO: Set the pandas version this shows up in (likely 1.0)
+        monkeypatch.setattr(pd.DataFrame, "value_counts", lambda x: None, raising=False)
+
     assert is_dataframe_like(df)
     assert is_dataframe_like(ddf)
     assert not is_dataframe_like(df.x)

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -376,13 +376,15 @@ def test_check_meta_typename():
     assert "pandas" in str(info.value)
 
 
-def test_is_dataframe_like(monkeypatch):
+@pytest.mark.parametrize("frame_value_counts", [True, False])
+def test_is_dataframe_like(monkeypatch, frame_value_counts):
+    # When we drop support for pandas 1.0, this compat check can
+    # be dropped
+    if frame_value_counts:
+        monkeypatch.setattr(pd.DataFrame, "value_counts", lambda x: None, raising=False)
+
     df = pd.DataFrame({"x": [1, 2, 3]})
     ddf = dd.from_pandas(df, npartitions=1)
-
-    if not hasattr(pd.DataFrame, "value_counts"):
-        # TODO: Set the pandas version this shows up in (likely 1.0)
-        monkeypatch.setattr(pd.DataFrame, "value_counts", lambda x: None, raising=False)
 
     assert is_dataframe_like(df)
     assert is_dataframe_like(ddf)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1075,8 +1075,8 @@ def is_dataframe_like(df):
     typ = type(df)
     return (
         all(hasattr(typ, name) for name in ("groupby", "head", "merge", "mean"))
-        and all(hasattr(df, name) for name in ("dtypes",))
-        and not any(hasattr(typ, name) for name in ("value_counts", "dtype"))
+        and all(hasattr(df, name) for name in ("dtypes", "columns"))
+        and not any(hasattr(typ, name) for name in ("name", "dtype"))
     )
 
 


### PR DESCRIPTION
Pandas is adding a DataFrame.value_counts. Adjust accordingly.

Closes https://github.com/dask/dask/issues/5109