### PR TITLE
_repr_html_: color sides darker instead of drawing all the lines

### DIFF
--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -164,7 +164,7 @@ def svg_nd(chunks, size=200):
     return header + "\n\n".join(out) + footer
 
 
-def svg_lines(x1, y1, x2, y2):
+def svg_lines(x1, y1, x2, y2, max_n=20):
     """Convert points into lines of text for an SVG plot
 
     Examples
@@ -174,9 +174,15 @@ def svg_lines(x1, y1, x2, y2):
      '  <line x1="1" y1="0" x2="11" y2="1" style="stroke-width:2" />']
     """
     n = len(x1)
+
+    if n > max_n:
+        indices = np.linspace(0, n - 1, max_n, dtype="int")
+    else:
+        indices = range(n)
+
     lines = [
         '  <line x1="%d" y1="%d" x2="%d" y2="%d" />' % (x1[i], y1[i], x2[i], y2[i])
-        for i in range(n)
+        for i in indices
     ]
 
     lines[0] = lines[0].replace(" /", ' style="stroke-width:2" /')
@@ -211,10 +217,9 @@ def svg_grid(x, y, offset=(0, 0), skew=(0, 0), size=200):
     min_y = min(y1.min(), y2.min())
     max_x = max(x1.max(), x2.max())
     max_y = max(y1.max(), y2.max())
+    max_n = size // 6
 
-    h_lines = []
-    if len(y) < size:
-        h_lines = ["", "  <!-- Horizontal lines -->"] + svg_lines(x1, y1, x2, y2)
+    h_lines = ["", "  <!-- Horizontal lines -->"] + svg_lines(x1, y1, x2, y2, max_n)
 
     # Vertical lines
     x1 = x + offset[0]
@@ -228,11 +233,9 @@ def svg_grid(x, y, offset=(0, 0), skew=(0, 0), size=200):
     if skew[1]:
         x2 += skew[1] * y.max()
 
-    v_lines = []
-    if len(x) < size:
-        v_lines = ["", "  <!-- Vertical lines -->"] + svg_lines(x1, y1, x2, y2)
+    v_lines = ["", "  <!-- Vertical lines -->"] + svg_lines(x1, y1, x2, y2, max_n)
 
-    color = "ECB172" if len(x) < size and len(y) < size else "8B4903"
+    color = "ECB172" if len(x) < max_n and len(y) < max_n else "8B4903"
     corners = f"{x1[0]},{y1[0]} {x1[-1]},{y1[-1]} {x2[-1]},{y2[-1]} {x2[0]},{y2[0]}"
     rect = [
         "",

--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -45,7 +45,9 @@ def svg_2d(chunks, offset=(0, 0), skew=(0, 0), size=200, sizes=None):
     sizes = sizes or draw_sizes(shape, size=size)
     y, x = grid_points(chunks, sizes)
 
-    lines, (min_x, max_x, min_y, max_y) = svg_grid(x, y, offset=offset, skew=skew)
+    lines, (min_x, max_x, min_y, max_y) = svg_grid(
+        x, y, offset=offset, skew=skew, size=size
+    )
 
     header = (
         '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n'
@@ -77,12 +79,14 @@ def svg_3d(chunks, size=200, sizes=None, offset=(0, 0)):
     ox, oy = offset
 
     xy, (mnx, mxx, mny, mxy) = svg_grid(
-        x / 1.7, y, offset=(ox + 10, oy + 0), skew=(1, 0)
+        x / 1.7, y, offset=(ox + 10, oy + 0), skew=(1, 0), size=size
     )
 
-    zx, (_, _, _, max_x) = svg_grid(z, x / 1.7, offset=(ox + 10, oy + 0), skew=(0, 1))
+    zx, (_, _, _, max_x) = svg_grid(
+        z, x / 1.7, offset=(ox + 10, oy + 0), skew=(0, 1), size=size
+    )
     zy, (min_z, max_z, min_y, max_y) = svg_grid(
-        z, y, offset=(ox + max_x + 10, oy + max_x), skew=(0, 0)
+        z, y, offset=(ox + max_x + 10, oy + max_x), skew=(0, 0), size=size
     )
 
     header = (
@@ -180,7 +184,7 @@ def svg_lines(x1, y1, x2, y2):
     return lines
 
 
-def svg_grid(x, y, offset=(0, 0), skew=(0, 0)):
+def svg_grid(x, y, offset=(0, 0), skew=(0, 0), size=200):
     """Create lines of SVG text that show a grid
 
     Parameters
@@ -208,7 +212,9 @@ def svg_grid(x, y, offset=(0, 0), skew=(0, 0)):
     max_x = max(x1.max(), x2.max())
     max_y = max(y1.max(), y2.max())
 
-    h_lines = ["", "  <!-- Horizontal lines -->"] + svg_lines(x1, y1, x2, y2)
+    h_lines = []
+    if len(y) < size:
+        h_lines = ["", "  <!-- Horizontal lines -->"] + svg_lines(x1, y1, x2, y2)
 
     # Vertical lines
     x1 = x + offset[0]
@@ -222,13 +228,16 @@ def svg_grid(x, y, offset=(0, 0), skew=(0, 0)):
     if skew[1]:
         x2 += skew[1] * y.max()
 
-    v_lines = ["", "  <!-- Vertical lines -->"] + svg_lines(x1, y1, x2, y2)
+    v_lines = []
+    if len(x) < size:
+        v_lines = ["", "  <!-- Vertical lines -->"] + svg_lines(x1, y1, x2, y2)
 
+    color = "ECB172" if len(x) < size and len(y) < size else "8B4903"
+    corners = f"{x1[0]},{y1[0]} {x1[-1]},{y1[-1]} {x2[-1]},{y2[-1]} {x2[0]},{y2[0]}"
     rect = [
         "",
         "  <!-- Colored Rectangle -->",
-        '  <polygon points="%f,%f %f,%f %f,%f %f,%f" style="fill:#ECB172A0;stroke-width:0"/>'
-        % (x1[0], y1[0], x1[-1], y1[-1], x2[-1], y2[-1], x2[0], y2[0]),
+        f'  <polygon points="{corners}" style="fill:#{color}A0;stroke-width:0"/>',
     ]
 
     return h_lines + v_lines + rect, (min_x, max_x, min_y, max_y)

--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -79,6 +79,14 @@ def test_draw_sizes():
     assert b < c * 5
 
 
+def test_too_many_lines_fills_sides_darker():
+    data = da.ones((16000, 2400, 3600), chunks=(1, 2400, 3600))
+    text = data.to_svg()
+    assert "8B4903" in text
+    assert text.count("Horizontal lines") == 2
+    assert text.count("\n") < 100
+
+
 def test_3d():
     text = da.ones((10, 10, 10, 10, 10)).to_svg()
     assert text.count("<svg") == 1

--- a/dask/array/tests/test_svg.py
+++ b/dask/array/tests/test_svg.py
@@ -83,8 +83,7 @@ def test_too_many_lines_fills_sides_darker():
     data = da.ones((16000, 2400, 3600), chunks=(1, 2400, 3600))
     text = data.to_svg()
     assert "8B4903" in text
-    assert text.count("Horizontal lines") == 2
-    assert text.count("\n") < 100
+    assert text.count("\n") < 300
 
 
 def test_3d():


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Closes #6670

See what you all think. I set the max number of gridlines to the size of the svg. I don't have a strong opinion, but 20 seemed small to me as a max.

### Original
![image](https://user-images.githubusercontent.com/1197350/94273468-74a9ca00-ff12-11ea-98ca-33e803c818bf.png)

### This PR
![image](https://user-images.githubusercontent.com/4806877/94488906-7e9d2880-01b1-11eb-8ff5-f4b4586fd4d1.png)

### UPDATED
![image](https://user-images.githubusercontent.com/4806877/94716425-d4421400-031c-11eb-8315-b79fb1378450.png)
