### PR TITLE
Add initial deprecation utilities

### DIFF
--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -1,6 +1,5 @@
 import contextlib
 import numbers
-import warnings
 from itertools import chain, product
 from numbers import Integral
 from operator import getitem
@@ -9,7 +8,7 @@ import numpy as np
 
 from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
-from ..utils import derived_from, random_state_data, skip_doctest
+from ..utils import _deprecated, derived_from, random_state_data, skip_doctest
 from .core import (
     Array,
     asarray,
@@ -21,12 +20,9 @@ from .core import (
 from .creation import arange
 
 
+@_deprecated()
 def doc_wraps(func):
     """Copy docstring from one function to another"""
-    warnings.warn(
-        "dask.array.random.doc_wraps is deprecated and will be removed in a future version",
-        FutureWarning,
-    )
 
     def _(func2):
         if func.__doc__ is not None:

--- a/dask/bytes/__init__.py
+++ b/dask/bytes/__init__.py
@@ -3,24 +3,15 @@ import warnings
 from fsspec.core import open as fs_open_file
 from fsspec.core import open_files as fs_open_files
 
+from ..utils import _deprecated
 from .core import read_bytes
 
 
+@_deprecated(use_instead="fsspec.core.open_file")
 def open_file(*arg, **kwargs):
-    warnings.warn(
-        "Importing ``open_file`` from dask.bytes is deprecated now and will be "
-        "removed in a future version. To silence this warning, "
-        "use ``from fsspec.core import open as open_file`` instead.",
-        FutureWarning,
-    )
     return fs_open_file(*arg, **kwargs)
 
 
+@_deprecated(use_instead="fsspec.core.open_files")
 def open_files(*arg, **kwargs):
-    warnings.warn(
-        "Importing ``open_files`` from dask.bytes is deprecated now and will be "
-        "removed in a future version. To silence this warning, "
-        "use ``from fsspec.core import open_files`` instead.",
-        FutureWarning,
-    )
     return fs_open_files(*arg, **kwargs)

--- a/dask/bytes/__init__.py
+++ b/dask/bytes/__init__.py
@@ -7,7 +7,7 @@ from ..utils import _deprecated
 from .core import read_bytes
 
 
-@_deprecated(use_instead="fsspec.core.open_file")
+@_deprecated(use_instead="fsspec.core.open")
 def open_file(*arg, **kwargs):
     return fs_open_file(*arg, **kwargs)
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -3,7 +3,6 @@ import collections.abc
 import contextlib
 import copy
 import html
-import warnings
 from typing import (
     AbstractSet,
     Any,
@@ -834,14 +833,9 @@ class HighLevelGraph(Mapping):
         return reverse_dict(self.dependencies)
 
     @property
+    @_deprecated(use_instead="HighLevelGraph.layers")
     def dicts(self):
         # Backwards compatibility for now
-        warnings.warn(
-            "'dicts' property of HighLevelGraph is deprecated now and will be "
-            "removed in a future version. To silence this warning, "
-            "use '.layers' instead.",
-            FutureWarning,
-        )
         return self.layers
 
     def copy(self):

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -21,7 +21,7 @@ import tlz as toolz
 from . import config
 from .base import clone_key, flatten, is_dask_collection
 from .core import keys_in_tasks, reverse_dict
-from .utils import ensure_dict, key_split, stringify
+from .utils import _deprecated, ensure_dict, key_split, stringify
 from .utils_test import add, inc  # noqa: F401
 
 
@@ -776,13 +776,9 @@ class HighLevelGraph(Mapping):
         """
         return self.to_dict().keys()
 
+    @_deprecated(use_instead="HighLevelGraph.keys")
     def keyset(self) -> AbstractSet:
         # Backwards compatibility for now
-        warnings.warn(
-            "'keyset' method of HighLevelGraph is deprecated now and will be removed "
-            "in a future version. To silence this warning, use '.keys' instead.",
-            FutureWarning,
-        )
         return self.keys()
 
     def get_all_external_keys(self) -> set:

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -52,14 +52,14 @@ def test_keys_values_items_to_dict_methods():
 def test_keyset_deprecated():
     a = {"x": 1, "y": (inc, "x")}
     hg = HighLevelGraph({"a": a}, {"a": set()})
-    with pytest.raises(FutureWarning, match="HighLevelGraph.keys"):
+    with pytest.warns(FutureWarning, match="HighLevelGraph.keys"):
         assert hg.keyset() == hg.keys()
 
 
 def test_dicts_deprecated():
     a = {"x": 1, "y": (inc, "x")}
     hg = HighLevelGraph({"a": a}, {"a": set()})
-    with pytest.raises(FutureWarning, match="HighLevelGraph.layers"):
+    with pytest.warns(FutureWarning, match="HighLevelGraph.layers"):
         assert hg.dicts == hg.layers
 
 

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -49,6 +49,13 @@ def test_keys_values_items_to_dict_methods():
     assert hg.to_dict() == dict(hg)
 
 
+def test_keyset_deprecated():
+    a = {"x": 1, "y": (inc, "x")}
+    hg = HighLevelGraph({"a": a}, {"a": set()})
+    with pytest.raises(FutureWarning, match="HighLevelGraph.keys"):
+        hg.keyset()
+
+
 def test_getitem():
     hg = HighLevelGraph(
         {"a": {"a": 1, ("a", 0): 2, "b": 3}, "b": {"c": 4}}, {"a": set(), "b": set()}

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -53,7 +53,14 @@ def test_keyset_deprecated():
     a = {"x": 1, "y": (inc, "x")}
     hg = HighLevelGraph({"a": a}, {"a": set()})
     with pytest.raises(FutureWarning, match="HighLevelGraph.keys"):
-        hg.keyset()
+        assert hg.keyset() == hg.keys()
+
+
+def test_dicts_deprecated():
+    a = {"x": 1, "y": (inc, "x")}
+    hg = HighLevelGraph({"a": a}, {"a": set()})
+    with pytest.raises(FutureWarning, match="HighLevelGraph.layers"):
+        assert hg.dicts == hg.layers
 
 
 def test_getitem():

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -696,6 +696,18 @@ def test_deprecated_category():
         assert foo() == "bar"
 
 
+def test_deprecated_message():
+    @_deprecated(message="woohoo")
+    def foo():
+        return "bar"
+
+    with pytest.warns(FutureWarning) as record:
+        assert foo() == "bar"
+
+    assert len(record) == 1
+    assert str(record[0].message) == "woohoo"
+
+
 def test_ignoring_deprecated():
     with pytest.raises(FutureWarning, match="contextlib.supress"):
         with ignoring(ValueError):

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -13,6 +13,7 @@ from dask.utils import (
     Dispatch,
     M,
     SerializableLock,
+    _deprecated,
     asciitable,
     derived_from,
     ensure_dict,
@@ -21,12 +22,14 @@ from dask.utils import (
     funcname,
     getargspec,
     has_keyword,
+    ignoring,
     is_arraylike,
     itemgetter,
     iter_chunks,
     memory_repr,
     methodcaller,
     ndeepmap,
+    noop_context,
     parse_bytes,
     parse_timedelta,
     partial_by_order,
@@ -659,3 +662,47 @@ def test_stringify_collection_keys():
 )
 def test_format_bytes(n, expect):
     assert format_bytes(int(n)) == expect
+
+
+def test_deprecated():
+    @_deprecated()
+    def foo():
+        return "bar"
+
+    with pytest.warns(FutureWarning) as record:
+        assert foo() == "bar"
+
+    assert len(record) == 1
+    msg = str(record[0].message)
+    assert "foo is deprecated" in msg
+    assert "removed in a future release" in msg
+
+
+def test_deprecated_version():
+    @_deprecated(version="1.2.3")
+    def foo():
+        return "bar"
+
+    with pytest.warns(FutureWarning, match="deprecated in version 1.2.3"):
+        assert foo() == "bar"
+
+
+def test_deprecated_category():
+    @_deprecated(category=DeprecationWarning)
+    def foo():
+        return "bar"
+
+    with pytest.warns(DeprecationWarning):
+        assert foo() == "bar"
+
+
+def test_ignoring_deprecated():
+    with pytest.raises(FutureWarning, match="contextlib.supress"):
+        with ignoring(ValueError):
+            pass
+
+
+def test_noop_context_deprecated():
+    with pytest.raises(FutureWarning, match="contextlib.nullcontext"):
+        with noop_context():
+            pass

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -709,12 +709,12 @@ def test_deprecated_message():
 
 
 def test_ignoring_deprecated():
-    with pytest.raises(FutureWarning, match="contextlib.supress"):
+    with pytest.warns(FutureWarning, match="contextlib.suppress"):
         with ignoring(ValueError):
             pass
 
 
 def test_noop_context_deprecated():
-    with pytest.raises(FutureWarning, match="contextlib.nullcontext"):
+    with pytest.warns(FutureWarning, match="contextlib.nullcontext"):
         with noop_context():
             pass

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -140,7 +140,9 @@ def ndeepmap(n, func, seq):
         return func(seq)
 
 
-@_deprecated(version="2021.06.1", use_instead="contextlib.supress")
+@_deprecated(
+    version="2021.06.1", use_instead="contextlib.supress from the standard library"
+)
 @contextmanager
 def ignoring(*exceptions):
     with suppress(*exceptions):
@@ -224,7 +226,9 @@ def tmp_cwd(dir=None):
             yield dirname
 
 
-@_deprecated(version="2021.06.1", use_instead="contextlib.nullcontext")
+@_deprecated(
+    version="2021.06.1", use_instead="contextlib.nullcontext from the standard library"
+)
 @contextmanager
 def noop_context():
     with nullcontext():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -16,7 +16,7 @@ from functools import lru_cache
 from importlib import import_module
 from numbers import Integral, Number
 from threading import Lock
-from typing import Dict, Iterable, Mapping, Optional, TypeVar
+from typing import Dict, Iterable, Mapping, Optional, Type, TypeVar
 from weakref import WeakValueDictionary
 
 from .core import get_deps
@@ -42,7 +42,7 @@ def _deprecated(
     version: str = None,
     msg: str = None,
     use_instead: str = None,
-    category: type[Warning] = FutureWarning,
+    category: Type[Warning] = FutureWarning,
 ):
     """Decorator to mark a function as deprecated
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -143,7 +143,7 @@ def ndeepmap(n, func, seq):
 
 
 @_deprecated(
-    version="2021.06.1", use_instead="contextlib.supress from the standard library"
+    version="2021.06.1", use_instead="contextlib.suppress from the standard library"
 )
 @contextmanager
 def ignoring(*exceptions):

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -40,7 +40,7 @@ def apply(func, args, kwargs=None):
 def _deprecated(
     *,
     version: str = None,
-    msg: str = None,
+    message: str = None,
     use_instead: str = None,
     category: Type[Warning] = FutureWarning,
 ):
@@ -52,7 +52,7 @@ def _deprecated(
         Version of Dask in which the function was deprecated.
         If specified, the version will be included in the default
         warning message.
-    msg : str, optional
+    message : str, optional
         Custom warning message to raise.
     use_instead : str, optional
         Name of function to use in place of the deprecated function.
@@ -71,19 +71,21 @@ def _deprecated(
     """
 
     def decorator(func):
+        if message is None:
+            msg = f"{func.__name__} "
+            if version is not None:
+                msg += f"was deprecated in version {version} "
+            else:
+                msg += "is deprecated "
+            msg += "and will be removed in a future release."
+
+            if use_instead is not None:
+                msg += f" Please use {use_instead} instead."
+        else:
+            msg = message
+
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            nonlocal version, msg
-            if msg is None:
-                msg = f"{funcname(func)} "
-                if version is not None:
-                    msg += f"was deprecated in version {version} "
-                else:
-                    msg += "is deprecated "
-                msg += "and will be removed in a future release."
-
-                if use_instead is not None:
-                    msg += f" Please use {use_instead} instead."
             warnings.warn(msg, category=category, stacklevel=2)
             return func(*args, **kwargs)
 


### PR DESCRIPTION
This PR adds a `_deprecated` utility decorator to streamline our deprecation process.

cc @jsignell @crusaderky @fjetter who may find this interesting or have comments 