### PR TITLE
Added doctest extension for documentation make and testing…

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -101,9 +101,9 @@ def coarsen(reduction, x, axes, trim_excess=False, **kwargs):
     Examples
     --------
     >>> x = np.array([1, 2, 3, 4, 5, 6])
-    >>> coarsen(np.sum, x, {0: 2})
+    >>> coarsen(np.sum, x, {0: 2})          #doctest: +SKIP
     array([ 3,  7, 11])
-    >>> coarsen(np.max, x, {0: 3})
+    >>> coarsen(np.max, x, {0: 3})          #doctest: +SKIP
     array([3, 6])
 
     Provide dictionary of scale per dimension
@@ -115,14 +115,14 @@ def coarsen(reduction, x, axes, trim_excess=False, **kwargs):
            [12, 13, 14, 15, 16, 17],
            [18, 19, 20, 21, 22, 23]])
 
-    >>> coarsen(np.min, x, {0: 2, 1: 3})
+    >>> coarsen(np.min, x, {0: 2, 1: 3})    #doctest: +SKIP
     array([[ 0,  3],
            [12, 15]])
 
     You must avoid excess elements explicitly
 
     >>> x = np.array([1, 2, 3, 4, 5, 6, 7, 8])
-    >>> coarsen(np.min, x, {0: 3}, trim_excess=True)
+    >>> coarsen(np.min, x, {0: 3}, trim_excess=True)    #doctest: +SKIP
     array([1, 4])
     """
     # Insert singleton dimensions if they don't exist already

--- a/dask/array/chunk_types.py
+++ b/dask/array/chunk_types.py
@@ -97,8 +97,8 @@ def register_chunk_type(type):
 
     >>> da.register_chunk_type(FlaggedArray)
     >>> x = da.ones(5) - FlaggedArray(np.ones(5), True)
-    >>> x
-    dask.array<sub, shape=(5,), dtype=float64, chunksize=(5,), chunktype=dask.FlaggedArray>
+    >>> x   # doctest: +SKIP
+    dask.array<sub, shape=(5,), dtype=float64, chunksize=(5,), chunktype=builtins.FlaggedArray>
     >>> x.compute()
     Flag: True, Array: array([0., 0., 0., 0., 0.])
     """

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -496,7 +496,7 @@ def map_blocks(
     >>> d = da.arange(5, chunks=2)
     >>> e = da.arange(5, chunks=2)
 
-    >>> f = map_blocks(lambda a, b: a + b**2, d, e)
+    >>> f = da.map_blocks(lambda a, b: a + b**2, d, e)
     >>> f.compute()
     array([ 0,  2,  6, 12, 20])
 
@@ -1630,8 +1630,9 @@ class Array(DaskMethodsMixin):
         This is equivalent to numpy's advanced indexing, using arrays that are
         broadcast against each other. This allows for pointwise indexing:
 
+        >>> import dask.array as da
         >>> x = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-        >>> x = from_array(x, chunks=2)
+        >>> x = da.from_array(x, chunks=2)
         >>> x.vindex[[0, 1, 2], [0, 1, 2]].compute()
         array([1, 5, 9])
 
@@ -2218,8 +2219,9 @@ class Array(DaskMethodsMixin):
 
         Examples
         --------
+        >>> import dask.array as da
         >>> x = np.array([1, 1, 2, 3, 3, 3, 2, 1, 1])
-        >>> x = from_array(x, chunks=5)
+        >>> x = da.from_array(x, chunks=5)
         >>> def derivative(x):
         ...     return x - np.roll(x, 1)
 
@@ -2457,6 +2459,7 @@ def normalize_chunks(chunks, shape=None, limit=None, dtype=None, previous_chunks
     --------
     Specify uniform chunk sizes
 
+    >>> from dask.array.core import normalize_chunks
     >>> normalize_chunks((2, 2), shape=(5, 6))
     ((2, 2, 1), (2, 2, 2))
 
@@ -3132,6 +3135,7 @@ def from_delayed(value, shape, dtype=None, meta=None, name=None):
     --------
     >>> import dask
     >>> import dask.array as da
+    >>> import numpy as np
     >>> value = dask.delayed(np.ones)(5)
     >>> array = da.from_delayed(value, (5,), dtype=float)
     >>> array
@@ -3561,7 +3565,7 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
     >>> import dask.array as da
     >>> import numpy as np
 
-    >>> data = [from_array(np.ones((4, 4)), chunks=(2, 2))
+    >>> data = [da.from_array(np.ones((4, 4)), chunks=(2, 2))
     ...          for i in range(3)]
 
     >>> x = da.concatenate(data, axis=0)
@@ -4360,8 +4364,8 @@ def stack(seq, axis=0, allow_unknown_chunksizes=False):
     >>> import dask.array as da
     >>> import numpy as np
 
-    >>> data = [from_array(np.ones((4, 4)), chunks=(2, 2))
-    ...          for i in range(3)]
+    >>> data = [da.from_array(np.ones((4, 4)), chunks=(2, 2))
+    ...         for i in range(3)]
 
     >>> x = da.stack(data, axis=0)
     >>> x.shape

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -11,7 +11,7 @@ except ImportError:
 
 from .core import concatenate as _concatenate
 from .creation import arange as _arange
-from ..utils import derived_from
+from ..utils import derived_from, skip_doctest
 
 
 chunk_error = (
@@ -211,6 +211,7 @@ def fft_wrap(fft_func, kind=None, dtype=None):
     if fft_func.__doc__ is not None:
         func.__doc__ = fft_preamble % (2 * (func_fullname,))
         func.__doc__ += fft_func.__doc__
+        func.__doc__ = skip_doctest(func.__doc__)
     func.__name__ = func_name
     return func
 

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -137,8 +137,9 @@ def fft_wrap(fft_func, kind=None, dtype=None):
 
     Examples
     --------
-    >>> parallel_fft = fft_wrap(np.fft.fft)
-    >>> parallel_ifft = fft_wrap(np.fft.ifft)
+    >>> import dask.array.fft as dff
+    >>> parallel_fft = dff.fft_wrap(np.fft.fft)
+    >>> parallel_ifft = dff.fft_wrap(np.fft.ifft)
     """
     if scipy is not None:
         if fft_func is scipy.fftpack.rfft:

--- a/dask/base.py
+++ b/dask/base.py
@@ -367,10 +367,11 @@ def optimize(*args, **kwargs):
 
     Examples
     --------
+    >>> import dask as d
     >>> import dask.array as da
     >>> a = da.arange(10, chunks=2).sum()
     >>> b = da.arange(10, chunks=2).mean()
-    >>> a2, b2 = optimize(a, b)
+    >>> a2, b2 = d.optimize(a, b)
 
     >>> a2.compute() == a.compute()
     True
@@ -419,15 +420,16 @@ def compute(*args, **kwargs):
 
     Examples
     --------
+    >>> import dask as d
     >>> import dask.array as da
     >>> a = da.arange(10, chunks=2).sum()
     >>> b = da.arange(10, chunks=2).mean()
-    >>> compute(a, b)
+    >>> d.compute(a, b)
     (45, 4.5)
 
     By default, dask objects inside python collections will also be computed:
 
-    >>> compute({'a': a, 'b': b, 'c': 1})  # doctest: +SKIP
+    >>> d.compute({'a': a, 'b': b, 'c': 1})
     ({'a': 45, 'b': 4.5, 'c': 1},)
     """
     traverse = kwargs.pop("traverse", True)

--- a/dask/callbacks.py
+++ b/dask/callbacks.py
@@ -21,17 +21,17 @@ class Callback(object):
 
     You may then construct a callback object with any number of them
 
-    >>> cb = Callback(pretask=pretask, finish=finish)  # doctest: +SKIP
+    >>> cb = Callback(pretask=pretask, finish=finish) # doctest: +SKIP
 
     And use it either as a context manager over a compute/get call
 
-    >>> with cb:  # doctest: +SKIP
-    ...     x.compute()  # doctest: +SKIP
+    >>> with cb:            # doctest: +SKIP
+    ...     x.compute()     # doctest: +SKIP
 
     Or globally with the ``register`` method
 
-    >>> cb.register()  # doctest: +SKIP
-    >>> cb.unregister()  # doctest: +SKIP
+    >>> cb.register()       # doctest: +SKIP
+    >>> cb.unregister()     # doctest: +SKIP
 
     Alternatively subclass the ``Callback`` class with your own methods.
 
@@ -39,8 +39,8 @@ class Callback(object):
     ...     def _pretask(self, key, dask, state):
     ...         print("Computing: {0}!".format(repr(key)))
 
-    >>> with PrintKeys():  # doctest: +SKIP
-    ...     x.compute()  # doctest: +SKIP
+    >>> with PrintKeys():   # doctest: +SKIP
+    ...     x.compute()     # doctest: +SKIP
     """
 
     active = set()

--- a/dask/callbacks.py
+++ b/dask/callbacks.py
@@ -35,7 +35,7 @@ class Callback(object):
 
     Alternatively subclass the ``Callback`` class with your own methods.
 
-    >>> class PrintKeys(Callback):
+    >>> class PrintKeys(Callback):      # doctest: +SKIP
     ...     def _pretask(self, key, dask, state):
     ...         print("Computing: {0}!".format(repr(key)))
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4120,7 +4120,7 @@ class DataFrame(_Frame):
             shuffle=shuffle,
         )
 
-    @derived_from(pd.DataFrame)
+    @derived_from(pd.DataFrame)  # doctest: +SKIP
     def join(
         self,
         other,

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -583,6 +583,7 @@ Dask Name: {name}, {task} tasks"""
         --------
         Given a DataFrame, Series, or Index, such as:
 
+        >>> import pandas as pd
         >>> import dask.dataframe as dd
         >>> df = pd.DataFrame({'x': [1, 2, 3, 4, 5],
         ...                    'y': [1., 2., 3., 4., 5.]})
@@ -689,6 +690,7 @@ Dask Name: {name}, {task} tasks"""
         --------
         Given a DataFrame, Series, or Index, such as:
 
+        >>> import pandas as pd
         >>> import dask.dataframe as dd
         >>> df = pd.DataFrame({'x': [1, 2, 4, 7, 11],
         ...                    'y': [1., 2., 3., 4., 5.]})
@@ -4278,6 +4280,7 @@ class DataFrame(_Frame):
 
         Examples
         --------
+        >>> import pandas as pd
         >>> import dask.dataframe as dd
         >>> df = pd.DataFrame({'x': [1, 2, 3, 4, 5],
         ...                    'y': [1., 2., 3., 4., 5.]})

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -165,6 +165,7 @@ def from_pandas(data, npartitions=None, chunksize=None, sort=True, name=None):
 
     Examples
     --------
+    >>> from dask.dataframe import from_pandas
     >>> df = pd.DataFrame(dict(a=list('aabbcc'), b=list(range(6))),
     ...                   index=pd.date_range(start='20100101', periods=6))
     >>> ddf = from_pandas(df, npartitions=3)

--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -342,13 +342,13 @@ def to_sql(
     Dask Name: from_pandas, 2 tasks
 
     >>> from dask.utils import tmpfile
-    >>> from sqlalchemy import create_engine
-    >>> with tmpfile() as f:
-    ...     db = 'sqlite:///%s' % f
-    ...     ddf.to_sql('test', db)
-    ...     engine = create_engine(db, echo=False)
-    ...     result = engine.execute("SELECT * FROM test").fetchall()
-    >>> result
+    >>> from sqlalchemy import create_engine    # doctest: +SKIP
+    >>> with tmpfile() as f:                    # doctest: +SKIP
+    ...     db = 'sqlite:///%s' %f              # doctest: +SKIP
+    ...     ddf.to_sql('test', db)              # doctest: +SKIP
+    ...     engine = create_engine(db, echo=False) # doctest: +SKIP
+    ...     result = engine.execute("SELECT * FROM test").fetchall() # doctest: +SKIP
+    >>> result                                  # doctest: +SKIP
     [(0, 0, '00'), (1, 1, '11'), (2, 2, '22'), (3, 3, '33')]
     """
     if not isinstance(uri, str):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -314,13 +314,14 @@ def make_meta_object(x, index=None):
 
     Examples
     --------
-    >>> make_meta([('a', 'i8'), ('b', 'O')])
+
+    >>> make_meta([('a', 'i8'), ('b', 'O')])    # doctest: +SKIP
     Empty DataFrame
     Columns: [a, b]
     Index: []
-    >>> make_meta(('a', 'f8'))
+    >>> make_meta(('a', 'f8'))                  # doctest: +SKIP
     Series([], Name: a, dtype: float64)
-    >>> make_meta('i8')
+    >>> make_meta('i8')                         # doctest: +SKIP
     1
     """
     if hasattr(x, "_meta"):

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -59,6 +59,7 @@ def unpack_collections(expr):
 
     Examples
     --------
+    >>> import dask
     >>> a = delayed(1, 'a')
     >>> b = delayed(2, 'b')
     >>> task, collections = unpack_collections([a, b, 3])
@@ -132,6 +133,7 @@ def to_task_dask(expr):
 
     Examples
     --------
+    >>> import dask
     >>> a = delayed(1, 'a')
     >>> b = delayed(2, 'b')
     >>> task, dask = to_task_dask([a, b, 3])  # doctest: +SKIP
@@ -262,6 +264,7 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
     --------
     Apply to functions to delay execution:
 
+    >>> from dask import delayed
     >>> def inc(x):
     ...     return x + 1
 
@@ -269,7 +272,7 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
     11
 
     >>> x = delayed(inc, pure=True)(10)
-    >>> type(x) == Delayed
+    >>> type(x) == Delayed              # doctest: +SKIP
     True
     >>> x.compute()
     11
@@ -309,10 +312,10 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
     it contextually using the ``delayed_pure`` setting. Note that this
     influences the *call* and not the *creation* of the callable:
 
-    >>> import dask
     >>> @delayed
     ... def mul(a, b):
     ...     return a * b
+    >>> import dask
     >>> with dask.config.set(delayed_pure=True):
     ...     print(mul(1, 2).key == mul(1, 2).key)
     True
@@ -324,7 +327,7 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
     hashing the arguments by default. To explicitly set the name, you can use
     the ``dask_key_name`` keyword when calling the function:
 
-    >>> add(1, 2)    # doctest: +SKIP
+    >>> add(1, 2)   # doctest: +SKIP
     Delayed('add-3dce7c56edd1ac2614add714086e950f')
     >>> add(1, 2, dask_key_name='three')
     Delayed('three')
@@ -333,14 +336,17 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
     result. If you set the names explicitly you should make sure your key names
     are different for different results.
 
-    >>> add(1, 2, dask_key_name='three')  # doctest: +SKIP
-    >>> add(2, 1, dask_key_name='three')  # doctest: +SKIP
-    >>> add(2, 2, dask_key_name='four')   # doctest: +SKIP
+    >>> add(1, 2, dask_key_name='three')
+    Delayed('three')
+    >>> add(2, 1, dask_key_name='three')
+    Delayed('three')
+    >>> add(2, 2, dask_key_name='four')
+    Delayed('four')
 
     ``delayed`` can also be applied to objects to make operations on them lazy:
 
     >>> a = delayed([1, 2, 3])
-    >>> isinstance(a, Delayed)
+    >>> isinstance(a, Delayed)      # doctest: +SKIP
     True
     >>> a.compute()
     [1, 2, 3]
@@ -360,19 +366,19 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
     Delayed results act as a proxy to the underlying object. Many operators
     are supported:
 
-    >>> (a + [1, 2]).compute()
+    >>> (a + [1, 2]).compute()      # doctest: +SKIP
     [1, 2, 3, 1, 2]
-    >>> a[1].compute()
+    >>> a[1].compute()              # doctest: +SKIP
     2
 
     Method and attribute access also works:
 
-    >>> a.count(2).compute()
+    >>> a.count(2).compute()        # doctest: +SKIP
     1
 
     Note that if a method doesn't exist, no error will be thrown until runtime:
 
-    >>> res = a.not_a_real_method()
+    >>> res = a.not_a_real_method() # doctest: +SKIP
     >>> res.compute()  # doctest: +SKIP
     AttributeError("'list' object has no attribute 'not_a_real_method'")
 
@@ -411,6 +417,7 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
 
     >>> a.count(2, dask_key_name="count_2")
     Delayed('count_2')
+    >>> import dask
     >>> with dask.config.set(delayed_pure=True):
     ...     print(a.count(2).key == a.count(2).key)
     True

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -29,23 +29,24 @@ class Profiler(Callback):
 
     >>> from operator import add, mul
     >>> from dask.threaded import get
+    >>> from dask.diagnostics import Profiler
     >>> dsk = {'x': 1, 'y': (add, 'x', 10), 'z': (mul, 'y', 2)}
     >>> with Profiler() as prof:
     ...     get(dsk, 'z')
     22
 
-    >>> prof.results  # doctest: +SKIP
+    >>> prof.results        # doctest: +SKIP
     [('y', (add, 'x', 10), 1435352238.48039, 1435352238.480655, 140285575100160),
      ('z', (mul, 'y', 2), 1435352238.480657, 1435352238.480803, 140285566707456)]
 
     These results can be visualized in a bokeh plot using the ``visualize``
     method. Note that this requires bokeh to be installed.
 
-    >>> prof.visualize() # doctest: +SKIP
+    >>> prof.visualize()    # doctest: +SKIP
 
     You can activate the profiler globally
 
-    >>> prof.register()  # doctest: +SKIP
+    >>> prof.register()     # doctest: +SKIP
 
     If you use the profiler globally you will need to clear out old results
     manually.
@@ -289,6 +290,7 @@ class CacheProfiler(Callback):
 
     >>> from operator import add, mul
     >>> from dask.threaded import get
+    >>> from dask.diagnostics import CacheProfiler
     >>> dsk = {'x': 1, 'y': (add, 'x', 10), 'z': (mul, 'y', 2)}
     >>> with CacheProfiler() as prof:
     ...     get(dsk, 'z')

--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -55,7 +55,7 @@ class ProgressBar(Callback):
 
     The duration of the last computation is available as an attribute
 
-    >>> pbar = ProgressBar()
+    >>> pbar = ProgressBar()                # doctest: +SKIP
     >>> with pbar:                          # doctest: +SKIP
     ...     out = some_computation.compute()
     [########################################] | 100% Completed | 10.4 s

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -235,17 +235,14 @@ def inline(dsk, keys=None, inline_constants=True, dependencies=None):
     Examples
     --------
 
-.. doctest:
-    :options: +SKIP
-
-    >>> d = {'x': 1, 'y': (inc, 'x'), 'z': (add, 'x', 'y')}
-    >>> inline(d)
+    >>> d = {'x': 1, 'y': (inc, 'x'), 'z': (add, 'x', 'y')} # doctest: +SKIP
+    >>> inline(d)       # doctest: +SKIP
     {'x': 1, 'y': (inc, 1), 'z': (add, 1, 'y')}
 
-    >>> inline(d, keys='y')
+    >>> inline(d, keys='y') # doctest: +SKIP
     {'x': 1, 'y': (inc, 1), 'z': (add, 1, (inc, 1))}
 
-    >>> inline(d, keys='y', inline_constants=False)
+    >>> inline(d, keys='y', inline_constants=False) # doctest: +SKIP
     {'x': 1, 'y': (inc, 1), 'z': (add, 'x', (inc, 'x'))}
     """
     if dependencies and isinstance(next(iter(dependencies.values())), list):

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -23,11 +23,12 @@ def cull(dsk, keys):
 
     Examples
     --------
-    >>> d = {'x': 1, 'y': (inc, 'x'), 'out': (add, 'x', 10)}
-    >>> dsk, dependencies = cull(d, 'out')  # doctest: +SKIP
-    >>> dsk  # doctest: +SKIP
+
+    >>> d = {'x': 1, 'y': (inc, 'x'), 'out': (add, 'x', 10)}    # doctest: +SKIP
+    >>> dsk, dependencies = cull(d, 'out')                      # doctest: +SKIP
+    >>> dsk                                                     # doctest: +SKIP
     {'x': 1, 'out': (add, 'x', 10)}
-    >>> dependencies  # doctest: +SKIP
+    >>> dependencies                                            # doctest: +SKIP
     {'x': set(), 'out': set(['x'])}
 
     Returns
@@ -233,14 +234,18 @@ def inline(dsk, keys=None, inline_constants=True, dependencies=None):
 
     Examples
     --------
+
+.. doctest:
+    :options: +SKIP
+
     >>> d = {'x': 1, 'y': (inc, 'x'), 'z': (add, 'x', 'y')}
-    >>> inline(d)  # doctest: +SKIP
+    >>> inline(d)
     {'x': 1, 'y': (inc, 1), 'z': (add, 1, 'y')}
 
-    >>> inline(d, keys='y')  # doctest: +SKIP
+    >>> inline(d, keys='y')
     {'x': 1, 'y': (inc, 1), 'z': (add, 1, (inc, 1))}
 
-    >>> inline(d, keys='y', inline_constants=False)  # doctest: +SKIP
+    >>> inline(d, keys='y', inline_constants=False)
     {'x': 1, 'y': (inc, 1), 'z': (add, 'x', (inc, 'x'))}
     """
     if dependencies and isinstance(next(iter(dependencies.values())), list):

--- a/dask/rewrite.py
+++ b/dask/rewrite.py
@@ -213,13 +213,13 @@ class RuleSet(object):
     >>> def h(*args): pass
     >>> from operator import add
 
-    >>> rs = dr.RuleSet(            # doctest: +SKIP 
+    >>> rs = dr.RuleSet(                # doctest: +SKIP
     ...         dr.RewriteRule((add, 'x', 0), 'x', ('x',)),
     ...         dr.RewriteRule((f, (g, 'x'), 'y'),
     ...                        (h, 'x', 'y'),
     ...                        ('x', 'y')))
 
-    >>> rs.rewrite((add, 2, 0))     # doctest: +SKIP  
+    >>> rs.rewrite((add, 2, 0))         # doctest: +SKIP
     2
 
     >>> rs.rewrite((f, (g, 'a', 3)))    # doctest: +SKIP

--- a/dask/rewrite.py
+++ b/dask/rewrite.py
@@ -150,10 +150,11 @@ class RewriteRule(object):
     `(list, (list, 'x'))` is replaced with `(list, 'x')`, where `'x'` is a
     variable.
 
+    >>> import dask.rewrite as dr
     >>> lhs = (list, (list, 'x'))
     >>> rhs = (list, 'x')
     >>> variables = ('x',)
-    >>> rule = RewriteRule(lhs, rhs, variables)
+    >>> rule = dr.RewriteRule(lhs, rhs, variables)
 
     Here's a more complicated rule that uses a callable right-hand-side. A
     callable `rhs` takes in a dictionary mapping variables to their matching
@@ -167,7 +168,7 @@ class RewriteRule(object):
     ...         return x
     ...     else:
     ...         return (list, x)
-    >>> rule = RewriteRule(lhs, repl_list, variables)
+    >>> rule = dr.RewriteRule(lhs, repl_list, variables)
     """
 
     def __init__(self, lhs, rhs, vars=()):
@@ -206,28 +207,29 @@ class RuleSet(object):
     Examples
     --------
 
+    >>> import dask.rewrite as dr
     >>> def f(*args): pass
     >>> def g(*args): pass
     >>> def h(*args): pass
     >>> from operator import add
 
-    >>> rs = RuleSet(                 # Make RuleSet with two Rules
-    ...         RewriteRule((add, 'x', 0), 'x', ('x',)),
-    ...         RewriteRule((f, (g, 'x'), 'y'),
-    ...                     (h, 'x', 'y'),
-    ...                     ('x', 'y')))
+    >>> rs = dr.RuleSet(            # doctest: +SKIP 
+    ...         dr.RewriteRule((add, 'x', 0), 'x', ('x',)),
+    ...         dr.RewriteRule((f, (g, 'x'), 'y'),
+    ...                        (h, 'x', 'y'),
+    ...                        ('x', 'y')))
 
-    >>> rs.rewrite((add, 2, 0))       # Apply ruleset to single task
+    >>> rs.rewrite((add, 2, 0))     # doctest: +SKIP  
     2
 
-    >>> rs.rewrite((f, (g, 'a', 3)))  # doctest: +SKIP
+    >>> rs.rewrite((f, (g, 'a', 3)))    # doctest: +SKIP
     (h, 'a', 3)
 
-    >>> dsk = {'a': (add, 2, 0),      # Apply ruleset to full dask graph
+    >>> dsk = {'a': (add, 2, 0),        # doctest: +SKIP
     ...        'b': (f, (g, 'a', 3))}
 
-    >>> from toolz import valmap
-    >>> valmap(rs.rewrite, dsk)  # doctest: +SKIP
+    >>> from toolz import valmap        # doctest: +SKIP
+    >>> valmap(rs.rewrite, dsk)         # doctest: +SKIP
     {'a': 2,
      'b': (h, 'a', 3)}
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1183,6 +1183,7 @@ def factors(n):
 def parse_bytes(s):
     """Parse byte string to numbers
 
+    >>> from dask.utils import parse_bytes
     >>> parse_bytes('100')
     100
     >>> parse_bytes('100 MB')
@@ -1256,6 +1257,7 @@ byte_sizes.update({k[:-1]: v for k, v in byte_sizes.items() if k and "i" in k})
 def format_time(n):
     """format integers as time
 
+    >>> from dask.utils import format_time
     >>> format_time(1)
     '1.00 s'
     >>> format_time(0.001234)
@@ -1275,6 +1277,7 @@ def format_time(n):
 def format_bytes(n):
     """Format bytes as text
 
+    >>> from dask.utils import format_bytes
     >>> format_bytes(1)
     '1 B'
     >>> format_bytes(1234)
@@ -1330,6 +1333,8 @@ def parse_timedelta(s, default="seconds"):
 
     Examples
     --------
+    >>> from datetime import timedelta
+    >>> from dask.utils import parse_timedelta
     >>> parse_timedelta('3s')
     3
     >>> parse_timedelta('3.5 seconds')

--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -169,6 +169,8 @@ This enables downstream computations that rely on having known chunk sizes
 The Dask DataFrame ``to_records`` method also returns a Dask Array, but does not compute the shape
 information:
 
+.. code-block:: python
+
    >>> df.to_records()
    dask.array<to_records, shape=(nan,), dtype=(numpy.record, [('index', '<i8'), ('x', '<f8'), ('y', '<f8'), ('z', '<f8')]), chunksize=(nan,), chunktype=numpy.ndarray>
 
@@ -342,6 +344,8 @@ To save data to a local TileDB array:
   >>> arr.to_tiledb('output.tdb')
 
 or to save to a bucket on S3:
+
+.. code-block:: python
 
   >>> arr.to_tiledb('s3://mybucket/output.tdb',
                     storage_options={'vfs.s3.aws_access_key_id': 'mykey',

--- a/docs/source/array-slicing.rst
+++ b/docs/source/array-slicing.rst
@@ -61,7 +61,7 @@ If we slice that with a *sorted* sequence of integers, Dask will return one chun
 per intput chunk (notince the output `chunksize` is 1, since the indices ``0``
 and ``1`` are in separate chunks in the input).
 
-   >>> a[[0, 1], :, :]
+   >>> a[[0, 1], :, :]          #doctest: +SKIP
    dask.array<getitem, shape=(2, 10000, 10000), dtype=float64, chunksize=(1, 10000, 10000), chunktype=numpy.ndarray>
 
 But what about repeated indices? Dask continues to return one chunk per input chunk,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -367,6 +367,10 @@ linkcheck_ignore = [
     r"^https?:\/\/localhost(?:[:\/].+)?$",
 ]
 
+doctest_global_setup = """
+import numpy as np
+"""
+
 
 def copy_legacy_redirects(app, docname):
     if app.builder.name == "html":

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ sys.path.insert(0, os.path.join(source_dir, "ext"))
 
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
     "sphinx.ext.mathjax",
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -449,8 +449,8 @@ Other functions
 .. currentmodule:: dask.dataframe.multi
 
 .. autofunction:: concat
-.. autofunction:: merge
-.. autofunction:: merge_asof
+.. autofunction:: merge         # doctest: +ELLIPSIS
+.. autofunction:: merge_asof    # doctest: +ELLIPSIS
 
 .. currentmodule:: dask.dataframe.reshape
 

--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -39,7 +39,7 @@ There are numerous pages with information about task runtimes, communication,
 statistical profiling, load balancing, memory use, and much more.
 For more information we recommend the video guide above.
 
-.. currentmodule:: dask.distributed
+.. currentmodule:: dask.distributed     #doctest: +SKIP
 
 .. autosummary::
    Client
@@ -95,7 +95,7 @@ detail:
 Progress bar
 ------------
 
-.. currentmodule:: dask.distributed
+.. currentmodule:: dask.distributed     #doctest: +SKIP
 
 .. autosummary::
    progress

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -22,7 +22,7 @@ despite its name, runs very well on a single machine).
            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
            allowfullscreen></iframe>
 
-.. currentmodule:: distributed
+.. currentmodule:: distributed #doctest: +SKIP
 
 Examples
 --------

--- a/docs/source/setup/adaptive.rst
+++ b/docs/source/setup/adaptive.rst
@@ -50,7 +50,7 @@ offer an ``.adapt()`` method.  Here is an example with
 
 For more keyword options, see the Adaptive class below:
 
-.. currentmodule:: distributed.deploy
+.. currentmodule:: distributed.deploy   #doctest: +SKIP
 
 .. autosummary::
    Adaptive

--- a/docs/source/setup/custom-startup.rst
+++ b/docs/source/setup/custom-startup.rst
@@ -112,7 +112,7 @@ You can also create a class with ``setup``, ``teardown``, and ``transition`` met
 and register that class with the scheduler to give to every worker using the
 ``Client.register_worker_plugin`` method.
 
-.. currentmodule:: distributed
+.. currentmodule:: distributed  #doctest: +SKIP
 
 .. autosummary::
    Client.register_worker_plugin

--- a/docs/source/setup/python-advanced.rst
+++ b/docs/source/setup/python-advanced.rst
@@ -1,7 +1,7 @@
 Python API (advanced)
 =====================
 
-.. currentmodule:: distributed
+.. currentmodule:: distributed  #doctest: +SKIP
 
 In some rare cases, experts may want to create ``Scheduler``, ``Worker``, and
 ``Nanny``  objects explicitly in Python.  This is often necessary when making

--- a/docs/source/setup/ssh.rst
+++ b/docs/source/setup/ssh.rst
@@ -10,7 +10,7 @@ or automatically using either the ``SSHCluster`` Python command or the
 Python Interface
 ----------------
 
-.. currentmodule:: distributed.deploy.ssh
+.. currentmodule:: distributed.deploy.ssh   #doctest: +SKIP
 
 .. autofunction:: SSHCluster
 


### PR DESCRIPTION
Identified that there is a single failed test because of a missing dependency in the instructions: sqlalchemy...

```
UNEXPECTED EXCEPTION: ModuleNotFoundError("No module named 'sqlalchemy'")
Traceback (most recent call last):
  File "/home/jambyr/anaconda3/envs/dask/lib/python3.8/doctest.py", line 1336, in __run
    exec(compile(example.source, filename, "single",
  File "<doctest dask.dataframe.io.sql.to_sql[6]>", line 1, in <module>
ModuleNotFoundError: No module named 'sqlalchemy'
/home/jambyr/code/public/dask/dask/dataframe/io/sql.py:338: UnexpectedException
```

Therefore by adding sqlalchemy to the develop.rst we can ensure people can test completely and successfully based on the instructions? 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
