### PR TITLE
add example and a test on using specific chunk sizes in from_array()

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3080,6 +3080,12 @@ def from_array(
     >>> a.dask[a.name, 0, 0][0]
     array([1])
 
+    Chunks with exactly-specified, different sizes can be created.
+
+    >>> import numpy as np
+    >>> import dask.array as da
+    >>> x = np.random.random((100, 6))
+    >>> a = da.from_array(x, chunks=((67, 33), (6,)))
     """
     if isinstance(x, Array):
         raise ValueError(

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -806,17 +806,6 @@ def test_persist_array_rename():
     da.utils.assert_eq(b, [1, 2, 3, 4])
 
 
-@pytest.mark.skipif("not da")
-def test_from_array_works_with_specific_chunk_sizes():
-    arr = np.random.random((100, 6))
-    with pytest.raises(ValueError, match="Chunks do not add up to shape"):
-        _ = da.from_array(arr, chunks=((33, 67), (6, 6)))
-    darr = da.from_array(arr, chunks=((33, 67), (6,)))
-    assert darr.npartitions == 2
-    assert np.allclose(darr.partitions[0].compute(), arr[:33, :])
-    assert np.allclose(darr.partitions[1].compute(), arr[33:, :])
-
-
 @pytest.mark.skipif("not dd")
 def test_compute_dataframe():
     df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [5, 5, 3, 3]})

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -806,6 +806,17 @@ def test_persist_array_rename():
     da.utils.assert_eq(b, [1, 2, 3, 4])
 
 
+@pytest.mark.skipif("not da")
+def test_from_array_works_with_specific_chunk_sizes():
+    arr = np.random.random((100, 6))
+    with pytest.raises(ValueError, match="Chunks do not add up to shape"):
+        _ = da.from_array(arr, chunks=((33, 67), (6, 6)))
+    darr = da.from_array(arr, chunks=((33, 67), (6,)))
+    assert darr.npartitions == 2
+    assert np.allclose(darr.partitions[0].compute(), arr[:33, :])
+    assert np.allclose(darr.partitions[1].compute(), arr[33:, :])
+
+
 @pytest.mark.skipif("not dd")
 def test_compute_dataframe():
     df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [5, 5, 3, 3]})


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

I recently found a need to convert a `numpy` 2D array into a 2-chunk Dask Array with exactly-specified, different sized chunks. I consulted the documentation at https://docs.dask.org/en/latest/array-api.html#dask.array.from_array but couldn't understand how to do this correctly, which led to me opening #7310. The way this works was explained to me in #7310 and that issue was closed.

Based on my experience with this feature of Dask Array, in this PR I'd like to propose two small changes:

* an example in the documentation for `from_array()` that shows how to explicitly control chunk sizes
* a unit test on the behavior of explicitly controlling task sizes (there are not currently any such tests in this repo, as far as I can tell, based on `git grep from_array dask/tests`)

Thanks for your time and consideration.