### PR TITLE
Improve accuracy of estimate_graph_size for rechunk

### DIFF
--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -264,7 +264,11 @@ def estimate_graph_size(old_chunks, new_chunks):
     # Estimate the number of intermediate blocks that will be produced
     # (we don't use intersect_chunks() which is much more expensive)
     crossed_size = reduce(
-        mul, (len(oc) + len(nc) for oc, nc in zip(old_chunks, new_chunks))
+        mul,
+        (
+            (len(oc) + len(nc) - 1 if oc != nc else len(oc))
+            for oc, nc in zip(old_chunks, new_chunks)
+        ),
     )
     return crossed_size
 

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -314,6 +314,8 @@ def test_plan_rechunk():
     _assert_steps(steps, [(c, c)])
     steps = _plan((f, c), (c, c))
     _assert_steps(steps, [(c, c)])
+    steps = _plan((c, c, c, c), (c, f, c, c))
+    _assert_steps(steps, [(c, f, c, c)])
 
     # An intermediate is used to reduce graph size
     steps = _plan((f, c), (c, f))


### PR DESCRIPTION
There are two improvements:
1. Special-case dimensions where the old and new chunking are the same
   (there is no expansion). When rechunking on only 1 axis in an
   n-dimensional array, this reduces the estimate by 2^(n-1).
2. Subtract 1 from per-dimension estimate, because the intersection of A
   chunks and B chunks cannot give more than A+B-1. In many cases this
   will be only a minor difference, but it can bring some cases just
   under the threshold. For example, 1D rechunking should now always
   be single-pass with threshold=1, whereas previously it would always
   be multi-pass.

- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
