### PR TITLE
Make index.map clear divisions.

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3015,7 +3015,7 @@ Dask Name: {name}, {task} tasks""".format(
         else:
             meta = make_meta(meta, index=getattr(make_meta(self), "index", None))
 
-        return self.__class__(graph, name, meta, self.divisions)
+        return type(self)(graph, name, meta, self.divisions)
 
     @derived_from(pd.Series)
     def dropna(self):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2998,9 +2998,6 @@ Dask Name: {name}, {task} tasks""".format(
     @insert_meta_param_description(pad=12)
     @derived_from(pd.Series)
     def map(self, arg, na_action=None, meta=no_default):
-        """
-        Note that the index and divisions are assumed to remain unchanged.
-        """
         if is_series_like(arg) and is_dask_collection(arg):
             return series_map(self, arg)
         if not (
@@ -3391,6 +3388,14 @@ class Index(Series):
                 )
             else:
                 return self.map_partitions(M.to_frame, meta=self._meta.to_frame())
+
+    @insert_meta_param_description(pad=12)
+    @derived_from(pd.Series)
+    def map(self, arg, na_action=None, meta=no_default):
+        """
+        Note that the index and divisions are assumed to remain unchanged.
+        """
+        return super().map(arg, na_action=na_action, meta=meta)
 
 
 class DataFrame(_Frame):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2998,6 +2998,9 @@ Dask Name: {name}, {task} tasks""".format(
     @insert_meta_param_description(pad=12)
     @derived_from(pd.Series)
     def map(self, arg, na_action=None, meta=no_default):
+        """
+        Note that the index and divisions are assumed to remain unchanged.
+        """
         if is_series_like(arg) and is_dask_collection(arg):
             return series_map(self, arg)
         if not (

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -443,12 +443,6 @@ Dask Name: {name}, {task} tasks"""
 
     @index.setter
     def index(self, value):
-        warnings.warn(
-            "Assigning values to index is deprecated since dask 2.18.0 "
-            "and will be an error in a future release. To silence this warning, "
-            "use the syntax set_index(value) instead.",
-            FutureWarning,
-        )
         self.divisions = value.divisions
         result = map_partitions(
             methods.assign_index, self, value, enforce_metadata=False
@@ -3021,7 +3015,7 @@ Dask Name: {name}, {task} tasks""".format(
         else:
             meta = make_meta(meta, index=getattr(make_meta(self), "index", None))
 
-        return Series(graph, name, meta, self.divisions)
+        return self.__class__(graph, name, meta, self.divisions)
 
     @derived_from(pd.Series)
     def dropna(self):
@@ -3393,9 +3387,14 @@ class Index(Series):
     @derived_from(pd.Series)
     def map(self, arg, na_action=None, meta=no_default):
         """
-        Note that the index and divisions are assumed to remain unchanged.
+        Note that this method clears any known divisions.
+
         """
-        return super().map(arg, na_action=na_action, meta=meta)
+        return (
+            super(Index, self)
+            .map(arg, na_action=na_action, meta=meta)
+            .clear_divisions()
+        )
 
 
 class DataFrame(_Frame):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -443,6 +443,12 @@ Dask Name: {name}, {task} tasks"""
 
     @index.setter
     def index(self, value):
+        warnings.warn(
+            "Assigning values to index is deprecated since dask 2.18.0 "
+            "and will be an error in a future release. To silence this warning, "
+            "use the syntax set_index(value) instead.",
+            FutureWarning,
+        )
         self.divisions = value.divisions
         result = map_partitions(
             methods.assign_index, self, value, enforce_metadata=False

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4108,8 +4108,12 @@ def test_map_index():
     ddf = dd.from_pandas(df, npartitions=2)
     assert ddf.known_divisions is True
 
-    actual = ddf.index.map(lambda x: x * 10)
-    assert actual.known_divisions is False
+    cleared = ddf.index.map(lambda x: x * 10)
+    assert cleared.known_divisions is False
+
+    applied = ddf.index.map(lambda x: x * 10, is_monotonic=True)
+    assert applied.known_divisions is True
+    assert applied.divisions == tuple(x * 10 for x in ddf.divisions)
 
 
 def test_assign_index():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4103,13 +4103,22 @@ def test_meta_error_message():
     assert "pandas" in str(info.value)
 
 
-def test_assign_index_raises_deprecation_warning():
+def test_map_index():
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert ddf.known_divisions is True
+
+    actual = ddf.index.map(lambda x: x * 10)
+    assert actual.known_divisions is False
+
+
+def test_assign_index():
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5]})
     ddf = dd.from_pandas(df, npartitions=2)
 
     ddf_copy = ddf.copy()
-    with pytest.warns(FutureWarning, match="deprecated"):
-        ddf.index = ddf.index * 10
+
+    ddf.index = ddf.index * 10
 
     expected = df.copy()
     expected.index = expected.index * 10

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4103,13 +4103,13 @@ def test_meta_error_message():
     assert "pandas" in str(info.value)
 
 
-def test_assign_index():
+def test_assign_index_raises_deprecation_warning():
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5]})
     ddf = dd.from_pandas(df, npartitions=2)
 
     ddf_copy = ddf.copy()
-
-    ddf.index = ddf.index * 10
+    with pytest.warns(FutureWarning, match="deprecated"):
+        ddf.index = ddf.index * 10
 
     expected = df.copy()
     expected.index = expected.index * 10


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
- [x] Closes #6265

~~@TomAugspurger I added a deprecation warning to the index setter, I think it's better to force people to use the `set_index` syntax so they know that it will be expensive.~~ I am now taking the opposite approach in this PR and making index.map clear divisions. 