### PR TITLE
Deprecate 'inplace' argument for dask series renaming

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3285,7 +3285,10 @@ Dask Name: {name}, {task} tasks""".format(
         ):
 
             if inplace:
-                warnings.warn("'inplace' argument for dask series will be removed in future versions", PendingDeprecationWarning)
+                warnings.warn(
+                    "'inplace' argument for dask series will be removed in future versions",
+                    PendingDeprecationWarning,
+                )
             res = self if inplace else self.copy()
             res.name = index
         else:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3212,6 +3212,9 @@ Dask Name: {name}, {task} tasks""".format(
             and not is_dict_like(index)
             and not isinstance(index, dd.Series)
         ):
+
+            if inplace:
+                warnings.warn("'inplace' argument for dask series will be removed in future versions", PendingDeprecationWarning)
             res = self if inplace else self.copy()
             res.name = index
         else:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -333,9 +333,6 @@ def test_rename_series_method():
     assert ds.name == "x"  # no mutation
     assert_eq(ds.rename(), s.rename())
 
-    ds.rename("z", inplace=True)
-    s.rename("z", inplace=True)
-    assert ds.name == "z"
     assert_eq(ds, s)
 
 


### PR DESCRIPTION
See issue #8082 