### PR TITLE
Update `distributed` version in `mindep` CI build

### DIFF
--- a/continuous_integration/environment-mindeps-distributed.yaml
+++ b/continuous_integration/environment-mindeps-distributed.yaml
@@ -10,10 +10,7 @@ dependencies:
   - fsspec=0.6.0
   - toolz=0.8.2
   # optional dependencies pulled in by pip install dask[distributed]
-  # TODO: Use distributed-2021.04.1 when it becomes available
-  - pip
-  - pip:
-    - git+https://github.com/dask/distributed.git
+  - distributed=2021.04.1
   # test dependencies
   - pytest
   - pytest-rerunfailures


### PR DESCRIPTION
`distributed=2021.04.1` will be on `conda-forge` soon, just pushing this up early so it'll be ready 