### PR TITLE
Updates for P2P shuffle skeleton

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -468,6 +468,16 @@ def rearrange_by_column(
         if ignore_index:
             df2._meta = df2._meta.reset_index(drop=True)
         return df2
+    elif shuffle == "p2p":
+        try:
+            from distributed.shuffle import rearrange_by_column_p2p
+        except ImportError:
+            raise ImportError(
+                "Cannot use `shuffle='p2p'`, since the package `distributed` is not installed.\n"
+                "Note that a peer-to-peer shuffle only makes sense when using a distributed cluster of "
+                "multiple machines. For large shuffles on a single machine, try `shuffle='disk'`."
+            )
+        return rearrange_by_column_p2p(df, col, npartitions)
     else:
         raise NotImplementedError("Unknown shuffle method %s" % shuffle)
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -204,11 +204,11 @@ def test_merge_indexed_dataframe_to_indexed_dataframe():
 
 def list_eq(aa, bb):
     if isinstance(aa, dd.DataFrame):
-        a = aa.compute(scheduler="sync")
+        a = aa.compute()
     else:
         a = aa
     if isinstance(bb, dd.DataFrame):
-        b = bb.compute(scheduler="sync")
+        b = bb.compute()
     else:
         b = bb
     tm.assert_index_equal(a.columns, b.columns)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -241,7 +241,7 @@ def test_hash_join(how, shuffle_method):
     c = hash_join(a, "x", b, "z", "outer", npartitions=3, shuffle=shuffle_method)
     assert c.npartitions == 3
 
-    result = c.compute(scheduler="single-threaded")
+    result = c.compute()
     expected = pd.merge(A, B, "outer", None, "x", "z")
 
     list_eq(result, expected)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -51,6 +51,7 @@ shuffle_func = shuffle  # conflicts with keyword argument
 
 def test_shuffle(shuffle_method):
     if shuffle_method == "p2p":
+        # uses synchronous scheduler
         pytest.skip()
 
     s = shuffle_func(d, d.b, shuffle=shuffle_method)
@@ -284,6 +285,7 @@ def test_shuffle_sort(shuffle_method):
 @pytest.mark.parametrize("scheduler", ["threads", "processes"])
 def test_rearrange(shuffle_method, scheduler):
     if shuffle_method == "p2p":
+        # p2p shuffle only runs on the distributed scheduler; substitute that for the "threads" case
         if scheduler == "processes":
             pytest.skip()
         scheduler = "distributed"


### PR DESCRIPTION
Changes to dask to support peer-to-peer shuffling implemented in https://github.com/dask/distributed/pull/5520.

The primary changes (besides supporting `shuffle="p2p"`) are adjusting tests to not force the synchronous scheduler, but use whatever scheduler is set as the current scheduler (including a distributed client). No tests actually seemed to be relying on this.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
