### PR TITLE
Do not materialize task graph in ArrayOverlapLayer __len__ method

### DIFF
--- a/dask/layers.py
+++ b/dask/layers.py
@@ -169,9 +169,9 @@ class ArrayOverlapLayer(Layer):
         n_tasks = 0
         for k in interior_keys:
             if all([isinstance(i, int) for i in k]):
-                n_tasks += 2  # represents a single getitem task
+                n_tasks += 2  # represents both getitem and overlap tasks
             else:
-                n_tasks += 1  # represents both getitem and overlap tasks
+                n_tasks += 1  # represents a single getitem task
         return n_tasks
 
     def is_materialized(self):


### PR DESCRIPTION
Follow up work to https://github.com/dask/dask/pull/7595#pullrequestreview-670702731

We need to avoid materializing the task graph at any point before `compute`. If the graph gets materialized, we lose most (all?) of the benefits of having a high level graph layer here. 

This case is particularly bad, because `__len__` is called a lot (even accidentally, since it gets called whenever the HTML representation of a dask array is shown). It's not good that it causes unwanted materialization of the graph. This PR addresses that problem.

- [x] Closes https://github.com/dask/dask/issues/7788
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
