### PR TITLE
Avoid rechunking in reshape with chunksize=1

### DIFF
--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -46,7 +46,8 @@ def reshape_rechunk(inshape, outshape, inchunks):
             # Special case to avoid intermediate rechunking:
             # When all the lower axis are completely chunked (chunksize=1) then
             # we're simply moving around blocks.
-            if all(len(inchunks[i]) == inshape[i] for i in range(ileft + 1)):
+            # breakpoint()
+            if all(len(inchunks[i]) == inshape[i] for i in range(ii)):
                 for i in range(ii + 1):
                     result_inchunks[i] = inchunks[i]
                 result_outchunks[oi] = inchunks[i] * np.prod(

--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -46,7 +46,6 @@ def reshape_rechunk(inshape, outshape, inchunks):
             # Special case to avoid intermediate rechunking:
             # When all the lower axis are completely chunked (chunksize=1) then
             # we're simply moving around blocks.
-            # breakpoint()
             if all(len(inchunks[i]) == inshape[i] for i in range(ii)):
                 for i in range(ii + 1):
                     result_inchunks[i] = inchunks[i]

--- a/dask/array/tests/test_reshape.py
+++ b/dask/array/tests/test_reshape.py
@@ -104,6 +104,8 @@ def test_reshape_unknown_sizes():
         ),
         # (2, 2, 3, 4) -> (4, 3, 4)
         ((2, 2, 3, 4), ((1, 1), (2,), (1, 2), (4,)), (4, 3, 4), ((2, 2), (1, 2), (4,))),
+        # (2, 3, 4) -> (24,).
+        ((2, 3, 4), ((1, 1), (1, 1, 1), (2, 2)), (24,), ((2,) * 12,)),
     ],
 )
 def test_reshape_all_chunked_no_merge(inshape, inchunks, outshape, outchunks):

--- a/dask/array/tests/test_reshape.py
+++ b/dask/array/tests/test_reshape.py
@@ -109,7 +109,8 @@ def test_reshape_unknown_sizes():
 def test_reshape_all_chunked_no_merge(inshape, inchunks, outshape, outchunks):
     # https://github.com/dask/dask/issues/5544#issuecomment-712280433
     # When the early axes are completely chunked then we are just moving blocks
-    # and can avoid any rechunking. The outchunks will always be ...
+    # and can avoid any rechunking. The result inchunks are the same as the
+    # input chunks.
     base = np.arange(np.prod(inshape)).reshape(inshape)
     a = da.from_array(base, chunks=inchunks)
 


### PR DESCRIPTION
When the slow-moving (early) axes in `.reshape` are all size 1, then we
can avoid an intermediate rechunk which could cause memory issues.

This is demonstrated in reshape a `(2, 3, 4)` array -> `(6, 4)`

```python
In [3]: a = da.from_array(np.arange(24).reshape(2, 3, 4), chunks=((1, 1), (1, 2), (2, 2)))
   ...: a.reshape(6, 4)
```

The "ideal" (zero communication) chunking is given by:

```
00 01 | 02 03   # a[0, :, :]
----- | -----
04 05 | 06 07
08 09 | 10 11

=============

12 13 | 14 15   # a[1, :, :]
----- | -----
16 17 | 18 19
20 21 | 22 23

-> (6, 4)

00 01 | 02 03
----- | -----
04 05 | 06 07
08 09 | 10 11
----- | -----
12 13 | 14 15
----- | -----
16 17 | 18 19
20 21 | 22 23
```

Previously, that merged the intermediates and had the result chunks

```python
Out[2]: ((3, 3), (2, 2))
```

![master](https://user-images.githubusercontent.com/1312546/96494556-2388af80-120c-11eb-8ead-3be9e50ab86e.png)


Now we have the result chunks


```python
Out[2]: ((1, 2, 1, 2), (2, 2))
```

![pr](https://user-images.githubusercontent.com/1312546/96494574-2a172700-120c-11eb-81d0-2a1b8a33add7.png)


This doesn't remove the need for something like https://github.com/dask/dask/issues/6272, since it only handles the special case of the low axes having `chunksize=1`.  But we also don't need a keyword for this since this implementation should be strictly better than the old one for this special case. There's no tradeoff between number of tasks and data movement when the input is already fully chunked along the low axes..

xref https://github.com/dask/dask/issues/5544, specifically the examples
given in https://github.com/dask/dask/issues/5544#issuecomment-593723196.