### PR TITLE
[WIP] Adding ParquetIterator class

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -38,7 +38,7 @@ try:
     from .io.orc import read_orc
 
     try:
-        from .io import read_parquet, to_parquet
+        from .io import ParquetIterator, read_parquet, to_parquet
     except ImportError:
         pass
     try:

--- a/dask/dataframe/io/__init__.py
+++ b/dask/dataframe/io/__init__.py
@@ -17,6 +17,6 @@ from .json import read_json, to_json
 from . import demo
 
 try:
-    from .parquet import read_parquet, to_parquet
+    from .parquet import ParquetIterator, read_parquet, to_parquet
 except ImportError:
     pass

--- a/dask/dataframe/io/parquet/__init__.py
+++ b/dask/dataframe/io/parquet/__init__.py
@@ -1,1 +1,1 @@
-from .core import read_parquet, to_parquet, read_parquet_part
+from .core import ParquetIterator, read_parquet, to_parquet, read_parquet_part

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -132,6 +132,7 @@ class ArrowEngine(Engine):
         index=None,
         gather_statistics=None,
         filters=None,
+        split_row_groups=True,
         **kwargs
     ):
         # Define the dataset object to use for metadata,
@@ -220,7 +221,7 @@ class ArrowEngine(Engine):
                     dataset.metadata.row_group(i)
                     for i in range(dataset.metadata.num_row_groups)
                 ]
-                if not partitions and len(dataset.paths) == 1:
+                if split_row_groups and not partitions and len(dataset.paths) == 1:
                     row_groups_per_piece = _get_row_groups_per_piece(
                         pieces, dataset.metadata, dataset.paths[0], fs
                     )
@@ -284,7 +285,7 @@ class ArrowEngine(Engine):
         # This is a list of row-group-descriptor dicts, or file-paths
         # if we have a list of files and gather_statistics=False
         if not parts:
-            if row_groups_per_piece:
+            if split_row_groups and row_groups_per_piece:
                 parts = []
                 for i, piece in enumerate(pieces):
                     num_row_groups = row_groups_per_piece[i]

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1,4 +1,5 @@
 from functools import partial
+from collections import OrderedDict
 import json
 
 import pandas as pd
@@ -35,6 +36,7 @@ def _get_md_row_groups(pieces):
         row_groups_per_piece.append(num_row_groups)
     if len(row_groups) == len(pieces):
         row_groups_per_piece = None
+    # TODO: Skip row_groups_per_piece after ARROW-2801
     return row_groups, row_groups_per_piece
 
 
@@ -43,10 +45,9 @@ def _get_row_groups_per_piece(pieces, metadata, path, fs):
 
     This function requires access to ParquetDataset.metadata
     """
+    # TODO: Remove this function after ARROW-2801
     if metadata.num_row_groups == len(pieces):
         return None  # pieces already map to row-groups
-
-    from collections import OrderedDict
 
     result = OrderedDict()
     for piece in pieces:
@@ -133,7 +134,7 @@ class ArrowEngine(Engine):
         gather_statistics=None,
         filters=None,
         split_row_groups=True,
-        **kwargs
+        **kwargs,
     ):
         # Define the dataset object to use for metadata,
         # Also, initialize `parts`.  If `parts` is populated here,
@@ -142,6 +143,9 @@ class ArrowEngine(Engine):
         parts, dataset = _determine_dataset_parts(
             fs, paths, gather_statistics, filters, kwargs.get("dataset", {})
         )
+        # TODO: Call to `_determine_dataset_parts` uses `pq.ParquetDataset`
+        # to define the `dataset` object. `split_row_groups` should be passed
+        # to that constructor once it is supported (see ARROW-2801).
         if dataset.partitions is not None:
             partitions = [
                 n for n in dataset.partitions.partition_names if n is not None
@@ -288,6 +292,7 @@ class ArrowEngine(Engine):
         # if we have a list of files and gather_statistics=False
         if not parts:
             if split_row_groups and row_groups_per_piece:
+                # TODO: This block can be removed after ARROW-2801
                 parts = []
                 for i, piece in enumerate(pieces):
                     num_row_groups = row_groups_per_piece[i]
@@ -350,7 +355,7 @@ class ArrowEngine(Engine):
         partition_on=None,
         ignore_divisions=False,
         division_info=None,
-        **kwargs
+        **kwargs,
     ):
         dataset = fmd = None
         i_offset = 0
@@ -449,7 +454,7 @@ class ArrowEngine(Engine):
         compression=None,
         index_cols=None,
         schema=None,
-        **kwargs
+        **kwargs,
     ):
         md_list = []
         preserve_index = False
@@ -475,7 +480,8 @@ class ArrowEngine(Engine):
                     metadata_collector=md_list,
                     **kwargs,
                 )
-            md_list[0].set_file_path(filename)
+            if md_list:
+                md_list[0].set_file_path(filename)
         # Return the schema needed to write the metadata
         if return_metadata:
             return [{"schema": t.schema, "meta": md_list[0]}]

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -23,14 +23,41 @@ def _get_md_row_groups(pieces):
     if any metadata or statistics are missing
     """
     row_groups = []
+    row_groups_per_piece = []
     for piece in pieces:
-        for rg in range(piece.get_metadata().num_row_groups):
+        num_row_groups = piece.get_metadata().num_row_groups
+        for rg in range(num_row_groups):
             row_group = piece.get_metadata().row_group(rg)
             for c in range(row_group.num_columns):
                 if not row_group.column(c).statistics:
                     return []
             row_groups.append(row_group)
-    return row_groups
+        row_groups_per_piece.append(num_row_groups)
+    if len(row_groups) == len(pieces):
+        row_groups_per_piece = None
+    return row_groups, row_groups_per_piece
+
+
+def _get_row_groups_per_piece(pieces, metadata, path, fs):
+    """ Determine number of row groups in each dataset piece.
+
+    This function requires access to ParquetDataset.metadata
+    """
+    if metadata.num_row_groups == len(pieces):
+        return None  # pieces already map to row-groups
+
+    from collections import OrderedDict
+
+    result = OrderedDict()
+    for piece in pieces:
+        result[piece.path] = 0
+    for rg in range(metadata.num_row_groups):
+        filename = metadata.row_group(rg).column(0).file_path
+        if filename:
+            result[fs.sep.join([path, filename])] += 1
+        else:
+            return None  # File path is missing, abort
+    return tuple(result.values())
 
 
 def _determine_dataset_parts(fs, paths, gather_statistics, filters, dataset_kwargs):
@@ -185,17 +212,22 @@ class ArrowEngine(Engine):
         if not pieces:
             gather_statistics = False
 
+        row_groups_per_piece = None
         if gather_statistics:
             # Read from _metadata file
-            if dataset.metadata and dataset.metadata.num_row_groups == len(pieces):
+            if dataset.metadata:
                 row_groups = [
                     dataset.metadata.row_group(i)
                     for i in range(dataset.metadata.num_row_groups)
                 ]
+                if not partitions and len(dataset.paths) == 1:
+                    row_groups_per_piece = _get_row_groups_per_piece(
+                        pieces, dataset.metadata, dataset.paths[0], fs
+                    )
                 names = dataset.metadata.schema.names
             else:
                 # Read from each individual piece (quite possibly slow).
-                row_groups = _get_md_row_groups(pieces)
+                row_groups, row_groups_per_piece = _get_md_row_groups(pieces)
                 if row_groups:
                     piece = pieces[0]
                     md = piece.get_metadata()
@@ -252,9 +284,17 @@ class ArrowEngine(Engine):
         # This is a list of row-group-descriptor dicts, or file-paths
         # if we have a list of files and gather_statistics=False
         if not parts:
-            parts = [
-                (piece.path, piece.row_group, piece.partition_keys) for piece in pieces
-            ]
+            if row_groups_per_piece:
+                parts = []
+                for i, piece in enumerate(pieces):
+                    num_row_groups = row_groups_per_piece[i]
+                    for rg in range(num_row_groups):
+                        parts.append((piece.path, rg, piece.partition_keys))
+            else:
+                parts = [
+                    (piece.path, piece.row_group, piece.partition_keys)
+                    for piece in pieces
+                ]
         parts = [
             {
                 "piece": piece,
@@ -432,6 +472,7 @@ class ArrowEngine(Engine):
                     metadata_collector=md_list,
                     **kwargs,
                 )
+            md_list[0].set_file_path(filename)
         # Return the schema needed to write the metadata
         if return_metadata:
             return [{"schema": t.schema, "meta": md_list[0]}]

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -146,6 +146,8 @@ class ArrowEngine(Engine):
             partitions = [
                 n for n in dataset.partitions.partition_names if n is not None
             ]
+            if partitions:
+                split_row_groups = False
         else:
             partitions = []
 
@@ -216,12 +218,12 @@ class ArrowEngine(Engine):
         row_groups_per_piece = None
         if gather_statistics:
             # Read from _metadata file
-            if dataset.metadata:
+            if dataset.metadata and dataset.metadata.num_row_groups >= len(pieces):
                 row_groups = [
                     dataset.metadata.row_group(i)
                     for i in range(dataset.metadata.num_row_groups)
                 ]
-                if split_row_groups and not partitions and len(dataset.paths) == 1:
+                if split_row_groups and len(dataset.paths) == 1:
                     row_groups_per_piece = _get_row_groups_per_piece(
                         pieces, dataset.metadata, dataset.paths[0], fs
                     )

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -91,6 +91,7 @@ def read_parquet(
     storage_options=None,
     engine="auto",
     gather_statistics=None,
+    split_row_groups=True,
     **kwargs
 ):
     """
@@ -138,6 +139,11 @@ def read_parquet(
         this will only be done if the _metadata file is available. Otherwise,
         statistics will only be gathered if True, because the footer of
         every file will be parsed (which is very slow on some systems).
+    split_row_groups : bool
+        If True (default) then output dataframe partitions will correspond
+        to parquet-file row-groups (when enough row-group metadata is
+        available). Otherwise, partitions correspond to distinct files.
+        Only the "pyarrow" engine currently supports this argument.
     **kwargs: dict (of dicts)
         Passthrough key-word arguments for read backend.
         The top-level keys correspond to the appropriate operation type, and
@@ -206,6 +212,7 @@ def read_parquet(
         index=index,
         gather_statistics=gather_statistics,
         filters=filters,
+        split_row_groups=split_row_groups,
         **kwargs
     )
     if meta.index.name is not None:

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -224,7 +224,7 @@ def read_parquet(
     engine="auto",
     gather_statistics=None,
     split_row_groups=True,
-    **kwargs,
+    **kwargs
 ):
     """
     Read a Parquet file into a Dask DataFrame
@@ -399,7 +399,7 @@ def to_parquet(
     storage_options=None,
     write_metadata_file=True,
     compute=True,
-    **kwargs,
+    **kwargs
 ):
     """Store Dask.dataframe to Parquet files
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -99,7 +99,7 @@ class ParquetIterator:
         index=None,
         storage_options=None,
         engine="auto",
-        **kwargs,
+        kwargs={},
     ):
 
         if isinstance(engine, str):

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -218,116 +218,16 @@ def read_parquet(
     if meta.index.name is not None:
         index = meta.index.name
 
-    ignore_index_column_intersection = False
-    if columns is None:
-        # User didn't specify columns, so ignore any intersection
-        # of auto-detected values with the index (if necessary)
-        ignore_index_column_intersection = True
-        columns = [c for c in meta.columns]
-
-    if not set(columns).issubset(set(meta.columns)):
-        raise ValueError(
-            "The following columns were not found in the dataset %s\n"
-            "The following columns were found %s"
-            % (set(columns) - set(meta.columns), meta.columns)
-        )
-
     # Parse dataset statistics from metadata (if available)
-    index_in_columns = False
-    if statistics:
-        result = list(
-            zip(
-                *[
-                    (part, stats)
-                    for part, stats in zip(parts, statistics)
-                    if stats["num-rows"] > 0
-                ]
-            )
-        )
-        parts, statistics = result or [[], []]
-        if filters:
-            parts, statistics = apply_filters(parts, statistics, filters)
+    parts, divisions, index, index_in_columns = process_statistics(
+        parts, statistics, filters, index
+    )
 
-        out = sorted_columns(statistics)
-
-        if index and isinstance(index, str):
-            index = [index]
-        if index and out:
-            # Only one valid column
-            out = [o for o in out if o["name"] in index]
-        if index is not False and len(out) == 1:
-            # Use only sorted column with statistics as the index
-            divisions = out[0]["divisions"]
-            if index is None:
-                index_in_columns = True
-                index = [out[0]["name"]]
-            elif index != [out[0]["name"]]:
-                raise ValueError("Specified index is invalid.\nindex: {}".format(index))
-        elif index is not False and len(out) > 1:
-            if any(o["name"] == "index" for o in out):
-                # Use sorted column named "index" as the index
-                [o] = [o for o in out if o["name"] == "index"]
-                divisions = o["divisions"]
-                if index is None:
-                    index = [o["name"]]
-                    index_in_columns = True
-                elif index != [o["name"]]:
-                    raise ValueError(
-                        "Specified index is invalid.\nindex: {}".format(index)
-                    )
-            else:
-                # Multiple sorted columns found, cannot autodetect the index
-                warnings.warn(
-                    "Multiple sorted columns found %s, cannot\n "
-                    "autodetect index. Will continue without an index.\n"
-                    "To pick an index column, use the index= keyword; to \n"
-                    "silence this warning use index=False."
-                    "" % [o["name"] for o in out],
-                    RuntimeWarning,
-                )
-                index = False
-                divisions = [None] * (len(parts) + 1)
-        else:
-            divisions = [None] * (len(parts) + 1)
-    else:
-        divisions = [None] * (len(parts) + 1)
-
-    if index:
-        if isinstance(index, str):
-            index = [index]
-        if isinstance(columns, str):
-            columns = [columns]
-
-        if ignore_index_column_intersection:
-            columns = [col for col in columns if col not in index]
-        if set(index).intersection(columns):
-            if auto_index_allowed:
-                raise ValueError(
-                    "Specified index and column arguments must not intersect"
-                    " (set index=False or remove the detected index from columns).\n"
-                    "index: {} | column: {}".format(index, columns)
-                )
-            else:
-                raise ValueError(
-                    "Specified index and column arguments must not intersect.\n"
-                    "index: {} | column: {}".format(index, columns)
-                )
-
-        # Leaving index as a column in `meta`, because the index
-        # will be reset below (in case the index was detected after
-        # meta was created)
-        if index_in_columns:
-            meta = meta[columns + index]
-        else:
-            meta = meta[columns]
-
-    else:
-        meta = meta[list(columns)]
-
-    def _merge_kwargs(x, y):
-        z = x.copy()
-        z.update(y)
-        return z
+    # Account for index and columns arguments.
+    # Modify `meta` dataframe accordingly
+    meta, index, columns = set_index_columns(
+        meta, index, columns, index_in_columns, auto_index_allowed
+    )
 
     subgraph = ParquetSubgraph(name, engine, fs, meta, columns, index, parts, kwargs)
 
@@ -682,6 +582,127 @@ def apply_filters(parts, statistics, filters):
         parts, statistics = out_parts, out_statistics
 
     return parts, statistics
+
+
+def process_statistics(parts, statistics, filters, index):
+    """Process row-group column statistics in metadata
+
+    Used in read_parquet.
+    """
+    index_in_columns = False
+    if statistics:
+        result = list(
+            zip(
+                *[
+                    (part, stats)
+                    for part, stats in zip(parts, statistics)
+                    if stats["num-rows"] > 0
+                ]
+            )
+        )
+        parts, statistics = result or [[], []]
+        if filters:
+            parts, statistics = apply_filters(parts, statistics, filters)
+
+        out = sorted_columns(statistics)
+
+        if index and isinstance(index, str):
+            index = [index]
+        if index and out:
+            # Only one valid column
+            out = [o for o in out if o["name"] in index]
+        if index is not False and len(out) == 1:
+            # Use only sorted column with statistics as the index
+            divisions = out[0]["divisions"]
+            if index is None:
+                index_in_columns = True
+                index = [out[0]["name"]]
+            elif index != [out[0]["name"]]:
+                raise ValueError("Specified index is invalid.\nindex: {}".format(index))
+        elif index is not False and len(out) > 1:
+            if any(o["name"] == "index" for o in out):
+                # Use sorted column named "index" as the index
+                [o] = [o for o in out if o["name"] == "index"]
+                divisions = o["divisions"]
+                if index is None:
+                    index = [o["name"]]
+                    index_in_columns = True
+                elif index != [o["name"]]:
+                    raise ValueError(
+                        "Specified index is invalid.\nindex: {}".format(index)
+                    )
+            else:
+                # Multiple sorted columns found, cannot autodetect the index
+                warnings.warn(
+                    "Multiple sorted columns found %s, cannot\n "
+                    "autodetect index. Will continue without an index.\n"
+                    "To pick an index column, use the index= keyword; to \n"
+                    "silence this warning use index=False."
+                    "" % [o["name"] for o in out],
+                    RuntimeWarning,
+                )
+                index = False
+                divisions = [None] * (len(parts) + 1)
+        else:
+            divisions = [None] * (len(parts) + 1)
+    else:
+        divisions = [None] * (len(parts) + 1)
+
+    return parts, divisions, index, index_in_columns
+
+
+def set_index_columns(meta, index, columns, index_in_columns, auto_index_allowed):
+    """Handle index/column arguments, and modify `meta`
+
+    Used in read_parquet.
+    """
+    ignore_index_column_intersection = False
+    if columns is None:
+        # User didn't specify columns, so ignore any intersection
+        # of auto-detected values with the index (if necessary)
+        ignore_index_column_intersection = True
+        columns = [c for c in meta.columns]
+
+    if not set(columns).issubset(set(meta.columns)):
+        raise ValueError(
+            "The following columns were not found in the dataset %s\n"
+            "The following columns were found %s"
+            % (set(columns) - set(meta.columns), meta.columns)
+        )
+
+    if index:
+        if isinstance(index, str):
+            index = [index]
+        if isinstance(columns, str):
+            columns = [columns]
+
+        if ignore_index_column_intersection:
+            columns = [col for col in columns if col not in index]
+        if set(index).intersection(columns):
+            if auto_index_allowed:
+                raise ValueError(
+                    "Specified index and column arguments must not intersect"
+                    " (set index=False or remove the detected index from columns).\n"
+                    "index: {} | column: {}".format(index, columns)
+                )
+            else:
+                raise ValueError(
+                    "Specified index and column arguments must not intersect.\n"
+                    "index: {} | column: {}".format(index, columns)
+                )
+
+        # Leaving index as a column in `meta`, because the index
+        # will be reset below (in case the index was detected after
+        # meta was created)
+        if index_in_columns:
+            meta = meta[columns + index]
+        else:
+            meta = meta[columns]
+
+    else:
+        meta = meta[list(columns)]
+
+    return meta, index, columns
 
 
 DataFrame.to_parquet.__doc__ = to_parquet.__doc__


### PR DESCRIPTION
This is an experimental RFC for a new `ParquetIterator` class, which allows users to *manually* process larger-than-memory (LTM) parquet datasets.  The motivation is to provide an explicit API for dask/parquet users to read in a dataset in a batch-by-batch fashion.

It is my understanding that `read_parquet` should handle LTM datasets just fine, but that dask may need to spill intermediate data to disk (assuming that the memory limits are set correctly and that the uncompressed parquet row-groups fit in worker memory).  This `ParquetIterator` approach is intended to be an *alternative* for fragile cases with poor disk-spilling performance, etc.

Please do let me know if the user should  never (or *almost* never) need to manually iterate throgh a dataset like this.

Feedback is very welcome :)

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
