### PR TITLE
Delayed: nout when arguments become tasks

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -435,11 +435,9 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
         task = quote(obj)
         collections = set()
 
+    if not (nout is None or (type(nout) is int and nout >= 0)):
+        raise ValueError("nout must be None or a non-negative integer, got %s" % nout)
     if task is obj:
-        if not (nout is None or (type(nout) is int and nout >= 0)):
-            raise ValueError(
-                "nout must be None or a non-negative integer, got %s" % nout
-            )
         if not name:
             try:
                 prefix = obj.__name__
@@ -453,7 +451,7 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
             name = "%s-%s" % (type(obj).__name__, tokenize(task, pure=pure))
         layer = {name: task}
         graph = HighLevelGraph.from_collections(name, layer, dependencies=collections)
-        return Delayed(name, graph)
+        return Delayed(name, graph, nout)
 
 
 def right(method):

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -395,6 +395,17 @@ def test_nout():
     assert x.compute() == tuple()
 
 
+@pytest.mark.parametrize(
+    "x",
+    [[1, 2], (1, 2), (add, 1, 2), [], ()],
+)
+def test_nout_with_tasks(x):
+    length = len(x)
+    d = delayed(x, nout=length)
+    assert len(d) == len(list(d)) == length
+    assert d.compute() == x
+
+
 def test_kwargs():
     def mysum(a, b, c=(), **kwargs):
         return a + b + sum(c) + sum(kwargs.values())


### PR DESCRIPTION
`nout` was ignored when the arguments either contained dask collections, or had to be quoted.

Previously:
```python
>>> import dask
>>> d = dask.delayed([1, 2], nout=2)
>>> list(d)
TypeError: Delayed objects of unspecified length are not iterable
>>> d = dask.delayed([1, 2], nout=2, traverse=False)
>>> list(d)
TypeError: Delayed objects of unspecified length are not iterable
```

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
