### PR TITLE
Ensure we error on warnings from `distributed`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ filterwarnings =
     error:::dask[.*]
     error:::pandas[.*]
     error:::numpy[.*]
-    error:::distributed[.*]]
+    error:::distributed[.*]
 xfail_strict=true
 
 [metadata]


### PR DESCRIPTION
There's an extra `]` character which is causing warnings coming from `distributed` to not be elevated to errors. This PR removes the extra `]`.