### PR TITLE
Include compression in write_table call

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -932,7 +932,14 @@ class ArrowEngine(Engine):
         t = pa.Table.from_pandas(df, preserve_index=preserve_index, schema=schema)
         if partition_on:
             md_list = _write_partitioned(
-                t, path, filename, partition_on, fs, index_cols=index_cols, **kwargs
+                t,
+                path,
+                filename,
+                partition_on,
+                fs,
+                index_cols=index_cols,
+                compression=compression,
+                **kwargs,
             )
             if md_list:
                 _meta = md_list[0]

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1455,6 +1455,20 @@ def test_writing_parquet_with_compression(tmpdir, compression, engine):
     check_compression(engine, fn, compression)
 
 
+@pytest.mark.parametrize("compression,", ["default", None, "gzip", "snappy"])
+def test_writing_parquet_with_partition_on_and_compression(tmpdir, compression, engine):
+    fn = str(tmpdir)
+    if compression in ["snappy", "default"]:
+        pytest.importorskip("snappy")
+
+    df = pd.DataFrame({"x": ["a", "b", "c"] * 10, "y": [1, 2, 3] * 10})
+    df.index.name = "index"
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    ddf.to_parquet(fn, compression=compression, engine=engine, partition_on=["x"])
+    check_compression(engine, fn, compression)
+
+
 @pytest.fixture(
     params=[
         # fastparquet 0.1.3


### PR DESCRIPTION
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
- [x] Fixes #6496 

@rjzamora - I am not sure if this is working properly - the file size doesn't appear to change when I use different compression mechanisms. 
