### PR TITLE
Add transparent compression for on-disk shuffle with partd

### DIFF
--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -1,5 +1,7 @@
 temporary-directory: null     # Directory for local disk like /tmp, /scratch, or /local
 
+shuffle-disk-compression: null  # compression for on disk-shuffling. Partd supports ZLib, BZ2, SNAPPY, BLOSC
+
 array:
   svg:
     size: 120  # pixels

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -1,6 +1,7 @@
 temporary-directory: null     # Directory for local disk like /tmp, /scratch, or /local
 
-shuffle-disk-compression: null  # compression for on disk-shuffling. Partd supports ZLib, BZ2, SNAPPY, BLOSC
+dataframe:
+  shuffle-compression: null  # compression for on disk-shuffling. Partd supports ZLib, BZ2, SNAPPY, BLOSC
 
 array:
   svg:

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -320,7 +320,7 @@ class maybe_buffered_partd(object):
     def __init__(self, buffer=True, tempdir=None):
         self.tempdir = tempdir or config.get("temporary_directory", None)
         self.buffer = buffer
-        self.compression = config.get("shuffle_disk_compression", None)
+        self.compression = config.get("shuffle-disk-compression", None)
 
     def __reduce__(self):
         if self.tempdir:
@@ -333,7 +333,11 @@ class maybe_buffered_partd(object):
 
         # Try to load partd compression module. Silently fail, if compression algorithm is not found.
         try:
-            partd_compression = getattr(partd.compressed, self.compression) if self.compression else None
+            partd_compression = (
+                getattr(partd.compressed, self.compression)
+                if self.compression
+                else None
+            )
         except AttributeError:
             partd_compression = None
         if self.tempdir:
@@ -341,7 +345,11 @@ class maybe_buffered_partd(object):
         else:
             file = partd.File()
         # Envelope partd file with compression, if set and if available
-        if self.compression and partd_compression and isinstance(partd_compression(), partd.encode.Encode):
+        if (
+            self.compression
+            and partd_compression
+            and isinstance(partd_compression(), partd.encode.Encode)
+        ):
             file = partd_compression(file)
 
         if self.buffer:

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -330,7 +330,7 @@ class maybe_buffered_partd(object):
 
     def __call__(self, *args, **kwargs):
         import partd
-        # Try to load partd compression module. Silently fail, if compression algorithm is not found.
+
         try:
             partd_compression = (
                 getattr(partd.compressed, self.compression)
@@ -338,12 +338,17 @@ class maybe_buffered_partd(object):
                 else None
             )
         except AttributeError:
-            raise AttributeError('Not able to import and load {0} as compression algorithm. Is it supported by Partd or installed?')
+            raise ImportError(
+                "Not able to import and load {0} as compression algorithm."
+                "Please check if the library is installed and supported by Partd.".format(
+                    self.compression
+                )
+            )
         if self.tempdir:
             file = partd.File(dir=self.tempdir)
         else:
             file = partd.File()
-        # Envelope partd file with compression, if set and if available
+        # Envelope partd file with compression, if set and available
         if partd_compression:
             file = partd_compression(file)
         if self.buffer:

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -334,7 +334,7 @@ class maybe_buffered_partd(object):
         # Try to load partd compression module. Silently fail, if compression algorithm is not found.
         try:
             partd_compression = getattr(partd.compressed, self.compression) if self.compression else None
-        except ImportError:
+        except AttributeError:
             partd_compression = None
         if self.tempdir:
             file = partd.File(dir=self.tempdir)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -920,5 +920,12 @@ def test_set_index_timestamp():
 
 @pytest.mark.parametrize("compression", [None, "ZLib"])
 def test_disk_shuffle_with_compression(compression):
-    with dask.config.set({"shuffle-disk-compression": compression}):
+    with dask.config.set({"dataframe.shuffle-compression": compression}):
         test_shuffle("disk")
+
+@pytest.mark.parametrize("compression", ["UNKOWN_COMPRESSION_ALGO", ])
+def test_disk_shuffle_with_unkown_compression(compression):
+    # test if dask raises an error in case of fault config string
+    with dask.config.set({"dataframe.shuffle-compression": compression}):
+        with pytest.raises(AttributeError):
+            test_shuffle("disk")

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -920,12 +920,19 @@ def test_set_index_timestamp():
 
 @pytest.mark.parametrize("compression", [None, "ZLib"])
 def test_disk_shuffle_with_compression(compression):
+    # test if dataframe shuffle works both with and without compression
     with dask.config.set({"dataframe.shuffle-compression": compression}):
         test_shuffle("disk")
 
-@pytest.mark.parametrize("compression", ["UNKOWN_COMPRESSION_ALGO", ])
-def test_disk_shuffle_with_unkown_compression(compression):
+
+@pytest.mark.parametrize("compression", ["UNKOWN_COMPRESSION_ALGO",])
+def test_disk_shuffle_with_unknown_compression(compression):
     # test if dask raises an error in case of fault config string
     with dask.config.set({"dataframe.shuffle-compression": compression}):
-        with pytest.raises(AttributeError):
+        with pytest.raises(ImportError) as excinfo:
             test_shuffle("disk")
+        assert str(
+            excinfo.value
+        ) == "Not able to import and load {0} as compression algorithm." "Please check if the library is installed and supported by Partd.".format(
+            compression
+        )

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -946,7 +946,7 @@ def test_disk_shuffle_check_actual_compression():
         df1 = pd.DataFrame({"a": list(range(10000))})
         df1["b"] = (df1["a"] * 123).astype(str)
         with dask.config.set({"dataframe.shuffle-compression": compression}):
-            f = maybe_buffered_partd(buffer=False, tempdir=None)
+            p1 = maybe_buffered_partd(buffer=False, tempdir=None)()
             p1 = f()
             p1.append({"x": df1})
             # get underlying filename from partd - depending on nested structure of partd object

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -947,7 +947,6 @@ def test_disk_shuffle_check_actual_compression():
         df1["b"] = (df1["a"] * 123).astype(str)
         with dask.config.set({"dataframe.shuffle-compression": compression}):
             p1 = maybe_buffered_partd(buffer=False, tempdir=None)()
-            p1 = f()
             p1.append({"x": df1})
             # get underlying filename from partd - depending on nested structure of partd object
             filename = (

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -929,14 +929,16 @@ def test_disk_shuffle_with_compression_option(compression):
 def test_disk_shuffle_with_unknown_compression(compression):
     # test if dask raises an error in case of fault config string
     with dask.config.set({"dataframe.shuffle-compression": compression}):
-        with pytest.raises(ImportError) as excinfo:
+        with pytest.raises(
+            ImportError,
+            match=(
+                "Not able to import and load {0} as compression algorithm."
+                "Please check if the library is installed and supported by Partd.".format(
+                    compression
+                )
+            ),
+        ):
             test_shuffle("disk")
-        assert str(excinfo.value) == (
-            "Not able to import and load {0} as compression algorithm."
-            "Please check if the library is installed and supported by Partd.".format(
-                compression
-            )
-        )
 
 
 def test_disk_shuffle_check_actual_compression():

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -916,3 +916,9 @@ def test_set_index_timestamp():
 
     assert_eq(df2, ddf_new_div)
     assert_eq(df2, ddf.set_index("A"))
+
+
+@pytest.mark.parametrize("compression", [None, "ZLib"])
+def test_disk_shuffle_with_compression(compression):
+    with dask.config.set({"shuffle-disk-compression": compression}):
+        test_shuffle("disk")

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -416,4 +416,5 @@ def test_merge_None_to_dict():
 
 def test_core_file():
     assert "temporary-directory" in dask.config.config
-    assert "shuffle-disk-compression" in dask.config.config
+    assert "dataframe" in dask.config.config
+    assert "shuffle-compression" in dask.config.get("dataframe")

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -416,3 +416,4 @@ def test_merge_None_to_dict():
 
 def test_core_file():
     assert "temporary-directory" in dask.config.config
+    assert "shuffle-disk-compression" in dask.config.config


### PR DESCRIPTION
Shoud close https://github.com/dask/dask/issues/5704

This change adds transparent file compression for on-disk shuffle via partd.
The compression algorithm can be specified by dask config (keyword shuffle_disk_compression). 
It can be any algorithm which is exposed by partd.compressed. In case an algorithm is absent, it silently falls back to no compression.

Please check one thing - I am not sure about the naming schema and where to document the config parameter.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
