### PR TITLE
Use `loc` if needed for series `__get_item__`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3273,10 +3273,7 @@ Dask Name: {name}, {task} tasks""".format(
             dsk = partitionwise_graph(operator.getitem, name, self, key)
             graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self, key])
             return Series(graph, name, self._meta, self.divisions)
-        raise NotImplementedError(
-            "Series getitem is only supported for other series objects "
-            "with matching partition structure"
-        )
+        return self.loc[key]
 
     @derived_from(pd.DataFrame)
     def _get_numeric_data(self, how="any", subset=None):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3669,6 +3669,13 @@ def test_getitem_with_bool_dataframe_as_key():
     assert_eq(df[df > 3], ddf[ddf > 3])
 
 
+def test_getitem_with_non_series():
+    s = pd.Series(list(range(10)), index=list("abcdefghij"))
+    ds = dd.from_pandas(s, npartitions=3)
+
+    assert_eq(s[["a", "b"]], ds[["a", "b"]])
+
+
 def test_ipython_completion():
     df = pd.DataFrame({"a": [1], "b": [2]})
     ddf = dd.from_pandas(df, npartitions=1)


### PR DESCRIPTION
- [x] Closes #1279
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

This seems like a nice convenience method:

```python
import dask

ddf = dask.datasets.timeseries()
ddf.x["2000-01-02": "2000-01-04"]
```