### PR TITLE
Raise error when converting a dask dataframe scalar to a boolean

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -185,9 +185,11 @@ class Scalar(DaskMethodsMixin, OperatorMethodMixin):
 
     def __bool__(self):
         raise TypeError(
-            "Dask dataframe Scalars don't support conversion to a "
-            "boolean because they are lazily evaluated. Consider computing "
-            "the scalar value prior to converting to a boolean."
+            "Trying to convert {} to a boolean value. Because Dask objects are "
+            "lazily evaluated, they cannot be converted to a boolean value or used "
+            "in boolean conditions like if statements. Try calling .compute() to "
+            "force computation prior to converting to a boolean value or using in "
+            "a conditional statement.".format(self)
         )
 
     @property

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -183,6 +183,13 @@ class Scalar(DaskMethodsMixin, OperatorMethodMixin):
     def __setstate__(self, state):
         self.dask, self._name, self._meta = state
 
+    def __bool__(self):
+        raise TypeError(
+            "Dask dataframe Scalars don't support conversion to a "
+            "boolean because they are lazily evaluated. Consider computing "
+            "the scalar value prior to converting to a boolean."
+        )
+
     @property
     def key(self):
         return (self._name, 0)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -161,7 +161,7 @@ def test_Scalar():
 def test_scalar_raises():
     val = np.int64(1)
     s = Scalar({("a", 0): val}, "a", "i8")
-    msg = "Dask dataframe Scalars don't support conversion to a boolean"
+    msg = "cannot be converted to a boolean value"
     with pytest.raises(TypeError, match=msg):
         bool(s)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -158,6 +158,14 @@ def test_Scalar():
     assert repr(s) == "dd.Scalar<a, type=Timestamp>"
 
 
+def test_scalar_raises():
+    val = np.int64(1)
+    s = Scalar({("a", 0): val}, "a", "i8")
+    msg = "Dask dataframe Scalars don't support conversion to a boolean"
+    with pytest.raises(TypeError, match=msg):
+        bool(s)
+
+
 def test_attributes():
     assert "a" in dir(d)
     assert "foo" not in dir(d)


### PR DESCRIPTION
This PR updates `dd.Scalar` to raise an error when being converted to a boolean value. This doesn't currently happen and can lead to unexpected results:

```python
In [1]: import pandas as pd

In [2]: import dask.dataframe as dd

In [3]: s = pd.Series([1, -1])

In [4]: ds = dd.from_pandas(s, npartitions=2)

In [5]: bool(s.sum())
Out[5]: False

In [6]: bool(ds.sum())
Out[6]: True
```

xref https://github.com/dask/dask/pull/5711#issuecomment-568196938

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
