### PR TITLE
Add HighLevelGraph.validate call to assert_eq in tests

### DIFF
--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -178,6 +178,7 @@ def _check_dsk(dsk):
     if not isinstance(dsk, HighLevelGraph):
         return
 
+    dsk.validate()
     assert all(isinstance(k, (tuple, str)) for k in dsk.layers)
     freqs = frequencies(concat(dsk.dicts.values()))
     non_one = {k: v for k, v in freqs.items() if v != 1}

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -716,7 +716,10 @@ def index_summary(idx, name=None):
 def _check_dask(dsk, check_names=True, check_dtypes=True, result=None):
     import dask.dataframe as dd
 
-    if hasattr(dsk, "dask"):
+    if hasattr(dsk, "__dask_graph__"):
+        graph = dsk.__dask_graph__()
+        if hasattr(graph, "validate"):
+            graph.validate()
         if result is None:
             result = dsk.compute(scheduler="sync")
         if isinstance(dsk, dd.Index):


### PR DESCRIPTION
This applies a validation function made by @madsbk in https://github.com/dask/dask/pull/6508 to all of the dask array and dask dataframe test suite.  It exposes a few cases where our book keeping around HLG dependencies is incorrect.