### PR TITLE
Use html_css_files in docs for custom CSS

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -358,9 +358,7 @@ redirect_template = """\
 </html>
 """
 
-html_context = {
-    "css_files": ["_static/theme_overrides.css"]  # override wide tables in RTD theme
-}
+html_css_files = ["_static/theme_overrides.css"]  # override wide tables in RTD theme
 
 # Rate limiting issue for github: https://github.com/sphinx-doc/sphinx/issues/7388
 linkcheck_ignore = [


### PR DESCRIPTION
There was an update in the recent Sphinx 3.5.0 release which caused our documentation to fail to build due to our use of `html_context`. This PR switches to using `html_css_files` instead (xref https://github.com/sphinx-doc/sphinx/issues/8885#issuecomment-779272887) which should work with both earlier versions of Sphinx as well as 3.5.0. 

Closes https://github.com/dask/dask/issues/7216. Alternative to https://github.com/dask/dask/pull/7217. 