### PR TITLE
Avoid data loss in set_index with sorted=True

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -1229,12 +1229,13 @@ def fix_overlap(ddf, overlap):
     frames = []
     for i in overlap:
 
-        # `frames` is a list of data from <i partitions that may belong in
-        # partition i.  Add "overlap" from the previous partition (i-1) to the list.
+        # `frames` is a list of data from previous partitions that we may want to
+        # move to partition i.  Here, we add "overlap" from the previous partition
+        # (i-1) to this list.
         frames.append((get_overlap, (ddf._name, i - 1), ddf.divisions[i]))
 
-        # Make sure data that any data added from i-1 to `frames` is removed from
-        # that partition.
+        # Make sure that any data added from partition i-1 to `frames` is removed
+        # from partition i-1.
         dsk[(name, i - 1)] = (drop_overlap, dsk[(name, i - 1)], ddf.divisions[i])
 
         # We do not want to move "overlap" from the previous partition (i-1) into

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1030,6 +1030,22 @@ def test_set_index_overlap():
     assert_eq(a, b)
 
 
+def test_set_index_overlap_2():
+    data = pd.DataFrame(
+        index=pd.Index(
+            ["A", "A", "A", "A", "A", "A", "A", "A", "A", "B", "B", "B", "C"],
+            name="index",
+        )
+    )
+    ddf1 = dd.from_pandas(data, npartitions=2)
+    ddf2 = ddf1.reset_index().repartition(8).set_index("index", sorted=True)
+    # import pdb; pdb.set_trace()
+    # pass
+    assert_eq(ddf1, ddf2)
+    # assert_eq(data.reset_index(), ddf2.reset_index(), check_index=False)
+    assert ddf2.npartitions == 8
+
+
 def test_shuffle_hlg_layer():
     # This test checks that the `ShuffleLayer` HLG Layer
     # is used (as expected) for a multi-stage shuffle.

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1039,10 +1039,8 @@ def test_set_index_overlap_2():
     )
     ddf1 = dd.from_pandas(data, npartitions=2)
     ddf2 = ddf1.reset_index().repartition(8).set_index("index", sorted=True)
-    # import pdb; pdb.set_trace()
-    # pass
+
     assert_eq(ddf1, ddf2)
-    # assert_eq(data.reset_index(), ddf2.reset_index(), check_index=False)
     assert ddf2.npartitions == 8
 
 


### PR DESCRIPTION
Closes #6973 

The existing `set_index(..., sorted=True)` code path (for `dask.dataframe`) does not correctly handle cases where the same index value is present in >2 partitions.  The goal of this PR is to prevent data loss in cases like this.