### PR TITLE
Remove import of dask_cudf

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -15,4 +15,4 @@ from .utils import hash_object_dispatch, group_split_dispatch
 @meta_nonempty.register_lazy("cudf")
 @make_meta.register_lazy("cudf")
 def _register_cudf():
-    import dask_cudf  # noqa: F401
+    import cudf  # noqa: F401


### PR DESCRIPTION
Removed the import of `dask_cudf` in the `dataframe` backend. The features of `dask_cudf` has been merged into `cudf`.

Do we need a cudf version check here?
