### PR TITLE
Use HighLevelGraph optimizations in delayed

### DIFF
--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -713,6 +713,6 @@ def test_annotations():
     # Ensure optimizing a Delayed object returns a HighLevelGraph
     # and doesn't loose annotations
     (d_opt,) = dask.optimize(d)
-    assert type(d.dask) is HighLevelGraph
+    assert type(d_opt.dask) is HighLevelGraph
     assert len(d_opt.dask.layers) == 1
     assert next(iter(d_opt.dask.layers.values())).annotations == {"foo": "bar"}


### PR DESCRIPTION
This PR updates the default graph manipulation for `delayed` objects to use `HighLevelGraph.cull` instead of the low-level (`dict`) graph `cull` routine. This allows us to maintain annotations through our optimization pipeline (xref https://github.com/dask/dask/issues/7036).

cc @ian-r-rose @madsbk  

- [ ] Closes https://github.com/dask/dask/issues/7294
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
