### PR TITLE
Avoid schema validation by default in ArrowEngine

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -110,6 +110,8 @@ def _index_in_schema(index, schema):
 def _get_dataset_object(paths, fs, filters, dataset_kwargs):
     """ Generate a ParquetDataset object
     """
+    if "validate_schema" not in dataset_kwargs:
+        dataset_kwargs["validate_schema"] = False
     if len(paths) > 1:
         # This is a list of files
         base, fns = _analyze_paths(paths, fs)
@@ -138,8 +140,6 @@ def _get_dataset_object(paths, fs, filters, dataset_kwargs):
         #       expensive in storage systems like S3.
         allpaths = fs.glob(paths[0] + fs.sep + "*")
         base, fns = _analyze_paths(allpaths, fs)
-        if "_metadata" in fns and "validate_schema" not in dataset_kwargs:
-            dataset_kwargs["validate_schema"] = False
         dataset = pq.ParquetDataset(
             paths[0], filesystem=fs, filters=filters, **dataset_kwargs
         )


### PR DESCRIPTION
Addresses [cudf#6055](https://github.com/rapidsai/cudf/issues/6055)

Given the computational expense required to validate the schema of every file in a dataset, we should certainly be avoiding this by default.

[Example/motivation](https://github.com/rapidsai/cudf/issues/6055#issuecomment-677831484) (I can confirm that this PR achieves the same performance improvement).

Non-`dask_cudf` example:

```python
import dask.dataframe as dd
import dask

path = "test.parquet"
dask.datasets.timeseries(partition_freq='600s').to_parquet(path)

%timeit dd.read_parquet(
    path,
    engine="pyarrow",
    gather_statistics=False,
    split_row_groups=False,
)
```
**With This PR**:
```
274 ms ± 3.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**Before This PR**:
```
4.4 s ± 14.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
