### PR TITLE
Cope with missing HDF keys

### DIFF
--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -297,20 +297,25 @@ def _read_single_hdf(
         """
         with pd.HDFStore(path, mode=mode) as hdf:
             import glob
+            from distutils.version import LooseVersion
 
-            if not glob.has_magic(key):
-                keys = [key]
+            if LooseVersion(pd.__version__) >= LooseVersion('0.24'):
+                if not glob.has_magic(key):
+                    keys = [key]
+                else:
+                    keys = [k for k in hdf.keys() if fnmatch(k, key)]
+                    # https://github.com/dask/dask/issues/5934
+                    # TODO: remove this part if/when pandas copes with all keys
+                    keys.extend(
+                        n._v_pathname
+                        for n in hdf._handle.walk_nodes("/", classname="Table")
+                        if fnmatch(n._v_pathname, key)
+                        and n._v_name != u"table"
+                        and n._v_pathname not in keys
+                    )
             else:
+                # TODO: remove if we require pandas >= 0.24
                 keys = [k for k in hdf.keys() if fnmatch(k, key)]
-                # https://github.com/dask/dask/issues/5934
-                # TODO: remove this part if/when pandas copes with all keys
-                keys.extend(
-                    n._v_pathname
-                    for n in hdf._handle.walk_nodes("/", classname="Table")
-                    if fnmatch(n._v_pathname, key)
-                    and n._v_name != u"table"
-                    and n._v_pathname not in keys
-                )
             stops = []
             divisions = []
             for k in keys:

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -298,6 +298,8 @@ def _read_single_hdf(
         with pd.HDFStore(path, mode=mode) as hdf:
             keys = [k for k in hdf.keys() if fnmatch(k, key)]
             if not keys:
+                # https://github.com/dask/dask/issues/5934
+                # TODO: remove this if/when pandas copes with all keys
                 keys = [
                     n._v_pathname
                     for n in hdf._handle.walk_nodes("/", classname="Table")

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -299,7 +299,7 @@ def _read_single_hdf(
             import glob
             from distutils.version import LooseVersion
 
-            if LooseVersion(pd.__version__) >= LooseVersion('0.24'):
+            if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
                 if not glob.has_magic(key):
                     keys = [key]
                 else:

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -297,6 +297,11 @@ def _read_single_hdf(
         """
         with pd.HDFStore(path, mode=mode) as hdf:
             keys = [k for k in hdf.keys() if fnmatch(k, key)]
+            if not keys:
+                keys = [
+                    n._v_pathname
+                    for n in hdf._handle.walk_nodes("/", classname="Table")
+                ]
             stops = []
             divisions = []
             for k in keys:

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -847,7 +847,9 @@ def test_hdf_path_exceptions():
         dd.read_hdf([], "/tmp")
 
 
-@pytest.mark.skipif(pd.__version__ < LooseVersion("0.24.2"), reason='HDF key behaviour changed')
+@pytest.mark.skipif(
+    pd.__version__ < LooseVersion("0.24.2"), reason="HDF key behaviour changed"
+)
 def test_hdf_nonpandas_keys():
     # https://github.com/dask/dask/issues/5934
     # TODO: maybe remove this if/when pandas copes with all keys
@@ -882,7 +884,7 @@ def test_hdf_nonpandas_keys():
 
         # pandas keys should still work
         bar = pd.DataFrame(np.random.randn(10, 4))
-        bar.to_hdf(path, "/bar", format="table", mode='a')
+        bar.to_hdf(path, "/bar", format="table", mode="a")
 
         dd.read_hdf(path, "/group/table1")
         dd.read_hdf(path, "/group/table2")


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/5934

Putting the proposed solution concretely: the "private" method mentioned in the issue is here only used as the fallback, relying on the pandas `keys()`, which may or may not get fixed in the meantime.

The line should be at least commented, and we could use gathering a test case from https://github.com/pandas-dev/pandas/pull/32723 or elsewhere. I think it's fine to do this kind of thing, but indeed the whole HDF module is fairly complex.