### PR TITLE
Add "sample_rows" to read_csv-like

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from io import BytesIO, IOBase
+from io import BytesIO
 from warnings import catch_warnings, simplefilter, warn
 
 from ...highlevelgraph import HighLevelGraph
@@ -14,7 +14,7 @@ import fsspec.implementations.local
 import numpy as np
 import pandas as pd
 from fsspec.compression import compr
-from fsspec.core import OpenFile, get_fs_token_paths
+from fsspec.core import get_fs_token_paths
 from fsspec.core import open as open_file
 from fsspec.core import open_files
 from fsspec.utils import infer_compression
@@ -168,18 +168,11 @@ def pandas_read_text(
     --------
     dask.dataframe.csv.read_pandas_from_bytes
     """
-    if isinstance(b, OpenFile):
-        # make file from fsspec input
-        bio = b.open()
-    elif not isinstance(b, IOBase):
-        bio = BytesIO()
-        if write_header and not b.startswith(header.rstrip()):
-            bio.write(header)
-        bio.write(b)
-        bio.seek(0)
-    else:
-        # assume it already is a file-like
-        bio = b
+    bio = BytesIO()
+    if write_header and not b.startswith(header.rstrip()):
+        bio.write(header)
+    bio.write(b)
+    bio.seek(0)
     df = reader(bio, **kwargs)
     if dtypes:
         coerce_dtypes(df, dtypes)

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -577,11 +577,8 @@ def read_pandas(
     header = b"" if header is None else parts[firstrow] + b_lineterminator
 
     # Use sample to infer dtypes and check for presence of include_path_column
-    head_kwargs = kwargs.copy()
-    if sample_rows is not None:
-        head_kwargs["nrows"] = sample_rows
     try:
-        head = reader(BytesIO(b_sample), **head_kwargs)
+        head = reader(BytesIO(b_sample), nrows=sample_rows, **kwargs)
     except pd.errors.ParserError as e:
         if "EOF" in str(e):
             raise ValueError(

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -586,8 +586,8 @@ def read_pandas(
         if "EOF" in str(e):
             raise ValueError(
                 "EOF encountered while reading header. \n"
-                "Pass argument `sample_rows=` and make sure the value of `sample` "
-                "is large enough to accommodate that may rows of data"
+                "Pass argument `sample_rows` and make sure the value of `sample` "
+                "is large enough to accommodate that many rows of data"
             ) from e
         raise
     if include_path_column and (include_path_column in head.columns):

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1668,3 +1668,15 @@ def test_csv_getitem_column_order(tmpdir):
     columns = list("hczzkylaape")
     df2 = dd.read_csv(path)[columns].head(1)
     assert_eq(df1[columns], df2)
+
+
+def test_csv_parse_fail(tmpdir):
+    path = os.path.join(str(tmpdir), "test.csv")
+    data = b'a,b\n1,"hi\n"\n2,"oi\n"\n'
+    expected = pd.read_csv(BytesIO(data))
+    with open(path, "wb") as f:
+        f.write(data)
+    with pytest.raises(ValueError):
+        dd.read_csv(path, sample=13)
+    df = dd.read_csv(path, sample=13, sample_rows=1)
+    assert_eq(df, expected)

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1,7 +1,6 @@
 import gzip
 import os
 from io import BytesIO
-from time import sleep
 from unittest import mock
 
 import pytest
@@ -885,16 +884,10 @@ def test_csv_with_integer_names():
         assert list(df.columns) == [0, 1]
 
 
-@pytest.mark.slow
 def test_read_csv_of_modified_file_has_different_name():
     with filetext(csv_text) as fn:
-        sleep(1)
-        a = dd.read_csv(fn)
-        sleep(1)
-        with open(fn, "a") as f:
-            f.write("\nGeorge,700")
-            os.fsync(f)
-        b = dd.read_csv(fn)
+        a = dd.read_csv(fn, sample_rows=5)
+        b = dd.read_csv(fn, sample_rows=6)
 
         assert sorted(a.dask, key=str) != sorted(b.dask, key=str)
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1664,12 +1664,13 @@ def test_csv_getitem_column_order(tmpdir):
 
 
 def test_csv_parse_fail(tmpdir):
+    # See GH #7680
     path = os.path.join(str(tmpdir), "test.csv")
     data = b'a,b\n1,"hi\n"\n2,"oi\n"\n'
     expected = pd.read_csv(BytesIO(data))
     with open(path, "wb") as f:
         f.write(data)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="EOF encountered"):
         dd.read_csv(path, sample=13)
     df = dd.read_csv(path, sample=13, sample_rows=1)
     assert_eq(df, expected)

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -884,14 +884,6 @@ def test_csv_with_integer_names():
         assert list(df.columns) == [0, 1]
 
 
-def test_read_csv_of_modified_file_has_different_name():
-    with filetext(csv_text) as fn:
-        a = dd.read_csv(fn, sample_rows=5)
-        b = dd.read_csv(fn, sample_rows=6)
-
-        assert sorted(a.dask, key=str) != sorted(b.dask, key=str)
-
-
 def test_late_dtypes():
     text = "numbers,names,more_numbers,integers,dates\n"
     for i in range(1000):


### PR DESCRIPTION
This is for the case that the sample bytecount ends mid-
quoted string.

- [x] Closes #7680
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

cc @jrbourbeau 
