### PR TITLE
Remove compatibility entries for old distributed.

### DIFF
--- a/continuous_integration/scripts/test_imports.sh
+++ b/continuous_integration/scripts/test_imports.sh
@@ -6,8 +6,12 @@ test_import () {
     echo "Create environment: python=$PYTHON_VERSION $1"
     # Create an empty environment
     mamba create -q -y -n test-imports -c conda-forge python=$PYTHON_VERSION pyyaml fsspec toolz partd cloudpickle $1
+    if [[ $1 =~ "distributed" ]]; then
+        # dask[distributed] depends on the latest version of distributed
+        python -m pip install git+https://github.com/dask/distributed
+    fi
     conda activate test-imports
-    pip install -e .
+    python -m pip install -e .
     echo "python -c '$2'"
     python -c "$2"
     conda deactivate

--- a/continuous_integration/scripts/test_imports.sh
+++ b/continuous_integration/scripts/test_imports.sh
@@ -12,6 +12,7 @@ test_import () {
     fi
     conda activate test-imports
     python -m pip install -e .
+    mamba list
     echo "python -c '$2'"
     python -c "$2"
     conda deactivate

--- a/continuous_integration/scripts/test_imports.sh
+++ b/continuous_integration/scripts/test_imports.sh
@@ -8,6 +8,7 @@ test_import () {
     mamba create -q -y -n test-imports -c conda-forge python=$PYTHON_VERSION pyyaml fsspec toolz partd cloudpickle $1
     if [[ $1 =~ "distributed" ]]; then
         # dask[distributed] depends on the latest version of distributed
+        mamba uninstall --force -y distributed
         python -m pip install git+https://github.com/dask/distributed
     fi
     conda activate test-imports

--- a/continuous_integration/scripts/test_imports.sh
+++ b/continuous_integration/scripts/test_imports.sh
@@ -8,7 +8,9 @@ test_import () {
     mamba create -q -y -n test-imports -c conda-forge python=$PYTHON_VERSION pyyaml fsspec toolz partd cloudpickle $1
     if [[ $1 =~ "distributed" ]]; then
         # dask[distributed] depends on the latest version of distributed
-        mamba uninstall --force -y distributed
+        # mamba uninstall doesn't have --force yet https://github.com/mamba-org/mamba/issues/412
+        # mamba uninstall -y --force distributed
+        conda uninstall -y --force distributed
         python -m pip install git+https://github.com/dask/distributed
     fi
     conda activate test-imports

--- a/continuous_integration/scripts/test_imports.sh
+++ b/continuous_integration/scripts/test_imports.sh
@@ -9,9 +9,6 @@ test_import () {
     conda activate test-imports
     if [[ $1 =~ "distributed" ]]; then
         # dask[distributed] depends on the latest version of distributed
-        # mamba uninstall doesn't have --force yet https://github.com/mamba-org/mamba/issues/412
-        # mamba uninstall -y --force distributed
-        conda uninstall -y --force distributed
         python -m pip install git+https://github.com/dask/distributed
     fi
     python -m pip install -e .

--- a/continuous_integration/scripts/test_imports.sh
+++ b/continuous_integration/scripts/test_imports.sh
@@ -6,6 +6,7 @@ test_import () {
     echo "Create environment: python=$PYTHON_VERSION $1"
     # Create an empty environment
     mamba create -q -y -n test-imports -c conda-forge python=$PYTHON_VERSION pyyaml fsspec toolz partd cloudpickle $1
+    conda activate test-imports
     if [[ $1 =~ "distributed" ]]; then
         # dask[distributed] depends on the latest version of distributed
         # mamba uninstall doesn't have --force yet https://github.com/mamba-org/mamba/issues/412
@@ -13,7 +14,6 @@ test_import () {
         conda uninstall -y --force distributed
         python -m pip install git+https://github.com/dask/distributed
     fi
-    conda activate test-imports
     python -m pip install -e .
     mamba list
     echo "python -c '$2'"

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -10,11 +10,10 @@ import numpy as np
 from tlz import concat, interleave, sliding_window
 
 from ..base import is_dask_collection, tokenize
-from ..compatibility import apply
 from ..core import flatten
 from ..delayed import Delayed, unpack_collections
 from ..highlevelgraph import HighLevelGraph
-from ..utils import derived_from, funcname, is_arraylike, is_cupy_type
+from ..utils import apply, derived_from, funcname, is_arraylike, is_cupy_type
 from . import chunk
 from .core import (
     Array,

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -1,12 +1,6 @@
 import sys
 from distutils.version import LooseVersion
 
-# TODO: remove this import once dask requires distributed > 2.3.2
-from .utils import apply  # noqa
-
-# TODO: remove this once dask requires distributed >= 2.2.0
-unicode = str  # noqa
-
 try:
     from math import prod
 except ImportError:


### PR DESCRIPTION
setup.py lists distributed as 2021.06.0, which is far above the
2.something in these comments.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
