### PR TITLE
Raise more informative exception if there's no matching files in read_hdf

### DIFF
--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -473,6 +473,8 @@ def read_hdf(
         paths = sorted(glob(pattern))
     else:
         paths = pattern
+    if len(paths) == 0:
+        raise FileNotFoundError("No matching file(s) found for path")
     if (start != 0 or stop is not None) and len(paths) > 1:
         raise NotImplementedError(read_hdf_error_msg)
     if chunksize <= 0:


### PR DESCRIPTION
Raise more informative exception if there's no matching files in ``read_hdf``
Fixes #1613 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
