### PR TITLE
Update layer annotation packing method

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -147,7 +147,7 @@ class Layer(collections.abc.Mapping):
         """
         return keys_in_tasks(all_hlg_keys, [self[key]])
 
-    def __dask_distributed_anno_pack__(self) -> Optional[Mapping[str, Any]]:
+    def __dask_distributed_annotations_pack__(self) -> Optional[Mapping[str, Any]]:
         """Packs Layer annotations for transmission to scheduler
 
         Callables annotations are fully expanded over Layer keys, while
@@ -927,7 +927,7 @@ class HighLevelGraph(Mapping):
         """Pack the high level graph for Scheduler -> Worker communication
 
         The approach is to delegate the packaging to each layer in the high level graph
-        by calling .__dask_distributed_pack__() and .__dask_distributed_anno_pack__()
+        by calling .__dask_distributed_pack__() and .__dask_distributed_annotations_pack__()
         on each layer. If the layer doesn't implement packaging, we materialize the
         layer and pack it.
 
@@ -958,7 +958,7 @@ class HighLevelGraph(Mapping):
                         client,
                         client_keys,
                     ),
-                    "annotations": layer.__dask_distributed_anno_pack__(),
+                    "annotations": layer.__dask_distributed_annotations_pack__(),
                 }
             )
         return dumps_msgpack({"layers": layers})

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -170,7 +170,7 @@ def test_multiple_annotations():
 
 def test_annotation_pack_unpack():
     layer = MaterializedLayer({"n": 42}, annotations={"workers": ("alice",)})
-    packed_anno = layer.__dask_distributed_anno_pack__()
+    packed_anno = layer.__dask_distributed_annotations_pack__()
     annotations = {}
     Layer.__dask_distributed_annotations_unpack__(
         annotations, packed_anno, layer.keys()


### PR DESCRIPTION
This PR updates the name for our `Layer` annotation packing method from `__dask_distributed_anno_pack__`  to `__dask_distributed_annotations_pack__` to match the corresponding unpacking method `__dask_distributed_annotations_unpack__`. In an earlier PR we decided to use the full `annotations` instead of `anno` and I guess we forgot to update the name in the packing method. 

cc @madsbk 