### PR TITLE
Easier link for subscribing to the Google calendar

### DIFF
--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -33,7 +33,7 @@ Conversation happens in the following places:
 
     You can subscribe to this calendar to be notified of changes:
 
-    * `Google Calendar <https://calendar.google.com/calendar/embed?src=4l0vts0c1cgdbq5jhcogj55sfs%40group.calendar.google.com>`__
+    * `Google Calendar <https://calendar.google.com/calendar/u/0?cid=NGwwdnRzMGMxY2dkYnE1amhjb2dqNTVzZnNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ>`__
     * `iCal <https://calendar.google.com/calendar/ical/4l0vts0c1cgdbq5jhcogj55sfs%40group.calendar.google.com/public/basic.ics>`__
 
 .. _`Stack Overflow with the #dask tag`: https://stackoverflow.com/questions/tagged/dask


### PR DESCRIPTION
This PR updates the link for subscribing to the Dask google calendar to one that's easier for people to use. I've always found it super awkward to get the information from the Dask calendar on this page into my actual calendar with only the old link.

- [x] Closes https://github.com/dask/dask.github.io/issues/50
- [ ] ~~Tests added / passed~~
- [ ] ~~Passes `black dask` / `flake8 dask` / `isort dask`~~
