### PR TITLE
Do not return delayed object from to_zarr

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3302,8 +3302,7 @@ def to_zarr(
         paths)
     overwrite: bool
         If given array already exists, overwrite=False will cause an error,
-        where overwrite=True will replace the existing data.  Note that this
-        check is done at computation time, not during graph creation.
+        where overwrite=True will replace the existing data.
     compute: bool
         See :func:`~dask.array.store` for more details.
     return_stored: bool
@@ -3358,14 +3357,7 @@ def to_zarr(
 
     chunks = [c[0] for c in arr.chunks]
 
-    # The zarr.create function has the side-effect of immediately
-    # creating metadata on disk.  This may not be desired,
-    # particularly if compute=False.  The caller may be creating many
-    # arrays on a slow filesystem, with the desire that any I/O be
-    # sharded across workers (not done serially on the originating
-    # machine).  Or the caller may decide later to not to do this
-    # computation, and so nothing should be written to disk.
-    z = delayed(zarr.create)(
+    z = zarr.create(
         shape=arr.shape,
         chunks=chunks,
         dtype=arr.dtype,

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4235,18 +4235,6 @@ def test_zarr_return_stored(compute):
         assert a2.chunks == a.chunks
 
 
-def test_to_zarr_delayed_creates_no_metadata():
-    pytest.importorskip("zarr")
-    with tmpdir() as d:
-        a = da.from_array([42])
-        result = a.to_zarr(d, compute=False)
-        assert not os.listdir(d)  # No .zarray file
-        # Verify array still created upon compute.
-        result.compute()
-        a2 = da.from_zarr(d)
-        assert_eq(a, a2)
-
-
 def test_zarr_inline_array():
     zarr = pytest.importorskip("zarr")
     a = zarr.array([1, 2, 3])


### PR DESCRIPTION
The change to wrap zarr.create in dask.delayed was originally made by me in #5797.  I did this when I was still new to dask, and when it made sense (to me) to defer any file operations, including the initial metadata creation, until run time.

After having worked with the dask ecosystem for a while, I see that this is not the typical paradign for I/O.  A call to to_zarr should immediately create the zarr metadata, so as not to surprise others.


- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
