### PR TITLE
Fixing issue #6906 : Return a `Bag` from `sample`

### DIFF
--- a/dask/bag/random.py
+++ b/dask/bag/random.py
@@ -4,6 +4,8 @@ import math
 import random as rnd
 from functools import partial
 
+from .core import Bag
+
 
 def sample(population, k):
     """Chooses k unique random elements from a bag.
@@ -57,6 +59,7 @@ def _sample(population, k, replace=False):
     return population.reduction(
         partial(_sample_map_partitions, k=k, replace=replace),
         partial(_sample_reduce, k=k, replace=replace),
+        out_type=Bag,
     )
 
 

--- a/dask/bag/tests/test_random.py
+++ b/dask/bag/tests/test_random.py
@@ -108,6 +108,7 @@ def test_weighted_sampling_without_replacement():
     )
     assert len(set(sampled)) == k
 
+
 def test_sample_return_bag():
     seq = range(20)
     sut = db.from_sequence(seq, npartitions=3)

--- a/dask/bag/tests/test_random.py
+++ b/dask/bag/tests/test_random.py
@@ -107,3 +107,8 @@ def test_weighted_sampling_without_replacement():
         population=population, weights=p, k=k
     )
     assert len(set(sampled)) == k
+
+def test_sample_return_bag():
+    seq = range(20)
+    sut = db.from_sequence(seq, npartitions=3)
+    assert isinstance(random.sample(sut, k=2), db.Bag)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Note: `black` and `flake8` were only run on the modified files. Running `black` on `dask/` shows a lot more files that needs reformatting, but that would not be related to this PR.
