### PR TITLE
Fix for paths ending with "/" in parquet overwrite

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -20,7 +20,7 @@ dependencies:
   - zarr
   - tiledb-py
   - xarray
-  - fsspec=2021.5.0
+  - fsspec
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
   # along with other issues https://github.com/pandas-dev/pandas/issues/40467
   - sqlalchemy<1.4.0

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -29,7 +29,7 @@ dependencies:
   - bcolz
   - blosc
   - s3fs
-  - fsspec=2021.5.0
+  - fsspec
   - boto3
   - botocore
   - aiohttp

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -20,7 +20,7 @@ dependencies:
   - zarr
   - tiledb-py
   - xarray
-  - fsspec=2021.5.0
+  - fsspec
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
   # along with other issues https://github.com/pandas-dev/pandas/issues/40467
   - sqlalchemy<1.4.0

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -20,7 +20,7 @@ dependencies:
   - zarr
   - tiledb-py
   - xarray
-  - fsspec=2021.5.0
+  - fsspec
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
   # along with other issues https://github.com/pandas-dev/pandas/issues/40467
   - sqlalchemy<1.4.0

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -487,7 +487,7 @@ def to_parquet(
     if overwrite:
         if isinstance(fs, LocalFileSystem):
             working_dir = fs.expand_path(".")[0]
-            if path == working_dir:
+            if path.rstrip("/") == working_dir.rstrip("/"):
                 raise ValueError(
                     "Cannot clear the contents of the current working directory!"
                 )


### PR DESCRIPTION
- [ ] Follows #7771
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`

This fixes failures showing up in CI following fsspec's 2021.06.0 release. The issue is also fixed in https://github.com/intake/filesystem_spec/pull/662 , but doesn't hurt here.