### PR TITLE
Fix upstream `__array_ufunc__` tests

### DIFF
--- a/dask/array/gufunc.py
+++ b/dask/array/gufunc.py
@@ -640,6 +640,7 @@ class gufunc:
         )
 
     def __call__(self, *args, **kwargs):
+        allow_rechunk = self.allow_rechunk or kwargs.pop("allow_rechunk", False)
         return apply_gufunc(
             self.pyfunc,
             self.signature,
@@ -650,7 +651,7 @@ class gufunc:
             keepdims=self.keepdims,
             output_sizes=self.output_sizes,
             output_dtypes=self.output_dtypes,
-            allow_rechunk=self.allow_rechunk or kwargs.pop("allow_rechunk", False),
+            allow_rechunk=allow_rechunk,
             meta=self.meta,
             **kwargs,
         )

--- a/dask/array/gufunc.py
+++ b/dask/array/gufunc.py
@@ -640,7 +640,6 @@ class gufunc:
         )
 
     def __call__(self, *args, **kwargs):
-        allow_rechunk = self.allow_rechunk or kwargs.pop("allow_rechunk", False)
         return apply_gufunc(
             self.pyfunc,
             self.signature,
@@ -651,7 +650,7 @@ class gufunc:
             keepdims=self.keepdims,
             output_sizes=self.output_sizes,
             output_dtypes=self.output_dtypes,
-            allow_rechunk=allow_rechunk,
+            allow_rechunk=self.allow_rechunk or kwargs.pop("allow_rechunk", False),
             meta=self.meta,
             **kwargs,
         )

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -297,20 +297,17 @@ def test_Array_numpy_gufunc_call__array_ufunc__01():
     x = da.random.normal(size=(3, 10, 10), chunks=(2, 10, 10))
     nx = x.compute()
     ny = np.linalg._umath_linalg.inv(nx)
-    y = np.linalg._umath_linalg.inv(x, output_dtypes=float)
-    vy = y.compute()
-    assert_eq(ny, vy)
+    y = np.linalg._umath_linalg.inv(x)
+    assert_eq(ny, y)
 
 
 def test_Array_numpy_gufunc_call__array_ufunc__02():
     x = da.random.normal(size=(3, 10, 10), chunks=(2, 10, 10))
     nx = x.compute()
     nw, nv = np.linalg._umath_linalg.eig(nx)
-    w, v = np.linalg._umath_linalg.eig(x, output_dtypes=(float, float))
-    vw = w.compute()
-    vv = v.compute()
-    assert_eq(nw, vw)
-    assert_eq(nv, vv)
+    w, v = np.linalg._umath_linalg.eig(x)
+    assert_eq(nw, w)
+    assert_eq(nv, v)
 
 
 def test_stack():

--- a/dask/array/tests/test_gufunc.py
+++ b/dask/array/tests/test_gufunc.py
@@ -586,11 +586,10 @@ def test_apply_gufunc_via_numba_02():
         for i in range(x.shape[0]):
             res[0] += x[i]
 
-    a = da.random.normal(size=(20, 30), chunks=5)
+    a = da.random.normal(size=(20, 30), chunks=30)
 
     x = a.sum(axis=0, keepdims=True)
-    y = mysum(a, axis=0, keepdims=True, allow_rechunk=True)
-
+    y = mysum(a, axis=0, keepdims=True)
     assert_eq(x, y)
 
 


### PR DESCRIPTION
- [x] Closes #7493 
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

This changes the contents of tests, but I think it's necessary. It seems like extra kwargs are purposefully not being passed through anymore when using `__array_ufunc__`