### PR TITLE
Require pandas>=0.23

### DIFF
--- a/continuous_integration/appveyor/environment.yaml
+++ b/continuous_integration/appveyor/environment.yaml
@@ -6,7 +6,7 @@ dependencies:
   # required dependencies
   - python=3.6.*
   - numpy>=1.13.0,<=1.16.4    # >= 1.17.0 breaks from https://github.com/pydata/sparse/issues/257
-  - pandas>=0.21.0
+  - pandas>=0.23.0
   - pytest
   - cloudpickle
   - distributed

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -6,7 +6,6 @@ import pandas as pd
 
 
 PANDAS_VERSION = LooseVersion(pd.__version__)
-PANDAS_GT_0230 = PANDAS_VERSION >= LooseVersion("0.23.0")
 PANDAS_GT_0240 = PANDAS_VERSION >= LooseVersion("0.24.0")
 PANDAS_GT_0250 = PANDAS_VERSION >= LooseVersion("0.25.0")
 PANDAS_GT_100 = PANDAS_VERSION >= LooseVersion("1.0.0")

--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -3,7 +3,6 @@ import pandas as pd
 from toolz import partial
 
 from ..utils import derived_from
-from .utils import PANDAS_VERSION
 
 
 def maybe_wrap_pandas(obj, x):
@@ -154,11 +153,6 @@ class StringAccessor(Accessor):
     def extractall(self, pat, flags=0):
         # TODO: metadata inference here won't be necessary for pandas >= 0.23.0
         meta = self._series._meta.str.extractall(pat, flags=flags)
-        if PANDAS_VERSION < "0.23.0":
-            index_name = self._series.index.name
-            meta.index = pd.MultiIndex(
-                levels=[[], []], labels=[[], []], names=[index_name, "match"]
-            )
         return self._series.map_partitions(
             str_extractall, pat, flags, meta=meta, token="str-extractall"
         )

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -6,7 +6,6 @@ from pandas.api.types import is_categorical_dtype, union_categoricals
 from toolz import partition
 
 from .utils import (
-    PANDAS_VERSION,
     is_series_like,
     is_dataframe_like,
     PANDAS_GT_0250,
@@ -14,11 +13,6 @@ from .utils import (
     group_split_dispatch,
 )
 from ..utils import Dispatch
-
-if PANDAS_VERSION >= "0.23":
-    concat_kwargs = {"sort": False}
-else:
-    concat_kwargs = {}
 
 # ---------------------------------
 # indexing
@@ -151,7 +145,7 @@ def describe_aggregate(values):
             if name not in names:
                 names.append(name)
 
-    return pd.concat(values, axis=1, **concat_kwargs).reindex(names)
+    return pd.concat(values, axis=1, sort=False).reindex(names)
 
 
 def describe_numeric_aggregate(stats, name=None, is_timedelta_col=False):
@@ -173,7 +167,7 @@ def describe_numeric_aggregate(stats, name=None, is_timedelta_col=False):
         q = q.to_frame()
     part3 = typ([max], index=["max"])
 
-    result = pd.concat([part1, q, part3], **concat_kwargs)
+    result = pd.concat([part1, q, part3], sort=False)
 
     if isinstance(result, pd.Series):
         result.name = name
@@ -377,7 +371,7 @@ def concat(dfs, axis=0, join="outer", uniform=False, filter_warning=True):
 @concat_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
 def concat_pandas(dfs, axis=0, join="outer", uniform=False, filter_warning=True):
     if axis == 1:
-        return pd.concat(dfs, axis=axis, join=join, **concat_kwargs)
+        return pd.concat(dfs, axis=axis, join=join, sort=False)
 
     # Support concatenating indices along axis 0
     if isinstance(dfs[0], pd.Index):
@@ -448,7 +442,7 @@ def concat_pandas(dfs, axis=0, join="outer", uniform=False, filter_warning=True)
                 cat_mask = pd.concat(
                     [(df.dtypes == "category").to_frame().T for df in dfs3],
                     join=join,
-                    **concat_kwargs
+                    sort=False,
                 ).any()
 
         if cat_mask.any():
@@ -457,7 +451,7 @@ def concat_pandas(dfs, axis=0, join="outer", uniform=False, filter_warning=True)
             out = pd.concat(
                 [df[df.columns.intersection(not_cat)] for df in dfs3],
                 join=join,
-                **concat_kwargs
+                sort=False,
             )
             temp_ind = out.index
             for col in cat_mask.index.difference(not_cat):
@@ -489,7 +483,7 @@ def concat_pandas(dfs, axis=0, join="outer", uniform=False, filter_warning=True)
                 warnings.simplefilter("ignore", RuntimeWarning)
                 if filter_warning:
                     warnings.simplefilter("ignore", FutureWarning)
-                out = pd.concat(dfs3, join=join, **concat_kwargs)
+                out = pd.concat(dfs3, join=join, sort=False)
     else:
         if is_categorical_dtype(dfs2[0].dtype):
             if ind is None:
@@ -498,7 +492,7 @@ def concat_pandas(dfs, axis=0, join="outer", uniform=False, filter_warning=True)
         with warnings.catch_warnings():
             if filter_warning:
                 warnings.simplefilter("ignore", FutureWarning)
-            out = pd.concat(dfs2, join=join, **concat_kwargs)
+            out = pd.concat(dfs2, join=join, sort=False)
     # Re-add the index if needed
     if ind is not None:
         out.index = ind

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -80,7 +80,7 @@ from .core import (
 from .io import from_pandas
 from . import methods
 from .shuffle import shuffle, rearrange_by_divisions
-from .utils import strip_unknown_categories, is_series_like, asciitable, PANDAS_GT_0230
+from .utils import strip_unknown_categories, is_series_like, asciitable
 
 
 def align_partitions(*dfs):
@@ -719,7 +719,7 @@ def _concat_compat(frames, left, right):
     if PANDAS_GT_100:
         # join_axes removed
         return (pd.concat, frames, 0, "outer", False, None, None, None, False, False)
-    elif PANDAS_GT_0230:
+    else:
         # (axis, join, join_axis, ignore_index, keys, levels, names, verify_integrity, sort)
         # we only care about sort, to silence warnings.
         return (
@@ -735,9 +735,6 @@ def _concat_compat(frames, left, right):
             False,
             False,
         )
-    else:
-        columns = get_unsorted_columns([left, right])
-        return (concat_and_unsort, frames, columns)
 
 
 def merge_asof_indexed(left, right, **kwargs):

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from .core import Series, DataFrame, map_partitions, apply_concat_apply
 from . import methods
-from .utils import is_categorical_dtype, is_scalar, has_known_categories, PANDAS_VERSION
+from .utils import is_categorical_dtype, is_scalar, has_known_categories
 from ..utils import M
 import sys
 
@@ -103,17 +103,6 @@ def get_dummies(
     --------
     pandas.get_dummies
     """
-    if PANDAS_VERSION >= "0.23.0":
-        # dtype added to pandas
-        kwargs["dtype"] = dtype
-    elif dtype != np.uint8:
-        # User specified something other than the default.
-        raise ValueError(
-            "Your version of pandas is '{}'. "
-            "The 'dtype' keyword was added in pandas "
-            "0.23.0.".format(PANDAS_VERSION)
-        )
-
     if isinstance(data, (pd.Series, pd.DataFrame)):
         return pd.get_dummies(
             data,
@@ -123,6 +112,7 @@ def get_dummies(
             columns=columns,
             sparse=sparse,
             drop_first=drop_first,
+            dtype=dtype,
             **kwargs
         )
 

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -158,6 +158,7 @@ def get_dummies(
         columns=columns,
         sparse=sparse,
         drop_first=drop_first,
+        dtype=dtype,
         **kwargs
     )
 
@@ -171,6 +172,7 @@ def get_dummies(
         sparse=sparse,
         drop_first=drop_first,
         meta=meta,
+        dtype=dtype,
         **kwargs
     )
 

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -5,7 +5,7 @@ from pandas.core.window import Rolling as pd_Rolling
 from numbers import Integral
 
 from ..base import tokenize
-from ..utils import M, funcname, derived_from
+from ..utils import M, funcname, derived_from, has_keyword
 from ..highlevelgraph import HighLevelGraph
 from ._compat import PANDAS_GT_100, PANDAS_VERSION
 from .core import _emulate
@@ -404,8 +404,9 @@ class Rolling(object):
         compat_kwargs = {}
         kwargs = kwargs or {}
         args = args or ()
-
-        if PANDAS_GT_100:
+        meta = self.obj._meta.rolling(0)
+        if has_keyword(meta, "engine"):
+            # PANDAS_GT_100
             compat_kwargs = dict(engine=engine, engine_kwargs=engine_kwargs)
         elif engine != "cython" or engine_kwargs is not None:
             raise NotImplementedError(

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -7,8 +7,9 @@ from numbers import Integral
 from ..base import tokenize
 from ..utils import M, funcname, derived_from
 from ..highlevelgraph import HighLevelGraph
+from .compat import PANDAS_GT_100
 from .core import _emulate
-from .utils import make_meta, PANDAS_VERSION
+from .utils import make_meta
 from . import methods
 
 
@@ -391,20 +392,28 @@ class Rolling(object):
         return self._call_method("quantile", quantile)
 
     @derived_from(pd_Rolling)
-    def apply(self, func, args=(), kwargs={}, **kwds):
-        # TODO: In a future version of pandas this will change to
-        # raw=False. Think about inspecting the function signature and setting
-        # to that?
-        if PANDAS_VERSION >= "0.23.0":
-            kwds.setdefault("raw", None)
-        else:
-            if kwargs:
-                msg = (
-                    "Invalid argument to 'apply'. Keyword arguments "
-                    "should be given as a dict to the 'kwargs' argument. "
-                )
-                raise TypeError(msg)
-        return self._call_method("apply", func, args=args, kwargs=kwargs, **kwds)
+    def apply(
+        self,
+        func,
+        raw=None,
+        engine="cython",
+        engine_kwargs=None,
+        args=None,
+        kwargs=None,
+    ):
+        if raw is None and PANDAS_GT_100:
+            # pandas changed the default
+            raw = False
+
+        return self._call_method(
+            "apply",
+            func,
+            raw=raw,
+            engine=engine,
+            engine_kwargs=engine_kwargs,
+            args=None,
+            kwargs=None,
+        )
 
     @derived_from(pd_Rolling)
     def aggregate(self, func, args=(), kwargs={}, **kwds):

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -411,8 +411,8 @@ class Rolling(object):
             raw=raw,
             engine=engine,
             engine_kwargs=engine_kwargs,
-            args=None,
-            kwargs=None,
+            args=args,
+            kwargs=kwargs,
         )
 
     @derived_from(pd_Rolling)

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -7,7 +7,7 @@ from numbers import Integral
 from ..base import tokenize
 from ..utils import M, funcname, derived_from
 from ..highlevelgraph import HighLevelGraph
-from .compat import PANDAS_GT_100
+from ._compat import PANDAS_GT_100
 from .core import _emulate
 from .utils import make_meta
 from . import methods

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -12,7 +12,7 @@ import dask.array as da
 from dask.array.numpy_compat import _numpy_118
 import dask.dataframe as dd
 from dask.dataframe import _compat
-from dask.dataframe._compat import tm, PANDAS_GT_0230, PANDAS_GT_100
+from dask.dataframe._compat import tm, PANDAS_GT_100
 from dask.base import compute_as_if_collection
 from dask.utils import put_lines, M
 
@@ -2119,10 +2119,7 @@ def test_select_dtypes(include, exclude):
 
     if not PANDAS_GT_100:
         # removed in pandas 1.0
-        if PANDAS_GT_0230:
-            ctx = pytest.warns(FutureWarning)
-        else:
-            ctx = pytest.warns(None)
+        ctx = pytest.warns(FutureWarning)
 
         with ctx:
             tm.assert_series_equal(a.get_ftype_counts(), df.get_ftype_counts())

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -32,10 +32,7 @@ def test_loc():
     assert_eq(d.loc[3:], full.loc[3:])
     assert_eq(d.loc[[5]], full.loc[[5]])
 
-    if PANDAS_VERSION >= "0.23.0":
-        expected_warning = FutureWarning
-    else:
-        expected_warning = None
+    expected_warning = FutureWarning
 
     if not PANDAS_GT_100:
         # removed in pandas 1.0

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -22,7 +22,6 @@ from dask.dataframe.utils import (
     make_meta,
     has_known_categories,
     clear_known_categories,
-    PANDAS_GT_0230,
 )
 
 import pytest
@@ -560,10 +559,7 @@ def test_concat(join):
     )
     ddf3 = dd.from_pandas(pdf3, 2)
 
-    if PANDAS_GT_0230:
-        kwargs = {"sort": False}
-    else:
-        kwargs = {}
+    kwargs = {"sort": False}
 
     for (dd1, dd2, pd1, pd2) in [(ddf1, ddf2, pdf1, pdf2), (ddf1, ddf3, pdf1, pdf3)]:
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -8,7 +8,7 @@ import pandas as pd
 from dask.base import compute_as_if_collection
 from dask.dataframe._compat import tm
 from dask.dataframe.core import _Frame
-from dask.dataframe.methods import concat, concat_kwargs
+from dask.dataframe.methods import concat
 from dask.dataframe.multi import (
     align_partitions,
     merge_indexed_dataframes,
@@ -528,7 +528,7 @@ def test_indexed_concat(join):
     B = pd.DataFrame({"x": [10, 20, 40, 50, 60, 80]}, index=[1, 2, 4, 5, 6, 8])
     b = dd.repartition(B, [1, 2, 5, 8])
 
-    expected = pd.concat([A, B], axis=0, join=join, **concat_kwargs)
+    expected = pd.concat([A, B], axis=0, join=join, sort=False)
     result = concat_indexed_dataframes([a, b], join=join)
     assert_eq(result, expected)
 
@@ -1398,7 +1398,7 @@ def test_concat2():
         pdcase = [_c.compute() for _c in case]
 
         with warnings.catch_warnings(record=True) as w:
-            expected = pd.concat(pdcase, **concat_kwargs)
+            expected = pd.concat(pdcase, sort=False)
 
         ctx = FutureWarning if w else None
 
@@ -1414,7 +1414,7 @@ def test_concat2():
             assert set(result.dask) == set(dd.concat(case).dask)
 
         with warnings.catch_warnings(record=True) as w:
-            expected = pd.concat(pdcase, join="inner", **concat_kwargs)
+            expected = pd.concat(pdcase, join="inner", sort=False)
 
         ctx = FutureWarning if w else None
 
@@ -1444,7 +1444,7 @@ def test_concat3():
     ddf3 = dd.from_pandas(pdf3, 2)
 
     with warnings.catch_warnings(record=True) as w:
-        expected = pd.concat([pdf1, pdf2], **concat_kwargs)
+        expected = pd.concat([pdf1, pdf2], sort=False)
 
     ctx = FutureWarning if w else None
 
@@ -1462,7 +1462,7 @@ def test_concat3():
         )
 
     with warnings.catch_warnings(record=True) as w:
-        expected = pd.concat([pdf1, pdf2, pdf3], **concat_kwargs)
+        expected = pd.concat([pdf1, pdf2, pdf3], sort=False)
 
     ctx = FutureWarning if w else None
 
@@ -1519,12 +1519,11 @@ def test_concat4_interleave_partitions():
         pdcase = [c.compute() for c in case]
 
         assert_eq(
-            dd.concat(case, interleave_partitions=True),
-            pd.concat(pdcase, **concat_kwargs),
+            dd.concat(case, interleave_partitions=True), pd.concat(pdcase, sort=False)
         )
         assert_eq(
             dd.concat(case, join="inner", interleave_partitions=True),
-            pd.concat(pdcase, join="inner", **concat_kwargs),
+            pd.concat(pdcase, join="inner", sort=False),
         )
 
     msg = "'join' must be 'inner' or 'outer'"
@@ -1584,7 +1583,7 @@ def test_concat5():
             # some cases will raise warning directly from pandas
             assert_eq(
                 dd.concat(case, interleave_partitions=True),
-                pd.concat(pdcase, **concat_kwargs),
+                pd.concat(pdcase, sort=False),
             )
 
         assert_eq(
@@ -1817,31 +1816,27 @@ def test_append2():
     meta = make_meta({"b": "i8", "c": "i8"})
     ddf3 = dd.DataFrame(dsk, "y", meta, [None, None])
 
-    assert_eq(ddf1.append(ddf2), ddf1.compute().append(ddf2.compute(), **concat_kwargs))
-    assert_eq(ddf2.append(ddf1), ddf2.compute().append(ddf1.compute(), **concat_kwargs))
+    assert_eq(ddf1.append(ddf2), ddf1.compute().append(ddf2.compute(), sort=False))
+    assert_eq(ddf2.append(ddf1), ddf2.compute().append(ddf1.compute(), sort=False))
 
     # different columns
-    assert_eq(ddf1.append(ddf3), ddf1.compute().append(ddf3.compute(), **concat_kwargs))
-    assert_eq(ddf3.append(ddf1), ddf3.compute().append(ddf1.compute(), **concat_kwargs))
+    assert_eq(ddf1.append(ddf3), ddf1.compute().append(ddf3.compute(), sort=False))
+    assert_eq(ddf3.append(ddf1), ddf3.compute().append(ddf1.compute(), sort=False))
 
     # Dask + pandas
     assert_eq(
-        ddf1.append(ddf2.compute()),
-        ddf1.compute().append(ddf2.compute(), **concat_kwargs),
+        ddf1.append(ddf2.compute()), ddf1.compute().append(ddf2.compute(), sort=False)
     )
     assert_eq(
-        ddf2.append(ddf1.compute()),
-        ddf2.compute().append(ddf1.compute(), **concat_kwargs),
+        ddf2.append(ddf1.compute()), ddf2.compute().append(ddf1.compute(), sort=False)
     )
 
     # different columns
     assert_eq(
-        ddf1.append(ddf3.compute()),
-        ddf1.compute().append(ddf3.compute(), **concat_kwargs),
+        ddf1.append(ddf3.compute()), ddf1.compute().append(ddf3.compute(), sort=False)
     )
     assert_eq(
-        ddf3.append(ddf1.compute()),
-        ddf3.compute().append(ddf1.compute(), **concat_kwargs),
+        ddf3.append(ddf1.compute()), ddf3.compute().append(ddf1.compute(), sort=False)
     )
 
 

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -5,18 +5,7 @@ import pytest
 import dask.dataframe as dd
 
 from dask.dataframe._compat import tm
-from dask.dataframe.utils import assert_eq, make_meta, PANDAS_VERSION, PANDAS_GT_0240
-
-
-skip_if_no_get_dummies_sparse = pytest.mark.skipif(
-    PANDAS_VERSION < "0.23.0", reason="sparse added."
-)
-skip_if_no_get_dummies_dtype = pytest.mark.skipif(
-    PANDAS_VERSION < "0.23.0", reason="dtype added."
-)
-skip_if_get_dummies_dtype = pytest.mark.skipif(
-    PANDAS_VERSION >= "0.23.0", reason="dtype added."
-)
+from dask.dataframe.utils import assert_eq, make_meta, PANDAS_GT_0240
 
 
 @pytest.mark.parametrize(
@@ -119,7 +108,6 @@ def test_get_dummies_sparse():
     assert pd.api.types.is_sparse(res.a_a.compute())
 
 
-@skip_if_no_get_dummies_sparse
 def test_get_dummies_sparse_mix():
     df = pd.DataFrame(
         {
@@ -141,7 +129,6 @@ def test_get_dummies_sparse_mix():
     assert pd.api.types.is_sparse(res.A_a.compute())
 
 
-@skip_if_no_get_dummies_dtype
 def test_get_dummies_dtype():
     df = pd.DataFrame(
         {
@@ -159,22 +146,6 @@ def test_get_dummies_dtype():
     # dask's get_dummies on a pandas dataframe.
     assert_eq(dd.get_dummies(df, dtype="float64"), exp)
     assert res.compute().A_a.dtype == "float64"
-
-
-@skip_if_get_dummies_dtype
-def test_get_dummies_dtype_raises():
-    df = pd.DataFrame(
-        {
-            "A": pd.Categorical(["a", "b", "a"], categories=["a", "b", "c"]),
-            "B": [0, 0, 1],
-        }
-    )
-    ddf = dd.from_pandas(df, 2)
-
-    with pytest.raises(ValueError) as m:
-        dd.get_dummies(ddf, dtype="float64")
-
-    assert m.match("0.23.0")
 
 
 def test_get_dummies_errors():

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -146,10 +146,7 @@ def test_rolling_methods(method, args, window, center, check_less_precise):
     # DataFrame
     prolling = df.rolling(window, center=center)
     drolling = ddf.rolling(window, center=center)
-    if method == "apply" and PANDAS_VERSION >= "0.23.0":
-        kwargs = {"raw": False}
-    else:
-        kwargs = {}
+    kwargs = {"raw": False}
     assert_eq(
         getattr(prolling, method)(*args, **kwargs),
         getattr(drolling, method)(*args, **kwargs),
@@ -166,7 +163,7 @@ def test_rolling_methods(method, args, window, center, check_less_precise):
     )
 
 
-if PANDAS_VERSION <= "0.25.0" and PANDAS_VERSION >= "0.20.0":
+if PANDAS_VERSION <= "0.25.0":
     filter_panel_warning = pytest.mark.filterwarnings(
         "ignore::DeprecationWarning:pandas[.*]"
     )
@@ -187,12 +184,6 @@ def test_rolling_cov(window, center):
     prolling = df.b.rolling(window, center=center)
     drolling = ddf.b.rolling(window, center=center)
     assert_eq(prolling.cov(), drolling.cov())
-
-
-@pytest.mark.skipif(PANDAS_VERSION >= "0.23.0", reason="Raw is allowed.")
-def test_rolling_raw_pandas_lt_0230_raises():
-    with pytest.raises(TypeError):
-        df.rolling(2).apply(mad, raw=True)
 
 
 def test_rolling_raises():
@@ -274,10 +265,7 @@ def test_time_rolling_constructor():
 @pytest.mark.parametrize("window", ["1S", "2S", "3S", pd.offsets.Second(5)])
 def test_time_rolling_methods(method, args, window, check_less_precise):
     # DataFrame
-    if method == "apply" and PANDAS_VERSION >= "0.23.0":
-        kwargs = {"raw": False}
-    else:
-        kwargs = {}
+    kwargs = {"raw": False}
     prolling = ts.rolling(window)
     drolling = dts.rolling(window)
     assert_eq(
@@ -379,11 +367,23 @@ def test_rolling_agg_aggregate():
         ddf.rolling(window=3).agg({"A": [np.sum, np.mean]}),
     )
 
-    kwargs = {}
-    if PANDAS_VERSION >= "0.23.0":
-        kwargs["raw"] = True
-
+    kwargs = {"raw": True}
     assert_eq(
         df.rolling(window=3).apply(lambda x: np.std(x, ddof=1), **kwargs),
         ddf.rolling(window=3).apply(lambda x: np.std(x, ddof=1), **kwargs),
+    )
+
+
+@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="needs pandas>=1.0.0")
+def test_rolling_numba_engine():
+    pytest.importorskip("numba")
+    df = pd.DataFrame({"A": range(5), "B": range(0, 10, 2)})
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    def f(x):
+        return np.sum(x) + 5
+
+    assert_eq(
+        df.rolling(3).apply(f, engine="numba", raw=True),
+        ddf.rolling(3).apply(f, engine="numba", raw=True),
     )

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -146,7 +146,11 @@ def test_rolling_methods(method, args, window, center, check_less_precise):
     # DataFrame
     prolling = df.rolling(window, center=center)
     drolling = ddf.rolling(window, center=center)
-    kwargs = {"raw": False}
+    if method == "apply":
+        kwargs = {"raw": False}
+    else:
+        kwargs = {}
+
     assert_eq(
         getattr(prolling, method)(*args, **kwargs),
         getattr(drolling, method)(*args, **kwargs),

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -22,7 +22,6 @@ from pandas.api.types import (
 # include these here for compat
 from ._compat import (  # noqa: F401
     PANDAS_VERSION,
-    PANDAS_GT_0230,
     PANDAS_GT_0240,
     PANDAS_GT_0250,
     PANDAS_GT_100,
@@ -639,10 +638,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
             typename(type(x)),
         )
     elif is_dataframe_like(meta):
-        kwargs = dict()
-        if PANDAS_VERSION >= "0.23.0":
-            kwargs["sort"] = True
-        dtypes = pd.concat([x.dtypes, meta.dtypes], axis=1, **kwargs)
+        dtypes = pd.concat([x.dtypes, meta.dtypes], axis=1, sort=True)
         bad_dtypes = [
             (col, a, b)
             for col, a, b in dtypes.fillna("-").itertuples()

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -4,7 +4,7 @@ dask-sphinx-theme>=1.1.0
 sphinx-click
 toolz
 cloudpickle
-pandas>=0.19.0
+pandas>=0.23.0
 distributed
 fsspec
 scipy

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,11 @@ extras_require = {
         "cloudpickle >= 0.2.1",
         "fsspec >= 0.6.0",
         "toolz >= 0.7.3",
-        "partd >= 0.3.10"
+        "partd >= 0.3.10",
     ],
     "dataframe": [
         "numpy >= 1.13.0",
-        "pandas >= 0.21.0",
+        "pandas >= 0.23.0",
         "toolz >= 0.7.3",
         "partd >= 0.3.10",
         "fsspec >= 0.6.0",
@@ -30,39 +30,48 @@ extras_require["complete"] = sorted(
     {"PyYaml"} | {v for req in extras_require.values() for v in req}
 )
 
-packages = ['dask', 'dask.array', 'dask.bag', 'dask.bytes',
-            'dask.dataframe', 'dask.dataframe.io', 'dask.dataframe.tseries',
-            'dask.diagnostics']
+packages = [
+    "dask",
+    "dask.array",
+    "dask.bag",
+    "dask.bytes",
+    "dask.dataframe",
+    "dask.dataframe.io",
+    "dask.dataframe.tseries",
+    "dask.diagnostics",
+]
 
-tests = [p + '.tests' for p in packages]
+tests = [p + ".tests" for p in packages]
 
 # Only include pytest-runner in setup_requires if we're invoking tests
-if {'pytest', 'test', 'ptr'}.intersection(sys.argv):
-    setup_requires = ['pytest-runner']
+if {"pytest", "test", "ptr"}.intersection(sys.argv):
+    setup_requires = ["pytest-runner"]
 else:
     setup_requires = []
 
-setup(name='dask',
-      version=versioneer.get_version(),
-      cmdclass=versioneer.get_cmdclass(),
-      description='Parallel PyData with Task Scheduling',
-      url='https://github.com/dask/dask/',
-      maintainer='Matthew Rocklin',
-      maintainer_email='mrocklin@gmail.com',
-      license='BSD',
-      keywords='task-scheduling parallel numpy pandas pydata',
-      classifiers=[
-          "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.6",
-          "Programming Language :: Python :: 3.7",
-          "Programming Language :: Python :: 3.8",
-      ],
-      packages=packages + tests,
-      long_description=open('README.rst').read() if exists('README.rst') else '',
-      python_requires=">=3.6",
-      install_requires=[],
-      setup_requires=setup_requires,
-      tests_require=['pytest'],
-      extras_require=extras_require,
-      include_package_data=True,
-      zip_safe=False)
+setup(
+    name="dask",
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+    description="Parallel PyData with Task Scheduling",
+    url="https://github.com/dask/dask/",
+    maintainer="Matthew Rocklin",
+    maintainer_email="mrocklin@gmail.com",
+    license="BSD",
+    keywords="task-scheduling parallel numpy pandas pydata",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+    ],
+    packages=packages + tests,
+    long_description=open("README.rst").read() if exists("README.rst") else "",
+    python_requires=">=3.6",
+    install_requires=[],
+    setup_requires=setup_requires,
+    tests_require=["pytest"],
+    extras_require=extras_require,
+    include_package_data=True,
+    zip_safe=False,
+)


### PR DESCRIPTION
Turns out we didn't have a CI build pinned at `pandas==0.21.*` We do have one at `0.23.*`.