### PR TITLE
Handle asarray/asanyarray cases where like is a dask.Array

### DIFF
--- a/dask/array/tests/test_cupy_core.py
+++ b/dask/array/tests/test_cupy_core.py
@@ -608,13 +608,14 @@ def test_setitem_errs():
 
 @pytest.mark.skipif(not _numpy_120, reason="NEP-35 is not available")
 @pytest.mark.parametrize("xp", [np, da])
+@pytest.mark.parametrize("orig_arr", [np.array, da.array])
 @pytest.mark.parametrize("array_func", ["array", "asarray", "asanyarray"])
-def test_array_like(xp, array_func):
+def test_array_like(xp, orig_arr, array_func):
     cp_func = getattr(cupy, array_func)
     xp_func = getattr(xp, array_func)
 
     cp_a = cp_func([1, 2, 3])
-    xp_a = xp_func([1, 2, 3], like=da.from_array(cupy.array(())))
+    xp_a = xp_func(orig_arr([1, 2, 3]), like=da.from_array(cupy.array(())))
     assert isinstance(xp_a, da.Array)
     assert isinstance(xp_a._meta, cupy.ndarray)
     assert_eq(xp_a, cp_a)


### PR DESCRIPTION
Follow-up case to https://github.com/dask/dask/pull/8054 where the input is a Dask array and `like=` is another Dask array but with a different chunk type.

Before:

```python
>>> import numpy as np, cupy as cp, dask.array as da
>>> np.asarray(da.array([1, 2, 3]), like=da.from_array(cp.array(())))
dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), chunktype=numpy.ndarray>
```

After:

```python
>>> import numpy as np, cupy as cp, dask.array as da
>>> np.asarray(da.array([1, 2, 3]), like=da.from_array(cp.array(())))
dask.array<asarray, shape=(3,), dtype=int64, chunksize=(3,), chunktype=cupy.ndarray>
```