### PR TITLE
add numpy array of dask keys to Array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1240,6 +1240,10 @@ class Array(DaskMethodsMixin):
             self.__dict__.pop(key, None)
 
     @cached_property
+    def key_array(self):
+        return np.array(self.__dask_keys__(), dtype=object)
+
+    @cached_property
     def numblocks(self):
         return tuple(map(len, self.chunks))
 
@@ -1501,10 +1505,6 @@ class Array(DaskMethodsMixin):
             "It is uncommon to need to change it, but if you do\n"
             "please set ``._name``"
         )
-
-    def __iter__(self):
-        for i in range(len(self)):
-            yield self[i]
 
     __array_priority__ = 11  # higher than numpy.ndarray and numpy.matrix
 
@@ -1830,7 +1830,7 @@ class Array(DaskMethodsMixin):
 
         name = "blocks-" + tokenize(self, index)
 
-        new_keys = np.array(self.__dask_keys__(), dtype=object)[index]
+        new_keys = self.key_array[index]
 
         chunks = tuple(
             tuple(np.array(c)[i].tolist()) for c, i in zip(self.chunks, index)


### PR DESCRIPTION
- [x] Closes ##7832
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

This PR adds the cached `key_array` property to the `Array` class. This property is just a cached numpy array of the `Array.__dask_keys__()` property with `dtype=object`. Adding this as a property of the `Array` class allows me to remove [expensive numpy array creation](https://github.com/dask/dask/blob/main/dask/array/core.py#L1833) in `Array._blocks` and thereby make iterating over `Array.blocks` more performant.

I benchmarked iteration over `Array.blocks` with the following code:

```python
import timeit
result = timeit.timeit('[d for d in data.blocks]', setup='import dask.array as da; data = da.zeros((5000,), chunks=(1,))', number=3)
print(result)
```

Running this benchmark on main takes 17.60s; with the changes in this PR, the benchmark takes 4.58s.

As mentioned in #7832, another solution to this problem would be to implement the numpy array slicing interface for the `Array.__dask_keys__` property. This might be a better approach (I don't like adding properties just to enhance performance of one method), but it would be much more work and require more test coverage (unless there's an existing test suite for "adapt numpy array slicing to lists-of-lists"). Additionally, the approach I took in this PR will organically track any changes in the numpy array slicing interface. But maybe that interface changes too slowly for this to be valuable.