### PR TITLE
Fix empty chunk causes exception in nanmin/nanmax

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -515,6 +515,12 @@ def nancumprod(x, axis, dtype=None, out=None, *, method="sequential"):
 
 @derived_from(np)
 def nanmin(a, axis=None, keepdims=False, split_every=None, out=None):
+    if np.isnan(a.size):
+        a = a.compute_chunk_sizes()
+    if a.size == 0:
+        raise ValueError(
+            "zero-size array to reduction operation fmin which has no identity"
+        )
     return reduction(
         a,
         _nanmin_skip,
@@ -536,6 +542,12 @@ def _nanmin_skip(x_chunk, axis, keepdims):
 
 @derived_from(np)
 def nanmax(a, axis=None, keepdims=False, split_every=None, out=None):
+    if np.isnan(a.size):
+        a = a.compute_chunk_sizes()
+    if a.size == 0:
+        raise ValueError(
+            "zero-size array to reduction operation fmax which has no identity"
+        )
     return reduction(
         a,
         _nanmax_skip,

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -537,7 +537,7 @@ def _nanmin_skip(x_chunk, axis, keepdims):
     if len(x_chunk):
         return np.nanmin(x_chunk, axis=axis, keepdims=keepdims)
     else:
-        return asarray_safe(np.array([]), like=meta_from_array(x_chunk))
+        return asarray_safe(np.array([], dtype=x_chunk.dtype), like=meta_from_array(x_chunk))
 
 
 @derived_from(np)
@@ -564,7 +564,7 @@ def _nanmax_skip(x_chunk, axis, keepdims):
     if len(x_chunk):
         return np.nanmax(x_chunk, axis=axis, keepdims=keepdims)
     else:
-        return asarray_safe(np.array([]), like=meta_from_array(x_chunk))
+        return asarray_safe(np.array([], dtype=x_chunk.dtype), like=meta_from_array(x_chunk))
 
 
 def numel(x, **kwargs):

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -537,7 +537,7 @@ def _nanmin_skip(x_chunk, axis, keepdims):
     if len(x_chunk):
         return np.nanmin(x_chunk, axis=axis, keepdims=keepdims)
     else:
-        return np.array([], dtype=x_chunk.dtype)
+        return asarray_safe(np.array([]), like=meta_from_array(x_chunk))
 
 
 @derived_from(np)
@@ -564,7 +564,7 @@ def _nanmax_skip(x_chunk, axis, keepdims):
     if len(x_chunk):
         return np.nanmax(x_chunk, axis=axis, keepdims=keepdims)
     else:
-        return np.array([], dtype=x_chunk.dtype)
+        return asarray_safe(np.array([]), like=meta_from_array(x_chunk))
 
 
 def numel(x, **kwargs):

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -17,7 +17,7 @@ from ..highlevelgraph import HighLevelGraph
 from ..utils import deepmap, derived_from, funcname, getargspec, is_series_like
 from . import chunk
 from .blockwise import blockwise
-from .core import Array, _concatenate2, handle_out, implements
+from .core import Array, _concatenate2, handle_out, implements, unknown_chunk_message
 from .creation import arange, diagonal
 
 # Keep empty_lookup here for backwards compatibility
@@ -30,15 +30,6 @@ from .utils import (
     validate_axis,
 )
 from .wrap import ones, zeros
-
-unknown_chunk_message = (
-    "\n\n"
-    "A possible solution: "
-    "https://docs.dask.org/en/latest/array-chunks.html#unknown-chunks\n"
-    "Summary: to compute chunks sizes, use\n\n"
-    "   x.compute_chunk_sizes()  # for Dask Array `x`\n"
-    "   ddf.to_dask_array(lengths=True)  # for Dask DataFrame `ddf`"
-)
 
 
 def divide(a, b, dtype=None):

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -31,6 +31,15 @@ from .utils import (
 )
 from .wrap import ones, zeros
 
+unknown_chunk_message = (
+    "\n\n"
+    "A possible solution: "
+    "https://docs.dask.org/en/latest/array-chunks.html#unknown-chunks\n"
+    "Summary: to compute chunks sizes, use\n\n"
+    "   x.compute_chunk_sizes()  # for Dask Array `x`\n"
+    "   ddf.to_dask_array(lengths=True)  # for Dask DataFrame `ddf`"
+)
+
 
 def divide(a, b, dtype=None):
     key = lambda x: getattr(x, "__array_priority__", float("-inf"))
@@ -516,7 +525,7 @@ def nancumprod(x, axis, dtype=None, out=None, *, method="sequential"):
 @derived_from(np)
 def nanmin(a, axis=None, keepdims=False, split_every=None, out=None):
     if np.isnan(a.size):
-        a = a.compute_chunk_sizes()
+        raise ValueError(f"Arrays chunk sizes are unknown. {unknown_chunk_message}")
     if a.size == 0:
         raise ValueError(
             "zero-size array to reduction operation fmin which has no identity"
@@ -545,7 +554,7 @@ def _nanmin_skip(x_chunk, axis, keepdims):
 @derived_from(np)
 def nanmax(a, axis=None, keepdims=False, split_every=None, out=None):
     if np.isnan(a.size):
-        a = a.compute_chunk_sizes()
+        raise ValueError(f"Arrays chunk sizes are unknown. {unknown_chunk_message}")
     if a.size == 0:
         raise ValueError(
             "zero-size array to reduction operation fmax which has no identity"

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -537,7 +537,9 @@ def _nanmin_skip(x_chunk, axis, keepdims):
     if len(x_chunk):
         return np.nanmin(x_chunk, axis=axis, keepdims=keepdims)
     else:
-        return asarray_safe(np.array([], dtype=x_chunk.dtype), like=meta_from_array(x_chunk))
+        return asarray_safe(
+            np.array([], dtype=x_chunk.dtype), like=meta_from_array(x_chunk)
+        )
 
 
 @derived_from(np)
@@ -564,7 +566,9 @@ def _nanmax_skip(x_chunk, axis, keepdims):
     if len(x_chunk):
         return np.nanmax(x_chunk, axis=axis, keepdims=keepdims)
     else:
-        return asarray_safe(np.array([], dtype=x_chunk.dtype), like=meta_from_array(x_chunk))
+        return asarray_safe(
+            np.array([], dtype=x_chunk.dtype), like=meta_from_array(x_chunk)
+        )
 
 
 def numel(x, **kwargs):

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -517,28 +517,42 @@ def nancumprod(x, axis, dtype=None, out=None, *, method="sequential"):
 def nanmin(a, axis=None, keepdims=False, split_every=None, out=None):
     return reduction(
         a,
-        chunk.nanmin,
-        chunk.nanmin,
+        _nanmin_skip,
+        _nanmin_skip,
         axis=axis,
         keepdims=keepdims,
         dtype=a.dtype,
         split_every=split_every,
         out=out,
     )
+
+
+def _nanmin_skip(x_chunk, axis, keepdims):
+    if len(x_chunk):
+        return np.nanmin(x_chunk, axis=axis, keepdims=keepdims)
+    else:
+        return np.array([], dtype=x_chunk.dtype)
 
 
 @derived_from(np)
 def nanmax(a, axis=None, keepdims=False, split_every=None, out=None):
     return reduction(
         a,
-        chunk.nanmax,
-        chunk.nanmax,
+        _nanmax_skip,
+        _nanmax_skip,
         axis=axis,
         keepdims=keepdims,
         dtype=a.dtype,
         split_every=split_every,
         out=out,
     )
+
+
+def _nanmax_skip(x_chunk, axis, keepdims):
+    if len(x_chunk):
+        return np.nanmax(x_chunk, axis=axis, keepdims=keepdims)
+    else:
+        return np.array([], dtype=x_chunk.dtype)
 
 
 def numel(x, **kwargs):

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -734,6 +734,10 @@ def test_empty_chunk_nanmin_nanmax(func):
     d = d[d > 4]
     block_lens = np.array([len(x.compute()) for x in d.blocks])
     assert 0 in block_lens
+    with pytest.raises(ValueError) as err:
+        getattr(da, func)(d)
+    assert "Arrays chunk sizes are unknown" in str(err)
+    d = d.compute_chunk_sizes()
     assert_eq(getattr(da, func)(d), getattr(np, func)(x))
 
 
@@ -744,6 +748,7 @@ def test_empty_chunk_nanmin_nanmax_raise(func):
     d = da.from_array(x, chunks=2)
     d = d[d > 9]
     x = x[x > 9]
+    d = d.compute_chunk_sizes()
     with pytest.raises(ValueError) as err_np:
         getattr(np, func)(x)
     with pytest.raises(ValueError) as err_da:

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -725,6 +725,24 @@ def test_object_reduction(method):
     assert result == 1
 
 
+def test_nanmin_empty_chunks():
+    # see https://github.com/dask/dask/issues/8352
+    arr = np.array([[-1, -2, -3], [1, 2, 3]], dtype=np.int8)
+    darr = da.from_array(arr, chunks=(1, 3))
+    expeted = np.nanmin(arr[arr >= 0])
+    result = da.nanmin(darr[darr >= 0]).compute()
+    assert_eq(expeted, result)
+
+
+def test_nanmax_empty_chunks():
+    # see https://github.com/dask/dask/issues/8352
+    arr = np.array([[-1, -2, -3], [1, 2, 3]], dtype=np.int8)
+    darr = da.from_array(arr, chunks=(1, 3))
+    expeted = np.nanmax(arr[arr >= 0])
+    result = da.nanmax(darr[darr >= 0]).compute()
+    assert_eq(expeted, result)
+
+
 def test_mean_func_does_not_warn():
     # non-regression test for https://github.com/pydata/xarray/issues/5151
     xr = pytest.importorskip("xarray")

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -737,6 +737,21 @@ def test_empty_chunk_nanmin_nanmax(func):
     assert_eq(getattr(da, func)(d), getattr(np, func)(x))
 
 
+@pytest.mark.parametrize("func", ["nanmin", "nanmax"])
+def test_empty_chunk_nanmin_nanmax_raise(func):
+    # see https://github.com/dask/dask/issues/8352
+    x = np.arange(10).reshape(2, 5)
+    d = da.from_array(x, chunks=2)
+    d = d[d > 9]
+    x = x[x > 9]
+    with pytest.raises(ValueError) as err_np:
+        x = getattr(np, func)(x)
+    with pytest.raises(ValueError) as err_da:
+        d = getattr(da, func)(d)
+        d.compute()
+    assert str(err_np.value) == str(err_da.value)
+
+
 def test_mean_func_does_not_warn():
     # non-regression test for https://github.com/pydata/xarray/issues/5151
     xr = pytest.importorskip("xarray")

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -745,7 +745,7 @@ def test_empty_chunk_nanmin_nanmax_raise(func):
     d = d[d > 9]
     x = x[x > 9]
     with pytest.raises(ValueError) as err_np:
-        x = getattr(np, func)(x)
+        getattr(np, func)(x)
     with pytest.raises(ValueError) as err_da:
         d = getattr(da, func)(d)
         d.compute()

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -732,12 +732,9 @@ def test_empty_chunk_nanmin_nanmax(func):
     d = da.from_array(x, chunks=2)
     x = x[x > 4]
     d = d[d > 4]
-    chunks = np.array([len(x.compute()) for x in d.blocks])
-    assert 0 in chunks
-    assert_eq(
-        getattr(da, func)(d),
-        getattr(np, func)(x),
-    )
+    block_lens = np.array([len(x.compute()) for x in d.blocks])
+    assert 0 in block_lens
+    assert_eq(getattr(da, func)(d), getattr(np, func)(x))
 
 
 def test_mean_func_does_not_warn():

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -725,22 +725,19 @@ def test_object_reduction(method):
     assert result == 1
 
 
-def test_nanmin_empty_chunks():
+@pytest.mark.parametrize("func", ["nanmin", "nanmax"])
+def test_empty_chunk_nanmin_nanmax(func):
     # see https://github.com/dask/dask/issues/8352
-    arr = np.array([[-1, -2, -3], [1, 2, 3]], dtype=np.int8)
-    darr = da.from_array(arr, chunks=(1, 3))
-    expeted = np.nanmin(arr[arr >= 0])
-    result = da.nanmin(darr[darr >= 0]).compute()
-    assert_eq(expeted, result)
-
-
-def test_nanmax_empty_chunks():
-    # see https://github.com/dask/dask/issues/8352
-    arr = np.array([[-1, -2, -3], [1, 2, 3]], dtype=np.int8)
-    darr = da.from_array(arr, chunks=(1, 3))
-    expeted = np.nanmax(arr[arr >= 0])
-    result = da.nanmax(darr[darr >= 0]).compute()
-    assert_eq(expeted, result)
+    x = np.arange(10).reshape(2, 5)
+    d = da.from_array(x, chunks=2)
+    x = x[x > 4]
+    d = d[d > 4]
+    chunks = np.array([len(x.compute()) for x in d.blocks])
+    assert 0 in chunks
+    assert_eq(
+        getattr(da, func)(d),
+        getattr(np, func)(x),
+    )
 
 
 def test_mean_func_does_not_warn():


### PR DESCRIPTION
- [x] Closes #8352 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Not sure if there is a better way to do this.
First I only added the check for empty blocks but then a 0 length array would return a zero length array in dask but raise an error in numpy.
This might have performance regressions as a `compute_chunk_sizes` call was added.