### PR TITLE
Remove unnecessary `dask.multiprocessing` import in docs

### DIFF
--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -69,7 +69,7 @@ Local Processes
 
 .. code-block:: python
 
-   import dask.multiprocessing
+   import dask
    dask.config.set(scheduler='processes')  # overwrite default with multiprocessing scheduler
 
 


### PR DESCRIPTION
- [x] Closes https://github.com/dask/dask/issues/8226
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`

@jrbourbeau suggested dask.multiprocessing doesn't need to be imported.

Not tested/not sure how to test.