### PR TITLE
Make sure dask array are writable via the __array__ protocol.

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -977,7 +977,7 @@ def blockdims_from_blockshape(shape, chunks):
     )
 
 
-def finalize(results):
+def _finalize(results):
     if not results:
         return concatenate3(results)
     results2 = results
@@ -987,6 +987,13 @@ def finalize(results):
         else:
             results2 = results2[0]
     return unpack_singleton(results)
+
+
+def finalize(results):
+    res = _finalize(results)
+    if isinstance(res, np.ndarray) and not res.flags.writeable:
+        res = np.array(res, copy=True)
+    return res
 
 
 CHUNKS_NONE_ERROR_MESSAGE = """

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -991,7 +991,7 @@ def _finalize(results):
 
 def finalize(results):
     res = _finalize(results)
-    if isinstance(res, np.ndarray) and not res.flags.writeable:
+    if type(res) == np.ndarray and not res.flags.writeable:
         res = np.array(res, copy=True)
     return res
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -992,7 +992,7 @@ def _finalize(results):
 def finalize(results):
     res = _finalize(results)
     if type(res) == np.ndarray and not res.flags.writeable:
-        res = np.array(res, copy=True)
+        res = res.copy()
     return res
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4426,3 +4426,16 @@ def test_rechunk_auto():
     y = x.rechunk()
 
     assert y.npartitions == 1
+
+
+def test_compute_writable():
+    """
+    Also ensure that not all items are backed by the same value.
+
+    In particular zeros_like and co use a broadcast trick.
+    """
+
+    dask_array = da.zeros_like(da.arange(2))
+    numpy_array = dask_array.compute()
+    numpy_array[0] = 1
+    assert all(numpy_array == np.array([1, 0]))


### PR DESCRIPTION
When trying to access dask array via the __array__ protocol, and those
are read only due to broadcast trick;  copy them to make them writable.

Closes #6520

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
