### PR TITLE
Begin experimenting with parallel prefix scan for cumsum and cumprod

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2252,16 +2252,16 @@ class Array(DaskMethodsMixin):
         )
 
     @derived_from(np.ndarray)
-    def cumsum(self, axis, dtype=None, out=None):
+    def cumsum(self, axis, dtype=None, out=None, method="sequential"):
         from .reductions import cumsum
 
-        return cumsum(self, axis, dtype, out=out)
+        return cumsum(self, axis, dtype, out=out, method=method)
 
     @derived_from(np.ndarray)
-    def cumprod(self, axis, dtype=None, out=None):
+    def cumprod(self, axis, dtype=None, out=None, method="sequential"):
         from .reductions import cumprod
 
-        return cumprod(self, axis, dtype, out=out)
+        return cumprod(self, axis, dtype, out=out, method=method)
 
     @derived_from(np.ndarray)
     def squeeze(self, axis=None):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2252,13 +2252,35 @@ class Array(DaskMethodsMixin):
         )
 
     @derived_from(np.ndarray)
-    def cumsum(self, axis, dtype=None, out=None, method="sequential"):
+    def cumsum(self, axis, dtype=None, out=None, *, method="sequential"):
+        """Dask added an additional keyword-only argument ``method``.
+
+        method : {'sequential', 'blelloch'}, optional
+            Choose which method to use to perform the cumsum.  Default is 'sequential'.
+
+            * 'sequential' performs the cumsum of each prior block before the current block.
+            * 'blelloch' is a work-efficient parallel cumsum.  It exposes parallelism by
+              first taking the sum of each block and combines the sums via a binary tree.
+              This method may be faster or more memory efficient depending on workload,
+              scheduler, and hardware.  More benchmarking is necessary.
+        """
         from .reductions import cumsum
 
         return cumsum(self, axis, dtype, out=out, method=method)
 
     @derived_from(np.ndarray)
-    def cumprod(self, axis, dtype=None, out=None, method="sequential"):
+    def cumprod(self, axis, dtype=None, out=None, *, method="sequential"):
+        """Dask added an additional keyword-only argument ``method``.
+
+        method : {'sequential', 'blelloch'}, optional
+            Choose which method to use to perform the cumprod.  Default is 'sequential'.
+
+            * 'sequential' performs the cumprod of each prior block before the current block.
+            * 'blelloch' is a work-efficient parallel cumprod.  It exposes parallelism by first
+              taking the product of each block and combines the products via a binary tree.
+              This method may be faster or more memory efficient depending on workload,
+              scheduler, and hardware.  More benchmarking is necessary.
+        """
         from .reductions import cumprod
 
         return cumprod(self, axis, dtype, out=out, method=method)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1093,7 +1093,14 @@ def _compute_prefixscan0(func, x, axis, dtype):
 
 
 def prefixscan(
-    func, batchop, binop, x, axis=None, dtype=None, out=None, method="blelloch",
+    func,
+    batchop,
+    binop,
+    x,
+    axis=None,
+    dtype=None,
+    out=None,
+    method="blelloch",
 ):
     if method not in {"blelloch", "blelloch-split"}:
         raise ValueError(f"Invalid method: {method}")
@@ -1295,7 +1302,14 @@ def cumsum(x, axis=None, dtype=None, out=None, method="sequential"):
         return cumreduction(np.cumsum, _cumsum_merge, 0, x, axis, dtype, out=out)
     else:
         return prefixscan(
-            np.cumsum, np.sum, _cumsum_merge, x, axis, dtype, out=out, method=method,
+            np.cumsum,
+            np.sum,
+            _cumsum_merge,
+            x,
+            axis,
+            dtype,
+            out=out,
+            method=method,
         )
 
 
@@ -1305,7 +1319,14 @@ def cumprod(x, axis=None, dtype=None, out=None, method="sequential"):
         return cumreduction(np.cumprod, _cumprod_merge, 1, x, axis, dtype, out=out)
     else:
         return prefixscan(
-            np.cumprod, np.prod, _cumprod_merge, x, axis, dtype, out=out, method=method,
+            np.cumprod,
+            np.prod,
+            _cumprod_merge,
+            x,
+            axis,
+            dtype,
+            out=out,
+            method=method,
         )
 
 

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -536,7 +536,7 @@ def test_array_reduction_out(func):
 @pytest.mark.parametrize("func", ["cumsum", "cumprod", "nancumsum", "nancumprod"])
 @pytest.mark.parametrize("use_nan", [False, True])
 @pytest.mark.parametrize("axis", [None, 0, 1, -1])
-@pytest.mark.parametrize("method", ["sequential", "blelloch", "blelloch-split"])
+@pytest.mark.parametrize("method", ["sequential", "blelloch"])
 def test_array_cumreduction_axis(func, use_nan, axis, method):
     np_func = getattr(np, func)
     da_func = getattr(da, func)
@@ -645,7 +645,7 @@ def test_topk_argtopk3():
     "func",
     [da.cumsum, da.cumprod, da.argmin, da.argmax, da.min, da.max, da.nansum, da.nanmax],
 )
-@pytest.mark.parametrize("method", ["sequential", "blelloch", "blelloch-split"])
+@pytest.mark.parametrize("method", ["sequential", "blelloch"])
 def test_regres_3940(func, method):
     if func in {da.cumsum, da.cumprod}:
         kwargs = {"method": method}

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -536,7 +536,7 @@ def test_array_reduction_out(func):
 @pytest.mark.parametrize("func", ["cumsum", "cumprod", "nancumsum", "nancumprod"])
 @pytest.mark.parametrize("use_nan", [False, True])
 @pytest.mark.parametrize("axis", [None, 0, 1, -1])
-@pytest.mark.parametrize("method", ['sequential', 'blelloch', 'blelloch-split'])
+@pytest.mark.parametrize("method", ["sequential", "blelloch", "blelloch-split"])
 def test_array_cumreduction_axis(func, use_nan, axis, method):
     np_func = getattr(np, func)
     da_func = getattr(da, func)
@@ -645,10 +645,10 @@ def test_topk_argtopk3():
     "func",
     [da.cumsum, da.cumprod, da.argmin, da.argmax, da.min, da.max, da.nansum, da.nanmax],
 )
-@pytest.mark.parametrize("method", ['sequential', 'blelloch', 'blelloch-split'])
+@pytest.mark.parametrize("method", ["sequential", "blelloch", "blelloch-split"])
 def test_regres_3940(func, method):
     if func in {da.cumsum, da.cumprod}:
-        kwargs = {'method': method}
+        kwargs = {"method": method}
     else:
         kwargs = {}
     a = da.ones((5, 2), chunks=(2, 2))


### PR DESCRIPTION
This is a WIP and needs benchmarked.  I think it's interesting, though, and want to share.  It's been a while since I've worked on `dask.array`, so feedback is most welcome.

This is a work-efficient parallel prefix scan.  It uses a Brent-Kung construction and is known as the Blelloch algorithm.  We adapt it to work on chunks.

Previously, to do a `cumsum` across N chunks would require N levels of dependencies.  This PR takes approximately 2 * lg(N) levels of dependencies.  It exposes parallelism.  It is work-efficient and only requires a third more tasks than the previous method.  Scans on floating point values should also be more accurate.

Our parallel `cumsum` works by first taking the sum of each block, then do a binary tree merge followed by a fan-out (i.e., the Brent-Kung pattern).  We then take the `cumsum` of each block and add the sum of the previous blocks.

NumPy calculates `cumsum` and `cumprod` very fast, but it calculates `sum` and `prod` significantly faster.  This is why I think this approach will be faster.  Exposing parallelism and an efficient communication pattern is another reason I think this should be faster (especially when communication costs are significant).

I also think this will be an interesting test for `dask.order` and the scheduler.

Q: Should we allow users to choose which method to use (i.e., prev or new in this PR)?  Does the answer to this depend on benchmarks?

Benchmarks and graph diagrams are forthcoming :)

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

See: https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-39-parallel-prefix-sum-scan-cuda