### PR TITLE
Temporarily xfail `test_daily_stock`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3401,7 +3401,7 @@ Dask Name: {name}, {task} tasks""".format(
         return self.map_partitions(M.dropna, enforce_metadata=False)
 
     @derived_from(pd.Series)
-    def between(self, left, right, inclusive=True):
+    def between(self, left, right, inclusive="both"):
         return self.map_partitions(
             M.between, left=left, right=right, inclusive=inclusive
         )

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -113,6 +113,7 @@ def test_no_overlaps():
     )
 
 
+@pytest.mark.xfail(reason="https://github.com/pydata/pandas-datareader/issues/867")
 @pytest.mark.network
 def test_daily_stock():
     pytest.importorskip("pandas_datareader", minversion="0.8.0")


### PR DESCRIPTION
`test_daily_stock` is failing for unrelated reasons (xref https://github.com/dask/dask/pull/7854#issuecomment-872646626, https://github.com/dask/dask/pull/7856#issuecomment-872945999), so I suggest we temporarily `xfail` it in CI. There's some discussion upstream about how the issue should be resolved https://github.com/pydata/pandas-datareader/issues/867. 

cc @jsignell 