### PR TITLE
Update minimum pyarrow version on CI

### DIFF
--- a/continuous_integration/hdfs/install.sh
+++ b/continuous_integration/hdfs/install.sh
@@ -1,6 +1,6 @@
 set -xe
 
-docker exec -it $CONTAINER_ID conda install -y -q dask pyarrow">0.13.0" fsspec -c conda-forge
+docker exec -it $CONTAINER_ID conda install -y -q dask pyarrow">=0.14.0" fsspec -c conda-forge
 docker exec -it $CONTAINER_ID pip install -e .
 
 set +xe

--- a/continuous_integration/hdfs/install.sh
+++ b/continuous_integration/hdfs/install.sh
@@ -1,6 +1,6 @@
 set -xe
 
-docker exec -it $CONTAINER_ID conda install -y -q dask pyarrow fsspec -c conda-forge
+docker exec -it $CONTAINER_ID conda install -y -q dask pyarrow">0.13.0" fsspec -c conda-forge
 docker exec -it $CONTAINER_ID pip install -e .
 
 set +xe

--- a/continuous_integration/travis/travis-36.yaml
+++ b/continuous_integration/travis/travis-36.yaml
@@ -22,7 +22,7 @@ dependencies:
   - zarr
   - tiledb-py
   - sqlalchemy
-  - pyarrow
+  - pyarrow>=0.14.0
   # other -- IO
   - bcolz
   - blosc

--- a/continuous_integration/travis/travis-37-dev.yaml
+++ b/continuous_integration/travis/travis-37-dev.yaml
@@ -18,7 +18,7 @@ dependencies:
   - zarr
   - tiledb-py
   - sqlalchemy
-  - pyarrow
+  - pyarrow>=0.14.0
   # other -- IO
   - bcolz
   - blosc

--- a/continuous_integration/travis/travis-37.yaml
+++ b/continuous_integration/travis/travis-37.yaml
@@ -17,7 +17,7 @@ dependencies:
   - tiledb-py
   - fsspec>=0.5.1
   - sqlalchemy
-  - pyarrow
+  - pyarrow>=0.14.0
   # other -- IO
   - bcolz
   - blosc

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -110,7 +110,7 @@ These optional dependencies and their minimum supported versions are listed belo
 +-------------+----------+--------------------------------------------------------------+
 |    psutil   |          |             Enables a more accurate CPU count                |
 +-------------+----------+--------------------------------------------------------------+
-|    pyarrow  | >=0.9.0  |               Python library for Apache Arrow                |
+|    pyarrow  | >=0.14.0 |               Python library for Apache Arrow                |
 +-------------+----------+--------------------------------------------------------------+
 |    s3fs     |          |                    Reading from Amazon S3                    |
 +-------------+----------+--------------------------------------------------------------+


### PR DESCRIPTION
This PR sets `pyarrow>=0.14.0` on the CI, which has recently started failing due to pulling in older, unsupported versions of `pyarrow` (ref https://travis-ci.org/dask/dask/jobs/607318590)