### PR TITLE
Make pyyaml required

### DIFF
--- a/continuous_integration/environment-mindeps-array-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-array-dataframe.yaml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.6
+  - pyyaml
   # optional dependencies pulled in by pip install dask[array, dataframe]
   - numpy=1.15
   - pandas=0.23

--- a/continuous_integration/environment-mindeps-bag-delayed.yaml
+++ b/continuous_integration/environment-mindeps-bag-delayed.yaml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.6
+  - pyyaml
   # optional dependencies pulled in by pip install dask[bag, delayed]
   - cloudpickle
   - partd

--- a/continuous_integration/travis/test_imports.sh
+++ b/continuous_integration/travis/test_imports.sh
@@ -5,7 +5,7 @@ set -o errexit
 test_import () {
     echo "Create environment: python=$PYTHON $1"
     # Create an empty environment
-    conda create -y -n test-imports -c conda-forge python=$PYTHON_VERSION $1 > /dev/null 2>&1
+    conda create -y -n test-imports -c conda-forge python=$PYTHON_VERSION pyyaml $1 > /dev/null 2>&1
     source activate test-imports > /dev/null 2>&1
     echo "python -c '$2'"
     python -c "$2"

--- a/dask/config.py
+++ b/dask/config.py
@@ -6,10 +6,7 @@ import sys
 import threading
 import warnings
 
-try:
-    import yaml
-except ImportError:
-    yaml = None
+import yaml
 
 
 no_default = "__no_default__"
@@ -387,11 +384,8 @@ def collect(paths=paths, env=None):
     """
     if env is None:
         env = os.environ
-    configs = []
 
-    if yaml:
-        configs.extend(collect_yaml(paths=paths))
-
+    configs = collect_yaml(paths=paths)
     configs.append(collect_env(env=env))
 
     return merge(*configs)
@@ -581,10 +575,7 @@ def check_deprecations(key: str, deprecations: dict = deprecations):
         return key
 
 
-refresh()
-
-
-if yaml:
+def _initialize():
     fn = os.path.join(os.path.dirname(__file__), "dask.yaml")
     ensure_file(source=fn)
 
@@ -592,4 +583,7 @@ if yaml:
         _defaults = yaml.safe_load(f)
 
     update_defaults(_defaults)
-    del fn, _defaults
+
+
+refresh()
+_initialize()

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,8 @@ extras_require = {
     "diagnostics": ["bokeh >= 1.0.0"],
     "delayed": ["cloudpickle >= 0.2.2", "toolz >= 0.8.2"],
 }
-extras_require["complete"] = sorted(
-    {"PyYaml"} | {v for req in extras_require.values() for v in req}
-)
+
+install_requires = ["pyyaml"]
 
 packages = [
     "dask",
@@ -68,7 +67,7 @@ setup(
     packages=packages + tests,
     long_description=open("README.rst").read() if exists("README.rst") else "",
     python_requires=">=3.6",
-    install_requires=[],
+    install_requires=install_requires,
     setup_requires=setup_requires,
     tests_require=["pytest"],
     extras_require=extras_require,


### PR DESCRIPTION
Having two code paths - one that loaded from config, and one that loaded from the code - made testing and QA trickier, for minor perceivable benefit. We now standardize on loading from config in all cases, and make `pyyaml` a required dependency.

Fixes #6221.