### PR TITLE
Allow custom sort functions for `sort_values`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4204,7 +4204,14 @@ class DataFrame(_Frame):
         return self[list(cs)]
 
     def sort_values(
-        self, by, npartitions=None, ascending=True, na_position="last", **kwargs
+        self,
+        by,
+        npartitions=None,
+        ascending=True,
+        na_position="last",
+        sort_function=None,
+        sort_function_kwargs=None,
+        **kwargs,
     ):
         """Sort the dataset by a single column.
 
@@ -4230,16 +4237,25 @@ class DataFrame(_Frame):
         """
         from .shuffle import sort_values
 
+        if sort_function is None:
+            sort_function = M.sort_values
+        if sort_function_kwargs is None:
+            sort_function_kwargs = {
+                "by": by,
+                "ascending": ascending,
+                "na_position": na_position,
+            }
+
         if self.npartitions == 1:
-            return self.map_partitions(
-                M.sort_values, by, ascending=ascending, na_position=na_position
-            )
+            return self.map_partitions(sort_function, **sort_function_kwargs)
         return sort_values(
             self,
             by,
             ascending=ascending,
             npartitions=npartitions,
             na_position=na_position,
+            sort_function=sort_function,
+            sort_function_kwargs=sort_function_kwargs,
             **kwargs,
         )
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -78,6 +78,8 @@ def sort_values(
     na_position="last",
     upsample=1.0,
     partition_size=128e6,
+    sort_function=None,
+    sort_function_kwargs=None,
     **kwargs,
 ):
     """See DataFrame.sort_values for docstring"""
@@ -107,9 +109,11 @@ def sort_values(
         df, sort_by_col, repartition, npartitions, upsample, partition_size
     )
 
+    breakpoint()
+
     if len(divisions) == 2:
         return df.repartition(npartitions=1).map_partitions(
-            M.sort_values, by, ascending=ascending, na_position=na_position
+            sort_function, **sort_function_kwargs
         )
 
     if (
@@ -126,9 +130,7 @@ def sort_values(
         and npartitions == df.npartitions
     ):
         # divisions are in the right place
-        return df.map_partitions(
-            M.sort_values, by, ascending=ascending, na_position=na_position
-        )
+        return df.map_partitions(sort_function, **sort_function_kwargs)
 
     df = rearrange_by_divisions(
         df,
@@ -138,9 +140,7 @@ def sort_values(
         na_position=na_position,
         duplicates=False,
     )
-    df = df.map_partitions(
-        M.sort_values, by, ascending=ascending, na_position=na_position
-    )
+    df = df.map_partitions(sort_function, **sort_function_kwargs)
     return df
 
 


### PR DESCRIPTION
This PR allows the sorting function called on each partition in last step of `sort_values` to be generalized, along with the kwargs that are supplied to it. This allows `sort_values` to be extended to support multi-column sorting and more complex ascending / null position handling.

The context for this PR is a desire to simplify the [sorting algorithm](https://github.com/dask-contrib/dask-sql/blob/main/dask_sql/physical/utils/sort.py) used by dask-sql; since it only really differs from Dask's sorting algorithm in that it uses a custom sorting function, it seems like it would be easier to allow for that extension upstream rather than duplicate Dask code in dask-sql.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
