### PR TITLE
Histogram: support lazy values for range/bins (another way)

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -718,7 +718,7 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
 
     if density and isinstance(bins, Array) and bins.ndim == 0:
         raise NotImplementedError(
-            "When `density` is True, the number of bins cannot be a delayed Dask array. "
+            "When `density` is True, `bins` cannot be a scalar Dask object. "
             "It must be a concrete number or a (possibly-delayed) array/sequence of bin edges."
         )
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -777,11 +777,7 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
 
     # Turn graph into a 2D Array of shape (nchunks, nbins)
     nchunks = len(list(flatten(a.__dask_keys__())))
-    try:
-        nbins = len(bins) - 1
-    except TypeError:
-        # `bins` has a NaN in its chunks
-        nbins = float("nan")
+    nbins = bins.size  # since `bins` is 1D
     chunks = ((1,) * nchunks, (nbins,))
     mapped = Array(graph, name, chunks, dtype=dtype)
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -635,10 +635,6 @@ def digitize(a, bins, right=False):
     return a.map_blocks(np.digitize, dtype=dtype, bins=bins, right=right)
 
 
-def is_scalary(x):
-    return np.isscalar(x) or (isinstance(x, Array) and x.chunks == ())
-
-
 # TODO: dask linspace doesn't support delayed values
 def _linspace_from_delayed(start, stop, num=50):
     linspace_name = "linspace-" + tokenize(start, stop, num)
@@ -651,7 +647,7 @@ def _linspace_from_delayed(start, stop, num=50):
         linspace_name, linspace_dsk, dependencies=deps
     )
 
-    chunks = ((np.nan,),) if is_dask_collection(num) else ((num,),)
+    chunks = ((float("nan"),),) if is_dask_collection(num) else ((num,),)
     return Array(linspace_graph, linspace_name, chunks, dtype=float)
 
 
@@ -670,6 +666,8 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
       and a ``range`` argument is required as computing ``min`` and ``max``
       over blocked arrays is an expensive operation that must be performed
       explicitly.
+
+    - If ``bins`` is a single number, it cannot be a delayed value.
 
     - ``weights`` must be a dask.array.Array with the same block structure
       as ``a``.
@@ -696,11 +694,19 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
     >>> h.compute()
     array([5000, 5000])
     """
-    if bins is None or (is_scalary(bins) and range is None):
+    scalar_bins = np.isscalar(bins) or (isinstance(bins, np.ndarray) and bins.ndim == 0)
+
+    if bins is None or (scalar_bins and range is None):
         raise ValueError(
             "dask.array.histogram requires either specifying "
             "bins as an iterable or specifying both a range and "
             "the number of bins"
+        )
+
+    if isinstance(bins, Array) and bins.ndim == 0:
+        raise ValueError(
+            "The number of bins cannot be a delayed Dask array. It must be a concrete number, "
+            "or a (possibly-delayed) array/sequence of bin edges."
         )
 
     if weights is not None and weights.chunks != a.chunks:
@@ -728,10 +734,13 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
                 f"Expected a sequence or array for range, not {range}"
             ) from None
 
-    if is_scalary(bins):
+    token = tokenize(a, bins, range, weights, density)
+    name = "histogram-sum-" + token
+
+    if scalar_bins:
         bins = _linspace_from_delayed(range[0], range[1], bins + 1)
         # ^ NOTE `range[1]` is safe because of the above check, and the initial check
-        # that range must not be None if `is_scalary(bins)`
+        # that `range` must not be None if `scalar_bins` is True
     else:
         if not isinstance(bins, (Array, np.ndarray)):
             bins = asarray(bins)
@@ -739,9 +748,6 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
             raise ValueError(
                 f"bins must be a 1-dimensional array or sequence, got shape {bins.shape}"
             )
-
-    token = tokenize(a, bins, range, weights, density)
-    name = "histogram-sum-" + token
 
     (bins_ref, range_ref), deps = unpack_collections([bins, range])
 
@@ -768,12 +774,7 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
 
     # Turn graph into a 2D Array of shape (nchunks, nbins)
     nchunks = len(list(flatten(a.__dask_keys__())))
-    try:
-        nbins = len(bins) - 1
-    except TypeError:
-        # `bins` has a NaN in its chunks
-        nbins = float("nan")
-    chunks = ((1,) * nchunks, (nbins,))
+    chunks = ((1,) * nchunks, (len(bins) - 1,))
     mapped = Array(graph, name, chunks, dtype=dtype)
 
     # Sum over chunks to get the final histogram

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -789,7 +789,7 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
 
     # Turn graph into a 2D Array of shape (nchunks, nbins)
     nchunks = len(list(flatten(a.__dask_keys__())))
-    nbins = bins.size  # since `bins` is 1D
+    nbins = bins.size - 1  # since `bins` is 1D
     chunks = ((1,) * nchunks, (nbins,))
     mapped = Array(graph, name, chunks, dtype=dtype)
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -635,6 +635,10 @@ def digitize(a, bins, right=False):
     return a.map_blocks(np.digitize, dtype=dtype, bins=bins, right=right)
 
 
+def is_scalary(x):
+    return np.isscalar(x) or (isinstance(x, Array) and x.chunks == ())
+
+
 # TODO: dask linspace doesn't support delayed values
 def _linspace_from_delayed(start, stop, num=50):
     linspace_name = "linspace-" + tokenize(start, stop, num)
@@ -647,7 +651,7 @@ def _linspace_from_delayed(start, stop, num=50):
         linspace_name, linspace_dsk, dependencies=deps
     )
 
-    chunks = ((float("nan"),),) if is_dask_collection(num) else ((num,),)
+    chunks = ((np.nan,),) if is_dask_collection(num) else ((num,),)
     return Array(linspace_graph, linspace_name, chunks, dtype=float)
 
 
@@ -666,8 +670,6 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
       and a ``range`` argument is required as computing ``min`` and ``max``
       over blocked arrays is an expensive operation that must be performed
       explicitly.
-
-    - If ``bins`` is a single number, it cannot be a delayed value.
 
     - ``weights`` must be a dask.array.Array with the same block structure
       as ``a``.
@@ -694,19 +696,11 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
     >>> h.compute()
     array([5000, 5000])
     """
-    scalar_bins = np.isscalar(bins) or (isinstance(bins, np.ndarray) and bins.ndim == 0)
-
-    if bins is None or (scalar_bins and range is None):
+    if bins is None or (is_scalary(bins) and range is None):
         raise ValueError(
             "dask.array.histogram requires either specifying "
             "bins as an iterable or specifying both a range and "
             "the number of bins"
-        )
-
-    if isinstance(bins, Array) and bins.ndim == 0:
-        raise ValueError(
-            "The number of bins cannot be a delayed Dask array. It must be a concrete number, "
-            "or a (possibly-delayed) array/sequence of bin edges."
         )
 
     if weights is not None and weights.chunks != a.chunks:
@@ -734,13 +728,10 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
                 f"Expected a sequence or array for range, not {range}"
             ) from None
 
-    token = tokenize(a, bins, range, weights, density)
-    name = "histogram-sum-" + token
-
-    if scalar_bins:
+    if is_scalary(bins):
         bins = _linspace_from_delayed(range[0], range[1], bins + 1)
         # ^ NOTE `range[1]` is safe because of the above check, and the initial check
-        # that `range` must not be None if `scalar_bins` is True
+        # that range must not be None if `is_scalary(bins)`
     else:
         if not isinstance(bins, (Array, np.ndarray)):
             bins = asarray(bins)
@@ -748,6 +739,9 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
             raise ValueError(
                 f"bins must be a 1-dimensional array or sequence, got shape {bins.shape}"
             )
+
+    token = tokenize(a, bins, range, weights, density)
+    name = "histogram-sum-" + token
 
     (bins_ref, range_ref), deps = unpack_collections([bins, range])
 
@@ -774,7 +768,12 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
 
     # Turn graph into a 2D Array of shape (nchunks, nbins)
     nchunks = len(list(flatten(a.__dask_keys__())))
-    chunks = ((1,) * nchunks, (len(bins) - 1,))
+    try:
+        nbins = len(bins) - 1
+    except TypeError:
+        # `bins` has a NaN in its chunks
+        nbins = float("nan")
+    chunks = ((1,) * nchunks, (nbins,))
     mapped = Array(graph, name, chunks, dtype=dtype)
 
     # Sum over chunks to get the final histogram

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -659,6 +659,7 @@ def test_histogram_normed_deprecation():
         (10, [0]),
         (10, np.array([[0, 1]])),
         (10, da.array([[0, 1]])),
+        (da.array(10), [1, 10]),
         ([[0, 1, 2]], None),
         (np.array([[0, 1, 2]]), None),
         (da.array([[0, 1, 2]]), None),
@@ -675,8 +676,7 @@ def test_histogram_bin_range_raises(bins, hist_range):
 @pytest.mark.parametrize("density", [True, False])
 @pytest.mark.parametrize("weighted", [True, False])
 @pytest.mark.parametrize("non_delayed_i", [None, 0, 1])
-@pytest.mark.parametrize("delay_n_bins", [False, True])
-def test_histogram_delayed_range(density, weighted, non_delayed_i, delay_n_bins):
+def test_histogram_delayed_range(density, weighted, non_delayed_i):
     n = 100
     v = np.random.random(n)
     vd = da.from_array(v, chunks=10)
@@ -690,7 +690,7 @@ def test_histogram_delayed_range(density, weighted, non_delayed_i, delay_n_bins)
         d_range[non_delayed_i] = d_range[non_delayed_i].compute()
     hist_d, bins_d = da.histogram(
         vd,
-        bins=da.array(n) if delay_n_bins else n,
+        bins=n,
         range=d_range,
         density=density,
         weights=weights_d if weighted else None,

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -690,7 +690,7 @@ def test_histogram_delayed_range(density, weighted, non_delayed_i, delay_n_bins)
         d_range[non_delayed_i] = d_range[non_delayed_i].compute()
     hist_d, bins_d = da.histogram(
         vd,
-        bins=da.array(n) if delay_n_bins else n,
+        bins=da.array(n) if delay_n_bins and not density else n,
         range=d_range,
         density=density,
         weights=weights_d if weighted else None,
@@ -741,6 +741,14 @@ def test_histogram_delayed_bins(density, weighted):
     assert bins_d is bins_d2
     assert_eq(hist_d, hist)
     assert_eq(bins_d2, bins)
+
+
+def test_histogram_delayed_n_bins_raises_with_density():
+    data = da.random.random(10, chunks=2)
+    with pytest.raises(
+        NotImplementedError, match="number of bins cannot be a delayed Dask array"
+    ):
+        da.histogram(data, bins=da.array(10), range=[0, 1], density=True)
 
 
 def test_cov():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -659,7 +659,6 @@ def test_histogram_normed_deprecation():
         (10, [0]),
         (10, np.array([[0, 1]])),
         (10, da.array([[0, 1]])),
-        (da.array(10), [1, 10]),
         ([[0, 1, 2]], None),
         (np.array([[0, 1, 2]]), None),
         (da.array([[0, 1, 2]]), None),
@@ -676,7 +675,8 @@ def test_histogram_bin_range_raises(bins, hist_range):
 @pytest.mark.parametrize("density", [True, False])
 @pytest.mark.parametrize("weighted", [True, False])
 @pytest.mark.parametrize("non_delayed_i", [None, 0, 1])
-def test_histogram_delayed_range(density, weighted, non_delayed_i):
+@pytest.mark.parametrize("delay_n_bins", [False, True])
+def test_histogram_delayed_range(density, weighted, non_delayed_i, delay_n_bins):
     n = 100
     v = np.random.random(n)
     vd = da.from_array(v, chunks=10)
@@ -690,7 +690,7 @@ def test_histogram_delayed_range(density, weighted, non_delayed_i):
         d_range[non_delayed_i] = d_range[non_delayed_i].compute()
     hist_d, bins_d = da.histogram(
         vd,
-        bins=n,
+        bins=da.array(n) if delay_n_bins else n,
         range=d_range,
         density=density,
         weights=weights_d if weighted else None,

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -649,15 +649,98 @@ def test_histogram_normed_deprecation():
 
 
 @pytest.mark.parametrize(
-    "bins, hist_range", [(None, None), (10, None), (None, (1, 10))]
+    "bins, hist_range",
+    [
+        (None, None),
+        (10, None),
+        (10, 1),
+        (None, (1, 10)),
+        (10, [0, 1, 2]),
+        (10, [0]),
+        (10, np.array([[0, 1]])),
+        (10, da.array([[0, 1]])),
+        ([[0, 1, 2]], None),
+        (np.array([[0, 1, 2]]), None),
+        (da.array([[0, 1, 2]]), None),
+    ],
 )
 def test_histogram_bin_range_raises(bins, hist_range):
     data = da.random.random(10, chunks=2)
-    with pytest.raises(ValueError) as info:
+    with pytest.raises((ValueError, TypeError)) as info:
         da.histogram(data, bins=bins, range=hist_range)
     err_msg = str(info.value)
-    assert "bins" in err_msg
-    assert "range" in err_msg
+    assert "bins" in err_msg or "range" in err_msg
+
+
+@pytest.mark.parametrize("density", [True, False])
+@pytest.mark.parametrize("weighted", [True, False])
+@pytest.mark.parametrize("non_delayed_i", [None, 0, 1])
+@pytest.mark.parametrize("delay_n_bins", [False, True])
+def test_histogram_delayed_range(density, weighted, non_delayed_i, delay_n_bins):
+    n = 100
+    v = np.random.random(n)
+    vd = da.from_array(v, chunks=10)
+
+    if weighted:
+        weights = np.random.random(n)
+        weights_d = da.from_array(weights, chunks=vd.chunks)
+
+    d_range = [vd.min(), vd.max()]
+    if non_delayed_i is not None:
+        d_range[non_delayed_i] = d_range[non_delayed_i].compute()
+    hist_d, bins_d = da.histogram(
+        vd,
+        bins=da.array(n) if delay_n_bins else n,
+        range=d_range,
+        density=density,
+        weights=weights_d if weighted else None,
+    )
+
+    hist, bins = np.histogram(
+        v,
+        bins=n,
+        range=[v.min(), v.max()],
+        density=density,
+        weights=weights if weighted else None,
+    )
+
+    assert_eq(hist_d, hist)
+    assert_eq(bins_d, bins)
+
+
+@pytest.mark.parametrize("density", [True, False])
+@pytest.mark.parametrize("weighted", [True, False])
+def test_histogram_delayed_bins(density, weighted):
+    n = 100
+    v = np.random.random(n)
+    bins = np.array([0, 0.2, 0.5, 0.8, 1])
+
+    vd = da.from_array(v, chunks=10)
+    bins_d = da.from_array(bins, chunks=2)
+
+    if weighted:
+        weights = np.random.random(n)
+        weights_d = da.from_array(weights, chunks=vd.chunks)
+
+    hist_d, bins_d2 = da.histogram(
+        vd,
+        bins=bins_d,
+        range=[bins_d[0], bins_d[-1]],
+        density=density,
+        weights=weights_d if weighted else None,
+    )
+
+    hist, bins = np.histogram(
+        v,
+        bins=bins,
+        range=[bins[0], bins[-1]],
+        density=density,
+        weights=weights if weighted else None,
+    )
+
+    assert bins_d is bins_d2
+    assert_eq(hist_d, hist)
+    assert_eq(bins_d2, bins)
 
 
 def test_cov():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -746,7 +746,7 @@ def test_histogram_delayed_bins(density, weighted):
 def test_histogram_delayed_n_bins_raises_with_density():
     data = da.random.random(10, chunks=2)
     with pytest.raises(
-        NotImplementedError, match="number of bins cannot be a delayed Dask array"
+        NotImplementedError, match="`bins` cannot be a scalar Dask object"
     ):
         da.histogram(data, bins=da.array(10), range=[0, 1], density=True)
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

A perhaps-more-readable implementation of #6073, which leverages `dask.delayed.unpack_collections` to eliminate separate logic when `bins` and `range` are delayed versus concrete values (thanks for the tip @jcrist).

Unlike #6073, this also supports `bins` being a delayed scalar (in that case, the returned `bins` have unknown chunks)—_except_ when `density=True`, since `diff` fails on Arrays that contain NaN chunks.

I went back and forth (see commits) on whether to just not support `bins` as a delayed scalar at all, since it's awkward to document, arrays with unknown chunks are generally annoying/restrictive, and I'm not sure it's a common use-case. But I'm currently leaning towards supporting it anyway, except when `density=True`, since if someone wanted to implement a delayed version of a bin-selecting algorithm, they would appreciate having the flexibility.

Also addresses, but does not close, #4544.