### PR TITLE
Fix test_describe_empty to work without global -Werror

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -570,7 +570,11 @@ def test_describe_empty():
     )
 
     with pytest.raises((ValueError, RuntimeWarning)):
-        ddf_len0.describe(percentiles_method="dask").compute()
+        with warnings.catch_warnings():
+            # ensure that the warning is turned into an error since this is
+            # the easiest way to assert for exception-or-warning
+            warnings.simplefilter("error")
+            ddf_len0.describe(percentiles_method="dask").compute()
 
     with pytest.raises(ValueError):
         ddf_nocols.describe(percentiles_method="dask").compute()

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -569,12 +569,8 @@ def test_describe_empty():
         df_none.describe(), ddf_none.describe(percentiles_method="dask").compute()
     )
 
-    with pytest.raises((ValueError, RuntimeWarning)):
-        with warnings.catch_warnings():
-            # ensure that the warning is turned into an error since this is
-            # the easiest way to assert for exception-or-warning
-            warnings.simplefilter("error")
-            ddf_len0.describe(percentiles_method="dask").compute()
+    with pytest.warns(RuntimeWarning):
+        ddf_len0.describe(percentiles_method="dask").compute()
 
     with pytest.raises(ValueError):
         ddf_nocols.describe(percentiles_method="dask").compute()


### PR DESCRIPTION
Fix test_describe_empty to work when the test suite is run without
global -Werror.  This is e.g. desirable for packagers who don't want
the test suite for a fixed version to suddenly start failing due to
DeprecationWarnings in dependencies that otherwise don't break
the package.

Since the test expects either a ValueError or a RuntimeWarning, it seems
that the easiest way to assert for that is to inject the "error" filter
for the scope of the call.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
