### PR TITLE
LINT: Fixup black string normalization

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1188,8 +1188,8 @@ class Array(DaskMethodsMixin):
             cbytes = "unknown"
 
         table = [
-            "<table>"
-            "  <thead>"
+            "<table>",
+            "  <thead>",
             "    <tr><td> </td><th> Array </th><th> Chunk </th></tr>",
             "  </thead>",
             "  <tbody>",
@@ -1205,7 +1205,8 @@ class Array(DaskMethodsMixin):
                 type(self._meta).__module__.split(".")[0],
                 type(self._meta).__name__,
             ),
-            "  </tbody>" "</table>",
+            "  </tbody>",
+            "</table>",
         ]
         return "\n".join(table)
 
@@ -1378,9 +1379,7 @@ class Array(DaskMethodsMixin):
 
     def _scalarfunc(self, cast_type):
         if self.size > 1:
-            raise TypeError(
-                "Only length-1 arrays can be converted " "to Python scalars"
-            )
+            raise TypeError("Only length-1 arrays can be converted to Python scalars")
         else:
             return cast_type(self.compute())
 
@@ -2466,7 +2465,7 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
             and np.isnan(x).any()
         ):
             raise ValueError(
-                "Can not perform automatic rechunking with unknown " "(nan) chunk sizes"
+                "Can not perform automatic rechunking with unknown (nan) chunk sizes"
             )
 
     limit = max(1, limit)
@@ -4353,9 +4352,7 @@ def _vindex(x, *indexes):
         if not isinstance(ind, slice):
             ind = np.array(ind, copy=True)
             if ind.dtype.kind == "b":
-                raise IndexError(
-                    "vindex does not support indexing with " "boolean arrays"
-                )
+                raise IndexError("vindex does not support indexing with boolean arrays")
             if ((ind >= size) | (ind < -size)).any():
                 raise IndexError(
                     "vindex key has entries out of bounds for "

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -517,7 +517,7 @@ def diag(v):
         return Array(dsk, name, chunks, meta=meta)
     if not isinstance(v, Array):
         raise TypeError(
-            "v must be a dask array or numpy array, " "got {0}".format(type(v))
+            "v must be a dask array or numpy array, got {0}".format(type(v))
         )
     if v.ndim != 1:
         if v.chunks[0] == v.chunks[1]:
@@ -528,7 +528,7 @@ def diag(v):
             return Array(graph, name, (v.chunks[0],), meta=meta)
         else:
             raise NotImplementedError(
-                "Extracting diagonals from non-square " "chunked arrays"
+                "Extracting diagonals from non-square chunked arrays"
             )
     chunks_1d = v.chunks[0]
     blocks = v.__dask_keys__()

--- a/dask/array/einsumfuncs.py
+++ b/dask/array/einsumfuncs.py
@@ -189,7 +189,7 @@ def parse_einsum_input(operands):
     # Make sure number operands is equivalent to the number of terms
     if len(input_subscripts.split(",")) != len(operands):
         raise ValueError(
-            "Number of einsum subscripts must be equal to the " "number of operands."
+            "Number of einsum subscripts must be equal to the number of operands."
         )
 
     return (input_subscripts, output_subscript, operands)

--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -30,7 +30,7 @@ def _concatenate(arrays, axis=0):
     fill_values = [i.fill_value for i in arrays if hasattr(i, "fill_value")]
     if any(isinstance(f, np.ndarray) for f in fill_values):
         raise ValueError(
-            "Dask doesn't support masked array's with " "non-scalar `fill_value`s"
+            "Dask doesn't support masked array's with non-scalar `fill_value`s"
         )
     if fill_values:
         # If all the fill_values are the same copy over the fill value

--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -113,7 +113,7 @@ def percentile(a, q, interpolation="linear", method="default"):
         from dask.utils import import_required
 
         import_required(
-            "crick", "crick is a required dependency for using the t-digest " "method."
+            "crick", "crick is a required dependency for using the t-digest method."
         )
 
         name = "percentile_tdigest_chunk-" + token

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -946,7 +946,7 @@ def arg_reduction(x, chunk, combine, agg, axis=None, split_every=None, out=None)
         axis = (axis,)
         ravel = x.ndim == 1
     else:
-        raise TypeError("axis must be either `None` or int, " "got '{0}'".format(axis))
+        raise TypeError("axis must be either `None` or int, got '{0}'".format(axis))
 
     for ax in axis:
         chunks = x.chunks[ax]

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -531,7 +531,7 @@ def gradient(f, *varargs, **kwargs):
         varargs = len(axis) * varargs
     if len(varargs) != len(axis):
         raise TypeError(
-            "Spacing must either be a single scalar, or a scalar / 1d-array " "per axis"
+            "Spacing must either be a single scalar, or a scalar / 1d-array per axis"
         )
 
     if issubclass(f.dtype.type, (np.bool8, Integral)):
@@ -592,7 +592,7 @@ def _bincount_sum(bincounts, dtype=int):
 @derived_from(np)
 def bincount(x, weights=None, minlength=0):
     if x.ndim != 1:
-        raise ValueError("Input array must be one dimensional. " "Try using x.ravel()")
+        raise ValueError("Input array must be one dimensional. Try using x.ravel()")
     if weights is not None:
         if weights.chunks != x.chunks:
             raise ValueError("Chunks of input array x and weights must match.")
@@ -681,9 +681,7 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
         )
 
     if weights is not None and weights.chunks != a.chunks:
-        raise ValueError(
-            "Input array and weights must have the same " "chunked structure"
-        )
+        raise ValueError("Input array and weights must have the same chunked structure")
 
     if normed is not False:
         raise ValueError(
@@ -1003,7 +1001,7 @@ def roll(array, shift, axis=None):
 
         if not isinstance(shift, Integral):
             raise TypeError(
-                "Expect `shift` to be an instance of Integral" " when `axis` is None."
+                "Expect `shift` to be an instance of Integral when `axis` is None."
             )
 
         shift = (shift,)
@@ -1394,7 +1392,7 @@ def _average(a, axis=None, weights=None, returned=False, is_masked=False):
         if a.shape != wgt.shape:
             if axis is None:
                 raise TypeError(
-                    "Axis must be specified when shapes of a and weights " "differ."
+                    "Axis must be specified when shapes of a and weights differ."
                 )
             if wgt.ndim != 1:
                 raise TypeError(

--- a/dask/array/stats.py
+++ b/dask/array/stats.py
@@ -94,7 +94,7 @@ def ttest_ind(a, b, axis=0, equal_var=True):
 def ttest_1samp(a, popmean, axis=0, nan_policy="propagate"):
     if nan_policy != "propagate":
         raise NotImplementedError(
-            "`nan_policy` other than 'propagate' " "have not been implemented."
+            "`nan_policy` other than 'propagate' have not been implemented."
         )
     n = a.shape[axis]
     df = n - 1
@@ -113,7 +113,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy="propagate"):
 def ttest_rel(a, b, axis=0, nan_policy="propagate"):
     if nan_policy != "propagate":
         raise NotImplementedError(
-            "`nan_policy` other than 'propagate' " "have not been implemented."
+            "`nan_policy` other than 'propagate' have not been implemented."
         )
 
     n = a.shape[axis]
@@ -187,7 +187,7 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
 def skew(a, axis=0, bias=True, nan_policy="propagate"):
     if nan_policy != "propagate":
         raise NotImplementedError(
-            "`nan_policy` other than 'propagate' " "have not been implemented."
+            "`nan_policy` other than 'propagate' have not been implemented."
         )
 
     n = a.shape[axis]  # noqa; for bias
@@ -214,7 +214,7 @@ def skew(a, axis=0, bias=True, nan_policy="propagate"):
 def skewtest(a, axis=0, nan_policy="propagate"):
     if nan_policy != "propagate":
         raise NotImplementedError(
-            "`nan_policy` other than 'propagate' " "have not been implemented."
+            "`nan_policy` other than 'propagate' have not been implemented."
         )
 
     b2 = skew(a, axis)
@@ -245,7 +245,7 @@ def skewtest(a, axis=0, nan_policy="propagate"):
 def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy="propagate"):
     if nan_policy != "propagate":
         raise NotImplementedError(
-            "`nan_policy` other than 'propagate' " "have not been implemented."
+            "`nan_policy` other than 'propagate' have not been implemented."
         )
     n = a.shape[axis]  # noqa; for bias
     m2 = moment(a, 2, axis)
@@ -272,7 +272,7 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy="propagate"):
 def kurtosistest(a, axis=0, nan_policy="propagate"):
     if nan_policy != "propagate":
         raise NotImplementedError(
-            "`nan_policy` other than 'propagate' " "have not been implemented."
+            "`nan_policy` other than 'propagate' have not been implemented."
         )
 
     n = float(a.shape[axis])
@@ -309,7 +309,7 @@ def kurtosistest(a, axis=0, nan_policy="propagate"):
 def normaltest(a, axis=0, nan_policy="propagate"):
     if nan_policy != "propagate":
         raise NotImplementedError(
-            "`nan_policy` other than 'propagate' " "have not been implemented."
+            "`nan_policy` other than 'propagate' have not been implemented."
         )
 
     s, _ = skewtest(a, axis)
@@ -357,7 +357,7 @@ def f_oneway(*args):
 def moment(a, moment=1, axis=0, nan_policy="propagate"):
     if nan_policy != "propagate":
         raise NotImplementedError(
-            "`nan_policy` other than 'propagate' " "have not been implemented."
+            "`nan_policy` other than 'propagate' have not been implemented."
         )
     return da.moment(a, moment, axis=axis)
 

--- a/dask/array/tiledb_io.py
+++ b/dask/array/tiledb_io.py
@@ -151,7 +151,7 @@ def to_tiledb(
             and (darray.ndim == tdb.ndim)
         ):
             raise ValueError(
-                "Target TileDB array layout is not compatible with " "source array"
+                "Target TileDB array layout is not compatible with source array"
             )
     else:
         raise ValueError(

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -79,9 +79,7 @@ class da_frompyfunc(object):
     def __getattr__(self, a):
         if not a.startswith("_"):
             return getattr(self._ufunc, a)
-        raise AttributeError(
-            "%r object has no attribute " "%r" % (type(self).__name__, a)
-        )
+        raise AttributeError("%r object has no attribute %r" % (type(self).__name__, a))
 
     def __dir__(self):
         o = set(dir(type(self)))
@@ -122,7 +120,7 @@ class ufunc(object):
         if key in self._forward_attrs:
             return getattr(self._ufunc, key)
         raise AttributeError(
-            "%r object has no attribute " "%r" % (type(self).__name__, key)
+            "%r object has no attribute %r" % (type(self).__name__, key)
         )
 
     def __dir__(self):
@@ -139,7 +137,7 @@ class ufunc(object):
                 if type(result) != type(NotImplemented):
                     return result
             raise TypeError(
-                "Parameters of such types " "are not supported by " + self.__name__
+                "Parameters of such types are not supported by " + self.__name__
             )
         else:
             return self._ufunc(*args, **kwargs)

--- a/dask/bag/avro.py
+++ b/dask/bag/avro.py
@@ -93,7 +93,7 @@ def read_avro(urlpath, blocksize=100000000, storage_options=None, compression=No
     from dask.bag import from_delayed
 
     import_required(
-        "fastavro", "fastavro is a required dependency for using " "bag.read_avro()."
+        "fastavro", "fastavro is a required dependency for using bag.read_avro()."
     )
 
     storage_options = storage_options or {}
@@ -237,7 +237,7 @@ def to_avro(
     from dask.bytes.core import open_files
 
     import_required(
-        "fastavro", "fastavro is a required dependency for using " "bag.to_avro()."
+        "fastavro", "fastavro is a required dependency for using bag.to_avro()."
     )
     _verify_schema(schema)
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1690,7 +1690,7 @@ class Bag(DaskMethodsMixin):
         """
         if not _implement_accumulate:
             raise NotImplementedError(
-                "accumulate requires `toolz` > 0.7.4" " or `cytoolz` > 0.7.3."
+                "accumulate requires `toolz` > 0.7.4 or `cytoolz` > 0.7.3."
             )
         token = tokenize(self, binop, initial)
         binop_name = funcname(binop)

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -97,7 +97,12 @@ def test_urlpath_inference_errors():
     # Unknown type
     with pytest.raises(TypeError):
         get_fs_token_paths(
-            {"sets/are.csv", "unordered/so/they.csv", "should/not/be.csv" "allowed.csv"}
+            {
+                "sets/are.csv",
+                "unordered/so/they.csv",
+                "should/not/be.csv",
+                "allowed.csv",
+            }
         )
 
 

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -167,7 +167,7 @@ else:
                 raise
 
     def _make_reraise():
-        _code = "def reraise(exc, tb=None):" "    raise type(exc), exc, tb"
+        _code = "def reraise(exc, tb=None): raise type(exc), exc, tb"
         namespace = {}
         exec("exec _code in namespace")
         return namespace["reraise"]

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -522,9 +522,7 @@ Dask Name: {name}, {task} tasks""".format(
 
     def _scalarfunc(self, cast_type):
         def wrapper():
-            raise TypeError(
-                "cannot convert the series to " "{0}".format(str(cast_type))
-            )
+            raise TypeError("cannot convert the series to {0}".format(str(cast_type)))
 
         return wrapper
 
@@ -884,7 +882,7 @@ Dask Name: {name}, {task} tasks""".format(
             func, target = func
             if target in kwargs:
                 raise ValueError(
-                    "%s is both the pipe target and a keyword " "argument" % target
+                    "%s is both the pipe target and a keyword argument" % target
                 )
             kwargs[target] = self
             return func(*args, **kwargs)
@@ -2974,9 +2972,7 @@ Dask Name: {name}, {task} tasks""".format(
         if not isinstance(other, Series):
             raise TypeError("other must be a dask.dataframe.Series")
         if method != "pearson":
-            raise NotImplementedError(
-                "Only Pearson correlation has been " "implemented"
-            )
+            raise NotImplementedError("Only Pearson correlation has been implemented")
         df = concat([self, other], axis=1)
         return cov_corr(
             df, min_periods, corr=True, scalar=True, split_every=split_every
@@ -3555,7 +3551,7 @@ class DataFrame(_Frame):
             inplace = False
         if "=" in expr and inplace in (True, None):
             raise NotImplementedError(
-                "Inplace eval not supported." " Please use inplace=False"
+                "Inplace eval not supported. Please use inplace=False"
             )
         meta = self._meta.eval(expr, inplace=inplace, **kwargs)
         return self.map_partitions(M.eval, expr, meta=meta, inplace=inplace, **kwargs)
@@ -3588,7 +3584,7 @@ class DataFrame(_Frame):
 
         elif axis == 0:
             raise NotImplementedError(
-                "{0} does not support " "squeeze along axis 0".format(type(self))
+                "{0} does not support squeeze along axis 0".format(type(self))
             )
 
         elif axis not in [0, 1, None]:
@@ -3988,9 +3984,7 @@ class DataFrame(_Frame):
     @derived_from(pd.DataFrame)
     def corr(self, method="pearson", min_periods=None, split_every=False):
         if method != "pearson":
-            raise NotImplementedError(
-                "Only Pearson correlation has been " "implemented"
-            )
+            raise NotImplementedError("Only Pearson correlation has been implemented")
         return cov_corr(self, min_periods, True, split_every=split_every)
 
     def info(self, buf=None, verbose=False, memory_usage=False):
@@ -4997,7 +4991,7 @@ def quantile(df, q, method="default"):
         from dask.utils import import_required
 
         import_required(
-            "crick", "crick is a required dependency for using the t-digest " "method."
+            "crick", "crick is a required dependency for using the t-digest method."
         )
 
         from dask.array.percentile import _tdigest_chunk, _percentiles_from_tdigest

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1438,7 +1438,7 @@ class _GroupBy(object):
             isinstance(item, Series) for item in self.index
         ):
             raise NotImplementedError(
-                "groupby-apply with a multiple Series " "is currently not supported"
+                "groupby-apply with a multiple Series is currently not supported"
             )
 
         df = self.obj

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -140,7 +140,7 @@ def coerce_dtypes(df, dtypes):
 
         bad_dtypes = sorted(bad_dtypes, key=lambda x: str(x[0]))
         table = asciitable(["Column", "Found", "Expected"], bad_dtypes)
-        dtype_kw = "dtype={%s}" % ",\n" "       ".join(
+        dtype_kw = "dtype={%s}" % ",\n       ".join(
             "%r: '%s'" % (k, v) for (k, v, _) in bad_dtypes
         )
 
@@ -172,7 +172,7 @@ def coerce_dtypes(df, dtypes):
 
     if bad_dtypes or bad_dates:
         rule = "\n\n%s\n\n" % ("-" * 61)
-        msg = "Mismatched dtypes found in `pd.read_csv`/`pd.read_table`.\n\n" "%s" % (
+        msg = "Mismatched dtypes found in `pd.read_csv`/`pd.read_table`.\n\n%s" % (
             rule.join(filter(None, [dtype_msg, date_msg]))
         )
         raise ValueError(msg)
@@ -349,7 +349,7 @@ def read_pandas(
         )
     for kw in ["iterator", "chunksize"]:
         if kw in kwargs:
-            raise ValueError("{0} not supported for " "dd.{1}".format(kw, reader_name))
+            raise ValueError("{0} not supported for dd.{1}".format(kw, reader_name))
     if kwargs.get("nrows", None):
         raise ValueError(
             "The 'nrows' keyword is not supported by "
@@ -371,7 +371,7 @@ def read_pandas(
         firstrow = min(set(range(len(skiprows) + 1)) - set(skiprows))
     if isinstance(kwargs.get("header"), list):
         raise TypeError(
-            "List of header rows not supported for " "dd.{0}".format(reader_name)
+            "List of header rows not supported for dd.{0}".format(reader_name)
         )
     if isinstance(kwargs.get("converters"), dict) and include_path_column:
         path_converter = kwargs.get("converters").get(include_path_column, None)

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -45,9 +45,7 @@ def _meta_from_array(x, columns=None, index=None):
             raise ValueError("For a struct dtype, columns must be a list.")
         elif not all(i in x.dtype.names for i in columns):
             extra = sorted(set(columns).difference(x.dtype.names))
-            raise ValueError(
-                "dtype {0} doesn't have fields " "{1}".format(x.dtype, extra)
-            )
+            raise ValueError("dtype {0} doesn't have fields {1}".format(x.dtype, extra))
         fields = x.dtype.fields
         dtypes = [fields[n][0] if n in fields else "f8" for n in columns]
     elif x.ndim == 1:
@@ -58,7 +56,7 @@ def _meta_from_array(x, columns=None, index=None):
                 np.array([], dtype=x.dtype), columns=columns, index=index
             )
         raise ValueError(
-            "For a 1d array, columns must be a scalar or single " "element list"
+            "For a 1d array, columns must be a scalar or single element list"
         )
     else:
         if np.isnan(x.shape[1]):

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -201,9 +201,7 @@ def read_parquet(
                 index_in_columns = True
                 index = [out[0]["name"]]
             elif index != [out[0]["name"]]:
-                raise ValueError(
-                    "Specified index is invalid.\n" "index: {}".format(index)
-                )
+                raise ValueError("Specified index is invalid.\nindex: {}".format(index))
         elif index is not False and len(out) > 1:
             if any(o["name"] == "index" for o in out):
                 # Use sorted column named "index" as the index
@@ -214,7 +212,7 @@ def read_parquet(
                     index_in_columns = True
                 elif index != [o["name"]]:
                     raise ValueError(
-                        "Specified index is invalid.\n" "index: {}".format(index)
+                        "Specified index is invalid.\nindex: {}".format(index)
                     )
             else:
                 # Multiple sorted columns found, cannot autodetect the index

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -364,7 +364,7 @@ class FastParquetEngine(Engine):
         if append:
             if pf.file_scheme not in ["hive", "empty", "flat"]:
                 raise ValueError(
-                    "Requested file scheme is hive, " "but existing file scheme is not."
+                    "Requested file scheme is hive, but existing file scheme is not."
                 )
             elif (set(pf.columns) != set(df.columns) - set(partition_on)) or (
                 set(partition_on) != set(pf.cats)

--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -107,7 +107,7 @@ def read_sql_table(
     )
     if not isinstance(index_col, string_types + (elements.Label,)):
         raise ValueError(
-            "Use label when passing an SQLAlchemy instance" " as the index (%s)" % index
+            "Use label when passing an SQLAlchemy instance as the index (%s)" % index
         )
     if divisions and npartitions:
         raise TypeError("Must supply either divisions or npartitions, not both")
@@ -147,7 +147,7 @@ def read_sql_table(
     else:
         if divisions is None and npartitions is None:
             raise ValueError(
-                "Must provide divisions or npartitions when" "using explicit meta."
+                "Must provide divisions or npartitions when using explicit meta."
             )
 
     if divisions is None:

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -792,11 +792,9 @@ def test_auto_blocksize_csv(monkeypatch):
 def test_head_partial_line_fix():
     files = {
         ".overflow1.csv": (
-            "a,b\n" '0,"abcdefghijklmnopqrstuvwxyz"\n' '1,"abcdefghijklmnopqrstuvwxyz"'
+            "a,b\n0,'abcdefghijklmnopqrstuvwxyz'\n1,'abcdefghijklmnopqrstuvwxyz'"
         ),
-        ".overflow2.csv": (
-            "a,b\n" "111111,-11111\n" "222222,-22222\n" "333333,-33333\n"
-        ),
+        ".overflow2.csv": ("a,b\n111111,-11111\n222222,-22222\n333333,-33333\n"),
     }
     with filetexts(files):
         # 64 byte file, 52 characters is mid-quote; this should not cause exception in head-handling code.
@@ -1160,9 +1158,7 @@ def test_robust_column_mismatch():
 
 
 def test_error_if_sample_is_too_small():
-    text = (
-        "AAAAA,BBBBB,CCCCC,DDDDD,EEEEE\n" "1,2,3,4,5\n" "6,7,8,9,10\n" "11,12,13,14,15"
-    )
+    text = "AAAAA,BBBBB,CCCCC,DDDDD,EEEEE\n1,2,3,4,5\n6,7,8,9,10\n11,12,13,14,15"
     with filetext(text) as fn:
         # Sample size stops mid header row
         sample = 20
@@ -1174,7 +1170,7 @@ def test_error_if_sample_is_too_small():
             dd.read_csv(fn, sample=sample, header=None), pd.read_csv(fn, header=None)
         )
 
-    skiptext = "# skip\n" "# these\n" "# lines\n"
+    skiptext = "# skip\n# these\n# lines\n"
 
     text = skiptext + text
     with filetext(text) as fn:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2532,8 +2532,7 @@ def test_apply():
 
 
 @pytest.mark.skipif(
-    PY2,
-    reason="Global filter is applied by another library, and " "not reset properly.",
+    PY2, reason="Global filter is applied by another library, and not reset properly."
 )
 def test_apply_warns():
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -336,7 +336,7 @@ def make_meta_object(x, index=None):
     elif isinstance(x, (list, tuple)):
         if not all(isinstance(i, tuple) and len(i) == 2 for i in x):
             raise ValueError(
-                "Expected iterable of tuples of (name, dtype), " "got {0}".format(x)
+                "Expected iterable of tuples of (name, dtype), got {0}".format(x)
             )
         return pd.DataFrame(
             {c: _empty_series(c, d, index=index) for (c, d) in x},
@@ -448,7 +448,7 @@ def _nonempty_index(idx):
             return pd.MultiIndex(levels=levels, labels=codes, names=idx.names)
 
     raise TypeError(
-        "Don't know how to handle index of " "type {0}".format(typename(type(idx)))
+        "Don't know how to handle index of type {0}".format(typename(type(idx)))
     )
 
 
@@ -497,7 +497,7 @@ def _nonempty_scalar(x):
         dtype = x.dtype if hasattr(x, "dtype") else np.dtype(type(x))
         return make_scalar(dtype)
 
-    raise TypeError("Can't handle meta of type " "'{0}'".format(typename(type(x))))
+    raise TypeError("Can't handle meta of type '{0}'".format(typename(type(x))))
 
 
 @meta_nonempty.register(pd.Series)
@@ -600,7 +600,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
         )
 
     if type(x) != type(meta):
-        errmsg = "Expected partition of type `%s` but got " "`%s`" % (
+        errmsg = "Expected partition of type `%s` but got `%s`" % (
             typename(type(meta)),
             typename(type(x)),
         )

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -418,7 +418,7 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
     if task is obj:
         if not (nout is None or (type(nout) is int and nout >= 0)):
             raise ValueError(
-                "nout must be None or a non-negative integer," " got %s" % nout
+                "nout must be None or a non-negative integer, got %s" % nout
             )
         if not name:
             try:
@@ -525,13 +525,13 @@ class Delayed(DaskMethodsMixin, OperatorMethodMixin):
 
     def __iter__(self):
         if getattr(self, "_length", None) is None:
-            raise TypeError("Delayed objects of unspecified length are " "not iterable")
+            raise TypeError("Delayed objects of unspecified length are not iterable")
         for i in range(self._length):
             yield self[i]
 
     def __len__(self):
         if getattr(self, "_length", None) is None:
-            raise TypeError("Delayed objects of unspecified length have " "no len()")
+            raise TypeError("Delayed objects of unspecified length have no len()")
         return self._length
 
     def __call__(self, *args, **kwargs):

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -235,7 +235,7 @@ class _Tracker(Process):
     def run(self):
 
         psutil = import_required(
-            "psutil", "Tracking resource usage requires " "`psutil` to be installed"
+            "psutil", "Tracking resource usage requires `psutil` to be installed"
         )
         self.parent = psutil.Process(self.parent_pid)
 

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -57,7 +57,7 @@ class RemoteException(Exception):
         self.traceback = traceback
 
     def __str__(self):
-        return str(self.exception) + "\n\n" "Traceback\n" "---------\n" + self.traceback
+        return str(self.exception) + "\n\nTraceback\n---------\n" + self.traceback
 
     def __dir__(self):
         return sorted(set(dir(type(self)) + list(self.__dict__) + dir(self.exception)))

--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -137,7 +137,7 @@ def test_thread_safety():
 
 @pytest.mark.xfail(
     "xdist" in sys.modules,
-    reason=("This test fails intermittently when using " "pytest-xdist (maybe)"),
+    reason="This test fails intermittently when using pytest-xdist (maybe)",
 )
 def test_interrupt():
     # Python 2 and windows 2 & 3 both implement `queue.get` using polling,

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -550,13 +550,13 @@ def ignore_warning(doc, cls, name, extra=""):
     import inspect
 
     if inspect.isclass(cls):
-        l1 = "This docstring was copied from %s.%s.%s. \n\n" "" % (
+        l1 = "This docstring was copied from %s.%s.%s. \n\n" % (
             cls.__module__,
             cls.__name__,
             name,
         )
     else:
-        l1 = "This docstring was copied from %s.%s. \n\n" "" % (cls.__name__, name)
+        l1 = "This docstring was copied from %s.%s. \n\n" % (cls.__name__, name)
     l2 = "Some inconsistencies with the Dask version may exist."
 
     i = doc.find("\n\n")


### PR DESCRIPTION
After running black, several places in our codebase were rewritten from
something like

```
raise ValueError("part one of the message "
                 "part two")
```

to

```
raise ValueError("part one of the message " "part two")
```

This fixes those cases, removing the unnecessary two-part string.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
