### PR TITLE
Fix numpy upstream failures `xfail` pandas and fastparquet failures

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -11,7 +11,6 @@ PANDAS_GT_104 = PANDAS_VERSION >= LooseVersion("1.0.4")
 PANDAS_GT_110 = PANDAS_VERSION >= LooseVersion("1.1.0")
 PANDAS_GT_120 = PANDAS_VERSION >= LooseVersion("1.2.0")
 PANDAS_GT_121 = PANDAS_VERSION >= LooseVersion("1.2.1")
-PANDAS_GT_123 = PANDAS_VERSION >= LooseVersion("1.2.3")
 PANDAS_GT_130 = PANDAS_VERSION >= LooseVersion("1.3.0")
 
 

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -11,6 +11,7 @@ PANDAS_GT_104 = PANDAS_VERSION >= LooseVersion("1.0.4")
 PANDAS_GT_110 = PANDAS_VERSION >= LooseVersion("1.1.0")
 PANDAS_GT_120 = PANDAS_VERSION >= LooseVersion("1.2.0")
 PANDAS_GT_121 = PANDAS_VERSION >= LooseVersion("1.2.1")
+PANDAS_GT_123 = PANDAS_VERSION >= LooseVersion("1.2.3")
 PANDAS_GT_130 = PANDAS_VERSION >= LooseVersion("1.3.0")
 
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -16,7 +16,6 @@ import dask.dataframe as dd
 from dask.dataframe._compat import (
     PANDAS_GT_110,
     PANDAS_GT_121,
-    PANDAS_GT_123,
     PANDAS_GT_130,
 )
 from dask.dataframe.utils import assert_eq
@@ -978,9 +977,6 @@ def test_categories_unnamed_index(tmpdir, engine):
 
     if engine.startswith("pyarrow") and pa.__version__ < LooseVersion("0.15.0"):
         pytest.skip("PyArrow>=0.15 Required.")
-
-    if engine == "fastparquet" and PANDAS_GT_123:
-        pytest.skip("https://github.com/dask/fastparquet/issues/576")
 
     tmpdir = str(tmpdir)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -13,7 +13,7 @@ import pytest
 import dask
 import dask.multiprocessing
 import dask.dataframe as dd
-from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_121
+from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_121, PANDAS_GT_123
 from dask.dataframe.utils import assert_eq
 from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.dataframe.optimize import optimize_read_parquet_getitem
@@ -966,6 +966,9 @@ def test_categories_unnamed_index(tmpdir, engine):
 
     if engine.startswith("pyarrow") and pa.__version__ < LooseVersion("0.15.0"):
         pytest.skip("PyArrow>=0.15 Required.")
+
+    if engine == "fastparquet" and PANDAS_GT_123:
+        pytest.skip("https://github.com/dask/fastparquet/issues/576")
 
     tmpdir = str(tmpdir)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -13,7 +13,12 @@ import pytest
 import dask
 import dask.multiprocessing
 import dask.dataframe as dd
-from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_121, PANDAS_GT_123
+from dask.dataframe._compat import (
+    PANDAS_GT_110,
+    PANDAS_GT_121,
+    PANDAS_GT_123,
+    PANDAS_GT_130,
+)
 from dask.dataframe.utils import assert_eq
 from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.dataframe.optimize import optimize_read_parquet_getitem
@@ -917,6 +922,13 @@ def test_read_parquet_custom_columns(tmpdir, engine):
     ],
 )
 def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
+    if (
+        PANDAS_GT_130
+        and engine == "fastparquet"
+        and read_kwargs.get("categories", None)
+    ):
+        pytest.xfail("https://github.com/dask/fastparquet/issues/577")
+
     tmp = str(tmpdir)
     if df.index.name is None:
         df.index.name = "index"

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -225,6 +225,9 @@ def test_index_names():
     assert ddf.index.compute().name == "x"
 
 
+@pytest.mark.xfail(
+    dd._compat.PANDAS_GT_130, reason="https://github.com/dask/dask/issues/7444"
+)
 @pytest.mark.parametrize(
     "npartitions",
     [

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1634,13 +1634,22 @@ def test_combine():
 
     first = lambda a, b: a
 
+    # You can add series with strings and nans but you can't add scalars 'a' + np.NaN
+    str_add = lambda a, b: a + b if a is not np.nan else a
+
     # DataFrame
-    for dda, ddb, a, b in [
-        (ddf1, ddf2, df1, df2),
-        (ddf1.A, ddf2.A, df1.A, df2.A),
-        (ddf1.B, ddf2.B, df1.B, df2.B),
+    for dda, ddb, a, b, runs in [
+        (ddf1, ddf2, df1, df2, [(add, None), (first, None)]),
+        (ddf1.A, ddf2.A, df1.A, df2.A, [(add, None), (add, 100), (first, None)]),
+        (
+            ddf1.B,
+            ddf2.B,
+            df1.B,
+            df2.B,
+            [(str_add, None), (str_add, "d"), (first, None)],
+        ),
     ]:
-        for func, fill_value in [(add, None), (add, 100), (first, None)]:
+        for func, fill_value in runs:
             sol = a.combine(b, func, fill_value=fill_value)
             assert_eq(dda.combine(ddb, func, fill_value=fill_value), sol)
             assert_eq(dda.combine(b, func, fill_value=fill_value), sol)

--- a/dask/dataframe/tests/test_numeric.py
+++ b/dask/dataframe/tests/test_numeric.py
@@ -15,7 +15,7 @@ def test_to_numeric_on_scalars(arg):
 
 
 def test_to_numeric_on_dask_array():
-    arg = from_array(["1.0", "2", -3, 5.1])
+    arg = from_array(["1.0", "2", "-3", "5.1"])
     expected = np.array([1.0, 2.0, -3.0, 5.1])
     output = to_numeric(arg)
     assert isinstance(output, Array)

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -74,11 +74,6 @@ def test_futures_to_delayed_dataframe(c):
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
 
-    from dask.array.numpy_compat import _numpy_120
-
-    if _numpy_120:
-        pytest.skip("https://github.com/dask/dask/issues/7170")
-
     df = pd.DataFrame({"x": [1, 2, 3]})
 
     futures = c.scatter([df, df])


### PR DESCRIPTION
This just fixes these two tests on upstream.

```python
dask/dataframe/tests/test_dataframe.py::test_combine
dask/dataframe/tests/test_numeric.py::test_to_numeric_on_dask_array
dask/tests/test_distributed::test_futures_to_delayed_dataframe
```

ref https://github.com/dask/dask/issues/7366#issuecomment-796655791