### PR TITLE
dask.array.asarray should handle case where xarray class is in top-level namespace

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4100,7 +4100,7 @@ def asarray(a, **kwargs):
         return a
     elif hasattr(a, "to_dask_array"):
         return a.to_dask_array()
-    elif type(a).__module__.startswith("xarray.") and hasattr(a, "data"):
+    elif type(a).__module__.split(".")[0] == "xarray" and hasattr(a, "data"):
         return asarray(a.data)
     elif isinstance(a, (list, tuple)) and any(isinstance(i, Array) for i in a):
         return stack(a)
@@ -4140,7 +4140,7 @@ def asanyarray(a):
         return a
     elif hasattr(a, "to_dask_array"):
         return a.to_dask_array()
-    elif type(a).__module__.startswith("xarray.") and hasattr(a, "data"):
+    elif type(a).__module__.split(".")[0] == "xarray" and hasattr(a, "data"):
         return asanyarray(a.data)
     elif isinstance(a, (list, tuple)) and any(isinstance(i, Array) for i in a):
         return stack(a)


### PR DESCRIPTION
In some cases (e.g. https://github.com/pydata/xarray/issues/4279), xarray's `DataArray` class is in the `xarray` module, rather than the usual `xarray.core.dataarray` module. This causes `dask.array.asarray` to fail to wrap the array correctly, since it checks for a module name starting with `xarray.` (note the dot). This PR handles both cases.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
