### PR TITLE
Temporarily use pyarrow<2 in CI

### DIFF
--- a/continuous_integration/environment-3.6.yaml
+++ b/continuous_integration/environment-3.6.yaml
@@ -23,7 +23,9 @@ dependencies:
   - zarr
   - tiledb-py
   - sqlalchemy
-  - pyarrow>=0.14.0
+  # Remove <2 version constraint once we've added pyarrow 2.0 compatibility
+  # xref https://github.com/dask/dask/issues/6754
+  - pyarrow>=0.14.0,<2
   # other -- IO
   - bcolz
   - blosc

--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -19,7 +19,9 @@ dependencies:
   - tiledb-py
   - fsspec>=0.6.0
   - sqlalchemy
-  - pyarrow>=0.14.0
+  # Remove <2 version constraint once we've added pyarrow 2.0 compatibility
+  # xref https://github.com/dask/dask/issues/6754
+  - pyarrow>=0.14.0,<2
   - coverage
   - jsonschema
   # other -- IO

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -19,7 +19,9 @@ dependencies:
   - zarr
   - tiledb-py
   - sqlalchemy
-  - pyarrow>=0.14.0
+  # Remove <2 version constraint once we've added pyarrow 2.0 compatibility
+  # xref https://github.com/dask/dask/issues/6754
+  - pyarrow>=0.14.0,<2
   - jsonschema
   # other -- IO
   - bcolz

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -19,7 +19,9 @@ dependencies:
   - tiledb-py
   - fsspec>=0.6.0
   - sqlalchemy
-  - pyarrow>=0.14.0
+  # Remove <2 version constraint once we've added pyarrow 2.0 compatibility
+  # xref https://github.com/dask/dask/issues/6754
+  - pyarrow>=0.14.0,<2
   - coverage
   - jsonschema
   # other -- IO

--- a/continuous_integration/hdfs/install.sh
+++ b/continuous_integration/hdfs/install.sh
@@ -1,6 +1,8 @@
 set -xe
 
-docker exec -it $CONTAINER_ID conda install -y -q dask pyarrow">=0.14.0" fsspec -c conda-forge
+# Remove <2 version constraint once we've added pyarrow 2.0 compatibility
+# xref https://github.com/dask/dask/issues/6754
+docker exec -it $CONTAINER_ID conda install -y -q dask pyarrow">=0.14.0,<2" fsspec -c conda-forge
 docker exec -it $CONTAINER_ID python -m pip install -e .
 
 set +xe


### PR DESCRIPTION
This PR adds a `pyarrow < 2` version constraint to our CI builds. This is a temporary update to prevent CI builds from failing on PRs until we add compatibility code for the recent pyarrow 2.0 release (xref https://github.com/dask/dask/issues/6754) 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
