### PR TITLE
comment fixes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -298,7 +298,7 @@ def dotmany(A, B, leftfunc=None, rightfunc=None, **kwargs):
 
 
 def _concatenate2(arrays, axes=[]):
-    """Recursively Concatenate nested lists of arrays along axes
+    """Recursively concatenate nested lists of arrays along axes
 
     Each entry in axes corresponds to each level of the nested list.  The
     length of axes should correspond to the level of nesting of arrays.
@@ -3464,7 +3464,7 @@ def common_blockdim(blockdims):
 
     if np.isnan(sum(map(sum, blockdims))):
         raise ValueError(
-            "Arrays chunk sizes (%s) are unknown.\n\n"
+            "Arrays' chunk sizes (%s) are unknown.\n\n"
             "A possible solution:\n"
             "  x.compute_chunk_sizes()" % blockdims
         )

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3707,7 +3707,6 @@ class DataFrame(_Frame):
             return new_dd_object(graph, name, meta, self.divisions)
         if isinstance(key, Series):
             # do not perform dummy calculation, as columns will not be changed.
-            #
             if self.divisions != key.divisions:
                 from .multi import _maybe_align_partitions
 

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -118,7 +118,7 @@ class _LocIndexer(_IndexerBase):
                 return self._loc_element(iindexer, cindexer)
         else:
             if isinstance(iindexer, (list, np.ndarray)):
-                # applying map_pattition to each partitions
+                # applying map_partitions to each partition
                 # results in duplicated NaN rows
                 msg = "Cannot index with list against unknown division"
                 raise KeyError(msg)

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -286,8 +286,8 @@ class FastParquetEngine(Engine):
         index_cols,
         filters,
     ):
-        # Cannot gather_statistics if our `parts` is alreadey a list
-        # of paths, or if we are building a multiindex (for now).
+        # Cannot gather_statistics if our `parts` is already a list
+        # of paths, or if we are building a multi-index (for now).
         # We also don't "need" to gather statistics if we don't
         # want to apply any filters or calculate divisions.
         if (

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -313,8 +313,8 @@ def test_columns_auto_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=write_engine)
 
-    # XFAIL, auto index selection not longer supported (for simplicity)
-    # ### Emtpy columns ###
+    # XFAIL, auto index selection no longer supported (for simplicity)
+    # ### Empty columns ###
     # With divisions if supported
     assert_eq(dd.read_parquet(fn, columns=[], engine=read_engine), ddf[[]])
 
@@ -344,7 +344,7 @@ def test_columns_index(tmpdir, write_engine, read_engine):
 
     # With Index
     # ----------
-    # ### Emtpy columns, specify index ###
+    # ### Empty columns, specify index ###
     # With divisions if supported
     assert_eq(
         dd.read_parquet(fn, columns=[], engine=read_engine, index="myindex"), ddf[[]]
@@ -2912,7 +2912,7 @@ def test_multi_partition_none_index_false(tmpdir, engine):
         assert engine == "fastparquet"
         write_engine = "fastparquet"
 
-    # Write dataset without dast.to_parquet
+    # Write dataset without dask.to_parquet
     ddf1 = ddf.reset_index(drop=True)
     for i, part in enumerate(ddf1.partitions):
         path = tmpdir.join(f"test.{i}.parquet")

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -1218,7 +1218,7 @@ def get_overlap(df, index):
 
 
 def fix_overlap(ddf, overlap):
-    """ Ensures that the upper bound on each partition of ddf is exclusive """
+    """ Ensures that the upper bound on each partition of ddf (except the last) is exclusive """
     name = "fix-overlap-" + tokenize(ddf, overlap)
     n = len(ddf.divisions) - 1
     dsk = {(name, i): (ddf._name, i) for i in range(n)}
@@ -1237,8 +1237,8 @@ def fix_overlap(ddf, overlap):
 
         # We do not want to move "overlap" from the previous partition (i-1) into
         # this partition (i) if the data from this partition will need to be moved
-        # to the next partitition (i+1) anyway.  If we concatenate data too early,
-        # we may loose rows (https://github.com/dask/dask/issues/6972).
+        # to the next partition (i+1) anyway.  If we concatenate data too early,
+        # we may lose rows (https://github.com/dask/dask/issues/6972).
         if i == ddf.npartitions - 2 or ddf.divisions[i] != ddf.divisions[i + 1]:
             frames.append((ddf._name, i))
             dsk[(name, i)] = (methods.concat, frames)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4460,7 +4460,7 @@ def test_attrs_series_in_dataframes():
     ddf = dd.from_pandas(df, 2)
 
     # Fails because the pandas iloc method doesn't currently persist
-    # the attrs dict for series in a dataframee. Dask uses df.iloc[:0]
+    # the attrs dict for series in a dataframe. Dask uses df.iloc[:0]
     # when creating the _meta dataframe in make_meta_pandas(x, index=None).
     # Should start xpassing when df.iloc works. Remove the xfail then.
     assert df.A.attrs == ddf.A.attrs

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -593,7 +593,7 @@ class HighLevelGraph(Mapping):
         layer : Mapping
             The graph layer itself
         dependencies : List of Dask collections
-            A lit of other dask collections (like arrays or dataframes) that
+            A list of other dask collections (like arrays or dataframes) that
             have graphs themselves
 
         Examples


### PR DESCRIPTION
- [x] ~Tests added / passed~ (N/A)
- [x] Passes `black dask` / `flake8 dask`

Factored out of #6661 (DDF.iloc).