### PR TITLE
Ensure filepath exists in `to_parquet`

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -564,7 +564,7 @@ def to_parquet(
                 )
         if append:
             raise ValueError("Cannot use both `overwrite=True` and `append=True`!")
-        if fs.isdir(path):
+        if fs.exists(path) and fs.isdir(path):
             # Only remove path contents if
             # (1) The path exists
             # (2) The path is a directory


### PR DESCRIPTION
This is a possible solution for https://github.com/dask/dask/issues/8056. Though from my comment in that issue

> This makes me think there's a mismatch between how fsspec filesystems behave

we may want a more upstream solution in `s3fs` and/or `fsspec` (cc @martindurant). Also, given I've only been able to trigger this issue using S3 remote files so far, any ideas on how we might add a test are welcome 