### PR TITLE
Fix inconsistent hashing when using multiprocessing

### DIFF
--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -61,6 +61,20 @@ def test_keys():
     assert b.__dask_keys__() == sorted(dsk.keys())
 
 
+def test_bag_groupby_pure_hash():
+    # https://github.com/dask/dask/issues/6640
+    result = b.groupby(iseven).compute()
+    assert result == [(False, [1, 3] * 3), (True, [0, 2, 4] * 3)]
+
+
+def test_bag_groupby_normal_hash():
+    # https://github.com/dask/dask/issues/6640
+    result = b.groupby(lambda x: "even" if iseven(x) else "odd").compute()
+    assert len(result) == 2
+    assert ("odd", [1, 3] * 3) in result
+    assert ("even", [0, 2, 4] * 3) in result
+
+
 def test_bag_map():
     b = db.from_sequence(range(100), npartitions=10)
     b2 = db.from_sequence(range(100, 200), npartitions=10)


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

Fixes #6640 

Includes the tests written by @lazarillo