### PR TITLE
Add dtype and order to asarray and asanyarray definitions

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4122,12 +4122,21 @@ def asarray(
     Parameters
     ----------
     a : array-like
-        Input data, in any form that can be converted to a dask array.
+        Input data, in any form that can be converted to a dask array. This
+        includes lists, lists of tuples, tuples, tuples of tuples, tuples of
+        lists and ndarrays.
     allow_unknown_chunksizes: bool
         Allow unknown chunksizes, such as come from converting from dask
         dataframes.  Dask.array is unable to verify that chunks line up.  If
         data comes from differently aligned sources then this can cause
         unexpected results.
+    dtype : data-type, optional
+        By default, the data-type is inferred from the input data.
+    order : {‘C’, ‘F’, ‘A’, ‘K’}, optional
+        Memory layout. ‘A’ and ‘K’ depend on the order of input array a.
+        ‘C’ row-major (C-style), ‘F’ column-major (Fortran-style) memory
+        representation. ‘A’ (any) means ‘F’ if a is Fortran contiguous, ‘C’
+        otherwise ‘K’ (keep) preserve input order. Defaults to ‘C’.
     like: array-like
         Reference object to allow the creation of Dask arrays with chunks
         that are not NumPy arrays. If an array-like passed in as ``like``
@@ -4181,7 +4190,16 @@ def asanyarray(a, dtype=None, order=None, *, like=None):
     Parameters
     ----------
     a : array-like
-        Input data, in any form that can be converted to a dask array.
+        Input data, in any form that can be converted to a dask array. This
+        includes lists, lists of tuples, tuples, tuples of tuples, tuples of
+        lists and ndarrays.
+    dtype : data-type, optional
+        By default, the data-type is inferred from the input data.
+    order : {‘C’, ‘F’, ‘A’, ‘K’}, optional
+        Memory layout. ‘A’ and ‘K’ depend on the order of input array a.
+        ‘C’ row-major (C-style), ‘F’ column-major (Fortran-style) memory
+        representation. ‘A’ (any) means ‘F’ if a is Fortran contiguous, ‘C’
+        otherwise ‘K’ (keep) preserve input order. Defaults to ‘C’.
     like: array-like
         Reference object to allow the creation of Dask arrays with chunks
         that are not NumPy arrays. If an array-like passed in as ``like``

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4114,7 +4114,9 @@ def retrieve_from_ooc(keys, dsk_pre, dsk_post=None):
     return load_dsk
 
 
-def asarray(a, allow_unknown_chunksizes=False, *, like=None, **kwargs):
+def asarray(
+    a, allow_unknown_chunksizes=False, dtype=None, order=None, *, like=None, **kwargs
+):
     """Convert the input to a dask array.
 
     Parameters
@@ -4165,13 +4167,13 @@ def asarray(a, allow_unknown_chunksizes=False, *, like=None, **kwargs):
         if like is not None:
             if not _numpy_120:
                 raise RuntimeError("The use of ``like`` required NumPy >= 1.20")
-            a = np.asarray(a, like=meta_from_array(like))
+            a = np.asarray(a, like=meta_from_array(like), dtype=dtype, order=order)
         else:
-            a = np.asarray(a)
+            a = np.asarray(a, dtype=dtype, order=order)
     return from_array(a, getitem=getter_inline, **kwargs)
 
 
-def asanyarray(a, *, like=None):
+def asanyarray(a, dtype=None, order=None, *, like=None):
     """Convert the input to a dask array.
 
     Subclasses of ``np.ndarray`` will be passed through as chunks unchanged.
@@ -4219,9 +4221,9 @@ def asanyarray(a, *, like=None):
         if like is not None:
             if not _numpy_120:
                 raise RuntimeError("The use of ``like`` required NumPy >= 1.20")
-            a = np.asanyarray(a, like=meta_from_array(like))
+            a = np.asanyarray(a, like=meta_from_array(like), dtype=dtype, order=order)
         else:
-            a = np.asanyarray(a)
+            a = np.asanyarray(a, dtype=dtype, order=order)
     return from_array(a, chunks=a.shape, getitem=getter_inline, asarray=False)
 
 

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -237,3 +237,9 @@ def test_like_raises(func):
 @pytest.mark.parametrize("func", [np.array, np.asarray, np.asanyarray])
 def test_like_with_numpy_func(func):
     assert_eq(func(1, like=da.array((1))), func(1))
+
+
+@pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
+@pytest.mark.parametrize("func", [np.array, np.asarray, np.asanyarray])
+def test_like_with_numpy_func_and_dtype(func):
+    assert_eq(func(1, dtype=float, like=da.array((1))), func(1, dtype=float))

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -233,12 +233,7 @@ def test_like_raises(func):
             func(1, like=func((1)))
 
 
+@pytest.mark.skipif(not _numpy_120)
 @pytest.mark.parametrize("func", [np.array, np.asarray, np.asanyarray])
 def test_like_with_numpy_func(func):
-    if _numpy_120:
-        assert_eq(func(1, like=da.array((1))), func(1))
-    else:
-        with pytest.raises(
-            RuntimeError, match="The use of ``like`` required NumPy >= 1.20"
-        ):
-            func(1, like=da.array((1)))
+    assert_eq(func(1, like=da.array((1))), func(1))

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -231,3 +231,14 @@ def test_like_raises(func):
             RuntimeError, match="The use of ``like`` required NumPy >= 1.20"
         ):
             func(1, like=func((1)))
+
+
+@pytest.mark.parametrize("func", [np.array, np.asarray, np.asanyarray])
+def test_like_with_numpy_func(func):
+    if _numpy_120:
+        assert_eq(func(1, like=da.array((1))), func(1))
+    else:
+        with pytest.raises(
+            RuntimeError, match="The use of ``like`` required NumPy >= 1.20"
+        ):
+            func(1, like=da.array((1)))

--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -233,7 +233,7 @@ def test_like_raises(func):
             func(1, like=func((1)))
 
 
-@pytest.mark.skipif(not _numpy_120)
+@pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 @pytest.mark.parametrize("func", [np.array, np.asarray, np.asanyarray])
 def test_like_with_numpy_func(func):
     assert_eq(func(1, like=da.array((1))), func(1))


### PR DESCRIPTION
- [x] Closes #8105
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

I'll leave this here for when @pentschev gets back. 