### PR TITLE
Add `create_metadata_file` utility for existing parquet datasets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.6", "3.7", "3.8"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.6", "3.7", "3.8"]

--- a/dask/dataframe/io/parquet/__init__.py
+++ b/dask/dataframe/io/parquet/__init__.py
@@ -1,1 +1,1 @@
-from .core import read_parquet, to_parquet, read_parquet_part
+from .core import read_parquet, to_parquet, read_parquet_part, create_metadata_file

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1047,3 +1047,29 @@ class ArrowEngine(Engine):
                 _append_row_groups(_meta, parts[i][0]["meta"])
             with fs.open(metadata_path, "wb") as fil:
                 _meta.write_metadata_file(fil)
+
+    @classmethod
+    def collect_file_metadata(cls, path, fs, file_path):
+        with fs.open(path, "rb") as f:
+            meta = pq.ParquetFile(f).metadata
+        if file_path:
+            meta.set_file_path(file_path)
+        return meta
+
+    @classmethod
+    def aggregate_metadata(cls, meta_list, fs, out_path):
+        meta = None
+        for _meta in meta_list:
+            if meta:
+                _append_row_groups(meta, _meta)
+            else:
+                meta = _meta
+        if out_path:
+            metadata_path = fs.sep.join([out_path, "_metadata"])
+            with fs.open(metadata_path, "wb") as fil:
+                if not meta:
+                    raise ValueError("Cannot write empty metdata!")
+                meta.write_metadata_file(fil)
+            return None
+        else:
+            return meta

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -197,10 +197,47 @@ class Engine:
 
     @classmethod
     def collect_file_metadata(cls, path, fs, file_path):
+        """
+        Collect parquet metadata from a file and set the file_path.
+
+        Parameters
+        ----------
+        path: str
+            Parquet-file path to extract metadata from.
+        fs: FileSystem
+        file_path: str
+            Relative path to set as `file_path` in the metadata.
+
+        Returns
+        -------
+        A metadata object.  The specific type should be recognized
+        by the aggregate_metadata method.
+        """
         raise NotImplementedError()
 
     @classmethod
-    def aggregate_metadata(cls, meta_list):
+    def aggregate_metadata(cls, meta_list, fs, out_path):
+        """
+        Aggregate a list of metadata objects and optionally
+        write out the final result as a _metadata file.
+
+        Parameters
+        ----------
+        meta_list: list
+            List of metadata objects to be aggregated into a single
+            metadata object, and optionally written to disk. The
+            specific element type can be engine specific.
+        fs: FileSystem
+        out_path: str or None
+            Directory to write the final _metadata file. If None
+            is specified, the aggregated metadata will be returned,
+            and nothing will be written to disk.
+
+        Returns
+        -------
+        If out_path is None, an aggregate metadata object is returned.
+        Otherwise, None is returned.
+        """
         raise NotImplementedError()
 
 

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -195,6 +195,14 @@ class Engine:
         """
         raise NotImplementedError()
 
+    @classmethod
+    def collect_file_metadata(cls, path, fs, file_path):
+        raise NotImplementedError()
+
+    @classmethod
+    def aggregate_metadata(cls, meta_list):
+        raise NotImplementedError()
+
 
 def _parse_pandas_metadata(pandas_metadata):
     """Get the set of names from the pandas metadata section

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2919,6 +2919,7 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
         fns,
         tmpdir,
         engine="pyarrow",
+        split_every=3,  # Force tree reduction
     )
 
     # Check that we can now read the ddf
@@ -2928,7 +2929,6 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
         gather_statistics=True,
         split_row_groups=False,
         engine=read_engine,
-        split_every=3,  # Force tree reduction
         index="myindex",  # python-3.6 CI
     )
     if partition_on:

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1,5 +1,6 @@
 import math
 import os
+import glob
 import sys
 import warnings
 from distutils.version import LooseVersion
@@ -811,7 +812,6 @@ def test_ordering(tmpdir, write_engine, read_engine):
 
 
 def test_read_parquet_custom_columns(tmpdir, engine):
-    import glob
 
     tmp = str(tmpdir)
     data = pd.DataFrame(
@@ -2093,7 +2093,6 @@ def test_read_glob_no_stats(tmpdir, write_engine, read_engine):
 def test_read_glob_yes_stats(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
     ddf.to_parquet(tmp_path, engine=write_engine)
-    import glob
 
     paths = glob.glob(os.path.join(tmp_path, "*.parquet"))
     paths.append(os.path.join(tmp_path, "_metadata"))
@@ -2894,7 +2893,6 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
 @pytest.mark.parametrize("partition_on", [None, "a"])
 @write_read_engines()
 def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
-    import glob
 
     check_pyarrow()
     tmpdir = str(tmpdir)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2900,9 +2900,9 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
     tmpdir = str(tmpdir)
 
     # Write ddf without a _metadata file
-    df = pd.DataFrame({"b": range(100), "a": ["A", "B", "C", "D"] * 25})
-    ddf = dd.from_pandas(df, npartitions=10)
-    ddf.to_parquet(
+    df1 = pd.DataFrame({"b": range(100), "a": ["A", "B", "C", "D"] * 25})
+    ddf1 = dd.from_pandas(df1, npartitions=10)
+    ddf1.to_parquet(
         tmpdir,
         write_metadata_file=False,
         partition_on=partition_on,
@@ -2930,10 +2930,10 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
         split_every=3,  # Force tree reduction
     )
     if partition_on:
-        ddf = df.sort_values("b")
+        ddf1 = df1.sort_values("b")
         ddf2 = ddf2.compute().sort_values("b")
         ddf2.a = ddf2.a.astype("object")
-    assert_eq(ddf, ddf2)
+    assert_eq(ddf1, ddf2)
 
 
 def test_create_metadata_file_inconsistent_schema_cudf(tmpdir, engine):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -823,8 +823,6 @@ def test_read_parquet_custom_columns(tmpdir, engine):
     df2 = dd.read_parquet(tmp, columns=["i32", "f"], engine=engine)
     assert_eq(df[["i32", "f"]], df2, check_index=False)
 
-    import glob
-
     fns = glob.glob(os.path.join(tmp, "*.parquet"))
     df2 = dd.read_parquet(fns, columns=["i32"], engine=engine).compute()
     df2.sort_values("i32", inplace=True)
@@ -2891,3 +2889,99 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
         append=True,
         ignore_divisions=True,
     )
+
+
+@pytest.mark.parametrize("partition_on", [None, "a"])
+@write_read_engines()
+def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
+    import glob
+
+    check_pyarrow()
+    tmpdir = str(tmpdir)
+
+    # Write ddf without a _metadata file
+    df = pd.DataFrame({"b": range(100), "a": ["A", "B", "C", "D"] * 25})
+    ddf = dd.from_pandas(df, npartitions=10)
+    ddf.to_parquet(
+        tmpdir,
+        write_metadata_file=False,
+        partition_on=partition_on,
+        engine=write_engine,
+    )
+
+    # Add global _metadata file
+    if partition_on:
+        fns = glob.glob(os.path.join(tmpdir, partition_on + "=*/*.parquet"))
+    else:
+        fns = glob.glob(os.path.join(tmpdir, "*.parquet"))
+    dd.io.parquet.core.create_metadata_file(
+        fns,
+        tmpdir,
+        engine="pyarrow",
+    )
+
+    # Check that we can now read the ddf
+    # with the _metadata file present
+    ddf2 = dd.read_parquet(
+        tmpdir,
+        gather_statistics=True,
+        split_row_groups=False,
+        engine=read_engine,
+        split_every=3,  # Force tree reduction
+    )
+    if partition_on:
+        ddf = df.sort_values("b")
+        ddf2 = ddf2.compute().sort_values("b")
+        ddf2.a = ddf2.a.astype("object")
+    assert_eq(ddf, ddf2)
+
+
+def test_create_metadata_file_inconsistent_schema_cudf(tmpdir, engine):
+
+    # NOTE: This is a TEMPORARY test to demonstrate
+    # that the CudfEngine can be used to generate
+    # a global `_metadata` file even if there are
+    # inconsistent schemas in the dataset.
+
+    check_pyarrow()
+    dask_cudf = pytest.importorskip("dask_cudf")
+
+    # Write file 0
+    df0 = pd.DataFrame({"a": [None] * 10, "b": range(10)})
+    p0 = os.path.join(tmpdir, "part.0.parquet")
+    df0.to_parquet(p0, engine="pyarrow")
+
+    # Write file 1
+    b = list(range(10))
+    b[1] = None
+    df1 = pd.DataFrame({"a": range(10), "b": b})
+    p1 = os.path.join(tmpdir, "part.1.parquet")
+    df1.to_parquet(p1, engine="pyarrow")
+
+    with pytest.raises(RuntimeError):
+        # Pyarrow will fail to aggregate metadata
+        # if gather_statistics=True
+        dd.read_parquet(
+            str(tmpdir),
+            gather_statistics=True,
+            engine="pyarrow",
+        ).compute()
+
+    # Add global metadata file.
+    # Dask-CuDF can do this without requiring schema
+    # consistency.  Once the _metadata file is avaible,
+    # parsing metadata should no longer be a problem
+    dd.io.parquet.core.create_metadata_file(
+        [p0, p1],
+        str(tmpdir),
+        out_dir=str(tmpdir),
+        engine=dask_cudf.io.parquet.CudfEngine,
+    )
+
+    # Check that we can now read the ddf
+    # with the _metadata file present
+    dd.read_parquet(
+        str(tmpdir),
+        gather_statistics=True,
+        engine=engine,
+    ).compute()

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2917,7 +2917,6 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
         fns = glob.glob(os.path.join(tmpdir, "*.parquet"))
     dd.io.parquet.create_metadata_file(
         fns,
-        tmpdir,
         engine="pyarrow",
         split_every=3,  # Force tree reduction
     )

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2901,6 +2901,7 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
 
     # Write ddf without a _metadata file
     df1 = pd.DataFrame({"b": range(100), "a": ["A", "B", "C", "D"] * 25})
+    df1.index.name = "myindex"
     ddf1 = dd.from_pandas(df1, npartitions=10)
     ddf1.to_parquet(
         tmpdir,


### PR DESCRIPTION
This PR adds a simple utility to construct a global `_metadata` file from the footer metadata in a list of files.  Since Dask's `read_parquet` code is optimized to leverage this shared metadata source, it makes a lot of sense to make this file easy to generate.

**Use Example**

```python
import glob
import dask.datframe as dd

# Specify the list of parquet files to collect metadata from
paths = glob.glob("/my/dataset/*.parquet")

# Use `create_metadata_file` to generate `_metadata`
dd.io.parquet.create_metadata_file(paths)
...
```

**TODO**:
- [x] Add better description to this PR
- [x] Remove temporary cudf-based test (open separate cudf PR)
- [x] Avoid use of `os.path.relpath`
- [x] General cleanup (and add comments)

NOTE: This will help resolve to [NVT#429](https://github.com/NVIDIA/NVTabular/issues/429) (Updating the `CudfEngine` engine in `dask_cudf` will avoid the "inconsistent schema" error altogether)