### PR TITLE
Separate array and dataframe mindeps builds

### DIFF
--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        environment: ["mindeps-array-dataframe", "mindeps-non-optional", "mindeps-distributed"]
+        environment: ["mindeps-array", mindeps-dataframe", "mindeps-non-optional", "mindeps-distributed"]
 
     env:
       COVERAGE: "true"

--- a/continuous_integration/environment-mindeps-array.yaml
+++ b/continuous_integration/environment-mindeps-array.yaml
@@ -1,0 +1,19 @@
+name: test-environment
+channels:
+  - conda-forge
+dependencies:
+  # required dependencies
+  - packaging=20.0
+  - python=3.7
+  - pyyaml
+  - cloudpickle=1.1.1
+  - partd=0.3.10
+  - fsspec=0.6.0
+  - toolz=0.8.2
+  # optional dependencies pulled in by pip install dask[array]
+  - numpy=1.18
+  # test dependencies
+  - pytest
+  - pytest-cov
+  - pytest-rerunfailures
+  - pytest-xdist

--- a/continuous_integration/environment-mindeps-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-dataframe.yaml
@@ -10,7 +10,7 @@ dependencies:
   - partd=0.3.10
   - fsspec=0.6.0
   - toolz=0.8.2
-  # optional dependencies pulled in by pip install dask[array, dataframe]
+  # optional dependencies pulled in by pip install dask[dataframe]
   - numpy=1.18
   - pandas=1.0
   # test dependencies


### PR DESCRIPTION
This PR separates our existing array + dataframe mindeps CI build into separate builds for array and dataframe. This is to ensure that `dask.array` and `dask.dataframe` only depend on their specified minimum dependencies (i.e. `numpy` and `numpy` + `pandas`, respectively). 

xref https://github.com/dask/dask/issues/8078