### PR TITLE
DOC: Add dask.array import to progress bar docs

### DIFF
--- a/docs/source/diagnostics-local.rst
+++ b/docs/source/diagnostics-local.rst
@@ -31,6 +31,7 @@ computation:
 
 .. code-block:: python
 
+    >>> import dask.array as da
     >>> from dask.diagnostics import ProgressBar
     >>> a = da.random.normal(size=(10000, 10000), chunks=(1000, 1000))
     >>> res = a.dot(a.T).mean(axis=0)


### PR DESCRIPTION
I followed the docs on using the progress bar and found that imporing `dask.array` was missing. I think this change will make following the docs a tiny bit easier since it avoids a `NameError`.

- ~[ ] Closes #xxxx~
- ~[ ] Tests added / passed~
- [x] Passes `black dask` / `flake8 dask` / `isort dask`