### PR TITLE
Remove `try..except` block in `set_partitions_pre`

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -785,25 +785,18 @@ def collect(p, part, meta, barrier_token):
 
 
 def set_partitions_pre(s, divisions, ascending=True, na_position="last"):
-    try:
-        if ascending:
-            partitions = divisions.searchsorted(s, side="right") - 1
-        else:
-            partitions = len(divisions) - divisions.searchsorted(s, side="right") - 1
-    except TypeError:
-        # `searchsorted` fails if `s` contains nulls and strings
-        partitions = np.empty(len(s), dtype="int32")
-        not_null = s.notna()
-        if ascending:
-            partitions[not_null] = divisions.searchsorted(s[not_null], side="right") - 1
-        else:
-            partitions[not_null] = (
-                len(divisions) - divisions.searchsorted(s[not_null], side="right") - 1
-            )
+    partitions = np.zeros(len(s))
+    not_null = s.notna().values
+    if ascending:
+        partitions[not_null] = divisions.searchsorted(s[not_null], side="right") - 1
+    else:
+        partitions[not_null] = (
+            len(divisions) - divisions.searchsorted(s[not_null], side="right") - 1
+        )
+    partitions[s.isna().values] = len(divisions) - 2 if na_position == "last" else 0
     partitions[(partitions < 0) | (partitions >= len(divisions) - 1)] = (
         len(divisions) - 2 if ascending else 0
     )
-    partitions[s.isna().values] = len(divisions) - 2 if na_position == "last" else 0
     return partitions
 
 


### PR DESCRIPTION
As discussed in #8193, now that Dask's `sort_values` has null handling, it might be worthwhile refactoring `set_partitions_pre` to remove the `try..except` block there. Now the function does the following:

- Calls `searchsorted` on only the non-null elements of `divisions` and `s` (avoiding the failure caused when `divisions` and `s` contain strings)
- Uses item assignment to place the null elements of `s` in the correct partition based on `na_position`
- Uses item assignment to place any elements of `s` incorrectly sorted by `searchsorted` into the correct partition based on `ascending`

Additionally, as suggested by @rjzamora there might be less overhead by initializing our `partitions` array with `np.zeros` rather than `np.empty`.

After the cuDF breakage that resulted from #8167, I would prefer merging this after we have some additional dask-cuDF testing for `set_index`.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
