### PR TITLE
Set lower bound on compression level for svd_compressed using rows and cols

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -668,8 +668,8 @@ def compression_matrix(data, q, n_power_iter=0, seed=None, compute=False):
     pp. 217-288, June 2011
     https://arxiv.org/abs/0909.4061
     """
-    n = data.shape[1]
-    comp_level = compression_level(n, q)
+    m, n = data.shape
+    comp_level = compression_level(min(m, n), q)
     if isinstance(seed, RandomState):
         state = seed
     else:

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -489,6 +489,30 @@ def test_svd_compressed_deterministic():
     assert all(da.compute((u == u2).all(), (s == s2).all(), (vt == vt2).all()))
 
 
+@pytest.mark.parametrize("m", [5, 10, 15, 20])
+@pytest.mark.parametrize("n", [5, 10, 15, 20])
+@pytest.mark.parametrize("k", [5])
+@pytest.mark.parametrize("chunks", [(5, 10), (10, 5)])
+def test_svd_compressed_shapes(m, n, k, chunks):
+    x = da.random.random(size=(m, n), chunks=chunks)
+    u, s, v = svd_compressed(x, k=k, n_power_iter=1, compute=True, seed=1)
+    u, s, v = da.compute(u, s, v)
+    r = min(m, n, k)
+    assert u.shape == (m, r)
+    assert s.shape == (r,)
+    assert v.shape == (r, n)
+
+
+def test_svd_compressed_compute():
+    x = da.ones((100, 100), chunks=(10, 10))
+    u, s, v = da.linalg.svd_compressed(x, k=2, n_power_iter=0, compute=True, seed=123)
+    uu, ss, vv = da.linalg.svd_compressed(x, k=2, n_power_iter=0, seed=123)
+
+    assert len(v.dask) < len(vv.dask)
+
+    assert_eq(v, vv)
+
+
 def _check_lu_result(p, l, u, A):
     assert np.allclose(p.dot(l).dot(u), A)
 
@@ -957,13 +981,3 @@ def test_norm_implemented_errors(shape, chunks, axis, norm, keepdims):
     if len(shape) > 2 and len(axis) == 2:
         with pytest.raises(NotImplementedError):
             da.linalg.norm(d, ord=norm, axis=axis, keepdims=keepdims)
-
-
-def test_svd_compressed_compute():
-    x = da.ones((100, 100), chunks=(10, 10))
-    u, s, v = da.linalg.svd_compressed(x, k=2, n_power_iter=0, compute=True, seed=123)
-    uu, ss, vv = da.linalg.svd_compressed(x, k=2, n_power_iter=0, seed=123)
-
-    assert len(v.dask) < len(vv.dask)
-
-    assert_eq(v, vv)


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`

https://github.com/dask/dask/issues/6620

Hey @TomAugspurger, I think I was on the right track in https://github.com/dask/dask/issues/6620#issuecomment-690762194.  I modified the `svd_compressed` code so that the [comp_level](https://github.com/dask/dask/blob/3327b2e158dbadf2057685fdb51b74ce3129416e/dask/array/linalg.py#L672) value was a parameter I could pass in directly. Then I set up a grid of small array dimensions and for ~50 different inputs (all with fewer rows than cols) found in all cases that the error occurs when the compression level exceeds the number of rows and never occurs when it's less than that.  Right now, that `comp_level` value is bounded only by the number of columns in the input matrix, but including rows in that bound seems to fix it.  That also seems like a pretty plausible thing to have never tested or cared much about in the original implementation.

This PR includes that small change as well as a related test.  It would be great if that test also validated result accuracy though I'm not sure how to do that.  This much seems like a reasonable improvement.