### PR TITLE
Using fns from _analyze_paths to detect metadata file

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -106,7 +106,7 @@ def _determine_dataset_parts(fs, paths, gather_statistics, filters, dataset_kwar
             # Otherwise, just use 0th file
             if "_common_metadata" in fns:
                 dataset = pq.ParquetDataset(
-                    base + fs.sep + "_common_metadata", filesystem=fs, **dataset_kwargs,
+                    base + fs.sep + "_common_metadata", filesystem=fs, **dataset_kwargs
                 )
             else:
                 dataset = pq.ParquetDataset(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1915,7 +1915,10 @@ def test_read_dir_nometa(tmpdir, write_engine, read_engine, statistics, remove_c
 
 
 def test_timeseries_nulls_in_schema(tmpdir, engine):
-    tmp_path = str(tmpdir)
+    # GH#5608: relative path failing _metadata/_common_metadata detection.
+    tmp_path = str(tmpdir.mkdir("files"))
+    tmp_path = os.path.join(tmp_path, "../", "files")
+
     ddf2 = (
         dask.datasets.timeseries(start="2000-01-01", end="2000-01-03", freq="1h")
         .reset_index()


### PR DESCRIPTION
Related to: https://github.com/dask/dask/pull/5307

While using those changes and because I was using a path for the parquet folder of the form `/home/user/repo/src/../../files/` (because of `os.path.join(__file__, '../../files')`) the default behavior of `"validate_schema"=False` was not working.

This is due to `relpaths = [path.replace(base, "").lstrip("/") for path in allpaths]` not detecting `base` with such a relative path.

Looking into the code I see no problem of using `base, fns = _analyze_paths(allpaths, fs)` directly to detect the metadata file. I did the changes both for pyarrow and fastparquet. 

In the way I simplified the if/else conditions, made it more readable to me. If someone disagrees I can revert that (the changes comparison in a code editor look much simpler than in github I have to say)

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
