### PR TITLE
Support __array_function__ dispatching on Array subclasses

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1404,7 +1404,9 @@ class Array(DaskMethodsMixin):
             return _HANDLED_FUNCTIONS[func](*args, **kwargs)
 
         # First, verify that all types are handled by Dask. Otherwise, return NotImplemented.
-        if not all(type is Array or is_valid_chunk_type(type) for type in types):
+        if not all(
+            issubclass(type, Array) or is_valid_chunk_type(type) for type in types
+        ):
             return NotImplemented
 
         # Now try to find a matching function name.  If that doesn't work, we may

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1405,7 +1405,7 @@ class Array(DaskMethodsMixin):
 
         # First, verify that all types are handled by Dask. Otherwise, return NotImplemented.
         if not all(
-            issubclass(type, Array) or is_valid_chunk_type(type) for type in types
+            type_ is type(self) or is_valid_chunk_type(type_) for type_ in types
         ):
             return NotImplemented
 


### PR DESCRIPTION
#6393 breaks many operations on subclasses of `Array`, since the inherited `__array_function__` no longer considers them to be Dask-supported types.

https://github.com/dask/dask/pull/6393#discussion_r498536767

- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
