### PR TITLE
Shuffle drops column "_partitions" in-place

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3676,11 +3676,11 @@ class DataFrame(_Frame):
         return {None: 0, "index": 0, "columns": 1}.get(axis, axis)
 
     @derived_from(pd.DataFrame)
-    def drop(self, labels=None, axis=0, columns=None, errors="raise"):
+    def drop(self, labels=None, axis=0, columns=None, errors="raise", inplace=False):
         axis = self._validate_axis(axis)
         if (axis == 1) or (columns is not None):
             return self.map_partitions(
-                M.drop, labels=labels, axis=axis, columns=columns, errors=errors
+                M.drop, labels=labels, axis=axis, columns=columns, errors=errors, inplace=inplace
             )
         raise NotImplementedError(
             "Drop currently only works for axis=1 or when columns is not None"

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -248,7 +248,7 @@ def shuffle(df, index, shuffle=None, npartitions=None, max_branch=32, compute=No
         shuffle=shuffle,
         compute=compute,
     )
-    del df3["_partitions"]
+    df3.drop(columns="_partitions", inplace=True)
     return df3
 
 
@@ -270,7 +270,7 @@ def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None)
         npartitions=len(divisions) - 1,
         shuffle=shuffle,
     )
-    del df3["_partitions"]
+    df3.drop(columns="_partitions", inplace=True)
     return df3
 
 


### PR DESCRIPTION
Pandas' Dataframe support dropping a column in-place, which shuffle now uses.
Notice, cuDF will also support in-place drop: https://github.com/rapidsai/cudf/pull/3497

This PR **doubles** the performance of a distributed cuDF merge on a DGX1: 

### Before this PR (full copy)
```
Merge benchmark
--------------------------
Chunk-size  | 100000000
Frac-match  | 0.3
Ignore-size | 1.05 MB
Protocol    | ucx
Device(s)   | 1,2
==========================
Total time  | 2.51 s
==========================
(w1,w2)     | 25% 50% 75% (total nbytes)
--------------------------
(01,02)     | 6.77 GB/s 10.25 GB/s 10.36 GB/s (5.20 GB)
(02,01)     | 6.65 GB/s 10.06 GB/s 10.59 GB/s (5.20 GB)
```


### After this PR (drop in-place)
```
Merge benchmark
--------------------------
Chunk-size  | 100000000
Frac-match  | 0.3
Ignore-size | 1.05 MB
Protocol    | ucx
Device(s)   | 1,2
==========================
Total time  | 1.26 s
==========================
(w1,w2)     | 25% 50% 75% (total nbytes)
--------------------------
(01,02)     | 9.79 GB/s 9.96 GB/s 10.91 GB/s (5.60 GB)
(02,01)     | 9.74 GB/s 9.88 GB/s 10.69 GB/s (5.60 GB)
```

cc @mrocklin 