### PR TITLE
Avoid unnecessary step in pivot_table

### DIFF
--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -243,22 +243,25 @@ def pivot_table(df, index=None, columns=None, values=None, aggfunc="mean"):
 
     kwargs = {"index": index, "columns": columns, "values": values}
 
-    pv_sum = apply_concat_apply(
-        [df],
-        chunk=methods.pivot_sum,
-        aggregate=methods.pivot_agg,
-        meta=meta,
-        token="pivot_table_sum",
-        chunk_kwargs=kwargs,
-    )
-    pv_count = apply_concat_apply(
-        [df],
-        chunk=methods.pivot_count,
-        aggregate=methods.pivot_agg,
-        meta=meta,
-        token="pivot_table_count",
-        chunk_kwargs=kwargs,
-    )
+    if aggfunc in ["sum", "mean"]:
+        pv_sum = apply_concat_apply(
+            [df],
+            chunk=methods.pivot_sum,
+            aggregate=methods.pivot_agg,
+            meta=meta,
+            token="pivot_table_sum",
+            chunk_kwargs=kwargs,
+        )
+
+    if aggfunc in ["count", "mean"]:
+        pv_count = apply_concat_apply(
+            [df],
+            chunk=methods.pivot_count,
+            aggregate=methods.pivot_agg,
+            meta=meta,
+            token="pivot_table_count",
+            chunk_kwargs=kwargs,
+        )
 
     if aggfunc == "sum":
         return pv_sum


### PR DESCRIPTION
- [ x ] Passes `black dask` / `flake8 dask`

This PR is to avoid doing unnecessary calculation in `dataframe.reshape.pivot_table` when the `aggfunc` is either `"sum"` or `"count"`.  Right now both aggregations (sums and counts) are calculated regardless of the `aggfunc`, even though we only need both when `aggfunc == "mean"`.