### PR TITLE
Add groupby shift method

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1873,7 +1873,7 @@ class _GroupBy:
             isinstance(item, Series) for item in self.by
         ):
             raise NotImplementedError(
-                "groupby-transform with a multiple Series is currently not supported"
+                "groupby-shift with a multiple Series is currently not supported"
             )
         df = self.obj
         should_shuffle = not (df.known_divisions and df._contains_index_name(self.by))
@@ -1894,6 +1894,7 @@ class _GroupBy:
             freq=freq,
             axis=axis,
             fill_value=fill_value,
+            token="groupby-shift",
             group_keys=self.group_keys,
             meta=meta,
             **self.observed,

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1842,8 +1842,7 @@ class _GroupBy:
         --------
         >>> import dask
         >>> ddf = dask.datasets.timeseries(freq="1H")
-        >>> result = ddf.groupby("name").shift()
-        >>> result = ddf.groupby("name")["x"].shift(1, fill_value=ddf.x.mean())
+        >>> result = ddf.groupby("name").shift(1, meta={"id": int, "x": float, "y": float})
         """
         if meta is no_default:
             with raise_on_meta_error("groupby.shift()", udf=False):


### PR DESCRIPTION
- [x] Closes #7095
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

I have to implemented the shift `method` following the `transform` and `apply` methods. Let me know if you'd like any changes/improvements.