### PR TITLE
Add link to diagnostic visualize function in local diagnostic docs

### DIFF
--- a/docs/source/diagnostics-local.rst
+++ b/docs/source/diagnostics-local.rst
@@ -185,7 +185,7 @@ These can be analyzed separately or viewed in a bokeh plot using the provided
             marginwidth="0" marginheight="0" scrolling="no"
             width="650" height="300" style="border:none"></iframe>
 
-To view multiple profilers at the same time, the ``dask.diagnostics.visualize``
+To view multiple profilers at the same time, the :func:`dask.diagnostics.visualize`
 function can be used. This takes a list of profilers and creates a vertical
 stack of plots aligned along the x-axis:
 


### PR DESCRIPTION
I was reading the diagnostic docs and got annoyed that I didn't know where the visualize method API docs were defined when it was reading about its usage. I was going to do the same for the visualize method of the profiler classes, but the way these are documented doesn't seem to allow for this.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
