### PR TITLE
ignore runtime warning in compute_meta

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4081,6 +4081,12 @@ def test_auto_chunks_h5py():
 
 def test_no_warnings_from_blockwise():
     with pytest.warns(None) as record:
+        x = da.ones((3, 10, 10), chunks=(3, 2, 2))
+        y = da.map_blocks(lambda z: np.mean(z, axis=0), x,
+                          dtype=x.dtype, drop_axis=0)
+    assert not record
+
+    with pytest.warns(None) as record:
         x = da.ones((15, 15), chunks=(5, 5))
         (x.dot(x.T + 1) - x.mean(axis=0)).std()
     assert not record

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4082,8 +4082,7 @@ def test_auto_chunks_h5py():
 def test_no_warnings_from_blockwise():
     with pytest.warns(None) as record:
         x = da.ones((3, 10, 10), chunks=(3, 2, 2))
-        y = da.map_blocks(lambda z: np.mean(z, axis=0), x,
-                          dtype=x.dtype, drop_axis=0)
+        da.map_blocks(lambda y: np.mean(y, axis=0), x, dtype=x.dtype, drop_axis=0)
     assert not record
 
     with pytest.warns(None) as record:

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -5,6 +5,7 @@ import functools
 import math
 import numbers
 import os
+import warnings
 
 import numpy as np
 from toolz import frequencies, concat
@@ -108,7 +109,9 @@ def meta_from_array(x, ndim=None, dtype=None):
 
 
 def compute_meta(func, _dtype, *args, **kwargs):
-    with np.errstate(all="ignore"):
+    with np.errstate(all="ignore"), warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+
         args_meta = [meta_from_array(x) if is_arraylike(x) else x for x in args]
         kwargs_meta = {
             k: meta_from_array(v) if is_arraylike(v) else v for k, v in kwargs.items()


### PR DESCRIPTION
Fixes #5337 
cc @jrbourbeau 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
