### PR TITLE
Allow dask.array.ravel to accept 'array_like' arguments.

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1194,8 +1194,8 @@ def union1d(ar1, ar2):
 
 
 @derived_from(np)
-def ravel(array):
-    return array.reshape((-1,))
+def ravel(array_like):
+    return asanyarray(array_like).reshape((-1,))
 
 
 @derived_from(np)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -975,6 +975,18 @@ def test_ravel():
 
     assert_eq(x.flatten(), a.flatten())
     assert_eq(np.ravel(x), da.ravel(a))
+    
+
+def test_ravel_array_like_transformation():
+
+    # int
+    assert_eq(np.ravel(0), da.ravel(0))
+    # list
+    assert_eq(np.ravel([0, 0]), da.ravel([0, 0]))
+    # tuple
+    assert_eq(np.ravel((0, 0)), da.ravel((0, 0)))
+    # nested -> tuples in list
+    assert_eq(np.ravel([(0,), (0,)]), da.ravel([(0,), (0,)]))
 
 
 def test_ravel_1D_no_op():


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
- [x] Closes #7132
