### PR TITLE
[WIP] fix OOM error of dask-glm with cupy on GPU

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -264,7 +264,8 @@ def _tensordot(a, b, axes):
     tensordot = tensordot_lookup.dispatch(type(x))
     x = tensordot(a, b, axes=axes)
 
-    if len(axes[0]) != 1:
+    # TODO: fix the condition
+    if True:
         ind = [slice(None, None)] * x.ndim
         for a in sorted(axes[0]):
             ind.insert(a, None)
@@ -289,7 +290,8 @@ def tensordot(lhs, rhs, axes=2):
         left_axes = tuple(left_axes)
     if isinstance(right_axes, list):
         right_axes = tuple(right_axes)
-    if len(left_axes) == 1:
+    # TODO: fix the condition
+    if False:
         concatenate = True
     else:
         concatenate = False


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`

This is not a fix and it breaks current tests, especially cupy sparse. It is supposed to demonstrate the problem and facilitate discussion. It simply reverts the changes made in  https://github.com/dask/dask/pull/6846

With this commit, [the dask glm cupy demo notebook](https://github.com/daxiongshu/rapids-demos/blob/master/dask_glm_Multi-GPU_demo.ipynb) can achieve its original speedup and scales to 100GB.
