### PR TITLE
Put conda-forge over defaults in windows tests

### DIFF
--- a/continuous_integration/appveyor/environment.yaml
+++ b/continuous_integration/appveyor/environment.yaml
@@ -1,6 +1,7 @@
 name: testenv
 channels:
   - conda-forge
+  - defaults
 dependencies:
   # required dependencies
   - python=3.6.*

--- a/continuous_integration/appveyor/environment.yaml
+++ b/continuous_integration/appveyor/environment.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.6.*
-  - numpy<=1.16.4
+  - numpy>=1.13.0,<=1.16.4    # >= 1.17.0 breaks from https://github.com/pydata/sparse/issues/257
   - pandas>=0.21.0
   - pytest
   - cloudpickle

--- a/continuous_integration/appveyor/environment.yaml
+++ b/continuous_integration/appveyor/environment.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.6.*
-  - numpy>=1.13.0
+  - numpy<=1.16.4
   - pandas>=0.21.0
   - pytest
   - cloudpickle


### PR DESCRIPTION
Our windows tests are currently failing, likely due to a difference in
environment (numba 0.45.0 is being used from defaults in appveyor, numba
0.45.1 is being used from conda-forge on travis). We update our
environment.yml to specify using conda-forge over defaults when
possible.