### PR TITLE
Adds docker container customization example to docs

### DIFF
--- a/docs/source/setup/docker.rst
+++ b/docs/source/setup/docker.rst
@@ -41,12 +41,19 @@ Extensibility
 
 Users can mildly customize the software environment by populating the
 environment variables ``EXTRA_APT_PACKAGES``, ``EXTRA_CONDA_PACKAGES``, and
-``EXTRA_PIP_PACKAGES``.  If these environment variables are set, they will
-trigger calls to the following respectively::
+``EXTRA_PIP_PACKAGES``.  If these environment variables are set in the container,
+they will trigger calls to the following respectively::
 
    apt-get install $EXTRA_APT_PACKAGES
    conda install $EXTRA_CONDA_PACKAGES
    pip install $EXTRA_PIP_PACKAGES
+
+For example, the following ``conda`` installs the ``joblib`` package into
+the Dask worker software environment:
+
+.. code-block:: bash
+
+   docker run -it -e EXTRA_CONDA_PACKAGES="joblib" daskdev/dask dask-worker localhost:8786
 
 Note that using these can significantly delay the container from starting,
 especially when using ``apt``, or ``conda`` (``pip`` is relatively fast).


### PR DESCRIPTION
This PR specifies that the ``EXTRA_*_PACKAGES`` environment variables should be set *inside* the docker container and adds an example of how to do so. 