### PR TITLE
Typo in optimize docs

### DIFF
--- a/docs/source/optimize.rst
+++ b/docs/source/optimize.rst
@@ -79,7 +79,7 @@ output keys to a scheduler ``get`` function:
     >>> outputs = ['print1', 'print2']
     >>> dsk1, dependencies = cull(dsk, outputs)  # remove unnecessary tasks from the graph
 
-    >>> results = get(dsk2, outputs)
+    >>> results = get(dsk1, outputs)
     word list has 2 occurrences of apple, out of 7 words
     word list has 2 occurrences of orange, out of 7 words
 


### PR DESCRIPTION
I was not able to run the examples given. This should fix the cell.

- [ ] Passes `black dask` / `flake8 dask`
