### PR TITLE
DOC: complete parameter server implementation

### DIFF
--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -791,15 +791,15 @@ Attribute access is synchronous and blocking:
 Example: Parameter Server
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Here's an example of a parameter server, one method to perform distributed
-machine learning. This parameter server perform this minimization:
+This example will perform the following minimization with a parameter server:
 
 .. math::
 
    \min_{p\in\R^{1000}} \sum_{i=1}^1000 (p_i - 2)^2
 
-Of course, this minimization is trivial and :math:`p_i = 2` for all :math:`i`.
-However, it suffices for illustration:
+The parameter server will hold the model, and the client will calculate the
+gradient. Of course, this minimization is trivial and :math:`p_i = 2` for all
+:math:`i`.  However, it suffices for illustration.
 
 .. code-block:: python
 
@@ -832,6 +832,7 @@ However, it suffices for illustration:
        new_params = train(params)
        ps.put('parameters', new_params)
 
+This example could be adapted to machine learning if desired.
 
 Asynchronous Operation
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -809,25 +809,25 @@ gradient. Of course, this minimization is trivial and :math:`p_i = 2` for all
    client = Client(processes=False)
 
    class ParameterServer:
-      def __init__(self):
-          self.data = dict()
+       def __init__(self):
+           self.data = dict()
 
-      def put(self, key, value):
-          self.data[key] = value
+       def put(self, key, value):
+           self.data[key] = value
 
-      def get(self, key):
-          return self.data[key]
+       def get(self, key):
+           return self.data[key]
 
    def train(params, lr=0.1):
-      grad = 2 * (params - 2)  # gradient of (params - 2)**2
-      new_params = params - lr * grad
-      return new_params
+       grad = 2 * (params - 2)  # gradient of (params - 2)**2
+       new_params = params - lr * grad
+       return new_params
 
-    ps_future = client.submit(ParameterServer, actor=True)
-    ps = ps_future.result()
+   ps_future = client.submit(ParameterServer, actor=True)
+   ps = ps_future.result()
 
-    ps.put('parameters', np.random.random(1000))
-    for k in range(20):
+   ps.put('parameters', np.random.random(1000))
+   for k in range(20):
        params = ps.get('parameters').result()
        new_params = train(params)
        ps.put('parameters', new_params)


### PR DESCRIPTION
**What does this PR implement?**
It completes the implementation of the parameter server in the documentation. Right now, it has invalid syntax: https://docs.dask.org/en/latest/futures.html#example-parameter-server.

**Reference issues/PRs**
I saw this issue when linked from https://github.com/dask/dask-examples/pull/158#discussion_r459106996.

- [n/a] Tests added / passed
- [n/a] Passes `black dask` / `flake8 dask`
