### PR TITLE
[WIP] add `blockview` property for array-like operations on blocks

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -15,6 +15,7 @@ from itertools import product, zip_longest
 from numbers import Integral, Number
 from operator import add, mul
 from threading import Lock
+from typing import Any, List, Sequence, Tuple, Union
 
 import numpy as np
 from fsspec import get_mapper
@@ -1818,66 +1819,45 @@ class Array(DaskMethodsMixin):
         """
         return IndexCallable(self._vindex)
 
-    def _blocks(self, index):
-        from .slicing import normalize_index
-
-        if not isinstance(index, tuple):
-            index = (index,)
-        if sum(isinstance(ind, (np.ndarray, list)) for ind in index) > 1:
-            raise ValueError("Can only slice with a single list")
-        if any(ind is None for ind in index):
-            raise ValueError("Slicing with np.newaxis or None is not supported")
-        index = normalize_index(index, self.numblocks)
-        index = tuple(slice(k, k + 1) if isinstance(k, Number) else k for k in index)
-
-        name = "blocks-" + tokenize(self, index)
-
-        new_keys = self._key_array[index]
-
-        chunks = tuple(
-            tuple(np.array(c)[i].tolist()) for c, i in zip(self.chunks, index)
-        )
-
-        keys = product(*(range(len(c)) for c in chunks))
-
-        layer = {(name,) + key: tuple(new_keys[key].tolist()) for key in keys}
-
-        graph = HighLevelGraph.from_collections(name, layer, dependencies=[self])
-        return Array(graph, name, chunks, meta=self)
-
     @property
     def blocks(self):
-        """Slice an array by blocks
+        """An array-like interface to the blocks of an array.
 
-        This allows blockwise slicing of a Dask array.  You can perform normal
-        Numpy-style slicing but now rather than slice elements of the array you
-        slice along blocks so, for example, ``x.blocks[0, ::2]`` produces a new
-        dask array with every other block in the first row of blocks.
+        This returns a ``Blockview`` object that provides an array-like interface
+        to the blocks of a dask array.  Numpy-style indexing of a ``Blockview`` object
+        returns a selection of blocks as a new dask array.
 
-        You can index blocks in any way that could index a numpy array of shape
+        You can index ``array.blocks`` like a numpy array of shape
         equal to the number of blocks in each dimension, (available as
-        array.numblocks).  The dimension of the output array will be the same
-        as the dimension of this array, even if integer indices are passed.
-        This does not support slicing with ``np.newaxis`` or multiple lists.
+        array.blocks.size).  The dimensionality of the output array matches
+        the dimension of this array, even if integer indices are passed.
+        Slicing with ``np.newaxis`` or multiple lists is not supported.
 
         Examples
         --------
         >>> import dask.array as da
-        >>> x = da.arange(10, chunks=2)
+        >>> x = da.arange(8, chunks=2)
+        >>> x.blocks.shape # aliases x.numblocks
+        (4,)
         >>> x.blocks[0].compute()
         array([0, 1])
         >>> x.blocks[:3].compute()
         array([0, 1, 2, 3, 4, 5])
         >>> x.blocks[::2].compute()
-        array([0, 1, 4, 5, 8, 9])
+        array([0, 1, 4, 5])
         >>> x.blocks[[-1, 0]].compute()
         array([8, 9, 0, 1])
+        >>> x.blocks.ravel()
+        [dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>,
+         dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>,
+         dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>,
+         dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>]
 
         Returns
         -------
-        A Dask array
+        An instance of ``dask.array.Blockview``
         """
-        return IndexCallable(self._blocks)
+        return BlockView(self)
 
     @property
     def partitions(self):
@@ -1886,41 +1866,41 @@ class Array(DaskMethodsMixin):
         This alias allows you to write agnostic code that works with both
         dask arrays and dask dataframes.
 
-        This allows blockwise slicing of a Dask array.  You can perform normal
-        Numpy-style slicing but now rather than slice elements of the array you
-        slice along blocks so, for example, ``x.blocks[0, ::2]`` produces a new
-        dask array with every other block in the first row of blocks.
+        This returns a ``Blockview`` object that provides an array-like interface
+        to the blocks of a dask array.  Numpy-style indexing of a ``Blockview`` object
+        returns a selection of blocks as a new dask array.
 
-        You can index blocks in any way that could index a numpy array of shape
+        You can index ``array.blocks`` like a numpy array of shape
         equal to the number of blocks in each dimension, (available as
-        array.numblocks).  The dimension of the output array will be the same
-        as the dimension of this array, even if integer indices are passed.
-        This does not support slicing with ``np.newaxis`` or multiple lists.
+        array.blocks.size).  The dimensionality of the output array matches
+        the dimension of this array, even if integer indices are passed.
+        Slicing with ``np.newaxis`` or multiple lists is not supported.
 
         Examples
         --------
         >>> import dask.array as da
-        >>> x = da.arange(10, chunks=2)
+        >>> x = da.arange(8, chunks=2)
+        >>> x.partitions.shape # aliases x.numblocks
+        (4,)
         >>> x.partitions[0].compute()
         array([0, 1])
         >>> x.partitions[:3].compute()
         array([0, 1, 2, 3, 4, 5])
         >>> x.partitions[::2].compute()
-        array([0, 1, 4, 5, 8, 9])
+        array([0, 1, 4, 5])
         >>> x.partitions[[-1, 0]].compute()
         array([8, 9, 0, 1])
-        >>> all(x.partitions[:].compute() == x.blocks[:].compute())
-        True
+        >>> x.partitions.ravel()
+        [dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>,
+         dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>,
+         dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>,
+         dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>]
 
         Returns
         -------
-        A Dask array
+        An instance of ``da.array.Blockview``
         """
         return self.blocks
-
-    @property
-    def blockview(self):
-        return BlockView(self)
 
     @derived_from(np.ndarray)
     def dot(self, other):
@@ -5291,14 +5271,53 @@ def new_da_object(dsk, name, chunks, meta=None, dtype=None):
 
 
 class BlockView:
-    """
-    An array-like interface to the chunks of a chunked array.
+    """An array-like interface to the blocks of an array.
+
+    ``BlockView`` provides an array-like interface
+    to the blocks of a dask array.  Numpy-style indexing of a
+     ``BlockView`` returns a selection of blocks as a new dask array.
+
+    You can index ``BlockView`` like a numpy array of shape
+    equal to the number of blocks in each dimension, (available as
+    array.blocks.size).  The dimensionality of the output array matches
+    the dimension of this array, even if integer indices are passed.
+    Slicing with ``np.newaxis`` or multiple lists is not supported.
+
+    Examples
+    --------
+    >>> import dask.array as da
+    >>> from dask.array import BlockView
+    >>> x = da.arange(8, chunks=2)
+    >>> bv = BlockView(x)
+    >>> bv.shape # aliases x.numblocks
+    (4,)
+    >>> bv.size
+    4
+    >>> bv[0].compute()
+    array([0, 1])
+    >>> bv[:3].compute()
+    array([0, 1, 2, 3, 4, 5])
+    >>> bv[::2].compute()
+    array([0, 1, 4, 5])
+    >>> bv[[-1, 0]].compute()
+    array([8, 9, 0, 1])
+    >>> bv.ravel()
+    [dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>,
+     dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>,
+     dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>,
+     dask.array<blocks, shape=(2,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>]
+
+    Returns
+    -------
+    An instance of ``da.array.Blockview``
     """
 
-    def __init__(self, array):
+    def __init__(self, array: Array) -> "BlockView":
         self._array = array
 
-    def __getitem__(self, index):
+    def __getitem__(
+        self, index: Union[int, Sequence[int], slice, Sequence[slice]]
+    ) -> Array:
         from .slicing import normalize_index
 
         if not isinstance(index, tuple):
@@ -5325,15 +5344,30 @@ class BlockView:
         graph = HighLevelGraph.from_collections(name, layer, dependencies=[self._array])
         return Array(graph, name, chunks, meta=self._array)
 
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, BlockView):
+            return self._array is other._array
+        else:
+            return NotImplemented
+
     @property
-    def size(self):
+    def size(self) -> int:
+        """
+        The total number of blocks in the array.
+        """
         return np.prod(self.shape)
 
     @property
-    def shape(self):
-        return tuple(map(len, self._array.chunks))
+    def shape(self) -> Tuple[int, ...]:
+        """
+        The number of blocks per axis. Alias of ``dask.array.numblocks``.
+        """
+        return self._array.numblocks
 
-    def ravel(self):
+    def ravel(self) -> List[Array]:
+        """
+        Return a flattened list of all the blocks in the array in C order.
+        """
         return [self[idx] for idx in np.ndindex(self.shape)]
 
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black dask` / `flake8 dask` / `isort dask`

In the spirit of https://github.com/dask/dask/pull/7845, this PR is a proof-of-concept of adding a numpy-array-like interface to the chunks of a dask array. 

This PR contains a class `BlockView`, defined in `dask/array/core.py`, that takes a dask array in its constructor and exposes a `__getitem__` method (with code copied directly from `dask.array.blocks`), a `ravel` method (return a flattened list of all the blocks), and `shape` property (return a tuple representing the number of chunks along each axis). In `Array.__new__`, an instance of `BlockView` is assigned to the attribute `blockview`, enabling the following :

```python
In [1]: import dask.array as da; data = da.arange(10, chunks=5)

In [2]: data.blockview.ravel()
Out[2]: 
[dask.array<blocks, shape=(5,), dtype=int64, chunksize=(5,), chunktype=numpy.ndarray>,
 dask.array<blocks, shape=(5,), dtype=int64, chunksize=(5,), chunktype=numpy.ndarray>]

In [3]: data.blockview.shape
Out[3]: (2,)

In [4]: data.blockview[0] # the same as data.blocks[0]
Out[4]: dask.array<blocks, shape=(5,), dtype=int64, chunksize=(5,), chunktype=numpy.ndarray>
```
Open questions: 

- Is there a better name than `BlockView` / `Array.blockview`?
- how would this functionality coexist with `Array.blocks`?
- There is a circular reference; `Array` has a reference to `BlockView`, and that `BlockView` retains a reference to the `Array`. It's not clear to me how this can be avoided.
- Do we want any other array methods / properties on `BlockView`?
