### PR TITLE
Blockwise: stringify constant key inputs

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -508,7 +508,7 @@ class Blockwise(Layer):
                 if val_is_a_key:
                     keys2.append(key)
                     indices2.append((val, index))
-                    global_dependencies.add(val)
+                    global_dependencies.add(stringify(val))
                 else:
                     dsk[key] = val  # Literal
             else:

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -553,7 +553,6 @@ def test_map_partitions_df_input():
     """
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
-    dist = pytest.importorskip("distributed")
 
     def f(d, a):
         assert isinstance(d, pd.DataFrame)
@@ -572,10 +571,10 @@ def test_map_partitions_df_input():
         df = df.persist(optimize_graph=False)
         df.compute()
 
-    with dist.LocalCluster(
+    with distributed.LocalCluster(
         scheduler_port=0, asynchronous=False, n_workers=1, nthreads=1, processes=False
     ) as cluster:
-        with dist.Client(cluster, asynchronous=False):
+        with distributed.Client(cluster, asynchronous=False):
             main()
 
 

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -546,6 +546,39 @@ async def test_map_partitions_da_input(c, s, a, b):
     await c.compute(df.map_partitions(f, arr, meta=df._meta))
 
 
+def test_map_partitions_df_input():
+    """
+    Check that map_partitions can handle a delayed
+    partition of a dataframe input
+    """
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+    dist = pytest.importorskip("distributed")
+
+    def f(d, a):
+        assert isinstance(d, pd.DataFrame)
+        assert isinstance(a, pd.DataFrame)
+        return d
+
+    def main():
+        delayed_df = dd.from_pandas(
+            pd.DataFrame({"a": range(5)}), npartitions=2
+        ).to_delayed()
+        dl = delayed_df[0].persist()
+        wait(dl)
+
+        df = dd.from_pandas(pd.DataFrame({"a": range(5)}), npartitions=2)
+        df = df.map_partitions(f, dl, meta=df._meta)
+        df = df.persist(optimize_graph=False)
+        df.compute()
+
+    with dist.LocalCluster(
+        scheduler_port=0, asynchronous=False, n_workers=1, nthreads=1, processes=False
+    ) as cluster:
+        with dist.Client(cluster, asynchronous=False):
+            main()
+
+
 @gen_cluster(client=True)
 async def test_annotation_pack_unpack(c, s, a, b):
     hlg = HighLevelGraph({"l1": MaterializedLayer({"n": 42})}, {"l1": set()})


### PR DESCRIPTION
Fixing a bug in https://github.com/dask/dask/pull/7734, which didn't stringify the constant key inputs.

- [ ] Closes https://github.com/dask/distributed/issues/4980
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
