### PR TITLE
Attempt to resolve: https://github.com/dask/dask/issues/6307

### DIFF
--- a/docs/source/dataframe-design.rst
+++ b/docs/source/dataframe-design.rst
@@ -119,3 +119,22 @@ divided.  In this case ``.divisions`` will be all ``None``:
 In these cases, any operation that requires a cleanly partitioned DataFrame with
 known divisions will have to perform a sort.  This can generally achieved by
 calling ``df.set_index(...)``.
+
+
+.. _dataframe-design-groupby:
+
+Groupby
+-------
+
+By default, groupby methods return an object with only 1 partition. This is to
+optimize performance, and assumes the groupby reduction returns an object that
+is small enough to fit into memory. If your returned object is larger than this,
+you can increase the number of output partitions using the `split_out` argument.
+
+.. code-block:: python
+
+   result = df.groupby('id').value.mean()
+   result.npartitions  # returns 1
+
+   result = df.groupby('id').value.mean(split_out=8)
+   result.npartitions  # returns 8


### PR DESCRIPTION
* Add function (that is called by derived_from) to update docstrings for methods containing the `split_out` parameter.
* Add `split_out` documentation to dataframe best practices.

- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
