### PR TITLE
Only rechunk for median if needed

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1584,8 +1584,7 @@ def median(a, axis=None, keepdims=False, out=None):
     axis = [ax + a.ndim if ax < 0 else ax for ax in axis]
 
     # rechunk if reduced axes are not contained in a single chunk
-    # cannot use `any` to check since `any` is defined in this file
-    if any(a.numblocks[ax] > 1 for ax in axis):
+    if builtins.any(a.numblocks[ax] > 1 for ax in axis):
         a = a.rechunk({ax: -1 if ax in axis else "auto" for ax in range(a.ndim)})
 
     result = a.map_blocks(
@@ -1620,14 +1619,7 @@ def nanmedian(a, axis=None, keepdims=False, out=None):
     axis = [ax + a.ndim if ax < 0 else ax for ax in axis]
 
     # rechunk if reduced axes are not contained in a single chunk
-    # cannot use `any` to check since `any` is defined in this file
-    needs_rechunk = False
-    for ax in axis:
-        if a.numblocks[ax] > 1:
-            needs_rechunk = True
-            break
-
-    if needs_rechunk:
+    if builtins.any(a.numblocks[ax] > 1 for ax in axis):
         a = a.rechunk({ax: -1 if ax in axis else "auto" for ax in range(a.ndim)})
 
     result = a.map_blocks(

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1585,13 +1585,7 @@ def median(a, axis=None, keepdims=False, out=None):
 
     # rechunk if reduced axes are not contained in a single chunk
     # cannot use `any` to check since `any` is defined in this file
-    needs_rechunk = False
-    for ax in axis:
-        if a.numblocks[ax] > 1:
-            needs_rechunk = True
-            break
-
-    if needs_rechunk:
+    if any(a.numblocks[ax] > 1 for ax in axis):
         a = a.rechunk({ax: -1 if ax in axis else "auto" for ax in range(a.ndim)})
 
     result = a.map_blocks(

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1569,7 +1569,7 @@ def trace(a, offset=0, axis1=0, axis2=1, dtype=None):
 @derived_from(np)
 def median(a, axis=None, keepdims=False, out=None):
     """
-    This works by automatically chunking the reduced axes to a single chunk
+    This works by automatically chunking the reduced axes to a single chunk if necessary
     and then calling ``numpy.median`` function across the remaining dimensions
     """
     if axis is None:
@@ -1583,7 +1583,16 @@ def median(a, axis=None, keepdims=False, out=None):
 
     axis = [ax + a.ndim if ax < 0 else ax for ax in axis]
 
-    a = a.rechunk({ax: -1 if ax in axis else "auto" for ax in range(a.ndim)})
+    # rechunk if reduced axes are not contained in a single chunk
+    # cannot use `any` to check since `any` is defined in this file
+    needs_rechunk = False
+    for ax in axis:
+        if a.numblocks[ax] > 1:
+            needs_rechunk = True
+            break
+
+    if needs_rechunk:
+        a = a.rechunk({ax: -1 if ax in axis else "auto" for ax in range(a.ndim)})
 
     result = a.map_blocks(
         np.median,
@@ -1616,7 +1625,16 @@ def nanmedian(a, axis=None, keepdims=False, out=None):
 
     axis = [ax + a.ndim if ax < 0 else ax for ax in axis]
 
-    a = a.rechunk({ax: -1 if ax in axis else "auto" for ax in range(a.ndim)})
+    # rechunk if reduced axes are not contained in a single chunk
+    # cannot use `any` to check since `any` is defined in this file
+    needs_rechunk = False
+    for ax in axis:
+        if a.numblocks[ax] > 1:
+            needs_rechunk = True
+            break
+
+    if needs_rechunk:
+        a = a.rechunk({ax: -1 if ax in axis else "auto" for ax in range(a.ndim)})
 
     result = a.map_blocks(
         np.nanmedian,

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -13,7 +13,6 @@ import dask.config as config
 from dask.array.utils import assert_eq as _assert_eq
 from dask.array.utils import same_keys
 from dask.core import get_deps
-from dask.utils import key_split
 
 
 def assert_eq(a, b):

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -712,9 +712,7 @@ def test_median_does_not_rechunk_if_whole_axis_in_one_chunk(axis, func):
     actual = getattr(da, func)(d, axis=axis)
     expected = getattr(np, func)(x, axis=axis)
     assert_eq(actual, expected)
-    does_rechunk = any(
-        ["rechunk" in key_split(k) for k in actual.__dask_graph__().keys()]
-    )
+    does_rechunk = "rechunk" in str(dict(actual.__dask_graph__()))
     if axis == 1:
         assert does_rechunk
     else:


### PR DESCRIPTION
- [x] Closes #7780
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

From original issue:
```python
import dask.array as da
x = da.random.normal(10, 0.1, size=(100000, 100000), chunks=(10, 100000))
y = da.reductions.median(x, axis=1)
%time z = y.compute()

# CPU times: user 17min 32s, sys: 2.68 s, total: 17min 35s
# Wall time: 1min 36s
```