### PR TITLE
Avoid quadratic-time performance for HLG culling

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -855,6 +855,8 @@ class HighLevelGraph(Mapping):
                 ret_layers[layer_name] = culled_layer
                 ret_key_deps.update(culled_deps)
 
+        # Converting dict_keys to a real set lets Python optimise the set
+        # intersection to iterate over the smaller of the two sets.
         ret_layers_keys = set(ret_layers.keys())
         ret_dependencies = {
             layer_name: ret_layers_keys & self.dependencies[layer_name]

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -859,7 +859,7 @@ class HighLevelGraph(Mapping):
         # intersection to iterate over the smaller of the two sets.
         ret_layers_keys = set(ret_layers.keys())
         ret_dependencies = {
-            layer_name: ret_layers_keys & self.dependencies[layer_name]
+            layer_name: self.dependencies[layer_name] & ret_layers_keys
             for layer_name in ret_layers
         }
 


### PR DESCRIPTION
There were two areas that scaled badly with the number of layers:
- _toposort_layers walked all the remaining layers after processing each
  layer. I've rewritten it using an algorithm that's linear in the total
  number of dependencies.
- Several of the set operations were written in a way that took time
  dependent on the larger set, rather than the smaller. In some cases
  this is due to one of the sets actually being a collections.abc.Set
  rather than a real Python set, which can cause supposedly in-place
  operations like `set1 |= set2` to create a new set, requiring time
  proportional to the size of the result rather than of set2.

- [x] Closes #7402
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
