### PR TITLE
Fix required_extension behavior in read_parquet

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -807,9 +807,15 @@ class ArrowDatasetEngine(Engine):
                     gather_statistics = True
             elif require_extension:
                 # Need to materialize all paths if we are missing the _metadata file
+                # Raise error if all files have been filtered by extension
+                len0 = len(paths)
                 paths = [
                     path for path in fs.find(paths) if path.endswith(require_extension)
                 ]
+                if len0 and paths == []:
+                    raise ValueError(
+                        "No files satisfy the `required_extension` criteria."
+                    )
 
         elif len(paths) > 1:
             paths, base, fns = _sort_and_analyze_paths(paths, fs)
@@ -833,13 +839,7 @@ class ArrowDatasetEngine(Engine):
                 # Populate valid_paths, since the original path list
                 # must be used to filter the _metadata-based dataset
                 fns.remove("_metadata")
-                valid_paths = (
-                    [fn for fn in fns if fn.endswith(require_extension)]
-                    if require_extension
-                    else fns
-                )
-            elif require_extension:
-                paths = [path for path in paths if path.endswith(require_extension)]
+                valid_paths = fns
 
         # Final "catch-all" pyarrow.dataset call
         if ds is None:

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -814,7 +814,8 @@ class ArrowDatasetEngine(Engine):
                 ]
                 if len0 and paths == []:
                     raise ValueError(
-                        "No files satisfy the `required_extension` criteria."
+                        "No files satisfy the `required_extension` criteria "
+                        f"(files must end with {required_extension})."
                     )
 
         elif len(paths) > 1:

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -814,8 +814,8 @@ class ArrowDatasetEngine(Engine):
                 ]
                 if len0 and paths == []:
                     raise ValueError(
-                        "No files satisfy the `required_extension` criteria "
-                        f"(files must end with {required_extension})."
+                        "No files satisfy the `require_extension` criteria "
+                        f"(files must end with {require_extension})."
                     )
 
         elif len(paths) > 1:

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -426,7 +426,8 @@ class FastParquetEngine(Engine):
                     paths = [path for path in paths if path.endswith(require_extension)]
                     if len0 and paths == []:
                         raise ValueError(
-                            "No files satisfy the `required_extension` criteria."
+                            "No files satisfy the `require_extension` criteria "
+                            f"(files must end with {require_extension})."
                         )
                 pf = ParquetFile(paths[:1], open_with=fs.open, root=base, **kwargs)
                 scheme = get_file_scheme(fns)

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -407,9 +407,6 @@ class FastParquetEngine(Engine):
                 if _update_paths:
                     paths = [fs.sep.join([base, fn]) for fn in fns]
                 _metadata_exists = False
-
-            if require_extension:
-                paths = [path for path in paths if path.endswith(require_extension)]
             if _metadata_exists:
                 # Using _metadata file (best-case scenario)
                 pf = ParquetFile(
@@ -423,6 +420,14 @@ class FastParquetEngine(Engine):
                 # Use 0th file
                 # Note that "_common_metadata" can cause issues for
                 # partitioned datasets.
+                if require_extension:
+                    # Raise error if all files have been filtered by extension
+                    len0 = len(paths)
+                    paths = [path for path in paths if path.endswith(require_extension)]
+                    if len0 and paths == []:
+                        raise ValueError(
+                            "No files satisfy the `required_extension` criteria."
+                        )
                 pf = ParquetFile(paths[:1], open_with=fs.open, root=base, **kwargs)
                 scheme = get_file_scheme(fns)
                 pf.file_scheme = scheme
@@ -439,8 +444,6 @@ class FastParquetEngine(Engine):
             if _metadata_exists and ignore_metadata_file:
                 fns.remove("_metadata")
                 _metadata_exists = False
-            if require_extension:
-                fns = [fn for fn in fns if fn.endswith(require_extension)]
             paths = [fs.sep.join([base, fn]) for fn in fns]
 
             if _metadata_exists:


### PR DESCRIPTION
This PR changes the behavior of `read_parquet(path, ..., required_extension=)` to only apply when `path` is a directory without an active `_metadata` file. That is, we should not be filtering out "unsupported extensions" when the `path` is a single file, and specific list of files, or when we are using a `_metadata` file to tell us what files are valid.

- [x] Closes #8349
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
