### PR TITLE
Add  ignore_metadata_file option to read_parquet (pyarrow-dataset and fastparquet support only)

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1045,7 +1045,7 @@ class ArrowDatasetEngine(Engine):
             paths = fs.sep.join([base, fns[0]])
 
             meta_path = fs.sep.join([paths, "_metadata"])
-            if fs.exists(meta_path) and not ignore_metadata_file:
+            if not ignore_metadata_file and fs.exists(meta_path):
                 # Use _metadata file
                 ds = pa_ds.parquet_dataset(
                     meta_path,

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -521,12 +521,16 @@ class ArrowDatasetEngine(Engine):
         read_from_paths=None,
         chunksize=None,
         aggregate_files=None,
+        ignore_metadata_file=False,
         **kwargs,
     ):
         # Gather necessary metadata information. This includes
         # the schema and (parquet) partitioning information.
         # This may also set split_row_groups and gather_statistics,
         # depending on _metadata availability.
+        dataset_kwargs = kwargs.get("dataset", {})
+        if ignore_metadata_file:
+            dataset_kwargs["ignore_metadata_file"] = ignore_metadata_file
         (
             schema,
             metadata,
@@ -541,7 +545,7 @@ class ArrowDatasetEngine(Engine):
             gather_statistics,
             filters,
             index,
-            kwargs.get("dataset", {}),
+            dataset_kwargs,
         )
 
         # Process metadata to define `meta` and `index_cols`
@@ -1750,6 +1754,10 @@ class ArrowDatasetEngine(Engine):
 def _get_dataset_object(paths, fs, filters, dataset_kwargs):
     """Generate a ParquetDataset object"""
     kwargs = dataset_kwargs.copy()
+    ignore_metadata_file = kwargs.pop("ignore_metadata_file", False)
+    if ignore_metadata_file:
+        raise ValueError("ignore_metadata_file not supported for ArrowLegacyEngine.")
+
     if "validate_schema" not in kwargs:
         kwargs["validate_schema"] = False
     if len(paths) > 1:

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -178,7 +178,7 @@ def read_parquet(
         statistics will only be gathered if True, because the footer of
         every file will be parsed (which is very slow on some systems).
     ignore_metadata_file : bool, default False
-        Whether to ignore the global _metadata file (when one is present).
+        Whether to ignore the global ``_metadata`` file (when one is present).
     split_row_groups : bool or int, default None
         Default is True if a _metadata file is available or if
         the dataset is composed of a single file (otherwise defult is False).

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -104,6 +104,7 @@ def read_parquet(
     storage_options=None,
     engine="auto",
     gather_statistics=None,
+    ignore_metadata_file=False,
     split_row_groups=None,
     read_from_paths=None,
     chunksize=None,
@@ -176,6 +177,8 @@ def read_parquet(
         this will only be done if the _metadata file is available. Otherwise,
         statistics will only be gathered if True, because the footer of
         every file will be parsed (which is very slow on some systems).
+    ignore_metadata_file : bool, default False
+        Whether to ignore the global _metadata file (when one is present).
     split_row_groups : bool or int, default None
         Default is True if a _metadata file is available or if
         the dataset is composed of a single file (otherwise defult is False).
@@ -259,6 +262,7 @@ def read_parquet(
             storage_options=storage_options,
             engine=engine,
             gather_statistics=gather_statistics,
+            ignore_metadata_file=ignore_metadata_file,
             split_row_groups=split_row_groups,
             read_from_paths=read_from_paths,
             chunksize=chunksize,
@@ -279,6 +283,7 @@ def read_parquet(
         storage_options,
         engine,
         gather_statistics,
+        ignore_metadata_file,
         split_row_groups,
         read_from_paths,
         chunksize,
@@ -321,6 +326,7 @@ def read_parquet(
         read_from_paths=read_from_paths,
         chunksize=chunksize,
         aggregate_files=aggregate_files,
+        ignore_metadata_file=ignore_metadata_file,
         **kwargs,
     )
 

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -724,8 +724,16 @@ class FastParquetEngine(Engine):
         split_row_groups=True,
         chunksize=None,
         aggregate_files=None,
+        ignore_metadata_file=False,
         **kwargs,
     ):
+        # Check if user has specified ignore_metadata_file=True
+        # (not supported for now)
+        if ignore_metadata_file:
+            raise ValueError(
+                "ignore_metadata_file not supported for FastParquetEngine."
+            )
+
         # Define the parquet-file (pf) object to use for metadata,
         # Also, initialize `parts`.  If `parts` is populated here,
         # then each part will correspond to a file.  Otherwise, each part will

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -158,14 +158,17 @@ def _determine_pf_parts(fs, paths, gather_statistics, ignore_metadata_file, **kw
         # This is a directory.
         # Check if _metadata and/or _common_metadata files exists
         base = paths[0]
-        _metadata_exists = fs.isfile(fs.sep.join([base, "_metadata"]))
-        _common_metadata_exists = fs.isfile(fs.sep.join([base, "_common_metadata"]))
+        _metadata_exists = _common_metadata_exists = True
+        if not ignore_metadata_file:
+            _metadata_exists = fs.isfile(fs.sep.join([base, "_metadata"]))
+            _common_metadata_exists = fs.isfile(fs.sep.join([base, "_common_metadata"]))
 
         # Find all files if we are not using a _metadata file
         if ignore_metadata_file or not _metadata_exists:
             # For now, we need to discover every file under paths[0]
             paths, base, fns = _sort_and_analyze_paths(fs.find(base), fs)
-            if _metadata_exists:
+            _common_metadata_exists = "_common_metadata" in fns
+            if "_metadata" in fns:
                 fns.remove("_metadata")
                 paths = [fs.sep.join([base, fn]) for fn in fns]
             _metadata_exists = False

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -107,7 +107,7 @@ paths_to_cats = (
 )
 
 
-def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
+def _determine_pf_parts(fs, paths, gather_statistics, ignore_metadata_file, **kwargs):
     """Determine how to access metadata and break read into ``parts``
 
     This logic is mostly to handle `gather_statistics=False` cases,
@@ -118,21 +118,30 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
     parts = []
     if len(paths) > 1:
         paths, base, fns = _sort_and_analyze_paths(paths, fs)
+
+        # Check if _metadata is in paths, and
+        # remove it if ignore_metadata_file=True
+        _metadata_exists = "_metadata" in fns
+        if _metadata_exists and ignore_metadata_file:
+            fns.remove("_metadata")
+            paths = [fs.sep.join([base, fn]) for fn in fns]
+            _metadata_exists = False
+
         if gather_statistics is not False:
             # This scans all the files, allowing index/divisions
             # and filtering
-            if "_metadata" not in fns:
-                paths_use = paths
+            if _metadata_exists:
+                paths_use = fs.sep.join([base, "_metadata"])
             else:
-                paths_use = base + fs.sep + "_metadata"
+                paths_use = paths
             pf = ParquetFile(
                 paths_use, open_with=fs.open, sep=fs.sep, **kwargs.get("file", {})
             )
         else:
-            if "_metadata" in fns:
+            if _metadata_exists:
                 # We have a _metadata file, lets use it
                 pf = ParquetFile(
-                    base + fs.sep + "_metadata",
+                    fs.sep.join([base, "_metadata"]),
                     open_with=fs.open,
                     sep=fs.sep,
                     **kwargs.get("file", {}),
@@ -146,13 +155,25 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
                 pf.cats = paths_to_cats(fns, scheme)
                 parts = paths.copy()
     elif fs.isdir(paths[0]):
-        # This is a directory, check for _metadata, then _common_metadata
-        paths = fs.glob(paths[0] + fs.sep + "*")
-        paths, base, fns = _sort_and_analyze_paths(paths, fs)
-        if "_metadata" in fns:
+        # This is a directory.
+        # Check if _metadata and/or _common_metadata files exists
+        base = paths[0]
+        _metadata_exists = fs.isfile(fs.sep.join([base, "_metadata"]))
+        _common_metadata_exists = fs.isfile(fs.sep.join([base, "_common_metadata"]))
+
+        # Find all files if we are not using a _metadata file
+        if ignore_metadata_file or not _metadata_exists:
+            # For now, we need to discover every file under paths[0]
+            paths, base, fns = _sort_and_analyze_paths(fs.find(base), fs)
+            if _metadata_exists:
+                fns.remove("_metadata")
+                paths = [fs.sep.join([base, fn]) for fn in fns]
+            _metadata_exists = False
+
+        if _metadata_exists:
             # Using _metadata file (best-case scenario)
             pf = ParquetFile(
-                base + fs.sep + "_metadata",
+                fs.sep.join([base, "_metadata"]),
                 open_with=fs.open,
                 sep=fs.sep,
                 **kwargs.get("file", {}),
@@ -166,9 +187,9 @@ def _determine_pf_parts(fs, paths, gather_statistics, **kwargs):
         else:
             # Use _common_metadata file if it is available.
             # Otherwise, just use 0th file
-            if "_common_metadata" in fns:
+            if _common_metadata_exists:
                 pf = ParquetFile(
-                    base + fs.sep + "_common_metadata",
+                    fs.sep.join([base, "_common_metadata"]),
                     open_with=fs.open,
                     **kwargs.get("file", {}),
                 )
@@ -727,19 +748,16 @@ class FastParquetEngine(Engine):
         ignore_metadata_file=False,
         **kwargs,
     ):
-        # Check if user has specified ignore_metadata_file=True
-        # (not supported for now)
-        if ignore_metadata_file:
-            raise ValueError(
-                "ignore_metadata_file not supported for FastParquetEngine."
-            )
-
         # Define the parquet-file (pf) object to use for metadata,
         # Also, initialize `parts`.  If `parts` is populated here,
         # then each part will correspond to a file.  Otherwise, each part will
         # correspond to a row group (populated below).
         parts, pf, gather_statistics, base_path = _determine_pf_parts(
-            fs, paths, gather_statistics, **kwargs
+            fs,
+            paths,
+            gather_statistics,
+            ignore_metadata_file,
+            **kwargs,
         )
 
         # Process metadata to define `meta` and `index_cols`

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3589,13 +3589,13 @@ def test_custom_metadata(tmpdir, engine):
     assert "User-defined key/value" in str(e.value)
 
 
-@pytest.mark.parametrize("gather_statistics", [True, None])
+@pytest.mark.parametrize("gather_statistics", [True, False])
 def test_ignore_metadata_file(tmpdir, engine, gather_statistics):
     tmpdir = str(tmpdir)
     df = pd.DataFrame({"a": range(100), "b": ["dog", "cat"] * 50})
     ddf1 = dd.from_pandas(df, npartitions=2)
     ddf1.to_parquet(path=tmpdir, engine=engine)
-    if engine == "pyarrow-dataset":
+    if engine != "pyarrow-legacy":
         ddf2 = dd.read_parquet(
             tmpdir,
             engine=engine,
@@ -3603,7 +3603,7 @@ def test_ignore_metadata_file(tmpdir, engine, gather_statistics):
             gather_statistics=gather_statistics,
         )
 
-        if gather_statistics is None:
+        if gather_statistics is False:
             # Should not have known divisions if gather_statistics=None
             # Otherwise, we must have used a _metadata file
             assert set(ddf2.divisions) == {None}

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3589,7 +3589,6 @@ def test_custom_metadata(tmpdir, engine):
     assert "User-defined key/value" in str(e.value)
 
 
-@PYARROW_MARK
 @pytest.mark.parametrize("gather_statistics", [True, None])
 def test_ignore_metadata_file(tmpdir, engine, gather_statistics):
     tmpdir = str(tmpdir)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1264,12 +1264,12 @@ def test_partition_on(tmpdir, engine):
         tmpdir, engine=engine, index=False, gather_statistics=False
     ).compute()
     for val in df.a1.unique():
-        assert set(df.b[df.a1 == val]) == set(out.b[out.a1 == val])
+        assert set(df.d[df.a1 == val]) == set(out.d[out.a1 == val])
 
     # Now specify the columns and allow auto-index detection
-    out = dd.read_parquet(tmpdir, engine=engine, columns=["b", "a2"]).compute()
+    out = dd.read_parquet(tmpdir, engine=engine, columns=["d", "a2"]).compute()
     for val in df.a2.unique():
-        assert set(df.b[df.a2 == val]) == set(out.b[out.a2 == val])
+        assert set(df.d[df.a2 == val]) == set(out.d[out.a2 == val])
 
 
 def test_partition_on_duplicates(tmpdir, engine):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1,7 +1,6 @@
 import glob
 import math
 import os
-import shutil
 import sys
 import warnings
 from decimal import Decimal
@@ -3593,14 +3592,8 @@ def test_custom_metadata(tmpdir, engine):
 @pytest.mark.parametrize("gather_statistics", [True, False, None])
 def test_ignore_metadata_file(tmpdir, engine, gather_statistics):
     tmpdir = str(tmpdir)
-    other_dataset = os.path.join(tmpdir, "data0")
     dataset_with_bad_metadata = os.path.join(tmpdir, "data1")
     dataset_without_metadata = os.path.join(tmpdir, "data2")
-
-    # Write a reference dataset with a "bad" _metadata file
-    df0 = pd.DataFrame({"c": range(20), "d": ["fox", "bird"] * 10})
-    ddf0 = dd.from_pandas(df0, npartitions=1)
-    ddf0.to_parquet(path=other_dataset, engine=engine, write_metadata_file=True)
 
     # Write two identical datasets without any _metadata file
     df1 = pd.DataFrame({"a": range(100), "b": ["dog", "cat"] * 50})
@@ -3614,10 +3607,8 @@ def test_ignore_metadata_file(tmpdir, engine, gather_statistics):
 
     # Copy "bad" metadata into `dataset_with_bad_metadata`
     assert "_metadata" not in os.listdir(dataset_with_bad_metadata)
-    shutil.copyfile(
-        os.path.join(other_dataset, "_metadata"),
-        os.path.join(dataset_with_bad_metadata, "_metadata"),
-    )
+    with open(os.path.join(dataset_with_bad_metadata, "_metadata"), "w") as f:
+        f.write("BAD _METADATA.")
     assert "_metadata" in os.listdir(dataset_with_bad_metadata)
     assert "_metadata" not in os.listdir(dataset_without_metadata)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3608,7 +3608,7 @@ def test_ignore_metadata_file(tmpdir, engine, gather_statistics):
     # Copy "bad" metadata into `dataset_with_bad_metadata`
     assert "_metadata" not in os.listdir(dataset_with_bad_metadata)
     with open(os.path.join(dataset_with_bad_metadata, "_metadata"), "w") as f:
-        f.write("BAD _METADATA.")
+        f.write("INVALID METADATA")
     assert "_metadata" in os.listdir(dataset_with_bad_metadata)
     assert "_metadata" not in os.listdir(dataset_without_metadata)
 


### PR DESCRIPTION
May address #8030

This PR makes it possible to ignore a global _metadata file using the `ignore_metadata_file` argument:

```python
ddf = dd.read_parquet(
    path,
    engine="pyarrow-dataset",
    ignore_metadata_file=True,
)
```

~Note that I did not add support for fastparquet or pyarrow-legacy (they will both raise an error if `ignore_metadata_file=True`), only because it is much trickier to implement for those engines (and because the pyarrow-legacy engine will be deprecated soon anyway).~

**EDIT**: This PR now adds `ignore_metadata_file` support for both "pyarrow-datset" **and** "fastparquet".  The "pyarrow-legacy" case still doesn't make much sense because: (1) it is deprecated, and (2) the engine will still construct a proxy _metadata file anyway.
