### PR TITLE
Don't compare text and SQLalchemy column types

### DIFF
--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -24,7 +24,7 @@ dependencies:
   - fsspec
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
   # along with other issues https://github.com/pandas-dev/pandas/issues/40467
-  - sqlalchemy<1.4.0
+  - sqlalchemy
   - pyarrow=4.0
   - coverage
   - jsonschema

--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -125,7 +125,8 @@ def read_sql_table(
         if columns
         else list(table.columns)
     )
-    if index_col not in columns:
+    index_col_name = index_col if isinstance(index_col, str) else index_col.name
+    if index_col_name not in [column.name for column in columns]:
         columns.append(
             table.columns[index_col] if isinstance(index_col, str) else index_col
         )

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 import pytest
 
 # import dask
+import dask.dataframe as dd
 from dask.dataframe.io.sql import read_sql_table
 from dask.dataframe.utils import assert_eq
 from dask.utils import tmpfile
@@ -210,6 +211,11 @@ def test_simple(db):
     data = read_sql_table("test", db, npartitions=2, index_col="number").compute()
     assert (data.name == df.name).all()
     assert data.index.name == "number"
+    assert_eq(data, df)
+
+
+def test_top_level(db):
+    data = dd.read_sql_table("test", db, npartitions=1, index_col="number")
     assert_eq(data, df)
 
 


### PR DESCRIPTION
Can end up with duplicate of the index column in some cases

- [ ] Closes #7436 (sorry for the wait,  @McToel 
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
