### PR TITLE
Using tmp_path and tmpdir to avoid temporary files and directories hanging in the repo

### DIFF
--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1122,7 +1122,7 @@ def test_to_delayed_optimize_graph(tmpdir):
     assert dict(d2.dask) == dict(x.dask)
     assert d.compute() == d2.compute()
 
-    [d] = b2.to_textfiles(tmpdir, compute=False)
+    [d] = b2.to_textfiles(str(tmpdir), compute=False)
     text = str(dict(d.dask))
     assert text.count("reify") <= 0
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1103,7 +1103,7 @@ def test_to_delayed():
     assert t.compute() == 21
 
 
-def test_to_delayed_optimize_graph():
+def test_to_delayed_optimize_graph(tmpdir):
     b = db.from_sequence([1, 2, 3, 4, 5, 6], npartitions=1)
     b2 = b.map(inc).map(inc).map(inc)
 
@@ -1122,7 +1122,7 @@ def test_to_delayed_optimize_graph():
     assert dict(d2.dask) == dict(x.dask)
     assert d.compute() == d2.compute()
 
-    [d] = b2.to_textfiles("foo.txt", compute=False)
+    [d] = b2.to_textfiles(tmpdir, compute=False)
     text = str(dict(d.dask))
     assert text.count("reify") <= 0
 

--- a/dask/bag/tests/test_text.py
+++ b/dask/bag/tests/test_text.py
@@ -85,9 +85,9 @@ def test_read_text(fmt, bs, encoding, include_path):
         assert "".join(line for block in L for line in block) == expected
 
 
-def test_read_text_unicode_no_collection():
+def test_read_text_unicode_no_collection(tmp_path):
     data = b"abcd\xc3\xa9"
-    fn = "./data.txt"
+    fn = tmp_path / "data.txt"
     with open(fn, "wb") as f:
         f.write(b"\n".join([data, data]))
 


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

After running `py.test dask  --doctest-modules` a file name `data.txt` and a directory named `foo.txt` get created and they should not live after finishing the tests since they are temporary created for the particular tests. This PR modifies the specific tests to use `tmp_path` and `tmpdir` to handle this problem. 