### PR TITLE
Fix docs build warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   = sphinx-build
 PYTEST        = pytest
 PAPER         =

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -30,7 +30,7 @@ Top level functions
    argtopk
    argwhere
    around
-   Array
+   array
    asanyarray
    asarray
    atleast_1d

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -30,7 +30,7 @@ Top level functions
    argtopk
    argwhere
    around
-   array
+   Array
    asanyarray
    asarray
    atleast_1d

--- a/docs/source/array-overlap.rst
+++ b/docs/source/array-overlap.rst
@@ -25,6 +25,7 @@ below:
    map_overlap
 
 .. autofunction:: map_overlap
+   :noindex:
 
 
 Explanation

--- a/docs/source/array-overlap.rst
+++ b/docs/source/array-overlap.rst
@@ -121,7 +121,7 @@ that is not stored locally in each block:
 
    >>> filt = g.map_blocks(func)
 
-While in this case we used a SciPy function, any arbitrary function could have been 
+While in this case we used a SciPy function, any arbitrary function could have been
 used instead. This is a good interaction point with Numba_.
 
 If your function does not preserve the shape of the block, then you will need to

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4666,6 +4666,7 @@ Other
 .. _`Martin Fleischmann`: https://github.com/martinfleis
 .. _`Robert Hales`: https://github.com/robalar
 .. _`João Paulo Lacerda`: https://github.com/jopasdev
+.. _`neel iyer`: https://github.com/spiyer99
 .. _`SnkSynthesis`: https://github.com/SnkSynthesis
 .. _`JoranDox`: https://github.com/JoranDox
 .. _`Kinshuk Dua`: https://github.com/kinshukdua

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -719,9 +719,6 @@ Publish-Subscribe
 Dask implements the `Publish Subscribe pattern <https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern>`_,
 providing an additional channel of communication between ongoing tasks.
 
-.. autoclass:: Pub
-   :members:
-   :noindex:
 
 Actors
 ------

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -721,6 +721,7 @@ providing an additional channel of communication between ongoing tasks.
 
 .. autoclass:: Pub
    :members:
+   :noindex:
 
 Actors
 ------

--- a/docs/source/high-level-graphs.rst
+++ b/docs/source/high-level-graphs.rst
@@ -190,3 +190,7 @@ API
 .. autoclass:: HighLevelGraph
    :members:
    :inherited-members:
+   :exclude-members: visualize
+
+.. TODO: Fix graphviz dependency in docs build and remove ``visualize`` from
+   exclude-members in the above directive


### PR DESCRIPTION
- [X] Fixes #5610
- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`

Fixes all remaining docs build warnings via the following changes:

- Change `array` to `Array` in Array API docs page
- Set `:noindex:` option on `.. autofunction:: map_overlap` and `.. autoclass:: Pub` to avoid duplicate object descriptions
- Add missing contributor / reference target in changelog
- Exclude `HighLevelGraph.visualize` from API docs due to missing build dep (added TODO for future work)
- Treat docs warnings as errors (to avoid introducing new warnings in the future)

Note that some docs build warnings in Dask were a result of some warnings/docs issues in `distributed`. I opened the following PR in `distributed` that addresses those: https://github.com/dask/distributed/pull/5549. That PR will need to be merged upstream before getting a clean docs build in this PR.