### PR TITLE
Prevent fuse_roots from clobbering annotations

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1460,6 +1460,7 @@ def fuse_roots(graph: HighLevelGraph, keys: list):
             and len(deps) > 1
             and not any(dependencies[dep] for dep in deps)  # no need to fuse if 0 or 1
             and all(len(dependents[dep]) == 1 for dep in deps)
+            and all(layer.annotations == graph.layers[dep].annotations for dep in deps)
         ):
             new = toolz.merge(layer, *[layers[dep] for dep in deps])
             new, _ = fuse(new, keys, ave_width=len(deps))


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
