### PR TITLE
Array.view() with dtype=None

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2191,13 +2191,15 @@ class Array(DaskMethodsMixin):
 
         return clip(self, min, max)
 
-    def view(self, dtype, order="C"):
+    def view(self, dtype=None, order="C"):
         """ Get a view of the array as a new data type
 
         Parameters
         ----------
         dtype:
-            The dtype by which to view the array
+            The dtype by which to view the array.
+            The default, None, results in the view having the same data-type
+            as the original array.
         order: string
             'C' or 'F' (Fortran) ordering
 
@@ -2211,7 +2213,10 @@ class Array(DaskMethodsMixin):
         views of Fortran ordered arrays if the first dimension has chunks of
         size one.
         """
-        dtype = np.dtype(dtype)
+        if dtype is None:
+            dtype = self.dtype
+        else:
+            dtype = np.dtype(dtype)
         mult = self.dtype.itemsize / dtype.itemsize
 
         if order == "C":

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2803,6 +2803,7 @@ def test_view():
     x = np.arange(56).reshape((7, 8))
     d = da.from_array(x, chunks=(2, 3))
 
+    assert_eq(x.view(), d.view())
     assert_eq(x.view("i4"), d.view("i4"))
     assert_eq(x.view("i2"), d.view("i2"))
     assert all(isinstance(s, int) for s in d.shape)


### PR DESCRIPTION

- [x] Fixes https://github.com/dask/dask/issues/5175
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
