### PR TITLE
Add `TaskCallable` that is like `SubgraphCallable`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -629,11 +629,11 @@ def map_blocks(
 
     if has_keyword(func, "block_id"):
         for k, vv in dsk.items():
-            v = copy.copy(vv[0])  # Need to copy and unpack subgraph callable
-            v.dsk = copy.copy(v.dsk)
-            [(key, task)] = v.dsk.items()
-            task = subs(task, {"__block_id_dummy__": k[1:]})
-            v.dsk[key] = task
+            # Right now we expect `v` to always be TaskCallable, because `func`
+            # above has a keyword and the task has kwargs.
+            v = vv[0]
+            v = copy.copy(v)  # Need to copy and unpack task callable
+            v.task = subs(v.task, {"__block_id_dummy__": k[1:]})
             dsk[k] = (v,) + vv[1:]
 
     if chunks is not None:
@@ -688,11 +688,7 @@ def map_blocks(
                     num_chunks[i] = arg.numblocks
         out_starts = [cached_cumsum(c, initial_zero=True) for c in out.chunks]
 
-        for k, v in dsk.items():
-            vv = v
-            v = v[0]
-            [(key, task)] = v.dsk.items()  # unpack subgraph callable
-
+        for k, vv in dsk.items():
             # Get position of chunk, indexed by axis labels
             location = {out_ind[i]: loc for i, loc in enumerate(k[1:])}
             info = {}
@@ -727,11 +723,11 @@ def map_blocks(
                 "dtype": dtype,
             }
 
-            v = copy.copy(v)  # Need to copy and unpack subgraph callable
-            v.dsk = copy.copy(v.dsk)
-            [(key, task)] = v.dsk.items()
-            task = subs(task, {"__block_info_dummy__": info})
-            v.dsk[key] = task
+            # Right now we expect `v` to always be TaskCallable, because `func`
+            # above has a keyword and the task has kwargs.
+            v = vv[0]
+            v = copy.copy(v)  # Need to copy and unpack task callable
+            v.task = subs(v.task, {"__block_info_dummy__": info})
             dsk[k] = (v,) + vv[1:]
 
     return out

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -12,7 +12,7 @@ except ImportError:
 from .core import reverse_dict
 from .delayed import to_task_dask
 from .highlevelgraph import HighLevelGraph
-from .optimization import SubgraphCallable, fuse
+from .optimization import fuse, callable_from_subgraph
 from .utils import ensure_dict, homogeneous_deepmap, apply
 
 
@@ -193,7 +193,7 @@ class Blockwise(Mapping):
             return self._cached_dict
         else:
             keys = tuple(map(blockwise_token, range(len(self.indices))))
-            func = SubgraphCallable(self.dsk, self.output, keys)
+            func = callable_from_subgraph(self.dsk, self.output, keys)
             self._cached_dict = make_blockwise_graph(
                 func,
                 self.output,

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4129,7 +4129,7 @@ def test_simple_map_partitions():
     ddf = dd.from_pandas(df, npartitions=2)
     ddf = ddf.clip(-4, 6)
     task = ddf.__dask_graph__()[ddf.__dask_keys__()[0]]
-    [v] = task[0].dsk.values()
+    v = task[0].task  # task from TaskCallable
     assert v[0] == M.clip or v[1] == M.clip
 
 


### PR DESCRIPTION
Also, use ``callable_from_subgraph`` to get the best callable:
  - the original callable if possible
  - ``TaskCallable`` if length 1
  - else ``SubgraphCallable``

This should help serialize tasks more efficiently.

When running the dask test suite on my machine (so some get skipped), `callable_from_subgraph` returns the following types these number of times:
  - the original callable: 17334 (52%)
  - `TaskCallable`:  11427 (34%)
  - `SubgraphCallable`: 4680 (14%)

Thanks @jcrist who pointed me in this direction.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
