### PR TITLE
Make categorical hive-partition columns optional

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -108,7 +108,7 @@ def read_parquet(
     read_from_paths=None,
     chunksize=None,
     aggregate_files=None,
-    categorical_hive_columns=True,
+    categorical_partitions=True,
     **kwargs,
 ):
     """
@@ -230,7 +230,7 @@ def read_parquet(
                 └── └── 04.parquet
 
         Note that the default behavior of ``aggregate_files`` is False.
-    categorical_hive_columns : bool, default True
+    categorical_partitions : bool, default True
         Specify if directory-partitioned (hive) columns should be read in as
         "category" dtypes.
     **kwargs: dict (of dicts)
@@ -267,7 +267,7 @@ def read_parquet(
             read_from_paths=read_from_paths,
             chunksize=chunksize,
             aggregate_files=aggregate_files,
-            categorical_hive_columns=categorical_hive_columns,
+            categorical_partitions=categorical_partitions,
         )
         return df[columns]
 
@@ -288,7 +288,7 @@ def read_parquet(
         read_from_paths,
         chunksize,
         aggregate_files,
-        categorical_hive_columns,
+        categorical_partitions,
     )
 
     if isinstance(engine, str):
@@ -327,7 +327,7 @@ def read_parquet(
         read_from_paths=read_from_paths,
         chunksize=chunksize,
         aggregate_files=aggregate_files,
-        categorical_hive_columns=categorical_hive_columns,
+        categorical_partitions=categorical_partitions,
         **kwargs,
     )
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -108,6 +108,7 @@ def read_parquet(
     read_from_paths=None,
     chunksize=None,
     aggregate_files=None,
+    categorical_hive_columns=True,
     **kwargs,
 ):
     """
@@ -229,6 +230,9 @@ def read_parquet(
                 └── └── 04.parquet
 
         Note that the default behavior of ``aggregate_files`` is False.
+    categorical_hive_columns : bool, default True
+        Specify if directory-partitioned (hive) columns should be read in as
+        "category" dtypes.
     **kwargs: dict (of dicts)
         Passthrough key-word arguments for read backend.
         The top-level keys correspond to the appropriate operation type, and
@@ -263,6 +267,7 @@ def read_parquet(
             read_from_paths=read_from_paths,
             chunksize=chunksize,
             aggregate_files=aggregate_files,
+            categorical_hive_columns=categorical_hive_columns,
         )
         return df[columns]
 
@@ -283,6 +288,7 @@ def read_parquet(
         read_from_paths,
         chunksize,
         aggregate_files,
+        categorical_hive_columns,
     )
 
     if isinstance(engine, str):
@@ -321,6 +327,7 @@ def read_parquet(
         read_from_paths=read_from_paths,
         chunksize=chunksize,
         aggregate_files=aggregate_files,
+        categorical_hive_columns=categorical_hive_columns,
         **kwargs,
     )
 

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -724,8 +724,16 @@ class FastParquetEngine(Engine):
         split_row_groups=True,
         chunksize=None,
         aggregate_files=None,
+        categorical_hive_columns=True,
         **kwargs,
     ):
+
+        if not categorical_hive_columns:
+            raise ValueError(
+                "`categorical_hive_columns=False` is not supported for "
+                "`engine='fastparquet'`."
+            )
+
         # Define the parquet-file (pf) object to use for metadata,
         # Also, initialize `parts`.  If `parts` is populated here,
         # then each part will correspond to a file.  Otherwise, each part will

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -724,13 +724,13 @@ class FastParquetEngine(Engine):
         split_row_groups=True,
         chunksize=None,
         aggregate_files=None,
-        categorical_hive_columns=True,
+        categorical_partitions=True,
         **kwargs,
     ):
 
-        if not categorical_hive_columns:
+        if not categorical_partitions:
             raise ValueError(
-                "`categorical_hive_columns=False` is not supported for "
+                "`categorical_partitions=False` is not supported for "
                 "`engine='fastparquet'`."
             )
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3583,7 +3583,7 @@ def test_custom_metadata(tmpdir, engine):
 
 
 @pytest.mark.parametrize("categorical", [True, None])
-def test_categorical_hive_columns(tmpdir, engine, categorical):
+def test_categorical_partitions(tmpdir, engine, categorical):
     tmpdir = str(tmpdir)
     df1 = pd.DataFrame({"a": range(100), "b": ["dog", "cat"] * 50})
     ddf1 = dd.from_pandas(df1, npartitions=2)
@@ -3592,7 +3592,7 @@ def test_categorical_hive_columns(tmpdir, engine, categorical):
         ddf2 = dd.read_parquet(
             tmpdir,
             engine=engine,
-            categorical_hive_columns=categorical,
+            categorical_partitions=categorical,
         )
         if categorical:
             df1.b = df1.b.astype("category")
@@ -3600,11 +3600,11 @@ def test_categorical_hive_columns(tmpdir, engine, categorical):
         df2 = ddf2.compute().sort_values("a")
         assert_eq(df1, df2)
     else:
-        # `categorical_hive_columns=False` is not supported
+        # `categorical_partitions=False` is not supported
         # for "fastparquet" or "pyarrow-legacy"
         with pytest.raises(ValueError):
             dd.read_parquet(
                 tmpdir,
                 engine=engine,
-                categorical_hive_columns=categorical,
+                categorical_partitions=categorical,
             )


### PR DESCRIPTION
This PR adds an optional `categorical_partitions` argument, so that the user can control whether or not hive-partitioned columns should be converted to a `"category"` dtype in the output DataFrame collection.  To provide backward compatibility, the default value for this option is `True` (meaning, all hive-partition columns should be converted to a`"category"` dtype).  This PR only adds support for `categorical_partitions=False` when `engine="pyarrow-dataset"`.
