### PR TITLE
Improvements to histogramdd (for handling inputs that are sequences-of-arrays).

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1164,7 +1164,7 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
     >>> h.compute()
     array([[[0., 2.],
             [0., 1.]],
-
+    <BLANKLINE>
            [[1., 0.],
             [2., 0.]]])
     >>> edges[0].compute()

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1152,12 +1152,27 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
 
     Using a sequence of 1D arrays as the input:
 
-    >>> x = da.random.uniform(0, 1, size=(1000,), chunks=(200,))
-    >>> y = da.random.uniform(0, 1, size=(1000,), chunks=(200,))
-    >>> z = da.random.uniform(0, 1, size=(1000,), chunks=(200,))
-    >>> bins = (6,) * 3
-    >>> range = ((0, 1),) * 3
-    >>> h, edges = da.histogramdd((x, y, z), bins=bins, range=range)
+    >>> x = da.array([2, 4, 2, 4, 2, 4])
+    >>> y = da.array([2, 2, 4, 4, 2, 4])
+    >>> z = da.array([4, 2, 4, 2, 4, 2])
+    >>> bins = ([0, 3, 6],) * 3
+    >>> h, edges = da.histogramdd((x, y, z), bins)
+    >>> h
+    dask.array<sum-aggregate, shape=(2, 2, 2), dtype=float64, chunksize=(2, 2, 2), chunktype=numpy.ndarray>
+    >>> edges[0]
+    dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), chunktype=numpy.ndarray>
+    >>> h.compute()
+    array([[[0., 2.],
+            [0., 1.]],
+
+           [[1., 0.],
+            [2., 0.]]])
+    >>> edges[0].compute()
+    array([0, 3, 6])
+    >>> edges[1].compute()
+    array([0, 3, 6])
+    >>> edges[2].compute()
+    array([0, 3, 6])
 
     """
     # logic used in numpy.histogramdd to handle normed/density.

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1206,9 +1206,7 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
     # D == total number of dimensions
     if hasattr(sample, "shape"):
         if len(sample.shape) != 2:
-            raise ValueError(
-                "Single array input to histogramdd should be columnar"
-            )
+            raise ValueError("Single array input to histogramdd should be columnar")
         else:
             _, D = sample.shape
         n_chunks = sample.numblocks[0]

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1262,7 +1262,7 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
         if not all(len(r) == 2 for r in range):
             raise ValueError("range argument should be a sequence of pairs")
 
-    # If bins is a single int, clone it D times.
+    # If bins is a single int, create a tuple of len `D` containing `bins`.
     if isinstance(bins, int):
         bins = (bins,) * D
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1221,7 +1221,7 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
         D = len(sample)
         n_chunks = sample[0].numblocks[0]
         for i in _range(1, D):
-            if sample[i].chunksize != sample[0].chunksize:
+            if sample[i].chunks != sample[0].chunks:
                 raise ValueError("All coordinate arrays must be chunked identically.")
     else:
         raise ValueError(

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1189,7 +1189,6 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
     elif isinstance(sample, (tuple, list)):
         rectangular_sample = False
         D = len(sample)
-        N = sample[0].shape[0]
         n_chunks = sample[0].numblocks[0]
         for i in _range(1, D):
             if sample[i].chunksize != sample[0].chunksize:

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1025,10 +1025,10 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
     compatible with this function. If weights are used, they must be
     chunked along the 0th axis identically to the input sample.
 
-    A proper example setup for a three dimensional histogram, where
-    the sample shape is ``(8, 3)`` and weights are shape ``(8,)``,
-    sample chunks would be ``((4, 4), (3,))`` and the weights chunks
-    would be ``((4, 4),)`` a table of the structure:
+    An example setup for a three dimensional histogram, where the
+    sample shape is ``(8, 3)`` and weights are shape ``(8,)``, sample
+    chunks would be ``((4, 4), (3,))`` and the weights chunks would be
+    ``((4, 4),)`` a table of the structure:
 
     +-------+-----------------------+-----------+
     |       |      sample (8 x 3)   |  weights  |
@@ -1064,6 +1064,10 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
     from ``dask.dataframe``, i.e. :class:`dask.dataframe.Series` or
     :class:`dask.dataframe.DataFrame`.
 
+    The function is also compatible with `x`, `y`, and `z` being
+    individual 1D arrays with equal chunking. In that case, the data
+    should be passed as a tuple: ``histogramdd((x, y, z), ...)``
+
     Parameters
     ----------
     sample : dask.array.Array (N, D) or sequence of dask.array.Array
@@ -1075,9 +1079,7 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
         * When a (N, D) dask Array, each row is an entry in the sample
           (coordinate in D dimensional space).
         * When a sequence of dask Arrays, each element in the sequence
-          is the array of values for a single coordinate. This type of
-          input will be automatically rechunked along the column axis
-          if necessary. This may induce a runtime increase.
+          is the array of values for a single coordinate.
     bins : sequence of arrays describing bin edges, int, or sequence of ints
         The bin specification.
 
@@ -1148,8 +1150,16 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
     >>> np.isclose(h.sum().compute(), w.sum().compute())
     True
 
-    """
+    Using a sequence of 1D arrays as the input:
 
+    >>> x = da.random.uniform(0, 1, size=(1000,), chunks=(200,))
+    >>> y = da.random.uniform(0, 1, size=(1000,), chunks=(200,))
+    >>> z = da.random.uniform(0, 1, size=(1000,), chunks=(200,))
+    >>> bins = (6,) * 3
+    >>> range = ((0, 1),) * 3
+    >>> h, edges = da.histogramdd((x, y, z), bins=bins, range=range)
+
+    """
     # logic used in numpy.histogramdd to handle normed/density.
     if normed is None:
         if density is None:

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -945,11 +945,11 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
         }
         dtype = np.histogram([])[0].dtype
     else:
-        sample_keys = flatten(a.__dask_keys__())
+        a_keys = flatten(a.__dask_keys__())
         w_keys = flatten(weights.__dask_keys__())
         dsk = {
             (name, i, 0): (_block_hist, k, bins_ref, range_ref, w)
-            for i, (k, w) in enumerate(zip(sample_keys, w_keys))
+            for i, (k, w) in enumerate(zip(a_keys, w_keys))
         }
         dtype = weights.dtype
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1205,7 +1205,12 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
     # N == total number of samples
     # D == total number of dimensions
     if hasattr(sample, "shape"):
-        N, D = sample.shape
+        if len(sample.shape) != 2:
+            raise ValueError(
+                "Single array input to histogramdd should be columnar"
+            )
+        else:
+            _, D = sample.shape
         n_chunks = sample.numblocks[0]
         rectangular_sample = True
         # Require data to be chunked along the first axis only.

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1021,8 +1021,6 @@ def test_histogramdd_raise_incompat_shape():
         da.histogramdd(data, bins=4, range=((-3, 3),))
 
 
-
-
 def test_histogramdd_edges():
     data = da.random.random(size=(10, 3), chunks=(5, 3))
     edges = [

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -850,6 +850,7 @@ def test_histogramdd():
     assert a1.sum() == n1
     assert a2.sum() == n1
     assert same_keys(da.histogramdd(x, bins=bins)[0], a1)
+    assert a1.compute().shape == a3.shape
 
 
 def test_histogramdd_seq_of_arrays():
@@ -860,7 +861,9 @@ def test_histogramdd_seq_of_arrays():
     by = [0.0, 0.30, 0.70, 0.8, 1.0]
     (a1, b1) = da.histogramdd([x, y], bins=[bx, by])
     (a2, b2) = np.histogramdd([x, y], bins=[bx, by])
+    (a3, b3) = np.histogramdd((x.compute(), y.compute()), bins=[bx, by])
     assert_eq(a1, a2)
+    assert_eq(a1, a3)
 
 
 def test_histogramdd_alternative_bins_range():
@@ -871,7 +874,9 @@ def test_histogramdd_alternative_bins_range():
     ranges = ((0, 1),) * len(bins)
     (a1, b1) = da.histogramdd(x, bins=bins, range=ranges)
     (a2, b2) = np.histogramdd(x, bins=bins, range=ranges)
+    (a3, b3) = np.histogramdd(x.compute(), bins=bins, range=ranges)
     assert_eq(a1, a2)
+    assert_eq(a1, a3)
     bins = 4
     (a1, b1) = da.histogramdd(x, bins=bins, range=ranges)
     (a2, b2) = np.histogramdd(x, bins=bins, range=ranges)
@@ -891,22 +896,13 @@ def test_histogramdd_weighted():
     ranges = ((0, 1),) * len(bins)
     (a1, b1) = da.histogramdd(x, bins=bins, range=ranges, weights=w)
     (a2, b2) = np.histogramdd(x, bins=bins, range=ranges, weights=w)
+    (a3, b3) = np.histogramdd(x.compute(), bins=bins, range=ranges, weights=w.compute())
     assert_eq(a1, a2)
+    assert_eq(a1, a3)
     bins = 4
     (a1, b1) = da.histogramdd(x, bins=bins, range=ranges, weights=w)
     (a2, b2) = np.histogramdd(x, bins=bins, range=ranges, weights=w)
-    assert_eq(a1, a2)
-
-
-def test_histogramdd_trigger_rechunk():
-    n = 600
-    x = da.random.uniform(0, 1, size=(n,), chunks=200)
-    y = da.random.uniform(0, 1, size=(n,), chunks=200)
-    bins = (6, 7)
-    ranges = ((0, 1),) * len(bins)
-    (a1, b1) = da.histogramdd([x, y], bins=bins, range=ranges)
-    (a2, b2) = np.histogramdd([x, y], bins=bins, range=ranges)
-    (a3, b3) = np.histogramdd([x.compute(), y.compute()], bins=bins, range=ranges)
+    (a3, b3) = np.histogramdd(x.compute(), bins=bins, range=ranges, weights=w.compute())
     assert_eq(a1, a2)
     assert_eq(a1, a3)
 
@@ -918,8 +914,10 @@ def test_histogramdd_density():
     (a1, b1) = da.histogramdd(x, bins=bins, density=True)
     (a2, b2) = np.histogramdd(x, bins=bins, density=True)
     (a3, b3) = da.histogramdd(x, bins=bins, normed=True)
+    (a4, b4) = np.histogramdd(x.compute(), bins=bins, density=True)
     assert_eq(a1, a2)
     assert_eq(a1, a3)
+    assert_eq(a1, a4)
     assert same_keys(da.histogramdd(x, bins=bins, density=True)[0], a1)
 
 
@@ -936,12 +934,39 @@ def test_histogramdd_weighted_density():
     assert_eq(a1, a3)
 
 
-def test_histogramdd_raises_incompat_sample_chuks():
+def test_histogramdd_raises_incompat_sample_chunks():
     data = da.random.random(size=(10, 3), chunks=(5, 1))
     with pytest.raises(
         ValueError, match="Input array can only be chunked along the 0th axis"
     ):
         da.histogramdd(data, bins=10, range=((0, 1),) * 3)
+
+
+def test_histogramdd_raises_incompat_multiarg_chunks():
+    x = da.random.random(size=(10,), chunks=2)
+    y = da.random.random(size=(10,), chunks=2)
+    z = da.random.random(size=(10,), chunks=5)
+    with pytest.raises(
+        ValueError, match="All coordinate arrays must be chunked identically."
+    ):
+        da.histogramdd((x, y, z), bins=(3,) * 3, range=((0, 1),) * 3)
+
+
+def test_histogramdd_raises_incompat_weight_chunks():
+    x = da.random.random(size=(10,), chunks=2)
+    y = da.random.random(size=(10,), chunks=2)
+    z = da.atleast_2d((x, y)).T.rechunk((2, 2))
+    w = da.random.random(size=(10,), chunks=5)
+    with pytest.raises(
+        ValueError,
+        match="Input arrays and weights must have the same shape and chunk structure.",
+    ):
+        da.histogramdd((x, y), bins=(3,) * 2, range=((0, 1),) * 2, weights=w)
+    with pytest.raises(
+        ValueError,
+        match="Input array and weights must have the same shape and chunk structure along the first dimension.",
+    ):
+        da.histogramdd(z, bins=(3,) * 2, range=((0, 1),) * 2, weights=w)
 
 
 def test_histogramdd_raises_incompat_bins_or_range():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1006,6 +1006,23 @@ def test_histogramdd_raise_normed_and_density():
         da.histogramdd(data, bins=bins, range=ranges, normed=True, density=True)
 
 
+def test_histogramdd_raise_incompat_shape():
+    # 1D
+    data = da.random.random(size=(10,), chunks=(2,))
+    with pytest.raises(
+        ValueError, match="Single array input to histogramdd should be columnar"
+    ):
+        da.histogramdd(data, bins=4, range=((-3, 3),))
+    # 3D (not columnar)
+    data = da.random.random(size=(4, 4, 4), chunks=(2, 2, 2))
+    with pytest.raises(
+        ValueError, match="Single array input to histogramdd should be columnar"
+    ):
+        da.histogramdd(data, bins=4, range=((-3, 3),))
+
+
+
+
 def test_histogramdd_edges():
     data = da.random.random(size=(10, 3), chunks=(5, 3))
     edges = [


### PR DESCRIPTION
- [x] ~~Closes #xxxx~~
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

This PR improves `dask.array.histogramdd` such that multi-sequence input does not have to be stacked, transposed, and potentially rechunked.

The original implementation of `histogramdd` was focused on columnar/rectangular input, with each column of the input array representing one coordinate of the input to be histogrammed. If the input was a sequence of 1D arrays then we stacked the 1D arrays and transposed that stack to convert to the 2D/rectangular/columnar format we were mainly supporting. This stacking/fusing and transposing is an unnecessary step.

The rectangular input implementation is still there, but now we handle the sequence-of-1D inputs without converting to a 2D array. This optimization is important for supporting `numpy.histogram2d` as `dask.array.histogram2d` (subsequent PR).

Along with supporting sequence-of-1D input, this PR also does some general cleanup.