### PR TITLE
Consolidating hash dispatch functions

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -1,6 +1,6 @@
 from .methods import concat_dispatch
 from .core import get_parallel_type, meta_nonempty, make_meta
-from .utils import hash_object_dispatch
+from .utils import hash_object_dispatch, group_split_dispatch
 
 
 ######################################
@@ -10,6 +10,7 @@ from .utils import hash_object_dispatch
 
 @concat_dispatch.register_lazy("cudf")
 @hash_object_dispatch.register_lazy("cudf")
+@group_split_dispatch.register_lazy("cudf")
 @get_parallel_type.register_lazy("cudf")
 @meta_nonempty.register_lazy("cudf")
 @make_meta.register_lazy("cudf")

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -4,10 +4,9 @@ import numpy as np
 import pandas as pd
 from pandas.util import hash_pandas_object
 from pandas.api.types import is_categorical_dtype, union_categoricals
-from pandas._libs.algos import groupsort_indexer
 from toolz import partition
 
-from .utils import PANDAS_VERSION, is_series_like, is_dataframe_like, PANDAS_GT_0250
+from .utils import PANDAS_VERSION, is_series_like, is_dataframe_like, PANDAS_GT_0250, hash_object_dispatch, group_split_dispatch
 from ..utils import Dispatch
 
 if PANDAS_VERSION >= "0.23":
@@ -480,32 +479,12 @@ def concat_pandas(dfs, axis=0, join="outer", uniform=False, filter_warning=True)
     return out
 
 
+# cuDF may try to import old dispatch functions
+hash_df = hash_object_dispatch
+group_split = group_split_dispatch
+
+
 def assign_index(df, ind):
     df = df.copy()
     df.index = ind
     return df
-
-
-# ---------------------------------
-# Shuffling/merging/sorting
-# ---------------------------------
-
-
-hash_df = Dispatch("hash_df")
-
-
-@hash_df.register((pd.DataFrame, pd.Series, pd.Index))
-def hash_df_pandas(dfs):
-    return hash_pandas_object(dfs, index=False)
-
-
-group_split = Dispatch("group_split")
-
-
-@group_split.register((pd.DataFrame, pd.Series, pd.Index))
-def group_split_pandas(df, c, k):
-    indexer, locations = groupsort_indexer(c, k)
-    df2 = df.take(indexer)
-    locations = locations.cumsum()
-    parts = [df2.iloc[a:b] for a, b in zip(locations[:-1], locations[1:])]
-    return dict(zip(range(k), parts))

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -6,7 +6,14 @@ from pandas.util import hash_pandas_object
 from pandas.api.types import is_categorical_dtype, union_categoricals
 from toolz import partition
 
-from .utils import PANDAS_VERSION, is_series_like, is_dataframe_like, PANDAS_GT_0250, hash_object_dispatch, group_split_dispatch
+from .utils import (
+    PANDAS_VERSION,
+    is_series_like,
+    is_dataframe_like,
+    PANDAS_GT_0250,
+    hash_object_dispatch,
+    group_split_dispatch,
+)
 from ..utils import Dispatch
 
 if PANDAS_VERSION >= "0.23":

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -2,7 +2,6 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from pandas.util import hash_pandas_object
 from pandas.api.types import is_categorical_dtype, union_categoricals
 from toolz import partition
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -462,6 +462,18 @@ def hash_object_pandas(
     )
 
 
+group_split_dispatch = Dispatch("group_split_dispatch")
+
+
+@group_split_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
+def group_split_pandas(df, c, k):
+    indexer, locations = pd._libs.algos.groupsort_indexer(c, k)
+    df2 = df.take(indexer)
+    locations = locations.cumsum()
+    parts = [df2.iloc[a:b] for a, b in zip(locations[:-1], locations[1:])]
+    return dict(zip(range(k), parts))
+
+
 _simple_fake_mapping = {
     "b": np.bool_(True),
     "V": np.void(b" "),


### PR DESCRIPTION
Both [#5184 ](https://github.com/dask/dask/pull/5184) and [#5322 ](https://github.com/dask/dask/pull/5322) have implemented/used dispatch functions to generalize the use of Pandas' `hash_pandas_object` function.

This PR (mostly) drops the use of `hash_df` (introduced in #5322 ) and moves both the hash_df and group_split dispatch functions into `dask.dataframe.utils` (for consistency with other non-method dispatches).

Note that definitions of `hash_df` and `group_split` are left in `dask.dataframe.methods` only to avoid breaking dask_cudf in the short term.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
