### PR TITLE
Deprecate `token` keyword argument to `map_blocks`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -672,7 +672,12 @@ def map_blocks(
         )
         raise TypeError(msg % type(func).__name__)
     if token:
-        warnings.warn("The token= keyword to map_blocks has been moved to name=")
+        warnings.warn(
+            "The `token=` keyword to `map_blocks` has been moved to `name=`. "
+            "Please use `name=` instead as the `token=` keyword will be removed "
+            "in a future release.",
+            category=FutureWarning,
+        )
         name = token
 
     name = f"{name or funcname(func)}-{tokenize(func, *args, **kwargs)}"

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3399,6 +3399,12 @@ def test_map_blocks_name():
     assert da.ones(5, chunks=2).map_blocks(inc).name.startswith("inc-")
 
 
+def test_map_blocks_token_deprecated():
+    with pytest.warns(FutureWarning, match="use `name=` instead"):
+        x = da.ones(5, chunks=2).map_blocks(inc, token="foo")
+    assert x.name.startswith("foo-")
+
+
 def test_from_array_names():
     pytest.importorskip("distributed")
 


### PR DESCRIPTION
In https://github.com/dask/dask/pull/3597 we replaced the `token=` keyword argument to `map_blocks` with a `name=` keyword and pointed users who were using `token` to `name` instead. This PR proposes we explicitly deprecate `token` by emitting a `FutureWarning` and mentioning that `token=` will be removed in the future. 