### PR TITLE
Empty arr rechunk

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2590,7 +2590,6 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
         )
         last_multiplier = 0
         last_autos = set()
-
         while (
             multiplier != last_multiplier or autos != last_autos
         ):  # while things change

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -220,6 +220,8 @@ def rechunk(x, chunks="auto", threshold=None, block_size_limit=None):
 
     >>> y = x.rechunk({0: -1, 1: 'auto'}, block_size_limit=1e8)
     """
+    if x.shape == (0,):
+        return x
     if isinstance(chunks, dict):
         chunks = {validate_axis(c, x.ndim): v for c, v in chunks.items()}
         for i in range(x.ndim):
@@ -230,7 +232,7 @@ def rechunk(x, chunks="auto", threshold=None, block_size_limit=None):
     chunks = normalize_chunks(
         chunks, x.shape, limit=block_size_limit, dtype=x.dtype, previous_chunks=x.chunks
     )
-
+    
     if chunks == x.chunks:
         return x
     ndim = x.ndim

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -220,7 +220,8 @@ def rechunk(x, chunks="auto", threshold=None, block_size_limit=None):
 
     >>> y = x.rechunk({0: -1, 1: 'auto'}, block_size_limit=1e8)
     """
-    if x.shape == (0,):
+    # don't rechunk if array is empty
+    if x.ndim > 0 and x.shape[-1] == 0:
         return x
     if isinstance(chunks, dict):
         chunks = {validate_axis(c, x.ndim): v for c, v in chunks.items()}

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -232,7 +232,7 @@ def rechunk(x, chunks="auto", threshold=None, block_size_limit=None):
     chunks = normalize_chunks(
         chunks, x.shape, limit=block_size_limit, dtype=x.dtype, previous_chunks=x.chunks
     )
-    
+
     if chunks == x.chunks:
         return x
     ndim = x.ndim

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -207,8 +207,6 @@ def test_rechunk_empty_array():
 
 def test_rechunk_empty():
     x = da.ones((0, 10), chunks=(5, 5))
-    print(x)
-    print(x.size)
     y = x.rechunk((2, 2))
     assert y.chunks == ((0,), (2,) * 5)
     assert_eq(x, y)

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -79,6 +79,9 @@ def test_intersect_2():
     assert answer == cross
 
 
+
+    
+
 def test_rechunk_1d():
     """Try rechunking a random 1d matrix"""
     a = np.random.uniform(0, 1, 30)
@@ -199,8 +202,16 @@ def test_rechunk_0d():
     assert y.compute() == a
 
 
+def test_rechunk_empty_array():
+    x = da.array([])
+    x.rechunk()
+    assert x.size == 0
+
+
 def test_rechunk_empty():
     x = da.ones((0, 10), chunks=(5, 5))
+    print(x)
+    print(x.size)
     y = x.rechunk((2, 2))
     assert y.chunks == ((0,), (2,) * 5)
     assert_eq(x, y)

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -79,9 +79,6 @@ def test_intersect_2():
     assert answer == cross
 
 
-
-    
-
 def test_rechunk_1d():
     """Try rechunking a random 1d matrix"""
     a = np.random.uniform(0, 1, 30)

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -199,10 +199,12 @@ def test_rechunk_0d():
     assert y.compute() == a
 
 
-def test_rechunk_empty_array():
-    x = da.array([])
-    x.rechunk()
-    assert x.size == 0
+@pytest.mark.parametrize(
+    "arr", [da.array([]), da.array([[], []]), da.array([[[]], [[]]])]
+)
+def test_rechunk_empty_array(arr):
+    arr.rechunk()
+    assert arr.size == 0
 
 
 def test_rechunk_empty():


### PR DESCRIPTION
Currently if you try to rechunk an empty array, you will get caught in an infinite loop. This PR fixes that by simply returning the array when the `rechunk` method is called if `shape == (0,)`.

Example of failing code:
``` python
import dask.array as da

array = da.array([])
array.rechunk()
```

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
