### PR TITLE
Fix to_parquet bug in call to pyarrow.parquet.read_metadata

### DIFF
--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -476,7 +476,7 @@ def test_parquet(s3, engine, s3so, metadata_file):
     )
     assert len(df2.divisions) > 1
 
-    pd.testing.assert_frame_equal(data, df2.compute())
+    dd.utils.assert_eq(data, df2)
 
 
 @pytest.mark.parametrize("engine", ["pyarrow", "fastparquet"])
@@ -526,9 +526,10 @@ def test_parquet_append(s3, engine, s3so):
         storage_options=s3so,
     )
 
-    pd.testing.assert_frame_equal(
-        pd.concat([data, data], ignore_index=True),
-        df2.compute().reset_index(drop=True),
+    dd.utils.assert_eq(
+        pd.concat([data, data]),
+        df2,
+        check_index=False,
     )
 
 

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -479,6 +479,27 @@ def test_parquet(s3, engine, s3so, metadata_file):
 
     tm.assert_frame_equal(data, df2.compute())
 
+    # Check that a simple append operation works
+    if metadata_file:
+        df.to_parquet(
+            url,
+            engine=engine,
+            storage_options=s3so,
+            write_metadata_file=metadata_file,
+            ignore_divisions=True,
+            append=True,
+        )
+
+        df3 = dd.read_parquet(
+            url,
+            index="foo",
+            gather_statistics=True,
+            engine=engine,
+            storage_options=s3so,
+        )
+
+        assert len(df3) == 2 * len(df2)
+
 
 def test_parquet_wstoragepars(s3, s3so):
     dd = pytest.importorskip("dask.dataframe")

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -435,7 +435,6 @@ def test_parquet(s3, engine, s3so, metadata_file):
     dd = pytest.importorskip("dask.dataframe")
     pd = pytest.importorskip("pandas")
     np = pytest.importorskip("numpy")
-    from dask.dataframe._compat import tm
 
     lib = pytest.importorskip(engine)
     lib_version = parse_version(lib.__version__)
@@ -477,7 +476,7 @@ def test_parquet(s3, engine, s3so, metadata_file):
     )
     assert len(df2.divisions) > 1
 
-    tm.assert_frame_equal(data, df2.compute())
+    pd.testing.assert_frame_equal(data, df2.compute())
 
 
 @pytest.mark.parametrize("engine", ["pyarrow", "fastparquet"])
@@ -486,7 +485,6 @@ def test_parquet_append(s3, engine, s3so):
     dd = pytest.importorskip("dask.dataframe")
     pd = pytest.importorskip("pandas")
     np = pytest.importorskip("numpy")
-    from dask.dataframe._compat import tm
 
     url = "s3://%s/test.parquet.append" % test_bucket_name
 
@@ -528,7 +526,7 @@ def test_parquet_append(s3, engine, s3so):
         storage_options=s3so,
     )
 
-    tm.assert_frame_equal(
+    pd.testing.assert_frame_equal(
         pd.concat([data, data], ignore_index=True),
         df2.compute().reset_index(drop=True),
     )

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -748,7 +748,8 @@ class ArrowDatasetEngine(Engine):
                 # No dataset to append to
                 return fmd, i_offset, False
             try:
-                fmd = pq.read_metadata(fs.sep.join([path, "_metadata"]))
+                with fs.open(fs.sep.join([path, "_metadata"]), mode="rb") as fil:
+                    fmd = pq.read_metadata(fil)
             except (IOError, FileNotFoundError):
                 # No _metadata file present - No appending allowed (for now)
                 if not ignore_divisions:


### PR DESCRIPTION
- [x] Closes #8175
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`
