### PR TITLE
Fix flaky test

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -81,7 +81,7 @@ class CSVSubgraph(Mapping):
             path_info = (
                 self.colname,
                 self.paths[i],
-                list(self.head[self.colname].cat.categories),
+                sorted(list(self.head[self.colname].cat.categories)),
             )
         else:
             path_info = None


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

I just merged a PR #6911 that made the order of the categories when using `include_path_column` ambiguous. That resulted in a flaky test which this fixes.