### PR TITLE
Add pytest marker for GPU tests

### DIFF
--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -3,6 +3,8 @@ from distutils.version import LooseVersion
 import numpy as np
 import pytest
 
+pytestmark = pytest.mark.gpu
+
 import dask
 import dask.array as da
 from dask.array.gufunc import apply_gufunc

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2248,6 +2248,7 @@ def test_groupby_dropna_pandas(dropna):
     assert_eq(dask_result, pd_result)
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize("dropna", [False, True, None])
 @pytest.mark.parametrize("by", ["a", "c", "d", ["a", "b"], ["a", "c"], ["a", "d"]])
 def test_groupby_dropna_cudf(dropna, by):
@@ -2349,6 +2350,7 @@ def test_groupby_split_out_multiindex(split_out, column):
     assert_eq(ddf_result, ddf_result_so1, check_index=False)
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize("backend", ["cudf", "pandas"])
 def test_groupby_large_ints_exception(backend):
     data_source = pytest.importorskip(backend)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -795,6 +795,7 @@ def test_merge(how, shuffle):
     #         pd.merge(A, B, left_index=True, right_on='y'))
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize("parts", [(3, 3), (3, 1), (1, 3)])
 @pytest.mark.parametrize("how", ["leftsemi", "leftanti"])
 @pytest.mark.parametrize(
@@ -2099,6 +2100,7 @@ def test_dtype_equality_warning():
     assert len(r) == 0
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize("engine", ["pandas", "cudf"])
 def test_groupby_concat_cudf(engine):
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -620,6 +620,7 @@ def test_set_index():
     assert_eq(d5, full.set_index(["b"]))
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize("engine", ["pandas", "cudf"])
 def test_set_index_interpolate(engine):
     if engine == "cudf":
@@ -647,6 +648,7 @@ def test_set_index_interpolate(engine):
     assert d2.divisions[3] == 2.0
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize("engine", ["pandas", "cudf"])
 def test_set_index_interpolate_int(engine):
     if engine == "cudf":
@@ -669,6 +671,7 @@ def test_set_index_interpolate_int(engine):
     assert all(np.issubdtype(type(x), np.integer) for x in d1.divisions)
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize("engine", ["pandas", "cudf"])
 def test_set_index_interpolate_large_uint(engine):
     if engine == "cudf":

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ test = pytest
 markers:
   network: Test requires an internet connection
   slow: Skipped unless --runslow passed
+  gpu: marks tests we want to run on GPUs
 addopts = -v -rsxfE --durations=10
 filterwarnings =
     # From Cython-1753


### PR DESCRIPTION
Corresponds with dask/distributed#5023 in adding a new pytest marker to all tests we intend to run on GPU.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
