### PR TITLE
Cleanup array API reference links

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1093,7 +1093,7 @@ class Array(DaskMethodsMixin):
     A parallel nd-array comprised of many numpy arrays arranged in a grid.
 
     This constructor is for advanced uses only.  For normal use see the
-    :func:`da.from_array <dask.array.from_array>` function.
+    :func:`dask.array.from_array` function.
 
     Parameters
     ----------
@@ -5163,7 +5163,7 @@ def to_npy_stack(dirname, x, axis=0):
         |-- info
 
     The ``info`` file stores the dtype, chunks, and axis information of the array.
-    You can load these stacks with the :func:`da.from_npy_stack <dask.array.from_npy_stack>` function.
+    You can load these stacks with the :func:`dask.array.from_npy_stack` function.
 
     >>> y = da.from_npy_stack('data/')  # doctest: +SKIP
 
@@ -5196,7 +5196,7 @@ def to_npy_stack(dirname, x, axis=0):
 def from_npy_stack(dirname, mmap_mode="r"):
     """Load dask array from stack of npy files
 
-    See :func:`da.to_npy_stack <dask.array.to_npy_stack>` for docstring.
+    See :func:`dask.array.to_npy_stack` for docstring.
 
     Parameters
     ----------

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -432,7 +432,7 @@ def normalize_arg(x):
 
 
 def _pass_extra_kwargs(func, keys, *args, **kwargs):
-    """Helper for :func:`map_blocks` to pass `block_info` or `block_id`.
+    """Helper for :func:`dask.array.map_blocks` to pass `block_info` or `block_id`.
 
     For each element of `keys`, a corresponding element of args is changed
     to a keyword argument with that key, before all arguments re passed on
@@ -919,7 +919,7 @@ def store(
     lock: boolean or threading.Lock, optional
         Whether or not to lock the data stores while storing.
         Pass True (lock each file individually), False (don't lock) or a
-        particular ``threading.Lock`` object to be shared among all writes.
+        particular :class:`threading.Lock` object to be shared among all writes.
     regions: tuple of slices or list of tuples of slices
         Each ``region`` tuple in ``regions`` should be such that
         ``target[region].shape = source.shape``
@@ -927,7 +927,7 @@ def store(
         respectively. If this is a tuple, the contents will be assumed to be
         slices, so do not provide a tuple of tuples.
     compute: boolean, optional
-        If true compute immediately, return ``dask.delayed.Delayed`` otherwise
+        If true compute immediately, return :class:`dask.delayed.Delayed` otherwise
     return_stored: boolean, optional
         Optionally return the stored result (default False).
 
@@ -1093,7 +1093,7 @@ class Array(DaskMethodsMixin):
     A parallel nd-array comprised of many numpy arrays arranged in a grid.
 
     This constructor is for advanced uses only.  For normal use see the
-    ``da.from_array`` function.
+    :func:`da.from_array <dask.array.from_array>` function.
 
     Parameters
     ----------
@@ -1965,7 +1965,9 @@ class Array(DaskMethodsMixin):
     def topk(self, k, axis=-1, split_every=None):
         """The top k elements of an array.
 
-        See ``da.topk`` for docstring"""
+        See :func:`dask.array.topk` for docstring.
+
+        """
         from .reductions import topk
 
         return topk(self, k, axis=axis, split_every=split_every)
@@ -1973,7 +1975,9 @@ class Array(DaskMethodsMixin):
     def argtopk(self, k, axis=-1, split_every=None):
         """The indices of the top k elements of an array.
 
-        See ``da.argtopk`` for docstring"""
+        See :func:`dask.array.argtopk` for docstring.
+
+        """
         from .reductions import argtopk
 
         return argtopk(self, k, axis=axis, split_every=split_every)
@@ -2366,7 +2370,7 @@ class Array(DaskMethodsMixin):
 
         Note that this function will attempt to automatically determine the output
         array type before computing it, please refer to the ``meta`` keyword argument
-        in ``map_blocks`` if you expect that the function will not succeed when
+        in :func:`map_blocks <dask.array.core.map_blocks>` if you expect that the function will not succeed when
         operating on 0-d arrays.
 
         Parameters
@@ -2385,7 +2389,7 @@ class Array(DaskMethodsMixin):
             calling the map function.
             Set this to False if your mapping function already does this for you
         **kwargs:
-            Other keyword arguments valid in ``map_blocks``
+            Other keyword arguments valid in :func:`map_blocks <dask.array.core.map_blocks>`.
 
         Examples
         --------
@@ -2587,13 +2591,13 @@ class Array(DaskMethodsMixin):
         return c
 
     def to_delayed(self, optimize_graph=True):
-        """Convert into an array of ``dask.delayed`` objects, one per chunk.
+        """Convert into an array of :class:`dask.delayed.Delayed` objects, one per chunk.
 
         Parameters
         ----------
         optimize_graph : bool, optional
             If True [default], the graph is optimized before converting into
-            ``dask.delayed`` objects.
+            :class:`dask.delayed.Delayed` objects.
 
         See Also
         --------
@@ -2625,14 +2629,14 @@ class Array(DaskMethodsMixin):
 
         See https://zarr.readthedocs.io for details about the format.
 
-        See function ``to_zarr()`` for parameters.
+        See function :func:`dask.array.to_zarr` for parameters.
         """
         return to_zarr(self, *args, **kwargs)
 
     def to_tiledb(self, uri, *args, **kwargs):
         """Save array to the TileDB storage manager
 
-        See function ``to_tiledb()`` for argument documentation.
+        See function :func:`dask.array.to_tiledb` for argument documentation.
 
         See https://docs.tiledb.io for details about the format and engine.
         """
@@ -2712,7 +2716,7 @@ def normalize_chunks(chunks, shape=None, limit=None, dtype=None, previous_chunks
     >>> normalize_chunks(("auto",), shape=(20,), limit=5, dtype='uint8')
     ((5, 5, 5, 5),)
 
-    You can also use byte sizes (see ``dask.utils.parse_bytes``) in place of
+    You can also use byte sizes (see :func:`dask.utils.parse_bytes`) in place of
     "auto" to ask for a particular size
 
     >>> normalize_chunks("1kiB", shape=(2000,), dtype='float32')
@@ -3014,8 +3018,8 @@ def from_array(
         arrays, as Dask can then recognise that they're the same and
         avoid duplicate computations. However, it can also be slow, and if the
         array is not contiguous it is copied for hashing. If the array uses
-        stride tricks (such as ``np.broadcast_to`` or
-        ``skimage.util.view_as_windows``) to have a larger logical
+        stride tricks (such as :func:`numpy.broadcast_to` or
+        :func:`skimage.util.view_as_windows`) to have a larger logical
         than physical size, this copy can cause excessive memory usage.
 
         If you don't need the deduplication provided by hashing, use
@@ -3242,12 +3246,13 @@ def from_zarr(
         Any additional parameters for the storage backend (ignored for local
         paths)
     chunks: tuple of ints or tuples of ints
-        Passed to ``da.from_array``, allows setting the chunks on
+        Passed to :func:`dask.array.from_array`, allows setting the chunks on
         initialisation, if the chunking scheme in the on-disc dataset is not
         optimal for the calculations to follow.
     name : str, optional
          An optional keyname for the array.  Defaults to hashing the input
-    kwargs: passed to ``zarr.Array``.
+    kwargs:
+        Passed to :class:`zarr.core.Array`.
     inline_array : bool, default False
         Whether to inline the zarr Array in the values of the task graph.
         See :meth:`dask.array.from_array` for an explanation.
@@ -3553,8 +3558,8 @@ def unify_chunks(*args, **kwargs):
     Unify chunks across a sequence of arrays
 
     This utility function is used within other common operations like
-    ``map_blocks`` and ``blockwise``.  It is not commonly used by end-users
-    directly.
+    :func:`dask.array.core.map_blocks` and :func:`dask.array.core.blockwise`.
+    It is not commonly used by end-users directly.
 
     Parameters
     ----------
@@ -4043,7 +4048,7 @@ def insert_to_ooc(
         Where to store results too.
     lock: Lock-like or bool, optional
         Whether to lock or with what (default is ``True``,
-        which means a ``threading.Lock`` instance).
+        which means a :class:`threading.Lock` instance).
     region: slice-like, optional
         Where in ``out`` to store ``arr``'s results
         (default is ``None``, meaning all of ``out``).
@@ -5158,7 +5163,7 @@ def to_npy_stack(dirname, x, axis=0):
         |-- info
 
     The ``info`` file stores the dtype, chunks, and axis information of the array.
-    You can load these stacks with the ``da.from_npy_stack`` function.
+    You can load these stacks with the :func:`da.from_npy_stack <dask.array.from_npy_stack>` function.
 
     >>> y = da.from_npy_stack('data/')  # doctest: +SKIP
 
@@ -5191,7 +5196,7 @@ def to_npy_stack(dirname, x, axis=0):
 def from_npy_stack(dirname, mmap_mode="r"):
     """Load dask array from stack of npy files
 
-    See ``da.to_npy_stack`` for docstring
+    See :func:`da.to_npy_stack <dask.array.to_npy_stack>` for docstring.
 
     Parameters
     ----------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -301,6 +301,7 @@ extlinks = {
 #  --Options for sphinx extensions -----------------------------------------------
 
 intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
     "pandas": (
         "https://pandas.pydata.org/pandas-docs/stable/",
         "https://pandas.pydata.org/pandas-docs/stable/objects.inv",
@@ -318,6 +319,7 @@ intersphinx_mapping = {
         "https://zarr.readthedocs.io/en/latest/",
         "https://zarr.readthedocs.io/en/latest/objects.inv",
     ),
+    "skimage": ("https://scikit-image.org/docs/dev/", None),
 }
 
 # Redirects


### PR DESCRIPTION
This is a continuation of #7683. Basically I found everywhere where two backticks were used to make a literal in sphinx but where the content was actually referring to some python object that could be linked to. To do as much as I did required adding the python stdlib and skimage to intersphinx mapping. A couple questions or odd things I noticed are below. I'm happy to change anything that feels "wrong".

1. Do you want references to have the text `da.some_func`? The `da` shortcut is used a lot but obviously the default for API links is to have the full module path (ex. `dask.array.some_func`). I used by best judgement when to go with one versus the other.
2. Dask delayed references are odd. On one hand you are talking about the actual `Delayed` object so you should link to it, but on the other hand users should almost never be created Delayed objects directly and are instead using one of the functions that creates or converts to them. So should docstrings link to the Delayed class docs (not a lot there), the delayed API page, or the higher level Delayed documentation (https://docs.dask.org/en/latest/delayed.html) which may not be what someone reading docstrings cares about?
3. I'm sure this has been brought up before (I'm pretty sure I was one of the people that did it a long time ago), but there are a lot of functions listed in the autosummary section that don't have the related docstring-level documentation. It looks like most of these are internal (kind of) utility functions so not something users need, but I thought I'd bring it up.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
