### PR TITLE
Change flake8 max-line-length to match black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ ignore =
     W503,  # line break before binary operator
     W504,  # line break after binary operator
     F811,  # redefinition of unused 'loop' from line 10
-max-line-length = 120
+max-line-length = 88
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

xref https://github.com/dask/dask/pull/7128#issuecomment-769509959