### PR TITLE
map_overlap: Don't rechunk axes without overlap

### DIFF
--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -817,9 +817,7 @@ def coerce_depth(ndim, depth):
     if isinstance(depth, tuple):
         depth = dict(zip(range(ndim), depth))
     if isinstance(depth, dict):
-        for i in range(ndim):
-            if i not in depth:
-                depth[i] = 0
+        depth = {ax: depth.get(ax, default) for ax in range(ndim)}
     return coerce_depth_type(ndim, depth)
 
 
@@ -841,7 +839,5 @@ def coerce_boundary(ndim, boundary):
     if isinstance(boundary, tuple):
         boundary = dict(zip(range(ndim), boundary))
     if isinstance(boundary, dict):
-        for i in range(ndim):
-            if i not in boundary:
-                boundary[i] = default
+        boundary = {ax: boundary.get(ax, default) for ax in range(ndim)}
     return boundary

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -302,6 +302,10 @@ def test_map_overlap():
     assert all([(type(s) is int) for s in y.shape])
     assert_eq(y, np.arange(10) + 5 + 2 + 2)
 
+    x = da.ones((10, 10), chunks=(3, 4))
+    z = x.map_overlap(lambda x: x, depth={1: 5})
+    assert z.chunks[0] == x.chunks[0]  # don't rechunk the first dimension
+
     x = np.arange(16).reshape((4, 4))
     d = da.from_array(x, chunks=(2, 2))
     exp1 = d.map_overlap(lambda x: x + x.size, depth=1, dtype=d.dtype)


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
