### PR TITLE
Fix rolling for compatibility with pandas > 1.3.0

### DIFF
--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -273,7 +273,7 @@ class Rolling:
         # that information here.
         # See https://github.com/pandas-dev/pandas/issues/15969
         self._window = pd_roll.window
-        self._win_type = pd_roll.win_type
+        self._win_type = None if isinstance(self._window, int) else "freq"
         self._min_periods = pd_roll.min_periods
 
     def _rolling_kwargs(self):

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -266,15 +266,13 @@ class Rolling:
         self.axis = axis
         self.win_type = win_type
         # Allow pandas to raise if appropriate
-        pd_roll = obj._meta.rolling(**self._rolling_kwargs())
+        obj._meta.rolling(**self._rolling_kwargs())
         # Using .rolling(window='2s'), pandas will convert the
         # offset str to a window in nanoseconds. But pandas doesn't
         # accept the integer window with win_type='freq', so we store
         # that information here.
         # See https://github.com/pandas-dev/pandas/issues/15969
-        self._window = pd_roll.window
-        self._win_type = None if isinstance(self._window, int) else "freq"
-        self._min_periods = pd_roll.min_periods
+        self._win_type = None if isinstance(self.window, int) else "freq"
 
     def _rolling_kwargs(self):
         return {
@@ -429,8 +427,7 @@ class Rolling:
             return _order[k]
 
         rolling_kwargs = self._rolling_kwargs()
-        # pandas translates the '2S' offset to nanoseconds
-        rolling_kwargs["window"] = self._window
+        rolling_kwargs["window"] = self.window
         rolling_kwargs["win_type"] = self._win_type
         return "Rolling [{}]".format(
             ",".join(

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -257,8 +257,6 @@ def test_time_rolling_constructor():
     assert result.win_type is None
 
     assert result._win_type == "freq"
-    assert result._window == "4s"
-    assert result._min_periods == 1
 
 
 @pytest.mark.parametrize(

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -4,7 +4,6 @@ import pytest
 from packaging.version import parse as parse_version
 
 import dask.dataframe as dd
-from dask.dataframe._compat import PANDAS_GT_130
 from dask.dataframe.utils import assert_eq
 
 N = 40
@@ -246,15 +245,11 @@ def test_rolling_repr():
     assert res == "Rolling [window=4,center=False,axis=0]"
 
 
-# TODO(pandas) fix rolling to be compatible with pandas 1.3.0
-@pytest.mark.skipif(PANDAS_GT_130, reason="win_type changed in pandas master")
 def test_time_rolling_repr():
     res = repr(dts.rolling("4s"))
-    assert res == "Rolling [window=4000000000,center=False,win_type=freq,axis=0]"
+    assert res == "Rolling [window=4s,center=False,win_type=freq,axis=0]"
 
 
-# TODO(pandas) fix rolling to be compatible with pandas 1.3.0
-@pytest.mark.skipif(PANDAS_GT_130, reason="win_type changed in pandas master")
 def test_time_rolling_constructor():
     result = dts.rolling("4s")
     assert result.window == "4s"
@@ -262,12 +257,10 @@ def test_time_rolling_constructor():
     assert result.win_type is None
 
     assert result._win_type == "freq"
-    assert result._window == 4000000000  # ns
+    assert result._window == "4s"
     assert result._min_periods == 1
 
 
-# TODO(pandas) fix rolling to be compatible with pandas 1.3.0
-@pytest.mark.filterwarnings("ignore:win_type:FutureWarning")
 @pytest.mark.parametrize(
     "method,args,check_less_precise", rolling_method_args_check_less_precise
 )
@@ -304,8 +297,6 @@ def test_time_rolling_methods(method, args, window, check_less_precise):
     )
 
 
-# TODO(pandas) fix rolling to be compatible with pandas 1.3.0
-@pytest.mark.filterwarnings("ignore:win_type:FutureWarning")
 @pytest.mark.parametrize("window", ["1S", "2S", "3S", pd.offsets.Second(5)])
 def test_time_rolling_cov(window):
     # DataFrame
@@ -319,8 +310,6 @@ def test_time_rolling_cov(window):
     assert_eq(prolling.cov(), drolling.cov())
 
 
-# TODO(pandas) fix rolling to be compatible with pandas 1.3.0
-@pytest.mark.filterwarnings("ignore:win_type:FutureWarning")
 @pytest.mark.parametrize(
     "window,N",
     [("1s", 10), ("2s", 10), ("10s", 10), ("10h", 10), ("10s", 100), ("10h", 100)],
@@ -339,8 +328,6 @@ def test_time_rolling_large_window_fixed_chunks(window, N):
     assert_eq(ddf.rolling(window).mean(), df.rolling(window).mean())
 
 
-# TODO(pandas) fix rolling to be compatible with pandas 1.3.0
-@pytest.mark.filterwarnings("ignore:win_type:FutureWarning")
 @pytest.mark.parametrize("window", ["2s", "5s", "20s", "10h"])
 def test_time_rolling_large_window_variable_chunks(window):
     df = pd.DataFrame(
@@ -358,7 +345,6 @@ def test_time_rolling_large_window_variable_chunks(window):
     assert_eq(ddf.rolling(window).mean(), df.rolling(window).mean())
 
 
-# TODO(pandas) fix rolling to be compatible with pandas 1.3.0
 @pytest.mark.parametrize("before, after", [("6s", "6s"), ("2s", "2s"), ("6s", "2s")])
 def test_time_rolling(before, after):
     window = before


### PR DESCRIPTION
This is just a little fix to get it working again and remove skips
