### PR TITLE
Fix __array_function__ dispatching for tril/triu

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -261,6 +261,7 @@ def argtopk_aggregate(a_plus_idx, k, axis, keepdims):
 
 def arange(start, stop, step, length, dtype, like=None):
     from .utils import arange_safe
+
     res = arange_safe(start, stop, step, dtype, like=like)
     return res[:-1] if len(res) > length else res
 

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -259,8 +259,9 @@ def argtopk_aggregate(a_plus_idx, k, axis, keepdims):
     ]
 
 
-def arange(start, stop, step, length, dtype):
-    res = np.arange(start, stop, step, dtype)
+def arange(start, stop, step, length, dtype, like=None):
+    from .utils import arange_safe
+    res = arange_safe(start, stop, step, dtype, like=like)
     return res[:-1] if len(res) > length else res
 
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -378,6 +378,9 @@ def arange(*args, **kwargs):
 
     num = int(max(np.ceil((stop - start) / step), 0))
 
+    like = kwargs.pop("like", None)
+    meta = meta_from_array(like) if like is not None else None
+
     dtype = kwargs.pop("dtype", None)
     if dtype is None:
         dtype = np.arange(start, stop, step * num if num else step).dtype
@@ -394,11 +397,11 @@ def arange(*args, **kwargs):
     for i, bs in enumerate(chunks[0]):
         blockstart = start + (elem_count * step)
         blockstop = start + ((elem_count + bs) * step)
-        task = (chunk.arange, blockstart, blockstop, step, bs, dtype)
+        task = (partial(chunk.arange, like=like), blockstart, blockstop, step, bs, dtype)
         dsk[(name, i)] = task
         elem_count += bs
 
-    return Array(dsk, name, chunks, dtype=dtype)
+    return Array(dsk, name, chunks, dtype=dtype, meta=meta)
 
 
 @derived_from(np)
@@ -677,7 +680,7 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
 
 
 @derived_from(np)
-def tri(N, M=None, k=0, dtype=float, chunks="auto"):
+def tri(N, M=None, k=0, dtype=float, chunks="auto", like=None):
     _min_int = np.lib.twodim_base._min_int
 
     if M is None:
@@ -685,9 +688,9 @@ def tri(N, M=None, k=0, dtype=float, chunks="auto"):
 
     chunks = normalize_chunks(chunks, shape=(N, M), dtype=dtype)
 
-    m = greater_equal.outer(
-        arange(N, chunks=chunks[0][0], dtype=_min_int(0, N)),
-        arange(-k, M - k, chunks=chunks[1][0], dtype=_min_int(-k, M - k)),
+    m = greater_equal(
+        arange(N, chunks=chunks[0][0], dtype=_min_int(0, N), like=like).reshape(1, N).T,
+        arange(-k, M - k, chunks=chunks[1][0], dtype=_min_int(-k, M - k), like=like),
     )
 
     # Avoid making a copy if the requested type is already bool

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -397,7 +397,14 @@ def arange(*args, **kwargs):
     for i, bs in enumerate(chunks[0]):
         blockstart = start + (elem_count * step)
         blockstop = start + ((elem_count + bs) * step)
-        task = (partial(chunk.arange, like=like), blockstart, blockstop, step, bs, dtype)
+        task = (
+            partial(chunk.arange, like=like),
+            blockstart,
+            blockstop,
+            step,
+            bs,
+            dtype,
+        )
         dsk[(name, i)] = task
         elem_count += bs
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1721,18 +1721,20 @@ def average(a, axis=None, weights=None, returned=False):
 
 @derived_from(np)
 def tril(m, k=0):
-    m = asarray(m)
-    mask = tri(*m.shape[-2:], k=k, dtype=bool, chunks=m.chunks[-2:])
+    from .utils import asarray_safe
+    m = asarray_safe(m, like=m)
+    mask = tri(*m.shape[-2:], k=k, dtype=bool, chunks=m.chunks[-2:], like=meta_from_array(m))
 
-    return where(mask, m, zeros(1, dtype=m.dtype))
+    return where(mask, m, zeros_like_safe(m, shape=(1, )))
 
 
 @derived_from(np)
 def triu(m, k=0):
-    m = asarray(m)
-    mask = tri(*m.shape[-2:], k=k - 1, dtype=bool, chunks=m.chunks[-2:])
+    from .utils import asarray_safe
+    m = asarray_safe(m, like=m)
+    mask = tri(*m.shape[-2:], k=k - 1, dtype=bool, chunks=m.chunks[-2:], like=meta_from_array(m))
 
-    return where(mask, zeros(1, dtype=m.dtype), m)
+    return where(mask, zeros_like_safe(m, shape=(1, )), m)
 
 
 @derived_from(np)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -23,6 +23,7 @@ from .utils import (
     meta_from_array,
     zeros_like_safe,
     array_safe,
+    asarray_safe,
 )
 from .wrap import ones
 from .ufunc import multiply, sqrt
@@ -684,8 +685,6 @@ def bincount(x, weights=None, minlength=0, split_every=None):
 
 @derived_from(np)
 def digitize(a, bins, right=False):
-    from .utils import asarray_safe
-
     bins = asarray_safe(bins, like=meta_from_array(a))
     dtype = np.digitize(asarray_safe([0], like=bins), bins, right=False).dtype
     return a.map_blocks(np.digitize, dtype=dtype, bins=bins, right=right)
@@ -1721,8 +1720,6 @@ def average(a, axis=None, weights=None, returned=False):
 
 @derived_from(np)
 def tril(m, k=0):
-    from .utils import asarray_safe
-
     m = asarray_safe(m, like=m)
     mask = tri(
         *m.shape[-2:], k=k, dtype=bool, chunks=m.chunks[-2:], like=meta_from_array(m)
@@ -1733,8 +1730,6 @@ def tril(m, k=0):
 
 @derived_from(np)
 def triu(m, k=0):
-    from .utils import asarray_safe
-
     m = asarray_safe(m, like=m)
     mask = tri(
         *m.shape[-2:],

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -16,7 +16,7 @@ from ..delayed import unpack_collections, Delayed
 from ..highlevelgraph import HighLevelGraph
 from ..utils import funcname, derived_from, is_arraylike
 from . import chunk
-from .creation import arange, diag, empty, indices, tri, zeros
+from .creation import arange, diag, empty, indices, tri
 from .utils import (
     safe_wraps,
     validate_axis,
@@ -1722,19 +1722,29 @@ def average(a, axis=None, weights=None, returned=False):
 @derived_from(np)
 def tril(m, k=0):
     from .utils import asarray_safe
-    m = asarray_safe(m, like=m)
-    mask = tri(*m.shape[-2:], k=k, dtype=bool, chunks=m.chunks[-2:], like=meta_from_array(m))
 
-    return where(mask, m, zeros_like_safe(m, shape=(1, )))
+    m = asarray_safe(m, like=m)
+    mask = tri(
+        *m.shape[-2:], k=k, dtype=bool, chunks=m.chunks[-2:], like=meta_from_array(m)
+    )
+
+    return where(mask, m, zeros_like_safe(m, shape=(1,)))
 
 
 @derived_from(np)
 def triu(m, k=0):
     from .utils import asarray_safe
-    m = asarray_safe(m, like=m)
-    mask = tri(*m.shape[-2:], k=k - 1, dtype=bool, chunks=m.chunks[-2:], like=meta_from_array(m))
 
-    return where(mask, zeros_like_safe(m, shape=(1, )), m)
+    m = asarray_safe(m, like=m)
+    mask = tri(
+        *m.shape[-2:],
+        k=k - 1,
+        dtype=bool,
+        chunks=m.chunks[-2:],
+        like=meta_from_array(m),
+    )
+
+    return where(mask, zeros_like_safe(m, shape=(1,)), m)
 
 
 @derived_from(np)

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -426,6 +426,21 @@ def zeros_like_safe(a, shape, **kwargs):
         return np.zeros(shape, **kwargs)
 
 
+def arange_safe(*args, like, **kwargs):
+    """
+    Use the `like=` from `np.arange` to create a new array dispatching
+    to the downstream library. If that fails, falls back to the
+    default NumPy behavior, resulting in a `numpy.ndarray`.
+    """
+    if like is None:
+        return np.arange(*args, **kwargs)
+    else:
+        try:
+            return np.arange(*args, like=meta_from_array(like), **kwargs)
+        except TypeError:
+            return np.arange(*args, **kwargs)
+
+
 def _array_like_safe(np_func, da_func, a, like, **kwargs):
     if like is a and hasattr(a, "__array_function__"):
         return a


### PR DESCRIPTION
This PR fixes `__array_function__` dispatching for `tril`/`triu`, which broke for downstream libraries such as CuPy after #6997 .

- [ ] Closes #7324 , closes #7452 
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
