### PR TITLE
Fix import failing when using "python -OO"

### DIFF
--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -170,6 +170,4 @@ def full_like(a, fill_value, *args, **kwargs):
 
 
 full.__doc__ = _full.__doc__
-full.__name__ = _full.__name__
 full_like.__doc__ = _full_like.__doc__
-full_like.__name__ = _full_like.__name__


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
- [x] Fixes #6296

cc @dask/maintenance 
 
To test: try `python -OO -c 'import dask.array'`  on this branch vs master.