### PR TITLE
full & full_like: error on non-scalar fill_value

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -26,7 +26,7 @@ from .wrap import empty, ones, zeros, full
 from .utils import AxisError, meta_from_array, zeros_like_safe
 
 
-def empty_like(a, dtype=None, chunks=None):
+def empty_like(a, dtype=None, chunks=None, name=None):
     """
     Return a new array with the same shape and type as a given array.
 
@@ -40,6 +40,9 @@ def empty_like(a, dtype=None, chunks=None):
     chunks : sequence of ints
         The number of samples on each block. Note that the last block will have
         fewer samples if ``len(array) % chunks != 0``.
+    name : str, optional
+        An optional keyname for the array. Defaults to hashing the input
+        keyword arguments.
 
     Returns
     -------
@@ -67,10 +70,11 @@ def empty_like(a, dtype=None, chunks=None):
         a.shape,
         dtype=(dtype or a.dtype),
         chunks=(chunks if chunks is not None else a.chunks),
+        name=name,
     )
 
 
-def ones_like(a, dtype=None, chunks=None):
+def ones_like(a, dtype=None, chunks=None, name=None):
     """
     Return an array of ones with the same shape and type as a given array.
 
@@ -84,6 +88,9 @@ def ones_like(a, dtype=None, chunks=None):
     chunks : sequence of ints
         The number of samples on each block. Note that the last block will have
         fewer samples if ``len(array) % chunks != 0``.
+    name : str, optional
+        An optional keyname for the array. Defaults to hashing the input
+        keyword arguments.
 
     Returns
     -------
@@ -104,10 +111,11 @@ def ones_like(a, dtype=None, chunks=None):
         a.shape,
         dtype=(dtype or a.dtype),
         chunks=(chunks if chunks is not None else a.chunks),
+        name=name,
     )
 
 
-def zeros_like(a, dtype=None, chunks=None):
+def zeros_like(a, dtype=None, chunks=None, name=None):
     """
     Return an array of zeros with the same shape and type as a given array.
 
@@ -121,6 +129,9 @@ def zeros_like(a, dtype=None, chunks=None):
     chunks : sequence of ints
         The number of samples on each block. Note that the last block will have
         fewer samples if ``len(array) % chunks != 0``.
+    name : str, optional
+        An optional keyname for the array. Defaults to hashing the input
+        keyword arguments.
 
     Returns
     -------
@@ -141,10 +152,11 @@ def zeros_like(a, dtype=None, chunks=None):
         a.shape,
         dtype=(dtype or a.dtype),
         chunks=(chunks if chunks is not None else a.chunks),
+        name=name,
     )
 
 
-def full_like(a, fill_value, dtype=None, chunks=None):
+def full_like(a, fill_value, dtype=None, chunks=None, name=None):
     """
     Return a full array with the same shape and type as a given array.
 
@@ -160,6 +172,9 @@ def full_like(a, fill_value, dtype=None, chunks=None):
     chunks : sequence of ints
         The number of samples on each block. Note that the last block will have
         fewer samples if ``len(array) % chunks != 0``.
+    name : str, optional
+        An optional keyname for the array. Defaults to hashing the input
+        keyword arguments.
 
     Returns
     -------
@@ -183,6 +198,7 @@ def full_like(a, fill_value, dtype=None, chunks=None):
         fill_value,
         dtype=(dtype or a.dtype),
         chunks=(chunks if chunks is not None else a.chunks),
+        name=name,
     )
 
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -26,7 +26,7 @@ from .wrap import empty, ones, zeros, full
 from .utils import AxisError, meta_from_array, zeros_like_safe
 
 
-def empty_like(a, dtype=None, chunks=None, name=None):
+def empty_like(a, dtype=None, order="C", chunks=None, name=None):
     """
     Return a new array with the same shape and type as a given array.
 
@@ -37,6 +37,9 @@ def empty_like(a, dtype=None, chunks=None, name=None):
         returned array.
     dtype : data-type, optional
         Overrides the data type of the result.
+    order : {'C', 'F'}, optional
+        Whether to store multidimensional data in C- or Fortran-contiguous
+        (row- or column-wise) order in memory.
     chunks : sequence of ints
         The number of samples on each block. Note that the last block will have
         fewer samples if ``len(array) % chunks != 0``.
@@ -69,12 +72,13 @@ def empty_like(a, dtype=None, chunks=None, name=None):
     return empty(
         a.shape,
         dtype=(dtype or a.dtype),
+        order=order,
         chunks=(chunks if chunks is not None else a.chunks),
         name=name,
     )
 
 
-def ones_like(a, dtype=None, chunks=None, name=None):
+def ones_like(a, dtype=None, order="C", chunks=None, name=None):
     """
     Return an array of ones with the same shape and type as a given array.
 
@@ -85,6 +89,9 @@ def ones_like(a, dtype=None, chunks=None, name=None):
         the returned array.
     dtype : data-type, optional
         Overrides the data type of the result.
+    order : {'C', 'F'}, optional
+        Whether to store multidimensional data in C- or Fortran-contiguous
+        (row- or column-wise) order in memory.
     chunks : sequence of ints
         The number of samples on each block. Note that the last block will have
         fewer samples if ``len(array) % chunks != 0``.
@@ -110,12 +117,13 @@ def ones_like(a, dtype=None, chunks=None, name=None):
     return ones(
         a.shape,
         dtype=(dtype or a.dtype),
+        order=order,
         chunks=(chunks if chunks is not None else a.chunks),
         name=name,
     )
 
 
-def zeros_like(a, dtype=None, chunks=None, name=None):
+def zeros_like(a, dtype=None, order="C", chunks=None, name=None):
     """
     Return an array of zeros with the same shape and type as a given array.
 
@@ -126,6 +134,9 @@ def zeros_like(a, dtype=None, chunks=None, name=None):
         the returned array.
     dtype : data-type, optional
         Overrides the data type of the result.
+    order : {'C', 'F'}, optional
+        Whether to store multidimensional data in C- or Fortran-contiguous
+        (row- or column-wise) order in memory.
     chunks : sequence of ints
         The number of samples on each block. Note that the last block will have
         fewer samples if ``len(array) % chunks != 0``.
@@ -151,12 +162,13 @@ def zeros_like(a, dtype=None, chunks=None, name=None):
     return zeros(
         a.shape,
         dtype=(dtype or a.dtype),
+        order=order,
         chunks=(chunks if chunks is not None else a.chunks),
         name=name,
     )
 
 
-def full_like(a, fill_value, dtype=None, chunks=None, name=None):
+def full_like(a, fill_value, order="C", dtype=None, chunks=None, name=None):
     """
     Return a full array with the same shape and type as a given array.
 
@@ -169,6 +181,9 @@ def full_like(a, fill_value, dtype=None, chunks=None, name=None):
         Fill value.
     dtype : data-type, optional
         Overrides the data type of the result.
+    order : {'C', 'F'}, optional
+        Whether to store multidimensional data in C- or Fortran-contiguous
+        (row- or column-wise) order in memory.
     chunks : sequence of ints
         The number of samples on each block. Note that the last block will have
         fewer samples if ``len(array) % chunks != 0``.
@@ -196,6 +211,7 @@ def full_like(a, fill_value, dtype=None, chunks=None, name=None):
     return full(
         a.shape,
         fill_value,
+        order=order,
         dtype=(dtype or a.dtype),
         chunks=(chunks if chunks is not None else a.chunks),
         name=name,

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -29,8 +29,9 @@ from dask.array.numpy_compat import _numpy_117, _numpy_118
 @pytest.mark.parametrize("cast_shape", [tuple, list, np.asarray])
 @pytest.mark.parametrize("cast_chunks", [tuple, list, np.asarray])
 @pytest.mark.parametrize("shape, chunks", [((10, 10), (4, 4))])
+@pytest.mark.parametrize("name", [None, "my-name"])
 @pytest.mark.parametrize("dtype", ["i4"])
-def test_arr_like(funcname, shape, cast_shape, dtype, cast_chunks, chunks):
+def test_arr_like(funcname, shape, cast_shape, dtype, cast_chunks, chunks, name):
     np_func = getattr(np, funcname)
     da_func = getattr(da, funcname)
     shape = cast_shape(shape)
@@ -49,16 +50,21 @@ def test_arr_like(funcname, shape, cast_shape, dtype, cast_chunks, chunks):
         a = np.random.randint(0, 10, shape).astype(dtype)
 
         np_r = np_func(a)
-        da_r = da_func(a, chunks=chunks)
+        da_r = da_func(a, chunks=chunks, name=name)
     else:
         np_r = np_func(shape, dtype=dtype)
-        da_r = da_func(shape, dtype=dtype, chunks=chunks)
+        da_r = da_func(shape, dtype=dtype, chunks=chunks, name=name)
 
     assert np_r.shape == da_r.shape
     assert np_r.dtype == da_r.dtype
 
     if "empty" not in funcname:
         assert (np_r == np.asarray(da_r)).all()
+
+    if name is None:
+        assert funcname.split("_")[0] in da_r.name
+    else:
+        assert da_r.name == name
 
 
 @pytest.mark.parametrize("endpoint", [True, False])

--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -51,7 +51,7 @@ def test_full_like_error_nonscalar_fill_value():
     x = np.full((3, 3), 1, dtype="i8")
     with pytest.raises(ValueError, match="fill_value must be scalar"):
         da.full_like(x, [100, 100], chunks=(2, 2), dtype="i8")
-    
+
 
 def test_can_make_really_big_array_of_ones():
     ones((1000000, 1000000), chunks=(100000, 100000))

--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -42,6 +42,17 @@ def test_full():
     assert a.name.startswith("full-")
 
 
+def test_full_error_nonscalar_fill_value():
+    with pytest.raises(ValueError, match="fill_value must be scalar"):
+        da.full((3, 3), [100, 100], chunks=(2, 2), dtype="i8")
+
+
+def test_full_like_error_nonscalar_fill_value():
+    x = np.full((3, 3), 1, dtype="i8")
+    with pytest.raises(ValueError, match="fill_value must be scalar"):
+        da.full_like(x, [100, 100], chunks=(2, 2), dtype="i8")
+    
+
 def test_can_make_really_big_array_of_ones():
     ones((1000000, 1000000), chunks=(100000, 100000))
     ones(shape=(1000000, 1000000), chunks=(100000, 100000))

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -122,7 +122,7 @@ def wrap(wrap_func, func, **kwargs):
     Blocked variant of %(name)s
 
     Follows the signature of %(name)s exactly except that it also features
-    optional keyword arguments `chunks: int, tuple, or dict` and `name: str`.
+    optional keyword arguments ``chunks: int, tuple, or dict`` and ``name: str``.
 
     Original signature follows below.
     """
@@ -142,8 +142,6 @@ empty = w(np.empty, dtype="f8")
 w_like = wrap(wrap_func_like_safe)
 
 
-ones_like = w_like(np.ones, func_like=np.ones_like)
-zeros_like = w_like(np.zeros, func_like=np.zeros_like)
 empty_like = w_like(np.empty, func_like=np.empty_like)
 
 

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -18,6 +18,7 @@ def _parse_wrap_args(func, args, kwargs, shape):
     if not isinstance(shape, (tuple, list)):
         shape = (shape,)
 
+    name = kwargs.pop("name", None)
     chunks = kwargs.pop("chunks", "auto")
 
     dtype = kwargs.pop("dtype", None)
@@ -26,7 +27,6 @@ def _parse_wrap_args(func, args, kwargs, shape):
     dtype = np.dtype(dtype)
 
     chunks = normalize_chunks(chunks, shape, dtype=dtype)
-    name = kwargs.pop("name", None)
 
     name = name or funcname(func) + "-" + tokenize(
         func, shape, chunks, dtype, args, kwargs
@@ -121,8 +121,8 @@ def wrap(wrap_func, func, **kwargs):
     template = """
     Blocked variant of %(name)s
 
-    Follows the signature of %(name)s exactly except that it also requires a
-    keyword argument chunks=(...)
+    Follows the signature of %(name)s exactly except that it also features
+    optional keyword arguments `chunks: int, tuple, or dict` and `name: str`.
 
     Original signature follows below.
     """
@@ -153,24 +153,20 @@ _full = w(np.full)
 _full_like = w_like(np.full, func_like=np.full_like)
 
 
-def full(shape, fill_value, dtype=None, order="C", chunks=None):
+def full(shape, fill_value, *args, **kwargs):
     # np.isscalar has somewhat strange behavior:
     # https://docs.scipy.org/doc/numpy/reference/generated/numpy.isscalar.html
     if np.ndim(fill_value) != 0:
-        raise ValueError(f"fill_value must be scalar. Received {type(fill_value)} instead.")
-    return _full(
-        shape=shape, fill_value=fill_value, dtype=dtype, order=order, chunks=chunks
-    )
+        raise ValueError(
+            f"fill_value must be scalar. Received {type(fill_value)} instead."
+        )
+    return _full(shape=shape, fill_value=fill_value, *args, **kwargs)
 
 
-def full_like(
-    a, fill_value, dtype=None, order="K", subok=True, shape=None, chunks=None
-):
+def full_like(a, fill_value, *args, **kwargs):
     if np.ndim(fill_value) != 0:
         raise ValueError(f"fill_value must be scalar. Received {fill_value} instead.")
-    return _full_like(
-        a=a, fill_value=fill_value, dtype=dtype, order=order, subok=subok, chunks=chunks
-    )
+    return _full_like(a=a, fill_value=fill_value, *args, **kwargs,)
 
 
 full.__doc__ = _full.__doc__

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -157,7 +157,7 @@ def full(shape, fill_value, dtype=None, order="C", chunks=None):
     # np.isscalar has somewhat strange behavior:
     # https://docs.scipy.org/doc/numpy/reference/generated/numpy.isscalar.html
     if np.ndim(fill_value) != 0:
-        raise ValueError(f"fill_value must be scalar. Received {fill_value} instead.")
+        raise ValueError(f"fill_value must be scalar. Received {type(fill_value)} instead.")
     return _full(
         shape=shape, fill_value=fill_value, dtype=dtype, order=order, chunks=chunks
     )

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -137,7 +137,6 @@ w = wrap(wrap_func_shape_as_first_arg)
 ones = w(np.ones, dtype="f8")
 zeros = w(np.zeros, dtype="f8")
 empty = w(np.empty, dtype="f8")
-full = w(np.full)
 
 
 w_like = wrap(wrap_func_like_safe)
@@ -146,4 +145,29 @@ w_like = wrap(wrap_func_like_safe)
 ones_like = w_like(np.ones, func_like=np.ones_like)
 zeros_like = w_like(np.zeros, func_like=np.zeros_like)
 empty_like = w_like(np.empty, func_like=np.empty_like)
-full_like = w_like(np.full, func_like=np.full_like)
+
+
+# full and full_like require special casing due to argument check on fill_value
+# Generate wrapped functions only once
+_full = w(np.full)  
+_full_like = w_like(np.full, func_like=np.full_like)
+
+
+def full(shape, fill_value, dtype=None, order='C', chunks=None):
+    # np.isscalar has somewhat strange behavior: 
+    # https://docs.scipy.org/doc/numpy/reference/generated/numpy.isscalar.html 
+    if np.ndim(fill_value) != 0:
+        raise ValueError(f"fill_value must be scalar. Received {fill_value} instead.")
+    return _full(shape=shape, fill_value=fill_value, dtype=dtype, order=order, chunks=chunks)
+
+
+def full_like(a, fill_value, dtype=None, order='K', subok=True, shape=None, chunks=None):
+    if np.ndim(fill_value) != 0:
+        raise ValueError(f"fill_value must be scalar. Received {fill_value} instead.")
+    return _full_like(a=a, fill_value=fill_value, dtype=dtype, order=order, subok=subok, chunks=chunks)
+
+
+full.__doc__ = _full.__doc__
+full.__name__ = _full.__name__
+full_like.__doc__ = _full_like.__doc__
+full_like.__name__ = _full_like.__name__

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -149,22 +149,28 @@ empty_like = w_like(np.empty, func_like=np.empty_like)
 
 # full and full_like require special casing due to argument check on fill_value
 # Generate wrapped functions only once
-_full = w(np.full)  
+_full = w(np.full)
 _full_like = w_like(np.full, func_like=np.full_like)
 
 
-def full(shape, fill_value, dtype=None, order='C', chunks=None):
-    # np.isscalar has somewhat strange behavior: 
-    # https://docs.scipy.org/doc/numpy/reference/generated/numpy.isscalar.html 
+def full(shape, fill_value, dtype=None, order="C", chunks=None):
+    # np.isscalar has somewhat strange behavior:
+    # https://docs.scipy.org/doc/numpy/reference/generated/numpy.isscalar.html
     if np.ndim(fill_value) != 0:
         raise ValueError(f"fill_value must be scalar. Received {fill_value} instead.")
-    return _full(shape=shape, fill_value=fill_value, dtype=dtype, order=order, chunks=chunks)
+    return _full(
+        shape=shape, fill_value=fill_value, dtype=dtype, order=order, chunks=chunks
+    )
 
 
-def full_like(a, fill_value, dtype=None, order='K', subok=True, shape=None, chunks=None):
+def full_like(
+    a, fill_value, dtype=None, order="K", subok=True, shape=None, chunks=None
+):
     if np.ndim(fill_value) != 0:
         raise ValueError(f"fill_value must be scalar. Received {fill_value} instead.")
-    return _full_like(a=a, fill_value=fill_value, dtype=dtype, order=order, subok=subok, chunks=chunks)
+    return _full_like(
+        a=a, fill_value=fill_value, dtype=dtype, order=order, subok=subok, chunks=chunks
+    )
 
 
 full.__doc__ = _full.__doc__

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -158,14 +158,16 @@ def full(shape, fill_value, *args, **kwargs):
     # https://docs.scipy.org/doc/numpy/reference/generated/numpy.isscalar.html
     if np.ndim(fill_value) != 0:
         raise ValueError(
-            f"fill_value must be scalar. Received {type(fill_value)} instead."
+            f"fill_value must be scalar. Received {type(fill_value).__name__} instead."
         )
     return _full(shape=shape, fill_value=fill_value, *args, **kwargs)
 
 
 def full_like(a, fill_value, *args, **kwargs):
     if np.ndim(fill_value) != 0:
-        raise ValueError(f"fill_value must be scalar. Received {fill_value} instead.")
+        raise ValueError(
+            f"fill_value must be scalar. Received {type(fill_value).__name__} instead."
+        )
     return _full_like(a=a, fill_value=fill_value, *args, **kwargs,)
 
 


### PR DESCRIPTION
Fixes #6107
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Because it touches the docstrings, I also ran `make html`, I didn't come across any issues.

I also found two nits to pick -- I think -- in the docstring:

First, the docstring template of `wrap` mentions:
>    Follows the signature of %(name)s exactly except that it also requires a  keyword argument chunks=(...)

The chunks argument is optional, not required. Maybe reword it to: 
> "... it also features an optional keyword argument chunks=(...)"


Second: technically another keyword argument is supported, `name`.

For this function:
https://github.com/dask/dask/blob/f58b95584dbdd19aad5c409892196f1e29a84534/dask/array/wrap.py#L14

`name` is explicitly extracted, if present, generated otherwise:
https://github.com/dask/dask/blob/f58b95584dbdd19aad5c409892196f1e29a84534/dask/array/wrap.py#L29-L33

So I think I'd have to add it to the function arguments.

Or is this form preferable?
```python
def full(shape, fill_value, *args, **kwargs):
```