### PR TITLE
DOCS: best practices storage line typo

### DIFF
--- a/docs/source/best-practices.rst
+++ b/docs/source/best-practices.rst
@@ -235,7 +235,7 @@ For example ...
     not work well
 -   You may want to partition or chunk your data in ways that align well to
     common queries.  In Dask DataFrame this might mean choosing a column to
-    sort by for fast selection and joins.  For Dask dataframe this might mean
+    sort by for fast selection and joins.  For Dask Array this might mean
     choosing chunk sizes that are aligned with your access patterns and
     algorithms.
 


### PR DESCRIPTION
No workflow stages - docs change only.

This is a super small tweak - in the [Best Practices section on storing data efficiently](https://docs.dask.org/en/stable/best-practices.html#store-data-efficiently), these lines seem to be making recommendations for two dask classes, DataFrame and Array, but they reference DataFrame in both cases. I think this is a typo - the second should refer to Array.

>    In Dask DataFrame this might mean choosing a column to
>    sort by for fast selection and joins.  For Dask DataFrame this might mean
>    choosing chunk sizes that are aligned with your access patterns and
>    algorithms.

