### PR TITLE
Use latest release of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: cad4138050b86d1c8570b926883e32f7465c2880
+    rev: stable
     hooks:
     - id: black
       language_version: python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ script:
   - if [[ $TEST_HDFS == 'true' ]]; then source continuous_integration/hdfs/run_tests.sh; fi
   - if [[ $TEST == 'true' ]]; then source continuous_integration/travis/run_tests.sh; fi
   - if [[ $LINT == 'true' ]]; then pip install flake8 ; flake8 dask; fi
-  - if [[ $LINT == 'true' ]]; then pip install git+https://github.com/psf/black@73bd7038fbefdb1c6a61fa1edf16ff61613050a5; black dask --check; fi
+  - if [[ $LINT == 'true' ]]; then pip install black ; black dask --check; fi
   - if [[ $TEST_IMPORTS == 'true' ]]; then bash continuous_integration/travis/test_imports.sh; fi
 
 after_success:

--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -47,9 +47,9 @@ def svg_2d(chunks, offset=(0, 0), skew=(0, 0), size=200, sizes=None):
 
     lines, (min_x, max_x, min_y, max_y) = svg_grid(x, y, offset=offset, skew=skew)
 
-    header = '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n' % (
-        max_x + 50,
-        max_y + 50,
+    header = (
+        '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n'
+        % (max_x + 50, max_y + 50,)
     )
     footer = "\n</svg>"
 
@@ -85,9 +85,9 @@ def svg_3d(chunks, size=200, sizes=None, offset=(0, 0)):
         z, y, offset=(ox + max_x + 10, oy + max_x), skew=(0, 0)
     )
 
-    header = '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n' % (
-        max_z + 50,
-        max_y + 50,
+    header = (
+        '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n'
+        % (max_z + 50, max_y + 50,)
     )
     footer = "\n</svg>"
 
@@ -152,9 +152,9 @@ def svg_nd(chunks, size=200):
 
         out.append(o)
 
-    header = '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n' % (
-        left,
-        total_height,
+    header = (
+        '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n'
+        % (left, total_height,)
     )
     footer = "\n</svg>"
     return header + "\n\n".join(out) + footer


### PR DESCRIPTION
We pinned `black` to a specific commit in https://github.com/dask/dask/pull/5491 to avoid formatting issues with Python 3.5. We've since dropped support for 3.5, so we should be able to use the latest release of `black` now. 

This will help avoid discrepencies where users `pip install black` and manually run `black dask` instead of using the pre-commit hook (xref https://github.com/dask/dask/pull/5796#issue-363910617)

cc @quasiben 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
