### PR TITLE
Add std() support for datetime64 dtype for Pandas-like objects (#8214)

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2178,6 +2178,7 @@ Dask Name: {name}, {task} tasks"""
     ):
         axis = self._validate_axis(axis)
         _raise_if_object_series(self, "std")
+        _raise_if_not_series_or_dataframe(self, "std")
 
         meta = self._meta_nonempty.std(axis=axis, skipna=skipna)
         is_df_like = is_dataframe_like(self._meta)
@@ -7587,3 +7588,14 @@ def _sqrt_and_convert_to_timedelta(partition, axis, *args, **kwargs):
         sqrt[time_col] = pd.to_timedelta(matching_val)
 
     return sqrt
+
+
+def _raise_if_not_series_or_dataframe(x, funcname):
+    """
+    Utility function to raise an error if an object is not a Series or DataFrame
+    """
+    if not is_series_like(x) and not is_dataframe_like(x):
+        raise NotImplementedError(
+            "`%s` is only supported with objects that are Dataframes or Series"
+            % funcname
+        )

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1185,12 +1185,8 @@ def test_reductions_frame_dtypes():
     assert_eq(df.max(), ddf.max())
     assert_eq(df.count(), ddf.count())
     if PANDAS_GT_120:
-        # std is implemented for datetimes in pandas 1.2.0, but dask
-        # implementation depends on var which isn't
-        assert_eq(
-            df_no_timedelta.drop("dt", axis=1).std(),
-            ddf_no_timedelta.drop("dt", axis=1).std(),
-        )
+        assert_eq(df_no_timedelta.std(), ddf_no_timedelta.std())
+        assert_eq(df_no_timedelta.std(skipna=False), ddf_no_timedelta.std(skipna=False))
     else:
         assert_eq(df_no_timedelta.std(), ddf_no_timedelta.std())
     assert_eq(df_no_timedelta.var(), ddf_no_timedelta.var())
@@ -1202,8 +1198,8 @@ def test_reductions_frame_dtypes():
     assert_eq(df.sem(), ddf.sem())
     if PANDAS_GT_120:
         assert_eq(
-            df_no_timedelta.drop("dt", axis=1).std(ddof=0),
-            ddf_no_timedelta.drop("dt", axis=1).std(ddof=0),
+            df_no_timedelta.std(ddof=0),
+            ddf_no_timedelta.std(ddof=0),
         )
     else:
         assert_eq(df_no_timedelta.std(ddof=0), ddf_no_timedelta.std(ddof=0))
@@ -1477,3 +1473,146 @@ def test_series_agg_with_min_count(method, min_count):
         assert result == 1
     else:
         assert result is np.nan
+
+
+# Default absolute tolerance of 2000 nanoseconds
+def assert_near_timedeltas(t1, t2, atol=2000):
+    assert t1.dtype == t2.dtype
+    assert_eq(pd.to_numeric(t1), pd.to_numeric(t2), atol=atol)
+
+
+@pytest.mark.skipif(
+    not PANDAS_GT_120, reason="std() for datetime only added in pandas>=1.2"
+)
+def test_datetime_std_creates_copy_cols():
+    pdf = pd.DataFrame(
+        {
+            "dt1": [
+                datetime.fromtimestamp(1636426700 + (i * 250000)) for i in range(10)
+            ],
+            "dt2": [
+                datetime.fromtimestamp(1636426700 + (i * 300000)) for i in range(10)
+            ],
+        }
+    )
+
+    ddf = dd.from_pandas(pdf, 3)
+
+    # Series test
+    assert_eq(ddf["dt1"].std(), pdf["dt1"].std())
+    assert_eq(ddf["dt1"].std(), pdf["dt1"].std())
+
+    # DataFrame test
+    assert_near_timedeltas(ddf.std().compute(), pdf.std())
+    assert_near_timedeltas(ddf.std().compute(), pdf.std())
+
+
+@pytest.mark.skipif(
+    not PANDAS_GT_120, reason="std() for datetime only added in pandas>=1.2"
+)
+def test_datetime_std_with_larger_dataset():
+    num_rows = 250
+
+    dt1 = pd.Series([pd.NaT] * 15, index=range(15)).append(
+        pd.to_datetime(
+            pd.Series(
+                [
+                    datetime.fromtimestamp(1636426704 + (i * 250000))
+                    for i in range(num_rows - 15)
+                ],
+                index=range(15, 250),
+            )
+        )
+    )
+
+    base_numbers = [
+        (1638290040706793300 + (i * 69527182702409)) for i in range(num_rows)
+    ]
+
+    dt2 = pd.to_datetime(pd.Series(base_numbers))
+    dt3 = pd.to_datetime(pd.Series([int(x * 1.25) for x in base_numbers]))
+    dt4 = pd.to_datetime(pd.Series([int(x * 1.33) for x in base_numbers]))
+
+    pdf = pd.DataFrame(
+        {"dt1": dt1, "dt2": dt2, "dt3": dt3, "dt4": dt4},
+        index=range(250),
+    )
+
+    ddf = dd.from_pandas(pdf, 8)
+
+    # Do NaT checks (not skipped so should be NaTs)
+    assert_eq(ddf[["dt1"]].std(skipna=False), pdf[["dt1"]].std(skipna=False))
+
+    # Same thing but as Series
+    assert ddf["dt1"].std(skipna=False).compute() is pdf["dt1"].std(skipna=False)
+
+    assert_near_timedeltas(ddf.std(skipna=True).compute(), pdf.std(skipna=True))
+    assert_near_timedeltas(ddf.std(skipna=False).compute(), pdf.std(skipna=False))
+
+
+@pytest.mark.skipif(
+    not PANDAS_GT_120, reason="std() for datetime only added in pandas>=1.2"
+)
+def test_datetime_std_across_axis_1():
+    pdf = pd.DataFrame(
+        {
+            "dt1": [
+                datetime.fromtimestamp(1636426704 + (i * 250000)) for i in range(10)
+            ],
+            "dt2": [
+                datetime.fromtimestamp(1636426704 + (i * 217790)) for i in range(10)
+            ],
+        }
+    )
+
+    ddf = dd.from_pandas(pdf, 3)
+
+    assert_eq(ddf.std(axis=1), pdf.std(axis=1))
+
+
+@pytest.mark.skipif(
+    not PANDAS_GT_120, reason="std() for datetime only added in pandas>=1.2"
+)
+@pytest.mark.filterwarnings(
+    "ignore:Dropping of nuisance columns:FutureWarning"
+)  # https://github.com/dask/dask/issues/7714
+def test_datetime_std_across_axis1_null_results():
+    pdf = pd.DataFrame(
+        {
+            "dt1": [
+                datetime.fromtimestamp(1636426704 + (i * 250000)) for i in range(10)
+            ],
+            "dt2": [
+                datetime.fromtimestamp(1636426704 + (i * 217790)) for i in range(10)
+            ],
+            "nums": [i for i in range(10)],
+        }
+    )
+
+    ddf = dd.from_pandas(pdf, 3)
+
+    # Single column always results in NaT
+    assert_eq(ddf[["dt1"]].std(axis=1), pdf[["dt1"]].std(axis=1))
+
+    # Mix of datetimes with other numeric types produces NaNs
+    assert_eq(ddf.std(axis=1), pdf.std(axis=1))
+
+    # Test with mix of na and truthy datetimes
+    pdf2 = pd.DataFrame(
+        {
+            "dt1": [pd.NaT]
+            + [datetime.fromtimestamp(1636426704 + (i * 250000)) for i in range(10)]
+            + [pd.NaT],
+            "dt2": [
+                datetime.fromtimestamp(1636426704 + (i * 250000)) for i in range(12)
+            ],
+            "dt3": [
+                datetime.fromtimestamp(1636426704 + (i * 282616)) for i in range(12)
+            ],
+        }
+    )
+
+    ddf2 = dd.from_pandas(pdf2, 3)
+
+    assert_eq(ddf2.std(axis=1, skipna=True), pdf2.std(axis=1, skipna=True))
+    assert_eq(ddf2.std(axis=1, skipna=False), pdf2.std(axis=1, skipna=False))

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1522,16 +1522,20 @@ def test_datetime_std_creates_copy_cols(axis):
 def test_datetime_std_with_larger_dataset(axis, skipna):
     num_rows = 250
 
-    dt1 = pd.Series([pd.NaT] * 15, index=range(15)).append(
-        pd.to_datetime(
-            pd.Series(
-                [
-                    datetime.fromtimestamp(1636426704 + (i * 250000))
-                    for i in range(num_rows - 15)
-                ],
-                index=range(15, 250),
-            )
-        )
+    dt1 = pd.concat(
+        [
+            pd.Series([pd.NaT] * 15, index=range(15)),
+            pd.to_datetime(
+                pd.Series(
+                    [
+                        datetime.fromtimestamp(1636426704 + (i * 250000))
+                        for i in range(num_rows - 15)
+                    ],
+                    index=range(15, 250),
+                )
+            ),
+        ],
+        ignore_index=False,
     )
 
     base_numbers = [

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1617,3 +1617,11 @@ def test_datetime_std_across_axis1_null_results(skipna):
     ddf2 = dd.from_pandas(pdf2, 3)
 
     assert_eq(ddf2.std(axis=1, skipna=skipna), pdf2.std(axis=1, skipna=skipna))
+
+
+def test_std_raises_on_index():
+    with pytest.raises(
+        NotImplementedError,
+        match="`std` is only supported with objects that are Dataframes or Series",
+    ):
+        dd.from_pandas(pd.DataFrame({"test": [1, 2]}), npartitions=2).index.std()

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1185,28 +1185,19 @@ def test_reductions_frame_dtypes():
     assert_eq(df.min(), ddf.min())
     assert_eq(df.max(), ddf.max())
     assert_eq(df.count(), ddf.count())
-    if PANDAS_GT_120:
-        assert_eq(df_no_timedelta.std(), ddf_no_timedelta.std())
-        assert_eq(df_no_timedelta.std(skipna=False), ddf_no_timedelta.std(skipna=False))
-    else:
-        assert_eq(df_no_timedelta.std(), ddf_no_timedelta.std())
-    assert_eq(df_no_timedelta.var(), ddf_no_timedelta.var())
-
-    df2 = df.drop("timedelta", axis=1)
-    ddf2 = ddf.drop("timedelta", axis=1)
-
-    assert_eq(df2.var(skipna=False), ddf2.var(skipna=False))
     assert_eq(df.sem(), ddf.sem())
-    if PANDAS_GT_120:
-        assert_eq(
-            df_no_timedelta.std(ddof=0),
-            ddf_no_timedelta.std(ddof=0),
-        )
-    else:
-        assert_eq(df_no_timedelta.std(ddof=0), ddf_no_timedelta.std(ddof=0))
-    assert_eq(df2.var(ddof=0), ddf2.var(ddof=0))
-    assert_eq(df2.var(ddof=0, skipna=False), ddf2.var(ddof=0, skipna=False))
     assert_eq(df.sem(ddof=0), ddf.sem(ddof=0))
+
+    assert_eq(df_no_timedelta.std(), ddf_no_timedelta.std())
+    assert_eq(df_no_timedelta.std(skipna=False), ddf_no_timedelta.std(skipna=False))
+    assert_eq(df_no_timedelta.std(ddof=0), ddf_no_timedelta.std(ddof=0))
+    assert_eq(df_no_timedelta.var(), ddf_no_timedelta.var())
+    assert_eq(df_no_timedelta.var(skipna=False), ddf_no_timedelta.var(skipna=False))
+    assert_eq(df_no_timedelta.var(ddof=0), ddf_no_timedelta.var(ddof=0))
+    assert_eq(
+        df_no_timedelta.var(ddof=0, skipna=False),
+        ddf_no_timedelta.var(ddof=0, skipna=False),
+    )
 
     assert_eq(df._get_numeric_data(), ddf._get_numeric_data())
 


### PR DESCRIPTION
Adds support for calling `std()` on Dask Series and DataFrames when they include datetime64 dtypes.

- [x] Closes #8214 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
