### PR TITLE
__dask_layers__() should return layers 

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -134,7 +134,7 @@ class Scalar(DaskMethodsMixin, OperatorMethodMixin):
         return self._name
 
     def __dask_layers__(self):
-        return (self.key,)
+        return (self._name,)
 
     __dask_optimize__ = globalmethod(
         optimize, key="dataframe_optimize", falsey=dont_optimize


### PR DESCRIPTION
This PR makes [`Scalar.__dask_layers__()`](https://github.com/dask/dask/blob/b5156d660b705c97abafd2ebf639115f37ce39b6/dask/dataframe/core.py#L136) return `self._name` instead of `self.key`.

[Quoting from the docs](https://docs.dask.org/en/latest/high-level-graphs.html#motivation-and-example), the `.__dask_layers__()` should return the output layers:
```
While the DataFrame points to the output layers on which it depends directly:
>>> df.__dask_layers__()
{'filter'}
```

### Context
I am working on a higher level `cull()` function (see https://github.com/dask/dask/issues/6438) that uses `HighLevelGraph.dependencies` to determine the dependency relationship between layers. Doing this work I noticed that sometimes `HighLevelGraph.dependencies` will refer to _low level_ keys and not layers because of `__dask_layers__()` returning keys instead of names,  which means `HighLevelGraph.dependencies` will have values that refer to non-existing keys.

### What to do with `Delayed`?
[`Delayed.__dask_layers__()`](https://github.com/dask/dask/blob/b5156d660b705c97abafd2ebf639115f37ce39b6/dask/delayed.py#L486) also returns a key. However, `Delayed` doesn't have a name or anything other than the key so I am not sure what to do. Does it even make sense to define `__dask_layers__()` when `Delayed` isn't a collection?

Any suggestions?
