### PR TITLE
Fix for github issue 6849

### DIFF
--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -820,6 +820,15 @@ def coerce_depth(ndim, depth):
         for i in range(ndim):
             if i not in depth:
                 depth[i] = 0
+    return coerce_depth_type(ndim, depth)
+
+
+def coerce_depth_type(ndim, depth):
+    for i in range(ndim):
+        if isinstance(depth[i], tuple):
+            depth[i] = tuple(int(d) for d in depth[i])
+        else:
+            depth[i] = int(depth[i])
     return depth
 
 

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -247,7 +247,7 @@ def test_overlap():
     assert same_keys(g, overlap(d, depth={0: 2, 1: 1}, boundary={0: 100, 1: "reflect"}))
 
     u_depth = np.uint16([2, 1])
-    u_depth = {k:v for k, v in enumerate(u_depth)}
+    u_depth = {k: v for k, v in enumerate(u_depth)}
     g = overlap(d, depth=u_depth, boundary={0: 100, 1: "reflect"})
     assert g.chunks == ((8, 8), (6, 6))
     assert_eq(g, expected)
@@ -278,7 +278,7 @@ def test_overlap():
     assert g.chunks == ((8, 8), (5, 5))
 
     u_depth = np.uint16([2, 1])
-    u_depth = {k:v for k, v in enumerate(u_depth)}
+    u_depth = {k: v for k, v in enumerate(u_depth)}
     g = overlap(d, depth=u_depth, boundary={0: 100, 1: "none"})
     assert_eq(g, expected)
     assert g.chunks == ((8, 8), (5, 5))

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -246,6 +246,13 @@ def test_overlap():
     assert_eq(g, expected)
     assert same_keys(g, overlap(d, depth={0: 2, 1: 1}, boundary={0: 100, 1: "reflect"}))
 
+    u_depth = np.uint16([2, 1])
+    u_depth = {k:v for k, v in enumerate(u_depth)}
+    g = overlap(d, depth=u_depth, boundary={0: 100, 1: "reflect"})
+    assert g.chunks == ((8, 8), (6, 6))
+    assert_eq(g, expected)
+    assert same_keys(g, overlap(d, depth={0: 2, 1: 1}, boundary={0: 100, 1: "reflect"}))
+
     g = overlap(d, depth={0: 2, 1: 1}, boundary={0: 100, 1: "none"})
     expected = np.array(
         [
@@ -267,6 +274,12 @@ def test_overlap():
             [100, 100, 100, 100, 100, 100, 100, 100, 100, 100],
         ]
     )
+    assert_eq(g, expected)
+    assert g.chunks == ((8, 8), (5, 5))
+
+    u_depth = np.uint16([2, 1])
+    u_depth = {k:v for k, v in enumerate(u_depth)}
+    g = overlap(d, depth=u_depth, boundary={0: 100, 1: "none"})
     assert_eq(g, expected)
     assert g.chunks == ((8, 8), (5, 5))
 


### PR DESCRIPTION
I modified dask/array/overlap.py::coerce_depth to cast all inputs to `int` datatype.
Since issue 6849 passed to the overlap function, I added 2 new test cases to dask/array/tests/test_overlap.py::test_overlap
The test cases are duplicates of the existing 2 test cases, but use `np.uint16` inputs for the depth argument.

- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`

<img width="960" alt="Screen Shot 2020-11-30 at 1 07 13 PM" src="https://user-images.githubusercontent.com/8507206/100647961-411e5e00-330e-11eb-8c61-ce1d1c74623f.png">
<img width="948" alt="Screen Shot 2020-11-30 at 1 13 27 PM" src="https://user-images.githubusercontent.com/8507206/100647962-41b6f480-330e-11eb-9f4a-7162712569ca.png">

