### PR TITLE
Don't include or expect `freq` in divisions

### DIFF
--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -14,8 +14,8 @@ def test_make_timeseries():
         "2000", "2015", {"A": float, "B": int, "C": str}, freq="2D", partition_freq="6M"
     )
 
-    assert df.divisions[0] == pd.Timestamp("2000-01-31", freq="6M")
-    assert df.divisions[-1] == pd.Timestamp("2014-07-31", freq="6M")
+    assert df.divisions[0] == pd.Timestamp("2000-01-31")
+    assert df.divisions[-1] == pd.Timestamp("2014-07-31")
     tm.assert_index_equal(df.columns, pd.Index(["A", "B", "C"]))
     assert df["A"].head().dtype == float
     assert df["B"].head().dtype == int

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2059,12 +2059,12 @@ def test_repartition_freq_month():
     assert_eq(df, ddf)
 
     assert ddf.divisions == (
-        pd.Timestamp("2015-1-1 00:00:00", freq="MS"),
-        pd.Timestamp("2015-2-1 00:00:00", freq="MS"),
-        pd.Timestamp("2015-3-1 00:00:00", freq="MS"),
-        pd.Timestamp("2015-4-1 00:00:00", freq="MS"),
-        pd.Timestamp("2015-5-1 00:00:00", freq="MS"),
-        pd.Timestamp("2015-5-1 23:50:00", freq="10T"),
+        pd.Timestamp("2015-1-1 00:00:00"),
+        pd.Timestamp("2015-2-1 00:00:00"),
+        pd.Timestamp("2015-3-1 00:00:00"),
+        pd.Timestamp("2015-4-1 00:00:00"),
+        pd.Timestamp("2015-5-1 00:00:00"),
+        pd.Timestamp("2015-5-1 23:50:00"),
     )
 
     assert ddf.npartitions == 5
@@ -2082,8 +2082,8 @@ def test_repartition_freq_day():
     assert_eq(ddf, pdf)
     assert ddf.npartitions == 2
     assert ddf.divisions == (
-        pd.Timestamp("2020-1-1", freq="D"),
-        pd.Timestamp("2020-1-2", freq="D"),
+        pd.Timestamp("2020-1-1"),
+        pd.Timestamp("2020-1-2"),
         pd.Timestamp("2020-1-2"),
     )
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1013,8 +1013,8 @@ def test_set_index_timestamp():
     df = pd.DataFrame({"A": pd.date_range("2000", periods=12, tz="US/Central"), "B": 1})
     ddf = dd.from_pandas(df, 2)
     divisions = (
-        pd.Timestamp("2000-01-01 00:00:00-0600", tz="US/Central", freq="D"),
-        pd.Timestamp("2000-01-12 00:00:00-0600", tz="US/Central", freq="D"),
+        pd.Timestamp("2000-01-01 00:00:00-0600", tz="US/Central"),
+        pd.Timestamp("2000-01-12 00:00:00-0600", tz="US/Central"),
     )
 
     # Note: `freq` is lost during round trip


### PR DESCRIPTION
Resolve: `FutureWarning: The 'freq' argument in Timestamp is deprecated and will be removed in a future version.`

Towards #7783 -- see discussion there. 