### PR TITLE
PR: Add missing methods of the Dataframe summary table API

### DIFF
--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -9,14 +9,21 @@ Dataframe
 .. autosummary::
 
     DataFrame
+    DataFrame.abs
     DataFrame.add
+    DataFrame.align
+    DataFrame.all
+    DataFrame.any
     DataFrame.append
     DataFrame.apply
+    DataFrame.applymap
     DataFrame.assign
     DataFrame.astype
+    DataFrame.bfill
     DataFrame.categorize
     DataFrame.columns
     DataFrame.compute
+    DataFrame.copy
     DataFrame.corr
     DataFrame.count
     DataFrame.cov
@@ -25,40 +32,62 @@ Dataframe
     DataFrame.cumprod
     DataFrame.cumsum
     DataFrame.describe
+    DataFrame.diff
     DataFrame.div
+    DataFrame.divide
     DataFrame.drop
     DataFrame.drop_duplicates
     DataFrame.dropna
     DataFrame.dtypes
+    DataFrame.eq
+    DataFrame.eval
     DataFrame.explode
+    DataFrame.ffill
     DataFrame.fillna
+    DataFrame.first
     DataFrame.floordiv
+    DataFrame.ge
     DataFrame.get_partition
     DataFrame.groupby
+    DataFrame.gt
     DataFrame.head
+    DataFrame.idxmax
+    DataFrame.idxmin
     DataFrame.iloc
     DataFrame.index
+    DataFrame.info
+    DataFrame.isin
     DataFrame.isna
     DataFrame.isnull
+    DataFrame.items
+    DataFrame.iteritems
     DataFrame.iterrows
     DataFrame.itertuples
     DataFrame.join
     DataFrame.known_divisions
+    DataFrame.last
+    DataFrame.le
     DataFrame.loc
+    DataFrame.lt
     DataFrame.map_partitions
     DataFrame.mask
     DataFrame.max
     DataFrame.mean
+    DataFrame.melt
     DataFrame.memory_usage
     DataFrame.memory_usage_per_partition
     DataFrame.merge
     DataFrame.min
     DataFrame.mod
+    DataFrame.mode
     DataFrame.mul
     DataFrame.ndim
+    DataFrame.ne
     DataFrame.nlargest
     DataFrame.npartitions
+    DataFrame.nsmallest
     DataFrame.partitions
+    DataFrame.pivot_table
     DataFrame.pop
     DataFrame.pow
     DataFrame.prod
@@ -70,16 +99,22 @@ Dataframe
     DataFrame.rename
     DataFrame.repartition
     DataFrame.replace
+    DataFrame.resample
     DataFrame.reset_index
     DataFrame.rfloordiv
     DataFrame.rmod
     DataFrame.rmul
+    DataFrame.round
     DataFrame.rpow
     DataFrame.rsub
     DataFrame.rtruediv
     DataFrame.sample
+    DataFrame.select_dtypes
+    DataFrame.sem
     DataFrame.set_index
     DataFrame.shape
+    DataFrame.size
+    DataFrame.squeeze
     DataFrame.std
     DataFrame.sub
     DataFrame.sum
@@ -89,10 +124,13 @@ Dataframe
     DataFrame.to_dask_array
     DataFrame.to_delayed
     DataFrame.to_hdf
+    DataFrame.to_html
     DataFrame.to_json
     DataFrame.to_parquet
     DataFrame.to_records
+    DataFrame.to_string
     DataFrame.to_sql
+    DataFrame.to_timestamp
     DataFrame.truediv
     DataFrame.values
     DataFrame.var


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

Add the following missing methods in the summary table of the documentation

- [x] DataFrame.abs
- [x] DataFrame.align
- [x] DataFrame.all
- [x] DataFrame.any
- [x] DataFrame.applymap
- [x] DataFrame.bfill
- [x] DataFrame.copy
- [x] DataFrame.diff
- [x] DataFrame.divide
- [x] DataFrame.eq
- [x] DataFrame.eval
- [x] DataFrame.ffill
- [x] DataFrame.first
- [x] DataFrame.ge
- [x] DataFrame.gt
- [x] DataFrame.idxmax
- [x] DataFrame.idxmin
- [x] DataFrame.info
- [x] DataFrame.isin
- [x] DataFrame.items
- [x] DataFrame.iteritems
- [x] DataFrame.last
- [x] DataFrame.le
- [x] DataFrame.lt
- [x] DataFrame.melt
- [x] DataFrame.mode
- [x] DataFrame.ne
- [x] DataFrame.nsmallest
- [x] DataFrame.pivot_table
- [x] DataFrame.resample
- [x] DataFrame.round
- [x] DataFrame.select_dtypes
- [x] DataFrame.sem
- [x] DataFrame.size
- [x] DataFrame.squeeze
- [x] DataFrame.to_html
- [x] DataFrame.to_string
- [x] DataFrame.to_timestamp

Fixes #6788 
