### PR TITLE
Fix upstream

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6516,7 +6516,7 @@ def idxmaxmin_row(x, fn=None, skipna=True):
 
 
 def idxmaxmin_combine(x, fn=None, skipna=True):
-    if len(x) == 0:
+    if len(x) <= 1:
         return x
     return (
         x.groupby(level=0)


### PR DESCRIPTION
- [x] Closes #7535
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

Something might have changed in pandas groupby code, but this seems like a good solution for cases where there might be only one partition in a tree reduction. I didn't check to see if there are more cases where this pattern needs updating. 