### PR TITLE
Bump NumPy and Pandas to 1.17 and 0.25 in CI test

### DIFF
--- a/continuous_integration/travis/travis-37.yaml
+++ b/continuous_integration/travis/travis-37.yaml
@@ -4,8 +4,8 @@ channels:
 dependencies:
   # required dependencies
   - python=3.7.*
-  - numpy=1.16.*
-  - pandas=0.24.*
+  - numpy=1.17.*
+  - pandas=0.25.*
   # test dependencies
   - pytest
   - pytest-xdist


### PR DESCRIPTION
Go ahead and bump the Python 3.7 environment's version constraints for NumPy and Pandas to the latest released versions. This should help us see what breaks (if anything) and should allow us to test against them going forward.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
