### PR TITLE
Add median along an axis with automatic rechunking

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -190,6 +190,7 @@ try:
         all,
         min,
         max,
+        median,
         moment,
         trace,
         argmin,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -45,7 +45,6 @@ from ..utils import (
     is_integer,
     IndexCallable,
     funcname,
-    derived_from,
     SerializableLock,
     Dispatch,
     factors,

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -21,7 +21,7 @@ from .wrap import zeros, ones
 from .numpy_compat import ma_divide, divide as np_divide
 from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
-from ..utils import ignoring, funcname, Dispatch, deepmap, getargspec
+from ..utils import ignoring, funcname, Dispatch, deepmap, getargspec, derived_from
 from .. import config
 
 # Generic functions to support chunks of different types
@@ -1254,8 +1254,12 @@ def trace(a, offset=0, axis1=0, axis2=1, dtype=None):
     return diagonal(a, offset=offset, axis1=axis1, axis2=axis2).sum(-1, dtype=dtype)
 
 
-@wraps(np.median)
+@derived_from(np)
 def median(a, axis=None, keepdims=False, out=None):
+    """
+    This works by automatically chunking the reduced axes to a single chunk
+    and then calling ``numpy.median`` function across the remaining dimensions
+    """
     if axis is None:
         raise NotImplementedError(
             "The da.median function only works along an axis.  "

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1274,7 +1274,9 @@ def median(a, axis=None, keepdims=False, out=None):
         axis=axis,
         keepdims=keepdims,
         drop_axis=axis if not keepdims else None,
-        chunks=[1 if ax in axis else c for ax, c in enumerate(a.chunks)] if keepdims else None,
+        chunks=[1 if ax in axis else c for ax, c in enumerate(a.chunks)]
+        if keepdims
+        else None,
     )
 
     result = handle_out(out, result)

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -61,7 +61,6 @@ def test_array_function_fft(func):
         lambda x: np.min_scalar_type(x),
         lambda x: np.linalg.det(x),
         lambda x: np.linalg.eigvals(x),
-        lambda x: np.median(x),
     ],
 )
 def test_array_notimpl_function_dask(func):
@@ -226,15 +225,14 @@ def test_unregistered_func(func):
     assert_eq(xx, yy, check_meta=False)
 
 
-def test_median_func():
+def test_non_existent_func():
     # Regression test for __array_function__ becoming default in numpy 1.17
-    # dask has no median function, so ensure that this still calls np.median
-    image = da.from_array(np.array([[0, 1], [1, 2]]), chunks=(1, 2))
+    # dask has no sort function, so ensure that this still calls np.sort
+    x = da.from_array(np.array([1, 2, 4, 3]), chunks=(2,))
     if IS_NEP18_ACTIVE:
         with pytest.warns(
-            FutureWarning,
-            match="The `numpy.median` function is not implemented by Dask",
+            FutureWarning, match="The `numpy.sort` function is not implemented by Dask"
         ):
-            assert int(np.median(image)) == 1
+            assert list(np.sort(x)) == [1, 2, 3, 4]
     else:
-        assert int(np.median(image)) == 1
+        assert list(np.sort(x)) == [1, 2, 3, 4]

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -663,3 +663,15 @@ def test_trace():
     _assert(a, b, 0, 1, 2, float)
     _assert(a, b, offset=1, axis1=0, axis2=2, dtype=int)
     _assert(a, b, offset=1, axis1=0, axis2=2, dtype=float)
+
+
+@pytest.mark.parametrize("axis", [0, [0, 1], 1, -1])
+@pytest.mark.parametrize("keepdims", [True, False])
+def test_median(axis, keepdims):
+    x = np.arange(100).reshape((2, 5, 10))
+    d = da.from_array(x, chunks=2)
+
+    assert_eq(
+        da.median(d, axis=axis, keepdims=keepdims),
+        np.median(x, axis=axis, keepdims=keepdims)
+    )

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -673,5 +673,5 @@ def test_median(axis, keepdims):
 
     assert_eq(
         da.median(d, axis=axis, keepdims=keepdims),
-        np.median(x, axis=axis, keepdims=keepdims)
+        np.median(x, axis=axis, keepdims=keepdims),
     )


### PR DESCRIPTION
This rechunks the array along the axes to be medianed and then performs a
blockwise call to `np.median`.

Fixes https://github.com/dask/dask/issues/5062
This was specifically asked for by astronomers.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
