### PR TITLE
[REVIEW] Backend generalize rolling windows

### DIFF
--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -11,7 +11,7 @@ from ..utils import M, funcname, derived_from
 from ..highlevelgraph import HighLevelGraph
 from .core import _emulate
 from .utils import make_meta, PANDAS_VERSION
-
+from . import methods
 
 def overlap_chunk(
     func, prev_part, current_part, next_part, before, after, args, kwargs
@@ -32,7 +32,7 @@ def overlap_chunk(
             raise NotImplementedError(msg)
 
     parts = [p for p in (prev_part, current_part, next_part) if p is not None]
-    combined = pd.concat(parts)
+    combined = methods.concat(parts)
     out = func(combined, *args, **kwargs)
     if prev_part is None:
         before = None

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -13,6 +13,7 @@ from .core import _emulate
 from .utils import make_meta, PANDAS_VERSION
 from . import methods
 
+
 def overlap_chunk(
     func, prev_part, current_part, next_part, before, after, args, kwargs
 ):

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -242,7 +242,7 @@ def _tail_timedelta(prevs, current, before):
     -------
     overlapped : DataFrame
     """
-    selected = pd.concat(
+    selected = methods.concat(
         [prev[prev.index > (current.index.min() - before)] for prev in prevs]
     )
     return selected


### PR DESCRIPTION
**Summary of Changes**
- Uses the dispatchable concat instead of pandas concat in `overlap_chunk` and `_tail_timedelta`, as these can both be large

**Notes**
- I don't believe the pandas-specific code related to the timestamp divisions (`divs`) is a concern, as the operations are simple and the size is not likely to be significant enough to cause concern (number of rows in divs is `npartitions+1`)

- [x] Tests passed (locally)
- [x] Passes `black dask` / `flake8 dask`

This closes #5135 