### PR TITLE
Renamed inner loop variables to avoid duplication

### DIFF
--- a/dask/array/gufunc.py
+++ b/dask/array/gufunc.py
@@ -489,12 +489,12 @@ significantly.".format(
             leaf_arr = leaf_arr[slices]
 
         tidcs = [None] * len(leaf_arr.shape)
-        for i, oa in zip(range(-len(oax), 0), oax):
-            tidcs[oa] = i
+        for ii, oa in zip(range(-len(oax), 0), oax):
+            tidcs[oa] = ii
         j = 0
-        for i in range(len(tidcs)):
-            if tidcs[i] is None:
-                tidcs[i] = j
+        for ii in range(len(tidcs)):
+            if tidcs[ii] is None:
+                tidcs[ii] = j
                 j += 1
         leaf_arr = leaf_arr.transpose(tidcs)
         leaf_arrs.append(leaf_arr)

--- a/dask/base.py
+++ b/dask/base.py
@@ -336,8 +336,8 @@ def collections_to_dsk(collections, optimize_graph=True, optimizations=(), **kwa
             dsk, keys = _extract_graph_and_keys(val)
             dsk = opt(dsk, keys, **kwargs)
 
-            for opt in optimizations:
-                dsk = opt(dsk, keys, **kwargs)
+            for opt_inner in optimizations:
+                dsk = opt_inner(dsk, keys, **kwargs)
 
             graphs.append(dsk)
 

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1377,13 +1377,13 @@ def rewrite_blockwise(inputs):
             sub = {}
             # Map from (id(key), inds or None) -> index in indices. Used to deduplicate indices.
             index_map = {(id(k), inds): n for n, (k, inds) in enumerate(indices)}
-            for i, index in enumerate(new_indices):
+            for ii, index in enumerate(new_indices):
                 id_key = (id(index[0]), index[1])
                 if id_key in index_map:  # use old inputs if available
-                    sub[blockwise_token(i)] = blockwise_token(index_map[id_key])
+                    sub[blockwise_token(ii)] = blockwise_token(index_map[id_key])
                 else:
                     index_map[id_key] = len(indices)
-                    sub[blockwise_token(i)] = blockwise_token(len(indices))
+                    sub[blockwise_token(ii)] = blockwise_token(len(indices))
                     indices.append(index)
             new_dsk = subs(inputs[dep].dsk, sub)
 


### PR DESCRIPTION
Based on analysis from [lgtm.com](https://lgtm.com/projects/g/dask/dask/?mode=tree&severity=error%2Crecommendation%2Cwarning&ruleFocus=1780100). No new tests are needed as this did not introduce a bug, the variables were not used after the inner loops. 
If the maintainers feel this is not needed, feel free to reject.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
