### PR TITLE
Do balanced rechunking even if chunks are the same.

### DIFF
--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -256,7 +256,7 @@ def rechunk(x, chunks="auto", threshold=None, block_size_limit=None, balance=Fal
     )
 
     # Now chunks are tuple of tuples
-    if chunks == x.chunks:
+    if not balance and (chunks == x.chunks):
         return x
     ndim = x.ndim
     if not len(chunks) == ndim:

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -782,6 +782,16 @@ def test_rechunk_bad_keys():
 def test_balance_basics():
     arr_len = 220
 
+    x = da.from_array(np.arange(arr_len), chunks=100)
+    balanced = x.rechunk(chunks=100, balance=True)
+    unbalanced = x.rechunk(chunks=100, balance=False)
+    assert unbalanced.chunks[0] == (100, 100, 20)
+    assert balanced.chunks[0] == (110, 110)
+
+
+def test_balance_chunks_unchanged():
+    arr_len = 220
+
     x = da.from_array(np.arange(arr_len))
     balanced = x.rechunk(chunks=100, balance=True)
     unbalanced = x.rechunk(chunks=100, balance=False)


### PR DESCRIPTION
The initial chunking may be unbalanced, and specifying the `balance`
argument indicates a desire to balance.

- [ x ] Tests added / passed
- [ x ] Passes `black dask` / `flake8 dask`
