### PR TITLE
Make `read_csv` with `comment` kwarg work

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -572,7 +572,23 @@ def read_pandas(
     names = kwargs.get("names", None)
     header = kwargs.get("header", "infer" if names is None else None)
     need = 1 if header is None else 2
-    parts = b_sample.split(b_lineterminator, lastskiprow + need)
+
+    if kwargs.get("comment"):
+        # if comment is provided, step through lines of b_sample and strip out comments
+        parts = []
+        for part in b_sample.split(b_lineterminator):
+            split_comment = part.decode().split(kwargs.get("comment"))
+            if len(split_comment) > 1:
+                # if line starts with comment, don't include that line in parts.
+                if len(split_comment[0]) > 0:
+                    parts.append(split_comment[0].strip().encode())
+            else:
+                parts.append(part)
+            if len(parts) > need:
+                break
+    else:
+        parts = b_sample.split(b_lineterminator, lastskiprow + need)
+
     # If the last partition is empty, don't count it
     nparts = 0 if not parts else len(parts) - int(not parts[-1])
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -253,6 +253,23 @@ def test_skiprows(dd_read, pd_read, files):
     "dd_read,pd_read,files",
     [(dd.read_csv, pd.read_csv, csv_files), (dd.read_table, pd.read_table, tsv_files)],
 )
+def test_comment(dd_read, pd_read, files):
+    files = {
+        name: comment_header
+        + b"\n"
+        + content.replace(b"\n", b"  # just some comment\n", 1)
+        for name, content in files.items()
+    }
+    with filetexts(files, mode="b"):
+        df = dd_read("2014-01-*.csv", comment="#")
+        expected_df = pd.concat([pd_read(n, comment="#") for n in sorted(files)])
+        assert_eq(df, expected_df, check_dtype=False)
+
+
+@pytest.mark.parametrize(
+    "dd_read,pd_read,files",
+    [(dd.read_csv, pd.read_csv, csv_files), (dd.read_table, pd.read_table, tsv_files)],
+)
 def test_skipfooter(dd_read, pd_read, files):
     files = {name: content + b"\n" + comment_footer for name, content in files.items()}
     skip = len(comment_footer.splitlines())


### PR DESCRIPTION
Even if there is a comment in the header, dask should be able to handle that.

- [x] Closes #8418
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
