### PR TITLE
Use nearest interpolation for creating percentiles of integer input

### DIFF
--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -413,9 +413,9 @@ def percentiles_summary(df, num_old, num_new, upsample, state):
     if is_categorical_dtype(data):
         data = data.codes
         interpolation = "nearest"
+    elif np.issubdtype(data.dtype, np.integer):
+        interpolation = "nearest"
     vals, n = _percentile(data, qs, interpolation=interpolation)
-    if interpolation == "linear" and np.issubdtype(data.dtype, np.integer):
-        vals = np.round(vals).astype(data.dtype)
     vals_and_weights = percentiles_to_weights(qs, vals, length)
     return vals_and_weights
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -611,7 +611,7 @@ def test_set_index_interpolate():
 
     d1 = d.set_index("x", npartitions=3)
     assert d1.npartitions == 3
-    assert set(d1.divisions) == set([1, 2, 3, 4])
+    assert set(d1.divisions) == set([1, 2, 4])
 
     d2 = d.set_index("y", npartitions=3)
     assert d2.divisions[0] == 1.0

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -627,6 +627,18 @@ def test_set_index_interpolate_int():
     assert all(np.issubdtype(type(x), np.integer) for x in d1.divisions)
 
 
+def test_set_index_interpolate_large_uint():
+    """This test is for #7304"""
+    df = pd.DataFrame(
+        {"x": np.array([612509347682975743, 616762138058293247], dtype=np.uint64)}
+    )
+    d = dd.from_pandas(df, 1)
+
+    d1 = d.set_index("x", npartitions=1)
+    assert d1.npartitions == 1
+    assert set(d1.divisions) == set([612509347682975743, 616762138058293247])
+
+
 def test_set_index_timezone():
     s_naive = pd.Series(pd.date_range("20130101", periods=3))
     s_aware = pd.Series(pd.date_range("20130101", periods=3, tz="US/Eastern"))


### PR DESCRIPTION
- [x] Closes #7304
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
