### PR TITLE
fix issue with index dtype after applying dd.pivot_table (#5379)

### DIFF
--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -238,8 +238,9 @@ def pivot_table(df, index=None, columns=None, values=None, aggfunc="mean"):
     # _emulate can't work for empty data
     # the result must have CategoricalIndex columns
     new_columns = pd.CategoricalIndex(df[columns].cat.categories, name=columns)
-    meta = pd.DataFrame(columns=new_columns, dtype=np.float64,
-                        index=pd.Index(df._meta[index]))
+    meta = pd.DataFrame(
+        columns=new_columns, dtype=np.float64, index=pd.Index(df._meta[index])
+    )
 
     kwargs = {"index": index, "columns": columns, "values": values}
 

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -238,8 +238,8 @@ def pivot_table(df, index=None, columns=None, values=None, aggfunc="mean"):
     # _emulate can't work for empty data
     # the result must have CategoricalIndex columns
     new_columns = pd.CategoricalIndex(df[columns].cat.categories, name=columns)
-    meta = pd.DataFrame(columns=new_columns, dtype=np.float64)
-    meta.index.name = index
+    meta = pd.DataFrame(columns=new_columns, dtype=np.float64,
+                        index=pd.Index(df._meta[index]))
 
     kwargs = {"index": index, "columns": columns, "values": values}
 

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -246,6 +246,18 @@ def test_pivot_table_dtype():
     assert_eq(res, exp)
 
 
+def test_pivot_table_index_dtype():
+    df = pd.DataFrame({"A": pd.date_range(start="2019-08-01",
+                                          periods=3,
+                                          freq="1D"),
+                       "B": pd.Categorical(list("abc")),
+                       "C": [1,2,3]})
+    ddf = dd.from_pandas(df, 2)
+    res = dd.pivot_table(ddf, index="A", columns="B", values="C", aggfunc="count")
+
+    assert res.index.dtype == np.dtype('datetime64[ns]')
+
+
 def test_pivot_table_errors():
     df = pd.DataFrame(
         {

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -247,15 +247,17 @@ def test_pivot_table_dtype():
 
 
 def test_pivot_table_index_dtype():
-    df = pd.DataFrame({"A": pd.date_range(start="2019-08-01",
-                                          periods=3,
-                                          freq="1D"),
-                       "B": pd.Categorical(list("abc")),
-                       "C": [1,2,3]})
+    df = pd.DataFrame(
+        {
+            "A": pd.date_range(start="2019-08-01", periods=3, freq="1D"),
+            "B": pd.Categorical(list("abc")),
+            "C": [1, 2, 3],
+        }
+    )
     ddf = dd.from_pandas(df, 2)
     res = dd.pivot_table(ddf, index="A", columns="B", values="C", aggfunc="count")
 
-    assert res.index.dtype == np.dtype('datetime64[ns]')
+    assert res.index.dtype == np.dtype("datetime64[ns]")
 
 
 def test_pivot_table_errors():


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

I followed the recommended fix by @TomAugspurger and added a basic test for an index with type `datetime64`. Resolves #5379 