### PR TITLE
fuse_root(): update dependencies correctly

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -890,7 +890,7 @@ def fuse_roots(graph: HighLevelGraph, keys: list):
     graph: HighLevelGraph
         The full graph of the computation
     keys: list
-        The output keys of the comptuation, to be passed on to fuse
+        The output keys of the computation, to be passed on to fuse
 
     See Also
     --------
@@ -914,6 +914,7 @@ def fuse_roots(graph: HighLevelGraph, keys: list):
 
             for dep in deps:
                 del layers[dep]
+                del dependencies[dep]
 
             layers[name] = new
             dependencies[name] = set()

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4368,3 +4368,16 @@ def test_dataframe_groupby_agg_empty_partitions():
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7, 8]})
     ddf = dd.from_pandas(df, npartitions=4)
     assert_eq(ddf[ddf.x < 5].x.cumsum(), df[df.x < 5].x.cumsum())
+
+
+def test_fuse_roots():
+    pdf1 = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
+    )
+    ddf1 = dd.from_pandas(pdf1, 2)
+    pdf2 = pd.DataFrame({"a": [True, False, True] * 3, "b": [False, False, True] * 3})
+    ddf2 = dd.from_pandas(pdf2, 2)
+
+    res = ddf1.where(ddf2)
+    hlg = fuse_roots(res.__dask_graph__(), keys=res.__dask_keys__())
+    hlg.validate()

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -11,6 +11,7 @@ import dask
 import dask.array as da
 from dask.array.numpy_compat import _numpy_118, _numpy_120
 import dask.dataframe as dd
+from dask.blockwise import fuse_roots
 from dask.dataframe import _compat
 from dask.dataframe._compat import tm, PANDAS_GT_100, PANDAS_GT_110
 from dask.base import compute_as_if_collection

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -237,7 +237,7 @@ def to_graphviz(
     graph_attr={},
     node_attr=None,
     edge_attr=None,
-    **kwargs
+    **kwargs,
 ):
     from .dot import graphviz, name, label
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -217,6 +217,17 @@ class HighLevelGraph(Mapping):
         g = to_graphviz(self, **kwargs)
         return graphviz_to_file(g, filename, format)
 
+    def validate(self):
+        # Check dependencies
+        for layer_name, deps in self.dependencies.items():
+            if layer_name not in self.layers:
+                raise ValueError(
+                    f"dependencies[{repr(layer_name)}] not found in layers"
+                )
+            for dep in deps:
+                if dep not in self.dependencies:
+                    raise ValueError(f"{repr(dep)} not found in dependencies")
+
 
 def to_graphviz(
     hg,


### PR DESCRIPTION
This PR makes `fuse_roots()` remove deleted layers in dependencies. Also added `HighLevelGraph.validate()` that raises `ValueError` if the graph is in an invalid state.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
