### PR TITLE
Bump the minimum time in test_minimum_time

### DIFF
--- a/dask/diagnostics/tests/test_progress.py
+++ b/dask/diagnostics/tests/test_progress.py
@@ -41,7 +41,7 @@ def test_progressbar(capsys):
 
 
 def test_minimum_time(capsys):
-    with ProgressBar(1.0):
+    with ProgressBar(10.0):
         out = get_threaded(dsk, "e")
     out, err = capsys.readouterr()
     assert out == "" and err == ""


### PR DESCRIPTION
Fixes current build failures (e.g., https://github.com/dask/dask/runs/1572156128 ), where presumably it can take more than a second to run the function.