### PR TITLE
Make changelog subtitles match the hierarchy

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -291,7 +291,7 @@ All changes
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Allow ``rechunk`` to evenly split into N chunks (:pr:`6420`) `Scott Sievert`_
 
@@ -300,7 +300,7 @@ Array
 -------------------
 
 Array
-+++++
+^^^^^
 
 - ``_repr_html_``: color sides darker instead of drawing all the lines (:pr:`6683`) `Julia Signell`_
 - Removes warning from ``nanstd`` and ``nanvar`` (:pr:`6667`) `Thomas J. Fan`_
@@ -308,24 +308,24 @@ Array
 - Replace ``np.searchsorted`` with ``bisect`` in indexing (:pr:`6669`) `Joachim B Haga`_
 
 Bag
-+++
+^^^
 
 - Make sure subprocesses have a consistent hash for bag ``groupby`` (:pr:`6660`) `Itamar Turner-Trauring`_
 
 Core
-++++
+^^^^
 
 - Revert "Use ``HighLevelGraph`` layers everywhere in collections (:pr:`6510`)" (:pr:`6697`) `Tom Augspurger`_
 - Use ``pandas.testing`` (:pr:`6687`) `John A Kirkham`_
 - Improve 128-bit floating-point skip in tests (:pr:`6676`) `Elliott Sales de Andrade`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Allow setting dataframe items using a bool dataframe (:pr:`6608`) `Julia Signell`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Fix typo (:pr:`6692`) `garanews`_
 - Fix a few typos (:pr:`6678`) `Pav A`_
@@ -335,7 +335,7 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Partially reverted changes to ``Array`` indexing that produces large changes.
   This restores the behavior from Dask 2.25.0 and earlier, with a warning
@@ -349,7 +349,7 @@ Array
 - Fix flakey array ``mean`` (:pr:`6656`) `Sam Grayson`_
 
 Core
-++++
+^^^^
 
 - Removed ``dsk`` equality check from ``SubgraphCallable.__eq__`` (:pr:`6666`) `Mads R. B. Kristensen`_
 - Use ``HighLevelGraph`` layers everywhere in collections (:pr:`6510`) `Mads R. B. Kristensen`_
@@ -357,7 +357,7 @@ Core
 - Stop writing commented out config files by default (:pr:`6647`) `Matthew Rocklin`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Add support for collect list aggregation via ``agg`` API (:pr:`6655`) `Madhur Tandon`_
 - Slightly better error message (:pr:`6657`) `Julia Signell`_
@@ -367,12 +367,12 @@ DataFrame
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Preserve ``dtype`` in ``svd`` (:pr:`6643`) `Eric Czech`_
 
 Core
-++++
+^^^^
 
 - ``store()``: create a single HLG layer (:pr:`6601`) `Mads R. B. Kristensen`_
 - Add pre-commit CI build (:pr:`6645`) `James Bourbeau`_
@@ -381,13 +381,13 @@ Core
 - Remove u string prefixes (:pr:`6633`) `Poruri Sai Rahul`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Improve error message for ``to_sql`` (:pr:`6638`) `Julia Signell`_
 - Use empty list as categories (:pr:`6626`) `Julia Signell`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Add ``autofunction`` to array api docs for more ufuncs (:pr:`6644`) `James Bourbeau`_
 - Add a number of missing ufuncs to ``dask.array`` docs (:pr:`6642`) `Ralf Gommers`_
@@ -398,7 +398,7 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Backend-aware dtype inference for single-chunk svd (:pr:`6623`) `Eric Czech`_
 - Make ``array.reduction`` docstring match for dtype (:pr:`6624`) `Martin Durant`_
@@ -415,14 +415,14 @@ Array
 - Fixup reshape on unknown dimensions and other testing fixes (:pr:`6578`) `Ryan Williams`_
 
 Core
-++++
+^^^^
 
 - Add validation and fixes for ``HighLevelGraph`` dependencies (:pr:`6588`) `Mads R. B. Kristensen`_
 - Fix linting issue (:pr:`6598`) `Tom Augspurger`_
 - Skip ``bokeh`` version 2.0.0 (:pr:`6572`) `John A Kirkham`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Added bytes/row calculation when using meta (:pr:`6585`) `McToel`_
 - Handle ``min_count`` in ``Series.sum`` / ``prod`` (:pr:`6618`) `Daniel Saxton`_
@@ -431,7 +431,7 @@ DataFrame
 - Fix wrong path when reading empty csv file (:pr:`6573`) `Abdulelah Bin Mahfoodh`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Doc: Troubleshooting dashboard 404 (:pr:`6215`) `Kilian Lieret`_
 - Fixup ``extraConfig`` example (:pr:`6625`) `Tom Augspurger`_
@@ -443,19 +443,19 @@ Documentation
 -------------------
 
 Core
-++++
+^^^^
 
 - Compare key hashes in ``subs()`` (:pr:`6559`) `Mads R. B. Kristensen`_
 - Rerun with latest ``black`` release (:pr:`6568`) `James Bourbeau`_
 - License update (:pr:`6554`) `Tom Augspurger`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Add gs ``read_parquet`` example (:pr:`6548`) `Ray Bell`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Remove version from documentation page names (:pr:`6558`) `James Bourbeau`_
 - Update ``kubernetes-helm.rst`` (:pr:`6523`) `David Sheldon`_
@@ -466,14 +466,14 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 -   Fix setting random seed in tests. (:pr:`6518`) `Elliott Sales de Andrade`_
 -   Support meta in apply gufunc (:pr:`6521`) `joshreback`_
 -   Replace `cupy.sparse` with `cupyx.scipy.sparse` (:pr:`6530`) `John A Kirkham`_
 
 Dataframe
-+++++++++
+^^^^^^^^^
 
 -   Bump up tolerance for rolling tests (:pr:`6502`) `Julia Signell`_
 -   Implement DatFrame.__len__ (:pr:`6515`) `Tom Augspurger`_
@@ -483,7 +483,7 @@ Dataframe
 -   Avoid schema validation by default in ArrowEngine (:pr:`6536`) `Richard (Rick) Zamora`_
 
 Core
-++++
+^^^^
 
 -   Use unpack_collections in make_blockwise_graph (:pr:`6517`) `Thomas J. Fan`_
 -   Move key_split() from optimization.py to utils.py (:pr:`6529`) `Mads R. B. Kristensen`_
@@ -494,25 +494,25 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Reduce ``np.zeros``, ``ones``, and ``full`` array size with broadcasting (:pr:`6491`) `Matthias Bussonnier`_
 - Add missing ``meta=`` for ``trim`` in ``map_overlap`` (:pr:`6494`) `Peter Andreas Entschev`_
 
 Bag
-+++
+^^^
 
 - Bag repartition partition size (:pr:`6371`) `joshreback`_
 
 Core
-++++
+^^^^
 
 - ``Scalar.__dask_layers__()`` to return ``self._name`` instead of ``self.key`` (:pr:`6507`) `Mads R. B. Kristensen`_
 - Update dependencies correctly in ``fuse_root`` optimization (:pr:`6508`) `Mads R. B. Kristensen`_
 
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Adds ``items`` to dataframe (:pr:`6503`) `Thomas J. Fan`_
 - Include compression in ``write_table`` call (:pr:`6499`) `Julia Signell`_
@@ -522,7 +522,7 @@ DataFrame
 - Fix duplicate parquet output in ``to_parquet`` (:pr:`6451`) `michaelnarodovitch`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Fix documentation ``da.histogram`` (:pr:`6439`) `Roberto Panai`_
 - Add ``agg`` ``nunique`` example (:pr:`6404`) `Ray Bell`_
@@ -534,12 +534,12 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Compatibility for NumPy dtype deprecation (:pr:`6430`) `Tom Augspurger`_
 
 Core
-++++
+^^^^
 
 - Implement ``sizeof`` for some ``bytes``-like objects (:pr:`6457`) `John A Kirkham`_
 - HTTP error for new ``fsspec`` (:pr:`6446`) `Martin Durant`_
@@ -548,7 +548,7 @@ Core
 - Use updated link in ``setup.cfg`` (:pr:`6426`) `Zhengnan`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Add single quotes around column names if strings (:pr:`6471`) `Gil Forsyth`_
 - Refactor ``ArrowEngine`` for better ``read_parquet`` performance (:pr:`6346`) `Richard (Rick) Zamora`_
@@ -558,7 +558,7 @@ DataFrame
 - Duplicate argument definitions in ``to_csv`` docstring (:pr:`6411`) `Jun Han (Johnson) Ooi`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Add utility to docs to convert YAML config to env vars and back (:pr:`6472`) `Jacob Tomlinson`_
 - Fix parameter server rendering (:pr:`6466`) `Scott Sievert`_
@@ -571,32 +571,32 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Correct error message in ``array.routines.gradient()`` (:pr:`6417`) `johnomotani`_
 - Fix blockwise concatenate for array with some ``dimension=1`` (:pr:`6342`) `Matthias Bussonnier`_
 
 Bag
-+++
+^^^
 
 - Fix ``bag.take`` example (:pr:`6418`) `Roberto Panai`_
 
 Core
-++++
+^^^^
 
 - Groups values in optimization pass should only be graph and keys -- not an optimization + keys (:pr:`6409`) `Ben Zaitlen`_
 - Call custom optimizations once, with ``kwargs`` provided (:pr:`6382`) `Clark Zinzow`_
 - Include ``pickle5`` for testing on Python 3.7 (:pr:`6379`) `John A Kirkham`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Correct typo in error message (:pr:`6422`) `Tom McTiernan`_
 - Use ``pytest.warns`` to check for ``UserWarning`` (:pr:`6378`) `Richard (Rick) Zamora`_
 - Parse ``bytes_per_chunk keyword`` from string (:pr:`6370`) `Matthew Rocklin`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Numpydoc formatting (:pr:`6421`) `Matthias Bussonnier`_
 - Unpin ``numpydoc`` following 1.1 release (:pr:`6407`) `Gil Forsyth`_
@@ -609,14 +609,14 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Register ``sizeof`` for numpy zero-strided arrays (:pr:`6343`) `Matthias Bussonnier`_
 - Use ``concatenate_lookup`` in ``concatenate`` (:pr:`6339`) `John A Kirkham`_
 - Fix rechunking of arrays with some zero-length dimensions (:pr:`6335`) `Matthias Bussonnier`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Dispatch ``iloc``` calls to ``getitem`` (:pr:`6355`) `Gil Forsyth`_
 - Handle unnamed pandas ``RangeIndex`` in fastparquet engine (:pr:`6350`) `Richard (Rick) Zamora`_
@@ -624,7 +624,7 @@ DataFrame
 - Use ``ignore_index`` for pandas' ``group_split_dispatch`` (:pr:`6251`) `Richard (Rick) Zamora`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Add doc describing argument (:pr:`6318`) `asmith26`_
 
@@ -633,13 +633,13 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Cast chunk sizes to python int ``dtype`` (:pr:`6326`) `Gil Forsyth`_
 - Add ``shape=None`` to ``*_like()`` array creation functions (:pr:`6064`) `Anderson Banihirwe`_
 
 Core
-++++
+^^^^
 
 - Update expected error msg for protocol difference in fsspec (:pr:`6331`) `Gil Forsyth`_
 - Fix for floats < 1 in ``parse_bytes`` (:pr:`6311`) `Gil Forsyth`_
@@ -648,14 +648,14 @@ Core
 - Remove unused testing function (:pr:`6304`) `James Lamb`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Add high-level CSV Subgraph (:pr:`6262`) `Gil Forsyth`_
 - Fix ``ValueError`` when merging an index-only 1-partition dataframe (:pr:`6309`) `Krishan Bhasin`_
 - Make ``index.map`` clear divisions. (:pr:`6285`) `Julia Signell`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Add link to 2020 survey (:pr:`6328`) `Tom Augspurger`_
 - Update ``bag.rst`` (:pr:`6317`) `Ben Shaver`_
@@ -665,19 +665,19 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Don't try to set name on ``full`` (:pr:`6299`) `Julia Signell`_
 - Histogram: support lazy values for range/bins (another way) (:pr:`6252`) `Gabe Joseph`_
 
 Core
-++++
+^^^^
 
 - Fix exception causes in ``utils.py`` (:pr:`6302`) `Ram Rachum`_
 - Improve performance of ``HighLevelGraph`` construction (:pr:`6293`) `Julia Signell`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Now readthedocs builds unrelased features' docstrings (:pr:`6295`) `Antonio Ercole De Luca`_
 - Add ``asyncssh`` intersphinx mappings (:pr:`6298`) `Jacob Tomlinson`_
@@ -687,7 +687,7 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Cast slicing index to dask array if same shape as original (:pr:`6273`) `Julia Signell`_
 - Fix ``stack`` error message (:pr:`6268`) `Stephanie Gott`_
@@ -696,12 +696,12 @@ Array
 - Pad resample divisions so that edges are counted (:pr:`6255`) `Julia Signell`_
 
 Bag
-+++
+^^^
 
 - Random sampling of k elements from a dask bag #4799 (:pr:`6239`) `Antonio Ercole De Luca`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Add ``dropna``, ``sort``, and ``ascending`` to ``sort_values`` (:pr:`5880`) `Julia Signell`_
 - Generalize ``from_dask_array`` (:pr:`6263`) `GALI PREM SAGAR`_
@@ -710,7 +710,7 @@ DataFrame
 - Add ``dd.to_sql`` (:pr:`6038`) `Ryan Williams`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Update remote data section (:pr:`6258`) `Ray Bell`_
 
@@ -719,12 +719,12 @@ Documentation
 -------------------
 
 Core
-++++
+^^^^
 
 - Re-add the ``complete`` extra (:pr:`6257`) `Jim Crist-Harif`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Raise error if ``resample`` isn't going to give right answer (:pr:`6244`) `Julia Signell`_
 
@@ -733,19 +733,19 @@ DataFrame
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Empty array rechunk (:pr:`6233`) `Andrew Fulton`_
 
 Core
-++++
+^^^^
 
 - Make ``pyyaml`` required (:pr:`6250`) `Jim Crist-Harif`_
 - Fix install commands from ``ImportError`` (:pr:`6238`) `Gaurav Sheni`_
 - Remove issue template (:pr:`6249`) `Jacob Tomlinson`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Pass ``ignore_index`` to ``dd_shuffle`` from ``DataFrame.shuffle`` (:pr:`6247`) `Richard (Rick) Zamora`_
 - Cope with missing HDF keys (:pr:`6204`) `Martin Durant`_
@@ -756,19 +756,19 @@ DataFrame
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Small improvements to ``da.pad`` (:pr:`6213`) `Mark Boer`_
 - Return ``tuple`` if multiple outputs in ``dask.array.apply_gufunc``, add test to check for tuple (:pr:`6207`) `Kai Mühlbauer`_
 - Support ``stack`` with unknown chunksizes (:pr:`6195`) `swapna`_
 
 Bag
-+++
+^^^
 
 - Random Choice on Bags (:pr:`6208`) `Antonio Ercole De Luca`_
 
 Core
-++++
+^^^^
 
 - Raise warning ``delayed.visualise()`` (:pr:`6216`) `Amol Umbarkar`_
 - Ensure other pickle arguments work (:pr:`6229`) `John A Kirkham`_
@@ -776,7 +776,7 @@ Core
 - Update ``dask.order.order`` to consider "next" nodes using both FIFO and LIFO (:pr:`5872`) `Erik Welch`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Use 0 as ``fill_value`` for more agg methods (:pr:`6245`) `Julia Signell`_
 - Generalize ``rearrange_by_column_tasks`` and add ``DataFrame.shuffle`` (:pr:`6066`) `Richard (Rick) Zamora`_
@@ -795,7 +795,7 @@ DataFrame
 - Skip ``test_to_parquet_with_get`` if no parquet libs available (:pr:`6188`) `Scott Sanderson`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Added documentation for ``distributed.Event`` class (:pr:`6231`) `Nils Braun`_
 - Doc write to remote (:pr:`6124`) `Ray Bell`_
@@ -805,14 +805,14 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Fix array general-reduction name (:pr:`6176`) `Nick Evans`_
 - Replace ``dim`` with ``shape`` in ``unravel_index`` (:pr:`6155`) `Julia Signell`_
 - Moment: handle all elements being masked (:pr:`5339`) `Gabe Joseph`_
 
 Core
-++++
+^^^^
 
 - Remove Redundant string concatenations in dask code-base (:pr:`6137`) `GALI PREM SAGAR`_
 - Upstream compat (:pr:`6159`) `Tom Augspurger`_
@@ -824,7 +824,7 @@ Core
 - Update manifest to include dask-schema (:pr:`6140`) `Ben Zaitlen`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Harden inconsistent-schema handling in pyarrow-based ``read_parquet`` (:pr:`6160`) `Richard (Rick) Zamora`_
 - Add compute ``kwargs`` to methods that write data to disk (:pr:`6056`) `Krishan Bhasin`_
@@ -832,7 +832,7 @@ DataFrame
 - Fix internal error in ``map_partitions`` with collections (:pr:`6103`) `Tom Augspurger`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Add phase of computation to index TOC (:pr:`6157`) `Ben Zaitlen`_
 - Remove unused imports in scheduling script (:pr:`6138`) `James Lamb`_
@@ -844,14 +844,14 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Update ``dask.array.from_array`` to warn when passed a Dask collection (:pr:`6122`) `James Bourbeau`_
 - Un-numpy like behaviour in ``dask.array.pad`` (:pr:`6042`) `Mark Boer`_
 - Add support for ``repeats=0`` in ``da.repeat`` (:pr:`6080`) `James Bourbeau`_
 
 Core
-++++
+^^^^
 
 - Fix yaml layout for schema (:pr:`6132`) `Ben Zaitlen`_
 - Configuration Reference (:pr:`6069`) `Ben Zaitlen`_
@@ -862,7 +862,7 @@ Core
 - Bump checkout action to v2 (:pr:`6065`) `James Bourbeau`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Generalize categorical calls to support cudf ``Categorical`` (:pr:`6113`) `GALI PREM SAGAR`_
 - Avoid reading ``_metadata`` on every worker (:pr:`6017`) `Richard (Rick) Zamora`_
@@ -874,7 +874,7 @@ DataFrame
 - Added mode (:pr:`5958`) `Adam Lewis`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Update "helm install" for helm 3 usage (:pr:`6130`) `JulianWgs`_
 - Extend preload documentation (:pr:`6077`) `Matthew Rocklin`_
@@ -888,24 +888,24 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Added ``np.iscomplexobj`` implementation (:pr:`6045`) `Tom Augspurger`_
 
 Core
-++++
+^^^^
 
 - Update ``test_rearrange_disk_cleanup_with_exception`` to pass without cloudpickle installed (:pr:`6052`) `James Bourbeau`_
 - Fixed flaky ``test-rearrange`` (:pr:`5977`) `Tom Augspurger`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Use ``_meta_nonempty`` for dtype casting in ``stack_partitions`` (:pr:`6061`) `mlondschien`_
 - Fix bugs in ``_metadata`` creation and filtering in parquet ``ArrowEngine`` (:pr:`6023`) `Richard (Rick) Zamora`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - DOC: Add name caveats (:pr:`6040`) `Tom Augspurger`_
 
@@ -914,19 +914,19 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Support ``dtype`` and other keyword arguments in ``da.random`` (:pr:`6030`) `Matthew Rocklin`_
 - Register support for ``cupy`` sparse ``hstack``/``vstack`` (:pr:`5735`) `Corey J. Nolet`_
 - Force ``self.name`` to ``str`` in ``dask.array`` (:pr:`6002`) `Chuanzhu Xu`_
 
 Bag
-+++
+^^^
 
 - Set ``rename_fused_keys`` to ``None`` by default in ``bag.optimize`` (:pr:`6000`) `Lucas Rademaker`_
 
 Core
-++++
+^^^^
 
 - Copy dict in ``to_graphviz`` to prevent overwriting (:pr:`5996`) `JulianWgs`_
 - Stricter pandas ``xfail`` (:pr:`6024`) `Tom Augspurger`_
@@ -935,7 +935,7 @@ Core
 - Move Windows CI builds to GitHub Actions (:pr:`5862`) `James Bourbeau`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Improve path-related exceptions in ``read_hdf`` (:pr:`6032`) `psimaj`_
 - Fix ``dtype`` handling in ``dd.concat`` (:pr:`6006`) `mlondschien`_
@@ -944,7 +944,7 @@ DataFrame
 - Added shuffle to ``DataFrame.random_split`` (:pr:`5980`) `petiop`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Fix indentation in scheduler-overview docs (:pr:`6022`) `Matthew Rocklin`_
 - Update task graphs in optimize docs (:pr:`5928`) `Julia Signell`_
@@ -955,7 +955,7 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Improve reuse of temporaries with numpy (:pr:`5933`) `Bruce Merry`_
 - Make ``map_blocks`` with ``block_info`` produce a ``Blockwise`` (:pr:`5896`) `Bruce Merry`_
@@ -964,7 +964,7 @@ Array
 - Adds empty mode to ``array.pad`` (:pr:`5931`) `Thomas J. Fan`_
 
 Core
-++++
+^^^^
 
 - Remove ``toolz.memoize`` dependency in ``dask.utils`` (:pr:`5978`) `Ryan Grout`_
 - Close pool leaking subprocess (:pr:`5979`) `Tom Augspurger`_
@@ -975,7 +975,7 @@ Core
 - Add remaining optional dependencies to Travis 3.8 CI build environment (:pr:`5920`) `James Bourbeau`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Skip parquet ``getitem`` optimization for some keys (:pr:`5917`) `Tom Augspurger`_
 - Add ``ignore_index`` argument to ``rearrange_by_column`` code path (:pr:`5973`) `Richard J Zamora`_
@@ -986,7 +986,7 @@ DataFrame
 - Use shallow copy for assign operations when possible (:pr:`5740`) `Richard J Zamora`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Changed above to below in ``dask.array.triu`` docs (:pr:`5984`) `Henrik Andersson`_
 - Array slicing: fix typo in ``slice_with_int_dask_array`` error message (:pr:`5981`) `Gabe Joseph`_
@@ -1003,7 +1003,7 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Cache result of ``Array.shape`` (:pr:`5916`) `Bruce Merry`_
 - Improve accuracy of ``estimate_graph_size`` for ``rechunk`` (:pr:`5907`) `Bruce Merry`_
@@ -1015,13 +1015,13 @@ Array
 - Avoid unnecessary ``__getitem__`` in ``block()`` when chunks have correct dimensionality (:pr:`5884`) `Thomas Robitaille`_
 
 Bag
-+++
+^^^
 
 - Add ``include_path`` option for ``dask.bag.read_text`` (:pr:`5836`) `Yifan Gu`_
 - Fixes ``ValueError`` in delayed execution of bagged NumPy array (:pr:`5828`) `Surya Avala`_
 
 Core
-++++
+^^^^
 
 - CI: Pin ``msgpack`` (:pr:`5923`) `Tom Augspurger`_
 - Rename ``test_inner`` to ``test_outer`` (:pr:`5922`) `Shiva Raisinghani`_
@@ -1034,7 +1034,7 @@ Core
 - Remove ``dask.dataframe`` import in tokenization code (:pr:`5855`) `James Bourbeau`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Require ``pandas>=0.23`` (:pr:`5883`) `Tom Augspurger`_
 - Remove lambda from dataframe aggregation (:pr:`5901`) `Matthew Rocklin`_
@@ -1045,7 +1045,7 @@ DataFrame
 - Use parquet read speed-ups from ``fastparquet.api.paths_to_cats``. (:pr:`5821`) `Igor Gotlibovych`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Deprecate ``doc_wraps`` (:pr:`5912`) `Tom Augspurger`_
 - Update array internal design docs for HighLevelGraph era (:pr:`5889`) `Bruce Merry`_
@@ -1083,19 +1083,19 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 - Unify chunks in ``broadcast_arrays`` (:pr:`5765`) `Matthew Rocklin`_
 
 Core
-++++
+^^^^
 
 - ``xfail`` CSV encoding tests (:pr:`5791`) `Tom Augspurger`_
 - Update order to handle empty dask graph (:pr:`5789`) `James Bourbeau`_
 - Redo ``dask.order.order`` (:pr:`5646`) `Erik Welch`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Add transparent compression for on-disk shuffle with ``partd`` (:pr:`5786`) `Christian Wesp`_
 - Fix ``repr`` for empty dataframes (:pr:`5781`) `Shiva Raisinghani`_
@@ -1110,7 +1110,7 @@ DataFrame
 - Fixed partitioning in set index for ordered ``Categorical`` (:pr:`5715`) `Tom Augspurger`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Note additional use case for ``normalize_token.register`` (:pr:`5766`) `Thomas A Caswell`_
 - Update bag ``repartition`` docstring (:pr:`5772`) `Timost`_
@@ -1123,20 +1123,20 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Support Array.view with dtype=None (:pr:`5736`) `Anderson Banihirwe`_
 -  Add dask.array.nanmedian (:pr:`5684`) `Deepak Cherian`_
 
 Core
-++++
+^^^^
 
 -  xfail test_temporary_directory on Python 3.8 (:pr:`5734`) `James Bourbeau`_
 -  Add support for Python 3.8 (:pr:`5603`) `James Bourbeau`_
 -  Use id to dedupe constants in rewrite_blockwise (:pr:`5696`) `Jim Crist`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Raise error when converting a dask dataframe scalar to a boolean (:pr:`5743`) `James Bourbeau`_
 -  Ensure dataframe groupby-variance is greater than zero (:pr:`5728`) `Matthew Rocklin`_
@@ -1147,7 +1147,7 @@ DataFrame
 -  Fix independent optimization of parquet-getitem (:pr:`5613`) `Tom Augspurger`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Update helm config doc (:pr:`5750`) `Ray Bell`_
 -  Link to examples.dask.org in several places (:pr:`5733`) `Tom Augspurger`_
@@ -1163,16 +1163,16 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 - Fix ``da.std`` to work with NumPy arrays (:pr:`5681`) `James Bourbeau`_
 
 Core
-++++
+^^^^
 - Register ``sizeof`` functions for Numba and RMM (:pr:`5668`) `John A Kirkham`_
 - Update meeting time (:pr:`5682`) `Tom Augspurger`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 - Modify ``dd.DataFrame.drop`` to use shallow copy (:pr:`5675`) `Richard J Zamora`_
 - Fix bug in ``_get_md_row_groups`` (:pr:`5673`) `Richard J Zamora`_
 - Close sqlalchemy engine after querying DB (:pr:`5629`) `Krishan Bhasin`_
@@ -1182,7 +1182,7 @@ DataFrame
 - Compute length of dataframe as length of first column (:pr:`5635`) `Matthew Rocklin`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 - Doc fixup (:pr:`5665`) `James Bourbeau`_
 - Update doc build instructions (:pr:`5640`) `James Bourbeau`_
 - Fix ADL link (:pr:`5639`) `Ray Bell`_
@@ -1193,15 +1193,15 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 - Use auto rechunking in ``da.rechunk`` if no value given (:pr:`5605`) `Matthew Rocklin`_
 
 Core
-++++
+^^^^
 - Add simple action to activate GH actions (:pr:`5619`) `James Bourbeau`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 - Fix "file_path_0" bug in ``aggregate_row_groups`` (:pr:`5627`) `Richard J Zamora`_
 - Add ``chunksize`` argument to ``read_parquet`` (:pr:`5607`) `Richard J Zamora`_
 - Change ``test_repartition_npartitions`` to support arch64 architecture (:pr:`5620`) `ossdev07`_
@@ -1210,7 +1210,7 @@ DataFrame
 - Enable gpu-backed covariance/correlation in dataframes (:pr:`5597`) `Richard J Zamora`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 - Fix institutional faq and unknown doc warnings (:pr:`5616`) `James Bourbeau`_
 - Add doc for some utils (:pr:`5609`) `Tom Augspurger`_
 - Removes ``html_extra_path`` (:pr:`5614`) `James Bourbeau`_
@@ -1221,18 +1221,18 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 -  Implement complete dask.array.tile function (:pr:`5574`) `Bouwe Andela`_
 -  Add median along an axis with automatic rechunking (:pr:`5575`) `Matthew Rocklin`_
 -  Allow da.asarray to chunk inputs (:pr:`5586`) `Matthew Rocklin`_
 
 Bag
-+++
+^^^
 
 -  Use key_split in Bag name (:pr:`5571`) `Matthew Rocklin`_
 
 Core
-++++
+^^^^
 -  Switch Doctests to Py3.7 (:pr:`5573`) `Ryan Nazareth`_
 -  Relax get_colors test to adapt to new Bokeh release (:pr:`5576`) `Matthew Rocklin`_
 -  Add dask.blockwise.fuse_roots optimization (:pr:`5451`) `Matthew Rocklin`_
@@ -1240,12 +1240,12 @@ Core
 -  Update fsspec, gcsfs, s3fs (:pr:`5588`) `Tom Augspurger`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 -  Add dropna argument to groupby (:pr:`5579`) `Richard J Zamora`_
 -  Revert "Remove import of dask_cudf, which is now a part of cudf (:pr:`5568`)" (:pr:`5590`) `Matthew Rocklin`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Add best practice for dask.compute function (:pr:`5583`) `Matthew Rocklin`_
 -  Create FUNDING.yml (:pr:`5587`) `Gina Helfrich`_
@@ -1260,7 +1260,7 @@ Documentation
 This release drops support for Python 3.5
 
 Array
-+++++
+^^^^^
 
 -  Reuse code for assert_eq util method (:pr:`5496`) `Vijayant`_
 -  Update da.array to always return a dask array (:pr:`5510`) `James Bourbeau`_
@@ -1270,7 +1270,7 @@ Array
 -  Removes bytes from sparse array HTML repr (:pr:`5556`) `James Bourbeau`_
 
 Core
-++++
+^^^^
 
 -  Drop Python 3.5 (:pr:`5528`) `James Bourbeau`_
 -  Update the use of fixtures in distributed tests (:pr:`5497`) `Matthew Rocklin`_
@@ -1284,7 +1284,7 @@ Core
 -  Make cloudpickle optional (:pr:`5511`) `Guido Imperiale`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Add an example of index_col usage (:pr:`3072`) `Bruno Bonfils`_
 -  Explicitly use iloc for row indexing (:pr:`5500`) `Krishan Bhasin`_
@@ -1298,7 +1298,7 @@ DataFrame
 -  Remove import of dask_cudf, which is now a part of cudf (:pr:`5568`) `Mads R. B. Kristensen`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Make capitalization more consistent in FAQ docs (:pr:`5512`) `Matthew Rocklin`_
 -  Add CONTRIBUTING.md (:pr:`5513`) `Jacob Tomlinson`_
@@ -1313,13 +1313,13 @@ Documentation
 ------------------
 
 Core
-++++
+^^^^
 
 - Call ``ensure_dict`` on graphs before entering ``toolz.merge`` (:pr:`5486`) `Matthew Rocklin`_
 - Consolidating hash dispatch functions (:pr:`5476`) `Richard J Zamora`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Support Python 3.5 in Parquet code (:pr:`5491`) `Ben Zaitlen`_
 - Avoid identity check in ``warn_dtype_mismatch`` (:pr:`5489`) `Tom Augspurger`_
@@ -1331,7 +1331,7 @@ DataFrame
 - Fix ``KeyError`` with Groupby label (:pr:`5467`) `Ryan Nazareth`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Use Zoom meeting instead of appear.in (:pr:`5494`) `Matthew Rocklin`_
 - Added curated list of resources (:pr:`5460`) `Javad`_
@@ -1344,18 +1344,18 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Correct chunk size logic for asymmetric overlaps (:pr:`5449`) `Ben Jeffery`_
 -  Make da.unify_chunks public API (:pr:`5443`) `Matthew Rocklin`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Fix dask.dataframe.fillna handling of Scalar object (:pr:`5463`) `Zhenqing Li`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Remove boxes in Spark comparison page (:pr:`5445`) `Matthew Rocklin`_
 -  Add latest presentations (:pr:`5446`) `Javad`_
@@ -1366,14 +1366,14 @@ Documentation
 ------------------
 
 Core
-++++
+^^^^
 
 -  Add sentinel no_default to get_dependencies task (:pr:`5420`) `James Bourbeau`_
 -  Update fsspec version (:pr:`5415`) `Matthew Rocklin`_
 -  Remove PY2 checks (:pr:`5400`) `Jim Crist`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Add option to not check meta in dd.from_delayed (:pr:`5436`) `Christopher J. Wright`_
 -  Fix test_timeseries_nulls_in_schema failures with pyarrow master (:pr:`5421`) `Richard J Zamora`_
@@ -1385,7 +1385,7 @@ DataFrame
 -  drop_duplicates support for positional subset parameter (:pr:`5410`) `Wes Roach`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Add screencasts to array, bag, dataframe, delayed, futures and setup  (:pr:`5429`) (:pr:`5424`) `Matthew Rocklin`_
 -  Fix delimeter parsing documentation (:pr:`5428`) `Mahmut Bulut`_
@@ -1396,7 +1396,7 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 - Adds explicit ``h5py.File`` mode (:pr:`5390`) `James Bourbeau`_
 - Provides method to compute unknown array chunks sizes (:pr:`5312`) `Scott Sievert`_
@@ -1408,7 +1408,7 @@ Array
 - Array.random.choice: handle array-like non-arrays (:pr:`5283`) `Gabe Joseph`_
 
 Core
-++++
+^^^^
 
 - Remove deprecated code (:pr:`5401`) `Jim Crist`_
 - Fix ``funcname`` when vectorized func has no ``__name__`` (:pr:`5399`) `James Bourbeau`_
@@ -1420,7 +1420,7 @@ Core
 - Upstream fixups (:pr:`5300`) `Tom Augspurger`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Allow pandas to cast type of statistics (:pr:`5402`) `Richard J Zamora`_
 - Preserve index dtype after applying ``dd.pivot_table`` (:pr:`5385`) `therhaag`_
@@ -1436,7 +1436,7 @@ DataFrame
 - Add correlation calculation and add test (:pr:`5296`) `Ben Zaitlen`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Numpy docstring standard has moved (:pr:`5405`) `Wes Roach`_
 - Reference correct NumPy array name (:pr:`5403`) `Wes Roach`_
@@ -1456,7 +1456,7 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 - Raise exception when ``from_array`` is given a dask array (:pr:`5280`) `David Hoese`_
 - Avoid adjusting gufunc's meta dtype twice (:pr:`5274`) `Peter Andreas Entschev`_
@@ -1467,12 +1467,12 @@ Array
 - Fix ordering when indexing a dask array with a bool dask array (:pr:`5151`) `James Bourbeau`_
 
 Bag
-+++
+^^^
 
 - Add workaround for memory leaks in bag generators (:pr:`5208`) `Marco Neumann`_
 
 Core
-++++
+^^^^
 
 - Set strict xfail option (:pr:`5220`) `James Bourbeau`_
 - test-upstream (:pr:`5267`) `Tom Augspurger`_
@@ -1486,7 +1486,7 @@ Core
 - Bump NumPy and Pandas to 1.17 and 0.25 in CI test (:pr:`5179`) `John A Kirkham`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Fix ``DataFrame.query`` docstring (incorrect numexpr API) (:pr:`5271`) `Doug Davis`_
 - Parquet metadata-handling improvements (:pr:`5218`) `Richard J Zamora`_
@@ -1499,7 +1499,7 @@ DataFrame
 - Add columns argument in drop function (:pr:`5223`) `Henrique Ribeiro`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Update institutional FAQ doc (:pr:`5277`) `Matthew Rocklin`_
 - Add draft of institutional FAQ (:pr:`5214`) `Matthew Rocklin`_
@@ -1526,7 +1526,7 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Use da.from_array(..., asarray=False) if input follows NEP-18 (:pr:`5074`) `Matthew Rocklin`_
 -  Add missing attributes to from_array documentation (:pr:`5108`) `Peter Andreas Entschev`_
@@ -1538,12 +1538,12 @@ Array
 -  Support Numpy 1.17 in tests (:pr:`5192`) `Matthew Rocklin`_
 
 Bag
-+++
+^^^
 
 -  Supply pool to bag test to resolve intermittent failure (:pr:`5172`) `Tom Augspurger`_
 
 Core
-++++
+^^^^
 
 -  Base dask on fsspec (:pr:`5064`) (:pr:`5121`) `Martin Durant`_
 -  Various upstream compatibility fixes (:pr:`5056`) `Tom Augspurger`_
@@ -1552,7 +1552,7 @@ Core
 -  Ignore some more invalid value warnings. (:pr:`5140`) `Elliott Sales de Andrade`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Fix pd.MultiIndex size estimate (:pr:`5066`) `Brett Naul`_
 -  Generalizing has_known_categories (:pr:`5090`) `GALI PREM SAGAR`_
@@ -1568,7 +1568,7 @@ DataFrame
 -  Allow fastparquet to handle gather_statistics=False for file lists (:pr:`5157`) `Richard J Zamora`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Adds NumFOCUS badge to the README (:pr:`5086`) `James Bourbeau`_
 -  Update developer docs [ci skip] (:pr:`5093`) `Jim Crist`_
@@ -1588,7 +1588,7 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 - Add ``recompute=`` keyword to ``svd_compressed`` for lower-memory use (:pr:`5041`) `Matthew Rocklin`_
 - Change ``__array_function__`` implementation for backwards compatibility (:pr:`5043`) `Ralf Gommers`_
@@ -1597,7 +1597,7 @@ Array
 - Drop size 0 arrays in ``stack`` (:pr:`4978`) `John A Kirkham`_
 
 Core
-++++
+^^^^
 
 - Removes index keyword from pandas ``to_parquet`` call (:pr:`5075`) `James Bourbeau`_
 - Fixes upstream dev CI build installation (:pr:`5072`) `James Bourbeau`_
@@ -1607,7 +1607,7 @@ Core
 - pytest 5.0 compat (:pr:`5027`) `Tom Augspurger`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Fix ``compute_meta`` recursion in blockwise (:pr:`5048`) `Peter Andreas Entschev`_
 - Remove hard dependency on pandas in ``get_dummies`` (:pr:`5057`) `GALI PREM SAGAR`_
@@ -1622,7 +1622,7 @@ DataFrame
 - Adds path-like support to ``to_hdf`` (:pr:`5003`) `James Bourbeau`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Point to latest K8s setup article in JupyterHub docs (:pr:`5065`) `Sean McKenna`_
 - Changes vizualize to visualize (:pr:`5061`) `David Brochart`_
@@ -1636,7 +1636,7 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Support automatic chunking in da.indices (:pr:`4981`) `James Bourbeau`_
 -  Err if there are no arrays to stack (:pr:`4975`) `John A Kirkham`_
@@ -1673,7 +1673,7 @@ Array
 
 
 Core
-++++
+^^^^
 
 -  **Drop Python 2.7** (:pr:`4919`) `Jim Crist`_
 -  Quiet dependency installs in CI (:pr:`4960`) `Tom Augspurger`_
@@ -1694,7 +1694,7 @@ Core
 
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Add an optional partition_size parameter to repartition (:pr:`4416`) `George Sakkis`_
 -  merge_asof and prefix_reduction (:pr:`4877`) `Cody Johnson`_
@@ -1730,7 +1730,7 @@ DataFrame
 
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Move CLI API docs to relavant pages (:pr:`4980`) `James Bourbeau`_
 -  Add to_datetime function to dataframe API docs `Matthew Rocklin`_
@@ -1754,7 +1754,7 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 - Clarify regions kwarg to array.store (:pr:`4759`) `Martin Durant`_
 - Add dtype= parameter to da.random.randint (:pr:`4753`) `Matthew Rocklin`_
@@ -1763,12 +1763,12 @@ Array
 - Remove normed keyword in da.histogram (:pr:`4755`) `Matthew Rocklin`_
 
 Bag
-+++
+^^^
 
 - Add key argument to Bag.distinct (:pr:`4423`) `Daniel Severo`_
 
 Core
-++++
+^^^^
 
 - Add core dask config file (:pr:`4774`) `Matthew Rocklin`_
 - Add core dask config file to MANIFEST.in (:pr:`4780`) `James Bourbeau`_
@@ -1777,7 +1777,7 @@ Core
 - Remove config key normalization (:pr:`4742`) `Jim Crist`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Remove explicit references to Pandas in dask.dataframe.groupby (:pr:`4778`) `Matthew Rocklin`_
 - Add support for group_keys kwarg in DataFrame.groupby() (:pr:`4771`) `Brian Chu`_
@@ -1789,7 +1789,7 @@ DataFrame
 - Implement Series.str.split(expand=True) (:pr:`4744`) `Matthew Rocklin`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 - Tweaks to develop.rst from trying to run tests (:pr:`4772`) `Christian Hudon`_
 - Add document describing phases of computation (:pr:`4766`) `Matthew Rocklin`_
@@ -1805,7 +1805,7 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Fix map_blocks with block_info and broadcasting (:pr:`4737`) `Bruce Merry`_
 -  Make 'minlength' keyword argument optional in da.bincount (:pr:`4684`) `Genevieve Buckley`_
@@ -1818,7 +1818,7 @@ Array
 -  Add TileDB backend (:pr:`4679`) `Isaiah Norton`_
 
 Core
-++++
+^^^^
 
 -  Delay long list arguments (:pr:`4735`) `Matthew Rocklin`_
 -  Bump to numpy >= 1.13, pandas >= 0.21.0 (:pr:`4720`) `Jim Crist`_
@@ -1827,7 +1827,7 @@ Core
 -  Remove assertion in HighLevelGraph constructor (:pr:`4699`) `Matthew Rocklin`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Change cum-aggregation last-nonnull-value algorithm (:pr:`4736`) `Nick Becker`_
 -  Fixup series-groupby-apply (:pr:`4738`) `Jim Crist`_
@@ -1840,7 +1840,7 @@ DataFrame
 -  Add 'threshold' parameter to pd.DataFrame.dropna (:pr:`4625`) `Nathan Matare`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -   Add warning about derived docstrings early in the docstring (:pr:`4716`) `Matthew Rocklin`_
 -   Create dataframe best practices doc (:pr:`4703`) `Matthew Rocklin`_
@@ -1852,7 +1852,7 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Fixed mean() and moment() on sparse arrays (:pr:`4525`) `Peter Andreas Entschev`_
 -  Add test for NEP-18. (:pr:`4675`) `Hameer Abbasi`_
@@ -1860,14 +1860,14 @@ Array
 -  Fix limit value in auto_chunks (:pr:`4645`) `Matthew Rocklin`_
 
 Core
-++++
+^^^^
 
 -  Updated diagnostic bokeh test for compatibility with bokeh>=1.1.0 (:pr:`4680`) `Philipp Rudiger`_
 -  Adjusts codecov's target/threshold, disable patch (:pr:`4671`) `Peter Andreas Entschev`_
 -  Always start with empty http buffer, not None (:pr:`4673`) `Martin Durant`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Propagate index dtype and name when create dask dataframe from array (:pr:`4686`) `Henrique Ribeiro`_
 -  Fix ordering of quantiles in describe (:pr:`4647`) `gregrf`_
@@ -1881,7 +1881,7 @@ DataFrame
 -  Correct quantile to handle unsorted quantiles (:pr:`4650`) `gregrf`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Add delayed extra dependencies to install docs (:pr:`4660`) `James Bourbeau`_
 
@@ -1890,12 +1890,12 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Ensure that we use the dtype keyword in normalize_chunks (:pr:`4646`) `Matthew Rocklin`_
 
 Core
-++++
+^^^^
 
 -  Use recursive glob in LocalFileSystem (:pr:`4186`) `Brett Naul`_
 -  Avoid YAML deprecation (:pr:`4603`)
@@ -1907,7 +1907,7 @@ Core
 -  Enable codecov (:pr:`4631`) `Peter Andreas Entschev`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Support setting the index (:pr:`4565`)
 -  DataFrame.itertuples accepts index, name kwargs (:pr:`4593`) `Dan O'Donovan`_
@@ -1925,7 +1925,7 @@ DataFrame
 -  Add clear exception message when using index or index_col in read_csv (:pr:`4651`) `Álvaro Abella Bascarán`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Add documentation for custom groupby aggregations (:pr:`4571`)
 -  Docs dataframe joins (:pr:`4569`)
@@ -1938,7 +1938,7 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Use mask selection in compress (:pr:`4548`) `John A Kirkham`_
 -  Use `asarray` in `extract` (:pr:`4549`) `John A Kirkham`_
@@ -1946,13 +1946,13 @@ Array
 -  Fix CuPy tests or properly marks as xfail (:pr:`4564`) `Peter Andreas Entschev`_
 
 Core
-++++
+^^^^
 
 -  Fix local scheduler callback to deal with custom caching (:pr:`4542`) `Yu Feng`_
 -  Use parse_bytes in read_bytes(sample=...) (:pr:`4554`) `Matthew Rocklin`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Fix up groupby-standard deviation again on object dtype keys (:pr:`4541`) `Matthew Rocklin`_
 -  TST/CI: Updates for pandas 0.24.1 (:pr:`4551`) `Tom Augspurger`_
@@ -1960,7 +1960,7 @@ DataFrame
 -  Add support in read_csv for parameter skiprows for other iterables (:pr:`4560`) `@JulianWgs`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  DataFrame to Array conversion and unknown chunks (:pr:`4516`) `Scott Sievert`_
 -  Add docs for random array creation (:pr:`4566`) `Matthew Rocklin`_
@@ -1971,13 +1971,13 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Modify mean chunk functions to return dicts rather than arrays (:pr:`4513`) `Matthew Rocklin`_
 -  Change sparse installation in CI for NumPy/Python2 compatibility (:pr:`4537`) `Matthew Rocklin`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Make merge dispatchable on pandas/other dataframe types (:pr:`4522`) `Matthew Rocklin`_
 -  read_sql_table - datetime index fix and  index type checking (:pr:`4474`) `Joe Corbett`_
@@ -1986,7 +1986,7 @@ DataFrame
 -  Fixes #4467 : Updates time_series for pandas deprecation (:pr:`4530`) `@HSR05`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Add missing method to documentation index (:pr:`4528`) `Bart Broere`_
 
@@ -1995,7 +1995,7 @@ Documentation
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Fix another unicode/mixed-type edge case in normalize_array (:pr:`4489`) `Marco Neumann`_
 -  Add dask.array.diagonal (:pr:`4431`) `Danilo Horta`_
@@ -2004,7 +2004,7 @@ Array
 
 
 Bag
-+++
+^^^
 
 -  Don't inline output keys in dask.bag (:pr:`4464`) `Jim Crist`_
 -  Ensure that bag.from_sequence always includes at least one partition (:pr:`4475`) `Anderson Banihirwe`_
@@ -2014,7 +2014,7 @@ Bag
 
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Fix relative path parsing on windows when using fastparquet (:pr:`4445`) `Janne Vuorela`_
 -  Fix bug in pyarrow and hdfs (:pr:`4453`) (:pr:`4455`) `Michał Jastrzębski`_
@@ -2030,7 +2030,7 @@ DataFrame
 -  Propagate index metadata if not specified (:pr:`4509`) `Jim Crist`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Update docs to use ``from_zarr`` (:pr:`4472`) `John A Kirkham`_
 -  DOC: add section of `Using Other S3-Compatible Services` for remote-data-services (:pr:`4405`) `Aploium`_
@@ -2038,7 +2038,7 @@ Documentation
 -  Add quotes to pip install [skip-ci] (:pr:`4508`) `James Bourbeau`_
 
 Core
-++++
+^^^^
 
 -  Extend started_cbs AFTER state is initialized (:pr:`4460`) `Marco Neumann`_
 -  Fix bug in HTTPFile._fetch_range with headers (:pr:`4479`) (:pr:`4480`) `Ross Petchler`_
@@ -2049,14 +2049,14 @@ Core
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Add support for cupy.einsum (:pr:`4402`) `Johnnie Gray`_
 -  Provide byte size in chunks keyword (:pr:`4434`) `Adam Beberg`_
 -  Raise more informative error for histogram bins and range (:pr:`4430`) `James Bourbeau`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Lazily register more cudf functions and move to backends file (:pr:`4396`) `Matthew Rocklin`_
 -  Fix ORC tests for pyarrow 0.12.0 (:pr:`4413`) `Jim Crist`_
@@ -2066,18 +2066,18 @@ DataFrame
 -  Pass username as 'user' when using pyarrow (:pr:`4438`) `Roma Sokolov`_
 
 Delayed
-+++++++
+^^^^^^^
 
 -  Fix DelayedAttr return value (:pr:`4440`) `Matthew Rocklin`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Use SVG for pipeline graphic (:pr:`4406`) `John A Kirkham`_
 -  Add doctest-modules to py.test documentation (:pr:`4427`) `Daniel Severo`_
 
 Core
-++++
+^^^^
 
 -  Work around psutil 5.5.0 not allowing pickling Process objects `Janne Vuorela`_
 
@@ -2086,7 +2086,7 @@ Core
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Fix the average function when there is a masked array (:pr:`4236`) `Damien Garaud`_
 -  Add allow_unknown_chunksizes to hstack and vstack (:pr:`4287`) `Paul Vecchio`_
@@ -2100,7 +2100,7 @@ Array
 -  Rework normalize_array for numpy data (:pr:`4312`) `Marco Neumann`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Add fill_value support for series comparisons (:pr:`4250`) `James Bourbeau`_
 -  Add schema name in read_sql_table for empty tables (:pr:`4268`) `Mina Farid`_
@@ -2116,7 +2116,7 @@ DataFrame
 -  Pandas 0.24.0 compat (:pr:`4374`) `Tom Augspurger`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Fix link to 'map_blocks' function in array api docs (:pr:`4258`) `David Hoese`_
 -  Add a paragraph on Dask-Yarn in the cloud docs (:pr:`4260`) `Jim Crist`_
@@ -2130,7 +2130,7 @@ Documentation
 -  Added documentation for dask.dataframe.merge (:pr:`4382`) `Jendrik Jördening`_
 
 Core
-++++
+^^^^
 
 -  Avoid recursion in dask.core.get (:pr:`4219`) `Matthew Rocklin`_
 -  Remove verbose flag from pytest setup.cfg (:pr:`4281`) `Matthew Rocklin`_
@@ -2154,26 +2154,26 @@ Core
 ------------------
 
 Array
-+++++
+^^^^^
 
 -  Add nancumsum/nancumprod unit tests (:pr:`4215`) `Guido Imperiale`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Add index to to_dask_dataframe docstring (:pr:`4232`) `James Bourbeau`_
 -  Text and fix when appending categoricals with fastparquet (:pr:`4245`) `Martin Durant`_
 -  Don't reread metadata when passing ParquetFile to read_parquet (:pr:`4247`) `Martin Durant`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Copy edit documentation (:pr:`4222`) (:pr:`4224`) (:pr:`4228`) (:pr:`4231`) (:pr:`4230`) (:pr:`4234`) (:pr:`4235`) (:pr:`4254`) `Miguel Farrajota`_
 -  Updated doc for the new scheduler keyword (:pr:`4251`) `@milesial`_
 
 
 Core
-++++
+^^^^
 
 -  Avoid a few warnings (:pr:`4223`) `Matthew Rocklin`_
 -  Remove dask.store module (:pr:`4221`) `Matthew Rocklin`_
@@ -2184,19 +2184,19 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  Avoid fusing dependencies of atop reductions (:pr:`4207`) `Matthew Rocklin`_
 
 Dataframe
-+++++++++
+^^^^^^^^^
 
 -  Improve memory footprint for dataframe correlation (:pr:`4193`) `Damien Garaud`_
 -  Add empty DataFrame check to boundary_slice (:pr:`4212`) `James Bourbeau`_
 
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Copy edit documentation (:pr:`4197`) (:pr:`4204`) (:pr:`4198`) (:pr:`4199`) (:pr:`4200`) (:pr:`4202`) (:pr:`4209`) `Miguel Farrajota`_
 -  Add stats module namespace (:pr:`4206`) `James Bourbeau`_
@@ -2207,7 +2207,7 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  Only allocate the result space in wrapped_pad_func (:pr:`4153`) `John A Kirkham`_
 -  Generalize expand_pad_width to expand_pad_value (:pr:`4150`) `John A Kirkham`_
@@ -2217,7 +2217,7 @@ Array
 -  Validate index inputs to atop (:pr:`4182`) `Matthew Rocklin`_
 
 Core
-++++
+^^^^
 
 -  Dask.config set and get normalize underscores and hyphens (:pr:`4143`) `James Bourbeau`_
 -  Only subs on core collections, not subclasses (:pr:`4159`) `Matthew Rocklin`_
@@ -2228,14 +2228,14 @@ Core
 -  Use key_split rather than funcname in visualize names (:pr:`4160`) `Matthew Rocklin`_
 
 Dataframe
-+++++++++
+^^^^^^^^^
 
 -  Add fix for  DataFrame.__setitem__ for index (:pr:`4151`) `Anderson Banihirwe`_
 -  Fix column choice when passing list of files to fastparquet (:pr:`4174`) `Martin Durant`_
 -  Pass engine_kwargs from read_sql_table to sqlalchemy (:pr:`4187`) `Damien Garaud`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Fix documentation in Delayed best practices example that returned an empty list (:pr:`4147`) `Jonathan Fraine`_
 -  Copy edit documentation (:pr:`4164`) (:pr:`4175`) (:pr:`4185`) (:pr:`4192`) (:pr:`4191`) (:pr:`4190`) (:pr:`4180`) `Miguel Farrajota`_
@@ -2246,7 +2246,7 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  Fuse Atop operations (:pr:`3998`), (:pr:`4081`) `Matthew Rocklin`_
 -  Support da.asanyarray on dask dataframes (:pr:`4080`) `Matthew Rocklin`_
@@ -2259,12 +2259,12 @@ Array
 -  Normalize reversed slices in dask array (:pr:`4126`) `Matthew Rocklin`_
 
 Bag
-+++
+^^^
 
 -  Add bag.to_avro (:pr:`4076`) `Martin Durant`_
 
 Core
-++++
+^^^^
 
 -  Pull num_workers from config.get (:pr:`4086`), (:pr:`4093`) `James Bourbeau`_
 -  Fix invalid escape sequences with raw strings (:pr:`4112`) `Elliott Sales de Andrade`_
@@ -2273,7 +2273,7 @@ Core
 -  Avoid collections.Mapping/Sequence (:pr:`4138`)  `Matthew Rocklin`_
 
 Dataframe
-+++++++++
+^^^^^^^^^
 
 -  Include index keyword in to_dask_dataframe (:pr:`4071`) `Matthew Rocklin`_
 -  add support for duplicate column names (:pr:`4087`) `Jan Koch`_
@@ -2285,7 +2285,7 @@ Dataframe
 -  Swap 'old' and 'previous' when reporting append error (:pr:`4130`) `Martin Durant`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Copy edit documentation (:pr:`4073`), (:pr:`4074`), (:pr:`4094`), (:pr:`4097`), (:pr:`4107`), (:pr:`4124`), (:pr:`4133`), (:pr:`4139`) `Miguel Farrajota`_
 -  Fix typo in code example (:pr:`4089`) `Antonino Ingargiola`_
@@ -2300,28 +2300,28 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  Implement ``apply_gufunc(..., axes=..., keepdims=...)`` (:pr:`3985`) `Markus Gonser`_
 
 Bag
-+++
+^^^
 
 -  Fix typo in datasets.make_people (:pr:`4069`) `Matthew Rocklin`_
 
 Dataframe
-+++++++++
+^^^^^^^^^
 
 -  Added `percentiles` options for `dask.dataframe.describe` method (:pr:`4067`) `Zhenqing Li`_
 -  Add DataFrame.partitions accessor similar to Array.blocks (:pr:`4066`) `Matthew Rocklin`_
 
 Core
-++++
+^^^^
 
 -  Pass get functions and Clients through scheduler keyword (:pr:`4062`) `Matthew Rocklin`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Fix Typo on hpc example. (missing `=` in kwarg). (:pr:`4068`) `Matthias Bussonier`_
 -  Extensive copy-editing: (:pr:`4065`), (:pr:`4064`), (:pr:`4063`) `Miguel Farrajota`_
@@ -2331,7 +2331,7 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 -   Make da.RandomState extensible to other modules (:pr:`4041`) `Matthew Rocklin`_
 -   Support unknown dims in ravel no-op case (:pr:`4055`) `Jim Crist`_
@@ -2344,7 +2344,7 @@ Array
 -   Add unravel_index (:pr:`3958`) `John A Kirkham`_
 
 Bag
-+++
+^^^
 
 -   Sort result in Bag.frequencies (:pr:`4033`) `Matthew Rocklin`_
 -   Add support for npartitions=1 edge case in groupby (:pr:`4050`) `James Bourbeau`_
@@ -2353,7 +2353,7 @@ Bag
 -   Add bag.read_avro (:pr:`4000`) (:pr:`4007`) `Martin Durant`_
 
 Dataframe
-+++++++++
+^^^^^^^^^
 
 -   Added an ``index`` parameter to :meth:`dask.dataframe.from_dask_array` for creating a dask DataFrame from a dask Array with a given index. (:pr:`3991`) `Tom Augspurger`_
 -   Improve sub-classability of dask dataframe (:pr:`4015`) `Matthew Rocklin`_
@@ -2365,7 +2365,7 @@ Dataframe
 -   Fail early in fastparquet read for nonexistent column (:pr:`3989`) `Martin Durant`_
 
 Core
-++++
+^^^^
 
 -   Add support for npartitions=1 edge case in groupby (:pr:`4050`) `James Bourbeau`_
 -   Automatically wrap large arguments with dask.delayed in map_blocks/partitions (:pr:`4002`) `Matthew Rocklin`_
@@ -2373,7 +2373,7 @@ Core
 -   Make multiprocessing context configurable (:pr:`3763`) `Itamar Turner-Trauring`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -   Extensive copy-editing  (:pr:`4049`), (:pr:`4034`),  (:pr:`4031`), (:pr:`4020`), (:pr:`4021`), (:pr:`4022`), (:pr:`4023`), (:pr:`4016`), (:pr:`4017`), (:pr:`4010`), (:pr:`3997`), (:pr:`3996`), `Miguel Farrajota`_
 -   Update shuffle method selection docs (:pr:`4048`) `James Bourbeau`_
@@ -2386,7 +2386,7 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  ``apply_gufunc`` implements automatic infer of functions output dtypes (:pr:`3936`) `Markus Gonser`_
 -  Fix array histogram range error when array has nans (:pr:`3980`) `James Bourbeau`_
@@ -2395,13 +2395,13 @@ Array
 -  Support gradient with coordinate (:pr:`3949`) `Keisuke Fujii`_
 
 Core
-++++
+^^^^
 
 -  Fix use of has_keyword with partial in Python 2.7 (:pr:`3966`) `Mark Harfouche`_
 -  Set pyarrow as default for HDFS (:pr:`3957`) `Matthew Rocklin`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  Use dask_sphinx_theme (:pr:`3963`) `Matthew Rocklin`_
 -  Use JupyterLab in Binder links from main page `Matthew Rocklin`_
@@ -2412,7 +2412,7 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  Don't enforce dtype if result has no dtype (:pr:`3928`) `Matthew Rocklin`_
 -  Fix NumPy issubtype deprecation warning (:pr:`3939`) `Bruce Merry`_
@@ -2421,7 +2421,7 @@ Array
 -  Linalg.norm ndim along axis partial fix (:pr:`3933`) `Tobias de Jong`_
 
 Dataframe
-+++++++++
+^^^^^^^^^
 
 -  Deterministic DataFrame.set_index (:pr:`3867`) `George Sakkis`_
 -  Fix divisions in read_parquet when dealing with filters #3831 #3930 (:pr:`3923`) (:pr:`3931`)  `@andrethrill`_
@@ -2431,7 +2431,7 @@ Dataframe
 -  Don't constrict stage/k dtype in dataframe shuffle (:pr:`3942`) `Matthew Rocklin`_
 
 Documentation
-+++++++++++++
+^^^^^^^^^^^^^
 
 -  DOC: Add hint on how to render task graphs horizontally (:pr:`3922`) `Uwe Korn`_
 -  Add try-now button to main landing page (:pr:`3924`) `Matthew Rocklin`_
@@ -2441,7 +2441,7 @@ Documentation
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  Support coordinate in gradient (:pr:`3949`) `Keisuke Fujii`_
 -  Fix argtopk split_every bug (:pr:`3810`) `Guido Imperiale`_
@@ -2456,7 +2456,7 @@ Array
 -  Ensure copy preserves masked arrays (:pr:`3852`) `Tobias de Jong`_
 
 DataFrame
-++++++++++
+^^^^^^^^^^
 
 -  Added ``dtype`` and ``sparse`` keywords to :func:`dask.dataframe.get_dummies` (:pr:`3792`) `Tom Augspurger`_
 -  Added :meth:`dask.dataframe.to_dask_array` for converting a Dask Series or DataFrame to a
@@ -2476,7 +2476,7 @@ DataFrame
 -  Include filename in read_csv (:pr:`3908`) `Julia Signell`_
 
 Core
-++++
+^^^^
 
 -  Better error message on import when missing common dependencies (:pr:`3771`) `Danilo Horta`_
 -  Drop Python 3.4 support (:pr:`3840`) `Jim Crist`_
@@ -2491,7 +2491,7 @@ Core
 -  Add expand_environment_variables to dask.config (:pr:`3893`) `Joe Hamman`_
 
 Docs
-++++
+^^^^
 
 -  Fix typo in import statement of diagnostics (:pr:`3826`) `John Mrziglod`_
 -  Add link to YARN docs (:pr:`3838`) `Jim Crist`_
@@ -2508,7 +2508,7 @@ Docs
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Reimplemented ``argtopk`` to make it release the GIL (:pr:`3610`) `Guido Imperiale`_
 - Don't overlap on non-overlapped dimensions in ``map_overlap`` (:pr:`3653`) `Matthew Rocklin`_
@@ -2528,25 +2528,25 @@ Array
 - Ensure ``to_zarr`` with ``return_stored`` ``True`` returns a Dask Array (:pr:`3786`) `John A Kirkham`_
 
 Bag
-+++
+^^^
 
 - Add ``last_endline`` optional parameter in ``to_textfiles`` (:pr:`3745`) `George Sakkis`_
 
 Dataframe
-+++++++++
+^^^^^^^^^
 
 - Add aggregate function for rolling objects (:pr:`3772`) `Gerome Pistre`_
 - Properly tokenize cumulative groupby aggregations (:pr:`3799`) `Cloves Almeida`_
 
 Delayed
-+++++++
+^^^^^^^
 
 - Add the ``@`` operator to the delayed objects (:pr:`3691`) `Mark Harfouche`_
 - Add delayed best practices to documentation (:pr:`3737`) `Matthew Rocklin`_
 - Fix ``@delayed`` decorator for methods and add tests (:pr:`3757`) `Ziyao Wei`_
 
 Core
-++++
+^^^^
 
 - Fix extra progressbar (:pr:`3669`) `Mike Neish`_
 - Allow tasks back onto ordering stack if they have one dependency (:pr:`3652`) `Matthew Rocklin`_
@@ -2561,7 +2561,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 - ``from_array`` now supports scalar types and nested lists/tuples in input,
   just like all numpy functions do; it also produces a simpler graph when the
@@ -2574,13 +2574,13 @@ Array
 - Add outer for Dask Arrays (:pr:`3658`) `John A Kirkham`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Add Index.to_series method (:pr:`3613`) `Henrique Ribeiro`_
 - Fix missing partition columns in pyarrow-parquet (:pr:`3636`) `Martin Durant`_
 
 Core
-++++
+^^^^
 
 - Minor tweaks to CI (:pr:`3629`) `Guido Imperiale`_
 - Add back dask.utils.effective_get (:pr:`3642`) `Matthew Rocklin`_
@@ -2593,7 +2593,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Add to/from_zarr for Zarr-format datasets and arrays (:pr:`3460`) `Martin Durant`_
 - Experimental addition of generalized ufunc support, ``apply_gufunc``, ``gufunc``, and
@@ -2616,7 +2616,7 @@ Array
   (:pr:`3396`) `Guido Imperiale`_
 
 Dataframe
-+++++++++
+^^^^^^^^^
 
 - Add to/read_json (:pr:`3494`) `Martin Durant`_
 - Adds ``index`` to unsupported arguments for ``DataFrame.rename`` method (:pr:`3522`) `James Bourbeau`_
@@ -2631,12 +2631,12 @@ Dataframe
 - Add fastparquet ParquetFile object support (:pr:`3573`) `@andrethrill`_
 
 Bag
-+++
+^^^
 
 - Rename method= keyword to shuffle= in bag.groupby (:pr:`3470`) `Matthew Rocklin`_
 
 Core
-++++
+^^^^
 
 - Replace get= keyword with scheduler= keyword (:pr:`3448`) `Matthew Rocklin`_
 - Add centralized dask.config module to handle configuration for all Dask
@@ -2657,14 +2657,14 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Fix ``rechunk`` with chunksize of -1 in a dict (:pr:`3469`) `Stephan Hoyer`_
 - ``einsum`` now accepts the ``split_every`` parameter (:pr:`3471`) `Guido Imperiale`_
 - Improved slicing performance (:pr:`3479`) `Yu Feng`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Compatibility with pandas 0.23.0 (:pr:`3499`) `Tom Augspurger`_
 
@@ -2673,7 +2673,7 @@ DataFrame
 -------------------
 
 Dataframe
-+++++++++
+^^^^^^^^^
 
 - Add support for indexing Dask DataFrames with string subclasses (:pr:`3461`) `James Bourbeau`_
 - Allow using both sorted_index and chunksize in read_hdf (:pr:`3463`) `Pierre Bartet`_
@@ -2685,7 +2685,7 @@ Dataframe
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Add ``einsum`` for Dask Arrays (:pr:`3412`) `Simon Perkins`_
 - Add ``piecewise`` for Dask Arrays (:pr:`3350`) `John A Kirkham`_
@@ -2701,7 +2701,7 @@ Array
 - Add ``gradient`` for Dask Arrays (:pr:`3434`) `John A Kirkham`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Allow `t` as shorthand for `table` in `to_hdf` for pandas compatibility (:pr:`3330`) `Jörg Dietrich`_
 - Added top level `isna` method for Dask DataFrames (:pr:`3294`) `Christopher Ren`_
@@ -2718,7 +2718,7 @@ DataFrame
 - Add default values to make_timeseries (:pr:`3421`) `Matthew Rocklin`_
 
 Core
-++++
+^^^^
 
 - Support traversing collections in persist, visualize, and optimize (:pr:`3410`) `Jim Crist`_
 - Add schedule= keyword to compute and persist.  This replaces common use of the get= keyword (:pr:`3448`) `Matthew Rocklin`_
@@ -2728,7 +2728,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Add ``broadcast_arrays`` for Dask Arrays (:pr:`3217`) `John A Kirkham`_
 - Add ``bitwise_*`` ufuncs (:pr:`3219`) `John A Kirkham`_
@@ -2737,7 +2737,7 @@ Array
 - Avoid calls to astype in concatenate if all parts have the same dtype (:pr:`3301`) `Martin Durant`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Fixed bug in shuffle due to aggressive truncation (:pr:`3201`) `Matthew Rocklin`_
 - Support specifying categorical columns on ``read_parquet`` with ``categories=[…]`` for ``engine="pyarrow"`` (:pr:`3177`) `Uwe Korn`_
@@ -2746,12 +2746,12 @@ DataFrame
 - Support extra Scalar and Delayed args in ``dd.groupby._Groupby.apply`` (:pr:`3256`) `Gabriele Lanaro`_
 
 Bag
-+++
+^^^
 
 - Support joining against single-partitioned bags and delayed objects (:pr:`3254`) `Matthew Rocklin`_
 
 Core
-++++
+^^^^
 
 - Fixed bug when using unexpected but hashable types for keys (:pr:`3238`) `Daniel Collins`_
 - Fix bug in task ordering so that we break ties consistently with the key name (:pr:`3271`) `Matthew Rocklin`_
@@ -2762,19 +2762,19 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Corrected dimension chunking in indices (:issue:`3166`, :pr:`3167`) `Simon Perkins`_
 - Inline ``store_chunk`` calls for ``store``'s ``return_stored`` option (:pr:`3153`) `John A Kirkham`_
 - Compatibility with struct dtypes for NumPy 1.14.1 release (:pr:`3187`) `Matthew Rocklin`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Bugfix to allow column assignment of pandas datetimes(:pr:`3164`) `Max Epstein`_
 
 Core
-++++
+^^^^
 
 - New file-system for HTTP(S), allowing direct loading from specific URLs (:pr:`3160`) `Martin Durant`_
 - Fix bug when tokenizing partials with no keywords (:pr:`3191`) `Matthew Rocklin`_
@@ -2786,7 +2786,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Added a support object-type arrays for nansum, nanmin, and nanmax (:issue:`3133`) `Keisuke Fujii`_
 - Update error handling when len is called with empty chunks (:issue:`3058`) `Xander Johnson`_
@@ -2796,7 +2796,7 @@ Array
 - Tokenize scipy.sparse arrays and np.matrix (:pr:`3060`) `Roman Yurchak`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 - Support month timedeltas in repartition(freq=...) (:pr:`3110`) `Matthew Rocklin`_
 - Avoid mutation in dataframe groupby tests (:pr:`3118`) `Matthew Rocklin`_
 - ``read_csv``, ``read_table``, and ``read_parquet`` accept iterables of paths
@@ -2810,12 +2810,12 @@ DataFrame
 - dtype rationalization for sql queries (:pr:`3100`) `Martin Durant`_
 
 Bag
-+++
+^^^
 
 - Document ``bag.map_paritions`` function may receive either a list or generator. (:pr:`3150`) `Nir`_
 
 Core
-++++
+^^^^
 
 - Change default task ordering to prefer nodes with few dependents and then
   many downstream dependencies (:pr:`3056`) `Matthew Rocklin`_
@@ -2838,7 +2838,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Fix handling of scalar percentile values in ``percentile`` (:pr:`3021`) `James Bourbeau`_
 - Prevent ``bool()`` coercion from calling compute (:pr:`2958`) `Albert DeFusco`_
@@ -2857,7 +2857,7 @@ Array
 - Add the ``return_stored`` option to ``store`` for chaining stored results (:pr:`2980`) `John A Kirkham`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Fixed naming bug in cumulative aggregations (:issue:`3037`) `Martijn Arts`_
 - Fixed ``dd.read_csv`` when ``names`` is given but ``header`` is not set to ``None`` (:issue:`2976`) `Martijn Arts`_
@@ -2874,7 +2874,7 @@ DataFrame
 - Add support for ``Series.str.cat`` (:pr:`3028`) `Jim Crist`_
 
 Core
-++++
+^^^^
 
 - Improve 32-bit compatibility (:pr:`2937`) `Matthew Rocklin`_
 - Change task prioritization to avoid upwards branching (:pr:`3017`) `Matthew Rocklin`_
@@ -2887,7 +2887,7 @@ This is a major release.  It includes breaking changes, new protocols, and a
 large number of bug fixes.
 
 Array
-+++++
+^^^^^
 
 - Add ``atleast_1d``, ``atleast_2d``, and ``atleast_3d`` (:pr:`2760`) (:pr:`2765`) `John A Kirkham`_
 - Add ``allclose`` (:pr:`2771`) by `John A Kirkham`_
@@ -2901,7 +2901,7 @@ Array
 - Avoid removing some getter calls in array optimizations (:pr:`2826`) `Jim Crist`_
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Support ``pyarrow`` in ``dd.to_parquet`` (:pr:`2868`) `Jim Crist`_
 - Fixed ``DataFrame.quantile`` and ``Series.quantile`` returning ``nan`` when missing values are present (:pr:`2791`) `Tom Augspurger`_
@@ -2923,7 +2923,7 @@ DataFrame
 - Support reading/writing to hdfs using ``pyarrow`` in ``dd.to_parquet`` (:pr:`2894`, :pr:`2881`) `Jim Crist`_
 
 Core
-++++
+^^^^
 
 -  Allow tuples as sharedict keys (:pr:`2763`) `Matthew Rocklin`_
 -  Calling compute within a dask.distributed task defaults to distributed scheduler (:pr:`2762`) `Matthew Rocklin`_
@@ -2943,7 +2943,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  ``da.random.choice`` now works with array arguments (:pr:`2781`)
 -  Support indexing in arrays with np.int (fixes regression) (:pr:`2719`)
@@ -2952,7 +2952,7 @@ Array
 -  Call mkdir in array.to_npy_stack (:pr:`2709`)
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Added the `.str` accessor to Categoricals with string categories (:pr:`2743`)
 -  Support int96 (spark) datetimes in parquet writer (:pr:`2711`)
@@ -2960,13 +2960,13 @@ DataFrame
 -  Support Pandas 0.21 (:pr:`2737`)
 
 Bag
-+++
+^^^
 
 - Add tree reduction support for foldby (:pr:`2710`)
 
 
 Core
-++++
+^^^^
 
 -  Drop s3fs from ``pip install dask[complete]`` (:pr:`2750`)
 
@@ -2975,7 +2975,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  Add masked arrays (:pr:`2301`)
 -  Add ``*_like array creation functions`` (:pr:`2640`)
@@ -2989,7 +2989,7 @@ Array
 -  Add apply_along_axis (:pr:`2690`) and apply_over_axes (:pr:`2702`)
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Added ``Series.str[index]`` (:pr:`2634`)
 -  Allow the groupby by param to handle columns and index levels (:pr:`2636`)
@@ -3001,7 +3001,7 @@ DataFrame
 -  Repartition works with mixed categoricals (:pr:`2676`)
 
 Core
-++++
+^^^^
 
 -  ``python setup.py test`` now runs tests (:pr:`2641`)
 -  Added new cheatsheet (:pr:`2649`)
@@ -3012,7 +3012,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  Remove spurious keys from map_overlap graph (:pr:`2520`)
 -  where works with non-bool condition and scalar values (:pr:`2543`) (:pr:`2549`)
@@ -3026,12 +3026,12 @@ Array
 -  Improve dtype inference and reflection (:pr:`2571`)
 
 Bag
-+++
+^^^
 
 -   Remove deprecated Bag behaviors (:pr:`2525`)
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Support callables in assign (:pr:`2513`)
 -  better error messages for read_csv (:pr:`2522`)
@@ -3041,7 +3041,7 @@ DataFrame
 -  Read_hdf supports iterables of files (:pr:`2547`)
 
 Core
-++++
+^^^^
 
 -  Remove bare ``except:`` blocks everywhere (:pr:`2590`)
 
@@ -3059,7 +3059,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  Add dask.array.stats submodule (:pr:`2269`)
 -  Support ``ufunc.outer`` (:pr:`2345`)
@@ -3070,7 +3070,7 @@ Array
 -  Support NumPy's ``__array_ufunc__`` protocol (:pr:`2438`)
 
 Bag
-+++
+^^^
 
 -  Fix bug where reductions on bags with no partitions would fail (:pr:`2324`)
 -  Add broadcasting and variadic ``db.map`` top-level function.  Also remove
@@ -3078,12 +3078,12 @@ Bag
 -  Rename ``Bag.concat`` to ``Bag.flatten`` (:pr:`2402`)
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Parquet improvements (:pr:`2277`) (:pr:`2422`)
 
 Core
-++++
+^^^^
 
 -  Move dask.async module to dask.local (:pr:`2318`)
 -  Support callbacks with nested scheduler calls (:pr:`2397`)
@@ -3094,7 +3094,7 @@ Core
 -------------------
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Pandas 0.20.0 support
 
@@ -3102,7 +3102,7 @@ DataFrame
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  Add da.indices (:pr:`2268`), da.tile (:pr:`2153`), da.roll (:pr:`2135`)
 -  Simultaneously support drop_axis and new_axis in da.map_blocks (:pr:`2264`)
@@ -3115,12 +3115,12 @@ Array
 -  Multi-dimensional FFTs (single chunk) (:pr:`2116`)
 
 Bag
-+++
+^^^
 
 -  to_dataframe enforces consistent types (:pr:`2199`)
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Set_index always fully sorts the index (:pr:`2290`)
 -  Support compatibility with pandas 0.20.0 (:pr:`2249`), (:pr:`2248`), and (:pr:`2246`)
@@ -3129,7 +3129,7 @@ DataFrame
 -  Repartition can now create more partitions, not just less (:pr:`2168`)
 
 Core
-++++
+^^^^
 
 -  Always use absolute paths when on POSIX file system (:pr:`2263`)
 -  Support user provided graph optimizations (:pr:`2219`)
@@ -3141,7 +3141,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 -  Micro-optimize optimizations (:pr:`2058`)
 -  Change slicing optimizations to avoid fusing raw numpy arrays (:pr:`2075`) (:pr:`2080`)
@@ -3151,7 +3151,7 @@ Array
 -  Allow user-provided FFT implementations in ``da.fft`` (:pr:`2093`)
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 -  Fix to_parquet with empty partitions (:pr:`2020`)
 -  Optional ``npartitions='auto'`` mode in ``set_index`` (:pr:`2025`)
@@ -3163,12 +3163,12 @@ DataFrame
 -  Improve handling of integer-na handling in read_csv (:pr:`2098`)
 
 Delayed
-+++++++
+^^^^^^^
 
 -  Repeated attribute access on delayed objects uses the same key (:pr:`2084`)
 
 Core
-++++
+^^^^
 
 -   Improve naming of nodes in dot visuals to avoid generic ``apply``
     (:pr:`2070`)
@@ -3179,7 +3179,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Fix corner cases with zero shape and misaligned values in ``arange``
   (:pr:`1902`), (:pr:`1904`), (:pr:`1935`), (:pr:`1955`), (:pr:`1956`)
@@ -3187,7 +3187,7 @@ Array
 - Avoid hashing in ``from_array`` if name is provided (:pr:`1972`)
 
 Bag
-+++
+^^^
 
 - Repartition can now increase number of partitions (:pr:`1934`)
 - Fix bugs in some reductions with empty partitions (:pr:`1939`), (:pr:`1950`),
@@ -3195,7 +3195,7 @@ Bag
 
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Support non-uniform categoricals (:pr:`1877`), (:pr:`1930`)
 - Groupby cumulative reductions (:pr:`1909`)
@@ -3206,7 +3206,7 @@ DataFrame
 - Add ``dd.demo.daily_stock`` function for teaching (:pr:`1992`)
 
 Delayed
-+++++++
+^^^^^^^
 
 - Add ``traverse=`` keyword to delayed to optionally avoid traversing nested
   data structures (:pr:`1899`)
@@ -3214,7 +3214,7 @@ Delayed
 - Improve serialization of decorated delayed functions (:pr:`1969`)
 
 Core
-++++
+^^^^
 
 - Improve windows path parsing in corner cases (:pr:`1910`)
 - Rename tasks when fusing (:pr:`1919`)
@@ -3228,7 +3228,7 @@ Core
 -------------------
 
 Array
-+++++
+^^^^^
 
 - Mandatory dtypes on dask.array.  All operations maintain dtype information
   and UDF functions like map_blocks now require a dtype= keyword if it can not
@@ -3242,12 +3242,12 @@ Array
 - Rechunk optimization (:pr:`1737`), (:pr:`1827`)
 
 Bag
-+++
+^^^
 
 - Avoid wrong results when recomputing the same groupby twice (:pr:`1867`)
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Add ``map_overlap`` for custom rolling operations (:pr:`1769`)
 - Add ``shift`` (:pr:`1773`)
@@ -3261,7 +3261,7 @@ DataFrame
 - Add delitem and copy to DataFrames, increasing mutation support (:pr:`1858`)
 
 Delayed
-+++++++
+^^^^^^^
 
 - Changed behaviour for ``delayed(nout=0)`` and ``delayed(nout=1)``:
   ``delayed(nout=1)`` does not default to ``out=None`` anymore, and
@@ -3272,7 +3272,7 @@ Delayed
   ``delayed(lambda *args: args, nout=len(vals))(*vals)``
 
 Core
-++++
+^^^^
 
 - Refactor core byte ingest (:pr:`1768`), (:pr:`1774`)
 - Improve import time (:pr:`1833`)
@@ -3282,7 +3282,7 @@ Core
 -------------------
 
 DataFrame
-+++++++++
+^^^^^^^^^
 - Return a series when functions given to ``dataframe.map_partitions`` return
   scalars (:pr:`1515`)
 - Fix type size inference for series (:pr:`1513`)
@@ -3319,7 +3319,7 @@ DataFrame
 
 
 Array
-+++++
+^^^^^
 - Add information about how ``dask.array`` ``chunks`` argument work (:pr:`1504`)
 - Fix field access with non-scalar fields in ``dask.array`` (:pr:`1484`)
 - Add concatenate= keyword to atop to concatenate chunks of contracted dimensions
@@ -3331,13 +3331,13 @@ Array
 - Cull dask.arrays on slicing (:pr:`1709`)
 
 Bag
-++++
+^^^
 - Fix issue with callables in ``bag.from_sequence`` being interpreted as
   tasks (:pr:`1491`)
 - Avoid non-lazy memory use in reductions (:pr:`1747`)
 
 Administration
-++++++++++++++
+^^^^^^^^^^^^^^
 
 - Added changelog (:pr:`1526`)
 - Create new threadpool when operating from thread (:pr:`1487`)
@@ -3355,7 +3355,7 @@ Administration
 -------------------
 
 Major Points
-++++++++++++
+^^^^^^^^^^^^
 
 DataFrames now enforce knowing full metadata (columns, dtypes) everywhere.
 Previously we would operate in an ambiguous state when functions lost dtype
@@ -3370,7 +3370,7 @@ reasoning about scheduling, plugin operation, and logging.  It also makes
 the scheduler code easier to understand for newcomers.
 
 Breaking Changes
-++++++++++++++++
+^^^^^^^^^^^^^^^^
 
 - The ``distributed.s3`` and ``distributed.hdfs`` namespaces are gone.  Use
   protocols in normal methods like ``read_text('s3://...'`` instead.
@@ -3404,7 +3404,7 @@ Breaking Changes
 -------------------
 
 Major Changes
-+++++++++++++
+^^^^^^^^^^^^^
 
 - This version drops support for Python 2.6
 - Conda packages are built and served from conda-forge
@@ -3413,13 +3413,13 @@ Major Changes
 - Both Bag and DataFrame include a preliminary distributed shuffle.
 
 Bag
-++++
+^^^
 
 - Add task-based shuffle for distributed groupbys
 - Add accumulate for cumulative reductions
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Add a task-based shuffle suitable for distributed joins, groupby-applys, and
   set_index operations.  The single-machine shuffle remains untouched (and
@@ -3432,7 +3432,7 @@ DataFrame
 - Add eval, info, isnull, notnull for dataframes
 
 Distributed
-+++++++++++
+^^^^^^^^^^^
 
 - Rename executables like dscheduler to dask-scheduler
 - Improve scheduler performance in the many-fast-tasks case (important for
@@ -3447,7 +3447,7 @@ Distributed
 - Support clean cancellation of submitted futures in Joblib interface
 
 Other
-+++++
+^^^^^
 
 - All dask-related projects (dask, distributed, s3fs, hdfs, partd) are now
   building conda packages on conda-forge.
@@ -3461,7 +3461,7 @@ Other
 ------------------
 
 API Changes
-+++++++++++
+^^^^^^^^^^^
 
 - ``dask.do`` and ``dask.value`` have been renamed to ``dask.delayed``
 - ``dask.bag.from_filenames`` has been renamed to ``dask.bag.read_text``
@@ -3471,20 +3471,20 @@ API Changes
   ``dd.read_csv('s3://bucket/keys*.csv')``
 
 Array
-+++++
+^^^^^
 
 - Add support for ``scipy.LinearOperator``
 - Improve optional locking to on-disk data structures
 - Change rechunk to expose the intermediate chunks
 
 Bag
-++++
+^^^
 
 - Rename ``from_filename``\ s to ``read_text``
 - Remove ``from_s3`` in favor of ``read_text('s3://...')``
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Fixed numerical stability issue for correlation and covariance
 - Allow no-hash ``from_pandas`` for speedy round-trips to and from-pandas
@@ -3493,13 +3493,13 @@ DataFrame
 - Support fast ``set_index`` operations for sorted columns
 
 Delayed
-+++++++
+^^^^^^^
 
 - Rename ``do/value`` to ``delayed``
 - Rename ``to/from_imperative`` to ``to/from_delayed``
 
 Distributed
-+++++++++++
+^^^^^^^^^^^
 
 - Move s3 and hdfs functionality into the dask repository
 - Adaptively oversubscribe workers for very fast tasks
@@ -3508,7 +3508,7 @@ Distributed
 - Scatter data efficiently with tree-scatters
 
 Other
-+++++
+^^^^^
 
 - Add lzma/xz compression support
 - Raise a warning when trying to split unsplittable compression types, like
@@ -3522,18 +3522,18 @@ Other
 ------------------
 
 Array
-+++++
+^^^^^
 
 - Bugfix for range slicing that could periodically lead to incorrect results.
 - Improved support and resiliency of ``arg`` reductions (``argmin``, ``argmax``, etc.)
 
 Bag
-++++
+^^^
 
 - Add ``zip`` function
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Add ``corr`` and ``cov`` functions
 - Add ``melt`` function
@@ -3544,14 +3544,14 @@ DataFrame
 ------------------
 
 Array
-+++++
+^^^^^
 
 - Changed default array reduction split from 32 to 4
 - Linear algebra, ``tril``, ``triu``, ``LU``, ``inv``, ``cholesky``,
   ``solve``, ``solve_triangular``, ``eye``, ``lstsq``, ``diag``, ``corrcoef``.
 
 Bag
-++++
+^^^
 
 - Add tree reductions
 - Add range function
@@ -3559,7 +3559,7 @@ Bag
   distributed projects)
 
 DataFrame
-+++++++++
+^^^^^^^^^
 
 - Refactor ``dask.dataframe`` to include a full empty pandas dataframe as
   metadata.  Drop the ``.columns`` attribute on Series
@@ -3569,7 +3569,7 @@ DataFrame
 - Internal changes to improve graph serialization
 
 Other
-+++++
+^^^^^
 
 - Documentation updates
 - Add from_imperative and to_imperative functions for all collections
@@ -3581,23 +3581,23 @@ Other
 ------------------
 
 Array
-+++++
+^^^^^
 - Improve thread safety
 - Tree reductions
 - Add ``view``, ``compress``, ``hstack``, ``dstack``, ``vstack`` methods
 - ``map_blocks`` can now remove and add dimensions
 
 DataFrame
-+++++++++
+^^^^^^^^^
 - Improve thread safety
 - Extend sampling to include replacement options
 
 Imperative
-++++++++++
+^^^^^^^^^^
 - Removed optimization passes that fused results.
 
 Core
-++++
+^^^^
 
 - Removed ``dask.distributed``
 - Improved performance of blocked file reading
@@ -3622,7 +3622,7 @@ This was mostly a bugfix release. Some notable changes:
 - Support the creation of ``dask.arrays`` from ``dask.imperative`` objects
 
 Deprecation
-+++++++++++
+^^^^^^^^^^^
 
 This release also includes a deprecation warning for ``dask.distributed``, which
 will be removed in the next version.
@@ -3636,12 +3636,12 @@ welcome from this community.
 ------------------
 
 Diagnostics
-+++++++++++
+^^^^^^^^^^^
 - A utility for profiling memory and cpu usage has been added to the
   ``dask.diagnostics`` module.
 
 DataFrame
-+++++++++
+^^^^^^^^^
 This release improves coverage of the pandas API. Among other things
 it includes ``nunique``, ``nlargest``, ``quantile``. Fixes encoding issues
 with reading non-ascii csv files. Performance improvements and  bug fixes
@@ -3653,7 +3653,7 @@ bug fixes in ``dask.imperative`` and ``dask.bag``.
 ------------------
 
 DataFrame
-+++++++++
+^^^^^^^^^
 This release includes significant bugfixes and alignment with the Pandas API.
 This has resulted both from use and from recent involvement by Pandas core
 developers.
@@ -3663,15 +3663,15 @@ developers.
   constructor logic, merge/join, elemwise operations, groupby aggregations
 
 Bag
-++++
+^^^
 - Fixed a bug in fold where with a null default argument
 
 Array
-+++++
+^^^^^
 - New operations: da.fft module, da.image.imread
 
 Infrastructure
-++++++++++++++
+^^^^^^^^^^^^^^
 - The array and dataframe collections create graphs with deterministic keys.
   These tend to be longer (hash strings) but should be consistent between
   computations.  This will be useful for caching in the future.
@@ -3682,29 +3682,29 @@ Infrastructure
 ------------------
 
 Distributed
-+++++++++++
+^^^^^^^^^^^
 - Improved (though not yet sufficient) resiliency for ``dask.distributed``
   when workers die
 
 DataFrame
-+++++++++
+^^^^^^^^^
 - Improved writing to various formats, including to_hdf, to_castra, and
   to_csv
 - Improved creation of dask DataFrames from dask Arrays and Bags
 - Improved support for categoricals and various other methods
 
 Array
-+++++
+^^^^^
 - Various bug fixes
 - Histogram function
 
 Scheduling
-++++++++++
+^^^^^^^^^^
 - Added tie-breaking ordering of tasks within parallel workloads to
   better handle and clear intermediate results
 
 Other
-+++++
+^^^^^
 - Added the dask.do function for explicit construction of graphs with
   normal python code
 - Traded pydot for graphviz library for graph printing to support Python3


### PR DESCRIPTION
Fixes docs build issue like 

```
/home/docs/checkouts/readthedocs.org/user_builds/dask/checkouts/7418/docs/source/changelog.rst:293: WARNING: Title level inconsistent:

Array
+++++
```

ref https://github.com/dask/dask/issues/5610