### PR TITLE
Add plot width and height support for Bokeh 2.3.0

### DIFF
--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -253,9 +253,14 @@ def plot_tasks(results, dsk, palette="Viridis", label_size=60, **kwargs):
         title="Profile Results",
         tools="hover,save,reset,xwheel_zoom,xpan",
         toolbar_location="above",
-        plot_width=800,
-        plot_height=300,
+        width=800,
+        height=300,
     )
+    # Support plot_width and plot_height for backwards compatibility
+    if "plot_width" in kwargs:
+        kwargs["width"] = kwargs.pop("plot_width")
+    if "plot_height" in kwargs:
+        kwargs["height"] = kwargs.pop("plot_height")
     defaults.update((k, v) for (k, v) in kwargs.items() if k in _get_figure_keywords())
 
     if results:
@@ -351,9 +356,14 @@ def plot_resources(results, palette="Viridis", **kwargs):
         title="Profile Results",
         tools="save,reset,xwheel_zoom,xpan",
         toolbar_location="above",
-        plot_width=800,
-        plot_height=300,
+        width=800,
+        height=300,
     )
+    # Support plot_width and plot_height for backwards compatibility
+    if "plot_width" in kwargs:
+        kwargs["width"] = kwargs.pop("plot_width")
+    if "plot_height" in kwargs:
+        kwargs["height"] = kwargs.pop("plot_height")
     defaults.update((k, v) for (k, v) in kwargs.items() if k in _get_figure_keywords())
     if results:
         t, mem, cpu = zip(*results)
@@ -444,9 +454,14 @@ def plot_cache(
         title="Profile Results",
         tools="hover,save,reset,wheel_zoom,xpan",
         toolbar_location="above",
-        plot_width=800,
-        plot_height=300,
+        width=800,
+        height=300,
     )
+    # Support plot_width and plot_height for backwards compatibility
+    if "plot_width" in kwargs:
+        kwargs["width"] = kwargs.pop("plot_width")
+    if "plot_height" in kwargs:
+        kwargs["height"] = kwargs.pop("plot_height")
     defaults.update((k, v) for (k, v) in kwargs.items() if k in _get_figure_keywords())
 
     if results:


### PR DESCRIPTION
This PR ensures that user's who specify `plot_width=` and `plot_height=` keyword arguments in our diagnostic utilities aren't ignored when using `bokeh==2.3.0` (xref https://github.com/dask/dask/issues/7292#issuecomment-788310216) 

Additionally, I think we should try to eliminate the need for validating bokeh keyword arguments provided by users with `_get_figure_keywords`. Passing invalid keywords to bokeh and having bokeh raise the error seems like it might be less error prone. I gave this an initial attempt but there's some additional logic we'll need to implement to handle `label_size=`. In any event, the changes here seem like a reasonable first step and will get our CI passing again. 

cc @quasiben @bryevdv

Closes https://github.com/dask/dask/issues/7292 
