### PR TITLE
Ensure upstream CI cron job runs

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -26,8 +26,11 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     if: |
-      needs.check.outputs.test-upstream == 'true'
-      || (github.repository == 'dask/dask' && github.event_name != 'pull_request')
+      always()
+      && (
+          needs.check.outputs.test-upstream == 'true'
+          || (github.repository == 'dask/dask' && github.event_name != 'pull_request')
+      )
 
     env:
       COVERAGE: "true"
@@ -67,7 +70,7 @@ jobs:
     needs: build
     if: |
       always()
-      && github.event_name == 'schedule'
+      && github.event_name != 'pull_request'
       && github.repository == 'dask/dask'
       && needs.check.outputs.test-upstream == 'true'
       && needs.build.result == 'failure'


### PR DESCRIPTION
I noticed that our scheduled upstream CI build isn't currently being run (e.g. https://github.com/dask/dask/actions/runs/1289211920). This PR _should_ fix that.

This PR also updates the newly added upstream report job to run on pushes to `main` too

cc @jsignell 