### PR TITLE
Push chunk override from map_blocks into blockwise

### DIFF
--- a/dask/array/blockwise.py
+++ b/dask/array/blockwise.py
@@ -145,11 +145,15 @@ def blockwise(
         chunkss, arrays = unify_chunks(*args)
     else:
         arginds = [(a, i) for (a, i) in toolz.partition(2, args) if i is not None]
-        if arginds:
-            arg, ind = max(arginds, key=lambda ai: len(ai[1]))
-            chunkss = dict(zip(ind, arg.chunks))
-        else:
-            chunkss = {}
+        chunkss = {}
+        # For each dimension, use the input chunking that has the most blocks;
+        # this will ensure that broadcasting works as expected, and in
+        # particular the number of blocks should be correct if the inputs are
+        # consistent.
+        for arg, ind in arginds:
+            for c, i in zip(arg.chunks, ind):
+                if i not in chunkss or len(c) > len(chunkss[i]):
+                    chunkss[i] = c
         arrays = args[::2]
 
     for k, v in new_axes.items():
@@ -220,6 +224,12 @@ def blockwise(
                 elif isinstance(adjust_chunks[ind], numbers.Integral):
                     chunks[i] = tuple(adjust_chunks[ind] for _ in chunks[i])
                 elif isinstance(adjust_chunks[ind], (tuple, list)):
+                    if len(adjust_chunks[ind]) != len(chunks[i]):
+                        raise ValueError(
+                            "Dimension {0} has {1} blocks, "
+                            "adjust_chunks specified with "
+                            "{2} blocks".format(i, len(chunks[i]), len(adjust_chunks[ind]))
+                        )
                     chunks[i] = tuple(adjust_chunks[ind])
                 else:
                     raise NotImplementedError(

--- a/dask/array/blockwise.py
+++ b/dask/array/blockwise.py
@@ -228,7 +228,9 @@ def blockwise(
                         raise ValueError(
                             "Dimension {0} has {1} blocks, "
                             "adjust_chunks specified with "
-                            "{2} blocks".format(i, len(chunks[i]), len(adjust_chunks[ind]))
+                            "{2} blocks".format(
+                                i, len(chunks[i]), len(adjust_chunks[ind])
+                            )
                         )
                     chunks[i] = tuple(adjust_chunks[ind])
                 else:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1370,6 +1370,14 @@ def test_map_blocks_with_kwargs():
     assert_eq(result, np.array([4, 9]))
 
 
+def test_map_blocks_infer_chunks_broadcast():
+    dx = da.from_array([[1, 2, 3, 4]], chunks=((1,), (2, 2)))
+    dy = da.from_array([[10, 20], [30, 40]], chunks=((1, 1), (2,)))
+    result = da.map_blocks(lambda x, y: x + y, dx, dy)
+    assert result.chunks == ((1, 1), (2, 2),)
+    assert_eq(result, np.array([[11, 22, 13, 24], [31, 42, 33, 44]]))
+
+
 def test_map_blocks_with_chunks():
     dx = da.ones((5, 3), chunks=(2, 2))
     dy = da.ones((5, 3), chunks=(2, 2))
@@ -2872,6 +2880,9 @@ def test_map_blocks_with_changed_dimension():
 
     with pytest.raises(ValueError):
         d.map_blocks(lambda b: b.sum(axis=0), chunks=((4, 4, 4),), drop_axis=0)
+
+    with pytest.raises(ValueError):
+        d.map_blocks(lambda b: b.sum(axis=1), chunks=((3, 4),), drop_axis=1)
 
     d = da.from_array(x, chunks=(4, 8))
     e = d.map_blocks(lambda b: b.sum(axis=1), drop_axis=1, dtype=d.dtype)


### PR DESCRIPTION
Instead of calling dask.array.blockwise and then fiddling with the
chunks under the hood, pass the new chunking scheme into blockwise.
The verification that the number of blocks didn't change is now made
inside blockwise, so it will be a bit more robust.

To make that verification work I also improved the code inside blockwise
that estimates the chunks up front (in the adjust_chunks=False case, as
used by map_blocks). Previously it made the arbitrary choice of taking
the input with the most indices. When there is broadcasting, that can
get the wrong *number* of blocks (which is what lead to bugs to
like #4299). It now, per dimension, takes the chunk scheme with the most
blocks. Note that this might alter the behaviour in cases where the
chunking schemes are inconsistent and no explicit chunking scheme is
provided, but I believe the behaviour was undefined to start with.

A benefit of this change is that it's now possible to detect cases where
the user-provided chunks have more than one element and there should
only be more than one element (previously the check was skipped because
broadcasting wasn't correctly handled, as a workaround for #4299).

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
