### PR TITLE
Ensure natural sort order in parquet part paths

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -951,7 +951,7 @@ class ArrowDatasetEngine(Engine):
 
             # Use _analyze_paths to avoid relative-path
             # problems (see GH#5608)
-            base, fns = _analyze_paths(paths, fs)
+            paths, base, fns = _analyze_paths(paths, fs)
             paths = fs.sep.join([base, fns[0]])
 
             meta_path = fs.sep.join([paths, "_metadata"])
@@ -968,7 +968,7 @@ class ArrowDatasetEngine(Engine):
                 if gather_statistics is None:
                     gather_statistics = True
         elif len(paths) > 1:
-            base, fns = _analyze_paths(paths, fs)
+            paths, base, fns = _analyze_paths(paths, fs)
             meta_path = fs.sep.join([base, "_metadata"])
             if "_metadata" in fns:
                 # Pyarrow cannot handle "_metadata" when `paths` is a list
@@ -1611,7 +1611,7 @@ def _get_dataset_object(paths, fs, filters, dataset_kwargs):
         kwargs["validate_schema"] = False
     if len(paths) > 1:
         # This is a list of files
-        base, fns = _analyze_paths(paths, fs)
+        paths, base, fns = _analyze_paths(paths, fs)
         proxy_metadata = None
         if "_metadata" in fns:
             # We have a _metadata file. PyArrow cannot handle
@@ -1636,7 +1636,7 @@ def _get_dataset_object(paths, fs, filters, dataset_kwargs):
         #       existence of _metadata.  Listing may be much more
         #       expensive in storage systems like S3.
         allpaths = fs.glob(paths[0] + fs.sep + "*")
-        base, fns = _analyze_paths(allpaths, fs)
+        allpaths, base, fns = _analyze_paths(allpaths, fs)
         dataset = pq.ParquetDataset(paths[0], filesystem=fs, filters=filters, **kwargs)
     else:
         # This is a single file.  No danger in gathering statistics

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -23,6 +23,7 @@ from .utils import (
     _analyze_paths,
     _flatten_filters,
     _row_groups_to_parts,
+    _sort_and_analyze_paths,
 )
 
 
@@ -968,8 +969,7 @@ class ArrowDatasetEngine(Engine):
                 if gather_statistics is None:
                     gather_statistics = True
         elif len(paths) > 1:
-            paths = sorted(paths, key=natural_sort_key)
-            base, fns = _analyze_paths(paths, fs)
+            paths, base, fns = _sort_and_analyze_paths(paths, fs)
             meta_path = fs.sep.join([base, "_metadata"])
             if "_metadata" in fns:
                 # Pyarrow cannot handle "_metadata" when `paths` is a list
@@ -1612,8 +1612,7 @@ def _get_dataset_object(paths, fs, filters, dataset_kwargs):
         kwargs["validate_schema"] = False
     if len(paths) > 1:
         # This is a list of files
-        paths = sorted(paths, key=natural_sort_key)
-        base, fns = _analyze_paths(paths, fs)
+        paths, base, fns = _sort_and_analyze_paths(paths, fs)
         proxy_metadata = None
         if "_metadata" in fns:
             # We have a _metadata file. PyArrow cannot handle
@@ -1639,7 +1638,7 @@ def _get_dataset_object(paths, fs, filters, dataset_kwargs):
         #       expensive in storage systems like S3.
         allpaths = fs.glob(paths[0] + fs.sep + "*")
         allpaths = sorted(allpaths, key=natural_sort_key)
-        base, fns = _analyze_paths(allpaths, fs)
+        _, base, fns = _sort_and_analyze_paths(allpaths, fs)
         dataset = pq.ParquetDataset(paths[0], filesystem=fs, filters=filters, **kwargs)
     else:
         # This is a single file.  No danger in gathering statistics

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -951,7 +951,7 @@ class ArrowDatasetEngine(Engine):
 
             # Use _analyze_paths to avoid relative-path
             # problems (see GH#5608)
-            paths, base, fns = _analyze_paths(paths, fs)
+            base, fns = _analyze_paths(paths, fs)
             paths = fs.sep.join([base, fns[0]])
 
             meta_path = fs.sep.join([paths, "_metadata"])
@@ -968,7 +968,8 @@ class ArrowDatasetEngine(Engine):
                 if gather_statistics is None:
                     gather_statistics = True
         elif len(paths) > 1:
-            paths, base, fns = _analyze_paths(paths, fs)
+            paths = sorted(paths, key=natural_sort_key)
+            base, fns = _analyze_paths(paths, fs)
             meta_path = fs.sep.join([base, "_metadata"])
             if "_metadata" in fns:
                 # Pyarrow cannot handle "_metadata" when `paths` is a list
@@ -1611,7 +1612,8 @@ def _get_dataset_object(paths, fs, filters, dataset_kwargs):
         kwargs["validate_schema"] = False
     if len(paths) > 1:
         # This is a list of files
-        paths, base, fns = _analyze_paths(paths, fs)
+        paths = sorted(paths, key=natural_sort_key)
+        base, fns = _analyze_paths(paths, fs)
         proxy_metadata = None
         if "_metadata" in fns:
             # We have a _metadata file. PyArrow cannot handle
@@ -1636,7 +1638,8 @@ def _get_dataset_object(paths, fs, filters, dataset_kwargs):
         #       existence of _metadata.  Listing may be much more
         #       expensive in storage systems like S3.
         allpaths = fs.glob(paths[0] + fs.sep + "*")
-        allpaths, base, fns = _analyze_paths(allpaths, fs)
+        allpaths = sorted(allpaths, key=natural_sort_key)
+        base, fns = _analyze_paths(allpaths, fs)
         dataset = pq.ParquetDataset(paths[0], filesystem=fs, filters=filters, **kwargs)
     else:
         # This is a single file.  No danger in gathering statistics

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -20,7 +20,6 @@ from .utils import (
     _parse_pandas_metadata,
     _normalize_index_columns,
     Engine,
-    _analyze_paths,
     _flatten_filters,
     _row_groups_to_parts,
     _sort_and_analyze_paths,
@@ -952,7 +951,7 @@ class ArrowDatasetEngine(Engine):
 
             # Use _analyze_paths to avoid relative-path
             # problems (see GH#5608)
-            base, fns = _analyze_paths(paths, fs)
+            paths, base, fns = _sort_and_analyze_paths(paths, fs)
             paths = fs.sep.join([base, fns[0]])
 
             meta_path = fs.sep.join([paths, "_metadata"])
@@ -1637,8 +1636,7 @@ def _get_dataset_object(paths, fs, filters, dataset_kwargs):
         #       existence of _metadata.  Listing may be much more
         #       expensive in storage systems like S3.
         allpaths = fs.glob(paths[0] + fs.sep + "*")
-        allpaths = sorted(allpaths, key=natural_sort_key)
-        _, base, fns = _sort_and_analyze_paths(allpaths, fs)
+        allpaths, base, fns = _sort_and_analyze_paths(allpaths, fs)
         dataset = pq.ParquetDataset(paths[0], filesystem=fs, filters=filters, **kwargs)
     else:
         # This is a single file.  No danger in gathering statistics

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -749,7 +749,7 @@ def create_metadata_file(
         )
     paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
     ap_kwargs = {"root": root_dir} if root_dir else {}
-    root_dir, fns = _analyze_paths(paths, fs, **ap_kwargs)
+    paths, root_dir, fns = _analyze_paths(paths, fs, **ap_kwargs)
     out_dir = root_dir if out_dir is None else out_dir
 
     # Start constructing a raw graph

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -747,7 +747,6 @@ def create_metadata_file(
         fs, _, paths = get_fs_token_paths(
             paths, mode="rb", storage_options=storage_options
         )
-    paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
     ap_kwargs = {"root": root_dir} if root_dir else {}
     paths, root_dir, fns = _sort_and_analyze_paths(paths, fs, **ap_kwargs)
     out_dir = root_dir if out_dir is None else out_dir

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -7,7 +7,7 @@ from fsspec.core import get_fs_token_paths
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.utils import stringify_path
 
-from .utils import _analyze_paths
+from .utils import _sort_and_analyze_paths
 from ...core import DataFrame, new_dd_object
 from ....base import tokenize
 from ....delayed import Delayed
@@ -749,7 +749,7 @@ def create_metadata_file(
         )
     paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
     ap_kwargs = {"root": root_dir} if root_dir else {}
-    root_dir, fns = _analyze_paths(paths, fs, **ap_kwargs)
+    paths, root_dir, fns = _sort_and_analyze_paths(paths, fs, **ap_kwargs)
     out_dir = root_dir if out_dir is None else out_dir
 
     # Start constructing a raw graph

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -749,7 +749,7 @@ def create_metadata_file(
         )
     paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
     ap_kwargs = {"root": root_dir} if root_dir else {}
-    paths, root_dir, fns = _analyze_paths(paths, fs, **ap_kwargs)
+    root_dir, fns = _analyze_paths(paths, fs, **ap_kwargs)
     out_dir = root_dir if out_dir is None else out_dir
 
     # Start constructing a raw graph

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -24,13 +24,12 @@ except ImportError:
 from .utils import (
     _parse_pandas_metadata,
     _normalize_index_columns,
-    _analyze_paths,
     _flatten_filters,
     _row_groups_to_parts,
+    _sort_and_analyze_paths,
 )
 from ..utils import _meta_from_dtypes
 from ...utils import UNKNOWN_CATEGORIES
-from ....utils import natural_sort_key
 from ...methods import concat
 
 
@@ -117,8 +116,7 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
     """
     parts = []
     if len(paths) > 1:
-        paths = sorted(paths, key=natural_sort_key)
-        base, fns = _analyze_paths(paths, fs)
+        paths, base, fns = _sort_and_analyze_paths(paths, fs)
         if gather_statistics is not False:
             # This scans all the files, allowing index/divisions
             # and filtering
@@ -149,8 +147,7 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
     elif fs.isdir(paths[0]):
         # This is a directory, check for _metadata, then _common_metadata
         paths = fs.glob(paths[0] + fs.sep + "*")
-        paths = sorted(paths, key=natural_sort_key)
-        base, fns = _analyze_paths(paths, fs)
+        paths, base, fns = _sort_and_analyze_paths(paths, fs)
         if "_metadata" in fns:
             # Using _metadata file (best-case scenario)
             pf = ParquetFile(

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -30,6 +30,7 @@ from .utils import (
 )
 from ..utils import _meta_from_dtypes
 from ...utils import UNKNOWN_CATEGORIES
+from ....utils import natural_sort_key
 from ...methods import concat
 
 
@@ -116,7 +117,8 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
     """
     parts = []
     if len(paths) > 1:
-        paths, base, fns = _analyze_paths(paths, fs)
+        paths = sorted(paths, key=natural_sort_key)
+        base, fns = _analyze_paths(paths, fs)
         if gather_statistics is not False:
             # This scans all the files, allowing index/divisions
             # and filtering
@@ -147,7 +149,8 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
     elif fs.isdir(paths[0]):
         # This is a directory, check for _metadata, then _common_metadata
         paths = fs.glob(paths[0] + fs.sep + "*")
-        paths, base, fns = _analyze_paths(paths, fs)
+        paths = sorted(paths, key=natural_sort_key)
+        base, fns = _analyze_paths(paths, fs)
         if "_metadata" in fns:
             # Using _metadata file (best-case scenario)
             pf = ParquetFile(

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -116,7 +116,7 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
     """
     parts = []
     if len(paths) > 1:
-        base, fns = _analyze_paths(paths, fs)
+        paths, base, fns = _analyze_paths(paths, fs)
         if gather_statistics is not False:
             # This scans all the files, allowing index/divisions
             # and filtering
@@ -147,7 +147,7 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
     elif fs.isdir(paths[0]):
         # This is a directory, check for _metadata, then _common_metadata
         paths = fs.glob(paths[0] + fs.sep + "*")
-        base, fns = _analyze_paths(paths, fs)
+        paths, base, fns = _analyze_paths(paths, fs)
         if "_metadata" in fns:
             # Using _metadata file (best-case scenario)
             pf = ParquetFile(

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -3,7 +3,6 @@ import re
 import pandas as pd
 
 from ....core import flatten
-from ....utils import natural_sort_key
 
 
 class Engine:
@@ -475,12 +474,7 @@ def _analyze_paths(file_list, fs, root=False):
             "/".join(path_parts[l:])
         )  # use '/'.join() instead of _join_path to be consistent with split('/')
 
-    # numeric rather than glob ordering
-    out_list = sorted(out_list, key=natural_sort_key)
-    file_list = sorted(file_list, key=natural_sort_key)
-
     return (
-        file_list,
         "/".join(basepath),
         out_list,
     )  # use '/'.join() instead of _join_path to be consistent with split('/')

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -3,6 +3,7 @@ import re
 import pandas as pd
 
 from ....core import flatten
+from ....utils import natural_sort_key
 
 
 class Engine:
@@ -474,7 +475,12 @@ def _analyze_paths(file_list, fs, root=False):
             "/".join(path_parts[l:])
         )  # use '/'.join() instead of _join_path to be consistent with split('/')
 
+    # numeric rather than glob ordering
+    out_list = sorted(out_list, key=natural_sort_key)
+    file_list = sorted(file_list, key=natural_sort_key)
+
     return (
+        file_list,
         "/".join(basepath),
         out_list,
     )  # use '/'.join() instead of _join_path to be consistent with split('/')

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -3,6 +3,7 @@ import re
 import pandas as pd
 
 from ....core import flatten
+from ....utils import natural_sort_key
 
 
 class Engine:
@@ -389,6 +390,12 @@ def _normalize_index_columns(user_columns, data_columns, user_index, data_index)
         index_names = data_index
 
     return column_names, index_names
+
+
+def _sort_and_analyze_paths(file_list, fs, root=False):
+    file_list = sorted(file_list, key=natural_sort_key)
+    base, fns = _analyze_paths(file_list, fs, root=root)
+    return file_list, base, fns
 
 
 def _analyze_paths(file_list, fs, root=False):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2241,6 +2241,25 @@ def test_read_dir_nometa(tmpdir, write_engine, read_engine, statistics, remove_c
 
     ddf2 = dd.read_parquet(tmp_path, engine=read_engine, gather_statistics=statistics)
     assert_eq(ddf, ddf2, check_divisions=False)
+    assert ddf.divisions == tuple(range(0, 420, 30))
+    if statistics is True and read_engine.startswith("pyarrow"):
+        assert ddf2.divisions == tuple(range(0, 420, 30))
+    else:
+        assert ddf2.divisions == (None,) * 14
+
+
+@write_read_engines()
+def test_statistics_nometa(tmpdir, write_engine, read_engine):
+    tmp_path = str(tmpdir)
+    ddf.to_parquet(tmp_path, engine=write_engine, write_metadata_file=False)
+
+    ddf2 = dd.read_parquet(tmp_path, engine=read_engine, gather_statistics=True)
+    assert_eq(ddf, ddf2, check_divisions=False)
+    assert ddf.divisions == tuple(range(0, 420, 30))
+    if read_engine == "fastparquet":
+        assert ddf2.divisions == (None,) * 14
+    else:
+        assert ddf2.divisions == tuple(range(0, 420, 30))
 
 
 @pytest.mark.parametrize("schema", ["infer", None])

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2242,10 +2242,10 @@ def test_read_dir_nometa(tmpdir, write_engine, read_engine, statistics, remove_c
     ddf2 = dd.read_parquet(tmp_path, engine=read_engine, gather_statistics=statistics)
     assert_eq(ddf, ddf2, check_divisions=False)
     assert ddf.divisions == tuple(range(0, 420, 30))
-    if statistics is True and read_engine.startswith("pyarrow"):
-        assert ddf2.divisions == tuple(range(0, 420, 30))
-    else:
+    if statistics is False or statistics is None and read_engine.startswith("pyarrow"):
         assert ddf2.divisions == (None,) * 14
+    else:
+        assert ddf2.divisions == tuple(range(0, 420, 30))
 
 
 @write_read_engines()
@@ -2254,12 +2254,9 @@ def test_statistics_nometa(tmpdir, write_engine, read_engine):
     ddf.to_parquet(tmp_path, engine=write_engine, write_metadata_file=False)
 
     ddf2 = dd.read_parquet(tmp_path, engine=read_engine, gather_statistics=True)
-    assert_eq(ddf, ddf2, check_divisions=False)
+    assert_eq(ddf, ddf2)
     assert ddf.divisions == tuple(range(0, 420, 30))
-    if read_engine == "fastparquet":
-        assert ddf2.divisions == (None,) * 14
-    else:
-        assert ddf2.divisions == tuple(range(0, 420, 30))
+    assert ddf2.divisions == tuple(range(0, 420, 30))
 
 
 @pytest.mark.parametrize("schema", ["infer", None])


### PR DESCRIPTION
- [x] Closes #7248
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
-----
- First commit adds some tests that verify the existing behavior (incl. missing `divisions`)
- Second commit fixes bug + updates tests