### PR TITLE
Add support for empty dataframes

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -417,7 +417,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
 {data}
 Dask Name: {name}, {task} tasks"""
         if "Empty" in data:
-            data = data.partition("\n")[-1].replace("Index","Divisions")
+            data = data.partition("\n")[-1].replace("Index", "Divisions")
             _str_fmt = "Empty {}".format(_str_fmt)
         return _str_fmt.format(
             klass=self.__class__.__name__,

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -416,7 +416,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
         _str_fmt = """Dask {klass} Structure:
 {data}
 Dask Name: {name}, {task} tasks"""
-        if "Empty" in data:
+        if len(self.columns) == 0:
             data = data.partition("\n")[-1].replace("Index", "Divisions")
             _str_fmt = "Empty {}".format(_str_fmt)
         return _str_fmt.format(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -413,9 +413,13 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
 
     def __repr__(self):
         data = self._repr_data().to_string(max_rows=5, show_dimensions=False)
-        return """Dask {klass} Structure:
+        _str_fmt = """Dask {klass} Structure:
 {data}
-Dask Name: {name}, {task} tasks""".format(
+Dask Name: {name}, {task} tasks"""
+        if "Empty" in data:
+            data = data.partition("\n")[-1].replace("Index","Divisions")
+            _str_fmt = "Empty {}".format(_str_fmt)
+        return _str_fmt.format(
             klass=self.__class__.__name__,
             data=data,
             name=key_split(self._name),

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4297,8 +4297,14 @@ class DataFrame(_Frame):
     def _repr_data(self):
         meta = self._meta
         index = self._repr_divisions
-        series_list = [_repr_data_series(s, index=index) for _, s in meta.iteritems()]
-        return pd.concat(series_list, axis=1)
+        cols = meta.columns
+        if len(cols) == 0:
+            series_df = pd.DataFrame([[]] * len(index), columns=cols, index=index)
+        else:
+            series_df = pd.concat(
+                [_repr_data_series(s, index=index) for _, s in meta.iteritems()], axis=1
+            )
+        return series_df
 
     _HTML_FMT = """<div><strong>Dask DataFrame Structure:</strong></div>
 {data}

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -533,10 +533,35 @@ def test_empty_repr():
     df = pd.DataFrame()
     ddf = dd.from_pandas(df, npartitions=1)
     exp = (
-        "Dask DataFrame Structure:\n"
-        "Empty DataFrame\n"
+        "Empty Dask DataFrame Structure:\n"
         "Columns: []\n"
-        "Index: [, ]\n"
+        "Divisions: [, ]\n"
         "Dask Name: from_pandas, 1 tasks"
     )
     assert repr(ddf) == exp
+    exp_table = """<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+    </tr>
+    <tr>
+      <th>npartitions=1</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th></th>
+    </tr>
+    <tr>
+      <th></th>
+    </tr>
+  </tbody>
+</table>"""
+    exp = """<div><strong>Dask DataFrame Structure:</strong></div>
+<div>
+{style}{exp_table}
+</div>
+<div>Dask Name: from_pandas, 1 tasks</div>""".format(
+        style=style, exp_table=exp_table
+    )
+    assert ddf._repr_html_() == exp

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -532,4 +532,11 @@ def test_duplicate_columns_repr():
 def test_empty_repr():
     df = pd.DataFrame()
     ddf = dd.from_pandas(df, npartitions=1)
-    repr(ddf)
+    exp = (
+        "Dask DataFrame Structure:\n"
+        "Empty DataFrame\n"
+        "Columns: []\n"
+        "Index: [, ]\n"
+        "Dask Name: from_pandas, 1 tasks"
+    )
+    assert repr(ddf) == exp

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -527,3 +527,9 @@ def test_duplicate_columns_repr():
     arr = da.from_array(np.arange(10).reshape(5, 2), chunks=(5, 2))
     frame = dd.from_dask_array(arr, columns=["a", "a"])
     repr(frame)
+
+
+def test_empty_repr():
+    df = pd.DataFrame()
+    ddf = dd.from_pandas(df, npartitions=1)
+    repr(ddf)


### PR DESCRIPTION
Fixes #5761 

- modifies `_repr_data` to return special repr for empty dataframes

- adds a test that tries to print empty dataframe

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
