### PR TITLE
Implement da.searchsorted

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -133,6 +133,7 @@ try:
         roll,
         rot90,
         round,
+        searchsorted,
         shape,
         squeeze,
         swapaxes,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -750,7 +750,7 @@ def searchsorted(a, v, side="left", sorter=None):
         list(range(1, v.ndim + 1)),
         side,
         None,
-        dtype=dtype,
+        meta=meta,
         adjust_chunks={0: 1},  # one row for each block in a
     )
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -754,9 +754,11 @@ def searchsorted(a, v, side="left", sorter=None):
     # add offsets to take account of the position of each block within the array a
     a_chunk_sizes = np.array(a.chunks[0])
     a_chunk_offsets = np.cumsum(np.insert(a_chunk_sizes, 0, 0))[:-1]
-    a_chunk_offsets = np.expand_dims(a_chunk_offsets, axis=tuple(range(1, v.ndim + 1)))
+    for axis in range(1, v.ndim + 1):
+        # expand_dims in numpy < 1.18 does not support axis tuple, so we need to loop
+        a_chunk_offsets = np.expand_dims(a_chunk_offsets, axis=axis)
     a_offsets = asarray(a_chunk_offsets, chunks=1)
-    out = np.where(out < 0, out, out + a_offsets)
+    out = where(out < 0, out, out + a_offsets)
 
     # combine the results from each block (of a)
     out = out.max(axis=0)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -757,9 +757,7 @@ def searchsorted(a, v, side="left", sorter=None):
     # add offsets to take account of the position of each block within the array a
     a_chunk_sizes = np.array(a.chunks[0])
     a_chunk_offsets = np.cumsum(np.insert(a_chunk_sizes, 0, 0))[:-1]
-    for axis in range(1, v.ndim + 1):
-        # expand_dims in numpy < 1.18 does not support axis tuple, so we need to loop
-        a_chunk_offsets = np.expand_dims(a_chunk_offsets, axis=axis)
+    a_chunk_offsets = a_chunk_offsets[(Ellipsis,) + v.ndim * (np.newaxis,)]
     a_offsets = asarray(a_chunk_offsets, chunks=1)
     out = where(out < 0, out, out + a_offsets)
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -755,8 +755,8 @@ def searchsorted(a, v, side="left", sorter=None):
     )
 
     # add offsets to take account of the position of each block within the array a
-    a_chunk_sizes = np.array(a.chunks[0])
-    a_chunk_offsets = np.cumsum(np.insert(a_chunk_sizes, 0, 0))[:-1]
+    a_chunk_sizes = array_safe((0, *a.chunks[0]), like=meta_from_array(a))
+    a_chunk_offsets = np.cumsum(a_chunk_sizes)[:-1]
     a_chunk_offsets = a_chunk_offsets[(Ellipsis,) + v.ndim * (np.newaxis,)]
     a_offsets = asarray(a_chunk_offsets, chunks=1)
     out = where(out < 0, out, out + a_offsets)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -740,7 +740,7 @@ def searchsorted(a, v, side="left", sorter=None):
         )
 
     # call np.searchsorted for each pair of blocks in a and v
-    dtype = np.searchsorted(np.array([0]), np.array([0])).dtype
+    meta = np.searchsorted(a._meta, v._meta)
     out = blockwise(
         _searchsorted_block,
         list(range(v.ndim + 1)),

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -637,6 +637,9 @@ def test_digitize():
 )
 @pytest.mark.parametrize("side", ["left", "right"])
 def test_searchsorted(a, a_chunks, v, v_chunks, side):
+    a = np.array(a)
+    v = np.array(v)
+
     ad = da.asarray(a, chunks=a_chunks)
     vd = da.asarray(v, chunks=v_chunks)
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -647,7 +647,7 @@ def test_searchsorted(a, a_chunks, v, v_chunks, side):
 
     assert out.shape == vd.shape
     assert out.chunks == vd.chunks
-    np.testing.assert_equal(out, np.searchsorted(a, v, side))
+    assert_eq(out, np.searchsorted(a, v, side))
 
 
 def test_searchsorted_sorter_not_implemented():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -624,6 +624,34 @@ def test_digitize():
             )
 
 
+@pytest.mark.parametrize(
+    "a, a_chunks, v, v_chunks",
+    [
+        [[], 1, [], 1],
+        [[0], 1, [0], 1],
+        [[-10, 0, 10, 20, 30], 3, [11, 30], 2],
+        [[-10, 0, 10, 20, 30], 3, [11, 30, -20, 1, -10, 10, 37, 11], 5],
+        [[-10, 0, 10, 20, 30], 3, [[11, 30, -20, 1, -10, 10, 37, 11]], 5],
+        [[-10, 0, 10, 20, 30], 3, [[7, 0], [-10, 10], [11, -1], [15, 15]], (2, 2)],
+    ],
+)
+@pytest.mark.parametrize("side", ["left", "right"])
+def test_searchsorted(a, a_chunks, v, v_chunks, side):
+    ad = da.asarray(a, chunks=a_chunks)
+    vd = da.asarray(v, chunks=v_chunks)
+
+    out = da.searchsorted(ad, vd, side)
+
+    assert out.shape == vd.shape
+    assert out.chunks == vd.chunks
+    np.testing.assert_equal(out, np.searchsorted(a, v, side))
+
+
+def test_searchsorted_sorter_not_implemented():
+    with pytest.raises(NotImplementedError):
+        da.searchsorted(da.asarray([1, 0]), da.asarray([1]), sorter=da.asarray([1, 0]))
+
+
 def test_histogram():
     # Test for normal, flattened input
     n = 100

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -188,6 +188,7 @@ Top level user functions:
    rollaxis
    rot90
    round
+   searchsorted
    sign
    signbit
    sin


### PR DESCRIPTION
This adds a block implementation of [np.searchsorted](https://numpy.org/doc/stable/reference/generated/numpy.searchsorted.html). 

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
