### PR TITLE
Fixed independent optimization of parquet-getitem

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -157,6 +157,7 @@ class Blockwise(Mapping):
     new_axes: Dict
         New index dimensions that may have been created, and their extent
 
+
     See Also
     --------
     dask.blockwise.blockwise
@@ -182,6 +183,9 @@ class Blockwise(Mapping):
         self.numblocks = numblocks
         self.concatenate = concatenate
         self.new_axes = new_axes or {}
+
+    def __repr__(self):
+        return "Blockwise<{} -> {}>".format(self.indices, self.output)
 
     @property
     def _dict(self):

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -44,8 +44,8 @@ class ParquetSubgraph(Mapping):
         self.kwargs = kwargs
 
     def __repr__(self):
-        return "ParquetSubgraph<name='{}', n_parts={}>".format(
-            self.name, len(self.parts)
+        return "ParquetSubgraph<name='{}', n_parts={}, columns={}>".format(
+            self.name, len(self.parts), list(self.columns)
         )
 
     def __getitem__(self, key):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2114,6 +2114,18 @@ def test_split_row_groups_pyarrow(tmpdir):
     assert ddf3.npartitions == 4
 
 
+def test_optimize_getitem_and_nonblockwise(tmpdir):
+    path = os.path.join(tmpdir, "path.parquet")
+    df = pd.DataFrame(
+        {"a": [3, 4, 2], "b": [1, 2, 4], "c": [5, 4, 2], "d": [1, 2, 3]},
+        index=["a", "b", "c"],
+    )
+    df.to_parquet(path)
+
+    df2 = dd.read_parquet(path)
+    df2[["a", "b"]].rolling(3).max().compute()
+
+
 def test_optimize_and_not(tmpdir):
     path = os.path.join(tmpdir, "path.parquet")
     df = pd.DataFrame(
@@ -2125,13 +2137,15 @@ def test_optimize_and_not(tmpdir):
     df2 = dd.read_parquet(path)
     df2a = df2["a"].groupby(df2["c"]).first().to_delayed()
     df2b = df2["b"].groupby(df2["c"]).first().to_delayed()
-    df2c = df2.rename(columns=str.upper)[["D"]].to_delayed()
-    (result,) = dask.compute(df2a + df2b + df2c)
+    df2c = df2[["a", "b"]].rolling(2).max().to_delayed()
+    df2d = df2.rolling(2).max().to_delayed()
+    (result,) = dask.compute(df2a + df2b + df2c + df2d)
 
     expected = [
         dask.compute(df2a)[0][0],
         dask.compute(df2b)[0][0],
         dask.compute(df2c)[0][0],
+        dask.compute(df2d)[0][0],
     ]
     for a, b in zip(result, expected):
         assert_eq(a, b)

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -1,6 +1,7 @@
 """ Dataframe optimizations """
 import operator
 
+from dask.base import tokenize
 from ..optimization import cull, fuse
 from .. import config, core
 from ..highlevelgraph import HighLevelGraph
@@ -34,15 +35,17 @@ def optimize(dsk, keys, **kwargs):
 
 
 def optimize_read_parquet_getitem(dsk):
-    # find the keys to optimze
+    # find the keys to optimize
     from .io.parquet.core import ParquetSubgraph
 
     read_parquets = [k for k, v in dsk.layers.items() if isinstance(v, ParquetSubgraph)]
 
     layers = dsk.layers.copy()
+    dependencies = dsk.dependencies.copy()
 
     for k in read_parquets:
         columns = set()
+        update_blocks = {}
 
         for dep in dsk.dependents[k]:
             block = dsk.layers[dep]
@@ -65,28 +68,47 @@ def optimize_read_parquet_getitem(dsk):
                 block_columns = [block_columns]
 
             columns |= set(block_columns)
+            update_blocks[dep] = block
 
         old = layers[k]
 
         if columns and columns < set(old.meta.columns):
             columns = list(columns)
             meta = old.meta[columns]
+            name = "read-parquet-" + tokenize(old.name, columns)
+            assert len(update_blocks)
+
+            for block_key, block in update_blocks.items():
+                # (('read-parquet-old', (.,)), ( ... )) ->
+                # (('read-parquet-new', (.,)), ( ... ))
+                new_indices = ((name, block.indices[0][1]), block.indices[1])
+                numblocks = {name: block.numblocks[old.name]}
+                new_block = Blockwise(
+                    block.output,
+                    block.output_indices,
+                    block.dsk,
+                    new_indices,
+                    numblocks,
+                    block.concatenate,
+                    block.new_axes,
+                )
+                layers[block_key] = new_block
+                dependencies[block_key] = {name}
+            dependencies[name] = dependencies.pop(k)
+
         else:
             # Things like df[df.A == 'a'], where the argument to
             # getitem is not a column name
+            name = old.name
             meta = old.meta
             columns = list(meta.columns)
 
         new = ParquetSubgraph(
-            old.name,
-            old.engine,
-            old.fs,
-            meta,
-            columns,
-            old.index,
-            old.parts,
-            old.kwargs,
+            name, old.engine, old.fs, meta, columns, old.index, old.parts, old.kwargs
         )
-        layers[k] = new
+        layers[name] = new
+        if name != old.name:
+            del layers[old.name]
 
-    return HighLevelGraph(layers, dsk.dependencies)
+    new_hlg = HighLevelGraph(layers, dependencies)
+    return new_hlg


### PR DESCRIPTION
On master, the parquet-getitem optimization can cause us to form
invalid Dask graphs, as we (somehow I don't fully understand) reuse an
optimized `read_parquet` that doesn't contain all the keys needed for a
secondary `__getitem__`.

This fixes that by changing the `name` used for the `read_parquet`, and
all references to it.

Closes https://github.com/dask/dask/issues/5502

cc @mrocklin if you get a chance to review next week (no rush). This is a bit tricky.