### PR TITLE
Raise informative error in to_zarr if unknown chunks

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2780,8 +2780,10 @@ def to_zarr(
     import zarr
 
     if np.isnan(arr.shape).any():
-        raise ValueError("Saving a dask array with unknown chunk sizes is not "
-                         "currently supported by Zarr")
+        raise ValueError(
+            "Saving a dask array with unknown chunk sizes is not "
+            "currently supported by Zarr"
+        )
 
     if isinstance(url, zarr.Array):
         z = url

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2770,8 +2770,18 @@ def to_zarr(
         where overwrite=True will replace the existing data.
     compute, return_stored: see ``store()``
     kwargs: passed to the ``zarr.create()`` function, e.g., compression options
+
+    Raises
+    ------
+    ValueError
+        If ``arr`` has unknown chunk sizes, which is not supported by Zarr.
+
     """
     import zarr
+
+    if np.isnan(arr.shape).any():
+        raise ValueError("Saving a dask array with unknown chunk sizes is not "
+                         "currently supported by Zarr")
 
     if isinstance(url, zarr.Array):
         z = url

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3707,7 +3707,7 @@ def test_to_zarr_unknown_chunks_raises():
     pytest.importorskip("zarr")
     a = da.random.random((10,), chunks=(3,))
     a = a[a > 0.5]
-    with pytest.raises(ValueError, match='unknown chunk sizes'):
+    with pytest.raises(ValueError, match="unknown chunk sizes"):
         a.to_zarr({})
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3703,6 +3703,14 @@ def test_zarr_existing_array():
     assert a2.chunks == a.chunks
 
 
+def test_to_zarr_unknown_chunks_raises():
+    pytest.importorskip("zarr")
+    a = da.random.random((10,), chunks=(3,))
+    a = a[a > 0.5]
+    with pytest.raises(ValueError, match='unknown chunk sizes'):
+        a.to_zarr({})
+
+
 def test_read_zarr_chunks():
     pytest.importorskip("zarr")
     a = da.zeros((9,), chunks=(3,))


### PR DESCRIPTION
Closes #5144. cc @jakirkham 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
