### PR TITLE
Update DataFrame len to handle columns with the same name

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3359,7 +3359,7 @@ class DataFrame(_Frame):
 
     def __len__(self):
         try:
-            s = self[self.columns[0]]
+            s = self.iloc[:, 0]
         except IndexError:
             return super().__len__()
         else:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1062,6 +1062,8 @@ def test_len():
     assert len(d.a) == len(full.a)
     assert len(dd.from_pandas(pd.DataFrame(), npartitions=1)) == 0
     assert len(dd.from_pandas(pd.DataFrame(columns=[1, 2]), npartitions=1)) == 0
+    # Regression test for https://github.com/dask/dask/issues/6110
+    assert len(dd.from_pandas(pd.DataFrame(columns=["foo", "foo"]), npartitions=1)) == 0
 
 
 def test_size():


### PR DESCRIPTION
This PR update `DataFrame.__len__` to use integer-location based indexing, rather than selecting by column name, to avoid raising a `RecursionError` for DataFrames which contain multiple columns with the same name. 

Fixes https://github.com/dask/dask/issues/6110

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
