### PR TITLE
Handle infinite loops in merge_asof

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -808,6 +808,22 @@ def merge_asof_indexed(left, right, **kwargs):
     name = "asof-join-indexed-" + tokenize(left, right, **kwargs)
     meta = pd.merge_asof(left._meta_nonempty, right._meta_nonempty, **kwargs)
 
+    if all(map(pd.isnull, left.divisions)):
+        # results in an empty df that looks like ``meta``
+        return from_pandas(meta.iloc[len(meta) :], npartitions=left.npartitions)
+
+    if all(map(pd.isnull, right.divisions)):
+        # results in an df that looks like ``left`` with nulls for
+        # all ``right.columns``
+        return map_partitions(
+            pd.merge_asof,
+            left,
+            right=right,
+            left_index=True,
+            right_index=True,
+            meta=meta,
+        )
+
     dependencies = [left, right]
     tails = heads = None
     if kwargs["direction"] in ["backward", "nearest"]:
@@ -877,7 +893,7 @@ def merge_asof(
     }
 
     if left is None or right is None:
-        raise ValueError("Cannot merge_asof on empty DataFrames")
+        raise ValueError("Cannot merge_asof on None")
 
     # if is_dataframe_like(left) and is_dataframe_like(right):
     if isinstance(left, pd.DataFrame) and isinstance(right, pd.DataFrame):


### PR DESCRIPTION
Fixes infinite loop behavior in https://github.com/dask/dask/issues/7839. 

The core of the issue is that `merge_asof_indexed` could receive dataframes where `divisions` was filled with `nan` or `NaT`. Thus the while loop in `pair_partitions` would never finish executing. 

- [x] Closes https://github.com/dask/dask/issues/7839
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
