### PR TITLE
Added np.iscomplexobj implementation

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -808,6 +808,12 @@ def round(a, decimals=0):
     return a.map_blocks(np.round, decimals=decimals, dtype=a.dtype)
 
 
+@implements(np.iscomplexobj)
+@derived_from(np)
+def iscomplexobj(x):
+    return issubclass(x.dtype.type, np.complexfloating)
+
+
 def _unique_internal(ar, indices, counts, return_inverse=False):
     """
     Helper/wrapper function for :func:`numpy.unique`.

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1740,3 +1740,11 @@ def test_average_raises():
 
     with pytest.warns(RuntimeWarning):
         da.average(d_a, weights=da.zeros_like(d_a)).compute()
+
+
+def test_iscomplexobj():
+    a = da.from_array(np.array([1, 2]), 2)
+    assert np.iscomplexobj(a) is False
+
+    a = da.from_array(np.array([1, 2 + 0j]), 2)
+    assert np.iscomplexobj(a) is True


### PR DESCRIPTION
Came up in the dask-ml test suite. The current NumPy implementation is

```
    try:
        dtype = x.dtype
        type_ = dtype.type
    except AttributeError:
        type_ = asarray(x).dtype.type
    return issubclass(type_, _nx.complexfloating)
```

since Dask array's have a `dtype`, we're fine with checking `.dtype.type`. This avoids the warning on master.

```python
In [1]: import numpy as np

In [2]: import dask.array as da

In [3]: a = da.from_array(np.array([1, 2, 3+0j]), 2)

In [4]: np.iscomplexobj(a)
/Users/taugspurger/sandbox/dask/dask/array/core.py:1356: FutureWarning: The `numpy.iscomplexobj` function is not implemented by Dask array. You may want to use the da.map_blocks function or something similar to silence this warning. Your code may stop working in a future release.
  FutureWarning,
Out[4]: True

```