### PR TITLE
Allow da.asarray to chunk inputs

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3671,7 +3671,7 @@ def asarray(a, **kwargs):
         return stack(a)
     elif not isinstance(getattr(a, "shape", None), Iterable):
         a = np.asarray(a)
-    return from_array(a, chunks=a.shape, getitem=getter_inline, **kwargs)
+    return from_array(a, getitem=getter_inline, **kwargs)
 
 
 def asanyarray(a):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2372,6 +2372,13 @@ def test_asarray_h5py():
             assert not any(isinstance(v, np.ndarray) for v in x.dask.values())
 
 
+def test_asarray_chunks():
+    with dask.config.set({"array.chunk-size": "100 B"}):
+        x = np.ones(1000)
+        d = da.asarray(x)
+        assert d.npartitions > 1
+
+
 @pytest.mark.filterwarnings("ignore:the matrix subclass")
 def test_asanyarray():
     x = np.matrix([1, 2, 3])


### PR DESCRIPTION
Previously asarray used a single chunk.
This made sense with numpy arrays but didn't make sense when given large
on-disk arrays.  Now we allow chunks to pass through, and use auto
otherwise.

@jakirkham ran into this