### PR TITLE
DOC: Misc formatting.

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -407,7 +407,7 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
 
     In contrast, methods are assumed to be impure by default, meaning that
     subsequent calls may return different results. To assume purity, set
-    `pure=True`. This allows sharing of any intermediate values.
+    ``pure=True``. This allows sharing of any intermediate values.
 
     >>> a.count(2, pure=True).key == a.count(2, pure=True).key
     True

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -194,7 +194,9 @@ class IndexCallable(object):
 def filetexts(d, open=open, mode="t", use_tmpdir=True):
     """Dumps a number of textfiles to disk
 
-    d - dict
+    Parameters
+    ----------
+    d : dict
         a mapping from filename to text like {'a.csv': '1,1\n2,2'}
 
     Since this is meant for use in tests, this context manager will


### PR DESCRIPTION
 - single backtick arround pure=True is incorrect as single backticks
 are for references.
 - Invalid numpydoc formatting use appropriate one and section name for
 numpydoc to understand the types.