### PR TITLE
Non-intrusive task annotations

### DIFF
--- a/dask/annotation.py
+++ b/dask/annotation.py
@@ -1,0 +1,22 @@
+import functools
+
+
+def annotate_func(func: callable, annotation: dict) -> callable:
+    ret = functools.partial(func)
+    if not hasattr(ret, "_dask_annotation_dict"):
+        ret._dask_annotation_dict = {}
+        if hasattr(func, "__name__"):
+            ret.__name__ = func
+        if hasattr(func, "__repr__"):
+            ret.__repr__ = func
+        if hasattr(func, "__str__"):
+            ret.__str__ = func
+    ret._dask_annotation_dict.update(annotation)
+    return ret
+
+
+def get_annotation(obj: object) -> dict:
+    if hasattr(obj, "_dask_annotation_dict"):
+        return obj._dask_annotation_dict
+    else:
+        return {}

--- a/dask/annotation.py
+++ b/dask/annotation.py
@@ -5,12 +5,9 @@ def annotate_func(func: callable, annotation: dict) -> callable:
     ret = functools.partial(func)
     if not hasattr(ret, "_dask_annotation_dict"):
         ret._dask_annotation_dict = {}
-        if hasattr(func, "__name__"):
-            ret.__name__ = func
-        if hasattr(func, "__repr__"):
-            ret.__repr__ = func
-        if hasattr(func, "__str__"):
-            ret.__str__ = func
+        functools.update_wrapper(
+            ret, func, functools.WRAPPER_ASSIGNMENTS + ("__repr__",)
+        )
     ret._dask_annotation_dict.update(annotation)
     return ret
 

--- a/dask/order.py
+++ b/dask/order.py
@@ -75,7 +75,14 @@ Work towards *small goals* with *big steps*.
     good proxy for ordering.  This is usually a good idea and a sane default.
 """
 from math import log
-from .core import get_dependencies, reverse_dict, get_deps, getcycle  # noqa: F401
+from .annotation import get_annotation
+from .core import (
+    get_dependencies,
+    reverse_dict,
+    get_deps,
+    getcycle,
+    istask,
+)  # noqa: F401
 from .utils_test import add, inc  # noqa: F401
 
 
@@ -348,6 +355,14 @@ def order(dsk, dependencies=None):
         item = init_stack_pop()
         while item in result:
             item = init_stack_pop()
+
+    # Check task annotations
+    for k, v in dsk.items():
+        if istask(v):
+            f = v[0]  # We prioritize based on the first task function
+            priority = get_annotation(f).get("priority", None)
+            if priority is not None:
+                result[k] = priority
 
     return result
 

--- a/dask/order.py
+++ b/dask/order.py
@@ -76,13 +76,8 @@ Work towards *small goals* with *big steps*.
 """
 from math import log
 from .annotation import get_annotation
-from .core import (
-    get_dependencies,
-    reverse_dict,
-    get_deps,
-    getcycle,
-    istask,
-)  # noqa: F401
+from .core import get_dependencies, reverse_dict, getcycle, istask
+from .core import get_deps  # noqa: F401
 from .utils_test import add, inc  # noqa: F401
 
 


### PR DESCRIPTION
This PR introduces non-intrusive task annotation that makes it possible to annotate tasks with arbitrary information. In order to make this non-intrusive, this implementation annotate the task's callable using `functools.partial` thus any component in Dask/Distributed can be completely agnostic of the annotation without any performance overhead.

Overhead is introduced only for components that use the annotation. For instance, this PR makes [`order.order()`](https://github.com/madsbk/dask/blob/a8553e34a2da7fc9a69794aaba4ac8e2a50d6872/dask/order.py#L359) traverse the graph keys once in order to check annotations, which is negligible compared to the rest of the computation in `order.order()`.

Inspired by https://github.com/dask/distributed/pull/2180, but this PR is less intrusive because it doesn't change a task's arguments.
Fixes #6054
Closes #6051

- [ ] Docs added
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

cc. @rjzamora, @mrocklin, @eriknw, @dhirschfeld 