### PR TITLE
Support stack with unknwon chuncksizes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4216,12 +4216,23 @@ def transposelist(arrays, axes, extradims=0):
     return reshapelist(newshape, result)
 
 
-def stack(seq, axis=0):
+def stack(seq, axis=0, allow_unknown_chunksizes=False):
     """
     Stack arrays along a new axis
 
     Given a sequence of dask arrays, form a new dask array by stacking them
     along a new dimension (axis=0 by default)
+
+     Parameters
+    ----------
+    seq: list of dask.arrays
+    axis: int
+        Dimension along which to align all of the arrays
+    allow_unknown_chunksizes: bool
+        Allow unknown chunksizes, such as come from converting from dask
+        dataframes.  Dask.array is unable to verify that chunks line up.  If
+        data comes from differently aligned sources then this can cause
+        unexpected results.
 
     Examples
     --------
@@ -4256,7 +4267,7 @@ def stack(seq, axis=0):
 
     if not seq:
         raise ValueError("Need array(s) to stack")
-    if not all(x.shape == seq[0].shape for x in seq):
+    if not allow_unknown_chunksizes and not all(x.shape == seq[0].shape for x in seq):
         idx = np.where(np.asanyarray([x.shape for x in seq]) != seq[0].shape)[0]
         raise ValueError(
             "Stacked arrays must have the same shape. "

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -362,6 +362,43 @@ def test_stack_rechunk():
     assert_eq(z, np.stack([x.compute(), y.compute()], axis=0))
 
 
+def test_stack_unknown_chunksizes():
+    dd = pytest.importorskip("dask.dataframe")
+    pd = pytest.importorskip("pandas")
+
+    a_df = pd.DataFrame({"x": np.arange(12)})
+    b_df = pd.DataFrame({"y": np.arange(12) * 10})
+
+    a_ddf = dd.from_pandas(a_df, sort=False, npartitions=3)
+    b_ddf = dd.from_pandas(b_df, sort=False, npartitions=3)
+
+    a_x = a_ddf.values
+    b_x = b_ddf.values
+
+    assert np.isnan(a_x.shape[0])
+    assert np.isnan(b_x.shape[0])
+
+    with pytest.raises(ValueError) as exc_info:
+        da.stack([a_x, b_x], axis=0)
+
+    assert "shape" in str(exc_info.value)
+    assert "nan" in str(exc_info.value)
+
+    c_x = da.stack([a_x, b_x], axis=0, allow_unknown_chunksizes=True)
+
+    assert_eq(c_x, np.stack([a_df.values, b_df.values], axis=0))
+
+    with pytest.raises(ValueError) as exc_info:
+        da.stack([a_x, b_x], axis=1)
+
+    assert "shape" in str(exc_info.value)
+    assert "nan" in str(exc_info.value)
+
+    c_x = da.stack([a_x, b_x], axis=1, allow_unknown_chunksizes=True)
+
+    assert_eq(c_x, np.stack([a_df.values, b_df.values], axis=1))
+
+
 def test_concatenate():
     a, b, c = [
         Array(


### PR DESCRIPTION
Fixes #6177 
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
