### PR TITLE
Fix fsspec usage in create_metadata_file

### DIFF
--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -428,7 +428,8 @@ def test_modification_time_read_bytes(s3, s3so):
 
 
 @pytest.mark.parametrize("engine", ["pyarrow", "fastparquet"])
-def test_parquet(s3, engine, s3so):
+@pytest.mark.parametrize("metadata_file", [True, False])
+def test_parquet(s3, engine, s3so, metadata_file):
     import s3fs
 
     dd = pytest.importorskip("dask.dataframe")
@@ -461,13 +462,19 @@ def test_parquet(s3, engine, s3so):
         index=pd.Index(np.arange(1000), name="foo"),
     )
     df = dd.from_pandas(data, chunksize=500)
-    df.to_parquet(url, engine=engine, storage_options=s3so)
+    df.to_parquet(
+        url, engine=engine, storage_options=s3so, write_metadata_file=metadata_file
+    )
 
     files = [f.split("/")[-1] for f in s3.ls(url)]
-    assert "_common_metadata" in files
+    if metadata_file:
+        assert "_common_metadata" in files
+        assert "_metadata" in files
     assert "part.0.parquet" in files
 
-    df2 = dd.read_parquet(url, index="foo", engine=engine, storage_options=s3so)
+    df2 = dd.read_parquet(
+        url, index="foo", gather_statistics=True, engine=engine, storage_options=s3so
+    )
     assert len(df2.divisions) > 1
 
     tm.assert_frame_equal(data, df2.compute())

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1778,6 +1778,7 @@ class ArrowLegacyEngine(ArrowDatasetEngine):
                     root_dir=base,
                     engine=cls,
                     out_dir=False,
+                    fs=fs,
                 )
                 if schema is None:
                     schema = metadata.schema.to_arrow_schema()


### PR DESCRIPTION
For `read_parquet`, `ArrowEngine` uses a `create_metadata_file` utility to construct a global metadata object when a "_metadata" file is not available.  When reading from a remote file system, like s3, the list of paths being passed to this utility will not contain s3 prefix information (this is the cause of the bug discussed in [nvt#539](https://github.com/NVIDIA/NVTabular/issues/539)).

This PR adds an optional `fs` argument to `create_metadata_file`.  This avoids the need to infer the file system from a list of paths when the file system is already known (and the necessary information has already been stripped).
