### PR TITLE
Blockwise: handle non-string constant dependencies 

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -659,9 +659,12 @@ class Blockwise(Layer):
         # Gather constant dependencies (for all output keys)
         const_deps = set()
         for (arg, ind) in self.indices:
-            if ind is None and isinstance(arg, str):
-                if arg in all_hlg_keys:
-                    const_deps.add(arg)
+            if ind is None:
+                try:
+                    if arg in all_hlg_keys:
+                        const_deps.add(arg)
+                except TypeError:
+                    pass  # unhashable
 
         # Get dependencies for each output block
         key_deps = {}


### PR DESCRIPTION
Blockwise didn't consider non-string keys when gathering constant dependencies. Fixed.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
