### PR TITLE
Clarify differences in boolean indexing between dask and numpy arrays

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3955,8 +3955,7 @@ def broadcast_shapes(*shapes):
         return shapes[0]
     out, hint = [], ""
     for sizes in zip_longest(*map(reversed, shapes), fillvalue=-1):
-        any_isnan = np.isnan(sizes).any()
-        if any_isnan:
+        if np.isnan(sizes).any():
             dim = np.nan
             hint = (
                 "\nHint: Valid boolean index assignment in Dask "
@@ -3964,7 +3963,8 @@ def broadcast_shapes(*shapes):
             )
         else:
             dim = 0 if 0 in sizes else np.max(sizes)
-        if any_isnan or any(size not in [-1, 0, 1, dim] for size in sizes):
+        # if any_isnan or any(size not in [-1, 0, 1, dim] for size in sizes):
+        if any(i not in [-1, 0, 1, dim] and not np.isnan(i) for i in sizes):
             raise ValueError(
                 "operands could not be broadcast together with shapes "
                 f"{' '.join(map(str, shapes))}"

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3953,16 +3953,22 @@ def broadcast_shapes(*shapes):
     """
     if len(shapes) == 1:
         return shapes[0]
-    out = []
+    out, hint = [], ""
     for sizes in zip_longest(*map(reversed, shapes), fillvalue=-1):
-        if np.isnan(sizes).any():
+        any_isnan = np.isnan(sizes).any()
+        if any_isnan:
             dim = np.nan
+            hint = (
+                "\nHint: Valid boolean index assignment in Dask "
+                "for equally shaped arrays is da1[da2] = da3."
+            )
         else:
             dim = 0 if 0 in sizes else np.max(sizes)
-        if any(i not in [-1, 0, 1, dim] and not np.isnan(i) for i in sizes):
+        if any_isnan or any(size not in [-1, 0, 1, dim] for size in sizes):
             raise ValueError(
-                "operands could not be broadcast together with "
-                "shapes {0}".format(" ".join(map(str, shapes)))
+                "operands could not be broadcast together with shapes "
+                f"{' '.join(map(str, shapes))}"
+                f"{hint}"
             )
         out.append(dim)
     return tuple(reversed(out))


### PR DESCRIPTION
Dask arrays does boolean indexing differently compared to numpy arrays. 
Add a hint how it's done in the error, the hint is displayed when some shape is nan.

Related issue: dask#6711
