### PR TITLE
Fix typo in docs/source/develop.rst

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -294,7 +294,7 @@ Documentation is maintained in the RestructuredText markup language (``.rst``
 files) in ``dask/docs/source``.  The documentation consists both of prose
 and API documentation.
 
-The documentation is automatically build, and a live preview is available,
+The documentation is automatically built, and a live preview is available,
 for each pull request submitted to Dask. Additionally, you may also
 build the documentation yourself locally by following the instructions outlined
 below.


### PR DESCRIPTION
- [ ] ~~Closes #xxxx~~ N/A
- [ ] ~~Tests added / passed~~ N/A
- [ ] ~~Passes `black dask` / `flake8 dask`~~ N/A
- [x] Fixes a typo in the documentation.