### PR TITLE
Add workflow to update gpuCI

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -6,13 +6,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-version:
+  update-gpuci:
     runs-on: ubuntu-latest
     if: github.repository == 'charlesbluca/dask'
 
     steps:
       - uses: actions/checkout@v2
-
       - name: Get latest cuDF nightly version
         id: latest_version
         uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
@@ -20,12 +19,10 @@ jobs:
           org: "rapidsai-nightly"
           package: "cudf"
           version_system: "CalVer"
-
-      - name: Strip git tags from versions
+      - name: Strip git tags from version
         run: echo "RAPIDS_VER=${FULL_RAPIDS_VER::-10}" >> $GITHUB_ENV
         env:
           FULL_RAPIDS_VER: ${{ steps.latest_version.outputs.version }}
-
       - name: Find and Replace Release
         uses: jacobtomlinson/gha-find-replace@0.1.4
         with:
@@ -34,13 +31,12 @@ jobs:
           replace: |
             RAPIDS_VER:
             - "${{ env.RAPIDS_VER }}"
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.RAPIDS_VER }}`"
-          title: "Update gpuCI `RAPIDS_VER` to ${{ env.RAPIDS_VER }}"
+          title: "Update gpuCI `RAPIDS_VER` to `${{ env.RAPIDS_VER }}`"
           reviewers: "charlesbluca"
           # labels: ""
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -22,7 +22,7 @@ jobs:
           version_system: "CalVer"
 
       - name: Strip git tags from versions
-        run: echo "RAPIDS_VER=${FULL_RAPIDS_VER::-10} >> $GITHUB_ENV"
+        run: echo "RAPIDS_VER=${FULL_RAPIDS_VER::-10}" >> $GITHUB_ENV
         env:
           FULL_RAPIDS_VER: ${{ steps.latest_version.outputs.version }}
 

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Find and Replace Release
         uses: jacobtomlinson/gha-find-replace@0.1.4
         with:
-          include: '\continuous_integration\/gpuci\/axis\.yaml'
+          include: 'continuous_integration\/gpuci\/axis\.yaml'
           find: "RAPIDS_VER:\n- .*"
           replace: 'RAPIDS_VER:\n- "${{ steps.latest_version.outputs.version }}"'
 

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-version:
+  update-gpuci:
     runs-on: ubuntu-latest
     if: github.repository == 'dask/dask'
 

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -6,12 +6,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  update-gpuci:
+  check-version:
     runs-on: ubuntu-latest
     if: github.repository == 'charlesbluca/dask'
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Get latest cuDF nightly version
         id: latest_version
         uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
@@ -19,10 +20,12 @@ jobs:
           org: "rapidsai-nightly"
           package: "cudf"
           version_system: "CalVer"
-      - name: Strip git tags from version
+
+      - name: Strip git tags from versions
         run: echo "RAPIDS_VER=${FULL_RAPIDS_VER::-10}" >> $GITHUB_ENV
         env:
           FULL_RAPIDS_VER: ${{ steps.latest_version.outputs.version }}
+
       - name: Find and Replace Release
         uses: jacobtomlinson/gha-find-replace@0.1.4
         with:
@@ -31,12 +34,13 @@ jobs:
           replace: |
             RAPIDS_VER:
             - "${{ env.RAPIDS_VER }}"
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.RAPIDS_VER }}`"
-          title: "Update gpuCI `RAPIDS_VER` to `${{ env.RAPIDS_VER }}`"
+          title: "Update gpuCI `RAPIDS_VER` to ${{ env.RAPIDS_VER }}"
           reviewers: "charlesbluca"
           # labels: ""
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -21,19 +21,26 @@ jobs:
           package: "cudf"
           version_system: "CalVer"
 
+      - name: Strip git tags from versions
+        run: echo "RAPIDS_VER=${FULL_RAPIDS_VER::-10} >> $GITHUB_ENV"
+        env:
+          FULL_RAPIDS_VER: ${{ steps.latest_version.outputs.version }}
+
       - name: Find and Replace Release
         uses: jacobtomlinson/gha-find-replace@0.1.4
         with:
           include: 'continuous_integration\/gpuci\/axis\.yaml'
           find: "RAPIDS_VER:\n- .*"
-          replace: 'RAPIDS_VER:\n- "${{ steps.latest_version.outputs.version }}"'
+          replace: |
+            RAPIDS_VER:
+            - "${{ env.RAPIDS_VER }}"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update gpuCI `RAPIDS_VER` to ${{ steps.latest_version.outputs.version }}"
-          title: "Update gpuCI `RAPIDS_VER` to ${{ steps.latest_version.outputs.version }}"
+          commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.RAPIDS_VER }}`"
+          title: "Update gpuCI `RAPIDS_VER` to ${{ env.RAPIDS_VER }}"
           reviewers: "charlesbluca"
           # labels: ""
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
@@ -41,4 +48,4 @@ jobs:
           body: |
             A new cuDF nightly version has been detected.
 
-            Updated `axis.yaml` to use `${{ steps.latest_version.outputs.version }}`.
+            Updated `axis.yaml` to use `${{ env.RAPIDS_VER }}`.

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -15,14 +15,14 @@ jobs:
 
       - name: Get latest cuDF nightly version
         id: latest_version
-        uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
         with:
           org: "rapidsai-nightly"
           package: "cudf"
           version_system: "CalVer"
 
       - name: Find and Replace Release
-        uses: jacobtomlinson/gha-find-replace@0.1.1
+        uses: jacobtomlinson/gha-find-replace@0.1.4
         with:
           include: '\continuous_integration\/gpuci\/axis\.yaml'
           find: "RAPIDS_VER:\n- .*"

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           include: 'continuous_integration\/gpuci\/axis\.yaml'
           find: "RAPIDS_VER:\n- .*"
-          replace: |
+          replace: |-
             RAPIDS_VER:
             - "${{ env.RAPIDS_VER }}"
 
@@ -40,7 +40,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.RAPIDS_VER }}`"
-          title: "Update gpuCI `RAPIDS_VER` to ${{ env.RAPIDS_VER }}"
+          title: "Update gpuCI `RAPIDS_VER` to `${{ env.RAPIDS_VER }}`"
           reviewers: "charlesbluca"
           # labels: ""
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -1,4 +1,4 @@
-name: Check for new versions of cuDF on Conda Forge
+name: Check for gpuCI updates
 
 on:
   schedule:
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get latest Dask version
+      - name: Get latest cuDF nightly version
         id: latest_version
         uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
         with:

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-version:
     runs-on: ubuntu-latest
-    if: github.repository == 'charlesbluca/dask'
+    if: github.repository == 'dask/dask'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/watch-conda-forge.yml
+++ b/.github/workflows/watch-conda-forge.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           org: "rapidsai-nightly"
           package: "cudf"
+          version_system: "CalVer"
 
       - name: Find and Replace Release
         uses: jacobtomlinson/gha-find-replace@0.1.1

--- a/.github/workflows/watch-conda-forge.yml
+++ b/.github/workflows/watch-conda-forge.yml
@@ -1,0 +1,43 @@
+name: Check for new versions of cuDF on Conda Forge
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    if: github.repository == 'charlesbluca/dask'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get latest Dask version
+        id: latest_version
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
+        with:
+          org: "rapidsai-nightly"
+          package: "cudf"
+
+      - name: Find and Replace Release
+        uses: jacobtomlinson/gha-find-replace@0.1.1
+        with:
+          include: '\continuous_integration\/gpuci\/axis\.yaml'
+          find: "RAPIDS_VER:\n- .*"
+          replace: 'RAPIDS_VER:\n- "${{ steps.latest_version.outputs.version }}"'
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update gpuCI `RAPIDS_VER` to ${{ steps.latest_version.outputs.version }}"
+          title: "Update gpuCI `RAPIDS_VER` to ${{ steps.latest_version.outputs.version }}"
+          reviewers: "charlesbluca"
+          # labels: ""
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          branch: "upgrade-gpuci-rapids"
+          body: |
+            A new cuDF nightly version has been detected.
+
+            Updated `axis.yaml` to use `${{ steps.latest_version.outputs.version }}`.


### PR DESCRIPTION
Adds a workflow similar to [dask-docker's Dask updating workflow](https://github.com/dask/dask-docker/blob/main/.github/workflows/watch-conda-forge.yml) to update the `RAPIDS_VER` used by gpuCI when a new nightly version of cuDF is available.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
