### PR TITLE
Remove duplicate partition values (#6543)

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5964,7 +5964,7 @@ def repartition_npartitions(df, npartitions):
             if isinstance(divisions, np.ndarray):
                 divisions = divisions.tolist()
 
-            divisions = list(divisions)
+            divisions = sorted(set(divisions))
             divisions[0] = df.divisions[0]
             divisions[-1] = df.divisions[-1]
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1882,6 +1882,13 @@ def test_repartition_on_pandas_dataframe():
     assert_eq(ddf, df.y)
 
 
+def test_repartition_gh6543():
+    df = pd.DataFrame({"a": np.arange(16)})
+    a = dd.from_pandas(df, chunksize=4)
+    b = a.repartition(npartitions=16)
+    assert b.npartitions == 15
+
+
 @pytest.mark.parametrize("use_index", [True, False])
 @pytest.mark.parametrize("n", [1, 2, 4, 5])
 @pytest.mark.parametrize("k", [1, 2, 4, 5])


### PR DESCRIPTION
Update `core.repartition_npartitions` to remove duplicate partitions.

Note that _some_ of the`test_dataframe.test_repartition_partition_size` tests fail due to the change in behavior introduced by this change.

Should we split the failing tests out into a separate test case function and modify? They will not pass in the existing parameterized test cases without conditional logic or additional calculation of the number or partitions.

- [ ] Tests passed
- [x] Tests added 
- [x] Passes `black dask` / `flake8 dask`
