### PR TITLE
Avoid apply in _compute_sum_of_squares for groupby std agg

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -900,6 +900,7 @@ def _compute_sum_of_squares(grouped, column):
     if hasattr(grouped, "grouper"):
         keys = grouped.grouper
     else:
+        # Handle CuDF groupby object (different from pandas)
         keys = grouped.grouping._key_columns
     df = grouped.obj[column].pow(2) if column else grouped.obj.pow(2)
     return df.groupby(keys).sum()

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -901,7 +901,7 @@ def _compute_sum_of_squares(grouped, column):
         keys = grouped.grouper
     else:
         # Handle CuDF groupby object (different from pandas)
-        keys = grouped.grouping._key_columns
+        keys = grouped.grouping.keys
     df = grouped.obj[column].pow(2) if column else grouped.obj.pow(2)
     return df.groupby(keys).sum()
 


### PR DESCRIPTION
This PR addresses #6034 by avoiding the `apply` call in `_compute_sum_of_squares` for `std` groupby aggregations.

**Motivation**: The following does *not* currently work with `dask_cudf`, because the `dask.dataframe` implementation uses [groupby-apply](https://github.com/dask/dask/blob/2fae9e75a8ac03ea0c689d5d11755d98a370906e/dask/dataframe/groupby.py#L897-L899) (which does not exhibit "correct" behavior for all cases in cudf):

```python
import cudf, dask_cudf

df = cudf.DataFrame({'a': [1,1,2,2],'b': [4,5,6,10]})
ddf = dask_cudf.from_cudf(df, npartitions=2)
ddf.groupby('a').agg({'b':['mean','std']}).compute()
```

Note that this change also improves pandas-backed `dask.dataframe` performance:

```python
import cudf, dask_cudf
import dask.dataframe as dd
import pandas as pd
import numpy as np

size = 100_000_000
df = pd.DataFrame({'a': np.random.randint(10, size=size),'b': np.random.randint(10, size=size)})
ddf = dd.from_pandas(df, npartitions=2)

%timeit ddf.groupby('a').agg({'b':['mean','std']}).compute()
``` 

**Master**: `3.46 s ± 71.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`
**This PR**: `1.74 s ± 36.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
