### PR TITLE
Fix slicing Dask arrays with NumPy array of ndim=0

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -231,10 +231,10 @@ def slice_wrap_lists(out_name, in_name, blockdims, index, itemsize):
     if not len(blockdims) == len(index):
         raise IndexError("Too many indices for array")
 
+    # Handle 0-d arrays, e.g. np.array(0)
+    index = [int(ind) if is_arraylike(ind) and ind.ndim == 0 else ind for ind in index]
     # Do we have more than one list in the index?
-    where_list = [
-        i for i, ind in enumerate(index) if is_arraylike(ind) and ind.ndim > 0
-    ]
+    where_list = [i for i, ind in enumerate(index) if is_arraylike(ind)]
     if len(where_list) > 1:
         raise NotImplementedError("Don't yet support nd fancy indexing")
     # Is the single list an empty list? In this case just treat it as a zero

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -1064,3 +1064,23 @@ def test_slice_array_3d_with_bool_numpy_array():
     actual = array[mask].compute()
     expected = np.arange(13, 24)
     assert_eq(actual, expected)
+
+
+def test_slicing_with_0d_numpy_arrays():
+    x = da.arange(10)
+    x_np = np.arange(10)
+
+    actual = x[np.array(0)]
+    expected = x_np[np.array(0)]
+    assert_eq(actual, expected)
+
+    y = da.arange(25).reshape((5, 5))
+    y_np = np.arange(25).reshape((5, 5))
+
+    actual = y[np.array(1), np.array(2)]
+    expected = y_np[np.array(1), np.array(2)]
+    assert_eq(actual, expected)
+
+    actual = y[[2, 3], np.array(4)]
+    expected = y_np[[2, 3], np.array(4)]
+    assert_eq(actual, expected)


### PR DESCRIPTION
- [x] Closes #7951 
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

In addition to error described in #7951, this PR also fixes the following case which is caused by [this](https://github.com/dask/dask/blob/d3bf07cec0b77c37b3ec1c8c30a3ae0cf00a993a/dask/array/slicing.py#L253) line.
```python
In [1]: import dask.array as da

In [2]: import numpy as np

In [3]: x_np = np.arange(9).reshape((3, 3))

In [4]: x = da.from_array(x_np)

In [5]: x[[0], np.array(0)].compute()   # Slicing Dask array 
Out[5]: array([[0, 1, 2]])  # returns the first row in an array

In [6]: x_np[[0], np.array(0)]   # Slicing NumPy array
Out[6]: array([0])  # returns the element at (0, 0) in an array
```