### PR TITLE
Fix link in reshape docstring

### DIFF
--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -145,8 +145,7 @@ def reshape(x, shape):
     2.  It only allows for reshapings that collapse or merge dimensions like
         ``(1, 2, 3, 4) -> (1, 6, 4)`` or ``(64,) -> (4, 4, 4)``
 
-    .. _`column-major order`: https://en.wikipedia.org/wiki/
-                              Row-_and_column-major_order
+    .. _`row-major order`: https://en.wikipedia.org/wiki/Row-_and_column-major_order
 
     When communication is necessary this algorithm depends on the logic within
     rechunk.  It endeavors to keep chunk sizes roughly the same when possible.


### PR DESCRIPTION
Fixes a malformed link target in the `reshape` docstring