### PR TITLE
`da.eye` fix for `chunks=-1`

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -543,7 +543,7 @@ def eye(N, chunks="auto", M=None, k=0, dtype=float):
 
     if not isinstance(chunks, (int, str)):
         raise ValueError("chunks must be an int or string")
-    # elif isinstance(chunks, str):
+
     chunks = normalize_chunks(chunks, shape=(N, M), dtype=dtype)
     chunks = chunks[0][0]
     token = tokenize(N, chunks, M, k, dtype)

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -543,9 +543,9 @@ def eye(N, chunks="auto", M=None, k=0, dtype=float):
 
     if not isinstance(chunks, (int, str)):
         raise ValueError("chunks must be an int or string")
-    elif isinstance(chunks, str):
-        chunks = normalize_chunks(chunks, shape=(N, M), dtype=dtype)
-        chunks = chunks[0][0]
+    # elif isinstance(chunks, str):
+    chunks = normalize_chunks(chunks, shape=(N, M), dtype=dtype)
+    chunks = chunks[0][0]
     token = tokenize(N, chunks, M, k, dtype)
     name_eye = "eye-" + token
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -544,17 +544,11 @@ def eye(N, chunks="auto", M=None, k=0, dtype=float):
     if not isinstance(chunks, (int, str)):
         raise ValueError("chunks must be an int or string")
 
-    chunks = normalize_chunks(chunks, shape=(N, M), dtype=dtype)
-    chunks = chunks[0][0]
+    vchunks, hchunks = normalize_chunks(chunks, shape=(N, M), dtype=dtype)
+    chunks = vchunks[0]
+
     token = tokenize(N, chunks, M, k, dtype)
     name_eye = "eye-" + token
-
-    vchunks = [chunks] * (N // chunks)
-    if N % chunks != 0:
-        vchunks.append(N % chunks)
-    hchunks = [chunks] * (M // chunks)
-    if M % chunks != 0:
-        hchunks.append(M % chunks)
 
     for i, vchunk in enumerate(vchunks):
         for j, hchunk in enumerate(hchunks):

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -404,6 +404,7 @@ def test_eye():
 
     assert_eq(da.eye(9, chunks=3, dtype=int), np.eye(9, dtype=int))
     assert_eq(da.eye(10, chunks=3, dtype=int), np.eye(10, dtype=int))
+    assert_eq(da.eye(10, chunks=-1, dtype=int), np.eye(10, dtype=int))
 
     with dask.config.set({"array.chunk-size": "50 MiB"}):
         x = da.eye(10000, "auto")


### PR DESCRIPTION
- [x] Closes #7852
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

Fixes bug in `da.eye` case of chunks=-1. 