### PR TITLE
Use development version of distributed in CI

### DIFF
--- a/continuous_integration/environment-3.6.yaml
+++ b/continuous_integration/environment-3.6.yaml
@@ -57,3 +57,5 @@ dependencies:
   - python-xxhash
   - mmh3
   - pip
+  - pip:
+    - git+https://github.com/dask/distributed

--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -57,3 +57,5 @@ dependencies:
   - python-xxhash
   - mmh3
   - pip
+  - pip:
+    - git+https://github.com/dask/distributed

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -56,3 +56,5 @@ dependencies:
   - python-xxhash
   - mmh3
   - pip
+  - pip:
+    - git+https://github.com/dask/distributed


### PR DESCRIPTION
This PR updates our CI to use the latest development version of `distributed`. This is needed when changes are co-introduced in `dask` and `distributed` (e.g. https://github.com/dask/dask/pull/7179 / https://github.com/dask/distributed/pull/4489). Note that `distributed`s CI already points to the development version of `dask` -- when reviewing https://github.com/dask/dask/pull/7179 I mistakenly thought that we also did the same thing for `dask`s CI.

cc @madsbk 