### PR TITLE
Use key_split in Bag name

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -81,6 +81,7 @@ from ..utils import (
     ensure_dict,
     ensure_bytes,
     ensure_unicode,
+    key_split,
 )
 from . import chunk
 
@@ -492,8 +493,7 @@ class Bag(DaskMethodsMixin):
         return type(self), (self.name, self.npartitions)
 
     def __str__(self):
-        name = self.name if len(self.name) < 10 else self.name[:7] + "..."
-        return "dask.bag<%s, npartitions=%d>" % (name, self.npartitions)
+        return "dask.bag<%s, npartitions=%d>" % (key_split(self.name), self.npartitions)
 
     __repr__ = __str__
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -180,6 +180,8 @@ def test_repr(func):
     assert str(b.npartitions) in func(b)
     assert b.name[:5] in func(b)
 
+    assert "from_sequence" in func(db.from_sequence(range(5)))
+
 
 def test_pluck():
     d = {("x", 0): [(1, 10), (2, 20)], ("x", 1): [(3, 30), (4, 40)]}


### PR DESCRIPTION
Previously we were very conservative about function name length here

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
