### PR TITLE
Compress payload during shuffle operation

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -376,15 +376,18 @@ def pack_payload(df: DataFrame, group_key: Union[List[str], str]) -> DataFrame:
     Example::
 
         >>> import pandas as pd
-        ... import dask.dataframe as dd
-        ... from dask.dataframe.shuffle import pack_payload
-        ...
-        ... df = pd.DataFrame({"A": [1, 1] * 2 + [2, 2] * 2 + [3, 3] * 2, "B": range(12)})
-        ... ddf = dd.from_pandas(df, npartitions=2)
+        >>> import dask.dataframe as dd
+        >>> from dask.dataframe.shuffle import pack_payload
+
+        >>> df = pd.DataFrame({
+        ...    "A": [1, 1] * 2 + [2, 2] * 2 + [3, 3] * 2,
+        ...    "B": range(12)
+        ... })
+
+        >>> ddf = dd.from_pandas(df, npartitions=2)
 
         >>> ddf.partitions[0].compute()
-
-        A  B
+           A  B
         0  1  0
         1  1  1
         2  1  2
@@ -393,11 +396,9 @@ def pack_payload(df: DataFrame, group_key: Union[List[str], str]) -> DataFrame:
         5  2  5
 
         >>> pack_payload(ddf, "A").partitions[0].compute()
-
-        A                               __dask_payload_bytes
-        0  1  b'\x03\x00\x00\x00\x00\x00\x00\x00)\x00\x00\x03...
-        1  2  b'\x03\x00\x00\x00\x00\x00\x00\x00)\x00\x00\x03...
-
+           A                               __dask_payload_bytes
+        0  1  b'...
+        1  2  b'...
 
     """
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -402,7 +402,9 @@ def pack_payload(df: DataFrame, group_key: List[str]) -> DataFrame:
             res.columns = group_key + [_PAYLOAD_COL]
         else:
             res.name = _PAYLOAD_COL
-            res = pd.concat([partition[group_key], res], axis=1)
+            group = partition[group_key].drop_duplicates()
+            group.index = res.index
+            res = pd.concat([group, res], axis=1)
         return res
 
     return df.map_partitions(_pack_payload, meta=packed_meta)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1432,7 +1432,7 @@ def test_half_indexed_dataframe_avoids_shuffle():
 
     list_eq(c, cc)
 
-    assert len(cc.dask) < 500
+    assert len(cc.dask) < 525
 
 
 def test_errors_for_merge_on_frame_columns():


### PR DESCRIPTION
For jobs which process a dataframes with a significant amount of payload columns, shuffle operations can be incredibly memory consuming. Especially due to the multi stage algorithm, multiple copies of the data are in fact intended. Due to the multi stage shuffle we also need to (de)serialize these columns many times. However, for the shuffle itself these columns are effectively dead weight.

This change proposes to serialize (and more importantly compress) the payload columns during the shuffle operation which allows for a significant reduction in memory usage. Not only is the memory usage reduced (less spill to disk), but this also reduces the amount of IO (disk or network depending on the shuffle mode) and the overhead of (de)serializing "garbage". We've seen significant speed ups in runtime when testing this; even with reduced cluster sizes (I don't have proper benchmarks prepared yet but can follow up with some, if desired).

This is not ready to merge since it still fails for multiple environments (especially older pandas versions; The py3.8 job is successful with the exception of a failed doctest) and I will address these build failures if we are willing to accept this contribution.

To compress and serialize the payload, I'm using the `distributed.protocol` assuming that it is stable, fast, handles compression on the fly and allows for customization if desired (e.g. to use different serializers, arrow/parquet come to my mind but I haven't tested this lately). If there are other options for this format, I'm open for suggestions since atm this would obviously only work if distributed is installed.

The code itself is a bit messier than I would like to. I needed to use the `DataFrameGroupy.apply` which has the obvious downsides of being slow. I would argue, however, that this slowdown is acceptable, weighing in the performance gains I expect from this change.
On top of this, I observe funny/unstable behaviour of this function (It improves with more recent pandas versions but I consider it still unstable).
If somebody has a suggestion how to express this logic without using apply, I'd appreciate the input.

Thanks @crepererum for this cool idea

For completeness and transparency, we're building this currently into kartothek where we need to deal with fewer edge cases (see https://github.com/JDASoftwareGroup/kartothek/pull/286 ) but we would obviously prefer this to be part of dask itself.