### PR TITLE
Register sizeof functions for Numba and RMM

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -45,6 +45,15 @@ def register_cupy():
         return int(x.nbytes)
 
 
+@sizeof.register_lazy("numba")
+def register_numba():
+    import numba.cuda
+
+    @sizeof.register(numba.cuda.cudadrv.devicearray.DeviceNDArray)
+    def sizeof_numba_devicendarray(x):
+        return int(x.nbytes)
+
+
 @sizeof.register_lazy("numpy")
 def register_numpy():
     import numpy as np

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -54,6 +54,17 @@ def register_numba():
         return int(x.nbytes)
 
 
+@sizeof.register_lazy("rmm")
+def register_rmm():
+    import rmm
+
+    # Only included in 0.11.0+
+    if hasattr(rmm, "DeviceBuffer"):
+        @sizeof.register(rmm.DeviceBuffer)
+        def sizeof_rmm_devicebuffer(x):
+            return int(x.nbytes)
+
+
 @sizeof.register_lazy("numpy")
 def register_numpy():
     import numpy as np

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -60,6 +60,7 @@ def register_rmm():
 
     # Only included in 0.11.0+
     if hasattr(rmm, "DeviceBuffer"):
+
         @sizeof.register(rmm.DeviceBuffer)
         def sizeof_rmm_devicebuffer(x):
             return int(x.nbytes)


### PR DESCRIPTION
Makes sure that `sizeof` functions are registered for Numba `DeviceNDArray`s and RMM `DeviceBuffer`s.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
