### PR TITLE
Bugfix for parquet metadata writes of empty dataframe partitions (pyarrow) 

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1015,6 +1015,7 @@ class ArrowEngine(Engine):
 
     @staticmethod
     def write_metadata(parts, fmd, fs, path, append=False, **kwargs):
+        parts = [p for p in parts if p[0]["meta"] is not None]
         if parts:
             if not append:
                 # Get only arguments specified in the function

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2783,8 +2783,12 @@ def test_parquet_pyarrow_write_empty_metadata(tmpdir):
     df_a = dask.delayed(pd.DataFrame.from_dict)(
         {"x": [], "y": []}, dtype=("int", "int")
     )
-    df_b = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 1, 2, 2], "y": [1, 0, 1, 0]}, dtype=("int64", "int64"))
-    df_c = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 2, 1, 2], "y": [1, 0, 1, 0]}, dtype=("int64", "int64"))
+    df_b = dask.delayed(pd.DataFrame.from_dict)(
+        {"x": [1, 1, 2, 2], "y": [1, 0, 1, 0]}, dtype=("int64", "int64")
+    )
+    df_c = dask.delayed(pd.DataFrame.from_dict)(
+        {"x": [1, 2, 1, 2], "y": [1, 0, 1, 0]}, dtype=("int64", "int64")
+    )
 
     df = dd.from_delayed([df_a, df_b, df_c])
 
@@ -2805,8 +2809,12 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
     # https://github.com/dask/dask/issues/6600
     tmpdir = str(tmpdir)
 
-    df_a = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 1, 2, 2], "y": [1, 0, 1, 0]}, dtype=("int64", "int64"))
-    df_b = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 2, 1, 2], "y": [2, 0, 2, 0]}, dtype=("int64", "int64"))
+    df_a = dask.delayed(pd.DataFrame.from_dict)(
+        {"x": [1, 1, 2, 2], "y": [1, 0, 1, 0]}, dtype=("int64", "int64")
+    )
+    df_b = dask.delayed(pd.DataFrame.from_dict)(
+        {"x": [1, 2, 1, 2], "y": [2, 0, 2, 0]}, dtype=("int64", "int64")
+    )
 
     df1 = dd.from_delayed([df_a, df_b])
     df1.to_parquet(
@@ -2820,7 +2828,9 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
     df_c = dask.delayed(pd.DataFrame.from_dict)(
         {"x": [], "y": []}, dtype=("int64", "int64")
     )
-    df_d = dask.delayed(pd.DataFrame.from_dict)({"x": [3, 3, 4, 4], "y": [1, 0, 1, 0]}, dtype=("int64", "int64"))
+    df_d = dask.delayed(pd.DataFrame.from_dict)(
+        {"x": [3, 3, 4, 4], "y": [1, 0, 1, 0]}, dtype=("int64", "int64")
+    )
 
     df2 = dd.from_delayed([df_c, df_d])
     df2.to_parquet(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2774,3 +2774,52 @@ def test_divisions_with_null_partition(tmpdir, engine):
 
     ddf_read = dd.read_parquet(str(tmpdir), engine=engine, index="a")
     assert ddf_read.divisions == (None, None, None)
+
+
+def test_parquet_pyarrow_write_empty_metadata(tmpdir):
+    dd = pytest.importorskip("dask.dataframe")
+    pd = pytest.importorskip("pandas")
+
+    df_a = dask.delayed(pd.DataFrame.from_dict)({"x": [], "y": []}, dtype=("int", "int"))
+    df_b = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 1, 2, 2], "y": [1, 0, 1, 0]})
+    df_c = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 2, 1, 2], "y": [1, 0, 1, 0]})
+
+    df = dd.from_delayed([df_a, df_b, df_c])
+
+    df.to_parquet(
+        tmpdir,
+        engine="pyarrow",
+        partition_on=["x"],
+        append=False,
+        compute_kwargs={"scheduler": "synchronous"},
+    )
+
+
+def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
+    dd = pytest.importorskip("dask.dataframe")
+    pd = pytest.importorskip("pandas")
+
+    df_a = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 1, 2, 2], "y": [1, 0, 1, 0]})
+    df_b = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 2, 1, 2], "y": [2, 0, 2, 0]})
+
+    df1 = dd.from_delayed([df_a, df_b])
+    df1.to_parquet(
+        tmpdir,
+        engine="pyarrow",
+        partition_on=["x"],
+        append=False,
+        compute_kwargs={"scheduler": "synchronous"},
+    )
+
+    df_c = dask.delayed(pd.DataFrame.from_dict)({"x": [], "y": []}, dtype=("int", "int"))
+    df_d = dask.delayed(pd.DataFrame.from_dict)({"x": [3, 3, 4, 4], "y": [1, 0, 1, 0]})
+
+    df2 = dd.from_delayed([df_c, df_d])
+    df2.to_parquet(
+        tmpdir,
+        engine="pyarrow",
+        partition_on=["x"],
+        append=True,
+        ignore_divisions=True,
+        compute_kwargs={"scheduler": "synchronous"},
+    )

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2778,16 +2778,13 @@ def test_divisions_with_null_partition(tmpdir, engine):
 
 def test_parquet_pyarrow_write_empty_metadata(tmpdir):
     # https://github.com/dask/dask/issues/6600
-    dd = pytest.importorskip("dask.dataframe")
-    pd = pytest.importorskip("pandas")
-
     tmpdir = str(tmpdir)
 
     df_a = dask.delayed(pd.DataFrame.from_dict)(
         {"x": [], "y": []}, dtype=("int", "int")
     )
-    df_b = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 1, 2, 2], "y": [1, 0, 1, 0]})
-    df_c = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 2, 1, 2], "y": [1, 0, 1, 0]})
+    df_b = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 1, 2, 2], "y": [1, 0, 1, 0]}, dtype=("int64", "int64"))
+    df_c = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 2, 1, 2], "y": [1, 0, 1, 0]}, dtype=("int64", "int64"))
 
     df = dd.from_delayed([df_a, df_b, df_c])
 
@@ -2806,13 +2803,10 @@ def test_parquet_pyarrow_write_empty_metadata(tmpdir):
 
 def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
     # https://github.com/dask/dask/issues/6600
-    dd = pytest.importorskip("dask.dataframe")
-    pd = pytest.importorskip("pandas")
-
     tmpdir = str(tmpdir)
 
-    df_a = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 1, 2, 2], "y": [1, 0, 1, 0]})
-    df_b = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 2, 1, 2], "y": [2, 0, 2, 0]})
+    df_a = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 1, 2, 2], "y": [1, 0, 1, 0]}, dtype=("int64", "int64"))
+    df_b = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 2, 1, 2], "y": [2, 0, 2, 0]}, dtype=("int64", "int64"))
 
     df1 = dd.from_delayed([df_a, df_b])
     df1.to_parquet(
@@ -2824,9 +2818,9 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
     )
 
     df_c = dask.delayed(pd.DataFrame.from_dict)(
-        {"x": [], "y": []}, dtype=("int", "int")
+        {"x": [], "y": []}, dtype=("int64", "int64")
     )
-    df_d = dask.delayed(pd.DataFrame.from_dict)({"x": [3, 3, 4, 4], "y": [1, 0, 1, 0]})
+    df_d = dask.delayed(pd.DataFrame.from_dict)({"x": [3, 3, 4, 4], "y": [1, 0, 1, 0]}, dtype=("int64", "int64"))
 
     df2 = dd.from_delayed([df_c, df_d])
     df2.to_parquet(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2783,7 +2783,9 @@ def test_parquet_pyarrow_write_empty_metadata(tmpdir):
 
     tmpdir = str(tmpdir)
 
-    df_a = dask.delayed(pd.DataFrame.from_dict)({"x": [], "y": []}, dtype=("int", "int"))
+    df_a = dask.delayed(pd.DataFrame.from_dict)(
+        {"x": [], "y": []}, dtype=("int", "int")
+    )
     df_b = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 1, 2, 2], "y": [1, 0, 1, 0]})
     df_c = dask.delayed(pd.DataFrame.from_dict)({"x": [1, 2, 1, 2], "y": [1, 0, 1, 0]})
 
@@ -2821,7 +2823,9 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
         compute_kwargs={"scheduler": "synchronous"},
     )
 
-    df_c = dask.delayed(pd.DataFrame.from_dict)({"x": [], "y": []}, dtype=("int", "int"))
+    df_c = dask.delayed(pd.DataFrame.from_dict)(
+        {"x": [], "y": []}, dtype=("int", "int")
+    )
     df_d = dask.delayed(pd.DataFrame.from_dict)({"x": [3, 3, 4, 4], "y": [1, 0, 1, 0]})
 
     df2 = dd.from_delayed([df_c, df_d])
@@ -2833,4 +2837,3 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
         ignore_divisions=True,
         compute_kwargs={"scheduler": "synchronous"},
     )
-

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2798,7 +2798,6 @@ def test_parquet_pyarrow_write_empty_metadata(tmpdir):
             engine="pyarrow",
             partition_on=["x"],
             append=False,
-            compute_kwargs={"scheduler": "synchronous"},
         )
 
     except AttributeError:
@@ -2822,7 +2821,6 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
         engine="pyarrow",
         partition_on=["x"],
         append=False,
-        compute_kwargs={"scheduler": "synchronous"},
     )
 
     df_c = dask.delayed(pd.DataFrame.from_dict)(
@@ -2839,5 +2837,4 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
         partition_on=["x"],
         append=True,
         ignore_divisions=True,
-        compute_kwargs={"scheduler": "synchronous"},
     )


### PR DESCRIPTION
Attempting to write metadata for empty dataframe partitions with `to_parquet` (pyarrow impl.) can raise unintended exceptions or cause segfaults.

This PR filters out `None` meta data elements generated by `write_partition` that cause the issues. Unit tests cases demonstrating the current issue are included.

More details in the following comment https://github.com/dask/dask/issues/6600#issuecomment-710041237
