### PR TITLE
Fix ordering when indexing a dask array with a bool dask array

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1036,9 +1036,10 @@ def slice_with_bool_dask_array(x, index):
             index = tuple(i.ravel() for i in index)
         elif x.ndim > 1:
             warnings.warn(
-                "When slicing a dask array of unknown chunks with a boolean mask "
-                "dask array, the output array may have a different ordering "
-                "compared to the equivalent NumPy operation.",
+                "When slicing a Dask array of unknown chunks with a boolean mask "
+                "Dask array, the output array may have a different ordering "
+                "compared to the equivalent NumPy operation. This will raise an "
+                "error in a future release of Dask.",
                 stacklevel=3,
             )
         y = elemwise(getitem, x, *index, dtype=x.dtype)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1031,6 +1031,16 @@ def slice_with_bool_dask_array(x, index):
     ]
 
     if len(index) == 1 and index[0].ndim == x.ndim:
+        if not np.isnan(x.shape).any() and not np.isnan(index[0].shape).any():
+            x = x.ravel()
+            index = tuple(i.ravel() for i in index)
+        elif x.ndim > 1:
+            warnings.warn(
+                "When slicing a dask array of unknown chunks with a boolean mask "
+                "dask array, the output array may have a different ordering "
+                "compared to the equivalent NumPy operation.",
+                stacklevel=3,
+            )
         y = elemwise(getitem, x, *index, dtype=x.dtype)
         name = "getitem-" + tokenize(x, index)
         dsk = {(name, i): k for i, k in enumerate(core.flatten(y.__dask_keys__()))}

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3357,10 +3357,20 @@ def test_index_array_with_array_1d():
 def test_index_array_with_array_2d():
     x = np.arange(24).reshape((4, 6))
     dx = da.from_array(x, chunks=(2, 2))
+
+    assert_eq(x[x > 6], dx[dx > 6])
+    assert_eq(x[x % 2 == 0], dx[dx % 2 == 0])
+
+    # Test with unknown chunks
     dx._chunks = ((2, 2), (np.nan, np.nan, np.nan))
 
-    assert sorted(x[x % 2 == 0].tolist()) == sorted(dx[dx % 2 == 0].compute().tolist())
-    assert sorted(x[x > 6].tolist()) == sorted(dx[dx > 6].compute().tolist())
+    with pytest.warns(UserWarning, match="different ordering") as record:
+        assert sorted(x[x % 2 == 0].tolist()) == sorted(
+            dx[dx % 2 == 0].compute().tolist()
+        )
+        assert sorted(x[x > 6].tolist()) == sorted(dx[dx > 6].compute().tolist())
+
+    assert len(record) == 2
 
 
 @pytest.mark.xfail(reason="Chunking does not align well")


### PR DESCRIPTION
This PR partially addresses #3184 and builds on #3193 . To get the correct ordering when indexing, we `ravel` both the array being indexed and the boolean mask when their chunk sizes are known (`ravel` currently isn't supported for arrays with `nan` chunks). In the case that there are unknown chunks, we raise an informative warning and the current behavior is maintained. 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
