### PR TITLE
Add support for cupyx sparse to dask.array.dot

### DIFF
--- a/dask/array/backends.py
+++ b/dask/array/backends.py
@@ -73,11 +73,12 @@ def register_scipy_sparse():
 
     concatenate_lookup.register(scipy.sparse.spmatrix, _concatenate)
 
-    def _tensordot(a, b, axes=None):
+    def _tensordot(a, b, axes):
         assert a.ndim == b.ndim == 2
         assert len(axes[0]) == len(axes[1]) == 1
         a_axis, = axes[0]
         b_axis, = axes[1]
+        assert a.shape[a_axis] == b.shape[b_axis]
         if a_axis == 0 and b_axis == 0:
             return a.T * b
         elif a_axis == 0 and b_axis == 1:

--- a/dask/array/backends.py
+++ b/dask/array/backends.py
@@ -54,6 +54,7 @@ def register_sparse():
     tensordot_lookup.register(sparse.COO, sparse.tensordot)
 
 
+@tensordot_lookup.register_lazy("scipy")
 @concatenate_lookup.register_lazy("scipy")
 def register_scipy_sparse():
     import scipy.sparse
@@ -71,3 +72,19 @@ def register_scipy_sparse():
             raise ValueError(msg)
 
     concatenate_lookup.register(scipy.sparse.spmatrix, _concatenate)
+
+    def _tensordot(a, b, axes=None):
+        assert a.ndim == b.ndim == 2
+        assert len(axes[0]) == len(axes[1]) == 1
+        a_axis, = axes[0]
+        b_axis, = axes[1]
+        if a_axis == 0 and b_axis == 0:
+            return a.T * b
+        elif a_axis == 0 and b_axis == 1:
+            return a.T * b.T
+        elif a_axis == 1 and b_axis == 0:
+            return a * b
+        elif a_axis == 1 and b_axis == 1:
+            return a * b.T
+
+    tensordot_lookup.register(scipy.sparse.spmatrix, _tensordot)


### PR DESCRIPTION
This addresses https://github.com/dask/dask/issues/6820 and makes it available to run `dask.array.dot` with cupyx sparse (and scipy sparse as well).

```python
import dask.array as da

import cupy as xp
from cupyx.scipy.sparse import csr_matrix
# import numpy as xp
# from scipy.sparse import csr_matrix

matrix_type = csr_matrix
print('matrix_type: {}'.format(matrix_type))

dtype = 'f'
x = xp.arange(24, dtype=dtype).reshape(4, 6)
w = xp.arange(18, dtype=dtype).reshape(6, 3)
ref = xp.dot(x, w)
print('ref:\n{}'.format(ref))

dx = da.from_array(x, chunks=(2, 3), asarray=False, fancy=False)
dx = dx.map_blocks(matrix_type, dtype=dtype)

dw = da.from_array(w, chunks=(3, 1), asarray=False, fancy=False)
dw = dw.map_blocks(matrix_type, dtype=dtype)

ret = da.dot(dx, dw).compute()
print('type(ret): {}'.format(type(ret)))
print('ret:\n{}'.format(ret.todense()))
```

<details>
<summary> Click to see the output with current master </summary>

```
matrix_type: <class 'cupyx.scipy.sparse.csr.csr_matrix'>
ref:
[[ 165.  180.  195.]
 [ 435.  486.  537.]
 [ 705.  792.  879.]
 [ 975. 1098. 1221.]]
Traceback (most recent call last):
  File "test-cupyx-sparse.py", line 23, in <module>
    ret = da.dot(dx, dw).compute()
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/base.py", line 224, in compute
    (result,) = compute(self, traverse=False, **kwargs)
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/base.py", line 512, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/threaded.py", line 84, in get
    **kwargs
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/local.py", line 486, in get_async
    raise_exception(exc, tb)
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/local.py", line 316, in reraise
    raise exc
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/local.py", line 222, in execute_task
    result = _execute_task(task, data)
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/core.py", line 121, in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/optimization.py", line 963, in __call__
    return core.get(self.dsk, self.outkey, dict(zip(self.inkeys, args)))
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/core.py", line 151, in get
    result = _execute_task(task, cache)
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/core.py", line 121, in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/core.py", line 121, in <genexpr>
    return func(*(_execute_task(a, cache) for a in args))
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/core.py", line 115, in _execute_task
    return [_execute_task(a, cache) for a in arg]
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/core.py", line 115, in <listcomp>
    return [_execute_task(a, cache) for a in arg]
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/core.py", line 121, in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/utils.py", line 29, in apply
    return func(*args, **kwargs)
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/dask-2.30.0+57.g3e264491-py3.7.egg/dask/array/routines.py", line 229, in _tensordot
    x = tensordot(a, b, axes=axes)
  File "<__array_function__ internals>", line 6, in tensordot
  File "/home/anaruse/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/site-packages/numpy/core/numeric.py", line 1075, in tensordot
    if as_[axes_a[k]] != bs[axes_b[k]]:
IndexError: tuple index out of range
```
</details>

<details>
<summary> Click to see the output with this PR </summary>

```
matrix_type: <class 'cupyx.scipy.sparse.csr.csr_matrix'>
ref:
[[ 165.  180.  195.]
 [ 435.  486.  537.]
 [ 705.  792.  879.]
 [ 975. 1098. 1221.]]
type(ret): <class 'cupyx.scipy.sparse.coo.coo_matrix'>
ret:
[[ 165.  180.  195.]
 [ 435.  486.  537.]
 [ 705.  792.  879.]
 [ 975. 1098. 1221.]]
```
</details>