### PR TITLE
DOC fix doctest failures in slicing.py

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -138,8 +138,10 @@ def slice_array(out_name, in_name, blockdims, index, itemsize):
     >>> from pprint import pprint
     >>> dsk, blockdims = slice_array('y', 'x', [(20, 20, 20, 20, 20)],
     ...                              (slice(10, 35),), 8)
-    >>> pprint(dsk)  # doctest: +ELLIPSIS
-    {('y', 0): (<function getitem at ...>, ('x', 0), (slice(10, 20, 1),)),
+    >>> pprint(dsk)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    {('y', 0): (<function getitem at ...>,
+                ('x', 0),
+                (slice(10, 20, 1),)),
      ('y', 1): (<function getitem at ...>, ('x', 1), (slice(0, 15, 1),))}
     >>> blockdims
     ((10, 15),)
@@ -601,8 +603,10 @@ def take(outname, inname, chunks, index, itemsize, axis=0):
     >>> chunks, dsk = take('y', 'x', [(20, 20, 20, 20)], [1, 3, 5, 47], 8, axis=0)
     >>> chunks
     ((3, 1),)
-    >>> pprint(dsk)     # doctest: +ELLIPSIS
-    {('y', 0): (<function getitem at ...>, ('x', 0), (array([1, 3, 5]),)),
+    >>> pprint(dsk)     # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    {('y', 0): (<function getitem at ...>,
+                ('x', 0),
+                (array([1, 3, 5]),)),
      ('y', 1): (<function getitem at ...>, ('x', 2), (array([7]),))}
 
     When any indexed blocks would otherwise grow larger than

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -139,9 +139,7 @@ def slice_array(out_name, in_name, blockdims, index, itemsize):
     >>> dsk, blockdims = slice_array('y', 'x', [(20, 20, 20, 20, 20)],
     ...                              (slice(10, 35),), 8)
     >>> pprint(dsk)  # doctest: +ELLIPSIS
-    {('y', 0): (<function getitem at ...>,
-                ('x', 0),
-                (slice(10, 20, 1),)),
+    {('y', 0): (<function getitem at ...>, ('x', 0), (slice(10, 20, 1),)),
      ('y', 1): (<function getitem at ...>, ('x', 1), (slice(0, 15, 1),))}
     >>> blockdims
     ((10, 15),)
@@ -604,9 +602,7 @@ def take(outname, inname, chunks, index, itemsize, axis=0):
     >>> chunks
     ((3, 1),)
     >>> pprint(dsk)     # doctest: +ELLIPSIS
-    {('y', 0): (<function getitem at ...>,
-                ('x', 0),
-                (array([1, 3, 5]),)),
+    {('y', 0): (<function getitem at ...>, ('x', 0), (array([1, 3, 5]),)),
      ('y', 1): (<function getitem at ...>, ('x', 2), (array([7]),))}
 
     When any indexed blocks would otherwise grow larger than


### PR DESCRIPTION
When setting up the Dask development environment and testing the code with `py.test dask --verbose --doctest-modules` two docstring tests in `dask/array/slicing.py` failed. I fixed these docstring failures and now all tests are successful (at least on my machine which is a macOS).

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
