### PR TITLE
Partially revert chunk-splitting in indexing.

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -588,7 +588,7 @@ def take(outname, inname, chunks, index, itemsize, axis=0):
     depending on the value of ``dask.config.slicing.split-large-chunks``.
 
     >>> import dask
-    >>> with dask.config.set(**{"array.slicing.split-large-chunks": True}):
+    >>> with dask.config.set({"array.slicing.split-large-chunks": True}):
     ...      chunks, dsk = take('y', 'x', [(1, 1, 1), (1000, 1000), (1000, 1000)],
     ...                        [0] + [1] * 6 + [2], axis=0, itemsize=8)
     >>> chunks

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -618,7 +618,7 @@ def take(outname, inname, chunks, index, itemsize, axis=0):
         warnsize = maxsize = math.inf
     else:
         maxsize = math.ceil(nbytes / (other_numel * itemsize))
-        warnsize = maxsize * 10
+        warnsize = maxsize * 5
 
     split = config.get("array.slicing.split-large-chunks", None)
 

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -584,17 +584,21 @@ def take(outname, inname, chunks, index, itemsize, axis=0):
      ('y', 2): (getitem, ('x', 2), ([7],))}
 
     When any indexed blocks would otherwise grow larger than
-    dask.config.array.chunk-size, we split them.
+    dask.config.array.chunk-size, we might split them,
+    depending on the value of ``dask.config.slicing.split-large-chunks``.
 
-    >>> chunks, dsk = take('y', 'x', [(1, 1, 1), (1000, 1000), (1000, 1000)],
-    ...                    [0] + [1] * 6 + [2], axis=0, itemsize=8)
+    >>> import dask
+    >>> with dask.config.set(**{"array.slicing.split-large-chunks": True}):
+    ...      chunks, dsk = take('y', 'x', [(1, 1, 1), (1000, 1000), (1000, 1000)],
+    ...                        [0] + [1] * 6 + [2], axis=0, itemsize=8)
     >>> chunks
     ((1, 3, 3, 1), (1000, 1000), (1000, 1000))
     """
+    from .core import PerformanceWarning
+
     plan = slicing_plan(chunks[axis], index)
     if len(plan) >= len(chunks[axis]) * 10:
         factor = math.ceil(len(plan) / len(chunks[axis]))
-        from .core import PerformanceWarning
 
         warnings.warn(
             "Slicing with an out-of-order index is generating %d "
@@ -610,13 +614,36 @@ def take(outname, inname, chunks, index, itemsize, axis=0):
     other_chunks = [chunks[i] for i in range(len(chunks)) if i != axis]
     other_numel = np.prod([sum(x) for x in other_chunks])
 
-    maxsize = nbytes / (other_numel * itemsize)
+    if math.isnan(other_numel):
+        warnsize = maxsize = math.inf
+    else:
+        maxsize = math.ceil(nbytes / (other_numel * itemsize))
+        warnsize = maxsize * 10
+
+    split = config.get("array.slicing.split-large-chunks", None)
+
+    # Warn only when the default is not specified.
+    warned = split is not None
+
+    for _, index_list in plan:
+        if not warned and len(index_list) > warnsize:
+            msg = (
+                "Slicing is producing a large chunk. To accept the large\n"
+                "chunk and silence this warning, set the option\n"
+                "    >>> with dask.config.set(**{'array.slicing.split_large_chunks': False}):\n"
+                "    ...     array[indexer]\n\n"
+                "To avoid creating the large chunks, set the option\n"
+                "    >>> with dask.config.set(**{'array.slicing.split_large_chunks': True}):\n"
+                "    ...     array[indexer]"
+            )
+            warnings.warn(msg, PerformanceWarning, stacklevel=6)
+            warned = True
 
     where_index = []
     index_lists = []
     for where_idx, index_list in plan:
         index_length = len(index_list)
-        if index_length > maxsize:
+        if split and index_length > maxsize:
             index_sublist = np.array_split(
                 index_list, math.ceil(index_length / maxsize)
             )

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -882,7 +882,7 @@ def test_slicing_plan(chunks, index, expected):
 
 
 def test_getitem_avoids_large_chunks():
-    with dask.config.set(**{"array.chunk-size": "0.1Mb"}):
+    with dask.config.set({"array.chunk-size": "0.1Mb"}):
         a = np.arange(2 * 128 * 128, dtype="int64").reshape(2, 128, 128)
         arr = da.from_array(a, chunks=(1, 128, 128))
         indexer = [0] + [1] * 11
@@ -896,14 +896,14 @@ def test_getitem_avoids_large_chunks():
         assert result.chunks == ((1, 11), (128,), (128,))
 
         # Users can silence the warning
-        with dask.config.set(**{"array.slicing.split-large-chunks": False}):
+        with dask.config.set({"array.slicing.split-large-chunks": False}):
             with pytest.warns(None) as e:
                 result = arr[indexer]
             assert len(e) == 0
             assert_eq(result, expected)
 
         # Users can silence the warning
-        with dask.config.set(**{"array.slicing.split-large-chunks": True}):
+        with dask.config.set({"array.slicing.split-large-chunks": True}):
             with pytest.warns(None) as e:
                 result = arr[indexer]
             assert len(e) == 0  # no
@@ -925,7 +925,7 @@ def test_getitem_avoids_large_chunks():
 def test_getitem_avoids_large_chunks_missing(chunks):
     # We cannot apply the "avoid large chunks" optimization when
     # the chunks have unknown sizes.
-    with dask.config.set(**{"array.slicing.split-large-chunks": True}):
+    with dask.config.set({"array.slicing.split-large-chunks": True}):
         a = np.arange(4 * 500 * 500).reshape(4, 500, 500)
         arr = da.from_array(a, chunks=(1, 500, 500))
         arr._chunks = chunks
@@ -937,7 +937,7 @@ def test_getitem_avoids_large_chunks_missing(chunks):
 
 def test_take_avoids_large_chunks():
     # unit test for https://github.com/dask/dask/issues/6270
-    with dask.config.set(**{"array.slicing.split-large-chunks": True}):
+    with dask.config.set({"array.slicing.split-large-chunks": True}):
         chunks = ((1, 1, 1, 1), (500,), (500,))
         itemsize = 8
         index = np.array([0, 1] + [2] * 101 + [3])
@@ -963,11 +963,11 @@ def test_take_avoids_large_chunks():
 
 
 def test_take_uses_config():
-    with dask.config.set(**{"array.slicing.split-large-chunks": True}):
+    with dask.config.set({"array.slicing.split-large-chunks": True}):
         chunks = ((1, 1, 1, 1), (500,), (500,))
         index = np.array([0, 1] + [2] * 101 + [3])
         itemsize = 8
-        with config.set(**{"array.chunk-size": "10GB"}):
+        with config.set({"array.chunk-size": "10GB"}):
             chunks2, dsk = take("a", "b", chunks, index, itemsize)
         assert chunks2 == ((1, 1, 101, 1), (500,), (500,))
         assert len(dsk) == 4

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -40,11 +40,9 @@ properties:
         type: object
         properties:
           split-large-chunks:
-            type:
-              - bool
-              - "null"
+            type: [boolean, 'null']
             description: |
-              How to large chunks created when slicing Arrays. By default a
+              How to handle large chunks created when slicing Arrays. By default a
               warning is produced. Set to ``False`` to silence the warning
               and allow large output chunks. Set to ``True`` to silence the
               warning and avoid large output chunks.

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -36,6 +36,19 @@ properties:
               The size of pixels used when displaying a dask array as an SVG image.
               This is used, for example, for nice rendering in a Jupyter notebook
 
+      slicing:
+        type: object
+        properties:
+          split-large-chunks:
+            type:
+              - bool
+              - "null"
+            description: |
+              How to large chunks created when slicing Arrays. By default a
+              warning is produced. Set to ``False`` to silence the warning
+              and allow large output chunks. Set to ``True`` to silence the
+              warning and avoid large output chunks.
+
   optimization:
     type: object
     properties:

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -7,7 +7,7 @@ array:
   svg:
     size: 120  # pixels
   slicing:
-    split-large-chunks: None  # How to handle large output chunks in slicing. Warns by default.
+    split-large-chunks: null  # How to handle large output chunks in slicing. Warns by default.
 
 optimization:
   fuse:

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -6,6 +6,8 @@ dataframe:
 array:
   svg:
     size: 120  # pixels
+  slicing:
+    split-large-chunks: None  # How to handle large output chunks in slicing. Warns by default.
 
 optimization:
   fuse:

--- a/docs/source/array-chunks.rst
+++ b/docs/source/array-chunks.rst
@@ -1,3 +1,5 @@
+.. _array.chunks:
+
 Chunks
 ======
 

--- a/docs/source/array-slicing.rst
+++ b/docs/source/array-slicing.rst
@@ -85,7 +85,7 @@ Previously we had a chunksize of ``1`` along the first dimension since we select
 just one element from each input chunk. But now we've selected 15 elements
 from the first chunk, producing a large output chunk.
 
-Dask warns when indexing like this produces a chunk that's 10x larger
+Dask warns when indexing like this produces a chunk that's 5x larger
 than the ``array.chunk-size`` config option. You have two options to deal with
 that warning:
 

--- a/docs/source/array-slicing.rst
+++ b/docs/source/array-slicing.rst
@@ -21,6 +21,8 @@ However, it does not currently support the following:
 
 *  Slicing one :class:`~dask.array.Array` with a multi-dimensional :class:`~dask.array.Array` of ints
 
+.. _array.slicing.efficiency:
+
 Efficiency
 ----------
 
@@ -46,4 +48,49 @@ we are also a bit wasteful in that we still need to manipulate the Dask graph
 with a million or so tasks in it.  This can cause an interactive overhead of a
 second or two. 
 
-But generally, slicing works well.
+Slicing with concrete indexers (a list of integers, say) has a couple of possible
+failure modes that are worth mentioning. First, when you're indexing a chunked
+axis, Dask will typically "match" the chunking on the output.
+
+.. code-block:: python
+
+   # Array of ones, chunked along axis 0
+   >>> a = da.ones((4, 10000, 10000), chunks=(1, -1, -1))
+
+If we slice that with a *sorted* sequence of integers, Dask will return one chunk
+per intput chunk
+
+   >>> a[[0, 1], :, :]
+   dask.array<getitem, shape=(2, 10000, 10000), dtype=float64, chunksize=(1, 10000, 10000), chunktype=numpy.ndarray>
+
+But what about repeated indices? Dask continues to return one chunk per input chunk,
+but if you have many repetitions from the same input chunk, your output chunk could
+be much larger.
+
+.. code-block:: python
+
+   >>> a[[0] * 15, :, :]
+   PerformanceWarning: Slicing is producing a large chunk. To accept the large
+   chunk and silence this warning, set the option
+       >>> with dask.config.set(**{'array.slicing.split_large_chunks': False}):
+       ...     array[indexer]
+   
+   To avoid creating the large chunks, set the option
+       >>> with dask.config.set(**{'array.slicing.split_large_chunks': True}):
+       ...     array[indexer]
+   dask.array<getitem, shape=(15, 10000, 10000), dtype=float64, chunksize=(15, 10000, 10000), chunktype=numpy.ndarray>
+
+Previously we had a chunksize of ``1`` along the first dimension. But we've
+selected 15 elements from that first chunk, producing a large output chunk.
+
+Dask warns when indexing like this produces a chunk that's 10x larger
+than the ``array.chunk-size`` config option. You have two options to deal with
+that warning:
+
+1. Set ``dask.config.set(**{"array.slicing.split_large_chunks": False})`` to
+   allow the large chunk and silence the warning.
+2. Set ``dask.config.set(**{"array.slicing.split_large_chunks": True})`` to
+   avoid creating the large chunk in the first place.
+
+The right choice will depend on your downstream operations. See :ref:`array.chunks`
+for more on choosing chunk sizes.

--- a/docs/source/array-slicing.rst
+++ b/docs/source/array-slicing.rst
@@ -58,7 +58,8 @@ axis, Dask will typically "match" the chunking on the output.
    >>> a = da.ones((4, 10000, 10000), chunks=(1, -1, -1))
 
 If we slice that with a *sorted* sequence of integers, Dask will return one chunk
-per intput chunk
+per intput chunk (notince the output `chunksize` is 1, since the indices ``0``
+and ``1`` are in separate chunks in the input).
 
    >>> a[[0, 1], :, :]
    dask.array<getitem, shape=(2, 10000, 10000), dtype=float64, chunksize=(1, 10000, 10000), chunktype=numpy.ndarray>
@@ -72,24 +73,25 @@ be much larger.
    >>> a[[0] * 15, :, :]
    PerformanceWarning: Slicing is producing a large chunk. To accept the large
    chunk and silence this warning, set the option
-       >>> with dask.config.set(**{'array.slicing.split_large_chunks': False}):
+       >>> with dask.config.set({'array.slicing.split_large_chunks': False}):
        ...     array[indexer]
    
    To avoid creating the large chunks, set the option
-       >>> with dask.config.set(**{'array.slicing.split_large_chunks': True}):
+       >>> with dask.config.set({'array.slicing.split_large_chunks': True}):
        ...     array[indexer]
    dask.array<getitem, shape=(15, 10000, 10000), dtype=float64, chunksize=(15, 10000, 10000), chunktype=numpy.ndarray>
 
-Previously we had a chunksize of ``1`` along the first dimension. But we've
-selected 15 elements from that first chunk, producing a large output chunk.
+Previously we had a chunksize of ``1`` along the first dimension since we selected
+just one element from each input chunk. But now we've selected 15 elements
+from the first chunk, producing a large output chunk.
 
 Dask warns when indexing like this produces a chunk that's 10x larger
 than the ``array.chunk-size`` config option. You have two options to deal with
 that warning:
 
-1. Set ``dask.config.set(**{"array.slicing.split_large_chunks": False})`` to
+1. Set ``dask.config.set({"array.slicing.split_large_chunks": False})`` to
    allow the large chunk and silence the warning.
-2. Set ``dask.config.set(**{"array.slicing.split_large_chunks": True})`` to
+2. Set ``dask.config.set({"array.slicing.split_large_chunks": True})`` to
    avoid creating the large chunk in the first place.
 
 The right choice will depend on your downstream operations. See :ref:`array.chunks`

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,7 @@ Array
   This restores the behavior from Dask 2.25.0 and earlier, with a warning
   when large chunks are produced. A configuration option is provided
   to avoid creating the large chunks, see :ref:`array.slicing.efficiency`.
+  (:pr:`6665`) `Tom Augspurger`_
 
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+2.28.0 / 2020-09-25
+-------------------
+
+Array
++++++
+
+- Partially reverted changes to Array indexing that produces large changes.
+  This restores the behavior from Dask 2.25.0 and earlier, with a warning
+  when large chunks are produced. A configuration option is provided
+  to avoid creating the large chunks, see :ref:`array.slicing.efficiency`.
+
+
+
 2.27.0 / 2020-09-18
 -------------------
 


### PR DESCRIPTION
This partially reverts the changes made in
https://github.com/dask/dask/pull/6514. It restores the old behavior
with a warning that large chunks (10x array.chunk-size) are being
produced.

Additionally, it adds a new config option to control the behavior
(`array.slicing.split-large-chunks`). Setting that to `False` silences
the warnings and keeps the "old" behavior (one output block per input
block touched, even if this makes a large output). Setting that to
`True` silences the warning and restores the Dask 2.26 behavior of
splitting.

Closes https://github.com/dask/dask/issues/6646

cc @JSKenyon from the issue. @jrbourbeau this would be nice to include in the 2.28 release if we're able to get it done today or tomorrow.