### PR TITLE
Use pandas to cast row-group statistics in pyarrow.read_metadata

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -217,10 +217,11 @@ class ArrowEngine(Engine):
                             if None in [cs_min, cs_max]:
                                 skip_cols.add(name)
                                 continue
+                            cs_vals = pd.Series([cs_min, cs_max])
                             d.update(
                                 {
-                                    "min": cs_min,
-                                    "max": cs_max,
+                                    "min": cs_vals[0],
+                                    "max": cs_vals[1],
                                     "null_count": column.statistics.null_count,
                                 }
                             )


### PR DESCRIPTION
This is a very simple fix for #5398 (which was caused by [a recent pyarrow change](https://github.com/apache/arrow/commit/6f724576a98651ed32d915aa5367bd3b03bb4a86)).  

Since pyarrow-parquet will now only return `pandas.Timestamp` for nanosecond resolution, it has become possible for the row-group-statistics metadata to reflect `datetime.datetime` for columns/indices that were originally `pd.Timestamp`.  Pandas is already used to convert the types to define `meta`, so this PR simply uses pandas to cast the statistics as well.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

closes #5398 