### PR TITLE
Bump pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.5b1
     hooks:
     - id: black
       language_version: python3
       exclude: versioneer.py
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.9.2
     hooks:
     - id: flake8
       language_version: python3

--- a/dask/array/chunk_types.py
+++ b/dask/array/chunk_types.py
@@ -134,7 +134,7 @@ except ImportError:
 
 
 def is_valid_chunk_type(type):
-    """ Check if given type is a valid chunk and downcast array type"""
+    """Check if given type is a valid chunk and downcast array type"""
     try:
         return type in _HANDLED_CHUNK_TYPES or issubclass(
             type, tuple(_HANDLED_CHUNK_TYPES)
@@ -144,5 +144,5 @@ def is_valid_chunk_type(type):
 
 
 def is_valid_array_chunk(array):
-    """ Check if given array is of a valid type to operate with"""
+    """Check if given array is of a valid type to operate with"""
     return array is None or isinstance(array, tuple(_HANDLED_CHUNK_TYPES))

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -84,7 +84,7 @@ unknown_chunk_message = (
 
 
 class PerformanceWarning(Warning):
-    """ A warning given when bad chunking may cause poor performance """
+    """A warning given when bad chunking may cause poor performance"""
 
 
 def getter(a, b, asarray=True, lock=None):
@@ -1460,17 +1460,17 @@ class Array(DaskMethodsMixin):
 
     @cached_property
     def size(self):
-        """ Number of elements in array """
+        """Number of elements in array"""
         return reduce(mul, self.shape, 1)
 
     @property
     def nbytes(self):
-        """ Number of bytes in array """
+        """Number of bytes in array"""
         return self.size * self.dtype.itemsize
 
     @property
     def itemsize(self):
-        """ Length of one array element in bytes """
+        """Length of one array element in bytes"""
         return self.dtype.itemsize
 
     @property
@@ -2489,7 +2489,7 @@ class Array(DaskMethodsMixin):
     def rechunk(
         self, chunks="auto", threshold=None, block_size_limit=None, balance=False
     ):
-        """ See da.rechunk for docstring """
+        """See da.rechunk for docstring"""
         from . import rechunk  # avoid circular import
 
         return rechunk(self, chunks, threshold, block_size_limit, balance)
@@ -4590,7 +4590,7 @@ def deepfirst(seq):
 
 
 def shapelist(a):
-    """ Get the shape of nested list """
+    """Get the shape of nested list"""
     if type(a) is list:
         return tuple([len(a)] + list(shapelist(a[0])))
     else:
@@ -4823,7 +4823,7 @@ def concatenate3(arrays):
 
 
 def concatenate_axes(arrays, axes):
-    """ Recursively call np.concatenate along axes """
+    """Recursively call np.concatenate along axes"""
     if len(axes) != ndimlist(arrays):
         raise ValueError("Length of axes should equal depth of nested arrays")
 
@@ -5085,13 +5085,13 @@ def _get_axis(indexes):
 
 
 def _vindex_slice(block, points):
-    """ Pull out point-wise slices from block """
+    """Pull out point-wise slices from block"""
     points = [p if isinstance(p, slice) else list(p) for p in points]
     return block[tuple(points)]
 
 
 def _vindex_transpose(block, axis):
-    """ Rotate block so that points are on the first dimension """
+    """Rotate block so that points are on the first dimension"""
     axes = [axis] + list(range(axis)) + list(range(axis + 1, block.ndim))
     return block.transpose(axes)
 

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -32,7 +32,7 @@ fft_preamble = """
 
 
 def _fft_out_chunks(a, s, axes):
-    """ For computing the output chunks of [i]fft*"""
+    """For computing the output chunks of [i]fft*"""
     if s is None:
         return a.chunks
     chunks = list(a.chunks)
@@ -42,7 +42,7 @@ def _fft_out_chunks(a, s, axes):
 
 
 def _rfft_out_chunks(a, s, axes):
-    """ For computing the output chunks of rfft*"""
+    """For computing the output chunks of rfft*"""
     if s is None:
         s = [a.chunks[axis][0] for axis in axes]
     s = list(s)
@@ -54,7 +54,7 @@ def _rfft_out_chunks(a, s, axes):
 
 
 def _irfft_out_chunks(a, s, axes):
-    """ For computing the output chunks of irfft*"""
+    """For computing the output chunks of irfft*"""
     if s is None:
         s = [a.chunks[axis][0] for axis in axes]
         s[-1] = 2 * (s[-1] - 1)

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -361,7 +361,7 @@ def nearest(x, axis, depth):
 
 
 def constant(x, axis, depth, value):
-    """ Add constant slice to either side of array """
+    """Add constant slice to either side of array"""
     chunks = list(x.chunks)
     chunks[axis] = (depth,)
 

--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -21,7 +21,7 @@ from .creation import arange
 
 
 def doc_wraps(func):
-    """ Copy docstring from one function to another """
+    """Copy docstring from one function to another"""
     warnings.warn(
         "dask.array.random.doc_wraps is deprecated and will be removed in a future version",
         FutureWarning,

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -550,7 +550,7 @@ def nanmax(a, axis=None, keepdims=False, split_every=None, out=None):
 
 
 def numel(x, **kwargs):
-    """ A reduction to count the number of elements """
+    """A reduction to count the number of elements"""
 
     if hasattr(x, "mask"):
         return chunk.sum(np.ones_like(x), **kwargs)
@@ -582,7 +582,7 @@ def numel(x, **kwargs):
 
 
 def nannumel(x, **kwargs):
-    """ A reduction to count the number of elements """
+    """A reduction to count the number of elements"""
     return chunk.sum(~(np.isnan(x)), **kwargs)
 
 
@@ -931,7 +931,7 @@ def nanstd(
 
 
 def _arg_combine(data, axis, argfunc, keepdims=False):
-    """ Merge intermediate results from ``arg_*`` functions"""
+    """Merge intermediate results from ``arg_*`` functions"""
     axis = None if len(axis) == data.ndim or data.ndim == 1 else axis[0]
     vals = data["vals"]
     arg = data["arg"]

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1618,7 +1618,7 @@ def _asarray_isnull(values):
 
 
 def isnull(values):
-    """ pandas.isnull for dask arrays """
+    """pandas.isnull for dask arrays"""
     # eagerly raise ImportError, if pandas isn't available
     import pandas as pd  # noqa
 
@@ -1626,7 +1626,7 @@ def isnull(values):
 
 
 def notnull(values):
-    """ pandas.notnull for dask arrays """
+    """pandas.notnull for dask arrays"""
     return ~isnull(values)
 
 

--- a/dask/array/svg.py
+++ b/dask/array/svg.py
@@ -257,7 +257,7 @@ def grid_points(chunks, sizes):
 
 
 def draw_sizes(shape, size=200):
-    """ Get size in pixels for all dimensions """
+    """Get size in pixels for all dimensions"""
     mx = max(shape)
     ratios = [mx / max(0.1, d) for d in shape]
     ratios = [ratio_response(r) for r in ratios]

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -206,7 +206,7 @@ def test_non_existent_func():
     ],
 )
 def test_binary_function_type_precedence(func, arr_upcast, arr_downcast):
-    """ Test proper dispatch on binary NumPy functions"""
+    """Test proper dispatch on binary NumPy functions"""
     assert (
         type(func(arr_upcast, arr_downcast))
         == type(func(arr_downcast, arr_upcast))

--- a/dask/array/tests/test_dispatch.py
+++ b/dask/array/tests/test_dispatch.py
@@ -176,7 +176,7 @@ class WrappedArray(np.lib.mixins.NDArrayOperatorsMixin):
     ],
 )
 def test_binary_operation_type_precedence(op, arr_upcast, arr_downcast):
-    """ Test proper dispatch on binary operators and NumPy ufuncs"""
+    """Test proper dispatch on binary operators and NumPy ufuncs"""
     assert (
         type(op(arr_upcast, arr_downcast))
         == type(op(arr_downcast, arr_upcast))
@@ -202,7 +202,7 @@ def test_binary_operation_type_precedence(op, arr_upcast, arr_downcast):
     ],
 )
 def test_is_valid_array_chunk(arr, result):
-    """ Test is_valid_array_chunk for correctness"""
+    """Test is_valid_array_chunk for correctness"""
     assert is_valid_array_chunk(arr) is result
 
 
@@ -219,12 +219,12 @@ def test_is_valid_array_chunk(arr, result):
     ],
 )
 def test_is_valid_chunk_type(arr_type, result):
-    """ Test is_valid_chunk_type for correctness"""
+    """Test is_valid_chunk_type for correctness"""
     assert is_valid_chunk_type(arr_type) is result
 
 
 def test_direct_deferral_wrapping_override():
-    """ Directly test Dask defering to an upcast type and the ability to still wrap it."""
+    """Directly test Dask defering to an upcast type and the ability to still wrap it."""
     a = da.from_array(np.arange(4))
     b = WrappedArray(np.arange(4))
     assert a.__add__(b) is NotImplemented

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -62,7 +62,7 @@ def test_rechunk_internals_1():
 
 
 def test_intersect_1():
-    """ Convert 1 D chunks"""
+    """Convert 1 D chunks"""
     old = ((10, 10, 10, 10, 10),)
     new = ((25, 5, 20),)
     answer = [
@@ -75,7 +75,7 @@ def test_intersect_1():
 
 
 def test_intersect_2():
-    """ Convert 1 D chunks"""
+    """Convert 1 D chunks"""
     old = ((20, 20, 20, 20, 20),)
     new = ((58, 4, 20, 18),)
     answer = [
@@ -141,7 +141,7 @@ def test_rechunk_expand2():
 
 
 def test_rechunk_method():
-    """ Test rechunking can be done as a method of dask array."""
+    """Test rechunking can be done as a method of dask array."""
     old = ((5, 2, 3),) * 4
     new = ((3, 3, 3, 1),) * 4
     a = np.random.uniform(0, 1, 10000).reshape((10,) * 4)
@@ -152,7 +152,7 @@ def test_rechunk_method():
 
 
 def test_rechunk_blockshape():
-    """ Test that blockshape can be used."""
+    """Test that blockshape can be used."""
     new_shape, new_chunks = (10, 10), (4, 3)
     new_blockdims = normalize_chunks(new_chunks, new_shape)
     old_chunks = ((4, 4, 2), (3, 3, 3, 1))

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -22,7 +22,7 @@ def __array_wrap__(numpy_ufunc, x, *args, **kwargs):
 
 
 def wrap_elemwise(numpy_ufunc, array_wrap=False, source=np):
-    """ Wrap up numpy function into dask.array """
+    """Wrap up numpy function into dask.array"""
 
     def wrapped(*args, **kwargs):
         dsk = [arg for arg in args if hasattr(arg, "_elemwise")]

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -201,7 +201,7 @@ def _not_empty(x):
 
 
 def _check_dsk(dsk):
-    """ Check that graph is well named and non-overlapping """
+    """Check that graph is well named and non-overlapping"""
     if not isinstance(dsk, HighLevelGraph):
         return
 
@@ -509,7 +509,7 @@ def asanyarray_safe(a, like, **kwargs):
 
 
 def validate_axis(axis, ndim):
-    """ Validate an input to axis= keywords """
+    """Validate an input to axis= keywords"""
     if isinstance(axis, (tuple, list)):
         return tuple(validate_axis(ax, ndim) for ax in axis)
     if not isinstance(axis, numbers.Integral):

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -131,7 +131,7 @@ def inline_singleton_lists(dsk, keys, dependencies=None):
 
 
 def optimize(dsk, keys, fuse_keys=None, rename_fused_keys=None, **kwargs):
-    """ Optimize a dask from a dask Bag. """
+    """Optimize a dask from a dask Bag."""
     dsk = ensure_dict(dsk)
     dsk2, dependencies = cull(dsk, keys)
     kwargs = {}
@@ -329,7 +329,7 @@ class StringAccessor:
 
 
 def robust_wraps(wrapper):
-    """ A weak version of wraps that only copies doc. """
+    """A weak version of wraps that only copies doc."""
 
     def _(wrapped):
         wrapped.__doc__ = wrapper.__doc__
@@ -1047,31 +1047,31 @@ class Bag(DaskMethodsMixin):
             return Bag(graph, fmt, 1)
 
     def sum(self, split_every=None):
-        """ Sum all elements """
+        """Sum all elements"""
         return self.reduction(sum, sum, split_every=split_every)
 
     def max(self, split_every=None):
-        """ Maximum element """
+        """Maximum element"""
         return self.reduction(max, max, split_every=split_every)
 
     def min(self, split_every=None):
-        """ Minimum element """
+        """Minimum element"""
         return self.reduction(min, min, split_every=split_every)
 
     def any(self, split_every=None):
-        """ Are any of the elements truthy? """
+        """Are any of the elements truthy?"""
         return self.reduction(any, any, split_every=split_every)
 
     def all(self, split_every=None):
-        """ Are all elements truthy? """
+        """Are all elements truthy?"""
         return self.reduction(all, all, split_every=split_every)
 
     def count(self, split_every=None):
-        """ Count the number of elements. """
+        """Count the number of elements."""
         return self.reduction(count, sum, split_every=split_every)
 
     def mean(self):
-        """ Arithmetic mean """
+        """Arithmetic mean"""
 
         def mean_chunk(seq):
             total, n = 0.0, 0
@@ -1087,13 +1087,13 @@ class Bag(DaskMethodsMixin):
         return self.reduction(mean_chunk, mean_aggregate, split_every=False)
 
     def var(self, ddof=0):
-        """ Variance """
+        """Variance"""
         return self.reduction(
             chunk.var_chunk, partial(chunk.var_aggregate, ddof=ddof), split_every=False
         )
 
     def std(self, ddof=0):
-        """ Standard deviation """
+        """Standard deviation"""
         return self.var(ddof=ddof).apply(math.sqrt)
 
     def join(self, other, on_self, on_other=None):
@@ -1166,7 +1166,7 @@ class Bag(DaskMethodsMixin):
         return type(self)(graph, name, self.npartitions)
 
     def product(self, other):
-        """ Cartesian product between two bags. """
+        """Cartesian product between two bags."""
         assert isinstance(other, Bag)
         name = "product-" + tokenize(self, other)
         n, m = self.npartitions, other.npartitions
@@ -1682,7 +1682,7 @@ def accumulate_part(binop, seq, initial, is_first=False):
 
 
 def partition(grouper, sequence, npartitions, p, nelements=2 ** 20):
-    """ Partition a bag along a grouper, store partitions on disk. """
+    """Partition a bag along a grouper, store partitions on disk."""
     for block in partition_all(nelements, sequence):
         d = groupby(grouper, block)
         d2 = defaultdict(list)
@@ -1693,7 +1693,7 @@ def partition(grouper, sequence, npartitions, p, nelements=2 ** 20):
 
 
 def collect(grouper, group, p, barrier_token):
-    """ Collect partitions from disk and yield k,v group pairs. """
+    """Collect partitions from disk and yield k,v group pairs."""
     d = groupby(grouper, p.get(group, lock=False))
     return list(d.items())
 

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -204,7 +204,7 @@ def subs(task, substitution):
 
 
 def index_subs(ind, substitution):
-    """ A simple subs function that works both on tuples and strings """
+    """A simple subs function that works both on tuples and strings"""
     if ind is None:
         return ind
     else:

--- a/dask/core.py
+++ b/dask/core.py
@@ -427,7 +427,7 @@ def _toposort(dsk, keys=None, returncycle=False, dependencies=None):
 
 
 def toposort(dsk, dependencies=None):
-    """ Return a list of keys of dask sorted in topological order."""
+    """Return a list of keys of dask sorted in topological order."""
     return _toposort(dsk, dependencies=dependencies)
 
 

--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -177,7 +177,7 @@ def str_extractall(series, pat, flags):
 
 
 def str_get(series, index):
-    """ Implements series.str[index] """
+    """Implements series.str[index]"""
     return series.str[index]
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -110,7 +110,7 @@ def finalize(results):
 
 
 class Scalar(DaskMethodsMixin, OperatorMethodMixin):
-    """ A Dask object to represent a pandas scalar"""
+    """A Dask object to represent a pandas scalar"""
 
     def __init__(self, dsk, name, meta, divisions=None):
         # divisions is ignored, only present to be compatible with other
@@ -370,7 +370,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
 
     @property
     def _meta_nonempty(self):
-        """ A non-empty version of `_meta` with fake data."""
+        """A non-empty version of `_meta` with fake data."""
         return meta_nonempty(self._meta)
 
     @property
@@ -507,7 +507,7 @@ Dask Name: {name}, {task} tasks"""
         return len(self.divisions) > 0 and self.divisions[0] is not None
 
     def clear_divisions(self):
-        """ Forget division information """
+        """Forget division information"""
         divisions = (None,) * (self.npartitions + 1)
         return type(self)(self.dask, self._name, self._meta, divisions)
 
@@ -1455,13 +1455,13 @@ Dask Name: {name}, {task} tasks"""
         return arr
 
     def to_hdf(self, path_or_buf, key, mode="a", append=False, **kwargs):
-        """ See dd.to_hdf docstring for more information """
+        """See dd.to_hdf docstring for more information"""
         from .io import to_hdf
 
         return to_hdf(self, path_or_buf, key, mode, append, **kwargs)
 
     def to_csv(self, filename, **kwargs):
-        """ See dd.to_csv docstring for more information """
+        """See dd.to_csv docstring for more information"""
         from .io import to_csv
 
         return to_csv(self, filename, **kwargs)
@@ -1480,7 +1480,7 @@ Dask Name: {name}, {task} tasks"""
         compute=True,
         parallel=False,
     ):
-        """ See dd.to_sql docstring for more information """
+        """See dd.to_sql docstring for more information"""
         from .io import to_sql
 
         return to_sql(
@@ -1499,7 +1499,7 @@ Dask Name: {name}, {task} tasks"""
         )
 
     def to_json(self, filename, *args, **kwargs):
-        """ See dd.to_json docstring for more information """
+        """See dd.to_json docstring for more information"""
         from .io import to_json
 
         return to_json(self, filename, *args, **kwargs)
@@ -2514,7 +2514,7 @@ Dask Name: {name}, {task} tasks"""
     def _cum_agg(
         self, op_name, chunk, aggregate, axis, skipna=True, chunk_kwargs=None, out=None
     ):
-        """ Wrapper for cumulative operation """
+        """Wrapper for cumulative operation"""
 
         axis = self._validate_axis(axis)
 
@@ -2762,7 +2762,7 @@ Dask Name: {name}, {task} tasks"""
 
     @classmethod
     def _bind_operator_method(cls, name, op, original=pd.DataFrame):
-        """ bind operator method like DataFrame.add to this class """
+        """bind operator method like DataFrame.add to this class"""
         raise NotImplementedError
 
     @derived_from(pd.DataFrame)
@@ -2994,7 +2994,7 @@ class Series(_Frame):
 
     @property
     def ndim(self):
-        """ Return dimensionality """
+        """Return dimensionality"""
         return 1
 
     @property
@@ -3013,12 +3013,12 @@ class Series(_Frame):
 
     @property
     def dtype(self):
-        """ Return data type """
+        """Return data type"""
         return self._meta.dtype
 
     @cache_readonly
     def dt(self):
-        """ Namespace of datetime methods """
+        """Namespace of datetime methods"""
         return DatetimeAccessor(self)
 
     @cache_readonly
@@ -3027,7 +3027,7 @@ class Series(_Frame):
 
     @cache_readonly
     def str(self):
-        """ Namespace for string methods """
+        """Namespace for string methods"""
         return StringAccessor(self)
 
     def __dir__(self):
@@ -3043,7 +3043,7 @@ class Series(_Frame):
 
     @property
     def nbytes(self):
-        """ Number of bytes """
+        """Number of bytes"""
         return self.reduction(
             methods.nbytes, np.sum, token="nbytes", meta=int, split_every=False
         )
@@ -3052,7 +3052,7 @@ class Series(_Frame):
         return _repr_data_series(self._meta, self._repr_divisions)
 
     def __repr__(self):
-        """ have to overwrite footer """
+        """have to overwrite footer"""
         if self.name is not None:
             footer = "Name: {name}, dtype: {dtype}".format(
                 name=self.name, dtype=self.dtype
@@ -3407,7 +3407,7 @@ Dask Name: {name}, {task} tasks""".format(
         return self.map_partitions(M.combine_first, other)
 
     def to_bag(self, index=False):
-        """ Create a Dask Bag from a Series """
+        """Create a Dask Bag from a Series"""
         from .io import to_bag
 
         return to_bag(self, index)
@@ -3423,7 +3423,7 @@ Dask Name: {name}, {task} tasks""".format(
 
     @classmethod
     def _bind_operator_method(cls, name, op, original=pd.Series):
-        """ bind operator method like Series.add to this class """
+        """bind operator method like Series.add to this class"""
 
         def meth(self, other, level=None, fill_value=None, axis=0):
             if level is not None:
@@ -3439,7 +3439,7 @@ Dask Name: {name}, {task} tasks""".format(
 
     @classmethod
     def _bind_comparison_method(cls, name, comparison, original=pd.Series):
-        """ bind comparison method like Series.eq to this class """
+        """bind comparison method like Series.eq to this class"""
 
         def meth(self, other, level=None, fill_value=None, axis=0):
             if level is not None:
@@ -3960,7 +3960,7 @@ class DataFrame(_Frame):
 
     @property
     def ndim(self):
-        """ Return dimensionality """
+        """Return dimensionality"""
         return 2
 
     @property
@@ -3984,7 +3984,7 @@ class DataFrame(_Frame):
 
     @property
     def dtypes(self):
-        """ Return data types """
+        """Return data types"""
         return self._meta.dtypes
 
     @derived_from(pd.DataFrame)
@@ -4335,7 +4335,7 @@ class DataFrame(_Frame):
         return to_bag(self, index)
 
     def to_parquet(self, path, *args, **kwargs):
-        """ See dd.to_parquet docstring for more information """
+        """See dd.to_parquet docstring for more information"""
         from .io import to_parquet
 
         return to_parquet(self, path, *args, **kwargs)
@@ -4560,7 +4560,7 @@ class DataFrame(_Frame):
 
     @classmethod
     def _bind_operator_method(cls, name, op, original=pd.DataFrame):
-        """ bind operator method like DataFrame.add to this class """
+        """bind operator method like DataFrame.add to this class"""
 
         # name must be explicitly passed for div method whose name is truediv
 
@@ -4609,7 +4609,7 @@ class DataFrame(_Frame):
 
     @classmethod
     def _bind_comparison_method(cls, name, comparison, original=pd.DataFrame):
-        """ bind comparison method like DataFrame.eq to this class """
+        """bind comparison method like DataFrame.eq to this class"""
 
         def meth(self, other, axis="columns", level=None):
             if level is not None:
@@ -5283,7 +5283,7 @@ def hash_shard(
 
 
 def split_evenly(df, k):
-    """ Split dataframe into k roughly equal parts """
+    """Split dataframe into k roughly equal parts"""
     divisions = np.linspace(0, len(df), k + 1).astype(int)
     return {i: df.iloc[divisions[i] : divisions[i + 1]] for i in range(k)}
 
@@ -6300,7 +6300,7 @@ def repartition_divisions(a, b, name, out1, out2, force=False):
 
 
 def repartition_freq(df, freq=None):
-    """ Repartition a timeseries dataframe by a new frequency """
+    """Repartition a timeseries dataframe by a new frequency"""
     if not isinstance(df.divisions[0], pd.Timestamp):
         raise TypeError("Can only repartition on frequency for timeseries")
 
@@ -6399,7 +6399,7 @@ def total_mem_usage(df, index=True, deep=False):
 
 
 def repartition_npartitions(df, npartitions):
-    """ Repartition dataframe to a smaller number of partitions """
+    """Repartition dataframe to a smaller number of partitions"""
     new_name = "repartition-%d-%s" % (npartitions, tokenize(df))
     if df.npartitions == npartitions:
         return df
@@ -6748,7 +6748,7 @@ def get_parallel_type_object(_):
 
 
 def has_parallel_type(x):
-    """ Does this object have a dask dataframe equivalent? """
+    """Does this object have a dask dataframe equivalent?"""
     return get_parallel_type(x) is not Scalar
 
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1182,7 +1182,7 @@ class _GroupBy:
         )
 
     def _cum_agg(self, token, chunk, aggregate, initial):
-        """ Wrapper for cumulative groupby operation """
+        """Wrapper for cumulative groupby operation"""
         meta = chunk(self._meta)
         columns = meta.name if is_series_like(meta) else meta.columns
         index = self.index if isinstance(self.index, list) else [self.index]

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -75,7 +75,7 @@ class _iLocIndexer(_IndexerBase):
 
 
 class _LocIndexer(_IndexerBase):
-    """ Helper class for the .loc accessor """
+    """Helper class for the .loc accessor"""
 
     @property
     def _meta_indexer(self):
@@ -99,7 +99,7 @@ class _LocIndexer(_IndexerBase):
         return self._loc(iindexer, cindexer)
 
     def _loc(self, iindexer, cindexer):
-        """ Helper function for the .loc accessor """
+        """Helper function for the .loc accessor"""
         if isinstance(iindexer, Series):
             return self._loc_series(iindexer, cindexer)
         elif isinstance(iindexer, Array):

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -223,7 +223,7 @@ def generate_day(
     freq=pd.Timedelta(seconds=60),
     random_state=None,
 ):
-    """ Generate a day of financial data from open/close high/low values """
+    """Generate a day of financial data from open/close high/low values"""
     if not isinstance(random_state, np.random.RandomState):
         random_state = np.random.RandomState(random_state)
     if not isinstance(date, pd.Timestamp):

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -17,7 +17,7 @@ from .io import _link
 
 
 def _pd_to_hdf(pd_to_hdf, lock, args, kwargs=None):
-    """ A wrapper function around pd_to_hdf that enables locking"""
+    """A wrapper function around pd_to_hdf that enables locking"""
 
     if lock:
         lock.acquire()
@@ -395,7 +395,7 @@ def _read_single_hdf(
 
 
 def _pd_read_hdf(path, key, lock, kwargs):
-    """ Read from hdf5 file with a lock """
+    """Read from hdf5 file with a lock"""
     if lock:
         lock.acquire()
     try:

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -20,7 +20,7 @@ lock = Lock()
 
 
 def _meta_from_array(x, columns=None, index=None, meta=None):
-    """ Create empty DataFrame or Series which has correct dtype """
+    """Create empty DataFrame or Series which has correct dtype"""
 
     if x.ndim > 2:
         raise ValueError(

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -7,7 +7,7 @@ from ....utils import natural_sort_key
 
 
 class Engine:
-    """ The API necessary to provide a new Parquet reader/writer """
+    """The API necessary to provide a new Parquet reader/writer"""
 
     @classmethod
     def read_metadata(

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -287,7 +287,7 @@ def merge_chunk(lhs, *args, **kwargs):
 
 
 def merge_indexed_dataframes(lhs, rhs, left_index=True, right_index=True, **kwargs):
-    """ Join two partitioned dataframes along their index """
+    """Join two partitioned dataframes along their index"""
     how = kwargs.get("how", "left")
     kwargs["left_index"] = left_index
     kwargs["right_index"] = right_index
@@ -771,7 +771,7 @@ def pair_partitions(L, R):
 
 
 def merge_asof_padded(left, right, prev=None, next=None, **kwargs):
-    """ merge_asof but potentially adding rows to the beginning/end of right """
+    """merge_asof but potentially adding rows to the beginning/end of right"""
     frames = []
     if prev is not None:
         frames.append(prev)
@@ -979,7 +979,7 @@ def concat_unindexed_dataframes(dfs, ignore_order=False, **kwargs):
 
 
 def concat_indexed_dataframes(dfs, axis=0, join="outer", ignore_order=False, **kwargs):
-    """ Concatenate indexed dataframes together along the index """
+    """Concatenate indexed dataframes together along the index"""
     warn = axis != 0
     kwargs.update({"ignore_order": ignore_order})
     meta = methods.concat(

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -74,7 +74,7 @@ def sort_values(
     partition_size=128e6,
     **kwargs,
 ):
-    """ See DataFrame.sort_values for docstring """
+    """See DataFrame.sort_values for docstring"""
     if not ascending:
         raise NotImplementedError("The ascending= keyword is not supported")
     if not isinstance(by, str):
@@ -127,7 +127,7 @@ def set_index(
     partition_size=128e6,
     **kwargs,
 ):
-    """ See _Frame.set_index for docstring """
+    """See _Frame.set_index for docstring"""
     if isinstance(index, Series) and index._name == df.index._name:
         return df
     if isinstance(index, (DataFrame, tuple, list)):
@@ -374,7 +374,7 @@ def shuffle(
 
 
 def rearrange_by_divisions(df, column, divisions, max_branch=None, shuffle=None):
-    """ Shuffle dataframe so that column separates along divisions """
+    """Shuffle dataframe so that column separates along divisions"""
     divisions = df._meta._constructor_sliced(divisions)
     meta = df._meta._constructor_sliced([0])
     # Assign target output partitions to every row
@@ -730,7 +730,7 @@ def cleanup_partd_files(p, keys):
 
 
 def collect(p, part, meta, barrier_token):
-    """ Collect partitions from partd, yield dataframes """
+    """Collect partitions from partd, yield dataframes"""
     with ensure_cleanup_on_exception(p):
         res = p.get(part)
         return res if len(res) > 0 else meta
@@ -876,7 +876,7 @@ def get_overlap(df, index):
 
 
 def fix_overlap(ddf, overlap):
-    """ Ensures that the upper bound on each partition of ddf (except the last) is exclusive """
+    """Ensures that the upper bound on each partition of ddf (except the last) is exclusive"""
     name = "fix-overlap-" + tokenize(ddf, overlap)
     n = len(ddf.divisions) - 1
     dsk = {(name, i): (ddf._name, i) for i in range(n)}

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1367,7 +1367,7 @@ def test_quantile_for_possibly_unsorted_q():
 
 
 def test_quantile_tiny_partitions():
-    """ See https://github.com/dask/dask/issues/6551 """
+    """See https://github.com/dask/dask/issues/6551"""
     df = pd.DataFrame({"a": [1, 2, 3]})
     ddf = dd.from_pandas(df, npartitions=3)
     r = ddf["a"].quantile(0.5).compute()

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -711,5 +711,5 @@ except AttributeError:
 
 
 def single_key(seq):
-    """ Pick out the only element of this list, a list of keys """
+    """Pick out the only element of this list, a list of keys"""
     return seq[0]

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -587,7 +587,7 @@ class HighLevelGraph(Mapping):
 
     @classmethod
     def _from_collection(cls, name, layer, collection):
-        """ `from_collections` optimized for a single collection """
+        """`from_collections` optimized for a single collection"""
         if is_dask_collection(collection):
             graph = collection.__dask_graph__()
             if isinstance(graph, HighLevelGraph):

--- a/dask/local.py
+++ b/dask/local.py
@@ -456,7 +456,7 @@ def get_async(
                 raise ValueError("Found no accessible jobs in dask")
 
             def fire_tasks(chunksize):
-                """ Fire off a task to the thread pool """
+                """Fire off a task to the thread pool"""
                 # Determine chunksize and/or number of tasks to submit
                 nready = len(state["ready"])
                 if chunksize == -1:

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -73,7 +73,7 @@ exceptions = dict()
 
 
 def remote_exception(exc, tb):
-    """ Metaclass that wraps exception type in RemoteException """
+    """Metaclass that wraps exception type in RemoteException"""
     if type(exc) in exceptions:
         typ = exceptions[type(exc)]
         return typ(exc, tb)
@@ -128,7 +128,7 @@ and on Windows, because they each only support a single context.
 
 
 def get_context():
-    """ Return the current multiprocessing context."""
+    """Return the current multiprocessing context."""
     # fork context does fork()-without-exec(), which can lead to deadlocks,
     # so default to "spawn".
     context_name = config.get("multiprocessing.context", "spawn")

--- a/dask/order.py
+++ b/dask/order.py
@@ -211,7 +211,7 @@ def order(dsk, dependencies=None):
         )
 
     def finish_now_key(x):
-        """ Determine the order of dependents that are ready to run and be released"""
+        """Determine the order of dependents that are ready to run and be released"""
         return (-len(dependencies[x]), StrComparable(x))
 
     # Computing this for all keys can sometimes be relatively expensive :(

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -25,7 +25,7 @@ def my_small_function_global(a, b):
 
 
 def test_pickle_globals():
-    """ Unrelated globals should not be included in serialized bytes """
+    """Unrelated globals should not be included in serialized bytes"""
     b = _dumps(my_small_function_global)
     assert b"my_small_function_global" in b
     assert b"unrelated_function_global" not in b
@@ -265,7 +265,7 @@ def test_custom_context_ignored_elsewhere():
 
 @pytest.mark.skipif(sys.platform != "win32", reason="POSIX supports different contexts")
 def test_get_context_always_default():
-    """ On Python 2/Windows, get_context() always returns same context."""
+    """On Python 2/Windows, get_context() always returns same context."""
     assert get_context() is multiprocessing
     with pytest.warns(UserWarning):
         with dask.config.set({"multiprocessing.context": "forkserver"}):

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -417,14 +417,14 @@ def test_nearest_neighbor(abcde):
 
 
 def test_string_ordering():
-    """ Prefer ordering tasks by name first """
+    """Prefer ordering tasks by name first"""
     dsk = {("a", 1): (f,), ("a", 2): (f,), ("a", 3): (f,)}
     o = order(dsk)
     assert o == {("a", 1): 0, ("a", 2): 1, ("a", 3): 2}
 
 
 def test_string_ordering_dependents():
-    """ Prefer ordering tasks by name first even when in dependencies """
+    """Prefer ordering tasks by name first even when in dependencies"""
     dsk = {("a", 1): (f, "b"), ("a", 2): (f, "b"), ("a", 3): (f, "b"), "b": (f,)}
     o = order(dsk)
     assert o == {"b": 0, ("a", 1): 1, ("a", 2): 2, ("a", 3): 3}
@@ -586,7 +586,7 @@ def test_use_structure_not_keys(abcde):
 
 
 def test_dont_run_all_dependents_too_early(abcde):
-    """ From https://github.com/dask/dask-ml/issues/206#issuecomment-395873372 """
+    """From https://github.com/dask/dask-ml/issues/206#issuecomment-395873372"""
     a, b, c, d, e = abcde
     depth = 10
     dsk = {(a, 0): 0, (b, 0): 1, (c, 0): 2, (d, 0): (f, (a, 0), (b, 0), (c, 0))}

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -100,7 +100,7 @@ def test_dispatch():
     foo.register(tuple, lambda a: tuple(foo(i) for i in a))
 
     def f(a):
-        """ My Docstring """
+        """My Docstring"""
         return a
 
     foo.register(object, f)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -609,7 +609,7 @@ def ignore_warning(doc, cls, name, extra="", skipblocks=0):
 
 
 def unsupported_arguments(doc, args):
-    """ Mark unsupported arguments with a disclaimer """
+    """Mark unsupported arguments with a disclaimer"""
     lines = doc.split("\n")
     for arg in args:
         subset = [
@@ -624,7 +624,7 @@ def unsupported_arguments(doc, args):
 
 
 def _derived_from(cls, method, ua_args=[], extra="", skipblocks=0):
-    """ Helper function for derived_from to ease testing """
+    """Helper function for derived_from to ease testing"""
     # do not use wraps here, as it hides keyword arguments displayed
     # in the doc
     original_method = getattr(cls, method.__name__)
@@ -1059,7 +1059,7 @@ class OperatorMethodMixin:
 
     @classmethod
     def _bind_operator(cls, op):
-        """ bind operator to this class """
+        """bind operator to this class"""
         name = op.__name__
 
         if name.endswith("_"):
@@ -1083,12 +1083,12 @@ class OperatorMethodMixin:
 
     @classmethod
     def _get_unary_operator(cls, op):
-        """ Must return a method used by unary operator """
+        """Must return a method used by unary operator"""
         raise NotImplementedError
 
     @classmethod
     def _get_binary_operator(cls, op, inv=False):
-        """ Must return a method used by binary operator """
+        """Must return a method used by binary operator"""
         raise NotImplementedError
 
 
@@ -1151,7 +1151,7 @@ def is_arraylike(x):
 
 
 def is_dataframe_like(df):
-    """ Looks like a Pandas DataFrame """
+    """Looks like a Pandas DataFrame"""
     typ = df.__class__
     return (
         all(hasattr(typ, name) for name in ("groupby", "head", "merge", "mean"))
@@ -1161,7 +1161,7 @@ def is_dataframe_like(df):
 
 
 def is_series_like(s):
-    """ Looks like a Pandas Series """
+    """Looks like a Pandas Series"""
     typ = s.__class__
     return (
         all(hasattr(typ, name) for name in ("groupby", "head", "mean"))
@@ -1171,7 +1171,7 @@ def is_series_like(s):
 
 
 def is_index_like(s):
-    """ Looks like a Pandas Index """
+    """Looks like a Pandas Index"""
     typ = s.__class__
     return (
         all(hasattr(s, name) for name in ("name", "dtype"))

--- a/docs/source/scripts/scheduling.py
+++ b/docs/source/scripts/scheduling.py
@@ -15,7 +15,7 @@ nrepetitions = 1
 
 
 def trivial(width, height):
-    """ Embarrassingly parallel dask """
+    """Embarrassingly parallel dask"""
     d = {("x", 0, i): i for i in range(width)}
     for j in range(1, height):
         d.update({("x", j, i): (noop, ("x", j - 1, i)) for i in range(width)})
@@ -23,7 +23,7 @@ def trivial(width, height):
 
 
 def crosstalk(width, height, connections):
-    """ Natural looking dask with some inter-connections """
+    """Natural looking dask with some inter-connections"""
     d = {("x", 0, i): i for i in range(width)}
     for j in range(1, height):
         d.update(
@@ -39,7 +39,7 @@ def crosstalk(width, height, connections):
 
 
 def dense(width, height):
-    """ Full barriers between each step """
+    """Full barriers between each step"""
     d = {("x", 0, i): i for i in range(width)}
     for j in range(1, height):
         d.update(


### PR DESCRIPTION
This PR updates the version of `black` and `flake8` used in our pre-commit hooks. This will help avoid conflicts between running `black` manually and when `black` is run during our pre-commit hooks. 

EDIT: Note that all formatting changes here are from `black` removing leading and trailing spaces in docstrings