### PR TITLE
Shallow copy and drop

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3762,7 +3762,18 @@ class DataFrame(_Frame):
         )
 
     def shallow_copy_and_drop(self, columns):
-        """Makes a shallow copy of the DataFrame excluding specified columns"""
+        """Makes a shallow copy of the DataFrame excluding specified columns
+
+        Parameters
+        ----------
+        columns : str or list
+            A single column or a list of columns to drop.
+
+        Returns
+        -------
+        shallow_copy : DataFrame
+            A shallow copy of the DataFrame.
+        """
 
         def _shallow_copy_and_drop(m, cols):
             ret = m.copy(deep=False)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3780,7 +3780,7 @@ class DataFrame(_Frame):
             ret.drop(columns=cols, inplace=True)
             return ret
 
-        return self.map_partitions(_shallow_copy_and_drop, columns,)
+        return self.map_partitions(_shallow_copy_and_drop, columns)
 
     def merge(
         self,

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3761,6 +3761,16 @@ class DataFrame(_Frame):
             "Drop currently only works for axis=1 or when columns is not None"
         )
 
+    def shallow_copy_and_drop(self, columns):
+        """Makes a shallow copy of the DataFrame excluding specified columns"""
+
+        def _shallow_copy_and_drop(m, cols):
+            ret = m.copy(deep=False)
+            ret.drop(columns=cols, inplace=True)
+            return ret
+
+        return self.map_partitions(_shallow_copy_and_drop, columns,)
+
     def merge(
         self,
         right,

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3355,7 +3355,7 @@ class DataFrame(_Frame):
         self.divisions = df.divisions
 
     def __delitem__(self, key):
-        result = self.drop([key], axis=1)
+        result = self.shallow_copy_and_drop(key)
         self.dask = result.dask
         self._name = result._name
         self._meta = result._meta


### PR DESCRIPTION
Closes #5664, by manually _fuse_ a shallow copy and a drop of a DataFrame.

cc @rjzamora @mrocklin 