### PR TITLE
Allowing fastparquet to handle gather_statistics=False for file lists

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -107,7 +107,7 @@ class ArrowEngine(Engine):
         filters=None,
         **kwargs,
     ):
-        # Define the parquet-file (pf) object to use for metadata,
+        # Define the dataset object to use for metadata,
         # Also, initialize `parts`.  If `parts` is populated here,
         # then each part will correspond to a file.  Otherwise, each part will
         # correspond to a row group (populated below)

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -7,7 +7,12 @@ from ....utils import natural_sort_key, getargspec
 from ..utils import _get_pyarrow_dtypes, _meta_from_dtypes
 from ...utils import clear_known_categories
 
-from .utils import _parse_pandas_metadata, _normalize_index_columns, Engine
+from .utils import (
+    _parse_pandas_metadata,
+    _normalize_index_columns,
+    Engine,
+    _analyze_paths,
+)
 
 
 def _get_md_row_groups(pieces):
@@ -27,6 +32,70 @@ def _get_md_row_groups(pieces):
     return row_groups
 
 
+def _determine_dataset_parts(fs, paths, gather_statistics, **kwargs):
+    """ Determine how to access metadata and break read into ``parts``
+
+    This logic is mostly to handle `gather_statistics=False` cases,
+    because this also means we should avoid scanning every file in the
+    dataset.
+    """
+    parts = []
+    if len(paths) > 1:
+        if gather_statistics is not False:
+            # This scans all the files
+            dataset = pq.ParquetDataset(
+                paths, filesystem=fs, **kwargs.get("dataset", {})
+            )
+        else:
+            base, fns = _analyze_paths(paths, fs)
+            relpaths = [path.replace(base, "").lstrip("/") for path in paths]
+            if "_metadata" in relpaths:
+                # We have a _metadata file, lets use it
+                dataset = pq.ParquetDataset(
+                    base + fs.sep + "_metadata",
+                    filesystem=fs,
+                    **kwargs.get("dataset", {}),
+                )
+            else:
+                # Rely on metadata for 0th file.
+                # Will need to pass a list of paths to read_partition
+                dataset = pq.ParquetDataset(
+                    paths[0], filesystem=fs, **kwargs.get("dataset", {})
+                )
+                parts = [base + fs.sep + fn for fn in fns]
+    else:
+        if fs.isdir(paths[0]):
+            # This is a directory, check for _metadata, then _common_metadata
+            allpaths = fs.glob(paths[0] + fs.sep + "*")
+            base, fns = _analyze_paths(paths, fs)
+            relpaths = [path.replace(base, "").lstrip("/") for path in allpaths]
+            if "_metadata" in relpaths or gather_statistics is not False:
+                # Let arrow do its thing (use _metadata or scan files)
+                dataset = pq.ParquetDataset(
+                    paths, filesystem=fs, **kwargs.get("dataset", {})
+                )
+            else:
+                # Use _common_metadata file if it is available.
+                # Otherwise, just use 0th file
+                if "_common_metadata" in relpaths:
+                    dataset = pq.ParquetDataset(
+                        base + fs.sep + "_common_metadata",
+                        filesystem=fs,
+                        **kwargs.get("dataset", {}),
+                    )
+                else:
+                    dataset = pq.ParquetDataset(
+                        allpaths[0], filesystem=fs, **kwargs.get("dataset", {})
+                    )
+                parts = [base + fs.sep + fn for fn in fns]
+        else:
+            # There is only one file to read
+            dataset = pq.ParquetDataset(
+                paths, filesystem=fs, **kwargs.get("dataset", {})
+            )
+    return parts, dataset
+
+
 class ArrowEngine(Engine):
     @staticmethod
     def read_metadata(
@@ -38,7 +107,13 @@ class ArrowEngine(Engine):
         filters=None,
         **kwargs,
     ):
-        dataset = pq.ParquetDataset(paths, filesystem=fs, **kwargs.get("dataset", {}))
+        # Define the parquet-file (pf) object to use for metadata,
+        # Also, initialize `parts`.  If `parts` is populated here,
+        # then each part will correspond to a file.  Otherwise, each part will
+        # correspond to a row group (populated below)
+        parts, dataset = _determine_dataset_parts(
+            fs, paths, gather_statistics, **kwargs
+        )
 
         if dataset.partitions is not None:
             partitions = [
@@ -163,13 +238,17 @@ class ArrowEngine(Engine):
                         categories=partition.keys, values=[]
                     )
 
-        # Create `parts` (list of row-group-descriptor dicts)
+        # Create `parts`
+        # This is a list of row-group-descriptor dicts, or file-paths
+        # if we have a list of files and gather_statistics=False
+        if not parts:
+            parts = pieces
         parts = [
             {
                 "piece": piece,
                 "kwargs": {"partitions": dataset.partitions, "categories": categories},
             }
-            for piece in pieces
+            for piece in parts
         ]
 
         return (meta, stats, parts)
@@ -180,15 +259,28 @@ class ArrowEngine(Engine):
     ):
         if isinstance(index, list):
             columns += index
-        with fs.open(piece.path, mode="rb") as f:
-            table = piece.read(
+        if isinstance(piece, str):
+            # `piece` is a file path
+            # TODO: What to do about partitions?
+            table = pq.read_table(
+                piece,
                 columns=columns,
-                partitions=partitions,
                 use_pandas_metadata=True,
-                file=f,
+                filesystem=fs,
                 use_threads=False,
                 **kwargs.get("read", {}),
             )
+        else:
+            # `piece` is a row-group
+            with fs.open(piece.path, mode="rb") as f:
+                table = piece.read(
+                    columns=columns,
+                    partitions=partitions,
+                    use_pandas_metadata=True,
+                    file=f,
+                    use_threads=False,
+                    **kwargs.get("read", {}),
+                )
         df = table.to_pandas(
             categories=categories, use_threads=False, ignore_metadata=True
         )[list(columns)]

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -396,6 +396,7 @@ class ArrowEngine(Engine):
         fmd=None,
         compression=None,
         index_cols=None,
+        schema=None,
         **kwargs,
     ):
         md_list = []
@@ -403,7 +404,7 @@ class ArrowEngine(Engine):
         if index_cols:
             df = df.set_index(index_cols)
             preserve_index = True
-        t = pa.Table.from_pandas(df, preserve_index=preserve_index)
+        t = pa.Table.from_pandas(df, preserve_index=preserve_index, schema=schema)
         if partition_on:
             pq.write_to_dataset(
                 t,

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -13,13 +13,13 @@ from ....compatibility import string_types
 try:
     import fastparquet
     from fastparquet import ParquetFile
-    from fastparquet.util import analyse_paths, get_file_scheme
+    from fastparquet.util import get_file_scheme
     from fastparquet.util import ex_from_sep, val_to_num, groupby_types
     from fastparquet.writer import partition_on_columns, make_part_file
 except ModuleNotFoundError:
     pass
 
-from .utils import _parse_pandas_metadata, _normalize_index_columns
+from .utils import _parse_pandas_metadata, _normalize_index_columns, _analyze_paths
 from ..utils import _meta_from_dtypes
 from ...utils import UNKNOWN_CATEGORIES
 
@@ -73,6 +73,87 @@ def _paths_to_cats(paths, scheme):
     return {k: list(v) for k, v in cats.items()}
 
 
+def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
+    """ Determine how to access metadata and break read into ``parts``
+
+    This logic is mostly to handle `gather_statistics=False` cases,
+    because this also means we should avoid scanning every file in the
+    dataset.  If _metadata is available, set `gather_statistics=True`
+    (if `gather_statistics=None`).
+    """
+    parts = []
+    if len(paths) > 1:
+        if gather_statistics is not False:
+            # This scans all the files, allowing index/divisions
+            # and filtering
+            pf = ParquetFile(
+                paths, open_with=fs.open, sep=fs.sep, **kwargs.get("file", {})
+            )
+        else:
+            base, fns = _analyze_paths(paths, fs)
+            relpaths = [path.replace(base, "").lstrip("/") for path in paths]
+            if "_metadata" in relpaths:
+                # We have a _metadata file, lets use it
+                pf = ParquetFile(
+                    base + fs.sep + "_metadata",
+                    open_with=fs.open,
+                    sep=fs.sep,
+                    **kwargs.get("file", {})
+                )
+            else:
+                # Rely on metadata for 0th file.
+                # Will need to pass a list of paths to read_partition
+                scheme = get_file_scheme(fns)
+                pf = ParquetFile(paths[0], open_with=fs.open, **kwargs.get("file", {}))
+                pf.file_scheme = scheme
+                pf.cats = _paths_to_cats(fns, scheme)
+                parts = paths.copy()
+    else:
+        if fs.isdir(paths[0]):
+            # This is a directory, check for _metadata, then _common_metadata
+            paths = fs.glob(paths[0] + fs.sep + "*")
+            base, fns = _analyze_paths(paths, fs)
+            relpaths = [path.replace(base, "").lstrip("/") for path in paths]
+            if "_metadata" in relpaths:
+                # Using _metadata file (best-case scenario)
+                pf = ParquetFile(
+                    base + fs.sep + "_metadata",
+                    open_with=fs.open,
+                    sep=fs.sep,
+                    **kwargs.get("file", {})
+                )
+                if gather_statistics is None:
+                    gather_statistics = True
+
+            elif gather_statistics is not False:
+                # Scan every file
+                pf = ParquetFile(paths, open_with=fs.open, **kwargs.get("file", {}))
+            else:
+                # Use _common_metadata file if it is available.
+                # Otherwise, just use 0th file
+                if "_common_metadata" in relpaths:
+                    pf = ParquetFile(
+                        base + fs.sep + "_common_metadata",
+                        open_with=fs.open,
+                        **kwargs.get("file", {})
+                    )
+                else:
+                    pf = ParquetFile(
+                        paths[0], open_with=fs.open, **kwargs.get("file", {})
+                    )
+                scheme = get_file_scheme(fns)
+                pf.file_scheme = scheme
+                pf.cats = _paths_to_cats(fns, scheme)
+                parts = paths.copy()
+        else:
+            # There is only one file to read
+            pf = ParquetFile(
+                paths[0], open_with=fs.open, sep=fs.sep, **kwargs.get("file", {})
+            )
+
+    return parts, pf, gather_statistics
+
+
 class FastParquetEngine(Engine):
     @staticmethod
     def read_metadata(
@@ -84,65 +165,13 @@ class FastParquetEngine(Engine):
         filters=None,
         **kwargs
     ):
-        parts = []
-        if len(paths) > 1:
-            if gather_statistics is not False:
-                # This scans all the files, allowing index/divisions
-                # and filtering
-                pf = ParquetFile(
-                    paths, open_with=fs.open, sep=fs.sep, **kwargs.get("file", {})
-                )
-            else:
-                # Rely on metadata for 0th file.
-                # Will need to pass a list of paths to read_partition
-                _, fns = analyse_paths(paths)
-                scheme = get_file_scheme(fns)
-                pf = ParquetFile(paths[0], open_with=fs.open, **kwargs.get("file", {}))
-                pf.file_scheme = scheme
-                pf.cats = _paths_to_cats(fns, scheme)
-                parts = paths.copy()
-        else:
-            if fs.isdir(paths[0]):
-                # This is a directory, check for _metadata, then _common_metadata
-                paths = fs.glob(paths[0] + fs.sep + "*")
-                base, fns = analyse_paths(paths)
-                relpaths = [path.replace(base, "").lstrip("/") for path in paths]
-                if "_metadata" in relpaths:
-                    # Using _metadata file (best-case scenario)
-                    pf = ParquetFile(
-                        base + fs.sep + "_metadata",
-                        open_with=fs.open,
-                        sep=fs.sep,
-                        **kwargs.get("file", {})
-                    )
-                    if gather_statistics is None:
-                        gather_statistics = True
-
-                elif gather_statistics is not False:
-                    # Scan every file
-                    pf = ParquetFile(paths, open_with=fs.open, **kwargs.get("file", {}))
-                else:
-                    # Use _common_metadata file if it is available.
-                    # Otherwise, just use 0th file
-                    if "_common_metadata" in relpaths:
-                        pf = ParquetFile(
-                            base + fs.sep + "_common_metadata",
-                            open_with=fs.open,
-                            **kwargs.get("file", {})
-                        )
-                    else:
-                        pf = ParquetFile(
-                            paths[0], open_with=fs.open, **kwargs.get("file", {})
-                        )
-                    scheme = get_file_scheme(fns)
-                    pf.file_scheme = scheme
-                    pf.cats = _paths_to_cats(fns, scheme)
-                    parts = paths.copy()
-            else:
-                # There is only one file to read
-                pf = ParquetFile(
-                    paths[0], open_with=fs.open, sep=fs.sep, **kwargs.get("file", {})
-                )
+        # Define the parquet-file (pf) object to use for metadata,
+        # Also, initialize `parts`.  If `parts` is populated here,
+        # then each part will correspond to a file.  Otherwise, each part will
+        # correspond to a row group (populated below).
+        parts, pf, gather_statistics = _determine_pf_parts(
+            fs, paths, gather_statistics, **kwargs
+        )
 
         columns = None
         if pf.fmd.key_value_metadata:
@@ -286,7 +315,7 @@ class FastParquetEngine(Engine):
                 piece, columns, categories, index=index, **kwargs.get("read", {})
             )
         else:
-            base, fns = analyse_paths([piece])
+            base, fns = _analyze_paths([piece], fs)
             scheme = get_file_scheme(fns)
             pf = ParquetFile(piece, open_with=fs.open)
             relpath = piece.replace(base, "").lstrip("/")

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -87,7 +87,7 @@ class FastParquetEngine(Engine):
         parts = []
         if len(paths) > 1:
             if gather_statistics is not False:
-                # this scans all the files, allowing index/divisions
+                # This scans all the files, allowing index/divisions
                 # and filtering
                 pf = ParquetFile(
                     paths, open_with=fs.open, sep=fs.sep, **kwargs.get("file", {})
@@ -102,16 +102,42 @@ class FastParquetEngine(Engine):
                 pf.cats = _paths_to_cats(fns, scheme)
                 parts = paths.copy()
         else:
-            try:
-                pf = ParquetFile(
-                    paths[0] + fs.sep + "_metadata",
-                    open_with=fs.open,
-                    sep=fs.sep,
-                    **kwargs.get("file", {})
-                )
-                if gather_statistics is None:
-                    gather_statistics = True
-            except Exception:
+            if fs.isdir(paths[0]):
+                # This is a directory, check for _metadata, then _common_metadata
+                paths = fs.glob(paths[0]+fs.sep+'*')
+                base, fns = analyse_paths(paths)
+                relpaths = [path.replace(base, "").lstrip("/") for path in paths]
+                if "_metadata" in relpaths:
+                    # Using _metadata file (best-case scenario)
+                    pf = ParquetFile(
+                        base + fs.sep + "_metadata",
+                        open_with=fs.open,
+                        sep=fs.sep,
+                        **kwargs.get("file", {})
+                    )
+                    if gather_statistics is None:
+                        gather_statistics = True
+                    
+                elif gather_statistics is not False:
+                    # Scan every file
+                    pf = ParquetFile(paths, open_with=fs.open, **kwargs.get("file", {}))
+                else:
+                    # Use _common_metadata file if it is available.
+                    # Otherwise, just use 0th file
+                    if "_common_metadata" in relpaths:
+                        pf = ParquetFile(
+                            base + fs.sep + "_common_metadata",
+                            open_with=fs.open,
+                            **kwargs.get("file", {})
+                        )
+                    else:
+                        pf = ParquetFile(paths[0], open_with=fs.open, **kwargs.get("file", {}))
+                    scheme = get_file_scheme(fns)
+                    pf.file_scheme = scheme
+                    pf.cats = _paths_to_cats(fns, scheme)
+                    parts = paths.copy()
+            else:
+                # There is only one file to read
                 pf = ParquetFile(
                     paths[0], open_with=fs.open, sep=fs.sep, **kwargs.get("file", {})
                 )

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -104,7 +104,7 @@ class FastParquetEngine(Engine):
         else:
             if fs.isdir(paths[0]):
                 # This is a directory, check for _metadata, then _common_metadata
-                paths = fs.glob(paths[0]+fs.sep+'*')
+                paths = fs.glob(paths[0] + fs.sep + "*")
                 base, fns = analyse_paths(paths)
                 relpaths = [path.replace(base, "").lstrip("/") for path in paths]
                 if "_metadata" in relpaths:
@@ -117,7 +117,7 @@ class FastParquetEngine(Engine):
                     )
                     if gather_statistics is None:
                         gather_statistics = True
-                    
+
                 elif gather_statistics is not False:
                     # Scan every file
                     pf = ParquetFile(paths, open_with=fs.open, **kwargs.get("file", {}))
@@ -131,7 +131,9 @@ class FastParquetEngine(Engine):
                             **kwargs.get("file", {})
                         )
                     else:
-                        pf = ParquetFile(paths[0], open_with=fs.open, **kwargs.get("file", {}))
+                        pf = ParquetFile(
+                            paths[0], open_with=fs.open, **kwargs.get("file", {})
+                        )
                     scheme = get_file_scheme(fns)
                     pf.file_scheme = scheme
                     pf.cats = _paths_to_cats(fns, scheme)

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -61,7 +61,7 @@ class Engine:
             ]
         parts: List[object]
             A list of objects to be passed to ``Engine.read_partition``.
-            Each object should represent a row group of data.
+            Each object should represent a piece of data (usually a row-group).
             The type of each object can be anything, as long as the
             engine's read_partition function knows how to interpret it.
         """

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -339,3 +339,94 @@ def _normalize_index_columns(user_columns, data_columns, user_index, data_index)
         index_names = data_index
 
     return column_names, index_names
+
+
+def _analyze_paths(file_list, fs, root=False):
+    """Consolidate list of file-paths into  parquet relative paths
+
+    Note: This function was mostly copied from dask/fastparquet to
+    use in both `FastParquetEngine` and `ArrowEngine`."""
+
+    def _join_path(*path):
+        def _scrub(i, p):
+            # Convert path to standard form
+            # this means windows path separators are converted to linux
+            p = p.replace(fs.sep, "/")
+            if p == "":  # empty path is assumed to be a relative path
+                return "."
+            if p[-1] == "/":  # trailing slashes are not allowed
+                p = p[:-1]
+            if i > 0 and p[0] == "/":  # only the first path can start with /
+                p = p[1:]
+            return p
+
+        abs_prefix = ""
+        if path and path[0]:
+            if path[0][0] == "/":
+                abs_prefix = "/"
+                path = list(path)
+                path[0] = path[0][1:]
+            elif fs.sep == "\\" and path[0][1:].startswith(":/"):
+                # If windows, then look for the "c:/" prefix
+                abs_prefix = path[0][0:3]
+                path = list(path)
+                path[0] = path[0][3:]
+
+        _scrubbed = []
+        for i, p in enumerate(path):
+            _scrubbed.extend(_scrub(i, p).split("/"))
+        simpler = []
+        for s in _scrubbed:
+            if s == ".":
+                pass
+            elif s == "..":
+                if simpler:
+                    if simpler[-1] == "..":
+                        simpler.append(s)
+                    else:
+                        simpler.pop()
+                elif abs_prefix:
+                    raise Exception("can not get parent of root")
+                else:
+                    simpler.append(s)
+            else:
+                simpler.append(s)
+
+        if not simpler:
+            if abs_prefix:
+                joined = abs_prefix
+            else:
+                joined = "."
+        else:
+            joined = abs_prefix + ("/".join(simpler))
+        return joined
+
+    path_parts_list = [_join_path(fn).split("/") for fn in file_list]
+    if root is False:
+        basepath = path_parts_list[0][:-1]
+        for i, path_parts in enumerate(path_parts_list):
+            j = len(path_parts) - 1
+            for k, (base_part, path_part) in enumerate(zip(basepath, path_parts)):
+                if base_part != path_part:
+                    j = k
+                    break
+            basepath = basepath[:j]
+        l = len(basepath)
+
+    else:
+        basepath = _join_path(root).split("/")
+        l = len(basepath)
+        assert all(
+            p[:l] == basepath for p in path_parts_list
+        ), "All paths must begin with the given root"
+    l = len(basepath)
+    out_list = []
+    for path_parts in path_parts_list:
+        out_list.append(
+            "/".join(path_parts[l:])
+        )  # use '/'.join() instead of _join_path to be consistent with split('/')
+
+    return (
+        "/".join(basepath),
+        out_list,
+    )  # use '/'.join() instead of _join_path to be consistent with split('/')

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -938,8 +938,7 @@ def test_to_parquet_default_writes_nulls(tmpdir):
     assert table[1].null_count == 2
 
 
-@write_read_engines_xfail
-def test_partition_on(tmpdir, write_engine, read_engine):
+def test_partition_on(tmpdir, engine):
     tmpdir = str(tmpdir)
     df = pd.DataFrame(
         {
@@ -949,11 +948,11 @@ def test_partition_on(tmpdir, write_engine, read_engine):
         }
     )
     d = dd.from_pandas(df, npartitions=2)
-    d.to_parquet(tmpdir, partition_on=["a"], write_index=False, engine=write_engine)
-    # Note #1: fastparquet is not discovering the partions when written by pyarrow
+    d.to_parquet(tmpdir, partition_on=["a"], write_index=False, engine=engine)
+    # Note #1: Cross-engine functionality is missing
     # Note #2: The index is not preserved in pyarrow when partition_on is used
     out = dd.read_parquet(
-        tmpdir, index=False, engine=read_engine, gather_statistics=False
+        tmpdir, index=False, engine=engine, gather_statistics=False
     ).compute()
     for val in df.a.unique():
         assert set(df.b[df.a == val]) == set(out.b[out.a == val])

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1714,3 +1714,14 @@ def test_categories_large(tmpdir, engine):
     ddf = dd.read_parquet(fn, engine=engine, categories={"name": 80000})
 
     assert_eq(sorted(df.name.cat.categories), sorted(ddf.compute().name.cat.categories))
+
+
+@write_read_engines()
+def test_read_glob_nostats(tmpdir, write_engine, read_engine):
+    tmp_path = str(tmpdir)
+    ddf.to_parquet(tmp_path, engine=write_engine)
+
+    ddf2 = dd.read_parquet(
+        os.path.join(tmp_path, "*.parquet"), engine=read_engine, gather_statistics=False
+    )
+    assert_eq(ddf, ddf2, check_divisions=False)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -950,7 +950,9 @@ def test_to_parquet_pyarrow_w_inconsistent_schema_by_partition_fails_by_default(
 
     # Test that read fails because of default behavior when schema not provided
     with pytest.raises(ValueError) as e_info:
-        dd.read_parquet(str(tmpdir), engine="pyarrow", gather_statistics=False)
+        dd.read_parquet(
+            str(tmpdir), engine="pyarrow", gather_statistics=False
+        ).compute()
         assert e_info.message.contains("ValueError: Schema in partition")
         assert e_info.message.contains("was different")
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1725,3 +1725,25 @@ def test_read_glob_nostats(tmpdir, write_engine, read_engine):
         os.path.join(tmp_path, "*.parquet"), engine=read_engine, gather_statistics=False
     )
     assert_eq(ddf, ddf2, check_divisions=False)
+
+
+@pytest.mark.parametrize("statistics", [True, False, None])
+@pytest.mark.parametrize("remove_common", [True, False])
+@write_read_engines()
+def test_read_dir_nometa(tmpdir, write_engine, read_engine, statistics, remove_common):
+    tmp_path = str(tmpdir)
+    ddf.to_parquet(tmp_path, engine=write_engine)
+    if os.path.exists(os.path.join(tmp_path, "_metadata")):
+        os.unlink(os.path.join(tmp_path, "_metadata"))
+    files = os.listdir(tmp_path)
+    assert "_metadata" not in files
+
+    if remove_common and os.path.exists(os.path.join(tmp_path, "_common_metadata")):
+        os.unlink(os.path.join(tmp_path, "_common_metadata"))
+
+    ddf2 = dd.read_parquet(
+        tmp_path,
+        engine=read_engine,
+        gather_statistics=statistics,
+    )
+    assert_eq(ddf, ddf2, check_divisions=False)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1741,9 +1741,5 @@ def test_read_dir_nometa(tmpdir, write_engine, read_engine, statistics, remove_c
     if remove_common and os.path.exists(os.path.join(tmp_path, "_common_metadata")):
         os.unlink(os.path.join(tmp_path, "_common_metadata"))
 
-    ddf2 = dd.read_parquet(
-        tmp_path,
-        engine=read_engine,
-        gather_statistics=statistics,
-    )
+    ddf2 = dd.read_parquet(tmp_path, engine=read_engine, gather_statistics=statistics)
     assert_eq(ddf, ddf2, check_divisions=False)

--- a/dask/dataframe/io/utils.py
+++ b/dask/dataframe/io/utils.py
@@ -37,7 +37,10 @@ def _get_pyarrow_dtypes(schema, categories):
             else:
                 numpy_dtype = pandas_metadata_dtypes[field.name]
         else:
-            numpy_dtype = field.type.to_pandas_dtype()
+            try:
+                numpy_dtype = field.type.to_pandas_dtype()
+            except NotImplementedError:
+                continue  # Skip this field (in case we aren't reading it anyway)
 
         dtypes[field.name] = numpy_dtype
 


### PR DESCRIPTION
This is hopefully a fix for the bug raised in [Issue#5153](https://github.com/dask/dask/issues/5153).  The specific changes are in line with [this comment](https://github.com/dask/dask/issues/5153#issuecomment-515073768).

In the fastparquet engine, it is possible to take in a list of files, but have `gather_statistics=False`.  This case was previously untested.  I added a new test (`test_read_glob_nostats`), and tweaked the engine a bit to allow the `parts` output of `read_metadata` to (optionally) include file paths rather than row-group information.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
