### PR TITLE
Fix funcname when vectorized func has no __name__

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -360,9 +360,14 @@ def test_funcname_multipledispatch():
 def test_funcname_numpy_vectorize():
     np = pytest.importorskip("numpy")
 
-    func = np.vectorize(int)
+    vfunc = np.vectorize(int)
+    assert funcname(vfunc) == "vectorize_int"
 
-    assert funcname(func) == "vectorize_int"
+    # Regression test for https://github.com/pydata/xarray/issues/3303
+    # Partial functions don't have a __name__ attribute
+    func = functools.partial(np.add, out=None)
+    vfunc = np.vectorize(func)
+    assert funcname(vfunc) == "vectorize_add"
 
 
 def test_ndeepmap():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -688,7 +688,7 @@ def funcname(func):
         return func.name[:50]
     # numpy.vectorize objects
     if "numpy" in module_name and "vectorize" == type_name:
-        return ("vectorize_" + func.pyfunc.__name__)[:50]
+        return ("vectorize_" + funcname(func.pyfunc))[:50]
 
     # All other callables
     try:


### PR DESCRIPTION
This is a follow-up PR to #5396 to ensure `funcname` still works on `np.vectorize` objects that are vectorizing a function without a `__name__` attribute (e.g. `functools.partial` functions do not have a `__name__` attribute)

xref https://github.com/pydata/xarray/issues/3303

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
