### PR TITLE
fixed small typo with parentheses placement

### DIFF
--- a/docs/source/delayed-best-practices.rst
+++ b/docs/source/delayed-best-practices.rst
@@ -201,7 +201,7 @@ our own batching as follows
 
     batches = []
     for i in range(0, 10000000, 10000):
-        result_batch = dask.delayed(batch, range(i, i + 10000))
+        result_batch = dask.delayed(batch)(range(i, i + 10000))
         batches.append(result_batch)
 
 


### PR DESCRIPTION
I fixed a small typo with parentheses on https://github.com/dask/dask/blob/master/docs/source/delayed-best-practices.rst

I mentioned this error in issue #5308 (https://github.com/dask/dask/issues/5308)

Hope this is helpful,
Eugene
