### PR TITLE
remove nans when setting sorted index

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -1253,12 +1253,8 @@ def compute_and_set_divisions(df, **kwargs):
     mins = df.index.map_partitions(M.min, meta=df.index)
     maxes = df.index.map_partitions(M.max, meta=df.index)
     mins, maxes = compute(mins, maxes, **kwargs)
-
-    if mins.isna().any() or maxes.isna().any():
-        raise ValueError(
-            "Partitions with all-NaN index values are not supported for sorted indices. "
-            "You may want to repartition before setting the index."
-        )
+    mins = remove_nans(mins)
+    maxes = remove_nans(maxes)
 
     if (
         sorted(mins) != list(mins)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1078,8 +1078,4 @@ def test_shuffle_hlg_layer_serialize(npartitions):
 def test_set_index_nan_partition():
     d[d.a > 3].set_index("a")  # Set index with 1 null partition
     d[d.a > 1].set_index("a", sorted=True)  # Set sorted index with 0 null partitions
-    with pytest.raises(
-        ValueError,
-        match="Partitions with all-NaN index values are not supported for sorted indices.",
-    ):
-        d[d.a > 3].set_index("a", sorted=True)  # Set sorted index with 1 null partition
+    d[d.a > 3].set_index("a", sorted=True)  # Set sorted index with 1 null partition

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1078,4 +1078,5 @@ def test_shuffle_hlg_layer_serialize(npartitions):
 def test_set_index_nan_partition():
     d[d.a > 3].set_index("a")  # Set index with 1 null partition
     d[d.a > 1].set_index("a", sorted=True)  # Set sorted index with 0 null partitions
-    d[d.a > 3].set_index("a", sorted=True)  # Set sorted index with 1 null partition
+    a = d[d.a > 3].set_index("a", sorted=True)  # Set sorted index with 1 null partition
+    assert_eq(a, a)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
