### PR TITLE
Require fastparquet>=0.3.3

### DIFF
--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-xdist
   - moto
   - flask
-  - fastparquet
+  - fastparquet>=0.3.3
   - h5py
   - pytables
   - zarr

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-xdist
   - moto
   - flask
-  - fastparquet
+  - fastparquet>=0.3.3
   - h5py
   - pytables
   - zarr

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1402,9 +1402,6 @@ def test_filters(tmpdir, write_engine, read_engine):
 
 @write_read_engines()
 def test_filters_v0(tmpdir, write_engine, read_engine):
-    if write_engine == "fastparquet" or read_engine == "fastparquet":
-        pytest.importorskip("fastparquet", minversion="0.3.1")
-
     # Recent versions of pyarrow support full row-wise filtering
     # (fastparquet and older pyarrow versions do not)
     pyarrow_row_filtering = read_engine == "pyarrow-dataset"
@@ -1543,7 +1540,6 @@ def test_pyarrow_filter_divisions(tmpdir):
 
 
 def test_divisions_read_with_filters(tmpdir):
-    pytest.importorskip("fastparquet", minversion="0.3.1")
     tmpdir = str(tmpdir)
     # generate dataframe
     size = 100
@@ -1568,7 +1564,6 @@ def test_divisions_read_with_filters(tmpdir):
 
 
 def test_divisions_are_known_read_with_filters(tmpdir):
-    pytest.importorskip("fastparquet", minversion="0.3.1")
     tmpdir = str(tmpdir)
     # generate dataframe
     df = pd.DataFrame(
@@ -1694,8 +1689,6 @@ def test_parquet_select_cats(tmpdir, engine):
 
 
 def test_columns_name(tmpdir, engine):
-    if engine == "fastparquet" and fastparquet_version <= parse_version("0.3.1"):
-        pytest.skip("Fastparquet does not write column_indexes up to 0.3.1")
     tmp_path = str(tmpdir)
     df = pd.DataFrame({"A": [1, 2]}, index=pd.Index(["a", "b"], name="idx"))
     df.columns.name = "cols"
@@ -2119,9 +2112,6 @@ def test_select_partitioned_column(tmpdir, engine):
 
 
 def test_with_tz(tmpdir, engine):
-    if engine == "fastparquet" and fastparquet_version < parse_version("0.3.0"):
-        pytest.skip("fastparquet<0.3.0 did not support this")
-
     with warnings.catch_warnings():
         if engine == "fastparquet":
             # fastparquet-442

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -91,7 +91,7 @@ These optional dependencies and their minimum supported versions are listed belo
 +---------------+----------+--------------------------------------------------------------+
 |  distributed  | >=2.0    |               Distributed computing in Python                |
 +---------------+----------+--------------------------------------------------------------+
-|  fastparquet  |          |         Storing and reading data from parquet files          |
+|  fastparquet  | >= 0.3.3 |         Storing and reading data from parquet files          |
 +---------------+----------+--------------------------------------------------------------+
 |     gcsfs     | >=0.4.0  |        File-system interface to Google Cloud Storage         |
 +---------------+----------+--------------------------------------------------------------+


### PR DESCRIPTION
- [x] Closes #5865
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

Not sure if we want to enforce this anywhere, this PR just removes checks. 