### PR TITLE
DOC: use .to_parquet on dask.dataframe in doc string

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -486,7 +486,7 @@ def to_parquet(
     Examples
     --------
     >>> df = dd.read_csv(...)  # doctest: +SKIP
-    >>> dd.to_parquet(df, '/path/to/output/',...)  # doctest: +SKIP
+    >>> df.to_parquet('/path/to/output/', ...)  # doctest: +SKIP
 
     See Also
     --------


### PR DESCRIPTION
I feel `df.to_parquet('/path/to/output/', ...)` is a bit more compact than `dd.to_parquet(df, '/path/to/output/',...)`

It also matches the pandas doc string https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_parquet.html
