### PR TITLE
Check for precision error in datetime _percentile

### DIFF
--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -24,8 +24,11 @@ def _percentile(a, q, interpolation="linear"):
         return pd.Categorical.from_codes(result, a.categories, a.ordered), n
     if np.issubdtype(a.dtype, np.datetime64):
         a2 = a.astype("i8")
-        result = np.percentile(a2, q, interpolation=interpolation)
-        return result.astype(a.dtype), n
+        result = np.percentile(a2, q, interpolation=interpolation).astype(a.dtype)
+        if q[0] == 0:
+            # https://github.com/dask/dask/issues/6864
+            result[0] = min(result[0], a.min())
+        return result, n
     if not np.issubdtype(a.dtype, np.number):
         interpolation = "nearest"
     return np.percentile(a, q, interpolation=interpolation), n

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -650,6 +650,26 @@ def test_set_index_timezone():
         d2.divisions[0] == s2badtype[0]
 
 
+@pytest.mark.parametrize("unit", ["ns", "us"])
+def test_set_index_datetime_precision(unit):
+    # https://github.com/dask/dask/issues/6864
+
+    df = pd.DataFrame(
+        [
+            [1567703791155681, 1],
+            [1567703792155681, 2],
+            [1567703790155681, 0],
+            [1567703793155681, 3],
+        ],
+        columns=["ts", "rank"],
+    )
+    df.ts = pd.to_datetime(df.ts, unit=unit)
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = ddf.set_index("ts")
+
+    assert_eq(ddf, df.set_index("ts"))
+
+
 @pytest.mark.parametrize("drop", [True, False])
 def test_set_index_drop(drop):
     pdf = pd.DataFrame(


### PR DESCRIPTION
Closes #6864 

It is currently possible for a `set_index` operation to loose data when the target is a datetime64 column.  This is because the column is cast to `i8` to perform `numpy.percentile` on each partition, before casting back to the original dtype.  It seems that this round trip can lead to small errors in the first division (actually in all divisions, but the first division is the most critical).

Not sure that this PR is the cleanest solution, but it does ensure that the first division is not too large.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
