### PR TITLE
TST: use pytest.warns instead of raises for checking parquet engine deprecation

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -184,7 +184,7 @@ def test_pyarrow_getengine():
     assert get_engine("arrow") == ArrowDatasetEngine
 
     if SKIP_PYARROW_LE:
-        with pytest.raises(FutureWarning):
+        with pytest.warns(FutureWarning):
             get_engine("pyarrow-legacy")
 
 


### PR DESCRIPTION
cc @jrbourbeau @rjzamora 

Since dask is forcing all warnings to errors, this is equivalent, but `pytest.warns` works as well and fits more the intent (it's a warning that is being tested and not an error). 
Now, if there is a general practice to use `pytest.raises` in dask, this patch is certainly not needed (but it seems `pytest.warns` is used as well). This was causing a failure in pyarrow's nightly integration builds (we only run a subset, and are apparently not picking up the setup.cfg configs), but I can also fix it there by passing the appropriate flags if needed.