### PR TITLE
Error nicely if no file size inferred

### DIFF
--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -123,8 +123,8 @@ def read_bytes(
             size = fs.info(path)["size"]
             if size is None:
                 raise ValueError(
-                    "Backing filesystem doesn't provide file size information, "
-                    "cannot do chunked reads. To read, set blocksize=None"
+                    "Backing filesystem couldn't determine file size, cannot "
+                    "do chunked reads. To read, set blocksize=None."
                 )
             off = list(range(0, size, blocksize))
             length = [blocksize] * len(off)

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -117,10 +117,15 @@ def read_bytes(
                 comp = compression
             if comp is not None:
                 raise ValueError(
-                    "Cannot do chunked reads on compressed files."
+                    "Cannot do chunked reads on compressed files. "
                     "To read, set blocksize=None"
                 )
             size = fs.info(path)["size"]
+            if size is None:
+                raise ValueError(
+                    "Backing filesystem doesn't provide file size information, "
+                    "cannot do chunked reads. To read, set blocksize=None"
+                )
             off = list(range(0, size, blocksize))
             length = [blocksize] * len(off)
             if not_zero:

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -177,3 +177,15 @@ def test_bag():
     b = db.read_text(urls)
     assert b.npartitions == 2
     b.compute()
+
+
+@pytest.mark.xfail(reason="https://github.com/dask/dask/pull/5231")
+@pytest.mark.network
+def test_read_csv():
+    dd = pytest.importorskip("dask.dataframe")
+    url = (
+        "https://raw.githubusercontent.com/weierophinney/pastebin/"
+        "master/public/js-src/dojox/data/tests/stores/patterns.csv"
+    )
+    b = dd.read_csv(url)
+    b.compute()

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -3,6 +3,8 @@ import pytest
 import subprocess
 import sys
 import time
+import fsspec
+from distutils.version import LooseVersion
 
 from dask.bytes.core import open_files
 from dask.compatibility import PY2
@@ -179,7 +181,10 @@ def test_bag():
     b.compute()
 
 
-@pytest.mark.xfail(reason="https://github.com/dask/dask/pull/5231")
+@pytest.mark.xfail(
+    LooseVersion(fsspec.__version__) <= "0.4.1",
+    reason="https://github.com/dask/dask/pull/5231",
+)
 @pytest.mark.network
 def test_read_csv():
     dd = pytest.importorskip("dask.dataframe")


### PR DESCRIPTION
Error nicely for filesystems that fail to provide file size information.

This can happen with e.g. the http filesystem.

I wasn't sure how to test this, it will currently fail for the http filesystem until fsspec is released with the patch in https://github.com/intake/filesystem_spec/pull/93. I'm fine without a test for now if others are.

Fixes https://github.com/dask/dask/issues/5222.