### PR TITLE
add more informative error message to da.coarsen

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1471,7 +1471,7 @@ def aligned_coarsen_chunks(chunks: List[int], multiple: int) -> List[int]:
 @wraps(chunk.coarsen)
 def coarsen(reduction, x, axes, trim_excess=False, **kwargs):
     if not trim_excess and not all(x.shape[i] % div == 0 for i, div in axes.items()):
-        msg = "Coarsening factor does not align with block dimensions"
+        msg = f"Coarsening factors {axes} do not align with array shape {x.shape}."
         raise ValueError(msg)
 
     if "dask" in inspect.getfile(reduction):


### PR DESCRIPTION
Currently this error message makes a reference to "block dimensions", which could be interpreted to mean the array size or the size of chunks. Since the check that triggers this exception is based on the array size, I updated the message accordingly and added a bit more information (the coarsening factors and the array shape) to make the error message a bit more helpful.
  
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
