### PR TITLE
Remove references to `pd.Int64Index` in anticipation of deprecation

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -186,15 +186,12 @@ def meta_nonempty_dataframe(x):
     return res
 
 
-_numeric_index_types = (pd.Int64Index, pd.Float64Index, pd.UInt64Index)
-
-
 @meta_nonempty.register(pd.Index)
 def _nonempty_index(idx):
     typ = type(idx)
     if typ is pd.RangeIndex:
         return pd.RangeIndex(2, name=idx.name)
-    elif typ in _numeric_index_types:
+    elif idx.is_numeric():
         return typ([1, 2], name=idx.name)
     elif typ is pd.Index:
         return pd.Index(["a", "b"], name=idx.name)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3376,9 +3376,7 @@ def test_info():
     pandas_format._put_lines = put_lines
 
     test_frames = [
-        pd.DataFrame(
-            {"x": [1, 2, 3, 4], "y": [1, 0, 1, 0]}, index=pd.Int64Index(range(4))
-        ),  # No RangeIndex in dask
+        pd.DataFrame({"x": [1, 2, 3, 4], "y": [1, 0, 1, 0]}, index=[0, 1, 2, 3]),
         pd.DataFrame(),
     ]
 
@@ -3448,8 +3446,8 @@ def test_categorize_info():
 
     df = pd.DataFrame(
         {"x": [1, 2, 3, 4], "y": pd.Series(list("aabc")), "z": pd.Series(list("aabc"))},
-        index=pd.Int64Index(range(4)),
-    )  # No RangeIndex in dask
+        index=[0, 1, 2, 3],
+    )
     ddf = dd.from_pandas(df, npartitions=4).categorize(["y"])
 
     # Verbose=False

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -212,7 +212,7 @@ def test_meta_nonempty_index():
     idx = pd.Index([1], name="foo", dtype="int")
     res = meta_nonempty(idx)
     assert isinstance(res, pd.Index)
-    assert res.dtype == "int"
+    assert res.dtype == "int64"
     assert res.name == idx.name
 
     idx = pd.Index(["a"], name="foo")

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -87,12 +87,12 @@ def test_make_meta():
         index=idx,
     )
     assert type(meta.index) is type(idx)
-    assert meta.index.dtype == "int"
+    assert meta.index.dtype == "int64"
     assert len(meta.index) == 0
 
     meta = make_meta(("a", "i8"), index=idx)
     assert type(meta.index) is type(idx)
-    assert meta.index.dtype == "int"
+    assert meta.index.dtype == "int64"
     assert len(meta.index) == 0
 
     # Categoricals
@@ -283,7 +283,7 @@ def test_meta_nonempty_uint64index():
     idx = pd.Index([1], name="foo", dtype="uint64")
     res = meta_nonempty(idx)
     assert isinstance(res, pd.Index)
-    assert res.dtype == "uint"
+    assert res.dtype == "uint64"
     assert res.name == idx.name
 
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -211,7 +211,7 @@ def test_meta_nonempty_index():
 
     idx = pd.Index([1], name="foo", dtype="int")
     res = meta_nonempty(idx)
-    assert isinstance(res, pd.Index)
+    assert type(res) is type(idx)
     assert res.dtype == "int64"
     assert res.name == idx.name
 
@@ -282,7 +282,7 @@ def test_meta_nonempty_index():
 def test_meta_nonempty_uint64index():
     idx = pd.Index([1], name="foo", dtype="uint64")
     res = meta_nonempty(idx)
-    assert isinstance(res, pd.Index)
+    assert type(res) is type(idx)
     assert res.dtype == "uint64"
     assert res.name == idx.name
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -81,14 +81,18 @@ def test_make_meta():
     assert meta.name == "a"
 
     # With index
+    idx = pd.Index([1, 2], name="foo")
     meta = make_meta(
         {"a": "i8", "b": "i4"},
-        index=pd.Int64Index([1, 2], name="foo"),
+        index=idx,
     )
-    assert isinstance(meta.index, pd.Int64Index)
+    assert type(meta.index) is type(idx)
+    assert meta.index.dtype == "int"
     assert len(meta.index) == 0
-    meta = make_meta(("a", "i8"), index=pd.Int64Index([1, 2], name="foo"))
-    assert isinstance(meta.index, pd.Int64Index)
+
+    meta = make_meta(("a", "i8"), index=idx)
+    assert type(meta.index) is type(idx)
+    assert meta.index.dtype == "int"
     assert len(meta.index) == 0
 
     # Categoricals
@@ -205,9 +209,10 @@ def test_meta_nonempty_index():
     assert type(res) is pd.RangeIndex
     assert res.name == idx.name
 
-    idx = pd.Int64Index([1], name="foo")
+    idx = pd.Index([1], name="foo", dtype="int")
     res = meta_nonempty(idx)
-    assert type(res) is pd.Int64Index
+    assert isinstance(res, pd.Index)
+    assert res.dtype == "int"
     assert res.name == idx.name
 
     idx = pd.Index(["a"], name="foo")
@@ -247,7 +252,7 @@ def test_meta_nonempty_index():
     assert res.ordered == idx.ordered
     assert res.name == idx.name
 
-    levels = [pd.Int64Index([1], name="a"), pd.Float64Index([1.0], name="b")]
+    levels = [pd.Index([1], name="a"), pd.Index([1.0], name="b")]
     codes = [[0], [0]]
     idx = pd.MultiIndex(levels=levels, names=["a", "b"], codes=codes)
     res = meta_nonempty(idx)
@@ -258,7 +263,7 @@ def test_meta_nonempty_index():
     assert res.names == idx.names
 
     levels = [
-        pd.Int64Index([1], name="a"),
+        pd.Index([1], name="a"),
         pd.CategoricalIndex(data=["xyx"], categories=["xyx"], name="b"),
         pd.TimedeltaIndex([np.timedelta64(1, "D")], name="timedelta"),
     ]
@@ -275,9 +280,10 @@ def test_meta_nonempty_index():
 
 
 def test_meta_nonempty_uint64index():
-    idx = pd.UInt64Index([1], name="foo")
+    idx = pd.Index([1], name="foo", dtype="uint64")
     res = meta_nonempty(idx)
-    assert type(res) is pd.UInt64Index
+    assert isinstance(res, pd.Index)
+    assert res.dtype == "uint"
     assert res.name == idx.name
 
 


### PR DESCRIPTION
Ref https://github.com/dask/dask/issues/8036