### PR TITLE
Windows users can't use conda redirection with environment-latest.yml

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -105,7 +105,7 @@ pip or conda_
 
 ``conda``::
 
-  conda env create -n dask-dev -f continuous_integration/environment-latest.yaml
+  conda env create -n dask-dev -f continuous_integration/environment-3.8.yaml
   conda activate dask-dev
   python -m pip install --no-deps -e .
 


### PR DESCRIPTION
There has been a report that Windows users can't use the conda redirection we have in `environment-latest.yml`. See https://github.com/dask/dask/issues/6808

This PR changes the conda developer installation guide from `conda env create -n dask-dev -f continuous_integration/environment-latest.yaml` to instead specify the exact python version with `conda env create -n dask-dev -f continuous_integration/environment-3.8.yaml`.

This documentation change introduces a small maintenance burden, if we do this then periodically someone will need to edit this file and update the python version to keep it current.

- [x] Closes https://github.com/dask/dask/issues/6808
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
