### PR TITLE
Add some cross-references to DataFrame.to_bag() and Series.to_bag()

### DIFF
--- a/docs/source/bag-api.rst
+++ b/docs/source/bag-api.rst
@@ -52,6 +52,8 @@ Create Bags
    from_url
    read_avro
    range
+   dask.dataframe.DataFrame.to_bag
+   dask.dataframe.Series.to_bag
 
 Top-level functions
 -------------------

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -366,7 +366,6 @@ Store DataFrames
    to_hdf
    to_records
    to_sql
-   to_bag
    to_json
 
 Convert DataFrames
@@ -374,6 +373,7 @@ Convert DataFrames
 
 .. autosummary::
 
+   DataFrame.to_bag
    DataFrame.to_dask_array
    DataFrame.to_delayed
 


### PR DESCRIPTION
This PR adds some references to the DataFrame.to_bag() and Series.to_bag() methods in appropriate sections in the dataframe and bag API docs. If they'd been there before, it would have saved me some time and an embarrassing feature request! Hopefully this will make them a bit more discoverable for the next person.

(This replaces a PR that I recently submitted from the wrong branch. Sorry!)

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
