### PR TITLE
Include divisions when doing `Index.to_series`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3883,7 +3883,11 @@ class Index(Series):
 
     @derived_from(pd.Index)
     def to_series(self):
-        return self.map_partitions(M.to_series, meta=self._meta.to_series())
+        return self.map_partitions(
+            M.to_series,
+            meta=self._meta.to_series(),
+            transform_divisions=False,
+        )
 
     @derived_from(pd.Index, ua_args=["index"])
     def to_frame(self, index=True, name=None):

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -498,57 +498,43 @@ def test_getitem_period_str():
     assert_eq(df["2011":"2015"], ddf["2011":"2015"])
 
 
-def test_to_series():
-
-    # Test for time index
-    df = pd.DataFrame(
-        {"A": np.random.randn(100)},
-        index=pd.date_range("2011-01-01", freq="H", periods=100),
-    )
+@pytest.mark.parametrize(
+    "index",
+    [
+        pd.date_range("2011-01-01", freq="H", periods=100),  # time index
+        range(100),  # numerical index
+    ],
+)
+def test_to_series(index):
+    df = pd.DataFrame({"A": np.random.randn(100)}, index=index)
     ddf = dd.from_pandas(df, 10)
 
-    assert_eq(df.index.to_series(), ddf.index.to_series())
+    expected = df.index.to_series()
+    actual = ddf.index.to_series()
 
-    # Test for numerical index
-    df = pd.DataFrame({"A": np.random.randn(100)}, index=range(100))
+    assert actual.known_divisions
+    assert_eq(expected, actual)
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        pd.date_range("2011-01-01", freq="H", periods=100),  # time index
+        range(100),  # numerical index
+    ],
+)
+def test_to_frame(index):
+    df = pd.DataFrame({"A": np.random.randn(100)}, index=index)
     ddf = dd.from_pandas(df, 10)
 
-    assert_eq(df.index.to_series(), ddf.index.to_series())
+    expected = df.index.to_frame()
+    actual = ddf.index.to_frame()
 
+    assert actual.known_divisions
+    assert_eq(expected, actual)
 
-def test_to_frame():
-
-    # Test for time index
-    df = pd.DataFrame(
-        {"A": np.random.randn(100)},
-        index=pd.date_range("2011-01-01", freq="H", periods=100),
-    )
-    ddf = dd.from_pandas(df, 10)
-
-    assert_eq(df.index.to_frame(), ddf.index.to_frame())
-
-    # Test for numerical index
-    df = pd.DataFrame({"A": np.random.randn(100)}, index=range(100))
-    ddf = dd.from_pandas(df, 10)
-
-    assert_eq(df.index.to_frame(), ddf.index.to_frame())
-
-
-def test_to_frame_name():
-    # Test for time index
-    df = pd.DataFrame(
-        {"A": np.random.randn(100)},
-        index=pd.date_range("2011-01-01", freq="H", periods=100),
-    )
-    ddf = dd.from_pandas(df, 10)
-
+    # test name option
     assert_eq(df.index.to_frame(name="foo"), ddf.index.to_frame(name="foo"))
-
-    # Test for numerical index
-    df = pd.DataFrame({"A": np.random.randn(100)}, index=range(100))
-    ddf = dd.from_pandas(df, 10)
-
-    assert_eq(df.index.to_frame(name="bar"), ddf.index.to_frame(name="bar"))
 
 
 @pytest.mark.parametrize("indexer", [0, [0], [0, 1], [1, 0], [False, True, True]])


### PR DESCRIPTION
On main, the following snippet produces an error:

```python
import dask

ddf = dask.datasets.timeseries()
ddf["time"] = ddf.index.to_series().dt.time
```
```python-traceback
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-1-267fbe06d587> in <module>
      2 
      3 ddf = dask.datasets.timeseries()
----> 4 ddf["time"] = ddf.index.to_series().dt.time

~/dask/dask/dataframe/core.py in __setitem__(self, key, value)
   4115             raise NotImplementedError(f"Item assignment with {type(key)} not supported")
   4116         else:
-> 4117             df = self.assign(**{key: value})
   4118 
   4119         self.dask = df.dask

~/dask/dask/dataframe/core.py in assign(self, **kwargs)
   4428         # Figure out columns of the output
   4429         df2 = self._meta_nonempty.assign(**_extract_meta(kwargs, nonempty=True))
-> 4430         return elemwise(methods.assign, self, *pairs, meta=df2)
   4431 
   4432     @derived_from(pd.DataFrame, ua_args=["index"])

~/dask/dask/dataframe/core.py in elemwise(op, *args, **kwargs)
   5362     from .multi import _maybe_align_partitions
   5363 
-> 5364     args = _maybe_align_partitions(args)
   5365     dasks = [arg for arg in args if isinstance(arg, (_Frame, Scalar, Array))]
   5366     dfs = [df for df in dasks if isinstance(df, _Frame)]

~/dask/dask/dataframe/multi.py in _maybe_align_partitions(args)
    166     divisions = dfs[0].divisions
    167     if not all(df.divisions == divisions for df in dfs):
--> 168         dfs2 = iter(align_partitions(*dfs)[0])
    169         return [a if not isinstance(a, _Frame) else next(dfs2) for a in args]
    170     return args

~/dask/dask/dataframe/multi.py in align_partitions(*dfs)
    120         raise ValueError("dfs contains no DataFrame and Series")
    121     if not all(df.known_divisions for df in dfs1):
--> 122         raise ValueError(
    123             "Not all divisions are known, can't align "
    124             "partitions. Please use `set_index` "

ValueError: Not all divisions are known, can't align partitions. Please use `set_index` to set the index.
```

