### PR TITLE
Revert "Use HighLevelGraph layers everywhere in collections (#6510)"

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -191,34 +191,6 @@ def keys_in_tasks(keys, tasks, as_list=False):
     return ret if as_list else set(ret)
 
 
-def find_all_possible_keys(tasks) -> set:
-    """Returns all possible keys in `tasks` including hashable literals.
-
-    The definition of a key in a Dask graph is any hashable object
-    that is not a task. This function returns all such objects in
-    `tasks` even if the object is in fact a literal.
-
-    """
-    ret = set()
-    while tasks:
-        work = []
-        for w in tasks:
-            typ = type(w)
-            if typ is tuple and w and callable(w[0]):  # istask(w)
-                work.extend(w[1:])
-            elif typ is list:
-                work.extend(w)
-            elif typ is dict:
-                work.extend(w.values())
-            else:
-                try:
-                    ret.add(w)
-                except TypeError:  # not hashable
-                    pass
-        tasks = work
-    return ret
-
-
 def get_dependencies(dsk, key=None, task=no_default, as_list=False):
     """Get the immediate tasks on which this task depends
 

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -10,28 +10,25 @@ from ..blockwise import optimize_blockwise, fuse_roots, Blockwise
 
 
 def optimize(dsk, keys, **kwargs):
-    if not isinstance(keys, (list, set)):
-        keys = [keys]
-    keys = list(core.flatten(keys))
 
-    if not isinstance(dsk, HighLevelGraph):
-        dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
+    if isinstance(dsk, HighLevelGraph):
+        # Think about an API for this.
+        flat_keys = list(core.flatten(keys))
+        dsk = optimize_read_parquet_getitem(dsk, keys=flat_keys)
+        dsk = optimize_blockwise(dsk, keys=flat_keys)
+        dsk = fuse_roots(dsk, keys=flat_keys)
 
-    dsk = optimize_read_parquet_getitem(dsk, keys=keys)
-    dsk = optimize_blockwise(dsk, keys=keys)
-    dsk = fuse_roots(dsk, keys=keys)
-    dsk = dsk.cull(set(keys))
-
-    if not config.get("optimization.fuse.active"):
-        return dsk
-
-    dependencies = dsk.get_dependencies()
     dsk = ensure_dict(dsk)
+
+    if isinstance(keys, list):
+        dsk, dependencies = cull(dsk, list(core.flatten(keys)))
+    else:
+        dsk, dependencies = cull(dsk, [keys])
 
     fuse_subgraphs = config.get("optimization.fuse.subgraphs")
     if fuse_subgraphs is None:
         fuse_subgraphs = True
-    dsk, _ = fuse(
+    dsk, dependencies = fuse(
         dsk,
         keys,
         dependencies=dependencies,

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1,13 +1,10 @@
-import collections.abc
-from typing import Hashable, Optional, Set, Mapping, Iterable, Tuple
-import copy
+from collections.abc import Mapping
 
 import tlz as toolz
 
 from .utils import ignoring
 from .base import is_dask_collection
 from .core import reverse_dict, keys_in_tasks
-from .utils_test import add, inc  # noqa: F401
 
 
 def compute_layer_dependencies(layers):
@@ -25,109 +22,6 @@ def compute_layer_dependencies(layers):
         for key in keys_in_tasks(all_keys.difference(v.keys()), v.values()):
             ret[k].add(_find_layer_containing_key(key))
     return ret
-
-
-class Layer(collections.abc.Mapping):
-    """High level graph layer
-
-    This abstract class establish a protocol for high level graph layers.
-    """
-
-    def cull(
-        self, keys: Set, all_hlg_keys: Iterable
-    ) -> Tuple["Layer", Mapping[Hashable, Set]]:
-        """Return a new Layer with only the tasks required to calculate `keys`.
-
-        In other words, remove unnecessary tasks from the layer.
-
-        Examples
-        --------
-        >>> d = Layer({'x': 1, 'y': (inc, 'x'), 'out': (add, 'x', 10)})  # doctest: +SKIP
-        >>> d.cull({'out'})  # doctest: +SKIP
-        {'x': 1, 'out': (add, 'x', 10)}
-
-        Returns
-        -------
-        layer: Layer
-            Culled layer
-        """
-        deps = self.get_dependencies(all_hlg_keys)
-
-        if len(keys) == len(self):
-            return self, deps  # Nothing to cull if preserving all existing keys
-
-        ret_deps = {}
-        seen = set()
-        out = {}
-        work = keys.copy()
-        while work:
-            k = work.pop()
-            out[k] = self[k]
-            ret_deps[k] = deps[k]
-            for d in deps[k]:
-                if d not in seen:
-                    if d in self:
-                        seen.add(d)
-                        work.add(d)
-
-        return BasicLayer(out), ret_deps
-
-    def get_dependencies(self, all_hlg_keys: Iterable) -> Mapping[Hashable, Set]:
-        """Get dependencies of all keys in the layer
-
-        Parameters
-        ----------
-        all_hlg_keys : Iterable
-            All keys in the high level graph.
-
-        Returns
-        -------
-        map: Mapping
-            A map that maps each key in the layer to its dependencies
-        """
-        return {k: keys_in_tasks(all_hlg_keys, [v]) for k, v in self.items()}
-
-
-class BasicLayer(Layer):
-    """Basic implementation of `Layer`
-
-    Parameters
-    ----------
-    mapping : Mapping
-        The mapping between keys and tasks, typically a dask graph.
-    dependencies : Mapping[Hashable, Set], optional
-        Mapping between keys and their dependencies
-    global_dependencies: Set, optional
-        Set of dependencies that all keys in the layer depend on. Notice,
-        the set might also contain literals that will be ignored.
-    """
-
-    def __init__(self, mapping, dependencies=None, global_dependencies=None):
-        self.mapping = mapping
-        self.dependencies = dependencies
-        self.global_dependencies = global_dependencies
-
-    def __contains__(self, k):
-        return k in self.mapping
-
-    def __getitem__(self, k):
-        return self.mapping[k]
-
-    def __iter__(self):
-        return iter(self.mapping)
-
-    def __len__(self):
-        return len(self.mapping)
-
-    def get_dependencies(self, all_hlg_keys):
-        if self.dependencies is None or self.global_dependencies is None:
-            return super().get_dependencies(all_hlg_keys)
-
-        global_deps = self.global_dependencies.intersection(all_hlg_keys)
-        ret = self.dependencies.copy()
-        for v in ret.values():
-            v |= global_deps
-        return ret
 
 
 class HighLevelGraph(Mapping):
@@ -194,23 +88,9 @@ class HighLevelGraph(Mapping):
         typically used by developers to make new HighLevelGraphs
     """
 
-    def __init__(
-        self,
-        layers: Mapping[str, Mapping],
-        dependencies: Mapping[str, Set],
-        key_dependencies: Optional[Mapping[Hashable, Set]] = None,
-    ):
-        self.__keys = None
+    def __init__(self, layers, dependencies):
         self.layers = layers
         self.dependencies = dependencies
-        self.key_dependencies = key_dependencies
-
-    def keyset(self):
-        if self.__keys is None:
-            self.__keys = set()
-            for layer in self.layers.values():
-                self.__keys.update(layer.keys())
-        return self.__keys
 
     @property
     def dependents(self):
@@ -282,7 +162,8 @@ class HighLevelGraph(Mapping):
         if len(dependencies) == 1:
             return cls._from_collection(name, layer, dependencies[0])
         layers = {name: layer}
-        deps = {name: set()}
+        deps = {}
+        deps[name] = set()
         for collection in toolz.unique(dependencies, key=id):
             if is_dask_collection(collection):
                 graph = collection.__dask_graph__()
@@ -311,10 +192,7 @@ class HighLevelGraph(Mapping):
         raise KeyError(key)
 
     def __len__(self):
-        return len(self.keyset())
-
-    def __iter__(self):
-        return toolz.unique(toolz.concat(self.layers.values()))
+        return sum(1 for _ in self)
 
     def items(self):
         items = []
@@ -326,14 +204,14 @@ class HighLevelGraph(Mapping):
                     items.append((key, d[key]))
         return items
 
+    def __iter__(self):
+        return toolz.unique(toolz.concat(self.layers.values()))
+
     def keys(self):
         return [key for key, _ in self.items()]
 
     def values(self):
         return [value for _, value in self.items()]
-
-    def copy(self):
-        return HighLevelGraph(self.layers.copy(), self.dependencies.copy())
 
     @classmethod
     def merge(cls, *graphs):
@@ -355,97 +233,6 @@ class HighLevelGraph(Mapping):
 
         g = to_graphviz(self, **kwargs)
         return graphviz_to_file(g, filename, format)
-
-    def get_dependencies(self) -> Mapping[Hashable, Set]:
-        """Get dependencies of all keys in the HLG
-
-        Returns
-        -------
-        map: Mapping
-            A map that maps each key to its dependencies
-        """
-        if self.key_dependencies is None:
-            all_keys = self.keyset()
-            self.key_dependencies = {}
-            for layer in self.layers.values():
-                self.key_dependencies.update(layer.get_dependencies(all_keys))
-
-        return self.key_dependencies
-
-    def _fix_hlg_layers_inplace(self):
-        """Makes sure that all layers in hlg are `Layer`"""
-        new_layers = {}
-        for k, v in self.layers.items():
-            if not isinstance(v, Layer):
-                new_layers[k] = BasicLayer(v)
-        self.layers.update(new_layers)
-
-    def _toposort_layers(self):
-        """Sort the layers in a high level graph topologically
-
-        Parameters
-        ----------
-        hlg : HighLevelGraph
-            The high level graph's layers to sort
-
-        Returns
-        -------
-        sorted: list
-            List of layer names sorted topologically
-        """
-        dependencies = copy.deepcopy(self.dependencies)
-        ready = {k for k, v in dependencies.items() if len(v) == 0}
-        ret = []
-        while len(ready) > 0:
-            layer = ready.pop()
-            ret.append(layer)
-            del dependencies[layer]
-            for k, v in dependencies.items():
-                v.discard(layer)
-                if len(v) == 0:
-                    ready.add(k)
-        return ret
-
-    def cull(self, keys: Set):
-        """Return new high level graph with only the tasks required to calculate keys.
-
-        In other words, remove unnecessary tasks from dask.
-        ``keys`` may be a single key or list of keys.
-
-        Returns
-        -------
-        hlg: HighLevelGraph
-            Culled high level graph
-        """
-
-        self._fix_hlg_layers_inplace()
-        layers = self._toposort_layers()
-        all_keys = self.keyset()
-
-        ret_layers = {}
-        ret_key_deps = {}
-        for layer_name in reversed(layers):
-            layer = self.layers[layer_name]
-            key_deps = keys.intersection(layer)
-            if len(key_deps) > 0:
-                culled_layer, culled_deps = layer.cull(key_deps, all_keys)
-
-                external_deps = set()
-                for k in culled_layer.keys():
-                    external_deps |= culled_deps[k]
-                external_deps.difference_update(culled_layer.keys())
-
-                keys.update(external_deps)
-                ret_layers[layer_name] = culled_layer
-                ret_key_deps.update(culled_deps)
-
-        ret_dependencies = {}
-        for layer_name in ret_layers:
-            ret_dependencies[layer_name] = {
-                d for d in self.dependencies[layer_name] if d in ret_layers
-            }
-
-        return HighLevelGraph(ret_layers, ret_dependencies, ret_key_deps)
 
     def validate(self):
         # Check dependencies

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -4,7 +4,7 @@ import pytest
 
 import dask.array as da
 from dask.utils_test import inc
-from dask.highlevelgraph import HighLevelGraph, BasicLayer
+from dask.highlevelgraph import HighLevelGraph
 
 
 def test_visualize(tmpdir):
@@ -40,20 +40,3 @@ def test_keys_values_items_methods():
     assert keys == [i for i in hg]
     assert values == [hg[i] for i in hg]
     assert items == [(k, v) for k, v in zip(keys, values)]
-
-
-def test_cull():
-    a = {"x": 1, "y": (inc, "x")}
-    layers = {
-        "a": BasicLayer(
-            a, dependencies={"x": set(), "y": {"x"}}, global_dependencies=set()
-        )
-    }
-    dependencies = {"a": set()}
-    hg = HighLevelGraph(layers, dependencies)
-
-    culled_by_x = hg.cull({"x"})
-    assert dict(culled_by_x) == {"x": 1}
-
-    culled_by_y = hg.cull({"y"})
-    assert dict(culled_by_y) == a


### PR DESCRIPTION
This reverts commit f0b2ac29d0127aac7d29a1675772816bb8b54424 to fix the performance regression in https://github.com/dask/dask/issues/6694.

I'll be out tomorrow, but we should consider this for the the release, and revert this reversion just after, so that we don't block @rjzamora's and other's work that builds off that PR for too long.