### PR TITLE
Adjust the Parquet engine classes to allow more easily subclassing

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -594,16 +594,18 @@ class ArrowEngine(Engine):
         return df
 
     @classmethod
-    def _arrow_table_to_pandas(cls, arrow_table: pa.Table, categories, **kwargs) -> pd.DataFrame:
+    def _arrow_table_to_pandas(
+        cls, arrow_table: pa.Table, categories, **kwargs
+    ) -> pd.DataFrame:
         _kwargs = kwargs.get("arrow_to_pandas", {})
-        _kwargs.update({
-            'use_threads': False, 'ignore_metadata': False
-        })
+        _kwargs.update({"use_threads": False, "ignore_metadata": False})
 
         return arrow_table.to_pandas(categories=categories, **_kwargs)
 
     @classmethod
-    def _parquet_piece_as_arrow(cls, piece: pq.ParquetDatasetPiece, columns, partitions, **kwargs) -> pa.Table:
+    def _parquet_piece_as_arrow(
+        cls, piece: pq.ParquetDatasetPiece, columns, partitions, **kwargs
+    ) -> pa.Table:
         arrow_table = piece.read(
             columns=columns,
             partitions=partitions,

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -249,8 +249,9 @@ def _write_partitioned(
 
 
 class ArrowEngine(Engine):
-    @staticmethod
+    @classmethod
     def read_metadata(
+        cls,
         fs,
         paths,
         categories=None,
@@ -522,9 +523,9 @@ class ArrowEngine(Engine):
 
         return (meta, stats, parts)
 
-    @staticmethod
+    @classmethod
     def read_partition(
-        fs, piece, columns, index, categories=(), partitions=(), **kwargs
+        cls, fs, piece, columns, index, categories=(), partitions=(), **kwargs
     ):
         if isinstance(index, list):
             for level in index:
@@ -558,13 +559,8 @@ class ArrowEngine(Engine):
                     columns_and_parts.append(part_name)
             columns = columns or None
 
-        df = piece.read(
-            columns=columns,
-            partitions=partitions,
-            use_pandas_metadata=True,
-            use_threads=False,
-            **kwargs.get("read", {}),
-        ).to_pandas(categories=categories, use_threads=False, ignore_metadata=False)
+        arrow_table = cls._parquet_piece_as_arrow(piece, columns, partitions, **kwargs)
+        df = cls._arrow_table_to_pandas(arrow_table, categories, **kwargs)
 
         # Note that `to_pandas(ignore_metadata=False)` means
         # pyarrow will use the pandas metadata to set the index.
@@ -596,6 +592,26 @@ class ArrowEngine(Engine):
         if index:
             df = df.set_index(index)
         return df
+
+    @classmethod
+    def _arrow_table_to_pandas(cls, arrow_table: pa.Table, categories, **kwargs) -> pd.DataFrame:
+        _kwargs = kwargs.get("arrow_to_pandas", {})
+        _kwargs.update({
+            'use_threads': False, 'ignore_metadata': False
+        })
+
+        return arrow_table.to_pandas(categories=categories, **_kwargs)
+
+    @classmethod
+    def _parquet_piece_as_arrow(cls, piece: pq.ParquetDatasetPiece, columns, partitions, **kwargs) -> pa.Table:
+        arrow_table = piece.read(
+            columns=columns,
+            partitions=partitions,
+            use_pandas_metadata=True,
+            use_threads=False,
+            **kwargs.get("read", {}),
+        )
+        return arrow_table
 
     @staticmethod
     def initialize_write(

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -167,8 +167,9 @@ def read_parquet(
         the second level corresponds to the kwargs that will be passed on to
         the underlying `pyarrow` or `fastparquet` function.
         Supported top-level keys: 'dataset' (for opening a `pyarrow` dataset),
-        'file' (for opening a `fastparquet` `ParquetFile`), and 'read' (for the
-        backend read function)
+        'file' (for opening a `fastparquet` `ParquetFile`), 'read' (for the
+        backend read function), 'arrow_to_pandas' (for controlling the arguments
+        passed to convert from a `pyarrow.Table.to_pandas()`)
 
     Examples
     --------

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -440,7 +440,9 @@ class FastParquetEngine(Engine):
         return (meta, stats, parts)
 
     @classmethod
-    def read_partition(cls, fs, piece, columns, index, categories=(), pf=None, **kwargs):
+    def read_partition(
+        cls, fs, piece, columns, index, categories=(), pf=None, **kwargs
+    ):
         if isinstance(index, list):
             columns += index
 

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -189,8 +189,9 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
 
 
 class FastParquetEngine(Engine):
-    @staticmethod
+    @classmethod
     def read_metadata(
+        cls,
         fs,
         paths,
         categories=None,
@@ -438,8 +439,8 @@ class FastParquetEngine(Engine):
 
         return (meta, stats, parts)
 
-    @staticmethod
-    def read_partition(fs, piece, columns, index, categories=(), pf=None, **kwargs):
+    @classmethod
+    def read_partition(cls, fs, piece, columns, index, categories=(), pf=None, **kwargs):
         if isinstance(index, list):
             columns += index
 
@@ -471,8 +472,9 @@ class FastParquetEngine(Engine):
                 rg_piece, columns, categories, index=index, **kwargs.get("read", {})
             )
 
-    @staticmethod
+    @classmethod
     def initialize_write(
+        cls,
         df,
         fs,
         path,
@@ -551,8 +553,9 @@ class FastParquetEngine(Engine):
 
         return (fmd, i_offset)
 
-    @staticmethod
+    @classmethod
     def write_partition(
+        cls,
         df,
         path,
         fs,
@@ -599,8 +602,8 @@ class FastParquetEngine(Engine):
         else:
             return []
 
-    @staticmethod
-    def write_metadata(parts, fmd, fs, path, append=False, **kwargs):
+    @classmethod
+    def write_metadata(cls, parts, fmd, fs, path, append=False, **kwargs):
         _meta = copy.copy(fmd)
         if parts:
             for rg in parts:

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -4,8 +4,9 @@ import re
 class Engine:
     """ The API necessary to provide a new Parquet reader/writer """
 
-    @staticmethod
+    @classmethod
     def read_metadata(
+        cls,
         fs,
         paths,
         categories=None,
@@ -66,8 +67,8 @@ class Engine:
         """
         raise NotImplementedError()
 
-    @staticmethod
-    def read_partition(fs, piece, columns, index, **kwargs):
+    @classmethod
+    def read_partition(cls, fs, piece, columns, index, **kwargs):
         """ Read a single piece of a Parquet dataset into a Pandas DataFrame
 
         This function is called many times in individual tasks
@@ -93,8 +94,9 @@ class Engine:
         """
         raise NotImplementedError()
 
-    @staticmethod
+    @classmethod
     def initialize_write(
+        cls,
         df,
         fs,
         path,
@@ -134,9 +136,9 @@ class Engine:
         """
         raise NotImplementedError
 
-    @staticmethod
+    @classmethod
     def write_partition(
-        df, path, fs, filename, partition_on, return_metadata, **kwargs
+        cls, df, path, fs, filename, partition_on, return_metadata, **kwargs
     ):
         """
         Output a partition of a dask.DataFrame. This will correspond to
@@ -167,8 +169,8 @@ class Engine:
         """
         raise NotImplementedError
 
-    @staticmethod
-    def write_metadata(parts, meta, fs, path, append=False, **kwargs):
+    @classmethod
+    def write_metadata(cls, parts, meta, fs, path, append=False, **kwargs):
         """
         Write the shared metadata file for a parquet dataset.
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2449,6 +2449,9 @@ def test_pandas_metadata_nullable_pyarrow(tmpdir):
 def test_pandas_timestamp_overflow_pyarrow(tmpdir):
 
     check_pyarrow()
+    if pa.__version__ < LooseVersion("0.17.0"):
+        pytest.skip("PyArrow>=0.17 Required.")
+
     info = np.iinfo(np.dtype('int64'))
     arr_numeric = np.linspace(start=info.min + 2, stop=info.max, num=1024, dtype='int64')
     arr_dates = arr_numeric.astype("datetime64[ms]")


### PR DESCRIPTION
Reduces code duplication when subclassing and provides a hook for adjusting arrow / pandas conversion behavior more precisely

Add passthough for arrow_to_pandas options.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
