### PR TITLE
Add handling for null values in `sort_values`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4212,7 +4212,7 @@ class DataFrame(_Frame):
         ascending: bool, optional
             Sort ascending vs. descending.
             Defaults to True.
-        na_position: bool, optional
+        na_position: {'last', 'first'}, optional
             Puts NaNs at the beginning if 'first', puts NaN at the end if 'last'.
             Defaults to 'last'.
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4195,7 +4195,9 @@ class DataFrame(_Frame):
         cs = self._meta.select_dtypes(include=include, exclude=exclude).columns
         return self[list(cs)]
 
-    def sort_values(self, by, npartitions=None, ascending=True, **kwargs):
+    def sort_values(
+        self, by, npartitions=None, ascending=True, na_position="last", **kwargs
+    ):
         """Sort the dataset by a single column.
 
         Sorting a parallel dataset requires expensive shuffles and is generally
@@ -4222,6 +4224,7 @@ class DataFrame(_Frame):
             by,
             ascending=ascending,
             npartitions=npartitions,
+            na_position=na_position,
             **kwargs,
         )
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4210,8 +4210,11 @@ class DataFrame(_Frame):
             The ideal number of output partitions. If None, use the same as
             the input. If 'auto' then decide by memory use.
         ascending: bool, optional
-            Non ascending sort is not supported by Dask.
+            Sort ascending vs. descending.
             Defaults to True.
+        na_position: bool, optional
+            Puts NaNs at the beginning if 'first', puts NaN at the end if 'last'.
+            Defaults to 'last'.
 
         Examples
         --------

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -126,7 +126,12 @@ def sort_values(
         )
 
     df = rearrange_by_divisions(
-        df, by, divisions, ascending=ascending, na_position=na_position
+        df,
+        by,
+        divisions,
+        ascending=ascending,
+        na_position=na_position,
+        duplicates=False,
     )
     df = df.map_partitions(
         M.sort_values, by, ascending=ascending, na_position=na_position
@@ -400,9 +405,13 @@ def rearrange_by_divisions(
     shuffle=None,
     ascending=True,
     na_position="last",
+    duplicates=True,
 ):
     """Shuffle dataframe so that column separates along divisions"""
-    divisions = df._meta._constructor_sliced(divisions).drop_duplicates()
+    divisions = df._meta._constructor_sliced(divisions)
+    # duplicates need to be removed sometimes to properly sort null dataframes
+    if not duplicates:
+        divisions = divisions.drop_duplicates()
     meta = df._meta._constructor_sliced([0])
     # Assign target output partitions to every row
     partitions = df[column].map_partitions(


### PR DESCRIPTION
Makes changes to `sort_values` so that null values are no longer dropped. and their position can be specified with `na_position`; this should help upstream some logic in dask-sql's sorting algorithm.

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
