### PR TITLE
Update docs for required package for endpoint

### DIFF
--- a/docs/source/setup/prometheus.rst
+++ b/docs/source/setup/prometheus.rst
@@ -2,7 +2,7 @@ Prometheus Monitoring
 -----------------------
 
 Prometheus_ is a widely popular tool for monitoring and alerting a wide variety of systems. Dask.distributed exposes
-scheduler and worker metrics in a prometheus text based format. Metrics are available at ``http://scheduler-address:8787/metrics``.
+scheduler and worker metrics in a prometheus text based format. Metrics are available at ``http://scheduler-address:8787/metrics`` when the ``prometheus_client`` package has been installed.
 
 .. _Prometheus: https://prometheus.io
 


### PR DESCRIPTION
Was not sure why I was unable to see the `/metrics` endpoint but @jrbourbeau was able to help in [this discussion](https://github.com/dask/dask/discussions/7443). Felt it might be useful to add to the docs as it took me a few hours to figure it out.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
