### PR TITLE
Ensure HighLevelGraph layers always contain Layer instances

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -211,16 +211,9 @@ class HighLevelGraph(Mapping):
         key_dependencies: Mapping[Hashable, Set] = {},
     ):
         self.__keys = None
+        self.layers = layers
         self.dependencies = dependencies
         self.key_dependencies = key_dependencies
-
-        # Ensure all layers in the HighLevelGraph are Layer instances
-        new_layers = {}
-        for k, v in layers.items():
-            if not isinstance(v, Layer):
-                new_layers[k] = BasicLayer(v)
-        layers.update(new_layers)
-        self.layers = layers
 
     def keyset(self):
         if self.__keys is None:

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -211,9 +211,16 @@ class HighLevelGraph(Mapping):
         key_dependencies: Mapping[Hashable, Set] = {},
     ):
         self.__keys = None
-        self.layers = layers
         self.dependencies = dependencies
         self.key_dependencies = key_dependencies
+
+        # Ensure all layers in the HighLevelGraph are Layer instances
+        new_layers = {}
+        for k, v in layers.items():
+            if not isinstance(v, Layer):
+                new_layers[k] = BasicLayer(v)
+        layers.update(new_layers)
+        self.layers = layers
 
     def keyset(self):
         if self.__keys is None:
@@ -382,14 +389,6 @@ class HighLevelGraph(Mapping):
                     self.key_dependencies[k] = layer.get_dependencies(k, all_keys)
         return self.key_dependencies
 
-    def _fix_hlg_layers_inplace(self):
-        """Makes sure that all layers in hlg are `Layer`"""
-        new_layers = {}
-        for k, v in self.layers.items():
-            if not isinstance(v, Layer):
-                new_layers[k] = BasicLayer(v)
-        self.layers.update(new_layers)
-
     def _toposort_layers(self):
         """Sort the layers in a high level graph topologically
 
@@ -428,7 +427,6 @@ class HighLevelGraph(Mapping):
             Culled high level graph
         """
 
-        self._fix_hlg_layers_inplace()
         layers = self._toposort_layers()
         all_keys = self.keyset()
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -206,7 +206,7 @@ class HighLevelGraph(Mapping):
 
     def __init__(
         self,
-        layers: Mapping[str, Mapping],
+        layers: Mapping[str, Layer],
         dependencies: Mapping[str, Set],
         key_dependencies: Mapping[Hashable, Set] = {},
     ):

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -4,7 +4,7 @@ import pytest
 
 import dask.array as da
 from dask.utils_test import inc
-from dask.highlevelgraph import HighLevelGraph, BasicLayer
+from dask.highlevelgraph import HighLevelGraph, BasicLayer, Layer
 
 
 def test_visualize(tmpdir):
@@ -26,6 +26,7 @@ def test_basic():
     hg = HighLevelGraph(layers, dependencies)
 
     assert dict(hg) == {"x": 1, "y": (inc, "x")}
+    assert all(isinstance(layer, Layer) for layer in hg.layers.values())
 
 
 def test_keys_values_items_methods():


### PR DESCRIPTION
Following up on https://github.com/dask/dask/pull/6707#pullrequestreview-504315552, this PR moves some existing logic into `HighLevelGraph.__init__` to ensure that `HighLevelGraph.layers` is always a mapping from layer names and `Layer` instances. Additionally, since `_fix_hlg_layers_inplace` was only being called in one place, I inlined it in `HighLevelGraph.__init__` instead of keeping a separate method. 

cc @madsbk 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
