### PR TITLE
Add svd_flip (#6599)

### DIFF
--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -350,6 +350,40 @@ def validate_axis(axis, ndim):
     return axis
 
 
+def svd_flip(u, v):
+    """Sign correction to ensure deterministic output from SVD.
+
+    This function is useful for orienting eigenvectors such that
+    they all lie in a shared but arbitrary half-space. This makes
+    it possible to ensure that results are equivalent across SVD
+    implementations and random number generator states.
+
+    Parameters
+    ----------
+
+    u : (M, K) array_like
+        Left singular vectors
+    v : (K, N) array_like
+        Right singular vectors
+
+    Returns
+    -------
+
+    u : (M, K) array_like
+        Left singular vectors with corrected sign
+    v:  (K, N) array_like
+        Right singular vectors with corrected sign
+    """
+    # Determine half-space in which all left singular vectors
+    # lie relative to an arbitrary vector; this is equivalent
+    # to dot product with a row vector of ones
+    signs = np.sum(u, axis=0, keepdims=True)
+    signs = 2 * ((signs >= 0) - 0.5)
+    # Force all singular vectors into same half-space
+    u, v = u * signs, v * signs.T
+    return u, v
+
+
 def _is_nep18_active():
     class A:
         def __array_function__(self, *args, **kwargs):


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`

This adds the function mentioned in https://github.com/dask/dask/issues/6599.

Notes on it:

- Sign correction in SVD is a heuristic process though there seems to be some consensus that an idealized process for it identifies eigenvector directions that point in the direction of data vectors [[1](https://prod-ng.sandia.gov/techlib-noauth/access-control.cgi/2007/076422.pdf)] (this gets cited in a lot of stack exchanges / github issues)
- The "use the sign of the largest absolute value in a singular vector" approach taken in scikit-learn seems to be fairly common and is convenient when you want deterministic but arbitrary behavior (i.e. a data-independent heuristic)
- I don't think this needs to be a meaningful correction, just a deterministic one 
- The scikit-learn svd_flip function allows for the correction to be based on `U` or `V` and as best I can tell, this is only relevant when you're running SVD on transposed inputs in the first place.  I don't see any reason to need that and it appears to be used rarely so I simply left out the correct-based-on-`V` option (instead of `U`).
- The trivial dask implementation of [sklearn.svd_flip](https://github.com/scikit-learn/scikit-learn/blob/7bbd0d56530ad3758841595d81ab8deed069879d/sklearn/utils/extmath.py#L504) replaces `np.sign(u[max_abs_cols, range(u.shape[1])])` with `np.sign(u.vindex[max_abs_cols, range(u.shape[1])])` where `vindex` is used for fancy-indexing.  I found this to be unacceptably slow though.  Instead, a similarly arbitrary but more efficient correction would be to make sure all singular vectors fall in the same half-space as any arbitrarily chosen vector.  I can't find an authoritative citation for this but it's kind of a common sense approach. Here is a [notebook](https://gist.github.com/eric-czech/5c48337c034f7470328c55d93fcc730e) that compares the two approaches on equally sized short-fat or tall-skinny arrays and contains benchmark results that look like this: ![Screen Shot 2020-09-09 at 1 23 42 PM](https://user-images.githubusercontent.com/6130352/92631694-b8a89800-f29f-11ea-8e91-a33b75d46534.png)
    - *svd_flip1* = scikit-learn svd_flip adapted to dask arrays
    - *svd_flip2* = the implementation in this PR

Interestingly, the transposition needed to make SVD work for short-fat arrays (https://github.com/dask/dask/pull/6591) has almost no effect at all.  The scikit-learn correction using `vindex` on dask arrays almost doubles the time it takes for the whole SVD + correction routine to run but this approach using a matrix-vector multiplication instead (as a sum across rows) accounts for a fairly negligible increase in time taken.

**tl;dr** This method is efficient but I still don't know quite where to put it.  I think I would prefer if it was used based on an option in the `linalg.svd` signature set to `True` by default though that's not going to make sense until https://github.com/dask/dask/issues/3576 is done.  Also, it will mean that the setting `full_matrices=True, correct_signs=True` isn't a valid one.  For now though, I put this in `array.utils` and the test in `test_linalg.py` which is a little weird, but it seemed to make the most sense there alongside the other svd tests.