### PR TITLE
Backend-aware dtype inference for single-chunk svd

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -12,7 +12,7 @@ from ..utils import derived_from, apply
 from .core import dotmany, Array, concatenate, from_delayed
 from .creation import eye
 from .random import RandomState
-from .utils import meta_from_array, svd_flip
+from .utils import meta_from_array, svd_flip, ones_like_safe
 
 
 def _cumsum_blocks(it):
@@ -861,11 +861,11 @@ def svd(a, coerce_signs=True):
     if nb[0] == nb[1] == 1:
         m, n = a.shape
         k = min(a.shape)
-        mu, ms, mv = np.linalg.svd(np.ones((1, 1), dtype=a.dtype))
+        mu, ms, mv = np.linalg.svd(ones_like_safe(a._meta, shape=(1, 1)))
         u, s, v = delayed(np.linalg.svd, nout=3)(a, full_matrices=False)
-        u = from_delayed(u, shape=(m, k), meta=mu)
-        s = from_delayed(s, shape=(k,), meta=ms)
-        v = from_delayed(v, shape=(k, n), meta=mv)
+        u = from_delayed(u, shape=(m, k), dtype=mu.dtype)
+        s = from_delayed(s, shape=(k,), dtype=ms.dtype)
+        v = from_delayed(v, shape=(k, n), dtype=mv.dtype)
     # Multi-chunk cases
     else:
         # Tall-and-skinny case


### PR DESCRIPTION
- [ ] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`

This is a follow-up from https://github.com/dask/dask/pull/6616#discussion_r486638074.

As @pentschev and @TomAugspurger suggested, this will run svd using a tiny, non-empty array via whatever backend the given dask array is already wrapping.  I only needed this to get the dtypes for the results, and I assume the semantics for the result types could be different for numpy/cupy so this seems like the clearest way to ensure that the dtype passed to `from_delayed` accurately reflects what would come out of any svd function dispatched to from np.linalg.svd.

