### PR TITLE
Fix typo in `set_index` `partition_size` parameter description

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4324,7 +4324,7 @@ class DataFrame(_Frame):
             will still be triggered if ``divisions`` is ``None``.
         partition_size: int, optional
             Desired size of each partitions in bytes.
-            Only used when ``npartition='auto'``
+            Only used when ``npartitions='auto'``
 
         Examples
         --------


### PR DESCRIPTION
Found a typo in the docs. Haven't run any tests since it is such a small change.
