### PR TITLE
Bugfix in read_parquet for handling un-named indices with index=False

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1070,8 +1070,10 @@ def set_index_columns(meta, index, columns, index_in_columns, auto_index_allowed
         ignore_index_column_intersection = True
         # Do not allow "un-named" fields to be read in as columns.
         # These were intended to be un-named indices at write time.
-        if index is False:
-            columns = [c for c in meta.columns if c not in (None, NONE_LABEL)]
+        _index = index or []
+        columns = [
+            c for c in meta.columns if c not in (None, NONE_LABEL) or c in _index
+        ]
 
     if not set(columns).issubset(set(meta.columns)):
         raise ValueError(

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1068,7 +1068,10 @@ def set_index_columns(meta, index, columns, index_in_columns, auto_index_allowed
         # User didn't specify columns, so ignore any intersection
         # of auto-detected values with the index (if necessary)
         ignore_index_column_intersection = True
-        columns = [c for c in meta.columns]
+        # Cannot allow `None` in the column naems unless it is
+        # already specified in `index`
+        _index = index or []
+        columns = [c for c in meta.columns if c is not None or c in _index]
 
     if not set(columns).issubset(set(meta.columns)):
         raise ValueError(

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1068,10 +1068,10 @@ def set_index_columns(meta, index, columns, index_in_columns, auto_index_allowed
         # User didn't specify columns, so ignore any intersection
         # of auto-detected values with the index (if necessary)
         ignore_index_column_intersection = True
-        # Cannot allow `None` in the column naems unless it is
-        # already specified in `index`
-        _index = index or []
-        columns = [c for c in meta.columns if c is not None or c in _index]
+        # Do not allow "un-named" fields to be read in as columns.
+        # These were intended to be un-named indices at write time.
+        if index is False:
+            columns = [c for c in meta.columns if c not in (None, NONE_LABEL)]
 
     if not set(columns).issubset(set(meta.columns)):
         raise ValueError(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2916,6 +2916,22 @@ def test_from_pandas_preserve_none_index(tmpdir, engine):
     assert_eq(expect, got)
 
 
+def test_multi_partition_none_index_false(tmpdir, engine):
+    check_pyarrow()
+    if pa.__version__ < LooseVersion("0.15.0"):
+        pytest.skip("PyArrow>=0.15 Required.")
+
+    # Write dataset without dast.to_parquet
+    ddf1 = ddf.reset_index(drop=True)
+    for i, part in enumerate(ddf1.partitions):
+        path = tmpdir.join(f"test.{i}.parquet")
+        part.compute().to_parquet(str(path), engine="pyarrow")
+
+    # Read back with index=False
+    ddf2 = dd.read_parquet(str(tmpdir), index=False)
+    assert_eq(ddf1, ddf2)
+
+
 @write_read_engines()
 def test_from_pandas_preserve_none_rangeindex(tmpdir, write_engine, read_engine):
     # See GitHub Issue#6348


### PR DESCRIPTION
For datasets written without `dask.dataframe.to_parquet`, un-named indices will be written with the name "`None`" in the parquet metadata.  The `read_parquet` code is designed to handle "un-named" index columns, but the logic is broken when the user does **not** want an index to be read from disk (i.e. the user specifies `index=False`).

I propose that we ignore un-named indices when the user specifies `index=False`, and do not attempt to read them in as columns. It seems unlikely that the user is expecting these "default" indices to show up as columns anyway.