### PR TITLE
Add Dask Contrib docs

### DIFF
--- a/docs/source/contrib.rst
+++ b/docs/source/contrib.rst
@@ -1,0 +1,44 @@
+Dask Contrib
+============
+
+In addition to the primary `Dask GitHub Organization <https://github.com/dask>`_ there is also a secondary
+`Dask Contrib GitHub Organization <https://github.com/dask-contrib/>`_ which contains community supported
+projects which integrate with or enhance the Dask experience.
+
+These projects are owned and maintained by folks outside of the core Dask maintainer group and therefore
+the quality and stability may be different to that of the main Dask packages. However these projects are
+expected to conform to the `Dask Code of Conduct <https://github.com/dask/governance/blob/main/code-of-conduct.md>`_.
+
+The contrib organisztion exists to improve discoverability of user submitted projects.
+
+Contrib package criteria
+------------------------
+
+If you are working on a project which you think could be a great addition to the Dask Contrib org then please
+feel free to raise an issue on the `Dask Community repo <https://github.com/dask/community>`_ requesting a transfer.
+
+For a project to be accepted into Dask Contrib it must meet the following criteria:
+
+- Packages must complement or enhance Dask in some way, maybe it contains plugins, adds integration with some other library or just generally improves the Dask experience for users.
+- Packages must have at least one active maintainer.
+- Packages must be installable both from PyPI with ``pip`` and Conda Forge with ``conda``.
+- Packages must have documentation.
+
+Graduation to the main org
+--------------------------
+
+In some cases it may be appropriate to graduate a project to the main Dask Organization, or perhaps merge the code/functionality
+into an existing Dask project.
+
+This will be assessed on a case-by-case basis by the Dask maintenance team.
+
+For some projects it may make sense to graduate their content into other repositories. The now defunct ``dask-lightgbm`` project was integrated into
+LightGBM for example.
+
+Generally for a project to make it into the main Dask Org it should meet the following criteria:
+
+- Packages much have an active community.
+- Packages must be maintained by one or more people who are employed to do so and will dedicate a minimum of 1 day per week to Dask.
+- Maintainers must engage in providing support for the package on Stack Overflow.
+- Packages must have documentation integrated into the larger `Dask Sphinx website <https://github.com/dask/dask-sphinx-theme>`_.
+- Packages must have tests which are run via CI and clear acceptance criteria for PRs to enable other maintainers assist.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -190,6 +190,7 @@ messy situations in everyday problems.
    phases-of-computation.rst
    remote-data-services.rst
    gpu.rst
+   contrib.rst
    cite.rst
    funding.rst
    logos.rst


### PR DESCRIPTION
This PR adds a documentation page describing the [Dask Contrib GitHub Organization](https://github.com/dask-contrib).

I have kinda arbitrarily made up all the criteria and stuff in here with things I consider sensible to give the community some guiding points to keep in mind. However some discussion and feedback here would be much appreciated.

For example I've written it with pretty formal language, but perhaps we want to make it more informal. Perhaps we want to add/remove criteria. Perhaps we don't want any criteria at all.