### PR TITLE
Fix .loc of dataframe with nullable boolean dtype

### DIFF
--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -114,14 +114,14 @@ class _LocIndexer(_IndexerBase):
                 return self._loc_slice(iindexer, cindexer)
             elif isinstance(iindexer, (list, np.ndarray)):
                 return self._loc_list(iindexer, cindexer)
-            elif is_series_like(iindexer) and not is_bool_dtype(iindexer):
+            elif is_series_like(iindexer) and not is_bool_dtype(iindexer._meta):
                 return self._loc_list(iindexer.values, cindexer)
             else:
                 # element should raise KeyError
                 return self._loc_element(iindexer, cindexer)
         else:
             if isinstance(iindexer, (list, np.ndarray)) or (
-                is_series_like(iindexer) and is_bool_dtype(iindexer)
+                is_series_like(iindexer) and is_bool_dtype(iindexer._meta)
             ):
                 # applying map_partitions to each partition
                 # results in duplicated NaN rows
@@ -148,7 +148,7 @@ class _LocIndexer(_IndexerBase):
         return iindexer
 
     def _loc_series(self, iindexer, cindexer):
-        if not is_bool_dtype(iindexer):
+        if not is_bool_dtype(iindexer._meta):
             raise KeyError(
                 "Cannot index with non-boolean dask Series. Try passing computed "
                 "values instead (e.g. ``ddf.loc[iindexer.compute()]``)"

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -114,14 +114,18 @@ class _LocIndexer(_IndexerBase):
                 return self._loc_slice(iindexer, cindexer)
             elif isinstance(iindexer, (list, np.ndarray)):
                 return self._loc_list(iindexer, cindexer)
-            elif is_series_like(iindexer) and iindexer.dtype != bool:
+            elif is_series_like(iindexer) and iindexer.dtype not in [
+                bool,
+                pd.BooleanDtype(),
+            ]:
                 return self._loc_list(iindexer.values, cindexer)
             else:
                 # element should raise KeyError
                 return self._loc_element(iindexer, cindexer)
         else:
             if isinstance(iindexer, (list, np.ndarray)) or (
-                is_series_like(iindexer) and iindexer.dtype != bool
+                is_series_like(iindexer)
+                and iindexer.dtype not in [bool, pd.BooleanDtype()]
             ):
                 # applying map_partitions to each partition
                 # results in duplicated NaN rows
@@ -148,7 +152,7 @@ class _LocIndexer(_IndexerBase):
         return iindexer
 
     def _loc_series(self, iindexer, cindexer):
-        if iindexer.dtype != bool:
+        if iindexer.dtype not in [bool, pd.BooleanDtype()]:
             raise KeyError(
                 "Cannot index with non-boolean dask Series. Try passing computed "
                 "values instead (e.g. ``ddf.loc[iindexer.compute()]``)"

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -121,7 +121,7 @@ class _LocIndexer(_IndexerBase):
                 return self._loc_element(iindexer, cindexer)
         else:
             if isinstance(iindexer, (list, np.ndarray)) or (
-                is_series_like(iindexer) and is_bool_dtype(iindexer._meta)
+                is_series_like(iindexer) and not is_bool_dtype(iindexer._meta)
             ):
                 # applying map_partitions to each partition
                 # results in duplicated NaN rows

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -114,14 +114,14 @@ class _LocIndexer(_IndexerBase):
                 return self._loc_slice(iindexer, cindexer)
             elif isinstance(iindexer, (list, np.ndarray)):
                 return self._loc_list(iindexer, cindexer)
-            elif is_series_like(iindexer) and not is_bool_dtype(iindexer._meta):
+            elif is_series_like(iindexer) and not is_bool_dtype(iindexer.dtype):
                 return self._loc_list(iindexer.values, cindexer)
             else:
                 # element should raise KeyError
                 return self._loc_element(iindexer, cindexer)
         else:
             if isinstance(iindexer, (list, np.ndarray)) or (
-                is_series_like(iindexer) and not is_bool_dtype(iindexer._meta)
+                is_series_like(iindexer) and not is_bool_dtype(iindexer.dtype)
             ):
                 # applying map_partitions to each partition
                 # results in duplicated NaN rows
@@ -148,7 +148,7 @@ class _LocIndexer(_IndexerBase):
         return iindexer
 
     def _loc_series(self, iindexer, cindexer):
-        if not is_bool_dtype(iindexer._meta):
+        if not is_bool_dtype(iindexer.dtype):
             raise KeyError(
                 "Cannot index with non-boolean dask Series. Try passing computed "
                 "values instead (e.g. ``ddf.loc[iindexer.compute()]``)"

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -10,7 +10,7 @@ from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
 from . import methods
 from ._compat import PANDAS_GT_130
-from .core import Series, new_dd_object
+from .core import Series, is_bool_dtype, new_dd_object
 from .utils import is_index_like, is_series_like, meta_nonempty
 
 
@@ -114,18 +114,14 @@ class _LocIndexer(_IndexerBase):
                 return self._loc_slice(iindexer, cindexer)
             elif isinstance(iindexer, (list, np.ndarray)):
                 return self._loc_list(iindexer, cindexer)
-            elif is_series_like(iindexer) and iindexer.dtype not in [
-                bool,
-                pd.BooleanDtype(),
-            ]:
+            elif is_series_like(iindexer) and not is_bool_dtype(iindexer):
                 return self._loc_list(iindexer.values, cindexer)
             else:
                 # element should raise KeyError
                 return self._loc_element(iindexer, cindexer)
         else:
             if isinstance(iindexer, (list, np.ndarray)) or (
-                is_series_like(iindexer)
-                and iindexer.dtype not in [bool, pd.BooleanDtype()]
+                is_series_like(iindexer) and is_bool_dtype(iindexer)
             ):
                 # applying map_partitions to each partition
                 # results in duplicated NaN rows
@@ -152,7 +148,7 @@ class _LocIndexer(_IndexerBase):
         return iindexer
 
     def _loc_series(self, iindexer, cindexer):
-        if iindexer.dtype not in [bool, pd.BooleanDtype()]:
+        if not is_bool_dtype(iindexer):
             raise KeyError(
                 "Cannot index with non-boolean dask Series. Try passing computed "
                 "values instead (e.g. ``ddf.loc[iindexer.compute()]``)"

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -4,13 +4,14 @@ from datetime import datetime
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_bool_dtype
 
 from ..array.core import Array
 from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
 from . import methods
 from ._compat import PANDAS_GT_130
-from .core import Series, is_bool_dtype, new_dd_object
+from .core import Series, new_dd_object
 from .utils import is_index_like, is_series_like, meta_nonempty
 
 

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -671,3 +671,14 @@ def test_iloc_out_of_order_selection():
     assert a1.name == "C"
     assert b1.name == "A"
     assert c1.name == "B"
+
+
+def test_pandas_nullable_boolean_data_type():
+    s1 = pd.Series([0, 1, 2])
+    s2 = pd.Series([True, False, pd.NA], dtype="boolean")
+
+    ddf1 = dd.from_pandas(s1, npartitions=1)
+    ddf2 = dd.from_pandas(s2, npartitions=1)
+
+    assert_eq(ddf1[ddf2], s1[s2])
+    assert_eq(ddf1.loc[ddf2], s1.loc[s2])


### PR DESCRIPTION
I use the [Nullable Boolean data type](https://pandas.pydata.org/docs/user_guide/boolean.html) with Dask. It worked fine since the recent version `2021.11.0`. Let me show an example:

```python
import dask.dataframe as dd
import pandas as pd

s1 = pd.Series([0, 1, 2])
s2 = pd.Series([True, False, pd.NA], dtype="boolean")

ddf1 = dd.from_pandas(s1, npartitions=1)
ddf2 = dd.from_pandas(s2, npartitions=1)
```

While this indexing
```python
ddf1[ddf2]
```
works fine, this indexing
```python
ddf1.loc[ddf2]
```
fails with the following error
```python
KeyError: 'Cannot index with non-boolean dask Series. Try passing computed values instead (e.g. ``ddf.loc[iindexer.compute()]``)'
```

This PR adds the `pd.BooleanDtype()` to list of boolean-dask Series and adds a test which fails before my code changes.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
