### PR TITLE
Register sizeof dispatch for dictionaries

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -20,6 +20,11 @@ def sizeof_default(o):
     return getsizeof(o)
 
 
+@sizeof.register(dict)
+def sizeof_dict(o):
+    return getsizeof(o) + sum(map(sizeof, o.items()))
+
+
 @sizeof.register(list)
 @sizeof.register(tuple)
 @sizeof.register(set)

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -121,3 +121,11 @@ def test_pyarrow_table():
     assert sizeof(empty.columns[0]) > 0
     assert sizeof(empty.columns[1]) > 0
     assert sizeof(empty.columns[2]) > 0
+
+
+def test_dict():
+    dct = {"level2": "long_value" * 100}
+    dct2 = {"level1": dct}
+    assert sizeof(dct) > sizeof({})
+    assert sizeof(dct2) > sizeof(dct)
+    assert sizeof(dct2) > sizeof(dct) + sizeof({})


### PR DESCRIPTION
This adds a function to properly calculate dictionary sizes

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
