### PR TITLE
CI: Install deps of upstream-dev packages

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -36,7 +36,6 @@ if [[ ${UPSTREAM_DEV} ]]; then
         numpy \
         pandas
     python -m pip install \
-        --no-deps \
         --upgrade \
         locket \
         git+https://github.com/pydata/sparse \


### PR DESCRIPTION
gcsfs upstream tests failing since it now depends on aiohttp.

We should be OK to exclude `--no-deps` now that pip's default
upgrade-strategy is only-if-needed.

test-upstream