### PR TITLE
Added a test for dask.utils.infer_storage_options` and `//`-leading paths

### DIFF
--- a/dask/bytes/tests/test_bytes_utils.py
+++ b/dask/bytes/tests/test_bytes_utils.py
@@ -66,6 +66,11 @@ def test_infer_storage_options():
     assert so.pop("path") == "/mnt/datasets/test.csv"
     assert not so
 
+    so = infer_storage_options("//mnt/datasets/test.csv")
+    assert so.pop("protocol") == "file"
+    assert so.pop("path") == "//mnt/datasets/test.csv"
+    assert not so
+
     assert infer_storage_options("./test.csv")["path"] == "./test.csv"
     assert infer_storage_options("../test.csv")["path"] == "../test.csv"
 


### PR DESCRIPTION
This adds a test which fails when the following is called:

```python
infer_storage_options("//mnt/datasets/test.csv”)
```

It returns:

```python
{'protocol': 'file', 'path’: '/datasets/test.csv', 'host': ‘mnt’}
```

This corresponds to issue dask/dask#5519.