### PR TITLE
Update NumPy intersphinx URL

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -306,8 +306,8 @@ intersphinx_mapping = {
         "https://pandas.pydata.org/pandas-docs/stable/objects.inv",
     ),
     "numpy": (
-        "https://docs.scipy.org/doc/numpy/",
-        "https://docs.scipy.org/doc/numpy/objects.inv",
+        "https://numpy.org/doc/stable/",
+        "https://numpy.org/doc/stable/objects.inv",
     ),
     "asyncssh": (
         "https://asyncssh.readthedocs.io/en/latest/",


### PR DESCRIPTION
When building docs after `make clean`, you currently see
```
intersphinx inventory has moved: https://docs.scipy.org/doc/numpy/objects.inv -> https://numpy.org/doc/stable/objects.inv
```

- [x] Passes `black dask` / `flake8 dask`
