### PR TITLE
Bump checkout action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1


### PR DESCRIPTION
This fixes an issue where restarted GitHub actions builds would fail at the code checkout step  

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
