### PR TITLE
Fix edge case with like-arrays in _wrapped_qr

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -44,7 +44,7 @@ def _wrapped_qr(a):
     """
     # workaround may be removed when numpy stops rejecting edge cases
     if a.shape[0] == 0:
-        return np.zeros((0, 0)), np.zeros((0, a.shape[1]))
+        return np.zeros_like(a, shape=(0, 0)), np.zeros_like(a, shape=(0, a.shape[1]))
     else:
         return np.linalg.qr(a)
 


### PR DESCRIPTION
Fixes #8101. The test was flaky due to an edge case in `_wrapped_qr`, which was dependant on the input matrix. I was able to deterministically confirm this indeed resolves the flaky test by dumping the matrix generated in https://github.com/dask/dask/blob/05c380ecf05ebf93f18b5c28b970267d5a72876b/dask/array/tests/test_cupy_linalg.py#L195 to a file and loading it back in, which would fail consistently without this patch.