### PR TITLE
Add test deps for pip development

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -101,9 +101,7 @@ pip or conda_
 
 ``pip``::
 
-  python -m pip install -e ".[complete]"
-  # to run tests you'll also need
-  python -m pip install pytest pytest-rerunfailures pytest-xdist
+  python -m pip install -e ".[complete,test]"
 
 ``conda``::
 

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -102,6 +102,8 @@ pip or conda_
 ``pip``::
 
   python -m pip install -e ".[complete]"
+  # to run tests you'll also need
+  python -m pip install pytest pytest-rerunfailures pytest-xdist
 
 ``conda``::
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ extras_require = {
     "delayed": ["cloudpickle >= 0.2.2", "toolz >= 0.8.2"],
 }
 extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
+# after complete is set, add in test
+extras_require["test"] = ["pytest", "pytest-rerunfailures", "pytest-xdist"]
 
 install_requires = ["pyyaml"]
 


### PR DESCRIPTION
If you install with pip following https://docs.dask.org/en/latest/develop.html you'll be missing the testing dependencies. I'm wondering if this is best handled by adding more docs, or by having a `pip install -e ".[test]"`

ref https://github.com/dask/dask/issues/7358#issuecomment-795545859

This is the docs version, but I am wondering if people would be opposed to adding another pip extra option called `[test]` that would not be included in `[complete]` 

@dask/maintenance 
