### PR TITLE
[Bug fix] Pass ignore_index to dd_shuffle from DataFrame.shuffle

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1227,6 +1227,7 @@ Dask Name: {name}, {task} tasks"""
             on,
             npartitions=npartitions,
             max_branch=max_branch,
+            ignore_index=ignore_index,
             shuffle=shuffle,
             compute=compute,
         )

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1227,8 +1227,8 @@ Dask Name: {name}, {task} tasks"""
             on,
             npartitions=npartitions,
             max_branch=max_branch,
-            ignore_index=ignore_index,
             shuffle=shuffle,
+            ignore_index=ignore_index,
             compute=compute,
         )
 


### PR DESCRIPTION
Very trivial fix for (recently merged) #6066 - The `ignore_index` keyword is not being passed properly.

- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
