### PR TITLE
Mean implementation for datetime series 

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1669,7 +1669,8 @@ Dask Name: {name}, {task} tasks"""
             )
             return handle_out(out, result)
         else:
-            if self.dtype == "<M8[ns]":
+            dtype = getattr(self, "dtype", None)
+            if dtype == "<M8[ns]":
                 num = self._get_numeric_data().astype("i8")
             else:
                 num = self._get_numeric_data()
@@ -1686,7 +1687,7 @@ Dask Name: {name}, {task} tasks"""
             )
             if isinstance(self, DataFrame):
                 result.divisions = (min(self.columns), max(self.columns))
-            if self.dtype == "<M8[ns]":
+            if dtype == "<M8[ns]":
                 val = pd.Timestamp(result.compute())
                 add_layers = {result._name: {(result._name, 0): val}}
                 add_dependencies = {result._name: set()}

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1669,7 +1669,7 @@ Dask Name: {name}, {task} tasks"""
             )
             return handle_out(out, result)
         else:
-            if self.dtype == '<M8[ns]':
+            if self.dtype == "<M8[ns]":
                 num = self._get_numeric_data().astype("i8")
             else:
                 num = self._get_numeric_data()
@@ -1686,7 +1686,7 @@ Dask Name: {name}, {task} tasks"""
             )
             if isinstance(self, DataFrame):
                 result.divisions = (min(self.columns), max(self.columns))
-            if self.dtype == '<M8[ns]':
+            if self.dtype == "<M8[ns]":
                 val = pd.Timestamp(result.compute())
                 add_layers = {result._name: {(result._name, 0): val}}
                 add_dependencies = {result._name: set()}

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1349,6 +1349,8 @@ def test_moment():
 
 
 def test_datetime_series_mean():
-    pds = pd.Series(pd.date_range('2000', periods=4))
+    pds = pd.Series(pd.date_range("2000", periods=4))
     dds = dd.from_pandas(pds, npartitions=1)
-    assert_eq(pds.mean(),dds.mean(),)
+    assert_eq(
+        pds.mean(), dds.mean(),
+    )

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1346,3 +1346,9 @@ def test_moment():
     ddf = dd.from_pandas(df, npartitions=2)
 
     assert_eq(stats.moment(ddf, 2, 0), scipy.stats.moment(df, 2, 0))
+
+
+def test_datetime_series_mean():
+    pds = pd.Series(pd.date_range('2000', periods=4))
+    dds = dd.from_pandas(pds, npartitions=1)
+    assert_eq(pds.mean(),dds.mean(),)


### PR DESCRIPTION
Fixes #5051 

- modifies `mean` to handle calculation for datetime series

- adds test to check result is equivalent to pandas

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
