### PR TITLE
Avoid graph materialization during Blockwise culling

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -356,7 +356,10 @@ class Blockwise(Layer):
         return self._cached_dict["dsk"]
 
     def get_output_keys(self):
-        if self.flat_size:
+        if self.output_blocks:
+            # Culling has already generated a list of output blocks
+            return {(self.output, *p) for p in self.output_blocks}
+        elif self.flat_size:
             # Simple output-key mapping for "flat" transformations
             return {
                 (self.output, *p)

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -430,7 +430,7 @@ class Blockwise(Layer):
             if key[0] == self.output:
                 output_blocks.add(key[1:])
         culled_deps = self._cull_dependencies(all_hlg_keys, output_blocks)
-        out_size = (self.dims[i] for i in self.output_indices)
+        out_size = tuple([self.dims[i] for i in self.output_indices])
         if np.prod(out_size) != len(culled_deps):
             culled_layer = self._cull(output_blocks)
             return culled_layer, culled_deps

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -672,7 +672,9 @@ def make_blockwise_graph(func, output, out_indices, *arrind_pairs, **kwargs):
 
     # Apply Culling.
     # Only need to costruct the specified set of output blocks
-    output_blocks = itertools.product(*[range(dims[i]) for i in out_indices])
+    output_blocks = output_blocks or itertools.product(
+        *[range(dims[i]) for i in out_indices]
+    )
 
     dsk = {}
     # Create argument lists

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -670,7 +670,7 @@ def make_blockwise_graph(func, output, out_indices, *arrind_pairs, **kwargs):
     new_axes = kwargs.pop("new_axes", {})
     key_deps = kwargs.pop("key_deps", None)
     non_blockwise_keys = kwargs.pop("non_blockwise_keys", None)
-    output_blocks = kwargs.pop("output_blocks")
+    output_blocks = kwargs.pop("output_blocks", None)
     argpairs = list(toolz.partition(2, arrind_pairs))
 
     if concatenate is True:

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -192,10 +192,11 @@ class Blockwise(Layer):
         function) must be the same for all N tasks.  This "uniformity" is
         required for the abstract `SubgraphCallable` representation used
         within Blockwise.
-    output_blocks: Tuple[list[int]]
-        Specify an output block selection (list of block indices) for each
-        dimension of `output_indices`. If a tuple element contains `None`,
-        all blocks will be selected for that dimenstion. E.g. (None, [0,1])
+    output_blocks: Set[Tuple]
+        Specify a specific set of required output blocks. Since the graph
+        will only contain the necessary tasks to generate these outputs,
+        this kwarg can be used to "cull" the abstract layer (without needing
+        to materialize the low-level graph).
 
     See Also
     --------

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import tlz as toolz
 
-from .core import reverse_dict, flatten, keys_in_tasks, find_all_possible_keys
+from .core import reverse_dict, flatten, keys_in_tasks
 from .delayed import unpack_collections
 from .highlevelgraph import HighLevelGraph, Layer
 from .optimization import SubgraphCallable, fuse
@@ -624,8 +624,6 @@ def make_blockwise_graph(func, output, out_indices, *arrind_pairs, **kwargs):
     numblocks = kwargs.pop("numblocks")
     concatenate = kwargs.pop("concatenate", None)
     new_axes = kwargs.pop("new_axes", {})
-    key_deps = kwargs.pop("key_deps", None)
-    non_blockwise_keys = kwargs.pop("non_blockwise_keys", None)
     output_blocks = kwargs.pop("output_blocks", None)
     dims = kwargs.pop("dims", None)
     argpairs = list(toolz.partition(2, arrind_pairs))
@@ -658,14 +656,6 @@ def make_blockwise_graph(func, output, out_indices, *arrind_pairs, **kwargs):
             kwargs2 = task
         else:
             kwargs2 = kwargs
-        if non_blockwise_keys is not None:
-            non_blockwise_keys |= find_all_possible_keys([kwargs2])
-
-    # Find all non-blockwise keys in the input arguments
-    if non_blockwise_keys is not None:
-        for arg, ind in argpairs:
-            if ind is None:
-                non_blockwise_keys |= find_all_possible_keys([arg])
 
     # Apply Culling.
     # Only need to costruct the specified set of output blocks
@@ -703,8 +693,6 @@ def make_blockwise_graph(func, output, out_indices, *arrind_pairs, **kwargs):
             val = tuple(args)
         dsk[out_key] = val
 
-        if key_deps is not None:
-            key_deps[out_key] = deps
     if dsk2:
         dsk.update(ensure_dict(dsk2))
 

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -463,7 +463,7 @@ def _get_coord_mapping(
     which to concatenate for each input (`concat_axes`), and the dummy
     indices needed for broadcasting (`dummies`).
 
-    Used by `make_blockwise_graph` and `_cull_dependencies`.
+    Used by `make_blockwise_graph` and `Blockwise._cull_dependencies`.
 
     Parameters
     ----------
@@ -479,7 +479,7 @@ def _get_coord_mapping(
         Corresponds to the Blockwise `numblocks` attribute.
     argpairs: tuple
         Corresponds to the Blockwise `indices` attribute.
-    argpairs: bool
+    concatenate: bool
         Corresponds to the Blockwise `concatenate` attribute.
     """
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -832,6 +832,7 @@ def test_where_mask():
 
 
 def test_map_partitions_multi_argument():
+    dd.map_partitions(lambda a, b: a + b, d.a, d.b).compute(scheduler="synchronous")
     assert_eq(dd.map_partitions(lambda a, b: a + b, d.a, d.b), full.a + full.b)
     assert_eq(
         dd.map_partitions(lambda a, b, c: a + b + c, d.a, d.b, 1), full.a + full.b + 1

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -832,7 +832,9 @@ def test_where_mask():
 
 
 def test_map_partitions_multi_argument():
-    dd.map_partitions(lambda a, b: a + b, d.a, d.b).compute(scheduler="synchronous")
+    dd.map_partitions(lambda a, b: a + b, d.a, d.b).partitions[1].compute(
+        scheduler="synchronous"
+    )
     assert_eq(dd.map_partitions(lambda a, b: a + b, d.a, d.b), full.a + full.b)
     assert_eq(
         dd.map_partitions(lambda a, b, c: a + b + c, d.a, d.b, 1), full.a + full.b + 1
@@ -4052,6 +4054,7 @@ def test_map_partition_array(func):
         except Exception:
             continue
         x = pre(ddf).map_partitions(func)
+        x.compute(scheduler="synchronous")
         assert_eq(x, expected)
 
         assert isinstance(x, da.Array)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -832,9 +832,6 @@ def test_where_mask():
 
 
 def test_map_partitions_multi_argument():
-    dd.map_partitions(lambda a, b: a + b, d.a, d.b).partitions[1].compute(
-        scheduler="synchronous"
-    )
     assert_eq(dd.map_partitions(lambda a, b: a + b, d.a, d.b), full.a + full.b)
     assert_eq(
         dd.map_partitions(lambda a, b, c: a + b + c, d.a, d.b, 1), full.a + full.b + 1
@@ -4054,7 +4051,6 @@ def test_map_partition_array(func):
         except Exception:
             continue
         x = pre(ddf).map_partitions(func)
-        x.compute(scheduler="synchronous")
         assert_eq(x, expected)
 
         assert isinstance(x, da.Array)

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -171,10 +171,13 @@ def test_blockwise_cull(flat):
     dsk = x.__dask_graph__()
     select = (1, 1)  # Select a single chunk
     keys = {(x._name, *select)}
-    dsk = dsk.cull(keys)
-    for layer in dsk.layers.values():
+    dsk_cull = dsk.cull(keys)
+    for name, layer in dsk_cull.layers.items():
         if not isinstance(layer, dask.blockwise.Blockwise):
+            # The original layer shouldn't be Blockwise if the new one isn't
+            assert not isinstance(dsk.layers[name], dask.blockwise.Blockwise)
             continue
+        assert isinstance(dsk.layers[name], dask.blockwise.Blockwise)
         assert not layer.is_materialized()
         out_keys = layer.get_output_keys()
         assert out_keys == {(layer.output, *select)}

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -162,7 +162,7 @@ def test_blockwise_cull(flat):
     else:
         # Complex mapping between input and output
         # indices (outer product and transpose)
-        x = da.from_array(np.arange(10).reshape((10,)), (4,)) + 100
+        x = da.from_array(np.arange(10).reshape((10,)), (4,))
         y = da.from_array(np.arange(10).reshape((10,)), (4,))
         x = da.outer(x, y).transpose()
 


### PR DESCRIPTION
Closes #6792

Follow up to #6715 - Originally intended to avoid graph materialization for "flat" blockwise operations, but now attempts *all* Blockwise layers.

**TODO**:

- [x] General clean up (v1)
- [x] Validate "high-level" culling (test that graph is not materialized)
- [ ] Address serialization (may address in a separate PR)
