### PR TITLE
xfail test_describe when using Pandas 0.24.2

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -351,6 +351,10 @@ def test_describe_numeric(method, test_values):
     assert_eq(df.describe(), ddf.describe(split_every=2, percentiles_method=method))
 
 
+@pytest.mark.xfail(
+    PANDAS_VERSION == "0.24.2",
+    reason="Known bug in Pandas. See https://github.com/pandas-dev/pandas/issues/24011.",
+)
 @pytest.mark.parametrize(
     "include,exclude,percentiles,subset",
     [


### PR DESCRIPTION
I observed some test failures over in #5947 that I think are unrelated to the changes in that PR. This PR runs CI on the current master