### PR TITLE
SubgraphCallable.__eq__(): removed `self.dsk == other.dsk` check

### DIFF
--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -947,10 +947,9 @@ class SubgraphCallable(object):
     def __eq__(self, other):
         return (
             type(self) is type(other)
-            and self.dsk == other.dsk
+            and self.name == other.name
             and self.outkey == other.outkey
             and set(self.inkeys) == set(other.inkeys)
-            and self.name == other.name
         )
 
     def __ne__(self, other):

--- a/dask/tests/test_optimization.py
+++ b/dask/tests/test_optimization.py
@@ -1126,7 +1126,6 @@ def test_SubgraphCallable():
     f3 = SubgraphCallable(dsk, "g", ["in1", "in2"], name="test")
     assert f != f3
 
-    assert dict(f=None)
     assert hash(SubgraphCallable(None, None, [None]))
     assert hash(f3) != hash(f2)
     dsk2 = dsk.copy()
@@ -1136,6 +1135,25 @@ def test_SubgraphCallable():
 
     f2 = pickle.loads(pickle.dumps(f))
     assert f2(1, 2) == f(1, 2)
+
+
+def test_SubgraphCallable_with_numpy():
+    np = pytest.importorskip("numpy")
+
+    # Testing support of numpy arrays in `dsk`, which uses elementwise equalities.
+    dsk1 = {"a": np.arange(10)}
+    f1 = SubgraphCallable(dsk1, "a", [None], name="test")
+    f2 = SubgraphCallable(dsk1, "a", [None], name="test")
+    assert f1 == f2
+
+    # Notice, even though `dsk1` and `dsk2` are not equal they compare equal because
+    # SubgraphCallable.__eq__() only checks name, outkeys, and inkeys.
+    dsk2 = {"a": np.arange(10) + 1}
+    f3 = SubgraphCallable(dsk2, "a", [None], name="test")
+    assert f1 == f3
+
+    f4 = SubgraphCallable(dsk1, "a", [None], name="test2")
+    assert f1 != f4
 
 
 def test_fuse_subgraphs():


### PR DESCRIPTION
This PR address an issue with `SubgraphCallable.__eq__()` by removing the `self.dsk == other.dsk` test. 
This test fails in some cases. If `dsk` contains objects like Numpy arrays or Pandas Dataframes, the test will fail because `==` is elementwise: 

```
ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all(). 
``` 

@jcrist mention that `(name, outket, inkeys)` [should be unique in all cases](https://github.com/dask/dask/pull/6424#discussion_r467095786). 
If this is not the cases, we will have to traverse `dsk` and handle elementwise equalities.  

 



 

 

 


- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`


