### PR TITLE
Add datafile_name_template option to to_parquet

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -583,11 +583,14 @@ def to_parquet(
         **kwargs_pass,
     )
 
-    # Fall back to default template if user specified template is missing
     if datafile_name_template:
+        if append:
+            raise ValueError(
+                "Cannot use both `datafile_name_template` and `append=True`"
+            )
         if datafile_name_template.count("*") != 1:
             raise ValueError(
-                "datafile_name_template must contain exactly one * (exactly one asterisk)"
+                "`datafile_name_template` must contain exactly one * (exactly one asterisk)"
             )
         file_template = datafile_name_template.replace("*", "%i")
     else:

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -586,7 +586,9 @@ def to_parquet(
     # Fall back to default template if user specified template is missing
     if datafile_name_template:
         if datafile_name_template.count("*") != 1:
-            raise ValueError("datafile_name_template must contain exactly one * (exactly one asterisk)")
+            raise ValueError(
+                "datafile_name_template must contain exactly one * (exactly one asterisk)"
+            )
         file_template = datafile_name_template.replace("*", "%i")
     else:
         file_template = "part.%i.parquet"

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3530,6 +3530,31 @@ def test_custom_filename(tmpdir, engine):
     assert_eq(df, dd.read_parquet(fn, engine=engine))
 
 
+def test_custom_filename_throws_error_when_append_is_true(tmpdir, engine):
+    fn = str(tmpdir)
+    pdf = pd.DataFrame(
+        {"num1": [1, 2, 3, 4], "num2": [7, 8, 9, 10]},
+    )
+    df = dd.from_pandas(pdf, npartitions=2)
+    df.to_parquet(fn, datafile_name_template="hi-*.parquet", engine=engine)
+
+    pdf = pd.DataFrame(
+        {"num1": [33], "num2": [44]},
+    )
+    df = dd.from_pandas(pdf, npartitions=1)
+    with pytest.raises(ValueError) as excinfo:
+        df.to_parquet(
+            fn,
+            datafile_name_template="hi-*.parquet",
+            engine=engine,
+            append=True,
+            ignore_divisions=True,
+        )
+    assert "Cannot use both `datafile_name_template` and `append=True`" in str(
+        excinfo.value
+    )
+
+
 def test_throws_error_if_custom_filename_is_invalid(tmpdir, engine):
     fn = str(tmpdir)
     pdf = pd.DataFrame(
@@ -3539,13 +3564,13 @@ def test_throws_error_if_custom_filename_is_invalid(tmpdir, engine):
     with pytest.raises(ValueError) as excinfo:
         df.to_parquet(fn, datafile_name_template="whatever.parquet", engine=engine)
     assert (
-        "datafile_name_template must contain exactly one * (exactly one asterisk)"
+        "`datafile_name_template` must contain exactly one * (exactly one asterisk)"
         in str(excinfo.value)
     )
     with pytest.raises(ValueError) as excinfo:
         df.to_parquet(fn, datafile_name_template="*-whatever-*.parquet", engine=engine)
     assert (
-        "datafile_name_template must contain exactly one * (exactly one asterisk)"
+        "`datafile_name_template` must contain exactly one * (exactly one asterisk)"
         in str(excinfo.value)
     )
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3538,23 +3538,32 @@ def test_throws_error_if_custom_filename_is_invalid(tmpdir, engine):
     df = dd.from_pandas(pdf, npartitions=2)
     with pytest.raises(ValueError) as excinfo:
         df.to_parquet(fn, datafile_name_template="whatever.parquet", engine=engine)
-    assert "datafile_name_template must contain exactly one * (exactly one asterisk)" in str(excinfo.value)
+    assert (
+        "datafile_name_template must contain exactly one * (exactly one asterisk)"
+        in str(excinfo.value)
+    )
     with pytest.raises(ValueError) as excinfo:
         df.to_parquet(fn, datafile_name_template="*-whatever-*.parquet", engine=engine)
-    assert "datafile_name_template must contain exactly one * (exactly one asterisk)" in str(excinfo.value)
+    assert (
+        "datafile_name_template must contain exactly one * (exactly one asterisk)"
+        in str(excinfo.value)
+    )
 
 
 def test_custom_filename_with_partition(tmpdir, engine):
     fn = str(tmpdir)
     pdf = pd.DataFrame(
         {
-            "first_name": ["frank",  "li", "marcela", "luis"],
+            "first_name": ["frank", "li", "marcela", "luis"],
             "country": ["canada", "china", "venezuela", "venezuela"],
         },
     )
     df = dd.from_pandas(pdf, npartitions=4)
     df.to_parquet(
-        fn, partition_on=["country"], datafile_name_template="*-cool.parquet", write_index=False
+        fn,
+        partition_on=["country"],
+        datafile_name_template="*-cool.parquet",
+        write_index=False,
     )
 
     for root, dirs, files in os.walk(fn):
@@ -3576,4 +3585,6 @@ def test_custom_filename_with_partition(tmpdir, engine):
     pd.testing.assert_frame_equal(
         df.compute().reset_index(drop=True),
         actual.compute().reset_index(drop=True),
-        check_dtype=False, check_categorical=False)
+        check_dtype=False,
+        check_categorical=False,
+    )


### PR DESCRIPTION
- [X] Fixes #7657
- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask` / `isort dask`

## Description of feature

The `to_parquet` function does not currently allow for the customization of filenames that are outputted (it creates files like `part.0.parquet`, `part.1.parquet`).  This pull request adds a `datafile_name_template` option that lets the user customize the filename output.

Here's an example:

```python
df.to_parquet("some/path", datafile_name_template="hi-*.parquet")
```

Here's what's outputted:

```
some/path/
  hi-0.parquet
  hi-1.parquet
```

The asterisk convention follows what's used in `to_csv` to customize filenames.  I tried to expose this interface in a Dask-like manner, with the implementation @martindurant [suggested here](https://github.com/dask/dask/issues/7657#issuecomment-843139538).

## Is this needed?

Letting the user customize the filename is nice and consistent with the `to_csv` API.

`to_parquet` already has an `append` option, which is good for some use cases, but this `datafile_name_template` will be better in other cases, specifically:

* concurrent writes where append might cause filename collisions.  `datafile_name_template` lets us add a UUID to the filename to prevent filename collisions.
* writing to huge data stores where you don't want the overhead of a file listing operation (think of a partitioned S3 lake with hundreds of thousands of files).  This assumes `append` is implemented with a file listing operation, which may not be the case, so take this argument with a grain of salt.

## Backwards compatibility

All the existing tests are passing, so this feature should be entirely backwards compatible.

## Other notes

* I'm new to Dask and looking to get involved.  You all know a lot more about this codebase than I do.  Let me know if you think this should be implemented differently or not added at all.  Whatever the group wants is good with me.
* I couldn't get the `test_custom_filename_with_partition` test working properly with `assert_eq` (categories & dtypes errors).  Any suggestions?