### PR TITLE
Accept axis tuple for flip consistent with numpy

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -170,14 +170,14 @@ def transpose(a, axes=None):
     )
 
 
-def flip(m, axis):
+def flip(m, axis=None):
     """
     Reverse element order along axis.
 
     Parameters
     ----------
-    axis : int
-        Axis to reverse element order of.
+    axis : None or int or tuple of ints, optional
+        Axis or axes to reverse element order of. None will reverse all axes.
 
     Returns
     -------
@@ -187,8 +187,13 @@ def flip(m, axis):
     m = asanyarray(m)
 
     sl = m.ndim * [slice(None)]
+    if axis is None:
+        axis = range(m.ndim)
+    if not isinstance(axis, Iterable):
+        axis = (axis,)
     try:
-        sl[axis] = slice(None, None, -1)
+        for ax in axis:
+            sl[ax] = slice(None, None, -1)
     except IndexError as e:
         raise ValueError(
             "`axis` of %s invalid for %s-D array" % (str(axis), str(m.ndim))

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -176,12 +176,15 @@ def flip(m, axis=None):
 
     Parameters
     ----------
+    m : array_like
+        Input array.
     axis : None or int or tuple of ints, optional
         Axis or axes to reverse element order of. None will reverse all axes.
 
     Returns
     -------
-    reversed array : ndarray
+    dask.array.Array
+        The flipped array.
     """
 
     m = asanyarray(m)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -188,10 +188,12 @@ def test_moveaxis_rollaxis_numpy_api():
     [
         ("flipud", {}),
         ("fliplr", {}),
+        ("flip", {}),
         ("flip", {"axis": 0}),
         ("flip", {"axis": 1}),
         ("flip", {"axis": 2}),
         ("flip", {"axis": -1}),
+        ("flip", {"axis": (0, 2)}),
     ],
 )
 @pytest.mark.parametrize("shape", [tuple(), (4,), (4, 6), (4, 6, 8), (4, 6, 8, 10)])
@@ -199,9 +201,13 @@ def test_flip(funcname, kwargs, shape):
     axis = kwargs.get("axis")
     if axis is None:
         if funcname == "flipud":
-            axis = 0
+            axis = (0,)
         elif funcname == "fliplr":
-            axis = 1
+            axis = (1,)
+        elif funcname == "flip":
+            axis = range(len(shape))
+    elif not isinstance(axis, tuple):
+        axis = (axis,)
 
     np_a = np.random.random(shape)
     da_a = da.from_array(np_a, chunks=1)
@@ -210,7 +216,8 @@ def test_flip(funcname, kwargs, shape):
     da_func = getattr(da, funcname)
 
     try:
-        range(np_a.ndim)[axis]
+        for ax in axis:
+            range(np_a.ndim)[ax]
     except IndexError:
         with pytest.raises(ValueError):
             da_func(da_a, **kwargs)


### PR DESCRIPTION
Closes dask/dask#7674.

- [x] Closes #7674
- [x] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`

`black dask` caused a large delta of unrelated changes, so was not applied. Is some special invocation necessary beyond what's in the contribution docs? (This is my first dask contribution.) flake8 and isort were fine.

It's not clear from other array functions what degree of implementation and documentation consistency with numpy is desired, so I went for a simpler and more concise style similar to the existing version.