### PR TITLE
Dask-CuDF-map_partitions bug workaround

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -1254,6 +1254,13 @@ def compute_and_set_divisions(df, **kwargs):
     maxes = df.index.map_partitions(M.max, meta=df.index)
     mins, maxes = compute(mins, maxes, **kwargs)
 
+    # TODO: Remove these `is_series_like` checks when related
+    # cudf issue is resolved (https://github.com/rapidsai/cudf/issues/6738)
+    if not is_series_like(mins):
+        mins = pd.Series(mins)
+    if not is_series_like(maxes):
+        maxes = pd.Series(maxes)
+
     if mins.isna().any() or maxes.isna().any():
         raise ValueError(
             "Partitions with all-NaN index values are not supported for sorted indices. "

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -20,7 +20,7 @@ from ..delayed import delayed
 from ..highlevelgraph import HighLevelGraph, Layer
 from ..sizeof import sizeof
 from ..utils import digit, insert, M
-from .utils import hash_object_dispatch, group_split_dispatch
+from .utils import hash_object_dispatch, group_split_dispatch, is_series_like
 from . import methods
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
It seems that #6821 is causing a [dask_cudf CI failure](https://gpuci.gpuopenanalytics.com/blue/organizations/jenkins/rapidsai%2Fgpuci%2Fcudf%2Fprb%2Fcudf-gpu-build/detail/cudf-gpu-build/36328/pipeline/).  I believe I am accurately describing the root cause of the failure in [cudf#6738](https://github.com/rapidsai/cudf/issues/6738) (using `map_partitions` on an index is returning a `tuple` for dask_cudf objects, which clearly has no `isna` attribute).

Although I hope to get a fix into cudf soon, it would be ideal to merge a simple workaround in the meantime.
The only change here is a simple `is_series_like` check to make sure we can get away with the following `isna()` call.

cc @jsignell