### PR TITLE
Update setup.cfg for non-verbose pytest tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ test = pytest
 markers:
   network: Test requires an internet connection
   slow: Skipped unless --runslow passed
-addopts = -v -rsxfE --durations=10
+addopts = -rsxfE --durations=10
 filterwarnings =
     # From Cython-1753
     ignore:can't resolve:ImportWarning


### PR DESCRIPTION
When tests fail in the CI, the output logs are truncated to the point that ~~you can't see which tests have tailed~~ you can only see some of the earliest failing tests, but not necessarily the important tests for a specific PR's changes ([eg: this example](https://github.com/dask/dask/pull/7740/checks?check_run_id=2768237148))

> This step has been truncated due to its large size. Download the full logs from the menu once the workflow run has completed.

Has this problem been affecting other people?

While it should be possible to download the full logs archive and search through that, that's an extra step and also sometimes the download file is corrupted (this was the case when I tried to download the logs here several times).

If GitHub actions only allows approximately a few thousand lines in the logs for each CI stage, I think we should remove the pytest verbose flag & rely on the summarized list of failures/errors (from the pytest `-rfE` command line flag). This PR does that.

