### PR TITLE
Add pre-commit to test requirements for pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,12 @@ extras_require = {
 }
 extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
 # after complete is set, add in test
-extras_require["test"] = ["pytest", "pytest-rerunfailures", "pytest-xdist"]
+extras_require["test"] = [
+    "pytest",
+    "pytest-rerunfailures",
+    "pytest-xdist",
+    "pre-commit",
+]
 
 install_requires = [
     "cloudpickle >= 1.1.1",


### PR DESCRIPTION
This PR adds pre-commit to the test requirements for people installing Dask with pip.

If users follow the [development guidelines](https://docs.dask.org/en/latest/develop.html) for Dask installation, they should not need to install new packages to make a pull request. The pull request template asks whether your branch passes `pre-commit run --all-files`, so this is an important test requirement. 

Also, if you follow the development installation guide but use conda instead of pip, then we do already include pre-commit. This PR makes the development experience more consistent for pip users.

- [ ] ~~Closes #xxxx~~ Doesn't close a specific issue, I found it after looking into this comment: https://github.com/dask/dask/issues/7358#issuecomment-942606070
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
