### PR TITLE
Replace series_type_like_df with _constructor_sliced

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -15,7 +15,7 @@ from ..delayed import delayed
 from ..highlevelgraph import HighLevelGraph
 from ..sizeof import sizeof
 from ..utils import digit, insert, M
-from .utils import series_type_like_df, hash_object_dispatch, group_split_dispatch
+from .utils import hash_object_dispatch, group_split_dispatch
 
 
 def set_index(
@@ -170,8 +170,8 @@ def set_partition(
     shuffle
     partd
     """
-    divisions = series_type_like_df(df)(divisions)
-    meta = series_type_like_df(df)([0])
+    divisions = df._meta._constructor_sliced(divisions)
+    meta = df._meta._constructor_sliced([0])
     if np.isscalar(index):
         partitions = df[index].map_partitions(
             set_partitions_pre, divisions=divisions, meta=meta
@@ -235,7 +235,7 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32, compute=No
     partitions = index.map_partitions(
         partitioning_index,
         npartitions=npartitions or df.npartitions,
-        meta=series_type_like_df(df)([0]),
+        meta=df._meta._constructor_sliced([0]),
         transform_divisions=False,
     )
     df2 = df.assign(_partitions=partitions)
@@ -254,8 +254,8 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32, compute=No
 
 def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None):
     """ Shuffle dataframe so that column separates along divisions """
-    divisions = series_type_like_df(df)(divisions)
-    meta = series_type_like_df(df)([0])
+    divisions = df._meta._constructor_sliced(divisions)
+    meta = df._meta._constructor_sliced([0])
     # Assign target output partitions to every row
     partitions = df[column].map_partitions(
         set_partitions_pre, divisions=divisions, meta=meta

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1963,3 +1963,20 @@ def test_multi_duplicate_divisions():
     r2 = sf1.merge(sf2, how="left", left_index=True, right_index=True)
 
     assert_eq(r1, r2)
+
+
+def test_merge_outer_empty():
+    # Issue #5470 bug reproducer
+    k_clusters = 3
+    df = pd.DataFrame(
+        {"user": ["A", "B", "C", "D", "E", "F"], "cluster": [1, 1, 2, 2, 3, 3]}
+    )
+    df = dd.from_pandas(df, npartitions=10)
+    empty_df = dd.from_pandas(pd.DataFrame(), npartitions=10)
+
+    for x in range(0, k_clusters + 1):
+        assert_eq(
+            dd.merge(empty_df, df[df.cluster == x], how="outer").compute(),
+            df[df.cluster == x].compute(),
+            check_index=False,
+        )

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -679,13 +679,6 @@ def index_summary(idx, name=None):
     return "{}: {} entries{}".format(name, n, summary)
 
 
-def series_type_like_df(df):
-    """Get the concrete series type compatible with df."""
-    # TODO: https://github.com/pandas-dev/pandas/issues/27824
-    # Use a standard API, which will handle empty DataFrames.
-    return type(df._meta.iloc[:, 0])
-
-
 ###############################################################
 # Testing
 ###############################################################


### PR DESCRIPTION
Closes #5470 

This PR implements the [recommendation](https://github.com/dask/dask/pull/5205#discussion_r312178469) by @TomAugspurger to use the (more-robust) `_constructor_sliced` method in place of `series_type_like_df`.  Now that cudf has this method defined, there is no reason not to use it in the dask.dataframe shuffle-related code.

This PR also adds a test (`test_merge_outer_empty`) for the case that *broke* `series_type_like_df` (described in #5470 )

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
