### PR TITLE
Support for multiple arrays in map_overlap

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2165,7 +2165,9 @@ class Array(DaskMethodsMixin):
         """
         from .overlap import map_overlap
 
-        return map_overlap(self, func, depth, boundary, trim, **kwargs)
+        return map_overlap(
+            func, self, depth=depth, boundary=boundary, trim=trim, **kwargs
+        )
 
     @derived_from(np.ndarray)
     def cumsum(self, axis, dtype=None, out=None):

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -1,11 +1,19 @@
+import warnings
 from operator import getitem
 from itertools import product
 from numbers import Integral
-from tlz import merge, pipe, concat, partial
+from tlz import merge, pipe, concat, partial, get
 from tlz.curried import map
 
 from . import chunk, wrap
-from .core import Array, map_blocks, concatenate, concatenate3, reshapelist
+from .core import (
+    Array,
+    map_blocks,
+    concatenate,
+    concatenate3,
+    reshapelist,
+    unify_chunks,
+)
 from ..highlevelgraph import HighLevelGraph
 from ..base import tokenize
 from ..core import flatten
@@ -526,30 +534,46 @@ def add_dummy_padding(x, depth, boundary):
     return x
 
 
-def map_overlap(x, func, depth, boundary=None, trim=True, **kwargs):
-    """ Map a function over blocks of the array with some overlap
+def map_overlap(
+    func, *args, depth=None, boundary=None, trim=True, align_arrays=True, **kwargs
+):
+    """ Map a function over blocks of arrays with some overlap
 
-    We share neighboring zones between blocks of the array, then map a
-    function, then trim away the neighboring strips.
+    We share neighboring zones between blocks of the array, map a
+    function, and then trim away the neighboring strips.
 
     Parameters
     ----------
     func: function
         The function to apply to each extended block
-    depth: int, tuple, or dict
+    args : dask arrays
+    depth: int, tuple, dict or list
         The number of elements that each block should share with its neighbors
         If a tuple or dict then this can be different per axis.
+        If a list then each element of that list must be an int, tuple or dict
+        defining depth for the corresponding array in `args`.
         Asymmetric depths may be specified using a dict value of (-/+) tuples.
         Note that asymmetric depths are currently only supported when
         ``boundary`` is 'none'.
-    boundary: str, tuple, dict
+        The default value is 0.
+    boundary: str, tuple, dict or list
         How to handle the boundaries.
         Values include 'reflect', 'periodic', 'nearest', 'none',
-        or any constant value like 0 or np.nan
+        or any constant value like 0 or np.nan.
+        If a list then each element must be a str, tuple or dict defining the
+        boundary for the corresponding array in `args`.
+        The default value is 'reflect'.
     trim: bool
         Whether or not to trim ``depth`` elements from each block after
         calling the map function.
         Set this to False if your mapping function already does this for you
+    align_arrays: bool
+        Whether or not to align chunks along equally sized dimensions when
+        multiple arrays are provided.  This allows for larger chunks in some
+        arrays to be broken into smaller ones that match chunk sizes in other
+        arrays such that they are compatible for block function mapping. If
+        this is false, then an error will be thrown if arrays do not already
+        have the same number of blocks in each dimensions.
     **kwargs:
         Other keyword arguments valid in ``map_blocks``
 
@@ -584,29 +608,83 @@ def map_overlap(x, func, depth, boundary=None, trim=True, **kwargs):
            [20,  21,  22,  23],
            [24,  25,  26,  27]])
     """
-    depth2 = coerce_depth(x.ndim, depth)
-    boundary2 = coerce_boundary(x.ndim, boundary)
+    # Look for invocation using deprecated single-array signature
+    # map_overlap(x, func, depth, boundary=None, trim=True, **kwargs)
+    if isinstance(func, Array) and callable(args[0]):
+        warnings.warn(
+            "Detected use of signature map_overlap(x, func) rather than "
+            "map_overlap(func, *args) for multi-array support. Arguments "
+            "will be swapped in this case but such an exception will not "
+            "be made in a future release.",
+            FutureWarning,
+        )
+        sig = ["func", "depth", "boundary", "trim"]
+        depth = get(sig.index("depth"), args, depth)
+        boundary = get(sig.index("boundary"), args, boundary)
+        trim = get(sig.index("trim"), args, trim)
+        func, args = args[0], [func]
 
-    for i in range(x.ndim):
-        if isinstance(depth2[i], tuple) and boundary2[i] != "none":
-            raise NotImplementedError(
-                "Asymmetric overlap is currently only implemented "
-                "for boundary='none', however boundary for dimension "
-                "{} is {}".format(i, boundary2[i])
+    if not callable(func):
+        raise TypeError(
+            "First argument must be callable function, not {}\n"
+            "Usage:   da.map_overlap(function, x)\n"
+            "   or:   da.map_overlap(function, x, y, z)".format(type(func).__name__)
+        )
+    if not all(isinstance(x, Array) for x in args):
+        raise TypeError(
+            "All variadic arguments must be arrays, not {}\n"
+            "Usage:   da.map_overlap(function, x)\n"
+            "   or:   da.map_overlap(function, x, y, z)".format(
+                [type(x).__name__ for x in args]
             )
+        )
 
-    assert all(type(c) is int for cc in x.chunks for c in cc)
-    g = overlap(x, depth=depth2, boundary=boundary2)
-    assert all(type(c) is int for cc in g.chunks for c in cc)
-    g2 = g.map_blocks(func, **kwargs)
-    assert all(type(c) is int for cc in g2.chunks for c in cc)
+    # Coerce depth and boundary arguments to lists of individual
+    # specifications for each array argument
+    def coerce(xs, arg, fn):
+        if not isinstance(arg, list):
+            arg = [arg] * len(xs)
+        return [fn(x.ndim, a) for x, a in zip(xs, arg)]
+
+    depth = coerce(args, depth, coerce_depth)
+    boundary = coerce(args, boundary, coerce_boundary)
+
+    # Align chunks in each array to a common size
+    if align_arrays:
+        # Reverse unification order to allow block broadcasting
+        inds = [list(reversed(range(x.ndim))) for x in args]
+        _, args = unify_chunks(*list(concat(zip(args, inds))), warn=False)
+
+    for i, x in enumerate(args):
+        for j in range(x.ndim):
+            if isinstance(depth[i][j], tuple) and boundary[i][j] != "none":
+                raise NotImplementedError(
+                    "Asymmetric overlap is currently only implemented "
+                    "for boundary='none', however boundary for dimension "
+                    "{} in array argument {} is {}".format(j, i, boundary[i][j])
+                )
+
+    def assert_int_chunksize(xs):
+        assert all(type(c) is int for x in xs for cc in x.chunks for c in cc)
+
+    assert_int_chunksize(args)
+    args = [overlap(x, depth=d, boundary=b) for x, d, b in zip(args, depth, boundary)]
+    assert_int_chunksize(args)
+    x = map_blocks(func, *args, **kwargs)
+    assert_int_chunksize([x])
     if trim:
-        return trim_internal(g2, depth2, boundary2)
+        # Find index of array argument with maximum rank and break ties by choosing first provided
+        i = sorted(enumerate(args), key=lambda v: (v[1].ndim, -v[0]))[-1][0]
+        # Trim using depth/boundary setting for array of highest rank
+        return trim_internal(x, depth[i], boundary[i])
     else:
-        return g2
+        return x
 
 
 def coerce_depth(ndim, depth):
+    default = 0
+    if depth is None:
+        depth = default
     if isinstance(depth, Integral):
         depth = (depth,) * ndim
     if isinstance(depth, tuple):

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -615,9 +615,9 @@ def map_overlap(
     >>> func = lambda x, y: x + y
     >>> x = da.arange(8).reshape(2, 4).rechunk((1, 2))
     >>> y = da.arange(4).rechunk(2)
-    >>> da.map_overlap(func, x, y, depth=1).compute() # doctest: +NORMALIZE_WHITESPACE
-    array([[0,  2,  4,  6],
-           [4,  6,  8, 10]])
+    >>> da.map_overlap(func, x, y, depth=1).compute()
+    array([[0, 2, 4, 6],
+           [4, 6, 8, 10]])
 
     When multiple arrays are given, they do not need to have the
     same number of dimensions but they must broadcast together.

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -615,9 +615,9 @@ def map_overlap(
     >>> func = lambda x, y: x + y
     >>> x = da.arange(8).reshape(2, 4).rechunk((1, 2))
     >>> y = da.arange(4).rechunk(2)
-    >>> da.map_overlap(func, x, y, depth=1).compute()
-    array([[0, 2, 4, 6],
-           [4, 6, 8, 10]])
+    >>> da.map_overlap(func, x, y, depth=1).compute() # doctest: +NORMALIZE_WHITESPACE
+    array([[0,  2,  4,  6],
+           [4,  6,  8,  10]])
 
     When multiple arrays are given, they do not need to have the
     same number of dimensions but they must broadcast together.

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -631,8 +631,10 @@ def map_overlap(
     >>> len(r.to_delayed())
     4
 
-    >>> da.map_overlap(func, x, y, depth=1, align_arrays=False)
-    ValueError: Shapes do not align
+    >>> da.map_overlap(func, x, y, depth=1, align_arrays=False).compute()
+    Traceback (most recent call last):
+        ...
+    ValueError: Shapes do not align {'.0': {2, 4}}
 
     Note also that this function is equivalent to ``map_blocks``
     by default.  A non-zero ``depth`` must be defined for any

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -616,8 +616,8 @@ def map_overlap(
     >>> x = da.arange(8).reshape(2, 4).rechunk((1, 2))
     >>> y = da.arange(4).rechunk(2)
     >>> da.map_overlap(func, x, y, depth=1).compute() # doctest: +NORMALIZE_WHITESPACE
-    array([[0,  2,  4,  6],
-           [4,  6,  8,  10]])
+    array([[ 0,  2,  4,  6],
+           [ 4,  6,  8,  10]])
 
     When multiple arrays are given, they do not need to have the
     same number of dimensions but they must broadcast together.

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -372,6 +372,30 @@ def test_map_overlap_multiarray_defaults():
     assert_eq(z.sum(), 20)
 
 
+def test_map_overlap_multiarray_different_depths():
+    x = da.ones(5, dtype="int")
+    y = da.ones(5, dtype="int")
+
+    def run(depth):
+        return da.map_overlap(
+            lambda x, y: x.sum() + y.sum(), x, y, depth=depth, chunks=(0,), trim=False
+        ).compute()
+
+    # Check that the number of elements added
+    # to arrays in overlap works as expected
+    # when depths differ for each array
+    assert_eq(run([0, 0]), 10)
+    assert_eq(run([0, 1]), 12)
+    assert_eq(run([1, 1]), 14)
+    assert_eq(run([1, 2]), 16)
+    assert_eq(run([0, 5]), 20)
+    assert_eq(run([5, 5]), 30)
+
+    # Ensure that depth > chunk size results in error
+    with pytest.raises(ValueError):
+        run([0, 6])
+
+
 def test_map_overlap_multiarray_uneven_numblocks_exception():
     x = da.arange(10, chunks=(10,))
     y = da.arange(10, chunks=(5, 5))

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -391,10 +391,10 @@ def test_map_overlap_multiarray_block_broadcast():
     x = da.ones((12,), chunks=12)  # numblocks = (1,) -> (2, 2) after broadcast
     y = da.ones((16, 12), chunks=(8, 6))  # numblocks = (2, 2)
     z = da.map_overlap(func, x, y, chunks=(3, 3), depth=1, trim=True)
-    assert_eq(z.compute().shape, z.shape)
-    assert_eq(z.shape, (2, 2))
+    assert_eq(z, z)
+    assert z.shape ==, (2, 2)
     # func call will receive (8,) and (10, 8) arrays for each of 4 blocks
-    assert_eq(z.sum().compute(), 4 * (10 * 8 + 8))
+    assert_eq(z.sum(), 4 * (10 * 8 + 8))
 
 
 def test_map_overlap_multiarray_variadic():

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -322,9 +322,122 @@ def test_map_overlap():
 )
 def test_map_overlap_no_depth(boundary):
     x = da.arange(10, chunks=5)
-
     y = x.map_overlap(lambda i: i, depth=0, boundary=boundary, dtype=x.dtype)
     assert_eq(y, x)
+
+
+def test_map_overlap_multiarray():
+    # Same ndim, same numblocks, same chunks
+    x = da.arange(10, chunks=5)
+    y = da.arange(10, chunks=5)
+    z = da.map_overlap(lambda x, y: x + y, x, y, depth=1)
+    assert_eq(z, 2 * np.arange(10))
+
+    # Same ndim, same numblocks, different chunks
+    x = da.arange(10, chunks=(2, 3, 5))
+    y = da.arange(10, chunks=(5, 3, 2))
+    z = da.map_overlap(lambda x, y: x + y, x, y, depth=1)
+    assert z.chunks == ((2, 3, 3, 2),)
+    assert_eq(z, 2 * np.arange(10))
+
+    # Same ndim, different numblocks, different chunks
+    x = da.arange(10, chunks=(10,))
+    y = da.arange(10, chunks=(4, 4, 2))
+    z = da.map_overlap(lambda x, y: x + y, x, y, depth=1)
+    assert z.chunks == ((4, 4, 2),)
+    assert_eq(z, 2 * np.arange(10))
+
+    # Different ndim, different numblocks, different chunks
+    x = da.arange(10, chunks=(10,))
+    y = da.arange(10).reshape(1, 10).rechunk((1, (4, 4, 2)))
+    z = da.map_overlap(lambda x, y: x + y, x, y, depth=1)
+    assert z.chunks == ((1,), (4, 4, 2))
+    assert z.shape == (1, 10)
+    assert_eq(z, 2 * np.arange(10)[np.newaxis])
+
+    # Note: checks on arange equality in all of the above help ensure that
+    # trimming is applied appropriately to result chunks (i.e. results
+    # are not somehow shifted)
+
+
+def test_map_overlap_multiarray_defaults():
+    # Check that by default, chunk alignment and arrays of varying dimensionality
+    # are supported by with no effect on result shape
+    # (i.e. defaults are pass-through to map_blocks)
+    x = da.ones((10,), chunks=10)
+    y = da.ones((1, 10), chunks=5)
+    z = da.map_overlap(lambda x, y: x + y, x, y)
+    # func should be called twice and get (5,) and (1, 5) arrays of ones each time
+    assert_eq(z.shape, (1, 10))
+    assert_eq(z.sum(), 20)
+
+
+def test_map_overlap_multiarray_uneven_numblocks_exception():
+    x = da.arange(10, chunks=(10,))
+    y = da.arange(10, chunks=(5, 5))
+    with pytest.raises(ValueError):
+        # Fail with chunk alignment explicitly disabled
+        da.map_overlap(lambda x, y: x + y, x, y, align_arrays=False).compute()
+
+
+def test_map_overlap_multiarray_block_broadcast():
+    def func(x, y):
+        # Return result with expected padding
+        z = x.size + y.size
+        return np.ones((3, 3)) * z
+
+    # Chunks in trailing dimension will be unified to two chunks of size 6
+    # and block broadcast will allow chunks from x to repeat
+    x = da.ones((12,), chunks=12)  # numblocks = (1,) -> (2, 2) after broadcast
+    y = da.ones((16, 12), chunks=(8, 6))  # numblocks = (2, 2)
+    z = da.map_overlap(func, x, y, chunks=(3, 3), depth=1, trim=True)
+    assert_eq(z.compute().shape, z.shape)
+    assert_eq(z.shape, (2, 2))
+    # func call will receive (8,) and (10, 8) arrays for each of 4 blocks
+    assert_eq(z.sum().compute(), 4 * (10 * 8 + 8))
+
+
+def test_map_overlap_multiarray_variadic():
+    # Test overlapping row slices from 3D arrays
+    xs = [
+        # Dim 0 will unify to chunks of size 4 for all:
+        da.ones((12, 1, 1), chunks=((12,), 1, 1)),
+        da.ones((12, 8, 1), chunks=((8, 4), 8, 1)),
+        da.ones((12, 8, 4), chunks=((4, 8), 8, 4)),
+    ]
+
+    def func(*args):
+        return np.array([sum([x.size for x in args])])
+
+    x = da.map_overlap(func, *xs, chunks=(1,), depth=1, trim=False, drop_axis=[1, 2])
+
+    # Each func call should get 4 rows from each array padded by 1 in each dimension
+    size_per_slice = sum([np.pad(x[:4], 1, mode="constant").size for x in xs])
+    assert x.shape == (3,)
+    assert all(x.compute() == size_per_slice)
+
+
+def test_map_overlap_deprecated_signature():
+    def func(x):
+        return np.array(x.sum())
+
+    x = da.ones(3)
+
+    # Old positional signature: func, depth, boundary, trim
+    with pytest.warns(FutureWarning):
+        y = da.map_overlap(x, func, 0, "reflect", True)
+        assert y.compute() == 3
+        assert y.shape == (3,)
+
+    with pytest.warns(FutureWarning):
+        y = da.map_overlap(x, func, 1, "reflect", True)
+        assert y.compute() == 5
+        assert y.shape == (3,)
+
+    with pytest.warns(FutureWarning):
+        y = da.map_overlap(x, func, 1, "reflect", False)
+        assert y.compute() == 5
+        assert y.shape == (5,)
 
 
 def test_nearest_overlap():

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -392,7 +392,7 @@ def test_map_overlap_multiarray_block_broadcast():
     y = da.ones((16, 12), chunks=(8, 6))  # numblocks = (2, 2)
     z = da.map_overlap(func, x, y, chunks=(3, 3), depth=1, trim=True)
     assert_eq(z, z)
-    assert z.shape ==, (2, 2)
+    assert z.shape == (2, 2)
     # func call will receive (8,) and (10, 8) arrays for each of 4 blocks
     assert_eq(z.sum(), 4 * (10 * 8 + 8))
 


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`

This is an attempt to address https://github.com/dask/dask/issues/2403.

A summary of the changes here:

- The signature of `map_overlap` was changed to `map_overlap(func, *args, depth=None, ...)` to better match `map_blocks(func, *args, ...)`
  - My changes include detecting use of the old signature, throwing a warning, and converting the arguments where necessary (per @mrocklin's suggestion)
  - `da.overlap.map_overlap` was only called previously from `Array.map_overlap` (so it was easy to switch to the new signature), but this check should avoid issues for any users calling the module method directly
- All arrays can be of differing ranks but they must broadcast (i.e. they cannot have different sizes in any one dimension, if not unit size).  The broadcasting is not actually performed to avoid copying small arrays to match the size of larger ones.  Users could easily perform this broadcasting first though if that's the behavior they want.
- Chunk sizes can be different and are aligned where necessary by default, but users can opt out of this behavior using `align_arrays=False` (much like in `blockwise`).  I think this is an important flag because at least personally, I wouldn't want the automatic alignment creating non-uniformly sized chunks or very small chunks in large datasets where the block sizes were chosen carefully.
- Depth now has a default of 0 rather than being a required positional argument like before.  This means that given nothing other than a function and some arrays, `map_overlap` is a pass-through to `map_blocks`.
- `boundary` and `depth` arguments are interpreted as a sequence of arguments corresponding to each array if given as `list` type.
- The final trim step is done using `depth` and `boundary` for the array of largest rank since this seemed to be the most intuitive behavior, and is reverse compatible. 

I didn't add any examples to the docs yet, but I wanted to submit this for a preliminary look first before trying to put those finishing touches on it.  Let me know if there are any major issues here.
