### PR TITLE
Fix for index error with reading empty parquet file

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1265,7 +1265,7 @@ def set_index_columns(meta, index, columns, index_in_columns, auto_index_allowed
 def aggregate_row_groups(
     parts, stats, chunksize, split_row_groups, fs, aggregation_depth
 ):
-    if not stats[0].get("file_path_0", None):
+    if not stats or not stats[0].get("file_path_0", None):
         return parts, stats
 
     parts_agg = []

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2733,7 +2733,7 @@ def test_optimize_and_not(tmpdir):
 
 @write_read_engines()
 def test_chunksize_empty(tmpdir, write_engine, read_engine):
-    df = pd.DataFrame({"a": pd.Series(dtype="int"), "b": pd.Series(dtype="str")})
+    df = pd.DataFrame({"a": pd.Series(dtype="int"), "b": pd.Series(dtype="float")})
     ddf1 = dd.from_pandas(df, npartitions=1)
     ddf1.to_parquet(tmpdir, engine=write_engine)
     ddf2 = dd.read_parquet(tmpdir, engine=read_engine, chunksize="1MiB")

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2731,6 +2731,20 @@ def test_optimize_and_not(tmpdir):
         assert_eq(a, b)
 
 
+@pytest.mark.parametrize("dtype", ["str", "bool", "float"])
+@write_read_engines()
+def test_chunksize_empty(tmpdir, write_engine, read_engine, dtype):
+    df = pd.DataFrame(
+        {
+            "a": pd.Series(dtype="int"),
+            "b": pd.Series(dtype=dtype)
+        }
+    )
+    ddf = dd.from_pandas(df, npartitions=1)
+    ddf.to_parquet(tmpdir, engine=write_engine)
+    dd.read_parquet(tmpdir, engine=read_engine, chunksize="1MiB")
+
+
 @PYARROW_MARK
 @pytest.mark.parametrize("metadata", [True, False])
 @pytest.mark.parametrize("partition_on", [None, "a"])

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2737,7 +2737,7 @@ def test_chunksize_empty(tmpdir, write_engine, read_engine):
     ddf1 = dd.from_pandas(df, npartitions=1)
     ddf1.to_parquet(tmpdir, engine=write_engine)
     ddf2 = dd.read_parquet(tmpdir, engine=read_engine, chunksize="1MiB")
-    assert_eq(ddf1, ddf2)
+    assert_eq(ddf1, ddf2, check_index=False)
 
 
 @PYARROW_MARK

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2731,18 +2731,13 @@ def test_optimize_and_not(tmpdir):
         assert_eq(a, b)
 
 
-@pytest.mark.parametrize("dtype", ["str", "bool", "float"])
 @write_read_engines()
-def test_chunksize_empty(tmpdir, write_engine, read_engine, dtype):
-    df = pd.DataFrame(
-        {
-            "a": pd.Series(dtype="int"),
-            "b": pd.Series(dtype=dtype)
-        }
-    )
-    ddf = dd.from_pandas(df, npartitions=1)
-    ddf.to_parquet(tmpdir, engine=write_engine)
-    dd.read_parquet(tmpdir, engine=read_engine, chunksize="1MiB")
+def test_chunksize_empty(tmpdir, write_engine, read_engine):
+    df = pd.DataFrame({"a": pd.Series(dtype="int"), "b": pd.Series(dtype="str")})
+    ddf1 = dd.from_pandas(df, npartitions=1)
+    ddf1.to_parquet(tmpdir, engine=write_engine)
+    ddf2 = dd.read_parquet(tmpdir, engine=read_engine, chunksize="1MiB")
+    assert_eq(ddf1, ddf2)
 
 
 @PYARROW_MARK


### PR DESCRIPTION
Re #8374, implemented suggested change from @rjzamora to allow stats to be empty.
