### PR TITLE
Adding sizeof definition for pyarrow tables and columns

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -115,13 +115,13 @@ def register_pyarrow():
                     p += buffer.size
         return p
 
-    @sizeof.register(pa.lib.Table)
+    @sizeof.register(pa.Table)
     def sizeof_pyarrow_table(table):
         p = sizeof(table.schema.metadata)
         for col in table.itercolumns():
             p += _get_col_size(col)
         return int(p) + 1000
 
-    @sizeof.register(pa.lib.Column)
+    @sizeof.register(pa.Column)
     def sizeof_pyarrow_column(col):
         return int(_get_col_size(col)) + 1000

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -99,3 +99,25 @@ def test_empty():
     assert sizeof(empty.x) > 0
     assert sizeof(empty.y) > 0
     assert sizeof(empty.index) > 0
+
+
+def test_pyarrow_table():
+    pd = pytest.importorskip("pandas")
+    pa = pytest.importorskip("pyarrow")
+    df = pd.DataFrame(
+        {"x": [1, 2, 3], "y": ["a" * 100, "b" * 100, "c" * 100]}, index=[10, 20, 30]
+    )
+    table = pa.Table.from_pandas(df)
+
+    assert sizeof(table) > sizeof(table.schema.metadata)
+    assert isinstance(sizeof(table), int)
+    assert isinstance(sizeof(table.columns[0]), int)
+    assert isinstance(sizeof(table.columns[1]), int)
+    assert isinstance(sizeof(table.columns[2]), int)
+
+    empty = pa.Table.from_pandas(df.head(0))
+
+    assert sizeof(empty) > sizeof(empty.schema.metadata)
+    assert sizeof(empty.columns[0]) > 0
+    assert sizeof(empty.columns[1]) > 0
+    assert sizeof(empty.columns[2]) > 0


### PR DESCRIPTION
This PR adds (approximate) `sizeof` definitions for `pyarrow.lib.Table` and `pyarrow.lib.Column` objects. The new `sizeof_pyarrow_table` routine simply accounts for the size of the metadata, plus the cumulative size of all `pyarrow.Buffer` objects in the table. The new `sizeof_pyarrow_column` routine only accounts for the cumulative size of all `pyarrow.Buffer` objects in the column.

Note that these changes were motivated by discussion in [dask-cudf#44](https://github.com/rapidsai/dask-cuda/issues/44), and can be removed if/when [ARROW-6926](https://issues.apache.org/jira/browse/ARROW-6926) is directly addressed in pyarrow.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
