### PR TITLE
Doc: Troubleshooting dashboard 404

### DIFF
--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -167,7 +167,9 @@ forward port 8888 (the default Jupyter port) to port 8001 with
 Required Packages
 ~~~~~~~~~~~~~~~~~
 
-If you are unable to see the dashboard (404 error), you might also be missing some of the
+Bokeh must be installed in your scheduler's environment to run the dashboard. If it's not the dashboard page will instruct you to install it.
+
+Depending on your configuration, you might also need to install ``jupyter-server-proxy`` to access the dashboard.
 packages required to build it. Check that you have both ``bokeh`` and ``jupyter-server-proxy``
 installed. 
 

--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -170,7 +170,6 @@ Required Packages
 Bokeh must be installed in your scheduler's environment to run the dashboard. If it's not the dashboard page will instruct you to install it.
 
 Depending on your configuration, you might also need to install ``jupyter-server-proxy`` to access the dashboard.
-installed. 
 
 API
 ---

--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -170,7 +170,6 @@ Required Packages
 Bokeh must be installed in your scheduler's environment to run the dashboard. If it's not the dashboard page will instruct you to install it.
 
 Depending on your configuration, you might also need to install ``jupyter-server-proxy`` to access the dashboard.
-packages required to build it. Check that you have both ``bokeh`` and ``jupyter-server-proxy``
 installed. 
 
 API

--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -164,6 +164,13 @@ network, such as Jupyter notebooks. For example, if we chose to do this we could
 forward port 8888 (the default Jupyter port) to port 8001 with
 ``ssh -L 8001:localhost:8888 user@remote``.
 
+Required Packages
+~~~~~~~~~~~~~~~~~
+
+If you are unable to see the dashboard (404 error), you might also be missing some of the
+packages required to build it. Check that you have both ``bokeh`` and ``jupyter-server-proxy``
+installed. 
+
 API
 ---
 


### PR DESCRIPTION
If ``bokeh`` is missing the user is unable to see the dashboard with no warning displayed anywhere. 
There's already a troubleshooting section in the docs, so let's add this there.

- [x ] Tests added / passed
- [ x] Passes `black dask` / `flake8 dask`
