### PR TITLE
[DO NOT MERGE] Try PyArrow nightly release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.6", "3.7", "3.8"]

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -23,6 +23,9 @@ if [[ ${UPSTREAM_DEV} ]]; then
         git+https://github.com/dask/distributed
 fi
 
+# Try nightly version of pyarrow
+pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ --pre pyarrow
+
 # Install dask
 python -m pip install --quiet --no-deps -e .[complete]
 echo conda list

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -25,8 +25,7 @@ fi
 
 # Try nightly version of pyarrow
 conda uninstall --force pyarrow
-python -m pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ \
-    --pre pyarrow
+conda install -y -c arrow-nightlies pyarrow
 
 # Install dask
 python -m pip install --quiet --no-deps -e .[complete]

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -24,7 +24,9 @@ if [[ ${UPSTREAM_DEV} ]]; then
 fi
 
 # Try nightly version of pyarrow
-pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ --pre pyarrow
+conda uninstall --force pyarrow
+python -m pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ \
+    --pre pyarrow
 
 # Install dask
 python -m pip install --quiet --no-deps -e .[complete]


### PR DESCRIPTION
This is just to see if CI passes with the nightly version of `pyarrrow`, in anticipation of a new `pyarrrow` release (xref https://github.com/dask/dask/pull/6772#discussion_r535944610) 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
