### PR TITLE
Register deterministic tokenization for range objects

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -683,6 +683,11 @@ def normalize_literal(lit):
     return "literal", normalize_token(lit())
 
 
+@normalize_token.register(range)
+def normalize_range(r):
+    return list(map(normalize_token, [r.start, r.stop, r.step]))
+
+
 @normalize_token.register(object)
 def normalize_object(o):
     method = getattr(o, "__dask_tokenize__", None)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -394,6 +394,13 @@ def test_tokenize_ordered_dict():
     assert tokenize(a) != tokenize(c)
 
 
+def test_tokenize_range():
+    assert tokenize(range(5, 10, 2)) == tokenize(range(5, 10, 2))  # Identical ranges
+    assert tokenize(range(5, 10, 2)) != tokenize(range(1, 10, 2))  # Different start
+    assert tokenize(range(5, 10, 2)) != tokenize(range(5, 15, 2))  # Different stop
+    assert tokenize(range(5, 10, 2)) != tokenize(range(5, 10, 1))  # Different step
+
+
 @pytest.mark.skipif("not np")
 def test_tokenize_object_array_with_nans():
     a = np.array([u"foo", u"Jos\xe9", np.nan], dtype="O")


### PR DESCRIPTION
Currently our tokenization of `range` objects isn't deterministic. For example:

```python
from dask.base import tokenize

for _ in range(3):
    print(tokenize(range(5)))
```

outputs:

```
d424666834140c08de99b23f85a7b60c
a3a1bdd9013db6364668f1d224d4cac6
13142f6359eb57df2fc8230942f1ece9
```

This PR adds a deterministic tokenization for `range` objects based on their `start`, `stop`, and `step` attributes. With the changes in this PR, the above snippet outputs a consistent hash:

```
3b69507db0ea8dfcb39cfce774a1df29
3b69507db0ea8dfcb39cfce774a1df29
3b69507db0ea8dfcb39cfce774a1df29
```

- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
