### PR TITLE
 Moment: handle all elements being masked

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -15,7 +15,6 @@ from .core import _concatenate2, Array, handle_out, implements
 from .blockwise import blockwise
 from ..blockwise import lol_tuples
 from .creation import arange, diagonal
-from .ufunc import sqrt
 from .utils import full_like_safe, validate_axis, compute_meta, is_arraylike
 from .wrap import zeros, ones
 from .numpy_compat import ma_divide, divide as np_divide
@@ -812,9 +811,30 @@ with ignoring(AttributeError):
     nanvar = derived_from(np)(nanvar)
 
 
+def _sqrt(a):
+    o = np.sqrt(a)
+    if isinstance(o, np.ma.masked_array) and not o.shape and o.mask.all():
+        return np.ma.masked
+    return o
+
+
+def safe_sqrt(a):
+    """A version of sqrt that properly handles scalar masked arrays.
+
+    To mimic ``np.ma`` reductions, we need to convert scalar masked arrays that
+    have an active mask to the ``np.ma.masked`` singleton. This is properly
+    handled automatically for reduction code, but not for ufuncs. We implement
+    a simple version here, since calling `np.ma.sqrt` everywhere is
+    significantly more expensive.
+    """
+    if hasattr(a, "_elemwise"):
+        return a._elemwise(_sqrt, a)
+    return _sqrt(a)
+
+
 @derived_from(np)
 def std(a, axis=None, dtype=None, keepdims=False, ddof=0, split_every=None, out=None):
-    result = sqrt(
+    result = safe_sqrt(
         var(
             a,
             axis=axis,
@@ -834,7 +854,7 @@ def std(a, axis=None, dtype=None, keepdims=False, ddof=0, split_every=None, out=
 def nanstd(
     a, axis=None, dtype=None, keepdims=False, ddof=0, split_every=None, out=None
 ):
-    result = sqrt(
+    result = safe_sqrt(
         nanvar(
             a,
             axis=axis,

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -727,7 +727,7 @@ def moment_agg(
     if isinstance(denominator, Number):
         if denominator < 0:
             denominator = np.nan
-    else:
+    elif denominator is not np.ma.masked:
         denominator[denominator < 0] = np.nan
 
     return divide(M, denominator, dtype=dtype)

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -270,7 +270,7 @@ def test_reductions(dtype, reduction):
 )
 def test_reductions_allmasked(dtype, reduction):
     x = np.ma.masked_array([1, 2], mask=True)
-    dx = da.from_array(x)
+    dx = da.from_array(x, asarray=False)
 
     dfunc = getattr(da, reduction)
     func = getattr(np, reduction)

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -225,12 +225,15 @@ def test_filled():
 
 def assert_eq_ma(a, b):
     res = a.compute()
-    assert type(res) == type(b)
-    if hasattr(res, "mask"):
-        np.testing.assert_equal(res.mask, b.mask)
-        a = da.ma.filled(a)
-        b = np.ma.filled(b)
-    assert_eq(a, b, equal_nan=True)
+    if res is np.ma.masked:
+        assert res is b
+    else:
+        assert type(res) == type(b)
+        if hasattr(res, "mask"):
+            np.testing.assert_equal(res.mask, b.mask)
+            a = da.ma.filled(a)
+            b = np.ma.filled(b)
+        assert_eq(a, b, equal_nan=True)
 
 
 @pytest.mark.parametrize("dtype", ("i8", "f8"))
@@ -259,6 +262,20 @@ def test_reductions(dtype, reduction):
         dfunc(mdx, axis=1, keepdims=True, split_every=2),
         func(mx, axis=1, keepdims=True),
     )
+
+
+@pytest.mark.parametrize("dtype", ("i8", "f8"))
+@pytest.mark.parametrize(
+    "reduction", ["sum", "prod", "mean", "var", "std", "min", "max", "any", "all"]
+)
+def test_reductions_allmasked(dtype, reduction):
+    x = np.ma.masked_array([1, 2], mask=True)
+    dx = da.from_array(x)
+
+    dfunc = getattr(da, reduction)
+    func = getattr(np, reduction)
+
+    assert_eq_ma(dfunc(dx), func(x))
 
 
 @pytest.mark.parametrize("reduction", ["argmin", "argmax"])

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -98,7 +98,7 @@ class ufunc(object):
     }
 
     def __init__(self, ufunc):
-        if not isinstance(ufunc, (np.ufunc, da_frompyfunc)):
+        if not isinstance(ufunc, (np.ufunc, np.ma.core._MaskedUFunc, da_frompyfunc)):
             raise TypeError(
                 "must be an instance of `ufunc` or "
                 "`da_frompyfunc`, got `%s" % type(ufunc).__name__
@@ -211,7 +211,7 @@ log2 = ufunc(np.log2)
 log10 = ufunc(np.log10)
 log1p = ufunc(np.log1p)
 expm1 = ufunc(np.expm1)
-sqrt = ufunc(np.sqrt)
+sqrt = ufunc(np.ma.sqrt)
 square = ufunc(np.square)
 cbrt = ufunc(np.cbrt)
 reciprocal = ufunc(np.reciprocal)

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -98,7 +98,7 @@ class ufunc(object):
     }
 
     def __init__(self, ufunc):
-        if not isinstance(ufunc, (np.ufunc, np.ma.core._MaskedUFunc, da_frompyfunc)):
+        if not isinstance(ufunc, (np.ufunc, da_frompyfunc)):
             raise TypeError(
                 "must be an instance of `ufunc` or "
                 "`da_frompyfunc`, got `%s" % type(ufunc).__name__
@@ -211,7 +211,7 @@ log2 = ufunc(np.log2)
 log10 = ufunc(np.log10)
 log1p = ufunc(np.log1p)
 expm1 = ufunc(np.expm1)
-sqrt = ufunc(np.ma.sqrt)
+sqrt = ufunc(np.sqrt)
 square = ufunc(np.square)
 cbrt = ufunc(np.cbrt)
 reciprocal = ufunc(np.reciprocal)


### PR DESCRIPTION
This _almost_ works, but still fails for `std`, which returns 1-element array where the element is masked, instead of the MaskedConstant it should.

The issue is that `np.sqrt` doesn't return a masked constant, whereas `np.ma.sqrt` does:

```python
In [1]: import numpy as np                                                                                                                                                                                                                                                                                                                                                                                                                                       

In [2]: np.sqrt(np.ma.masked)                                                                                                                                                                                                                                                                                                                                                                                                                                    
Out[2]: 
masked_array(data=--,
             mask=True,
       fill_value=1e+20,
            dtype=float64)

In [3]: np.ma.sqrt(np.ma.masked)                                                                                                                                                                                                                                                                                                                                                                                                                                 
Out[3]: masked
```

`da.std` [calls `sqrt`](https://github.com/dask/dask/blob/master/dask/array/reductions.py#L818), which is a [dask ufunc wrapping `np.sqrt`](https://github.com/dask/dask/blob/2d8dd51fcdec25e8781ad69e40acfc5947bfb393/dask/array/ufunc.py#L222).

Replacing the `sqrt` ufunc with the masked version seems like a potentially significant change around the edge cases. For example, they handle NaN differently:

```python
In [1]: import numpy as np                                                                                                                                                                                                                                                                                                                                                                                                                                       

In [2]: np.ma.sqrt(np.nan)                                                                                                                                                                                                                                                                                                                                                                                                                                       
Out[2]: masked

In [3]: np.sqrt(np.nan)                                                                                                                                                                                                                                                                                                                                                                                                                                          
Out[3]: nan
```

I tried this in 45cef9a, but it doesn't seem like a good idea. (And breaks other tests due to the above discrepancy).

So the question is: how to write `std` in such a way that if the variance is a MaskedConstant, we just return the MaskedConstant without passing it to `sqrt`? (Or use a different version of `sqrt` that handles the MaskedConstant correctly, but doesn't interpret NaN as masked?)

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Closes #5338.