### PR TITLE
Skip df astype tasks when type already set

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2420,8 +2420,15 @@ Dask Name: {name}, {task} tasks"""
         # segfaulting.
         if is_dataframe_like(self._meta) and is_categorical_dtype(dtype):
             meta = self._meta_nonempty.astype(dtype)
+            # If the meta doesn't change, there's no need to map any tasks
+            if meta.equals(self._meta_nonempty):
+                return self
         else:
             meta = self._meta.astype(dtype)
+            # If the meta doesn't change, there's no need to map any tasks
+            if meta.equals(self._meta):
+                return self
+
         if hasattr(dtype, "items"):
             set_unknown = [
                 k
@@ -2432,36 +2439,8 @@ Dask Name: {name}, {task} tasks"""
         elif is_categorical_dtype(dtype) and getattr(dtype, "categories", None) is None:
             meta = clear_known_categories(meta)
 
-        from numpy import dtype as npdtype
-
-        if hasattr(dtype, "items"):
-            print(dtype)
-            culled_dtype = {}
-            for k,v in dtype.items():
-                ###### note that meta has already been changed by
-                ###### the first statements in this function
-
-                ###### TODO: these kinds of checks should be run on the meta
-                ###### at the very start of this function, not here
-                try:
-                    converted_dtype = npdtype(dtype.get(k))
-                except TypeError as e:
-                    converted_dtype = v
-                try:
-                    print(meta[k].dtype)
-                    converted_meta_dtype = npdtype(meta[k].dtype)
-                except TypeError as e:
-                    converted_meta_dtype = meta[k].dtype
-
-                if not converted_meta_dtype == converted_dtype:
-                    culled_dtype[k] = v
-
-
-        if culled_dtype=={}:
-            return self
-
         return self.map_partitions(
-            M.astype, dtype=culled_dtype, meta=meta, enforce_metadata=False
+            M.astype, dtype=dtype, meta=meta, enforce_metadata=False
         )
 
     @derived_from(pd.Series)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3139,7 +3139,7 @@ def test_astype_skips_if_type_unchanged():
     a = dd.from_pandas(df, 2)
     b = a.astype({"x": "float", "y": "int64"})
 
-    assert_eq(a, b)
+    assert a == b
 
 
 def test_astype_categoricals():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3139,8 +3139,7 @@ def test_astype_skips_if_type_unchanged():
     a = dd.from_pandas(df, 2)
     b = a.astype({"x": "float", "y": "int64"})
 
-    assert a == b
-
+    assert a is b
 
 def test_astype_categoricals():
     df = pd.DataFrame(

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3133,10 +3133,10 @@ def test_astype():
 
 def test_astype_skips_if_type_unchanged():
     df = pd.DataFrame(
-        {"x": ["a", "b", "c", "d"], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
+        {"x": [1.0, 2.0, 3.0, 4.0], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
     )
     a = dd.from_pandas(df, 2)
-    a = a.astype({"y":"int64"})
+    a = a.astype({"x":"float", "y":"int64"})
 
     assert_eq(df, a)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3131,14 +3131,16 @@ def test_astype():
     assert_eq(a.astype(float), df.astype(float))
     assert_eq(a.x.astype(float), df.x.astype(float))
 
+
 def test_astype_skips_if_type_unchanged():
     df = pd.DataFrame(
         {"x": [1.0, 2.0, 3.0, 4.0], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
     )
     a = dd.from_pandas(df, 2)
-    a = a.astype({"x":"float", "y":"int64"})
+    a = a.astype({"x": "float", "y": "int64"})
 
     assert_eq(df, a)
+
 
 def test_astype_categoricals():
     df = pd.DataFrame(

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3135,11 +3135,10 @@ def test_astype_skips_if_type_unchanged():
     df = pd.DataFrame(
         {"x": ["a", "b", "c", "d"], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
     )
-    df = df.astype({"x":"string"})
     a = dd.from_pandas(df, 2)
     a = a.astype({"y":"int64"})
 
-    print(a)
+    assert_eq(df, a)
 
 def test_astype_categoricals():
     df = pd.DataFrame(

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3137,9 +3137,9 @@ def test_astype_skips_if_type_unchanged():
         {"x": [1.0, 2.0, 3.0, 4.0], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
     )
     a = dd.from_pandas(df, 2)
-    a = a.astype({"x": "float", "y": "int64"})
+    b = a.astype({"x": "float", "y": "int64"})
 
-    assert_eq(df, a)
+    assert_eq(a, b)
 
 
 def test_astype_categoricals():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3131,6 +3131,15 @@ def test_astype():
     assert_eq(a.astype(float), df.astype(float))
     assert_eq(a.x.astype(float), df.x.astype(float))
 
+def test_astype_skips_if_type_unchanged():
+    df = pd.DataFrame(
+        {"x": ["a", "b", "c", "d"], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
+    )
+    df = df.astype({"x":"string"})
+    a = dd.from_pandas(df, 2)
+    a = a.astype({"y":"int64"})
+
+    print(a)
 
 def test_astype_categoricals():
     df = pd.DataFrame(


### PR DESCRIPTION
Closes #6868 
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

I originally was going to loop through the `dtype` items and pop out the ones that didn't cause a change, but I realised that Pandas probably had a clever optimisation to handle that anyway.

I'll have a quick look at their code/run a quick test to verify this. If needed I can open a second PR with that change, but this one solves the case when none of the dataframe's dtypes change after the `.astype()`