### PR TITLE
Pad symmetric reflect

### DIFF
--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -690,7 +690,9 @@ skip_stat_length = pytest.mark.xfail(_numpy_117, reason="numpy-14061")
         ((10, 11), (4, 5), 0, "edge", {}),
         ((10, 11), (4, 5), 0, "linear_ramp", {"end_values": 2}),
         ((10, 11), (4, 5), 0, "reflect", {}),
+        ((10, 11), (4, 5), 0, "reflect", {"reflect_type": "odd"}),
         ((10, 11), (4, 5), 0, "symmetric", {}),
+        ((10, 11), (4, 5), 0, "symmetric", {"reflect_type": "odd"}),
         ((10, 11), (4, 5), 0, "wrap", {}),
         pytest.param(
             (10, 11),
@@ -712,6 +714,37 @@ def test_pad_0_width(shape, chunks, pad_width, mode, kwargs):
     da_r = da.pad(da_a, pad_width, mode, **kwargs)
 
     assert da_r is da_a
+
+    assert_eq(np_r, da_r)
+
+
+@pytest.mark.parametrize(
+    "shape, pad_width, mode, kwargs",
+    [
+        ((0, 1), ((0, 0), (2, 3)), "constant", {"constant_values": 2}),
+        ((0, 1), ((2, 0), (2, 3)), "constant", {"constant_values": 2}),
+        ((0, 1), ((0, 0), (2, 3)), "edge", {}),
+        ((0, 1), ((0, 0), (2, 3)), "linear_ramp", {"end_values": 2}),
+        ((0, 1), ((0, 0), (2, 3)), "reflect", {}),
+        ((0, 1), ((0, 0), (2, 3)), "symmetric", {}),
+        ((0, 1), ((0, 0), (2, 3)), "wrap", {}),
+        pytest.param(
+            (0, 1),
+            ((0, 0), (2, 3)),
+            "empty",
+            {},
+            marks=pytest.mark.skipif(
+                not _numpy_117, reason="requires NumPy>=1.17 for empty mode support"
+            ),
+        ),
+    ],
+)
+def test_pad_1_width(shape, pad_width, mode, kwargs):
+    np_a = np.random.random(shape)
+    da_a = da.from_array(np_a)
+
+    np_r = np.pad(np_a, pad_width, mode, **kwargs)
+    da_r = da.pad(da_a, pad_width, mode, **kwargs)
 
     assert_eq(np_r, da_r)
 
@@ -794,7 +827,7 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
         "reflect",
         "symmetric",
         "wrap",
-        pytest.param("median", marks=pytest.mark.skip(reason="Not implemented"),),
+        pytest.param("median", marks=pytest.mark.xfail(raises=NotImplementedError)),
         pytest.param(
             "empty",
             marks=pytest.mark.skip(

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -740,7 +740,9 @@ def test_pad_0_width(shape, chunks, pad_width, mode, kwargs):
             {"end_values": ((-1, -2), (4, 3))},
         ),
         ((10, 11), (4, 5), ((1, 4), (2, 3)), "reflect", {}),
+        ((10, 11), (4, 5), ((1, 4), (2, 3)), "reflect", {"reflect_type": "odd"}),
         ((10, 11), (4, 5), ((1, 4), (2, 3)), "symmetric", {}),
+        ((10, 11), (4, 5), ((1, 4), (2, 3)), "symmetric", {"reflect_type": "odd"}),
         ((10, 11), (4, 5), ((1, 4), (2, 3)), "wrap", {}),
         ((10,), (3,), ((2, 3)), "maximum", {"stat_length": (1, 2)}),
         ((10, 11), (4, 5), ((1, 4), (2, 3)), "mean", {"stat_length": ((3, 4), (2, 1))}),
@@ -789,28 +791,10 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
         "maximum",
         "mean",
         "minimum",
-        pytest.param(
-            "reflect",
-            marks=pytest.mark.skip(
-                reason="Bug when pad_width is larger than dimension: https://github.com/dask/dask/issues/5303"
-            ),
-        ),
-        pytest.param(
-            "symmetric",
-            marks=pytest.mark.skip(
-                reason="Bug when pad_width is larger than dimension: https://github.com/dask/dask/issues/5303"
-            ),
-        ),
-        pytest.param(
-            "wrap",
-            marks=pytest.mark.skip(
-                reason="Bug when pad_width is larger than dimension: https://github.com/dask/dask/issues/5303"
-            ),
-        ),
-        pytest.param(
-            "median",
-            marks=pytest.mark.skip(reason="Not implemented"),
-        ),
+        "reflect",
+        "symmetric",
+        "wrap",
+        pytest.param("median", marks=pytest.mark.skip(reason="Not implemented"),),
         pytest.param(
             "empty",
             marks=pytest.mark.skip(


### PR DESCRIPTION
Fixes  issue #6127 and adds the `reflect_type="odd"` option to the `pad` method.

Performance is probably a little worse than it was before, since the array is reshaped multiple times.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
