### PR TITLE
Avoid updating with identical dicts in ensure_dict

### DIFF
--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1008,8 +1008,12 @@ def ensure_dict(d):
         return d
     elif hasattr(d, "dicts"):
         result = {}
+        seen = set()
         for dd in d.dicts.values():
-            result.update(dd)
+            dd_id = id(dd)
+            if dd_id not in seen:
+                result.update(dd)
+                seen.add(dd_id)
         return result
     return dict(d)
 


### PR DESCRIPTION
This PR updates `ensure_dict` to avoid repeated `dict.update` calls on identical dictionaries when traversing the layers of a `HighLevelGraph`. In particular, we can get many identical layers when passing collections to `dask.optimize`. 

For example, on the current `master` we have:

```python
In [1]: import dask
   ...: import dask.array as da
   ...:
   ...: x = [da.asarray([i]) for i in range(5_000)]
   ...: x_opt = dask.optimize(*x)

In [2]: %timeit -n 10 dask.compute(*x)
216 ms ± 2.14 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [3]: %timeit -n 10 dask.compute(*x_opt)
1.09 s ± 4.58 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

With the changes in this PR we have:

```python
In [2]: %timeit -n 10 dask.compute(*x)
229 ms ± 12.4 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [3]: %timeit -n 10 dask.compute(*x_opt)
219 ms ± 14.4 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
