### PR TITLE
Update title of DataFrame extension docs

### DIFF
--- a/docs/source/dataframe-extend.rst
+++ b/docs/source/dataframe-extend.rst
@@ -1,5 +1,8 @@
+Extending DataFrames
+====================
+
 Subclass DataFrames
-===================
+-------------------
 
 There are a few projects that subclass or replicate the functionality of Pandas
 objects:
@@ -9,26 +12,27 @@ objects:
 -  ...
 
 These projects may also want to produce parallel variants of themselves with
-Dask, and may want to reuse some of the code in Dask DataFrame.
-This document describes how to do this.  It is intended for maintainers of
-these libraries and not for general users.
+Dask, and may want to reuse some of the code in Dask DataFrame. Subclassing
+Dask DataFrames is intended for maintainers of these libraries and not for
+general users.
 
 
 Implement dask, name, meta, and divisions
------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You will need to implement ``._meta``, ``.dask``, ``.divisions``, and
 ``._name`` as defined in the :doc:`DataFrame design docs <dataframe-design>`.
 
 
 Extend Dispatched Methods
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you are going to pass around Pandas-like objects that are not normal Pandas
-objects, then we ask you to extend a few dispatched methods.
+objects, then we ask you to extend a few dispatched methods: ``make_meta``,
+``get_parallel_type``, and ``concat``.
 
 make_meta
-~~~~~~~~~
+"""""""""
 
 This function returns an empty version of one of your non-Dask objects, given a
 non-empty non-Dask object:
@@ -80,7 +84,7 @@ dtypes, index name, and it should return a non-empty version:
 
 
 get_parallel_type
-~~~~~~~~~~~~~~~~~
+"""""""""""""""""
 
 Given a non-Dask DataFrame object, return the Dask equivalent:
 
@@ -104,7 +108,7 @@ Given a non-Dask DataFrame object, return the Dask equivalent:
 
 
 concat
-~~~~~~
+""""""
 
 Concatenate many of your non-Dask DataFrame objects together.  It should expect
 a list of your objects (homogeneously typed):


### PR DESCRIPTION
This changes the page title of `dataframe-extend.rst` from "Subclass DataFrames" to "Extending DataFrames" as the documentation covers topics other than subclassing (e.g. registering extension arrays). Also, I updated "Extend Dispatched Methods" to be a subsection of the "Subclass DataFrames" section. I think this is correct, but am not 100% sure

cc @TomAugspurger 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
