### PR TITLE
Add support for skipping ci run on github actions

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    if: "!true"
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+    if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   checks:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
     name: Documentation build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,13 @@ on:
 
 jobs:
   checks:
-    if: "!contains('test ci skip', 'ci skip')"
     name: Documentation build
     runs-on: ubuntu-latest
     steps:
+
+    - name: debug
+      run: |
+        echo "$GITHUB_CONTEXT"
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Checkout
+      uses: actions/checkout@v2
+
     - name: get commit message
       run: |
           echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.after }})
-
-    - name: Checkout
-      if: "!contains(env.commitmsg , '[ci skip]')"
-      uses: actions/checkout@v2
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,27 +12,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: debug
-      run: |
-        echo "$GITHUB_CONTEXT"
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
 
-    - name: Checkout
-      uses: actions/checkout@v2
+    #- name: Checkout
+      #uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
+    #- name: Set up Python 3.7
+      #uses: actions/setup-python@v1
+      #with:
+        #python-version: 3.7
 
-    - name: Install Dask
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .
+    #- name: Install Dask
+      #run: |
+        #python -m pip install --upgrade pip
+        #python -m pip install -e .
 
-    - name: Install doc dependencies
-      run: python -m pip install -r docs/requirements-docs.txt
+    #- name: Install doc dependencies
+      #run: python -m pip install -r docs/requirements-docs.txt
 
-    - name: Build docs
-      run: |
-        cd docs
-        make html
+    #- name: Build docs
+      #run: |
+        #cd docs
+        #make html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   checks:
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     name: Documentation build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   checks:
-    if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Documentation build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,28 +12,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
+    - name: get commit message
+      run: |
+          echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.after }})
 
-    #- name: Checkout
-      #uses: actions/checkout@v2
+    - name: Checkout
+      if: "!contains(env.commitmsg , '[ci skip]')"
+      uses: actions/checkout@v2
 
-    #- name: Set up Python 3.7
-      #uses: actions/setup-python@v1
-      #with:
-        #python-version: 3.7
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
 
-    #- name: Install Dask
-      #run: |
-        #python -m pip install --upgrade pip
-        #python -m pip install -e .
+    - name: Install Dask
+      if: "!contains(env.commitmsg , '[ci skip]')"
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e .
 
-    #- name: Install doc dependencies
-      #run: python -m pip install -r docs/requirements-docs.txt
+    - name: Install doc dependencies
+      if: "!contains(env.commitmsg , '[ci skip]')"
+      run: python -m pip install -r docs/requirements-docs.txt
 
-    #- name: Build docs
-      #run: |
-        #cd docs
-        #make html
+    - name: Build docs
+      if: "!contains(env.commitmsg , '[ci skip]')"
+      run: |
+        cd docs
+        make html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   checks:
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    if: "!contains('test ci skip', 'ci skip')"
     name: Documentation build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   checks:
-    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+    if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
     name: Documentation build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Travis CI (and many other CIs) will skip runs if `[ci skip]` or `[skip ci]` are present in the commit header. This adds support for that here as well.