### PR TITLE
add error messages to assert_eq()

### DIFF
--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -277,32 +277,43 @@ def assert_eq(a, b, check_shape=True, check_graph=True, check_meta=True, **kwarg
             if hasattr(a, "_meta") and hasattr(b, "_meta"):
                 assert_eq(a._meta, b._meta)
             if hasattr(a_original, "_meta"):
-                assert (
-                    a_original._meta.ndim == a.ndim
-                ), f"compute()-ing 'a' changes its number of dimensions (before: {a_original._meta.ndim}, after: {a.ndim})"
+                msg = (
+                    f"compute()-ing 'a' changes its number of dimensions "
+                    f"(before: {a_original._meta.ndim}, after: {a.ndim})"
+                )
+                assert a_original._meta.ndim == a.ndim, msg
                 if a_meta is not None:
-                    assert type(a_original._meta) == type(
-                        a_meta
-                    ), f"compute()-ing 'a' changes its type (before: {type(a_original._meta)}, after: {type(a_meta)})"
+                    msg = (
+                        f"compute()-ing 'a' changes its type "
+                        f"(before: {type(a_original._meta)}, after: {type(a_meta)})"
+                    )
+                    assert type(a_original._meta) == type(a_meta), msg
                     if not (np.isscalar(a_meta) or np.isscalar(a_computed)):
-                        assert type(a_meta) == type(
-                            a_computed
-                        ), f"compute()-ing 'a' results in a different type than implied by its metadata (meta: {type(b_meta)}, computed: {type(b_computed)})"
+                        msg = (
+                            f"compute()-ing 'a' results in a different type than implied by its metadata "
+                            f"(meta: {type(b_meta)}, computed: {type(b_computed)})"
+                        )
+                        assert type(a_meta) == type(a_computed), msg
             if hasattr(b_original, "_meta"):
-                assert (
-                    b_original._meta.ndim == b.ndim
-                ), f"compute()-ing 'b' changes its number of dimensions (before: {b_original._meta.ndim}, after: {b.ndim})"
+                msg = (
+                    f"compute()-ing 'b' changes its number of dimensions "
+                    f"(before: {b_original._meta.ndim}, after: {b.ndim})"
+                )
+                assert b_original._meta.ndim == b.ndim, msg
                 if b_meta is not None:
-                    assert type(b_original._meta) == type(
-                        b_meta
-                    ), f"compute()-ing 'b' changes its type (before: {type(a_original._meta)}, after: {type(a_meta)})"
+                    msg = (
+                        f"compute()-ing 'b' changes its type "
+                        f"(before: {type(a_original._meta)}, after: {type(a_meta)})"
+                    )
+                    assert type(b_original._meta) == type(b_meta), msg
                     if not (np.isscalar(b_meta) or np.isscalar(b_computed)):
-                        assert type(b_meta) == type(
-                            b_computed
-                        ), f"compute()-ing 'b' results in a different type than implied by its metadata (meta: {type(b_meta)}, computed: {type(b_computed)})"
-        assert allclose(
-            a, b, **kwargs
-        ), "found values in 'a' and 'b'' which differ by more than the allowed amount"
+                        msg = (
+                            f"compute()-ing 'b' results in a different type than implied by its metadata "
+                            f"(meta: {type(b_meta)}, computed: {type(b_computed)})"
+                        )
+                        assert type(b_meta) == type(b_computed), msg
+        msg = "found values in 'a' and 'b' which differ by more than the allowed amount"
+        assert allclose(a, b, **kwargs), msg
         return True
     except TypeError:
         pass

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -270,23 +270,39 @@ def assert_eq(a, b, check_shape=True, check_graph=True, check_meta=True, **kwarg
             )
 
     try:
-        assert a.shape == b.shape
+        assert (
+            a.shape == b.shape
+        ), f"a and b have different shapes (a: {a.shape}, b: {b.shape})"
         if check_meta:
             if hasattr(a, "_meta") and hasattr(b, "_meta"):
                 assert_eq(a._meta, b._meta)
             if hasattr(a_original, "_meta"):
-                assert a_original._meta.ndim == a.ndim
+                assert (
+                    a_original._meta.ndim == a.ndim
+                ), f"compute()-ing 'a' changes its number of dimensions (before: {a_original._meta.ndim}, after: {a.ndim})"
                 if a_meta is not None:
-                    assert type(a_original._meta) == type(a_meta)
+                    assert type(a_original._meta) == type(
+                        a_meta
+                    ), f"compute()-ing 'a' changes its type (before: {type(a_original._meta)}, after: {type(a_meta)})"
                     if not (np.isscalar(a_meta) or np.isscalar(a_computed)):
-                        assert type(a_meta) == type(a_computed)
+                        assert type(a_meta) == type(
+                            a_computed
+                        ), f"compute()-ing 'a' results in a different type than implied by its metadata (meta: {type(b_meta)}, computed: {type(b_computed)})"
             if hasattr(b_original, "_meta"):
-                assert b_original._meta.ndim == b.ndim
+                assert (
+                    b_original._meta.ndim == b.ndim
+                ), f"compute()-ing 'b' changes its number of dimensions (before: {b_original._meta.ndim}, after: {b.ndim})"
                 if b_meta is not None:
-                    assert type(b_original._meta) == type(b_meta)
+                    assert type(b_original._meta) == type(
+                        b_meta
+                    ), f"compute()-ing 'b' changes its type (before: {type(a_original._meta)}, after: {type(a_meta)})"
                     if not (np.isscalar(b_meta) or np.isscalar(b_computed)):
-                        assert type(b_meta) == type(b_computed)
-        assert allclose(a, b, **kwargs)
+                        assert type(b_meta) == type(
+                            b_computed
+                        ), f"compute()-ing 'b' results in a different type than implied by its metadata (meta: {type(b_meta)}, computed: {type(b_computed)})"
+        assert allclose(
+            a, b, **kwargs
+        ), "found values in 'a' and 'b'' which differ by more than the allowed amount"
         return True
     except TypeError:
         pass

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -291,7 +291,7 @@ def assert_eq(a, b, check_shape=True, check_graph=True, check_meta=True, **kwarg
                     if not (np.isscalar(a_meta) or np.isscalar(a_computed)):
                         msg = (
                             f"compute()-ing 'a' results in a different type than implied by its metadata "
-                            f"(meta: {type(b_meta)}, computed: {type(b_computed)})"
+                            f"(meta: {type(a_meta)}, computed: {type(a_computed)})"
                         )
                         assert type(a_meta) == type(a_computed), msg
             if hasattr(b_original, "_meta"):
@@ -303,7 +303,7 @@ def assert_eq(a, b, check_shape=True, check_graph=True, check_meta=True, **kwarg
                 if b_meta is not None:
                     msg = (
                         f"compute()-ing 'b' changes its type "
-                        f"(before: {type(a_original._meta)}, after: {type(a_meta)})"
+                        f"(before: {type(b_original._meta)}, after: {type(b_meta)})"
                     )
                     assert type(b_original._meta) == type(b_meta), msg
                     if not (np.isscalar(b_meta) or np.isscalar(b_computed)):


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

## Changes in this PR

This PR proposes adding more informative error messages in `dask.array.utils.assert_eq()`.

## How this improves `dask`

We make heavy use of `assert_eq()` in [LightGBM's Dask tests](https://github.com/microsoft/LightGBM/blob/8593f8503cb004fe120ee53420bd272bde001f55/tests/python_package_test/test_dask.py). I've had the following experience a few times:

1. make changes
2. run `pytest`
3. tests fail. To figure out how they failed, scroll up to find the `assert_eq()` information dumped into the console, then try to understand the line in the code that's pointed to.

![image](https://user-images.githubusercontent.com/7608904/104993739-e4bfec80-59e8-11eb-808c-a2c75324fb01.png)

As of this PR, `assert_eq()` would raise an `AssertionError` with enough information to understand **how** the inputs `a` and `b` differ. For example:

![image](https://user-images.githubusercontent.com/7608904/104994108-8e9f7900-59e9-11eb-8391-46cad97745c0.png)

> AssertionError: a and b have different shapes (a: (100,), b: (100, 2))

## Notes for Reviewers

I wasn't sure where it would be appropriate to add tests on these changes. `tests/test_array_utils.py` doesn't currently contain tests on `assert_eq()` directly. If you're open to the change proposed in this PR, please let me know if you'd like me to add some tests on the specific messages as well.

Thanks for your time and consideration.