### PR TITLE
Eagerly slice numpy arrays in from_array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2835,6 +2835,7 @@ def from_array(
     Numpy ndarrays that are smaller than array.chunk-size are wholly embedded in the graph,
     communicated to all workers and then sliced at compute time. So operator.getitem
     tasks are present in the graph.
+    >>> import dask.array as da
     >>> a = da.from_array(np.array([[1, 2], [3, 4]]), chunks=(1,))
     >>> a.dask[a.name, 0, 0][0]
     <function _operator.getitem(a, b, /)>

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2832,20 +2832,23 @@ def from_array(
     >>> token = dask.base.tokenize(x)  # doctest: +SKIP
     >>> a = da.from_array('myarray-' + token)  # doctest: +SKIP
 
-    Numpy ndarrays that are smaller than array.chunk-size are wholly embedded in the graph,
-    communicated to all workers and then sliced at compute time. So operator.getitem
+    Numpy ndarrays that are smaller than ``array.chunk-size`` are wholly embedded in the graph,
+    communicated to all workers and then sliced at compute time. So ``operator.getitem``
     tasks are present in the graph.
+
     >>> import dask.array as da
     >>> a = da.from_array(np.array([[1, 2], [3, 4]]), chunks=(1,))
     >>> a.dask[a.name, 0, 0][0]
     <function _operator.getitem(a, b, /)>
 
-    Numpy ndarrays that are bigger than array.chunk-size are eagerly sliced and then
+    Numpy ndarrays that are bigger than ``array.chunk-size`` are eagerly sliced and then
     embedded in the graph.
+
     >>> with dask.config.set({"array.chunk-size": "1B"}):
     >>>     a = dask.array.from_array(np.array([[1, 2], [3, 4]]), chunks=(1,1))
     >>> a.dask[a.name, 0, 0][0]
     array([1])
+
     """
     if isinstance(x, Array):
         raise ValueError(
@@ -2894,7 +2897,6 @@ def from_array(
         # GH5367, GH5601
         slices = slices_from_chunks(chunks)
         keys = product([name], *(range(len(bds)) for bds in chunks))
-        slices = slices_from_chunks(chunks)
         values = [x[slc] for slc in slices]
         dsk = dict(zip(keys, values))
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2874,9 +2874,6 @@ def from_array(
     if lock is True:
         lock = SerializableLock()
 
-    limit = config.get("array.chunk-size")
-    if isinstance(limit, str):
-        limit = parse_bytes(limit)
     is_ndarray = type(x) is np.ndarray
     is_single_block = all(len(c) == 1 for c in chunks)
     # Always use the getter for h5py etc. Not using isinstance(x, np.ndarray)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2392,7 +2392,7 @@ def test_from_array_ndarray_getitem():
     with dask.config.set({"array.chunk-size": "1B"}):
         dx = da.from_array(x, chunks=(1, 2))
         assert_eq(x, dx)
-        assert dx.dask[dx.name, 0, 0] == np.array([[1, 2]])
+        assert (dx.dask[dx.name, 0, 0] == np.array([[1, 2]])).all()
 
 
 @pytest.mark.parametrize("x", [[1, 2], (1, 2), memoryview(b"abc")])

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2387,12 +2387,7 @@ def test_from_array_ndarray_getitem():
     x = np.array([[1, 2], [3, 4]])
     dx = da.from_array(x, chunks=(1, 2))
     assert_eq(x, dx)
-    assert dx.dask[dx.name, 0, 0][0] == operator.getitem
-
-    with dask.config.set({"array.chunk-size": "1B"}):
-        dx = da.from_array(x, chunks=(1, 2))
-        assert_eq(x, dx)
-        assert (dx.dask[dx.name, 0, 0] == np.array([[1, 2]])).all()
+    assert (dx.dask[dx.name, 0, 0] == np.array([[1, 2]])).all()
 
 
 @pytest.mark.parametrize("x", [[1, 2], (1, 2), memoryview(b"abc")])
@@ -2404,13 +2399,7 @@ def test_from_array_list(x):
 
     dx = da.from_array(x, chunks=1)
     assert_eq(np.array(x), dx)
-    assert dx.dask[dx.name, 0][0] == operator.getitem
-    assert isinstance(dx.dask[dx.name.replace("array", "array-original")], np.ndarray)
-
-    with dask.config.set({"array.chunk-size": "1B"}):
-        dx = da.from_array(x, chunks=1)
-        assert_eq(x, dx)
-        assert dx.dask[dx.name, 0][0] == x[0]
+    assert dx.dask[dx.name, 0][0] == x[0]
 
 
 @pytest.mark.parametrize("type_", [t for t in np.ScalarType if t is not memoryview])
@@ -3300,12 +3289,7 @@ def test_from_array_names():
     d = da.from_array(x, chunks=2)
 
     names = countby(key_split, d.dask)
-    assert set(names.values()) == set([1, 5])
-
-    with dask.config.set({"array.chunk-size": "1B"}):
-        d = da.from_array(x, chunks=2)
-        names = countby(key_split, d.dask)
-        assert set(names.values()) == set([5])
+    assert set(names.values()) == set([5])
 
 
 @pytest.mark.parametrize(

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2389,6 +2389,11 @@ def test_from_array_ndarray_getitem():
     assert_eq(x, dx)
     assert dx.dask[dx.name, 0, 0][0] == operator.getitem
 
+    with dask.config.set({"array.chunk-size": "1B"}):
+        dx = da.from_array(x, chunks=(1, 2))
+        assert_eq(x, dx)
+        assert dx.dask[dx.name, 0, 0] == np.array([[1, 2]])
+
 
 @pytest.mark.parametrize("x", [[1, 2], (1, 2), memoryview(b"abc")])
 def test_from_array_list(x):
@@ -2402,6 +2407,11 @@ def test_from_array_list(x):
     assert dx.dask[dx.name, 0][0] == operator.getitem
     assert isinstance(dx.dask[dx.name.replace("array", "array-original")], np.ndarray)
 
+    with dask.config.set({"array.chunk-size": "1B"}):
+        dx = da.from_array(x, chunks=1)
+        assert_eq(x, dx)
+        assert dx.dask[dx.name, 0][0] == x[0]
+
 
 @pytest.mark.parametrize("type_", [t for t in np.ScalarType if t is not memoryview])
 def test_from_array_scalar(type_):
@@ -2413,12 +2423,7 @@ def test_from_array_scalar(type_):
 
     dx = da.from_array(x, chunks=-1)
     assert_eq(np.array(x), dx)
-    assert isinstance(
-        dx.dask[
-            dx.name,
-        ],
-        np.ndarray,
-    )
+    assert isinstance(dx.dask[dx.name,], np.ndarray,)
 
 
 @pytest.mark.parametrize("asarray,cls", [(True, np.ndarray), (False, np.matrix)])
@@ -3297,13 +3302,14 @@ def test_from_array_names():
     names = countby(key_split, d.dask)
     assert set(names.values()) == set([1, 5])
 
+    with dask.config.set({"array.chunk-size": "1B"}):
+        d = da.from_array(x, chunks=2)
+        names = countby(key_split, d.dask)
+        assert set(names.values()) == set([5])
+
 
 @pytest.mark.parametrize(
-    "array",
-    [
-        da.arange(100, chunks=25),
-        da.ones((10, 10), chunks=25),
-    ],
+    "array", [da.arange(100, chunks=25), da.ones((10, 10), chunks=25),],
 )
 def test_array_picklable(array):
     from pickle import loads, dumps

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2412,7 +2412,12 @@ def test_from_array_scalar(type_):
 
     dx = da.from_array(x, chunks=-1)
     assert_eq(np.array(x), dx)
-    assert isinstance(dx.dask[dx.name,], np.ndarray,)
+    assert isinstance(
+        dx.dask[
+            dx.name,
+        ],
+        np.ndarray,
+    )
 
 
 @pytest.mark.parametrize("asarray,cls", [(True, np.ndarray), (False, np.matrix)])
@@ -3293,7 +3298,11 @@ def test_from_array_names():
 
 
 @pytest.mark.parametrize(
-    "array", [da.arange(100, chunks=25), da.ones((10, 10), chunks=25),],
+    "array",
+    [
+        da.arange(100, chunks=25),
+        da.ones((10, 10), chunks=25),
+    ],
 )
 def test_array_picklable(array):
     from pickle import loads, dumps

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -264,7 +264,8 @@ def test_dont_fuse_numpy_arrays():
 
 
 def test_minimize_data_transfer():
-    x = np.ones(100)
+    zarr = pytest.importorskip("zarr")
+    x = zarr.ones((100,))
     y = da.from_array(x, chunks=25)
     z = y + 1
     dsk = z.__dask_optimize__(z.dask, z.__dask_keys__())

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -263,24 +263,6 @@ def test_dont_fuse_numpy_arrays():
         assert sum(isinstance(v, np.ndarray) for v in dsk.values()) == 1
 
 
-def test_minimize_data_transfer():
-    x = np.ones(100)
-    y = da.from_array(x, chunks=25)
-    z = y + 1
-    dsk = z.__dask_optimize__(z.dask, z.__dask_keys__())
-
-    keys = list(dsk)
-    results = dask.get(dsk, keys)
-    big_key = [k for k, r in zip(keys, results) if r is x][0]
-    dependencies, dependents = dask.core.get_deps(dsk)
-    deps = dependents[big_key]
-
-    assert len(deps) == 4
-    for dep in deps:
-        assert dsk[dep][0] in (getitem, getter)
-        assert dsk[dep][1] == big_key
-
-
 def test_fuse_slices_with_alias():
     dsk = {
         "x": np.arange(16).reshape((4, 4)),


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Closes #5367, Closes #5601, Closes https://github.com/dask/distributed/issues/3032

I've been curious about the discussion about eagerly slicing numpy arrays to prevent adding large numpy arrays to the graph (see https://github.com/dask/dask/issues/5367, https://github.com/dask/distributed/issues/3032, https://github.com/dask/dask/issues/5601) so I tried to implement it. 

I am using `array.chunk-size` to decide if a numpy array is too big and should be sliced eagerly.

``` python
import dask.array as da
import numpy as np
import dask

test_np = np.random.uniform(low=0, high=10, size=(12, 5))
test_da = da.from_array(test_np, chunks=(2, 3))
np.testing.assert_equal(test_da, test_np)
test_da.visualize()
```
![image](https://user-images.githubusercontent.com/2448579/92336302-aa376200-f08e-11ea-988b-0bac4b1883ce.png)


``` python
with dask.config.set({"array.chunk-size": "3B"}):
    test_da = da.from_array(test_np, chunks=(2, 3))
np.testing.assert_equal(test_da, test_np)
test_da.visualize()
```
![image](https://user-images.githubusercontent.com/2448579/92336299-a4418100-f08e-11ea-9ab2-d8879096f7f3.png)

Happy to make changes, or even drop this if you don't think it is a good idea. 

The failing tests look for `operator.getitem` in the graph, which this PR removes. Then there's this test failure which I don't understand (EDIT: no longer fails now that I've added the `nbytes` check:
```
    def test_from_array_names():
        pytest.importorskip("distributed")
    
        x = np.ones(10)
        d = da.from_array(x, chunks=2)
    
        names = countby(key_split, d.dask)
>       assert set(names.values()) == set([1, 5])
E       assert {5} == {1, 5}
E         Extra items in the right set:
E         1
E         Use -v to get the full diff
```

cc @d-v-b 