### PR TITLE
Moving high level graph pack/unpack Dask 

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -23,9 +23,12 @@ if [[ ${UPSTREAM_DEV} ]]; then
         git+https://github.com/intake/filesystem_spec \
         git+https://github.com/dask/partd \
         git+https://github.com/dask/zict \
-        git+https://github.com/dask/distributed \
+        git+https://github.com/madsbk/distributed.git@hlg_pack_move_to_dask \
         git+https://github.com/zarr-developers/zarr-python
 fi
+
+# TODO: remove before PR merge!
+python -m pip install --quiet --no-deps git+https://github.com/madsbk/distributed.git@hlg_pack_move_to_dask
 
 # Install dask
 python -m pip install --quiet --no-deps -e .[complete]

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -23,12 +23,9 @@ if [[ ${UPSTREAM_DEV} ]]; then
         git+https://github.com/intake/filesystem_spec \
         git+https://github.com/dask/partd \
         git+https://github.com/dask/zict \
-        git+https://github.com/madsbk/distributed.git@hlg_pack_move_to_dask \
+        git+https://github.com/dask/distributed \
         git+https://github.com/zarr-developers/zarr-python
 fi
-
-# TODO: remove before PR merge!
-python -m pip install --quiet --no-deps git+https://github.com/madsbk/distributed.git@hlg_pack_move_to_dask
 
 # Install dask
 python -m pip install --quiet --no-deps -e .[complete]

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -359,7 +359,7 @@ class Blockwise(Layer):
             stringify(k): {stringify(d) for d in v} | g_deps
             for k, v in layer_deps.items()
         }
-        return layer_dsk, deps
+        return {"dsk": layer_dsk, "deps": deps}
 
     def _cull_dependencies(self, all_hlg_keys, output_blocks):
         """Determine the necessary dependencies to produce `output_blocks`.

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -289,7 +289,9 @@ class Blockwise(Layer):
     def is_materialized(self):
         return hasattr(self, "_cached_dict")
 
-    def __dask_distributed_pack__(self, client):
+    def __dask_distributed_pack__(
+        self, all_hlg_keys, known_key_dependencies, client, client_keys
+    ):
         from distributed.worker import dumps_function
         from distributed.utils import CancelledError
         from distributed.utils_comm import unpack_remotedata
@@ -318,7 +320,7 @@ class Blockwise(Layer):
         # All blockwise tasks will depend on the futures in `indices`
         global_dependencies = tuple(stringify(f.key) for f in indices_unpacked_futures)
 
-        ret = {
+        return {
             "output": self.output,
             "output_indices": self.output_indices,
             "func": func,
@@ -332,8 +334,6 @@ class Blockwise(Layer):
             "output_blocks": self.output_blocks,
             "dims": self.dims,
         }
-
-        return ret
 
     @classmethod
     def __dask_distributed_unpack__(cls, state, dsk, dependencies, annotations):

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -153,15 +153,15 @@ class SimpleShuffleLayer(Layer):
 
         # Convert all keys to strings and dump tasks
         raw = {stringify(k): stringify_collection_keys(v) for k, v in raw.items()}
-        dsk.update(toolz.valmap(dumps_task, raw))
+        keys = raw.keys() | dsk.keys()
 
         # TODO: use shuffle-knowledge to calculate dependencies more efficiently
-        dependencies.update(
-            {k: keys_in_tasks(dsk, [v], as_list=True) for k, v in raw.items()}
-        )
+        deps = {k: keys_in_tasks(keys, [v]) for k, v in raw.items()}
 
         if state["annotations"]:
             cls.unpack_annotations(annotations, state["annotations"], raw.keys())
+
+        return toolz.valmap(dumps_task, raw), deps
 
     def _keys_to_parts(self, keys):
         """Simple utility to convert keys to partition indices."""

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -120,7 +120,9 @@ class SimpleShuffleLayer(Layer):
         ]
         return (SimpleShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
 
-    def __dask_distributed_pack__(self, client):
+    def __dask_distributed_pack__(
+        self, all_hlg_keys, known_key_dependencies, client, client_keys
+    ):
         from distributed.protocol.serialize import to_serialize
 
         return {
@@ -341,8 +343,8 @@ class ShuffleLayer(SimpleShuffleLayer):
 
         return (ShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
 
-    def __dask_distributed_pack__(self, client):
-        ret = super().__dask_distributed_pack__(client)
+    def __dask_distributed_pack__(self, *args, **kwargs):
+        ret = super().__dask_distributed_pack__(*args, **kwargs)
         ret["inputs"] = self.inputs
         ret["stage"] = self.stage
         ret["nsplits"] = self.nsplits

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -159,7 +159,7 @@ class SimpleShuffleLayer(Layer):
         # TODO: use shuffle-knowledge to calculate dependencies more efficiently
         deps = {k: keys_in_tasks(keys, [v]) for k, v in layer_dsk.items()}
 
-        return toolz.valmap(dumps_task, layer_dsk), deps
+        return {"dsk": toolz.valmap(dumps_task, layer_dsk), "deps": deps}
 
     def _keys_to_parts(self, keys):
         """Simple utility to convert keys to partition indices."""

--- a/dask/graph_manipulation.py
+++ b/dask/graph_manipulation.py
@@ -15,7 +15,7 @@ from .base import (
 from .blockwise import blockwise
 from .core import flatten
 from .delayed import Delayed, delayed
-from .highlevelgraph import BasicLayer, HighLevelGraph, Layer
+from .highlevelgraph import MaterializedLayer, HighLevelGraph, Layer
 
 __all__ = ("bind", "checkpoint", "clone", "wait_on")
 
@@ -103,7 +103,7 @@ def _build_map_layer(
     func: Callable, name: str, collection, dependencies: Tuple[Delayed, ...] = ()
 ) -> Layer:
     """Apply func to all keys of collection. Create a Blockwise layer whenever possible;
-    fall back to BasicLayer otherwise.
+    fall back to MaterializedLayer otherwise.
 
     Parameters
     ----------
@@ -138,9 +138,9 @@ def _build_map_layer(
         )
     else:
         # Delayed, bag.Item, dataframe.core.Scalar, or third-party collection;
-        # fall back to BasicLayer
+        # fall back to MaterializedLayer
         dep_keys = tuple(d.key for d in dependencies)
-        return BasicLayer(
+        return MaterializedLayer(
             {
                 replace_name_in_key(k, name): (func, k) + dep_keys
                 for k in flatten(collection.__dask_keys__())

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -914,9 +914,7 @@ class HighLevelGraph(Mapping):
         return dumps_msgpack({"layers": layers})
 
     @staticmethod
-    def __dask_distributed_unpack__(
-        packed_hlg, annotations: Mapping[str, Any]
-    ) -> Tuple[Dict[str, Any], Dict[str, set], Dict[str, Any]]:
+    def __dask_distributed_unpack__(packed_hlg, annotations: Mapping[str, Any]) -> Dict:
         """Unpack the high level graph for Scheduler -> Worker communication
 
         The approach is to delegate the unpackaging to each layer in the high level graph
@@ -934,12 +932,13 @@ class HighLevelGraph(Mapping):
 
         Returns
         -------
-        dsk: Dict[str, Any]
-            Materialized (stringified) graph of all nodes in the high level graph
-        deps: Dict[str, set]
-            Dependencies of each key in `dsk`
-        anno: Dict[str, Any]
-            Annotations for `dsk`
+        unpacked-graph: dict
+            dsk: Dict[str, Any]
+                Materialized (stringified) graph of all nodes in the high level graph
+            deps: Dict[str, set]
+                Dependencies of each key in `dsk`
+            anno: Dict[str, Any]
+                Annotations for `dsk`
         """
         from distributed.protocol.core import loads_msgpack
         from distributed.protocol.serialize import import_allowed_module
@@ -972,7 +971,7 @@ class HighLevelGraph(Mapping):
             # Unpack the annotations
             unpack_anno(anno, layer["annotations"], unpacked_layer["dsk"].keys())
 
-        return dsk, deps, anno
+        return {"dsk": dsk, "deps": deps, "anno": anno}
 
 
 def to_graphviz(

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -214,11 +214,9 @@ class Layer(collections.abc.Mapping):
                 expanded[a] = dict.fromkeys(keys, v)
 
         # Merge the expanded annotations with the existing annotations mapping
-        to_merge = {}
         for k, v in expanded.items():
             v.update(annotations.get(k, {}))
-            to_merge[k] = v
-        annotations.update(to_merge)
+        annotations.update(expanded)
 
     def clone(
         self,

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -56,6 +56,8 @@ class Layer(collections.abc.Mapping):
     implementations.
     """
 
+    annotations: Optional[MutableMapping[str, Any]]
+
     def __init__(self, annotations=None):
         if annotations:
             self.annotations = annotations
@@ -83,7 +85,7 @@ class Layer(collections.abc.Mapping):
         """
         return self.keys()
 
-    def pack_annotations(self) -> Mapping[str, Any]:
+    def pack_annotations(self) -> Optional[Mapping[str, Any]]:
         """Packs Layer annotations for transmission to scheduler
 
         Callables annotations are fully expanded over Layer keys, while
@@ -405,7 +407,7 @@ class HighLevelGraph(Mapping):
         self,
         layers: Mapping[str, Mapping],
         dependencies: Mapping[str, AbstractSet],
-        key_dependencies: Dict[Hashable, AbstractSet] = None,
+        key_dependencies: Optional[Dict[Hashable, AbstractSet]] = None,
     ):
         self.dependencies = dependencies
         self.key_dependencies = key_dependencies or {}

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -179,10 +179,19 @@ class Layer(collections.abc.Mapping):
         keys: Iterable,
     ) -> None:
         """
-        Expand a set of layer annotations across a set of keys, then merge those
+        Unpack a set of layer annotations across a set of keys, then merge those
         expanded annotations for the layer into an existing annotations mapping.
+
         This is not a simple shallow merge because some annotations like retries,
         priority, workers, etc need to be able to retain keys from different layers.
+
+        Parameters
+        ----------
+        annotations: MutableMapping[str, Any], output
+            Already unpacked annotations, which are to be updated with the new
+            unpacked annotations
+        keys: Iterable
+            All keys in the layer.
         """
         if new_annotations is None:
             return None

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -128,7 +128,7 @@ class Layer(collections.abc.Mapping):
                         seen.add(d)
                         work.add(d)
 
-        return BasicLayer(out), ret_deps
+        return MaterializedLayer(out), ret_deps
 
     def get_dependencies(self, key: Hashable, all_hlg_keys: Iterable) -> set:
         """Get dependencies of `key` in the layer
@@ -291,7 +291,7 @@ class Layer(collections.abc.Mapping):
 
             dsk_new[key] = value
 
-        return BasicLayer(dsk_new), bound
+        return MaterializedLayer(dsk_new), bound
 
     def __dask_distributed_pack__(
         self,
@@ -424,7 +424,7 @@ class Layer(collections.abc.Mapping):
 
     def __reduce__(self):
         """Default serialization implementation, which materializes the Layer"""
-        return (BasicLayer, (dict(self),))
+        return (MaterializedLayer, (dict(self),))
 
     def __copy__(self):
         """Default shallow copy implementation"""
@@ -433,10 +433,8 @@ class Layer(collections.abc.Mapping):
         return obj
 
 
-class BasicLayer(Layer):
-    """Basic implementation of `Layer`
-
-    Fully materialized layer implemented by a mapping
+class MaterializedLayer(Layer):
+    """Fully materialized layer of `Layer`
 
     Parameters
     ----------
@@ -546,7 +544,8 @@ class HighLevelGraph(Mapping):
         self.key_dependencies = key_dependencies or {}
         # Makes sure that all layers are `Layer`
         self.layers = {
-            k: v if isinstance(v, Layer) else BasicLayer(v) for k, v in layers.items()
+            k: v if isinstance(v, Layer) else MaterializedLayer(v)
+            for k, v in layers.items()
         }
 
     @classmethod

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -423,15 +423,7 @@ class Layer(collections.abc.Mapping):
         return {"dsk": state["dsk"], "deps": state["dependencies"]}
 
     def __reduce__(self):
-        """Default serialization implementation, which materializes the Layer
-
-        This should follow the standard pickle protocol[1] but must always return
-        a tuple and the arguments for the callable object must be compatible with
-        msgpack. This is because Distributed uses msgpack to send Layers to the
-        scheduler.
-
-        [1] <https://docs.python.org/3/library/pickle.html#object.__reduce__>
-        """
+        """Default serialization implementation, which materializes the Layer"""
         return (BasicLayer, (dict(self),))
 
     def __copy__(self):

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -56,9 +56,9 @@ class Layer(collections.abc.Mapping):
     implementations.
     """
 
-    annotations: Optional[MutableMapping[str, Any]]
+    annotations: Optional[Mapping[str, Any]]
 
-    def __init__(self, annotations=None):
+    def __init__(self, annotations: Mapping[str, Any] = None):
         if annotations:
             self.annotations = annotations
         else:

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -923,7 +923,9 @@ class HighLevelGraph(Mapping):
     @staticmethod
     def __dask_distributed_unpack__(
         packed_hlg, annotations: Mapping[str, Any]
-    ) -> Tuple[Mapping[str, Any], Mapping[str, set], Mapping[str, Any]]:
+    ) -> Tuple[
+        MutableMapping[str, Any], MutableMapping[str, set], MutableMapping[str, Any]
+    ]:
         """Unpack the high level graph for Scheduler -> Worker communication
 
         The approach is to delegate the unpackaging to each layer in the high level graph
@@ -952,9 +954,9 @@ class HighLevelGraph(Mapping):
         from distributed.protocol.serialize import import_allowed_module
 
         hlg = loads_msgpack(*packed_hlg)
-        dsk: Mapping[str, Any] = {}
-        deps: Mapping[str, set] = {}
-        anno: Mapping[str, Any] = {}
+        dsk: MutableMapping[str, Any] = {}
+        deps: MutableMapping[str, set] = {}
+        anno: MutableMapping[str, Any] = {}
         if annotations:
             anno.update(annotations)
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -296,7 +296,11 @@ class Layer(collections.abc.Mapping):
         return BasicLayer(dsk_new), bound
 
     def __dask_distributed_pack__(
-        self, all_hlg_keys: Iterable[Hashable], known_key_dependencies, client, client_keys: Iterable[Hashable]
+        self,
+        all_hlg_keys: Iterable[Hashable],
+        known_key_dependencies,
+        client,
+        client_keys: Iterable[Hashable],
     ) -> Any:
         """Pack the layer for scheduler communication in Distributed
 
@@ -378,7 +382,8 @@ class Layer(collections.abc.Mapping):
 
         merged_hlg_keys = all_hlg_keys | dsk.keys()
         dsk = {
-            stringify(k): stringify(v, exclusive=merged_hlg_keys) for k, v in dsk.items()
+            stringify(k): stringify(v, exclusive=merged_hlg_keys)
+            for k, v in dsk.items()
         }
         dsk = toolz.valmap(dumps_task, dsk)
         return {"dsk": dsk, "dependencies": dependencies}

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -247,3 +247,40 @@ async def test_annotations_blockwise_unpack(c, s, a, b):
         z = await c.compute(z)
 
     assert_eq(z, np.ones(10) * 4.0)
+
+
+@gen_cluster(client=True)
+async def test_combo_of_layer_types(c, s, a, b):
+    """Check pack/unpack of a HLG that has every type of Layers!"""
+
+    da = pytest.importorskip("dask.array")
+    dd = pytest.importorskip("dask.dataframe")
+    np = pytest.importorskip("numpy")
+    pd = pytest.importorskip("pandas")
+
+    def add(x, y, z, extra_arg):
+        return x + y + z + extra_arg
+
+    y = c.submit(lambda x: x, 2)
+    z = c.submit(lambda x: x, 3)
+    x = da.blockwise(
+        add,
+        "x",
+        da.zeros((3,), chunks=(1,)),
+        "x",
+        da.ones((3,), chunks=(1,)),
+        "x",
+        y,
+        None,
+        concatenate=False,
+        dtype=int,
+        extra_arg=z,
+    )
+
+    df = dd.from_pandas(pd.DataFrame({"a": np.arange(3)}), npartitions=3)
+    df = df.shuffle("a", shuffle="tasks")
+    df = df["a"].to_dask_array()
+
+    res = x.sum() + df.sum()
+    res = await c.compute(res, optimize_graph=False)
+    assert res == 21

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -321,5 +321,5 @@ async def test_annotation_pack_unpack(c, s, a, b):
 
     annotations = {"workers": ("alice",)}
     unpacked_hlg = HighLevelGraph.__dask_distributed_unpack__(packed_hlg, annotations)
-    annotations = unpacked_hlg["anno"]
+    annotations = unpacked_hlg["annotations"]
     assert annotations == {"workers": {"n": ("alice",)}}

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -139,6 +139,14 @@ def test_multiple_annotations():
     assert clayer.annotations is None
 
 
+def test_annotation_pack_unpack():
+    layer = MaterializedLayer({"n": 42}, annotations={"workers": ("alice",)})
+    packed_anno = layer.__dask_distributed_anno_pack__()
+    anno = {}
+    Layer.__dask_distributed_anno_unpack__(anno, packed_anno, layer.keys())
+    assert anno == {"workers": {"n": ("alice",)}}
+
+
 @pytest.mark.parametrize("flat", [True, False])
 def test_blockwise_cull(flat):
     da = pytest.importorskip("dask.array")

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -142,9 +142,11 @@ def test_multiple_annotations():
 def test_annotation_pack_unpack():
     layer = MaterializedLayer({"n": 42}, annotations={"workers": ("alice",)})
     packed_anno = layer.__dask_distributed_anno_pack__()
-    anno = {}
-    Layer.__dask_distributed_anno_unpack__(anno, packed_anno, layer.keys())
-    assert anno == {"workers": {"n": ("alice",)}}
+    annotations = {}
+    Layer.__dask_distributed_annotations_unpack__(
+        annotations, packed_anno, layer.keys()
+    )
+    assert annotations == {"workers": {"n": ("alice",)}}
 
 
 @pytest.mark.parametrize("flat", [True, False])

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -5,7 +5,7 @@ import pytest
 
 import dask
 from dask.utils_test import inc
-from dask.highlevelgraph import HighLevelGraph, BasicLayer, Layer
+from dask.highlevelgraph import HighLevelGraph, MaterializedLayer, Layer
 
 
 def test_visualize(tmpdir):
@@ -174,6 +174,6 @@ def test_blockwise_cull(flat):
 
 def test_highlevelgraph_dicts_deprecation():
     with pytest.warns(FutureWarning):
-        layers = {"a": BasicLayer({"x": 1, "y": (inc, "x")})}
+        layers = {"a": MaterializedLayer({"x": 1, "y": (inc, "x")})}
         hg = HighLevelGraph(layers, {"a": set()})
         assert hg.dicts == layers


### PR DESCRIPTION
### Important: remove [CI hack](https://github.com/dask/dask/pull/7179/commits/c9bef90b29ff23a6d2c3a3df8b6be5036199bea0) before merge!

This PR moves all pack and unpacking of high level graphs from Distributed to Dask. This work is based on the discussion in https://github.com/dask/distributed/pull/4406. 
Beside the move, `unpack` now doesn't modify the input graph and dependencies, instead the unpacked graph and dependencies a returned, which makes it possible to delegate the pack and unpack of annotations to the base class. 

Notice, this PR includes a hack that makes CI install https://github.com/dask/distributed/pull/4489 before testing. This should be removed before merging.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
- [x] Remove CI hack

cc. @sjperkins, @ian-r-rose, @jrbourbeau 