### PR TITLE
Fix dict-column appending for pyarrow parquet engines

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -750,14 +750,14 @@ class ArrowDatasetEngine(Engine):
                 # Original dataset does not exist - cannot append
                 append = False
         if append:
-            names = dataset.metadata.schema.names
+            arrow_schema = dataset.schema.to_arrow_schema()
+            names = arrow_schema.names
             has_pandas_metadata = (
-                dataset.schema.to_arrow_schema().metadata is not None
-                and b"pandas" in dataset.schema.to_arrow_schema().metadata
+                arrow_schema.metadata is not None and b"pandas" in arrow_schema.metadata
             )
             if has_pandas_metadata:
                 pandas_metadata = json.loads(
-                    dataset.schema.to_arrow_schema().metadata[b"pandas"].decode("utf8")
+                    arrow_schema.metadata[b"pandas"].decode("utf8")
                 )
                 categories = [
                     c["name"]
@@ -766,7 +766,7 @@ class ArrowDatasetEngine(Engine):
                 ]
             else:
                 categories = None
-            dtypes = _get_pyarrow_dtypes(dataset.schema.to_arrow_schema(), categories)
+            dtypes = _get_pyarrow_dtypes(arrow_schema, categories)
             if set(names) != set(df.columns) - set(partition_on):
                 raise ValueError(
                     "Appended columns not the same.\n"

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -841,7 +841,7 @@ def test_append_dict_column(tmpdir, engine):
     if engine == "fastparquet":
         pytest.xfail("Fastparquet engine is missing dict-column support")
     elif pa.__version__ < LooseVersion("1.0.1"):
-        pytest.skip("PyArrow>=1.0.1 Required.")
+        pytest.skip("Newer PyArrow version required for dict-column support.")
 
     tmp = str(tmpdir)
     dts = pd.date_range("2020-01-01", "2021-01-01")

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -840,6 +840,8 @@ def test_append_dict_column(tmpdir, engine):
 
     if engine == "fastparquet":
         pytest.xfail("Fastparquet engine is missing dict-column support")
+    elif pa.__version__ < LooseVersion("1.0.1"):
+        pytest.skip("PyArrow>=1.0.1 Required.")
 
     tmp = str(tmpdir)
     dts = pd.date_range("2020-01-01", "2021-01-01")


### PR DESCRIPTION
Fixes a schema-handling bug for the `append=True` code path in the "pyarrow"-based parquet writers.  This PR does not address dict/struct-column handling in the fastparquet engine.

- [x] Closes #7492 
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
