### PR TITLE
Fix meta creation incase of `object`

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1564,7 +1564,7 @@ class Bag(DaskMethodsMixin):
         elif columns is not None:
             raise ValueError("Can't specify both `meta` and `columns`")
         else:
-            meta = dd.utils.make_meta(meta)
+            meta = dd.utils.make_meta_util(meta, parent_meta=pd.DataFrame())
         # Serializing the columns and dtypes is much smaller than serializing
         # the empty frame
         cols = list(meta.columns)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -71,7 +71,6 @@ from .utils import (
     is_dataframe_like,
     is_index_like,
     is_series_like,
-    make_meta,
     make_meta_util,
     meta_nonempty,
     raise_on_meta_error,
@@ -119,7 +118,7 @@ class Scalar(DaskMethodsMixin, OperatorMethodMixin):
             dsk = HighLevelGraph.from_collections(name, dsk, dependencies=[])
         self.dask = dsk
         self._name = name
-        self._parent_meta = pd.Series(dtype='float64')
+        self._parent_meta = pd.Series(dtype="float64")
 
         meta = make_meta_util(meta, parent_meta=self._parent_meta)
         if is_dataframe_like(meta) or is_series_like(meta) or is_index_like(meta):
@@ -1886,7 +1885,7 @@ Dask Name: {name}, {task} tasks"""
                 token=name,
                 meta=meta,
                 enforce_metadata=False,
-                parent_meta=self._meta
+                parent_meta=self._meta,
             )
             if isinstance(self, DataFrame):
                 result.divisions = (self.columns.min(), self.columns.max())
@@ -2063,7 +2062,12 @@ Dask Name: {name}, {task} tasks"""
             v = self.var(skipna=skipna, ddof=ddof, split_every=split_every)
             name = self._token_prefix + "std"
             result = map_partitions(
-                np.sqrt, v, meta=meta, token=name, enforce_metadata=False, parent_meta=self._meta
+                np.sqrt,
+                v,
+                meta=meta,
+                token=name,
+                enforce_metadata=False,
+                parent_meta=self._meta,
             )
             return handle_out(out, result)
 
@@ -2302,7 +2306,12 @@ Dask Name: {name}, {task} tasks"""
             n = num.count(split_every=split_every)
             name = self._token_prefix + "sem"
             result = map_partitions(
-                np.sqrt, v / n, meta=meta, token=name, enforce_metadata=False, parent_meta=self._meta
+                np.sqrt,
+                v / n,
+                meta=meta,
+                token=name,
+                enforce_metadata=False,
+                parent_meta=self._meta,
             )
 
             if isinstance(self, DataFrame):
@@ -3361,7 +3370,11 @@ Dask Name: {name}, {task} tasks""".format(
         if meta is no_default:
             meta = _emulate(M.map, self, arg, na_action=na_action, udf=True)
         else:
-            meta = make_meta_util(meta, index=getattr(make_meta_util(self), "index", None), parent_meta=self._meta)
+            meta = make_meta_util(
+                meta,
+                index=getattr(make_meta_util(self), "index", None),
+                parent_meta=self._meta,
+            )
 
         return type(self)(graph, name, meta, self.divisions)
 
@@ -5474,7 +5487,9 @@ def apply_concat_apply(
             aggregate, _concat([meta_chunk], ignore_index), udf=True, **aggregate_kwargs
         )
     meta = make_meta_util(
-        meta, index=(getattr(make_meta_util(dfs[0]), "index", None) if dfs else None), parent_meta=dfs[0]._meta
+        meta,
+        index=(getattr(make_meta_util(dfs[0]), "index", None) if dfs else None),
+        parent_meta=dfs[0]._meta,
     )
 
     graph = HighLevelGraph.from_collections(b, dsk, dependencies=dfs)
@@ -5947,7 +5962,9 @@ def cov_corr(df, min_periods=None, corr=False, scalar=False, split_every=False):
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[df])
     if scalar:
         return Scalar(graph, name, "f8")
-    meta = make_meta_util([(c, "f8") for c in df.columns], index=df.columns, parent_meta=df._meta)
+    meta = make_meta_util(
+        [(c, "f8") for c in df.columns], index=df.columns, parent_meta=df._meta
+    )
     return DataFrame(graph, name, meta, (df.columns[0], df.columns[-1]))
 
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -27,7 +27,7 @@ from .utils import (
     insert_meta_param_description,
     is_dataframe_like,
     is_series_like,
-    make_meta,
+    make_meta_util,
     raise_on_meta_error,
 )
 
@@ -1673,7 +1673,7 @@ class _GroupBy:
             )
             warnings.warn(msg, stacklevel=2)
 
-        meta = make_meta(meta)
+        meta = make_meta_util(meta, parent_meta=self._meta.obj)
 
         # Validate self.index
         if isinstance(self.index, list) and any(
@@ -1762,7 +1762,7 @@ class _GroupBy:
             )
             warnings.warn(msg, stacklevel=2)
 
-        meta = make_meta(meta)
+        meta = make_meta_util(meta, parent_meta=self._meta.obj)
 
         # Validate self.index
         if isinstance(self.index, list) and any(

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -14,7 +14,12 @@ from ...delayed import delayed
 from ...utils import M, ensure_dict
 from ..core import DataFrame, Index, Series, has_parallel_type, new_dd_object
 from ..shuffle import set_partition
-from ..utils import check_meta, insert_meta_param_description, is_series_like, make_meta_util
+from ..utils import (
+    check_meta,
+    insert_meta_param_description,
+    is_series_like,
+    make_meta_util,
+)
 
 lock = Lock()
 
@@ -587,7 +592,7 @@ def from_delayed(
     for df in dfs:
         if not isinstance(df, Delayed):
             raise TypeError("Expected Delayed object, got %s" % type(df).__name__)
-    
+
     parent_meta = delayed(make_meta_util)(dfs[0]).compute()
 
     if meta is None:

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -14,7 +14,7 @@ from ...delayed import delayed
 from ...utils import M, ensure_dict
 from ..core import DataFrame, Index, Series, has_parallel_type, new_dd_object
 from ..shuffle import set_partition
-from ..utils import check_meta, insert_meta_param_description, is_series_like, make_meta
+from ..utils import check_meta, insert_meta_param_description, is_series_like, make_meta_util
 
 lock = Lock()
 
@@ -587,11 +587,13 @@ def from_delayed(
     for df in dfs:
         if not isinstance(df, Delayed):
             raise TypeError("Expected Delayed object, got %s" % type(df).__name__)
+    
+    parent_meta = delayed(make_meta_util)(dfs[0]).compute()
 
     if meta is None:
-        meta = delayed(make_meta)(dfs[0]).compute()
+        meta = parent_meta
     else:
-        meta = make_meta(meta)
+        meta = make_meta_util(meta, parent_meta=parent_meta)
 
     name = prefix + "-" + tokenize(*dfs)
     dsk = merge(df.dask for df in dfs)

--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -7,7 +7,7 @@ from ...base import compute as dask_compute
 from ...bytes import read_bytes
 from ...core import flatten
 from ...delayed import delayed
-from ..utils import insert_meta_param_description, make_meta
+from ..utils import insert_meta_param_description, make_meta_util
 from .io import from_delayed
 
 
@@ -198,7 +198,7 @@ def read_json(
         chunks = list(flatten(chunks))
         if meta is None:
             meta = read_json_chunk(first, encoding, errors, engine, kwargs)
-        meta = make_meta(meta)
+        meta = make_meta_util(meta)
         parts = [
             delayed(read_json_chunk)(chunk, encoding, errors, engine, kwargs, meta=meta)
             for chunk in chunks

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -90,7 +90,7 @@ from .utils import (
     hash_object_dispatch,
     is_dataframe_like,
     is_series_like,
-    make_meta,
+    make_meta_util,
     strip_unknown_categories,
 )
 
@@ -1020,7 +1020,7 @@ def stack_partitions(dfs, divisions, join="outer", ignore_order=False, **kwargs)
 
     kwargs.update({"ignore_order": ignore_order})
 
-    meta = make_meta(
+    meta = make_meta_util(
         methods.concat(
             [df._meta_nonempty for df in dfs],
             join=join,

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -12,7 +12,7 @@ from ..utils import M, derived_from, funcname, has_keyword
 from . import methods
 from ._compat import PANDAS_VERSION
 from .core import _emulate
-from .utils import make_meta
+from .utils import make_meta_util
 
 
 def overlap_chunk(
@@ -103,7 +103,7 @@ def map_overlap(func, df, before, after, *args, **kwargs):
         meta = kwargs.pop("meta")
     else:
         meta = _emulate(func, df, *args, **kwargs)
-    meta = make_meta(meta, index=df._meta.index)
+    meta = make_meta_util(meta, index=df._meta.index, parent_meta=df._meta)
 
     name = "{0}-{1}".format(func_name, token)
     name_a = "overlap-prepend-" + tokenize(df, before)

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -7,7 +7,7 @@ import pytest
 
 import dask.dataframe as dd
 from dask.dataframe._compat import PANDAS_GT_100, PANDAS_GT_120, PANDAS_VERSION
-from dask.dataframe.utils import assert_dask_graph, assert_eq, make_meta
+from dask.dataframe.utils import assert_dask_graph, assert_eq, make_meta_util
 
 try:
     import scipy
@@ -22,7 +22,7 @@ def test_arithmetics():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
     }
-    meta = make_meta({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"))
+    meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
     ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
@@ -688,7 +688,7 @@ def test_reductions(split_every):
             index=[9, 9, 9],
         ),
     }
-    meta = make_meta({"a": "i8", "b": "i8", "c": "bool"}, index=pd.Index([], "i8"))
+    meta = make_meta_util({"a": "i8", "b": "i8", "c": "bool"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
     ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
@@ -966,7 +966,7 @@ def test_reduction_series_invalid_axis():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
     }
-    meta = make_meta({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"))
+    meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
     ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
@@ -1059,7 +1059,7 @@ def test_reductions_frame(split_every):
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
     }
-    meta = make_meta({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"))
+    meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
     ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -22,7 +22,9 @@ def test_arithmetics():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
     }
-    meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
+    meta = make_meta_util(
+        {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
+    )
     ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
@@ -688,7 +690,11 @@ def test_reductions(split_every):
             index=[9, 9, 9],
         ),
     }
-    meta = make_meta_util({"a": "i8", "b": "i8", "c": "bool"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
+    meta = make_meta_util(
+        {"a": "i8", "b": "i8", "c": "bool"},
+        index=pd.Index([], "i8"),
+        parent_meta=pd.DataFrame(),
+    )
     ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
@@ -966,7 +972,9 @@ def test_reduction_series_invalid_axis():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
     }
-    meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
+    meta = make_meta_util(
+        {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
+    )
     ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 
@@ -1059,7 +1067,9 @@ def test_reductions_frame(split_every):
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
     }
-    meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
+    meta = make_meta_util(
+        {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
+    )
     ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
     pdf1 = ddf1.compute()
 

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -13,7 +13,7 @@ from dask.dataframe.utils import (
     assert_eq,
     clear_known_categories,
     is_categorical_dtype,
-    make_meta,
+    make_meta_util,
 )
 
 # Generate a list of categorical series and indices
@@ -120,8 +120,8 @@ def test_unknown_categoricals():
     ddf = dd.DataFrame(
         {("unknown", i): df for (i, df) in enumerate(frames)},
         "unknown",
-        make_meta(
-            {"v": "object", "w": "category", "x": "i8", "y": "category", "z": "f8"}
+        make_meta_util(
+            {"v": "object", "w": "category", "x": "i8", "y": "category", "z": "f8"}, parent_meta=frames[0]
         ),
         [None] * 4,
     )

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -121,7 +121,8 @@ def test_unknown_categoricals():
         {("unknown", i): df for (i, df) in enumerate(frames)},
         "unknown",
         make_meta_util(
-            {"v": "object", "w": "category", "x": "i8", "y": "category", "z": "f8"}, parent_meta=frames[0]
+            {"v": "object", "w": "category", "x": "i8", "y": "category", "z": "f8"},
+            parent_meta=frames[0],
         ),
         [None] * 4,
     )

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -33,7 +33,9 @@ dsk = {
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
 }
-meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
+meta = make_meta_util(
+    {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
+)
 d = dd.DataFrame(dsk, "x", meta, [0, 5, 9, 9])
 full = d.compute()
 CHECK_FREQ = {}

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -25,7 +25,7 @@ from dask.dataframe.core import (
     repartition_divisions,
     total_mem_usage,
 )
-from dask.dataframe.utils import assert_eq, assert_max_deps, make_meta
+from dask.dataframe.utils import assert_eq, assert_max_deps, make_meta_util
 from dask.utils import M, put_lines
 
 dsk = {
@@ -33,7 +33,7 @@ dsk = {
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
 }
-meta = make_meta({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"))
+meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
 d = dd.DataFrame(dsk, "x", meta, [0, 5, 9, 9])
 full = d.compute()
 CHECK_FREQ = {}
@@ -1507,7 +1507,7 @@ def test_unknown_divisions():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}),
     }
-    meta = make_meta({"a": "i8", "b": "i8"})
+    meta = make_meta_util({"a": "i8", "b": "i8"}, parent_meta=pd.DataFrame())
     d = dd.DataFrame(dsk, "x", meta, [None, None, None, None])
     full = d.compute(scheduler="sync")
 
@@ -2264,7 +2264,7 @@ def test_sample_raises():
 
 
 def test_empty_max():
-    meta = make_meta({"x": "i8"})
+    meta = make_meta_util({"x": "i8"}, parent_meta=pd.DataFrame())
     a = dd.DataFrame(
         {("x", 0): pd.DataFrame({"x": [1]}), ("x", 1): pd.DataFrame({"x": []})},
         "x",

--- a/dask/dataframe/tests/test_extensions.py
+++ b/dask/dataframe/tests/test_extensions.py
@@ -46,5 +46,5 @@ def test_reduction():
 
 
 def test_scalar():
-    result = dd.utils.make_meta(Decimal("1.0"))
+    result = dd.utils.make_meta_util(Decimal("1.0"), parent_meta=pd.DataFrame())
     assert result == Decimal("1.0")

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -13,7 +13,9 @@ dsk = {
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
 }
-meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
+meta = make_meta_util(
+    {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
+)
 d = dd.DataFrame(dsk, "x", meta, [0, 5, 9, 9])
 full = d.compute()
 CHECK_FREQ = {}

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -6,14 +6,14 @@ import dask
 import dask.dataframe as dd
 from dask.dataframe._compat import PANDAS_GT_100, PANDAS_GT_110, PANDAS_GT_120, tm
 from dask.dataframe.indexing import _coerce_loc_index
-from dask.dataframe.utils import assert_eq, make_meta
+from dask.dataframe.utils import assert_eq, make_meta_util
 
 dsk = {
     ("x", 0): pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=[0, 1, 3]),
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
 }
-meta = make_meta({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"))
+meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
 d = dd.DataFrame(dsk, "x", meta, [0, 5, 9, 9])
 full = d.compute()
 CHECK_FREQ = {}

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1520,7 +1520,11 @@ def test_concat2():
             {"b": [40, 50, 60], "c": [30, 20, 10], "d": [90, 80, 70]}, index=[3, 4, 5]
         ),
     }
-    meta = make_meta_util({"b": "i8", "c": "i8", "d": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
+    meta = make_meta_util(
+        {"b": "i8", "c": "i8", "d": "i8"},
+        index=pd.Index([], "i8"),
+        parent_meta=pd.DataFrame(),
+    )
     d = dd.DataFrame(dsk, "y", meta, [0, 3, 5])
 
     cases = [[a, b], [a, c], [a, d]]

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -21,7 +21,7 @@ from dask.dataframe.utils import (
     assert_eq,
     clear_known_categories,
     has_known_categories,
-    make_meta,
+    make_meta_util,
 )
 
 
@@ -1496,7 +1496,7 @@ def test_concat2():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}),
     }
-    meta = make_meta({"a": "i8", "b": "i8"})
+    meta = make_meta_util({"a": "i8", "b": "i8"}, parent_meta=pd.DataFrame())
     a = dd.DataFrame(dsk, "x", meta, [None, None])
     dsk = {
         ("y", 0): pd.DataFrame({"a": [10, 20, 30], "b": [40, 50, 60]}),
@@ -1509,7 +1509,7 @@ def test_concat2():
         ("y", 0): pd.DataFrame({"b": [10, 20, 30], "c": [40, 50, 60]}),
         ("y", 1): pd.DataFrame({"b": [40, 50, 60], "c": [30, 20, 10]}),
     }
-    meta = make_meta({"b": "i8", "c": "i8"})
+    meta = make_meta_util({"b": "i8", "c": "i8"}, parent_meta=pd.DataFrame())
     c = dd.DataFrame(dsk, "y", meta, [None, None])
 
     dsk = {
@@ -1520,7 +1520,7 @@ def test_concat2():
             {"b": [40, 50, 60], "c": [30, 20, 10], "d": [90, 80, 70]}, index=[3, 4, 5]
         ),
     }
-    meta = make_meta({"b": "i8", "c": "i8", "d": "i8"}, index=pd.Index([], "i8"))
+    meta = make_meta_util({"b": "i8", "c": "i8", "d": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
     d = dd.DataFrame(dsk, "y", meta, [0, 3, 5])
 
     cases = [[a, b], [a, c], [a, d]]
@@ -1930,7 +1930,7 @@ def test_append2():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}),
     }
-    meta = make_meta({"a": "i8", "b": "i8"})
+    meta = make_meta_util({"a": "i8", "b": "i8"}, parent_meta=pd.DataFrame())
     ddf1 = dd.DataFrame(dsk, "x", meta, [None, None])
 
     dsk = {
@@ -1944,7 +1944,7 @@ def test_append2():
         ("y", 0): pd.DataFrame({"b": [10, 20, 30], "c": [40, 50, 60]}),
         ("y", 1): pd.DataFrame({"b": [40, 50, 60], "c": [30, 20, 10]}),
     }
-    meta = make_meta({"b": "i8", "c": "i8"})
+    meta = make_meta_util({"b": "i8", "c": "i8"}, parent_meta=pd.DataFrame())
     ddf3 = dd.DataFrame(dsk, "y", meta, [None, None])
 
     assert_eq(ddf1.append(ddf2), ddf1.compute().append(ddf2.compute(), sort=False))

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -149,7 +149,9 @@ def test_get_dummies_errors():
     # unknown categories
     df = pd.DataFrame({"x": list("abcbc"), "y": list("bcbcb")})
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf._meta = make_meta_util({"x": "category", "y": "category"}, parent_meta=pd.DataFrame())
+    ddf._meta = make_meta_util(
+        {"x": "category", "y": "category"}, parent_meta=pd.DataFrame()
+    )
 
     with pytest.raises(NotImplementedError):
         dd.get_dummies(ddf)
@@ -257,7 +259,9 @@ def test_pivot_table_errors():
     assert msg in str(err.value)
 
     # unknown categories
-    ddf._meta = make_meta_util({"A": object, "B": float, "C": "category"}, parent_meta=pd.DataFrame())
+    ddf._meta = make_meta_util(
+        {"A": object, "B": float, "C": "category"}, parent_meta=pd.DataFrame()
+    )
     msg = "'columns' must have known categories"
     with pytest.raises(ValueError) as err:
         dd.pivot_table(ddf, index="A", columns="C", values=["B"])

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -4,7 +4,7 @@ import pytest
 
 import dask.dataframe as dd
 from dask.dataframe._compat import tm
-from dask.dataframe.utils import assert_eq, make_meta
+from dask.dataframe.utils import assert_eq, make_meta_util
 
 
 @pytest.mark.parametrize(
@@ -149,7 +149,7 @@ def test_get_dummies_errors():
     # unknown categories
     df = pd.DataFrame({"x": list("abcbc"), "y": list("bcbcb")})
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf._meta = make_meta({"x": "category", "y": "category"})
+    ddf._meta = make_meta_util({"x": "category", "y": "category"}, parent_meta=pd.DataFrame())
 
     with pytest.raises(NotImplementedError):
         dd.get_dummies(ddf)
@@ -257,7 +257,7 @@ def test_pivot_table_errors():
     assert msg in str(err.value)
 
     # unknown categories
-    ddf._meta = make_meta({"A": object, "B": float, "C": "category"})
+    ddf._meta = make_meta_util({"A": object, "B": float, "C": "category"}, parent_meta=pd.DataFrame())
     msg = "'columns' must have known categories"
     with pytest.raises(ValueError) as err:
         dd.pivot_table(ddf, index="A", columns="C", values=["B"])

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -35,7 +35,9 @@ dsk = {
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [2, 5, 8]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [3, 6, 9]}, index=[9, 9, 9]),
 }
-meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
+meta = make_meta_util(
+    {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
+)
 d = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
 full = d.compute()
 CHECK_FREQ = {}

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -27,7 +27,7 @@ from dask.dataframe.shuffle import (
     remove_nans,
     shuffle,
 )
-from dask.dataframe.utils import assert_eq, make_meta
+from dask.dataframe.utils import assert_eq, make_meta_util
 from dask.optimization import cull
 
 dsk = {
@@ -35,7 +35,7 @@ dsk = {
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [2, 5, 8]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [3, 6, 9]}, index=[9, 9, 9]),
 }
-meta = make_meta({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"))
+meta = make_meta_util({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
 d = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
 full = d.compute()
 CHECK_FREQ = {}

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -68,7 +68,9 @@ def test_make_meta():
     assert isinstance(meta.index, pd.RangeIndex)
 
     # Iterable
-    meta = make_meta_util([("a", "i8"), ("c", "f8"), ("b", "O")], parent_meta=pd.DataFrame())
+    meta = make_meta_util(
+        [("a", "i8"), ("c", "f8"), ("b", "O")], parent_meta=pd.DataFrame()
+    )
     assert (meta.columns == ["a", "c", "b"]).all()
     assert len(meta) == 0
     assert (meta.dtypes == df.dtypes[meta.dtypes.index]).all()
@@ -82,10 +84,16 @@ def test_make_meta():
     assert meta.name == "a"
 
     # With index
-    meta = make_meta_util({"a": "i8", "b": "i4"}, index=pd.Int64Index([1, 2], name="foo"), parent_meta=pd.DataFrame())
+    meta = make_meta_util(
+        {"a": "i8", "b": "i4"},
+        index=pd.Int64Index([1, 2], name="foo"),
+        parent_meta=pd.DataFrame(),
+    )
     assert isinstance(meta.index, pd.Int64Index)
     assert len(meta.index) == 0
-    meta = make_meta_util(("a", "i8"), index=pd.Int64Index([1, 2], name="foo"), parent_meta=pd.DataFrame())
+    meta = make_meta_util(
+        ("a", "i8"), index=pd.Int64Index([1, 2], name="foo"), parent_meta=pd.DataFrame()
+    )
     assert isinstance(meta.index, pd.Int64Index)
     assert len(meta.index) == 0
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -16,7 +16,7 @@ from dask.dataframe.utils import (
     is_dataframe_like,
     is_index_like,
     is_series_like,
-    make_meta,
+    make_meta_util,
     meta_nonempty,
     raise_on_meta_error,
     shard_df_on_index,
@@ -40,84 +40,84 @@ def test_make_meta():
     )
 
     # Pandas dataframe
-    meta = make_meta(df)
+    meta = make_meta_util(df)
     assert len(meta) == 0
     assert (meta.dtypes == df.dtypes).all()
     assert isinstance(meta.index, type(df.index))
 
     # Pandas series
-    meta = make_meta(df.a)
+    meta = make_meta_util(df.a)
     assert len(meta) == 0
     assert meta.dtype == df.a.dtype
     assert isinstance(meta.index, type(df.index))
 
     # Pandas index
-    meta = make_meta(df.index)
+    meta = make_meta_util(df.index)
     assert isinstance(meta, type(df.index))
     assert len(meta) == 0
 
     # Dask object
     ddf = dd.from_pandas(df, npartitions=2)
-    assert make_meta(ddf) is ddf._meta
+    assert make_meta_util(ddf) is ddf._meta
 
     # Dict
-    meta = make_meta({"a": "i8", "b": "O", "c": "f8"})
+    meta = make_meta_util({"a": "i8", "b": "O", "c": "f8"}, parent_meta=pd.DataFrame())
     assert isinstance(meta, pd.DataFrame)
     assert len(meta) == 0
     assert (meta.dtypes == df.dtypes).all()
     assert isinstance(meta.index, pd.RangeIndex)
 
     # Iterable
-    meta = make_meta([("a", "i8"), ("c", "f8"), ("b", "O")])
+    meta = make_meta_util([("a", "i8"), ("c", "f8"), ("b", "O")], parent_meta=pd.DataFrame())
     assert (meta.columns == ["a", "c", "b"]).all()
     assert len(meta) == 0
     assert (meta.dtypes == df.dtypes[meta.dtypes.index]).all()
     assert isinstance(meta.index, pd.RangeIndex)
 
     # Tuple
-    meta = make_meta(("a", "i8"))
+    meta = make_meta_util(("a", "i8"), parent_meta=pd.DataFrame())
     assert isinstance(meta, pd.Series)
     assert len(meta) == 0
     assert meta.dtype == "i8"
     assert meta.name == "a"
 
     # With index
-    meta = make_meta({"a": "i8", "b": "i4"}, index=pd.Int64Index([1, 2], name="foo"))
+    meta = make_meta_util({"a": "i8", "b": "i4"}, index=pd.Int64Index([1, 2], name="foo"), parent_meta=pd.DataFrame())
     assert isinstance(meta.index, pd.Int64Index)
     assert len(meta.index) == 0
-    meta = make_meta(("a", "i8"), index=pd.Int64Index([1, 2], name="foo"))
+    meta = make_meta_util(("a", "i8"), index=pd.Int64Index([1, 2], name="foo"), parent_meta=pd.DataFrame())
     assert isinstance(meta.index, pd.Int64Index)
     assert len(meta.index) == 0
 
     # Categoricals
-    meta = make_meta({"a": "category"})
+    meta = make_meta_util({"a": "category"}, parent_meta=df)
     assert len(meta.a.cat.categories) == 1
     assert meta.a.cat.categories[0] == UNKNOWN_CATEGORIES
-    meta = make_meta(("a", "category"))
+    meta = make_meta_util(("a", "category"), parent_meta=df)
     assert len(meta.cat.categories) == 1
     assert meta.cat.categories[0] == UNKNOWN_CATEGORIES
 
     # Numpy scalar
-    meta = make_meta(np.float64(1.0))
+    meta = make_meta_util(np.float64(1.0), parent_meta=df)
     assert isinstance(meta, np.float64)
 
     # Python scalar
-    meta = make_meta(1.0)
+    meta = make_meta_util(1.0, parent_meta=df)
     assert isinstance(meta, np.float64)
 
     # Timestamp
     x = pd.Timestamp(2000, 1, 1)
-    meta = make_meta(x)
+    meta = make_meta_util(x, parent_meta=df)
     assert meta is x
 
     # Dtype expressions
-    meta = make_meta("i8")
+    meta = make_meta_util("i8", parent_meta=df)
     assert isinstance(meta, np.int64)
-    meta = make_meta(float)
+    meta = make_meta_util(float, parent_meta=df)
     assert isinstance(meta, np.dtype(float).type)
-    meta = make_meta(np.dtype("bool"))
+    meta = make_meta_util(np.dtype("bool"), parent_meta=df)
     assert isinstance(meta, np.bool_)
-    assert pytest.raises(TypeError, lambda: make_meta(None))
+    assert pytest.raises(TypeError, lambda: make_meta_util(None))
 
 
 def test_meta_nonempty():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -288,6 +288,7 @@ def _empty_series(name, dtype, index=None):
 make_meta = Dispatch("make_meta")
 make_meta_obj = Dispatch("make_meta_obj")
 
+
 @make_meta.register((pd.Series, pd.DataFrame))
 def make_meta_pandas(x, index=None):
     return x.iloc[:0]
@@ -298,7 +299,9 @@ def make_meta_index(x, index=None):
     return x[0:0]
 
 
-@make_meta_obj.register((pd.Series, pd.DataFrame, pd.Index, pd.MultiIndex, sp.csr.csr_matrix))
+@make_meta_obj.register(
+    (pd.Series, pd.DataFrame, pd.Index, pd.MultiIndex, sp.csr.csr_matrix)
+)
 def make_meta_object(x, index=None):
     """Create an empty pandas object containing the desired metadata.
 
@@ -366,8 +369,10 @@ def make_meta_object(x, index=None):
 
     raise TypeError("Don't know how to create metadata from {0}".format(x))
 
+
 def make_meta_util(x, index=None, parent_meta=None):
     import dask.dataframe as dd
+
     if isinstance(x, (dd.core.Series, dd.core.DataFrame)):
         return x._meta
     if hasattr(x, "_meta"):
@@ -382,6 +387,7 @@ def make_meta_util(x, index=None, parent_meta=None):
         else:
             func = make_meta_obj.dispatch(type(x))
             return func(x, index=index)
+
 
 _numeric_index_types = (pd.Int64Index, pd.Float64Index, pd.UInt64Index)
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -285,7 +285,7 @@ def _empty_series(name, dtype, index=None):
 
 
 make_meta = Dispatch("make_meta")
-
+make_meta_obj = Dispatch("make_meta_obj")
 
 @make_meta.register((pd.Series, pd.DataFrame))
 def make_meta_pandas(x, index=None):
@@ -297,7 +297,7 @@ def make_meta_index(x, index=None):
     return x[0:0]
 
 
-@make_meta.register(object)
+@make_meta_obj.register((pd.Series, pd.DataFrame, pd.Index, pd.MultiIndex, np.int64))
 def make_meta_object(x, index=None):
     """Create an empty pandas object containing the desired metadata.
 
@@ -365,6 +365,19 @@ def make_meta_object(x, index=None):
 
     raise TypeError("Don't know how to create metadata from {0}".format(x))
 
+def make_meta_util(x, index=None, parent_meta=None):
+    import dask.dataframe as dd
+    if isinstance(x, (dd.core.Series, dd.core.DataFrame)):
+        return x._meta
+
+    if parent_meta is None:
+        return make_meta(x, index=index)
+    else:
+        if hasattr(x, "_meta"):
+            return x._meta
+        # import pdb;pdb.set_trace()
+        func = make_meta_obj.dispatch(type(parent_meta))
+        return func(x, index=index)
 
 _numeric_index_types = (pd.Int64Index, pd.Float64Index, pd.UInt64Index)
 


### PR DESCRIPTION
There is an issue https://github.com/rapidsai/cudf/issues/7946, where the metadata creations ends up being something that is purely based on the order of importing a backend instead of the correct backend itself. 

So the root cause to the above issue is that we have `make_meta` dispatch registered both in [dask](https://github.com/dask/dask/blob/main/dask/dataframe/utils.py#L300) and [dask-cudf](https://github.com/rapidsai/cudf/blob/branch-0.20/python/dask_cudf/dask_cudf/backends.py#L136), against the same type `object`, wherein the Dispatch class will end up storing the function of the last/most-recently registered dispatch only(since its a simple dict). In this PR I have made a new utility function by the name `make_meta_util`, and a new dispatch that is responsible for object meta creation but is registered against object of a specific backend, this way we can guarantee the correct metadata is being generated and in-turn the right backend APIs are invoked.

One additional thing we would have to do to facilitate this change is that we would have to pass in `parent_meta` instead of `meta` as we would want to know the real API back-end which we would want to invoke, because some pandas APIs return numpy objects which are then stored as `meta` and will not be really helpful for us to determine which back-end to hit, but when we store/pass `parent_meta` to this utility that will help us to determine correctly the backend that is needed and accordingly dispatched.
cc: @jakirkham @quasiben @rjzamora @beckernick @kkraus14 
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
