### PR TITLE
Deprecate `zero_broadcast_dimensions` and `homogeneous_deepmap`

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1452,7 +1452,7 @@ def zero_broadcast_dimensions(lol, nblocks):
     ...        [('x', 1, 1, 0), ('x', 1, 1, 1)],
     ...        [('x', 1, 2, 0), ('x', 1, 2, 1)]]
 
-    >>> zero_broadcast_dimensions(lol, nblocks)  # doctest: +NORMALIZE_WHITESPACE
+    >>> zero_broadcast_dimensions(lol, nblocks)  # doctest: +SKIP
     [[('x', 1, 0, 0), ('x', 1, 0, 1)],
      [('x', 1, 0, 0), ('x', 1, 0, 1)],
      [('x', 1, 0, 0), ('x', 1, 0, 1)]]

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1442,6 +1442,7 @@ def rewrite_blockwise(inputs):
         io_deps=io_deps,
     )
 
+
 @_deprecated()
 def zero_broadcast_dimensions(lol, nblocks):
     """

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -23,6 +23,7 @@ from .delayed import unpack_collections
 from .highlevelgraph import HighLevelGraph, Layer
 from .optimization import SubgraphCallable, fuse
 from .utils import (
+    _deprecated,
     apply,
     ensure_dict,
     homogeneous_deepmap,
@@ -1441,7 +1442,7 @@ def rewrite_blockwise(inputs):
         io_deps=io_deps,
     )
 
-
+@_deprecated()
 def zero_broadcast_dimensions(lol, nblocks):
     """
     >>> lol = [('x', 1, 0), ('x', 1, 1), ('x', 1, 2)]

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -111,6 +111,7 @@ def deepmap(func, *seqs):
         return func(*seqs)
 
 
+@_deprecated()
 def homogeneous_deepmap(func, seq):
     if not seq:
         return seq


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

Deprecate `zero_broadcast_dimensions` and `homogenous_deepmap` as mentioned in #8126