### PR TITLE
Check for all-NaN partitions

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -1254,6 +1254,12 @@ def compute_and_set_divisions(df, **kwargs):
     maxes = df.index.map_partitions(M.max, meta=df.index)
     mins, maxes = compute(mins, maxes, **kwargs)
 
+    if mins.isna().any() or maxes.isna().any():
+        raise ValueError(
+            "Partitions with all-NaN index values are not supported for sorted indices. "
+            "You may want to repartition before setting the index."
+        )
+
     if (
         sorted(mins) != list(mins)
         or sorted(maxes) != list(maxes)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1073,3 +1073,13 @@ def test_shuffle_hlg_layer_serialize(npartitions):
         assert type(layer_roundtrip) == type(layer)
         assert not hasattr(layer_roundtrip, "_cached_dict")
         assert layer_roundtrip.keys() == layer.keys()
+
+
+def test_set_index_nan_partition():
+    d[d.a > 3].set_index("a")  # Set index with 1 null partition
+    d[d.a > 1].set_index("a", sorted=True)  # Set sorted index with 0 null partitions
+    with pytest.raises(
+        ValueError,
+        match="Partitions with all-NaN index values are not supported for sorted indices.",
+    ):
+        d[d.a > 3].set_index("a", sorted=True)  # Set sorted index with 1 null partition


### PR DESCRIPTION
Check for all-NaN partitions when calling `set_index` with `sorted=True`, and raise a more specific/helpful error.

Partially addresses https://github.com/dask/dask/issues/6721

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
