### PR TITLE
Use `pytest.param` to properly label param-specific GPU tests

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2240,8 +2240,13 @@ def test_groupby_split_out_multiindex(split_out, column):
     assert_eq(ddf_result, ddf_result_so1, check_index=False)
 
 
-@pytest.mark.gpu
-@pytest.mark.parametrize("backend", ["cudf", "pandas"])
+@pytest.mark.parametrize(
+    "backend",
+    [
+        "pandas",
+        pytest.param("cudf", marks=pytest.mark.gpu),
+    ],
+)
 def test_groupby_large_ints_exception(backend):
     data_source = pytest.importorskip(backend)
     if backend == "cudf":

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -847,19 +847,18 @@ def test_merge(how, shuffle):
     #         pd.merge(A, B, left_index=True, right_on='y'))
 
 
-@pytest.mark.gpu
 @pytest.mark.parametrize("parts", [(3, 3), (3, 1), (1, 3)])
 @pytest.mark.parametrize("how", ["leftsemi", "leftanti"])
 @pytest.mark.parametrize(
     "engine",
     [
-        "cudf",
         pytest.param(
             "pandas",
             marks=pytest.mark.xfail(
                 reason="Pandas does not support leftsemi or leftanti"
             ),
         ),
+        pytest.param("cudf", marks=pytest.mark.gpu),
     ],
 )
 def test_merge_tasks_semi_anti_cudf(engine, how, parts):
@@ -2148,8 +2147,9 @@ def test_dtype_equality_warning():
     assert len(r) == 0
 
 
-@pytest.mark.gpu
-@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+@pytest.mark.parametrize(
+    "engine", ["pandas", pytest.param("cudf", marks=pytest.mark.gpu)]
+)
 def test_groupby_concat_cudf(engine):
 
     # NOTE: Issue #5643 Reproducer

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -620,8 +620,9 @@ def test_set_index():
     assert_eq(d5, full.set_index(["b"]))
 
 
-@pytest.mark.gpu
-@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+@pytest.mark.parametrize(
+    "engine", ["pandas", pytest.param("cudf", marks=pytest.mark.gpu)]
+)
 def test_set_index_interpolate(engine):
     if engine == "cudf":
         # NOTE: engine == "cudf" requires cudf/dask_cudf,
@@ -648,8 +649,9 @@ def test_set_index_interpolate(engine):
     assert d2.divisions[3] == 2.0
 
 
-@pytest.mark.gpu
-@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+@pytest.mark.parametrize(
+    "engine", ["pandas", pytest.param("cudf", marks=pytest.mark.gpu)]
+)
 def test_set_index_interpolate_int(engine):
     if engine == "cudf":
         # NOTE: engine == "cudf" requires cudf/dask_cudf,
@@ -671,8 +673,9 @@ def test_set_index_interpolate_int(engine):
     assert all(np.issubdtype(type(x), np.integer) for x in d1.divisions)
 
 
-@pytest.mark.gpu
-@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+@pytest.mark.parametrize(
+    "engine", ["pandas", pytest.param("cudf", marks=pytest.mark.gpu)]
+)
 def test_set_index_interpolate_large_uint(engine):
     if engine == "cudf":
         # NOTE: engine == "cudf" requires cudf/dask_cudf,


### PR DESCRIPTION
When I originally marked some tests for GPU, I did it at either the file level or test function level. However, some test functions (such as [`test_groupby_large_ints_exception`](https://github.com/dask/dask/blob/a79319cd5609b47a6c5fbfc468c1d41c172229e5/dask/dataframe/tests/test_groupby.py#L2245)), only use GPUs for specific parameters.

This PR removes the GPU decorator from those functions and instead marks the GPU-relevant parameters, so that only these params will be run in gpuCI.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
