### PR TITLE
Support custom_metadata= argument in to_parquet

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -841,14 +841,9 @@ class ArrowDatasetEngine(Engine):
 
         t = cls._pandas_to_arrow_table(df, preserve_index=preserve_index, schema=schema)
         if custom_metadata:
-            if not hasattr(t, "replace_schema_metadata"):
-                raise ValueError(
-                    "The `custom_metadata=` argument is not supported "
-                    "for this version of pyarrow."
-                )
             _md = t.schema.metadata
             _md.update(custom_metadata)
-            t = t.replace_schema_metadata(_md)
+            t = t.replace_schema_metadata(metadata=_md)
 
         if partition_on:
             md_list = _write_partitioned(

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -828,6 +828,7 @@ class ArrowDatasetEngine(Engine):
         index_cols=None,
         schema=None,
         head=False,
+        custom_metadata=None,
         **kwargs,
     ):
         _meta = None
@@ -839,6 +840,15 @@ class ArrowDatasetEngine(Engine):
             index_cols = []
 
         t = cls._pandas_to_arrow_table(df, preserve_index=preserve_index, schema=schema)
+        if custom_metadata:
+            if not hasattr(t, "replace_schema_metadata"):
+                raise ValueError(
+                    "The `custom_metadata=` argument is not supported "
+                    "for this version of pyarrow."
+                )
+            _md = t.schema.metadata
+            _md.update(custom_metadata)
+            t = t.replace_schema_metadata(_md)
 
         if partition_on:
             md_list = _write_partitioned(

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -412,6 +412,7 @@ def to_parquet(
     ignore_divisions=False,
     partition_on=None,
     storage_options=None,
+    custom_metadata=None,
     write_metadata_file=True,
     compute=True,
     compute_kwargs=None,
@@ -460,6 +461,9 @@ def to_parquet(
         there will be no global groupby.
     storage_options : dict, optional
         Key/value pairs to be passed on to the file-system backend, if any.
+    custom_metadata : dict, optional
+        Custom key/value metadata to include in all footer metadata (and
+        in the global "_metadata" file, if applicable).
     write_metadata_file : bool, optional
         Whether to write the special "_metadata" file.
     compute : bool, optional
@@ -630,6 +634,8 @@ def to_parquet(
     kwargs_pass["compression"] = compression
     kwargs_pass["index_cols"] = index_cols
     kwargs_pass["schema"] = schema
+    if custom_metadata:
+        kwargs_pass["custom_metadata"] = custom_metadata
     for d, filename in enumerate(filenames):
         dsk[(name, d)] = (
             apply,

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -463,8 +463,8 @@ def to_parquet(
         Key/value pairs to be passed on to the file-system backend, if any.
     custom_metadata : dict, optional
         Custom key/value metadata to include in all footer metadata (and
-        in the global "_metadata" file, if applicable).  This argument is
-        only supported for the "pyarrow" engine, for now.
+        in the global "_metadata" file, if applicable).  Note that the custom
+        metadata may not contain the reserved b"pandas" key.
     write_metadata_file : bool, optional
         Whether to write the special "_metadata" file.
     compute : bool, optional
@@ -636,6 +636,13 @@ def to_parquet(
     kwargs_pass["index_cols"] = index_cols
     kwargs_pass["schema"] = schema
     if custom_metadata:
+        if b"pandas" in custom_metadata.keys():
+            raise ValueError(
+                "User-defined key/value metadata (custom_metadata) can not "
+                "contain a b'pandas' key.  This key is reserved by Pandas, "
+                "and overwriting the corresponding value can render the "
+                "entire dataset unreadable."
+            )
         kwargs_pass["custom_metadata"] = custom_metadata
     for d, filename in enumerate(filenames):
         dsk[(name, d)] = (

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -463,7 +463,8 @@ def to_parquet(
         Key/value pairs to be passed on to the file-system backend, if any.
     custom_metadata : dict, optional
         Custom key/value metadata to include in all footer metadata (and
-        in the global "_metadata" file, if applicable).
+        in the global "_metadata" file, if applicable).  This argument is
+        only supported for the "pyarrow" engine, for now.
     write_metadata_file : bool, optional
         Whether to write the special "_metadata" file.
     compute : bool, optional

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -898,9 +898,19 @@ class FastParquetEngine(Engine):
         return_metadata,
         fmd=None,
         compression=None,
+        custom_metadata=None,
         **kwargs,
     ):
+        # Update key/value metadata if necessary
         fmd = copy.copy(fmd)
+        if custom_metadata and fmd is not None:
+            fmd.key_value_metadata.extend(
+                [
+                    fastparquet.parquet_thrift.KeyValue(key=key, value=value)
+                    for key, value in custom_metadata.items()
+                ]
+            )
+
         if not len(df):
             # Write nothing for empty partitions
             rgs = []

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3347,7 +3347,7 @@ def test_roundtrip_rename_columns(tmpdir, engine):
     assert_eq(df1, ddf2.compute())
 
 
-def test_pyarrow_custom_metadata(tmpdir, engine):
+def test_custom_metadata(tmpdir, engine):
     # Write a parquet dataset with custom metadata
 
     # Define custom metadata

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3345,3 +3345,33 @@ def test_roundtrip_rename_columns(tmpdir, engine):
     df1.columns = ["d", "e", "f"]
 
     assert_eq(df1, ddf2.compute())
+
+
+def test_pyarrow_custom_metadata(tmpdir):
+    # Use "pyarrow" engine to write a parquet dataset
+    # with custom metadata
+    check_pyarrow()
+
+    # Define custom metadata
+    custom_metadata = {b"my_key": b"my_data"}
+
+    # Write parquet dataset
+    path = str(tmpdir)
+    df = pd.DataFrame({"a": range(10), "b": range(10)})
+    dd.from_pandas(df, npartitions=2).to_parquet(
+        path,
+        engine="pyarrow",
+        custom_metadata=custom_metadata,
+    )
+
+    # Check that data is correct
+    assert_eq(df, dd.read_parquet(path))
+
+    # Read footer metadata and _metadata.
+    # Check that it contains keys/values from `custom_metadata`
+    files = glob.glob(os.path.join(path, "*.parquet"))
+    files += [os.path.join(path, "_metadata")]
+    for fn in files:
+        _md = pq.ParquetFile(fn).metadata.metadata
+        for k, v in custom_metadata.items():
+            assert _md[k] == custom_metadata[k]


### PR DESCRIPTION
Adds a `custom_metadata=` argument to `DataFrame.to_parquet`.  If a dictionary is passed in by the user, those key/values will be included in all footer metadata, and in the global _metadata file, along with the usual `b"pandas"` metadata.

~Note that this PR only adds `custom_metadata=` support for the "pyarrow" engine. @martindurant - Do you know if something similar can be accomplished in the "fastparquet" engine?  I have not investigated that end just yet.~ [EDIT: Both pyarrow and fastparquet engines are now supported.]

- [x] Closes #7343
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
