### PR TITLE
Fixup da.asarray and da.asanyarray for datetime64 dtype and xarray objects

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3581,6 +3581,8 @@ def asarray(a, **kwargs):
         return a
     elif hasattr(a, "to_dask_array"):
         return a.to_dask_array()
+    elif type(a).__module__.startswith("xarray.") and hasattr(a, "data"):
+        return asarray(a.data)
     elif isinstance(a, (list, tuple)) and any(isinstance(i, Array) for i in a):
         return stack(a)
     elif not isinstance(getattr(a, "shape", None), Iterable):
@@ -3619,7 +3621,7 @@ def asanyarray(a):
         return a
     elif hasattr(a, "to_dask_array"):
         return a.to_dask_array()
-    elif hasattr(a, "data") and type(a).__module__.startswith("xarray."):
+    elif type(a).__module__.startswith("xarray.") and hasattr(a, "data"):
         return asanyarray(a.data)
     elif isinstance(a, (list, tuple)) and any(isinstance(i, Array) for i in a):
         a = stack(a)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2405,6 +2405,13 @@ def test_asanyarray_dataframe():
     assert_eq(x, dx)
 
 
+def test_asanyarray_datetime64():
+    x = np.array(["2000-01-01"], dtype="datetime64")
+    dx = da.asanyarray(x)
+    assert isinstance(dx, da.Array)
+    assert_eq(x, dx)
+
+
 def test_from_func():
     x = np.arange(10)
     f = lambda n: n * x

--- a/dask/array/tests/test_xarray.py
+++ b/dask/array/tests/test_xarray.py
@@ -19,6 +19,6 @@ def test_asarray():
 
 
 def test_asanyarray():
-    y = da.asarray(xr.DataArray([1, 2, 3.0]))
+    y = da.asanyarray(xr.DataArray([1, 2, 3.0]))
     assert isinstance(y, da.array)
     assert_eq(y, y)

--- a/dask/array/tests/test_xarray.py
+++ b/dask/array/tests/test_xarray.py
@@ -6,7 +6,19 @@ from ..utils import assert_eq
 xr = pytest.importorskip("xarray")
 
 
-def test_xarray():
+def test_mean():
     y = da.mean(xr.DataArray([1, 2, 3.0]))
+    assert isinstance(y, da.array)
+    assert_eq(y, y)
 
+
+def test_asarray():
+    y = da.asarray(xr.DataArray([1, 2, 3.0]))
+    assert isinstance(y, da.array)
+    assert_eq(y, y)
+
+
+def test_asanyarray():
+    y = da.asarray(xr.DataArray([1, 2, 3.0]))
+    assert isinstance(y, da.array)
     assert_eq(y, y)


### PR DESCRIPTION
`da.asanyarray()` currently crashes if passed a datetime64 dtype array, as noted
in https://github.com/pydata/xarray/pull/3220:

    >       elif hasattr(a, "data") and type(a).__module__.startswith("xarray."):
    E       ValueError: cannot include dtype 'M' in a buffer

Reversing the order of these checks fixes the issue. (`.data` is an attribute of NumPy arrays that creates a buffer, which isn't valid for datetime dtypes.)

I also adjusted `da.asarray()` to coerce xarray objects in the same way as `da.asanyarray()`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
