### PR TITLE
Remove individual API doc pages from sphinx toctree

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,8 +1,8 @@
 numpydoc
 sphinx>=4.0.0
-# dask-sphinx-theme>=2.0.0
-git+https://github.com/jrbourbeau/dask-sphinx-theme.git@remove-toctrees
+dask-sphinx-theme>=2.0.0
 sphinx-click
+sphinx-remove-toctrees
 sphinx-tabs
 toolz
 cloudpickle

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,11 +43,16 @@ extensions = [
     "sphinx_click.ext",
     "dask_config_sphinx_ext",
     "sphinx_tabs.tabs",
+    "sphinx_remove_toctrees",
 ]
 
 numpydoc_show_class_members = False
 
 sphinx_tabs_disable_tab_closing = True
+
+# Remove individual API pages from sphinx toctree to prevent long build times.
+# See https://github.com/dask/dask/issues/8227.
+remove_toctrees_from = ["generated/*"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -107,10 +112,7 @@ html_theme = "dask_sphinx_theme"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    "logo_only": True,
-    "remove_toctrees_from": ["array-api.rst", "bag-api.rst", "dataframe-api.rst"],
-}
+html_theme_options = {"logo_only": True}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []


### PR DESCRIPTION
This tries out the suggestion proposed by @choldgraf here https://github.com/dask/dask/issues/8227#issuecomment-938693461 to try and cut down out documentation build time 