### PR TITLE
remove unnecessary tiledb shape constraint

### DIFF
--- a/dask/array/tiledb_io.py
+++ b/dask/array/tiledb_io.py
@@ -145,11 +145,7 @@ def to_tiledb(
     elif isinstance(uri, tiledb.Array):
         tdb = uri
         # sanity checks
-        if not (
-            (darray.shape == tdb.shape)
-            and (darray.dtype == tdb.dtype)
-            and (darray.ndim == tdb.ndim)
-        ):
+        if not ((darray.dtype == tdb.dtype) and (darray.ndim == tdb.ndim)):
             raise ValueError(
                 "Target TileDB array layout is not compatible with source array"
             )


### PR DESCRIPTION
- [X] Tests added / passed - no tests affected
- [X] Passes `black dask` / `flake8 dask`

This change removes a check for shape when writing a TileDB array, removing this constraint is necessary when writing a TileDB array that is to be read in `global` order.