### PR TITLE
Unpin `numpydoc` following 1.1 release

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,4 @@
-# We pin numpydoc to avoid doubly-escaped *args and **kwargs in rendered docs
-# due to a weird interaction between sphinx autosummary and numpydoc >= 0.9.0
-numpydoc==0.8.0
+numpydoc
 sphinx
 dask-sphinx-theme>=1.1.0
 sphinx-click


### PR DESCRIPTION
Fix for errant backslashes was fixed upstream and released.
https://numpydoc.readthedocs.io/en/latest/release_notes.html#fixed-bugs
https://github.com/numpy/numpydoc/issues/218

- [ ] ~Tests added / passed~
- [x] Passes `black dask` / `flake8 dask`
