### PR TITLE
Bag: add implementation for reservoir sampling (#7068)

### DIFF
--- a/dask/bag/random.py
+++ b/dask/bag/random.py
@@ -2,6 +2,7 @@ import heapq
 import math
 import random as rnd
 from functools import partial
+from itertools import islice
 
 from .core import Bag
 
@@ -28,7 +29,7 @@ def sample(population, k):
     ... list(random.sample(b, 3).compute())
     [1, 3, 5]
     """
-    return _sample(population=population, k=k, replace=False)
+    return _reservoir_sample(population=population, k=k)
 
 
 def choices(population, k=1):
@@ -51,7 +52,7 @@ def choices(population, k=1):
     ... list(random.choices(b, 3).compute())
     [1, 1, 5]
     """
-    return _sample(population=population, k=k, replace=True)
+    return _reservoir_sample_with_replacement(population=population, k=k)
 
 
 def _sample(population, k, replace=False):
@@ -133,3 +134,76 @@ def _weighted_sampling_without_replacement(population, weights, k):
     """
     elt = [(math.log(rnd.random()) / weights[i], i) for i in range(len(weights))]
     return [population[x[1]] for x in heapq.nlargest(k, elt)]
+
+
+def _reservoir_sample(population, k):
+    return population.reduction(
+        partial(_reservoir_sample_map_partitions, k=k),
+        partial(_sample_reduce, k=k, replace=False),
+        out_type=Bag,
+    )
+
+
+def _reservoir_sample_map_partitions(population, k):
+    """
+    Reservoir sampling strategy based on the L algorithm
+    See https://en.wikipedia.org/wiki/Reservoir_sampling#An_optimal_algorithm
+    """
+
+    reservoir, stream_length = [], 0
+    stream = iter(population)
+    for e in islice(stream, k):
+        reservoir.append(e)
+        stream_length += 1
+
+    w = math.exp(math.log(rnd.random()) / k)
+    nxt = (k - 1) + _geometric(w)
+
+    for i, e in enumerate(stream, k):
+        if i == nxt:
+            reservoir[rnd.randrange(k)] = e
+            w *= math.exp(math.log(rnd.random()) / k)
+            nxt += _geometric(w)
+        stream_length += 1
+
+    return reservoir, stream_length
+
+
+def _reservoir_sample_with_replacement(population, k):
+    return population.reduction(
+        partial(_reservoir_sample_with_replacement_map_partitions, k=k),
+        partial(_sample_reduce, k=k, replace=True),
+        out_type=Bag,
+    )
+
+
+def _reservoir_sample_with_replacement_map_partitions(population, k):
+    """
+    Reservoir sampling with replacement, the main idea is to use k reservoirs of size 1
+    See Section Applications in http://utopia.duth.gr/~pefraimi/research/data/2007EncOfAlg.pdf
+    """
+
+    stream = iter(population)
+    e = next(stream)
+    reservoir, stream_length = [e for _ in range(k)], 1
+
+    w = [rnd.random() for _ in range(k)]
+    nxt = [_geometric(wi) for wi in w]
+    min_nxt = min(nxt)
+
+    for i, e in enumerate(stream, 1):
+        if i == min_nxt:
+            for j, n in enumerate(nxt):
+                if n == min_nxt:
+                    reservoir[j] = e
+                    w[j] *= rnd.random()
+                    nxt[j] += _geometric(w[j])
+            min_nxt = min(nxt)
+
+        stream_length += 1
+
+    return reservoir, stream_length
+
+
+def _geometric(p):
+    return int(math.log(rnd.uniform(0, 1)) / math.log(1 - p)) + 1

--- a/dask/bag/tests/test_random.py
+++ b/dask/bag/tests/test_random.py
@@ -136,7 +136,7 @@ def test_reservoir_sample_map_partitions_correctness():
     expected_distribution = [0 for _ in range(N)]
     reps = 2000
     for _ in range(reps):
-        picks, _ = random._reservoir_sample_map_partitions(seq, k)
+        picks, _ = random._sample_map_partitions(seq, k)
         for pick in picks:
             distribution[pick] += 1
         for pick in rnd.sample(seq, k=k):
@@ -159,7 +159,7 @@ def test_reservoir_sample_with_replacement_map_partitions_correctness():
     expected_distribution = [0 for _ in range(N)]
     reps = 2000
     for _ in range(reps):
-        picks, _ = random._reservoir_sample_with_replacement_map_partitions(seq, k)
+        picks, _ = random._sample_with_replacement_map_partitions(seq, k)
         for pick in picks:
             distribution[pick] += 1
         for pick in rnd.choices(seq, k=k):


### PR DESCRIPTION
- Closes #7068.
   -  Implement the [L algorithm](https://en.wikipedia.org/wiki/Reservoir_sampling#An_optimal_algorithm) for reservoir sampling without replacement. 
   - Use the **k** reservoir of size 1 strategy for sampling with replacement (see [reference](http://utopia.duth.gr/~pefraimi/research/data/2007EncOfAlg.pdf)) of **k** items
- Tests added / passed. Including those for verifying the correctness of the algorithm implementation
- Passes `black dask` / `flake8 dask` / `isort dask`
