### PR TITLE
add phase of computation to index TOC

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -186,6 +186,7 @@ messy situations in everyday problems.
    spark.rst
    caching.rst
    graphs.rst
+   phases-of-computation.rst
    remote-data-services.rst
    gpu.rst
    cite.rst


### PR DESCRIPTION
In https://github.com/dask/distributed/issues/3750#issuecomment-621507413 it was suggested we add the phases-of-computation page to the TOC.  This PR does that!

<img width="1176" alt="Screen Shot 2020-04-30 at 5 56 01 PM" src="https://user-images.githubusercontent.com/1403768/80763151-e4ef2380-8b0b-11ea-994c-a54715862642.png">
