### PR TITLE
Simplify has_parallel_type()

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6405,28 +6405,19 @@ def get_parallel_type_index(_):
     return Index
 
 
-@get_parallel_type.register(object)
-def get_parallel_type_object(o):
-    return Scalar
-
-
 @get_parallel_type.register(_Frame)
 def get_parallel_type_frame(o):
     return get_parallel_type(o._meta)
 
 
-def parallel_types():
-    return tuple(
-        k
-        for k, v in get_parallel_type._lookup.items()
-        if v is not get_parallel_type_object
-    )
+@get_parallel_type.register(object)
+def get_parallel_type_object(_):
+    return Scalar
 
 
 def has_parallel_type(x):
     """ Does this object have a dask dataframe equivalent? """
-    get_parallel_type(x)  # trigger lazy registration
-    return isinstance(x, parallel_types())
+    return get_parallel_type(x) is not Scalar
 
 
 def new_dd_object(dsk, name, meta, divisions):


### PR DESCRIPTION
This PR simplify the implementation of `has_parallel_type()` and make it easy to extend by down stream projects like https://github.com/rapidsai/dask-cuda/pull/451

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
