### PR TITLE
Allow pyarrow>=5 in to_parquet and read_parquet

### DIFF
--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -25,8 +25,7 @@ dependencies:
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
   # along with other issues https://github.com/pandas-dev/pandas/issues/40467
   - sqlalchemy<1.4.0
-  # TODO: Remove pyarrow pinning once pyarrow=5 deprecations have been resolved
-  - pyarrow<5
+  - pyarrow
   - jsonschema
   # other -- IO
   - bcolz

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -25,8 +25,7 @@ dependencies:
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
   # along with other issues https://github.com/pandas-dev/pandas/issues/40467
   - sqlalchemy<1.4.0
-  # TODO: Remove pyarrow pinning once pyarrow=5 deprecations have been resolved
-  - pyarrow<5
+  - pyarrow
   - coverage
   - jsonschema
   # other -- IO

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1708,6 +1708,32 @@ class ArrowDatasetEngine(Engine):
         )
         return arrow_table
 
+    @classmethod
+    def collect_file_metadata(cls, path, fs, file_path):
+        with fs.open(path, "rb") as f:
+            meta = pq.ParquetFile(f).metadata
+        if file_path:
+            meta.set_file_path(file_path)
+        return meta
+
+    @classmethod
+    def aggregate_metadata(cls, meta_list, fs, out_path):
+        meta = None
+        for _meta in meta_list:
+            if meta:
+                _append_row_groups(meta, _meta)
+            else:
+                meta = _meta
+        if out_path:
+            metadata_path = fs.sep.join([out_path, "_metadata"])
+            with fs.open(metadata_path, "wb") as fil:
+                if not meta:
+                    raise ValueError("Cannot write empty metdata!")
+                meta.write_metadata_file(fil)
+            return None
+        else:
+            return meta
+
 
 #
 #  PyArrow Legacy API [PyArrow<1.0.0]
@@ -2139,32 +2165,6 @@ class ArrowLegacyEngine(ArrowDatasetEngine):
             cls._parquet_piece_as_arrow,
             **kwargs,
         )
-
-    @classmethod
-    def collect_file_metadata(cls, path, fs, file_path):
-        with fs.open(path, "rb") as f:
-            meta = pq.ParquetFile(f).metadata
-        if file_path:
-            meta.set_file_path(file_path)
-        return meta
-
-    @classmethod
-    def aggregate_metadata(cls, meta_list, fs, out_path):
-        meta = None
-        for _meta in meta_list:
-            if meta:
-                _append_row_groups(meta, _meta)
-            else:
-                meta = _meta
-        if out_path:
-            metadata_path = fs.sep.join([out_path, "_metadata"])
-            with fs.open(metadata_path, "wb") as fil:
-                if not meta:
-                    raise ValueError("Cannot write empty metdata!")
-                meta.write_metadata_file(fil)
-            return None
-        else:
-            return meta
 
     @classmethod
     def multi_support(cls):

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -5,6 +5,7 @@ import tlz as toolz
 from fsspec.core import get_fs_token_paths
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.utils import stringify_path
+from packaging.version import parse as parse_version
 
 from ....base import tokenize
 from ....delayed import Delayed

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -919,7 +919,7 @@ def get_engine(engine):
         if engine in ("pyarrow", "arrow"):
             engine = "pyarrow-dataset"
         elif pa_version.major >= 5 and engine == "pyarrow-legacy":
-            raise ValueError(
+            warnings.warn(
                 "`ArrowLegacyEngine` ('pyarrow-legacy') is deprecated "
                 "for pyarrow>=5. Please use `engine='pyarrow'`."
             )

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -918,6 +918,19 @@ def get_engine(engine):
         if pa_version < parse_version("0.13.1"):
             raise RuntimeError("PyArrow version >= 0.13.1 required")
 
+        if pa_version.major >= 1 and engine in ("pyarrow", "arrow"):
+            engine = "pyarrow-dataset"
+        elif pa_version.major < 1 and engine == "pyarrow-datset":
+            raise ValueError(
+                "`ArrowDatasetEngine` ('pyarrow-dataset') requires "
+                "pyarrow>=1. Please use `engine='pyarrow'`."
+            )
+        elif pa_version.major >= 5 and engine == "pyarrow-legacy":
+            raise ValueError(
+                "`ArrowLegacyEngine` ('pyarrow-legacy') is deprecated "
+                "for pyarrow>=5. Please use `engine='pyarrow'`."
+            )
+
         if engine == "pyarrow-dataset" and pa_version.major >= 1:
             from .arrow import ArrowDatasetEngine
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -165,15 +165,12 @@ def read_parquet(
         Parquet reader library to use. Options include: 'auto', 'fastparquet',
         'pyarrow', 'pyarrow-dataset', and 'pyarrow-legacy'. Defaults to 'auto',
         which selects the FastParquetEngine if fastparquet is installed (and
-        ArrowLegacyEngine otherwise).  If 'pyarrow-dataset' is specified, the
-        ArrowDatasetEngine (which leverages the pyarrow.dataset API) will be used
-        for newer PyArrow versions (>=1.0.0). If 'pyarrow' or 'pyarrow-legacy' are
-        specified, the ArrowLegacyEngine will be used (which leverages the
-        pyarrow.parquet.ParquetDataset API).
-        NOTE: 'pyarrow-dataset' enables row-wise filtering, but requires
-        pyarrow>=1.0. The behavior of 'pyarrow' will most likely change to
-        ArrowDatasetEngine in a future release, and the 'pyarrow-legacy'
-        option will be deprecated once the ParquetDataset API is deprecated.
+        ArrowDatasetEngine otherwise).  If 'pyarrow' or 'pyarrow-dataset' is
+        specified, the ArrowDatasetEngine (which leverages the pyarrow.dataset
+        API) will be used. If 'pyarrow-legacy' is specified, ArrowLegacyEngine
+        will be used (which leverages the pyarrow.parquet.ParquetDataset API).
+        NOTE: The 'pyarrow-legacy' option (ArrowLegacyEngine) is deprecated
+        for pyarrow>=5.
     gather_statistics : bool, default None
         Gather the statistics for each dataset partition. By default,
         this will only be done if the _metadata file is available. Otherwise,
@@ -921,7 +918,8 @@ def get_engine(engine):
         elif pa_version.major >= 5 and engine == "pyarrow-legacy":
             warnings.warn(
                 "`ArrowLegacyEngine` ('pyarrow-legacy') is deprecated "
-                "for pyarrow>=5. Please use `engine='pyarrow'`."
+                "for pyarrow>=5. Please use `engine='pyarrow'`.",
+                FutureWarning,
             )
 
         if engine == "pyarrow-dataset":

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -15,8 +15,6 @@ import dask.dataframe as dd
 import dask.multiprocessing
 from dask.blockwise import Blockwise, optimize_blockwise
 from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_121, PANDAS_GT_130
-from dask.dataframe.io.parquet.arrow import ArrowDatasetEngine
-from dask.dataframe.io.parquet.core import get_engine
 from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.dataframe.optimize import optimize_dataframe_getitem
 from dask.dataframe.utils import assert_eq
@@ -172,8 +170,11 @@ else:
 
 @PYARROW_MARK
 def test_pyarrow_getengine():
+    from dask.dataframe.io.parquet.arrow import ArrowDatasetEngine
+    from dask.dataframe.io.parquet.core import get_engine
+
     # Check that the default engine for "pyarrow"/"arrow"
-    # is not the `pyarrow.dataset`-based engine
+    # is the `pyarrow.dataset`-based engine
     assert get_engine("pyarrow") == ArrowDatasetEngine
     assert get_engine("arrow") == ArrowDatasetEngine
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3012,7 +3012,10 @@ def test_pandas_timestamp_overflow_pyarrow(tmpdir):
         dd.read_parquet(str(tmpdir), engine="pyarrow").compute()
     assert "out of bounds" in str(e.value)
 
-    from dask.dataframe.io.parquet.arrow import ArrowEngine
+    if pa_version >= parse_version("5.0.0"):
+        from dask.dataframe.io.parquet.arrow import ArrowDatasetEngine as ArrowEngine
+    else:
+        from dask.dataframe.io.parquet.arrow import ArrowEngine
 
     class ArrowEngineWithTimestampClamp(ArrowEngine):
         @classmethod

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3388,7 +3388,7 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
     )
 
 
-@PYARROW_LE_MARK
+@PYARROW_MARK
 @pytest.mark.parametrize("partition_on", [None, "a"])
 @write_read_engines()
 def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
@@ -3412,7 +3412,7 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
         fns = glob.glob(os.path.join(tmpdir, "*.parquet"))
     dd.io.parquet.create_metadata_file(
         fns,
-        engine="pyarrow-legacy",
+        engine="pyarrow",
         split_every=3,  # Force tree reduction
     )
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2325,26 +2325,10 @@ def test_timeseries_nulls_in_schema(tmpdir, engine, schema):
 
     # Note: `append_row_groups` will fail with pyarrow>0.17.1 for _metadata write
     dataset = {"validate_schema": False}
-    engine_use = engine
-    # if schema != "infer" and engine.startswith("pyarrow"):
-    #    engine_use = "pyarrow-legacy"
-    ddf2.to_parquet(
-        tmp_path, engine=engine_use, write_metadata_file=False, schema=schema
-    )
-    ddf_read = dd.read_parquet(tmp_path, engine=engine_use, dataset=dataset)
+    ddf2.to_parquet(tmp_path, engine=engine, write_metadata_file=False, schema=schema)
+    ddf_read = dd.read_parquet(tmp_path, engine=engine, dataset=dataset)
 
     assert_eq(ddf_read, ddf2, check_divisions=False, check_index=False)
-
-    # # Can force schema validation on each partition in pyarrow
-    # if engine.startswith("pyarrow") and schema is None:
-    #     dataset = {"validate_schema": True}
-    #     engine_use = engine
-    #     if schema != "infer":
-    #         engine_use = "pyarrow-legacy"
-    #     # The schema mismatch should raise an error if the
-    #     # dataset was written with `schema=None` (no inference)
-    #     with pytest.raises(ValueError):
-    #         ddf_read = dd.read_parquet(tmp_path, dataset=dataset, engine=engine_use)
 
 
 @PYARROW_MARK

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -15,6 +15,8 @@ import dask.dataframe as dd
 import dask.multiprocessing
 from dask.blockwise import Blockwise, optimize_blockwise
 from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_121, PANDAS_GT_130
+from dask.dataframe.io.parquet.arrow import ArrowDatasetEngine
+from dask.dataframe.io.parquet.core import get_engine
 from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.dataframe.optimize import optimize_dataframe_getitem
 from dask.dataframe.utils import assert_eq
@@ -166,6 +168,18 @@ if (
 else:
     fp_pandas_msg = "pandas with fastparquet engine does not preserve index"
     fp_pandas_xfail = write_read_engines()
+
+
+@PYARROW_MARK
+def test_pyarrow_getengine():
+    # Check that the default engine for "pyarrow"/"arrow"
+    # is not the `pyarrow.dataset`-based engine
+    assert get_engine("pyarrow") == ArrowDatasetEngine
+    assert get_engine("arrow") == ArrowDatasetEngine
+
+    if SKIP_PYARROW_LE:
+        with pytest.raises(FutureWarning):
+            get_engine("pyarrow-legacy")
 
 
 @write_read_engines()


### PR DESCRIPTION
This PR changes operations like `ddf.to_parquet(..., engine="pyarrow")` and  `dd.read_parquet(..., engine="pyarrow")` to use `ArrowDatasetEngine` by default (for pyarrow>1).  This also add a `ValueError` when the user specifically request `engine="pyarrow-legacy"` for pyarrow>=5.

- [x] Closes #7961
- [x] Closes #7871
