### PR TITLE
Duplicate argument definitions in `to_csv` docstring

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -730,11 +730,6 @@ def to_csv(
         Data to save
     filename : string
         Path glob indicating the naming scheme for the output files
-    name_function : callable, default None
-        Function accepting an integer (partition index) and producing a
-        string to replace the asterisk in the given filename globstring.
-        Should preserve the lexicographic order of partitions. Not
-        supported when `single_file` is `True`.
     single_file : bool, default False
         Whether to save everything into a single CSV file. Under the
         single file mode, each partition is appended at the end of the
@@ -742,13 +737,33 @@ def to_csv(
         append mode and thus the single file mode, especially on cloud
         storage systems such as S3 or GCS. A warning will be issued when
         writing to a file that is not backed by a local filesystem.
+    encoding : string, optional
+        A string representing the encoding to use in the output file,
+        defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
+    mode : str
+        Python write mode, default 'w'
+    name_function : callable, default None
+        Function accepting an integer (partition index) and producing a
+        string to replace the asterisk in the given filename globstring.
+        Should preserve the lexicographic order of partitions. Not
+        supported when `single_file` is `True`.
     compression : string, optional
         a string representing the compression to use in the output file,
         allowed values are 'gzip', 'bz2', 'xz',
         only used when the first argument is a filename
-    compute: bool
+    compute : bool
         If true, immediately executes. If False, returns a set of delayed
         objects, which can be computed at a later time.
+    storage_options : dict
+        Parameters passed on to the backend filesystem class.
+    header_first_partition_only : boolean, default None
+        If set to `True`, only write the header row in the first output
+        file. By default, headers are written to all partitions under
+        the multiple file mode (`single_file` is `False`) and written
+        only once under the single file mode (`single_file` is `True`).
+        It must not be `False` under the single file mode.
+    compute_kwargs : dict, optional
+        Options to be passed in to the compute method
     sep : character, default ','
         Field delimiter for the output file
     na_rep : string, default ''
@@ -760,12 +775,6 @@ def to_csv(
     header : boolean or list of string, default True
         Write out column names. If a list of string is given it is assumed
         to be aliases for the column names
-    header_first_partition_only : boolean, default None
-        If set to `True`, only write the header row in the first output
-        file. By default, headers are written to all partitions under
-        the multiple file mode (`single_file` is `False`) and written
-        only once under the single file mode (`single_file` is `True`).
-        It must not be `False` under the single file mode.
     index : boolean, default True
         Write row names (index)
     index_label : string or sequence, or False, default None
@@ -776,11 +785,6 @@ def to_csv(
         for easier importing in R
     nanRep : None
         deprecated, use na_rep
-    mode : str
-        Python write mode, default 'w'
-    encoding : string, optional
-        A string representing the encoding to use in the output file,
-        defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
     line_terminator : string, default '\\n'
         The newline character or character sequence to use in the output
         file
@@ -802,10 +806,6 @@ def to_csv(
     decimal: string, default '.'
         Character recognized as decimal separator. E.g. use ',' for
         European data
-    storage_options: dict
-        Parameters passed on to the backend filesystem class.
-    compute_kwargs : dict, optional
-        Options to be passed in to the compute method
 
     Returns
     -------

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -726,6 +726,8 @@ def to_csv(
 
     Parameters
     ----------
+    df : dask.DataFrame
+        Data to save
     filename : string
         Path glob indicating the naming scheme for the output files
     name_function : callable, default None

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -764,48 +764,8 @@ def to_csv(
         It must not be `False` under the single file mode.
     compute_kwargs : dict, optional
         Options to be passed in to the compute method
-    sep : character, default ','
-        Field delimiter for the output file
-    na_rep : string, default ''
-        Missing data representation
-    float_format : string, default None
-        Format string for floating point numbers
-    columns : sequence, optional
-        Columns to write
-    header : boolean or list of string, default True
-        Write out column names. If a list of string is given it is assumed
-        to be aliases for the column names
-    index : boolean, default True
-        Write row names (index)
-    index_label : string or sequence, or False, default None
-        Column label for index column(s) if desired. If None is given, and
-        `header` and `index` are True, then the index names are used. A
-        sequence should be given if the DataFrame uses MultiIndex.  If
-        False do not print fields for index names. Use index_label=False
-        for easier importing in R
-    nanRep : None
-        deprecated, use na_rep
-    line_terminator : string, default '\\n'
-        The newline character or character sequence to use in the output
-        file
-    quoting : optional constant from csv module
-        defaults to csv.QUOTE_MINIMAL
-    quotechar : string (length 1), default '\"'
-        character used to quote fields
-    doublequote : boolean, default True
-        Control quoting of `quotechar` inside a field
-    escapechar : string (length 1), default None
-        character used to escape `sep` and `quotechar` when appropriate
-    chunksize : int or None
-        rows to write at a time
-    tupleize_cols : boolean, default False
-        write multi_index columns as a list of tuples (if True)
-        or new (expanded format) if False)
-    date_format : string, default None
-        Format string for datetime objects
-    decimal: string, default '.'
-        Character recognized as decimal separator. E.g. use ',' for
-        European data
+    kwargs : dict, optional
+        Additional parameters to pass to `pd.DataFrame.to_csv()`
 
     Returns
     -------

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -740,10 +740,10 @@ def to_csv(
         append mode and thus the single file mode, especially on cloud
         storage systems such as S3 or GCS. A warning will be issued when
         writing to a file that is not backed by a local filesystem.
-    compression : string or None
-        String like 'gzip' or 'xz'.  Must support efficient random access.
-        Filenames with extensions corresponding to known compression
-        algorithms (gz, bz2) will be compressed accordingly automatically
+    compression : string, optional
+        a string representing the compression to use in the output file,
+        allowed values are 'gzip', 'bz2', 'xz',
+        only used when the first argument is a filename
     compute: bool
         If true, immediately executes. If False, returns a set of delayed
         objects, which can be computed at a later time.
@@ -779,10 +779,6 @@ def to_csv(
     encoding : string, optional
         A string representing the encoding to use in the output file,
         defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
-    compression : string, optional
-        a string representing the compression to use in the output file,
-        allowed values are 'gzip', 'bz2', 'xz',
-        only used when the first argument is a filename
     line_terminator : string, default '\\n'
         The newline character or character sequence to use in the output
         file


### PR DESCRIPTION
There are two definitions of `compression` arguments in `data.dataframe.io.csv.to_csv` docstring and one of them does not match with the implementation. 

https://github.com/dask/dask/blob/7aaef9fa8d9d37c7c7e57a1125d7d06ef2a8fefb/dask/dataframe/io/csv.py#L743-L746

https://github.com/dask/dask/blob/7aaef9fa8d9d37c7c7e57a1125d7d06ef2a8fefb/dask/dataframe/io/csv.py#L782-L785

**What happened**:
I noticed that compression didn't apply automatically even though the `gz` was an extension of the filename when I was using `data.dataframe.io.csv.to_csv`. Then, I realized there were two `compression` arguments in the [API documentation](https://docs.dask.org/en/latest/dataframe-api.html#dask.dataframe.to_csv). 

**What you expected to happen**:
I expected the argument definitions in the `to_csv` docstring to match up with its implementation. 

**Environment**:
- Dask version: 2.19.0
- Python version: Python 3.7.3
- Operating System: macOS
- Install method (conda, pip, source): poetry