### PR TITLE
Initial da.select() implementation and test (#6067)

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -134,6 +134,7 @@ try:
         rot90,
         round,
         searchsorted,
+        select,
         shape,
         squeeze,
         swapaxes,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1868,13 +1868,8 @@ def select(condlist, choicelist, default=0):
         msg = f"Choicelist elements do not have a common dtype: {e}"
         raise TypeError(msg) from None
 
-    max_choice_dim = max([len(choice.shape) for choice in choicelist])
-    blockwise_shape = (0,)
-    if max_choice_dim > 1:
-        blockwise_shape = (0, 1)
-
-    condargs = [arg for elem in condlist for arg in (elem, blockwise_shape)]
-    choiceargs = [arg for elem in choicelist for arg in (elem, blockwise_shape)]
+    condargs = [arg for elem in condlist for arg in (elem, tuple(range(len(elem.ndim)))]
+    choiceargs = [arg for elem in choicelist for arg in (elem, tuple(range(len(elem.ndim)))]
 
     return blockwise(
         _select,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1843,6 +1843,22 @@ def piecewise(x, condlist, funclist, *args, **kw):
     )
 
 
+@derived_from(np)
+def select(condlist, choicelist, default=0):
+    return blockwise(
+        np.select,
+        "m",
+        condlist,
+        "nm",
+        choicelist,
+        "nm",
+        dtype=result_type(*choicelist),
+        name="select",
+        concatenate=True,
+        default=default,
+    )
+
+
 def _partition(total: int, divisor: int) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
     """
     Given a total and a divisor, return two tuples: A tuple containing `divisor` repeated

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1865,11 +1865,13 @@ def select(condlist, choicelist, default=0):
     try:
         intermediate_dtype = result_type(*choicelist)
     except TypeError as e:
-        msg = f"Choicelist elements do not have a common dtype."
+        msg = "Choicelist elements do not have a common dtype."
         raise TypeError(msg) from e
 
-    condargs = [arg for elem in condlist for arg in (elem, tuple(range(len(elem.ndim)))]
-    choiceargs = [arg for elem in choicelist for arg in (elem, tuple(range(len(elem.ndim)))]
+    blockwise_shape = tuple(range(choicelist[0].ndim))
+
+    condargs = [arg for elem in condlist for arg in (elem, blockwise_shape)]
+    choiceargs = [arg for elem in choicelist for arg in (elem, blockwise_shape)]
 
     return blockwise(
         _select,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1865,8 +1865,8 @@ def select(condlist, choicelist, default=0):
     try:
         intermediate_dtype = result_type(*choicelist)
     except TypeError as e:
-        msg = f"Choicelist elements do not have a common dtype: {e}"
-        raise TypeError(msg) from None
+        msg = f"Choicelist elements do not have a common dtype."
+        raise TypeError(msg) from e
 
     condargs = [arg for elem in condlist for arg in (elem, tuple(range(len(elem.ndim)))]
     choiceargs = [arg for elem in choicelist for arg in (elem, tuple(range(len(elem.ndim)))]

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1844,6 +1844,10 @@ def piecewise(x, condlist, funclist, *args, **kw):
 
 
 def _select(*args, **kwargs):
+    """
+    This is a version of :func:`numpy.select` that acceptes an arbitrary number of arguments and
+    splits them in half to create ``condlist`` and ``choicelist`` params.
+    """
     split_at = len(args) // 2
     condlist = args[:split_at]
     choicelist = args[split_at:]

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1847,11 +1847,11 @@ def piecewise(x, condlist, funclist, *args, **kw):
 def select(condlist, choicelist, default=0):
     return blockwise(
         np.select,
-        "m",
+        tuple(range(1, choicelist[0].ndim + 1)),
         condlist,
-        "nm",
+        tuple(range(choicelist[0].ndim + 1)),
         choicelist,
-        "nm",
+        tuple(range(choicelist[0].ndim + 1)),
         dtype=result_type(*choicelist),
         name="select",
         concatenate=True,

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -34,7 +34,9 @@ missing_arrfunc_reason = "NEP-18 support is not available in NumPy"
         lambda x: np.round(x),
         lambda x: np.insert(x, 0, 3, axis=0),
         lambda x: np.delete(x, 0, axis=0),
-        lambda x: np.select([x < 0, x > 2, x > 1], [x, x * 2, x * 3], default=1),
+        lambda x: np.select(
+            [x < 0.3, x < 0.6, x > 0.7], [x * 2, x, x / 2], default=0.65
+        ),
     ],
 )
 def test_array_function_dask(func):

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -34,6 +34,7 @@ missing_arrfunc_reason = "NEP-18 support is not available in NumPy"
         lambda x: np.round(x),
         lambda x: np.insert(x, 0, 3, axis=0),
         lambda x: np.delete(x, 0, axis=0),
+        lambda x: np.select([x < 0, x > 2, x > 1], [x, x * 2, x * 3], default=1),
     ],
 )
 def test_array_function_dask(func):

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1516,6 +1516,21 @@ def test_select_multidimension():
     assert_eq(res_y, res_x)
 
 
+def test_select_return_dtype():
+    d = np.array([1, 2, 3, np.nan, 5, 7])
+    m = np.isnan(d)
+    assert_eq(np.select([m], [d]), da.select([m], [d]), equal_nan=True)
+
+
+@pytest.mark.xfail(reason="broadcasting in select not implemented yet")
+def test_select_broadcasting():
+    conditions = [np.array(True), np.array([False, True, False])]
+    choices = [1, np.arange(12).reshape(4, 3)]
+    assert_eq(np.select(conditions, choices), da.select(conditions, choices))
+    # default can broadcast too:
+    assert_eq(np.select([True], [0], default=[0]), da.select([True], [0], default=[0]))
+
+
 def test_argwhere():
     for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1507,6 +1507,15 @@ def test_select():
     assert_eq(np.select(conditions, choices), da.select(d_conditions, d_choices))
 
 
+def test_select_multidimension():
+    x = np.random.random((100, 100))
+    y = da.from_array(x, chunks=(50, 50))
+    res_x = np.select([x < 0, x > 2, x > 1], [x, x * 2, x * 3], default=1)
+    res_y = da.select([y < 0, y > 2, y > 1], [y, y * 2, y * 3], default=1)
+    assert isinstance(res_y, da.Array)
+    assert_eq(res_y, res_x)
+
+
 def test_argwhere():
     for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1508,8 +1508,8 @@ def test_select():
 
 
 def test_select_multidimension():
-    x = np.random.random((100, 100))
-    y = da.from_array(x, chunks=(50, 50))
+    x = np.random.random((100, 50, 2))
+    y = da.from_array(x, chunks=(50, 50, 1))
     res_x = np.select([x < 0, x > 2, x > 1], [x, x * 2, x * 3], default=1)
     res_y = da.select([y < 0, y > 2, y > 1], [y, y * 2, y * 3], default=1)
     assert isinstance(res_y, da.Array)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1519,14 +1519,18 @@ def test_select_multidimension():
 def test_select_return_dtype():
     d = np.array([1, 2, 3, np.nan, 5, 7])
     m = np.isnan(d)
-    assert_eq(np.select([m], [d]), da.select([m], [d]), equal_nan=True)
+    d_d = da.from_array(d)
+    d_m = da.isnan(d_d)
+    assert_eq(np.select([m], [d]), da.select([d_m], [d_d]), equal_nan=True)
 
 
-@pytest.mark.xfail(reason="broadcasting in select not implemented yet")
+@pytest.mark.xfail(reason="broadcasting in da.select() not implemented yet")
 def test_select_broadcasting():
     conditions = [np.array(True), np.array([False, True, False])]
     choices = [1, np.arange(12).reshape(4, 3)]
-    assert_eq(np.select(conditions, choices), da.select(conditions, choices))
+    d_conditions = da.from_array(conditions)
+    d_choices = da.from_array(choices)
+    assert_eq(np.select(conditions, choices), da.select(d_conditions, d_choices))
     # default can broadcast too:
     assert_eq(np.select([True], [0], default=[0]), da.select([True], [0], default=[0]))
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1491,6 +1491,22 @@ def test_piecewise_otherwise():
     )
 
 
+def test_select():
+    conditions = [
+        np.array([False, False, False, False]),
+        np.array([False, True, False, True]),
+        np.array([False, False, True, True]),
+    ]
+    choices = [
+        np.array([1, 2, 3, 4]),
+        np.array([5, 6, 7, 8]),
+        np.array([9, 10, 11, 12]),
+    ]
+    d_conditions = da.from_array(conditions, chunks=(3, 2))
+    d_choices = da.from_array(choices)
+    assert_eq(np.select(conditions, choices), da.select(d_conditions, d_choices))
+
+
 def test_argwhere():
     for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
         x = np.random.randint(10, size=shape)


### PR DESCRIPTION
- [X] Closes #6067 
- [X] Tests added / passed
- [X] Passes `black dask` / `flake8 dask` / `isort dask`

̉First contribution! :muscle: 
I just implemented it as much as `da.piecewise()`, there are potential improvements as benchmarks, tests for broadcasting, but I think that it works for a first implementation.