### PR TITLE
[DOCS] Add warning to docs when partitioning on month/quarter/year end.

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1185,7 +1185,7 @@ Dask Name: {name}, {task} tasks"""
             .. warning::
                If you want, e.g., monthly partitions, then you should use
                ``freq="MS"`` (month start) and not ``freq="M"`` (month end)
-               since the divisions indicate the minimum of a partition
+               since the divisions indicate the start of a partition
                (same holds for quarterly and yearly).
 
         force : bool, default False

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1184,8 +1184,9 @@ Dask Name: {name}, {task} tasks"""
 
             .. warning::
                If you want, e.g., monthly partitions, then you should use
-               ``freq="MS"`` (and not ``freq="M"``), since the divisions indicate
-               the minimum of a partition (same holds for quarterly and yearly).
+               ``freq="MS"`` (month start) and not ``freq="M"`` (month end)
+               since the divisions indicate the minimum of a partition
+               (same holds for quarterly and yearly).
 
         force : bool, default False
             Allows the expansion of the existing divisions.

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1181,6 +1181,12 @@ Dask Name: {name}, {task} tasks"""
         freq : str, pd.Timedelta
             A period on which to partition timeseries data like ``'7D'`` or
             ``'12h'`` or ``pd.Timedelta(hours=12)``.  Assumes a datetime index.
+
+            .. warning::
+               If you want, e.g., monthly partitions, then you should use
+               ``freq="MS"`` (and not ``freq="M"``), since the divisions indicate
+               the minimum of a partition (same holds for quarterly and yearly).
+
         force : bool, default False
             Allows the expansion of the existing divisions.
             If False then the new divisions' lower and upper bounds must be


### PR DESCRIPTION
I'm convinced that many people use `.repartition(freq="M")` to partition their data on months (where they actually mean `freq="MS"`). 

In this PR I propose to add a warning to the docs.

I would also be in favour of throwing a warning at runtime when `freq in ["M", "Q", "Y"]`. WDYT?