### PR TITLE
Temporarily pin python-graphviz in CI

### DIFF
--- a/continuous_integration/environment-3.6.yaml
+++ b/continuous_integration/environment-3.6.yaml
@@ -51,7 +51,10 @@ dependencies:
   - python-snappy
   - sparse
   - cachey
-  - python-graphviz
+  # TODO: python-graphviz 0.16 is broken on windows so we're pinning to
+  # 0.15 as a temporary workaround. Remove pinning once
+  # https://github.com/conda-forge/python-graphviz-feedstock/issues/42 is resolved
+  - python-graphviz=0.15
   - pandas-datareader
   - python-xxhash
   - mmh3

--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -51,7 +51,10 @@ dependencies:
   - python-snappy
   - sparse
   - cachey
-  - python-graphviz
+  # TODO: python-graphviz 0.16 is broken on windows so we're pinning to
+  # 0.15 as a temporary workaround. Remove pinning once
+  # https://github.com/conda-forge/python-graphviz-feedstock/issues/42 is resolved
+  - python-graphviz=0.15
   - pandas-datareader
   - python-xxhash
   - mmh3

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -49,7 +49,10 @@ dependencies:
   - toolz
   - python-snappy
   - cachey
-  - python-graphviz
+  # TODO: python-graphviz 0.16 is broken on windows so we're pinning to
+  # 0.15 as a temporary workaround. Remove pinning once
+  # https://github.com/conda-forge/python-graphviz-feedstock/issues/42 is resolved
+  - python-graphviz=0.15
   - python-xxhash
   - mmh3
   - pip

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -50,7 +50,10 @@ dependencies:
   - python-snappy
   - sparse
   - cachey
-  - python-graphviz
+  # TODO: python-graphviz 0.16 is broken on windows so we're pinning to
+  # 0.15 as a temporary workaround. Remove pinning once
+  # https://github.com/conda-forge/python-graphviz-feedstock/issues/42 is resolved
+  - python-graphviz=0.15
   - pandas-datareader
   - python-xxhash
   - mmh3


### PR DESCRIPTION
`python-graphviz` 0.16 has an issue on Windows (xref https://github.com/conda-forge/python-graphviz-feedstock/issues/42) which is causing CI failures (xref https://github.com/dask/dask/pull/7027/checks?check_run_id=1646431295). This PR pins `python-graphviz` to 0.15 as a temporary workaround. 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
