### PR TITLE
RFC Allow size measurements of shuffle_group intermediate results

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -673,7 +673,7 @@ def set_partitions_pre(s, divisions):
 
 def shuffle_group_2(df, col, ignore_index):
     if not len(df):
-        return {}, df
+        return tuple(), df
     ind = df[col].astype(np.int32)
     n = ind.max() + 1
     result2 = group_split_dispatch(df, ind.values.view(), n, ignore_index=ignore_index)
@@ -682,7 +682,7 @@ def shuffle_group_2(df, col, ignore_index):
 
 def shuffle_group_get(g_head, i):
     g, head = g_head
-    if i in g:
+    if i < len(g):
         return g[i]
     else:
         return head

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -484,7 +484,7 @@ def group_split_pandas(df, c, k, ignore_index=False):
     df2 = df.take(indexer)
     locations = locations.cumsum()
     parts = [df2.iloc[a:b] for a, b in zip(locations[:-1], locations[1:])]
-    return dict(zip(range(k), parts))
+    return tuple(parts)
 
 
 _simple_fake_mapping = {


### PR DESCRIPTION
I'm currently investigating heavy memory usage of a shuffle (similar, if not identical to https://github.com/dask/dask/issues/2456) and realized that we do not have any sizing information about the intermediate stages when shuffling.
From my understanding this is mostly because we move the shuffle_group results around in dicts and we do not properly estimate dict sizes due to potentially severe performance implications. As a practical fix these results could be passed as tuples since the dict keys were integer indices anyhow.

The size estimation would not only be useful for debugging but I would also expect the distributed scheduler to assign tasks much smarter to the workers with proper size estimates. Especially for a data intensive operation like a shuffle I would expect this effect to be strong. I'll follow up with some measurements but wanted to pick your brains before I step too deep into the rabbit hole.
