### PR TITLE
minor sort_values housekeeping

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3982,9 +3982,6 @@ class DataFrame(_Frame):
         --------
         >>> df2 = df.sort_values('x')  # doctest: +SKIP
         """
-        if not ascending:
-            raise NotImplementedError("The ascending= keyword is not supported")
-
         from .shuffle import sort_values
 
         return sort_values(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3962,7 +3962,7 @@ class DataFrame(_Frame):
         cs = self._meta.select_dtypes(include=include, exclude=exclude).columns
         return self[list(cs)]
 
-    def sort_values(self, other, npartitions=None, ascending=True, **kwargs):
+    def sort_values(self, by, npartitions=None, ascending=True, **kwargs):
         """Sort the dataset by a single column.
 
         Sorting a parallel dataset requires expensive shuffles and is generally
@@ -3970,7 +3970,7 @@ class DataFrame(_Frame):
 
         Parameters
         ----------
-        other: string
+        by: string
         npartitions: int, None, or 'auto'
             The ideal number of output partitions. If None, use the same as
             the input. If 'auto' then decide by memory use.
@@ -3986,7 +3986,7 @@ class DataFrame(_Frame):
 
         return sort_values(
             self,
-            other,
+            by,
             ascending=ascending,
             npartitions=npartitions,
             **kwargs,

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -75,7 +75,7 @@ def sort_values(
     partition_size=128e6,
     **kwargs,
 ):
-    """ See _Frame.sort_values for docstring """
+    """ See DataFrame.sort_values for docstring """
     if not ascending:
         raise NotImplementedError("The ascending= keyword is not supported")
     if not isinstance(by, str):

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -76,6 +76,8 @@ def sort_values(
     **kwargs,
 ):
     """ See _Frame.sort_values for docstring """
+    if not ascending:
+        raise NotImplementedError("The ascending= keyword is not supported")
     if not isinstance(value, str):
         # support ["a"] as input
         if isinstance(value, list) and len(value) == 1 and isinstance(value[0], str):

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -109,7 +109,6 @@ def sort_values(
         and npartitions == df.npartitions
     ):
         # divisions are in the right place
-        divisions = mins + [maxes[-1]]
         return df.map_partitions(M.sort_values, by)
 
     df = rearrange_by_divisions(df, by, divisions)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -68,7 +68,7 @@ def _calculate_divisions(
 
 def sort_values(
     df,
-    value,
+    by,
     npartitions=None,
     ascending=True,
     upsample=1.0,
@@ -78,15 +78,15 @@ def sort_values(
     """ See _Frame.sort_values for docstring """
     if not ascending:
         raise NotImplementedError("The ascending= keyword is not supported")
-    if not isinstance(value, str):
+    if not isinstance(by, str):
         # support ["a"] as input
-        if isinstance(value, list) and len(value) == 1 and isinstance(value[0], str):
-            value = value[0]
+        if isinstance(by, list) and len(by) == 1 and isinstance(by[0], str):
+            by = by[0]
         else:
             raise NotImplementedError(
                 "Dataframe only supports sorting by a single column which must "
                 "be passed as a string or a list of a single string.\n"
-                "You passed %s" % str(value)
+                "You passed %s" % str(by)
             )
     if npartitions == "auto":
         repartition = True
@@ -96,7 +96,7 @@ def sort_values(
             npartitions = df.npartitions
         repartition = False
 
-    sort_by_col = df[value]
+    sort_by_col = df[by]
 
     divisions, mins, maxes = _calculate_divisions(
         df, sort_by_col, repartition, npartitions, upsample, partition_size
@@ -110,10 +110,10 @@ def sort_values(
     ):
         # divisions are in the right place
         divisions = mins + [maxes[-1]]
-        return df.map_partitions(M.sort_values, value)
+        return df.map_partitions(M.sort_values, by)
 
-    df = rearrange_by_divisions(df, value, divisions)
-    df = df.map_partitions(M.sort_values, value)
+    df = rearrange_by_divisions(df, by, divisions)
+    df = df.map_partitions(M.sort_values, by)
     return df
 
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1192,7 +1192,5 @@ def test_set_index_nan_partition():
 )
 def test_sort_values(npartitions):
     df = pd.DataFrame({"a": np.random.randint(0, 10, 100)})
-
     ddf = dd.from_pandas(df, npartitions=npartitions)
-
     assert_eq(ddf.sort_values("a"), df.sort_values("a"))


### PR DESCRIPTION
- [ ] ~Closes #xxxx~
- [ ] ~Tests added / passed~
- [x] Passes `black dask` / `flake8 dask`

a few mostly-cosmetic follow-ons to `sort_values` / #7286