### PR TITLE
Update/remove pandas and numpy in mindeps

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,17 @@ collect_ignore = [
     "dask/dot.py",
 ]
 
+collect_ignore_glob = []
+try:
+    import numpy  # noqa: F401
+except ImportError:
+    collect_ignore_glob.append("dask/array/*")
+
+try:
+    import pandas  # noqa: F401
+except ImportError:
+    collect_ignore_glob.append("dask/dataframe/*")
+
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", help="run slow tests")

--- a/continuous_integration/environment-mindeps-array-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-array-dataframe.yaml
@@ -6,8 +6,8 @@ dependencies:
   - python=3.7
   - pyyaml
   # optional dependencies pulled in by pip install dask[array, dataframe]
-  - numpy
-  - pandas
+  - numpy=1.15
+  - pandas=0.23
   - partd
   - fsspec
   - toolz

--- a/continuous_integration/environment-mindeps-array-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-array-dataframe.yaml
@@ -6,8 +6,8 @@ dependencies:
   - python=3.7
   - pyyaml
   # optional dependencies pulled in by pip install dask[array, dataframe]
-  - numpy=1.15
-  - pandas=0.23
+  - numpy
+  - pandas
   - partd
   - fsspec
   - toolz

--- a/continuous_integration/environment-mindeps-bag-delayed.yaml
+++ b/continuous_integration/environment-mindeps-bag-delayed.yaml
@@ -10,8 +10,6 @@ dependencies:
   - partd
   - fsspec
   - toolz
-  - numpy=1.15 # FIXME #5564
-  - pandas=0.23 # FIXME #5564
   # test dependencies
   - pytest
   - pytest-xdist

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -730,6 +730,7 @@ def test_from_long_sequence():
 
 
 def test_from_empty_sequence():
+    pytest.importorskip("dask.dataframe")
     b = db.from_sequence([])
     assert b.npartitions == 1
     df = b.to_dataframe(meta={"a": "int"}).compute()

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -9,7 +9,6 @@ import sys
 import time
 
 import pytest
-import numpy as np
 
 s3fs = pytest.importorskip("s3fs")
 boto3 = pytest.importorskip("boto3")
@@ -27,9 +26,15 @@ from fsspec.compression import compr
 
 
 compute = partial(compute, scheduler="sync")
-numpy_120_mark = pytest.mark.xfail(
-    LooseVersion(np.__version__) >= "1.20.0", reason="Upstream incompatibility"
-)
+
+try:
+    import numpy as np
+
+    numpy_120_mark = pytest.mark.xfail(
+        LooseVersion(np.__version__) >= "1.20.0", reason="Upstream incompatibility"
+    )
+except ImportError:
+    numpy_120_mark = pytest.mark.skip(reason="numpy not installed")
 
 
 test_bucket_name = "test"
@@ -143,6 +148,7 @@ def s3_with_yellow_tripdata(s3):
     * s3://test/nyc-taxi/2014/yellow_tripdata_2015-mm.csv
       for mm from 01 - 12.
     """
+    np = pytest.importorskip("numpy")
     pd = pytest.importorskip("pandas")
 
     data = {
@@ -434,13 +440,13 @@ def test_modification_time_read_bytes(s3, s3so):
 @numpy_120_mark
 def test_parquet(s3, engine, s3so):
     dd = pytest.importorskip("dask.dataframe")
+    pd = pytest.importorskip("pandas")
+    np = pytest.importorskip("numpy")
     from dask.dataframe._compat import tm
 
     lib = pytest.importorskip(engine)
     if engine == "pyarrow" and LooseVersion(lib.__version__) < "0.13.1":
         pytest.skip("pyarrow < 0.13.1 not supported for parquet")
-    import pandas as pd
-    import numpy as np
 
     url = "s3://%s/test.parquet" % test_bucket_name
 
@@ -472,9 +478,8 @@ def test_parquet(s3, engine, s3so):
 def test_parquet_wstoragepars(s3, s3so):
     dd = pytest.importorskip("dask.dataframe")
     pytest.importorskip("fastparquet")
-
-    import pandas as pd
-    import numpy as np
+    pd = pytest.importorskip("pandas")
+    np = pytest.importorskip("numpy")
 
     url = "s3://%s/test.parquet" % test_bucket_name
 

--- a/dask/diagnostics/tests/test_progress.py
+++ b/dask/diagnostics/tests/test_progress.py
@@ -21,9 +21,9 @@ def check_bar_completed(capsys, width=40):
 
 
 def test_array_compute(capsys):
-    from dask.array import ones
+    da = pytest.importorskip("dask.array")
 
-    data = ones((100, 100), dtype="f4", chunks=(100, 100))
+    data = da.ones((100, 100), dtype="f4", chunks=(100, 100))
     with ProgressBar():
         out = data.sum().compute()
     assert out == 10000

--- a/dask/tests/test_context.py
+++ b/dask/tests/test_context.py
@@ -1,9 +1,11 @@
+import pytest
+
 from dask.context import globalmethod
-import dask.array as da
 import dask
 
 
 def test_with_get():
+    da = pytest.importorskip("dask.array")
     var = [0]
 
     def myget(dsk, keys, **kwargs):

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -12,7 +12,6 @@ import dask
 from dask import compute
 from dask.delayed import delayed, to_task_dask, Delayed
 from dask.utils_test import inc
-from dask.dataframe.utils import assert_eq
 
 try:
     from operator import matmul
@@ -630,17 +629,16 @@ def test_attribute_of_attribute():
 
 
 def test_check_meta_flag():
+    dd = pytest.importorskip("dask.dataframe")
     from pandas import Series
-    from dask.delayed import delayed
-    from dask.dataframe import from_delayed
 
     a = Series(["a", "b", "a"], dtype="category")
     b = Series(["a", "c", "a"], dtype="category")
     da = delayed(lambda x: x)(a)
     db = delayed(lambda x: x)(b)
 
-    c = from_delayed([da, db], verify_meta=False)
-    assert_eq(c, c)
+    c = dd.from_delayed([da, db], verify_meta=False)
+    dd.utils.assert_eq(c, c)
 
 
 def modlevel_eager(x):

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -1,16 +1,15 @@
 import os
 
 import pytest
-import numpy as np
 
 import dask
-import dask.array as da
 from dask.utils_test import inc
 from dask.highlevelgraph import HighLevelGraph, BasicLayer, Layer
 
 
 def test_visualize(tmpdir):
     pytest.importorskip("graphviz")
+    da = pytest.importorskip("dask.array")
     fn = str(tmpdir)
     a = da.ones(10, chunks=(5,))
     b = a + 1
@@ -32,6 +31,7 @@ def test_basic():
 
 
 def test_keys_values_items_methods():
+    da = pytest.importorskip("dask.array")
     a = da.ones(10, chunks=(5,))
     b = a + 1
     c = a + 2
@@ -70,6 +70,7 @@ def annot_map_fn(key):
     ],
 )
 def test_single_annotation(annotation):
+    da = pytest.importorskip("dask.array")
     with dask.annotate(**annotation):
         A = da.ones((10, 10), chunks=(5, 5))
 
@@ -79,6 +80,7 @@ def test_single_annotation(annotation):
 
 
 def test_multiple_annotations():
+    da = pytest.importorskip("dask.array")
     with dask.annotate(block_id=annot_map_fn):
         with dask.annotate(resource="GPU"):
             A = da.ones((10, 10), chunks=(5, 5))
@@ -99,6 +101,8 @@ def test_multiple_annotations():
 
 @pytest.mark.parametrize("flat", [True, False])
 def test_blockwise_cull(flat):
+    da = pytest.importorskip("dask.array")
+    np = pytest.importorskip("numpy")
     if flat:
         # Simple "flat" mapping between input and
         # outut indices

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -3,7 +3,6 @@ import functools
 import operator
 import pickle
 
-import numpy as np
 import pytest
 
 from dask import get
@@ -157,6 +156,7 @@ def test_dispatch_lazy():
 
 
 def test_random_state_data():
+    np = pytest.importorskip("numpy")
     seed = 37
     state = np.random.RandomState(seed)
     n = 10000
@@ -562,6 +562,8 @@ def test_parse_timedelta():
 
 
 def test_is_arraylike():
+    np = pytest.importorskip("numpy")
+
     assert is_arraylike(0) is False
     assert is_arraylike(()) is False
     assert is_arraylike(0) is False


### PR DESCRIPTION
- [x] Tests skipped :smiley: 
- [x] Passes `black dask` / `flake8 dask`

This was discussed in #5564, and most of the changes in the PR are from this comment by @jrbourbeau https://github.com/dask/dask/issues/5564#issuecomment-550461304

The motivation for this is really that the combination of python 3.7 and pandas 0.23 was causing failures like the one: https://github.com/dask/dask/runs/1448351381

See https://github.com/jsignell/dask/runs/1449653228 for a successful run of the mindeps-bag tests.