### PR TITLE
Add `dask/ml.py` to pytest exclude list

### DIFF
--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: pytest -v --doctest-modules --ignore-glob='*/test_*.py' --ignore-glob "dask/ml.py" dask
+        run: pytest -v --doctest-modules --ignore-glob='*/test_*.py' dask
 
   imports:
     runs-on: "ubuntu-latest"

--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,7 @@ collect_ignore = [
     "dask/dataframe/io/io.py",
     "dask/dataframe/io/parquet/arrow.py",
     "dask/dot.py",
+    "dask/ml.py",
 ]
 
 collect_ignore_glob = []


### PR DESCRIPTION
Follow up from https://github.com/dask/dask/pull/6384 *"Add dask.ml module"* - the file `dask/ml.py` needs to be in the pytest exclude list.

The problem we see is a pytest collection error in cases when `dask_ml` is not installed and the pytest `--doctest-modules` flag is set. One case where this happens is immediately after following the [Dask contributing guide](https://docs.dask.org/en/stable/develop.html) instructions. Following them as written leads to a pytest collection error (observed on Linux and Mac), and this PR fixes that.

- [ ] ~~Closes #xxxx~~
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
