### PR TITLE
[docs] fixed typos in documentation

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -5,7 +5,7 @@ co-released.  We may want to check their status while releasing
 Release per project:
 
 *   Raise an issue in the https://github.com/dask/community issue tracker
-    signalling your intent to release and the motivation.  Let that issue
+    signaling your intent to release and the motivation.  Let that issue
     collect comments for a day to ensure that other maintainers are comfortable
     with releasing.
 
@@ -19,7 +19,7 @@ Release per project:
 
         git tag -a x.x.x -m 'Version x.x.x'
 
-*   Push to github
+*   Push to GitHub
 
         git push dask master --tags
 

--- a/docs/source/array-overlap.rst
+++ b/docs/source/array-overlap.rst
@@ -86,7 +86,7 @@ overlap function:
 Boundaries
 ----------
 
-With respect to overlaping, you can specify how to handle the boundaries.  Current policies
+With respect to overlapping, you can specify how to handle the boundaries.  Current policies
 include the following:
 
 *  ``periodic`` - wrap borders around to the other side
@@ -167,7 +167,7 @@ given to ``overlap``:
 Full Workflow
 -------------
 
-And so, a pretty typical overlaping workflow includes ``overlap``, ``map_blocks``
+And so, a pretty typical overlapping workflow includes ``overlap``, ``map_blocks``
 and ``trim_internal``:
 
 .. code-block:: python

--- a/docs/source/custom-collections.rst
+++ b/docs/source/custom-collections.rst
@@ -9,7 +9,7 @@ we describe the required methods to fulfill the Dask collection interface.
 .. note:: This is considered an advanced feature. For most cases the built-in
           collections are probably sufficient.
 
-Before reading this you should read and underestand:
+Before reading this you should read and understand:
 
 - :doc:`overview <graphs>`
 - :doc:`graph specification <spec>`

--- a/docs/source/delayed-best-practices.rst
+++ b/docs/source/delayed-best-practices.rst
@@ -179,7 +179,7 @@ of the Dask collections to help you.
 +------------------------------------+-------------------------------------------------------------+
 | .. code-block:: python             | .. code-block:: python                                      |
 |                                    |                                                             |
-|    # Too mamy tasks                |    # Use collections                                        |
+|    # Too many tasks                |    # Use collections                                        |
 |                                    |                                                             |
 |    results = []                    |    import dask.bag as db                                    |
 |    for x in range(10000000):       |    b = db.from_sequence(range(10000000), npartitions=1000)  |

--- a/docs/source/gpu.rst
+++ b/docs/source/gpu.rst
@@ -138,7 +138,7 @@ Some configurations may have many GPU devices per node.  Dask is often used to
 balance and coordinate work between these devices.
 
 In these situations it is common to start one Dask worker per device, and use
-the CUDA environment varible ``CUDA_VISIBLE_DEVICES`` to pin each worker to
+the CUDA environment variable ``CUDA_VISIBLE_DEVICES`` to pin each worker to
 prefer one device.
 
 .. code-block:: bash

--- a/docs/source/graphviz.rst
+++ b/docs/source/graphviz.rst
@@ -9,7 +9,7 @@ Visualize task graphs
 Before executing your computation you might consider visualizing the underlying task graph.
 By looking at the inter-connectedness of tasks
 you can learn more about potential bottlenecks
-where parallelism may not be possile,
+where parallelism may not be possible,
 or areas where many tasks depend on each other,
 which may cause a great deal of communication.
 

--- a/docs/source/institutional-faq.rst
+++ b/docs/source/institutional-faq.rst
@@ -151,7 +151,7 @@ those on Hadoop, HPC, Kubernetes, and Cloud clusters.
     To help with this, you'll likely want to use `Dask-Yarn <https://yarn.dask.org>`_.
 
 2.  **HPC**: If you have an HPC machine that runs resource managers like SGE,
-    SLLURM, PBS, LSF, Torque, Condor, or other job batch queuing systems, then
+    SLURM, PBS, LSF, Torque, Condor, or other job batch queuing systems, then
     users can launch Dask on these systems today using either:
 
     - `Dask Jobqueue <https://jobqueue.dask.org>`_ , which uses typical


### PR DESCRIPTION
In this PR, I propose a few fixes for typos in the docs. Thanks for your time and for this great project! 

## Required checks

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
