### PR TITLE
__dask_layers__() tests and tweaks

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4482,3 +4482,14 @@ def test_map_blocks_dataframe():
     assert isinstance(s, dd.DataFrame)
     assert s.npartitions == x.npartitions
     dd_assert_eq(s, s)
+
+
+def test_dask_layers():
+    a = da.ones(1)
+    assert a.dask.layers.keys() == {a.name}
+    assert a.dask.dependencies == {a.name: set()}
+    assert a.__dask_layers__() == (a.name,)
+    b = a + 1
+    assert b.dask.layers.keys() == {a.name, b.name}
+    assert b.dask.dependencies == {a.name: set(), b.name: {a.name}}
+    assert b.__dask_layers__() == (b.name,)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -358,6 +358,15 @@ class Item(DaskMethodsMixin):
     def __dask_keys__(self):
         return [self.key]
 
+    def __dask_layers__(self):
+        # Deal with instances created with Item.from_delayed()
+        # e.g.: Item.from_delayed(da.ones(1).to_delayed()[0])
+        # See Delayed.__dask_layers__
+        if isinstance(self.dask, HighLevelGraph) and len(self.dask.layers) == 1:
+            return tuple(self.dask.layers)
+        else:
+            return (self.key,)
+
     def __dask_tokenize__(self):
         return self.key
 
@@ -385,7 +394,7 @@ class Item(DaskMethodsMixin):
         if not isinstance(value, Delayed) and hasattr(value, "key"):
             value = delayed(value)
         assert isinstance(value, Delayed)
-        return Item(ensure_dict(value.dask), value.key)
+        return Item(value.dask, value.key)
 
     @property
     def _args(self):

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1564,3 +1564,26 @@ def test_bagged_array_delayed():
     bag = db.from_delayed(obj)
     b = bag.compute()
     assert_eq(b, [1.0, 1.0, 1.0, 1.0, 1.0])
+
+
+def test_dask_layers():
+    a = db.from_sequence([1, 2], npartitions=2)
+    assert a.__dask_layers__() == (a.name,)
+    assert a.dask.layers.keys() == {a.name}
+    assert a.dask.dependencies == {a.name: set()}
+    i = a.min()
+    assert i.__dask_layers__() == (i.key,)
+    assert i.dask.layers.keys() == {a.name, i.key}
+    assert i.dask.dependencies == {a.name: set(), i.key: {a.name}}
+
+
+def test_dask_layers_to_delayed():
+    # da.Array.to_delayed squashes the dask graph and causes the layer name not to
+    # match the key
+    da = pytest.importorskip("dask.array")
+    i = db.Item.from_delayed(da.ones(1).to_delayed()[0])
+    name = "ones-faa3493518a0405cb3183468efb75d4e"
+    assert i.key == (name, 0)
+    assert i.dask.layers.keys() == {"delayed-" + name}
+    assert i.dask.dependencies == {"delayed-" + name: set()}
+    assert i.__dask_layers__() == ("delayed-" + name,)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1582,8 +1582,8 @@ def test_dask_layers_to_delayed():
     # match the key
     da = pytest.importorskip("dask.array")
     i = db.Item.from_delayed(da.ones(1).to_delayed()[0])
-    name = "ones-faa3493518a0405cb3183468efb75d4e"
-    assert i.key == (name, 0)
+    name = i.key[0]
+    assert i.key[1:] == (0, )
     assert i.dask.layers.keys() == {"delayed-" + name}
     assert i.dask.dependencies == {"delayed-" + name: set()}
     assert i.__dask_layers__() == ("delayed-" + name,)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1583,7 +1583,7 @@ def test_dask_layers_to_delayed():
     da = pytest.importorskip("dask.array")
     i = db.Item.from_delayed(da.ones(1).to_delayed()[0])
     name = i.key[0]
-    assert i.key[1:] == (0, )
+    assert i.key[1:] == (0,)
     assert i.dask.layers.keys() == {"delayed-" + name}
     assert i.dask.dependencies == {"delayed-" + name: set()}
     assert i.__dask_layers__() == ("delayed-" + name,)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4467,3 +4467,24 @@ def test_join_series():
     expected_df = dd.from_pandas(df.join(df["x"], lsuffix="_"), npartitions=1)
     actual_df = ddf.join(ddf["x"], lsuffix="_")
     assert_eq(actual_df, expected_df)
+
+
+def test_dask_layers():
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7, 8]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert ddf.dask.layers.keys() == {ddf._name}
+    assert ddf.dask.dependencies == {ddf._name: set()}
+    assert ddf.__dask_layers__() == (ddf._name,)
+    dds = ddf["x"]
+    assert dds.dask.layers.keys() == {ddf._name, dds._name}
+    assert dds.dask.dependencies == {ddf._name: set(), dds._name: {ddf._name}}
+    assert dds.__dask_layers__() == (dds._name,)
+    ddi = dds.min()
+    assert ddi.key[1:] == (0,)
+    assert ddi.dask.layers.keys() == {ddf._name, dds._name, ddi.key[0]}
+    assert ddi.dask.dependencies == {
+        ddf._name: set(),
+        dds._name: {ddf._name},
+        ddi.key[0]: {dds._name},
+    }
+    assert ddi.__dask_layers__() == (ddi.key[0],)

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -696,7 +696,7 @@ def test_dask_layers_to_delayed():
     da = pytest.importorskip("dask.array")
     d = da.ones(1).to_delayed()[0]
     name = d.key[0]
-    assert d.key[1:] == (0, )
+    assert d.key[1:] == (0,)
     assert d.dask.layers.keys() == {"delayed-" + name}
     assert d.dask.dependencies == {"delayed-" + name: set()}
     assert d.__dask_layers__() == ("delayed-" + name,)

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -695,8 +695,8 @@ def test_dask_layers_to_delayed():
     # match the key
     da = pytest.importorskip("dask.array")
     d = da.ones(1).to_delayed()[0]
-    name = "ones-faa3493518a0405cb3183468efb75d4e"
-    assert d.key == (name, 0)
+    name = d.key[0]
+    assert d.key[1:] == (0, )
     assert d.dask.layers.keys() == {"delayed-" + name}
     assert d.dask.dependencies == {"delayed-" + name: set()}
     assert d.__dask_layers__() == ("delayed-" + name,)


### PR DESCRIPTION
- Avoid unnecessary squashing of the HighLevelGraph in ``db.Item.from_delayed``
- Add ``__dask_layers__`` method to db.Item
- Polish implementation of Delayed
- unit tests
