### PR TITLE
Updates due to https://github.com/dask/fastparquet/pull/623

### DIFF
--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -261,13 +261,13 @@ class FastParquetEngine(Engine):
         dtypes = {storage_name_mapping.get(k, k): v for k, v in dtypes.items()}
 
         index_cols = index or ()
-        meta = _meta_from_dtypes(all_columns, dtypes, index_cols, column_index_names)
         if isinstance(index_cols, str):
             index_cols = [index_cols]
-
-        # fastparquet doesn't handle multiindex
-        if len(index_names) > 1:
-            raise ValueError("fastparquet cannot read DataFrame with MultiIndex.")
+        for ind in index_cols:
+            if getattr(dtypes.get(ind), "numpy_dtype", None):
+                # index does not support masked types
+                dtypes[ind] = dtypes[ind].numpy_dtype
+        meta = _meta_from_dtypes(all_columns, dtypes, index_cols, column_index_names)
 
         for cat in categories:
             if cat in meta:

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -462,7 +462,6 @@ def test_columns_index_with_multi_index(tmpdir, engine):
     else:
         pq.write_table(pa.Table.from_pandas(df.reset_index(), preserve_index=False), fn)
 
-    # Pyarrow supports multi-index reads
     ddf = dd.read_parquet(fn, engine=engine, index=index.names)
     assert_eq(ddf, df)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -923,8 +923,6 @@ def test_read_parquet_custom_columns(tmpdir, engine):
     ],
 )
 def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
-    if engine == "pyarrow":
-        return
     if (
         PANDAS_GT_130
         and engine == "fastparquet"

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -943,7 +943,7 @@ def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
     else:
         dd.to_parquet(ddf, tmp, engine=engine, **write_kwargs)
     ddf2 = dd.read_parquet(tmp, index=df.index.name, engine=engine, **read_kwargs)
-    if df.dtypes.get("x") == "uint16" and engine == "fastparquet":
+    if str(ddf2.dtypes.get("x")) == "UInt16" and engine == "fastparquet":
         # fastparquet choooses to use masked type to be able to get true repr of
         # 16-bit int
         assert_eq(ddf.astype("UInt16"), ddf2)


### PR DESCRIPTION
NB: fastparquet has been able to do multi-index for a long time,
don't know why dask raised to this.

- [ ] ~Closes #xxxx~
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
