### PR TITLE
[POC] Do FS operations on remote workers

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -211,7 +211,8 @@ def read_parquet(
 
     if hasattr(path, "name"):
         path = stringify_path(path)
-    fs, _, paths = get_fs_token_paths(path, mode="rb", storage_options=storage_options)
+    fs, _, paths = get_fs_token_paths(path, mode="rb", storage_options=storage_options,
+                                      protocol="dask")
 
     paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
 
@@ -367,7 +368,8 @@ def to_parquet(
 
     if hasattr(path, "name"):
         path = stringify_path(path)
-    fs, _, _ = get_fs_token_paths(path, mode="wb", storage_options=storage_options)
+    fs, _, _ = get_fs_token_paths(path, mode="wb", storage_options=storage_options,
+                                  protocol="dask")
     # Trim any protocol information from the path before forwarding
     path = fs._strip_protocol(path)
 


### PR DESCRIPTION
For discussion.

Solves #5380 in combination with https://github.com/intake/filesystem_spec/pull/244

For a start, only parquet is affected.

Parquet tests here pass with the fsspec branch above (not with the env in CI); however, the tests only use the local scheduler, so they only show that the "pass through" part works.