### PR TITLE
Serialization of layers

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -87,6 +87,18 @@ class Layer(collections.abc.Mapping):
         """
         return {k: keys_in_tasks(all_hlg_keys, [v]) for k, v in self.items()}
 
+    def __reduce__(self):
+        """Default serialization implementation, which materialize the Layer
+
+        This should follow the standard pickle protocol[1] but must always return
+        a tuple and the arguments for the callable object must be compatibly with
+        msgpack. This is because Distributed uses msgpack to send Layers to the
+        scheduler.
+
+        [1] <https://docs.python.org/3/library/pickle.html#object.__reduce__>
+        """
+        return (BasicLayer, (dict(self),))
+
 
 class BasicLayer(Layer):
     """Basic implementation of `Layer`

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -88,10 +88,10 @@ class Layer(collections.abc.Mapping):
         return {k: keys_in_tasks(all_hlg_keys, [v]) for k, v in self.items()}
 
     def __reduce__(self):
-        """Default serialization implementation, which materialize the Layer
+        """Default serialization implementation, which materializes the Layer
 
         This should follow the standard pickle protocol[1] but must always return
-        a tuple and the arguments for the callable object must be compatibly with
+        a tuple and the arguments for the callable object must be compatible with
         msgpack. This is because Distributed uses msgpack to send Layers to the
         scheduler.
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -130,6 +130,12 @@ class Layer(collections.abc.Mapping):
         """
         return (BasicLayer, (dict(self),))
 
+    def __copy__(self):
+        """Default shallow copy implementation"""
+        obj = type(self).__new__(self.__class__)
+        obj.__dict__.update(self.__dict__)
+        return obj
+
 
 class BasicLayer(Layer):
     """Basic implementation of `Layer`


### PR DESCRIPTION
This PR implements a default serialization of `Layer`. In order to be compatible with pickle, we use the `__reduce__` protocol but for security reasons Distributed uses `msgpack` for serialization when communicating with the scheduler thus this must also be compatible with `msgpack` (see https://github.com/dask/distributed/pull/4140).

```python 

    def __reduce__(self):
        """Default serialization implementation, which materialize the Layer

        This should follow the standard pickle protocol[1] but must always return
        a tuple and the arguments for the callable object must be compatibly with
        msgpack. This is because Distributed uses msgpack to send Layers to the
        scheduler.

        [1] <https://docs.python.org/3/library/pickle.html#object.__reduce__>
        """
```

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
