### PR TITLE
Don't fail fast in CI

### DIFF
--- a/.github/workflows/ci-additional.yml
+++ b/.github/workflows/ci-additional.yml
@@ -55,7 +55,7 @@ jobs:
   imports:
     runs-on: "ubuntu-latest"
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.6", "3.7", "3.8"]


### PR DESCRIPTION
I've noticed [flaky test](https://github.com/dask/dask/labels/flaky%20test) failures, in particular `test_num_workers_config`, have been happening more recently. Should we temporarily turn fast failing off in CI to prevent other CI builds from being canceled? 

cc @jsignell @jacobtomlinson 