### PR TITLE
Copy dict in to_graphviz to prevent overwriting

### DIFF
--- a/dask/dot.py
+++ b/dask/dot.py
@@ -130,7 +130,7 @@ def to_graphviz(
     data_attributes=None,
     function_attributes=None,
     rankdir="BT",
-    graph_attr={},
+    graph_attr=None,
     node_attr=None,
     edge_attr=None,
     collapse_outputs=False,
@@ -141,6 +141,8 @@ def to_graphviz(
         data_attributes = {}
     if function_attributes is None:
         function_attributes = {}
+    if graph_attr is None:
+        graph_attr = {}
 
     graph_attr = graph_attr or {}
     graph_attr["rankdir"] = rankdir

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -1,4 +1,3 @@
-import copy
 import re
 import os
 from functools import partial
@@ -140,12 +139,8 @@ def to_graphviz(
 ):
     if data_attributes is None:
         data_attributes = {}
-    else:
-        data_attributes = copy.copy(data_attributes)
     if function_attributes is None:
         function_attributes = {}
-    else:
-        function_attributes = copy.copy(function_attributes)
 
     graph_attr = graph_attr or {}
     graph_attr["rankdir"] = rankdir
@@ -163,7 +158,7 @@ def to_graphviz(
             func_name = name((k, "function")) if not collapse_outputs else k_name
             if collapse_outputs or func_name not in seen:
                 seen.add(func_name)
-                attrs = function_attributes.get(k, {})
+                attrs = function_attributes.get(k, {}).copy()
                 attrs.setdefault("label", key_split(k))
                 attrs.setdefault("shape", "circle")
                 g.node(func_name, **attrs)
@@ -176,7 +171,7 @@ def to_graphviz(
                 dep_name = name(dep)
                 if dep_name not in seen:
                     seen.add(dep_name)
-                    attrs = data_attributes.get(dep, {})
+                    attrs = data_attributes.get(dep, {}).copy()
                     attrs.setdefault("label", box_label(dep, verbose))
                     attrs.setdefault("shape", "box")
                     g.node(dep_name, **attrs)
@@ -192,7 +187,7 @@ def to_graphviz(
 
         if (not collapse_outputs or k_name in connected) and k_name not in seen:
             seen.add(k_name)
-            attrs = data_attributes.get(k, {})
+            attrs = data_attributes.get(k, {}).copy()
             attrs.setdefault("label", box_label(k, verbose))
             attrs.setdefault("shape", "box")
             g.node(k_name, **attrs)

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -140,8 +140,12 @@ def to_graphviz(
 ):
     if data_attributes is None:
         data_attributes = {}
+    else:
+        data_attributes = copy.copy(data_attributes)
     if function_attributes is None:
         function_attributes = {}
+    else:
+        function_attributes = copy.copy(function_attributes)
 
     graph_attr = graph_attr or {}
     graph_attr["rankdir"] = rankdir
@@ -152,10 +156,6 @@ def to_graphviz(
 
     seen = set()
     connected = set()
-
-    function_attributes = copy.copy(function_attributes)
-    data_attributes = copy.copy(data_attributes)
-    data_attributes = copy.copy(data_attributes)
 
     for k, v in dsk.items():
         k_name = name(k)

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -1,3 +1,4 @@
+import copy
 import re
 import os
 from functools import partial
@@ -158,7 +159,7 @@ def to_graphviz(
             func_name = name((k, "function")) if not collapse_outputs else k_name
             if collapse_outputs or func_name not in seen:
                 seen.add(func_name)
-                attrs = function_attributes.get(k, {})
+                attrs = copy.copy(function_attributes.get(k, {}))
                 attrs.setdefault("label", key_split(k))
                 attrs.setdefault("shape", "circle")
                 g.node(func_name, **attrs)
@@ -171,7 +172,7 @@ def to_graphviz(
                 dep_name = name(dep)
                 if dep_name not in seen:
                     seen.add(dep_name)
-                    attrs = data_attributes.get(dep, {})
+                    attrs = copy.copy(data_attributes.get(dep, {}))
                     attrs.setdefault("label", box_label(dep, verbose))
                     attrs.setdefault("shape", "box")
                     g.node(dep_name, **attrs)
@@ -187,7 +188,7 @@ def to_graphviz(
 
         if (not collapse_outputs or k_name in connected) and k_name not in seen:
             seen.add(k_name)
-            attrs = data_attributes.get(k, {})
+            attrs = copy.copy(data_attributes.get(k, {}))
             attrs.setdefault("label", box_label(k, verbose))
             attrs.setdefault("shape", "box")
             g.node(k_name, **attrs)

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -153,13 +153,17 @@ def to_graphviz(
     seen = set()
     connected = set()
 
+    function_attributes = copy.copy(function_attributes)
+    data_attributes = copy.copy(data_attributes)
+    data_attributes = copy.copy(data_attributes)
+
     for k, v in dsk.items():
         k_name = name(k)
         if istask(v):
             func_name = name((k, "function")) if not collapse_outputs else k_name
             if collapse_outputs or func_name not in seen:
                 seen.add(func_name)
-                attrs = copy.copy(function_attributes.get(k, {}))
+                attrs = function_attributes.get(k, {})
                 attrs.setdefault("label", key_split(k))
                 attrs.setdefault("shape", "circle")
                 g.node(func_name, **attrs)
@@ -172,7 +176,7 @@ def to_graphviz(
                 dep_name = name(dep)
                 if dep_name not in seen:
                     seen.add(dep_name)
-                    attrs = copy.copy(data_attributes.get(dep, {}))
+                    attrs = data_attributes.get(dep, {})
                     attrs.setdefault("label", box_label(dep, verbose))
                     attrs.setdefault("shape", "box")
                     g.node(dep_name, **attrs)
@@ -188,7 +192,7 @@ def to_graphviz(
 
         if (not collapse_outputs or k_name in connected) and k_name not in seen:
             seen.add(k_name)
-            attrs = copy.copy(data_attributes.get(k, {}))
+            attrs = data_attributes.get(k, {})
             attrs.setdefault("label", box_label(k, verbose))
             attrs.setdefault("shape", "box")
             g.node(k_name, **attrs)

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -285,7 +285,7 @@ def test_immutable_attributes():
     to_graphviz(
         dsk,
         function_attributes=attrs_func,
-        datat_attributes=attrs_data,
+        data_attributes=attrs_data,
     )
 
     assert attrs_func_test == attrs_func

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -3,6 +3,7 @@ from functools import partial
 import re
 from operator import add, neg
 import sys
+import copy
 import pytest
 
 
@@ -271,3 +272,21 @@ def test_delayed_kwargs_apply():
     label = task_label(x.dask[x.key])
     assert "f" in label
     assert "apply" not in label
+
+
+def test_immutable_attributes():
+    def inc(x): return x + 1
+    dsk = {"a": (inc, 1), "b": (inc, 2), "c": (add , "a", "b")}
+    attrs_func = {"a": {}}
+    attrs_data = {"b": {}}
+    attrs_func_test = copy.deepcopy(attrs_func)
+    attrs_data_test = copy.deepcopy(attrs_data)
+
+    to_graphviz(
+        dsk,
+        function_attributes=attrs_func,
+        datat_attributes=attrs_data,
+    )
+
+    assert attrs_func_test == attrs_func
+    assert attrs_data_test == attrs_data

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -275,17 +275,17 @@ def test_delayed_kwargs_apply():
 
 
 def test_immutable_attributes():
-    def inc(x): return x + 1
-    dsk = {"a": (inc, 1), "b": (inc, 2), "c": (add , "a", "b")}
+    def inc(x):
+        return x + 1
+
+    dsk = {"a": (inc, 1), "b": (inc, 2), "c": (add, "a", "b")}
     attrs_func = {"a": {}}
     attrs_data = {"b": {}}
     attrs_func_test = copy.deepcopy(attrs_func)
     attrs_data_test = copy.deepcopy(attrs_data)
 
     to_graphviz(
-        dsk,
-        function_attributes=attrs_func,
-        data_attributes=attrs_data,
+        dsk, function_attributes=attrs_func, data_attributes=attrs_data,
     )
 
     assert attrs_func_test == attrs_func


### PR DESCRIPTION
- on the first iteration the value is not only set in attrs, but also in
e.g. function_attributes. On every consecutive iteration the label of
the first iteration will be used.

closes #5995

- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

I couldn't come up with an idea for a test.

I did add the copy to all places where I think the bug could occur. I've only tested it for `function_attributes` though.