### PR TITLE
Add node size scaling to the Graphviz output for the high level graphs

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1226,7 +1226,7 @@ def to_graphviz(
     for k in hg.dependencies:
         k_name = name(k)
         attrs = data_attributes.get(k, {})
-        xfontsize = int(10 + ((n_tasks_dict[k] - mn) / mx) * 20)
+        xfontsize = int(20 + ((n_tasks_dict[k] - mn) / mx) * 20)
         attrs.setdefault("label", label(k, cache=cache))
         attrs.setdefault("fontsize", str(xfontsize))
         g.node(k_name, **attrs)

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1214,28 +1214,34 @@ def to_graphviz(
         graph_attr=graph_attr, node_attr=node_attr, edge_attr=edge_attr
     )
 
-    n_tasks_dict = {}
+    n_tasks = {}
     for layer in hg.dependencies:
-        n_tasks_dict[layer] = len(hg.layers[layer])
+        n_tasks[layer] = len(hg.layers[layer])
 
-    mn = min(n_tasks_dict.values())
-    mx = max(n_tasks_dict.values())
+    mn = min(n_tasks.values())
+    mx = max(n_tasks.values())
 
     cache = {}
 
-    for k in hg.dependencies:
-        k_name = name(k)
-        attrs = data_attributes.get(k, {})
-        xfontsize = int(20 + ((n_tasks_dict[k] - mn) / mx) * 20)
-        attrs.setdefault("label", label(k, cache=cache))
-        attrs.setdefault("fontsize", str(xfontsize))
-        g.node(k_name, **attrs)
+    for layer in hg.dependencies:
+        layer_name = name(layer)
+        attrs = data_attributes.get(layer, {})
 
-    for k, deps in hg.dependencies.items():
-        k_name = name(k)
+        xlabel = label(layer, cache=cache)
+        xfontsize = (
+            20 if mx == mn else int(20 + ((n_tasks[layer] - mn) / (mx - mn)) * 20)
+        )
+
+        attrs.setdefault("label", str(xlabel))
+        attrs.setdefault("fontsize", str(xfontsize))
+
+        g.node(layer_name, **attrs)
+
+    for layer, deps in hg.dependencies.items():
+        layer_name = name(layer)
         for dep in deps:
             dep_name = name(dep)
-            g.edge(dep_name, k_name)
+            g.edge(dep_name, layer_name)
     return g
 
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1219,6 +1219,19 @@ def to_graphviz(
         attrs = data_attributes.get(k, {})
         attrs.setdefault("label", label(k, cache=cache))
         attrs.setdefault("shape", "box")
+        n_tasks = len(hg.layers[k])
+        # print(n_tasks)
+        if n_tasks <= 10:
+            attrs.setdefault("fontsize", "10")
+        elif n_tasks <= 50:
+            attrs.setdefault("fontsize", "17")
+        if n_tasks <= 100:
+            attrs.setdefault("fontsize", "20")
+        if n_tasks <= 500:
+            attrs.setdefault("fontsize", "25")
+        if n_tasks <= 1000:
+            attrs.setdefault("fontsize", "30")
+        # This implementation is very brute-force-y. Will make it clean once the plan is ready.
         g.node(k_name, **attrs)
 
     for k, deps in hg.dependencies.items():

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1207,7 +1207,7 @@ def to_graphviz(
 
     graph_attr = graph_attr or {}
     graph_attr["rankdir"] = rankdir
-    node_attr["shape"] = "record"
+    node_attr["shape"] = "box"
     graph_attr.update(kwargs)
 
     g = graphviz.Digraph(
@@ -1226,11 +1226,8 @@ def to_graphviz(
     for k in hg.dependencies:
         k_name = name(k)
         attrs = data_attributes.get(k, {})
-        xlabel = (
-            "{" + label(k, cache=cache) + " | n_tasks = " + str(n_tasks_dict[k]) + "}"
-        )
         xfontsize = int(10 + ((n_tasks_dict[k] - mn) / mx) * 20)
-        attrs.setdefault("label", str(xlabel))
+        attrs.setdefault("label", label(k, cache=cache))
         attrs.setdefault("fontsize", str(xfontsize))
         g.node(k_name, **attrs)
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1225,13 +1225,16 @@ def to_graphviz(
             attrs.setdefault("fontsize", "10")
         elif n_tasks <= 50:
             attrs.setdefault("fontsize", "17")
-        if n_tasks <= 100:
+        elif n_tasks <= 100:
             attrs.setdefault("fontsize", "20")
-        if n_tasks <= 500:
+        elif n_tasks <= 500:
             attrs.setdefault("fontsize", "25")
-        if n_tasks <= 1000:
+        elif n_tasks <= 1000:
             attrs.setdefault("fontsize", "30")
-        # This implementation is very brute-force-y. Will make it clean once the plan is ready.
+        else:
+            attrs.setdefault("fontsize", "35")
+        # this implementation is very brute-force-y. will make it clean once the plan is ready.
+
         g.node(k_name, **attrs)
 
     for k, deps in hg.dependencies.items():


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`

/cc @martindurant @GenevieveBuckley

Hi. I created this PR to add new size features to the HighLevelGraphs Graphviz depiction based on the amount of tasks each HLG layer has.

This is a follow-up to the information found at https://github.com/dask/dask/issues/7847/.

For now, I have just added a simple implementation of just a trivial case.

At this point in the code, adding new conditions and loops is simple and quick. All that remains is to decide how we want to display this information on the HLG.