### PR TITLE
HLG optimization for read_parquet + iloc

### DIFF
--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -50,10 +50,6 @@ def optimize_read_parquet_getitem(dsk, keys):
 
         old = layers[k]
 
-        # Bail out if there are any duplicate column names
-        if len(set(old.meta.columns)) < len(old.meta.columns):
-            return dsk
-
         for dep in dsk.dependents[k]:
             block = dsk.layers[dep]
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Starting to address one of the points raised by @martindurant in #6264.  

Adds a high level graph optimization to handle a `read_parquet` followed by a full-column `iloc` by updating the `ParquetSubgraph`.

Very much a draft and very much not completely working.

Need to:
- [x] make it pass tests
- ~[ ] not assume that _all_ calls to `iloc` are for full column selections~ dask only supports full column selection, so nm for now
- [x] Think about how / if to combine parts of this with the existing `getitem` optimizations as there are a bunch of similarities (and a number of differences)

But, initial simple benchmark:
timeseries parquet file created with `dask.dataframe.demo` with 4 columns and 34447680 rows

on master:
```
%%time
len(df)

CPU times: user 8.04 s, sys: 4.2 s, total: 12.2 s
Wall time: 6.21 s
```

with optimization:
```
%%time
len(df)

running getitem optimization
running iloc optimization
Updating iloc subgraph!
CPU times: user 4.62 s, sys: 734 ms, total: 5.35 s
Wall time: 2.14 s
```