### PR TITLE
Allow dask.array.ravel to accept 'array_like' argument

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1194,8 +1194,8 @@ def union1d(ar1, ar2):
 
 
 @derived_from(np)
-def ravel(array):
-    return array.reshape((-1,))
+def ravel(array_like):
+    return asanyarray(array_like).reshape((-1,))
 
 
 @derived_from(np)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -985,19 +985,20 @@ def test_ravel_1D_no_op():
     # Unknown dims
     assert_eq(dx[dx > 2].ravel(), x[x > 2].ravel())
 
+
 def test_ravel_with_array_like():
     # int
     assert_eq(np.ravel(0), da.ravel(0))
     assert isinstance(da.ravel(0), da.core.Array)
-    
+
     # list
     assert_eq(np.ravel([0, 0]), da.ravel([0, 0]))
-    assert isinstance(da.ravel([0,0]), da.core.Array)
-    
+    assert isinstance(da.ravel([0, 0]), da.core.Array)
+
     # tuple
     assert_eq(np.ravel((0, 0)), da.ravel((0, 0)))
-    assert isinstance(da.ravel((0,0)), da.core.Array)
-    
+    assert isinstance(da.ravel((0, 0)), da.core.Array)
+
     # nested i.e. tuples in list
     assert_eq(np.ravel([(0,), (0,)]), da.ravel([(0,), (0,)]))
     assert isinstance(da.ravel([(0,), (0,)]), da.core.Array)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -985,6 +985,23 @@ def test_ravel_1D_no_op():
     # Unknown dims
     assert_eq(dx[dx > 2].ravel(), x[x > 2].ravel())
 
+def test_ravel_with_array_like():
+    # int
+    assert_eq(np.ravel(0), da.ravel(0))
+    assert isinstance(da.ravel(0), da.core.Array)
+    
+    # list
+    assert_eq(np.ravel([0, 0]), da.ravel([0, 0]))
+    assert isinstance(da.ravel([0,0]), da.core.Array)
+    
+    # tuple
+    assert_eq(np.ravel((0, 0)), da.ravel((0, 0)))
+    assert isinstance(da.ravel((0,0)), da.core.Array)
+    
+    # nested i.e. tuples in list
+    assert_eq(np.ravel([(0,), (0,)]), da.ravel([(0,), (0,)]))
+    assert isinstance(da.ravel([(0,), (0,)]), da.core.Array)
+
 
 @pytest.mark.parametrize("is_func", [True, False])
 @pytest.mark.parametrize("axis", [None, 0, -1, (0, -1)])


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
- [x] Closes #7132