### PR TITLE
Remove warning filters in tests that are no longer needed

### DIFF
--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -526,7 +526,6 @@ def test_general_reduction_names():
     assert all(tokens)
 
 
-@pytest.mark.filterwarnings("ignore:`argmax` is not implemented by dask")
 @pytest.mark.parametrize("func", [np.sum, np.argmax])
 def test_array_reduction_out(func):
     x = da.arange(10, chunks=(5,))

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -742,7 +742,6 @@ def test_histogram_alternative_bins_range():
     assert_eq(b1, b2)
 
 
-@pytest.mark.filterwarnings("ignore:invalid value:RuntimeWarning")
 def test_histogram_bins_range_with_nan_array():
     # Regression test for issue #3977
     v = da.from_array(np.array([-2, np.nan, 2]), chunks=1)

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -1033,7 +1033,7 @@ def test_make_blockwise_sorted_slice():
     np.testing.assert_array_equal(b, index3)
 
 
-@pytest.mark.filterwarnings("ignore:dask.array.core.PerformanceWarning")
+@pytest.mark.filterwarnings("ignore:Slicing:dask.array.core.PerformanceWarning")
 @pytest.mark.parametrize(
     "size, chunks", [((100, 2), (50, 2)), ((100, 2), (37, 1)), ((100,), (55,))]
 )

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -1033,7 +1033,7 @@ def test_make_blockwise_sorted_slice():
     np.testing.assert_array_equal(b, index3)
 
 
-@pytest.mark.filterwarnings("ignore")
+@pytest.mark.filterwarnings("ignore:dask.array.core.PerformanceWarning")
 @pytest.mark.parametrize(
     "size, chunks", [((100, 2), (50, 2)), ((100, 2), (37, 1)), ((100,), (55,))]
 )

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -132,15 +132,11 @@ csv_units_row = b"str, int, int\n"
 tsv_units_row = csv_units_row.replace(b",", b"\t")
 
 
-# Pandas has deprecated read_table
-read_table_mark = pytest.mark.filterwarnings("ignore:read_table:FutureWarning")
-
-
 csv_and_table = pytest.mark.parametrize(
     "reader,files",
     [
         (pd.read_csv, csv_files),
-        pytest.param(pd.read_table, tsv_files, marks=read_table_mark),
+        (pd.read_table, tsv_files),
         (pd.read_fwf, fwf_files),
     ],
 )
@@ -244,7 +240,6 @@ def test_text_blocks_to_pandas_blocked(reader, files):
     "dd_read,pd_read,files",
     [(dd.read_csv, pd.read_csv, csv_files), (dd.read_table, pd.read_table, tsv_files)],
 )
-@read_table_mark
 def test_skiprows(dd_read, pd_read, files):
     files = {name: comment_header + b"\n" + content for name, content in files.items()}
     skip = len(comment_header.splitlines())
@@ -258,7 +253,6 @@ def test_skiprows(dd_read, pd_read, files):
     "dd_read,pd_read,files",
     [(dd.read_csv, pd.read_csv, csv_files), (dd.read_table, pd.read_table, tsv_files)],
 )
-@read_table_mark
 def test_skipfooter(dd_read, pd_read, files):
     files = {name: content + b"\n" + comment_footer for name, content in files.items()}
     skip = len(comment_footer.splitlines())
@@ -277,7 +271,6 @@ def test_skipfooter(dd_read, pd_read, files):
         (dd.read_table, pd.read_table, tsv_files, tsv_units_row),
     ],
 )
-@read_table_mark
 def test_skiprows_as_list(dd_read, pd_read, files, units):
     files = {
         name: (comment_header + b"\n" + content.replace(b"\n", b"\n" + units, 1))
@@ -304,7 +297,6 @@ tsv_blocks = [
 @pytest.mark.parametrize(
     "reader,blocks", [(pd.read_csv, csv_blocks), (pd.read_table, tsv_blocks)]
 )
-@read_table_mark
 def test_enforce_dtypes(reader, blocks):
     head = reader(BytesIO(blocks[0][0]), header=0)
     header = blocks[0][0].split(b"\n")[0] + b"\n"
@@ -316,7 +308,6 @@ def test_enforce_dtypes(reader, blocks):
 @pytest.mark.parametrize(
     "reader,blocks", [(pd.read_csv, csv_blocks), (pd.read_table, tsv_blocks)]
 )
-@read_table_mark
 def test_enforce_columns(reader, blocks):
     # Replace second header with different column name
     blocks = [blocks[0], [blocks[1][0].replace(b"a", b"A"), blocks[1][1]]]
@@ -340,7 +331,6 @@ def test_enforce_columns(reader, blocks):
         (dd.read_table, pd.read_table, tsv_text2, r"\s+"),
     ],
 )
-@read_table_mark
 def test_read_csv(dd_read, pd_read, text, sep):
     with filetext(text) as fn:
         f = dd_read(fn, blocksize=30, lineterminator=os.linesep, sep=sep)
@@ -357,7 +347,6 @@ def test_read_csv(dd_read, pd_read, text, sep):
         (dd.read_table, pd.read_table, tsv_text, [1, 13]),
     ],
 )
-@read_table_mark
 def test_read_csv_large_skiprows(dd_read, pd_read, text, skip):
     names = ["name", "amount"]
     with filetext(text) as fn:
@@ -372,7 +361,6 @@ def test_read_csv_large_skiprows(dd_read, pd_read, text, skip):
         (dd.read_table, pd.read_table, tsv_text, [1, 12]),
     ],
 )
-@read_table_mark
 def test_read_csv_skiprows_only_in_first_partition(dd_read, pd_read, text, skip):
     names = ["name", "amount"]
     with filetext(text) as fn:
@@ -390,7 +378,6 @@ def test_read_csv_skiprows_only_in_first_partition(dd_read, pd_read, text, skip)
     "dd_read,pd_read,files",
     [(dd.read_csv, pd.read_csv, csv_files), (dd.read_table, pd.read_table, tsv_files)],
 )
-@read_table_mark
 def test_read_csv_files(dd_read, pd_read, files):
     with filetexts(files, mode="b"):
         df = dd_read("2014-01-*.csv")
@@ -406,7 +393,6 @@ def test_read_csv_files(dd_read, pd_read, files):
     "dd_read,pd_read,files",
     [(dd.read_csv, pd.read_csv, csv_files), (dd.read_table, pd.read_table, tsv_files)],
 )
-@read_table_mark
 def test_read_csv_files_list(dd_read, pd_read, files):
     with filetexts(files, mode="b"):
         subset = sorted(files)[:2]  # Just first 2
@@ -421,7 +407,6 @@ def test_read_csv_files_list(dd_read, pd_read, files):
 @pytest.mark.parametrize(
     "dd_read,files", [(dd.read_csv, csv_files), (dd.read_table, tsv_files)]
 )
-@read_table_mark
 def test_read_csv_include_path_column(dd_read, files):
     with filetexts(files, mode="b"):
         df = dd_read(
@@ -438,7 +423,6 @@ def test_read_csv_include_path_column(dd_read, files):
 @pytest.mark.parametrize(
     "dd_read,files", [(dd.read_csv, csv_files), (dd.read_table, tsv_files)]
 )
-@read_table_mark
 def test_read_csv_include_path_column_as_str(dd_read, files):
     with filetexts(files, mode="b"):
         df = dd_read(
@@ -455,7 +439,6 @@ def test_read_csv_include_path_column_as_str(dd_read, files):
 @pytest.mark.parametrize(
     "dd_read,files", [(dd.read_csv, csv_files), (dd.read_table, tsv_files)]
 )
-@read_table_mark
 def test_read_csv_include_path_column_with_duplicate_name(dd_read, files):
     with filetexts(files, mode="b"):
         with pytest.raises(ValueError):
@@ -465,7 +448,6 @@ def test_read_csv_include_path_column_with_duplicate_name(dd_read, files):
 @pytest.mark.parametrize(
     "dd_read,files", [(dd.read_csv, csv_files), (dd.read_table, tsv_files)]
 )
-@read_table_mark
 def test_read_csv_include_path_column_is_dtype_category(dd_read, files):
     with filetexts(files, mode="b"):
         df = dd_read("2014-01-*.csv", include_path_column=True)
@@ -481,7 +463,6 @@ def test_read_csv_include_path_column_is_dtype_category(dd_read, files):
 @pytest.mark.parametrize(
     "dd_read,files", [(dd.read_csv, csv_files), (dd.read_table, tsv_files)]
 )
-@read_table_mark
 def test_read_csv_include_path_column_with_multiple_partitions_per_file(dd_read, files):
     with filetexts(files, mode="b"):
         df = dd_read("2014-01-*.csv", blocksize="10B", include_path_column=True)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -122,7 +122,6 @@ def test_head_tail():
     )
 
 
-@pytest.mark.filterwarnings("ignore:Insufficient:UserWarning")
 def test_head_npartitions():
     assert_eq(d.head(5, npartitions=2), full.head(5))
     assert_eq(d.head(5, npartitions=2, compute=False), full.head(5))

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -497,12 +497,6 @@ def test_groupby_set_index():
 
 
 @pytest.mark.parametrize("empty", [True, False])
-@pytest.mark.filterwarnings(
-    "ignore:0 should be:DeprecationWarning"
-)  # fixed in new pandas.
-@pytest.mark.filterwarnings(
-    "ignore:Promotion of numbers and bools to strings is deprecated:FutureWarning"
-)  #  _numpy_121 https://github.com/numpy/numpy/issues/19078
 def test_split_apply_combine_on_series(empty):
     if empty:
         pdf = pd.DataFrame({"a": [1.0], "b": [1.0]}, index=[0]).iloc[:0]
@@ -725,9 +719,6 @@ def test_split_apply_combine_on_series(empty):
 
 
 @pytest.mark.parametrize("keyword", ["split_every", "split_out"])
-@pytest.mark.filterwarnings(
-    "ignore:Promotion of numbers and bools to strings is deprecated:FutureWarning"
-)  # _numpy_121 https://github.com/numpy/numpy/issues/19078
 def test_groupby_reduction_split(keyword):
     pdf = pd.DataFrame(
         {"a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 100, "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100}

--- a/dask/dataframe/tests/test_hyperloglog.py
+++ b/dask/dataframe/tests/test_hyperloglog.py
@@ -48,18 +48,13 @@ rs = np.random.RandomState(96)
         ),
         pd.DataFrame({"x": [1, 2, 3] * 1000}),
         pd.DataFrame({"x": np.random.random(1000)}),
-        pytest.param(
-            pd.DataFrame(
-                {
-                    "a": [1, 2, 3] * 3,
-                    "b": [1.2, 3.4, 5.6] * 3,
-                    "c": [1 + 2j, 3 + 4j, 5 + 6j] * 3,
-                    "d": -(np.arange(9, dtype=np.int8)),
-                }
-            ),
-            marks=[
-                pytest.mark.filterwarnings("ignore::numpy.core.numeric.ComplexWarning")
-            ],
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3] * 3,
+                "b": [1.2, 3.4, 5.6] * 3,
+                "c": [1 + 2j, 3 + 4j, 5 + 6j] * 3,
+                "d": -(np.arange(9, dtype=np.int8)),
+            }
         ),
         pd.Series([1, 2, 3] * 1000),
         pd.Series(np.random.random(1000)),

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1672,7 +1672,6 @@ def test_concat3():
         )
 
 
-@pytest.mark.filterwarnings("ignore")
 def test_concat4_interleave_partitions():
     pdf1 = pd.DataFrame(
         np.random.randn(10, 5), columns=list("ABCDE"), index=list("abcdefghij")
@@ -1720,7 +1719,6 @@ def test_concat4_interleave_partitions():
     assert msg in str(err.value)
 
 
-@pytest.mark.filterwarnings("ignore")
 def test_concat5():
     pdf1 = pd.DataFrame(
         np.random.randn(7, 5), columns=list("ABCDE"), index=list("abcdefg")
@@ -1827,7 +1825,6 @@ def test_concat5():
         (False, False, False),
     ],
 )
-@pytest.mark.filterwarnings("ignore")
 def test_concat_categorical(known, cat_index, divisions):
     frames = [
         pd.DataFrame(
@@ -1980,7 +1977,6 @@ def test_append():
     check_with_warning(ddf.a, df3.b, df.a, df3.b)
 
 
-@pytest.mark.filterwarnings("ignore")
 def test_append2():
     dsk = {
         ("x", 0): pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}),

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -166,6 +166,8 @@ def test_ufunc_array_wrap(ufunc):
     - np.ufunc(dd.Series) => np.ndarray
     - np.ufunc(pd.Series) => np.ndarray
     """
+    if ufunc == "fix":
+        pytest.skip("fix calls floor in a way that we do not yet support")
 
     dafunc = getattr(da, ufunc)
     npfunc = getattr(np, ufunc)

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -166,8 +166,6 @@ def test_ufunc_array_wrap(ufunc):
     - np.ufunc(dd.Series) => np.ndarray
     - np.ufunc(pd.Series) => np.ndarray
     """
-    if ufunc == "fix" and np.__version__ >= "1.13.0":
-        pytest.skip("fix calls floor in a way that we do not yet support")
 
     dafunc = getattr(da, ufunc)
     npfunc = getattr(np, ufunc)


### PR DESCRIPTION
The goal of these changes is to get rid of warning filters in tests wherever possible. 