### PR TITLE
allow dataframes of different lengths to be concatenated when divisions are unknown

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -859,18 +859,14 @@ def merge_asof(
 # Concat
 ###############################################################
 
-
-def concat_and_check(dfs):
-    if len(set(map(len, dfs))) != 1:
-        raise ValueError("Concatenated DataFrames of different lengths")
-    return methods.concat(dfs, axis=1)
+concat_axis1 = partial(methods.concat, axis=1)
 
 
 def concat_unindexed_dataframes(dfs):
     name = "concat-" + tokenize(*dfs)
 
     dsk = {
-        (name, i): (concat_and_check, [(df._name, i) for df in dfs])
+        (name, i): (concat_axis1, [(df._name, i) for df in dfs])
         for i in range(dfs[0].npartitions)
     }
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1348,17 +1348,6 @@ def test_concat_unknown_divisions():
         dd.concat([aa, cc], axis=1)
 
 
-def test_concat_unknown_divisions_errors():
-    a = pd.Series([1, 2, 3, 4, 5, 6])
-    b = pd.Series([4, 3, 2, 1])
-    aa = dd.from_pandas(a, npartitions=2, sort=False)
-    bb = dd.from_pandas(b, npartitions=2, sort=False)
-
-    with pytest.raises(ValueError):
-        with pytest.warns(UserWarning):  # Concat with unknown divisions
-            dd.concat([aa, bb], axis=1).compute()
-
-
 def test_concat2():
     dsk = {
         ("x", 0): pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}),


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

This PR makes it possible to join series and dataframes when their lengths differ. I believe this PR would make dask more consistent with it's own behavior and with pandas  (see code block below). I removed one test which made sure an error was thrown when concatenating dataframes of various lengths, but all others pass.  This PR will also be helpful in a separate PR where I am implementing the mode function https://github.com/dask/dask/pull/5958#discussion_r389158341 in dask as mentioned in https://github.com/dask/dask/issues/5744.

```python3
s1 = pd.Series([1, 2])
s2 = pd.Series([1, 2, 3])
s3 = pd.concat([s1, s2], axis=1)  # completes successfully

s1 = dd.from_pandas(pd.Series([1, 2]), npartitions=1)
s2 = dd.from_pandas(pd.Series([1, 2, 3]), npartitions=1)
s3 = dd.concat([s1, s2], axis=1).compute()  # completes successfully

s1 = dd.from_pandas(pd.Series([1, 2]), npartitions=1)
s2 = dd.from_pandas(pd.Series([1, 2, 3]), npartitions=1)
s1.divisions = (None, None)
s2.divisions = (None, None)
s3 = dd.concat([s1, s2], axis=1).compute()  # prior to this PR threw error "ValueError: Concatenated DataFrames of different lengths"
```

