### PR TITLE
DOC: note additional use case for normalize_token.register

### DIFF
--- a/docs/source/custom-collections.rst
+++ b/docs/source/custom-collections.rst
@@ -560,9 +560,12 @@ implementation. There are two ways to do this:
 
 2. Register a function with ``dask.base.normalize_token``
 
-   If defining a method on the class isn't possible, you can register a tokenize
-   function with the ``normalize_token`` dispatch.  The function should have the
-   same signature as described above.
+   If defining a method on the class isn't possible or you need to
+   customize the tokenize function for a class who's super-class is
+   already registered (for example if you need to sub-class built-ins),
+   you can register a tokenize function with the ``normalize_token``
+   dispatch.  The function should have the same signature as described
+   above.
 
 In both cases the implementation should be the same, where only the location of the
 definition is different.

--- a/docs/source/custom-collections.rst
+++ b/docs/source/custom-collections.rst
@@ -561,7 +561,7 @@ implementation. There are two ways to do this:
 2. Register a function with ``dask.base.normalize_token``
 
    If defining a method on the class isn't possible or you need to
-   customize the tokenize function for a class who's super-class is
+   customize the tokenize function for a class whose super-class is
    already registered (for example if you need to sub-class built-ins),
    you can register a tokenize function with the ``normalize_token``
    dispatch.  The function should have the same signature as described


### PR DESCRIPTION
Only changes prose in docs

If any of your classes parents are already in registered with the
dispatcher that registration will be hit before the object
implementation (which is what calls `__dask_tokenize__`).  Thus to
over-ride the tokenize function of any class which is already
registered, you must also register the sub-class.