### PR TITLE
Pin mindeps-array-dataframe up a bit

### DIFF
--- a/continuous_integration/environment-mindeps-array-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-array-dataframe.yaml
@@ -6,8 +6,8 @@ dependencies:
   - python=3.7
   - pyyaml
   # optional dependencies pulled in by pip install dask[array, dataframe]
-  - numpy=1.15
-  - pandas=0.23
+  - numpy=1.17.*
+  - pandas=0.25.*
   - partd
   - fsspec
   - toolz


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

This just updates the pandas and numpy version in mindeps to something that works with Python 3.7