### PR TITLE
Fix rechunking of arrays with some zero-length dimensions.

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2515,6 +2515,19 @@ def normalize_chunks(chunks, shape=None, limit=None, dtype=None, previous_chunks
     return tuple(tuple(int(x) if not math.isnan(x) else x for x in c) for c in chunks)
 
 
+def _compute_multiplier(limit: int, dtype, largest_block: int, result):
+    """
+    Utility function for auto_chunk, to fin how much larger or smaller the ideal
+    chunk size is relative to what we have now.
+    """
+    return (
+        limit
+        / dtype.itemsize
+        / largest_block
+        / np.prod(list(r if r != 0 else 1 for r in result.values()))
+    )
+
+
 def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
     """ Determine automatic chunks
 
@@ -2595,9 +2608,8 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
                 ideal_shape.append(s)
 
         # How much larger or smaller the ideal chunk size is relative to what we have now
-        multiplier = (
-            limit / dtype.itemsize / largest_block / np.prod(list(result.values()))
-        )
+        multiplier = _compute_multiplier(limit, dtype, largest_block, result)
+
         last_multiplier = 0
         last_autos = set()
         while (
@@ -2608,6 +2620,9 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
 
             # Expand or contract each of the dimensions appropriately
             for a in sorted(autos):
+                if ideal_shape[a] == 0:
+                    result[a] = 0
+                    continue
                 proposed = result[a] * multiplier ** (1 / len(autos))
                 if proposed > shape[a]:  # we've hit the shape boundary
                     autos.remove(a)
@@ -2618,9 +2633,7 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
                     result[a] = round_to(proposed, ideal_shape[a])
 
             # recompute how much multiplier we have left, repeat
-            multiplier = (
-                limit / dtype.itemsize / largest_block / np.prod(list(result.values()))
-            )
+            multiplier = _compute_multiplier(limit, dtype, largest_block, result)
 
         for k, v in result.items():
             chunks[k] = v

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -221,7 +221,7 @@ def rechunk(x, chunks="auto", threshold=None, block_size_limit=None):
     >>> y = x.rechunk({0: -1, 1: 'auto'}, block_size_limit=1e8)
     """
     # don't rechunk if array is empty
-    if x.ndim > 0 and x.shape[-1] == 0:
+    if x.ndim > 0 and all(s == 0 for s in x.shape):
         return x
     if isinstance(chunks, dict):
         chunks = {validate_axis(c, x.ndim): v for c, v in chunks.items()}

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -214,6 +214,20 @@ def test_rechunk_empty():
     assert_eq(x, y)
 
 
+def test_rechunk_zero_dim_array():
+    x = da.zeros((4, 0), chunks=3)
+    y = x.rechunk({0: 4})
+    assert y.chunks == ((4,), (0,))
+    assert_eq(x, y)
+
+
+def test_rechunk_zero_dim_array_II():
+    x = da.zeros((4, 0, 6, 10), chunks=3)
+    y = x.rechunk({0: 4, 2: 2})
+    assert y.chunks == ((4,), (0,), (2, 2, 2), (3, 3, 3, 1))
+    assert_eq(x, y)
+
+
 def test_rechunk_same():
     x = da.ones((24, 24), chunks=(4, 8))
     y = x.rechunk(x.chunks)


### PR DESCRIPTION
While the arrays are _technically_ empty and contain no values,
the rechunking code does update the chunk size metadata.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
