### PR TITLE
Temporarily pin `pyarrow<5` in CI

### DIFF
--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -25,7 +25,8 @@ dependencies:
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
   # along with other issues https://github.com/pandas-dev/pandas/issues/40467
   - sqlalchemy<1.4.0
-  - pyarrow
+  # TODO: Remove pyarrow pinning once pyarrow=5 deprecations have been resolved
+  - pyarrow<5
   - jsonschema
   # other -- IO
   - bcolz

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -25,7 +25,8 @@ dependencies:
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
   # along with other issues https://github.com/pandas-dev/pandas/issues/40467
   - sqlalchemy<1.4.0
-  - pyarrow
+  # TODO: Remove pyarrow pinning once pyarrow=5 deprecations have been resolved
+  - pyarrow<5
   - coverage
   - jsonschema
   # other -- IO


### PR DESCRIPTION
This is just a temporary workaround the `pyarrow=5.0.0` release causing CI to fail