### PR TITLE
Use parquet metadata to calculate `len`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -313,6 +313,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
             )
         self._meta = meta
         self.divisions = tuple(divisions)
+        self.__lengths = None
 
     def __dask_graph__(self):
         return self.dask

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5296,7 +5296,7 @@ def elemwise(op, *args, **kwargs):
         with raise_on_meta_error(funcname(op)):
             meta = partial_by_order(*parts, function=op, other=other)
 
-    _lengths = deps[0]._lengths if deps else None
+    _lengths = deps[0]._lengths if deps and isinstance(deps, _Frame) else None
     result = new_dd_object(graph, _name, meta, divisions, lengths=_lengths)
     return handle_out(out, result)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3872,6 +3872,17 @@ class DataFrame(_Frame):
         return _iLocIndexer(self)
 
     def __len__(self):
+        # Check if this is a single-layer HLG with "num-rows"
+        # stored in the collection_annotations. If so, we already
+        # know the length
+        dsk = self.dask
+        if isinstance(dsk, HighLevelGraph) and len(dsk.layers) == 1:
+            layer = list(self.dask.layers.values())[0]
+            size = (layer.collection_annotations or {}).get("num-rows", None)
+            if size:
+                return size
+
+        # General Logic
         try:
             s = self.iloc[:, 0]
         except IndexError:

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1339,8 +1339,10 @@ class ArrowDatasetEngine(Engine):
         # `gather_statistics=True` for filtering.
         if split_row_groups is None:
             split_row_groups = False
-        _need_aggregation_stats = chunksize or (
-            int(split_row_groups) > 1 and aggregation_depth
+        _need_aggregation_stats = (
+            gather_statistics
+            or chunksize
+            or (int(split_row_groups) > 1 and aggregation_depth)
         )
         if (
             isinstance(metadata, list)
@@ -1384,8 +1386,7 @@ class ArrowDatasetEngine(Engine):
         split_row_groups,
         gather_statistics,
         stat_col_indices,
-        filters,
-        chunksize,
+        require_statistics,
         aggregation_depth,
     ):
         """Organize row-groups by file.
@@ -1446,7 +1447,7 @@ class ArrowDatasetEngine(Engine):
                             cmin = statistics[name]["min"]
                             cmax = statistics[name]["max"]
                             last = cmax_last.get(name, None)
-                            if not (filters or chunksize or aggregation_depth):
+                            if not (require_statistics or aggregation_depth):
                                 # Only think about bailing if we don't need
                                 # stats for filtering
                                 if cmin is None or (last and cmin < last):
@@ -1548,6 +1549,7 @@ class ArrowDatasetEngine(Engine):
         """
 
         # Organize row-groups by file
+        require_statistics = gather_statistics or chunksize or filters
         (
             file_row_groups,
             file_row_group_stats,
@@ -1559,8 +1561,7 @@ class ArrowDatasetEngine(Engine):
             split_row_groups,
             gather_statistics,
             stat_col_indices,
-            filters,
-            chunksize,
+            require_statistics,
             aggregation_depth,
         )
 
@@ -1929,8 +1930,7 @@ class ArrowLegacyEngine(ArrowDatasetEngine):
         split_row_groups,
         gather_statistics,
         stat_col_indices,
-        filters,
-        chunksize,
+        require_statistics,
         aggregation_depth,
     ):
         """Organize row-groups by file.
@@ -1988,7 +1988,7 @@ class ArrowLegacyEngine(ArrowDatasetEngine):
                         cmin = column.statistics.min
                         cmax = column.statistics.max
                         last = cmax_last.get(name, None)
-                        if not (filters or chunksize or aggregation_depth):
+                        if not (require_statistics or aggregation_depth):
                             # Only think about bailing if we don't need
                             # stats for filtering
                             if cmin is None or (last and cmin < last):
@@ -2018,7 +2018,7 @@ class ArrowLegacyEngine(ArrowDatasetEngine):
                     else:
 
                         if (
-                            not (filters or chunksize or aggregation_depth)
+                            not (require_statistics or aggregation_depth)
                             and column.num_values > 0
                         ):
                             # We are collecting statistics for divisions
@@ -2067,6 +2067,7 @@ class ArrowLegacyEngine(ArrowDatasetEngine):
         """
 
         # Organize row-groups by file
+        require_statistics = gather_statistics or chunksize or filters
         (
             file_row_groups,
             file_row_group_stats,
@@ -2077,8 +2078,7 @@ class ArrowLegacyEngine(ArrowDatasetEngine):
             split_row_groups,
             gather_statistics,
             stat_col_indices,
-            filters,
-            chunksize,
+            require_statistics,
             aggregation_depth,
         )
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -399,7 +399,7 @@ def read_parquet(
 
         graph = HighLevelGraph({output_name: layer}, {output_name: set()})
 
-    return new_dd_object(graph, output_name, meta, divisions, lens=partition_sizes)
+    return new_dd_object(graph, output_name, meta, divisions, lengths=partition_sizes)
 
 
 def check_multi_support(engine):

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -366,7 +366,7 @@ class FastParquetEngine(Engine):
         dtypes,
         base_path,
         paths,
-        chunksize,
+        require_statistics,
         aggregation_depth,
     ):
         """Organize row-groups by file."""
@@ -481,7 +481,7 @@ class FastParquetEngine(Engine):
                             cmax = pd.Timestamp(cmax, tz=tz)
                         last = cmax_last.get(name, None)
 
-                        if not (filters or chunksize or aggregation_depth):
+                        if not (require_statistics or aggregation_depth):
                             # Only think about bailing if we don't need
                             # stats for filtering
                             if cmin is None or (last and cmin < last):
@@ -509,7 +509,7 @@ class FastParquetEngine(Engine):
                         cmax_last[name] = cmax
                     else:
                         if (
-                            not (filters or chunksize or aggregation_depth)
+                            not (require_statistics or aggregation_depth)
                             and column.meta_data.num_values > 0
                         ):
                             # We are collecting statistics for divisions
@@ -616,6 +616,7 @@ class FastParquetEngine(Engine):
     ):
 
         # Organize row-groups by file
+        require_statistics = filters or chunksize or gather_statistics
         (
             file_row_groups,
             file_row_group_stats,
@@ -631,7 +632,7 @@ class FastParquetEngine(Engine):
             dtypes,
             base_path,
             paths,
-            chunksize,
+            require_statistics,
             aggregation_depth,
         )
 

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -308,8 +308,10 @@ class FastParquetEngine(Engine):
         # want to apply any filters or calculate divisions.
         if split_row_groups is None:
             split_row_groups = False
-        _need_aggregation_stats = chunksize or (
-            int(split_row_groups) > 1 and aggregation_depth
+        _need_aggregation_stats = (
+            gather_statistics
+            or chunksize
+            or (int(split_row_groups) > 1 and aggregation_depth)
         )
         if (
             isinstance(parts, list) and len(parts) and isinstance(parts[0], str)

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -339,6 +339,7 @@ def test_DataFrame_from_dask_array():
     tm.assert_index_equal(df.columns, pd.Index(["a", "b", "c"]))
     assert list(df.divisions) == [0, 4, 8, 9]
     assert (df.compute(scheduler="sync").values == x.compute(scheduler="sync")).all()
+    assert len(df) == x.shape[0]
 
     # dd.from_array should re-route to from_dask_array
     df2 = dd.from_array(x, columns=["a", "b", "c"])

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2506,7 +2506,7 @@ def test_blockwise_parquet_annotations(tmpdir):
     assert len(layers) == 1
     layer = next(iter((layers.values())))
     assert isinstance(layer, DataFrameIOLayer)
-    assert layer.annotations == {"foo": "bar"}
+    assert layer.annotations["foo"] == "bar"
 
 
 @ANY_ENGINE_MARK


### PR DESCRIPTION
Dask does not currently save/leverage the parquet-metadata statistics tp calculate the length of a DataFrame collection.  This PR modifies `read_parquet` to save the size of each partition (when this information is available and correct), and then uses it in `DataFrame.__len__`.

I am confident that we definitely want to do something like this.  However, I will mark this PR as a draft until we can agree on "where" the partition-size metadata should be stored.  For now, I am adding it to `collection_annotations`, but it may also make sense to make it a `DataFrameIOLayer` attribute.
