### PR TITLE
[REVIEW] Expose sort= argument for groupby

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4638,6 +4638,7 @@ def apply_concat_apply(
     split_out=None,
     split_out_setup=None,
     split_out_setup_kwargs=None,
+    # sort=True,
     **kwargs
 ):
     """Apply a function to blocks, then concat, then apply again
@@ -4677,6 +4678,8 @@ def apply_concat_apply(
         as is.
     split_out_setup_kwargs : dict, optional
         Keywords for the `split_out_setup` function only.
+    sort : bool, default True
+        If allowed, sort the keys of the output aggregation.
     kwargs :
         All remaining keywords will be passed to ``chunk``, ``aggregate``, and
         ``combine``.
@@ -4793,6 +4796,10 @@ def apply_concat_apply(
         k = part_i + 1
         a = b
         depth += 1
+
+    # if sort:
+    #     aggregate_kwargs = aggregate_kwargs or {}
+    #     aggregate_kwargs["sort"] = True
 
     # Aggregate
     for j in range(split_out):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4808,6 +4808,11 @@ def apply_concat_apply(
         depth += 1
 
     if sort is not None:
+        if sort and split_out > 1:
+            raise NotImplementedError(
+                "Cannot guarentee sorted keys for `split_out>1`."
+                " Try using split_out=1, or grouping with sort=False."
+            )
         aggregate_kwargs = aggregate_kwargs or {}
         aggregate_kwargs["sort"] = sort
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4807,9 +4807,9 @@ def apply_concat_apply(
         a = b
         depth += 1
 
-    if sort:
+    if sort is not None:
         aggregate_kwargs = aggregate_kwargs or {}
-        aggregate_kwargs["sort"] = True
+        aggregate_kwargs["sort"] = sort
 
     # Aggregate
     for j in range(split_out):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4688,7 +4688,7 @@ def apply_concat_apply(
         as is.
     split_out_setup_kwargs : dict, optional
         Keywords for the `split_out_setup` function only.
-    sort : bool, default True
+    sort : bool, default None
         If allowed, sort the keys of the output aggregation.
     kwargs :
         All remaining keywords will be passed to ``chunk``, ``aggregate``, and

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4648,7 +4648,7 @@ def apply_concat_apply(
     split_out=None,
     split_out_setup=None,
     split_out_setup_kwargs=None,
-    # sort=True,
+    sort=None,
     **kwargs
 ):
     """Apply a function to blocks, then concat, then apply again
@@ -4807,9 +4807,9 @@ def apply_concat_apply(
         a = b
         depth += 1
 
-    # if sort:
-    #     aggregate_kwargs = aggregate_kwargs or {}
-    #     aggregate_kwargs["sort"] = True
+    if sort:
+        aggregate_kwargs = aggregate_kwargs or {}
+        aggregate_kwargs["sort"] = True
 
     # Aggregate
     for j in range(split_out):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -276,7 +276,8 @@ class Aggregation(object):
 
 def _groupby_aggregate(df, aggfunc=None, levels=None, dropna=None, **kwargs):
     dropna = {"dropna": dropna} if dropna is not None else {}
-    return aggfunc(df.groupby(level=levels, sort=False, **dropna), **kwargs)
+    # sort = kwargs.pop("sort", False)
+    return aggfunc(df.groupby(level=levels, **dropna), **kwargs)
 
 
 def _apply_chunk(df, *index, dropna=None, **kwargs):
@@ -987,15 +988,21 @@ class _GroupBy(object):
         Passed to pandas.DataFrame.groupby()
     dropna: bool
         Whether to drop null values from groupby index
+    sort: bool, defult True
+        Passed along to aggregation methods. If allowed,
+        the output aggregation will have sorted keys.
     """
 
-    def __init__(self, df, by=None, slice=None, group_keys=True, dropna=None):
+    def __init__(
+        self, df, by=None, slice=None, group_keys=True, dropna=None, sort=True
+    ):
 
         assert isinstance(df, (DataFrame, Series))
         self.group_keys = group_keys
         self.obj = df
         # grouping key passed via groupby method
         self.index = _normalize_index(df, by)
+        # self.sort = sort
 
         if isinstance(self.index, list):
             do_index_partition_align = all(
@@ -1093,6 +1100,7 @@ class _GroupBy(object):
             ),
             split_out=split_out,
             split_out_setup=split_out_on_index,
+            # sort=self.sort,
         )
 
     def _cum_agg(self, token, chunk, aggregate, initial):
@@ -1347,6 +1355,7 @@ class _GroupBy(object):
             split_every=split_every,
             split_out=split_out,
             split_out_setup=split_out_on_index,
+            # sort=self.sort,
         )
 
         if isinstance(self.obj, Series):
@@ -1405,6 +1414,7 @@ class _GroupBy(object):
             split_every=split_every,
             split_out=split_out,
             split_out_setup=split_out_on_index,
+            # sort=self.sort,
         )
 
         if isinstance(self.obj, Series):
@@ -1520,6 +1530,7 @@ class _GroupBy(object):
             split_every=split_every,
             split_out=split_out,
             split_out_setup=split_out_on_index,
+            # sort=self.sort,
         )
 
     @insert_meta_param_description(pad=12)
@@ -1789,6 +1800,7 @@ class SeriesGroupBy(_GroupBy):
             split_every=split_every,
             split_out=split_out,
             split_out_setup=split_out_on_index,
+            # sort=self.sort,
         )
 
     @derived_from(pd.core.groupby.SeriesGroupBy)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -315,12 +315,12 @@ def _var_chunk(df, *index):
     return concat([x, x2, n], axis=1)
 
 
-def _var_combine(g, levels):
-    return g.groupby(level=levels, sort=False).sum()
+def _var_combine(g, levels, sort=False):
+    return g.groupby(level=levels, sort=sort).sum()
 
 
-def _var_agg(g, levels, ddof):
-    g = g.groupby(level=levels, sort=False).sum()
+def _var_agg(g, levels, ddof, sort=False):
+    g = g.groupby(level=levels, sort=sort).sum()
     nc = len(g.columns)
     x = g[g.columns[: nc // 3]]
     # chunks columns are tuples (value, name), so we just keep the value part
@@ -431,7 +431,7 @@ def _cov_chunk(df, *index):
     return (x, mul, n, col_mapping)
 
 
-def _cov_agg(_t, levels, ddof, std=False):
+def _cov_agg(_t, levels, ddof, std=False, sort=False):
     sums = []
     muls = []
     counts = []
@@ -446,8 +446,8 @@ def _cov_agg(_t, levels, ddof, std=False):
         counts.append(n)
         col_mapping = col_mapping
 
-    total_sums = concat(sums).groupby(level=levels, sort=False).sum()
-    total_muls = concat(muls).groupby(level=levels, sort=False).sum()
+    total_sums = concat(sums).groupby(level=levels, sort=sort).sum()
+    total_muls = concat(muls).groupby(level=levels, sort=sort).sum()
     total_counts = concat(counts).groupby(level=levels).sum()
     result = (
         concat([total_sums, total_muls, total_counts], axis=1)
@@ -525,8 +525,8 @@ def _drop_duplicates_rename(df):
     return df.drop_duplicates().rename_axis(names, copy=False)
 
 
-def _nunique_df_combine(df, levels):
-    result = df.groupby(level=levels, sort=False).apply(_drop_duplicates_rename)
+def _nunique_df_combine(df, levels, sort=False):
+    result = df.groupby(level=levels, sort=sort).apply(_drop_duplicates_rename)
 
     if isinstance(levels, list):
         result.index = pd.MultiIndex.from_arrays(
@@ -538,8 +538,8 @@ def _nunique_df_combine(df, levels):
     return result
 
 
-def _nunique_df_aggregate(df, levels, name):
-    return df.groupby(level=levels, sort=False)[name].nunique()
+def _nunique_df_aggregate(df, levels, name, sort=False):
+    return df.groupby(level=levels, sort=sort)[name].nunique()
 
 
 def _nunique_series_chunk(df, *index, **_ignored_):
@@ -899,7 +899,7 @@ def _compute_sum_of_squares(grouped, column):
     return base.apply(lambda x: (x ** 2).sum())
 
 
-def _agg_finalize(df, aggregate_funcs, finalize_funcs, level, sort=None):
+def _agg_finalize(df, aggregate_funcs, finalize_funcs, level, sort=False):
     # finish the final aggregation level
     df = _groupby_apply_funcs(df, funcs=aggregate_funcs, level=level, sort=sort)
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1409,8 +1409,6 @@ def test_groupby_not_supported():
     with pytest.raises(TypeError):
         ddf.groupby("A", as_index=False)
     with pytest.raises(TypeError):
-        ddf.groupby("A", sort=False)
-    with pytest.raises(TypeError):
         ddf.groupby("A", squeeze=True)
 
 


### PR DESCRIPTION
This may address #5441 and [cudf#3319](https://github.com/rapidsai/cudf/issues/3319), and may be a reasonable alternative to #5450 

The idea here is to accept a `sort=` argument for groupby operations, which can be passed along the final apply phase of apply-concat-apply groupby aggregations.  Currently, aggregations triggered by `_groupby_aggregate` are hard-coded to use `sort=False` (I assume for performance reasons), while others us the backend's default behavior.  Ideally, the (final) sorting behavior should always depend on the argument added here.

**Notes**:
- #5450 achieves something similar by exposing `sort=` for aggregations themselves.  The approach used here seems easier to implement/maintain, but I am open to feedback.
- ~[**TODO**] Perhaps we should also set `sort=False` for the first *apply* phase of aggregation (for performace reasons).~  Aggregations use `sort=False` for all but the final ACA phase (if the groupby object's `sort` attribute is `True`)
- ~[**TODO**] The changes in this PR currently address cudf#3319, but thorough testing still needs to be added.~

cc @beckernick (please feel free to advise on downstream needs here)

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
