### PR TITLE
Make `PY_VERSION` private

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -21,7 +21,7 @@ def __getattr__(name):
 
         warnings.warn(
             "dask.compatibility.PY_VERSION is deprecated and will be removed "
-            "in a future release. Use dask.compatibility._PY_VERSION instead.",
+            "in a future release.",
             category=FutureWarning,
         )
         return _PY_VERSION

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -25,3 +25,5 @@ def __getattr__(name):
             category=FutureWarning,
         )
         return _PY_VERSION
+    else:
+        raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -12,4 +12,16 @@ except ImportError:
         return acc
 
 
-PY_VERSION = LooseVersion(".".join(map(str, sys.version_info[:3])))
+_PY_VERSION = LooseVersion(".".join(map(str, sys.version_info[:3])))
+
+
+def __getattr__(name):
+    if name == "PY_VERSION":
+        import warnings
+
+        warnings.warn(
+            "dask.compatibility.PY_VERSION is deprecated and will be removed "
+            "in a future release. Use dask.compatibility._PY_VERSION instead.",
+            category=FutureWarning,
+        )
+        return _PY_VERSION

--- a/dask/tests/test_compatibility.py
+++ b/dask/tests/test_compatibility.py
@@ -1,0 +1,10 @@
+import pytest
+
+import dask
+
+
+def test_PY_VERSION_deprecated():
+
+    with pytest.warns(FutureWarning, match="dask.compatibility._PY_VERSION"):
+        from dask.compatibility import PY_VERSION
+    assert PY_VERSION is dask.compatibility._PY_VERSION

--- a/dask/tests/test_compatibility.py
+++ b/dask/tests/test_compatibility.py
@@ -5,6 +5,6 @@ import dask
 
 def test_PY_VERSION_deprecated():
 
-    with pytest.warns(FutureWarning, match="dask.compatibility._PY_VERSION"):
+    with pytest.warns(FutureWarning, match="removed in a future release"):
         from dask.compatibility import PY_VERSION
     assert PY_VERSION is dask.compatibility._PY_VERSION


### PR DESCRIPTION
Starting in Python 3.7 modules can [define their own `__getattr__` function to implement custom logic when a module attribute is not found](https://docs.python.org/3/whatsnew/3.7.html#pep-562-customization-of-access-to-module-attributes). This provides a convenient mechanism for us to smoothly transition certain variables to be private (i.e. start with an underscore `_`). This PR demonstrates this approach with `dask.compatibility.PY_VERSION`, which isn't intended to be part of our public API and currently isn't used anywhere internally. 

xref https://github.com/dask/dask/pull/7820 where whether or not `PY_VERSION` is intended to be part of our public API came up