### PR TITLE
Update docs on number of threads and workers in default LocalCluster

### DIFF
--- a/docs/source/setup/single-distributed.rst
+++ b/docs/source/setup/single-distributed.rst
@@ -34,8 +34,8 @@ Client with no arguments
    from dask.distributed import Client
    client = Client()
 
-This sets up a scheduler in your local process and several processes running
-single-threaded Workers.
+This sets up a scheduler in your local process along with a number of workers and
+threads per worker related to the number of cores in your machine.
 
 If you want to run workers in your same process, you can pass the
 ``processes=False`` keyword argument.


### PR DESCRIPTION
This PR updates an erroneous line in the documentation describing the default behavior of the dask.distributed Client() class.

When the caller does not pass arguments to the Client() class, the workers created are not necessarily single-threaded. In particular, if the number of cores in the machine exceeds 4, then the workers may not be single-threaded.

When the caller does not pass args to the Client() class, a LocalCluster is created and the `nprocesses_nthreads` function determines the number of workers and number of threads, as shown here: https://github.com/dask/distributed/blob/main/distributed/deploy/local.py#L180

If the number of cores is greater than 4, then the `nprocesses_nthreads` function may set `threads` to a number greater than 1. See the implementation of the nprocesses_nthreads function here: https://github.com/dask/distributed/blob/main/distributed/deploy/utils.py#L30

Please let me know if the updated wording can be more clear. I was considering splitting the sentence out into two.