### PR TITLE
Ensure shuffle layers have annotations

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -71,6 +71,7 @@ class SimpleShuffleLayer(Layer):
         self.name_input = name_input
         self.meta_input = meta_input
         self.parts_out = parts_out or range(npartitions)
+        super().__init__()
 
     def get_output_keys(self):
         return {(self.name, part) for part in self.parts_out}
@@ -302,6 +303,7 @@ class ShuffleLayer(SimpleShuffleLayer):
         self.name_input = name_input
         self.meta_input = meta_input
         self.parts_out = parts_out or range(len(inputs))
+        Layer.__init__(self)
 
     def __repr__(self):
         return "ShuffleLayer<name='{}', stage={}, nsplits={}, npartitions={}>".format(


### PR DESCRIPTION
CI over in https://github.com/dask/distributed/pull/4288 caught that our shuffle layers don't have an `annotations` attribute. This PR ensures that they do by calling `Layer.__init__`

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
