### PR TITLE
Update dask-sphinx-theme version

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 numpydoc
 sphinx
-dask-sphinx-theme>=1.3.3
+dask-sphinx-theme>=1.3.4
 sphinx-click
 toolz
 cloudpickle

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 numpydoc
 sphinx
-dask-sphinx-theme>=1.1.0
+dask-sphinx-theme>=1.3.3
 sphinx-click
 toolz
 cloudpickle

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 numpydoc
 sphinx
-dask-sphinx-theme>=1.3.4
+dask-sphinx-theme>=1.3.5
 sphinx-click
 toolz
 cloudpickle


### PR DESCRIPTION
Pulls in the fix for #6696

This shouldn't be merged until dask/dask-sphinx-theme#43 is in and a new release of `dask-sphinx-theme` is cut
