### PR TITLE
Move funding to .github repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: [numfocus]
-custom: ['https://numfocus.org/donate-to-dask']


### PR DESCRIPTION
We should inherit https://github.com/dask/.github

I assume so, but to confirm, are we OK with adding a "Sponsor" button to the repo? Just need to tick the box in each repo's settings.