### PR TITLE
Properly convert `HighLevelGraph` in multiprocessing scheduler

### DIFF
--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -11,6 +11,7 @@ from . import config
 from .system import CPU_COUNT
 from .local import reraise, get_async  # TODO: get better get
 from .optimization import fuse, cull
+from .utils import ensure_dict
 
 
 def _reduce_method_descriptor(m):
@@ -199,6 +200,7 @@ def get(
         cleanup = False
 
     # Optimize Dask
+    dsk = ensure_dict(dsk)
     dsk2, dependencies = cull(dsk, keys)
     if optimize_graph:
         dsk3, dependencies = fuse(dsk2, keys, dependencies)

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -200,6 +200,7 @@ def test_optimize_graph_false():
     assert len(keys) == 2
 
 
+@requires_cloudpickle
 def test_works_with_highlevel_graph():
     """Previously `dask.multiprocessing.get` would accidentally forward
     `HighLevelGraph` graphs through the dask optimization/scheduling routines,

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -200,6 +200,28 @@ def test_optimize_graph_false():
     assert len(keys) == 2
 
 
+def test_works_with_highlevel_graph():
+    """Previously `dask.multiprocessing.get` would accidentally forward
+    `HighLevelGraph` graphs through the dask optimization/scheduling routines,
+    resulting in odd errors. One way to trigger this was to have a
+    non-indexable object in a task. This is just a smoketest to ensure that
+    things work properly even if `HighLevelGraph` objects get passed to
+    `dask.multiprocessing.get`. See https://github.com/dask/dask/issues/7190.
+    """
+
+    class NoIndex:
+        def __init__(self, x):
+            self.x = x
+
+        def __getitem__(self, key):
+            raise Exception("Oh no!")
+
+    x = delayed(lambda x: x)(NoIndex(1))
+    (res,) = get(x.dask, x.__dask_keys__())
+    assert isinstance(res, NoIndex)
+    assert res.x == 1
+
+
 @requires_cloudpickle
 @pytest.mark.parametrize("random", ["numpy", "random"])
 def test_random_seeds(random):


### PR DESCRIPTION
Previously `dask.multiprocessing.get` would accidentally forward
`HighLevelGraph` objects through the dask optimization routines,
resulting in odd errors in the multiprocessing scheduler. We now
properly convert all dask graphs in the scheduler to dicts before
passing off to the optimization routines. This only affects the
multiprocessing scheduler, as it's the only one that manually calls
optimization routines - the other schedulers pass things off to
`get_async` which handles this conversion already.

Fixes #7190.