### PR TITLE
Doc `ipyparallel` & `mpi4py` `concurrent.futures`

### DIFF
--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -208,3 +208,9 @@ reusable ``ProcessPoolExecutor`` from loky_:
    from loky import get_reusable_executor
    with dask.config.set(pool=get_reusable_executor(max_workers=4)):
        x.compute()
+
+Other libraries like ipyparallel_ and mpi4py_ also supply
+``concurrent.futures.Executor`` subclasses that could be used as well.
+
+.. _ipyparallel: https://ipyparallel.readthedocs.io/en/latest/api/ipyparallel.html#ipyparallel.Client.executor
+.. _mpi4py: https://mpi4py.readthedocs.io/en/stable/mpi4py.futures.html

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -213,4 +213,4 @@ Other libraries like ipyparallel_ and mpi4py_ also supply
 ``concurrent.futures.Executor`` subclasses that could be used as well.
 
 .. _ipyparallel: https://ipyparallel.readthedocs.io/en/latest/api/ipyparallel.html#ipyparallel.Client.executor
-.. _mpi4py: https://mpi4py.readthedocs.io/en/stable/mpi4py.futures.html
+.. _mpi4py: https://mpi4py.readthedocs.io/en/latest/mpi4py.futures.html


### PR DESCRIPTION
Mention `ipyparallel` and `mpi4py` also support the `concurrent.futures` API and could be used as well.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
