### PR TITLE
Remove to_delayed operations from to_parquet

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -567,11 +567,11 @@ def to_parquet(
         schema,
     )
     part_tasks = []
+    kwargs_pass["fmd"] = meta
+    kwargs_pass["compression"] = compression
+    kwargs_pass["index_cols"] = index_cols
+    kwargs_pass["schema"] = schema
     for d, filename in enumerate(filenames):
-        kwargs_pass["fmd"] = meta
-        kwargs_pass["compression"] = compression
-        kwargs_pass["index_cols"] = index_cols
-        kwargs_pass["schema"] = schema
         dsk[(name, d)] = (
             _write_partition,
             engine.write_partition,

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -500,6 +500,7 @@ def to_parquet(
     # Use i_offset and df.npartitions to define file-name list
     filenames = ["part.%i.parquet" % (i + i_offset) for i in range(df.npartitions)]
 
+    # Construct IO graph
     dsk = {}
     name = "to-parquet-" + tokenize(
         df,
@@ -531,6 +532,7 @@ def to_parquet(
         )
         part_tasks.append((name, d))
 
+    # Collect metadata and write _metadata
     if write_metadata_file:
         dsk[name] = (
             _write_metadata,


### PR DESCRIPTION
Possible alternative to #6797 

Rather than avoiding optimizations in `to_delayed`, we avoid the call altogether.

~The disadvantage of droping the "delayed" approach is that we now need to "wrap" the `Engine.write_partition` and `Engine.write_metadata` functions to unpack `kwargs`.  Note that we *could* alternatively change the `Engine` API a bit, but that would break backward compatibility with cudf (and any other library/user code that has build upon the existing `Engine`).~ [**EDIT**: Although we cannot call the `Engine.write_metadata` functions directly, `apply` takes care of this pretty easily]

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`


Closes #6758 
Closes #6784 