### PR TITLE
Enable recursive config keys

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -447,13 +447,16 @@ def get(key, default=no_default, config=config):
     --------
     >>> from dask import config
     >>> config.get('foo')  # doctest: +SKIP
-    {'x': 1, 'y': 2}
+    {'x': 1, 'y': 2, 'z': 'y'}
 
     >>> config.get('foo.x')  # doctest: +SKIP
     1
 
     >>> config.get('foo.x.y', default=123)  # doctest: +SKIP
     123
+
+    >>> config.get('foo.{config:foo.z}')  # doctest: +SKIP
+    2
 
     See Also
     --------

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -187,13 +187,16 @@ def test_collect_env_none():
 
 
 def test_get():
-    d = {"x": 1, "y": {"a": 2}}
+    d = {"x": 1, "y": {"a": 2}, "z": "x"}
 
     assert get("x", config=d) == 1
     assert get("y.a", config=d) == 2
     assert get("y.b", 123, config=d) == 123
+    assert get("{config:z}", config=d) == 1
     with pytest.raises(KeyError):
         get("y.b", config=d)
+    with pytest.raises(KeyError):
+        get("{config:y.b}", config=d)
 
 
 def test_ensure_file(tmpdir):
@@ -257,6 +260,10 @@ def test_set():
     d = {}
     set({"abc.x": 123}, config=d)
     assert d["abc"]["x"] == 123
+
+    d = {"z": "x.y"}
+    set({"{config:z}": 123}, config=d)
+    assert d["x"]["y"] == 123
 
 
 def test_set_kwargs():


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

I've found myself in a situation where I want to load some config, but the section of config depends on some other bit of config.

#### Example

```yaml
awesomeconfig:
  bitiwant: thisone

  options:
    thisone: hooray
    notthisone: nope
    orthisone: neitherme
```

This change adds a new config syntax built on python string formatting to expand the `config` kwarg by a key specified as a formatting field `{config:<some key>}`.

This enables the following syntax:

```python
>>> dask.config.get('awesomeconfig.options.{config:awesomeconfig.bitiwant}')
hooray
```

This is just a first attempt at hitting my requirements, so feel free to point me in a different direction if this isn't quite right.