### PR TITLE
DOC: Link to examples.dask.org in several places

### DIFF
--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -33,6 +33,12 @@ these blocked algorithms using Dask graphs.
            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
            allowfullscreen></iframe>
 
+Examples
+--------
+
+Visit https://examples.dask.org/array.html to see and run examples using
+Dask Array.
+
 Design
 ------
 

--- a/docs/source/bag.rst
+++ b/docs/source/bag.rst
@@ -16,6 +16,11 @@ version of PyToolz_ or a Pythonic version of the `PySpark RDD`_.
 .. _PyToolz: https://toolz.readthedocs.io/en/latest/
 .. _`PySpark RDD`: https://spark.apache.org/docs/latest/api/python/pyspark.html
 
+Examples
+--------
+
+Visit https://examples.dask.org/bag.html to see and run examples using Dask Bag.
+
 Design
 ------
 

--- a/docs/source/dataframe.rst
+++ b/docs/source/dataframe.rst
@@ -31,6 +31,12 @@ on the constituent Pandas DataFrames.
            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
            allowfullscreen></iframe>
 
+Examples
+--------
+
+Visit https://examples.dask.org/dataframe.html to see and run examples using
+Dask DataFrame.
+
 Design
 ------
 

--- a/docs/source/delayed.rst
+++ b/docs/source/delayed.rst
@@ -39,6 +39,9 @@ directly with a light annotation of normal python code:
 Example
 -------
 
+Visit https://examples.dask.org/delayed.html to see and run examples using Dask
+Delayed.
+
 Sometimes we face problems that are parallelizable, but don't fit into high-level
 abstractions like Dask Array or Dask DataFrame.  Consider the following example:
 

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -24,6 +24,12 @@ despite its name, runs very well on a single machine).
 
 .. currentmodule:: distributed
 
+Examples
+--------
+
+Visit https://examples.dask.org/futures.html to see and run examples
+using futures with Dask.
+
 Start Dask Client
 -----------------
 


### PR DESCRIPTION
Unless I missed something, we only link to examples.dask.org from the educational resources page. This adds links from each of the collections pages.

We also might link from the main page `index.rst` or somewhere in "Getting Started". Perhaps install.rst?