### PR TITLE
Suppress `OSError` in `tmpfile`

### DIFF
--- a/dask/utils.py
+++ b/dask/utils.py
@@ -174,10 +174,10 @@ def tmpfile(extension="", dir=None):
         yield filename
     finally:
         if os.path.exists(filename):
-            if os.path.isdir(filename):
-                shutil.rmtree(filename)
-            else:
-                with suppress(OSError):
+            with suppress(OSError):  # sometimes we can't remove a generated temp file
+                if os.path.isdir(filename):
+                    shutil.rmtree(filename)
+                else:
                     os.remove(filename)
 
 


### PR DESCRIPTION
In https://github.com/dask/distributed/pull/5361, I'm proposing we deprecate the `tmpfile` utility in `distributed` in favor of using the upstream `tmpfile` utility here in `dask`. This change revealed an edge case (on Windows) where an `OSError` can be raised when we call `shutil.rmtree` in `tmpfile` (see [this CI build](https://github.com/dask/distributed/runs/3726243303) for an example). This PR proposes we `suppress` that exception (which was already done in `distributed`) similar to how we currently `suppress(OSError)` when we call `os.remove` in `tmpfile`.  

cc @jsignell for thoughts 