### PR TITLE
High level graph pack/unpack for Distributed

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -252,6 +252,9 @@ class Blockwise(Layer):
 
         return out_d
 
+    def is_materialized(self):
+        return hasattr(self, "_cached_dict")
+
     def get_dependencies(self, key, all_hlg_keys):
         _ = self._dict  # trigger materialization
         return self._cached_dict["basic_layer"].get_dependencies(key, all_hlg_keys)

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -89,6 +89,9 @@ class ParquetSubgraph(Layer):
         for i in self.part_ids:
             yield (self.name, i)
 
+    def is_materialized(self):
+        return False  # Never materialized
+
     def get_dependencies(self, all_hlg_keys):
         return {k: set() for k in self}
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -425,7 +425,7 @@ class ShuffleLayer(SimpleShuffleLayer):
                             # In order to make sure that to_serialize() serialize the
                             # empty dataframe input, we add it as a key.
                             input_key = (shuffle_group_name, _inp, "empty")
-                            dsk[(shuffle_group_name, _inp, "empty")] = self.meta_input
+                            dsk[input_key] = self.meta_input
                     else:
                         input_key = (self.name_input, _part)
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -116,7 +116,7 @@ class SimpleShuffleLayer(Layer):
         ]
         return (SimpleShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
 
-    def distributed_pack(self):
+    def __dask_distributed_pack__(self):
         return {
             "name": self.name,
             "column": self.column,
@@ -129,7 +129,7 @@ class SimpleShuffleLayer(Layer):
         }
 
     @classmethod
-    def distributed_unpack(cls, state, dsk, dependencies):
+    def __dask_distributed_unpack__(cls, state, dsk, dependencies):
         from distributed.utils import str_graph
         from distributed.worker import dumps_task
 
@@ -322,8 +322,8 @@ class ShuffleLayer(SimpleShuffleLayer):
         ]
         return (ShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
 
-    def distributed_pack(self):
-        ret = super().distributed_pack()
+    def __dask_distributed_pack__(self):
+        ret = super().__dask_distributed_pack__()
         ret["inputs"] = self.inputs
         ret["stage"] = self.stage
         ret["nsplits"] = self.nsplits

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -80,6 +80,9 @@ class SimpleShuffleLayer(Layer):
             self.name, self.npartitions
         )
 
+    def is_materialized(self):
+        return hasattr(self, "_cached_dict")
+
     @property
     def _dict(self):
         """Materialize full dict representation"""

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -160,13 +160,13 @@ class Layer(collections.abc.Mapping):
 
         return BasicLayer({k: func(v) for k, v in self.items()})
 
-    def distributed_pack(self) -> Optional[Any]:
+    def __dask_distributed_pack__(self) -> Optional[Any]:
         """Pack the layer for scheduler communication in Distributed
 
         This method should pack its current state and is called by the Client when
         communicating with the Scheduler.
-        The Scheduler will then use .distributed_unpack(data, ...) to unpack the
-        state, materialize the layer, and merge it into the global task graph.
+        The Scheduler will then use .__dask_distributed_unpack__(data, ...) to unpack
+        the state, materialize the layer, and merge it into the global task graph.
 
         The returned state must be compatible with Distributed's scheduler, which
         means it must obey the following:
@@ -186,10 +186,10 @@ class Layer(collections.abc.Mapping):
         return None
 
     @classmethod
-    def distributed_unpack(
+    def __dask_distributed_unpack__(
         cls, state: Any, dsk: Dict[str, Any], dependencies: Mapping[Hashable, Set]
     ) -> None:
-        """Unpack the state of a layer previously packed by .distributed_pack()
+        """Unpack the state of a layer previously packed by __dask_distributed_pack__()
 
         This method is called by the scheduler in Distributed in order to unpack
         the state of a layer and merge it into its global task graph. The method
@@ -197,18 +197,20 @@ class Layer(collections.abc.Mapping):
         state of the preceding layers in the high level graph. The layers of the
         high level graph are unpacked in topological order.
 
-        See Layer.distributed_pack() for packing detail.
+        See Layer.__dask_distributed_pack__() for packing detail.
 
         Parameters
         ----------
         state: Any
-            The state returned by Layer.distributed_pack()
+            The state returned by Layer.__dask_distributed_pack__()
         dsk: dict
             The materialized low level graph of the already unpacked layers
         dependencies: Mapping
             The dependencies of each key in `dsk`
         """
-        raise NotImplementedError(f"{type(cls)} doesn't implement distributed_unpack()")
+        raise NotImplementedError(
+            f"{type(cls)} doesn't implement __dask_distributed_unpack__()"
+        )
 
     def __reduce__(self):
         """Default serialization implementation, which materializes the Layer

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -170,7 +170,7 @@ class Layer(collections.abc.Mapping):
 
         The returned state must be compatible with Distributed's scheduler, which
         means it must obey the following:
-          - Serializable by msgpack
+          - Serializable by msgpack (notice, msgpack converts lists to tuples)
           - All remote data must be unpacked (see unpack_remotedata())
           - All keys must be converted to strings now or when unpacking
           - All tasks must be serialized (see dumps_task())


### PR DESCRIPTION
This PR introduce packing and unpacking of HLG layer:
```python
    def distributed_pack(self) -> Optional[Any]:
        """Pack the layer for scheduler communication in Distributed

        This method should pack its current state and is called by the Client when
        communicating with the Scheduler.
        The Scheduler will then use .distributed_unpack(data, ...) to unpack the
        state, materialize the layer, and merge it into the global task graph.

        The returned state must be compatible with Distributed's scheduler, which
        means it must obey the following:
          - Serializable by msgpack
          - All remote data must be unpacked (see unpack_remotedata())
          - All keys must be converted to strings now or when unpacking
          - All tasks must be serialized (see dumps_task())

        Alternatively, the method can return None, which will make Distributed
        materialize the layer and use a default packing method.

        Returns
        -------
        state: Object serializable by msgpack
            Scheduler compatible state of the layer
        """
        return None

    @classmethod
    def distributed_unpack(
        cls, state: Any, dsk: Dict[str, Any], dependencies: Mapping[Hashable, Set]
    ) -> None:
        """Unpack the state of a layer previously packed by .distributed_pack()

        This method is called by the scheduler in Distributed in order to unpack
        the state of a layer and merge it into its global task graph. The method
        should update `dsk` and `dependencies`, which are the already materialized
        state of the preceding layers in the high level graph. The layers of the
        high level graph are unpacked in topological order.

        See Layer.distributed_pack() for packing detail.

        Parameters
        ----------
        state: Any
            The state returned by Layer.distributed_pack()
        dsk: dict
            The materialized low level graph of the already unpacked layers
        dependencies: Mapping
            The dependencies of each key in `dsk`
        """
        raise NotImplementedError(f"{type(cls)} doesn't implement distributed_unpack()")
```

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
