### PR TITLE
Don't have upstream report depend on commit message

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -72,7 +72,6 @@ jobs:
       always()
       && github.event_name != 'pull_request'
       && github.repository == 'dask/dask'
-      && needs.check.outputs.test-upstream == 'true'
       && needs.build.result == 'failure'
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
This is a small follow-up to https://github.com/dask/dask/pull/8067 and https://github.com/dask/dask/pull/8200. The `report` job which opens an issue for upstream CI failures shouldn't depend on `test-upstream` being in the corresponding commit message