### PR TITLE
Avoid materialization for ArrayOverlapLayer in methods __len__ & get_output_keys

### DIFF
--- a/dask/layers.py
+++ b/dask/layers.py
@@ -169,9 +169,9 @@ class ArrayOverlapLayer(Layer):
         n_tasks = 0
         for k in interior_keys:
             if all([isinstance(i, int) for i in k]):
-                n_tasks += 2  # represents a single getitem task
+                n_tasks += 2  # represents both getitem and overlap tasks
             else:
-                n_tasks += 1  # represents both getitem and overlap tasks
+                n_tasks += 1  # represents a single getitem task
         return n_tasks
 
     def is_materialized(self):


### PR DESCRIPTION
Follow up work to https://github.com/dask/dask/pull/7595#pullrequestreview-670702731

We need to avoid materializing the task graph for the new `ArrayOverlapLayer`, most particularly for the `__len__` and `get_output_keys` methods. Currently, it is much too easy to accidentally materialize the layer (for example, the HTML repr triggers a call to `__len__`). This PR addresses that.

- [x] Closes https://github.com/dask/dask/issues/7788 and closes https://github.com/dask/dask/issues/7791
- [x] Tests ~~added~~ / passed
- [x] Passes `pre-commit run --all-files`
