### PR TITLE
Improve messaging around sorted parquet columns for index

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -221,7 +221,7 @@ def read_parquet(
                     "autodetect index. Will continue without an index.\n"
                     "To pick an index column, use the index= kwargs; to \n"
                     "silence this warning use index=False."
-                    "" % [o['name'] for o in out],
+                    "" % [o["name"] for o in out],
                     RuntimeWarning,
                 )
                 index = False

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -219,7 +219,7 @@ def read_parquet(
                 warnings.warn(
                     "Multiple sorted columns found %s, cannot\n "
                     "autodetect index. Will continue without an index.\n"
-                    "To pick an index column, use the index= kwargs; to \n"
+                    "To pick an index column, use the index= keyword; to \n"
                     "silence this warning use index=False."
                     "" % [o["name"] for o in out],
                     RuntimeWarning,

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -217,7 +217,11 @@ def read_parquet(
             else:
                 # Multiple sorted columns found, cannot autodetect the index
                 warnings.warn(
-                    "Multiple sorted columns found, cannot autodetect index",
+                    "Multiple sorted columns found %s, cannot\n "
+                    "autodetect index. Will continue without an index.\n"
+                    "To pick an index column, use the index= kwargs; to \n"
+                    "silence this warning use index=False."
+                    "" % [o['name'] for o in out],
                     RuntimeWarning,
                 )
                 index = False

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1701,14 +1701,15 @@ def test_arrow_partitioning(tmpdir):
 
 def test_sorted_warnings(tmpdir, engine):
     tmpdir = str(tmpdir)
-    df = dd.from_pandas(pd.DataFrame({'cola': range(10), 'colb': range(10)},),
-                        npartitions=2)
+    df = dd.from_pandas(
+        pd.DataFrame({"cola": range(10), "colb": range(10)}), npartitions=2
+    )
     df.to_parquet(tmpdir, engine=engine, write_index=False)
     with pytest.warns(RuntimeWarning) as record:
         out = dd.read_parquet(tmpdir, engine=engine)
     assert "['cola', 'colb']" in str(record[-1].message)
     warnings = len(record)
-    assert out.columns.tolist() == ['cola', 'colb']
+    assert out.columns.tolist() == ["cola", "colb"]
     with pytest.warns(None) as record:
         dd.read_parquet(tmpdir, engine=engine, index=False)
     assert len(record) < warnings  # still may have some arrow warnings


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Fixes #5260