### PR TITLE
Fix typo in configuration docs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -63,7 +63,7 @@ You can specify configuration values in YAML files. For example:
      chunk-size: 128 MiB
      
    distributed:
-      workers: 
+      worker:
          memory:
             spill: 0.85  # default: 0.7
             target: 0.75  # default: 0.6


### PR DESCRIPTION
Just a small typo that caught me out!