### PR TITLE
Expand dask YAML config search directories

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -3,6 +3,7 @@ import base64
 import builtins
 import json
 import os
+import site
 import sys
 import threading
 import warnings
@@ -16,6 +17,7 @@ no_default = "__no_default__"
 paths = [
     os.getenv("DASK_ROOT_CONFIG", "/etc/dask"),
     os.path.join(sys.prefix, "etc", "dask"),
+    *[os.path.join(prefix, "etc", "dask") for prefix in site.PREFIXES],
     os.path.join(os.path.expanduser("~"), ".config", "dask"),
     os.path.join(os.path.expanduser("~"), ".dask"),
 ]

--- a/dask/config.py
+++ b/dask/config.py
@@ -14,7 +14,7 @@ import yaml
 no_default = "__no_default__"
 
 
-paths = [
+_paths = [
     os.getenv("DASK_ROOT_CONFIG", "/etc/dask"),
     os.path.join(sys.prefix, "etc", "dask"),
     *[os.path.join(prefix, "etc", "dask") for prefix in site.PREFIXES],
@@ -24,10 +24,12 @@ paths = [
 
 if "DASK_CONFIG" in os.environ:
     PATH = os.environ["DASK_CONFIG"]
-    paths.append(PATH)
+    _paths.append(PATH)
 else:
     PATH = os.path.join(os.path.expanduser("~"), ".config", "dask")
 
+# Remove duplicate paths while preserving ordering
+paths = list(dict.fromkeys(_paths))
 
 global_config = config = {}
 

--- a/dask/config.py
+++ b/dask/config.py
@@ -29,7 +29,7 @@ else:
     PATH = os.path.join(os.path.expanduser("~"), ".config", "dask")
 
 # Remove duplicate paths while preserving ordering
-paths = list(dict.fromkeys(_paths))
+paths = list(reversed(dict.fromkeys(reversed(_paths))))
 
 global_config = config = {}
 

--- a/dask/config.py
+++ b/dask/config.py
@@ -29,7 +29,7 @@ else:
     PATH = os.path.join(os.path.expanduser("~"), ".config", "dask")
 
 # Remove duplicate paths while preserving ordering
-paths = list(reversed(dict.fromkeys(reversed(_paths))))
+paths = list(reversed(list(dict.fromkeys(reversed(_paths)))))
 
 global_config = config = {}
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -503,3 +503,15 @@ def test_config_inheritance():
         {"DASK_INTERNAL_INHERIT_CONFIG": serialize({"array": {"svg": {"size": 150}}})}
     )
     assert dask.config.get("array.svg.size", config=config) == 150
+
+
+def test_path_includes_site_prefix():
+    import subprocess
+    import sys
+
+    command = ('import site; '
+               'site.PREFIXES.append("include/this/path"); '
+               'import dask.config; '
+               'print("include/this/path/etc/dask" in dask.config.paths)')
+    res = subprocess.run([sys.executable, "-c", command], capture_output=True)
+    assert res.stdout == b"True\n"

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -1,5 +1,6 @@
 import os
 import stat
+import subprocess
 import sys
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -506,14 +507,13 @@ def test_config_inheritance():
 
 
 def test_path_includes_site_prefix():
-    import subprocess
-    import sys
 
     command = (
-        'import site; '
-        'site.PREFIXES.append("include/this/path"); '
-        'import dask.config; '
-        'print("include/this/path/etc/dask" in dask.config.paths)'
+        "import site, os; "
+        'prefix = os.path.join("include", "this", "path"); '
+        "site.PREFIXES.append(prefix); "
+        "import dask.config; "
+        'assert os.path.join(prefix, "etc", "dask") in dask.config.paths'
     )
-    res = subprocess.run([sys.executable, "-c", command], capture_output=True)
-    assert res.stdout == b"True\n"
+
+    subprocess.check_call([sys.executable, "-c", command])

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -509,9 +509,11 @@ def test_path_includes_site_prefix():
     import subprocess
     import sys
 
-    command = ('import site; '
-               'site.PREFIXES.append("include/this/path"); '
-               'import dask.config; '
-               'print("include/this/path/etc/dask" in dask.config.paths)')
+    command = (
+        'import site; '
+        'site.PREFIXES.append("include/this/path"); '
+        'import dask.config; '
+        'print("include/this/path/etc/dask" in dask.config.paths)'
+    )
     res = subprocess.run([sys.executable, "-c", command], capture_output=True)
     assert res.stdout == b"True\n"

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -78,7 +78,9 @@ These files can live in any of the following locations:
 
 1.  The ``~/.config/dask`` directory in the user's home directory
 2.  The ``{sys.prefix}/etc/dask`` directory local to Python
-3.  The root directory (specified by the ``DASK_ROOT_CONFIG`` environment
+3.  The ``{prefix}/etc/dask`` directories with ``{prefix}`` in `site.PREFIXES
+    <https://docs.python.org/3/library/site.html#site.PREFIXES>`_
+4.  The root directory (specified by the ``DASK_ROOT_CONFIG`` environment
     variable or ``/etc/dask/`` by default)
 
 Dask searches for *all* YAML files within each of these directories and merges


### PR DESCRIPTION
Search for dask YAML configuration in directories prefixed by elements of `site.PREFIXES`.
