### PR TITLE
Specifically ignore warnings on mean for empty slices

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -625,7 +625,8 @@ def mean_agg(pairs, dtype="f8", axis=None, computing_meta=False, **kwargs):
     totals = deepmap(lambda pair: pair["total"], pairs)
     total = _concatenate2(totals, axes=axis).sum(axis=axis, dtype=dtype, **kwargs)
 
-    return divide(total, n, dtype=dtype)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return divide(total, n, dtype=dtype)
 
 
 @derived_from(np)

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -726,6 +726,16 @@ def test_object_reduction(method):
     assert result == 1
 
 
+def test_mean_func_does_not_warn():
+    # non-regression test for https://github.com/pydata/xarray/issues/5151
+    xr = pytest.importorskip("xarray")
+    a = xr.DataArray(da.from_array(np.full((10, 10), np.nan)))
+
+    with pytest.warns(None) as rec:
+        a.mean().compute()
+    assert not rec  # did not warn
+
+
 @pytest.mark.parametrize("func", ["nanvar", "nanstd"])
 def test_nan_func_does_not_warn(func):
     # non-regression test for #6105


### PR DESCRIPTION
- [x] Closes https://github.com/pydata/xarray/issues/5151
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

It seems ok to me to ignore agg-level warnings like the one reported in this issue. @TomAugspurger what do you think?