### PR TITLE
ENH: Add meta support for DatetimeTZDtype

### DIFF
--- a/dask/dataframe/_dtypes.py
+++ b/dask/dataframe/_dtypes.py
@@ -3,6 +3,17 @@ import pandas as pd
 from ._compat import PANDAS_GT_100
 from .extensions import make_array_nonempty, make_scalar
 
+
+@make_array_nonempty.register(pd.DatetimeTZDtype)
+def _dtype(dtype):
+    return pd.array([pd.Timestamp(1), pd.NaT], dtype=dtype)
+
+
+@make_scalar.register(pd.DatetimeTZDtype)
+def _(x):
+    return pd.Timestamp(1, tz=x.tz, unit=x.unit)
+
+
 if PANDAS_GT_100:
 
     @make_array_nonempty.register(pd.StringDtype)

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -76,6 +76,12 @@ except ImportError:
     pass
 
 
+@meta_nonempty.register(pd.DatetimeTZDtype)
+@make_meta_dispatch.register(pd.DatetimeTZDtype)
+def make_meta_pandas_datetime_tz(x, index=None):
+    return _nonempty_scalar(x)
+
+
 @make_meta_obj.register(meta_object_types)
 def make_meta_object(x, index=None):
     """Create an empty pandas object containing the desired metadata.

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -113,6 +113,11 @@ def test_make_meta():
     meta = make_meta(x, parent_meta=df)
     assert meta is x
 
+    # DatetimeTZDtype
+    x = pd.DatetimeTZDtype(tz="UTC")
+    meta = make_meta(x)
+    assert meta == pd.Timestamp(1, tz=x.tz, unit=x.unit)
+
     # Dtype expressions
     meta = make_meta("i8", parent_meta=df)
     assert isinstance(meta, np.int64)
@@ -284,6 +289,11 @@ def test_meta_nonempty_scalar():
     x = pd.Timestamp(2000, 1, 1)
     meta = meta_nonempty(x)
     assert meta is x
+
+    # DatetimeTZDtype
+    x = pd.DatetimeTZDtype(tz="UTC")
+    meta = meta_nonempty(x)
+    assert meta == pd.Timestamp(1, tz=x.tz, unit=x.unit)
 
 
 def test_raise_on_meta_error():


### PR DESCRIPTION
Add support for [pandas.DatetimeTZDtype](https://pandas.pydata.org/docs/reference/api/pandas.DatetimeTZDtype.html) in `make_meta`. `DatetimeTZDtype` is a pandas duck type but is a valid dtype in the pandas world. 

Note:

- I added this where I thought it made sense, but happy to put it more with the numpy code. 
- I used `isinstance(x, pd.DatetimeTZDtype)` instead of `is_datetime64tz_dtype` because the latter will report true on array-like objects as well. 
- `_datetimetzdtype_scalar` returns a `pd.Timestamp` with the appropriate unit/tz, which would be the value in an array of this dtype, (I believe) matching the numpy behavior. 


- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask` / `isort dask`
