### PR TITLE
Add 2D possibility to da.linalg.lstsq, mirroring numpy

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -1309,17 +1309,21 @@ def lstsq(a, b):
     ----------
     a : (M, N) array_like
         "Coefficient" matrix.
-    b : (M,) array_like
-        Ordinate or "dependent variable" values.
+    b : {(M,), (M, K)} array_like
+        Ordinate or "dependent variable" values. If `b` is two-dimensional,
+        the least-squares solution is calculated for each of the `K` columns
+        of `b`.
 
     Returns
     -------
-    x : (N,) Array
+    x : {(N,), (N, K)} Array
         Least-squares solution. If `b` is two-dimensional,
         the solutions are in the `K` columns of `x`.
-    residuals : (1,) Array
+    residuals : {(1,), (K,)} Array
         Sums of residuals; squared Euclidean 2-norm for each column in
         ``b - a*x``.
+        If `b` is 1-dimensional, this is a (1,) shape array.
+        Otherwise the shape is (K,).
     rank : Array
         Rank of matrix `a`.
     s : (min(M, N),) Array
@@ -1328,7 +1332,7 @@ def lstsq(a, b):
     q, r = qr(a)
     x = solve_triangular(r, q.T.dot(b))
     residuals = b - a.dot(x)
-    residuals = (residuals ** 2).sum(keepdims=True)
+    residuals = (residuals ** 2).sum(axis=0, keepdims=b.ndim == 1)
 
     token = tokenize(a, b)
 

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -818,6 +818,19 @@ def test_lstsq(nrow, ncol, chunk):
     dx, dr, drank, ds = da.linalg.lstsq(dA, db)
     assert drank.compute() == rank
 
+    # 2D case
+    A = np.random.randint(1, 20, (nrow, ncol))
+    b2D = np.random.randint(1, 20, (nrow, ncol // 2))
+    dA = da.from_array(A, (chunk, ncol))
+    db2D = da.from_array(b2D, (chunk, ncol // 2))
+    x, r, rank, s = np.linalg.lstsq(A, b2D, rcond=-1)
+    dx, dr, drank, ds = da.linalg.lstsq(dA, db2D)
+
+    assert_eq(dx, x)
+    assert_eq(dr, r)
+    assert drank.compute() == rank
+    assert_eq(ds, s)
+
 
 def test_no_chunks_svd():
     x = np.random.random((100, 10))


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
Fixes  #6516.  Two months ago I said "I can fix it this week", but here we are anyway.

This simply modifies the way residuals are compute so `dask.array.linalg.lstsq(a,b)` can handle the case where `b` is bidimensional, mirroring the behaviour of `np.linalg.lstsq`. The doc was also updated.