### PR TITLE
Add pre-commit CI build

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -1,0 +1,15 @@
+name: pre-commit
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: stable
     hooks:
     - id: black
       language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
     - id: black
       language_version: python3
+      exclude: versioneer.py
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
--   repo: https://github.com/python/black
-    rev: stable
+-   repo: https://github.com/psf/black
+    rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.3
     hooks:
     - id: flake8
-      language_version: python3.7
+      language_version: python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os: linux
 
 _base_envs:
   - &test TEST='true'
-  - &test_and_lint TEST='true' LINT='true'
   - &coverage COVERAGE='true' PARALLEL='false'
   - &no_coverage COVERAGE='false' PARALLEL='true'
   - &optimize PYTHONOPTIMIZE=2 XTRATESTARGS='--ignore=dask/diagnostics --ignore=dask/array/tests/test_image.py --ignore=dask/array/tests/test_stats.py --ignore=dask/bytes/tests/test_s3.py'
@@ -20,7 +19,7 @@ jobs:
     - env: &py36_env
       - PYTHON_VERSION=3.6
       - ENV_FILE=continuous_integration/environment-3.6.yaml
-      - *test_and_lint
+      - *test
       - *no_coverage
       - *no_optimize
       - *imports
@@ -28,7 +27,7 @@ jobs:
     - env: &py37_env
       - PYTHON_VERSION=3.7
       - ENV_FILE=continuous_integration/environment-3.7.yaml
-      - *test_and_lint
+      - *test
       - *no_coverage
       - *no_optimize
       - *imports
@@ -37,7 +36,7 @@ jobs:
     - env: &py38_env
       - PYTHON_VERSION=3.8
       - ENV_FILE=continuous_integration/environment-3.8.yaml
-      - *test_and_lint
+      - *test
       - *coverage
       - *no_optimize
       - *imports
@@ -46,7 +45,7 @@ jobs:
     - env: &py38_dev
       - UPSTREAM_DEV=1  # Install nightly versions of NumPy, pandas, pyarrow
       - ENV_FILE=continuous_integration/environment-3.8-dev.yaml
-      - *test_and_lint
+      - *test
       - *no_coverage
       - *no_optimize
       - *no_imports
@@ -94,8 +93,6 @@ install:
 script:
   - if [[ $TEST_HDFS == 'true' ]]; then source continuous_integration/hdfs/run_tests.sh; fi
   - if [[ $TEST == 'true' ]]; then source continuous_integration/travis/run_tests.sh; fi
-  - if [[ $LINT == 'true' ]]; then python -m pip install flake8 ; flake8 dask; fi
-  - if [[ $LINT == 'true' ]]; then python -m pip install black ; black dask --check; fi
   - if [[ $TEST_IMPORTS == 'true' ]]; then bash continuous_integration/travis/test_imports.sh; fi
 
 after_success:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 # https://flake8.readthedocs.io/en/latest/user/configuration.html
 # https://flake8.readthedocs.io/en/latest/user/error-codes.html
 # https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
-exclude = __init__.py
+exclude = __init__.py,versioneer.py
 ignore =
     E20,   # Extra space in brackets
     E231,E241,  # Multiple spaces around ","


### PR DESCRIPTION
This PR moves our `black` and `flake8` checks to a separate `pre-commit` CI build on GitHub actions. This is nice because it means there's a single source of truth about which version of `black`/`flake8` we use in CI: our `.pre-commit-config.yaml` file. It also ensures that the pre-commit hooks used locally match up with the checks run in CI.

~~I've also pinned `black` to a specific version (20.8b1) instead of using the latest release on PyPI. This let's us be more intentional as to when we bump our `black` version.~~

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
