### PR TITLE
Call pip as a module to avoid warnings (#5857)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
     - name: Install Dask
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        python -m pip install -e .
 
     - name: Install doc dependencies
-      run: pip install -r docs/requirements-docs.txt
+      run: python -m pip install -r docs/requirements-docs.txt
 
     - name: Build docs
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,8 +94,8 @@ install:
 script:
   - if [[ $TEST_HDFS == 'true' ]]; then source continuous_integration/hdfs/run_tests.sh; fi
   - if [[ $TEST == 'true' ]]; then source continuous_integration/travis/run_tests.sh; fi
-  - if [[ $LINT == 'true' ]]; then pip install flake8 ; flake8 dask; fi
-  - if [[ $LINT == 'true' ]]; then pip install black ; black dask --check; fi
+  - if [[ $LINT == 'true' ]]; then python -m pip install flake8 ; flake8 dask; fi
+  - if [[ $LINT == 'true' ]]; then python -m pip install black ; black dask --check; fi
   - if [[ $TEST_IMPORTS == 'true' ]]; then bash continuous_integration/travis/test_imports.sh; fi
 
 after_success:

--- a/continuous_integration/appveyor/setup_conda_environment.cmd
+++ b/continuous_integration/appveyor/setup_conda_environment.cmd
@@ -2,7 +2,7 @@
 @rem script in non-root environments.
 set CONDA=cmd /C conda
 set CONDA_INSTALL=%CONDA% install -q -y
-set PIP_INSTALL=pip install -q
+set PIP_INSTALL=python -m pip install -q
 
 @echo on
 

--- a/continuous_integration/hdfs/install.sh
+++ b/continuous_integration/hdfs/install.sh
@@ -1,6 +1,6 @@
 set -xe
 
 docker exec -it $CONTAINER_ID conda install -y -q dask pyarrow">=0.14.0" fsspec -c conda-forge
-docker exec -it $CONTAINER_ID pip install -e .
+docker exec -it $CONTAINER_ID python -m pip install -e .
 
 set +xe

--- a/continuous_integration/travis/after_success.sh
+++ b/continuous_integration/travis/after_success.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [[ $COVERAGE == 'true' ]]; then
     coverage report --show-missing
-    pip install coveralls
+    python -m pip install coveralls
     coveralls
 fi

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -27,16 +27,16 @@ source activate test-environment
 # We don't have a conda-forge package for cityhash
 # We don't include it in the conda environment.yaml, since that may
 # make things harder for contributors that don't have a C++ compiler
-pip install --no-deps cityhash
+python -m pip install --no-deps cityhash
 
 if [[ ${UPSTREAM_DEV} ]]; then
     conda uninstall --force numpy pandas
-    pip install -f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com \
+    python -m pip install -f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com \
         --no-deps \
         --pre \
         numpy \
         pandas
-    pip install \
+    python -m pip install \
         --no-deps \
         --upgrade \
         locket \
@@ -49,7 +49,7 @@ if [[ ${UPSTREAM_DEV} ]]; then
 fi
 
 # Install dask
-pip install --quiet --no-deps -e .[complete]
+python -m pip install --quiet --no-deps -e .[complete]
 echo conda list
 conda list
 

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -245,6 +245,6 @@ except ImportError as e:
         "Dask array requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask                 # either conda install\n"
-        "  pip install dask[array] --upgrade  # or pip install"
+        "  python -m pip install dask[array] --upgrade  # or python -m pip install"
     )
     raise ImportError(str(e) + "\n\n" + msg)

--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -21,6 +21,6 @@ except ImportError as e:
         "Dask bag requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask               # either conda install\n"
-        "  pip install dask[bag] --upgrade  # or pip install"
+        "  python -m pip install dask[bag] --upgrade  # or python -m pip install"
     )
     raise ImportError(str(e) + "\n\n" + msg)

--- a/dask/bytes/__init__.py
+++ b/dask/bytes/__init__.py
@@ -11,7 +11,7 @@ if fsspec is None or LooseVersion(fsspec.__version__) < LooseVersion("0.3.3"):
         " Please install using\n"
         "conda install -c conda-forge 'fsspec>=0.3.3'\n"
         "or\n"
-        "pip install 'fsspec>=0.3.3'"
+        "python -m pip install 'fsspec>=0.3.3'"
     )
 
 from .core import read_bytes, open_file, open_files

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -50,6 +50,6 @@ except ImportError as e:
         "Dask dataframe requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask                     # either conda install\n"
-        "  pip install dask[dataframe] --upgrade  # or pip install"
+        "  python -m pip install dask[dataframe] --upgrade  # or python -m pip install"
     )
     raise ImportError(str(e) + "\n\n" + msg)

--- a/dask/datasets.py
+++ b/dask/datasets.py
@@ -145,7 +145,7 @@ def make_people(npartitions=10, records_per_partition=1000, seed=None, locale="e
     import_required(
         "mimesis",
         "The mimesis module is required for this function.  Try:\n"
-        "  pip install mimesis",
+        "  python -m pip install mimesis",
     )
 
     schema = lambda field: {

--- a/dask/distributed.py
+++ b/dask/distributed.py
@@ -6,6 +6,6 @@ except ImportError:
         "Dask's distributed scheduler is not installed.\n\n"
         "Please either conda or pip install dask distributed:\n\n"
         "  conda install dask distributed          # either conda install\n"
-        "  pip install dask distributed --upgrade  # or pip install"
+        "  python -m pip install dask distributed --upgrade  # or python -m pip install"
     )
     raise ImportError(msg)

--- a/dask/hashing.py
+++ b/dask/hashing.py
@@ -12,7 +12,7 @@ hashers = []  # In decreasing performance order
 # - SHA1 is significantly faster than all other hashlib algorithms
 
 try:
-    import cityhash  # `pip install cityhash`
+    import cityhash  # `python -m pip install cityhash`
 except ImportError:
     pass
 else:
@@ -31,7 +31,7 @@ else:
         hashers.append(_hash_cityhash)
 
 try:
-    import xxhash  # `pip install xxhash`
+    import xxhash  # `python -m pip install xxhash`
 except ImportError:
     pass
 else:
@@ -45,7 +45,7 @@ else:
     hashers.append(_hash_xxhash)
 
 try:
-    import mmh3  # `pip install mmh3`
+    import mmh3  # `python -m pip install mmh3`
 except ImportError:
     pass
 else:

--- a/dask/tests/test_datasets.py
+++ b/dask/tests/test_datasets.py
@@ -24,7 +24,7 @@ def test_no_mimesis():
         with pytest.raises(Exception) as info:
             dask.datasets.make_people()
 
-        assert "pip install mimesis" in str(info.value)
+        assert "python -m pip install mimesis" in str(info.value)
 
 
 def test_deterministic():

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -2,7 +2,7 @@ To build a local copy of the Dask documentation, install the packages in
 ``requirements-docs.txt`` and run ``make html``. These dependencies can be
 installed with ``pip``::
 
-  pip install -r requirements-docs.txt
+  python -m pip install -r requirements-docs.txt
 
 or ``conda``::
 

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -98,11 +98,11 @@ environment on your computer to compile them when installing with ``pip``::
 Install Dask and dependencies::
 
    cd dask
-   pip install -e ".[complete]"
+   python -m pip install -e ".[complete]"
 
 For development, Dask uses the following additional dependencies::
 
-   pip install pytest moto
+   python -m pip install pytest moto
 
 
 Run Tests
@@ -256,7 +256,7 @@ Dask uses `Black <https://black.readthedocs.io/en/stable/>`_ and
 format throughout the project. ``black`` and ``flake8`` can be installed with
 ``pip``::
 
-   pip install black flake8
+   python -m pip install black flake8
 
 and then run from the root of the Dask repository::
 
@@ -270,7 +270,7 @@ Optionally, you may wish to setup `pre-commit hooks <https://pre-commit.com/>`_
 to automatically run ``black`` and ``flake8`` when you make a git commit. This
 can be done by installing ``pre-commit``::
 
-   pip install pre-commit
+   python -m pip install pre-commit
 
 and then running::
 
@@ -292,7 +292,7 @@ and API documentation.
 To build the documentation locally, first install the necessary requirements::
 
    cd docs/
-   pip install -r requirements-docs.txt
+   python -m pip install -r requirements-docs.txt
 
 Then build the documentation with ``make``::
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -17,7 +17,7 @@ Optionally, you can obtain a minimal Dask installation using the following comma
 
    conda install dask-core
 
-This will install a minimal set of dependencies required to run Dask similar to (but not exactly the same as) ``pip install dask`` below.
+This will install a minimal set of dependencies required to run Dask similar to (but not exactly the same as) ``python -m pip install dask`` below.
 
 Pip
 ---
@@ -27,22 +27,22 @@ dataframes, ...)  This installs both Dask and dependencies like NumPy, Pandas,
 and so on that are necessary for different workloads.  This is often the right
 choice for Dask users::
 
-   pip install "dask[complete]"    # Install everything
+   python -m pip install "dask[complete]"    # Install everything
 
 You can also install only the Dask library.  Modules like ``dask.array``,
 ``dask.dataframe``, ``dask.delayed``, or ``dask.distributed`` won't work until you also install NumPy,
 Pandas, Toolz, or Tornado, respectively.  This is common for downstream library
 maintainers::
 
-   pip install dask                # Install only core parts of dask
+   python -m pip install dask                # Install only core parts of dask
 
 We also maintain other dependency sets for different subsets of functionality::
 
-   pip install "dask[array]"       # Install requirements for dask array
-   pip install "dask[bag]"         # Install requirements for dask bag
-   pip install "dask[dataframe]"   # Install requirements for dask dataframe
-   pip install "dask[delayed]"     # Install requirements for dask delayed
-   pip install "dask[distributed]" # Install requirements for distributed dask
+   python -m pip install "dask[array]"       # Install requirements for dask array
+   python -m pip install "dask[bag]"         # Install requirements for dask bag
+   python -m pip install "dask[dataframe]"   # Install requirements for dask dataframe
+   python -m pip install "dask[delayed]"     # Install requirements for dask delayed
+   python -m pip install "dask[distributed]" # Install requirements for distributed dask
 
 We have these options so that users of the lightweight core Dask scheduler
 aren't required to download the more exotic dependencies of the collections
@@ -57,11 +57,11 @@ To install Dask from source, clone the repository from `github
 
     git clone https://github.com/dask/dask.git
     cd dask
-    pip install .
+    python -m pip install .
 
 You can also install all dependencies as well::
 
-    pip install ".[complete]"
+    python -m pip install ".[complete]"
 
 You can view the list of all dependencies within the ``extras_require`` field
 of ``setup.py``.
@@ -69,7 +69,7 @@ of ``setup.py``.
 
 Or do a developer install by using the ``-e`` flag::
 
-    pip install -e .
+    python -m pip install -e .
 
 Anaconda
 --------

--- a/docs/source/setup/docker.rst
+++ b/docs/source/setup/docker.rst
@@ -46,7 +46,7 @@ they will trigger calls to the following respectively::
 
    apt-get install $EXTRA_APT_PACKAGES
    conda install $EXTRA_CONDA_PACKAGES
-   pip install $EXTRA_PIP_PACKAGES
+   python -m pip install $EXTRA_PIP_PACKAGES
 
 For example, the following ``conda`` installs the ``joblib`` package into
 the Dask worker software environment:

--- a/docs/source/setup/ssh.rst
+++ b/docs/source/setup/ssh.rst
@@ -39,7 +39,7 @@ Or you can specify a hostfile that includes a list of hosts::
 
 The ``dask-ssh`` utility depends on the ``paramiko``::
 
-    pip install paramiko
+    python -m pip install paramiko
 
 .. note::
 


### PR DESCRIPTION
Fix #5857

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
