### PR TITLE
Add "[source]" links to documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
     "sphinx.ext.extlinks",
+    "sphinx.ext.viewcode",
     "numpydoc",
     "sphinx_click.ext",
     "dask_config_sphinx_ext",


### PR DESCRIPTION
Many parts of dask's API are sparsely documented. The dataframe API usually only referes to pandas and does not document additional arguments. Adding a "source" link is quite handy to check what the addtitional, undocumented arguments really do.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

EDIT: replace "view code" by "source"