### PR TITLE
Fixes broken links (#4058)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ log
 .pytest_cache/
 .coverage
 .DS_Store
+*.sqlite
 *.swp
 *.swo
 .cache/

--- a/dask/array/gufunc.py
+++ b/dask/array/gufunc.py
@@ -12,7 +12,7 @@ from ..core import flatten
 # Modified version of `numpy.lib.function_base._parse_gufunc_signature`
 # Modifications:
 #   - Allow for zero input arguments
-# See https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
+# See https://docs.scipy.org/doc/numpy/reference/c-api/generalized-ufuncs.html
 _DIMENSION_NAME = r"\w+"
 _CORE_DIMENSION_LIST = "(?:{0:}(?:,{0:})*,?)?".format(_DIMENSION_NAME)
 _ARGUMENT = r"\({}\)".format(_CORE_DIMENSION_LIST)
@@ -270,7 +270,7 @@ def apply_gufunc(func, signature, *args, **kwargs):
     References
     ----------
     .. [1] https://docs.scipy.org/doc/numpy/reference/ufuncs.html
-    .. [2] https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
+    .. [2] https://docs.scipy.org/doc/numpy/reference/c-api/generalized-ufuncs.html
     """
     axes = kwargs.pop("axes", None)
     axis = kwargs.pop("axis", None)
@@ -580,7 +580,7 @@ class gufunc(object):
     References
     ----------
     .. [1] https://docs.scipy.org/doc/numpy/reference/ufuncs.html
-    .. [2] https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
+    .. [2] https://docs.scipy.org/doc/numpy/reference/c-api/generalized-ufuncs.html
     """
 
     def __init__(self, pyfunc, **kwargs):
@@ -710,7 +710,7 @@ def as_gufunc(signature=None, **kwargs):
     References
     ----------
     .. [1] https://docs.scipy.org/doc/numpy/reference/ufuncs.html
-    .. [2] https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
+    .. [2] https://docs.scipy.org/doc/numpy/reference/c-api/generalized-ufuncs.html
     """
     _allowedkeys = {
         "vectorize",

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+PYTEST        = pytest
 PAPER         =
 BUILDDIR      = build
 
@@ -142,10 +143,11 @@ changes:
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
 linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	# Preferring pytest check-links over sphinx due to rate limiting issue: https://github.com/sphinx-doc/sphinx/issues/7388
+	# $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	$(PYTEST) --check-links --check-links-cache
 	@echo
-	@echo "Link check complete; look for any errors in the above output " \
-	      "or in $(BUILDDIR)/linkcheck/output.txt."
+	@echo "Link check complete; look for any errors in the above output "
 
 doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -8,3 +8,6 @@ pandas>=0.23.0
 distributed>=2.14.0
 fsspec
 scipy
+pytest
+pytest-check-links
+requests-cache

--- a/docs/source/array-gufunc.rst
+++ b/docs/source/array-gufunc.rst
@@ -1,9 +1,9 @@
 Generalized Ufuncs
 ==================
 
-`NumPy <https://www.numpy.org>`_ provides the concept of `generalized ufuncs <https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html>`_. Generalized ufuncs are functions
+`NumPy <https://www.numpy.org>`_ provides the concept of `generalized ufuncs <https://docs.scipy.org/doc/numpy/reference/c-api/generalized-ufuncs.html>`_. Generalized ufuncs are functions
 that distinguish the various dimensions of passed arrays in the two classes loop dimensions
-and core dimensions. To accomplish this, a `signature <https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html#details-of-signature>`_ is specified for NumPy generalized ufuncs.
+and core dimensions. To accomplish this, a `signature <https://docs.scipy.org/doc/numpy/reference/c-api/generalized-ufuncs.html#details-of-signature>`_ is specified for NumPy generalized ufuncs.
 
 `Dask <https://dask.org/>`_ integrates interoperability with NumPy's generalized ufuncs
 by adhering to respective `ufunc protocol <https://docs.scipy.org/doc/numpy/reference/arrays.classes.html#numpy.class.__array_ufunc__>`_, and provides a wrapper to make a Python function a generalized ufunc.

--- a/docs/source/caching.rst
+++ b/docs/source/caching.rst
@@ -93,7 +93,7 @@ characteristics:
 
 We can activate a fixed sized cache as a callback_:
 
-.. _callback: diagnostics.rst
+.. _callback: diagnostics-local.html#custom-callbacks
 
 .. code-block:: python
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3163,7 +3163,7 @@ Other
 .. _`Albert DeFusco`: https://github.com/AlbertDeFusco
 .. _`Markus Gonser`: https://github.com/magonser
 .. _`Martijn Arts`: https://github.com/mfaafm
-.. _`Jon Mease`: https://github.com/jmmease
+.. _`Jon Mease`: https://github.com/jonmmease
 .. _`Xander Johnson`: https://github.com/metasyn
 .. _`Nir`: https://github.com/nirizr
 .. _`Keisuke Fujii`: https://github.com/fujiisoup
@@ -3252,7 +3252,7 @@ Other
 .. _`Adam Beberg`: https://github.com/beberg
 .. _`Johnnie Gray`: https://github.com/jcmgray
 .. _`Roma Sokolov`: https://github.com/little-arhat
-.. _`Daniel Severo`: https://github.com/daniel-severo
+.. _`Daniel Severo`: https://github.com/dsevero
 .. _`Michał Jastrzębski`: https://github.com/inc0
 .. _`Janne Vuorela`: https://github.com/Dimplexion
 .. _`Ross Petchler`: https://github.com/rpetchler
@@ -3264,7 +3264,7 @@ Other
 .. _`@HSR05`: https://github.com/HSR05
 .. _`Ben Zaitlen`: https://github.com/quasiben
 .. _`Brett Naul`: https://github.com/bnaul
-.. _`Justin Poehnelt`: https://github.com/justinwp
+.. _`Justin Poehnelt`: https://github.com/jpoehnelt
 .. _`Dan O'Donovan`: https://github.com/danodonovan
 .. _`amerkel2`: https://github.com/amerkel2
 .. _`Justin Waugh`: https://github.com/bluecoconut

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -372,6 +372,11 @@ html_context = {
     "css_files": ["_static/theme_overrides.css"]  # override wide tables in RTD theme
 }
 
+# Rate limiting issue for github: https://github.com/sphinx-doc/sphinx/issues/7388
+linkcheck_ignore = [
+    r"^https?:\/\/(?:www\.)?github.com\/",
+    r"^https?:\/\/localhost(?:[:\/].+)?$",
+]
 
 def copy_legacy_redirects(app, docname):
     if app.builder.name == "html":

--- a/docs/source/dataframe-best-practices.rst
+++ b/docs/source/dataframe-best-practices.rst
@@ -108,7 +108,7 @@ It is often ideal to load, filter, and shuffle data once and keep this result in
 memory.  Afterwards, each of the several complex queries can be based off of
 this in-memory data rather than have to repeat the full load-filter-shuffle
 process each time.  To do this, use the `client.persist
-<https://distributed.dask.org/en/latest/api.html#distributed.client.Client.persist>`_
+<https://distributed.dask.org/en/latest/api.html#distributed.Client.persist>`_
 method:
 
 .. code-block:: python

--- a/docs/source/dataframe-indexing.rst
+++ b/docs/source/dataframe-indexing.rst
@@ -92,7 +92,7 @@ Slicing rows and (optionally) columns with ``.loc``:
    c                ...
    Dask Name: try_loc, 2 tasks
 
-Dask DataFrame supports Pandas' `partial-string indexing <https://pandas.pydata.org/pandas-docs/stable/timeseries.html#partial-string-indexing>`_:
+Dask DataFrame supports Pandas' `partial-string indexing <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#partial-string-indexing>`_:
 
 .. code-block:: python
 

--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -155,16 +155,16 @@ commonly.
 Web Diagnostics
 ~~~~~~~~~~~~~~~
 
-First, the distributed scheduler has a number of `diagnostic web pages
-<https://distributed.dask.org/en/latest/web.html>`_ showing dozens of
+First, the distributed scheduler has a number of `diagnostic tools
+<https://distributed.dask.org/en/latest/diagnosing-performance.html>`_ showing dozens of
 recorded metrics like CPU, memory, network, and disk use, a history of previous
 tasks, allocation of tasks to workers, worker memory pressure, work stealing,
 open file handle limits, etc.  *Many* problems can be correctly diagnosed by
 inspecting these pages.  By default, these are available at
 ``http://scheduler:8787/``, ``http://scheduler:8788/``, and ``http://worker:8789/``,
 where ``scheduler`` and ``worker`` should be replaced by the addresses of the
-scheduler and each of the workers. See `web diagnostic docs
-<https://distributed.dask.org/en/latest/web.html>`_ for more information.
+scheduler and each of the workers. See `diagnosing performance docs
+<https://distributed.dask.org/en/latest/diagnosing-performance.html>`_ for more information.
 
 Logs
 ~~~~
@@ -232,7 +232,7 @@ LocalCluster
 
 If you are using the distributed scheduler from a single machine, you may be
 setting up workers manually using the command line interface or you may be
-using `LocalCluster <https://distributed.dask.org/en/latest/local-cluster.html>`_
+using `LocalCluster <https://distributed.dask.org/en/latest/api.html#cluster>`_
 which is what runs when you just call ``Client()``:
 
 .. code-block:: python

--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -30,7 +30,7 @@ For local use this happens when you create a client with no arguments:
    from dask.distributed import Client
    client = Client()  # start distributed scheduler locally.  Launch dashboard
 
-It is typically served at http://localhost:8787/status ,
+It is typically served at ``http://localhost:8787/status`` ,
 but may be served elsewhere if this port is taken.
 The address of the dashboard will be displayed if you are in a Jupyter Notebook,
 or can be queried from ``client.scheduler_info()['services']``.

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -45,7 +45,7 @@ among the various worker processes or threads:
    client = Client(processes=False)  # start local workers as threads
 
 If you have `Bokeh <https://bokeh.pydata.org>`_ installed, then this starts up a
-diagnostic dashboard at http://localhost:8787 .
+diagnostic dashboard at ``http://localhost:8787`` .
 
 Submit Tasks
 ------------

--- a/docs/source/remote-data-services.rst
+++ b/docs/source/remote-data-services.rst
@@ -131,7 +131,7 @@ The following additional options may be passed to the ``PyArrow`` driver via
 PyArrow's ``libhdfs`` driver can also be affected by a few environment
 variables. For more information on these, see the `PyArrow documentation`_.
 
-.. _PyArrow documentation: https://arrow.apache.org/docs/python/filesystems.html#hadoop-file-system-hdfs
+.. _PyArrow documentation: https://arrow.apache.org/docs/python/filesystems_deprecated.html#hadoop-file-system-hdfs
 
 
 Amazon S3
@@ -186,7 +186,7 @@ The following parameters may be passed to s3fs using ``storage_options``:
 
 .. _boto3 client: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client
 .. _boto3 Session: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
-.. _here: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#shared-credentials-file
+.. _here: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#shared-credentials-file
 .. _s3fs.S3FileSystem: https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem
 .. _boto3 client's config: https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
 

--- a/docs/source/setup/single-distributed.rst
+++ b/docs/source/setup/single-distributed.rst
@@ -20,7 +20,7 @@ set.
    from dask.distributed import Client
    client = Client()
 
-You can navigate to http://localhost:8787/status to see the diagnostic
+You can navigate to ``http://localhost:8787/status`` to see the diagnostic
 dashboard if you have Bokeh installed.
 
 Client

--- a/docs/source/spark.rst
+++ b/docs/source/spark.rst
@@ -189,7 +189,7 @@ In particular, for users coming from traditional Hadoop/Spark clusters (such as
 those sold by Cloudera/Hortonworks) you are using the Yarn resource
 manager.  You can deploy Dask on these systems using the `Dask Yarn
 <https://yarn.dask.org>`_ project, as well as other projects, like `JupyterHub
-on Hadoop <https://jcrist.github.io/jupyterhub-on-hadoop/>`_.
+on Hadoop <https://jupyterhub-on-hadoop.readthedocs.io/en/latest/>`_.
 
 
 Developer-Facing Differences

--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -75,5 +75,5 @@ Paid support
 ------------
 In addition to the previous options, paid support is available from
 
--   Anaconda: `<https://www.anaconda.com/support>`_
+-   Anaconda: `<https://www.anaconda.com/help>`_
 -   Quansight: `<https://www.quansight.com/open-source-support>`_


### PR DESCRIPTION
Some additional items addressed:

  * changed permissions to remove executable bit on dask/array/gufunc.py
  * altered sphinx configuration to not link check localhost and github.com (rate limiting) URLs
  * fixed all broken links identified in make linkcheck

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Draft request currently, as part of 4058 will investigate whether any other alterations are required to support CI and what impact the removal of github checks have before finalising