### PR TITLE
Add dark mode support to HLG HTML repr

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -476,13 +476,16 @@ class Layer(collections.abc.Mapping):
         unmaterialized_layer_icon = """
             <svg width="24" height="24" viewBox="0 0 32 32" fill="none"
                 xmlns="http://www.w3.org/2000/svg" style="position: absolute;">
-                <circle cx="16" cy="16" r="14" fill="#F2F2F2" stroke="#1D1D1D" stroke-width="2"/>
+                <circle cx="16" cy="16" r="14"
+                    style="stroke: var(--jp-ui-font-color2, #1D1D1D); fill: var(--jp-layout-color1, #F2F2F2);"
+                    stroke-width="2" />
             </svg>
         """
         materialized_layer_icon = """
             <svg width="24" height="24" viewBox="0 0 32 32" fill="none"
                 xmlns="http://www.w3.org/2000/svg" style="position: absolute;">
-                <circle cx="16" cy="16" r="14" fill="#8F8F8F" stroke="#1D1D1D" stroke-width="2"/>
+                <circle cx="16" cy="16" r="14" fill="#8F8F8F"
+                    style="stroke: var(--jp-ui-font-color2, #1D1D1D);" stroke-width="2"/>
             </svg>
         """
         if self.is_materialized():
@@ -506,7 +509,7 @@ class Layer(collections.abc.Mapping):
                     <summary style="margin-bottom: 10px; margin-top: 10px;">
                         <h3 style="display: inline;">Layer{layer_index}: {shortname}</h3>
                     </summary>
-                    <p style="color: #5D5851; margin-top: -0.25em; margin-bottom: 0px; margin-left: 0px;">
+                    <p style="color: var(--jp-ui-font-color2, #5D5851); margin: -0.25em 0px 0px 0px;">
                         {highlevelgraph_key}
                     </p>
                     {layer_info_table}
@@ -1126,23 +1129,32 @@ class HighLevelGraph(Mapping):
         highlevelgraph_info = f"{type(self).__name__} with {len(self.layers)} layers."
         highlevelgraph_icon = """
             <svg width="76" height="71" viewBox="0 0 76 71" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <circle cx="61.5" cy="36.5" r="13.5" fill="#F2F2F2" stroke="#1D1D1D" stroke-width="2"/>
-                <circle cx="14.5" cy="14.5" r="13.5" fill="#F2F2F2" stroke="#1D1D1D" stroke-width="2"/>
-                <circle cx="14.5" cy="56.5" r="13.5" fill="#F2F2F2" stroke="#1D1D1D" stroke-width="2"/>
+                <circle cx="61.5" cy="36.5" r="13.5"
+                    style="stroke: var(--jp-ui-font-color2, #1D1D1D); fill: var(--jp-layout-color1, #F2F2F2);"
+                    stroke-width="2"/>
+                <circle cx="14.5" cy="14.5" r="13.5"
+                    style="stroke: var(--jp-ui-font-color2, #1D1D1D); fill: var(--jp-layout-color1, #F2F2F2);"
+                    stroke-width="2"/>
+                <circle cx="14.5" cy="56.5" r="13.5"
+                    style="stroke: var(--jp-ui-font-color2, #1D1D1D); fill: var(--jp-layout-color1, #F2F2F2);"
+                    stroke-width="2"/>
                 <path d="M28 16L30.5 16C33.2614 16 35.5 18.2386 35.5 21L35.5 32.0001C35.5 34.7615 37.7386
-                    37.0001 40.5 37.0001L43 37.0001" stroke="black" stroke-width="1.5"/>
+                    37.0001 40.5 37.0001L43 37.0001" style="stroke: var(--jp-ui-font-color2, #1D1D1D);"
+                    stroke-width="1.5"/>
                 <path d="M40.5 37L40.5 37.75L40.5 37.75L40.5 37ZM35.5 42L36.25 42L35.5 42ZM35.5 52L34.75
                     52L35.5 52ZM30.5 57L30.5 57.75L30.5 57ZM41.5001 36.25L40.5 36.25L40.5 37.75L41.5001
                     37.75L41.5001 36.25ZM34.75 42L34.75 52L36.25 52L36.25 42L34.75 42ZM30.5 56.25L28.0001
                     56.25L28.0001 57.75L30.5 57.75L30.5 56.25ZM34.75 52C34.75 54.3472 32.8472 56.25 30.5
                     56.25L30.5 57.75C33.6756 57.75 36.25 55.1756 36.25 52L34.75 52ZM40.5 36.25C37.3244 36.25
                     34.75 38.8243 34.75 42L36.25 42C36.25 39.6528 38.1528 37.75 40.5 37.75L40.5 36.25Z"
-                    fill="black"/>
-                <circle cx="28" cy="16" r="2.25" fill="#E5E5E5" stroke="black" stroke-width="1.5"/>
-                <circle cx="28" cy="57" r="2.25" fill="#E5E5E5" stroke="black" stroke-width="1.5"/>
+                    style="fill: var(--jp-ui-font-color2, #1D1D1D);"/>
+                <circle cx="28" cy="16" r="2.25" fill="#E5E5E5"
+                    style="stroke: var(--jp-ui-font-color2, #1D1D1D);" stroke-width="1.5"/>
+                <circle cx="28" cy="57" r="2.25" fill="#E5E5E5"
+                    style="stroke: var(--jp-ui-font-color2, #1D1D1D);" stroke-width="1.5"/>
                 <path d="M45.25 36.567C45.5833 36.7594 45.5833 37.2406 45.25 37.433L42.25 39.1651C41.9167
                     39.3575 41.5 39.117 41.5 38.7321V35.2679C41.5 34.883 41.9167 34.6425 42.25 34.8349L45.25
-                    36.567Z" fill="#1D1D1D"/>
+                    36.567Z" style="fill: var(--jp-ui-font-color2, #1D1D1D);"/>
             </svg>
         """
         layers_html = ""
@@ -1160,7 +1172,7 @@ class HighLevelGraph(Mapping):
                     </div>
                     <div style="margin-left: 64px;">
                         <h3 style="margin-bottom: 0px;">HighLevelGraph</h3>
-                        <p style="color: #5D5851; margin-bottom:0px;">
+                        <p style="color: var(--jp-ui-font-color2, #5D5851); margin-bottom:0px;">
                             {highlevelgraph_info}
                         </p>
                         {layers_html}


### PR DESCRIPTION
Builds on  #7763 and adds dark mode support.

**Light**
![image](https://user-images.githubusercontent.com/1610850/122031347-872ca200-cdc6-11eb-8b45-d6d977db7e07.png)

**Dark**
![image](https://user-images.githubusercontent.com/1610850/122031382-8f84dd00-cdc6-11eb-9090-8480dfd7effa.png)
