### PR TITLE
Reducing read_metadata output size in pyarrow/parquet

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -249,7 +249,9 @@ class ArrowEngine(Engine):
         # This is a list of row-group-descriptor dicts, or file-paths
         # if we have a list of files and gather_statistics=False
         if not parts:
-            parts = [(piece.path, piece.partition_keys) for piece in pieces]
+            parts = [
+                (piece.path, piece.row_group, piece.partition_keys) for piece in pieces
+            ]
         parts = [
             {
                 "piece": piece,
@@ -272,10 +274,11 @@ class ArrowEngine(Engine):
                 piece, open_file_func=partial(fs.open, mode="rb")
             )
         else:
-            # `piece` contains (path, partition_keys)
+            # `piece` contains (path, row_group, partition_keys)
             piece = pq.ParquetDatasetPiece(
                 piece[0],
-                partition_keys=piece[1],
+                row_group=piece[1],
+                partition_keys=piece[2],
                 open_file_func=partial(fs.open, mode="rb"),
             )
         df = piece.read(

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -341,6 +341,8 @@ class FastParquetEngine(Engine):
         else:
             if isinstance(pf, tuple):
                 pf = _determine_pf_parts(fs, pf[0], pf[1], **kwargs)[1]
+                pf._dtypes = lambda *args: pf.dtypes  # ugly patch, could be fixed
+                pf.fmd.row_groups = None
             piece = pf.row_groups[piece]
             pf.fmd.key_value_metadata = None
             df = pf.read_row_group_file(

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -82,16 +82,21 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
     (if `gather_statistics=None`).
     """
     parts = []
+    fast_metadata = True
     if len(paths) > 1:
+        base, fns = _analyze_paths(paths, fs)
+        relpaths = [path.replace(base, "").lstrip("/") for path in paths]
         if gather_statistics is not False:
             # This scans all the files, allowing index/divisions
             # and filtering
             pf = ParquetFile(
                 paths, open_with=fs.open, sep=fs.sep, **kwargs.get("file", {})
             )
+            if "_metadata" not in relpaths:
+                fast_metadata = False
         else:
-            base, fns = _analyze_paths(paths, fs)
-            relpaths = [path.replace(base, "").lstrip("/") for path in paths]
+            # base, fns = _analyze_paths(paths, fs)
+            # relpaths = [path.replace(base, "").lstrip("/") for path in paths]
             if "_metadata" in relpaths:
                 # We have a _metadata file, lets use it
                 pf = ParquetFile(
@@ -128,6 +133,7 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
             elif gather_statistics is not False:
                 # Scan every file
                 pf = ParquetFile(paths, open_with=fs.open, **kwargs.get("file", {}))
+                fast_metadata = False
             else:
                 # Use _common_metadata file if it is available.
                 # Otherwise, just use 0th file
@@ -151,7 +157,7 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
                 paths[0], open_with=fs.open, sep=fs.sep, **kwargs.get("file", {})
             )
 
-    return parts, pf, gather_statistics
+    return parts, pf, gather_statistics, fast_metadata
 
 
 class FastParquetEngine(Engine):
@@ -169,7 +175,7 @@ class FastParquetEngine(Engine):
         # Also, initialize `parts`.  If `parts` is populated here,
         # then each part will correspond to a file.  Otherwise, each part will
         # correspond to a row group (populated below).
-        parts, pf, gather_statistics = _determine_pf_parts(
+        parts, pf, gather_statistics, fast_metadata = _determine_pf_parts(
             fs, paths, gather_statistics, **kwargs
         )
 
@@ -299,18 +305,16 @@ class FastParquetEngine(Engine):
         # if we have a list of files and gather_statistics=False
         if not parts:
             partsin = pf.row_groups
-            pf.fmd.key_value_metadata = None
+            if fast_metadata:
+                pf = (paths, gather_statistics)
         else:
-            pf = None
             partsin = parts
+            pf = None
         parts = []
-        for piece in partsin:
-            if pf is not None:
-                for col in piece.columns:
-                    col.meta_data.statistics = None
-                    col.meta_data.encoding_stats = None
+        for i, piece in enumerate(partsin):
+            piece_item = i if pf else piece
             part = {
-                "piece": piece,
+                "piece": piece_item,
                 "kwargs": {"pf": pf, "categories": categories_dict or categories},
             }
             parts.append(part)
@@ -322,11 +326,7 @@ class FastParquetEngine(Engine):
         if isinstance(index, list):
             columns += index
 
-        if pf:
-            df = pf.read_row_group_file(
-                piece, columns, categories, index=index, **kwargs.get("read", {})
-            )
-        else:
+        if pf is None:
             base, fns = _analyze_paths([piece], fs)
             scheme = get_file_scheme(fns)
             pf = ParquetFile(piece, open_with=fs.open)
@@ -338,6 +338,14 @@ class FastParquetEngine(Engine):
             pf.cats = _paths_to_cats(fns, scheme)
             pf.fn = base
             df = pf.to_pandas(columns, categories, index=index)
+        else:
+            if isinstance(pf, tuple):
+                pf = _determine_pf_parts(fs, pf[0], pf[1], **kwargs)[1]
+            piece = pf.row_groups[piece]
+            pf.fmd.key_value_metadata = None
+            df = pf.read_row_group_file(
+                piece, columns, categories, index=index, **kwargs.get("read", {})
+            )
 
         return df
 

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -95,8 +95,6 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
             if "_metadata" not in relpaths:
                 fast_metadata = False
         else:
-            # base, fns = _analyze_paths(paths, fs)
-            # relpaths = [path.replace(base, "").lstrip("/") for path in paths]
             if "_metadata" in relpaths:
                 # We have a _metadata file, lets use it
                 pf = ParquetFile(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1966,3 +1966,21 @@ def test_timeseries_nulls_in_schema(tmpdir, engine):
             check_divisions=False,
             check_index=False,
         )
+
+
+def test_graph_size_pyarrow(tmpdir):
+    check_pyarrow()
+
+    import pickle
+
+    fn = str(tmpdir)
+
+    ddf1 = dask.datasets.timeseries(
+        start="2000-01-01", end="2000-01-02", freq="60S", partition_freq="1H"
+    )
+
+    eng = "pyarrow"
+    ddf1.to_parquet(fn, engine=eng)
+    ddf2 = dd.read_parquet(fn, engine=eng)
+
+    assert len(pickle.dumps(ddf2.__dask_graph__())) < 10000

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1968,9 +1968,7 @@ def test_timeseries_nulls_in_schema(tmpdir, engine):
         )
 
 
-def test_graph_size_pyarrow(tmpdir):
-    check_pyarrow()
-
+def test_graph_size_pyarrow(tmpdir, engine):
     import pickle
 
     fn = str(tmpdir)
@@ -1979,8 +1977,7 @@ def test_graph_size_pyarrow(tmpdir):
         start="2000-01-01", end="2000-01-02", freq="60S", partition_freq="1H"
     )
 
-    eng = "pyarrow"
-    ddf1.to_parquet(fn, engine=eng)
-    ddf2 = dd.read_parquet(fn, engine=eng)
+    ddf1.to_parquet(fn, engine=engine)
+    ddf2 = dd.read_parquet(fn, engine=engine)
 
     assert len(pickle.dumps(ddf2.__dask_graph__())) < 10000


### PR DESCRIPTION
This is possible fix for the large-dask-graph problem raised in #5357.  We avoid passing around a `pq.ParquetDataset` "piece", and instead pass around the `path` and `partition_keys` members of each `piece`.  This dramitically reduces the amount of metadata stored in the task graph.

Since this solution does require the metadata to be parsed by each task in `read_partition`, I am including the results of a simple benchmark (performed on my local machine):

```python
import dask
import dask.dataframe as dd
import cloudpickle

ddf = dask.datasets.timeseries(...)
ddf.to_parquet(file, engine="pyarrow")

read_df = dd.read_parquet(file, engine="pyarrow")
fun = read_df.__dask_graph__().values()[0]
print("Graph Size:", len(cloudpickle.dumps(fun)))
%timeit read_df.compute()
```

**OUTPUT**...

*OLD ~365 partitions*:
```
Graph Size: 206328
5.71 s ± 22.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

*NEW ~365 partitions*:
```
Graph Size: 2022
5.74 s ± 101 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

*OLD ~36k partitions*:
```
Graph Size: 2144624
16.5 s ± 648 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

*NEW ~36k partitions*:
```
Graph Size: 2022
16 s ± 1.24 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```




- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
