### PR TITLE
Add dask.array.nanmedian

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -197,6 +197,7 @@ try:
         argmax,
         nansum,
         nanmean,
+        nanmedian,
         nanstd,
         nanvar,
         nanmin,

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -668,13 +668,13 @@ def test_trace():
     _assert(a, b, offset=1, axis1=0, axis2=2, dtype=float)
 
 
+@pytest.mark.parametrize("func", ["median", "nanmedian"])
 @pytest.mark.parametrize("axis", [0, [0, 1], 1, -1])
 @pytest.mark.parametrize("keepdims", [True, False])
-def test_median(axis, keepdims):
+def test_median(axis, keepdims, func):
     x = np.arange(100).reshape((2, 5, 10))
     d = da.from_array(x, chunks=2)
-
     assert_eq(
-        da.median(d, axis=axis, keepdims=keepdims),
-        np.median(x, axis=axis, keepdims=keepdims),
+        getattr(da, func)(d, axis=axis, keepdims=keepdims),
+        getattr(np, func)(x, axis=axis, keepdims=keepdims),
     )

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -123,6 +123,7 @@ Top level user functions:
    max
    maximum
    mean
+   median
    meshgrid
    min
    minimum
@@ -135,6 +136,7 @@ Top level user functions:
    nancumsum
    nanmax
    nanmean
+   nanmedian
    nanmin
    nanprod
    nanstd
@@ -499,6 +501,7 @@ Other functions
 .. autofunction:: max
 .. autofunction:: maximum
 .. autofunction:: mean
+.. autofunction:: median
 .. autofunction:: meshgrid
 .. autofunction:: min
 .. autofunction:: minimum
@@ -511,6 +514,7 @@ Other functions
 .. autofunction:: nancumsum
 .. autofunction:: nanmax
 .. autofunction:: nanmean
+.. autofunction:: nanmedian
 .. autofunction:: nanmin
 .. autofunction:: nanprod
 .. autofunction:: nanstd


### PR DESCRIPTION
Adds nanmedian. Automatically rechunk to one chunk per reduction axes just like dask.array.median

- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
