### PR TITLE
Fix bug in Dataframe column projection

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -103,10 +103,10 @@ class CSVFunctionWrapper:
         columns = self.full_columns
         project_after_read = False
         if self.columns is not None:
-            if rest_kwargs.get("parse_dates", None):
-                # If `parse_dates` is defined, avoid changing
-                # `usecols` here. Instead, we can just select
-                # columns after the read
+            if self.kwargs:
+                # To be safe, if any kwargs are defined, avoid
+                # changing `usecols` here. Instead, we can just
+                # select columns after the read
                 project_after_read = True
             else:
                 columns = self.columns

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -55,7 +55,7 @@ class CSVFunctionWrapper:
         kwargs,
     ):
         self.full_columns = full_columns
-        self.columns = columns  # Used to pass `usecols`
+        self.columns = columns
         self.colname = colname
         self.head = head
         self.header = header
@@ -110,6 +110,8 @@ class CSVFunctionWrapper:
             path_info,
         )
         if self.columns is not None:
+            # TODO: Use `usecols` in case the backend
+            # has column-selection optimizations
             return df[self.columns]
         return df
 

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -86,18 +86,15 @@ class MakeTimeseriesPart:
             return self
         func = copy.deepcopy(self)
         func.columns = columns
+        func.dtypes = {c: self.dtypes[c] for c in columns}
         return func
 
     def __call__(self, part):
         divisions, state_data = part
         if isinstance(state_data, int):
             state_data = random_state_data(1, state_data)
-        if self.columns:
-            dtypes = {k: v for k, v in self.dtypes.items() if k in self.columns}
-        else:
-            dtypes = self.dtypes
         return make_timeseries_part(
-            divisions[0], divisions[1], dtypes, self.freq, state_data, self.kwargs
+            divisions[0], divisions[1], self.dtypes, self.freq, state_data, self.kwargs
         )
 
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -510,8 +510,11 @@ def test_read_csv_skiprows_range():
 def test_usecols():
     with filetext(timeseries) as fn:
         df = dd.read_csv(fn, blocksize=30, usecols=["High", "Low"])
+        df_select = df[["High"]]
         expected = pd.read_csv(fn, usecols=["High", "Low"])
+        expected_select = expected[["High"]]
         assert (df.compute().values == expected.values).all()
+        assert (df_select.compute().values == expected_select.values).all()
 
 
 def test_string_blocksize():

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2456,6 +2456,7 @@ def test_getitem_optimization(tmpdir, engine, preserve_index, index):
     subgraph = dsk.layers[read]
     assert isinstance(subgraph, DataFrameIOLayer)
     assert subgraph.columns == ["B"]
+    assert next(iter((subgraph.dsk.values())))[0].columns == ["B"]
 
     assert_eq(ddf.compute(optimize_graph=False), ddf.compute())
 

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -937,18 +937,21 @@ class DataFrameIOLayer(Blockwise, DataFrameLayer):
     def project_columns(self, columns):
         # Method inherited from `DataFrameLayer.project_columns`
         if columns and (self.columns is None or columns < set(self.columns)):
+
+            # Apply column projection in IO function
+            try:
+                io_func = self.io_func.project_columns(list(columns))
+            except AttributeError:
+                io_func = self.io_func
+
             layer = DataFrameIOLayer(
                 (self.label or "subset-") + tokenize(self.name, columns),
                 list(columns),
                 self.inputs,
-                self.io_func,
+                io_func,
                 produces_tasks=self.produces_tasks,
                 annotations=self.annotations,
             )
-            try:
-                layer.io_func = layer.io_func.project_columns(columns)
-            except AttributeError:
-                pass
             return layer, None
         else:
             # Default behavior


### PR DESCRIPTION
The `DataFrameIOLayer.project_columns` definition is currently updating the `io_func` attribute **after** it has already been used to construct the underlying `Blockwise.dsk` (my mistake!).  This PR moves the column projection in `io_func` to occur **before** the new `DataFrameIOLayer` layer is initialized.
