### PR TITLE
Support nested dask.distributed imports

### DIFF
--- a/dask/distributed.py
+++ b/dask/distributed.py
@@ -1,15 +1,17 @@
 # flake8: noqa
+
+_import_error_message = (
+    "dask.distributed is not installed.\n\n"
+    "Please either conda or pip install distributed:\n\n"
+    "  conda install dask distributed             # either conda install\n"
+    '  python -m pip install "dask[distributed]" --upgrade    # or pip install'
+)
+
 try:
     from distributed import *
 except ImportError as e:
     if e.msg == "No module named 'distributed'":
-        msg = (
-            "Dask's distributed scheduler is not installed.\n\n"
-            "Please either conda or pip install dask distributed:\n\n"
-            "  conda install dask distributed          # either conda install\n"
-            '  python -m pip install "dask[distributed]" --upgrade  # or python -m pip install'
-        )
-        raise ImportError(msg) from e
+        raise ImportError(_import_error_message) from e
     else:
         raise
 
@@ -18,11 +20,5 @@ def __getattr__(value):
     try:
         import distributed
     except ImportError as e:
-        msg = (
-            "dask.distributed is not installed.\n\n"
-            "Please either conda or pip install distributed:\n\n"
-            "  conda install dask distributed             # either conda install\n"
-            "  python -m pip install dask[distributed] --upgrade    # or pip install"
-        )
-        raise ImportError(msg) from e
+        raise ImportError(_import_error_message) from e
     return getattr(distributed, value)

--- a/dask/distributed.py
+++ b/dask/distributed.py
@@ -12,3 +12,17 @@ except ImportError as e:
         raise ImportError(msg) from e
     else:
         raise
+
+
+def __getattr__(value):
+    try:
+        import distributed
+    except ImportError as e:
+        msg = (
+            "dask.distributed is not installed.\n\n"
+            "Please either conda or pip install distributed:\n\n"
+            "  conda install dask distributed             # either conda install\n"
+            "  python -m pip install dask[distributed] --upgrade    # or pip install"
+        )
+        raise ImportError(msg) from e
+    return getattr(distributed, value)

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -9,8 +9,6 @@ from operator import add
 
 from tornado import gen
 
-from distributed import futures_of
-from distributed.client import wait
 from distributed.utils_test import client as c  # noqa F401
 from distributed.utils_test import cluster_fixture  # noqa F401
 from distributed.utils_test import loop  # noqa F401
@@ -20,6 +18,7 @@ import dask
 import dask.bag as db
 from dask import compute, delayed, persist
 from dask.delayed import Delayed
+from dask.distributed import futures_of, wait
 from dask.highlevelgraph import HighLevelGraph, MaterializedLayer
 from dask.utils import get_named_args, tmpdir
 
@@ -30,6 +29,10 @@ if "should_check_state" in get_named_args(gen_cluster):
 
 def test_can_import_client():
     from dask.distributed import Client  # noqa: F401
+
+
+def test_can_import_nested_things():
+    from dask.distributed.protocol import dumps  # noqa: F401
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
This uses the module-level __getattr__ feature implemented in 3.7