### PR TITLE
[REVIEW] Dask Array's store to return a single HLG layer

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -920,6 +920,7 @@ def store(
     store_keys = list(store_dsk.keys())
 
     store_dsk = HighLevelGraph.merge(store_dsk, targets_dsk, sources_dsk)
+    store_dsk = HighLevelGraph.from_collections(id(store_dsk), dict(store_dsk))
 
     if return_stored:
         load_store_dsk = store_dsk


### PR DESCRIPTION
This PR merges all the layers in the returned `HighLevelGraph`. 

I am not exactly sure about the motivation of https://github.com/dask/dask/pull/3153 but the later transition to use high level graphs is incorrect -- all layer dependencies are empty.

If the idea of https://github.com/dask/dask/pull/3153 is to merge everything into a shallow graph my guess is we want a single layer in the returned high level graph?

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

cc @jakirkham 