### PR TITLE
Add human relative time formatting utility

### DIFF
--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1275,6 +1275,8 @@ def format_time(n):
 def format_time_ago(n):
     """Calculate a '3 hours ago' type string from a Python datetime.
 
+    Examples
+    --------
     >>> from datetime import datetime, timedelta
     >>> now = datetime.now()
     >>> format_time_ago(now)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 import functools
 import inspect
 import os
@@ -1270,6 +1270,62 @@ def format_time(n):
     if n >= 1e-3:
         return "%.2f ms" % (n * 1e3)
     return "%.2f us" % (n * 1e6)
+
+
+def format_time_ago(n):
+    """Calculate a '3 hours ago' type string from a Python datetime.
+
+    >>> from datetime import datetime, timedelta
+    >>> now = datetime.now()
+    >>> format_time_ago(now)
+    'Just now'
+    >>> past = datetime.now() - timedelta(minutes=1)
+    >>> format_time_ago(past)
+    '1 minute ago'
+    >>> past = datetime.now() - timedelta(minutes=2)
+    >>> format_time_ago(past)
+    '2 minutes ago'
+    >>> past = datetime.now() - timedelta(hours=1)
+    >>> format_time_ago(past)
+    '1 hour ago'
+    >>> past = datetime.now() - timedelta(hours=6)
+    >>> format_time_ago(past)
+    '6 hours ago'
+    >>> past = datetime.now() - timedelta(days=1)
+    >>> format_time_ago(past)
+    '1 day ago'
+    >>> past = datetime.now() - timedelta(days=5)
+    >>> format_time_ago(past)
+    '5 days ago'
+    >>> past = datetime.now() - timedelta(days=8)
+    >>> format_time_ago(past)
+    '1 week ago'
+    >>> past = datetime.now() - timedelta(days=16)
+    >>> format_time_ago(past)
+    '2 weeks ago'
+    >>> past = datetime.now() - timedelta(days=190)
+    >>> format_time_ago(past)
+    '6 months ago'
+    >>> past = datetime.now() - timedelta(days=800)
+    >>> format_time_ago(past)
+    '2 years ago'
+    """
+    units = {
+        "years": lambda diff: diff.days / 365,
+        "months": lambda diff: diff.days / 30.436875,  # Average days per month
+        "weeks": lambda diff: diff.days / 7,
+        "days": lambda diff: diff.days,
+        "hours": lambda diff: diff.seconds / 3600,
+        "minutes": lambda diff: diff.seconds % 3600 / 60,
+    }
+    diff = datetime.now() - n
+    for unit in units:
+        dur = int(units[unit](diff))
+        if dur > 0:
+            if dur == 1:  # De-pluralize
+                unit = unit[:-1]
+            return "%s %s ago" % (dur, unit)
+    return "Just now"
 
 
 def format_bytes(n):

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1322,6 +1322,7 @@ def format_time_ago(n: datetime) -> str:
     >>> past = datetime.now() - timedelta(days=800)
     >>> format_time_ago(past)
     '2 years ago'
+
     """
     units = {
         "years": lambda diff: diff.days / 365,

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1272,42 +1272,53 @@ def format_time(n):
     return "%.2f us" % (n * 1e6)
 
 
-def format_time_ago(n):
+def format_time_ago(n: datetime) -> str:
     """Calculate a '3 hours ago' type string from a Python datetime.
 
     Examples
     --------
     >>> from datetime import datetime, timedelta
+
     >>> now = datetime.now()
     >>> format_time_ago(now)
     'Just now'
+
     >>> past = datetime.now() - timedelta(minutes=1)
     >>> format_time_ago(past)
     '1 minute ago'
+
     >>> past = datetime.now() - timedelta(minutes=2)
     >>> format_time_ago(past)
     '2 minutes ago'
+
     >>> past = datetime.now() - timedelta(hours=1)
     >>> format_time_ago(past)
     '1 hour ago'
+
     >>> past = datetime.now() - timedelta(hours=6)
     >>> format_time_ago(past)
     '6 hours ago'
+
     >>> past = datetime.now() - timedelta(days=1)
     >>> format_time_ago(past)
     '1 day ago'
+
     >>> past = datetime.now() - timedelta(days=5)
     >>> format_time_ago(past)
     '5 days ago'
+
     >>> past = datetime.now() - timedelta(days=8)
     >>> format_time_ago(past)
     '1 week ago'
+
     >>> past = datetime.now() - timedelta(days=16)
     >>> format_time_ago(past)
     '2 weeks ago'
+
     >>> past = datetime.now() - timedelta(days=190)
     >>> format_time_ago(past)
     '6 months ago'
+
     >>> past = datetime.now() - timedelta(days=800)
     >>> format_time_ago(past)
     '2 years ago'


### PR DESCRIPTION
Added human relative time formatting utility `dask.utils.format_time_ago`.

```python
>>> from dask.utils import format_time_ago
>>> from datetime import datetime, timedelta

>>> now = datetime.now()
>>> format_time_ago(now)
'Just now'

>>> past = datetime.now() - timedelta(minutes=1)
>>> format_time_ago(past)
'1 minute ago'

>>> past = datetime.now() - timedelta(minutes=2)
>>> format_time_ago(past)
'2 minutes ago'

>>> past = datetime.now() - timedelta(hours=1)
>>> format_time_ago(past)
'1 hour ago'

>>> past = datetime.now() - timedelta(hours=6)
>>> format_time_ago(past)
'6 hours ago'

>>> past = datetime.now() - timedelta(days=1)
>>> format_time_ago(past)
'1 day ago'

>>> past = datetime.now() - timedelta(days=5)
>>> format_time_ago(past)
'5 days ago'

>>> past = datetime.now() - timedelta(days=8)
>>> format_time_ago(past)
'1 week ago'

>>> past = datetime.now() - timedelta(days=16)
>>> format_time_ago(past)
'2 weeks ago'

>>> past = datetime.now() - timedelta(days=190)
>>> format_time_ago(past)
'6 months ago'

>>> past = datetime.now() - timedelta(days=800)
>>> format_time_ago(past)
'2 years ago'
```
