### PR TITLE
save zarr arrays with dask-on-ray scheduler

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3384,8 +3384,10 @@ def to_zarr(
 
     if isinstance(url, zarr.Array):
         z = url
-        if isinstance(z.store, (dict, MutableMapping)) and "distributed" in config.get(
-            "scheduler", ""
+        if (
+            isinstance(z.store, (dict, MutableMapping))
+            and not callable(config.get("scheduler", ""))
+            and "distributed" in config.get("scheduler", "")
         ):
             raise RuntimeError(
                 "Cannot store into in memory Zarr Array using "

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3384,11 +3384,9 @@ def to_zarr(
 
     if isinstance(url, zarr.Array):
         z = url
-        if (
-            isinstance(z.store, (dict, MutableMapping))
-            and not callable(config.get("scheduler", ""))
-            and "distributed" in config.get("scheduler", "")
-        ):
+        if isinstance(z.store, (dict, MutableMapping)) and config.get(
+            "scheduler", ""
+        ) in ("dask.distributed", "distributed"):
             raise RuntimeError(
                 "Cannot store into in memory Zarr Array using "
                 "the Distributed Scheduler."


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This PR add a check for to_zarr method.
The method check "distributed" in config.get("scheduler", "") but [dask-on-ray scheduler](https://docs.ray.io/en/latest/data/dask-on-ray.html#scheduler) is a function and so not iterable.
This commit check that the scheduler is not a functin before look for "distributed"
