### PR TITLE
Add support for NumPy 1.20.0

### DIFF
--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -204,6 +204,7 @@ def getmaskarray(a):
 
 
 def _masked_array(data, mask=np.ma.nomask, **kwargs):
+    kwargs.pop("chunks", None)  # A Dask kwarg, not NumPy.
     dtype = kwargs.pop("masked_dtype", None)
     return np.ma.masked_array(data, mask=mask, dtype=dtype, **kwargs)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1577,7 +1577,7 @@ def test_slicing_flexible_type():
 
 def test_slicing_with_object_dtype():
     # https://github.com/dask/dask/issues/6892
-    d = da.from_array(np.array(["a", "b"], dtype=np.object), chunks=(1,))
+    d = da.from_array(np.array(["a", "b"], dtype=object), chunks=(1,))
     assert d.dtype == d[(0,)].dtype
 
 

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -542,7 +542,7 @@ def test_array_cumreduction_axis(func, use_nan, axis, method):
     da_func = getattr(da, func)
 
     s = (10, 11, 12)
-    a = np.arange(np.prod(s)).reshape(s)
+    a = np.arange(np.prod(s), dtype=float).reshape(s)
     if use_nan:
         a[1] = np.nan
     d = da.from_array(a, chunks=(4, 5, 6))


### PR DESCRIPTION
The NumPy 1.20.0 release candidate is already in Fedora Rawhide for testing, and 34 tests fail. This fixes most of them.

- [x] Tests added / passed
- [?] Passes `black dask` / `flake8 dask`
