### PR TITLE
[WIP] [Parquet] Handle new (dtype) pandas metadata with pyarrow

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -547,8 +547,32 @@ class ArrowEngine(Engine):
             use_threads=False,
             **kwargs.get("read", {}),
         ).to_pandas(categories=categories, use_threads=False, ignore_metadata=False)
-        if not isinstance(df.index, pd.RangeIndex):
-            df.reset_index(drop=False, inplace=True)
+
+        # Note that `to_pandas(ignore_metadata=False)` means
+        # pyarrow will use the pandas metadata to set the index.
+        index_in_columns_and_parts = bool(
+            set(df.index.names).intersection(set(columns_and_parts))
+        )
+        if not index:
+            if index_in_columns_and_parts:
+                # User does not want to set index and a desired
+                # column/partition has been set to the index
+                df.reset_index(drop=False, inplace=True)
+            else:
+                # User does not want to set index and an
+                # "unwanted" column has been set to the index
+                df.reset_index(drop=True, inplace=True)
+        else:
+            if set(df.index.names) != set(index) and index_in_columns_and_parts:
+                # The wrong index has been set and it contains
+                # one or more desired columns/partitions
+                df.reset_index(drop=False, inplace=True)
+            elif index_in_columns_and_parts:
+                # The correct index has already been set
+                index = False
+                columns_and_parts = list(
+                    set(columns_and_parts).difference(set(df.index.names))
+                )
         df = df[list(columns_and_parts)]
 
         if index:

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -550,8 +550,8 @@ class ArrowEngine(Engine):
 
         # Note that `to_pandas(ignore_metadata=False)` means
         # pyarrow will use the pandas metadata to set the index.
-        index_in_columns_and_parts = bool(
-            set(df.index.names).intersection(set(columns_and_parts))
+        index_in_columns_and_parts = set(df.index.names).issubset(
+            set(columns_and_parts)
         )
         if not index:
             if index_in_columns_and_parts:

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -546,9 +546,10 @@ class ArrowEngine(Engine):
             use_pandas_metadata=True,
             use_threads=False,
             **kwargs.get("read", {}),
-        ).to_pandas(categories=categories, use_threads=False, ignore_metadata=True)[
-            list(columns_and_parts)
-        ]
+        ).to_pandas(categories=categories, use_threads=False, ignore_metadata=False)
+        if not isinstance(df.index, pd.RangeIndex):
+            df.reset_index(drop=False, inplace=True)
+        df = df[list(columns_and_parts)]
 
         if index:
             df = df.set_index(index)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2360,18 +2360,22 @@ def test_filter_nonpartition_columns(
     assert df_read["time"].max() < 5
 
 
-@pytest.mark.parametrize("dtype", ["Int64", "str"])
-def test_pandas_metadata_nullable_pyarrow(tmpdir, dtype):
+def test_pandas_metadata_nullable_pyarrow(tmpdir):
 
     check_pyarrow()
-    if pa.__version__ < LooseVersion("0.16.0"):
-        pytest.skip("PyArrow 0.16 Required.")
-    if pd.__version__ < LooseVersion("1.0.0"):
-        pytest.skip("Pandas 1.0.0 Required.")
+    if pa.__version__ < LooseVersion("0.16.0") or pd.__version__ < LooseVersion(
+        "1.0.0"
+    ):
+        pytest.skip("PyArrow>=0.16 and Pandas>=1.0.0 Required.")
     tmpdir = str(tmpdir)
 
     ddf1 = dd.from_pandas(
-        pd.DataFrame({"A": ["dog" if dtype == "str" else 1, None]}, dtype=dtype),
+        pd.DataFrame(
+            {
+                "A": pd.array([1, None, 2], dtype="Int64"),
+                "B": pd.array(["dog", "cat", None], dtype="str"),
+            }
+        ),
         npartitions=1,
     )
     ddf1.to_parquet(tmpdir, engine="pyarrow")

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2366,6 +2366,8 @@ def test_pandas_metadata_nullable_pyarrow(tmpdir, dtype):
     check_pyarrow()
     if pa.__version__ < LooseVersion("0.16.0"):
         pytest.skip("PyArrow 0.16 Required.")
+    if pd.__version__ < LooseVersion("1.0.0"):
+        pytest.skip("Pandas 1.0.0 Required.")
     tmpdir = str(tmpdir)
 
     ddf1 = dd.from_pandas(


### PR DESCRIPTION
Closes #6085

Uses `ignore_metadata=False` during arrow -> pandas conversion in `ArrowEngine` parquet reader.  Before these changes, `ignore_metadata=True` was used to simplify the setting of the index.  However, the pandas metadata is needed to get certain dtype conversions correct.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

@martindurant @msebbah
