### PR TITLE
Deprecate doc_wraps

### DIFF
--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -1,4 +1,5 @@
 import numbers
+import warnings
 from itertools import product
 from numbers import Integral
 from operator import getitem
@@ -16,7 +17,22 @@ from .core import (
 from .creation import arange
 from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
-from ..utils import ignoring, random_state_data, derived_from
+from ..utils import ignoring, random_state_data, derived_from, skip_doctest
+
+
+def doc_wraps(func):
+    """ Copy docstring from one function to another """
+    warnings.warn(
+        "dask.array.random.doc_wraps is deprecated and will be removed in a future version",
+        FutureWarning,
+    )
+
+    def _(func2):
+        if func.__doc__ is not None:
+            func2.__doc__ = skip_doctest(func.__doc__)
+        return func2
+
+    return _
 
 
 class RandomState(object):

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -356,3 +356,11 @@ def test_randint_dtype():
     assert_eq(x, x)
     assert x.dtype == "uint8"
     assert x.compute().dtype == "uint8"
+
+
+def test_doc_wraps_deprecated():
+    with pytest.warns(FutureWarning):
+
+        @da.random.doc_wraps(np.random.normal)
+        def f():
+            pass


### PR DESCRIPTION
I was (probably inappropriately) using this in Dask-ML. Are people OK
with deprecating this for a bit?

xref https://github.com/dask/dask-ml/pull/609, which removes the usage.