### PR TITLE
Ensure sizeof dict and sequences returns an integer

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -29,9 +29,10 @@ def sizeof_python_collection(seq):
     num_items = len(seq)
     samples = 10
     if num_items > samples:
-        return getsizeof(seq) + num_items / samples * sum(
+        s = getsizeof(seq) + num_items / samples * sum(
             map(sizeof, random.sample(seq, samples))
         )
+        return int(s)
     else:
         return getsizeof(seq) + sum(map(sizeof, seq))
 

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -130,4 +130,6 @@ def test_dict():
     assert sizeof({"x": [x]}) > x.nbytes
     assert sizeof({"x": [{"y": x}]}) > x.nbytes
 
-    assert sizeof({i: x for i in range(100)}) > x.nbytes * 100
+    d = {i: x for i in range(100)}
+    assert sizeof(d) > x.nbytes * 100
+    assert isinstance(sizeof(d), int)


### PR DESCRIPTION
In https://github.com/dask/dask/pull/6154 we updated our `sizeof` estimate for large dictionaries and sequences. This PR ensures that we return an integer `sizeof` for these objects. 

cc @pentschev I think this should resolve the issue you were seeing over in https://github.com/dask/distributed/issues/3771

Closes https://github.com/dask/distributed/issues/3771

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
