### PR TITLE
[Docs] Add Section on Expectations to Graph Page

### DIFF
--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -108,6 +108,8 @@ However, note that each task comes with about 1ms of overhead.  If you want to
 map a function over a large number of inputs, then you might consider
 :doc:`dask.bag <bag>` or :doc:`dask.dataframe <dataframe>` instead.
 
+.. note: Futures are mutable and can be updated in-place. See the `Task Graphs <https://docs.dask.org/en/latest/graphs.html>`_ page for more details.
+
 Move Data
 ---------
 

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -108,7 +108,8 @@ However, note that each task comes with about 1ms of overhead.  If you want to
 map a function over a large number of inputs, then you might consider
 :doc:`dask.bag <bag>` or :doc:`dask.dataframe <dataframe>` instead.
 
-.. note: Futures are mutable and can be updated in-place. See the `Task Graphs <https://docs.dask.org/en/latest/graphs.html>`_ page for more details.
+.. note: See `this page <https://docs.dask.org/en/latest/graphs.html>`_ for
+   restrictions on what functions you use with Dask.
 
 Move Data
 ---------

--- a/docs/source/graphs.rst
+++ b/docs/source/graphs.rst
@@ -132,3 +132,16 @@ In the example above Dask will update the values of the Numpy array
 ``x`` in-place.  While efficient, this behavior can have unintended consequences,
 particularly if other tasks need to use ``x``, or if Dask needs to rerun this
 computation multiple times because of worker failure.
+
+
+Avoid Holding the GIL
+~~~~~~~~~~~~~~~~~~~~~
+
+Some Python functions that wrap external C/C++ code can hold onto the GIL,
+which stops other Python code from running in the background.  This is
+troublesome because while Dask workers run your function, they also need to
+communicate to each other in the background.
+
+If you wrap external code then please try to release the GIL.  This is usually
+easy to do if you are using any of the common solutions to code-wrapping like
+Cython, Numba, ctypes or others.

--- a/docs/source/graphs.rst
+++ b/docs/source/graphs.rst
@@ -104,9 +104,9 @@ Task Expectations
 
 When a task is submitted to Dask for execution, there are a number of assumptions
 that are made about that task. In general, tasks with side-effects that alter the
-state of a future in-place are not recommended. Values stored by Dask are mutable,
-and can be updated in-place. For example, consider a workflow involving a
-Numpy array:
+state of a future in-place are not recommended. Modifying data that is stored in
+Dask in-place can have unintended consequences. For example, consider a workflow 
+involving a Numpy array:
 
 .. code-block:: python
 
@@ -122,9 +122,9 @@ Numpy array:
 
    y = x.submit(f, x)
 
-In the example above Dask will update the field (``index``) of the Future in-place.
-This behavior holds for any object with mutable underlying data or fields. Completed 
-Futures in Dask contain pointers to Python objects. If a field or attribute of that
-underlying Python object is updated in-place, e.g. with ``setattr``, the Future
-is effectively modified in-place. Subsequent accesses of that Future will return the
-updated object.
+In the example above Dask will update the values of the Numpy array in the Future
+``x`` in-place. This behavior holds for any object with mutable underlying data or
+fields. Completed Futures in Dask contain pointers to Python objects. If a field
+or attribute of that underlying Python object is updated in-place, e.g. with
+``setattr``, the Future is effectively modified in-place. Subsequent accesses of
+that Future will return the updated object.

--- a/docs/source/graphs.rst
+++ b/docs/source/graphs.rst
@@ -106,7 +106,7 @@ When a task is submitted to Dask for execution, there are a number of assumption
 that are made about that task. In general, tasks with side-effects that alter the
 state of a future in-place are not recommended. Values stored by Dask are mutable,
 and can be updated in-place. For example, consider a workflow involving a
-``np.array``:
+Numpy array:
 
 .. code-block:: python
 

--- a/docs/source/graphs.rst
+++ b/docs/source/graphs.rst
@@ -110,10 +110,10 @@ be updated in-place. For example, consider a workflow involving a
 
 .. code-block:: python
 
-   from distributed import Client
+   from dask.distributed import Client
    import pandas 
 
-   c = Client()  # LocalCluster
+   client = Client() 
    df = pandas.DataFrame({"c":[1,2,3,4], "d":[4,5,6,76]})  
    a_future = c.scatter(df)
    assert a_future.result().index.equals(df.index) 


### PR DESCRIPTION
* Resolves dask/distributed#3350
* Adds a section in the documentation that discusses how Futures are handled when tasks operate on them `in-place`

cc @mrocklin 
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
