### PR TITLE
Add asyncssh intersphinx mappings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -318,6 +318,10 @@ intersphinx_mapping = {
         "https://docs.scipy.org/doc/numpy/",
         "https://docs.scipy.org/doc/numpy/objects.inv",
     ),
+    "asyncssh": (
+        "https://asyncssh.readthedocs.io/en/latest/",
+        "https://asyncssh.readthedocs.io/en/latest/objects.inv",
+    )
 }
 
 # Redirects


### PR DESCRIPTION
Add `asyncssh` intersphinx mappings for `distributed.deploy.SSHCluster` docstrings.

See dask/distributed#3861 for usage.