### PR TITLE
Raise NotImplementedError when using pd.Grouper in dask.dataframe.groupby

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1057,6 +1057,10 @@ class _GroupBy:
         observed=None,
     ):
 
+        by_ = by if isinstance(by, (tuple, list)) else [by]
+        if any(isinstance(key, pd.Grouper) for key in by_):
+            raise NotImplementedError("pd.Grouper is currently not supported by Dask.")
+
         assert isinstance(df, (DataFrame, Series))
         self.group_keys = group_keys
         self.obj = df

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2508,3 +2508,16 @@ def test_empty_partitions_with_value_counts():
     ddf = dd.from_pandas(df, npartitions=3)
     actual = ddf.groupby("A")["B"].value_counts()
     assert_eq(expected, actual)
+
+
+def test_groupby_with_pd_grouper():
+    ddf = dd.from_pandas(
+        pd.DataFrame(
+            {"key1": ["a", "b", "a"], "key2": ["c", "c", "c"], "value": [1, 2, 3]}
+        ),
+        npartitions=3,
+    )
+    with pytest.raises(NotImplementedError):
+        ddf.groupby(pd.Grouper(key="key1"))
+    with pytest.raises(NotImplementedError):
+        ddf.groupby(["key1", pd.Grouper(key="key2")])


### PR DESCRIPTION
- [x] Closes https://github.com/dask/dask/issues/5195, https://github.com/dask/dask/issues/7140, https://github.com/dask/dask/issues/6104
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

Currently `pd.Grouper` (to groupby on) is not supported by Dask. However, it can run without throwing errors (and give wrong results as a consequence).

I thought for quite a bit on a _real_ fix, but the current "apply-concat-apply" strategy of Dask makes it very difficult to support `pd.Grouper` (especially since the "second" groupby works on the index even when the first groupby is on the columns, if I'm not mistaken). 

Anyways, imo dask groupby should not run when it involves `pd.Grouper`.