### PR TITLE
Fix bugs in Blockwise and ShuffleLayer

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -325,6 +325,7 @@ class Blockwise(Layer):
             "func_future_args": func_future_args,
             "global_dependencies": global_dependencies,
             "indices": indices,
+            "is_list": [isinstance(x, list) for x in indices],
             "numblocks": self.numblocks,
             "concatenate": self.concatenate,
             "new_axes": self.new_axes,
@@ -337,11 +338,21 @@ class Blockwise(Layer):
 
     @classmethod
     def __dask_distributed_unpack__(cls, state, dsk, dependencies, annotations):
+
+        # Make sure we convert list items back from tuples in `indices`.
+        # The msgpack serialization will have converted lists into
+        # tuples, and tuples may be stringified during graph
+        # materialization (bad if the item was not a key).
+        indices = [
+            list(ind) if is_list else ind
+            for ind, is_list in zip(state["indices"], state["is_list"])
+        ]
+
         raw, raw_deps = make_blockwise_graph(
             state["func"],
             state["output"],
             state["output_indices"],
-            *state["indices"],
+            *indices,
             new_axes=state["new_axes"],
             numblocks=state["numblocks"],
             concatenate=state["concatenate"],

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -354,7 +354,6 @@ class ShuffleLayer(SimpleShuffleLayer):
         Does not require graph materialization.
         """
         deps = defaultdict(set)
-        shuffle_group_name = "group-" + self.name
         parts_out = parts_out or self._keys_to_parts(keys)
         inp_part_map = {inp: i for i, inp in enumerate(self.inputs)}
         for part in parts_out:
@@ -363,7 +362,7 @@ class ShuffleLayer(SimpleShuffleLayer):
                 _inp = insert(out, self.stage, k)
                 _part = inp_part_map[_inp]
                 if self.stage == 0 and _part >= self.npartitions_input:
-                    deps[(self.name, part)].add((shuffle_group_name, _inp, "empty"))
+                    deps[(self.name, part)].add(("group-" + self.name, _inp, "empty"))
                 else:
                     deps[(self.name, part)].add((self.name_input, _part))
         return deps
@@ -426,8 +425,6 @@ class ShuffleLayer(SimpleShuffleLayer):
                             dsk[input_key] = self.meta_input
                     else:
                         input_key = (self.name_input, _part)
-                    with open("debug.txt", "a") as f:
-                        f.write("self.name " + str(input_key) + "\n")
 
                     # Convert partition into dict of dataframe pieces
                     dsk[(shuffle_group_name, _inp)] = (

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -103,6 +103,8 @@ def test_fused_blockwise_dataframe_merge(c, fuse):
         ddfm = ddf1.merge(ddf2, on=["x"], how="left")
         ddfm.head()  # https://github.com/dask/dask/issues/7178
         dfm = ddfm.compute().sort_values("x")
+        # We call compute above since `sort_values` is not
+        # supported in `dask.dataframe`
     dd.utils.assert_eq(
         dfm, df1.merge(df2, on=["x"], how="left").sort_values("x"), check_index=False
     )


### PR DESCRIPTION
Fixes two `HighLevelGraph` bugs and adds test coverage in `test_distributed.py::test_fused_blockwise_dataframe_merge`:

1. `ShuffleLayer._cull_dependencies` bug (resulting in #7178)
2. `Blockwise` serialization bug (list arguments were being coverted to tuples by `msgpack`, and then accidentally stringified)

- [x] Closes #7178
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
