### PR TITLE
Fix array general-reduction name

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -153,7 +153,7 @@ def reduction(
     inds = tuple(range(x.ndim))
     # The dtype of `tmp` doesn't actually matter, and may be incorrect.
     tmp = blockwise(
-        chunk, inds, x, inds, axis=axis, keepdims=True, dtype=dtype or float
+        chunk, inds, x, inds, axis=axis, keepdims=True, token=name, dtype=dtype or float
     )
     tmp._chunks = tuple(
         (output_size,) * len(c) if i in axis else c for i, c in enumerate(tmp.chunks)

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -1,3 +1,4 @@
+from itertools import zip_longest
 import os
 import warnings
 
@@ -511,6 +512,16 @@ def test_reduction_names():
     assert x.all().name.startswith("all")
     assert any(k[0].startswith("nansum") for k in da.nansum(x).dask)
     assert x.mean().name.startswith("mean")
+
+
+def test_general_reduction_names():
+    dtype = np.int
+    a = da.reduction(
+        da.ones(10, dtype, chunks=2), np.sum, np.sum, dtype=dtype, name="foo"
+    )
+    names, tokens = list(zip_longest(*[key[0].rsplit("-", 1) for key in a.dask]))
+    assert set(names) == {"ones", "foo", "foo-partial", "foo-aggregate"}
+    assert all(tokens)
 
 
 @pytest.mark.filterwarnings("ignore:`argmax` is not implemented by dask")


### PR DESCRIPTION
Fixes #6170.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
