### PR TITLE
Add Xarray to CI software environment

### DIFF
--- a/continuous_integration/environment-3.6.yaml
+++ b/continuous_integration/environment-3.6.yaml
@@ -23,6 +23,7 @@ dependencies:
   - fsspec
   - zarr
   - tiledb-py
+  - xarray
   - sqlalchemy
   - pyarrow=0.14
   # other -- IO

--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -19,6 +19,7 @@ dependencies:
   - pytables
   - zarr
   - tiledb-py
+  - xarray
   - fsspec
   - sqlalchemy
   - pyarrow=1.0

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -19,6 +19,7 @@ dependencies:
   - pytables
   - zarr
   - tiledb-py
+  - xarray
   - sqlalchemy
   - pyarrow
   - jsonschema

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -19,6 +19,7 @@ dependencies:
   - pytables
   - zarr
   - tiledb-py
+  - xarray
   - fsspec
   - sqlalchemy
   - pyarrow

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -20,6 +20,7 @@ dependencies:
   - pytables
   - zarr
   - tiledb-py
+  - xarray
   - fsspec
   - sqlalchemy
   - pyarrow


### PR DESCRIPTION
This PR adds `xarray` to our CI software environments so that the few tests in `dask/array/tests/test_xarray.py` will run. FWIW [Xarray's dependencies](https://github.com/pydata/xarray/blob/7905c514a12fcbcaaeb634cab94733c7cbdd6ff2/setup.cfg#L76-L79), NumPy, pandas, and setuptools, are already installed in CI so we shouldn't need to pull in any additional packages other than Xarray itself.

cc @shoyer @crusaderky for visibility 
