### PR TITLE
Ensure dataframe groupby-variance is greater than zero

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -332,6 +332,7 @@ def _var_agg(g, levels, ddof):
     result /= div
     result[(n - ddof) == 0] = np.nan
     assert is_dataframe_like(result)
+    result[result < 0] = 0  # avoid rounding errors that take us to zero
     return result
 
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2286,3 +2286,13 @@ def test_groupby_dropna_cudf(dropna, by):
         dask_result.index.name = cudf_result.index.name
 
     assert_eq(dask_result, cudf_result)
+
+
+def test_rounding_negative_var():
+    x = [-0.00179999999 for _ in range(10)]
+    ids = [1 for _ in range(5)] + [2 for _ in range(5)]
+
+    df = pd.DataFrame({"ids": ids, "x": x})
+
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert_eq(ddf.groupby("ids").x.std(), df.groupby("ids").x.std())


### PR DESCRIPTION
Due to rounding errors and numerical instability of our groupby-variance
algorithm we can get small negative values.

Fixes https://github.com/dask/dask/issues/5725

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
