### PR TITLE
Improve performance of HighLevelGraph construction

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -85,40 +85,8 @@ class HighLevelGraph(Mapping):
         return self.layers
 
     @classmethod
-    def from_collection(cls, name, layer, collection):
-        """ Construct a HighLevelGraph from a new layer and a collection
-
-        This constructs a HighLevelGraph in the common case where we have a single
-        new layer and one collection on which we want to depend.
-
-        This pulls out the ``__dask_layers__()`` method of the collection if
-        it exists, and adds them to the dependencies for this new layer.  It
-        also merges all of the layers from all of the dependent collections
-        together into the new layers for this graph.
-
-        Parameters
-        ----------
-        name : str
-            The name of the new layer
-        layer : Mapping
-            The graph layer itself
-        collection : Dask collections
-            A dask collections (like array or dataframe) that
-            has a graph of itself
-
-        Examples
-        --------
-
-        In typical usage we make a new task layer, and then pass that layer
-        along with all dependent collections to this method.
-
-        >>> def add(self, other):
-        ...     name = 'add-' + tokenize(self, other)
-        ...     layer = {(name, i): (add, input_key, other)
-        ...              for i, input_key in enumerate(self.__dask_keys__())}
-        ...     graph = HighLevelGraph.from_collection(name, layer, self)
-        ...     return new_collection(name, graph)
-        """
+    def _from_collection(cls, name, layer, collection):
+        """ `from_collections` optimized for a single collection """
         if is_dask_collection(collection):
             graph = collection.__dask_graph__()
             if isinstance(graph, HighLevelGraph):

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -143,7 +143,7 @@ class HighLevelGraph(Mapping):
         ...     return new_collection(name, graph)
         """
         if len(dependencies) == 1:
-            return cls.from_collection(name, layer, dependencies[0])
+            return cls._from_collection(name, layer, dependencies[0])
         layers = {name: layer}
         deps = {}
         deps[name] = set()

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -133,7 +133,7 @@ class HighLevelGraph(Mapping):
                 except AttributeError:
                     key = id(graph)
                 layers = {name: layer, key: graph}
-                deps = {name: set(key), key: set()}
+                deps = {name: {key}, key: set()}
         else:
             raise TypeError(type(collection))
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -85,6 +85,61 @@ class HighLevelGraph(Mapping):
         return self.layers
 
     @classmethod
+    def from_collection(cls, name, layer, collection):
+        """ Construct a HighLevelGraph from a new layer and a collection
+
+        This constructs a HighLevelGraph in the common case where we have a single
+        new layer and one collection on which we want to depend.
+
+        This pulls out the ``__dask_layers__()`` method of the collection if
+        it exists, and adds them to the dependencies for this new layer.  It
+        also merges all of the layers from all of the dependent collections
+        together into the new layers for this graph.
+
+        Parameters
+        ----------
+        name : str
+            The name of the new layer
+        layer : Mapping
+            The graph layer itself
+        collection : Dask collections
+            A dask collections (like array or dataframe) that
+            has a graph of itself
+
+        Examples
+        --------
+
+        In typical usage we make a new task layer, and then pass that layer
+        along with all dependent collections to this method.
+
+        >>> def add(self, other):
+        ...     name = 'add-' + tokenize(self, other)
+        ...     layer = {(name, i): (add, input_key, other)
+        ...              for i, input_key in enumerate(self.__dask_keys__())}
+        ...     graph = HighLevelGraph.from_collection(name, layer, self)
+        ...     return new_collection(name, graph)
+        """
+        if is_dask_collection(collection):
+            graph = collection.__dask_graph__()
+            if isinstance(graph, HighLevelGraph):
+                layers = graph.layers.copy()
+                layers.update({name: layer})
+                deps = graph.dependencies.copy()
+                with ignoring(AttributeError):
+                    deps.update({name: set(collection.__dask_layers__())})
+            else:
+                try:
+                    [key] = collection.__dask_layers__()
+                except AttributeError:
+                    key = id(graph)
+                layers = {key: graph}
+                deps = {name: set(key), key: set()}
+        else:
+            raise TypeError(type(collection))
+
+        return cls(layers, deps)
+
+    @classmethod
     def from_collections(cls, name, layer, dependencies=()):
         """ Construct a HighLevelGraph from a new layer and a set of collections
 
@@ -119,6 +174,8 @@ class HighLevelGraph(Mapping):
         ...     graph = HighLevelGraph.from_collections(name, layer, dependencies=[self])
         ...     return new_collection(name, graph)
         """
+        if len(dependencies) == 1:
+            return cls.from_collection(name, layer, dependencies[0])
         layers = {name: layer}
         deps = {}
         deps[name] = set()

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -132,7 +132,7 @@ class HighLevelGraph(Mapping):
                     [key] = collection.__dask_layers__()
                 except AttributeError:
                     key = id(graph)
-                layers = {key: graph}
+                layers = {name: layer, key: graph}
                 deps = {name: set(key), key: set()}
         else:
             raise TypeError(type(collection))


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
- [x] Towards #5913

I think this is a better approach and will result in speedups in many other cases as well. This now takes ~10sec on my machine (down from ~20sec).

```python
%%snakeviz
sub_arrays = [
    da.from_delayed(
        dask.delayed(np.zeros)((100000,), dtype="int64"), 
        shape=(100000,), 
        dtype="int64", 
        name=idx
    ) 
    for idx in range(10000)
]

stacked = da.stack(sub_arrays)
for i in range(len(sub_arrays)):
    stacked[i]
```
