### PR TITLE
Fixing schema handling in arrow-parquet

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -114,7 +114,7 @@ class ArrowEngine(Engine):
         parts, dataset = _determine_dataset_parts(
             fs, paths, gather_statistics, **kwargs
         )
-
+        # import pdb; pdb.set_trace()
         if dataset.partitions is not None:
             partitions = [
                 n for n in dataset.partitions.partition_names if n is not None
@@ -122,7 +122,10 @@ class ArrowEngine(Engine):
         else:
             partitions = []
 
-        schema = dataset.schema.to_arrow_schema()
+        if dataset.metadata:
+            schema = dataset.metadata.schema.to_arrow_schema()
+        else:
+            schema = dataset.schema.to_arrow_schema()
         columns = None
 
         has_pandas_metadata = (

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -40,40 +40,35 @@ def _determine_dataset_parts(fs, paths, gather_statistics, **kwargs):
     dataset.
     """
     parts = []
+    dataset_kwargs = kwargs.get("dataset", {})
     if len(paths) > 1:
         if gather_statistics is not False:
             # This scans all the files
-            dataset = pq.ParquetDataset(
-                paths, filesystem=fs, **kwargs.get("dataset", {})
-            )
+            dataset = pq.ParquetDataset(paths, filesystem=fs, **dataset_kwargs)
         else:
             base, fns = _analyze_paths(paths, fs)
             relpaths = [path.replace(base, "").lstrip("/") for path in paths]
             if "_metadata" in relpaths:
                 # We have a _metadata file, lets use it
                 dataset = pq.ParquetDataset(
-                    base + fs.sep + "_metadata",
-                    filesystem=fs,
-                    **kwargs.get("dataset", {}),
+                    base + fs.sep + "_metadata", filesystem=fs, **dataset_kwargs
                 )
             else:
                 # Rely on metadata for 0th file.
                 # Will need to pass a list of paths to read_partition
-                dataset = pq.ParquetDataset(
-                    paths[0], filesystem=fs, **kwargs.get("dataset", {})
-                )
+                dataset = pq.ParquetDataset(paths[0], filesystem=fs, **dataset_kwargs)
                 parts = [base + fs.sep + fn for fn in fns]
     else:
         if fs.isdir(paths[0]):
             # This is a directory, check for _metadata, then _common_metadata
             allpaths = fs.glob(paths[0] + fs.sep + "*")
-            base, fns = _analyze_paths(paths, fs)
+            base, fns = _analyze_paths(allpaths, fs)
             relpaths = [path.replace(base, "").lstrip("/") for path in allpaths]
+            if "_metadata" in relpaths and "validate_schema" not in dataset_kwargs:
+                dataset_kwargs["validate_schema"] = False
             if "_metadata" in relpaths or gather_statistics is not False:
                 # Let arrow do its thing (use _metadata or scan files)
-                dataset = pq.ParquetDataset(
-                    paths, filesystem=fs, **kwargs.get("dataset", {})
-                )
+                dataset = pq.ParquetDataset(paths, filesystem=fs, **dataset_kwargs)
             else:
                 # Use _common_metadata file if it is available.
                 # Otherwise, just use 0th file
@@ -81,18 +76,16 @@ def _determine_dataset_parts(fs, paths, gather_statistics, **kwargs):
                     dataset = pq.ParquetDataset(
                         base + fs.sep + "_common_metadata",
                         filesystem=fs,
-                        **kwargs.get("dataset", {}),
+                        **dataset_kwargs,
                     )
                 else:
                     dataset = pq.ParquetDataset(
-                        allpaths[0], filesystem=fs, **kwargs.get("dataset", {})
+                        allpaths[0], filesystem=fs, **dataset_kwargs
                     )
                 parts = [base + fs.sep + fn for fn in fns]
         else:
             # There is only one file to read
-            dataset = pq.ParquetDataset(
-                paths, filesystem=fs, **kwargs.get("dataset", {})
-            )
+            dataset = pq.ParquetDataset(paths, filesystem=fs, **dataset_kwargs)
     return parts, dataset
 
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -952,7 +952,10 @@ def test_to_parquet_pyarrow_w_inconsistent_schema_by_partition_fails_by_default(
     # Test that read fails because of default behavior when schema not provided
     with pytest.raises(ValueError) as e_info:
         dd.read_parquet(
-            str(tmpdir), engine="pyarrow", gather_statistics=False
+            str(tmpdir),
+            engine="pyarrow",
+            gather_statistics=False,
+            dataset={"validate_schema": True},
         ).compute()
         assert e_info.message.contains("ValueError: Schema in partition")
         assert e_info.message.contains("was different")


### PR DESCRIPTION
Addresses the arrow + parquet "schema" bug discussed in [issue#5252](https://github.com/dask/dask/issues/5252).

When a dask-dataframe partition includes a column with all values missing, the corresponding parquet file for that partition (when written) will not include schema information for the correct column type (because there is no data).  This leads `pyarrow` to throw a schema-validation error in `ParquetDataset`.  This can be avoided by setting (by default) `"validate_schema"=False`  in the special case that a shared `"_metadata"` file is available.

If the user actually want the schema to be vaidated for each file/partition, they can still pass `dataset={"validate_schema": True}` as a kwarg to `read_parquet`.

Note that this PR also fixes a small (but important) bug in `_determine_dataset_parts` (`paths` vs `allpaths` mistake)

cc @bluecoconut 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
