### PR TITLE
Avoid using Delayed in to_csv and to_parquet

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -923,7 +923,9 @@ def to_csv(
         if scheduler is not None and compute_kwargs.get("scheduler") is None:
             compute_kwargs["scheduler"] = scheduler
 
-        delayed(values).compute(**compute_kwargs)
+        import dask
+
+        dask.compute(*values, **compute_kwargs)
         return [f.path for f in files]
     else:
         return values

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -711,6 +711,11 @@ def to_parquet(
             {"append": append, "compression": compression},
         )
     else:
+        if compute:
+            import dask
+
+            dask.compute(*part_tasks, **{compute_kwargs or {}})
+            return
         dsk[(final_name, 0)] = (lambda x: None, part_tasks)
 
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[df])


### PR DESCRIPTION
This accomplishes two things:

1.  Lets dataframe optimizations through
2.  Avoids a final synchronization point in the graph
    which improves scheduling heuristics

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
