### PR TITLE
Set ceiling for setuptools

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -8,6 +8,7 @@ dependencies:
   - packaging
   - numpy=1.18
   - pandas=1.0
+  - setuptools<60.0
   # test dependencies
   - pre-commit
   - pytest

--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -5,10 +5,10 @@ channels:
 dependencies:
   # required dependencies
   - python=3.7
+  - setuptools<60.0
   - packaging
   - numpy=1.18
   - pandas=1.0
-  - setuptools<60.0
   # test dependencies
   - pre-commit
   - pytest

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -8,6 +8,7 @@ dependencies:
   - packaging
   - numpy=1.19
   - pandas=1.2
+  - setuptools<60.0
   # test dependencies
   - pre-commit
   - pytest

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -5,10 +5,10 @@ channels:
 dependencies:
   # required dependencies
   - python=3.8
+  - setuptools<60.0
   - packaging
   - numpy=1.19
   - pandas=1.2
-  - setuptools<60.0
   # test dependencies
   - pre-commit
   - pytest

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.9
+  - setuptools<60.0
   - packaging
   - numpy
   - pandas

--- a/continuous_integration/environment-mindeps-array.yaml
+++ b/continuous_integration/environment-mindeps-array.yaml
@@ -5,6 +5,7 @@ dependencies:
   # required dependencies
   - packaging=20.0
   - python=3.7
+  - setuptools<60.0
   - pyyaml
   - cloudpickle=1.1.1
   - partd=0.3.10

--- a/continuous_integration/environment-mindeps-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-dataframe.yaml
@@ -5,6 +5,7 @@ dependencies:
   # required dependencies
   - packaging=20.0
   - python=3.7
+  - setuptools<60.0
   - pyyaml
   - cloudpickle=1.1.1
   - partd=0.3.10

--- a/continuous_integration/environment-mindeps-distributed.yaml
+++ b/continuous_integration/environment-mindeps-distributed.yaml
@@ -5,6 +5,7 @@ dependencies:
   # required dependencies
   - packaging=20.0
   - python=3.7
+  - setuptools<60.0
   - pyyaml
   - cloudpickle=1.5.0 # this is in the min from distributed
   - partd=0.3.10

--- a/continuous_integration/environment-mindeps-non-optional.yaml
+++ b/continuous_integration/environment-mindeps-non-optional.yaml
@@ -5,6 +5,7 @@ dependencies:
   # required dependencies
   - packaging=20.0
   - python=3.7
+  - setuptools<60.0
   - pyyaml
   - cloudpickle=1.1.1
   - partd=0.3.10


### PR DESCRIPTION
All the tests are failing this morning since setuptools was just released and it now warns for when you use `LooseVersion`. We've already made the shift in dask, but some of our environments test older versions of pandas and numpy which didn't have the change yet. So this puts a ceiling on setuptools in those envs.