### PR TITLE
Pin to a particular black tag in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
       language_version: python3


### PR DESCRIPTION
I started getting warnings from pre-commit recently pointing me to https://pre-commit.com/#using-the-latest-version-for-a-repository
which recommends pinning to a tag.
