### PR TITLE
Change heading level of UCX and RMM config reference sections

### DIFF
--- a/docs/source/configuration-reference.rst
+++ b/docs/source/configuration-reference.rst
@@ -83,7 +83,7 @@ Admin
 
 
 UCX
-~~~
+---
 
 .. dask-config-block::
    :location: ucx
@@ -92,7 +92,7 @@ UCX
 
 
 RMM
-~~~
+---
 
 .. dask-config-block::
     :location: rmm


### PR DESCRIPTION
Changes the heading levels of the UCX and RMM config reference sections to be the same as that of the Dask or Distributed sections, to reflect the fact that these are not Distributed-specific configurations. This would also force the config reference page to be rebuilt to reflect the changes of dask/distributed#4683.


- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
