### PR TITLE
Add dispatch for `union_categoricals`

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -26,6 +26,7 @@ from .dispatch import (
     make_meta,
     meta_nonempty,
     tolist_dispatch,
+    union_categoricals_dispatch,
 )
 from .extensions import make_array_nonempty, make_scalar
 from .utils import (
@@ -280,6 +281,15 @@ def _nonempty_series(s, idx=None):
     if PANDAS_GT_100:
         out.attrs = s.attrs
     return out
+
+
+@union_categoricals_dispatch.register(
+    (pd.DataFrame, pd.Series, pd.Index, pd.Categorical)
+)
+def union_categoricals_pandas(to_union, sort_categories=False, ignore_order=False):
+    return pd.api.types.union_categoricals(
+        to_union, sort_categories=sort_categories, ignore_order=ignore_order
+    )
 
 
 @get_parallel_type.register(pd.Series)

--- a/dask/dataframe/dispatch.py
+++ b/dask/dataframe/dispatch.py
@@ -15,6 +15,7 @@ categorical_dtype_dispatch = Dispatch("CategoricalDtype")
 concat_dispatch = Dispatch("concat")
 tolist_dispatch = Dispatch("tolist")
 is_categorical_dtype_dispatch = Dispatch("is_categorical_dtype")
+union_categoricals_dispatch = Dispatch("union_categoricals")
 
 
 def concat(
@@ -76,3 +77,8 @@ def categorical_dtype(meta, categories=None, ordered=False):
 def tolist(obj):
     func = tolist_dispatch.dispatch(type(obj))
     return func(obj)
+
+
+def union_categoricals(to_union, sort_categories=False, ignore_order=False):
+    func = union_categoricals_dispatch.dispatch(type(to_union[0]))
+    return func(to_union, sort_categories=sort_categories, ignore_order=ignore_order)

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -14,6 +14,7 @@ from .dispatch import (  # noqa: F401
     is_categorical_dtype_dispatch,
     tolist,
     tolist_dispatch,
+    union_categoricals,
 )
 from .utils import is_dataframe_like, is_index_like, is_series_like
 

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -66,7 +66,7 @@ from tlz import first, merge_sorted, unique
 from ..base import is_dask_collection, tokenize
 from ..highlevelgraph import HighLevelGraph
 from ..layers import BroadcastJoinLayer
-from ..utils import Dispatch, M, apply
+from ..utils import M, apply
 from . import methods
 from ._compat import PANDAS_GT_100
 from .core import (
@@ -231,17 +231,6 @@ required = {
 }
 allowed_left = ("inner", "left", "leftsemi", "leftanti")
 allowed_right = ("inner", "right")
-union_categoricals_dispatch = Dispatch("union_categoricals")
-
-
-@union_categoricals_dispatch.register((pd.DataFrame, pd.Series, pd.Index, pd.Categorical))
-def union_categoricals_pandas(to_union, sort_categories=False, ignore_order=False):
-    return pd.api.types.union_categoricals(to_union, sort_categories=sort_categories, ignore_order=ignore_order)
-
-
-def union_categoricals(to_union, sort_categories=False, ignore_order=False):
-    func = union_categoricals_dispatch.dispatch(type(to_union[0]))
-    return func(to_union, sort_categories=sort_categories, ignore_order=ignore_order)
 
 
 def merge_chunk(lhs, *args, **kwargs):
@@ -271,7 +260,7 @@ def merge_chunk(lhs, *args, **kwargs):
 
             dtype = "category"
             if left is not None and right is not None:
-                dtype = union_categoricals(
+                dtype = methods.union_categoricals(
                     [left.astype("category"), right.astype("category")]
                 ).dtype
 

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -66,7 +66,7 @@ from tlz import first, merge_sorted, unique
 from ..base import is_dask_collection, tokenize
 from ..highlevelgraph import HighLevelGraph
 from ..layers import BroadcastJoinLayer
-from ..utils import M, apply
+from ..utils import M, apply, Dispatch
 from . import methods
 from ._compat import PANDAS_GT_100
 from .core import (
@@ -232,9 +232,16 @@ required = {
 }
 allowed_left = ("inner", "left", "leftsemi", "leftanti")
 allowed_right = ("inner", "right")
+merge_chunk_dispatch = Dispatch("merge_chunk")
+
 
 
 def merge_chunk(lhs, *args, **kwargs):
+    func = merge_chunk_dispatch.dispatch(type(lhs))
+    return func(lhs, *args, **kwargs)
+
+@merge_chunk_dispatch.register((pd.DataFrame, pd.Series, pd.Index, pd.Categorical))
+def merge_chunk_pandas(lhs, *args, **kwargs):
     empty_index_dtype = kwargs.pop("empty_index_dtype", None)
     categorical_columns = kwargs.pop("categorical_columns", None)
 

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -66,7 +66,7 @@ from tlz import first, merge_sorted, unique
 from ..base import is_dask_collection, tokenize
 from ..highlevelgraph import HighLevelGraph
 from ..layers import BroadcastJoinLayer
-from ..utils import M, apply, Dispatch
+from ..utils import Dispatch, M, apply
 from . import methods
 from ._compat import PANDAS_GT_100
 from .core import (
@@ -235,10 +235,10 @@ allowed_right = ("inner", "right")
 merge_chunk_dispatch = Dispatch("merge_chunk")
 
 
-
 def merge_chunk(lhs, *args, **kwargs):
     func = merge_chunk_dispatch.dispatch(type(lhs))
     return func(lhs, *args, **kwargs)
+
 
 @merge_chunk_dispatch.register((pd.DataFrame, pd.Series, pd.Index, pd.Categorical))
 def merge_chunk_pandas(lhs, *args, **kwargs):


### PR DESCRIPTION
As part of `merge_chunk` there is `union_categoricals` API that is specific to pandas which will fail for a cudf series, and also cudf doesn't yet have a `cudf.Categorical` support. Both these are the root causes to this issue : https://github.com/rapidsai/cudf/issues/8200, where we cannot merge two categoricals. To resolve this we have introduced a dispatch for `union_categoricals` with which we introduce a work-around for `cudf` in `dask-cudf` backend : https://github.com/rapidsai/cudf/pull/8332.

cc: @VibhuJawa @jakirkham @quasiben 

- [x] Closes https://github.com/rapidsai/cudf/issues/8200
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
