### PR TITLE
Initial pass at blockwise array creation routines.

### DIFF
--- a/dask/array/blockwise.py
+++ b/dask/array/blockwise.py
@@ -29,9 +29,13 @@ class CreateArraySubgraph(Mapping):
         self.func = func
         self.shape = shape
         self.chunks = chunks
-        self._len = reduce(lambda acc, x: len(x) * acc, chunks, 1)  # Too tricky?
+        # Compute total number of blocks
+        self._len = reduce(lambda acc, x: len(x) * acc, chunks, 1)
 
     def __getitem__(self, key):
+        """
+        Construct a task for a given key.
+        """
         try:
             name, *idx = key
         except ValueError:
@@ -41,7 +45,9 @@ class CreateArraySubgraph(Mapping):
         if name != self.name:
             raise KeyError(key)
 
-        # TODO: check for invalid indices
+        # Check for invalid indices
+        if any(i < 0 or i >= len(c) for i, c in zip(idx, self.chunks)):
+            raise KeyError(key)
 
         # Get this chunk shape
         ndim = len(self.chunks)

--- a/dask/array/blockwise.py
+++ b/dask/array/blockwise.py
@@ -1,5 +1,4 @@
 import numbers
-import string
 import warnings
 
 import tlz as toolz
@@ -87,8 +86,7 @@ class BlockwiseCreateArray(BlockwiseIO):
             shape,
             chunks,
         )
-        # out_ind = tuple(range(len(shape)))
-        out_ind = string.ascii_lowercase[: len(shape)]  # mayday
+        out_ind = tuple(range(len(shape)))
 
         nchunks = tuple(len(chunk) for chunk in self.chunks)
         super().__init__(

--- a/dask/array/blockwise.py
+++ b/dask/array/blockwise.py
@@ -90,7 +90,7 @@ class BlockwiseCreateArray(BlockwiseIO):
 
         nchunks = tuple(len(chunk) for chunk in self.chunks)
         super().__init__(
-            { self.io_name: dsk_io },
+            {self.io_name: dsk_io},
             self.name,
             out_ind,
             None,

--- a/dask/array/blockwise.py
+++ b/dask/array/blockwise.py
@@ -16,6 +16,18 @@ from ..blockwise import BlockwiseIO, blockwise as core_blockwise
 class CreateArraySubgraph(Mapping):
     """
     Subgraph for numpy array creation utilities
+
+    Parameters
+    ----------
+    name: string
+        The output name.
+    func : callable
+        Function to apply to populate individual blocks. This function should take
+        an iterable containing the dimensions of the given block.
+    shape: iterable
+        Iterable containing the overall shape of the array.
+    chunks: iterable
+        Iterable containing the chunk sizes along each dimension of array.
     """
 
     def __init__(
@@ -34,7 +46,9 @@ class CreateArraySubgraph(Mapping):
 
     def __getitem__(self, key):
         """
-        Construct a task for a given key.
+        Get a task for a given key.
+
+        The tasks are constructed on demand.
         """
         try:
             name, *idx = key
@@ -69,9 +83,21 @@ class CreateArraySubgraph(Mapping):
 
 class BlockwiseCreateArray(BlockwiseIO):
     """
-    Specialized Blockwise Layer for numpy array creation routines.
+    Specialized Blockwise Layer for array creation routines.
 
     Enables HighLevelGraph optimizations.
+
+    Parameters
+    ----------
+    name: string
+        The output name.
+    func : callable
+        Function to apply to populate individual blocks. This function should take
+        an iterable containing the dimensions of the given block.
+    shape: iterable
+        Iterable containing the overall shape of the array.
+    chunks: iterable
+        Iterable containing the chunk sizes along each dimension of array.
     """
 
     def __init__(

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1528,7 +1528,7 @@ def test_map_blocks_optimize_blockwise(func):
     dsk = c.__dask_graph__()
     optimized = optimize_blockwise(dsk)
     # The two additions and the map_blocks should be fused together
-    assert len(optimized.layers) == len(dsk.layers) - 2
+    assert len(optimized.layers) == len(dsk.layers) - 6
 
 
 def test_repr():

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -428,7 +428,7 @@ def test_fuse_roots_annotations():
 
     z = (x + 1) + (2 * y)
     hlg = dask.blockwise.optimize_blockwise(z.dask)
-    assert len(hlg.layers) == 4
+    assert len(hlg.layers) == 3
     assert {"foo": "bar"} in [l.annotations for l in hlg.layers.values()]
     za = da.Array(hlg, z.name, z.chunks, z.dtype)
     assert_eq(za, z)

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -9,7 +9,13 @@ from dask.highlevelgraph import HighLevelGraph
 from dask.optimization import fuse
 from dask.utils import SerializableLock
 from dask.array.core import getter, getter_nofancy
-from dask.array.optimization import getitem, optimize, optimize_slices, fuse_slice
+from dask.array.optimization import (
+    getitem,
+    optimize,
+    optimize_blockwise,
+    optimize_slices,
+    fuse_slice,
+)
 from dask.array.utils import assert_eq
 
 
@@ -399,9 +405,8 @@ def test_array_creation_blockwise_fusion():
     a = x + y + z
     dsk1 = a.__dask_graph__()
     assert len(dsk1) == 5
-    with dask.config.set({"optimization.fuse.active": False}):
-        dsk2 = optimize(dsk1, y.__dask_keys__())
-        assert len(dsk2) == 1
+    dsk2 = optimize_blockwise(dsk1)
+    assert len(dsk2) == 1
     assert_eq(a, np.full(3, 3))
 
 

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1,5 +1,4 @@
 import itertools
-import warnings
 
 import numpy as np
 
@@ -1073,26 +1072,10 @@ def optimize_blockwise(graph, keys=()):
     --------
     rewrite_blockwise
     """
-    with warnings.catch_warnings():
-        # In some cases, rewrite_blockwise (called internally) will do a bad
-        # thing like `string in array[int].
-        # See dask/array/tests/test_atop.py::test_blockwise_numpy_arg for
-        # an example. NumPy currently raises a warning that 'a' == array([1, 2])
-        # will change from returning `False` to `array([False, False])`.
-        #
-        # Users shouldn't see those warnings, so we filter them.
-        # We set the filter here, rather than lower down, to avoid having to
-        # create and remove the filter many times inside a tight loop.
-
-        # https://github.com/dask/dask/pull/4805#discussion_r286545277 explains
-        # why silencing this warning shouldn't cause issues.
-        warnings.filterwarnings(
-            "ignore", "elementwise comparison failed", Warning
-        )  # FutureWarning or DeprecationWarning
+    out = _optimize_blockwise(graph, keys=keys)
+    while out.dependencies != graph.dependencies:
+        graph = out
         out = _optimize_blockwise(graph, keys=keys)
-        while out.dependencies != graph.dependencies:
-            graph = out
-            out = _optimize_blockwise(graph, keys=keys)
     return out
 
 

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -663,15 +663,7 @@ def _inject_io_tasks(dsk, io_deps, output_indices, new_axes):
                 io_subgraph = io_deps.get(io_key[0])
                 io_item = io_subgraph.get(io_key)
                 io_item = list(io_item[1:]) if len(io_item) > 1 else []
-                # Add additional type check to short circuit equality check.
-                # In some cases v can be array-like and want elementwise
-                # comparisons over strict object equality, which is not what
-                # we want here. For more discussion, see
-                # https://github.com/dask/dask/pull/4805#discussion_r284312315
-                new_task = [
-                    io_item if type(v) == type(io_key) and v == io_key else v
-                    for v in dsk[k]
-                ]
+                new_task = [io_item if j == i else v for j, v in enumerate(dsk[k])]
                 dsk[k] = tuple(new_task)
 
     return dsk

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -571,6 +571,9 @@ class BlockwiseIO(Blockwise):
         # BlockwiseIO requires `io_deps` inputs
         self.io_deps = io_deps
 
+    def __repr__(self):
+        return "BlockwiseIO<{} -> {}>".format(self.indices, self.output)
+
     @property
     def _dict(self):
         if hasattr(self, "_cached_dict"):

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -663,19 +663,15 @@ def _inject_io_tasks(dsk, io_deps, output_indices, new_axes):
                 io_subgraph = io_deps.get(io_key[0])
                 io_item = io_subgraph.get(io_key)
                 io_item = list(io_item[1:]) if len(io_item) > 1 else []
-                new_task = []
-                for v in dsk[k]:
-                    # Add additional type check to short circuit equality check.
-                    # In some cases v can be array-like and want elementwise
-                    # comparisons over strict object equality, which is not what
-                    # we want here. For more discussion, see
-                    # https://github.com/dask/dask/pull/4805#discussion_r284312315
-                    if type(v) == type(io_key) and v == io_key:
-                        new_task.append(io_item)
-                    else:
-                        new_task.append(v)
-
-                # new_task = [io_item if v == io_key else v for v in dsk[k]]
+                # Add additional type check to short circuit equality check.
+                # In some cases v can be array-like and want elementwise
+                # comparisons over strict object equality, which is not what
+                # we want here. For more discussion, see
+                # https://github.com/dask/dask/pull/4805#discussion_r284312315
+                new_task = [
+                    io_item if type(v) == type(io_key) and v == io_key else v
+                    for v in dsk[k]
+                ]
                 dsk[k] = tuple(new_task)
 
     return dsk


### PR DESCRIPTION
This is a start at adding blockwise high-level layers for dask array creation routines (for the moment, `ones`, `zeros`, and `full`), addressing part of #6791. I've patterned this after the blockwise CSV reader `Layer`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
