### PR TITLE
Test numeric edge case for repartition with npartitions.

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1794,6 +1794,18 @@ def test_repartition_npartitions_same_limits():
     ddf.repartition(npartitions=10)
 
 
+def test_repartition_npartitions_numeric_edge_case():
+    """
+    Test that we cover numeric edge cases when
+    int(ddf.npartitions / npartitions) * npartitions) != ddf.npartitions
+    """
+    df = pd.DataFrame({"x": range(100)})
+    a = dd.from_pandas(df, npartitions=15)
+    assert a.npartitions == 15
+    b = a.repartition(npartitions=11)
+    assert_eq(a, b)
+
+
 def test_repartition_object_index():
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6] * 10}, index=list("abdabd") * 10)
     a = dd.from_pandas(df, npartitions=5)


### PR DESCRIPTION
We had an issue with Dask 1.2.0 where repartitioning a certain number of source partitions into a certain number of target partitions led to one partition missing from the result. In the end, we found that this is because of a numeric instability when determining divisions (dividing and multiplying again with the same number might not always yield exactly the original number, but slightly less, which causes a problem here: https://github.com/dask/dask/blob/master/dask/dataframe/core.py#L5516).

Example:
```
>>> (15/11)*11
14.999999999999998
>>> int((15/11)*11)
14
```

With Dask >=2, the problem was fixed by introducing this check: https://github.com/dask/dask/commit/c4b677086a20a73977ba5731b0798db0032cbba5#diff-492da7893fa5fa6ad3a6ef6cdef985f2R4821

Nevertheless, it would be safer to preclude any chance of the same bug being introduced again by adding a test, as done by this PR.

- [ x ] Tests added / passed
- [ x ] Passes `black dask` / `flake8 dask`
