### PR TITLE
Dask calendar should show events in local time

### DIFF
--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -33,7 +33,7 @@ Conversation happens in the following places:
 
     .. raw:: html
 
-       <iframe id="calendariframe" src="https://calendar.google.com/calendar/embed?src=4l0vts0c1cgdbq5jhcogj55sfs%40group.calendar.google.com" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+       <iframe id="calendariframe" src="https://calendar.google.com/calendar/embed?ctz=local&amp;src=4l0vts0c1cgdbq5jhcogj55sfs%40group.calendar.google.com" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
        <script>document.getElementById("calendariframe").src = document.getElementById("calendariframe").src.replace("ctz=local", "ctz=" + Intl.DateTimeFormat().resolvedOptions().timeZone)</script>
 
     You can subscribe to this calendar to be notified of changes:


### PR DESCRIPTION
This PR makes the embedded google calendar [on this page](https://docs.dask.org/en/latest/support.html) display events in local time (according to the local timezone of the user's browser).

Relates to issue https://github.com/dask/community/issues/195

We are following...
- this suggestion: https://github.com/napari/napari.github.io/issues/274#issuecomment-953036181 
- from this PR: https://github.com/jupyter/jupyter.github.io/pull/419
- ...here it is in action on the jupyter website, looks like it's working well: https://jupyter.org/events

A similar PR for the napari project is here: https://github.com/napari/napari.github.io/pull/278

- [ ] Closes #xxxx
- [ ] ~~Tests added / passed~~
- [x] Passes `pre-commit run --all-files`
