### PR TITLE
allow tensordot to handle 32+ 'involved' dimensions

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -227,10 +227,6 @@ def _tensordot(a, b, axes):
     else:
         x = tensordot(a, b, axes=axes)
 
-    ind = [slice(None, None)] * x.ndim
-    for a in sorted(axes[0]):
-        ind.insert(a, None)
-    x = x[tuple(ind)]
     return x
 
 
@@ -259,9 +255,10 @@ def tensordot(lhs, rhs, axes=2):
 
     for l, r in zip(left_axes, right_axes):
         out_index.remove(right_index[r])
+        out_index.remove(left_index[l])
         right_index[r] = left_index[l]
 
-    intermediate = blockwise(
+    return blockwise(
         _tensordot,
         out_index,
         lhs,
@@ -270,10 +267,8 @@ def tensordot(lhs, rhs, axes=2):
         right_index,
         dtype=dt,
         axes=(left_axes, right_axes),
+        concatenate=True,
     )
-
-    result = intermediate.sum(axis=left_axes)
-    return result
 
 
 @derived_from(np)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -336,6 +336,13 @@ def test_tensordot_more_than_26_dims():
     assert_eq(da.tensordot(dx, dx, ndim), np.array(2 ** ndim))
 
 
+def test_tensordot_more_than_32_involved_dims():
+    shape = (1,) * 22
+    x = da.ones(shape=shape)
+    xx = da.tensordot(x, x, 11)
+    assert assert_eq(xx, np.ones(shape=shape))
+
+
 def test_dot_method():
     x = np.arange(400).reshape((20, 20))
     a = da.from_array(x, chunks=(5, 5))


### PR DESCRIPTION
This enables ``da.tensordot`` to handle contractions with more than 32 'involved' dimensions - i.e. when the number of unique left dimensions + unique right dimensions + contracted dimensions > 32, which is a much more stringent condition than simply the maximum dimension of any array (#5595).

The fix seems quite simple so I do wonder whether there was some reasoning behind not letting ``blockwise`` perform the sum itself, but possibly the particular explicit sum I'm removing just predates blockwise (#2186).

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
