### PR TITLE
Better layer name synthesis for non-HLGs

### DIFF
--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -587,3 +587,12 @@ def test_atop_legacy():
     z = da.blockwise(inc, "i", x, "i", dtype=x.dtype)
     assert_eq(y, z)
     assert y.name == z.name
+
+
+def test_non_hlg():
+    # Regression test for https://github.com/dask/dask/issues/5850
+    a = da.from_array(np.ones(1, np.float64), chunks=(1,))
+    a.dask = dict(a.dask)  # Convert from HighLevelGraph to plain dict
+    b = da.from_array(np.zeros(1, np.float64), chunks=(1,))
+    x = a + b
+    assert_eq(x, a)

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -132,8 +132,8 @@ class HighLevelGraph(Mapping):
                         deps[name] |= set(collection.__dask_layers__())
                 else:
                     try:
-                        key = collection.__dask_layers__()[0]
-                    except (AttributeError, IndexError):
+                        [key] = collection.__dask_layers__()
+                    except AttributeError:
                         key = id(graph)
                     layers[key] = graph
                     deps[name].add(key)

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -131,7 +131,10 @@ class HighLevelGraph(Mapping):
                     with ignoring(AttributeError):
                         deps[name] |= set(collection.__dask_layers__())
                 else:
-                    key = id(graph)
+                    try:
+                        key = collection.__dask_layers__()[0]
+                    except (AttributeError, IndexError):
+                        key = id(graph)
                     layers[key] = graph
                     deps[name].add(key)
                     deps[key] = set()


### PR DESCRIPTION
when a dependent collection passed to HighLevelGraph.from_collections
has a `__dask_graph__` that is not a HighLevelGraph, the layer synthesised
for it was being named with `id()`. This caused problems, because there
are places in the code that assume that the layer name matches the key
names inside the layer (see #5850), and dask.array.utils._check_dsk
asserts that layer names are all tuples or strings, not integers.

Address withby naming the layer `collection.__dask_layers__()[0]`,
falling back to the old behaviour if `__dask_layers__` doesn't exist or
returns an empty tuple.  I'm not sure what the ideal behaviour is if
`__dask_layers__()` returns more than one element. The built-in
collections (array, dataframe, bag and delayed) all return a singleton;
xarray's Dataset can return multiple values, but it also returns a
HighLevelGraph from `__dask_graph__` so the issue doesn't arise.

Closes #5850.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
