### PR TITLE
Add numpy functions tri, triu_indices, triu_indices_from, tril_indices, tril_indices_from

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -82,6 +82,8 @@ try:
         fliplr,
         einsum,
         average,
+        triu,
+        tril,
     )
     from .reshape import reshape
     from .ufunc import (
@@ -231,8 +233,6 @@ try:
         diag,
         eye,
         tri,
-        triu,
-        tril,
         fromfunction,
         tile,
         repeat,

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -84,6 +84,10 @@ try:
         average,
         triu,
         tril,
+        tril_indices,
+        tril_indices_from,
+        triu_indices,
+        triu_indices_from,
     )
     from .reshape import reshape
     from .ufunc import (

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -230,6 +230,7 @@ try:
         indices,
         diag,
         eye,
+        tri,
         triu,
         tril,
         fromfunction,

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -28,6 +28,7 @@ from .ufunc import rint
 from .wrap import empty, ones, zeros, full
 from .utils import AxisError, meta_from_array, zeros_like_safe
 
+
 def empty_like(a, dtype=None, order="C", chunks=None, name=None, shape=None):
     """
     Return a new array with the same shape and type as a given array.

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -655,7 +655,7 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
 
 
 @derived_from(np)
-def tri(N, chunks="auto", M=None, k=0, dtype=float):
+def tri(N, M=None, k=0, dtype=float, chunks="auto"):
     if M is None:
         M = N
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -656,6 +656,8 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
 
 @derived_from(np)
 def tri(N, M=None, k=0, dtype=float, chunks="auto"):
+    _min_int = np.lib.twodim_base._min_int
+
     if M is None:
         M = N
 
@@ -665,9 +667,9 @@ def tri(N, M=None, k=0, dtype=float, chunks="auto"):
         chunks = normalize_chunks(chunks, shape=(N, M), dtype=dtype)
         chunks = chunks[0][0]
 
-    # TODO: Add numpys _min_int() helper function?
     m = greater_equal.outer(
-        arange(N, chunks=chunks, dtype=int), arange(-k, M - k, chunks=chunks, dtype=int)
+        arange(N, chunks=chunks, dtype=_min_int(0, N)),
+        arange(-k, M - k, chunks=chunks, dtype=_min_int(-k, M - k)),
     )
 
     # Avoid making a copy if the requested type is already bool

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -661,17 +661,11 @@ def tri(N, M=None, k=0, dtype=float, chunks="auto"):
     if M is None:
         M = N
 
-    if not isinstance(chunks, (int, str, Sequence)):
-        raise ValueError("chunks must be an int, string or a sequence of int or string")
-    elif isinstance(chunks, str):
-        chunks = normalize_chunks(chunks, shape=(N, M), dtype=dtype)
-        chunks = (chunks[0][0], chunks[1][0])
-    elif isinstance(chunks, int):
-        chunks = (chunks, chunks)
+    chunks = normalize_chunks(chunks, shape=(N, M), dtype=dtype)
 
     m = greater_equal.outer(
-        arange(N, chunks=chunks[0], dtype=_min_int(0, N)),
-        arange(-k, M - k, chunks=chunks[1], dtype=_min_int(-k, M - k)),
+        arange(N, chunks=chunks[0][0], dtype=_min_int(0, N)),
+        arange(-k, M - k, chunks=chunks[1][0], dtype=_min_int(-k, M - k)),
     )
 
     # Avoid making a copy if the requested type is already bool

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -666,8 +666,9 @@ def tri(N, M=None, k=0, dtype=float, chunks="auto"):
         chunks = chunks[0][0]
 
     # TODO: Add numpys _min_int() helper function?
-    m = greater_equal.outer(arange(N, chunks=chunks, dtype=int),
-                            arange(-k, M-k, chunks=chunks, dtype=int))
+    m = greater_equal.outer(
+        arange(N, chunks=chunks, dtype=int), arange(-k, M - k, chunks=chunks, dtype=int)
+    )
 
     # Avoid making a copy if the requested type is already bool
     m = m.astype(dtype, copy=False)

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -661,15 +661,17 @@ def tri(N, M=None, k=0, dtype=float, chunks="auto"):
     if M is None:
         M = N
 
-    if not isinstance(chunks, (int, str)):
-        raise ValueError("chunks must be an int or string")
+    if not isinstance(chunks, (int, str, Sequence)):
+        raise ValueError("chunks must be an int, string or a sequence of int or string")
     elif isinstance(chunks, str):
         chunks = normalize_chunks(chunks, shape=(N, M), dtype=dtype)
-        chunks = chunks[0][0]
+        chunks = (chunks[0][0], chunks[1][0])
+    elif isinstance(chunks, int):
+        chunks = (chunks, chunks)
 
     m = greater_equal.outer(
-        arange(N, chunks=chunks, dtype=_min_int(0, N)),
-        arange(-k, M - k, chunks=chunks, dtype=_min_int(-k, M - k)),
+        arange(N, chunks=chunks[0], dtype=_min_int(0, N)),
+        arange(-k, M - k, chunks=chunks[1], dtype=_min_int(-k, M - k)),
     )
 
     # Avoid making a copy if the requested type is already bool

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -14,7 +14,6 @@ from . import chunk
 from .core import (
     Array,
     asarray,
-    greater_equal,
     normalize_chunks,
     stack,
     concatenate,
@@ -23,8 +22,7 @@ from .core import (
     broadcast_arrays,
     cached_cumsum,
 )
-from .routines import where
-from .ufunc import rint
+from .ufunc import rint, greater_equal
 from .wrap import empty, ones, zeros, full
 from .utils import AxisError, meta_from_array, zeros_like_safe
 
@@ -675,22 +673,6 @@ def tri(N, chunks="auto", M=None, k=0, dtype=float):
     m = m.astype(dtype, copy=False)
 
     return m
-
-
-@derived_from(np)
-def tril(m, k=0):
-    m = asarray(m)
-    mask = tri(*m.shape[-2:], k=k, dtype=bool)
-
-    return where(mask, m, zeros(1, dtype=m.dtype))
-
-
-@derived_from(np)
-def triu(m, k=0):
-    m = asarray(m)
-    mask = da_tri(*m.shape[-2:], k=k-1, dtype=bool)
-
-    return where(mask, zeros(1, dtype=m.dtype), m)
 
 
 def _np_fromfunction(func, shape, dtype, offset, func_kwargs):

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1610,7 +1610,7 @@ def average(a, axis=None, weights=None, returned=False):
 @derived_from(np)
 def tril(m, k=0):
     m = asarray(m)
-    mask = tri(*m.shape[-2:], k=k, dtype=bool)
+    mask = tri(*m.shape[-2:], k=k, dtype=bool, chunks=m.chunks)
 
     return where(mask, m, zeros(1, dtype=m.dtype))
 
@@ -1618,7 +1618,7 @@ def tril(m, k=0):
 @derived_from(np)
 def triu(m, k=0):
     m = asarray(m)
-    mask = tri(*m.shape[-2:], k=k - 1, dtype=bool)
+    mask = tri(*m.shape[-2:], k=k - 1, dtype=bool, chunks=m.chunks)
 
     return where(mask, zeros(1, dtype=m.dtype), m)
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -17,7 +17,7 @@ from ..delayed import unpack_collections, Delayed
 from ..highlevelgraph import HighLevelGraph
 from ..utils import funcname, derived_from, is_arraylike
 from . import chunk
-from .creation import arange, diag, empty, indices, tri
+from .creation import arange, diag, empty, indices, tri, zeros
 from .utils import safe_wraps, validate_axis, meta_from_array, zeros_like_safe
 from .wrap import ones
 from .ufunc import multiply, sqrt
@@ -1618,6 +1618,6 @@ def tril(m, k=0):
 @derived_from(np)
 def triu(m, k=0):
     m = asarray(m)
-    mask = da_tri(*m.shape[-2:], k=k-1, dtype=bool)
+    mask = tri(*m.shape[-2:], k=k-1, dtype=bool)
 
     return where(mask, zeros(1, dtype=m.dtype), m)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -17,7 +17,7 @@ from ..delayed import unpack_collections, Delayed
 from ..highlevelgraph import HighLevelGraph
 from ..utils import funcname, derived_from, is_arraylike
 from . import chunk
-from .creation import arange, diag, empty, indices
+from .creation import arange, diag, empty, indices, tri
 from .utils import safe_wraps, validate_axis, meta_from_array, zeros_like_safe
 from .wrap import ones
 from .ufunc import multiply, sqrt
@@ -1605,3 +1605,19 @@ def _average(a, axis=None, weights=None, returned=False, is_masked=False):
 @derived_from(np)
 def average(a, axis=None, weights=None, returned=False):
     return _average(a, axis, weights, returned, is_masked=False)
+
+
+@derived_from(np)
+def tril(m, k=0):
+    m = asarray(m)
+    mask = tri(*m.shape[-2:], k=k, dtype=bool)
+
+    return where(mask, m, zeros(1, dtype=m.dtype))
+
+
+@derived_from(np)
+def triu(m, k=0):
+    m = asarray(m)
+    mask = da_tri(*m.shape[-2:], k=k-1, dtype=bool)
+
+    return where(mask, zeros(1, dtype=m.dtype), m)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1618,6 +1618,6 @@ def tril(m, k=0):
 @derived_from(np)
 def triu(m, k=0):
     m = asarray(m)
-    mask = tri(*m.shape[-2:], k=k-1, dtype=bool)
+    mask = tri(*m.shape[-2:], k=k - 1, dtype=bool)
 
     return where(mask, zeros(1, dtype=m.dtype), m)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1621,3 +1621,27 @@ def triu(m, k=0):
     mask = tri(*m.shape[-2:], k=k - 1, dtype=bool)
 
     return where(mask, zeros(1, dtype=m.dtype), m)
+
+
+@derived_from(np)
+def tril_indices(n, k=0, m=None, chunks="auto"):
+    return nonzero(tri(n, m, k=k, dtype=bool, chunks=chunks))
+
+
+@derived_from(np)
+def tril_indices_from(arr, k=0):
+    if arr.ndim != 2:
+        raise ValueError("input array must be 2-d")
+    return tril_indices(arr.shape[-2], k=k, m=arr.shape[-1])
+
+
+@derived_from(np)
+def triu_indices(n, k=0, m=None, chunks="auto"):
+    return nonzero(~tri(n, m, k=k - 1, dtype=bool))
+
+
+@derived_from(np)
+def triu_indices_from(arr, k=0):
+    if arr.ndim != 2:
+        raise ValueError("input array must be 2-d")
+    return triu_indices(arr.shape[-2], k=k, m=arr.shape[-1])

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1632,16 +1632,16 @@ def tril_indices(n, k=0, m=None, chunks="auto"):
 def tril_indices_from(arr, k=0):
     if arr.ndim != 2:
         raise ValueError("input array must be 2-d")
-    return tril_indices(arr.shape[-2], k=k, m=arr.shape[-1])
+    return tril_indices(arr.shape[-2], k=k, m=arr.shape[-1], chunks=arr.chunks)
 
 
 @derived_from(np)
 def triu_indices(n, k=0, m=None, chunks="auto"):
-    return nonzero(~tri(n, m, k=k - 1, dtype=bool))
+    return nonzero(~tri(n, m, k=k - 1, dtype=bool, chunks=chunks))
 
 
 @derived_from(np)
 def triu_indices_from(arr, k=0):
     if arr.ndim != 2:
         raise ValueError("input array must be 2-d")
-    return triu_indices(arr.shape[-2], k=k, m=arr.shape[-1])
+    return triu_indices(arr.shape[-2], k=k, m=arr.shape[-1], chunks=arr.chunks)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1610,7 +1610,7 @@ def average(a, axis=None, weights=None, returned=False):
 @derived_from(np)
 def tril(m, k=0):
     m = asarray(m)
-    mask = tri(*m.shape[-2:], k=k, dtype=bool, chunks=m.chunks)
+    mask = tri(*m.shape[-2:], k=k, dtype=bool, chunks=m.chunks[-2:])
 
     return where(mask, m, zeros(1, dtype=m.dtype))
 
@@ -1618,7 +1618,7 @@ def tril(m, k=0):
 @derived_from(np)
 def triu(m, k=0):
     m = asarray(m)
-    mask = tri(*m.shape[-2:], k=k - 1, dtype=bool, chunks=m.chunks)
+    mask = tri(*m.shape[-2:], k=k - 1, dtype=bool, chunks=m.chunks[-2:])
 
     return where(mask, zeros(1, dtype=m.dtype), m)
 

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -376,7 +376,7 @@ def test_meshgrid_inputcoercion():
         (3, None, 2, int, 1),
         (6, 8, -2, int, (3, 4)),
         (6, 8, 0, int, (3, "auto")),
-    ]
+    ],
 )
 def test_tri(N, M, k, dtype, chunks):
     assert_eq(da.tri(N, M, k, dtype, chunks), np.tri(N, M, k, dtype))
@@ -775,10 +775,7 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
                 reason="Bug when pad_width is larger than dimension: https://github.com/dask/dask/issues/5303"
             ),
         ),
-        pytest.param(
-            "median",
-            marks=pytest.mark.skip(reason="Not implemented"),
-        ),
+        pytest.param("median", marks=pytest.mark.skip(reason="Not implemented"),),
         pytest.param(
             "empty",
             marks=pytest.mark.skip(

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -775,7 +775,10 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
                 reason="Bug when pad_width is larger than dimension: https://github.com/dask/dask/issues/5303"
             ),
         ),
-        pytest.param("median", marks=pytest.mark.skip(reason="Not implemented"),),
+        pytest.param(
+            "median", 
+            marks=pytest.mark.skip(reason="Not implemented"),
+        ),
         pytest.param(
             "empty",
             marks=pytest.mark.skip(

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -369,55 +369,6 @@ def test_tri():
     assert_eq(da.tri(3), np.tri(3))
 
 
-def test_tril_triu():
-    A = np.random.randn(20, 20)
-    for chk in [5, 4]:
-        dA = da.from_array(A, (chk, chk))
-
-        assert np.allclose(da.triu(dA).compute(), np.triu(A))
-        assert np.allclose(da.tril(dA).compute(), np.tril(A))
-
-        for k in [
-            -25,
-            -20,
-            -19,
-            -15,
-            -14,
-            -9,
-            -8,
-            -6,
-            -5,
-            -1,
-            1,
-            4,
-            5,
-            6,
-            8,
-            10,
-            11,
-            15,
-            16,
-            19,
-            20,
-            21,
-        ]:
-            assert np.allclose(da.triu(dA, k).compute(), np.triu(A, k))
-            assert np.allclose(da.tril(dA, k).compute(), np.tril(A, k))
-
-
-def test_tril_ndims():
-    A = np.random.randint(0, 11, (10, 10, 10))
-    dA = da.from_array(A, chunks=(5, 5, 5))
-    assert_eq(da.triu(dA), np.triu(A))
-
-
-def test_tril_triu_non_square_arrays():
-    A = np.random.randint(0, 11, (30, 35))
-    dA = da.from_array(A, chunks=(5, 5))
-    assert_eq(da.triu(dA), np.triu(A))
-    assert_eq(da.tril(dA), np.tril(A))
-
-
 def test_eye():
     assert_eq(da.eye(9, chunks=3), np.eye(9))
     assert_eq(da.eye(9), np.eye(9))

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -365,8 +365,21 @@ def test_meshgrid_inputcoercion():
     assert_eq(z, z_d)
 
 
-def test_tri():
-    assert_eq(da.tri(3), np.tri(3))
+@pytest.mark.parametrize(
+    "N, M, k, dtype, chunks",
+    [
+        (3, None, 0, float, "auto"),
+        (4, None, 0, float, "auto"),
+        (3, 4, 0, bool, "auto"),
+        (3, None, 1, int, "auto"),
+        (3, None, -1, int, "auto"),
+        (3, None, 2, int, 1),
+        (6, 8, -2, int, (3, 4)),
+        (6, 8, 0, int, (3, "auto")),
+    ]
+)
+def test_tri(N, M, k, dtype, chunks):
+    assert_eq(da.tri(N, M, k, dtype, chunks), np.tri(N, M, k, dtype))
 
 
 def test_eye():

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -776,7 +776,7 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
             ),
         ),
         pytest.param(
-            "median", 
+            "median",
             marks=pytest.mark.skip(reason="Not implemented"),
         ),
         pytest.param(

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -405,10 +405,10 @@ def test_tril_triu():
             assert np.allclose(da.tril(dA, k).compute(), np.tril(A, k))
 
 
-def test_tril_triu_errors():
+def test_tril_ndims():
     A = np.random.randint(0, 11, (10, 10, 10))
     dA = da.from_array(A, chunks=(5, 5, 5))
-    pytest.raises(ValueError, lambda: da.triu(dA))
+    assert_eq(da.triu(dA), np.triu(A))
 
 
 def test_tril_triu_non_square_arrays():

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -365,6 +365,10 @@ def test_meshgrid_inputcoercion():
     assert_eq(z, z_d)
 
 
+def test_tri():
+    assert_eq(da.tri(3), np.tri(3))
+
+    
 def test_tril_triu():
     A = np.random.randn(20, 20)
     for chk in [5, 4]:

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -368,7 +368,7 @@ def test_meshgrid_inputcoercion():
 def test_tri():
     assert_eq(da.tri(3), np.tri(3))
 
-    
+
 def test_tril_triu():
     A = np.random.randn(20, 20)
     for chk in [5, 4]:

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1863,3 +1863,64 @@ def test_iscomplexobj():
 
     a = da.from_array(np.array([1, 2 + 0j]), 2)
     assert np.iscomplexobj(a) is True
+
+
+def test_tril_triu():
+    A = np.random.randn(20, 20)
+    for chk in [5, 4]:
+        dA = da.from_array(A, (chk, chk))
+
+        assert np.allclose(da.triu(dA).compute(), np.triu(A))
+        assert np.allclose(da.tril(dA).compute(), np.tril(A))
+
+        for k in [
+            -25,
+            -20,
+            -19,
+            -15,
+            -14,
+            -9,
+            -8,
+            -6,
+            -5,
+            -1,
+            1,
+            4,
+            5,
+            6,
+            8,
+            10,
+            11,
+            15,
+            16,
+            19,
+            20,
+            21,
+        ]:
+            assert np.allclose(da.triu(dA, k).compute(), np.triu(A, k))
+            assert np.allclose(da.tril(dA, k).compute(), np.tril(A, k))
+
+
+def test_tril_ndims():
+    A = np.random.randint(0, 11, (10, 10, 10))
+    dA = da.from_array(A, chunks=(5, 5, 5))
+    assert_eq(da.triu(dA), np.triu(A))
+
+
+def test_tril_triu_non_square_arrays():
+    A = np.random.randint(0, 11, (30, 35))
+    dA = da.from_array(A, chunks=(5, 5))
+    assert_eq(da.triu(dA), np.triu(A))
+    assert_eq(da.tril(dA), np.tril(A))
+
+
+@pytest.mark.parametrize("n", [3, 3, 3, 4])
+@pytest.mark.parametrize("k", [0, 1, -1, 0])
+@pytest.mark.parametrize("m", [3, 3, 3, 5])
+def test_tril_triu_indices(n, k, m):
+    assert_eq(
+        da.tril_indices(n=n, k=k, m=m)[0].compute(), np.tril_indices(n=n, k=k, m=m)[0]
+    )
+    assert_eq(
+        da.triu_indices(n=n, k=k, m=m)[0].compute(), np.triu_indices(n=n, k=k, m=m)[0]
+    )

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1914,13 +1914,16 @@ def test_tril_triu_non_square_arrays():
     assert_eq(da.tril(dA), np.tril(A))
 
 
-@pytest.mark.parametrize("n", [3, 3, 3, 4])
-@pytest.mark.parametrize("k", [0, 1, -1, 0])
-@pytest.mark.parametrize("m", [3, 3, 3, 5])
-def test_tril_triu_indices(n, k, m):
+@pytest.mark.parametrize(
+    "n, k, m, chunks",
+    [(3, 0, 3, "auto"), (3, 1, 3, "auto"), (3, -1, 3, "auto"), (5, 0, 5, 1)],
+)
+def test_tril_triu_indices(n, k, m, chunks):
     assert_eq(
-        da.tril_indices(n=n, k=k, m=m)[0].compute(), np.tril_indices(n=n, k=k, m=m)[0]
+        da.tril_indices(n=n, k=k, m=m, chunks=chunks)[0].compute(),
+        np.tril_indices(n=n, k=k, m=m)[0],
     )
     assert_eq(
-        da.triu_indices(n=n, k=k, m=m)[0].compute(), np.triu_indices(n=n, k=k, m=m)[0]
+        da.triu_indices(n=n, k=k, m=m, chunks=chunks)[0].compute(),
+        np.triu_indices(n=n, k=k, m=m)[0],
     )


### PR DESCRIPTION
Add the numpy functions `tri`, `triu_indices`, `triu_indices_from`, `tril_indices`, `tril_indices_from`.

Closes some of #2911. 
- [ x] Tests added / passed
- [ x] Passes `black dask` / `flake8 dask`

`da.triu` and `da.tril` got simplified as well and looks very similar to the numpy version now. It was just an old implementation, right? Or was there a clever reason for all the loops?
Chunking in `da.triu` and `da.tril` is a bit different now because because they use `da.tri` which uses `da.greater_equal.outer`, not sure if this is better. Would love some thoughts on that.

I had to move around a few functions as well to avoid circular dependencies. 

