### PR TITLE
Raise error when read and write happens to the same directory location in the same task graph

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1,5 +1,6 @@
 import math
 import warnings
+from distutils.version import LooseVersion
 
 import tlz as toolz
 from fsspec.core import get_fs_token_paths

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1,7 +1,6 @@
 import math
 import os
 import warnings
-from distutils.version import LooseVersion
 
 import tlz as toolz
 from fsspec.core import get_fs_token_paths


### PR DESCRIPTION

- [x] Closes #7466
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

I had a few queries, marking as draft till then.
* The format of `parts`. The fastparquet engine seems to accept [two formats](https://github.com/dask/dask/blob/c5633c21e754df6b2c13195f1e2688e347c48963/dask/dataframe/io/parquet/fastparquet.py#L750) - one where the path is the first element of the `parts` tuple and another where the path is part of `kwargs`. I can't seem to find usage of the second format anywhere. Could you point me to an example so I can handle that case too?
