### PR TITLE
Support Parquet filters in disjunctive normal form, like PyArrow

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -590,6 +590,8 @@ def apply_filters(parts, statistics, filters):
                         and max > value
                         or operator == ">="
                         and max >= value
+                        or operator == "in"
+                        and any(min <= item <= max for item in value)
                     ):
                         out_parts.append(part)
                         out_statistics.append(stats)

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -117,11 +117,20 @@ def read_parquet(
         non-index fields will be read (as determined by the pandas parquet
         metadata, if present). Provide a single field name instead of a list to
         read in the data as a Series.
-    filters : list
-        List of filters to apply, like ``[('x', '>', 0), ...]``. This
-         implements row-group (partition) -level filtering only, i.e., to
-        prevent the loading of some chunks of the data, and only if relevant
-        statistics have been included in the metadata.
+    filters : Union[List[Tuple[str, str, Any]], List[List[Tuple[str, str, Any]]]]
+        List of filters to apply, like ``[[('x', '=', 0), ...], ...]``. This
+        implements partition-level (hive) filtering only, i.e., to prevent the
+        loading of some row-groups and/or files.
+
+        Predicates can be expressed in disjunctive normal form (DNF). This means
+        that the innermost tuple describes a single column predicate. These
+        inner predicates are combined with an AND conjunction into a larger
+        predicate. The outer-most list then combines all of the combined
+        filters with an OR disjunction.
+
+        Predicates can also be expressed as a List[Tuple]. These are evaluated
+        as an AND conjunction. To express OR in predictates, one must use the
+        (preferred) List[List[Tuple]] notation.
     index : string, list, False or None (default)
         Field name(s) to use as the output frame index. By default will be
         inferred from the pandas parquet file metadata (if present). Use False
@@ -557,7 +566,19 @@ def apply_filters(parts, statistics, filters):
     statistics: List[dict]
         List of statistics for each part, including min and max values
     filters: Union[List[Tuple[str, str, Any]], List[List[Tuple[str, str, Any]]]]
-        List of filters to apply, like [[('x', '=', 0), ...], ...]
+        List of filters to apply, like ``[[('x', '=', 0), ...], ...]``. This
+        implements partition-level (hive) filtering only, i.e., to prevent the
+        loading of some row-groups and/or files.
+
+        Predicates can be expressed in disjunctive normal form (DNF). This means
+        that the innermost tuple describes a single column predicate. These
+        inner predicates are combined with an AND conjunction into a larger
+        predicate. The outer-most list then combines all of the combined
+        filters with an OR disjunction.
+
+        Predicates can also be expressed as a List[Tuple]. These are evaluated
+        as an AND conjunction. To express OR in predictates, one must use the
+        (preferred) List[List[Tuple]] notation.
 
     Returns
     -------

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1084,7 +1084,7 @@ def test_partition_on_string(tmpdir, partition_on):
 
 
 @write_read_engines_xfail
-def test_filters(tmpdir, write_engine, read_engine):
+def test_filters_categorical(tmpdir, write_engine, read_engine):
     tmpdir = str(tmpdir)
     cats = ["2018-01-01", "2018-01-02", "2018-01-03", "2018-01-04"]
     dftest = pd.DataFrame(
@@ -1101,25 +1101,25 @@ def test_filters(tmpdir, write_engine, read_engine):
     assert len(ddftest_read) == 2
 
 
-def test_filters_pyarrow(tmpdir):
-    check_pyarrow()
+@write_read_engines_xfail
+def test_filters(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
     df = pd.DataFrame({"x": range(10), "y": list("aabbccddee")})
     ddf = dd.from_pandas(df, npartitions=5)
     assert ddf.npartitions == 5
 
-    ddf.to_parquet(tmp_path, engine="pyarrow")
+    ddf.to_parquet(tmp_path, engine=write_engine)
 
-    a = dd.read_parquet(tmp_path, engine="pyarrow", filters=[("x", ">", 4)])
+    a = dd.read_parquet(tmp_path, engine=read_engine, filters=[("x", ">", 4)])
     assert a.npartitions == 3
     assert (a.x > 3).all().compute()
 
-    b = dd.read_parquet(tmp_path, engine="pyarrow", filters=[("y", "==", "c")])
+    b = dd.read_parquet(tmp_path, engine=read_engine, filters=[("y", "==", "c")])
     assert b.npartitions == 1
     assert (b.y == "c").all().compute()
 
     c = dd.read_parquet(
-        tmp_path, engine="pyarrow", filters=[("y", "==", "c"), ("x", ">", 6)]
+        tmp_path, engine=read_engine, filters=[("y", "==", "c"), ("x", ">", 6)]
     )
     assert c.npartitions <= 1
     assert not len(c)
@@ -1127,7 +1127,7 @@ def test_filters_pyarrow(tmpdir):
 
     d = dd.read_parquet(
         tmp_path,
-        engine="pyarrow",
+        engine=read_engine,
         filters=[
             # Select two overlapping ranges
             [("x", ">", 1), ("x", "<", 6)],
@@ -1137,7 +1137,7 @@ def test_filters_pyarrow(tmpdir):
     assert d.npartitions == 3
     assert ((d.x > 1) & (d.x < 8)).all().compute()
 
-    e = dd.read_parquet(tmp_path, engine="pyarrow", filters=[("x", "in", (0, 9))])
+    e = dd.read_parquet(tmp_path, engine=read_engine, filters=[("x", "in", (0, 9))])
     assert e.npartitions == 2
     assert ((e.x < 2) | (e.x > 7)).all().compute()
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1125,6 +1125,18 @@ def test_filters_pyarrow(tmpdir):
     assert not len(c)
     assert_eq(c, c)
 
+    d = dd.read_parquet(
+        tmp_path,
+        engine="pyarrow",
+        filters=[
+            # Select two overlapping ranges
+            [("x", ">", 1), ("x", "<", 6)],
+            [("x", ">", 3), ("x", "<", 8)],
+        ],
+    )
+    assert d.npartitions == 3
+    assert ((d.x > 1) & (d.x < 8)).all().compute()
+
 
 @write_read_engines()
 def test_filters_v0(tmpdir, write_engine, read_engine):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1137,6 +1137,10 @@ def test_filters_pyarrow(tmpdir):
     assert d.npartitions == 3
     assert ((d.x > 1) & (d.x < 8)).all().compute()
 
+    e = dd.read_parquet(tmp_path, engine="pyarrow", filters=[("x", "in", (0, 9))])
+    assert e.npartitions == 2
+    assert ((e.x < 2) | (e.x > 7)).all().compute()
+
 
 @write_read_engines()
 def test_filters_v0(tmpdir, write_engine, read_engine):

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -213,6 +213,10 @@ class Resampler(object):
         return self._agg("max")
 
     @derived_from(pd_Resampler)
+    def nunique(self):
+        return self._agg("nunique")
+
+    @derived_from(pd_Resampler)
     def ohlc(self):
         return self._agg("ohlc")
 
@@ -229,9 +233,17 @@ class Resampler(object):
         return self._agg("std")
 
     @derived_from(pd_Resampler)
+    def size(self):
+        return self._agg("size")
+
+    @derived_from(pd_Resampler)
     def sum(self):
         return self._agg("sum")
 
     @derived_from(pd_Resampler)
     def var(self):
         return self._agg("var")
+
+    @derived_from(pd_Resampler)
+    def quantile(self):
+        return self._agg("quantile")

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -3,7 +3,7 @@ from itertools import product
 import pandas as pd
 import pytest
 
-from dask.dataframe.utils import assert_eq
+from dask.dataframe.utils import assert_eq, PANDAS_VERSION
 import dask.dataframe as dd
 
 
@@ -36,6 +36,7 @@ def test_series_resample(obj, method, npartitions, freq, closed, label):
 
     result = resample(ds, freq, how=method, closed=closed, label=label)
     expected = resample(ps, freq, how=method, closed=closed, label=label)
+
     assert_eq(result, expected, check_dtype=False)
 
     divisions = result.divisions
@@ -100,3 +101,18 @@ def test_resample_index_name():
     ddf = dd.from_pandas(df, npartitions=4)
 
     assert ddf.resample("D").mean().head().index.name == "date"
+
+
+@pytest.mark.skipif(PANDAS_VERSION <= "0.23.4", reason="quantile not in 0.23")
+@pytest.mark.parametrize("agg", ["nunique", "mean", "count", "size", "quantile"])
+def test_common_aggs(agg):
+    index = pd.date_range("2000-01-01", "2000-02-15", freq="h")
+    ps = pd.Series(range(len(index)), index=index)
+    ds = dd.from_pandas(ps, npartitions=2)
+
+    f = lambda df: getattr(df, agg)()
+
+    res = f(ps.resample("1d"))
+    expected = f(ds.resample("1d"))
+
+    assert_eq(res, expected, check_dtype=False)


### PR DESCRIPTION
PyArrow supports filter predicates in disjunctive normal form, as described in #3847. This PR allows `dd.read_parquet` to apply such filters over multiple partitions. Previously, only _AND_ predicates were supported by Dask.

The documentation of the `filters` argument still needs some work. Perhaps the PyArrow docs could be referenced here?

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
