### PR TITLE
Deprecate `daily_stock` utility

### DIFF
--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from ...highlevelgraph import HighLevelGraph
 from ...layers import DataFrameIOLayer
-from ...utils import random_state_data
+from ...utils import _deprecated, random_state_data
 from ..core import DataFrame, tokenize
 
 __all__ = ["make_timeseries"]
@@ -265,6 +265,7 @@ def generate_day(
     )
 
 
+@_deprecated()
 def daily_stock(
     symbol,
     start,

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -265,7 +265,7 @@ def generate_day(
     )
 
 
-@_deprecated()
+@_deprecated(use_instead="dask.datasets.timeseries for generating example DataFrames")
 def daily_stock(
     symbol,
     start,

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -6,7 +6,6 @@ import dask.dataframe as dd
 from dask.blockwise import Blockwise, optimize_blockwise
 from dask.dataframe._compat import tm
 from dask.dataframe.optimize import optimize_dataframe_getitem
-from dask.dataframe.utils import assert_eq
 
 
 def test_make_timeseries():
@@ -114,21 +113,10 @@ def test_no_overlaps():
 
 
 @pytest.mark.network
-def test_daily_stock():
+def test_daily_stock_deprecated():
     pytest.importorskip("pandas_datareader", minversion="0.10.0")
-    df = dd.demo.daily_stock("GOOG", start="2010-01-01", stop="2010-01-30", freq="1h")
-    assert isinstance(df, dd.DataFrame)
-    assert 10 < df.npartitions < 31
-    assert_eq(df, df)
-
-    # Check `optimize_blockwise`
-    df = df[["open", "close"]]
-    keys = [(df._name, i) for i in range(df.npartitions)]
-    graph = optimize_blockwise(df.__dask_graph__(), keys)
-    layers = graph.layers
-    name = list(layers.keys())[0]
-    assert len(layers) == 1
-    assert isinstance(layers[name], Blockwise)
+    with pytest.warns(FutureWarning, match="deprecated"):
+        dd.demo.daily_stock("GOOG", start="2010-01-01", stop="2010-01-30", freq="1h")
 
 
 def test_make_timeseries_keywords():


### PR DESCRIPTION
This PR proposes we deprecate and later remove the `daily_stock` demo utility which has recently been causing us some problems (xref https://github.com/dask/dask/pull/7858, https://github.com/dask/dask/pull/7939#issuecomment-887871090). I'm not sure how widely this is used, most examples I've seen recently use our `timeseries` utility