### PR TITLE
[WIP] Add read_avro to dask.dataframe

### DIFF
--- a/dask/dataframe/io/__init__.py
+++ b/dask/dataframe/io/__init__.py
@@ -20,3 +20,8 @@ try:
     from .parquet import read_parquet, to_parquet
 except ImportError:
     pass
+
+try:
+    from .avro import read_avro
+except ImportError:
+    pass

--- a/dask/dataframe/io/avro.py
+++ b/dask/dataframe/io/avro.py
@@ -1,0 +1,192 @@
+import pandas as pd
+from ..utils import insert_meta_param_description, make_meta
+
+from fsspec.core import get_fs_token_paths
+from fsspec.utils import stringify_path
+
+from ..core import new_dd_object
+from ...base import tokenize
+from ...utils import natural_sort_key, parse_bytes
+
+try:
+    import fastavro as fa
+except ImportError:
+    fa = None
+
+
+@insert_meta_param_description
+def read_avro(
+    url_path,
+    storage_options=None,
+    blocksize_rows=None,
+    blocksize_bytes="100MB",
+    meta=None,
+    engine=None,
+    index=None,
+    columns=None,
+    divisions=None,
+    **kwargs,
+):
+    """Create a dataframe from a set of Avro files
+
+    Parameters
+    ----------
+    url_path: str, list of str
+        Location to read from. If a string, can include a glob character to
+        find a set of file names.
+        Supports protocol specifications such as ``"s3://"``.
+    storage_options: dict
+        Passed to backend file-system implementation
+    blocksize_rows: None or int
+        If None, files are not blocked, and you get one partition per input
+        file. If int, Avro blocks will be aggregated together for each
+        partition.
+    engine : AvroEngine Class
+        The underlying Engine that dask will use to read the dataset.
+    $META
+
+    Returns
+    -------
+    dask.DataFrame
+    """
+
+    if engine is None:
+        if fa is None:
+            raise ValueError("read_avro requires the fastavro library.")
+        engine = FastAvroEngine
+
+    if hasattr(url_path, "name"):
+        url_path = stringify_path(url_path)
+    fs, _, paths = get_fs_token_paths(
+        url_path, mode="rb", storage_options=storage_options
+    )
+
+    paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
+
+    # Get list of pieces for each output
+    blocksize_bytes = parse_bytes(blocksize_bytes)
+    pieces = engine.process_metadata(
+        fs, paths, index, columns, blocksize_rows, blocksize_bytes, **kwargs
+    )
+    npartitions = len(pieces)
+
+    token = tokenize(fs, paths, index, columns)
+    read_avro_name = "read-avro-partition-" + token
+    dsk = {
+        (read_avro_name, i): (engine.read_partition, fs, piece, index, columns)
+        for i, piece in enumerate(pieces)
+    }
+
+    # Create metadata
+    if meta is None:
+        meta = engine.read_partition(fs, pieces[0], index, columns)
+    meta = make_meta(meta)
+
+    # Create collection
+    if divisions is None or divisions == "sorted":
+        divs = [None] * (npartitions + 1)
+    else:
+        divs = tuple(divisions)
+        if len(divs) != npartitions + 1:
+            raise ValueError("divisions should be a tuple of npartitions + 1")
+    df = new_dd_object(dsk, read_avro_name, meta, divs)
+
+    # Sort divisions if necessary
+    if divisions == "sorted":
+        from ..shuffle import compute_and_set_divisions
+
+        df = compute_and_set_divisions(df)
+
+    return df
+
+
+class AvroEngine:
+    """ The API necessary to provide a new Avro reader/writer """
+
+    @classmethod
+    def process_metadata(
+        cls, fs, paths, index, columns, blocksize, blocksize_bytes, **kwargs
+    ):
+        raise NotImplementedError()
+
+    @classmethod
+    def read_partition(cls, fs, piece, index, columns):
+        raise NotImplementedError()
+
+
+class FastAvroEngine(AvroEngine):
+    @classmethod
+    def process_metadata(
+        cls, fs, paths, index, columns, blocksize_rows, blocksize_bytes, **kwargs
+    ):
+
+        sizes = []
+        for path in paths:
+            size = 0
+            with fs.open(path, "rb") as fo:
+                avro_reader = fa.block_reader(fo)
+                for block in avro_reader:
+                    n = block.num_records
+                    size += n
+                    if blocksize_rows is None:
+                        # Use first avro block to estimate memory req
+                        # for each row
+                        row_mem = (
+                            pd.DataFrame.from_records(list(block))
+                            .memory_usage(deep=True)
+                            .sum()
+                            / n
+                        )
+                        blocksize_rows = int(blocksize_bytes // row_mem)
+            sizes.append(size)
+
+        pieces = []
+        if blocksize_rows >= max(sizes):
+            # Map entire file to each partition
+            # TODO: Handle many small files.
+            for path in paths:
+                pieces.append((path, None, None, None))
+        else:
+            # Break apart files at the "Avro block" granularity
+            for path in paths:
+                global_offset = part_offset = part_records = part_blocks = 0
+                with fs.open(path, "rb") as fo:
+                    avro_reader = fa.block_reader(fo)
+                    for i, block in enumerate(avro_reader):
+                        n = block.num_records
+                        if part_records + n >= blocksize_rows:
+                            pieces.append(
+                                (path, part_offset, part_records, part_blocks)
+                            )
+                            part_records = part_blocks = 0
+                            part_offset = global_offset + n
+                        else:
+                            part_records += n
+                            part_blocks += 1
+                        global_offset += n
+                    if part_blocks:
+                        pieces.append((path, part_offset, part_records, part_blocks))
+
+        # `pieces` is a list with the following tuple elements:
+        # (<file-path>, <record-index-offset>, <record-count>, <block-count>)
+        #
+        # Note: If only the file-path is not None, the entire file
+        #       should be read.
+
+        return pieces
+
+    @classmethod
+    def read_partition(cls, fs, piece, index, columns):
+
+        path, part_offset, part_records, part_blocks = piece
+
+        if False:  # part_blocks:
+            pass
+        else:
+            reader = fa.reader(fs.open(path, "rb"))
+            df = pd.DataFrame.from_records(reader)
+            if index:
+                df.set_index(index, inplace=True)
+            if columns is None:
+                columns = list(df.columns)
+            return df[columns]

--- a/dask/dataframe/io/avro.py
+++ b/dask/dataframe/io/avro.py
@@ -25,7 +25,6 @@ def read_avro(
     index=None,
     columns=None,
     divisions=None,
-    **kwargs,
 ):
     """Create a dataframe from a set of Avro files
 
@@ -80,7 +79,6 @@ def read_avro(
         columns=columns,
         split_blocks=split_blocks,
         chunksize=chunksize,
-        **kwargs,
     )
     npartitions = len(pieces)
 
@@ -125,7 +123,13 @@ class AvroEngine:
 
     @classmethod
     def process_metadata(
-        cls, fs, paths, index, columns, blocksize, blocksize_bytes, **kwargs
+        cls,
+        fs,
+        paths,
+        index=None,
+        columns=None,
+        split_blocks=True,
+        chunksize=None,
     ):
         raise NotImplementedError()
 
@@ -142,9 +146,8 @@ class FastAvroEngine(AvroEngine):
         paths,
         index=None,
         columns=None,
-        split_blocks=True,  # Whether to split by avro blocks
-        chunksize=None,  # Target partition size (in bytes)
-        **kwargs,
+        split_blocks=True,
+        chunksize=None,
     ):
         chunksize = parse_bytes(chunksize or "100MB")
         if split_blocks:

--- a/dask/dataframe/io/avro.py
+++ b/dask/dataframe/io/avro.py
@@ -23,7 +23,7 @@ _ENGINES = {}
 
 
 def get_engine(engine):
-    """Get the parquet engine backend implementation.
+    """Get the avro engine backend implementation.
 
     Parameters
     ----------

--- a/dask/dataframe/io/avro.py
+++ b/dask/dataframe/io/avro.py
@@ -122,7 +122,7 @@ def read_avro(
     )
     npartitions = len(pieces)
 
-    # `pieces` is a list with the following dict (possible) elements:
+    # `pieces` is a list with the following dict elements:
     # {
     #    "path" : <file-path>,
     #    "rows" : (<file-row-offset>, <row-count>),

--- a/dask/dataframe/io/avro.py
+++ b/dask/dataframe/io/avro.py
@@ -72,7 +72,7 @@ def read_avro(
     storage_options=None,
     blocksize=None,
     meta=None,
-    engine=None,
+    engine="auto",
     index=None,
     columns=None,
     divisions=None,

--- a/dask/dataframe/io/tests/test_avro.py
+++ b/dask/dataframe/io/tests/test_avro.py
@@ -1,0 +1,85 @@
+import os
+
+# import pandas as pd
+import numpy as np
+import pytest
+
+import dask.dataframe as dd
+
+# from dask.dataframe.utils import assert_eq
+
+try:
+    import fastavro as fa
+except ImportError:
+    fa = None
+
+name_list = [
+    "Alice",
+    "Bob",
+    "Charlie",
+    "Dan",
+    "Edith",
+    "Frank",
+    "George",
+    "Hannah",
+    "Ingrid",
+    "Jerry",
+    "Kevin",
+    "Laura",
+    "Michael",
+    "Norbert",
+    "Oliver",
+    "Patricia",
+    "Quinn",
+    "Ray",
+    "Sarah",
+    "Tim",
+    "Ursula",
+    "Victor",
+    "Wendy",
+    "Xavier",
+    "Yvonne",
+    "Zelda",
+]
+
+
+@pytest.mark.parametrize("blocksize", [1, 100, 1000])
+def test_read_avro_basic(tmpdir, blocksize):
+
+    pytest.importorskip("fastavro")
+
+    schema = fa.parse_schema(
+        {
+            "name": "avro.example.User",
+            "type": "record",
+            "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "age", "type": "int"},
+            ],
+        }
+    )
+
+    size = 1_000_000
+    nblocks = 0
+    nrecords = 0
+    paths = [
+        os.path.join(str(tmpdir), "test.0.avro"),
+        os.path.join(str(tmpdir), "test.1.avro"),
+    ]
+
+    for path in paths:
+        names = np.random.choice(name_list, size)
+        ages = np.random.randint(18, 100, size)
+        data = [{"name": names[i], "age": ages[i]} for i in range(size)]
+        with open(path, "wb") as f:
+            fa.writer(f, schema, data)
+        with open(path, "rb") as fo:
+            avro_reader = fa.block_reader(fo)
+            for block in avro_reader:
+                nrecords += block.num_records
+                nblocks += 1
+
+    dd.io.avro.read_avro(paths)
+
+    # print(nblocks, nrecords)
+    # assert_eq(out, df)

--- a/dask/dataframe/io/tests/test_avro.py
+++ b/dask/dataframe/io/tests/test_avro.py
@@ -16,7 +16,7 @@ except ImportError:
 
 
 @pytest.mark.parametrize("chunksize", [None, "1KB"])
-@pytest.mark.parametrize("split_blocks", [None, True, False])
+@pytest.mark.parametrize("split_blocks", [True, False])
 @pytest.mark.parametrize("size", [100, 10_000])
 def test_read_avro_basic(tmpdir, chunksize, size, split_blocks):
     # Require fastavro library
@@ -60,7 +60,7 @@ def test_read_avro_basic(tmpdir, chunksize, size, split_blocks):
     df = dd.io.avro.read_avro(paths, chunksize=chunksize, split_blocks=split_blocks)
 
     # Check basic length and partition count
-    if split_blocks is True:
+    if split_blocks is True and chunksize == "1KB":
         assert df.npartitions == nblocks
     assert len(df) == nrecords
 

--- a/dask/dataframe/io/tests/test_avro.py
+++ b/dask/dataframe/io/tests/test_avro.py
@@ -17,7 +17,7 @@ except ImportError:
 
 @pytest.mark.parametrize("chunksize", [None, "1KB"])
 @pytest.mark.parametrize("split_blocks", [True, False])
-@pytest.mark.parametrize("size", [100, 10_000])
+@pytest.mark.parametrize("size", [100, 1000])
 def test_read_avro_basic(tmpdir, chunksize, size, split_blocks):
     # Require fastavro library
     pytest.importorskip("fastavro")

--- a/dask/dataframe/io/tests/test_avro.py
+++ b/dask/dataframe/io/tests/test_avro.py
@@ -1,53 +1,28 @@
 import os
 
-# import pandas as pd
+import pandas as pd
 import numpy as np
 import pytest
 
 import dask.dataframe as dd
 
-# from dask.dataframe.utils import assert_eq
+from dask.dataframe.utils import assert_eq
+from dask.dataframe.io.demo import names as name_list
 
 try:
     import fastavro as fa
 except ImportError:
     fa = None
 
-name_list = [
-    "Alice",
-    "Bob",
-    "Charlie",
-    "Dan",
-    "Edith",
-    "Frank",
-    "George",
-    "Hannah",
-    "Ingrid",
-    "Jerry",
-    "Kevin",
-    "Laura",
-    "Michael",
-    "Norbert",
-    "Oliver",
-    "Patricia",
-    "Quinn",
-    "Ray",
-    "Sarah",
-    "Tim",
-    "Ursula",
-    "Victor",
-    "Wendy",
-    "Xavier",
-    "Yvonne",
-    "Zelda",
-]
 
-
-@pytest.mark.parametrize("blocksize", [1, 100, 1000])
-def test_read_avro_basic(tmpdir, blocksize):
-
+@pytest.mark.parametrize("chunksize", [None, "1KB"])
+@pytest.mark.parametrize("split_blocks", [None, True, False])
+@pytest.mark.parametrize("size", [100, 10_000])
+def test_read_avro_basic(tmpdir, chunksize, size, split_blocks):
+    # Require fastavro library
     pytest.importorskip("fastavro")
 
+    # Define avro schema
     schema = fa.parse_schema(
         {
             "name": "avro.example.User",
@@ -59,14 +34,15 @@ def test_read_avro_basic(tmpdir, blocksize):
         }
     )
 
-    size = 1_000_000
+    # Write avro dataset with two files.
+    # Collect block and record (row) count while writing.
     nblocks = 0
     nrecords = 0
     paths = [
         os.path.join(str(tmpdir), "test.0.avro"),
         os.path.join(str(tmpdir), "test.1.avro"),
     ]
-
+    records = []
     for path in paths:
         names = np.random.choice(name_list, size)
         ages = np.random.randint(18, 100, size)
@@ -78,8 +54,16 @@ def test_read_avro_basic(tmpdir, blocksize):
             for block in avro_reader:
                 nrecords += block.num_records
                 nblocks += 1
+                records += list(block)
 
-    dd.io.avro.read_avro(paths)
+    # Read back with dask.dataframe
+    df = dd.io.avro.read_avro(paths, chunksize=chunksize, split_blocks=split_blocks)
 
-    # print(nblocks, nrecords)
-    # assert_eq(out, df)
+    # Check basic length and partition count
+    if split_blocks is True:
+        assert df.npartitions == nblocks
+    assert len(df) == nrecords
+
+    # Full comparison
+    expect = pd.DataFrame.from_records(records)
+    assert_eq(df.compute(scheduler="synchronous").reset_index(drop=True), expect)

--- a/dask/dataframe/io/tests/test_avro.py
+++ b/dask/dataframe/io/tests/test_avro.py
@@ -16,7 +16,7 @@ except ImportError:
 
 
 @pytest.mark.parametrize("blocksize", [None, "1KB", False])
-@pytest.mark.parametrize("size", [100, 1000])
+@pytest.mark.parametrize("size", [100, 4000])
 @pytest.mark.parametrize("nfiles", [1, 2])
 @pytest.mark.parametrize("engine", ["uavro", "fastavro"])
 def test_read_avro_basic(tmpdir, blocksize, size, nfiles, engine):


### PR DESCRIPTION
There has been [interest](https://github.com/rapidsai/cudf/issues/6496) by users of dask-cudf to have Avro support in Dask.  This PR includes a simple `read_avro` implementation, using the [fastavro](https://fastavro.readthedocs.io/en/latest/) library.

@dask/io - This design allows the output partitioning to be comprised of groups of avro "blocks" or entire files.  Please do feel free to advise, or to ping people who may have real-world avro knowledge.  I am personally new to the format, and it is not clear to be if there are beter library and/or decompositions methods I should focus on.

@albert17 - I have confirmed that this design works with the cudf avro reader as well (you just need to define your own engine that overrides the `FastAvroEngine.read_partition` logic to use cudf).

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
