### PR TITLE
Add attrs property to Series/Dataframe

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -339,7 +339,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
     @attrs.setter
     def attrs(self, value):
         self._meta.attrs = dict(value)
-        
+
     @property
     def size(self):
         """Size of the Series or DataFrame as a Delayed object.

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -332,6 +332,15 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
         return len(self.divisions) - 1
 
     @property
+    def attrs(self):
+        """Return a dictionary storing arbitrary metadata."""
+        return self._meta.attrs
+
+    @attrs.setter
+    def attrs(self, value):
+        self._meta.attrs = dict(value)
+        
+    @property
     def size(self):
         """Size of the Series or DataFrame as a Delayed object.
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -332,8 +332,8 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
         return len(self.divisions) - 1
 
     @property
+    @derived_from(pd.DataFrame)
     def attrs(self):
-        """Return a dictionary storing arbitrary metadata."""
         return self._meta.attrs
 
     @attrs.setter

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4441,4 +4441,4 @@ def test_attrs():
     assert df.abs().attrs == ddf.abs().attrs
 
     # Series:
-    assert df.A.attrs == ddf.A.attrs
+    # assert df.A.attrs == ddf.A.attrs

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4429,11 +4429,12 @@ def test_fuse_roots():
     res = ddf1.where(ddf2)
     hlg = fuse_roots(res.__dask_graph__(), keys=res.__dask_keys__())
     hlg.validate()
-    
+
+
 def test_attrs():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
-    df.attrs = {'date': '2020-10-16'}
-    df.A.attrs['unit'] = 'kg'
+    df.attrs = {"date": "2020-10-16"}
+    df.A.attrs["unit"] = "kg"
     ddf = dd.from_pandas(df, 2)
 
     # Dataframe:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4429,3 +4429,16 @@ def test_fuse_roots():
     res = ddf1.where(ddf2)
     hlg = fuse_roots(res.__dask_graph__(), keys=res.__dask_keys__())
     hlg.validate()
+    
+def test_attrs():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
+    df.attrs = {'date': '2020-10-16'}
+    df.A.attrs['unit'] = 'kg'
+    ddf = dd.from_pandas(df, 2)
+
+    # Dataframe:
+    assert df.attrs == ddf.attrs
+    assert df.abs().attrs == ddf.abs().attrs
+
+    # Series:
+    assert df.A.attrs == ddf.A.attrs

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4431,7 +4431,7 @@ def test_fuse_roots():
     hlg.validate()
 
 
-@pytest.mark.skipif(PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0")
+@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="attrs intro]duced in 1.0.0")
 def test_attrs_dataframe():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
     df.attrs = {"date": "2020-10-16"}

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4431,6 +4431,9 @@ def test_fuse_roots():
     hlg.validate()
 
 
+@pytest.mark.skipif(
+    PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0"
+)
 def test_attrs_dataframe():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
     df.attrs = {"date": "2020-10-16"}
@@ -4440,6 +4443,9 @@ def test_attrs_dataframe():
     assert df.abs().attrs == ddf.abs().attrs
 
 
+@pytest.mark.skipif(
+    PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0"
+)
 def test_attrs_series():
     s = pd.Series([1, 2], name="A")
     s.attrs["unit"] = "kg"
@@ -4449,6 +4455,9 @@ def test_attrs_series():
     assert s.fillna(1).attrs == ds.fillna(1).attrs
 
 
+@pytest.mark.skipif(
+    PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0"
+)
 @pytest.mark.xfail(reason="df.iloc[:0] does not keep the series attrs")
 def test_attrs_series_in_dataframes():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4431,7 +4431,7 @@ def test_fuse_roots():
     hlg.validate()
 
 
-@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="attrs intro]duced in 1.0.0")
+@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="attrs introduced in 1.0.0")
 def test_attrs_dataframe():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
     df.attrs = {"date": "2020-10-16"}
@@ -4441,7 +4441,7 @@ def test_attrs_dataframe():
     assert df.abs().attrs == ddf.abs().attrs
 
 
-@pytest.mark.skipif(PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0")
+@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="attrs introduced in 1.0.0")
 def test_attrs_series():
     s = pd.Series([1, 2], name="A")
     s.attrs["unit"] = "kg"
@@ -4451,7 +4451,7 @@ def test_attrs_series():
     assert s.fillna(1).attrs == ds.fillna(1).attrs
 
 
-@pytest.mark.skipif(PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0")
+@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="attrs introduced in 1.0.0")
 @pytest.mark.xfail(reason="df.iloc[:0] does not keep the series attrs")
 def test_attrs_series_in_dataframes():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4431,9 +4431,7 @@ def test_fuse_roots():
     hlg.validate()
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0"
-)
+@pytest.mark.skipif(PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0")
 def test_attrs_dataframe():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
     df.attrs = {"date": "2020-10-16"}
@@ -4443,9 +4441,7 @@ def test_attrs_dataframe():
     assert df.abs().attrs == ddf.abs().attrs
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0"
-)
+@pytest.mark.skipif(PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0")
 def test_attrs_series():
     s = pd.Series([1, 2], name="A")
     s.attrs["unit"] = "kg"
@@ -4455,9 +4451,7 @@ def test_attrs_series():
     assert s.fillna(1).attrs == ds.fillna(1).attrs
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0"
-)
+@pytest.mark.skipif(PANDAS_VERSION < "1.0.0", reason="attrs introduced in 1.0.0")
 @pytest.mark.xfail(reason="df.iloc[:0] does not keep the series attrs")
 def test_attrs_series_in_dataframes():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -398,6 +398,7 @@ def meta_nonempty_dataframe(x):
         data[i] = dt_s_dict[dt]
     res = pd.DataFrame(data, index=idx, columns=np.arange(len(x.columns)))
     res.columns = x.columns
+    res.attrs = x.attrs
     return res
 
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -587,7 +587,9 @@ def _nonempty_series(s, idx=None):
         entry = _scalar_from_dtype(dtype)
         data = np.array([entry, entry], dtype=dtype)
 
-    return pd.Series(data, name=s.name, index=idx)
+    out = pd.Series(data, name=s.name, index=idx)
+    out.attrs = s.attrs
+    return out
 
 
 def is_dataframe_like(df):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -398,7 +398,8 @@ def meta_nonempty_dataframe(x):
         data[i] = dt_s_dict[dt]
     res = pd.DataFrame(data, index=idx, columns=np.arange(len(x.columns)))
     res.columns = x.columns
-    res.attrs = x.attrs
+    if PANDAS_GT_100:
+        res.attrs = x.attrs
     return res
 
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -589,7 +589,8 @@ def _nonempty_series(s, idx=None):
         data = np.array([entry, entry], dtype=dtype)
 
     out = pd.Series(data, name=s.name, index=idx)
-    out.attrs = s.attrs
+    if PANDAS_GT_100:
+        out.attrs = s.attrs
     return out
 
 


### PR DESCRIPTION
Pandas has a property called `attrs` that supports attaching arbitrary metadata, such as physical units, to DataFrames and persisting it across operations. I've added support for that property in the dask Series/Dataframe as well. 

The `attrs` doesn't work that great with dask series because the pandas `iloc` method doesn't currently persist the `attrs` dict. Because dask uses `df.iloc` when creating the _meta dataframe in `make_meta_pandas(x, index=None)` the attrs of all the series are therefore lost.

I've added some simple tests that passes the dataframe tests but fails when testing series. It shouldn't once iloc persists the attrs dict but I find this important enough to be reminded by the failing tests.

- [x]  Closes #6730
