### PR TITLE
Update order to handle empty task graph

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -102,6 +102,9 @@ def order(dsk, dependencies=None):
     >>> order(dsk)
     {'a': 0, 'c': 1, 'b': 2, 'd': 3}
     """
+    if not dsk:
+        return {}
+
     if dependencies is None:
         dependencies = {k: get_dependencies(dsk, k) for k in dsk}
 

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -652,3 +652,7 @@ def test_order_cycle():
         order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a", "d"), "d": 1})
     with pytest.raises(RuntimeError, match="Cycle detected"):
         order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a", "d"), "d": (f, "b")})
+
+
+def test_order_empty():
+    assert order({}) == {}


### PR DESCRIPTION
This is a follow-up to https://github.com/dask/dask/pull/5646 which allows us to maintain backwards compatibility when dealing with empty task graphs.

On the latest release (2.9.1), we have:

```python
In [1]: import dask

In [2]: dask.__version__
Out[2]: '2.9.1'

In [3]: dask.order.order({})
Out[3]: {}
```

while on the current `master`, we have:

```python
In [1]: import dask

In [2]: dask.order.order({})
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-32827a593ec3> in <module>
----> 1 dask.order.order({})

~/github/dask/dask/dask/order.py in order(dsk, dependencies)
    232
    233     is_init_sorted = False
--> 234     item = min(init_stack, key=initial_stack_key)
    235     while True:
    236         outer_stack_append(item)

ValueError: min() arg is an empty sequence
```

For reference, this came up in the `distributed` test suite where several tests pass empty graphs to `order()`

- [x] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
