### PR TITLE
Warn if using pandas datetimelike string in `dataframe.__getitem__`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -65,6 +65,7 @@ from .optimize import optimize
 from .utils import (
     PANDAS_GT_100,
     PANDAS_GT_110,
+    PANDAS_GT_120,
     check_matching_columns,
     clear_known_categories,
     drop_by_shallow_copy,
@@ -3880,6 +3881,14 @@ class DataFrame(_Frame):
 
             if isinstance(self._meta.index, (pd.DatetimeIndex, pd.PeriodIndex)):
                 if key not in self._meta.columns:
+                    if PANDAS_GT_120:
+                        warnings.warn(
+                            "Indexing a DataFrame with a datetimelike index using a single "
+                            "string to slice the rows, like `frame[string]`, is deprecated "
+                            "and will be removed in a future version. Use `frame.loc[string]` "
+                            "instead.",
+                            FutureWarning,
+                        )
                     return self.loc[key]
 
             # error is raised from pandas

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -429,10 +429,13 @@ def test_getitem_timestamp_str():
     )
     ddf = dd.from_pandas(df, 10)
 
-    # partial string slice
-    # TODO(pandas) starting with pandas 1.2, __getitem__ with an implicit slice
-    # is deprecated -> should we deprecate this in dask as well?
-    assert_eq(df.loc["2011-01-02"], ddf["2011-01-02"])
+    if PANDAS_GT_120:
+        with pytest.warns(
+            FutureWarning, match="Indexing a DataFrame with a datetimelike"
+        ):
+            assert_eq(df.loc["2011-01-02"], ddf["2011-01-02"])
+    else:
+        assert_eq(df.loc["2011-01-02"], ddf["2011-01-02"])
     assert_eq(df["2011-01-02":"2011-01-10"], ddf["2011-01-02":"2011-01-10"])
 
     df = pd.DataFrame(
@@ -440,8 +443,8 @@ def test_getitem_timestamp_str():
         index=pd.date_range("2011-01-01", freq="D", periods=100),
     )
     ddf = dd.from_pandas(df, 50)
-    assert_eq(df.loc["2011-01"], ddf["2011-01"])
-    assert_eq(df.loc["2011"], ddf["2011"])
+    assert_eq(df.loc["2011-01"], ddf.loc["2011-01"])
+    assert_eq(df.loc["2011"], ddf.loc["2011"])
 
     assert_eq(df["2011-01":"2012-05"], ddf["2011-01":"2012-05"])
     assert_eq(df["2011":"2015"], ddf["2011":"2015"])
@@ -486,9 +489,12 @@ def test_getitem_period_str():
     ddf = dd.from_pandas(df, 10)
 
     # partial string slice
-    # TODO(pandas) starting with pandas 1.2, __getitem__ with an implicit slice
-    # is deprecated -> should we deprecate this in dask as well?
-    if not PANDAS_GT_120:
+    if PANDAS_GT_120:
+        with pytest.warns(
+            FutureWarning, match="Indexing a DataFrame with a datetimelike"
+        ):
+            assert_eq(df["2011-01-02"], ddf["2011-01-02"])
+    else:
         assert_eq(df["2011-01-02"], ddf["2011-01-02"])
     assert_eq(df["2011-01-02":"2011-01-10"], ddf["2011-01-02":"2011-01-10"])
     # same reso, dask result is always DataFrame
@@ -498,9 +504,16 @@ def test_getitem_period_str():
         index=pd.period_range("2011-01-01", freq="D", periods=100),
     )
     ddf = dd.from_pandas(df, 50)
-    if not PANDAS_GT_120:
+
+    if PANDAS_GT_120:
+        with pytest.warns(
+            FutureWarning, match="Indexing a DataFrame with a datetimelike"
+        ):
+            assert_eq(df["2011-01"], ddf["2011-01"])
+    else:
         assert_eq(df["2011-01"], ddf["2011-01"])
-        assert_eq(df["2011"], ddf["2011"])
+
+    assert_eq(df.loc["2011"], ddf.loc["2011"])
 
     assert_eq(df["2011-01":"2012-05"], ddf["2011-01":"2012-05"])
     assert_eq(df["2011":"2015"], ddf["2011":"2015"])

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -493,7 +493,7 @@ def test_getitem_period_str():
         with pytest.warns(
             FutureWarning, match="Indexing a DataFrame with a datetimelike"
         ):
-            assert_eq(df["2011-01-02"], ddf["2011-01-02"])
+            assert_eq(df.loc["2011-01-02"], ddf["2011-01-02"])
     else:
         assert_eq(df["2011-01-02"], ddf["2011-01-02"])
     assert_eq(df["2011-01-02":"2011-01-10"], ddf["2011-01-02":"2011-01-10"])
@@ -509,11 +509,17 @@ def test_getitem_period_str():
         with pytest.warns(
             FutureWarning, match="Indexing a DataFrame with a datetimelike"
         ):
-            assert_eq(df["2011-01"], ddf["2011-01"])
+            assert_eq(df.loc["2011-01"], ddf["2011-01"])
     else:
         assert_eq(df["2011-01"], ddf["2011-01"])
 
-    assert_eq(df.loc["2011"], ddf.loc["2011"])
+    if PANDAS_GT_120:
+        with pytest.warns(
+            FutureWarning, match="Indexing a DataFrame with a datetimelike"
+        ):
+            assert_eq(df.loc["2011"], ddf["2011"])
+    else:
+        assert_eq(df["2011"], ddf["2011"])
 
     assert_eq(df["2011-01":"2012-05"], ddf["2011-01":"2012-05"])
     assert_eq(df["2011":"2015"], ddf["2011":"2015"])


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

Part of  #7100 