### PR TITLE
Support negative drop_axis in map_blocks and map_overlap

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -697,8 +697,10 @@ def map_blocks(
     if drop_axis:
         ndim_out = len(out_ind)
         if any(i < -ndim_out or i >= ndim_out for i in drop_axis):
-            raise ValueError(f"drop_axis out of range (drop_axis={drop_axis}, "
-                             f"but output is {ndim_out}d).")
+            raise ValueError(
+                f"drop_axis out of range (drop_axis={drop_axis}, "
+                f"but output is {ndim_out}d)."
+            )
         drop_axis = [i % ndim_out for i in drop_axis]
         out_ind = tuple(x for i, x in enumerate(out_ind) if i not in drop_axis)
     if new_axis is None and chunks is not None and len(out_ind) < len(chunks):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -695,8 +695,11 @@ def map_blocks(
         dtype = apply_infer_dtype(func, args, original_kwargs, "map_blocks")
 
     if drop_axis:
-        if any(i < 0 for i in drop_axis):
-            raise ValueError(f"Expected drop_axis to be non-negative; got {drop_axis}.")
+        ndim_out = len(out_ind)
+        if any(i < -ndim_out or i >= ndim_out for i in drop_axis):
+            raise ValueError(f"drop_axis out of range (drop_axis={drop_axis}, "
+                             f"but output is {ndim_out}d).")
+        drop_axis = [i % ndim_out for i in drop_axis]
         out_ind = tuple(x for i, x in enumerate(out_ind) if i not in drop_axis)
     if new_axis is None and chunks is not None and len(out_ind) < len(chunks):
         new_axis = range(len(chunks) - len(out_ind))

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -703,6 +703,11 @@ def map_overlap(
         if drop_axis is not None:
             if isinstance(drop_axis, Number):
                 drop_axis = [drop_axis]
+
+            # convert negative drop_axis to equivalent positive value
+            ndim_out = max([a.ndim for a in args if isinstance(a, Array)])
+            drop_axis = [d % ndim_out for d in drop_axis]
+
             kept_axes = tuple(ax for ax in range(args[i].ndim) if ax not in drop_axis)
             # note that keys are relabeled to match values in range(x.ndim)
             depth = {n: depth[ax] for n, ax in enumerate(kept_axes)}

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3125,6 +3125,26 @@ def test_map_blocks_with_changed_dimension():
     assert_eq(e, x.sum(axis=1)[:, None, None])
 
 
+def test_map_blocks_with_negative_drop_axis():
+    x = np.arange(56).reshape((7, 8))
+    d = da.from_array(x, chunks=(7, 4))
+
+    for drop_axis in [0, -2]:
+        # test with equivalent positive and negative drop_axis
+        e = d.map_blocks(lambda b: b.sum(axis=0), chunks=(4,), drop_axis=drop_axis, dtype=d.dtype)
+        assert e.chunks == ((4, 4),)
+        assert_eq(e, x.sum(axis=0))
+
+
+def test_map_blocks_with_invalid_drop_axis():
+    x = np.arange(56).reshape((7, 8))
+    d = da.from_array(x, chunks=(7, 4))
+
+    for drop_axis in [x.ndim, -x.ndim - 1]:
+        with pytest.raises(ValueError):
+            d.map_blocks(lambda b: b.sum(axis=0), chunks=(4,), drop_axis=drop_axis, dtype=d.dtype)
+
+
 def test_map_blocks_with_changed_dimension_and_broadcast_chunks():
     # https://github.com/dask/dask/issues/4299
     a = da.from_array([1, 2, 3], 3)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3131,7 +3131,9 @@ def test_map_blocks_with_negative_drop_axis():
 
     for drop_axis in [0, -2]:
         # test with equivalent positive and negative drop_axis
-        e = d.map_blocks(lambda b: b.sum(axis=0), chunks=(4,), drop_axis=drop_axis, dtype=d.dtype)
+        e = d.map_blocks(
+            lambda b: b.sum(axis=0), chunks=(4,), drop_axis=drop_axis, dtype=d.dtype
+        )
         assert e.chunks == ((4, 4),)
         assert_eq(e, x.sum(axis=0))
 
@@ -3142,7 +3144,9 @@ def test_map_blocks_with_invalid_drop_axis():
 
     for drop_axis in [x.ndim, -x.ndim - 1]:
         with pytest.raises(ValueError):
-            d.map_blocks(lambda b: b.sum(axis=0), chunks=(4,), drop_axis=drop_axis, dtype=d.dtype)
+            d.map_blocks(
+                lambda b: b.sum(axis=0), chunks=(4,), drop_axis=drop_axis, dtype=d.dtype
+            )
 
 
 def test_map_blocks_with_changed_dimension_and_broadcast_chunks():

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -447,7 +447,25 @@ def test_map_overlap_multiarray_variadic():
     assert all(x.compute() == size_per_slice)
 
 
-@pytest.mark.parametrize("drop_axis", ((0,), (1,), (2,), (0, 1), (1, 2), (2, 0), 1))
+@pytest.mark.parametrize(
+    "drop_axis",
+    (
+        (0,),
+        (1,),
+        (2,),
+        (0, 1),
+        (1, 2),
+        (2, 0),
+        1,
+        (-3,),
+        (-2,),
+        (-1,),
+        (-3, -2),
+        (-2, -1),
+        (-1, -3),
+        -2,
+    ),
+)
 def test_map_overlap_trim_using_drop_axis_and_different_depths(drop_axis):
     x = da.random.standard_normal((5, 10, 8), chunks=(2, 5, 4))
 
@@ -461,6 +479,7 @@ def test_map_overlap_trim_using_drop_axis_and_different_depths(drop_axis):
     depth = (1, 3, 2)
     # to match expected result, dropped axes must have depth 0
     _drop_axis = (drop_axis,) if np.isscalar(drop_axis) else drop_axis
+    _drop_axis = [d % x.ndim for d in _drop_axis]
     depth = tuple(0 if i in _drop_axis else d for i, d in enumerate(depth))
 
     y = da.map_overlap(


### PR DESCRIPTION
This PR allows the `drop_axis` argument of `map_blocks` and `map_overlap` to use negative axis values in the same manner as functions in the NumPy API. 

This improves on #8064 which added a more informative error message on negative `drop_axis` (closing #7924). This PR changes the error to only occur when the specified axis exceeds the dimensions of the output array, otherwise the axis is converted to the equivalent positive-valued axis.