### PR TITLE
Documentation: highlight the client.dashboard_link

### DIFF
--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -33,7 +33,7 @@ For local use this happens when you create a client with no arguments:
 It is typically served at ``http://localhost:8787/status`` ,
 but may be served elsewhere if this port is taken.
 The address of the dashboard will be displayed if you are in a Jupyter Notebook,
-or can be queried from ``client.scheduler_info()['services']``.
+or can be queried from ``client.dashboard_link``.
 
 There are numerous pages with information about task runtimes, communication,
 statistical profiling, load balancing, memory use, and much more.

--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -33,7 +33,8 @@ For local use this happens when you create a client with no arguments:
 It is typically served at ``http://localhost:8787/status`` ,
 but may be served elsewhere if this port is taken.
 The address of the dashboard will be displayed if you are in a Jupyter Notebook,
-or can be queried from ``client.dashboard_link``.
+or can be queried from ``client.dashboard_link``
+(or for older versions of distributed, ``client.scheduler_info()['services']``).
 
 There are numerous pages with information about task runtimes, communication,
 statistical profiling, load balancing, memory use, and much more.


### PR DESCRIPTION
Documentation update. Jacob introduced a `dashboard_link` attribute last year on the client, for an easier way of exposing the dashboard url https://github.com/dask/distributed/pull/3429

We should highlight this information in the docs. (Since many people still might have older versions of distributed, I haven't removed the previous suggestion. We can revisit that at a much later date.)
