### PR TITLE
Implement dask.dataframe.to_numeric

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -29,6 +29,7 @@ try:
         to_json,
         read_fwf,
     )
+    from .numeric import to_numeric
     from .optimize import optimize
     from .multi import merge, concat, merge_asof
     from . import rolling, backends

--- a/dask/dataframe/numeric.py
+++ b/dask/dataframe/numeric.py
@@ -9,7 +9,7 @@ from .core import Series
 __all__ = ("to_numeric",)
 
 
-def to_numeric(arg):
+def to_numeric(arg, meta=None):
     """
     Convert argument to a numeric type.
 
@@ -37,14 +37,14 @@ def to_numeric(arg):
         return arg.map_partitions(
             pd.to_numeric,
             token=arg._name + "-to_numeric",
-            meta=pd.to_numeric(arg._meta),
+            meta=meta if meta is not None else pd.to_numeric(arg._meta),
             enforce_metadata=False,
         )
     if isinstance(arg, Array):
         return arg.map_blocks(
             pd.to_numeric,
             name=arg._name + "-to_numeric",
-            meta=pd.to_numeric(arg._meta),
+            meta=meta if meta is not None else pd.to_numeric(arg._meta),
         )
     if is_scalar(arg):
         return delayed(pd.to_numeric, pure=True)(arg)

--- a/dask/dataframe/numeric.py
+++ b/dask/dataframe/numeric.py
@@ -1,0 +1,54 @@
+import pandas as pd
+from pandas.core.dtypes.common import is_scalar
+
+from ..delayed import delayed
+from ..array import Array
+from .core import Series
+
+
+__all__ = ("to_numeric",)
+
+
+def to_numeric(arg):
+    """
+    Convert argument to a numeric type.
+
+    The default return dtype is `float64` or `int64`
+    depending on the data supplied.
+
+    Please note that precision loss may occur if really large numbers
+    are passed in. Due to the internal limitations of `ndarray`, if
+    numbers smaller than `-9223372036854775808` (np.iinfo(np.int64).min)
+    or larger than `18446744073709551615` (np.iinfo(np.uint64).max) are
+    passed in, it is very likely they will be converted to float so that
+    they can stored in an `ndarray`. These warnings apply similarly to
+    `Series` since it internally leverages `ndarray`.
+
+    Parameters
+    ----------
+    arg : scalar, dask.array.Array, or dask.dataframe.Series
+
+    Returns
+    -------
+    ret : numeric if parsing succeeded.
+        Return type depends on input. Delayed if scalar, otherwise same as input.
+    """
+    if isinstance(arg, Series):
+        return arg.map_partitions(
+            pd.to_numeric,
+            token=arg._name + "-to_numeric",
+            meta=pd.to_numeric(arg._meta),
+            enforce_metadata=False,
+        )
+    if isinstance(arg, Array):
+        return arg.map_blocks(
+            pd.to_numeric,
+            name=arg._name + "-to_numeric",
+            meta=pd.to_numeric(arg._meta),
+        )
+    if is_scalar(arg):
+        return delayed(pd.to_numeric, pure=True)(arg)
+
+    raise TypeError(
+        "arg must be a list, tuple, dask.array.Array, or dask.dataframe.Series"
+    )

--- a/dask/dataframe/numeric.py
+++ b/dask/dataframe/numeric.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from pandas.core.dtypes.common import is_scalar as pd_is_scalar
+from pandas.api.types import is_scalar as pd_is_scalar
 
 from ..utils import derived_from
 from ..delayed import delayed
@@ -10,15 +10,13 @@ from .core import Series
 __all__ = ("to_numeric",)
 
 
-@derived_from(pd)
-def to_numeric(arg, errors="raise", downcast=None, meta=None):
+@derived_from(pd, ua_args=["downcast"])
+def to_numeric(arg, errors="raise", meta=None):
     """
     Return type depends on input. Delayed if scalar, otherwise same as input.
+    For errors, only "raise" and "coerce" are allowed.
     """
-    if downcast not in (None, "integer", "signed", "unsigned", "float"):
-        raise ValueError("invalid downcasting method provided")
-
-    if errors not in ("ignore", "raise", "coerce"):
+    if errors not in ("raise", "coerce"):
         raise ValueError("invalid error value specified")
 
     is_series = isinstance(arg, Series)
@@ -33,20 +31,9 @@ def to_numeric(arg, errors="raise", downcast=None, meta=None):
     if meta is not None:
         if is_scalar:
             raise KeyError("``meta`` is not allowed when input is a scalar.")
-        if downcast is not None:
-            raise KeyError("Only one of downcast and meta should be specified.")
     else:
         if is_series or is_array:
-            if downcast is None:
-                meta = pd.to_numeric(arg._meta)
-            else:
-                if downcast in ["integer", "signed"]:
-                    dtype = "int8"
-                elif downcast == "unsigned":
-                    dtype = "uint8"
-                elif downcast == "float":
-                    dtype = "float32"
-                meta = (0, dtype)
+            meta = pd.to_numeric(arg._meta)
 
     if is_series:
         return arg.map_partitions(
@@ -55,16 +42,10 @@ def to_numeric(arg, errors="raise", downcast=None, meta=None):
             meta=meta,
             enforce_metadata=False,
             errors=errors,
-            downcast=downcast,
         )
     if is_array:
         return arg.map_blocks(
-            pd.to_numeric,
-            name=arg._name + "-to_numeric",
-            meta=meta,
-            errors=errors,
-            downcast=downcast,
+            pd.to_numeric, name=arg._name + "-to_numeric", meta=meta, errors=errors,
         )
     if is_scalar:
-        obj = lambda x: pd.to_numeric(x, errors=errors, downcast=downcast)
-        return delayed(obj, name="to_numeric", pure=True)(arg)
+        return delayed(pd.to_numeric, pure=True)(arg, errors=errors)

--- a/dask/dataframe/tests/test_numeric.py
+++ b/dask/dataframe/tests/test_numeric.py
@@ -42,30 +42,6 @@ def test_to_numeric_on_dask_dataframe_series_with_meta():
     assert list(output.compute()) == list(expected)
 
 
-def test_to_numeric_on_dask_dataframe_series_with_downcast_as_valid_integer():
-    s = pd.Series(["1", "2"])
-    arg = from_pandas(s, npartitions=2)
-    expected = pd.to_numeric(s)
-    output = to_numeric(arg, downcast="integer")
-    assert output.dtype == "int8"
-    assert isinstance(output, Series)
-    actual = output.compute()
-    assert actual.dtype == "int8"
-    assert list(actual) == list(expected)
-
-
-def test_to_numeric_on_dask_dataframe_series_with_downcast_as_invalid_integer():
-    s = pd.Series(["1", "2.3"])
-    arg = from_pandas(s, npartitions=2)
-    expected = pd.to_numeric(s)
-    output = to_numeric(arg, downcast="integer")
-    assert output.dtype == "int8"
-    assert isinstance(output, Series)
-    actual = output.compute()
-    assert actual.dtype == "float64"
-    assert list(actual) == list(expected)
-
-
 def test_to_numeric_on_dask_dataframe_dataframe_raises_error():
     s = pd.Series(["1.0", "2", -3, -5.1])
     df = pd.DataFrame({"a": s, "b": s})

--- a/dask/dataframe/tests/test_numeric.py
+++ b/dask/dataframe/tests/test_numeric.py
@@ -1,0 +1,39 @@
+import pytest
+import numpy as np
+import pandas as pd
+
+from dask.array import from_array, Array
+from dask.delayed import Delayed
+from dask.dataframe import from_pandas, Series, to_numeric
+
+
+@pytest.mark.parametrize("arg", ["5", 5, "5 "])
+def test_to_numeric_on_scalars(arg):
+    output = to_numeric(arg)
+    assert isinstance(output, Delayed)
+    assert output.compute() == 5
+
+
+def test_to_numeric_on_dask_array():
+    arg = from_array(["1.0", "2", -3, 5.1])
+    expected = np.array([1.0, 2.0, -3.0, 5.1])
+    output = to_numeric(arg)
+    assert isinstance(output, Array)
+    assert list(output.compute()) == list(expected)
+
+
+def test_to_numeric_on_dask_dataframe_series():
+    s = pd.Series(["1.0", "2", -3, -5.1])
+    arg = from_pandas(s, npartitions=2)
+    expected = pd.to_numeric(s)
+    output = to_numeric(arg)
+    assert isinstance(output, Series)
+    assert list(output.compute()) == list(expected)
+
+
+def test_to_numeric_on_dask_dataframe_dataframe_raises_error():
+    s = pd.Series(["1.0", "2", -3, -5.1])
+    df = pd.DataFrame({"a": s, "b": s})
+    arg = from_pandas(df, npartitions=2)
+    with pytest.raises(TypeError, match="arg must be a list, tuple, dask."):
+        to_numeric(arg)

--- a/dask/dataframe/tests/test_numeric.py
+++ b/dask/dataframe/tests/test_numeric.py
@@ -42,6 +42,30 @@ def test_to_numeric_on_dask_dataframe_series_with_meta():
     assert list(output.compute()) == list(expected)
 
 
+def test_to_numeric_on_dask_dataframe_series_with_downcast_as_valid_integer():
+    s = pd.Series(["1", "2"])
+    arg = from_pandas(s, npartitions=2)
+    expected = pd.to_numeric(s)
+    output = to_numeric(arg, downcast="integer")
+    assert output.dtype == "int8"
+    assert isinstance(output, Series)
+    actual = output.compute()
+    assert actual.dtype == "int8"
+    assert list(actual) == list(expected)
+
+
+def test_to_numeric_on_dask_dataframe_series_with_downcast_as_invalid_integer():
+    s = pd.Series(["1", "2.3"])
+    arg = from_pandas(s, npartitions=2)
+    expected = pd.to_numeric(s)
+    output = to_numeric(arg, downcast="integer")
+    assert output.dtype == "int8"
+    assert isinstance(output, Series)
+    actual = output.compute()
+    assert actual.dtype == "float64"
+    assert list(actual) == list(expected)
+
+
 def test_to_numeric_on_dask_dataframe_dataframe_raises_error():
     s = pd.Series(["1.0", "2", -3, -5.1])
     df = pd.DataFrame({"a": s, "b": s})

--- a/dask/dataframe/tests/test_numeric.py
+++ b/dask/dataframe/tests/test_numeric.py
@@ -27,6 +27,17 @@ def test_to_numeric_on_dask_dataframe_series():
     arg = from_pandas(s, npartitions=2)
     expected = pd.to_numeric(s)
     output = to_numeric(arg)
+    assert output.dtype == "int64"
+    assert isinstance(output, Series)
+    assert list(output.compute()) == list(expected)
+
+
+def test_to_numeric_on_dask_dataframe_series_with_meta():
+    s = pd.Series(["1.0", "2", -3, -5.1])
+    arg = from_pandas(s, npartitions=2)
+    expected = pd.to_numeric(s)
+    output = to_numeric(arg, meta=pd.Series([], dtype="float64"))
+    assert output.dtype == "float64"
     assert isinstance(output, Series)
     assert list(output.compute()) == list(expected)
 

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -438,6 +438,7 @@ Other functions
 .. autofunction:: compute
 .. autofunction:: map_partitions
 .. autofunction:: to_datetime
+.. autofunciton:: to_numeric
 
 .. currentmodule:: dask.dataframe.multi
 


### PR DESCRIPTION
Closes: #5698 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

@TomAugspurger I haven't added any of the kwargs yet, but just wanted to make sure that this is what you intended.