### PR TITLE
Check that computed chunks have right size and dtype

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3383,12 +3383,12 @@ def test_blockwise_concatenate():
         assert b.shape == (4, 4)
         assert c.shape == (4, 2)
 
-        return np.ones(5)
+        return np.ones(2)
 
     z = da.blockwise(
         f, "j", x, "ijk", y, "ki", y, "ij", concatenate=True, dtype=x.dtype
     )
-    assert_eq(z, np.ones(10), check_shape=False)
+    assert_eq(z, np.ones(4), check_shape=False)
 
 
 def test_common_blockdim():

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -234,7 +234,6 @@ def _check_chunks(x):
             chunk = np.array(chunk, dtype="O")
         expected_shape = tuple(c[i] for c, i in zip(x.chunks, idx))
         assert_eq_shape(expected_shape, chunk.shape, check_nan=False)
-        print(chunk.shape, chunk.dtype, x.dtype)
         assert chunk.dtype == x.dtype
     return x
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -234,6 +234,7 @@ def _check_chunks(x):
             chunk = np.array(chunk, dtype="O")
         expected_shape = tuple(c[i] for c, i in zip(x.chunks, idx))
         assert_eq_shape(expected_shape, chunk.shape, check_nan=False)
+        print(chunk.shape, chunk.dtype, x.dtype)
         assert chunk.dtype == x.dtype
     return x
 
@@ -377,6 +378,7 @@ def empty_like_safe(a, shape, **kwargs):
     try:
         return np.empty_like(a, shape=shape, **kwargs)
     except TypeError:
+        kwargs.setdefault("dtype", a.dtype)
         return np.empty(shape, **kwargs)
 
 
@@ -390,6 +392,7 @@ def full_like_safe(a, fill_value, shape, **kwargs):
     try:
         return np.full_like(a, fill_value, shape=shape, **kwargs)
     except TypeError:
+        kwargs.setdefault("dtype", a.dtype)
         return np.full(shape, fill_value, **kwargs)
 
 
@@ -402,6 +405,7 @@ def ones_like_safe(a, shape, **kwargs):
     try:
         return np.ones_like(a, shape=shape, **kwargs)
     except TypeError:
+        kwargs.setdefault("dtype", a.dtype)
         return np.ones(shape, **kwargs)
 
 
@@ -414,6 +418,7 @@ def zeros_like_safe(a, shape, **kwargs):
     try:
         return np.zeros_like(a, shape=shape, **kwargs)
     except TypeError:
+        kwargs.setdefault("dtype", a.dtype)
         return np.zeros(shape, **kwargs)
 
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -377,7 +377,7 @@ def empty_like_safe(a, shape, **kwargs):
     try:
         return np.empty_like(a, shape=shape, **kwargs)
     except TypeError:
-        kwargs.setdefault("dtype", a.dtype)
+        kwargs.setdefault("dtype", np.asanyarray(a).dtype)
         return np.empty(shape, **kwargs)
 
 
@@ -391,7 +391,7 @@ def full_like_safe(a, fill_value, shape, **kwargs):
     try:
         return np.full_like(a, fill_value, shape=shape, **kwargs)
     except TypeError:
-        kwargs.setdefault("dtype", a.dtype)
+        kwargs.setdefault("dtype", np.asanyarray(a).dtype)
         return np.full(shape, fill_value, **kwargs)
 
 
@@ -404,7 +404,7 @@ def ones_like_safe(a, shape, **kwargs):
     try:
         return np.ones_like(a, shape=shape, **kwargs)
     except TypeError:
-        kwargs.setdefault("dtype", a.dtype)
+        kwargs.setdefault("dtype", np.asanyarray(a).dtype)
         return np.ones(shape, **kwargs)
 
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -227,7 +227,7 @@ def assert_eq_shape(a, b, check_nan=True):
 
 
 def _check_chunks(x):
-    x = x.persist()
+    x = x.persist(scheduler="sync")
     for idx in itertools.product(*(range(len(c)) for c in x.chunks)):
         chunk = x.dask[(x.name,) + idx]
         if not hasattr(chunk, "dtype"):

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -368,6 +368,16 @@ def safe_wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS):
         return lambda x: x
 
 
+def _dtype_of(a):
+    """Determine dtype of an array-like."""
+    try:
+        # Check for the attribute before using asanyarray, because some types
+        # (notably sparse arrays) don't work with it.
+        return a.dtype
+    except AttributeError:
+        return np.asanyarray(a).dtype
+
+
 def empty_like_safe(a, shape, **kwargs):
     """
     Return np.empty_like(a, shape=shape, **kwargs) if the shape argument
@@ -377,7 +387,7 @@ def empty_like_safe(a, shape, **kwargs):
     try:
         return np.empty_like(a, shape=shape, **kwargs)
     except TypeError:
-        kwargs.setdefault("dtype", np.asanyarray(a).dtype)
+        kwargs.setdefault("dtype", _dtype_of(a))
         return np.empty(shape, **kwargs)
 
 
@@ -391,7 +401,7 @@ def full_like_safe(a, fill_value, shape, **kwargs):
     try:
         return np.full_like(a, fill_value, shape=shape, **kwargs)
     except TypeError:
-        kwargs.setdefault("dtype", np.asanyarray(a).dtype)
+        kwargs.setdefault("dtype", _dtype_of(a))
         return np.full(shape, fill_value, **kwargs)
 
 
@@ -404,7 +414,7 @@ def ones_like_safe(a, shape, **kwargs):
     try:
         return np.ones_like(a, shape=shape, **kwargs)
     except TypeError:
-        kwargs.setdefault("dtype", np.asanyarray(a).dtype)
+        kwargs.setdefault("dtype", _dtype_of(a))
         return np.ones(shape, **kwargs)
 
 
@@ -417,7 +427,7 @@ def zeros_like_safe(a, shape, **kwargs):
     try:
         return np.zeros_like(a, shape=shape, **kwargs)
     except TypeError:
-        kwargs.setdefault("dtype", np.asanyarray(a).dtype)
+        kwargs.setdefault("dtype", _dtype_of(a))
         return np.zeros(shape, **kwargs)
 
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -417,7 +417,7 @@ def zeros_like_safe(a, shape, **kwargs):
     try:
         return np.zeros_like(a, shape=shape, **kwargs)
     except TypeError:
-        kwargs.setdefault("dtype", a.dtype)
+        kwargs.setdefault("dtype", np.asanyarray(a).dtype)
         return np.zeros(shape, **kwargs)
 
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1248,7 +1248,7 @@ def test_optimize_globals():
     assert_eq(x + 1, np.ones(10) + 1)
 
     with dask.config.set(array_optimize=optimize_double):
-        assert_eq(x + 1, (np.ones(10) * 2 + 1) * 2)
+        assert_eq(x + 1, (np.ones(10) * 2 + 1) * 2, check_chunks=False)
 
     assert_eq(x + 1, np.ones(10) + 1)
 


### PR DESCRIPTION
This was inspired by a question in #7234. At present `assert_eq` checks
that the computed array has the right size and dtype, but it's still
possible that the individual chunks have the wrong size (as long as they
add up to the right total size) and maybe the wrong dtype (as long as
they coerce to produce the right dtype - although I haven't actually
checked that this would slip through).

Now `persist` is used to access the individual computed chunks and
checked for shape and dtype.

This is a draft because there are a couple of failures. One is in
`test_zarr_return_stored[False]` (which I'll need to investigate
further, but possibly `persist` just doesn't make sense for this case)
and the other is in `test_blockwise_concatenate` which looks like it
might just be a test bug.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
