### PR TITLE
Add compression='infer' default to read_csv

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -32,6 +32,7 @@ from ...blockwise import BlockwiseIO
 import fsspec.implementations.local
 from fsspec.compression import compr
 from fsspec.core import get_fs_token_paths
+from fsspec.utils import infer_compression
 
 
 class CSVSubgraph(Mapping):
@@ -518,11 +519,8 @@ def read_pandas(
             raise TypeError("Path should be a string, os.PathLike, list or tuple")
         paths = get_fs_token_paths(urlpath, mode="rb", storage_options=kwargs)[2]
 
-        # "Recognized" compression options
-        compression_options = {"gz": "gzip", "bz2": "bz2", "zip": "zip", "xz": "xz"}
-
-        # Check if the first path suffix is a recognized compression option
-        compression = compression_options.get(paths[0].split(".")[-1], None)
+        # Infer compression from first path
+        compression = infer_compression(paths[0])
 
     if blocksize == "default":
         blocksize = AUTO_BLOCKSIZE

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import Mapping
 from io import BytesIO
 from warnings import warn, catch_warnings, simplefilter
@@ -515,8 +514,6 @@ def read_pandas(
     # set the proper compression option if the suffix is recongnized.
     if compression == "infer":
         # Translate the input urlpath to a simple path list
-        if not isinstance(urlpath, (str, list, tuple, os.PathLike)):
-            raise TypeError("Path should be a string, os.PathLike, list or tuple")
         paths = get_fs_token_paths(urlpath, mode="rb", storage_options=kwargs)[2]
 
         # Infer compression from first path

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -721,13 +721,15 @@ def test_read_csv_sensitive_to_enforce():
 def test_read_csv_compression(fmt, blocksize):
     if fmt not in compress:
         pytest.skip("compress function not provided for %s" % fmt)
+    suffix = {"gzip": ".gz", "bz2": ".bz2", "zip": ".zip", "xz": ".xz"}.get(fmt, "")
     files2 = valmap(compress[fmt], csv_files)
-    with filetexts(files2, mode="b"):
+    renamed_files = {k + suffix: v for k, v in files2.items()}
+    with filetexts(renamed_files, mode="b"):
         if fmt and blocksize:
             with pytest.warns(UserWarning):
-                df = dd.read_csv("2014-01-*.csv", compression=fmt, blocksize=blocksize)
+                df = dd.read_csv("2014-01-*.csv" + suffix, blocksize=blocksize)
         else:
-            df = dd.read_csv("2014-01-*.csv", compression=fmt, blocksize=blocksize)
+            df = dd.read_csv("2014-01-*.csv" + suffix, blocksize=blocksize)
         assert_eq(
             df.compute(scheduler="sync").reset_index(drop=True),
             expected.reset_index(drop=True),

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -680,7 +680,8 @@ def test_categorical_known():
 
 
 @pytest.mark.slow
-def test_compression_multiple_files():
+@pytest.mark.parametrize("compression", ["infer", "gzip"])
+def test_compression_multiple_files(compression):
     with tmpdir() as tdir:
         f = gzip.open(os.path.join(tdir, "a.csv.gz"), "wb")
         f.write(csv_text.encode())
@@ -691,7 +692,7 @@ def test_compression_multiple_files():
         f.close()
 
         with pytest.warns(UserWarning):
-            df = dd.read_csv(os.path.join(tdir, "*.csv.gz"), compression="gzip")
+            df = dd.read_csv(os.path.join(tdir, "*.csv.gz"), compression=compression)
 
         assert len(df.compute()) == (len(csv_text.split("\n")) - 1) * 2
 


### PR DESCRIPTION
Adds default `compression="infer"` option to `read_csv`.

Closes #6929

**TODO**:
- [x] Test `compression="infer"` for bz2, zip and xz (gzip done) 