### PR TITLE
Remove unused functions: `zero_broadcast_dimensions` and `homogeneous_deepmap`

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -23,6 +23,7 @@ from .delayed import unpack_collections
 from .highlevelgraph import HighLevelGraph, Layer
 from .optimization import SubgraphCallable, fuse
 from .utils import (
+    _deprecated,
     apply,
     ensure_dict,
     homogeneous_deepmap,
@@ -1441,7 +1442,7 @@ def rewrite_blockwise(inputs):
         io_deps=io_deps,
     )
 
-
+@_deprecated()
 def zero_broadcast_dimensions(lol, nblocks):
     """
     >>> lol = [('x', 1, 0), ('x', 1, 1), ('x', 1, 2)]

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -111,6 +111,7 @@ def deepmap(func, *seqs):
         return func(*seqs)
 
 
+@_deprecated()
 def homogeneous_deepmap(func, seq):
     if not seq:
         return seq


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

[`zero_broadcast_dimensions`](https://github.com/dask/dask/blob/474f479e1b5e77e831da02232a84a9f49508889b/dask/blockwise.py#L1445) and [`homogeneous_deepmap`](https://github.com/dask/dask/blob/474f479e1b5e77e831da02232a84a9f49508889b/dask/utils.py#L114) are unused internally in the Dask codebase since #5940 was merged. They also aren't mentioned in the documentation.