### PR TITLE
ENH: Adds sort_values to dask.DataFrame

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3810,25 +3810,36 @@ class DataFrame(_Frame):
         cs = self._meta.select_dtypes(include=include, exclude=exclude).columns
         return self[list(cs)]
 
-    def sort_values(
-        self,
-        other,
-        npartitions=None,
-        divisions=None,
-        ascending=True,
-        **kwargs
-    ):
-        if divisions is not None:
-            check_divisions(divisions)
+    def sort_values(self, other, npartitions=None, ascending=True, **kwargs):
+        """Sort the dataset by a single column.
+
+        Sorting a parallel dataset requires expensive shuffles and is generally
+        not recommended. See ``set_index`` for implementation details.
+
+        Parameters
+        ----------
+        other: string
+        npartitions: int, None, or 'auto'
+            The ideal number of output partitions. If None, use the same as
+            the input. If 'auto' then decide by memory use.
+        ascending: bool, optional
+            Non ascending sort is not supported by Dask.
+            Defaults to True.
+
+        Examples
+        --------
+        >>> df2 = df.sort_values('x')  # doctest: +SKIP
+        """
+        if not ascending:
+            raise NotImplementedError("The ascending= keyword is not supported")
 
         from .shuffle import sort_values
 
         return sort_values(
             self,
             other,
-            ascending=True,
+            ascending=ascending,
             npartitions=npartitions,
-            divisions=divisions,
             **kwargs,
         )
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3810,6 +3810,28 @@ class DataFrame(_Frame):
         cs = self._meta.select_dtypes(include=include, exclude=exclude).columns
         return self[list(cs)]
 
+    def sort_values(
+        self,
+        other,
+        npartitions=None,
+        divisions=None,
+        ascending=True,
+        **kwargs
+    ):
+        if divisions is not None:
+            check_divisions(divisions)
+
+        from .shuffle import sort_values
+
+        return sort_values(
+            self,
+            other,
+            ascending=True,
+            npartitions=npartitions,
+            divisions=divisions,
+            **kwargs,
+        )
+
     def set_index(
         self,
         other,

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1132,3 +1132,15 @@ def test_set_index_nan_partition():
     d[d.a > 1].set_index("a", sorted=True)  # Set sorted index with 0 null partitions
     a = d[d.a > 3].set_index("a", sorted=True)  # Set sorted index with 1 null partition
     assert_eq(a, a)
+
+
+@pytest.mark.parametrize(
+    "npartitions",
+    [10, 1],
+)
+def test_sort_values(npartitions):
+    df = pd.DataFrame({"a": np.random.randint(0, 10, 100)})
+
+    ddf = dd.from_pandas(df, npartitions=npartitions)
+
+    assert_eq(ddf.sort_values("a"), df.sort_values("a"))


### PR DESCRIPTION
- [X] Closes https://github.com/dask/dask/issues/958
- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask`. Running black on `core.py` and `shuffle.py` caused large diffs - maybe I have something misconfigured?

As suggested https://github.com/dask/dask/issues/958#issuecomment-573121520 and https://github.com/dask/dask/pull/2367, I've pretty much reused the code in `set_index` and don't mess with the underlying bits. Shared code between `set_index` and `sort_values` is in `_calculate_divisions`. 

Implementation caveats:

- only single column sorting is supported
- only `ascending=True` is supported


Closes https://github.com/dask/dask/issues/958