### PR TITLE
Support Python 3.5 in Parquet code

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -105,7 +105,7 @@ class ArrowEngine(Engine):
         index=None,
         gather_statistics=None,
         filters=None,
-        **kwargs,
+        **kwargs
     ):
         # Define the dataset object to use for metadata,
         # Also, initialize `parts`.  If `parts` is populated here,
@@ -307,7 +307,7 @@ class ArrowEngine(Engine):
         partition_on=None,
         ignore_divisions=False,
         division_info=None,
-        **kwargs,
+        **kwargs
     ):
         dataset = fmd = None
         i_offset = 0
@@ -406,7 +406,7 @@ class ArrowEngine(Engine):
         compression=None,
         index_cols=None,
         schema=None,
-        **kwargs,
+        **kwargs
     ):
         md_list = []
         preserve_index = False

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -14,7 +14,7 @@ try:
     from fastparquet.util import get_file_scheme
     from fastparquet.util import ex_from_sep, val_to_num, groupby_types
     from fastparquet.writer import partition_on_columns, make_part_file
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 from .utils import _parse_pandas_metadata, _normalize_index_columns, _analyze_paths


### PR DESCRIPTION
Fixes #5447

cc @TomAugspurger @quasiben 

I still don't know why black wanted to change this file.  Things seem to be valid in Python 3.5