### PR TITLE
Fix `optimize_blockwise` bug for duplicate dependency names

### DIFF
--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -259,32 +259,29 @@ i, j, k = "ijk"
         ],
         [
             [
-                (b, "ij", {b: (add, _0, _1)}, [(a, "ij"), (2, None)]),
-                (c, "ijk", {c: (add, _0, _1, _2)}, [(b, "ij"), (b, "jk"), (b, "ij")]),
-                (d, "ijk", {d: (add, _0, _1)}, [(c, "ij"), (c, "jk")]),
+                (b, "jk", {b: (add, _0, _1)}, [(a, "jk"), (2, None)]),
+                (c, "ijk", {c: (add, _0, _1)}, [(b, "ij"), (b, "jk")]),
+                (d, "ijk", {d: (add, _0, _1, _2)}, [(b, "ij"), (c, "ij"), (b, "ij")]),
             ],
             (
                 "d",
                 "ijk",
                 {
-                    "d": (add, _unique_dep(c, "ij"), _unique_dep(c, "jk")),
+                    "d": (
+                        add,
+                        _unique_dep(b, "ij"),
+                        _unique_dep(c, "ij"),
+                        _unique_dep(b, "ij"),
+                    ),
                     _unique_dep(c, "ij"): (
                         add,
                         _unique_dep(b, "ij"),
                         _unique_dep(b, "jk"),
-                        _unique_dep(b, "ij"),
-                    ),
-                    _unique_dep(c, "jk"): (
-                        add,
-                        _unique_dep(b, "jk"),
-                        _unique_dep(b, "kk"),
-                        _unique_dep(b, "jk"),
                     ),
                     _unique_dep(b, "ij"): (add, _0, _1),
-                    _unique_dep(b, "jk"): (add, _3, _1),
-                    _unique_dep(b, "kk"): (add, _2, _1),
+                    _unique_dep(b, "jk"): (add, _2, _1),
                 },
-                [(a, "ij"), (2, None), (a, "kk"), (a, "jk")],
+                [(a, "ij"), (2, None), (a, "jk")],
             ),
         ],
     ],

--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -231,8 +231,9 @@ i, j, k = "ijk"
                 [(123, None), (a, "j")],
             ),
         ],
-        # Check case where two distinct indices are used
-        # for the same dependency name
+        # Check cases where two distinct indices are used
+        # for the same dependency name, and where the same
+        # dependency-index combination is repeated
         # (See: https://github.com/dask/dask/issues/8535)
         [
             [
@@ -254,6 +255,36 @@ i, j, k = "ijk"
                     _unique_dep(b, "jk"): (add, _3, _2),
                 },
                 [(123, None), (a, "ij"), (2, None), (a, "jk")],
+            ),
+        ],
+        [
+            [
+                (b, "ij", {b: (add, _0, _1)}, [(a, "ij"), (2, None)]),
+                (c, "ijk", {c: (add, _0, _1, _2)}, [(b, "ij"), (b, "jk"), (b, "ij")]),
+                (d, "ijk", {d: (add, _0, _1)}, [(c, "ij"), (c, "jk")]),
+            ],
+            (
+                "d",
+                "ijk",
+                {
+                    "d": (add, _unique_dep(c, "ij"), _unique_dep(c, "jk")),
+                    _unique_dep(c, "ij"): (
+                        add,
+                        _unique_dep(b, "ij"),
+                        _unique_dep(b, "jk"),
+                        _unique_dep(b, "ij"),
+                    ),
+                    _unique_dep(c, "jk"): (
+                        add,
+                        _unique_dep(b, "jk"),
+                        _unique_dep(b, "kk"),
+                        _unique_dep(b, "jk"),
+                    ),
+                    _unique_dep(b, "ij"): (add, _0, _1),
+                    _unique_dep(b, "jk"): (add, _3, _1),
+                    _unique_dep(b, "kk"): (add, _2, _1),
+                },
+                [(a, "ij"), (2, None), (a, "kk"), (a, "jk")],
             ),
         ],
     ],

--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -10,6 +10,7 @@ from dask.array.utils import assert_eq
 from dask.blockwise import (
     _BLOCKWISE_DEFAULT_PREFIX,
     Blockwise,
+    _unique_dep,
     index_subs,
     optimize_blockwise,
     rewrite_blockwise,
@@ -35,21 +36,40 @@ i, j, k = "ijk"
                 (c, "i", {c: (dec, _0)}, [(a, "i")]),
                 (d, "i", {d: (add, _0, _1, _2)}, [(a, "i"), (b, "i"), (c, "i")]),
             ],
-            (d, "i", {b: (inc, _0), c: (dec, _0), d: (add, _0, b, c)}, [(a, "i")]),
+            (
+                d,
+                "i",
+                {
+                    _unique_dep(b, "i"): (inc, _0),
+                    _unique_dep(c, "i"): (dec, _0),
+                    d: (add, _0, _unique_dep(b, "i"), _unique_dep(c, "i")),
+                },
+                [(a, "i")],
+            ),
         ],
         [
             [
                 (b, "i", {b: (inc, _0)}, [(a, "i")]),
                 (c, "j", {c: (inc, _0)}, [(b, "j")]),
             ],
-            (c, "j", {b: (inc, _0), c: (inc, b)}, [(a, "j")]),
+            (
+                c,
+                "j",
+                {_unique_dep(b, "j"): (inc, _0), c: (inc, _unique_dep(b, "j"))},
+                [(a, "j")],
+            ),
         ],
         [
             [
                 (b, "i", {b: (sum, _0)}, [(a, "ij")]),
                 (c, "k", {c: (inc, _0)}, [(b, "k")]),
             ],
-            (c, "k", {b: (sum, _0), c: (inc, b)}, [(a, "kA")]),
+            (
+                c,
+                "k",
+                {_unique_dep(b, "k"): (sum, _0), c: (inc, _unique_dep(b, "k"))},
+                [(a, "kA")],
+            ),
         ],
         [
             [
@@ -60,7 +80,11 @@ i, j, k = "ijk"
             (
                 g,
                 "ij",
-                {g: (add, c, d), c: (inc, _0), d: (inc, _1)},
+                {
+                    g: (add, _unique_dep(c, "i"), _unique_dep(d, "j")),
+                    _unique_dep(c, "i"): (inc, _0),
+                    _unique_dep(d, "j"): (inc, _1),
+                },
                 [(a, "i"), (b, "j")],
             ),
         ],
@@ -69,14 +93,27 @@ i, j, k = "ijk"
                 (b, "ji", {b: (np.transpose, _0)}, [(a, "ij")]),
                 (c, "ij", {c: (add, _0, _1)}, [(a, "ij"), (b, "ij")]),
             ],
-            (c, "ij", {c: (add, _0, b), b: (np.transpose, _1)}, [(a, "ij"), (a, "ji")]),
+            (
+                c,
+                "ij",
+                {
+                    c: (add, _0, _unique_dep(b, "ij")),
+                    _unique_dep(b, "ij"): (np.transpose, _1),
+                },
+                [(a, "ij"), (a, "ji")],
+            ),
         ],
         [
             [
                 (c, "i", {c: (add, _0, _1)}, [(a, "i"), (b, "i")]),
                 (d, "i", {d: (inc, _0)}, [(c, "i")]),
             ],
-            (d, "i", {d: (inc, c), c: (add, _0, _1)}, [(a, "i"), (b, "i")]),
+            (
+                d,
+                "i",
+                {d: (inc, _unique_dep(c, "i")), _unique_dep(c, "i"): (add, _0, _1)},
+                [(a, "i"), (b, "i")],
+            ),
         ],
         [
             [
@@ -86,7 +123,10 @@ i, j, k = "ijk"
             (
                 d,
                 "ij",
-                {d: (np.dot, b, _0), b: (np.transpose, _1)},
+                {
+                    d: (np.dot, _unique_dep(b, "ik"), _0),
+                    _unique_dep(b, "ik"): (np.transpose, _1),
+                },
                 [(c, "kj"), (a, "ki")],
             ),
         ],
@@ -99,7 +139,11 @@ i, j, k = "ijk"
             (
                 g,
                 "i",
-                {g: (add, c, f), f: (add, _2, _3), c: (add, _0, _1)},
+                {
+                    g: (add, _unique_dep(c, "i"), _unique_dep(f, "i")),
+                    _unique_dep(f, "i"): (add, _2, _3),
+                    _unique_dep(c, "i"): (add, _0, _1),
+                },
                 [(a, i), (b, i), (d, i), (e, i)],
             ),
         ],
@@ -112,7 +156,11 @@ i, j, k = "ijk"
             (
                 g,
                 "i",
-                {g: (add, c, f), f: (add, _0, _2), c: (add, _0, _1)},
+                {
+                    g: (add, _unique_dep(c, "i"), _unique_dep(f, "i")),
+                    _unique_dep(f, "i"): (add, _0, _2),
+                    _unique_dep(c, "i"): (add, _0, _1),
+                },
                 [(a, "i"), (b, "i"), (e, "i")],
             ),
         ],
@@ -121,14 +169,24 @@ i, j, k = "ijk"
                 (b, "i", {b: (sum, _0)}, [(a, "ij")]),
                 (c, "i", {c: (inc, _0)}, [(b, "i")]),
             ],
-            (c, "i", {c: (inc, b), b: (sum, _0)}, [(a, "iA")]),
+            (
+                c,
+                "i",
+                {c: (inc, _unique_dep(b, "i")), _unique_dep(b, "i"): (sum, _0)},
+                [(a, "iA")],
+            ),
         ],
         [
             [
                 (c, "i", {c: (inc, _0)}, [(b, "i")]),
                 (d, "i", {d: (add, _0, _1, _2)}, [(a, "i"), (b, "i"), (c, "i")]),
             ],
-            (d, "i", {d: (add, _0, _1, c), c: (inc, _1)}, [(a, "i"), (b, "i")]),
+            (
+                d,
+                "i",
+                {d: (add, _0, _1, _unique_dep(c, "i")), _unique_dep(c, "i"): (inc, _1)},
+                [(a, "i"), (b, "i")],
+            ),
         ],
         # Include literals
         [
@@ -143,7 +201,7 @@ i, j, k = "ijk"
             (
                 c,
                 "j",
-                {b: (add, _1, _2), c: (add, b, _0)},
+                {_unique_dep(b, "j"): (add, _1, _2), c: (add, _unique_dep(b, "j"), _0)},
                 [(456, None), (a, "j"), (123, None)],
             ),
         ],
@@ -156,7 +214,7 @@ i, j, k = "ijk"
             (
                 c,
                 "j",
-                {b: (add, _1, _2), c: (add, b, _0)},
+                {_unique_dep(b, "j"): (add, _1, _2), c: (add, _unique_dep(b, "j"), _0)},
                 [(False, None), (a, "j"), (0, None)],
             ),
         ],
@@ -166,7 +224,37 @@ i, j, k = "ijk"
                 (b, "i", {b: (add, _0, _1)}, [(a, "i"), (123, None)]),
                 (c, "j", {c: (add, _0, _1)}, [(b, "j"), (123, None)]),
             ],
-            (c, "j", {b: (add, _1, _0), c: (add, b, _0)}, [(123, None), (a, "j")]),
+            (
+                c,
+                "j",
+                {_unique_dep(b, "j"): (add, _1, _0), c: (add, _unique_dep(b, "j"), _0)},
+                [(123, None), (a, "j")],
+            ),
+        ],
+        # Check case where two distinct indices are used
+        # for the same dependency name
+        # (See: https://github.com/dask/dask/issues/8535)
+        [
+            [
+                (b, "jk", {b: (add, _0, _1)}, [(a, "jk"), (2, None)]),
+                (c, "ijk", {c: (add, _0, _1)}, [(b, "ij"), (b, "jk")]),
+                (d, "ijk", {d: (inc, _0, _1)}, [(c, "ijk"), (123, None)]),
+            ],
+            (
+                "d",
+                "ijk",
+                {
+                    "d": (inc, _unique_dep(c, "ijk"), _0),
+                    _unique_dep(c, "ijk"): (
+                        add,
+                        _unique_dep(b, "ij"),
+                        _unique_dep(b, "jk"),
+                    ),
+                    _unique_dep(b, "ij"): (add, _1, _2),
+                    _unique_dep(b, "jk"): (add, _3, _2),
+                },
+                [(123, None), (a, "ij"), (2, None), (a, "jk")],
+            ),
         ],
     ],
 )

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -455,3 +455,16 @@ def test_fuse_roots_annotations():
     assert {"foo": "bar"} in [l.annotations for l in hlg.layers.values()]
     za = da.Array(hlg, z.name, z.chunks, z.dtype)
     assert_eq(za, z)
+
+
+@pytest.mark.parametrize("optimize_graph", [True, False])
+def test_optimize_blockwise_duplicate_dependency(optimize_graph):
+    # Two blockwise operations in a row with duplicate name
+    # (See: https://github.com/dask/dask/issues/8535)
+    xx = da.from_array(np.array([[1, 1], [2, 2]]), chunks=1)
+    xx = xx * 2
+    z = da.matmul(xx, xx)
+
+    # Compare to known answer
+    result = z.compute(optimize_graph=optimize_graph)
+    assert assert_eq(result, [[12, 12], [24, 24]])

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1443,9 +1443,7 @@ def rewrite_blockwise(inputs):
     io_deps = {}
     for v in inputs.values():
         io_deps.update(v.io_deps)
-    import pdb
 
-    pdb.set_trace()
     return Blockwise(
         root,
         inputs[root].output_indices,

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+from collections import defaultdict
 from itertools import product
 from typing import (
     Any,
@@ -1343,7 +1344,7 @@ def rewrite_blockwise(inputs):
     new_axes = inputs[root].new_axes
     concatenate = inputs[root].concatenate
     dsk = dict(inputs[root].dsk)
-    seen = {}
+    seen = defaultdict(int)
 
     changed = True
     while changed:
@@ -1361,19 +1362,8 @@ def rewrite_blockwise(inputs):
             # to the name to avoid fusing distinct indices
             # into a single dependency within the subgraph
             # (see: https://github.com/dask/dask/issues/8535)
-            use_dep = dep
-            if dep in seen:
-                try:
-                    _ind = seen[dep][ind]
-                    if _ind:
-                        # We only append a "counting" label for
-                        # `ind` cases after the first ooccurrence
-                        use_dep = dep + f"_{_ind}"
-                except KeyError:
-                    use_dep = dep + f"_{len(seen[dep])}"
-                    seen[dep][ind] = len(seen[dep])
-            else:
-                seen[dep] = {ind: 0}
+            use_dep = dep + f"_{seen[dep]}" if seen[dep] else dep
+            seen[dep] += 1
 
             # Replace _n with dep name in existing tasks
             # (inc, _0) -> (inc, 'b')
@@ -1453,7 +1443,9 @@ def rewrite_blockwise(inputs):
     io_deps = {}
     for v in inputs.values():
         io_deps.update(v.io_deps)
+    import pdb
 
+    pdb.set_trace()
     return Blockwise(
         root,
         inputs[root].output_indices,

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1,6 +1,5 @@
 import itertools
 import os
-from collections import defaultdict
 from itertools import product
 from typing import (
     Any,
@@ -1301,6 +1300,11 @@ def _optimize_blockwise(full_graph, keys=()):
     return HighLevelGraph(out, dependencies)
 
 
+def _unique_dep(dep, ind):
+    # Append blockwise index information to dependency name
+    return dep + "_" + "_".join(str(i) for i in list(ind))
+
+
 def rewrite_blockwise(inputs):
     """Rewrite a stack of Blockwise expressions into a single blockwise expression
 
@@ -1344,7 +1348,6 @@ def rewrite_blockwise(inputs):
     new_axes = inputs[root].new_axes
     concatenate = inputs[root].concatenate
     dsk = dict(inputs[root].dsk)
-    seen = defaultdict(int)
 
     changed = True
     while changed:
@@ -1357,17 +1360,14 @@ def rewrite_blockwise(inputs):
 
             changed = True
 
-            # Check if this dep was already encountered.
-            # If so, we should append a "counter" label
-            # to the name to avoid fusing distinct indices
+            # Change dep name to avoid fusing distinct indices
             # into a single dependency within the subgraph
             # (see: https://github.com/dask/dask/issues/8535)
-            use_dep = dep + f"_{seen[dep]}" if seen[dep] else dep
-            seen[dep] += 1
+            local_dep = dep if dep == root else _unique_dep(dep, ind)
 
             # Replace _n with dep name in existing tasks
             # (inc, _0) -> (inc, 'b')
-            dsk = {k: subs(v, {blockwise_token(i): use_dep}) for k, v in dsk.items()}
+            dsk = {k: subs(v, {blockwise_token(i): local_dep}) for k, v in dsk.items()}
 
             # Remove current input from input indices
             # [('a', 'i'), ('b', 'i')] -> [('a', 'i')]
@@ -1411,9 +1411,9 @@ def rewrite_blockwise(inputs):
                     indices.append(index)
             new_dsk = subs(inputs[dep].dsk, sub)
 
-            # Change new_dsk key to match use_dep
-            if dep != use_dep and dep in new_dsk:
-                new_dsk[use_dep] = new_dsk.pop(dep)
+            # Change new_dsk key to match local_dep
+            if dep != local_dep and dep in new_dsk:
+                new_dsk[local_dep] = new_dsk.pop(dep)
 
             # indices.extend(new_indices)
             dsk.update(new_dsk)

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1360,8 +1360,9 @@ def rewrite_blockwise(inputs):
 
             changed = True
 
-            # Change dep name to avoid fusing distinct indices
-            # into a single dependency within the subgraph
+            # Change dep name to avoid fusing the same dep
+            # (in different iteration orders) into a single
+            # subgraph key/dependency
             # (see: https://github.com/dask/dask/issues/8535)
             local_dep = dep if dep == root else _unique_dep(dep, ind)
 


### PR DESCRIPTION
This PR addsd a possible solution to #8535

It seems that the `rewrite_blockwise` phase of the current `optimize_blockwise` implementation can loose important information when a `Blockwise` layer depends on two other `Blockwise` layers with the same name (i.e. the same layer). For example, if `matmul` is used to multiply a matrix with itself, the same matrix projection may be used for both inputs to the binomial operation (rather than the proper ij,jk projections).  This will happen if the duplicate input is also a `Blockwise` layer (like `X*2`), because the original `indices` information in the `matmul` layer will be lost when the `X*2` result is fused into the root subgraph.

This PR proposes that we avoid this problem by appending a "counting" label to duplicated dependency names when they are fused into the root subgraph. This ensures that operations like `matmul(a, b)` will always store a distinct key-value pair for `a` and `b` the subgraph.

- [x] Closes #8535
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @ian-r-rose 