### PR TITLE
[REVIEW] Generalize `fix_overlap`

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -19,6 +19,7 @@ from ..highlevelgraph import HighLevelGraph
 from ..sizeof import sizeof
 from ..utils import digit, insert, M
 from .utils import hash_object_dispatch, group_split_dispatch
+from . import methods
 
 logger = logging.getLogger(__name__)
 
@@ -778,7 +779,7 @@ def drop_overlap(df, index):
 
 
 def get_overlap(df, index):
-    return df.loc[[index]] if index in df.index else None
+    return df.loc[[index]] if index in df.index else df._constructor()
 
 
 def fix_overlap(ddf, overlap):
@@ -789,7 +790,7 @@ def fix_overlap(ddf, overlap):
 
     for i in overlap:
         frames = [(get_overlap, (ddf._name, i - 1), ddf.divisions[i]), (ddf._name, i)]
-        dsk[(name, i)] = (pd.concat, frames)
+        dsk[(name, i)] = (methods.concat, frames)
         dsk[(name, i - 1)] = (drop_overlap, dsk[(name, i - 1)], ddf.divisions[i])
 
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[ddf])


### PR DESCRIPTION
With the recent changes introduced in https://github.com/dask/dask/pull/6226/, there was an issue on the cudf side:

```python
>>> import dask.dataframe as dd
>>> import dask_cudf as dgd
>>> import cudf
>>> import pandas as pd
>>> df1 = pd.DataFrame({"val": [4, 3, 2, 1, 0], "id": [0, 1, 3, 5, 7]})
>>> ddf1 = dd.from_pandas(df1, npartitions=2)
>>>     
>>> gdf1 = cudf.from_pandas(df1)
>>> gddf1 = dgd.from_cudf(gdf1, npartitions=2)
>>>     
>>> expect = ddf1.set_index("id", sorted=True)
>>> got = gddf1.set_index("id", sorted=True)
>>> expect.compute()
    val
id     
0     4
1     3
3     2
5     1
7     0
>>> got.compute()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/cudf/dask/dask/base.py", line 166, in compute
    (result,) = compute(self, traverse=False, **kwargs)
  File "/cudf/dask/dask/base.py", line 444, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/cudf/dask/dask/local.py", line 527, in get_sync
    return get_async(apply_sync, 1, dsk, keys, **kwargs)
  File "/cudf/dask/dask/local.py", line 494, in get_async
    fire_task()
  File "/cudf/dask/dask/local.py", line 466, in fire_task
    callback=queue.put,
  File "/cudf/dask/dask/local.py", line 516, in apply_sync
    res = func(*args, **kwds)
  File "/cudf/dask/dask/local.py", line 227, in execute_task
    result = pack_exception(e, dumps)
  File "/cudf/dask/dask/local.py", line 222, in execute_task
    result = _execute_task(task, data)
  File "/cudf/dask/dask/core.py", line 121, in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
  File "/conda/envs/cudf/lib/python3.7/site-packages/pandas/core/reshape/concat.py", line 255, in concat
    sort=sort,
  File "/conda/envs/cudf/lib/python3.7/site-packages/pandas/core/reshape/concat.py", line 332, in __init__
    raise TypeError(msg)
TypeError: cannot concatenate object of type '<class 'cudf.core.dataframe.DataFrame'>'; only Series and DataFrame objs are valid
```

Fix to this issue is : 

1. Removing `pd.concat` and replacing with a `concat` dispatch.
2. Because we are using `concat` dispatch, we shouldn't be returning `None` in its list otherwise the dispatch method will fail to recognize the underlying backend when it tries to access type of `dfs[0]` and it turns out to be `None`: https://github.com/dask/dask/blob/master/dask/dataframe/methods.py#L377

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
