### PR TITLE
[READY] Add ignore_index argument to rearrange_by_column code path

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -77,7 +77,7 @@ no_default = "__no_default__"
 pd.set_option("compute.use_numexpr", False)
 
 
-def _concat(args):
+def _concat(args, ignore_index=False):
     if not args:
         return args
     if isinstance(first(core.flatten(args)), np.ndarray):
@@ -92,7 +92,11 @@ def _concat(args):
     # Ideally this would be handled locally for each operation, but in practice
     # this seems easier. TODO: don't do this.
     args2 = [i for i in args if len(i)]
-    return args[0] if not args2 else methods.concat(args2, uniform=True)
+    return (
+        args[0]
+        if not args2
+        else methods.concat(args2, uniform=True, ignore_index=ignore_index)
+    )
 
 
 def finalize(results):

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -349,7 +349,9 @@ def pivot_count(df, index, columns, values):
 concat_dispatch = Dispatch("concat")
 
 
-def concat(dfs, axis=0, join="outer", uniform=False, filter_warning=True):
+def concat(
+    dfs, axis=0, join="outer", uniform=False, filter_warning=True, ignore_index=False
+):
     """Concatenate, handling some edge cases:
 
     - Unions categoricals between partitions
@@ -364,18 +366,28 @@ def concat(dfs, axis=0, join="outer", uniform=False, filter_warning=True):
         Whether to treat ``dfs[0]`` as representative of ``dfs[1:]``. Set to
         True if all arguments have the same columns and dtypes (but not
         necessarily categories). Default is False.
+    ignore_index : bool, optional
+        Whether to allow index values to be ignored/droped during
+        concatenation. Default is False.
     """
     if len(dfs) == 1:
         return dfs[0]
     else:
         func = concat_dispatch.dispatch(type(dfs[0]))
         return func(
-            dfs, axis=axis, join=join, uniform=uniform, filter_warning=filter_warning
+            dfs,
+            axis=axis,
+            join=join,
+            uniform=uniform,
+            filter_warning=filter_warning,
+            ignore_index=ignore_index,
         )
 
 
 @concat_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
-def concat_pandas(dfs, axis=0, join="outer", uniform=False, filter_warning=True):
+def concat_pandas(
+    dfs, axis=0, join="outer", uniform=False, filter_warning=True, ignore_index=False
+):
     if axis == 1:
         return pd.concat(dfs, axis=axis, join=join, sort=False)
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -216,6 +216,7 @@ def set_partition(
         npartitions=len(divisions) - 1,
         shuffle=shuffle,
         compute=compute,
+        ignore_index=True,
     )
 
     if np.isscalar(index):
@@ -301,13 +302,21 @@ def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None)
 
 
 def rearrange_by_column(
-    df, col, npartitions=None, max_branch=None, shuffle=None, compute=None
+    df,
+    col,
+    npartitions=None,
+    max_branch=None,
+    shuffle=None,
+    compute=None,
+    ignore_index=False,
 ):
     shuffle = shuffle or config.get("shuffle", None) or "disk"
     if shuffle == "disk":
         return rearrange_by_column_disk(df, col, npartitions, compute=compute)
     elif shuffle == "tasks":
-        return rearrange_by_column_tasks(df, col, max_branch, npartitions)
+        return rearrange_by_column_tasks(
+            df, col, max_branch, npartitions, ignore_index=ignore_index
+        )
     else:
         raise NotImplementedError("Unknown shuffle method %s" % shuffle)
 
@@ -411,7 +420,9 @@ def rearrange_by_column_disk(df, column, npartitions=None, compute=False):
     return DataFrame(graph, name, df._meta, divisions)
 
 
-def rearrange_by_column_tasks(df, column, max_branch=32, npartitions=None):
+def rearrange_by_column_tasks(
+    df, column, max_branch=32, npartitions=None, ignore_index=False
+):
     """ Order divisions of DataFrame so that all values within column align
 
     This enacts a task-based shuffle.  It contains most of the tricky logic
@@ -493,6 +504,7 @@ def rearrange_by_column_tasks(df, column, max_branch=32, npartitions=None):
                 stage - 1,
                 k,
                 n,
+                ignore_index,
             )
             for inp in inputs
         }
@@ -519,6 +531,7 @@ def rearrange_by_column_tasks(df, column, max_branch=32, npartitions=None):
                     )
                     for j in range(k)
                 ],
+                ignore_index,
             )
             for inp in inputs
         }
@@ -540,7 +553,12 @@ def rearrange_by_column_tasks(df, column, max_branch=32, npartitions=None):
         token = tokenize(df2, npartitions)
 
         dsk = {
-            ("repartition-group-" + token, i): (shuffle_group_2, k, column)
+            ("repartition-group-" + token, i): (
+                shuffle_group_2,
+                k,
+                column,
+                ignore_index,
+            )
             for i, k in enumerate(df2.__dask_keys__())
         }
         for p in range(npartitions):
@@ -605,12 +623,14 @@ def set_partitions_pre(s, divisions):
     return partitions
 
 
-def shuffle_group_2(df, col):
+def shuffle_group_2(df, col, ignore_index):
     if not len(df):
         return {}, df
     ind = df[col].astype(np.int64)
     n = ind.max() + 1
-    result2 = group_split_dispatch(df, ind.values.view(np.int64), n)
+    result2 = group_split_dispatch(
+        df, ind.values.view(np.int64), n, ignore_index=ignore_index
+    )
     return result2, df.iloc[:0]
 
 
@@ -622,7 +642,7 @@ def shuffle_group_get(g_head, i):
         return head
 
 
-def shuffle_group(df, col, stage, k, npartitions):
+def shuffle_group(df, col, stage, k, npartitions, ignore_index):
     """ Splits dataframe into groups
 
     The group is determined by their final partition, and which stage we are in
@@ -660,7 +680,7 @@ def shuffle_group(df, col, stage, k, npartitions):
     np.floor_divide(c, k ** stage, out=c)
     np.mod(c, k, out=c)
 
-    return group_split_dispatch(df, c.astype(np.int64), k)
+    return group_split_dispatch(df, c.astype(np.int64), k, ignore_index=ignore_index)
 
 
 def shuffle_group_3(df, col, npartitions, p):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -477,7 +477,7 @@ group_split_dispatch = Dispatch("group_split_dispatch")
 
 
 @group_split_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
-def group_split_pandas(df, c, k):
+def group_split_pandas(df, c, k, ignore_index=True):
     indexer, locations = pd._libs.algos.groupsort_indexer(c, k)
     df2 = df.take(indexer)
     locations = locations.cumsum()

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -477,7 +477,7 @@ group_split_dispatch = Dispatch("group_split_dispatch")
 
 
 @group_split_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
-def group_split_pandas(df, c, k, ignore_index=True):
+def group_split_pandas(df, c, k, ignore_index=False):
     indexer, locations = pd._libs.algos.groupsort_indexer(c, k)
     df2 = df.take(indexer)
     locations = locations.cumsum()


### PR DESCRIPTION
This PR adds an `ignore_index` argument to the `rearrange_by_column` code path (typically used for `set_index`).

The `set_index` operation in dask.dataframe currently uses `rearrange_by_column` (within `set_partition`) to shuffle data into new partitions.  When `shuffle="tasks"`, the shuffling is performed in `rearrange_by_column_tasks`, where a significant proportion of run time is spent within `group_split_dispatch` and `concat_dispatch`.   Since `set_partition` is only used within `set_index`, there is no reason for these dispatch functions to handle/preserve index values (since the index will just be replaced after the shuffle).  In cudf, we can sometimes improve both performance and memory consumption significantly by ignoring the index in both `group_split_dispatch` and `concat_dispatch`.

For example, here is a simple `set_index` benchmark (with `cudf`):
```python
import cudf
import dask_cudf
import numpy as np

npartitions = 13
datarange = 600
size = 1_000_000
np.random.seed(215)
df = cudf.DataFrame(
    {
        "a": np.arange(0, stop=size, dtype="int64"),
        "b": np.random.randint(datarange, size=size),
        "c": np.random.choice(["a", "b", "c", "d"], size=size),
        "d": np.random.choice([1, 2, 3, 4], size=size),
    }
)
df.d = df.d.astype("datetime64[ms]")
ddf = dask_cudf.from_cudf(df, npartitions=npartitions)

ddf_sorted = ddf.set_index("b")
%timeit ddf_sorted.persist()
```
With `master`, I get:
```
1.65 s ± 14.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
With this PR, I get:
```
1.23 s ± 34.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```


- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
