### PR TITLE
Don't sample dict result of a shuffle group when calculating its size

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -59,6 +59,29 @@ def sizeof_python_collection(seq):
         return getsizeof(seq) + sum(map(sizeof, seq))
 
 
+class SimpleSizeof:
+    """Sentinel class to mark a class to be skipped by the dispatcher. This only
+    works if this sentinel mixin is first in the mro.
+
+    Examples
+    --------
+
+    >>> class TheAnswer(SimpleSizeof):
+    ...         def __sizeof__(self):
+    ...             # Sizeof always add overhead of an object for GC
+    ...             return 42 - sizeof(object())
+
+    >>> sizeof(TheAnswer())
+    42
+
+    """
+
+
+@sizeof.register(SimpleSizeof)
+def sizeof_blocked(d):
+    return getsizeof(d)
+
+
 @sizeof.register(dict)
 def sizeof_python_dict(d):
     return (


### PR DESCRIPTION
The size calculation for shuffle group results is very sensitive to sampling since there may
be empty splits skewing the result.

See also https://github.com/dask/distributed/issues/4962

I decided to go for this weird sentinel to not have to import `dask.dataframe.backends` in `dask.sizeof` but rather the opposite. Open to other suggestions.

Regarding the implementation, there is also the possibility to have some pseudo sampling which ensures that we have at least X% of the rows in our sum. I figured this is not necessary since iterating over the splits should be sufficiently fast. In my micro benchmarks it was still about a factor of 2 slower than the ordinary `sizeof` but still around 1ms for a DF with 1M rows (incl a str col) 

- [x] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
