### PR TITLE
Fix tuple as input to ravel_multi_index

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1757,7 +1757,7 @@ def ravel_multi_index(multi_index, dims, mode="raise", order="C"):
     return multi_index.map_blocks(
         _ravel_multi_index_kernel,
         dtype=np.intp,
-        chunks=multi_index.shape[1:],
+        chunks=multi_index.chunks[1:],
         drop_axis=0,
         func_kwargs=dict(dims=dims, mode=mode, order=order),
     )

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1753,10 +1753,11 @@ def _ravel_multi_index_kernel(multi_index, func_kwargs):
 
 @wraps(np.ravel_multi_index)
 def ravel_multi_index(multi_index, dims, mode="raise", order="C"):
+    multi_index = asarray(multi_index)
     return multi_index.map_blocks(
         _ravel_multi_index_kernel,
         dtype=np.intp,
-        chunks=(multi_index.shape[-1],),
+        chunks=multi_index.shape[1:],
         drop_axis=0,
         func_kwargs=dict(dims=dims, mode=mode, order=order),
     )

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1745,6 +1745,25 @@ def test_ravel_multi_index(arr, chunks, kwargs):
     )
 
 
+@pytest.mark.parametrize(
+    "arr, chunks, kwargs",
+    [
+        ([[3, 6, 6], [4, 5, 1]], (2, 3), dict(dims=(7, 7))),
+    ],
+)
+def test_ravel_multi_index_tuple(arr, chunks, kwargs):
+    arr = np.asarray(arr)
+    darr = da.from_array(arr, chunks=chunks)
+    assert_eq(
+        np.ravel_multi_index(arr, **kwargs),
+        da.ravel_multi_index(darr, **kwargs).compute(),
+    )
+    assert_eq(
+        np.ravel_multi_index((arr, arr), **kwargs),
+        da.ravel_multi_index((darr, darr), **kwargs).compute(),
+    )
+
+
 def test_coarsen():
     x = np.random.randint(10, size=(24, 24))
     d = da.from_array(x, chunks=(4, 8))

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1740,8 +1740,8 @@ def test_ravel_multi_index(arr, chunks, kwargs):
     arr = np.asarray(arr)
     darr = da.from_array(arr, chunks=chunks)
     assert_eq(
-        da.ravel_multi_index(darr, **kwargs).compute(),
         np.ravel_multi_index(arr, **kwargs),
+        da.ravel_multi_index(darr, **kwargs),
     )
 
 
@@ -1756,11 +1756,11 @@ def test_ravel_multi_index_tuple(arr, chunks, kwargs):
     darr = da.from_array(arr, chunks=chunks)
     assert_eq(
         np.ravel_multi_index(arr, **kwargs),
-        da.ravel_multi_index(darr, **kwargs).compute(),
+        da.ravel_multi_index(darr, **kwargs),
     )
     assert_eq(
         np.ravel_multi_index((arr, arr), **kwargs),
-        da.ravel_multi_index((darr, darr), **kwargs).compute(),
+        da.ravel_multi_index((darr, darr), **kwargs),
     )
 
 


### PR DESCRIPTION
Make sure to convert to dask array before using map_blocks.
- [x] Closes #7580
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
