### PR TITLE
Fixes ValueError in delayed execution of bagged numpy array

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1833,7 +1833,7 @@ def concat(bags):
 def reify(seq):
     if isinstance(seq, Iterator):
         seq = list(seq)
-    if seq and isinstance(seq[0], Iterator):
+    if len(seq) and isinstance(seq[0], Iterator):
         seq = list(map(list, seq))
     return seq
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1473,3 +1473,12 @@ def test_map_releases_element_references_as_soon_as_possible():
         b.compute(scheduler="sync")
     finally:
         gc.enable()
+
+
+def test_bagged_array_delayed():
+    import dask.array as da
+
+    obj = da.ones(10, chunks=5).to_delayed()[0]
+    bag = db.from_delayed(obj)
+    b = bag.compute()
+    assert b == [1.0, 1.0, 1.0, 1.0, 1.0]

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1476,9 +1476,9 @@ def test_map_releases_element_references_as_soon_as_possible():
 
 
 def test_bagged_array_delayed():
-    import dask.array as da
+    da = pytest.importorskip("dask.array")
 
     obj = da.ones(10, chunks=5).to_delayed()[0]
     bag = db.from_delayed(obj)
     b = bag.compute()
-    assert b == [1.0, 1.0, 1.0, 1.0, 1.0]
+    assert_eq(b, [1.0, 1.0, 1.0, 1.0, 1.0])


### PR DESCRIPTION
Fixes ValueError raised by bagged numpy array from #5706 
- [x] Tests passed
- [x] Passes `black dask` / `flake8 dask`

Looks like this issue is fixed by using `if len(seq)` instead of `if seq` to check for a non-empty array (as suggested by @TomAugspurger)