### PR TITLE
Fix handling of filter expressions in parquet pyarrow-dataset engine

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -246,7 +246,7 @@ def _collect_pyarrow_dataset_frags(
             ]
 
         # Append fragments to our "metadata" list
-        if ds_filters:
+        if ds_filters is not None:
             # If we have filters, we need to split the row groups to apply them.
             # If any row-groups are filtered out, we convert the remaining row-groups
             # to a NEW (filtered) fragment, and append the filtered fragment to our


### PR DESCRIPTION
On pyarrow master, we disallowed the "boolean evaluation" of Expression objects (see https://github.com/apache/arrow/pull/9352, because Python doesn't allow us to override the meaning of `not expr` or `expr1 and expr2`, those do not what one would expect from it. So better to raise an error similar to how numpy arrays raise). 

The main consequence is that you explicitly need to check `is not None` to check if the expression has a value.