### PR TITLE
set_index accepts single-item unnested list.

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -36,9 +36,9 @@ def set_index(
     if isinstance(index, (DataFrame, tuple, list)):
         # Accept ["a"], but not [["a"]]
         if (
-            isinstance(index, (tuple, list))
+            isinstance(index, list)
             and len(index) == 1
-            and not isinstance(index[0], (list, tuple))
+            and not isinstance(index[0], list)  # if index = [["a"]], leave it that way
         ):
             index = index[0]
         else:

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -34,11 +34,19 @@ def set_index(
     if isinstance(index, Series) and index._name == df.index._name:
         return df
     if isinstance(index, (DataFrame, tuple, list)):
-        raise NotImplementedError(
-            "Dask dataframe does not yet support multi-indexes.\n"
-            "You tried to index with this index: %s\n"
-            "Indexes must be single columns only." % str(index)
-        )
+        # Accept ["a"], but not [["a"]]
+        if (
+            isinstance(index, (tuple, list))
+            and len(index) == 1
+            and not isinstance(index[0], (list, tuple))
+        ):
+            index = index[0]
+        else:
+            raise NotImplementedError(
+                "Dask dataframe does not yet support multi-indexes.\n"
+                "You tried to index with this index: %s\n"
+                "Indexes must be single columns only." % str(index)
+            )
 
     if npartitions == "auto":
         repartition = True

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -557,6 +557,16 @@ def test_set_index():
     assert_eq(d4, full.set_index("b"))
 
 
+def test_set_index_single_item_list_tuple():
+    d1 = d.set_index(["b"])
+    assert d1.index.name == "b"
+    assert_eq(d1, full.set_index("b"))
+
+    d2 = d.set_index(("b",))
+    assert d2.index.name == "b"
+    assert_eq(d2, full.set_index("b"))
+
+
 def test_set_index_interpolate():
     df = pd.DataFrame({"x": [4, 1, 1, 3, 3], "y": [1.0, 1, 1, 1, 2]})
     d = dd.from_pandas(df, 2)
@@ -641,6 +651,18 @@ def test_set_index_raises_error_on_bad_input():
     msg = r"Dask dataframe does not yet support multi-indexes"
     with pytest.raises(NotImplementedError) as err:
         ddf.set_index(["a", "b"])
+    assert msg in str(err.value)
+
+    with pytest.raises(NotImplementedError) as err:
+        ddf.set_index([["a", "b"]])
+    assert msg in str(err.value)
+
+    with pytest.raises(NotImplementedError) as err:
+        ddf.set_index([["a"]])
+    assert msg in str(err.value)
+
+    with pytest.raises(NotImplementedError) as err:
+        ddf.set_index((("a",),))
     assert msg in str(err.value)
 
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -556,15 +556,9 @@ def test_set_index():
     assert d4.index.name == "b"
     assert_eq(d4, full.set_index("b"))
 
-
-def test_set_index_single_item_list_tuple():
-    d1 = d.set_index(["b"])
-    assert d1.index.name == "b"
-    assert_eq(d1, full.set_index("b"))
-
-    d2 = d.set_index(("b",))
-    assert d2.index.name == "b"
-    assert_eq(d2, full.set_index("b"))
+    d5 = d.set_index(["b"])
+    assert d5.index.name == "b"
+    assert_eq(d5, full.set_index("b"))
 
 
 def test_set_index_interpolate():
@@ -659,10 +653,6 @@ def test_set_index_raises_error_on_bad_input():
 
     with pytest.raises(NotImplementedError) as err:
         ddf.set_index([["a"]])
-    assert msg in str(err.value)
-
-    with pytest.raises(NotImplementedError) as err:
-        ddf.set_index((("a",),))
     assert msg in str(err.value)
 
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -558,7 +558,7 @@ def test_set_index():
 
     d5 = d.set_index(["b"])
     assert d5.index.name == "b"
-    assert_eq(d5, full.set_index("b"))
+    assert_eq(d5, full.set_index(["b"]))
 
 
 def test_set_index_interpolate():


### PR DESCRIPTION
Closes #5755

Tests:
set_index accepts single-item unnested list.
set_index raises on nested list.

- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`
