### PR TITLE
]WIP] Blockwise from array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -59,7 +59,7 @@ from ..sizeof import sizeof
 from ..highlevelgraph import HighLevelGraph
 from .numpy_compat import _Recurser, _make_sliced_dtype
 from .slicing import slice_array, replace_ellipsis, cached_cumsum
-from .blockwise import blockwise
+from .blockwise import blockwise, BlockwiseCreateArray
 from .chunk_types import is_valid_array_chunk, is_valid_chunk_type
 
 
@@ -222,7 +222,11 @@ def slices_from_chunks(chunks):
     return list(product(*slices))
 
 
-def getem(
+def _get_from_block_info(getter, block_info):
+    return getter(tuple(slice(*s, None) for s in block_info["array-location"]))
+
+
+def graph_from_arraylike(
     arr,
     chunks,
     getitem=getter,
@@ -234,13 +238,13 @@ def getem(
 ):
     """Dask getting various chunks from an array-like
 
-    >>> getem('X', chunks=(2, 3), shape=(4, 6))  # doctest: +SKIP
+    >>> graph_from_arraylike('X', chunks=(2, 3), shape=(4, 6))  # doctest: +SKIP
     {('X', 0, 0): (getter, 'X', (slice(0, 2), slice(0, 3))),
      ('X', 1, 0): (getter, 'X', (slice(2, 4), slice(0, 3))),
      ('X', 1, 1): (getter, 'X', (slice(2, 4), slice(3, 6))),
      ('X', 0, 1): (getter, 'X', (slice(0, 2), slice(3, 6)))}
 
-    >>> getem('X', chunks=((2, 2), (3, 3)))  # doctest: +SKIP
+    >>> graph_from_arraylike('X', chunks=((2, 2), (3, 3)))  # doctest: +SKIP
     {('X', 0, 0): (getter, 'X', (slice(0, 2), slice(0, 3))),
      ('X', 1, 0): (getter, 'X', (slice(2, 4), slice(0, 3))),
      ('X', 1, 1): (getter, 'X', (slice(2, 4), slice(3, 6))),
@@ -248,20 +252,20 @@ def getem(
     """
     out_name = out_name or arr
     chunks = normalize_chunks(chunks, shape, dtype=dtype)
-    keys = product([out_name], *(range(len(bds)) for bds in chunks))
-    slices = slices_from_chunks(chunks)
 
     if (
         has_keyword(getitem, "asarray")
         and has_keyword(getitem, "lock")
         and (not asarray or lock)
     ):
-        values = [(getitem, arr, x, asarray, lock) for x in slices]
+        getter = partial(getitem, arr, asarray=asarray, lock=lock)
     else:
         # Common case, drop extra parameters
-        values = [(getitem, arr, x) for x in slices]
+        getter = partial(getitem, arr)
 
-    return dict(zip(keys, values))
+    return BlockwiseCreateArray(
+        out_name, partial(_get_from_block_info, getter), shape, chunks
+    )
 
 
 def dotmany(A, B, leftfunc=None, rightfunc=None, **kwargs):
@@ -2978,12 +2982,9 @@ def from_array(
 
     if name in (None, True):
         token = tokenize(x, chunks)
-        original_name = "array-original-" + token
         name = name or "array-" + token
     elif name is False:
-        original_name = name = "array-" + str(uuid.uuid1())
-    else:
-        original_name = name
+        name = "array-" + str(uuid.uuid1())
 
     if lock is True:
         lock = SerializableLock()
@@ -3010,8 +3011,8 @@ def from_array(
             else:
                 getitem = getter_nofancy
 
-        dsk = getem(
-            original_name,
+        dsk = graph_from_arraylike(
+            x,
             chunks,
             getitem=getitem,
             shape=x.shape,
@@ -3020,7 +3021,7 @@ def from_array(
             asarray=asarray,
             dtype=x.dtype,
         )
-        dsk[original_name] = x
+        dsk = HighLevelGraph.from_collections(name, dsk)
 
     # Workaround for TileDB, its indexing is 1-based,
     # and doesn't seems to support 0-length slicing

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -250,6 +250,7 @@ def graph_from_arraylike(
      ('X', 1, 1): (getter, 'X', (slice(2, 4), slice(3, 6))),
      ('X', 0, 1): (getter, 'X', (slice(0, 2), slice(3, 6)))}
     """
+    # TODO: probably get shape, dtype(?) from arr
     out_name = out_name or arr
     chunks = normalize_chunks(chunks, shape, dtype=dtype)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2329,10 +2329,15 @@ def test_from_array_with_lock():
     x = np.arange(10)
     d = da.from_array(x, chunks=5, lock=True)
 
+    # Pull io_subgraph and getter functions from deep in the graph
     tasks = [v for k, v in d.dask.items() if k[0] == d.name]
+    io_subgraphs = [t[0] for t in tasks]
+    getters = [next(iter(i.dsk.values()))[0].func.args[0] for i in io_subgraphs]
 
-    assert hasattr(tasks[0][4], "acquire")
-    assert len(set(task[4] for task in tasks)) == 1
+    # Check that a lock is set.
+    assert hasattr(getters[0].keywords.get("lock"), "acquire")
+    # Check that the same lock is shared between tasks.
+    assert len(set(getter.keywords["lock"] for getter in getters)) == 1
 
     assert_eq(d, x)
 

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -48,6 +48,14 @@ def _parse_wrap_args(func, args, kwargs, shape):
     }
 
 
+def _create_array_from_block_info(func, block_info, **kwargs):
+    """
+    BlockwiseCreateArray passes a block_info object. Adapt numpy-like
+    array creation routines with shape as first arg to that.
+    """
+    return func(block_info["chunk-shape"], **kwargs)
+
+
 def wrap_func_shape_as_first_arg(func, *args, **kwargs):
     """
     Transform np creation function into blocked version
@@ -69,7 +77,8 @@ def wrap_func_shape_as_first_arg(func, *args, **kwargs):
     chunks = parsed["chunks"]
     name = parsed["name"]
     kwargs = parsed["kwargs"]
-    func = partial(func, dtype=dtype, **kwargs)
+
+    func = partial(_create_array_from_block_info, func, dtype=dtype, **kwargs)
 
     graph = BlockwiseCreateArray(
         name,


### PR DESCRIPTION
Follow-up to #6931. Switches `from_array` and its ilk (zarr, hdf5) to use `BlockwiseIO`.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
