### PR TITLE
Revise HighLevelGraph Mapping API

### DIFF
--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -206,11 +206,11 @@ def test_basic(func):
     ddc = func(dc)
     ddn = func(dn)
 
-    assert type(ddc._meta) == cupy.core.core.ndarray
+    assert type(ddc._meta) is cupy.core.core.ndarray
 
-    if ddc.dask.keys()[0][0].startswith("empty"):
+    if next(iter(ddc.dask.keys()))[0].startswith("empty"):
         # We can't verify for data correctness when testing empty_like
-        assert type(ddc._meta) == type(ddc.compute())
+        assert type(ddc._meta) is type(ddc.compute())
     else:
         assert_eq(ddc, ddc)  # Check that _meta and computed arrays match types
         assert_eq(ddc, ddn)

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1207,8 +1207,8 @@ def fuse_roots(graph: HighLevelGraph, keys: list):
     Blockwise
     fuse
     """
-    layers = graph.layers.copy()
-    dependencies = graph.dependencies.copy()
+    layers = ensure_dict(graph.layers, copy=True)
+    dependencies = ensure_dict(graph.dependencies, copy=True)
     dependents = reverse_dict(dependencies)
 
     for name, layer in graph.layers.items():

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -553,7 +553,7 @@ def read_pandas(
             if is_integer_dtype(head[c].dtype) and c not in specified_dtypes:
                 head[c] = head[c].astype(float)
 
-    values = [[dsk.dask.values() for dsk in block] for block in values]
+    values = [[list(dsk.dask.values()) for dsk in block] for block in values]
 
     return text_blocks_to_pandas(
         reader,

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2421,7 +2421,7 @@ def test_getitem_optimization_empty(tmpdir, engine):
     df2 = dd.read_parquet(fn, columns=[], engine=engine)
     dsk = optimize_read_parquet_getitem(df2.dask, keys=[df2._name])
 
-    subgraph = list(dsk.layers.values())[0]
+    subgraph = next(iter((dsk.layers.values())))
     assert isinstance(subgraph, ParquetSubgraph)
     assert subgraph.columns == []
 
@@ -2471,8 +2471,9 @@ def test_blockwise_parquet_annotations(tmpdir):
     # `ddf` should now have ONE Blockwise layer
     layers = ddf.__dask_graph__().layers
     assert len(layers) == 1
-    assert isinstance(list(layers.values())[0], ParquetSubgraph)
-    assert list(layers.values())[0].annotations == {"foo": "bar"}
+    layer = next(iter((layers.values())))
+    assert isinstance(layer, ParquetSubgraph)
+    assert layer.annotations == {"foo": "bar"}
 
 
 def test_split_row_groups(tmpdir, engine):

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -2,12 +2,12 @@ import abc
 import collections.abc
 import warnings
 from typing import (
+    AbstractSet,
     Any,
     Dict,
     Hashable,
     MutableMapping,
     Optional,
-    Set,
     Mapping,
     Iterable,
     Tuple,
@@ -17,7 +17,7 @@ import copy
 import tlz as toolz
 
 from . import config
-from .utils import ignoring, stringify
+from .utils import ensure_dict, ignoring, stringify
 from .base import is_dask_collection
 from .core import reverse_dict, keys_in_tasks
 from .utils_test import add, inc  # noqa: F401
@@ -35,7 +35,7 @@ def compute_layer_dependencies(layers):
     all_keys = set(key for layer in layers.values() for key in layer)
     ret = {k: set() for k in layers.keys()}
     for k, v in layers.items():
-        for key in keys_in_tasks(all_keys.difference(v.keys()), v.values()):
+        for key in keys_in_tasks(all_keys - v.keys(), v.values()):
             ret[k].add(_find_layer_containing_key(key))
     return ret
 
@@ -67,7 +67,7 @@ class Layer(collections.abc.Mapping):
         """Return whether the layer is materialized or not"""
         return True
 
-    def get_output_keys(self) -> Set:
+    def get_output_keys(self) -> AbstractSet:
         """Return a set of all output keys
 
         Output keys are all keys in the layer that might be referenced by
@@ -78,7 +78,7 @@ class Layer(collections.abc.Mapping):
 
         Returns
         -------
-        keys: Set
+        keys: AbstractSet
             All output keys
         """
         return self.keys()
@@ -150,8 +150,8 @@ class Layer(collections.abc.Mapping):
         annotations.update(to_merge)
 
     def cull(
-        self, keys: Set, all_hlg_keys: Iterable
-    ) -> Tuple["Layer", Mapping[Hashable, Set]]:
+        self, keys: set, all_hlg_keys: Iterable
+    ) -> Tuple["Layer", Mapping[Hashable, set]]:
         """Return a new Layer with only the tasks required to calculate `keys` and
         a map of external key dependencies.
 
@@ -194,7 +194,7 @@ class Layer(collections.abc.Mapping):
 
         return BasicLayer(out), ret_deps
 
-    def get_dependencies(self, key: Hashable, all_hlg_keys: Iterable) -> Set:
+    def get_dependencies(self, key: Hashable, all_hlg_keys: Iterable) -> set:
         """Get dependencies of `key` in the layer
 
         Parameters
@@ -246,7 +246,7 @@ class Layer(collections.abc.Mapping):
         cls,
         state: Any,
         dsk: Dict[str, Any],
-        dependencies: MutableMapping[Hashable, Set],
+        dependencies: MutableMapping[Hashable, set],
         annotations: Dict[str, Any],
     ) -> None:
         """Unpack the state of a layer previously packed by __dask_distributed_pack__()
@@ -348,9 +348,9 @@ class HighLevelGraph(Mapping):
     ----------
     layers : Mapping[str, Mapping]
         The subgraph layers, keyed by a unique name
-    dependencies : Mapping[str, Set[str]]
+    dependencies : Mapping[str, set[str]]
         The set of layers on which each layer depends
-    key_dependencies : Mapping[Hashable, Set], optional
+    key_dependencies : Mapping[Hashable, set], optional
         Mapping (some) keys in the high level graph to their dependencies. If
         a key is missing, its dependencies will be calculated on-the-fly.
 
@@ -395,22 +395,23 @@ class HighLevelGraph(Mapping):
         typically used by developers to make new HighLevelGraphs
     """
 
+    layers: Mapping[str, Layer]
+    dependencies: Mapping[str, AbstractSet]
+    key_dependencies: Dict[Hashable, AbstractSet]
+    _to_dict: dict
+    _all_external_keys: set
+
     def __init__(
         self,
-        layers: Mapping[str, Layer],
-        dependencies: Mapping[str, Set],
-        key_dependencies: Optional[Mapping[Hashable, Set]] = None,
+        layers: Mapping[str, Mapping],
+        dependencies: Mapping[str, AbstractSet],
+        key_dependencies: Dict[Hashable, AbstractSet] = None,
     ):
-        self._keys = None
-        self._all_external_keys = None
-        self.layers = layers
         self.dependencies = dependencies
-        self.key_dependencies = key_dependencies if key_dependencies else {}
-
+        self.key_dependencies = key_dependencies or {}
         # Makes sure that all layers are `Layer`
         self.layers = {
-            k: v if isinstance(v, Layer) else BasicLayer(v)
-            for k, v in self.layers.items()
+            k: v if isinstance(v, Layer) else BasicLayer(v) for k, v in layers.items()
         }
 
     @classmethod
@@ -419,9 +420,9 @@ class HighLevelGraph(Mapping):
         if is_dask_collection(collection):
             graph = collection.__dask_graph__()
             if isinstance(graph, HighLevelGraph):
-                layers = graph.layers.copy()
+                layers = ensure_dict(graph.layers, copy=True)
                 layers.update({name: layer})
-                deps = graph.dependencies.copy()
+                deps = ensure_dict(graph.dependencies, copy=True)
                 with ignoring(AttributeError):
                     deps.update({name: set(collection.__dask_layers__())})
             else:
@@ -497,36 +498,59 @@ class HighLevelGraph(Mapping):
         return cls(layers, deps)
 
     def __getitem__(self, key):
+        # Attempt O(1) direct access first, under the assumption that layer names match
+        # either the keys (Scalar, Item, Delayed) or the first element of the key tuples
+        # (Array, Bag, DataFrame, Series). This assumption is not always true.
+        try:
+            return self.layers[key][key]
+        except KeyError:
+            pass
+        try:
+            return self.layers[key[0]][key]
+        except (KeyError, IndexError, TypeError):
+            pass
+
+        # Fall back to O(n) access
         for d in self.layers.values():
-            if key in d:
+            try:
                 return d[key]
+            except KeyError:
+                pass
+
         raise KeyError(key)
 
     def __len__(self):
-        return len(self.keyset())
+        return len(self.to_dict())
 
     def __iter__(self):
-        return toolz.unique(toolz.concat(self.layers.values()))
+        return iter(self.to_dict())
 
-    def keyset(self) -> Set:
-        """Get all keys of all the layers
+    def to_dict(self) -> dict:
+        """Efficiently convert to plain dict. This method is faster than dict(self)."""
+        try:
+            return self._to_dict
+        except AttributeError:
+            out = self._to_dict = ensure_dict(self)
+            return out
 
-        This will in many cases materialize layers, which makes it
-        a relative cheap operation. See `get_all_external_keys()`
-        for a faster alternative.
+    def keys(self) -> AbstractSet:
+        """Get all keys of all the layers.
 
-        Returns
-        -------
-        keys: Set
-            A set of all keys
+        This will in many cases materialize layers, which makes it a relatively
+        expensive operation. See :meth:`get_all_external_keys` for a faster alternative.
         """
-        if self._keys is None:
-            self._keys = set()
-            for layer in self.layers.values():
-                self._keys.update(layer.keys())
-        return self._keys
+        return self.to_dict().keys()
 
-    def get_all_external_keys(self) -> Set:
+    def keyset(self) -> AbstractSet:
+        # Backwards compatibility for now
+        warnings.warn(
+            "'keyset' method of HighLevelGraph is deprecated now and will be removed "
+            "in a future version. To silence this warning, use '.keys' instead.",
+            FutureWarning,
+        )
+        return self.keys()
+
+    def get_all_external_keys(self) -> set:
         """Get all output keys of all layers
 
         This will in most cases _not_ materialize any layers, which makes
@@ -534,16 +558,25 @@ class HighLevelGraph(Mapping):
 
         Returns
         -------
-        keys: Set
+        keys: set
             A set of all external keys
         """
-        if self._all_external_keys is None:
-            self._all_external_keys = set()
+        try:
+            return self._all_external_keys
+        except AttributeError:
+            keys: set = set()
             for layer in self.layers.values():
-                self._all_external_keys.update(layer.get_output_keys())
-        return self._all_external_keys
+                keys |= layer.get_output_keys()
+            self._all_external_keys = keys
+            return keys
 
-    def get_all_dependencies(self) -> Mapping[Hashable, Set]:
+    def items(self):
+        return self.to_dict().items()
+
+    def values(self):
+        return self.to_dict().values()
+
+    def get_all_dependencies(self) -> Dict[Hashable, AbstractSet]:
         """Get dependencies of all keys
 
         This will in most cases materialize all layers, which makes
@@ -554,11 +587,11 @@ class HighLevelGraph(Mapping):
         map: Mapping
             A map that maps each key to its dependencies
         """
-        all_keys = self.keyset()
-        missing_keys = all_keys.difference(self.key_dependencies.keys())
+        all_keys = self.keys()
+        missing_keys = all_keys - self.key_dependencies.keys()
         if missing_keys:
             for layer in self.layers.values():
-                for k in missing_keys.intersection(layer.keys()):
+                for k in missing_keys & layer.keys():
                     self.key_dependencies[k] = layer.get_dependencies(k, all_keys)
         return self.key_dependencies
 
@@ -577,24 +610,12 @@ class HighLevelGraph(Mapping):
         )
         return self.layers
 
-    def items(self):
-        items = []
-        seen = set()
-        for d in self.layers.values():
-            for key in d:
-                if key not in seen:
-                    seen.add(key)
-                    items.append((key, d[key]))
-        return items
-
-    def keys(self):
-        return [key for key, _ in self.items()]
-
-    def values(self):
-        return [value for _, value in self.items()]
-
     def copy(self):
-        return HighLevelGraph(self.layers.copy(), self.dependencies.copy())
+        return HighLevelGraph(
+            ensure_dict(self.layers, copy=True),
+            ensure_dict(self.dependencies, copy=True),
+            self.key_dependencies.copy(),
+        )
 
     @classmethod
     def merge(cls, *graphs):
@@ -643,8 +664,8 @@ class HighLevelGraph(Mapping):
                     ready.add(k)
         return ret
 
-    def cull(self, keys: Set) -> "HighLevelGraph":
-        """Return new high level graph with only the tasks required to calculate keys.
+    def cull(self, keys: set) -> "HighLevelGraph":
+        """Return new HighLevelGraph with only the tasks required to calculate keys.
 
         In other words, remove unnecessary tasks from dask.
         ``keys`` may be a single key or list of keys.
@@ -661,8 +682,8 @@ class HighLevelGraph(Mapping):
         for layer_name in reversed(self._toposort_layers()):
             layer = self.layers[layer_name]
             # Let's cull the layer to produce its part of `keys`
-            output_keys = keys.intersection(layer.get_output_keys())
-            if len(output_keys) > 0:
+            output_keys = keys & layer.get_output_keys()
+            if output_keys:
                 culled_layer, culled_deps = layer.cull(output_keys, all_ext_keys)
                 # Update `keys` with all layer's external key dependencies, which
                 # are all the layer's dependencies (`culled_deps`) excluding
@@ -670,18 +691,17 @@ class HighLevelGraph(Mapping):
                 external_deps = set()
                 for d in culled_deps.values():
                     external_deps |= d
-                external_deps.difference_update(culled_layer.get_output_keys())
-                keys.update(external_deps)
+                external_deps -= culled_layer.get_output_keys()
+                keys |= external_deps
 
                 # Save the culled layer and its key dependencies
                 ret_layers[layer_name] = culled_layer
                 ret_key_deps.update(culled_deps)
 
-        ret_dependencies = {}
-        for layer_name in ret_layers:
-            ret_dependencies[layer_name] = {
-                d for d in self.dependencies[layer_name] if d in ret_layers
-            }
+        ret_dependencies = {
+            layer_name: self.dependencies[layer_name] & ret_layers.keys()
+            for layer_name in ret_layers
+        }
 
         return HighLevelGraph(ret_layers, ret_dependencies, ret_key_deps)
 

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -417,17 +417,18 @@ def test_ndeepmap():
 def test_ensure_dict():
     d = {"x": 1}
     assert ensure_dict(d) is d
-    hlg = HighLevelGraph.from_collections("x", d)
-    assert type(ensure_dict(hlg)) is dict
-    assert ensure_dict(hlg) == d
 
     class mydict(dict):
         pass
 
-    md = mydict()
-    md["x"] = 1
-    assert type(ensure_dict(md)) is dict
-    assert ensure_dict(md) == d
+    d2 = ensure_dict(d, copy=True)
+    d3 = ensure_dict(HighLevelGraph.from_collections("x", d))
+    d4 = ensure_dict(mydict(d))
+
+    for di in (d2, d3, d4):
+        assert type(di) is dict
+        assert di is not d
+        assert di == d
 
 
 def test_itemgetter():


### PR DESCRIPTION
Changes to HighLevelGraph:

- Order-of-magnitude speedup of ``__getitem__`` in the most common use cases
- various minor speedups thanks to set arithmetics
- type annotations to declare layers, dependencies, and all other internal collections as read-only
- copy() now also copies the memoized data of get_all_dependencies()
- new method to_dict(), which is a memoized wrapper around ensure_dict()
- keys(), items(), and values() are now memoized. The extra RAM usage compared to the previous design should be trivial (I replaced a set with a dict where all the values are already referenced objects)
- keys(), items(), and values() now respect the Mapping protocol and are respectively KeysView, ItemsView and ValuesView instead of lists
- deprecated keyset()
- 50x speedup in keys(), items(), values(), upstream of memoization:
```python
import dask.array as da 
a = da.random.randint(0, 10, size=10_000, chunks=10) 
# Create more layers for HighLevelGraph 
for i in range(10): 
    a = a + 1


def bench(k):
    try:
        del a._to_dict
    except AttributeError:
        pass
    list(getattr(a.dask, k)())

%timeit bench("keys")
%timeit bench("values")  
%timeit bench("items")  
```
Before:
```
3.19 ms ± 8.28 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
3.2 ms ± 5.39 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
3.1 ms ± 46.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
After:
```
57.1 µs ± 493 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
58.1 µs ± 152 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
243 µs ± 1.16 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
This iterates upon #4918.
