### PR TITLE
Removes html_extra_path from docs configuration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,6 @@ source_suffix = ".rst"
 
 # The master toctree document.
 master_doc = "index"
-html_extra_path = ["index.html"]
 
 # General information about the project.
 project = u"Dask"
@@ -359,10 +358,9 @@ redirect_template = """\
 """
 
 html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+    "css_files": ["_static/theme_overrides.css"]  # override wide tables in RTD theme
+}
+
 
 def copy_legacy_redirects(app, docname):
     if app.builder.name == "html":


### PR DESCRIPTION
We currently get this warning when building the documentation:

```
WARNING: html_extra_path entry 'index.html' does not exist
```

Based on the [description of `html_extra_path`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_extra_path) in the sphinx docs, I don't think `html_extra_path` is needed as this config value is for specifying files that are not meant to be built. 

xref #5610