### PR TITLE
CI: Fixed bug causing flaky test failure in pivot

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -338,7 +338,7 @@ def pivot_agg(df):
 
 def pivot_sum(df, index, columns, values):
     return pd.pivot_table(
-        df, index=index, columns=columns, values=values, aggfunc="sum"
+        df, index=index, columns=columns, values=values, aggfunc="sum", dropna=False
     )
 
 
@@ -346,7 +346,7 @@ def pivot_count(df, index, columns, values):
     # we cannot determine dtype until concatenationg all partitions.
     # make dtype deterministic, always coerce to np.float64
     return pd.pivot_table(
-        df, index=index, columns=columns, values=values, aggfunc="count"
+        df, index=index, columns=columns, values=values, aggfunc="count", dropna=False
     ).astype(np.float64)
 
 

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -181,7 +181,7 @@ def test_pivot_table(values, aggfunc):
             "D": np.random.randn(100),
         }
     )
-    ddf = dd.from_pandas(df, 5)
+    ddf = dd.from_pandas(df, 5).repartition((0, 20, 40, 60, 80, 98, 99))
 
     res = dd.pivot_table(ddf, index="A", columns="C", values=values, aggfunc=aggfunc)
     exp = pd.pivot_table(df, index="A", columns="C", values=values, aggfunc=aggfunc)


### PR DESCRIPTION
When a partition had unobserved categories, the result MultiIndex would
have the right dtype but not the right shape. This caused the `concat`
to later cast to object dtype, causing the test failure.

The fix is to not drop the all-NA columns.

Closes https://github.com/dask/dask/issues/6729