### PR TITLE
Fix maximum recursion depth exception in array.linspace (#7644)

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -265,6 +265,18 @@ def arange(start, stop, step, length, dtype, like=None):
     return res[:-1] if len(res) > length else res
 
 
+def linspace(start, stop, num, endpoint=True, dtype=None):
+    from .core import Array
+
+    if isinstance(start, Array):
+        start = start.compute()
+
+    if isinstance(stop, Array):
+        stop = stop.compute()
+
+    return np.linspace(start, stop, num, endpoint=endpoint, dtype=dtype)
+
+
 def astype(x, astype_dtype=None, **kwargs):
     return x.astype(astype_dtype, **kwargs)
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -309,7 +309,7 @@ def linspace(
         bs_space = bs - 1 if endpoint else bs
         blockstop = blockstart + (bs_space * step)
         task = (
-            partial(np.linspace, endpoint=endpoint, dtype=dtype),
+            partial(chunk.linspace, endpoint=endpoint, dtype=dtype),
             blockstart,
             blockstop,
             bs,

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -142,6 +142,11 @@ def test_linspace(endpoint):
         da.linspace(6, 49, endpoint=endpoint, chunks=5, dtype=float).dask
     ) == sorted(da.linspace(6, 49, endpoint=endpoint, chunks=5, dtype=float).dask)
 
+    x = da.array([0.2, 6.4, 3.0, 1.6])
+    nparr = np.linspace(0, 2, 8, endpoint=endpoint)
+    darr = da.linspace(da.argmin(x), da.argmax(x) + 1, 8, endpoint=endpoint)
+    assert_eq(darr, nparr)
+
 
 def test_arange():
     darr = da.arange(77, chunks=13)


### PR DESCRIPTION
- [x] Closes #7644 
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

It seems that the problem was that the call to `np.linspace` inside `da.linspace` is intercepted by `__array_function__` causing an infinite recursion, solved this by creating a function in chunk, that avoids interception of `__array_function__`. 