### PR TITLE
Don't set PYTHONHASHSEED in CI environment

### DIFF
--- a/continuous_integration/scripts/run_tests.sh
+++ b/continuous_integration/scripts/run_tests.sh
@@ -2,11 +2,8 @@
 
 set -e
 
-# Need to make test order deterministic when parallelizing tests, hence PYTHONHASHSEED
-# (see https://github.com/pytest-dev/pytest-xdist/issues/63)
 if [[ $PARALLEL == 'true' ]]; then
     export XTRATESTARGS="-n4 $XTRATESTARGS"
-    export PYTHONHASHSEED=42
 fi
 
 if [[ $COVERAGE == 'true' ]]; then


### PR DESCRIPTION
The NumPy `ScalarType` list is populated using a dictionary. While
stable within a process on latest Python 3, `pytest-xdist` sets
different seeds per process, which may make the dictionary change order.
This causes `pytest` to balk at the different parameterizations for
`test_from_array_scalar`.

Types cannot be sorted though, so sort by the name of the type.

- [x] Tests added / passed
- [?] Passes `black dask` / `flake8 dask`
