### PR TITLE
[REVIEW] Fix issue where `unique` returns an index like result from backends.

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -7,6 +7,7 @@ from tlz import partition
 
 from .utils import (
     is_series_like,
+    is_index_like,
     is_dataframe_like,
     PANDAS_GT_0250,
     hash_object_dispatch,
@@ -271,7 +272,7 @@ def unique(x, series_name=None):
     out = x.unique()
     # out can be either an np.ndarray or may already be a series
     # like object.  When out is an np.ndarray, it must be wrapped.
-    if not is_series_like(out):
+    if not (is_series_like(out) or is_index_like(out)):
         out = pd.Series(out, name=series_name)
     return out
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1037,6 +1037,7 @@ def test_unique():
 
     assert_eq(ddf.x.unique(split_every=2), pd.Series(pdf.x.unique(), name="x"))
     assert_eq(ddf.y.unique(split_every=2), pd.Series(pdf.y.unique(), name="y"))
+    assert_eq(ddf.index.unique(), pdf.index.unique())
     assert ddf.x.unique(split_every=2)._name != ddf.x.unique()._name
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1038,6 +1038,7 @@ def test_unique():
     assert_eq(ddf.x.unique(split_every=2), pd.Series(pdf.x.unique(), name="x"))
     assert_eq(ddf.y.unique(split_every=2), pd.Series(pdf.y.unique(), name="y"))
     assert_eq(ddf.index.unique(), pdf.index.unique())
+
     assert ddf.x.unique(split_every=2)._name != ddf.x.unique()._name
 
 


### PR DESCRIPTION
`unique` currently is converting to `pd.Series` when the result is of type index-like as well. Hence guarding the series conversion with `is_index_like` check too.

Fixes: https://github.com/rapidsai/cudf/issues/5037

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
