### PR TITLE
Improve documentation of `name` in from_array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3048,7 +3048,7 @@ def from_array(
     meta=None,
     inline_array=False,
 ):
-    """Create dask array from something that looks like an array
+    """Create dask array from something that looks like an array.
 
     Input must have a ``.shape``, ``.ndim``, ``.dtype`` and support numpy-style slicing.
 
@@ -3069,12 +3069,25 @@ def from_array(
 
         -1 or None as a blocksize indicate the size of the corresponding
         dimension.
-    name : str, optional
+    name : str or bool, optional
         The key name to use for the array. Defaults to a hash of ``x``.
-        By default, hash uses python's standard sha1. This behaviour can be
+
+        Hashing is useful if the same value of ``x`` is used to create multiple
+        arrays, as Dask can then recognise that they're the same and
+        avoid duplicate computations. However, it can also be slow, and if the
+        array is not contiguous it is copied for hashing. If the array uses
+        stride tricks (such as ``np.broadcast_to`` or
+        ``skimage.util.view_as_windows``) to have a larger logical
+        than physical size, this copy can cause excessive memory usage.
+
+        If you don't need the deduplication provided by hashing, use
+        ``name=False`` to generate a random name instead of hashing, which
+        avoids the pitfalls described above. Using ``name=True`` is
+        equivalent to the default.
+
+        By default, hashing uses python's standard sha1. This behaviour can be
         changed by installing cityhash, xxhash or murmurhash. If installed,
         a large-factor speedup can be obtained in the tokenisation step.
-        Use ``name=False`` to generate a random name instead of hashing (fast)
 
         .. note::
 
@@ -3130,10 +3143,10 @@ def from_array(
         Note that there's no key in the task graph with just the array `x`
         anymore. Instead it's placed directly in the values.
 
-        The right choice for ``inline_arary`` depends on several factors,
+        The right choice for ``inline_array`` depends on several factors,
         including the size of ``x``, how expensive it is to create, which
         scheduler you're using, and the pattern of downstream computations.
-        As a hueristic, ``inline_array=True`` may be the right choice when
+        As a heuristic, ``inline_array=True`` may be the right choice when
         the array ``x`` is cheap to serialize and deserialize (since it's
         included in the graph many times) and if you're experiencing ordering
         issues (see :ref:`order` for more).


### PR DESCRIPTION
This attempts to explain what the advantages and disadvantages of
`name=False`, and more strongly encourage its use. Motivated by #7208.

I also fixed some typos along the way.

[skipci]

- [x] Passes `black dask` / `flake8 dask`
