### PR TITLE
Add meta support to `__setitem__`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1704,8 +1704,12 @@ class Array(DaskMethodsMixin):
         out = "setitem-" + tokenize(self, key, value)
         dsk = setitem_array(out, self, key, value)
 
+        meta = meta_from_array(self._meta)
+        if np.isscalar(meta):
+            meta = np.array(meta)
+
         graph = HighLevelGraph.from_collections(out, dsk, dependencies=[self])
-        y = Array(graph, out, chunks=self.chunks, dtype=self.dtype)
+        y = Array(graph, out, chunks=self.chunks, dtype=self.dtype, meta=meta)
 
         self._meta = y._meta
         self.dask = y.dask

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1407,9 +1407,7 @@ def parse_assignment_indices(indices, shape):
                 f"boolean index: {index!r}"
             )
 
-        if (
-            isinstance(index, np.ndarray) or is_dask_collection(index)
-        ) and not index.ndim:
+        if (is_arraylike(index) or is_dask_collection(index)) and not index.ndim:
             raise NotImplementedError(
                 "dask does not yet implement assignment to a scalar "
                 f"numpy or dask array index: {index!r}"

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -1468,3 +1468,57 @@ def test_cupy_cholesky(shape, chunk):
         check_graph=False,
         check_chunks=False,
     )
+
+
+def test_setitem_1d():
+    x = cupy.arange(10)
+    dx = da.from_array(x.copy(), chunks=(5,))
+
+    x[x > 6] = -1
+    x[x % 2 == 0] = -2
+
+    dx[dx > 6] = -1
+    dx[dx % 2 == 0] = -2
+
+    assert_eq(x, dx)
+
+
+def test_setitem_2d():
+    x = cupy.arange(24).reshape((4, 6))
+    dx = da.from_array(x.copy(), chunks=(2, 2))
+
+    x[x > 6] = -1
+    x[x % 2 == 0] = -2
+
+    dx[dx > 6] = -1
+    dx[dx % 2 == 0] = -2
+
+    assert_eq(x, dx)
+
+
+def test_setitem_extended_API_0d():
+    # 0-d array
+    x = cupy.array(9)
+    dx = da.from_array(x.copy())
+
+    x[()] = -1
+    dx[()] = -1
+    assert_eq(x, dx.compute())
+
+    x[...] = -11
+    dx[...] = -11
+    assert_eq(x, dx.compute())
+
+
+def test_setitem_extended_API_1d():
+    # 1-d array
+    x = cupy.arange(10)
+    dx = da.from_array(x.copy(), chunks=(4, 6))
+
+    x[2:8:2] = -1
+    dx[2:8:2] = -1
+    assert_eq(x, dx.compute())
+
+    x[...] = -11
+    dx[...] = -11
+    assert_eq(x, dx.compute())

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -1639,3 +1639,283 @@ def test_setitem_extended_API_1d():
     x[...] = -11
     dx[...] = -11
     assert_eq(x, dx.compute())
+
+
+@pytest.mark.parametrize(
+    "index, value",
+    [
+        [Ellipsis, -1],
+        [(slice(None, None, 2), slice(None, None, -1)), -1],
+        [slice(1, None, 2), -1],
+        [[4, 3, 1], -1],
+        [(Ellipsis, 4), -1],
+        [5, -1],
+        pytest.param(
+            (slice(None), 2),
+            range(6),
+            marks=pytest.mark.skip(
+                reason="Assigning `range` to CuPy array is not supported",
+            ),
+        ),
+        pytest.param(
+            3,
+            range(10),
+            marks=pytest.mark.skip(
+                reason="Assigning `range` to CuPy array is not supported",
+            ),
+        ),
+        [(slice(None), [3, 5, 6]), [-30, -31, -32]],
+        [([-1, 0, 1], 2), [-30, -31, -32]],
+        pytest.param(
+            (slice(None, 2), slice(None, 3)),
+            [-50, -51, -52],
+            marks=pytest.mark.skip(
+                reason="Unsupported assigning `list` to CuPy array",
+            ),
+        ),
+        [(slice(None), [6, 1, 3]), [-60, -61, -62]],
+        pytest.param(
+            (slice(1, 3), slice(1, 4)),
+            [[-70, -71, -72]],
+            marks=pytest.mark.skip(
+                reason="Unsupported assigning `list` to CuPy array",
+            ),
+        ),
+        [(slice(None), [9, 8, 8]), [-80, -81, 91]],
+        [([True, False, False, False, True, False], 2), -1],
+        [(3, [True, True, False, True, True, False, True, False, True, True]), -1],
+        [(np.array([False, False, True, True, False, False]), slice(5, 7)), -1],
+        [(cupy.array([False, False, True, True, False, False]), slice(5, 7)), -1],
+        pytest.param(
+            (
+                4,
+                da.from_array(
+                    [False, False, True, True, False, False, True, False, False, True]
+                ),
+            ),
+            -1,
+            marks=pytest.mark.skip(
+                reason="Unsupported assigning Dask Array to CuPy array",
+            ),
+        ),
+    ],
+)
+def test_setitem_extended_API_2d(index, value):
+    # 2-d array
+    x = cupy.arange(60).reshape((6, 10))
+    dx = da.from_array(x, chunks=(2, 3))
+    dx[index] = value
+    x[index] = value
+    assert_eq(x, dx.compute())
+
+
+def test_setitem_extended_API_2d_rhs_func_of_lhs():
+    # Cases:
+    # * RHS and/or indices are a function of the LHS
+    # * Indices have unknown chunk sizes
+    # * RHS has extra leading size 1 dimensions compared to LHS
+    x = cupy.arange(60).reshape((6, 10))
+    chunks = (2, 3)
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[2:4, dx[0] > 3] = -5
+    x[2:4, x[0] > 3] = -5
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[2, dx[0] < -2] = -7
+    x[2, x[0] < -2] = -7
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[dx % 2 == 0] = -8
+    x[x % 2 == 0] = -8
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[dx % 2 == 0] = -8
+    x[x % 2 == 0] = -8
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[3:5, 5:1:-2] = -dx[:2, 4:1:-2]
+    x[3:5, 5:1:-2] = -x[:2, 4:1:-2]
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[0, 1:3] = -dx[0, 4:2:-1]
+    x[0, 1:3] = -x[0, 4:2:-1]
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[...] = dx
+    x[...] = x
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[...] = dx[...]
+    x[...] = x[...]
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[0] = dx[-1]
+    x[0] = x[-1]
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[0, :] = dx[-2, :]
+    x[0, :] = x[-2, :]
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[:, 1] = dx[:, -3]
+    x[:, 1] = x[:, -3]
+    assert_eq(x, dx.compute())
+
+    index = da.from_array([0, 2], chunks=(2,))
+    dx = da.from_array(x, chunks=chunks)
+    dx[index, 8] = [99, 88]
+    x[[0, 2], 8] = [99, 88]
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=chunks)
+    dx[:, index] = dx[:, :2]
+    x[:, [0, 2]] = x[:, :2]
+    assert_eq(x, dx.compute())
+
+    index = da.where(da.arange(3, chunks=(1,)) < 2)[0]
+    dx = da.from_array(x, chunks=chunks)
+    dx[index, 7] = [-23, -33]
+    x[index.compute(), 7] = [-23, -33]
+    assert_eq(x, dx.compute())
+
+    index = da.where(da.arange(3, chunks=(1,)) < 2)[0]
+    dx = da.from_array(x, chunks=chunks)
+    dx[(index,)] = -34
+    x[(index.compute(),)] = -34
+    assert_eq(x, dx.compute())
+
+    index = index - 4
+    dx = da.from_array(x, chunks=chunks)
+    dx[index, 7] = [-43, -53]
+    x[index.compute(), 7] = [-43, -53]
+    assert_eq(x, dx.compute())
+
+    index = da.from_array([0, -1], chunks=(1,))
+    x[[0, -1]] = 9999
+    dx[(index,)] = 9999
+    assert_eq(x, dx.compute())
+
+    dx = da.from_array(x, chunks=(-1, -1))
+    dx[...] = da.from_array(x, chunks=chunks)
+    assert_eq(x, dx.compute())
+
+    # Both tests below fail in CuPy due to leading singular dimensions
+    if False:
+        # RHS has extra leading size 1 dimensions compared to LHS
+        dx = da.from_array(x.copy(), chunks=(2, 3))
+        v = x.reshape((1, 1) + x.shape)
+        x[...] = v
+        dx[...] = v
+        assert_eq(x, dx.compute())
+
+        index = da.where(da.arange(3, chunks=(1,)) < 2)[0]
+        v = -cupy.arange(12).reshape(1, 1, 6, 2)
+        x[:, [0, 1]] = v
+        dx[:, index] = v
+        assert_eq(x, dx.compute())
+
+
+def test_setitem_on_read_only_blocks():
+    # Outputs of broadcast_trick-style functions contain read-only
+    # arrays
+    dx = da.empty_like(cupy.array(()), shape=(4, 6), dtype=float, chunks=(2, 2))
+    dx[0] = 99
+
+    assert_eq(dx[0, 0], 99.0)
+
+    dx[0:2] = 88
+
+    assert_eq(dx[0, 0], 88.0)
+
+
+def test_setitem_errs():
+    x = da.ones_like(cupy.array(()), shape=(4, 4), chunks=(2, 2))
+
+    with pytest.raises(ValueError):
+        x[x > 1] = x
+
+    # Shape mismatch
+    with pytest.raises(ValueError):
+        x[[True, True, False, False], 0] = [2, 3, 4]
+
+    with pytest.raises(ValueError):
+        x[[True, True, True, False], 0] = [2, 3]
+
+    x = da.ones((4, 4), chunks=(2, 2))
+    with pytest.raises(ValueError):
+        x[0, da.from_array([True, False, False, True])] = [2, 3, 4]
+
+    x = da.ones((4, 4), chunks=(2, 2))
+    with pytest.raises(ValueError):
+        x[0, da.from_array([True, True, False, False])] = [2, 3, 4]
+
+    x = da.ones((4, 4), chunks=(2, 2))
+    with pytest.raises(ValueError):
+        x[da.from_array([True, True, True, False]), 0] = [2, 3]
+
+    x = da.ones((4, 4), chunks=(2, 2))
+
+    # Too many indices
+    with pytest.raises(IndexError):
+        x[:, :, :] = 2
+
+    # 2-d boolean indexing a single dimension
+    with pytest.raises(IndexError):
+        x[[[True, True, False, False]], 0] = 5
+
+    # Too many/not enough booleans
+    with pytest.raises(IndexError):
+        x[[True, True, False]] = 5
+
+    with pytest.raises(IndexError):
+        x[[False, True, True, True, False]] = 5
+
+    # 2-d indexing a single dimension
+    with pytest.raises(IndexError):
+        x[[[1, 2, 3]], 0] = 5
+
+    # Multiple 1-d boolean/integer arrays
+    with pytest.raises(NotImplementedError):
+        x[[1, 2], [2, 3]] = 6
+
+    with pytest.raises(NotImplementedError):
+        x[[True, True, False, False], [2, 3]] = 5
+
+    with pytest.raises(NotImplementedError):
+        x[[True, True, False, False], [False, True, False, False]] = 7
+
+    # scalar boolean indexing
+    with pytest.raises(NotImplementedError):
+        x[True] = 5
+
+    with pytest.raises(NotImplementedError):
+        x[cupy.array(True)] = 5
+
+    with pytest.raises(NotImplementedError):
+        x[0, da.from_array(True)] = 5
+
+    # Scalar arrays
+    y = da.from_array(cupy.array(1))
+    with pytest.raises(IndexError):
+        y[:] = 2
+
+    # RHS has non-brodacastable extra leading dimensions
+    x = cupy.arange(12).reshape((3, 4))
+    dx = da.from_array(x, chunks=(2, 2))
+    with pytest.raises(ValueError):
+        dx[...] = cupy.arange(24).reshape((2, 1, 3, 4))
+
+    # RHS has extra leading size 1 dimensions compared to LHS
+    x = cupy.arange(12).reshape((3, 4))
+    dx = da.from_array(x, chunks=(2, 3))


### PR DESCRIPTION
With changes in this PR it's now possible to assign values to Dask arrays backed by CuPy and other libraries supporting `__array_function__`.