### PR TITLE
Use powers-of-two when displaying RAM

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -32,6 +32,7 @@ from dask.utils import (
     iter_chunks,
     stringify,
     stringify_collection_keys,
+    format_bytes,
 )
 from dask.utils_test import inc
 from dask.highlevelgraph import HighLevelGraph
@@ -637,3 +638,24 @@ def test_stringify_collection_keys():
     assert res[0] == str(obj[0])
     assert res[1] == str(obj[1])
     assert res[2] == obj[2]
+
+
+@pytest.mark.parametrize(
+    "n,expect",
+    [
+        (0, "0 B"),
+        (920, "920 B"),
+        (930, "0.91 kiB"),
+        (921.23 * 2 ** 10, "921.23 kiB"),
+        (931.23 * 2 ** 10, "0.91 MiB"),
+        (921.23 * 2 ** 20, "921.23 MiB"),
+        (931.23 * 2 ** 20, "0.91 GiB"),
+        (921.23 * 2 ** 30, "921.23 GiB"),
+        (931.23 * 2 ** 30, "0.91 TiB"),
+        (921.23 * 2 ** 40, "921.23 TiB"),
+        (931.23 * 2 ** 40, "0.91 PiB"),
+        (2 ** 60, "1024.00 PiB"),
+    ],
+)
+def test_format_bytes(n, expect):
+    assert format_bytes(int(n)) == expect

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1387,34 +1387,35 @@ def format_time_ago(n: datetime) -> str:
     return "Just now"
 
 
-def format_bytes(n):
+def format_bytes(n: int) -> str:
     """Format bytes as text
 
     >>> from dask.utils import format_bytes
     >>> format_bytes(1)
     '1 B'
     >>> format_bytes(1234)
-    '1.23 kB'
+    '1.21 kiB'
     >>> format_bytes(12345678)
-    '12.35 MB'
+    '11.77 MiB'
     >>> format_bytes(1234567890)
-    '1.23 GB'
+    '1.15 GiB'
     >>> format_bytes(1234567890000)
-    '1.23 TB'
+    '1.12 TiB'
     >>> format_bytes(1234567890000000)
-    '1.23 PB'
+    '1.10 PiB'
+
+    For all values < 2**60, the output is always <= 10 characters.
     """
-    if n > 1e15:
-        return "%0.2f PB" % (n / 1e15)
-    if n > 1e12:
-        return "%0.2f TB" % (n / 1e12)
-    if n > 1e9:
-        return "%0.2f GB" % (n / 1e9)
-    if n > 1e6:
-        return "%0.2f MB" % (n / 1e6)
-    if n > 1e3:
-        return "%0.2f kB" % (n / 1000)
-    return "%d B" % n
+    for prefix, k in (
+        ("Pi", 2 ** 50),
+        ("Ti", 2 ** 40),
+        ("Gi", 2 ** 30),
+        ("Mi", 2 ** 20),
+        ("ki", 2 ** 10),
+    ):
+        if n >= k * 0.9:
+            return f"{n / k:.2f} {prefix}B"
+    return f"{n} B"
 
 
 timedelta_sizes = {


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/3818
Twin of https://github.com/dask/distributed/pull/4649

Memory is ubiquitously expressed in power of twos.
The one and only exception that I'm aware of is when selling hard drives.

This change impacts:
- dask.array.Array.\_repr_html\_
- distributed.Client.\_\_repr\_\_
- distributed.Client.\_repr_html\_
- distributed.cluster.Cluster._widget_status
- distributed.cluster.Cluster.\_\_repr\_\_
- distributed.Scheduler.performance_report
- distributed worker logs
- distributed bokeh GUI

