### PR TITLE
BUG: len / column subset failing on filtered parquet dataset using pyarrow.dataset engine

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3342,3 +3342,42 @@ def test_roundtrip_rename_columns(tmpdir, engine):
     df1.columns = ["d", "e", "f"]
 
     assert_eq(df1, ddf2.compute())
+
+
+def test_filtered_column_subset(tmpdir, engine):
+    df = pd.DataFrame({"col": range(20), "part": ["A", "B"] * 10})
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf.to_parquet(tmpdir, partition_on=["part"], engine=engine)
+
+    # # Filtered on a partition column
+    ddf2 = dd.read_parquet(tmpdir, filters=[[("part", "=", "A")]], engine=engine)
+    expected = df.astype({"part": "category"})
+    expected = expected[expected["part"] == "A"]
+
+    # length does column selection under the hood
+    assert len(ddf2) == 10
+    # explicit column selection
+    assert_eq(ddf2["col"].compute(), expected["col"])
+    assert_eq(ddf2["col"].sum().compute(), expected["col"].sum())
+    # full dataframe
+    assert_eq(ddf2.compute(), expected)
+
+    # # Filtered on a normal column
+    ddf2 = dd.read_parquet(tmpdir, filters=[[("col", ">=", 5)]], engine=engine)
+    expected = df.astype({"part": "category"})
+    expected = expected[expected["col"] >= 5]
+
+    if engine == "pyarrow-dataset":
+        # length does column selection under the hood
+        assert len(ddf2) == 15
+        # explicit column selection
+        assert_eq(ddf2["col"].compute(), expected["col"])
+        assert_eq(ddf2["col"].sum().compute(), expected["col"].sum())
+        # full dataframe
+        assert_eq(ddf2.compute(), expected)
+    else:
+        # not actually filtered
+        assert len(ddf2) == 20
+        assert_eq(ddf2["col"].compute(), df["col"])
+        assert_eq(ddf2["col"].sum().compute(), df["col"].sum())
+        assert_eq(ddf2.compute(), df.astype({"part": "category"}))


### PR DESCRIPTION
This is actually a bug report, but in form of a PR with test. I noticed that my demo notebook with the pyarrow dataset engine was not actually fully working anymore (it seems this was already the case at the end of https://github.com/dask/dask/pull/6534, though, so the bug was probably introduced somewhere along that long PR). 

The rather simple case of checking the length or getting a subset of columns of a filtered partitioned dataset is failing:

```python
df = pd.DataFrame({"part": ["A", "B"] * 10, "col": range(20)})
ddf = dd.from_pandas(df, npartitions=2)
ddf.to_parquet("test_dask_pyarrow_filter", partition_on=["part"])
ddf_subset = dd.read_parquet("test_dask_pyarrow_filter", filters=[[('part', '=', "A")]], engine="pyarrow-dataset")

# both fail
len(ddf_subset)
ddf_subset["col"].sum().compute()
```

cc @rjzamora 

The reason that it is failing is because in `read_partition` in the lines below, we don't calculate a `keys_dict` if we have a pyarrow.dataset ParquetFileFragment, but we *still* have `partitions`:

https://github.com/dask/dask/blob/9bb586a6b8fac1983b7cea3ab399719f93dbbb29/dask/dataframe/io/parquet/arrow.py#L616-L625

The "easy" fix might be to just always calculate `keys_dict`, but on the other hand, in the case that we have a ParquetFileFragment, we shouldn't remove the partition columns from `columns` and let pyarrow read the `arrow_table` with partition columns included (I suppose was the rationale about the above if/else, but in practice that doesn't happen anymore, and `arrow_table` does not actually include the partition columns, and thus the code here is trying to add them, getting it from `keys_dict`, but which is empty. 