### PR TITLE
add dask.delayed.Delayed to docs so it can be referenced by other sphinx docs

### DIFF
--- a/docs/source/delayed-api.rst
+++ b/docs/source/delayed-api.rst
@@ -42,5 +42,7 @@ Even with this limitation, many workflows can easily be parallelized.
 
 .. autosummary::
    delayed
+   Delayed
 
 .. autofunction:: delayed
+.. autoclass:: Delayed


### PR DESCRIPTION
- [x] Closes #6465
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
