### PR TITLE
Ignore whitespace when gufunc `signature`

### DIFF
--- a/dask/array/gufunc.py
+++ b/dask/array/gufunc.py
@@ -39,7 +39,7 @@ def _parse_gufunc_signature(signature):
     of the form List[Tuple[str, ...]], except for one output. For one output
     core dimension is not a list, but of the form Tuple[str, ...]
     """
-    signature = signature.replace(" ", "")
+    signature = re.sub(r"\s+", "", signature)
     if not re.match(_SIGNATURE, signature):
         raise ValueError("Not a valid gufunc signature: {}".format(signature))
     in_txt, out_txt = signature.split("->")
@@ -305,6 +305,10 @@ def apply_gufunc(
         if output_dtypes is None:
             ## Infer `output_dtypes`
             if vectorize:
+                # NumPy versions before https://github.com/numpy/numpy/pull/19627
+                # would not ignore whitespace characters in `signature` like they
+                # are supposed to. We remove the whitespace here as a workaround.
+                signature = re.sub(r"\s+", "", signature)
                 tempfunc = np.vectorize(func, signature=signature)
             else:
                 tempfunc = func

--- a/dask/array/tests/test_gufunc.py
+++ b/dask/array/tests/test_gufunc.py
@@ -18,6 +18,8 @@ from dask.array.utils import assert_eq
 def test__parse_gufunc_signature():
     assert_equal(_parse_gufunc_signature("(x)->()"), ([("x",)], ()))
     assert_equal(_parse_gufunc_signature("(x,y)->()"), ([("x", "y")], ()))
+    # whitespace
+    assert_equal(_parse_gufunc_signature("  (x, y) ->()"), ([("x", "y")], ()))
     assert_equal(_parse_gufunc_signature("(x),(y)->()"), ([("x",), ("y",)], ()))
     assert_equal(_parse_gufunc_signature("(x)->(y)"), ([("x",)], ("y",)))
     assert_equal(_parse_gufunc_signature("(x)->(y),()"), ([("x",)], [("y",), ()]))
@@ -326,6 +328,19 @@ def test_gufunc_mixed_inputs_vectorize():
     a = da.ones((8, 3, 5), chunks=(2, 3, 5), dtype=int)
     b = np.ones(5, dtype=int)
     x = apply_gufunc(foo, "(m,n),(n)->(m)", a, b, vectorize=True)
+
+    assert_eq(x, np.full((8, 3), 10, dtype=int))
+
+
+def test_gufunc_vectorize_whitespace():
+    # Regression test for https://github.com/dask/dask/issues/7972
+
+    def foo(x, y):
+        return (x + y).sum(axis=1)
+
+    a = da.ones((8, 3, 5), chunks=(2, 3, 5), dtype=int)
+    b = np.ones(5, dtype=int)
+    x = apply_gufunc(foo, "(m, n),(n)->(m)", a, b, vectorize=True)
 
     assert_eq(x, np.full((8, 3), 10, dtype=int))
 


### PR DESCRIPTION
This is similar to the upstream change in NumPy here https://github.com/numpy/numpy/pull/19627

- [x] Closes https://github.com/dask/dask/issues/7972
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
