### PR TITLE
Remove `ImportError` catching from `dask/__init__.py`

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -1,24 +1,9 @@
 from . import config, datasets
-from .core import istask
-from .local import get_sync as get
-
-try:
-    from .delayed import delayed
-except ImportError:
-    pass
-try:
-    from .base import (
-        annotate,
-        compute,
-        is_dask_collection,
-        optimize,
-        persist,
-        visualize,
-    )
-except ImportError:
-    pass
-
 from ._version import get_versions
+from .base import annotate, compute, is_dask_collection, optimize, persist, visualize
+from .core import istask
+from .delayed import delayed
+from .local import get_sync as get
 
 versions = get_versions()
 __version__ = versions["version"]


### PR DESCRIPTION
These `try`/ `except ImportError` blocks shouldn't be needed anymore now that we've included `toolz`, `cloudpickle`, etc. as minimum dependencies for Dask. Additionally, our import check in CI

https://github.com/dask/dask/blob/7af542afaeba9eea46cea653c51a02a2c3376962/continuous_integration/scripts/test_imports.sh#L17

will ensure that we can continue to import `dask.delayed` and `dask.base` without any packages beyond Dask's minimum required dependencies. 