### PR TITLE
Upstream typename instance fix from dask/distributed#5210

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -724,3 +724,12 @@ def test_noop_context_deprecated():
 def test_typename():
     assert typename(HighLevelGraph) == "dask.highlevelgraph.HighLevelGraph"
     assert typename(HighLevelGraph, short=True) == "dask.HighLevelGraph"
+
+
+class MyType:
+    pass
+
+
+def test_typename_on_instances():
+    instance = MyType()
+    assert typename(instance) == typename(MyType)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -826,6 +826,8 @@ def typename(typ, short=False):
     >>> typename(literal, short=True)
     'dask.literal'
     """
+    if not isinstance(typ, type):
+        return typename(type(typ))
     try:
         if not typ.__module__ or typ.__module__ == "builtins":
             return typ.__name__


### PR DESCRIPTION
In #8019 and dask/distributed#5205 the `typename` util has been consolidated and removed from `distributed` in favour of the `dask` one. Both packages had slightly different implementations of the method.

It looks like `distributed.utils.typename` changed between these two PRs being merged (dask/distributed#5210).

This PR upstreams those changes too and unblocks dask/distributed#5205.

cc @fjetter 