### PR TITLE
Switch Doctests to Py3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
       - PYTHON_VERSION=3.6
       - ENV_FILE=continuous_integration/travis/travis-36.yaml
       - *test_and_lint
-      - *coverage
+      - *no_coverage
       - *no_optimize
       - *imports
 
@@ -29,7 +29,7 @@ jobs:
       - PYTHON_VERSION=3.7
       - ENV_FILE=continuous_integration/travis/travis-37.yaml
       - *test_and_lint
-      - *no_coverage
+      - *coverage
       - *no_optimize
       - *imports
       - *array_function
@@ -38,7 +38,7 @@ jobs:
       - UPSTREAM_DEV=1  # Install nightly versions of NumPy, pandas, pyarrow
       - ENV_FILE=continuous_integration/travis/travis-37-dev.yaml
       - *test_and_lint
-      - *no_coverage
+      - *coverage
       - *no_optimize
       - *no_imports
       - *array_function

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
       - UPSTREAM_DEV=1  # Install nightly versions of NumPy, pandas, pyarrow
       - ENV_FILE=continuous_integration/travis/travis-37-dev.yaml
       - *test_and_lint
-      - *coverage
+      - *no_coverage
       - *no_optimize
       - *no_imports
       - *array_function

--- a/continuous_integration/travis/travis-36.yaml
+++ b/continuous_integration/travis/travis-36.yaml
@@ -1,4 +1,3 @@
-# This job includes coverage
 name: test-environment
 channels:
   - conda-forge

--- a/continuous_integration/travis/travis-37.yaml
+++ b/continuous_integration/travis/travis-37.yaml
@@ -1,3 +1,4 @@
+# This job includes coverage
 name: test-environment
 channels:
   - conda-forge
@@ -18,6 +19,7 @@ dependencies:
   - fsspec>=0.5.1
   - sqlalchemy
   - pyarrow>=0.14.0
+  - coverage
   # other -- IO
   - bcolz
   - blosc

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1543,10 +1543,10 @@ class Bag(DaskMethodsMixin):
         >>> df = b.to_dataframe()
 
         >>> df.compute()
-           balance     name
-        0      100    Alice
-        1      200      Bob
-        0      300  Charlie
+              name  balance
+        0    Alice      100
+        1      Bob      200
+        0  Charlie      300
         """
         import pandas as pd
         import dask.dataframe as dd

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -717,7 +717,7 @@ Dask Name: {name}, {task} tasks""".format(
         2017-01-08    13.0
         2017-01-09    15.0
         2017-01-10    17.0
-        dtype: float64
+        Freq: D, dtype: float64
         """
         from .rolling import map_overlap
 


### PR DESCRIPTION
- [x] Tests pass on python 3.7
- [x] Passes `black dask` / `flake8 dask`

This PR fixes the following doctests which throw errors when running `py.test dask/bag/core.py --doctest-modules` and   `py.test dask/dataframe/core.py --doctest-modules` locally

```
1536         Examples
1537         --------
1538         >>> import dask.bag as db
1539         >>> b = db.from_sequence([{'name': 'Alice',   'balance': 100},
1540         ...                       {'name': 'Bob',     'balance': 200},
1541         ...                       {'name': 'Charlie', 'balance': 300}],
1542         ...                      npartitions=2)
1543         >>> df = b.to_dataframe()
1544 
1545         >>> df.compute()
Differences (unified diff with -expected +actual):
    @@ -1,4 +1,4 @@
    -   balance     name
    -0      100    Alice
    -1      200      Bob
    -0      300  Charlie
    +      name  balance
    +0    Alice      100
    +1      Bob      200
    +0  Charlie      300

/Users/ryannazareth/Documents/Python_sprints/dask/dask/bag/core.py:1545: DocTestFailure
```

```
_______________ [doctest] dask.dataframe.core._Frame.map_overlap _______________
710         2  2.0  1.0
711         3  3.0  1.0
712         4  4.0  1.0
713 
714         If you have a ``DatetimeIndex``, you can use a ``pd.Timedelta`` for time-
715         based windows.
716 
717         >>> ts = pd.Series(range(10), index=pd.date_range('2017', periods=10))
718         >>> dts = dd.from_pandas(ts, npartitions=2)
719         >>> dts.map_overlap(lambda df: df.rolling('2D').sum(),
Differences (unified diff with -expected +actual):
    @@ -9,3 +9,3 @@
     2017-01-09    15.0
     2017-01-10    17.0
    -dtype: float64
    +Freq: D, dtype: float64

/Users/ryannazareth/Documents/Python_sprints/dask/dask/dataframe/core.py:719: DocTestFailure
```