### PR TITLE
DOC: Misc fixes for numpydoc.

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -955,6 +955,7 @@ def lol_product(head, values):
     values : sequence
         Mix of singletons and lists. Each list is substituted with every
         possible value and introduces another level of list in the output.
+
     Examples
     --------
 

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -615,19 +615,19 @@ def _get_coord_mapping(
 
     Parameters
     ----------
-    dims: dict
+    dims : dict
         Mapping between each index specified in `argpairs` and
         the number of output blocks for that index. Corresponds
         to the Blockwise `dims` attribute.
-    output: str
+    output : str
         Corresponds to the Blockwise `output` attribute.
-    out_indices: tuple
+    out_indices : tuple
         Corresponds to the Blockwise `output_indices` attribute.
-    numblocks: dict
+    numblocks : dict
         Corresponds to the Blockwise `numblocks` attribute.
-    argpairs: tuple
+    argpairs : tuple
         Corresponds to the Blockwise `indices` attribute.
-    concatenate: bool
+    concatenate : bool
         Corresponds to the Blockwise `concatenate` attribute.
     """
 
@@ -728,7 +728,6 @@ def make_blockwise_graph(
 
     Examples
     --------
-
     Simple embarrassing map operation
 
     >>> inc = lambda x: x + 1
@@ -803,7 +802,6 @@ def make_blockwise_graph(
     >>> make_blockwise_graph(add, 'z', 'i', 'x', 'i', 100, None,  numblocks={'x': (2,)})  # doctest: +SKIP
     {('z', 0): (add, ('x', 0), 100),
      ('z', 1): (add, ('x', 1), 100)}
-
 
     See Also
     --------
@@ -949,7 +947,6 @@ def lol_product(head, values):
 
     Parameters
     ----------
-
     head : tuple
         Prefix prepended to all results.
     values : sequence
@@ -958,7 +955,6 @@ def lol_product(head, values):
 
     Examples
     --------
-
     >>> lol_product(('x',), (1, 2, 3))
     ('x', 1, 2, 3)
     >>> lol_product(('x',), (1, [2, 3], 4, [5, 6]))  # doctest: +NORMALIZE_WHITESPACE
@@ -978,7 +974,6 @@ def lol_tuples(head, ind, values, dummies):
 
     Parameters
     ----------
-
     head : tuple
         The known tuple so far
     ind : Iterable
@@ -990,7 +985,6 @@ def lol_tuples(head, ind, values, dummies):
 
     Examples
     --------
-
     >>> lol_tuples(('x',), 'ij', {'i': 1, 'j': 0}, {})
     ('x', 1, 0)
 
@@ -1024,8 +1018,8 @@ def optimize_blockwise(graph, keys=()):
 
     Parameters
     ----------
-    full_graph: HighLevelGraph
-    keys: Iterable
+    graph : HighLevelGraph
+    keys : Iterable
         The keys of all outputs of all collections.
         Used to make sure that we don't fuse a layer needed by an output
 
@@ -1278,7 +1272,6 @@ def rewrite_blockwise(inputs):
 
 def zero_broadcast_dimensions(lol, nblocks):
     """
-
     >>> lol = [('x', 1, 0), ('x', 1, 1), ('x', 1, 2)]
     >>> nblocks = (4, 1, 2)  # note singleton dimension in second place
     >>> lol = [[('x', 1, 0, 0), ('x', 1, 0, 1)],
@@ -1303,13 +1296,13 @@ def broadcast_dimensions(argpairs, numblocks, sentinels=(1, (1,)), consolidate=N
 
     Parameters
     ----------
-    argpairs: iterable
+    argpairs : iterable
         name, ijk index pairs
-    numblocks: dict
+    numblocks : dict
         maps {name: number of blocks}
-    sentinels: iterable (optional)
+    sentinels : iterable (optional)
         values for singleton dimensions
-    consolidate: func (optional)
+    consolidate : func (optional)
         use this to reduce each set of common blocks into a smaller set
 
     Examples
@@ -1390,9 +1383,9 @@ def fuse_roots(graph: HighLevelGraph, keys: list):
 
     Parameters
     ----------
-    graph: HighLevelGraph
+    graph : HighLevelGraph
         The full graph of the computation
-    keys: list
+    keys : list
         The output keys of the computation, to be passed on to fuse
 
     See Also


### PR DESCRIPTION
2 commits, first one manual to be sure docstrings are properly parsed:

DOC: Blank line for numpydoc parsing
w/o the blankline, numpydoc does not find the Example section

and second then autoreformat and fix issues:

DOC: Reformatting of dask/blockwise to conform to numpydoc.

The space before the `:` are critical for numpydoc to find the types correctly.
Note also that this renames `high_graph` to `graph` which was likely due to a refactor.