### PR TITLE
Hyphenate "single-machine scheduler" for consistency

### DIFF
--- a/docs/source/custom-collections.rst
+++ b/docs/source/custom-collections.rst
@@ -339,7 +339,7 @@ created. It too has three stages:
 
    - A ``rebuild`` function, which takes in a persisted graph.  The keys of
      this graph are the same as ``__dask_keys__`` for the corresponding
-     collection, and the values are computed results (for the single machine
+     collection, and the values are computed results (for the single-machine
      scheduler) or futures (for the distributed scheduler).
    - A tuple of extra arguments to pass to ``rebuild`` after the graph
 

--- a/docs/source/custom-graphs.rst
+++ b/docs/source/custom-graphs.rst
@@ -75,10 +75,10 @@ Dask schedulers differ in the following ways:
 
 1.  You specify the entire graph as a Python dict rather than using a
     specialized API
-2.  You get a variety of schedulers ranging from single machine, single core 
-    to threaded, multiprocessing, distributed, and
-3.  The Dask single-machine schedulers have logic to execute the graph in a
-    way that minimizes memory footprint
+2.  You get a variety of schedulers, ranging from a single-machine, single-core
+    scheduler to threaded, multi-process, and distributed options
+3.  You benefit from logic to execute the graph in a way that minimizes memory
+    footprint with the Dask single-machine schedulers
 
 But the other projects offer different advantages and different programming
 paradigms.  One should inspect all such projects before selecting one.

--- a/docs/source/custom-graphs.rst
+++ b/docs/source/custom-graphs.rst
@@ -74,11 +74,11 @@ logic.
 Dask schedulers differ in the following ways:
 
 1.  You specify the entire graph as a Python dict rather than using a
-    specialized API
+    specialized API.
 2.  You get a variety of schedulers, ranging from a single-machine, single-core
-    scheduler to threaded, multi-process, and distributed options
+    scheduler to threaded, multi-process, and distributed options.
 3.  You benefit from logic to execute the graph in a way that minimizes memory
-    footprint with the Dask single-machine schedulers
+    footprint with the Dask single-machine schedulers.
 
 But the other projects offer different advantages and different programming
 paradigms.  One should inspect all such projects before selecting one.

--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -109,7 +109,7 @@ The ``progress`` function takes a Dask object that is executing in the backgroun
 
 .. code-block:: python
 
-   # Progress bar on a single machine
+   # Progress bar on a single-machine scheduler
    from dask.diagnostics import ProgressBar
 
    with ProgressBar():

--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -109,14 +109,13 @@ The ``progress`` function takes a Dask object that is executing in the backgroun
 
 .. code-block:: python
 
-   # Single machine progress bar
+   # Progress bar on a single machine
    from dask.diagnostics import ProgressBar
 
    with ProgressBar():
        x.compute()
 
-   # Distributed scheduler ProgressBar
-
+   # Progress bar with the distributed scheduler
    from dask.distributed import Client, progress
 
    client = Client()  # use dask.distributed by default

--- a/docs/source/how-to/debug.rst
+++ b/docs/source/how-to/debug.rst
@@ -81,7 +81,7 @@ If a remote task fails, we can collect the function and all inputs, bring them
 to the local thread, and then rerun the function in hopes of triggering the
 same exception locally where normal debugging tools can be used.
 
-With the single machine schedulers, use the ``rerun_exceptions_locally=True``
+With the single-machine schedulers, use the ``rerun_exceptions_locally=True``
 keyword:
 
 .. code-block:: python

--- a/docs/source/how-to/deploy-dask-clusters.rst
+++ b/docs/source/how-to/deploy-dask-clusters.rst
@@ -20,7 +20,7 @@ You can continue reading or watch the screencast below:
 
 Dask has two families of task schedulers:
 
-1.  **Single machine scheduler**: This scheduler provides basic features on a
+1.  **Single-machine scheduler**: This scheduler provides basic features on a
     local process or thread pool.  This scheduler was made first and is the
     default.  It is simple and cheap to use.  It can only be used on a single
     machine and does not scale.

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -14,7 +14,7 @@ same result, but with different performance characteristics.
 
 Dask has two families of task schedulers:
 
-1.  **Single machine scheduler**: This scheduler provides basic features on a
+1.  **Single-machine scheduler**: This scheduler provides basic features on a
     local process or thread pool.  This scheduler was made first and is the
     default.  It is simple and cheap to use, although it can only be used on
     a single machine and does not scale


### PR DESCRIPTION
Fixes a minor grammatical error/inconsistency