### PR TITLE
fix: support Path objects in from_zarr (#8168)

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3277,7 +3277,9 @@ def from_zarr(
     storage_options = storage_options or {}
     if isinstance(url, zarr.Array):
         z = url
-    elif isinstance(url, str):
+    elif isinstance(url, (str, os.PathLike)):
+        if isinstance(url, os.PathLike):
+            url = os.fspath(url)
         mapper = get_mapper(url, **storage_options)
         z = zarr.Array(mapper, read_only=True, path=component, **kwargs)
     else:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1,5 +1,6 @@
 import contextlib
 import copy
+import pathlib
 import xml.etree.ElementTree
 from unittest import mock
 
@@ -4271,6 +4272,17 @@ def test_zarr_roundtrip():
         a = da.zeros((3, 3), chunks=(1, 1))
         a.to_zarr(d)
         a2 = da.from_zarr(d)
+        assert_eq(a, a2)
+        assert a2.chunks == a.chunks
+
+
+def test_zarr_roundtrip_with_path_like():
+    pytest.importorskip("zarr")
+    with tmpdir() as d:
+        path = pathlib.Path(d)
+        a = da.zeros((3, 3), chunks=(1, 1))
+        a.to_zarr(path)
+        a2 = da.from_zarr(path)
         assert_eq(a, a2)
         assert a2.chunks == a.chunks
 


### PR DESCRIPTION
to_zarr already handles it so this allows from_zarr to be on par with it.

- [x] Closes #8168
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
