### PR TITLE
Intelligently determine partitions based on type of first arg

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1153,6 +1153,12 @@ Dask Name: {name}, {task} tasks"""
         >>> df = df.repartition(divisions=[0, 5, 10, 20])  # doctest: +SKIP
         >>> df = df.repartition(freq='7d')  # doctest: +SKIP
         """
+        if isinstance(divisions, int):
+            npartitions = divisions
+            divisions = None
+        if isinstance(divisions, str):
+            partition_size = divisions
+            divisions = None
         if (
             sum(
                 [

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1120,6 +1120,8 @@ Dask Name: {name}, {task} tasks"""
         divisions : list, optional
             List of partitions to be used. Only used if npartitions and
             partition_size isn't specified.
+            For convenience if given an integer this will defer to npartitions
+            and if given a string it will defer to partition_size (see below)
         npartitions : int, optional
             Number of partitions of output. Only used if partition_size
             isn't specified.

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1886,7 +1886,7 @@ def test_repartition_npartitions(use_index, n, k, dtype, transform):
     )
     df = transform(df)
     a = dd.from_pandas(df, npartitions=n, sort=use_index)
-    b = a.repartition(npartitions=k)
+    b = a.repartition(k)
     assert_eq(a, b)
     assert b.npartitions == k
     parts = dask.get(b.dask, b.__dask_keys__())
@@ -1909,6 +1909,13 @@ def test_repartition_partition_size(use_index, n, partition_size, transform):
     assert np.alltrue(b.map_partitions(total_mem_usage, deep=True).compute() <= 1024)
     parts = dask.get(b.dask, b.__dask_keys__())
     assert all(map(len, parts))
+
+
+def test_repartition_partition_size_arg():
+    df = pd.DataFrame({"x": range(10)},)
+    a = dd.from_pandas(df, npartitions=2)
+    b = a.repartition("1 MiB")
+    assert b.npartitions == 1
 
 
 def test_iter_chunks():


### PR DESCRIPTION
This allows for inputs like the following:

```
df.repartition(100)
and
df.repartition("100 MiB")
```

It's a bit less explicit, but seems harmless.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
