### PR TITLE
Layers must implement get_output_keys method

### DIFF
--- a/dask/layers.py
+++ b/dask/layers.py
@@ -159,6 +159,9 @@ class ArrayOverlapLayer(Layer):
     def is_materialized(self):
         return hasattr(self, "_cached_dict")
 
+    def get_output_keys(self):
+        return self.keys()  # FIXME! this implementation materializes the graph
+
     def _dask_keys(self):
         if self._cached_keys is not None:
             return self._cached_keys


### PR DESCRIPTION
PR https://github.com/dask/dask/pull/7775 and PR https://github.com/dask/dask/pull/7595 conflict slightly. This stopgap should avoid test failures until we can put a proper method in place that won't materialize the task graph.

Issue tracking that planned follow up work is here https://github.com/dask/dask/issues/7791

- [x] Tests passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
