### PR TITLE
[REVIEW] Fix meta data generation & error message in `str.split` when `expand=True`

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -123,10 +123,11 @@ class StringAccessor(Accessor):
             if n == -1:
                 raise NotImplementedError(
                     "To use the expand parameter you must specify the number of "
-                    "expected output columns with the n= parameter"
+                    "expected splits with the n= parameter. Usually n splits result in n+1 output columns."
                 )
             else:
-                meta = type(self._series._meta)([" ".join(["a"] * 2 * n)])
+                delimiter = " " if pat is None else pat
+                meta = type(self._series._meta)([delimiter.join(["a"] * (n + 1))])
                 meta = meta.str.split(n=n, expand=expand, pat=pat)
         else:
             meta = (self._series.name, object)

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -244,6 +244,15 @@ def test_str_accessor_expand():
 
     assert "n=" in str(info.value)
 
+    s = pd.Series(["a,bcd,zz,f", "aabb,ccdd,z,kk", "aaabbb,cccdddd,l,pp"])
+    ds = dd.from_pandas(s, npartitions=2)
+
+    for n in [1, 2, 3]:
+        assert_eq(
+            s.str.split(pat=",", n=n, expand=True),
+            ds.str.split(pat=",", n=n, expand=True),
+        )
+
 
 @pytest.mark.xfail(reason="Need to pad columns")
 def test_str_accessor_expand_more_columns():


### PR DESCRIPTION
Fixes: #6193
Fixes: #6191

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
