### PR TITLE
Adds table of contents to why dask page

### DIFF
--- a/docs/source/why.rst
+++ b/docs/source/why.rst
@@ -3,8 +3,7 @@ Why Dask?
 
 This document gives high-level motivation on why people choose to adopt Dask.
 
-.. toctree::
-   :maxdepth: 1
+.. contents:: :local:
 
 Python's role in Data Science
 -----------------------------


### PR DESCRIPTION
This PR adds a table of contents to the top of the "Why Dask?" page which links to the sections throughout the page

xref https://github.com/dask/community/issues/2