### PR TITLE
Move over dashboard connection docs

### DIFF
--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -124,12 +124,45 @@ The ``progress`` function takes a Dask object that is executing in the backgroun
    x.compute()      # convert to final result when done if desired
 
 
-External Documentation
-----------------------
+Connecting to the Dashboard
+---------------------------
 
-More in-depth technical documentation about Dask's distributed scheduler is
-available at https://distributed.dask.org/en/latest
+Some computer networks may restrict access to certain ports or only allow
+access from certain machines.  If you are unable to access the dashboard then
+you may want to contact your IT administrator.
 
+Some common problems and solutions follow:
+
+Specify an accessible port
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some clusters restrict the ports that are visible to the outside world.  These
+ports may include the default port for the web interface, ``8787``.  There are
+a few ways to handle this:
+
+1.  Open port ``8787`` to the outside world.  Often this involves asking your
+    cluster administrator.
+2.  Use a different port that is publicly accessible using the
+    ``--dashboard-address :8787`` option on the ``dask-scheduler`` command.
+3.  Use fancier techniques, like `Port Forwarding`_
+
+Port Forwarding
+~~~~~~~~~~~~~~~
+
+If you have SSH access then one way to gain access to a blocked port is through
+SSH port forwarding. A typical use case looks like the following:
+
+.. code:: bash
+
+   local$ ssh -L 8000:localhost:8787 user@remote
+   remote$ dask-scheduler  # now, the web UI is visible at localhost:8000
+   remote$ # continue to set up dask if needed -- add workers, etc
+
+It is then possible to go to ``localhost:8000`` and see Dask Web UI. This same approach is
+not specific to dask.distributed, but can be used by any service that operates over a
+network, such as Jupyter notebooks. For example, if we chose to do this we could
+forward port 8888 (the default Jupyter port) to port 8001 with
+``ssh -L 8001:localhost:8888 user@remote``.
 
 API
 ---


### PR DESCRIPTION
We're removing the old docs in distributed.dask.org

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
