### PR TITLE
Bump Bokeh min version to 2.1.1

### DIFF
--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -383,11 +383,7 @@ def plot_resources(results, palette="Viridis", **kwargs):
         cpu,
         color=colors[0],
         line_width=4,
-        **{
-            "legend_label"
-            if parse_version(bokeh.__version__) >= parse_version("1.4")
-            else "legend": "% CPU"
-        },
+        legend_label="% CPU",
     )
     p.yaxis.axis_label = "% CPU"
     p.extra_y_ranges = {
@@ -401,11 +397,7 @@ def plot_resources(results, palette="Viridis", **kwargs):
         color=colors[2],
         y_range_name="memory",
         line_width=4,
-        **{
-            "legend_label"
-            if parse_version(bokeh.__version__) >= parse_version("1.4")
-            else "legend": "Memory"
-        },
+        legend_label="Memory",
     )
     p.add_layout(LinearAxis(y_range_name="memory", axis_label="Memory (MB)"), "right")
     p.xaxis.axis_label = "Time (s)"

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -4,7 +4,6 @@ from bisect import bisect_left
 from itertools import cycle
 from operator import add, itemgetter
 
-from packaging.version import parse as parse_version
 from tlz import accumulate, groupby, pluck, unique
 
 from ..core import istask
@@ -342,7 +341,6 @@ def plot_resources(results, palette="Viridis", **kwargs):
     The completed bokeh plot object.
     """
     bp = import_required("bokeh.plotting", _BOKEH_MISSING_MSG)
-    import bokeh
     from bokeh import palettes
     from bokeh.models import LinearAxis, Range1d
 

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -4,7 +4,6 @@ from operator import add, mul
 from time import sleep
 
 import pytest
-from packaging.version import parse as parse_version
 
 from dask.diagnostics import CacheProfiler, Profiler, ResourceProfiler
 from dask.threaded import get
@@ -214,6 +213,7 @@ def test_pprint_task():
     assert pprint_task(task, keys) == "foo(_, _, y=[_, _], z=_)"
     task = (apply, foo, (tuple, ["a", "b"]), (dict, [["y", ["a", 1]], ["z", 1]]))
     assert pprint_task(task, keys) == "foo(_, _, y=[_, *], z=*)"
+
 
 @pytest.mark.skipif("not bokeh")
 def test_profiler_plot():

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -85,7 +85,7 @@ These optional dependencies and their minimum supported versions are listed belo
 +---------------+----------+--------------------------------------------------------------+
 | Dependency    | Version  |                          Description                         |
 +===============+==========+==============================================================+
-|     bokeh     | >=1.0.0  |                Visualizing dask diagnostics                  |
+|     bokeh     | >=2.1.1  |                Visualizing dask diagnostics                  |
 +---------------+----------+--------------------------------------------------------------+
 |   cityhash    |          |                  Faster hashing of arrays                    |
 +---------------+----------+--------------------------------------------------------------+

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
     "dataframe": ["numpy >= 1.18", "pandas >= 1.0"],
     "distributed": ["distributed == 2021.11.2"],
     "diagnostics": [
-        "bokeh >= 1.0.0, != 2.0.0",
+        "bokeh >= 2.1.1",
         "jinja2",
     ],
     "delayed": [],  # keeping for backwards compatibility


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`


xref: https://github.com/dask/distributed/pull/5548

cc @jrbourbeau 

I am not sure if the same update in `distributed` in linked PR is wanted/warranted here, but in case it is, this PR also updates the Bokeh min version to 2.1.1. to match, and deletes old version-check codes. 