### PR TITLE
add agg function

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3695,26 +3695,49 @@ def test_dataframe_mode():
 
 
 def test_agg():
-    data = {'col0': [1.1, 2, 3], 'col1': ['a', 'b', 'c']}
-    s = pd.Series(data['col1'])
+    data = {"col0": [1.1, 2, 3], "col1": ["a", "b", "c"]}
+    s = pd.Series(data["col1"])
     ds = dd.from_pandas(s, npartitions=2)
-    ds.name = 'my_series'
+    ds.name = "my_series"
     df = pd.DataFrame(data)
     ddf = dd.from_pandas(df, npartitions=1)
 
     with pytest.raises(ValueError):
-        ds.agg(['mode'])
+        ds.agg(["mode"])
 
     # series tests
-    assert_eq(s.agg('min'), ds.agg('min'))
-    assert_eq(s.agg(['min']), ds.agg(['min']))
-    supported_funcs = ['sum', 'min', 'max', 'count', 'prod', 'var', 'std', 'mean'] # 'any' also works in dask, but yields a different result in pandas
-    assert_eq(s.agg(supported_funcs), ds.agg(supported_funcs), check_dtypes=False, check_dtype=False)
+    assert_eq(s.agg("min"), ds.agg("min"))
+    assert_eq(s.agg(["min"]), ds.agg(["min"]))
+    supported_funcs = [
+        "sum",
+        "min",
+        "max",
+        "count",
+        "prod",
+        "var",
+        "std",
+        "mean",
+    ]  # 'any' also works in dask, but yields a different result in pandas
+    assert_eq(
+        s.agg(supported_funcs),
+        ds.agg(supported_funcs),
+        check_dtypes=False,
+        check_dtype=False,
+    )
 
     # dataframe tests
-    assert_eq(df.agg('min'), ddf.agg('min'))
-    assert_eq(df.agg(['min']), ddf.agg(['min']))
-    supported_funcs = ['sum', 'prod', 'min', 'max', 'count', 'var', 'std', 'mean']  # 'any' also works in dask, but yields a different result in pandas
+    assert_eq(df.agg("min"), ddf.agg("min"))
+    assert_eq(df.agg(["min"]), ddf.agg(["min"]))
+    supported_funcs = [
+        "sum",
+        "prod",
+        "min",
+        "max",
+        "count",
+        "var",
+        "std",
+        "mean",
+    ]  # 'any' also works in dask, but yields a different result in pandas
     assert_eq(df.agg(supported_funcs), ddf.agg(supported_funcs))
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3694,6 +3694,30 @@ def test_dataframe_mode():
     assert_eq(ddf.mode(), df.mode(), check_index=False)
 
 
+def test_agg():
+    data = {'col0': [1.1, 2, 3], 'col1': ['a', 'b', 'c']}
+    s = pd.Series(data['col1'])
+    ds = dd.from_pandas(s, npartitions=2)
+    ds.name = 'my_series'
+    df = pd.DataFrame(data)
+    ddf = dd.from_pandas(df, npartitions=1)
+
+    with pytest.raises(ValueError):
+        ds.agg(['mode'])
+
+    # series tests
+    assert_eq(s.agg('min'), ds.agg('min'))
+    assert_eq(s.agg(['min']), ds.agg(['min']))
+    supported_funcs = ['sum', 'min', 'max', 'count', 'prod', 'var', 'std', 'mean'] # 'any' also works in dask, but yields a different result in pandas
+    assert_eq(s.agg(supported_funcs), ds.agg(supported_funcs), check_dtypes=False, check_dtype=False)
+
+    # dataframe tests
+    assert_eq(df.agg('min'), ddf.agg('min'))
+    assert_eq(df.agg(['min']), ddf.agg(['min']))
+    supported_funcs = ['sum', 'prod', 'min', 'max', 'count', 'var', 'std', 'mean']  # 'any' also works in dask, but yields a different result in pandas
+    assert_eq(df.agg(supported_funcs), ddf.agg(supported_funcs))
+
+
 def test_datetime_loc_open_slicing():
     dtRange = pd.date_range("01.01.2015", "05.05.2015")
     df = pd.DataFrame(np.random.random((len(dtRange), 2)), index=dtRange)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Adds the `agg` function as mentioned https://github.com/dask/dask/issues/3527

A few notes:
- It doesn't support passing args or kwargs being passed in to be passed to the aggregating functions.
- It doesn't support passing in aggregating functions, only strings  (e.g. 'min' allowed, dd.DataFrame.min not allowed)
- I wanted to support 'size' as one of the aggregations allowed, but dd.DataFrame produces a dask.dataframe.Scalar object, and I'm unsure how to convert that to a dask Series or dask DataFrame.
- I could put the concatenate bit at the end of DataFrame.agg into it's own function somewhere since it's now used by DataFrame.mode and DataFrame.agg
- I don't compare the result of agg('any') with the pandas result.  This is because I would expect Series.agg('any') to return True or False, while in pandas it returns a value from the series when the dtype='object'. See example below.
```python3
import pandas as pd
s = pd.Series(['a', 'b', 'c'])
assert s.agg(['any']).equals(pd.Series(['a'], index=['any']))  # no error thrown
``` 