### PR TITLE
Minor correction to test_parquet

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -24,10 +24,8 @@ except ImportError:
 
 try:
     import pyarrow as pa
-
-    check_pa_divs = pa.__version__ >= LooseVersion("0.9.0")
 except ImportError:
-    check_pa_divs = False
+    pa = False
 
 
 try:
@@ -44,7 +42,7 @@ if pq and pa.__version__ < LooseVersion("0.13.1"):
     SKIP_PYARROW = True
     SKIP_PYARROW_REASON = "pyarrow >= 0.13.1 required for parquet"
 else:
-    if sys.platform == "win32" and pa.__version__ == LooseVersion("0.16.0"):
+    if sys.platform == "win32" and pa and pa.__version__ == LooseVersion("0.16.0"):
         SKIP_PYARROW = True
         SKIP_PYARROW_REASON = "https://github.com/dask/dask/issues/6093"
     else:

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -25,7 +25,7 @@ except ImportError:
 try:
     import pyarrow as pa
 except ImportError:
-    pa = False
+    check_pa_divs = pa = False
 
 
 try:


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Correct issue #6189.