### PR TITLE
Client-shutdown method appears twice

### DIFF
--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -884,7 +884,6 @@ API
    Client.scatter
    Client.shutdown
    Client.scheduler_info
-   Client.shutdown
    Client.start_ipython_workers
    Client.start_ipython_scheduler
    Client.submit


### PR DESCRIPTION
- Remove reappearing `shutdown` method.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
