### PR TITLE
Bugfix: dask.dataframe.utils.make_meta() allow dict or list/tuple inputs

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -67,6 +67,16 @@ def make_meta_index(x, index=None):
     return x[0:0]
 
 
+@make_meta.register(dict)
+def make_meta_from_dict(x, index=None):
+    return pd.DataFrame.from_dict(x)
+
+
+@make_meta.register((list, tuple))
+def make_meta_from_list(x, index=None):
+    return pd.DataFrame({col: pd.Series([], dtype=dtype) for col, dtype in x})
+
+
 meta_object_types = (pd.Series, pd.DataFrame, pd.Index, pd.MultiIndex)
 try:
     import scipy.sparse as sp

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -67,17 +67,15 @@ def make_meta_index(x, index=None):
     return x[0:0]
 
 
-@make_meta.register(dict)
-def make_meta_from_dict(x, index=None):
-    return pd.DataFrame.from_dict(x)
-
-
-@make_meta.register((list, tuple))
-def make_meta_from_list(x, index=None):
-    return pd.DataFrame({col: pd.Series([], dtype=dtype) for col, dtype in x})
-
-
-meta_object_types = (pd.Series, pd.DataFrame, pd.Index, pd.MultiIndex)
+meta_object_types = (
+    pd.Series,
+    pd.DataFrame,
+    pd.Index,
+    pd.MultiIndex,
+    dict,
+    list,
+    tuple,
+)
 try:
     import scipy.sparse as sp
 
@@ -86,6 +84,7 @@ except ImportError:
     pass
 
 
+@make_meta.register((dict, list, tuple))
 @make_meta_obj.register(meta_object_types)
 def make_meta_object(x, index=None):
     """Create an empty pandas object containing the desired metadata.


### PR DESCRIPTION
The `dask.dataframe.make_meta()` function has lost the ability to accept dictionary or list/tuple inputs (this was possible before https://github.com/dask/dask/pull/7503).

This PR aims to restore that functionality, and add tests to ensure that we keep it.

- [x] Closes https://github.com/dask/dask/issues/7731
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
