### PR TITLE
Add original class or module as a kwarg on _bind_* methods

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2327,7 +2327,7 @@ Dask Name: {name}, {task} tasks"""
         return self.map_partitions(M.combine_first, other)
 
     @classmethod
-    def _bind_operator_method(cls, name, op):
+    def _bind_operator_method(cls, name, op, original=pd.DataFrame):
         """ bind operator method like DataFrame.add to this class """
         raise NotImplementedError
 
@@ -2946,7 +2946,7 @@ Dask Name: {name}, {task} tasks""".format(
         return self._repr_data().to_string(max_rows=max_rows)
 
     @classmethod
-    def _bind_operator_method(cls, name, op):
+    def _bind_operator_method(cls, name, op, original=pd.Series):
         """ bind operator method like Series.add to this class """
 
         def meth(self, other, level=None, fill_value=None, axis=0):
@@ -2959,10 +2959,10 @@ Dask Name: {name}, {task} tasks""".format(
             )
 
         meth.__name__ = name
-        setattr(cls, name, derived_from(pd.Series)(meth))
+        setattr(cls, name, derived_from(original)(meth))
 
     @classmethod
-    def _bind_comparison_method(cls, name, comparison):
+    def _bind_comparison_method(cls, name, comparison, original=pd.Series):
         """ bind comparison method like Series.eq to this class """
 
         def meth(self, other, level=None, fill_value=None, axis=0):
@@ -2976,7 +2976,7 @@ Dask Name: {name}, {task} tasks""".format(
                 return elemwise(op, self, other, axis=axis)
 
         meth.__name__ = name
-        setattr(cls, name, derived_from(pd.Series)(meth))
+        setattr(cls, name, derived_from(original)(meth))
 
     @insert_meta_param_description(pad=12)
     def apply(self, func, convert_dtype=True, meta=no_default, args=(), **kwds):
@@ -3964,7 +3964,7 @@ class DataFrame(_Frame):
                 yield row
 
     @classmethod
-    def _bind_operator_method(cls, name, op):
+    def _bind_operator_method(cls, name, op, original=pd.DataFrame):
         """ bind operator method like DataFrame.add to this class """
 
         # name must be explicitly passed for div method whose name is truediv
@@ -4010,10 +4010,10 @@ class DataFrame(_Frame):
             )
 
         meth.__name__ = name
-        setattr(cls, name, derived_from(pd.DataFrame)(meth))
+        setattr(cls, name, derived_from(original)(meth))
 
     @classmethod
-    def _bind_comparison_method(cls, name, comparison):
+    def _bind_comparison_method(cls, name, comparison, original=pd.DataFrame):
         """ bind comparison method like DataFrame.eq to this class """
 
         def meth(self, other, axis="columns", level=None):
@@ -4023,7 +4023,7 @@ class DataFrame(_Frame):
             return elemwise(comparison, self, other, axis=axis)
 
         meth.__name__ = name
-        setattr(cls, name, derived_from(pd.DataFrame)(meth))
+        setattr(cls, name, derived_from(original)(meth))
 
     @insert_meta_param_description(pad=12)
     def apply(

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -44,6 +44,24 @@ def test_dataframe_doc():
     assert disclaimer in doc
 
 
+def test_dataframe_doc_from_non_pandas():
+    class Foo:
+        def foo(self):
+            """This is a new docstring that I just made up
+
+            Parameters:
+            ----------
+            None
+            """
+
+    d._bind_operator_method("foo", Foo.foo, original=Foo)
+
+    doc = d.foo.__doc__
+    disclaimer = "Some inconsistencies with the Dask version may exist."
+    assert disclaimer in doc
+    assert "new docstring that I just made up" in doc
+
+
 def test_Dataframe():
     expected = pd.Series(
         [2, 3, 4, 5, 6, 7, 8, 9, 10], index=[0, 1, 3, 5, 6, 8, 9, 9, 9], name="a"

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -55,11 +55,14 @@ def test_dataframe_doc_from_non_pandas():
             """
 
     d._bind_operator_method("foo", Foo.foo, original=Foo)
-
-    doc = d.foo.__doc__
-    disclaimer = "Some inconsistencies with the Dask version may exist."
-    assert disclaimer in doc
-    assert "new docstring that I just made up" in doc
+    try:
+        doc = d.foo.__doc__
+        disclaimer = "Some inconsistencies with the Dask version may exist."
+        assert disclaimer in doc
+        assert "new docstring that I just made up" in doc
+    finally:
+        # make sure to clean up this alteration of the dd.DataFrame class
+        del dd.DataFrame.foo
 
 
 def test_Dataframe():


### PR DESCRIPTION
In #5709 I added `pd.DataFrame` and `pd.Series` into these bind methods, but now I understand how they are used (I was trying to use them in dask-geopandas) and I think that they need to be a bit more general. I still think it is important to augment the docstring so I'm not just reverting the change.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
