### PR TITLE
Fix dask.dataframe.fillna handling of Scalar object

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1128,6 +1128,8 @@ Dask Name: {name}, {task} tasks""".format(
             raise NotImplementedError("fillna with set limit and method=None")
         if isinstance(value, _Frame):
             test_value = value._meta_nonempty.values[0]
+        elif isinstance(value, Scalar):
+            test_value = value._meta_nonempty
         else:
             test_value = value
         meta = self._meta_nonempty.fillna(

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1914,6 +1914,7 @@ def test_fillna():
 
     assert_eq(ddf.fillna(100), df.fillna(100))
     assert_eq(ddf.A.fillna(100), df.A.fillna(100))
+    assert_eq(ddf.A.fillna(ddf["A"].mean()), df.A.fillna(df["A"].mean()))
 
     assert_eq(ddf.fillna(method="pad"), df.fillna(method="pad"))
     assert_eq(ddf.A.fillna(method="pad"), df.A.fillna(method="pad"))


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`

Fix #5461