### PR TITLE
Use meta value in series non_empty

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4152,6 +4152,20 @@ def test_meta_raises():
     assert "meta=" not in str(info.value)
 
 
+def test_meta_nonempty_uses_meta_value_if_provided():
+    # https://github.com/dask/dask/issues/6958
+    base = pd.Series([1, 2, 3], dtype="datetime64[ns]")
+    offsets = pd.Series([pd.offsets.DateOffset(years=o) for o in range(3)])
+    dask_base = dd.from_pandas(base, npartitions=1)
+    dask_offsets = dd.from_pandas(offsets, npartitions=1)
+    dask_offsets._meta = offsets.head()
+
+    with pytest.warns(None):  # not vectorized performance warning
+        expected = base + offsets
+        actual = dask_base + dask_offsets
+        assert_eq(expected, actual)
+
+
 def test_dask_dataframe_holds_scipy_sparse_containers():
     sparse = pytest.importorskip("scipy.sparse")
     da = pytest.importorskip("dask.array")

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -542,7 +542,10 @@ def _nonempty_series(s, idx=None):
     if idx is None:
         idx = _nonempty_index(s.index)
     dtype = s.dtype
-    if is_datetime64tz_dtype(dtype):
+    if len(s) > 0:
+        # use value from meta if provided
+        data = [s.iloc[0]] * 2
+    elif is_datetime64tz_dtype(dtype):
         entry = pd.Timestamp("1970-01-01", tz=dtype.tz)
         data = [entry, entry]
     elif is_categorical_dtype(dtype):


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Partially fixes #6958

This allows a workaround like:

```python
import dask.dataframe as dd
import pandas as pd

base = pd.Series([1,2,3], dtype="datetime64[ns]")
offsets = pd.Series([pd.offsets.DateOffset(years=o) for o in range(3)])

dask_base = dd.from_pandas(base, npartitions=1)
dask_offsets = dd.from_pandas(offsets, npartitions=1)
dask_offsets._meta = offsets.head()

dask_base + dask_offsets
```
