### PR TITLE
Automatically show graph visualization in jupyter notebooks

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -809,7 +809,8 @@ class HighLevelGraph(Mapping):
         from .dot import graphviz_to_file
 
         g = to_graphviz(self, **kwargs)
-        return graphviz_to_file(g, filename, format)
+        graphviz_to_file(g, filename, format)
+        return g
 
     def _toposort_layers(self):
         """Sort the layers in a high level graph topologically

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -961,9 +961,9 @@ def test_visualize():
 )
 def test_visualize_highlevelgraph():
     graphviz = pytest.importorskip("graphviz")
-    with tmpdir():
+    with tmpdir() as d:
         x = da.arange(5, chunks=2)
-        viz = x.dask.visualize()
+        viz = x.dask.visualize(filename=os.path.join(d, "mydask.png"))
         # check visualization will automatically render in the jupyter notebook
         assert isinstance(viz, graphviz.dot.Digraph)
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -955,6 +955,19 @@ def test_visualize():
         assert os.path.exists(os.path.join(d, "mydask.png"))
 
 
+@pytest.mark.skipif("not da")
+@pytest.mark.skipif(
+    sys.flags.optimize, reason="graphviz exception with Python -OO flag"
+)
+def test_visualize_highlevelgraph():
+    graphviz = pytest.importorskip("graphviz")
+    with tmpdir():
+        x = da.arange(5, chunks=2)
+        viz = x.dask.visualize()
+        # check visualization will automatically render in the jupyter notebook
+        assert isinstance(viz, graphviz.dot.Digraph)
+
+
 @pytest.mark.skipif(
     sys.flags.optimize, reason="graphviz exception with Python -OO flag"
 )


### PR DESCRIPTION
While talking to @freyam about visualizing high level task graphs, I noticed that `result.dask.visualize()`  / `result.__dask_graph__().visualize()` in a jupyter notebook, it writes the graph visualization to file, but *doesn't* automatically show you the graph in the notebook cell output.

In contrast, when you call `result.visualize()` on a dask computation in a jupyter notebook, you are automatically shown the visualization of the low level task graph in the notebook cell output. This is convenient, and I'd like both visualize functions to have this behaviour.

This PR changes it so we do automatically see the high level graphs visualized in the jupyter notebook.

- [ ] Tests passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
