### PR TITLE
Labels in dot language must be positive integers

### DIFF
--- a/dask/dot.py
+++ b/dask/dot.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-import re
 import os
+import re
+import sys
 from functools import partial
 
 from .compatibility import apply
-from .core import istask, get_dependencies, ishashable
+from .core import get_dependencies, ishashable, istask
 from .utils import funcname, import_required, key_split
-
 
 graphviz = import_required(
     "graphviz",
@@ -55,11 +55,15 @@ def has_sub_tasks(task):
         return False
 
 
+def poshash(x):
+    return hash(x) % ((sys.maxsize + 1) * 2)
+
+
 def name(x):
     try:
-        return str(hash(x))
+        return str(poshash(x))
     except TypeError:
-        return str(hash(str(x)))
+        return str(poshash(str(x)))
 
 
 _HASHPAT = re.compile("([0-9a-z]{32})")


### PR DESCRIPTION
- [ x] Tests added / passed
- [ x] Passes `black dask` / `flake8 dask`

--- 

This PR is intended to make a dask graph parsable by pydot. The character `-` seem to be reserved in dot language, so I am proposing replacing the `hash` function in dot.py with `poshash` which is a positive hash key as suggested in https://stackoverflow.com/questions/18766535/positive-integer-from-python-hash-function.

--- 

```
import pydot
from dask import visualize
graph = {
    'a': 1,
    'b': 2,
    'c': [1, 2],
    'd': ['a', 'b', 'c']
}
digraph = to_graphviz(graph)
dot = pydot.graph_from_dot_data(digraph.source)
```

This code used to yield the following error: ```ParseException: Expected "}" (at char 73), (line:4, col:2)```.
It is now running correctly.

Comments are welcome.