### PR TITLE
CI: Fix black dependency issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,8 @@ script:
   - if [[ $TEST_HDFS == 'true' ]]; then source continuous_integration/hdfs/run_tests.sh; fi
   - if [[ $TEST == 'true' ]]; then source continuous_integration/travis/run_tests.sh; fi
   - if [[ $LINT == 'true' ]]; then pip install flake8 ; flake8 dask; fi
-  - if [[ $LINT == 'true' ]]; then pip install git+https://github.com/psf/black@73bd7038fbefdb1c6a61fa1edf16ff61613050a5; black dask --check; fi
+  # See https://bitbucket.org/mrabarnett/mrab-regex/issues/349/ for why we have --no-binary=regex
+  - if [[ $LINT == 'true' ]]; then pip install git+https://github.com/psf/black@73bd7038fbefdb1c6a61fa1edf16ff61613050a5 --no-binary=regex; black dask --check; fi
   - if [[ $TEST_IMPORTS == 'true' ]]; then bash continuous_integration/travis/test_imports.sh; fi
 
 after_success:


### PR DESCRIPTION
Apparently, there's an issue with the regex wheel, so we disable
downloading binaries for it.

See https://bitbucket.org/mrabarnett/mrab-regex/issues/349/

If this passes, I'll send a PR to distributed too.