### PR TITLE
Redo `dask.order.order`.  Fix #5584.  Use structural info, not key names

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -436,7 +436,7 @@ def ndependencies(dependencies, dependents):
     --------
     >>> dsk = {'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b')}
     >>> dependencies, dependents = get_deps(dsk)
-    >>> num_dependencies, total_dependencies = ndependencies(dependencies, dependents).items())
+    >>> num_dependencies, total_dependencies = ndependencies(dependencies, dependents).items()
     >>> sorted(total_dependencies.items())
     [('a', 1), ('b', 2), ('c', 3)]
 

--- a/dask/order.py
+++ b/dask/order.py
@@ -112,7 +112,7 @@ def order(dsk, dependencies=None):
         cycle = getcycle(dsk, None)
         raise RuntimeError(
             "Cycle detected between the following keys:\n  -> %s"
-            % "\n  -> ".join(cycle)
+            % "\n  -> ".join(str(x) for x in cycle)
         )
 
     def initial_stack_key(x):

--- a/dask/order.py
+++ b/dask/order.py
@@ -436,7 +436,7 @@ def ndependencies(dependencies, dependents):
     --------
     >>> dsk = {'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b')}
     >>> dependencies, dependents = get_deps(dsk)
-    >>> num_dependencies, total_dependencies = ndependencies(dependencies, dependents).items()
+    >>> num_dependencies, total_dependencies = ndependencies(dependencies, dependents)
     >>> sorted(total_dependencies.items())
     [('a', 1), ('b', 2), ('c', 3)]
 

--- a/dask/order.py
+++ b/dask/order.py
@@ -118,20 +118,19 @@ def order(dsk, dependencies=None):
         First prioritize large, tall groups, then prioritize the same as `dependents_key`.
         """
         num_dependents = len(dependents[x])
-        total_dependents, min_dependencies, max_dependencies, min_heights, max_heights = metrics[x]
+        total_dependents, min_dependencies, max_dependencies, min_heights, max_heights = metrics[
+            x
+        ]
         return (
             # at a high-level, work towards a large goal (and prefer tall and narrow)
             -max_dependencies,
             num_dependents - max_heights,
-
             # tactically, finish small connected jobs first
             min_dependencies,
             num_dependents - min_heights,  # prefer tall and narrow
             -total_dependents,  # take a big step
-
             # try to be memory efficient
             num_dependents,
-
             # tie-breaker
             StrComparable(x),
         )
@@ -148,11 +147,9 @@ def order(dsk, dependencies=None):
             min_dependencies,
             num_dependents - min_heights,  # prefer tall and narrow
             -total_dependents,  # take a big step
-
             # try to be memory efficient
             num_dependents - len(dependencies[x]) + num_needed[x],
             num_dependents,
-
             # tie-breaker
             StrComparable(x),
         )
@@ -163,21 +160,20 @@ def order(dsk, dependencies=None):
         This is very similar to both `initial_stack_key` and `dependents_key`.
         """
         num_dependents = len(dependents[x])
-        total_dependents, min_dependencies, max_dependencies, min_heights, max_heights = metrics[x]
+        total_dependents, min_dependencies, max_dependencies, min_heights, max_heights = metrics[
+            x
+        ]
         return (
             # at a high-level, work towards a large goal (and prefer tall and narrow)
             -max_dependencies,
             num_dependents - max_heights,
-
             # tactically, finish small connected jobs first
             min_dependencies,
             num_dependents - min_heights,  # prefer tall and narrow
             -total_dependents,  # stay where the work is
-
             # try to be memory efficient
             num_dependents - len(dependencies[x]) + num_needed[x],
             num_dependents,
-
             # tie-breaker
             StrComparable(x),
         )
@@ -227,10 +223,14 @@ def order(dsk, dependencies=None):
                         inner_stack_append(item)
                         deps = dependencies[item].difference(result)
                         if len(deps) < 1000:
-                            inner_stack_extend(sorted(deps, key=dependencies_key, reverse=True))
+                            inner_stack_extend(
+                                sorted(deps, key=dependencies_key, reverse=True)
+                            )
                         else:
                             inner_stack_extend(deps)
-                            inner_stack_append(min(deps, key=dependencies_key))  # one good one
+                            inner_stack_append(
+                                min(deps, key=dependencies_key)  # one good one
+                            )
                         continue
 
                     result[item] = i
@@ -251,7 +251,9 @@ def order(dsk, dependencies=None):
             while not outer_stack and outer_stack_seeds_index < len(outer_stack_seeds):
                 outer_stack_extend(
                     sorted(
-                        dependents[outer_stack_seeds[outer_stack_seeds_index]].difference(result),
+                        dependents[
+                            outer_stack_seeds[outer_stack_seeds_index]
+                        ].difference(result),
                         key=dependents_key,
                         reverse=True,
                     )
@@ -271,7 +273,8 @@ def order(dsk, dependencies=None):
             init_stack = init_stack.difference(result)
             N = len(init_stack)
             m = prev_len - N
-            if m >= N or N + (N - m) * log(N - m) < N * log(N):  # is `min` likely better than `sort`?
+            # is `min` likely better than `sort`?
+            if m >= N or N + (N - m) * log(N - m) < N * log(N):
                 item = min(init_stack, key=initial_stack_key)
                 continue
 

--- a/dask/order.py
+++ b/dask/order.py
@@ -389,7 +389,7 @@ Number of total data elements that depend on key
         key = current_pop()
         parents = dependents[key]
         if len(parents) == 1:
-            parent, = parents
+            (parent,) = parents
             (
                 total_dependents,
                 min_dependencies,

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -178,7 +178,6 @@ def test_avoid_upwards_branching_complex(abcde):
     assert o[(c, 1)] < o[(b, 1)]
 
 
-# @pytest.mark.xfail(reason="this case is ambiguous", strict=False)  # this now passes
 def test_deep_bases_win_over_dependents(abcde):
     r"""
     It's not clear who should run first, e or d
@@ -186,6 +185,8 @@ def test_deep_bases_win_over_dependents(abcde):
     1.  d is nicer because it exposes parallelism
     2.  e is nicer (hypothetically) because it will be sooner released
         (though in this case we need d to run first regardless)
+
+    Regardless of e or d first, we should run b before c.
 
             a
           / | \   .
@@ -197,8 +198,8 @@ def test_deep_bases_win_over_dependents(abcde):
     dsk = {a: (f, b, c, d), b: (f, d, e), c: (f, d), d: 1, e: 2}
 
     o = order(dsk)
-    assert o[e] < o[d]
-    assert o[d] < o[b] or o[d] < o[c]
+    assert o[e] < o[d]  # ambiguous, but this is what we currently expect
+    assert o[b] < o[c]
 
 
 def test_prefer_deep(abcde):

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -597,8 +597,53 @@ def test_dont_run_all_dependents_too_early(abcde):
     for i in range(1, depth):
         dsk[(b, i)] = (f, (b, 0))
         dsk[(c, i)] = (f, (c, 0))
-        dsk[(d, i)] = (f, (d, i-1), (b, i), (c, i))
+        dsk[(d, i)] = (f, (d, i - 1), (b, i), (c, i))
     o = order(dsk)
     expected = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30]
     actual = sorted(v for (letter, num), v in o.items() if letter == d)
     assert expected == actual
+
+
+def test_many_branches_use_ndependencies(abcde):
+    """ From https://github.com/dask/dask/pull/5646#issuecomment-562700533
+
+    Sometimes we need larger or wider DAGs to test behavior.  This test
+    ensures we choose the branch with more work twice in successtion.
+    This is important, because ``order`` may search along dependencies
+    and then along dependents.
+
+    """
+    a, b, c, d, e = abcde
+    dd = d + d
+    ee = e + e
+    dsk = {
+        (a, 0): 0,
+
+        (a, 1): (f, (a, 0)),
+        (a, 2): (f, (a, 1)),
+
+        (b, 1): (f, (a, 0)),
+        (b, 2): (f, (b, 1)),
+
+        (c, 1): (f, (a, 0)),  # most short and thin; should go last
+
+        (d, 1): (f, (a, 0)),
+        (d, 2): (f, (d, 1)),
+        (dd, 1): (f, (a, 0)),
+        (dd, 2): (f, (dd, 1)),
+        (dd, 3): (f, (d, 2), (dd, 2)),
+
+        (e, 1): (f, (a, 0)),
+        (e, 2): (f, (e, 1)),
+        (ee, 1): (f, (a, 0)),
+        (ee, 2): (f, (ee, 1)),
+        (ee, 3): (f, (e, 2), (ee, 2)),
+
+        (a, 3): (f, (a, 2), (b, 2), (c, 1), (dd, 3), (ee, 3)),
+    }
+    o = order(dsk)
+    # run all d's and e's first
+    expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    actual = sorted(v for(letter, _), v in o.items() if letter in {d, dd, e, ee})
+    assert actual == expected
+    assert o[(c, 1)] == o[(a, 3)] - 1

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -582,3 +582,23 @@ def test_use_structure_not_keys(abcde):
     else:
         assert As == [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
         assert Bs == [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+
+
+def test_dont_run_all_dependents_too_early(abcde):
+    """ From https://github.com/dask/dask-ml/issues/206#issuecomment-395873372 """
+    a, b, c, d, e = abcde
+    depth = 10
+    dsk = {
+        (a, 0): 0,
+        (b, 0): 1,
+        (c, 0): 2,
+        (d, 0): (f, (a, 0), (b, 0), (c, 0))
+    }
+    for i in range(1, depth):
+        dsk[(b, i)] = (f, (b, 0))
+        dsk[(c, i)] = (f, (c, 0))
+        dsk[(d, i)] = (f, (d, i-1), (b, i), (c, i))
+    o = order(dsk)
+    expected = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30]
+    actual = sorted(v for (letter, num), v in o.items() if letter == d)
+    assert expected == actual

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -637,3 +637,14 @@ def test_many_branches_use_ndependencies(abcde):
     actual = sorted(v for (letter, _), v in o.items() if letter in {d, dd, e, ee})
     assert actual == expected
     assert o[(c, 1)] == o[(a, 3)] - 1
+
+
+def test_order_cycle():
+    with pytest.raises(RuntimeError, match="Cycle detected"):
+        dask.get({"a": (f, "a")}, "a")
+    with pytest.raises(RuntimeError, match="Cycle detected"):
+        order({"a": (f, "a")})
+    with pytest.raises(RuntimeError, match="Cycle detected"):
+        order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a")})
+    with pytest.raises(RuntimeError, match="Cycle detected"):
+        order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a", "d"), "d": 1})

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -641,10 +641,14 @@ def test_many_branches_use_ndependencies(abcde):
 
 def test_order_cycle():
     with pytest.raises(RuntimeError, match="Cycle detected"):
-        dask.get({"a": (f, "a")}, "a")
+        dask.get({"a": (f, "a")}, "a")  # we encounter this in `get`
     with pytest.raises(RuntimeError, match="Cycle detected"):
-        order({"a": (f, "a")})
+        order({"a": (f, "a")})  # trivial self-loop
     with pytest.raises(RuntimeError, match="Cycle detected"):
-        order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a")})
+        order({("a", 0): (f, ("a", 0))})  # non-string
+    with pytest.raises(RuntimeError, match="Cycle detected"):
+        order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a")})  # non-trivial loop
     with pytest.raises(RuntimeError, match="Cycle detected"):
         order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a", "d"), "d": 1})
+    with pytest.raises(RuntimeError, match="Cycle detected"):
+        order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a", "d"), "d": (f, "b")})


### PR DESCRIPTION
Closes #5584 

This is a rewrite of `dask.order.order`, but the goals remain the same and many previous lessons were taken into consideration.  The new version relies less on the key name by using more metrics and using a different strategy for walking up and down the DAG.

Performance appears to be about the same (often a little faster).

@TomAugspurger also suggested I add some benchmarks to `dask-benchmarks`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
