### PR TITLE
Upstream config serialization and inheritance

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -178,10 +178,19 @@ def collect_env(env=None):
     -  Lower-cases the key text
     -  Treats ``__`` (double-underscore) as nested access
     -  Calls ``ast.literal_eval`` on the value
+
+    Any serialized config passed via ``DASK_INTERNAL_INHERIT_CONFIG`` is also set here.
+
     """
+
     if env is None:
         env = os.environ
-    d = {}
+
+    if "DASK_INTERNAL_INHERIT_CONFIG" in env:
+        d = deserialize(env["DASK_INTERNAL_INHERIT_CONFIG"])
+    else:
+        d = {}
+
     for name, value in env.items():
         if name.startswith("DASK_"):
             varname = name[5:].lower().replace("__", ".")
@@ -627,9 +636,6 @@ def deserialize(data):
 
 
 def _initialize():
-    if "DASK_INTERNAL_INHERIT_CONFIG" in os.environ:
-        update(global_config, deserialize(os.environ["DASK_INTERNAL_INHERIT_CONFIG"]))
-
     fn = os.path.join(os.path.dirname(__file__), "dask.yaml")
 
     with open(fn) as f:

--- a/dask/config.py
+++ b/dask/config.py
@@ -588,8 +588,10 @@ def check_deprecations(key: str, deprecations: dict = deprecations):
         return key
 
 
-def serialize_for_cli(data):
-    """Serialize config data into a string that can be passed via the CLI.
+def serialize(data):
+    """Serialize config data into a string.
+
+    Typically used to pass config via the ``DASK_INTERNAL_INHERIT_CONFIG`` environment variable.
 
     Parameters
     ----------
@@ -605,13 +607,15 @@ def serialize_for_cli(data):
     return base64.urlsafe_b64encode(json.dumps(data).encode()).decode()
 
 
-def deserialize_for_cli(data):
+def deserialize(data):
     """De-serialize config data into the original object.
+
+    Typically when receiving config via the ``DASK_INTERNAL_INHERIT_CONFIG`` environment variable.
 
     Parameters
     ----------
     data: str
-        String serialied by serialize_for_cli()
+        String serialied by :func:`dask.config.serialize`
 
     Returns
     -------
@@ -624,8 +628,7 @@ def deserialize_for_cli(data):
 
 def _initialize():
     if "DASK_INTERNAL_INHERIT_CONFIG" in os.environ:
-        config = deserialize_for_cli(os.environ["DASK_INTERNAL_INHERIT_CONFIG"])
-        update(global_config, config)
+        update(global_config, deserialize(os.environ["DASK_INTERNAL_INHERIT_CONFIG"]))
 
     fn = os.path.join(os.path.dirname(__file__), "dask.yaml")
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -511,3 +511,6 @@ def test_config_inheritance():
     )
     refresh()
     assert dask.config.get("array.svg.size") == 150
+
+    del os.environ["DASK_INTERNAL_INHERIT_CONFIG"]
+    refresh()

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -506,11 +506,7 @@ def test_config_serialization():
 
 
 def test_config_inheritance():
-    os.environ["DASK_INTERNAL_INHERIT_CONFIG"] = serialize(
-        {"array": {"svg": {"size": 150}}}
+    config = collect_env(
+        {"DASK_INTERNAL_INHERIT_CONFIG": serialize({"array": {"svg": {"size": 150}}})}
     )
-    refresh()
-    assert dask.config.get("array.svg.size") == 150
-
-    del os.environ["DASK_INTERNAL_INHERIT_CONFIG"]
-    refresh()
+    assert dask.config.get("array.svg.size", config=config) == 150

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -24,7 +24,6 @@ from dask.config import (
     canonical_name,
     serialize,
     deserialize,
-    _initialize,
 )
 
 from dask.utils import tmpfile
@@ -510,5 +509,5 @@ def test_config_inheritance():
     os.environ["DASK_INTERNAL_INHERIT_CONFIG"] = serialize(
         {"array": {"svg": {"size": 150}}}
     )
-    _initialize()
+    refresh()
     assert dask.config.get("array.svg.size") == 150

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -22,8 +22,8 @@ from dask.config import (
     refresh,
     expand_environment_variables,
     canonical_name,
-    serialize_for_cli,
-    deserialize_for_cli,
+    serialize,
+    deserialize,
     _initialize,
 )
 
@@ -499,15 +499,15 @@ def test_cli_serialization():
     with dask.config.set({"array.svg.size": dask.config.get("array.svg.size")}):
 
         # Take a round trip through the serialization
-        serialized = serialize_for_cli({"array": {"svg": {"size": 150}}})
-        config = deserialize_for_cli(serialized)
+        serialized = serialize({"array": {"svg": {"size": 150}}})
+        config = deserialize(serialized)
 
         dask.config.update(dask.config.global_config, config)
         assert dask.config.get("array.svg.size") == 150
 
 
 def test_config_inheritance():
-    os.environ["DASK_INTERNAL_INHERIT_CONFIG"] = serialize_for_cli(
+    os.environ["DASK_INTERNAL_INHERIT_CONFIG"] = serialize(
         {"array": {"svg": {"size": 150}}}
     )
     _initialize()

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -494,7 +494,7 @@ def test_get_override_with():
         assert dask.config.get("foo", override_with=["one"]) == ["one"]
 
 
-def test_cli_serialization():
+def test_config_serialization():
     # Use context manager without changing the value to ensure test side effects are restored
     with dask.config.set({"array.svg.size": dask.config.get("array.svg.size")}):
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -213,8 +213,8 @@ This is typically handled by the downstream libraries which use base64 encoding 
 config via the ``DASK_INTERNAL_INHERIT_CONFIG`` environment variable.
 
 .. autosummary::
-   dask.config.serialize_for_cli
-   dask.config.deserialize_for_cli
+   dask.config.serialize
+   dask.config.deserialize
 
 Conversion Utility
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -202,6 +202,20 @@ Note that the ``set`` function treats underscores and hyphens identically.
 For example, ``dask.config.set({'scheduler.work-stealing': True})`` is
 equivalent to ``dask.config.set({'scheduler.work_stealing': True})``.
 
+Distributing configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It may also be desirable to package up your whole Dask configuration for use on
+another machine. This is used in some Dask Distributed libraries to ensure remote components
+have the same configuration as your local system.
+
+This is typically handled by the downstream libraries which use base64 encoding to pass
+config via the ``DASK_INTERNAL_INHERIT_CONFIG`` environment variable.
+
+.. autosummary::
+   dask.config.serialize_for_cli
+   dask.config.deserialize_for_cli
+
 Conversion Utility
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
When running schedulers and workers from the CLI in distributed there is a hidden environment variable which allows you to serialize your config for passing to other components.

This is used in `distributed.SSHCluster` and other downstream cluster managers to pass all config from the system creating the cluster to the scheduler and workers.

Being able to serialize config seems useful beyond the CLI methods, so I'm upstreaming that functionality here.

This PR updates the config initialization with a check for the `DASK_INTERNAL_INHERIT_CONFIG` environment variable. If found the `dask.config.global_config` object is initialized from this serialized config.

Also upstreamed utilities and added tests and docs.

See dask/distributed#4372 for the counterpart PR.

cc @madsbk 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
