### PR TITLE
Point users to Discourse 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Dask
 ====
 
-|Build Status| |Coverage| |Doc Status| |Gitter| |Version Status| |NumFOCUS|
+|Build Status| |Coverage| |Doc Status| |Discourse| |Version Status| |NumFOCUS|
 
 Dask is a flexible parallel computing library for analytics.  See
 documentation_ for more information.
@@ -21,9 +21,9 @@ New BSD. See `License File <https://github.com/dask/dask/blob/main/LICENSE.txt>`
 .. |Doc Status| image:: https://readthedocs.org/projects/dask/badge/?version=latest
    :target: https://dask.org
    :alt: Documentation Status
-.. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
-   :alt: Join the chat at https://gitter.im/dask/dask
-   :target: https://gitter.im/dask/dask?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+.. |Discourse| image:: https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fdask.discourse.group
+   :alt: Discuss Dask-related things and ask for help
+   :target: https://dask.discourse.group
 .. |Version Status| image:: https://img.shields.io/pypi/v/dask.svg
    :target: https://pypi.python.org/pypi/dask/
 .. |NumFOCUS| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1782,7 +1782,7 @@ def from_url(urls):
     (b'Dask\\n',
      b'====\\n',
      b'\\n',
-     b'|Build Status| |Coverage| |Doc Status| |Gitter| |Version Status| |NumFOCUS|\\n',
+     b'|Build Status| |Coverage| |Doc Status| |Discourse| |Version Status| |NumFOCUS|\\n',
      b'\\n',
      b'Dask is a flexible parallel computing library for analytics.  See\\n',
      b'documentation_ for more information.\\n',

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -17,18 +17,20 @@ Where to ask for help
 
 Dask conversation happens in the following places:
 
-1.  `Stack Overflow #dask tag`_: for usage questions
-2.  `GitHub Issue Tracker`_: for discussions around new features or established bugs
-3.  `Gitter chat`_: for real-time discussion
+#.  `Dask Discourse forum`_: for usage questions and general discussion
+#.  `Stack Overflow #dask tag`_: for usage questions
+#.  `GitHub Issue Tracker`_: for discussions around new features or established bugs
+#.  `Dask Community Slack`_: for real-time discussion
 
-For usage questions and bug reports we strongly prefer the use of Stack Overflow
-and GitHub issues over gitter chat.  GitHub and Stack Overflow are more easily
-searchable by future users and so is more efficient for everyone's time.
-Gitter chat is generally reserved for community discussion.
+For usage questions and bug reports we prefer the use of Discourse, Stack Overflow
+and GitHub issues over Slack chat.  Discourse, GitHub and Stack Overflow are more easily
+searchable by future users, so conversations had there can be useful to many more people
+than just those directly involved.
 
+.. _`Dask Discourse forum`: https://dask.discourse.group
 .. _`Stack Overflow  #dask tag`: https://stackoverflow.com/questions/tagged/dask
 .. _`GitHub Issue Tracker`: https://github.com/dask/dask/issues/
-.. _`Gitter chat`: https://gitter.im/dask/dask
+.. _`Dask Community Slack`: https://join.slack.com/t/dask/shared_invite/zt-mfmh7quc-nIrXL6ocgiUH2haLYA914g
 
 
 Separate Code Repositories

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -166,7 +166,6 @@ messy situations in everyday problems.
 
 .. _`#dask tag`: https://stackoverflow.com/questions/tagged/dask
 .. _`GitHub issue tracker`: https://github.com/dask/dask/issues
-.. _`gitter chat room`: https://gitter.im/dask/dask
 .. _`xarray`: https://xarray.pydata.org/en/stable/
 .. _`scikit-image`: https://scikit-image.org/docs/stable/
 .. _`scikit-allel`: https://scikits.appspot.com/scikit-allel

--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -14,19 +14,23 @@ Discussion
 
 Conversation happens in the following places:
 
-1.  **Usage questions** are directed to `Stack Overflow with the #dask tag`_.
-    Dask developers monitor this tag and get e-mails whenever a question is
-    asked
-2.  **Bug reports and feature requests** are managed on the `GitHub issue
+#.  **Usage questions, requests for help, and general discussions** happen in the
+    `Dask Discourse forum`_. If your discussion topic is not a bug report
+    or a feature request, this is the best place to start. It's also a good
+    place to show off cool things you have built using Dask and to get to know other
+    community members.
+#.  **Usage questions** may also be directed to `Stack Overflow with the #dask tag`_,
+    which is monitored by Dask developers. However, the scope of what is considered
+    a good Stack Overflow question can be narrow, so the Dask Discourse forum may
+    be a better place to start.
+#.  **Bug reports and feature requests** are managed on the `GitHub issue
     tracker`_
-3.  **Chat** occurs on `gitter.im/dask/dask <https://gitter.im/dask/dask>`_
-    for general conversation and `gitter.im/dask/dev
-    <https://gitter.im/dask/dev>`_ for developer conversation.  Note that
-    because gitter chat is not searchable by future users we discourage usage
-    questions and bug reports on gitter and instead ask people to use Stack
-    Overflow or GitHub. You can also find the community chatting in
+#.  **Real-time chat** occurs on
     `https://dask.slack.com/ <https://join.slack.com/t/dask/shared_invite/zt-mfmh7quc-nIrXL6ocgiUH2haLYA914g>`_.
-4.  **Monthly developer meeting** happens the first Thursday of the month at
+    Note that Slack chat not easily searchable and indexed by search engines, so
+    detailed discussion topics around bug reports or usage should go to GitHub issues or
+    the Dask Discourse forum, respectively.
+#.  **Monthly developer meeting** happens the first Thursday of the month at
     10:00 US Central Time in `this video meeting <https://us06web.zoom.us/j/87619866741?pwd=S2RxMlRKcnVvakt4NHZoS1cwOGZoZz09>`_.
     Meeting notes are available in
     `this Google doc <https://docs.google.com/document/d/1UqNAP87a56ERH_xkQsS5Q_0PKYybd5Lj2WANy_hRzI0/edit>`_.
@@ -41,6 +45,7 @@ Conversation happens in the following places:
     * `Google Calendar <https://calendar.google.com/calendar/u/0?cid=NGwwdnRzMGMxY2dkYnE1amhjb2dqNTVzZnNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ>`__
     * `iCal <https://calendar.google.com/calendar/ical/4l0vts0c1cgdbq5jhcogj55sfs%40group.calendar.google.com/public/basic.ics>`__
 
+.. _`Dask Discourse forum`: https://dask.discourse.group
 .. _`Stack Overflow with the #dask tag`: https://stackoverflow.com/questions/tagged/dask
 .. _`GitHub issue tracker`: https://github.com/dask/dask/issues/
 
@@ -53,17 +58,16 @@ new to using the project.  There are a few things you can do to improve the
 likelihood of quickly getting a good answer.
 
 1.  **Ask questions in the right place**:  We strongly prefer the use
-    of Stack Overflow or GitHub issues over Gitter chat.  GitHub and
-    Stack Overflow are more easily searchable by future users, and therefore is more
-    efficient for everyone's time.  Gitter chat is strictly reserved for
-    developer and community discussion.
+    of Discourse or GitHub issues over Slack chat.  Discourse and
+    GitHub are more easily searchable by future users, and therefore can be
+    useful to many more people than those directly involved.
 
     If you have a general question about how something should work or
-    want best practices then use Stack Overflow.  If you think you have found a
+    want best practices then use Discourse.  If you think you have found a
     bug then use GitHub
 
 2.  **Ask only in one place**: Please restrict yourself to posting your
-    question in only one place (likely Stack Overflow or GitHub) and don't post
+    question in only one place (likely the Dask Discourse or GitHub) and don't post
     in both
 
 3.  **Create a minimal example**:  It is ideal to create `minimal, complete,


### PR DESCRIPTION
Point users to https://dask.discourse.org a place to ask questions over Slack, Gitter, or Stack Overflow. Also tweaks some of the language to be a bit friendlier and removes references to Gitter.

There could (and maybe should) be a more comprehensive restructuring of the "how to get help" page, but in the interests of expediency this is fairly lightweight, deferring such work for later.

- [x] Addresses part of https://github.com/dask/community/issues/194
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
