### PR TITLE
Improve path-related exceptions in read_hdf

### DIFF
--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -473,7 +473,7 @@ def read_hdf(
         paths = sorted(glob(pattern))
     else:
         paths = pattern
-        
+
     if not isinstance(pattern, str) and len(paths) == 0:
         raise ValueError("No files provided")
     if not paths or len(paths) == 0:
@@ -484,7 +484,9 @@ def read_hdf(
         except (ValueError, TypeError):
             exists = False
         if not exists:
-            raise IOError("File not found or insufficient permissions: {0}".format(path))
+            raise IOError(
+                "File not found or insufficient permissions: {0}".format(path)
+            )
     if (start != 0 or stop is not None) and len(paths) > 1:
         raise NotImplementedError(read_hdf_error_msg)
     if chunksize <= 0:

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -473,6 +473,18 @@ def read_hdf(
         paths = sorted(glob(pattern))
     else:
         paths = pattern
+        
+    if not isinstance(pattern, str) and len(paths) == 0:
+        raise ValueError("No files provided")
+    if not paths or len(paths) == 0:
+        raise IOError("File(s) not found: {0}".format(pattern))
+    for path in paths:
+        try:
+            exists = os.path.exists(path)
+        except (ValueError, TypeError):
+            exists = False
+        if not exists:
+            raise IOError("File not found or insufficient permissions: {0}".format(path))
     if (start != 0 or stop is not None) and len(paths) > 1:
         raise NotImplementedError(read_hdf_error_msg)
     if chunksize <= 0:

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -830,16 +830,17 @@ def test_hdf_filenames():
     os.remove("foo0.hdf5")
     os.remove("foo1.hdf5")
 
+
 def test_hdf_path_exceptions():
 
     # single file doesn't exist
     with pytest.raises(IOError):
-        dd.read_hdf('nonexistant_store_X34HJK', '/tmp')
+        dd.read_hdf("nonexistant_store_X34HJK", "/tmp")
 
     # a file from a list of files doesn't exist
     with pytest.raises(IOError):
-        dd.read_hdf(['nonexistant_store_X34HJK', 'nonexistant_store_UY56YH'], '/tmp')
+        dd.read_hdf(["nonexistant_store_X34HJK", "nonexistant_store_UY56YH"], "/tmp")
 
     # list of files is empty
     with pytest.raises(ValueError):
-        dd.read_hdf([], '/tmp')
+        dd.read_hdf([], "/tmp")

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -829,3 +829,17 @@ def test_hdf_filenames():
     assert ddf.to_hdf("foo*.hdf5", "key") == ["foo0.hdf5", "foo1.hdf5"]
     os.remove("foo0.hdf5")
     os.remove("foo1.hdf5")
+
+def test_hdf_path_exceptions():
+
+    # single file doesn't exist
+    with pytest.raises(IOError):
+        dd.read_hdf('nonexistant_store_X34HJK', '/tmp')
+
+    # a file from a list of files doesn't exist
+    with pytest.raises(IOError):
+        dd.read_hdf(['nonexistant_store_X34HJK', 'nonexistant_store_UY56YH'], '/tmp')
+
+    # list of files is empty
+    with pytest.raises(ValueError):
+        dd.read_hdf([], '/tmp')


### PR DESCRIPTION
Fixes #1613
I reviewed previous work on this issue, and this is my proposal of improved error messages in `read_hdf`, alongside tests.
Note that the case of empty list as an argument was considered ambiguous, as far as error handling goes. To me it would make sense if `read_hdf` returned an empty `DataFrame` instead of throwing an exception in this case, but as I haven't found any concrete definition of a "canonical" empty Dask `DataFrame`, it should be more consistent to just throw an error here. The fact that `concat` also throws an exception if provided an empty list further makes me feel like we should avoid empty `DataFrames`.
Also the reason why I chose to return two distinct error messages is that according to Python docs, `os.path.exists` can also return `false` if the user has insufficient permissions to call `os.stat`.