### PR TITLE
Update sphinx currentmodule usage

### DIFF
--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -39,7 +39,7 @@ There are numerous pages with information about task runtimes, communication,
 statistical profiling, load balancing, memory use, and much more.
 For more information we recommend the video guide above.
 
-.. currentmodule:: dask.distributed     #doctest: +SKIP
+.. currentmodule:: dask.distributed
 
 .. autosummary::
    Client
@@ -95,7 +95,7 @@ detail:
 Progress bar
 ------------
 
-.. currentmodule:: dask.distributed     #doctest: +SKIP
+.. currentmodule:: dask.distributed
 
 .. autosummary::
    progress

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -22,7 +22,7 @@ despite its name, runs very well on a single machine).
            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
            allowfullscreen></iframe>
 
-.. currentmodule:: distributed #doctest: +SKIP
+.. currentmodule:: distributed
 
 Examples
 --------

--- a/docs/source/setup/adaptive.rst
+++ b/docs/source/setup/adaptive.rst
@@ -50,7 +50,7 @@ offer an ``.adapt()`` method.  Here is an example with
 
 For more keyword options, see the Adaptive class below:
 
-.. currentmodule:: distributed.deploy   #doctest: +SKIP
+.. currentmodule:: distributed.deploy
 
 .. autosummary::
    Adaptive

--- a/docs/source/setup/custom-startup.rst
+++ b/docs/source/setup/custom-startup.rst
@@ -112,7 +112,7 @@ You can also create a class with ``setup``, ``teardown``, and ``transition`` met
 and register that class with the scheduler to give to every worker using the
 ``Client.register_worker_plugin`` method.
 
-.. currentmodule:: distributed  #doctest: +SKIP
+.. currentmodule:: distributed
 
 .. autosummary::
    Client.register_worker_plugin

--- a/docs/source/setup/python-advanced.rst
+++ b/docs/source/setup/python-advanced.rst
@@ -1,7 +1,7 @@
 Python API (advanced)
 =====================
 
-.. currentmodule:: distributed  #doctest: +SKIP
+.. currentmodule:: distributed
 
 In some rare cases, experts may want to create ``Scheduler``, ``Worker``, and
 ``Nanny``  objects explicitly in Python.  This is often necessary when making

--- a/docs/source/setup/ssh.rst
+++ b/docs/source/setup/ssh.rst
@@ -10,7 +10,7 @@ or automatically using either the ``SSHCluster`` Python command or the
 Python Interface
 ----------------
 
-.. currentmodule:: distributed.deploy.ssh   #doctest: +SKIP
+.. currentmodule:: distributed.deploy.ssh
 
 .. autofunction:: SSHCluster
 


### PR DESCRIPTION
Currently we have several instances of `#doctest: +SKIP` being used in conjunction with `.. currentmodule::` in our docs. This is causing API docs to not render properly (see screenshots below). This PR removes `#doctest: +SKIP` which results in API docs rendering as expected

Current rendering:

<img width="1552" alt="Screen Shot 2020-11-13 at 1 59 37 PM" src="https://user-images.githubusercontent.com/11656932/99116310-6c3c4a00-25b9-11eb-8194-420370163660.png">

With the changes in this PR:

<img width="1552" alt="Screen Shot 2020-11-13 at 1 59 40 PM" src="https://user-images.githubusercontent.com/11656932/99116324-72cac180-25b9-11eb-9c7f-ec8d3787e207.png">


- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
