### PR TITLE
Add back pyarrow-legacy test coverage for pyarrow>=5

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -917,8 +917,9 @@ def get_engine(engine):
             engine = "pyarrow-dataset"
         elif pa_version.major >= 5 and engine == "pyarrow-legacy":
             warnings.warn(
-                "`ArrowLegacyEngine` ('pyarrow-legacy') is deprecated "
-                "for pyarrow>=5. Please use `engine='pyarrow'`.",
+                "`ArrowLegacyEngine` ('pyarrow-legacy') is deprecated for "
+                "pyarrow>=5 and will be removed in a future release. Please "
+                "use `engine='pyarrow'` or `engine='pyarrow-dataset'`.",
                 FutureWarning,
             )
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -66,7 +66,7 @@ SKIP_PYARROW_DS = SKIP_PYARROW
 SKIP_PYARROW_DS_REASON = "pyarrow not found"
 if pa_version.major >= 5 and not SKIP_PYARROW:
     # NOTE: We should use PYARROW_LE_MARK to skip
-    # pyarrow-legacy tests one pyarrow officially
+    # pyarrow-legacy tests once pyarrow officially
     # removes ParquetDataset support in the future.
     PYARROW_LE_MARK = pytest.mark.filterwarnings(
         "ignore::DeprecationWarning",

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -64,11 +64,16 @@ SKIP_PYARROW_LE = SKIP_PYARROW
 SKIP_PYARROW_LE_REASON = "pyarrow not found"
 SKIP_PYARROW_DS = SKIP_PYARROW
 SKIP_PYARROW_DS_REASON = "pyarrow not found"
-if pa and pa_version.major >= 5:
-    SKIP_PYARROW_LE = True
-    SKIP_PYARROW_LE_REASON = "pyarrow < 5.0.0 required for pyarrow legacy API"
-PYARROW_LE_MARK = pytest.mark.skipif(SKIP_PYARROW_LE, reason=SKIP_PYARROW_LE_REASON)
-
+if pa_version.major >= 5 and not SKIP_PYARROW:
+    # NOTE: We should use PYARROW_LE_MARK to skip
+    # pyarrow-legacy tests one pyarrow officially
+    # removes ParquetDataset support in the future.
+    PYARROW_LE_MARK = pytest.mark.filterwarnings(
+        "ignore::DeprecationWarning",
+        "ignore::FutureWarning",
+    )
+else:
+    PYARROW_LE_MARK = pytest.mark.skipif(SKIP_PYARROW_LE, reason=SKIP_PYARROW_LE_REASON)
 PYARROW_DS_MARK = pytest.mark.skipif(SKIP_PYARROW_DS, reason=SKIP_PYARROW_DS_REASON)
 
 ANY_ENGINE_MARK = pytest.mark.skipif(


### PR DESCRIPTION
This PR addresses the [discussion](https://github.com/dask/dask/pull/7967#issuecomment-891997484) in #7967 - Since it is still possible to use the "pyarrow-legacy" engine in parquet, it seems clear that we still need test coverage for this engine (even if it is "deprecated").
