### PR TITLE
Allow `array.chunksize` property to handle uneven chunking

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1139,7 +1139,7 @@ class Array(DaskMethodsMixin):
 
     @property
     def chunksize(self):
-        return tuple(map(tuple, map(set, self.chunks)))
+        return tuple(map(lambda v: tuple(sorted(v)), map(set, self.chunks)))
 
     @property
     def dtype(self):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1139,7 +1139,7 @@ class Array(DaskMethodsMixin):
 
     @property
     def chunksize(self):
-        return tuple(max(c) for c in self.chunks)
+        return tuple(map(tuple, map(set, self.chunks)))
 
     @property
     def dtype(self):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -206,6 +206,7 @@ def test_uneven_chunks():
     assert a.chunks == ((3, 3, 3, 1), (3, 3, 3, 1))
     assert a.chunksize == ((1, 3), (1, 3))
 
+
 def test_numblocks_suppoorts_singleton_block_dims():
     shape = (100, 10)
     chunks = (10, 10)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -204,7 +204,7 @@ def test_Array():
 def test_uneven_chunks():
     a = Array({}, "x", chunks=(3, 3), shape=(10, 10), dtype="f8")
     assert a.chunks == ((3, 3, 3, 1), (3, 3, 3, 1))
-
+    assert a.chunksize == ((1, 3), (1, 3))
 
 def test_numblocks_suppoorts_singleton_block_dims():
     shape = (100, 10)
@@ -283,7 +283,7 @@ def test_stack():
 
     assert s.shape == (3, 4, 6)
     assert s.chunks == ((1, 1, 1), (2, 2), (3, 3))
-    assert s.chunksize == (1, 2, 3)
+    assert s.chunksize == ((1,), (2,), (3,))
     assert s.dask[(s.name, 0, 1, 0)] == (getitem, ("A", 1, 0), (None, colon, colon))
     assert s.dask[(s.name, 2, 1, 0)] == (getitem, ("C", 1, 0), (None, colon, colon))
     assert same_keys(s, stack([a, b, c], axis=0))
@@ -291,7 +291,7 @@ def test_stack():
     s2 = stack([a, b, c], axis=1)
     assert s2.shape == (4, 3, 6)
     assert s2.chunks == ((2, 2), (1, 1, 1), (3, 3))
-    assert s2.chunksize == (2, 1, 3)
+    assert s2.chunksize == ((2,), (1,), (3,))
     assert s2.dask[(s2.name, 0, 1, 0)] == (getitem, ("B", 0, 0), (colon, None, colon))
     assert s2.dask[(s2.name, 1, 1, 0)] == (getitem, ("B", 1, 0), (colon, None, colon))
     assert same_keys(s2, stack([a, b, c], axis=1))
@@ -299,7 +299,7 @@ def test_stack():
     s2 = stack([a, b, c], axis=2)
     assert s2.shape == (4, 6, 3)
     assert s2.chunks == ((2, 2), (3, 3), (1, 1, 1))
-    assert s2.chunksize == (2, 3, 1)
+    assert s2.chunksize == ((2,), (3,), (1,))
     assert s2.dask[(s2.name, 0, 1, 0)] == (getitem, ("A", 0, 1), (colon, colon, None))
     assert s2.dask[(s2.name, 1, 1, 2)] == (getitem, ("C", 1, 1), (colon, colon, None))
     assert same_keys(s2, stack([a, b, c], axis=2))


### PR DESCRIPTION
At present, the `chunksize` property of a dask array only displays a single value per axis, even for  arrays with irregular chunking (i.e., multiple chunk sizes). For arrays with irregular chunking, the `chunksize` property can be a source of confusion, as in this example where the existence of single chunks is elided by the `chunksize` property:

```python
import dask.array as da
a = da.zeros((10,10), chunks=((9,1),(9,1)))
print(a)
# prints dask.array<zeros, shape=(10, 10), dtype=float64, chunksize=(9, 9), chunktype=numpy.ndarray>
```

The current behavior of the `chunksize` property is to report the maximum chunksize per axis. In this PR, the `chunksize` property reports the set of all chunksizes per axis: 

```python
import dask.array as da;
a = da.zeros((10,10), chunks=((9,1),(9,1))); print(a)
# prints dask.array<zeros, shape=(10, 10), dtype=float64, chunksize=((1, 9), (1, 9)), chunktype=numpy.ndarray>
```

This has the advantage of giving a more accurate summary of the chunking of the array, but there is a disadvantage: in this PR, `chunksize` becomes a tuple of tuples, many of which will likely be singletons, e.g. `((1 ,) (1,))` , which (to me) is uglier than `(1, 1)`.

So it's not a strict improvement, but in my view the reduced likelihood of confusion about chunking is worth the pain of the ugly nested tuples. 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
