### PR TITLE
Handle unnamed pandas RangeIndex in fastparquet engine

### DIFF
--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -467,7 +467,7 @@ class FastParquetEngine(Engine):
             pf.fn = base
             if null_index_name and "__index_level_0__" in pf.columns:
                 index = ["__index_level_0__"]
-                columns.append("__index_level_0__")
+                columns += index
             return pf.to_pandas(columns, categories, index=index)
         else:
             if isinstance(pf, tuple):
@@ -483,7 +483,7 @@ class FastParquetEngine(Engine):
             if null_index_name:
                 if "__index_level_0__" in pf.columns:
                     index = ["__index_level_0__"]
-                    columns.append("__index_level_0__")
+                    columns += index
                     pf.fmd.key_value_metadata = None
             else:
                 pf.fmd.key_value_metadata = None

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2554,6 +2554,17 @@ def test_from_pandas_preserve_none_index(tmpdir, engine):
     assert_eq(expect, got)
 
 
+@write_read_engines()
+def test_from_pandas_preserve_none_rangeindex(tmpdir, write_engine, read_engine):
+    # See GitHub Issue#6348
+    fn = str(tmpdir.join("test.parquet"))
+    df0 = pd.DataFrame({"t": [1, 2, 3]}, index=pd.RangeIndex(start=1, stop=4))
+    df0.to_parquet(fn, engine=write_engine)
+
+    df1 = dd.read_parquet(fn, engine=read_engine)
+    assert_eq(df0, df1.compute())
+
+
 def test_illegal_column_name(tmpdir, engine):
     # Make sure user is prevented from preserving a "None" index
     # name if there is already a column using the special `null_name`


### PR DESCRIPTION
Closes #6348 

Modifies `FastParquetEngine` to use the "pandas metadata" to handle round-tripping unnamed `RangeIndex` columns from pandas.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
