### PR TITLE
Add rearrange_by_divisions and set_index support for cudf

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4712,8 +4712,6 @@ def _emulate(func, *args, **kwargs):
     """
     with raise_on_meta_error(funcname(func), udf=kwargs.pop("udf", False)):
         return func(*_extract_meta(args, True), **_extract_meta(kwargs, True))
-    # kwargs.pop('udf')
-    # return func(*_extract_meta(args, True), **_extract_meta(kwargs, True))
 
 
 @insert_meta_param_description

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4712,6 +4712,8 @@ def _emulate(func, *args, **kwargs):
     """
     with raise_on_meta_error(funcname(func), udf=kwargs.pop("udf", False)):
         return func(*_extract_meta(args, True), **_extract_meta(kwargs, True))
+    # kwargs.pop('udf')
+    # return func(*_extract_meta(args, True), **_extract_meta(kwargs, True))
 
 
 @insert_meta_param_description

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -140,13 +140,7 @@ def remove_nans(divisions):
 
 
 def set_partition(
-    df,
-    index,
-    divisions,
-    max_branch=32,
-    drop=True,
-    shuffle=None,
-    compute=None,
+    df, index, divisions, max_branch=32, drop=True, shuffle=None, compute=None
 ):
     """ Group DataFrame by index
 
@@ -262,9 +256,7 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32, compute=No
     return df3
 
 
-def rearrange_by_divisions(
-    df, column, divisions, max_branch=None, shuffle=None
-):
+def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None):
     """ Shuffle dataframe so that column separates along divisions """
     if isinstance(divisions, (list, tuple)):
         divisions = pd.Series(divisions)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -19,6 +19,7 @@ from ..delayed import delayed
 from ..highlevelgraph import HighLevelGraph
 from ..sizeof import sizeof
 from ..utils import digit, insert, M
+from .utils import series_like_df
 
 
 def set_index(
@@ -173,9 +174,8 @@ def set_partition(
     shuffle
     partd
     """
-    series_type = type(df[df.columns[0]]._meta)
-    divisions = series_type(divisions)
-    meta = series_type([0])
+    divisions = series_like_df(df, values=divisions)
+    meta = series_like_df(df, values=[0])
     if np.isscalar(index):
         partitions = df[index].map_partitions(
             set_partitions_pre, divisions=divisions, meta=meta
@@ -211,7 +211,7 @@ def set_partition(
             column_dtype=df.columns.dtype,
         )
 
-    df4.divisions = [v for v in divisions.values]
+    df4.divisions = divisions.tolist()  # [v for v in divisions.values]
 
     return df4.map_partitions(M.sort_index)
 
@@ -258,9 +258,8 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32, compute=No
 
 def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None):
     """ Shuffle dataframe so that column separates along divisions """
-    series_type = type(df[df.columns[0]]._meta)
-    divisions = series_type(divisions)
-    meta = series_type([0])
+    divisions = series_like_df(df, values=divisions)
+    meta = series_like_df(df, values=[0])
     # Assign target output partitions to every row
     partitions = df[column].map_partitions(
         set_partitions_pre, divisions=divisions, meta=meta

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -632,10 +632,7 @@ def shuffle_group_3(df, col, npartitions, p):
 
 
 def set_index_post_scalar(df, index_name, drop, column_dtype):
-    if not drop:
-        df2 = df.drop("_partitions", axis=1).set_index(index_name, drop=drop)
-    else:
-        df2 = df.drop("_partitions", axis=1).set_index(index_name)
+    df2 = df.drop("_partitions", axis=1).set_index(index_name, drop=drop)
     df2.columns = df2.columns.astype(column_dtype)
     return df2
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -173,9 +173,9 @@ def set_partition(
     shuffle
     partd
     """
-    if isinstance(divisions, (list, tuple)):
-        divisions = pd.Series(divisions)
-    meta = type(df[df.columns[0]]._meta)([0])
+    series_type = type(df[df.columns[0]]._meta)
+    divisions = series_type(divisions)
+    meta = series_type([0])
     if np.isscalar(index):
         partitions = df[index].map_partitions(
             set_partitions_pre, divisions=divisions, meta=meta
@@ -258,9 +258,9 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32, compute=No
 
 def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None):
     """ Shuffle dataframe so that column separates along divisions """
-    if isinstance(divisions, (list, tuple)):
-        divisions = pd.Series(divisions)
-    meta = type(df[df.columns[0]]._meta)([0])
+    series_type = type(df[df.columns[0]]._meta)
+    divisions = series_type(divisions)
+    meta = series_type([0])
     # Assign target output partitions to every row
     partitions = df[column].map_partitions(
         set_partitions_pre, divisions=divisions, meta=meta

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -657,6 +657,12 @@ def index_summary(idx, name=None):
     return "{}: {} entries{}".format(name, n, summary)
 
 
+def series_like_df(df, values=()):
+    """Get a series that is compatible with df.
+    """
+    return type(df._meta.iloc[:, 0])(values)
+
+
 ###############################################################
 # Testing
 ###############################################################

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -657,10 +657,11 @@ def index_summary(idx, name=None):
     return "{}: {} entries{}".format(name, n, summary)
 
 
-def series_like_df(df, values=()):
-    """Get a series that is compatible with df.
-    """
-    return type(df._meta.iloc[:, 0])(values)
+def series_type_like_df(df):
+    """Get the concrete series type compatible with df."""
+    # TODO: https://github.com/pandas-dev/pandas/issues/27824
+    # Use a standard API, which will handle empty DataFrames.
+    return type(df._meta.iloc[:, 0])
 
 
 ###############################################################


### PR DESCRIPTION
This is a work in progress, and is also not (yet) intended to be a *performant* solution for cudf+dask..

In `dask.dataframe`, `shuffle.rearrange_by_divisions` and `shuffle.set_index` do not currently work for cudf dataframes ([there is a detailed discussion is this cudf issue](https://github.com/rapidsai/cudf/issues/2272)).  This PR provides support for both pandas and cudf dataframes, but does not implement an *performant* solution for cudf (a followup PR will target better performance for cudf; avoiding copying data to host, etc).

The target here is to allow us to sort a cudf-based dask dataframe by some column.  For example, consider the following pandas and cudf-based dataframe defintions:

```python
import cudf, dask.dataframe as dd, pandas as pd

# Make a dataframe, we'd like to divide the data by y
gdf = cudf.DataFrame({'x': [i for i in range(10)], 'y': [0, 4]*5})
df = pd.DataFrame({'x': [i for i in range(10)], 'y': [0, 4]*5})

# Split it up into a few partitions with Dask
gddf = dd.from_pandas(gdf, npartitions=3)
ddf = dd.from_pandas(df, npartitions=3)
```

This PR allows us to use `rearrange_by_divisions` on a pandas-based dataframe exaclty as before:

```python
out_pd = dd.shuffle.rearrange_by_divisions(ddf, column='y', divisions=[0, 2, 4], shuffle='tasks')
result_pd = out_pd.compute()
```

We can also handle a cudf-based dataframe in the same way:

```python
out_cd = dd.shuffle.rearrange_by_divisions(
    gddf,
    column='y',
    divisions=[0, 2, 4], 
    shuffle='tasks'
)
result_cd = out_cd.compute()
```

**[EDIT: `meta=` argument has been removed in snippet above. Also, we no longer need to specify divisions as a cudf dataframe]**

The same result can be obtained using the `set_index` function.  For example:

```python
out_cd_si = dd.shuffle.set_index(
    gddf,
    'y',
    divisions=[0, 2, 4],
    shuffle='tasks'
)
result_cd_si = out_cd_si.compute()
```

**[EDIT: `meta=` argument has been removed in snippet above. Also, we no longer need to specify divisions as a cudf dataframe]**

**The primary changes here**:

- ~~[Temporary?]~~ Switching from the use of `_values` to `values` (which is now supported by cudf).  After glancing through pandas source, it is not obvious to me how they are different. However, please do let me know if/why this is wrong.
- ~~Modifying `rearrange_by_divisions`, `set_index`, and `set_partitions_pre` to accept `divisions` as either a series or list.  A `meta` kwarg was also added to each of the functions to avoid the `pd.Series([0])` call for cudf cases.~~
- ~~Removing explicit `drop=True` arguments for `set_index` within `set_index_post_scalar` (cudf does not support `drop`)~~
- [EDIT] Converting divisions to a series-based object in both `set_partition` and `rearrange_by_divisions`


**Performance note**:

On my local machine, the example above becomes faster with cudf dataframes than with pandas dataframes when I get up to 1e7 rows and 1-10 columns (~1.5-3x).  With smaller dataframes, the cudf version is typically slower.


Overall, this PR is meant to be modest compared to the changes that will be needed for optimal cudf behavior (which will likely require changes in both libraries).  Please do suggest other/better solutions.  If needed, I will add pandas-based tests to cover the new logic if/when these changes get positive feedback, etc.

- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

