### PR TITLE
Add rolling cov

### DIFF
--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -39,14 +39,16 @@ def overlap_chunk(
     if isinstance(before, datetime.timedelta):
         before = len(prev_part)
 
-    expansion = out.shape[0] // combined.shape[0]
-    if before:
+    expansion = None
+    if combined.shape[0] != 0:
+        expansion = out.shape[0] // combined.shape[0]
+    if before and expansion:
         before *= expansion
     if next_part is None:
         return out.iloc[before:]
     if isinstance(after, datetime.timedelta):
         after = len(next_part)
-    if after:
+    if after and expansion:
         after *= expansion
     return out.iloc[before:-after]
 

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -39,6 +39,9 @@ def overlap_chunk(
     if isinstance(before, datetime.timedelta):
         before = len(prev_part)
 
+    if before:
+        expansion = out.shape[0] // combined.shape[0]
+        before *= expansion
     if next_part is None:
         return out.iloc[before:]
     if isinstance(after, datetime.timedelta):
@@ -352,6 +355,10 @@ class Rolling(object):
         return self._call_method("count")
 
     @derived_from(pd_Rolling)
+    def cov(self):
+        return self._call_method("cov")
+
+    @derived_from(pd_Rolling)
     def sum(self):
         return self._call_method("sum")
 
@@ -402,7 +409,7 @@ class Rolling(object):
             if kwargs:
                 msg = (
                     "Invalid argument to 'apply'. Keyword arguments "
-                    "should be given as a dict to the 'kwargs' arugment. "
+                    "should be given as a dict to the 'kwargs' argument. "
                 )
                 raise TypeError(msg)
         return self._call_method("apply", func, args=args, kwargs=kwargs, **kwds)

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -39,13 +39,15 @@ def overlap_chunk(
     if isinstance(before, datetime.timedelta):
         before = len(prev_part)
 
+    expansion = out.shape[0] // combined.shape[0]
     if before:
-        expansion = out.shape[0] // combined.shape[0]
         before *= expansion
     if next_part is None:
         return out.iloc[before:]
     if isinstance(after, datetime.timedelta):
         after = len(next_part)
+    if after:
+        after *= expansion
     return out.iloc[before:-after]
 
 

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -117,33 +117,33 @@ def mad(x):
 
 
 rolling_method_args_check_less_precise = [
-    ("count", (), False),
-    ("cov", (), False),
-    ("sum", (), False),
-    ("mean", (), False),
-    ("median", (), False),
-    ("min", (), False),
-    ("max", (), False),
-    ("std", (), True),
-    ("var", (), True),
-    ("skew", (), True),  # here and elsewhere, results for kurt and skew are
-    ("kurt", (), True),  # checked with check_less_precise=True so that we are
+    ("count", (), False, False),
+    ("cov", (), False, True),
+    ("sum", (), False, False),
+    ("mean", (), False, False),
+    ("median", (), False, False),
+    ("min", (), False, False),
+    ("max", (), False, False),
+    ("std", (), True, False),
+    ("var", (), True, False),
+    ("skew", (), True, False),  # here and elsewhere, results for kurt and skew are
+    ("kurt", (), True, False),  # checked with check_less_precise=True so that we are
     # only looking at 3ish decimal places for the equality check
     # rather than 5ish. I have encountered a case where a test
     # seems to have failed due to numerical problems with kurt.
     # So far, I am only weakening the check for kurt and skew,
     # as they involve third degree powers and higher
-    ("quantile", (0.38,), False),
-    ("apply", (mad,), False),
+    ("quantile", (0.38,), False, False),
+    ("apply", (mad,), False, False),
 ]
 
 
 @pytest.mark.parametrize(
-    "method,args,check_less_precise", rolling_method_args_check_less_precise
+    "method,args,check_less_precise,inf_as_nan", rolling_method_args_check_less_precise
 )
 @pytest.mark.parametrize("window", [1, 2, 4, 5])
 @pytest.mark.parametrize("center", [True, False])
-def test_rolling_methods(method, args, window, center, check_less_precise):
+def test_rolling_methods(method, args, window, center, check_less_precise, inf_as_nan):
     # DataFrame
     prolling = df.rolling(window, center=center)
     drolling = ddf.rolling(window, center=center)
@@ -155,6 +155,7 @@ def test_rolling_methods(method, args, window, center, check_less_precise):
         getattr(prolling, method)(*args, **kwargs),
         getattr(drolling, method)(*args, **kwargs),
         check_less_precise=check_less_precise,
+        inf_as_nan=inf_as_nan,
     )
 
     # Series
@@ -164,6 +165,7 @@ def test_rolling_methods(method, args, window, center, check_less_precise):
         getattr(prolling, method)(*args, **kwargs),
         getattr(drolling, method)(*args, **kwargs),
         check_less_precise=check_less_precise,
+        inf_as_nan=inf_as_nan,
     )
 
 
@@ -247,10 +249,10 @@ def test_time_rolling_constructor():
 
 
 @pytest.mark.parametrize(
-    "method,args,check_less_precise", rolling_method_args_check_less_precise
+    "method,args,check_less_precise,inf_as_nan", rolling_method_args_check_less_precise
 )
 @pytest.mark.parametrize("window", ["1S", "2S", "3S", pd.offsets.Second(5)])
-def test_time_rolling_methods(method, args, window, check_less_precise):
+def test_time_rolling_methods(method, args, window, check_less_precise, inf_as_nan):
     # DataFrame
     if method == "apply" and PANDAS_VERSION >= "0.23.0":
         kwargs = {"raw": False}
@@ -262,6 +264,7 @@ def test_time_rolling_methods(method, args, window, check_less_precise):
         getattr(prolling, method)(*args, **kwargs),
         getattr(drolling, method)(*args, **kwargs),
         check_less_precise=check_less_precise,
+        inf_as_nan=inf_as_nan,
     )
 
     # Series
@@ -271,6 +274,7 @@ def test_time_rolling_methods(method, args, window, check_less_precise):
         getattr(prolling, method)(*args, **kwargs),
         getattr(drolling, method)(*args, **kwargs),
         check_less_precise=check_less_precise,
+        inf_as_nan=inf_as_nan,
     )
 
 

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -296,6 +296,7 @@ def test_time_rolling_methods(method, args, window, check_less_precise):
     )
 
 
+@filter_panel_warning
 @pytest.mark.parametrize("window", ["1S", "2S", "3S", pd.offsets.Second(5)])
 def test_time_rolling_cov(window):
     # DataFrame

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -118,6 +118,7 @@ def mad(x):
 
 rolling_method_args_check_less_precise = [
     ("count", (), False),
+    ("cov", (), False),
     ("sum", (), False),
     ("mean", (), False),
     ("median", (), False),

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -166,6 +166,15 @@ def test_rolling_methods(method, args, window, center, check_less_precise):
     )
 
 
+if PANDAS_VERSION <= "0.25.0" and PANDAS_VERSION >= "0.20.0":
+    filter_panel_warning = pytest.mark.filterwarnings(
+        "ignore::DeprecationWarning:pandas[.*]"
+    )
+else:
+    filter_panel_warning = lambda f: f
+
+
+@filter_panel_warning
 @pytest.mark.parametrize("window", [1, 2, 4, 5])
 @pytest.mark.parametrize("center", [True, False])
 def test_rolling_cov(window, center):

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -287,17 +287,16 @@ def test_time_rolling_methods(method, args, window, check_less_precise):
     )
 
 
-@pytest.mark.parametrize("window", [1, 2, 4, 5])
-@pytest.mark.parametrize("center", [True, False])
-def test_time_rolling_cov(window, center):
+@pytest.mark.parametrize("window", ["1S", "2S", "3S", pd.offsets.Second(5)])
+def test_time_rolling_cov(window):
     # DataFrame
     prolling = ts.drop("a", 1).rolling(window)
     drolling = dts.drop("a", 1).rolling(window)
     assert_eq(getattr(prolling, "cov")(), getattr(drolling, "cov")())
 
     # Series
-    prolling = ts.b.rolling(window, center=center)
-    drolling = dts.b.rolling(window, center=center)
+    prolling = ts.b.rolling(window)
+    drolling = dts.b.rolling(window)
     assert_eq(getattr(prolling, "cov")(), getattr(drolling, "cov")())
 
 

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -172,12 +172,12 @@ def test_rolling_cov(window, center):
     # DataFrame
     prolling = df.drop("a", 1).rolling(window, center=center)
     drolling = ddf.drop("a", 1).rolling(window, center=center)
-    assert_eq(getattr(prolling, "cov")(), getattr(drolling, "cov")())
+    assert_eq(prolling.cov(), drolling.cov())
 
     # Series
     prolling = df.b.rolling(window, center=center)
     drolling = ddf.b.rolling(window, center=center)
-    assert_eq(getattr(prolling, "cov")(), getattr(drolling, "cov")())
+    assert_eq(prolling.cov(), drolling.cov())
 
 
 @pytest.mark.skipif(PANDAS_VERSION >= "0.23.0", reason="Raw is allowed.")
@@ -292,12 +292,12 @@ def test_time_rolling_cov(window):
     # DataFrame
     prolling = ts.drop("a", 1).rolling(window)
     drolling = dts.drop("a", 1).rolling(window)
-    assert_eq(getattr(prolling, "cov")(), getattr(drolling, "cov")())
+    assert_eq(prolling.cov(), drolling.cov())
 
     # Series
     prolling = ts.b.rolling(window)
     drolling = dts.b.rolling(window)
-    assert_eq(getattr(prolling, "cov")(), getattr(drolling, "cov")())
+    assert_eq(prolling.cov(), drolling.cov())
 
 
 @pytest.mark.parametrize(

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -165,24 +165,20 @@ def test_rolling_methods(method, args, window, center, check_less_precise):
         check_less_precise=check_less_precise,
     )
 
+
 @pytest.mark.parametrize("window", [1, 2, 4, 5])
 @pytest.mark.parametrize("center", [True, False])
 def test_rolling_cov(window, center):
     # DataFrame
-    prolling = df.drop('a', 1).rolling(window, center=center)
-    drolling = ddf.drop('a', 1).rolling(window, center=center)
-    assert_eq(
-        getattr(prolling, 'cov')(),
-        getattr(drolling, 'cov')(),
-    )
+    prolling = df.drop("a", 1).rolling(window, center=center)
+    drolling = ddf.drop("a", 1).rolling(window, center=center)
+    assert_eq(getattr(prolling, "cov")(), getattr(drolling, "cov")())
 
     # Series
     prolling = df.b.rolling(window, center=center)
     drolling = ddf.b.rolling(window, center=center)
-    assert_eq(
-        getattr(prolling, 'cov')(),
-        getattr(drolling, 'cov')(),
-    )
+    assert_eq(getattr(prolling, "cov")(), getattr(drolling, "cov")())
+
 
 @pytest.mark.skipif(PANDAS_VERSION >= "0.23.0", reason="Raw is allowed.")
 def test_rolling_raw_pandas_lt_0230_raises():
@@ -289,6 +285,20 @@ def test_time_rolling_methods(method, args, window, check_less_precise):
         getattr(drolling, method)(*args, **kwargs),
         check_less_precise=check_less_precise,
     )
+
+
+@pytest.mark.parametrize("window", [1, 2, 4, 5])
+@pytest.mark.parametrize("center", [True, False])
+def test_time_rolling_cov(window, center):
+    # DataFrame
+    prolling = ts.drop("a", 1).rolling(window)
+    drolling = dts.drop("a", 1).rolling(window)
+    assert_eq(getattr(prolling, "cov")(), getattr(drolling, "cov")())
+
+    # Series
+    prolling = ts.b.rolling(window, center=center)
+    drolling = dts.b.rolling(window, center=center)
+    assert_eq(getattr(prolling, "cov")(), getattr(drolling, "cov")())
 
 
 @pytest.mark.parametrize(

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -743,6 +743,7 @@ def assert_eq(
     check_dtypes=True,
     check_divisions=True,
     check_index=True,
+    inf_as_nan=False,
     **kwargs
 ):
     if check_divisions:
@@ -756,6 +757,9 @@ def assert_eq(
     assert_sane_keynames(b)
     a = _check_dask(a, check_names=check_names, check_dtypes=check_dtypes)
     b = _check_dask(b, check_names=check_names, check_dtypes=check_dtypes)
+    if inf_as_nan:
+        a = a.replace([np.inf, -np.inf], np.nan)
+        b = b.replace([np.inf, -np.inf], np.nan)
     if not check_index:
         a = a.reset_index(drop=True)
         b = b.reset_index(drop=True)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -743,7 +743,6 @@ def assert_eq(
     check_dtypes=True,
     check_divisions=True,
     check_index=True,
-    inf_as_nan=False,
     **kwargs
 ):
     if check_divisions:
@@ -757,9 +756,6 @@ def assert_eq(
     assert_sane_keynames(b)
     a = _check_dask(a, check_names=check_names, check_dtypes=check_dtypes)
     b = _check_dask(b, check_names=check_names, check_dtypes=check_dtypes)
-    if inf_as_nan:
-        a = a.replace([np.inf, -np.inf], np.nan)
-        b = b.replace([np.inf, -np.inf], np.nan)
     if not check_index:
         a = a.reset_index(drop=True)
         b = b.reset_index(drop=True)


### PR DESCRIPTION
The issue is that since cov output is 2D (https://github.com/dask/dask/issues/4053#issuecomment-466738711) chunk overlap is calculated incorrectly. In cov tests the output was only differing in infs and nans. I've marked this as WIP because I'm not completely sure if this is a good approach.

- [x] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`

closes issue #4053