### PR TITLE
Fix docstring `DataFrame.set_index`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3741,6 +3741,7 @@ class DataFrame(_Frame):
         partition_size: int, optional
             Desired size of each partitions in bytes.
             Only used when ``npartition='auto'``
+
         Examples
         --------
         >>> df2 = df.set_index('x')  # doctest: +SKIP


### PR DESCRIPTION
Small fix for a missing line that was causing weird rendering in the docs

qq: is there a flag to skip non-doc CI for docs-only changes?  

- [ ] ~Tests added / passed~
- [x] Passes `black dask` / `flake8 dask`
