### PR TITLE
Remove old parquet and bcolz dataframe optimizations

### DIFF
--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -1,7 +1,7 @@
 """ Dataframe optimizations """
 import operator
 
-from ..optimization import cull, fuse_getitem, fuse
+from ..optimization import cull, fuse
 from .. import config, core
 from ..highlevelgraph import HighLevelGraph
 from ..utils import ensure_dict
@@ -16,17 +16,11 @@ def optimize(dsk, keys, **kwargs):
         dsk = optimize_blockwise(dsk, keys=list(core.flatten(keys)))
 
     dsk = ensure_dict(dsk)
-    from .io import dataframe_from_ctable
 
     if isinstance(keys, list):
         dsk, dependencies = cull(dsk, list(core.flatten(keys)))
     else:
         dsk, dependencies = cull(dsk, [keys])
-    dsk = fuse_getitem(dsk, dataframe_from_ctable, 3)
-
-    from .io.parquet import read_parquet_part
-
-    dsk = fuse_getitem(dsk, read_parquet_part, 4)
 
     dsk, dependencies = fuse(
         dsk,

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -1,9 +1,4 @@
-import pytest
-from operator import getitem
-from toolz import merge
-
 import dask
-from dask.dataframe.io import dataframe_from_ctable
 import dask.dataframe as dd
 import pandas as pd
 
@@ -13,29 +8,6 @@ dsk = {
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
 }
 dfs = list(dsk.values())
-
-
-def test_column_optimizations_with_bcolz_and_rewrite():
-    bcolz = pytest.importorskip("bcolz")
-
-    bc = bcolz.ctable([[1, 2, 3], [10, 20, 30]], names=["a", "b"])
-    for cols in [None, "abc", ["abc"]]:
-        dsk2 = merge(
-            dict(
-                (("x", i), (dataframe_from_ctable, bc, slice(0, 2), cols, {}))
-                for i in [1, 2, 3]
-            ),
-            dict((("y", i), (getitem, ("x", i), ["a", "b"])) for i in [1, 2, 3]),
-        )
-
-        expected = dict(
-            (("y", i), (dataframe_from_ctable, bc, slice(0, 2), ["a", "b"], {}))
-            for i in [1, 2, 3]
-        )
-
-        with dask.config.set(fuse_ave_width=0):
-            result = dd.optimize(dsk2, [("y", i) for i in [1, 2, 3]])
-        assert result == expected
 
 
 def test_fuse_ave_width():

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -1,6 +1,5 @@
 import math
 import re
-from operator import getitem
 
 from . import config, core
 from .core import (
@@ -422,36 +421,6 @@ def fuse_selections(dsk, head1, head2, merge):
         except TypeError:
             dsk2[k] = v
     return dsk2
-
-
-def fuse_getitem(dsk, func, place):
-    """ Fuse getitem with lower operation
-
-    Parameters
-    ----------
-    dsk: dict
-        dask graph
-    func: function
-        A function in a task to merge
-    place: int
-        Location in task to insert the getitem key
-
-    Examples
-    --------
-    >>> def load(store, partition, columns):
-    ...     pass
-    >>> dsk = {'x': (load, 'store', 'part', ['a', 'b']),
-    ...        'y': (getitem, 'x', 'a')}
-    >>> dsk2 = fuse_getitem(dsk, load, 3)  # columns in arg place 3
-    >>> cull(dsk2, 'y')[0]
-    {'y': (<function load at ...>, 'store', 'part', 'a')}
-    """
-    return fuse_selections(
-        dsk,
-        getitem,
-        func,
-        lambda a, b: tuple(b[:place]) + (a[2],) + tuple(b[place + 1 :]),
-    )
 
 
 def default_fused_keys_renamer(keys):

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -376,53 +376,6 @@ def functions_of(task):
     return funcs
 
 
-def fuse_selections(dsk, head1, head2, merge):
-    """Fuse selections with lower operation.
-
-    Handles graphs of the form:
-    ``{key1: (head1, key2, ...), key2: (head2, ...)}``
-
-    Parameters
-    ----------
-    dsk : dict
-        dask graph
-    head1 : function
-        The first element of task1
-    head2 : function
-        The first element of task2
-    merge : function
-        Takes ``task1`` and ``task2`` and returns a merged task to
-        replace ``task1``.
-
-    Examples
-    --------
-    >>> def load(store, partition, columns):
-    ...     pass
-    >>> dsk = {'x': (load, 'store', 'part', ['a', 'b']),
-    ...        'y': (getitem, 'x', 'a')}
-    >>> merge = lambda t1, t2: (load, t2[1], t2[2], t1[2])
-    >>> dsk2 = fuse_selections(dsk, getitem, load, merge)
-    >>> cull(dsk2, 'y')[0]
-    {'y': (<function load at ...>, 'store', 'part', 'a')}
-    """
-    dsk2 = dict()
-    for k, v in dsk.items():
-        try:
-            if (
-                istask(v)
-                and v[0] == head1
-                and v[1] in dsk
-                and istask(dsk[v[1]])
-                and dsk[v[1]][0] == head2
-            ):
-                dsk2[k] = merge(v, dsk[v[1]])
-            else:
-                dsk2[k] = v
-        except TypeError:
-            dsk2[k] = v
-    return dsk2
-
-
 def default_fused_keys_renamer(keys):
     """Create new keys for ``fuse`` tasks"""
     it = reversed(keys)

--- a/dask/tests/test_optimization.py
+++ b/dask/tests/test_optimization.py
@@ -1,6 +1,5 @@
 import itertools
 import pickle
-from operator import getitem
 from functools import partial
 
 import pytest
@@ -14,7 +13,6 @@ from dask.optimization import (
     inline,
     inline_functions,
     functions_of,
-    fuse_selections,
     fuse_linear,
     SubgraphCallable,
 )
@@ -304,17 +302,6 @@ def test_functions_of():
     assert functions_of(1) == set()
     assert functions_of(a) == set()
     assert functions_of((a,)) == set([a])
-
-
-def test_fuse_selections():
-    def load(*args):
-        pass
-
-    dsk = {"x": (load, "store", "part", ["a", "b"]), "y": (getitem, "x", "a")}
-    merge = lambda t1, t2: (load, t2[1], t2[2], t1[2])
-    dsk2 = fuse_selections(dsk, getitem, load, merge)
-    dsk2, dependencies = cull(dsk2, "y")
-    assert dsk2 == {"y": (load, "store", "part", "a")}
 
 
 def test_inline_cull_dependencies():

--- a/dask/tests/test_optimization.py
+++ b/dask/tests/test_optimization.py
@@ -14,7 +14,6 @@ from dask.optimization import (
     inline,
     inline_functions,
     functions_of,
-    fuse_getitem,
     fuse_selections,
     fuse_linear,
     SubgraphCallable,
@@ -305,16 +304,6 @@ def test_functions_of():
     assert functions_of(1) == set()
     assert functions_of(a) == set()
     assert functions_of((a,)) == set([a])
-
-
-def test_fuse_getitem():
-    def load(*args):
-        pass
-
-    dsk = {"x": (load, "store", "part", ["a", "b"]), "y": (getitem, "x", "a")}
-    dsk2 = fuse_getitem(dsk, load, 3)
-    dsk2, dependencies = cull(dsk2, "y")
-    assert dsk2 == {"y": (load, "store", "part", "a")}
 
 
 def test_fuse_selections():


### PR DESCRIPTION
Follows on https://github.com/dask/dask/pull/5453

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
