### PR TITLE
[WIP] Add optional pass_key argument to map_tasks

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -260,11 +260,14 @@ class Blockwise(Layer):
         _ = self._dict  # trigger materialization
         return self._cached_dict["basic_layer"].cull(keys, all_hlg_keys)
 
-    def map_tasks(self, func):
+    def map_tasks(self, func, pass_key=False):
         new_indices = []
         for key, input_indices in self.indices:
             if input_indices is None:  # A literal
-                new_indices.append((func([key]), None))
+                if pass_key:
+                    new_indices.append((func([key], key), None))
+                else:
+                    new_indices.append((func([key]), None))
             else:
                 new_indices.append((key, input_indices))
         ret = copy.copy(self)

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -106,7 +106,7 @@ class ParquetSubgraph(Layer):
         )
         return ret, ret.get_dependencies(all_hlg_keys)
 
-    def map_tasks(self, func):
+    def map_tasks(self, func, pass_key=False):
         # ParquetSubgraph has no input tasks
         return self
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -99,7 +99,9 @@ class Layer(collections.abc.Mapping):
     ) -> "Layer":
         """Map `func` on tasks in the layer and returns a new layer.
 
-        `func` should take an iterable of the tasks as input and return a new
+        `func` should return a new Layer and take two input arguments:
+          - The key of the task
+          - An iterable of the tasks
         iterable as output and **cannot** change the dependencies between Layers.
 
         Warning


### PR DESCRIPTION
Adds an optional `pass_key` argument to `map_tasks`.  This enables a simple fix to [distributed#4177](https://github.com/dask/distributed/issues/4177), because it allows the `map_tasks` utility to be used to collect proper task-future dependencies.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
