### PR TITLE
Add optional information about originating function call in DataFrameIOLayer

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -260,51 +260,43 @@ def read_parquet(
             FutureWarning,
         )
 
+    # Store initial function arguments
+    input_kwargs = {
+        "columns": columns,
+        "filters": filters,
+        "categories": categories,
+        "index": index,
+        "storage_options": storage_options,
+        "engine": engine,
+        "gather_statistics": gather_statistics,
+        "ignore_metadata_file": ignore_metadata_file,
+        "metadata_task_size": metadata_task_size,
+        "split_row_groups": split_row_groups,
+        "chunksize=": chunksize,
+        "aggregate_files": aggregate_files,
+        **kwargs,
+    }
+
     if isinstance(columns, str):
-        df = read_parquet(
-            path,
-            columns=[columns],
-            filters=filters,
-            categories=categories,
-            index=index,
-            storage_options=storage_options,
-            engine=engine,
-            gather_statistics=gather_statistics,
-            ignore_metadata_file=ignore_metadata_file,
-            split_row_groups=split_row_groups,
-            chunksize=chunksize,
-            aggregate_files=aggregate_files,
-            metadata_task_size=metadata_task_size,
-        )
+        input_kwargs["columns"] = [columns]
+        df = read_parquet(path, **input_kwargs)
         return df[columns]
 
     if columns is not None:
         columns = list(columns)
-
-    label = "read-parquet-"
-    output_name = label + tokenize(
-        path,
-        columns,
-        filters,
-        categories,
-        index,
-        storage_options,
-        engine,
-        gather_statistics,
-        ignore_metadata_file,
-        metadata_task_size,
-        split_row_groups,
-        chunksize,
-        aggregate_files,
-    )
 
     if isinstance(engine, str):
         engine = get_engine(engine)
 
     if hasattr(path, "name"):
         path = stringify_path(path)
-    fs, _, paths = get_fs_token_paths(path, mode="rb", storage_options=storage_options)
 
+    # Update input_kwargs and tokenize inputs
+    label = "read-parquet-"
+    input_kwargs.update({"columns": columns, "engine": engine})
+    output_name = label + tokenize(path, **input_kwargs)
+
+    fs, _, paths = get_fs_token_paths(path, mode="rb", storage_options=storage_options)
     paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
 
     auto_index_allowed = False
@@ -399,6 +391,11 @@ def read_parquet(
                 common_kwargs,
             ),
             label=label,
+            creation_info={
+                "func": read_parquet,
+                "args": (path,),
+                "kwargs": input_kwargs,
+            },
         )
         graph = HighLevelGraph({output_name: layer}, {output_name: set()})
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2494,6 +2494,32 @@ def test_getitem_optimization_multi(tmpdir, engine):
     assert_eq(a3, b3)
 
 
+def test_layer_creation_info(tmpdir, engine):
+    df = pd.DataFrame({"a": range(10), "b": ["cat", "dog"] * 5})
+    dd.from_pandas(df, npartitions=1).to_parquet(
+        tmpdir, engine=engine, partition_on=["b"]
+    )
+
+    # Apply filters directly in dd.read_parquet
+    filters = [("b", "==", "cat")]
+    ddf1 = dd.read_parquet(tmpdir, engine=engine, filters=filters)
+    assert "dog" not in ddf1["b"].compute()
+
+    # Results will not match if we use dd.read_parquet
+    # without filters
+    ddf2 = dd.read_parquet(tmpdir, engine=engine)
+    with pytest.raises(AssertionError):
+        assert_eq(ddf1, ddf2)
+
+    # However, we can use `creation_info` to regenerate
+    # the same collection with `filters` defined
+    info = ddf2.dask.layers[ddf2._name].creation_info
+    kwargs = info.get("kwargs", {})
+    kwargs["filters"] = filters
+    ddf3 = info["func"](*info.get("args", []), **kwargs)
+    assert_eq(ddf1, ddf3)
+
+
 @ANY_ENGINE_MARK
 def test_blockwise_parquet_annotations(tmpdir):
     df = pd.DataFrame({"a": np.arange(40, dtype=np.int32)})

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -1,6 +1,5 @@
 """ Dataframe optimizations """
 import operator
-import warnings
 
 import numpy as np
 
@@ -106,14 +105,6 @@ def optimize_dataframe_getitem(dsk, keys):
         if column_projection:
             old = layers[k]
             new = old.project_columns(columns)
-            if isinstance(new, (list, tuple)):
-                # Support project_columns tuple output, but raise FutureWarning
-                warnings.warn(
-                    f"{type(new)} return type for project_columns is deprecated. "
-                    f"This method should now return the projected Layer only.",
-                    FutureWarning,
-                )
-                new = new[0]
             if new.name != old.name:
                 columns = list(columns)
                 assert len(update_blocks)

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -1,5 +1,6 @@
 """ Dataframe optimizations """
 import operator
+import warnings
 
 import numpy as np
 
@@ -47,18 +48,14 @@ def optimize(dsk, keys, **kwargs):
 
 
 def optimize_dataframe_getitem(dsk, keys):
-    # This optimization looks for all `DataFrameLayer` instances,
+    # This optimization looks for all `DataFrameIOLayer` instances,
     # and calls `project_columns` on any layers that directly precede
-    # a (qualified) `getitem` operation. In the future, we can
-    # search for `getitem` operations instead, and work backwards
-    # through multiple adjacent `DataFrameLayer`s. This approach
-    # may become beneficial once `DataFrameLayer` is made a base
-    # type for all relevant DataFrame operations.
+    # a (qualified) `getitem` operation.
 
-    from ..layers import DataFrameLayer
+    from ..layers import DataFrameIOLayer
 
     dataframe_blockwise = [
-        k for k, v in dsk.layers.items() if isinstance(v, DataFrameLayer)
+        k for k, v in dsk.layers.items() if isinstance(v, DataFrameIOLayer)
     ]
 
     layers = dsk.layers.copy()
@@ -109,6 +106,14 @@ def optimize_dataframe_getitem(dsk, keys):
         if column_projection:
             old = layers[k]
             new = old.project_columns(columns)[0]
+            if isinstance(new, (list, tuple)):
+                # Support project_columns tuple output, but raise FutureWarning
+                warnings.warn(
+                    f"{type(new)} return type for project_columns is deprecated. "
+                    f"This method should now return the projected Layer only.",
+                    FutureWarning,
+                )
+                new = new[0]
             if new.name != old.name:
                 columns = list(columns)
                 assert len(update_blocks)

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -105,7 +105,7 @@ def optimize_dataframe_getitem(dsk, keys):
         # Project columns and update blocks
         if column_projection:
             old = layers[k]
-            new = old.project_columns(columns)[0]
+            new = old.project_columns(columns)
             if isinstance(new, (list, tuple)):
                 # Support project_columns tuple output, but raise FutureWarning
                 warnings.warn(

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -342,13 +342,7 @@ def fractional_slice(task, axes):
 #
 
 
-class DataFrameLayer(Layer):
-    """DataFrame-based HighLevelGraph Layer"""
-
-    pass
-
-
-class SimpleShuffleLayer(DataFrameLayer):
+class SimpleShuffleLayer(Layer):
     """Simple HighLevelGraph Shuffle layer
 
     High-level graph layer for a simple shuffle operation in which
@@ -839,7 +833,7 @@ class ShuffleLayer(SimpleShuffleLayer):
         return dsk
 
 
-class BroadcastJoinLayer(DataFrameLayer):
+class BroadcastJoinLayer(Layer):
     """Broadcast-based Join Layer
 
     High-level graph layer for a join operation requiring the
@@ -1134,7 +1128,7 @@ class BroadcastJoinLayer(DataFrameLayer):
         return dsk
 
 
-class DataFrameIOLayer(Blockwise, DataFrameLayer):
+class DataFrameIOLayer(Blockwise):
     """DataFrame-based Blockwise Layer with IO
 
     Parameters
@@ -1224,6 +1218,7 @@ class DataFrameIOLayer(Blockwise, DataFrameLayer):
                 list(columns),
                 self.inputs,
                 io_func,
+                label=self.label,
                 produces_tasks=self.produces_tasks,
                 annotations=self.annotations,
             )

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -1160,6 +1160,11 @@ class DataFrameIOLayer(Blockwise, DataFrameLayer):
         contain a nested task. This argument in only used for
         serialization purposes, and will be deprecated in the
         future. Default is False.
+    creation_info: dict (optional)
+        Dictionary containing the callable function ('func'),
+        positional arguments ('args'), and key-word arguments
+        ('kwargs') used to produce the dask collection with
+        this underlying ``DataFrameIOLayer``.
     annotations: dict (optional)
         Layer annotations to pass through to Blockwise.
     """
@@ -1172,6 +1177,7 @@ class DataFrameIOLayer(Blockwise, DataFrameLayer):
         io_func,
         label=None,
         produces_tasks=False,
+        creation_info=None,
         annotations=None,
     ):
         self.name = name
@@ -1181,6 +1187,7 @@ class DataFrameIOLayer(Blockwise, DataFrameLayer):
         self.label = label
         self.produces_tasks = produces_tasks
         self.annotations = annotations
+        self.creation_info = creation_info
 
         # Define mapping between key index and "part"
         io_arg_map = BlockwiseDepDict(

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -345,20 +345,7 @@ def fractional_slice(task, axes):
 class DataFrameLayer(Layer):
     """DataFrame-based HighLevelGraph Layer"""
 
-    def project_columns(self, output_columns):
-        """Produce a column projection for this layer.
-        Given a list of required output columns, this method
-        returns a tuple with the projected layer, and any column
-        dependencies for this layer.  A value of ``None`` for
-        ``output_columns`` means that the current layer (and
-        any dependent layers) cannot be projected. This method
-        should be overridden by specialized DataFrame layers
-        to enable column projection.
-        """
-
-        # Default behavior.
-        # Return: `projected_layer`, `dep_columns`
-        return self, None
+    pass
 
 
 class SimpleShuffleLayer(DataFrameLayer):
@@ -1213,7 +1200,10 @@ class DataFrameIOLayer(Blockwise, DataFrameLayer):
         )
 
     def project_columns(self, columns):
-        # Method inherited from `DataFrameLayer.project_columns`
+        """Produce a column projection for this IO layer.
+        Given a list of required output columns, this method
+        returns the projected layer.
+        """
         if columns and (self.columns is None or columns < set(self.columns)):
 
             # Apply column projection in IO function
@@ -1230,10 +1220,10 @@ class DataFrameIOLayer(Blockwise, DataFrameLayer):
                 produces_tasks=self.produces_tasks,
                 annotations=self.annotations,
             )
-            return layer, None
+            return layer
         else:
             # Default behavior
-            return self, None
+            return self
 
     def __repr__(self):
         return "DataFrameIOLayer<name='{}', n_parts={}, columns={}>".format(


### PR DESCRIPTION
This PR does two simple things:

1. It adds a new (optional) `creation_info` argument to `DataFrameIOLayer`, which simply stores the callable (in "func"), positional arguments (in "args"), and key-word arguments (in "kwargs") used to create the original DataFrame collection. The motivation for this PR is to make basic predicate-pushdown optimizations much simpler in both [dask.dataframe.optimize](https://github.com/dask-contrib/dask-sql/issues/323), and in [dask-sql](https://github.com/dask-contrib/dask-sql/issues/323).  In dask-sql, where it should be possible to extract a DNF-formatted `filters` argument from Calcite, the `creation_info` attribute should be all that is needed for filters to be pushed into the underlying `read_parquet` call.
2. It removes `column_projection` from `DataFrameLayer`, since that method only makes sense in `DataFrameIOLayer`.  Note that I would be happy to move this small change into a standalone PR.  However, I am including it here since I accidentally used the same branch for the `creation_info` change :)