### PR TITLE
HLG: get_all_external_keys()

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -72,6 +72,9 @@ class SimpleShuffleLayer(Layer):
         self.meta_input = meta_input
         self.parts_out = parts_out or range(npartitions)
 
+    def get_output_keys(self):
+        return {(self.name, part) for part in self.parts_out}
+
     def __repr__(self):
         return "SimpleShuffleLayer<name='{}', npartitions={}>".format(
             self.name, self.npartitions

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -133,7 +133,7 @@ class SimpleShuffleLayer(Layer):
         materialization.
         """
         deps = defaultdict(set)
-        parts_out = self._keys_to_parts(keys)
+        parts_out = parts_out or self._keys_to_parts(keys)
         for part in parts_out:
             deps[(self.name, part)] |= {
                 (self.name_input, i) for i in range(self.npartitions_input)


### PR DESCRIPTION
This PR introduces `HighLevelGraph.get_all_external_keys()`, which makes it possible to cull high level graphs that contains `ShuffleLayer` without materializing them.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

cc. @rjzamora 
