### PR TITLE
Allow `scheduler` to be an `Executor`

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -1160,17 +1160,21 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
             return scheduler
         elif "Client" in type(scheduler).__name__ and hasattr(scheduler, "get"):
             return scheduler.get
-        elif scheduler.lower() in named_schedulers:
-            return named_schedulers[scheduler.lower()]
-        elif scheduler.lower() in ("dask.distributed", "distributed"):
-            from distributed.worker import get_client
+        elif isinstance(scheduler, str):
+            scheduler = scheduler.lower()
+            if scheduler in named_schedulers:
+                return named_schedulers[scheduler]
+            elif scheduler in ("dask.distributed", "distributed"):
+                from distributed.worker import get_client
 
-            return get_client().get
+                return get_client().get
+            else:
+                raise ValueError(
+                    "Expected one of [distributed, %s]"
+                    % ", ".join(sorted(named_schedulers))
+                )
         else:
-            raise ValueError(
-                "Expected one of [distributed, %s]"
-                % ", ".join(sorted(named_schedulers))
-            )
+            raise ValueError("Unexpected scheduler: %s" % repr(scheduler))
         # else:  # try to connect to remote scheduler with this name
         #     return get_client(scheduler).get
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1349,7 +1349,7 @@ def test_get_scheduler():
     assert get_scheduler(scheduler="threads") is dask.threaded.get
     assert get_scheduler(scheduler="sync") is dask.local.get_sync
     with dask.config.set(scheduler="threads"):
-        assert get_scheduler(scheduler="threads") is dask.threaded.get
+        assert get_scheduler() is dask.threaded.get
     assert get_scheduler() is None
 
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1346,6 +1346,7 @@ def test_raise_get_keyword():
 
 def test_get_scheduler():
     assert get_scheduler() is None
+    assert get_scheduler(scheduler=dask.local.get_sync) is dask.local.get_sync
     assert get_scheduler(scheduler="threads") is dask.threaded.get
     assert get_scheduler(scheduler="sync") is dask.local.get_sync
     with dask.config.set(scheduler="threads"):

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1349,6 +1349,7 @@ def test_get_scheduler():
     assert get_scheduler(scheduler=dask.local.get_sync) is dask.local.get_sync
     assert get_scheduler(scheduler="threads") is dask.threaded.get
     assert get_scheduler(scheduler="sync") is dask.local.get_sync
+    assert callable(get_scheduler(scheduler=dask.local.synchronous_executor))
     with dask.config.set(scheduler="threads"):
         assert get_scheduler() is dask.threaded.get
     assert get_scheduler() is None

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -212,5 +212,5 @@ such as the ``ReusablePoolExecutor`` from loky_:
 Other libraries like ipyparallel_ and mpi4py_ also supply
 ``concurrent.futures.Executor`` subclasses that could be used as well.
 
-.. _ipyparallel: https://ipyparallel.readthedocs.io/en/latest/api/ipyparallel.html#ipyparallel.Client.executor
+.. _ipyparallel: https://ipyparallel.readthedocs.io/en/latest/examples/Futures.html#Executors
 .. _mpi4py: https://mpi4py.readthedocs.io/en/latest/mpi4py.futures.html

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -198,8 +198,8 @@ specify the desired number of workers:
    with dask.config.set(num_workers=4):
        x.compute()
 
-Note that Dask also supports custom ``concurrent.futures.Executor`` subclasses, such as the 
-reusable ``ProcessPoolExecutor`` from loky_:
+Note that Dask also supports custom ``concurrent.futures.Executor`` subclasses,
+such as the ``ReusablePoolExecutor`` from loky_:
 
 .. _loky: https://github.com/joblib/loky
 

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -206,7 +206,7 @@ reusable ``ProcessPoolExecutor`` from loky_:
 .. code-block:: python
 
    from loky import get_reusable_executor
-   with dask.config.set(pool=get_reusable_executor(max_workers=4)):
+   with dask.config.set(scheduler=get_reusable_executor(max_workers=4)):
        x.compute()
 
 Other libraries like ipyparallel_ and mpi4py_ also supply

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -206,7 +206,7 @@ such as the ``ReusablePoolExecutor`` from loky_:
 .. code-block:: python
 
    from loky import get_reusable_executor
-   with dask.config.set(scheduler=get_reusable_executor(max_workers=4)):
+   with dask.config.set(scheduler=get_reusable_executor()):
        x.compute()
 
 Other libraries like ipyparallel_ and mpi4py_ also supply


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

Allows the `scheduler` config parameter to be an `Executor`. If specified, it will use the `Executor`'s `submit` function to dispatch work.