### PR TITLE
Use toolz.unique for possible speedup in ensure_dict

### DIFF
--- a/dask/utils.py
+++ b/dask/utils.py
@@ -15,11 +15,6 @@ from threading import Lock
 import uuid
 from weakref import WeakValueDictionary
 
-try:
-    import cytoolz as toolz
-except ImportError:
-    import toolz
-
 from .core import get_deps
 from .optimization import key_split  # noqa: F401
 
@@ -1013,14 +1008,28 @@ def get_scheduler_lock(collection=None, scheduler=None):
     return SerializableLock()
 
 
+def unique(seq, key=id):
+    seen = set()
+    seen_add = seen.add
+    for item in seq:
+        _id = key(item)
+        if _id not in seen:
+            seen_add(_id)
+            yield item
+
+
+def merge(*dicts):
+    rv = {}
+    for d in dicts:
+        rv.update(d)
+    return rv
+
+
 def ensure_dict(d):
     if type(d) is dict:
         return d
     elif hasattr(d, "dicts"):
-        result = {}
-        for dd in toolz.unique(d.dicts.values(), key=id):
-            result.update(dd)
-        return result
+        return merge(*unique(d.dicts.values(), key=id))
     return dict(d)
 
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -15,6 +15,11 @@ from threading import Lock
 import uuid
 from weakref import WeakValueDictionary
 
+try:
+    import cytoolz as toolz
+except ImportError:
+    import toolz
+
 from .core import get_deps
 from .optimization import key_split  # noqa: F401
 
@@ -1013,12 +1018,8 @@ def ensure_dict(d):
         return d
     elif hasattr(d, "dicts"):
         result = {}
-        seen = set()
-        for dd in d.dicts.values():
-            dd_id = id(dd)
-            if dd_id not in seen:
-                result.update(dd)
-                seen.add(dd_id)
+        for dd in toolz.unique(d.dicts.values(), key=id):
+            result.update(dd)
         return result
     return dict(d)
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1018,7 +1018,7 @@ def unique(seq, key=id):
             yield item
 
 
-def merge(*dicts):
+def merge(dicts):
     rv = {}
     for d in dicts:
         rv.update(d)
@@ -1029,7 +1029,7 @@ def ensure_dict(d):
     if type(d) is dict:
         return d
     elif hasattr(d, "dicts"):
-        return merge(*unique(d.dicts.values(), key=id))
+        return merge(unique(d.dicts.values(), key=id))
     return dict(d)
 
 


### PR DESCRIPTION
When cytoolz is present, ensure_dict gets a small performance boost in one case.
Otherwise, there is no change in performance.

- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
