### PR TITLE
SimpleShuffleLayer should compare parts_out with set(self.parts_out)

### DIFF
--- a/dask/layers.py
+++ b/dask/layers.py
@@ -489,7 +489,7 @@ class SimpleShuffleLayer(DataFrameLayer):
         """
         parts_out = self._keys_to_parts(keys)
         culled_deps = self._cull_dependencies(keys, parts_out=parts_out)
-        if parts_out != self.parts_out:
+        if parts_out != set(self.parts_out):
             culled_layer = self._cull(parts_out)
             return culled_layer, culled_deps
         else:


### PR DESCRIPTION
I noticed that the `SimpleShuffleLayer` cull method should probably be comparing:
```python
        if parts_out != set(self.parts_out):
```
instead of the current
```python
        if parts_out != self.parts_out:
```

The reason for this is that we often find `self.parts_out` is something like `range(0, 30)`, and python won't recognize if a set and range are equal or not, unless we turn the range into a set too.

The `BroadcastJoinLayer` does do this comparison with a set, I think this is the right way:

https://github.com/dask/dask/blob/65999051ca1bdd50a0e2d01490134ee6bebe35f4/dask/layers.py#L1017

The consequences aren't super severe, I think it's just taking up extra time running an optimization that doesn't have any real effect (so we may as well save time and skip it).

Here's an example you can use where `self.parts_out` is a range and not a set. I put a breakpoint in before the line I've edited and looked at the values from there.
```python
from dask.datasets import timeseries

ddf = timeseries().shuffle("id", shuffle="tasks")
ddf.compute()
 
```

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
