### PR TITLE
Use `s.isna` instead of `pd.isna(s)` in `set_partitions_pre` (fix cudf CI)

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -791,11 +791,8 @@ def set_partitions_pre(s, divisions, ascending=True, na_position="last"):
         else:
             partitions = len(divisions) - divisions.searchsorted(s, side="right") - 1
     except TypeError:
-        # When `searchsorted` fails with `TypeError`, it may be
-        # caused by nulls in `s`. Try again with the null-values
-        # explicitly mapped to the first partition.
+        # `searchsorted` fails if `s` contains nulls and strings
         partitions = np.empty(len(s), dtype="int32")
-        partitions[s.isna()] = 0
         not_null = s.notna()
         if ascending:
             partitions[not_null] = divisions.searchsorted(s[not_null], side="right") - 1

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -785,24 +785,10 @@ def collect(p, part, meta, barrier_token):
 
 
 def set_partitions_pre(s, divisions, ascending=True, na_position="last"):
-    try:
-        if ascending:
-            partitions = divisions.searchsorted(s, side="right") - 1
-        else:
-            partitions = len(divisions) - divisions.searchsorted(s, side="right") - 1
-    except TypeError:
-        # When `searchsorted` fails with `TypeError`, it may be
-        # caused by nulls in `s`. Try again with the null-values
-        # explicitly mapped to the first partition.
-        partitions = np.empty(len(s), dtype="int32")
-        partitions[s.isna()] = 0
-        not_null = s.notna()
-        if ascending:
-            partitions[not_null] = divisions.searchsorted(s[not_null], side="right") - 1
-        else:
-            partitions[not_null] = (
-                len(divisions) - divisions.searchsorted(s[not_null], side="right") - 1
-            )
+    if ascending:
+        partitions = divisions.searchsorted(s, side="right") - 1
+    else:
+        partitions = len(divisions) - divisions.searchsorted(s, side="right") - 1
     partitions[(partitions < 0) | (partitions >= len(divisions) - 1)] = (
         len(divisions) - 2 if ascending else 0
     )

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -806,7 +806,7 @@ def set_partitions_pre(s, divisions, ascending=True, na_position="last"):
     partitions[(partitions < 0) | (partitions >= len(divisions) - 1)] = (
         len(divisions) - 2 if ascending else 0
     )
-    partitions[pd.isna(s).values] = len(divisions) - 2 if na_position == "last" else 0
+    partitions[s.isna().values] = len(divisions) - 2 if na_position == "last" else 0
     return partitions
 
 


### PR DESCRIPTION
With #8167, an additional null check was added to `set_partitions_pre` using `pd.isna(s)`. Because this function is sometimes accessed by `dask_cudf.set_index`, making `s` a cuDF series, we would see a failure trying to call the Pandas function:

```
../envs/cudfdev/lib/python3.8/site-packages/dask/dataframe/shuffle.py:809: in set_partitions_pre
    partitions[pd.isna(s).values] = len(divisions) - 2 if na_position == "last" else 0
../envs/cudfdev/lib/python3.8/site-packages/pandas/core/dtypes/missing.py:138: in isna
    return _isna(obj)
../envs/cudfdev/lib/python3.8/site-packages/pandas/core/dtypes/missing.py:185: in _isna
    return _isna_array(np.asarray(obj), inf_as_na=inf_as_na)

    def __array__(self, dtype=None):
>       raise TypeError(
            "Implicit conversion to a host NumPy array via __array__ is not "
            "allowed, To explicitly construct a GPU array, consider using "
            "cupy.asarray(...)\nTo explicitly construct a "
            "host array, consider using .to_array()"
        )
E       TypeError: Implicit conversion to a host NumPy array via __array__ is not allowed, To explicitly construct a GPU array, consider using cupy.asarray(...)
E       To explicitly construct a host array, consider using .to_array()
```

This PR switches this null check to `s.isna()`, which works for both Pandas and cuDF dataframes; additionally, the try/except block in `set_partitions_pre` is removed, as it shouldn't be needed now that multiple nulls in `divisions` are handled elsewhere in the `sort_values` logic.

cc @galipremsagar @quasiben 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
