### PR TITLE
Resolve warning in `distributed` tests

### DIFF
--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -610,7 +610,12 @@ def test_map_partitions_df_input():
         ).compute()
 
     with distributed.LocalCluster(
-        scheduler_port=0, asynchronous=False, n_workers=1, nthreads=1, processes=False
+        scheduler_port=0,
+        dashboard_address=":0",
+        asynchronous=False,
+        n_workers=1,
+        nthreads=1,
+        processes=False,
     ) as cluster:
         with distributed.Client(cluster, asynchronous=False):
             main()


### PR DESCRIPTION
This is a small follow-up to https://github.com/dask/dask/pull/8002