### PR TITLE
Add sizeof implementation for small dicts

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -28,6 +28,13 @@ def sizeof_python_collection(seq):
     return getsizeof(seq) + sum(map(sizeof, seq))
 
 
+@sizeof.register(dict)
+def sizeof_python_dict(d):
+    if len(d) > 10:
+        return getsizeof(d) + 1000 * len(d)
+    else:
+        return getsizeof(d) + sum(map(sizeof, d.keys())) + sum(map(sizeof, d.values()))
+
 @sizeof.register_lazy("cupy")
 def register_cupy():
     import cupy

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -35,6 +35,7 @@ def sizeof_python_dict(d):
     else:
         return getsizeof(d) + sum(map(sizeof, d.keys())) + sum(map(sizeof, d.values()))
 
+
 @sizeof.register_lazy("cupy")
 def register_cupy():
     import cupy

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -121,3 +121,11 @@ def test_pyarrow_table():
     assert sizeof(empty.columns[0]) > 0
     assert sizeof(empty.columns[1]) > 0
     assert sizeof(empty.columns[2]) > 0
+
+
+def test_dict():
+    np = pytest.importorskip("numpy")
+    x = np.ones(10000)
+    assert sizeof({"x": x}) > x.nbytes
+    assert sizeof({"x": [x]}) > x.nbytes
+    assert sizeof({"x": [{"y": x}]}) > x.nbytes


### PR DESCRIPTION
This traverses small dictionaries with sizeof.
We avoid doing this for large dictionaries because we want to avoid traversing
JSON-like data.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
