### PR TITLE
Add cloudpickle to dask.dataframe dependencies

### DIFF
--- a/continuous_integration/travis/travis-mindeps-array-dataframe.yaml
+++ b/continuous_integration/travis/travis-mindeps-array-dataframe.yaml
@@ -5,6 +5,7 @@ dependencies:
   # required dependencies
   - python=3.6
   # optional dependencies pulled in by pip install dask[array, dataframe]
+  - cloudpickle
   - numpy=1.15
   - pandas=0.23
   - partd

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,10 @@ extras_require = {
         "cloudpickle >= 0.2.1",
         "fsspec >= 0.6.0",
         "toolz >= 0.7.3",
-        "partd >= 0.3.10"
+        "partd >= 0.3.10",
     ],
     "dataframe": [
+        "cloudpickle >= 0.2.1",
         "numpy >= 1.13.0",
         "pandas >= 0.21.0",
         "toolz >= 0.7.3",
@@ -30,39 +31,48 @@ extras_require["complete"] = sorted(
     {"PyYaml"} | {v for req in extras_require.values() for v in req}
 )
 
-packages = ['dask', 'dask.array', 'dask.bag', 'dask.bytes',
-            'dask.dataframe', 'dask.dataframe.io', 'dask.dataframe.tseries',
-            'dask.diagnostics']
+packages = [
+    "dask",
+    "dask.array",
+    "dask.bag",
+    "dask.bytes",
+    "dask.dataframe",
+    "dask.dataframe.io",
+    "dask.dataframe.tseries",
+    "dask.diagnostics",
+]
 
-tests = [p + '.tests' for p in packages]
+tests = [p + ".tests" for p in packages]
 
 # Only include pytest-runner in setup_requires if we're invoking tests
-if {'pytest', 'test', 'ptr'}.intersection(sys.argv):
-    setup_requires = ['pytest-runner']
+if {"pytest", "test", "ptr"}.intersection(sys.argv):
+    setup_requires = ["pytest-runner"]
 else:
     setup_requires = []
 
-setup(name='dask',
-      version=versioneer.get_version(),
-      cmdclass=versioneer.get_cmdclass(),
-      description='Parallel PyData with Task Scheduling',
-      url='https://github.com/dask/dask/',
-      maintainer='Matthew Rocklin',
-      maintainer_email='mrocklin@gmail.com',
-      license='BSD',
-      keywords='task-scheduling parallel numpy pandas pydata',
-      classifiers=[
-          "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.6",
-          "Programming Language :: Python :: 3.7",
-          "Programming Language :: Python :: 3.8",
-      ],
-      packages=packages + tests,
-      long_description=open('README.rst').read() if exists('README.rst') else '',
-      python_requires=">=3.6",
-      install_requires=[],
-      setup_requires=setup_requires,
-      tests_require=['pytest'],
-      extras_require=extras_require,
-      include_package_data=True,
-      zip_safe=False)
+setup(
+    name="dask",
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+    description="Parallel PyData with Task Scheduling",
+    url="https://github.com/dask/dask/",
+    maintainer="Matthew Rocklin",
+    maintainer_email="mrocklin@gmail.com",
+    license="BSD",
+    keywords="task-scheduling parallel numpy pandas pydata",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+    ],
+    packages=packages + tests,
+    long_description=open("README.rst").read() if exists("README.rst") else "",
+    python_requires=">=3.6",
+    install_requires=[],
+    setup_requires=setup_requires,
+    tests_require=["pytest"],
+    extras_require=extras_require,
+    include_package_data=True,
+    zip_safe=False,
+)


### PR DESCRIPTION
This PR adds `cloudpickle` as a dependency for Dask DataFrame. In #5804 we added a `lambda` function that results in a non-deterministic key test failures when `cloudpickle` isn't installed (xref https://travis-ci.org/dask/dask/jobs/647052775#L833-L865). 

Alternatively, we could just move the `lambda` to a top level function in `dask/dataframe/core.py` that can be serialized by `pickle`. However, I suspect adding `cloudpickle` as a dependency isn't too big of a deal and will help us avoid this type of thing in the future. 

cc @TomAugspurger 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
