### PR TITLE
Adds 'wheel' package dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,9 @@ packages = ['dask', 'dask.array', 'dask.bag', 'dask.bytes',
 tests = [p + '.tests' for p in packages]
 
 # Only include pytest-runner in setup_requires if we're invoking tests
+setup_requires = ['wheel']
 if {'pytest', 'test', 'ptr'}.intersection(sys.argv):
-    setup_requires = ['pytest-runner']
-else:
-    setup_requires = []
+    setup_requires += ['pytest-runner']
 
 setup(name='dask',
       version=versioneer.get_version(),


### PR DESCRIPTION
Setup fails on fresh Python 3.x systems where the wheel package has
not been installed yet. A 'python3 -m pip install dask[complete]'
will not be able to complete the 'bdist_wheel' step without it,
displaying an "invalid command 'bdist_wheel'" error message.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
