### PR TITLE
Fix "file_path_0" bug in aggregate_row_groups

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -721,7 +721,7 @@ def set_index_columns(meta, index, columns, index_in_columns, auto_index_allowed
 
 
 def aggregate_row_groups(parts, stats, chunksize):
-    if ("file_path_0" not in stats[0]) or (stats[0]["file_path_0"] is None):
+    if not stats[0].get("file_path_0", None):
         return parts, stats
 
     parts_agg = []

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -721,7 +721,7 @@ def set_index_columns(meta, index, columns, index_in_columns, auto_index_allowed
 
 
 def aggregate_row_groups(parts, stats, chunksize):
-    if not stats[0]["file_path_0"]:
+    if ("file_path_0" not in stats[0]) or (stats[0]["file_path_0"] is None):
         return parts, stats
 
     parts_agg = []


### PR DESCRIPTION
Closes #5624 

PR #5607 does not check if there is a `"file_path_0"` entry in the `statistics` item before checking it's value. This entry will **not** be present in the case that each partition corresponds to a distinct file (because there are not multiple row-groups per file).  The changes here just add a simple check, and a corresponding test.  

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
