### PR TITLE
Fix bugs in _metadata creation and filtering in parquet ArrowEngine

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -232,7 +232,8 @@ class ArrowEngine(Engine):
         # Therefore, we cannot perform filtering with split_row_groups=False.
         # For "partitioned" datasets, each file (usually) corresponds to a
         # row-group anyway.
-        # TODO: Map row-group statistics onto the file-level statistics.
+        # TODO: Map row-group statistics onto file pieces for filtering.
+        #       This shouldn't be difficult if `col_chunk_paths==True`
         if not split_row_groups:
             if gather_statistics is None and not partitions:
                 gather_statistics = False

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -291,7 +291,7 @@ class ArrowEngine(Engine):
                     for i in range(dataset.metadata.num_row_groups)
                 ]
 
-                # Alight row-group paths with pieces
+                # Re-order row-groups by path name if known
                 if col_chunk_paths:
                     row_groups = sorted(
                         row_groups,

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -159,6 +159,9 @@ def _write_partitioned(
 
         Logic copied from pyarrow.parquet.
         (arrow/python/pyarrow/parquet.py::write_to_dataset)
+
+        TODO: Remove this in favor of pyarrow's `write_to_dataset`
+              once ARROW-8244 is addressed.
     """
     fs.mkdirs(root_path, exist_ok=True)
 

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -134,7 +134,7 @@ def _write_partitioned(table, root_path, partition_cols, filesystem=None, **kwar
         (arrow/python/pyarrow/parquet.py::write_to_dataset)
     """
     fs, root_path = _get_filesystem_and_path(filesystem, root_path)
-    fs.mkdir(root_path, exists_ok=True)
+    fs.mkdirs(root_path, exist_ok=True)
 
     df = table.to_pandas(ignore_metadata=True)
     partition_keys = [df[col] for col in partition_cols]

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -222,6 +222,13 @@ def read_parquet(
     if index and isinstance(index, str):
         index = [index]
 
+    if filters:
+        # Filters require us to gather statistics
+        if gather_statistics is False:
+            raise ValueError("Cannot apply filters with gather_statistics=False")
+        elif not gather_statistics:
+            gather_statistics = True
+
     meta, statistics, parts = engine.read_metadata(
         fs,
         paths,

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -222,13 +222,6 @@ def read_parquet(
     if index and isinstance(index, str):
         index = [index]
 
-    if filters:
-        # Filters require us to gather statistics
-        if gather_statistics is False:
-            raise ValueError("Cannot apply filters with gather_statistics=False")
-        elif not gather_statistics:
-            gather_statistics = True
-
     meta, statistics, parts = engine.read_metadata(
         fs,
         paths,

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1002,9 +1002,14 @@ def test_to_parquet_pyarrow_w_inconsistent_schema_by_partition_succeeds_w_manual
             ("partition_column", pa.int64()),
         ]
     )
-    ddf.to_parquet(
-        str(tmpdir), engine="pyarrow", partition_on="partition_column", schema=schema
+    fut = ddf.to_parquet(
+        str(tmpdir),
+        compute=False,
+        engine="pyarrow",
+        partition_on="partition_column",
+        schema=schema,
     )
+    fut.compute(scheduler="single-threaded")
     ddf_after_write = (
         dd.read_parquet(str(tmpdir), engine="pyarrow", gather_statistics=False)
         .compute()

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1093,7 +1093,7 @@ def test_partition_on_string(tmpdir, partition_on):
         assert set(df.bb[df.aa == val]) == set(out.bb[out.aa == val])
 
 
-@write_read_engines_xfail
+@write_read_engines()
 def test_filters_categorical(tmpdir, write_engine, read_engine):
     tmpdir = str(tmpdir)
     cats = ["2018-01-01", "2018-01-02", "2018-01-03", "2018-01-04"]
@@ -1767,9 +1767,9 @@ def test_arrow_partitioning(tmpdir):
     }
     pdf = pd.DataFrame(data)
     ddf = dd.from_pandas(pdf, npartitions=2)
-    ddf.to_parquet(path, engine="pyarrow", partition_on="p")
+    ddf.to_parquet(path, engine="pyarrow", write_index=False, partition_on="p")
 
-    ddf = dd.read_parquet(path, engine="pyarrow")
+    ddf = dd.read_parquet(path, index=False, engine="pyarrow")
 
     ddf.astype({"b": np.float32}).compute()
 
@@ -2268,7 +2268,7 @@ def test_read_parquet_getitem_skip_when_getting_getitem(tmpdir, engine):
 
 
 @pytest.mark.parametrize("gather_statistics", [None, True])
-@write_read_engines_xfail
+@write_read_engines()
 def test_filter_nonpartition_columns(
     tmpdir, write_engine, read_engine, gather_statistics
 ):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2109,7 +2109,7 @@ def test_split_row_groups_pyarrow(tmpdir):
     assert ddf3.npartitions == 4
 
     ddf3 = dd.read_parquet(
-        tmp, engine="pyarrow", gather_statistics=True, split_row_groups=False
+        tmp, engine="pyarrow", gather_statistics=False, split_row_groups=False
     )
     assert ddf3.npartitions == 2
 
@@ -2127,7 +2127,7 @@ def test_split_row_groups_pyarrow(tmpdir):
     assert ddf3.npartitions == 12
 
     ddf3 = dd.read_parquet(
-        tmp, engine="pyarrow", gather_statistics=True, split_row_groups=False
+        tmp, engine="pyarrow", gather_statistics=False, split_row_groups=False
     )
     assert ddf3.npartitions == 4
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -639,7 +639,9 @@ def test_append_with_partition(tmpdir, engine):
         engine=engine,
     )
 
-    out = dd.read_parquet(tmp, engine=engine, gather_statistics=True).compute()
+    out = dd.read_parquet(
+        tmp, engine=engine, index="index", gather_statistics=True
+    ).compute()
     out["lon"] = out.lon.astype("int")  # just to pass assert
     # sort required since partitioning breaks index order
     assert_eq(


### PR DESCRIPTION
~Mostly addresses #5959 (More work needed for a `"_metadata"`-based solution)~

Closes #5959

~The current `ArrowEngine` implementation is **not** writing a correct global `"_metadata"` file, because it is only including metadata for a single parquet partition originating from each dask partition. This PR includes a simple fix for the `"_metadata"`-creation bug, but still skips the step of populating the "file_path" fields in the metadata.  We are skipping this for now, because it is not trivial to back out the full file_path for each metadata element.~

~While the global metadata file now contains the correct number of row-groups in this PR, the `read_metadata`  definition must ignore it (mostly) when gathering statistics, because the **order** of the row-groups is different than the order of the `dataset.pieces` (which uses a `natural_sort_key` ordering by default).  There are several ways to rearrange the `"_metadata"`-based row groups to align with `dataset.pieces`, but the most general solution would be to add the "file_path" fields in the metadata (and simply align the row-group paths with the pieces paths).  To make this clean, we may want to add an option to populate the file_path in pyarrow's `write_to_dataset` definition... I am still trying to make a decision on the best solution (I'm certainly open to ideas/suggestions).~

EDIT: This PR now generates/uses a correct "_metadata" file for partitioned datasets in `ArrowEngine` (note that this has fixed some pyarrow-fastparquet compatibility issues).  To achieve this, the dataset partitioning is now performed in dask rather than pyarrow.  The *new* code added here for partitioning can be removed if/when the pyarrow `write_to_dataset` API is modified to return new file paths or to explicitly set the file_path for metadata objects added to `metadata_collector`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
