### PR TITLE
CI: force nightly pyarrow in the upstream build

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -7,7 +7,7 @@ set -xe
 # python -m pip install --no-deps cityhash
 
 if [[ ${UPSTREAM_DEV} ]]; then
-    mamba install -y -c arrow-nightlies pyarrow>3.0
+    mamba install -y -c arrow-nightlies "pyarrow>3.0"
 
     # FIXME https://github.com/mamba-org/mamba/issues/412
     # mamba uninstall --force numpy pandas

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -7,7 +7,7 @@ set -xe
 # python -m pip install --no-deps cityhash
 
 if [[ ${UPSTREAM_DEV} ]]; then
-    mamba update -y -c arrow-nightlies pyarrow
+    mamba install -y -c arrow-nightlies pyarrow>3.0
 
     # FIXME https://github.com/mamba-org/mamba/issues/412
     # mamba uninstall --force numpy pandas


### PR DESCRIPTION
The `mamba update` reports that there is "nothing to do". So trying something else to get it to install the nightly pyarrow version (we were now using the released pyarrow 3.0 in the upstream build)