### PR TITLE
Fix read_sql_table returning wrong result for single column loads

### DIFF
--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -141,7 +141,7 @@ def read_sql_table(
         q = sql.select(columns).limit(head_rows).select_from(table)
         head = pd.read_sql(q, engine, **kwargs)
 
-        if head.empty:
+        if len(head) == 0:
             # no results at all
             name = table.name
             schema = table.schema
@@ -224,7 +224,7 @@ def _read_sql_chunk(q, uri, meta, engine_kwargs=None, **kwargs):
     engine = sa.create_engine(uri, **engine_kwargs)
     df = pd.read_sql(q, engine, **kwargs)
     engine.dispose()
-    if df.empty:
+    if len(df) == 0:
         return meta
     else:
         return df.astype(meta.dtypes.to_dict(), copy=False)

--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -226,6 +226,10 @@ def _read_sql_chunk(q, uri, meta, engine_kwargs=None, **kwargs):
     engine.dispose()
     if len(df) == 0:
         return meta
+    elif len(meta.dtypes.to_dict()) == 0:
+        # only index column in loaded
+        # required only for pandas < 1.0.0
+        return df
     else:
         return df.astype(meta.dtypes.to_dict(), copy=False)
 

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -59,6 +59,43 @@ def test_empty(db):
         assert pd_dataframe.empty is True
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The default dtype for empty Series " "will be 'object' instead of 'float64'"
+)
+@pytest.mark.parametrize("use_head", [True, False])
+def test_single_column(db, use_head):
+    from sqlalchemy import Column, Integer, MetaData, Table, create_engine
+
+    with tmpfile() as f:
+        uri = "sqlite:///%s" % f
+        metadata = MetaData()
+        engine = create_engine(uri)
+        table = Table(
+            "single_column",
+            metadata,
+            Column("id", Integer, primary_key=True),
+        )
+        metadata.create_all(engine)
+        test_data = pd.DataFrame({"id": list(range(50))}).set_index("id")
+        test_data.to_sql(table.name, uri, index=True, if_exists="replace")
+
+        if use_head:
+            dask_df = read_sql_table(table.name, uri, index_col="id", npartitions=2)
+        else:
+            dask_df = read_sql_table(
+                table.name,
+                uri,
+                head_rows=0,
+                npartitions=2,
+                meta=test_data.iloc[:0],
+                index_col="id",
+            )
+        assert dask_df.index.name == "id"
+        assert dask_df.npartitions == 2
+        pd_dataframe = dask_df.compute()
+        assert_eq(test_data, pd_dataframe)
+
+
 def test_passing_engine_as_uri_raises_helpful_error(db):
     # https://github.com/dask/dask/issues/6473
     from sqlalchemy import create_engine


### PR DESCRIPTION
Pandas .empty returns True if a Dataframe has no columns - no matter of how many rows are in the index. 
This leads to two problems in ``dask.dataframe.io.read_sql_table`` if only a single column is loaded:

1. ``npartitions`` is ignored if ``head_rows`` is not specified - even though there might be tons of data in the index
2. if ``head_rows`` is specified, the wrong result (namely ``meta``) is returned with no data in the index.

This PR resolves both issues and adds a test for them.

- [x] Closes #7539
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
