### PR TITLE
Use pytest tmpdir for files generated by tests

### DIFF
--- a/dask/bag/tests/test_text.py
+++ b/dask/bag/tests/test_text.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -85,9 +86,9 @@ def test_read_text(fmt, bs, encoding, include_path):
         assert "".join(line for block in L for line in block) == expected
 
 
-def test_read_text_unicode_no_collection(tmp_path):
+def test_read_text_unicode_no_collection(tmpdir):
     data = b"abcd\xc3\xa9"
-    fn = tmp_path / "data.txt"
+    fn = os.path.join(tmpdir, "data.txt")
     with open(fn, "wb") as f:
         f.write(b"\n".join([data, data]))
 


### PR DESCRIPTION
I kept noticing this `data.txt` file appearing when I'd use `git status`. Turns out it keeps getting created by a test in dask bag, which wasn't using a pytest tmpdir fixture. This PR should make tidier.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
