### PR TITLE
Introduce BlockwiseIO layer

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -230,7 +230,7 @@ class Blockwise(Layer):
 
         # No IO subgraph allowed in `Blockwise`.
         # Use `BlockwiseIO` to include IO. Note that the `io_name`
-        # attribute is only included added to `Blockwise` to help
+        # attribute is only included in `Blockwise` to help
         # simplify `_optimize_blockwise` logic.
         self.io_name = None
 

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -441,6 +441,7 @@ class Blockwise(Layer):
             concatenate=self.concatenate,
             new_axes=self.new_axes,
             output_blocks=output_blocks,
+            annotations=self.annotations,
         )
 
     def cull(self, keys, all_hlg_keys):

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -191,6 +191,7 @@ class Blockwise(Layer):
 
     See Also
     --------
+    dask.blockwise.BlockwiseIO
     dask.blockwise.blockwise
     dask.array.blockwise
     """
@@ -455,19 +456,20 @@ class Blockwise(Layer):
 
 
 class BlockwiseIO(Blockwise):
-    """Tensor Operation
+    """Blockwise layer with IO
 
-    This a specialized Blockwise layer containing an IO subgraph.
+    This a specialized Blockwise layer containing the IO "subgraph"
+    required to construct a brand new collection.
 
     Parameters
     ----------
     io_subgraph: Tuple[str, Dict or Mapping]
-        Since a BlockwiseIO layer corresponds to the generation of a new
+        A BlockwiseIO layer corresponds to the generation of a new
         collection (i.e. `indices` includes keys for a collection that has
-        yet to be constructed), this argument must be used to specify the
-        `(key-name, subgraph)` pair for the to-be-created collection. Note
-        that `key-name` must match the name used in both `indices` and in
-        the keys of `subgraph`.
+        yet to be constructed). Therefore, this argument must be used to
+        specify the `(key-name, subgraph)` pair for the to-be-created
+        collection. Note that `key-name` must match the name used in both
+        `indices` and in the keys of `subgraph`.
 
         NOTE: The `subgraph` must comprise of exactly N keys (where N is the
         number of chunks/partitions in the new collection), and each value
@@ -517,7 +519,7 @@ class BlockwiseIO(Blockwise):
         new_axes=None,
         output_blocks=None,
     ):
-        # Handel the case that this is a "pure" IO layer (dsk is None).
+        # Handle the case that this is a "pure" IO layer (dsk is None).
         # Note that `dsk` should only be defined after fusion.
         if not dsk:
             # Extract actual IO function for SubgraphCallable construction.
@@ -1283,6 +1285,7 @@ def rewrite_blockwise(inputs):
             concatenate=concatenate,
         )
     else:
+        # Fused layer does NOT include IO
         out = Blockwise(
             root,
             inputs[root].output_indices,
@@ -1291,7 +1294,6 @@ def rewrite_blockwise(inputs):
             numblocks=numblocks,
             new_axes=new_axes,
             concatenate=concatenate,
-            # io_subgraph=io_info,
         )
 
     return out

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -27,7 +27,7 @@ from ...core import flatten
 from ...delayed import delayed
 from ...utils import asciitable, parse_bytes
 from ..utils import clear_known_categories
-from ...blockwise import Blockwise
+from ...blockwise import BlockwiseIO
 
 import fsspec.implementations.local
 from fsspec.compression import compr
@@ -111,7 +111,7 @@ class CSVSubgraph(Mapping):
             yield (self.name, i)
 
 
-class BlockwiseReadCSV(Blockwise):
+class BlockwiseReadCSV(BlockwiseIO):
     """
     Specialized Blockwise Layer for read_csv.
 
@@ -149,12 +149,12 @@ class BlockwiseReadCSV(Blockwise):
             path,
         )
         super().__init__(
+            (self.io_name, dsk_io),
             self.name,
             "i",
             None,
             [(self.io_name, "i")],
             {self.io_name: (len(self.blocks),)},
-            io_subgraph=(self.io_name, dsk_io),
         )
 
     def __repr__(self):

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -149,7 +149,8 @@ class BlockwiseReadCSV(BlockwiseIO):
             path,
         )
         super().__init__(
-            (self.io_name, dsk_io),
+            self.io_name,
+            dsk_io,
             self.name,
             "i",
             None,

--- a/dask/dataframe/io/orc.py
+++ b/dask/dataframe/io/orc.py
@@ -3,7 +3,7 @@ from distutils.version import LooseVersion
 from .utils import _get_pyarrow_dtypes, _meta_from_dtypes
 from ..core import DataFrame
 from ...base import tokenize
-from ...blockwise import Blockwise
+from ...blockwise import BlockwiseIO
 from ...bytes.core import get_fs_token_paths
 from ...highlevelgraph import HighLevelGraph
 from ...utils import import_required
@@ -97,13 +97,13 @@ def read_orc(path, columns=None, storage_options=None):
 
     # Create Blockwise layer
     npartitions = len(dsk_io)
-    layer = Blockwise(
+    layer = BlockwiseIO(
+        (name, dsk_io),
         output_name,
         "i",
         None,
         [(name, "i")],
         {name: (npartitions,)},
-        io_subgraph=(name, dsk_io),
     )
     graph = HighLevelGraph({output_name: layer}, {output_name: set()})
 

--- a/dask/dataframe/io/orc.py
+++ b/dask/dataframe/io/orc.py
@@ -98,7 +98,8 @@ def read_orc(path, columns=None, storage_options=None):
     # Create Blockwise layer
     npartitions = len(dsk_io)
     layer = BlockwiseIO(
-        (name, dsk_io),
+        name,
+        dsk_io,
         output_name,
         "i",
         None,

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -15,7 +15,7 @@ from ....delayed import Delayed
 from ....utils import import_required, natural_sort_key, parse_bytes, apply
 from ...methods import concat
 from ....highlevelgraph import Layer, HighLevelGraph
-from ....blockwise import Blockwise
+from ....blockwise import BlockwiseIO
 
 
 try:
@@ -115,9 +115,9 @@ class ParquetSubgraph(Layer):
         return ret, ret.get_dependencies(all_hlg_keys)
 
 
-class BlockwiseParquet(Blockwise):
+class BlockwiseParquet(BlockwiseIO):
     """
-    Specialized Blockwise Layer for read_parquet.
+    Specialized BlockwiseIO Layer for read_parquet.
 
     Enables HighLevelGraph optimizations.
     """
@@ -149,12 +149,12 @@ class BlockwiseParquet(Blockwise):
         )
 
         super().__init__(
+            (self.io_name, dsk_io),
             self.name,
             "i",
             None,
             [(self.io_name, "i")],
             {self.io_name: (len(self.part_ids),)},
-            io_subgraph=(self.io_name, dsk_io),
         )
 
     def __repr__(self):

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -149,7 +149,8 @@ class BlockwiseParquet(BlockwiseIO):
         )
 
         super().__init__(
-            (self.io_name, dsk_io),
+            self.io_name,
+            dsk_io,
             self.name,
             "i",
             None,


### PR DESCRIPTION
As described in #6791 , this PR introduces a new `BlockwiseIO` layer to handle all IO-subgraph-sepcific logic required in the current `Blockwise` layer.  The goal here is to keep the base `Blockwise` code as simple as possible.

cc @madsbk @mrocklin 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
