### PR TITLE
Fix name of cuDF in extension documentation.

### DIFF
--- a/docs/source/dataframe-extend.rst
+++ b/docs/source/dataframe-extend.rst
@@ -8,7 +8,7 @@ There are a few projects that subclass or replicate the functionality of Pandas
 objects:
 
 -  GeoPandas: for Geospatial analytics
--  PyGDF: for data analysis on GPUs
+-  cuDF: for data analysis on GPUs
 -  ...
 
 These projects may also want to produce parallel variants of themselves with


### PR DESCRIPTION
I was looking at the documentation for extending Dask and found this typo. It's a very small and purely documentation-focused change, so I haven't opened an issue or run tests.