### PR TITLE
Fix threaded scheduler memory backpressure regression

### DIFF
--- a/dask/local.py
+++ b/dask/local.py
@@ -489,8 +489,7 @@ def get_async(
                             pack_exception,
                         )
                     )
-                while len(state["ready"]) > nready - ntasks:
-                    state["ready"].pop()
+                del state["ready"][:ntasks]
 
                 # Batch submit
                 for i in range(-(len(args) // -chunksize)):

--- a/dask/local.py
+++ b/dask/local.py
@@ -469,7 +469,7 @@ def get_async(
 
                 # Prep all ready tasks for submission
                 args = []
-                for key in state["ready"][nready - ntasks : nready]:
+                for key in state["ready"][:ntasks]:
                     # Notify task is running
                     state["running"].add(key)
                     for f in pretask_cbs:
@@ -489,7 +489,8 @@ def get_async(
                             pack_exception,
                         )
                     )
-                del state["ready"][nready - ntasks : nready]
+                while len(state["ready"]) > nready - ntasks:
+                    state["ready"].pop()
 
                 # Batch submit
                 for i in range(-(len(args) // -chunksize)):

--- a/dask/local.py
+++ b/dask/local.py
@@ -469,7 +469,9 @@ def get_async(
 
                 # Prep all ready tasks for submission
                 args = []
-                for key in state["ready"][:ntasks]:
+                for _ in range(ntasks):
+                    # Get the next task to compute (most recently added)
+                    key = state["ready"].pop()
                     # Notify task is running
                     state["running"].add(key)
                     for f in pretask_cbs:
@@ -489,7 +491,6 @@ def get_async(
                             pack_exception,
                         )
                     )
-                del state["ready"][:ntasks]
 
                 # Batch submit
                 for i in range(-(len(args) // -chunksize)):

--- a/dask/local.py
+++ b/dask/local.py
@@ -181,7 +181,7 @@ def start_state_from_dask(dsk, cache=None, sortkey=None):
     waiting_data = dict((k, v.copy()) for k, v in dependents.items() if v)
 
     ready_set = set([k for k, v in waiting.items() if not v])
-    ready = sorted(ready_set, key=sortkey)
+    ready = sorted(ready_set, key=sortkey, reverse=True)
     waiting = dict((k, v) for k, v in waiting.items() if v)
 
     state = {
@@ -262,7 +262,7 @@ def finish_task(
 
     Mutates.  This should run atomically (with a lock).
     """
-    for dep in sorted(state["dependents"][key], key=sortkey):
+    for dep in sorted(state["dependents"][key], key=sortkey, reverse=True):
         s = state["waiting"][dep]
         s.remove(key)
         if not s:

--- a/dask/tests/test_local.py
+++ b/dask/tests/test_local.py
@@ -1,3 +1,5 @@
+import pytest
+
 import dask
 from dask.local import finish_task, get_sync, sortkey, start_state_from_dask
 from dask.order import order
@@ -170,3 +172,22 @@ def test_ordering():
     get_sync(dsk, "y")
 
     assert L == sorted(L)
+
+
+def test_complex_ordering():
+    da = pytest.importorskip("dask.array")
+    from dask.diagnostics import Callback
+
+    actual_order = []
+
+    def track_order(key, dask, state):
+        actual_order.append(key)
+
+    x = da.random.normal(size=(20, 20), chunks=(-1, -1))
+    res = (x.dot(x.T) - x.mean(axis=0)).std()
+    dsk = dict(res.__dask_graph__())
+    exp_order_dict = order(dsk)
+    exp_order = sorted(exp_order_dict.keys(), key=exp_order_dict.get)
+    with Callback(pretask=track_order):
+        get_sync(dsk, exp_order[-1])
+    assert actual_order == exp_order

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -351,7 +351,7 @@ def test_local_parents_of_reduction(abcde):
     b1, b2, b3 = [b + i for i in "123"]
     c1, c2, c3 = [c + i for i in "123"]
 
-    expected = [a3, b3, c3, a2, a1, b2, b1, c2, c1]
+    expected = [a3, a2, a1, b3, b2, b1, c3, c2, c1]
 
     log = []
 


### PR DESCRIPTION
The main debug of this issue can be seen in #7583. I went through the entire series of steps for this where I started with no knowledge of how this worked to now coming up with ideas for how this could perform better :wink: 

### The Issues

The issues fixed here were introduced in #6322 (CC @jakirkham). They can be tested by monitoring/profiling the memory usage from this example:

```python
from dask.diagnostics import ResourceProfiler, Profiler, CacheProfiler, visualize
import dask.array as da
from datetime import datetime

if __name__ == "__main__":
    with Profiler() as prof, ResourceProfiler(dt=0.5) as rprof, CacheProfiler() as cprof:
        d = da.random.random((5000, 250000), chunks=(1, -1)).sum()
        d.compute(optimize_graph=False)
    #visualize(
    #        [rprof, prof, cprof],
    #        file_path=f'/tmp/profile_{datetime.utcnow():%Y%m%d_%H%M%S}.html',
    #        show=False
    #        )
    print(max(x.mem for x in rprof.results))
```

If you uncomment the visualize call then you can see the full profile output for it (see the related issue for screenshots). Ever since #6322 the memory for this example is huge at ~10GB max. Prior to that PR the max memory was ~220MB.

### Fixes

This PR fixes things by doing two main things:

1. Only submit new tasks to workers when they are available. In #6322 only the number of workers are used, not the available workers. This ends up with dask submitting **all** tasks and over subscribing workers.
2. Submit tasks in reverse order. I think @jakirkham assumed ni #6322 that the reverse order wasn't needed, but without it in cases like the example above you end up filling up memory by producing **all** the `np.random` chunks into memory before ever going on to the `sum` tasks. This is the main reason memory fills up.

### Assumptions

1. I assumed that `state['ready']` can be updated by other threads so instead of doing the simpler syntax of grabbing and deleting the *end* of the `state['ready']` list I keep track of the current index and do changes relative to that. If someone can confirm that this `state` is only updated in the current thread and isn't asynchronous (never gets updated outside of `get_async`) then this can be simplified.
2. In the related issue I originally suggested an `if not len(state["running"]): continue` in the main loop because I wanted to avoid the case where we wait on the `queue.get` but there is nothing submitted by `fire_tasks`. However, after thinking about it more I don't think this is possible.

### Tests and Questions

1. Tests: Where is best?
2. Tests: How?
3. What is the fastest/most performant way to delete the end of the `state['nready']` list? I assume since everything else was done in-place in previous versions that I must also do things in-place here.
4. I wonder if there are more simple optimizations that could be done by doing batches based on the actual hierarchy of the graph. For example from the example above, group a couple `sum` tasks with the `np.random` tasks that they depend on.

- [x] Closes #7583
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
