### PR TITLE
Register pytest marker for 'flaky' tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ test = pytest
 markers:
   network: Test requires an internet connection
   slow: Skipped unless --runslow passed
+  flaky: marks tests as flaky (deselect with '-m "not flaky"')
 addopts = -v -rsx --durations=10
 filterwarnings =
     # From Cython-1753


### PR DESCRIPTION
- [ ] ~~Closes #xxxx~~
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

PR https://github.com/dask/dask/pull/7319 added a new pytest `flaky` mark for tests. Pytest expects [marks should be registered](https://docs.pytest.org/en/stable/mark.html). If they're not, it produces an error and you can't run the test suite (this is true from about pytest version 4.6.0 onwards).

This was happening to me on my local machine, so I've added a line to `setup.cfg` to register the pytest `flaky` mark. Now the test suite runs again for me.
