### PR TITLE
Fix for #5448: Correct chunk size logic in `map_overlap` for asymmetric overlaps

### DIFF
--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -157,8 +157,8 @@ def overlap_internal(x, axes):
         if len(bds) == 1:
             chunks.append(bds)
         else:
-            left = [bds[0] + left_depth]
-            right = [bds[-1] + right_depth]
+            left = [bds[0] + right_depth]
+            right = [bds[-1] + left_depth]
             mid = []
             for bd in bds[1:-1]:
                 mid.append(bd + left_depth + right_depth)

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -74,7 +74,7 @@ def test_overlap_internal_asymmetric():
     d = da.from_array(x, chunks=(4, 4))
 
     result = overlap_internal(d, {0: (2, 0), 1: (1, 0)})
-    assert result.chunks == ((6, 4), (5, 4))
+    assert result.chunks == ((4, 6), (4, 5))
 
     expected = np.array(
         [


### PR DESCRIPTION
See #5448 
I've modified the test for this code as I think it was incorrect. Would appreciate another pair of eyes on it though.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
