### PR TITLE
Use sentinel no_default in get_dependencies

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -2,6 +2,8 @@ from itertools import chain
 
 from .utils_test import add, inc  # noqa: F401
 
+no_default = "__no_default__"
+
 
 def ishashable(x):
     """ Is x hashable?
@@ -152,7 +154,7 @@ def get(dsk, out, cache=None):
     return result
 
 
-def get_dependencies(dsk, key=None, task=None, as_list=False):
+def get_dependencies(dsk, key=None, task=no_default, as_list=False):
     """ Get the immediate tasks on which this task depends
 
     Examples
@@ -183,7 +185,7 @@ def get_dependencies(dsk, key=None, task=None, as_list=False):
     """
     if key is not None:
         arg = dsk[key]
-    elif task is not None:
+    elif task is not no_default:
         arg = task
     else:
         raise ValueError("Provide either key or task")

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -133,6 +133,12 @@ def test_get_dependencies_many():
     assert s == []
 
 
+def test_get_dependencies_task_none():
+    # Regression test for https://github.com/dask/distributed/issues/2756
+    dsk = {"foo": None}
+    assert get_dependencies(dsk, task=dsk["foo"]) == set()
+
+
 def test_get_deps():
     """
     >>> dsk = {'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b')}


### PR DESCRIPTION
This PR updates our handling of the default value for `task=` in `get_dependencies` to use a sentinel `no_default` value instead of `None` (this helps with `is not None` checks in `get_dependencies`). Fixes https://github.com/dask/distributed/issues/2756

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
