### PR TITLE
[REVIEW] Use ignore_index for pandas' group_split_dispatch

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1227,6 +1227,7 @@ Dask Name: {name}, {task} tasks"""
             on,
             npartitions=npartitions,
             max_branch=max_branch,
+            ignore_index=ignore_index,
             shuffle=shuffle,
             compute=compute,
         )

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1227,8 +1227,8 @@ Dask Name: {name}, {task} tasks"""
             on,
             npartitions=npartitions,
             max_branch=max_branch,
-            ignore_index=ignore_index,
             shuffle=shuffle,
+            ignore_index=ignore_index,
             compute=compute,
         )
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -348,9 +348,12 @@ def rearrange_by_column(
     if shuffle == "disk":
         return rearrange_by_column_disk(df, col, npartitions, compute=compute)
     elif shuffle == "tasks":
-        return rearrange_by_column_tasks(
+        df2 = rearrange_by_column_tasks(
             df, col, max_branch, npartitions, ignore_index=ignore_index
         )
+        if ignore_index:
+            df2._meta = df2._meta.reset_index(drop=True)
+        return df2
     else:
         raise NotImplementedError("Unknown shuffle method %s" % shuffle)
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -991,7 +991,12 @@ def test_dataframe_shuffle_on_tasks_api(on, ignore_index, max_branch):
     )
     df_out_2 = df_in.shuffle(ext_on, shuffle="tasks", ignore_index=ignore_index)
 
-    assert_eq(df_out_1, df_out_2)
+    assert_eq(df_out_1, df_out_2, check_index=(not ignore_index))
+
+    if ignore_index:
+        assert df_out_1.index.dtype != df_in.index.dtype
+    else:
+        assert df_out_1.index.dtype == df_in.index.dtype
 
 
 def test_set_index_overlap():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -483,7 +483,10 @@ def group_split_pandas(df, c, k, ignore_index=False):
     )
     df2 = df.take(indexer)
     locations = locations.cumsum()
-    parts = [df2.iloc[a:b] for a, b in zip(locations[:-1], locations[1:])]
+    parts = [
+        df2.iloc[a:b].reset_index(drop=True) if ignore_index else df2.iloc[a:b]
+        for a, b in zip(locations[:-1], locations[1:])
+    ]
     return dict(zip(range(k), parts))
 
 


### PR DESCRIPTION
After thinking about [this comment](https://github.com/dask/dask/pull/6247#issuecomment-634816509) from @jcrist in #6247 , I decided to put some effort into making the pandas handling of `ignore_index` in `group_split_dispatch` more consistent with that of cudf (allowing us to test that the `ignore_index` argument is actually handled).  With the changes in this PR, passing `ignore_index=True` will ensure that the original index will be replaced with a default RangeIndex.

If others feel this is **not** actually the behavior we want, I'll be happy to close :)

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
