### PR TITLE
Fix label typo in upstream CI build

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -116,7 +116,7 @@ jobs:
                     repo: variables.name,
                     body: issue_body,
                     title: title,
-                    label: [variables.label]
+                    labels: [variables.label]
                 })
             } else {
                 github.issues.update({


### PR DESCRIPTION
I think this should fix the issue where our upstream report job isn't automatically assigning the `upstream` label xref https://github.com/dask/dask/issues/8203#issuecomment-931731648