### PR TITLE
DataFrame: allow map_partitions to make Arrays with non-NumPy chunks

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5181,12 +5181,10 @@ def from_npy_stack(dirname, mmap_mode="r"):
     ]
     dsk = dict(zip(keys, values))
 
-    return Array(
-        dsk,
-        name,
-        chunks,
-        meta=np.ndarray(shape=(0,) * len(chunks), dtype=dtype).view(np.memmap),
-    )
+    result = Array(dsk, name, chunks, dtype)
+    result._meta = result._meta.view(type=np.memmap)
+    # ^ passing a memmap object as `meta` gets turned back into plain ndarray; override it
+    return result
 
 
 def new_da_object(dsk, name, chunks, meta=None, dtype=None):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6514,7 +6514,7 @@ def new_dd_object(dsk, name, meta, divisions):
                 suffix = (0,) * (len(chunks) - 1)
                 for i in range(len(chunks[0])):
                     layer[(name, i) + suffix] = layer.pop((name, i))
-        return da.Array(dsk, name=name, chunks=chunks, dtype=meta.dtype)
+        return da.Array(dsk, name=name, chunks=chunks, meta=meta)
     else:
         return get_parallel_type(meta)(dsk, name, meta, divisions)
 


### PR DESCRIPTION
Currently, if your `map_partitions` function returns an array-like object that's not a NumPy array (and has a dtype which isn't a NumPy dtype), `map_partitions` will fail when constructing `meta`. This PR allows whatever `meta` was produced to pass through directly to the Array. This _should_ make mapped functions that return pandas ExtensionArrays "just work" (can add some tests that that's so if we want to go ahead with this). And if the ExtensionArray type won't behave well as an Array chunk type for a particular operation, then hopefully doing that operation on the `meta` should fail as well.

This was a 1-line change, but it then breaks other tests:

* `DataFrame.to_records` now produces an Array where the `meta` is an `np.recarray`, not an `np.ndarray`
* But when you `compute` an Array of `recarray`s, the chunks get concatenated with `np.concatenate`, which doesn't preserve ndarray subclasses. This causes `assert_eq` to complain that the type changed when computed (meta type is `recarray`, computed type is `ndarray`).
* When you make `concatenate` preserve ndarray subclasses, `test_to_npy_stack` fails, because the `meta` for the Array indicated `ndarray`, but the result was actually `memmap` (because the chunks are `memmap`s, which we now preserve).

So that's why I also added logic for concatenate to preserve ndarray subclasses. If we even are okay with that change, I'd be fine splitting it to a separate PR for clarity.

cc @jrbourbeau: is this worth doing?

Related to https://github.com/dask/dask/issues/7377#issuecomment-799594266 and #7206.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
