### PR TITLE
Add meta= keyword to map_blocks and add test with sparse

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -391,7 +391,18 @@ def normalize_arg(x):
         return x
 
 
-def map_blocks(func, *args, **kwargs):
+def map_blocks(
+    func,
+    *args,
+    name=None,
+    token=None,
+    dtype=None,
+    chunks=None,
+    drop_axis=[],
+    new_axis=None,
+    meta=None,
+    **kwargs
+):
     """ Map a function across all blocks of a dask array.
 
     Parameters
@@ -541,17 +552,11 @@ def map_blocks(func, *args, **kwargs):
             "   or:   da.map_blocks(function, x, y, z)"
         )
         raise TypeError(msg % type(func).__name__)
-    name = kwargs.pop("name", None)
-    token = kwargs.pop("token", None)
     if token:
         warnings.warn("The token= keyword to map_blocks has been moved to name=")
         name = token
 
     name = "%s-%s" % (name or funcname(func), tokenize(func, *args, **kwargs))
-    dtype = kwargs.pop("dtype", None)
-    chunks = kwargs.pop("chunks", None)
-    drop_axis = kwargs.pop("drop_axis", [])
-    new_axis = kwargs.pop("new_axis", None)
     new_axes = {}
 
     if isinstance(drop_axis, Number):
@@ -577,7 +582,7 @@ def map_blocks(func, *args, **kwargs):
 
     original_kwargs = kwargs
 
-    if dtype is None:
+    if dtype is None and meta is None:
         dtype = apply_infer_dtype(func, args, original_kwargs, "map_blocks")
 
     if drop_axis:
@@ -606,6 +611,7 @@ def map_blocks(func, *args, **kwargs):
         dtype=dtype,
         concatenate=True,
         align_arrays=False,
+        meta=meta,
         **kwargs
     )
 

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -202,3 +202,16 @@ def test_from_array():
     assert isinstance(d._meta, sparse.COO)
     assert_eq(d, d)
     assert isinstance(d.compute(), sparse.COO)
+
+
+def test_map_blocks():
+    x = da.eye(10, chunks=5)
+    y = x.map_blocks(sparse.COO.from_numpy, meta=sparse.COO.from_numpy(np.eye(1)))
+    assert isinstance(y._meta, sparse.COO)
+    assert_eq(y, y)
+
+
+def test_meta_from_array():
+    x = sparse.COO.from_numpy(np.eye(1))
+    y = da.utils.meta_from_array(x, ndim=2)
+    assert isinstance(y, sparse.COO)


### PR DESCRIPTION
cc @pentschev because of `meta=`

cc @quasiben because we were trying to use `meta=` with map_blocks.

Test fails due to https://github.com/pydata/sparse/issues/276 for now

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
