### PR TITLE
Document `meta` kwarg in `map_blocks` and `map_overlap`.

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -455,7 +455,7 @@ def map_blocks(
 
     Note that this function will attempt to automatically determine the output
     array type before computing it, please refer to the ``meta`` keyword argument
-    below if you expect that the function will not suceed when operating on 0-d
+    below if you expect that the function will not succeed when operating on 0-d
     arrays.
 
     Parameters
@@ -484,14 +484,14 @@ def map_blocks(
         specifies the output key name, and must be unique. If not provided,
         will be determined by a hash of the arguments.
     meta : array-like, optional
-        The ``meta`` of the output array, when specified it is expected to be an
+        The ``meta`` of the output array, when specified is expected to be an
         array of the same type of that returned when calling ``.compute()`` on
-        the array returned by this function. When not provided, will be inferred
-        by applying the function to a small set of fake data, usually a 0-d array.
-        It's important to ensure that ``func`` can successfully complete
+        the array returned by this function. When not provided, ``meta`` will be
+        inferred by applying the function to a small set of fake data, usually a
+        0-d array. It's important to ensure that ``func`` can successfully complete
         computation without raising exceptions when 0-d is passed to it. If the
         output type is known beforehand (e.g., ``np.ndarray``, ``cupy.ndarray``),
-        an empty array of such type can be passed , for example: ``meta=np.array(())``.
+        an empty array of such type can be passed, for example: ``meta=np.array(())``.
     **kwargs :
         Other keyword arguments to pass to function. Values must be constants
         (not dask.arrays)
@@ -2237,7 +2237,7 @@ class Array(DaskMethodsMixin):
 
         Note that this function will attempt to automatically determine the output
         array type before computing it, please refer to the ``meta`` keyword argument
-        in ``map_blocks`` if you expect that the function will not suceed when
+        in ``map_blocks`` if you expect that the function will not succeed when
         operating on 0-d arrays.
 
         Parameters

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -453,10 +453,10 @@ def map_blocks(
 ):
     """Map a function across all blocks of a dask array.
 
-    Note that this function will attempt to automatically determine the output
-    array type before computing it, please refer to the ``meta`` keyword argument
-    below if you expect that the function will not succeed when operating on 0-d
-    arrays.
+    Note that ``map_blocks`` will attempt to automatically determine the output
+    array type by calling ``func`` on 0-d versions of the inputs. Please refer to
+    the ``meta`` keyword argument below if you expect that the function will not
+    succeed when operating on 0-d arrays.
 
     Parameters
     ----------
@@ -485,13 +485,14 @@ def map_blocks(
         will be determined by a hash of the arguments.
     meta : array-like, optional
         The ``meta`` of the output array, when specified is expected to be an
-        array of the same type of that returned when calling ``.compute()`` on
-        the array returned by this function. When not provided, ``meta`` will be
+        array of the same type and dtype of that returned when calling ``.compute()``
+        on the array returned by this function. When not provided, ``meta`` will be
         inferred by applying the function to a small set of fake data, usually a
         0-d array. It's important to ensure that ``func`` can successfully complete
-        computation without raising exceptions when 0-d is passed to it. If the
-        output type is known beforehand (e.g., ``np.ndarray``, ``cupy.ndarray``),
-        an empty array of such type can be passed, for example: ``meta=np.array(())``.
+        computation without raising exceptions when 0-d is passed to it, providing
+        ``meta`` will be required otherwise. If the output type is known beforehand
+        (e.g., ``np.ndarray``, ``cupy.ndarray``), an empty array of such type dtype
+        can be passed, for example: ``meta=np.array((), dtype=np.int32)``.
     **kwargs :
         Other keyword arguments to pass to function. Values must be constants
         (not dask.arrays)
@@ -619,10 +620,12 @@ def map_blocks(
     >>> da.map_blocks(lambda x: x[2], da.random.random(5), meta=np.array(()))
     dask.array<lambda, shape=(5,), dtype=float64, chunksize=(5,), chunktype=numpy.ndarray>
 
-    Similarly, it's possible to specify a non-NumPy array to ``meta``:
+    Similarly, it's possible to specify a non-NumPy array to ``meta``, and provide
+    a ``dtype``:
 
     >>> rs = da.random.RandomState(RandomState=cupy.random.RandomState)
-    >>> da.map_blocks(lambda x: x[2], rs.random(5), meta=cupy.array(()))
+    >>> dt = np.float32
+    >>> da.map_blocks(lambda x: x[2], rs.random(5, dtype=dt), meta=cupy.array((), dtype=dt))
     dask.array<lambda, shape=(5,), dtype=float64, chunksize=(5,), chunktype=cupy.ndarray>
     """
     if not callable(func):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -623,10 +623,11 @@ def map_blocks(
     Similarly, it's possible to specify a non-NumPy array to ``meta``, and provide
     a ``dtype``:
 
-    >>> rs = da.random.RandomState(RandomState=cupy.random.RandomState)
+    >>> import cupy  # doctest: +SKIP
+    >>> rs = da.random.RandomState(RandomState=cupy.random.RandomState)  # doctest: +SKIP
     >>> dt = np.float32
-    >>> da.map_blocks(lambda x: x[2], rs.random(5, dtype=dt), meta=cupy.array((), dtype=dt))
-    dask.array<lambda, shape=(5,), dtype=float64, chunksize=(5,), chunktype=cupy.ndarray>
+    >>> da.map_blocks(lambda x: x[2], rs.random(5, dtype=dt), meta=cupy.array((), dtype=dt))  # doctest: +SKIP
+    dask.array<lambda, shape=(5,), dtype=float32, chunksize=(5,), chunktype=cupy.ndarray>
     """
     if not callable(func):
         msg = (
@@ -2302,12 +2303,13 @@ class Array(DaskMethodsMixin):
                [20, 22, 24, 26],
                [24, 26, 28, 30]])
 
-        >>> x = cupy.arange(16).reshape((4, 4))
-        >>> d = da.from_array(x, chunks=(2, 2))
-        >>> y = d.map_overlap(lambda x: x + x[2], depth=1, meta=cupy.array(()))
-        >>> y
+        >>> import cupy  # doctest: +SKIP
+        >>> x = cupy.arange(16).reshape((5, 4))  # doctest: +SKIP
+        >>> d = da.from_array(x, chunks=(2, 2))  # doctest: +SKIP
+        >>> y = d.map_overlap(lambda x: x + x[2], depth=1, meta=cupy.array(()))  # doctest: +SKIP
+        >>> y  # doctest: +SKIP
         dask.array<_trim, shape=(4, 4), dtype=float64, chunksize=(2, 2), chunktype=cupy.ndarray>
-        >>> y.compute()
+        >>> y.compute()  # doctest: +SKIP
         array([[ 4,  6,  8, 10],
                [ 8, 10, 12, 14],
                [20, 22, 24, 26],

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -539,6 +539,11 @@ def map_overlap(
     We share neighboring zones between blocks of the array, map a
     function, and then trim away the neighboring strips.
 
+    Note that this function will attempt to automatically determine the output
+    array type before computing it, please refer to the ``meta`` keyword argument
+    in ``map_blocks`` if you expect that the function will not suceed when
+    operating on 0-d arrays.
+
     Parameters
     ----------
     func: function
@@ -646,6 +651,35 @@ def map_overlap(
     10
     >>> da.map_overlap(func, x, **block_args, depth=1).compute()
     12
+
+    For functions that may not handle 0-d arrays, it's also possible to specify
+    ``meta`` with an empty array matching the type of the expected result. In
+    the example below, ``func`` will result in an ``IndexError`` when computing
+    ``meta``:
+
+    >>> x = np.arange(16).reshape((4, 4))
+    >>> d = da.from_array(x, chunks=(2, 2))
+    >>> y = d.map_overlap(lambda x: x + x[2], depth=1, meta=np.array(()))
+    >>> y
+    dask.array<_trim, shape=(4, 4), dtype=float64, chunksize=(2, 2), chunktype=numpy.ndarray>
+    >>> y.compute()
+    array([[ 4,  6,  8, 10],
+           [ 8, 10, 12, 14],
+           [20, 22, 24, 26],
+           [24, 26, 28, 30]])
+
+    Similarly, it's possible to specify a non-NumPy array to ``meta``:
+
+    >>> x = cupy.arange(16).reshape((4, 4))
+    >>> d = da.from_array(x, chunks=(2, 2))
+    >>> y = d.map_overlap(lambda x: x + x[2], depth=1, meta=cupy.array(()))
+    >>> y
+    dask.array<_trim, shape=(4, 4), dtype=float64, chunksize=(2, 2), chunktype=cupy.ndarray>
+    >>> y.compute()
+    array([[ 4,  6,  8, 10],
+           [ 8, 10, 12, 14],
+           [20, 22, 24, 26],
+           [24, 26, 28, 30]])
     """
     # Look for invocation using deprecated single-array signature
     # map_overlap(x, func, depth, boundary=None, trim=True, **kwargs)

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -541,7 +541,7 @@ def map_overlap(
 
     Note that this function will attempt to automatically determine the output
     array type before computing it, please refer to the ``meta`` keyword argument
-    in ``map_blocks`` if you expect that the function will not suceed when
+    in ``map_blocks`` if you expect that the function will not succeed when
     operating on 0-d arrays.
 
     Parameters

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -670,12 +670,13 @@ def map_overlap(
 
     Similarly, it's possible to specify a non-NumPy array to ``meta``:
 
-    >>> x = cupy.arange(16).reshape((4, 4))
-    >>> d = da.from_array(x, chunks=(2, 2))
-    >>> y = d.map_overlap(lambda x: x + x[2], depth=1, meta=cupy.array(()))
-    >>> y
+    >>> import cupy  # doctest: +SKIP
+    >>> x = cupy.arange(16).reshape((4, 4))  # doctest: +SKIP
+    >>> d = da.from_array(x, chunks=(2, 2))  # doctest: +SKIP
+    >>> y = d.map_overlap(lambda x: x + x[2], depth=1, meta=cupy.array(()))  # doctest: +SKIP
+    >>> y  # doctest: +SKIP
     dask.array<_trim, shape=(4, 4), dtype=float64, chunksize=(2, 2), chunktype=cupy.ndarray>
-    >>> y.compute()
+    >>> y.compute()  # doctest: +SKIP
     array([[ 4,  6,  8, 10],
            [ 8, 10, 12, 14],
            [20, 22, 24, 26],


### PR DESCRIPTION
This should address https://github.com/dask/dask/issues/6690 partially, documenting how/when one should need `meta=` in `map_blocks` and `map_overlap`, as well as providing some very simple examples.