### PR TITLE
Remove warning filter in `test_dataframe_picklable`

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1712,9 +1712,6 @@ def test_combine_first():
     assert_eq(ddf1.B.combine_first(df2.B), df1.B.combine_first(df2.B))
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The 'freq' argument in Timestamp is deprecated:FutureWarning"
-)  #  PANDAS_GT_130 https://github.com/pandas-dev/pandas/issues/41949
 def test_dataframe_picklable():
     from pickle import dumps, loads
 


### PR DESCRIPTION
With https://github.com/pandas-dev/pandas/issues/41949 resolved, we can remove this warning filter

cc @jsignell 

EDIT: xref https://github.com/dask/dask/pull/7795#discussion_r650207634