### PR TITLE
set `memory_usage` to `True` if `verbose` is `True` in info

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5031,6 +5031,7 @@ class DataFrame(_Frame):
         # Group and execute the required computations
         computations = {}
         if verbose:
+            memory_usage = True
             computations.update({"index": self.index, "count": self.count()})
         if memory_usage:
             computations.update(


### PR DESCRIPTION
- [x] Closes #8115 
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

I think, the expected behavior for `dd.info(verbose=True)` would be to also return the total memory being used, it would also be in line with pandas and will prevent confusions like issue #8115. 
This was discussed in the comments of the issue a while back but a PR was never made. 