### PR TITLE
Construct `Array` from `DataFrame` with `meta`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6689,7 +6689,7 @@ def new_dd_object(dsk, name, meta, divisions):
                 suffix = (0,) * (len(chunks) - 1)
                 for i in range(len(chunks[0])):
                     layer[(name, i) + suffix] = layer.pop((name, i))
-        return da.Array(dsk, name=name, chunks=chunks, dtype=meta.dtype)
+        return da.Array(dsk, name=name, chunks=chunks, meta=meta)
     else:
         return get_parallel_type(meta)(dsk, name, meta, divisions)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3779,9 +3779,13 @@ def test_values():
     ddf = dd.from_pandas(df, 2)
 
     assert_eq(df.values, ddf.values)
+    assert isinstance(ddf.values._meta, type(df.values))
     assert_eq(df.x.values, ddf.x.values)
+    assert isinstance(ddf.x.values._meta, type(df.x.values))
     assert_eq(df.y.values, ddf.y.values)
+    assert isinstance(ddf.y.values._meta, type(df.y.values))
     assert_eq(df.index.values, ddf.index.values)
+    assert isinstance(ddf.index.values._meta, type(df.index.values))
 
 
 def test_copy():


### PR DESCRIPTION
Currently the `_meta` of `values` doesn't get correctly updated when using cuDF DataFrames instead of Pandas ones. Thus the `_meta` winds up being a NumPy array instead of a CuPy array.

It seems the `meta` handling code in Dask DataFrame hadn't been updated since Dask Array got its own `meta`. So simply update the `Array` construction code to use `meta`.

cc @rjzamora @kkraus14

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
