### PR TITLE
Map on HighLevelGraph Layers

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -106,6 +106,10 @@ class ParquetSubgraph(Layer):
         )
         return ret, ret.get_dependencies(all_hlg_keys)
 
+    def map_tasks(self, func):
+        # ParquetSubgraph has no input tasks
+        return self
+
 
 def read_parquet(
     path,

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -500,15 +500,10 @@ class HighLevelGraph(Mapping):
             A high level graph containing the transformed BasicLayers and the other
             Layers untouched
         """
-        layers = {}
-        for k, v in self.layers.items():
-            if isinstance(v, BasicLayer):
-                layer = func(v)
-                if not isinstance(layer, Layer):
-                    layer = BasicLayer(layer)
-                layers[k] = layer
-            else:
-                layers[k] = v
+        layers = {
+            k: func(v) if isinstance(v, BasicLayer) else v
+            for k, v in self.layers.items()
+        }
         return HighLevelGraph(layers, self.dependencies)
 
     def map_tasks(self, func: Callable[[Iterable], Iterable]) -> "HighLevelGraph":

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -96,7 +96,7 @@ class Layer(collections.abc.Mapping):
         Warning
         -------
         A layer is allowed to ignore the map on tasks that are part of its internals.
-        For instance, Blockwise will only evoke `func` on the input literals.
+        For instance, Blockwise will only invoke `func` on the input literals.
 
         Parameters
         ----------
@@ -511,7 +511,7 @@ class HighLevelGraph(Mapping):
         Warning
         -------
         A layer is allowed to ignore the map on tasks that are part of its internals.
-        For instance, Blockwise will only evoke `func` on the input literals.
+        For instance, Blockwise will only invoke `func` on the input literals.
 
         Parameters
         ----------

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -486,7 +486,7 @@ class HighLevelGraph(Mapping):
         `func` should take a BasicLayer as input and return a new Mapping as output
         and **cannot** change the dependencies between Layers.
 
-        If `func` returns a non-BasicLayer type, it will be wrapped in a `BasicLayer`
+        If `func` returns a non-Layer type, it will be wrapped in a `BasicLayer`
         object automatically.
 
         Parameters
@@ -504,7 +504,7 @@ class HighLevelGraph(Mapping):
         for k, v in self.layers.items():
             if isinstance(v, BasicLayer):
                 layer = func(v)
-                if not isinstance(layer, BasicLayer):
+                if not isinstance(layer, Layer):
                     layer = BasicLayer(layer)
                 layers[k] = layer
             else:

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -405,7 +405,7 @@ class HighLevelGraph(Mapping):
                     ready.add(k)
         return ret
 
-    def cull(self, keys: Set):
+    def cull(self, keys: Set) -> "HighLevelGraph":
         """Return new high level graph with only the tasks required to calculate keys.
 
         In other words, remove unnecessary tasks from dask.

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -147,14 +147,15 @@ class HighLevelGraph(Mapping):
 
     Parameters
     ----------
-    layers : Dict[str, Mapping]
+    layers : Mapping[str, Mapping]
         The subgraph layers, keyed by a unique name
-    dependencies : Dict[str, Set[str]]
+    dependencies : Mapping[str, Set[str]]
         The set of layers on which each layer depends
+    key_dependencies : Mapping[Hashable, Set], optional
+        Mapping all keys in the high level graph to their dependencies
 
     Examples
     --------
-
     Here is an idealized example that shows the internal state of a
     HighLevelGraph
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -536,6 +536,7 @@ class HighLevelGraph(Mapping):
         return HighLevelGraph(
             {k: v.map_tasks(func) for k, v in self.layers.items()},
             self.dependencies,
+            self.key_dependencies,
         )
 
     def validate(self):

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -201,7 +201,7 @@ class HighLevelGraph(Mapping):
         dependencies: Mapping[str, Set],
         key_dependencies: Optional[Mapping[Hashable, Set]] = None,
     ):
-        self.__keys = None
+        self._keys = None
         self.layers = layers
         self.dependencies = dependencies
         self.key_dependencies = key_dependencies
@@ -213,11 +213,11 @@ class HighLevelGraph(Mapping):
         }
 
     def keyset(self):
-        if self.__keys is None:
-            self.__keys = set()
+        if self._keys is None:
+            self._keys = set()
             for layer in self.layers.values():
-                self.__keys.update(layer.keys())
-        return self.__keys
+                self._keys.update(layer.keys())
+        return self._keys
 
     @property
     def dependents(self):

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -206,6 +206,12 @@ class HighLevelGraph(Mapping):
         self.dependencies = dependencies
         self.key_dependencies = key_dependencies
 
+        # Makes sure that all layers are `Layer`
+        self.layers = {
+            k: v if isinstance(v, Layer) else BasicLayer(v)
+            for k, v in self.layers.items()
+        }
+
     def keyset(self):
         if self.__keys is None:
             self.__keys = set()
@@ -373,14 +379,6 @@ class HighLevelGraph(Mapping):
 
         return self.key_dependencies
 
-    def _fix_hlg_layers_inplace(self):
-        """Makes sure that all layers in hlg are `Layer`"""
-        new_layers = {}
-        for k, v in self.layers.items():
-            if not isinstance(v, Layer):
-                new_layers[k] = BasicLayer(v)
-        self.layers.update(new_layers)
-
     def _toposort_layers(self):
         """Sort the layers in a high level graph topologically
 
@@ -419,7 +417,6 @@ class HighLevelGraph(Mapping):
             Culled high level graph
         """
 
-        self._fix_hlg_layers_inplace()
         layers = self._toposort_layers()
         all_keys = self.keyset()
 

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -102,7 +102,8 @@ def test_map_tasks(use_layer_map_task):
     dsk = y.__dask_graph__()
 
     if use_layer_map_task:
-        # Overwrite Blockwise.map_tasks with Layer.map_tasks
+        # In order to test the default map_tasks() implementation on a Blockwise Layer,
+        # we overwrite Blockwise.map_tasks with Layer.map_tasks
         blockwise_layer = list(dsk.layers.values())[1]
         blockwise_layer.map_tasks = partial(Layer.map_tasks, blockwise_layer)
 

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -81,8 +81,8 @@ def test_map_basic_layers(inject_dict):
     dsk = y.__dask_graph__()
     y.dask = dsk.map_basic_layers(inject_inc)
     layers = list(y.dask.layers.values())
-    assert type(layers[0]) == BasicLayer
-    assert type(layers[1]) == Blockwise
+    assert isinstance(layers[0], BasicLayer)
+    assert isinstance(layers[1], Blockwise)
     assert_eq(y, [42] * 3)
 
 

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -7,6 +7,7 @@ import dask.array as da
 from dask.utils_test import inc
 from dask.highlevelgraph import HighLevelGraph, BasicLayer, Layer
 from dask.blockwise import Blockwise
+from dask.array.utils import assert_eq
 
 
 def test_visualize(tmpdir):
@@ -82,7 +83,7 @@ def test_map_basic_layers(inject_dict):
     layers = list(y.dask.layers.values())
     assert type(layers[0]) == BasicLayer
     assert type(layers[1]) == Blockwise
-    assert list(y.compute()) == [42] * 3
+    assert_eq(y, [42] * 3)
 
 
 @pytest.mark.parametrize("use_layer_map_task", [True, False])
@@ -106,4 +107,4 @@ def test_map_tasks(use_layer_map_task):
         blockwise_layer.map_tasks = partial(Layer.map_tasks, blockwise_layer)
 
     y.dask = dsk.map_tasks(plus_one)
-    assert list(y.compute()) == [42] * 3
+    assert_eq(y, [42] * 3)


### PR DESCRIPTION
This PR introduces two `HighLevelGraph` methods:

```python
    def map_basic_layers(
        self, func: Callable[[BasicLayer], Mapping]
    ) -> "HighLevelGraph":
        """Map `func` on each basic layer and returns a new high level graph.
        `func` should take a BasicLayer as input and return a new Mapping as output
        and **cannot** change the dependencies between Layers.
        If `func` returns a non-BasicLayer type, it will be wrapped in a `BasicLayer`
        object automatically.

        Parameters
        ----------
        func : callable
            The function to call on each BasicLayer

        Returns
        -------
        hlg : HighLevelGraph
            A high level graph containing the transformed BasicLayers and the other
            Layers untouched
        """

    def map_tasks(self, func: Callable[[Iterable], Iterable]) -> "HighLevelGraph":
        """Map `func` on all tasks and returns a new high level graph.
        `func` should take an iterable of the tasks as input and return a new
        iterable as output and **cannot** change the dependencies between Layers.

        Warning
        -------
        A layer is allowed to ignore the map on tasks that are part of its internals.
        For instance, Blockwise will only invoke `func` on the input literals.

        Parameters
        ----------
        func : callable
            The function to call on tasks

        Returns
        -------
        hlg : HighLevelGraph
            A high level graph containing the transformed tasks
        """
```

The motivation is to avoid materialization of high level graphs in Distributed: https://github.com/dask/distributed/issues/4119

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
