### PR TITLE
allow dask.array.ravel to accept array_like arguments 

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1194,8 +1194,8 @@ def union1d(ar1, ar2):
 
 
 @derived_from(np)
-def ravel(array):
-    return array.reshape((-1,))
+def ravel(array_like):
+    return asanyarray(array_like).reshape((-1,))
 
 
 @derived_from(np)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -959,7 +959,7 @@ def test_ravel():
         a = da.from_array(x, chunks=chunks)
         assert_eq(x.ravel(), a.ravel())
         assert len(a.ravel().dask) == len(a.dask) + len(a.chunks[0])
-
+    
     # 0d
     assert_eq(x[0, 0].ravel(), a[0, 0].ravel())
 
@@ -976,7 +976,14 @@ def test_ravel():
     assert_eq(x.flatten(), a.flatten())
     assert_eq(np.ravel(x), da.ravel(a))
 
-
+def test_ravel_array_like():
+    #int
+    assert_eq(np.ravel(0), da.ravel(0))
+    #list
+    assert_eq(np.ravel([0,0]), da.ravel([0,0])
+    #tuple
+    assert_eq(np.ravel((0,0)), da.ravel((0,0))
+    
 def test_ravel_1D_no_op():
     x = np.random.randint(10, size=100)
     dx = da.from_array(x, chunks=10)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -980,9 +980,9 @@ def test_ravel_array_like():
     #int
     assert_eq(np.ravel(0), da.ravel(0))
     #list
-    assert_eq(np.ravel([0,0]), da.ravel([0,0])
+    assert_eq(np.ravel([0,0]), da.ravel([0,0]))
     #tuple
-    assert_eq(np.ravel((0,0)), da.ravel((0,0))
+    assert_eq(np.ravel((0,0)), da.ravel((0,0)))
     
 def test_ravel_1D_no_op():
     x = np.random.randint(10, size=100)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -977,10 +977,13 @@ def test_ravel():
     assert_eq(np.ravel(x), da.ravel(a))
 
 def test_ravel_array_like():
+    
     #int
     assert_eq(np.ravel(0), da.ravel(0))
+    
     #list
     assert_eq(np.ravel([0,0]), da.ravel([0,0]))
+    
     #tuple
     assert_eq(np.ravel((0,0)), da.ravel((0,0)))
     


### PR DESCRIPTION
- [x] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
- [x]  Closes #7121
