### PR TITLE
Revert Keep normal optimizations when adding custom optimizations 

### DIFF
--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -24,7 +24,6 @@ from dask.base import (
     unpack_collections,
     named_schedulers,
     get_scheduler,
-    collections_to_dsk,
 )
 from dask.core import literal
 from dask.delayed import Delayed
@@ -1078,13 +1077,3 @@ def test_num_workers_config(scheduler):
     workers = {i.worker_id for i in prof.results}
 
     assert len(workers) == num_workers
-
-
-def test_optimizations_ctd():
-    da = pytest.importorskip("dask.array")
-    x = da.arange(2, chunks=1)[:1]
-    dsk1 = collections_to_dsk([x])
-    with dask.config.set({"optimizations": [lambda dsk, keys: dsk]}):
-        dsk2 = collections_to_dsk([x])
-
-    assert dsk1 == dsk2


### PR DESCRIPTION
This reverts #7016. It appears this PR has caused CI failures in distributed (dask/distributed#4404).

I propose we revert this PR, for now, to unblock distributed CI and investigate separately.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
