### PR TITLE
Adding v_based flag for svd_flip

### DIFF
--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -866,9 +866,7 @@ def test_svd_flip_correction(shape, chunks, dtype):
     np.testing.assert_almost_equal(np.asarray(np.dot(uc * s, vc)), x, decimal=decimal)
 
 
-@pytest.mark.parametrize(
-    "dtype", ["i1", "i2", "i4", "i8", "f2", "f4", "f8", "f16", "c8", "c16", "c32"]
-)
+@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "f16", "c8", "c16", "c32"])
 @pytest.mark.parametrize("u_based", [True, False])
 def test_svd_flip_sign(dtype, u_based):
     if sys.platform == "win32" and dtype in ["f16", "c32"]:

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -4,6 +4,7 @@ pytest.importorskip("numpy")
 pytest.importorskip("scipy")
 
 import numpy as np
+import sys
 import scipy.linalg
 
 import dask.array as da
@@ -870,6 +871,8 @@ def test_svd_flip_correction(shape, chunks, dtype):
 )
 @pytest.mark.parametrize("u_based", [True, False])
 def test_svd_flip_sign(dtype, u_based):
+    if sys.platform == "win32" and dtype in ["f16", "c32"]:
+        pytest.skip("128-bit floats not supported on windows")
     # fmt: off
     x = np.array(
         [[1, -1, 1, -1],

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -871,14 +871,9 @@ def test_svd_flip_correction(shape, chunks, dtype):
 def test_svd_flip_sign(dtype, u_based):
     if sys.platform == "win32" and dtype in ["f16", "c32"]:
         pytest.skip("128-bit floats not supported on windows")
-    # fmt: off
     x = np.array(
-        [[1, -1, 1, -1],
-         [1, -1, 1, -1],
-         [-1, 1, 1, -1],
-         [-1, 1, 1, -1]], dtype=dtype
+        [[1, -1, 1, -1], [1, -1, 1, -1], [-1, 1, 1, -1], [-1, 1, 1, -1]], dtype=dtype
     )
-    # fmt: on
     u, v = svd_flip(x, x.T, u_based_decision=u_based)
     assert u.dtype == x.dtype
     assert v.dtype == x.dtype

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -842,19 +842,51 @@ def test_no_chunks_svd():
 
 @pytest.mark.parametrize("shape", [(10, 20), (10, 10), (20, 10)])
 @pytest.mark.parametrize("chunks", [(-1, -1), (10, -1), (-1, 10)])
-def test_svd_flip(shape, chunks):
+@pytest.mark.parametrize("dtype", ["f4", "f8"])
+def test_svd_flip_correction(shape, chunks, dtype):
     # Verify that sign-corrected SVD results can still
     # be used to reconstruct inputs
-    x = da.random.random(size=shape, chunks=chunks)
+    x = da.random.random(size=shape, chunks=chunks).astype(dtype)
     u, s, v = da.linalg.svd(x)
+
+    # Choose precision in evaluation based on float precision
+    decimal = 9 if np.dtype(dtype).itemsize > 4 else 6
 
     # Validate w/ dask inputs
     uf, vf = svd_flip(u, v)
-    np.testing.assert_almost_equal(np.asarray(np.dot(uf * s, vf)), x, decimal=9)
+    assert uf.dtype == u.dtype
+    assert vf.dtype == v.dtype
+    np.testing.assert_almost_equal(np.asarray(np.dot(uf * s, vf)), x, decimal=decimal)
 
     # Validate w/ numpy inputs
     uc, vc = svd_flip(*da.compute(u, v))
-    np.testing.assert_almost_equal(np.asarray(np.dot(uc * s, vc)), x, decimal=9)
+    assert uc.dtype == u.dtype
+    assert vc.dtype == v.dtype
+    np.testing.assert_almost_equal(np.asarray(np.dot(uc * s, vc)), x, decimal=decimal)
+
+
+@pytest.mark.parametrize(
+    "dtype", ["i1", "i2", "i4", "i8", "f2", "f4", "f8", "f16", "c8", "c16", "c32"]
+)
+@pytest.mark.parametrize("u_based", [True, False])
+def test_svd_flip_sign(dtype, u_based):
+    # fmt: off
+    x = np.array(
+        [[1, -1, 1, -1],
+         [1, -1, 1, -1],
+         [-1, 1, 1, -1],
+         [-1, 1, 1, -1]], dtype=dtype
+    )
+    # fmt: on
+    u, v = svd_flip(x, x.T, u_based_decision=u_based)
+    assert u.dtype == x.dtype
+    assert v.dtype == x.dtype
+    # Verify that all singular vectors have same
+    # sign except for the last one (i.e. last column)
+    y = x.copy()
+    y[:, -1] *= y.dtype.type(-1)
+    assert_eq(u, y)
+    assert_eq(v, y.T)
 
 
 @pytest.mark.parametrize("chunks", [(10, -1), (-1, 10), (9, -1), (-1, 9)])

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -350,7 +350,7 @@ def validate_axis(axis, ndim):
     return axis
 
 
-def svd_flip(u, v, u_based_decision=True):
+def svd_flip(u, v, u_based_decision=False):
     """Sign correction to ensure deterministic output from SVD.
 
     This function is useful for orienting eigenvectors such that
@@ -367,7 +367,7 @@ def svd_flip(u, v, u_based_decision=True):
         Right singular vectors (in rows)
     u_based_decision: bool
         Whether or not to choose signs based
-        on `u`, by default True
+        on `u` rather than `v`, by default False
 
     Returns
     -------

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -386,7 +386,7 @@ def svd_flip(u, v, u_based_decision=True):
     else:
         dtype = v.dtype
         signs = np.sum(v, axis=1, keepdims=True).T
-    signs = np.where(signs >= 0, dtype.type(1), dtype.type(-1))
+    signs = dtype.type(2) * ((signs >= 0) - dtype.type(0.5))
     # Force all singular vectors into same half-space
     u, v = u * signs, v * signs.T
     return u, v

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -350,7 +350,7 @@ def validate_axis(axis, ndim):
     return axis
 
 
-def svd_flip(u, v):
+def svd_flip(u, v, u_based_decision=True):
     """Sign correction to ensure deterministic output from SVD.
 
     This function is useful for orienting eigenvectors such that
@@ -362,9 +362,12 @@ def svd_flip(u, v):
     ----------
 
     u : (M, K) array_like
-        Left singular vectors
+        Left singular vectors (in columns)
     v : (K, N) array_like
-        Right singular vectors
+        Right singular vectors (in rows)
+    u_based_decision: bool
+        Whether or not to choose signs based
+        on `u`, by default True
 
     Returns
     -------
@@ -374,11 +377,16 @@ def svd_flip(u, v):
     v:  (K, N) array_like
         Right singular vectors with corrected sign
     """
-    # Determine half-space in which all left singular vectors
-    # lie relative to an arbitrary vector; this is equivalent
-    # to dot product with a row vector of ones
-    signs = np.sum(u, axis=0, keepdims=True)
-    signs = signs.dtype.type(2) * ((signs >= 0) - signs.dtype.type(0.5))
+    # Determine half-space in which all singular vectors
+    # lie relative to an arbitrary vector; summation
+    # equivalent to dot product with row vector of ones
+    if u_based_decision:
+        dtype = u.dtype
+        signs = np.sum(u, axis=0, keepdims=True)
+    else:
+        dtype = v.dtype
+        signs = np.sum(v, axis=1, keepdims=True).T
+    signs = np.where(signs >= 0, dtype.type(1), dtype.type(-1))
     # Force all singular vectors into same half-space
     u, v = u * signs, v * signs.T
     return u, v


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

This adds the `u_based_decision` flag to `svd_flip` as supported by [sklearn#svd_flip](https://github.com/scikit-learn/scikit-learn/blob/06d6f8a9f6e3d847b9db79a5fdebe64f78deef7f/sklearn/utils/extmath.py#L504).  This is necessary when right singular vectors are the target of an analysis rather than left singular vectors.

This also makes `u_based_decision` default to False, since there are no downstream applications in dask-ml that care about gram matrix eigenvectors rather than covariance matrix eigenvectors.