### PR TITLE
Show failing tests summary in CI

### DIFF
--- a/continuous_integration/scripts/run_tests.sh
+++ b/continuous_integration/scripts/run_tests.sh
@@ -10,7 +10,7 @@ if [[ $COVERAGE == 'true' ]]; then
     export XTRATESTARGS="--cov=dask --cov-report=xml $XTRATESTARGS"
 fi
 
-echo "py.test dask --runslow -rfE $XTRATESTARGS"
-py.test dask --runslow -rfE $XTRATESTARGS
+echo "py.test dask --runslow $XTRATESTARGS"
+py.test dask --runslow $XTRATESTARGS
 
 set +e

--- a/continuous_integration/scripts/run_tests.sh
+++ b/continuous_integration/scripts/run_tests.sh
@@ -10,7 +10,7 @@ if [[ $COVERAGE == 'true' ]]; then
     export XTRATESTARGS="--cov=dask --cov-report=xml $XTRATESTARGS"
 fi
 
-echo "py.test dask --runslow $XTRATESTARGS"
-py.test dask --runslow $XTRATESTARGS
+echo "py.test dask --runslow -rfE $XTRATESTARGS"
+py.test dask --runslow -rfE $XTRATESTARGS
 
 set +e

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ test = pytest
 markers:
   network: Test requires an internet connection
   slow: Skipped unless --runslow passed
-addopts = -v -rsx --durations=10
+addopts = -v -rsxfE --durations=10
 filterwarnings =
     # From Cython-1753
     ignore:can't resolve:ImportWarning


### PR DESCRIPTION
This PR adds the `-rfE` command line flag to our pytest call would print a short summary of all the failing test names at the very bottom of the log.

Whenever I have tests fail in the CI, I'm often frustrated by how long it takes to figure out which tests were the ones that failed. You have to open the CI log then scroll back a long way: past the slowest test duration summary, past the warnings, past the xfail test information, and *then* you can see the failing test results.

- [ ] ~~Closes #xxxx~~
- [ ] ~~Tests added / passed~~ This combination of pytest command line flags works as expected locally. I don't think there's an easy way to test it on the CI without merging a PR.
- [ ] ~~Passes `black dask` / `flake8 dask` / `isort dask`~~
