### PR TITLE
Enable gpu-backed covariance/correlation

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5183,10 +5183,6 @@ def cov_corr_combine(data_in, corr=False):
             (n1 * n2) / (n1 + n2) * (d * d.transpose((0, 2, 1))), 0
         ) + np.nansum(data["cov"], 0)
 
-    dtype = []
-    for name in items:
-        dtype.append((name, data[name].dtype))
-
     out = {"sum": cum_sums[-1], "count": cum_counts[-1], "cov": C}
 
     if corr:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5206,10 +5206,7 @@ def cov_corr_agg(data, cols, min_periods=2, corr=False, scalar=False):
     with np.errstate(invalid="ignore", divide="ignore"):
         mat = C / den
     if scalar:
-        result = mat[0, 1]
-        if hasattr(result, "get"):
-            return np.asscalar(result.get())
-        return result
+        return float(mat[0, 1])
     return pd.DataFrame(mat, columns=cols, index=cols)
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5190,7 +5190,7 @@ def cov_corr_combine(data_in, corr=False):
     for name in items:
         dtype.append((name, data[name].dtype))
 
-    out = np.empty(C.shape, dtype=dtype)
+    out = {}
     out["sum"] = cum_sums[-1]
     out["count"] = cum_counts[-1]
     out["cov"] = C

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5125,8 +5125,10 @@ def cov_corr_chunk(df, corr=False):
     """Chunk part of a covariance or correlation computation
     """
     shape = (df.shape[1], df.shape[1])
-    sums = np.zeros(shape)
-    counts = np.zeros(shape)
+    # sums = np.zeros(shape)
+    # counts = np.zeros(shape)
+    sums = np.zeros_like(df.values, shape=shape)
+    counts = np.zeros_like(df.values, shape=shape)
     df = df.astype("float64", copy=False)
     for idx, col in enumerate(df):
         mask = df.iloc[:, idx].notnull()

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5125,8 +5125,8 @@ def cov_corr_chunk(df, corr=False):
     """Chunk part of a covariance or correlation computation
     """
     shape = (df.shape[1], df.shape[1])
-    sums = np.zeros_like(None, shape=shape)
-    counts = np.zeros_like(None, shape=shape)
+    sums = np.zeros(shape)
+    counts = np.zeros(shape)
     df = df.astype("float64", copy=False)
     for idx, col in enumerate(df):
         mask = df.iloc[:, idx].notnull()
@@ -5148,7 +5148,7 @@ def cov_corr_chunk(df, corr=False):
         m = m.T
         dtype.append(("m", m.dtype))
 
-    out = {}  # np.empty(counts.shape, dtype=dtype)
+    out = {}
     out["sum"] = sums
     out["count"] = counts
     out["cov"] = cov * (counts - 1)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5158,12 +5158,11 @@ def cov_corr_chunk(df, corr=False):
 
 def cov_corr_combine(data_in, corr=False):
 
-    items = ["sum", "count", "cov"]
+    data = {"sum": None, "count": None, "cov": None}
     if corr:
-        items.append("m")
+        data["m"] = None
 
-    data = {}
-    for k in items:
+    for k in data.keys():
         data[k] = [d[k] for d in data_in]
         data[k] = np.concatenate(data[k]).reshape((len(data[k]),) + data[k][0].shape)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5126,8 +5126,9 @@ def cov_corr_chunk(df, corr=False):
     """
     shape = (df.shape[1], df.shape[1])
     df = df.astype("float64", copy=False)
-    sums = np.zeros_like(df.values, shape=shape)
-    counts = np.zeros_like(df.values, shape=shape)
+    ref = np.empty(shape, dtype="float64")
+    sums = np.zeros_like(ref)
+    counts = np.zeros_like(ref)
     for idx, col in enumerate(df):
         mask = df.iloc[:, idx].notnull()
         sums[idx] = df[mask].sum().values
@@ -5138,11 +5139,12 @@ def cov_corr_chunk(df, corr=False):
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             mu = (sums / counts).T
-        m = np.zeros_like(df.values, shape=shape)
+        m = np.zeros_like(ref)
         mask = df.isnull().values
+        r = np.empty((len(df), len(mu)), dtype="float64")
         for idx, x in enumerate(df):
             # Avoid using ufunc.outer, since it is not supported by cupy
-            mu_discrepancy = np.zeros_like(df.values, shape=(len(df), len(mu)))
+            mu_discrepancy = np.zeros_like(r)
             for j in range(len(mu)):
                 mu_discrepancy[:, j] = np.subtract(df.iloc[:, idx].values, mu[idx, j])
             mu_discrepancy = mu_discrepancy ** 2

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5132,12 +5132,7 @@ def cov_corr_chunk(df, corr=False):
         mask = df.iloc[:, idx].notnull()
         sums[idx] = df[mask].sum().values
         counts[idx] = df[mask].count().values
-    try:
-        cov = df.cov().values
-    except NotImplementedError:
-        # Numpy version of covariance is slightly different from pandas
-        cov = np.cov(df.values, rowvar=False)
-
+    cov = df.cov().values
     dtype = [("sum", sums.dtype), ("count", counts.dtype), ("cov", cov.dtype)]
     if corr:
         with warnings.catch_warnings(record=True):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5164,9 +5164,7 @@ def cov_corr_combine(data_in, corr=False):
 
     data = {}
     for k in items:
-        data[k] = []
-        for d in data_in:
-            data[k].append(d[k])
+        data[k] = [d[k] for d in data_in]
         data[k] = np.concatenate(data[k]).reshape((len(data[k]),) + data[k][0].shape)
 
     sums = np.nan_to_num(data["sum"])


### PR DESCRIPTION
Addresses the dask-component of [cudf#3363](https://github.com/rapidsai/cudf/issues/3363)

These changes make the numpy-based `cov_corr_chunk` and `cov_corr_combine` algorithms cupy-friendly.  The motivation is to support covariance/correlation on cudf-backed dask dataframes.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
