### PR TITLE
Ensure worker process shutdown calls atexit handlers

### DIFF
--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -3,6 +3,7 @@ import multiprocessing
 import multiprocessing.pool
 import os
 import pickle
+import signal
 import sys
 import traceback
 from concurrent.futures import ProcessPoolExecutor
@@ -244,3 +245,7 @@ def initialize_worker_process():
     np = sys.modules.get("numpy")
     if np is not None:
         np.random.seed()
+
+    # Ensure that shutdown of the worker process follows the normal python
+    # shutdown procedure (including calling `atexit` hooks, etc...).
+    signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit())

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -17,8 +17,8 @@ from dask.multiprocessing import (
     _loads,
     get,
     get_context,
-    remote_exception,
     initialize_worker_process,
+    remote_exception,
 )
 from dask.system import CPU_COUNT
 from dask.utils_test import inc


### PR DESCRIPTION
Processes managed by Python's `multiprocessing` don't follow the normal
interpreter shutdown procedure by default (since `multiprocessing` kills
workers with `SIGTERM`). We register our own signal handler to fix that,
ensuring that the normal shutdown procedure is followed (including
calling atexit hooks). This matters both for users of the
multiprocessing scheduler, as well as distributed's `LocalCluster`,
since that also uses `multiprocessing` to manage workers (and also uses
`dask.multiprocessing.initialize_worker_process`).