### PR TITLE
[HACK] Ordering to priorities "shuffle-split"

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -507,6 +507,15 @@ def order(dsk, dependencies=None):
             item = init_stack_pop()
         inner_stacks_append([item])
 
+    # TODO: Hack to priorities "shuffle-split"
+    shuffle_split_keys = []
+    for k in result.keys():
+        if len(k) > 0 and "split" in k[0]:
+            shuffle_split_keys.append(k)
+
+    for k in shuffle_split_keys:
+        result[k] = 0
+
     return result
 
 

--- a/dask/order.py
+++ b/dask/order.py
@@ -507,14 +507,16 @@ def order(dsk, dependencies=None):
             item = init_stack_pop()
         inner_stacks_append([item])
 
-    # TODO: Hack to priorities "shuffle-split"
-    shuffle_split_keys = []
-    for k in result.keys():
-        if len(k) > 0 and "split" in k[0]:
-            shuffle_split_keys.append(k)
+    # # TODO: Hack to priorities "shuffle-split"
+    # shuffle_split_keys = []
+    # for k in result.keys():
+    #     print("k: ", repr(k))
+    #     if "split" in k:
+    #         shuffle_split_keys.append(k)
 
-    for k in shuffle_split_keys:
-        result[k] = 0
+    # print("shuffle_split_keys: ", shuffle_split_keys)
+    # for k in shuffle_split_keys:
+    #     result[k] = 0
 
     return result
 


### PR DESCRIPTION
This PR is a HACK to do **breadth first** ordering of `shuffle-split` tasks.

The scheduling policies of Dask is **depth-first** generally speaking, which works great in most cases. However, it can increase the memory usage significantly when we are splitting the output of a task into many small task (like in [`rearrange_by_column_tasks()`](https://github.com/dask/dask/blob/fa63ce13ee1773d2042654a26a479bce932f292e/dask/dataframe/shuffle.py#L423)'s `shuffle-group` and `shuffle-split` tasks). In this case **depth-first** delays the freeing of  `shuffle-group` until the end of the _shuffling_, which uses  much more memory than a **breadth first** ordering where all the `shuffle-split` tasks are finished immediately and the output of `shuffle-group` can be freed before continuing.

This is a HACK please don't merge, let's find a more general solution to this issue.

cc. @rjzamora, @beckernick
