### PR TITLE
DOC: mention dashboard link in config

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -59,19 +59,19 @@ You can specify configuration values in YAML files. For example:
 
 .. code-block:: yaml
 
-  array:
-    chunk-size: 128 MiB
+   array:
+     chunk-size: 128 MiB
 
-  distributed:
-    worker:
-      memory:
-        spill: 0.85  # default: 0.7
-        target: 0.75  # default: 0.6
-        terminate: 0.98  # default: 0.95
+   distributed:
+     worker:
+       memory:
+         spill: 0.85  # default: 0.7
+         target: 0.75  # default: 0.6
+         terminate: 0.98  # default: 0.95
             
-    dashboard:
-      # Locate the dashboard if working on a server
-      link: /user/<user>/proxy/8787/status
+     dashboard:
+       # Locate the dashboard if working on a Jupyter Hub server
+       link: /user/<user>/proxy/8787/status
         
 
 These files can live in any of the following locations:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -105,7 +105,7 @@ the following:
 
    export DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING=True
    export DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES=5
-   export DASK_DISTRIBUTED__DASHBOARD__LINK="/user/{JUPYTERHUB_USER}/proxy/{port}/status"
+   export DASK_DISTRIBUTED__DASHBOARD__LINK="/user/<user>/proxy/8787/status"
 
 resulting in configuration values like the following:
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -70,7 +70,7 @@ You can specify configuration values in YAML files. For example:
         terminate: 0.98  # default: 0.95
             
     dashboard:
-      # Locate the dashboard on a server
+      # Locate the dashboard if working on a server
       link: /user/<user>/proxy/8787/status
         
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -59,16 +59,20 @@ You can specify configuration values in YAML files. For example:
 
 .. code-block:: yaml
 
-   array:
-      chunk-size: 128 MiB
+  array:
+    chunk-size: 128 MiB
 
-   distributed:
-      worker:
-         memory:
-            spill: 0.85  # default: 0.7
-            target: 0.75  # default: 0.6
-            terminate: 0.98  # default: 0.95
-
+  distributed:
+    worker:
+      memory:
+        spill: 0.85  # default: 0.7
+        target: 0.75  # default: 0.6
+        terminate: 0.98  # default: 0.95
+            
+    dashboard:
+      # Locate the dashboard on a server
+      link: /user/<user>/proxy/8787/status
+        
 
 These files can live in any of the following locations:
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -105,6 +105,7 @@ the following:
 
    export DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING=True
    export DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES=5
+   export DASK_DISTRIBUTED__DASHBOARD__LINK="/user/{JUPYTERHUB_USER}/proxy/{port}/status"
 
 resulting in configuration values like the following:
 


### PR DESCRIPTION
Finding the daskboard link when working on a server (e.g. jupyter hub/MyBinder) can troublesome. I had to remember how to do this recently.

I'm was trying to think where to put this info. I think it should live somewhere in the docs.

In this PR i've yaml linted the `dask.config` example and made a comment about why distributed: dashboard: link is included
