### PR TITLE
Optionally get rid of intermediary boxes in visualize, and add more labels

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -464,6 +464,9 @@ def visualize(*args, **kwargs):
     collapse : bool, optional
         Whether to collapse output boxes, which often have empty labels.
         Default is False.
+    verbose : bool, optional
+        Whether to label output and input boxes even if the data aren't chunked.
+        Beware: these labels can get very long. Default is False.
     **kwargs
        Additional keyword arguments to forward to ``to_graphviz``.
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -458,9 +458,12 @@ def visualize(*args, **kwargs):
     optimize_graph : bool, optional
         If True, the graph is optimized before rendering.  Otherwise,
         the graph is displayed as is. Default is False.
-    color: {None, 'order'}, optional
+    color : {None, 'order'}, optional
         Options to color nodes.  Provide ``cmap=`` keyword for additional
         colormap
+    collapse : bool, optional
+        Whether to collapse output boxes, which often have empty labels.
+        Default is False.
     **kwargs
        Additional keyword arguments to forward to ``to_graphviz``.
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -461,7 +461,7 @@ def visualize(*args, **kwargs):
     color : {None, 'order'}, optional
         Options to color nodes.  Provide ``cmap=`` keyword for additional
         colormap
-    collapse : bool, optional
+    collapse_outputs : bool, optional
         Whether to collapse output boxes, which often have empty labels.
         Default is False.
     verbose : bool, optional

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -104,7 +104,7 @@ def label(x, cache=None):
     return s
 
 
-def box_label(key):
+def box_label(key, value=None, verbose=True):
     """ Label boxes in graph by chunk index
 
     >>> box_label(('x', 1, 2, 3))
@@ -119,6 +119,10 @@ def box_label(key):
         if len(key) == 1:
             [key] = key
         return str(key)
+    elif verbose and value is None:
+        return str(key)
+    elif verbose:
+        return f"{key}={value}"
     else:
         return ""
 
@@ -132,7 +136,8 @@ def to_graphviz(
     node_attr=None,
     edge_attr=None,
     collapse=False,
-    **kwargs
+    verbose=False,
+    **kwargs,
 ):
     if data_attributes is None:
         data_attributes = {}
@@ -147,6 +152,7 @@ def to_graphviz(
     )
 
     seen = set()
+    connected = set()
 
     for k, v in dsk.items():
         k_name = name(k)
@@ -160,24 +166,31 @@ def to_graphviz(
                 g.node(func_name, **attrs)
             if not collapse:
                 g.edge(func_name, k_name)
+                connected.add(func_name)
+                connected.add(k_name)
 
             for dep in get_dependencies(dsk, k):
                 dep_name = name(dep)
                 if dep_name not in seen:
                     seen.add(dep_name)
                     attrs = data_attributes.get(dep, {})
-                    attrs.setdefault("label", box_label(dep))
+                    attrs.setdefault("label", box_label(dep, dsk.get(dep), verbose))
                     attrs.setdefault("shape", "box")
                     g.node(dep_name, **attrs)
                 g.edge(dep_name, func_name)
+                connected.add(dep_name)
+                connected.add(func_name)
 
         elif ishashable(v) and v in dsk:
-            g.edge(name(v), k_name)
+            v_name = name(v)
+            g.edge(v_name, k_name)
+            connected.add(v_name)
+            connected.add(k_name)
 
-        if k_name not in seen:
+        if ((collapse and k_name in connected) or not collapse) and k_name not in seen:
             seen.add(k_name)
             attrs = data_attributes.get(k, {})
-            attrs.setdefault("label", box_label(k))
+            attrs.setdefault("label", box_label(k, None, verbose))
             attrs.setdefault("shape", "box")
             g.node(k_name, **attrs)
     return g

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -104,7 +104,7 @@ def label(x, cache=None):
     return s
 
 
-def box_label(key, value=None, verbose=True):
+def box_label(key, verbose=True):
     """ Label boxes in graph by chunk index
 
     >>> box_label(('x', 1, 2, 3))
@@ -119,10 +119,8 @@ def box_label(key, value=None, verbose=True):
         if len(key) == 1:
             [key] = key
         return str(key)
-    elif verbose and value is None:
-        return str(key)
     elif verbose:
-        return f"{key}={value}"
+        return str(key)
     else:
         return ""
 
@@ -174,7 +172,7 @@ def to_graphviz(
                 if dep_name not in seen:
                     seen.add(dep_name)
                     attrs = data_attributes.get(dep, {})
-                    attrs.setdefault("label", box_label(dep, dsk.get(dep), verbose))
+                    attrs.setdefault("label", box_label(dep, verbose))
                     attrs.setdefault("shape", "box")
                     g.node(dep_name, **attrs)
                 g.edge(dep_name, func_name)
@@ -190,7 +188,7 @@ def to_graphviz(
         if ((collapse and k_name in connected) or not collapse) and k_name not in seen:
             seen.add(k_name)
             attrs = data_attributes.get(k, {})
-            attrs.setdefault("label", box_label(k, None, verbose))
+            attrs.setdefault("label", box_label(k, verbose))
             attrs.setdefault("shape", "box")
             g.node(k_name, **attrs)
     return g

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -104,7 +104,7 @@ def label(x, cache=None):
     return s
 
 
-def box_label(key, verbose=True):
+def box_label(key, verbose=False):
     """ Label boxes in graph by chunk index
 
     >>> box_label(('x', 1, 2, 3))
@@ -133,7 +133,7 @@ def to_graphviz(
     graph_attr={},
     node_attr=None,
     edge_attr=None,
-    collapse=False,
+    collapse_outputs=False,
     verbose=False,
     **kwargs,
 ):
@@ -155,14 +155,14 @@ def to_graphviz(
     for k, v in dsk.items():
         k_name = name(k)
         if istask(v):
-            func_name = name((k, "function")) if not collapse else k_name
-            if collapse or func_name not in seen:
+            func_name = name((k, "function")) if not collapse_outputs else k_name
+            if collapse_outputs or func_name not in seen:
                 seen.add(func_name)
                 attrs = function_attributes.get(k, {})
                 attrs.setdefault("label", key_split(k))
                 attrs.setdefault("shape", "circle")
                 g.node(func_name, **attrs)
-            if not collapse:
+            if not collapse_outputs:
                 g.edge(func_name, k_name)
                 connected.add(func_name)
                 connected.add(k_name)
@@ -185,7 +185,7 @@ def to_graphviz(
             connected.add(v_name)
             connected.add(k_name)
 
-        if ((collapse and k_name in connected) or not collapse) and k_name not in seen:
+        if (not collapse_outputs or k_name in connected) and k_name not in seen:
             seen.add(k_name)
             attrs = data_attributes.get(k, {})
             attrs.setdefault("label", box_label(k, verbose))

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -130,8 +130,8 @@ def test_to_graphviz_verbose():
     assert set(shapes) == set(("box", "circle"))
 
 
-def test_to_graphviz_collapse():
-    g = to_graphviz(dsk, collapse=True)
+def test_to_graphviz_collapse_outputs():
+    g = to_graphviz(dsk, collapse_outputs=True)
     labels = list(filter(None, map(get_label, g.body)))
     assert len(labels) == 6  # 6 nodes total
     assert set(labels) == {"c", "d", "e", "f", '""'}
@@ -139,8 +139,8 @@ def test_to_graphviz_collapse():
     assert set(shapes) == set(("box", "circle"))
 
 
-def test_to_graphviz_collapse_and_verbose():
-    g = to_graphviz(dsk, collapse=True, verbose=True)
+def test_to_graphviz_collapse_outputs_and_verbose():
+    g = to_graphviz(dsk, collapse_outputs=True, verbose=True)
     labels = list(filter(None, map(get_label, g.body)))
     assert len(labels) == 6  # 6 nodes total
     assert set(labels) == {"a", "b", "c", "d", "e", "f"}
@@ -155,7 +155,7 @@ def test_to_graphviz_with_unconnected_node():
     assert len(labels) == 11  # 11 nodes total
     assert set(labels) == {"a", "b", "c", "d", "e", "f", "g"}
 
-    g = to_graphviz(dsk, verbose=True, collapse=True)
+    g = to_graphviz(dsk, verbose=True, collapse_outputs=True)
     labels = list(filter(None, map(get_label, g.body)))
     assert len(labels) == 6  # 6 nodes total
     assert set(labels) == {"a", "b", "c", "d", "e", "f"}

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -121,6 +121,46 @@ def test_aliases():
     assert len(g.body) - len(labels) == 1  # Single edge
 
 
+def test_to_graphviz_verbose():
+    g = to_graphviz(dsk, verbose=True)
+    labels = list(filter(None, map(get_label, g.body)))
+    assert len(labels) == 10  # 10 nodes total
+    assert set(labels) == {"a", "b", "c", "d", "e", "f"}
+    shapes = list(filter(None, map(get_shape, g.body)))
+    assert set(shapes) == set(("box", "circle"))
+
+
+def test_to_graphviz_collapse():
+    g = to_graphviz(dsk, collapse=True)
+    labels = list(filter(None, map(get_label, g.body)))
+    assert len(labels) == 6  # 6 nodes total
+    assert set(labels) == {"c", "d", "e", "f", '""'}
+    shapes = list(filter(None, map(get_shape, g.body)))
+    assert set(shapes) == set(("box", "circle"))
+
+
+def test_to_graphviz_collapse_and_verbose():
+    g = to_graphviz(dsk, collapse=True, verbose=True)
+    labels = list(filter(None, map(get_label, g.body)))
+    assert len(labels) == 6  # 6 nodes total
+    assert set(labels) == {"a", "b", "c", "d", "e", "f"}
+    shapes = list(filter(None, map(get_shape, g.body)))
+    assert set(shapes) == set(("box", "circle"))
+
+
+def test_to_graphviz_with_unconnected_node():
+    dsk["g"] = 3
+    g = to_graphviz(dsk, verbose=True)
+    labels = list(filter(None, map(get_label, g.body)))
+    assert len(labels) == 11  # 11 nodes total
+    assert set(labels) == {"a", "b", "c", "d", "e", "f", "g"}
+
+    g = to_graphviz(dsk, verbose=True, collapse=True)
+    labels = list(filter(None, map(get_label, g.body)))
+    assert len(labels) == 6  # 6 nodes total
+    assert set(labels) == {"a", "b", "c", "d", "e", "f"}
+
+
 @pytest.mark.parametrize(
     "format,typ",
     [


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

This PR adds the `collapse` and `verbose` options to `visualize`. Collapse gets rid of all non-connected non-task boxes as well as any boxes that are just the output of a task that feeds into other tasks. Verbose adds a label to all the boxes even if the label is a duplicate.

This came up in #5928. Here are some images of what the new graphs from that page would look like:
## With lots of intermediary outputs
| | collapse=False  | collapse=True |
| - | -------------------- | ------------------- |
| **verbose=False** | ![image](https://user-images.githubusercontent.com/4806877/75917123-8406e000-5e27-11ea-9f77-45c4d5ec2e6f.png) | ![image](https://user-images.githubusercontent.com/4806877/75917072-718ca680-5e27-11ea-9011-13e678f20989.png) |
| **verbose=True** | ![image](https://user-images.githubusercontent.com/4806877/75917182-9a14a080-5e27-11ea-9fb8-e9051a18b9b6.png) | ![image](https://user-images.githubusercontent.com/4806877/75916831-0642d480-5e27-11ea-8d1c-112170debee2.png) | 


## With unconnected nodes
| | collapse=False  | collapse=True |
| - | -------------------- | ------------------- |
| **verbose=False** | ![image](https://user-images.githubusercontent.com/4806877/75990196-879b7500-5ec2-11ea-9e32-f14012a5add5.png) | ![image](https://user-images.githubusercontent.com/4806877/75990235-96822780-5ec2-11ea-9948-2a7efca76d97.png) |
| **verbose=True** | ![image](https://user-images.githubusercontent.com/4806877/75990151-73f00e80-5ec2-11ea-90c7-7e66398ff0ee.png) | ![image](https://user-images.githubusercontent.com/4806877/75990092-5a4ec700-5ec2-11ea-807a-e07332da8b3e.png) |
