### PR TITLE
Include invalid DataFrame key in `assert_eq` check

### DIFF
--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -620,7 +620,7 @@ def assert_sane_keynames(ddf):
         assert isinstance(k, (str, bytes))
         assert len(k) < 100
         assert " " not in k
-        assert k.split("-")[0].isidentifier()
+        assert k.split("-")[0].isidentifier(), k
 
 
 def assert_dask_dtypes(ddf, res, numeric_equal=True):


### PR DESCRIPTION
This ensures the `AssertionError` that's raised includes the key being checked, which is useful when debugging 