### PR TITLE
Update `accessor.py` to make `x.str.cat()` more flexible

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -140,11 +140,9 @@ class StringAccessor(Accessor):
         valid_types = (Series, Index, pd.Series, pd.Index)
 
         if others is None:
-            if not isinstance(self, valid_types):
-                raise TypeError("self must be Series/Index")
-            return self._series.map_partitions(
+            return delayed(self._series.map_partitions(
             str_cat, meta=self._series._meta
-        ).compute().str.cat(sep=sep, na_rep=na_rep)
+        ).str.cat(sep=sep, na_rep=na_rep))
 
         else:
 

--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -137,16 +137,23 @@ class StringAccessor(Accessor):
     def cat(self, others=None, sep=None, na_rep=None):
         from .core import Series, Index
 
-        if others is None:
-            raise NotImplementedError("x.str.cat() with `others == None`")
-
         valid_types = (Series, Index, pd.Series, pd.Index)
-        if isinstance(others, valid_types):
-            others = [others]
-        elif not all(isinstance(a, valid_types) for a in others):
-            raise TypeError("others must be Series/Index")
 
-        return self._series.map_partitions(
+        if others is None:
+            if not isinstance(self, valid_types):
+                raise TypeError("self must be Series/Index")
+            return self._series.map_partitions(
+            str_cat, meta=self._series._meta
+        ).compute().str.cat(sep=sep, na_rep=na_rep)
+
+        else:
+
+            if isinstance(others, valid_types):
+                others = [others]
+            elif not all(isinstance(a, valid_types) for a in others):
+                raise TypeError("others must be Series/Index")
+
+            return self._series.map_partitions(
             str_cat, *others, sep=sep, na_rep=na_rep, meta=self._series._meta
         )
 


### PR DESCRIPTION
- Removes condition on `x.str.cat()` that `others != None`
- Allows concatenation of strings from a single Series, mirroring [pandas functionality](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.cat.html))

Feel free to suggest changes that would make the proposed merge more performant.
