### PR TITLE
Add deprecation warning for top-level `ucx` and `rmm` config values

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -549,6 +549,15 @@ deprecations = {
     "fuse_subgraphs": "optimization.fuse.subgraphs",
     "fuse_rename_keys": "optimization.fuse.rename-keys",
     "fuse_max_depth_new_edges": "optimization.fuse.max-depth-new-edges",
+    # See https://github.com/dask/distributed/pull/4916
+    "ucx.cuda_copy": "distributed.ucx.cuda_copy",
+    "ucx.tcp": "distributed.ucx.tcp",
+    "ucx.nvlink": "distributed.ucx.nvlink",
+    "ucx.infiniband": "distributed.ucx.infiniband",
+    "ucx.rdmacm": "distributed.ucx.rdmacm",
+    "ucx.net-devices": "distributed.ucx.net-devices",
+    "ucx.reuse-endpoints": "distributed.ucx.reuse-endpoints",
+    "rmm.pool-size": "distributed.rmm.pool-size",
 }
 
 


### PR DESCRIPTION
This is a follow-up to https://github.com/dask/distributed/pull/4916 where we moved the top-level `ucx` and `rmm` config values into the `distributed` namespace. With the changes here, users will be informed of this config name migration. See the conversation starting at https://github.com/dask/distributed/pull/4916#issuecomment-889270380

```
$ DASK_UCX__TCP="foo" python -c "import dask, distributed; print(dask.config.get('distributed.comm.ucx.tcp'))"
/Users/james/projects/dask/dask/dask/config.py:597: UserWarning: Configuration key "ucx.tcp" has been deprecated. Please use "distributed.ucx.tcp" instead
  warnings.warn(
False
```

cc @pentschev @charlesbluca 