### PR TITLE
Raise error when setitem on unknown chunks

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1682,6 +1682,9 @@ class Array(DaskMethodsMixin):
             self._chunks = y.chunks
             return
 
+        if np.isnan(self.shape).any():
+            raise ValueError(f"Arrays chunk sizes are unknown. {unknown_chunk_message}")
+
         # Still here? Then apply the assignment to other type of
         # indices via the `setitem_array` function.
         value = asanyarray(value)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3954,9 +3954,10 @@ def test_setitem_errs():
     with pytest.raises(ValueError):
         dx[...] = np.arange(24).reshape((2, 1, 3, 4))
 
-    # RHS has extra leading size 1 dimensions compared to LHS
-    x = np.arange(12).reshape((3, 4))
-    dx = da.from_array(x, chunks=(2, 3))
+    # RHS doesn't have chunks set
+    dx = da.unique(da.random.random([10]))
+    with pytest.raises(ValueError, match="Arrays chunk sizes are unknown"):
+        dx[0] = 0
 
 
 def test_zero_slice_dtypes():


### PR DESCRIPTION
- [x] Closes #8164
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
