### PR TITLE
Fix bugs in broadcast-join packing and culling

### DIFF
--- a/dask/dataframe/tests/test_merge_column_and_index.py
+++ b/dask/dataframe/tests/test_merge_column_and_index.py
@@ -210,6 +210,9 @@ def test_merge_known_to_double_bcast_left(
     assert_eq(result.divisions, ddf_right.divisions)
     assert len(result.__dask_graph__()) < 90
 
+    # Check that culling works
+    result.head(1)
+
 
 @pytest.mark.parametrize("repartition", [None, 4])
 def test_merge_column_with_nulls(repartition):

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -637,7 +637,7 @@ class BroadcastJoinLayer(Layer):
     def __len__(self):
         return len(self._dict)
 
-    def __dask_distributed_pack__(self, client):
+    def __dask_distributed_pack__(self, *args, **kwargs):
         import pickle
 
         # Pickle complex merge_kwargs elements. Also
@@ -744,9 +744,9 @@ class BroadcastJoinLayer(Layer):
             self.lhs_npartitions,
             self.rhs_name,
             self.rhs_npartitions,
-            self.merge_kwargs,
             annotations=self.annotations,
             parts_out=parts_out,
+            **self.merge_kwargs,
         )
 
     def cull(self, keys, all_keys):

--- a/dask/tests/test_layers.py
+++ b/dask/tests/test_layers.py
@@ -41,7 +41,7 @@ def _dataframe_shuffle():
 
     # Perform a computation using an HLG-based shuffle
     df = pd.DataFrame({"a": range(10), "b": range(10, 20)})
-    return dd.from_pandas(df, npartitions=2)
+    return dd.from_pandas(df, npartitions=2).shuffle("a", shuffle="tasks")
 
 
 def _dataframe_broadcast_join():
@@ -52,7 +52,7 @@ def _dataframe_broadcast_join():
     df = pd.DataFrame({"a": range(10), "b": range(10, 20)})
     ddf1 = dd.from_pandas(df, npartitions=4)
     ddf2 = dd.from_pandas(df, npartitions=1)
-    return ddf1.merge(ddf2, how="left", broadcast=True)
+    return ddf1.merge(ddf2, how="left", broadcast=True, shuffle="tasks")
 
 
 def _array_creation():


### PR DESCRIPTION
While doing some HLG benchmarking,  I discovered some bugs in the broadcast-join packing and culling behavior.  This PR includes some simple fixes and tweaks in test coverage.
