### PR TITLE
Use ``by`` instead of ``index`` internally on the Groupby class

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1093,7 +1093,7 @@ class _GroupBy:
         )
 
     @property
-    @_deprecated
+    @_deprecated()
     def index(self):
         return self.by
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1055,20 +1055,14 @@ class _GroupBy:
         self.by = _normalize_by(df, by)
         self.sort = sort
 
-        if isinstance(self.by, list):
-            do_by_partition_align = all(
-                item.npartitions == df.npartitions if isinstance(item, Series) else True
-                for item in self.by
-            )
-        elif isinstance(self.by, Series):
-            do_by_partition_align = df.npartitions == self.by.npartitions
-        else:
-            do_by_partition_align = True
+        partitions_aligned = all(
+            item.npartitions == df.npartitions if isinstance(item, Series) else True
+            for item in (self.by if isinstance(self.by, (tuple, list)) else [self.by])
+        )
 
-        if not do_by_partition_align:
+        if not partitions_aligned:
             raise NotImplementedError(
-                "The grouped object and by of the "
-                "groupby must have the same divisions."
+                "The grouped object and 'by' of the groupby must have the same divisions."
             )
 
         # slicing key applied to _GroupBy instance
@@ -1099,7 +1093,7 @@ class _GroupBy:
         )
 
     @property
-    @_deprecated(use_instead="Groupby.by")
+    @_deprecated
     def index(self):
         return self.by
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
-from ..utils import M, derived_from, funcname, itemgetter
+from ..utils import M, _deprecated, derived_from, funcname, itemgetter
 from .core import (
     DataFrame,
     Series,
@@ -1097,6 +1097,15 @@ class _GroupBy:
         self._meta = self.obj._meta.groupby(
             by_meta, group_keys=group_keys, **self.observed, **self.dropna
         )
+
+    @property
+    @_deprecated(use_instead="Groupby.by")
+    def index(self):
+        return self.by
+
+    @index.setter
+    def index(self, value):
+        self.by = value
 
     @property
     def _groupby_kwargs(self):

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -457,10 +457,10 @@ class RollingGroupby(Rolling):
                 sliced_plus = [self._groupby_slice]
             else:
                 sliced_plus = list(self._groupby_slice)
-            if isinstance(groupby.index, str):
-                sliced_plus.append(groupby.index)
+            if isinstance(groupby.by, str):
+                sliced_plus.append(groupby.by)
             else:
-                sliced_plus.extend(groupby.index)
+                sliced_plus.extend(groupby.by)
             obj = obj[sliced_plus]
 
         super().__init__(

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -921,20 +921,20 @@ def test_groupby_multiprocessing():
         )
 
 
-def test_groupby_normalize_index():
+def test_groupby_normalize_by():
     full = pd.DataFrame(
         {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
         index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
     )
     d = dd.from_pandas(full, npartitions=3)
 
-    assert d.groupby("a").index == "a"
-    assert d.groupby(d["a"]).index == "a"
-    assert d.groupby(d["a"] > 2).index._name == (d["a"] > 2)._name
-    assert d.groupby(["a", "b"]).index == ["a", "b"]
+    assert d.groupby("a").by == "a"
+    assert d.groupby(d["a"]).by == "a"
+    assert d.groupby(d["a"] > 2).by._name == (d["a"] > 2)._name
+    assert d.groupby(["a", "b"]).by == ["a", "b"]
 
-    assert d.groupby([d["a"], d["b"]]).index == ["a", "b"]
-    assert d.groupby([d["a"], "b"]).index == ["a", "b"]
+    assert d.groupby([d["a"], d["b"]]).by == ["a", "b"]
+    assert d.groupby([d["a"], "b"]).by == ["a", "b"]
 
 
 def test_aggregate__single_element_groups(agg_func):


### PR DESCRIPTION
I was trying to get a handle on the Groupby implementation and realized that the internal implementation still uses ``index`` rather than ``by``. This is an effort to make the name consistent. As part of this work I plan to add `index` as a deprecated alias property for `by`.