### PR TITLE
Require NumPy 1.18+ & Pandas 1.0+

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -6,8 +6,8 @@ dependencies:
   # required dependencies
   - python=3.7
   - packaging
-  - numpy=1.16
-  - pandas=0.25
+  - numpy=1.18
+  - pandas=1.0
   # test dependencies
   - pytest
   - pytest-cov
@@ -25,7 +25,7 @@ dependencies:
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
   # along with other issues https://github.com/pandas-dev/pandas/issues/40467
   - sqlalchemy<1.4.0
-  - pyarrow=0.14
+  - pyarrow=1
   - coverage
   - jsonschema
   # other -- IO

--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -25,7 +25,7 @@ dependencies:
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
   # along with other issues https://github.com/pandas-dev/pandas/issues/40467
   - sqlalchemy<1.4.0
-  - pyarrow=1
+  - pyarrow=1.0
   - coverage
   - jsonschema
   # other -- IO

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -6,7 +6,7 @@ dependencies:
   # required dependencies
   - python=3.8
   - packaging
-  - numpy=1.17
+  - numpy=1.19
   - pandas=1.1
   # test dependencies
   - pytest

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.8
   - packaging
   - numpy=1.19
-  - pandas=1.1
+  - pandas=1.2
   # test dependencies
   - pytest
   - pytest-cov
@@ -25,7 +25,7 @@ dependencies:
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
   # along with other issues https://github.com/pandas-dev/pandas/issues/40467
   - sqlalchemy<1.4.0
-  - pyarrow=1.0
+  - pyarrow=4.0
   - coverage
   - jsonschema
   # other -- IO

--- a/continuous_integration/environment-mindeps-array-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-array-dataframe.yaml
@@ -12,7 +12,7 @@ dependencies:
   - toolz=0.8.2
   # optional dependencies pulled in by pip install dask[array, dataframe]
   - numpy=1.18
-  - pandas=1.0.0
+  - pandas=1.0
   # test dependencies
   - pytest
   - pytest-cov

--- a/continuous_integration/environment-mindeps-array-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-array-dataframe.yaml
@@ -11,8 +11,8 @@ dependencies:
   - fsspec=0.6.0
   - toolz=0.8.2
   # optional dependencies pulled in by pip install dask[array, dataframe]
-  - numpy=1.16
-  - pandas=0.25.0
+  - numpy=1.18
+  - pandas=1.0.0
   # test dependencies
   - pytest
   - pytest-cov

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -369,11 +369,11 @@ def apply_infer_dtype(func, args, kwargs, funcname, suggest_dtype="dtype", nout=
     : dtype or List of dtype
         One or many dtypes (depending on ``nout``)
     """
-    from .utils import meta_from_array, ones_like_safe
+    from .utils import meta_from_array
 
     # make sure that every arg is an evaluated array
     args = [
-        ones_like_safe(meta_from_array(x), shape=((1,) * x.ndim), dtype=x.dtype)
+        np.ones_like(meta_from_array(x), shape=((1,) * x.ndim), dtype=x.dtype)
         if is_arraylike(x)
         else x
         for x in args
@@ -4771,8 +4771,6 @@ def concatenate3(arrays):
            [1, 2, 1, 2],
            [1, 2, 1, 2]])
     """
-    from .utils import IS_NEP18_ACTIVE
-
     # We need this as __array_function__ may not exist on older NumPy versions.
     # And to reduce verbosity.
     NDARRAY_ARRAY_FUNCTION = getattr(np.ndarray, "__array_function__", None)
@@ -4786,7 +4784,7 @@ def concatenate3(arrays):
         key=lambda x: getattr(x, "__array_priority__", 0),
     )
 
-    if IS_NEP18_ACTIVE and not all(
+    if not all(
         NDARRAY_ARRAY_FUNCTION
         is getattr(type(arr), "__array_function__", NDARRAY_ARRAY_FUNCTION)
         for arr in core.flatten(arrays, container=(list, tuple))
@@ -5112,8 +5110,6 @@ def _vindex_merge(locations, values):
            [40, 50, 60],
            [10, 20, 30]])
     """
-    from .utils import empty_like_safe
-
     locations = list(map(list, locations))
     values = list(values)
 
@@ -5125,7 +5121,7 @@ def _vindex_merge(locations, values):
 
     dtype = values[0].dtype
 
-    x = empty_like_safe(values[0], dtype=dtype, shape=shape)
+    x = np.empty_like(values[0], dtype=dtype, shape=shape)
 
     ind = [slice(None, None) for i in range(x.ndim)]
     for loc, val in zip(locations, values):

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -25,7 +25,7 @@ from .core import (
     stack,
 )
 from .ufunc import greater_equal, rint
-from .utils import AxisError, meta_from_array, zeros_like_safe
+from .utils import AxisError, meta_from_array
 from .wrap import empty, full, ones, zeros
 
 
@@ -608,7 +608,7 @@ def diag(v):
                 dsk[key] = (np.diag, blocks[i])
             else:
                 dsk[key] = (np.zeros, (m, n))
-                dsk[key] = (partial(zeros_like_safe, shape=(m, n)), meta)
+                dsk[key] = (partial(np.zeros_like, shape=(m, n)), meta)
 
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[v])
     return Array(graph, name, (chunks_1d, chunks_1d), meta=meta)
@@ -855,9 +855,6 @@ def linear_ramp_chunk(start, stop, num, dim, step):
     """
     Helper function to find the linear ramp for a chunk.
     """
-
-    from .utils import empty_like_safe
-
     num1 = num + 1
 
     shape = list(start.shape)
@@ -866,7 +863,7 @@ def linear_ramp_chunk(start, stop, num, dim, step):
 
     dtype = np.dtype(start.dtype)
 
-    result = empty_like_safe(start, shape, dtype=dtype)
+    result = np.empty_like(start, shape=shape, dtype=dtype)
     for i in np.ndindex(start.shape):
         j = list(i)
         j[dim] = slice(None)

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -1,4 +1,5 @@
 import operator
+from functools import partial
 from numbers import Number
 
 import numpy as np
@@ -12,14 +13,7 @@ from ..utils import apply, derived_from
 from .core import Array, concatenate, dotmany, from_delayed
 from .creation import eye
 from .random import RandomState
-from .utils import (
-    array_safe,
-    meta_from_array,
-    ones_like_safe,
-    solve_triangular_safe,
-    svd_flip,
-    zeros_like_safe,
-)
+from .utils import array_safe, meta_from_array, solve_triangular_safe, svd_flip
 
 
 def _cumsum_blocks(it):
@@ -942,7 +936,7 @@ def svd(a, coerce_signs=True):
         m, n = a.shape
         k = min(a.shape)
         mu, ms, mv = np.linalg.svd(
-            ones_like_safe(a._meta, shape=(1, 1), dtype=a._meta.dtype)
+            np.ones_like(a._meta, shape=(1, 1), dtype=a._meta.dtype)
         )
         u, s, v = delayed(np.linalg.svd, nout=3)(a, full_matrices=False)
         u = from_delayed(u, shape=(m, k), meta=mu)
@@ -1325,9 +1319,8 @@ def _cholesky(a):
         for j in range(hdim):
             if i < j:
                 dsk[name, i, j] = (
-                    zeros_like_safe,
+                    partial(np.zeros_like, shape=(a.chunks[0][i], a.chunks[1][j])),
                     meta_from_array(a),
-                    (a.chunks[0][i], a.chunks[1][j]),
                 )
                 dsk[name_upper, j, i] = (name, i, j)
             elif i == j:

--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -6,8 +6,6 @@ from packaging.version import parse as parse_version
 from ..utils import derived_from
 
 _np_version = parse_version(np.__version__)
-_numpy_117 = _np_version >= parse_version("1.17.0")
-_numpy_118 = _np_version >= parse_version("1.18.0")
 _numpy_120 = _np_version >= parse_version("1.20.0")
 _numpy_121 = _np_version >= parse_version("1.21.0")
 

--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -186,7 +186,7 @@ def merge_percentiles(finalq, qs, vals, interpolation="lower", Ns=None):
     >>> merge_percentiles(finalq, qs, vals, Ns=Ns)
     array([ 1,  2,  3,  4, 10, 11, 12, 13])
     """
-    from .utils import array_safe, empty_like_safe
+    from .utils import array_safe
 
     if isinstance(finalq, Iterator):
         finalq = list(finalq)
@@ -220,7 +220,7 @@ def merge_percentiles(finalq, qs, vals, interpolation="lower", Ns=None):
     # transform qs and Ns into number of observations between percentiles
     counts = []
     for q, N in zip(qs, Ns):
-        count = empty_like_safe(finalq, shape=len(q))
+        count = np.empty_like(finalq, shape=len(q))
         count[1:] = np.diff(array_safe(q, like=q[0]))
         count[0] = q[0]
         count *= N

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -22,7 +22,7 @@ from .creation import arange, diagonal
 
 # Keep empty_lookup here for backwards compatibility
 from .dispatch import divide_lookup, empty_lookup  # noqa: F401
-from .utils import compute_meta, full_like_safe, is_arraylike, validate_axis
+from .utils import compute_meta, is_arraylike, validate_axis
 from .wrap import ones, zeros
 
 
@@ -549,7 +549,7 @@ def numel(x, **kwargs):
     if axis is None:
         prod = np.prod(shape, dtype=dtype)
         return (
-            full_like_safe(x, prod, shape=(1,) * len(shape), dtype=dtype)
+            np.full_like(x, prod, shape=(1,) * len(shape), dtype=dtype)
             if keepdims is True
             else prod
         )
@@ -564,7 +564,7 @@ def numel(x, **kwargs):
         )
     else:
         new_shape = tuple(shape[dim] for dim in range(len(shape)) if dim not in axis)
-    return full_like_safe(x, prod, shape=new_shape, dtype=dtype)
+    return np.full_like(x, prod, shape=new_shape, dtype=dtype)
 
 
 def nannumel(x, **kwargs):

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -33,14 +33,7 @@ from .core import (
 from .creation import arange, diag, empty, indices, tri
 from .einsumfuncs import einsum  # noqa
 from .ufunc import multiply, sqrt
-from .utils import (
-    array_safe,
-    asarray_safe,
-    meta_from_array,
-    safe_wraps,
-    validate_axis,
-    zeros_like_safe,
-)
+from .utils import array_safe, asarray_safe, meta_from_array, safe_wraps, validate_axis
 from .wrap import ones
 
 # save built-in for histogram functions which use range as a kwarg.
@@ -672,7 +665,7 @@ def _bincount_agg(bincounts, dtype, **kwargs):
         return bincounts
 
     n = max(map(len, bincounts))
-    out = zeros_like_safe(bincounts[0], shape=n, dtype=dtype)
+    out = np.zeros_like(bincounts[0], shape=n, dtype=dtype)
     for b in bincounts:
         out[: len(b)] += b
     return out
@@ -2336,7 +2329,7 @@ def tril(m, k=0):
         *m.shape[-2:], k=k, dtype=bool, chunks=m.chunks[-2:], like=meta_from_array(m)
     )
 
-    return where(mask, m, zeros_like_safe(m, shape=(1,)))
+    return where(mask, m, np.zeros_like(m, shape=(1,)))
 
 
 @derived_from(np)
@@ -2350,7 +2343,7 @@ def triu(m, k=0):
         like=meta_from_array(m),
     )
 
-    return where(mask, zeros_like_safe(m, shape=(1,)), m)
+    return where(mask, np.zeros_like(m, shape=(1,)), m)
 
 
 @derived_from(np)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -43,7 +43,6 @@ from dask.array.core import (
     stack,
     store,
 )
-from dask.array.numpy_compat import _numpy_117
 from dask.array.utils import assert_eq, same_keys
 from dask.base import compute_as_if_collection, tokenize
 from dask.blockwise import broadcast_dimensions
@@ -2675,7 +2674,6 @@ def test_concatenate3_2():
     )
 
 
-@pytest.mark.skipif(not _numpy_117, reason="NEP-18 is not enabled by default")
 @pytest.mark.parametrize("one_d", [True, False])
 @mock.patch.object(da.core, "_concatenate2", wraps=da.core._concatenate2)
 def test_concatenate3_nep18_dispatching(mock_concatenate2, one_d):

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -2,15 +2,11 @@ import numpy as np
 import pytest
 
 import dask.array as da
-from dask.array.utils import IS_NEP18_ACTIVE, assert_eq
+from dask.array.utils import assert_eq
 
 from .test_dispatch import EncapsulateNDArray, WrappedArray
 
-missing_arrfunc_cond = not IS_NEP18_ACTIVE
-missing_arrfunc_reason = "NEP-18 support is not available in NumPy"
 
-
-@pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
 @pytest.mark.parametrize(
     "func",
     [
@@ -49,7 +45,6 @@ def test_array_function_dask(func):
     assert_eq(res_y, res_x)
 
 
-@pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
 @pytest.mark.parametrize(
     "func",
     [
@@ -68,7 +63,6 @@ def test_stack_functions_require_sequence_of_arrays(func):
         func(y)
 
 
-@pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
 @pytest.mark.parametrize("func", [np.fft.fft, np.fft.fft2])
 def test_array_function_fft(func):
     x = np.random.random((100, 100))
@@ -81,7 +75,6 @@ def test_array_function_fft(func):
     assert_eq(res_y, res_x)
 
 
-@pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
 @pytest.mark.parametrize(
     "func",
     [
@@ -100,7 +93,6 @@ def test_array_notimpl_function_dask(func):
         func(y)
 
 
-@pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
 @pytest.mark.parametrize(
     "func", [lambda x: np.real(x), lambda x: np.imag(x), lambda x: np.transpose(x)]
 )
@@ -114,7 +106,6 @@ def test_array_function_sparse(func):
     assert_eq(func(x), func(y))
 
 
-@pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
 def test_array_function_sparse_tensordot():
     sparse = pytest.importorskip("sparse")
     x = np.random.random((2, 3, 4))
@@ -130,7 +121,6 @@ def test_array_function_sparse_tensordot():
     )
 
 
-@pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
 @pytest.mark.parametrize("chunks", [(100, 100), (500, 100)])
 def test_array_function_cupy_svd(chunks):
     cupy = pytest.importorskip("cupy")
@@ -146,7 +136,6 @@ def test_array_function_cupy_svd(chunks):
     assert_eq(v, v_base)
 
 
-@pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
 @pytest.mark.parametrize(
     "func",
     [
@@ -191,16 +180,12 @@ def test_non_existent_func():
     # Regression test for __array_function__ becoming default in numpy 1.17
     # dask has no sort function, so ensure that this still calls np.sort
     x = da.from_array(np.array([1, 2, 4, 3]), chunks=(2,))
-    if IS_NEP18_ACTIVE:
-        with pytest.warns(
-            FutureWarning, match="The `numpy.sort` function is not implemented by Dask"
-        ):
-            assert list(np.sort(x)) == [1, 2, 3, 4]
-    else:
+    with pytest.warns(
+        FutureWarning, match="The `numpy.sort` function is not implemented by Dask"
+    ):
         assert list(np.sort(x)) == [1, 2, 3, 4]
 
 
-@pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
 @pytest.mark.parametrize(
     "func",
     [

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -9,7 +9,6 @@ from tlz import concat
 import dask
 import dask.array as da
 from dask.array.core import normalize_chunks
-from dask.array.numpy_compat import _numpy_117, _numpy_118
 from dask.array.utils import AxisError, assert_eq, same_keys
 
 
@@ -73,9 +72,6 @@ def test_arr_like(funcname, shape, cast_shape, dtype, cast_chunks, chunks, name,
         assert not np.isfortran(da_r.compute())
 
 
-@pytest.mark.skipif(
-    not _numpy_117, reason="requires NumPy>=1.17 for shape argument support"
-)
 @pytest.mark.parametrize(
     "funcname, kwargs",
     [
@@ -654,9 +650,6 @@ def test_tile_np_kroncompare_examples(shape, reps):
     assert_eq(np.tile(x, reps), da.tile(d, reps))
 
 
-skip_stat_length = pytest.mark.xfail(_numpy_117, reason="numpy-14061")
-
-
 @pytest.mark.parametrize(
     "shape, chunks, pad_width, mode, kwargs",
     [
@@ -666,16 +659,7 @@ skip_stat_length = pytest.mark.xfail(_numpy_117, reason="numpy-14061")
         ((10, 11), (4, 5), 0, "reflect", {}),
         ((10, 11), (4, 5), 0, "symmetric", {}),
         ((10, 11), (4, 5), 0, "wrap", {}),
-        pytest.param(
-            (10, 11),
-            (4, 5),
-            0,
-            "empty",
-            {},
-            marks=pytest.mark.skipif(
-                not _numpy_117, reason="requires NumPy>=1.17 for empty mode support"
-            ),
-        ),
+        ((10, 11), (4, 5), 0, "empty", {}),
     ],
 )
 def test_pad_0_width(shape, chunks, pad_width, mode, kwargs):
@@ -719,16 +703,7 @@ def test_pad_0_width(shape, chunks, pad_width, mode, kwargs):
         ((10,), (3,), ((2, 3)), "maximum", {"stat_length": (1, 2)}),
         ((10, 11), (4, 5), ((1, 4), (2, 3)), "mean", {"stat_length": ((3, 4), (2, 1))}),
         ((10,), (3,), ((2, 3)), "minimum", {"stat_length": (2, 3)}),
-        pytest.param(
-            (10,),
-            (3,),
-            1,
-            "empty",
-            {},
-            marks=pytest.mark.skipif(
-                not _numpy_117, reason="requires NumPy>=1.17 for empty mode support"
-            ),
-        ),
+        ((10,), (3,), 1, "empty", {}),
     ],
 )
 def test_pad(shape, chunks, pad_width, mode, kwargs):
@@ -754,12 +729,7 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
     [
         "constant",
         "edge",
-        pytest.param(
-            "linear_ramp",
-            marks=pytest.mark.skipif(
-                not _numpy_118, reason="numpy changed pad behaviour"
-            ),
-        ),
+        "linear_ramp",
         "maximum",
         "mean",
         "minimum",

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -8,7 +8,7 @@ import dask
 import dask.array as da
 from dask.array.gufunc import apply_gufunc
 from dask.array.numpy_compat import _numpy_120
-from dask.array.utils import IS_NEP18_ACTIVE, AxisError, assert_eq, same_keys
+from dask.array.utils import AxisError, assert_eq, same_keys
 from dask.sizeof import sizeof
 
 cupy = pytest.importorskip("cupy")
@@ -37,8 +37,8 @@ functions = [
     pytest.param(
         lambda x: x.mean(),
         marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
-            reason="NEP-18 support is not available in NumPy or CuPy older than "
+            cupy_version < parse_version("6.4.0"),
+            reason="NEP-18 support is not available in CuPy older than "
             "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
         ),
     ),
@@ -49,16 +49,16 @@ functions = [
     pytest.param(
         lambda x: x.std(),
         marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
-            reason="NEP-18 support is not available in NumPy or CuPy older than "
+            cupy_version < parse_version("6.4.0"),
+            reason="NEP-18 support is not available in CuPy older than "
             "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
         ),
     ),
     pytest.param(
         lambda x: x.var(),
         marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
-            reason="NEP-18 support is not available in NumPy or CuPy older than "
+            cupy_version < parse_version("6.4.0"),
+            reason="NEP-18 support is not available in CuPy older than "
             "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
         ),
     ),
@@ -95,114 +95,24 @@ functions = [
     ),
     lambda x: np.isneginf(x),
     lambda x: np.isposinf(x),
-    pytest.param(
-        lambda x: np.isreal(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.iscomplex(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.real(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.imag(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.exp(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.fix(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.i0(x.reshape((24,))),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.sinc(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.nan_to_num(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.max(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.min(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.prod(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.any(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.all(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.nansum(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.nanprod(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.nanmin(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
-    pytest.param(
-        lambda x: np.nanmax(x),
-        marks=pytest.mark.skipif(
-            not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-        ),
-    ),
+    lambda x: np.isreal(x),
+    lambda x: np.iscomplex(x),
+    lambda x: np.real(x),
+    lambda x: np.imag(x),
+    lambda x: np.exp(x),
+    lambda x: np.fix(x),
+    lambda x: np.i0(x.reshape((24,))),
+    lambda x: np.sinc(x),
+    lambda x: np.nan_to_num(x),
+    lambda x: np.max(x),
+    lambda x: np.min(x),
+    lambda x: np.prod(x),
+    lambda x: np.any(x),
+    lambda x: np.all(x),
+    lambda x: np.nansum(x),
+    lambda x: np.nanprod(x),
+    lambda x: np.nanmin(x),
+    lambda x: np.nanmax(x),
 ]
 
 
@@ -233,9 +143,6 @@ def test_sizeof(dtype):
     assert sizeof(c) == c.nbytes
 
 
-@pytest.mark.skipif(
-    not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-)
 def test_diag():
     v = cupy.arange(11)
     dv = da.from_array(v, chunks=(4,), asarray=False)
@@ -258,9 +165,6 @@ def test_diag():
     assert_eq(da.diag(dx), cupy.diag(x))
 
 
-@pytest.mark.skipif(
-    not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-)
 def test_diagonal():
     v = cupy.arange(11)
     with pytest.raises(ValueError):
@@ -320,8 +224,8 @@ def test_diagonal():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
-    reason="NEP-18 support is not available in NumPy or CuPy older than "
+    cupy_version < parse_version("6.4.0"),
+    reason="NEP-18 support is not available in CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
 def test_tril_triu():
@@ -338,8 +242,8 @@ def test_tril_triu():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
-    reason="NEP-18 support is not available in NumPy or CuPy older than "
+    cupy_version < parse_version("6.4.0"),
+    reason="NEP-18 support is not available in CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
 def test_tril_triu_non_square_arrays():
@@ -349,9 +253,6 @@ def test_tril_triu_non_square_arrays():
     assert_eq(da.tril(dA), np.tril(A))
 
 
-@pytest.mark.skipif(
-    not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-)
 def test_apply_gufunc_axis():
     def mydiff(x):
         return np.diff(x)
@@ -402,9 +303,6 @@ def test_trim_internal():
     assert e.chunks == ((8, 8, 8, 8), (6, 6, 6, 6, 6, 6))
 
 
-@pytest.mark.skipif(
-    not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-)
 def test_periodic():
     x = cupy.arange(64).reshape((8, 8))
     d = da.from_array(x, chunks=(4, 4), asarray=False)
@@ -417,9 +315,6 @@ def test_periodic():
     assert_eq(e[0, :], d[-2, :])
 
 
-@pytest.mark.skipif(
-    not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-)
 def test_reflect():
     x = cupy.arange(10)
     d = da.from_array(x, chunks=(5, 5), asarray=False)
@@ -433,9 +328,6 @@ def test_reflect():
     assert_eq(e, expected, check_type=False)
 
 
-@pytest.mark.skipif(
-    not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-)
 def test_nearest():
     x = cupy.arange(10)
     d = da.from_array(x, chunks=(5, 5), asarray=False)
@@ -450,8 +342,8 @@ def test_nearest():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
-    reason="NEP-18 support is not available in NumPy or CuPy older than "
+    cupy_version < parse_version("6.4.0"),
+    reason="NEP-18 support is not available in CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
 def test_constant():
@@ -467,8 +359,8 @@ def test_constant():
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
-    reason="NEP-18 support is not available in NumPy or CuPy older than "
+    cupy_version < parse_version("6.4.0"),
+    reason="NEP-18 support is not available in CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
 def test_boundaries():
@@ -558,8 +450,8 @@ def test_random_shapes(shape):
 
 
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.1.0"),
-    reason="NEP-18 support is not available in NumPy or CuPy older than "
+    cupy_version < parse_version("6.1.0"),
+    reason="NEP-18 support is not available in CuPy older than "
     "6.1.0 (requires https://github.com/cupy/cupy/pull/2209)",
 )
 @pytest.mark.parametrize(
@@ -653,9 +545,6 @@ def test_tsqr(m, n, chunks, error_type):
             u, s, vh = da.linalg.tsqr(data, compute_svd=True)
 
 
-@pytest.mark.skipif(
-    not IS_NEP18_ACTIVE, reason="NEP-18 support is not available in NumPy"
-)
 @pytest.mark.parametrize(
     "m_min,n_max,chunks,vary_rows,vary_cols,error_type",
     [
@@ -938,8 +827,8 @@ def test_cupy_sparse_concatenate(axis):
 
 @pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 @pytest.mark.skipif(
-    not IS_NEP18_ACTIVE or cupy_version < parse_version("6.4.0"),
-    reason="NEP-18 support is not available in NumPy or CuPy older than "
+    cupy_version < parse_version("6.4.0"),
+    reason="NEP-18 support is not available in CuPy older than "
     "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
 )
 def test_bincount():

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -225,8 +225,7 @@ def test_diagonal():
 
 @pytest.mark.skipif(
     cupy_version < parse_version("6.4.0"),
-    reason="Requires CuPy 6.4.0+ "
-    "(with https://github.com/cupy/cupy/pull/2418)",
+    reason="Requires CuPy 6.4.0+ (with https://github.com/cupy/cupy/pull/2418)",
 )
 def test_tril_triu():
     A = cupy.random.randn(20, 20)
@@ -243,8 +242,7 @@ def test_tril_triu():
 
 @pytest.mark.skipif(
     cupy_version < parse_version("6.4.0"),
-    reason="Requires CuPy 6.4.0+ "
-    "(with https://github.com/cupy/cupy/pull/2418)",
+    reason="Requires CuPy 6.4.0+ (with https://github.com/cupy/cupy/pull/2418)",
 )
 def test_tril_triu_non_square_arrays():
     A = cupy.random.randint(0, 11, (30, 35))
@@ -343,8 +341,7 @@ def test_nearest():
 
 @pytest.mark.skipif(
     cupy_version < parse_version("6.4.0"),
-    reason="Requires CuPy 6.4.0+ "
-    "(with https://github.com/cupy/cupy/pull/2418)",
+    reason="Requires CuPy 6.4.0+ (with https://github.com/cupy/cupy/pull/2418)",
 )
 def test_constant():
     x = cupy.arange(64).reshape((8, 8))
@@ -360,8 +357,7 @@ def test_constant():
 
 @pytest.mark.skipif(
     cupy_version < parse_version("6.4.0"),
-    reason="Requires CuPy 6.4.0+ "
-    "(with https://github.com/cupy/cupy/pull/2418)",
+    reason="Requires CuPy 6.4.0+ (with https://github.com/cupy/cupy/pull/2418)",
 )
 def test_boundaries():
     x = cupy.arange(64).reshape((8, 8))
@@ -451,8 +447,7 @@ def test_random_shapes(shape):
 
 @pytest.mark.skipif(
     cupy_version < parse_version("6.1.0"),
-    reason="Requires CuPy 6.1.0+ "
-    "(with https://github.com/cupy/cupy/pull/2209)",
+    reason="Requires CuPy 6.1.0+ (with https://github.com/cupy/cupy/pull/2209)",
 )
 @pytest.mark.parametrize(
     "m,n,chunks,error_type",
@@ -828,8 +823,7 @@ def test_cupy_sparse_concatenate(axis):
 @pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 @pytest.mark.skipif(
     cupy_version < parse_version("6.4.0"),
-    reason="Requires CuPy 6.4.0+ "
-    "(with https://github.com/cupy/cupy/pull/2418)",
+    reason="Requires CuPy 6.4.0+ (with https://github.com/cupy/cupy/pull/2418)",
 )
 def test_bincount():
     x = cupy.array([2, 1, 5, 2, 1])

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -38,8 +38,8 @@ functions = [
         lambda x: x.mean(),
         marks=pytest.mark.skipif(
             cupy_version < parse_version("6.4.0"),
-            reason="NEP-18 support is not available in CuPy older than "
-            "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
+            reason="Requires CuPy 6.4.0+ "
+            "(with https://github.com/cupy/cupy/pull/2418)",
         ),
     ),
     pytest.param(
@@ -50,16 +50,16 @@ functions = [
         lambda x: x.std(),
         marks=pytest.mark.skipif(
             cupy_version < parse_version("6.4.0"),
-            reason="NEP-18 support is not available in CuPy older than "
-            "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
+            reason="Requires CuPy 6.4.0+ "
+            "(with https://github.com/cupy/cupy/pull/2418)",
         ),
     ),
     pytest.param(
         lambda x: x.var(),
         marks=pytest.mark.skipif(
             cupy_version < parse_version("6.4.0"),
-            reason="NEP-18 support is not available in CuPy older than "
-            "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
+            reason="Requires CuPy 6.4.0+ "
+            "(with https://github.com/cupy/cupy/pull/2418)",
         ),
     ),
     pytest.param(
@@ -225,8 +225,8 @@ def test_diagonal():
 
 @pytest.mark.skipif(
     cupy_version < parse_version("6.4.0"),
-    reason="NEP-18 support is not available in CuPy older than "
-    "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
+    reason="Requires CuPy 6.4.0+ "
+    "(with https://github.com/cupy/cupy/pull/2418)",
 )
 def test_tril_triu():
     A = cupy.random.randn(20, 20)
@@ -243,8 +243,8 @@ def test_tril_triu():
 
 @pytest.mark.skipif(
     cupy_version < parse_version("6.4.0"),
-    reason="NEP-18 support is not available in CuPy older than "
-    "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
+    reason="Requires CuPy 6.4.0+ "
+    "(with https://github.com/cupy/cupy/pull/2418)",
 )
 def test_tril_triu_non_square_arrays():
     A = cupy.random.randint(0, 11, (30, 35))
@@ -343,8 +343,8 @@ def test_nearest():
 
 @pytest.mark.skipif(
     cupy_version < parse_version("6.4.0"),
-    reason="NEP-18 support is not available in CuPy older than "
-    "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
+    reason="Requires CuPy 6.4.0+ "
+    "(with https://github.com/cupy/cupy/pull/2418)",
 )
 def test_constant():
     x = cupy.arange(64).reshape((8, 8))
@@ -360,8 +360,8 @@ def test_constant():
 
 @pytest.mark.skipif(
     cupy_version < parse_version("6.4.0"),
-    reason="NEP-18 support is not available in CuPy older than "
-    "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
+    reason="Requires CuPy 6.4.0+ "
+    "(with https://github.com/cupy/cupy/pull/2418)",
 )
 def test_boundaries():
     x = cupy.arange(64).reshape((8, 8))
@@ -451,8 +451,8 @@ def test_random_shapes(shape):
 
 @pytest.mark.skipif(
     cupy_version < parse_version("6.1.0"),
-    reason="NEP-18 support is not available in CuPy older than "
-    "6.1.0 (requires https://github.com/cupy/cupy/pull/2209)",
+    reason="Requires CuPy 6.1.0+ "
+    "(with https://github.com/cupy/cupy/pull/2209)",
 )
 @pytest.mark.parametrize(
     "m,n,chunks,error_type",
@@ -828,8 +828,8 @@ def test_cupy_sparse_concatenate(axis):
 @pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 @pytest.mark.skipif(
     cupy_version < parse_version("6.4.0"),
-    reason="NEP-18 support is not available in CuPy older than "
-    "6.4.0 (requires https://github.com/cupy/cupy/pull/2418)",
+    reason="Requires CuPy 6.4.0+ "
+    "(with https://github.com/cupy/cupy/pull/2418)",
 )
 def test_bincount():
     x = cupy.array([2, 1, 5, 2, 1])

--- a/dask/array/tests/test_gufunc.py
+++ b/dask/array/tests/test_gufunc.py
@@ -11,7 +11,7 @@ from dask.array.gufunc import (
     as_gufunc,
     gufunc,
 )
-from dask.array.utils import IS_NEP18_ACTIVE, assert_eq
+from dask.array.utils import assert_eq
 
 
 # Copied from `numpy.lib.test_test_function_base.py`:
@@ -615,9 +615,6 @@ def test_apply_gufunc_via_numba_02():
     assert_eq(x, y)
 
 
-@pytest.mark.skipif(
-    not IS_NEP18_ACTIVE, reason="NEP18 required for sparse meta propagation"
-)
 def test_preserve_meta_type():
     sparse = pytest.importorskip("sparse")
 

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -522,7 +522,7 @@ def test_general_reduction_names():
         da.ones(10, dtype, chunks=2), np.sum, np.sum, dtype=dtype, name="foo"
     )
     names, tokens = list(zip_longest(*[key[0].rsplit("-", 1) for key in a.dask]))
-    assert set(names) == {"ones", "foo", "foo-partial", "foo-aggregate"}
+    assert set(names) == {"ones_like", "foo", "foo-partial", "foo-aggregate"}
     assert all(tokens)
 
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -10,7 +10,7 @@ from dask.delayed import delayed
 np = pytest.importorskip("numpy")
 
 import dask.array as da
-from dask.array.utils import IS_NEP18_ACTIVE, AxisError, assert_eq, same_keys
+from dask.array.utils import AxisError, assert_eq, same_keys
 
 
 def test_array():
@@ -1292,8 +1292,7 @@ def test_union1d(shape, reverse):
     result = np.union1d(dx1, dx2)
     expected = np.union1d(x1, x2)
 
-    if IS_NEP18_ACTIVE:
-        assert isinstance(result, da.Array)
+    assert isinstance(result, da.Array)
 
     assert_eq(result, expected)
 

--- a/dask/array/tests/test_sparse.py
+++ b/dask/array/tests/test_sparse.py
@@ -6,8 +6,7 @@ from packaging.version import parse as parse_version
 
 import dask
 import dask.array as da
-from dask.array.numpy_compat import _numpy_117
-from dask.array.utils import IS_NEP18_ACTIVE, assert_eq
+from dask.array.utils import assert_eq
 
 sparse = pytest.importorskip("sparse")
 if sparse:
@@ -175,13 +174,11 @@ def test_metadata():
     assert isinstance(y.rechunk((2, 2))._meta, sparse.COO)
     assert isinstance((y - z)._meta, sparse.COO)
     assert isinstance(y.persist()._meta, sparse.COO)
-    if IS_NEP18_ACTIVE:
-        assert isinstance(np.concatenate([y, y])._meta, sparse.COO)
-        assert isinstance(np.concatenate([y, y[:0], y])._meta, sparse.COO)
-        assert isinstance(np.stack([y, y])._meta, sparse.COO)
-        if _numpy_117:
-            assert isinstance(np.stack([y[:0], y[:0]])._meta, sparse.COO)
-            assert isinstance(np.concatenate([y[:0], y[:0]])._meta, sparse.COO)
+    assert isinstance(np.concatenate([y, y])._meta, sparse.COO)
+    assert isinstance(np.concatenate([y, y[:0], y])._meta, sparse.COO)
+    assert isinstance(np.stack([y, y])._meta, sparse.COO)
+    assert isinstance(np.stack([y[:0], y[:0]])._meta, sparse.COO)
+    assert isinstance(np.concatenate([y[:0], y[:0]])._meta, sparse.COO)
 
 
 def test_html_repr():

--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -13,7 +13,7 @@ def test_ones():
     x = np.array(a)
     assert (x == np.ones((10, 10), "i4")).all()
 
-    assert a.name.startswith("ones-")
+    assert a.name.startswith("ones_like-")
 
 
 def test_size_as_list():
@@ -40,7 +40,7 @@ def test_full():
     assert (a.compute() == 100).all()
     assert a.dtype == a.compute(scheduler="sync").dtype == "i8"
 
-    assert a.name.startswith("full-")
+    assert a.name.startswith("full_like-")
 
 
 def test_full_error_nonscalar_fill_value():

--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -14,7 +14,6 @@ from ..utils import (
     is_series_like,
 )
 from .core import Array, apply_infer_dtype, asarray, blockwise, elemwise
-from .utils import IS_NEP18_ACTIVE, empty_like_safe
 
 
 def __array_wrap__(numpy_ufunc, x, *args, **kwargs):
@@ -32,7 +31,7 @@ def wrap_elemwise(numpy_ufunc, array_wrap=False, source=np):
                 or is_series_like(dsk[0])
                 or is_index_like(dsk[0])
             )
-            if array_wrap and (is_dataframe or not IS_NEP18_ACTIVE):
+            if array_wrap and is_dataframe:
                 return dsk[0]._elemwise(__array_wrap__, numpy_ufunc, *args, **kwargs)
             else:
                 return dsk[0]._elemwise(numpy_ufunc, *args, **kwargs)
@@ -319,7 +318,7 @@ def frexp(x):
         for key in core.flatten(tmp.__dask_keys__())
     }
 
-    a = empty_like_safe(getattr(x, "_meta", x), shape=(1,) * x.ndim, dtype=x.dtype)
+    a = np.empty_like(getattr(x, "_meta", x), shape=(1,) * x.ndim, dtype=x.dtype)
     l, r = np.frexp(a)
 
     graph = HighLevelGraph.from_collections(left, ldsk, dependencies=[tmp])
@@ -344,7 +343,7 @@ def modf(x):
         for key in core.flatten(tmp.__dask_keys__())
     }
 
-    a = empty_like_safe(getattr(x, "_meta", x), shape=(1,) * x.ndim, dtype=x.dtype)
+    a = np.empty_like(getattr(x, "_meta", x), shape=(1,) * x.ndim, dtype=x.dtype)
     l, r = np.modf(a)
 
     graph = HighLevelGraph.from_collections(left, ldsk, dependencies=[tmp])

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -380,59 +380,6 @@ def _dtype_of(a):
         return np.asanyarray(a).dtype
 
 
-def empty_like_safe(a, shape, **kwargs):
-    """
-    Return ``np.empty_like(a, shape=shape, **kwargs)`` if the shape argument
-    is supported (requires NumPy >= 1.17), otherwise falls back to
-    using the old behavior, returning ``np.empty(shape, **kwargs)``.
-    """
-    try:
-        return np.empty_like(a, shape=shape, **kwargs)
-    except TypeError:
-        kwargs.setdefault("dtype", _dtype_of(a))
-        return np.empty(shape, **kwargs)
-
-
-def full_like_safe(a, fill_value, shape, **kwargs):
-    """
-    Return ``np.full_like(a, fill_value, shape=shape, **kwargs)`` if the
-    shape argument is supported (requires NumPy >= 1.17), otherwise
-    falls back to using the old behavior, returning
-    ``np.full(shape, fill_value, **kwargs)``.
-    """
-    try:
-        return np.full_like(a, fill_value, shape=shape, **kwargs)
-    except TypeError:
-        kwargs.setdefault("dtype", _dtype_of(a))
-        return np.full(shape, fill_value, **kwargs)
-
-
-def ones_like_safe(a, shape, **kwargs):
-    """
-    Return ``np.ones_like(a, shape=shape, **kwargs)`` if the shape argument
-    is supported (requires NumPy >= 1.17), otherwise falls back to
-    using the old behavior, returning ``np.ones(shape, **kwargs)``.
-    """
-    try:
-        return np.ones_like(a, shape=shape, **kwargs)
-    except TypeError:
-        kwargs.setdefault("dtype", _dtype_of(a))
-        return np.ones(shape, **kwargs)
-
-
-def zeros_like_safe(a, shape, **kwargs):
-    """
-    Return ``np.zeros_like(a, shape=shape, **kwargs)`` if the shape argument
-    is supported (requires NumPy >= 1.17), otherwise falls back to
-    using the old behavior, returning ``np.zeros(shape, **kwargs)``.
-    """
-    try:
-        return np.zeros_like(a, shape=shape, **kwargs)
-    except TypeError:
-        kwargs.setdefault("dtype", _dtype_of(a))
-        return np.zeros(shape, **kwargs)
-
-
 def arange_safe(*args, like, **kwargs):
     """
     Use the `like=` from `np.arange` to create a new array dispatching
@@ -583,17 +530,3 @@ def scipy_linalg_safe(func_name, *args, **kwargs):
 
 def solve_triangular_safe(a, b, lower=False):
     return scipy_linalg_safe("solve_triangular", a, b, lower=lower)
-
-
-def _is_nep18_active():
-    class A:
-        def __array_function__(self, *args, **kwargs):
-            return True
-
-    try:
-        return np.concatenate([A()])
-    except ValueError:
-        return False
-
-
-IS_NEP18_ACTIVE = _is_nep18_active()

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -8,13 +8,7 @@ from ..base import tokenize
 from ..layers import BlockwiseCreateArray
 from ..utils import funcname
 from .core import Array, normalize_chunks
-from .utils import (
-    empty_like_safe,
-    full_like_safe,
-    meta_from_array,
-    ones_like_safe,
-    zeros_like_safe,
-)
+from .utils import meta_from_array
 
 
 def _parse_wrap_args(func, args, kwargs, shape):
@@ -180,9 +174,9 @@ def broadcast_trick(func):
     return inner
 
 
-ones = w(broadcast_trick(ones_like_safe), dtype="f8")
-zeros = w(broadcast_trick(zeros_like_safe), dtype="f8")
-empty = w(broadcast_trick(empty_like_safe), dtype="f8")
+ones = w(broadcast_trick(np.ones_like), dtype="f8")
+zeros = w(broadcast_trick(np.zeros_like), dtype="f8")
+empty = w(broadcast_trick(np.empty_like), dtype="f8")
 
 
 w_like = wrap(wrap_func_like_safe)
@@ -193,7 +187,7 @@ empty_like = w_like(np.empty, func_like=np.empty_like)
 
 # full and full_like require special casing due to argument check on fill_value
 # Generate wrapped functions only once
-_full = w(broadcast_trick(full_like_safe))
+_full = w(broadcast_trick(np.full_like))
 _full_like = w_like(np.full, func_like=np.full_like)
 
 # workaround for numpy doctest failure: https://github.com/numpy/numpy/pull/17472

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -13,7 +13,7 @@ PANDAS_GT_130 = PANDAS_VERSION >= parse_version("1.3.0")
 PANDAS_GT_131 = PANDAS_VERSION >= parse_version("1.3.1")
 
 
-import pandas.testing as tm  # noqa: F401
+import pandas.testing as tm
 
 
 def assert_categorical_equal(left, right, *args, **kwargs):

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -5,7 +5,6 @@ import pandas as pd
 from packaging.version import parse as parse_version
 
 PANDAS_VERSION = parse_version(pd.__version__)
-PANDAS_GT_100 = PANDAS_VERSION >= parse_version("1.0.0")
 PANDAS_GT_104 = PANDAS_VERSION >= parse_version("1.0.4")
 PANDAS_GT_110 = PANDAS_VERSION >= parse_version("1.1.0")
 PANDAS_GT_120 = PANDAS_VERSION >= parse_version("1.2.0")
@@ -14,23 +13,17 @@ PANDAS_GT_130 = PANDAS_VERSION >= parse_version("1.3.0")
 PANDAS_GT_131 = PANDAS_VERSION >= parse_version("1.3.1")
 
 
-if PANDAS_GT_100:
-    import pandas.testing as tm  # noqa: F401
-else:
-    import pandas.util.testing as tm  # noqa: F401
+import pandas.testing as tm  # noqa: F401
 
 
 def assert_categorical_equal(left, right, *args, **kwargs):
-    if PANDAS_GT_100:
-        tm.assert_extension_array_equal(left, right, *args, **kwargs)
-        assert pd.api.types.is_categorical_dtype(
-            left.dtype
-        ), "{} is not categorical dtype".format(left)
-        assert pd.api.types.is_categorical_dtype(
-            right.dtype
-        ), "{} is not categorical dtype".format(right)
-    else:
-        return tm.assert_categorical_equal(left, right, *args, **kwargs)
+    tm.assert_extension_array_equal(left, right, *args, **kwargs)
+    assert pd.api.types.is_categorical_dtype(
+        left.dtype
+    ), "{} is not categorical dtype".format(left)
+    assert pd.api.types.is_categorical_dtype(
+        right.dtype
+    ), "{} is not categorical dtype".format(right)
 
 
 def assert_numpy_array_equal(left, right):

--- a/dask/dataframe/_dtypes.py
+++ b/dask/dataframe/_dtypes.py
@@ -1,6 +1,5 @@
 import pandas as pd
 
-from ._compat import PANDAS_GT_100
 from .extensions import make_array_nonempty, make_scalar
 
 
@@ -14,20 +13,21 @@ def _(x):
     return pd.Timestamp(1, tz=x.tz, unit=x.unit)
 
 
-if PANDAS_GT_100:
+@make_array_nonempty.register(pd.StringDtype)
+def _(dtype):
+    return pd.array(["a", pd.NA], dtype=dtype)
 
-    @make_array_nonempty.register(pd.StringDtype)
-    def _(dtype):
-        return pd.array(["a", pd.NA], dtype=dtype)
 
-    @make_scalar.register(str)
-    def _(x):
-        return "s"
+@make_scalar.register(str)
+def _(x):
+    return "s"
 
-    @make_array_nonempty.register(pd.BooleanDtype)
-    def _dtype(dtype):
-        return pd.array([True, pd.NA], dtype=dtype)
 
-    @make_scalar.register(bool)
-    def _(x):
-        return True
+@make_array_nonempty.register(pd.BooleanDtype)
+def _dtype(dtype):
+    return pd.array([True, pd.NA], dtype=dtype)
+
+
+@make_scalar.register(bool)
+def _(x):
+    return True

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -15,7 +15,6 @@ from pandas.api.types import (
 from dask.sizeof import SimpleSizeof, sizeof
 
 from ..utils import is_arraylike, typename
-from ._compat import PANDAS_GT_100
 from .core import DataFrame, Index, Scalar, Series, _Frame
 from .dispatch import (
     categorical_dtype_dispatch,
@@ -181,8 +180,7 @@ def meta_nonempty_dataframe(x):
         data[i] = dt_s_dict[dt]
     res = pd.DataFrame(data, index=idx, columns=np.arange(len(x.columns)))
     res.columns = x.columns
-    if PANDAS_GT_100:
-        res.attrs = x.attrs
+    res.attrs = x.attrs
     return res
 
 
@@ -281,10 +279,7 @@ def _nonempty_series(s, idx=None):
         data = [pd.Period("2000", freq), pd.Period("2001", freq)]
     elif is_sparse(dtype):
         entry = _scalar_from_dtype(dtype.subtype)
-        if PANDAS_GT_100:
-            data = pd.array([entry, entry], dtype=dtype)
-        else:
-            data = pd.SparseArray([entry, entry], dtype=dtype)
+        data = pd.array([entry, entry], dtype=dtype)
     elif is_interval_dtype(dtype):
         entry = _scalar_from_dtype(dtype.subtype)
         data = pd.array([entry, entry], dtype=dtype)
@@ -295,8 +290,7 @@ def _nonempty_series(s, idx=None):
         data = np.array([entry, entry], dtype=dtype)
 
     out = pd.Series(data, name=s.name, index=idx)
-    if PANDAS_GT_100:
-        out.attrs = s.attrs
+    out.attrs = s.attrs
     return out
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6780,8 +6780,7 @@ def maybe_shift_divisions(df, periods, freq):
 
     is_offset = isinstance(freq, pd.DateOffset)
     if is_offset:
-        is_anchored = freq.is_anchored()
-        if is_anchored or not hasattr(freq, "delta"):
+        if freq.is_anchored() or not hasattr(freq, "delta"):
             # Can't infer divisions on relative or anchored offsets, as
             # divisions may now split identical index value.
             # (e.g. index_partitions = [[1, 2, 3], [3, 4, 5]])

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4807,6 +4807,13 @@ class DataFrame(_Frame):
         dask.DataFrame.map_partitions
         """
 
+        if broadcast is not None:
+            warnings.warn(
+                "The `broadcast` argument is no longer used/supported. "
+                "It will be dropped in a future release.",
+                category=FutureWarning,
+            )
+
         axis = self._validate_axis(axis)
         pandas_kwargs = {"axis": axis, "raw": raw, "result_type": result_type}
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -26,7 +26,6 @@ except ImportError:
 from .. import array as da
 from .. import core, threaded
 from ..array.core import Array, normalize_arg
-from ..array.utils import zeros_like_safe
 from ..base import DaskMethodsMixin, dont_optimize, is_dask_collection, tokenize
 from ..blockwise import Blockwise, blockwise, subs
 from ..context import globalmethod
@@ -63,7 +62,6 @@ from .dispatch import (
 )
 from .optimize import optimize
 from .utils import (
-    PANDAS_GT_100,
     PANDAS_GT_110,
     PANDAS_GT_120,
     check_matching_columns,
@@ -1978,18 +1976,8 @@ Dask Name: {name}, {task} tasks"""
                 result = self._var_1d(self, skipna, ddof, split_every)
                 return handle_out(out, result)
 
-            count_timedeltas = len(
-                self._meta_nonempty.select_dtypes(include=[np.timedelta64]).columns
-            )
-
             # pandas 1.0+ does not implement var on timedelta
-
-            if not PANDAS_GT_100 and count_timedeltas == len(self._meta.columns):
-                result = self._var_timedeltas(skipna, ddof, split_every)
-            elif not PANDAS_GT_100 and count_timedeltas > 0:
-                result = self._var_mixed(skipna, ddof, split_every)
-            else:
-                result = self._var_numeric(skipna, ddof, split_every)
+            result = self._var_numeric(skipna, ddof, split_every)
 
             if isinstance(self, DataFrame):
                 result.divisions = (self.columns.min(), self.columns.max())
@@ -2880,10 +2868,7 @@ Dask Name: {name}, {task} tasks"""
         date = self.divisions[0] + offset
         end = self.loc._get_partitions(date)
 
-        if PANDAS_GT_100:
-            is_anchored = offset.is_anchored()
-        else:
-            is_anchored = offset.isAnchored()
+        is_anchored = offset.is_anchored()
 
         include_right = is_anchored or not hasattr(offset, "delta")
 
@@ -4825,10 +4810,6 @@ class DataFrame(_Frame):
         axis = self._validate_axis(axis)
         pandas_kwargs = {"axis": axis, "raw": raw, "result_type": result_type}
 
-        if not PANDAS_GT_100:
-            pandas_kwargs["broadcast"] = broadcast
-            pandas_kwargs["reduce"] = None
-
         kwds.update(pandas_kwargs)
 
         if axis == 0:
@@ -6119,8 +6100,8 @@ def cov_corr_chunk(df, corr=False):
     """Chunk part of a covariance or correlation computation"""
     shape = (df.shape[1], df.shape[1])
     df = df.astype("float64", copy=False)
-    sums = zeros_like_safe(df.values, shape=shape)
-    counts = zeros_like_safe(df.values, shape=shape)
+    sums = np.zeros_like(df.values, shape=shape)
+    counts = np.zeros_like(df.values, shape=shape)
     for idx, col in enumerate(df):
         mask = df.iloc[:, idx].notnull()
         sums[idx] = df[mask].sum().values
@@ -6131,7 +6112,7 @@ def cov_corr_chunk(df, corr=False):
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             mu = (sums / counts).T
-        m = zeros_like_safe(df.values, shape=shape)
+        m = np.zeros_like(df.values, shape=shape)
         mask = df.isnull().values
         for idx, x in enumerate(df):
             # Avoid using ufunc.outer (not supported by cupy)
@@ -6799,10 +6780,7 @@ def maybe_shift_divisions(df, periods, freq):
 
     is_offset = isinstance(freq, pd.DateOffset)
     if is_offset:
-        if PANDAS_GT_100:
-            is_anchored = freq.is_anchored()
-        else:
-            is_anchored = freq.isAnchored()
+        is_anchored = freq.is_anchored()
         if is_anchored or not hasattr(freq, "delta"):
             # Can't infer divisions on relative or anchored offsets, as
             # divisions may now split identical index value.

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -22,7 +22,6 @@ from .core import (
 from .methods import concat, drop_columns
 from .shuffle import shuffle
 from .utils import (
-    PANDAS_GT_100,
     PANDAS_GT_110,
     insert_meta_param_description,
     is_dataframe_like,
@@ -279,8 +278,6 @@ def _groupby_aggregate(
     df, aggfunc=None, levels=None, dropna=None, sort=False, observed=None, **kwargs
 ):
     dropna = {"dropna": dropna} if dropna is not None else {}
-    if not PANDAS_GT_100 and observed:
-        raise NotImplementedError("``observed`` is only supported for pandas >= 1.0.0")
     observed = {"observed": observed} if observed is not None else {}
 
     grouped = df.groupby(level=levels, sort=sort, **observed, **dropna)

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -5,7 +5,6 @@ import tlz as toolz
 from fsspec.core import get_fs_token_paths
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.utils import stringify_path
-from packaging.version import parse as parse_version
 
 from ....base import tokenize
 from ....delayed import Delayed
@@ -911,13 +910,7 @@ def get_engine(engine):
         return eng
 
     elif engine in ("pyarrow", "arrow", "pyarrow-legacy", "pyarrow-dataset"):
-        pa = import_required("pyarrow", "`pyarrow` not installed")
-        pa_version = parse_version(pa.__version__)
-
-        if pa_version < parse_version("0.13.1"):
-            raise RuntimeError("PyArrow version >= 0.13.1 required")
-
-        if engine == "pyarrow-dataset" and pa_version.major >= 1:
+        if engine == "pyarrow-dataset":
             from .arrow import ArrowDatasetEngine
 
             _ENGINES[engine] = eng = ArrowDatasetEngine

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1076,9 +1076,7 @@ def test_read_csv_with_datetime_index_partitions_n():
         assert_eq(df, ddf)
 
 
-xfail_pandas_100 = pytest.mark.xfail(
-    dd._compat.PANDAS_GT_100, reason="https://github.com/dask/dask/issues/5787"
-)
+xfail_pandas_100 = pytest.mark.xfail(reason="https://github.com/dask/dask/issues/5787")
 
 
 @pytest.mark.parametrize(

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -3,7 +3,6 @@ import shutil
 import tempfile
 
 import pytest
-from packaging.version import parse as parse_version
 
 import dask.dataframe as dd
 from dask.dataframe import read_orc
@@ -11,17 +10,6 @@ from dask.dataframe.optimize import optimize_dataframe_getitem
 from dask.dataframe.utils import assert_eq
 
 pytest.importorskip("pyarrow.orc")
-
-# Skip for broken ORC reader
-import pyarrow as pa
-
-pytestmark = pytest.mark.skipif(
-    parse_version(pa.__version__).base_version == parse_version("0.10.0"),
-    reason=(
-        "PyArrow 0.10.0 release broke the ORC reader, see "
-        "https://issues.apache.org/jira/browse/ARROW-3009"
-    ),
-)
 
 
 url = (

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -47,35 +47,20 @@ except ImportError:
 SKIP_FASTPARQUET = not fastparquet
 FASTPARQUET_MARK = pytest.mark.skipif(SKIP_FASTPARQUET, reason="fastparquet not found")
 
-if pq and pa_version < parse_version("0.13.1"):
+if sys.platform == "win32" and pa and pa_version == parse_version("2.0.0"):
     SKIP_PYARROW = True
-    SKIP_PYARROW_REASON = "pyarrow >= 0.13.1 required for parquet"
+    SKIP_PYARROW_REASON = (
+        "skipping pyarrow 2.0.0 on windows: "
+        "https://github.com/dask/dask/issues/6093"
+        "|https://github.com/dask/dask/issues/6754"
+    )
 else:
-    if (
-        sys.platform == "win32"
-        and pa
-        and (
-            pa_version == parse_version("0.16.0")
-            or pa_version == parse_version("2.0.0")
-        )
-    ):
-        SKIP_PYARROW = True
-        SKIP_PYARROW_REASON = (
-            "skipping pyarrow 0.16.0 and 2.0.0 on windows: "
-            "https://github.com/dask/dask/issues/6093"
-            "|https://github.com/dask/dask/issues/6754"
-        )
-    else:
-        SKIP_PYARROW = not pq
-        SKIP_PYARROW_REASON = "pyarrow not found"
+    SKIP_PYARROW = not pq
+    SKIP_PYARROW_REASON = "pyarrow not found"
 PYARROW_MARK = pytest.mark.skipif(SKIP_PYARROW, reason=SKIP_PYARROW_REASON)
 
-if pa and pa_version.major < 1:
-    SKIP_PYARROW_DS = True
-    SKIP_PYARROW_DS_REASON = "pyarrow >= 1.0.0 required for pyarrow dataset API"
-else:
-    SKIP_PYARROW_DS = SKIP_PYARROW
-    SKIP_PYARROW_DS_REASON = "pyarrow not found"
+SKIP_PYARROW_DS = SKIP_PYARROW
+SKIP_PYARROW_DS_REASON = "pyarrow not found"
 PYARROW_DS_MARK = pytest.mark.skipif(SKIP_PYARROW_DS, reason=SKIP_PYARROW_DS_REASON)
 
 ANY_ENGINE_MARK = pytest.mark.skipif(
@@ -838,7 +823,7 @@ def test_append_dict_column(tmpdir, engine):
     if engine == "fastparquet":
         pytest.xfail("Fastparquet engine is missing dict-column support")
     elif pa_version < parse_version("1.0.1"):
-        pytest.skip("Newer PyArrow version required for dict-column support.")
+        pytest.skip("PyArrow 1.0.1+ required for dict-column support.")
 
     tmp = str(tmpdir)
     dts = pd.date_range("2020-01-01", "2021-01-01")
@@ -1007,9 +992,6 @@ def test_categories(tmpdir, engine):
 def test_categories_unnamed_index(tmpdir, engine):
     # Check that we can handle an unnamed categorical index
     # https://github.com/dask/dask/issues/6885
-
-    if engine.startswith("pyarrow") and pa_version < parse_version("0.15.0"):
-        pytest.skip("PyArrow>=0.15 Required.")
 
     tmpdir = str(tmpdir)
 
@@ -1193,8 +1175,6 @@ def test_to_parquet_pyarrow_w_inconsistent_schema_by_partition_succeeds_w_manual
 @pytest.mark.parametrize("index", [False, True])
 @pytest.mark.parametrize("schema", ["infer", "complex"])
 def test_pyarrow_schema_inference(tmpdir, index, engine, schema):
-    if pa_version < parse_version("0.15.0"):
-        pytest.skip("PyArrow>=0.15 Required.")
     if schema == "complex":
         schema = {"index": pa.string(), "amount": pa.int64()}
 
@@ -1386,7 +1366,7 @@ def test_filters_v0(tmpdir, write_engine, read_engine):
 
     # Recent versions of pyarrow support full row-wise filtering
     # (fastparquet and older pyarrow versions do not)
-    pyarrow_row_filtering = read_engine == "pyarrow-dataset" and pa_version.major >= 1
+    pyarrow_row_filtering = read_engine == "pyarrow-dataset"
 
     fn = str(tmpdir)
     df = pd.DataFrame({"at": ["ab", "aa", "ba", "da", "bb"]})
@@ -1487,18 +1467,17 @@ def test_pyarrow_filter_divisions(tmpdir):
         str(tmpdir.join("file.1.parquet")), engine="pyarrow", row_group_size=2
     )
 
-    if pa_version.major >= 1:
-        # Only works for ArrowDatasetEngine.
-        # Legacy code will not apply filters on individual row-groups
-        # when `split_row_groups=False`.
-        ddf = dd.read_parquet(
-            str(tmpdir),
-            engine="pyarrow-dataset",
-            split_row_groups=False,
-            gather_statistics=True,
-            filters=[("a", "<=", 3)],
-        )
-        assert ddf.divisions == (0, 2, 3)
+    # Only works for ArrowDatasetEngine.
+    # Legacy code will not apply filters on individual row-groups
+    # when `split_row_groups=False`.
+    ddf = dd.read_parquet(
+        str(tmpdir),
+        engine="pyarrow-dataset",
+        split_row_groups=False,
+        gather_statistics=True,
+        filters=[("a", "<=", 3)],
+    )
+    assert ddf.divisions == (0, 2, 3)
 
     ddf = dd.read_parquet(
         str(tmpdir),
@@ -2065,9 +2044,6 @@ def test_to_parquet_with_get(tmpdir):
 
 def test_select_partitioned_column(tmpdir, engine):
     pytest.importorskip("snappy")
-    if engine.startswith("pyarrow"):
-        if pa_version < parse_version("0.9.0"):
-            pytest.skip("pyarrow<0.9.0 did not support this")
 
     fn = str(tmpdir)
     size = 20
@@ -2090,8 +2066,6 @@ def test_select_partitioned_column(tmpdir, engine):
 
 
 def test_with_tz(tmpdir, engine):
-    if engine.startswith("pyarrow") and pa_version < parse_version("0.11.0"):
-        pytest.skip("pyarrow<0.11.0 did not support this")
     if engine == "fastparquet" and fastparquet_version < parse_version("0.3.0"):
         pytest.skip("fastparquet<0.3.0 did not support this")
 
@@ -2297,14 +2271,6 @@ def test_statistics_nometa(tmpdir, write_engine, read_engine):
 
 @pytest.mark.parametrize("schema", ["infer", None])
 def test_timeseries_nulls_in_schema(tmpdir, engine, schema):
-
-    if (
-        schema == "infer"
-        and engine.startswith("pyarrow")
-        and pa_version < parse_version("0.15.0")
-    ):
-        pytest.skip("PyArrow>=0.15 Required.")
-
     # GH#5608: relative path failing _metadata/_common_metadata detection.
     tmp_path = str(tmpdir.mkdir("files"))
     tmp_path = os.path.join(tmp_path, "../", "files")
@@ -2966,8 +2932,6 @@ def test_filter_nonpartition_columns(
 
 @PYARROW_MARK
 def test_pandas_metadata_nullable_pyarrow(tmpdir):
-    if pa_version < parse_version("0.16.0") or parse_version(pd.__version__).major < 1:
-        pytest.skip("PyArrow>=0.16 and Pandas>=1.0.0 Required.")
     tmpdir = str(tmpdir)
 
     ddf1 = dd.from_pandas(
@@ -2987,9 +2951,6 @@ def test_pandas_metadata_nullable_pyarrow(tmpdir):
 
 @PYARROW_MARK
 def test_pandas_timestamp_overflow_pyarrow(tmpdir):
-    if pa_version < parse_version("0.17.0"):
-        pytest.skip("PyArrow>=0.17 Required.")
-
     info = np.iinfo(np.dtype("int64"))
     arr_numeric = np.linspace(
         start=info.min + 2, stop=info.max, num=1024, dtype="int64"
@@ -3096,10 +3057,6 @@ def test_partitioned_column_overlap(tmpdir, engine, write_cols):
 
 @fp_pandas_xfail
 def test_partitioned_preserve_index(tmpdir, write_engine, read_engine):
-
-    if write_engine.startswith("pyarrow") and pa_version < parse_version("0.15.0"):
-        pytest.skip("PyArrow>=0.15 Required.")
-
     tmp = str(tmpdir)
     size = 1_000
     npartitions = 4
@@ -3215,11 +3172,6 @@ def test_pyarrow_dataset_simple(tmpdir, engine):
 @PYARROW_MARK
 @pytest.mark.parametrize("test_filter", [True, False])
 def test_pyarrow_dataset_partitioned(tmpdir, engine, test_filter):
-    if pa_version <= parse_version("0.17.1"):
-        # Using pyarrow.dataset API does not produce
-        # Categorical type for partitioned columns.
-        pytest.skip("PyArrow>0.17.1 Required.")
-
     fn = str(tmpdir)
     df = pd.DataFrame({"a": [4, 5, 6], "b": ["a", "b", "b"]})
     df["b"] = df["b"].astype("category")
@@ -3243,11 +3195,6 @@ def test_pyarrow_dataset_partitioned(tmpdir, engine, test_filter):
 def test_pyarrow_dataset_read_from_paths(
     tmpdir, read_from_paths, test_filter_partitioned
 ):
-    if pa_version <= parse_version("0.17.1"):
-        # Using pyarrow.dataset API does not produce
-        # Categorical type for partitioned columns.
-        pytest.skip("PyArrow>0.17.1 Required.")
-
     fn = str(tmpdir)
     df = pd.DataFrame({"a": [4, 5, 6], "b": ["a", "b", "b"]})
     df["b"] = df["b"].astype("category")
@@ -3273,10 +3220,6 @@ def test_pyarrow_dataset_read_from_paths(
 @PYARROW_MARK
 @pytest.mark.parametrize("split_row_groups", [True, False])
 def test_pyarrow_dataset_filter_partitioned(tmpdir, split_row_groups):
-    if pa_version.major < 1:
-        # pyarrow.dataset API required.
-        pytest.skip("PyArrow>=1.0.0 Required.")
-
     fn = str(tmpdir)
     df = pd.DataFrame(
         {

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -68,7 +68,6 @@ from ..highlevelgraph import HighLevelGraph
 from ..layers import BroadcastJoinLayer
 from ..utils import M, apply
 from . import methods
-from ._compat import PANDAS_GT_100
 from .core import (
     DataFrame,
     Index,
@@ -241,7 +240,7 @@ def merge_chunk(lhs, *args, **kwargs):
     left_index = kwargs.get("left_index", False)
     right_index = kwargs.get("right_index", False)
 
-    if categorical_columns is not None and PANDAS_GT_100:
+    if categorical_columns is not None:
         for col in categorical_columns:
             left = None
             right = None

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -10,7 +10,6 @@ from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
 from ..utils import M, derived_from, funcname, has_keyword
 from . import methods
-from ._compat import PANDAS_VERSION
 from .core import _emulate
 from .utils import make_meta
 
@@ -403,10 +402,6 @@ class Rolling:
         if has_keyword(meta.apply, "engine"):
             # PANDAS_GT_100
             compat_kwargs = dict(engine=engine, engine_kwargs=engine_kwargs)
-        elif engine != "cython" or engine_kwargs is not None:
-            raise NotImplementedError(
-                f"Specifying the engine requires pandas>=1.0.0. Version '{PANDAS_VERSION}' installed."
-            )
         if raw is None:
             # PANDAS_GT_100: The default changed from None to False
             raw = inspect.signature(meta.apply).parameters["raw"]

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -81,9 +81,8 @@ def df_ddf():
         index=["E", "f", "g", "h"],
     )
 
-    if dd._compat.PANDAS_GT_100:
-        df["string_col"] = df["str_col"].astype("string")
-        df.loc["E", "string_col"] = pd.NA
+    df["string_col"] = df["str_col"].astype("string")
+    df.loc["E", "string_col"] = pd.NA
 
     ddf = dd.from_pandas(df, 2)
 
@@ -125,8 +124,7 @@ def test_str_accessor(df_ddf):
 
     # implemented methods are present in tab completion
     assert "upper" in dir(ddf.str_col.str)
-    if dd._compat.PANDAS_GT_100:
-        assert "upper" in dir(ddf.string_col.str)
+    assert "upper" in dir(ddf.string_col.str)
     assert "upper" in dir(ddf.index.str)
 
     # not implemented methods don't show up
@@ -137,19 +135,15 @@ def test_str_accessor(df_ddf):
     assert_eq(ddf.str_col.str.upper(), df.str_col.str.upper())
     assert set(ddf.str_col.str.upper().dask) == set(ddf.str_col.str.upper().dask)
 
-    if dd._compat.PANDAS_GT_100:
-        assert_eq(ddf.string_col.str.upper(), df.string_col.str.upper())
-        assert set(ddf.string_col.str.upper().dask) == set(
-            ddf.string_col.str.upper().dask
-        )
+    assert_eq(ddf.string_col.str.upper(), df.string_col.str.upper())
+    assert set(ddf.string_col.str.upper().dask) == set(ddf.string_col.str.upper().dask)
 
     assert_eq(ddf.index.str.upper(), df.index.str.upper())
     assert set(ddf.index.str.upper().dask) == set(ddf.index.str.upper().dask)
 
     # make sure to pass through args & kwargs
     assert_eq(ddf.str_col.str.contains("a"), df.str_col.str.contains("a"))
-    if dd._compat.PANDAS_GT_100:
-        assert_eq(ddf.string_col.str.contains("a"), df.string_col.str.contains("a"))
+    assert_eq(ddf.string_col.str.contains("a"), df.string_col.str.contains("a"))
     assert set(ddf.str_col.str.contains("a").dask) == set(
         ddf.str_col.str.contains("a").dask
     )
@@ -276,7 +270,6 @@ def test_str_accessor_expand_more_columns():
     ds.str.split(n=10, expand=True).compute()
 
 
-@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="No StringDtype")
 def test_string_nullable_types(df_ddf):
     df, ddf = df_ddf
     assert_eq(ddf.string_col.str.count("A"), df.string_col.str.count("A"))

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 import dask.dataframe as dd
-from dask.dataframe._compat import PANDAS_GT_100, PANDAS_GT_120, PANDAS_VERSION
+from dask.dataframe._compat import PANDAS_GT_120, PANDAS_VERSION
 from dask.dataframe.utils import assert_dask_graph, assert_eq, make_meta
 
 try:
@@ -1173,16 +1173,11 @@ def test_reductions_frame_dtypes():
     df_no_timedelta = df.drop("timedelta", axis=1, inplace=False)
     ddf_no_timedelta = dd.from_pandas(df_no_timedelta, 3)
 
-    if not PANDAS_GT_100:
-        # https://github.com/pandas-dev/pandas/issues/30886
-        assert_eq(df.sum(), ddf.sum())
-        assert_eq(df_no_timedelta.mean(), ddf_no_timedelta.mean())
-    else:
-        assert_eq(df.drop(columns="dt").sum(), ddf.drop(columns="dt").sum())
-        assert_eq(
-            df_no_timedelta.drop(columns="dt").mean(),
-            ddf_no_timedelta.drop(columns="dt").mean(),
-        )
+    assert_eq(df.drop(columns="dt").sum(), ddf.drop(columns="dt").sum())
+    assert_eq(
+        df_no_timedelta.drop(columns="dt").mean(),
+        ddf_no_timedelta.drop(columns="dt").mean(),
+    )
 
     assert_eq(df.prod(), ddf.prod())
     assert_eq(df.product(), ddf.product())
@@ -1266,8 +1261,8 @@ def test_reductions_frame_dtypes_numeric_only():
         assert_eq(
             getattr(df, func)(**kwargs),
             getattr(ddf, func)(**kwargs),
-            check_dtypes=func in ["mean", "max"]
-            and (PANDAS_GT_120 or not PANDAS_GT_100),
+            check_dtypes=func in ["mean", "max"] and PANDAS_GT_120,
+            check_dtype=func in ["mean", "max"] and PANDAS_GT_120,
         )
         with pytest.raises(NotImplementedError, match="'numeric_only=False"):
             getattr(ddf, func)(numeric_only=False)
@@ -1293,10 +1288,8 @@ def test_reductions_frame_dtypes_numeric_only():
         assert_eq(
             getattr(df_numerics, func)(),
             getattr(ddf_numerics, func)(),
-            check_dtypes=func in ["mean", "max"]
-            and (PANDAS_GT_120 or not PANDAS_GT_100),
-            check_dtype=func in ["mean", "max"]
-            and (PANDAS_GT_120 or not PANDAS_GT_100),
+            check_dtypes=func in ["mean", "max"] and PANDAS_GT_120,
+            check_dtype=func in ["mean", "max"] and PANDAS_GT_120,
         )
 
 

--- a/dask/dataframe/tests/test_boolean.py
+++ b/dask/dataframe/tests/test_boolean.py
@@ -1,11 +1,6 @@
 import pandas as pd
-import pytest
 
 import dask.dataframe as dd
-
-pytestmark = pytest.mark.skipif(
-    not dd._compat.PANDAS_GT_100, reason="BooleanArray added in 1.0.0"
-)
 
 
 def test_meta():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -11,11 +11,10 @@ from pandas.io.formats import format as pandas_format
 import dask
 import dask.array as da
 import dask.dataframe as dd
-from dask.array.numpy_compat import _numpy_118
 from dask.base import compute_as_if_collection
 from dask.blockwise import fuse_roots
 from dask.dataframe import _compat, methods
-from dask.dataframe._compat import PANDAS_GT_100, PANDAS_GT_110, tm
+from dask.dataframe._compat import PANDAS_GT_110, tm
 from dask.dataframe.core import (
     Scalar,
     _concat,
@@ -306,12 +305,7 @@ def test_rename_series():
     ind.name = "renamed"
     dind.name = "renamed"
     assert ind.name == "renamed"
-    with warnings.catch_warnings():
-        if _numpy_118:
-            # Catch DeprecationWarning from numpy from rewrite_blockwise
-            # where we attempt to do `'str' in ndarray`.
-            warnings.simplefilter("ignore", DeprecationWarning)
-        assert_eq(dind, ind)
+    assert_eq(dind, ind)
 
 
 def test_rename_series_method():
@@ -2368,16 +2362,6 @@ def test_select_dtypes(include, exclude):
 
     tm.assert_series_equal(result.dtypes.value_counts(), expected.dtypes.value_counts())
 
-    if not PANDAS_GT_100:
-        # removed in pandas 1.0
-        ctx = pytest.warns(FutureWarning)
-
-        with ctx:
-            tm.assert_series_equal(a.get_ftype_counts(), df.get_ftype_counts())
-            tm.assert_series_equal(
-                result.get_ftype_counts(), expected.get_ftype_counts()
-            )
-
 
 def test_deterministic_apply_concat_apply_names():
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [5, 6, 7, 8]})
@@ -3351,7 +3335,6 @@ def _assert_info(df, ddf, memory_usage=True):
     assert stdout_pd == stdout_da
 
 
-@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="Changed info repr")
 def test_info():
     from io import StringIO
 
@@ -3386,7 +3369,6 @@ def test_info():
     assert ddf.info(buf=None) is None
 
 
-@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="Changed info repr")
 def test_groupby_multilevel_info():
     # GH 1844
     from io import StringIO
@@ -3422,7 +3404,6 @@ def test_groupby_multilevel_info():
     assert buf.getvalue() == expected
 
 
-@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="Changed info repr")
 def test_categorize_info():
     # assert that we can call info after categorize
     # workaround for: https://github.com/pydata/pandas/issues/14368
@@ -4591,7 +4572,6 @@ def test_fuse_roots():
     hlg.validate()
 
 
-@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="attrs introduced in 1.0.0")
 def test_attrs_dataframe():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
     df.attrs = {"date": "2020-10-16"}
@@ -4601,7 +4581,6 @@ def test_attrs_dataframe():
     assert df.abs().attrs == ddf.abs().attrs
 
 
-@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="attrs introduced in 1.0.0")
 def test_attrs_series():
     s = pd.Series([1, 2], name="A")
     s.attrs["unit"] = "kg"
@@ -4611,7 +4590,6 @@ def test_attrs_series():
     assert s.fillna(1).attrs == ds.fillna(1).attrs
 
 
-@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="attrs introduced in 1.0.0")
 @pytest.mark.xfail(reason="df.iloc[:0] does not keep the series attrs")
 def test_attrs_series_in_dataframes():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -8,7 +8,7 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.dataframe import _compat
-from dask.dataframe._compat import PANDAS_GT_100, tm
+from dask.dataframe._compat import tm
 from dask.dataframe.utils import assert_dask_graph, assert_eq, assert_max_deps
 from dask.utils import M
 
@@ -926,106 +926,6 @@ def test_groupby_normalize_index():
 
     assert d.groupby([d["a"], d["b"]]).index == ["a", "b"]
     assert d.groupby([d["a"], "b"]).index == ["a", "b"]
-
-
-@pytest.mark.parametrize(
-    "spec",
-    [
-        {"b": {"c": "mean"}, "c": {"a": "max", "b": "min"}},
-        {"b": "mean", "c": ["min", "max"]},
-        {"b": np.sum, "c": ["min", np.max, np.std, np.var]},
-        [
-            "sum",
-            "mean",
-            "min",
-            "max",
-            "count",
-            "size",
-            "std",
-            "var",
-            "first",
-            "last",
-            "prod",
-        ],
-        "var",
-        {"b": "mean", "c": "first", "d": "last", "a": ["first", "last"]},
-        {"b": {"c": "mean"}, "c": {"a": "first", "b": "last"}},
-    ],
-)
-@pytest.mark.parametrize("split_every", [False, None])
-@pytest.mark.parametrize(
-    "grouper",
-    [
-        lambda df: "a",
-        lambda df: ["a", "d"],
-        lambda df: [df["a"], df["d"]],
-        lambda df: df["a"],
-        lambda df: df["a"] > 2,
-    ],
-)
-def test_aggregate__examples(spec, split_every, grouper):
-    pdf = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 1, 1, 2, 4, 3, 7] * 10,
-            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-            "d": [3, 2, 1, 3, 2, 1, 2, 6, 4] * 10,
-        },
-        columns=["c", "b", "a", "d"],
-    )
-    ddf = dd.from_pandas(pdf, npartitions=10)
-
-    # Warning from pandas deprecation .agg(dict[dict])
-    # it's from pandas, so no reason to assert the deprecation warning,
-    # but we should still test it for now
-    if not PANDAS_GT_100:
-        # removed in pandas 1.0
-        with pytest.warns(None):
-            assert_eq(
-                pdf.groupby(grouper(pdf)).agg(spec),
-                ddf.groupby(grouper(ddf)).agg(spec, split_every=split_every),
-            )
-
-
-@pytest.mark.parametrize(
-    "spec",
-    [
-        {"b": "sum", "c": "min", "d": "max"},
-        ["sum"],
-        ["sum", "mean", "min", "max", "count", "size", "std", "var", "first", "last"],
-        "sum",
-        "size",
-    ],
-)
-@pytest.mark.parametrize("split_every", [False, None])
-@pytest.mark.parametrize(
-    "grouper",
-    [lambda df: [df["a"], df["d"]], lambda df: df["a"], lambda df: df["a"] > 2],
-)
-def test_series_aggregate__examples(spec, split_every, grouper):
-    pdf = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 1, 1, 2, 4, 3, 7] * 10,
-            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 10,
-            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 10,
-            "d": [3, 2, 1, 3, 2, 1, 2, 6, 4] * 10,
-        },
-        columns=["c", "b", "a", "d"],
-    )
-    ps = pdf["c"]
-
-    ddf = dd.from_pandas(pdf, npartitions=10)
-    ds = ddf["c"]
-    # Warning from pandas deprecation .agg(dict[dict])
-    # it's from pandas, so no reason to assert the deprecation warning,
-    # but we should still test it for now
-    if not PANDAS_GT_100:
-        # removed in pandas 1.0
-        with pytest.warns(None):
-            assert_eq(
-                ps.groupby(grouper(pdf)).agg(spec),
-                ds.groupby(grouper(ddf)).agg(spec, split_every=split_every),
-            )
 
 
 def test_aggregate__single_element_groups(agg_func):
@@ -2199,16 +2099,9 @@ def test_groupby_transform_ufunc_partitioning(npartitions, indexed):
             lambda grp: grp.agg("mean"),
         ),
         (lambda df: df.groupby(["category_1", "category_2"]), lambda grp: grp.mean()),
-        pytest.param(
+        (
             lambda df: df.groupby(["category_1", "category_2"]),
             lambda grp: grp.agg("mean"),
-            marks=pytest.mark.xfail(
-                not dask.dataframe.utils.PANDAS_GT_100,
-                reason=(
-                    "Should work starting from pandas 1.0.0: "
-                    "https://github.com/dask/dask/pull/5423"
-                ),
-            ),
         ),
     ],
 )
@@ -2439,9 +2332,6 @@ def test_groupby_sort_true_split_out():
         M.sum(ddf.groupby("x", sort=True), split_out=2)
 
 
-@pytest.mark.skipif(
-    not dd._compat.PANDAS_GT_100, reason="observed only supported for newer pandas"
-)
 @pytest.mark.parametrize("known_cats", [True, False])
 @pytest.mark.parametrize("ordered_cats", [True, False])
 @pytest.mark.parametrize("groupby", ["cat_1", ["cat_1", "cat_2"]])

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -8,7 +8,7 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.dataframe import _compat
-from dask.dataframe._compat import tm
+from dask.dataframe._compat import PANDAS_GT_110, tm
 from dask.dataframe.utils import assert_dask_graph, assert_eq, assert_max_deps
 from dask.utils import M
 
@@ -2332,6 +2332,9 @@ def test_groupby_sort_true_split_out():
         M.sum(ddf.groupby("x", sort=True), split_out=2)
 
 
+@pytest.mark.skipif(
+    not PANDAS_GT_110, reason="observed only supported for newer pandas"
+)
 @pytest.mark.parametrize("known_cats", [True, False])
 @pytest.mark.parametrize("ordered_cats", [True, False])
 @pytest.mark.parametrize("groupby", ["cat_1", ["cat_1", "cat_2"]])

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -4,7 +4,7 @@ import pytest
 
 import dask
 import dask.dataframe as dd
-from dask.dataframe._compat import PANDAS_GT_100, PANDAS_GT_110, PANDAS_GT_120, tm
+from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_120, tm
 from dask.dataframe.indexing import _coerce_loc_index
 from dask.dataframe.utils import assert_eq, make_meta
 
@@ -35,32 +35,11 @@ def test_loc():
     assert_eq(d.loc[3:], full.loc[3:])
     assert_eq(d.loc[[5]], full.loc[[5]])
 
-    expected_warning = FutureWarning
-
-    if not PANDAS_GT_100:
-        # removed in pandas 1.0
-        with pytest.warns(expected_warning):
-            assert_eq(d.loc[[3, 4, 1, 8]], full.loc[[3, 4, 1, 8]])
-        with pytest.warns(expected_warning):
-            assert_eq(d.loc[[3, 4, 1, 9]], full.loc[[3, 4, 1, 9]])
-        with pytest.warns(expected_warning):
-            assert_eq(d.loc[np.array([3, 4, 1, 9])], full.loc[np.array([3, 4, 1, 9])])
-
     assert_eq(d.a.loc[5], full.a.loc[5:5])
     assert_eq(d.a.loc[3:8], full.a.loc[3:8])
     assert_eq(d.a.loc[:8], full.a.loc[:8])
     assert_eq(d.a.loc[3:], full.a.loc[3:])
     assert_eq(d.a.loc[[5]], full.a.loc[[5]])
-    if not PANDAS_GT_100:
-        # removed in pandas 1.0
-        with pytest.warns(expected_warning):
-            assert_eq(d.a.loc[[3, 4, 1, 8]], full.a.loc[[3, 4, 1, 8]])
-        with pytest.warns(expected_warning):
-            assert_eq(d.a.loc[[3, 4, 1, 9]], full.a.loc[[3, 4, 1, 9]])
-        with pytest.warns(expected_warning):
-            assert_eq(
-                d.a.loc[np.array([3, 4, 1, 9])], full.a.loc[np.array([3, 4, 1, 9])]
-            )
     assert_eq(d.a.loc[[]], full.a.loc[[]])
     assert_eq(d.a.loc[np.array([])], full.a.loc[np.array([])])
 
@@ -181,12 +160,6 @@ def test_loc2d():
 
     with pytest.raises(pd.core.indexing.IndexingError):
         d.a.loc[d.a % 2 == 0, 3]
-
-
-@pytest.mark.skip(PANDAS_GT_100, reason="Removed in pandas 1.0")
-def test_loc2d_some_missing():
-    with pytest.warns(FutureWarning):
-        assert_eq(d.loc[[3, 4, 3], ["a"]], full.loc[[3, 4, 3], ["a"]])
 
 
 def test_loc2d_with_known_divisions():

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2246,12 +2246,8 @@ def test_categorical_join():
     assert actual_dask.join_col.dtype == "category"
 
     actual = actual_dask.compute()
-    if dd._compat.PANDAS_GT_100:
-        assert actual.join_col.dtype == "category"
-        assert assert_eq(expected, actual)
-    else:
-        assert actual.join_col.dtype == "object"
-        assert (expected.values == actual.values).all()
+    assert actual.join_col.dtype == "category"
+    assert assert_eq(expected, actual)
 
 
 def test_categorical_merge_with_columns_missing_from_left():
@@ -2302,9 +2298,8 @@ def test_categorical_merge_retains_category_dtype():
     actual_dask = df1.merge(df2, on="A")
     assert actual_dask.A.dtype == "category"
 
-    if dd._compat.PANDAS_GT_100:
-        actual = actual_dask.compute()
-        assert actual.A.dtype == "category"
+    actual = actual_dask.compute()
+    assert actual.A.dtype == "category"
 
 
 def test_categorical_merge_does_not_raise_setting_with_copy_warning():

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -400,7 +400,6 @@ def test_rolling_agg_aggregate():
     )
 
 
-@pytest.mark.skipif(not dd._compat.PANDAS_GT_100, reason="needs pandas>=1.0.0")
 def test_rolling_numba_engine():
     numba = pytest.importorskip("numba")
     numba_version = parse_version(numba.__version__)
@@ -418,11 +417,3 @@ def test_rolling_numba_engine():
         df.rolling(3).apply(f, engine="numba", raw=True),
         ddf.rolling(3).apply(f, engine="numba", raw=True),
     )
-
-
-@pytest.mark.skipif(dd._compat.PANDAS_GT_100, reason="Requires pandas>1.0.0")
-def test_rolling_apply_numba_raises():
-    df = pd.DataFrame({"A": range(5), "B": range(0, 10, 2)})
-    ddf = dd.from_pandas(df, npartitions=3)
-    with pytest.raises(NotImplementedError, match="pandas>=1.0.0"):
-        ddf.rolling(3).apply(lambda x: x.sum(), engine="numba", raw=True)

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -8,7 +8,6 @@ import dask.dataframe as dd
 from dask.dataframe._compat import tm
 from dask.dataframe.core import apply_and_enforce
 from dask.dataframe.utils import (
-    PANDAS_GT_100,
     PANDAS_GT_120,
     UNKNOWN_CATEGORIES,
     check_matching_columns,
@@ -376,21 +375,20 @@ def test_check_meta():
     )
     assert str(err.value) == exp
 
-    if PANDAS_GT_100:
-        # pandas dtype metadata error
-        with pytest.raises(ValueError) as err:
-            check_meta(df.a, pd.Series([], dtype="string"), numeric_equal=False)
-        assert str(err.value) == (
-            "Metadata mismatch found.\n"
-            "\n"
-            "Partition type: `pandas.core.series.Series`\n"
-            "+----------+--------+\n"
-            "|          | dtype  |\n"
-            "+----------+--------+\n"
-            "| Found    | object |\n"
-            "| Expected | string |\n"
-            "+----------+--------+"
-        )
+    # pandas dtype metadata error
+    with pytest.raises(ValueError) as err:
+        check_meta(df.a, pd.Series([], dtype="string"), numeric_equal=False)
+    assert str(err.value) == (
+        "Metadata mismatch found.\n"
+        "\n"
+        "Partition type: `pandas.core.series.Series`\n"
+        "+----------+--------+\n"
+        "|          | dtype  |\n"
+        "+----------+--------+\n"
+        "| Found    | object |\n"
+        "| Expected | string |\n"
+        "+----------+--------+"
+    )
 
 
 def test_check_matching_columns_raises_appropriate_errors():
@@ -493,7 +491,6 @@ def test_apply_and_enforce_message():
         apply_and_enforce(_func=func, _meta=meta)
 
 
-@pytest.mark.skipif(not PANDAS_GT_100, reason="Only pandas>1")
 def test_nonempty_series_sparse():
     ser = pd.Series(pd.array([0, 1], dtype="Sparse"))
     with pytest.warns(None) as w:

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -23,7 +23,7 @@ from ..utils import is_series_like as dask_is_series_like
 from ..utils import typename
 from . import _dtypes  # noqa: F401 register pandas extension types
 from . import methods
-from ._compat import PANDAS_GT_100, PANDAS_GT_110, PANDAS_GT_120, tm  # noqa: F401
+from ._compat import PANDAS_GT_110, PANDAS_GT_120, tm  # noqa: F401
 from .dispatch import make_meta  # noqa : F401
 from .dispatch import make_meta_obj, meta_nonempty  # noqa : F401
 from .extensions import make_scalar

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -3,8 +3,6 @@ import random
 import sys
 from array import array
 
-from packaging.version import parse as parse_version
-
 from .utils import Dispatch
 
 try:  # PyPy does not support sys.getsizeof
@@ -217,10 +215,3 @@ def register_pyarrow():
     @sizeof.register(pa.ChunkedArray)
     def sizeof_pyarrow_chunked_array(data):
         return int(_get_col_size(data)) + 1000
-
-    # Handle pa.Column for pyarrow < 0.15
-    if parse_version(pa.__version__) < parse_version("0.15.0"):
-
-        @sizeof.register(pa.Column)
-        def sizeof_pyarrow_column(col):
-            return int(_get_col_size(col)) + 1000

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -283,13 +283,12 @@ def test_tokenize_pandas_extension_array():
         ),
     ]
 
-    if dd._compat.PANDAS_GT_100:
-        arrays.extend(
-            [
-                pd.array(["a", "b", None], dtype="string"),
-                pd.array([True, False, None], dtype="boolean"),
-            ]
-        )
+    arrays.extend(
+        [
+            pd.array(["a", "b", None], dtype="string"),
+            pd.array([True, False, None], dtype="boolean"),
+        ]
+    )
 
     for arr in arrays:
         assert tokenize(arr) == tokenize(arr)

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -574,7 +574,7 @@ def test_finalize_name():
     def key(s):
         if isinstance(s, tuple):
             s = s[0]
-        return s.split("-")[0]
+        return s.split("-")[0].replace("_", "")
 
     assert all(key(k).isalpha() for k in v.dask)
 

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -574,6 +574,7 @@ def test_finalize_name():
     def key(s):
         if isinstance(s, tuple):
             s = s[0]
+        # Ignore _ in 'ones_like'
         return s.split("-")[0].replace("_", "")
 
     assert all(key(k).isalpha() for k in v.dask)

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -103,7 +103,7 @@ These optional dependencies and their minimum supported versions are listed belo
 +---------------+----------+--------------------------------------------------------------+
 |     psutil    |          |             Enables a more accurate CPU count                |
 +---------------+----------+--------------------------------------------------------------+
-|     pyarrow   | >=0.14.0 |               Python library for Apache Arrow                |
+|     pyarrow   | >=1.0    |               Python library for Apache Arrow                |
 +---------------+----------+--------------------------------------------------------------+
 |     s3fs      | >=0.4.0  |                    Reading from Amazon S3                    |
 +---------------+----------+--------------------------------------------------------------+

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -99,7 +99,7 @@ These optional dependencies and their minimum supported versions are listed belo
 +---------------+----------+--------------------------------------------------------------+
 |     numpy     | >=1.18   |                   Required for dask.array                    |
 +---------------+----------+--------------------------------------------------------------+
-|     pandas    | >=1.0.0  |                  Required for dask.dataframe                 |
+|     pandas    | >=1.0  |                  Required for dask.dataframe                 |
 +---------------+----------+--------------------------------------------------------------+
 |     psutil    |          |             Enables a more accurate CPU count                |
 +---------------+----------+--------------------------------------------------------------+

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -99,7 +99,7 @@ These optional dependencies and their minimum supported versions are listed belo
 +---------------+----------+--------------------------------------------------------------+
 |     numpy     | >=1.18   |                   Required for dask.array                    |
 +---------------+----------+--------------------------------------------------------------+
-|     pandas    | >=1.0  |                  Required for dask.dataframe                 |
+|     pandas    | >=1.0    |                  Required for dask.dataframe                 |
 +---------------+----------+--------------------------------------------------------------+
 |     psutil    |          |             Enables a more accurate CPU count                |
 +---------------+----------+--------------------------------------------------------------+

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -97,9 +97,9 @@ These optional dependencies and their minimum supported versions are listed belo
 +---------------+----------+--------------------------------------------------------------+
 |   murmurhash  |          |                   Faster hashing of arrays                   |
 +---------------+----------+--------------------------------------------------------------+
-|     numpy     | >=1.16   |                   Required for dask.array                    |
+|     numpy     | >=1.18   |                   Required for dask.array                    |
 +---------------+----------+--------------------------------------------------------------+
-|     pandas    | >=0.25.0 |                  Required for dask.dataframe                 |
+|     pandas    | >=1.0.0  |                  Required for dask.dataframe                 |
 +---------------+----------+--------------------------------------------------------------+
 |     psutil    |          |             Enables a more accurate CPU count                |
 +---------------+----------+--------------------------------------------------------------+

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ import versioneer
 # NOTE: These are tested in `continuous_integration/test_imports.sh` If
 # you modify these, make sure to change the corresponding line there.
 extras_require = {
-    "array": ["numpy >= 1.16"],
+    "array": ["numpy >= 1.18"],
     "bag": [],  # keeping for backwards compatibility
-    "dataframe": ["numpy >= 1.16", "pandas >= 0.25.0"],
+    "dataframe": ["numpy >= 1.18", "pandas >= 1.0.0"],
     "distributed": ["distributed == 2021.07.1"],
     "diagnostics": ["bokeh >= 1.0.0, != 2.0.0"],
     "delayed": [],  # keeping for backwards compatibility


### PR DESCRIPTION
Following up on the discussion in issue ( https://github.com/dask/dask/issues/7378 ), this bumps the minimums to NumPy 1.18+ and Pandas 1.0+.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
