### PR TITLE
Add DataFrame and Series memory_usage_per_partition methods

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3084,6 +3084,29 @@ Dask Name: {name}, {task} tasks""".format(
         )
         return delayed(sum)(result.to_delayed())
 
+    def memory_usage_per_partition(self, index=True, deep=False):
+        """ Return the memory usage of each partition
+
+        Parameters
+        ----------
+        index : bool, default True
+            Specifies whether to include the memory usage of the Series'
+            index in returned Series.
+        deep : bool, default False
+            If True, introspect the data deeply by interrogating
+            ``object`` dtypes for system-level memory consumption, and include
+            it in the returned values.
+
+        Returns
+        -------
+        Series
+            A Series whose index is the parition number and whose values
+            are the memory usage of each partition in bytes.
+        """
+        return self.map_partitions(
+            M.memory_usage, index=index, deep=deep
+        ).clear_divisions()
+
     def __divmod__(self, other):
         res1 = self // other
         res2 = self % other
@@ -4233,6 +4256,28 @@ class DataFrame(_Frame):
         result = self.map_partitions(M.memory_usage, index=index, deep=deep)
         result = result.groupby(result.index).sum()
         return result
+
+    def memory_usage_per_partition(self, index=True, deep=False):
+        """ Return the memory usage of each partition
+
+        Parameters
+        ----------
+        index : bool, default True
+            Specifies whether to include the memory usage of the DataFrame's
+            index in returned Series.
+        deep : bool, default False
+            If True, introspect the data deeply by interrogating
+            ``object`` dtypes for system-level memory consumption, and include
+            it in the returned values.
+
+        Returns
+        -------
+        Series
+            A Series whose index is the parition number and whose values
+            are the memory usage of each partition in bytes.
+        """
+        result = self.map_partitions(M.memory_usage, index=index, deep=deep)
+        return result.map_partitions(M.sum).clear_divisions()
 
     def pivot_table(self, index=None, columns=None, values=None, aggfunc="mean"):
         """

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -744,6 +744,29 @@ Dask Name: {name}, {task} tasks"""
 
         return map_overlap(func, self, before, after, *args, **kwargs)
 
+    def memory_usage_per_partition(self, index=True, deep=False):
+        """ Return the memory usage of each partition
+
+        Parameters
+        ----------
+        index : bool, default True
+            Specifies whether to include the memory usage of the index in
+            returned Series.
+        deep : bool, default False
+            If True, introspect the data deeply by interrogating
+            ``object`` dtypes for system-level memory consumption, and include
+            it in the returned values.
+
+        Returns
+        -------
+        Series
+            A Series whose index is the parition number and whose values
+            are the memory usage of each partition in bytes.
+        """
+        return self.map_partitions(
+            total_mem_usage, index=index, deep=deep
+        ).clear_divisions()
+
     @insert_meta_param_description(pad=12)
     def reduction(
         self,
@@ -3084,29 +3107,6 @@ Dask Name: {name}, {task} tasks""".format(
         )
         return delayed(sum)(result.to_delayed())
 
-    def memory_usage_per_partition(self, index=True, deep=False):
-        """ Return the memory usage of each partition
-
-        Parameters
-        ----------
-        index : bool, default True
-            Specifies whether to include the memory usage of the Series'
-            index in returned Series.
-        deep : bool, default False
-            If True, introspect the data deeply by interrogating
-            ``object`` dtypes for system-level memory consumption, and include
-            it in the returned values.
-
-        Returns
-        -------
-        Series
-            A Series whose index is the parition number and whose values
-            are the memory usage of each partition in bytes.
-        """
-        return self.map_partitions(
-            M.memory_usage, index=index, deep=deep
-        ).clear_divisions()
-
     def __divmod__(self, other):
         res1 = self // other
         res2 = self % other
@@ -4256,28 +4256,6 @@ class DataFrame(_Frame):
         result = self.map_partitions(M.memory_usage, index=index, deep=deep)
         result = result.groupby(result.index).sum()
         return result
-
-    def memory_usage_per_partition(self, index=True, deep=False):
-        """ Return the memory usage of each partition
-
-        Parameters
-        ----------
-        index : bool, default True
-            Specifies whether to include the memory usage of the DataFrame's
-            index in returned Series.
-        deep : bool, default False
-            If True, introspect the data deeply by interrogating
-            ``object`` dtypes for system-level memory consumption, and include
-            it in the returned values.
-
-        Returns
-        -------
-        Series
-            A Series whose index is the parition number and whose values
-            are the memory usage of each partition in bytes.
-        """
-        result = self.map_partitions(M.memory_usage, index=index, deep=deep)
-        return result.map_partitions(M.sum).clear_divisions()
 
     def pivot_table(self, index=None, columns=None, values=None, aggfunc="mean"):
         """
@@ -5699,7 +5677,7 @@ def repartition_size(df, size):
         size = parse_bytes(size)
     size = int(size)
 
-    mem_usages = df.map_partitions(total_mem_usage).compute()
+    mem_usages = df.map_partitions(total_mem_usage, deep=True).compute()
 
     # 1. split each partition that is larger than partition_size
     nsplits = 1 + mem_usages // size
@@ -5720,8 +5698,8 @@ def repartition_size(df, size):
     return _repartition_from_boundaries(df, new_partitions_boundaries, new_name)
 
 
-def total_mem_usage(df):
-    mem_usage = df.memory_usage(deep=True)
+def total_mem_usage(df, index=True, deep=False):
+    mem_usage = df.memory_usage(index=index, deep=deep)
     if is_series_like(mem_usage):
         mem_usage = mem_usage.sum()
     return mem_usage

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1802,7 +1802,7 @@ def test_repartition_partition_size(use_index, n, partition_size, transform):
     a = dd.from_pandas(df, npartitions=n, sort=use_index)
     b = a.repartition(partition_size=partition_size)
     assert_eq(a, b, check_divisions=False)
-    assert np.alltrue(b.map_partitions(total_mem_usage).compute() <= 1024)
+    assert np.alltrue(b.map_partitions(total_mem_usage, deep=True).compute() <= 1024)
     parts = dask.get(b.dask, b.__dask_keys__())
     assert all(map(len, parts))
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3614,6 +3614,34 @@ def test_memory_usage(index, deep):
     )
 
 
+@pytest.mark.parametrize("index", [True, False])
+@pytest.mark.parametrize("deep", [True, False])
+def test_memory_usage_per_partition(index, deep):
+    df = pd.DataFrame(
+        {
+            "x": [1, 2, 3, 4, 5],
+            "y": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "z": ["a", "b", "c", "d", "e"],
+        }
+    )
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    # DataFrame.memory_usage_per_partition
+    expected = pd.Series(
+        part.compute().memory_usage(index=index, deep=deep).sum()
+        for part in ddf.partitions
+    )
+    result = ddf.memory_usage_per_partition(index=index, deep=deep)
+    assert_eq(expected, result)
+
+    # Series.memory_usage_per_partition
+    expected = pd.Series(
+        part.x.compute().memory_usage(index=index, deep=deep) for part in ddf.partitions
+    )
+    result = ddf.x.memory_usage_per_partition(index=index, deep=deep)
+    assert_eq(expected, result)
+
+
 @pytest.mark.parametrize(
     "reduction",
     [

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -49,6 +49,8 @@ Dataframe
     DataFrame.mask
     DataFrame.max
     DataFrame.mean
+    DataFrame.memory_usage
+    DataFrame.memory_usage_per_partition
     DataFrame.merge
     DataFrame.min
     DataFrame.mod
@@ -162,6 +164,7 @@ Series
    Series.max
    Series.mean
    Series.memory_usage
+   Series.memory_usage_per_partition
    Series.min
    Series.mod
    Series.mul


### PR DESCRIPTION
This PR adds a `memory_usage_per_partition` method to Dask's `Series` and `DataFrame` collections. Closes #5952

cc @xhochy @quasiben 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
