### PR TITLE
Fixed warning in nonempty_series

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -441,3 +441,11 @@ def test_apply_and_enforce_message():
 
     with pytest.raises(ValueError, match=re.escape("Missing: ['D']")):
         apply_and_enforce(_func=func, _meta=meta)
+
+
+def test_nonempty_series_sparse():
+    ser = pd.Series(pd.array([0, 1], dtype="Sparse"))
+    with pytest.warns(None) as w:
+        dd.utils._nonempty_series(ser)
+
+    assert len(w) == 0

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -17,6 +17,7 @@ from dask.dataframe.utils import (
     is_series_like,
     is_index_like,
     PANDAS_GT_0240,
+    PANDAS_GT_100,
 )
 
 import pytest
@@ -443,6 +444,7 @@ def test_apply_and_enforce_message():
         apply_and_enforce(_func=func, _meta=meta)
 
 
+@pytest.mark.skipif(not PANDAS_GT_100, reason="Only pandas>1")
 def test_nonempty_series_sparse():
     ser = pd.Series(pd.array([0, 1], dtype="Sparse"))
     with pytest.warns(None) as w:

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -570,7 +570,10 @@ def _nonempty_series(s, idx=None):
             entry = _scalar_from_dtype(dtype.subtype)
         else:
             entry = _scalar_from_dtype(dtype.subtype)
-        data = pd.SparseArray([entry, entry], dtype=dtype)
+        if PANDAS_GT_100:
+            data = pd.array([entry, entry], dtype=dtype)
+        else:
+            data = pd.SparseArray([entry, entry], dtype=dtype)
     elif is_interval_dtype(dtype):
         entry = _scalar_from_dtype(dtype.subtype)
         if PANDAS_GT_0240:


### PR DESCRIPTION
```
dask/dask/dataframe/utils.py:573: FutureWarning: The pandas.SparseArray class is deprecated and will be removed from pandas in a future version. Use pandas.arrays.SparseArray instead.
  data = pd.SparseArray([entry, entry], dtype=dtype)
```