### PR TITLE
Use `pandas.testing`

### DIFF
--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import os
 import pytest
 from operator import add, mul
@@ -45,6 +46,15 @@ dd = import_or_none("dask.dataframe")
 np = import_or_none("numpy")
 sp = import_or_none("scipy.sparse")
 pd = import_or_none("pandas")
+
+if pd:
+    PANDAS_VERSION = LooseVersion(pd.__version__)
+    PANDAS_GT_100 = PANDAS_VERSION >= LooseVersion("1.0.0")
+
+    if PANDAS_GT_100:
+        import pandas.testing as tm  # noqa: F401
+    else:
+        import pandas.util.testing as tm  # noqa: F401
 
 
 def f1(a, b, c=1):
@@ -677,8 +687,8 @@ def test_compute_dataframe():
     ddf1 = ddf.a + 1
     ddf2 = ddf.a + ddf.b
     out1, out2 = compute(ddf1, ddf2)
-    pd.testing.assert_series_equal(out1, df.a + 1)
-    pd.testing.assert_series_equal(out2, df.a + df.b)
+    tm.assert_series_equal(out1, df.a + 1)
+    tm.assert_series_equal(out2, df.a + df.b)
 
 
 @pytest.mark.skipif("not dd or not da")


### PR DESCRIPTION
`pandas.utils.testing` is deprecated ( https://github.com/pandas-dev/pandas/pull/30745 ). The preferred way forward is to use `pandas.testing`. So this updates our usage accordingly.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

Note: A similar change is being made to Distributed ( https://github.com/dask/distributed/pull/4138 ).