### PR TITLE
Fix delayed with dataclasses where init=False

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -109,7 +109,11 @@ def unpack_collections(expr):
 
     if is_dataclass(expr):
         args, collections = unpack_collections(
-            [[f.name, getattr(expr, f.name)] for f in fields(expr)]
+            [
+                [f.name, getattr(expr, f.name)]
+                for f in fields(expr)
+                if hasattr(expr, f.name)
+            ]
         )
 
         return (apply, typ, (), (dict, args)), collections

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -100,7 +100,9 @@ def test_delayed_with_dataclass():
     dataclasses = pytest.importorskip("dataclasses")
 
     # Avoid @dataclass decorator as Python < 3.7 fail to interpret the type hints
-    ADataClass = dataclasses.make_dataclass("ADataClass", [("a", int)])
+    ADataClass = dataclasses.make_dataclass(
+        "ADataClass", [("a", int), ("b", int, dataclasses.field(init=False))]
+    )
 
     literal = dask.delayed(3)
     with_class = dask.delayed({"a": ADataClass(a=literal)})


### PR DESCRIPTION
- [x] Closes #7654
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`


