### PR TITLE
Use more context managers from the standard library

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -1,4 +1,5 @@
 """ A set of NumPy functions to apply per chunk """
+import contextlib
 from collections.abc import Container, Iterable, Sequence
 from functools import wraps
 from numbers import Integral
@@ -7,7 +8,6 @@ import numpy as np
 from tlz import concat
 
 from ..core import flatten
-from ..utils import ignoring
 from . import numpy_compat as npcompat
 
 try:
@@ -71,17 +71,17 @@ nanmin = np.nanmin
 nanmax = np.nanmax
 mean = np.mean
 
-with ignoring(AttributeError):
+with contextlib.suppress(AttributeError):
     nanmean = np.nanmean
 
 var = np.var
 
-with ignoring(AttributeError):
+with contextlib.suppress(AttributeError):
     nanvar = np.nanvar
 
 std = np.std
 
-with ignoring(AttributeError):
+with contextlib.suppress(AttributeError):
     nanstd = np.nanstd
 
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1,3 +1,4 @@
+import contextlib
 import math
 import operator
 import os
@@ -47,7 +48,6 @@ from ..utils import (
     format_bytes,
     funcname,
     has_keyword,
-    ignoring,
     is_arraylike,
     is_dataframe_like,
     is_index_like,
@@ -4537,7 +4537,7 @@ def offset_func(func, offset, *args):
         args2 = list(map(add, args, offset))
         return func(*args2)
 
-    with ignoring(Exception):
+    with contextlib.suppress(Exception):
         _offset.__name__ = "offset_" + func.__name__
 
     return _offset

--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -1,3 +1,4 @@
+import contextlib
 import numbers
 import warnings
 from itertools import chain, product
@@ -8,7 +9,7 @@ import numpy as np
 
 from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
-from ..utils import derived_from, ignoring, random_state_data, skip_doctest
+from ..utils import derived_from, random_state_data, skip_doctest
 from .core import (
     Array,
     asarray,
@@ -204,7 +205,7 @@ class RandomState:
     def chisquare(self, df, size=None, chunks="auto", **kwargs):
         return self._wrap("chisquare", df, size=size, chunks=chunks, **kwargs)
 
-    with ignoring(AttributeError):
+    with contextlib.suppress(AttributeError):
 
         @derived_from(np.random.RandomState, skipblocks=1)
         def choice(self, a, size=None, replace=True, p=None, chunks="auto"):

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -14,13 +14,7 @@ from .. import config
 from ..base import tokenize
 from ..blockwise import lol_tuples
 from ..highlevelgraph import HighLevelGraph
-from ..utils import (
-    deepmap,
-    derived_from,
-    funcname,
-    getargspec,
-    is_series_like,
-)
+from ..utils import deepmap, derived_from, funcname, getargspec, is_series_like
 from . import chunk
 from .blockwise import blockwise
 from .core import Array, _concatenate2, handle_out, implements

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1,4 +1,5 @@
 import builtins
+import contextlib
 import operator
 from collections.abc import Iterable
 from functools import partial
@@ -18,7 +19,6 @@ from ..utils import (
     derived_from,
     funcname,
     getargspec,
-    ignoring,
     is_series_like,
 )
 from . import chunk
@@ -327,7 +327,7 @@ def partial_reduce(
     if np.isscalar(meta):
         return Array(graph, name, out_chunks, dtype=dtype)
     else:
-        with ignoring(AttributeError):
+        with contextlib.suppress(AttributeError):
             meta = meta.astype(dtype)
         return Array(graph, name, out_chunks, meta=meta)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1,3 +1,4 @@
+import contextlib
 import copy
 from unittest import mock
 
@@ -48,7 +49,7 @@ from dask.blockwise import broadcast_dimensions
 from dask.blockwise import make_blockwise_graph as top
 from dask.blockwise import optimize_blockwise
 from dask.delayed import Delayed, delayed
-from dask.utils import apply, ignoring, key_split, tmpdir, tmpfile
+from dask.utils import apply, key_split, tmpdir, tmpfile
 from dask.utils_test import dec, inc
 
 from .test_dispatch import EncapsulateNDArray
@@ -2081,7 +2082,7 @@ def test_dtype_complex():
     assert_eq(da.exp(b).dtype, np.exp(y).dtype)
     assert_eq(da.floor(a).dtype, np.floor(x).dtype)
     assert_eq(da.isnan(b).dtype, np.isnan(y).dtype)
-    with ignoring(ImportError):
+    with contextlib.suppress(ImportError):
         assert da.isnull(b).dtype == "bool"
         assert da.notnull(b).dtype == "bool"
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1,3 +1,4 @@
+import contextlib
 import itertools
 from numbers import Number
 
@@ -9,7 +10,6 @@ np = pytest.importorskip("numpy")
 
 import dask.array as da
 from dask.array.utils import IS_NEP18_ACTIVE, AxisError, assert_eq, same_keys
-from dask.utils import ignoring
 
 
 def test_array():
@@ -1408,7 +1408,7 @@ def test_extract():
 def test_isnull():
     x = np.array([1, np.nan])
     a = da.from_array(x, chunks=(2,))
-    with ignoring(ImportError):
+    with contextlib.suppress(ImportError):
         assert_eq(da.isnull(a), np.isnan(x))
         assert_eq(da.notnull(a), ~(np.isnan(x)))
 
@@ -1416,7 +1416,7 @@ def test_isnull():
 def test_isnull_result_is_an_array():
     # regression test for https://github.com/dask/dask/issues/3822
     arr = da.from_array(np.arange(3, dtype=np.int64), chunks=-1)
-    with ignoring(ImportError):
+    with contextlib.suppress(ImportError):
         result = da.isnull(arr[0]).compute()
         assert type(result) is np.ndarray
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import difflib
 import functools
 import itertools
@@ -10,7 +11,7 @@ import numpy as np
 from tlz import concat, frequencies
 
 from ..highlevelgraph import HighLevelGraph
-from ..utils import has_keyword, ignoring, is_arraylike, is_cupy_type
+from ..utils import has_keyword, is_arraylike, is_cupy_type
 from .core import Array
 
 try:
@@ -167,7 +168,7 @@ def compute_meta(func, _dtype, *args, **kwargs):
                 return None
 
         if _dtype and getattr(meta, "dtype", None) != _dtype:
-            with ignoring(AttributeError):
+            with contextlib.suppress(AttributeError):
                 meta = meta.astype(_dtype)
 
         if np.isscalar(meta):

--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -1,10 +1,10 @@
+import contextlib
 import sys
 import threading
 import time
 from timeit import default_timer
 
 from ..callbacks import Callback
-from ..utils import ignoring
 
 
 def format_time(t):
@@ -137,7 +137,7 @@ class ProgressBar(Callback):
         msg = "\r[{0:<{1}}] | {2}% Completed | {3}".format(
             bar, self._width, percent, elapsed
         )
-        with ignoring(ValueError):
+        with contextlib.suppress(ValueError):
             if self._file is not None:
                 self._file.write(msg)
                 self._file.flush()

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 from distutils.version import LooseVersion
 from operator import add, mul
@@ -7,7 +8,7 @@ import pytest
 
 from dask.diagnostics import CacheProfiler, Profiler, ResourceProfiler
 from dask.threaded import get
-from dask.utils import apply, ignoring, tmpfile
+from dask.utils import apply, tmpfile
 
 try:
     import bokeh
@@ -44,7 +45,7 @@ def test_profiler_works_under_error():
     div = lambda x, y: x / y
     dsk = {"x": (div, 1, 1), "y": (div, "x", 2), "z": (div, "y", 0)}
 
-    with ignoring(ZeroDivisionError):
+    with contextlib.suppress(ZeroDivisionError):
         with prof:
             get(dsk, "z")
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1,5 +1,6 @@
 import abc
 import collections.abc
+import contextlib
 import copy
 import warnings
 from typing import (
@@ -19,7 +20,7 @@ import tlz as toolz
 from . import config
 from .base import clone_key, flatten, is_dask_collection
 from .core import keys_in_tasks, reverse_dict
-from .utils import ensure_dict, ignoring, stringify
+from .utils import ensure_dict, stringify
 from .utils_test import add, inc  # noqa: F401
 
 
@@ -598,7 +599,7 @@ class HighLevelGraph(Mapping):
                 layers = ensure_dict(graph.layers, copy=True)
                 layers.update({name: layer})
                 deps = ensure_dict(graph.dependencies, copy=True)
-                with ignoring(AttributeError):
+                with contextlib.suppress(AttributeError):
                     deps.update({name: set(collection.__dask_layers__())})
             else:
                 key = _get_some_layer_name(collection)
@@ -654,7 +655,7 @@ class HighLevelGraph(Mapping):
                 if isinstance(graph, HighLevelGraph):
                     layers.update(graph.layers)
                     deps.update(graph.dependencies)
-                    with ignoring(AttributeError):
+                    with contextlib.suppress(AttributeError):
                         deps[name] |= set(collection.__dask_layers__())
                 else:
                     key = _get_some_layer_name(collection)


### PR DESCRIPTION
This PR switches our use of `dask.utils.ignoring` and `dask.utils.noop_context` to `contextlib.suppress` and `contextlib.nullcontext` from the standard library, respectively. 

Since these internal utilities have been around for a long time and may (?) be used outside of Dask, I've opted to go through a short deprecation cycle. 