### PR TITLE
Make map_blocks with block_info produce a Blockwise

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -181,7 +181,16 @@ class Blockwise(Mapping):
             (name, tuple(ind) if ind is not None else ind) for name, ind in indices
         )
         self.numblocks = numblocks
-        self.concatenate = concatenate
+        # optimize_blockwise won't merge where `concatenate` doesn't match, so
+        # enforce a canonical value if there are no axes for reduction.
+        if all(
+            all(i in output_indices for i in ind)
+            for name, ind in indices
+            if ind is not None
+        ):
+            self.concatenate = None
+        else:
+            self.concatenate = concatenate
         self.new_axes = new_axes or {}
 
     def __repr__(self):


### PR DESCRIPTION
Previously, using map_blocks with block_info or block_id would denature
a Blockwise and do a substitution on every instantiation of the subgraph
callable to inject the block info.

Instead, create a dask array whose elements are the block infos, and
pass this as an extra parameter into `dask.array.blockwise`. This makes
the layer a Blockwise, and hence a candidate for `rewrite_blockwise`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
