### PR TITLE
Revert: temporarly pin sphinx version to 3.3.1 (#7002)

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,7 +1,5 @@
 numpydoc
-# TODO: Remove sphinx pinning once sphinx==3.4.1 is released
-# See https://github.com/dask/dask/issues/7001
-sphinx==3.3.1
+sphinx
 dask-sphinx-theme>=1.3.5
 sphinx-click
 toolz


### PR DESCRIPTION
This reverts commit 4a7a2438219c4ee493434042e50f4cdb67b6ec9f.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Fixes #7001