### PR TITLE
Fix groupby for future pandas

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -395,7 +395,7 @@ def _mul_cols(df, cols):
     # Fix index in a groupby().apply() context
     # https://github.com/dask/dask/issues/8137
     # https://github.com/pandas-dev/pandas/issues/43568
-    _df.index = [None] * len(_df)
+    _df.index = [0] * len(_df)
     return _df
 
 
@@ -505,7 +505,7 @@ def _drop_duplicates_reindex(df):
     # https://github.com/dask/dask/issues/8137
     # https://github.com/pandas-dev/pandas/issues/43568
     result = df.drop_duplicates()
-    result.index = [None] * len(result)
+    result.index = [0] * len(result)
     return result
 
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -9,7 +9,7 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.dataframe import _compat
-from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_133, tm
+from dask.dataframe._compat import PANDAS_GT_110, tm
 from dask.dataframe.utils import assert_dask_graph, assert_eq, assert_max_deps
 from dask.utils import M
 
@@ -470,7 +470,6 @@ def test_series_groupby_errors():
         ss.groupby("x")  # dask should raise the same error
 
 
-@pytest.mark.skipif(PANDAS_GT_133, reason="https://github.com/dask/dask/issues/8137")
 def test_groupby_index_array():
     df = _compat.makeTimeDataFrame()
     ddf = dd.from_pandas(df, npartitions=2)


### PR DESCRIPTION
- [x] Closes #8137, #8036
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

Implementing @TomAugspurger's workaround from https://github.com/dask/dask/issues/8137#issuecomment-920173096