### PR TITLE
Skip empty partitions when doing groupby.value_counts

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1960,7 +1960,7 @@ def _value_counts(x, **kwargs):
     if len(x):
         return M.value_counts(x, **kwargs)
     else:
-        return pd.Series()
+        return pd.Series(dtype=int)
 
 
 def _value_counts_aggregate(series_gb):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1931,7 +1931,7 @@ class SeriesGroupBy(_GroupBy):
     def value_counts(self, split_every=None, split_out=1):
         return self._aca_agg(
             token="value_counts",
-            func=M.value_counts,
+            func=_value_counts,
             aggfunc=_value_counts_aggregate,
             split_every=split_every,
             split_out=split_out,
@@ -1954,6 +1954,13 @@ def _unique_aggregate(series_gb, name=None):
     ret = pd.Series({k: v.explode().unique() for k, v in series_gb}, name=name)
     ret.index.names = series_gb.obj.index.names
     return ret
+
+
+def _value_counts(x, **kwargs):
+    if len(x):
+        return M.value_counts(x, **kwargs)
+    else:
+        return pd.Series()
 
 
 def _value_counts_aggregate(series_gb):

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2475,3 +2475,26 @@ def test_groupby_aggregate_categorical_observed(
         agg(pdf.groupby(groupby, observed=observed)),
         agg(ddf.groupby(groupby, observed=observed)),
     )
+
+
+def test_empty_partitions_with_value_counts():
+    # https://github.com/dask/dask/issues/7065
+    df = pd.DataFrame(
+        data=[
+            ["a1", "b1"],
+            ["a1", None],
+            ["a1", "b1"],
+            [None, None],
+            [None, None],
+            [None, None],
+            ["a3", "b3"],
+            ["a3", "b3"],
+            ["a5", "b5"],
+        ],
+        columns=["A", "B"],
+    )
+
+    expected = df.groupby("A")["B"].value_counts()
+    ddf = dd.from_pandas(df, npartitions=3)
+    actual = ddf.groupby("A")["B"].value_counts().compute()
+    assert_eq(expected, actual)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2496,5 +2496,5 @@ def test_empty_partitions_with_value_counts():
 
     expected = df.groupby("A")["B"].value_counts()
     ddf = dd.from_pandas(df, npartitions=3)
-    actual = ddf.groupby("A")["B"].value_counts().compute()
+    actual = ddf.groupby("A")["B"].value_counts()
     assert_eq(expected, actual)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
- [x] Closes #7065 
