### PR TITLE
Added License Classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "License :: OSI Approved :: BSD License",
     ],
     packages=packages + tests,
     long_description=open("README.rst").read() if exists("README.rst") else "",


### PR DESCRIPTION
This adds the `License :: OSI Approved :: BSD License` classifier to the setup.py, which some static analysis tools look for.
