### PR TITLE
Automatically cancel previous CI builds

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -2,7 +2,7 @@ name: Cancel
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI", "CI Additional", "Upstream"]
     types:
       - requested
 


### PR DESCRIPTION
This PR adds a step to our test CI builds to automatically cancel any workflows associated with previous commits in a PR. I'm hoping this will help minimize wait time for CI builds to start -- in particular macOS builds which allow fewer concurrent builds.