### PR TITLE
Remove map_tasks() and map_basic_layers()

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1,6 +1,5 @@
 import itertools
 import warnings
-import copy
 
 import numpy as np
 
@@ -426,23 +425,6 @@ class Blockwise(Layer):
             return culled_layer, culled_deps
         else:
             return self, culled_deps
-
-    def map_tasks(self, func):
-        new_indices = []
-        for key, input_indices in self.indices:
-            if input_indices is None:  # A literal
-                new_indices.append((func([key]), None))
-            else:
-                new_indices.append((key, input_indices))
-        ret = copy.copy(self)
-        ret.indices = new_indices
-
-        # This operation invalidate the cache
-        try:
-            del self._cached_dict
-        except AttributeError:
-            pass
-        return ret
 
 
 def _get_coord_mapping(

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -111,10 +111,6 @@ class ParquetSubgraph(Layer):
         )
         return ret, ret.get_dependencies(all_hlg_keys)
 
-    def map_tasks(self, func):
-        # ParquetSubgraph has no input tasks
-        return self
-
 
 class BlockwiseParquet(Blockwise):
     """

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -1,4 +1,3 @@
-from functools import partial
 import os
 
 import pytest
@@ -8,8 +7,6 @@ import dask
 import dask.array as da
 from dask.utils_test import inc
 from dask.highlevelgraph import HighLevelGraph, BasicLayer, Layer
-from dask.blockwise import Blockwise
-from dask.array.utils import assert_eq
 
 
 def test_visualize(tmpdir):
@@ -63,55 +60,6 @@ def test_cull():
 
     culled_by_y = hg.cull({"y"})
     assert dict(culled_by_y) == a
-
-
-@pytest.mark.parametrize("inject_dict", [True, False])
-def test_map_basic_layers(inject_dict):
-    """Check map_basic_layers() by injecting an inc() call"""
-
-    y = da.ones(3, chunks=(3,), dtype="int") + 40
-
-    def inject_inc(dsk):
-        assert isinstance(dsk, BasicLayer)
-        dsk = dict(dsk)
-        k = next(iter(dsk))
-        dsk[k] = (inc, dsk[k])
-        if inject_dict:
-            return dsk  # map_basic_layers() should automatically convert it to a `BasicLayer`
-        else:
-            return BasicLayer(dsk)
-
-    dsk = y.__dask_graph__()
-    y.dask = dsk.map_basic_layers(inject_inc)
-    layers = list(y.dask.layers.values())
-    assert isinstance(layers[0], BasicLayer)
-    assert isinstance(layers[1], Blockwise)
-    assert_eq(y, [42] * 3)
-
-
-@pytest.mark.parametrize("use_layer_map_task", [True, False])
-def test_map_tasks(use_layer_map_task):
-    """Check map_tasks() by injecting an +1 to the `40` literal"""
-    y = da.ones(3, chunks=(3,), dtype="int") + 40
-
-    def plus_one(tasks):
-        ret = []
-        for t in tasks:
-            if t == 40:
-                t += 1
-            ret.append(t)
-        return tuple(ret)
-
-    dsk = y.__dask_graph__()
-
-    if use_layer_map_task:
-        # In order to test the default map_tasks() implementation on a Blockwise Layer,
-        # we overwrite Blockwise.map_tasks with Layer.map_tasks
-        blockwise_layer = list(dsk.layers.values())[1]
-        blockwise_layer.map_tasks = partial(Layer.map_tasks, blockwise_layer)
-
-    y.dask = dsk.map_tasks(plus_one)
-    assert_eq(y, [42] * 3)
 
 
 def annot_map_fn(key):


### PR DESCRIPTION
Removing `map_tasks()` and `map_basic_layers()` from high level graphs as they are not used anymore. 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
