### PR TITLE
Added support for Float64 in column assignment

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4468,3 +4468,17 @@ def test_join_series():
     expected_df = dd.from_pandas(df.join(df["x"], lsuffix="_"), npartitions=1)
     actual_df = ddf.join(ddf["x"], lsuffix="_")
     assert_eq(actual_df, expected_df)
+
+
+@pytest.mark.skipif(
+    not dd._compat.PANDAS_GT_120, reason="Float64 was introduced in pandas>=1.2"
+)
+def test_assign_na_float_columns():
+    # See https://github.com/dask/dask/issues/7156
+    df_pandas = pd.DataFrame({"a": [1.1]}, dtype="Float64")
+    df = dd.from_pandas(df_pandas, npartitions=1)
+
+    df = df.assign(new_col=df["a"])
+
+    assert df.compute()["a"].dtypes == "Float64"
+    assert df.compute()["new_col"].dtypes == "Float64"

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -18,6 +18,7 @@ from dask.dataframe.utils import (
     is_index_like,
     PANDAS_GT_100,
 )
+from dask.dataframe._compat import PANDAS_GT_120
 
 import pytest
 
@@ -470,3 +471,10 @@ def test_nonempty_series_sparse():
         dd.utils._nonempty_series(ser)
 
     assert len(w) == 0
+
+
+@pytest.mark.skipif(not PANDAS_GT_120, reason="Float64 was introduced in pandas>=1.2")
+def test_nonempty_series_nullable_float():
+    ser = pd.Series([], dtype="Float64")
+    non_empty = dd.utils._nonempty_series(ser)
+    assert non_empty.dtype == "Float64"

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -17,8 +17,8 @@ from dask.dataframe.utils import (
     is_series_like,
     is_index_like,
     PANDAS_GT_100,
+    PANDAS_GT_120,
 )
-from dask.dataframe._compat import PANDAS_GT_120
 
 import pytest
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -23,6 +23,7 @@ from pandas.api.types import (
 from ._compat import (  # noqa: F401
     PANDAS_GT_100,
     PANDAS_GT_110,
+    PANDAS_GT_120,
     tm,
 )
 
@@ -56,6 +57,9 @@ def is_integer_na_dtype(t):
 
 
 def is_float_na_dtype(t):
+    if not PANDAS_GT_120:
+        return False
+
     dtype = getattr(t, "dtype", t)
     types = (
         pd.Float32Dtype,

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -55,6 +55,15 @@ def is_integer_na_dtype(t):
     return isinstance(dtype, types)
 
 
+def is_float_na_dtype(t):
+    dtype = getattr(t, "dtype", t)
+    types = (
+        pd.Float32Dtype,
+        pd.Float64Dtype,
+    )
+    return isinstance(dtype, types)
+
+
 def shard_df_on_index(df, divisions):
     """Shard a DataFrame by ranges on its index
 
@@ -558,6 +567,8 @@ def _nonempty_series(s, idx=None):
         data = pd.Categorical(data, categories=cats, ordered=s.cat.ordered)
     elif is_integer_na_dtype(dtype):
         data = pd.array([1, None], dtype=dtype)
+    elif is_float_na_dtype(dtype):
+        data = pd.array([1.0, None], dtype=dtype)
     elif is_period_dtype(dtype):
         # pandas 0.24.0+ should infer this to be Series[Period[freq]]
         freq = dtype.freq


### PR DESCRIPTION
Fixes #7156
As described in the issue, I added another small helper function for Float64/32 (similar to Int64, ...).

- [X] Closes #7156
- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`
