### PR TITLE
Groupby Rolling

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1821,10 +1821,6 @@ class _GroupBy:
            adjacent partition. If using an offset or offset alias like '5D',
            the data must have a ``DatetimeIndex``
 
-           .. versionchanged:: 0.15.0
-
-              Now accepts offsets and string offset aliases
-
         min_periods : int, default None
             Minimum number of observations in window required to have a value
             (otherwise result is NA).

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -452,8 +452,15 @@ class RollingGroupby(Rolling):
         self._groupby_slice = groupby._slice
 
         obj = groupby.obj
-        if self._groupby_slice:
-            sliced_plus = [self._groupby_slice, groupby.index]
+        if self._groupby_slice is not None:
+            if isinstance(self._groupby_slice, str):
+                sliced_plus = [self._groupby_slice]
+            else:
+                sliced_plus = list(self._groupby_slice)
+            if isinstance(groupby.index, str):
+                sliced_plus.append(groupby.index)
+            else:
+                sliced_plus.extend(groupby.index)
             obj = obj[sliced_plus]
 
         super().__init__(

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -401,3 +401,25 @@ def test_rolling_numba_engine():
         df.rolling(3).apply(f, engine="numba", raw=True),
         ddf.rolling(3).apply(f, engine="numba", raw=True),
     )
+
+
+def test_groupby_rolling():
+    df = pd.DataFrame(
+        {
+            "column1": range(600),
+            "group1": 5 * ["g" + str(i) for i in range(120)],
+        },
+        index=pd.date_range("20190101", periods=60).repeat(10),
+    )
+
+    ddf = dd.from_pandas(df, npartitions=8)
+
+    expected = df.groupby("group1").rolling("15D").sum()
+    actual = ddf.groupby("group1").rolling("15D").sum()
+
+    assert_eq(expected, actual, check_divisions=False)
+
+    expected = df.groupby("group1").column1.rolling("15D").mean()
+    actual = ddf.groupby("group1").column1.rolling("15D").mean()
+
+    assert_eq(expected, actual, check_divisions=False)

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -423,3 +423,13 @@ def test_groupby_rolling():
     actual = ddf.groupby("group1").column1.rolling("15D").mean()
 
     assert_eq(expected, actual, check_divisions=False)
+
+
+def test_groupby_rolling_with_integer_window_raises():
+    df = pd.DataFrame(
+        {"B": [0, 1, 2, np.nan, 4, 5, 6], "C": ["a", "a", "a", "b", "b", "a", "b"]}
+    )
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    with pytest.raises(ValueError, match="``window`` must be a ``freq``"):
+        ddf.groupby("C").rolling(2).sum()

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -291,6 +291,8 @@ DataFrame Groupby
    DataFrameGroupBy.last
    DataFrameGroupBy.idxmin
    DataFrameGroupBy.idxmax
+   DataFrameGroupBy.rolling
+
 
 Series Groupby
 **************
@@ -317,6 +319,7 @@ Series Groupby
    SeriesGroupBy.last
    SeriesGroupBy.idxmin
    SeriesGroupBy.idxmax
+   SeriesGroupBy.rolling
 
 Custom Aggregation
 ******************


### PR DESCRIPTION
- [x] Closes #5974
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
- [x] Docs added

Implements overlap first, groupby rolling. This is based on the idea put forward in this comment:

https://github.com/dask/dask/issues/6498#issuecomment-671983351