### PR TITLE
Remove toolz.memoize dependency in dask.utils.

### DIFF
--- a/dask/utils.py
+++ b/dask/utils.py
@@ -809,7 +809,7 @@ def insert(tup, loc, val):
 def dependency_depth(dsk):
     deps, _ = get_deps(dsk)
 
-    @lru_cache()
+    @lru_cache(maxsize=None)
     def max_depth_by_deps(key):
         if not deps[key]:
             return 1

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -14,6 +14,7 @@ from numbers import Integral, Number
 from threading import Lock
 import uuid
 from weakref import WeakValueDictionary
+from functools import lru_cache
 
 from .core import get_deps
 from .optimization import key_split  # noqa: F401
@@ -806,11 +807,9 @@ def insert(tup, loc, val):
 
 
 def dependency_depth(dsk):
-    import toolz
-
     deps, _ = get_deps(dsk)
 
-    @toolz.memoize
+    @lru_cache
     def max_depth_by_deps(key):
         if not deps[key]:
             return 1

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -809,7 +809,7 @@ def insert(tup, loc, val):
 def dependency_depth(dsk):
     deps, _ = get_deps(dsk)
 
-    @lru_cache
+    @lru_cache()
     def max_depth_by_deps(key):
         if not deps[key]:
             return 1


### PR DESCRIPTION
Use lru_cache to cache function outputs instead of toolz.memoize. For now, just using the default settings for lru_cache.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
