### PR TITLE
Fix pandas dtype inference for read_parquet

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3291,3 +3291,27 @@ def test_dir_filter(tmpdir, engine):
     ddf.to_parquet(tmpdir, partition_on="year", engine=engine)
     dd.read_parquet(tmpdir, filters=[("year", "==", 2020)], engine=engine)
     assert all
+
+
+def test_roundtrip_decimal_dtype(tmpdir):
+    # https://github.com/dask/dask/issues/6948
+    from decimal import Decimal
+
+    check_pyarrow()
+    tmpdir = str(tmpdir)
+
+    schema = {"col1": pa.decimal128(5, 2)}
+    data = [
+        {
+            "ts": pd.to_datetime("2021-01-01", utc="Europe/Berlin"),
+            "col1": Decimal("123.00"),
+        }
+        for i in range(23)
+    ]
+    ddf1 = dd.from_pandas(pd.DataFrame(data), npartitions=1)
+
+    ddf1.to_parquet(path=tmpdir, engine="pyarrow", schema=schema)
+    ddf2 = dd.read_parquet(tmpdir, engine="pyarrow")
+
+    assert ddf1["col1"].dtype == ddf2["col1"].dtype
+    assert_eq(ddf1, ddf2, check_divisions=False)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3300,7 +3300,6 @@ def test_roundtrip_decimal_dtype(tmpdir):
     check_pyarrow()
     tmpdir = str(tmpdir)
 
-    schema = {"col1": pa.decimal128(5, 2)}
     data = [
         {
             "ts": pd.to_datetime("2021-01-01", utc="Europe/Berlin"),
@@ -3310,7 +3309,7 @@ def test_roundtrip_decimal_dtype(tmpdir):
     ]
     ddf1 = dd.from_pandas(pd.DataFrame(data), npartitions=1)
 
-    ddf1.to_parquet(path=tmpdir, engine="pyarrow", schema=schema)
+    ddf1.to_parquet(path=tmpdir, engine="pyarrow")
     ddf2 = dd.read_parquet(tmpdir, engine="pyarrow")
 
     assert ddf1["col1"].dtype == ddf2["col1"].dtype

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3,6 +3,7 @@ import glob
 import os
 import sys
 import warnings
+from decimal import Decimal
 from distutils.version import LooseVersion
 
 import numpy as np
@@ -3295,8 +3296,6 @@ def test_dir_filter(tmpdir, engine):
 
 def test_roundtrip_decimal_dtype(tmpdir):
     # https://github.com/dask/dask/issues/6948
-    from decimal import Decimal
-
     check_pyarrow()
     tmpdir = str(tmpdir)
 

--- a/dask/dataframe/io/utils.py
+++ b/dask/dataframe/io/utils.py
@@ -19,7 +19,7 @@ def _get_pyarrow_dtypes(schema, categories):
                 "timezone", None
             )
             for c in pandas_metadata.get("columns", [])
-            if c["metadata"]
+            if c["pandas_type"] in ("datetime", "datetimetz") and c["metadata"]
         }
     else:
         pandas_metadata_dtypes = {}


### PR DESCRIPTION
Closes #6948 

The existing [_get_pyarrow_dtypes](https://github.com/dask/dask/blob/06947129999ee480a6a977b081631723e7233ce9/dask/dataframe/io/utils.py#L6) definition treats a column as "datetime" if it has a `"metadata"` field in the "pandas metadata."  This causes problems for other special pandas datatypes.  This PR proposes a simple fix.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
