### PR TITLE
Add introductory screencasts to array/dataframe/futures

### DIFF
--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -23,6 +23,15 @@ algorithms, cutting up the large array into many small arrays. This lets us
 compute on arrays larger than memory using all of our cores.  We coordinate
 these blocked algorithms using Dask graphs.
 
+.. raw:: html
+
+   <iframe width="560"
+           height="315"
+           src="https://www.youtube.com/embed/ZrP-QTxwwnU"
+           frameborder="0"
+           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+           allowfullscreen></iframe>
+
 Design
 ------
 

--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -27,7 +27,7 @@ these blocked algorithms using Dask graphs.
 
    <iframe width="560"
            height="315"
-           src="https://www.youtube.com/embed/ZrP-QTxwwnU"
+           src="https://www.youtube.com/embed/9h_61hXCDuI"
            frameborder="0"
            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
            allowfullscreen></iframe>

--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -28,6 +28,7 @@ these blocked algorithms using Dask graphs.
    <iframe width="560"
            height="315"
            src="https://www.youtube.com/embed/9h_61hXCDuI"
+           style="margin: 0 auto 20px auto; display: block;"
            frameborder="0"
            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
            allowfullscreen></iframe>

--- a/docs/source/dataframe.rst
+++ b/docs/source/dataframe.rst
@@ -25,7 +25,7 @@ on the constituent Pandas DataFrames.
 
    <iframe width="560"
            height="315"
-           src="https://www.youtube.com/embed/6qwlDc959b0"
+           src="https://www.youtube.com/embed/AT2XtFehFSQ"
            frameborder="0"
            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
            allowfullscreen></iframe>

--- a/docs/source/dataframe.rst
+++ b/docs/source/dataframe.rst
@@ -21,6 +21,15 @@ for larger-than-memory computing on a single machine, or on many different
 machines in a cluster.  One Dask DataFrame operation triggers many operations
 on the constituent Pandas DataFrames.
 
+.. raw:: html
+
+   <iframe width="560"
+           height="315"
+           src="https://www.youtube.com/embed/6qwlDc959b0"
+           frameborder="0"
+           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+           allowfullscreen></iframe>
+
 Design
 ------
 

--- a/docs/source/dataframe.rst
+++ b/docs/source/dataframe.rst
@@ -26,6 +26,7 @@ on the constituent Pandas DataFrames.
    <iframe width="560"
            height="315"
            src="https://www.youtube.com/embed/AT2XtFehFSQ"
+           style="margin: 0 auto 20px auto; display: block;"
            frameborder="0"
            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
            allowfullscreen></iframe>

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -17,6 +17,7 @@ despite its name, runs very well on a single machine).
    <iframe width="560"
            height="315"
            src="https://www.youtube.com/embed/07EiCpdhtDE"
+           style="margin: 0 auto 20px auto; display: block;"
            frameborder="0"
            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
            allowfullscreen></iframe>

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -12,6 +12,15 @@ These features depend on the second generation task scheduler found in
 `dask.distributed <https://distributed.dask.org/en/latest>`_ (which,
 despite its name, runs very well on a single machine).
 
+.. raw:: html
+
+   <iframe width="560"
+           height="315"
+           src="https://www.youtube.com/embed/4gLaEbchZW0"
+           frameborder="0"
+           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+           allowfullscreen></iframe>
+
 .. currentmodule:: distributed
 
 Start Dask Client

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -16,7 +16,7 @@ despite its name, runs very well on a single machine).
 
    <iframe width="560"
            height="315"
-           src="https://www.youtube.com/embed/4gLaEbchZW0"
+           src="https://www.youtube.com/embed/07EiCpdhtDE"
            frameborder="0"
            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
            allowfullscreen></iframe>


### PR DESCRIPTION
These videos provide a short 5m introduction to each of arrays/dataframes/futures.  I plan to link them to each other, and maybe include them in docs.  Do we want to do this?

I'm also inclined to make a bunch of these.  To that end, feedback would be welcome.  I would also be totally open if we want to have another, more audiogenic person do this.