### PR TITLE
Define __tracebackhide__ in assert_eq

### DIFF
--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -789,6 +789,8 @@ def assert_eq(
     check_index=True,
     **kwargs,
 ):
+    __tracebackhide__ = True
+
     if check_divisions:
         assert_divisions(a)
         assert_divisions(b)


### PR DESCRIPTION
Defines `__tracebackhide__` in assert_eq for nicer results.
https://docs.pytest.org/en/latest/example/simple.html

With this, it's more important that the messages in the assert are more
meaningful, since the context is hidden. I've done just a bit, but there's
room for improvement.

New

```pytb
________________________________________________________________________ test_array ________________________________________________________________________

    def test_array():
        a = da.ones((4, 4), chunks=(2, 2))
        b = np.zeros((5, 5))
>       da.utils.assert_eq(a, b)
E       AssertionError: ((4, 4), (5, 5))

test_foo.py:10: AssertionError
________________________________________________________________________ test_frame ________________________________________________________________________

    def test_frame():
        a = dd.from_pandas(pd.DataFrame({"A": [1, 2, 2]}), 2)
        b = pd.DataFrame({"A": [1, 2, 3]})
>       dd.utils.assert_eq(a, b)

test_foo.py:16:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pandas/_libs/testing.pyx:68: in pandas._libs.testing.assert_almost_equal
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   AssertionError: DataFrame.iloc[:, 0] (column name="A") are different
E
E   DataFrame.iloc[:, 0] (column name="A") values are different (33.33333 %)
E   [index]: [0, 1, 2]
E   [left]:  [1, 2, 2]
E   [right]: [1, 2, 3]

pandas/_libs/testing.pyx:183: AssertionError
```

old:

```pytb
________________________________________________________________________ test_array ________________________________________________________________________

    def test_array():
        a = da.ones((4, 4), chunks=(2, 2))
        b = np.zeros((5, 5))
>       da.utils.assert_eq(a, b)

test_foo.py:10:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

a = array([[1., 1., 1., 1.],
       [1., 1., 1., 1.],
       [1., 1., 1., 1.],
       [1., 1., 1., 1.]])
b = array([[0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.]])
check_shape = True, check_graph = True, check_meta = True, kwargs = {}
a_original = dask.array<ones, shape=(4, 4), dtype=float64, chunksize=(2, 2), chunktype=numpy.ndarray>
b_original = array([[0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.]])
adt = dtype('float64'), a_meta = array([], shape=(0, 0), dtype=float64)
a_computed = array([[1., 1., 1., 1.],
       [1., 1., 1., 1.],
       [1., 1., 1., 1.],
       [1., 1., 1., 1.]]), bdt = dtype('float64'), b_meta = None

    def assert_eq(a, b, check_shape=True, check_graph=True, check_meta=True, **kwargs):
        a_original = a
        b_original = b

        a, adt, a_meta, a_computed = _get_dt_meta_computed(
            a, check_shape=check_shape, check_graph=check_graph
        )
        b, bdt, b_meta, b_computed = _get_dt_meta_computed(
            b, check_shape=check_shape, check_graph=check_graph
        )

        if str(adt) != str(bdt):
            # Ignore check for matching length of flexible dtypes, since Array._meta
            # can't encode that information
            if adt.type == bdt.type and not (adt.type == np.bytes_ or adt.type == np.str_):
                diff = difflib.ndiff(str(adt).splitlines(), str(bdt).splitlines())
                raise AssertionError(
                    "string repr are different" + os.linesep + os.linesep.join(diff)
                )

        try:
>           assert a.shape == b.shape
E           AssertionError

dask/array/utils.py:246: AssertionError
________________________________________________________________________ test_frame ________________________________________________________________________

    def test_frame():
        a = dd.from_pandas(pd.DataFrame({"A": [1, 2, 2]}), 2)
        b = pd.DataFrame({"A": [1, 2, 3]})
>       dd.utils.assert_eq(a, b)

test_foo.py:16:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
dask/dataframe/utils.py:813: in assert_eq
    tm.assert_frame_equal(a, b, **kwargs)
pandas/_libs/testing.pyx:68: in pandas._libs.testing.assert_almost_equal
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   AssertionError: DataFrame.iloc[:, 0] (column name="A") are different
E
E   DataFrame.iloc[:, 0] (column name="A") values are different (33.33333 %)
E   [index]: [0, 1, 2]
E   [left]:  [1, 2, 2]
E   [right]: [1, 2, 3]

pandas/_libs/testing.pyx:183: AssertionError
```

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
