### PR TITLE
Update Anaconda link in "Paid support" section of docs

### DIFF
--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -86,6 +86,6 @@ Paid support
 In addition to the previous options, paid support is available from the
 following organizations (listed in alphabetical order):
 
--   Anaconda: `<https://www.anaconda.com/help>`_
+-   Anaconda: `<https://www.anaconda.com/products/professional-services>`_
 -   Coiled: `<https://coiled.io>`_
 -   Quansight: `<https://www.quansight.com/open-source-support>`_


### PR DESCRIPTION
In "paid support" - old page was retired

- [ ] ~Closes #xxxx~
- [ ] ~Tests added / passed~
- [ ] ~Passes `pre-commit run --all-files`~
