### PR TITLE
Overhaul fuse() config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.py[cod]
 __pycache__/
 *.egg-info
+.mypy_cache
 dask-worker-space/
 docs/build
 build/

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -133,9 +133,10 @@ def optimize(dsk, keys, fuse_keys=None, rename_fused_keys=None, **kwargs):
     """ Optimize a dask from a dask Bag. """
     dsk = ensure_dict(dsk)
     dsk2, dependencies = cull(dsk, keys)
-    dsk3, dependencies = fuse(
-        dsk2, keys + (fuse_keys or []), dependencies, rename_keys=rename_fused_keys
-    )
+    kwargs = {}
+    if rename_fused_keys is not None:
+        kwargs["rename_keys"] = rename_fused_keys
+    dsk3, dependencies = fuse(dsk2, keys + (fuse_keys or []), dependencies, **kwargs)
     dsk4 = inline_singleton_lists(dsk3, keys, dependencies)
     dsk5 = lazify(dsk4)
     return dsk5

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -47,26 +47,46 @@ properties:
 
           active:
             type: boolean
-            description: |
-              Configuration setting to turn task fusion on/off
+            description: Turn task fusion on/off
 
           ave-width:
-            type: integer
-            description: |
+            type: number
+            minimum: 0
+            description:
               Upper limit for width, where width = num_nodes / height, a good measure
               of parallelizability
 
-          subraphs:
-            type: boolean
+          max-width:
+            type: [number, 'null']
+            minimum: 0
+            description:
+              Don't fuse if total width is greater than this. Set to null to dynamically
+              adjust to 1.5 + ave_width * log(ave_width + 1)
+
+          max-height:
+            type: number
+            minimum: 0
+            description: Don't fuse more than this many levels
+
+          max-depth-new-edges:
+            type: [number, 'null']
+            minimum: 0
+            description:
+              Don't fuse if new dependencies are added after this many levels.
+              Set to null to dynamically adjust to ave_width * 1.5.
+
+          subgraphs:
+            type: [boolean, 'null']
             description: |
-              Configuration setting to control whether to fuse multiple tasks into
-              SubgraphCallable objects.
+              Set to True to fuse multiple tasks into SubgraphCallable objects. Set to
+              None to let the default optimizer of individual dask collections decide.
+              If no collection-specific default exists, None defaults to False.
 
           rename-keys:
             type: boolean
-            description: |
-              Configuration setting to control renaming of the fused keys with
-              `default_fused_keys_renamer` or not. Renaming fused keys can keep the
-              graph more understandable and comprehensive, but it comes at the cost of
-              additional processing. If False, then the top-most key will be used. For
-              advanced usage, a function to create the new name is also accepted.
+            description:
+              Set to true to rename the fused keys with `default_fused_keys_renamer`.
+              Renaming fused keys can keep the graph more understandable and
+              comprehensible, but it comes at the cost of additional processing. If
+              False, then the top-most key will be used. For advanced usage, a function
+              to create the new name is also accepted.

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -1,4 +1,4 @@
-temporary-directory: null     # Directory for local disk like /tmp, /scratch, or /local
+temporary-directory: null  # Directory for local disk like /tmp, /scratch, or /local
 
 dataframe:
   shuffle-compression: null  # compression for on disk-shuffling. Partd supports ZLib, BZ2, SNAPPY, BLOSC
@@ -11,5 +11,8 @@ optimization:
   fuse:
     active: true
     ave-width: 1
-    subraphs: false
+    max-width: null  # 1.5 + ave_width * log(ave_width + 1)
+    max-height: .inf
+    max-depth-new-edges: null  # ave_width * 1.5
+    subgraphs: null  # true for dask.dataframe, false for everything else
     rename-keys: true

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -25,11 +25,11 @@ def optimize(dsk, keys, **kwargs):
     else:
         dsk, dependencies = cull(dsk, [keys])
 
+    fuse_subgraphs = config.get("optimization.fuse.subgraphs")
+    if fuse_subgraphs is None:
+        fuse_subgraphs = True
     dsk, dependencies = fuse(
-        dsk,
-        keys,
-        dependencies=dependencies,
-        fuse_subgraphs=config.get("optimization.fuse.subgraphs", True),
+        dsk, keys, dependencies=dependencies, fuse_subgraphs=fuse_subgraphs,
     )
     dsk, _ = cull(dsk, keys)
     return dsk

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -411,16 +411,19 @@ def default_fused_keys_renamer(keys, max_fused_key_length=120):
         return (_enforce_max_key_limit(concatenated_name),) + first_key[1:]
 
 
+_use_config = object()
+
+
 def fuse(
     dsk,
     keys=None,
     dependencies=None,
-    ave_width=None,
-    max_width=None,
-    max_height=None,
-    max_depth_new_edges=None,
-    rename_keys=None,
-    fuse_subgraphs=None,
+    ave_width=_use_config,
+    max_width=_use_config,
+    max_height=_use_config,
+    max_depth_new_edges=_use_config,
+    rename_keys=_use_config,
+    fuse_subgraphs=_use_config,
 ):
     """ Fuse tasks that form reductions; more advanced than ``fuse_linear``
 
@@ -446,29 +449,41 @@ def fuse(
         This optional input often comes from ``cull``
     ave_width: float (default 1)
         Upper limit for ``width = num_nodes / height``, a good measure of
-        parallelizability
-    max_width: int
-        Don't fuse if total width is greater than this
-    max_height: int
-        Don't fuse more than this many levels
-    max_depth_new_edges: int
-        Don't fuse if new dependencies are added after this many levels
-    rename_keys: bool or func, optional
+        parallelizability.
+        dask.config key: ``optimization.fuse.ave-width``
+    max_width: int (default infinite)
+        Don't fuse if total width is greater than this.
+        dask.config key: ``optimization.fuse.max-width``
+    max_height: int or None (default None)
+        Don't fuse more than this many levels. Set to None to dynamically
+        adjust to ``1.5 + ave_width * log(ave_width + 1)``.
+        dask.config key: ``optimization.fuse.max-height``
+    max_depth_new_edges: int or None (default None)
+        Don't fuse if new dependencies are added after this many levels.
+        Set to None to dynamically adjust to ave_width * 1.5.
+        dask.config key: ``optimization.fuse.max-depth-new-edges``
+    rename_keys: bool or func, optional (default True)
         Whether to rename the fused keys with ``default_fused_keys_renamer``
         or not.  Renaming fused keys can keep the graph more understandable
         and comprehensive, but it comes at the cost of additional processing.
         If False, then the top-most key will be used.  For advanced usage, a
         function to create the new name is also accepted.
-    fuse_subgraphs : bool, optional
+        dask.config key: ``optimization.fuse.rename-keys``
+    fuse_subgraphs : bool or None, optional (default None)
         Whether to fuse multiple tasks into ``SubgraphCallable`` objects.
+        Set to None to let the default optimizer of individual dask collections decide.
+        If no collection-specific default exists, None defaults to False.
+        dask.config key: ``optimization.fuse.subgraphs``
 
     Returns
     -------
-    dsk: output graph with keys fused
-    dependencies: dict mapping dependencies after fusion.  Useful side effect
-        to accelerate other downstream optimizations.
+    dsk
+        output graph with keys fused
+    dependencies
+        dict mapping dependencies after fusion.  Useful side effect to accelerate other
+        downstream optimizations.
     """
-    if not config.get("optimization.fuse.active", True):
+    if not config.get("optimization.fuse.active"):
         return dsk, dependencies
 
     if keys is not None and not isinstance(keys, set):
@@ -476,28 +491,29 @@ def fuse(
             keys = [keys]
         keys = set(flatten(keys))
 
-    # Assign reasonable, not too restrictive defaults
-    if ave_width is None:
-        ave_width = config.get("optimization.fuse.ave-width", 1)
-    if max_height is None:
-        max_height = config.get("optimization.fuse.max-height", None) or len(dsk)
-    max_depth_new_edges = (
-        max_depth_new_edges
-        or config.get("optimization.fuse.max-depth-new-edges", None)
-        or ave_width * 1.5
-    )
-    max_width = (
-        max_width
-        or config.get("optimization.fuse.max-width", None)
-        or 1.5 + ave_width * math.log(ave_width + 1)
-    )
-    fuse_subgraphs = fuse_subgraphs or config.get("optimization.fuse.subgraphs", False)
+    # Read defaults from dask.yaml and/or user-defined config file
+    if ave_width is _use_config:
+        ave_width = config.get("optimization.fuse.ave-width")
+    if max_height is _use_config:
+        max_height = config.get("optimization.fuse.max-height")
+    if max_depth_new_edges is _use_config:
+        max_depth_new_edges = config.get("optimization.fuse.max-depth-new-edges")
+    if max_depth_new_edges is None:
+        max_depth_new_edges = ave_width * 1.5
+    if max_width is _use_config:
+        max_width = config.get("optimization.fuse.max-width")
+    if max_width is None:
+        max_width = 1.5 + ave_width * math.log(ave_width + 1)
+    if fuse_subgraphs is _use_config:
+        fuse_subgraphs = config.get("optimization.fuse.subgraphs")
+    if fuse_subgraphs is None:
+        fuse_subgraphs = False
 
     if not ave_width or not max_height:
         return dsk, dependencies
 
-    if rename_keys is None:
-        rename_keys = config.get("optimization.fuse.rename-keys", True)
+    if rename_keys is _use_config:
+        rename_keys = config.get("optimization.fuse.rename-keys")
     if rename_keys is True:
         key_renamer = default_fused_keys_renamer
     elif rename_keys is False:


### PR DESCRIPTION
Overhaul the config file and default values for fuse().

- Now all defaults are properly and uniquely defined in dask.yaml. Removed all hardcoded defaults in the code.
- The schema now fully covers all config settings
- Overhauled documentation
- Fixed bug where a user with ``subgraphs: true`` would explicitly set ``fuse_subgraphs=False`` when invoking fuse() and have it ignored
- It is now possible to have a static value in the config for ``max-width`` and ``max-depth-new-edges`` and explicitly pass None when invoking fuse to make them revert to the dynamic calculation

**Caveats:** none. I was extremely conservative in the change so there shouldn't be anything at risk of breaking. This came at the cost of a rather unsightly and inconsistent design in the optimization functions for array and bag - where I strictly retained the previous behaviour.

From looking at the code I see that many other config settings could use the same kind of attention - but they would substantially increase the scope of the change, so I'd rather leave them to a later PR.