### PR TITLE
Add index to meta after .str.split with expand

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -129,6 +129,7 @@ class StringAccessor(Accessor):
                 delimiter = " " if pat is None else pat
                 meta = type(self._series._meta)([delimiter.join(["a"] * (n + 1))])
                 meta = meta.str.split(n=n, expand=expand, pat=pat)
+                meta = meta.drop(0).set_index(self._series._meta.index)
         else:
             meta = (self._series.name, object)
         return self._function_map("split", pat=pat, n=n, expand=expand, meta=meta)

--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -129,7 +129,7 @@ class StringAccessor(Accessor):
                 delimiter = " " if pat is None else pat
                 meta = type(self._series._meta)([delimiter.join(["a"] * (n + 1))])
                 meta = meta.str.split(n=n, expand=expand, pat=pat)
-                meta = meta.drop(0).set_index(self._series._meta.index)
+                meta = meta.iloc[:0].set_index(self._series._meta.index)
         else:
             meta = (self._series.name, object)
         return self._function_map("split", pat=pat, n=n, expand=expand, meta=meta)

--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -127,9 +127,11 @@ class StringAccessor(Accessor):
                 )
             else:
                 delimiter = " " if pat is None else pat
-                meta = type(self._series._meta)([delimiter.join(["a"] * (n + 1))])
+                meta = self._series._meta._constructor(
+                    [delimiter.join(["a"] * (n + 1))],
+                    index=self._series._meta_nonempty[:1].index,
+                )
                 meta = meta.str.split(n=n, expand=expand, pat=pat)
-                meta = meta.iloc[:0].set_index(self._series._meta.index)
         else:
             meta = (self._series.name, object)
         return self._function_map("split", pat=pat, n=n, expand=expand, meta=meta)

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -236,7 +236,6 @@ def test_str_accessor_expand():
     s = pd.Series(
         ["a b c d", "aa bb cc dd", "aaa bbb ccc dddd"], index=["row1", "row2", "row3"]
     )
-    # s = pd.Series(["a b c d", "aa bb cc dd", "aaa bbb ccc dddd"])
     ds = dd.from_pandas(s, npartitions=2)
 
     for n in [1, 2, 3]:

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -233,7 +233,10 @@ def test_str_accessor_noexpand():
 
 
 def test_str_accessor_expand():
-    s = pd.Series(["a b c d", "aa bb cc dd", "aaa bbb ccc dddd"])
+    s = pd.Series(
+        ["a b c d", "aa bb cc dd", "aaa bbb ccc dddd"], index=["row1", "row2", "row3"]
+    )
+    # s = pd.Series(["a b c d", "aa bb cc dd", "aaa bbb ccc dddd"])
     ds = dd.from_pandas(s, npartitions=2)
 
     for n in [1, 2, 3]:


### PR DESCRIPTION
This PR proposes a fix for https://github.com/dask/dask/issues/7021. 

Without the proposed fix, `dask/dataframe/tests/test_accessors.py::test_str_accessor_expand` fails if the index is of any other type than `int`. 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
