### PR TITLE
update to calendar link

### DIFF
--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -23,13 +23,16 @@ Conversation happens in the following places:
     Overflow or GitHub.
 4.  **Monthly developer meeting** happens the first Thursday of the month at
     11:00 US Central Time in `this video meeting <https://zoom.us/j/802251830>`_.
-    Subscribe to `this Google Calendar invite`_ to be notified of changes to
-    the meeting schedule. Meeting notes are available at
+    Meeting notes are available at
     https://docs.google.com/document/d/1UqNAP87a56ERH_xkQsS5Q_0PKYybd5Lj2WANy_hRzI0/edit
+
+    You can subscribe to this calendar to be notified of changes:
+
+    * `Google Calendar <https://calendar.google.com/calendar/embed?src=4l0vts0c1cgdbq5jhcogj55sfs%40group.calendar.google.com&ctz=America%2FChicago>`__
+    * `iCal <https://calendar.google.com/calendar/ical/4l0vts0c1cgdbq5jhcogj55sfs%40group.calendar.google.com/public/basic.ics>`__
 
 .. _`Stack Overflow with the #dask tag`: https://stackoverflow.com/questions/tagged/dask
 .. _`GitHub issue tracker`: https://github.com/dask/dask/issues/
-.. _`this Google Calendar invite`: https://calendar.google.com/event?action=TEMPLATE&tmeid=NmxnamVvcGtjY3E2NGI5bTZzcW1hYjlrYzhybTZiYjFjY29qOGI5ZzY0cWoyYzFrNjFpMzhwaGlja18yMDE5MDYwNlQxNjAwMDBaIDRsMHZ0czBjMWNnZGJxNWpoY29najU1c2ZzQGc&tmsrc=4l0vts0c1cgdbq5jhcogj55sfs%40group.calendar.google.com&scp=ALL
 
 
 Asking for help


### PR DESCRIPTION
Hopefully this fixes everything. This points to a calendar to subscribe to, rather than a single url.

You *may* need to delete the current one from your local calendar and re-subscribe. cc @pentschev.