### PR TITLE
Change graphviz font family to sans

### DIFF
--- a/dask/dot.py
+++ b/dask/dot.py
@@ -143,7 +143,6 @@ def to_graphviz(
     edge_attr = edge_attr or {}
 
     graph_attr["rankdir"] = rankdir
-    node_attr["shape"] = "box"
     node_attr["fontname"] = "roboto"
 
     graph_attr.update(kwargs)

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -143,7 +143,7 @@ def to_graphviz(
     edge_attr = edge_attr or {}
 
     graph_attr["rankdir"] = rankdir
-    node_attr["fontname"] = "roboto"
+    node_attr["fontname"] = "helvetica"
 
     graph_attr.update(kwargs)
     g = graphviz.Digraph(

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -136,15 +136,16 @@ def to_graphviz(
     verbose=False,
     **kwargs,
 ):
-    if data_attributes is None:
-        data_attributes = {}
-    if function_attributes is None:
-        function_attributes = {}
-    if graph_attr is None:
-        graph_attr = {}
-
+    data_attributes = data_attributes or {}
+    function_attributes = function_attributes or {}
     graph_attr = graph_attr or {}
+    node_attr = node_attr or {}
+    edge_attr = edge_attr or {}
+
     graph_attr["rankdir"] = rankdir
+    node_attr["shape"] = "box"
+    node_attr["fontname"] = "roboto"
+
     graph_attr.update(kwargs)
     g = graphviz.Digraph(
         graph_attr=graph_attr, node_attr=node_attr, edge_attr=edge_attr

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1194,23 +1194,24 @@ def to_graphviz(
     data_attributes=None,
     function_attributes=None,
     rankdir="BT",
-    graph_attr={},
-    node_attr={},
+    graph_attr=None,
+    node_attr=None,
     edge_attr=None,
     **kwargs,
 ):
     from .dot import graphviz, label, name
 
-    if data_attributes is None:
-        data_attributes = {}
-    if function_attributes is None:
-        function_attributes = {}
-
+    data_attributes = data_attributes or {}
+    function_attributes = function_attributes or {}
     graph_attr = graph_attr or {}
+    node_attr = node_attr or {}
+    edge_attr = edge_attr or {}
+
     graph_attr["rankdir"] = rankdir
     node_attr["shape"] = "box"
-    graph_attr.update(kwargs)
+    node_attr["fontname"] = "roboto"
 
+    graph_attr.update(kwargs)
     g = graphviz.Digraph(
         graph_attr=graph_attr, node_attr=node_attr, edge_attr=edge_attr
     )

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1209,7 +1209,7 @@ def to_graphviz(
 
     graph_attr["rankdir"] = rankdir
     node_attr["shape"] = "box"
-    node_attr["fontname"] = "roboto"
+    node_attr["fontname"] = "helvetica"
 
     graph_attr.update(kwargs)
     g = graphviz.Digraph(


### PR DESCRIPTION
- [X] Tests passed
- [X] Passes `black dask` / `flake8 dask` / `isort dask`

I was working on #7869 and realized that the Graphviz output would look even cleaner if we use a sans-serif font instead of the current serif font.

In this PR, I have changed the font of the Graphviz from **Times-Roman** to ~~**Roboto**~~ **Helvetica**. I have also cleaned the code in the method `to_graphviz()` to be more consistent in `dot.py` (LOW LEVEL) and `highlevelgraph.py` (HIGH LEVEL). Now, they look similar and it might be easier to work with this code in the future.

It follows the https://marketing.dask.org/en/latest/colors.html
![dask](https://user-images.githubusercontent.com/62539811/126878443-5ec1f7af-f44a-45bd-9ed7-2481390e82b2.png)
(Font mentioned in image: Roboto)

Even the HTML Representation uses a Sans font, so it makes sense to have the Graph representations also follow suit.

## Demo

```py
import dask.array as da

x = da.ones((10, 10), chunks=(5, 5))
x = x + 100
x = x * 100

x.visualize()
```

### Before
![b1](https://user-images.githubusercontent.com/62539811/126878530-974c2258-1dea-4b71-bf4f-022109db9b27.png)

### After
![a1](https://user-images.githubusercontent.com/62539811/126878533-3df2abf6-0d71-496c-b614-28c971c08def.png)


```py
import dask.array as da

XL = da.ones((67552, 365941), chunks=(652, 5792))
XL2 = XL.T.astype("f4")
XC = da.ones((365941, 26), chunks=(365941, 26))
LS = da.linalg.lstsq(XC, XL2)[0]
XC_LS = XC @ LS
XLP = XL2 - XC_LS

XLP.dask.visualize(\)
```
### Before
![b2](https://user-images.githubusercontent.com/62539811/126878594-476bf436-4fd6-462f-af48-81f71e7fcd7b.png)


### After
![a2](https://user-images.githubusercontent.com/62539811/126878561-8fb50e0b-f7ff-4ff8-983c-26cdcfb56892.png)


/cc @GenevieveBuckley @martindurant 







