### PR TITLE
Small tweaks to the HTML repr for Layer & HighLevelGraph

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1156,8 +1156,8 @@ class Array(DaskMethodsMixin):
                     "shape": self.shape,
                     "dtype": self.dtype,
                     "chunksize": self.chunksize,
-                    "type": type(self),
-                    "chunk_type": type(self._meta),
+                    "type": typename(type(self)),
+                    "chunk_type": typename(type(self._meta)),
                 }
             else:
                 layer.collection_annotations.update(
@@ -1165,8 +1165,8 @@ class Array(DaskMethodsMixin):
                         "shape": self.shape,
                         "dtype": self.dtype,
                         "chunksize": self.chunksize,
-                        "type": type(self),
-                        "chunk_type": type(self._meta),
+                        "type": typename(type(self)),
+                        "chunk_type": typename(type(self._meta)),
                     }
                 )
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3808,8 +3808,8 @@ class DataFrame(_Frame):
             self.dask.layers[name].collection_annotations = {
                 "npartitions": self.npartitions,
                 "columns": [col for col in self.columns],
-                "type": type(self),
-                "dataframe_type": type(self._meta),
+                "type": typename(type(self)),
+                "dataframe_type": typename(type(self._meta)),
                 "series_dtypes": {
                     col: self._meta[col].dtype
                     if hasattr(self._meta[col], "dtype")
@@ -3822,8 +3822,8 @@ class DataFrame(_Frame):
                 {
                     "npartitions": self.npartitions,
                     "columns": [col for col in self.columns],
-                    "type": type(self),
-                    "dataframe_type": type(self._meta),
+                    "type": typename(type(self)),
+                    "dataframe_type": typename(type(self._meta)),
                     "series_dtypes": {
                         col: self._meta[col].dtype
                         if hasattr(self._meta[col], "dtype")

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -507,7 +507,7 @@ class Layer(collections.abc.Mapping):
                 {layer_icon}
                 <details style="margin-left: 32px;">
                     <summary style="margin-bottom: 10px; margin-top: 10px;">
-                        <h3 style="display: inline;">Layer{layer_index}: {shortname}</h3>
+                        <h4 style="display: inline;">Layer{layer_index}: {shortname}</h4>
                     </summary>
                     <p style="color: var(--jp-ui-font-color2, #5D5851); margin: -0.25em 0px 0px 0px;">
                         {highlevelgraph_key}


### PR DESCRIPTION
This PR adds tweaks discussed for the HighLevelGraph HTML repr https://github.com/dask/dask/pull/7763
1. Reduce the Layer heading size down to h4
2. Use typename (`from dask.utils import typename`) to get a nicer string rendering of types in the `collection_annotations` dictionary (see https://github.com/dask/dask/pull/7309 for details on `collection_annotations`). Thanks @jrbourbeau - I didn't know about the `typename` function!

Jacob has already added dark mode support here: https://github.com/dask/dask/pull/7809 (thanks Jacob!)

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
- [ ] Screenshots of jupyter notebook output added to this PR comment thread
