### PR TITLE
Add HTML Repr for `dask.config.config`

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -10,6 +10,41 @@ from collections.abc import Mapping
 
 import yaml
 
+
+class ConfigDict(dict):
+    # def __init__(self, *args, **kw):
+    #     super(ConfigDict, self).__init__(*args, **kw)
+    #     for key, value in self.items():
+    #         if isinstance(value, dict):
+    #             self[key] = ConfigDict(value)
+
+    def _repr_html_(self):
+        attr = self
+
+        rows = ""
+
+        for key, val in attr.items():
+            rows += f"""
+            <tr>
+                <th style="text-align: left; width: 150px;">{key}</th>
+                <td style="text-align: left;">{val}</td>
+            </tr>
+            """
+
+        html = f"""
+            <div style="margin-left: auto;">
+                <h3 style="margin-bottom: 0px;"><b>Dask Config</b></h3>
+                <p>
+                    <table style="width: 100%;">
+                    {rows}
+                    </table>
+                </p>
+            </div>
+        """
+
+        return html
+
+
 no_default = "__no_default__"
 
 


### PR DESCRIPTION
- [ ] Closes #8032
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

I am adding a simple Table-like HTML Repr for the dictionary `dask.config.config`

I am achieving this by subclassing the `dict` and then creating the `_repr_html_()` under the class.

```py
config = ConfigDict(dask.config.config)
config
```

[DRAFT]