### PR TITLE
Update da.std to work with NumPy arrays

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -813,7 +813,8 @@ with ignoring(AttributeError):
 @wraps(chunk.std)
 def std(a, axis=None, dtype=None, keepdims=False, ddof=0, split_every=None, out=None):
     result = sqrt(
-        a.var(
+        var(
+            a,
             axis=axis,
             dtype=dtype,
             keepdims=keepdims,

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -49,6 +49,9 @@ def test_numel(dtype, keepdims):
 
 def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True, split_every=True):
     assert_eq(da_func(darr), np_func(narr))
+    assert_eq(
+        da_func(narr), np_func(narr)
+    )  # Ensure Dask reductions work with NumPy arrays
     assert_eq(da_func(darr, keepdims=True), np_func(narr, keepdims=True))
     assert_eq(da_func(darr, axis=()), np_func(narr, axis=()))
     assert same_keys(da_func(darr), da_func(darr))


### PR DESCRIPTION
This PR updates `da.std` to use `da.var(arr, ...)` instead of `arr.var(...)` to allow `da.std` to operate on NumPy arrays. Also adds a test. 

Closes #5680

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
