### PR TITLE
Parse bytes_per_chunk keyword from string

### DIFF
--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -176,7 +176,7 @@ def test_npartitions(db):
         "test",
         db,
         columns=list(df.columns),
-        bytes_per_chunk=2 ** 30,
+        bytes_per_chunk="2 GiB",
         index_col="number",
     )
     assert data.npartitions == 1


### PR DESCRIPTION
Inspired by https://stackoverflow.com/questions/62700350/storing-dask-dataframes-to-parquet-when-data-doesnt-fit-in-memory

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
