### PR TITLE
Add tolist dispatch

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2827,7 +2827,7 @@ Dask Name: {name}, {task} tasks""".format(
                             "isn't monotonic_increasing"
                         )
                         raise ValueError(msg)
-                    res.divisions = tuple(methods.to_list(new))
+                    res.divisions = tuple(methods.tolist(new))
                 else:
                     res = res.clear_divisions()
             if inplace:
@@ -3597,7 +3597,7 @@ class DataFrame(_Frame):
         return iter(self._meta)
 
     def _ipython_key_completions_(self):
-        return methods.to_list(self.columns)
+        return methods.tolist(self.columns)
 
     @property
     def ndim(self):
@@ -4747,7 +4747,7 @@ def elemwise(op, *args, **kwargs):
                 **kwargs,
             )
             if isinstance(divisions, pd.Index):
-                divisions = methods.to_list(divisions)
+                divisions = methods.tolist(divisions)
         except Exception:
             pass
         else:
@@ -5238,7 +5238,7 @@ def map_partitions(
                 *[pd.Index(a.divisions) if a is dfs[0] else a for a in args], **kwargs
             )
             if isinstance(divisions, pd.Index):
-                divisions = methods.to_list(divisions)
+                divisions = methods.tolist(divisions)
         except Exception:
             pass
         else:
@@ -5857,7 +5857,7 @@ def repartition_freq(df, freq=None):
         start = df.divisions[0].ceil(freq)
     except ValueError:
         start = df.divisions[0]
-    divisions = methods.to_list(
+    divisions = methods.tolist(
         pd.date_range(start=start, end=df.divisions[-1], freq=freq)
     )
     if not len(divisions):
@@ -5966,7 +5966,7 @@ def repartition_npartitions(df, npartitions):
                 fp=divisions,
             )
             if np.issubdtype(original_divisions.dtype, np.datetime64):
-                divisions = methods.to_list(
+                divisions = methods.tolist(
                     pd.Series(divisions).astype(original_divisions.dtype)
                 )
             elif np.issubdtype(original_divisions.dtype, np.integer):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2827,7 +2827,7 @@ Dask Name: {name}, {task} tasks""".format(
                             "isn't monotonic_increasing"
                         )
                         raise ValueError(msg)
-                    res.divisions = tuple(new.tolist())
+                    res.divisions = tuple(methods.to_list(new))
                 else:
                     res = res.clear_divisions()
             if inplace:
@@ -3597,7 +3597,7 @@ class DataFrame(_Frame):
         return iter(self._meta)
 
     def _ipython_key_completions_(self):
-        return self.columns.tolist()
+        return methods.to_list(self.columns)
 
     @property
     def ndim(self):
@@ -4747,7 +4747,7 @@ def elemwise(op, *args, **kwargs):
                 **kwargs,
             )
             if isinstance(divisions, pd.Index):
-                divisions = divisions.tolist()
+                divisions = methods.to_list(divisions)
         except Exception:
             pass
         else:
@@ -5238,7 +5238,7 @@ def map_partitions(
                 *[pd.Index(a.divisions) if a is dfs[0] else a for a in args], **kwargs
             )
             if isinstance(divisions, pd.Index):
-                divisions = divisions.tolist()
+                divisions = methods.to_list(divisions)
         except Exception:
             pass
         else:
@@ -5857,7 +5857,7 @@ def repartition_freq(df, freq=None):
         start = df.divisions[0].ceil(freq)
     except ValueError:
         start = df.divisions[0]
-    divisions = pd.date_range(start=start, end=df.divisions[-1], freq=freq).tolist()
+    divisions = methods.to_list(pd.date_range(start=start, end=df.divisions[-1], freq=freq))
     if not len(divisions):
         divisions = [df.divisions[0], df.divisions[-1]]
     else:
@@ -5965,7 +5965,7 @@ def repartition_npartitions(df, npartitions):
             )
             if np.issubdtype(original_divisions.dtype, np.datetime64):
                 divisions = (
-                    pd.Series(divisions).astype(original_divisions.dtype).tolist()
+                    methods.to_list(pd.Series(divisions).astype(original_divisions.dtype))
                 )
             elif np.issubdtype(original_divisions.dtype, np.integer):
                 divisions = divisions.astype(original_divisions.dtype)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5857,7 +5857,9 @@ def repartition_freq(df, freq=None):
         start = df.divisions[0].ceil(freq)
     except ValueError:
         start = df.divisions[0]
-    divisions = methods.to_list(pd.date_range(start=start, end=df.divisions[-1], freq=freq))
+    divisions = methods.to_list(
+        pd.date_range(start=start, end=df.divisions[-1], freq=freq)
+    )
     if not len(divisions):
         divisions = [df.divisions[0], df.divisions[-1]]
     else:
@@ -5964,8 +5966,8 @@ def repartition_npartitions(df, npartitions):
                 fp=divisions,
             )
             if np.issubdtype(original_divisions.dtype, np.datetime64):
-                divisions = (
-                    methods.to_list(pd.Series(divisions).astype(original_divisions.dtype))
+                divisions = methods.to_list(
+                    pd.Series(divisions).astype(original_divisions.dtype)
                 )
             elif np.issubdtype(original_divisions.dtype, np.integer):
                 divisions = divisions.astype(original_divisions.dtype)

--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -8,6 +8,7 @@ from .io import from_delayed, from_pandas
 from ... import delayed
 from .. import methods
 
+
 def read_sql_table(
     table,
     uri,
@@ -179,11 +180,13 @@ def read_sql_table(
                 or 1
             )
         if dtype.kind == "M":
-            divisions = methods.to_list(pd.date_range(
-                start=mini,
-                end=maxi,
-                freq="%iS" % ((maxi - mini).total_seconds() / npartitions),
-            ))
+            divisions = methods.to_list(
+                pd.date_range(
+                    start=mini,
+                    end=maxi,
+                    freq="%iS" % ((maxi - mini).total_seconds() / npartitions),
+                )
+            )
             divisions[0] = mini
             divisions[-1] = maxi
         elif dtype.kind in ["i", "u", "f"]:

--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -6,7 +6,7 @@ from dask.dataframe.utils import PANDAS_GT_0240, PANDAS_VERSION
 from dask.delayed import tokenize
 from .io import from_delayed, from_pandas
 from ... import delayed
-
+from .. import methods
 
 def read_sql_table(
     table,
@@ -179,11 +179,11 @@ def read_sql_table(
                 or 1
             )
         if dtype.kind == "M":
-            divisions = pd.date_range(
+            divisions = methods.to_list(pd.date_range(
                 start=mini,
                 end=maxi,
                 freq="%iS" % ((maxi - mini).total_seconds() / npartitions),
-            ).tolist()
+            ))
             divisions[0] = mini
             divisions[-1] = maxi
         elif dtype.kind in ["i", "u", "f"]:

--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -180,7 +180,7 @@ def read_sql_table(
                 or 1
             )
         if dtype.kind == "M":
-            divisions = methods.to_list(
+            divisions = methods.tolist(
                 pd.date_range(
                     start=mini,
                     end=maxi,

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -167,7 +167,7 @@ def describe_numeric_aggregate(stats, name=None, is_timedelta_col=False):
 
     part1 = typ([count, mean, std, min], index=["count", "mean", "std", "min"])
 
-    q.index = ["{0:g}%".format(l * 100) for l in to_list(q.index)]
+    q.index = ["{0:g}%".format(l * 100) for l in tolist(q.index)]
     if is_series_like(q) and typ != type(q):
         q = q.to_frame()
     part3 = typ([max], index=["max"])
@@ -540,16 +540,16 @@ def concat_pandas(
     return out
 
 
-to_list_dispatch = Dispatch("to_list")
+tolist_dispatch = Dispatch("tolist")
 
 
-def to_list(obj):
-    func = to_list_dispatch.dispatch(type(obj))
+def tolist(obj):
+    func = tolist_dispatch.dispatch(type(obj))
     return func(obj)
 
 
-@to_list_dispatch.register((pd.Series, pd.Index, pd.Categorical))
-def to_list_pandas(obj):
+@tolist_dispatch.register((pd.Series, pd.Index, pd.Categorical))
+def tolist_pandas(obj):
     return obj.tolist()
 
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -167,7 +167,7 @@ def describe_numeric_aggregate(stats, name=None, is_timedelta_col=False):
 
     part1 = typ([count, mean, std, min], index=["count", "mean", "std", "min"])
 
-    q.index = ["{0:g}%".format(l * 100) for l in q.index.tolist()]
+    q.index = ["{0:g}%".format(l * 100) for l in to_list(q.index)]
     if is_series_like(q) and typ != type(q):
         q = q.to_frame()
     part3 = typ([max], index=["max"])
@@ -539,6 +539,18 @@ def concat_pandas(
         out.index = ind
     return out
 
+
+to_list_dispatch = Dispatch("to_list")
+
+
+def to_list(obj):
+    func = to_list_dispatch.dispatch(type(obj))
+    return func(obj)
+
+
+@to_list_dispatch.register((pd.Series, pd.Index, pd.Categorical))
+def to_list_pandas(obj):
+    return obj.tolist()
 
 # cuDF may try to import old dispatch functions
 hash_df = hash_object_dispatch

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -552,6 +552,7 @@ def to_list(obj):
 def to_list_pandas(obj):
     return obj.tolist()
 
+
 # cuDF may try to import old dispatch functions
 hash_df = hash_object_dispatch
 group_split = group_split_dispatch

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -84,7 +84,7 @@ def set_index(
         divisions, sizes, mins, maxes = base.compute(
             divisions, sizes, mins, maxes, optimize_graph=False
         )
-        divisions = methods.to_list(divisions)
+        divisions = methods.tolist(divisions)
 
         empty_dataframe_detected = pd.isnull(divisions).all()
         if repartition or empty_dataframe_detected:
@@ -238,7 +238,7 @@ def set_partition(
             column_dtype=df.columns.dtype,
         )
 
-    df4.divisions = methods.to_list(divisions)
+    df4.divisions = methods.tolist(divisions)
 
     return df4.map_partitions(M.sort_index)
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -84,7 +84,7 @@ def set_index(
         divisions, sizes, mins, maxes = base.compute(
             divisions, sizes, mins, maxes, optimize_graph=False
         )
-        divisions = divisions.tolist()
+        divisions = methods.to_list(divisions)
 
         empty_dataframe_detected = pd.isnull(divisions).all()
         if repartition or empty_dataframe_detected:
@@ -238,7 +238,7 @@ def set_partition(
             column_dtype=df.columns.dtype,
         )
 
-    df4.divisions = divisions.tolist()
+    df4.divisions = methods.to_list(divisions)
 
     return df4.map_partitions(M.sort_index)
 

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -7,7 +7,7 @@ from ...base import tokenize
 from ...utils import derived_from
 from ...highlevelgraph import HighLevelGraph
 from .._compat import PANDAS_GT_0240
-
+from .. import methods
 
 def getnanos(rule):
     try:
@@ -75,8 +75,8 @@ def _resample_bin_and_out_divs(divisions, rule, closed="left", label="left"):
     else:
         outdivs = tempdivs
 
-    newdivs = newdivs.tolist()
-    outdivs = outdivs.tolist()
+    newdivs = methods.to_list(newdivs)
+    outdivs = methods.to_list(outdivs)
 
     # Adjust ends
     if newdivs[0] < divisions[0]:

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -76,8 +76,8 @@ def _resample_bin_and_out_divs(divisions, rule, closed="left", label="left"):
     else:
         outdivs = tempdivs
 
-    newdivs = methods.to_list(newdivs)
-    outdivs = methods.to_list(outdivs)
+    newdivs = methods.tolist(newdivs)
+    outdivs = methods.tolist(outdivs)
 
     # Adjust ends
     if newdivs[0] < divisions[0]:

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -9,6 +9,7 @@ from ...highlevelgraph import HighLevelGraph
 from .._compat import PANDAS_GT_0240
 from .. import methods
 
+
 def getnanos(rule):
     try:
         return getattr(rule, "nanos", None)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -676,8 +676,8 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
 def check_matching_columns(meta, actual):
     # Need nan_to_num otherwise nan comparison gives False
     if not np.array_equal(np.nan_to_num(meta.columns), np.nan_to_num(actual.columns)):
-        extra = methods.to_list(actual.columns.difference(meta.columns))
-        missing = methods.to_list(meta.columns.difference(actual.columns))
+        extra = methods.tolist(actual.columns.difference(meta.columns))
+        missing = methods.tolist(meta.columns.difference(actual.columns))
         if extra or missing:
             extra_info = f"  Extra:   {extra}\n  Missing: {missing}"
         else:
@@ -776,7 +776,7 @@ def _maybe_sort(a):
                 a.index.names = [
                     "-overlapped-index-name-%d" % i for i in range(len(a.index.names))
                 ]
-            a = a.sort_values(by=methods.to_list(a.columns))
+            a = a.sort_values(by=methods.tolist(a.columns))
         else:
             a = a.sort_values()
     except (TypeError, IndexError, ValueError):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -43,6 +43,7 @@ from ..utils import is_index_like as dask_is_index_like
 from . import _dtypes  # noqa: F401
 from . import methods
 
+
 def is_integer_na_dtype(t):
     dtype = getattr(t, "dtype", t)
     if HAS_INT_NA:

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -41,7 +41,7 @@ from ..utils import is_index_like as dask_is_index_like
 
 # register pandas extension types
 from . import _dtypes  # noqa: F401
-
+from . import methods
 
 def is_integer_na_dtype(t):
     dtype = getattr(t, "dtype", t)
@@ -675,8 +675,8 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
 def check_matching_columns(meta, actual):
     # Need nan_to_num otherwise nan comparison gives False
     if not np.array_equal(np.nan_to_num(meta.columns), np.nan_to_num(actual.columns)):
-        extra = actual.columns.difference(meta.columns).tolist()
-        missing = meta.columns.difference(actual.columns).tolist()
+        extra = methods.to_list(actual.columns.difference(meta.columns))
+        missing = methods.to_list(meta.columns.difference(actual.columns))
         if extra or missing:
             extra_info = f"  Extra:   {extra}\n  Missing: {missing}"
         else:
@@ -775,7 +775,7 @@ def _maybe_sort(a):
                 a.index.names = [
                     "-overlapped-index-name-%d" % i for i in range(len(a.index.names))
                 ]
-            a = a.sort_values(by=a.columns.tolist())
+            a = a.sort_values(by=methods.to_list(a.columns))
         else:
             a = a.sort_values()
     except (TypeError, IndexError, ValueError):


### PR DESCRIPTION
This PR adds support for `tolist` dispatch to allow various backends to convert the values of the object into a python list object. Motivation of this addition is that `cudf` is going to be disabling direct support for `Index.tolist`/`Series.tolist` due to implicit performance impact as it involves moving data from GPU to host memory. 
However, we would be allowing this operation via a dispatch that is being added to dask in this PR.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

cc: @kkraus14 @jakirkham @shwina 