### PR TITLE
Stop writing commented out config files by default

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -577,7 +577,6 @@ def check_deprecations(key: str, deprecations: dict = deprecations):
 
 def _initialize():
     fn = os.path.join(os.path.dirname(__file__), "dask.yaml")
-    ensure_file(source=fn)
 
     with open(fn) as f:
         _defaults = yaml.safe_load(f)


### PR DESCRIPTION
Fixes #6634

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
