### PR TITLE
Update import tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
       - *no_imports
 
     - env: &py36_env
+      - PYTHON_VERSION=3.6
       - ENV_FILE=continuous_integration/travis/travis-36.yaml
       - *test_and_lint
       - *coverage
@@ -32,6 +33,7 @@ jobs:
       - *imports
 
     - env: &py37_env
+      - PYTHON_VERSION=3.7
       - ENV_FILE=continuous_integration/travis/travis-37.yaml
       - *test_and_lint
       - *no_coverage

--- a/continuous_integration/travis/test_imports.sh
+++ b/continuous_integration/travis/test_imports.sh
@@ -24,7 +24,7 @@ test_import () {
 }
 
 # Create an empty environment
-conda create -n test-imports python=$PYTHON
+conda create -n test-imports -c conda-forge python=$PYTHON_VERSION
 source activate test-imports
 
 (test_import "Core" "" "import dask, dask.threaded, dask.optimization") && \


### PR DESCRIPTION
This PR updates `test_imports.sh` to install Python from `conda-forge` instead of the defaults channel. Also pins the Python version to match that used when running tests. 

cc @TomAugspurger 