### PR TITLE
Use random integers in `timeseries` demo

### DIFF
--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -119,6 +119,48 @@ def test_daily_stock_deprecated():
         dd.demo.daily_stock("GOOG", start="2010-01-01", stop="2010-01-30", freq="1h")
 
 
+# TODO: Remove this test when we remove support for poisson integers
+def test_make_timeseries_keywords_old():
+    with pytest.warns(FutureWarning):
+        df = dd.demo.make_timeseries(
+            "2000",
+            "2001",
+            {"A": int, "B": int, "C": str},
+            freq="1D",
+            partition_freq="6M",
+            A_lam=1000000,
+            B_lam=2,
+        )
+        a_cardinality = df.A.nunique()
+        b_cardinality = df.B.nunique()
+
+        aa, bb = dask.compute(a_cardinality, b_cardinality, scheduler="single-threaded")
+
+        assert 100 < aa <= 10000000
+        assert 1 < bb <= 100
+
+
+# TODO: Remove this test when we remove support for poisson integers
+def test_make_timeseries_fancy_keywords_old():
+    with pytest.warns(FutureWarning):
+        df = dd.demo.make_timeseries(
+            "2000",
+            "2001",
+            {"A_B": int, "B_": int, "C": str},
+            freq="1D",
+            partition_freq="6M",
+            A_B_lam=1000000,
+            B__lam=2,
+        )
+        a_cardinality = df.A_B.nunique()
+        b_cardinality = df.B_.nunique()
+
+        aa, bb = dask.compute(a_cardinality, b_cardinality, scheduler="single-threaded")
+
+        assert 100 < aa <= 10000000
+        assert 1 < bb <= 100
+
+
 def test_make_timeseries_keywords():
     df = dd.demo.make_timeseries(
         "2000",
@@ -126,16 +168,18 @@ def test_make_timeseries_keywords():
         {"A": int, "B": int, "C": str},
         freq="1D",
         partition_freq="6M",
-        A_lam=1000000,
-        B_lam=2,
+        A_low=5,
+        A_high=10,
+        B_low=20,
+        B_high=25,
     )
-    a_cardinality = df.A.nunique()
-    b_cardinality = df.B.nunique()
 
-    aa, bb = dask.compute(a_cardinality, b_cardinality, scheduler="single-threaded")
+    a_min, a_max, b_min, b_max = dask.compute(
+        df.A.min(), df.A.max(), df.B.min(), df.B.max(), scheduler="single-threaded"
+    )
 
-    assert 100 < aa <= 10000000
-    assert 1 < bb <= 100
+    assert 5 <= a_min <= a_max < 10
+    assert 20 <= b_min <= b_max < 25
 
 
 def test_make_timeseries_fancy_keywords():
@@ -145,16 +189,22 @@ def test_make_timeseries_fancy_keywords():
         {"A_B": int, "B_": int, "C": str},
         freq="1D",
         partition_freq="6M",
-        A_B_lam=1000000,
-        B__lam=2,
+        A_B_low=5,
+        A_B_high=10,
+        B__low=20,
+        B__high=25,
     )
-    a_cardinality = df.A_B.nunique()
-    b_cardinality = df.B_.nunique()
 
-    aa, bb = dask.compute(a_cardinality, b_cardinality, scheduler="single-threaded")
+    a_min, a_max, b_min, b_max = dask.compute(
+        df.A_B.min(),
+        df.A_B.max(),
+        df.B_.min(),
+        df.B_.max(),
+        scheduler="single-threaded",
+    )
 
-    assert 100 < aa <= 10000000
-    assert 1 < bb <= 100
+    assert 5 <= a_min <= a_max < 10
+    assert 20 <= b_min <= b_max < 25
 
 
 def test_make_timeseries_getitem_compute():

--- a/dask/datasets.py
+++ b/dask/datasets.py
@@ -48,7 +48,7 @@ def timeseries(
     ...     '2000', '2010',
     ...     freq='2H', partition_freq='1D', seed=1,  # data frequency
     ...     dtypes={'value': float, 'name': str, 'id': int},  # data types
-    ...     id_lam=1000  # control number of items in id column
+    ...     id_high=1000  # control range of items in id column
     ... )
     """
     from dask.dataframe.io.demo import make_timeseries


### PR DESCRIPTION
I was putting together a demo using our `timeseries` utility and noticed generating random integers can take a significant amount of time -- especially when generating a DataFrame with many columns. After digging in a bit deeper, this is because we're generating integers from a Poisson distribution

https://github.com/dask/dask/blob/da2458250d4fcd8f1a99458778de536a667224a2/dask/dataframe/io/demo.py#L16-L17

which can be an order of magnitude slower than from, for example, a uniform distribution:

```python
In [1]: import numpy as np

In [2]: rstate = np.random.RandomState(2)

In [3]: %timeit rstate.poisson(1_000, size=86_400)   # 86_400 is the default partition size for `timeseries`
5.39 ms ± 41.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [4]: %timeit rstate.randint(low=0, high=1e9, size=86_400)
395 µs ± 1.98 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [5]: 5.39e3 / 395
Out[5]: 13.645569620253164
```

This PR proposes we switch to using a uniform distribution for generating random integers. 

cc @rjzamora who has recently worked with our `timeseries` utility