### PR TITLE
Use _meta_nonempty for dtype casting in stack_partitions

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -928,6 +928,8 @@ def concat_indexed_dataframes(dfs, axis=0, join="outer"):
 
 def stack_partitions(dfs, divisions, join="outer"):
     """Concatenate partitions on axis=0 by doing a simple stack"""
+    # Use _meta_nonempty as pandas.concat will incorrectly cast float to datetime
+    # for empty data frames. See https://github.com/pandas-dev/pandas/issues/32934.
     meta = make_meta(
         methods.concat(
             [df._meta_nonempty for df in dfs], join=join, filter_warning=False

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -85,6 +85,7 @@ from .utils import (
     is_series_like,
     asciitable,
     is_dataframe_like,
+    make_meta,
 )
 
 
@@ -927,7 +928,11 @@ def concat_indexed_dataframes(dfs, axis=0, join="outer"):
 
 def stack_partitions(dfs, divisions, join="outer"):
     """Concatenate partitions on axis=0 by doing a simple stack"""
-    meta = methods.concat([df._meta for df in dfs], join=join, filter_warning=False)
+    meta = make_meta(
+        methods.concat(
+            [df._meta_nonempty for df in dfs], join=join, filter_warning=False
+        )
+    )
     empty = strip_unknown_categories(meta)
 
     name = "concat-{0}".format(tokenize(*dfs))

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -585,9 +585,7 @@ def test_concat(join):
     [
         (1.0, 1),
         (1.0, "one"),
-        # See https://github.com/dask/dask/issues/5968 and
-        # https://github.com/pandas-dev/pandas/issues/32934
-        pytest.param(1.0, pd.to_datetime("1970-01-01"), marks=pytest.mark.xfail),
+        (1.0, pd.to_datetime("1970-01-01")),
         (1, "one"),
         (1, pd.to_datetime("1970-01-01")),
         ("one", pd.to_datetime("1970-01-01")),


### PR DESCRIPTION
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

This PR improves upon #6006, using `_meta_nonempty` instead of `_meta`  to forego incorrect dtype handling when combining `datetime64[ns]` and `float` (see [here](https://github.com/pandas-dev/pandas/issues/32934)). 
@TomAugspurger 