### PR TITLE
Add percentile support for NEP-35

### DIFF
--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -84,16 +84,19 @@ def percentile(a, q, interpolation="linear", method="default"):
     --------
     numpy.percentile : Numpy's equivalent Percentile function
     """
+    from .utils import array_safe, meta_from_array
+
     if not a.ndim == 1:
         raise NotImplementedError("Percentiles only implemented for 1-d arrays")
     if isinstance(q, Number):
         q = [q]
-    q = np.array(q)
+    q = array_safe(q, like=meta_from_array(a))
     token = tokenize(a, q, interpolation)
 
     dtype = a.dtype
     if np.issubdtype(dtype, np.integer):
-        dtype = (np.array([], dtype=dtype) / 0.5).dtype
+        dtype = (array_safe([], dtype=dtype, like=meta_from_array(a)) / 0.5).dtype
+    meta = meta_from_array(a, dtype=dtype)
 
     allowed_methods = ["default", "dask", "tdigest"]
     if method not in allowed_methods:
@@ -151,7 +154,7 @@ def percentile(a, q, interpolation="linear", method="default"):
 
     dsk = merge(dsk, dsk2)
     graph = HighLevelGraph.from_collections(name2, dsk, dependencies=[a])
-    return Array(graph, name2, chunks=((len(q),),), dtype=dtype)
+    return Array(graph, name2, chunks=((len(q),),), meta=meta)
 
 
 def merge_percentiles(finalq, qs, vals, interpolation="lower", Ns=None):
@@ -183,9 +186,11 @@ def merge_percentiles(finalq, qs, vals, interpolation="lower", Ns=None):
     >>> merge_percentiles(finalq, qs, vals, Ns=Ns)
     array([ 1,  2,  3,  4, 10, 11, 12, 13])
     """
+    from .utils import array_safe, empty_like_safe
+
     if isinstance(finalq, Iterator):
         finalq = list(finalq)
-    finalq = np.array(finalq)
+    finalq = array_safe(finalq, like=finalq)
     qs = list(map(list, qs))
     vals = list(vals)
     if Ns is None:
@@ -215,8 +220,8 @@ def merge_percentiles(finalq, qs, vals, interpolation="lower", Ns=None):
     # transform qs and Ns into number of observations between percentiles
     counts = []
     for q, N in zip(qs, Ns):
-        count = np.empty(len(q))
-        count[1:] = np.diff(q)
+        count = empty_like_safe(finalq, shape=len(q))
+        count[1:] = np.diff(array_safe(q, like=q[0]))
         count[0] = q[0]
         count *= N
         counts.append(count)
@@ -232,8 +237,8 @@ def merge_percentiles(finalq, qs, vals, interpolation="lower", Ns=None):
     combined_vals_counts = merge_sorted(*map(zip, vals, counts))
     combined_vals, combined_counts = zip(*combined_vals_counts)
 
-    combined_vals = np.array(combined_vals)
-    combined_counts = np.array(combined_counts)
+    combined_vals = array_safe(combined_vals, like=combined_vals[0])
+    combined_counts = array_safe(combined_counts, like=combined_counts[0])
 
     # percentile-like, but scaled by total number of observations
     combined_q = np.cumsum(combined_counts)

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import dask.array as da
+from dask.array.numpy_compat import _numpy_120
 from dask.array.utils import assert_eq, same_keys, AxisError, IS_NEP18_ACTIVE
 from dask.array.gufunc import apply_gufunc
 from dask.sizeof import sizeof
@@ -958,7 +959,7 @@ def test_sparse_dot(sp_format):
     assert_eq(z, da_z.todense())
 
 
-@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
 def test_percentile():
     d = da.from_array(cupy.ones((16,)), chunks=(4,))
     qs = np.array([0, 50, 100])
@@ -984,7 +985,7 @@ def test_percentile():
     reason="Non-deterministic tokenize(cupy.array(...)), "
     "see https://github.com/dask/dask/issues/6718"
 )
-@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
 def test_percentile_tokenize():
     d = da.from_array(cupy.ones((16,)), chunks=(4,))
     qs = np.array([0, 50, 100])
@@ -992,7 +993,7 @@ def test_percentile_tokenize():
     assert same_keys(da.percentile(d, qs), da.percentile(d, qs))
 
 
-@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
 def test_percentiles_with_empty_arrays():
     x = da.from_array(cupy.ones(10), chunks=((5, 0, 5),))
     res = da.percentile(x, [10, 50, 90], interpolation="midpoint")
@@ -1002,7 +1003,7 @@ def test_percentiles_with_empty_arrays():
     assert_eq(res, np.array([1, 1, 1], dtype=x.dtype))
 
 
-@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
 def test_percentiles_with_empty_q():
     x = da.from_array(cupy.ones(10), chunks=((5, 0, 5),))
     result = da.percentile(x, [], interpolation="midpoint")
@@ -1012,7 +1013,7 @@ def test_percentiles_with_empty_q():
     assert_eq(result, np.array([], dtype=x.dtype))
 
 
-@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
 @pytest.mark.parametrize("q", [5, 5.0, np.int64(5), np.float64(5)])
 def test_percentiles_with_scaler_percentile(q):
     # Regression test to ensure da.percentile works with scalar percentiles
@@ -1025,7 +1026,7 @@ def test_percentiles_with_scaler_percentile(q):
     assert_eq(result, np.array([1], dtype=d.dtype))
 
 
-@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
 def test_percentiles_with_unknown_chunk_sizes():
     rs = da.random.RandomState(RandomState=cupy.random.RandomState)
     x = rs.random(1000, chunks=(100,))

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -956,3 +956,83 @@ def test_sparse_dot(sp_format):
 
     assert cupyx.scipy.sparse.isspmatrix(da_z)
     assert_eq(z, da_z.todense())
+
+
+@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+def test_percentile():
+    d = da.from_array(cupy.ones((16,)), chunks=(4,))
+    qs = np.array([0, 50, 100])
+
+    assert_eq(
+        da.percentile(d, qs, interpolation="midpoint"),
+        np.array([1, 1, 1], dtype=d.dtype),
+    )
+
+    x = cupy.array([0, 0, 5, 5, 5, 5, 20, 20])
+    d = da.from_array(x, chunks=(3,))
+
+    result = da.percentile(d, qs, interpolation="midpoint")
+    assert_eq(result, np.array([0, 5, 20], dtype=result.dtype))
+
+    # Currently fails, tokenize(cupy.array(...)) is not deterministic.
+    # See https://github.com/dask/dask/issues/6718
+    # assert same_keys(
+    #     da.percentile(d, qs),
+    #     da.percentile(d, qs)
+    # )
+
+    assert not same_keys(
+        da.percentile(d, qs, interpolation="midpoint"),
+        da.percentile(d, [0, 50], interpolation="midpoint"),
+    )
+
+
+@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+def test_percentiles_with_empty_arrays():
+    x = da.from_array(cupy.ones(10), chunks=((5, 0, 5),))
+    res = da.percentile(x, [10, 50, 90], interpolation="midpoint")
+
+    assert type(res._meta) == cupy.core.core.ndarray
+    assert_eq(res, res)  # Check that _meta and computed arrays match types
+    assert_eq(res, np.array([1, 1, 1], dtype=x.dtype))
+
+
+@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+def test_percentiles_with_empty_q():
+    x = da.from_array(cupy.ones(10), chunks=((5, 0, 5),))
+    result = da.percentile(x, [], interpolation="midpoint")
+
+    assert type(result._meta) == cupy.core.core.ndarray
+    assert_eq(result, result)  # Check that _meta and computed arrays match types
+    assert_eq(result, np.array([], dtype=x.dtype))
+
+
+@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+@pytest.mark.parametrize("q", [5, 5.0, np.int64(5), np.float64(5)])
+def test_percentiles_with_scaler_percentile(q):
+    # Regression test to ensure da.percentile works with scalar percentiles
+    # See #3020
+    d = da.from_array(cupy.ones((16,)), chunks=(4,))
+    result = da.percentile(d, q, interpolation="midpoint")
+
+    assert type(result._meta) == cupy.core.core.ndarray
+    assert_eq(result, result)  # Check that _meta and computed arrays match types
+    assert_eq(result, np.array([1], dtype=d.dtype))
+
+
+@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+def test_percentiles_with_unknown_chunk_sizes():
+    rs = da.random.RandomState(RandomState=cupy.random.RandomState)
+    x = rs.random(1000, chunks=(100,))
+    x._chunks = ((np.nan,) * 10,)
+
+    result = da.percentile(x, 50, interpolation="midpoint").compute()
+    assert type(result) == cupy.core.core.ndarray
+    assert 0.1 < result < 0.9
+
+    a, b = da.percentile(x, [40, 60], interpolation="midpoint").compute()
+    assert type(a) == cupy.core.core.ndarray
+    assert type(b) == cupy.core.core.ndarray
+    assert 0.1 < a < 0.9
+    assert 0.1 < b < 0.9
+    assert a < b

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -974,17 +974,22 @@ def test_percentile():
     result = da.percentile(d, qs, interpolation="midpoint")
     assert_eq(result, np.array([0, 5, 20], dtype=result.dtype))
 
-    # Currently fails, tokenize(cupy.array(...)) is not deterministic.
-    # See https://github.com/dask/dask/issues/6718
-    # assert same_keys(
-    #     da.percentile(d, qs),
-    #     da.percentile(d, qs)
-    # )
-
     assert not same_keys(
         da.percentile(d, qs, interpolation="midpoint"),
         da.percentile(d, [0, 50], interpolation="midpoint"),
     )
+
+
+@pytest.mark.xfail(
+    reason="Non-deterministic tokenize(cupy.array(...)), "
+    "see https://github.com/dask/dask/issues/6718"
+)
+@pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")
+def test_percentile_tokenize():
+    d = da.from_array(cupy.ones((16,)), chunks=(4,))
+    qs = np.array([0, 50, 100])
+
+    assert same_keys(da.percentile(d, qs), da.percentile(d, qs))
 
 
 @pytest.mark.skipif(np.__version__ < "1.20", reason="NEP-35 is not available")

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -959,7 +959,7 @@ def test_sparse_dot(sp_format):
     assert_eq(z, da_z.todense())
 
 
-@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
+@pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 def test_percentile():
     d = da.from_array(cupy.ones((16,)), chunks=(4,))
     qs = np.array([0, 50, 100])
@@ -985,7 +985,7 @@ def test_percentile():
     reason="Non-deterministic tokenize(cupy.array(...)), "
     "see https://github.com/dask/dask/issues/6718"
 )
-@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
+@pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 def test_percentile_tokenize():
     d = da.from_array(cupy.ones((16,)), chunks=(4,))
     qs = np.array([0, 50, 100])
@@ -993,7 +993,7 @@ def test_percentile_tokenize():
     assert same_keys(da.percentile(d, qs), da.percentile(d, qs))
 
 
-@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
+@pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 def test_percentiles_with_empty_arrays():
     x = da.from_array(cupy.ones(10), chunks=((5, 0, 5),))
     res = da.percentile(x, [10, 50, 90], interpolation="midpoint")
@@ -1003,7 +1003,7 @@ def test_percentiles_with_empty_arrays():
     assert_eq(res, np.array([1, 1, 1], dtype=x.dtype))
 
 
-@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
+@pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 def test_percentiles_with_empty_q():
     x = da.from_array(cupy.ones(10), chunks=((5, 0, 5),))
     result = da.percentile(x, [], interpolation="midpoint")
@@ -1013,7 +1013,7 @@ def test_percentiles_with_empty_q():
     assert_eq(result, np.array([], dtype=x.dtype))
 
 
-@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
+@pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 @pytest.mark.parametrize("q", [5, 5.0, np.int64(5), np.float64(5)])
 def test_percentiles_with_scaler_percentile(q):
     # Regression test to ensure da.percentile works with scalar percentiles
@@ -1026,7 +1026,7 @@ def test_percentiles_with_scaler_percentile(q):
     assert_eq(result, np.array([1], dtype=d.dtype))
 
 
-@pytest.mark.skipif(_numpy_120, reason="NEP-35 is not available")
+@pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 def test_percentiles_with_unknown_chunk_sizes():
     rs = da.random.RandomState(RandomState=cupy.random.RandomState)
     x = rs.random(1000, chunks=(100,))

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -411,12 +411,14 @@ def _array_like_safe(np_func, da_func, a, like, **kwargs):
 
 def array_safe(a, like, **kwargs):
     """
-    If a is dask.array, return dask.array.asarray(a, **kwargs),
-    otherwise return np.asarray(a, like=like, **kwargs), dispatching
+    If `a` is `dask.array`, return `dask.array.asarray(a, **kwargs)`,
+    otherwise return `np.asarray(a, like=like, **kwargs)`, dispatching
     the call to the library that implements the like array. Note that
-    when a is a dask.Array but like isn't, this function will call
-    a.compute(scheduler="sync") before np.asarray, as downstream
-    libraries are unlikely to know how to convert a dask.Array.
+    when `a` is a `dask.Array` backed by `cupy.ndarray` but `like`
+    isn't, this function will call `a.compute(scheduler="sync")`
+    before `np.array`, as downstream libraries are unlikely to know how
+    to convert a `dask.Array` and CuPy doesn't implement `__array__` to
+    prevent implicit copies to host.
     """
     from .routines import array
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -397,7 +397,10 @@ def _array_like_safe(np_func, da_func, a, like, **kwargs):
     elif isinstance(a, Array):
         a = a.compute(scheduler="sync")
 
-    return np_func(a, like=meta_from_array(like), **kwargs)
+    try:
+        return np_func(a, like=meta_from_array(like), **kwargs)
+    except TypeError:
+        return np_func(a, **kwargs)
 
 
 def array_safe(a, like, **kwargs):

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -395,7 +395,12 @@ def _array_like_safe(np_func, da_func, a, like, **kwargs):
     if isinstance(like, Array):
         return da_func(a, **kwargs)
     elif isinstance(a, Array):
-        a = a.compute(scheduler="sync")
+        try:
+            import cupy as cp
+            if isinstance(a._meta, cp.ndarray):
+                a = a.compute(scheduler="sync")
+        except ImportError:
+            pass
 
     try:
         return np_func(a, like=meta_from_array(like), **kwargs)

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -21,8 +21,13 @@ except AttributeError:
         AxisError = type(e)
 
 
+def _is_cupy_type(x):
+    # TODO: avoid explicit reference to CuPy
+    return "cupy" in str(type(x))
+
+
 def normalize_to_array(x):
-    if "cupy" in str(type(x)):  # TODO: avoid explicit reference to cupy
+    if _is_cupy_type(x):
         return x.get()
     else:
         return x
@@ -395,12 +400,8 @@ def _array_like_safe(np_func, da_func, a, like, **kwargs):
     if isinstance(like, Array):
         return da_func(a, **kwargs)
     elif isinstance(a, Array):
-        try:
-            import cupy as cp
-            if isinstance(a._meta, cp.ndarray):
-                a = a.compute(scheduler="sync")
-        except ImportError:
-            pass
+        if _is_cupy_type(a._meta):
+            a = a.compute(scheduler="sync")
 
     try:
         return np_func(a, like=meta_from_array(like), **kwargs)


### PR DESCRIPTION
This PR is a slim version of https://github.com/dask/dask/pull/6738 with two purposes:

1. Unblock https://github.com/rapidsai/cudf/issues/7289 with NumPy >= 1.20;
2. Serve as a first push on NEP-35 into Dask, hopefully a much easier review task than the full https://github.com/dask/dask/pull/6738.

Given this is a blocker for RAPIDS 0.18 to be released in two weeks, it would be great if it can make its way into the upcoming Dask release on Friday.