### PR TITLE
asanyarray: handle sequences containing dask Arrays

### DIFF
--- a/dask/array/chunk_types.py
+++ b/dask/array/chunk_types.py
@@ -8,7 +8,7 @@ _HANDLED_CHUNK_TYPES = [np.ndarray, np.ma.MaskedArray]
 
 
 def register_chunk_type(type):
-    """ Register the given type as a valid chunk and downcast array type
+    """Register the given type as a valid chunk and downcast array type
 
     Parameters
     ----------

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3864,7 +3864,7 @@ def asanyarray(a):
     elif type(a).__module__.startswith("xarray.") and hasattr(a, "data"):
         return asanyarray(a.data)
     elif isinstance(a, (list, tuple)) and any(isinstance(i, Array) for i in a):
-        a = stack(a)
+        return stack(a)
     elif not isinstance(getattr(a, "shape", None), Iterable):
         a = np.asanyarray(a)
     return from_array(a, chunks=a.shape, getitem=getter_inline, asarray=False)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -168,7 +168,7 @@ def implements(*numpy_functions):
 
 
 def check_if_handled_given_other(f):
-    """ Check if method is handled by Dask given type of other
+    """Check if method is handled by Dask given type of other
 
     Ensures proper deferral to upcast types in dunder operations without
     assuming unknown types are automatically downcast types.

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2413,7 +2413,12 @@ def test_from_array_scalar(type_):
 
     dx = da.from_array(x, chunks=-1)
     assert_eq(np.array(x), dx)
-    assert isinstance(dx.dask[dx.name,], np.ndarray)
+    assert isinstance(
+        dx.dask[
+            dx.name,
+        ],
+        np.ndarray,
+    )
 
 
 @pytest.mark.parametrize("asarray,cls", [(True, np.ndarray), (False, np.matrix)])

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -179,7 +179,7 @@ def test_non_existent_func():
 
 @pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
 @pytest.mark.parametrize(
-    "func", [np.equal, np.matmul, np.dot, lambda x, y: np.stack([x, y]),],
+    "func", [np.equal, np.matmul, np.dot, lambda x, y: np.stack([x, y])]
 )
 @pytest.mark.parametrize(
     "arr_upcast, arr_downcast",


### PR DESCRIPTION
`asarray` worked on lists containing dask Arrays, but `asanyarray` didn't.

```python
x = da.asarray([1, 2, 3])
# works
da.asarray([0, x[1], x[2]])
# failed
da.asanyarray([0, x[1], x[2]])
```

Looks like #5280 only changed `asarray`, not `asanyarray`. I made most of the `asarray` tests use both methods, just to guard against such drift in the future.

`test_asarray_chunks` was the only one with inconsistent behavior, because `asanyarray` sets `chunks=a.shape`, but `asarray` does not. Unclear to me if that's intentional---if not, I'm happy to make them consistent in this PR.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
