### PR TITLE
Fix some minor typos and trailing whitespaces in array-slice.rst

### DIFF
--- a/docs/source/array-slicing.rst
+++ b/docs/source/array-slicing.rst
@@ -30,8 +30,8 @@ The normal Dask schedulers are smart enough to compute only those blocks that
 are necessary to achieve the desired slicing.  Hence, large operations may be cheap
 if only a small output is desired.
 
-In the example below, we create a Dask array with a trillion elements with million 
-element sized blocks.  We then operate on the entire array and finally slice out 
+In the example below, we create a Dask array with a trillion elements with million
+element sized blocks.  We then operate on the entire array and finally slice out
 only a portion of the output:
 
 .. code-block:: python
@@ -43,10 +43,10 @@ only a portion of the output:
    ...
 
 This only needs to compute the top-left four blocks to achieve the result.  We
-are slightly wasteful on those blocks where we need only partial results.  Moreover, 
+are slightly wasteful on those blocks where we need only partial results.  Moreover,
 we are also a bit wasteful in that we still need to manipulate the Dask graph
 with a million or so tasks in it.  This can cause an interactive overhead of a
-second or two. 
+second or two.
 
 Slicing with concrete indexers (a list of integers, say) has a couple of possible
 failure modes that are worth mentioning. First, when you're indexing a chunked
@@ -75,7 +75,7 @@ be much larger.
    chunk and silence this warning, set the option
        >>> with dask.config.set({'array.slicing.split_large_chunks': False}):
        ...     array[indexer]
-   
+
    To avoid creating the large chunks, set the option
        >>> with dask.config.set({'array.slicing.split_large_chunks': True}):
        ...     array[indexer]

--- a/docs/source/array-slicing.rst
+++ b/docs/source/array-slicing.rst
@@ -58,7 +58,7 @@ axis, Dask will typically "match" the chunking on the output.
    >>> a = da.ones((4, 10000, 10000), chunks=(1, -1, -1))
 
 If we slice that with a *sorted* sequence of integers, Dask will return one chunk
-per intput chunk (notince the output `chunksize` is 1, since the indices ``0``
+per input chunk (notice the output `chunksize` is 1, since the indices ``0``
 and ``1`` are in separate chunks in the input).
 
    >>> a[[0, 1], :, :]          #doctest: +SKIP


### PR DESCRIPTION
This pull request fixes some minor typos in `docs/source/array-slicing.rst`, and removes some trailing whitespaces in the same file.