### PR TITLE
Ensure single-partition join `divisions` is tuple

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -440,7 +440,7 @@ def single_partition_join(left, right, **kwargs):
         align_dataframes=False,
         **kwargs,
     )
-    joined.divisions = divisions
+    joined.divisions = tuple(divisions)
     return joined
 
 


### PR DESCRIPTION
We ran into some downstream breakage in dask-sql (see https://github.com/dask-contrib/dask-sql/issues/320) as a result of #8341's changing `single_partition_join`'s output `divisions` from tuple to list - this PR casts them to tuple before returning.

Ideally depending on discussion in #8388, we might enforce all `divisions` to be one type, which should cut down on breakages like this in the future.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
