### PR TITLE
Avoid reading _metadata on every worker

### DIFF
--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -372,7 +372,11 @@ class FastParquetEngine(Engine):
         i_path = 0
         path_last = None
         for i, piece in enumerate(partsin):
-            if (
+            if partitions and fast_metadata:
+                # We can pass a "_metadata" path
+                file_path = base_path + "_metadata"
+                i_path = i
+            elif (
                 pf_deps
                 and isinstance(piece.columns[0].file_path, str)
                 and not partitions
@@ -384,14 +388,12 @@ class FastParquetEngine(Engine):
                 else:
                     i_path = 0
                     path_last = path_curr
-                file_path = base_path + piece.columns[0].file_path
+                file_path = base_path + path_curr
             else:
                 # We cannot pass a specific file/part path
                 file_path = paths
                 i_path = i
-            if partitions and fast_metadata:
-                # We can pass a "_metadata" path
-                file_path = base_path + "_metadata"
+
             piece_item = i_path if pf_deps else piece
             pf_piece = pf_deps
             if pf_deps:

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -395,11 +395,7 @@ class FastParquetEngine(Engine):
                 i_path = i
 
             piece_item = i_path if pf_deps else piece
-            pf_piece = pf_deps
-            if pf_deps:
-                pf_piece = (
-                    (file_path, gather_statistics) if pf_deps == "tuple" else pf_deps
-                )
+            pf_piece = (file_path, gather_statistics) if pf_deps == "tuple" else pf_deps
             part = {
                 "piece": piece_item,
                 "kwargs": {"pf": pf_piece, "categories": categories_dict or categories},

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -348,13 +348,24 @@ class FastParquetEngine(Engine):
         # This is a list of row-group-descriptor dicts, or file-paths
         # if we have a list of files and gather_statistics=False
         if not parts:
+            # Populate `partsin` with dataset row-groups
             partsin = pf.row_groups
             partitions = pf.info.get("partitions", None)
             if partitions and not fast_metadata:
+                # We have partitions, and do not have
+                # a "_metadata" file for the worker to read.
+                # Therefore, we need to pass the pf object in
+                # the task graph
                 pf_deps = pf
             else:
+                # We don't need to pass a pf object in the task graph.
+                # Instead, we can pass the path for each part. Start
+                # with `paths`, since the worker can find `_metadata`
+                # from there if `partitions=True`
                 pf_deps = (paths, gather_statistics)
         else:
+            # `parts` is just a list of path names.
+            # No tricky logic necessary
             partitions = None
             pf_deps = None
             partsin = parts


### PR DESCRIPTION
~Closes~ Partially addresses #5842 

For `FastParquetEngine`,  we are currently re-reading the "_metadata" file for every partition in many cases. This PR will avoid doing so whenever possible.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
