### PR TITLE
Specify module to import rechunk from

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2507,7 +2507,7 @@ class Array(DaskMethodsMixin):
         self, chunks="auto", threshold=None, block_size_limit=None, balance=False
     ):
         """See da.rechunk for docstring"""
-        from . import rechunk  # avoid circular import
+        from .rechunk import rechunk  # avoid circular import
 
         return rechunk(self, chunks, threshold, block_size_limit, balance)
 


### PR DESCRIPTION
Specify where to import rechunk from, which seems to be inline with what is done in other nearby code.
A minor change that might give some imaginary speedups but it's mostly for readability.

- [x] Passes `black dask` / `flake8 dask` / `isort dask`
