### PR TITLE
Improve SVD consistency and small array handling

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -861,7 +861,7 @@ def svd(a, coerce_signs=True):
     if nb[0] == nb[1] == 1:
         m, n = a.shape
         k = min(a.shape)
-        mu, ms, mv = np.linalg.svd(np.ones((1, 1), dtype=a.dtype))
+        mu, ms, mv = np.linalg.svd(a._meta)
         u, s, v = delayed(np.linalg.svd, nout=3)(a, full_matrices=False)
         u = from_delayed(u, shape=(m, k), meta=mu)
         s = from_delayed(s, shape=(k,), meta=ms)

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -861,7 +861,7 @@ def svd(a, coerce_signs=True):
     if nb[0] == nb[1] == 1:
         m, n = a.shape
         k = min(a.shape)
-        mu, ms, mv = np.linalg.svd(a._meta)
+        mu, ms, mv = np.linalg.svd(np.ones((1, 1), dtype=a.dtype))
         u, s, v = delayed(np.linalg.svd, nout=3)(a, full_matrices=False)
         u = from_delayed(u, shape=(m, k), meta=mu)
         s = from_delayed(s, shape=(k,), meta=ms)


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`

This addresses https://github.com/dask/dask/issues/6612, builds on https://github.com/dask/dask/issues/6599, and is related to https://github.com/dask/dask/issues/3576.

For https://github.com/dask/dask/issues/6612, this calls numpy.linalg.svd for single-chunk arrays which avoids performance issues and result shape inconsistencies that occur when the array has more columns than rows.

This uses the svd_flip function added for https://github.com/dask/dask/issues/6599 by default and adds a `coerce_signs` argument to disable that behavior.

For https://github.com/dask/dask/issues/3576, this ensures that all results are consistent with `np.linalg.svd` when `full_matrices=False`. 

Note: The code I added here related to the `truncate` flag is a bit of a band-aid on top of not knowing what's going on in tsqr.  To be clear that code is addressing a corner case that should never happen on real datasets though.  It only occurs when an array has column blocks but is still wider than it is tall (e.g. as shown in this example: https://github.com/dask/dask/issues/3576#issuecomment-689788421).  Let me know if anybody thinks that is worthy of a separate tsqr-specific issue.  I'm on the fence about it but leaning towards no, that this is actually more of an SVD-specific problem so having the logic here may not be a bad solution anyways.