### PR TITLE
TST: Remove global env mutation upon running test_config.py

### DIFF
--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -180,13 +180,10 @@ def test_collect():
             assert config == expected
 
 
-def test_collect_env_none():
-    os.environ["DASK_FOO"] = "bar"
-    try:
-        config = collect([])
-        assert config == {"foo": "bar"}
-    finally:
-        del os.environ["DASK_FOO"]
+def test_collect_env_none(monkeypatch):
+    monkeypatch.setenv("DASK_FOO", "bar")
+    config = collect([])
+    assert config == {"foo": "bar"}
 
 
 def test_get():
@@ -367,12 +364,9 @@ def test_refresh():
         ({"a": "A", "b": [1, "2", "$FOO"]}, {"a": "A", "b": [1, "2", "foo"]}),
     ],
 )
-def test_expand_environment_variables(inp, out):
-    try:
-        os.environ["FOO"] = "foo"
-        assert expand_environment_variables(inp) == out
-    finally:
-        del os.environ["FOO"]
+def test_expand_environment_variables(monkeypatch, inp, out):
+    monkeypatch.setenv("FOO", "foo")
+    assert expand_environment_variables(inp) == out
 
 
 def test_env_var_canonical_name(monkeypatch):


### PR DESCRIPTION
- [ ] ~~Closes #xxxx~~ N/A
- [x] Tests ~~added~~ / passed
- [x] Passes `black dask` / `flake8 dask`

This PR proposes an update to the config tests, so that they won't modify the global env state upon execution.
The only other tests which reference `os.environ` are:
- [dask/bytes/tests/test_s3.py](https://github.com/dask/dask/blob/main/dask/bytes/tests/test_s3.py) - The design choice [here](https://github.com/dask/dask/pull/4276/files) was to implement a context manager which handles the bookkeeping pertaining to resetting the global env upon completion. I've opted to not propose modification to those tests, because it's essentially a different way of achieving the same effect. My personal preference is employing `mock`.
- [dask/bytes/tests/test_hdfs.py](https://github.com/dask/dask/blob/main/dask/bytes/tests/test_hdfs.py) - This one is also OK, because it legitimately relies upon the global env state and doesn't mutate it.
