### PR TITLE
[Review]Repartition before shuffle if the requested partitions are less than input partitions 

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -405,6 +405,14 @@ def rearrange_by_column(
     ignore_index=False,
 ):
     shuffle = shuffle or config.get("shuffle", None) or "disk"
+
+    # if the requested output partitions < input partitions
+    # we repartition first as shuffling overhead is
+    # proportionate to the number of input partitions
+
+    if npartitions is not None and npartitions < df.npartitions:
+        df = df.repartition(npartitions=npartitions)
+
     if shuffle == "disk":
         return rearrange_by_column_disk(df, col, npartitions, compute=compute)
     elif shuffle == "tasks":

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -80,6 +80,19 @@ def test_shuffle_npartitions_task():
     assert set(map(tuple, sc.values.tolist())) == set(map(tuple, df.values.tolist()))
 
 
+def test_shuffle_npartitions_lt_input_partitions_task():
+    df = pd.DataFrame({"x": np.random.random(100)})
+    ddf = dd.from_pandas(df, npartitions=20)
+    s = shuffle(ddf, ddf.x, shuffle="tasks", npartitions=5, max_branch=2)
+    sc = s.compute(scheduler="sync")
+    assert s.npartitions == 5
+    assert set(s.dask).issuperset(set(ddf.dask))
+
+    assert len(sc) == len(df)
+    assert list(s.columns) == list(df.columns)
+    assert set(map(tuple, sc.values.tolist())) == set(map(tuple, df.values.tolist()))
+
+
 @pytest.mark.parametrize("method", ["disk", "tasks"])
 def test_index_with_non_series(method):
     from dask.dataframe.tests.test_multi import list_eq

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -71,7 +71,7 @@ def test_shuffle_npartitions_task():
     df = pd.DataFrame({"x": np.random.random(100)})
     ddf = dd.from_pandas(df, npartitions=10)
     s = shuffle(ddf, ddf.x, shuffle="tasks", npartitions=17, max_branch=4)
-    sc = s.compute(scheduler="sync")
+    sc = s.compute()
     assert s.npartitions == 17
     assert set(s.dask).issuperset(set(ddf.dask))
 
@@ -84,7 +84,7 @@ def test_shuffle_npartitions_lt_input_partitions_task():
     df = pd.DataFrame({"x": np.random.random(100)})
     ddf = dd.from_pandas(df, npartitions=20)
     s = shuffle(ddf, ddf.x, shuffle="tasks", npartitions=5, max_branch=2)
-    sc = s.compute(scheduler="sync")
+    sc = s.compute()
     assert s.npartitions == 5
     assert set(s.dask).issuperset(set(ddf.dask))
 


### PR DESCRIPTION
This PR changes shuffle behavior to repartition before shuffling if requested output partitions is less than input partitions. 
This helps speed up repartitioning quite a bit. 

#### Benchmarks on a 32 core machine 
##### Code
```python
df = dask.datasets.timeseries(end='2010-01-31',partition_freq='12H').persist()
wait(df);

%%time
x = df.shuffle(on=['id'], npartitions=100)
print(len(x))
```
###### Results
| Granularity 	| Input partitions 	| Output Partitions 	| PR 	| Mainline 	| Speed up 	|
|-	|-	|-	|-	|-	|-	|
| 12 H 	| 7366 	| 100 	| 44.3 	| 130 	| 2.93 	|
| 6 H 	| 14732 	| 100 	| 48.3 	| 238 	| 4.93 	|
| 3H 	| 29464 	| 100 	| 55.4 	| 515 	| 9.30 	|


#### Dask Task Graph Visualization

###### PR
<img width="1345" alt="Screen Shot 2021-05-26 at 3 56 55 PM" src="https://user-images.githubusercontent.com/4837571/119742022-c0af6480-be3b-11eb-80d7-1b5b09c26a11.png">


###### Mainline 
<img width="1334" alt="Screen Shot 2021-05-26 at 3 56 30 PM" src="https://user-images.githubusercontent.com/4837571/119742036-c6a54580-be3b-11eb-915c-e77e1d30e352.png">
 



### TODO:
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`


CC: @rjzamora 