### PR TITLE
Preserve dtype in svd

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -861,7 +861,9 @@ def svd(a, coerce_signs=True):
     if nb[0] == nb[1] == 1:
         m, n = a.shape
         k = min(a.shape)
-        mu, ms, mv = np.linalg.svd(ones_like_safe(a._meta, shape=(1, 1)))
+        mu, ms, mv = np.linalg.svd(
+            ones_like_safe(a._meta, shape=(1, 1), dtype=a._meta.dtype)
+        )
         u, s, v = delayed(np.linalg.svd, nout=3)(a, full_matrices=False)
         u = from_delayed(u, shape=(m, k), dtype=mu.dtype)
         s = from_delayed(s, shape=(k,), dtype=ms.dtype)

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -480,6 +480,14 @@ def test_svd_compressed():
     assert_eq(s, s_exact)  # s must contain the singular values
 
 
+@pytest.mark.parametrize("chunks", [(10, 50), (50, 10), (-1, -1)])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_svd_dtype_preservation(chunks, dtype):
+    x = da.random.random((50, 50), chunks=chunks).astype(dtype)
+    u, s, v = svd(x)
+    assert u.dtype == s.dtype == v.dtype == dtype
+
+
 def test_svd_compressed_deterministic():
     m, n = 30, 25
     x = da.random.RandomState(1234).random_sample(size=(m, n), chunks=(5, 5))

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -378,7 +378,7 @@ def svd_flip(u, v):
     # lie relative to an arbitrary vector; this is equivalent
     # to dot product with a row vector of ones
     signs = np.sum(u, axis=0, keepdims=True)
-    signs = 2 * ((signs >= 0) - 0.5)
+    signs = signs.dtype.type(2) * ((signs >= 0) - signs.dtype.type(0.5))
     # Force all singular vectors into same half-space
     u, v = u * signs, v * signs.T
     return u, v


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

My changes in https://github.com/dask/dask/pull/6613 cause `svd` to promote 32-bit float inputs.  This fixes that and adds a test for it.