### PR TITLE
Detect default dtype on array-likes

### DIFF
--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -48,6 +48,14 @@ def test_full_error_nonscalar_fill_value():
         da.full((3, 3), [100, 100], chunks=(2, 2), dtype="i8")
 
 
+def test_full_detects_da_dtype():
+    x = da.from_array(100)
+    # This shall not raise an NotImplementedError due to dtype detected as object.
+    a = da.full(shape=(3, 3), fill_value=x)
+    assert a.dtype == x.dtype
+    assert (a.compute() == 100).all()
+
+
 def test_full_like_error_nonscalar_fill_value():
     x = np.full((3, 3), 1, dtype="i8")
     with pytest.raises(ValueError, match="fill_value must be scalar"):

--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -56,7 +56,7 @@ def test_full_detects_da_dtype():
         a = da.full(shape=(3, 3), fill_value=x)
         assert a.dtype == x.dtype
         assert_eq(a, np.full(shape=(3, 3), fill_value=100))
-    assert len(record) == 2
+    assert len(record) == 1
 
 
 def test_full_like_error_nonscalar_fill_value():

--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -5,6 +5,7 @@ pytest.importorskip("numpy")
 import numpy as np
 
 import dask.array as da
+from dask.array.utils import assert_eq
 from dask.array.wrap import ones
 
 
@@ -50,10 +51,12 @@ def test_full_error_nonscalar_fill_value():
 
 def test_full_detects_da_dtype():
     x = da.from_array(100)
-    # This shall not raise an NotImplementedError due to dtype detected as object.
-    a = da.full(shape=(3, 3), fill_value=x)
-    assert a.dtype == x.dtype
-    assert (a.compute() == 100).all()
+    with pytest.warns(FutureWarning, match="not implemented by Dask array") as record:
+        # This shall not raise an NotImplementedError due to dtype detected as object.
+        a = da.full(shape=(3, 3), fill_value=x)
+        assert a.dtype == x.dtype
+        assert_eq(a, np.full(shape=(3, 3), fill_value=100))
+    assert len(record) == 2
 
 
 def test_full_like_error_nonscalar_fill_value():

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -188,7 +188,7 @@ def full(shape, fill_value, *args, **kwargs):
             f"fill_value must be scalar. Received {type(fill_value).__name__} instead."
         )
     if "dtype" not in kwargs:
-        kwargs["dtype"] = type(fill_value)
+        kwargs["dtype"] = np.dtype(fill_value)
     return _full(shape=shape, fill_value=fill_value, *args, **kwargs)
 
 

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -188,7 +188,10 @@ def full(shape, fill_value, *args, **kwargs):
             f"fill_value must be scalar. Received {type(fill_value).__name__} instead."
         )
     if "dtype" not in kwargs:
-        kwargs["dtype"] = np.dtype(fill_value)
+        if hasattr(fill_value, "dtype"):
+            kwargs["dtype"] = fill_value.dtype
+        else:
+            kwargs["dtype"] = type(fill_value)
     return _full(shape=shape, fill_value=fill_value, *args, **kwargs)
 
 


### PR DESCRIPTION
This is a fix for issue #8461 where `da.full` refused Dask arrays for `fill_value` as the dtype would be detected as `object`.

- [X] Closes #8461
- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`

I was a bit confused that pytest was raising errors for FutureWarnings related to `np.ndim` and `np.dtype`, not sure whether it was due to versions in my dask-env environment or something I need to implement differently in this PR.