### PR TITLE
Update pre-commit-config to latest black.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/python/black
+-   repo: https://github.com/psf/black
     rev: stable
     hooks:
     - id: black

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ import sys
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../../'))
+sys.path.insert(0, os.path.abspath("../../"))
 
 source_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(source_dir, "ext"))
@@ -310,7 +310,7 @@ intersphinx_mapping = {
     "asyncssh": (
         "https://asyncssh.readthedocs.io/en/latest/",
         "https://asyncssh.readthedocs.io/en/latest/objects.inv",
-    )
+    ),
 }
 
 # Redirects
@@ -365,6 +365,7 @@ linkcheck_ignore = [
     r"^https?:\/\/(?:www\.)?github.com\/",
     r"^https?:\/\/localhost(?:[:\/].+)?$",
 ]
+
 
 def copy_legacy_redirects(app, docname):
     if app.builder.name == "html":

--- a/docs/source/scripts/scheduling.py
+++ b/docs/source/scripts/scheduling.py
@@ -8,33 +8,45 @@ import matplotlib.pyplot as plt
 def noop(x):
     pass
 
+
 nrepetitions = 1
+
 
 def trivial(width, height):
     """ Embarrassingly parallel dask """
-    d = {('x', 0, i): i for i in range(width)}
+    d = {("x", 0, i): i for i in range(width)}
     for j in range(1, height):
-        d.update({('x', j, i): (noop, ('x', j - 1, i))
-                                  for i in range(width)})
-    return d, [('x', height - 1, i) for i in range(width)]
+        d.update({("x", j, i): (noop, ("x", j - 1, i)) for i in range(width)})
+    return d, [("x", height - 1, i) for i in range(width)]
+
 
 def crosstalk(width, height, connections):
     """ Natural looking dask with some inter-connections """
-    d = {('x', 0, i): i for i in range(width)}
+    d = {("x", 0, i): i for i in range(width)}
     for j in range(1, height):
-        d.update({('x', j, i): (noop, [('x', j - 1, randint(0, width))
-                                            for _ in range(connections)])
-                    for i in range(width)})
-    return d, [('x', height - 1, i) for i in range(width)]
+        d.update(
+            {
+                ("x", j, i): (
+                    noop,
+                    [("x", j - 1, randint(0, width)) for _ in range(connections)],
+                )
+                for i in range(width)
+            }
+        )
+    return d, [("x", height - 1, i) for i in range(width)]
+
 
 def dense(width, height):
     """ Full barriers between each step """
-    d = {('x', 0, i): i for i in range(width)}
+    d = {("x", 0, i): i for i in range(width)}
     for j in range(1, height):
-        d.update({('x', j, i): (noop, [('x', j - 1, k)
-                                            for k in range(width)])
-                    for i in range(width)})
-    return d, [('x', height - 1, i) for i in range(width)]
+        d.update(
+            {
+                ("x", j, i): (noop, [("x", j - 1, k) for k in range(width)])
+                for i in range(width)
+            }
+        )
+    return d, [("x", height - 1, i) for i in range(width)]
 
 
 import numpy as np
@@ -56,21 +68,23 @@ for get in [dask.get, threaded.get, local.get_sync, multiprocessing.get]:
 # Plot #
 ########
 
-f, (left, right) = plt.subplots(nrows=1, ncols=2, sharex=True, figsize=(12, 5), squeeze=True)
+f, (left, right) = plt.subplots(
+    nrows=1, ncols=2, sharex=True, figsize=(12, 5), squeeze=True
+)
 
 for get in trivial_results:
     left.loglog(x * 5, trivial_results[get], label=get.__module__)
     right.loglog(x * 5, trivial_results[get] / x, label=get.__module__)
 
-left.set_title('Cost for Entire graph')
-right.set_title('Cost per task')
-left.set_ylabel('Duration (s)')
-right.set_ylabel('Duration (s)')
-left.set_xlabel('Number of tasks')
-right.set_xlabel('Number of tasks')
+left.set_title("Cost for Entire graph")
+right.set_title("Cost per task")
+left.set_ylabel("Duration (s)")
+right.set_ylabel("Duration (s)")
+left.set_xlabel("Number of tasks")
+right.set_xlabel("Number of tasks")
 
 plt.legend()
-plt.savefig('images/scaling-nodes.png')
+plt.savefig("images/scaling-nodes.png")
 
 #####################
 # Crosstalk example #
@@ -92,17 +106,19 @@ for get in [threaded.get, local.get_sync]:
 # Plot #
 ########
 
-f, (left, right) = plt.subplots(nrows=1, ncols=2, sharex=True, figsize=(12, 5), squeeze=True)
+f, (left, right) = plt.subplots(
+    nrows=1, ncols=2, sharex=True, figsize=(12, 5), squeeze=True
+)
 
 for get in crosstalk_results:
     left.plot(x, crosstalk_results[get], label=get.__module__)
-    right.semilogy(x, crosstalk_results[get] / 5000. / x, label=get.__module__)
+    right.semilogy(x, crosstalk_results[get] / 5000.0 / x, label=get.__module__)
 
-left.set_title('Cost for Entire graph')
-right.set_title('Cost per edge')
-left.set_ylabel('Duration (s)')
-right.set_ylabel('Duration (s)')
-left.set_xlabel('Number of edges per task')
-right.set_xlabel('Number of edges per task')
+left.set_title("Cost for Entire graph")
+right.set_title("Cost per edge")
+left.set_ylabel("Duration (s)")
+right.set_ylabel("Duration (s)")
+left.set_xlabel("Number of edges per task")
+right.set_xlabel("Number of edges per task")
 plt.legend()
-plt.savefig('images/scaling-edges.png')
+plt.savefig("images/scaling-edges.png")


### PR DESCRIPTION
- [x] Passes `black dask` / `flake8 dask`

Black released a new version (20.8b1) recently. As a result py pre-commit wasn't catching formatting issues that were failing on CI. I changed the repo to point to the one recommended in the [black docs](https://black.readthedocs.io/en/stable/version_control_integration.html) which fixed things for me locally.

I also ran latest black on the repo so that people don't have to include formatting changes in their PRs.