### PR TITLE
Fix read-csv name - when path is different, use different name for task

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -292,6 +292,7 @@ def text_blocks_to_pandas(
     specified_dtypes=None,
     path=None,
     blocksize=None,
+    urlpath=None,
 ):
     """Convert blocks of bytes to a dask.dataframe
 
@@ -379,7 +380,7 @@ def text_blocks_to_pandas(
 
     # Create Blockwise layer
     label = "read-csv-"
-    name = label + tokenize(reader, columns, enforce, head, blocksize)
+    name = label + tokenize(reader, urlpath, columns, enforce, head, blocksize)
     layer = DataFrameIOLayer(
         name,
         columns,
@@ -616,6 +617,7 @@ def read_pandas(
         specified_dtypes=specified_dtypes,
         path=path,
         blocksize=blocksize,
+        urlpath=urlpath,
     )
 
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1693,10 +1693,10 @@ def test_csv_name_should_be_different_even_if_head_is_same(tmpdir):
             )
 
     new_df = dd.read_csv(
-        "new.csv", header=None, delimiter=",", dtype=str, blocksize=None
+        new_csv_path, header=None, delimiter=",", dtype=str, blocksize=None
     )
     old_df = dd.read_csv(
-        "old.csv", header=None, delimiter=",", dtype=str, blocksize=None
+        old_csv_path, header=None, delimiter=",", dtype=str, blocksize=None
     )
 
     assert new_df.dask.keys() != old_df.dask.keys()


### PR DESCRIPTION
- [x] Closes #7904
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

Not sure if we need to do this in other places cc @martindurant and @rjzamora 
