### PR TITLE
Don't ignore `index` argument in `make_meta_object` for scalar `x`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5562,8 +5562,12 @@ def map_partitions(
     args = _maybe_from_pandas(args)
     args = _maybe_align_partitions(args)
     dfs = [df for df in args if isinstance(df, _Frame)]
-    meta_index = getattr(make_meta(dfs[0]), "index", None) if dfs else None
-
+    # func might return a different index.
+    meta_index = (
+        getattr(_emulate(func, *args, udf=True, **kwargs), "index", None)
+        if dfs
+        else None
+    )
     if meta is no_default:
         # Use non-normalized kwargs here, as we want the real values (not
         # delayed values)
@@ -5663,7 +5667,6 @@ def map_partitions(
                     name=f"{subgraph.name}-info-{tokenize(info)}",
                 ),
             ) + v[1:]
-
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=dependencies)
     return new_dd_object(graph, name, meta, divisions)
 


### PR DESCRIPTION
See https://github.com/dask/dask/issues/7610#issuecomment-829111539.

- [x] Closes #7610
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
