### PR TITLE
Use `concatenate_lookup` in `concatenate`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3492,7 +3492,11 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
     if not seq:
         raise ValueError("Need array(s) to concatenate")
 
-    meta = np.concatenate([meta_from_array(s) for s in seq], axis=axis)
+    seq_metas = [meta_from_array(s) for s in seq]
+    _concatenate = concatenate_lookup.dispatch(
+        type(max(seq_metas, key=lambda x: getattr(x, "__array_priority__", 0)))
+    )
+    meta = _concatenate(seq_metas, axis=axis)
 
     # Promote types to match meta
     seq = [a.astype(meta.dtype) for a in seq]


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/5008

As we sometimes need to have custom ways to dispatch `concatenate` over different array types like SciPy's or CuPy's sparse matrices, make sure we lookup the appropriate `concatenate` implementation and use that.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`