### PR TITLE
Update bag repartition docstring

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1601,7 +1601,10 @@ class Bag(DaskMethodsMixin):
         return [Delayed(k, dsk) for k in keys]
 
     def repartition(self, npartitions):
-        """ Coalesce bag into fewer partitions.
+        """ Changes the number of partitions of the bag.
+
+        This can be used to reduce or increase the number of partitions
+        of the bag.
 
         Examples
         --------


### PR DESCRIPTION
repartition can be used both for reducing and increasing the number of partitions. The docstring only mentioned reducing the number of partitions

Fixes #5570 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
