### PR TITLE
Fixed bug that broke resampling when the new index have a non-existin…

### DIFF
--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -49,7 +49,7 @@ def svg_2d(chunks, offset=(0, 0), skew=(0, 0), size=200, sizes=None):
 
     header = (
         '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n'
-        % (max_x + 50, max_y + 50,)
+        % (max_x + 50, max_y + 50)
     )
     footer = "\n</svg>"
 
@@ -87,7 +87,7 @@ def svg_3d(chunks, size=200, sizes=None, offset=(0, 0)):
 
     header = (
         '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n'
-        % (max_z + 50, max_y + 50,)
+        % (max_z + 50, max_y + 50)
     )
     footer = "\n</svg>"
 
@@ -154,7 +154,7 @@ def svg_nd(chunks, size=200):
 
     header = (
         '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n'
-        % (left, total_height,)
+        % (left, total_height)
     )
     footer = "\n</svg>"
     return header + "\n\n".join(out) + footer

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -32,8 +32,12 @@ def _resample_series(
     )
     return out.reindex(
         pd.date_range(
-            start, end, freq=rule, closed=reindex_closed, name=out.index.name
-        ),
+            start.tz_localize(None),
+            end.tz_localize(None),
+            freq=rule,
+            closed=reindex_closed,
+            name=out.index.name,
+        ).tz_localize(start.tz, nonexistent="shift_forward"),
         fill_value=fill_value,
     )
 

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -6,6 +6,7 @@ from ..core import DataFrame, Series
 from ...base import tokenize
 from ...utils import derived_from
 from ...highlevelgraph import HighLevelGraph
+from .._compat import PANDAS_GT_0240
 
 
 def getnanos(rule):
@@ -30,16 +31,20 @@ def _resample_series(
     out = getattr(series.resample(rule, **resample_kwargs), how)(
         *how_args, **how_kwargs
     )
-    return out.reindex(
+    new_index = (
         pd.date_range(
             start.tz_localize(None),
             end.tz_localize(None),
             freq=rule,
             closed=reindex_closed,
             name=out.index.name,
-        ).tz_localize(start.tz, nonexistent="shift_forward"),
-        fill_value=fill_value,
+        ).tz_localize(start.tz, nonexistent="shift_forward")
+        if PANDAS_GT_0240
+        else pd.date_range(
+            start, end, freq=rule, closed=reindex_closed, name=out.index.name
+        )
     )
+    return out.reindex(new_index, fill_value=fill_value)
 
 
 def _resample_bin_and_out_divs(divisions, rule, closed="left", label="left"):

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -31,19 +31,19 @@ def _resample_series(
     out = getattr(series.resample(rule, **resample_kwargs), how)(
         *how_args, **how_kwargs
     )
-    new_index = (
-        pd.date_range(
+    if PANDAS_GT_0240:
+        new_index = pd.date_range(
             start.tz_localize(None),
             end.tz_localize(None),
             freq=rule,
             closed=reindex_closed,
             name=out.index.name,
         ).tz_localize(start.tz, nonexistent="shift_forward")
-        if PANDAS_GT_0240
-        else pd.date_range(
+
+    else:
+        new_index = pd.date_range(
             start, end, freq=rule, closed=reindex_closed, name=out.index.name
         )
-    )
     return out.reindex(new_index, fill_value=fill_value)
 
 

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -103,6 +103,21 @@ def test_resample_index_name():
     assert ddf.resample("D").mean().head().index.name == "date"
 
 
+def test_series_resample_non_existent_datetime():
+    index = [
+        pd.Timestamp("2016-10-15 00:00:00"),
+        pd.Timestamp("2016-10-16 10:00:00"),
+        pd.Timestamp("2016-10-17 00:00:00"),
+    ]
+    df = pd.DataFrame([[1], [2], [3]], index=index)
+    df.index = df.index.tz_localize("America/Sao_Paulo")
+    ddf = dd.from_pandas(df, npartitions=1)
+    result = ddf.resample("1D").mean().compute()
+    expected = df.resample("1D").mean()
+
+    assert_eq(result, expected)
+
+
 @pytest.mark.skipif(PANDAS_VERSION <= "0.23.4", reason="quantile not in 0.23")
 @pytest.mark.parametrize("agg", ["nunique", "mean", "count", "size", "quantile"])
 def test_common_aggs(agg):

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -114,7 +114,7 @@ def test_series_resample_non_existent_datetime():
     df = pd.DataFrame([[1], [2], [3]], index=index)
     df.index = df.index.tz_localize("America/Sao_Paulo")
     ddf = dd.from_pandas(df, npartitions=1)
-    result = ddf.resample("1D").mean().compute()
+    result = ddf.resample("1D").mean()
     expected = df.resample("1D").mean()
 
     assert_eq(result, expected)

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from dask.dataframe.utils import assert_eq, PANDAS_VERSION
+from dask.dataframe._compat import PANDAS_GT_0240
 import dask.dataframe as dd
 
 
@@ -103,6 +104,7 @@ def test_resample_index_name():
     assert ddf.resample("D").mean().head().index.name == "date"
 
 
+@pytest.mark.skipif(PANDAS_GT_0240, reason="nonexistent not in 0.23 or older")
 def test_series_resample_non_existent_datetime():
     index = [
         pd.Timestamp("2016-10-15 00:00:00"),

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -104,7 +104,7 @@ def test_resample_index_name():
     assert ddf.resample("D").mean().head().index.name == "date"
 
 
-@pytest.mark.skipif(PANDAS_GT_0240, reason="nonexistent not in 0.23 or older")
+@pytest.mark.skipif(not PANDAS_GT_0240, reason="nonexistent not in 0.23 or older")
 def test_series_resample_non_existent_datetime():
     index = [
         pd.Timestamp("2016-10-15 00:00:00"),

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
     ],
     "dataframe": [
         "numpy >= 1.13.0",
-        "pandas >= 0.21.0",
+        "pandas >= 0.24.0",
         "toolz >= 0.7.3",
         "partd >= 0.3.10",
         "fsspec >= 0.6.0",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
     ],
     "dataframe": [
         "numpy >= 1.13.0",
-        "pandas >= 0.24.0",
+        "pandas >= 0.21.0",
         "toolz >= 0.7.3",
         "partd >= 0.3.10",
         "fsspec >= 0.6.0",


### PR DESCRIPTION
The new implementation removes the timezones of the start and end datetimes to ensure that all datetimes exist. Then adds the same timezone using the parameter nonexsistent.

- [ x] Tests added / passed
- [ x] Passes `black dask` / `flake8 dask`
