### PR TITLE
Set "priority" annotations in SimpleShuffleLayer-based __init__ functions

### DIFF
--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -80,29 +80,6 @@ def test_shuffle_npartitions_task():
     assert set(map(tuple, sc.values.tolist())) == set(map(tuple, df.values.tolist()))
 
 
-def test_shuffle_task_priorities():
-    df = pd.DataFrame({"x": np.random.random(100)})
-    ddf = dd.from_pandas(df, npartitions=10)
-
-    # ShuffleLayer
-    s = shuffle(ddf, ddf.x, shuffle="tasks", npartitions=17, max_branch=4)
-    layer = [k for k in s.dask.layers.keys() if k.startswith("shuffle-0-")]
-    layer = s.dask.layers[layer[0]]
-    k, v = next(iter(layer.annotations["priority"].items()))
-    assert v == 1
-    assert k[0].startswith("split-shuffle-0")
-    assert isinstance(k[2], tuple)  # Not true for SimpleShuffleLayer
-
-    # SimpleShuffleLayer
-    s = shuffle(ddf, ddf.x, shuffle="tasks", max_branch=32)
-    layer = [k for k in s.dask.layers.keys() if k.startswith("simple-shuffle")]
-    layer = s.dask.layers[layer[0]]
-    k, v = next(iter(layer.annotations["priority"].items()))
-    assert v == 1
-    assert k[0].startswith("split-simple-shuffle")
-    assert isinstance(k[2], int)  # Not true for ShuffleLayer
-
-
 def test_shuffle_npartitions_lt_input_partitions_task():
     df = pd.DataFrame({"x": np.random.random(100)})
     ddf = dd.from_pandas(df, npartitions=20)

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -423,7 +423,7 @@ class SimpleShuffleLayer(DataFrameLayer):
     def get_split_keys(self):
         # Return SimpleShuffleLayer "split" keys
         return [
-            (self.split_name, part_out, part_in)
+            stringify((self.split_name, part_out, part_in))
             for part_in in range(self.npartitions_input)
             for part_out in self.parts_out
         ]
@@ -692,10 +692,12 @@ class ShuffleLayer(SimpleShuffleLayer):
             out = self.inputs[part]
             for i in range(self.nsplits):
                 keys.append(
-                    (
-                        self.split_name,
-                        out[self.stage],
-                        insert(out, self.stage, i),
+                    stringify(
+                        (
+                            self.split_name,
+                            out[self.stage],
+                            insert(out, self.stage, i),
+                        )
                     )
                 )
         return keys

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -417,6 +417,7 @@ class SimpleShuffleLayer(DataFrameLayer):
         self.annotations = self.annotations or {}
         if "priority" not in self.annotations:
             self.annotations["priority"] = {}
+        self.annotations["priority"]["__expanded_annotations__"] = None
         self.annotations["priority"].update({_key: 1 for _key in self.get_split_keys()})
 
     def get_split_keys(self):

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -411,6 +411,21 @@ class SimpleShuffleLayer(DataFrameLayer):
         self.name_input = name_input
         self.meta_input = meta_input
         self.parts_out = parts_out or range(npartitions)
+        self.split_name = "split-" + self.name
+
+        # Set high-priority to "split" tasks
+        self.annotations = self.annotations or {}
+        if "priority" not in self.annotations:
+            self.annotations["priority"] = {}
+        self.annotations["priority"].update({_key: 1 for _key in self.get_split_keys()})
+
+    def get_split_keys(self):
+        # Return SimpleShuffleLayer "split" keys
+        return [
+            (self.split_name, part_out, part_in)
+            for part_in in range(self.npartitions_input)
+            for part_out in self.parts_out
+        ]
 
     def get_output_keys(self):
         return {(self.name, part) for part in self.parts_out}
@@ -557,7 +572,6 @@ class SimpleShuffleLayer(DataFrameLayer):
         """Construct graph for a simple shuffle operation."""
 
         shuffle_group_name = "group-" + self.name
-        shuffle_split_name = "split-" + self.name
 
         if deserializing:
             # Use CallableLazyImport objects to avoid importing dataframe
@@ -574,7 +588,7 @@ class SimpleShuffleLayer(DataFrameLayer):
         dsk = {}
         for part_out in self.parts_out:
             _concat_list = [
-                (shuffle_split_name, part_out, part_in)
+                (self.split_name, part_out, part_in)
                 for part_in in range(self.npartitions_input)
             ]
             dsk[(self.name, part_out)] = (
@@ -583,7 +597,7 @@ class SimpleShuffleLayer(DataFrameLayer):
                 self.ignore_index,
             )
             for _, _part_out, _part_in in _concat_list:
-                dsk[(shuffle_split_name, _part_out, _part_in)] = (
+                dsk[(self.split_name, _part_out, _part_in)] = (
                     operator.getitem,
                     (shuffle_group_name, _part_in),
                     _part_out,
@@ -655,6 +669,9 @@ class ShuffleLayer(SimpleShuffleLayer):
         parts_out=None,
         annotations=None,
     ):
+        self.inputs = inputs
+        self.stage = stage
+        self.nsplits = nsplits
         super().__init__(
             name,
             column,
@@ -666,9 +683,21 @@ class ShuffleLayer(SimpleShuffleLayer):
             parts_out=parts_out or range(len(inputs)),
             annotations=annotations,
         )
-        self.inputs = inputs
-        self.stage = stage
-        self.nsplits = nsplits
+
+    def get_split_keys(self):
+        # Return ShuffleLayer "split" keys
+        keys = []
+        for part in self.parts_out:
+            out = self.inputs[part]
+            for i in range(self.nsplits):
+                keys.append(
+                    (
+                        self.split_name,
+                        out[self.stage],
+                        insert(out, self.stage, i),
+                    )
+                )
+        return keys
 
     def __repr__(self):
         return "ShuffleLayer<name='{}', stage={}, nsplits={}, npartitions={}>".format(
@@ -738,7 +767,6 @@ class ShuffleLayer(SimpleShuffleLayer):
         """Construct graph for a "rearrange-by-column" stage."""
 
         shuffle_group_name = "group-" + self.name
-        shuffle_split_name = "split-" + self.name
 
         if deserializing:
             # Use CallableLazyImport objects to avoid importing dataframe
@@ -763,7 +791,7 @@ class ShuffleLayer(SimpleShuffleLayer):
                 # Get out each individual dataframe piece from the dicts
                 _inp = insert(out, self.stage, i)
                 _idx = out[self.stage]
-                _concat_list.append((shuffle_split_name, _idx, _inp))
+                _concat_list.append((self.split_name, _idx, _inp))
 
             # concatenate those pieces together, with their friends
             dsk[(self.name, part)] = (
@@ -773,7 +801,7 @@ class ShuffleLayer(SimpleShuffleLayer):
             )
 
             for _, _idx, _inp in _concat_list:
-                dsk[(shuffle_split_name, _idx, _inp)] = (
+                dsk[(self.split_name, _idx, _inp)] = (
                     operator.getitem,
                     (shuffle_group_name, _inp),
                     _idx,

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -529,6 +529,35 @@ async def test_futures_in_subgraphs(c, s, a, b):
 
 
 @gen_cluster(client=True)
+async def test_shuffle_priority(c, s, a, b):
+    pd = pytest.importorskip("pandas")
+    np = pytest.importorskip("numpy")
+    dd = pytest.importorskip("dask.dataframe")
+
+    df = pd.DataFrame({"a": range(1000)})
+    ddf = dd.from_pandas(df, npartitions=10)
+    ddf2 = ddf.shuffle("a", shuffle="tasks", max_branch=32)
+    await c.compute(ddf2)
+
+    # Parse transition log for processing tasks
+    log = [
+        eval(l[0])[0]
+        for l in s.transition_log
+        if l[1] == "processing" and "simple-shuffle-" in l[0]
+    ]
+
+    # Make sure most "split" tasks are processing before
+    # any "combine" tasks begin
+    late_split = np.quantile(
+        [i for i, st in enumerate(log) if st.startswith("split")], 0.75
+    )
+    early_combine = np.quantile(
+        [i for i, st in enumerate(log) if st.startswith("simple")], 0.25
+    )
+    assert late_split < early_combine
+
+
+@gen_cluster(client=True)
 async def test_map_partitions_da_input(c, s, a, b):
     """Check that map_partitions can handle a dask array input"""
     np = pytest.importorskip("numpy")
@@ -556,32 +585,3 @@ async def test_annotation_pack_unpack(c, s, a, b):
     unpacked_hlg = HighLevelGraph.__dask_distributed_unpack__(packed_hlg)
     annotations = unpacked_hlg["annotations"]
     assert annotations == {"workers": {"n": ("alice",)}}
-
-
-@gen_cluster(client=True)
-async def test_shuffle_priority(c, s, a, b):
-    pd = pytest.importorskip("pandas")
-    np = pytest.importorskip("numpy")
-    dd = pytest.importorskip("dask.dataframe")
-
-    df = pd.DataFrame({"a": range(1000)})
-    ddf = dd.from_pandas(df, npartitions=10)
-    ddf2 = ddf.shuffle("a", shuffle="tasks", max_branch=32)
-    await c.compute(ddf2)
-
-    # Parse transition log for processing tasks
-    log = [
-        eval(l[0])[0]
-        for l in s.transition_log
-        if l[1] == "processing" and "simple-shuffle-" in l[0]
-    ]
-
-    # Make sure most "split" tasks are processing before
-    # any "combine" tasks begin
-    late_split = np.quantile(
-        [i for i, st in enumerate(log) if st.startswith("split")], 0.75
-    )
-    early_combine = np.quantile(
-        [i for i, st in enumerate(log) if st.startswith("simple")], 0.25
-    )
-    assert late_split < early_combine

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -564,7 +564,7 @@ async def test_shuffle_priority(c, s, a, b):
     dd = pytest.importorskip("dask.dataframe")
 
     df = pd.DataFrame({"a": range(1000)})
-    ddf = dd.from_pandas(df, npartitions=5)
+    ddf = dd.from_pandas(df, npartitions=3)
     ddf2 = ddf.shuffle("a", shuffle="tasks", max_branch=32)
     await c.compute(ddf2)
 

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -556,3 +556,27 @@ async def test_annotation_pack_unpack(c, s, a, b):
     unpacked_hlg = HighLevelGraph.__dask_distributed_unpack__(packed_hlg)
     annotations = unpacked_hlg["annotations"]
     assert annotations == {"workers": {"n": ("alice",)}}
+
+
+@gen_cluster(client=True)
+async def test_shuffle_priority(c, s, a, b):
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    df = pd.DataFrame({"a": range(1000)})
+    ddf = dd.from_pandas(df, npartitions=5)
+    ddf2 = ddf.shuffle("a", shuffle="tasks", max_branch=32)
+    await c.compute(ddf2)
+
+    # Parse transition log for processing tasks
+    log = [
+        eval(l[0])[0]
+        for l in s.transition_log
+        if l[1] == "processing" and "simple-shuffle-" in l[0]
+    ]
+
+    # Make sure all "split" tasks are processing before
+    # any "combine" tasks begin
+    max_split = max([i for i, st in enumerate(log) if st.startswith("split")])
+    min_combine = min([i for i, st in enumerate(log) if st.startswith("simple")])
+    assert max_split < min_combine

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -576,7 +576,7 @@ async def test_shuffle_priority(c, s, a, b):
         if l[1] == "processing" and "simple-shuffle-" in l[0]
     ]
 
-    # Make sure all "split" tasks are processing before
+    # Make sure most "split" tasks are processing before
     # any "combine" tasks begin
     late_split = np.quantile(
         [i for i, st in enumerate(log) if st.startswith("split")], 0.75


### PR DESCRIPTION
Possible alternative to #7826

- [x] Closes #7826
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
