### PR TITLE
Bump up tolerance for rolling tests

### DIFF
--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -272,8 +272,8 @@ def test_time_rolling_methods(method, args, window, check_less_precise):
     if dd._compat.PANDAS_GT_110:
         if check_less_precise:
             check_less_precise = {"atol": 0.5e-3, "rtol": 0.5e-3}
-         else:
-             check_less_precise = {"atol": 0.5e-5, "rtol": 0.5e-5}
+        else:
+            check_less_precise = {"atol": 0.5e-5, "rtol": 0.5e-5}
     else:
         check_less_precise = {"check_less_precise": check_less_precise}
 

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -270,7 +270,10 @@ def test_time_rolling_constructor():
 @pytest.mark.parametrize("window", ["1S", "2S", "3S", pd.offsets.Second(5)])
 def test_time_rolling_methods(method, args, window, check_less_precise):
     if dd._compat.PANDAS_GT_110:
-        check_less_precise = {"atol": 1e-4, "rtol": 1e-2}
+                if check_less_precise:
+                    check_less_precise = {"atol": 0.5e-3, "rtol": 0.5e-3}
+                 else:
+                     check_less_precise = {"atol": 0.5e-5, "rtol": 0.5e-5}
     else:
         check_less_precise = {"check_less_precise": check_less_precise}
 

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -273,7 +273,7 @@ def test_time_rolling_methods(method, args, window, check_less_precise):
         if check_less_precise:
             check_less_precise = {"atol": 0.5e-3, "rtol": 0.5e-3}
         else:
-            check_less_precise = {"atol": 0.5e-5, "rtol": 0.5e-5}
+            check_less_precise = {}
     else:
         check_less_precise = {"check_less_precise": check_less_precise}
 

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -270,10 +270,10 @@ def test_time_rolling_constructor():
 @pytest.mark.parametrize("window", ["1S", "2S", "3S", pd.offsets.Second(5)])
 def test_time_rolling_methods(method, args, window, check_less_precise):
     if dd._compat.PANDAS_GT_110:
-                if check_less_precise:
-                    check_less_precise = {"atol": 0.5e-3, "rtol": 0.5e-3}
-                 else:
-                     check_less_precise = {"atol": 0.5e-5, "rtol": 0.5e-5}
+        if check_less_precise:
+            check_less_precise = {"atol": 0.5e-3, "rtol": 0.5e-3}
+         else:
+             check_less_precise = {"atol": 0.5e-5, "rtol": 0.5e-5}
     else:
         check_less_precise = {"check_less_precise": check_less_precise}
 

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -270,7 +270,7 @@ def test_time_rolling_constructor():
 @pytest.mark.parametrize("window", ["1S", "2S", "3S", pd.offsets.Second(5)])
 def test_time_rolling_methods(method, args, window, check_less_precise):
     if dd._compat.PANDAS_GT_110:
-        check_less_precise = {}
+        check_less_precise = {"atol": 1e-4, "rtol": 1e-2}
     else:
         check_less_precise = {"check_less_precise": check_less_precise}
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
- [x] Fixes #6497, fixes #6478

@TomAugspurger not sure if this is legit or not. But it does make the tests less flakey with pandas >=1.1.0