### PR TITLE
Update dask.array.from_array to warn when passed a Dask collection

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2751,6 +2751,13 @@ def from_array(
         raise ValueError(
             "Array is already a dask array. Use 'asarray' or " "'rechunk' instead."
         )
+    elif is_dask_collection(x):
+        warnings.warn(
+            "Passing an object to dask.array.from_array which is "
+            "already a Dask collection. This can lead to unexpected "
+            "behavior."
+        )
+
     if isinstance(x, (list, tuple, memoryview) + np.ScalarType):
         x = np.array(x)
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2755,7 +2755,8 @@ def from_array(
         warnings.warn(
             "Passing an object to dask.array.from_array which is "
             "already a Dask collection. This can lead to unexpected "
-            "behavior."
+            "behavior. Consider using dask.array.asarray or "
+            "dask.array.rechunk instead."
         )
 
     if isinstance(x, (list, tuple, memoryview) + np.ScalarType):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2753,10 +2753,8 @@ def from_array(
         )
     elif is_dask_collection(x):
         warnings.warn(
-            "Passing an object to dask.array.from_array which is "
-            "already a Dask collection. This can lead to unexpected "
-            "behavior. Consider using dask.array.asarray or "
-            "dask.array.rechunk instead."
+            "Passing an object to dask.array.from_array which is already a "
+            "Dask collection. This can lead to unexpected behavior."
         )
 
     if isinstance(x, (list, tuple, memoryview) + np.ScalarType):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2386,6 +2386,10 @@ def test_from_array_dask_collection_warns():
     with pytest.warns(UserWarning):
         da.from_array(x)
 
+    # Ensure da.array warns too
+    with pytest.warns(UserWarning):
+        da.array(x)
+
 
 def test_asarray():
     assert_eq(da.asarray([1, 2, 3]), np.asarray([1, 2, 3]))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2377,6 +2377,16 @@ def test_from_array_dask_array():
         da.from_array(dx)
 
 
+def test_from_array_dask_collection_warns():
+    class CustomCollection(np.ndarray):
+        def __dask_graph__(self):
+            return {"bar": 1}
+
+    x = CustomCollection([1, 2, 3])
+    with pytest.warns(UserWarning):
+        da.from_array(x)
+
+
 def test_asarray():
     assert_eq(da.asarray([1, 2, 3]), np.asarray([1, 2, 3]))
 


### PR DESCRIPTION
We now inform users when they are passing a Dask collection to `dask.array.from_array` (xref https://github.com/dask/distributed/issues/3714#issuecomment-618005562)

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
