### PR TITLE
Add FileNotFound to expected http errors

### DIFF
--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -13,7 +13,7 @@ from dask.utils import tmpdir
 
 files = ["a", "b"]
 requests = pytest.importorskip("requests")
-errs = (requests.exceptions.RequestException,)
+errs = requests.exceptions.RequestException, FileNotFoundError
 if parse_version(fsspec.__version__) > parse_version("0.7.4"):
     aiohttp = pytest.importorskip("aiohttp")
     errs = errs + (aiohttp.client_exceptions.ClientResponseError,)


### PR DESCRIPTION
- [ ] Closes #8108
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`

Note that I am still leaving the requests error for now, so that tests will pass with previous fsspec too.