### PR TITLE
Update "helm install" for helm 3 usage

### DIFF
--- a/docs/source/setup/kubernetes-helm.rst
+++ b/docs/source/setup/kubernetes-helm.rst
@@ -47,7 +47,7 @@ You will need to add this to your known channels and update your local charts::
 
 Now, you can launch Dask on your Kubernetes cluster using the Dask Helm_ chart::
 
-   helm install dask/dask
+   helm install my-dask dask/dask
 
 This deploys a ``dask-scheduler``, several ``dask-worker`` processes, and
 also an optional Jupyter server.


### PR DESCRIPTION
Helm 3 now requires to set a name or use a flag to automatically create a name

Just changed the docs :)
