### PR TITLE
Fix parquet filtering bug for "pyarrow-dataset" with pyarrow-3.0.0

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1293,7 +1293,7 @@ class ArrowDatasetEngine(Engine):
         file_row_group_stats = defaultdict(list)
         file_row_group_column_stats = defaultdict(list)
         cmax_last = {}
-        for (frag, row_group_info) in metadata:
+        for i, (frag, row_group_info) in enumerate(metadata):
             fpath = frag.path
             # Note that we include an optional `row_group_info` list
             # in each element of `metadata` to avoid the need to
@@ -1308,7 +1308,11 @@ class ArrowDatasetEngine(Engine):
                 if row_group_info is None:
                     frag.ensure_complete_metadata()
                     row_group_info = frag.row_groups
-                frag_map[(fpath, row_group_info[0].id)] = frag
+                if len(row_group_info):
+                    frag_map[(fpath, row_group_info[0].id)] = frag
+                else:
+                    # All row-groups were filtered.
+                    continue
             else:
                 file_row_groups[fpath] = [None]
                 frag_map[(fpath, None)] = frag

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1311,7 +1311,7 @@ class ArrowDatasetEngine(Engine):
                 if len(row_group_info):
                     frag_map[(fpath, row_group_info[0].id)] = frag
                 else:
-                    # All row-groups were filtered.
+                    # All row-groups were filtered
                     continue
             else:
                 file_row_groups[fpath] = [None]

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1293,7 +1293,7 @@ class ArrowDatasetEngine(Engine):
         file_row_group_stats = defaultdict(list)
         file_row_group_column_stats = defaultdict(list)
         cmax_last = {}
-        for i, (frag, row_group_info) in enumerate(metadata):
+        for (frag, row_group_info) in metadata:
             fpath = frag.path
             # Note that we include an optional `row_group_info` list
             # in each element of `metadata` to avoid the need to

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3034,6 +3034,41 @@ def test_pyarrow_dataset_read_from_paths(
         assert_eq(ddf[ddf["b"] == "a"].compute(), read_df.compute())
     else:
         assert_eq(ddf, read_df)
+    
+
+@pytest.mark.parametrize("split_row_groups", [True, False])
+def test_pyarrow_dataset_filter_partitioned(tmpdir, split_row_groups):
+    check_pyarrow()
+
+    if pa.__version__ < LooseVersion("1.0.0"):
+        # pyarrow.dataset API required.
+        pytest.skip("PyArrow>=1.0.0 Required.")
+
+    fn = str(tmpdir)
+    df = pd.DataFrame(
+        {
+            "a": [4, 5, 6],
+            "b": ["a", "b", "b"],
+            "c": ["A", "B", "B"],
+        }
+    )
+    df["b"] = df["b"].astype("category")
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf.to_parquet(fn, engine="pyarrow", partition_on=["b", "c"])
+
+    # Filter on a a non-partition column
+    read_df = dd.read_parquet(
+        fn,
+        engine="pyarrow-dataset",
+        split_row_groups=split_row_groups,
+        filters=[("a", "==", 5)],
+    )
+
+    assert_eq(
+        read_df.compute()[["a"]],
+        df[df["a"] == 5][["a"]],
+        check_index=False,
+    )
 
 
 def test_parquet_pyarrow_write_empty_metadata(tmpdir):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3034,7 +3034,7 @@ def test_pyarrow_dataset_read_from_paths(
         assert_eq(ddf[ddf["b"] == "a"].compute(), read_df.compute())
     else:
         assert_eq(ddf, read_df)
-    
+
 
 @pytest.mark.parametrize("split_row_groups", [True, False])
 def test_pyarrow_dataset_filter_partitioned(tmpdir, split_row_groups):
@@ -3063,7 +3063,6 @@ def test_pyarrow_dataset_filter_partitioned(tmpdir, split_row_groups):
         split_row_groups=split_row_groups,
         filters=[("a", "==", 5)],
     )
-
     assert_eq(
         read_df.compute()[["a"]],
         df[df["a"] == 5][["a"]],


### PR DESCRIPTION
Fixes the bug reported in [this 6376 comment](https://github.com/dask/dask/issues/6376#issuecomment-776107196).  The problem only shows up (with the latest pyarrow-3.0.0 release) when filtering a non-partitioned column with `split_row_groups=False`.
