### PR TITLE
Add remaining optional depedencies to Travis 3.8 CI build environment

### DIFF
--- a/continuous_integration/travis/travis-38-dev.yaml
+++ b/continuous_integration/travis/travis-38-dev.yaml
@@ -12,9 +12,7 @@ dependencies:
   - pytest
   - pytest-xdist
   - moto
-  # Fastparquet depends on numba being available for Python 3.8
-  # Uncomment the line below when fastparquet is avaialbe on conda-forge for 3.8
-  # - fastparquet
+  - fastparquet
   - h5py
   - pytables
   - zarr
@@ -38,9 +36,7 @@ dependencies:
   - graphviz
   - ipython
   - lz4
-  # Numba is not currently released for Python 3.8. Uncomment the numba line
-  # below when https://github.com/conda-forge/numba-feedstock/pull/38 is resolved
-  # - numba
+  - numba
   - partd
   - psutil
   - requests

--- a/continuous_integration/travis/travis-38.yaml
+++ b/continuous_integration/travis/travis-38.yaml
@@ -11,9 +11,7 @@ dependencies:
   - pytest
   - pytest-xdist
   - moto
-  # Fastparquet depends on numba being available for Python 3.8
-  # Uncomment the line below when fastparquet is available on conda-forge for 3.8
-  # - fastparquet
+  - fastparquet
   - h5py
   - pytables
   - zarr
@@ -38,9 +36,7 @@ dependencies:
   - graphviz
   - ipython
   - lz4
-  # Numba is not currently released for Python 3.8. Uncomment the numba line
-  # below when https://github.com/conda-forge/numba-feedstock/pull/38 is resolved
-  # - numba
+  - numba
   - partd
   - psutil
   - requests
@@ -49,9 +45,7 @@ dependencies:
   - scipy
   - toolz
   - python-snappy
-  # Sparse depends on numba being available for Python 3.8
-  # Uncomment the line below when sparse is available on conda-forge for 3.8
-  # - sparse
+  - sparse
   - cachey
   - python-graphviz
   - pandas-datareader


### PR DESCRIPTION
This PR adds `numba`, `sparse`, and `fastparquet` back into the Python 3.8 test environments on our Travis CI builds. These were commented out in #5603 due to lack of Python 3.8 support, but now can be added back in  

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
