### PR TITLE
[RFC] Coerce `bytes` to `str` in `stringify`

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -594,7 +594,7 @@ def test_stringify():
     obj = "Hello"
     assert stringify(obj) is obj
     obj = b"Hello"
-    assert stringify(obj) is obj
+    assert stringify(obj) is obj.decode()
     dsk = {"x": 1}
 
     assert stringify(dsk) == str(dsk)
@@ -635,5 +635,5 @@ def test_stringify_collection_keys():
     obj = [("a", 0), (b"a", 0), (1, 1)]
     res = stringify_collection_keys(obj)
     assert res[0] == str(obj[0])
-    assert res[1] == str(obj[1])
+    assert res[1] == str((obj[1][0].decode(), obj[1][1]))
     assert res[2] == obj[2]

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1570,7 +1570,7 @@ def stringify(obj, exclusive: Optional[Iterable] = None):
     Examples
     --------
     >>> stringify(b'x')
-    b'x'
+    'x'
     >>> stringify('x')
     'x'
     >>> stringify({('a',0):('a',0), ('a',1): ('a',1)})
@@ -1580,8 +1580,10 @@ def stringify(obj, exclusive: Optional[Iterable] = None):
     """
 
     typ = type(obj)
-    if typ is str or typ is bytes:
+    if typ is str:
         return obj
+    elif typ is bytes:
+        return obj.decode()
     elif exclusive is None:
         return str(obj)
 


### PR DESCRIPTION
As this is used on the `Client` to handle keys and it seems we would prefer to coerce `bytes` to `str` there, one way to get that behavior would be to change `stringify`'s.

xref: https://github.com/dask/distributed/pull/4336

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
