### PR TITLE
Implement `sizeof` for some `bytes`-like objects

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -1,5 +1,6 @@
 import random
 import sys
+from array import array
 from distutils.version import LooseVersion
 
 from .utils import Dispatch
@@ -19,6 +20,22 @@ sizeof = Dispatch(name="sizeof")
 @sizeof.register(object)
 def sizeof_default(o):
     return getsizeof(o)
+
+
+@sizeof.register(bytes)
+@sizeof.register(bytearray)
+def sizeof_bytes(o):
+    return len(o)
+
+
+@sizeof.register(memoryview)
+def sizeof_memoryview(o):
+    return o.nbytes
+
+
+@sizeof.register(array)
+def sizeof_array(o):
+    return o.itemsize * len(o)
 
 
 @sizeof.register(list)

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -1,4 +1,5 @@
 import sys
+from array import array
 
 import pytest
 
@@ -16,6 +17,13 @@ def test_name():
 
 def test_containers():
     assert sizeof([1, 2, [3]]) > (getsizeof(3) * 3 + getsizeof([]))
+
+
+def test_bytes_like():
+    assert 1000 <= sizeof(bytes(1000)) <= 2000
+    assert 1000 <= sizeof(bytearray(1000)) <= 2000
+    assert 1000 <= sizeof(memoryview(bytes(1000))) <= 2000
+    assert 8000 <= sizeof(array("d", range(1000))) <= 9000
 
 
 def test_numpy():


### PR DESCRIPTION
As it appears we don't actually support `sizeof` for `bytes`-like types [on PyPy]( https://github.com/dask/dask/blob/326a12a940f815d27ecf3afac623927a17c1c83b/dask/sizeof.py#L7 ), but they are easy to implement and commonly encountered, go ahead and implement custom `sizeof` for these `bytes`-like types.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
