### PR TITLE
Histogram: support lazy values for range/bins

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -701,6 +701,10 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
                 raise ValueError(
                     f"range must be a sequence of length 2, but got {len(range)} items"
                 )
+            if isinstance(range, (Array, np.ndarray)) and range.ndim != 1:
+                raise ValueError(
+                    f"range must be a 1-dimensional array of two items, but got an array of shape {range.shape}"
+                )
         except TypeError:
             raise TypeError(f"expected a sequence for range, not {range}") from None
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -12,6 +12,7 @@ from tlz import concat, sliding_window, interleave
 from ..compatibility import apply
 from ..core import flatten
 from ..base import tokenize
+from ..delayed import unpack_collections
 from ..highlevelgraph import HighLevelGraph
 from ..utils import funcname, derived_from, is_arraylike
 from . import chunk
@@ -764,9 +765,9 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
         dependencies.append(bins)
         bins_ref = "histogram-bins-" + token
 
-        bins_dsk = {bins_ref: (np.concatenate, bins.__dask_keys__())}
+        bins_task, bins_deps = unpack_collections(bins)
         bins_graph = HighLevelGraph.from_collections(
-            bins_ref, bins_dsk, dependencies=[bins]
+            bins_ref, {bins_ref: bins_task}, dependencies=bins_deps
         )
     else:
         bins_ref = bins

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -757,16 +757,15 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
         if bins.ndim != 1:
             raise ValueError(f"bins must have 1 dimension, got {bins.ndim}")
         dependencies.append(bins)
-        bins_ref = ("histogram-bins-" + token, 0)
+        bins_ref = "histogram-bins-" + token
 
         bins_dsk = {bins_ref: (np.concatenate, bins.__dask_keys__())}
         bins_graph = HighLevelGraph.from_collections(
-            bins_ref[0], bins_dsk, dependencies=[bins]
+            bins_ref, bins_dsk, dependencies=[bins]
         )
     else:
         bins_ref = bins
         bins_graph = None
-        # bins_dsk = {}
 
     nchunks = len(list(flatten(a.__dask_keys__())))
     chunks = ((1,) * nchunks, (len(bins) - 1,))
@@ -793,7 +792,6 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
         }
         dtype = weights.dtype
 
-    # dsk.update(bins_dsk)
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=dependencies)
     if bins_graph:
         graph = HighLevelGraph.merge(graph, bins_graph)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -722,10 +722,11 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
             else:
                 range_refs.append(elem)
 
+    if isinstance(bins, Array) and bins.ndim == 0:
+        raise ValueError(
+            "The number of bins cannot be a delayed Dask array, it must be an actual value or a Dask array of bin edges"
+        )
     if not np.iterable(bins):
-        assert not isinstance(
-            bins, Array
-        ), "The number of bins cannot be a Dask array, it must be an actual value"
         bin_token = bins
         if len(dependencies) == 1:
             # ^ `len(dependencies) == 1` here iff neither element in `range` was a Dask array.

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -801,7 +801,7 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
         dtype = weights.dtype
 
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=dependencies)
-    if bins_graph:
+    if bins_graph is not None:
         graph = HighLevelGraph.merge(graph, bins_graph)
 
     mapped = Array(graph, name, chunks, dtype=dtype)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -672,7 +672,8 @@ def test_histogram_bin_range_raises(bins, hist_range):
 
 @pytest.mark.parametrize("density", [True, False])
 @pytest.mark.parametrize("weighted", [True, False])
-def test_histogram_delayed_range(density, weighted):
+@pytest.mark.parametrize("non_delayed_i", [None, 0, 1])
+def test_histogram_delayed_range(density, weighted, non_delayed_i):
     n = 100
     v = np.random.random(n)
     vd = da.from_array(v, chunks=10)
@@ -681,10 +682,13 @@ def test_histogram_delayed_range(density, weighted):
         weights = np.random.random(n)
         weights_d = da.from_array(weights, chunks=vd.chunks)
 
+    d_range = [vd.min(), vd.max()]
+    if non_delayed_i is not None:
+        d_range[non_delayed_i] = d_range[non_delayed_i].compute()
     hist_d, bins_d = da.histogram(
         vd,
         bins=n,
-        range=[vd.min(), vd.max()],
+        range=d_range,
         density=density,
         weights=weights_d if weighted else None,
     )

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -659,6 +659,7 @@ def test_histogram_normed_deprecation():
         (10, [0]),
         (10, np.array([[0, 1]])),
         (10, da.array([[0, 1]])),
+        (da.array(10), (1, 10)),
     ],
 )
 def test_histogram_bin_range_raises(bins, hist_range):

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -649,15 +649,24 @@ def test_histogram_normed_deprecation():
 
 
 @pytest.mark.parametrize(
-    "bins, hist_range", [(None, None), (10, None), (None, (1, 10))]
+    "bins, hist_range",
+    [
+        (None, None),
+        (10, None),
+        (10, 1),
+        (None, (1, 10)),
+        (10, [0, 1, 2]),
+        (10, [0]),
+        (10, np.array([[0, 1]])),
+        (10, da.array([[0, 1]])),
+    ],
 )
 def test_histogram_bin_range_raises(bins, hist_range):
     data = da.random.random(10, chunks=2)
-    with pytest.raises(ValueError) as info:
+    with pytest.raises((ValueError, TypeError)) as info:
         da.histogram(data, bins=bins, range=hist_range)
     err_msg = str(info.value)
-    assert "bins" in err_msg
-    assert "range" in err_msg
+    assert "bins" in err_msg or "range" in err_msg
 
 
 @pytest.mark.parametrize("density", [True, False])

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -660,6 +660,72 @@ def test_histogram_bin_range_raises(bins, hist_range):
     assert "range" in err_msg
 
 
+@pytest.mark.parametrize("density", [True, False])
+@pytest.mark.parametrize("weighted", [True, False])
+def test_histogram_delayed_range(density, weighted):
+    n = 100
+    v = np.random.random(n)
+    vd = da.from_array(v, chunks=10)
+
+    if weighted:
+        weights = np.random.random(n)
+        weights_d = da.from_array(weights, chunks=vd.chunks)
+
+    hist_d, bins_d = da.histogram(
+        vd,
+        bins=n,
+        range=[vd.min(), vd.max()],
+        density=density,
+        weights=weights_d if weighted else None,
+    )
+
+    hist, bins = np.histogram(
+        v,
+        bins=n,
+        range=[v.min(), v.max()],
+        density=density,
+        weights=weights if weighted else None,
+    )
+
+    assert_eq(hist_d, hist)
+    assert_eq(bins_d, bins)
+
+
+@pytest.mark.parametrize("density", [True, False])
+@pytest.mark.parametrize("weighted", [True, False])
+def test_histogram_delayed_bins(density, weighted):
+    n = 100
+    v = np.random.random(n)
+    bins = np.array([0, 0.2, 0.5, 0.8, 1])
+
+    vd = da.from_array(v, chunks=10)
+    bins_d = da.from_array(bins, chunks=2)
+
+    if weighted:
+        weights = np.random.random(n)
+        weights_d = da.from_array(weights, chunks=vd.chunks)
+
+    hist_d, bins_d2 = da.histogram(
+        vd,
+        bins=bins_d,
+        range=[bins_d[0], bins_d[-1]],
+        density=density,
+        weights=weights_d if weighted else None,
+    )
+
+    hist, bins = np.histogram(
+        v,
+        bins=bins,
+        range=[bins[0], bins[-1]],
+        density=density,
+        weights=weights if weighted else None,
+    )
+
+    assert bins_d is bins_d2
+    assert_eq(hist_d, hist)
+    assert_eq(bins_d2, bins)
+
+
 def test_cov():
     x = np.arange(56).reshape((7, 8))
     d = da.from_array(x, chunks=(4, 4))


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Addresses, but does not close, #4544.

This makes `da.histogram(arr, range=[arr.min(), arr.max()], bins=10)` possible. It would be easy to make it the default to fully match NumPy, but whether that's a good idea due to the [performance implications](https://github.com/dask/dask/issues/4544#issuecomment-488023186) is a debate I'll leave for someone else.

Lazy values (dask Arrays) didn't work in `range`/`bins` because their graphs weren't being added as dependencies and referenced as keys—if you passed in a dask array, the actual dask array would be passed into `np.histogram` at compute time. (This triggered confusing recursion, since `np.histogram` dispatched back to `da.histogram`, which was then passed a NumPy array, which then failed.)

If dask arrays are given for either of these, we add them as dependencies and refer to them by key.

Style questions:

- Is there a more idiomatic way to reference a fully-computed (non-chunked) Dask array in a graph than [this](https://github.com/dask/dask/compare/master...gjoseph92:histogram/delayed-range?expand=1#diff-02bfb8d5198c7e872d9e73af248a17a6R762) (assumes 1D)?
  ```python
  {bins_ref: (np.concatenate, bins.__dask_keys__())}
  ```
- Do you mind [manually delaying `linspace`](https://github.com/dask/dask/compare/master...gjoseph92:histogram/delayed-range?expand=1#diff-02bfb8d5198c7e872d9e73af248a17a6R736-R749) since `da.linspace` also doesn't support lazy values as inputs? Would be nice to fix, but I didn't feel like dragging that into this PR as well.
- Overall, is there a better way to handle this "it-might-be-a-lazy-value-or-it-might-not" situation than the [`bins_ref` sort of pattern I'm using here](https://github.com/dask/dask/compare/master...gjoseph92:histogram/delayed-range?expand=1#diff-02bfb8d5198c7e872d9e73af248a17a6R760-R765) (which feels cumbersome)?