### PR TITLE
Avoid unbounded memory usage in matmul by delegating to dot

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -321,16 +321,20 @@ def matmul(a, b):
     elif a.ndim > b.ndim:
         b = b[(a.ndim - b.ndim) * (np.newaxis,)]
 
-    out = blockwise(
-        np.matmul,
-        tuple(range(1, a.ndim + 1)),
-        a,
-        tuple(range(1, a.ndim - 1)) + (a.ndim - 1, 0),
-        b,
-        tuple(range(1, a.ndim - 1)) + (0, a.ndim),
-        dtype=result_type(a, b),
-        concatenate=True,
-    )
+    if a.ndim == b.ndim == 2:
+        # avoid concatenate=True in common case
+        out = dot(a, b)
+    else:
+        out = blockwise(
+            np.matmul,
+            tuple(range(1, a.ndim + 1)),
+            a,
+            tuple(range(1, a.ndim - 1)) + (a.ndim - 1, 0),
+            b,
+            tuple(range(1, a.ndim - 1)) + (0, a.ndim),
+            dtype=result_type(a, b),
+            concatenate=True,
+        )
 
     if a_is_1d:
         out = out[..., 0, :]


### PR DESCRIPTION
... in the common case of 1D or 2D arrays (#6874)

Note that this depends on #6916 to be fixed to have an effect though.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
