### PR TITLE
Remove problematic `filter` arguments in ArrowEngine

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -148,9 +148,7 @@ def _get_dataset_object(paths, fs, filters, dataset_kwargs):
         # and/or splitting row-groups without a "_metadata" file
         base = paths[0]
         fns = [None]
-        dataset = pq.ParquetDataset(
-            paths[0], filesystem=fs, filters=filters, **dataset_kwargs
-        )
+        dataset = pq.ParquetDataset(paths[0], filesystem=fs, **dataset_kwargs)
 
     return dataset, base, fns
 

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -120,21 +120,14 @@ def _get_dataset_object(paths, fs, filters, dataset_kwargs):
             # open "_metadata" separately.
             paths.remove(fs.sep.join([base, "_metadata"]))
             fns.remove("_metadata")
-            proxy_metadata = (
-                pq.ParquetDataset(
-                    fs.sep.join([base, "_metadata"]),
-                    filesystem=fs,
-                    filters=filters,
-                    **dataset_kwargs,
-                )
-                .pieces[0]
-                .get_metadata()
-            )
+            with fs.open(fs.sep.join([base, "_metadata"]), mode="rb") as fil:
+                proxy_metadata = pq.ParquetFile(fil).metadata
         # Create our dataset from the list of data files.
-        # Note that this will not parse all the files (yet)
-        dataset = pq.ParquetDataset(
-            paths, filesystem=fs, filters=filters, **dataset_kwargs
-        )
+        # Note #1: that this will not parse all the files (yet)
+        # Note #2: Cannot pass filters for legacy pyarrow API (see issue#6512).
+        #          We can handle partitions + filtering for list input after
+        #          adopting new pyarrow.dataset API.
+        dataset = pq.ParquetDataset(paths, filesystem=fs, **dataset_kwargs)
         if proxy_metadata:
             dataset.metadata = proxy_metadata
     elif fs.isdir(paths[0]):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1296,6 +1296,20 @@ def test_filters_v0(tmpdir, write_engine, read_engine):
     assert len(ddf2) > 0
 
 
+def test_fiters_file_list(tmpdir, engine):
+    df = pd.DataFrame({"x": range(10), "y": list("aabbccddee")})
+    ddf = dd.from_pandas(df, npartitions=5)
+
+    ddf.to_parquet(str(tmpdir), engine=engine)
+    fils = str(tmpdir.join("*.parquet"))
+    ddf_out = dd.read_parquet(
+        fils, gather_statistics=True, engine=engine, filters=[("x", ">", 3)]
+    )
+
+    assert ddf_out.npartitions == 3
+    assert_eq(df[df["x"] > 3], ddf_out.compute(), check_index=False)
+
+
 def test_divisions_read_with_filters(tmpdir):
     pytest.importorskip("fastparquet", minversion="0.3.1")
     tmpdir = str(tmpdir)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1309,6 +1309,15 @@ def test_fiters_file_list(tmpdir, engine):
     assert ddf_out.npartitions == 3
     assert_eq(df[df["x"] > 3], ddf_out.compute(), check_index=False)
 
+    # Check that first parition gets filtered for single-path input
+    ddf2 = dd.read_parquet(
+        str(tmpdir.join("part.0.parquet")),
+        gather_statistics=True,
+        engine=engine,
+        filters=[("x", ">", 3)],
+    )
+    assert len(ddf2) == 0
+
 
 def test_divisions_read_with_filters(tmpdir):
     pytest.importorskip("fastparquet", minversion="0.3.1")


### PR DESCRIPTION
Closes #6512 
May address #6504 

The `ArrowEngine` currently creates a reference `ParquetDataset` object within the `read_metadata` (planning) stage of `read_parquet`.  It seems that pyarrow now raises an error when a `filters` argument is passed to this API, unless the `path_or_paths` argument is a directory path (not a list of file or single file).  This PR adds test coverage and removes the `filters` argument for this case.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
