### PR TITLE
fix tokenizing for when subindexing into numpy arrays

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -800,15 +800,15 @@ def register_numpy():
         if not x.shape:
             return (str(x), x.dtype)
         if hasattr(x, "mode") and getattr(x, "filename", None):
-            if hasattr(x, "offset"):
-                offset = getattr(x, "offset")
-            elif hasattr(x.base, "ctypes"):
+            if hasattr(x.base, "ctypes"):
                 offset = (
                     x.ctypes.get_as_parameter().value
                     - x.base.ctypes.get_as_parameter().value
                 )
             else:
                 offset = 0  # root memmap's have mmap object as base
+            if hasattr(x, "offset"): #offset numpy used while opening, and not the offset to the beginning of the file
+                offset += getattr(x, "offset")
             return (
                 x.filename,
                 os.path.getmtime(x.filename),

--- a/dask/base.py
+++ b/dask/base.py
@@ -807,7 +807,9 @@ def register_numpy():
                 )
             else:
                 offset = 0  # root memmap's have mmap object as base
-            if hasattr(x, "offset"): #offset numpy used while opening, and not the offset to the beginning of the file
+            if hasattr(
+                x, "offset"
+            ):  # offset numpy used while opening, and not the offset to the beginning of the file
                 offset += getattr(x, "offset")
             return (
                 x.filename,

--- a/dask/base.py
+++ b/dask/base.py
@@ -800,13 +800,13 @@ def register_numpy():
         if not x.shape:
             return (str(x), x.dtype)
         if hasattr(x, "mode") and getattr(x, "filename", None):
-            if hasattr(x.base, "ctypes"):
+            if hasattr(x, "offset"):
+                offset = getattr(x, "offset")
+            elif hasattr(x.base, "ctypes"):
                 offset = (
                     x.ctypes.get_as_parameter().value
                     - x.base.ctypes.get_as_parameter().value
                 )
-            elif hasattr(x, "offset"):
-                offset = getattr(x, "offset")
             else:
                 offset = 0  # root memmap's have mmap object as base
             return (

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -164,6 +164,10 @@ def test_tokenize_numpy_memmap_offset(tmpdir):
         mmap2 = np.memmap(f, dtype=np.uint8, mode="r", offset=5, shape=5)
 
         assert tokenize(mmap1) != tokenize(mmap2)
+        # also make sure that they tokenize correctly when taking sub-arrays
+        sub1 = mmap1[1:-1]
+        sub2 = mmap2[1:-1]
+        assert tokenize(sub1) != tokenize(sub2)
 
 
 @pytest.mark.skipif("not np")


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

fix for #5350 