### PR TITLE
Add chunktype to array text repr

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1157,11 +1157,13 @@ class Array(DaskMethodsMixin):
         """
         chunksize = str(self.chunksize)
         name = self.name.rsplit("-", 1)[0]
-        return "dask.array<%s, shape=%s, dtype=%s, chunksize=%s>" % (
+        return "dask.array<%s, shape=%s, dtype=%s, chunksize=%s, meta=%s.%s>" % (
             name,
             self.shape,
             self.dtype,
             chunksize,
+            type(self._meta).__module__.split(".")[0],
+            type(self._meta).__name__,
         )
 
     def _repr_html_(self):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -492,7 +492,7 @@ def map_blocks(
     ...     return np.array([a.max(), b.max()])
 
     >>> da.map_blocks(func, x, y, chunks=(2,), dtype='i8')
-    dask.array<func, shape=(20,), dtype=int64, chunksize=(2,), meta=numpy.ndarray>
+    dask.array<func, shape=(20,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>
 
     >>> _.compute()
     array([ 99,   9, 199,  19, 299,  29, 399,  39, 499,  49, 599,  59, 699,
@@ -534,7 +534,7 @@ def map_blocks(
     ...     return np.arange(loc[0], loc[1])
 
     >>> da.map_blocks(func, chunks=((4, 4),), dtype=np.float_)
-    dask.array<func, shape=(8,), dtype=float64, chunksize=(4,), meta=numpy.ndarray>
+    dask.array<func, shape=(8,), dtype=float64, chunksize=(4,), chunktype=numpy.ndarray>
 
     >>> _.compute()
     array([0, 1, 2, 3, 4, 5, 6, 7])
@@ -543,7 +543,7 @@ def map_blocks(
     the optional ``token`` keyword argument.
 
     >>> x.map_blocks(lambda x: x + 1, name='increment')  # doctest: +SKIP
-    dask.array<increment, shape=(100,), dtype=int64, chunksize=(10,), meta=numpy.ndarray>
+    dask.array<increment, shape=(100,), dtype=int64, chunksize=(10,), chunktype=numpy.ndarray>
     """
     if not callable(func):
         msg = (
@@ -1153,11 +1153,11 @@ class Array(DaskMethodsMixin):
 
         >>> import dask.array as da
         >>> da.ones((10, 10), chunks=(5, 5), dtype='i4')
-        dask.array<..., shape=(10, 10), dtype=int32, chunksize=(5, 5), meta=numpy.ndarray>
+        dask.array<..., shape=(10, 10), dtype=int32, chunksize=(5, 5), chunktype=numpy.ndarray>
         """
         chunksize = str(self.chunksize)
         name = self.name.rsplit("-", 1)[0]
-        return "dask.array<%s, shape=%s, dtype=%s, chunksize=%s, meta=%s.%s>" % (
+        return "dask.array<%s, shape=%s, dtype=%s, chunksize=%s, chunktype=%s.%s>" % (
             name,
             self.shape,
             self.dtype,
@@ -2892,7 +2892,7 @@ def from_delayed(value, shape, dtype=None, meta=None, name=None):
     >>> value = dask.delayed(np.ones)(5)
     >>> array = da.from_delayed(value, (5,), dtype=float)
     >>> array
-    dask.array<from-value, shape=(5,), dtype=float64, chunksize=(5,), meta=numpy.ndarray>
+    dask.array<from-value, shape=(5,), dtype=float64, chunksize=(5,), chunktype=numpy.ndarray>
     >>> array.compute()
     array([1., 1., 1., 1., 1.])
     """
@@ -3571,11 +3571,11 @@ def asarray(a, **kwargs):
     >>> import numpy as np
     >>> x = np.arange(3)
     >>> da.asarray(x)
-    dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), meta=numpy.ndarray>
+    dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), chunktype=numpy.ndarray>
 
     >>> y = [[1, 2, 3], [4, 5, 6]]
     >>> da.asarray(y)
-    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3), meta=numpy.ndarray>
+    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3), chunktype=numpy.ndarray>
     """
     if isinstance(a, Array):
         return a
@@ -3609,11 +3609,11 @@ def asanyarray(a):
     >>> import numpy as np
     >>> x = np.arange(3)
     >>> da.asanyarray(x)
-    dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), meta=numpy.ndarray>
+    dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), chunktype=numpy.ndarray>
 
     >>> y = [[1, 2, 3], [4, 5, 6]]
     >>> da.asanyarray(y)
-    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3), meta=numpy.ndarray>
+    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3), chunktype=numpy.ndarray>
     """
     if isinstance(a, Array):
         return a

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -492,7 +492,7 @@ def map_blocks(
     ...     return np.array([a.max(), b.max()])
 
     >>> da.map_blocks(func, x, y, chunks=(2,), dtype='i8')
-    dask.array<func, shape=(20,), dtype=int64, chunksize=(2,)>
+    dask.array<func, shape=(20,), dtype=int64, chunksize=(2,), meta=numpy.ndarray>
 
     >>> _.compute()
     array([ 99,   9, 199,  19, 299,  29, 399,  39, 499,  49, 599,  59, 699,
@@ -534,7 +534,7 @@ def map_blocks(
     ...     return np.arange(loc[0], loc[1])
 
     >>> da.map_blocks(func, chunks=((4, 4),), dtype=np.float_)
-    dask.array<func, shape=(8,), dtype=float64, chunksize=(4,)>
+    dask.array<func, shape=(8,), dtype=float64, chunksize=(4,), meta=numpy.ndarray>
 
     >>> _.compute()
     array([0, 1, 2, 3, 4, 5, 6, 7])
@@ -543,7 +543,7 @@ def map_blocks(
     the optional ``token`` keyword argument.
 
     >>> x.map_blocks(lambda x: x + 1, name='increment')  # doctest: +SKIP
-    dask.array<increment, shape=(100,), dtype=int64, chunksize=(10,)>
+    dask.array<increment, shape=(100,), dtype=int64, chunksize=(10,), meta=numpy.ndarray>
     """
     if not callable(func):
         msg = (
@@ -1153,7 +1153,7 @@ class Array(DaskMethodsMixin):
 
         >>> import dask.array as da
         >>> da.ones((10, 10), chunks=(5, 5), dtype='i4')
-        dask.array<..., shape=(10, 10), dtype=int32, chunksize=(5, 5)>
+        dask.array<..., shape=(10, 10), dtype=int32, chunksize=(5, 5), meta=numpy.ndarray>
         """
         chunksize = str(self.chunksize)
         name = self.name.rsplit("-", 1)[0]
@@ -2892,7 +2892,7 @@ def from_delayed(value, shape, dtype=None, meta=None, name=None):
     >>> value = dask.delayed(np.ones)(5)
     >>> array = da.from_delayed(value, (5,), dtype=float)
     >>> array
-    dask.array<from-value, shape=(5,), dtype=float64, chunksize=(5,)>
+    dask.array<from-value, shape=(5,), dtype=float64, chunksize=(5,), meta=numpy.ndarray>
     >>> array.compute()
     array([1., 1., 1., 1., 1.])
     """
@@ -3571,11 +3571,11 @@ def asarray(a, **kwargs):
     >>> import numpy as np
     >>> x = np.arange(3)
     >>> da.asarray(x)
-    dask.array<array, shape=(3,), dtype=int64, chunksize=(3,)>
+    dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), meta=numpy.ndarray>
 
     >>> y = [[1, 2, 3], [4, 5, 6]]
     >>> da.asarray(y)
-    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3)>
+    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3), meta=numpy.ndarray>
     """
     if isinstance(a, Array):
         return a
@@ -3609,11 +3609,11 @@ def asanyarray(a):
     >>> import numpy as np
     >>> x = np.arange(3)
     >>> da.asanyarray(x)
-    dask.array<array, shape=(3,), dtype=int64, chunksize=(3,)>
+    dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), meta=numpy.ndarray>
 
     >>> y = [[1, 2, 3], [4, 5, 6]]
     >>> da.asanyarray(y)
-    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3)>
+    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3), meta=numpy.ndarray>
     """
     if isinstance(a, Array):
         return a

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1419,6 +1419,16 @@ def test_repr():
     assert len(str(d)) < 1000
 
 
+def test_repr_meta():
+    d = da.ones((4, 4), chunks=(2, 2))
+    assert "meta=numpy.ndarray" in repr(d)
+
+    # Test non-numpy meta
+    sparse = pytest.importorskip("sparse")
+    s = d.map_blocks(sparse.COO)
+    assert "meta=sparse.COO" in repr(s)
+
+
 def test_slicing_with_ellipsis():
     x = np.arange(256).reshape((4, 4, 4, 4))
     d = da.from_array(x, chunks=((2, 2, 2, 2)))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1421,12 +1421,12 @@ def test_repr():
 
 def test_repr_meta():
     d = da.ones((4, 4), chunks=(2, 2))
-    assert "meta=numpy.ndarray" in repr(d)
+    assert "chunktype=numpy.ndarray" in repr(d)
 
     # Test non-numpy meta
     sparse = pytest.importorskip("sparse")
     s = d.map_blocks(sparse.COO)
-    assert "meta=sparse.COO" in repr(s)
+    assert "chunktype=sparse.COO" in repr(s)
 
 
 def test_slicing_with_ellipsis():

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -516,7 +516,7 @@ def to_records(df):
     Examples
     --------
     >>> df.to_records()  # doctest: +SKIP
-    dask.array<to_records, shape=(nan,), dtype=(numpy.record, [('ind', '<f8'), ('x', 'O'), ('y', '<i8')]), chunksize=(nan,), meta=numpy.ndarray>  # noqa: E501
+    dask.array<to_records, shape=(nan,), dtype=(numpy.record, [('ind', '<f8'), ('x', 'O'), ('y', '<i8')]), chunksize=(nan,), chunktype=numpy.ndarray>  # noqa: E501
 
     See Also
     --------

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -516,7 +516,7 @@ def to_records(df):
     Examples
     --------
     >>> df.to_records()  # doctest: +SKIP
-    dask.array<shape=(nan,), dtype=(numpy.record, [('ind', '<f8'), ('x', 'O'), ('y', '<i8')]), chunksize=(nan,)>
+    dask.array<to_records, shape=(nan,), dtype=(numpy.record, [('ind', '<f8'), ('x', 'O'), ('y', '<i8')]), chunksize=(nan,), meta=numpy.ndarray>  # noqa: E501
 
     See Also
     --------

--- a/docs/source/array-chunks.rst
+++ b/docs/source/array-chunks.rst
@@ -83,7 +83,7 @@ This can also happen when creating a Dask array from a Dask DataFrame:
 
    >>> ddf = dask.dataframe.from_pandas(...)
    >>> ddf.to_dask_array()
-   ... dask.array<values, shape=(nan, 2), dtype=float64, chunksize=(nan, 2), meta=numpy.ndarray>
+   ... dask.array<values, shape=(nan, 2), dtype=float64, chunksize=(nan, 2), chunktype=numpy.ndarray>
 
 For details on how to avoid unknown chunk sizes, look at how to create a Dask
 array from a Dask DataFrame in the :doc:`documentation on Dask array creation
@@ -268,4 +268,4 @@ These values can also be used when creating arrays with operations like
 .. code-block:: python
 
    >>> dask.array.ones((10000, 10000), chunks=(-1, 'auto'))
-   dask.array<wrapped, shape=(10000, 10000), dtype=float64, chunksize=(10000, 1250), meta=numpy.ndarray>
+   dask.array<wrapped, shape=(10000, 10000), dtype=float64, chunksize=(10000, 1250), chunktype=numpy.ndarray>

--- a/docs/source/array-chunks.rst
+++ b/docs/source/array-chunks.rst
@@ -83,7 +83,7 @@ This can also happen when creating a Dask array from a Dask DataFrame:
 
    >>> ddf = dask.dataframe.from_pandas(...)
    >>> ddf.to_dask_array()
-   ... dask.array<values, shape=(nan, 2), dtype=float64, chunksize=(nan, 2)>
+   ... dask.array<values, shape=(nan, 2), dtype=float64, chunksize=(nan, 2), meta=numpy.ndarray>
 
 For details on how to avoid unknown chunk sizes, look at how to create a Dask
 array from a Dask DataFrame in the :doc:`documentation on Dask array creation
@@ -268,4 +268,4 @@ These values can also be used when creating arrays with operations like
 .. code-block:: python
 
    >>> dask.array.ones((10000, 10000), chunks=(-1, 'auto'))
-   dask.array<wrapped, shape=(10000, 10000), dtype=float64, chunksize=(10000, 1250)>
+   dask.array<wrapped, shape=(10000, 10000), dtype=float64, chunksize=(10000, 1250), meta=numpy.ndarray>

--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -141,7 +141,7 @@ There are several ways to create a Dask array from a Dask DataFrame. Dask DataFr
 
    >>> df = dask.dataframes.from_pandas(...)
    >>> df.to_dask_array()
-   dask.array<values, shape=(nan, 3), dtype=float64, chunksize=(nan, 3)>
+   dask.array<values, shape=(nan, 3), dtype=float64, chunksize=(nan, 3), meta=numpy.ndarray>
 
 This mirrors the `to_numpy
 <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_numpy.html>`_
@@ -150,7 +150,7 @@ function in Pandas. The ``values`` attribute is also supported:
 .. code-block:: python
 
    >>> df.values
-   dask.array<values, shape=(nan, 3), dtype=float64, chunksize=(nan, 3)>
+   dask.array<values, shape=(nan, 3), dtype=float64, chunksize=(nan, 3), meta=numpy.ndarray>
 
 However, these arrays do not have known chunk sizes because dask.dataframe does
 not track the number of rows in each partition. This means that some operations
@@ -161,7 +161,7 @@ The chunk sizes can be computed:
 .. code-block:: python
 
    >>> df.to_dask_array(lengths=True)
-   dask.array<array, shape=(100, 3), dtype=float64, chunksize=(50, 3)>
+   dask.array<array, shape=(100, 3), dtype=float64, chunksize=(50, 3), meta=numpy.ndarray>
 
 Specifying ``lengths=True`` triggers immediate computation of the chunk sizes.
 This enables downstream computations that rely on having known chunk sizes
@@ -171,7 +171,7 @@ The Dask DataFrame ``to_records`` method also returns a Dask Array, but does not
 information:
 
    >>> df.to_records()
-   dask.array<to_records, shape=(nan,), dtype=(numpy.record, [('index', '<i8'), ('x', '<f8'), ('y', '<f8'), ('z', '<f8')]), chunksize=(nan,)>
+   dask.array<to_records, shape=(nan,), dtype=(numpy.record, [('index', '<i8'), ('x', '<f8'), ('y', '<f8'), ('z', '<f8')]), chunksize=(nan,), meta=numpy.ndarray>
 
 If you have a function that converts a Pandas DataFrame into a NumPy array,
 then calling ``map_partitions`` with that function on a Dask DataFrame will
@@ -180,7 +180,7 @@ produce a Dask array:
 .. code-block:: python
 
    >>> df.map_partitions(np.asarray)
-   dask.array<asarray, shape=(nan, 3), dtype=float64, chunksize=(nan, 3)>
+   dask.array<asarray, shape=(nan, 3), dtype=float64, chunksize=(nan, 3), meta=numpy.ndarray>
 
 
 Interactions with NumPy arrays
@@ -205,7 +205,7 @@ chunk shape:
    >>> y = np.ones(10)
    >>> z = x + y
    >>> z
-   dask.array<add, shape=(10,), dtype=float64, chunksize=(5,)>
+   dask.array<add, shape=(10,), dtype=float64, chunksize=(5,), meta=numpy.ndarray>
 
 These interactions work not just for NumPy arrays but for any object that has
 shape and dtype attributes and implements NumPy slicing syntax.

--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -141,7 +141,7 @@ There are several ways to create a Dask array from a Dask DataFrame. Dask DataFr
 
    >>> df = dask.dataframes.from_pandas(...)
    >>> df.to_dask_array()
-   dask.array<values, shape=(nan, 3), dtype=float64, chunksize=(nan, 3), meta=numpy.ndarray>
+   dask.array<values, shape=(nan, 3), dtype=float64, chunksize=(nan, 3), chunktype=numpy.ndarray>
 
 This mirrors the `to_numpy
 <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_numpy.html>`_
@@ -150,7 +150,7 @@ function in Pandas. The ``values`` attribute is also supported:
 .. code-block:: python
 
    >>> df.values
-   dask.array<values, shape=(nan, 3), dtype=float64, chunksize=(nan, 3), meta=numpy.ndarray>
+   dask.array<values, shape=(nan, 3), dtype=float64, chunksize=(nan, 3), chunktype=numpy.ndarray>
 
 However, these arrays do not have known chunk sizes because dask.dataframe does
 not track the number of rows in each partition. This means that some operations
@@ -161,7 +161,7 @@ The chunk sizes can be computed:
 .. code-block:: python
 
    >>> df.to_dask_array(lengths=True)
-   dask.array<array, shape=(100, 3), dtype=float64, chunksize=(50, 3), meta=numpy.ndarray>
+   dask.array<array, shape=(100, 3), dtype=float64, chunksize=(50, 3), chunktype=numpy.ndarray>
 
 Specifying ``lengths=True`` triggers immediate computation of the chunk sizes.
 This enables downstream computations that rely on having known chunk sizes
@@ -171,7 +171,7 @@ The Dask DataFrame ``to_records`` method also returns a Dask Array, but does not
 information:
 
    >>> df.to_records()
-   dask.array<to_records, shape=(nan,), dtype=(numpy.record, [('index', '<i8'), ('x', '<f8'), ('y', '<f8'), ('z', '<f8')]), chunksize=(nan,), meta=numpy.ndarray>
+   dask.array<to_records, shape=(nan,), dtype=(numpy.record, [('index', '<i8'), ('x', '<f8'), ('y', '<f8'), ('z', '<f8')]), chunksize=(nan,), chunktype=numpy.ndarray>
 
 If you have a function that converts a Pandas DataFrame into a NumPy array,
 then calling ``map_partitions`` with that function on a Dask DataFrame will
@@ -180,7 +180,7 @@ produce a Dask array:
 .. code-block:: python
 
    >>> df.map_partitions(np.asarray)
-   dask.array<asarray, shape=(nan, 3), dtype=float64, chunksize=(nan, 3), meta=numpy.ndarray>
+   dask.array<asarray, shape=(nan, 3), dtype=float64, chunksize=(nan, 3), chunktype=numpy.ndarray>
 
 
 Interactions with NumPy arrays
@@ -205,7 +205,7 @@ chunk shape:
    >>> y = np.ones(10)
    >>> z = x + y
    >>> z
-   dask.array<add, shape=(10,), dtype=float64, chunksize=(5,), meta=numpy.ndarray>
+   dask.array<add, shape=(10,), dtype=float64, chunksize=(5,), chunktype=numpy.ndarray>
 
 These interactions work not just for NumPy arrays but for any object that has
 shape and dtype attributes and implements NumPy slicing syntax.


### PR DESCRIPTION
This PR adds `meta=` to the text repr for dask arrays. 

```python
In [1]: import dask.array as da

In [2]: a = da.arange(10)

In [3]: a
Out[3]: dask.array<arange, shape=(10,), dtype=int64, chunksize=(10,), meta=numpy.ndarray>

In [4]: import sparse

In [5]: a.map_blocks(sparse.COO)
Out[5]: dask.array<COO, shape=(10,), dtype=int64, chunksize=(10,), meta=sparse.COO>
```


Closes #5288

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
