### PR TITLE
[TEST] See if adding `nodefaults` fixes tiledb + mac issue

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -2,6 +2,7 @@
 name: test-environment
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   # required dependencies
   - python=3.7

--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -23,6 +23,9 @@ dependencies:
   - pytables
   - zarr
   - tiledb-py
+  # resolver was pulling in old versions, so hard-coding floor
+  # https://github.com/dask/dask/pull/8505
+  - tiledb>=2.5.0
   - xarray
   - fsspec
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -2,6 +2,7 @@
 name: test-environment
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   # required dependencies
   - python=3.8

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -23,6 +23,9 @@ dependencies:
   - pytables
   - zarr
   - tiledb-py
+  # resolver was pulling in old versions, so hard-coding floor
+  # https://github.com/dask/dask/pull/8505
+  - tiledb>=2.5.0
   - xarray
   - fsspec
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -2,6 +2,7 @@
 name: test-environment
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   # required dependencies
   - python=3.9

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -23,6 +23,9 @@ dependencies:
   - pytables
   - zarr
   - tiledb-py
+  # resolver was pulling in old versions, so hard-coding floor
+  # https://github.com/dask/dask/pull/8505
+  - tiledb>=2.5.0
   - xarray
   - fsspec
   # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas


### PR DESCRIPTION
There have been issues with the mac 3.7 and 3.9 builds recently that result in:

```python-traceback
ImportError while loading conftest '/Users/runner/work/dask/dask/conftest.py'.
conftest.py:43: in <module>
    import tiledb  # noqa: F401
../../../miniconda3/envs/test-environment/lib/python3.9/site-packages/tiledb/__init__.py:34: in <module>
    ctypes.CDLL(lib_name)
../../../miniconda3/envs/test-environment/lib/python3.9/ctypes/__init__.py:374: in __init__
    self._handle = _dlopen(self._name, mode)
E   OSError: dlopen(libtiledb.dylib, 6): Library not loaded: @rpath/libcrypto.1.1.dylib
E     Referenced from: /Users/runner/miniconda3/envs/test-environment/lib/libtiledb.dylib
E     Reason: image not found
```

for instance in https://github.com/dask/dask/runs/4587205735?check_suite_focus=true this is a test to see if removing defaults channel as an option helps.