### PR TITLE
Register sizeof for numpy zero-strided arrays

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -83,6 +83,9 @@ def register_numpy():
 
     @sizeof.register(np.ndarray)
     def sizeof_numpy_ndarray(x):
+        if 0 in x.strides:
+            xs = x[tuple(slice(None) if s != 0 else slice(1) for s in x.strides)]
+            return xs.nbytes
         return int(x.nbytes)
 
 

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -25,6 +25,12 @@ def test_numpy():
     assert sizeof(dt) == sys.getsizeof(dt)
 
 
+def test_numpy_0_strided():
+    np = pytest.importorskip("numpy")
+    x = np.broadcast_to(1, (100, 100, 100))
+    assert sizeof(x) <= 8
+
+
 def test_pandas():
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(


### PR DESCRIPTION
Use code written by jrbourbeau in a private thread. Add tests.
Related to dask/distributed#3180

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`


cc @jrbourbeau 