### PR TITLE
Actually ignore index when asked in `assert_eq`

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -10,6 +10,7 @@ from dask.dataframe.core import apply_and_enforce
 from dask.dataframe.utils import (
     PANDAS_GT_120,
     UNKNOWN_CATEGORIES,
+    assert_eq,
     check_matching_columns,
     check_meta,
     is_dataframe_like,
@@ -510,3 +511,13 @@ def test_nonempty_series_nullable_float():
     ser = pd.Series([], dtype="Float64")
     non_empty = meta_nonempty(ser)
     assert non_empty.dtype == "Float64"
+
+
+def test_assert_eq_sorts():
+    df1 = pd.DataFrame({"A": np.linspace(0, 1, 10), "B": np.random.random(10)})
+    df2 = df1.sort_values("B")
+    df2_r = df2.reset_index(drop=True)
+    assert_eq(df1, df2)
+    assert_eq(df1, df2_r, check_index=False)
+    with pytest.raises(AssertionError):
+        assert_eq(df1, df2_r)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -506,7 +506,7 @@ def _check_dask(dsk, check_names=True, check_dtypes=True, result=None):
     return dsk
 
 
-def _maybe_sort(a):
+def _maybe_sort(a, check_index: bool):
     # sort by value, then index
     try:
         if is_dataframe_like(a):
@@ -519,7 +519,7 @@ def _maybe_sort(a):
             a = a.sort_values()
     except (TypeError, IndexError, ValueError):
         pass
-    return a.sort_index()
+    return a.sort_index() if check_index else a
 
 
 def assert_eq(
@@ -542,20 +542,21 @@ def assert_eq(
     assert_sane_keynames(b)
     a = _check_dask(a, check_names=check_names, check_dtypes=check_dtype)
     b = _check_dask(b, check_names=check_names, check_dtypes=check_dtype)
-    if not check_index:
-        a = a.reset_index(drop=True)
-        b = b.reset_index(drop=True)
     if hasattr(a, "to_pandas"):
         a = a.to_pandas()
     if hasattr(b, "to_pandas"):
         b = b.to_pandas()
+    if isinstance(a, (pd.DataFrame, pd.Series)):
+        a = _maybe_sort(a, check_index)
+        b = _maybe_sort(b, check_index)
+    if not check_index:
+        a = a.reset_index(drop=True)
+        b = b.reset_index(drop=True)
     if isinstance(a, pd.DataFrame):
-        a = _maybe_sort(a)
-        b = _maybe_sort(b)
-        tm.assert_frame_equal(a, b, check_dtype=check_dtype, **kwargs)
+        tm.assert_frame_equal(
+            a, b, check_names=check_names, check_dtype=check_dtype, **kwargs
+        )
     elif isinstance(a, pd.Series):
-        a = _maybe_sort(a)
-        b = _maybe_sort(b)
         tm.assert_series_equal(
             a, b, check_names=check_names, check_dtype=check_dtype, **kwargs
         )


### PR DESCRIPTION
When passing `ignore_index=True`, two things were wrong:
1. We were resetting the index before sorting. After sorting, the values will be in the same order, but the newly-reset indexes may now be in different orders.
2. We were still sorting by the index in `_maybe_sort`.

cc @jcrist @jsignell 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
