### PR TITLE
Fix install commands from ImportError

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -245,6 +245,6 @@ except ImportError as e:
         "Dask array requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask                 # either conda install\n"
-        "  python -m pip install "dask[array]" --upgrade  # or python -m pip install"
+        "  python -m pip install \"dask[array]\" --upgrade  # or python -m pip install"
     )
     raise ImportError(str(e) + "\n\n" + msg)

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -245,6 +245,6 @@ except ImportError as e:
         "Dask array requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask                 # either conda install\n"
-        "  python -m pip install dask[array] --upgrade  # or python -m pip install"
+        "  python -m pip install "dask[array]" --upgrade  # or python -m pip install"
     )
     raise ImportError(str(e) + "\n\n" + msg)

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -245,6 +245,6 @@ except ImportError as e:
         "Dask array requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask                 # either conda install\n"
-        "  python -m pip install \"dask[array]\" --upgrade  # or python -m pip install"
+        '  python -m pip install "dask[array]" --upgrade  # or python -m pip install'
     )
     raise ImportError(str(e) + "\n\n" + msg)

--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -21,6 +21,6 @@ except ImportError as e:
         "Dask bag requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask               # either conda install\n"
-        "  python -m pip install \"dask[bag]\" --upgrade  # or python -m pip install"
+        '  python -m pip install "dask[bag]" --upgrade  # or python -m pip install'
     )
     raise ImportError(str(e) + "\n\n" + msg)

--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -21,6 +21,6 @@ except ImportError as e:
         "Dask bag requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask               # either conda install\n"
-        "  python -m pip install dask[bag] --upgrade  # or python -m pip install"
+        "  python -m pip install "dask[bag]" --upgrade  # or python -m pip install"
     )
     raise ImportError(str(e) + "\n\n" + msg)

--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -21,6 +21,6 @@ except ImportError as e:
         "Dask bag requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask               # either conda install\n"
-        "  python -m pip install "dask[bag]" --upgrade  # or python -m pip install"
+        "  python -m pip install \"dask[bag]\" --upgrade  # or python -m pip install"
     )
     raise ImportError(str(e) + "\n\n" + msg)

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -51,6 +51,6 @@ except ImportError as e:
         "Dask dataframe requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask                     # either conda install\n"
-        "  python -m pip install "dask[dataframe]" --upgrade  # or python -m pip install"
+        "  python -m pip install \"dask[dataframe]\" --upgrade  # or python -m pip install"
     )
     raise ImportError(msg) from e

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -51,6 +51,6 @@ except ImportError as e:
         "Dask dataframe requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask                     # either conda install\n"
-        "  python -m pip install dask[dataframe] --upgrade  # or python -m pip install"
+        "  python -m pip install "dask[dataframe]" --upgrade  # or python -m pip install"
     )
     raise ImportError(msg) from e

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -51,6 +51,6 @@ except ImportError as e:
         "Dask dataframe requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
         "  conda install dask                     # either conda install\n"
-        "  python -m pip install \"dask[dataframe]\" --upgrade  # or python -m pip install"
+        '  python -m pip install "dask[dataframe]" --upgrade  # or python -m pip install'
     )
     raise ImportError(msg) from e

--- a/dask/distributed.py
+++ b/dask/distributed.py
@@ -6,6 +6,6 @@ except ImportError:
         "Dask's distributed scheduler is not installed.\n\n"
         "Please either conda or pip install dask distributed:\n\n"
         "  conda install dask distributed          # either conda install\n"
-        "  python -m pip install dask distributed --upgrade  # or python -m pip install"
+        "  python -m pip install "dask[distributed]" --upgrade  # or python -m pip install"
     )
     raise ImportError(msg)

--- a/dask/distributed.py
+++ b/dask/distributed.py
@@ -6,6 +6,6 @@ except ImportError:
         "Dask's distributed scheduler is not installed.\n\n"
         "Please either conda or pip install dask distributed:\n\n"
         "  conda install dask distributed          # either conda install\n"
-        "  python -m pip install "dask[distributed]" --upgrade  # or python -m pip install"
+        "  python -m pip install \"dask[distributed]\" --upgrade  # or python -m pip install"
     )
     raise ImportError(msg)

--- a/dask/distributed.py
+++ b/dask/distributed.py
@@ -6,6 +6,6 @@ except ImportError:
         "Dask's distributed scheduler is not installed.\n\n"
         "Please either conda or pip install dask distributed:\n\n"
         "  conda install dask distributed          # either conda install\n"
-        "  python -m pip install \"dask[distributed]\" --upgrade  # or python -m pip install"
+        '  python -m pip install "dask[distributed]" --upgrade  # or python -m pip install'
     )
     raise ImportError(msg)


### PR DESCRIPTION
There are multiple install written incorrectly (missing double quotes). Those install commands do not work if you copy and paste into terminal. This PR fixes that. 

- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

