### PR TITLE
Use pytest.warns to check for UserWarning in test_parquet.py

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2575,10 +2575,9 @@ def test_illegal_column_name(tmpdir, engine):
     ddf = dd.from_pandas(df, npartitions=2)
 
     # If we don't want to preserve the None index name, the
-    # write should work, but a UserWarning should be raised
-    with pytest.raises(UserWarning) as w:
+    # write should work, but the user should be warned
+    with pytest.warns(UserWarning, match=null_name):
         ddf.to_parquet(fn, engine=engine, write_index=False)
-    assert null_name in str(w.value)
 
     # If we do want to preserve the None index name, should
     # get a ValueError for having an illegal column name


### PR DESCRIPTION
May address a nightly-pyarrow [CI failure](https://issues.apache.org/jira/browse/ARROW-9353?focusedCommentId=17153420&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17153420)

It seems that `test_illegal_column_name` may be checking for a `UserWarning` in a fragile way - This *may* fix the pyarrow CI problem.  cc @jorisvandenbossche 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
