### PR TITLE
Add support for numpy.vectorize in funcname

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -346,6 +346,14 @@ def test_funcname_multipledispatch():
     assert funcname(functools.partial(foo, a=1)) == "foo"
 
 
+def test_funcname_numpy_vectorize():
+    np = pytest.importorskip("numpy")
+
+    func = np.vectorize(int)
+
+    assert funcname(func) == "vectorize_int"
+
+
 def test_ndeepmap():
     L = 1
     assert ndeepmap(0, inc, L) == 2

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -686,6 +686,9 @@ def funcname(func):
     # multipledispatch objects
     if "multipledispatch" in module_name and "Dispatcher" == type_name:
         return func.name
+    # numpy.vectorize objects
+    if "numpy" in module_name and "vectorize" == type_name:
+        return "vectorize_" + func.pyfunc.__name__
 
     # All other callables
     try:


### PR DESCRIPTION
This PR adds support for `numpy.vectorize` objects to `funcname` in `utils.py` (similar to `toolz.curry` and `multipledispatch`). `numpy.vectorize` objects don't have a `__name__` attribute so currently `funcname` returns the string representation of the object:

```python
In [1]: import numpy as np

In [2]: from dask.utils import funcname

In [3]: funcname(np.vectorize(int))
Out[3]: '<numpy.vectorize object at 0x110280400>'
```

This impacts `da.gufunc` in that when `vectorize=True` a deterministic `.name` is not produced. For example, running:

```python
import numpy as np
import dask.array as da

a = np.arange(25, dtype=np.float64).reshape(5, 5)
x = da.from_array(a, chunks=(2, 2))

print('With vectorize=True')
for _ in range(3):
    # These will all be different
    print(da.gufunc(int, signature="()->()", output_dtypes="int", vectorize=True)(x).name)
    
print('With vectorize=False')
for _ in range(3):
    # These will all be the same
    print(da.gufunc(int, signature="()->()", output_dtypes="int", vectorize=False)(x).name)
```

outputs:

```
With vectorize=True
transpose-8ea88bc4583435ddb2df090b1ec7656f
transpose-c69ba9a64d19bbc94d9e215a8240c338
transpose-223766214d0c94c74a8f036099a60b79
With vectorize=False
transpose-4eedbcddb1b68531b9a52ba6b6219f07
transpose-4eedbcddb1b68531b9a52ba6b6219f07
transpose-4eedbcddb1b68531b9a52ba6b6219f07
```


- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
