### PR TITLE
Fix `blocksize` description formatting in `read_pandas`

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -667,7 +667,7 @@ urlpath : string or list
 blocksize : str, int or None, optional
     Number of bytes by which to cut up larger files. Default value is computed
     based on available physical memory and the number of cores, up to a maximum
-    of 64MB. Can be a number like ``64000000` or a string like ``"64MB"``. If
+    of 64MB. Can be a number like ``64000000`` or a string like ``"64MB"``. If
     ``None``, a single block is used for each file.
 sample : int, optional
     Number of bytes to use when determining dtypes


### PR DESCRIPTION
- [x] No issue opened for a minor typo
- [x] No test changes
- [x] No lint changes

I verified no other cases of this bug by running

```sh
grep -r --include \*.py "\`\`[^\`]*\` "
```

(I don't expect this is worth adding as a test)