### PR TITLE
[docs] Missing name arg in `helm install ...`

### DIFF
--- a/docs/source/setup/kubernetes.rst
+++ b/docs/source/setup/kubernetes.rst
@@ -22,9 +22,9 @@ following two ways:
        helm repo add dask https://helm.dask.org/    # add the Dask Helm chart repository
        helm repo update                             # get latest Helm charts
        # For single-user deployments, use dask/dask
-       helm install dask/dask                       # deploy standard Dask chart
+       helm install my-dask dask/dask               # deploy standard Dask chart
        # For multi-user deployments, use dask/daskhub
-       helm install dask/daskhub                    # deploy JupyterHub & Dask
+       helm install my-dask dask/daskhub            # deploy JupyterHub & Dask
 
     This is a good choice if you want to do the following:
 


### PR DESCRIPTION
To install a repo with Helm 3, you need to do (https://helm.sh/docs/helm/helm_install/):

```helm install [NAME] [CHART] [flags]```

hence the current snippet (`helm install dask/dask`) in https://docs.dask.org/en/latest/setup/kubernetes.html throws an error (in other parts of the docs my proposed change is already included, cf. https://docs.dask.org/en/latest/setup/kubernetes-helm.html#helm-install-dask-for-a-single-user). 