### PR TITLE
Fix map_overlap trimming behavior when drop_axis is not None

### DIFF
--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -696,7 +696,16 @@ def map_overlap(
         # Find index of array argument with maximum rank and break ties by choosing first provided
         i = sorted(enumerate(args), key=lambda v: (v[1].ndim, -v[0]))[-1][0]
         # Trim using depth/boundary setting for array of highest rank
-        return trim_internal(x, depth[i], boundary[i])
+        x_depth = depth[i]
+        x_boundary = boundary[i]
+        # remove any dropped axes from depth and boundary variables
+        drop_axis = kwargs.pop("drop_axis", None)
+        if drop_axis is not None:
+            x_axis = tuple(ax for ax in range(args[i].ndim) if ax not in drop_axis)
+            # note that keys are relabeled to match values in range(x.ndim)
+            x_depth = {n: x_depth[ax] for n, ax in enumerate(x_axis)}
+            x_boundary = {n: x_boundary[ax] for n, ax in enumerate(x_axis)}
+        return trim_internal(x, x_depth, x_boundary)
     else:
         return x
 

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -1,5 +1,5 @@
 import warnings
-from numbers import Integral
+from numbers import Integral, Number
 
 import numpy as np
 from tlz import concat, get, partial
@@ -701,6 +701,8 @@ def map_overlap(
         # remove any dropped axes from depth and boundary variables
         drop_axis = kwargs.pop("drop_axis", None)
         if drop_axis is not None:
+            if isinstance(drop_axis, Number):
+                drop_axis = [drop_axis]
             kept_axes = tuple(ax for ax in range(args[i].ndim) if ax not in drop_axis)
             # note that keys are relabeled to match values in range(x.ndim)
             depth = {n: depth[ax] for n, ax in enumerate(kept_axes)}

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -696,16 +696,16 @@ def map_overlap(
         # Find index of array argument with maximum rank and break ties by choosing first provided
         i = sorted(enumerate(args), key=lambda v: (v[1].ndim, -v[0]))[-1][0]
         # Trim using depth/boundary setting for array of highest rank
-        x_depth = depth[i]
-        x_boundary = boundary[i]
+        depth = depth[i]
+        boundary = boundary[i]
         # remove any dropped axes from depth and boundary variables
         drop_axis = kwargs.pop("drop_axis", None)
         if drop_axis is not None:
-            x_axis = tuple(ax for ax in range(args[i].ndim) if ax not in drop_axis)
+            kept_axes = tuple(ax for ax in range(args[i].ndim) if ax not in drop_axis)
             # note that keys are relabeled to match values in range(x.ndim)
-            x_depth = {n: x_depth[ax] for n, ax in enumerate(x_axis)}
-            x_boundary = {n: x_boundary[ax] for n, ax in enumerate(x_axis)}
-        return trim_internal(x, x_depth, x_boundary)
+            depth = {n: depth[ax] for n, ax in enumerate(kept_axes)}
+            boundary = {n: boundary[ax] for n, ax in enumerate(kept_axes)}
+        return trim_internal(x, depth, boundary)
     else:
         return x
 

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -460,7 +460,8 @@ def test_map_overlap_trim_using_drop_axis_and_different_depths(drop_axis):
     boundary = (0, "reflect", "nearest")
     depth = (1, 3, 2)
     # to match expected result, dropped axes must have depth 0
-    depth = tuple(0 if i in drop_axis else d for i, d in enumerate(depth))
+    _drop_axis = (drop_axis,) if np.isscalar(drop_axis) else drop_axis
+    depth = tuple(0 if i in _drop_axis else d for i, d in enumerate(depth))
 
     y = da.map_overlap(
         _mean, x, depth=depth, boundary=boundary, drop_axis=drop_axis, dtype=float

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -447,7 +447,7 @@ def test_map_overlap_multiarray_variadic():
     assert all(x.compute() == size_per_slice)
 
 
-@pytest.mark.parametrize("drop_axis", ((0,), (1,), (2,), (0, 1), (1, 2), (2, 0)))
+@pytest.mark.parametrize("drop_axis", ((0,), (1,), (2,), (0, 1), (1, 2), (2, 0), 1))
 def test_map_overlap_trim_using_drop_axis_and_different_depths(drop_axis):
     x = da.random.standard_normal((5, 10, 8), chunks=(2, 5, 4))
 

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -447,6 +447,20 @@ def test_map_overlap_multiarray_variadic():
     assert all(x.compute() == size_per_slice)
 
 
+def test_map_overlap_trim_using_drop_axis_and_different_depths():
+    x = da.ones((5, 10), dtype=float)
+
+    y = da.map_overlap(
+        lambda x: x.mean(0), x, depth=(0, 2), drop_axis=(0,), chunks=(0,), dtype=float
+    ).compute()
+    assert y.shape == (x.shape[1],)
+
+    y = da.map_overlap(
+        lambda x: x.mean(1), x, depth=(2, 0), drop_axis=(1,), chunks=(0,), dtype=float
+    ).compute()
+    assert y.shape == (x.shape[0],)
+
+
 def test_map_overlap_assumes_shape_matches_first_array_if_trim_is_false():
     # https://github.com/dask/dask/issues/6681
     x1 = da.ones((10,), chunks=(5, 5))


### PR DESCRIPTION
This is a bug fix PR

It regenerates the depth and boundary variables, taking `drop_axis` into account before calling `trim_internal`

- [x] Closes #7893  (See more detailed description and example there)
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

