### PR TITLE
Array: Fix NEP18 dispatching in finalize

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4740,8 +4740,8 @@ def concatenate3(arrays):
 
     if IS_NEP18_ACTIVE and not all(
         NDARRAY_ARRAY_FUNCTION
-        is getattr(arr, "__array_function__", NDARRAY_ARRAY_FUNCTION)
-        for arr in arrays
+        is getattr(type(arr), "__array_function__", NDARRAY_ARRAY_FUNCTION)
+        for arr in core.flatten(arrays, container=(list, tuple))
     ):
         try:
             x = unpack_singleton(arrays)
@@ -4767,7 +4767,9 @@ def concatenate3(arrays):
 
     result = np.empty(shape=shape, dtype=dtype(deepfirst(arrays)))
 
-    for (idx, arr) in zip(slices_from_chunks(chunks), core.flatten(arrays)):
+    for (idx, arr) in zip(
+        slices_from_chunks(chunks), core.flatten(arrays, container=(list, tuple))
+    ):
         if hasattr(arr, "ndim"):
             while arr.ndim < ndim:
                 arr = arr[None, ...]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -41,6 +41,7 @@ from dask.array.core import (
     stack,
     store,
 )
+from dask.array.numpy_compat import _numpy_117
 from dask.array.utils import assert_eq, same_keys
 from dask.base import compute_as_if_collection, tokenize
 from dask.blockwise import broadcast_dimensions
@@ -2645,6 +2646,7 @@ def test_concatenate3_2():
     )
 
 
+@pytest.mark.skipif(not _numpy_117, reason="NEP-18 is not enabled by default")
 @pytest.mark.parametrize("one_d", [True, False])
 @mock.patch.object(da.core, "_concatenate2", wraps=da.core._concatenate2)
 def test_concatenate3_nep18_dispatching(mock_concatenate2, one_d):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1,4 +1,5 @@
 import copy
+from unittest import mock
 
 import pytest
 
@@ -48,6 +49,8 @@ from dask.blockwise import optimize_blockwise
 from dask.delayed import Delayed, delayed
 from dask.utils import apply, ignoring, key_split, tmpdir, tmpfile
 from dask.utils_test import dec, inc
+
+from .test_dispatch import EncapsulateNDArray
 
 
 def test_getem():
@@ -2640,6 +2643,24 @@ def test_concatenate3_2():
             ]
         ),
     )
+
+
+@pytest.mark.parametrize("one_d", [True, False])
+@mock.patch.object(da.core, "_concatenate2", wraps=da.core._concatenate2)
+def test_concatenate3_nep18_dispatching(mock_concatenate2, one_d):
+    x = EncapsulateNDArray(np.arange(10))
+    concat = [x, x] if one_d else [[x[None]], [x[None]]]
+    result = concatenate3(concat)
+    assert type(result) is type(x)
+    mock_concatenate2.assert_called()
+    mock_concatenate2.reset_mock()
+
+    # When all the inputs are supported by plain `np.concatenate`, we should take the concatenate3
+    # fastpath of allocating the full array up front and writing blocks into it.
+    concat = [x.arr, x.arr] if one_d else [[x.arr[None]], [x.arr[None]]]
+    plain_np_result = concatenate3(concat)
+    mock_concatenate2.assert_not_called()
+    assert type(plain_np_result) is np.ndarray
 
 
 def test_map_blocks3():


### PR DESCRIPTION
#4669 was meant to do this, but it wasn't working anymore. Turns out `arr.__array_function__ is not type(arr).__array_function__`, even when `arr` is a plain ndarray. So I believe we've actually being going down the `_concatenate2` path for all array types, even plain ndarrays where we could do the more efficient fill-in-the-blocks method of `concatenate3`.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
