### PR TITLE
Pin `numpydoc` to `0.8.0` (fix double autoescape)

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,6 @@
-numpydoc==0.9.1
+# We pin numpydoc to avoid doubly-escaped *args and **kwargs in rendered docs
+# due to a weird interaction between sphinx autosummary and numpydoc >= 0.9.0
+numpydoc==0.8.0
 sphinx
 dask-sphinx-theme>=1.1.0
 sphinx-click

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -438,7 +438,7 @@ Other functions
 .. autofunction:: compute
 .. autofunction:: map_partitions
 .. autofunction:: to_datetime
-.. autofunciton:: to_numeric
+.. autofunction:: to_numeric
 
 .. currentmodule:: dask.dataframe.multi
 


### PR DESCRIPTION
This is a temporary fix for the doubly escaped `*`s that are present in
the current dask docs (and `pandas`, and `scipy`...).
This issue started with `numpydoc=0.9.0` when `numpydoc` started
escaping `*args` and `**kwargs`.  sphinx autosummary _also_ escapes
`*args` and `**kwargs`, so in conjunction, they end up double-escaped:

```
Client.run(self, function, \*args, \*\*kwargs)
```

There are a couple of different ways to fix this TheRightWay™ but this
will make the docs prettier for now.  Also a quickfix for a typo in the docs on `master`

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
