### PR TITLE
Order requirements alphabetically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,12 @@ extras_require["complete"] = sorted({v for req in extras_require.values() for v 
 extras_require["test"] = ["pytest", "pytest-rerunfailures", "pytest-xdist"]
 
 install_requires = [
-    "packaging >= 20.0",
-    "pyyaml",
     "cloudpickle >= 1.1.1",
     "fsspec >= 0.6.0",
-    "toolz >= 0.8.2",
+    "packaging >= 20.0",
     "partd >= 0.3.10",
+    "pyyaml",
+    "toolz >= 0.8.2",
 ]
 
 packages = [


### PR DESCRIPTION
Sorts the dependencies here alphabetically to make it easier to spot check against [the Conda recipe]( https://github.com/conda-forge/dask-core-feedstock/blob/b7e61c544bee3c3bc8dfc9a7a89ad5fb80da5342/recipe/meta.yaml#L24-L29 ) and make sure we have everything.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
