### PR TITLE
Fix "point" -> "pointers" typo in docs

### DIFF
--- a/docs/source/remote-data-services.rst
+++ b/docs/source/remote-data-services.rst
@@ -316,7 +316,7 @@ their input locations (file system, S3, HDFS), line delimiters, and compression
 formats.
 
 Both functions are *lazy*, returning either
-point to blocks of bytes (``read_bytes``) or open file objects
+pointers to blocks of bytes (``read_bytes``) or open file objects
 (``open_files``).  They can handle different storage backends by prepending
 protocols like ``s3://`` or ``hdfs://`` (see below). They handle compression formats
 listed in ``fsspec.compression``, some of which may require additional packages


### PR DESCRIPTION
Just fixing a typo in the docs.

It looks like "pointers" is what was intended (and seems correct).