### PR TITLE
With reference to issue #3663

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1253,7 +1253,7 @@ def take_along_axis(arr,indices,axis):
     if (indices.dtype != 'int64'):
         raise IndexError('indices must be an integer array')
     if axis == 0:
-        arr = arr.flatten()
+        arr = arr.flatten
     Ni, Nk = arr.shape[:axis], arr.shape[axis + 1:]
     j = indices.shape[axis]
     out = np.empty(Ni + (j,) + Nk)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1243,28 +1243,26 @@ def cached_cumsum(seq, initial_zero=False):
 
 
 def take_along_axis(arr,indices,axis):
+    from .core import from_array
     out_d = np.array([]) #creating a new empty array to store the value of result
     arr = np.array(arr)
     indices = np.array(indices)
-    if arr.shape != indices.ndim:
+    if arr.shape != indices.shape:
         raise ValueError(
             "`indices` and `arr` must have the same number of dimensions")
-    for integer in indices:
-        if not isinstance(integer,int):
-            raiseIndexError('indices must be an integer array')
+    if (indices.dtype != 'int64'):
+        raise IndexError('indices must be an integer array')
     if axis == 0:
         arr = arr.flatten
-        arr_shape = (np.prod((arr.shape),))
-    Ni, M, Nk=arr.shape[:axis], arr.shape[axis], arr.shape[axis+1:]
-    j=indices.shape[axis]
-    out=np.empty(Ni+ (j,)+Nk)
+    Ni, Nk = arr.shape[:axis], arr.shape[axis + 1:]
+    j = indices.shape[axis]
+    out = np.empty(Ni + (j,) + Nk)
     for i in np.ndindex(Ni):
         for k in np.ndindex(Nk):
-            a_1d = a[i+np.s_[:,]+ k]
-            indices_1d=indices[i+np.s_[:,]+k]
-            out_1d= out[i+np.s_[:,]+k]
-            out_1d[:]=a_1d[indices_1d]
-            out_d=np.append(out_d,out_1d,axis=0)
-    out_d=np.reshape(out_d, arr.shape)
-    return(da.from_array(out_d))
-    
+            a_1d = arr[i + np.s_[:,] + k]
+            indices_1d = indices[i + np.s_[:,] + k]
+            out_1d = out[i + np.s_[:,] + k]
+            out_1d[:] = a_1d[indices_1d]
+            out_d = np.append(out_d,out_1d,axis=0)
+    out_d = np.reshape(out_d, arr.shape)
+    return(from_array(out_d))

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1253,7 +1253,7 @@ def take_along_axis(arr,indices,axis):
     if (indices.dtype != 'int64'):
         raise IndexError('indices must be an integer array')
     if axis == 0:
-        arr = arr.flatten
+        arr = arr.flatten()
     Ni, Nk = arr.shape[:axis], arr.shape[axis + 1:]
     j = indices.shape[axis]
     out = np.empty(Ni + (j,) + Nk)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1240,3 +1240,73 @@ def cached_cumsum(seq, initial_zero=False):
     if not initial_zero:
         result = result[1:]
     return result
+
+
+def take_along_axis(arr,indices,axis=None):
+ out_d=np.array([]) #creating a new empty array to store the value of result
+ arr=np.array(arr)
+ indices=np.array(indices)
+ if arr.shape != indices.ndim:
+        raise ValueError(
+            "`indices` and `arr` must have the same number of dimensions")
+ 
+ for integer in indices:
+  if not isinstance(integer,int):
+    raiseIndexError('indices must be an integer array')
+ if axis is None:
+    arr=arr.flatten
+    arr_shape=(np.prod((arr.shape),)
+    axis = 0
+ Ni, M, Nk=arr.shape[:axis], arr.shape[axis], arr.shape[axis+1:]
+ j=indices.shape[axis]
+ out=np.empty(Ni+ (j,)+Nk)
+ for i in np.ndindex(Ni):
+  for k in np.ndindex(Nk):
+   a_1d = a[i+np.s_[:,]+ k]
+   indices_1d=indices[i+np.s_[:,]+k]
+   out_1d= out[i+np.s_[:,]+k]
+   out_1d[:]=a_1d[indices_1d]
+   out_d=np.append(out_d,out_1d,axis=0)
+ out_d=np.reshape(out_d,arr.shape)   
+ return(da.from_array(out_d))
+    
+a =np.array([[10, 30, 20], [60, 40, 50]])
+ai=np.array([[0, 2, 1],[1, 2, 0]])      
+y=take_along_axis(a,ai,axis=0)
+print(y.compute())
+
+
+
+ef take_along_axis(arr,indices,axis=None):
+ out_d=np.array([]) #creating a new empty array to store the value of result
+ arr=np.array(arr)
+ indices=np.array(indices)
+ if arr.shape != indices.ndim:
+        raise ValueError(
+            "`indices` and `arr` must have the same number of dimensions")
+ 
+ for integer in indices:
+  if not isinstance(integer,int):
+    raiseIndexError('indices must be an integer array')
+ if axis is None:
+    arr=arr.flatten
+    arr_shape=(np.prod((arr.shape),)
+    axis = 0
+ Ni, M, Nk=arr.shape[:axis], arr.shape[axis], arr.shape[axis+1:]
+ j=indices.shape[axis]
+ out=np.empty(Ni+ (j,)+Nk)
+ for i in np.ndindex(Ni):
+  for k in np.ndindex(Nk):
+   a_1d = a[i+np.s_[:,]+ k]
+   indices_1d=indices[i+np.s_[:,]+k]
+   out_1d= out[i+np.s_[:,]+k]
+   out_1d[:]=a_1d[indices_1d]
+   out_d=np.append(out_d,out_1d,axis=0)
+ out_d=np.reshape(out_d,arr.shape)   
+ return(da.from_array(out_d))
+"""    
+a =np.array([[10, 30, 20], [60, 40, 50]])
+ai=np.array([[0, 2, 1],[1, 2, 0]])      
+y=take_along_axis(a,ai,axis=0)
+print(y.compute())
+"""

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1254,7 +1254,7 @@ def take_along_axis(arr,indices,axis=None):
             raiseIndexError('indices must be an integer array')
     if axis is None:
         arr = arr.flatten
-        arr_shape = (np.prod((arr.shape),)
+        arr_shape = (np.prod((arr.shape),))
         axis = 0
     Ni, M, Nk=arr.shape[:axis], arr.shape[axis], arr.shape[axis+1:]
     j=indices.shape[axis]
@@ -1268,10 +1268,4 @@ def take_along_axis(arr,indices,axis=None):
             out_d=np.append(out_d,out_1d,axis=0)
     out_d=np.reshape(out_d, arr.shape)
     return(da.from_array(out_d))
-"""                     
-a =np.array([[10, 30, 20], [60, 40, 50]])
-ai=np.array([[0, 2, 1],[1, 2, 0]])
-y=take_along_axis(a,ai,axis=0)
-print(y.compute())
-"""   
-             
+    

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1242,7 +1242,7 @@ def cached_cumsum(seq, initial_zero=False):
     return result
 
 
-def take_along_axis(arr,indices,axis=None):
+def take_along_axis(arr,indices,axis):
     out_d = np.array([]) #creating a new empty array to store the value of result
     arr = np.array(arr)
     indices = np.array(indices)
@@ -1252,10 +1252,9 @@ def take_along_axis(arr,indices,axis=None):
     for integer in indices:
         if not isinstance(integer,int):
             raiseIndexError('indices must be an integer array')
-    if axis is None:
+    if axis == 0:
         arr = arr.flatten
         arr_shape = (np.prod((arr.shape),))
-        axis = 0
     Ni, M, Nk=arr.shape[:axis], arr.shape[axis], arr.shape[axis+1:]
     j=indices.shape[axis]
     out=np.empty(Ni+ (j,)+Nk)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1243,70 +1243,35 @@ def cached_cumsum(seq, initial_zero=False):
 
 
 def take_along_axis(arr,indices,axis=None):
- out_d=np.array([]) #creating a new empty array to store the value of result
- arr=np.array(arr)
- indices=np.array(indices)
- if arr.shape != indices.ndim:
+    out_d = np.array([]) #creating a new empty array to store the value of result
+    arr = np.array(arr)
+    indices = np.array(indices)
+    if arr.shape != indices.ndim:
         raise ValueError(
             "`indices` and `arr` must have the same number of dimensions")
- 
- for integer in indices:
-  if not isinstance(integer,int):
-    raiseIndexError('indices must be an integer array')
- if axis is None:
-    arr=arr.flatten
-    arr_shape=(np.prod((arr.shape),)
-    axis = 0
- Ni, M, Nk=arr.shape[:axis], arr.shape[axis], arr.shape[axis+1:]
- j=indices.shape[axis]
- out=np.empty(Ni+ (j,)+Nk)
- for i in np.ndindex(Ni):
-  for k in np.ndindex(Nk):
-   a_1d = a[i+np.s_[:,]+ k]
-   indices_1d=indices[i+np.s_[:,]+k]
-   out_1d= out[i+np.s_[:,]+k]
-   out_1d[:]=a_1d[indices_1d]
-   out_d=np.append(out_d,out_1d,axis=0)
- out_d=np.reshape(out_d,arr.shape)   
- return(da.from_array(out_d))
-    
+    for integer in indices:
+        if not isinstance(integer,int):
+            raiseIndexError('indices must be an integer array')
+    if axis is None:
+        arr = arr.flatten
+        arr_shape = (np.prod((arr.shape),)
+        axis = 0
+    Ni, M, Nk=arr.shape[:axis], arr.shape[axis], arr.shape[axis+1:]
+    j=indices.shape[axis]
+    out=np.empty(Ni+ (j,)+Nk)
+    for i in np.ndindex(Ni):
+        for k in np.ndindex(Nk):
+            a_1d = a[i+np.s_[:,]+ k]
+            indices_1d=indices[i+np.s_[:,]+k]
+            out_1d= out[i+np.s_[:,]+k]
+            out_1d[:]=a_1d[indices_1d]
+            out_d=np.append(out_d,out_1d,axis=0)
+    out_d=np.reshape(out_d, arr.shape)
+    return(da.from_array(out_d))
+"""                     
 a =np.array([[10, 30, 20], [60, 40, 50]])
-ai=np.array([[0, 2, 1],[1, 2, 0]])      
+ai=np.array([[0, 2, 1],[1, 2, 0]])
 y=take_along_axis(a,ai,axis=0)
 print(y.compute())
-
-
-
-ef take_along_axis(arr,indices,axis=None):
- out_d=np.array([]) #creating a new empty array to store the value of result
- arr=np.array(arr)
- indices=np.array(indices)
- if arr.shape != indices.ndim:
-        raise ValueError(
-            "`indices` and `arr` must have the same number of dimensions")
- 
- for integer in indices:
-  if not isinstance(integer,int):
-    raiseIndexError('indices must be an integer array')
- if axis is None:
-    arr=arr.flatten
-    arr_shape=(np.prod((arr.shape),)
-    axis = 0
- Ni, M, Nk=arr.shape[:axis], arr.shape[axis], arr.shape[axis+1:]
- j=indices.shape[axis]
- out=np.empty(Ni+ (j,)+Nk)
- for i in np.ndindex(Ni):
-  for k in np.ndindex(Nk):
-   a_1d = a[i+np.s_[:,]+ k]
-   indices_1d=indices[i+np.s_[:,]+k]
-   out_1d= out[i+np.s_[:,]+k]
-   out_1d[:]=a_1d[indices_1d]
-   out_d=np.append(out_d,out_1d,axis=0)
- out_d=np.reshape(out_d,arr.shape)   
- return(da.from_array(out_d))
-"""    
-a =np.array([[10, 30, 20], [60, 40, 50]])
-ai=np.array([[0, 2, 1],[1, 2, 0]])      
-y=take_along_axis(a,ai,axis=0)
-print(y.compute())
-"""
+"""   
+             

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -952,3 +952,9 @@ def test_gh4043(lock, asarray, fancy):
     a2 = da.from_array(np.ones(3), chunks=1, asarray=asarray, lock=lock, fancy=fancy)
     al = da.stack([a1, a2])
     assert_eq(al, al)
+def test_take_along_axis():
+    a = np.array([[10, 30, 20], [60, 40, 50]])
+    b = np.array([[0, 2, 1],[1, 2, 0]])      
+    y = take_along_axis(a,b,axis=0)
+    x = np.take_along_axis(a,b,axis=0)
+    assert_eq(x, y)

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -19,6 +19,7 @@ from dask.array.slicing import (
     slicing_plan,
     make_block_sorted_slices,
     shuffle_slice,
+    take_along_axis,
 )
 from dask.array.slicing import (
     _sanitize_index_element,
@@ -956,8 +957,10 @@ def test_gh4043(lock, asarray, fancy):
     
 def test_take_along_axis():
     a = np.array([[10, 30, 20], [60, 40, 50]])
-    b = np.array([[0, 2, 1],[1, 2, 0]])      
-    y = take_along_axis(a,b,axis=0)
-    x = np.take_along_axis(a,b,axis=0)
+    b = np.array([[0, 2, 1],[1, 2, 0]])
+    arr = np.array([[10, 30, 20]])
+    with pytest.raises(ValueError):
+        take_along_axis(arr, b, axis=0)      
+    y = take_along_axis(a, b, axis=0)
+    x = np.take_along_axis(a, b, axis=0)
     assert_eq(x, y)
-    

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -960,7 +960,7 @@ def test_take_along_axis():
     b = np.array([[0, 2, 1],[1, 2, 0]])
     arr = np.array([[10, 30, 20]])
     with pytest.raises(ValueError):
-        take_along_axis(arr, b, axis=0)      
-    y = take_along_axis(a, b, axis=0)
-    x = np.take_along_axis(a, b, axis=0)
+        take_along_axis(arr, b, axis=1)      
+    y = take_along_axis(a, b, axis=1)
+    x = np.take_along_axis(a, b, axis=1)
     assert_eq(x, y)

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -952,9 +952,12 @@ def test_gh4043(lock, asarray, fancy):
     a2 = da.from_array(np.ones(3), chunks=1, asarray=asarray, lock=lock, fancy=fancy)
     al = da.stack([a1, a2])
     assert_eq(al, al)
+    
+    
 def test_take_along_axis():
     a = np.array([[10, 30, 20], [60, 40, 50]])
     b = np.array([[0, 2, 1],[1, 2, 0]])      
     y = take_along_axis(a,b,axis=0)
     x = np.take_along_axis(a,b,axis=0)
     assert_eq(x, y)
+    


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
Added a new function which is  similar to numpys `take_along_axis` (related to issue #3663)