### PR TITLE
Relax get_colors test to adapt to new Bokeh release

### DIFF
--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -341,6 +341,7 @@ def plot_resources(results, palette="Viridis", **kwargs):
     The completed bokeh plot object.
     """
     bp = import_required("bokeh.plotting", _BOKEH_MISSING_MSG)
+    import bokeh
     from bokeh import palettes
     from bokeh.models import LinearAxis, Range1d
 
@@ -365,7 +366,17 @@ def plot_resources(results, palette="Viridis", **kwargs):
         t = mem = cpu = []
         p = bp.figure(y_range=(0, 100), x_range=(0, 1), **defaults)
     colors = palettes.all_palettes[palette][6]
-    p.line(t, cpu, color=colors[0], line_width=4, legend="% CPU")
+    p.line(
+        t,
+        cpu,
+        color=colors[0],
+        line_width=4,
+        **{
+            "legend_label"
+            if LooseVersion(bokeh.__version__) >= "1.4"
+            else "legend": "% CPU"
+        }
+    )
     p.yaxis.axis_label = "% CPU"
     p.extra_y_ranges = {
         "memory": Range1d(
@@ -373,7 +384,16 @@ def plot_resources(results, palette="Viridis", **kwargs):
         )
     }
     p.line(
-        t, mem, color=colors[2], y_range_name="memory", line_width=4, legend="Memory"
+        t,
+        mem,
+        color=colors[2],
+        y_range_name="memory",
+        line_width=4,
+        **{
+            "legend_label"
+            if LooseVersion(bokeh.__version__) >= "1.4"
+            else "legend": "Memory"
+        }
     )
     p.add_layout(LinearAxis(y_range_name="memory", axis_label="Memory (MB)"), "right")
     p.xaxis.axis_label = "Time (s)"

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -362,13 +362,12 @@ def test_saves_file():
 @ignore_abc_warning
 def test_get_colors():
     from dask.diagnostics.profile_visualize import get_colors
-    from bokeh.palettes import Blues9, Blues5, Viridis
-    from itertools import cycle
+    from bokeh.palettes import Blues256, Blues5, Viridis
 
     funcs = list(range(11))
     cmap = get_colors("Blues", funcs)
-    lk = dict(zip(funcs, cycle(Blues9)))
-    assert cmap == [lk[i] for i in funcs]
+    assert set(cmap) < set(Blues256)
+    assert len(set(cmap)) == 11
 
     funcs = list(range(5))
     cmap = get_colors("Blues", funcs)


### PR DESCRIPTION
Previously this test assumed that Blues9 was the largest cardinality
colormap set.  This caused a failure with the most recent bokeh
release.  We relax this test.

cc @jcrist 