### PR TITLE
Adds missing prepend/append functionality to da.diff

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -35,7 +35,6 @@ from .einsumfuncs import einsum  # noqa
 from .ufunc import multiply, sqrt
 from .utils import (
     array_safe,
-    asanyarray_safe,
     asarray_safe,
     meta_from_array,
     safe_wraps,
@@ -531,7 +530,7 @@ def ptp(a, axis=None):
 
 
 @derived_from(np)
-def diff(a, n=1, axis=-1, prepend=None):
+def diff(a, n=1, axis=-1, prepend=None, append=None):
     a = asarray(a)
     n = int(n)
     axis = int(axis)
@@ -541,7 +540,7 @@ def diff(a, n=1, axis=-1, prepend=None):
 
     combined = []
     if prepend is not None:
-        prepend = asanyarray_safe(prepend, like=a)
+        prepend = asarray_safe(prepend, like=a)
         if prepend.ndim == 0:
             shape = list(a.shape)
             shape[axis] = 1
@@ -549,6 +548,14 @@ def diff(a, n=1, axis=-1, prepend=None):
         combined.append(prepend)
 
     combined.append(a)
+
+    if append is not None:
+        append = asarray_safe(append, like=a)
+        if append.ndim == 0:
+            shape = list(a.shape)
+            shape[axis] = 1
+            append = np.broadcast_to(append, tuple(shape))
+        combined.append(append)
 
     if len(combined) > 1:
         a = concatenate(combined, axis)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -542,7 +542,7 @@ def diff(a, n=1, axis=-1, prepend=None, append=None):
 
     combined = []
     if prepend is not None:
-        prepend = asarray_safe(prepend, like=a)
+        prepend = asarray_safe(prepend, like=meta_from_array(a))
         if prepend.ndim == 0:
             shape = list(a.shape)
             shape[axis] = 1
@@ -552,7 +552,7 @@ def diff(a, n=1, axis=-1, prepend=None, append=None):
     combined.append(a)
 
     if append is not None:
-        append = asarray_safe(append, like=a)
+        append = asarray_safe(append, like=meta_from_array(a))
         if append.ndim == 0:
             shape = list(a.shape)
             shape[axis] = 1

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -537,6 +537,8 @@ def diff(a, n=1, axis=-1, prepend=None, append=None):
 
     if n == 0:
         return a
+    if n < 0:
+        raise ValueError("order must be non-negative but got %d" % n)
 
     combined = []
     if prepend is not None:

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -35,6 +35,7 @@ from .einsumfuncs import einsum  # noqa
 from .ufunc import multiply, sqrt
 from .utils import (
     array_safe,
+    asanyarray_safe,
     asarray_safe,
     meta_from_array,
     safe_wraps,
@@ -530,10 +531,27 @@ def ptp(a, axis=None):
 
 
 @derived_from(np)
-def diff(a, n=1, axis=-1):
+def diff(a, n=1, axis=-1, prepend=None):
     a = asarray(a)
     n = int(n)
     axis = int(axis)
+
+    if n == 0:
+        return a
+
+    combined = []
+    if prepend is not None:
+        prepend = asanyarray_safe(prepend, like=a)
+        if prepend.ndim == 0:
+            shape = list(a.shape)
+            shape[axis] = 1
+            prepend = broadcast_to(prepend, tuple(shape))
+        combined.append(prepend)
+
+    combined.append(a)
+
+    if len(combined) > 1:
+        a = concatenate(combined, axis)
 
     sl_1 = a.ndim * [slice(None)]
     sl_2 = a.ndim * [slice(None)]

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -1919,3 +1919,71 @@ def test_setitem_errs():
     # RHS has extra leading size 1 dimensions compared to LHS
     x = cupy.arange(12).reshape((3, 4))
     dx = da.from_array(x, chunks=(2, 3))
+
+
+@pytest.mark.parametrize(
+    "shape, axis",
+    [[(10, 15, 20), 0], [(10, 15, 20), 1], [(10, 15, 20), 2], [(10, 15, 20), -1]],
+)
+@pytest.mark.parametrize("n", [0, 1, 2])
+def test_diff(shape, n, axis):
+    x = cupy.random.randint(0, 10, shape)
+    a = da.from_array(x, chunks=(len(shape) * (5,)))
+
+    assert_eq(da.diff(a, n, axis), cupy.diff(x, n, axis))
+
+
+@pytest.mark.parametrize("n", [0, 1, 2])
+def test_diff_prepend(n):
+    x = cupy.arange(5) + 1
+    a = da.from_array(x, chunks=2)
+    assert_eq(da.diff(a, n, prepend=0), cupy.diff(x, n, prepend=0))
+    assert_eq(da.diff(a, n, prepend=[0]), cupy.diff(x, n, prepend=[0]))
+    assert_eq(da.diff(a, n, prepend=[-1, 0]), cupy.diff(x, n, prepend=[-1, 0]))
+
+    x = cupy.arange(16).reshape(4, 4)
+    a = da.from_array(x, chunks=2)
+    assert_eq(da.diff(a, n, axis=1, prepend=0), cupy.diff(x, n, axis=1, prepend=0))
+    assert_eq(
+        da.diff(a, n, axis=1, prepend=[[0], [0], [0], [0]]),
+        cupy.diff(x, n, axis=1, prepend=[[0], [0], [0], [0]]),
+    )
+    assert_eq(da.diff(a, n, axis=0, prepend=0), cupy.diff(x, n, axis=0, prepend=0))
+    assert_eq(
+        da.diff(a, n, axis=0, prepend=[[0, 0, 0, 0]]),
+        cupy.diff(x, n, axis=0, prepend=[[0, 0, 0, 0]]),
+    )
+
+    if n > 0:
+        # When order is 0 the result is the icupyut array, it doesn't raise
+        # an error
+        with pytest.raises(ValueError):
+            da.diff(a, n, prepend=cupy.zeros((3, 3)))
+
+
+@pytest.mark.parametrize("n", [0, 1, 2])
+def test_diff_append(n):
+    x = cupy.arange(5) + 1
+    a = da.from_array(x, chunks=2)
+    assert_eq(da.diff(a, n, append=0), cupy.diff(x, n, append=0))
+    assert_eq(da.diff(a, n, append=[0]), cupy.diff(x, n, append=[0]))
+    assert_eq(da.diff(a, n, append=[-1, 0]), cupy.diff(x, n, append=[-1, 0]))
+
+    x = cupy.arange(16).reshape(4, 4)
+    a = da.from_array(x, chunks=2)
+    assert_eq(da.diff(a, n, axis=1, append=0), cupy.diff(x, n, axis=1, append=0))
+    assert_eq(
+        da.diff(a, n, axis=1, append=[[0], [0], [0], [0]]),
+        cupy.diff(x, n, axis=1, append=[[0], [0], [0], [0]]),
+    )
+    assert_eq(da.diff(a, n, axis=0, append=0), cupy.diff(x, n, axis=0, append=0))
+    assert_eq(
+        da.diff(a, n, axis=0, append=[[0, 0, 0, 0]]),
+        cupy.diff(x, n, axis=0, append=[[0, 0, 0, 0]]),
+    )
+
+    if n > 0:
+        with pytest.raises(ValueError):
+            # When order is 0 the result is the icupyut array, it doesn't raise
+            # an error
+            da.diff(a, n, append=cupy.zeros((3, 3)))

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -518,6 +518,34 @@ def test_diff(shape, n, axis):
     assert_eq(da.diff(a, n, axis), np.diff(x, n, axis))
 
 
+@pytest.mark.parametrize("n", [0, 1, 2])
+def test_diff_prepend(n):
+    x = np.arange(5) + 1
+    a = da.from_array(x, chunks=2)
+    assert_eq(da.diff(a, n, prepend=0), np.diff(x, n, prepend=0))
+    assert_eq(da.diff(a, n, prepend=[0]), np.diff(x, n, prepend=[0]))
+    assert_eq(da.diff(a, n, prepend=[-1, 0]), np.diff(x, n, prepend=[-1, 0]))
+
+    x = np.arange(16).reshape(4, 4)
+    a = da.from_array(x, chunks=2)
+    assert_eq(da.diff(a, n, axis=1, prepend=0), np.diff(x, n, axis=1, prepend=0))
+    assert_eq(
+        da.diff(a, n, axis=1, prepend=[[0], [0], [0], [0]]),
+        np.diff(x, n, axis=1, prepend=[[0], [0], [0], [0]]),
+    )
+    assert_eq(da.diff(a, n, axis=0, prepend=0), np.diff(x, n, axis=0, prepend=0))
+    assert_eq(
+        da.diff(a, n, axis=0, prepend=[[0, 0, 0, 0]]),
+        np.diff(x, n, axis=0, prepend=[[0, 0, 0, 0]]),
+    )
+
+    if n > 0:
+        # When n == 0 the result is the input array, it doesn't raise
+        # an error
+        with pytest.raises(ValueError):
+            da.diff(a, n, prepend=np.zeros((3, 3)))
+
+
 @pytest.mark.parametrize("shape", [(10,), (10, 15)])
 @pytest.mark.parametrize("to_end, to_begin", [[None, None], [0, 0], [[1, 2], [3, 4]]])
 def test_ediff1d(shape, to_end, to_begin):

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -540,10 +540,37 @@ def test_diff_prepend(n):
     )
 
     if n > 0:
-        # When n == 0 the result is the input array, it doesn't raise
+        # When order is 0 the result is the input array, it doesn't raise
         # an error
         with pytest.raises(ValueError):
             da.diff(a, n, prepend=np.zeros((3, 3)))
+
+
+@pytest.mark.parametrize("n", [0, 1, 2])
+def test_diff_append(n):
+    x = np.arange(5) + 1
+    a = da.from_array(x, chunks=2)
+    assert_eq(da.diff(a, n, append=0), np.diff(x, n, append=0))
+    assert_eq(da.diff(a, n, append=[0]), np.diff(x, n, append=[0]))
+    assert_eq(da.diff(a, n, append=[-1, 0]), np.diff(x, n, append=[-1, 0]))
+
+    x = np.arange(16).reshape(4, 4)
+    a = da.from_array(x, chunks=2)
+    assert_eq(da.diff(a, n, axis=1, append=0), np.diff(x, n, axis=1, append=0))
+    assert_eq(
+        da.diff(a, n, axis=1, append=[[0], [0], [0], [0]]),
+        np.diff(x, n, axis=1, append=[[0], [0], [0], [0]]),
+    )
+    assert_eq(da.diff(a, n, axis=0, append=0), np.diff(x, n, axis=0, append=0))
+    assert_eq(
+        da.diff(a, n, axis=0, append=[[0, 0, 0, 0]]),
+        np.diff(x, n, axis=0, append=[[0, 0, 0, 0]]),
+    )
+
+    with pytest.raises(ValueError):
+        # When order is 0 the result is the input array, it doesn't raise
+        # an error
+        da.diff(a, n, append=np.zeros((3, 3)))
 
 
 @pytest.mark.parametrize("shape", [(10,), (10, 15)])

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -567,10 +567,11 @@ def test_diff_append(n):
         np.diff(x, n, axis=0, append=[[0, 0, 0, 0]]),
     )
 
-    with pytest.raises(ValueError):
-        # When order is 0 the result is the input array, it doesn't raise
-        # an error
-        da.diff(a, n, append=np.zeros((3, 3)))
+    if n > 0:
+        with pytest.raises(ValueError):
+            # When order is 0 the result is the input array, it doesn't raise
+            # an error
+            da.diff(a, n, append=np.zeros((3, 3)))
 
 
 def test_diff_negative_order():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -573,6 +573,11 @@ def test_diff_append(n):
         da.diff(a, n, append=np.zeros((3, 3)))
 
 
+def test_diff_negative_order():
+    with pytest.raises(ValueError):
+        da.diff(da.arange(10), -1)
+
+
 @pytest.mark.parametrize("shape", [(10,), (10, 15)])
 @pytest.mark.parametrize("to_end, to_begin", [[None, None], [0, 0], [[1, 2], [3, 4]]])
 def test_ediff1d(shape, to_end, to_begin):


### PR DESCRIPTION
Complements `dask.array.diff` implementation with `prepend`/`append` keyword arguments to match NumPy API more closely. Verify correct against NumPy and CuPy implementations.