### PR TITLE
Fix `to_orc` delayed compute behavior

### DIFF
--- a/dask/dataframe/io/orc/core.py
+++ b/dask/dataframe/io/orc/core.py
@@ -207,7 +207,7 @@ def to_orc(
         write_index,
         storage_options,
     )
-    final_name = "final-" + name
+    final_name = name + "-final"
     part_tasks = []
     for d, filename in enumerate(filenames):
         part_tasks.append((name, d))

--- a/dask/dataframe/io/orc/core.py
+++ b/dask/dataframe/io/orc/core.py
@@ -208,10 +208,8 @@ def to_orc(
         storage_options,
     )
     final_name = name + "-final"
-    part_tasks = []
     for d, filename in enumerate(filenames):
-        part_tasks.append((name, d))
-        dsk[part_tasks[-1]] = (
+        dsk[(name, d)] = (
             apply,
             engine.write_partition,
             [
@@ -221,6 +219,7 @@ def to_orc(
                 filename,
             ],
         )
+    part_tasks = list(dsk.keys())
     dsk[(final_name, 0)] = (lambda x: None, part_tasks)
     graph = HighLevelGraph.from_collections((final_name, 0), dsk, dependencies=[df])
 

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -144,6 +144,10 @@ def test_orc_aggregate_files_offset(orc_files):
     assert len(df2.partitions[0].index) > len(df2.index) // 2
 
 
+@pytest.mark.skipif(
+    parse_version(pa.__version__) < parse_version("4.0.0"),
+    reason=("PyArrow>=4.0.0 required for ORC write support."),
+)
 def test_orc_names(orc_files, tmp_path):
     df = dd.read_orc(orc_files)
     assert df._name.startswith("read-orc")

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -151,6 +151,10 @@ def test_orc_names(orc_files, tmp_path):
     assert out._name.startswith("to-orc")
 
 
+@pytest.mark.skipif(
+    parse_version(pa.__version__) < parse_version("4.0.0"),
+    reason=("PyArrow>=4.0.0 required for ORC write support."),
+)
 def test_to_orc_delayed(tmp_path):
     # See: https://github.com/dask/dask/issues/8022
     df = pd.DataFrame(np.random.randn(100, 4), columns=["a", "b", "c", "d"])


### PR DESCRIPTION
Fixes a bug in `to_orc` that leads to incorrect behavior for `to_orc(..., compute=False)`

- [x] Closes #8022
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
