### PR TITLE
CI: Open an issue for test-upstream failures

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -55,8 +55,72 @@ jobs:
         run: source continuous_integration/scripts/install.sh
 
       - name: Run tests
+        id: run_tests
         shell: bash -l {0}
         run: source continuous_integration/scripts/run_tests.sh
 
       - name: Coverage
         uses: codecov/codecov-action@v1
+
+  report:
+    name: report
+    needs: build
+    if: |
+      always()
+      && github.event_name == 'schedule'
+      && github.repository == 'dask/dask'
+      && needs.check.outputs.test-upstream == 'true'
+      && needs.build.result == 'failure'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v2
+      - name: Report failures
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = "⚠️ Upstream CI failed ⚠️"
+            const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+            const issue_body = `[Workflow Run URL](${workflow_url})`
+            // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
+            const query = `query($owner:String!, $name:String!, $creator:String!, $label:String!){
+              repository(owner: $owner, name: $name) {
+                issues(first: 1, states: OPEN, filterBy: {createdBy: $creator, labels: [$label]}, orderBy: {field: CREATED_AT, direction: DESC}) {
+                  edges {
+                    node {
+                      body
+                      id
+                      number
+                    }
+                  }
+                }
+              }
+            }`;
+            const variables = {
+                owner: context.repo.owner,
+                name: context.repo.repo,
+                label: 'CI,upstream',
+                creator: "github-actions[bot]"
+            }
+            const result = await github.graphql(query, variables)
+            // If no issue is open, create a new issue,
+            // else update the body of the existing issue.
+            if (result.repository.issues.edges.length === 0) {
+                github.issues.create({
+                    owner: variables.owner,
+                    repo: variables.name,
+                    body: issue_body,
+                    title: title,
+                    label: [variables.label]
+                })
+            } else {
+                github.issues.update({
+                    owner: variables.owner,
+                    repo: variables.name,
+                    issue_number: result.repository.issues.edges[0].node.number,
+                    body: issue_body
+                })
+            }

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -67,6 +67,7 @@ jobs:
     needs: build
     if: |
       always()
+      && github.event_name == 'schedule'
       && github.repository == 'dask/dask'
       && needs.check.outputs.test-upstream == 'true'
       && needs.build.result == 'failure'

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -102,7 +102,7 @@ jobs:
             const variables = {
                 owner: context.repo.owner,
                 name: context.repo.repo,
-                label: 'CI,upstream',
+                label: 'upstream',
                 creator: "github-actions[bot]"
             }
             const result = await github.graphql(query, variables)

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -67,7 +67,6 @@ jobs:
     needs: build
     if: |
       always()
-      && github.event_name == 'schedule'
       && github.repository == 'dask/dask'
       && needs.check.outputs.test-upstream == 'true'
       && needs.build.result == 'failure'


### PR DESCRIPTION
This proposes to open an issue in case of failures from upstream CI
build, labelled with `CI` and `upstream` and link to the workflow run.

- [x] Closes #7007
