### PR TITLE
Add SVD support for short-and-fat arrays

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -799,13 +799,45 @@ def svd(a):
     s:  Array, singular values in decreasing order (largest first)
     v:  Array, unitary / orthogonal
 
+    Warnings
+    --------
+
+    SVD is only supported for arrays with chunking in one dimension.
+    This requires that all inputs either contain a single column
+    of chunks (tall-and-skinny) or a single row of chunks (short-and-fat).
+    For arrays with chunking in both dimensions, see da.linalg.svd_compressed.
+
     See Also
     --------
 
     np.linalg.svd : Equivalent NumPy Operation
-    dask.array.linalg.tsqr: Implementation for tall-and-skinny arrays
+    da.linalg.svd_compressed : Randomized SVD for fully chunked arrays
+    dask.array.linalg.tsqr: QR factorization for tall-and-skinny arrays
     """
-    return tsqr(a, compute_svd=True)
+    nb = a.numblocks
+    if a.ndim != 2:
+        raise ValueError(
+            "Array must be 2D.\n"
+            "Input shape: {}\n"
+            "Input ndim: {}\n".format(a.shape, a.ndim)
+        )
+    if nb[0] > 1 and nb[1] > 1:
+        raise ValueError(
+            "Array must be chunked in one dimension only. "
+            "This function (svd) only supports tall-and-skinny or short-and-fat "
+            "matrices (see da.linalg.svd_compressed for SVD on fully chunked arrays).\n"
+            "Input shape: {}\n"
+            "Input numblocks: {}\n".format(a.shape, nb)
+        )
+
+    # Tall-and-skinny case
+    if nb[0] >= nb[1]:
+        u, s, v = tsqr(a, compute_svd=True)
+        return u, s, v
+    # Short-and-fat case
+    else:
+        vt, s, ut = tsqr(a.T, compute_svd=True)
+        return ut.T, s, vt.T
 
 
 def _solve_triangular_lower(a, b):


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`

This is for https://github.com/dask/dask/issues/6590 and adds support for SVD on short-and-fat arrays by transposing inputs/outputs to/from `tsqr`. 

To do a comparison to `np.lingalg.svd`, I needed to ensure that the eigenvector signs are always the same.  I lifted [svd_flip](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/extmath.py#L504) from scikit-learn for that, but I'm not sure where to put it.  Alternatively, the comparison could look for equality on either sign in each vector as in [dask-ml#731](https://github.com/dask/dask-ml/issues/731#issuecomment-682211742).  Any thoughts on that @mrocklin?

**EDIT**

FYI there were a few changes in here from the current upstream master branch that weren't passing the black formatter check.  This commit bases on https://github.com/dask/dask/commit/0ca1607aa14cb81520ca9526f871b631fe6706fa.  Hm how did that get into master without passing CI?