### PR TITLE
[docs] replace 'container' with 'image'

### DIFF
--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -72,7 +72,7 @@ how to set up Dask on a variety of local and distributed hardware.
       ``Scheduler`` and ``Worker`` objects from Python as part of a distributed
       Tornado TCP application.  This page is useful for those building custom
       frameworks.
-    - :doc:`Docker <setup/docker>` containers are available and may be useful
+    - :doc:`Docker <setup/docker>` images are available and may be useful
       in some of the solutions above.
     - :doc:`Cloud <setup/cloud>` for current recommendations on how to
       deploy Dask and Jupyter on common cloud providers like Amazon, Google, or


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

The documentation at https://docs.dask.org/en/latest/setup.html currently says

> Docker containers are available and may be useful in some of the solutions above.

This PR proposes changing to the phrase "docker **image**", since I think that more accurately describes what is available. That also matches the language used in the page linked to from that line, https://docs.dask.org/en/latest/setup/docker.html.

Thanks for your time and consideration.