### PR TITLE
Infer arrow schema in to_parquet  (for ArrowEngine)

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -864,9 +864,10 @@ class ArrowEngine(Engine):
             # until we find non-null data for each column in `sample`
             sample = [col for col in df.columns if df[col].dtype == "object"]
             if schema_field_supported and sample and schema == "infer":
+                delayed_schema_from_pandas = delayed(pa.Schema.from_pandas)
                 for i in range(df.npartitions):
                     # Keep data on worker
-                    _s = delayed(lambda x: pa.Schema.from_pandas(x))(
+                    _s = delayed_schema_from_pandas(
                         df[sample].to_delayed()[i]
                     ).compute()
                     for name, typ in zip(_s.names, _s.types):

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -872,7 +872,7 @@ class ArrowEngine(Engine):
                             if typ != "null":
                                 i = _schema.get_field_index(name)
                                 j = _s.get_field_index(name)
-                                _schema.set(i, _s.field(j))
+                                _schema = _schema.set(i, _s.field(j))
                                 sample.remove(name)
                     if not sample:
                         break

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -857,7 +857,7 @@ class ArrowEngine(Engine):
                 for name in schema.names:
                     i = _schema.get_field_index(name)
                     j = schema.get_field_index(name)
-                    _schema.set(i, schema.field(j))
+                    _schema = _schema.set(i, schema.field(j))
 
             # If we have object columns, we need to sample partitions
             # until we find non-null data for each column in `sample`

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -98,7 +98,7 @@ def read_parquet(
     gather_statistics=None,
     split_row_groups=None,
     chunksize=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Read a Parquet file into a Dask DataFrame
@@ -236,7 +236,7 @@ def read_parquet(
         gather_statistics=gather_statistics,
         filters=filters,
         split_row_groups=split_row_groups,
-        **kwargs
+        **kwargs,
     )
 
     # Parse dataset statistics from metadata (if available)
@@ -301,7 +301,8 @@ def to_parquet(
     write_metadata_file=True,
     compute=True,
     compute_kwargs=None,
-    **kwargs
+    schema="sample",
+    **kwargs,
 ):
     """Store Dask.dataframe to Parquet files
 
@@ -345,6 +346,13 @@ def to_parquet(
         then a ``dask.delayed`` object is returned for future computation.
     compute_kwargs : dict, optional
         Options to be passed in to the compute method
+    schema : Schema object, or {"sample", "meta", None}, optional
+        Global schema to use for the output dataset. If "sample" (default),
+        the `head` of the first non-empty partition will be used to infer
+        the global schema. If "meta", `_meta_nonempty` will be used to infer
+        the global schema. If None, we let the backend infer the schema
+        for each distinct output partition. Note that this argument is
+        currently ignored by the "fastparquet" engine.
     **kwargs :
         Extra options to be passed on to the specific backend.
 
@@ -404,6 +412,14 @@ def to_parquet(
                 "will be set to the index (and renamed to None)."
             )
 
+    # There are some "resrved" names that may be used as the default column
+    # name after resetting the index. However, we don't want to treat it as
+    # a "special" name if the string is already used as a "real" column name.
+    reserved_names = []
+    for name in ["index", "level_0"]:
+        if name not in df.columns:
+            reserved_names.append(name)
+
     # If write_index==True (default), reset the index and record the
     # name of the original index in `index_cols` (we will set the name
     # to the NONE_LABEL constant if it is originally `None`).
@@ -418,7 +434,9 @@ def to_parquet(
         none_index = list(df._meta.index.names) == [None]
         df = df.reset_index()
         if none_index:
-            df.columns = [c if c != "index" else NONE_LABEL for c in df.columns]
+            df.columns = [
+                c if c not in reserved_names else NONE_LABEL for c in df.columns
+            ]
         index_cols = [c for c in set(df.columns).difference(real_cols)]
     else:
         # Not writing index - might as well drop it
@@ -439,7 +457,7 @@ def to_parquet(
 
     # Engine-specific initialization steps to write the dataset.
     # Possibly create parquet metadata, and load existing stuff if appending
-    meta, i_offset = engine.initialize_write(
+    meta, schema, i_offset = engine.initialize_write(
         df,
         fs,
         path,
@@ -448,7 +466,8 @@ def to_parquet(
         partition_on=partition_on,
         division_info=division_info,
         index_cols=index_cols,
-        **kwargs_pass
+        schema=schema,
+        **kwargs_pass,
     )
 
     # Use i_offset and df.npartitions to define file-name list
@@ -467,7 +486,8 @@ def to_parquet(
             fmd=meta,
             compression=compression,
             index_cols=index_cols,
-            **kwargs_pass
+            schema=schema,
+            **kwargs_pass,
         )
         for d, filename in zip(df.to_delayed(), filenames)
     ]

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -301,7 +301,7 @@ def to_parquet(
     write_metadata_file=True,
     compute=True,
     compute_kwargs=None,
-    schema="sample",
+    schema=None,
     **kwargs,
 ):
     """Store Dask.dataframe to Parquet files
@@ -346,11 +346,10 @@ def to_parquet(
         then a ``dask.delayed`` object is returned for future computation.
     compute_kwargs : dict, optional
         Options to be passed in to the compute method
-    schema : Schema object, or {"sample", "meta", None}, optional
-        Global schema to use for the output dataset. If "sample" (default),
-        the `head` of the first non-empty partition will be used to infer
-        the global schema. If "meta", `_meta_nonempty` will be used to infer
-        the global schema. If None, we let the backend infer the schema
+    schema : Schema object, or {"infer", None}, optional
+        Global schema to use for the output dataset. If "infer", the `head`
+        of the first non-empty partition will be used to infer the global
+        schema. If None (default), we let the backend infer the schema
         for each distinct output partition. Note that this argument is
         currently ignored by the "fastparquet" engine.
     **kwargs :

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -346,12 +346,15 @@ def to_parquet(
         then a ``dask.delayed`` object is returned for future computation.
     compute_kwargs : dict, optional
         Options to be passed in to the compute method
-    schema : Schema object, or {"infer", None}, optional
-        Global schema to use for the output dataset. If "infer", the `head`
-        of the first non-empty partition will be used to infer the global
-        schema. If None (default), we let the backend infer the schema
-        for each distinct output partition. Note that this argument is
-        currently ignored by the "fastparquet" engine.
+    schema : Schema object, dict, or {"infer", None}, optional
+        Global schema to use for the output dataset. Alternatively, a `dict`
+        of pyarrow types can be specified (e.g. `schema={"id": pa.string()}`).
+        For this case, fields excluded from the dictionary will be inferred
+        from `_meta_nonempty`.  If "infer", the first non-empty and non-null
+        partition will be used to infer the type for "object" columns. If
+        None (default), we let the backend infer the schema for each distinct
+        output partition. Note that this argument is currently ignored by
+        the "fastparquet" engine.
     **kwargs :
         Extra options to be passed on to the specific backend.
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -353,8 +353,9 @@ def to_parquet(
         from `_meta_nonempty`.  If "infer", the first non-empty and non-null
         partition will be used to infer the type for "object" columns. If
         None (default), we let the backend infer the schema for each distinct
-        output partition. Note that this argument is currently ignored by
-        the "fastparquet" engine.
+        output partition. If the partitions produce inconsistent schemas,
+        pyarrow will throw an error when writing the shared _metadata file.
+        Note that this argument is ignored by the "fastparquet" engine.
     **kwargs :
         Extra options to be passed on to the specific backend.
 

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -510,6 +510,7 @@ class FastParquetEngine(Engine):
         partition_on=None,
         ignore_divisions=False,
         division_info=None,
+        schema=None,
         **kwargs
     ):
         if append and division_info is None:
@@ -579,7 +580,8 @@ class FastParquetEngine(Engine):
             )
             i_offset = 0
 
-        return (fmd, i_offset)
+        schema = None  # ArrowEngine compatibility
+        return (fmd, schema, i_offset)
 
     @classmethod
     def write_partition(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1074,8 +1074,7 @@ def test_to_parquet_pyarrow_w_inconsistent_schema_by_partition_succeeds_w_manual
 
 @pytest.mark.parametrize("index", [False, True])
 @pytest.mark.parametrize(
-    "schema",
-    ["infer", {"index": pa.string(), "date": pa.string(), "amount": pa.int64()}],
+    "schema", ["infer", {"index": pa.string(), "amount": pa.int64()}]
 )
 def test_pyarrow_schema_inference(tmpdir, index, engine, schema):
 
@@ -1107,7 +1106,9 @@ def test_pyarrow_schema_inference(tmpdir, index, engine, schema):
     else:
         df = dd.from_pandas(df, npartitions=2)
 
-    df.to_parquet(tmpdir, engine="pyarrow", schema=schema)
+    df.to_parquet(tmpdir, engine="pyarrow", schema=schema, compute=False).compute(
+        scheduler="synchronous"
+    )
     df_out = dd.read_parquet(tmpdir, engine=engine)
 
     if index and engine == "fastparquet":

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1074,7 +1074,11 @@ def test_to_parquet_pyarrow_w_inconsistent_schema_by_partition_succeeds_w_manual
 
 @write_read_engines()
 @pytest.mark.parametrize("index", [False, True])
-def test_schema_inference(tmpdir, index, write_engine, read_engine):
+@pytest.mark.parametrize(
+    "schema",
+    ["infer", {"index": pa.string(), "date": pa.string(), "amount": pa.int64()}],
+)
+def test_schema_inference(tmpdir, index, write_engine, read_engine, schema):
 
     tmpdir = str(tmpdir)
     df = pd.DataFrame(
@@ -1100,7 +1104,7 @@ def test_schema_inference(tmpdir, index, write_engine, read_engine):
     else:
         df = dd.from_pandas(df, npartitions=2)
 
-    df.to_parquet(tmpdir, engine=write_engine, schema="infer")
+    df.to_parquet(tmpdir, engine=write_engine, schema=schema)
     df_out = dd.read_parquet(tmpdir, engine=read_engine)
 
     if index and read_engine == "fastparquet":

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1074,8 +1074,7 @@ def test_to_parquet_pyarrow_w_inconsistent_schema_by_partition_succeeds_w_manual
 
 @write_read_engines()
 @pytest.mark.parametrize("index", [False, True])
-@pytest.mark.parametrize("schema", ["meta", "sample"])
-def test_schema_inference(tmpdir, index, schema, write_engine, read_engine):
+def test_schema_inference(tmpdir, index, write_engine, read_engine):
 
     tmpdir = str(tmpdir)
     df = pd.DataFrame(
@@ -1101,7 +1100,7 @@ def test_schema_inference(tmpdir, index, schema, write_engine, read_engine):
     else:
         df = dd.from_pandas(df, npartitions=2)
 
-    df.to_parquet(tmpdir, engine=write_engine, schema=schema)
+    df.to_parquet(tmpdir, engine=write_engine, schema="infer")
     df_out = dd.read_parquet(tmpdir, engine=read_engine)
 
     if index and read_engine == "fastparquet":
@@ -2072,7 +2071,7 @@ def test_read_dir_nometa(tmpdir, write_engine, read_engine, statistics, remove_c
     assert_eq(ddf, ddf2, check_divisions=False)
 
 
-@pytest.mark.parametrize("schema", ["meta", None])
+@pytest.mark.parametrize("schema", ["infer", None])
 def test_timeseries_nulls_in_schema(tmpdir, engine, schema):
     # GH#5608: relative path failing _metadata/_common_metadata detection.
     tmp_path = str(tmpdir.mkdir("files"))


### PR DESCRIPTION
Closes #6243 

As of the 1.0 release, pyarrow now (understandably) compains when you try to compose a shared `_metadata` file from partitions with inconsistent schemas.  This PR adds a public `schema` argument to `to_parquet` (although it is only *used* by the ArrowEngine). 

~By default (if the user does not specify an *actual* arrow schema), this new argument is set to `"sample"`, which means the client will find the first partition with data, and use the `head` of this partition to infer the global arrow schema.  The user can also pass `schema="meta"` to use the `_meta_nonempty` for inference, or `schema=None` to allow the backend (pyarrow) to infer the schema for each output partition separately.~

~The advantage of using `"sample"` over `"meta"` as the default is that we are much less likely to set an incorrect global schema.  For example, using `"meta"` will not correcly detect the difference between string and binary (they are both "object" types in `_meta_nonempty`).  The obvious disadvantage is the need to sample "real" data (requiring worker-client data transfer in a distributed environment).~

~Given the competing factors described above: **Do we want to infer the schema by default?** An alternative to the current solution is to set the default to `None`, and only perform inference (via sampling) if the user passes `schema="infer"`~

As stated in a comment below, the following approach is now used:

>- The default is  now `schema=None`.  However, if/when pyarrow fails to write the _metadata, we "handle" the exception by also recommending that the user try "schema="infer"` (or to pass an explicit schema).
>- The user can now pass in a `dict` with only a subset of column-types included (similar to "object_encoding")
>- When `schema="infer"` or when the user passes in a `dict`, we start with an inital schema based on the `_meta_nonempty`.  For `schema="infer"`, we further sample partitions for non-null data to update the "object" fields.  For the `dict`, we only update the fields specified by the user.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
