### PR TITLE
POC: dask.dataframe reader using the Arrow Datasets API

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -43,6 +43,10 @@ try:
     except ImportError:
         pass
     try:
+        from .io import read_arrow_dataset
+    except ImportError:
+        pass
+    try:
         from .core import isna
     except ImportError:
         pass

--- a/dask/dataframe/io/__init__.py
+++ b/dask/dataframe/io/__init__.py
@@ -20,3 +20,8 @@ try:
     from .parquet import read_parquet, to_parquet
 except ImportError:
     pass
+
+try:
+    from .arrow import read_arrow_dataset
+except ImportError:
+    pass

--- a/dask/dataframe/io/arrow.py
+++ b/dask/dataframe/io/arrow.py
@@ -1,0 +1,126 @@
+"""Arrow Dataset reader"""
+
+from collections.abc import Mapping
+
+import pyarrow.dataset as ds
+
+from ...base import tokenize
+from ..core import DataFrame, new_dd_object
+
+
+class ArrowDatasetSubgraph(Mapping):
+    """
+    Subgraph for reading Arrow Datasets.
+
+    Enables optimiziations (see optimize_read_arrow_dataset).
+    """
+
+    def __init__(self, name, parts, fs, schema, partitioning, format, columns, filter, meta):
+        self.name = name
+        self.parts = parts
+        self.fs = fs
+        self.schema = schema
+        self.partitioning = partitioning
+        self.format = format
+        self.columns = columns
+        self.filter = filter
+        self.meta = meta
+
+    def __repr__(self):
+        return "ArrowDatasetSubgraph<name='{}', n_parts={}>".format(
+            self.name, len(self.parts)
+        )
+
+    def __getitem__(self, key):
+        try:
+            name, i = key
+        except ValueError:
+            # too many / few values to unpack
+            raise KeyError(key) from None
+
+        if name != self.name:
+            raise KeyError(key)
+
+        if i < 0 or i >= len(self.parts):
+            raise KeyError(key)
+
+        part = self.parts[i]
+
+        return (
+            read_arrow_dataset_part, 
+            part,
+            self.fs,
+            self.schema, 
+            self.partitioning, 
+            self.format, 
+            self.columns, 
+            self.filter,
+        )
+
+    def __len__(self):
+        return len(self.parts)
+
+    def __iter__(self):
+        for i in range(len(self)):
+            yield (self.name, i)
+
+
+def get_paths_and_expressions(path, partitioning):
+    """
+    Split path and infer expressions. Assumes that path is a single file path.
+
+    Returns list of paths and expressions, as expected by FilesystemSource.
+    """
+    paths = []
+    exprs = []
+
+    for i in range(len(path.split("/")) - 1, 0, -1):
+
+        path_dir = path.rsplit("/", maxsplit=i)[0]
+        path_dir_last = path_dir.split("/")[-1]
+        expr_dir = partitioning.parse(path_dir_last)
+
+        paths.append(path_dir)
+        exprs.append(expr_dir)
+
+    paths.append(path)
+    exprs.append(ds.scalar(True))
+    return paths, exprs
+
+
+def read_arrow_dataset_part(
+        path, fs, schema, partitioning, format, columns, filter
+):
+    if fs is None:
+        from pyarrow.fs import LocalFileSystem
+        fs = LocalFileSystem()
+    paths, exprs = get_paths_and_expressions(path, partitioning)
+    source = ds.FileSystemSource(schema, None, format, fs, paths, exprs)
+    dataset = ds.Dataset([source], schema)
+    table = dataset.to_table(columns=columns, filter=filter, use_threads=False)
+    return table.to_pandas()
+
+
+def read_arrow_dataset(path, partitioning, columns=None, filter=None):
+
+    dataset = ds.dataset(path, partitioning=partitioning)
+    source = dataset.sources[0]
+    schema = dataset.schema
+    files = source.files
+    format = ds.ParquetFileFormat()
+
+    # meta = next(dataset.to_batches()).to_pandas()
+    meta = schema.empty_table().to_pandas()
+    if columns is not None:
+        meta = meta[columns]
+    name = "read-arrow-dataset-" + tokenize(path, partitioning, columns, filter)
+
+    # tasks = [(read_arrow_dataset_part, f, None, schema, partitioning, format, columns, filter) for f in files]
+    # dsk = {(name, i): tasks[i] for i in range(len(tasks))}
+    # return DataFrame(dsk, name, meta, tuple([None]*(len(dsk) + 1)))
+
+    subgraph = ArrowDatasetSubgraph(
+        name, files, None, schema, partitioning, format, columns, filter, meta,
+    )
+
+    return new_dd_object(subgraph, name, meta, tuple([None]*(len(files) + 1)))

--- a/dask/dataframe/io/arrow.py
+++ b/dask/dataframe/io/arrow.py
@@ -101,13 +101,12 @@ def read_arrow_dataset_part(
     return table.to_pandas()
 
 
-def read_arrow_dataset(path, partitioning, columns=None, filter=None):
+def read_arrow_dataset(path, partitioning, columns=None, filter=None, filesystem=None, format="parquet"):
 
-    dataset = ds.dataset(path, partitioning=partitioning)
+    dataset = ds.dataset(path, partitioning=partitioning, filesystem=filesystem, format=format)
     source = dataset.sources[0]
     schema = dataset.schema
     files = source.files
-    format = ds.ParquetFileFormat()
 
     # meta = next(dataset.to_batches()).to_pandas()
     meta = schema.empty_table().to_pandas()
@@ -120,7 +119,7 @@ def read_arrow_dataset(path, partitioning, columns=None, filter=None):
     # return DataFrame(dsk, name, meta, tuple([None]*(len(dsk) + 1)))
 
     subgraph = ArrowDatasetSubgraph(
-        name, files, None, schema, partitioning, format, columns, filter, meta,
+        name, files, filesystem, schema, partitioning, format, columns, filter, meta,
     )
 
     return new_dd_object(subgraph, name, meta, tuple([None]*(len(files) + 1)))

--- a/dask/dataframe/io/parquet/arrow_dataset.py
+++ b/dask/dataframe/io/parquet/arrow_dataset.py
@@ -1,0 +1,199 @@
+"""Arrow Dataset reader"""
+
+from collections.abc import Mapping
+
+from ...methods import concat
+from ...utils import clear_known_categories
+from ....utils import natural_sort_key
+
+from .arrow import ArrowEngine, _get_meta_from_schema
+
+
+class ArrowDatasetSubgraph(Mapping):
+    """
+    Subgraph for reading Arrow Datasets.
+
+    Enables optimiziations (see optimize_read_arrow_dataset).
+    """
+
+    def __init__(
+        self, name, engine, meta, parts, schema, columns, filter, index, kwargs
+    ):
+        self.name = name
+        self.engine = engine
+        self.meta = meta
+        self.parts = parts
+        self.schema = schema
+        self.columns = columns
+        self.filter = filter
+        self.index = index
+        self.kwargs = kwargs
+
+    def __repr__(self):
+        return "ArrowDatasetSubgraph<name='{}', n_parts={}>".format(
+            self.name, len(self.parts)
+        )
+
+    def __getitem__(self, key):
+        try:
+            name, i = key
+        except ValueError:
+            # too many / few values to unpack
+            raise KeyError(key) from None
+
+        if name != self.name:
+            raise KeyError(key)
+
+        if i < 0 or i >= len(self.parts):
+            raise KeyError(key)
+
+        part = self.parts[i]
+        # TODO check kwargs
+        # kwargs = self.kwargs[i]
+
+        return (
+            read_parquet_part,
+            self.engine.read_partition,
+            self.meta,
+            part,
+            self.schema,
+            self.columns,
+            self.filter,
+            self.index,
+            self.kwargs,
+        )
+
+    def __len__(self):
+        return len(self.parts)
+
+    def __iter__(self):
+        for i in range(len(self)):
+            yield (self.name, i)
+
+
+class ArrowDatasetEngine(ArrowEngine):
+    # sublass ArrowEngine to inherit the writing functionality
+
+    @staticmethod
+    def read_metadata(
+        fs,
+        paths,
+        categories=None,
+        index=None,
+        gather_statistics=None,
+        filters=None,
+        split_row_groups=True,
+        **kwargs,
+    ):
+        import pyarrow.dataset as ds
+        from pyarrow.fs import LocalFileSystem
+        from pyarrow.parquet import _filters_to_expression
+
+        # dataset discovery
+        # TODO support filesystems
+        if len(paths) == 1:
+            # list of 1 directory path is not supported
+            paths = paths[0]
+        dataset = ds.dataset(
+            paths, partitioning="hive", filesystem=None, format="parquet"
+        )
+
+        # get all (filtered) fragments
+        if filters is not None:
+            filter = _filters_to_expression(filters)
+        else:
+            filter = None
+
+        fragments = list(dataset.get_fragments(filter=filter))
+
+        # numeric rather than glob ordering
+        # TODO how does this handle different partitioned directories?
+        fragments = sorted(fragments, key=lambda f: natural_sort_key(f.path))
+
+        if split_row_groups:
+            fragments = [
+                f_rg for f in fragments for f_rg in f.get_row_group_fragments(filter)
+            ]
+
+        # create dask object
+        schema = dataset.schema
+        # meta = schema.empty_table().to_pandas()
+        # breakpoint()
+        meta, categories = _get_meta_from_schema(
+            schema, index, categories, [], check_partitions=False
+        )
+
+        kwargs = {"categories": categories}
+        return meta, fragments, schema, filter, kwargs
+
+    @staticmethod
+    def read_partition(
+        fragment, schema, columns, filter, index, categories=None, **kwargs
+    ):
+        if isinstance(index, list):
+            for level in index:
+                # unclear if we can use set ops here. I think the order matters.
+                # Need the membership test to avoid duplicating index when
+                # we slice with `columns` later on.
+                if level not in columns:
+                    columns.append(level)
+
+        # works with pyarrow master, not with released pyarrow 0.17
+        df = fragment.to_table(
+            use_threads=False, schema=schema, columns=columns, filter=filter
+        ).to_pandas(categories=categories)
+
+        # Note that `to_pandas(ignore_metadata=False)` means
+        # pyarrow will use the pandas metadata to set the index.
+
+        # TODO below is copied from existing ArrowEngine method -> could be
+        # split out in a helper function
+        columns_and_parts = columns
+        index_in_columns_and_parts = set(df.index.names).issubset(
+            set(columns_and_parts)
+        )
+        if not index:
+            if index_in_columns_and_parts:
+                # User does not want to set index and a desired
+                # column/partition has been set to the index
+                df.reset_index(drop=False, inplace=True)
+            else:
+                # User does not want to set index and an
+                # "unwanted" column has been set to the index
+                df.reset_index(drop=True, inplace=True)
+        else:
+            if set(df.index.names) != set(index) and index_in_columns_and_parts:
+                # The wrong index has been set and it contains
+                # one or more desired columns/partitions
+                df.reset_index(drop=False, inplace=True)
+            elif index_in_columns_and_parts:
+                # The correct index has already been set
+                index = False
+                columns_and_parts = list(
+                    set(columns_and_parts).difference(set(df.index.names))
+                )
+        df = df[list(columns_and_parts)]
+
+        if index:
+            df = df.set_index(index)
+        return df
+
+
+def read_parquet_part(func, meta, part, schema, columns, filter, index, kwargs):
+    """ Read a part of a parquet dataset
+
+    This function is used by `read_parquet`."""
+    if isinstance(part, list):
+        dfs = [func(fr, schema, columns.copy(), filter, index, **kwargs) for fr in part]
+        df = concat(dfs, axis=0)
+    else:
+        df = func(part, schema, columns.copy(), filter, index, **kwargs)
+
+    if meta.columns.name:
+        df.columns.name = meta.columns.name
+
+    # TODO is this needed?
+    # columns = columns or []
+    # index = index or []
+    # return df[[c for c in columns if c not in index]]
+    return df

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -127,7 +127,7 @@ def optimize_read_parquet_getitem(dsk, keys):
 # this is just a copy paste of optimize_read_parquet_getitem for now
 def optimize_read_arrow_dataset(dsk, keys):
     # find the keys to optimize
-    from .io.arrow import ArrowDatasetSubgraph
+    from .io.parquet.arrow_dataset import ArrowDatasetSubgraph
 
     read_arrows = [
         k for k, v in dsk.layers.items() if isinstance(v, ArrowDatasetSubgraph)
@@ -206,14 +206,14 @@ def optimize_read_arrow_dataset(dsk, keys):
 
         new = ArrowDatasetSubgraph(
             name,
+            old.engine,
+            meta,
             old.parts,
-            old.fs,
             old.schema,
-            old.format,
             columns,
             old.filter,
+            old.index,
             old.kwargs,
-            meta,
         )
         layers[name] = new
         if name != old.name:

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -129,7 +129,9 @@ def optimize_read_arrow_dataset(dsk, keys):
     # find the keys to optimize
     from .io.arrow import ArrowDatasetSubgraph
 
-    read_arrows = [k for k, v in dsk.layers.items() if isinstance(v, ArrowDatasetSubgraph)]
+    read_arrows = [
+        k for k, v in dsk.layers.items() if isinstance(v, ArrowDatasetSubgraph)
+    ]
 
     layers = dsk.layers.copy()
     dependencies = dsk.dependencies.copy()
@@ -153,7 +155,7 @@ def optimize_read_arrow_dataset(dsk, keys):
             if list(block.dsk.values())[0][0] != operator.getitem:
                 # ... where this value is __getitem__...
                 return dsk
-            
+
             if any(block.output == x[0] for x in keys if isinstance(x, tuple)):
                 # if any(block.output == x[0] for x in keys if isinstance(x, tuple)):
                 # ... but bail on the optimization if the getitem is what's requested
@@ -203,7 +205,15 @@ def optimize_read_arrow_dataset(dsk, keys):
             columns = list(meta.columns)
 
         new = ArrowDatasetSubgraph(
-            name, old.parts, old.fs, old.schema, old.format, columns, old.filter, meta
+            name,
+            old.parts,
+            old.fs,
+            old.schema,
+            old.format,
+            columns,
+            old.filter,
+            old.kwargs,
+            meta,
         )
         layers[name] = new
         if name != old.name:

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -203,7 +203,7 @@ def optimize_read_arrow_dataset(dsk, keys):
             columns = list(meta.columns)
 
         new = ArrowDatasetSubgraph(
-            name, old.parts, old.fs, old.schema, old.partitioning, old.format, columns, old.filter, meta
+            name, old.parts, old.fs, old.schema, old.format, columns, old.filter, meta
         )
         layers[name] = new
         if name != old.name:

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -15,6 +15,7 @@ def optimize(dsk, keys, **kwargs):
         # Think about an API for this.
         flat_keys = list(core.flatten(keys))
         dsk = optimize_read_parquet_getitem(dsk, keys=flat_keys)
+        dsk = optimize_read_arrow_dataset(dsk, keys=flat_keys)
         dsk = optimize_blockwise(dsk, keys=flat_keys)
         dsk = fuse_roots(dsk, keys=flat_keys)
 
@@ -114,6 +115,95 @@ def optimize_read_parquet_getitem(dsk, keys):
 
         new = ParquetSubgraph(
             name, old.engine, old.fs, meta, columns, old.index, old.parts, old.kwargs
+        )
+        layers[name] = new
+        if name != old.name:
+            del layers[old.name]
+
+    new_hlg = HighLevelGraph(layers, dependencies)
+    return new_hlg
+
+
+# this is just a copy paste of optimize_read_parquet_getitem for now
+def optimize_read_arrow_dataset(dsk, keys):
+    # find the keys to optimize
+    from .io.arrow import ArrowDatasetSubgraph
+
+    read_arrows = [k for k, v in dsk.layers.items() if isinstance(v, ArrowDatasetSubgraph)]
+
+    layers = dsk.layers.copy()
+    dependencies = dsk.dependencies.copy()
+
+    for k in read_arrows:
+        columns = set()
+        update_blocks = {}
+
+        for dep in dsk.dependents[k]:
+            block = dsk.layers[dep]
+
+            # Check if we're a read_parquet followed by a getitem
+            if not isinstance(block, Blockwise):
+                # getitem are Blockwise...
+                return dsk
+
+            if len(block.dsk) != 1:
+                # ... with a single item...
+                return dsk
+
+            if list(block.dsk.values())[0][0] != operator.getitem:
+                # ... where this value is __getitem__...
+                return dsk
+            
+            if any(block.output == x[0] for x in keys if isinstance(x, tuple)):
+                # if any(block.output == x[0] for x in keys if isinstance(x, tuple)):
+                # ... but bail on the optimization if the getitem is what's requested
+                # These keys are structured like [('getitem-<token>', 0), ...]
+                # so we check for the first item of the tuple.
+                # See https://github.com/dask/dask/issues/5893
+                return dsk
+
+            block_columns = block.indices[1][0]
+            if isinstance(block_columns, str):
+                block_columns = [block_columns]
+
+            columns |= set(block_columns)
+            update_blocks[dep] = block
+
+        old = layers[k]
+
+        if columns and columns < set(old.meta.columns):
+            columns = list(columns)
+            meta = old.meta[columns]
+            name = "read-arrow-dataset-" + tokenize(old.name, columns)
+            assert len(update_blocks)
+
+            for block_key, block in update_blocks.items():
+                # (('read-parquet-old', (.,)), ( ... )) ->
+                # (('read-parquet-new', (.,)), ( ... ))
+                new_indices = ((name, block.indices[0][1]), block.indices[1])
+                numblocks = {name: block.numblocks[old.name]}
+                new_block = Blockwise(
+                    block.output,
+                    block.output_indices,
+                    block.dsk,
+                    new_indices,
+                    numblocks,
+                    block.concatenate,
+                    block.new_axes,
+                )
+                layers[block_key] = new_block
+                dependencies[block_key] = {name}
+            dependencies[name] = dependencies.pop(k)
+
+        else:
+            # Things like df[df.A == 'a'], where the argument to
+            # getitem is not a column name
+            name = old.name
+            meta = old.meta
+            columns = list(meta.columns)
+
+        new = ArrowDatasetSubgraph(
+            name, old.parts, old.fs, old.schema, old.partitioning, old.format, columns, old.filter, meta
         )
         layers[name] = new
         if name != old.name:

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -662,6 +662,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
             asciitable(["", "dtype"], [("Found", x.dtype), ("Expected", meta.dtype)]),
         )
 
+    breakpoint()
     raise ValueError(
         "Metadata mismatch found%s.\n\n"
         "%s" % ((" in `%s`" % funcname if funcname else ""), errmsg)


### PR DESCRIPTION
This is a proof of concept of a `dask.dataframe` reader using the [Arrow Datasets API](https://arrow.apache.org/docs/python/dataset.html). This is (at the moment) not meant to get merged, but serves as illustration for the issue I opened about this topic: https://github.com/dask/dask/issues/6174

This is also not a "clean" implementation, since some parts are basically copy pasted from the current parquet implementation (the Subgraph and the optimize function, for a proper PR we should look into sharing more code between those), the unique parts here are basically the `read_arrow_dataset` and `read_arrow_dataset_part` functions.