### PR TITLE
`quote` should quote dicts too

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -463,6 +463,6 @@ def quote(x):
     >>> quote((add, 1, 2))  # doctest: +SKIP
     (literal<type=tuple>,)
     """
-    if istask(x) or type(x) is list:
+    if istask(x) or type(x) is list or type(x) is dict:
         return (literal(x),)
     return x

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -250,7 +250,7 @@ def test_subs_unexpected_hashable_key():
 
 
 def test_quote():
-    literals = [[1, 2, 3], (add, 1, 2), [1, [2, 3]], (add, 1, (add, 2, 3))]
+    literals = [[1, 2, 3], (add, 1, 2), [1, [2, 3]], (add, 1, (add, 2, 3)), {"x": "x"}]
 
     for l in literals:
         assert core.get({"x": quote(l)}, "x") == l


### PR DESCRIPTION
Closes #5904.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
