### PR TITLE
Fix `map_blocks` not using own arguments in `name` generation

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -675,7 +675,7 @@ def map_blocks(
         warnings.warn("The token= keyword to map_blocks has been moved to name=")
         name = token
 
-    name = f"{name or funcname(func)}-{tokenize(func, *args, **kwargs)}"
+    name = f"{name or funcname(func)}-{tokenize(func, dtype, chunks, drop_axis, new_axis, *args, **kwargs)}"
     new_axes = {}
 
     if isinstance(drop_axis, Number):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1532,12 +1532,11 @@ def test_map_blocks_infer_newaxis():
 
 
 def test_map_blocks_no_array_args():
-    def func(block_info=None):
+    def func(dtype, block_info=None):
         loc = block_info[None]["array-location"]
-        dtype = block_info[None]["dtype"]
         return np.arange(loc[0][0], loc[0][1], dtype=dtype)
 
-    x = da.map_blocks(func, chunks=((5, 3),), dtype=np.float32)
+    x = da.map_blocks(func, np.float32, chunks=((5, 3),), dtype=np.float32)
     assert x.chunks == ((5, 3),)
     assert_eq(x, np.arange(8, dtype=np.float32))
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1532,13 +1532,70 @@ def test_map_blocks_infer_newaxis():
 
 
 def test_map_blocks_no_array_args():
-    def func(dtype, block_info=None):
+    def func(block_info=None):
         loc = block_info[None]["array-location"]
+        dtype = block_info[None]["dtype"]
         return np.arange(loc[0][0], loc[0][1], dtype=dtype)
 
-    x = da.map_blocks(func, np.float32, chunks=((5, 3),), dtype=np.float32)
+    x = da.map_blocks(func, chunks=((5, 3),), dtype=np.float32)
     assert x.chunks == ((5, 3),)
     assert_eq(x, np.arange(8, dtype=np.float32))
+
+
+def test_map_blocks_unique_name_chunks_dtype():
+    def func(block_info=None):
+        loc = block_info[None]["array-location"]
+        dtype = block_info[None]["dtype"]
+        return np.arange(loc[0][0], loc[0][1], dtype=dtype)
+
+    x = da.map_blocks(func, chunks=((5, 3),), dtype=np.float32)
+    assert x.chunks == ((5, 3),)
+    assert_eq(x, np.arange(8, dtype=np.float32))
+
+    y = da.map_blocks(func, chunks=((2, 2, 1, 3),), dtype=np.float32)
+    assert y.chunks == ((2, 2, 1, 3),)
+    assert_eq(y, np.arange(8, dtype=np.float32))
+    assert x.name != y.name
+
+    z = da.map_blocks(func, chunks=((5, 3),), dtype=np.float64)
+    assert z.chunks == ((5, 3),)
+    assert_eq(z, np.arange(8, dtype=np.float64))
+    assert x.name != z.name
+    assert y.name != z.name
+
+
+def test_map_blocks_unique_name_drop_axis():
+    def func(some_3d, block_info=None):
+        if not block_info:
+            return some_3d
+        return np.zeros(block_info[None]["shape"])
+
+    input_arr = da.zeros((3, 4, 5), chunks=((3,), (4,), (5,)), dtype=np.float32)
+    x = da.map_blocks(func, input_arr, drop_axis=[0], dtype=np.float32)
+    assert x.chunks == ((4,), (5,))
+    assert x.compute().shape == (4, 5)
+
+    y = da.map_blocks(func, input_arr, drop_axis=[2], dtype=np.float32)
+    assert y.chunks == ((3,), (4,))
+    assert y.compute().shape == (3, 4)
+    assert x.name != y.name
+
+
+def test_map_blocks_unique_name_new_axis():
+    def func(some_2d, block_info=None):
+        if not block_info:
+            return some_2d
+        return np.zeros(block_info[None]["shape"])
+
+    input_arr = da.zeros((3, 4), chunks=((3,), (4,)), dtype=np.float32)
+    x = da.map_blocks(func, input_arr, new_axis=[0], dtype=np.float32)
+    assert x.chunks == ((1,), (3,), (4,))
+    assert x.compute().shape == (1, 3, 4)
+
+    y = da.map_blocks(func, input_arr, new_axis=[2], dtype=np.float32)
+    assert y.chunks == ((3,), (4,), (1,))
+    assert y.compute().shape == (3, 4, 1)
+    assert x.name != y.name
 
 
 @pytest.mark.parametrize("func", [lambda x, y: x + y, lambda x, y, block_info: x + y])

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1567,16 +1567,17 @@ def test_map_blocks_unique_name_drop_axis():
     def func(some_3d, block_info=None):
         if not block_info:
             return some_3d
-        return np.zeros(block_info[None]["shape"])
+        dtype = block_info[None]["dtype"]
+        return np.zeros(block_info[None]["shape"], dtype=dtype)
 
     input_arr = da.zeros((3, 4, 5), chunks=((3,), (4,), (5,)), dtype=np.float32)
     x = da.map_blocks(func, input_arr, drop_axis=[0], dtype=np.float32)
     assert x.chunks == ((4,), (5,))
-    assert x.compute().shape == (4, 5)
+    assert_eq(x, np.zeros((4, 5), dtype=np.float32))
 
     y = da.map_blocks(func, input_arr, drop_axis=[2], dtype=np.float32)
     assert y.chunks == ((3,), (4,))
-    assert y.compute().shape == (3, 4)
+    assert_eq(y, np.zeros((3, 4), dtype=np.float32))
     assert x.name != y.name
 
 
@@ -1584,16 +1585,17 @@ def test_map_blocks_unique_name_new_axis():
     def func(some_2d, block_info=None):
         if not block_info:
             return some_2d
-        return np.zeros(block_info[None]["shape"])
+        dtype = block_info[None]["dtype"]
+        return np.zeros(block_info[None]["shape"], dtype=dtype)
 
     input_arr = da.zeros((3, 4), chunks=((3,), (4,)), dtype=np.float32)
     x = da.map_blocks(func, input_arr, new_axis=[0], dtype=np.float32)
     assert x.chunks == ((1,), (3,), (4,))
-    assert x.compute().shape == (1, 3, 4)
+    assert_eq(x, np.zeros((1, 3, 4), dtype=np.float32))
 
     y = da.map_blocks(func, input_arr, new_axis=[2], dtype=np.float32)
     assert y.chunks == ((3,), (4,), (1,))
-    assert y.compute().shape == (3, 4, 1)
+    assert_eq(y, np.zeros((3, 4, 1), dtype=np.float32))
     assert x.name != y.name
 
 


### PR DESCRIPTION
See #8450 for the full discussion. This PR adds (as suggested by @gjoseph92) the `map_blocks` argument's `chunks`, `dtype`, `new_axis`, and `drop_axis` to the call to `tokenize` so they are included as part of the result's name. Without this it is possible to get two results that should be treated differently by the scheduler but the scheduler won't know since they have the same name. I did verify that all of these tests fail without the fix.

- [x] Closes #8450
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
