### PR TITLE
Get config item if variable is None

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -423,11 +423,11 @@ def refresh(config=config, defaults=defaults, **kwargs):
     update(config, collect(**kwargs))
 
 
-def get(key, default=no_default, config=config, if_not_set=None):
+def get(key, default=no_default, config=config, override_with=None):
     """
     Get elements from global config
 
-    If ``if_not_set`` is not None this value will be passed straight back.
+    If ``override_with`` is not None this value will be passed straight back.
     Useful for getting kwarg defaults from Dask config.
 
     Use '.' for nested access
@@ -444,18 +444,18 @@ def get(key, default=no_default, config=config, if_not_set=None):
     >>> config.get('foo.x.y', default=123)  # doctest: +SKIP
     123
 
-    >>> config.get('foo.y', if_not_set=None)  # doctest: +SKIP
+    >>> config.get('foo.y', override_with=None)  # doctest: +SKIP
     2
 
-    >>> config.get('foo.y', if_not_set=3)  # doctest: +SKIP
+    >>> config.get('foo.y', override_with=3)  # doctest: +SKIP
     3
 
     See Also
     --------
     dask.config.set
     """
-    if if_not_set is not None:
-        return if_not_set
+    if override_with is not None:
+        return override_with
     keys = key.split(".")
     result = config
     for k in keys:

--- a/dask/config.py
+++ b/dask/config.py
@@ -459,29 +459,6 @@ def get(key, default=no_default, config=config):
     return result
 
 
-def default_get(default, key, **kwargs):
-    """Get config if default is not set.
-
-    It is common for functions in Dask to fall back to config if
-    a keyword argument has not been set. This results in code like the following.
-
-    >>> def my_func(my_kwarg=None):
-    ...     var = my_kwarg if my_kwarg is not None else dask.config.get("some.option")
-
-    This method replaces this pattern.
-
-    >>> def my_func(my_kwarg=None):
-    ...     var = dask.config.default_get(my_kwarg, "some.option")
-
-    In this case if ``my_kwarg`` has been set it will be returned, otherwise the config option
-    ``some.option`` will be returned.
-
-    """
-    if default is not None:
-        return default
-    return get(key, **kwargs)
-
-
 def rename(aliases, config=config):
     """Rename old keys to new keys
 

--- a/dask/config.py
+++ b/dask/config.py
@@ -459,6 +459,29 @@ def get(key, default=no_default, config=config):
     return result
 
 
+def default_get(default, key, **kwargs):
+    """Get config if default is not set.
+
+    It is common for functions in Dask to fall back to config if
+    a keyword argument has not been set. This results in code like the following.
+
+    >>> def my_func(my_kwarg=None):
+    ...     var = my_kwarg if my_kwarg is not None else dask.config.get("some.option")
+
+    This method replaces this pattern.
+
+    >>> def my_func(my_kwarg=None):
+    ...     var = dask.config.default_get(my_kwarg, "some.option")
+
+    In this case if ``my_kwarg`` has been set it will be returned, otherwise the config option
+    ``some.option`` will be returned.
+
+    """
+    if default is not None:
+        return default
+    return get(key, **kwargs)
+
+
 def rename(aliases, config=config):
     """Rename old keys to new keys
 

--- a/dask/config.py
+++ b/dask/config.py
@@ -423,9 +423,12 @@ def refresh(config=config, defaults=defaults, **kwargs):
     update(config, collect(**kwargs))
 
 
-def get(key, default=no_default, config=config):
+def get(key, default=no_default, config=config, if_not_set=None):
     """
     Get elements from global config
+
+    If ``if_not_set`` is not None this value will be passed straight back.
+    Useful for getting kwarg defaults from Dask config.
 
     Use '.' for nested access
 
@@ -441,10 +444,18 @@ def get(key, default=no_default, config=config):
     >>> config.get('foo.x.y', default=123)  # doctest: +SKIP
     123
 
+    >>> config.get('foo.y', if_not_set=None)  # doctest: +SKIP
+    2
+
+    >>> config.get('foo.y', if_not_set=3)  # doctest: +SKIP
+    3
+
     See Also
     --------
     dask.config.set
     """
+    if if_not_set is not None:
+        return if_not_set
     keys = key.split(".")
     result = config
     for k in keys:

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -13,7 +13,6 @@ from dask.config import (
     collect,
     collect_yaml,
     collect_env,
-    default_get,
     get,
     ensure_file,
     set,
@@ -482,9 +481,8 @@ def test_default_get():
 
         # Otherwise pass the default straight through
         assert dask.config.default_get("baz", "foo") == "baz"
-        assert dask.config.default_get(False, "foo") == False
-        assert dask.config.default_get(True, "foo") == True
+        assert dask.config.default_get(False, "foo") is False
+        assert dask.config.default_get(True, "foo") is True
         assert dask.config.default_get(123, "foo") == 123
         assert dask.config.default_get({"hello": "world"}, "foo") == {"hello": "world"}
         assert dask.config.default_get(["one"], "foo") == ["one"]
-

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -13,7 +13,6 @@ from dask.config import (
     collect,
     collect_yaml,
     collect_env,
-    default_get,
     get,
     ensure_file,
     set,
@@ -473,18 +472,3 @@ def test_deprecations():
             assert dask.config.get("optimization.fuse.ave-width") == 123
 
     assert "optimization.fuse.ave-width" in str(info[0].message)
-
-
-def test_default_get():
-    with dask.config.set({"foo": "bar"}):
-        # If the default is None get the config key
-        assert dask.config.default_get(None, "foo") == "bar"
-
-        # Otherwise pass the default straight through
-        assert dask.config.default_get("baz", "foo") == "baz"
-        assert dask.config.default_get(False, "foo") == False
-        assert dask.config.default_get(True, "foo") == True
-        assert dask.config.default_get(123, "foo") == 123
-        assert dask.config.default_get({"hello": "world"}, "foo") == {"hello": "world"}
-        assert dask.config.default_get(["one"], "foo") == ["one"]
-

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -13,6 +13,7 @@ from dask.config import (
     collect,
     collect_yaml,
     collect_env,
+    default_get,
     get,
     ensure_file,
     set,
@@ -481,8 +482,9 @@ def test_default_get():
 
         # Otherwise pass the default straight through
         assert dask.config.default_get("baz", "foo") == "baz"
-        assert dask.config.default_get(False, "foo") is False
-        assert dask.config.default_get(True, "foo") is True
+        assert dask.config.default_get(False, "foo") == False
+        assert dask.config.default_get(True, "foo") == True
         assert dask.config.default_get(123, "foo") == 123
         assert dask.config.default_get({"hello": "world"}, "foo") == {"hello": "world"}
         assert dask.config.default_get(["one"], "foo") == ["one"]
+

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -472,3 +472,20 @@ def test_deprecations():
             assert dask.config.get("optimization.fuse.ave-width") == 123
 
     assert "optimization.fuse.ave-width" in str(info[0].message)
+
+
+def test_get_if_not_set():
+    with dask.config.set({"foo": "bar"}):
+        # If if_not_set is None get the config key
+        assert dask.config.get("foo") == "bar"
+        assert dask.config.get("foo", if_not_set=None) == "bar"
+
+        # Otherwise pass the default straight through
+        assert dask.config.get("foo", if_not_set="baz") == "baz"
+        assert dask.config.get("foo", if_not_set=False) is False
+        assert dask.config.get("foo", if_not_set=True) is True
+        assert dask.config.get("foo", if_not_set=123) == 123
+        assert dask.config.get("foo", if_not_set={"hello": "world"}) == {
+            "hello": "world"
+        }
+        assert dask.config.get("foo", if_not_set=["one"]) == ["one"]

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -474,18 +474,18 @@ def test_deprecations():
     assert "optimization.fuse.ave-width" in str(info[0].message)
 
 
-def test_get_if_not_set():
+def test_get_override_with():
     with dask.config.set({"foo": "bar"}):
-        # If if_not_set is None get the config key
+        # If override_with is None get the config key
         assert dask.config.get("foo") == "bar"
-        assert dask.config.get("foo", if_not_set=None) == "bar"
+        assert dask.config.get("foo", override_with=None) == "bar"
 
         # Otherwise pass the default straight through
-        assert dask.config.get("foo", if_not_set="baz") == "baz"
-        assert dask.config.get("foo", if_not_set=False) is False
-        assert dask.config.get("foo", if_not_set=True) is True
-        assert dask.config.get("foo", if_not_set=123) == 123
-        assert dask.config.get("foo", if_not_set={"hello": "world"}) == {
+        assert dask.config.get("foo", override_with="baz") == "baz"
+        assert dask.config.get("foo", override_with=False) is False
+        assert dask.config.get("foo", override_with=True) is True
+        assert dask.config.get("foo", override_with=123) == 123
+        assert dask.config.get("foo", override_with={"hello": "world"}) == {
             "hello": "world"
         }
-        assert dask.config.get("foo", if_not_set=["one"]) == ["one"]
+        assert dask.config.get("foo", override_with=["one"]) == ["one"]

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -13,6 +13,7 @@ from dask.config import (
     collect,
     collect_yaml,
     collect_env,
+    default_get,
     get,
     ensure_file,
     set,
@@ -472,3 +473,18 @@ def test_deprecations():
             assert dask.config.get("optimization.fuse.ave-width") == 123
 
     assert "optimization.fuse.ave-width" in str(info[0].message)
+
+
+def test_default_get():
+    with dask.config.set({"foo": "bar"}):
+        # If the default is None get the config key
+        assert dask.config.default_get(None, "foo") == "bar"
+
+        # Otherwise pass the default straight through
+        assert dask.config.default_get("baz", "foo") == "baz"
+        assert dask.config.default_get(False, "foo") == False
+        assert dask.config.default_get(True, "foo") == True
+        assert dask.config.default_get(123, "foo") == 123
+        assert dask.config.default_get({"hello": "world"}, "foo") == {"hello": "world"}
+        assert dask.config.default_get(["one"], "foo") == ["one"]
+


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Add config method which either passes a value straight through, of if it is `None` gets a value from the config.

```python
>>> with dask.config.set({"foo": "bar"}):
...     # If the default is None get the config key
...     dask.config.default_get(None, "foo")
"bar"

>>> with dask.config.set({"foo": "bar"}):
...     # Otherwise pass the default straight through
...     dask.config.default_get("baz", "foo")
"baz"
```

Method name still very much up for discussion. Current contenders are:
- `default_get`
- `get_if_none`
- `maybe_get` (@jsignell)

Closes #6860 