### PR TITLE
Use __class__ when comparing meta data

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4946,7 +4946,7 @@ def handle_out(out, result):
         else:
             out = None
 
-    if out is not None and type(out) != type(result):
+    if out is not None and out.__class__ != result.__class__:
         raise TypeError(
             "Mismatched types between result and out parameter. "
             "out=%s, result=%s" % (str(type(out)), str(type(result)))

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4946,6 +4946,8 @@ def handle_out(out, result):
         else:
             out = None
 
+    # Notice, we use .__class__ as opposed to type() in order to support
+    # object proxies see <https://github.com/dask/dask/pull/6981>
     if out is not None and out.__class__ != result.__class__:
         raise TypeError(
             "Mismatched types between result and out parameter. "

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -633,7 +633,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
             "Index, got `%s`" % typename(type(meta))
         )
 
-    if type(x) != type(meta):
+    if x.__class__ != meta.__class__:
         errmsg = "Expected partition of type `%s` but got `%s`" % (
             typename(type(meta)),
             typename(type(x)),

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -633,6 +633,8 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
             "Index, got `%s`" % typename(type(meta))
         )
 
+    # Notice, we use .__class__ as opposed to type() in order to support
+    # object proxies see <https://github.com/dask/dask/pull/6981>
     if x.__class__ != meta.__class__:
         errmsg = "Expected partition of type `%s` but got `%s`" % (
             typename(type(meta)),


### PR DESCRIPTION
In order to support object wrappers/proxies like https://github.com/rapidsai/dask-cuda/pull/451 and [`weakref.proxy`](https://docs.python.org/3/library/weakref.html#weakref.proxy), this PR implements type checking through `x.__class__` instead of `type(x)`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
