### PR TITLE
Pad resample divisions so that edges are counted

### DIFF
--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -86,7 +86,7 @@ def _resample_bin_and_out_divs(divisions, rule, closed="left", label="left"):
             setter = lambda a, val: a.append(val)
         else:
             setter = lambda a, val: a.__setitem__(-1, val)
-        setter(newdivs, divisions[-1])
+        setter(newdivs, divisions[-1] + res)
         if outdivs[-1] > divisions[-1]:
             setter(outdivs, outdivs[-1])
         elif outdivs[-1] < divisions[-1]:

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -91,6 +91,43 @@ def test_resample_throws_error_when_parition_index_does_not_match_index():
         ds.resample("2M").count().compute()
 
 
+def test_resample_pads_last_division_to_avoid_off_by_one():
+    # https://github.com/dask/dask/issues/6230
+    times = [
+        1545362463409128000,
+        1545362504369352000,
+        1545362545326966000,
+        1545363118769636000,
+        1545363159726490000,
+        1545363200687178000,
+        1545363241648824000,
+        1573318190393973000,
+        1573318231353350000,
+        1573318272313774000,
+        1573318313275299000,
+        1573318354233962000,
+        1573318395195456000,
+        1573318436154609000,
+        1580687544437145000,
+        1580687585394881000,
+        1580687667316809000,
+        1580687708275414000,
+        1580687790195742000,
+        1580687831154951000,
+        1580687872115363000,
+        1580687954035133000,
+        1559127673402811000,
+    ]
+
+    df = pd.DataFrame({"Time": times, "Counts": range(len(times))})
+    df["Time"] = pd.to_datetime(df["Time"], utc=True)
+    expected = df.set_index("Time").resample("1Q").size()
+
+    ddf = dd.from_pandas(df, npartitions=2).set_index("Time")
+    actual = ddf.resample("1Q").size().compute()
+    assert_eq(actual, expected)
+
+
 def test_series_resample_not_implemented():
     index = pd.date_range(start="2012-01-02", periods=100, freq="T")
     s = pd.Series(range(len(index)), index=index)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

This is part of #6230