### PR TITLE
Raise if attempting to group by pd.Grouper (#6104)

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3072,6 +3072,9 @@ Dask Name: {name}, {task} tasks""".format(
     def groupby(
         self, by=None, group_keys=True, sort=None, observed=None, dropna=None, **kwargs
     ):
+        if isinstance(by, pd.Grouper):
+            raise NotImplementedError("Dask does not support Pandas Grouper objects.")
+
         from dask.dataframe.groupby import SeriesGroupBy
 
         return SeriesGroupBy(
@@ -3960,6 +3963,9 @@ class DataFrame(_Frame):
     def groupby(
         self, by=None, group_keys=True, sort=None, observed=None, dropna=None, **kwargs
     ):
+        if isinstance(by, pd.Grouper):
+            raise NotImplementedError("Dask does not support Pandas Grouper objects.")
+
         from dask.dataframe.groupby import DataFrameGroupBy
 
         return DataFrameGroupBy(


### PR DESCRIPTION
- [x] Closes (the "good first issue" part of) #6104
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
