### PR TITLE
Add high-level CSV Subgraph

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -39,6 +39,7 @@ class CSVSubgraph(Mapping):
         reader,
         blocks,
         is_first,
+        head,
         header,
         kwargs,
         dtypes,
@@ -51,10 +52,12 @@ class CSVSubgraph(Mapping):
         self.reader = reader
         self.blocks = blocks
         self.is_first = is_first
-        self.header = header
+        self.head = head if collection else None #example pandas DF for metadata
+        self.header = header #prepend to all blocks
         self.kwargs = kwargs
         self.dtypes = dtypes
         self.columns = columns
+        self.collection = collection
         self.enforce = enforce
         self.colname, self.paths = path or (None, None)
         self.delayed_pandas_read_text = delayed(pandas_read_text, pure=True)
@@ -353,6 +356,7 @@ def text_blocks_to_pandas(
         blocks,
         is_first,
         head,
+        header,
         kwargs,
         dtypes,
         columns,

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -35,6 +35,7 @@ class CSVSubgraph(Mapping):
     """
     Subgraph for reading CSV files.
     """
+
     def __init__(
         self,
         name,

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -330,7 +330,7 @@ def text_blocks_to_pandas(
     # Create mask of first blocks from nested block_lists
     is_first = tuple(block_mask(block_lists))
 
-    name = "read-csv-" + tokenize(reader, columns, enforce)
+    name = "read-csv-" + tokenize(reader, columns, enforce, head)
 
     if collection:
         if path:

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -365,6 +365,13 @@ def text_blocks_to_pandas(
 
 
 def block_mask(block_lists):
+    """
+    Yields a flat iterable of booleans to mark the zeroth elements of the
+    nested input ``block_lists`` in a flattened output.
+
+    >>> list(block_mask([[1, 2], [3, 4], [5]]))
+    [True, False, True, False, True]
+    """
     for block in block_lists:
         if not block:
             continue

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -21,7 +21,7 @@ from ...base import tokenize
 
 # this import checks for the importability of fsspec
 from ...bytes import read_bytes, open_file, open_files
-from ..core import new_dd_object
+from ..core import new_dd_object, DataFrame
 from ...core import flatten
 from ...delayed import delayed
 from ...utils import asciitable, parse_bytes, ensure_dict
@@ -79,23 +79,24 @@ class CSVSubgraph(Mapping):
         else:
             path_info = None
 
-        header = True
+        write_header = False
         rest_kwargs = self.kwargs.copy()
         if not self.is_first[i]:
-            header = False
+            write_header = True
             rest_kwargs.pop("skiprows", None)
 
-        # or self.delayed_pandas_read_text
-        return self.delayed_pandas_read_text(
-            self.reader,
-            block,
-            self.header,
-            self.kwargs,
-            self.dtypes,
-            self.columns,
-            write_header=False,
-            enforce=self.enforce,
-            path=path_info,
+        return from_delayed(
+            self.delayed_pandas_read_text(
+                self.reader,
+                block,
+                self.header,
+                rest_kwargs,
+                self.dtypes,
+                self.columns,
+                write_header=write_header,
+                enforce=self.enforce,
+                path=path_info,
+            )
         )
 
     def __len__(self):
@@ -333,46 +334,6 @@ def text_blocks_to_pandas(
     name = "read-csv-" + tokenize(
         reader, blocks, header, kwargs, dtypes, columns, collection, path,
     )
-
-    #    delayed_pandas_read_text = delayed(pandas_read_text, pure=True)
-    #    dfs = []
-    #    colname, paths = path or (None, None)
-    #
-    #    for i, blocks in enumerate(block_lists):
-    #        if not blocks:
-    #            continue
-    #        if path:
-    #            path_info = (colname, paths[i], paths)
-    #        else:
-    #            path_info = None
-    #        df = delayed_pandas_read_text(
-    #            reader,
-    #            blocks[0],
-    #            header,
-    #            kwargs,
-    #            dtypes,
-    #            columns,
-    #            write_header=False,
-    #            enforce=enforce,
-    #            path=path_info,
-    #        )
-    #
-    #        dfs.append(df)
-    #        rest_kwargs = kwargs.copy()
-    #        rest_kwargs.pop("skiprows", None)
-    #        for b in blocks[1:]:
-    #            dfs.append(
-    #                delayed_pandas_read_text(
-    #                    reader,
-    #                    b,
-    #                    header,
-    #                    rest_kwargs,
-    #                    dtypes,
-    #                    columns,
-    #                    enforce=enforce,
-    #                    path=path_info,
-    #                )
-    #            )
 
     if collection:
         if path:

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -21,12 +21,11 @@ from ...base import tokenize
 
 # this import checks for the importability of fsspec
 from ...bytes import read_bytes, open_file, open_files
-from ..core import new_dd_object, DataFrame
+from ..core import new_dd_object
 from ...core import flatten
 from ...delayed import delayed
-from ...utils import asciitable, parse_bytes, ensure_dict
+from ...utils import asciitable, parse_bytes
 from ..utils import clear_known_categories
-from .io import from_delayed
 
 import fsspec.implementations.local
 from fsspec.compression import compr

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -186,8 +186,7 @@ def test_text_blocks_to_pandas_simple(reader, files):
     assert isinstance(df, dd.DataFrame)
     assert list(df.columns) == ["name", "amount", "id"]
 
-    values = text_blocks_to_pandas(
-        reader, blocks, header, head, kwargs)
+    values = text_blocks_to_pandas(reader, blocks, header, head, kwargs)
     assert isinstance(values, dd.DataFrame)
     assert hasattr(values, "dask")
     assert len(values.dask) == 3
@@ -303,9 +302,7 @@ def test_enforce_columns(reader, blocks):
     head = reader(BytesIO(blocks[0][0]), header=0)
     header = blocks[0][0].split(b"\n")[0] + b"\n"
     with pytest.raises(ValueError):
-        dfs = text_blocks_to_pandas(
-            reader, blocks, header, head, {}, enforce=True
-        )
+        dfs = text_blocks_to_pandas(reader, blocks, header, head, {}, enforce=True)
         dask.compute(*dfs, scheduler="sync")
 
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -182,13 +182,12 @@ def test_text_blocks_to_pandas_simple(reader, files):
     head = pandas_read_text(reader, files["2014-01-01.csv"], b"", {})
     header = files["2014-01-01.csv"].split(b"\n")[0] + b"\n"
 
-    df = text_blocks_to_pandas(reader, blocks, header, head, kwargs, collection=True)
+    df = text_blocks_to_pandas(reader, blocks, header, head, kwargs)
     assert isinstance(df, dd.DataFrame)
     assert list(df.columns) == ["name", "amount", "id"]
 
     values = text_blocks_to_pandas(
-        reader, blocks, header, head, kwargs, collection=False
-    )
+        reader, blocks, header, head, kwargs)
     assert isinstance(values, dd.DataFrame)
     assert hasattr(values, "dask")
     assert len(values.dask) == 3
@@ -204,7 +203,7 @@ def test_text_blocks_to_pandas_kwargs(reader, files):
     head = pandas_read_text(reader, files["2014-01-01.csv"], b"", kwargs)
     header = files["2014-01-01.csv"].split(b"\n")[0] + b"\n"
 
-    df = text_blocks_to_pandas(reader, blocks, header, head, kwargs, collection=True)
+    df = text_blocks_to_pandas(reader, blocks, header, head, kwargs)
     assert list(df.columns) == ["name", "id"]
     result = df.compute()
     assert (result.columns == df.columns).all()
@@ -289,7 +288,7 @@ tsv_blocks = [
 def test_enforce_dtypes(reader, blocks):
     head = reader(BytesIO(blocks[0][0]), header=0)
     header = blocks[0][0].split(b"\n")[0] + b"\n"
-    dfs = text_blocks_to_pandas(reader, blocks, header, head, {}, collection=False)
+    dfs = text_blocks_to_pandas(reader, blocks, header, head, {})
     dfs = dask.compute(dfs, scheduler="sync")
     assert all(df.dtypes.to_dict() == head.dtypes.to_dict() for df in dfs)
 
@@ -305,7 +304,7 @@ def test_enforce_columns(reader, blocks):
     header = blocks[0][0].split(b"\n")[0] + b"\n"
     with pytest.raises(ValueError):
         dfs = text_blocks_to_pandas(
-            reader, blocks, header, head, {}, collection=False, enforce=True
+            reader, blocks, header, head, {}, enforce=True
         )
         dask.compute(*dfs, scheduler="sync")
 
@@ -455,7 +454,7 @@ def test_read_csv_include_path_column_is_dtype_category(dd_read, files):
         assert df.path.dtype == "category"
         assert has_known_categories(df.path)
 
-        dfs = dd_read("2014-01-*.csv", include_path_column=True, collection=False)
+        dfs = dd_read("2014-01-*.csv", include_path_column=True)
         result = dfs.compute()
         assert result.path.dtype == "category"
         assert has_known_categories(result.path)


### PR DESCRIPTION
Very much still a work-in-progress -- no optimizations applied yet, but CSV reading works as expected (some test failures because of `read_table` stuff and also some non-deterministic task naming I need to fix).

This was a little hairier than I expected since sticking `delayed` objects inside of other subgraphs was causing problems like `Delayed objects of unspecified length have no len()`.  Or at least I didn't get it to work the first time around, so this instead has switched a few things to just construct the graph directly ( and one particularly heinous hack of unpacking a delayed graph).

Definitely not ready for review, but throwing it up here so I don't forget to come back to it.

cc @TomAugspurger 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
