### PR TITLE
Xfail test_rolling_numba_engine for newer numba and older pandas

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -9,6 +9,7 @@ PANDAS_VERSION = LooseVersion(pd.__version__)
 PANDAS_GT_0240 = PANDAS_VERSION >= LooseVersion("0.24.0")
 PANDAS_GT_0250 = PANDAS_VERSION >= LooseVersion("0.25.0")
 PANDAS_GT_100 = PANDAS_VERSION >= LooseVersion("1.0.0")
+PANDAS_GT_104 = PANDAS_VERSION >= LooseVersion("1.0.4")
 HAS_INT_NA = PANDAS_GT_0240
 
 

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -386,10 +386,7 @@ def test_rolling_agg_aggregate():
 @pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="needs pandas>=1.0.0")
 def test_rolling_numba_engine():
     numba = pytest.importorskip("numba")
-    if (
-        dd._compat.PANDAS_VERSION <= "1.0.3"
-        and LooseVersion(numba.__version__) >= "0.49"
-    ):
+    if not dd._compat.PANDAS_GT_104 and LooseVersion(numba.__version__) >= "0.49":
         # Was fixed in https://github.com/pandas-dev/pandas/pull/33687
         pytest.xfail("Known incompatibility between pandas and numba")
 

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 import pandas as pd
 import pytest
 import numpy as np
@@ -383,7 +385,14 @@ def test_rolling_agg_aggregate():
 
 @pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="needs pandas>=1.0.0")
 def test_rolling_numba_engine():
-    pytest.importorskip("numba")
+    numba = pytest.importorskip("numba")
+    if (
+        dd._compat.PANDAS_VERSION <= "1.0.3"
+        and LooseVersion(numba.__version__) >= "0.49"
+    ):
+        # Was fixed in https://github.com/pandas-dev/pandas/pull/33687
+        pytest.xfail("Known incompatibility between pandas and numba")
+
     df = pd.DataFrame({"A": range(5), "B": range(0, 10, 2)})
     ddf = dd.from_pandas(df, npartitions=3)
 


### PR DESCRIPTION
There was an internal refactor in the Numba 0.49 release which moved modules around. We're now running into a test failure (xref https://travis-ci.org/github/dask/dask/jobs/690752889#L1264) based on `numba.targets` being moved to `numba.core`. This issue was fixed upstream in Pandas (xref https://github.com/pandas-dev/pandas/pull/33687) but isn't yet out in a release.

This PR `xfail`s `test_rolling_numba_engine` when `pandas<=1.0.3` and `numba>=0.49`. I confirmed locally that this test passes when using the nightly wheel for pandas. 

cc @TomAugspurger 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
