### PR TITLE
Add keyword overwrite=True to to_parquet to remove dangling files when overwriting a pyarrow Dataset.

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -489,7 +489,7 @@ def to_parquet(
             )
         if append:
             raise ValueError("Cannot use both `overwrite=True` and `append=True`!")
-        if fs.exists(path) and fs.isdir(path):
+        if fs.isdir(path):
             # Only remove path contents if
             # (1) The path exists
             # (2) The path is a directory

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -483,19 +483,18 @@ def to_parquet(
 
     if overwrite:
         working_dir = fs.expand_path(".")[0]
-        if path in ["", ".", "./", "/", working_dir]:
+        if path == working_dir:
             raise ValueError(
-                "If using overwrite=True, path must be an explicit and not the current directory!!"
+                "Cannot clear the contents of the current working directory!"
             )
+        if append:
+            raise ValueError("Cannot use both `overwrite=True` and `append=True`!")
         if fs.exists(path) and fs.isdir(path):
-            # If the path exists, is a directory, and there are files present to overwrite
-            pfiles = fs.ls(path)
-            if len(pfiles) > 0:
-                fs.rm(path, recursive=True)
-            else:
-                raise FileNotFoundError(
-                    "Can not overwrite empty path or path not found!!"
-                )
+            # Only remove path contents if
+            # (1) The path exists
+            # (2) The path is a directory
+            # (3) The path is not the current working directory
+            fs.rm(path, recursive=True)
 
     # Save divisions and corresponding index name. This is necessary,
     # because we may be resetting the index to write the file

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -373,6 +373,7 @@ def to_parquet(
     compression="default",
     write_index=True,
     append=False,
+    overwrite=False,
     ignore_divisions=False,
     partition_on=None,
     storage_options=None,
@@ -408,6 +409,9 @@ def to_parquet(
         If False (default), construct data-set from scratch. If True, add new
         row-group(s) to an existing data-set. In the latter case, the data-set
         must exist, and the schema must match the input data.
+    overwrite : bool, optional
+        If False (default), write dataset to existing folder.  If True, delete
+        all files in the partitioned folder and write a fresh set of partitioned files
     ignore_divisions : bool, optional
         If False (default) raises error when previous divisions overlap with
         the new appended divisions. Ignored if append=False.
@@ -472,6 +476,9 @@ def to_parquet(
     fs, _, _ = get_fs_token_paths(path, mode="wb", storage_options=storage_options)
     # Trim any protocol information from the path before forwarding
     path = fs._strip_protocol(path)
+
+    if overwrite:
+        fs.rm(path, recursive=True)
 
     # Save divisions and corresponding index name. This is necessary,
     # because we may be resetting the index to write the file

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -477,7 +477,7 @@ def to_parquet(
     # Trim any protocol information from the path before forwarding
     path = fs._strip_protocol(path)
 
-    if overwrite and path:
+    if overwrite:
         if path in ["", ".", "./", "/"]:
             raise ValueError("If using overwrite=True, path must be an explicit directory!!")
         fs.rm(path, recursive=True)

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -478,9 +478,19 @@ def to_parquet(
     path = fs._strip_protocol(path)
 
     if overwrite:
-        if path in ["", ".", "./", "/"]:
-            raise ValueError("If using overwrite=True, path must be an explicit directory!!")
-        fs.rm(path, recursive=True)
+        import pdb;pdb.set_trace()
+        working_dir = fs.expand_path(".")
+        if path in ["", ".", "./", "/", working_dir]:
+            raise ValueError(
+                "If using overwrite=True, path must be an explicit and not the current directory!!"
+            )
+        if fs.exists(path) and fs.isdir(path):
+            # If the path exists, is a directory, and there are files present to overwrite
+            pfiles = fs.ls(path)
+            if len(pfiles) > 0:
+                fs.rm(path, recursive=True)
+            else:
+                raise FileNotFoundError("Can not overwrite empty path or path not found!!")
 
     # Save divisions and corresponding index name. This is necessary,
     # because we may be resetting the index to write the file

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -410,8 +410,10 @@ def to_parquet(
         row-group(s) to an existing data-set. In the latter case, the data-set
         must exist, and the schema must match the input data.
     overwrite : bool, optional
-        If False (default), write dataset to existing folder.  If True, delete
-        all files in the partitioned folder and write a fresh set of partitioned files
+        If False (default), write dataset to specified folder at path.  If True, delete
+        all files in the partitioned folder and write a fresh set of partitioned files.
+        Overwrite expects that path already exists, is a non-empty directory, and does
+        not reside in the location from which the function is being called.
     ignore_divisions : bool, optional
         If False (default) raises error when previous divisions overlap with
         the new appended divisions. Ignored if append=False.
@@ -478,8 +480,7 @@ def to_parquet(
     path = fs._strip_protocol(path)
 
     if overwrite:
-        import pdb;pdb.set_trace()
-        working_dir = fs.expand_path(".")
+        working_dir = fs.expand_path(".")[0]
         if path in ["", ".", "./", "/", working_dir]:
             raise ValueError(
                 "If using overwrite=True, path must be an explicit and not the current directory!!"
@@ -490,7 +491,9 @@ def to_parquet(
             if len(pfiles) > 0:
                 fs.rm(path, recursive=True)
             else:
-                raise FileNotFoundError("Can not overwrite empty path or path not found!!")
+                raise FileNotFoundError(
+                    "Can not overwrite empty path or path not found!!"
+                )
 
     # Save divisions and corresponding index name. This is necessary,
     # because we may be resetting the index to write the file

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -4,6 +4,7 @@ import tlz as toolz
 import warnings
 from ....bytes import core  # noqa
 from fsspec.core import get_fs_token_paths
+from fsspec.implementations.local import LocalFileSystem
 from fsspec.utils import stringify_path
 
 from ...core import DataFrame, new_dd_object
@@ -482,11 +483,12 @@ def to_parquet(
     path = fs._strip_protocol(path)
 
     if overwrite:
-        working_dir = fs.expand_path(".")[0]
-        if path == working_dir:
-            raise ValueError(
-                "Cannot clear the contents of the current working directory!"
-            )
+        if isinstance(fs, LocalFileSystem):
+            working_dir = fs.expand_path(".")[0]
+            if path == working_dir:
+                raise ValueError(
+                    "Cannot clear the contents of the current working directory!"
+                )
         if append:
             raise ValueError("Cannot use both `overwrite=True` and `append=True`!")
         if fs.isdir(path):

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -410,10 +410,12 @@ def to_parquet(
         row-group(s) to an existing data-set. In the latter case, the data-set
         must exist, and the schema must match the input data.
     overwrite : bool, optional
-        If False (default), write dataset to specified folder at path.  If True, delete
-        all files in the partitioned folder and write a fresh set of partitioned files.
-        Overwrite expects that path already exists, is a non-empty directory, and does
-        not reside in the location from which the function is being called.
+        Whether or not to remove the contents of `path` before writing the dataset.
+        The default is False.  If True, the specified path must correspond to
+        a directory (but not the current working directory).  This option cannot
+        be set to True if `append=True`.
+        NOTE: `overwrite=True` will remove the original data even if the current
+        write operation fails.  Use at your own risk.
     ignore_divisions : bool, optional
         If False (default) raises error when previous divisions overlap with
         the new appended divisions. Ignored if append=False.

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -477,7 +477,9 @@ def to_parquet(
     # Trim any protocol information from the path before forwarding
     path = fs._strip_protocol(path)
 
-    if overwrite:
+    if overwrite and path:
+        if path in ["", ".", "./", "/"]:
+            raise ValueError("If using overwrite=True, path must be an explicit directory!!")
         fs.rm(path, recursive=True)
 
     # Save divisions and corresponding index name. This is necessary,

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2977,19 +2977,3 @@ def test_nonempty_path_to_parquet_overwrite(tmpdir):
     with pytest.raises(ValueError):
         dd.to_parquet(ddf, ".", engine="pyarrow", overwrite=True)
 
-
-def test_dir_not_empty_overwrite(tmpdir):
-    # https://github.com/dask/dask/issues/6824
-    # Create a Dask DataFrame if size (100, 3) with 5 partitions and write to local, partitioning on the column E
-    df = pd.DataFrame(
-        np.vstack(
-            (
-                np.full((50, 3), 0),
-                np.full((50, 3), 1),
-            )
-        )
-    )
-    df.columns = ["A", "B", "C"]
-    ddf = dd.from_pandas(df, npartitions=5)
-    with pytest.raises(FileNotFoundError):
-        dd.to_parquet(ddf, tmpdir, overwrite=True)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2909,7 +2909,7 @@ def test_read_write_partitioned_overwrite_is_true(tmpdir):
 
     # Overwrite the existing Dataset with the new dataframe and evaluate
     # the number of files against the number of dask partitions
-    dd.to_parquet(ddf2, tmpdir, engine="pyarrow", overwrite=True)
+    dd.to_parquet(ddf2, tmpdir, engine=engine, overwrite=True)
 
     # Assert the # of files written are identical to the number of
     # Dask DataFrame partitions (we exclude _metadata and _common_metadata)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2953,3 +2953,25 @@ def test_read_write_partition_on_overwrite_is_true(tmpdir):
     # After reducing the # of partitions and overwriting, we expect
     # there to be fewer total files than were originally written
     assert len(files2) < len(files)
+
+def test_nonempty_path_to_parquet_overwrite(tmpdir):
+    # https://github.com/dask/dask/issues/6824
+    # Create a Dask DataFrame if size (10000, 10) with 5 partitions and write to local, partitioning on the column E
+    df = pd.DataFrame(
+        np.vstack(
+            (
+                np.full((50, 3), 0),
+                np.full((50, 3), 1),
+            )
+        )
+    )
+    df.columns = ["A", "B", "C"]
+    ddf = dd.from_pandas(df, npartitions=5)
+    with pytest.raises(ValueError):
+        dd.to_parquet(ddf, "", engine="pyarrow", overwrite=True)
+
+    with pytest.raises(ValueError):
+        dd.to_parquet(ddf, ".", engine="pyarrow", overwrite=True)
+
+    with pytest.raises(ValueError):
+        dd.to_parquet(ddf, "./", engine="pyarrow", overwrite=True)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2902,7 +2902,7 @@ def test_read_write_partitioned_overwrite_is_true(tmpdir):
         npartitions=5,
     )
     ddf = ddf.reset_index(drop=True)
-    dd.to_parquet(ddf, tmpdir, engine="pyarrow")
+    dd.to_parquet(ddf, tmpdir, engine=engine, overwrite=True)
 
     # Keep the contents of the DataFrame constatn but change the # of partitions
     ddf2 = ddf.repartition(npartitions=3)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2946,7 +2946,7 @@ def test_read_write_partition_on_overwrite_is_true(tmpdir, engine):
     # the number of files against the number of dask partitions
     # Get the total number of files and directories from the original write
     dd.to_parquet(
-        ddf2, tmpdir, engine="pyarrow", partition_on=["A", "B"], overwrite=True
+        ddf2, tmpdir, engine=engine, partition_on=["A", "B"], overwrite=True
     )
     files2_ = Path(tmpdir).rglob("*")
     files2 = [f.as_posix() for f in files2_]

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2956,7 +2956,7 @@ def test_read_write_partition_on_overwrite_is_true(tmpdir):
 
 def test_nonempty_path_to_parquet_overwrite(tmpdir):
     # https://github.com/dask/dask/issues/6824
-    # Create a Dask DataFrame if size (10000, 10) with 5 partitions and write to local, partitioning on the column E
+    # Create a Dask DataFrame if size (100, 3) with 5 partitions and write to local, partitioning on the column E
     df = pd.DataFrame(
         np.vstack(
             (
@@ -2971,7 +2971,23 @@ def test_nonempty_path_to_parquet_overwrite(tmpdir):
         dd.to_parquet(ddf, "", engine="pyarrow", overwrite=True)
 
     with pytest.raises(ValueError):
-        dd.to_parquet(ddf, ".", engine="pyarrow", overwrite=True)
+        dd.to_parquet(ddf, "", engine="pyarrow", overwrite=True)
 
     with pytest.raises(ValueError):
-        dd.to_parquet(ddf, "./", engine="pyarrow", overwrite=True)
+        dd.to_parquet(ddf, ".", engine="pyarrow", overwrite=True)
+
+def test_dir_not_empty_overwrite(tmpdir):
+    # https://github.com/dask/dask/issues/6824
+    # Create a Dask DataFrame if size (100, 3) with 5 partitions and write to local, partitioning on the column E
+    df = pd.DataFrame(
+        np.vstack(
+            (
+                np.full((50, 3), 0),
+                np.full((50, 3), 1),
+            )
+        )
+    )
+    df.columns = ["A", "B", "C"]
+    ddf = dd.from_pandas(df, npartitions=5)
+    with pytest.raises(FileNotFoundError):
+        dd.to_parquet(ddf, tmpdir, overwrite=True)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2890,7 +2890,7 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
     )
 
 
-def test_read_write_partitioned_overwrite_is_true(tmpdir):
+def test_read_write_overwrite_is_true(tmpdir, engine):
     # https://github.com/dask/dask/issues/6824
 
     # Create a Dask DataFrame if size (10000, 10) with 5 partitions and write to local

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2893,10 +2893,10 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
 def test_read_write_overwrite_is_true(tmpdir, engine):
     # https://github.com/dask/dask/issues/6824
 
-    # Create a Dask DataFrame if size (10000, 10) with 5 partitions and write to local
+    # Create a Dask DataFrame if size (100, 10) with 5 partitions and write to local
     ddf = dd.from_pandas(
         pd.DataFrame(
-            np.random.randint(low=0, high=100, size=(10000, 10)),
+            np.random.randint(low=0, high=100, size=(100, 10)),
             columns=["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"],
         ),
         npartitions=5,
@@ -2922,7 +2922,7 @@ def test_read_write_partition_on_overwrite_is_true(tmpdir, engine):
     # https://github.com/dask/dask/issues/6824
     from pathlib import Path
 
-    # Create a Dask DataFrame if size (10000, 10) with 5 partitions and write to local, partitioning on the column E
+    # Create a Dask DataFrame with 5 partitions and write to local, partitioning on the column A and column B
     df = pd.DataFrame(
         np.vstack(
             (

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2934,7 +2934,7 @@ def test_read_write_partition_on_overwrite_is_true(tmpdir, engine):
     )
     df.columns = ["A", "B", "C"]
     ddf = dd.from_pandas(df, npartitions=5)
-    dd.to_parquet(ddf, tmpdir, engine="pyarrow", partition_on=["A", "B"])
+    dd.to_parquet(ddf, tmpdir, engine=engine, partition_on=["A", "B"], overwrite=True)
 
     # Get the total number of files and directories from the original write
     files_ = Path(tmpdir).rglob("*")

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2955,25 +2955,13 @@ def test_read_write_partition_on_overwrite_is_true(tmpdir):
     assert len(files2) < len(files)
 
 
-def test_nonempty_path_to_parquet_overwrite(tmpdir):
+def test_to_parquet_overwrite_raises(tmpdir, engine):
     # https://github.com/dask/dask/issues/6824
-    # Create a Dask DataFrame if size (100, 3) with 5 partitions and write to local, partitioning on the column E
-    df = pd.DataFrame(
-        np.vstack(
-            (
-                np.full((50, 3), 0),
-                np.full((50, 3), 1),
-            )
-        )
-    )
-    df.columns = ["A", "B", "C"]
-    ddf = dd.from_pandas(df, npartitions=5)
+    # Check that overwrite=True will raise an error if the
+    # specified path is the current working directory
+    df = pd.DataFrame({"a": range(12)})
+    ddf = dd.from_pandas(df, npartitions=3)
     with pytest.raises(ValueError):
-        dd.to_parquet(ddf, "", engine="pyarrow", overwrite=True)
-
+        dd.to_parquet(ddf, "./", engine=engine, overwrite=True)
     with pytest.raises(ValueError):
-        dd.to_parquet(ddf, "", engine="pyarrow", overwrite=True)
-
-    with pytest.raises(ValueError):
-        dd.to_parquet(ddf, ".", engine="pyarrow", overwrite=True)
-
+        dd.to_parquet(ddf, tmpdir, engine=engine, append=True, overwrite=True)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2945,9 +2945,7 @@ def test_read_write_partition_on_overwrite_is_true(tmpdir, engine):
     # Overwrite the existing Dataset with the new dataframe and evaluate
     # the number of files against the number of dask partitions
     # Get the total number of files and directories from the original write
-    dd.to_parquet(
-        ddf2, tmpdir, engine=engine, partition_on=["A", "B"], overwrite=True
-    )
+    dd.to_parquet(ddf2, tmpdir, engine=engine, partition_on=["A", "B"], overwrite=True)
     files2_ = Path(tmpdir).rglob("*")
     files2 = [f.as_posix() for f in files2_]
     # After reducing the # of partitions and overwriting, we expect

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2918,7 +2918,7 @@ def test_read_write_partitioned_overwrite_is_true(tmpdir):
     assert len(files) == ddf2.npartitions
 
 
-def test_read_write_partition_on_overwrite_is_true(tmpdir):
+def test_read_write_partition_on_overwrite_is_true(tmpdir, engine):
     # https://github.com/dask/dask/issues/6824
     from pathlib import Path
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2954,6 +2954,7 @@ def test_read_write_partition_on_overwrite_is_true(tmpdir):
     # there to be fewer total files than were originally written
     assert len(files2) < len(files)
 
+
 def test_nonempty_path_to_parquet_overwrite(tmpdir):
     # https://github.com/dask/dask/issues/6824
     # Create a Dask DataFrame if size (100, 3) with 5 partitions and write to local, partitioning on the column E
@@ -2975,6 +2976,7 @@ def test_nonempty_path_to_parquet_overwrite(tmpdir):
 
     with pytest.raises(ValueError):
         dd.to_parquet(ddf, ".", engine="pyarrow", overwrite=True)
+
 
 def test_dir_not_empty_overwrite(tmpdir):
     # https://github.com/dask/dask/issues/6824

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2888,3 +2888,59 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
         append=True,
         ignore_divisions=True,
     )
+
+def test_read_write_partitioned_overwrite_is_true(tmpdir):
+    # https://github.com/dask/dask/issues/6824
+
+    # Create a Dask DataFrame if size (10000, 10) with 5 partitions and write to local
+    ddf = dd.from_pandas(pd.DataFrame(np.random.randint(
+        low=0, high=100, size=(10000, 10)
+        ),
+        columns=["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+        ), npartitions=5)
+    ddf = ddf.reset_index(drop=True)
+    dd.to_parquet(ddf, tmpdir, engine="pyarrow")
+
+    # Keep the contents of the DataFrame constatn but change the # of partitions
+    ddf2 = ddf.repartition(npartitions=3)
+
+    # Overwrite the existing Dataset with the new dataframe and evaluate
+    # the number of files against the number of dask partitions
+    dd.to_parquet(ddf2, tmpdir, engine="pyarrow", overwrite=True)
+
+    # Assert the # of files written are identical to the number of Dask DataFrame partitions (we exclude _metadata and _common_metadata)
+    files = os.listdir(tmpdir)
+    files = [f for f in files if f not in ['_common_metadata', '_metadata']]
+    assert len(files) == ddf2.npartitions
+
+def test_read_write_partition_on_overwrite_is_true(tmpdir):
+    # https://github.com/dask/dask/issues/6824
+    from pathlib import Path
+
+    # Create a Dask DataFrame if size (10000, 10) with 5 partitions and write to local, partitioning on the column E
+    df = pd.DataFrame(
+        np.vstack((
+        np.full((50, 3), 0),
+        np.full((50, 3), 1),
+        np.full((20, 3), 2),
+        ))
+    )
+    df.columns = ['A', 'B', 'C']
+    ddf = dd.from_pandas(df, npartitions=5)
+    dd.to_parquet(ddf, tmpdir, engine="pyarrow", partition_on=["A", "B"])
+
+    # Get the total number of files and directories from the original write
+    files_ = Path(tmpdir).rglob("*" )
+    files = [f.as_posix() for f in files_]
+    # Keep the contents of the DataFrame constant but change the # of partitions
+    ddf2 = ddf.repartition(npartitions=3)
+
+    # Overwrite the existing Dataset with the new dataframe and evaluate
+    # the number of files against the number of dask partitions
+    # Get the total number of files and directories from the original write
+    dd.to_parquet(ddf2, tmpdir, engine="pyarrow", partition_on=["A", "B"], overwrite=True)
+    files2_ = Path(tmpdir).rglob("*" )
+    files2 = [f.as_posix() for f in files_]
+    # After reducing the # of partitions and overwriting, we expect there to be fewer total files than were originally written
+    assert files2 < files
+    


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
Addresses #6824 