### PR TITLE
Rechunking arrays with empty chunks

### DIFF
--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -98,6 +98,8 @@ def _intersect_1d(breaks):
         end = br - last_br + start
         last_end = end
         if br == last_br:
+            if label == "o":
+                old_idx += 1
             continue
         ret_next.append((old_idx, slice(start, end)))
         if label == "o":

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -626,6 +626,12 @@ def test_rechunk_zero_dim():
     assert len(x.compute()) == 0
 
 
+def test_rechunk_empty_chunks():
+    x = da.zeros((7, 24), chunks=((7,), (10, 0, 0, 9, 0, 5)))
+    y = x.rechunk((2, 3))
+    assert_eq(x, y)
+
+
 def test_rechunk_avoid_needless_chunking():
     x = da.ones(16, chunks=2)
     y = x.rechunk(8)


### PR DESCRIPTION
It looks like our current `rechunk` implementation can fail when there are empty chunks present. For example:

```python
import dask.array as da

# Create array with empty chunks
x = da.zeros((7, 24), chunks=((7,), (10, 0, 0, 9, 0, 5)))
# Rechunk array
y = x.rechunk((-1, -1))
print(f'x.shape, x.compute().shape = {x.shape}, {x.compute().shape}')
print(f'y.shape, y.compute().shape = {y.shape}, {y.compute().shape}')
```

Rechunking shouldn't impact the output shape of `y`. However, running this example on the current `master` branch gives:

```
x.shape, x.compute().shape = (7, 24), (7, 24)
y.shape, y.compute().shape = (7, 24), (7, 10)
```

I was able to track down the problem to `_intersect_1d` (in `dask/array/rechunk.py`) not properly incrementing the chunk index for the "old" (pre-rechunking) chunking scheme in the case where empty chunks are present. This PR adds logic to ensure the chunk index is always incremented, even when there are empty chunks. 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
