### PR TITLE
Avoid NumPy scalar string representation in tokenize

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -775,7 +775,7 @@ def register_numpy():
     @normalize_token.register(np.ndarray)
     def normalize_array(x):
         if not x.shape:
-            return (str(x), x.dtype)
+            return (x.item(), x.dtype)
         if hasattr(x, "mode") and getattr(x, "filename", None):
             if hasattr(x.base, "ctypes"):
                 offset = (

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -130,6 +130,15 @@ def test_tokenize_numpy_scalar():
 
 
 @pytest.mark.skipif("not np")
+def test_tokenize_numpy_scalar_string_rep():
+    # Test tokenizing numpy scalars doesn't depend on their string representation
+    np.set_string_function(lambda x: "foo")
+    assert tokenize(np.array(1)) != tokenize(np.array(2))
+    # Reset back to default
+    np.set_string_function(None)
+
+
+@pytest.mark.skipif("not np")
 def test_tokenize_numpy_array_on_object_dtype():
     assert tokenize(np.array(["a", "aa", "aaa"], dtype=object)) == tokenize(
         np.array(["a", "aa", "aaa"], dtype=object)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -132,10 +132,12 @@ def test_tokenize_numpy_scalar():
 @pytest.mark.skipif("not np")
 def test_tokenize_numpy_scalar_string_rep():
     # Test tokenizing numpy scalars doesn't depend on their string representation
-    np.set_string_function(lambda x: "foo")
-    assert tokenize(np.array(1)) != tokenize(np.array(2))
-    # Reset back to default
-    np.set_string_function(None)
+    try:
+        np.set_string_function(lambda x: "foo")
+        assert tokenize(np.array(1)) != tokenize(np.array(2))
+    finally:
+        # Reset back to default
+        np.set_string_function(None)
 
 
 @pytest.mark.skipif("not np")


### PR DESCRIPTION
This PR updates how `tokenize` operates on NumPy scalars to avoid using array string representations.

Since NumPy allows users to [customize how arrays are printed](https://docs.scipy.org/doc/numpy/reference/generated/numpy.set_string_function.html), the current `tokenize` behavior can lead to non-deterministic hashes for NumPy scalars in some edge cases. Instead, here we use `x.item()` to convert NumPy scalars to Python scalars which are then used in `tokenize`. This allows us to cover edge cases where `str(x)` has been modified without a performance degradation. With the changes in this PR we have:

```python
In [1]: import numpy as np

In [2]: import dask

In [3]: %timeit dask.base.tokenize(np.array(1.23))
13 µs ± 273 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

and on the current `master` branch:

```python
In [3]: %timeit dask.base.tokenize(np.array(1.23))
16.2 µs ± 372 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

cc @jcrist if you get a moment to take a look at this or have any thoughts on the topic

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
