### PR TITLE
DataFrame fusion when some layers are materialized

### DIFF
--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -91,8 +91,8 @@ properties:
               Turn task fusion on/off. This option refers to the fusion of a
               fully-materialized task graph (not a high-Level graph). By default
               (None), the active task-fusion option will be treated as ``False``
-              for Dask-Dataframe collections, and as ``True`` for all other graphs
-              (including Dask-Array collections).
+              for Dask-Dataframe collections using only Blockwise layers,
+              and as ``True`` for all other graphs (including Dask-Array collections).
 
           ave-width:
             type: number

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -1,7 +1,10 @@
 import pandas as pd
+import pytest
 
 import dask
 import dask.dataframe as dd
+from dask.blockwise import optimize_blockwise
+from dask.core import ishashable
 
 dsk = {
     ("x", 0): pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=[0, 1, 3]),
@@ -27,8 +30,6 @@ def test_fuse_ave_width():
 
 
 def test_optimize_blockwise():
-    from dask.array.optimization import optimize_blockwise
-
     df = pd.DataFrame({"x": range(10), "y": range(10)})
     ddf = dd.from_pandas(df, npartitions=2)
 
@@ -38,3 +39,65 @@ def test_optimize_blockwise():
     graph = optimize_blockwise(ddf.dask)
 
     assert len(graph) <= 4
+
+
+@pytest.mark.parametrize("fuse", [False, None, True])
+def test_lowlevel_fuse_default_blockwise_only(fuse):
+    df = dask.datasets.timeseries(dtypes={"x": int, "y": int})
+    df2 = df + 1
+    shuffle = df2.shuffle("x", shuffle="tasks")
+    # ^ Not Blockwise, but still non-materialized
+    df4 = shuffle - 1
+    df5 = df4 * 2
+
+    with dask.config.set({"optimization.fuse.active": fuse}):
+        (opt,) = dask.optimize(df5)
+    dsk = opt.__dask_graph__()
+    layers = dsk.layers
+
+    if fuse in (False, None):
+        # `ensure_dict` was not called, because no layers require low-level fusion.
+
+        # Layers in parenthesis are fused by high-level Blockwise fusion:
+        # (df,df2) -> shuffle -> (df4,df5)
+        assert len(layers) == 3
+        assert not any(l.is_materialized() for l in layers.values())
+    else:
+        # `ensure_dict` was called
+        assert len(layers) == 1
+        assert next(iter(layers.values())).is_materialized()
+
+
+@pytest.mark.parametrize("fuse", [False, None, True])
+def test_lowlevel_fuse_default_with_materialized(fuse):
+    df = dask.datasets.timeseries(dtypes={"x": int, "y": int})
+    df2 = df + 1
+    delayed = df2.to_delayed(optimize_graph=True)
+    # ^ FIXME: this will fail with `optimize_graph=False` due to https://github.com/dask/dask/issues/8173!
+    delayed2 = [p * 2 for p in delayed]
+    df3 = dd.from_delayed(
+        delayed2, meta=df2, divisions=df2.divisions, verify_meta=False
+    )
+    df4 = df3 - 1
+    df5 = df4 - 1
+
+    with dask.config.set({"optimization.fuse.active": fuse}):
+        (opt,) = dask.optimize(df5)
+    dsk = opt.__dask_graph__()
+
+    if fuse is False:
+        # Blockwise-only fusion doesn't work across the delayed operations.
+
+        # Layers in parenthesis are fused by high-level Blockwise fusion:
+        # (df,df2) -> delayed2 * 30 -> df3 -> (df4,df5)
+        assert len(dsk.layers) == df.npartitions + 3
+    else:
+        # Entire graph should be fused, including the non-Blockwise operations from delayed.
+        assert len(dsk.layers) == 1
+        layer = next(iter(dsk.layers.values()))
+        assert layer.is_materialized()
+        dsk = layer.mapping
+        # Optimization produces 2 * npartitions keys for some reason,
+        # where half of them are aliases to the others.
+        de_aliased = {k: v for k, v in dsk.items() if not (ishashable(v) and v in dsk)}
+        assert len(de_aliased) == df5.npartitions


### PR DESCRIPTION
Change the DataFrame optimization default so that DataFrames that may need low-level fusion still get it.

cc @rjzamora @ian-r-rose @jrbourbeau

- [x] Closes #8447
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
