### PR TITLE
Rename make_meta_util to make_meta

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1564,7 +1564,7 @@ class Bag(DaskMethodsMixin):
         elif columns is not None:
             raise ValueError("Can't specify both `meta` and `columns`")
         else:
-            meta = dd.utils.make_meta_util(meta, parent_meta=pd.DataFrame())
+            meta = dd.utils.make_meta(meta, parent_meta=pd.DataFrame())
         # Serializing the columns and dtypes is much smaller than serializing
         # the empty frame
         cols = list(meta.columns)

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -23,7 +23,7 @@ from .dispatch import (
     group_split_dispatch,
     hash_object_dispatch,
     is_categorical_dtype_dispatch,
-    make_meta,
+    make_meta_dispatch,
     make_meta_obj,
     meta_nonempty,
     tolist_dispatch,
@@ -57,12 +57,12 @@ def _(x):
     return x
 
 
-@make_meta.register((pd.Series, pd.DataFrame))
+@make_meta_dispatch.register((pd.Series, pd.DataFrame))
 def make_meta_pandas(x, index=None):
     return x.iloc[:0]
 
 
-@make_meta.register(pd.Index)
+@make_meta_dispatch.register(pd.Index)
 def make_meta_index(x, index=None):
     return x[0:0]
 
@@ -109,7 +109,7 @@ def make_meta_object(x, index=None):
         return x[:0]
 
     if index is not None:
-        index = make_meta(index)
+        index = make_meta_dispatch(index)
 
     if isinstance(x, dict):
         return pd.DataFrame(
@@ -524,7 +524,7 @@ def is_categorical_dtype_pandas(obj):
 @group_split_dispatch.register_lazy("cudf")
 @get_parallel_type.register_lazy("cudf")
 @meta_nonempty.register_lazy("cudf")
-@make_meta.register_lazy("cudf")
+@make_meta_dispatch.register_lazy("cudf")
 @make_meta_obj.register_lazy("cudf")
 def _register_cudf():
     import dask_cudf  # noqa: F401

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -75,7 +75,7 @@ from .utils import (
     is_dataframe_like,
     is_index_like,
     is_series_like,
-    make_meta_util,
+    make_meta,
     raise_on_meta_error,
     valid_divisions,
 )
@@ -123,7 +123,7 @@ class Scalar(DaskMethodsMixin, OperatorMethodMixin):
         self._name = name
         self._parent_meta = pd.Series(dtype="float64")
 
-        meta = make_meta_util(meta, parent_meta=self._parent_meta)
+        meta = make_meta(meta, parent_meta=self._parent_meta)
         if is_dataframe_like(meta) or is_series_like(meta) or is_index_like(meta):
             raise TypeError(
                 "Expected meta to specify scalar, got "
@@ -267,7 +267,7 @@ def _scalar_binary(op, self, other, inv=False):
         (op, other_key, (self._name, 0)) if inv else (op, (self._name, 0), other_key)
     )
 
-    other_meta = make_meta_util(other, parent_meta=self._parent_meta)
+    other_meta = make_meta(other, parent_meta=self._parent_meta)
     other_meta_nonempty = meta_nonempty(other_meta)
     if inv:
         meta = op(other_meta_nonempty, self._meta_nonempty)
@@ -303,7 +303,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
             dsk = HighLevelGraph.from_collections(name, dsk, dependencies=[])
         self.dask = dsk
         self._name = name
-        meta = make_meta_util(meta)
+        meta = make_meta(meta)
         if not self._is_partition_type(meta):
             raise TypeError(
                 "Expected meta to specify type {0}, got type "
@@ -3373,9 +3373,9 @@ Dask Name: {name}, {task} tasks""".format(
         if meta is no_default:
             meta = _emulate(M.map, self, arg, na_action=na_action, udf=True)
         else:
-            meta = make_meta_util(
+            meta = make_meta(
                 meta,
-                index=getattr(make_meta_util(self), "index", None),
+                index=getattr(make_meta(self), "index", None),
                 parent_meta=self._meta,
             )
 
@@ -5523,9 +5523,9 @@ def apply_concat_apply(
         meta = _emulate(
             aggregate, _concat([meta_chunk], ignore_index), udf=True, **aggregate_kwargs
         )
-    meta = make_meta_util(
+    meta = make_meta(
         meta,
-        index=(getattr(make_meta_util(dfs[0]), "index", None) if dfs else None),
+        index=(getattr(make_meta(dfs[0]), "index", None) if dfs else None),
         parent_meta=dfs[0]._meta,
     )
 
@@ -5617,7 +5617,7 @@ def map_partitions(
     args = _maybe_from_pandas(args)
     args = _maybe_align_partitions(args)
     dfs = [df for df in args if isinstance(df, _Frame)]
-    meta_index = getattr(make_meta_util(dfs[0]), "index", None) if dfs else None
+    meta_index = getattr(make_meta(dfs[0]), "index", None) if dfs else None
     if parent_meta is None and dfs:
         parent_meta = dfs[0]._meta
 
@@ -5626,7 +5626,7 @@ def map_partitions(
         # delayed values)
         meta = _emulate(func, *args, udf=True, **kwargs)
     else:
-        meta = make_meta_util(meta, index=meta_index, parent_meta=parent_meta)
+        meta = make_meta(meta, index=meta_index, parent_meta=parent_meta)
 
     if has_keyword(func, "partition_info"):
         kwargs["partition_info"] = "__dummy__"
@@ -5640,10 +5640,10 @@ def map_partitions(
     elif not (has_parallel_type(meta) or is_arraylike(meta) and meta.shape):
         # If `meta` is not a pandas object, the concatenated results will be a
         # different type
-        meta = make_meta_util(_concat([meta]), index=meta_index)
+        meta = make_meta(_concat([meta]), index=meta_index)
 
     # Ensure meta is empty series
-    meta = make_meta_util(meta, parent_meta=parent_meta)
+    meta = make_meta(meta, parent_meta=parent_meta)
 
     args2 = []
     dependencies = []
@@ -6004,7 +6004,7 @@ def cov_corr(df, min_periods=None, corr=False, scalar=False, split_every=False):
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[df])
     if scalar:
         return Scalar(graph, name, "f8")
-    meta = make_meta_util(
+    meta = make_meta(
         [(c, "f8") for c in df.columns], index=df.columns, parent_meta=df._meta
     )
     return DataFrame(graph, name, meta, (df.columns[0], df.columns[-1]))
@@ -7053,7 +7053,7 @@ def series_map(base_series, map_series):
 
     meta = map_series._meta.copy()
     meta.index = base_series._meta.index
-    meta = make_meta_util(meta)
+    meta = make_meta(meta)
 
     dependencies = [base_series, map_series, base_series.index]
     graph = HighLevelGraph.from_collections(

--- a/dask/dataframe/dispatch.py
+++ b/dask/dataframe/dispatch.py
@@ -9,7 +9,7 @@ import dask.dataframe as dd
 
 from ..utils import Dispatch
 
-make_meta = Dispatch("make_meta")
+make_meta_dispatch = Dispatch("make_meta_dispatch")
 make_meta_obj = Dispatch("make_meta_obj")
 meta_nonempty = Dispatch("meta_nonempty")
 hash_object_dispatch = Dispatch("hash_object_dispatch")
@@ -83,7 +83,30 @@ def tolist(obj):
     return func(obj)
 
 
-def make_meta_util(x, index=None, parent_meta=None):
+def make_meta(x, index=None, parent_meta=None):
+    """
+    This method creates meta-data based on the type of ``x``,
+    and ``parent_meta`` if supplied.
+
+    Parameters
+    ----------
+    x : Object of any type.
+        This can be an object of type Dask-like or Frame-like.
+    index :  Index, optional
+        Any index to use in the metadata. This is a pass-through
+        parameter to dispatches registered.
+    parent_meta : Object, optional
+        If ``x`` is of arbitrary types and thus Dask cannot determine
+        which back-end to be used to generate the meta-data for this
+        object type, in which case ``parent_meta`` will be used to
+        determine which back-end to select and dispatch to. To use
+        utilize this parameter ``make_meta_obj`` has be dispatched.
+
+    Returns
+    -------
+    A valid meta-data
+    """
+
     if isinstance(
         x,
         (
@@ -97,7 +120,7 @@ def make_meta_util(x, index=None, parent_meta=None):
         return x._meta
 
     try:
-        return make_meta(x, index=index)
+        return make_meta_dispatch(x, index=index)
     except TypeError:
         if parent_meta is not None:
             func = make_meta_obj.dispatch(type(parent_meta))

--- a/dask/dataframe/dispatch.py
+++ b/dask/dataframe/dispatch.py
@@ -85,7 +85,7 @@ def tolist(obj):
     return func(obj)
 
 
-def make_meta(x, index=None, parent_meta=pd.DataFrame()):
+def make_meta(x, index=None, parent_meta=None):
     """
     This method creates meta-data based on the type of ``x``,
     and ``parent_meta`` if supplied.
@@ -97,14 +97,14 @@ def make_meta(x, index=None, parent_meta=pd.DataFrame()):
     index :  Index, optional
         Any index to use in the metadata. This is a pass-through
         parameter to dispatches registered.
-    parent_meta : Frame-like, default pd.DataFrame()
+    parent_meta : Object, default None
         If ``x`` is of arbitrary types and thus Dask cannot determine
         which back-end to be used to generate the meta-data for this
         object type, in which case ``parent_meta`` will be used to
         determine which back-end to select and dispatch to. To use
         utilize this parameter ``make_meta_obj`` has be dispatched.
-        The default is a pandas DataFrame thats chooses pandas as
-        backend.
+        If ``parent_meta`` is ``None``, a pandas DataFrame is used for
+        ``parent_meta`` thats chooses pandas as the backend.
 
     Returns
     -------
@@ -122,6 +122,8 @@ def make_meta(x, index=None, parent_meta=pd.DataFrame()):
         ),
     ):
         return x._meta
+    elif parent_meta is None:
+        parent_meta = pd.DataFrame()
 
     try:
         return make_meta_dispatch(x, index=index)

--- a/dask/dataframe/dispatch.py
+++ b/dask/dataframe/dispatch.py
@@ -4,6 +4,8 @@ Dispatch in dask.dataframe.
 Also see extension.py
 """
 
+import pandas as pd
+
 import dask.array as da
 import dask.dataframe as dd
 
@@ -83,7 +85,7 @@ def tolist(obj):
     return func(obj)
 
 
-def make_meta(x, index=None, parent_meta=None):
+def make_meta(x, index=None, parent_meta=pd.DataFrame()):
     """
     This method creates meta-data based on the type of ``x``,
     and ``parent_meta`` if supplied.
@@ -95,12 +97,14 @@ def make_meta(x, index=None, parent_meta=None):
     index :  Index, optional
         Any index to use in the metadata. This is a pass-through
         parameter to dispatches registered.
-    parent_meta : Object, optional
+    parent_meta : Frame-like, default pd.DataFrame()
         If ``x`` is of arbitrary types and thus Dask cannot determine
         which back-end to be used to generate the meta-data for this
         object type, in which case ``parent_meta`` will be used to
         determine which back-end to select and dispatch to. To use
         utilize this parameter ``make_meta_obj`` has be dispatched.
+        The default is a pandas DataFrame thats chooses pandas as
+        backend.
 
     Returns
     -------

--- a/dask/dataframe/dispatch.py
+++ b/dask/dataframe/dispatch.py
@@ -93,8 +93,7 @@ def make_meta(x, index=None, parent_meta=pd.DataFrame()):
     Parameters
     ----------
     x : Object of any type.
-        This can be an object of type Dask-like/Frame-like/any arbitrary
-        type.
+        Object to construct meta-data from.
     index :  Index, optional
         Any index to use in the metadata. This is a pass-through
         parameter to dispatches registered.

--- a/dask/dataframe/dispatch.py
+++ b/dask/dataframe/dispatch.py
@@ -122,8 +122,6 @@ def make_meta(x, index=None, parent_meta=None):
         ),
     ):
         return x._meta
-    elif parent_meta is None:
-        parent_meta = pd.DataFrame()
 
     try:
         return make_meta_dispatch(x, index=index)
@@ -132,7 +130,9 @@ def make_meta(x, index=None, parent_meta=None):
             func = make_meta_obj.dispatch(type(parent_meta))
             return func(x, index=index)
         else:
-            func = make_meta_obj.dispatch(type(x))
+            # Default to using the pandas backend
+            # if ``parent_meta`` is not specified
+            func = make_meta_obj.dispatch(pd.DataFrame)
             return func(x, index=index)
 
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -27,7 +27,7 @@ from .utils import (
     insert_meta_param_description,
     is_dataframe_like,
     is_series_like,
-    make_meta_util,
+    make_meta,
     raise_on_meta_error,
 )
 
@@ -1673,7 +1673,7 @@ class _GroupBy:
             )
             warnings.warn(msg, stacklevel=2)
 
-        meta = make_meta_util(meta, parent_meta=self._meta.obj)
+        meta = make_meta(meta, parent_meta=self._meta.obj)
 
         # Validate self.index
         if isinstance(self.index, list) and any(
@@ -1762,7 +1762,7 @@ class _GroupBy:
             )
             warnings.warn(msg, stacklevel=2)
 
-        meta = make_meta_util(meta, parent_meta=self._meta.obj)
+        meta = make_meta(meta, parent_meta=self._meta.obj)
 
         # Validate self.index
         if isinstance(self.index, list) and any(

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -14,12 +14,7 @@ from ...delayed import delayed
 from ...utils import M, ensure_dict
 from ..core import DataFrame, Index, Series, has_parallel_type, new_dd_object
 from ..shuffle import set_partition
-from ..utils import (
-    check_meta,
-    insert_meta_param_description,
-    is_series_like,
-    make_meta_util,
-)
+from ..utils import check_meta, insert_meta_param_description, is_series_like, make_meta
 
 lock = Lock()
 
@@ -593,12 +588,12 @@ def from_delayed(
         if not isinstance(df, Delayed):
             raise TypeError("Expected Delayed object, got %s" % type(df).__name__)
 
-    parent_meta = delayed(make_meta_util)(dfs[0]).compute()
+    parent_meta = delayed(make_meta)(dfs[0]).compute()
 
     if meta is None:
         meta = parent_meta
     else:
-        meta = make_meta_util(meta, parent_meta=parent_meta)
+        meta = make_meta(meta, parent_meta=parent_meta)
 
     name = prefix + "-" + tokenize(*dfs)
     dsk = merge(df.dask for df in dfs)

--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -7,7 +7,7 @@ from ...base import compute as dask_compute
 from ...bytes import read_bytes
 from ...core import flatten
 from ...delayed import delayed
-from ..utils import insert_meta_param_description, make_meta_util
+from ..utils import insert_meta_param_description, make_meta
 from .io import from_delayed
 
 
@@ -198,7 +198,7 @@ def read_json(
         chunks = list(flatten(chunks))
         if meta is None:
             meta = read_json_chunk(first, encoding, errors, engine, kwargs)
-        meta = make_meta_util(meta)
+        meta = make_meta(meta)
         parts = [
             delayed(read_json_chunk)(chunk, encoding, errors, engine, kwargs, meta=meta)
             for chunk in chunks

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -89,7 +89,7 @@ from .utils import (
     asciitable,
     is_dataframe_like,
     is_series_like,
-    make_meta_util,
+    make_meta,
     strip_unknown_categories,
 )
 
@@ -1022,7 +1022,7 @@ def stack_partitions(dfs, divisions, join="outer", ignore_order=False, **kwargs)
 
     kwargs.update({"ignore_order": ignore_order})
 
-    meta = make_meta_util(
+    meta = make_meta(
         methods.concat(
             [df._meta_nonempty for df in dfs],
             join=join,

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -12,7 +12,7 @@ from ..utils import M, derived_from, funcname, has_keyword
 from . import methods
 from ._compat import PANDAS_VERSION
 from .core import _emulate
-from .utils import make_meta_util
+from .utils import make_meta
 
 
 def overlap_chunk(
@@ -103,7 +103,7 @@ def map_overlap(func, df, before, after, *args, **kwargs):
         meta = kwargs.pop("meta")
     else:
         meta = _emulate(func, df, *args, **kwargs)
-    meta = make_meta_util(meta, index=df._meta.index, parent_meta=df._meta)
+    meta = make_meta(meta, index=df._meta.index, parent_meta=df._meta)
 
     name = "{0}-{1}".format(func_name, token)
     name_a = "overlap-prepend-" + tokenize(df, before)

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -7,7 +7,7 @@ import pytest
 
 import dask.dataframe as dd
 from dask.dataframe._compat import PANDAS_GT_100, PANDAS_GT_120, PANDAS_VERSION
-from dask.dataframe.utils import assert_dask_graph, assert_eq, make_meta_util
+from dask.dataframe.utils import assert_dask_graph, assert_eq, make_meta
 
 try:
     import scipy
@@ -22,7 +22,7 @@ def test_arithmetics():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
     }
-    meta = make_meta_util(
+    meta = make_meta(
         {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
     )
     ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
@@ -690,7 +690,7 @@ def test_reductions(split_every):
             index=[9, 9, 9],
         ),
     }
-    meta = make_meta_util(
+    meta = make_meta(
         {"a": "i8", "b": "i8", "c": "bool"},
         index=pd.Index([], "i8"),
         parent_meta=pd.DataFrame(),
@@ -972,7 +972,7 @@ def test_reduction_series_invalid_axis():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
     }
-    meta = make_meta_util(
+    meta = make_meta(
         {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
     )
     ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])
@@ -1067,7 +1067,7 @@ def test_reductions_frame(split_every):
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
     }
-    meta = make_meta_util(
+    meta = make_meta(
         {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
     )
     ddf1 = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -13,7 +13,7 @@ from dask.dataframe.utils import (
     assert_eq,
     clear_known_categories,
     is_categorical_dtype,
-    make_meta_util,
+    make_meta,
 )
 
 # Generate a list of categorical series and indices
@@ -120,7 +120,7 @@ def test_unknown_categoricals():
     ddf = dd.DataFrame(
         {("unknown", i): df for (i, df) in enumerate(frames)},
         "unknown",
-        make_meta_util(
+        make_meta(
             {"v": "object", "w": "category", "x": "i8", "y": "category", "z": "f8"},
             parent_meta=frames[0],
         ),

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -25,7 +25,7 @@ from dask.dataframe.core import (
     repartition_divisions,
     total_mem_usage,
 )
-from dask.dataframe.utils import assert_eq, assert_max_deps, make_meta_util
+from dask.dataframe.utils import assert_eq, assert_max_deps, make_meta
 from dask.utils import M, put_lines
 
 dsk = {
@@ -33,7 +33,7 @@ dsk = {
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
 }
-meta = make_meta_util(
+meta = make_meta(
     {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
 )
 d = dd.DataFrame(dsk, "x", meta, [0, 5, 9, 9])
@@ -1520,7 +1520,7 @@ def test_unknown_divisions():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}),
     }
-    meta = make_meta_util({"a": "i8", "b": "i8"}, parent_meta=pd.DataFrame())
+    meta = make_meta({"a": "i8", "b": "i8"}, parent_meta=pd.DataFrame())
     d = dd.DataFrame(dsk, "x", meta, [None, None, None, None])
     full = d.compute(scheduler="sync")
 
@@ -2277,7 +2277,7 @@ def test_sample_raises():
 
 
 def test_empty_max():
-    meta = make_meta_util({"x": "i8"}, parent_meta=pd.DataFrame())
+    meta = make_meta({"x": "i8"}, parent_meta=pd.DataFrame())
     a = dd.DataFrame(
         {("x", 0): pd.DataFrame({"x": [1]}), ("x", 1): pd.DataFrame({"x": []})},
         "x",

--- a/dask/dataframe/tests/test_extensions.py
+++ b/dask/dataframe/tests/test_extensions.py
@@ -46,5 +46,5 @@ def test_reduction():
 
 
 def test_scalar():
-    result = dd.utils.make_meta_util(Decimal("1.0"), parent_meta=pd.DataFrame())
+    result = dd.utils.make_meta(Decimal("1.0"), parent_meta=pd.DataFrame())
     assert result == Decimal("1.0")

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -6,14 +6,14 @@ import dask
 import dask.dataframe as dd
 from dask.dataframe._compat import PANDAS_GT_100, PANDAS_GT_110, PANDAS_GT_120, tm
 from dask.dataframe.indexing import _coerce_loc_index
-from dask.dataframe.utils import assert_eq, make_meta_util
+from dask.dataframe.utils import assert_eq, make_meta
 
 dsk = {
     ("x", 0): pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=[0, 1, 3]),
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
 }
-meta = make_meta_util(
+meta = make_meta(
     {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
 )
 d = dd.DataFrame(dsk, "x", meta, [0, 5, 9, 9])

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -21,7 +21,7 @@ from dask.dataframe.utils import (
     assert_eq,
     clear_known_categories,
     has_known_categories,
-    make_meta_util,
+    make_meta,
 )
 
 
@@ -1496,7 +1496,7 @@ def test_concat2():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}),
     }
-    meta = make_meta_util({"a": "i8", "b": "i8"}, parent_meta=pd.DataFrame())
+    meta = make_meta({"a": "i8", "b": "i8"}, parent_meta=pd.DataFrame())
     a = dd.DataFrame(dsk, "x", meta, [None, None])
     dsk = {
         ("y", 0): pd.DataFrame({"a": [10, 20, 30], "b": [40, 50, 60]}),
@@ -1509,7 +1509,7 @@ def test_concat2():
         ("y", 0): pd.DataFrame({"b": [10, 20, 30], "c": [40, 50, 60]}),
         ("y", 1): pd.DataFrame({"b": [40, 50, 60], "c": [30, 20, 10]}),
     }
-    meta = make_meta_util({"b": "i8", "c": "i8"}, parent_meta=pd.DataFrame())
+    meta = make_meta({"b": "i8", "c": "i8"}, parent_meta=pd.DataFrame())
     c = dd.DataFrame(dsk, "y", meta, [None, None])
 
     dsk = {
@@ -1520,7 +1520,7 @@ def test_concat2():
             {"b": [40, 50, 60], "c": [30, 20, 10], "d": [90, 80, 70]}, index=[3, 4, 5]
         ),
     }
-    meta = make_meta_util(
+    meta = make_meta(
         {"b": "i8", "c": "i8", "d": "i8"},
         index=pd.Index([], "i8"),
         parent_meta=pd.DataFrame(),
@@ -1934,7 +1934,7 @@ def test_append2():
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}),
         ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}),
     }
-    meta = make_meta_util({"a": "i8", "b": "i8"}, parent_meta=pd.DataFrame())
+    meta = make_meta({"a": "i8", "b": "i8"}, parent_meta=pd.DataFrame())
     ddf1 = dd.DataFrame(dsk, "x", meta, [None, None])
 
     dsk = {
@@ -1948,7 +1948,7 @@ def test_append2():
         ("y", 0): pd.DataFrame({"b": [10, 20, 30], "c": [40, 50, 60]}),
         ("y", 1): pd.DataFrame({"b": [40, 50, 60], "c": [30, 20, 10]}),
     }
-    meta = make_meta_util({"b": "i8", "c": "i8"}, parent_meta=pd.DataFrame())
+    meta = make_meta({"b": "i8", "c": "i8"}, parent_meta=pd.DataFrame())
     ddf3 = dd.DataFrame(dsk, "y", meta, [None, None])
 
     assert_eq(ddf1.append(ddf2), ddf1.compute().append(ddf2.compute(), sort=False))

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -4,7 +4,7 @@ import pytest
 
 import dask.dataframe as dd
 from dask.dataframe._compat import tm
-from dask.dataframe.utils import assert_eq, make_meta_util
+from dask.dataframe.utils import assert_eq, make_meta
 
 
 @pytest.mark.parametrize(
@@ -149,7 +149,7 @@ def test_get_dummies_errors():
     # unknown categories
     df = pd.DataFrame({"x": list("abcbc"), "y": list("bcbcb")})
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf._meta = make_meta_util(
+    ddf._meta = make_meta(
         {"x": "category", "y": "category"}, parent_meta=pd.DataFrame()
     )
 
@@ -259,7 +259,7 @@ def test_pivot_table_errors():
     assert msg in str(err.value)
 
     # unknown categories
-    ddf._meta = make_meta_util(
+    ddf._meta = make_meta(
         {"A": object, "B": float, "C": "category"}, parent_meta=pd.DataFrame()
     )
     msg = "'columns' must have known categories"

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -27,7 +27,7 @@ from dask.dataframe.shuffle import (
     remove_nans,
     shuffle,
 )
-from dask.dataframe.utils import assert_eq, make_meta_util
+from dask.dataframe.utils import assert_eq, make_meta
 from dask.optimization import cull
 
 dsk = {
@@ -35,7 +35,7 @@ dsk = {
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [2, 5, 8]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [3, 6, 9]}, index=[9, 9, 9]),
 }
-meta = make_meta_util(
+meta = make_meta(
     {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
 )
 d = dd.DataFrame(dsk, "x", meta, [0, 4, 9, 9])

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -16,7 +16,7 @@ from dask.dataframe.utils import (
     is_dataframe_like,
     is_index_like,
     is_series_like,
-    make_meta_util,
+    make_meta,
     meta_nonempty,
     raise_on_meta_error,
     shard_df_on_index,
@@ -40,92 +40,90 @@ def test_make_meta():
     )
 
     # Pandas dataframe
-    meta = make_meta_util(df)
+    meta = make_meta(df)
     assert len(meta) == 0
     assert (meta.dtypes == df.dtypes).all()
     assert isinstance(meta.index, type(df.index))
 
     # Pandas series
-    meta = make_meta_util(df.a)
+    meta = make_meta(df.a)
     assert len(meta) == 0
     assert meta.dtype == df.a.dtype
     assert isinstance(meta.index, type(df.index))
 
     # Pandas index
-    meta = make_meta_util(df.index)
+    meta = make_meta(df.index)
     assert isinstance(meta, type(df.index))
     assert len(meta) == 0
 
     # Dask object
     ddf = dd.from_pandas(df, npartitions=2)
-    assert make_meta_util(ddf) is ddf._meta
+    assert make_meta(ddf) is ddf._meta
 
     # Dict
-    meta = make_meta_util({"a": "i8", "b": "O", "c": "f8"}, parent_meta=pd.DataFrame())
+    meta = make_meta({"a": "i8", "b": "O", "c": "f8"}, parent_meta=pd.DataFrame())
     assert isinstance(meta, pd.DataFrame)
     assert len(meta) == 0
     assert (meta.dtypes == df.dtypes).all()
     assert isinstance(meta.index, pd.RangeIndex)
 
     # Iterable
-    meta = make_meta_util(
-        [("a", "i8"), ("c", "f8"), ("b", "O")], parent_meta=pd.DataFrame()
-    )
+    meta = make_meta([("a", "i8"), ("c", "f8"), ("b", "O")], parent_meta=pd.DataFrame())
     assert (meta.columns == ["a", "c", "b"]).all()
     assert len(meta) == 0
     assert (meta.dtypes == df.dtypes[meta.dtypes.index]).all()
     assert isinstance(meta.index, pd.RangeIndex)
 
     # Tuple
-    meta = make_meta_util(("a", "i8"), parent_meta=pd.DataFrame())
+    meta = make_meta(("a", "i8"), parent_meta=pd.DataFrame())
     assert isinstance(meta, pd.Series)
     assert len(meta) == 0
     assert meta.dtype == "i8"
     assert meta.name == "a"
 
     # With index
-    meta = make_meta_util(
+    meta = make_meta(
         {"a": "i8", "b": "i4"},
         index=pd.Int64Index([1, 2], name="foo"),
         parent_meta=pd.DataFrame(),
     )
     assert isinstance(meta.index, pd.Int64Index)
     assert len(meta.index) == 0
-    meta = make_meta_util(
+    meta = make_meta(
         ("a", "i8"), index=pd.Int64Index([1, 2], name="foo"), parent_meta=pd.DataFrame()
     )
     assert isinstance(meta.index, pd.Int64Index)
     assert len(meta.index) == 0
 
     # Categoricals
-    meta = make_meta_util({"a": "category"}, parent_meta=df)
+    meta = make_meta({"a": "category"}, parent_meta=df)
     assert len(meta.a.cat.categories) == 1
     assert meta.a.cat.categories[0] == UNKNOWN_CATEGORIES
-    meta = make_meta_util(("a", "category"), parent_meta=df)
+    meta = make_meta(("a", "category"), parent_meta=df)
     assert len(meta.cat.categories) == 1
     assert meta.cat.categories[0] == UNKNOWN_CATEGORIES
 
     # Numpy scalar
-    meta = make_meta_util(np.float64(1.0), parent_meta=df)
+    meta = make_meta(np.float64(1.0), parent_meta=df)
     assert isinstance(meta, np.float64)
 
     # Python scalar
-    meta = make_meta_util(1.0, parent_meta=df)
+    meta = make_meta(1.0, parent_meta=df)
     assert isinstance(meta, np.float64)
 
     # Timestamp
     x = pd.Timestamp(2000, 1, 1)
-    meta = make_meta_util(x, parent_meta=df)
+    meta = make_meta(x, parent_meta=df)
     assert meta is x
 
     # Dtype expressions
-    meta = make_meta_util("i8", parent_meta=df)
+    meta = make_meta("i8", parent_meta=df)
     assert isinstance(meta, np.int64)
-    meta = make_meta_util(float, parent_meta=df)
+    meta = make_meta(float, parent_meta=df)
     assert isinstance(meta, np.dtype(float).type)
-    meta = make_meta_util(np.dtype("bool"), parent_meta=df)
+    meta = make_meta(np.dtype("bool"), parent_meta=df)
     assert isinstance(meta, np.bool_)
-    assert pytest.raises(TypeError, lambda: make_meta_util(None))
+    assert pytest.raises(TypeError, lambda: make_meta(None))
 
 
 def test_meta_nonempty():

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -61,21 +61,21 @@ def test_make_meta():
     assert make_meta(ddf) is ddf._meta
 
     # Dict
-    meta = make_meta({"a": "i8", "b": "O", "c": "f8"}, parent_meta=pd.DataFrame())
+    meta = make_meta({"a": "i8", "b": "O", "c": "f8"})
     assert isinstance(meta, pd.DataFrame)
     assert len(meta) == 0
     assert (meta.dtypes == df.dtypes).all()
     assert isinstance(meta.index, pd.RangeIndex)
 
     # Iterable
-    meta = make_meta([("a", "i8"), ("c", "f8"), ("b", "O")], parent_meta=pd.DataFrame())
+    meta = make_meta([("a", "i8"), ("c", "f8"), ("b", "O")])
     assert (meta.columns == ["a", "c", "b"]).all()
     assert len(meta) == 0
     assert (meta.dtypes == df.dtypes[meta.dtypes.index]).all()
     assert isinstance(meta.index, pd.RangeIndex)
 
     # Tuple
-    meta = make_meta(("a", "i8"), parent_meta=pd.DataFrame())
+    meta = make_meta(("a", "i8"))
     assert isinstance(meta, pd.Series)
     assert len(meta) == 0
     assert meta.dtype == "i8"
@@ -85,13 +85,10 @@ def test_make_meta():
     meta = make_meta(
         {"a": "i8", "b": "i4"},
         index=pd.Int64Index([1, 2], name="foo"),
-        parent_meta=pd.DataFrame(),
     )
     assert isinstance(meta.index, pd.Int64Index)
     assert len(meta.index) == 0
-    meta = make_meta(
-        ("a", "i8"), index=pd.Int64Index([1, 2], name="foo"), parent_meta=pd.DataFrame()
-    )
+    meta = make_meta(("a", "i8"), index=pd.Int64Index([1, 2], name="foo"))
     assert isinstance(meta.index, pd.Int64Index)
     assert len(meta.index) == 0
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -25,7 +25,7 @@ from . import _dtypes  # noqa: F401 register pandas extension types
 from . import methods
 from ._compat import PANDAS_GT_100, PANDAS_GT_110, PANDAS_GT_120, tm  # noqa: F401
 from .dispatch import make_meta  # noqa : F401
-from .dispatch import make_meta_obj, make_meta_util, meta_nonempty  # noqa : F401
+from .dispatch import make_meta_obj, meta_nonempty  # noqa : F401
 from .extensions import make_scalar
 
 meta_object_types = (pd.Series, pd.DataFrame, pd.Index, pd.MultiIndex)

--- a/docs/source/dataframe-extend.rst
+++ b/docs/source/dataframe-extend.rst
@@ -39,21 +39,38 @@ non-empty non-Dask object:
 
 .. code-block:: python
 
-   from dask.dataframe.utils import make_meta
+   from dask.dataframe.dispatch import make_meta_dispatch
 
-   @make_meta.register(MyDataFrame)
-   def make_meta_dataframe(df):
+   @make_meta_dispatch.register(MyDataFrame)
+   def make_meta_dataframe(df, index=None):
        return df.head(0)
 
 
-   @make_meta.register(MySeries)
-   def make_meta_series(s):
+   @make_meta_dispatch.register(MySeries)
+   def make_meta_series(s, index=None):
        return s.head(0)
 
 
-   @make_meta.register(MyIndex)
-   def make_meta_index(ind):
+   @make_meta_dispatch.register(MyIndex)
+   def make_meta_index(ind, index=None):
        return ind[:0]
+
+For dispatching any arbitrary ``object`` types to a respective back-end, we
+recommend registering a dispatch for ``make_meta_obj``:
+
+.. code-block:: python
+
+    from dask.dataframe.dispatch import make_meta_obj
+
+    @make_meta_obj.register(MyDataFrame)
+    def make_meta_object(x, index=None):
+        if isinstance(x, dict):
+            return MyDataFrame()
+        elif isinstance(x, int):
+            return MySeries
+        .
+        .
+        .
 
 
 Additionally, you should create a similar function that returns a non-empty


### PR DESCRIPTION
For context: https://github.com/dask/dask/pull/7732#issuecomment-852327719

This PR renames `make_meta_util` to `make_meta` and renames `make_meta` dispatch to `make_meta_dispatch`.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
