### PR TITLE
Make slice errors match numpy

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -973,7 +973,7 @@ def check_index(axis, ind, dimension):
         if ind.dtype == bool:
             if ind.size != dimension:
                 raise IndexError(
-                    f"Boolean array with size {ind.size} is not long enough"
+                    f"Boolean array with size {ind.size} is not long enough "
                     f"for axis {axis} with size {dimension}"
                 )
         elif (ind >= dimension).any() or (ind < -dimension).any():


### PR DESCRIPTION
- [ ] Partially fixes #8229
- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask` / `isort dask`
