### PR TITLE
fastparquet now supports new time types, including ns precision

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -931,6 +931,7 @@ def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
     if (
         PANDAS_GT_130
         and read_kwargs.get("categories", None)
+        and engine == "fastparquet"
         and fastparquet.__version__ <= LooseVersion("0.6.3")
     ):
         pytest.xfail("https://github.com/dask/fastparquet/issues/577")

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -921,7 +921,13 @@ def test_read_parquet_custom_columns(tmpdir, engine):
 def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
     if "x" in df and df.x.dtype == "M8[ns]" and "arrow" in engine:
         pytest.xfail(reason="Parquet pyarrow v1 doesn't support nanosecond precision")
-
+    if (
+        "x" in df
+        and df.x.dtype == "M8[ns]"
+        and engine == "fastparquet"
+        and fastparquet.__version__ <= LooseVersion("0.6.3")
+    ):
+        pytest.xfail(reason="fastparquet doesn't support nanosecond precision yet")
     tmp = str(tmpdir)
     if df.index.name is None:
         df.index.name = "index"

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -14,7 +14,7 @@ import dask
 import dask.dataframe as dd
 import dask.multiprocessing
 from dask.blockwise import Blockwise, optimize_blockwise
-from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_121
+from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_121, PANDAS_GT_130
 from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.dataframe.optimize import optimize_dataframe_getitem
 from dask.dataframe.utils import assert_eq
@@ -928,6 +928,13 @@ def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
         and fastparquet.__version__ <= LooseVersion("0.6.3")
     ):
         pytest.xfail(reason="fastparquet doesn't support nanosecond precision yet")
+    if (
+        PANDAS_GT_130
+        and read_kwargs.get("categories", None)
+        and fastparquet.__version__ <= LooseVersion("0.6.3")
+    ):
+        pytest.xfail("https://github.com/dask/fastparquet/issues/577")
+
     tmp = str(tmpdir)
     if df.index.name is None:
         df.index.name = "index"


### PR DESCRIPTION
- [ ] Closes #7877
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`

Mainly removing previous xfails.