### PR TITLE
Cache result of Array.shape

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -667,7 +667,7 @@ def map_blocks(
                         (
                             cached_cumsum(arg.chunks[j], initial_zero=True)
                             if ind in out_ind
-                            else np.array([0, arg.shape[j]])
+                            else [0, arg.shape[j]]
                         )
                         for j, ind in enumerate(in_ind)
                     ]
@@ -1126,7 +1126,7 @@ class Array(DaskMethodsMixin):
 
     @property
     def shape(self):
-        return tuple(map(sum, self.chunks))
+        return tuple(cached_cumsum(c, initial_zero=True)[-1] for c in self.chunks)
 
     @property
     def chunksize(self):

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -579,8 +579,8 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
 
     diag_chunks = []
     chunk_offsets = []
-    cum1 = list(cached_cumsum(a.chunks[axis1], initial_zero=True)[:-1])
-    cum2 = list(cached_cumsum(a.chunks[axis2], initial_zero=True)[:-1])
+    cum1 = cached_cumsum(a.chunks[axis1], initial_zero=True)[:-1]
+    cum2 = cached_cumsum(a.chunks[axis2], initial_zero=True)[:-1]
     for co1, c1 in zip(cum1, a.chunks[axis1]):
         chunk_offsets.append([])
         for co2, c2 in zip(cum2, a.chunks[axis2]):

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1,12 +1,13 @@
 from itertools import product
 import math
 from numbers import Integral, Number
-from operator import getitem, itemgetter
+from operator import add, getitem, itemgetter
 import warnings
 import functools
+import bisect
 
 import numpy as np
-from toolz import memoize, merge, pluck, concat
+from toolz import memoize, merge, pluck, concat, accumulate
 
 from .. import core
 from ..highlevelgraph import HighLevelGraph
@@ -400,7 +401,7 @@ def _slice_1d(dim_shape, lengths, index):
 
     if isinstance(index, Integral):
         # use right-side search to be consistent with previous result
-        i = chunk_boundaries.searchsorted(index, side="right")
+        i = bisect.bisect_right(chunk_boundaries, index)
         if i > 0:
             # the very first chunk has no relative shift
             ind = index - chunk_boundaries[i - 1]
@@ -430,8 +431,8 @@ def _slice_1d(dim_shape, lengths, index):
 
     d = dict()
     if step > 0:
-        istart = chunk_boundaries.searchsorted(start, side="right")
-        istop = chunk_boundaries.searchsorted(stop, side="left")
+        istart = bisect.bisect_right(chunk_boundaries, start)
+        istop = bisect.bisect_left(chunk_boundaries, stop)
 
         # the bound is not exactly tight; make it tighter?
         istop = min(istop + 1, len(lengths))
@@ -452,8 +453,8 @@ def _slice_1d(dim_shape, lengths, index):
     else:
         rstart = start  # running start
 
-        istart = chunk_boundaries.searchsorted(start, side="left")
-        istop = chunk_boundaries.searchsorted(stop, side="right")
+        istart = bisect.bisect_left(chunk_boundaries, start)
+        istop = bisect.bisect_right(chunk_boundaries, stop)
 
         # the bound is not exactly tight; make it tighter?
         istart = min(istart + 1, len(chunk_boundaries) - 1)
@@ -1201,26 +1202,22 @@ class _HashIdWrapper(object):
 
 
 @functools.lru_cache()
-def _cumsum(seq):
+def _cumsum(seq, initial_zero):
     if isinstance(seq, _HashIdWrapper):
-        return _cumsum(seq.wrapped)
-    seq = np.array(seq)
-    dtype = np.int64 if np.issubdtype(seq.dtype, np.integer) else seq.dtype
-    out = np.empty(len(seq) + 1, dtype)
-    out[0] = 0
-    np.cumsum(seq, out=out[1:], dtype=dtype)
-    return out
+        seq = seq.wrapped
+    if initial_zero:
+        return tuple(accumulate(add, seq, 0))
+    else:
+        return tuple(accumulate(add, seq))
 
 
 def cached_cumsum(seq, initial_zero=False):
-    """Compute :meth:`np.cumsum` with caching.
+    """Compute :meth:`toolz.accumulate` with caching.
 
     Caching is by the identify of `seq` rather than the value. It is thus
     important that `seq` is a tuple of immutable objects, and this function
-    is intended for use where `seq` is a value that will persist.
-
-    The result has type int64 if the sequence contains integers, and
-    otherwise the type of ``np.array(seq)``.
+    is intended for use where `seq` is a value that will persist (generally
+    block sizes).
 
     Parameters
     ----------
@@ -1228,15 +1225,16 @@ def cached_cumsum(seq, initial_zero=False):
         Values to cumulatively sum.
     initial_zero : bool, optional
         If true, the return value is prefixed with a zero.
+
+    Returns
+    -------
+    tuple
     """
     if isinstance(seq, tuple):
         # Look up by identity first, to avoid a linear-time __hash__
         # if we've seen this tuple object before.
-        result = _cumsum(_HashIdWrapper(seq))
+        result = _cumsum(_HashIdWrapper(seq), initial_zero)
     else:
         # Construct a temporary tuple, and look up by value.
-        result = _cumsum(tuple(seq))
-
-    if not initial_zero:
-        result = result[1:]
+        result = _cumsum(tuple(seq), initial_zero)
     return result

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -874,27 +874,23 @@ def test_cached_cumsum():
     a = (1, 2, 3, 4)
     x = cached_cumsum(a)
     y = cached_cumsum(a, initial_zero=True)
-    np.testing.assert_array_equal(x, [1, 3, 6, 10])
-    assert x.dtype == np.int64
-    np.testing.assert_array_equal(y, [0, 1, 3, 6, 10])
-    assert y.dtype == np.int64
+    assert x == (1, 3, 6, 10)
+    assert y == (0, 1, 3, 6, 10)
 
 
 def test_cached_cumsum_nan():
     a = (1, np.nan, 3)
     x = cached_cumsum(a)
     y = cached_cumsum(a, initial_zero=True)
-    np.testing.assert_array_equal(x, [1, np.nan, np.nan])
-    assert x.dtype == np.float64
-    np.testing.assert_array_equal(y, [0, 1, np.nan, np.nan])
-    assert y.dtype == np.float64
+    np.testing.assert_equal(x, (1, np.nan, np.nan))
+    np.testing.assert_equal(y, (0, 1, np.nan, np.nan))
 
 
 def test_cached_cumsum_non_tuple():
     a = [1, 2, 3]
-    np.testing.assert_array_equal(cached_cumsum(a), [1, 3, 6])
+    assert cached_cumsum(a) == (1, 3, 6)
     a[1] = 4
-    np.testing.assert_array_equal(cached_cumsum(a), [1, 5, 8])
+    assert cached_cumsum(a) == (1, 5, 8)
 
 
 @pytest.mark.parametrize("params", [(2, 2, 1), (5, 3, 2)])


### PR DESCRIPTION
One of the performance problems identified in #5913 was because
Array.shape gets called many times, and each time it is computed by
summing the chunk sizes. By using `cached_cumsum`, the calculation
should be fast after the first time. While a cumsum is overkill for
computing shape, it's likely that the cached result will be used again
at some point.

An alternative would be just to store the shape in the object (e.g.
computed during the destructor). That would need all the bits of
internal code that modify `_chunks` directly to be modified to update
the shape as well.

Also change `cached_cumsum` to return a tuple instead of a numpy array,
and also use `toolz.accumulate` rather than `np.cumsum`. I originally
needed this because `shape` was getting the wrong type (tuple of numpy
scalars instead of Python scalars), but it also makes the example in
https://github.com/dask/dask/issues/5913#issuecomment-587360588 about
10% faster. While it's a little slower to compute the first time, the
result of `cached_cumsum` is typically used for iteration or indexing in
Python land, rather than with vectorised numpy operations, and those are
a lot faster on a tuple. Similarly the bisect module is much faster than
np.searchsorted because the latter is dominated by C API overhead.

The one downside of using a tuple instead of a numpy array is that
slicing it is O(n) instead of O(1). That means that the
initial_zero=False answer is now a separate cache entry instead of the
initial_zero=True answer with the first element sliced off. There are
also a few bits of code that don't need the final element and slice it
with `[:-1]` which will now be making a copy. But I think it's still an
improvement overall.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
