### PR TITLE
make ValueError in len(index_names) > 1 explicit it's using fastparquet

### DIFF
--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -254,7 +254,7 @@ class FastParquetEngine(Engine):
 
         # fastparquet doesn't handle multiindex
         if len(index_names) > 1:
-            raise ValueError("Cannot read DataFrame with MultiIndex.")
+            raise ValueError("fastparquet cannot read DataFrame with MultiIndex.")
 
         for cat in categories:
             if cat in meta:


### PR DESCRIPTION
- [x] Closes #7555 
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
