### PR TITLE
Escape from map_overlap to map_blocks if depth is zero

### DIFF
--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -775,15 +775,15 @@ def map_overlap(
     depth = coerce(args, depth, coerce_depth)
     boundary = coerce(args, boundary, coerce_boundary)
 
-    # Escape to map_blocks if depth is zero (a more efficient computation)
-    if all(depth_val == 0 for depth_val in depth[0].values()):
-        return map_blocks(func, *args, **kwargs)
-
     # Align chunks in each array to a common size
     if align_arrays:
         # Reverse unification order to allow block broadcasting
         inds = [list(reversed(range(x.ndim))) for x in args]
         _, args = unify_chunks(*list(concat(zip(args, inds))), warn=False)
+
+    # Escape to map_blocks if depth is zero (a more efficient computation)
+    if all([all(depth_val == 0 for depth_val in d.values()) for d in depth]):
+        return map_blocks(func, *args, **kwargs)
 
     for i, x in enumerate(args):
         for j in range(x.ndim):

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -775,6 +775,10 @@ def map_overlap(
     depth = coerce(args, depth, coerce_depth)
     boundary = coerce(args, boundary, coerce_boundary)
 
+    # Escape to map_blocks if depth is zero (a more efficient computation)
+    if all(depth_val == 0 for depth_val in depth[0].values()):
+        return map_blocks(func, *args, **kwargs)
+
     # Align chunks in each array to a common size
     if align_arrays:
         # Reverse unification order to allow block broadcasting

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -294,6 +294,11 @@ def test_asymmetric_overlap_boundary_exception():
 
 
 def test_map_overlap():
+    x = da.from_array(np.arange(10), chunks=5)
+    y = x.map_overlap(lambda x: x + 1, depth=0)
+    assert len(y.dask) == 2 * x.numblocks[0]  # depth=0 --> map_blocks
+    assert_eq(y, np.arange(10) + 1)
+
     x = da.arange(10, chunks=5)
     y = x.map_overlap(lambda x: x + len(x), depth=2, dtype=x.dtype)
     assert_eq(y, np.arange(10) + 5 + 2 + 2)

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -295,11 +295,6 @@ def test_asymmetric_overlap_boundary_exception():
 
 def test_map_overlap():
     x = da.arange(10, chunks=5)
-    y = x.map_overlap(lambda x: x + 1, depth=0)
-    assert len(y.dask) == 2 * x.numblocks[0]  # depth=0 --> map_blocks
-    assert_eq(y, np.arange(10) + 1)
-
-    x = da.arange(10, chunks=5)
     y = x.map_overlap(lambda x: x + len(x), depth=2, dtype=x.dtype)
     assert_eq(y, np.arange(10) + 5 + 2 + 2)
 
@@ -339,6 +334,13 @@ def test_map_overlap():
             [[x[0:2, 0:2] + 4, x[0:2, 2:4] + 6], [x[2:4, 0:2] + 4, x[2:4, 2:4] + 6]]
         ),
     )
+
+
+def test_map_overlap_escapes_to_map_blocks_when_depth_is_zero():
+    x = da.arange(10, chunks=5)
+    y = x.map_overlap(lambda x: x + 1, depth=0)
+    assert len(y.dask) == 2 * x.numblocks[0]  # depth=0 --> map_blocks
+    assert_eq(y, np.arange(10) + 1)
 
 
 @pytest.mark.parametrize(

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -294,7 +294,7 @@ def test_asymmetric_overlap_boundary_exception():
 
 
 def test_map_overlap():
-    x = da.from_array(np.arange(10), chunks=5)
+    x = da.arange(10, chunks=5)
     y = x.map_overlap(lambda x: x + 1, depth=0)
     assert len(y.dask) == 2 * x.numblocks[0]  # depth=0 --> map_blocks
     assert_eq(y, np.arange(10) + 1)


### PR DESCRIPTION
- [x] Closes https://github.com/dask/dask/issues/7435
- [x] Tests added & passed
- [x] Passes `black dask` / `flake8 dask`

We talked [here](https://github.com/dask/dask/issues/7435#issuecomment-804096028) about adding a little "escape hatch" to `map_overlap`, so that in cases where the depth is zero (i.e. equivalent to no overlap), then the more computationally efficient `map_blocks` can be used instead. This PR does just that.
