### PR TITLE
__dask_distributed_pack__(): client argument

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -137,7 +137,7 @@ class SimpleShuffleLayer(Layer):
         ]
         return (SimpleShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
 
-    def __dask_distributed_pack__(self):
+    def __dask_distributed_pack__(self, client):
         from distributed.protocol.serialize import to_serialize
 
         return {
@@ -347,8 +347,8 @@ class ShuffleLayer(SimpleShuffleLayer):
         ]
         return (ShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
 
-    def __dask_distributed_pack__(self):
-        ret = super().__dask_distributed_pack__()
+    def __dask_distributed_pack__(self, client):
+        ret = super().__dask_distributed_pack__(client)
         ret["inputs"] = self.inputs
         ret["stage"] = self.stage
         ret["nsplits"] = self.nsplits

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -164,7 +164,7 @@ class Layer(collections.abc.Mapping):
 
         return BasicLayer({k: func(v) for k, v in self.items()})
 
-    def __dask_distributed_pack__(self) -> Optional[Any]:
+    def __dask_distributed_pack__(self, client) -> Optional[Any]:
         """Pack the layer for scheduler communication in Distributed
 
         This method should pack its current state and is called by the Client when
@@ -181,6 +181,11 @@ class Layer(collections.abc.Mapping):
 
         Alternatively, the method can return None, which will make Distributed
         materialize the layer and use a default packing method.
+
+        Parameters
+        ----------
+        client: distributed.Client
+            The client calling this function.
 
         Returns
         -------


### PR DESCRIPTION
This PR adds a `client` argument to `Layer.__dask_distributed_pack__()`, which is need when serializing `Blockwise` (see https://github.com/dask/dask/pull/6848)

Notice, this PR should be merged together with https://github.com/dask/distributed/pull/4248

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
