### PR TITLE
Avoid unnecessary __getitem__ in block() when chunks have correct dimensionality

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3301,7 +3301,10 @@ def block(arrays, allow_unknown_chunksizes=False):
     def atleast_nd(x, ndim):
         x = asanyarray(x)
         diff = max(ndim - x.ndim, 0)
-        return x[(None,) * diff + (Ellipsis,)]
+        if diff == 0:
+            return x
+        else:
+            return x[(None,) * diff + (Ellipsis,)]
 
     def format_index(index):
         return "arrays" + "".join("[{}]".format(i) for i in index)


### PR DESCRIPTION
This improves performance in ``block()`` by almost a factor of 2 when chunks have the same dimensionality as the final array. Here is an example:

```python
import numpy as np
import dask.array as da


class ArrayLikeObject:

    def __init__(self):
        self._array = np.ones((1, 1, 20, 30), dtype=float)
        self.shape = self._array.shape
        self.ndim = self._array.ndim
        self.dtype = self._array.dtype

    def __getitem__(self, item):
        return self._array[item]


def test_perf():
    meta = np.zeros((0,), dtype=float)
    chunks = [[[[da.from_array(ArrayLikeObject(), meta=meta)] * 269] * 6] * 4]
    da.block(chunks)
```

Before this patch:

```
In [2]: %timeit test_perf()                                                                                                                                          
1.09 s ± 152 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

After this patch:

```
In [2]: %timeit test_perf()                                                                                                                                          
580 ms ± 13.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

I haven't added any specific tests since both cases (same and different dimensionality) are likely already covered by the test suite, and this is just a performance improvement.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
