### PR TITLE
Update expected error msg for protocol difference in fsspec

### DIFF
--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -1,5 +1,5 @@
+import os
 import copy
-from pathlib import Path
 
 from fsspec.core import (  # noqa: F401
     OpenFile,  # noqa: F401
@@ -91,8 +91,8 @@ def read_bytes(
         represented in the corresponding block.
 
     """
-    if not isinstance(urlpath, (str, list, tuple, Path)):
-        raise TypeError("Path should be a string, pathlib.Path, list or tuple")
+    if not isinstance(urlpath, (str, list, tuple, os.PathLike)):
+        raise TypeError("Path should be a string, os.PathLike, list or tuple")
 
     fs, fs_token, paths = get_fs_token_paths(urlpath, mode="rb", storage_options=kwargs)
 

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -1,4 +1,5 @@
 import copy
+from pathlib import Path
 
 from fsspec.core import (  # noqa: F401
     OpenFile,  # noqa: F401
@@ -90,6 +91,9 @@ def read_bytes(
         represented in the corresponding block.
 
     """
+    if not isinstance(urlpath, (str, list, tuple, Path)):
+        raise TypeError("Path should be a string, pathlib.Path, list or tuple")
+
     fs, fs_token, paths = get_fs_token_paths(urlpath, mode="rb", storage_options=kwargs)
 
     if len(paths) == 0:

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -70,7 +70,7 @@ def test_urlpath_inference_errors():
         get_fs_token_paths([])
 
     # Protocols differ
-    with pytest.raises(ValueError, match="the same protocol"):
+    with pytest.raises(ValueError, match="Protocol mismatch"):
         get_fs_token_paths(["s3://test/path.csv", "/other/path.csv"])
 
     # Options differ
@@ -80,17 +80,6 @@ def test_urlpath_inference_errors():
                 "ftp://myuser@node.com/test/path.csv",
                 "ftp://otheruser@node.com/other/path.csv",
             ]
-        )
-
-    # Unknown type
-    with pytest.raises(TypeError):
-        get_fs_token_paths(
-            {
-                "sets/are.csv",
-                "unordered/so/they.csv",
-                "should/not/be.csv",
-                "allowed.csv",
-            }
         )
 
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -83,6 +83,20 @@ def test_urlpath_inference_errors():
         )
 
 
+def test_unordered_urlpath_errors():
+
+    # Unordered urlpath argument
+    with pytest.raises(TypeError):
+        read_bytes(
+            {
+                "sets/are.csv",
+                "unordered/so/they.csv",
+                "should/not/be.csv",
+                "allowed.csv",
+            }
+        )
+
+
 def test_urlpath_expand_read():
     """Make sure * is expanded in file paths when reading."""
     # when reading, globs should be expanded to read files by mask

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -64,25 +64,6 @@ def test_urlpath_inference_strips_protocol(tmpdir):
     assert paths2 == paths3
 
 
-def test_urlpath_inference_errors():
-    # Empty list
-    with pytest.raises(ValueError, match="empty"):
-        get_fs_token_paths([])
-
-    # Protocols differ
-    with pytest.raises(ValueError, match="Protocol mismatch"):
-        get_fs_token_paths(["s3://test/path.csv", "/other/path.csv"])
-
-    # Options differ
-    with pytest.raises(ValueError, match="the same file-system options"):
-        get_fs_token_paths(
-            [
-                "ftp://myuser@node.com/test/path.csv",
-                "ftp://otheruser@node.com/other/path.csv",
-            ]
-        )
-
-
 def test_unordered_urlpath_errors():
 
     # Unordered urlpath argument


### PR DESCRIPTION
Also remove check for error is a set of filenames is passed in as this
is now supported upstream.

Fixes #6327 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Open question around whether a `set` of filenames is OK.  I've removed the test for that for now, happy to put it back in and add some checks on the `dask` side of things if that's what we settle on.