### PR TITLE
Temporarily pin sphinx version to 3.3.1

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,5 +1,7 @@
 numpydoc
-sphinx
+# TODO: Remove sphinx pinning once sphinx==3.4.1 is released
+# See https://github.com/dask/dask/issues/7001
+sphinx==3.3.1
 dask-sphinx-theme>=1.3.5
 sphinx-click
 toolz


### PR DESCRIPTION
Related https://github.com/sphinx-doc/sphinx/issues/8568 (#7001). When 3.4.1 is out, we can revert this commit.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
