### PR TITLE
Avoid running unit tests during doctest CI build

### DIFF
--- a/.github/workflows/ci-additional.yml
+++ b/.github/workflows/ci-additional.yml
@@ -54,8 +54,6 @@ jobs:
 
   doctest:
     runs-on: "ubuntu-latest"
-    env:
-      XTRATESTARGS: "--doctest-modules --ignore-glob='*test_*.py'"
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -75,7 +73,7 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: source continuous_integration/scripts/run_tests.sh
+        run: pytest -v --doctest-modules --ignore-glob='*/test_*.py' dask
 
   imports:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
This PR is a follow up to https://github.com/dask/dask/pull/7238 to try and avoid running unit tests during our new doctest build (see https://github.com/dask/dask/runs/1920953522 for an example doctest build where we also end up running unit tests).

cc @jsignell 