### PR TITLE
test-ci

### DIFF
--- a/continuous_integration/appveyor/environment.yaml
+++ b/continuous_integration/appveyor/environment.yaml
@@ -8,6 +8,7 @@ dependencies:
   - numpy>=1.13.0,<=1.16.4    # >= 1.17.0 breaks from https://github.com/pydata/sparse/issues/257
   - pandas>=0.21.0
   - pytest
+  - pytest-rerunfailures
   - cloudpickle
   - distributed
   - toolz

--- a/continuous_integration/travis/travis-35.yaml
+++ b/continuous_integration/travis/travis-35.yaml
@@ -11,6 +11,7 @@ dependencies:
   # test dependencies
   - pytest
   - pytest-xdist
+  - pytest-rerunfailures
   - moto
   - fastparquet
   - h5py

--- a/continuous_integration/travis/travis-36.yaml
+++ b/continuous_integration/travis/travis-36.yaml
@@ -10,6 +10,7 @@ dependencies:
   # test dependencies
   - pytest
   - pytest-xdist
+  - pytest-rerunfailures
   - moto
   - coverage
   - codecov

--- a/continuous_integration/travis/travis-37-dev.yaml
+++ b/continuous_integration/travis/travis-37-dev.yaml
@@ -11,6 +11,7 @@ dependencies:
   # test dependencies
   - pytest
   - pytest-xdist
+  - pytest-rerunfailures
   - moto
   - fastparquet
   - h5py

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -661,6 +661,7 @@ def test_read_text_large_gzip():
 
 @pytest.mark.slow
 @pytest.mark.network
+@pytest.mark.flaky(reruns=5)  # possible DNS issues on travis? See Dask-5524
 def test_from_s3():
     # note we don't test connection modes with aws_access_key and
     # aws_secret_key because these are not on travis-ci


### PR DESCRIPTION
debugging the s3 failure in https://travis-ci.org/dask/dask/jobs/601469430

```
_________________________________ test_from_s3 _________________________________

[gw1] linux -- Python 3.5.5 /home/travis/miniconda/envs/test-environment/bin/python

    @pytest.mark.slow

    @pytest.mark.network

    def test_from_s3():

        # note we don't test connection modes with aws_access_key and

        # aws_secret_key because these are not on travis-ci

        pytest.importorskip("s3fs")

    

        five_tips = (

            u"total_bill,tip,sex,smoker,day,time,size\n",

            u"16.99,1.01,Female,No,Sun,Dinner,2\n",

            u"10.34,1.66,Male,No,Sun,Dinner,3\n",

            u"21.01,3.5,Male,No,Sun,Dinner,3\n",

            u"23.68,3.31,Male,No,Sun,Dinner,2\n",

        )

    

        # test compressed data

>       e = db.read_text("s3://tip-data/t*.gz", storage_options=dict(anon=True))

dask/bag/tests/test_bag.py:678: 

_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

dask/bag/text.py:85: in read_text

    **(storage_options or {})

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/fsspec/core.py:193: in open_files

    protocol=protocol,

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/fsspec/core.py:390: in get_fs_token_paths

    paths = sorted(fs.glob(path))

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/fsspec/spec.py:456: in glob

    allpaths = self.find(root, maxdepth=depth, withdirs=True, **kwargs)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/fsspec/spec.py:383: in find

    for path, dirs, files in self.walk(path, maxdepth, **kwargs):

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/fsspec/spec.py:339: in walk

    listing = self.ls(path, True, **kwargs)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/s3fs/core.py:530: in ls

    files = self._ls(path, refresh=refresh)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/s3fs/core.py:452: in _ls

    return self._lsdir(path, refresh)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/s3fs/core.py:343: in _lsdir

    for i in it:

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/paginate.py:255: in __iter__

    response = self._make_request(current_kwargs)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/paginate.py:332: in _make_request

    return self._method(**current_kwargs)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/client.py:357: in _api_call

    return self._make_api_call(operation_name, kwargs)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/client.py:648: in _make_api_call

    operation_model, request_dict, request_context)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/client.py:667: in _make_request

    return self._endpoint.make_request(operation_model, request_dict)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/endpoint.py:102: in make_request

    return self._send_request(request_dict, operation_model)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/endpoint.py:137: in _send_request

    success_response, exception):

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/endpoint.py:231: in _needs_retry

    caught_exception=caught_exception, request_dict=request_dict)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/hooks.py:356: in emit

    return self._emitter.emit(aliased_event_name, **kwargs)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/hooks.py:228: in emit

    return self._emit(event_name, kwargs)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/hooks.py:211: in _emit

    response = handler(**kwargs)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/retryhandler.py:183: in __call__

    if self._checker(attempts, response, caught_exception):

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/retryhandler.py:251: in __call__

    caught_exception)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/retryhandler.py:277: in _should_retry

    return self._checker(attempt_number, response, caught_exception)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/retryhandler.py:317: in __call__

    caught_exception)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/retryhandler.py:223: in __call__

    attempt_number, caught_exception)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/retryhandler.py:359: in _check_caught_exception

    raise caught_exception

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/endpoint.py:200: in _do_get_response

    http_response = self._send(request)

../../../miniconda/envs/test-environment/lib/python3.5/site-packages/botocore/endpoint.py:244: in _send

    return self.http_session.send(request)

_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
```