### PR TITLE
[TEST] See if reducing the number of processes helps windows test pass

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -2,6 +2,7 @@
 name: test-environment
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   # required dependencies
   - python=3.7

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -2,6 +2,7 @@
 name: test-environment
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   # required dependencies
   - python=3.8

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -2,6 +2,7 @@
 name: test-environment
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   # required dependencies
   - python=3.9

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -446,7 +446,7 @@ def test_set_index_consistent_divisions():
     ddf = ddf.clear_divisions()
 
     ctx = mp.get_context("spawn")
-    with ProcessPoolExecutor(8, ctx) as pool:
+    with ProcessPoolExecutor(4, ctx) as pool:
         func = partial(_set_index, df=ddf, idx="x")
         divisions_set = set(pool.map(func, range(100)))
     assert len(divisions_set) == 1


### PR DESCRIPTION
- [ ] Closes #8506
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

One of the main tests that seems to be failing for windows 3.7 is `test_set_index_consistent_divisions`. I went back and looked at the original context in which that test was added: https://github.com/dask/dask/pull/3867 and it seems like the main objective is to make sure that the divisions are equal if assigned multiple times. So this is just an experiment to see if reducing the number of times (8 processes down to 4) helps get the tests passing again. 