### PR TITLE
Apply enforce error message shows non-overlapping columns.

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4846,11 +4846,13 @@ def apply_and_enforce(*args, **kwargs):
             if not np.array_equal(
                 np.nan_to_num(meta.columns), np.nan_to_num(df.columns)
             ):
+                extra = df.columns.difference(meta.columns).tolist()
+                missing = meta.columns.difference(df.columns).tolist()
                 raise ValueError(
                     "The columns in the computed data do not match"
                     " the columns in the provided metadata\n"
-                    "  Expected: %s\n"
-                    "  Actual:   %s" % (str(list(meta.columns)), str(list(df.columns)))
+                    "  Extra:   %s\n"
+                    "  Missing: %s" % (extra, missing)
                 )
             else:
                 c = meta.columns

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -69,6 +69,7 @@ from .utils import (
     is_index_like,
     valid_divisions,
     hash_object_dispatch,
+    check_matching_columns,
 )
 
 no_default = "__no_default__"
@@ -4843,19 +4844,8 @@ def apply_and_enforce(*args, **kwargs):
             return meta
         if is_dataframe_like(df):
             # Need nan_to_num otherwise nan comparison gives False
-            if not np.array_equal(
-                np.nan_to_num(meta.columns), np.nan_to_num(df.columns)
-            ):
-                extra = df.columns.difference(meta.columns).tolist()
-                missing = meta.columns.difference(df.columns).tolist()
-                raise ValueError(
-                    "The columns in the computed data do not match"
-                    " the columns in the provided metadata\n"
-                    "  Extra:   %s\n"
-                    "  Missing: %s" % (extra, missing)
-                )
-            else:
-                c = meta.columns
+            check_matching_columns(meta, df)
+            c = meta.columns
         else:
             c = meta.name
         return _rename(c, df)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4858,7 +4858,6 @@ def apply_and_enforce(*args, **kwargs):
         if not len(df):
             return meta
         if is_dataframe_like(df):
-            # Need nan_to_num otherwise nan comparison gives False
             check_matching_columns(meta, df)
             c = meta.columns
         else:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -16,7 +16,6 @@ from dask.base import compute_as_if_collection
 from dask.utils import put_lines, M
 
 from dask.dataframe.core import (
-    apply_and_enforce,
     repartition_divisions,
     aca,
     _concat,
@@ -4077,19 +4076,6 @@ def test_series_map(base_npart, map_npart, sorted_index, sorted_map_index):
     dask_map = dd.from_pandas(mapper, npartitions=map_npart, sort=False)
     result = dask_base.map(dask_map)
     dd.utils.assert_eq(expected, result)
-
-
-def test_apply_and_enforce_error_message():
-    meta = pd.DataFrame({"x": [1]}).iloc[:0]
-
-    def func():
-        return pd.DataFrame({"x": [1.0], "y": [1]})
-
-    with pytest.raises(ValueError) as info:
-        apply_and_enforce(_func=func, _meta=meta)
-
-    assert "['x']" in str(info.value)
-    assert "['x', 'y']" in str(info.value)
 
 
 @pytest.mark.skipif(

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -1,7 +1,10 @@
+import re
+
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 import dask.dataframe as dd
+from dask.dataframe.core import apply_and_enforce
 from dask.dataframe.utils import (
     shard_df_on_index,
     meta_nonempty,
@@ -409,3 +412,15 @@ def test_is_dataframe_like(monkeypatch, frame_value_counts):
     assert is_index_like(df.index)
     assert is_index_like(ddf.index)
     assert not is_index_like(pd.Index)
+
+
+def test_apply_and_enforce_message():
+    def func():
+        return pd.DataFrame(columns=["A", "B", "C"], index=[0])
+
+    meta = pd.DataFrame(columns=["A", "D"], index=[0])
+    with pytest.raises(ValueError, match="Extra: *['B', 'C']"):
+        apply_and_enforce(_func=func, _meta=meta)
+
+    with pytest.raises(ValueError, match=re.escape("Missing: ['D']")):
+        apply_and_enforce(_func=func, _meta=meta)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -660,6 +660,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
 
 
 def check_matching_columns(meta, actual):
+    # Need nan_to_num otherwise nan comparison gives False
     if not np.array_equal(np.nan_to_num(meta.columns), np.nan_to_num(actual.columns)):
         extra = actual.columns.difference(meta.columns).tolist()
         missing = meta.columns.difference(actual.columns).tolist()

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -642,13 +642,8 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
                 typename(type(meta)),
                 asciitable(["Column", "Found", "Expected"], bad_dtypes),
             )
-        elif not np.array_equal(np.nan_to_num(meta.columns), np.nan_to_num(x.columns)):
-            errmsg = (
-                "The columns in the computed data do not match"
-                " the columns in the provided metadata.\n"
-                " %s\n  :%s" % (meta.columns, x.columns)
-            )
         else:
+            check_matching_columns(meta, x)
             return x
     else:
         if equal_dtypes(x.dtype, meta.dtype):
@@ -662,6 +657,18 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
         "Metadata mismatch found%s.\n\n"
         "%s" % ((" in `%s`" % funcname if funcname else ""), errmsg)
     )
+
+
+def check_matching_columns(meta, actual):
+    if not np.array_equal(np.nan_to_num(meta.columns), np.nan_to_num(actual.columns)):
+        extra = actual.columns.difference(meta.columns).tolist()
+        missing = meta.columns.difference(actual.columns).tolist()
+        raise ValueError(
+            "The columns in the computed data do not match"
+            " the columns in the provided metadata\n"
+            "  Extra:   %s\n"
+            "  Missing: %s" % (extra, missing)
+        )
 
 
 def index_summary(idx, name=None):

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -232,3 +232,10 @@ def test_delayed_kwargs_apply():
     label = task_label(x.dask[x.key])
     assert "f" in label
     assert "apply" not in label
+
+
+def test_positive_labels():
+    graph = {"a": 1, "b": 2, "c": [1, 2], "d": ["a", "b", "c"]}
+    digraph = to_graphviz(graph)
+    assert digraph
+    # dot = pydot.graph_from_dot_data(digraph.source)

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -232,10 +232,3 @@ def test_delayed_kwargs_apply():
     label = task_label(x.dask[x.key])
     assert "f" in label
     assert "apply" not in label
-
-
-def test_positive_labels():
-    graph = {"a": 1, "b": 2, "c": [1, 2], "d": ["a", "b", "c"]}
-    digraph = to_graphviz(graph)
-    assert digraph
-    # dot = pydot.graph_from_dot_data(digraph.source)


### PR DESCRIPTION
@birdsarah I think this would have made your debugging easier.

```pytb
ValueError: The columns in the computed data do not match the columns in the provided metadata
  Extra:   ['B', 'C']
  Missing: ['D']
```

rather than

```pytb
ValueError: The columns in the computed data do not match the columns in the provided metadata
  Expected: ['A', 'D']
  Actual:   ['A', 'B', 'C']
```

cc @jrbourbeau 
