### PR TITLE
Fix bug in pyarrow-dataset partition ordering

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -243,7 +243,7 @@ def _collect_pyarrow_dataset_frags(
                 "partition_keys": {},
                 "partition_names": [],
             }
-            return metadata, partition_info
+            return sorted(metadata, key=natural_sort_key), partition_info
 
     # Get/transate filters
     ds_filters = None

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -275,6 +275,20 @@ def test_read_glob(tmpdir, write_engine, read_engine):
 
 
 @write_read_engines()
+def test_gather_statistics_false(tmpdir, write_engine, read_engine):
+    tmp_path = str(tmpdir)
+    ddf.to_parquet(tmp_path, write_index=False, engine=write_engine)
+
+    ddf2 = dd.read_parquet(
+        tmp_path,
+        engine=read_engine,
+        index=False,
+        gather_statistics=False,
+    )
+    assert_eq(ddf, ddf2, check_index=False, check_divisions=False)
+
+
+@write_read_engines()
 def test_read_list(tmpdir, write_engine, read_engine):
     if write_engine == read_engine == "fastparquet" and os.name == "nt":
         # fastparquet or dask is not normalizing filepaths correctly on


### PR DESCRIPTION
In the interest of #7871, this PR adds a simple fix to a partition-ordering bug in `ArrowDatasetEngine`.  This bug is currently blocking [cudf#8656](https://github.com/rapidsai/cudf/issues/8656).
