### PR TITLE
Include properties in array API docs

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -240,7 +240,7 @@ Array
    Array.argtopk
    Array.astype
    Array.blocks
-Array.choose
+   Array.choose
    Array.chunks
    Array.chunksize
    Array.clip

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -226,8 +226,8 @@ Top level functions
    zeros
    zeros_like
 
-Array Methods
-~~~~~~~~~~~~~
+Array
+~~~~~
 
 .. autosummary::
    :toctree: generated/
@@ -239,7 +239,10 @@ Array Methods
    Array.argmin
    Array.argtopk
    Array.astype
-   Array.choose
+   Array.blocks
+Array.choose
+   Array.chunks
+   Array.chunksize
    Array.clip
    Array.compute
    Array.compute_chunk_sizes
@@ -247,22 +250,35 @@ Array Methods
    Array.copy
    Array.cumprod
    Array.cumsum
+   Array.dask
    Array.dot
+   Array.dtype
    Array.flatten
+   Array.imag
+   Array.itemsize
    Array.map_blocks
    Array.map_overlap
    Array.max
    Array.mean
    Array.min
    Array.moment
+   Array.name
+   Array.nbytes
+   Array.ndim
    Array.nonzero
+   Array.npartitions
+   Array.numblocks
+   Array.partitions
    Array.persist
    Array.prod
    Array.ravel
+   Array.real
    Array.rechunk
    Array.repeat
    Array.reshape
    Array.round
+   Array.shape
+   Array.size
    Array.squeeze
    Array.std
    Array.store
@@ -279,6 +295,7 @@ Array Methods
    Array.transpose
    Array.var
    Array.view
+   Array.vindex
    Array.visualize
 
 


### PR DESCRIPTION
I went looking for the `blocks` docs this morning and realized that there were some missing items in the array API docs. I think mostly the missing bits were the properties.
