### PR TITLE
fix typo in array docs

### DIFF
--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -47,7 +47,7 @@ Design
    :align: right
 
 Dask arrays coordinate many NumPy arrays (or "duck arrays" that are
-sufficiently NumPy-like in API such as CuPy or Spare arrays) arranged into a
+sufficiently NumPy-like in API such as CuPy or Sparse arrays) arranged into a
 grid. These arrays may live on disk or on other machines.
 
 New duck array chunk types (types below Dask on


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`

Was reading https://docs.dask.org/en/latest/array.html tonight and noticed what I think is a typo. That doc has a mention of "Spare" arrays but based on the context around it I think that was supposed to be "Sparse". This PR proposes fixing that typo.