### PR TITLE
Estimate dict sizes properly

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -1,3 +1,4 @@
+import random
 import sys
 from distutils.version import LooseVersion
 
@@ -10,6 +11,12 @@ except (AttributeError, TypeError):  # Monkey patch
 
     def getsizeof(x):
         return 100
+
+
+try:
+    from cytoolz.itertoolz import map
+except ImportError:
+    pass
 
 
 sizeof = Dispatch(name="sizeof")
@@ -25,15 +32,24 @@ def sizeof_default(o):
 @sizeof.register(set)
 @sizeof.register(frozenset)
 def sizeof_python_collection(seq):
-    return getsizeof(seq) + sum(map(sizeof, seq))
+    num_items = len(seq)
+    samples = 10
+    if num_items > samples:
+        return getsizeof(seq) + num_items / samples * sum(
+            map(sizeof, random.sample(seq, samples))
+        )
+    else:
+        return getsizeof(seq) + sum(map(sizeof, seq))
 
 
 @sizeof.register(dict)
 def sizeof_python_dict(d):
-    if len(d) > 10:
-        return getsizeof(d) + 1000 * len(d)
-    else:
-        return getsizeof(d) + sum(map(sizeof, d.keys())) + sum(map(sizeof, d.values()))
+    return (
+        getsizeof(d)
+        + sizeof(list(d.keys()))
+        + sizeof(list(d.values()))
+        - 2 * sizeof(list())
+    )
 
 
 @sizeof.register_lazy("cupy")

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -13,12 +13,6 @@ except (AttributeError, TypeError):  # Monkey patch
         return 100
 
 
-try:
-    from cytoolz.itertoolz import map
-except ImportError:
-    pass
-
-
 sizeof = Dispatch(name="sizeof")
 
 

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -129,3 +129,5 @@ def test_dict():
     assert sizeof({"x": x}) > x.nbytes
     assert sizeof({"x": [x]}) > x.nbytes
     assert sizeof({"x": [{"y": x}]}) > x.nbytes
+
+    assert sizeof({i: x for i in range(100)}) > x.nbytes * 100


### PR DESCRIPTION
This would be the implementation alternative for #6149 which is supposed to address the issue that the size of intermediate shuffle tasks are not measured since they are usually dicts with > 10 keys.

This issue has been frequently discussed and there were some concerns about performance, most notably https://github.com/dask/distributed/pull/1626

For the sampling I also tried to use `(cy)toolz.itertoolz.random_sample` but the builtin random performed the same so I chose to go this way.

Regarding mirco benchmarks of the function this code is useful

```python
import sys
from distutils.version import LooseVersion
from dask.sizeof import sizeof

from cytoolz.itertoolz import map
getsizeof = sys.getsizeof

import random
def sizeof_python_collection(seq):
    
    num_items = len(seq)
    samples = 10
    if num_items > samples:
        return getsizeof(seq) + num_items / samples * sum(
            map(sizeof, random.sample(seq, samples))
        )
    else:
        return getsizeof(seq) + sum(map(sizeof, seq))


def sizeof_python_dict(d):
    return (
        getsizeof(d)
        + sizeof_python_collection(list(d.keys()))
        + sizeof_python_collection(list(d.values()))
        - 2 * sizeof_python_collection(list())
    )

def sizeof_python_dict_orig(d):
    if len(d) > 10:
        return getsizeof(d) + 1000 * len(d)
    else:
        return getsizeof(d) + sum(map(sizeof, d.keys())) + sum(map(sizeof, d.values()))
```

Benchmarks from https://github.com/dask/dask-benchmarks will follow

xref https://github.com/dask/dask/issues/2456