### PR TITLE
Fix bug in read_csv for integer header argument

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -105,6 +105,8 @@ class CSVFunctionWrapper:
         if not is_first:
             write_header = True
             rest_kwargs.pop("skiprows", None)
+            if rest_kwargs.get("header", 0) is not None:
+                rest_kwargs.pop("header", None)
         if not is_last:
             rest_kwargs.pop("skipfooter", None)
 
@@ -581,6 +583,8 @@ def read_pandas(
             "in `sample` in the call to `read_csv`/`read_table`"
         )
 
+    if isinstance(header, int):
+        firstrow += header
     header = b"" if header is None else parts[firstrow] + b_lineterminator
 
     # Use sample to infer dtypes and check for presence of include_path_column

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -775,6 +775,22 @@ def test_windows_line_terminator():
         assert df.a.sum().compute() == 1 + 2 + 3 + 4 + 5 + 6
 
 
+def test_header_int():
+    text = (
+        "id0,name0,x0,y0\n"
+        "id,name,x,y\n"
+        "1034,Victor,-0.25,0.84\n"
+        "998,Xavier,-0.48,-0.13\n"
+        "999,Zelda,0.00,0.47\n"
+        "980,Alice,0.67,-0.98\n"
+        "989,Zelda,-0.04,0.03\n"
+    )
+    with filetexts({"test_header_int.csv": text}):
+        df = dd.read_csv("test_header_int.csv", header=1, blocksize=64)
+        expected = pd.read_csv("test_header_int.csv", header=1)
+        assert_eq(df, expected, check_index=False)
+
+
 def test_header_None():
     with filetexts({".tmp.1.csv": "1,2", ".tmp.2.csv": "", ".tmp.3.csv": "3,4"}):
         df = dd.read_csv(".tmp.*.csv", header=None)


### PR DESCRIPTION
Passing a non-zero integer to `read_csv(..., header=)` is currently broken for the case that there are multiple partitions per file. This PR adds a simple fix and test.

- [x] Closes #8407
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
