### PR TITLE
[REVIEW] Generalize categorical calls

### DIFF
--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -13,6 +13,8 @@ from .utils import (
 )
 from . import methods
 from . import core
+
+
 def _categorize_block(df, categories, index):
     """ Categorize a dataframe with given categories
 
@@ -24,13 +26,17 @@ def _categorize_block(df, categories, index):
         if is_categorical_dtype(df[col]):
             df[col] = df[col].cat.set_categories(vals)
         else:
-            cat_dtype = core.categoricalDtype(meta=df[col], categories=vals, ordered=False)
+            cat_dtype = core.categoricalDtype(
+                meta=df[col], categories=vals, ordered=False
+            )
             df[col] = df[col].astype(cat_dtype)
     if index is not None:
         if is_categorical_dtype(df.index):
             ind = df.index.set_categories(index)
         else:
-            cat_dtype = core.categoricalDtype(meta=df.index, categories=index, ordered=False)
+            cat_dtype = core.categoricalDtype(
+                meta=df.index, categories=index, ordered=False
+            )
             ind = df.index.astype(dtype=cat_dtype)
         ind.name = df.index.name
         df.index = ind
@@ -59,7 +65,10 @@ def _get_categories_agg(parts):
         for k, v in p[0].items():
             res[k].append(v)
         res_ind.append(p[1])
-    res = {k: methods.concat(v, ignore_index=True).drop_duplicates() for k, v in res.items()}
+    res = {
+        k: methods.concat(v, ignore_index=True).drop_duplicates()
+        for k, v in res.items()
+    }
     if res_ind[0] is None:
         return res, None
     return res, res_ind[0].append(res_ind[1:]).drop_duplicates()

--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -12,7 +12,7 @@ from .utils import (
     is_categorical_dtype,
 )
 from . import methods
-
+from . import core
 def _categorize_block(df, categories, index):
     """ Categorize a dataframe with given categories
 
@@ -21,14 +21,17 @@ def _categorize_block(df, categories, index):
     """
     df = df.copy()
     for col, vals in categories.items():
-        if not is_categorical_dtype(df[col]):
-            df[col] = df[col].astype('category')
-        df[col] = df[col].cat.set_categories(vals)
+        if is_categorical_dtype(df[col]):
+            df[col] = df[col].cat.set_categories(vals)
+        else:
+            cat_dtype = core.categoricalDtype(meta=df[col], categories=vals, ordered=False)
+            df[col] = df[col].astype(cat_dtype)
     if index is not None:
-        ind = df.index
-        if not is_categorical_dtype(ind):
-            ind = ind.astype(dtype='category')
-        ind = ind.set_categories(index)
+        if is_categorical_dtype(df.index):
+            ind = df.index.set_categories(index)
+        else:
+            cat_dtype = core.categoricalDtype(meta=df.index, categories=index, ordered=False)
+            ind = df.index.astype(dtype=cat_dtype)
         ind.name = df.index.name
         df.index = ind
     return df

--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -25,8 +25,9 @@ def _categorize_block(df, categories, index):
             df[col] = df[col].astype('category')
         df[col] = df[col].cat.set_categories(vals)
     if index is not None:
-        if not is_categorical_dtype(df.index):
-            ind = df.index.astype(dtype='category')
+        ind = df.index
+        if not is_categorical_dtype(ind):
+            ind = ind.astype(dtype='category')
         ind = ind.set_categories(index)
         ind.name = df.index.name
         df.index = ind

--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -21,7 +21,6 @@ def _categorize_block(df, categories, index):
     """
     df = df.copy()
     for col, vals in categories.items():
-        import pdb;pdb.set_trace()
         if not is_categorical_dtype(df[col]):
             df[col] = df[col].astype('category')
         df[col] = df[col].cat.set_categories(vals)

--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 import pandas as pd
 from tlz import partition_all
 from numbers import Integral
-import sys
 
 from ..base import tokenize, compute_as_if_collection
 from .accessor import Accessor
@@ -21,19 +20,15 @@ def _categorize_block(df, categories, index):
     categories: dict mapping column name to iterable of categories
     """
     df = df.copy()
-    package_name = df.__class__.__module__.split(".")[0]
     for col, vals in categories.items():
-        if is_categorical_dtype(df[col]):
-            df[col] = df[col].cat.set_categories(vals)
-        else:
-            cat_dtype = sys.modules[package_name].CategoricalDtype(categories=vals, ordered=False)
-            df[col] = sys.modules[package_name].Series(df[col], dtype=cat_dtype)
+        import pdb;pdb.set_trace()
+        if not is_categorical_dtype(df[col]):
+            df[col] = df[col].astype('category')
+        df[col] = df[col].cat.set_categories(vals)
     if index is not None:
-        if is_categorical_dtype(df.index):
-            ind = df.index.set_categories(index)
-        else:
-            cat_dtype = sys.modules[package_name].CategoricalDtype(categories=index, ordered=False)
-            ind = sys.modules[package_name].Series(df.index,dtype=cat_dtype)
+        if not is_categorical_dtype(df.index):
+            ind = df.index.astype(dtype='category')
+        ind = ind.set_categories(index)
         ind.name = df.index.name
         df.index = ind
     return df

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6465,19 +6465,3 @@ def series_map(base_series, map_series):
     divisions = list(base_series.divisions)
 
     return new_dd_object(graph, final_prefix, meta, divisions)
-
-
-categoricalDtype_dispatch = Dispatch("categoricalDtype")
-
-
-def categoricalDtype(meta, categories=None, ordered=False):
-    func = categoricalDtype_dispatch.dispatch(type(meta))
-    return func(categories=categories, ordered=ordered)
-
-
-@categoricalDtype_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
-def categoricalDtype_pandas(categories=None, ordered=False):
-    if PANDAS_VERSION > "0.23.4":
-        return pd.CategoricalDtype(categories=categories, ordered=ordered)
-    else:
-        return pd.api.types.CategoricalDtype(categories=categories, ordered=ordered)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6477,4 +6477,7 @@ def categoricalDtype(meta, categories=None, ordered=None):
 
 @categoricalDtype_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
 def categoricalDtype_pandas(categories=None, ordered=None):
-    return pd.CategoricalDtype(categories=categories, ordered=ordered)
+    if PANDAS_VERSION > '0.23.4':
+        return pd.CategoricalDtype(categories=categories, ordered=ordered)
+    else:
+        return pd.api.types.CategoricalDtype(categories=categories, ordered=ordered)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6477,7 +6477,7 @@ def categoricalDtype(meta, categories=None, ordered=False):
 
 @categoricalDtype_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
 def categoricalDtype_pandas(categories=None, ordered=False):
-    if PANDAS_VERSION > '0.23.4':
+    if PANDAS_VERSION > "0.23.4":
         return pd.CategoricalDtype(categories=categories, ordered=ordered)
     else:
         return pd.api.types.CategoricalDtype(categories=categories, ordered=ordered)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6465,3 +6465,13 @@ def series_map(base_series, map_series):
     divisions = list(base_series.divisions)
 
     return new_dd_object(graph, final_prefix, meta, divisions)
+
+categoricalDtype_dispatch = Dispatch("categoricalDtype")
+
+def categoricalDtype(meta, categories=None, ordered=None):
+    func = categoricalDtype_dispatch.dispatch(type(meta))
+    return func(categories=categories, ordered=ordered)
+
+@categoricalDtype_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
+def categoricalDtype_pandas(categories=None, ordered=None):
+    return pd.CategoricalDtype(categories=categories, ordered=ordered)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6470,13 +6470,13 @@ def series_map(base_series, map_series):
 categoricalDtype_dispatch = Dispatch("categoricalDtype")
 
 
-def categoricalDtype(meta, categories=None, ordered=None):
+def categoricalDtype(meta, categories=None, ordered=False):
     func = categoricalDtype_dispatch.dispatch(type(meta))
     return func(categories=categories, ordered=ordered)
 
 
 @categoricalDtype_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
-def categoricalDtype_pandas(categories=None, ordered=None):
+def categoricalDtype_pandas(categories=None, ordered=False):
     if PANDAS_VERSION > '0.23.4':
         return pd.CategoricalDtype(categories=categories, ordered=ordered)
     else:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6466,11 +6466,14 @@ def series_map(base_series, map_series):
 
     return new_dd_object(graph, final_prefix, meta, divisions)
 
+
 categoricalDtype_dispatch = Dispatch("categoricalDtype")
+
 
 def categoricalDtype(meta, categories=None, ordered=None):
     func = categoricalDtype_dispatch.dispatch(type(meta))
     return func(categories=categories, ordered=ordered)
+
 
 @categoricalDtype_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
 def categoricalDtype_pandas(categories=None, ordered=None):

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -213,17 +213,19 @@ def test_categorize():
 
 
 def test_categorical_dtype():
-    cat_dtype = dd.core.categoricalDtype(
+    cat_dtype = dd.categorical.categorical_dtype(
         meta=a, categories=["a", "b", "c"], ordered=False
     )
     assert_eq(cat_dtype.categories, pd.Index(["a", "b", "c"]))
     assert_eq(cat_dtype.ordered, False)
 
-    cat_dtype = dd.core.categoricalDtype(meta=a, categories=["a", "b", "c"])
+    cat_dtype = dd.categorical.categorical_dtype(meta=a, categories=["a", "b", "c"])
     assert_eq(cat_dtype.categories, pd.Index(["a", "b", "c"]))
     assert_eq(cat_dtype.ordered, False)
 
-    cat_dtype = dd.core.categoricalDtype(meta=a, categories=[1, 100, 200], ordered=True)
+    cat_dtype = dd.categorical.categorical_dtype(
+        meta=a, categories=[1, 100, 200], ordered=True
+    )
     assert_eq(cat_dtype.categories, pd.Index([1, 100, 200]))
     assert_eq(cat_dtype.ordered, True)
 

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -211,6 +211,18 @@ def test_categorize():
     with pytest.raises(ValueError):
         ddf.categorize(split_every="foo")
 
+    cat_dtype = dd.core.categoricalDtype(
+        meta=meta, categories=["a", "b", "c"], ordered=False
+    )
+    assert_eq(cat_dtype.categories, pd.Index(["a", "b", "c"]))
+    assert_eq(cat_dtype.ordered, False)
+
+    cat_dtype = dd.core.categoricalDtype(
+        meta=meta, categories=[1, 100, 200], ordered=True
+    )
+    assert_eq(cat_dtype.categories, pd.Index([1, 100, 200]))
+    assert_eq(cat_dtype.ordered, True)
+
 
 def test_categorize_index():
     # Object dtype

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -211,14 +211,21 @@ def test_categorize():
     with pytest.raises(ValueError):
         ddf.categorize(split_every="foo")
 
+def test_categorical_dtype():
     cat_dtype = dd.core.categoricalDtype(
-        meta=meta, categories=["a", "b", "c"], ordered=False
+        meta=a, categories=["a", "b", "c"], ordered=False
     )
     assert_eq(cat_dtype.categories, pd.Index(["a", "b", "c"]))
     assert_eq(cat_dtype.ordered, False)
 
     cat_dtype = dd.core.categoricalDtype(
-        meta=meta, categories=[1, 100, 200], ordered=True
+        meta=a, categories=["a", "b", "c"]
+    )
+    assert_eq(cat_dtype.categories, pd.Index(["a", "b", "c"]))
+    assert_eq(cat_dtype.ordered, False)
+
+    cat_dtype = dd.core.categoricalDtype(
+        meta=a, categories=[1, 100, 200], ordered=True
     )
     assert_eq(cat_dtype.categories, pd.Index([1, 100, 200]))
     assert_eq(cat_dtype.ordered, True)

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -211,6 +211,7 @@ def test_categorize():
     with pytest.raises(ValueError):
         ddf.categorize(split_every="foo")
 
+
 def test_categorical_dtype():
     cat_dtype = dd.core.categoricalDtype(
         meta=a, categories=["a", "b", "c"], ordered=False
@@ -218,15 +219,11 @@ def test_categorical_dtype():
     assert_eq(cat_dtype.categories, pd.Index(["a", "b", "c"]))
     assert_eq(cat_dtype.ordered, False)
 
-    cat_dtype = dd.core.categoricalDtype(
-        meta=a, categories=["a", "b", "c"]
-    )
+    cat_dtype = dd.core.categoricalDtype(meta=a, categories=["a", "b", "c"])
     assert_eq(cat_dtype.categories, pd.Index(["a", "b", "c"]))
     assert_eq(cat_dtype.ordered, False)
 
-    cat_dtype = dd.core.categoricalDtype(
-        meta=a, categories=[1, 100, 200], ordered=True
-    )
+    cat_dtype = dd.core.categoricalDtype(meta=a, categories=[1, 100, 200], ordered=True)
     assert_eq(cat_dtype.categories, pd.Index([1, 100, 200]))
     assert_eq(cat_dtype.ordered, True)
 


### PR DESCRIPTION
These changes would be needed for fixing a cudf related issue: https://github.com/rapidsai/cudf/issues/4916
This is because we previously had `CategoricalAccessor` in `dask-cudf` but it was removed recently: https://github.com/rapidsai/cudf/pull/4807/files

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

