### PR TITLE
[WIP] ENH Adds tree reduction to bincount

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -17,7 +17,7 @@ from ..highlevelgraph import HighLevelGraph
 from ..utils import funcname, derived_from, is_arraylike
 from . import chunk
 from .creation import arange, diag, empty, indices
-from .utils import safe_wraps, validate_axis, meta_from_array, zeros_like_safe
+from .utils import safe_wraps, validate_axis, zeros_like_safe
 from .wrap import ones
 from .ufunc import multiply, sqrt
 
@@ -642,7 +642,7 @@ def bincount(x, weights=None, minlength=0, split_every=None):
     token = tokenize(x, weights, minlength)
     args = [x, "i"]
     if weights is not None:
-        meta = meta_from_array(weights)
+        meta = np.bincount([1], weights=[1])
         args.extend([weights, "i"])
     else:
         meta = np.bincount([])

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -622,7 +622,7 @@ def gradient(f, *varargs, **kwargs):
 
 def _bincount_agg(bincounts, dtype, **kwargs):
     if not isinstance(bincounts, list):
-        bincounts = [bincounts]
+        return bincounts
 
     n = max(map(len, bincounts))
     out = zeros_like_safe(bincounts[0], shape=n, dtype=dtype)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -17,7 +17,7 @@ from ..highlevelgraph import HighLevelGraph
 from ..utils import funcname, derived_from, is_arraylike
 from . import chunk
 from .creation import arange, diag, empty, indices
-from .utils import safe_wraps, validate_axis, zeros_like_safe
+from .utils import safe_wraps, validate_axis, meta_from_array, zeros_like_safe
 from .wrap import ones
 from .ufunc import multiply, sqrt
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -620,7 +620,10 @@ def gradient(f, *varargs, **kwargs):
     return results
 
 
-def _bincount_sum(bincounts, dtype=int):
+def _bincount_agg(bincounts, dtype, **kwargs):
+    if not isinstance(bincounts, list):
+        bincounts = [bincounts]
+
     n = max(map(len, bincounts))
     out = zeros_like_safe(bincounts[0], shape=n, dtype=dtype)
     for b in bincounts:
@@ -629,7 +632,7 @@ def _bincount_sum(bincounts, dtype=int):
 
 
 @derived_from(np)
-def bincount(x, weights=None, minlength=0):
+def bincount(x, weights=None, minlength=0, split_every=None):
     if x.ndim != 1:
         raise ValueError("Input array must be one dimensional. Try using x.ravel()")
     if weights is not None:
@@ -637,35 +640,30 @@ def bincount(x, weights=None, minlength=0):
             raise ValueError("Chunks of input array x and weights must match.")
 
     token = tokenize(x, weights, minlength)
-    name = "bincount-" + token
-    final_name = "bincount-sum" + token
-    # Call np.bincount on each block, possibly with weights
+    args = [x, "i"]
     if weights is not None:
-        dsk = {
-            (name, i): (np.bincount, (x.name, i), (weights.name, i), minlength)
-            for i, _ in enumerate(x.__dask_keys__())
-        }
-        dtype = np.bincount([1], weights=[1]).dtype
+        meta = meta_from_array(weights)
+        args.extend([weights, "i"])
     else:
-        dsk = {
-            (name, i): (np.bincount, (x.name, i), None, minlength)
-            for i, _ in enumerate(x.__dask_keys__())
-        }
-        dtype = np.bincount([]).dtype
+        meta = np.bincount([])
 
-    dsk[(final_name, 0)] = (_bincount_sum, list(dsk), dtype)
-    graph = HighLevelGraph.from_collections(
-        final_name, dsk, dependencies=[x] if weights is None else [x, weights]
+    chunked_counts = blockwise(
+        partial(np.bincount, minlength=minlength), "i", *args, token=token, meta=meta
     )
 
-    if minlength == 0:
-        chunks = ((np.nan,),)
-    else:
-        chunks = ((minlength,),)
+    from .reductions import _tree_reduce
 
-    meta = meta_from_array(x, 1, dtype=dtype)
-
-    return Array(graph, final_name, chunks, meta=meta)
+    output = _tree_reduce(
+        chunked_counts,
+        aggregate=partial(_bincount_agg, dtype=meta.dtype),
+        axis=(0,),
+        keepdims=False,
+        dtype=meta.dtype,
+        split_every=split_every,
+        concatenate=False,
+    )
+    output._meta = meta
+    return output
 
 
 @derived_from(np)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -535,10 +535,16 @@ def test_bincount():
     assert da.bincount(d, minlength=6).name == da.bincount(d, minlength=6).name
 
 
-def test_bincount_with_weights():
+@pytest.mark.parametrize(
+    "weights",
+    [
+        np.array([1, 2, 1, 0.5, 1], dtype=np.float32),
+        np.array([1, 2, 1, 0, 1], dtype=np.int32),
+    ],
+)
+def test_bincount_with_weights(weights):
     x = np.array([2, 1, 5, 2, 1])
     d = da.from_array(x, chunks=2)
-    weights = np.array([1, 2, 1, 0.5, 1])
 
     dweights = da.from_array(weights, chunks=2)
     e = da.bincount(d, weights=dweights, minlength=6)


### PR DESCRIPTION
- [x] Closes #4852
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

This implementation is not faster with this benchmark:

```py
import dask.array as da
import numpy as np

rng = np.random.RandomState(42)
x = rng.randint(5000, size=10_000_000)
x_da = da.from_array(x, chunks=300_000)
out = da.bincount(x_da)
```

```py
%%timeit
_ = out.compute()
```

### This PR

```
26.1 ms ± 2.06 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

### Master

```
21.2 ms ± 272 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Maybe there is not a benefit to tree reduction here?
