### PR TITLE
Merge annotations

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -354,7 +354,8 @@ class Blockwise(Layer):
         global_dependencies = list(state["global_dependencies"])
 
         if state["annotations"]:
-            annotations.update(cls.expand_annotations(state["annotations"], raw.keys()))
+            expanded = cls.expand_annotations(state["annotations"], raw.keys())
+            cls.merge_annotations(annotations, expanded)
 
         raw = {stringify(k): stringify_collection_keys(v) for k, v in raw.items()}
         dsk.update(raw)

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -354,8 +354,7 @@ class Blockwise(Layer):
         global_dependencies = list(state["global_dependencies"])
 
         if state["annotations"]:
-            expanded = cls.expand_annotations(state["annotations"], raw.keys())
-            cls.merge_annotations(annotations, expanded)
+            cls.unpack_annotations(annotations, state["annotations"], raw.keys())
 
         raw = {stringify(k): stringify_collection_keys(v) for k, v in raw.items()}
         dsk.update(raw)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -159,8 +159,7 @@ class SimpleShuffleLayer(Layer):
         )
 
         if state["annotations"]:
-            expanded = cls.expand_annotations(state["annotations"], raw.keys())
-            cls.merge_annotations(annotations, expanded)
+            cls.unpack_annotations(annotations, state["annotations"], raw.keys())
 
     def _keys_to_parts(self, keys):
         """Simple utility to convert keys to partition indices."""

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -159,7 +159,8 @@ class SimpleShuffleLayer(Layer):
         )
 
         if state["annotations"]:
-            annotations.update(cls.expand_annotations(state["annotations"], raw.keys()))
+            expanded = cls.expand_annotations(state["annotations"], raw.keys())
+            cls.merge_annotations(annotations, expanded)
 
     def _keys_to_parts(self, keys):
         """Simple utility to convert keys to partition indices."""

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -221,7 +221,6 @@ async def test_annotations_blockwise_unpack(c, s, a, b):
     da = pytest.importorskip("dask.array")
     np = pytest.importorskip("numpy")
     from dask.array.utils import assert_eq
-    import numpy as np
 
     # A flaky doubling function -- need extra args because it is called before
     # application to establish dtype/meta.

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -21,6 +21,7 @@ from distributed.utils_test import (  # noqa F401
     cluster_fixture,
     loop,
     client as c,
+    varying,
 )
 
 
@@ -213,3 +214,35 @@ def test_local_scheduler():
         assert len(z.dask) == 1
 
     asyncio.get_event_loop().run_until_complete(f())
+
+
+@gen_cluster(client=True)
+async def test_annotations_blockwise_unpack(c, s, a, b):
+    da = pytest.importorskip("dask.array")
+    np = pytest.importorskip("numpy")
+    from dask.array.utils import assert_eq
+    import numpy as np
+
+    # A flaky doubling function -- need extra args because it is called before
+    # application to establish dtype/meta.
+    scale = varying([ZeroDivisionError("one"), ZeroDivisionError("two"), 2, 2])
+
+    def flaky_double(x):
+        return scale() * x
+
+    # A reliable double function.
+    def reliable_double(x):
+        return 2 * x
+
+    x = da.ones(10, chunks=(5,))
+
+    # The later annotations should not override the earlier annotations
+    with dask.annotate(retries=2):
+        y = x.map_blocks(flaky_double, meta=np.array((), dtype=np.float))
+    with dask.annotate(retries=0):
+        z = y.map_blocks(reliable_double, meta=np.array((), dtype=np.float))
+
+    with dask.config.set(optimization__fuse__active=False):
+        z = await c.compute(z)
+
+    assert_eq(z, np.ones(10) * 4.0)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

This is partner to dask/distributed#4406. The motivation there is to unify the implementation of control flow like workers/retries/priority around the newer annotations system. In that PR, we found that the final step of unpacking annotations on the scheduler needed to be a non-shallow merge so that constructing a final annotations structure would allow for different layers to have different annotations. For example, two layers could have `retries: { 'a' : 2 }` and `retries: { 'b': 3 }`. With a shallow merge the latter `retries` would overwrite the former, when in fact we want a result of `retries: { 'a': 2, 'b': 3 }`.

This implements that deeper-merge for annotations in `__dask_distributed_unpack__()`. It also moves the default unpacking function from `distributed` to this package, in order to be more consistent with where other layers have implemented that behavior.

cc @sjperkins @madsbk 