### PR TITLE
improved the efficiency of `matmul()` by completely removing concatenation

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -369,6 +369,11 @@ def _matmul(a, b):
     xp = np
 
     if is_cupy_type(a):
+        # This branch appears to  be unnecessary since cupy
+        # version 9.0. See the following link:
+        # https://github.com/dask/dask/pull/8423#discussion_r768291271
+        # But it remains here  for  backward-compatibility.
+        # Consider removing it in a future version of dask.
         import cupy
 
         xp = cupy

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -343,14 +343,7 @@ def _chunk_sum(a, axis=None, dtype=None, keepdims=None):
     # the output can be merely squeezed to lose the `axis`-
     # dimension when keepdims = False
     if type(a) is list:
-        xp = np
-
-        if is_cupy_type(a[0]):
-            import cupy
-
-            xp = cupy
-
-        out = reduce(partial(xp.add, dtype=dtype), a)
+        out = reduce(partial(np.add, dtype=dtype), a)
     else:
         out = a
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -340,7 +340,7 @@ def _chunk_sum(a, axis=None, dtype=None, keepdims=None):
     # same shape,  with a size of 1 for the dimension given
     # by `axis` (the reduction axis).  This makes mere ele-
     # ment-wise addition of the arrays possible.   Besides,
-    # the output can be merely reshaped to lose the `axis`-
+    # the output can be merely squeezed to lose the `axis`-
     # dimension when keepdims = False
     if type(a) is list:
         xp = np
@@ -352,9 +352,8 @@ def _chunk_sum(a, axis=None, dtype=None, keepdims=None):
 
         out = reduce(partial(xp.add, dtype=dtype), a)
     else:
-        if a.shape == (0,):
-            return a
         out = a
+
     if keepdims:
         return out
     else:

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -333,12 +333,6 @@ def vdot(a, b):
     return dot(a.conj().ravel(), b.ravel())
 
 
-def _shape_minus_axis(shape, axis):
-    newshape = list(shape)
-    newshape.pop(axis)
-    return tuple(newshape)
-
-
 def _chunk_sum(a, axis=None, dtype=None, keepdims=None):
     # Caution: this is not your conventional array-sum: due
     # to the special nature of the preceding blockwise con-
@@ -364,7 +358,7 @@ def _chunk_sum(a, axis=None, dtype=None, keepdims=None):
     if keepdims:
         return out
     else:
-        return out.reshape(_shape_minus_axis(out.shape, axis[0]))
+        return out.squeeze(axis[0])
 
 
 def _sum_wo_cat(a, axis=None, dtype=None):

--- a/dask/array/tests/test_dispatch.py
+++ b/dask/array/tests/test_dispatch.py
@@ -85,6 +85,7 @@ class EncapsulateNDArray(np.lib.mixins.NDArrayOperatorsMixin):
     sum = wrap("sum")
     prod = wrap("prod")
     reshape = wrap("reshape")
+    squeeze = wrap("squeeze")
 
 
 da.register_chunk_type(EncapsulateNDArray)


### PR DESCRIPTION
- [x] Supplements #7000 
- [x] Tests passed
- [x] Passes `pre-commit run --all-files`

This PR avoids concatenation in both `blockwise()` and `reduction()` within the implementation of `matmul()`.  Previously, `matmul()` avoided concatenation only in `blockwise()`.

Due to the special nature of the preceding blockwise contraction, all chunk-operands of a sum during the reduction phase are expected to have exactly the same shape, with a size of 1 for the reduction axis.  This makes mere element-wise addition of the chunks possible.   Furthermore, the summation result can be merely reshaped to lose the reduction axis when requested.  In principle, both these operations (element-wise addition and reshaping) are performance boosters compared to the default concatenation-mediated reduction which often involves data rearrangement.

The code of `matmul()` has also been shortened, making it a bit more readable.  This is a direct consequence of ensuring that the position of the new-axis introduced in the output of chunk-function `_matmul()` \[the first argument to `blockwise()`\] is consistent with its expected position in the output of `blockwise()` (the position of the contraction-axis).

Performance is comparable to the original `matmul()` implementation in all cases except one, in which this new implementation is approximately 20% faster, namely, "the case where all dimensions are chunked".  This outcome is consistent with the total absence of concatenation-overhead in the new version.   Performance results can be found in this [jupyter notebook](https://github.com/ParticularMiner/dask/blob/matmul_performance/matmul_perf_second2last.ipynb).

See discussion with @ravwojdyla at https://github.com/dask/dask/pull/7000#discussion_r756926031 for the motivation of this PR.