### PR TITLE
Fix groupby/mean error with with categorical index

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -365,6 +365,9 @@ def concat_pandas(dfs, axis=0, join="outer", uniform=False, filter_warning=True)
     # Support concatenating indices along axis 0
     if isinstance(dfs[0], pd.Index):
         if isinstance(dfs[0], pd.CategoricalIndex):
+            for i in range(1, len(dfs)):
+                if not isinstance(dfs[i], pd.CategoricalIndex):
+                    dfs[i] = dfs[i].astype("category")
             return pd.CategoricalIndex(union_categoricals(dfs), name=dfs[0].name)
         elif isinstance(dfs[0], pd.MultiIndex):
             first, rest = dfs[0], dfs[1:]


### PR DESCRIPTION
Closes #5775

As discussed in [cudf#3486](https://github.com/rapidsai/cudf/pull/3486#issuecomment-570708074), groupby aggregation is failing in certain cases for Pandas>25.0

The error occurs during [categorical index concatenation](https://github.com/dask/dask/blob/8530bdd0f54d7576f05c9162bb3a835864edf016/dask/dataframe/methods.py#L385).  Therefore, we can *avoid* the error by checking that all arguments to `union_categoricals` has the appropriate type.

I am leaving this as a WIP, because I do not quite understand the root cause of the type mismatch, and I would prefer to solve *that* problem (if possible).


- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
