### PR TITLE
check_meta(): use __class__ when checking dataframe types

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -425,7 +425,7 @@ def test_is_dataframe_like(monkeypatch, frame_value_counts):
     assert not is_index_like(pd.Index)
 
     # The following checks support of class wrappers, which
-    # requires the comparions of `x__class__` instead of `type(x)`
+    # requires the comparions of `x.__class__` instead of `type(x)`
     class DataFrameWrapper:
         __class__ = pd.DataFrame
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -424,6 +424,32 @@ def test_is_dataframe_like(monkeypatch, frame_value_counts):
     assert is_index_like(ddf.index)
     assert not is_index_like(pd.Index)
 
+    # The following checks support of class wrappers, which
+    # requires the comparions of `x__class__` instead of `type(x)`
+    class DataFrameWrapper:
+        __class__ = pd.DataFrame
+
+    wrap = DataFrameWrapper()
+    wrap.dtypes = None
+    wrap.columns = None
+    assert is_dataframe_like(wrap)
+
+    class SeriesWrapper:
+        __class__ = pd.Series
+
+    wrap = SeriesWrapper()
+    wrap.dtype = None
+    wrap.name = None
+    assert is_series_like(wrap)
+
+    class IndexWrapper:
+        __class__ = pd.Index
+
+    wrap = IndexWrapper()
+    wrap.dtype = None
+    wrap.name = None
+    assert is_index_like(wrap)
+
 
 def test_apply_and_enforce_message():
     def func():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1119,7 +1119,7 @@ def is_arraylike(x):
 
 def is_dataframe_like(df):
     """ Looks like a Pandas DataFrame """
-    typ = type(df)
+    typ = df.__class__
     return (
         all(hasattr(typ, name) for name in ("groupby", "head", "merge", "mean"))
         and all(hasattr(df, name) for name in ("dtypes", "columns"))
@@ -1129,7 +1129,7 @@ def is_dataframe_like(df):
 
 def is_series_like(s):
     """ Looks like a Pandas Series """
-    typ = type(s)
+    typ = s.__class__
     return (
         all(hasattr(typ, name) for name in ("groupby", "head", "mean"))
         and all(hasattr(s, name) for name in ("dtype", "name"))
@@ -1139,7 +1139,7 @@ def is_series_like(s):
 
 def is_index_like(s):
     """ Looks like a Pandas Index """
-    typ = type(s)
+    typ = s.__class__
     return (
         all(hasattr(s, name) for name in ("name", "dtype"))
         and "index" in typ.__name__.lower()


### PR DESCRIPTION
Similar to https://github.com/dask/dask/pull/6981, this PR makes `check_meta()` use `x.__class__` instead of `type(x)` when checking dataframe types.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
