### PR TITLE
When RecursionError is raised, return uuid from tokenize function

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -697,7 +697,13 @@ def normalize_set(s):
 
 @normalize_token.register((tuple, list))
 def normalize_seq(seq):
-    return type(seq).__name__, list(map(normalize_token, seq))
+    def func(seq):
+        try:
+            return list(map(normalize_token, seq))
+        except RecursionError:
+            return str(uuid.uuid4())
+
+    return type(seq).__name__, func(seq)
 
 
 @normalize_token.register(literal)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -460,6 +460,13 @@ def test_tokenize_dense_sparse_array(cls_name):
     assert tokenize(a) != tokenize(b)
 
 
+def test_tokenize_object_with_recursion_error_returns_uuid():
+    cycle = dict(a=None)
+    cycle["a"] = cycle
+
+    assert len(tokenize(cycle)) == 32
+
+
 def test_is_dask_collection():
     class DummyCollection(object):
         def __init__(self, dsk=None):


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
- [x] Closes #6425
