### PR TITLE
Loosen criteria for gather_statistics=True default in parquet ArrowEngine

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -215,9 +215,12 @@ class ArrowEngine(Engine):
         if (
             gather_statistics is None
             and dataset.metadata
-            and dataset.metadata.num_row_groups == len(pieces)
+            and dataset.metadata.num_row_groups >= len(pieces)
         ):
             gather_statistics = True
+            # Don't gather stats by default if this is a partitioned dataset
+            if dataset.metadata.num_row_groups != len(pieces) and partitions:
+                gather_statistics = False
         if not pieces:
             gather_statistics = False
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2095,13 +2095,7 @@ def test_split_row_groups_pyarrow(tmpdir):
         tmp, engine="pyarrow", row_group_size=100
     )
 
-    ddf3 = dd.read_parquet(
-        tmp,
-        engine="pyarrow",
-        gather_statistics=True,
-        split_row_groups=True,
-        chunksize=1,
-    )
+    ddf3 = dd.read_parquet(tmp, engine="pyarrow", split_row_groups=True, chunksize=1)
     assert ddf3.npartitions == 4
 
     ddf3 = dd.read_parquet(


### PR DESCRIPTION
Currently, the `read_parquet` implementation for the pyarrow backend [requires a 1-to-1 file to row-group mapping](https://github.com/dask/dask/blob/61354989318d33fe5796abab7450eee44997c93b/dask/dataframe/io/parquet/arrow.py#L218) for the `gather_statistics` default to be `True` (along with the existience of a shared `"_metadata"` file).  This criteria prevents statistics from being gathered (by default) when: (1) one or more files cointain multiple row-groups, and/or (2) the dataset is *partitioned*.   Only the second of these criteria (dataset is partitioned) should prevent default statistics gathering, because it currently requires the parsing of more than `"_metadata"`.

This PR enables a `gather_statistics=True` default when there are multiple row-groups per file.  This will also enable `split_row_groups=True` (which requires `gather_statistics=True`) to *work* in more cases.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
