### PR TITLE
extract ignore_order from kwargs

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -449,10 +449,10 @@ def concat_pandas(
     ignore_index=False,
     **kwargs
 ):
+    ignore_order = kwargs.pop("ignore_order", False)
+
     if axis == 1:
         return pd.concat(dfs, axis=axis, join=join, **kwargs)
-
-    ignore_order = kwargs.pop("ignore_order", False)
 
     # Support concatenating indices along axis 0
     if isinstance(dfs[0], pd.Index):

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -452,7 +452,7 @@ def concat_pandas(
     if axis == 1:
         return pd.concat(dfs, axis=axis, join=join, **kwargs)
 
-    ignore_order = kwargs.get("ignore_order", False)
+    ignore_order = kwargs.pop("ignore_order", False)
 
     # Support concatenating indices along axis 0
     if isinstance(dfs[0], pd.Index):

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -425,7 +425,7 @@ def concat(
     if len(dfs) == 1:
         return dfs[0]
     else:
-        ignore_order = kwargs.get("ignore_order", False)
+        ignore_order = kwargs.pop("ignore_order", False)
         func = concat_dispatch.dispatch(type(dfs[0]))
         return func(
             dfs,

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -398,7 +398,6 @@ def concat(
     join="outer",
     uniform=False,
     filter_warning=True,
-    ignore_order=False,
     ignore_index=False,
     **kwargs
 ):
@@ -426,6 +425,7 @@ def concat(
     if len(dfs) == 1:
         return dfs[0]
     else:
+        ignore_order = kwargs.get("ignore_order", False)
         func = concat_dispatch.dispatch(type(dfs[0]))
         return func(
             dfs,
@@ -446,12 +446,13 @@ def concat_pandas(
     join="outer",
     uniform=False,
     filter_warning=True,
-    ignore_order=False,
     ignore_index=False,
     **kwargs
 ):
     if axis == 1:
         return pd.concat(dfs, axis=axis, join=join, **kwargs)
+
+    ignore_order = kwargs.get("ignore_order", False)
 
     # Support concatenating indices along axis 0
     if isinstance(dfs[0], pd.Index):

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -425,7 +425,6 @@ def concat(
     if len(dfs) == 1:
         return dfs[0]
     else:
-        ignore_order = kwargs.pop("ignore_order", False)
         func = concat_dispatch.dispatch(type(dfs[0]))
         return func(
             dfs,
@@ -434,7 +433,6 @@ def concat(
             uniform=uniform,
             filter_warning=filter_warning,
             ignore_index=ignore_index,
-            ignore_order=ignore_order,
             **kwargs
         )
 

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -1019,6 +1019,7 @@ def stack_partitions(dfs, divisions, join="outer", ignore_order=False, **kwargs)
     # for empty data frames. See https://github.com/pandas-dev/pandas/issues/32934.
 
     kwargs.update({"ignore_order": ignore_order})
+
     meta = make_meta(
         methods.concat(
             [df._meta_nonempty for df in dfs],
@@ -1074,12 +1075,9 @@ def stack_partitions(dfs, divisions, join="outer", ignore_order=False, **kwargs)
                 dsk[(name, i)] = key
             else:
                 dsk[(name, i)] = (
+                    apply,
                     methods.concat,
-                    [empty, key],
-                    0,
-                    join,
-                    uniform,
-                    filter_warning,
+                    [[empty, key], 0, join, uniform, filter_warning],
                     kwargs,
                 )
             i += 1
@@ -1187,6 +1185,7 @@ def concat(
     ... ], interleave_partitions=True).dtype
     CategoricalDtype(categories=['a', 'b', 'c'], ordered=False)
     """
+
     if not isinstance(dfs, list):
         raise TypeError("dfs must be a list of DataFrames/Series objects")
     if len(dfs) == 0:

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -1080,7 +1080,6 @@ def stack_partitions(dfs, divisions, join="outer", ignore_order=False, **kwargs)
                     join,
                     uniform,
                     filter_warning,
-                    False,
                     kwargs,
                 )
             i += 1

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -1003,7 +1003,7 @@ def concat_indexed_dataframes(dfs, axis=0, join="outer", ignore_order=False, **k
     dsk = dict(
         (
             (name, i),
-            (methods.concat, part, axis, join, uniform, filter_warning, ignore_order),
+            (methods.concat, part, axis, join, uniform, filter_warning, kwargs),
         )
         for i, part in enumerate(parts2)
     )

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -969,9 +969,7 @@ def concat_unindexed_dataframes(dfs, ignore_order=False, **kwargs):
         for i in range(dfs[0].npartitions)
     }
     kwargs.update({"ignore_order": ignore_order})
-    meta = methods.concat(
-        [df._meta for df in dfs], axis=1, **kwargs
-    )
+    meta = methods.concat([df._meta for df in dfs], axis=1, **kwargs)
 
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=dfs)
     return new_dd_object(graph, name, meta, dfs[0].divisions)


### PR DESCRIPTION
When https://github.com/dask/dask/pull/7473 was merged, `ignore_order` was added in the middle of the function signature of `concat_dispatch`, this leads to breakages in downstream libraries using this dispatch. Hence with these changes `ignore_order` will be extracted from `**kwargs`. 

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
