### PR TITLE
Use xxhash3 for hashing arrays

### DIFF
--- a/dask/hashing.py
+++ b/dask/hashing.py
@@ -6,29 +6,10 @@ hashers = []  # In decreasing performance order
 
 
 # Timings on a largish array:
+# - xxHash3 is faster than CityHash
 # - CityHash is 2x faster than MurmurHash
-# - xxHash is slightly slower than CityHash
 # - MurmurHash is 8x faster than SHA1
 # - SHA1 is significantly faster than all other hashlib algorithms
-
-try:
-    import cityhash  # `python -m pip install cityhash`
-except ImportError:
-    pass
-else:
-    # CityHash disabled unless the reference leak in
-    # https://github.com/escherba/python-cityhash/pull/16
-    # is fixed.
-    if cityhash.__version__ >= "0.2.2":
-
-        def _hash_cityhash(buf):
-            """
-            Produce a 16-bytes hash of *buf* using CityHash.
-            """
-            h = cityhash.CityHash128(buf)
-            return h.to_bytes(16, "little")
-
-        hashers.append(_hash_cityhash)
 
 try:
     import xxhash  # `python -m pip install xxhash`
@@ -38,11 +19,26 @@ else:
 
     def _hash_xxhash(buf):
         """
-        Produce a 8-bytes hash of *buf* using xxHash.
+        Produce a 8-bytes hash of *buf* using xxHash3.
         """
-        return xxhash.xxh64(buf).digest()
+        return xxhash.xxh3_64(buf).digest()
 
     hashers.append(_hash_xxhash)
+
+try:
+    import cityhash  # `python -m pip install cityhash`
+except ImportError:
+    pass
+else:
+
+    def _hash_cityhash(buf):
+        """
+        Produce a 16-bytes hash of *buf* using CityHash.
+        """
+        h = cityhash.CityHash128(buf)
+        return h.to_bytes(16, "little")
+
+    hashers.append(_hash_cityhash)
 
 try:
     import mmh3  # `python -m pip install mmh3`


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

[xxHash v0.8.0](https://github.com/Cyan4973/xxHash/releases/tag/v0.8.0) added support for `XXH3`. Using `xxhash.xxh3_64` instead of `xxhash.xxh64` in `hashing.py` shows better performance for tokenizing arrays.

Using XXH3:
```
$ python -m pyperf timeit -s "from dask.base import tokenize; import numpy as np; a =np.ones((10_000,10_000))" "tokenize(a)"
.....................
Mean +- std dev: 75.2 ms +- 3.1 ms
```

Using Cityhash:
```
$ python -m pyperf timeit -s "from dask.base import tokenize; import numpy as np; a =np.ones((10_000,10_000))" "tokenize(a)"
.....................
Mean +- std dev: 94.5 ms +- 16.0 ms
```

Using XXH:
```
$ python -m pyperf timeit -s "from dask.base import tokenize; import numpy as np; a =np.ones((10_000,10_000))" "tokenize(a)"
.....................
Mean +- std dev: 97.4 ms +- 4.9 ms
```

ref: https://fastcompression.blogspot.com/2019/03/presenting-xxh3.html