### PR TITLE
Deprecate `boundary_slice` kwarg: kind following pandas

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -11,7 +11,6 @@ PANDAS_GT_120 = PANDAS_VERSION >= parse_version("1.2.0")
 PANDAS_GT_121 = PANDAS_VERSION >= parse_version("1.2.1")
 PANDAS_GT_130 = PANDAS_VERSION >= parse_version("1.3.0")
 PANDAS_GT_131 = PANDAS_VERSION >= parse_version("1.3.1")
-PANDAS_GT_140 = PANDAS_VERSION >= parse_version("1.4.0")
 
 import pandas.testing as tm
 

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -11,7 +11,7 @@ PANDAS_GT_120 = PANDAS_VERSION >= parse_version("1.2.0")
 PANDAS_GT_121 = PANDAS_VERSION >= parse_version("1.2.1")
 PANDAS_GT_130 = PANDAS_VERSION >= parse_version("1.3.0")
 PANDAS_GT_131 = PANDAS_VERSION >= parse_version("1.3.1")
-
+PANDAS_GT_140 = PANDAS_VERSION >= parse_version("1.4.0")
 
 import pandas.testing as tm
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2886,7 +2886,6 @@ Dask Name: {name}, {task} tasks"""
             date,
             include_right,
             True,
-            "loc",
         )
         graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
         return new_dd_object(graph, name, self, divs)
@@ -2920,7 +2919,6 @@ Dask Name: {name}, {task} tasks"""
             None,
             True,
             False,
-            "loc",
         )
         graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
         return new_dd_object(graph, name, self, divs)

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from tlz import partition
 
-from ._compat import PANDAS_GT_140
+from ._compat import PANDAS_GT_131
 
 #  preserve compatibility while moving dispatch objects
 from .dispatch import (  # noqa: F401
@@ -88,7 +88,7 @@ def boundary_slice(df, start, stop, right_boundary=True, left_boundary=True, kin
     if len(df.index) == 0:
         return df
 
-    if PANDAS_GT_140:
+    if PANDAS_GT_131:
         if kind is not None:
             warnings.warn(
                 "The `kind` argument is no longer used/supported. "

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 from tlz import partition
 
+from ._compat import PANDAS_GT_140
+
 #  preserve compatibility while moving dispatch objects
 from .dispatch import (  # noqa: F401
     concat,
@@ -86,13 +88,20 @@ def boundary_slice(df, start, stop, right_boundary=True, left_boundary=True, kin
     if len(df.index) == 0:
         return df
 
-    if kind is not None:
-        warnings.warn(
-            "The `kind` argument is no longer used/supported. "
-            "It will be dropped in a future release.",
-            category=FutureWarning,
-        )
-    if not df.index.is_monotonic:
+    if PANDAS_GT_140:
+        if kind is not None:
+            warnings.warn(
+                "The `kind` argument is no longer used/supported. "
+                "It will be dropped in a future release.",
+                category=FutureWarning,
+            )
+        kind_opts = {}
+        kind = "loc"
+    else:
+        kind = kind or "loc"
+        kind_opts = {"kind": kind}
+
+    if kind == "loc" and not df.index.is_monotonic:
         # Pandas treats missing keys differently for label-slicing
         # on monotonic vs. non-monotonic indexes
         # If the index is monotonic, `df.loc[start:stop]` is fine.
@@ -109,12 +118,12 @@ def boundary_slice(df, start, stop, right_boundary=True, left_boundary=True, kin
                 df = df[df.index < stop]
         return df
 
-    result = df.loc[start:stop]
+    result = getattr(df, kind)[start:stop]
     if not right_boundary and stop is not None:
-        right_index = result.index.get_slice_bound(stop, "left")
+        right_index = result.index.get_slice_bound(stop, "left", **kind_opts)
         result = result.iloc[:right_index]
     if not left_boundary and start is not None:
-        left_index = result.index.get_slice_bound(start, "right")
+        left_index = result.index.get_slice_bound(start, "right", **kind_opts)
         result = result.iloc[left_index:]
     return result
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -51,9 +51,7 @@ def try_loc(df, iindexer, cindexer=None):
         return df.head(0).loc[:, cindexer]
 
 
-def boundary_slice(
-    df, start, stop, right_boundary=True, left_boundary=True, kind="loc"
-):
+def boundary_slice(df, start, stop, right_boundary=True, left_boundary=True, kind=None):
     """Index slice start/stop. Can switch include/exclude boundaries.
 
     Examples
@@ -88,7 +86,13 @@ def boundary_slice(
     if len(df.index) == 0:
         return df
 
-    if kind == "loc" and not df.index.is_monotonic:
+    if kind is not None:
+        warnings.warn(
+            "The `kind` argument is no longer used/supported. "
+            "It will be dropped in a future release.",
+            category=FutureWarning,
+        )
+    if not df.index.is_monotonic:
         # Pandas treats missing keys differently for label-slicing
         # on monotonic vs. non-monotonic indexes
         # If the index is monotonic, `df.loc[start:stop]` is fine.
@@ -104,13 +108,13 @@ def boundary_slice(
             else:
                 df = df[df.index < stop]
         return df
-    else:
-        result = getattr(df, kind)[start:stop]
+
+    result = df.loc[start:stop]
     if not right_boundary and stop is not None:
-        right_index = result.index.get_slice_bound(stop, "left", kind)
+        right_index = result.index.get_slice_bound(stop, "left")
         result = result.iloc[:right_index]
     if not left_boundary and start is not None:
-        left_index = result.index.get_slice_bound(start, "right", kind)
+        left_index = result.index.get_slice_bound(start, "right")
         result = result.iloc[left_index:]
     return result
 


### PR DESCRIPTION
- [x] Towards #8036
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

Expect 38 failures on upstream on this branch