### PR TITLE
Add chunksize argument to read_parquet

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -324,7 +324,10 @@ class ArrowEngine(Engine):
         return (meta, stats, parts)
 
     @staticmethod
-    def aggregate_row_groups(parts, stats, chunksize):
+    def aggregate_row_groups(parts, stats, chunksize, split_row_groups=True, **kwargs):
+        if not split_row_groups:
+            return parts, stats
+
         def _init_piece(part, stat):
             piece = [
                 part["piece"][0],

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -320,60 +320,6 @@ class ArrowEngine(Engine):
         return (meta, stats, parts)
 
     @staticmethod
-    def aggregate_row_groups(parts, stats, chunksize, split_row_groups=True, **kwargs):
-        if (
-            (not split_row_groups)
-            or (not stats[0]["file_path_0"])
-            or (not stats[0]["total_byte_size"])
-        ):
-            return parts, stats
-
-        def _init_piece(part, stat):
-            piece = [part["piece"][0], [part["piece"][1]], part["piece"][2]]
-            new_part = {"piece": piece, "kwargs": part["kwargs"]}
-            new_stat = stat.copy()
-            return new_part, new_stat
-
-        def _add_piece(part, part_list, stat, stat_list):
-            part["piece"] = tuple(part["piece"])
-            part_list.append(part)
-            stat_list.append(stat)
-
-        def _update_piece(part, next_part, stat, next_stat):
-            row_group = part["piece"][1]
-            next_part["piece"][1].append(row_group)  # Engine Specific #
-            next_stat["total_byte_size"] += stat["total_byte_size"]
-            next_stat["num-rows"] += stat["num-rows"]
-            for col, col_add in zip(next_stat["columns"], stat["columns"]):
-                if col["name"] != col_add["name"]:
-                    raise ValueError("Columns are different!!")
-                if "null_count" in col:
-                    col["null_count"] += col_add["null_count"]
-                if "min" in col:
-                    col["min"] = min(col["min"], col_add["min"])
-                if "max" in col:
-                    col["max"] = max(col["max"], col_add["max"])
-
-        parts_agg = []
-        stats_agg = []
-        next_part, next_stat = _init_piece(parts[0], stats[0])
-        for i in range(1, len(parts)):
-            stat, part = stats[i], parts[i]
-            print("stat[file_path_0]", stat["file_path_0"])
-            print("stat[total_byte_size]", stat["total_byte_size"])
-            if (stat["file_path_0"] == next_stat["file_path_0"]) and (
-                (next_stat["total_byte_size"] + stat["total_byte_size"]) <= chunksize
-            ):
-                _update_piece(part, next_part, stat, next_stat)
-            else:
-                _add_piece(next_part, parts_agg, next_stat, stats_agg)
-                next_part, next_stat = _init_piece(part, stat)
-
-        _add_piece(next_part, parts_agg, next_stat, stats_agg)
-
-        return parts_agg, stats_agg
-
-    @staticmethod
     def read_partition(
         fs, piece, columns, index, categories=(), partitions=(), **kwargs
     ):
@@ -381,47 +327,32 @@ class ArrowEngine(Engine):
             columns += index
         if isinstance(piece, str):
             # `piece` is a file-path string
-            pieces = [
-                pq.ParquetDatasetPiece(
-                    piece, open_file_func=partial(fs.open, mode="rb")
-                )
-            ]
+            piece = pq.ParquetDatasetPiece(
+                piece, open_file_func=partial(fs.open, mode="rb")
+            )
         else:
             # `piece` contains (path, row_group, partition_keys)
-            (path, row_groups, partition_keys) = piece
-            if not isinstance(row_groups, list):
-                row_groups = [row_groups]
-            pieces = [
-                pq.ParquetDatasetPiece(
-                    path,
-                    row_group=row_group,
-                    partition_keys=partition_keys,
-                    open_file_func=partial(fs.open, mode="rb"),
-                )
-                for row_group in row_groups
-            ]
+            (path, row_group, partition_keys) = piece
+            piece = pq.ParquetDatasetPiece(
+                path,
+                row_group=row_group,
+                partition_keys=partition_keys,
+                open_file_func=partial(fs.open, mode="rb"),
+            )
 
-        dfs = []
-        for piece in pieces:
-            df = piece.read(
-                columns=columns,
-                partitions=partitions,
-                use_pandas_metadata=True,
-                use_threads=False,
-                **kwargs.get("read", {}),
-            ).to_pandas(categories=categories, use_threads=False, ignore_metadata=True)[
-                list(columns)
-            ]
+        df = piece.read(
+            columns=columns,
+            partitions=partitions,
+            use_pandas_metadata=True,
+            use_threads=False,
+            **kwargs.get("read", {}),
+        ).to_pandas(categories=categories, use_threads=False, ignore_metadata=True)[
+            list(columns)
+        ]
 
-            if index:
-                df = df.set_index(index)
-
-            if len(pieces) == 1:
-                return df
-
-            dfs.append(df)
-
-        return pd.concat(dfs, axis=0)
+        if index:
+            df = df.set_index(index)
+        return df
 
     @staticmethod
     def initialize_write(

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -310,7 +310,7 @@ class ArrowEngine(Engine):
                         )
             else:
                 parts = [
-                    (piece.path, piece.row_group, piece.partition_keys)
+                    (piece.path, piece.row_group, piece.partition_keys, None)
                     for piece in pieces
                 ]
         parts = [

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -218,116 +218,16 @@ def read_parquet(
     if meta.index.name is not None:
         index = meta.index.name
 
-    ignore_index_column_intersection = False
-    if columns is None:
-        # User didn't specify columns, so ignore any intersection
-        # of auto-detected values with the index (if necessary)
-        ignore_index_column_intersection = True
-        columns = [c for c in meta.columns]
-
-    if not set(columns).issubset(set(meta.columns)):
-        raise ValueError(
-            "The following columns were not found in the dataset %s\n"
-            "The following columns were found %s"
-            % (set(columns) - set(meta.columns), meta.columns)
-        )
-
     # Parse dataset statistics from metadata (if available)
-    index_in_columns = False
-    if statistics:
-        result = list(
-            zip(
-                *[
-                    (part, stats)
-                    for part, stats in zip(parts, statistics)
-                    if stats["num-rows"] > 0
-                ]
-            )
-        )
-        parts, statistics = result or [[], []]
-        if filters:
-            parts, statistics = apply_filters(parts, statistics, filters)
+    parts, divisions, index, index_in_columns = process_statistics(
+        parts, statistics, filters, index
+    )
 
-        out = sorted_columns(statistics)
-
-        if index and isinstance(index, str):
-            index = [index]
-        if index and out:
-            # Only one valid column
-            out = [o for o in out if o["name"] in index]
-        if index is not False and len(out) == 1:
-            # Use only sorted column with statistics as the index
-            divisions = out[0]["divisions"]
-            if index is None:
-                index_in_columns = True
-                index = [out[0]["name"]]
-            elif index != [out[0]["name"]]:
-                raise ValueError("Specified index is invalid.\nindex: {}".format(index))
-        elif index is not False and len(out) > 1:
-            if any(o["name"] == "index" for o in out):
-                # Use sorted column named "index" as the index
-                [o] = [o for o in out if o["name"] == "index"]
-                divisions = o["divisions"]
-                if index is None:
-                    index = [o["name"]]
-                    index_in_columns = True
-                elif index != [o["name"]]:
-                    raise ValueError(
-                        "Specified index is invalid.\nindex: {}".format(index)
-                    )
-            else:
-                # Multiple sorted columns found, cannot autodetect the index
-                warnings.warn(
-                    "Multiple sorted columns found %s, cannot\n "
-                    "autodetect index. Will continue without an index.\n"
-                    "To pick an index column, use the index= keyword; to \n"
-                    "silence this warning use index=False."
-                    "" % [o["name"] for o in out],
-                    RuntimeWarning,
-                )
-                index = False
-                divisions = [None] * (len(parts) + 1)
-        else:
-            divisions = [None] * (len(parts) + 1)
-    else:
-        divisions = [None] * (len(parts) + 1)
-
-    if index:
-        if isinstance(index, str):
-            index = [index]
-        if isinstance(columns, str):
-            columns = [columns]
-
-        if ignore_index_column_intersection:
-            columns = [col for col in columns if col not in index]
-        if set(index).intersection(columns):
-            if auto_index_allowed:
-                raise ValueError(
-                    "Specified index and column arguments must not intersect"
-                    " (set index=False or remove the detected index from columns).\n"
-                    "index: {} | column: {}".format(index, columns)
-                )
-            else:
-                raise ValueError(
-                    "Specified index and column arguments must not intersect.\n"
-                    "index: {} | column: {}".format(index, columns)
-                )
-
-        # Leaving index as a column in `meta`, because the index
-        # will be reset below (in case the index was detected after
-        # meta was created)
-        if index_in_columns:
-            meta = meta[columns + index]
-        else:
-            meta = meta[columns]
-
-    else:
-        meta = meta[list(columns)]
-
-    def _merge_kwargs(x, y):
-        z = x.copy()
-        z.update(y)
-        return z
+    # Account for index and columns arguments.
+    # Modify `meta` dataframe accordingly
+    meta, index, columns = set_index_columns(
+        meta, index, columns, index_in_columns, auto_index_allowed
+    )
 
     subgraph = ParquetSubgraph(name, engine, fs, meta, columns, index, parts, kwargs)
 
@@ -682,6 +582,125 @@ def apply_filters(parts, statistics, filters):
         parts, statistics = out_parts, out_statistics
 
     return parts, statistics
+
+
+def process_statistics(parts, statistics, filters, index):
+    """Process row-group column statistics in metadata
+    Used in read_parquet.
+    """
+    index_in_columns = False
+    if statistics:
+        result = list(
+            zip(
+                *[
+                    (part, stats)
+                    for part, stats in zip(parts, statistics)
+                    if stats["num-rows"] > 0
+                ]
+            )
+        )
+        parts, statistics = result or [[], []]
+        if filters:
+            parts, statistics = apply_filters(parts, statistics, filters)
+
+        out = sorted_columns(statistics)
+
+        if index and isinstance(index, str):
+            index = [index]
+        if index and out:
+            # Only one valid column
+            out = [o for o in out if o["name"] in index]
+        if index is not False and len(out) == 1:
+            # Use only sorted column with statistics as the index
+            divisions = out[0]["divisions"]
+            if index is None:
+                index_in_columns = True
+                index = [out[0]["name"]]
+            elif index != [out[0]["name"]]:
+                raise ValueError("Specified index is invalid.\nindex: {}".format(index))
+        elif index is not False and len(out) > 1:
+            if any(o["name"] == "index" for o in out):
+                # Use sorted column named "index" as the index
+                [o] = [o for o in out if o["name"] == "index"]
+                divisions = o["divisions"]
+                if index is None:
+                    index = [o["name"]]
+                    index_in_columns = True
+                elif index != [o["name"]]:
+                    raise ValueError(
+                        "Specified index is invalid.\nindex: {}".format(index)
+                    )
+            else:
+                # Multiple sorted columns found, cannot autodetect the index
+                warnings.warn(
+                    "Multiple sorted columns found %s, cannot\n "
+                    "autodetect index. Will continue without an index.\n"
+                    "To pick an index column, use the index= keyword; to \n"
+                    "silence this warning use index=False."
+                    "" % [o["name"] for o in out],
+                    RuntimeWarning,
+                )
+                index = False
+                divisions = [None] * (len(parts) + 1)
+        else:
+            divisions = [None] * (len(parts) + 1)
+    else:
+        divisions = [None] * (len(parts) + 1)
+
+    return parts, divisions, index, index_in_columns
+
+
+def set_index_columns(meta, index, columns, index_in_columns, auto_index_allowed):
+    """Handle index/column arguments, and modify `meta`
+    Used in read_parquet.
+    """
+    ignore_index_column_intersection = False
+    if columns is None:
+        # User didn't specify columns, so ignore any intersection
+        # of auto-detected values with the index (if necessary)
+        ignore_index_column_intersection = True
+        columns = [c for c in meta.columns]
+
+    if not set(columns).issubset(set(meta.columns)):
+        raise ValueError(
+            "The following columns were not found in the dataset %s\n"
+            "The following columns were found %s"
+            % (set(columns) - set(meta.columns), meta.columns)
+        )
+
+    if index:
+        if isinstance(index, str):
+            index = [index]
+        if isinstance(columns, str):
+            columns = [columns]
+
+        if ignore_index_column_intersection:
+            columns = [col for col in columns if col not in index]
+        if set(index).intersection(columns):
+            if auto_index_allowed:
+                raise ValueError(
+                    "Specified index and column arguments must not intersect"
+                    " (set index=False or remove the detected index from columns).\n"
+                    "index: {} | column: {}".format(index, columns)
+                )
+            else:
+                raise ValueError(
+                    "Specified index and column arguments must not intersect.\n"
+                    "index: {} | column: {}".format(index, columns)
+                )
+
+        # Leaving index as a column in `meta`, because the index
+        # will be reset below (in case the index was detected after
+        # meta was created)
+        if index_in_columns:
+            meta = meta[columns + index]
+        else:
+            meta = meta[columns]
+
+    else:
+        meta = meta[list(columns)]
+
+    return meta, index, columns
 
 
 DataFrame.to_parquet.__doc__ = to_parquet.__doc__

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -254,14 +254,18 @@ def read_parquet_part(func, fs, meta, part, columns, index, kwargs):
     """ Read a part of a parquet dataset
 
     This function is used by `read_parquet`."""
-    import pandas as pd
+    concat_func = kwargs.pop("concat_func", False)
+    if not concat_func:
+        import pandas as pd
+
+        concat_func = pd.concat
 
     if isinstance(part, list):
         dfs = []
         for rg in part:
             df = func(fs, rg, columns.copy(), index, **kwargs)
             dfs.append(df)
-        df = pd.concat(dfs, axis=0)
+        df = concat_func(dfs, axis=0)
     else:
         df = func(fs, part, columns, index, **kwargs)
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -224,9 +224,11 @@ def read_parquet(
         index = meta.index.name
 
     # Aggregate parts/statistics if we are splitting by row-group
-    if split_row_groups and gather_statistics:
+    if statistics:
         chunksize = chunksize or 250000000
-        parts, statistics = engine.aggregate_row_groups(parts, statistics, chunksize)
+        parts, statistics = engine.aggregate_row_groups(
+            parts, statistics, chunksize, split_row_groups=split_row_groups
+        )
 
     # Parse dataset statistics from metadata (if available)
     parts, divisions, index, index_in_columns = process_statistics(

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -225,29 +225,8 @@ def read_parquet(
 
     # Aggregate parts/statistics if we are splitting by row-group
     if split_row_groups and gather_statistics:
-
-        row_size = 0
-        for column in statistics[0]["columns"]:
-            name = column["name"]
-            if name in meta.columns:
-                dtype = meta[name].dtype
-            else:
-                dtype = meta.index.dtype
-            if dtype == "object":
-                item_size = dtype.itemsize
-                if "max" in column:
-                    item_size *= len(column["max"])
-                else:
-                    item_size *= 10
-                row_size += item_size
-            else:
-                row_size += dtype.itemsize
-
-        target_batch_size = (chunksize or 250000000) // row_size
-        if target_batch_size > 1:
-            parts, statistics = engine.aggregate_row_groups(
-                parts, statistics, target_batch_size
-            )
+        chunksize = chunksize or 250000000
+        parts, statistics = engine.aggregate_row_groups(parts, statistics, chunksize)
 
     # Parse dataset statistics from metadata (if available)
     parts, divisions, index, index_in_columns = process_statistics(

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -238,9 +238,11 @@ def read_parquet(
             else:
                 row_size += dtype.itemsize
 
-        parts_agg, statistics_agg = engine.aggregate_row_groups(
-            parts, statistics, (chunksize or 250000000) // row_size
-        )
+        target_batch_size = (chunksize or 250000000) // row_size
+        if target_batch_size > 1:
+            parts, statistics = engine.aggregate_row_groups(
+                parts, statistics, target_batch_size
+            )
 
     # Parse dataset statistics from metadata (if available)
     parts, divisions, index, index_in_columns = process_statistics(

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -146,9 +146,9 @@ def read_parquet(
         available). Otherwise, partitions correspond to distinct files.
         Only the "pyarrow" engine currently supports this argument.
     chunksize : int
-        The target task partition size.  If consecutive row-groups are stored
-        in the same file, they will be aggregated into the same output
-        partition until the aggregate size reaches this value (default 250MB).
+        The target task partition size.  If set, consecutive row-groups
+        from the same file will be aggregated into the same output
+        partition until the aggregate size reaches this value.
     **kwargs: dict (of dicts)
         Passthrough key-word arguments for read backend.
         The top-level keys correspond to the appropriate operation type, and
@@ -224,10 +224,7 @@ def read_parquet(
         index = meta.index.name
 
     # Aggregate parts/statistics if we are splitting by row-group
-    if statistics:
-        if chunksize is None:
-            chunksize = 250000000
-
+    if statistics and chunksize:
         parts, statistics = engine.aggregate_row_groups(
             parts, statistics, chunksize, split_row_groups=split_row_groups
         )

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -8,7 +8,7 @@ from fsspec.utils import stringify_path
 
 from ...core import DataFrame, new_dd_object
 from ....base import tokenize
-from ....utils import import_required, natural_sort_key
+from ....utils import import_required, natural_sort_key, parse_bytes
 from collections.abc import Mapping
 
 
@@ -731,6 +731,8 @@ def set_index_columns(meta, index, columns, index_in_columns, auto_index_allowed
 def aggregate_row_groups(parts, stats, chunksize):
     if not (stats[0]["file_path_0"] and stats[0]["total_byte_size"]):
         return parts, stats
+
+    chunksize = parse_bytes(chunksize)
 
     def _add_piece(part, part_list, stat, stat_list):
         part_list.append(part)

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -10,6 +10,7 @@ from ...core import DataFrame, new_dd_object
 from ....base import tokenize
 from ....utils import import_required, natural_sort_key, parse_bytes
 from collections.abc import Mapping
+from ...methods import concat
 
 
 try:
@@ -255,14 +256,8 @@ def read_parquet_part(func, fs, meta, part, columns, index, kwargs):
 
     This function is used by `read_parquet`."""
     if isinstance(part, list):
-        concat_func = kwargs.pop("concat_func", False)
-        if not concat_func:
-            import pandas as pd
-
-            concat_func = pd.concat
-
         dfs = [func(fs, rg, columns.copy(), index, **kwargs) for rg in part]
-        df = concat_func(dfs, axis=0)
+        df = concat(dfs, axis=0)
     else:
         df = func(fs, part, columns, index, **kwargs)
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -234,7 +234,12 @@ def read_parquet(
             else:
                 dtype = meta.index.dtype
             if dtype == "object":
-                row_size += len(column["max"]) * dtype.itemsize
+                item_size = dtype.itemsize
+                if "max" in column:
+                    item_size *= len(column["max"])
+                else:
+                    item_size *= 10
+                row_size += item_size
             else:
                 row_size += dtype.itemsize
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -146,9 +146,9 @@ def read_parquet(
         available). Otherwise, partitions correspond to distinct files.
         Only the "pyarrow" engine currently supports this argument.
     chunksize : int
-        The target task partition size.  If split_row_groups is `True` the
-        row-groups will be aggregated (if consecutive groups are in the same
-        file) until the aggregate data size reach this value (default 250MB).
+        The target task partition size.  If consecutive row-groups are stored
+        in the same file, they will be aggregated into the same output
+        partition until the aggregate size reaches this value (default 250MB).
     **kwargs: dict (of dicts)
         Passthrough key-word arguments for read backend.
         The top-level keys correspond to the appropriate operation type, and
@@ -225,7 +225,9 @@ def read_parquet(
 
     # Aggregate parts/statistics if we are splitting by row-group
     if statistics:
-        chunksize = chunksize or 250000000
+        if chunksize is None:
+            chunksize = 250000000
+
         parts, statistics = engine.aggregate_row_groups(
             parts, statistics, chunksize, split_row_groups=split_row_groups
         )

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -147,7 +147,7 @@ def read_parquet(
         to parquet-file row-groups (when enough row-group metadata is
         available). Otherwise, partitions correspond to distinct files.
         Only the "pyarrow" engine currently supports this argument.
-    chunksize : int
+    chunksize : int, str
         The target task partition size.  If set, consecutive row-groups
         from the same file will be aggregated into the same output
         partition until the aggregate size reaches this value.
@@ -254,13 +254,13 @@ def read_parquet_part(func, fs, meta, part, columns, index, kwargs):
     """ Read a part of a parquet dataset
 
     This function is used by `read_parquet`."""
-    concat_func = kwargs.pop("concat_func", False)
-    if not concat_func:
-        import pandas as pd
-
-        concat_func = pd.concat
-
     if isinstance(part, list):
+        concat_func = kwargs.pop("concat_func", False)
+        if not concat_func:
+            import pandas as pd
+
+            concat_func = pd.concat
+
         dfs = []
         for rg in part:
             df = func(fs, rg, columns.copy(), index, **kwargs)

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -330,6 +330,48 @@ class FastParquetEngine(Engine):
         return (meta, stats, parts)
 
     @staticmethod
+    def aggregate_row_groups(parts, stats, batch_size):
+        def _init_piece(part, stat):
+            new_part = part.copy()
+            new_part["piece"] = [new_part["piece"]]
+            return new_part, stat.copy()
+
+        def _add_piece(part, part_list, stat, stat_list):
+            part_list.append(part)
+            stat_list.append(stat)
+
+        def _update_piece(part, next_part, stat, next_stat):
+            row_group = part["piece"]
+            next_part["piece"].append(row_group)
+
+            # Update Statistics
+            next_stat["num-rows"] += stat["num-rows"]
+            for col, col_add in zip(next_stat["columns"], stat["columns"]):
+                if col["name"] != col_add["name"]:
+                    raise ValueError("Columns are different!!")
+                if "null_count" in col:
+                    col["null_count"] += col_add["null_count"]
+                if "min" in col:
+                    col["min"] = min(col["min"], col_add["min"])
+                if "max" in col:
+                    col["max"] = max(col["max"], col_add["max"])
+
+        parts_agg = []
+        stats_agg = []
+        next_part, next_stat = _init_piece(parts[0], stats[0])
+        for i in range(1, len(parts)):
+            stat, part = stats[i], parts[i]
+            if next_stat["num-rows"] <= (batch_size + stat["num-rows"]):
+                _update_piece(part, next_part, stat, next_stat)
+            else:
+                _add_piece(next_part, parts_agg, next_stat, stats_agg)
+                next_part, next_stat = _init_piece(part, stat)
+
+        _add_piece(next_part, parts_agg, next_stat, stats_agg)
+
+        return parts_agg, stats_agg
+
+    @staticmethod
     def read_partition(fs, piece, columns, index, categories=(), pf=None, **kwargs):
         if isinstance(index, list):
             columns += index
@@ -345,23 +387,30 @@ class FastParquetEngine(Engine):
             pf.file_scheme = scheme
             pf.cats = _paths_to_cats(fns, scheme)
             pf.fn = base
-            df = pf.to_pandas(columns, categories, index=index)
+            return pf.to_pandas(columns, categories, index=index)
         else:
-            if isinstance(pf, tuple):
-                pf = _determine_pf_parts(fs, pf[0], pf[1], **kwargs)[1]
-                pf._dtypes = lambda *args: pf.dtypes  # ugly patch, could be fixed
-                pf.fmd.row_groups = None
-            piece = pf.row_groups[piece]
-            pf.fmd.key_value_metadata = None
-            df = pf.read_row_group_file(
-                piece, columns, categories, index=index, **kwargs.get("read", {})
-            )
+            pieces = piece
+            if not isinstance(pieces, list):
+                pieces = [piece]
 
-        return df
+            dfs = []
+            for piece in pieces:
+                if isinstance(pf, tuple):
+                    pf = _determine_pf_parts(fs, pf[0], pf[1], **kwargs)[1]
+                    pf._dtypes = lambda *args: pf.dtypes  # ugly patch, could be fixed
+                    pf.fmd.row_groups = None
+                rg_piece = pf.row_groups[piece]
+                pf.fmd.key_value_metadata = None
+                df = pf.read_row_group_file(
+                    rg_piece, columns, categories, index=index, **kwargs.get("read", {})
+                )
 
-    @staticmethod
-    def aggregate_row_groups(parts, stats, batch_size):
-        return parts, stats
+                if len(pieces) == 1:
+                    return df
+
+                dfs.append(df)
+
+            return pd.concat(dfs, axis=0)
 
     @staticmethod
     def initialize_write(

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -360,6 +360,10 @@ class FastParquetEngine(Engine):
         return df
 
     @staticmethod
+    def aggregate_row_groups(parts, stats, batch_size):
+        return parts, stats
+
+    @staticmethod
     def initialize_write(
         df,
         fs,

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -67,26 +67,6 @@ class Engine:
         raise NotImplementedError()
 
     @staticmethod
-    def aggregate_row_groups(parts, stats, batch_size, **kwargs):
-        """
-        Aggregate row-groups, and produce new parts and stats objects.
-
-        Parameters
-        ----------
-        parts: List
-            Contains metadata objects to write, of the type undrestood by
-            the specific implementation.
-        statistics: List[Dict]
-            A list of dictionaries of statistics data, one dict for every
-            partition.
-        batch_size: int
-            The ideal number of rows to use for a single task/paritition.
-        **kwargs: dict
-            Other keyword arguments
-        """
-        raise NotImplementedError()
-
-    @staticmethod
     def read_partition(fs, piece, columns, index, **kwargs):
         """ Read a single piece of a Parquet dataset into a Pandas DataFrame
 

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -193,6 +193,24 @@ class Engine:
         """
         raise NotImplementedError()
 
+    @staticmethod
+    def aggregate_row_groups(parts, stats, batch_size):
+        """
+        Aggregate row-groups, and produce new parts and stats objects.
+
+        Parameters
+        ----------
+        parts: List
+            Contains metadata objects to write, of the type undrestood by
+            the specific implementation.
+        statistics: List[Dict]
+            A list of dictionaries of statistics data, one dict for every
+            partition.
+        batch_size: int
+            The ideal number of rows to use for a single task/paritition.
+        """
+        raise NotImplementedError()
+
 
 def _parse_pandas_metadata(pandas_metadata):
     """Get the set of names from the pandas metadata section

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -67,6 +67,26 @@ class Engine:
         raise NotImplementedError()
 
     @staticmethod
+    def aggregate_row_groups(parts, stats, batch_size, **kwargs):
+        """
+        Aggregate row-groups, and produce new parts and stats objects.
+
+        Parameters
+        ----------
+        parts: List
+            Contains metadata objects to write, of the type undrestood by
+            the specific implementation.
+        statistics: List[Dict]
+            A list of dictionaries of statistics data, one dict for every
+            partition.
+        batch_size: int
+            The ideal number of rows to use for a single task/paritition.
+        **kwargs: dict
+            Other keyword arguments
+        """
+        raise NotImplementedError()
+
+    @staticmethod
     def read_partition(fs, piece, columns, index, **kwargs):
         """ Read a single piece of a Parquet dataset into a Pandas DataFrame
 
@@ -190,24 +210,6 @@ class Engine:
             or start from scratch (False)
         **kwargs: dict
             Other keyword arguments (including `compression`)
-        """
-        raise NotImplementedError()
-
-    @staticmethod
-    def aggregate_row_groups(parts, stats, batch_size):
-        """
-        Aggregate row-groups, and produce new parts and stats objects.
-
-        Parameters
-        ----------
-        parts: List
-            Contains metadata objects to write, of the type undrestood by
-            the specific implementation.
-        statistics: List[Dict]
-            A list of dictionaries of statistics data, one dict for every
-            partition.
-        batch_size: int
-            The ideal number of rows to use for a single task/paritition.
         """
         raise NotImplementedError()
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2112,7 +2112,7 @@ def test_split_row_groups_pyarrow(tmpdir):
 
 
 @pytest.mark.parametrize("metadata", [True, False])
-@pytest.mark.parametrize("chunksize", [None, 16, 1024, 4096])
+@pytest.mark.parametrize("chunksize", [None, 0, 1024, 4096])
 def test_chunksize(tmpdir, chunksize, engine, metadata):
     check_pyarrow()
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -14,7 +14,7 @@ from dask.dataframe.utils import assert_eq, PANDAS_VERSION
 from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.dataframe.optimize import optimize_read_parquet_getitem
 from dask.dataframe.io.parquet.core import ParquetSubgraph
-from dask.utils import natural_sort_key
+from dask.utils import natural_sort_key, parse_bytes
 
 try:
     import fastparquet
@@ -2112,7 +2112,7 @@ def test_split_row_groups_pyarrow(tmpdir):
 
 
 @pytest.mark.parametrize("metadata", [True, False])
-@pytest.mark.parametrize("chunksize", [None, 1024, 4096, 40960])
+@pytest.mark.parametrize("chunksize", [None, 1024, 4096, "1MiB"])
 def test_chunksize(tmpdir, chunksize, engine, metadata):
     check_pyarrow()
 
@@ -2156,4 +2156,4 @@ def test_chunksize(tmpdir, chunksize, engine, metadata):
 
     for df_part in ddf2.partitions:
         if chunksize and len(df_part) > row_group_size:
-            assert df_part.compute().memory_usage().sum() <= chunksize
+            assert df_part.compute().memory_usage().sum() <= parse_bytes(chunksize)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2104,7 +2104,7 @@ def test_split_row_groups_pyarrow(tmpdir):
 
 
 @pytest.mark.parametrize("chunksize", [None, 16, 1024, 4096])
-def test_chunksize(tmpdir, chunksize):
+def test_chunksize(tmpdir, chunksize, engine):
     check_pyarrow()
 
     df = pd.DataFrame(
@@ -2123,7 +2123,7 @@ def test_chunksize(tmpdir, chunksize):
 
     ddf2 = dd.read_parquet(
         str(tmpdir),
-        engine="pyarrow",
+        engine=engine,
         chunksize=chunksize,
         split_row_groups=True,
         gather_statistics=True,

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2112,7 +2112,7 @@ def test_split_row_groups_pyarrow(tmpdir):
 
 
 @pytest.mark.parametrize("metadata", [True, False])
-@pytest.mark.parametrize("chunksize", [None, 0, 1024, 4096])
+@pytest.mark.parametrize("chunksize", [None, 1024, 4096, 40960])
 def test_chunksize(tmpdir, chunksize, engine, metadata):
     check_pyarrow()
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2114,6 +2114,8 @@ def test_split_row_groups_pyarrow(tmpdir):
 @pytest.mark.parametrize("metadata", [True, False])
 @pytest.mark.parametrize("chunksize", [None, 1024, 4096, "1MiB"])
 def test_chunksize(tmpdir, chunksize, engine, metadata):
+    check_pyarrow()  # Need pyarrow for write phase in this test
+
     nparts = 2
     df_size = 100
     row_group_size = 5

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2079,7 +2079,11 @@ def test_split_row_groups_pyarrow(tmpdir):
     )
 
     ddf3 = dd.read_parquet(
-        tmp, engine="pyarrow", gather_statistics=True, split_row_groups=True
+        tmp,
+        engine="pyarrow",
+        gather_statistics=True,
+        split_row_groups=True,
+        chunksize=1,
     )
     assert ddf3.npartitions == 4
 
@@ -2093,7 +2097,11 @@ def test_split_row_groups_pyarrow(tmpdir):
     )
 
     ddf3 = dd.read_parquet(
-        tmp, engine="pyarrow", gather_statistics=True, split_row_groups=True
+        tmp,
+        engine="pyarrow",
+        gather_statistics=True,
+        split_row_groups=True,
+        chunksize=1,
     )
     assert ddf3.npartitions == 12
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2114,19 +2114,20 @@ def test_split_row_groups_pyarrow(tmpdir):
 @pytest.mark.parametrize("metadata", [True, False])
 @pytest.mark.parametrize("chunksize", [None, 1024, 4096, "1MiB"])
 def test_chunksize(tmpdir, chunksize, engine, metadata):
-    check_pyarrow()
+    nparts = 2
+    df_size = 100
+    row_group_size = 5
+    row_group_byte_size = 451  # Empirically measured
 
     df = pd.DataFrame(
         {
-            "a": np.random.choice(["apple", "banana", "carrot"], size=100),
-            "b": np.random.random(size=100),
-            "c": np.random.randint(1, 5, size=100),
-            "index": np.arange(0, 100),
+            "a": np.random.choice(["apple", "banana", "carrot"], size=df_size),
+            "b": np.random.random(size=df_size),
+            "c": np.random.randint(1, 5, size=df_size),
+            "index": np.arange(0, df_size),
         }
     ).set_index("index")
 
-    nparts = 2
-    row_group_size = 6
     ddf1 = dd.from_pandas(df, npartitions=nparts)
     ddf1.to_parquet(
         str(tmpdir),
@@ -2154,6 +2155,13 @@ def test_chunksize(tmpdir, chunksize, engine, metadata):
 
     assert_eq(ddf1, ddf2, check_divisions=False)
 
-    for df_part in ddf2.partitions:
-        if chunksize and len(df_part) > row_group_size:
-            assert df_part.compute().memory_usage().sum() <= parse_bytes(chunksize)
+    num_row_groups = df_size // row_group_size
+    if not chunksize:
+        assert ddf2.npartitions == num_row_groups
+    else:
+        # Check that we are really aggregating
+        df_byte_size = row_group_byte_size * num_row_groups
+        expected = df_byte_size // parse_bytes(chunksize)
+        remainder = (df_byte_size % parse_bytes(chunksize)) > 0
+        expected += int(remainder) * nparts
+        assert ddf2.npartitions == max(nparts, expected)


### PR DESCRIPTION
Adds the functionality requested in [cudf#3394](https://github.com/rapidsai/cudf/issues/3394).  

Currently, the `read_parquet` implementation in dask allows the dataset to be partitioned by row-group.  However, the optimal task/partition size can be larger than a single row group in many cases.  This PR adds a `chunksize` argument to `read_parquet`, which allows the user to specify the target data size (in bytes) for each task/partition.  Consecutive row-groups will be read/aggregated by the same task until the data size reaches `chunksize`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`


**Notes**:
- For the `"pyarrow"` engine, aggregation can only occur if `split_row_groups=True` (default)
- Since the algorithm uses row-group metadata to aggregate tasks before the actual read, the aggregation will only occur if `gather_statistics=True` (or if `gather_statistics=None` and `"_metadata"` is available)
- ~The default value for `chunksize` is 250MB (please feel free to suggest other options)~
- By default, no row-group aggregation will be performed (`chunksize` must be set by the user)
