### PR TITLE
Enforce dtype conservation in ufuncs that explicitly use dtype=

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4313,15 +4313,6 @@ def elemwise(op, *args, **kwargs):
     if "dtype" in kwargs:
         need_enforce_dtype = True
         dt = kwargs["dtype"]
-    elif out is not None:
-        need_enforce_dtype = True
-        if isinstance(out, Array):
-            dt = out.dtype
-        else:
-            # if `out` is not an Array we assume it's a tuple due to
-            # __array_ufunc__, in that case we get the dtype from the
-            # first element of the tuple.
-            dt = out[0].dtype
     else:
         # We follow NumPy's rules for dtype promotion, which special cases
         # scalars and 0d ndarrays (which it considers equivalent) by using

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4311,7 +4311,17 @@ def elemwise(op, *args, **kwargs):
 
     need_enforce_dtype = False
     if "dtype" in kwargs:
+        need_enforce_dtype = True
         dt = kwargs["dtype"]
+    elif out is not None:
+        need_enforce_dtype = True
+        if isinstance(out, Array):
+            dt = out.dtype
+        else:
+            # if `out` is not an Array we assume it's a tuple due to
+            # __array_ufunc__, in that case we get the dtype from the
+            # first element of the tuple.
+            dt = out[0].dtype
     else:
         # We follow NumPy's rules for dtype promotion, which special cases
         # scalars and 0d ndarrays (which it considers equivalent) by using

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -478,14 +478,14 @@ def test_divmod():
 
 @pytest.mark.parametrize("dt", ["float64", "float32", "int32", "int64"])
 def test_dtype_kwarg(dt):
-    x1, y1 = da.asarray([1, 2, 3]), da.asarray([4, 5, 6])
-    assert x1.dtype == np.dtype("int64")
-    assert y1.dtype == np.dtype("int64")
+    x1 = da.asarray([1, 2, 3], dtype=np.int64)
+    y1 = da.asarray([4, 5, 6], dtype=np.int64)
     z1 = np.add(x1, y1, dtype=np.dtype(dt))
     assert z1.dtype == np.dtype(dt)
     assert z1.compute().dtype == z1.dtype
 
-    x2, y2 = da.asarray([1, 2, 3]), da.asarray([4, 5, 6])
+    x2 = da.asarray([1, 2, 3], dtype=np.int64)
+    y2 = da.asarray([4, 5, 6], dtype=np.int64)
     z2 = da.add(x2, y2, dtype=np.dtype(dt))
     assert z2.dtype == np.dtype(dt)
     assert z2.compute().dtype == z2.dtype

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -478,16 +478,15 @@ def test_divmod():
 
 @pytest.mark.parametrize("dt", ["float64", "float32", "int32", "int64"])
 def test_dtype_kwarg(dt):
-    x1 = da.asarray([1, 2, 3])
-    y1 = da.asarray([4, 5, 6])
-    z1 = np.add(x1, y1, dtype=np.dtype(dt))
-    assert z1.dtype == np.dtype(dt)
-    assert z1.compute().dtype == z1.dtype
+    arr1 = np.array([1, 2, 3])
+    arr2 = np.array([4, 5, 6])
 
-    x2 = da.asarray([1, 2, 3])
-    y2 = da.asarray([4, 5, 6])
-    z2 = da.add(x2, y2, dtype=np.dtype(dt))
-    assert z2.dtype == np.dtype(dt)
-    assert z2.compute().dtype == z2.dtype
+    darr1 = da.from_array(arr1)
+    darr2 = da.from_array(arr2)
 
-    assert_eq(z1, z2)
+    expected = np.add(arr1, arr2, dtype=dt)
+    result = np.add(darr1, darr2, dtype=dt)
+    assert_eq(expected, result)
+
+    result = da.add(darr1, darr2, dtype=dt)
+    assert_eq(expected, result)

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -474,3 +474,12 @@ def test_divmod():
     expected = divmod(arr1, arr2)
     assert_eq(result[0], expected[0])
     assert_eq(result[1], expected[1])
+
+
+def test_dtype_kwarg():
+    x, y = da.asarray([1, 2, 3]), da.asarray([4, 5, 6])
+    assert x.dtype == np.dtype("int64")
+    assert y.dtype == np.dtype("int64")
+    z = np.add(x, y, dtype=np.float64)
+    assert z.dtype == np.dtype("float64")
+    assert z.compute().dtype == np.dtype("float64")

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -476,10 +476,20 @@ def test_divmod():
     assert_eq(result[1], expected[1])
 
 
-def test_dtype_kwarg():
-    x, y = da.asarray([1, 2, 3]), da.asarray([4, 5, 6])
-    assert x.dtype == np.dtype("int64")
-    assert y.dtype == np.dtype("int64")
-    z = np.add(x, y, dtype=np.float64)
-    assert z.dtype == np.dtype("float64")
-    assert z.compute().dtype == np.dtype("float64")
+@pytest.mark.parametrize(
+    "dt", ["float64", "float32", "int32", "int64"]
+)
+def test_dtype_kwarg(dt):
+    x1, y1 = da.asarray([1, 2, 3]), da.asarray([4, 5, 6])
+    assert x1.dtype == np.dtype("int64")
+    assert y1.dtype == np.dtype("int64")
+    z1 = np.add(x1, y1, dtype=np.dtype(dt))
+    assert z1.dtype == np.dtype(dt)
+    assert z1.compute().dtype == np.dtype(dt)
+
+    x2, y2 = da.asarray([1, 2, 3]), da.asarray([4, 5, 6])
+    z2 = da.add(x2, y2, dtype=np.dtype(dt))
+    assert z2.dtype == np.dtype(dt)
+    assert z2.compute().dtype == np.dtype(dt)
+
+    assert_eq(z1, z2)

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -483,11 +483,11 @@ def test_dtype_kwarg(dt):
     assert y1.dtype == np.dtype("int64")
     z1 = np.add(x1, y1, dtype=np.dtype(dt))
     assert z1.dtype == np.dtype(dt)
-    assert z1.compute().dtype == np.dtype(dt)
+    assert z1.compute().dtype == z1.dtype
 
     x2, y2 = da.asarray([1, 2, 3]), da.asarray([4, 5, 6])
     z2 = da.add(x2, y2, dtype=np.dtype(dt))
     assert z2.dtype == np.dtype(dt)
-    assert z2.compute().dtype == np.dtype(dt)
+    assert z2.compute().dtype == z2.dtype
 
     assert_eq(z1, z2)

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -478,14 +478,14 @@ def test_divmod():
 
 @pytest.mark.parametrize("dt", ["float64", "float32", "int32", "int64"])
 def test_dtype_kwarg(dt):
-    x1 = da.asarray([1, 2, 3], dtype=np.int64)
-    y1 = da.asarray([4, 5, 6], dtype=np.int64)
+    x1 = da.asarray([1, 2, 3])
+    y1 = da.asarray([4, 5, 6])
     z1 = np.add(x1, y1, dtype=np.dtype(dt))
     assert z1.dtype == np.dtype(dt)
     assert z1.compute().dtype == z1.dtype
 
-    x2 = da.asarray([1, 2, 3], dtype=np.int64)
-    y2 = da.asarray([4, 5, 6], dtype=np.int64)
+    x2 = da.asarray([1, 2, 3])
+    y2 = da.asarray([4, 5, 6])
     z2 = da.add(x2, y2, dtype=np.dtype(dt))
     assert z2.dtype == np.dtype(dt)
     assert z2.compute().dtype == z2.dtype

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -476,9 +476,7 @@ def test_divmod():
     assert_eq(result[1], expected[1])
 
 
-@pytest.mark.parametrize(
-    "dt", ["float64", "float32", "int32", "int64"]
-)
+@pytest.mark.parametrize("dt", ["float64", "float32", "int32", "int64"])
 def test_dtype_kwarg(dt):
     x1, y1 = da.asarray([1, 2, 3]), da.asarray([4, 5, 6])
     assert x1.dtype == np.dtype("int64")


### PR DESCRIPTION
- [x] Closes #7774 
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`