### PR TITLE
Only provide installation instructions when distributed is missing

### DIFF
--- a/dask/distributed.py
+++ b/dask/distributed.py
@@ -2,10 +2,13 @@
 try:
     from distributed import *
 except ImportError as e:
-    msg = (
-        "Dask's distributed scheduler is not installed.\n\n"
-        "Please either conda or pip install dask distributed:\n\n"
-        "  conda install dask distributed          # either conda install\n"
-        '  python -m pip install "dask[distributed]" --upgrade  # or python -m pip install'
-    )
-    raise ImportError(msg) from e
+    if e.msg == "No module named 'distributed'":
+        msg = (
+            "Dask's distributed scheduler is not installed.\n\n"
+            "Please either conda or pip install dask distributed:\n\n"
+            "  conda install dask distributed          # either conda install\n"
+            '  python -m pip install "dask[distributed]" --upgrade  # or python -m pip install'
+        )
+        raise ImportError(msg) from e
+    else:
+        raise


### PR DESCRIPTION
The line "from dask.distributed import ..." causes us to import
distributed.
If that doesn't work today, we currently tell people to go and install
distributed with pip/conda.

However, if there is an underlying optional library that is missing
(like uvloop)
then this message hides the actual issue and so leads the user astray.

This commit restricts the use of the informative message to only the
case when distributed is missing, and falls back to normal Python
behavior otherwise.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
