### PR TITLE
Fix check on dataclass instances in unpack_collections

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -292,7 +292,7 @@ def unpack_collections(*args, **kwargs):
                 tsk = (typ, [_unpack(i) for i in expr])
             elif typ in (dict, OrderedDict):
                 tsk = (typ, [[_unpack(k), _unpack(v)] for k, v in expr.items()])
-            elif is_dataclass(expr):
+            elif is_dataclass(expr) and not isinstance(expr, type):
                 tsk = (
                     apply,
                     typ,

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -456,6 +456,7 @@ def test_unpack_collections():
 
         if dataclasses is not None:
             t[2]["f"] = ADataClass(a=a)
+            t[2]["g"] = (ADataClass, a)
 
         return t
 


### PR DESCRIPTION
This fixes a crash when encountering a dataclass type object (not an instance):

```python
File "/code/.venv/lib/python3.7/site-packages/dask/base.py", line 315, in unpack_collections
    ...
File "/code/.venv/lib/python3.7/site-packages/dask/base.py", line 304, in <listcomp>
    for f in dataclass_fields(expr)
AttributeError: type object 'MyClass' has no attribute 'example'
```

From the [dataclasses docs](https://docs.python.org/3.7/library/dataclasses.html#dataclasses.is_dataclass):

> If you need to know if a class is an instance of a dataclass (and not a dataclass itself), then add a further check for `not isinstance(obj, type)`

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
