### PR TITLE
Keep normal optimizations when adding custom optimizations

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -314,13 +314,13 @@ def optimization_function(x):
     return getattr(x, "__dask_optimize__", dont_optimize)
 
 
-def collections_to_dsk(collections, optimize_graph=True, optimizations=[], **kwargs):
+def collections_to_dsk(collections, optimize_graph=True, optimizations=(), **kwargs):
     """
     Convert many collections into a single dask graph, after optimization
     """
     from .highlevelgraph import HighLevelGraph
 
-    optimizations = optimizations + config.get("optimizations", [])
+    optimizations = tuple(optimizations) + tuple(config.get("optimizations", ()))
 
     if optimize_graph:
         groups = groupby(optimization_function, collections)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -24,6 +24,7 @@ from dask.base import (
     unpack_collections,
     named_schedulers,
     get_scheduler,
+    collections_to_dsk,
 )
 from dask.core import literal
 from dask.delayed import Delayed
@@ -1077,3 +1078,13 @@ def test_num_workers_config(scheduler):
     workers = {i.worker_id for i in prof.results}
 
     assert len(workers) == num_workers
+
+
+def test_optimizations_ctd():
+    da = pytest.importorskip("dask.array")
+    x = da.arange(2, chunks=1)[:1]
+    dsk1 = collections_to_dsk([x])
+    with dask.config.set({"optimizations": [lambda dsk, keys: dsk]}):
+        dsk2 = collections_to_dsk([x])
+
+    assert dsk1 == dsk2


### PR DESCRIPTION
Previously we would forget the results of normal optimizations when
custom optimizations were added.  Now we include the new optimizations
in the normal pipeline and apply them on top of the normal results.

This also has the effect of simplifying code slightly.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
