### PR TITLE
Bugfix in optimize_read_parquet_getitem

### DIFF
--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -107,7 +107,7 @@ def optimize_read_parquet_getitem(dsk):
             name, old.engine, old.fs, meta, columns, old.index, old.parts, old.kwargs
         )
         layers[name] = new
-        if name != old.name:
+        if name != old.name and old.name in layers:
             del layers[old.name]
 
     new_hlg = HighLevelGraph(layers, dependencies)


### PR DESCRIPTION
#5613  is causing [test failures in dask_cdf](https://gpuci.gpuopenanalytics.com/view/RAPIDS%20branch-gpu-matrix/job/rapidsai/job/gpuci/job/cudf/job/branches/job/cudf-gpu-matrix-branch-0.11/CC_VERSION=7,CUDA=10.0,LINUX_VERSION=centos7,PYTHON_VERSION=3.7/lastCompletedBuild/testReport/dask_cudf.io.tests/test_parquet/test_filters/).  It seems that the original task name is not guarenteed to exist in the final `del layers[old.name]` - This PR is a very simple fix.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
