### PR TITLE
Remove abstract tokens from graph keys in rewrite_blockwise

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1405,7 +1405,7 @@ def rewrite_blockwise(inputs):
             new_indices.append(x)
 
     sub = {blockwise_token(k): blockwise_token(v) for k, v in sub.items()}
-    dsk = {k: subs(v, sub) for k, v in dsk.items()}
+    dsk = {k: subs(v, sub) for k, v in dsk.items() if k not in sub.keys()}
 
     indices_check = {k for k, v in indices if v is not None}
     numblocks = toolz.merge([inp.numblocks for inp in inputs.values()])

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -354,6 +354,8 @@ def test_blockwise_dataframe_io(c, tmpdir, io, fuse):
 
 
 def test_blockwise_fusion_after_compute(c):
+    # See: https://github.com/dask/dask/issues/7720
+
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
 
@@ -362,8 +364,9 @@ def test_blockwise_fusion_after_compute(c):
     series = dd.from_pandas(df, npartitions=2)["x"]
     result = series < 3
 
-    # Trigger a optimization of the `series` graph
-    # (which `result` depends on), then compute result
+    # Trigger an optimization of the `series` graph
+    # (which `result` depends on), then compute `result`.
+    # This is essentially a test of `rewrite_blockwise`.
     series_len = len(series)
     assert series_len == 15
     assert df.x[result.compute()].sum() == 15


### PR DESCRIPTION
Fixes a `rewrite_blockwise` bug that shows up when the same graph is optimized multiple times for different output keys.

- [x] Closes #7720
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
