### PR TITLE
Avoid using rewrite_blockwise for a singleton

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -551,7 +551,10 @@ def _optimize_blockwise(full_graph, keys=()):
                         stack.append(d)
 
             # Merge these Blockwise layers into one
-            new_layer = rewrite_blockwise([layers[l] for l in blockwise_layers])
+            if len(blockwise_layers) > 1:
+                new_layer = rewrite_blockwise([layers[l] for l in blockwise_layers])
+            else:
+                new_layer = layers[layer]
             out[layer] = new_layer
             dependencies[layer] = {k for k, v in new_layer.indices if v is not None}
         else:

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -551,10 +551,7 @@ def _optimize_blockwise(full_graph, keys=()):
                         stack.append(d)
 
             # Merge these Blockwise layers into one
-            if len(blockwise_layers) > 1:
-                new_layer = rewrite_blockwise([layers[l] for l in blockwise_layers])
-            else:
-                new_layer = layers[layer]
+            new_layer = rewrite_blockwise([layers[l] for l in blockwise_layers])
             out[layer] = new_layer
             dependencies[layer] = {k for k, v in new_layer.indices if v is not None}
         else:
@@ -584,6 +581,10 @@ def rewrite_blockwise(inputs):
     --------
     optimize_blockwise
     """
+    if len(inputs) == 1:
+        # Fast path: if there's only one input we can just use it as-is.
+        return inputs[0]
+
     inputs = {inp.output: inp for inp in inputs}
     dependencies = {
         inp.output: {d for d, v in inp.indices if v is not None and d in inputs}


### PR DESCRIPTION
rewrite_blockwise does a lot of work, which is unnecessary in the case
where only one Blockwise is passed to it. Skipping that work halves the
time for da.optimize in this simple example:

```python3
import timeit

import dask.array as da
import numpy as np

a = da.from_array(np.ones((1, 1)), chunks=1)
b = da.from_array(np.zeros((1, 1)), chunks=1)
c = a + b
dsk = c.__dask_graph__()
keys = c.__dask_keys__()
print(timeit.timeit('da.optimize(dsk, keys)', number=5000, globals=globals()))
```

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
