### PR TITLE
Better error message for length of array with unknown chunk sizes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1404,7 +1404,11 @@ class Array(DaskMethodsMixin):
     def __len__(self):
         if not self.chunks:
             raise TypeError("len() of unsized object")
-        return sum(self.chunks[0])
+        try:
+            return int(sum(self.chunks[0]))
+        except (TypeError, ValueError):
+            pass
+        raise TypeError("len() of object with unknown size is unsupported.")
 
     def __array_ufunc__(self, numpy_ufunc, method, *inputs, **kwargs):
         out = kwargs.get("out", ())

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1404,11 +1404,13 @@ class Array(DaskMethodsMixin):
     def __len__(self):
         if not self.chunks:
             raise TypeError("len() of unsized object")
-        try:
-            return int(sum(self.chunks[0]))
-        except (TypeError, ValueError):
-            pass
-        raise TypeError("len() of object with unknown size is unsupported.")
+        if np.isnan(self.chunks[0]).any():
+            msg = (
+                "Cannot call len() on object with unknown chunk size."
+                f"{unknown_chunk_message}"
+            )
+            raise ValueError(msg)
+        return int(sum(self.chunks[0]))
 
     def __array_ufunc__(self, numpy_ufunc, method, *inputs, **kwargs):
         out = kwargs.get("out", ())

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4966,5 +4966,5 @@ def test_dask_layers():
 def test_len_object_with_unknown_size():
     a = da.random.random(size=(20, 2))
     b = a[a < 0.5]
-    with pytest.raises(TypeError, match="object with unknown size"):
+    with pytest.raises(ValueError, match="on object with unknown chunk size"):
         assert len(b)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4961,3 +4961,10 @@ def test_dask_layers():
     assert b.dask.layers.keys() == {a.name, b.name}
     assert b.dask.dependencies == {a.name: set(), b.name: {a.name}}
     assert b.__dask_layers__() == (b.name,)
+
+
+def test_len_object_with_unknown_size():
+    a = da.random.random(size=(20, 2))
+    b = a[a < 0.5]
+    with pytest.raises(TypeError, match="object with unknown size"):
+        assert len(b)


### PR DESCRIPTION
- ~~[ ] Closes #xxxx~~
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Discovered this while tinkering with `len` of collections for some dask-awkward dev. Previous behavior:

```python
>>> import dask.array as da
>>> a = da.random.random((100, 2))
>>> a = a[a < 0.5]
>>> len(a)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'float' object cannot be interpreted as an integer
```
with this PR:

```python
>>> a = da.random.random((100, 2))
>>> a = a[a < 0.5]
>>> len(a)
ValueError: Cannot call len() on object with unknown chunk size.

A possible solution: https://docs.dask.org/en/latest/array-chunks.html#unknown-chunks
Summary: to compute chunks sizes, use

   x.compute_chunk_sizes()  # for Dask Array `x`
   ddf.to_dask_array(lengths=True)  # for Dask DataFrame `ddf`
```
