### PR TITLE
Add observed keyword to groupby

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1123,7 +1123,12 @@ class _GroupBy(object):
         else:
             index_meta = self.index
 
-        grouped = sample.groupby(index_meta, group_keys=self.group_keys, **self.dropna)
+        grouped = sample.groupby(
+            index_meta,
+            group_keys=self.group_keys,
+            **self.dropna,
+            observed=self.observed
+        )
         return _maybe_slice(grouped, self._slice)
 
     def _aca_agg(

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2422,6 +2422,9 @@ def test_groupby_sort_true_split_out():
         M.sum(ddf.groupby("x", sort=True), split_out=2)
 
 
+@pytest.mark.skipif(
+    not dd._compat.PANDAS_GT_100, reason="observed only supported for newer pandas"
+)
 @pytest.mark.parametrize("known_cats", [True, False])
 @pytest.mark.parametrize("ordered_cats", [True, False])
 @pytest.mark.parametrize("groupby", ["cat_1", ["cat_1", "cat_2"]])
@@ -2429,9 +2432,12 @@ def test_groupby_sort_true_split_out():
 def test_groupby_aggregate_categorical_observed(
     known_cats, ordered_cats, agg_func, groupby, observed
 ):
-    # nunique is not implemented for DataFrameGroupBy
-    if agg_func == "nunique":
+    if agg_func in ["cov", "corr", "nunique"]:
         pytest.skip("Not implemented for DataFrameGroupBy yet.")
+    if agg_func in ["sum", "count", "prod"] and groupby != "cat_1":
+        pytest.skip("Gives zeros rather than nans.")
+    if agg_func in ["std", "var"] and observed:
+        pytest.skip("Can't calculate observed with all nans")
 
     pdf = pd.DataFrame(
         {

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2420,3 +2420,38 @@ def test_groupby_sort_true_split_out():
     with pytest.raises(NotImplementedError):
         # Cannot use sort=True with split_out>1 (for now)
         M.sum(ddf.groupby("x", sort=True), split_out=2)
+
+
+@pytest.mark.parametrize("known_cats", [True, False])
+@pytest.mark.parametrize("ordered_cats", [True, False])
+@pytest.mark.parametrize("groupby", ["cat_1", ["cat_1", "cat_2"]])
+@pytest.mark.parametrize("observed", [True, False])
+def test_groupby_aggregate_categorical_observed(
+    known_cats, ordered_cats, agg_func, groupby, observed
+):
+    # nunique is not implemented for DataFrameGroupBy
+    if agg_func == "nunique":
+        pytest.skip("Not implemented for DataFrameGroupBy yet.")
+
+    pdf = pd.DataFrame(
+        {
+            "cat_1": pd.Categorical(
+                list("AB"), categories=list("ABCDE"), ordered=ordered_cats
+            ),
+            "cat_2": pd.Categorical([1, 2], categories=[1, 2, 3], ordered=ordered_cats),
+            "value_1": np.random.uniform(size=2),
+        }
+    )
+    ddf = dd.from_pandas(pdf, 2)
+
+    if not known_cats:
+        ddf["cat_1"] = ddf["cat_1"].cat.as_unknown()
+        ddf["cat_2"] = ddf["cat_2"].cat.as_unknown()
+
+    def agg(grp, **kwargs):
+        return getattr(grp, agg_func)(**kwargs)
+
+    assert_eq(
+        agg(pdf.groupby(groupby, observed=observed)),
+        agg(ddf.groupby(groupby, observed=observed)),
+    )


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
closes #4371


~~Remaining error:~~
<details>

```python-traceback
dask/dataframe/tests/test_groupby.py::test_groupby_aggregate_categorical_observed[sum-False-groupby1-True-True] 
>>>>>>>>>>>>>>>>>>>>>>>>> PDB set_trace (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>
> /home/julia/dask/dask/dataframe/tests/test_groupby.py(2457)test_groupby_aggregate_categorical_observed()
-> assert_eq(expected, actual)
(Pdb) expected
              value_1
cat_1 cat_2          
A     1      0.783048
      2           NaN
      3           NaN
B     1           NaN
      2      0.376080
      3           NaN
C     1           NaN
      2           NaN
      3           NaN
D     1           NaN
      2           NaN
      3           NaN
E     1           NaN
      2           NaN
      3           NaN
(Pdb) actual.compute()
              value_1
cat_1 cat_2          
A     1      0.783048
      2      0.000000
      3      0.000000
B     1      0.000000
      2      0.376080
      3      0.000000
C     1      0.000000
      2      0.000000
      3      0.000000
D     1      0.000000
      2      0.000000
      3      0.000000
E     1      0.000000
      2      0.000000
      3      0.000000
(Pdb) c

>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB continue (IO-capturing resumed) >>>>>>>>>>>>>>>>>>>>>>>>>>>
FAILED [  5%]
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

known_cats = True, ordered_cats = True, agg_func = 'sum', groupby = ['cat_1', 'cat_2']
observed = False

    @pytest.mark.parametrize("known_cats", [True, False])
    @pytest.mark.parametrize("ordered_cats", [True, False])
    @pytest.mark.parametrize("groupby", ["cat_1", ["cat_1", "cat_2"]])
    @pytest.mark.parametrize("observed", [True, False])
    def test_groupby_aggregate_categorical_observed(
        known_cats, ordered_cats, agg_func, groupby, observed
    ):
        # nunique is not implemented for DataFrameGroupBy
        if agg_func == "nunique":
            pytest.skip("Not implemented for DataFrameGroupBy yet.")
    
        pdf = pd.DataFrame(
            {
                "cat_1": pd.Categorical(
                    list("AB"), categories=list("ABCDE"), ordered=ordered_cats
                ),
                "cat_2": pd.Categorical([1, 2], categories=[1, 2, 3], ordered=ordered_cats),
                "value_1": np.random.uniform(size=2),
            }
        )
        ddf = dd.from_pandas(pdf, 2)
    
        if not known_cats:
            ddf["cat_1"] = ddf["cat_1"].cat.as_unknown()
            ddf["cat_2"] = ddf["cat_2"].cat.as_unknown()
    
        def agg(grp, **kwargs):
            return getattr(grp, agg_func)(**kwargs)
    
        expected = agg(pdf.groupby(groupby, observed=observed))
        actual = agg(ddf.groupby(groupby, observed=observed))
        breakpoint()
>       assert_eq(expected, actual)

dask/dataframe/tests/test_groupby.py:2457: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
dask/dataframe/utils.py:828: in assert_eq
    tm.assert_frame_equal(a, b, **kwargs)
pandas/_libs/testing.pyx:64: in pandas._libs.testing.assert_almost_equal
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   AssertionError: DataFrame.iloc[:, 0] (column name="value_1") are different
E   
E   DataFrame.iloc[:, 0] (column name="value_1") values are different (86.66667 %)
E   [index]: [(A, 1), (A, 2), (A, 3), (B, 1), (B, 2), (B, 3), (C, 1), (C, 2), (C, 3), (D, 1), (D, 2), (D, 3), (E, 1), (E, 2), (E, 3)]
E   [left]:  [0.7830476213592577, nan, nan, nan, 0.3760800903574838, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan]
E   [right]: [0.7830476213592577, 0.0, 0.0, 0.0, 0.3760800903574838, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]

pandas/_libs/testing.pyx:178: AssertionError
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

>>>>>>>>>>>>>>>>>>>>>>>> PDB post_mortem (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>
> /home/julia/dask/pandas/_libs/testing.pyx(178)pandas._libs.testing.assert_almost_equal()
```
</details>