### PR TITLE
Fix performance issue in dask.graph_manipulation.wait_on()

### DIFF
--- a/dask/graph_manipulation.py
+++ b/dask/graph_manipulation.py
@@ -124,7 +124,7 @@ def _build_map_layer(
         except AttributeError:
             numblocks = (collection.npartitions,)
         indices = tuple(i for i, _ in enumerate(numblocks))
-        kwargs = {"_deps": dependencies} if dependencies else {}
+        kwargs = {"_deps": [d.key for d in dependencies]} if dependencies else {}
         prev_name = get_collection_name(collection)
         return blockwise(
             func,


### PR DESCRIPTION
wait_on() is affected by a severe performance degradation issue caused by an incorrect usage of blockwise().

To reproduce:

```bash
dask-worker localhost:8786 --nthreads 1 --nprocs 150 --memory-limit 370MiB
```
(you'll need 64 GiB RAM)

```python
import dask.array as da
import dask.graph_manipulation as gm
from distributed import Client

client = Client("localhost:8786")
%time gm.wait_on(da.random.random(150, chunks=1)).sum().compute()
%time gm.wait_on(da.random.random(150, chunks=1).persist()).sum().compute()
```
|  | master | this PR |
| :-- | --: | --: |
| without persist() | 1.62s | 587 ms |
| with persist() | 12.3s | 604 ms |