### PR TITLE
[REVIEW] Harden inconsistent-schema handling in pyarrow-based read_parquet

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -144,6 +144,15 @@ def _determine_dataset_parts(fs, paths, gather_statistics, filters, dataset_kwar
             dataset = pq.ParquetDataset(
                 paths, filesystem=fs, filters=filters, **dataset_kwargs
             )
+            if dataset.schema is None:
+                # The dataset may have inconsistent schemas between files.
+                # If so, we should try to use a "_common_metadata" file
+                proxy_path = (
+                    base + fs.sep + "_common_metadata"
+                    if "_common_metadata" in fns
+                    else paths[0]
+                )
+                dataset.schema = pq.ParquetFile(proxy_path).schema
         else:
             # Rely on schema for 0th file.
             # Will need to pass a list of paths to read_partition
@@ -163,6 +172,15 @@ def _determine_dataset_parts(fs, paths, gather_statistics, filters, dataset_kwar
             dataset = pq.ParquetDataset(
                 paths, filesystem=fs, filters=filters, **dataset_kwargs
             )
+            if dataset.schema is None:
+                # The dataset may have inconsistent schemas between files.
+                # If so, we should try to use a "_common_metadata" file
+                proxy_path = (
+                    base + fs.sep + "_common_metadata"
+                    if "_common_metadata" in fns
+                    else allpaths[0]
+                )
+                dataset.schema = pq.ParquetFile(proxy_path).schema
         else:
             # Use _common_metadata file if it is available.
             # Otherwise, just use 0th file

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -152,7 +152,7 @@ def _determine_dataset_parts(fs, paths, gather_statistics, filters, dataset_kwar
                     if "_common_metadata" in fns
                     else paths[0]
                 )
-                dataset.schema = pq.ParquetFile(proxy_path).schema
+                dataset.schema = pq.ParquetDataset(proxy_path, filesystem=fs).schema
         else:
             # Rely on schema for 0th file.
             # Will need to pass a list of paths to read_partition
@@ -180,7 +180,7 @@ def _determine_dataset_parts(fs, paths, gather_statistics, filters, dataset_kwar
                     if "_common_metadata" in fns
                     else allpaths[0]
                 )
-                dataset.schema = pq.ParquetFile(proxy_path).schema
+                dataset.schema = pq.ParquetDataset(proxy_path, filesystem=fs).schema
         else:
             # Use _common_metadata file if it is available.
             # Otherwise, just use 0th file

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2062,7 +2062,7 @@ def test_read_inconsistent_schema_pyarrow(tmpdir):
     df2.val = df2.val.astype(other_type)
 
     df_expect = pd.concat([df1, df2], ignore_index=True)
-    df_expect.val = df_expect.val.astype(desired_type)
+    df_expect['val'] = df_expect.val.astype(desired_type)
 
     df1.to_parquet(os.path.join(tmpdir, "0.parquet"))
     df2.to_parquet(os.path.join(tmpdir, "1.parquet"))

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2047,7 +2047,7 @@ def test_timeseries_nulls_in_schema_pyarrow(tmpdir, timestamp, numerical):
 def test_read_inconsistent_schema_pyarrow(tmpdir):
     check_pyarrow()
 
-    # Note: This is a proxy test for a current cudf issue
+    # Note: This is a proxy test for a cudf-related issue fix
     # (see cudf#5062 github issue).  The cause of that issue is
     # schema inconsistencies that do not actually correspond to
     # different types, but whether or not the file/column contains

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2062,7 +2062,7 @@ def test_read_inconsistent_schema_pyarrow(tmpdir):
     df2.val = df2.val.astype(other_type)
 
     df_expect = pd.concat([df1, df2], ignore_index=True)
-    df_expect['val'] = df_expect.val.astype(desired_type)
+    df_expect["val"] = df_expect.val.astype(desired_type)
 
     df1.to_parquet(os.path.join(tmpdir, "0.parquet"))
     df2.to_parquet(os.path.join(tmpdir, "1.parquet"))

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2044,6 +2044,40 @@ def test_timeseries_nulls_in_schema_pyarrow(tmpdir, timestamp, numerical):
     )
 
 
+def test_read_inconsistent_schema_pyarrow(tmpdir):
+    check_pyarrow()
+
+    # Note: This is a proxy test for a current cudf issue
+    # (see cudf#5062 github issue).  The cause of that issue is
+    # schema inconsistencies that do not actually correspond to
+    # different types, but whether or not the file/column contains
+    # null values.
+
+    df1 = pd.DataFrame({"id": [0, 1], "val": [10, 20]})
+    df2 = pd.DataFrame({"id": [2, 3], "val": [30, 40]})
+
+    desired_type = "int64"
+    other_type = "int32"
+    df1.val = df1.val.astype(desired_type)
+    df2.val = df2.val.astype(other_type)
+
+    df_expect = pd.concat([df1, df2], ignore_index=True)
+    df_expect.val = df_expect.val.astype(desired_type)
+
+    df1.to_parquet(os.path.join(tmpdir, "0.parquet"))
+    df2.to_parquet(os.path.join(tmpdir, "1.parquet"))
+
+    # Read Directory
+    check = dd.read_parquet(str(tmpdir), dataset={"validate_schema": False})
+    assert_eq(check.compute(), df_expect, check_index=False)
+
+    # Read List
+    check = dd.read_parquet(
+        os.path.join(tmpdir, "*.parquet"), dataset={"validate_schema": False}
+    )
+    assert_eq(check.compute(), df_expect, check_index=False)
+
+
 def test_graph_size_pyarrow(tmpdir, engine):
     import pickle
 


### PR DESCRIPTION
Addressed [cudf#5062](https://github.com/rapidsai/cudf/issues/5062)

The `ArrowEngine` version of `read_parquet` is meant to handle inconsistent schemas if the user passes in `dataset={"validate_schema": False}`.  However, this is currently crashing in some cases when the dataset is written with `dask_cudf`.  This PR adds a small fix to make sure the schema is defined when the `pq.ParquetDataset` API fails to populate it.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
