### PR TITLE
Add astype errors

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2224,15 +2224,15 @@ Dask Name: {name}, {task} tasks""".format(
         )
 
     @derived_from(pd.DataFrame)
-    def astype(self, dtype):
+    def astype(self, dtype, errors="raise"):
         # XXX: Pandas will segfault for empty dataframes when setting
         # categorical dtypes. This operation isn't allowed currently anyway. We
         # get the metadata with a non-empty frame to throw the error instead of
         # segfaulting.
         if is_dataframe_like(self._meta) and is_categorical_dtype(dtype):
-            meta = self._meta_nonempty.astype(dtype)
+            meta = self._meta_nonempty.astype(dtype, errors=errors)
         else:
-            meta = self._meta.astype(dtype)
+            meta = self._meta.astype(dtype, errors=errors)
         if hasattr(dtype, "items"):
             set_unknown = [
                 k
@@ -2243,7 +2243,7 @@ Dask Name: {name}, {task} tasks""".format(
         elif is_categorical_dtype(dtype) and getattr(dtype, "categories", None) is None:
             meta = clear_known_categories(meta)
         return self.map_partitions(
-            M.astype, dtype=dtype, meta=meta, enforce_metadata=False
+            M.astype, dtype=dtype, meta=meta, enforce_metadata=False, errors=errors
         )
 
     @derived_from(pd.Series)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2926,6 +2926,23 @@ def test_astype():
     assert_eq(a.x.astype(float), df.x.astype(float))
 
 
+def test_astype_errors():
+    df = pd.DataFrame(
+        {"x": [1, 2, 3, "invalid_string"], "y": [10, 20, 30, 40]},
+        index=[10, 20, 30, 40],
+    )
+    a = dd.from_pandas(df, 2)
+
+    msg = "could not convert string to float: 'invalid_string'"
+    with pytest.raises(ValueError, match=msg):
+        assert_eq(a.astype(float), df.astype(float))
+    with pytest.raises(ValueError, match=msg):
+        assert_eq(a.x.astype(float), df.x.astype(float))
+
+    assert_eq(a.astype(str, errors="ignore"), df.astype(str, errors="ignore"))
+    assert_eq(a.x.astype(str, errors="ignore"), df.x.astype(str, errors="ignore"))
+
+
 def test_astype_categoricals():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
As described in #5666 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
