### PR TITLE
Use group_split_dispatch and ignore_index in apply_concat_apply

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -674,11 +674,9 @@ def set_partitions_pre(s, divisions):
 def shuffle_group_2(df, col, ignore_index):
     if not len(df):
         return {}, df
-    ind = df[col].astype(np.int64)
+    ind = df[col].astype(np.int32)
     n = ind.max() + 1
-    result2 = group_split_dispatch(
-        df, ind.values.view(np.int64), n, ignore_index=ignore_index
-    )
+    result2 = group_split_dispatch(df, ind.values.view(), n, ignore_index=ignore_index)
     return result2, df.iloc[:0]
 
 
@@ -728,7 +726,7 @@ def shuffle_group(df, col, stage, k, npartitions, ignore_index):
     np.floor_divide(c, k ** stage, out=c)
     np.mod(c, k, out=c)
 
-    return group_split_dispatch(df, c.astype(np.int64), k, ignore_index=ignore_index)
+    return group_split_dispatch(df, c, k, ignore_index=ignore_index)
 
 
 @contextlib.contextmanager

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -478,7 +478,9 @@ group_split_dispatch = Dispatch("group_split_dispatch")
 
 @group_split_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
 def group_split_pandas(df, c, k, ignore_index=False):
-    indexer, locations = pd._libs.algos.groupsort_indexer(c.astype(np.int64), k)
+    indexer, locations = pd._libs.algos.groupsort_indexer(
+        c.astype(np.int64, copy=False), k
+    )
     df2 = df.take(indexer)
     locations = locations.cumsum()
     parts = [df2.iloc[a:b] for a, b in zip(locations[:-1], locations[1:])]

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -478,7 +478,7 @@ group_split_dispatch = Dispatch("group_split_dispatch")
 
 @group_split_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
 def group_split_pandas(df, c, k, ignore_index=False):
-    indexer, locations = pd._libs.algos.groupsort_indexer(c, k)
+    indexer, locations = pd._libs.algos.groupsort_indexer(c.astype(np.int64), k)
     df2 = df.take(indexer)
     locations = locations.cumsum()
     parts = [df2.iloc[a:b] for a, b in zip(locations[:-1], locations[1:])]


### PR DESCRIPTION
When using `split_out>1` in `apply_concat_apply`, the `hash_shard` routine is doing something very similar to the `shuffle_group` routine in `dask.dataframe.shuffle`.  The shuffle code leverages `group_split_dispatch`, which should be better optimized (it certainly is for a cudf backend).  The `group_split_dispatch` and `_concat` functions can also leverage `ignore_index=True` to improve performance in some cases.

This PR modifies `hash_shard` to use `group_split_dispatch`, and also handles `ignore_index` in `apply_concat_apply` (and `drop_duplicates`).

The motivation for these changes is to improve the performance of `drop_duplicates` with the `cudf` backend (using `dask_cudf.DataFrame`).


- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
