### PR TITLE
Use packaging for version comparisons.

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.7
+  - packaging
   - numpy=1.16
   - pandas=0.25
   # test dependencies

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.8
+  - packaging
   # For the dependencies. These will be re-installed later.
   - numpy
   - pandas

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.8
+  - packaging
   - numpy=1.17
   - pandas=1.1
   # test dependencies

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.9
+  - packaging
   - numpy
   - pandas
   # test dependencies

--- a/continuous_integration/environment-mindeps-array-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-array-dataframe.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # required dependencies
+  - packaging=20.0
   - python=3.7
   - pyyaml
   - cloudpickle=1.1.1

--- a/continuous_integration/environment-mindeps-distributed.yaml
+++ b/continuous_integration/environment-mindeps-distributed.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # required dependencies
+  - packaging=20.0
   - python=3.7
   - pyyaml
   - cloudpickle=1.5.0  # this is in the min from distributed

--- a/continuous_integration/environment-mindeps-non-optional.yaml
+++ b/continuous_integration/environment-mindeps-non-optional.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # required dependencies
+  - packaging=20.0
   - python=3.7
   - pyyaml
   - cloudpickle=1.1.1

--- a/continuous_integration/scripts/test_imports.sh
+++ b/continuous_integration/scripts/test_imports.sh
@@ -5,7 +5,7 @@ set -o errexit
 test_import () {
     echo "Create environment: python=$PYTHON_VERSION $1"
     # Create an empty environment
-    mamba create -q -y -n test-imports -c conda-forge python=$PYTHON_VERSION pyyaml fsspec toolz partd cloudpickle $1
+    mamba create -q -y -n test-imports -c conda-forge python=$PYTHON_VERSION packaging pyyaml fsspec toolz partd cloudpickle $1
     conda activate test-imports
     if [[ $1 =~ "distributed" ]]; then
         # dask[distributed] depends on the latest version of distributed

--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -1,14 +1,15 @@
 import warnings
-from distutils.version import LooseVersion
 
 import numpy as np
+from packaging.version import parse as parse_version
 
 from ..utils import derived_from
 
-_numpy_117 = LooseVersion(np.__version__) >= "1.17.0"
-_numpy_118 = LooseVersion(np.__version__) >= "1.18.0"
-_numpy_120 = LooseVersion(np.__version__) >= "1.20.0"
-_numpy_121 = LooseVersion(np.__version__) >= "1.21.0"
+_np_version = parse_version(np.__version__)
+_numpy_117 = _np_version >= parse_version("1.17.0")
+_numpy_118 = _np_version >= parse_version("1.18.0")
+_numpy_120 = _np_version >= parse_version("1.20.0")
+_numpy_121 = _np_version >= parse_version("1.21.0")
 
 
 # Taken from scikit-learn:

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -1,7 +1,6 @@
-from distutils.version import LooseVersion
-
 import numpy as np
 import pytest
+from packaging.version import parse as parse_version
 
 import dask
 import dask.array as da
@@ -12,6 +11,7 @@ from dask.sizeof import sizeof
 
 cupy = pytest.importorskip("cupy")
 cupyx = pytest.importorskip("cupyx")
+cupy_version = parse_version(cupy.__version__)
 
 
 functions = [
@@ -35,7 +35,7 @@ functions = [
     pytest.param(
         lambda x: x.mean(),
         marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
+            not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
             reason="NEP-18 support is not available in NumPy or CuPy older than "
             "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
         ),
@@ -47,7 +47,7 @@ functions = [
     pytest.param(
         lambda x: x.std(),
         marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
+            not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
             reason="NEP-18 support is not available in NumPy or CuPy older than "
             "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
         ),
@@ -55,7 +55,7 @@ functions = [
     pytest.param(
         lambda x: x.var(),
         marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
+            not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
             reason="NEP-18 support is not available in NumPy or CuPy older than "
             "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
         ),
@@ -318,7 +318,7 @@ def test_diagonal():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
+    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
@@ -336,7 +336,7 @@ def test_tril_triu():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
+    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
@@ -448,7 +448,7 @@ def test_nearest():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
+    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
@@ -465,7 +465,7 @@ def test_constant():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
+    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
@@ -556,7 +556,7 @@ def test_random_shapes(shape):
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.1.0"),
+    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.1.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.1.0 (requires https://github.com/cupy/cupy/pull/2209)",
 )
@@ -936,7 +936,7 @@ def test_cupy_sparse_concatenate(axis):
 
 @pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy.__version__ < LooseVersion("6.4.0"),
+    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
     reason="NEP-18 support is not available in NumPy or CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -1,8 +1,8 @@
 import random
-from distutils.version import LooseVersion
 
 import numpy as np
 import pytest
+from packaging.version import parse as parse_version
 
 import dask
 import dask.array as da
@@ -34,7 +34,7 @@ functions = [
     pytest.param(
         lambda x: x.mean(),
         marks=pytest.mark.skipif(
-            sparse.__version__ >= LooseVersion("0.12.0"),
+            parse_version(sparse.__version__) >= parse_version("0.12.0"),
             reason="https://github.com/dask/dask/issues/7169",
         ),
     ),
@@ -91,7 +91,7 @@ def test_basic(func):
 
 
 @pytest.mark.skipif(
-    sparse.__version__ < LooseVersion("0.7.0+10"),
+    parse_version(sparse.__version__) < parse_version("0.7.0+10"),
     reason="fixed in https://github.com/pydata/sparse/pull/256",
 )
 def test_tensordot():

--- a/dask/base.py
+++ b/dask/base.py
@@ -6,13 +6,13 @@ import uuid
 from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import fields, is_dataclass
-from distutils.version import LooseVersion
 from functools import partial
 from hashlib import md5
 from numbers import Number
 from operator import getitem
 from typing import Iterator, Mapping, Set
 
+from packaging.version import parse as parse_version
 from tlz import curry, groupby, identity, merge
 from tlz.functoolz import Compose
 
@@ -898,7 +898,7 @@ def _normalize_function(func):
 def register_pandas():
     import pandas as pd
 
-    PANDAS_GT_130 = LooseVersion(pd.__version__) >= LooseVersion("1.3.0")
+    PANDAS_GT_130 = parse_version(pd.__version__) >= parse_version("1.3.0")
 
     @normalize_token.register(pd.Index)
     def normalize_index(ind):

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -2,11 +2,11 @@ import os
 import subprocess
 import sys
 import time
-from distutils.version import LooseVersion
 
 import fsspec
 import pytest
 from fsspec.core import open_files
+from packaging.version import parse as parse_version
 
 import dask.bag as db
 from dask.utils import tmpdir
@@ -14,7 +14,7 @@ from dask.utils import tmpdir
 files = ["a", "b"]
 requests = pytest.importorskip("requests")
 errs = (requests.exceptions.RequestException,)
-if LooseVersion(fsspec.__version__) > "0.7.4":
+if parse_version(fsspec.__version__) > parse_version("0.7.4"):
     aiohttp = pytest.importorskip("aiohttp")
     errs = errs + (aiohttp.client_exceptions.ClientResponseError,)
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -2,7 +2,6 @@ import gzip
 import os
 import pathlib
 import sys
-from distutils.version import LooseVersion
 from functools import partial
 from time import sleep
 
@@ -11,6 +10,7 @@ import pytest
 from fsspec.compression import compr
 from fsspec.core import open_files
 from fsspec.implementations.local import LocalFileSystem
+from packaging.version import parse as parse_version
 from tlz import concat, valmap
 
 from dask import compute
@@ -356,7 +356,7 @@ def test_get_pyarrow_filesystem():
     from fsspec.implementations.local import LocalFileSystem
 
     pa = pytest.importorskip("pyarrow")
-    if pa.__version__ >= LooseVersion("2.0.0"):
+    if parse_version(pa.__version__).major >= 2:
         pytest.skip("fsspec no loger inherits from pyarrow>=2.0.")
 
     fs = LocalFileSystem()

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -1,5 +1,6 @@
 import sys
-from distutils.version import LooseVersion
+
+from packaging.version import parse as parse_version
 
 try:
     from math import prod
@@ -12,7 +13,7 @@ except ImportError:
         return acc
 
 
-_PY_VERSION = LooseVersion(".".join(map(str, sys.version_info[:3])))
+_PY_VERSION = parse_version(".".join(map(str, sys.version_info[:3])))
 
 
 def __getattr__(name):

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -1,16 +1,16 @@
 import string
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
+from packaging.version import parse as parse_version
 
-PANDAS_VERSION = LooseVersion(pd.__version__)
-PANDAS_GT_100 = PANDAS_VERSION >= LooseVersion("1.0.0")
-PANDAS_GT_104 = PANDAS_VERSION >= LooseVersion("1.0.4")
-PANDAS_GT_110 = PANDAS_VERSION >= LooseVersion("1.1.0")
-PANDAS_GT_120 = PANDAS_VERSION >= LooseVersion("1.2.0")
-PANDAS_GT_121 = PANDAS_VERSION >= LooseVersion("1.2.1")
-PANDAS_GT_130 = PANDAS_VERSION >= LooseVersion("1.3.0")
+PANDAS_VERSION = parse_version(pd.__version__)
+PANDAS_GT_100 = PANDAS_VERSION >= parse_version("1.0.0")
+PANDAS_GT_104 = PANDAS_VERSION >= parse_version("1.0.4")
+PANDAS_GT_110 = PANDAS_VERSION >= parse_version("1.1.0")
+PANDAS_GT_120 = PANDAS_VERSION >= parse_version("1.2.0")
+PANDAS_GT_121 = PANDAS_VERSION >= parse_version("1.2.1")
+PANDAS_GT_130 = PANDAS_VERSION >= parse_version("1.3.0")
 
 
 if PANDAS_GT_100:

--- a/dask/dataframe/io/orc.py
+++ b/dask/dataframe/io/orc.py
@@ -1,6 +1,5 @@
-from distutils.version import LooseVersion
-
 from fsspec.core import get_fs_token_paths
+from packaging.version import parse as parse_version
 
 from ...base import tokenize
 from ...highlevelgraph import HighLevelGraph
@@ -49,7 +48,7 @@ def _read_orc_stripe(fs, path, stripe, columns=None):
     with fs.open(path, "rb") as f:
         o = orc.ORCFile(f)
         table = o.read_stripe(stripe, columns)
-    if pa.__version__ < LooseVersion("0.11.0"):
+    if parse_version(pa.__version__) < parse_version("0.11.0"):
         return table.to_pandas()
     else:
         return table.to_pandas(date_as_object=False)
@@ -80,7 +79,7 @@ def read_orc(path, columns=None, storage_options=None):
     orc = import_required("pyarrow.orc", "Please install pyarrow >= 0.9.0")
     import pyarrow as pa
 
-    if LooseVersion(pa.__version__) == "0.10.0":
+    if parse_version(pa.__version__) == parse_version("0.10.0"):
         raise RuntimeError(
             "Due to a bug in pyarrow 0.10.0, the ORC reader is "
             "unavailable. Please either downgrade pyarrow to "

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -2,13 +2,13 @@ import json
 import warnings
 from collections import defaultdict
 from datetime import datetime
-from distutils.version import LooseVersion
 from functools import partial
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
+from packaging.version import parse as parse_version
 
 from dask import delayed
 
@@ -27,14 +27,16 @@ from .utils import (
 )
 
 # Check PyArrow version for feature support
-preserve_ind_supported = pa.__version__ >= LooseVersion("0.15.0")
+_pa_version = parse_version(pa.__version__)
+preserve_ind_supported = _pa_version >= parse_version("0.15.0")
 read_row_groups_supported = preserve_ind_supported
-if pa.__version__ >= LooseVersion("1.0.0"):
+if _pa_version.major >= 1:
     from pyarrow import dataset as pa_ds
 else:
     pa_ds = None
-subset_stats_supported = pa.__version__ > LooseVersion("2.0.0")
-schema_field_supported = pa.__version__ >= LooseVersion("0.15.0")
+subset_stats_supported = _pa_version > parse_version("2.0.0")
+schema_field_supported = _pa_version >= parse_version("0.15.0")
+del _pa_version
 
 #
 #  Helper Utilities

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1,11 +1,11 @@
 import math
 import warnings
-from distutils.version import LooseVersion
 
 import tlz as toolz
 from fsspec.core import get_fs_token_paths
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.utils import stringify_path
+from packaging.version import parse as parse_version
 
 from ....base import tokenize
 from ....delayed import Delayed
@@ -844,11 +844,12 @@ def get_engine(engine):
 
     elif engine in ("pyarrow", "arrow", "pyarrow-legacy", "pyarrow-dataset"):
         pa = import_required("pyarrow", "`pyarrow` not installed")
+        pa_version = parse_version(pa.__version__)
 
-        if LooseVersion(pa.__version__) < "0.13.1":
+        if pa_version < parse_version("0.13.1"):
             raise RuntimeError("PyArrow version >= 0.13.1 required")
 
-        if engine == "pyarrow-dataset" and LooseVersion(pa.__version__) >= "1.0.0":
+        if engine == "pyarrow-dataset" and pa_version.major >= 1:
             from .arrow import ArrowDatasetEngine
 
             _ENGINES[engine] = eng = ArrowDatasetEngine

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -3,11 +3,11 @@ import json
 import pickle
 import warnings
 from collections import OrderedDict, defaultdict
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
 import tlz as toolz
+from packaging.version import parse as parse_version
 
 try:
     import fastparquet
@@ -924,7 +924,7 @@ class FastParquetEngine(Engine):
             rgs = []
         elif partition_on:
             mkdirs = lambda x: fs.mkdirs(x, exist_ok=True)
-            if LooseVersion(fastparquet.__version__) >= "0.1.4":
+            if parse_version(fastparquet.__version__) >= parse_version("0.1.4"):
                 rgs = partition_on_columns(
                     df, partition_on, path, filename, fmd, compression, fs.open, mkdirs
                 )

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -1,9 +1,9 @@
 import os
 import shutil
 import tempfile
-from distutils.version import LooseVersion
 
 import pytest
+from packaging.version import parse as parse_version
 
 import dask.dataframe as dd
 from dask.dataframe import read_orc
@@ -16,7 +16,7 @@ pytest.importorskip("pyarrow.orc")
 import pyarrow as pa
 
 pytestmark = pytest.mark.skipif(
-    LooseVersion(pa.__version__) == "0.10.0",
+    parse_version(pa.__version__).base_version == parse_version("0.10.0"),
     reason=(
         "PyArrow 0.10.0 release broke the ORC reader, see "
         "https://issues.apache.org/jira/browse/ARROW-3009"

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -931,14 +931,14 @@ def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
         "x" in df
         and df.x.dtype == "M8[ns]"
         and engine == "fastparquet"
-        and fastparquet.__version__ <= LooseVersion("0.6.3")
+        and fastparquet_version <= parse_version("0.6.3")
     ):
         pytest.xfail(reason="fastparquet doesn't support nanosecond precision yet")
     if (
         PANDAS_GT_130
         and read_kwargs.get("categories", None)
         and engine == "fastparquet"
-        and fastparquet.__version__ <= LooseVersion("0.6.3")
+        and fastparquet_version <= parse_version("0.6.3")
     ):
         pytest.xfail("https://github.com/dask/fastparquet/issues/577")
 

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -1,8 +1,7 @@
-from distutils.version import LooseVersion
-
 import numpy as np
 import pandas as pd
 import pytest
+from packaging.version import parse as parse_version
 
 import dask.dataframe as dd
 from dask.dataframe._compat import PANDAS_GT_130
@@ -404,7 +403,8 @@ def test_rolling_agg_aggregate():
 @pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="needs pandas>=1.0.0")
 def test_rolling_numba_engine():
     numba = pytest.importorskip("numba")
-    if not dd._compat.PANDAS_GT_104 and LooseVersion(numba.__version__) >= "0.49":
+    numba_version = parse_version(numba.__version__)
+    if not dd._compat.PANDAS_GT_104 and numba_version >= parse_version("0.49"):
         # Was fixed in https://github.com/pandas-dev/pandas/pull/33687
         pytest.xfail("Known incompatibility between pandas and numba")
 

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -1,9 +1,9 @@
 import random
 from bisect import bisect_left
-from distutils.version import LooseVersion
 from itertools import cycle
 from operator import add, itemgetter
 
+from packaging.version import parse as parse_version
 from tlz import accumulate, groupby, pluck, unique
 
 from ..core import istask
@@ -372,7 +372,7 @@ def plot_resources(results, palette="Viridis", **kwargs):
         line_width=4,
         **{
             "legend_label"
-            if LooseVersion(bokeh.__version__) >= "1.4"
+            if parse_version(bokeh.__version__) >= parse_version("1.4")
             else "legend": "% CPU"
         }
     )
@@ -390,7 +390,7 @@ def plot_resources(results, palette="Viridis", **kwargs):
         line_width=4,
         **{
             "legend_label"
-            if LooseVersion(bokeh.__version__) >= "1.4"
+            if parse_version(bokeh.__version__) >= parse_version("1.4")
             else "legend": "Memory"
         }
     )

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -1,10 +1,10 @@
 import contextlib
 import os
-from distutils.version import LooseVersion
 from operator import add, mul
 from time import sleep
 
 import pytest
+from packaging.version import parse as parse_version
 
 from dask.diagnostics import CacheProfiler, Profiler, ResourceProfiler
 from dask.threaded import get
@@ -326,10 +326,10 @@ def test_plot_multiple():
     p = visualize(
         [prof, rprof], label_size=50, title="Not the default", show=False, save=False
     )
-    bokeh_version = LooseVersion(bokeh.__version__)
-    if bokeh_version >= "1.1.0":
+    bokeh_version = parse_version(bokeh.__version__)
+    if bokeh_version >= parse_version("1.1.0"):
         figures = [r[0] for r in p.children[1].children]
-    elif bokeh_version >= "0.12.0":
+    elif bokeh_version >= parse_version("0.12.0"):
         figures = [r.children[0] for r in p.children[1].children]
     else:
         figures = [r[0] for r in p.children]
@@ -364,7 +364,7 @@ def test_get_colors():
     from dask.diagnostics.profile_visualize import get_colors
 
     # 256-color palettes were added in bokeh 1.4.0
-    if LooseVersion(bokeh.__version__) >= "1.4.0":
+    if parse_version(bokeh.__version__) >= parse_version("1.4.0"):
         from bokeh.palettes import Blues256
 
         funcs = list(range(11))

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -2,7 +2,8 @@ import itertools
 import random
 import sys
 from array import array
-from distutils.version import LooseVersion
+
+from packaging.version import parse as parse_version
 
 from .utils import Dispatch
 
@@ -195,7 +196,7 @@ def register_pyarrow():
         return int(_get_col_size(data)) + 1000
 
     # Handle pa.Column for pyarrow < 0.15
-    if pa.__version__ < LooseVersion("0.15.0"):
+    if parse_version(pa.__version__) < parse_version("0.15.0"):
 
         @sizeof.register(pa.Column)
         def sizeof_pyarrow_column(col):

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -2,10 +2,8 @@ import multiprocessing
 import pickle
 import sys
 from concurrent.futures import ProcessPoolExecutor
-from distutils.version import LooseVersion
 from operator import add
 
-import cloudpickle
 import pytest
 
 import dask
@@ -49,13 +47,10 @@ def test_pickle_locals():
 
 
 @pytest.mark.skipif(pickle.HIGHEST_PROTOCOL < 5, reason="requires pickle protocol 5")
-@pytest.mark.skipif(
-    cloudpickle.__version__ < LooseVersion("1.3.0"),
-    reason="requires cloudpickle >= 1.3.0",
-)
 def test_out_of_band_pickling():
     """Test that out-of-band pickling works"""
     np = pytest.importorskip("numpy")
+    pytest.importorskip("cloudpickle", minversion="1.3.0")
 
     a = np.arange(5)
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require["complete"] = sorted({v for req in extras_require.values() for v 
 extras_require["test"] = ["pytest", "pytest-rerunfailures", "pytest-xdist"]
 
 install_requires = [
-    "packaging",
+    "packaging >= 20.0",
     "pyyaml",
     "cloudpickle >= 1.1.1",
     "fsspec >= 0.6.0",

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ extras_require["complete"] = sorted({v for req in extras_require.values() for v 
 extras_require["test"] = ["pytest", "pytest-rerunfailures", "pytest-xdist"]
 
 install_requires = [
+    "packaging",
     "pyyaml",
     "cloudpickle >= 1.1.1",
     "fsspec >= 0.6.0",


### PR DESCRIPTION
Because `distutils` is deprecated in Python 3.10.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
