### PR TITLE
Run docstring tests on CI services

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: pytest dask
+        run: pytest dask --doctest-modules

--- a/continuous_integration/travis/run_tests.sh
+++ b/continuous_integration/travis/run_tests.sh
@@ -13,8 +13,8 @@ if [[ $COVERAGE == 'true' ]]; then
     echo "coverage run `which py.test` dask --runslow --doctest-modules $XTRATESTARGS"
     coverage run `which py.test` dask --runslow --doctest-modules $XTRATESTARGS
 else
-    echo "py.test dask --runslow $XTRATESTARGS"
-    py.test dask --runslow $XTRATESTARGS
+    echo "py.test dask --runslow --doctest-modules $XTRATESTARGS"
+    py.test dask --runslow --doctest-modules $XTRATESTARGS
 fi
 
 set +e

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1167,7 +1167,7 @@ class Array(DaskMethodsMixin):
         >>> y.chunks
         ((nan, nan, nan),)
         >>> y.compute_chunk_sizes()  # in-place computation
-        dask.array<getitem, shape=(3,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>
+        dask.array<getitem, shape=(3,), dtype=int32, chunksize=(2,), chunktype=numpy.ndarray>
         >>> y.chunks
         ((2, 1, 0),)
 
@@ -3837,11 +3837,11 @@ def asarray(a, **kwargs):
     >>> import numpy as np
     >>> x = np.arange(3)
     >>> da.asarray(x)
-    dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), chunktype=numpy.ndarray>
+    dask.array<array, shape=(3,), dtype=int32, chunksize=(3,), chunktype=numpy.ndarray>
 
     >>> y = [[1, 2, 3], [4, 5, 6]]
     >>> da.asarray(y)
-    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3), chunktype=numpy.ndarray>
+    dask.array<array, shape=(2, 3), dtype=int32, chunksize=(2, 3), chunktype=numpy.ndarray>
     """
     if isinstance(a, Array):
         return a
@@ -3877,11 +3877,11 @@ def asanyarray(a):
     >>> import numpy as np
     >>> x = np.arange(3)
     >>> da.asanyarray(x)
-    dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), chunktype=numpy.ndarray>
+    dask.array<array, shape=(3,), dtype=int32, chunksize=(3,), chunktype=numpy.ndarray>
 
     >>> y = [[1, 2, 3], [4, 5, 6]]
     >>> da.asanyarray(y)
-    dask.array<array, shape=(2, 3), dtype=int64, chunksize=(2, 3), chunktype=numpy.ndarray>
+    dask.array<array, shape=(2, 3), dtype=int32, chunksize=(2, 3), chunktype=numpy.ndarray>
     """
     if isinstance(a, Array):
         return a

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1234,9 +1234,9 @@ def argtopk(a, k, axis=-1, split_every=None):
     >>> x = np.array([5, 1, 3, 6])
     >>> d = da.from_array(x, chunks=2)
     >>> d.argtopk(2).compute()
-    array([3, 0])
+    array([3, 0], dtype=int64)
     >>> d.argtopk(-2).compute()
-    array([1, 2])
+    array([1, 2], dtype=int64)
     """
     axis = validate_axis(axis, a.ndim)
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -722,7 +722,8 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
     array([    0.,  1000.,  2000.,  3000.,  4000.,  5000.,  6000.,  7000.,
             8000.,  9000., 10000.])
     >>> h.compute()
-    array([1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000])
+    array([1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000],
+          dtype=int64)
 
     Explicitly specifying the bins:
 
@@ -730,7 +731,7 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
     >>> bins
     array([    0,  5000, 10000])
     >>> h.compute()
-    array([5000, 5000])
+    array([5000, 5000], dtype=int64)
     """
     if isinstance(bins, Array):
         scalar_bins = bins.ndim == 0

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -38,11 +38,11 @@ def sanitize_index(ind):
     >>> sanitize_index([2, 3, 5])
     array([2, 3, 5])
     >>> sanitize_index([True, False, True, False])
-    array([0, 2])
+    array([0, 2], dtype=int64)
     >>> sanitize_index(np.array([1, 2, 3]))
     array([1, 2, 3])
     >>> sanitize_index(np.array([False, True, True]))
-    array([1, 2])
+    array([1, 2], dtype=int64)
     >>> type(sanitize_index(np.int32(0)))
     <class 'int'>
     >>> sanitize_index(1.0)

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -150,7 +150,7 @@ def broadcast_trick(func):
 
     >>> x = np.broadcast_to(1, (100,100,100))
     >>> x.base.nbytes
-    8
+    4
 
     Those array are not only more efficient locally, but dask serialisation is
     aware of the _real_ size of those array and thus can send them around


### PR DESCRIPTION
I was recently confused to find failing tests on the dask master branch. It turns out that there are a handful of docstring tests that are failing locally, and the CI checks here don't run the docstring tests.

This PR does two things:
1. Makes the CI checks include docstring tests, by passing `--doctest-modules` (as was recommended in the [dask developer guide here](https://docs.dask.org/en/latest/develop.html)).
2. Updates the output for the doctest examples that were failing locally, so these tests now pass.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
