### PR TITLE
Add `DataFrame.sort_values` to API docs

### DIFF
--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -115,11 +115,11 @@ Dataframe
     DataFrame.shape
     DataFrame.shuffle
     DataFrame.size
+    DataFrame.sort_values
     DataFrame.squeeze
     DataFrame.std
     DataFrame.sub
     DataFrame.sum
-    DataFrame.sort_values
     DataFrame.tail
     DataFrame.to_bag
     DataFrame.to_csv

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -119,6 +119,7 @@ Dataframe
     DataFrame.std
     DataFrame.sub
     DataFrame.sum
+    DataFrame.sort_values
     DataFrame.tail
     DataFrame.to_bag
     DataFrame.to_csv


### PR DESCRIPTION
PR adds the `sort_values` method to API docs

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`

