### PR TITLE
Add `rot90`

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -91,6 +91,7 @@ try:
         tril_indices_from,
         triu_indices,
         triu_indices_from,
+        rot90,
     )
     from .reshape import reshape
     from .ufunc import (

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -207,6 +207,39 @@ def fliplr(m):
     return flip(m, 1)
 
 
+@derived_from(np)
+def rot90(m, k=1, axes=(0, 1)):
+    axes = tuple(axes)
+    if len(axes) != 2:
+        raise ValueError("len(axes) must be 2.")
+
+    m = asanyarray(m)
+
+    if axes[0] == axes[1] or np.absolute(axes[0] - axes[1]) == m.ndim:
+        raise ValueError("Axes must be different.")
+
+    if axes[0] >= m.ndim or axes[0] < -m.ndim or axes[1] >= m.ndim or axes[1] < -m.ndim:
+        raise ValueError(
+            "Axes={} out of range for array of ndim={}.".format(axes, m.ndim)
+        )
+
+    k %= 4
+
+    if k == 0:
+        return m[:]
+    if k == 2:
+        return flip(flip(m, axes[0]), axes[1])
+
+    axes_list = list(range(0, m.ndim))
+    (axes_list[axes[0]], axes_list[axes[1]]) = (axes_list[axes[1]], axes_list[axes[0]])
+
+    if k == 1:
+        return transpose(flip(m, axes[1]), axes_list)
+    else:
+        # k == 3
+        return flip(transpose(m, axes_list), axes[1])
+
+
 alphabet = "abcdefghijklmnopqrstuvwxyz"
 ALPHABET = alphabet.upper()
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -222,6 +222,36 @@ def test_flip(funcname, kwargs, shape):
 
 
 @pytest.mark.parametrize(
+    "kwargs",
+    [{}, {"axes": (1, 0)}, {"axes": (2, 3)}, {"axes": (0, 1, 2)}, {"axes": (1, 1)}],
+)
+@pytest.mark.parametrize("shape", [tuple(), (4,), (4, 6), (4, 6, 8), (4, 6, 8, 10)])
+def test_rot90(kwargs, shape):
+    axes = kwargs.get("axes", (0, 1))
+    np_a = np.random.random(shape)
+    da_a = da.from_array(np_a, chunks=1)
+
+    np_func = getattr(np, "rot90")
+    da_func = getattr(da, "rot90")
+
+    try:
+        for axis in axes[:2]:
+            range(np_a.ndim)[axis]
+    except IndexError:
+        with pytest.raises(ValueError):
+            da_func(da_a, **kwargs)
+    else:
+        if len(axes) != 2 or axes[0] == axes[1]:
+            with pytest.raises(ValueError):
+                da_func(da_a, **kwargs)
+        else:
+            for k in range(4):
+                np_r = np_func(np_a, k=k, **kwargs)
+                da_r = da_func(da_a, k=k, **kwargs)
+                assert_eq(np_r, da_r)
+
+
+@pytest.mark.parametrize(
     "x_shape, y_shape, x_chunks, y_chunks",
     [
         [(), (), (), ()],

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -245,7 +245,7 @@ def test_rot90(kwargs, shape):
             with pytest.raises(ValueError):
                 da_func(da_a, **kwargs)
         else:
-            for k in range(4):
+            for k in range(-3, 9):
                 np_r = np_func(np_a, k=k, **kwargs)
                 da_r = da_func(da_a, k=k, **kwargs)
                 assert_eq(np_r, da_r)

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -185,6 +185,7 @@ Top level user functions:
    rint
    roll
    rollaxis
+   rot90
    round
    sign
    signbit
@@ -584,6 +585,7 @@ Other functions
 .. autofunction:: rint
 .. autofunction:: roll
 .. autofunction:: rollaxis
+.. autofunction:: rot90
 .. autofunction:: round
 .. autofunction:: sign
 .. autofunction:: signbit


### PR DESCRIPTION
The dask docstrings for `flip`, `fliplr`, and `flipud` are inherited from numpy and contain a "See also" note that references `rot90`, not yet implemented in dask. e.g:

```
See also

`fliplr`
  Flip array in the left/right direction.
`rot90`
  Rotate array counterclockwise.
```

This PR adds `rot90`, which is nearly an exact [copy of the numpy implementation](https://github.com/numpy/numpy/blob/v1.20.0/numpy/lib/function_base.py#L59-L143) (except composed of `da.flip` and `da.transpose`). 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`
- [ ] Update checklist in #2911
