### PR TITLE
Change the active-fusion default to False for Dask-Dataframe

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -46,7 +46,9 @@ def optimize(
     dsk = fuse_roots(dsk, keys=keys)
     dsk = dsk.cull(set(keys))
 
-    if not config.get("optimization.fuse.active"):
+    # Perform low-level fusion unless the user has
+    # specified False explicitly.
+    if config.get("optimization.fuse.active") is False:
         return dsk
 
     dependencies = dsk.get_all_dependencies()

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -58,7 +58,12 @@ properties:
 
           active:
             type: [boolean, 'null']
-            description: Turn task fusion on/off
+            description: |
+              Turn task fusion on/off. This setting only applies to a
+              fully-materialized task graph (not to a high-Level graph). By default
+              (None), the active task fusion option will be treated as ``False`` for
+              Dask-Dataframe collections, and as ``True`` for all other graphs
+              (including Dask-Array collections).
 
           ave-width:
             type: number

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -63,9 +63,7 @@ properties:
               fully-materialized task graph (not a high-Level graph). By default
               (None), the active task-fusion option will be treated as ``False``
               for Dask-Dataframe collections, and as ``True`` for all other graphs
-              (including Dask-Array collections). The only exception to the Dask-
-              Dataframe default is when the input graph is already materialized.
-              The default will be treated as ``True`` in this case.
+              (including Dask-Array collections).
 
           ave-width:
             type: number

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -59,11 +59,13 @@ properties:
           active:
             type: [boolean, 'null']
             description: |
-              Turn task fusion on/off. This setting only applies to a
-              fully-materialized task graph (not to a high-Level graph). By default
-              (None), the active task fusion option will be treated as ``False`` for
-              Dask-Dataframe collections, and as ``True`` for all other graphs
-              (including Dask-Array collections).
+              Turn task fusion on/off. This option refers to the fusion of a
+              fully-materialized task graph (not a high-Level graph). By default
+              (None), the active task-fusion option will be treated as ``False``
+              for Dask-Dataframe collections, and as ``True`` for all other graphs
+              (including Dask-Array collections). The only exception to the Dask-
+              Dataframe default is when the input graph is already materialized.
+              The default will be treated as ``True`` in this case.
 
           ave-width:
             type: number

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -57,7 +57,7 @@ properties:
         properties:
 
           active:
-            type: boolean
+            type: [boolean, 'null']
             description: Turn task fusion on/off
 
           ave-width:

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -11,7 +11,7 @@ array:
 
 optimization:
   fuse:
-    active: true
+    active: null  # Treat as false for dask.dataframe, true for everything else
     ave-width: 1
     max-width: null  # 1.5 + ave_width * log(ave_width + 1)
     max-height: .inf

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -18,21 +18,16 @@ def optimize(dsk, keys, **kwargs):
     fuse_active = config.get("optimization.fuse.active")
     if not isinstance(dsk, HighLevelGraph):
         dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
-        dsk = dsk.cull(set(keys))
-        if not fuse_active:
-            # TODO: Figure out why the key_dependencies cause
-            # a problem when active fusion is disabled.
-            dsk.key_dependencies = {}
     else:
+        # Perform Blockwise optimizations for HLG input
         dsk = optimize_dataframe_getitem(dsk, keys=keys)
         dsk = optimize_blockwise(dsk, keys=keys)
         dsk = fuse_roots(dsk, keys=keys)
-        dsk = dsk.cull(set(keys))
+    dsk = dsk.cull(set(keys))
 
     # Do not perform low-level fusion unless the user has
-    # specified True explicitly, or if the input to this
-    # `optimize` function was a materialized graph. The
-    # configuration will be None by default.
+    # specified True explicitly. The configuration will
+    # be None by default.
     if not fuse_active:
         return dsk
 

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -23,6 +23,9 @@ def optimize(dsk, keys, **kwargs):
     dsk = fuse_roots(dsk, keys=keys)
     dsk = dsk.cull(set(keys))
 
+    # Do not perform low-level fusion unless the user has
+    # specified True explicitly. The configuration will be
+    # None by default.
     if not config.get("optimization.fuse.active"):
         return dsk
 

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -15,7 +15,6 @@ def optimize(dsk, keys, **kwargs):
         keys = [keys]
     keys = list(core.flatten(keys))
 
-    fuse_active = config.get("optimization.fuse.active")
     if not isinstance(dsk, HighLevelGraph):
         dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
     else:
@@ -28,7 +27,7 @@ def optimize(dsk, keys, **kwargs):
     # Do not perform low-level fusion unless the user has
     # specified True explicitly. The configuration will
     # be None by default.
-    if not fuse_active:
+    if not config.get("optimization.fuse.active"):
         return dsk
 
     dependencies = dsk.get_all_dependencies()

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -19,13 +19,11 @@ def optimize(dsk, keys, **kwargs):
     if not isinstance(dsk, HighLevelGraph):
         dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
         if fuse_active is None:
-            # Input graph is materialized.
-            # Set fuse.active default to True.
             fuse_active = True
-
-    dsk = optimize_dataframe_getitem(dsk, keys=keys)
-    dsk = optimize_blockwise(dsk, keys=keys)
-    dsk = fuse_roots(dsk, keys=keys)
+    else:
+        dsk = optimize_dataframe_getitem(dsk, keys=keys)
+        dsk = optimize_blockwise(dsk, keys=keys)
+        dsk = fuse_roots(dsk, keys=keys)
     dsk = dsk.cull(set(keys))
 
     # Do not perform low-level fusion unless the user has

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -469,7 +469,7 @@ def test_describe_empty():
         df_none.describe(), ddf_none.describe(percentiles_method="dask").compute()
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, RuntimeWarning)):
         ddf_len0.describe(percentiles_method="dask").compute()
 
     with pytest.raises(ValueError):

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -404,6 +404,7 @@ class Layer(collections.abc.Mapping):
         }
         for k, v in unpacked_futures_deps.items():
             dependencies[k] = set(dependencies.get(k, ())) | v
+        dependencies.update(known_key_dependencies)
 
         # The scheduler expect all keys to be strings
         dependencies = {

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -494,7 +494,10 @@ def fuse(
         dict mapping dependencies after fusion.  Useful side effect to accelerate other
         downstream optimizations.
     """
-    if not config.get("optimization.fuse.active"):
+
+    # Perform low-level fusion unless the user has
+    # specified False explicitly.
+    if config.get("optimization.fuse.active") is False:
         return dsk, dependencies
 
     if keys is not None and not isinstance(keys, set):

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -286,7 +286,7 @@ async def test_annotations_blockwise_unpack(c, s, a, b):
         "full",
     ],
 )
-@pytest.mark.parametrize("fuse", [True, False])
+@pytest.mark.parametrize("fuse", [True, False, None])
 def test_blockwise_array_creation(c, io, fuse):
     np = pytest.importorskip("numpy")
     da = pytest.importorskip("dask.array")
@@ -308,6 +308,9 @@ def test_blockwise_array_creation(c, io, fuse):
     narr += 2
     with dask.config.set({"optimization.fuse.active": fuse}):
         darr.compute()
+        dsk = dask.array.optimize(darr.dask, darr.__dask_keys__())
+        # dsk should be a dict unless fuse is explicitly False
+        assert isinstance(dsk, dict) == (fuse is not False)
         da.assert_eq(darr, narr)
 
 
@@ -319,7 +322,7 @@ def test_blockwise_array_creation(c, io, fuse):
         "csv",
     ],
 )
-@pytest.mark.parametrize("fuse", [True, False])
+@pytest.mark.parametrize("fuse", [True, False, None])
 def test_blockwise_dataframe_io(c, tmpdir, io, fuse):
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
@@ -344,6 +347,9 @@ def test_blockwise_dataframe_io(c, tmpdir, io, fuse):
     ddf = ddf[["x"]] + 10
     with dask.config.set({"optimization.fuse.active": fuse}):
         ddf.compute()
+        dsk = dask.dataframe.optimize(ddf.dask, ddf.__dask_keys__())
+        # dsk should not be a dict unless fuse is explicitly True
+        assert isinstance(dsk, dict) == bool(fuse)
         dd.assert_eq(ddf, df, check_index=False)
 
 


### PR DESCRIPTION
Now that #7415 is merged, low-level fusion is unnecessary for most Dask-Dataframe workflows (parquet, csv, and orc leverage Blockwise fusion, and other IO mechanisms are on their way to Blockwise).  This PR changes the configuration default to be `None` for `"optimization.fuse.active"`. In `dask.dataframe.optimize`, a `None` configuration setting will be treated as `False`, while everywhere else the `None` setting will be treated as `True`.

To clarify: This PR should only change fusion behavior for Dask-Dataframe.
