### PR TITLE
Add add_(prefix|suffix) to dataframe and series

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1661,6 +1661,14 @@ Dask Name: {name}, {task} tasks"""
             return handle_out(out, result)
 
     @derived_from(pd.DataFrame)
+    def add_prefix(self, prefix):
+        return self.map_partitions(M.add_prefix, prefix)
+
+    @derived_from(pd.DataFrame)
+    def add_suffix(self, suffix):
+        return self.map_partitions(M.add_suffix, suffix)
+
+    @derived_from(pd.DataFrame)
     def abs(self):
         _raise_if_object_series(self, "abs")
         meta = self._meta_nonempty.abs()

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2732,14 +2732,14 @@ def test_add_prefix():
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [4, 5, 6, 7, 8]})
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf.add_prefix("abc"), df.add_prefix("abc"))
-    assert_eq(ddf.x.add_prefix("abc").compute(), df.x.add_prefix("abc"))
+    assert_eq(ddf.x.add_prefix("abc"), df.x.add_prefix("abc"))
 
 
 def test_add_suffix():
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [4, 5, 6, 7, 8]})
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf.add_suffix("abc"), df.add_suffix("abc"))
-    assert_eq(ddf.x.add_suffix("abc").compute(), df.x.add_suffix("abc"))
+    assert_eq(ddf.x.add_suffix("abc"), df.x.add_suffix("abc"))
 
 
 def test_abs():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2728,6 +2728,20 @@ def test_applymap():
     assert_eq(ddf.applymap(lambda x: (x, x)), df.applymap(lambda x: (x, x)))
 
 
+def test_add_prefix():
+    df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert_eq(ddf.add_prefix("abc"), df.add_prefix("abc"))
+    assert_eq(ddf.x.add_prefix("abc").compute(), df.x.add_prefix("abc"))
+
+
+def test_add_suffix():
+    df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert_eq(ddf.add_suffix("abc"), df.add_suffix("abc"))
+    assert_eq(ddf.x.add_suffix("abc").compute(), df.x.add_suffix("abc"))
+
+
 def test_abs():
     df = pd.DataFrame(
         {

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2729,14 +2729,14 @@ def test_applymap():
 
 
 def test_add_prefix():
-    df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [4, 5, 6, 7, 8]})
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf.add_prefix("abc"), df.add_prefix("abc"))
     assert_eq(ddf.x.add_prefix("abc").compute(), df.x.add_prefix("abc"))
 
 
 def test_add_suffix():
-    df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [4, 5, 6, 7, 8]})
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf.add_suffix("abc"), df.add_suffix("abc"))
     assert_eq(ddf.x.add_suffix("abc").compute(), df.x.add_suffix("abc"))


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Closes https://github.com/dask/dask/issues/7105 by adding a very thin wrapped around `add_(prefix|suffix)`. First PR to the Dask codebase, so let me know if I've messed up anywhere and more than happy to fix anything! :)