### PR TITLE
Config array optimize to skip fusion and return a HLG

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -3,7 +3,7 @@ from operator import getitem
 
 import numpy as np
 
-from .core import getter, getter_nofancy, getter_inline
+from .core import getter, getter_nofancy, getter_inline, config
 from ..blockwise import optimize_blockwise, fuse_roots
 from ..core import flatten, reverse_dict
 from ..optimization import fuse, inline_functions
@@ -46,6 +46,10 @@ def optimize(
     dsk = fuse_roots(dsk, keys=keys)
     dsk = dsk.cull(set(keys))
     dependencies = dsk.get_all_dependencies()
+
+    if not config.get("optimization.fuse.active"):
+        return dsk
+
     dsk = ensure_dict(dsk)
 
     # Low level task optimizations

--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -3,7 +3,8 @@ from operator import getitem
 
 import numpy as np
 
-from .core import getter, getter_nofancy, getter_inline, config
+from .core import getter, getter_nofancy, getter_inline
+from .. import config
 from ..blockwise import optimize_blockwise, fuse_roots
 from ..core import flatten, reverse_dict
 from ..optimization import fuse, inline_functions

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -5,6 +5,7 @@ pytest.importorskip("numpy")
 import numpy as np
 import dask
 import dask.array as da
+from dask.highlevelgraph import HighLevelGraph
 from dask.optimization import fuse
 from dask.utils import SerializableLock
 from dask.array.core import getter, getter_nofancy
@@ -369,6 +370,22 @@ def test_turn_off_fusion():
 
     assert dask.get(a, y.__dask_keys__()) == dask.get(b, y.__dask_keys__())
     assert len(a) < len(b)
+
+
+def test_disable_lowlevel_fusion():
+    """Check that by disabling fusion, the HLG survives through optimizations"""
+
+    with dask.config.set({"optimization.fuse.active": False}):
+        y = da.ones(3, chunks=(3,), dtype="int")
+        optimize = y.__dask_optimize__
+        dsk1 = y.__dask_graph__()
+        dsk2 = optimize(dsk1, y.__dask_keys__())
+        assert isinstance(dsk1, HighLevelGraph)
+        assert isinstance(dsk2, HighLevelGraph)
+        assert dsk1 == dsk2
+        y = y.persist()
+        assert isinstance(y.__dask_graph__(), HighLevelGraph)
+        assert_eq(y, [1] * 3)
 
 
 def test_gh3937():

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -8,7 +8,6 @@ from dask.utils_test import inc
 from dask.highlevelgraph import HighLevelGraph, BasicLayer, Layer
 from dask.blockwise import Blockwise
 from dask.array.utils import assert_eq
-from dask import config
 
 
 def test_visualize(tmpdir):
@@ -111,19 +110,3 @@ def test_map_tasks(use_layer_map_task):
 
     y.dask = dsk.map_tasks(plus_one)
     assert_eq(y, [42] * 3)
-
-
-def test_disable_lowlevel_fusion():
-    """Check that by disabling fusion, the HLG survives through optimizations"""
-
-    with config.set({"optimization.fuse.active": False}):
-        y = da.ones(3, chunks=(3,), dtype="int")
-        optimize = y.__dask_optimize__
-        dsk1 = y.__dask_graph__()
-        dsk2 = optimize(dsk1, y.__dask_keys__())
-        assert isinstance(dsk1, HighLevelGraph)
-        assert isinstance(dsk2, HighLevelGraph)
-        assert dsk1 == dsk2
-        y = y.persist()
-        assert isinstance(y.__dask_graph__(), HighLevelGraph)
-        assert_eq(y, [1] * 3)


### PR DESCRIPTION
This PR makes array optimize to exit early when `optimization.fuse.active=False` and return a high level graph.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
