### PR TITLE
fix duplicated tests

### DIFF
--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -52,7 +52,7 @@ def test_errors():
     assert "unknown chunk sizes" in str(excpt.value)
 
 
-def test_repr_html():
+def test_repr_html_size_units():
     x = da.ones((10000, 5000))
     x = da.ones((3000, 10000), chunks=(1000, 1000))
     text = x._repr_html_()

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -390,7 +390,7 @@ def test_merge_asof_left_on_right_index(
             assert_eq(c, C)
 
 
-def test_merge_asof_indexed():
+def test_merge_asof_indexed_two_partitions():
     A = pd.DataFrame({"left_val": ["a", "b", "c"]}, index=[1, 5, 10])
     a = dd.from_pandas(A, npartitions=2)
     B = pd.DataFrame({"right_val": [1, 2, 3, 6, 7]}, index=[1, 2, 3, 6, 7])


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

This pull request proposes fixing a minor issue: there are two tests whose names are duplicated within the same module. When test names are duplicated within a module, `pytest` will only run the one defined last.

Thanks for your time and consideration.