### PR TITLE
Pass magic partition info to map_partitions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5140,10 +5140,9 @@ def map_partitions(
         meta = make_meta(meta, index=meta_index)
 
     partition_info = {
-        "npartitions" : 0,
+        "npartitions" : df[0].npartitions,
         "partition_number" : 0,
-        "divisions" : tuple(),
-        "curr_partition_divisions":tuple()
+        "divisions" : df[0].divisions,
     }
 
     if all(isinstance(arg, Scalar) for arg in args):
@@ -5166,8 +5165,6 @@ def map_partitions(
         if isinstance(arg, _Frame):
             args2.append(arg)
             dependencies.append(arg)
-            partition_info["npartitions"] = arg.npartitions
-            partition_info["divisions"] = arg.divisions
             continue
         arg = normalize_arg(arg)
         arg2, collections = unpack_collections(arg)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -810,6 +810,21 @@ def test_map_partitions_type():
     assert isinstance(result, pd.Series)
     assert all(x == pd.DataFrame for x in result)
 
+def test_map_partitions_magic():
+
+    def f(df, partition_info=None):
+        print(partition_info)
+        print("I'm in teh fn")
+        if partition_info:
+            df["a"] = partition_info["npartitions"]
+        return df
+    
+    result = d.map_partitions(f, meta=d)
+
+    print(result.compute(scheduler="single-threaded"))
+
+    assert False
+
 
 def test_map_partitions_names():
     func = lambda x: x

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -814,7 +814,6 @@ def test_map_partitions_magic():
 
     def f(df, partition_info=None):
         print(partition_info)
-        print("I'm in teh fn")
         if partition_info:
             df["a"] = partition_info["npartitions"]
         return df


### PR DESCRIPTION
This is a very rough draft that I've been slowly working through.

Something that puzzled me is that it appears like Dask is allowing/expecting multiple dataframes to be passed in, and not necessarily as the first argument(s):

https://github.com/dask/dask/blob/2612cfa0189d51ef1633254524da4588b55fbd13/dask/dataframe/core.py#L5165-L5168

Is this a requirement, or just a byproduct of how the code is structured?

--------
 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

Fixes #3707 
