### PR TITLE
FIX: `make_people` works with `processes` scheduler

### DIFF
--- a/dask/datasets.py
+++ b/dask/datasets.py
@@ -76,8 +76,6 @@ def _generate_mimesis(field, schema_description, records_per_partition, seed):
     field = Field(seed=seed, **field)
     schema = Schema(schema=lambda: schema_description(field))
     return [schema.create(iterations=1)[0] for i in range(records_per_partition)]
-    # for i in range(records_per_partition):
-    #     yield schema.create(iterations=1)[0]
 
 
 def _make_mimesis(field, schema, npartitions, records_per_partition, seed=None):

--- a/dask/datasets.py
+++ b/dask/datasets.py
@@ -75,8 +75,9 @@ def _generate_mimesis(field, schema_description, records_per_partition, seed):
 
     field = Field(seed=seed, **field)
     schema = Schema(schema=lambda: schema_description(field))
-    for i in range(records_per_partition):
-        yield schema.create(iterations=1)[0]
+    return [schema.create(iterations=1)[0] for i in range(records_per_partition)]
+    # for i in range(records_per_partition):
+    #     yield schema.create(iterations=1)[0]
 
 
 def _make_mimesis(field, schema, npartitions, records_per_partition, seed=None):

--- a/dask/tests/test_datasets.py
+++ b/dask/tests/test_datasets.py
@@ -18,6 +18,14 @@ def test_full_dataset():
     assert b.count().compute() == 20
 
 
+def test_make_dataset_with_processes():
+    b = dask.datasets.make_people(npartitions=2)
+    try:
+        b.compute(scheduler="processes")
+    except TypeError:
+        pytest.fail("Failed to execute make_people using processes")
+
+
 def test_no_mimesis():
     try:
         import mimesis  # noqa: F401

--- a/dask/tests/test_datasets.py
+++ b/dask/tests/test_datasets.py
@@ -19,6 +19,7 @@ def test_full_dataset():
 
 
 def test_make_dataset_with_processes():
+    pytest.importorskip("mimesis")
     b = dask.datasets.make_people(npartitions=2)
     try:
         b.compute(scheduler="processes")


### PR DESCRIPTION
- [x] Closes #8094 
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
