### PR TITLE
Improve dask stack performance

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -580,10 +580,10 @@ class HighLevelGraph(Mapping):
         self.dependencies = dependencies
         self.key_dependencies = key_dependencies or {}
         # Makes sure that all layers are `Layer`
-        self.layers = {
-            k: v if isinstance(v, Layer) else MaterializedLayer(v)
-            for k, v in layers.items()
-        }
+        for k, v in layers.items():
+            if not isinstance(v, Layer):
+                layers[k] = MaterializedLayer(v)
+        self.layers = layers
 
     @classmethod
     def _from_collection(cls, name, layer, collection):


### PR DESCRIPTION
This PR attempts to improve the performance of stacked arrays, by NOT copying all the keys & values from the dictionary, and instead modifies those values in place to materialize non-layer values.

Famous last words, but I think all the tests pass? I've got to run, or I'm going to be late. We'll see how it is when I come back.

- [x] Closes https://github.com/dask/dask/issues/5913
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
