### PR TITLE
Use `multiprocessing.Pool` in `test_read_text`

### DIFF
--- a/dask/bytes/tests/test_hdfs.py
+++ b/dask/bytes/tests/test_hdfs.py
@@ -147,11 +147,10 @@ def test_read_csv(hdfs):
 
 def test_read_text(hdfs):
     import multiprocessing as mp
-    from concurrent.futures import ProcessPoolExecutor
 
-    ctx = mp.get_context("spawn")
+    pool = mp.get_context("spawn").Pool(2)
 
-    with ProcessPoolExecutor(2, ctx) as pool:
+    with pool:
         with hdfs.open("%s/text.1.txt" % basedir, "wb") as f:
             f.write("Alice 100\nBob 200\nCharlie 300".encode())
 


### PR DESCRIPTION
As this is being used with Dask's local scheduler, we can't make this change while the local scheduler relies on `apply_async`. So revert for now.

- [ ] Closes https://github.com/dask/dask/issues/7471 , Also xref https://github.com/dask/dask/pull/7429#issuecomment-808432026
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`

cc @jsignell @jrbourbeau