### PR TITLE
Properly support dd.Index in setitem

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3594,6 +3594,12 @@ class DataFrame(_Frame):
             if callable(v):
                 kwargs[k] = v(self)
 
+            if isinstance(v, Index):
+                # TODO: Could probably get a simpler graph by handling these
+                #   directly instead of via to_dask_array / from_dask_array,
+                #   but this is simplest for now.
+                v = v.to_dask_array()
+
             if isinstance(v, Array):
                 from .io import from_dask_array
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3194,6 +3194,16 @@ def test_setitem_triggering_realign():
     assert len(a) == 12
 
 
+def test_setitem_index_value_no_alignment():
+    df = pd.DataFrame({"A": [1, 2, 3, 4]}, index=["a", "b", "c", "d"])
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf["B"] = ddf.index.str.upper()
+    expected = pd.DataFrame(
+        {"A": [1, 2, 3, 4], "B": ["A", "B", "C", "D"]}, index=["a", "b", "c", "d"]
+    )
+    assert_eq(ddf, expected)
+
+
 def test_inplace_operators():
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [1.0, 2.0, 3.0, 4.0, 5.0]})
     ddf = dd.from_pandas(df, npartitions=2)


### PR DESCRIPTION
We don't want to align these. It has the same semantics as setting a dask array: we validate that the number of blocks match the number of partitions, and assume that the size of each block / partition matches.

This is a bit light on tests at the moment for invalid input (since we're re-using the dask.array implementation).