### PR TITLE
Add loky example

### DIFF
--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -199,7 +199,9 @@ specify the desired number of workers:
        x.compute()
 
 The scheduler accepts any ``concurrent.futures.Executer`` instance as well as any other 
-subclass from a third party library, such as ``loky``. For example:
+subclass from a third party library, such as loky_. For example:
+
+.. _loky: https://github.com/joblib/loky
 
 .. code-block:: python
 

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -193,7 +193,7 @@ or specify the desired number of workers:
 
    from concurrent.futures import ThreadPoolExecutor
    with dask.config.set(pool=ThreadPoolExecutor(4)):
-       ...
+       x.compute()
 
    with dask.config.set(num_workers=4):
-       ...
+       x.compute()

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -198,7 +198,7 @@ specify the desired number of workers:
    with dask.config.set(num_workers=4):
        x.compute()
 
-The scheduler accepts any ``concurrent.futures.Executer`` instance as well as any other 
+The scheduler accepts any ``concurrent.futures.Executor`` instance as well as any other 
 subclass from a third party library, such as loky_. For example:
 
 .. _loky: https://github.com/joblib/loky

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -185,9 +185,9 @@ or within a single compute call:
 
    x.compute(scheduler='threads')
 
-Additionally some of the scheduler support other keyword arguments.
-For example, the pool-based single-machine scheduler allows you to provide custom pools
-or specify the desired number of workers:
+Each scheduler may support extra keywords specific to that scheduler. For example,
+the pool-based single-machine scheduler allows you to provide custom pools or
+specify the desired number of workers:
 
 .. code-block:: python
 
@@ -197,3 +197,13 @@ or specify the desired number of workers:
 
    with dask.config.set(num_workers=4):
        x.compute()
+
+The scheduler accepts any ``concurrent.futures.Executer`` instance as well as any other 
+subclass from a third party library, such as ``loky``. For example:
+
+.. code-block:: python
+
+   from loky import get_reusable_executor
+   with dask.config.set(pool=get_reusable_executor(max_workers=4)):
+       x.compute()
+


### PR DESCRIPTION
This PR adds  an example showing that the scheduler can use an arbitrary executor such as the `get_reusable_executor()` from `loky`. 

- [ x ] Closes #7511
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
