### PR TITLE
Use zarr.array rather than zarr.create

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3311,17 +3311,16 @@ def to_zarr(
 
     chunks = [c[0] for c in arr.chunks]
 
-    # The zarr.create function has the side-effect of immediately
+    # The zarr.array function has the side-effect of immediately
     # creating metadata on disk.  This may not be desired,
     # particularly if compute=False.  The caller may be creating many
     # arrays on a slow filesystem, with the desire that any I/O be
     # sharded across workers (not done serially on the originating
     # machine).  Or the caller may decide later to not to do this
     # computation, and so nothing should be written to disk.
-    z = delayed(zarr.create)(
-        shape=arr.shape,
+    z = delayed(zarr.array)(
+        data=arr,
         chunks=chunks,
-        dtype=arr.dtype,
         store=mapper,
         path=component,
         overwrite=overwrite,


### PR DESCRIPTION
- [x] Closes #5942
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

If this seems like a sane change, I'll add some tests. 