### PR TITLE
Re-add the `complete` extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ extras_require = {
     "diagnostics": ["bokeh >= 1.0.0"],
     "delayed": ["cloudpickle >= 0.2.2", "toolz >= 0.8.2"],
 }
+extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
 
 install_requires = ["pyyaml"]
 


### PR DESCRIPTION
Mistakenly removed when making pyyaml a required dependency.

See https://github.com/dask/dask/pull/6250#pullrequestreview-420264420.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
