### PR TITLE
Add new error message content when columns are in a different order

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -11,6 +11,7 @@ from dask.dataframe.utils import (
     make_meta,
     raise_on_meta_error,
     check_meta,
+    check_matching_columns,
     UNKNOWN_CATEGORIES,
     is_dataframe_like,
     is_series_like,
@@ -366,6 +367,22 @@ def test_check_meta():
         "+--------+----------+----------+"
     )
     assert str(err.value) == exp
+
+
+def test_check_matching_columns_raises_appropriate_errors():
+    df = pd.DataFrame(columns=["a", "b", "c"])
+
+    meta = pd.DataFrame(columns=["b", "a", "c"])
+    with pytest.raises(ValueError, match="Order of columns does not match"):
+        assert check_matching_columns(meta, df)
+
+    meta = pd.DataFrame(columns=["a", "b", "c", "d"])
+    with pytest.raises(ValueError, match="Missing: \\['d'\\]"):
+        assert check_matching_columns(meta, df)
+
+    meta = pd.DataFrame(columns=["a", "b"])
+    with pytest.raises(ValueError, match="Extra:   \\['c'\\]"):
+        assert check_matching_columns(meta, df)
 
 
 def test_check_meta_typename():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -671,11 +671,14 @@ def check_matching_columns(meta, actual):
     if not np.array_equal(np.nan_to_num(meta.columns), np.nan_to_num(actual.columns)):
         extra = actual.columns.difference(meta.columns).tolist()
         missing = meta.columns.difference(actual.columns).tolist()
+        if extra or missing:
+            extra_info = f"  Extra:   {extra}\n  Missing: {missing}"
+        else:
+            extra_info = "Order of columns does not match"
         raise ValueError(
             "The columns in the computed data do not match"
             " the columns in the provided metadata\n"
-            "  Extra:   %s\n"
-            "  Missing: %s" % (extra, missing)
+            f"{extra_info}"
         )
 
 
@@ -781,7 +784,7 @@ def assert_eq(
     check_dtypes=True,
     check_divisions=True,
     check_index=True,
-    **kwargs
+    **kwargs,
 ):
     if check_divisions:
         assert_divisions(a)


### PR DESCRIPTION
Closes: #5886
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`


