### PR TITLE
Move numpy skip into test

### DIFF
--- a/.github/workflows/ci-additional.yml
+++ b/.github/workflows/ci-additional.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: ["mindeps-array-dataframe", "mindeps-bag-delayed"]
+        environment: ["mindeps-array-dataframe", "mindeps-bag-delayed", "mindeps-distributed"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-additional.yml
+++ b/.github/workflows/ci-additional.yml
@@ -7,9 +7,8 @@ jobs:
     runs-on: "ubuntu-latest"
 
     strategy:
-      fail-fast: false
       matrix:
-        environment: ["mindeps-array-dataframe", "mindeps-bag-delayed", "mindeps-distributed"]
+        environment: ["mindeps-array-dataframe", "mindeps-bag-delayed"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-additional.yml
+++ b/.github/workflows/ci-additional.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     strategy:
+      fail-fast: false
       matrix:
         environment: ["mindeps-array-dataframe", "mindeps-bag-delayed"]
 

--- a/conftest.py
+++ b/conftest.py
@@ -26,6 +26,11 @@ try:
 except ImportError:
     collect_ignore_glob.append("dask/dataframe/*")
 
+try:
+    import fsspec  # noqa: F401
+except ImportError:
+    collect_ignore_glob.extend(["dask/bag/*", "dask/bytes/*"])
+
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", help="run slow tests")

--- a/continuous_integration/environment-mindeps-distributed.yaml
+++ b/continuous_integration/environment-mindeps-distributed.yaml
@@ -1,0 +1,12 @@
+name: test-environment
+channels:
+  - conda-forge
+dependencies:
+  # required dependencies
+  - python=3.7
+  - pyyaml
+  # optional dependencies pulled in by pip install dask[distributed]
+  - distributed
+  # test dependencies
+  - pytest
+  - pytest-xdist

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -11,7 +11,6 @@ from tornado import gen
 
 import dask
 from dask import persist, delayed, compute
-from dask.array.numpy_compat import _numpy_120
 from dask.delayed import Delayed
 from dask.utils import tmpdir, get_named_args
 from distributed import futures_of
@@ -70,10 +69,15 @@ def test_persist_nested(c):
     assert res[2:] == (4, [5])
 
 
-@pytest.mark.skipif(_numpy_120, reason="https://github.com/dask/dask/issues/7170")
 def test_futures_to_delayed_dataframe(c):
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
+
+    from dask.array.numpy_compat import _numpy_120
+
+    if _numpy_120:
+        pytest.skip("https://github.com/dask/dask/issues/7170")
+
     df = pd.DataFrame({"x": [1, 2, 3]})
 
     futures = c.scatter([df, df])

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -151,6 +151,9 @@ def test_local_get_with_distributed_active(c, s, a, b):
 
 
 def test_to_hdf_distributed(c):
+    pytest.importorskip("numpy")
+    pytest.importorskip("pandas")
+
     from ..dataframe.io.tests.test_hdf import test_to_hdf
 
     test_to_hdf()
@@ -171,6 +174,9 @@ def test_to_hdf_distributed(c):
     ],
 )
 def test_to_hdf_scheduler_distributed(npartitions, c):
+    pytest.importorskip("numpy")
+    pytest.importorskip("pandas")
+
     from ..dataframe.io.tests.test_hdf import test_to_hdf_schedulers
 
     test_to_hdf_schedulers(None, npartitions)


### PR DESCRIPTION
It came up in https://github.com/dask/dask/issues/7170#issuecomment-780872128 that the skip should be inside the test in case numpy is not installed in the testing env.