### PR TITLE
Use id to dedupe constants in rewrite_blockwise

### DIFF
--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -141,6 +141,27 @@ i, j, k = "ijk"
                 [(456, None), (a, "j"), (123, None)],
             ),
         ],
+        # Literals that compare equal (e.g. 0 and False) aren't deduplicated
+        [
+            [
+                (b, "i", {b: (add, _0, _1)}, [(a, "i"), (0, None)]),
+                (c, "j", {c: (add, _0, _1)}, [(b, "j"), (False, None)]),
+            ],
+            (
+                c,
+                "j",
+                {b: (add, _1, _2), c: (add, b, _0)},
+                [(False, None), (a, "j"), (0, None)],
+            ),
+        ],
+        # Literals are deduplicated
+        [
+            [
+                (b, "i", {b: (add, _0, _1)}, [(a, "i"), (123, None)]),
+                (c, "j", {c: (add, _0, _1)}, [(b, "j"), (123, None)]),
+            ],
+            (c, "j", {b: (add, _1, _0), c: (add, b, _0)}, [(123, None), (a, "j")]),
+        ],
     ],
 )
 def test_rewrite(inputs, expected):

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -643,23 +643,20 @@ def rewrite_blockwise(inputs):
 
             # Bump new inputs up in list
             sub = {}
+            # Map from (id(key), inds or None) -> index in indices. Used to deduplicate indices.
+            index_map = {(id(k), inds): n for n, (k, inds) in enumerate(indices)}
             for i, index in enumerate(new_indices):
-                try:
-                    contains = index in indices
-                except (ValueError, TypeError):
-                    contains = False
-
-                if contains:  # use old inputs if available
-                    sub[blockwise_token(i)] = blockwise_token(indices.index(index))
+                id_key = (id(index[0]), index[1])
+                if id_key in index_map:  # use old inputs if available
+                    sub[blockwise_token(i)] = blockwise_token(index_map[id_key])
                 else:
+                    index_map[id_key] = len(indices)
                     sub[blockwise_token(i)] = blockwise_token(len(indices))
                     indices.append(index)
             new_dsk = subs(inputs[dep].dsk, sub)
 
             # indices.extend(new_indices)
             dsk.update(new_dsk)
-
-    indices = [(a, tuple(b) if isinstance(b, list) else b) for a, b in indices]
 
     # De-duplicate indices like [(a, ij), (b, i), (a, ij)] -> [(a, ij), (b, i)]
     # Make sure that we map everything else appropriately as we remove inputs


### PR DESCRIPTION
Previously we compared on value, which was bad since things that aren't
identical can still be equal (e.g. `0 == False`, but `0 is not False`).
We now compare based on id.

A few tests have been added to confirm the new behavior.

Fixes #5688.
