### PR TITLE
Revert "Remove import of dask_cudf, which is now a part of cudf (#5568)"

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -15,4 +15,4 @@ from .utils import hash_object_dispatch, group_split_dispatch
 @meta_nonempty.register_lazy("cudf")
 @make_meta.register_lazy("cudf")
 def _register_cudf():
-    import cudf  # noqa: F401
+    import dask_cudf  # noqa: F401


### PR DESCRIPTION
This reverts commit a44790a0b39b117d37d70212f1793cf3ebc27109.

We *do* need to import the dask_cudf library, which populates some Dask registries as a side effect.