### PR TITLE
Added capability to shuffle when splitting a dataframe.

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5453,6 +5453,8 @@ def pd_split(df, p, random_state=None, shuffle=False):
     """
     p = list(p)
     if shuffle:
+        if not isinstance(random_state, np.random.RandomState):
+            random_state = np.random.RandomState(random_state)
         df = df.sample(frac=1.0, random_state=random_state)
     index = pseudorandom(len(df), p, random_state)
     return [df.iloc[index == i] for i in range(len(p))]

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -31,7 +31,6 @@ from ..context import globalmethod
 from ..utils import (
     random_state_data,
     pseudorandom,
-    pseudorandom_shuffle,
     derived_from,
     funcname,
     memory_repr,
@@ -932,7 +931,7 @@ Dask Name: {name}, {task} tasks"""
         else:
             return func(self, *args, **kwargs)
 
-    def random_split(self, frac, random_state=None, shuffle=True):
+    def random_split(self, frac, random_state=None, shuffle=False):
         """ Pseudorandomly split dataframe into different pieces row-wise
 
         Parameters
@@ -942,7 +941,7 @@ Dask Name: {name}, {task} tasks"""
         random_state : int or np.random.RandomState
             If int create a new RandomState with this as the seed.
             Otherwise draw from the passed RandomState.
-        shuffle : bool, default True
+        shuffle : bool, default False
             If set to True, the dataframe is shuffled (within partition)
              before the split.
 
@@ -5432,7 +5431,7 @@ def cov_corr_agg(data, cols, min_periods=2, corr=False, scalar=False):
     return pd.DataFrame(mat, columns=cols, index=cols)
 
 
-def pd_split(df, p, random_state=None, shuffle=True):
+def pd_split(df, p, random_state=None, shuffle=False):
     """ Split DataFrame into multiple pieces pseudorandomly
 
     >>> df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6],
@@ -5454,11 +5453,7 @@ def pd_split(df, p, random_state=None, shuffle=True):
     """
     p = list(p)
     if shuffle:
-        shuffle_index = pseudorandom_shuffle(
-            n=len(df),
-            random_state=random_state
-        )
-        df = df.iloc[shuffle_index]
+        df = df.sample(frac=1.0, random_state=random_state)
     index = pseudorandom(len(df), p, random_state)
     return [df.iloc[index == i] for i in range(len(p))]
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -943,7 +943,7 @@ Dask Name: {name}, {task} tasks"""
             Otherwise draw from the passed RandomState.
         shuffle : bool, default False
             If set to True, the dataframe is shuffled (within partition)
-             before the split.
+            before the split.
 
         Examples
         --------
@@ -5443,12 +5443,12 @@ def pd_split(df, p, random_state=None, shuffle=False):
     >>> a
        a  b
     3  4  5
-    4  5  6
+    0  1  2
     5  6  7
     >>> b
        a  b
     1  2  3
-    0  1  2
+    4  5  6
     2  3  4
     """
     p = list(p)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1602,18 +1602,21 @@ def test_random_partitions():
     assert isinstance(a, dd.DataFrame)
     assert isinstance(b, dd.DataFrame)
     assert a._name != b._name
+    np.testing.assert_array_equal(a.index, sorted(a.index))
 
     assert len(a.compute()) + len(b.compute()) == len(full)
     a2, b2 = d.random_split([0.5, 0.5], 42)
     assert a2._name == a._name
     assert b2._name == b._name
 
+    a1, b1 = d.random_split([0.5, 0.5], random_state=42, shuffle=True)
+    a2, b2 = d.random_split([0.5, 0.5], random_state=42, shuffle=True)
+    assert_eq(a1, a2)
+    assert_eq(b1, b2)
+
     a, b = d.random_split([0.5, 0.5], 42, True)
     with pytest.raises(AssertionError):
         np.testing.assert_array_equal(a.index, sorted(a.index))
-
-    a, b = d.random_split([0.5, 0.5], 42, False)
-    np.testing.assert_array_equal(a.index, sorted(a.index))
 
     parts = d.random_split([0.4, 0.5, 0.1], 42)
     names = set([p._name for p in parts])

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1609,12 +1609,10 @@ def test_random_partitions():
     assert a2._name == a._name
     assert b2._name == b._name
 
-    a1, b1 = d.random_split([0.5, 0.5], random_state=42, shuffle=True)
-    a2, b2 = d.random_split([0.5, 0.5], random_state=42, shuffle=True)
-    assert_eq(a1, a2)
-    assert_eq(b1, b2)
-
     a, b = d.random_split([0.5, 0.5], 42, True)
+    a2, b2 = d.random_split([0.5, 0.5], 42, True)
+    assert_eq(a, a2)
+    assert_eq(b, b2)
     with pytest.raises(AssertionError):
         np.testing.assert_array_equal(a.index, sorted(a.index))
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1608,6 +1608,13 @@ def test_random_partitions():
     assert a2._name == a._name
     assert b2._name == b._name
 
+    a, b = d.random_split([0.5, 0.5], 42, True)
+    with pytest.raises(AssertionError):
+        np.testing.assert_array_equal(a.index, sorted(a.index))
+
+    a, b = d.random_split([0.5, 0.5], 42, False)
+    np.testing.assert_array_equal(a.index, sorted(a.index))
+
     parts = d.random_split([0.4, 0.5, 0.1], 42)
     names = set([p._name for p in parts])
     names.update([a._name, b._name])

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -265,6 +265,25 @@ def pseudorandom(n, p, random_state=None):
     return out
 
 
+def pseudorandom_shuffle(n, random_state=None):
+    """Return a list of shuffled indices for an array of length n.
+
+    Parameters
+    ----------
+    n : int
+        Length of list to shuffle.
+    random_state : int or np.random.RandomState, optional
+        If an int, is used to seed a new ``RandomState``.
+    """
+    import numpy as np
+
+    if not isinstance(random_state, np.random.RandomState):
+        random_state = np.random.RandomState(random_state)
+
+    out = random_state.permutation(n)
+    return out
+
+
 def random_state_data(n, random_state=None):
     """Return a list of arrays that can initialize
     ``np.random.RandomState``.

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -265,25 +265,6 @@ def pseudorandom(n, p, random_state=None):
     return out
 
 
-def pseudorandom_shuffle(n, random_state=None):
-    """Return a list of shuffled indices for an array of length n.
-
-    Parameters
-    ----------
-    n : int
-        Length of list to shuffle.
-    random_state : int or np.random.RandomState, optional
-        If an int, is used to seed a new ``RandomState``.
-    """
-    import numpy as np
-
-    if not isinstance(random_state, np.random.RandomState):
-        random_state = np.random.RandomState(random_state)
-
-    out = random_state.permutation(n)
-    return out
-
-
 def random_state_data(n, random_state=None):
     """Return a list of arrays that can initialize
     ``np.random.RandomState``.


### PR DESCRIPTION
This is the first part of our internal implementation extending dask-ml's `train_test_split` to shuffle dataframes within partitions (second commit will be in dask-ml). Thought we give it a shot at a contribution.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
