### PR TITLE
Add more packages to Python 3.9 CI build

### DIFF
--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -14,8 +14,7 @@ dependencies:
   - pytest-xdist
   - moto
   - flask
-  # Not available for Python 3.9 on conda-forge yet
-  # - fastparquet
+  - fastparquet
   - h5py
   - pytables
   - zarr
@@ -46,8 +45,7 @@ dependencies:
   - graphviz
   - ipython
   - lz4
-  # Not available for Python 3.9 on conda-forge yet
-  # - numba
+  - numba
   - partd
   - psutil
   - requests
@@ -56,8 +54,7 @@ dependencies:
   - scipy
   - toolz
   - python-snappy
-  # Depends on numba
-  # - sparse
+  - sparse
   - cachey
   - python-graphviz
   - pandas-datareader


### PR DESCRIPTION
These have Python 3.9 builds on `conda-forge` now 