### PR TITLE
Add `autofunction` for `unify_chunks` in API docs

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -213,7 +213,6 @@ Top level user functions:
    tril
    triu
    trunc
-   unify_chunks
    unique
    unravel_index
    var
@@ -397,6 +396,7 @@ Internal functions
 .. autosummary::
    blockwise
    normalize_chunks
+   unify_chunks
 
 
 Other functions
@@ -761,6 +761,7 @@ Other functions
 .. autofunction:: map_blocks
 .. autofunction:: blockwise
 .. autofunction:: normalize_chunks
+.. autofunction:: unify_chunks
 
 .. currentmodule:: dask.array
 


### PR DESCRIPTION
This PR adds ensures that the `unify_chunks` docstring is rendered as part of the array API docs. Currently there's just an `autosummary` entry. 