### PR TITLE
Skip another zarr-using test if it's unavailable.

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4177,6 +4177,7 @@ def test_compute_chunk_sizes_warning_fixes_rechunk(unknown):
 
 
 def test_compute_chunk_sizes_warning_fixes_to_zarr(unknown):
+    pytest.importorskip('zarr')
     y = unknown
     with pytest.raises(ValueError, match="compute_chunk_sizes"):
         with StringIO() as f:


### PR DESCRIPTION
Fixes #5406.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`