### PR TITLE
Added color to show the materialization of HLG layers

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1219,6 +1219,9 @@ def to_graphviz(
         attrs = data_attributes.get(k, {})
         attrs.setdefault("label", label(k, cache=cache))
         attrs.setdefault("shape", "box")
+        if hg.layers[k].is_materialized() is True:
+            attrs.setdefault("style", "filled")
+            attrs.setdefault("fillcolor", "gray84")
         g.node(k_name, **attrs)
 
     for k, deps in hg.dependencies.items():

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1221,7 +1221,7 @@ def to_graphviz(
         attrs.setdefault("shape", "box")
         if hg.layers[k].is_materialized() is True:
             attrs.setdefault("style", "filled")
-            attrs.setdefault("fillcolor", "gray84")
+            attrs.setdefault("fillcolor", "gray94")
         g.node(k_name, **attrs)
 
     for k, deps in hg.dependencies.items():


### PR DESCRIPTION
- [ ] Tests added 
- [x] Tests passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

/cc @martindurant @GenevieveBuckley 

Hi. I have opened this PR to add a little color to the Graphviz visualization of the HighLevelGraphs.


## The Issue

Currently, Dask doesn't do anything differently to distinguish the materialized layers from the unmaterialized layers in the final output of the `HLG.dask.visualize()`.

![image](https://user-images.githubusercontent.com/62539811/123757023-99323880-d8ce-11eb-9f83-55d72917d4b8.png)

As seen here, `head` is actually a materialized layer, but it is visualized the same as the `same-shuffle` and the `make-timeseries` layers.

## The Fix

I have added a simple light gray fill color to all the materialized layer nodes.

```py
if hg.layers[k].is_materialized() is True:
    attrs.setdefault("style", "filled")
    attrs.setdefault("fillcolor", "gray94")
```

This adds **gray84** fill color to the node.

## The Colour

Graphviz supports a wide range of colors. (https://graphviz.org/doc/info/colors.html)
![image](https://user-images.githubusercontent.com/62539811/123758682-3c378200-d8d0-11eb-916c-3413413bb7ab.png)

The color I have chosen (**gray94**) has been inspired by the already existing HLG HTML Representation.
![image](https://user-images.githubusercontent.com/62539811/123758710-4194cc80-d8d0-11eb-8329-ce717894e652.png)

## The Demo

![image](https://user-images.githubusercontent.com/62539811/123865171-a6860c00-d93c-11eb-9e8a-73551c39780b.png)

[Open to Discussion]