### PR TITLE
HLG: get_dependencies() of single keys

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -45,7 +45,7 @@ def optimize(
     dsk = optimize_blockwise(dsk, keys=keys)
     dsk = fuse_roots(dsk, keys=keys)
     dsk = dsk.cull(set(keys))
-    dependencies = dsk.get_dependencies()
+    dependencies = dsk.get_all_dependencies()
     dsk = ensure_dict(dsk)
 
     # Low level task optimizations

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -251,9 +251,9 @@ class Blockwise(Layer):
 
         return out_d
 
-    def get_dependencies(self, all_hlg_keys):
+    def get_dependencies(self, key, all_hlg_keys):
         _ = self._dict  # trigger materialization
-        return self._cached_dict["basic_layer"].get_dependencies(all_hlg_keys)
+        return self._cached_dict["basic_layer"].get_dependencies(key, all_hlg_keys)
 
     def cull(self, keys, all_hlg_keys):
         _ = self._dict  # trigger materialization

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -25,7 +25,7 @@ def optimize(dsk, keys, **kwargs):
     if not config.get("optimization.fuse.active"):
         return dsk
 
-    dependencies = dsk.get_dependencies()
+    dependencies = dsk.get_all_dependencies()
     dsk = ensure_dict(dsk)
 
     fuse_subgraphs = config.get("optimization.fuse.subgraphs")

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1,5 +1,5 @@
 import collections.abc
-from typing import Hashable, Optional, Set, Mapping, Iterable, Tuple
+from typing import Hashable, Set, Mapping, Iterable, Tuple
 import copy
 
 import tlz as toolz
@@ -152,7 +152,8 @@ class HighLevelGraph(Mapping):
     dependencies : Mapping[str, Set[str]]
         The set of layers on which each layer depends
     key_dependencies : Mapping[Hashable, Set], optional
-        Mapping all keys in the high level graph to their dependencies
+        Mapping (some) keys in the high level graph to their dependencies. If
+        a key is missing, its dependencies will be calculated automatically.
 
     Examples
     --------
@@ -199,7 +200,7 @@ class HighLevelGraph(Mapping):
         self,
         layers: Mapping[str, Mapping],
         dependencies: Mapping[str, Set],
-        key_dependencies: Optional[Mapping[Hashable, Set]] = None,
+        key_dependencies: Mapping[Hashable, Set] = {},
     ):
         self.__keys = None
         self.layers = layers
@@ -357,7 +358,7 @@ class HighLevelGraph(Mapping):
         g = to_graphviz(self, **kwargs)
         return graphviz_to_file(g, filename, format)
 
-    def get_dependencies(self) -> Mapping[Hashable, Set]:
+    def get_all_dependencies(self) -> Mapping[Hashable, Set]:
         """Get dependencies of all keys in the HLG
 
         Returns
@@ -365,9 +366,9 @@ class HighLevelGraph(Mapping):
         map: Mapping
             A map that maps each key to its dependencies
         """
-        if self.key_dependencies is None:
-            all_keys = self.keyset()
-            self.key_dependencies = {}
+        all_keys = self.keyset()
+        missing_keys = all_keys.difference(self.key_dependencies.keys())
+        if missing_keys:
             for layer in self.layers.values():
                 self.key_dependencies.update(layer.get_dependencies(all_keys))
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -379,9 +379,7 @@ class HighLevelGraph(Mapping):
         if missing_keys:
             for layer in self.layers.values():
                 for k in missing_keys.intersection(layer.keys()):
-                    assert k not in self.key_dependencies
                     self.key_dependencies[k] = layer.get_dependencies(k, all_keys)
-
         return self.key_dependencies
 
     def _fix_hlg_layers_inplace(self):

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -147,14 +147,15 @@ class HighLevelGraph(Mapping):
 
     Parameters
     ----------
-    layers : Dict[str, Mapping]
+    layers : Mapping[str, Mapping]
         The subgraph layers, keyed by a unique name
-    dependencies : Dict[str, Set[str]]
+    dependencies : Mapping[str, Set[str]]
         The set of layers on which each layer depends
+    key_dependencies : Mapping[Hashable, Set], optional
+        Mapping all keys in the high level graph to their dependencies
 
     Examples
     --------
-
     Here is an idealized example that shows the internal state of a
     HighLevelGraph
 


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/6694 by letting `get_dependencies()` work on single keys instead of all keys in the `Layer`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
