### PR TITLE
Close ThreadPool at exit

### DIFF
--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -3,6 +3,7 @@ A threaded shared-memory scheduler
 
 See local.py
 """
+import atexit
 import sys
 from collections import defaultdict
 from multiprocessing.pool import ThreadPool
@@ -63,11 +64,13 @@ def get(dsk, result, cache=None, num_workers=None, pool=None, **kwargs):
             if num_workers is None and thread is main_thread:
                 if default_pool is None:
                     default_pool = ThreadPool(CPU_COUNT)
+                    atexit.register(default_pool.close)
                 pool = default_pool
             elif thread in pools and num_workers in pools[thread]:
                 pool = pools[thread][num_workers]
             else:
                 pool = ThreadPool(num_workers)
+                atexit.register(pool.close)
                 pools[thread][num_workers] = pool
 
     results = get_async(


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/5806

I added calls to close at exit for the ThreadPools we create. We don't / shouldn't do this for user-provided thread pools.

I'm not sure how to test this.