### PR TITLE
svd_compressed propagate ability of oversampling

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -675,7 +675,7 @@ def compression_matrix(
     https://arxiv.org/abs/0909.4061
     """
     m, n = data.shape
-    comp_level = compression_level(min(m, n), q, n_oversamples=n_oversamples)
+    comp_level = compression_level(min(m, n), q, n_oversamples)
     if isinstance(seed, RandomState):
         state = seed
     else:


### PR DESCRIPTION
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

compression_level already had an oversampling input, however, this was not propagated as a user setting in svd_compressed.

Note: also see #6757 