### PR TITLE
Add Series.dot method to dataframe module

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2582,7 +2582,7 @@ Dask Name: {name}, {task} tasks"""
     @derived_from(pd.Series)
     def dot(self, other, meta=no_default):
         if not isinstance(other, _Frame):
-            raise TypeError("The second operand must be dask array / dask dataframe")
+            raise TypeError("The second operand must be a dask array or dask dataframe")
 
         if isinstance(other, DataFrame):
             s = self.map_partitions(M.dot, other, token="dot", meta=meta)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2591,9 +2591,8 @@ Dask Name: {name}, {task} tasks"""
             )
 
         def _dot_series(*args, **kwargs):
-            # The return type will be a series in case `other` is a dataframe
-            # but a scalar value in case `other` is a series. Casting to a pandas series
-            # will normalize the expected return type's value for both cases
+            # .sum() is invoked on each partition before being applied to all
+            # partitions. The return type is expected to be a series, not a numpy object
             return pd.Series(M.dot(*args, **kwargs))
 
         return self.map_partitions(_dot_series, other, token="dot", meta=meta).sum(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2581,6 +2581,9 @@ Dask Name: {name}, {task} tasks"""
 
     @derived_from(pd.Series)
     def dot(self, other, meta=no_default):
+        if not isinstance(other, _Frame):
+            raise TypeError("The second operand must be dask array / dask dataframe")
+
         if isinstance(other, DataFrame):
             s = self.map_partitions(M.dot, other, token="dot", meta=meta)
             return s.groupby(by=s.index).apply(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2579,6 +2579,22 @@ Dask Name: {name}, {task} tasks"""
             [self, other], join="outer", interleave_partitions=interleave_partitions
         )
 
+    @derived_from(pd.Series)
+    def dot(self, other):
+        def _dot_series(*args, **kwargs):
+            # The return type will be a series in case `other` is a dataframe
+            # but a scalar value in case `other` is a series. Casting to a pandas series
+            # will normalize the expected return type's value for both cases
+            return pd.Series(M.dot(*args, **kwargs))
+
+        if isinstance(other, DataFrame):
+            s = self.map_partitions(M.dot, other, token="dot")
+            return s.groupby(by=s.index).apply(
+                lambda x: x.sum(skipna=False), meta=s._meta_nonempty
+            )
+
+        return self.map_partitions(_dot_series, other, token="dot").sum(skipna=False)
+
     @derived_from(pd.DataFrame)
     def align(self, other, join="outer", axis=None, fill_value=None):
         meta1, meta2 = _emulate(
@@ -5230,6 +5246,7 @@ def apply_concat_apply(
     npartitions = set(arg.npartitions for arg in dfs)
     if len(npartitions) > 1:
         raise ValueError("All arguments must have same number of partitions")
+
     npartitions = npartitions.pop()
 
     if split_every is None:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4556,20 +4556,20 @@ def test_dot():
     dask_df = dd.from_pandas(df, npartitions=1)
     dask_s2 = dd.from_pandas(s2, npartitions=1)
 
-    assert_eq(s1.dot(s2), dask_s1.dot(dask_s2).compute())
-    assert_eq(s1.dot(df), dask_s1.dot(dask_df).compute())
+    assert_eq(s1.dot(s2), dask_s1.dot(dask_s2))
+    assert_eq(s1.dot(df), dask_s1.dot(dask_df))
 
     # With partitions
     partitioned_s1 = dd.from_pandas(s1, npartitions=2)
     partitioned_df = dd.from_pandas(df, npartitions=2)
     partitioned_s2 = dd.from_pandas(s2, npartitions=2)
 
-    assert_eq(s1.dot(s2), partitioned_s1.dot(partitioned_s2).compute())
-    assert_eq(s1.dot(df), partitioned_s1.dot(partitioned_df).compute())
+    assert_eq(s1.dot(s2), partitioned_s1.dot(partitioned_s2))
+    assert_eq(s1.dot(df), partitioned_s1.dot(partitioned_df))
 
     # Test passing meta kwarg
     res = dask_s1.dot(dask_df, meta=pd.Series([1], name="test_series")).compute()
-    assert_eq(res.name, "test_series")
+    assert res.name == "test_series"
 
     # Test validation of second operand
     with pytest.raises(TypeError):
@@ -4577,6 +4577,7 @@ def test_dot():
 
 
 def test_dot_nan():
+    # Test that nan inputs match pandas' behavior
     s1 = pd.Series([1, 2, 3, 4])
     dask_s1 = dd.from_pandas(s1, npartitions=1)
 
@@ -4586,5 +4587,5 @@ def test_dot_nan():
     df = pd.DataFrame({"one": s1, "two": s2})
     dask_df = dd.from_pandas(df, npartitions=1)
 
-    assert np.isnan(dask_s1.dot(dask_s2).compute())
-    assert dask_s2.dot(dask_df).isnull().all().compute()
+    assert_eq(s1.dot(s2), dask_s1.dot(dask_s2))
+    assert_eq(s2.dot(df), dask_s2.dot(dask_df))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4571,6 +4571,10 @@ def test_dot():
     res = dask_s1.dot(dask_df, meta=pd.Series([1], name="test_series")).compute()
     assert_eq(res.name, "test_series")
 
+    # Test validation of second operand
+    with pytest.raises(TypeError):
+        dask_s1.dot(da.array([1, 2, 3, 4]))
+
 
 def test_dot_nan():
     s1 = pd.Series([1, 2, 3, 4])

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4567,6 +4567,10 @@ def test_dot():
     assert_eq(s1.dot(s2), partitioned_s1.dot(partitioned_s2).compute())
     assert_eq((s1.dot(df) == partitioned_s1.dot(partitioned_df).compute()).all(), True)
 
+    # Test passing meta kwarg
+    res = dask_s1.dot(dask_df, meta=pd.Series([1], name="test_series")).compute()
+    assert_eq(res.name, "test_series")
+
 
 def test_dot_nan():
     s1 = pd.Series([1, 2, 3, 4])

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4557,7 +4557,7 @@ def test_dot():
     dask_s2 = dd.from_pandas(s2, npartitions=1)
 
     assert_eq(s1.dot(s2), dask_s1.dot(dask_s2).compute())
-    assert_eq((s1.dot(df) == dask_s1.dot(dask_df).compute()).all(), True)
+    assert_eq(s1.dot(df), dask_s1.dot(dask_df).compute())
 
     # With partitions
     partitioned_s1 = dd.from_pandas(s1, npartitions=2)
@@ -4565,7 +4565,7 @@ def test_dot():
     partitioned_s2 = dd.from_pandas(s2, npartitions=2)
 
     assert_eq(s1.dot(s2), partitioned_s1.dot(partitioned_s2).compute())
-    assert_eq((s1.dot(df) == partitioned_s1.dot(partitioned_df).compute()).all(), True)
+    assert_eq(s1.dot(df), partitioned_s1.dot(partitioned_df).compute())
 
     # Test passing meta kwarg
     res = dask_s1.dot(dask_df, meta=pd.Series([1], name="test_series")).compute()
@@ -4586,5 +4586,5 @@ def test_dot_nan():
     df = pd.DataFrame({"one": s1, "two": s2})
     dask_df = dd.from_pandas(df, npartitions=1)
 
-    assert_eq(np.isnan(dask_s1.dot(dask_s2).compute()), True)
-    assert_eq(dask_s2.dot(dask_df).isnull().all().compute(), True)
+    assert np.isnan(dask_s1.dot(dask_s2).compute())
+    assert dask_s2.dot(dask_df).isnull().all().compute()


### PR DESCRIPTION
Ref: #1259

- [ ] Closes #1259
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

I had a few questions about how to attempt this so I am marking this `WIP`. 

1. Should I handle the case for dot product of a dask series and a dask array? I didn't do so because a lot of the underlying infrastructure (like the `_extract_meta` utility) assumed the operands were all either dask series or dask dataframes.
2. Should I implement this for dask dataframe as part of this PR too or can that be done separately?
3. Should the method accept a `meta` kwarg too, for the case when the other operand could be a dataframe?

Any other feedback on the code would really help, thanks in advance!