### PR TITLE
Evaluate graph lazily if meta is provided in from_delayed

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -584,16 +584,18 @@ def from_delayed(
         delayed(df) if not isinstance(df, Delayed) and hasattr(df, "key") else df
         for df in dfs
     ]
+
     for df in dfs:
         if not isinstance(df, Delayed):
             raise TypeError("Expected Delayed object, got %s" % type(df).__name__)
 
-    parent_meta = delayed(make_meta)(dfs[0]).compute()
-
     if meta is None:
-        meta = parent_meta
+        meta = delayed(make_meta)(dfs[0]).compute()
     else:
-        meta = make_meta(meta, parent_meta=parent_meta)
+        meta = make_meta(meta)
+
+    if not dfs:
+        dfs = [delayed(make_meta)(meta)]
 
     name = prefix + "-" + tokenize(*dfs)
     dsk = merge(df.dask for df in dfs)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2205,9 +2205,8 @@ def test_from_delayed_lazy_if_meta_provided():
 
 def test_from_delayed_empty_meta_provided():
     ddf = dd.from_delayed([], meta=dict(a=float))
-    df = ddf.compute()
     expected = pd.DataFrame({"a": [0.1]}).iloc[:0]
-    assert_eq(df, expected)
+    assert_eq(ddf, expected)
 
 
 def test_fillna_duplicate_index():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2189,6 +2189,27 @@ def test_fillna():
     assert_eq(df.fillna(method="pad", limit=3), ddf.fillna(method="pad", limit=3))
 
 
+def test_from_delayed_lazy_if_meta_provided():
+    """Ensure that the graph is 100% lazily evaluted if meta is provided"""
+
+    @dask.delayed
+    def raise_exception():
+        raise RuntimeError()
+
+    tasks = [raise_exception()]
+    ddf = dd.from_delayed(tasks, meta=dict(a=float))
+
+    with pytest.raises(RuntimeError):
+        ddf.compute()
+
+
+def test_from_delayed_empty_meta_provided():
+    ddf = dd.from_delayed([], meta=dict(a=float))
+    df = ddf.compute()
+    expected = pd.DataFrame({"a": [0.1]}).iloc[:0]
+    assert_eq(df, expected)
+
+
 def test_fillna_duplicate_index():
     @dask.delayed
     def f():


### PR DESCRIPTION
The `from_delayed` no longer is lazy and always computes the first element. This is unfortunate, particularly since the tasks typically involve remote connections. 

This is a regression which was introduced in https://github.com/dask/dask/pull/7586

Apparently this was somehow purposefully done, see https://github.com/dask/dask/pull/7586#discussion_r637579242 but I don't understand the reasoning. @galipremsagar can you please shed a bit more light onto this?

Disclaimer: I haven't run the full test suite, yet, in case this lights up like a xmas tree. Anyhow, I believe we should try to preserve the lazy evaluation if meta is provided

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

xref https://github.com/JDASoftwareGroup/kartothek/issues/475
