### PR TITLE
Drop duplicate test in `test_describe_empty`

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -474,9 +474,6 @@ def test_describe_empty():
         ddf_len0.describe(percentiles_method="dask").compute()
 
     with pytest.raises(ValueError):
-        ddf_len0.describe(percentiles_method="dask").compute()
-
-    with pytest.raises(ValueError):
         ddf_nocols.describe(percentiles_method="dask").compute()
 
 


### PR DESCRIPTION
It appears this test is run twice. Since it is already covered once, just drop the second one.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
