### PR TITLE
Allow a callable scheduler for `bag.groupby`

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1514,7 +1514,7 @@ class Bag(DaskMethodsMixin):
         if shuffle is None:
             shuffle = config.get("shuffle", None)
         if shuffle is None:
-            if "distributed" in config.get("scheduler", ""):
+            if config.get("scheduler", None) in ("dask.distributed", "distributed"):
                 shuffle = "tasks"
             else:
                 shuffle = "disk"

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -793,6 +793,13 @@ def test_groupby_with_npartitions_changed():
     assert result.npartitions == 1
 
 
+def test_groupby_with_scheduler_func():
+    from dask.threaded import get
+
+    with dask.config.set(scheduler=get):
+        b.groupby(lambda x: x, npartitions=1).compute()
+
+
 def test_concat():
     a = db.from_sequence([1, 2, 3])
     b = db.from_sequence([4, 5, 6])


### PR DESCRIPTION
This is related to https://github.com/dask/dask/pull/8472 and represents the only other place in the codebase that I could find where `dask.config.get("scheduler")` is assumed to be a string.