### PR TITLE
ArrowEngine bug fixes for statistics and `_metadata` handling

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -664,6 +664,23 @@ def test_partition_on_cats(tmpdir, engine):
     assert set(df.b.cat.categories) == {"x", "y", "z"}
 
 
+@pytest.mark.parametrize("meta", [False, True])
+@pytest.mark.parametrize("stats", [False, True])
+def test_partition_on_cats_pyarrow(tmpdir, stats, meta):
+    tmp = str(tmpdir)
+    d = pd.DataFrame(
+        {
+            "a": np.random.rand(50),
+            "b": np.random.choice(["x", "y", "z"], size=50),
+            "c": np.random.choice(["x", "y", "z"], size=50),
+        }
+    )
+    d = dd.from_pandas(d, 2)
+    d.to_parquet(tmp, partition_on=["b"], engine="pyarrow", write_metadata_file=meta)
+    df = dd.read_parquet(tmp, engine="pyarrow", gather_statistics=stats)
+    assert set(df.b.cat.categories) == {"x", "y", "z"}
+
+
 def test_partition_on_cats_2(tmpdir, engine):
     tmp = str(tmpdir)
     d = pd.DataFrame(
@@ -1910,13 +1927,25 @@ def test_categories_large(tmpdir, engine):
 
 
 @write_read_engines()
-def test_read_glob_nostats(tmpdir, write_engine, read_engine):
+def test_read_glob_no_stats(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
     ddf.to_parquet(tmp_path, engine=write_engine)
 
     ddf2 = dd.read_parquet(
         os.path.join(tmp_path, "*.parquet"), engine=read_engine, gather_statistics=False
     )
+    assert_eq(ddf, ddf2, check_divisions=False)
+
+
+@write_read_engines()
+def test_read_glob_yes_stats(tmpdir, write_engine, read_engine):
+    tmp_path = str(tmpdir)
+    ddf.to_parquet(tmp_path, engine=write_engine)
+    import glob
+
+    paths = glob.glob(os.path.join(tmp_path, "*.parquet"))
+    paths.append(os.path.join(tmp_path, "_metadata"))
+    ddf2 = dd.read_parquet(paths, engine=read_engine, gather_statistics=False)
     assert_eq(ddf, ddf2, check_divisions=False)
 
 


### PR DESCRIPTION
This includes some follow-up fixes for [#6023](https://github.com/dask/dask/pull/6023).  These fixes include:

- The [min/max typo](https://github.com/dask/dask/pull/6023#discussion_r400387144) pointed out by @jorisvandenbossche 
- Proper handling of `"_metadata"` when it is included within a file-path list as input to `read_parquet` (pyarrow raises an error when the metadata file is included in the list)
- Adding a check that the dataset is flat (not partitioned) before avoiding/skipping the use of `pq.ParquetDataset` on a directory when `gather_statistics=False` (the previous approach will try to create a list of paths, but these paths will be wrong, and partition information will be lost anyway)

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
