### PR TITLE
Validate config using jsonschema

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -386,8 +386,6 @@ class set:
 
         path = path + (key,)
 
-        validate({key: value})
-
         if len(keys) == 1:
             if record:
                 if key in d:
@@ -395,6 +393,7 @@ class set:
                 else:
                     self._record.append(("insert", path, None))
             d[key] = value
+            validate(d)
         else:
             if key not in d:
                 if record:

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -12,6 +12,7 @@ properties:
 
   tokenize:
     type: object
+    additionalProperties: false
     properties:
       ensure-deterministic:
         type:
@@ -23,6 +24,7 @@ properties:
 
   dataframe:
     type: object
+    additionalProperties: false
     properties:
 
       shuffle-compression:
@@ -53,7 +55,19 @@ properties:
 
   array:
     type: object
+    additionalProperties: false
     properties:
+
+      chunk-size:
+        type: [string, integer]
+        description: |
+          The maximum size (in bytes) of a chunk in an array.
+
+      rechunk-threshold:
+        type: integer
+        description: |
+          The graph growth factor under which we don't bother
+          introducing an intermediate step
 
       svg:
         type: object
@@ -78,6 +92,7 @@ properties:
 
   optimization:
     type: object
+    additionalProperties: false
     properties:
 
       fuse:


### PR DESCRIPTION
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
- [x] Closes #5695

I thought I'd open this to start the discussion around validation. I am not sure that this is the right approach. This is probably too aggressive since it'll make `import dask` fail if there is a bad config file. But maybe that *is* the right behavior? Obviously we can choose a much more user-facing error. 

![Screenshot from 2020-07-24 17-13-10](https://user-images.githubusercontent.com/4806877/88435804-ff662f80-cdd0-11ea-9dca-4e02400ecbfa.png)

Here are some timings:

```python 

# with jsonschema import
>>> %timeit from dask.config import config
616 ns ± 6.08 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

# without
>>> %timeit from dask.config import config
622 ns ± 17.1 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)