### PR TITLE
Add warning to read_parquet when statistics and partitions are misaligned

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1150,6 +1150,7 @@ def process_statistics(
                 f"We must ignore the statistics and disable: "
                 f"filtering, divisions, and/or file aggregation."
             )
+            statistics = []
 
     if statistics:
         result = list(

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1139,18 +1139,19 @@ def process_statistics(
     Used in read_parquet.
     """
     index_in_columns = False
-    if statistics:
-        # Check that parts and statistics are the same length.
+    if statistics and len(parts) != len(statistics):
         # It is up to the Engine to guarantee that these
-        # lists are the same length (if statistics are defined)
-        if len(parts) != len(statistics):
-            warnings.warn(
-                f"Length of partition statistics ({len(statistics)}) "
-                f"does not match the partition count ({len(parts)}). "
-                f"We must ignore the statistics and disable: "
-                f"filtering, divisions, and/or file aggregation."
-            )
-            statistics = []
+        # lists are the same length (if statistics are defined).
+        # This misalignment may be indicative of a bug or
+        # incorrect read_parquet usage, so throw a warning.
+        warnings.warn(
+            f"Length of partition statistics ({len(statistics)}) "
+            f"does not match the partition count ({len(parts)}). "
+            f"This may indicate a bug or incorrect read_parquet "
+            f"usage. We must ignore the statistics and disable: "
+            f"filtering, divisions, and/or file aggregation."
+        )
+        statistics = []
 
     if statistics:
         result = list(

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1140,6 +1140,18 @@ def process_statistics(
     """
     index_in_columns = False
     if statistics:
+        # Check that parts and statistics are the same length.
+        # It is up to the Engine to guarantee that these
+        # lists are the same length (if statistics are defined)
+        if len(parts) != len(statistics):
+            warnings.warn(
+                f"Length of partition statistics ({len(statistics)}) "
+                f"does not match the partition count ({len(parts)}). "
+                f"We must ignore the statistics and disable: "
+                f"filtering, divisions, and/or file aggregation."
+            )
+
+    if statistics:
         result = list(
             zip(
                 *[


### PR DESCRIPTION
Motivated by #8399

This PR does not add test coverage because I cannot reproduce a case where statistics and partitions are misaligned. Even so, it seems best to have this edge case covered with a clear user warning.
