### PR TITLE
Add missing meta= for trim in map_overlap

### DIFF
--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -234,7 +234,11 @@ def trim_internal(x, axes, boundary=None):
     chunks = tuple(olist)
 
     return map_blocks(
-        partial(_trim, axes=axes, boundary=boundary), x, chunks=chunks, dtype=x.dtype, meta=x._meta
+        partial(_trim, axes=axes, boundary=boundary),
+        x,
+        chunks=chunks,
+        dtype=x.dtype,
+        meta=x._meta,
     )
 
 

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -234,7 +234,7 @@ def trim_internal(x, axes, boundary=None):
     chunks = tuple(olist)
 
     return map_blocks(
-        partial(_trim, axes=axes, boundary=boundary), x, chunks=chunks, dtype=x.dtype
+        partial(_trim, axes=axes, boundary=boundary), x, chunks=chunks, dtype=x.dtype, meta=x._meta
     )
 
 

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -59,6 +59,8 @@ functions = [
     pytest.param(lambda x: x.sum(axis=(1, 2)), marks=numpy_120_xfail),
     lambda x: x.astype(np.complex128),
     lambda x: x.map_blocks(lambda x: x * 2),
+    lambda x: x.map_overlap(lambda x: x * 2, depth=0, trim=True),
+    lambda x: x.map_overlap(lambda x: x * 2, depth=0, trim=False),
     lambda x: x.round(1),
     lambda x: x.reshape((x.shape[0] * x.shape[1], x.shape[2])),
     lambda x: abs(x),


### PR DESCRIPTION
Adds missing `meta=` to `map_overlap`, which prevents proper `__array_function__` dispatching if `trim=True`.

Fixes #6493 