### PR TITLE
Only run gpuCI bump script daily

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -2,7 +2,7 @@ name: Check for gpuCI updates
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 0 * * *" # Daily “At 00:00” UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Even though the job only takes 1-5 minutes, it's apparent now that we don't need this running any more than once a day; if there's any pertinent changes we want to capture, we can run the job manually through workflow dispatch

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
