### PR TITLE
[REVIEW] Fix exception when `groupby.std()` with `by` column containing large values

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -305,11 +305,8 @@ def _var_chunk(df, *index):
 
     n = g[x.columns].count().rename(columns=lambda c: (c, "-count"))
 
-    try:
-        for col in set(cols).difference(set(index)):
-            df[col] = df[col] ** 2
-    except TypeError:
-        df[cols] = df[cols] ** 2
+    cols = x.columns
+    df[cols] = df[cols] ** 2
 
     g2 = _groupby_raise_unaligned(df, by=index)
     x2 = g2.sum().rename(columns=lambda c: (c, "-x2"))

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -298,7 +298,6 @@ def _var_chunk(df, *index):
         df = df.to_frame()
 
     df = df.copy()
-    cols = df._get_numeric_data().columns
 
     g = _groupby_raise_unaligned(df, by=index)
     x = g.sum()

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -305,8 +305,11 @@ def _var_chunk(df, *index):
 
     n = g[x.columns].count().rename(columns=lambda c: (c, "-count"))
 
-    for col in set(cols).difference(set(index)):
-        df[col] = df[col] ** 2
+    try:
+        for col in set(cols).difference(set(index)):
+            df[col] = df[col] ** 2
+    except TypeError:
+        df[cols] = df[cols] ** 2
 
     g2 = _groupby_raise_unaligned(df, by=index)
     x2 = g2.sum().rename(columns=lambda c: (c, "-x2"))

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -297,16 +297,6 @@ def _var_chunk(df, *index):
     if is_series_like(df):
         df = df.to_frame()
 
-    for col in df.columns:
-        if df[col].dtype == np.int64:
-            if df[col].max() > np.iinfo(df[col].dtype).max ** 0.5:
-                raise ValueError(
-                    "Unable to calculate stddev of int64 columns"
-                    " larger than the sqrt of their maximum value."
-                    " Convert to string before proceeding. Column"
-                    " %s" % col
-                )
-
     df = df.copy()
     cols = df._get_numeric_data().columns
 
@@ -315,11 +305,12 @@ def _var_chunk(df, *index):
 
     n = g[x.columns].count().rename(columns=lambda c: (c, "-count"))
 
-    df[cols] = df[cols] ** 2
+    for col in set(cols).difference(set(index)):
+        df[col] = df[col] ** 2
+
     g2 = _groupby_raise_unaligned(df, by=index)
     x2 = g2.sum().rename(columns=lambda c: (c, "-x2"))
 
-    x2.index = x.index
     return concat([x, x2, n], axis=1)
 
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -297,6 +297,16 @@ def _var_chunk(df, *index):
     if is_series_like(df):
         df = df.to_frame()
 
+    for col in df.columns:
+        if df[col].dtype == np.int64:
+            if df[col].max() > np.iinfo(df[col].dtype).max ** 0.5:
+                raise ValueError(
+                    "Unable to calculate stddev of int64 columns"
+                    " larger than the sqrt of their maximum value."
+                    " Convert to string before proceeding. Column"
+                    " %s" % col
+                )
+
     df = df.copy()
     cols = df._get_numeric_data().columns
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2304,9 +2304,9 @@ def test_groupby_large_ints_exception_cudf():
 
     max = np.iinfo(np.uint64).max
     sqrt = max ** 0.5
-    series = pd.Series(
-        np.concatenate([sqrt * np.arange(5), np.arange(35)])
-    ).astype("int64")
+    series = pd.Series(np.concatenate([sqrt * np.arange(5), np.arange(35)])).astype(
+        "int64"
+    )
     pdf = pd.DataFrame({"x": series, "z": np.arange(40), "y": np.arange(40)})
     gdf = cudf.from_pandas(pdf)
     gddf = dask_cudf.from_cudf(gdf, npartitions=2)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2357,4 +2357,7 @@ def test_groupby_large_ints_exception_pandas():
     )
     df = pd.DataFrame({"x": series, "z": np.arange(40), "y": np.arange(40)})
     ddf = dd.from_pandas(df, npartitions=1)
-    ddf.groupby("x").std().compute(scheduler="single-threaded")
+    assert_eq(
+        df.groupby("x").std(),
+        ddf.groupby("x").std().compute(scheduler="single-threaded"),
+    )

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2341,9 +2341,9 @@ def test_groupby_large_ints_exception(backend):
         data_frame = dd.from_pandas
     max = np.iinfo(np.uint64).max
     sqrt = max ** 0.5
-    series = data_source.Series(np.concatenate([sqrt * np.arange(5), np.arange(35)])).astype(
-        "int64"
-    )
+    series = data_source.Series(
+        np.concatenate([sqrt * np.arange(5), np.arange(35)])
+    ).astype("int64")
     df = data_source.DataFrame({"x": series, "z": np.arange(40), "y": np.arange(40)})
     ddf = data_frame(df, npartitions=1)
     assert_eq(

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2296,3 +2296,11 @@ def test_rounding_negative_var():
 
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf.groupby("ids").x.std(), df.groupby("ids").x.std())
+
+
+@pytest.mark.xfail(reason="Unable to calculate stddev")
+def test_groupby_large_ints_exception():
+    dtype_max = int(np.iinfo(np.int64).max ** 0.5 + 1)
+    df = pd.DataFrame({"x": [1, 1, dtype_max, dtype_max], "y": [1, 2, 3, 4]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf.groupby("x").std().compute()


### PR DESCRIPTION
Fixes #5762 and https://github.com/rapidsai/cudf/issues/3649

The `dask` `std` code invokes `**2`, which introduces a surjection in groupby when the `by` column is an `int64` dtype and contains values larger than `b = np.iinfo(np.int64).max ** 0.5`. Float dtypes can also produce the surjection. By squaring the `by` column, values in pandas that are multiples of `b` above all map to zero - that is, `[b, b*2, b*3]**2 = [0, 0, 0]`. After the values in the `by` column are squared, `.groupby` is called which then produces a resulting `DataFrame` with a different size than the `.groupby` called on the original, unsquared `by` column. We exposed this issue working in `cudf`, which instead of wrapping squared large `int64` values, clamps them. Any value larger than `b` above will produce the same surjection.

This snippet reproduces the failure in `cudf`. A snippet in a cell below will produce the error in pandas.
```
import cudf
import numpy as np
import dask_cudf
dtype_max = int(np.iinfo(np.int64).max ** 0.5 + 1)
df = cudf.DataFrame({"x": [1, 1, dtype_max, dtype_max], "y": [1, 2, 3, 4]})
ddf = dask_cudf.from_cudf(df, npartitions=2)
ddf.groupby('x').std().compute()
```

See https://github.com/rapidsai/cudf/issues/3649.

Pandas reproduces the same issue whenever the groupby key contains `sqrt(dtype_max)` and multiples of it. Harder to reproduce because of `pandas` wrapping instead of clamping, but still the same issue.

The issue is caused by `df[cols] = df[cols] ** 2` in `_var_chunks` - by squaring large int64 values, a surjection is created and the results of `df.groupby` and `(df**2).groupby` have different sizes.