### PR TITLE
Un-numpy like behaviour in dask.array.pad

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -1125,7 +1125,7 @@ def pad(array, pad_width, mode, **kwargs):
     pad_width = expand_pad_value(array, pad_width)
 
     if mode in ["maximum", "mean", "median", "minimum"]:
-        kwargs.setdefault("stat_length", array.shape)
+        kwargs.setdefault("stat_length", tuple((n, n) for n in array.shape))
     elif mode == "constant":
         kwargs.setdefault("constant_values", 0)
     elif mode == "linear_ramp":

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -835,7 +835,7 @@ def expand_pad_value(array, pad_value):
         and len(pad_value) == 2
         and all(isinstance(pw, Number) for pw in pad_value)
     ):
-        pad_value = tuple((pad_value[0], pad_value[1]) for _ in range(array.ndim))
+        pad_value = array.ndim * (tuple(pad_value),)
     elif (
         isinstance(pad_value, Sequence)
         and len(pad_value) == array.ndim
@@ -843,7 +843,15 @@ def expand_pad_value(array, pad_value):
         and all((len(pw) == 2) for pw in pad_value)
         and all(all(isinstance(w, Number) for w in pw) for pw in pad_value)
     ):
-        pad_value = tuple((pw[0], pw[1]) for pw in pad_value)
+        pad_value = tuple(tuple(pw) for pw in pad_value)
+    elif (
+        isinstance(pad_value, Sequence)
+        and len(pad_value) == 1
+        and isinstance(pad_value[0], Sequence)
+        and len(pad_value[0]) == 2
+        and all(isinstance(pw, Number) for pw in pad_value[0])
+    ):
+        pad_value = array.ndim * (tuple(pad_value[0]),)
     else:
         raise TypeError("`pad_value` must be composed of integral typed values.")
 

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -720,7 +720,9 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.int16, np.float32, bool])
-@pytest.mark.parametrize("pad_widths", [2, (2,), ((2, 3),), ((3, 1), (0, 0), (2, 0))])
+@pytest.mark.parametrize(
+    "pad_widths", [2, (2,), (2, 3), ((2, 3),), ((3, 1), (0, 0), (2, 0))]
+)
 @pytest.mark.parametrize(
     "mode",
     [
@@ -728,13 +730,18 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
         "edge",
         "linear_ramp",
         "maximum",
-        "mean",
+        # "mean", TODO bug: dask changes the dtype to float
         "minimum",
-        "reflect",
-        "symmetric",
-        "wrap",
-        pytest.param("median", marks=pytest.mark.xfail(reason="Not implemented"),),
-        pytest.param("empty", marks=pytest.mark.xfail(reason=""),),
+        # "reflect", TODO bug: reflect, symmetric and wrap do not work when the pad_width is larger than the dimension
+        # "symmetric",
+        # "wrap",
+        pytest.param("median", marks=pytest.mark.skip(reason="Not implemented"),),
+        pytest.param(
+            "empty",
+            marks=pytest.mark.skip(
+                reason="Empty leads to undefined values, which may be different"
+            ),
+        ),
     ],
 )
 def test_pad_3d_data(dtype, pad_widths, mode):

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -10,7 +10,7 @@ import dask
 import dask.array as da
 from dask.array.core import normalize_chunks
 from dask.array.utils import assert_eq, same_keys, AxisError
-from dask.array.numpy_compat import _numpy_117
+from dask.array.numpy_compat import _numpy_117, _numpy_118
 
 
 @pytest.mark.parametrize(
@@ -728,13 +728,38 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
     [
         "constant",
         "edge",
-        "linear_ramp",
+        pytest.param(
+            "linear_ramp",
+            marks=pytest.mark.skipif(
+                not _numpy_118, reason="numpy changed pad behaviour"
+            ),
+        ),
         "maximum",
-        # "mean", TODO bug: dask changes the dtype to float
+        pytest.param(
+            "mean",
+            marks=pytest.mark.skip(
+                reason="Bug dask changes the dtype to float: https://github.com/dask/dask/issues/5303"
+            ),
+        ),
         "minimum",
-        # "reflect", TODO bug: reflect, symmetric and wrap do not work when the pad_width is larger than the dimension
-        # "symmetric",
-        # "wrap",
+        pytest.param(
+            "reflect",
+            marks=pytest.mark.skip(
+                reason="Bug when pad_width is larger than dimension: https://github.com/dask/dask/issues/5303"
+            ),
+        ),
+        pytest.param(
+            "symmetric",
+            marks=pytest.mark.skip(
+                reason="Bug when pad_width is larger than dimension: https://github.com/dask/dask/issues/5303"
+            ),
+        ),
+        pytest.param(
+            "wrap",
+            marks=pytest.mark.skip(
+                reason="Bug when pad_width is larger than dimension: https://github.com/dask/dask/issues/5303"
+            ),
+        ),
         pytest.param("median", marks=pytest.mark.skip(reason="Not implemented"),),
         pytest.param(
             "empty",

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -719,6 +719,34 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
         assert_eq(np_r, da_r)
 
 
+@pytest.mark.parametrize("dtype", [np.uint8, np.int16, np.float32, bool])
+@pytest.mark.parametrize("pad_widths", [2, (2,), ((2, 3),), ((3, 1), (0, 0), (2, 0))])
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "constant",
+        "edge",
+        "linear_ramp",
+        "maximum",
+        "mean",
+        "minimum",
+        "reflect",
+        "symmetric",
+        "wrap",
+        pytest.param("median", marks=pytest.mark.xfail(reason="Not implemented"),),
+        pytest.param("empty", marks=pytest.mark.xfail(reason=""),),
+    ],
+)
+def test_pad_3d_data(dtype, pad_widths, mode):
+    np_a = np.arange(2 * 3 * 4).reshape(2, 3, 4).astype(dtype)
+    da_a = da.from_array(np_a, chunks="auto")
+
+    np_r = np.pad(np_a, pad_widths, mode=mode)
+    da_r = da.pad(da_a, pad_widths, mode=mode)
+
+    assert_eq(np_r, da_r)
+
+
 @pytest.mark.parametrize("kwargs", [{}, {"scaler": 2}])
 def test_pad_udf(kwargs):
     def udf_pad(vector, pad_width, iaxis, kwargs):


### PR DESCRIPTION
Hi everyone, this is my first PR on this project.

This PR fixes two very minor bugs in `dask.array.pad` and has the tests available for two more bugs.

 1. `pad_widths` did not support an argument of the form `((a, b),)`, where numpy does.
 2. Fixes #5303: `mode` is stats did not work on 3D data.
 3. `mode="mean"` converts data to floats. Test is available, but not yet fixed
 4. If `mode` one of ("reflect", "symmetric", "wrap"), and the `pad_width` is larger than the size of the array, it is handled differently by numpy as dask. Test available, but not yet fixed.

Should I add separate issues in the issue tracker for items 3 and 4?

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
