### PR TITLE
fix DataFrame.query docstring (incorrect numexpr API)

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3550,7 +3550,7 @@ class DataFrame(_Frame):
         single thread
 
             import numexpr
-            numexpr.set_nthreads(1)
+            numexpr.set_num_threads(1)
 
         See also
         --------


### PR DESCRIPTION
`DataFrame.query` recommends setting `numexpr` to use a single thread, the function in the code snippet was incorrect (https://github.com/pydata/numexpr/blob/master/numexpr/utils.py#L81)

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
