### PR TITLE
MNT Uses unpack_collections in make_blockwise_graph

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -21,8 +21,8 @@ import dask.array as da
 import dask.dataframe
 from dask.base import tokenize, compute_as_if_collection
 from dask.delayed import Delayed, delayed
-from dask.utils import ignoring, tmpfile, tmpdir, key_split
-from dask.utils_test import inc, dec
+from dask.utils import ignoring, tmpfile, tmpdir, key_split, apply
+from dask.utils_test import inc, dec, add_with_default
 
 from dask.array.core import (
     getem,
@@ -94,6 +94,15 @@ def test_top():
 
     assert top(identity, "z", "", "x", "ij", numblocks={"x": (2, 2)}) == {
         ("z",): (identity, [[("x", 0, 0), ("x", 0, 1)], [("x", 1, 0), ("x", 1, 1)]])
+    }
+
+
+def test_top_with_kwargs():
+    assert top(
+        add_with_default, "z", "i", "x", "i", numblocks={"x": (2, 0)}, b=100
+    ) == {
+        ("z", 0): (apply, add_with_default, [("x", 0)], {"b": 100}),
+        ("z", 1): (apply, add_with_default, [("x", 1)], {"b": 100}),
     }
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -22,7 +22,7 @@ import dask.dataframe
 from dask.base import tokenize, compute_as_if_collection
 from dask.delayed import Delayed, delayed
 from dask.utils import ignoring, tmpfile, tmpdir, key_split, apply
-from dask.utils_test import inc, dec, add_with_default
+from dask.utils_test import inc, dec
 
 from dask.array.core import (
     getem,
@@ -98,11 +98,9 @@ def test_top():
 
 
 def test_top_with_kwargs():
-    assert top(
-        add_with_default, "z", "i", "x", "i", numblocks={"x": (2, 0)}, b=100
-    ) == {
-        ("z", 0): (apply, add_with_default, [("x", 0)], {"b": 100}),
-        ("z", 1): (apply, add_with_default, [("x", 1)], {"b": 100}),
+    assert top(add, "z", "i", "x", "i", numblocks={"x": (2, 0)}, b=100) == {
+        ("z", 0): (apply, add, [("x", 0)], {"b": 100}),
+        ("z", 1): (apply, add, [("x", 1)], {"b": 100}),
     }
 
 

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -7,7 +7,7 @@ import numpy as np
 import tlz as toolz
 
 from .core import reverse_dict
-from .delayed import to_task_dask
+from .delayed import unpack_collections
 from .highlevelgraph import HighLevelGraph
 from .optimization import SubgraphCallable, fuse
 from .utils import ensure_dict, homogeneous_deepmap, apply
@@ -420,7 +420,7 @@ def make_blockwise_graph(func, output, out_indices, *arrind_pairs, **kwargs):
     # Unpack delayed objects in kwargs
     dsk2 = {}
     if kwargs:
-        task, dsk2 = to_task_dask(kwargs)
+        task, dsk2 = unpack_collections(kwargs)
         if dsk2:
             kwargs2 = task
         else:

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -10,10 +10,6 @@ def add(x, y):
     return x + y
 
 
-def add_with_default(x, y=10):
-    return x + y
-
-
 class GetFunctionTestMixin(object):
     """
     The GetFunctionTestCase class can be imported and used to test foreign

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -10,6 +10,10 @@ def add(x, y):
     return x + y
 
 
+def add_with_default(x, y=10):
+    return x + y
+
+
 class GetFunctionTestMixin(object):
     """
     The GetFunctionTestCase class can be imported and used to test foreign


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/5970

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Also adds test to check that `kwargs` is used correctly.