### PR TITLE
Make da.unify_chunks public API

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -19,6 +19,7 @@ try:
         broadcast_to,
         from_zarr,
         to_zarr,
+        unify_chunks,
     )
     from .tiledb_io import from_tiledb, to_tiledb
     from .numpy_compat import rollaxis, moveaxis

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3074,6 +3074,10 @@ def unify_chunks(*args, **kwargs):
     """
     Unify chunks across a sequence of arrays
 
+    This utility function is used within other common operations like
+    ``map_blocks`` and ``blockwise``.  It is not commonly used by end-users
+    directly.
+
     Parameters
     ----------
     *args: sequence of Array, index pairs

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -187,6 +187,7 @@ Top level user functions:
    tril
    triu
    trunc
+   unify_chunks
    unique
    unravel_index
    var


### PR DESCRIPTION
Fixes #5442

This is useful for Xarray's map_blocks functionality

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
