### PR TITLE
Add cytoolz back to CI environment

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -36,9 +36,4 @@ conda list
 echo -e "--\n--Conda Environment (re-create this with \`conda env create --name <name> -f <output_file>\`)\n--"
 conda env export | grep -E -v '^prefix:.*$'
 
-# Ensure cytoolz is not installed in the CI environment when tests are run
-# We can add cytoolz back in once
-# https://github.com/conda-forge/cytoolz-feedstock/issues/36 is resolved
-conda uninstall --force cytoolz
-
 set +xe


### PR DESCRIPTION
Following up on https://github.com/dask/dask/pull/7069, now that https://github.com/conda-forge/cytoolz-feedstock/issues/36 has been resolved we can add `cytoolz` back to the CI environment. 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
