### PR TITLE
Make Layer get_output_keys officially an abstract method

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -96,6 +96,7 @@ class Layer(collections.abc.Mapping):
         """Return whether the layer is materialized or not"""
         return True
 
+    @abc.abstractmethod
     def get_output_keys(self) -> AbstractSet:
         """Return a set of all output keys
 
@@ -110,7 +111,7 @@ class Layer(collections.abc.Mapping):
         keys: AbstractSet
             All output keys
         """
-        return self.keys()
+        return self.keys()  # this implementation will materialize the graph
 
     def cull(
         self, keys: set, all_hlg_keys: Iterable
@@ -497,6 +498,9 @@ class MaterializedLayer(Layer):
 
     def is_materialized(self):
         return True
+
+    def get_output_keys(self):
+        return self.keys()
 
 
 class HighLevelGraph(Mapping):


### PR DESCRIPTION
@ian-r-rose and I think that the `get_output_keys` method on `Layer` should be marked as an abstract method (similar to `is_materialized`). This [comment by Mads](https://github.com/dask/dask/pull/6774/files#r514027464) and the fact the return type is marked as an `AbstractSet` seem to support that conclusion.

Context: Ian and I were debugging some slicing high level graph work, and found that this method was causing unwanted materialization of the task graph & we should have been writing our own implementation of it for the new layer class. Marking the original as an abstract method means other people won't be able to make the same mistake easily.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
