### PR TITLE
Use BlockwiseDep for map_blocks with block_id or block_info

### DIFF
--- a/dask/array/blockwise.py
+++ b/dask/array/blockwise.py
@@ -49,6 +49,13 @@ def blockwise(
         Dictionary mapping index to function to be applied to chunk sizes
     new_axes : dict, keyword only
         New indexes and their dimension lengths
+    align_arrays : bool, keyword only
+        If ``True`` (the default), the input arrays will be rechunked if
+        necessary to be aligned along shared dimensions. If ``False``, the
+        input chunks will not be altered. If the inputs do not have
+        consistent chunking along a particular dimension, ``adjust_chunks``
+        should be specified to determine the output chunks for that
+        dimension.
 
     Examples
     --------

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -492,9 +492,8 @@ class _BlockInfo:
 def _pass_block_info(func, block_info, block_id, *args, **kwargs):
     """Helper for :func:`dask.array.map_blocks` to pass `block_info` or `block_id`.
 
-    For each element of `keys`, a corresponding element of args is changed
-    to a keyword argument with that key, before all arguments are passed on
-    to `func`.
+    `block_id` must always be passed. If `block_info` is not needed it may be
+    ``None``.
     """
     if has_keyword(func, "block_id"):
         kwargs.update(block_id=block_id)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -435,7 +435,7 @@ def _pass_extra_kwargs(func, keys, *args, **kwargs):
     """Helper for :func:`dask.array.map_blocks` to pass `block_info` or `block_id`.
 
     For each element of `keys`, a corresponding element of args is changed
-    to a keyword argument with that key, before all arguments re passed on
+    to a keyword argument with that key, before all arguments are passed on
     to `func`.
     """
     kwargs.update(zip(keys, args))

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -15,6 +15,9 @@ from itertools import product, zip_longest
 from numbers import Integral, Number
 from operator import add, getitem, mul
 from threading import Lock
+from typing import Dict
+from typing import Mapping as TypingMapping
+from typing import Optional, Tuple
 
 import numpy as np
 from fsspec import get_mapper
@@ -30,7 +33,7 @@ from ..base import (
     persist,
     tokenize,
 )
-from ..blockwise import broadcast_dimensions
+from ..blockwise import BlockwiseDep, BlockwiseDepDict, broadcast_dimensions
 from ..context import globalmethod
 from ..core import quote
 from ..delayed import Delayed, delayed
@@ -431,6 +434,63 @@ def normalize_arg(x):
         return x
 
 
+class _BlockInfoInput:
+    def __init__(
+        self,
+        idx_remap: Tuple[int, ...],
+        shape: Tuple[int, ...],
+        starts: Tuple[int, ...],
+    ) -> None:
+        self.idx_remap = idx_remap
+        self.shape = shape
+        self.starts = starts
+        self.num_chunks = tuple(len(s) - 1 for s in self.starts)
+
+    def __getitem__(self, idx: Tuple[int, ...]) -> dict:
+        location = tuple((idx[c] if c >= 0 else 0) for c in self.idx_remap)
+        return {
+            "shape": self.shape,
+            "num-chunks": self.num_chunks,
+            "array-location": [(s[i], s[i + 1]) for s, i in zip(self.starts, location)],
+            "chunk-location": location,
+        }
+
+
+class _BlockInfoOutput:
+    def __init__(self, shape: Tuple[int, ...], starts: Tuple[int, ...], dtype) -> None:
+        self.shape = shape
+        self.starts = starts
+        self.dtype = dtype
+        self.num_chunks = tuple(len(s) - 1 for s in self.starts)
+
+    def __getitem__(self, idx: Tuple[int, ...]) -> dict:
+        return {
+            "shape": self.shape,
+            "num-chunks": self.num_chunks,
+            "array-location": [(s[i], s[i + 1]) for s, i in zip(self.starts, idx)],
+            "chunk-location": idx,
+            "chunk-shape": tuple(s[i + 1] - s[i] for s, i in zip(self.starts, idx)),
+            "dtype": self.dtype,
+        }
+
+
+class _BlockInfo(BlockwiseDep):
+    """Generate ``block_info`` parameters for :func:`map_blocks` on the fly."""
+
+    def __init__(
+        self, output: _BlockInfoOutput, inputs: TypingMapping[int, _BlockInfoInput]
+    ):
+        self.numblocks = output.num_chunks
+        self.produces_tasks = False
+        self.output = output
+        self.inputs = inputs
+
+    def __getitem__(self, idx: Tuple[int, ...]) -> Dict[Optional[str], dict]:
+        info = {key: array_info[idx] for key, array_info in self.inputs.items()}
+        info[None] = self.output[idx]
+        return info
+
+
 def _pass_extra_kwargs(func, keys, *args, **kwargs):
     """Helper for :func:`dask.array.map_blocks` to pass `block_info` or `block_id`.
 
@@ -729,34 +789,22 @@ def map_blocks(
     # If func has block_id as an argument, construct an array of block IDs and
     # prepare to inject it.
     if has_keyword(func, "block_id"):
-        block_id_name = "block-id-" + out.name
-        block_id_dsk = {
-            (block_id_name,) + block_id: block_id
-            for block_id in product(*(range(len(c)) for c in out.chunks))
-        }
-        block_id_array = Array(
-            block_id_dsk,
-            block_id_name,
-            chunks=tuple((1,) * len(c) for c in out.chunks),
-            dtype=np.object_,
-        )
-        extra_argpairs.append((block_id_array, out_ind))
+        # We don't need to provide any keys to BlockwiseDepDict, because the
+        # default for missing keys is to provide the block ID.
+        extra_argpairs.append((BlockwiseDepDict({}, numblocks=out.numblocks), out_ind))
         extra_names.append("block_id")
 
     # If func has block_info as an argument, construct an array of block info
     # objects and prepare to inject it.
     if has_keyword(func, "block_info"):
-        starts = {}
-        num_chunks = {}
-        shapes = {}
-
+        block_info_inputs = {}
+        out_ind_map = {ind: i for i, ind in enumerate(out_ind)}
         for i, (arg, in_ind) in enumerate(argpairs):
             if in_ind is not None:
-                shapes[i] = arg.shape
                 if drop_axis:
                     # We concatenate along dropped axes, so we need to treat them
                     # as if there is only a single chunk.
-                    starts[i] = [
+                    starts = [
                         (
                             cached_cumsum(arg.chunks[j], initial_zero=True)
                             if ind in out_ind
@@ -764,60 +812,23 @@ def map_blocks(
                         )
                         for j, ind in enumerate(in_ind)
                     ]
-                    num_chunks[i] = tuple(len(s) - 1 for s in starts[i])
                 else:
-                    starts[i] = [
-                        cached_cumsum(c, initial_zero=True) for c in arg.chunks
-                    ]
-                    num_chunks[i] = arg.numblocks
-        out_starts = [cached_cumsum(c, initial_zero=True) for c in out.chunks]
-
-        block_info_name = "block-info-" + out.name
-        block_info_dsk = {}
-        for block_id in product(*(range(len(c)) for c in out.chunks)):
-            # Get position of chunk, indexed by axis labels
-            location = {out_ind[i]: loc for i, loc in enumerate(block_id)}
-            info = {}
-            for i, shape in shapes.items():
-                # Compute chunk key in the array, taking broadcasting into
-                # account. We don't directly know which dimensions are
-                # broadcast, but any dimension with only one chunk can be
-                # treated as broadcast.
-                arr_k = tuple(
-                    location.get(ind, 0) if num_chunks[i][j] > 1 else 0
-                    for j, ind in enumerate(argpairs[i][1])
-                )
-                info[i] = {
-                    "shape": shape,
-                    "num-chunks": num_chunks[i],
-                    "array-location": [
-                        (starts[i][ij][j], starts[i][ij][j + 1])
-                        for ij, j in enumerate(arr_k)
-                    ],
-                    "chunk-location": arr_k,
-                }
-
-            info[None] = {
-                "shape": out.shape,
-                "num-chunks": out.numblocks,
-                "array-location": [
-                    (out_starts[ij][j], out_starts[ij][j + 1])
-                    for ij, j in enumerate(block_id)
-                ],
-                "chunk-location": block_id,
-                "chunk-shape": tuple(
-                    out.chunks[ij][j] for ij, j in enumerate(block_id)
-                ),
-                "dtype": dtype,
-            }
-            block_info_dsk[(block_info_name,) + block_id] = info
-
-        block_info = Array(
-            block_info_dsk,
-            block_info_name,
-            chunks=tuple((1,) * len(c) for c in out.chunks),
-            dtype=np.object_,
+                    starts = [cached_cumsum(c, initial_zero=True) for c in arg.chunks]
+                # Compute index mapping from input to output indices, taking
+                # broadcasting into account. We don't directly know which
+                # dimensions are broadcast, but any dimension with only one
+                # chunk can be treated as broadcast.
+                idx_remap = [
+                    out_ind_map.get(ind, -1) if len(s) > 2 else -1
+                    for s, ind in zip(starts, in_ind)
+                ]
+                block_info_inputs[i] = _BlockInfoInput(idx_remap, arg.shape, starts)
+        block_info_output = _BlockInfoOutput(
+            out.shape,
+            [cached_cumsum(c, initial_zero=True) for c in out.chunks],
+            out.dtype,
         )
+        block_info = _BlockInfo(block_info_output, block_info_inputs)
         extra_argpairs.append((block_info, out_ind))
         extra_names.append("block_info")
 
@@ -836,6 +847,7 @@ def map_blocks(
             *concat(extra_argpairs),
             *concat(argpairs),
             name=out.name,
+            new_axes=new_axes,
             dtype=out.dtype,
             concatenate=True,
             align_arrays=False,

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -167,7 +167,7 @@ class BlockwiseDepDict(BlockwiseDep):
         self.produces_tasks = produces_tasks
 
         # By default, assume 1D shape
-        self.numblocks = numblocks or (len(mapping),)
+        self.numblocks = numblocks if numblocks is not None else (len(mapping),)
 
     def __getitem__(self, idx: Tuple[int, ...]) -> Any:
         return self.mapping[idx]

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -42,7 +42,7 @@ class BlockwiseDep:
     ``Blockwise`` layer.
 
     All ``BlockwiseDep`` instances must define a ``numblocks``
-    attribute to speficy the number of blocks/partitions the
+    attribute to specify the number of blocks/partitions the
     object can support along each dimension. The object should
     also define a ``produces_tasks`` attribute to specify if
     any nested tasks will be passed to the Blockwise function.
@@ -95,6 +95,10 @@ class BlockwiseDep:
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__} {self.numblocks}>"
+
+    @property
+    def ndim(self) -> int:
+        return len(self.numblocks)
 
 
 class BlockwiseDepDict(BlockwiseDep):

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -492,6 +492,47 @@ async def test_blockwise_concatenate(c, s, a, b):
 
 
 @gen_cluster(client=True)
+async def test_map_blocks_block_info(c, s, a, b):
+    da = pytest.importorskip("dask.array")
+    np = pytest.importorskip("numpy")
+
+    def func(x, y, block_info):
+        return np.array([[block_info]], dtype=object)
+
+    a = da.ones((4,), chunks=2)
+    b = da.ones((3, 2), chunks=(1, 2))
+    # optimize_graph=False ensures that the _BlockInfo is serialized to the
+    # scheduler, rather than materialised on the client.
+    blocks = await c.compute(
+        da.map_blocks(func, a, b, meta=np.ndarray((), dtype=object), chunks=(1, 1)),
+        optimize_graph=False,
+    )
+    assert blocks.shape == (3, 2)
+    assert blocks[2, 1] == {
+        0: {
+            "shape": (4,),
+            "num-chunks": (2,),
+            "array-location": [(2, 4)],
+            "chunk-location": (1,),
+        },
+        1: {
+            "shape": (3, 2),
+            "num-chunks": (3, 1),
+            "array-location": [(2, 3), (0, 2)],
+            "chunk-location": (2, 0),
+        },
+        None: {
+            "shape": (3, 2),
+            "num-chunks": (3, 2),
+            "array-location": [(2, 3), (1, 2)],
+            "chunk-location": (2, 1),
+            "chunk-shape": (1, 1),
+            "dtype": object,
+        },
+    }
+
+
+@gen_cluster(client=True)
 async def test_map_partitions_partition_info(c, s, a, b):
     dd = pytest.importorskip("dask.dataframe")
     pd = pytest.importorskip("pandas")


### PR DESCRIPTION
When the `map_blocks` function has `block_id` or `block_info` arguments, it is populated with information about the current block. Previously this was done by synthesizing all the information at the time `map_blocks` was called and stored in a da.Array of objects. Now that Blockwise supports I/O-deps, it's feasible to defer this work until the Blockwise is materialised.

I've made this a draft PR because I have no idea what I'm doing with the serialization and need some advice. I've made a distributed test pass, but after seeing some comments in other PRs I'm aware that there are some subtleties about what may be deserialized on the scheduler (in this case I think an np.ndarray is getting deserialized there).

Maybe a solution would be to have `_BlockInfo.__getitem__` generate a task to generate the block_info, rather than generating it itself? That would also have the advantage that constructing the block info would be left to the workers.

I've extended `da.blockwise` to accept BlockwiseDep arguments (and documented it), so that `map_blocks` can pass them through (since `map_blocks` calls `da.blockwise` rather than `dask.blockwise`). I probably still need to add some direct tests, rather than relying on the coverage from `map_blocks`.

The performance looks good. Here's some benchmark code:
```
#!/usr/bin/env python3

from time import monotonic

import dask.array as da
import numpy as np


def func(a, b, block_info=None):
    return a + b


a = da.from_array(np.arange(200)[np.newaxis, :], chunks=1)
b = da.from_array(np.arange(200)[:, np.newaxis], chunks=1)
t0 = monotonic()
c = da.map_blocks(func, a, b)
t1 = monotonic()
c.compute()
t2 = monotonic()
print(f'Prepare: {t1 - t0:.3f}')
print(f'Compute: {t2 - t1:.3f}')
```

Before:
```
Prepare: 0.446
Compute: 7.457
```

After:
```
Prepare: 0.001
Compute: 6.715
```

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
