### PR TITLE
Improve reshape test when limiting max chunk size

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2024,7 +2024,7 @@ class Array(DaskMethodsMixin):
         return choose(self, choices)
 
     @derived_from(np.ndarray)
-    def reshape(self, *shape, merge_chunks=True):
+    def reshape(self, *shape, merge_chunks=True, limit=None):
         """
         .. note::
 
@@ -2035,7 +2035,7 @@ class Array(DaskMethodsMixin):
 
         if len(shape) == 1 and not isinstance(shape[0], Number):
             shape = shape[0]
-        return reshape(self, shape, merge_chunks=merge_chunks)
+        return reshape(self, shape, merge_chunks=merge_chunks, limit=limit)
 
     def topk(self, k, axis=-1, split_every=None):
         """The top k elements of an array.

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2029,7 +2029,7 @@ class Array(DaskMethodsMixin):
         .. note::
 
            See :meth:`dask.array.reshape` for an explanation of
-           the ``merge_chunks`` keyword.
+           the ``merge_chunks`` and `limit` keywords.
         """
         from .reshape import reshape
 

--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -233,7 +233,7 @@ def reshape(x, shape, merge_chunks=True, limit=None):
     inchunks, outchunks = reshape_rechunk(x.shape, shape, x.chunks)
     # Check output chunks are not too large
     max_chunksize_in_bytes = reduce(mul, [max(i) for i in outchunks]) * x.dtype.itemsize
-    if limit is None and config.get("array.slicing.split-large-chunks") is not False:
+    if limit is None and config.get("array.slicing.split-large-chunks"):
         limit = parse_bytes(config.get("array.chunk-size"))
     if max_chunksize_in_bytes > limit:
         # Leave chunk sizes unaltered where possible

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1211,6 +1211,14 @@ def test_reshape_unknown_dimensions():
 
 
 @pytest.mark.parametrize(
+    "limit",  # in bytes
+    [
+        None,  # Default value: dask.config.get("array.chunk-size")
+        134217728,  # 128 MiB (default value size on a typical laptop)
+        67108864,  # 64 MiB (half the typical default value size)
+    ],
+)
+@pytest.mark.parametrize(
     "shape, chunks, reshape_size",
     [
         # Test reshape where output chunks would otherwise be too large
@@ -1219,13 +1227,14 @@ def test_reshape_unknown_dimensions():
         ((300, 300, 4, 18483), (-1, -1, 1, 183), (300, 300, -1)),
     ],
 )
-def test_reshape_avoids_large_chunks(shape, chunks, reshape_size):
-    limit = parse_bytes("128MiB")
+def test_reshape_avoids_large_chunks(limit, shape, chunks, reshape_size):
     array = da.random.random(shape, chunks=chunks)
-    result = array.reshape(*reshape_size)
+    result = array.reshape(*reshape_size, limit=limit)
     nbytes = array.dtype.itemsize
     max_chunksize_in_bytes = reduce(operator.mul, result.chunksize) * nbytes
-    assert max_chunksize_in_bytes < (limit)
+    if limit is None:
+        limit = parse_bytes(dask.config.get("array.chunk-size"))
+    assert max_chunksize_in_bytes < limit
 
 
 def test_full():


### PR DESCRIPTION
Follow up work from PR 8124, to address [James' suggestions made here](https://github.com/dask/dask/pull/8124/files#r768951852).

This PR:
- Adds a `limit` keyword argument to the reshape method (in addition to the reshape function)
- improves the test cases when testing whether a reshaped Dask array will respect a chunk size limit.

Checklist:
- [x] Follow up work from https://github.com/dask/dask/pull/8124
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
