### PR TITLE
Add explicit `like` kwarg support to array creation functions

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1,4 +1,5 @@
 import contextlib
+import inspect
 import math
 import operator
 import os
@@ -1567,6 +1568,12 @@ class Array(DaskMethodsMixin):
         da_func = getattr(module, func.__name__)
         if da_func is func:
             return handle_nonmatching_names(func, args, kwargs)
+
+        # If ``like`` is contained in ``da_func``'s signature, add ``like=self``
+        # to the kwargs dictionary.
+        if "like" in inspect.getfullargspec(da_func).kwonlyargs:
+            kwargs["like"] = self
+
         return da_func(*args, **kwargs)
 
     @property

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4148,7 +4148,7 @@ def retrieve_from_ooc(keys, dsk_pre, dsk_post=None):
     return load_dsk
 
 
-def asarray(a, allow_unknown_chunksizes=False, **kwargs):
+def asarray(a, allow_unknown_chunksizes=False, *, like=None, **kwargs):
     """Convert the input to a dask array.
 
     Parameters
@@ -4187,7 +4187,10 @@ def asarray(a, allow_unknown_chunksizes=False, **kwargs):
     elif isinstance(a, (list, tuple)) and any(isinstance(i, Array) for i in a):
         return stack(a, allow_unknown_chunksizes=allow_unknown_chunksizes)
     elif not isinstance(getattr(a, "shape", None), Iterable):
-        a = np.asarray(a)
+        if like is not None:
+            a = np.asarray(a, like=meta_from_array(like))
+        else:
+            a = np.asarray(a)
     return from_array(a, getitem=getter_inline, **kwargs)
 
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4194,7 +4194,7 @@ def asarray(a, allow_unknown_chunksizes=False, *, like=None, **kwargs):
     return from_array(a, getitem=getter_inline, **kwargs)
 
 
-def asanyarray(a):
+def asanyarray(a, *, like=None):
     """Convert the input to a dask array.
 
     Subclasses of ``np.ndarray`` will be passed through as chunks unchanged.
@@ -4230,7 +4230,10 @@ def asanyarray(a):
     elif isinstance(a, (list, tuple)) and any(isinstance(i, Array) for i in a):
         return stack(a)
     elif not isinstance(getattr(a, "shape", None), Iterable):
-        a = np.asanyarray(a)
+        if like is not None:
+            a = np.asarray(a, like=meta_from_array(like))
+        else:
+            a = np.asarray(a)
     return from_array(a, chunks=a.shape, getitem=getter_inline, asarray=False)
 
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -683,7 +683,7 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
 
 
 @derived_from(np)
-def tri(N, M=None, k=0, dtype=float, chunks="auto", like=None):
+def tri(N, M=None, k=0, dtype=float, chunks="auto", *, like=None):
     _min_int = np.lib.twodim_base._min_int
 
     if M is None:

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -41,8 +41,8 @@ _range = range
 
 
 @derived_from(np)
-def array(x, dtype=None, ndmin=None):
-    x = asarray(x)
+def array(x, dtype=None, ndmin=None, *, like=None):
+    x = asarray(x, like=like)
     while ndmin is not None and x.ndim < ndmin:
         x = x[None, :]
     if dtype is not None and x.dtype != dtype:

--- a/dask/array/tests/test_cupy_core.py
+++ b/dask/array/tests/test_cupy_core.py
@@ -604,3 +604,16 @@ def test_setitem_errs():
     # RHS has extra leading size 1 dimensions compared to LHS
     x = cupy.arange(12).reshape((3, 4))
     dx = da.from_array(x, chunks=(2, 3))
+
+
+@pytest.mark.parametrize("xp", [np, da])
+@pytest.mark.parametrize("array_func", ["array", "asarray", "asanyarray"])
+def test_array_like(xp, array_func):
+    cp_func = getattr(cupy, array_func)
+    xp_func = getattr(xp, array_func)
+
+    cp_a = cp_func([1, 2, 3])
+    xp_a = xp_func([1, 2, 3], like=da.from_array(cupy.array(())))
+    assert isinstance(xp_a, da.Array)
+    assert isinstance(xp_a._meta, cupy.ndarray)
+    assert_eq(xp_a, cp_a)

--- a/dask/array/tests/test_cupy_creation.py
+++ b/dask/array/tests/test_cupy_creation.py
@@ -140,3 +140,31 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
         )
     else:
         assert_eq(np_r, da_r, check_type=False)
+
+
+@pytest.mark.parametrize("xp", [np, da])
+@pytest.mark.parametrize(
+    "N, M, k, dtype, chunks",
+    [
+        (3, None, 0, float, "auto"),
+        (4, None, 0, float, "auto"),
+        (3, 4, 0, bool, "auto"),
+        (3, None, 1, int, "auto"),
+        (3, None, -1, int, "auto"),
+        (3, None, 2, int, 1),
+        (6, 8, -2, int, (3, 4)),
+        (6, 8, 0, int, (3, "auto")),
+    ],
+)
+def test_tri_like(xp, N, M, k, dtype, chunks):
+    xp_tri = getattr(xp, "tri")
+
+    args = [N, M, k, dtype]
+
+    cp_a = cupy.tri(*args)
+
+    if xp is da:
+        args.append(chunks)
+    xp_a = xp_tri(*args, like=da.from_array(cupy.array(())))
+
+    assert_eq(xp_a, cp_a)


### PR DESCRIPTION
With this change, it's now possible to create a Dask array backed by a non-NumPy array, provided the reference array passed via `like=` is a Dask array by some other library such as CuPy:

```python
>>> import numpy as np, cupy as cp, dask.array as da
>>> np.asarray([1, 2, 3], like=da.from_array(cp.array(())))
dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), chunktype=cupy.ndarray>
```