### PR TITLE
Replace np.searchsorted with bisect in indexing

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4693,7 +4693,7 @@ def _vindex_array(x, dict_indexes):
     points = list()
     for i, idx in enumerate(zip(*[i for i in flat_indexes if i is not None])):
         block_idx = [
-            np.searchsorted(b, ind, "right") - 1 for b, ind in zip(bounds2, idx)
+            bisect(b, ind) - 1 for b, ind in zip(bounds2, idx)
         ]
         inblock_idx = [
             ind - bounds2[k][j] for k, (ind, j) in enumerate(zip(idx, block_idx))

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4692,9 +4692,7 @@ def _vindex_array(x, dict_indexes):
 
     points = list()
     for i, idx in enumerate(zip(*[i for i in flat_indexes if i is not None])):
-        block_idx = [
-            bisect(b, ind) - 1 for b, ind in zip(bounds2, idx)
-        ]
+        block_idx = [bisect(b, ind) - 1 for b, ind in zip(bounds2, idx)]
         inblock_idx = [
             ind - bounds2[k][j] for k, (ind, j) in enumerate(zip(idx, block_idx))
         ]


### PR DESCRIPTION
Increases indexing performance, and is consistent with general `bisect` usage in the rest of the file.

By using `bisect` instead of `np.searchsorted`, v-indexing performance increases significantly. Since the search index (`ind`) seems to be a always scalar, `bisect` is a drop-in replacement.

Test case:
```
import dask.array as da
idx = np.random.randint(0, 10000, size=1000)
x = da.random.random((10000,), chunks=(10,))

%timeit x.vindex[idx]
```
Before: `57 ms ± 337 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)`

After: `4.17 ms ± 217 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)`

- [x] Tests ~~added~~ / passed
- [x] Passes ~~`black dask`~~ / `flake8 dask`

(I do see one test failure, but it happens also without the change).