### PR TITLE
Add fsspec to readthedocs

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -6,3 +6,4 @@ toolz
 cloudpickle
 pandas>=0.19.0
 distributed
+fsspec


### PR DESCRIPTION
Fixes #5206

See errant logs in https://readthedocs.org/projects/dask/builds/9457535/

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
