### PR TITLE
Array chunk warning

### DIFF
--- a/a.txt
+++ b/a.txt
@@ -1,0 +1,2 @@
+test
+test text

--- a/a.txt
+++ b/a.txt
@@ -1,2 +1,0 @@
-test
-test text

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -661,6 +661,22 @@ def map_blocks(
 
     original_kwargs = kwargs
 
+    # issue warning when mapping function with axis argument when array chunks > 1
+    if has_keyword(func, "axis"):
+        if len(arrs) == 1:
+            n_axis_chunks = [len(x) for x in arrs[0].chunks]
+            if any([n_chunks > 1 for n_chunks in n_axis_chunks]):
+                if "axis" in original_kwargs.keys():
+                    axis_chunks = n_axis_chunks[original_kwargs["axis"]]
+                    if axis_chunks > 1:
+                        warnings.warn(
+                            "Operating along axis with nchunks>1 may produce unexpected behavior"
+                        )
+                else:
+                    warnings.warn(
+                        "Mapping function with axis arguments along axis with nchunks>1 may produce unexpected behavior"
+                    )
+
     if dtype is None and meta is None:
         try:
             meta = compute_meta(func, dtype, *args, **kwargs)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -661,20 +661,13 @@ def map_blocks(
 
     original_kwargs = kwargs
 
-    # issue warning when mapping function with axis argument when array chunks > 1
-    if has_keyword(func, "axis"):
-        if len(arrs) == 1:
-            n_axis_chunks = [len(x) for x in arrs[0].chunks]
-            if any([n_chunks > 1 for n_chunks in n_axis_chunks]):
-                if "axis" in original_kwargs.keys():
-                    axis_chunks = n_axis_chunks[original_kwargs["axis"]]
-                    if axis_chunks > 1:
-                        warnings.warn(
-                            "Operating along axis with nchunks>1 may produce unexpected behavior"
-                        )
-                else:
+    if has_keyword(func, "axis") and "axis" in original_kwargs:
+        axis = original_kwargs["axis"]
+        if type(axis) == int:
+            if len(arrs) == 1:
+                if arrs[0].chunksize[axis] != arrs[0].shape[axis]:
                     warnings.warn(
-                        "Mapping function with axis arguments along axis with nchunks>1 may produce unexpected behavior"
+                        "Operating along axis with nchunks>1 may produce unexpected behavior"
                     )
 
     if dtype is None and meta is None:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2410,12 +2410,7 @@ def test_from_array_scalar(type_):
 
     dx = da.from_array(x, chunks=-1)
     assert_eq(np.array(x), dx)
-    assert isinstance(
-        dx.dask[
-            dx.name,
-        ],
-        np.ndarray,
-    )
+    assert isinstance(dx.dask[dx.name,], np.ndarray,)
 
 
 @pytest.mark.parametrize("asarray,cls", [(True, np.ndarray), (False, np.matrix)])
@@ -3302,11 +3297,7 @@ def test_from_array_names():
 
 
 @pytest.mark.parametrize(
-    "array",
-    [
-        da.arange(100, chunks=25),
-        da.ones((10, 10), chunks=25),
-    ],
+    "array", [da.arange(100, chunks=25), da.ones((10, 10), chunks=25),],
 )
 def test_array_picklable(array):
     from pickle import loads, dumps
@@ -4453,6 +4444,17 @@ def test_map_blocks_series():
     assert s.npartitions == x.npartitions
 
     dd_assert_eq(s, s)
+
+
+def test_map_blocks_axis_kwarg_warning():
+    x = da.zeros((2, 2), chunks=(2, 1))
+    with pytest.warns(UserWarning) as record_with_warning:
+        x.map_blocks(np.argsort, axis=1)
+    with pytest.warns(None) as record_without_warning:
+        x.map_blocks(np.argsort, axis=0)
+
+    assert len(record_with_warning) == 1
+    assert len(record_without_warning) == 0
 
 
 @pytest.mark.xfail(reason="need to remove singleton index dimension")


### PR DESCRIPTION
- [] Tests passed
- [x] Passes `black dask` / `flake8 dask`


Pull request to address issue #6810 . Issue a warning when mapping a function with 'axis' arguments onto a dask array. This alerts users to possible unexpected behavior when applying a function with axis argument along a dask array axis comprised of more than 1 chunk. Unfortunately not all tests are passing (they passed in my env before this commit). @jsignell would you mind taking a look when you have a chance and seeing if my approach to warning makes sense?