### PR TITLE
Support out-of-band pickling in multiprocessing

### DIFF
--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -24,7 +24,7 @@ def my_small_function_global(a, b):
 
 def test_pickle_globals():
     """ Unrelated globals should not be included in serialized bytes """
-    b = _dumps(my_small_function_global)
+    b, *_ = _dumps(my_small_function_global)
     assert b"my_small_function_global" in b
     assert b"unrelated_function_global" not in b
     assert b"numpy" not in b
@@ -40,7 +40,7 @@ def test_pickle_locals():
     def my_small_function_local(a, b):
         return a + b
 
-    b = _dumps(my_small_function_local)
+    b, *_ = _dumps(my_small_function_local)
     assert b"my_small_function_global" not in b
     assert b"my_small_function_local" in b
     assert b"unrelated_function_local" not in b
@@ -57,13 +57,13 @@ def test_out_of_band_pickling():
 
     a = np.arange(5)
 
-    l = []
-    b = _dumps(a, buffer_callback=l.append)
-    assert len(l) == 1
-    assert isinstance(l[0], pickle.PickleBuffer)
-    assert memoryview(l[0]) == memoryview(a)
+    l = _dumps(a)
+    assert len(l) == 2
+    assert isinstance(l[0], bytes)
+    assert isinstance(l[1], pickle.PickleBuffer)
+    assert memoryview(l[1]) == memoryview(a)
 
-    a2 = _loads(b, buffers=l)
+    a2 = _loads(l)
     assert np.all(a == a2)
 
 


### PR DESCRIPTION
Tweak the implementations of `_dumps` and `_loads` to optionally handle out-of-band buffers during pickling. This can help avoid unnecessary copying of data before sending it over the wire. We do this by storing the pickled result in a `list` instead of a `bytes` object. The first element is what `dumps` would produce or `loads` would consume, but the rest of the elements are buffers that pickling has extracted and sent alongside. This analogous to the strategy we use in Distributed. As a result large array or dataframes, can be sent along without copying their content necessarily. Thus putting the multiprocessing use case on more even footing with the threaded or distributed use cases.

Note that if pickle protocol 5 is not supported, we just send over a singleton `list` bypassing all out-of-band buffer handling. As cloudpickle can detect whether pickle protocol 5 is supported, we use that determine whether to leverage the out-of-band pickling case or not.


- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
