### PR TITLE
[REVIEW] HighLevelGraph: now returns iterators

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -143,6 +143,8 @@ class HighLevelGraph(Mapping):
 
         return cls(layers, deps)
 
+    # To conform with collections.abc.Mapping, we implement
+    # __getitem__, __len__, and __iter__.
     def __getitem__(self, key):
         for d in self.layers.values():
             if key in d:
@@ -152,24 +154,8 @@ class HighLevelGraph(Mapping):
     def __len__(self):
         return sum(1 for _ in self)
 
-    def items(self):
-        items = []
-        seen = set()
-        for d in self.layers.values():
-            for key in d:
-                if key not in seen:
-                    seen.add(key)
-                    items.append((key, d[key]))
-        return items
-
     def __iter__(self):
         return toolz.unique(toolz.concat(self.layers.values()))
-
-    def keys(self):
-        return [key for key, _ in self.items()]
-
-    def values(self):
-        return [value for _, value in self.items()]
 
     @classmethod
     def merge(cls, *graphs):

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -35,8 +35,7 @@ def test_keys_values_items_methods():
     d = b + c
     hg = d.dask
 
-    keys, values, items = hg.keys(), hg.values(), hg.items()
-    assert all(isinstance(i, list) for i in [keys, values, items])
+    keys, values, items = list(hg.keys()), list(hg.values()), list(hg.items())
     assert keys == [i for i in hg]
     assert values == [hg[i] for i in hg]
     assert items == [(k, v) for k, v in zip(keys, values)]


### PR DESCRIPTION
This PR makes `HighLevelGraph.items(), .keys(), .values()` return iterators, which speed up the calls and reduce memory use.

Notice, `dict` in python3 returns `dict_items, dict_keys, dict_values`, which support `len()` but apparently [it is not possible to create them at the Python level cleanly](https://stackoverflow.com/questions/35784289/where-can-i-find-the-dict-keys-class) thus I don't think it is worth the extra complexity to implement our own.


- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
