### PR TITLE
Track HLG layer name in Delayed

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1068,7 +1068,7 @@ def store(
         store_dsk = HighLevelGraph(layers, dependencies)
         load_store_dsk = store_dsk
         if compute:
-            store_dlyds = [Delayed(k, store_dsk) for k in map_keys]
+            store_dlyds = [Delayed(k, store_dsk, layer=k[0]) for k in map_keys]
             store_dlyds = persist(*store_dlyds, **kwargs)
             store_dsk_2 = HighLevelGraph.merge(*[e.dask for e in store_dlyds])
             load_store_dsk = retrieve_from_ooc(map_keys, store_dsk, store_dsk_2)
@@ -2639,11 +2639,12 @@ class Array(DaskMethodsMixin):
         """
         keys = self.__dask_keys__()
         graph = self.__dask_graph__()
+        layer = self.__dask_layers__()[0]
         if optimize_graph:
             graph = self.__dask_optimize__(graph, keys)  # TODO, don't collape graph
-            name = "delayed-" + self.name
+            layer = name = "delayed-" + self.name
             graph = HighLevelGraph.from_collections(name, graph, dependencies=())
-        L = ndeepmap(self.ndim, lambda k: Delayed(k, graph), keys)
+        L = ndeepmap(self.ndim, lambda k: Delayed(k, graph, layer=layer), keys)
         return np.array(L, dtype=object)
 
     @derived_from(np.ndarray)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2642,8 +2642,8 @@ class Array(DaskMethodsMixin):
         layer = self.__dask_layers__()[0]
         if optimize_graph:
             graph = self.__dask_optimize__(graph, keys)  # TODO, don't collape graph
-            layer = name = "delayed-" + self.name
-            graph = HighLevelGraph.from_collections(name, graph, dependencies=())
+            layer = "delayed-" + self.name
+            graph = HighLevelGraph.from_collections(layer, graph, dependencies=())
         L = ndeepmap(self.ndim, lambda k: Delayed(k, graph, layer=layer), keys)
         return np.array(L, dtype=object)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3277,10 +3277,16 @@ def test_to_delayed_optimize_graph():
     # optimizations
     d = y.to_delayed().flatten().tolist()[0]
     assert len([k for k in d.dask if k[0].startswith("getitem")]) == 1
+    assert d.key == (y.name, 0, 0)
+    assert d.dask.layers.keys() == {"delayed-" + y.name}
+    assert d.dask.dependencies == {"delayed-" + y.name: set()}
+    assert d.__dask_layers__() == ("delayed-" + y.name,)
 
     # no optimizations
     d2 = y.to_delayed(optimize_graph=False).flatten().tolist()[0]
-    assert dict(d2.dask) == dict(y.dask)
+    assert d2.dask is y.dask
+    assert d2.key == (y.name, 0, 0)
+    assert d2.__dask_layers__() == y.__dask_layers__()
 
     assert (d.compute() == d2.compute()).all()
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -341,10 +341,19 @@ def robust_wraps(wrapper):
 
 
 class Item(DaskMethodsMixin):
-    def __init__(self, dsk, key):
+    def __init__(self, dsk, key, layer=None):
         self.dask = dsk
         self.key = key
         self.name = key
+
+        # NOTE: Layer only used by `Item.from_delayed`, to handle Delayed objects created by other collections.
+        # e.g.: Item.from_delayed(da.ones(1).to_delayed()[0])
+        # See Delayed.__init__
+        self._layer = layer or key
+        if isinstance(dsk, HighLevelGraph) and self._layer not in dsk.layers:
+            raise ValueError(
+                f"Layer {self._layer} not in the HighLevelGraph's layers: {list(dsk.layers)}"
+            )
 
     def __dask_graph__(self):
         return self.dask
@@ -353,13 +362,7 @@ class Item(DaskMethodsMixin):
         return [self.key]
 
     def __dask_layers__(self):
-        # Deal with instances created with Item.from_delayed()
-        # e.g.: Item.from_delayed(da.ones(1).to_delayed()[0])
-        # See Delayed.__dask_layers__
-        if isinstance(self.dask, HighLevelGraph) and len(self.dask.layers) == 1:
-            return tuple(self.dask.layers)
-        else:
-            return (self.key,)
+        return (self._layer,)
 
     def __dask_tokenize__(self):
         return self.key
@@ -388,7 +391,7 @@ class Item(DaskMethodsMixin):
         if not isinstance(value, Delayed) and hasattr(value, "key"):
             value = delayed(value)
         assert isinstance(value, Delayed)
-        return Item(value.dask, value.key)
+        return Item(value.dask, value.key, layer=value.__dask_layers__()[0])
 
     @property
     def _args(self):
@@ -422,7 +425,7 @@ class Item(DaskMethodsMixin):
         dsk = self.__dask_graph__()
         if optimize_graph:
             dsk = self.__dask_optimize__(dsk, self.__dask_keys__())
-        return Delayed(self.key, dsk)
+        return Delayed(self.key, dsk, layer=self._layer)
 
 
 class Bag(DaskMethodsMixin):
@@ -1619,9 +1622,11 @@ class Bag(DaskMethodsMixin):
 
         keys = self.__dask_keys__()
         dsk = self.__dask_graph__()
+        layer = self.name
         if optimize_graph:
             dsk = self.__dask_optimize__(dsk, keys)
-        return [Delayed(k, dsk) for k in keys]
+            layer = None
+        return [Delayed(k, dsk, layer=layer) for k in keys]
 
     def repartition(self, npartitions=None, partition_size=None):
         """Repartition Bag across new divisions.

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1625,7 +1625,8 @@ class Bag(DaskMethodsMixin):
         layer = self.name
         if optimize_graph:
             dsk = self.__dask_optimize__(dsk, keys)
-            layer = None
+            layer = "delayed-" + layer
+            dsk = HighLevelGraph.from_collections(layer, dsk, dependencies=())
         return [Delayed(k, dsk, layer=layer) for k in keys]
 
     def repartition(self, npartitions=None, partition_size=None):

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1110,16 +1110,20 @@ def test_to_delayed_optimize_graph(tmpdir):
     [d] = b2.to_delayed()
     text = str(dict(d.dask))
     assert text.count("reify") == 1
+    assert d.__dask_layers__() != b2.__dask_layers__()
     [d2] = b2.to_delayed(optimize_graph=False)
     assert dict(d2.dask) == dict(b2.dask)
+    assert d2.__dask_layers__() == b2.__dask_layers__()
     assert d.compute() == d2.compute()
 
     x = b2.sum()
     d = x.to_delayed()
     text = str(dict(d.dask))
+    assert d.__dask_layers__() != x.__dask_layers__()
     assert text.count("reify") == 0
     d2 = x.to_delayed(optimize_graph=False)
     assert dict(d2.dask) == dict(x.dask)
+    assert d2.__dask_layers__() == x.__dask_layers__()
     assert d.compute() == d2.compute()
 
     [d] = b2.to_textfiles(str(tmpdir), compute=False)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1119,7 +1119,7 @@ def test_to_delayed_optimize_graph(tmpdir):
     x = b2.sum()
     d = x.to_delayed()
     text = str(dict(d.dask))
-    assert d.__dask_layers__() != x.__dask_layers__()
+    assert d.__dask_layers__() == x.__dask_layers__()
     assert text.count("reify") == 0
     d2 = x.to_delayed(optimize_graph=False)
     assert dict(d2.dask) == dict(x.dask)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1571,13 +1571,26 @@ def test_dask_layers():
     assert i.dask.dependencies == {a.name: set(), i.key: {a.name}}
 
 
-def test_dask_layers_to_delayed():
-    # da.Array.to_delayed squashes the dask graph and causes the layer name not to
-    # match the key
+@pytest.mark.parametrize("optimize", [False, True])
+def test_dask_layers_to_delayed(optimize):
+    # `da.Array.to_delayed` causes the layer name to not match the key.
+    # Ensure the layer name is propagated between `Delayed` and `Item`.
     da = pytest.importorskip("dask.array")
-    i = db.Item.from_delayed(da.ones(1).to_delayed()[0])
-    name = i.key[0]
-    assert i.key[1:] == (0,)
-    assert i.dask.layers.keys() == {"delayed-" + name}
-    assert i.dask.dependencies == {"delayed-" + name: set()}
-    assert i.__dask_layers__() == ("delayed-" + name,)
+    arr = da.ones(1) + 1
+    delayed = arr.to_delayed(optimize_graph=optimize)[0]
+    i = db.Item.from_delayed(delayed)
+    assert i.key == delayed.key
+    assert i.dask is delayed.dask
+    assert i.__dask_layers__() == delayed.__dask_layers__()
+
+    back = i.to_delayed(optimize_graph=optimize)
+    assert back.__dask_layers__() == i.__dask_layers__()
+
+    if not optimize:
+        assert back.dask is arr.dask
+        # When not optimized, the key is not a layer in the graph, so using it should fail
+        with pytest.raises(ValueError, match="not in"):
+            db.Item(back.dask, back.key)
+
+    with pytest.raises(ValueError, match="not in"):
+        db.Item(arr.dask, (arr.name,), layer="foo")

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -253,11 +253,12 @@ class Scalar(DaskMethodsMixin, OperatorMethodMixin):
             ``dask.delayed`` objects.
         """
         dsk = self.__dask_graph__()
+        layer = self.__dask_layers__()[0]
         if optimize_graph:
             dsk = self.__dask_optimize__(dsk, self.__dask_keys__())
-            name = "delayed-" + self._name
+            layer = name = "delayed-" + self._name
             dsk = HighLevelGraph.from_collections(name, dsk, dependencies=())
-        return Delayed(self.key, dsk)
+        return Delayed(self.key, dsk, layer=layer)
 
 
 def _scalar_binary(op, self, other, inv=False):
@@ -1572,11 +1573,12 @@ Dask Name: {name}, {task} tasks"""
         """
         keys = self.__dask_keys__()
         graph = self.__dask_graph__()
+        layer = self.__dask_layers__()[0]
         if optimize_graph:
             graph = self.__dask_optimize__(graph, self.__dask_keys__())
-            name = "delayed-" + self._name
+            layer = name = "delayed-" + self._name
             graph = HighLevelGraph.from_collections(name, graph, dependencies=())
-        return [Delayed(k, graph) for k in keys]
+        return [Delayed(k, graph, layer=layer) for k in keys]
 
     @classmethod
     def _get_unary_operator(cls, op):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -256,8 +256,8 @@ class Scalar(DaskMethodsMixin, OperatorMethodMixin):
         layer = self.__dask_layers__()[0]
         if optimize_graph:
             dsk = self.__dask_optimize__(dsk, self.__dask_keys__())
-            layer = name = "delayed-" + self._name
-            dsk = HighLevelGraph.from_collections(name, dsk, dependencies=())
+            layer = "delayed-" + self._name
+            dsk = HighLevelGraph.from_collections(layer, dsk, dependencies=())
         return Delayed(self.key, dsk, layer=layer)
 
 
@@ -1576,8 +1576,8 @@ Dask Name: {name}, {task} tasks"""
         layer = self.__dask_layers__()[0]
         if optimize_graph:
             graph = self.__dask_optimize__(graph, self.__dask_keys__())
-            layer = name = "delayed-" + self._name
-            graph = HighLevelGraph.from_collections(name, graph, dependencies=())
+            layer = "delayed-" + self._name
+            graph = HighLevelGraph.from_collections(layer, graph, dependencies=())
         return [Delayed(k, graph, layer=layer) for k in keys]
 
     @classmethod

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2315,6 +2315,41 @@ def test_fillna():
     assert_eq(df.fillna(method="pad", limit=3), ddf.fillna(method="pad", limit=3))
 
 
+@pytest.mark.parametrize(
+    "optimize",
+    [
+        True,
+        pytest.param(
+            False,
+            marks=pytest.mark.xfail(
+                strict=True, reason="https://github.com/dask/dask/issues/8173"
+            ),
+        ),
+        # ^ remove this param and xfail when issue is closed
+    ],
+)
+def test_delayed_roundtrip(optimize: bool):
+    df1 = d + 1 + 1
+    delayed = df1.to_delayed(optimize_graph=optimize)
+
+    for x in delayed:
+        x.dask.validate()
+
+    assert len(delayed) == df1.npartitions
+    assert len(delayed[0].dask.layers) == (1 if optimize else 3)
+
+    delayed2 = [x * 2 for x in delayed]
+
+    for x in delayed2:
+        x.dask.validate()
+
+    df3 = dd.from_delayed(delayed2, meta=df1, divisions=df1.divisions)
+    df4 = df3 - 1 - 1
+
+    df4.dask.validate()
+    assert_eq(df4, (full + 2) * 2 - 2)
+
+
 def test_from_delayed_lazy_if_meta_provided():
     """Ensure that the graph is 100% lazily evaluted if meta is provided"""
 

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -702,6 +702,14 @@ def test_dask_layers():
     assert d2.dask.dependencies == {d1.key: set(), d2.key: {d1.key}}
     assert d2.__dask_layers__() == (d2.key,)
 
+    hlg = HighLevelGraph.from_collections("foo", {"alias": d2.key}, dependencies=[d2])
+    with pytest.raises(ValueError, match="not in"):
+        Delayed("alias", hlg)
+
+    explicit = Delayed("alias", hlg, layer="foo")
+    assert explicit.__dask_layers__() == ("foo",)
+    explicit.dask.validate()
+
 
 def test_dask_layers_to_delayed():
     # da.Array.to_delayed squashes the dask graph and causes the layer name not to

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -224,6 +224,9 @@ def test_delayed_optimize():
     (x2,) = dask.optimize(x)
     # Delayed's __dask_optimize__ culls out 'c'
     assert sorted(x2.dask.keys()) == ["a", "b"]
+    assert x2._layer != x2._key
+    # Optimize generates its own layer name, which doesn't match the key.
+    # `Delayed._rebuild` handles this.
 
 
 def test_lists():

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -711,18 +711,6 @@ def test_dask_layers():
     explicit.dask.validate()
 
 
-def test_dask_layers_to_delayed():
-    # da.Array.to_delayed squashes the dask graph and causes the layer name not to
-    # match the key
-    da = pytest.importorskip("dask.array")
-    d = da.ones(1).to_delayed()[0]
-    name = d.key[0]
-    assert d.key[1:] == (0,)
-    assert d.dask.layers.keys() == {"delayed-" + name}
-    assert d.dask.dependencies == {"delayed-" + name: set()}
-    assert d.__dask_layers__() == ("delayed-" + name,)
-
-
 def test_annotations_survive_optimization():
     with dask.annotate(foo="bar"):
         graph = HighLevelGraph.from_collections(


### PR DESCRIPTION
As discussed in https://github.com/dask/dask/issues/8173, it's necessary for `Delayed` and `bag.Item` objects to be able to keep track of the HLG layer name they're referencing. When constructed with `to_delayed(optimize_graph=False)`, this layer name will not be the same as the key (`array-abcde` vs `('array-abcde', 0)`).

- [x] Closes #8173
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
