### PR TITLE
Add shape implementation

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -31,6 +31,8 @@ try:
         where,
         coarsen,
         insert,
+        shape,
+        union1d,
         ravel,
         roll,
         unique,

--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -7,6 +7,7 @@ import warnings
 
 from ..utils import derived_from
 
+_numpy_115 = LooseVersion(np.__version__) >= "1.15.0"
 _numpy_116 = LooseVersion(np.__version__) >= "1.16.0"
 _numpy_117 = LooseVersion(np.__version__) >= "1.17.0"
 _numpy_118 = LooseVersion(np.__version__) >= "1.18.0"

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1039,6 +1039,12 @@ def roll(array, shift, axis=None):
     return result
 
 
+@implements(np.shape)
+@derived_from(np)
+def shape(array):
+    return array.shape
+
+
 @derived_from(np)
 def ravel(array):
     return array.reshape((-1,))

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1045,6 +1045,12 @@ def shape(array):
     return array.shape
 
 
+@implements(np.union1d)
+@derived_from(np)
+def union1d(ar1, ar2):
+    return unique(concatenate((ar1.ravel(), ar2.ravel())))
+
+
 @derived_from(np)
 def ravel(array):
     return array.reshape((-1,))

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1039,13 +1039,11 @@ def roll(array, shift, axis=None):
     return result
 
 
-@implements(np.shape)
 @derived_from(np)
 def shape(array):
     return array.shape
 
 
-@implements(np.union1d)
 @derived_from(np)
 def union1d(ar1, ar2):
     return unique(concatenate((ar1.ravel(), ar2.ravel())))

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -788,6 +788,12 @@ def test_roll(chunks, shift, axis):
         assert_eq(np.roll(x, shift, axis), da.roll(a, shift, axis))
 
 
+@pytest.mark.parametrize("shape", [(10,), (5, 10), (5, 10, 10)])
+def test_shape(shape):
+    x = da.random.random(shape)
+    assert np.shape(x) == shape
+
+
 def test_ravel():
     x = np.random.randint(10, size=(4, 6))
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -794,6 +794,29 @@ def test_shape(shape):
     assert np.shape(x) == shape
 
 
+@pytest.mark.parametrize(
+    "shape", [((12,), (12,)), ((4, 3), (3, 4)), ((12,), (1, 6, 2))]
+)
+@pytest.mark.parametrize("reverse", [True, False])
+def test_union1d(shape, reverse):
+    s1, s2 = shape
+    x1 = np.arange(12).reshape(s1)
+    x2 = np.arange(6, 18).reshape(s2)
+
+    if reverse:
+        x1 = x1[::-1]
+
+    dx1 = da.from_array(x1)
+    dx2 = da.from_array(x2)
+
+    result = np.union1d(dx1, dx2)
+    expected = np.union1d(x1, x2)
+
+    assert isinstance(result, da.Array)
+
+    assert_eq(result, expected)
+
+
 def test_ravel():
     x = np.random.randint(10, size=(4, 6))
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -11,7 +11,7 @@ np = pytest.importorskip("numpy")
 import dask.array as da
 from dask.compatibility import PY2
 from dask.utils import ignoring
-from dask.array.utils import assert_eq, same_keys, AxisError
+from dask.array.utils import assert_eq, same_keys, AxisError, IS_NEP18_ACTIVE
 
 
 def test_array():
@@ -812,7 +812,8 @@ def test_union1d(shape, reverse):
     result = np.union1d(dx1, dx2)
     expected = np.union1d(x1, x2)
 
-    assert isinstance(result, da.Array)
+    if IS_NEP18_ACTIVE:
+        assert isinstance(result, da.Array)
 
     assert_eq(result, expected)
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -801,7 +801,7 @@ def test_shape(shape):
 @pytest.mark.parametrize("reverse", [True, False])
 def test_union1d(shape, reverse):
     if any(len(x) > 1 for x in shape) and not _numpy_115:
-        pytest.skip(reason="NumPy-10563.")
+        pytest.skip("NumPy-10563.")
 
     s1, s2 = shape
     x1 = np.arange(12).reshape(s1)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -12,6 +12,7 @@ import dask.array as da
 from dask.compatibility import PY2
 from dask.utils import ignoring
 from dask.array.utils import assert_eq, same_keys, AxisError, IS_NEP18_ACTIVE
+from dask.array.numpy_compat import _numpy_115
 
 
 def test_array():
@@ -799,6 +800,9 @@ def test_shape(shape):
 )
 @pytest.mark.parametrize("reverse", [True, False])
 def test_union1d(shape, reverse):
+    if any(len(x) > 1 for x in shape) and not _numpy_115:
+        pytest.skip(reason="NumPy-10563.")
+
     s1, s2 = shape
     x1 = np.arange(12).reshape(s1)
     x2 = np.arange(6, 18).reshape(s2)


### PR DESCRIPTION
Fixes this warning on master

```python
In [1]: import numpy as np; import dask.array as da

In [2]: np.shape(da.arange(12))
/Users/taugspurger/sandbox/dask/dask/array/core.py:1272: FutureWarning: The `numpy.shape` function is not implemented by Dask array. You may want to use the da.map_blocks function or something similar to silence this warning. Your code may stop working in a future release.
  FutureWarning,
Out[2]: (12,)
```