### PR TITLE
Use pytest.register_assert_rewrite on util modules

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -36,4 +36,6 @@ def pytest_runtest_setup(item):
         pytest.skip("need --runslow option to run")
 
 
-pytest.register_assert_rewrite("dask.array.utils", "dask.dataframe.utils", "dask.bag.utils")
+pytest.register_assert_rewrite(
+    "dask.array.utils", "dask.dataframe.utils", "dask.bag.utils"
+)

--- a/conftest.py
+++ b/conftest.py
@@ -34,3 +34,6 @@ def pytest_addoption(parser):
 def pytest_runtest_setup(item):
     if "slow" in item.keywords and not item.config.getoption("--runslow"):
         pytest.skip("need --runslow option to run")
+
+
+pytest.register_assert_rewrite("dask.array.utils", "dask.dataframe.utils", "dask.bag.utils")


### PR DESCRIPTION
This makes failures in various assert_eq functions easier to debug,
because pytest will be able to introspect the failure and print the
arguments.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
