### PR TITLE
Fix documentation about task scheduler

### DIFF
--- a/docs/source/scheduler-overview.rst
+++ b/docs/source/scheduler-overview.rst
@@ -55,7 +55,7 @@ of the collection:
 
 The compute method takes a number of keywords:
 
-- ``scheduler``: the name of the desired scheduler like ``"threads"``, ``"processes"``, or ``"single-threaded"`, a ``get`` function, or a ``dask.distributed.Client`` object.  Overrides the default for the collection.
+- ``scheduler``: the name of the desired scheduler as a string (``"threads"``, ``"processes"``, ``"single-threaded"``, etc.), a ``get`` function, or a ``dask.distributed.Client`` object.  Overrides the default for the collection.
 - ``**kwargs``: extra keywords to pass on to the scheduler ``get`` function.
 
 See also: :ref:`configuring-schedulers`.
@@ -105,7 +105,7 @@ The dask collections each have a default scheduler:
 For most cases, the default settings are good choices. However, sometimes you
 may want to use a different scheduler. There are two ways to do this.
 
-1. Using the ``get`` keyword in the ``compute`` method:
+1. Using the ``scheduler`` keyword in the ``compute`` method:
 
     .. code-block:: python
 


### PR DESCRIPTION
Currently the [formatting](https://docs.dask.org/en/latest/scheduler-overview.html#using-compute-methods) is slightly off.

![image](https://user-images.githubusercontent.com/17503044/100026611-1fc2ec80-2db9-11eb-821d-2bca72944c94.png)

Not sure why some of the CI runs failed / were skipped though. All I did was update the doc.