### PR TITLE
Fixing calling `.visualize()` with `filename=None`

### DIFF
--- a/dask/dot.py
+++ b/dask/dot.py
@@ -275,9 +275,8 @@ def graphviz_to_file(g, filename, format):
     fmts = [".png", ".pdf", ".dot", ".svg", ".jpeg", ".jpg"]
 
     if format is None and filename is None:
-        format = "png"
-
-    if format is None and any(filename.lower().endswith(fmt) for fmt in fmts):
+        pass
+    elif format is None and any(filename.lower().endswith(fmt) for fmt in fmts):
         filename, format = os.path.splitext(filename)
         format = format[1:].lower()
 

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -274,9 +274,11 @@ def dot_graph(dsk, filename="mydask", format=None, **kwargs):
 def graphviz_to_file(g, filename, format):
     fmts = [".png", ".pdf", ".dot", ".svg", ".jpeg", ".jpg"]
 
-    if format is None and filename is None:
-        pass
-    elif format is None and any(filename.lower().endswith(fmt) for fmt in fmts):
+    if (
+        format is None
+        and filename is not None
+        and any(filename.lower().endswith(fmt) for fmt in fmts)
+    ):
         filename, format = os.path.splitext(filename)
         format = format[1:].lower()
 

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -281,6 +281,9 @@ def graphviz_to_file(g, filename, format):
         filename, format = os.path.splitext(filename)
         format = format[1:].lower()
 
+    if format is None:
+        format = "png"
+
     data = g.pipe(format=format)
     if not data:
         raise RuntimeError(

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -273,12 +273,13 @@ def dot_graph(dsk, filename="mydask", format=None, **kwargs):
 
 def graphviz_to_file(g, filename, format):
     fmts = [".png", ".pdf", ".dot", ".svg", ".jpeg", ".jpg"]
+
+    if format is None and filename is None:
+        format = "png"
+
     if format is None and any(filename.lower().endswith(fmt) for fmt in fmts):
         filename, format = os.path.splitext(filename)
         format = format[1:].lower()
-
-    if format is None:
-        format = "png"
 
     data = g.pipe(format=format)
     if not data:
@@ -292,7 +293,7 @@ def graphviz_to_file(g, filename, format):
 
     display_cls = _get_display_cls(format)
 
-    if not filename:
+    if filename is None:
         return display_cls(data=data)
 
     full_filename = ".".join([filename, format])

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -809,7 +809,8 @@ class HighLevelGraph(Mapping):
         from .dot import graphviz_to_file
 
         g = to_graphviz(self, **kwargs)
-        return graphviz_to_file(g, filename, format)
+        graphviz_to_file(g, filename, format)
+        return g
 
     def _toposort_layers(self):
         """Sort the layers in a high level graph topologically

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -965,11 +965,11 @@ def test_visualize_no_filename(monkeypatch):
 
     x = da.arange(10)
 
-    test_list = []
+    was_mock_function_called = []
     _mock_get_display_cls = dask.dot._get_display_cls
 
     def mock_fx(format):
-        test_list.append(True)
+        was_mock_function_called.append(True)
         return _mock_get_display_cls(format)
 
     # using monkey patching to ensure dask.dot._get_display_cls gets called
@@ -977,7 +977,7 @@ def test_visualize_no_filename(monkeypatch):
 
     x.visualize(filename=None)
 
-    assert True in test_list
+    assert True in was_mock_function_called
 
 
 @pytest.mark.skipif("not da")

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -972,8 +972,11 @@ def test_visualize_no_filename(monkeypatch):
         test_list.append(True)
         return _mock_get_display_cls(format)
 
+    # using monkey patching to ensure dask.dot._get_display_cls gets called
     monkeypatch.setattr(dask.dot, "_get_display_cls", mock_fx)
-    visualize(x, filename=None)
+
+    x.visualize(filename=None)
+
     assert True in test_list
 
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -955,6 +955,19 @@ def test_visualize():
         assert os.path.exists(os.path.join(d, "mydask.png"))
 
 
+@pytest.mark.skipif("not da")
+@pytest.mark.skipif(
+    sys.flags.optimize, reason="graphviz exception with Python -OO flag"
+)
+def test_visualize_highlevelgraph():
+    graphviz = pytest.importorskip("graphviz")
+    with tmpdir() as d:
+        x = da.arange(5, chunks=2)
+        viz = x.dask.visualize(filename=os.path.join(d, "mydask.png"))
+        # check visualization will automatically render in the jupyter notebook
+        assert isinstance(viz, graphviz.dot.Digraph)
+
+
 @pytest.mark.skipif(
     sys.flags.optimize, reason="graphviz exception with Python -OO flag"
 )

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -933,7 +933,7 @@ def test_compute_nested():
 @pytest.mark.skipif(
     sys.flags.optimize, reason="graphviz exception with Python -OO flag"
 )
-def test_visualize():
+def test_visualize(monkeypatch):
     pytest.importorskip("graphviz")
     with tmpdir() as d:
         x = da.arange(5, chunks=2)
@@ -953,6 +953,17 @@ def test_visualize():
         x = Tuple(dsk, ["a", "b", "c"])
         visualize(x, filename=os.path.join(d, "mydask.png"))
         assert os.path.exists(os.path.join(d, "mydask.png"))
+
+        test_list = []
+        _mock_get_display_cls = dask.dot._get_display_cls
+
+        def mock_fx(format):
+            test_list.append(True)
+            return _mock_get_display_cls(format)
+
+        monkeypatch.setattr(dask.dot, "_get_display_cls", mock_fx)
+        visualize(x, filename=None)
+        assert True in test_list
 
 
 @pytest.mark.skipif("not da")

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -954,8 +954,8 @@ def test_visualize():
         visualize(x, filename=os.path.join(d, "mydask.png"))
         assert os.path.exists(os.path.join(d, "mydask.png"))
 
-        # To check whether visualize() works when called with no filename
-        # Test will fail if the fucntion raises an error
+        # To see if visualize() works when the filename parameter is set to None
+        # If the function returns an error, the test will fail
         x.visualize(filename=None)
 
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -954,30 +954,9 @@ def test_visualize():
         visualize(x, filename=os.path.join(d, "mydask.png"))
         assert os.path.exists(os.path.join(d, "mydask.png"))
 
-
-@pytest.mark.skipif("not da")
-@pytest.mark.skipif(
-    sys.flags.optimize, reason="graphviz exception with Python -OO flag"
-)
-def test_visualize_no_filename(monkeypatch):
-    pytest.importorskip("graphviz")
-    pytest.importorskip("dask.dot")
-
-    x = da.arange(10)
-
-    was_mock_function_called = []
-    _mock_get_display_cls = dask.dot._get_display_cls
-
-    def mock_fx(format):
-        was_mock_function_called.append(True)
-        return _mock_get_display_cls(format)
-
-    # using monkey patching to ensure dask.dot._get_display_cls gets called
-    monkeypatch.setattr(dask.dot, "_get_display_cls", mock_fx)
-
-    x.visualize(filename=None)
-
-    assert True in was_mock_function_called
+        # To check whether visualize() works when called with no filename
+        # Test will fail if the fucntion raises an error
+        x.visualize(filename=None)
 
 
 @pytest.mark.skipif("not da")

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -955,7 +955,7 @@ def test_visualize():
         assert os.path.exists(os.path.join(d, "mydask.png"))
 
         # To see if visualize() works when the filename parameter is set to None
-        # If the function returns an error, the test will fail
+        # If the function raises an error, the test will fail
         x.visualize(filename=None)
 
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -933,7 +933,7 @@ def test_compute_nested():
 @pytest.mark.skipif(
     sys.flags.optimize, reason="graphviz exception with Python -OO flag"
 )
-def test_visualize(monkeypatch):
+def test_visualize():
     pytest.importorskip("graphviz")
     with tmpdir() as d:
         x = da.arange(5, chunks=2)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -954,16 +954,27 @@ def test_visualize(monkeypatch):
         visualize(x, filename=os.path.join(d, "mydask.png"))
         assert os.path.exists(os.path.join(d, "mydask.png"))
 
-        test_list = []
-        _mock_get_display_cls = dask.dot._get_display_cls
 
-        def mock_fx(format):
-            test_list.append(True)
-            return _mock_get_display_cls(format)
+@pytest.mark.skipif("not da")
+@pytest.mark.skipif(
+    sys.flags.optimize, reason="graphviz exception with Python -OO flag"
+)
+def test_visualize_no_filename(monkeypatch):
+    pytest.importorskip("graphviz")
+    pytest.importorskip("dask.dot")
 
-        monkeypatch.setattr(dask.dot, "_get_display_cls", mock_fx)
-        visualize(x, filename=None)
-        assert True in test_list
+    x = da.arange(10)
+
+    test_list = []
+    _mock_get_display_cls = dask.dot._get_display_cls
+
+    def mock_fx(format):
+        test_list.append(True)
+        return _mock_get_display_cls(format)
+
+    monkeypatch.setattr(dask.dot, "_get_display_cls", mock_fx)
+    visualize(x, filename=None)
+    assert True in test_list
 
 
 @pytest.mark.skipif("not da")


### PR DESCRIPTION
- [x] Closes #7685 
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

## The Issue
The issue arised when the `format` and the `filename` arguments both were `None`. So, 

https://github.com/dask/dask/blob/1a6a85258bccb14fe37bb54c211beeeffd46cd55/dask/dot.py#L276-L278

would result in an error as it's trying to call the `.lower()` function on a `NoneType` filename.

## The Fix
To fix this, I added an extra condition before it reaches the line of error to make sure `format` is not `None` by making it equal to the default ("png").


## The Demo
![image](https://user-images.githubusercontent.com/62539811/120347731-97944580-c30d-11eb-96e7-9f513e46075d.png)

