### PR TITLE
Remove `NotImplementedError` in resample with rule 

### DIFF
--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -124,16 +124,7 @@ class Resampler(object):
             )
             raise ValueError(msg)
         self.obj = obj
-        rule = pd.tseries.frequencies.to_offset(rule)
-        day_nanos = pd.tseries.frequencies.Day().nanos
-
-        if getnanos(rule) and day_nanos % rule.nanos:
-            raise NotImplementedError(
-                "Resampling frequency %s that does"
-                " not evenly divide a day is not "
-                "implemented" % rule
-            )
-        self._rule = rule
+        self._rule = pd.tseries.frequencies.to_offset(rule)
         self._kwargs = kwargs
 
     def _agg(self, how, meta=None, fill_value=np.nan, how_args=(), how_kwargs={}):

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -130,6 +130,7 @@ def test_resample_pads_last_division_to_avoid_off_by_one():
 
 def test_resample_does_not_evenly_divide_day():
     import numpy as np
+
     p = 100
     index = pd.date_range(start="2012-01-02", periods=p, freq="H")
     df = pd.DataFrame({"p": np.random.random(p)}, index=index)

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -128,12 +128,28 @@ def test_resample_pads_last_division_to_avoid_off_by_one():
     assert_eq(actual, expected)
 
 
-def test_series_resample_not_implemented():
+def test_resample_does_not_evenly_divide_day():
+    import numpy as np
+    p = 100
+    index = pd.date_range(start="2012-01-02", periods=p, freq="H")
+    df = pd.DataFrame({"p": np.random.random(p)}, index=index)
+    ddf = dd.from_pandas(df, npartitions=5)
+    # Frequency doesn't evenly divide day
+    expected = df.resample("2D").count()
+    result = ddf.resample("2D").count().compute()
+
+    assert_eq(result, expected)
+
+
+def test_series_resample_does_not_evenly_divide_day():
     index = pd.date_range(start="2012-01-02", periods=100, freq="T")
     s = pd.Series(range(len(index)), index=index)
     ds = dd.from_pandas(s, npartitions=5)
     # Frequency doesn't evenly divide day
-    pytest.raises(NotImplementedError, lambda: resample(ds, "57T"))
+    expected = s.resample("57T").mean()
+    result = ds.resample("57T").mean().compute()
+
+    assert_eq(result, expected)
 
 
 def test_unknown_divisions_error():

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -131,9 +131,9 @@ def test_resample_pads_last_division_to_avoid_off_by_one():
 def test_resample_does_not_evenly_divide_day():
     import numpy as np
 
-    p = 100
-    index = pd.date_range(start="2012-01-02", periods=p, freq="H")
-    df = pd.DataFrame({"p": np.random.random(p)}, index=index)
+    index = pd.date_range("2012-01-02", "2012-02-02", freq="H")
+    index = index.union(pd.date_range("2012-03-02", "2012-04-02", freq="H"))
+    df = pd.DataFrame({"p": np.random.random(len(index))}, index=index)
     ddf = dd.from_pandas(df, npartitions=5)
     # Frequency doesn't evenly divide day
     expected = df.resample("2D").count()

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -143,7 +143,10 @@ def test_resample_does_not_evenly_divide_day():
 
 
 def test_series_resample_does_not_evenly_divide_day():
-    index = pd.date_range(start="2012-01-02", periods=100, freq="T")
+    index = pd.date_range("2012-01-02 00:00:00", "2012-01-02 01:00:00", freq="T")
+    index = index.union(
+        pd.date_range("2012-01-02 06:00:00", "2012-01-02 08:00:00", freq="T")
+    )
     s = pd.Series(range(len(index)), index=index)
     ds = dd.from_pandas(s, npartitions=5)
     # Frequency doesn't evenly divide day


### PR DESCRIPTION
This PR closes #6271

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
