### PR TITLE
Update `accessor.py` to make `x.str.cat()` more flexible

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -137,9 +137,6 @@ class StringAccessor(Accessor):
     def cat(self, others=None, sep=None, na_rep=None):
         from .core import Series, Index
 
-        if others is None:
-            raise NotImplementedError("x.str.cat() with `others == None`")
-
         valid_types = (Series, Index, pd.Series, pd.Index)
         if isinstance(others, valid_types):
             others = [others]


### PR DESCRIPTION
- Removes condition on `x.str.cat()` that `others != None`
- Allows concatenation of strings from a single Series (mirrors [pandas functionality](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.cat.html))

It's not clear to me why this condition on `x.str.cat()` was added to begin with---perhaps extra code is required to implement this function for individual series---so please keep this in mind as you determine downstream effects.