### PR TITLE
Close SQLAlchemy engine after querying DB

### DIFF
--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -195,6 +195,8 @@ def read_sql_table(
             )
         )
 
+    engine.dispose()
+
     return from_delayed(parts, meta, divisions=divisions)
 
 
@@ -202,8 +204,9 @@ def _read_sql_chunk(q, uri, meta, engine_kwargs=None, **kwargs):
     import sqlalchemy as sa
 
     engine_kwargs = engine_kwargs or {}
-    conn = sa.create_engine(uri, **engine_kwargs)
-    df = pd.read_sql(q, conn, **kwargs)
+    engine = sa.create_engine(uri, **engine_kwargs)
+    df = pd.read_sql(q, engine, **kwargs)
+    engine.dispose()
     if df.empty:
         return meta
     else:


### PR DESCRIPTION
- [x] Tests ~added~ / passed 
    - *None added as this shouldn't affect the functionality of dask - open to challenge on this!*
- [x] Passes `black dask` / `flake8 dask`

Per the pandas issue https://github.com/pandas-dev/pandas/issues/23086, users/code that creates a SQLAlchemy engine to pull data is also responsible for closing/disposing of it; failure to do so leaves the engine and all connections it has in the connection pool hanging around until garbage collected. 
This is sub-optimal as it means the database will have some of its precious resources locked without actually being used.

This PR explicitly calls `engine.dispose()` in both functions that generate an engine.

Fixes https://github.com/dask/dask/issues/5623