### PR TITLE
Add convenience method is_materialized to check all high level graph layers

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -695,6 +695,10 @@ class HighLevelGraph(Mapping):
     def __iter__(self):
         return iter(self.to_dict())
 
+    def is_materialized(self):
+        """Checks whether all high level graph layers are fully materialized."""
+        return all([layer.is_materialized() for layer in self.layers.values()])
+
     def to_dict(self) -> dict:
         """Efficiently convert to plain dict. This method is faster than dict(self)."""
         try:

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -209,6 +209,7 @@ def test_blockwise_cull(flat):
         out_keys = layer.get_output_keys()
         assert out_keys == {(layer.output, *select)}
         assert not layer.is_materialized()
+    assert not x.dask.is_materialized()
 
 
 def test_highlevelgraph_dicts_deprecation():
@@ -236,7 +237,9 @@ def test_len_does_not_materialize():
 
     assert hg.layers["a"].is_materialized()
     assert not hg.layers["b"].is_materialized()
+    assert not hg.is_materialized()  # check if all HLG layers are materialized
 
     assert len(hg) == len(a) + len(b) == 7
 
     assert not hg.layers["b"].is_materialized()
+    assert not hg.is_materialized()  # check if all HLG layers are materialized


### PR DESCRIPTION
I wanted a convenience method to check whether all layers in a high level graph have been materialized or not. This is a lot easier than checking multiple individual layers, or writing your own for loop every time.

It might also come in handy for improved representations of high level graphs https://github.com/dask/dask/issues/7754

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
