### PR TITLE
Remove check for outdated bokeh.

### DIFF
--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -171,18 +171,9 @@ def visualize(profilers, file_path=None, show=True, save=True, mode=None, **kwar
     The completed bokeh plot object.
     """
     bp = import_required("bokeh.plotting", _BOKEH_MISSING_MSG)
-    import bokeh
+    from bokeh.io import state
 
-    if LooseVersion(bokeh.__version__) >= "0.12.10":
-        from bokeh.io import state
-
-        in_notebook = state.curstate().notebook
-    else:
-        from bokeh.io import _state
-
-        in_notebook = _state._notebook
-
-    if not in_notebook:
+    if not state.curstate().notebook:
         file_path = file_path or "profile.html"
         bp.output_file(file_path, mode=mode)
 


### PR DESCRIPTION
The minimum is now 1.0.0.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
