### PR TITLE
Deprecate HighlevelGraph.dicts in favour of .layers

### DIFF
--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -197,7 +197,7 @@ def test_optimize_blockwise():
     assert isinstance(dsk, HighLevelGraph)
 
     assert (
-        len([layer for layer in dsk.dicts.values() if isinstance(layer, Blockwise)])
+        len([layer for layer in dsk.layers.values() if isinstance(layer, Blockwise)])
         == 1
     )
 
@@ -220,7 +220,7 @@ def test_optimize_blockwise_annotations():
 
     annotations = (
         layer.annotations
-        for layer in dsk.dicts.values()
+        for layer in dsk.layers.values()
         if isinstance(layer, Blockwise)
     )
     annotations = collections.Counter(
@@ -245,7 +245,7 @@ def test_blockwise_diamond_fusion():
     assert isinstance(dsk, HighLevelGraph)
 
     assert (
-        len([layer for layer in dsk.dicts.values() if isinstance(layer, Blockwise)])
+        len([layer for layer in dsk.layers.values() if isinstance(layer, Blockwise)])
         == 1
     )
 
@@ -256,15 +256,15 @@ def test_blockwise_non_blockwise_output():
     w = y.sum()
     z = ((y * 2) * 3) * 4
 
-    z_top_before = tuple(z.dask.dicts[z.name].indices)
+    z_top_before = tuple(z.dask.layers[z.name].indices)
     (zz,) = dask.optimize(z)
-    z_top_after = tuple(z.dask.dicts[z.name].indices)
+    z_top_after = tuple(z.dask.layers[z.name].indices)
     assert z_top_before == z_top_after, "z_top mutated"
 
     dsk = optimize_blockwise(z.dask, keys=list(dask.core.flatten(z.__dask_keys__())))
     assert isinstance(dsk, HighLevelGraph)
     assert (
-        len([layer for layer in dsk.dicts.values() if isinstance(layer, Blockwise)])
+        len([layer for layer in dsk.layers.values() if isinstance(layer, Blockwise)])
         == 1
     )
 
@@ -274,7 +274,7 @@ def test_blockwise_non_blockwise_output():
     )
     assert isinstance(dsk, HighLevelGraph)
     assert (
-        len([layer for layer in z.dask.dicts.values() if isinstance(layer, Blockwise)])
+        len([layer for layer in z.dask.layers.values() if isinstance(layer, Blockwise)])
         >= 1
     )
 
@@ -283,7 +283,7 @@ def test_top_len():
     x = da.ones(10, chunks=(5,))
     y = x[:, None] * x[None, :]
 
-    d = y.dask.dicts[y.name]
+    d = y.dask.layers[y.name]
     assert len(d) == 4
 
 
@@ -606,7 +606,7 @@ def test_dont_merge_before_reductions():
 
     dsk = optimize_blockwise(w.dask)
 
-    assert len([d for d in dsk.dicts.values() if isinstance(d, Blockwise)]) == 2
+    assert len([d for d in dsk.layers.values() if isinstance(d, Blockwise)]) == 2
 
     z.compute()
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -206,7 +206,7 @@ def _check_dsk(dsk):
 
     dsk.validate()
     assert all(isinstance(k, (tuple, str)) for k in dsk.layers)
-    freqs = frequencies(concat(dsk.dicts.values()))
+    freqs = frequencies(concat(dsk.layers.values()))
     non_one = {k: v for k, v in freqs.items() if v != 1}
     assert not non_one, non_one
 

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -861,9 +861,9 @@ def optimize_blockwise(graph, keys=()):
 
 def _optimize_blockwise(full_graph, keys=()):
     keep = {k[0] if type(k) is tuple else k for k in keys}
-    layers = full_graph.dicts
+    layers = full_graph.layers
     dependents = reverse_dict(full_graph.dependencies)
-    roots = {k for k in full_graph.dicts if not dependents.get(k)}
+    roots = {k for k in full_graph.layers if not dependents.get(k)}
     stack = list(roots)
 
     out = {}

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1,5 +1,6 @@
 import abc
 import collections.abc
+import warnings
 from typing import (
     Any,
     Dict,
@@ -568,6 +569,12 @@ class HighLevelGraph(Mapping):
     @property
     def dicts(self):
         # Backwards compatibility for now
+        warnings.warn(
+            "'dicts' property of HighLevelGraph is deprecated now and will be "
+            "removed in a future version. To silence this warning, "
+            "use '.layers' instead.",
+            FutureWarning,
+        )
         return self.layers
 
     def items(self):

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -130,3 +130,10 @@ def test_blockwise_cull(flat):
         out_keys = layer.get_output_keys()
         assert out_keys == {(layer.output, *select)}
         assert not layer.is_materialized()
+
+
+def test_highlevelgraph_dicts_deprecation():
+    with pytest.warns(FutureWarning):
+        layers = {"a": BasicLayer({"x": 1, "y": (inc, "x")})}
+        hg = HighLevelGraph(layers, {"a": set()})
+        assert hg.dicts == layers

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1027,10 +1027,10 @@ def get_scheduler_lock(collection=None, scheduler=None):
 def ensure_dict(d):
     if type(d) is dict:
         return d
-    elif hasattr(d, "dicts"):
+    elif hasattr(d, "layers"):
         result = {}
         seen = set()
-        for dd in d.dicts.values():
+        for dd in d.layers.values():
             dd_id = id(dd)
             if dd_id not in seen:
                 result.update(dd)


### PR DESCRIPTION
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Replaces all usage of `.dicts` with `.layers` and deprecates `.dicts`.
Fixes #7108 

cc @jrbourbeau @crusaderky 