### PR TITLE
Make check_meta understand pandas dtypes better

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -325,6 +325,7 @@ def test_check_meta():
             "d": [1, 2, 3],
             "e": pd.Categorical(["x", "y", "z"]),
             "f": pd.Series([1, 2, 3], dtype=np.uint64),
+            "g": pd.Series(["a", "b", "c"], dtype="string"),
         }
     )
     meta = df.iloc[:0]
@@ -375,6 +376,21 @@ def test_check_meta():
         "+--------+----------+----------+"
     )
     assert str(err.value) == exp
+
+    # pandas dtype metadata error
+    with pytest.raises(ValueError) as err:
+        check_meta(df.a, pd.Series([], dtype="string"), numeric_equal=False)
+    assert str(err.value) == (
+        "Metadata mismatch found.\n"
+        "\n"
+        "Partition type: `pandas.core.series.Series`\n"
+        "+----------+--------+\n"
+        "|          | dtype  |\n"
+        "+----------+--------+\n"
+        "| Found    | object |\n"
+        "| Expected | string |\n"
+        "+----------+--------+"
+    )
 
 
 def test_check_matching_columns_raises_appropriate_errors():

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -325,7 +325,6 @@ def test_check_meta():
             "d": [1, 2, 3],
             "e": pd.Categorical(["x", "y", "z"]),
             "f": pd.Series([1, 2, 3], dtype=np.uint64),
-            "g": pd.Series(["a", "b", "c"], dtype="string"),
         }
     )
     meta = df.iloc[:0]
@@ -377,20 +376,21 @@ def test_check_meta():
     )
     assert str(err.value) == exp
 
-    # pandas dtype metadata error
-    with pytest.raises(ValueError) as err:
-        check_meta(df.a, pd.Series([], dtype="string"), numeric_equal=False)
-    assert str(err.value) == (
-        "Metadata mismatch found.\n"
-        "\n"
-        "Partition type: `pandas.core.series.Series`\n"
-        "+----------+--------+\n"
-        "|          | dtype  |\n"
-        "+----------+--------+\n"
-        "| Found    | object |\n"
-        "| Expected | string |\n"
-        "+----------+--------+"
-    )
+    if PANDAS_GT_100:
+        # pandas dtype metadata error
+        with pytest.raises(ValueError) as err:
+            check_meta(df.a, pd.Series([], dtype="string"), numeric_equal=False)
+        assert str(err.value) == (
+            "Metadata mismatch found.\n"
+            "\n"
+            "Partition type: `pandas.core.series.Series`\n"
+            "+----------+--------+\n"
+            "|          | dtype  |\n"
+            "+----------+--------+\n"
+            "| Found    | object |\n"
+            "| Expected | string |\n"
+            "+----------+--------+"
+        )
 
 
 def test_check_matching_columns_raises_appropriate_errors():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_scalar  # noqa: F401
-from pandas.api.types import is_categorical_dtype
+from pandas.api.types import is_categorical_dtype, is_dtype_equal
 
 from ..base import is_dask_collection
 from ..core import get_deps
@@ -363,7 +363,7 @@ def check_meta(x, meta, funcname=None, numeric_equal=True):
             if UNKNOWN_CATEGORIES in a.categories or UNKNOWN_CATEGORIES in b.categories:
                 return True
             return a == b
-        return (a.kind in eq_types and b.kind in eq_types) or (a == b)
+        return (a.kind in eq_types and b.kind in eq_types) or is_dtype_equal(a, b)
 
     if not (
         is_dataframe_like(meta) or is_series_like(meta) or is_index_like(meta)


### PR DESCRIPTION
- [x] Closes #7805
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

Original MRE:
```python
from dask import delayed
import dask.dataframe as dd
import pandas as pd

df = pd.DataFrame({"x": ["a"]}, dtype="object")
meta = pd.DataFrame({"x": []}, dtype="string")
task = delayed(df)

ddf = dd.from_delayed(task, meta)
ddf.compute(scheduler="single-threaded")
```
Now results in:
```python-traceback
ValueError: Metadata mismatch found in `from_delayed`.

Partition type: `pandas.core.frame.DataFrame`
+--------+--------+----------+
| Column | Found  | Expected |
+--------+--------+----------+
| 'x'    | object | string   |
+--------+--------+----------+
```
@mlondschien 