### PR TITLE
Mark gpuCI CuPy test as flaky

### DIFF
--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -1574,7 +1574,13 @@ def test_setitem_extended_API_1d():
                 reason="Unsupported assigning `list` to CuPy array",
             ),
         ),
-        [(slice(None), [9, 8, 8]), [-80, -81, 91]],
+        pytest.param(
+            (slice(None), [9, 8, 8]),
+            [[-80, -81, 91]],
+            marks=pytest.mark.xfail(
+                reason="Flaky test on gpuCI",
+            ),
+        ),
         [([True, False, False, False, True, False], 2), -1],
         [(3, [True, True, False, True, True, False, True, False, True, True]), -1],
         [(np.array([False, False, True, True, False, False]), slice(5, 7)), -1],

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -1577,9 +1577,7 @@ def test_setitem_extended_API_1d():
         pytest.param(
             (slice(None), [9, 8, 8]),
             [[-80, -81, 91]],
-            marks=pytest.mark.xfail(
-                reason="Flaky test on gpuCI",
-            ),
+            marks=pytest.mark.flaky(reruns=10),
         ),
         [([True, False, False, False, True, False], 2), -1],
         [(3, [True, True, False, True, True, False, True, False, True, True]), -1],


### PR DESCRIPTION
There is a flaky CuPy test on gpuCI, initially noticed in https://github.com/dask/dask/pull/7982#issuecomment-891656571, but seen again in [a recent build](https://gpuci.gpuopenanalytics.com/job/dask/job/dask/job/prb/job/dask-prb/75/testReport/).