### PR TITLE
Skip `bokeh` version `2.0.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
         "fsspec >= 0.6.0",
     ],
     "distributed": ["distributed >= 2.0"],
-    "diagnostics": ["bokeh >= 1.0.0"],
+    "diagnostics": ["bokeh >= 1.0.0, != 2.0.0"],
     "delayed": ["cloudpickle >= 0.2.2", "toolz >= 0.8.2"],
 }
 extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})


### PR DESCRIPTION
We have [this requirement in `conda-forge`]( https://github.com/conda-forge/dask-feedstock/pull/106/files#diff-e178b687b10a71a3348107ae3154e44cR22 ). Also this version of `bokeh` has caused us issues on CI before ( https://github.com/dask/distributed/pull/3637 ). So this updates the version requirement here accordingly.

cc @jrbourbeau

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
