### PR TITLE
add pyarrow sphinx intersphinx_mapping

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -253,6 +253,7 @@ def read_parquet(
     See Also
     --------
     to_parquet
+    pyarrow.parquet.ParquetDataset
     """
 
     if isinstance(columns, str):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -313,7 +313,7 @@ intersphinx_mapping = {
         "https://asyncssh.readthedocs.io/en/latest/",
         "https://asyncssh.readthedocs.io/en/latest/objects.inv",
     ),
-    "pyarrow": ("https://arrow.apache.org/docs/python/", None),
+    "pyarrow": ("https://arrow.apache.org/docs/", None),
 }
 
 # Redirects

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -313,6 +313,7 @@ intersphinx_mapping = {
         "https://asyncssh.readthedocs.io/en/latest/",
         "https://asyncssh.readthedocs.io/en/latest/objects.inv",
     ),
+    "pyarrow": ("https://arrow.apache.org/docs/python/", None),
 }
 
 # Redirects


### PR DESCRIPTION
I'm and hoping to add a link to https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html#pyarrow.parquet.ParquetDataset
in the See Also of https://docs.dask.org/en/latest/dataframe-api.html#dask.dataframe.read_parquet

My motivation is the pyarrow page has good docs and example of the filters argument. For example, I was looking for an example of how to use `in` with the filters arg today.

This will also make it easier for people to navigate to that page and update the read_parquet dask docs .

I'm just unsure on how to link as the page is different to packages i've linked before https://github.com/xarray-contrib/xskillscore/blob/main/docs/source/conf.py#L113

I believe the dask docs also requests a .inv in the intersphinx_mapping which is something i'm not familiar with.

If anyone has time would appreciate some help here cc. @jorisvandenbossche 

Current the doc build gives

```
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://arrow.apache.org/docs/python/objects.inv' not fetchable due to <class 'requests.exceptions.HTTPError'>: 404 Client Error: Not Found for url: https://arrow.apache.org/docs/python/objects.inv
```

It's places the link in the right place (see below) it's just not clickable.

![Screenshot from 2021-04-27 12-43-21](https://user-images.githubusercontent.com/17162724/116279990-3ac5ce00-a756-11eb-8c2a-2ccd4638ffe0.png)
 