### PR TITLE
remove unused imports in scheduling script

### DIFF
--- a/docs/source/scripts/scheduling.py
+++ b/docs/source/scripts/scheduling.py
@@ -1,8 +1,6 @@
-from toolz import merge
 from time import time
 import dask
 from dask import threaded, multiprocessing, local
-from dask.compatibility import Iterator
 from random import randint
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

In this PR, I'd like to remove two imports in `docs/source/scripts/scheduling.py`.

Thanks for your time and consideration.