### PR TITLE
WIP: fix categoricals for non-object dtypes

### DIFF
--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -277,6 +277,10 @@ class FastParquetEngine(Engine):
 
         for cat in categories:
             if cat in meta:
+                import ipdb
+
+                ipdb.set_trace()
+
                 meta[cat] = pd.Series(
                     pd.Categorical([], categories=[UNKNOWN_CATEGORIES]),
                     index=meta.index,

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -89,11 +89,9 @@ def test_make_meta():
 
     # Categoricals
     meta = make_meta({"a": "category"})
-    assert len(meta.a.cat.categories) == 1
-    assert meta.a.cat.categories[0] == UNKNOWN_CATEGORIES
+    assert meta.a.cat.categories == []
     meta = make_meta(("a", "category"))
-    assert len(meta.cat.categories) == 1
-    assert meta.cat.categories[0] == UNKNOWN_CATEGORIES
+    assert meta.cat.categories == []
 
     # Numpy scalar
     meta = make_meta(np.float64(1.0))
@@ -230,7 +228,7 @@ def test_meta_nonempty_index():
     assert res.ordered == idx.ordered
     assert res.name == idx.name
 
-    idx = pd.CategoricalIndex([], [UNKNOWN_CATEGORIES], ordered=True, name="foo")
+    idx = pd.CategoricalIndex([], [], ordered=True, name="foo")
     res = meta_nonempty(idx)
     assert type(res) is pd.CategoricalIndex
     assert res.ordered == idx.ordered

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -196,6 +196,11 @@ def raise_on_meta_error(funcname=None, udf=False):
 UNKNOWN_CATEGORIES = "__UNKNOWN_CATEGORIES__"
 
 
+def empty_categories(df_column):
+    """Returns `pd.CategoricalDtype` with empty categories"""
+    return pd.CategoricalDtype(pd.Index([], dtype=df_column.dtype.categories.dtype))
+
+
 def has_known_categories(x):
     """Returns whether the categories in `x` are known.
 
@@ -205,9 +210,9 @@ def has_known_categories(x):
     """
     x = getattr(x, "_meta", x)
     if is_series_like(x):
-        return UNKNOWN_CATEGORIES not in x.cat.categories
+        return not x.cat.categories.empty
     elif is_index_like(x) and hasattr(x, "categories"):
-        return UNKNOWN_CATEGORIES not in x.categories
+        return not x.categories.empty
     raise TypeError("Expected Series or CategoricalIndex")
 
 
@@ -225,12 +230,13 @@ def strip_unknown_categories(x, just_drop_unknown=False):
                 for c in cats:
                     if not has_known_categories(x[c]):
                         if just_drop_unknown:
-                            x[c].cat.remove_categories(UNKNOWN_CATEGORIES, inplace=True)
+                            pass
+                            # x[c].cat.remove_categories(UNKNOWN_CATEGORIES, inplace=True)
                         else:
-                            x[c].cat.set_categories([], inplace=True)
+                            x[c] = x[c].cat.set_categories([])
         elif isinstance(x, pd.Series):
             if is_categorical_dtype(x.dtype) and not has_known_categories(x):
-                x.cat.set_categories([], inplace=True)
+                x = x.cat.set_categories([])
         if isinstance(x.index, pd.CategoricalIndex) and not has_known_categories(
             x.index
         ):
@@ -262,21 +268,29 @@ def clear_known_categories(x, cols=None, index=True):
             elif not mask.loc[cols].all():
                 raise ValueError("Not all columns are categoricals")
             for c in cols:
-                x[c].cat.set_categories([UNKNOWN_CATEGORIES], inplace=True)
+                x[c] = x[c].cat.set_categories(
+                    pd.Index([], dtype=x[c].dtype.categories.dtype)
+                )
         elif isinstance(x, pd.Series):
             if is_categorical_dtype(x.dtype):
-                x.cat.set_categories([UNKNOWN_CATEGORIES], inplace=True)
+                x = x.cat.set_categories(pd.Index([], dtype=x.dtype.categories.dtype))
         if index and isinstance(x.index, pd.CategoricalIndex):
-            x.index = x.index.set_categories([UNKNOWN_CATEGORIES])
+            x.index = x.index.set_categories(
+                pd.Index([], dtype=x.index.dtype.categories.dtype)
+            )
     elif isinstance(x, pd.CategoricalIndex):
-        x = x.set_categories([UNKNOWN_CATEGORIES])
+        x = x.set_categories(pd.Index([], dtype=x.dtype.categories.dtype))
     return x
 
 
 def _empty_series(name, dtype, index=None):
     if isinstance(dtype, str) and dtype == "category":
+        if type(dtype) == pd.CategoricalDtype:
+            categories_dtype = dtype.categories.dtype
+        else:
+            categories_dtype = np.object  # TODO: raise warning
         return pd.Series(
-            pd.Categorical([UNKNOWN_CATEGORIES]), name=name, index=index
+            pd.Categorical(pd.Index([], dtype=categories_dtype)), name=name, index=index
         ).iloc[:0]
     return pd.Series([], dtype=dtype, name=name, index=index)
 
@@ -442,7 +456,11 @@ def _nonempty_index(idx):
             )
     elif typ is pd.CategoricalIndex:
         if len(idx.categories) == 0:
-            data = pd.Categorical(_nonempty_index(idx.categories), ordered=idx.ordered)
+            data = pd.Categorical(
+                _nonempty_index(idx.categories),
+                categories=idx.categories,
+                ordered=idx.ordered,
+            )
         else:
             data = pd.Categorical.from_codes(
                 [-1, 0], categories=idx.categories, ordered=idx.ordered
@@ -543,12 +561,12 @@ def _nonempty_series(s, idx=None):
         entry = pd.Timestamp("1970-01-01", tz=dtype.tz)
         data = [entry, entry]
     elif is_categorical_dtype(dtype):
+        cats = s.cat.categories
+
         if len(s.cat.categories):
             data = [s.cat.categories[0]] * 2
-            cats = s.cat.categories
         else:
             data = _nonempty_index(s.cat.categories)
-            cats = None
         data = pd.Categorical(data, categories=cats, ordered=s.cat.ordered)
     elif is_integer_na_dtype(dtype):
         data = pd.array([1, None], dtype=dtype)
@@ -619,7 +637,9 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
         if isinstance(a, str) and a == "-" or isinstance(b, str) and b == "-":
             return False
         if is_categorical_dtype(a) and is_categorical_dtype(b):
-            if UNKNOWN_CATEGORIES in a.categories or UNKNOWN_CATEGORIES in b.categories:
+            if (
+                a.categories.empty or b.categories.empty
+            ):  # Assume either of them has "unknown categories"
                 return True
             return a == b
         return (a.kind in eq_types and b.kind in eq_types) or (a == b)


### PR DESCRIPTION
This PR intends to fix categoricals support for categories whose dtypes are not `object`, see #5756 for more info.

I started work on this branch a while ago, receiving some input from @TomAugspurger . 
Unfortunately, I don't have time to work on this atm so if anybody would like to pick this up, feel free to do so.

Fixes #5756 


