### PR TITLE
Enable row-group task partitioning in pyarrow-based read_parquet

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -132,6 +132,7 @@ class ArrowEngine(Engine):
         index=None,
         gather_statistics=None,
         filters=None,
+        split_row_groups=True,
         **kwargs
     ):
         # Define the dataset object to use for metadata,
@@ -220,7 +221,7 @@ class ArrowEngine(Engine):
                     dataset.metadata.row_group(i)
                     for i in range(dataset.metadata.num_row_groups)
                 ]
-                if not partitions and len(dataset.paths) == 1:
+                if split_row_groups and not partitions and len(dataset.paths) == 1:
                     row_groups_per_piece = _get_row_groups_per_piece(
                         pieces, dataset.metadata, dataset.paths[0], fs
                     )
@@ -284,7 +285,7 @@ class ArrowEngine(Engine):
         # This is a list of row-group-descriptor dicts, or file-paths
         # if we have a list of files and gather_statistics=False
         if not parts:
-            if row_groups_per_piece:
+            if split_row_groups and row_groups_per_piece:
                 parts = []
                 for i, piece in enumerate(pieces):
                     num_row_groups = row_groups_per_piece[i]

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1,4 +1,5 @@
 from functools import partial
+from collections import OrderedDict
 import json
 
 import pandas as pd
@@ -35,6 +36,7 @@ def _get_md_row_groups(pieces):
         row_groups_per_piece.append(num_row_groups)
     if len(row_groups) == len(pieces):
         row_groups_per_piece = None
+    # TODO: Skip row_groups_per_piece after ARROW-2801
     return row_groups, row_groups_per_piece
 
 
@@ -43,10 +45,9 @@ def _get_row_groups_per_piece(pieces, metadata, path, fs):
 
     This function requires access to ParquetDataset.metadata
     """
+    # TODO: Remove this function after ARROW-2801
     if metadata.num_row_groups == len(pieces):
         return None  # pieces already map to row-groups
-
-    from collections import OrderedDict
 
     result = OrderedDict()
     for piece in pieces:
@@ -133,7 +134,7 @@ class ArrowEngine(Engine):
         gather_statistics=None,
         filters=None,
         split_row_groups=True,
-        **kwargs
+        **kwargs,
     ):
         # Define the dataset object to use for metadata,
         # Also, initialize `parts`.  If `parts` is populated here,
@@ -142,6 +143,9 @@ class ArrowEngine(Engine):
         parts, dataset = _determine_dataset_parts(
             fs, paths, gather_statistics, filters, kwargs.get("dataset", {})
         )
+        # TODO: Call to `_determine_dataset_parts` uses `pq.ParquetDataset`
+        # to define the `dataset` object. `split_row_groups` should be passed
+        # to that constructor once it is supported (see ARROW-2801).
         if dataset.partitions is not None:
             partitions = [
                 n for n in dataset.partitions.partition_names if n is not None
@@ -288,6 +292,7 @@ class ArrowEngine(Engine):
         # if we have a list of files and gather_statistics=False
         if not parts:
             if split_row_groups and row_groups_per_piece:
+                # TODO: This block can be removed after ARROW-2801
                 parts = []
                 for i, piece in enumerate(pieces):
                     num_row_groups = row_groups_per_piece[i]
@@ -350,7 +355,7 @@ class ArrowEngine(Engine):
         partition_on=None,
         ignore_divisions=False,
         division_info=None,
-        **kwargs
+        **kwargs,
     ):
         dataset = fmd = None
         i_offset = 0
@@ -449,7 +454,7 @@ class ArrowEngine(Engine):
         compression=None,
         index_cols=None,
         schema=None,
-        **kwargs
+        **kwargs,
     ):
         md_list = []
         preserve_index = False
@@ -475,7 +480,8 @@ class ArrowEngine(Engine):
                     metadata_collector=md_list,
                     **kwargs,
                 )
-            md_list[0].set_file_path(filename)
+            if md_list:
+                md_list[0].set_file_path(filename)
         # Return the schema needed to write the metadata
         if return_metadata:
             return [{"schema": t.schema, "meta": md_list[0]}]

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -23,14 +23,41 @@ def _get_md_row_groups(pieces):
     if any metadata or statistics are missing
     """
     row_groups = []
+    row_groups_per_piece = []
     for piece in pieces:
-        for rg in range(piece.get_metadata().num_row_groups):
+        num_row_groups = piece.get_metadata().num_row_groups
+        for rg in range(num_row_groups):
             row_group = piece.get_metadata().row_group(rg)
             for c in range(row_group.num_columns):
                 if not row_group.column(c).statistics:
                     return []
             row_groups.append(row_group)
-    return row_groups
+        row_groups_per_piece.append(num_row_groups)
+    if len(row_groups) == len(pieces):
+        row_groups_per_piece = None
+    return row_groups, row_groups_per_piece
+
+
+def _get_row_groups_per_piece(pieces, metadata, path, fs):
+    """ Determine number of row groups in each dataset piece.
+
+    This function requires access to ParquetDataset.metadata
+    """
+    if metadata.num_row_groups == len(pieces):
+        return None  # pieces already map to row-groups
+
+    from collections import OrderedDict
+
+    result = OrderedDict()
+    for piece in pieces:
+        result[piece.path] = 0
+    for rg in range(metadata.num_row_groups):
+        filename = metadata.row_group(rg).column(0).file_path
+        if filename:
+            result[fs.sep.join([path, filename])] += 1
+        else:
+            return None  # File path is missing, abort
+    return tuple(result.values())
 
 
 def _determine_dataset_parts(fs, paths, gather_statistics, filters, dataset_kwargs):
@@ -185,17 +212,22 @@ class ArrowEngine(Engine):
         if not pieces:
             gather_statistics = False
 
+        row_groups_per_piece = None
         if gather_statistics:
             # Read from _metadata file
-            if dataset.metadata and dataset.metadata.num_row_groups == len(pieces):
+            if dataset.metadata:
                 row_groups = [
                     dataset.metadata.row_group(i)
                     for i in range(dataset.metadata.num_row_groups)
                 ]
+                if not partitions and len(dataset.paths) == 1:
+                    row_groups_per_piece = _get_row_groups_per_piece(
+                        pieces, dataset.metadata, dataset.paths[0], fs
+                    )
                 names = dataset.metadata.schema.names
             else:
                 # Read from each individual piece (quite possibly slow).
-                row_groups = _get_md_row_groups(pieces)
+                row_groups, row_groups_per_piece = _get_md_row_groups(pieces)
                 if row_groups:
                     piece = pieces[0]
                     md = piece.get_metadata()
@@ -252,9 +284,17 @@ class ArrowEngine(Engine):
         # This is a list of row-group-descriptor dicts, or file-paths
         # if we have a list of files and gather_statistics=False
         if not parts:
-            parts = [
-                (piece.path, piece.row_group, piece.partition_keys) for piece in pieces
-            ]
+            if row_groups_per_piece:
+                parts = []
+                for i, piece in enumerate(pieces):
+                    num_row_groups = row_groups_per_piece[i]
+                    for rg in range(num_row_groups):
+                        parts.append((piece.path, rg, piece.partition_keys))
+            else:
+                parts = [
+                    (piece.path, piece.row_group, piece.partition_keys)
+                    for piece in pieces
+                ]
         parts = [
             {
                 "piece": piece,
@@ -432,6 +472,7 @@ class ArrowEngine(Engine):
                     metadata_collector=md_list,
                     **kwargs,
                 )
+            md_list[0].set_file_path(filename)
         # Return the schema needed to write the metadata
         if return_metadata:
             return [{"schema": t.schema, "meta": md_list[0]}]

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -146,6 +146,8 @@ class ArrowEngine(Engine):
             partitions = [
                 n for n in dataset.partitions.partition_names if n is not None
             ]
+            if partitions:
+                split_row_groups = False
         else:
             partitions = []
 
@@ -216,12 +218,12 @@ class ArrowEngine(Engine):
         row_groups_per_piece = None
         if gather_statistics:
             # Read from _metadata file
-            if dataset.metadata:
+            if dataset.metadata and dataset.metadata.num_row_groups >= len(pieces):
                 row_groups = [
                     dataset.metadata.row_group(i)
                     for i in range(dataset.metadata.num_row_groups)
                 ]
-                if split_row_groups and not partitions and len(dataset.paths) == 1:
+                if split_row_groups and len(dataset.paths) == 1:
                     row_groups_per_piece = _get_row_groups_per_piece(
                         pieces, dataset.metadata, dataset.paths[0], fs
                     )

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -91,6 +91,7 @@ def read_parquet(
     storage_options=None,
     engine="auto",
     gather_statistics=None,
+    split_row_groups=True,
     **kwargs
 ):
     """
@@ -138,6 +139,11 @@ def read_parquet(
         this will only be done if the _metadata file is available. Otherwise,
         statistics will only be gathered if True, because the footer of
         every file will be parsed (which is very slow on some systems).
+    split_row_groups : bool
+        If True (default) then output dataframe partitions will correspond
+        to parquet-file row-groups (when enough row-group metadata is
+        available). Otherwise, partitions correspond to distinct files.
+        Only the "pyarrow" engine currently supports this argument.
     **kwargs: dict (of dicts)
         Passthrough key-word arguments for read backend.
         The top-level keys correspond to the appropriate operation type, and
@@ -206,6 +212,7 @@ def read_parquet(
         index=index,
         gather_statistics=gather_statistics,
         filters=filters,
+        split_row_groups=split_row_groups,
         **kwargs
     )
     if meta.index.name is not None:


### PR DESCRIPTION
This PR adds the `split_row_groups` kwarg to `read_parquet`, which is used within the `"pyarrow"` engine to specify if output dataframe partitions should correspond to row groups (rather than distinct files).  In its current `read_metadata` definition, the `"pyarrow"` engine uses `pq.ParquetDataset.pieces`  to ultimately decide the granularity of `read_partition` tasks.  When the dataset is not *partitioned on columns*, these `pieces` each correspond to a file (note that, in contrast, the `"fastparquet"` engine uses row-groups, rather than files).

As discussed in [cudf#3142](https://github.com/rapidsai/cudf/issues/3142), in `dask_cudf` file-based task partitioning is problematic when the uncompressed file size is larger than GPU memory. 

**Notes**:
- `split_row_groups` is set to `True` by default (for consistency with fastparquet, and because this seems like a reasonable default)
- Row-group based task partitioning is disabled when `gather_statistics=False`, or when the dataset is already partitioned on 1+ columns (in the partitioned dataset case, the `pieces` are already smaller than the row-group).
- The logic added here can be dramatically simplified once the `split_row_groups` argument is implemented in pyarrow (for `pq.ParquetDataset`).  Although this argument [is already documented](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html?highlight=split_row_groups), using it results in `NotImplementedError`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
