### PR TITLE
Fix meta for min/max reductions

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -313,7 +313,12 @@ def partial_reduce(
             meta = func(reduced_meta, computing_meta=True)
         # no meta keyword argument exists for func, and it isn't required
         except TypeError:
-            meta = func(reduced_meta)
+            try:
+                meta = func(reduced_meta)
+            except ValueError as e:
+                # min/max functions have no identity, don't apply function to meta
+                if "zero-size array to reduction operation" in str(e):
+                    meta = reduced_meta
         # when no work can be computed on the empty array (e.g., func is a ufunc)
         except ValueError:
             pass

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -136,6 +136,60 @@ functions = [
             not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
         ),
     ),
+    pytest.param(
+        lambda x: np.max(x),
+        marks=pytest.mark.skipif(
+            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
+        ),
+    ),
+    pytest.param(
+        lambda x: np.min(x),
+        marks=pytest.mark.skipif(
+            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
+        ),
+    ),
+    pytest.param(
+        lambda x: np.prod(x),
+        marks=pytest.mark.skipif(
+            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
+        ),
+    ),
+    pytest.param(
+        lambda x: np.any(x),
+        marks=pytest.mark.skipif(
+            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
+        ),
+    ),
+    pytest.param(
+        lambda x: np.all(x),
+        marks=pytest.mark.skipif(
+            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
+        ),
+    ),
+    pytest.param(
+        lambda x: np.nansum(x),
+        marks=pytest.mark.skipif(
+            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
+        ),
+    ),
+    pytest.param(
+        lambda x: np.nanprod(x),
+        marks=pytest.mark.skipif(
+            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
+        ),
+    ),
+    pytest.param(
+        lambda x: np.nanmin(x),
+        marks=pytest.mark.skipif(
+            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
+        ),
+    ),
+    pytest.param(
+        lambda x: np.nanmax(x),
+        marks=pytest.mark.skipif(
+            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
+        ),
+    ),
 ]
 
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -138,6 +138,8 @@ def compute_meta(func, _dtype, *args, **kwargs):
                 # min/max functions have no identity, attempt to use the first meta
                 if "zero-size array to reduction operation" in str(e):
                     meta = args_meta[0]
+                else:
+                    return None
             except Exception:
                 return None
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -134,6 +134,10 @@ def compute_meta(func, _dtype, *args, **kwargs):
                     raise
                 else:
                     return None
+            except ValueError as e:
+                # min/max functions have no identity, attempt to use the first meta
+                if "zero-size array to reduction operation" in str(e):
+                    meta = args_meta[0]
             except Exception:
                 return None
 


### PR DESCRIPTION
Fix meta for min/max reductions which prevented output arrays to be of the correct type, e.g., CuPy.