### PR TITLE
Unregister callbacks in doctests

### DIFF
--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -51,6 +51,7 @@ class Profiler(Callback):
     manually.
 
     >>> prof.clear()
+    >>> prof.unregister()
 
     """
 
@@ -140,6 +141,8 @@ class ResourceProfiler(Callback):
     Note that when used as a context manager data will be collected throughout
     the duration of the enclosed block. In contrast, when registered globally
     data will only be collected while a dask scheduler is active.
+
+    >>> prof.unregister()
     """
 
     def __init__(self, dt=1):
@@ -322,6 +325,7 @@ class CacheProfiler(Callback):
     manually.
 
     >>> prof.clear()
+    >>> prof.unregister()
 
     """
 

--- a/dask/diagnostics/tests/test_progress.py
+++ b/dask/diagnostics/tests/test_progress.py
@@ -68,6 +68,7 @@ def test_format_time():
 
 def test_register(capsys):
     try:
+        assert not Callback.active
         p = ProgressBar()
         p.register()
 


### PR DESCRIPTION
Some of our callback doctests weren't calling `unregister()` which lead to `Callback.active` being unexpectedly populated when running both unit tests and doctests at the same time. This PR adds `unregister()` calls accordingly. 

cc @GenevieveBuckley 

Closes https://github.com/dask/dask/issues/8268