### PR TITLE
feat: use blake3 for byte hasing

### DIFF
--- a/dask/hashing.py
+++ b/dask/hashing.py
@@ -6,10 +6,26 @@ hashers = []  # In decreasing performance order
 
 
 # Timings on a largish array:
+# - blake3 is up to ~5x faster then CityHash on a 32 core machine (2x slower single threaded)
 # - CityHash is 2x faster than MurmurHash
 # - xxHash is slightly slower than CityHash
 # - MurmurHash is 8x faster than SHA1
 # - SHA1 is significantly faster than all other hashlib algorithms
+
+try:
+    import blake3  # `python -m pip install blake3`
+except ImportError:
+    pass
+else:
+
+    def _hash_blake3(buf):
+        """
+        Produce a 32-bytes hash of *buf* using blake3.
+        """
+        return blake3.blake3(buf, multithreading=True).digest()
+
+    hashers.append(_hash_blake3)
+
 
 try:
     import cityhash  # `python -m pip install cityhash`


### PR DESCRIPTION
This is using blake3, which is a multithreaded hasher: 
https://github.com/BLAKE3-team/BLAKE3

It's 5x faster on a 32core machine than cityhash, 2x faster on a quadcore than xxhash.

Python binding (pypi wheel available)
https://github.com/oconnor663/blake3-py
Conda-forge in the pipeline:
https://github.com/conda-forge/staged-recipes/pull/12703

Might be an interesting hasher, I'm using this in Vaex, but I prefer to use the dask machinery, without losing the blake3 performance.