### PR TITLE
Add single quotes around column names if strings

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -361,9 +361,9 @@ def test_check_meta():
         "+--------+----------+----------+\n"
         "| Column | Found    | Expected |\n"
         "+--------+----------+----------+\n"
-        "| a      | object   | category |\n"
-        "| c      | -        | float64  |\n"
-        "| e      | category | -        |\n"
+        "| 'a'    | object   | category |\n"
+        "| 'c'    | -        | float64  |\n"
+        "| 'e'    | category | -        |\n"
         "+--------+----------+----------+"
     )
     assert str(err.value) == exp

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -647,7 +647,9 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
     elif is_dataframe_like(meta):
         dtypes = pd.concat([x.dtypes, meta.dtypes], axis=1, sort=True)
         bad_dtypes = [
-            (col, a, b)
+            # add single quotes around string variables
+            # to more clearly demarcate column type
+            (f"'{col}'", a, b) if isinstance(col, str) else (col, a, b)
             for col, a, b in dtypes.fillna("-").itertuples()
             if not equal_dtypes(a, b)
         ]

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -647,9 +647,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
     elif is_dataframe_like(meta):
         dtypes = pd.concat([x.dtypes, meta.dtypes], axis=1, sort=True)
         bad_dtypes = [
-            # add single quotes around string variables
-            # to more clearly demarcate column type
-            (f"'{col}'", a, b) if isinstance(col, str) else (col, a, b)
+            (repr(col), a, b)
             for col, a, b in dtypes.fillna("-").itertuples()
             if not equal_dtypes(a, b)
         ]


### PR DESCRIPTION
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Fixes #6470 

Adds explicit single quotes around the column names in `bad_dtypes` so that it's easier to distinguish between `str(int)` column names and `int` column names.

```
Traceback (most recent call last):
  File "metadata_mismatch.py", line 11, in <module>
    df.compute()
  File "/Users/gil/github.com/dask/dask/dask/base.py", line 167, in compute
    (result,) = compute(self, traverse=False, **kwargs)
  File "/Users/gil/github.com/dask/dask/dask/base.py", line 447, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/Users/gil/github.com/dask/dask/dask/threaded.py", line 76, in get
    results = get_async(
  File "/Users/gil/github.com/dask/dask/dask/local.py", line 486, in get_async
    raise_exception(exc, tb)
  File "/Users/gil/github.com/dask/dask/dask/local.py", line 316, in reraise
    raise exc
  File "/Users/gil/github.com/dask/dask/dask/local.py", line 222, in execute_task
    result = _execute_task(task, data)
  File "/Users/gil/github.com/dask/dask/dask/core.py", line 121, in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
  File "/Users/gil/github.com/dask/dask/dask/dataframe/utils.py", line 672, in check_meta
    raise ValueError(
ValueError: Metadata mismatch found in `from_delayed`.

Partition type: `pandas.core.frame.DataFrame`
+--------+-------+----------+
| Column | Found | Expected |
+--------+-------+----------+
| '7'    | int64 | -        |
| '8'    | int64 | -        |
| 7      | -     | int64    |
| 8      | -     | int64    |
+--------+-------+----------+
```