### PR TITLE
Fix typo in `config.deserialize` docstring

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -623,7 +623,7 @@ def deserialize(data):
     Parameters
     ----------
     data: str
-        String serialied by :func:`dask.config.serialize`
+        String serialized by :func:`dask.config.serialize`
 
     Returns
     -------


### PR DESCRIPTION
Just a fixed typo.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
