### PR TITLE
Update `visualize` docstrings

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -54,8 +54,9 @@ class DaskMethodsMixin(object):
         Parameters
         ----------
         filename : str or None, optional
-            The name (without an extension) of the file to write to disk.  If
-            `filename` is None, no file will be written, and we communicate
+            The name of the file to write to disk. If the provided `filename`
+            doesn't include an extension, '.png' will be used by default.
+            If `filename` is None, no file will be written, and we communicate
             with dot using only pipes.
         format : {'png', 'pdf', 'dot', 'svg', 'jpeg', 'jpg'}, optional
             Format in which to write output file.  Default is 'png'.
@@ -70,7 +71,7 @@ class DaskMethodsMixin(object):
 
         Examples
         --------
-        >>> x.visualize(filename='dask.pdf')  # doctest: +SKIP
+        >>> x.visualize(filename='dask')  # doctest: +SKIP
         >>> x.visualize(filename='dask.pdf', color='order')  # doctest: +SKIP
 
         Returns
@@ -143,8 +144,8 @@ class DaskMethodsMixin(object):
         """Compute this dask collection
 
         This turns a lazy Dask collection into its in-memory equivalent.
-        For example a Dask.array turns into a  :func:`numpy.array` and a Dask.dataframe
-        turns into a Pandas dataframe.  The entire dataset must fit into memory
+        For example a Dask.array turns into a :func:`numpy.array` and a Dask.dataframe
+        turns into a :func:`pandas.dataframe`.  The entire dataset must fit into memory
         before calling this operation.
 
         Parameters
@@ -457,8 +458,9 @@ def visualize(*args, **kwargs):
     dsk : dict(s) or collection(s)
         The dask graph(s) to visualize.
     filename : str or None, optional
-        The name (without an extension) of the file to write to disk.  If
-        `filename` is None, no file will be written, and we communicate
+        The name of the file to write to disk. If the provided `filename`
+        doesn't include an extension, '.png' will be used by default.
+        If `filename` is None, no file will be written, and we communicate
         with dot using only pipes.
     format : {'png', 'pdf', 'dot', 'svg', 'jpeg', 'jpg'}, optional
         Format in which to write output file.  Default is 'png'.
@@ -479,7 +481,7 @@ def visualize(*args, **kwargs):
 
     Examples
     --------
-    >>> x.visualize(filename='dask.pdf')  # doctest: +SKIP
+    >>> x.visualize(filename='dask')  # doctest: +SKIP
     >>> x.visualize(filename='dask.pdf', color='order')  # doctest: +SKIP
 
     Returns

--- a/dask/base.py
+++ b/dask/base.py
@@ -71,7 +71,7 @@ class DaskMethodsMixin(object):
 
         Examples
         --------
-        >>> x.visualize(filename='dask')  # doctest: +SKIP
+        >>> x.visualize(filename='dask.pdf')  # doctest: +SKIP
         >>> x.visualize(filename='dask.pdf', color='order')  # doctest: +SKIP
 
         Returns
@@ -144,8 +144,8 @@ class DaskMethodsMixin(object):
         """Compute this dask collection
 
         This turns a lazy Dask collection into its in-memory equivalent.
-        For example a Dask.array turns into a :func:`numpy.array` and a Dask.dataframe
-        turns into a :func:`pandas.dataframe`.  The entire dataset must fit into memory
+        For example a Dask array turns into a NumPy array and a Dask dataframe
+        turns into a Pandas dataframe.  The entire dataset must fit into memory
         before calling this operation.
 
         Parameters
@@ -481,7 +481,7 @@ def visualize(*args, **kwargs):
 
     Examples
     --------
-    >>> x.visualize(filename='dask')  # doctest: +SKIP
+    >>> x.visualize(filename='dask.pdf')  # doctest: +SKIP
     >>> x.visualize(filename='dask.pdf', color='order')  # doctest: +SKIP
 
     Returns

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -250,7 +250,7 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
         object. If provided, the ``Delayed`` output of the call can be iterated
         into ``nout`` objects, allowing for unpacking of results. By default
         iteration over ``Delayed`` objects will error. Note, that ``nout=1``
-        expects ``obj``, to return a tuple of length 1, and consequently for
+        expects ``obj`` to return a tuple of length 1, and consequently for
         ``nout=0``, ``obj`` should return an empty tuple.
     traverse : bool, optional
         By default dask traverses builtin python collections looking for dask
@@ -523,10 +523,10 @@ class Delayed(DaskMethodsMixin, OperatorMethodMixin):
             raise AttributeError("Attribute {0} not found".format(attr))
 
         if attr == "visualise":
-            # added to warn users incase of spelling error
+            # added to warn users in case of spelling error
             # for more details: https://github.com/dask/dask/issues/5721
             warnings.warn(
-                "dask.delayed objects have no `visualise` method, perhaps you meant `visualize`?"
+                "dask.delayed objects have no `visualise` method. Perhaps you meant `visualize`?"
             )
 
         return DelayedAttr(self, attr)

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -234,17 +234,18 @@ def dot_graph(dsk, filename="mydask", format=None, **kwargs):
     """
     Render a task graph using dot.
 
-    If `filename` is not None, write a file to disk with that name in the
-    format specified by `format`.  `filename` should not include an extension.
+    If `filename` is not None, write a file to disk with the specified name and extension.
+    If no extension is specified, '.png' will be used by default.
 
     Parameters
     ----------
     dsk : dict
         The graph to display.
     filename : str or None, optional
-        The name (without an extension) of the file to write to disk.  If
-        `filename` is None, no file will be written, and we communicate with
-        dot using only pipes.  Default is 'mydask'.
+        The name of the file to write to disk. If the provided `filename`
+        doesn't include an extension, '.png' will be used by default.
+        If `filename` is None, no file will be written, and we communicate
+        with dot using only pipes.  Default is 'mydask'.
     format : {'png', 'pdf', 'dot', 'svg', 'jpeg', 'jpg'}, optional
         Format in which to write output file.  Default is 'png'.
     **kwargs


### PR DESCRIPTION
To reflect the fact that the `filename` kwarg can now accept file extensions.
https://github.com/dask/dask/blob/3903843aba6b248ce4d9c8c6ef696b16ae4a6351/dask/dot.py#L276-L278

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
