### PR TITLE
Add support for repeats=0 in da.repeat

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -763,7 +763,9 @@ def repeat(a, repeats, axis=None):
     elif not 0 <= axis <= a.ndim - 1:
         raise ValueError("axis(=%d) out of bounds" % axis)
 
-    if repeats == 1:
+    if repeats == 0:
+        return a[tuple(slice(None) if d != axis else slice(0) for d in range(a.ndim))]
+    elif repeats == 1:
         return a
 
     cchunks = cached_cumsum(a.chunks[axis], initial_zero=True)

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -540,7 +540,7 @@ def test_repeat():
     x = np.random.random((10, 11, 13))
     d = da.from_array(x, chunks=(4, 5, 3))
 
-    repeats = [1, 2, 5]
+    repeats = [0, 1, 2, 5]
     axes = [-3, -2, -1, 0, 1, 2]
 
     for r in repeats:


### PR DESCRIPTION
Currently when `repeats == 0` we end up passing an empty list to `concatenate` which raises an error. This PR updates `da.repeat` to return an appropriate slice of the array (when `repeats == 0`) to match NumPy's `repeat` behavior. cc @TomAugspurger 

Fixes https://github.com/dask/dask/issues/6076


- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
