### PR TITLE
Unpin numpydoc dependency

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
-numpydoc
+numpydoc==0.9.1
 sphinx
 dask-sphinx-theme>=1.1.0
 sphinx-click

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
-numpydoc==0.8
+numpydoc
 sphinx
 dask-sphinx-theme>=1.1.0
 sphinx-click


### PR DESCRIPTION
This PR unpins the `numpydoc` version in our documentation requirements

Closes #5611