### PR TITLE
API: provides method to compute unknown chunks sizes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1083,7 +1083,7 @@ class Array(DaskMethodsMixin):
     def npartitions(self):
         return reduce(mul, self.numblocks, 1)
 
-    def compute_chunk_sizes(self, inplace=True):
+    def compute_chunk_sizes(self):
         """
         Compute the chunk sizes for a Dask array. This is especially useful
         when the chunk sizes are unknown (e.g., when indexing one Dask array
@@ -1108,7 +1108,7 @@ class Array(DaskMethodsMixin):
         ((2, 1, 0),)
 
         """
-        x = self if inplace else self.copy()
+        x = self
         chunk_shapes = x.map_blocks(
             _get_chunk_shape,
             dtype=int,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1083,16 +1083,16 @@ class Array(DaskMethodsMixin):
     def persist(self,):
         return super().persist()
 
-    def compute_chunksizes(self):
+    def compute_metadata(self):
         from .rechunk import _get_chunks
 
         chunks = compute(_get_chunks(self))[0]
         self._chunks = normalize_chunks(chunks, self.shape, dtype=self.dtype)
         return self
 
-    def persist(self, metadata=False, **kwargs):
-        if metadata:
-            self.compute_chunksizes()
+    def persist(self, compute_metadata=False, **kwargs):
+        if compute_metadata:
+            self.compute_metadata()
         return super().persist(**kwargs)
 
     @property

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1080,14 +1080,30 @@ class Array(DaskMethodsMixin):
     def npartitions(self):
         return reduce(mul, self.numblocks, 1)
 
-    def persist(self):
-        return super().persist()
+    def compute_chunk_sizes(self):
+        """
+        Compute the chunk sizes for a Dask array. This is especially useful
+        when the chunk sizes are unknown.
 
-    def compute_metadata(self):
-        from .rechunk import _get_chunks
+        Notes
+        -----
+        This function modifies the Dask array in-place.
 
-        chunks = compute(_get_chunks(self))[0]
-        self._chunks = normalize_chunks(chunks, self.shape, dtype=self.dtype)
+        Examples
+        --------
+
+        >>> x = da.from_array(np.linspace(-1, 1), chunks=10)
+        >>> y = x[x < 0]
+        >>> y.chunks
+        ((nan, nan, nan, nan, nan),)
+        >>> y.compute_chunk_sizes()
+        >>> y.chunks
+        ((10, 10, 5, 0, 0),)
+
+        """
+        from .rechunk import _get_chunk_shapes
+
+        self._chunks = compute(_get_chunk_shapes(self))[0]
         return self
 
     @property

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1081,13 +1081,18 @@ class Array(DaskMethodsMixin):
     def npartitions(self):
         return reduce(mul, self.numblocks, 1)
 
-    def persist(self, ):
+    def persist(self,):
         return super().persist()
 
     def compute_chunksizes(self):
         chunks = compute(_get_chunks(self))[0]
         self._chunks = normalize_chunks(chunks, self.shape, dtype=self.dtype)
         return self
+
+    def persist(self, metadata=False, **kwargs):
+        if metadata:
+            self.compute_chunksizes()
+        return super().persist(**kwargs)
 
     @property
     def shape(self):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1080,7 +1080,9 @@ class Array(DaskMethodsMixin):
     def npartitions(self):
         return reduce(mul, self.numblocks, 1)
 
-    def persist(self,):
+    def persist(self, compute_metadata=False):
+        if compute_metadata:
+            self.compute_metadata()
         return super().persist()
 
     def compute_metadata(self):
@@ -1089,11 +1091,6 @@ class Array(DaskMethodsMixin):
         chunks = compute(_get_chunks(self))[0]
         self._chunks = normalize_chunks(chunks, self.shape, dtype=self.dtype)
         return self
-
-    def persist(self, compute_metadata=False, **kwargs):
-        if compute_metadata:
-            self.compute_metadata()
-        return super().persist(**kwargs)
 
     @property
     def shape(self):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1085,6 +1085,7 @@ class Array(DaskMethodsMixin):
 
     def compute_chunksizes(self):
         from .rechunk import _get_chunks
+
         chunks = compute(_get_chunks(self))[0]
         self._chunks = normalize_chunks(chunks, self.shape, dtype=self.dtype)
         return self

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -65,7 +65,6 @@ from ..highlevelgraph import HighLevelGraph
 from .numpy_compat import _Recurser, _make_sliced_dtype
 from .slicing import slice_array, replace_ellipsis, cached_cumsum
 from .blockwise import blockwise
-from .rechunk import _get_chunks
 
 config.update_defaults({"array": {"chunk-size": "128MiB", "rechunk-threshold": 4}})
 
@@ -1085,6 +1084,7 @@ class Array(DaskMethodsMixin):
         return super().persist()
 
     def compute_chunksizes(self):
+        from .rechunk import _get_chunks
         chunks = compute(_get_chunks(self))[0]
         self._chunks = normalize_chunks(chunks, self.shape, dtype=self.dtype)
         return self

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1092,6 +1092,9 @@ class Array(DaskMethodsMixin):
         Examples
         --------
 
+        >>> import dask.array as da
+        >>> import numpy as np
+        >>>
         >>> x = da.from_array(np.linspace(-1, 1), chunks=10)
         >>> y = x[x < 0]
         >>> y.chunks

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1094,12 +1094,11 @@ class Array(DaskMethodsMixin):
 
         >>> import dask.array as da
         >>> import numpy as np
-        >>>
         >>> x = da.from_array(np.linspace(-1, 1), chunks=10)
         >>> y = x[x < 0]
         >>> y.chunks
         ((nan, nan, nan, nan, nan),)
-        >>> y.compute_chunk_sizes()
+        >>> y = y.compute_chunk_sizes()
         >>> y.chunks
         ((10, 10, 5, 0, 0),)
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2844,6 +2844,10 @@ def to_zarr(
     ValueError
         If ``arr`` has unknown chunk sizes, which is not supported by Zarr.
 
+    See Also
+    --------
+    dask.array.Array.compute_chunk_sizes
+
     """
     import zarr
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -65,6 +65,7 @@ from ..highlevelgraph import HighLevelGraph
 from .numpy_compat import _Recurser, _make_sliced_dtype
 from .slicing import slice_array, replace_ellipsis, cached_cumsum
 from .blockwise import blockwise
+from .rechunk import _get_chunks
 
 config.update_defaults({"array": {"chunk-size": "128MiB", "rechunk-threshold": 4}})
 
@@ -1079,6 +1080,14 @@ class Array(DaskMethodsMixin):
     @property
     def npartitions(self):
         return reduce(mul, self.numblocks, 1)
+
+    def persist(self, ):
+        return super().persist()
+
+    def compute_chunksizes(self):
+        chunks = compute(_get_chunks(self))[0]
+        self._chunks = normalize_chunks(chunks, self.shape, dtype=self.dtype)
+        return self
 
     @property
     def shape(self):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1110,7 +1110,8 @@ class Array(DaskMethodsMixin):
         >>> y = x[x <= 0]
         >>> y.chunks
         ((nan, nan, nan),)
-        >>> y = y.compute_chunk_sizes()
+        >>> y.compute_chunk_sizes()  # in-place computation
+        dask.array<getitem, shape=(3,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>
         >>> y.chunks
         ((2, 1, 0),)
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1080,9 +1080,7 @@ class Array(DaskMethodsMixin):
     def npartitions(self):
         return reduce(mul, self.numblocks, 1)
 
-    def persist(self, compute_metadata=False):
-        if compute_metadata:
-            self.compute_metadata()
+    def persist(self):
         return super().persist()
 
     def compute_metadata(self):

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -651,3 +651,31 @@ def format_plan(plan):
     [(3*[10], 2*[15]), ([30], 3*[10])]
     """
     return [format_chunks(c) for c in plan]
+
+
+def _get_shape_helper(a):
+    s = np.asarray(a.shape, dtype=int)
+    return s[len(s) * (None,) + (slice(None),)]
+
+
+def _get_all_chunk_shapes(a):
+    return a.map_blocks(
+        _get_shape_helper,
+        dtype=int,
+        chunks=tuple(len(c) * (1,) for c in a.chunks) + ((a.ndim,),),
+        new_axis=a.ndim,
+    )
+
+
+def _get_chunks(a):
+    cs = _get_all_chunk_shapes(a)
+
+    c = []
+    for i in range(a.ndim):
+        s = a.ndim * [0] + [i]
+        s[i] = slice(None)
+        s = tuple(s)
+
+        c.append(tuple(cs[s]))
+
+    return tuple(c)

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -653,22 +653,22 @@ def format_plan(plan):
     return [format_chunks(c) for c in plan]
 
 
-def _get_shape_helper(a):
+def _get_chunk_shape(a):
     s = np.asarray(a.shape, dtype=int)
     return s[len(s) * (None,) + (slice(None),)]
 
 
-def _get_all_chunk_shapes(a):
-    return a.map_blocks(
-        _get_shape_helper,
+def _get_chunk_shapes(a):
+    """
+    This function finds chunk shapes for a Dask array `a`.
+
+    """
+    chunk_shapes = a.map_blocks(
+        _get_chunk_shape,
         dtype=int,
         chunks=tuple(len(c) * (1,) for c in a.chunks) + ((a.ndim,),),
         new_axis=a.ndim,
     )
-
-
-def _get_chunks(a):
-    cs = _get_all_chunk_shapes(a)
 
     c = []
     for i in range(a.ndim):
@@ -676,6 +676,6 @@ def _get_chunks(a):
         s[i] = slice(None)
         s = tuple(s)
 
-        c.append(tuple(cs[s]))
+        c.append(tuple(chunk_shapes[s]))
 
     return tuple(c)

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -651,31 +651,3 @@ def format_plan(plan):
     [(3*[10], 2*[15]), ([30], 3*[10])]
     """
     return [format_chunks(c) for c in plan]
-
-
-def _get_chunk_shape(a):
-    s = np.asarray(a.shape, dtype=int)
-    return s[len(s) * (None,) + (slice(None),)]
-
-
-def _get_chunk_shapes(a):
-    """
-    This function finds chunk shapes for a Dask array `a`.
-
-    """
-    chunk_shapes = a.map_blocks(
-        _get_chunk_shape,
-        dtype=int,
-        chunks=tuple(len(c) * (1,) for c in a.chunks) + ((a.ndim,),),
-        new_axis=a.ndim,
-    )
-
-    c = []
-    for i in range(a.ndim):
-        s = a.ndim * [0] + [i]
-        s[i] = slice(None)
-        s = tuple(s)
-
-        c.append(tuple(chunk_shapes[s]))
-
-    return tuple(c)

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -143,8 +143,8 @@ def _old_to_new(old_chunks, new_chunks):
         raise ValueError("Cannot change dimensions from %r to %r" % (sums, sums2))
     if not n_missing == n_missing2:
         raise ValueError(
-            "Chunks must be unchanging along unknown dimensions. "
-            "A possible solution is with x.compute_chunk_sizes()"
+            "Chunks must be unchanging along unknown dimensions.\n\n"
+            "A possible solution:\n  x.compute_chunk_sizes()"
         )
 
     old_to_new = [_intersect_1d(_breakpoints(cm[0], cm[1])) for cm in zip(cmo, cmn)]

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -142,7 +142,10 @@ def _old_to_new(old_chunks, new_chunks):
     if not sums == sums2:
         raise ValueError("Cannot change dimensions from %r to %r" % (sums, sums2))
     if not n_missing == n_missing2:
-        raise ValueError("Chunks must be unchanging along unknown dimensions")
+        raise ValueError(
+            "Chunks must be unchanging along unknown dimensions. "
+            "A possible solution is with x.compute_chunk_sizes()"
+        )
 
     old_to_new = [_intersect_1d(_breakpoints(cm[0], cm[1])) for cm in zip(cmo, cmn)]
     for idx, missing in enumerate(n_missing):

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -953,8 +953,10 @@ def arg_reduction(x, chunk, combine, agg, axis=None, split_every=None, out=None)
         if len(chunks) > 1 and np.isnan(chunks).any():
             raise ValueError(
                 "Arg-reductions do not work with arrays that have "
-                "unknown chunksizes.  At some point in your computation "
-                "this array lost chunking information"
+                "unknown chunksizes. At some point in your computation "
+                "this array lost chunking information.\n\n"
+                "A possible solution is with \n"
+                "  x.compute_chunk_sizes()"
             )
 
     # Map chunk across all blocks

--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -162,7 +162,9 @@ def reshape(x, shape):
     known_sizes = [s for s in shape if s != -1]
     if len(known_sizes) < len(shape):
         if len(known_sizes) - len(shape) > 1:
-            raise ValueError("can only specify one unknown dimension")
+            raise ValueError(
+                "can only specify one unknown dimension"
+            )
         # Fastpath for x.reshape(-1) on 1D arrays, allows unknown shape in x
         # for this case only.
         if len(shape) == 1 and x.ndim == 1:
@@ -171,7 +173,10 @@ def reshape(x, shape):
         shape = tuple(missing_size if s == -1 else s for s in shape)
 
     if np.isnan(sum(x.shape)):
-        raise ValueError("Array chunk size or shape is unknown. shape: %s", x.shape)
+        raise ValueError(
+            "Array chunk size or shape is unknown. shape: %s\n\n"
+            "Possible solution with x.compute_chunk_sizes()" % x.shape
+        )
 
     if reduce(mul, shape, 1) != x.size:
         raise ValueError("total size of new array must be unchanged")

--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -162,9 +162,7 @@ def reshape(x, shape):
     known_sizes = [s for s in shape if s != -1]
     if len(known_sizes) < len(shape):
         if len(known_sizes) - len(shape) > 1:
-            raise ValueError(
-                "can only specify one unknown dimension"
-            )
+            raise ValueError("can only specify one unknown dimension")
         # Fastpath for x.reshape(-1) on 1D arrays, allows unknown shape in x
         # for this case only.
         if len(shape) == 1 and x.ndim == 1:

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -281,7 +281,11 @@ def slice_slices_and_integers(out_name, in_name, blockdims, index):
 
     for dim, ind in zip(shape, index):
         if np.isnan(dim) and ind != slice(None, None, None):
-            raise ValueError("Arrays chunk sizes are unknown: %s", shape)
+            raise ValueError(
+                "Arrays chunk sizes are unknown: %s\n\n"
+                "Possible solution:\n  x.compute_chunk_sizes()",
+                shape
+            )
 
     assert all(isinstance(ind, (slice, Integral)) for ind in index)
     assert len(index) == len(blockdims)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -284,7 +284,7 @@ def slice_slices_and_integers(out_name, in_name, blockdims, index):
             raise ValueError(
                 "Arrays chunk sizes are unknown: %s\n\n"
                 "Possible solution:\n  x.compute_chunk_sizes()",
-                shape
+                shape,
             )
 
     assert all(isinstance(ind, (slice, Integral)) for ind in index)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -277,14 +277,14 @@ def slice_slices_and_integers(out_name, in_name, blockdims, index):
 
     _slice_1d
     """
+    from .core import unknown_chunk_message
+
     shape = tuple(cached_cumsum(dim, initial_zero=True)[-1] for dim in blockdims)
 
     for dim, ind in zip(shape, index):
         if np.isnan(dim) and ind != slice(None, None, None):
             raise ValueError(
-                "Arrays chunk sizes are unknown: %s\n\n"
-                "Possible solution:\n  x.compute_chunk_sizes()",
-                shape,
+                "Arrays chunk sizes are unknown: %s%s" % (shape, unknown_chunk_message)
             )
 
     assert all(isinstance(ind, (slice, Integral)) for ind in index)

--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -21,7 +21,10 @@ def svg(chunks, size=200, **kwargs):
     """
     shape = tuple(map(sum, chunks))
     if np.isnan(shape).any():  # don't support unknown sizes
-        raise NotImplementedError("Can't generate SVG with unknown chunk sizes")
+        raise NotImplementedError(
+            "Can't generate SVG with unknown chunk sizes.\n\n"
+            " A possible solution is with x.compute_chunk_sizes()"
+        )
     if not all(shape):
         raise NotImplementedError("Can't generate SVG with 0-length dimensions")
     if len(chunks) == 0:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4094,16 +4094,14 @@ def test_from_array_meta():
     assert isinstance(y._meta, sparse.COO)
 
 
-@pytest.mark.parametrize("inplace", [True, False])
-def test_compute_chunk_sizes(inplace):
+def test_compute_chunk_sizes():
     x = da.from_array(np.linspace(-1, 1, num=50), chunks=10)
     y = x[x < 0]
     assert np.isnan(y.shape[0])
     assert y.chunks == ((np.nan,) * 5,)
 
     z = y.compute_chunk_sizes()
-    if inplace:
-        assert y is z
+    assert y is z
     assert z.chunks == ((10, 10, 5, 0, 0),)
     assert len(z) == 25
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4175,3 +4175,18 @@ class TestUnkownChunkSizesErrors:
             da.argmin(y)
         y.compute_chunk_sizes()
         da.argmin(y)
+
+    def test_reshape(self):
+        y = self.unknown
+        with pytest.raises(ValueError, match="compute_chunk_sizes"):
+            da.reshape(y, (5, 5))
+        y.compute_chunk_sizes()
+        da.reshape(y, (5, 5))
+
+    def test_slicing(self):
+        x = self.known(num=100).reshape(10, 10)
+        y = x[x.sum(axis=0) < 0]
+        with pytest.raises(ValueError, match="compute_chunk_sizes"):
+            y[:3, :]
+        y.compute_chunk_sizes()
+        y[:3, :]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4137,6 +4137,7 @@ def test_compute_chunk_sizes_2d_array():
 def _known(num=50):
     return da.from_array(np.linspace(-1, 1, num=num), chunks=10)
 
+
 @pytest.fixture()
 def unknown():
     x = _known()
@@ -4144,12 +4145,14 @@ def unknown():
     assert y.chunks == ((np.nan,) * 5,)
     return y
 
+
 def test_compute_chunk_sizes_warning_fixes_rechunk(unknown):
     y = unknown
     with pytest.raises(ValueError, match="compute_chunk_sizes"):
         y.rechunk("auto")
     y.compute_chunk_sizes()
     y.rechunk("auto")
+
 
 def test_compute_chunk_sizes_warning_fixes_to_zarr(unknown):
     y = unknown
@@ -4162,12 +4165,14 @@ def test_compute_chunk_sizes_warning_fixes_to_zarr(unknown):
         with StringIO() as f:
             y.to_zarr(f)
 
+
 def test_compute_chunk_sizes_warning_fixes_to_svg(unknown):
     y = unknown
     with pytest.raises(NotImplementedError, match="compute_chunk_sizes"):
         y.to_svg()
     y.compute_chunk_sizes()
     y.to_svg()
+
 
 def test_compute_chunk_sizes_warning_fixes_concatenate():
     x = _known(num=100).reshape(10, 10)
@@ -4180,6 +4185,7 @@ def test_compute_chunk_sizes_warning_fixes_concatenate():
     y2.compute_chunk_sizes()
     da.concatenate((y1, y2), axis=1)
 
+
 def test_compute_chunk_sizes_warning_fixes_reduction(unknown):
     y = unknown
     with pytest.raises(ValueError, match="compute_chunk_sizes"):
@@ -4187,12 +4193,14 @@ def test_compute_chunk_sizes_warning_fixes_reduction(unknown):
     y.compute_chunk_sizes()
     da.argmin(y)
 
+
 def test_compute_chunk_sizes_warning_fixes_reshape(unknown):
     y = unknown
     with pytest.raises(ValueError, match="compute_chunk_sizes"):
         da.reshape(y, (5, 5))
     y.compute_chunk_sizes()
     da.reshape(y, (5, 5))
+
 
 def test_compute_chunk_sizes_warning_fixes_slicing():
     x = _known(num=100).reshape(10, 10)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4148,7 +4148,7 @@ def test_compute_chunk_sizes_3d_array(N=8):
     assert Y.compute().shape == (8, 3, 5)
     assert X.compute().shape == (8, 8, 8)
 
-    assert Y.chunks == ((np.nan, np.nan), ) * 3
+    assert Y.chunks == ((np.nan, np.nan),) * 3
     assert all(np.isnan(s) for s in Y.shape)
     Z = Y.compute_chunk_sizes()
     assert Z is Y

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -747,17 +747,17 @@ def test_rechunk_bad_keys():
     assert "-100" in str(info.value)
 
 
-@pytest.mark.parametrize("persist", [True, False])
-def test_compute_chunks(persist):
+@pytest.mark.parametrize("metadata", [True, False])
+def test_compute_chunks(metadata):
     x = da.from_array(np.linspace(-1, 1, num=50), chunks=10)
     y = x[x < 0]
     assert y.chunks == ((np.nan,) * 5,)
 
-    if not persist:
+    if not metadata:
         z = y.compute_chunksizes()
+        assert y is z
     else:
         z = y.persist(metadata=True)
-    assert y is z
     assert z.chunks == ((10, 10, 5, 0, 0),)
     assert isinstance(z, da.Array)
     assert (z.compute() < 0).all()

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -747,12 +747,16 @@ def test_rechunk_bad_keys():
     assert "-100" in str(info.value)
 
 
-def test_compute_chunks():
+@pytest.mark.parametrize("persist", [True, False])
+def test_compute_chunks(persist):
     x = da.from_array(np.linspace(-1, 1, num=50), chunks=10)
     y = x[x < 0]
-    assert y.chunks == ((np.nan, ) * 5, )
+    assert y.chunks == ((np.nan,) * 5,)
 
-    z = y.compute_chunksizes()
+    if not persist:
+        z = y.compute_chunksizes()
+    else:
+        z = y.persist(metadata=True)
     assert y is z
     assert z.chunks == ((10, 10, 5, 0, 0),)
     assert isinstance(z, da.Array)

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -747,12 +747,12 @@ def test_rechunk_bad_keys():
     assert "-100" in str(info.value)
 
 
-def test_compute_metadata():
+def test_compute_chunk_sizes():
     x = da.from_array(np.linspace(-1, 1, num=50), chunks=10)
     y = x[x < 0]
     assert y.chunks == ((np.nan,) * 5,)
 
-    z = y.compute_metadata()
+    z = y.compute_chunk_sizes()
     assert y is z
     assert z.chunks == ((10, 10, 5, 0, 0),)
     assert isinstance(z, da.Array)

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -760,4 +760,4 @@ def test_compute_metadata(compute_metadata):
         z = y.persist(compute_metadata=True)
     assert z.chunks == ((10, 10, 5, 0, 0),)
     assert isinstance(z, da.Array)
-    assert (z.compute() < 0).all()
+    assert ((-1 * z).compute() > 0).all()

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -747,17 +747,17 @@ def test_rechunk_bad_keys():
     assert "-100" in str(info.value)
 
 
-@pytest.mark.parametrize("metadata", [True, False])
-def test_compute_chunks(metadata):
+@pytest.mark.parametrize("compute_metadata", [True, False])
+def test_compute_metadata(compute_metadata):
     x = da.from_array(np.linspace(-1, 1, num=50), chunks=10)
     y = x[x < 0]
     assert y.chunks == ((np.nan,) * 5,)
 
-    if not metadata:
-        z = y.compute_chunksizes()
+    if not compute_metadata:
+        z = y.compute_metadata()
         assert y is z
     else:
-        z = y.persist(metadata=True)
+        z = y.persist(compute_metadata=True)
     assert z.chunks == ((10, 10, 5, 0, 0),)
     assert isinstance(z, da.Array)
     assert (z.compute() < 0).all()

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -745,15 +745,3 @@ def test_rechunk_bad_keys():
         x.rechunk({-100: 4})
 
     assert "-100" in str(info.value)
-
-
-def test_compute_chunk_sizes():
-    x = da.from_array(np.linspace(-1, 1, num=50), chunks=10)
-    y = x[x < 0]
-    assert y.chunks == ((np.nan,) * 5,)
-
-    z = y.compute_chunk_sizes()
-    assert y is z
-    assert z.chunks == ((10, 10, 5, 0, 0),)
-    assert isinstance(z, da.Array)
-    assert ((-1 * z).compute() > 0).all()

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -745,3 +745,15 @@ def test_rechunk_bad_keys():
         x.rechunk({-100: 4})
 
     assert "-100" in str(info.value)
+
+
+def test_compute_chunks():
+    x = da.from_array(np.linspace(-1, 1, num=50), chunks=10)
+    y = x[x < 0]
+    assert y.chunks == ((np.nan, ) * 5, )
+
+    z = y.compute_chunksizes()
+    assert y is z
+    assert z.chunks == ((10, 10, 5, 0, 0),)
+    assert isinstance(z, da.Array)
+    assert (z.compute() < 0).all()

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -747,17 +747,13 @@ def test_rechunk_bad_keys():
     assert "-100" in str(info.value)
 
 
-@pytest.mark.parametrize("compute_metadata", [True, False])
-def test_compute_metadata(compute_metadata):
+def test_compute_metadata():
     x = da.from_array(np.linspace(-1, 1, num=50), chunks=10)
     y = x[x < 0]
     assert y.chunks == ((np.nan,) * 5,)
 
-    if not compute_metadata:
-        z = y.compute_metadata()
-        assert y is z
-    else:
-        z = y.persist(compute_metadata=True)
+    z = y.compute_metadata()
+    assert y is z
     assert z.chunks == ((10, 10, 5, 0, 0),)
     assert isinstance(z, da.Array)
     assert ((-1 * z).compute() > 0).all()


### PR DESCRIPTION

**What does this PR implement?**
It provides a method to compute unknown chunk sizes:

``` python
x = da.random.normal(size=20, chunks=5)
y = x[x < 0]
assert y.chunks == ((nan, nan, nan, nan), )
y.compute_chunksizes()
assert y.chunks  ((1, 2, 2, 1), )
```

**References issues/PRs**
* The implementation is slightly adapted from @jakirkham's implementation in https://github.com/dask/dask/issues/3293#issuecomment-382909361).

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

