### PR TITLE
Add support for histogram2d in dask.array

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -115,6 +115,7 @@ try:
         flipud,
         gradient,
         histogram,
+        histogram2d,
         histogramdd,
         hstack,
         insert,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1322,7 +1322,7 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
                 "Input array and weights must have the same shape "
                 "and chunk structure along the first dimension."
             )
-        elif not rectangular_sample and weights.numblocks != n_chunks:
+        elif not rectangular_sample and weights.numblocks[0] != n_chunks:
             raise ValueError(
                 "Input arrays and weights must have the same shape "
                 "and chunk structure."

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -977,6 +977,80 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
         return n, bins
 
 
+def histogram2d(x, y, bins=10, range=None, normed=None, weights=None, density=None):
+    """Blocked variant of :func:`numpy.histogram2d`.
+
+    Parameters
+    ----------
+    x : dask.array.Array
+        An array containing the `x`-coordinates of the points to be
+        histogrammed.
+    y : dask.array.Array
+        An array containing the `y`-coordinates of the points to be
+        histogrammed.
+    bins : sequence of arrays describing bin edges, int, or sequence of ints
+        The bin specification. See the `bins` argument description for
+        :py:func:`histogramdd` for a complete description of all
+        possible bin configurations (this function is a 2D specific
+        version of histogramdd).
+    range : tuple of pairs, optional.
+        The leftmost and rightmost edges of the bins along each
+        dimension when integers are passed to `bins`; of the form:
+        ((xmin, xmax), (ymin, ymax)).
+    normed : bool, optional
+        An alias for the density argument that behaves identically. To
+        avoid confusion with the broken argument in the `histogram`
+        function, `density` should be preferred.
+    weights : dask.array.Array, optional
+        An array of values weighing each sample in the input data. The
+        chunks of the weights must be identical to the chunking along
+        the 0th (row) axis of the data sample.
+    density : bool, optional
+        If False (the default) return the number of samples in each
+        bin. If True, the returned array represents the probability
+        density function at each bin.
+
+    Returns
+    -------
+    dask.array.Array
+        The values of the histogram.
+    dask.array.Array
+        The edges along the `x`-dimension.
+    dask.array.Array
+        The edges along the `y`-dimension.
+
+    See Also
+    --------
+    histogram
+    histogramdd
+
+    Examples
+    --------
+    >>> import dask.array as da
+    >>> x = da.array([2, 4, 2, 4, 2, 4])
+    >>> y = da.array([2, 2, 4, 4, 2, 4])
+    >>> bins = 2
+    >>> range = ((0, 6), (0, 6))
+    >>> h, xedges, yedges = da.histogram2d(x, y, bins=bins, range=range)
+    >>> h
+    dask.array<sum-aggregate, shape=(2, 2), dtype=float64, chunksize=(2, 2), chunktype=numpy.ndarray>
+    >>> xedges
+    dask.array<array, shape=(3,), dtype=float64, chunksize=(3,), chunktype=numpy.ndarray>
+    >>> h.compute()
+    array([[2., 1.],
+           [1., 2.]])
+    """
+    counts, edges = histogramdd(
+        (x, y),
+        bins=bins,
+        range=range,
+        normed=normed,
+        weights=weights,
+        density=density,
+    )
+    return counts, *edges
+
+
 def _block_histogramdd_rect(sample, bins, range, weights):
     """Call numpy.histogramdd for a blocked/chunked calculation.
 
@@ -1099,8 +1173,8 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
     range : sequence of pairs, optional
         A sequence of length D, each a (min, max) tuple giving the
         outer bin edges to be used if the edges are not given
-        explicitly in ``bins``. If defined, this argument is required
-        to have an entry for each dimension. Unlike
+        explicitly in `bins`. If defined, this argument is required to
+        have an entry for each dimension. Unlike
         :func:`numpy.histogramdd`, if `bins` does not define bin
         edges, this argument is required (this function will not
         automatically use the min and max of of the value in a given
@@ -1121,6 +1195,14 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
     See Also
     --------
     histogram
+
+    Returns
+    -------
+    dask.array.Array
+        The values of the histogram.
+    list(dask.array.Array)
+        Sequence of arrays representing the bin edges along each
+        dimension.
 
     Examples
     --------

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1048,7 +1048,7 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None, density=No
         weights=weights,
         density=density,
     )
-    return counts, *edges
+    return counts, edges[0], edges[1]
 
 
 def _block_histogramdd_rect(sample, bins, range, weights):

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -838,6 +838,58 @@ def test_histogram_delayed_n_bins_raises_with_density():
         da.histogram(data, bins=da.array(10), range=[0, 1], density=True)
 
 
+def test_histogram2d():
+    n = 800
+    bins = (5, 6)
+    range = ((0, 1), (0, 1))
+    x = da.random.uniform(0, 1, size=(n,), chunks=(200,))
+    y = da.random.uniform(0, 1, size=(n,), chunks=(200,))
+    a1, b1x, b1y = da.histogram2d(x, y, bins=bins, range=range)
+    a2, b2x, b2y = np.histogram2d(x, y, bins=bins, range=range)
+    a3, b3x, b3y = np.histogram2d(x.compute(), y.compute(), bins=bins, range=range)
+    assert_eq(a1, a2)
+    assert_eq(a1, a3)
+    assert a1.sum() == n
+    assert a2.sum() == n
+    assert same_keys(da.histogram2d(x, y, bins=bins, range=range)[0], a1)
+    assert a1.compute().shape == a3.shape
+
+
+def test_histogram2d_single_bins():
+    n = 800
+    bins = 5
+    range = ((0, 1), (0, 1))
+    x = da.random.uniform(0, 1, size=(n,), chunks=(200,))
+    y = da.random.uniform(0, 1, size=(n,), chunks=(200,))
+    a1, b1x, b1y = da.histogram2d(x, y, bins=bins, range=range)
+    a2, b2x, b2y = np.histogram2d(x, y, bins=bins, range=range)
+    a3, b3x, b3y = np.histogram2d(x.compute(), y.compute(), bins=bins, range=range)
+    assert_eq(a1, a2)
+    assert_eq(a1, a3)
+    assert a1.sum() == n
+    assert a2.sum() == n
+    assert same_keys(da.histogram2d(x, y, bins=bins, range=range)[0], a1)
+    assert a1.compute().shape == a3.shape
+
+
+def test_histogram2d_array_bins():
+    n = 800
+    x = da.random.uniform(0, 1, size=(n,), chunks=(200,))
+    y = da.random.uniform(0, 1, size=(n,), chunks=(200,))
+    xbins = [0.0, 0.2, 0.6, 0.9, 1.0]
+    ybins = [0.0, 0.1, 0.4, 0.5, 1.0]
+    bins = [xbins, ybins]
+    a1, b1x, b1y = da.histogram2d(x, y, bins=bins)
+    a2, b2x, b2y = np.histogram2d(x, y, bins=bins)
+    a3, b3x, b3y = np.histogram2d(x.compute(), y.compute(), bins=bins)
+    assert_eq(a1, a2)
+    assert_eq(a1, a3)
+    assert a1.sum() == n
+    assert a2.sum() == n
+    assert same_keys(da.histogram2d(x, y, bins=bins)[0], a1)
+    assert a1.compute().shape == a3.shape
+
+
 def test_histogramdd():
     n1, n2 = 800, 3
     x = da.random.uniform(0, 1, size=(n1, n2), chunks=(200, 3))

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -838,55 +838,66 @@ def test_histogram_delayed_n_bins_raises_with_density():
         da.histogram(data, bins=da.array(10), range=[0, 1], density=True)
 
 
-def test_histogram2d():
+@pytest.mark.parametrize("weights", [True, False])
+@pytest.mark.parametrize("density", [True, False])
+@pytest.mark.parametrize("bins", [(5, 6), 5])
+def test_histogram2d(weights, density, bins):
     n = 800
-    bins = (5, 6)
-    range = ((0, 1), (0, 1))
+    b = bins
+    r = ((0, 1), (0, 1))
     x = da.random.uniform(0, 1, size=(n,), chunks=(200,))
     y = da.random.uniform(0, 1, size=(n,), chunks=(200,))
-    a1, b1x, b1y = da.histogram2d(x, y, bins=bins, range=range)
-    a2, b2x, b2y = np.histogram2d(x, y, bins=bins, range=range)
-    a3, b3x, b3y = np.histogram2d(x.compute(), y.compute(), bins=bins, range=range)
+    w = da.random.uniform(0.2, 1.1, size=(n,), chunks=(200,)) if weights else None
+    a1, b1x, b1y = da.histogram2d(x, y, bins=b, range=r, density=density, weights=w)
+    a2, b2x, b2y = np.histogram2d(x, y, bins=b, range=r, density=density, weights=w)
+    a3, b3x, b3y = np.histogram2d(
+        x.compute(),
+        y.compute(),
+        bins=b,
+        range=r,
+        density=density,
+        weights=w.compute() if weights else None,
+    )
     assert_eq(a1, a2)
     assert_eq(a1, a3)
-    assert a1.sum() == n
-    assert a2.sum() == n
-    assert same_keys(da.histogram2d(x, y, bins=bins, range=range)[0], a1)
+    if not (weights or density):
+        assert a1.sum() == n
+        assert a2.sum() == n
+    assert same_keys(
+        da.histogram2d(x, y, bins=b, range=r, density=density, weights=w)[0],
+        a1,
+    )
     assert a1.compute().shape == a3.shape
 
 
-def test_histogram2d_single_bins():
+@pytest.mark.parametrize("weights", [True, False])
+@pytest.mark.parametrize("density", [True, False])
+def test_histogram2d_array_bins(weights, density):
     n = 800
-    bins = 5
-    range = ((0, 1), (0, 1))
-    x = da.random.uniform(0, 1, size=(n,), chunks=(200,))
-    y = da.random.uniform(0, 1, size=(n,), chunks=(200,))
-    a1, b1x, b1y = da.histogram2d(x, y, bins=bins, range=range)
-    a2, b2x, b2y = np.histogram2d(x, y, bins=bins, range=range)
-    a3, b3x, b3y = np.histogram2d(x.compute(), y.compute(), bins=bins, range=range)
-    assert_eq(a1, a2)
-    assert_eq(a1, a3)
-    assert a1.sum() == n
-    assert a2.sum() == n
-    assert same_keys(da.histogram2d(x, y, bins=bins, range=range)[0], a1)
-    assert a1.compute().shape == a3.shape
-
-
-def test_histogram2d_array_bins():
-    n = 800
-    x = da.random.uniform(0, 1, size=(n,), chunks=(200,))
-    y = da.random.uniform(0, 1, size=(n,), chunks=(200,))
     xbins = [0.0, 0.2, 0.6, 0.9, 1.0]
     ybins = [0.0, 0.1, 0.4, 0.5, 1.0]
-    bins = [xbins, ybins]
-    a1, b1x, b1y = da.histogram2d(x, y, bins=bins)
-    a2, b2x, b2y = np.histogram2d(x, y, bins=bins)
-    a3, b3x, b3y = np.histogram2d(x.compute(), y.compute(), bins=bins)
+    b = [xbins, ybins]
+    x = da.random.uniform(0, 1, size=(n,), chunks=(200,))
+    y = da.random.uniform(0, 1, size=(n,), chunks=(200,))
+    w = da.random.uniform(0.2, 1.1, size=(n,), chunks=(200,)) if weights else None
+    a1, b1x, b1y = da.histogram2d(x, y, bins=b, density=density, weights=w)
+    a2, b2x, b2y = np.histogram2d(x, y, bins=b, density=density, weights=w)
+    a3, b3x, b3y = np.histogram2d(
+        x.compute(),
+        y.compute(),
+        bins=b,
+        density=density,
+        weights=w.compute() if weights else None,
+    )
     assert_eq(a1, a2)
     assert_eq(a1, a3)
-    assert a1.sum() == n
-    assert a2.sum() == n
-    assert same_keys(da.histogram2d(x, y, bins=bins)[0], a1)
+    if not (weights or density):
+        assert a1.sum() == n
+        assert a2.sum() == n
+    assert same_keys(
+        da.histogram2d(x, y, bins=b, density=density, weights=w)[0],
+        a1,
+    )
     assert a1.compute().shape == a3.shape
 
 

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -98,6 +98,7 @@ Top level user functions:
    greater
    greater_equal
    histogram
+   histogram2d
    histogramdd
    hstack
    hypot

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -496,6 +496,7 @@ Other functions
 .. autofunction:: greater
 .. autofunction:: greater_equal
 .. autofunction:: histogram
+.. autofunction:: histogram2d
 .. autofunction:: histogramdd
 .. autofunction:: hstack
 .. autofunction:: hypot


### PR DESCRIPTION
- [x] ~~Closes #xxxx~~
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

This PR completes support of the NumPy histogramming API in dask.array. This is the final chapter of the story told by #7307, #7387, #7634. Conveniently, histogramdd is 99% of what we need for histogram2d. Tests for histogram2d uncovered the need for a small bugfix in histogramdd (this PR includes that fix, the change on line 1326).