### PR TITLE
Small improvements to `da.pad`

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -1021,12 +1021,8 @@ def pad_reuse(array, pad_width, mode, *args):
 def _round_if_needed(arr, dtype):
     if np.issubdtype(dtype, np.integer):
         rint(arr, out=arr)
-        return arr.astype(dtype)
 
-    if dtype == np.bool:
-        return arr.astype(dtype)
-
-    return arr
+    return arr.astype(dtype)
 
 
 def pad_stats(array, pad_width, mode, *args):

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -1024,13 +1024,6 @@ def pad_reuse(array, pad_width, mode, **kwargs):
     return result
 
 
-def _round_if_needed(arr, dtype):
-    if np.issubdtype(dtype, np.integer):
-        rint(arr, out=arr)
-
-    return arr.astype(dtype)
-
-
 def pad_stats(array, pad_width, mode, stat_length):
     """
     Helper function for padding boundaries with statistics from the array.
@@ -1086,7 +1079,9 @@ def pad_stats(array, pad_width, mode, stat_length):
             result_idx = broadcast_to(result_idx, pad_shape, chunks=pad_chunks)
 
             if mode == "mean":
-                result_idx = _round_if_needed(result_idx, array.dtype)
+                if np.issubdtype(array.dtype, np.integer):
+                    result_idx = rint(result_idx)
+                result_idx = result_idx.astype(array.dtype)
 
         result[idx] = result_idx
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -904,14 +904,14 @@ def linear_ramp_chunk(start, stop, num, dim, step):
     return result
 
 
-def pad_edge(array, pad_width, mode, *args):
+def pad_edge(array, pad_width, mode, **kwargs):
     """
     Helper function for padding edges.
 
     Handles the cases where the only the values on the edge are needed.
     """
 
-    args = tuple(expand_pad_value(array, e) for e in args)
+    kwargs = {k: expand_pad_value(array, v) for k, v in kwargs.items()}
 
     result = array
     for d in range(array.ndim):
@@ -919,7 +919,7 @@ def pad_edge(array, pad_width, mode, *args):
         pad_arrays = [result, result]
 
         if mode == "constant":
-            constant_values = args[0][d]
+            constant_values = kwargs["constant_values"][d]
             constant_values = [asarray(c).astype(result.dtype) for c in constant_values]
 
             pad_arrays = [
@@ -940,7 +940,7 @@ def pad_edge(array, pad_width, mode, *args):
                     for a, s, c in zip(pad_arrays, pad_shapes, pad_chunks)
                 ]
             elif mode == "linear_ramp":
-                end_values = args[0][d]
+                end_values = kwargs["end_values"][d]
 
                 pad_arrays = [
                     a.map_blocks(
@@ -967,7 +967,7 @@ def pad_edge(array, pad_width, mode, *args):
     return result
 
 
-def pad_reuse(array, pad_width, mode, *args):
+def pad_reuse(array, pad_width, mode, **kwargs):
     """
     Helper function for padding boundaries with values in the array.
 
@@ -976,8 +976,14 @@ def pad_reuse(array, pad_width, mode, *args):
     boundary constraints.
     """
 
-    if mode in ["reflect", "symmetric"] and "odd" in args:
-        raise NotImplementedError("`pad` does not support `reflect_type` of `odd`.")
+    if mode in {"reflect", "symmetric"}:
+        reflect_type = kwargs.get("reflect", "even")
+        if reflect_type == "odd":
+            raise NotImplementedError("`pad` does not support `reflect_type` of `odd`.")
+        if reflect_type != "even":
+            raise ValueError(
+                "unsupported value for reflect_type, must be one of (`even`, `odd`)"
+            )
 
     result = np.empty(array.ndim * (3,), dtype=object)
     for idx in np.ndindex(result.shape):
@@ -1025,7 +1031,7 @@ def _round_if_needed(arr, dtype):
     return arr.astype(dtype)
 
 
-def pad_stats(array, pad_width, mode, *args):
+def pad_stats(array, pad_width, mode, stat_length):
     """
     Helper function for padding boundaries with statistics from the array.
 
@@ -1037,7 +1043,7 @@ def pad_stats(array, pad_width, mode, *args):
     if mode == "median":
         raise NotImplementedError("`pad` does not support `mode` of `median`.")
 
-    stat_length = expand_pad_value(array, args[0])
+    stat_length = expand_pad_value(array, stat_length)
 
     result = np.empty(array.ndim * (3,), dtype=object)
     for idx in np.ndindex(result.shape):
@@ -1108,7 +1114,7 @@ def pad_udf(array, pad_width, mode, **kwargs):
     boundaries.
     """
 
-    result = pad_edge(array, pad_width, "constant", 0)
+    result = pad_edge(array, pad_width, "constant", constant_values=0)
 
     chunks = result.chunks
     for d in range(result.ndim):
@@ -1137,32 +1143,46 @@ def pad(array, pad_width, mode="constant", **kwargs):
 
     pad_width = expand_pad_value(array, pad_width)
 
-    if mode in ["maximum", "mean", "median", "minimum"]:
-        kwargs.setdefault("stat_length", tuple((n, n) for n in array.shape))
+    if callable(mode):
+        return pad_udf(array, pad_width, mode, **kwargs)
+
+    # Make sure that no unsupported keywords were passed for the current mode
+    allowed_kwargs = {
+        "empty": [],
+        "edge": [],
+        "wrap": [],
+        "constant": ["constant_values"],
+        "linear_ramp": ["end_values"],
+        "maximum": ["stat_length"],
+        "mean": ["stat_length"],
+        "median": ["stat_length"],
+        "minimum": ["stat_length"],
+        "reflect": ["reflect_type"],
+        "symmetric": ["reflect_type"],
+    }
+    try:
+        unsupported_kwargs = set(kwargs) - set(allowed_kwargs[mode])
+    except KeyError:
+        raise ValueError("mode '{}' is not supported".format(mode))
+    if unsupported_kwargs:
+        raise ValueError(
+            "unsupported keyword arguments for mode '{}': {}".format(
+                mode, unsupported_kwargs
+            )
+        )
+
+    if mode in {"maximum", "mean", "median", "minimum"}:
+        stat_length = kwargs.get("stat_length", tuple((n, n) for n in array.shape))
+        return pad_stats(array, pad_width, mode, stat_length)
     elif mode == "constant":
         kwargs.setdefault("constant_values", 0)
+        return pad_edge(array, pad_width, mode, **kwargs)
     elif mode == "linear_ramp":
         kwargs.setdefault("end_values", 0)
-    elif mode in ["reflect", "symmetric"]:
-        kwargs.setdefault("reflect_type", "even")
-    elif mode in ["edge", "wrap", "empty"]:
-        if kwargs:
-            raise TypeError("Got unsupported keyword arguments.")
-    elif callable(mode):
-        kwargs.setdefault("kwargs", {})
-    else:
-        raise ValueError("Got an unsupported `mode`.")
-
-    if not callable(mode) and len(kwargs) > 1:
-        raise TypeError("Got too many keyword arguments.")
-
-    if mode in ["maximum", "mean", "median", "minimum"]:
-        return pad_stats(array, pad_width, mode, *kwargs.values())
-    elif mode in ["constant", "edge", "linear_ramp", "empty"]:
-        return pad_edge(array, pad_width, mode, *kwargs.values())
+        return pad_edge(array, pad_width, mode, **kwargs)
+    elif mode in {"edge", "empty"}:
+        return pad_edge(array, pad_width, mode)
     elif mode in ["reflect", "symmetric", "wrap"]:
-        return pad_reuse(array, pad_width, mode, *kwargs.values())
-    elif callable(mode):
-        return pad_udf(array, pad_width, mode, **kwargs)
-    else:
-        raise ValueError("Unsupported mode selected.")
+        return pad_reuse(array, pad_width, mode, **kwargs)
+
+    assert False, "unreachable"

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -22,6 +22,7 @@ from .core import (
     broadcast_arrays,
     cached_cumsum,
 )
+from .ufunc import rint
 from .wrap import empty, ones, zeros, full
 from .utils import AxisError, meta_from_array, zeros_like_safe
 
@@ -1017,6 +1018,14 @@ def pad_reuse(array, pad_width, mode, *args):
     return result
 
 
+def _round_if_needed(arr, dtype):
+    if np.issubdtype(dtype, np.integer):
+        rint(arr, out=arr)
+        return arr.astype(dtype)
+
+    return arr
+
+
 def pad_stats(array, pad_width, mode, *args):
     """
     Helper function for padding boundaries with statistics from the array.
@@ -1070,6 +1079,9 @@ def pad_stats(array, pad_width, mode, *args):
                 result_idx = result_idx.min(axis=axes, keepdims=True)
 
             result_idx = broadcast_to(result_idx, pad_shape, chunks=pad_chunks)
+
+            if mode == "mean":
+                result_idx = _round_if_needed(result_idx, array.dtype)
 
         result[idx] = result_idx
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -1132,7 +1132,7 @@ def pad_udf(array, pad_width, mode, **kwargs):
 
 
 @derived_from(np)
-def pad(array, pad_width, mode, **kwargs):
+def pad(array, pad_width, mode="constant", **kwargs):
     array = asarray(array)
 
     pad_width = expand_pad_value(array, pad_width)

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -1023,6 +1023,9 @@ def _round_if_needed(arr, dtype):
         rint(arr, out=arr)
         return arr.astype(dtype)
 
+    if dtype == np.bool:
+        return arr.astype(dtype)
+
     return arr
 
 

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -735,12 +735,7 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
             ),
         ),
         "maximum",
-        pytest.param(
-            "mean",
-            marks=pytest.mark.skip(
-                reason="Bug dask changes the dtype to float: https://github.com/dask/dask/issues/5303"
-            ),
-        ),
+        "mean",
         "minimum",
         pytest.param(
             "reflect",

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -776,8 +776,9 @@ def test_pad_3d_data(dtype, pad_widths, mode):
 
 @pytest.mark.parametrize("kwargs", [{}, {"scaler": 2}])
 def test_pad_udf(kwargs):
-    def udf_pad(vector, pad_width, iaxis, kwargs):
-        scaler = kwargs.get("scaler", 1)
+    def udf_pad(vector, pad_width, iaxis, inner_kwargs):
+        assert kwargs == inner_kwargs
+        scaler = inner_kwargs.get("scaler", 1)
         vector[: pad_width[0]] = -scaler * pad_width[0]
         vector[-pad_width[1] :] = scaler * pad_width[1]
         return vector
@@ -789,8 +790,8 @@ def test_pad_udf(kwargs):
     np_a = np.random.random(shape)
     da_a = da.from_array(np_a, chunks=chunks)
 
-    np_r = np.pad(np_a, pad_width, udf_pad, kwargs=kwargs)
-    da_r = da.pad(da_a, pad_width, udf_pad, kwargs=kwargs)
+    np_r = np.pad(np_a, pad_width, udf_pad, **kwargs)
+    da_r = da.pad(da_a, pad_width, udf_pad, **kwargs)
 
     assert_eq(np_r, da_r)
 


### PR DESCRIPTION
This PR makes a couple of small improvements to `dask.array.pad`
* Fixes bug of mode="mean", where it would change dtype to float #6127
* Add default value for mode
* Refactor error message if invalid kwargs are passed to pad function. Uses some of the same code from the numpy project.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

This PR does not address the issue with wrap, reflect and symmetric. That will require a rewrite of pad_reuse, I'll have a look at this in a next PR.