### PR TITLE
Added dataframe skew method

### DIFF
--- a/dask/array/stats.py
+++ b/dask/array/stats.py
@@ -203,9 +203,8 @@ def skew(a, axis=0, bias=True, nan_policy="propagate"):
         raise NotImplementedError("bias=False is not implemented.")
 
     if vals.ndim == 0:
-        return vals
-        # TODO: scalar
-        # return vals.item()
+        # TODO: scalar, min is a workaround
+        return vals.min()
 
     return vals
 

--- a/dask/array/tests/test_stats.py
+++ b/dask/array/tests/test_stats.py
@@ -143,3 +143,12 @@ def test_skew_raises():
     a = da.ones((7,), chunks=(7,))
     with pytest.raises(ValueError, match="7 samples"):
         dask.array.stats.skewtest(a)
+
+
+def test_skew_single_return_type():
+    """This function tests the return type for the skew method for a 1d array.
+    """
+    numpy_array = np.random.random(size=(30,))
+    dask_array = da.from_array(numpy_array, 3)
+    result = dask.array.stats.skew(dask_array).compute()
+    assert isinstance(result, np.float64)

--- a/dask/array/tests/test_stats.py
+++ b/dask/array/tests/test_stats.py
@@ -146,8 +146,7 @@ def test_skew_raises():
 
 
 def test_skew_single_return_type():
-    """This function tests the return type for the skew method for a 1d array.
-    """
+    """This function tests the return type for the skew method for a 1d array."""
     numpy_array = np.random.random(size=(30,))
     dask_array = da.from_array(numpy_array, 3)
     result = dask.array.stats.skew(dask_array).compute()

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2064,13 +2064,6 @@ Dask Name: {name}, {task} tasks"""
         # import depends on scipy, not installed by default
         from ..array import stats as da_stats
 
-        is_timedelta = is_timedelta64_dtype(column._meta)
-
-        if is_timedelta:
-            is_nan = column.isna()
-            column = column.astype("i8")
-            column = column.mask(is_nan)
-
         if PANDAS_VERSION >= "0.24.0":
             if pd.Int64Dtype.is_dtype(column._meta_nonempty):
                 column = column.astype("f8")

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2031,6 +2031,19 @@ Dask Name: {name}, {task} tasks"""
 
     @derived_from(pd.DataFrame)
     def skew(self, axis=None, bias=True, nan_policy="propagate", out=None):
+        """
+        .. note::
+
+           This implementation follows the dask.array.stats implementation
+           of skewness and calculates skewness without taking into account
+           a bias term for finite sample size, which corresponds to the
+           default settings of the scipy.stats skewness calculation. However,
+           Pandas corrects for this, so the values differ by a factor of
+           (n * (n - 1)) ** 0.5 / (n - 2), where n is the number of samples.
+
+           Further, this method currently does not support filtering out NaN
+           values, which is again a difference to Pandas.
+        """
         axis = self._validate_axis(axis)
         _raise_if_object_series(self, "skew")
         meta = self._meta_nonempty.skew()

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -24,7 +24,6 @@ except ImportError:
 
 from .. import array as da
 from .. import core
-from ..array import stats as da_stats
 
 from ..utils import parse_bytes, partial_by_order, Dispatch, IndexCallable, apply
 from .. import threaded
@@ -2062,6 +2061,9 @@ Dask Name: {name}, {task} tasks"""
 
         Uses the array version from da.stats in case we are passing in a single series
         """
+        # import depends on scipy, not installed by default
+        from ..array import stats as da_stats
+
         is_timedelta = is_timedelta64_dtype(column._meta)
 
         if is_timedelta:
@@ -2094,6 +2096,9 @@ Dask Name: {name}, {task} tasks"""
 
         Maps the array version from da.stats onto the numeric array of columns.
         """
+        # import depends on scipy, not installed by default
+        from ..array import stats as da_stats
+
         num = self.select_dtypes(include=["number", "bool"], exclude=[np.timedelta64])
 
         values_dtype = num.values.dtype

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -129,6 +129,13 @@ def wrap_var_reduction(array_var, index):
     return array_var
 
 
+def wrap_skew_reduction(array_skew, index):
+    if isinstance(array_skew, np.ndarray) or isinstance(array_skew, list):
+        return pd.Series(array_skew, index=index)
+
+    return array_skew
+
+
 def var_mixed_concat(numeric_var, timedelta_var, columns):
     vars = pd.concat([numeric_var, timedelta_var])
 

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -992,6 +992,7 @@ def test_reductions_non_numeric_dtypes():
     check_raises(dds, pds, "std")
     check_raises(dds, pds, "var")
     check_raises(dds, pds, "sem")
+    check_raises(dds, pds, "skew")
     if not PANDAS_GT_0250:
         # pandas 0.25 added DatetimeIndex.mean. We need to follow.
         check_raises(dds, pds, "mean")
@@ -1012,6 +1013,7 @@ def test_reductions_non_numeric_dtypes():
         check_raises(dds, pds, "std")
         check_raises(dds, pds, "var")
         check_raises(dds, pds, "sem")
+        check_raises(dds, pds, "skew")
         if not (PANDAS_GT_0250 and is_datetime64_ns_dtype(pds.dtype)):
             # pandas 0.25 added DatetimeIndex.mean. We need to follow
             check_raises(dds, pds, "mean")
@@ -1023,6 +1025,8 @@ def test_reductions_non_numeric_dtypes():
     assert_eq(dds.min(), pds.min())
     assert_eq(dds.max(), pds.max())
     assert_eq(dds.count(), pds.count())
+    # both pandas and dask skew calculations do not support timedelta
+    check_raises(dds, pds, "skew")
 
     # ToDo: pandas supports timedelta std, dask returns float64
     # assert_eq(dds.std(), pds.std())

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -814,39 +814,6 @@ def test_reductions_timedelta(split_every):
     assert_eq(dds.count(split_every=split_every), ds.count())
 
 
-def test_skew():
-    dsk = {
-        ("x", 0): pd.DataFrame(
-            {"a": [1, 2, 3], "b": [4, 5, 6], "c": [True, True, False]}, index=[0, 1, 3]
-        ),
-        ("x", 1): pd.DataFrame(
-            {"a": [4, 5, 6], "b": [3, 2, 1], "c": [False, False, False]},
-            index=[5, 6, 8],
-        ),
-        ("x", 2): pd.DataFrame(
-            {
-                "a": [13094304034, 3489385935, 100006774],
-                "b": [0, 0, 0],
-                "c": [True, True, True],
-            },
-            index=[9, 9, 9],
-        ),
-    }
-    meta = make_meta({"a": "i8", "b": "i8", "c": "bool"}, index=pd.Index([], "i8"))
-    ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
-    pdf1 = ddf1.compute()
-
-    for dds, pds in [
-        (ddf1.a, pdf1.a),
-        (ddf1.b, pdf1.b),
-        (ddf1.c, pdf1.c),
-        (ddf1["a"], pdf1["a"]),
-        (ddf1["b"], pdf1["b"]),
-    ]:
-        assert isinstance(dds, dd.Series)
-        assert isinstance(pds, pd.Series)
-
-
 @pytest.mark.parametrize(
     "frame,axis,out",
     [

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -114,6 +114,8 @@ These optional dependencies and their minimum supported versions are listed belo
 +---------------+----------+--------------------------------------------------------------+
 |     s3fs      | >=0.4.0  |                    Reading from Amazon S3                    |
 +---------------+----------+--------------------------------------------------------------+
+|     scipy     |          |                  Required for dask.array.stats               |
++---------------+----------+--------------------------------------------------------------+
 |   sqlalchemy  |          |            Writing and reading from SQL databases            |
 +---------------+----------+--------------------------------------------------------------+
 | cytoolz/toolz | >=0.8.2  | Utility functions for iterators, functions, and dictionaries |


### PR DESCRIPTION
In this PR I am addressing #6880 by adding a skew-method to the DataFrame class. I pretty much followed the `var` implementation, for now focusing on the numeric part. 

In order to make the output consistent with methods like `var`, `min` and `max` I had to slightly edit the 0d output for the stats `skew`-method such that it returns a float and not a 0d array. I don't think it should be considered a full fix and more of a temporary fix, so I kept the `TODO` there to properly fix that. I couldn't figure out how to properly extract the float without `item`, but using `min` or `max` worked decently well. When changing the output, I noticed it didn't break any test, so I added one for the case I changed.

I noticed, one of the import tests failed when I added the `array.stats` import to the top of the `core.py` file because `scipy` is needed for `array.stats`. Given the conversation in #6890, I moved the import into the method so as to not break the overall module.

Futher, I checked the pandas behaviour for timedelta columns and generally pandas `skew()` fails with `TypeError: reduction operation 'skew' not allowed for this dtype` when using the method on such a column. This translates through to dask via `meta = self._meta_nonempty.skew()`, so the behaviour is consistent. I added a test for that as well.

One thing to note is that the dask version does not handle `nan`'s (returns `nan` for a column that inclued `nan`), but the pandas version does.

Lastly, I also added the dependency entry to the docs for `scipy` to address #6890.

Please let me know if there are more things that should be changed or adjusted and I'm happy to do it!

