### PR TITLE
Remove unused alphabet variables

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -249,10 +249,6 @@ def rot90(m, k=1, axes=(0, 1)):
         return flip(transpose(m, axes_list), axes[1])
 
 
-alphabet = "abcdefghijklmnopqrstuvwxyz"
-ALPHABET = alphabet.upper()
-
-
 def _tensordot(a, b, axes):
     x = max([a, b], key=lambda x: x.__array_priority__)
     tensordot = tensordot_lookup.dispatch(type(x))


### PR DESCRIPTION
We used to use these alphabet variables in `tensordot`, but after https://github.com/dask/dask/pull/4304 generalized our `tensordot` implementation, `alphabet` and `ALPHABET` are no longer used anywhere in the codebase. This PR removes these unused variables