### PR TITLE
Add `datetime_is_numeric` to dataframe.describe

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2466,9 +2466,18 @@ Dask Name: {name}, {task} tasks"""
         exclude=None,
         datetime_is_numeric=False,
     ):
+        if PANDAS_GT_110:
+            datetime_is_numeric_kwarg = {"datetime_is_numeric": datetime_is_numeric}
+        elif datetime_is_numeric:
+            raise NotImplementedError(
+                "datetime_is_numeric=True is only supported for pandas >= 1.1.0"
+            )
+        else:
+            datetime_is_numeric_kwarg = {}
 
         if self._meta.ndim == 1:
-            meta = self._meta_nonempty.describe(datetime_is_numeric=datetime_is_numeric)
+
+            meta = self._meta_nonempty.describe(**datetime_is_numeric_kwarg)
             output = self._describe_1d(
                 self, split_every, percentiles, percentiles_method, datetime_is_numeric
             )
@@ -2522,7 +2531,7 @@ Dask Name: {name}, {task} tasks"""
         layer = {(name, 0): (methods.describe_aggregate, stats_names)}
         graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
         meta = self._meta_nonempty.describe(
-            include=include, exclude=exclude, datetime_is_numeric=datetime_is_numeric
+            include=include, exclude=exclude, **datetime_is_numeric_kwarg
         )
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
@@ -2652,7 +2661,17 @@ Dask Name: {name}, {task} tasks"""
             (name, 0): (methods.describe_nonnumeric_aggregate, stats_names, colname)
         }
         graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
-        meta = data._meta_nonempty.describe(datetime_is_numeric=datetime_is_numeric)
+
+        if PANDAS_GT_110:
+            datetime_is_numeric_kwarg = {"datetime_is_numeric": datetime_is_numeric}
+        elif datetime_is_numeric:
+            raise NotImplementedError(
+                "datetime_is_numeric=True is only supported for pandas >= 1.1.0"
+            )
+        else:
+            datetime_is_numeric_kwarg = {}
+
+        meta = data._meta_nonempty.describe(**datetime_is_numeric_kwarg)
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
     def _cum_agg(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2464,24 +2464,35 @@ Dask Name: {name}, {task} tasks"""
         percentiles_method="default",
         include=None,
         exclude=None,
+        datetime_is_numeric=False,
     ):
 
         if self._meta.ndim == 1:
-            return self._describe_1d(self, split_every, percentiles, percentiles_method)
+            return self._describe_1d(
+                self, split_every, percentiles, percentiles_method, datetime_is_numeric
+            )
         elif (include is None) and (exclude is None):
-            data = self._meta.select_dtypes(include=[np.number, np.timedelta64])
+            include = [np.number, np.timedelta64]
+            if datetime_is_numeric:
+                include.append(np.datetime64)
+            data = self._meta.select_dtypes(include=include)
 
             # when some numerics/timedeltas are found, by default keep them
             if len(data.columns) == 0:
                 chosen_columns = self._meta.columns
             else:
-                # check if there are timedelta or boolean columns
-                bools_and_timedeltas = self._meta.select_dtypes(
-                    include=[np.timedelta64, "bool"]
-                )
-                if len(bools_and_timedeltas.columns) == 0:
+                # check if there are timedelta, boolean, or datetime columns
+                include = [np.timedelta64, bool]
+                if datetime_is_numeric:
+                    include.append(np.datetime64)
+                bools_and_times = self._meta.select_dtypes(include=include)
+                if len(bools_and_times.columns) == 0:
                     return self._describe_numeric(
-                        self, split_every, percentiles, percentiles_method
+                        self,
+                        split_every,
+                        percentiles,
+                        percentiles_method,
+                        datetime_is_numeric,
                     )
                 else:
                     chosen_columns = data.columns
@@ -2495,7 +2506,11 @@ Dask Name: {name}, {task} tasks"""
 
         stats = [
             self._describe_1d(
-                self[col_idx], split_every, percentiles, percentiles_method
+                self[col_idx],
+                split_every,
+                percentiles,
+                percentiles_method,
+                datetime_is_numeric,
             )
             for col_idx in chosen_columns
         ]
@@ -2504,14 +2519,23 @@ Dask Name: {name}, {task} tasks"""
         name = "describe--" + tokenize(self, split_every)
         layer = {(name, 0): (methods.describe_aggregate, stats_names)}
         graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
-        meta = self._meta_nonempty.describe(include=include, exclude=exclude)
+        meta = self._meta_nonempty.describe(
+            include=include, exclude=exclude, datetime_is_numeric=datetime_is_numeric
+        )
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
     def _describe_1d(
-        self, data, split_every=False, percentiles=None, percentiles_method="default"
+        self,
+        data,
+        split_every=False,
+        percentiles=None,
+        percentiles_method="default",
+        datetime_is_numeric=False,
     ):
         if is_bool_dtype(data._meta):
-            return self._describe_nonnumeric_1d(data, split_every=split_every)
+            return self._describe_nonnumeric_1d(
+                data, split_every=split_every, datetime_is_numeric=datetime_is_numeric
+            )
         elif is_numeric_dtype(data._meta):
             return self._describe_numeric(
                 data,
@@ -2527,8 +2551,18 @@ Dask Name: {name}, {task} tasks"""
                 percentiles_method=percentiles_method,
                 is_timedelta_column=True,
             )
+        elif is_datetime64_any_dtype(data._meta) and datetime_is_numeric:
+            return self._describe_numeric(
+                data.dropna(),
+                split_every=split_every,
+                percentiles=percentiles,
+                percentiles_method=percentiles_method,
+                is_datetime_column=True,
+            )
         else:
-            return self._describe_nonnumeric_1d(data, split_every=split_every)
+            return self._describe_nonnumeric_1d(
+                data, split_every=split_every, datetime_is_numeric=datetime_is_numeric
+            )
 
     def _describe_numeric(
         self,
@@ -2537,9 +2571,13 @@ Dask Name: {name}, {task} tasks"""
         percentiles=None,
         percentiles_method="default",
         is_timedelta_column=False,
+        is_datetime_column=False,
     ):
 
-        num = data._get_numeric_data()
+        if not is_datetime_column:
+            num = data._get_numeric_data()
+        else:
+            num = pd.to_numeric(data)
 
         if data.ndim == 2 and len(num.columns) == 0:
             raise ValueError("DataFrame contains only non-numeric data.")
@@ -2573,13 +2611,16 @@ Dask Name: {name}, {task} tasks"""
                 stats_names,
                 colname,
                 is_timedelta_column,
+                is_datetime_column,
             )
         }
         graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
         meta = num._meta_nonempty.describe()
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
-    def _describe_nonnumeric_1d(self, data, split_every=False):
+    def _describe_nonnumeric_1d(
+        self, data, split_every=False, datetime_is_numeric=False
+    ):
         vcounts = data.value_counts(split_every=split_every)
         count_nonzero = vcounts[vcounts != 0]
         count_unique = count_nonzero.size
@@ -2593,11 +2634,6 @@ Dask Name: {name}, {task} tasks"""
             vcounts._head(1, npartitions=1, compute=False, safe=False),
         ]
 
-        if is_datetime64_any_dtype(data._meta):
-            min_ts = data.dropna().astype("i8").min(split_every=split_every)
-            max_ts = data.dropna().astype("i8").max(split_every=split_every)
-            stats.extend([min_ts, max_ts])
-
         stats_names = [(s._name, 0) for s in stats]
         colname = data._meta.name
 
@@ -2606,7 +2642,7 @@ Dask Name: {name}, {task} tasks"""
             (name, 0): (methods.describe_nonnumeric_aggregate, stats_names, colname)
         }
         graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
-        meta = data._meta_nonempty.describe()
+        meta = data._meta_nonempty.describe(datetime_is_numeric=datetime_is_numeric)
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
     def _cum_agg(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2466,6 +2466,7 @@ Dask Name: {name}, {task} tasks"""
         exclude=None,
         datetime_is_numeric=False,
     ):
+
         if PANDAS_GT_110:
             datetime_is_numeric_kwarg = {"datetime_is_numeric": datetime_is_numeric}
         elif datetime_is_numeric:
@@ -2477,7 +2478,12 @@ Dask Name: {name}, {task} tasks"""
 
         if self._meta.ndim == 1:
 
-            meta = self._meta_nonempty.describe(**datetime_is_numeric_kwarg)
+            meta = self._meta_nonempty.describe(
+                percentiles=percentiles,
+                include=include,
+                exclude=exclude,
+                **datetime_is_numeric_kwarg,
+            )
             output = self._describe_1d(
                 self, split_every, percentiles, percentiles_method, datetime_is_numeric
             )

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2468,9 +2468,12 @@ Dask Name: {name}, {task} tasks"""
     ):
 
         if self._meta.ndim == 1:
-            return self._describe_1d(
+            meta = self._meta_nonempty.describe(datetime_is_numeric=datetime_is_numeric)
+            output = self._describe_1d(
                 self, split_every, percentiles, percentiles_method, datetime_is_numeric
             )
+            output._meta = meta
+            return output
         elif (include is None) and (exclude is None):
             _include = [np.number, np.timedelta64]
             if datetime_is_numeric:

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -202,13 +202,13 @@ def describe_numeric_aggregate(
         q = q.apply(lambda x: pd.to_timedelta(x))
 
     if is_datetime_col:
-        mean = pd.to_datetime(mean)
+        # mean is not implemented for datetime
         min = pd.to_datetime(min)
         max = pd.to_datetime(max)
         q = q.apply(lambda x: pd.to_datetime(x))
 
     if is_datetime_col:
-        part1 = typ([count, mean, min], index=["count", "mean", "min"])
+        part1 = typ([count, min], index=["count", "min"])
     else:
         part1 = typ([count, mean, std, min], index=["count", "mean", "std", "min"])
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -183,7 +183,9 @@ def describe_aggregate(values):
     return pd.concat(values, axis=1, sort=False).reindex(names)
 
 
-def describe_numeric_aggregate(stats, name=None, is_timedelta_col=False):
+def describe_numeric_aggregate(
+    stats, name=None, is_timedelta_col=False, is_datetime_col=False
+):
     assert len(stats) == 6
     count, mean, std, min, q, max = stats
 
@@ -198,6 +200,13 @@ def describe_numeric_aggregate(stats, name=None, is_timedelta_col=False):
         min = pd.to_timedelta(min)
         max = pd.to_timedelta(max)
         q = q.apply(lambda x: pd.to_timedelta(x))
+
+    if is_datetime_col:
+        mean = pd.to_datetime(mean)
+        std = pd.NaT
+        min = pd.to_datetime(min)
+        max = pd.to_datetime(max)
+        q = q.apply(lambda x: pd.to_datetime(x))
 
     part1 = typ([count, mean, std, min], index=["count", "mean", "std", "min"])
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -203,12 +203,14 @@ def describe_numeric_aggregate(
 
     if is_datetime_col:
         mean = pd.to_datetime(mean)
-        std = pd.NaT
         min = pd.to_datetime(min)
         max = pd.to_datetime(max)
         q = q.apply(lambda x: pd.to_datetime(x))
 
-    part1 = typ([count, mean, std, min], index=["count", "mean", "std", "min"])
+    if is_datetime_col:
+        part1 = typ([count, mean, min], index=["count", "mean", "min"])
+    else:
+        part1 = typ([count, mean, std, min], index=["count", "mean", "std", "min"])
 
     q.index = ["{0:g}%".format(l * 100) for l in tolist(q.index)]
     if is_series_like(q) and typ != type(q):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -495,6 +495,41 @@ def test_describe(include, exclude, percentiles, subset):
             )
 
 
+def test_describe_without_datetime_is_numeric():
+    data = {
+        "a": ["aaa", "bbb", "bbb", None, None, "zzz"] * 2,
+        "c": [None, 0, 1, 2, 3, 4] * 2,
+        "d": [None, 0, 1] * 4,
+        "e": [
+            pd.Timestamp("2017-05-09 00:00:00.006000"),
+            pd.Timestamp("2017-05-09 00:00:00.006000"),
+            pd.Timestamp("2017-05-09 07:56:23.858694"),
+            pd.Timestamp("2017-05-09 05:59:58.938999"),
+            None,
+            None,
+        ]
+        * 2,
+    }
+    # Arrange
+    df = pd.DataFrame(data)
+    ddf = dd.from_pandas(df, 2)
+
+    # Assert
+    assert_eq(ddf.describe(), df.describe())
+
+    # Check series
+    for col in ["a", "c"]:
+        assert_eq(df[col].describe(), ddf[col].describe())
+
+    with pytest.warns(
+        FutureWarning,
+        match=(
+            "Treating datetime data as categorical rather than numeric in `.describe` is deprecated"
+        ),
+    ):
+        assert_eq(df.e.describe(), ddf.e.describe())
+
+
 def test_describe_empty():
     df_none = pd.DataFrame({"A": [None, None]})
     ddf_none = dd.from_pandas(df_none, 2)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -465,21 +465,28 @@ def test_describe(include, exclude, percentiles, subset):
 
     ddf = dd.from_pandas(df, 2)
 
+    if PANDAS_GT_110:
+        datetime_is_numeric = True
+        datetime_is_numeric_kwarg = {"datetime_is_numeric": True}
+    else:
+        datetime_is_numeric = None
+        datetime_is_numeric_kwarg = {}
+
     # Act
     actual = ddf.describe(
         include=include,
         exclude=exclude,
         percentiles=percentiles,
-        datetime_is_numeric=True,
+        **datetime_is_numeric_kwarg,
     )
     expected = df.describe(
         include=include,
         exclude=exclude,
         percentiles=percentiles,
-        datetime_is_numeric=True,
+        **datetime_is_numeric_kwarg,
     )
 
-    if "e" in expected:
+    if "e" in expected and datetime_is_numeric:
         expected.at["mean", "e"] = np.nan
         expected.dropna(how="all", inplace=True)
 
@@ -489,12 +496,12 @@ def test_describe(include, exclude, percentiles, subset):
     if subset is None:
         for col in ["a", "c", "e", "g"]:
             expected = df[col].describe(
-                include=include, exclude=exclude, datetime_is_numeric=True
+                include=include, exclude=exclude, **datetime_is_numeric_kwarg
             )
-            if col == "e":
+            if col == "e" and datetime_is_numeric:
                 expected.drop("mean", inplace=True)
             actual = ddf[col].describe(
-                include=include, exclude=exclude, datetime_is_numeric=True
+                include=include, exclude=exclude, **datetime_is_numeric_kwarg
             )
             assert_eq(expected, actual)
 
@@ -525,13 +532,21 @@ def test_describe_without_datetime_is_numeric():
     for col in ["a", "c"]:
         assert_eq(df[col].describe(), ddf[col].describe())
 
-    with pytest.warns(
-        FutureWarning,
-        match=(
-            "Treating datetime data as categorical rather than numeric in `.describe` is deprecated"
-        ),
-    ):
+    if PANDAS_GT_110:
+        with pytest.warns(
+            FutureWarning,
+            match=(
+                "Treating datetime data as categorical rather than numeric in `.describe` is deprecated"
+            ),
+        ):
+            ddf.e.describe()
+    else:
         assert_eq(df.e.describe(), ddf.e.describe())
+        with pytest.raises(
+            NotImplementedError,
+            match="datetime_is_numeric=True is only supported for pandas >= 1.1.0",
+        ):
+            ddf.e.describe(datetime_is_numeric=True)
 
 
 def test_describe_empty():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -415,10 +415,6 @@ def test_describe_numeric(method, test_values):
     assert_eq(df.describe(), ddf.describe(split_every=2, percentiles_method=method))
 
 
-# TODO(pandas) deal with this describe warning instead of ignoring
-@pytest.mark.filterwarnings(
-    "ignore:Treating datetime data as categorical|casting:FutureWarning"
-)
 @pytest.mark.parametrize(
     "include,exclude,percentiles,subset",
     [
@@ -470,8 +466,18 @@ def test_describe(include, exclude, percentiles, subset):
     ddf = dd.from_pandas(df, 2)
 
     # Act
-    desc_ddf = ddf.describe(include=include, exclude=exclude, percentiles=percentiles)
-    desc_df = df.describe(include=include, exclude=exclude, percentiles=percentiles)
+    desc_ddf = ddf.describe(
+        include=include,
+        exclude=exclude,
+        percentiles=percentiles,
+        datetime_is_numeric=True,
+    )
+    desc_df = df.describe(
+        include=include,
+        exclude=exclude,
+        percentiles=percentiles,
+        datetime_is_numeric=True,
+    )
 
     # Assert
     assert_eq(desc_ddf, desc_df)
@@ -480,8 +486,12 @@ def test_describe(include, exclude, percentiles, subset):
     if subset is None:
         for col in ["a", "c", "e", "g"]:
             assert_eq(
-                df[col].describe(include=include, exclude=exclude),
-                ddf[col].describe(include=include, exclude=exclude),
+                df[col].describe(
+                    include=include, exclude=exclude, datetime_is_numeric=True
+                ),
+                ddf[col].describe(
+                    include=include, exclude=exclude, datetime_is_numeric=True
+                ),
             )
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -466,10 +466,8 @@ def test_describe(include, exclude, percentiles, subset):
     ddf = dd.from_pandas(df, 2)
 
     if PANDAS_GT_110:
-        datetime_is_numeric = True
         datetime_is_numeric_kwarg = {"datetime_is_numeric": True}
     else:
-        datetime_is_numeric = None
         datetime_is_numeric_kwarg = {}
 
     # Act
@@ -486,7 +484,7 @@ def test_describe(include, exclude, percentiles, subset):
         **datetime_is_numeric_kwarg,
     )
 
-    if "e" in expected and datetime_is_numeric:
+    if "e" in expected and datetime_is_numeric_kwarg:
         expected.at["mean", "e"] = np.nan
         expected.dropna(how="all", inplace=True)
 
@@ -498,7 +496,7 @@ def test_describe(include, exclude, percentiles, subset):
             expected = df[col].describe(
                 include=include, exclude=exclude, **datetime_is_numeric_kwarg
             )
-            if col == "e" and datetime_is_numeric:
+            if col == "e" and datetime_is_numeric_kwarg:
                 expected.drop("mean", inplace=True)
             actual = ddf[col].describe(
                 include=include, exclude=exclude, **datetime_is_numeric_kwarg

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -466,33 +466,37 @@ def test_describe(include, exclude, percentiles, subset):
     ddf = dd.from_pandas(df, 2)
 
     # Act
-    desc_ddf = ddf.describe(
+    actual = ddf.describe(
         include=include,
         exclude=exclude,
         percentiles=percentiles,
         datetime_is_numeric=True,
     )
-    desc_df = df.describe(
+    expected = df.describe(
         include=include,
         exclude=exclude,
         percentiles=percentiles,
         datetime_is_numeric=True,
     )
 
-    # Assert
-    assert_eq(desc_ddf, desc_df)
+    if "e" in expected:
+        expected.at["mean", "e"] = np.nan
+        expected.dropna(how="all", inplace=True)
+
+    assert_eq(actual, expected)
 
     # Check series
     if subset is None:
         for col in ["a", "c", "e", "g"]:
-            assert_eq(
-                df[col].describe(
-                    include=include, exclude=exclude, datetime_is_numeric=True
-                ),
-                ddf[col].describe(
-                    include=include, exclude=exclude, datetime_is_numeric=True
-                ),
+            expected = df[col].describe(
+                include=include, exclude=exclude, datetime_is_numeric=True
             )
+            if col == "e":
+                expected.drop("mean", inplace=True)
+            actual = ddf[col].describe(
+                include=include, exclude=exclude, datetime_is_numeric=True
+            )
+            assert_eq(expected, actual)
 
 
 def test_describe_without_datetime_is_numeric():


### PR DESCRIPTION
Start working on adding `datetime_is_numeric` to the `dataframe.describe` method.  

Part of https://github.com/dask/dask/issues/7100
Closes #6434

Update, this is getting closer. The last remaining issue is that the means of `np.datetime` are not correct.

My current thinking is that  somehow the  empty rows are being counted 