### PR TITLE
Run upstream tests based on commit message

### DIFF
--- a/.github/workflows/ci-upstream.yml
+++ b/.github/workflows/ci-upstream.yml
@@ -20,11 +20,11 @@ jobs:
       - uses: xarray-contrib/ci-trigger@v1
         id: detect-trigger
         with:
-          keyword: "[test-upstream]"
+          keyword: "test-upstream"
 
   build:
     needs: check
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     if: |
       needs.check-upstream.outputs.test-upstream == 'true'
       || (github.repository == 'dask/dask' && github.event_name != 'pull_request')

--- a/.github/workflows/ci-upstream.yml
+++ b/.github/workflows/ci-upstream.yml
@@ -7,9 +7,27 @@ on:
   pull_request:
 
 jobs:
+
+  check:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    outputs:
+      test-upstream: ${{ steps.detect-trigger.outputs.trigger-found }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - uses: xarray-contrib/ci-trigger@v1
+        id: detect-trigger
+        with:
+          keyword: "[test-upstream]"
+
   build:
+    needs: check
     runs-on: "ubuntu-latest"
-    if: "contains(github.event.head_commit.message, 'test-upstream') || (github.repository == 'dask/dask' && github.event_name != 'pull_request')"
+    if: |
+      needs.check-upstream.outputs.test-upstream == 'true'
+      || (github.repository == 'dask/dask' && github.event_name != 'pull_request')
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-upstream.yml
+++ b/.github/workflows/ci-upstream.yml
@@ -26,7 +26,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     if: |
-      needs.check-upstream.outputs.test-upstream == 'true'
+      needs.check.outputs.test-upstream == 'true'
       || (github.repository == 'dask/dask' && github.event_name != 'pull_request')
 
     steps:


### PR DESCRIPTION
This PR enables us to run an upstream test build when a commit message contains the phrase `test-upstream`. We do this by adding a new `check` job to our existing upstream GHA workflow which utilizes [`xarray-contrib/ci-trigger`](https://github.com/xarray-contrib/ci-trigger) to search the corresponding commit message for `test-upstream`. If it is found in the commit message then the upstream build is launched otherwise the upstream build is skipped.

The extra `check` job takes ~5 seconds to run, so I don't anticipate it impacting our CI backlog in a meaningful way. 

Here are a couple of example CI builds which demonstrate the upstream tests being skipped or not:

- https://github.com/jrbourbeau/dask/runs/2047507385 -- did not contain `test-upstream` in the commit message
- https://github.com/jrbourbeau/dask/runs/2047551865 -- did contain `test-upstream` in the commit message 