### PR TITLE
Restore ability to pickle dask arrays

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2413,12 +2413,7 @@ def test_from_array_scalar(type_):
 
     dx = da.from_array(x, chunks=-1)
     assert_eq(np.array(x), dx)
-    assert isinstance(
-        dx.dask[
-            dx.name,
-        ],
-        np.ndarray,
-    )
+    assert isinstance(dx.dask[dx.name,], np.ndarray,)
 
 
 @pytest.mark.parametrize("asarray,cls", [(True, np.ndarray), (False, np.matrix)])
@@ -3298,10 +3293,9 @@ def test_from_array_names():
     assert set(names.values()) == set([1, 5])
 
 
-@pytest.mark.parametrize("array", [
-    da.arange(100, chunks=25),
-    da.ones((10, 10), chunks=25),
-])
+@pytest.mark.parametrize(
+    "array", [da.arange(100, chunks=25), da.ones((10, 10), chunks=25),]
+)
 def test_array_picklable(array):
     from pickle import loads, dumps
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3298,12 +3298,15 @@ def test_from_array_names():
     assert set(names.values()) == set([1, 5])
 
 
-def test_array_picklable():
+@pytest.mark.parametrize("array", [
+    da.arange(100, chunks=25),
+    da.ones((10, 10), chunks=25),
+])
+def test_array_picklable(array):
     from pickle import loads, dumps
 
-    a = da.arange(100, chunks=25)
-    a2 = loads(dumps(a))
-    assert_eq(a, a2)
+    a2 = loads(dumps(array))
+    assert_eq(array, a2)
 
 
 def test_from_array_raises_on_bad_chunks():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2413,7 +2413,12 @@ def test_from_array_scalar(type_):
 
     dx = da.from_array(x, chunks=-1)
     assert_eq(np.array(x), dx)
-    assert isinstance(dx.dask[dx.name,], np.ndarray,)
+    assert isinstance(
+        dx.dask[
+            dx.name,
+        ],
+        np.ndarray,
+    )
 
 
 @pytest.mark.parametrize("asarray,cls", [(True, np.ndarray), (False, np.matrix)])
@@ -3294,7 +3299,11 @@ def test_from_array_names():
 
 
 @pytest.mark.parametrize(
-    "array", [da.arange(100, chunks=25), da.ones((10, 10), chunks=25),]
+    "array",
+    [
+        da.arange(100, chunks=25),
+        da.ones((10, 10), chunks=25),
+    ],
 )
 def test_array_picklable(array):
     from pickle import loads, dumps

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -134,6 +134,10 @@ def wrap(wrap_func, func, **kwargs):
 
 w = wrap(wrap_func_shape_as_first_arg)
 
+@curry
+def _broadcast_trick_inner(func, shape, *args, **kwargs):
+    return np.broadcast_to(func((), *args, **kwargs), shape)
+
 
 def broadcast_trick(func):
     """
@@ -155,8 +159,7 @@ def broadcast_trick(func):
     so should be safe.
     """
 
-    def inner(shape, *args, **kwargs):
-        return np.broadcast_to(func((), *args, **kwargs), shape)
+    inner = _broadcast_trick_inner(func)
 
     if func.__doc__ is not None:
         inner.__doc__ = func.__doc__

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -201,7 +201,12 @@ def full_like(a, fill_value, *args, **kwargs):
         raise ValueError(
             f"fill_value must be scalar. Received {type(fill_value).__name__} instead."
         )
-    return _full_like(a=a, fill_value=fill_value, *args, **kwargs,)
+    return _full_like(
+        a=a,
+        fill_value=fill_value,
+        *args,
+        **kwargs,
+    )
 
 
 full.__doc__ = _full.__doc__

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -134,6 +134,7 @@ def wrap(wrap_func, func, **kwargs):
 
 w = wrap(wrap_func_shape_as_first_arg)
 
+
 @curry
 def _broadcast_trick_inner(func, shape, *args, **kwargs):
     return np.broadcast_to(func((), *args, **kwargs), shape)
@@ -200,12 +201,7 @@ def full_like(a, fill_value, *args, **kwargs):
         raise ValueError(
             f"fill_value must be scalar. Received {type(fill_value).__name__} instead."
         )
-    return _full_like(
-        a=a,
-        fill_value=fill_value,
-        *args,
-        **kwargs,
-    )
+    return _full_like(a=a, fill_value=fill_value, *args, **kwargs,)
 
 
 full.__doc__ = _full.__doc__


### PR DESCRIPTION
Dask arrays outputted by `dask.array.ones` can no longer be pickled because of a change in how `broadcast_trick` is implemented. This went unnoticed by the existing pickle/unpickle test, which only tested pickling for the output of `da.arange`.  This PR adds a failing test case and repairs it.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Resolves #6589 