### PR TITLE
Dispatch `iloc` calls to `getitem`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3482,6 +3482,7 @@ class DataFrame(_Frame):
         """
         from .indexing import _iLocIndexer
 
+        # For dataframes with unique column names, this will be transformed into a __getitem__ call
         return _iLocIndexer(self)
 
     def __len__(self):

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -58,7 +58,7 @@ class _iLocIndexer(_IndexerBase):
         if iindexer != slice(None):
             raise NotImplementedError(msg)
 
-        if len(set(self.obj.columns)) < len(self.obj.columns):
+        if not self.obj.columns.is_unique:
             # if there are any duplicate column names, do an iloc
             return self._iloc(iindexer, cindexer)
         else:

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -58,7 +58,16 @@ class _iLocIndexer(_IndexerBase):
         if iindexer != slice(None):
             raise NotImplementedError(msg)
 
-        return self._iloc(iindexer, cindexer)
+        if len(set(self.obj.columns)) < len(self.obj.columns):
+            # if there are any duplicate column names, do an iloc
+            return self._iloc(iindexer, cindexer)
+        else:
+            # otherwise dispatch to dask.dataframe.core.DataFrame.__getitem__
+            return self._getitem(cindexer)
+
+    def _getitem(self, cindexer):
+        col_names = self.obj.columns[cindexer]
+        return self.obj.__getitem__(col_names)
 
     def _iloc(self, iindexer, cindexer):
         assert iindexer == slice(None)

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -63,11 +63,8 @@ class _iLocIndexer(_IndexerBase):
             return self._iloc(iindexer, cindexer)
         else:
             # otherwise dispatch to dask.dataframe.core.DataFrame.__getitem__
-            return self._getitem(cindexer)
-
-    def _getitem(self, cindexer):
-        col_names = self.obj.columns[cindexer]
-        return self.obj.__getitem__(col_names)
+            col_names = self.obj.columns[cindexer]
+            return self.obj.__getitem__(col_names)
 
     def _iloc(self, iindexer, cindexer):
         assert iindexer == slice(None)

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -3,6 +3,7 @@ import numpy as np
 
 import pytest
 
+import dask
 import dask.dataframe as dd
 
 from dask.dataframe._compat import tm, PANDAS_GT_100
@@ -549,3 +550,42 @@ def test_iloc_raises():
 
     with pytest.raises(IndexError):
         ddf.iloc[:, [5, 6]]
+
+
+def test_iloc_dup_column_no_getitem():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
+    ddf = dd.from_pandas(df, 2)
+    ddf.columns = ["A", "A", "C"]
+
+    selection = ddf.iloc[:, 2]
+
+    assert any([key.startswith("iloc") for key in selection.dask.layers.keys()])
+
+
+def test_iloc_dispatch_to_getitem():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
+    ddf = dd.from_pandas(df, 2)
+
+    selection = ddf.iloc[:, 2]
+
+    assert all([not key.startswith("iloc") for key in selection.dask.layers.keys()])
+    assert any([key.startswith("getitem") for key in selection.dask.layers.keys()])
+
+
+def test_iloc_out_of_order_selection():
+    df = pd.DataFrame({"A": [1] * 100, "B": [2] * 100, "C": [3] * 100, "D": [4] * 100})
+    ddf = dd.from_pandas(df, 2)
+    ddf = ddf[["C", "A", "B"]]
+    a = ddf.iloc[:, 0]
+    b = ddf.iloc[:, 1]
+    c = ddf.iloc[:, 2]
+
+    assert a.name == "C"
+    assert b.name == "A"
+    assert c.name == "B"
+
+    a1, b1, c1 = dask.compute(a, b, c)
+
+    assert a1.name == "C"
+    assert b1.name == "A"
+    assert c1.name == "B"

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -552,14 +552,27 @@ def test_iloc_raises():
         ddf.iloc[:, [5, 6]]
 
 
-def test_iloc_dup_column_no_getitem():
+def test_iloc_duplicate_columns():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
     ddf = dd.from_pandas(df, 2)
+    df.columns = ["A", "A", "C"]
     ddf.columns = ["A", "A", "C"]
 
     selection = ddf.iloc[:, 2]
-
+    # Check that `iloc` is called instead of getitem
     assert any([key.startswith("iloc") for key in selection.dask.layers.keys()])
+
+    select_first = ddf.iloc[:, 1]
+    assert_eq(select_first, df.iloc[:, 1])
+
+    select_zeroth = ddf.iloc[:, 0]
+    assert_eq(select_zeroth, df.iloc[:, 0])
+
+    select_list_cols = ddf.iloc[:, [0, 2]]
+    assert_eq(select_list_cols, df.iloc[:, [0, 2]])
+
+    select_negative = ddf.iloc[:, -1:-3:-1]
+    assert_eq(select_negative, df.iloc[:, -1:-3:-1])
 
 
 def test_iloc_dispatch_to_getitem():
@@ -570,6 +583,18 @@ def test_iloc_dispatch_to_getitem():
 
     assert all([not key.startswith("iloc") for key in selection.dask.layers.keys()])
     assert any([key.startswith("getitem") for key in selection.dask.layers.keys()])
+
+    select_first = ddf.iloc[:, 1]
+    assert_eq(select_first, df.iloc[:, 1])
+
+    select_zeroth = ddf.iloc[:, 0]
+    assert_eq(select_zeroth, df.iloc[:, 0])
+
+    select_list_cols = ddf.iloc[:, [0, 2]]
+    assert_eq(select_list_cols, df.iloc[:, [0, 2]])
+
+    select_negative = ddf.iloc[:, -1:-3:-1]
+    assert_eq(select_negative, df.iloc[:, -1:-3:-1])
 
 
 def test_iloc_out_of_order_selection():


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Alternate solution to speeding up certain `iloc` calls xref #6345 #6264 

This is a much smaller change and also provides a nice speedup for my simple local benchmarks:
timeseries parquet file created with dask.dataframe.demo with 4 columns and 34447680 rows

current master:

```
In [3]: %time len(ddf)
CPU times: user 11.8 s, sys: 1.89 s, total: 13.7 s
Wall time: 7.1 s
Out[3]: 34447680

In [4]: %time len(ddf)
CPU times: user 10.1 s, sys: 1.6 s, total: 11.7 s
Wall time: 5.2 s
Out[4]: 34447680
```

this branch:

```
In [3]: %time len(ddf)
CPU times: user 5.9 s, sys: 777 ms, total: 6.68 s
Wall time: 3.79 s
Out[3]: 34447680

In [4]: %time len(ddf)
CPU times: user 4.01 s, sys: 504 ms, total: 4.51 s
Wall time: 1.72 s
Out[4]: 34447680
```
