### PR TITLE
Fix single item `nanmax` and `nanmin` reductions

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -534,7 +534,7 @@ def nanmin(a, axis=None, keepdims=False, split_every=None, out=None):
 
 
 def _nanmin_skip(x_chunk, axis, keepdims):
-    if len(x_chunk):
+    if x_chunk.size > 0:
         return np.nanmin(x_chunk, axis=axis, keepdims=keepdims)
     else:
         return asarray_safe(
@@ -563,7 +563,7 @@ def nanmax(a, axis=None, keepdims=False, split_every=None, out=None):
 
 
 def _nanmax_skip(x_chunk, axis, keepdims):
-    if len(x_chunk):
+    if x_chunk.size > 0:
         return np.nanmax(x_chunk, axis=axis, keepdims=keepdims)
     else:
         return asarray_safe(

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -49,6 +49,38 @@ def test_numel(dtype, keepdims):
             )
 
 
+def reduction_0d_test(da_func, darr, np_func, narr):
+    expected = np_func(narr)
+    actual = da_func(darr)
+
+    assert_eq(actual, expected)
+    assert_eq(da_func(narr), expected)  # Ensure Dask reductions work with NumPy arrays
+    assert actual.size == 1
+
+
+def test_reductions_0D():
+    x = np.int_(3)  # np.int_ has a dtype attribute, np.int does not.
+    a = da.from_array(x, chunks=(1,))
+
+    reduction_0d_test(da.sum, a, np.sum, x)
+    reduction_0d_test(da.prod, a, np.prod, x)
+    reduction_0d_test(da.mean, a, np.mean, x)
+    reduction_0d_test(da.var, a, np.var, x)
+    reduction_0d_test(da.std, a, np.std, x)
+    reduction_0d_test(da.min, a, np.min, x)
+    reduction_0d_test(da.max, a, np.max, x)
+    reduction_0d_test(da.any, a, np.any, x)
+    reduction_0d_test(da.all, a, np.all, x)
+
+    reduction_0d_test(da.nansum, a, np.nansum, x)
+    reduction_0d_test(da.nanprod, a, np.nanprod, x)
+    reduction_0d_test(da.nanmean, a, np.mean, x)
+    reduction_0d_test(da.nanvar, a, np.var, x)
+    reduction_0d_test(da.nanstd, a, np.std, x)
+    reduction_0d_test(da.nanmin, a, np.nanmin, x)
+    reduction_0d_test(da.nanmax, a, np.nanmax, x)
+
+
 def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True, split_every=True):
     assert_eq(da_func(darr), np_func(narr))
     assert_eq(


### PR DESCRIPTION
- [x] Closes #8482
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

I chose to include all reductions in one test to match the pattern in the 1d and 2d reduction tests. I can see revamping this test file to parametrize by reduction func, but that would result in many more tests, which might not be desirable.
