### PR TITLE
Enable parquet metadata collection in parallel

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -340,6 +340,7 @@ def read_parquet(
         filters=filters,
         split_row_groups=split_row_groups,
         read_from_paths=read_from_paths,
+        engine=engine,
         **kwargs,
     )
 
@@ -778,6 +779,10 @@ def create_metadata_file(
                     None,
                     None,
                 )
+
+    # There will be no aggregation tasks if there is only one file
+    if len(paths) == 1:
+        dsk[name] = (engine.aggregate_metadata, [(collect_name, 0, 0)], fs, out_dir)
 
     # Convert the raw graph to a `Delayed` object
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[])

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -693,9 +693,11 @@ def create_metadata_file(
         Root directory of dataset.  The `file_path` fields in the new
         _metadata file will relative to this directory.  If None, a common
         root directory will be inferred.
-    out_dir : string, optional
+    out_dir : string or False, optional
         Directory location to write the final _metadata file.  By default,
-        this will be set to `root_dir`.
+        this will be set to `root_dir`.  If False is specified, the global
+        metadata will be returned as an in-memory object (and will not be
+        written to disk).
     engine : str or Engine, default 'pyarrow'
         Parquet Engine to use. Only 'pyarrow' is supported if a string
         is passed.
@@ -729,7 +731,7 @@ def create_metadata_file(
     paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
     ap_kwargs = {"root": root_dir} if root_dir else {}
     root_dir, fns = _analyze_paths(paths, fs, **ap_kwargs)
-    out_dir = out_dir or root_dir
+    out_dir = root_dir if out_dir is None else out_dir
 
     # Start constructing a raw graph
     dsk = {}

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1,7 +1,6 @@
 import math
 import glob
 import os
-import glob
 import sys
 import warnings
 from distutils.version import LooseVersion

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3159,6 +3159,21 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
         ddf2.a = ddf2.a.astype("object")
     assert_eq(ddf1, ddf2)
 
+    # Check if we can avoid writing an actual file
+    fmd = dd.io.parquet.create_metadata_file(
+        fns,
+        engine="pyarrow",
+        split_every=3,  # Force tree reduction
+        out_dir=False,  # Avoid writing file
+    )
+
+    # Check that the in-memory metadata is the same as
+    # the metadata in the file.
+    fmd_file = pq.ParquetFile(os.path.join(tmpdir, "_metadata")).metadata
+    assert fmd.num_rows == fmd_file.num_rows
+    assert fmd.num_columns == fmd_file.num_columns
+    assert fmd.num_row_groups == fmd_file.num_row_groups
+
 
 def test_read_write_overwrite_is_true(tmpdir, engine):
     # https://github.com/dask/dask/issues/6824


### PR DESCRIPTION
This PR modifies the `create_metadata_file` to return an in-memory metdata structure in the case that that `out_dir=False`.  With this functionality in place, parquet metadata can be collected in parallel for the "pyarrow-legacy" engine (`ArrowLegacyEngine`) when there is not `_metadata` file available.

Note that the same optimization can be added for "pyarrow-dataset" and "fastparquet" after those engines are supported by `create_metadata_file`. 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
