### PR TITLE
Array slicing: fix typo in slice_with_int_dask_array error message

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -917,7 +917,7 @@ def slice_with_int_dask_array(x, index):
         for idx in index
     ]
     if sum(fancy_indexes) > 1:
-        raise NotImplementedError("Don't yet support nd fancy indexing)")
+        raise NotImplementedError("Don't yet support nd fancy indexing")
 
     out_index = []
     dropped_axis_cnt = 0


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`