### PR TITLE
couple bugfixes + comment nits

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3903,7 +3903,7 @@ def elemwise(op, *args, **kwargs):
     for arg in args:
         shape = getattr(arg, "shape", ())
         if any(is_dask_collection(x) for x in shape):
-            # Want to excluded Delayed shapes and dd.Scalar
+            # Want to exclude Delayed shapes and dd.Scalar
             shape = ()
         shapes.append(shape)
 

--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -159,7 +159,7 @@ def reshape(x, shape):
     shape = tuple(map(sanitize_index, shape))
     known_sizes = [s for s in shape if s != -1]
     if len(known_sizes) < len(shape):
-        if len(known_sizes) - len(shape) > 1:
+        if len(shape) - len(known_sizes) > 1:
             raise ValueError("can only specify one unknown dimension")
         # Fastpath for x.reshape(-1) on 1D arrays, allows unknown shape in x
         # for this case only.

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4138,7 +4138,7 @@ def test_dask_array_holds_scipy_sparse_containers():
 
     z = x.T.map_blocks(scipy.sparse.csr_matrix)
     zz = z.compute(scheduler="single-threaded")
-    assert isinstance(yy, scipy.sparse.spmatrix)
+    assert isinstance(zz, scipy.sparse.spmatrix)
     assert (zz == xx.T).all()
 
 

--- a/dask/array/tests/test_reshape.py
+++ b/dask/array/tests/test_reshape.py
@@ -1,6 +1,8 @@
 import pytest
 import numpy as np
+import dask.array as da
 from dask.array.reshape import reshape_rechunk, expand_tuple, contract_tuple
+from dask.array.utils import assert_eq
 
 
 @pytest.mark.parametrize(
@@ -61,3 +63,19 @@ def test_contract_tuple():
     assert contract_tuple((1, 1, 2, 5, 1), 2) == (2, 2, 4, 2)
     assert contract_tuple((2, 4), 2) == (2, 4)
     assert contract_tuple((2, 4), 3) == (6,)
+
+
+def test_reshape_unknown_sizes():
+    a = np.random.random((10, 6, 6))
+    A = da.from_array(a, chunks=(5, 2, 3))
+
+    a2 = a.reshape((60, -1))
+    A2 = A.reshape((60, -1))
+
+    assert A2.shape == (60, 6)
+    assert_eq(A2, a2)
+
+    with pytest.raises(ValueError):
+        a.reshape((60, -1, -1))
+    with pytest.raises(ValueError):
+        A.reshape((60, -1, -1))

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3535,7 +3535,10 @@ class DataFrame(_Frame):
             # Slicing with integer labels is always iloc based except for a
             # float indexer for some reason
             if is_integer_slice and not is_float_dtype(self.index.dtype):
-                self.iloc[key]
+                # NOTE: this always fails currently, as iloc is mostly
+                # unsupported, but we call it anyway here for future-proofing
+                # and error-attribution purposes
+                return self.iloc[key]
             else:
                 return self.loc[key]
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1141,8 +1141,8 @@ Dask Name: {name}, {task} tasks"""
             ``'12h'`` or ``pd.Timedelta(hours=12)``.  Assumes a datetime index.
         force : bool, default False
             Allows the expansion of the existing divisions.
-            If False then the new divisions lower and upper bounds must be
-            the same as the old divisions.
+            If False then the new divisions' lower and upper bounds must be
+            the same as the old divisions'.
 
         Notes
         -----
@@ -2801,7 +2801,7 @@ Dask Name: {name}, {task} tasks""".format(
             from the input series and the transformation. Ignored for
             non-callable/dict-like ``index`` or when the input series has
             unknown divisions. Note that this may only be set to ``True`` if
-            you know that the transformed index is monotonicly increasing. Dask
+            you know that the transformed index is monotonically increasing. Dask
             will check that transformed divisions are monotonic, but cannot
             check all the values between divisions, so incorrectly setting this
             can result in bugs.
@@ -5336,7 +5336,7 @@ def _rename_dask(df, names):
     Destructively rename columns of dd.DataFrame or name of dd.Series.
     Not for pd.DataFrame or pd.Series.
 
-    Internaly used to overwrite dd.DataFrame.columns and dd.Series.name
+    Internally used to overwrite dd.DataFrame.columns and dd.Series.name
     We can't use map_partition because it applies function then rename
 
     Parameters

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -11,7 +11,7 @@ There are two important cases:
 2.  We combine along an unpartitioned index or other column
 
 In the first case we know which partitions of each dataframe interact with
-which others.  This lets uss be significantly more clever and efficient.
+which others.  This lets us be significantly more clever and efficient.
 
 In the second case each partition from one dataset interacts with all
 partitions from the other.  We handle this through a shuffle operation.

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2609,7 +2609,7 @@ def test_to_dask_array_raises(as_frame):
         a.to_dask_array(5)
 
 
-@pytest.mark.parametrize("as_frame", [False, False])
+@pytest.mark.parametrize("as_frame", [False, True])
 def test_to_dask_array_unknown(as_frame):
     s = pd.Series([1, 2, 3, 4, 5], name="foo")
     a = dd.from_pandas(s, chunksize=2)
@@ -2622,11 +2622,12 @@ def test_to_dask_array_unknown(as_frame):
     result = result.chunks
 
     if as_frame:
+        assert len(result) == 2
         assert result[1] == (1,)
+    else:
+        assert len(result) == 1
 
-    assert len(result) == 1
     result = result[0]
-
     assert len(result) == 2
     assert all(np.isnan(x) for x in result)
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
-----

- a length check related to passing `-1`s to array.reshape was incorrect; fixed + added test
- cryptic unused `ddf.iloc` expression was intended to fail, but should probably `return`; fixed + documented (spoiler: [I've implemented ddf.iloc separately](https://github.com/celsiustx/dask/tree/sizes), for some cases; PR incoming…)
- a pytest was parameterized with `[False, False]` when `[False, True]` was presumably intended; fixed + adjusted test to work in both cases
- misc comment clarifications / typo fixes

(I previously pushed a commit here where I'd run an older version of `black` and introduced some incorrect formatting changes; force-pushed to correct that, as well as add a few more fixes).