### PR TITLE
Add doc for some utils

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -72,5 +72,7 @@ configuration values.
 
 .. currentmodule:: dask.utils
 
+.. autofunction:: format_bytes
+.. autofunction:: format_time
 .. autofunction:: parse_bytes
 .. autofunction:: parse_timedelta

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -62,6 +62,8 @@ Dask has a few helpers for generating demo datasets
 .. autofunction:: make_people
 .. autofunction:: timeseries
 
+.. _api.utilities:
+
 Utilities
 ---------
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -52,7 +52,23 @@ This more advanced API is available in the `Dask distributed documentation
 .. autofunction:: persist
 .. autofunction:: visualize
 
-Finally, Dask has a few helpers for generating demo datasets
+Datasets
+--------
 
-.. autofunction:: datasets.make_people
-.. autofunction:: datasets.timeseries
+Dask has a few helpers for generating demo datasets
+
+.. currentmodule:: dask.datasets
+
+.. autofunction:: make_people
+.. autofunction:: timeseries
+
+Utilities
+---------
+
+Dask has some public utility methods. These are primarily used for parsing
+configuration values.
+
+.. currentmodule:: dask.utils
+
+.. autofunction:: parse_bytes
+.. autofunction:: parse_timedelta

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -66,6 +66,8 @@ Note that the ``get`` function treats underscores and hyphens identically.
 For example, ``dask.config.get('num_workers')`` is equivalent to
 ``dask.config.get('num-workers')``.
 
+The values in the like ``"128 MiB"`` and ``"10s"`` are parsed using the
+functions in :ref:`api.utilities`.
 
 Specify Configuration
 ---------------------

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -66,8 +66,8 @@ Note that the ``get`` function treats underscores and hyphens identically.
 For example, ``dask.config.get('num_workers')`` is equivalent to
 ``dask.config.get('num-workers')``.
 
-The values in the like ``"128 MiB"`` and ``"10s"`` are parsed using the
-functions in :ref:`api.utilities`.
+Values like ``"128 MiB"`` and ``"10s"`` are parsed using the functions in
+:ref:`api.utilities`.
 
 Specify Configuration
 ---------------------


### PR DESCRIPTION
It's not clear to me what all in `dask/utils.py` is considered public, but I think these are. Any others? `format_bytes` and `format_time`?