### PR TITLE
Broadcast-based Merge implementation

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4162,7 +4162,7 @@ class DataFrame(_Frame):
         indicator=False,
         npartitions=None,
         shuffle=None,
-        bcast=None,
+        broadcast=None,
     ):
         """Merge the DataFrame with another DataFrame
 
@@ -4218,6 +4218,11 @@ class DataFrame(_Frame):
         shuffle: {'disk', 'tasks'}, optional
             Either ``'disk'`` for single-node operation or ``'tasks'`` for
             distributed operation.  Will be inferred by your current scheduler.
+        broadcast: boolean, optional
+            Whether to use a broadcast-based join in lieu of a shuffle-based
+            join for supported cases.  By default, a simple heuristic will be
+            used to select the underlying algorithm. See ``broadcast_join``
+            for more information.
 
         Notes
         -----
@@ -4259,7 +4264,7 @@ class DataFrame(_Frame):
             npartitions=npartitions,
             indicator=indicator,
             shuffle=shuffle,
-            bcast=bcast,
+            broadcast=broadcast,
         )
 
     @derived_from(pd.DataFrame)  # doctest: +SKIP

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4218,10 +4218,13 @@ class DataFrame(_Frame):
         shuffle: {'disk', 'tasks'}, optional
             Either ``'disk'`` for single-node operation or ``'tasks'`` for
             distributed operation.  Will be inferred by your current scheduler.
-        broadcast: boolean, optional
+        broadcast: boolean or float, optional
             Whether to use a broadcast-based join in lieu of a shuffle-based
             join for supported cases.  By default, a simple heuristic will be
-            used to select the underlying algorithm. See ``broadcast_join``
+            used to select the underlying algorithm. If a floating-point value
+            is specified, that number will be used as the ``broadcast_bias``
+            within the simple heuristic (a large number makes Dask more likely
+            to choose the ``broacast_join`` code path). See ``broadcast_join``
             for more information.
 
         Notes

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4162,6 +4162,7 @@ class DataFrame(_Frame):
         indicator=False,
         npartitions=None,
         shuffle=None,
+        bcast=None,
     ):
         """Merge the DataFrame with another DataFrame
 
@@ -4258,6 +4259,7 @@ class DataFrame(_Frame):
             npartitions=npartitions,
             indicator=indicator,
             shuffle=shuffle,
+            bcast=bcast,
         )
 
     @derived_from(pd.DataFrame)  # doctest: +SKIP

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -628,8 +628,15 @@ def merge(
         # See note on `broadcast_bias` below.
         broadcast_bias = 0.5
         if isinstance(broadcast, float):
-            broadcast_bias = broadcast
+            broadcast_bias = float(broadcast)
             broadcast = None
+        elif not isinstance(broadcast, bool) and broadcast is not None:
+            # Let's be strict about the `broadcast` type to
+            # avoid arbitrarily casting int to float or bool.
+            raise ValueError(
+                f"Optional `broadcast` argument must be float or bool."
+                f"Type={type(broadcast)} is not supported."
+            )
         bcast_side = "left" if left.npartitions < right.npartitions else "right"
         n_small = min(left.npartitions, right.npartitions)
         n_big = max(left.npartitions, right.npartitions)

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -22,7 +22,8 @@ def optimize(dsk, keys, **kwargs):
     dsk = fuse_roots(dsk, keys=keys)
     dsk = dsk.cull(set(keys))
 
-    if not config.get("optimization.fuse.active"):
+    # import pdb; pdb.set_trace()
+    if True:  # not config.get("optimization.fuse.active"):
         return dsk
 
     dependencies = dsk.get_all_dependencies()

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -22,8 +22,7 @@ def optimize(dsk, keys, **kwargs):
     dsk = fuse_roots(dsk, keys=keys)
     dsk = dsk.cull(set(keys))
 
-    # import pdb; pdb.set_trace()
-    if True:  # not config.get("optimization.fuse.active"):
+    if not config.get("optimization.fuse.active"):
         return dsk
 
     dependencies = dsk.get_all_dependencies()

--- a/dask/dataframe/tests/test_merge_column_and_index.py
+++ b/dask/dataframe/tests/test_merge_column_and_index.py
@@ -193,15 +193,16 @@ def test_merge_known_to_double_bcast_right(
 
 
 @pytest.mark.parametrize("how", ["inner", "right"])
+@pytest.mark.parametrize("broadcast", [True, 0.75])
 def test_merge_known_to_double_bcast_left(
-    df_left, df_right, ddf_left_double, ddf_right, on, how
+    df_left, df_right, ddf_left_double, ddf_right, on, how, broadcast
 ):
     # Compute expected
     expected = df_left.merge(df_right, on=on, how=how)
 
     # Perform merge
     result = ddf_left_double.merge(
-        ddf_right, on=on, how=how, shuffle="tasks", broadcast=True
+        ddf_right, on=on, how=how, shuffle="tasks", broadcast=broadcast
     )
 
     # Assertions

--- a/dask/dataframe/tests/test_merge_column_and_index.py
+++ b/dask/dataframe/tests/test_merge_column_and_index.py
@@ -66,6 +66,11 @@ def ddf_right_single(df_right):
     return dd.from_pandas(df_right, npartitions=1, sort=False)
 
 
+@pytest.fixture
+def ddf_right_double(df_right):
+    return dd.from_pandas(df_right, npartitions=2, sort=False)
+
+
 @pytest.fixture(params=["inner", "left", "right", "outer"])
 def how(request):
     return request.param
@@ -162,3 +167,22 @@ def test_merge_unknown_to_unknown(
     assert_eq(result, expected)
     assert_eq(result.divisions, tuple(None for _ in range(11)))
     assert len(result.__dask_graph__()) >= 390
+
+
+@pytest.mark.parametrize("how", ["inner", "left"])
+def test_merge_known_to_double_bcast(
+    df_left, df_right, ddf_left, ddf_right_double, on, how
+):
+    # Compute expected
+    expected = df_left.merge(df_right, on=on, how=how)
+
+    # Perform merge
+    result = ddf_left.merge(
+        ddf_right_double, on=on, how=how, shuffle="tasks", bcast=True
+    )
+    result.compute(scheduler="synchronous")
+
+    # Assertions
+    assert_eq(result, expected)
+    assert_eq(result.divisions, ddf_left.divisions)
+    assert len(result.__dask_graph__()) < 90

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2292,4 +2292,5 @@ def test_merge_tasks_large_to_small(how, npartitions, base):
         dd_result.compute().sort_values("y"),
         pd_result.sort_values("y"),
         check_index=False,
+        check_dtypes=False,
     )

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2285,6 +2285,10 @@ def test_merge_tasks_large_to_small(how, npartitions, base):
     )
     pd_result = pd.merge(left, right, on="y", how=how)
 
+    # Make sure `on` dtypes match
+    dd_result["y"] = dd_result["y"].astype(np.int32)
+    pd_result["y"] = pd_result["y"].astype(np.int32)
+
     if npartitions:
         assert dd_result.npartitions == npartitions
 
@@ -2292,5 +2296,4 @@ def test_merge_tasks_large_to_small(how, npartitions, base):
         dd_result.compute().sort_values("y"),
         pd_result.sort_values("y"),
         check_index=False,
-        check_dtypes=False,
     )

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2234,3 +2234,62 @@ def test_categorical_merge_does_not_raise_setting_with_copy_warning():
 
     df2 = df2.astype({"B": "category"})
     assert_eq(df1.join(df2), ddf1.join(df2))
+
+
+@pytest.mark.parametrize("how", ["inner", "left", "right"])
+@pytest.mark.parametrize("npartitions", [28, 32])
+@pytest.mark.parametrize("base", ["lg", "sm"])
+def test_merge_tasks_large_to_small(how, npartitions, base):
+
+    size_lg = 3000
+    size_sm = 300
+    npartitions_lg = 30
+    npartitions_sm = 3
+    broadcast_bias = 1.0  # Prioritize broadcast
+
+    lg = pd.DataFrame(
+        {
+            "x": np.random.choice(np.arange(100), size_lg),
+            "y": np.arange(size_lg),
+        }
+    )
+    ddf_lg = dd.from_pandas(lg, npartitions=npartitions_lg)
+
+    sm = pd.DataFrame(
+        {
+            "x": np.random.choice(np.arange(100), size_sm),
+            "y": np.arange(size_sm),
+        }
+    )
+    ddf_sm = dd.from_pandas(sm, npartitions=npartitions_sm)
+
+    if base == "lg":
+        left = lg
+        ddf_left = ddf_lg
+        right = sm
+        ddf_right = ddf_sm
+    else:
+        left = sm
+        ddf_left = ddf_sm
+        right = lg
+        ddf_right = ddf_lg
+
+    dd_result = dd.merge(
+        ddf_left,
+        ddf_right,
+        on="y",
+        how=how,
+        npartitions=npartitions,
+        broadcast=broadcast_bias,
+        shuffle="tasks",
+    )
+    pd_result = pd.merge(left, right, on="y", how=how)
+
+    if npartitions:
+        assert dd_result.npartitions == npartitions
+
+    assert_eq(
+        dd_result.compute().sort_values("y"),
+        pd_result.sort_values("y"),
+        check_index=False,
+    )


### PR DESCRIPTION
Dask-DataFrame will currently perform a shuffle-based merge for all cases where there are multiple partitions in both collections (and when the join is not on an index with known divisions).  The shuffle-based approach makes a lot of sense when both of the collections comprise many partitions, but makes less sense when one of the collections is huge (making the shuffle expensive) and the other is very small (only a few partitions).   This PR introduces a `bcast_join` for this latter scenario.

**NOTE**: There is still more work to do here, but preliminary tests suggest that the broadcast algorithm is indeed faster than a broadcast merge when a 240-partition DataFrame is joined with a DataFrame comprising 2-4 partitions (with the benefit increasing as the large DataFrame becomes larger)... I will share benchmarks here as the remaining tasks are completed.

**TODO**:

- [x] Add support for `how="right"`
- [x] Add support for `npartitions` kwarg (**not sure this "should" be supported?**)
- [x] Translate into an HLG layer
- [x] Expand testing
- [x] Investigate best heuristic for shuffle vs. bcast default.  Need to test various workflows with `dask.dataframe` **and** `dask_cudf`

cc @beckernick 