### PR TITLE
Fix upstream freq tests

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -240,6 +240,28 @@ def test_index_names():
     assert ddf.index.compute().name == "x"
 
 
+@pytest.mark.skipif(dd._compat.PANDAS_GT_130, reason="Freq no longer included in ts")
+@pytest.mark.parametrize(
+    "npartitions",
+    [
+        1,
+        pytest.param(
+            2,
+            marks=pytest.mark.xfail(
+                not dd._compat.PANDAS_GT_110, reason="Fixed upstream."
+            ),
+        ),
+    ],
+)
+def test_timezone_freq(npartitions):
+    s_naive = pd.Series(pd.date_range("20130101", periods=10))
+    s_aware = pd.Series(pd.date_range("20130101", periods=10, tz="US/Eastern"))
+    pdf = pd.DataFrame({"tz": s_aware, "notz": s_naive})
+    ddf = dd.from_pandas(pdf, npartitions=npartitions)
+
+    assert pdf.tz[0].freq == ddf.compute().tz[0].freq == ddf.tz.compute()[0].freq
+
+
 def test_rename_columns():
     # GH 819
     df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7], "b": [7, 6, 5, 4, 3, 2, 1]})

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -240,27 +240,6 @@ def test_index_names():
     assert ddf.index.compute().name == "x"
 
 
-@pytest.mark.parametrize(
-    "npartitions",
-    [
-        1,
-        pytest.param(
-            2,
-            marks=pytest.mark.xfail(
-                not dd._compat.PANDAS_GT_110, reason="Fixed upstream."
-            ),
-        ),
-    ],
-)
-def test_timezone_freq(npartitions):
-    s_naive = pd.Series(pd.date_range("20130101", periods=10))
-    s_aware = pd.Series(pd.date_range("20130101", periods=10, tz="US/Eastern"))
-    pdf = pd.DataFrame({"tz": s_aware, "notz": s_naive})
-    ddf = dd.from_pandas(pdf, npartitions=npartitions)
-
-    assert pdf.tz[0].freq == ddf.compute().tz[0].freq == ddf.tz.compute()[0].freq
-
-
 def test_rename_columns():
     # GH 819
     df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7], "b": [7, 6, 5, 4, 3, 2, 1]})

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1683,6 +1683,9 @@ def test_combine_first():
     assert_eq(ddf1.B.combine_first(df2.B), df1.B.combine_first(df2.B))
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The 'freq' argument in Timestamp is deprecated:FutureWarning"
+)  #  PANDAS_GT_130 https://github.com/pandas-dev/pandas/issues/41949
 def test_dataframe_picklable():
     from pickle import dumps, loads
 


### PR DESCRIPTION
Note that this does not resolve the pickle issue. To see what that looks like on distributed do:

```python
import dask
from distributed import Client

client = Client()
ddf = dask.datasets.timeseries()
ddf.persist()
```

output:
```python
/home/julia/conda/envs/dask-upstream-dev/lib/python3.8/site-packages/distributed/protocol/pickle.py:75: FutureWarning: The 'freq' argument in Timestamp is deprecated and will be removed in a future version.
  return pickle.loads(x)
/home/julia/conda/envs/dask-upstream-dev/lib/python3.8/site-packages/distributed/protocol/pickle.py:75: FutureWarning: The 'freq' argument in Timestamp is deprecated and will be removed in a future version.
  return pickle.loads(x)
/home/julia/conda/envs/dask-upstream-dev/lib/python3.8/site-packages/distributed/protocol/pickle.py:75: FutureWarning: The 'freq' argument in Timestamp is deprecated and will be removed in a future version.
  return pickle.loads(x)
/home/julia/conda/envs/dask-upstream-dev/lib/python3.8/site-packages/distributed/protocol/pickle.py:75: FutureWarning: The 'freq' argument in Timestamp is deprecated and will be removed in a future version.
  return pickle.loads(x)
/home/julia/conda/envs/dask-upstream-dev/lib/python3.8/site-packages/distributed/protocol/pickle.py:75: FutureWarning: The 'freq' argument in Timestamp is deprecated and will be removed in a future version.
  return pickle.loads(x)
```

ref #7783 