### PR TITLE
Fix exception causes in utils.py

### DIFF
--- a/dask/utils.py
+++ b/dask/utils.py
@@ -96,8 +96,8 @@ def import_required(mod_name, error_msg):
     """
     try:
         return import_module(mod_name)
-    except ImportError:
-        raise RuntimeError(error_msg)
+    except ImportError as e:
+        raise RuntimeError(error_msg) from e
 
 
 @contextmanager
@@ -1224,13 +1224,13 @@ def parse_bytes(s):
 
     try:
         n = float(prefix)
-    except ValueError:
-        raise ValueError("Could not interpret '%s' as a number" % prefix)
+    except ValueError as e:
+        raise ValueError("Could not interpret '%s' as a number" % prefix) from e
 
     try:
         multiplier = byte_sizes[suffix.lower()]
-    except KeyError:
-        raise ValueError("Could not interpret '%s' as a byte unit" % suffix)
+    except KeyError as e:
+        raise ValueError("Could not interpret '%s' as a byte unit" % suffix) from e
 
     result = n * multiplier
     return int(result)


### PR DESCRIPTION
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 