### PR TITLE
Remove experimental feature warning from actors docs

### DIFF
--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -725,9 +725,6 @@ providing an additional channel of communication between ongoing tasks.
 Actors
 ------
 
-.. note:: This is an advanced feature and is rarely necessary in the common case.
-.. note:: This is an experimental feature and is subject to change without notice.
-
 Actors allow workers to manage rapidly changing state without coordinating with
 the central scheduler.  This has the advantage of reducing latency
 (worker-to-worker roundtrip latency is around 1ms), reducing pressure on the


### PR DESCRIPTION
Also remove the "this is rarely necessary" message.
I still think that this is true, but it seems like more of a distraction
to keep it in today.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
