### PR TITLE
Fix io_deps bug in rewrite_blockwise

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1145,7 +1145,6 @@ def _optimize_blockwise(full_graph, keys=()):
 
             # Merge these Blockwise layers into one
             new_layer = rewrite_blockwise([layers[l] for l in blockwise_layers])
-            # io_names |= set(new_layer.io_deps)
             out[layer] = new_layer
 
             new_deps = set()


### PR DESCRIPTION
Addresses [xarray#4703](https://github.com/pydata/xarray/issues/4703) (which is alse described in #6931 )

The current `rewrite_blockwise` code is updating a list of IO-dependencies (`io_deps`) within a loop that can be escaped before all dependencies are collected.  This is causing CI errors in xarray.  This PR moves the `io_deps` update to a simple/dedicated loop over all input layers.

**TODO**:
- [ ] come up with a test
