### PR TITLE
Make byte blocks more even in read_bytes

### DIFF
--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -113,7 +113,11 @@ def read_bytes(
                     "do chunked reads. To read, set blocksize=None."
                 )
 
-            if size:
+            elif size == 0:
+                # skip empty
+                offsets.append([])
+                lengths.append([])
+            else:
                 # shrink blocksize to give same number of parts
                 if size % blocksize and size > blocksize:
                     blocksize = size / (size // blocksize)
@@ -133,10 +137,6 @@ def read_bytes(
                     length[0] -= 1
                 offsets.append(off)
                 lengths.append(length)
-            else:
-                # skip empty
-                offsets.append([])
-                lengths.append([])
 
     delayed_read = delayed(read_block_from_file)
 

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -114,7 +114,8 @@ def read_bytes(
                 )
 
             # shrink blocksize to give same number of parts
-            blocksize = size / (size // blocksize + (size % blocksize > 0))
+            if size % blocksize and size > blocksize:
+                blocksize = size / (size // blocksize)
             place = 0
             off = [0]
             length = []

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -120,14 +120,16 @@ def read_bytes(
             else:
                 # shrink blocksize to give same number of parts
                 if size % blocksize and size > blocksize:
-                    blocksize = size / (size // blocksize)
+                    blocksize1 = size / (size // blocksize)
+                else:
+                    blocksize1 = blocksize
                 place = 0
                 off = [0]
                 length = []
 
                 # figure out offsets, spreading around spare bytes
-                while size - place > (blocksize * 2) - 1:
-                    place += blocksize
+                while size - place > (blocksize1 * 2) - 1:
+                    place += blocksize1
                     off.append(int(place))
                     length.append(off[-1] - off[-2])
                 length.append(size - off[-1])

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -112,8 +112,20 @@ def read_bytes(
                     "Backing filesystem couldn't determine file size, cannot "
                     "do chunked reads. To read, set blocksize=None."
                 )
-            off = list(range(0, size, blocksize))
-            length = [blocksize] * len(off)
+
+            # shrink blocksize to give same number of parts
+            blocksize = size / (size // blocksize + (size % blocksize > 0))
+            place = 0
+            off = [0]
+            length = []
+
+            # figure out offsets, spreading around spare bytes
+            while size - place > (blocksize * 2) - 1:
+                place += blocksize
+                off.append(int(place))
+                length.append(off[-1] - off[-2])
+            length.append(size - off[-1])
+
             if not_zero:
                 off[0] = 1
                 length[0] -= 1

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -113,25 +113,30 @@ def read_bytes(
                     "do chunked reads. To read, set blocksize=None."
                 )
 
-            # shrink blocksize to give same number of parts
-            if size % blocksize and size > blocksize:
-                blocksize = size / (size // blocksize)
-            place = 0
-            off = [0]
-            length = []
+            if size:
+                # shrink blocksize to give same number of parts
+                if size % blocksize and size > blocksize:
+                    blocksize = size / (size // blocksize)
+                place = 0
+                off = [0]
+                length = []
 
-            # figure out offsets, spreading around spare bytes
-            while size - place > (blocksize * 2) - 1:
-                place += blocksize
-                off.append(int(place))
-                length.append(off[-1] - off[-2])
-            length.append(size - off[-1])
+                # figure out offsets, spreading around spare bytes
+                while size - place > (blocksize * 2) - 1:
+                    place += blocksize
+                    off.append(int(place))
+                    length.append(off[-1] - off[-2])
+                length.append(size - off[-1])
 
-            if not_zero:
-                off[0] = 1
-                length[0] -= 1
-            offsets.append(off)
-            lengths.append(length)
+                if not_zero:
+                    off[0] = 1
+                    length[0] -= 1
+                offsets.append(off)
+                lengths.append(length)
+            else:
+                # skip empty
+                offsets.append([])
+                lengths.append([])
 
     delayed_read = delayed(read_block_from_file)
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -151,8 +151,9 @@ def test_read_bytes_block():
     with filetexts(files, mode="b"):
         for bs in [5, 15, 45, 1500]:
             sample, vals = read_bytes(".test.account*", blocksize=bs)
-            # No longer true, the exact blocksize is not generally expected
-            # assert list(map(len, vals)) == [(len(v) // bs + 1) for v in files.values()]
+            assert list(map(len, vals)) == [
+                max((len(v) // bs), 1) for v in files.values()
+            ]
 
             results = compute(*concat(vals))
             assert sum(len(r) for r in results) == sum(len(v) for v in files.values())

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -151,7 +151,8 @@ def test_read_bytes_block():
     with filetexts(files, mode="b"):
         for bs in [5, 15, 45, 1500]:
             sample, vals = read_bytes(".test.account*", blocksize=bs)
-            assert list(map(len, vals)) == [(len(v) // bs + 1) for v in files.values()]
+            # No longer true, the exact blocksize is not generally expected
+            # assert list(map(len, vals)) == [(len(v) // bs + 1) for v in files.values()]
 
             results = compute(*concat(vals))
             assert sum(len(r) for r in results) == sum(len(v) for v in files.values())

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -318,8 +318,9 @@ def test_read_bytes_block(s3, blocksize, s3so):
     _, vals = read_bytes(
         "s3://" + test_bucket_name + "/test/account*", blocksize=blocksize, **s3so
     )
-    # No longer true, the exact blocksize is not generally expected
-    # assert list(map(len, vals)) == [(len(v) // blocksize + 1) for v in files.values()]
+    assert list(map(len, vals)) == [
+        max((len(v) // blocksize), 1) for v in files.values()
+    ]
 
     results = compute(*concat(vals))
     assert sum(len(r) for r in results) == sum(len(v) for v in files.values())

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -318,7 +318,8 @@ def test_read_bytes_block(s3, blocksize, s3so):
     _, vals = read_bytes(
         "s3://" + test_bucket_name + "/test/account*", blocksize=blocksize, **s3so
     )
-    assert list(map(len, vals)) == [(len(v) // blocksize + 1) for v in files.values()]
+    # No longer true, the exact blocksize is not generally expected
+    # assert list(map(len, vals)) == [(len(v) // blocksize + 1) for v in files.values()]
 
     results = compute(*concat(vals))
     assert sum(len(r) for r in results) == sum(len(v) for v in files.values())

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pytest
 
 import dask
 import dask.dataframe as dd
@@ -110,13 +109,6 @@ def test_no_overlaps():
         < df.get_partition(i + 1).index.min().compute()
         for i in range(df.npartitions - 2)
     )
-
-
-@pytest.mark.network
-def test_daily_stock_deprecated():
-    pytest.importorskip("pandas_datareader", minversion="0.10.0")
-    with pytest.warns(FutureWarning, match="deprecated"):
-        dd.demo.daily_stock("GOOG", start="2010-01-01", stop="2010-01-30", freq="1h")
 
 
 def test_make_timeseries_keywords():

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -117,7 +117,7 @@ def test_read_chunked(block):
         fn = os.path.join(path, "1.json")
         df.to_json(fn, orient="records", lines=True)
         d = dd.read_json(fn, blocksize=block, sample=10)
-        assert (d.npartitions > 1) or (block > 50)
+        assert (d.npartitions > 1) or (block > 30)
         assert_eq(d, df, check_index=False)
 
 


### PR DESCRIPTION
This avoids the chance of having a final block with just a few
useless bytes in, by shrinking the blocksize to make all the
blocks roughly equal

- [x] ~Closes #xxxx~
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @douglasdavis , this would solve one half of the "empty array" issue.