### PR TITLE
Added set_names to dask Index.

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3420,6 +3420,19 @@ class Index(Series):
             applied = applied.clear_divisions()
         return applied
 
+    def _get_names(self):
+        return self._meta.names
+
+    @derived_from(pd.Index)
+    def set_names(self, names, level=None, inplace=False):
+        if inplace:
+            raise NotImplementedError("The inplace= keyword is not supported")
+        meta = self._meta_nonempty.set_names(names, level)
+        result = self.map_partitions(M.set_names, names, level, inplace, meta=meta)
+        return result
+
+    names = property(fset=set_names, fget=_get_names)
+
 
 class DataFrame(_Frame):
     """

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -549,3 +549,31 @@ def test_iloc_raises():
 
     with pytest.raises(IndexError):
         ddf.iloc[:, [5, 6]]
+
+
+@pytest.fixture
+def ddf():
+    return dd.from_pandas(
+        pd.DataFrame({"a": [1, 1, 2, 2], "b": [3, 4, 3, 4]}), npartitions=2,
+    )
+
+
+def test_set_names(ddf):
+    index_names = ["c"]
+    ddf.index = ddf.index.set_names(index_names)
+    assert ddf.index.names == index_names
+    index_names = ["d"]
+    ddf.index = ddf.index.set_names(index_names)
+    assert ddf.index.names == index_names
+
+
+def test_set_names_inplace(ddf):
+    with pytest.raises(NotImplementedError):
+        ddf.index.set_names(["c"], inplace=True)
+
+
+def test_set_names_multi_index(ddf):
+    ddf = ddf.groupby(["a", "b"]).sum()
+    index_names = ["c", "d"]
+    ddf.index = ddf.index.set_names(index_names)
+    assert ddf.index.names == index_names


### PR DESCRIPTION
This PR is related to issue  #6315.
It aims to add `set_names` method to Dask Index.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
