### PR TITLE
Unpin fastparquet in CI

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -15,10 +15,7 @@ dependencies:
   - pytest-xdist
   - moto
   - flask
-  # Temporarily pin to avoid incompatible pandas depedency.
-  # Unpin once build 0 for fastparquet=0.7.0 is marked as bad on conda-forge.
-  # https://github.com/dask/dask/pull/7907
-  - fastparquet<0.7.0
+  - fastparquet
   - h5py
   - pytables
   - zarr


### PR DESCRIPTION
With https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/152 merged, we can undo the temporary `fastparquet` pin introduced in https://github.com/dask/dask/pull/7907