### PR TITLE
Update super usage

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3083,9 +3083,7 @@ Dask Name: {name}, {task} tasks""".format(
 
     @derived_from(pd.Series)
     def align(self, other, join="outer", axis=None, fill_value=None):
-        return super().align(
-            other, join=join, axis=axis, fill_value=fill_value
-        )
+        return super().align(other, join=join, axis=axis, fill_value=fill_value)
 
     @derived_from(pd.Series)
     def combine(self, other, func, fill_value=None):
@@ -4146,9 +4144,7 @@ class DataFrame(_Frame):
             raise ValueError(msg)
         elif is_series_like(other):
             other = other.to_frame().T
-        return super().append(
-            other, interleave_partitions=interleave_partitions
-        )
+        return super().append(other, interleave_partitions=interleave_partitions)
 
     @derived_from(pd.DataFrame)
     def iterrows(self):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2929,11 +2929,11 @@ Dask Name: {name}, {task} tasks""".format(
 
     @derived_from(pd.Series)
     def count(self, split_every=False):
-        return super(Series, self).count(split_every=split_every)
+        return super().count(split_every=split_every)
 
     @derived_from(pd.Series)
     def mode(self, dropna=True, split_every=False):
-        return super(Series, self).mode(dropna=dropna, split_every=split_every)
+        return super().mode(dropna=dropna, split_every=split_every)
 
     @derived_from(pd.Series, version="0.25.0")
     def explode(self):
@@ -3020,7 +3020,7 @@ Dask Name: {name}, {task} tasks""".format(
     @derived_from(pd.Series)
     def isin(self, values):
         # Added just to get the different docstring for Series
-        return super(Series, self).isin(values)
+        return super().isin(values)
 
     @insert_meta_param_description(pad=12)
     @derived_from(pd.Series)
@@ -3083,7 +3083,7 @@ Dask Name: {name}, {task} tasks""".format(
 
     @derived_from(pd.Series)
     def align(self, other, join="outer", axis=None, fill_value=None):
-        return super(Series, self).align(
+        return super().align(
             other, join=join, axis=axis, fill_value=fill_value
         )
 
@@ -3314,7 +3314,7 @@ class Index(Series):
         raise AttributeError("'Index' object has no attribute %r" % key)
 
     def __dir__(self):
-        out = super(Index, self).__dir__()
+        out = super().__dir__()
         out.extend(self._dt_attributes)
         if is_categorical_dtype(self.dtype):
             out.extend(self._cat_attributes)
@@ -3427,7 +3427,7 @@ class Index(Series):
         divisions to the output.
 
         """
-        applied = super(Index, self).map(arg, na_action=na_action, meta=meta)
+        applied = super().map(arg, na_action=na_action, meta=meta)
         if is_monotonic and self.known_divisions:
             applied.divisions = tuple(
                 pd.Series(self.divisions).map(arg, na_action=na_action)
@@ -4146,7 +4146,7 @@ class DataFrame(_Frame):
             raise ValueError(msg)
         elif is_series_like(other):
             other = other.to_frame().T
-        return super(DataFrame, self).append(
+        return super().append(
             other, interleave_partitions=interleave_partitions
         )
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1756,9 +1756,7 @@ class DataFrameGroupBy(_GroupBy):
         if arg == "size":
             return self.size()
 
-        return super().aggregate(
-            arg, split_every=split_every, split_out=split_out
-        )
+        return super().aggregate(arg, split_every=split_every, split_out=split_out)
 
     @derived_from(pd.core.groupby.DataFrameGroupBy)
     def agg(self, arg, split_every=None, split_out=1):
@@ -1828,9 +1826,7 @@ class SeriesGroupBy(_GroupBy):
 
     @derived_from(pd.core.groupby.SeriesGroupBy)
     def aggregate(self, arg, split_every=None, split_out=1):
-        result = super().aggregate(
-            arg, split_every=split_every, split_out=split_out
-        )
+        result = super().aggregate(arg, split_every=split_every, split_out=split_out)
         if self._slice:
             result = result[self._slice]
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1756,7 +1756,7 @@ class DataFrameGroupBy(_GroupBy):
         if arg == "size":
             return self.size()
 
-        return super(DataFrameGroupBy, self).aggregate(
+        return super().aggregate(
             arg, split_every=split_every, split_out=split_out
         )
 
@@ -1786,7 +1786,7 @@ class SeriesGroupBy(_GroupBy):
                 # raise error from pandas, if applicable
                 df._meta.groupby(by)
 
-        super(SeriesGroupBy, self).__init__(df, by=by, slice=slice, **kwargs)
+        super().__init__(df, by=by, slice=slice, **kwargs)
 
     @derived_from(pd.core.groupby.SeriesGroupBy)
     def nunique(self, split_every=None, split_out=1):
@@ -1828,7 +1828,7 @@ class SeriesGroupBy(_GroupBy):
 
     @derived_from(pd.core.groupby.SeriesGroupBy)
     def aggregate(self, arg, split_every=None, split_out=1):
-        result = super(SeriesGroupBy, self).aggregate(
+        result = super().aggregate(
             arg, split_every=split_every, split_out=split_out
         )
         if self._slice:

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -653,7 +653,7 @@ class DelayedAttr(Delayed):
         # code). See https://github.com/dask/dask/pull/4374#issuecomment-454381465
         if attr == "dtype" and self._attr == "dtype":
             raise AttributeError("Attribute %s not found" % attr)
-        return super(DelayedAttr, self).__getattr__(attr)
+        return super().__getattr__(attr)
 
     @property
     def dask(self):

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -61,7 +61,7 @@ class Profiler(Callback):
 
     def __enter__(self):
         self.clear()
-        return super(Profiler, self).__enter__()
+        return super().__enter__()
 
     def _start(self, dsk):
         self._dsk.update(dsk)
@@ -166,13 +166,13 @@ class ResourceProfiler(Callback):
         self._entered = True
         self.clear()
         self._start_collect()
-        return super(ResourceProfiler, self).__enter__()
+        return super().__enter__()
 
     def __exit__(self, *args):
         self._entered = False
         self._stop_collect()
         self.close()
-        super(ResourceProfiler, self).__exit__(*args)
+        super().__exit__(*args)
 
     def _start(self, dsk):
         self._start_collect()
@@ -335,7 +335,7 @@ class CacheProfiler(Callback):
 
     def __enter__(self):
         self.clear()
-        return super(CacheProfiler, self).__enter__()
+        return super().__enter__()
 
     def _start(self, dsk):
         self._dsk.update(dsk)


### PR DESCRIPTION
On Python 3, `super` can be called without any arguments where as on Python 2, `super` needs to be called with the class object and an instance e.g. `super(DelayedAttr, self)`. Given that dask does not support Python 2 anymore on master, the `super` usage can be updated.

Note that this was an automated regex-based search and replace. The regex used was - `(super)+\(+(\w+)(,)+\s(self)+\)+`. After the automated search and replace happened, each change was individually checked and committed.

Ref : https://docs.python.org/3/library/functions.html#super

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
