### PR TITLE
Implement `Array.__iter__` [test-upstream]

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1341,6 +1341,13 @@ class Array(DaskMethodsMixin):
             "  x.compute_chunk_sizes()"
         )
 
+    def __iter__(self):
+        """Iterating over a dask array forces values to be evaluated"""
+        for block in self.blocks:
+            array = block.compute()
+            for row in array:
+                yield row
+
     def __len__(self):
         if not self.chunks:
             raise TypeError("len() of unsized object")

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -119,12 +119,22 @@ def atleast_1d(*arys):
 
 @derived_from(np)
 def vstack(tup, allow_unknown_chunksizes=False):
+    if isinstance(tup, Array):
+        raise NotImplementedError(
+            "``vstack`` expects a sequence of arrays as the first argument"
+        )
+
     tup = tuple(atleast_2d(x) for x in tup)
     return concatenate(tup, axis=0, allow_unknown_chunksizes=allow_unknown_chunksizes)
 
 
 @derived_from(np)
 def hstack(tup, allow_unknown_chunksizes=False):
+    if isinstance(tup, Array):
+        raise NotImplementedError(
+            "``hstack`` expects a sequence of arrays as the first argument"
+        )
+
     if all(x.ndim == 1 for x in tup):
         return concatenate(
             tup, axis=0, allow_unknown_chunksizes=allow_unknown_chunksizes
@@ -137,6 +147,11 @@ def hstack(tup, allow_unknown_chunksizes=False):
 
 @derived_from(np)
 def dstack(tup, allow_unknown_chunksizes=False):
+    if isinstance(tup, Array):
+        raise NotImplementedError(
+            "``dstack`` expects a sequence of arrays as the first argument"
+        )
+
     tup = tuple(atleast_3d(x) for x in tup)
     return concatenate(tup, axis=2, allow_unknown_chunksizes=allow_unknown_chunksizes)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2333,6 +2333,11 @@ def test_getter():
     assert_eq(getter(np.arange(5), (None, slice(None, None))), np.arange(5)[None, :])
 
 
+def test_iter_returns_real_values():
+    x = da.ones((10, 2), chunks=(3, 1))
+    assert list(x) == list(np.array(x))
+
+
 def test_size():
     x = da.ones((10, 2), chunks=(3, 1))
     assert x.size == np.array(x).size
@@ -4208,6 +4213,13 @@ def test_normalize_chunks_nan():
     with pytest.raises(ValueError) as info:
         normalize_chunks(((np.nan, np.nan), "auto"), (10, 10), limit=10, dtype=np.uint8)
     assert "auto" in str(info.value)
+
+
+def test_pandas_from_dask_array():
+    pd = pytest.importorskip("pandas")
+    a = da.ones((12,), chunks=4)
+    s = pd.Series(a, index=range(12))
+    assert_eq(s.values, a)
 
 
 def test_from_zarr_unique_name():

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -18,16 +18,16 @@ missing_arrfunc_reason = "NEP-18 support is not available in NumPy"
         lambda x: np.concatenate([x, x, x]),
         lambda x: np.cov(x, x),
         lambda x: np.dot(x, x),
-        lambda x: np.dstack(x),
+        lambda x: np.dstack((x, x)),
         lambda x: np.flip(x, axis=0),
-        lambda x: np.hstack(x),
+        lambda x: np.hstack((x, x)),
         lambda x: np.matmul(x, x),
         lambda x: np.mean(x),
         lambda x: np.stack([x, x]),
         lambda x: np.block([x, x]),
         lambda x: np.sum(x),
         lambda x: np.var(x),
-        lambda x: np.vstack(x),
+        lambda x: np.vstack((x, x)),
         lambda x: np.linalg.norm(x),
         lambda x: np.min(x),
         lambda x: np.amin(x),
@@ -47,6 +47,25 @@ def test_array_function_dask(func):
 
     assert isinstance(res_y, da.Array)
     assert_eq(res_y, res_x)
+
+
+@pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
+@pytest.mark.parametrize(
+    "func",
+    [
+        lambda x: np.dstack(x),
+        lambda x: np.hstack(x),
+        lambda x: np.vstack(x),
+    ],
+)
+def test_stack_functions_require_sequence_of_arrays(func):
+    x = np.random.random((100, 100))
+    y = da.from_array(x, chunks=(50, 50))
+
+    with pytest.raises(
+        NotImplementedError, match="expects a sequence of arrays as the first argument"
+    ):
+        func(y)
 
 
 @pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1929,7 +1929,7 @@ def test_ravel_multi_index_unknown_shape_fails():
 @pytest.mark.parametrize("wrap_in_list", [False, True])
 def test_ravel_multi_index_delayed_dims(dims, wrap_in_list):
     with pytest.raises(NotImplementedError, match="Dask types are not supported"):
-        da.ravel_multi_index((2, 1), list(dims) if wrap_in_list else dims)
+        da.ravel_multi_index((2, 1), [dims[0], dims[1]] if wrap_in_list else dims)
 
 
 def test_ravel_multi_index_non_int_dtype():


### PR DESCRIPTION
ref https://github.com/pandas-dev/pandas/issues/38645

- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

See the linked pandas issue for reference. This PR adds an `__iter__` method that greedily computes the array. I am unsure if this behavior would be too surprising. For additional context, the `dd.Series.__iter__` method already computes the data. 

Here's a comparison between this PR and main:

## This PR
```python
In [1]: import dask.array as da
   ...: 
   ...: a = da.ones((12,), chunks=4)
   ...: list(a)
Out[1]: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]

In [2]: 1 in a
Out[2]: True

In [3]: [value for value in a]
Out[3]: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]

In [4]: [a[i] for i in range(len(a))]
Out[4]: 
[dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>]
```

## Main
```python
In [1]: import dask.array as da
   ...: 
   ...: a = da.ones((12,), chunks=4)
   ...: list(a)
Out[1]: 
[dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>]

In [2]: 1 in a
Out[2]: True

In [3]: [value for value in a]
Out[3]: 
[dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>]

In [4]: [a[i] for i in range(len(a))]
Out[4]: 
[dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>,
 dask.array<getitem, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>]
```