### PR TITLE
DOC Fixes link in array design doc

### DIFF
--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -51,7 +51,7 @@ sufficiently NumPy-like in API such as CuPy or Spare arrays) arranged into a
 grid. These arrays may live on disk or on other machines.
 
 New duck array chunk types (types below Dask on
-`NEP-13's type-casting heirarchy`_) can be registered via
+`NEP-13's type-casting hierarchy`_) can be registered via
 :func:`~dask.array.register_chunk_type`. Any other duck array types that are
 not registered will be deferred to in binary operations and NumPy
 ufuncs/functions (that is, Dask will return ``NotImplemented``). Note, however,


### PR DESCRIPTION
Fixes link to NEP-13 in array design doc

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
