### PR TITLE
Add iteration for array blocks

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4440,6 +4440,19 @@ def test_blocks_indexer():
         x.blocks[100, 100]
 
 
+def test_blocks_iteration():
+    x = da.from_array(np.arange(16).reshape(4, 4).astype(int), chunks=(2, 2))
+    expected_output = [
+        [[0, 1], [4, 5]],  # top left array chunk
+        [[2, 3], [6, 7]],  # top right array chunk
+        [[8, 9], [12, 13]],  # bottom left array chunk
+        [[10, 11], [14, 15]],  # bottom right array chunk
+    ]
+    for block, expected in zip(x.blocks, expected_output):
+        assert block.shape == (2, 2)
+        assert np.allclose(block.compute(), expected)
+
+
 def test_partitions_indexer():
     # .partitions is an alias of .blocks for dask arrays
     x = da.arange(10, chunks=2)


### PR DESCRIPTION
I think there should  be an easy way to iterate over the blocks in a dask array.

Desired behavior:
* iteration over the dask array object directly - gives you the rows, just like iterating over a numpy array (this is already happening)
* iteration over the dask array `.blocks` - should give you each block one by one (instead of our current situation, where it iterates over the rows of the whole dask array instead). This is what I want to change.

### Before
```python
In [1]: import dask.array as da
In [2]: import numpy as np
In [3]: x = da.from_array(np.arange(16).reshape((4,4)), chunks=(2,2))
In [4]: x.compute()
Out[4]: 
array([[ 0,  1,  2,  3],
       [ 4,  5,  6,  7],
       [ 8,  9, 10, 11],
       [12, 13, 14, 15]])

In [5]: for block in x.blocks:
   ...:     print("block shape:", block.shape)
   ...:     print(block.compute())
   ...:     print("")
   ...: 
Out[5]: 
block shape: (2, 4)
[[0 1 2 3]
 [4 5 6 7]]

block shape: (2, 4)
[[ 8  9 10 11]
 [12 13 14 15]]

```

### After
```python
In [1]: import dask.array as da
In [2]: import numpy as np
In [3]: x = da.from_array(np.arange(16).reshape((4,4)), chunks=(2,2))
In [4]: x.compute()
Out[4]: 
array([[ 0,  1,  2,  3],
       [ 4,  5,  6,  7],
       [ 8,  9, 10, 11],
       [12, 13, 14, 15]])
In [5]: for block in x.blocks:
   ...:     print("block shape:", block.shape)
   ...:     print(block.compute())
   ...:     print("")
   ...: 
Out[5]: 
block shape: (2, 2)
[[0 1]
 [4 5]]

block shape: (2, 2)
[[2 3]
 [6 7]]

block shape: (2, 2)
[[ 8  9]
 [12 13]]

block shape: (2, 2)
[[10 11]
 [14 15]]
```


- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
