### PR TITLE
TEST: Skip test_to_parquet_with_get if no parquet libs available.

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1738,6 +1738,8 @@ def test_writing_parquet_with_unknown_kwargs(tmpdir, engine):
 
 
 def test_to_parquet_with_get(tmpdir):
+    check_engine()
+
     from dask.multiprocessing import get as mp_get
 
     tmpdir = str(tmpdir)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Fixes https://github.com/dask/dask/issues/6187.