### PR TITLE
Add a dispatch for `is_categorical_dtype` to handle non-pandas objects

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -578,6 +578,7 @@ tolist_dispatch = Dispatch("tolist")
 is_categorical_dtype_dispatch = Dispatch("is_categorical_dtype")
 
 def is_categorical_dtype(obj):
+    obj = getattr(obj, "dtype", obj)
     func = is_categorical_dtype_dispatch.dispatch(type(obj))
     return func(obj)
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -575,7 +575,11 @@ def concat_pandas(
 
 
 tolist_dispatch = Dispatch("tolist")
+is_categorical_dtype_dispatch = Dispatch("is_categorical_dtype")
 
+def is_categorical_dtype(obj):
+    func = is_categorical_dtype_dispatch.dispatch(type(obj))
+    return func(obj)
 
 def tolist(obj):
     func = tolist_dispatch.dispatch(type(obj))
@@ -586,6 +590,10 @@ def tolist(obj):
 def tolist_pandas(obj):
     return obj.tolist()
 
+
+@tolist_dispatch.register((pd.Series, pd.Index, pd.CategoricalDtype))
+def is_categorical_dtype_pandas(obj):
+    return pd.api.types.is_categorical_dtype(obj)
 
 # cuDF may try to import old dispatch functions
 hash_df = hash_object_dispatch

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -591,7 +591,7 @@ def tolist_pandas(obj):
     return obj.tolist()
 
 
-@tolist_dispatch.register((pd.Series, pd.Index, pd.CategoricalDtype))
+@is_categorical_dtype_dispatch.register((pd.Series, pd.Index, pd.api.extensions.ExtensionDtype, np.dtype))
 def is_categorical_dtype_pandas(obj):
     return pd.api.types.is_categorical_dtype(obj)
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -577,10 +577,12 @@ def concat_pandas(
 tolist_dispatch = Dispatch("tolist")
 is_categorical_dtype_dispatch = Dispatch("is_categorical_dtype")
 
+
 def is_categorical_dtype(obj):
     obj = getattr(obj, "dtype", obj)
     func = is_categorical_dtype_dispatch.dispatch(type(obj))
     return func(obj)
+
 
 def tolist(obj):
     func = tolist_dispatch.dispatch(type(obj))
@@ -592,9 +594,12 @@ def tolist_pandas(obj):
     return obj.tolist()
 
 
-@is_categorical_dtype_dispatch.register((pd.Series, pd.Index, pd.api.extensions.ExtensionDtype, np.dtype))
+@is_categorical_dtype_dispatch.register(
+    (pd.Series, pd.Index, pd.api.extensions.ExtensionDtype, np.dtype)
+)
 def is_categorical_dtype_pandas(obj):
     return pd.api.types.is_categorical_dtype(obj)
+
 
 # cuDF may try to import old dispatch functions
 hash_df = hash_object_dispatch

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from .core import Series, DataFrame, map_partitions, apply_concat_apply
 from . import methods
-from .utils import is_categorical_dtype, is_scalar, has_known_categories
+from .utils import is_scalar, has_known_categories
 from ..utils import M
 import sys
 from pandas.api.types import is_list_like
@@ -130,7 +130,7 @@ def get_dummies(
     )
 
     if isinstance(data, Series):
-        if not is_categorical_dtype(data):
+        if not methods.is_categorical_dtype(data):
             raise NotImplementedError(not_cat_msg)
         if not has_known_categories(data):
             raise NotImplementedError(unknown_cat_msg)
@@ -140,7 +140,8 @@ def get_dummies(
                 raise NotImplementedError(not_cat_msg)
             columns = data._meta.select_dtypes(include=["category"]).columns
         else:
-            if not all(is_categorical_dtype(data[c]) for c in columns):
+            breakpoint()
+            if not all(methods.is_categorical_dtype(data[c]) for c in columns):
                 raise NotImplementedError(not_cat_msg)
 
         if not all(has_known_categories(data[c]) for c in columns):

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -140,7 +140,6 @@ def get_dummies(
                 raise NotImplementedError(not_cat_msg)
             columns = data._meta.select_dtypes(include=["category"]).columns
         else:
-            breakpoint()
             if not all(methods.is_categorical_dtype(data[c]) for c in columns):
                 raise NotImplementedError(not_cat_msg)
 

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -213,7 +213,7 @@ def pivot_table(df, index=None, columns=None, values=None, aggfunc="mean"):
         raise ValueError("'index' must be the name of an existing column")
     if not is_scalar(columns) or columns is None:
         raise ValueError("'columns' must be the name of an existing column")
-    if not is_categorical_dtype(df[columns]):
+    if not methods.is_categorical_dtype(df[columns]):
         raise ValueError("'columns' must be category dtype")
     if not has_known_categories(df[columns]):
         raise ValueError(


### PR DESCRIPTION
- [x] Closes https://github.com/dask/dask/issues/7054
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

