### PR TITLE
CI: force nightly pyarrow in the upstream build

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -7,7 +7,7 @@ set -xe
 # python -m pip install --no-deps cityhash
 
 if [[ ${UPSTREAM_DEV} ]]; then
-    mamba install -y -c arrow-nightlies "pyarrow>3.0"
+    mamba install -y -c arrow-nightlies "pyarrow>5.0"
 
     # FIXME https://github.com/mamba-org/mamba/issues/412
     # mamba uninstall --force numpy pandas


### PR DESCRIPTION
Similarly as https://github.com/dask/dask/pull/7530, the upstream build is not picking up the latest version, so need to force it with an updated version requirement.