### PR TITLE
Fix error handeling for str.cat dataframe #5621

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -135,15 +135,23 @@ class StringAccessor(Accessor):
 
     @derived_from(pd.core.strings.StringMethods)
     def cat(self, others=None, sep=None, na_rep=None):
-        from .core import Series, Index
+        from .core import DataFrame, Series, Index
 
         if others is None:
             raise NotImplementedError("x.str.cat() with `others == None`")
 
-        valid_types = (Series, Index, pd.Series, pd.Index)
-        if isinstance(others, valid_types):
+        is_dataframe_like = (DataFrame, pd.DataFrame)
+        is_series_like = (Series, pd.Series)
+        is_index_like = (Index, pd.Index)
+
+        if isinstance(others, is_series_like) or isinstance(others, is_index_like):
             others = [others]
-        elif not all(isinstance(a, valid_types) for a in others):
+        elif isinstance(others, is_dataframe_like):
+            raise TypeError("others must be Series/Index and not dataframe")
+        elif not all(
+            isinstance(a, is_series_like) or isinstance(a, is_index_like)
+            for a in others
+        ):
             raise TypeError("others must be Series/Index")
 
         return self._series.map_partitions(

--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -3,7 +3,7 @@ import pandas as pd
 from toolz import partial
 
 from ..utils import derived_from
-from .utils import PANDAS_VERSION
+from .utils import PANDAS_VERSION, is_dataframe_like, is_series_like, is_index_like
 
 
 def maybe_wrap_pandas(obj, x):
@@ -135,21 +135,17 @@ class StringAccessor(Accessor):
 
     @derived_from(pd.core.strings.StringMethods)
     def cat(self, others=None, sep=None, na_rep=None):
-        from .core import DataFrame, Series, Index
+        from .core import Series, Index
 
         if others is None:
             raise NotImplementedError("x.str.cat() with `others == None`")
 
-        is_dataframe_like = (DataFrame, pd.DataFrame)
-        is_series_like = (Series, pd.Series)
-        is_index_like = (Index, pd.Index)
-
-        if isinstance(others, is_series_like) or isinstance(others, is_index_like):
+        if is_series_like(others) or is_index_like(others):
             others = [others]
-        elif isinstance(others, is_dataframe_like):
+        elif is_dataframe_like(others):
             raise TypeError("others must be Series/Index and not dataframe")
         elif not all(
-            isinstance(a, is_series_like) or isinstance(a, is_index_like)
+            is_series_like(a) or is_index_like(a)
             for a in others
         ):
             raise TypeError("others must be Series/Index")

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -200,7 +200,7 @@ def test_str_accessor_cat(df_ddf):
         df.str_col.str.cat([df.str_col.str.upper(), df.str_col.str.lower()], sep=":"),
     )
 
-    for o in ["foo", ["foo"]]:
+    for o in ["foo", ["foo"], df, ddf]:
         with pytest.raises(TypeError):
             ddf.str_col.str.cat(o)
 


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`

Following issue: #5621 
Update str.cat function to handle dataframe input
