### PR TITLE
Move DataFrame from_array and from_pandas to Blockwise

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -64,10 +64,6 @@ class BlockwiseDep:
             "Must define `__getitem__` for `BlockwiseDep` subclass."
         )
 
-    def __len__(self):
-        """BlockwiseDep object length"""
-        return product(*self.numblocks)
-
     def get(self, idx: Tuple[int, ...], default) -> Any:
         """BlockwiseDep ``__getitem__`` Wrapper"""
         try:

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -259,10 +259,6 @@ class BlockwiseDepFrames(BlockwiseDepDict):
 
     def project_columns(self, columns):
 
-        import pdb
-
-        pdb.set_trace()
-
         # Make sure column selection is a list
         if isinstance(columns, (tuple, set)):
             columns = list(columns)
@@ -275,10 +271,9 @@ class BlockwiseDepFrames(BlockwiseDepDict):
         try:
             if sorted(next(iter(self.mapping.values())).columns) == sorted(columns):
                 return self
-        except AttributeError:
+            return BlockwiseDepFrames({k: v[columns] for k, v in self.mapping.items()})
+        except (AttributeError, KeyError):
             return self
-
-        return BlockwiseDepFrames({k: v[columns] for k, v in self.mapping.items()})
 
 
 def subs(task, substitution):

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -196,24 +196,15 @@ class BlockwiseDepFrameDict(BlockwiseDepDict):
 
     This is a special case of ``BlockwiseDepDict`` in
     which each element of ``mapping`` is a frame-like
-    object (e.g. ``pandas.DataFrame``/``Series``). The
-    primary purpose of this class is to provide formal
-    ``from_frame`` and ``project_columns`` methods.
+    object (e.g. ``pandas.DataFrame``/``Series``).
+    The primary purpose of this class is to provide a
+    formal ``project_columns`` method.
 
     See Also
     --------
     dask.blockwise.Blockwise
     dask.blockwise.BlockwiseDepDict
     """
-
-    @classmethod
-    def from_frame(cls, data, locations):
-        return cls(
-            mapping={
-                (i,): data.iloc[start:stop]
-                for i, (start, stop) in enumerate(zip(locations[:-1], locations[1:]))
-            }
-        )
 
     def project_columns(self, columns):
 

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -957,12 +957,12 @@ class DataFrameIOLayer(Blockwise, DataFrameLayer):
             common_kwargs=common_inputs,
         )
 
-        # # Try projecting columns in `io_arg_map`
-        # if columns and (from_framelike or from_arraylike):
-        #     try:
-        #         io_arg_map = io_arg_map.project_columns(columns)
-        #     except AttributeError:
-        #         pass
+        # Try projecting columns in `io_arg_map`
+        if columns and (from_framelike or from_arraylike):
+            try:
+                io_arg_map = io_arg_map.project_columns(columns)
+            except AttributeError:
+                pass
 
         # Use Blockwise initializer
         dsk = {self.name: (io_func, blockwise_token(0))}


### PR DESCRIPTION
Continuation of Blockwise + IO work in #7415 (being tracked in #6791)

Changes:

- Add `BlockwiseDepColumnar` class (inherits from `BlockwiseDepDict`)
    - Purpose is to provide a `project_columns` mothod on the `BlockwiseDep` object itself (rather than relying entirely on the io-function).
- Add `common_kwargs` argument to `BlockwiseDepDict` (dictionary of common arguments to be merged with every element of the `mapping` attribute (lazily, when `__getitem__` is called)
- Move `DataFrame.from_array` to `Blockwise`
    - Add `eager_slice` kwarg to `from_array` to enable more control over whether to slice on the client or on the worker.
- Move `DataFrame.form_pandas` to `Blockwise`
