### PR TITLE
Ignore arrow doctests if pyarrow not installed

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -31,6 +31,11 @@ try:
 except ImportError:
     collect_ignore.append("dask/array/stats.py")
 
+try:
+    import pyarrow  # noqa: F401
+except ImportError:
+    collect_ignore.append("dask/dataframe/io/orc/arrow.py")
+
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", help="run slow tests")


### PR DESCRIPTION
This PR skips doctests in `arrow.py` if pyarrow is not installed. 

- [x] Closes https://github.com/dask/dask/issues/7358
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
