### PR TITLE
Adjust parquet ArrowEngine to allow more easy subclass for writing

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -938,9 +938,7 @@ class ArrowEngine(Engine):
         else:
             index_cols = []
 
-        t = cls._pandas_to_arrow_table(
-            df, preserve_index=preserve_index, schema=schema
-        )
+        t = cls._pandas_to_arrow_table(df, preserve_index=preserve_index, schema=schema)
 
         if partition_on:
             md_list = _write_partitioned(

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -908,8 +908,16 @@ class ArrowEngine(Engine):
 
         return fmd, i_offset
 
-    @staticmethod
+    @classmethod
+    def _pandas_to_arrow_table(
+        cls, df: pd.DataFrame, preserve_index=False, schema=None
+    ) -> pa.Table:
+        table = pa.Table.from_pandas(df, preserve_index=preserve_index, schema=schema)
+        return table
+
+    @classmethod
     def write_partition(
+        cls,
         df,
         path,
         fs,
@@ -929,7 +937,9 @@ class ArrowEngine(Engine):
             preserve_index = True
         else:
             index_cols = []
-        t = pa.Table.from_pandas(df, preserve_index=preserve_index, schema=schema)
+
+        t = cls._pandas_to_arrow_table(df, preserve_index, schema)
+
         if partition_on:
             md_list = _write_partitioned(
                 t,

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -938,7 +938,9 @@ class ArrowEngine(Engine):
         else:
             index_cols = []
 
-        t = cls._pandas_to_arrow_table(df, preserve_index, schema)
+        t = cls._pandas_to_arrow_table(
+            df, preserve_index=preserve_index, schema=schema
+        )
 
         if partition_on:
             md_list = _write_partitioned(


### PR DESCRIPTION
Similar as @mariusvniekerk's PR https://github.com/dask/dask/pull/6211/, but now also adding an overridable method for the "pandas->arrow" conversion in the write path.

cc @rjzamora I don't think this should have any impact on other subclasses?

Context: https://github.com/jsignell/dask-geopandas/pull/13