### PR TITLE
Should check module name only, not the entire directory filepath

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -2045,7 +2045,7 @@ def coarsen(reduction, x, axes, trim_excess=False, **kwargs):
         msg = f"Coarsening factors {axes} do not align with array shape {x.shape}."
         raise ValueError(msg)
 
-    if "dask" in reduction.__module__:
+    if reduction.__module__.startswith("dask."):
         reduction = getattr(np, reduction.__name__)
 
     new_chunks = {}

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1,4 +1,3 @@
-import inspect
 import math
 import warnings
 from collections.abc import Iterable
@@ -2046,7 +2045,7 @@ def coarsen(reduction, x, axes, trim_excess=False, **kwargs):
         msg = f"Coarsening factors {axes} do not align with array shape {x.shape}."
         raise ValueError(msg)
 
-    if "dask" in inspect.getfile(reduction):
+    if "dask" in reduction.__module__:
         reduction = getattr(np, reduction.__name__)
 
     new_chunks = {}


### PR DESCRIPTION
A subtle thing that might not strictly be correct in `dask.array.coarsen`.

## What the dask main branch currently does
Dask does clever things in order to avoid users having to call `.compute()` on their results twice, if they happen to use `coarsen` and pass it a Dask reduction function like `da.mean` (instead of `np.mean`).

Currently, it looks at the reduction function that is passed, then searches for the word "dask" in the text string of the entire directory filename of that function (`inspect.getfile()` is used). The idea is, if we see "dask" anywhere in the filename, the function must belong to a dask module, and we can replace it with the equivalent 

## Where this fails
I use conda environments, and will quite often name my environments with phrases/words that contain "dask" somewhere in the title. That meant dask was *always* trying to replace the functions I passed to `coarsen` with a numpy equivalent, regardless of what I did.

This behaviour is a problem for:
1. People using cupy
2. People experimenting with reduction functions for other scientific python libraries (This is what I was doing when I found this behaviour. As a side note, I found my experiments generally don't work very well unless your third party function accepts an `axis` kwarg like numpy does)

## What I think dask should be doing instead
I think instead of inpecting the entire filepath string for the word "dask", we should just look for "dask" in only the `.__module__` attribute of the function is passed in. This PR should mean that `coarsen` now works with cupy+dask arrays.

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
