### PR TITLE
Explicitly use iloc for row indexing within read_sql_table()

### DIFF
--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -144,7 +144,7 @@ def read_sql_table(
             return from_pandas(head, npartitions=1)
 
         bytes_per_row = (head.memory_usage(deep=True, index=True)).sum() / head_rows
-        meta = head[:0]
+        meta = head.iloc[:0]
     else:
         if divisions is None and npartitions is None:
             raise ValueError(


### PR DESCRIPTION
When I was attempting to read from my database, I was getting repeated mysterious `'KeyError': 0.0`. After digging around, it seems that for some reason the line of code `head[:0]` was attempting label-based indexing instead of row-based indexing.

The expected behaviour of that line is to return an empty dataframe that we can derive the metadata from; by explicitly using `head.iloc[:0]` we can guarantee that behaviour.

I have not been able to explain why my returned dataframe behaves strangely in this way; I have not been able to recreate it when I create a dataframe outside of this dask data pull, but this seems like a zero-loss change to make as the desired behaviour is always that of `.iloc[:0]`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
