### PR TITLE
Avoid deprecated yield_fixture in test_sql.py

### DIFF
--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -29,7 +29,7 @@ Garreth,6,20,0
 df = pd.read_csv(io.StringIO(data), index_col="number")
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def db():
     with tmpfile() as f:
         uri = "sqlite:///%s" % f


### PR DESCRIPTION
Minor change to avoid using `@pytest.yield_fixture` (See related [CI Failure](https://github.com/dask/dask/pull/6960/checks?check_run_id=1551459495))

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
