### PR TITLE
Ensure correct column order in csv project_columns

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -68,6 +68,8 @@ class CSVFunctionWrapper:
         """Return a new CSVFunctionWrapper object with
         a sub-column projection.
         """
+        # Make sure columns is ordered correctly
+        columns = [c for c in self.head.columns if c in columns]
         if columns == self.columns:
             return self
         func = copy.deepcopy(self)

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1664,6 +1664,7 @@ def test_csv_getitem_column_order(tmpdir):
     df1 = pd.DataFrame([{c: v for c, v in zip(columns, values)}])
     df1.to_csv(path)
 
-    columns = list("hczkylape")
+    # Use disordered and duplicated column selection
+    columns = list("hczzkylaape")
     df2 = dd.read_csv(path)[columns].head(1)
     assert_eq(df1[columns], df2)

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1652,3 +1652,18 @@ def test_read_csv_groupby_get_group(tmpdir):
     ddfs = ddf1.groupby("foo")
 
     assert_eq(df1, ddfs.get_group(10).compute())
+
+
+def test_csv_getitem_column_order(tmpdir):
+    # See: https://github.com/dask/dask/issues/7759
+
+    path = os.path.join(str(tmpdir), "test.csv")
+    columns = list("abcdefghijklmnopqrstuvwxyz")
+    values = list(range(len(columns)))
+
+    df1 = pd.DataFrame([{c: v for c, v in zip(columns, values)}])
+    df1.to_csv(path)
+
+    columns = list("hczkylape")
+    df2 = dd.read_csv(path)[columns].head(1)
+    assert_eq(df1[columns], df2)


### PR DESCRIPTION
There is no guarantee that the function-wrapper used within a `DataFrameIOLayer` will be passed an **ordered** column list when `project_columns` is used.  Since `CSVFunctionWrapper.project_columns` **does** require the column selection to be ordered, it must explicitly reorder the list before it is passed as a pandas `usecols` parameter.

This PR includes the necessary order check and adds relevant test coverage.

- [x] Closes #7759
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
