### PR TITLE
Call ensure_dict on graphs before entering toolz.merge

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -236,7 +236,7 @@ def _extract_graph_and_keys(vals):
     if any(isinstance(graph, HighLevelGraph) for graph in graphs):
         graph = HighLevelGraph.merge(*graphs)
     else:
-        graph = merge(*graphs)
+        graph = merge(*map(ensure_dict, graphs))
 
     return graph, keys
 


### PR DESCRIPTION
Otherwise, we run afoul of a small bug in toolz
https://github.com/pytoolz/toolz/issues/468

This triggers a failure when we have a single non-dict Mapping in our
graph.  This was identified from the cudf test suite.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
