### PR TITLE
Support empty partitions when performing cumulative aggregation

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2118,6 +2118,7 @@ Dask Name: {name}, {task} tasks""".format(
                 else:
                     # aggregate with previous cumulation results
                     layer[(cname, i)] = (
+                        methods._cum_aggregate_apply,
                         aggregate,
                         (cname, i - 1),
                         (cumlast._name, i - 1),

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -231,6 +231,23 @@ def describe_nonnumeric_aggregate(stats, name):
     return pd.Series(values, index=index, name=name)
 
 
+def _cum_aggregate_apply(aggregate, x, y):
+    """ Apply aggregation function within a cumulative aggregation
+
+    Parameters
+    ----------
+    aggregate: function (a, a) -> a
+        The aggregation function, like add, which is used to and subsequent
+        results
+    x:
+    y:
+    """
+    if y is None:
+        return x
+    else:
+        return aggregate(x, y)
+
+
 def cummin_aggregate(x, y):
     if is_series_like(x) or is_dataframe_like(x):
         return x.where((x < y) | x.isnull(), y, axis=x.ndim - 1)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4140,3 +4140,9 @@ def test_iter():
     assert list(df) == list(ddf)
     for col, expected in zip(ddf, ["A", "B"]):
         assert col == expected
+
+
+def test_dataframe_groupby_agg_empty_partitions():
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7, 8]})
+    ddf = dd.from_pandas(df, npartitions=4)
+    assert_eq(ddf[ddf.x < 5].x.cumsum(), df[df.x < 5].x.cumsum())


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/5726

Previously we assumed that all partitions were non-empty and that we
could combine the two values from the previous and next partition.

Now we are robust to a null result coming from a cumulative aggregation
of an empty partition.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
