### PR TITLE
Example for memory-mapped Dask array

### DIFF
--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -242,7 +242,7 @@ Memory mapping
 
 Memory mapping can be a highly effective method to access raw binary data since
 it has nearly zero overhead if the data is already in the file system cache. For
-a threaded scheduler, creating a Dask array from a raw binary file can be as simple as
+the threaded scheduler, creating a Dask array from a raw binary file can be as simple as
 :code:`a = da.from_array(np.memmap(filename, shape=shape, dtype=dtype, mode='r'))`.
 
 For multiprocessing or distributed schedulers, the memory map for each array

--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -237,6 +237,110 @@ chunk shape:
 These interactions work not just for NumPy arrays but for any object that has
 shape and dtype attributes and implements NumPy slicing syntax.
 
+Memory mapping
+--------------
+
+Memory mapping can be a highly effective method to access raw binary data since it has
+nearly zero overhead if the data is already in the file system cache. This example
+creates a Dask array that is backed by memory-mapped chunks. For optimal
+compatibility with :code:`dask.distributed`, it wraps the function that creates the memory map
+using :code:`dask.delayed` so that it is always executed on the node and process where
+the data is actually being accessed.
+
+.. code-block:: python
+
+   import numpy as np
+   import dask
+   import dask.array as da
+
+
+   def mmap_load_chunk(filename, shape, dtype, offset, sl):
+       '''
+       Memory map the given file with overall shape and dtype and return a slice
+       specified by :code:`sl`.
+
+       Parameters
+       ----------
+
+       filename : str
+       shape : tuple
+           Total shape of the data in the file
+       dtype:
+           NumPy dtype of the data in the file
+       offset : int
+           Skip :code:`offset` bytes from the beginning of the file.
+       sl:
+           Object that can be used for indexing or slicing a NumPy array to
+           extract a chunk
+
+       Returns
+       -------
+
+       numpy.memmap or numpy.ndarray
+           View into memory map created by indexing with :code:`sl`,
+           or NumPy ndarray in case no view can be created using :code:`sl`.
+       '''
+       data = np.memmap(filename, mode='r', shape=shape, dtype=dtype, offset=offset)
+       return data[sl]
+
+
+   def mmap_dask_array(filename, shape, dtype, offset=0, blocksize=5):
+       '''
+       Create a Dask array from raw binary data in :code:`filename`
+       by memory mapping.
+
+       This method is particularly effective if the file is already
+       in the file system cache and if arbitrary smaller subsets are
+       to be extracted from the Dask array without optimizing its
+       chunking scheme.
+
+       It may perform poorly on Windows if the file is not in the file
+       system cache. On Linux it performs well under most circumstances.
+
+       Parameters
+       ----------
+
+       filename : str
+       shape : tuple
+           Total shape of the data in the file
+       dtype:
+           NumPy dtype of the data in the file
+       offset : int, optional
+           Skip :code:`offset` bytes from the beginning of the file.
+       blocksize : int, optional
+           Chunk size for the outermost axis. The other axes remain unchunked.
+
+       Returns
+       -------
+
+       dask.array.Array
+           Dask array matching :code:`shape` and :code:`dtype`, backed by
+           memory-mapped chunks.
+       '''
+       chunks = []
+       for index in range(0, shape[0], blocksize):
+           # Truncate the last chunk if necessary
+           chunk_size = min(blocksize, shape[0] - index)
+           chunk = dask.array.from_delayed(
+               dask.delayed(mmap_load_chunk)(
+                   filename,
+                   shape=shape,
+                   dtype=dtype,
+                   offset=offset,
+                   sl=slice(index, index + chunk_size)
+               ),
+               shape=(chunk_size, ) + shape[1:],
+               dtype=dtype
+           )
+           chunks.append(chunk)
+       return da.concatenate(chunks, axis=0)
+
+   x = mmap_dask_array(
+       filename='testfile-50-50-100-100-float32.raw',
+       shape=(50, 50, 100, 100),
+       dtype=np.float32
+   )
+
 
 Chunks
 ------


### PR DESCRIPTION
Closes #7355

- [x] Closes #7355
- [x] Tests added / passed
        * Documentation builds and example runs in notebook. No https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html to run the examples, I guess?
- [x] Passes `black dask` / `flake8 dask`
