### PR TITLE
Add simple chunk type registry and defer as appropriate to upcast types

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -23,6 +23,7 @@ try:
     )
     from .tiledb_io import from_tiledb, to_tiledb
     from .numpy_compat import rollaxis, moveaxis
+    from .chunk_types import register_chunk_type
     from .routines import (
         take,
         choose,

--- a/dask/array/chunk_types.py
+++ b/dask/array/chunk_types.py
@@ -49,7 +49,7 @@ def register_chunk_type(type):
 
     >>> import numpy.lib.mixins
     >>> class FlaggedArray(numpy.lib.mixins.NDArrayOperatorsMixin):
-    ...     def __init__(self, a, flag):
+    ...     def __init__(self, a, flag=False):
     ...         self.a = a
     ...         self.flag = flag
     ...     def __repr__(self):
@@ -88,23 +88,21 @@ def register_chunk_type(type):
     Before registering ``FlaggedArray``, both types will attempt to defer to the
     other:
 
+    >>> import dask.array as da
     >>> da.ones(5) - FlaggedArray(np.ones(5), True)
-    TypeError: operand type(s) all returned NotImplemented from __array_ufunc__(<ufunc
-    'subtract'>, '__call__', dask.array<ones, shape=(5,), dtype=float64,
-    chunksize=(5,), chunktype=numpy.ndarray>, Flag: True, Array:
-    array([1., 1., 1., 1., 1.])): 'Array', 'FlaggedArray'
+    Traceback (most recent call last):
+    ...
+    TypeError: operand type(s) all returned NotImplemented ...
 
     However, once registered, Dask will be able to handle operations with this new
     type:
 
     >>> da.register_chunk_type(FlaggedArray)
-    >>> x = da.ones(5) - FlaggedArray(np.ones(5))
+    >>> x = da.ones(5) - FlaggedArray(np.ones(5), True)
     >>> x
-    dask.array<sub, shape=(5,), dtype=float64, chunksize=(5,),
-    chunktype=__main__.FlaggedArray>
+    dask.array<sub, shape=(5,), dtype=float64, chunksize=(5,), chunktype=dask.FlaggedArray>
     >>> x.compute()
     Flag: True, Array: array([0., 0., 0., 0., 0.])
-
     """
     _HANDLED_CHUNK_TYPES.append(type)
 

--- a/dask/array/chunk_types.py
+++ b/dask/array/chunk_types.py
@@ -8,7 +8,104 @@ _HANDLED_CHUNK_TYPES = [np.ndarray, np.ma.MaskedArray]
 
 
 def register_chunk_type(type):
-    """ Register the given type as a valid chunk and downcast array type"""
+    """ Register the given type as a valid chunk and downcast array type
+
+    Parameters
+    ----------
+    type : type
+        Duck array type to be registered as a type Dask can safely wrap as a chunk and
+        to which Dask does not defer in arithmetic operations and NumPy
+        functions/ufuncs.
+
+    Notes
+    -----
+    A :py:class:`dask.array.Array` can contain any sufficiently "NumPy-like" array in
+    its chunks. These are also referred to as "duck arrays" since they match the most
+    important parts of NumPy's array API, and so, behave the same way when relying on
+    duck typing.
+
+    However, for multiple duck array types to interoperate properly, they need to
+    properly defer to each other in arithmetic operations and NumPy functions/ufuncs
+    according to a well-defined type casting hierarchy (
+    `see NEP 13<https://numpy.org/neps/nep-0013-ufunc-overrides.html#type-casting-hierarchy>`_
+    ). In an effort to maintain this hierarchy, Dask defers to all other duck array
+    types except those in its internal registry. By default, this registry contains
+
+    * :py:class:`numpy.ndarray`
+    * :py:class:`numpy.ma.MaskedArray`
+    * :py:class:`cupy.ndarray`
+    * :py:class:`sparse.SparseArray`
+    * :py:class:`scipy.sparse.spmatrix`
+
+    This function exists to append any other types to this registry. If a type is not
+    in this registry, and yet is a downcast type (it comes below
+    :py:class:`dask.array.Array` in the type casting hierarchy), a ``TypeError`` will
+    be raised due to all operand types returning ``NotImplemented``.
+
+    Examples
+    --------
+    Using a mock ``FlaggedArray`` class as an example chunk type unknown to Dask with
+    minimal duck array API:
+
+    >>> import numpy.lib.mixins
+    >>> class FlaggedArray(numpy.lib.mixins.NDArrayOperatorsMixin):
+    ...     def __init__(self, a, flag):
+    ...         self.a = a
+    ...         self.flag = flag
+    ...     def __repr__(self):
+    ...         return f"Flag: {self.flag}, Array: " + repr(self.a)
+    ...     def __array__(self):
+    ...         return np.asarray(self.a)
+    ...     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+    ...         if method == '__call__':
+    ...             downcast_inputs = []
+    ...             flag = False
+    ...             for input in inputs:
+    ...                 if isinstance(input, self.__class__):
+    ...                     flag = flag or input.flag
+    ...                     downcast_inputs.append(input.a)
+    ...                 elif isinstance(input, np.ndarray):
+    ...                     downcast_inputs.append(input)
+    ...                 else:
+    ...                     return NotImplemented
+    ...             return self.__class__(ufunc(*downcast_inputs, **kwargs), flag)
+    ...         else:
+    ...             return NotImplemented
+    ...     @property
+    ...     def shape(self):
+    ...         return self.a.shape
+    ...     @property
+    ...     def ndim(self):
+    ...         return self.a.ndim
+    ...     @property
+    ...     def dtype(self):
+    ...         return self.a.dtype
+    ...     def __getitem__(self, key):
+    ...         return type(self)(self.a[key], self.flag)
+    ...     def __setitem__(self, key, value):
+    ...         self.a[key] = value
+
+    Before registering ``FlaggedArray``, both types will attempt to defer to the
+    other:
+
+    >>> da.ones(5) - FlaggedArray(np.ones(5), True)
+    TypeError: operand type(s) all returned NotImplemented from __array_ufunc__(<ufunc
+    'subtract'>, '__call__', dask.array<ones, shape=(5,), dtype=float64,
+    chunksize=(5,), chunktype=numpy.ndarray>, Flag: True, Array:
+    array([1., 1., 1., 1., 1.])): 'Array', 'FlaggedArray'
+
+    However, once registered, Dask will be able to handle operations with this new
+    type:
+
+    >>> da.register_chunk_type(FlaggedArray)
+    >>> x = da.ones(5) - FlaggedArray(np.ones(5))
+    >>> x
+    dask.array<sub, shape=(5,), dtype=float64, chunksize=(5,),
+    chunktype=__main__.FlaggedArray>
+    >>> x.compute()
+    Flag: True, Array: array([0., 0., 0., 0., 0.])
+
+    """
     _HANDLED_CHUNK_TYPES.append(type)
 
 

--- a/dask/array/chunk_types.py
+++ b/dask/array/chunk_types.py
@@ -29,7 +29,7 @@ except ImportError:
 try:
     import sparse
 
-    register_chunk_type(sparse.COO)
+    register_chunk_type(sparse.SparseArray)
 except ImportError:
     pass
 

--- a/dask/array/chunk_types.py
+++ b/dask/array/chunk_types.py
@@ -1,0 +1,60 @@
+from numbers import Number
+
+import numpy as np
+
+
+# Start list of valid chunk types, to be added to with guarded imports
+_HANDLED_CHUNK_TYPES = [np.ndarray, np.ma.MaskedArray]
+
+
+def register_chunk_type(type):
+    """ Register the given type as a valid chunk and downcast array type"""
+    _HANDLED_CHUNK_TYPES.append(type)
+
+
+try:
+    import cupy
+
+    register_chunk_type(cupy.ndarray)
+except ImportError:
+    pass
+
+try:
+    from cupyx.scipy.sparse import spmatrix
+
+    register_chunk_type(spmatrix)
+except ImportError:
+    pass
+
+try:
+    import sparse
+
+    register_chunk_type(sparse.COO)
+except ImportError:
+    pass
+
+try:
+    import scipy.sparse
+
+    register_chunk_type(scipy.sparse.spmatrix)
+except ImportError:
+    pass
+
+
+def is_valid_chunk_type(type):
+    """ Check if given type is a valid chunk and downcast array type"""
+    try:
+        return type in _HANDLED_CHUNK_TYPES or issubclass(
+            type, tuple(_HANDLED_CHUNK_TYPES)
+        )
+    except TypeError:
+        return False
+
+
+def is_valid_array_chunk(array):
+    """ Check if given array is of a valid type to operate with"""
+    return (
+        array is None
+        or isinstance(array, Number)
+        or isinstance(array, tuple(_HANDLED_CHUNK_TYPES))
+    )

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -170,7 +170,7 @@ def implements(*numpy_functions):
 def check_if_handled_given_other(f):
     """ Check if method is handled by Dask given type of other
 
-    Ensures proper deferal to upcast types in dunder operations without
+    Ensures proper deferral to upcast types in dunder operations without
     assuming unknown types are automatically downcast types.
     """
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -57,6 +57,8 @@ from ..highlevelgraph import HighLevelGraph
 from .numpy_compat import _Recurser, _make_sliced_dtype
 from .slicing import slice_array, replace_ellipsis, cached_cumsum
 from .blockwise import blockwise
+from .chunk_types import is_valid_array_chunk, is_valid_chunk_type
+
 
 config.update_defaults({"array": {"chunk-size": "128MiB", "rechunk-threshold": 4}})
 
@@ -163,6 +165,27 @@ def implements(*numpy_functions):
         return dask_func
 
     return decorator
+
+
+def check_if_handled_given_other(f):
+    """ Check if method is handled by Dask given type of other
+
+    Ensures proper deferal to upcast types in dunder operations without
+    assuming unknown types are automatically downcast types.
+    """
+
+    @wraps(f)
+    def wrapper(self, other):
+        if (
+            is_valid_array_chunk(other)
+            or isinstance(other, (self.__class__, list, tuple) + np.ScalarType)
+            or "dask.dataframe.core.Scalar" in str(other.__class__)
+        ):
+            return f(self, other)
+        else:
+            return NotImplemented
+
+    return wrapper
 
 
 def slices_from_chunks(chunks):
@@ -1194,7 +1217,8 @@ class Array(DaskMethodsMixin):
     def __array_ufunc__(self, numpy_ufunc, method, *inputs, **kwargs):
         out = kwargs.get("out", ())
         for x in inputs + out:
-            if not isinstance(x, (np.ndarray, Number, Array)):
+            # Verify all arrays are properly handled by Dask
+            if not isinstance(x, Array) and not is_valid_array_chunk(x):
                 return NotImplemented
 
         if method == "__call__":
@@ -1367,7 +1391,11 @@ class Array(DaskMethodsMixin):
 
             return _HANDLED_FUNCTIONS[func](*args, **kwargs)
 
-        # First try to find a matching function name.  If that doesn't work, we may
+        # First, verify that all types are handled by Dask. Otherwise, return NotImplemented.
+        if not all(type is Array or is_valid_chunk_type(type) for type in types):
+            return NotImplemented
+
+        # Now try to find a matching function name.  If that doesn't work, we may
         # be dealing with an alias or a function that's simply not in the Dask API.
         # Handle aliases via the _HANDLED_FUNCTIONS dict mapping, and warn otherwise.
         for submodule in func.__module__.split(".")[1:]:
@@ -1818,126 +1846,162 @@ class Array(DaskMethodsMixin):
     def __abs__(self):
         return elemwise(operator.abs, self)
 
+    @check_if_handled_given_other
     def __add__(self, other):
         return elemwise(operator.add, self, other)
 
+    @check_if_handled_given_other
     def __radd__(self, other):
         return elemwise(operator.add, other, self)
 
+    @check_if_handled_given_other
     def __and__(self, other):
         return elemwise(operator.and_, self, other)
 
+    @check_if_handled_given_other
     def __rand__(self, other):
         return elemwise(operator.and_, other, self)
 
+    @check_if_handled_given_other
     def __div__(self, other):
         return elemwise(operator.div, self, other)
 
+    @check_if_handled_given_other
     def __rdiv__(self, other):
         return elemwise(operator.div, other, self)
 
+    @check_if_handled_given_other
     def __eq__(self, other):
         return elemwise(operator.eq, self, other)
 
+    @check_if_handled_given_other
     def __gt__(self, other):
         return elemwise(operator.gt, self, other)
 
+    @check_if_handled_given_other
     def __ge__(self, other):
         return elemwise(operator.ge, self, other)
 
     def __invert__(self):
         return elemwise(operator.invert, self)
 
+    @check_if_handled_given_other
     def __lshift__(self, other):
         return elemwise(operator.lshift, self, other)
 
+    @check_if_handled_given_other
     def __rlshift__(self, other):
         return elemwise(operator.lshift, other, self)
 
+    @check_if_handled_given_other
     def __lt__(self, other):
         return elemwise(operator.lt, self, other)
 
+    @check_if_handled_given_other
     def __le__(self, other):
         return elemwise(operator.le, self, other)
 
+    @check_if_handled_given_other
     def __mod__(self, other):
         return elemwise(operator.mod, self, other)
 
+    @check_if_handled_given_other
     def __rmod__(self, other):
         return elemwise(operator.mod, other, self)
 
+    @check_if_handled_given_other
     def __mul__(self, other):
         return elemwise(operator.mul, self, other)
 
+    @check_if_handled_given_other
     def __rmul__(self, other):
         return elemwise(operator.mul, other, self)
 
+    @check_if_handled_given_other
     def __ne__(self, other):
         return elemwise(operator.ne, self, other)
 
     def __neg__(self):
         return elemwise(operator.neg, self)
 
+    @check_if_handled_given_other
     def __or__(self, other):
         return elemwise(operator.or_, self, other)
 
     def __pos__(self):
         return self
 
+    @check_if_handled_given_other
     def __ror__(self, other):
         return elemwise(operator.or_, other, self)
 
+    @check_if_handled_given_other
     def __pow__(self, other):
         return elemwise(operator.pow, self, other)
 
+    @check_if_handled_given_other
     def __rpow__(self, other):
         return elemwise(operator.pow, other, self)
 
+    @check_if_handled_given_other
     def __rshift__(self, other):
         return elemwise(operator.rshift, self, other)
 
+    @check_if_handled_given_other
     def __rrshift__(self, other):
         return elemwise(operator.rshift, other, self)
 
+    @check_if_handled_given_other
     def __sub__(self, other):
         return elemwise(operator.sub, self, other)
 
+    @check_if_handled_given_other
     def __rsub__(self, other):
         return elemwise(operator.sub, other, self)
 
+    @check_if_handled_given_other
     def __truediv__(self, other):
         return elemwise(operator.truediv, self, other)
 
+    @check_if_handled_given_other
     def __rtruediv__(self, other):
         return elemwise(operator.truediv, other, self)
 
+    @check_if_handled_given_other
     def __floordiv__(self, other):
         return elemwise(operator.floordiv, self, other)
 
+    @check_if_handled_given_other
     def __rfloordiv__(self, other):
         return elemwise(operator.floordiv, other, self)
 
+    @check_if_handled_given_other
     def __xor__(self, other):
         return elemwise(operator.xor, self, other)
 
+    @check_if_handled_given_other
     def __rxor__(self, other):
         return elemwise(operator.xor, other, self)
 
+    @check_if_handled_given_other
     def __matmul__(self, other):
         from .routines import matmul
 
         return matmul(self, other)
 
+    @check_if_handled_given_other
     def __rmatmul__(self, other):
         from .routines import matmul
 
         return matmul(other, self)
 
+    @check_if_handled_given_other
     def __divmod__(self, other):
         from .ufunc import divmod
 
         return divmod(self, other)
 
+    @check_if_handled_given_other
     def __rdivmod__(self, other):
         from .ufunc import divmod
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -178,7 +178,7 @@ def check_if_handled_given_other(f):
     def wrapper(self, other):
         if (
             is_valid_array_chunk(other)
-            or isinstance(other, (self.__class__, list, tuple) + np.ScalarType)
+            or isinstance(other, (self.__class__, list, tuple, np.generic))
             or "dask.dataframe.core.Scalar" in str(other.__class__)
         ):
             return f(self, other)

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -167,7 +167,8 @@ def test_unregistered_func(func):
         A class that "mocks" ndarray by encapsulating an ndarray and using
         protocols to "look like" an ndarray. Basically tests whether Dask
         works fine with something that is essentially an array but uses
-        protocols instead of being an actual array.
+        protocols instead of being an actual array. Must be manually
+        registered as a valid chunk type.
         """
 
         __array_priority__ = 20
@@ -205,6 +206,8 @@ def test_unregistered_func(func):
         astype = wrap("astype")
         sum = wrap("sum")
         prod = wrap("prod")
+
+    da.register_chunk_type(EncapsulateNDArray)
 
     # Wrap a procol-based encapsulated ndarray
     x = EncapsulateNDArray(np.random.random((100, 100)))

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -5,6 +5,9 @@ import dask.array as da
 from dask.array.utils import assert_eq, IS_NEP18_ACTIVE
 from dask.array.numpy_compat import _numpy_120
 
+from .test_dispatch import EncapsulateNDArray
+
+
 missing_arrfunc_cond = not IS_NEP18_ACTIVE
 missing_arrfunc_reason = "NEP-18 support is not available in NumPy"
 
@@ -140,75 +143,6 @@ def test_array_function_cupy_svd():
     ],
 )
 def test_unregistered_func(func):
-    def wrap(func_name):
-        """
-        Wrap a function.
-        """
-
-        def wrapped(self, *a, **kw):
-            a = getattr(self.arr, func_name)(*a, **kw)
-            return a if not isinstance(a, np.ndarray) else type(self)(a)
-
-        return wrapped
-
-    def dispatch_property(prop_name):
-        """
-        Wrap a simple property.
-        """
-
-        @property
-        def wrapped(self, *a, **kw):
-            return getattr(self.arr, prop_name)
-
-        return wrapped
-
-    class EncapsulateNDArray(np.lib.mixins.NDArrayOperatorsMixin):
-        """
-        A class that "mocks" ndarray by encapsulating an ndarray and using
-        protocols to "look like" an ndarray. Basically tests whether Dask
-        works fine with something that is essentially an array but uses
-        protocols instead of being an actual array. Must be manually
-        registered as a valid chunk type.
-        """
-
-        __array_priority__ = 20
-
-        def __init__(self, arr):
-            self.arr = arr
-
-        def __array__(self, *args, **kwargs):
-            return np.asarray(self.arr, *args, **kwargs)
-
-        def __array_function__(self, f, t, arrs, kw):
-            arrs = tuple(
-                arr if not isinstance(arr, type(self)) else arr.arr for arr in arrs
-            )
-            t = tuple(ti for ti in t if not issubclass(ti, type(self)))
-            print(t)
-            a = self.arr.__array_function__(f, t, arrs, kw)
-            return a if not isinstance(a, np.ndarray) else type(self)(a)
-
-        __getitem__ = wrap("__getitem__")
-
-        __setitem__ = wrap("__setitem__")
-
-        def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-            inputs = tuple(
-                i if not isinstance(i, type(self)) else i.arr for i in inputs
-            )
-            a = getattr(ufunc, method)(*inputs, **kwargs)
-            return a if not isinstance(a, np.ndarray) else type(self)(a)
-
-        shape = dispatch_property("shape")
-        ndim = dispatch_property("ndim")
-        dtype = dispatch_property("dtype")
-
-        astype = wrap("astype")
-        sum = wrap("sum")
-        prod = wrap("prod")
-
-    da.register_chunk_type(EncapsulateNDArray)
-
     # Wrap a procol-based encapsulated ndarray
     x = EncapsulateNDArray(np.random.random((100, 100)))
 

--- a/dask/array/tests/test_dispatch.py
+++ b/dask/array/tests/test_dispatch.py
@@ -103,23 +103,21 @@ class WrappedArray(np.lib.mixins.NDArrayOperatorsMixin):
     def __array__(self, *args, **kwargs):
         return np.asarray(self.arr, *args, **kwargs)
 
-    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        inputs = tuple(
-            arg.arr if isinstance(arg, type(self)) else arg for arg in inputs
-        )
-        return type(self)(getattr(ufunc, method)(*inputs, **kwargs), **self.attrs)
+    def _downcast_args(self, args):
+        for arg in args:
+            if isinstance(arg, type(self)):
+                yield arg.arr
+            elif isinstance(arg, (tuple, list)):
+                yield tuple(_downcast_args(arg))
+            else:
+                yield arg
 
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        inputs = tuple(self._downcast_args(inputs))
+        return type(self)(getattr(ufunc, method)(*inputs, **kwargs), **self.attrs)
+    
     def __array_function__(self, func, types, args, kwargs):
-        args = tuple(
-            arg.arr
-            if isinstance(arg, type(self))
-            else (
-                tuple(a.arr if isinstance(a, type(self)) else a for a in arg)
-                if isinstance(arg, (tuple, list))
-                else arg
-            )
-            for arg in args
-        )
+        args = tuple(self._downcast_args(args))
         return type(self)(func(*args, **kwargs), **self.attrs)
 
     shape = dispatch_property("shape")

--- a/dask/array/tests/test_dispatch.py
+++ b/dask/array/tests/test_dispatch.py
@@ -149,13 +149,8 @@ class WrappedArray(np.lib.mixins.NDArrayOperatorsMixin):
         operator.sub,
         operator.truediv,
         operator.floordiv,
-        operator.matmul,
         np.add,
         np.subtract,
-        np.equal,
-        np.matmul,
-        np.dot,
-        lambda x, y: np.stack([x, y]),
     ],
 )
 @pytest.mark.parametrize(
@@ -176,7 +171,7 @@ class WrappedArray(np.lib.mixins.NDArrayOperatorsMixin):
     ],
 )
 def test_binary_operation_type_precedence(op, arr_upcast, arr_downcast):
-    """ Test proper dispatch on binary operators, NumPy ufuncs, and NumPy functions"""
+    """ Test proper dispatch on binary operators and NumPy ufuncs"""
     assert (
         type(op(arr_upcast, arr_downcast))
         == type(op(arr_downcast, arr_upcast))

--- a/dask/array/tests/test_dispatch.py
+++ b/dask/array/tests/test_dispatch.py
@@ -1,0 +1,229 @@
+import operator
+
+import pytest
+import numpy as np
+
+import dask.array as da
+from dask.array.chunk_types import is_valid_array_chunk, is_valid_chunk_type
+from dask.array.utils import assert_eq
+
+
+def wrap(func_name):
+    """
+    Wrap a function.
+    """
+
+    def wrapped(self, *a, **kw):
+        a = getattr(self.arr, func_name)(*a, **kw)
+        return a if not isinstance(a, np.ndarray) else type(self)(a)
+
+    return wrapped
+
+
+def dispatch_property(prop_name):
+    """
+    Wrap a simple property.
+    """
+
+    @property
+    def wrapped(self, *a, **kw):
+        return getattr(self.arr, prop_name)
+
+    return wrapped
+
+
+class EncapsulateNDArray(np.lib.mixins.NDArrayOperatorsMixin):
+    """
+    A class that "mocks" ndarray by encapsulating an ndarray and using
+    protocols to "look like" an ndarray. Basically tests whether Dask
+    works fine with something that is essentially an array but uses
+    protocols instead of being an actual array. Must be manually
+    registered as a valid chunk type to be considered a downcast type
+    of Dask array in the type casting hierarchy.
+    """
+
+    __array_priority__ = 20
+
+    def __init__(self, arr):
+        self.arr = arr
+
+    def __array__(self, *args, **kwargs):
+        return np.asarray(self.arr, *args, **kwargs)
+
+    def __array_function__(self, f, t, arrs, kw):
+        if not all(
+            issubclass(ti, (type(self), np.ndarray) + np.ScalarType) for ti in t
+        ):
+            return NotImplemented
+        arrs = tuple(
+            arr if not isinstance(arr, type(self)) else arr.arr for arr in arrs
+        )
+        t = tuple(ti for ti in t if not issubclass(ti, type(self)))
+        print(t)
+        a = self.arr.__array_function__(f, t, arrs, kw)
+        return a if not isinstance(a, np.ndarray) else type(self)(a)
+
+    __getitem__ = wrap("__getitem__")
+
+    __setitem__ = wrap("__setitem__")
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        if not all(
+            isinstance(i, (type(self), np.ndarray) + np.ScalarType) for i in inputs
+        ):
+            return NotImplemented
+        inputs = tuple(i if not isinstance(i, type(self)) else i.arr for i in inputs)
+        a = getattr(ufunc, method)(*inputs, **kwargs)
+        return a if not isinstance(a, np.ndarray) else type(self)(a)
+
+    shape = dispatch_property("shape")
+    ndim = dispatch_property("ndim")
+    dtype = dispatch_property("dtype")
+
+    astype = wrap("astype")
+    sum = wrap("sum")
+    prod = wrap("prod")
+
+
+da.register_chunk_type(EncapsulateNDArray)
+
+
+class WrappedArray(np.lib.mixins.NDArrayOperatorsMixin):
+    """
+    Another mock duck array class (like EncapsulateNDArray), but
+    designed to be above Dask in the type casting hierarchy (that is,
+    WrappedArray wraps Dask Array) and be even more minimal in API.
+    Tests that Dask defers properly to upcast types.
+    """
+
+    def __init__(self, arr, **attrs):
+        self.arr = arr
+        self.attrs = attrs
+
+    def __array__(self, *args, **kwargs):
+        return np.asarray(self.arr, *args, **kwargs)
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        inputs = tuple(
+            arg.arr if isinstance(arg, type(self)) else arg for arg in inputs
+        )
+        return type(self)(getattr(ufunc, method)(*inputs, **kwargs), **self.attrs)
+
+    def __array_function__(self, func, types, args, kwargs):
+        args = tuple(
+            arg.arr
+            if isinstance(arg, type(self))
+            else (
+                tuple(a.arr if isinstance(a, type(self)) else a for a in arg)
+                if isinstance(arg, (tuple, list))
+                else arg
+            )
+            for arg in args
+        )
+        return type(self)(func(*args, **kwargs), **self.attrs)
+
+    shape = dispatch_property("shape")
+    ndim = dispatch_property("ndim")
+    dtype = dispatch_property("dtype")
+
+    def __getitem__(self, key):
+        return type(self)(self.arr[key], **self.attrs)
+
+    def __setitem__(self, key, value):
+        self.arr[key] = value
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        operator.add,
+        operator.eq,
+        operator.gt,
+        operator.ge,
+        operator.lt,
+        operator.le,
+        operator.mod,
+        operator.mul,
+        operator.ne,
+        operator.pow,
+        operator.sub,
+        operator.truediv,
+        operator.floordiv,
+        operator.matmul,
+        np.add,
+        np.subtract,
+        np.equal,
+        np.matmul,
+        np.dot,
+        lambda x, y: np.stack([x, y]),
+    ],
+)
+@pytest.mark.parametrize(
+    "arr_upcast, arr_downcast",
+    [
+        (
+            WrappedArray(np.random.random((10, 10))),
+            da.random.random((10, 10), chunks=(5, 5)),
+        ),
+        (
+            da.random.random((10, 10), chunks=(5, 5)),
+            EncapsulateNDArray(np.random.random((10, 10))),
+        ),
+        (
+            WrappedArray(np.random.random((10, 10))),
+            EncapsulateNDArray(np.random.random((10, 10))),
+        ),
+    ],
+)
+def test_binary_operation_type_precedence(op, arr_upcast, arr_downcast):
+    """ Test proper dispatch on binary operators, NumPy ufuncs, and NumPy functions"""
+    assert (
+        type(op(arr_upcast, arr_downcast))
+        == type(op(arr_downcast, arr_upcast))
+        == type(arr_upcast)
+    )
+
+
+@pytest.mark.parametrize(
+    "arr, result",
+    [
+        (WrappedArray(np.arange(4)), False),
+        (da.from_array(np.arange(4)), False),
+        (EncapsulateNDArray(np.arange(4)), True),
+        (np.ma.masked_array(np.arange(4), [True, False, True, False]), True),
+        (np.arange(4), True),
+        (0.0, True),
+        (0, True),
+        (None, True),
+    ],
+)
+def test_is_valid_array_chunk(arr, result):
+    """ Test is_valid_array_chunk for correctness"""
+    assert is_valid_array_chunk(arr) is result
+
+
+@pytest.mark.parametrize(
+    "arr_type, result",
+    [
+        (WrappedArray, False),
+        (da.Array, False),
+        (EncapsulateNDArray, True),
+        (np.ma.MaskedArray, True),
+        (np.ndarray, True),
+        (float, False),
+        (int, False),
+    ],
+)
+def test_is_valid_chunk_type(arr_type, result):
+    """ Test is_valid_chunk_type for correctness"""
+    assert is_valid_chunk_type(arr_type) is result
+
+
+def test_direct_deferral_wrapping_override():
+    """ Directly test Dask defering to an upcast type and the ability to still wrap it."""
+    a = da.from_array(np.arange(4))
+    b = WrappedArray(np.arange(4))
+    assert a.__add__(b) is NotImplemented
+    res = a + da.from_array(b)
+    assert isinstance(res, da.Array)
+    assert_eq(res, 2 * np.arange(4))

--- a/dask/array/tests/test_dispatch.py
+++ b/dask/array/tests/test_dispatch.py
@@ -108,14 +108,14 @@ class WrappedArray(np.lib.mixins.NDArrayOperatorsMixin):
             if isinstance(arg, type(self)):
                 yield arg.arr
             elif isinstance(arg, (tuple, list)):
-                yield tuple(_downcast_args(arg))
+                yield tuple(self._downcast_args(arg))
             else:
                 yield arg
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         inputs = tuple(self._downcast_args(inputs))
         return type(self)(getattr(ufunc, method)(*inputs, **kwargs), **self.attrs)
-    
+
     def __array_function__(self, func, types, args, kwargs):
         args = tuple(self._downcast_args(args))
         return type(self)(func(*args, **kwargs), **self.attrs)

--- a/dask/array/tests/test_dispatch.py
+++ b/dask/array/tests/test_dispatch.py
@@ -108,7 +108,7 @@ class WrappedArray(np.lib.mixins.NDArrayOperatorsMixin):
             if isinstance(arg, type(self)):
                 yield arg.arr
             elif isinstance(arg, (tuple, list)):
-                yield tuple(self._downcast_args(arg))
+                yield type(arg)(self._downcast_args(arg))
             else:
                 yield arg
 

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -161,6 +161,7 @@ Top level user functions:
    real
    rechunk
    reduction
+   register_chunk_type
    repeat
    reshape
    result_type

--- a/docs/source/array-chunks.rst
+++ b/docs/source/array-chunks.rst
@@ -1,11 +1,11 @@
 Chunks
 ======
 
-Dask arrays are composed of many NumPy arrays.  How these arrays are arranged
-can significantly affect performance.  For example, for a square array you might
-arrange your chunks along rows, along columns, or in a more square-like
-fashion.  Different arrangements of NumPy arrays will be faster or slower for
-different algorithms.
+Dask arrays are composed of many NumPy (or NumPy-like) arrays. How these arrays
+are arranged can significantly affect performance.  For example, for a square
+array you might arrange your chunks along rows, along columns, or in a more
+square-like fashion. Different arrangements of NumPy arrays will be faster or
+slower for different algorithms.
 
 Thinking about and controlling chunking is important to optimize advanced
 algorithms.

--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -46,8 +46,17 @@ Design
    :alt: Dask arrays coordinate many numpy arrays
    :align: right
 
-Dask arrays coordinate many NumPy arrays arranged into a grid.  These
-NumPy arrays may live on disk or on other machines.
+Dask arrays coordinate many NumPy arrays (or "duck arrays" that are
+sufficiently NumPy-like in API such as CuPy or Spare arrays) arranged into a
+grid. These arrays may live on disk or on other machines.
+
+New duck array chunk types (types below Dask on
+`NEP-13's type-casting heirarchy`_) can be registered via
+:func:`~dask.array.register_chunk_type`. Any other duck array types that are
+not registered will be deferred to in binary operations and NumPy
+ufuncs/functions (that is, Dask will return ``NotImplemented``). Note, however,
+that *any* ndarray-like type can be inserted into a Dask Array using
+:func:`~dask.array.Array.from_array`.
 
 Common Uses
 -----------
@@ -100,3 +109,4 @@ transfer costs, and because NumPy releases the GIL well.  It is also quite
 effective on a cluster using the `dask.distributed`_ scheduler.
 
 .. _`dask.distributed`: https://distributed.dask.org/en/latest/
+.. _`NEP-13's type-casting heirarchy`: https://numpy.org/neps/nep-0013-ufunc-overrides.html#type-casting-hierarchy


### PR DESCRIPTION
Adds a basic list-based registry of valid chunk types for use within `dask.array.Array`, with the ability to add otherwise unknown types with `dask.array.register_chunk_type`. When a type *not* in this list or defined/handled by Dask is encountered, defer to it instead. This means raising `TypeError` on creation/wrapping and returning `NotImplemented` in `elemwise`, `__array_function__`, and `__array_ufunc__`. With changes of this PR, `dask.array.Array` will be better able to [respect a well-defined type casting hierarchy](https://numpy.org/neps/nep-0013-ufunc-overrides.html#type-casting-hierarchy) and will by default follow [the generally-accepted hierarchy among common PyData/SciPy packages that I'm aware of](https://pint.readthedocs.io/en/latest/numpy.html#Technical-Commentary). It is very much a breaking change for any array types not known by default to Dask, but these otherwise unknown types can be easily added with `dask.array.register_chunk_type`. It fixes bugs with non-commutative operations with Pint Quantities and xarray DataArrays.

Right now, this is a draft PR since I have not added tests for the new registry functions or for `dask.array.Array` respecting the type casting hierarchy. If at all possible, I'd like to get feedback/approval on this general approach before spending a bunch of time on the tests of it, in case it needs to be redone in a different fashion.

- [x] Tests added
- [x] Tests passed
- [x] Passes `black dask` / `flake8 dask`

Tagging @pentschev, @shoyer, @hameerabbasi, and @mrocklin based on input in https://github.com/dask/dask/issues/4583. I would greatly appreciate any of your feedback on this!

Closes https://github.com/dask/dask/issues/4583
