### PR TITLE
Use parquet read speed-ups from `fastparquet.api.paths_to_cats`.

### DIFF
--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -5,6 +5,11 @@ import copy
 import json
 import warnings
 
+try:
+    import cytoolz as toolz
+except ModuleNotFoundError:
+    import toolz
+
 import numpy as np
 import pandas as pd
 
@@ -24,7 +29,7 @@ from ...utils import UNKNOWN_CATEGORIES
 #########################
 # Fastparquet interface #
 #########################
-from .utils import Engine, unique_everseen
+from .utils import Engine
 
 
 def _paths_to_cats(paths, file_scheme):
@@ -49,16 +54,14 @@ def _paths_to_cats(paths, file_scheme):
     cats = OrderedDict()
     raw_cats = OrderedDict()
     s = ex_from_sep("/")
-    paths = unique_everseen(paths)
+    paths = toolz.unique(paths)
     if file_scheme == "hive":
-        partitions = unique_everseen(
-            (k, v) for path in paths for k, v in s.findall(path)
-        )
+        partitions = toolz.unique((k, v) for path in paths for k, v in s.findall(path))
         for key, val in partitions:
             cats.setdefault(key, set()).add(val_to_num(val))
             raw_cats.setdefault(key, set()).add(val)
     else:
-        i_val = unique_everseen(
+        i_val = toolz.unique(
             (i, val) for path in paths for i, val in enumerate(path.split("/")[:-1])
         )
         for i, val in i_val:

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -1,5 +1,4 @@
 import re
-import itertools
 
 
 class Engine:
@@ -430,18 +429,3 @@ def _analyze_paths(file_list, fs, root=False):
         "/".join(basepath),
         out_list,
     )  # use '/'.join() instead of _join_path to be consistent with split('/')
-
-
-def unique_everseen(iterable):
-    """List unique elements, preserving order. Remember all elements ever seen.
-    FixMe: This has been pasted from https://github.com/dask/fastparquet/pull/471
-    and is not needed with fastparquet>0.3.2.
-
-    unique_everseen('AAAABBBCCDAABBB') --> A B C D
-    """
-
-    seen = set()
-    seen_add = seen.add
-    for element in itertools.filterfalse(seen.__contains__, iterable):
-        seen_add(element)
-        yield element

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -1,4 +1,5 @@
 import re
+import itertools
 
 
 class Engine:
@@ -429,3 +430,18 @@ def _analyze_paths(file_list, fs, root=False):
         "/".join(basepath),
         out_list,
     )  # use '/'.join() instead of _join_path to be consistent with split('/')
+
+
+def unique_everseen(iterable):
+    """List unique elements, preserving order. Remember all elements ever seen.
+    FixMe: This has been pasted from https://github.com/dask/fastparquet/pull/471
+    and is not needed with fastparquet>0.3.2.
+
+    unique_everseen('AAAABBBCCDAABBB') --> A B C D
+    """
+
+    seen = set()
+    seen_add = seen.add
+    for element in itertools.filterfalse(seen.__contains__, iterable):
+        seen_add(element)
+        yield element


### PR DESCRIPTION
This PR propagates parquet partition read speed-ups merged in https://github.com/dask/fastparquet/pull/471/

Before this change, code was duplicated from `fastparquet`.
After this change, an optimized function is imported from `fastparquet`.

Since `fastparquet` versions range is not explicit in `dask`,
the import is for now made optional, reverting to existing implementation if
using older `fastparquet`.

@rjzamora I am not entirely happy with "try-catch imports" and would rather have `fastparquet` as e.g. an optional dependency with well-specced version ranges, but for now this could be a work-around.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

## Potentially related issues
https://github.com/dask/dask/issues/5272
https://github.com/dask/dask/issues/4701