### PR TITLE
Comparing string versions won't always work

### DIFF
--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 import numpy as np
 import pytest
 
@@ -31,7 +33,7 @@ functions = [
     pytest.param(
         lambda x: x.mean(),
         marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE or cupy.__version__ < "6.4.0",
+            not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
             reason="NEP-18 support is not available in NumPy or CuPy older than "
             "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
         ),
@@ -43,7 +45,7 @@ functions = [
     pytest.param(
         lambda x: x.std(),
         marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE or cupy.__version__ < "6.4.0",
+            not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
             reason="NEP-18 support is not available in NumPy or CuPy older than "
             "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
         ),
@@ -51,7 +53,7 @@ functions = [
     pytest.param(
         lambda x: x.var(),
         marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE or cupy.__version__ < "6.4.0",
+            not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
             reason="NEP-18 support is not available in NumPy or CuPy older than "
             "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
         ),
@@ -308,7 +310,7 @@ def test_diagonal():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < "6.4.0",
+    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
@@ -326,7 +328,7 @@ def test_tril_triu():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < "6.4.0",
+    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
@@ -438,7 +440,7 @@ def test_nearest():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < "6.4.0",
+    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
@@ -455,7 +457,7 @@ def test_constant():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < "6.4.0",
+    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
@@ -546,7 +548,7 @@ def test_random_shapes(shape):
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < "6.1.0",
+    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.1.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.1.0 (requires https://github.com/cupy/cupy/pull/2209)",
 )
@@ -913,7 +915,7 @@ def test_cupy_sparse_concatenate(axis):
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < "6.4.0",
+    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -1,4 +1,5 @@
 import random
+from distutils.version import LooseVersion
 
 import numpy as np
 import pytest
@@ -91,7 +92,7 @@ def test_basic(func):
 
 
 @pytest.mark.skipif(
-    sparse.__version__ < "0.7.0+10",
+    sparse.__version__ < LooseVersion("0.7.0+10"),
     reason="fixed in https://github.com/pydata/sparse/pull/256",
 )
 def test_tensordot():


### PR DESCRIPTION
Fixed some cupy and sparse skip test markers. cupy were still fine, but sparse actually skips the test on the recent version of sparse (0.11.2):

```
"0.11.2" < "0.7.0+1"
```

on strings evaluates to `True`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
