### PR TITLE
Added bytes/row calculation when using meta

### DIFF
--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -152,9 +152,7 @@ def read_sql_table(
         if meta is None:
             meta = head.iloc[:0]
     elif meta is None:
-        raise ValueError(
-            "Must provide meta if head_rows is 0"
-        )
+        raise ValueError("Must provide meta if head_rows is 0")
     else:
         if divisions is None and npartitions is None:
             raise ValueError(

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -233,23 +233,37 @@ def test_division_or_partition(db):
 
 
 def test_meta(db):
-    data = read_sql_table("test", db, index_col="number", meta=dd.from_pandas(df, npartitions=1)).compute()
+    data = read_sql_table(
+        "test", db, index_col="number", meta=dd.from_pandas(df, npartitions=1)
+    ).compute()
     assert (data.name == df.name).all()
     assert data.index.name == "number"
     assert_eq(data, df)
 
 
 def test_meta_no_head_rows(db):
-    data = read_sql_table("test", db, index_col="number", meta=dd.from_pandas(df, npartitions=1),
-                          npartitions=2, head_rows=0)
+    data = read_sql_table(
+        "test",
+        db,
+        index_col="number",
+        meta=dd.from_pandas(df, npartitions=1),
+        npartitions=2,
+        head_rows=0,
+    )
     assert len(data.divisions) == 3
     data = data.compute()
     assert (data.name == df.name).all()
     assert data.index.name == "number"
     assert_eq(data, df)
 
-    data = read_sql_table("test", db, index_col="number", meta=dd.from_pandas(df, npartitions=1),
-                          divisions=[0, 3, 6], head_rows=0)
+    data = read_sql_table(
+        "test",
+        db,
+        index_col="number",
+        meta=dd.from_pandas(df, npartitions=1),
+        divisions=[0, 3, 6],
+        head_rows=0,
+    )
     assert len(data.divisions) == 3
     data = data.compute()
     assert (data.name == df.name).all()

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -232,6 +232,36 @@ def test_division_or_partition(db):
     assert_eq(out, df)
 
 
+def test_meta(db):
+    data = read_sql_table("test", db, index_col="number", meta=dd.from_pandas(df, npartitions=1)).compute()
+    assert (data.name == df.name).all()
+    assert data.index.name == "number"
+    assert_eq(data, df)
+
+
+def test_meta_no_head_rows(db):
+    data = read_sql_table("test", db, index_col="number", meta=dd.from_pandas(df, npartitions=1),
+                          npartitions=2, head_rows=0)
+    assert len(data.divisions) == 3
+    data = data.compute()
+    assert (data.name == df.name).all()
+    assert data.index.name == "number"
+    assert_eq(data, df)
+
+    data = read_sql_table("test", db, index_col="number", meta=dd.from_pandas(df, npartitions=1),
+                          divisions=[0, 3, 6], head_rows=0)
+    assert len(data.divisions) == 3
+    data = data.compute()
+    assert (data.name == df.name).all()
+    assert data.index.name == "number"
+    assert_eq(data, df)
+
+
+def test_no_meta_no_head_rows(db):
+    with pytest.raises(ValueError):
+        read_sql_table("test", db, index_col="number", head_rows=0, npartitions=1)
+
+
 def test_range(db):
     data = read_sql_table("test", db, npartitions=2, index_col="number", limits=[1, 4])
     assert data.index.min().compute() == 1


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
