### PR TITLE
HighLevelGraph length without materializing layers

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -270,20 +270,13 @@ class Blockwise(Layer):
     def __iter__(self):
         return iter(self._dict)
 
-    def __len__(self):
-        return int(prod(self._out_numblocks().values()))
-
-    def _out_numblocks(self):
-        d = {}
-        out_d = {}
-        indices = {k: v for k, v in self.indices if v is not None}
-        for k, v in self.numblocks.items():
-            for a, b in zip(indices[k], v):
-                d[a] = max(d.get(a, 0), b)
-                if a in self.output_indices:
-                    out_d[a] = d[a]
-
-        return out_d
+    def __len__(self) -> int:
+        # same method as `get_output_keys`, without manifesting the keys themselves
+        return (
+            len(self.output_blocks)
+            if self.output_blocks
+            else int(prod(self.dims[i] for i in self.output_indices))
+        )
 
     def is_materialized(self):
         return hasattr(self, "_cached_dict")

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -275,7 +275,7 @@ class Blockwise(Layer):
         return (
             len(self.output_blocks)
             if self.output_blocks
-            else int(prod(self.dims[i] for i in self.output_indices))
+            else prod(self.dims[i] for i in self.output_indices)
         )
 
     def is_materialized(self):

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -659,8 +659,8 @@ class HighLevelGraph(Mapping):
 
         raise KeyError(key)
 
-    def __len__(self):
-        return len(self.to_dict())
+    def __len__(self) -> int:
+        return sum(len(layer) for layer in self.layers.values())
 
     def __iter__(self):
         return iter(self.to_dict())

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -660,6 +660,11 @@ class HighLevelGraph(Mapping):
         raise KeyError(key)
 
     def __len__(self) -> int:
+        # NOTE: this will double-count keys that are duplicated between layers, so it's
+        # possible that `len(hlg) > len(hlg.to_dict())`. However, duplicate keys should
+        # not occur through normal use, and their existence would usually be a bug.
+        # So we ignore this case in favor of better performance.
+        # https://github.com/dask/dask/issues/7271
         return sum(len(layer) for layer in self.layers.values())
 
     def __iter__(self):

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -1,3 +1,4 @@
+from dask.blockwise import Blockwise, blockwise_token
 import os
 from collections.abc import Set
 
@@ -187,3 +188,27 @@ def test_highlevelgraph_dicts_deprecation():
         layers = {"a": MaterializedLayer({"x": 1, "y": (inc, "x")})}
         hg = HighLevelGraph(layers, {"a": set()})
         assert hg.dicts == layers
+
+
+def test_len_does_not_materialize():
+    a = {"x": 1}
+    b = Blockwise(
+        output="b",
+        output_indices=tuple("ij"),
+        dsk={"b": [[blockwise_token(0)]]},
+        indices=(),
+        numblocks={},
+        new_axes={"i": (1, 1, 1), "j": (1, 1)},
+    )
+    assert len(b) == len(b.get_output_keys())
+
+    layers = {"a": a, "b": b}
+    dependencies = {"a": set(), "b": {"a"}}
+    hg = HighLevelGraph(layers, dependencies)
+
+    assert hg.layers["a"].is_materialized()
+    assert not hg.layers["b"].is_materialized()
+
+    assert len(hg) == len(a) + len(b) == 7
+
+    assert not hg.layers["b"].is_materialized()


### PR DESCRIPTION
Calculate the `__len__` of a HighLevelGraph from the sum of the legths of its layers, instead of `len(self.to_dict())`. This is much faster and prevents causing all the layers to materialize.

I also changed the `__len__` implementation on `Blockwise`. It was using `_out_numblocks`, which is unused anywhere else in the codebase, and a bit hard to read. As far as I could tell, `_out_numblocks` was equivalent to `{i: self.dims[i] for i in self.output_indices}`. Basically, the length of a Blockwise layer should be equal to the number of output keys (right?), so I just reused the logic from `get_output_keys`, without materializing the keys.

For the example in the linked issue, where `_repr_html_` took 19sec before, it now takes 5ms.

cc @crusaderky

- [x] Closes #7271
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
