### PR TITLE
[REVIEW] Add dropna argument to groupby

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -162,29 +162,25 @@ def _groupby_raise_unaligned(df, **kwargs):
     return df.groupby(**kwargs)
 
 
-def _groupby_slice_apply(df, grouper, key, func, *args, **kwargs):
+def _groupby_slice_apply(
+    df, grouper, key, func, *args, group_keys=True, dropna=None, **kwargs
+):
     # No need to use raise if unaligned here - this is only called after
     # shuffling, which makes everything aligned already
-    group_keys = kwargs.pop("group_keys", True)
-    dropna = kwargs.pop("dropna", None)
-    if dropna is not None:
-        g = df.groupby(grouper, group_keys=group_keys, dropna=dropna)
-    else:
-        g = df.groupby(grouper, group_keys=group_keys)
+    dropna = {"dropna": dropna} if dropna is not None else {}
+    g = df.groupby(grouper, group_keys=group_keys, **dropna)
     if key:
         g = g[key]
     return g.apply(func, *args, **kwargs)
 
 
-def _groupby_slice_transform(df, grouper, key, func, *args, **kwargs):
+def _groupby_slice_transform(
+    df, grouper, key, func, *args, group_keys=True, dropna=None, **kwargs
+):
     # No need to use raise if unaligned here - this is only called after
     # shuffling, which makes everything aligned already
-    group_keys = kwargs.pop("group_keys", True)
-    dropna = kwargs.pop("dropna", None)
-    if dropna is not None:
-        g = df.groupby(grouper, group_keys=group_keys, dropna=dropna)
-    else:
-        g = df.groupby(grouper, group_keys=group_keys)
+    dropna = {"dropna": dropna} if dropna is not None else {}
+    g = df.groupby(grouper, group_keys=group_keys, **dropna)
     if key:
         g = g[key]
 
@@ -278,22 +274,16 @@ class Aggregation(object):
         self.__name__ = name
 
 
-def _groupby_aggregate(df, aggfunc=None, levels=None, **kwargs):
-    dropna = kwargs.pop("dropna", None)
-    if dropna is not None:
-        return aggfunc(df.groupby(level=levels, sort=False, dropna=dropna), **kwargs)
-    else:
-        return aggfunc(df.groupby(level=levels, sort=False), **kwargs)
+def _groupby_aggregate(df, aggfunc=None, levels=None, dropna=None, **kwargs):
+    dropna = {"dropna": dropna} if dropna is not None else {}
+    return aggfunc(df.groupby(level=levels, sort=False, **dropna), **kwargs)
 
 
-def _apply_chunk(df, *index, **kwargs):
+def _apply_chunk(df, *index, dropna=None, **kwargs):
     func = kwargs.pop("chunk")
     columns = kwargs.pop("columns")
-    dropna = kwargs.pop("dropna", None)
-    if dropna is not None:
-        g = _groupby_raise_unaligned(df, by=index, dropna=dropna)
-    else:
-        g = _groupby_raise_unaligned(df, by=index)
+    dropna = {"dropna": dropna} if dropna is not None else {}
+    g = _groupby_raise_unaligned(df, by=index, **dropna)
 
     if is_series_like(df) or columns is None:
         return func(g, **kwargs)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -994,9 +994,11 @@ class _GroupBy(object):
         The slice keys applied to GroupBy result
     group_keys: bool
         Passed to pandas.DataFrame.groupby()
+    dropna: bool
+        Whether to drop null values from groupby index
     """
 
-    def __init__(self, df, by=None, slice=None, group_keys=True, **kwargs):
+    def __init__(self, df, by=None, slice=None, group_keys=True, dropna=None):
 
         assert isinstance(df, (DataFrame, Series))
         self.group_keys = group_keys
@@ -1034,9 +1036,6 @@ class _GroupBy(object):
         else:
             index_meta = self.index
 
-        # Set self.dropna to {"dropna": True/False} if the argument was passed.
-        # Otherwise, set self.dropna={}
-        dropna = kwargs.pop("dropna", None)
         self.dropna = {}
         if dropna is not None:
             self.dropna["dropna"] = dropna

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2189,30 +2189,26 @@ def test_groupby_transform_ufunc_partitioning(npartitions, indexed):
         )
 
 
-@pytest.mark.parametrize("dropna", [False, True, None])
+@pytest.mark.xfail(reason="dropna kwarg not supported in pandas groupby.")
+@pytest.mark.parametrize("dropna", [False, True])
 def test_groupby_dropna_pandas(dropna):
 
     # The `dropna` arg is not currently supported by pandas
     # (See #https://github.com/pandas-dev/pandas/pull/21669)
     # Dask supports the argument for the cudf backend,
-    # but should raise an error for pandas.
+    # but passing it to the pandas backend will fail.
 
-    # TODO: Expand test when `dropna`is supported in pandas.
+    # TODO: Expand test when `dropna` is supported in pandas.
+    #       (See: `test_groupby_dropna_cudf`)
 
     df = pd.DataFrame(
         {"a": [1, 2, 3, 4, None, None, 7, 8], "e": [4, 5, 6, 3, 2, 1, 0, 0]}
     )
     ddf = dd.from_pandas(df, npartitions=3)
 
-    if dropna is None:
-        dask_result = ddf.groupby("a").e.sum()
-        pd_result = df.groupby("a").e.sum()
-        assert_eq(dask_result, pd_result)
-    else:
-        with pytest.raises(TypeError):
-            ddf.groupby("a", dropna=dropna)
-        with pytest.raises(TypeError):
-            df.groupby("a", dropna=dropna)
+    dask_result = ddf.groupby("a", dropna=dropna)
+    pd_result = df.groupby("a", dropna=dropna)
+    assert_eq(dask_result, pd_result)
 
 
 @pytest.mark.parametrize("dropna", [False, True, None])

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2187,3 +2187,23 @@ def test_groupby_transform_ufunc_partitioning(npartitions, indexed):
                 lambda series: series - series.mean()
             ),
         )
+
+
+def test_groupby_dropna_cudf():
+
+    cudf = pytest.importorskip("cudf")
+    dask_cudf = pytest.importorskip("dask_cudf")
+
+    df = cudf.DataFrame(
+        {
+            "a": [1, 2, 3, 4, None, None, 7, 8, 9],
+            "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]
+        },
+        index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
+    )
+    ddf = dask_cudf.from_cudf(df, npartitions=3)
+
+    assert_eq(
+        ddf.groupby("a", dropna=False).b.sum(),
+        df.groupby("a", dropna=False).b.sum()
+    )

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2189,21 +2189,62 @@ def test_groupby_transform_ufunc_partitioning(npartitions, indexed):
         )
 
 
-def test_groupby_dropna_cudf():
+@pytest.mark.parametrize("dropna", [False, True, None])
+def test_groupby_dropna_pandas(dropna):
+
+    # The `dropna` arg is not currently supported by pandas
+    # (See #https://github.com/pandas-dev/pandas/pull/21669)
+    # Dask supports the argument for the cudf backend,
+    # but should raise an error for pandas.
+
+    # TODO: Expand test when `dropna`is supported in pandas.
+
+    df = pd.DataFrame(
+        {"a": [1, 2, 3, 4, None, None, 7, 8], "e": [4, 5, 6, 3, 2, 1, 0, 0]}
+    )
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    if dropna is None:
+        dask_result = ddf.groupby("a").e.sum()
+        pd_result = df.groupby("a").e.sum()
+        assert_eq(dask_result, pd_result)
+    else:
+        with pytest.raises(TypeError):
+            ddf.groupby("a", dropna=dropna)
+        with pytest.raises(TypeError):
+            df.groupby("a", dropna=dropna)
+
+
+@pytest.mark.parametrize("dropna", [False, True, None])
+@pytest.mark.parametrize("by", ["a", "c", "d", ["a", "b"], ["a", "c"], ["a", "d"]])
+def test_groupby_dropna_cudf(dropna, by):
+
+    # NOTE: This test requires cudf/dask_cudf, and will
+    # be skipped by non-GPU CI
 
     cudf = pytest.importorskip("cudf")
     dask_cudf = pytest.importorskip("dask_cudf")
 
     df = cudf.DataFrame(
         {
-            "a": [1, 2, 3, 4, None, None, 7, 8, 9],
-            "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]
-        },
-        index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
+            "a": [1, 2, 3, 4, None, None, 7, 8],
+            "b": [1, 0] * 4,
+            "c": ["a", "b", None, None, "e", "f", "g", "h"],
+            "e": [4, 5, 6, 3, 2, 1, 0, 0],
+        }
     )
+    df["d"] = df["c"].astype("category")
     ddf = dask_cudf.from_cudf(df, npartitions=3)
 
-    assert_eq(
-        ddf.groupby("a", dropna=False).b.sum(),
-        df.groupby("a", dropna=False).b.sum()
-    )
+    if dropna is None:
+        dask_result = ddf.groupby(by).e.sum()
+        cudf_result = df.groupby(by).e.sum()
+    else:
+        dask_result = ddf.groupby(by, dropna=dropna).e.sum()
+        cudf_result = df.groupby(by, dropna=dropna).e.sum()
+    if by in ["c", "d"]:
+        # Loose string/category index name in cudf...
+        dask_result = dask_result.compute()
+        dask_result.index.name = cudf_result.index.name
+
+    assert_eq(dask_result, cudf_result)


### PR DESCRIPTION
This PR allows `cudf`-backed groupby operations to include (or exclude) null values in the index.  The changes are directly motivated by [cudf#3302](https://github.com/rapidsai/cudf/issues/3302).

Since pandas does not yet support the `dropna` argument (see: [pandas#3729](https://github.com/pandas-dev/pandas/issues/3729) and [pandas#21669](https://github.com/pandas-dev/pandas/pull/21669)), the new `test_groupby_dropna_pandas` test only checks for an unknown-argument `TypeError`.  A more-thorough `test_groupby_dropna_cudf` test was also added here, but this was mostly to illustrate the value of these changes.  The cudf-based test should most-likely be removed before merging, because it will be skipped by CI anyway.

Closes #5565 (Although not a permanent solution -- Cleanup will be necessary once pandas supports the `dropna` argument).  




- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
