### PR TITLE
Efficient serialization of shuffle layers

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -96,6 +96,19 @@ class SimpleShuffleLayer(Layer):
     def __len__(self):
         return len(self._dict)
 
+    def __reduce__(self):
+        attrs = [
+            "name",
+            "column",
+            "npartitions",
+            "npartitions_input",
+            "ignore_index",
+            "name_input",
+            "meta_input",
+            "parts_out",
+        ]
+        return (SimpleShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
+
     def _keys_to_parts(self, keys):
         """Simple utility to convert keys to partition indices."""
         parts = set()
@@ -251,6 +264,22 @@ class ShuffleLayer(SimpleShuffleLayer):
         return "ShuffleLayer<name='{}', stage={}, nsplits={}, npartitions={}>".format(
             self.name, self.stage, self.nsplits, self.npartitions
         )
+
+    def __reduce__(self):
+        attrs = [
+            "name",
+            "column",
+            "inputs",
+            "stage",
+            "npartitions",
+            "npartitions_input",
+            "nsplits",
+            "ignore_index",
+            "name_input",
+            "meta_input",
+            "parts_out",
+        ]
+        return (ShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
 
     def _cull_dependencies(self, keys, parts_out=None):
         """Determine the necessary dependencies to produce `keys`.

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1039,3 +1039,29 @@ def test_shuffle_hlg_layer():
     dsk_dict = dict(dsk_culled)
     dsk_dict_culled, _ = cull(dsk_dict, keys)
     assert dsk_dict_culled == dsk_dict
+
+
+@pytest.mark.parametrize(
+    "npartitions",
+    [
+        10,  # ShuffleLayer
+        1,  # SimpleShuffleLayer
+    ],
+)
+def test_shuffle_hlg_layer_serialize(npartitions):
+    ddf = dd.from_pandas(
+        pd.DataFrame({"a": np.random.randint(0, 10, 100)}), npartitions=npartitions
+    )
+    ddf_shuffled = ddf.shuffle("a", max_branch=3, shuffle="tasks")
+
+    # Ensure shuffle layers can be serialized and don't result in
+    # the underlying low-level graph being materialized
+    dsk = ddf_shuffled.__dask_graph__()
+    for layer in dsk.layers.values():
+        if not isinstance(layer, dd.shuffle.SimpleShuffleLayer):
+            continue
+        assert not hasattr(layer, "_cached_dict")
+        layer_roundtrip = pickle.loads(pickle.dumps(layer))
+        assert type(layer_roundtrip) == type(layer)
+        assert not hasattr(layer_roundtrip, "_cached_dict")
+        assert layer_roundtrip.keys() == layer.keys()


### PR DESCRIPTION
Following up on https://github.com/dask/dask/pull/6693 and https://github.com/dask/dask/pull/6650 this PR overloads `__reduce__` on our new shuffle layers to avoid materializing the underlying low-level task graph for when we start sending these layers to the distributed scheduler 

cc @madsbk @rjzamora

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
