### PR TITLE
Don't allow setting `.name` for array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4443,7 +4443,7 @@ def handle_out(out, result):
         out._chunks = result.chunks
         out.dask = result.dask
         out._meta = result._meta
-        out.name = result.name
+        out._name = result.name
     elif out is not None:
         msg = (
             "The out parameter is not fully supported."

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1125,7 +1125,7 @@ class Array(DaskMethodsMixin):
     dask.array.from_array
     """
 
-    __slots__ = "dask", "_name", "_cached_keys", "__chunks", "_meta", "__dict__"
+    __slots__ = "dask", "__name", "_cached_keys", "__chunks", "_meta", "__dict__"
 
     def __new__(cls, dask, name, chunks, dtype=None, meta=None, shape=None):
         self = super(Array, cls).__new__(cls)
@@ -1133,7 +1133,7 @@ class Array(DaskMethodsMixin):
         if not isinstance(dask, HighLevelGraph):
             dask = HighLevelGraph.from_collections(name, dask, dependencies=())
         self.dask = dask
-        self.name = str(name)
+        self._name = str(name)
         meta = meta_from_array(meta, dtype=dtype)
 
         if (
@@ -1454,14 +1454,27 @@ class Array(DaskMethodsMixin):
         return self.dtype.itemsize
 
     @property
+    def _name(self):
+        return self.__name
+
+    @_name.setter
+    def _name(self, val):
+        self.__name = val
+        # Clear the key cache when the name is reset
+        self._cached_keys = None
+
+    @property
     def name(self):
-        return self._name
+        return self.__name
 
     @name.setter
     def name(self, val):
-        self._name = val
-        # Clear the key cache when the name is reset
-        self._cached_keys = None
+        raise TypeError(
+            "Cannot set name directly\n\n"
+            "Name is used to relate the array to the task graph.\n"
+            "It is uncommon to need to change it, but if you do\n"
+            "please set ``._name``"
+        )
 
     __array_priority__ = 11  # higher than numpy.ndarray and numpy.matrix
 
@@ -1648,7 +1661,7 @@ class Array(DaskMethodsMixin):
                 ) from e
             self._meta = y._meta
             self.dask = y.dask
-            self.name = y.name
+            self._name = y.name
             self._chunks = y.chunks
             return self
 
@@ -1766,7 +1779,7 @@ class Array(DaskMethodsMixin):
 
         self._meta = y._meta
         self.dask = y.dask
-        self.name = y.name
+        self._name = y.name
         self._chunks = y.chunks
 
         return self

--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -254,7 +254,7 @@ def set_fill_value(a, fill_value):
     fill_value = np.ma.core._check_fill_value(fill_value, a.dtype)
     res = a.map_blocks(_set_fill_value, fill_value)
     a.dask = res.dask
-    a.name = res.name
+    a._name = res.name
 
 
 @derived_from(np.ma)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -284,7 +284,7 @@ def test_keys():
     assert dx.__dask_keys__() is dx.__dask_keys__()
     # Test mutating names clears key cache
     dx.dask = {("y", i, j): () for i in range(5) for j in range(6)}
-    dx.name = "y"
+    dx._name = "y"
     assert dx.__dask_keys__() == [[(dx.name, i, j) for j in range(6)] for i in range(5)]
     d = Array({}, "x", (), shape=(), dtype="f8")
     assert d.__dask_keys__() == [("x",)]


### PR DESCRIPTION
This addresses the confusion in #7218 without getting rid of `.name` or adding any `rename` functionality.