### PR TITLE
Array.random.choice: handle array-like non-arrays

### DIFF
--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -222,7 +222,8 @@ class RandomState(object):
                 if a < 0:
                     raise ValueError("a must be greater than 0")
             else:
-                a = asarray(a).rechunk(a.shape)
+                a = asarray(a)
+                a = a.rechunk(a.shape)
                 dtype = a.dtype
                 if a.ndim != 1:
                     raise ValueError("a must be one dimensional")

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -237,14 +237,16 @@ def test_choice():
     assert res.dtype == np_dtype
     assert res.shape == size
 
-    np_a = np.array([1, 3, 5, 7, 9], dtype="f8")
+    py_a = [1, 3, 5, 7, 9]
+    np_a = np.array(py_a, dtype="f8")
     da_a = da.from_array(np_a, chunks=2)
 
-    for a in [np_a, da_a]:
+    for a in [py_a, np_a, da_a]:
         x = da.random.choice(a, size=size, chunks=chunks)
         res = x.compute()
-        assert x.dtype == np_a.dtype
-        assert res.dtype == np_a.dtype
+        expected_dtype = np.asarray(a).dtype
+        assert x.dtype == expected_dtype
+        assert res.dtype == expected_dtype
         assert set(np.unique(res)).issubset(np_a)
 
     np_p = np.array([0, 0.2, 0.2, 0.3, 0.3])


### PR DESCRIPTION
```python
In [1]: import dask.array as da

In [2]: import numpy as np

In [3]: np.random.choice([True, False], 4)
Out[3]: array([ True, False,  True, False])

In [4]: da.random.choice([True, False], 4)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-33075a6cbfe5> in <module>()
----> 1 da.random.choice([True, False], 4)

/home/gabejoseph/.cache/bazel/_bazel_gabejoseph/cbd078f976ef86a52da9fe15f5a84af9/execroot/__main__/bazel-out/k8-opt/bin/descarteslabs/services/workbench/impl/repl.runf
iles/requirements_py3_pypi__dask_1_2_2_41_g32f0fac0/dask/array/random.py in choice(self, a, size, replace, p, chunks)
    201                     raise ValueError("a must be greater than 0")
    202             else:
--> 203                 a = asarray(a).rechunk(a.shape)
    204                 dtype = a.dtype
    205                 if a.ndim != 1:

AttributeError: 'list' object has no attribute 'shape'
```

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
