### PR TITLE
[Prototype] Task Generator for Shuffle

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -506,12 +506,12 @@ class All2All:
                 deps[out_key] = keys
                 tasks[out_key] = (_concat, keys)
 
-            for i, inp in enumerate(self.inputs):
-                out_key = str(("shuffle-" + self.token, i))
-                in_key = str(("shuffle-join-" + self.token, self.stages, inp))
-                deps[out_key] = (in_key,)
-                tasks[out_key] = in_key
-                self.output_keys.append(out_key)
+        for i, inp in enumerate(self.inputs):
+            out_key = str(("shuffle-" + self.token, i))
+            in_key = str(("shuffle-join-" + self.token, self.stages, inp))
+            deps[out_key] = (in_key,)
+            tasks[out_key] = in_key
+            self.output_keys.append(out_key)
         print("stages: ", self.stages)
         return tasks, deps, priorities
 


### PR DESCRIPTION
_Warning, this is a prototype and very hacky!_

This PR, together with https://github.com/dask/distributed/pull/3765, address the scheduler overhead #6163 by replacing `rearrange_by_column_tasks()` with a task generator.

Instead of creating `n**2` tasks or `n log n` tasks when staging on the client upfront, this PR makes it possible to delay tasks creations until later.

To enable the task generator set `USE_TASK_GENERATOR=1`

#### Preliminary Results

Shuffle with 536554 tasks (no staging) now takes ~6 seconds instead of ~60 seconds on my machine.
```python 

from distributed import Client, LocalCluster
from dask.datasets import timeseries
from dask.dataframe.shuffle import shuffle
from dask.distributed import wait
import time

if __name__ == "__main__":
    cluster = LocalCluster(nthreads=1)
    client = Client(cluster)

    ddf_d = timeseries(start='2000-01-01', end='2002-01-01', partition_freq='1d')
    ddf_d_2 = shuffle(ddf_d, "id", shuffle="tasks", max_branch=10**8)  # disable staging

    t1 = time.time()
    ddf_d_2 = ddf_d_2.persist(optimize_graph=False)
    t2 = time.time()
    print("persist returned: ", t2-t1)
    wait(ddf_d_2)
    t3 = time.time()
    print("wait returned: ", t3-t2)
    client.close()
```




