### PR TITLE
Dispatch walks mro for lazily registered handlers

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -161,6 +161,38 @@ def test_dispatch_lazy():
     assert foo(1) == 1
 
 
+def test_dispatch_lazy_walks_mro():
+    """Check that subclasses of classes with lazily registered handlers still
+    use their parent class's handler by default"""
+    import decimal
+
+    class Lazy(decimal.Decimal):
+        pass
+
+    class Eager(Lazy):
+        pass
+
+    foo = Dispatch()
+
+    @foo.register(Eager)
+    def eager_handler(x):
+        return "eager"
+
+    def lazy_handler(a):
+        return "lazy"
+
+    @foo.register_lazy("decimal")
+    def register_decimal():
+        foo.register(decimal.Decimal, lazy_handler)
+
+    assert foo.dispatch(Lazy) == lazy_handler
+    assert foo(Lazy(1)) == "lazy"
+    assert foo.dispatch(decimal.Decimal) == lazy_handler
+    assert foo(decimal.Decimal(1)) == "lazy"
+    assert foo.dispatch(Eager) == eager_handler
+    assert foo(Eager(1)) == "eager"
+
+
 def test_random_state_data():
     np = pytest.importorskip("numpy")
     seed = 37

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -544,28 +544,26 @@ class Dispatch:
 
     def dispatch(self, cls):
         """Return the function implementation for the given ``cls``"""
-        # Fast path with direct lookup on cls
         lk = self._lookup
-        try:
-            impl = lk[cls]
-        except KeyError:
-            pass
-        else:
-            return impl
-        # Is a lazy registration function present?
-        toplevel, _, _ = cls.__module__.partition(".")
-        try:
-            register = self._lazy.pop(toplevel)
-        except KeyError:
-            pass
-        else:
-            register()
-            return self.dispatch(cls)  # recurse
-        # Walk the MRO and cache the lookup result
-        for cls2 in inspect.getmro(cls)[1:]:
-            if cls2 in lk:
-                lk[cls] = lk[cls2]
-                return lk[cls2]
+        for cls2 in cls.__mro__:
+            try:
+                impl = lk[cls2]
+            except KeyError:
+                pass
+            else:
+                if cls is not cls2:
+                    # Cache lookup
+                    lk[cls] = impl
+                return impl
+            # Is a lazy registration function present?
+            toplevel, _, _ = cls2.__module__.partition(".")
+            try:
+                register = self._lazy.pop(toplevel)
+            except KeyError:
+                pass
+            else:
+                register()
+                return self.dispatch(cls)  # recurse
         raise TypeError("No dispatch for {0}".format(cls))
 
     def __call__(self, arg, *args, **kwargs):


### PR DESCRIPTION
Previously when `Dispatch` walked the `mro` of a class, it would only
look for eagerly registered handlers (instead of lazily registered
handlers). This meant that subclasses of lazily registered handlers
would only be used when dispatching on a subclass if the parent class
had been dispatched on earlier (this triggering the registration).

This patch fixes this to check for lazily registered handlers when
walking the mro. This results in negligible slowdown during the fast
path.

Fixes #8111.

- [x] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
