### PR TITLE
Support read_parquet for data with overlapping partition columns and file columns

### DIFF
--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -180,6 +180,19 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
             paths[0], open_with=fs.open, sep=fs.sep, **kwargs.get("file", {})
         )
 
+    # Ensure that there is no overlap between partition columns
+    # and explicit columns in `pf`
+    if pf.cats:
+        _partitions = [p for p in pf.cats if p not in pf.columns]
+        if not _partitions:
+            pf.cats = {}
+        elif len(_partitions) != len(pf.cats):
+            raise ValueError(
+                "No partition-columns should be written in the \n"
+                "file unless they are ALL written in the file.\n"
+                "columns: {} | partitions: {}".format(pf.columns, pf.cats.keys())
+            )
+
     return parts, pf, gather_statistics, base
 
 


### PR DESCRIPTION
As discussed in #7512, some systems may generate partitioned parquet datasets with the partitioned column also included in the file.  This PR adds support for this situation, as long as **all** partitioned-on columns are included in the file.

Please feel free to raise concerns if there are real use cases where an "all-or-nothing" approach will fail (the alternative is doable, but requires a bit more work).

- [x] Closes #7512
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
