### PR TITLE
Fix flakey array mean

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -583,7 +583,7 @@ def mean(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None):
     if dtype is not None:
         dt = dtype
     else:
-        dt = getattr(np.mean(np.empty(shape=(1,), dtype=a.dtype)), "dtype", object)
+        dt = getattr(np.mean(np.zeros(shape=(1,), dtype=a.dtype)), "dtype", object)
     return reduction(
         a,
         mean_chunk,


### PR DESCRIPTION
- [x] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

[`test_pad_3d_data`][1] has intermittent failures (failure [1][2] [2][3] [3][4] [4][5]).

In all of the failures the `np.empty` in question returned `array([nan])`, which causes a `RuntimeWarning` which gets promoted to an error.

    E       RuntimeWarning: invalid value encountered in reduce

This PR fixes that nondeterministic failure by using `np.zeros` instead of `np.empty`, which will never return `nan`.

This fix was already applied to an analogous case in [this commit][6].

[1]: https://github.com/dask/dask/blob/64e2a9b3b9992503221a074a547827501927d1fa/dask/array/tests/test_creation.py#L822
[2]: https://travis-ci.org/github/dask/dask/jobs/725637024
[3]: https://travis-ci.org/github/dask/dask/jobs/725414420
[4]: https://travis-ci.org/github/dask/dask/jobs/723263004
[5]: https://travis-ci.org/github/dask/dask/jobs/723613268
[6]: https://github.com/dask/dask/pull/5511/commits/c30930e225ba4581c50a9d04fe5de444dcf3a3aa
