### PR TITLE
Add `fuse` to delayed object optimization

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -13,7 +13,7 @@ from .compatibility import is_dataclass, dataclass_fields
 
 from .core import quote
 from .context import globalmethod
-from .optimization import cull
+from .optimization import cull, fuse
 from .utils import funcname, methodcaller, OperatorMethodMixin, ensure_dict, apply
 from .highlevelgraph import HighLevelGraph
 
@@ -456,8 +456,9 @@ def right(method):
 
 def optimize(dsk, keys, **kwargs):
     dsk = ensure_dict(dsk)
-    dsk2, _ = cull(dsk, keys)
-    return dsk2
+    dsk, deps = cull(dsk, keys)
+    dsk, _ = fuse(dsk, keys, dependencies=deps)
+    return dsk
 
 
 def rebuild(dsk, key, length):

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -198,7 +198,7 @@ def test_delayed_optimize():
     x = Delayed("b", {"a": 1, "b": (inc, "a"), "c": (inc, "b")})
     (x2,) = dask.optimize(x)
     # Delayed's __dask_optimize__ culls out 'c'
-    assert sorted(x2.dask.keys()) == ["a", "b"]
+    assert sorted(x2.dask.keys()) == ["a-b", "b"]
 
 
 def test_lists():


### PR DESCRIPTION
Many of our IO routes start/end with Delayed objects. With fuse enabled,
we can more effectively optimize these graphs. Since using `Delayed` to
build large graphs is already taking a performance hit (the delayed api
is more ergonomic, but less efficient than raw graphs), the slower
optimization time should be negligible for users compared to other
overheads.

See #6219.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
