### PR TITLE
skip transpose in array.gufunc when possible

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1696,7 +1696,11 @@ class Array(DaskMethodsMixin):
             axes = None
         elif len(axes) == 1 and isinstance(axes[0], Iterable):
             axes = axes[0]
-        return transpose(self, axes=axes)
+        if (axes == tuple(range(self.ndim))) or (axes == tuple(range(-self.ndim, 0))):
+            # no transpose necessary
+            return self
+        else:
+            return transpose(self, axes=axes)
 
     @derived_from(np.ndarray)
     def ravel(self):

--- a/dask/array/gufunc.py
+++ b/dask/array/gufunc.py
@@ -351,11 +351,8 @@ def apply_gufunc(func, signature, *args, **kwargs):
         shape = arg.shape
         iax = tuple(a if a < 0 else a - len(shape) for a in iax)
         tidc = tuple(i for i in range(-len(shape) + 0, 0) if i not in iax) + iax
-        if tidc == tuple(range(-arg.ndim, 0)):
-            # transpose not necessary
-            transposed_arg = arg
-        else:
-            transposed_arg = arg.transpose(tidc)
+        
+        transposed_arg = arg.transpose(tidc)
         transposed_args.append(transposed_arg)
     args = transposed_args
 

--- a/dask/array/gufunc.py
+++ b/dask/array/gufunc.py
@@ -351,7 +351,6 @@ def apply_gufunc(func, signature, *args, **kwargs):
         shape = arg.shape
         iax = tuple(a if a < 0 else a - len(shape) for a in iax)
         tidc = tuple(i for i in range(-len(shape) + 0, 0) if i not in iax) + iax
-        
         transposed_arg = arg.transpose(tidc)
         transposed_args.append(transposed_arg)
     args = transposed_args

--- a/dask/array/gufunc.py
+++ b/dask/array/gufunc.py
@@ -351,8 +351,11 @@ def apply_gufunc(func, signature, *args, **kwargs):
         shape = arg.shape
         iax = tuple(a if a < 0 else a - len(shape) for a in iax)
         tidc = tuple(i for i in range(-len(shape) + 0, 0) if i not in iax) + iax
-
-        transposed_arg = arg.transpose(tidc)
+        if tidc == tuple(range(-arg.ndim, 0)):
+            # transpose not necessary
+            transposed_arg = arg
+        else:
+            transposed_arg = arg.transpose(tidc)
         transposed_args.append(transposed_arg)
     args = transposed_args
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -128,6 +128,12 @@ def test_transpose_negative_axes():
     assert_eq(x.transpose([-1, -2, 0, 1]), y.transpose([-1, -2, 0, 1]))
 
 
+def test_transpose_skip_when_possible():
+    x = da.ones((2, 3, 4), chunks=3)
+    assert x.transpose((0, 1, 2)) is x
+    assert x.transpose((-3, -2, -1)) is x
+
+
 def test_swapaxes():
     x = np.random.normal(0, 10, size=(10, 12, 7))
     d = da.from_array(x, chunks=(4, 5, 2))


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

We are using and loving `gufunc` in a [new package](https://github.com/xgcm/xcape) which wraps a custom fortran code. Thanks for this awesome feature! (I know it's been here for a while, but I just discovered it.)

In our application, the function we want to apply is already behaves as a gufunc at the numpy level--it operates along one core dimension (axis -1) and vectorizes (within fortran) over all preceding dimensions. So we don't necessarily need all of the transposing / reshaping that gufunc provides, just the ability to parallelize an existing gufunc.

On the other end of the performance spectrum, I'm also interested in minimizing the number of tasks in the dask graph. This PR adds a small check that eliminates an unnecessary transpose step on the inputs of gufunc in the (likely quite common) case that the inputs don't have to be transposed.

I wasn't sure how to test for this, since it is a purely internal optimization.