### PR TITLE
Add `da.ndim` to match `np.ndim`

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -123,6 +123,7 @@ try:
         isin,
         isnull,
         matmul,
+        ndim,
         nonzero,
         notnull,
         outer,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1554,6 +1554,12 @@ def round(a, decimals=0):
     return a.map_blocks(np.round, decimals=decimals, dtype=a.dtype)
 
 
+@implements(np.ndim)
+@derived_from(np)
+def ndim(a):
+    return a.ndim
+
+
 @implements(np.iscomplexobj)
 @derived_from(np)
 def iscomplexobj(x):

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1329,9 +1329,12 @@ def test_roll(chunks, shift, axis):
 
 
 @pytest.mark.parametrize("shape", [(10,), (5, 10), (5, 10, 10)])
-def test_shape(shape):
+def test_shape_and_ndim(shape):
     x = da.random.random(shape)
     assert np.shape(x) == shape
+
+    x = da.random.random(shape)
+    assert np.ndim(x) == len(shape)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This just implements a small top-level array function that matches `np.ndim`. This came up in the context of https://github.com/dask/dask/pull/8501 
