### PR TITLE
Fixes for `svd` with `__array_function__`

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -865,9 +865,9 @@ def svd(a, coerce_signs=True):
             ones_like_safe(a._meta, shape=(1, 1), dtype=a._meta.dtype)
         )
         u, s, v = delayed(np.linalg.svd, nout=3)(a, full_matrices=False)
-        u = from_delayed(u, shape=(m, k), dtype=mu.dtype)
-        s = from_delayed(s, shape=(k,), dtype=ms.dtype)
-        v = from_delayed(v, shape=(k, n), dtype=mv.dtype)
+        u = from_delayed(u, shape=(m, k), meta=mu)
+        s = from_delayed(s, shape=(k,), meta=ms)
+        v = from_delayed(v, shape=(k, n), meta=mv)
     # Multi-chunk cases
     else:
         # Tall-and-skinny case

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -109,11 +109,12 @@ def test_array_function_sparse_tensordot():
 
 
 @pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
-def test_array_function_cupy_svd():
+@pytest.mark.parametrize("chunks", [(100, 100), (500, 100)])
+def test_array_function_cupy_svd(chunks):
     cupy = pytest.importorskip("cupy")
     x = cupy.random.random((500, 100))
 
-    y = da.from_array(x, chunks=(100, 100), asarray=False)
+    y = da.from_array(x, chunks=chunks, asarray=False)
 
     u_base, s_base, v_base = da.linalg.svd(y)
     u, s, v = np.linalg.svd(y)

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -386,7 +386,7 @@ def svd_flip(u, v, u_based_decision=False):
     else:
         dtype = v.dtype
         signs = np.sum(v, axis=1, keepdims=True).T
-    signs = dtype.type(2) * ((signs >= 0) - dtype.type(0.5))
+    signs = 2.0 * ((signs >= 0) - 0.5).astype(dtype)
     # Force all singular vectors into same half-space
     u, v = u * signs, v * signs.T
     return u, v


### PR DESCRIPTION
Fixes a couple of small issues that were introduced with `__array_function__`-only cases in the works of #6616 and #6623 .