### PR TITLE
Fix map(series) for unsorted base series index

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6098,7 +6098,7 @@ def mapseries(base_chunk, concat_map):
 
 def mapseries_combine(index, concat_result):
     final_series = concat_result.sort_index()
-    final_series.index = index
+    final_series = pd.Series(index, index=index).map(final_series)
     return final_series
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6097,8 +6097,7 @@ def mapseries(base_chunk, concat_map):
 
 
 def mapseries_combine(index, concat_result):
-    final_series = concat_result.sort_index()
-    final_series = pd.Series(index, index=index).map(final_series)
+    final_series = concat_result.take(index.argsort())
     return final_series
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6098,7 +6098,7 @@ def mapseries(base_chunk, concat_map):
 
 def mapseries_combine(index, concat_result):
     final_series = concat_result.sort_index()
-    final_series = pd.Series(index, index=index).map(final_series)
+    final_series = index.to_series().map(final_series)
     return final_series
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6097,7 +6097,7 @@ def mapseries(base_chunk, concat_map):
 
 
 def mapseries_combine(index, concat_result):
-    final_series = concat_result.take(index.argsort())
+    final_series = concat_result.sort_index().take(index.argsort())
     return final_series
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6097,7 +6097,8 @@ def mapseries(base_chunk, concat_map):
 
 
 def mapseries_combine(index, concat_result):
-    final_series = concat_result.sort_index().take(index.argsort())
+    final_series = concat_result.sort_index()
+    final_series = pd.Series(index, index=index).map(final_series)
     return final_series
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4046,8 +4046,8 @@ def test_series_map(base_npart, map_npart, sorted_index, sorted_map_index):
         np.random.shuffle(map_index)
         mapper.index = map_index
     expected = base.map(mapper)
-    dask_base = dd.from_pandas(base, npartitions=base_npart)
-    dask_map = dd.from_pandas(mapper, npartitions=map_npart)
+    dask_base = dd.from_pandas(base, npartitions=base_npart, sort=False)
+    dask_map = dd.from_pandas(mapper, npartitions=map_npart, sort=False)
     result = dask_base.map(dask_map)
     dd.utils.assert_eq(expected, result)
 


### PR DESCRIPTION
Found a bug where tests were not actually catching this, fixes https://github.com/dask/dask/issues/5458

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
