### PR TITLE
Add `numeric_only` kwarg to dataframe reductions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -87,13 +87,16 @@ pd.set_option("compute.use_numexpr", False)
 
 
 def _numeric_only(func):
+    """Decorator for methods that accept a numeric_only kwarg"""
+
     @wraps(func)
     def wrapper(self, *args, **kwargs):
+        # numeric_only is None by default - in that case self = self.
         if kwargs.get("numeric_only") is False:
             raise NotImplementedError(
                 "'numeric_only=False' is not implemented in Dask."
             )
-        elif kwargs.get("numeric_only"):
+        elif kwargs.get("numeric_only") is True:
             self = self._get_numeric_data()
         return func(self, *args, **kwargs)
 

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1235,6 +1235,65 @@ def test_reductions_frame_dtypes():
     assert_eq(df_numerics.var(), ddf_numerics.var())
 
 
+def test_reductions_frame_dtypes_numeric_only():
+    df = pd.DataFrame(
+        {
+            "int": [1, 2, 3, 4, 5, 6, 7, 8],
+            "float": [1.0, 2.0, 3.0, 4.0, np.nan, 6.0, 7.0, 8.0],
+            "dt": [pd.NaT] + [datetime(2011, i, 1) for i in range(1, 8)],
+            "str": list("abcdefgh"),
+            "timedelta": pd.to_timedelta([1, 2, 3, 4, 5, 6, 7, np.nan]),
+            "bool": [True, False] * 4,
+        }
+    )
+
+    ddf = dd.from_pandas(df, 3)
+    kwargs = {"numeric_only": True}
+    funcs = [
+        "sum",
+        "prod",
+        "product",
+        "min",
+        "max",
+        "mean",
+        "var",
+        "std",
+        "count",
+        "sem",
+    ]
+
+    for func in funcs:
+        assert_eq(
+            getattr(df, func)(**kwargs),
+            getattr(ddf, func)(**kwargs),
+        )
+        with pytest.raises(NotImplementedError, match="'numeric_only=False"):
+            getattr(ddf, func)(numeric_only=False)
+
+    assert_eq(df.sem(ddof=0, **kwargs), ddf.sem(ddof=0, **kwargs))
+    assert_eq(df.std(ddof=0, **kwargs), ddf.std(ddof=0, **kwargs))
+    assert_eq(df.var(ddof=0, **kwargs), ddf.var(ddof=0, **kwargs))
+    assert_eq(df.var(skipna=False, **kwargs), ddf.var(skipna=False, **kwargs))
+    assert_eq(
+        df.var(skipna=False, ddof=0, **kwargs), ddf.var(skipna=False, ddof=0, **kwargs)
+    )
+
+    # ------ only include numerics columns ------ #
+    assert_eq(df._get_numeric_data(), ddf._get_numeric_data())
+
+    df_numerics = df[["int", "float", "bool"]]
+    ddf_numerics = ddf[["int", "float", "bool"]]
+
+    assert_eq(df_numerics, ddf._get_numeric_data())
+    assert ddf_numerics._get_numeric_data().dask == ddf_numerics.dask
+
+    for func in funcs:
+        assert_eq(
+            getattr(df_numerics, func)(**kwargs),
+            getattr(ddf_numerics, func)(**kwargs),
+        )
+
+
 @pytest.mark.parametrize("split_every", [False, 2])
 def test_reductions_frame_nan(split_every):
     df = pd.DataFrame(

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1266,6 +1266,8 @@ def test_reductions_frame_dtypes_numeric_only():
         assert_eq(
             getattr(df, func)(**kwargs),
             getattr(ddf, func)(**kwargs),
+            check_dtypes=func in ["mean", "max"]
+            and (PANDAS_GT_120 or not PANDAS_GT_100),
         )
         with pytest.raises(NotImplementedError, match="'numeric_only=False"):
             getattr(ddf, func)(numeric_only=False)
@@ -1289,8 +1291,12 @@ def test_reductions_frame_dtypes_numeric_only():
 
     for func in funcs:
         assert_eq(
-            getattr(df_numerics, func)(**kwargs),
-            getattr(ddf_numerics, func)(**kwargs),
+            getattr(df_numerics, func)(),
+            getattr(ddf_numerics, func)(),
+            check_dtypes=func in ["mean", "max"]
+            and (PANDAS_GT_120 or not PANDAS_GT_100),
+            check_dtype=func in ["mean", "max"]
+            and (PANDAS_GT_120 or not PANDAS_GT_100),
         )
 
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1859,13 +1859,10 @@ def test_groupby_select_column_agg(func):
     assert_eq(actual, expected)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Dropping of nuisance columns:FutureWarning"
-)  # https://github.com/dask/dask/issues/7714
 @pytest.mark.parametrize(
     "func",
     [
-        lambda x: x.std(),
+        lambda x: x.std(numeric_only=True),
         lambda x: x.groupby("x").std(),
         lambda x: x.groupby("x").var(),
         lambda x: x.groupby("x").mean(),


### PR DESCRIPTION
- [x] Closes #7714
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

This implementation might seem kind of intense, but I was thinking that it would be most efficient to pull out the `numeric_only` columns at the beginning rather than passing the arg down into the chunk functions.

Regarding tests, I chose to leave in the old test to make sure that existing functionality isn't affected at all, and I made a new test to test out the `numeric_only` kwarg.