### PR TITLE
DOC: add defaults in parameters in to_parquet

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -432,45 +432,45 @@ def to_parquet(
     engine : {'auto', 'fastparquet', 'pyarrow'}, default 'auto'
         Parquet library to use. If only one library is installed, it will use
         that one; if both, it will use 'fastparquet'.
-    compression : string or dict, optional
+    compression : string or dict, optional, default 'default'
         Either a string like ``"snappy"`` or a dictionary mapping column names
         to compressors like ``{"name": "gzip", "values": "snappy"}``. The
         default is ``"default"``, which uses the default compression for
         whichever engine is selected.
-    write_index : boolean, optional
+    write_index : boolean, optional, default True
         Whether or not to write the index. Defaults to True.
-    append : bool, optional
+    append : bool, optional, default False
         If False (default), construct data-set from scratch. If True, add new
         row-group(s) to an existing data-set. In the latter case, the data-set
         must exist, and the schema must match the input data.
-    overwrite : bool, optional
+    overwrite : bool, optional, default False
         Whether or not to remove the contents of `path` before writing the dataset.
         The default is False.  If True, the specified path must correspond to
         a directory (but not the current working directory).  This option cannot
         be set to True if `append=True`.
         NOTE: `overwrite=True` will remove the original data even if the current
         write operation fails.  Use at your own risk.
-    ignore_divisions : bool, optional
+    ignore_divisions : bool, optional, default False
         If False (default) raises error when previous divisions overlap with
         the new appended divisions. Ignored if append=False.
-    partition_on : list, optional
+    partition_on : list, optional, default None
         Construct directory-based partitioning by splitting on these fields'
         values. Each dask partition will result in one or more datafiles,
         there will be no global groupby.
-    storage_options : dict, optional
+    storage_options : dict, optional, default None
         Key/value pairs to be passed on to the file-system backend, if any.
-    custom_metadata : dict, optional
+    custom_metadata : dict, optional, default None
         Custom key/value metadata to include in all footer metadata (and
         in the global "_metadata" file, if applicable).  Note that the custom
         metadata may not contain the reserved b"pandas" key.
-    write_metadata_file : bool, optional
+    write_metadata_file : bool, optional, default True
         Whether to write the special "_metadata" file.
     compute : bool, optional
         If True (default) then the result is computed immediately. If False
         then a ``dask.delayed`` object is returned for future computation.
-    compute_kwargs : dict, optional
+    compute_kwargs : dict, optional, default True
         Options to be passed in to the compute method
-    schema : Schema object, dict, or {"infer", None}, optional
+    schema : Schema object, dict, or {"infer", None}, optional, default None
         Global schema to use for the output dataset. Alternatively, a `dict`
         of pyarrow types can be specified (e.g. `schema={"id": pa.string()}`).
         For this case, fields excluded from the dictionary will be inferred

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -432,45 +432,45 @@ def to_parquet(
     engine : {'auto', 'fastparquet', 'pyarrow'}, default 'auto'
         Parquet library to use. If only one library is installed, it will use
         that one; if both, it will use 'fastparquet'.
-    compression : string or dict, optional, default 'default'
+    compression : string or dict, default 'default'
         Either a string like ``"snappy"`` or a dictionary mapping column names
         to compressors like ``{"name": "gzip", "values": "snappy"}``. The
         default is ``"default"``, which uses the default compression for
         whichever engine is selected.
-    write_index : boolean, optional, default True
+    write_index : boolean, default True
         Whether or not to write the index. Defaults to True.
-    append : bool, optional, default False
+    append : bool, default False
         If False (default), construct data-set from scratch. If True, add new
         row-group(s) to an existing data-set. In the latter case, the data-set
         must exist, and the schema must match the input data.
-    overwrite : bool, optional, default False
+    overwrite : bool, default False
         Whether or not to remove the contents of `path` before writing the dataset.
         The default is False.  If True, the specified path must correspond to
         a directory (but not the current working directory).  This option cannot
         be set to True if `append=True`.
         NOTE: `overwrite=True` will remove the original data even if the current
         write operation fails.  Use at your own risk.
-    ignore_divisions : bool, optional, default False
+    ignore_divisions : bool, default False
         If False (default) raises error when previous divisions overlap with
         the new appended divisions. Ignored if append=False.
-    partition_on : list, optional, default None
+    partition_on : list, default None
         Construct directory-based partitioning by splitting on these fields'
         values. Each dask partition will result in one or more datafiles,
         there will be no global groupby.
-    storage_options : dict, optional, default None
+    storage_options : dict, default None
         Key/value pairs to be passed on to the file-system backend, if any.
-    custom_metadata : dict, optional, default None
+    custom_metadata : dict, default None
         Custom key/value metadata to include in all footer metadata (and
         in the global "_metadata" file, if applicable).  Note that the custom
         metadata may not contain the reserved b"pandas" key.
-    write_metadata_file : bool, optional, default True
+    write_metadata_file : bool, default True
         Whether to write the special "_metadata" file.
-    compute : bool, optional
+    compute : bool, default True
         If True (default) then the result is computed immediately. If False
         then a ``dask.delayed`` object is returned for future computation.
-    compute_kwargs : dict, optional, default True
+    compute_kwargs : dict, default True
         Options to be passed in to the compute method
-    schema : Schema object, dict, or {"infer", None}, optional, default None
+    schema : Schema object, dict, or {"infer", None}, default None
         Global schema to use for the output dataset. Alternatively, a `dict`
         of pyarrow types can be specified (e.g. `schema={"id": pa.string()}`).
         For this case, fields excluded from the dictionary will be inferred


### PR DESCRIPTION
I find this helps with legibility in the docs (https://docs.dask.org/en/latest/dataframe-api.html#dask.dataframe.to_parquet). It also matches the pandas docs (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_parquet.html)