### PR TITLE
Update da.array to always return a dask array

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -42,6 +42,7 @@ from .numpy_compat import _unravel_index_keyword
 
 @derived_from(np)
 def array(x, dtype=None, ndmin=None):
+    x = asarray(x)
     while ndmin is not None and x.ndim < ndmin:
         x = x[None, :]
     if dtype is not None and x.dtype != dtype:

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -23,6 +23,14 @@ def test_array():
     assert isinstance(y, da.Array)
 
 
+def test_array_return_type():
+    # Regression test for https://github.com/dask/dask/issues/5426
+    x = [0, 1, 2, 3]
+    dx = da.array(x)
+    assert isinstance(dx, da.Array)
+    assert_eq(x, dx)
+
+
 def test_derived_docstrings():
     assert "This docstring was copied from numpy.array" in da.routines.array.__doc__
     assert "Create an array." in da.routines.array.__doc__


### PR DESCRIPTION
This PR updates `da.array` to always return a dask array by passing it's input through `da.asarray`

Closes #5426

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
