### PR TITLE
Remove `ignore_abc_warning` after merge

### DIFF
--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -307,7 +307,6 @@ def test_cache_profiler_plot():
 
 
 @pytest.mark.skipif("not bokeh")
-@ignore_abc_warning
 def test_cache_profiler_plot_with_invalid_bokeh_kwarg_raises_error():
     with CacheProfiler(metric_name="non-standard") as cprof:
         get(dsk, "e")


### PR DESCRIPTION
:facepalm: I merged two separate PRs each touching the same file and missed removing one `ignore_abc_warning`