### PR TITLE
Fix parquet getitem optimization

### DIFF
--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -70,9 +70,9 @@ def optimize_read_parquet_getitem(dsk, keys):
                 # ... where this value is __getitem__...
                 return dsk
 
-            if any(block.output == x[0] for x in keys if isinstance(x, tuple)):
-                # if any(block.output == x[0] for x in keys if isinstance(x, tuple)):
-                # ... but bail on the optimization if the getitem is what's requested
+            if any(layers[k].name == x[0] for x in keys if isinstance(x, tuple)):
+                # ... but bail on the optimization if the read_parquet layer is in
+                # the requested keys, because we cannot change the name anymore.
                 # These keys are structured like [('getitem-<token>', 0), ...]
                 # so we check for the first item of the tuple.
                 # See https://github.com/dask/dask/issues/5893
@@ -125,5 +125,8 @@ def optimize_read_parquet_getitem(dsk, keys):
         if name != old.name:
             del layers[old.name]
 
+    # import pdb; pdb.set_trace()
+    # print("old.name",old.name,"\n")
+    # print("LAYERS",layers,"\n")
     new_hlg = HighLevelGraph(layers, dependencies)
     return new_hlg

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -125,8 +125,5 @@ def optimize_read_parquet_getitem(dsk, keys):
         if name != old.name:
             del layers[old.name]
 
-    # import pdb; pdb.set_trace()
-    # print("old.name",old.name,"\n")
-    # print("LAYERS",layers,"\n")
     new_hlg = HighLevelGraph(layers, dependencies)
     return new_hlg


### PR DESCRIPTION
Addresses column-selection component of #7090

It seems that #5917 added a change to `optimize_read_parquet_getitem` that bails on the parquet optimization whenever a `getitem` task is in the list of requested keys.  This means that the optimization is skipped when the column selection is the last thing the user does before computing/persisting.  I may be misunderstanding, but I don't think this change makes sense. 
 The original problem in #5893 was that the `read-parquet` task was in the list of requested keys (not that the `getitem` task was included).  As far as I can tell, we just need to check that the `read-parquet` tasks are not in the list of requested keys, otherwise we cannot change the name of that layer during the optimization.

This PR changes the `optimize_read_parquet_getitem` logic to bail if the requested keys include any keys from the `read-parquet` layer.  This is the "conservative" approach, since it is probably fine to continue with the optimization if we preserve the original name.  Note that I may be misunderstanding the reason for the original logic, so please do let me know if this makes sense (cc @TomAugspurger).
