### PR TITLE
Compute length of dataframe as length of first column

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3222,6 +3222,14 @@ class DataFrame(_Frame):
 
         return _iLocIndexer(self)
 
+    def __len__(self):
+        try:
+            s = self[self.columns[0]]
+        except IndexError:
+            return super().__len__()
+        else:
+            return len(s)
+
     def __getitem__(self, key):
         name = "getitem-%s" % tokenize(self, key)
         if np.isscalar(key) or isinstance(key, (tuple, str)):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1018,6 +1018,8 @@ def test_isin():
 def test_len():
     assert len(d) == len(full)
     assert len(d.a) == len(full.a)
+    assert len(dd.from_pandas(pd.DataFrame(), npartitions=1)) == 0
+    assert len(dd.from_pandas(pd.DataFrame(columns=[1, 2]), npartitions=1)) == 0
 
 
 def test_size():


### PR DESCRIPTION
This should reduce work when we're able to pass down column access,
such as is the case with parquet.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
