### PR TITLE
Add ravel_multi_index

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -56,6 +56,7 @@ try:
         flatnonzero,
         nonzero,
         unravel_index,
+        ravel_multi_index,
         around,
         isin,
         isnull,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1389,13 +1389,13 @@ def _ravel_multi_index_kernel(multi_index, func_kwargs):
 
 
 @wraps(np.ravel_multi_index)
-def ravel_multi_index(multi_index, dims, mode='raise', order='C'):
+def ravel_multi_index(multi_index, dims, mode="raise", order="C"):
     return multi_index.map_blocks(
         _ravel_multi_index_kernel,
         dtype=np.intp,
-        chunks=(multi_index.shape[-1], ),
+        chunks=(multi_index.shape[-1],),
         drop_axis=0,
-        func_kwargs=dict(dims=dims, mode=mode, order=order)
+        func_kwargs=dict(dims=dims, mode=mode, order=order),
     )
 
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1362,12 +1362,6 @@ def nonzero(a):
         return (ind,)
 
 
-def _int_piecewise(x, *condlist, **kwargs):
-    return np.piecewise(
-        x, list(condlist), kwargs["funclist"], *kwargs["func_args"], **kwargs["func_kw"]
-    )
-
-
 def _unravel_index_kernel(indices, func_kwargs):
     return np.stack(np.unravel_index(indices, **func_kwargs))
 
@@ -1388,6 +1382,27 @@ def unravel_index(indices, shape, order="C"):
         unraveled_indices = tuple(empty((0,), dtype=np.intp, chunks=1) for i in shape)
 
     return unraveled_indices
+
+
+def _ravel_multi_index_kernel(multi_index, func_kwargs):
+    return np.ravel_multi_index(multi_index, **func_kwargs)
+
+
+@wraps(np.ravel_multi_index)
+def ravel_multi_index(multi_index, dims, mode='raise', order='C'):
+    return multi_index.map_blocks(
+        _ravel_multi_index_kernel,
+        dtype=np.intp,
+        chunks=(multi_index.shape[-1], ),
+        drop_axis=0,
+        func_kwargs=dict(dims=dims, mode=mode, order=order)
+    )
+
+
+def _int_piecewise(x, *condlist, **kwargs):
+    return np.piecewise(
+        x, list(condlist), kwargs["funclist"], *kwargs["func_args"], **kwargs["func_kw"]
+    )
 
 
 @derived_from(np)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1503,30 +1503,26 @@ def test_unravel_index():
         assert_eq(darr.vindex[d_indices], arr[indices])
 
 
-def test_ravel_multi_index():
-    for arr, chunks, kwargs in [
+@pytest.mark.parametrize(
+    "arr, chunks, kwargs",
+    [
         # Numpy doctests:
-        (np.array([[3, 6, 6], [4, 5, 1]]), (2, 3), dict(dims=(7, 6), order="C")),
-        (np.array([[3, 6, 6], [4, 5, 1]]), (2, 1), dict(dims=(7, 6), order="F")),
-        (np.array([[3, 6, 6], [4, 5, 1]]), 1, dict(dims=(4, 6), mode="clip")),
-        (
-            np.array([[3, 6, 6], [4, 5, 1]]),
-            (2, 3),
-            dict(dims=(4, 4), mode=("clip", "wrap")),
-        ),
-        # Shape tests:
-        (np.array([[3, 6, 6]]), (1, 1), dict(dims=(7), order="C")),
-        (
-            np.array([[3, 6, 6], [4, 5, 1], [8, 6, 2]]),
-            (3, 1),
-            dict(dims=(7, 6, 9), order="C"),
-        ),
-    ]:
-        darr = da.from_array(arr, chunks=chunks)
-        assert_eq(
-            da.ravel_multi_index(darr, **kwargs).compute(),
-            np.ravel_multi_index(arr, **kwargs),
-        )
+        ([[3, 6, 6], [4, 5, 1]], (2, 3), dict(dims=(7, 6), order="C")),
+        ([[3, 6, 6], [4, 5, 1]], (2, 1), dict(dims=(7, 6), order="F")),
+        ([[3, 6, 6], [4, 5, 1]], 1, dict(dims=(4, 6), mode="clip")),
+        ([[3, 6, 6], [4, 5, 1]], (2, 3), dict(dims=(4, 4), mode=("clip", "wrap"))),
+        # Shaoe tests:
+        ([[3, 6, 6]], (1, 1), dict(dims=(7), order="C")),
+        ([[3, 6, 6], [4, 5, 1], [8, 6, 2]], (3, 1), dict(dims=(7, 6, 9), order="C")),
+    ],
+)
+def test_ravel_multi_index(arr, chunks, kwargs):
+    arr = np.asarray(arr)
+    darr = da.from_array(arr, chunks=chunks)
+    assert_eq(
+        da.ravel_multi_index(darr, **kwargs).compute(),
+        np.ravel_multi_index(arr, **kwargs),
+    )
 
 
 def test_coarsen():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1503,7 +1503,7 @@ def test_unravel_index():
         assert_eq(darr.vindex[d_indices], arr[indices])
 
 
-    def test_ravel_multi_index():
+def test_ravel_multi_index():
     for arr, chunks, kwargs in [
         # Numpy doctests:
         (np.array([[3, 6, 6], [4, 5, 1]]), (2, 3), dict(dims=(7, 6), order="C")),

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1511,7 +1511,7 @@ def test_unravel_index():
         ([[3, 6, 6], [4, 5, 1]], (2, 1), dict(dims=(7, 6), order="F")),
         ([[3, 6, 6], [4, 5, 1]], 1, dict(dims=(4, 6), mode="clip")),
         ([[3, 6, 6], [4, 5, 1]], (2, 3), dict(dims=(4, 4), mode=("clip", "wrap"))),
-        # Shaoe tests:
+        # Shape tests:
         ([[3, 6, 6]], (1, 1), dict(dims=(7), order="C")),
         ([[3, 6, 6], [4, 5, 1], [8, 6, 2]], (3, 1), dict(dims=(7, 6, 9), order="C")),
     ],

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1503,6 +1503,32 @@ def test_unravel_index():
         assert_eq(darr.vindex[d_indices], arr[indices])
 
 
+    def test_ravel_multi_index():
+    for arr, chunks, kwargs in [
+        # Numpy doctests:
+        (np.array([[3, 6, 6], [4, 5, 1]]), (2, 3), dict(dims=(7, 6), order="C")),
+        (np.array([[3, 6, 6], [4, 5, 1]]), (2, 1), dict(dims=(7, 6), order="F")),
+        (np.array([[3, 6, 6], [4, 5, 1]]), 1, dict(dims=(4, 6), mode="clip")),
+        (
+            np.array([[3, 6, 6], [4, 5, 1]]),
+            (2, 3),
+            dict(dims=(4, 4), mode=("clip", "wrap")),
+        ),
+        # Shape tests:
+        (np.array([[3, 6, 6]]), (1, 1), dict(dims=(7), order="C")),
+        (
+            np.array([[3, 6, 6], [4, 5, 1], [8, 6, 2]]),
+            (3, 1),
+            dict(dims=(7, 6, 9), order="C"),
+        ),
+    ]:
+        darr = da.from_array(arr, chunks=chunks)
+        assert_eq(
+            da.ravel_multi_index(darr, **kwargs).compute(),
+            np.ravel_multi_index(arr, **kwargs),
+        )
+
+
 def test_coarsen():
     x = np.random.randint(10, size=(24, 24))
     d = da.from_array(x, chunks=(4, 8))


### PR DESCRIPTION
Closes #2557.
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

I've seen a couple of ways implementing this functionality when trying to understand what's going on:
* https://github.com/pydata/sparse/blob/9dc40e15a04eda8d8efff35dfc08950b4c07a810/sparse/_coo/common.py#L56-L64
* https://github.com/xgcm/xhistogram/blob/7ba35baf0d40b8b9d9d5fa22ffe48b6fb11bc7d3/xhistogram/duck_array_ops.py#L39

I don't know if these are better alternatives. I mainly just went with getting the numpy version working, and I think it would start to get messy if we want to support all the options that numpy has without using `np.ravel_multi_index`.