### PR TITLE
Handle plot_width / plot_height deprecations

### DIFF
--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -4,14 +4,18 @@ from bisect import bisect_left
 from itertools import cycle
 from operator import add, itemgetter
 
-import bokeh
-from packaging.version import parse as parse_version
 from tlz import accumulate, groupby, pluck, unique
 
 from ..core import istask
 from ..utils import apply, funcname, import_required
 
-BOKEH_VERSION = parse_version(bokeh.__version__)
+
+def BOKEH_VERSION():
+    import bokeh
+    from packaging.version import parse as parse_version
+
+    return parse_version(bokeh.__version__)
+
 
 _BOKEH_MISSING_MSG = "Diagnostics plots require `bokeh` to be installed"
 
@@ -204,14 +208,14 @@ def visualize(
             f.x_range = top.x_range
             f.title = None
             f.min_border_top = 20
-            if BOKEH_VERSION.major < 3:
+            if BOKEH_VERSION().major < 3:
                 f.plot_height -= 30
             else:
                 f.height -= 30
         for f in figs[:-1]:
             f.xaxis.axis_label = None
             f.min_border_bottom = 20
-            if BOKEH_VERSION.major < 3:
+            if BOKEH_VERSION().major < 3:
                 f.plot_height -= 30
             else:
                 f.height -= 30

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -368,8 +368,12 @@ def plot_resources(results, palette="Viridis", **kwargs):
     # Support plot_width and plot_height for backwards compatibility
     if "plot_width" in kwargs:
         kwargs["width"] = kwargs.pop("plot_width")
+        if BOKEH_VERSION().major >= 3:
+            warnings.warn("Use width instead of plot_width with Bokeh >= 3")
     if "plot_height" in kwargs:
         kwargs["height"] = kwargs.pop("plot_height")
+        if BOKEH_VERSION().major >= 3:
+            warnings.warn("Use height instead of plot_height with Bokeh >= 3")
 
     # Drop `label_size` to match `plot_cache` and `plot_tasks` kwargs
     if "label_size" in kwargs:
@@ -462,8 +466,12 @@ def plot_cache(
     # Support plot_width and plot_height for backwards compatibility
     if "plot_width" in kwargs:
         kwargs["width"] = kwargs.pop("plot_width")
+        if BOKEH_VERSION().major >= 3:
+            warnings.warn("Use width instead of plot_width with Bokeh >= 3")
     if "plot_height" in kwargs:
         kwargs["height"] = kwargs.pop("plot_height")
+        if BOKEH_VERSION().major >= 3:
+            warnings.warn("Use height instead of plot_height with Bokeh >= 3")
     defaults.update(**kwargs)
 
     if results:

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -4,10 +4,14 @@ from bisect import bisect_left
 from itertools import cycle
 from operator import add, itemgetter
 
+import bokeh
+from packaging.version import parse as parse_version
 from tlz import accumulate, groupby, pluck, unique
 
 from ..core import istask
 from ..utils import apply, funcname, import_required
+
+BOKEH_VERSION = parse_version(bokeh.__version__)
 
 _BOKEH_MISSING_MSG = "Diagnostics plots require `bokeh` to be installed"
 
@@ -200,11 +204,17 @@ def visualize(
             f.x_range = top.x_range
             f.title = None
             f.min_border_top = 20
-            f.plot_height -= 30
+            if BOKEH_VERSION.major < 3:
+                f.plot_height -= 30
+            else:
+                f.height -= 30
         for f in figs[:-1]:
             f.xaxis.axis_label = None
             f.min_border_bottom = 20
-            f.plot_height -= 30
+            if BOKEH_VERSION.major < 3:
+                f.plot_height -= 30
+            else:
+                f.height -= 30
         for f in figs:
             f.min_border_left = 75
             f.min_border_right = 75

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -228,7 +228,7 @@ def test_profiler_plot():
         show=False,
         save=False,
     )
-    if BOKEH_VERSION.major < 3:
+    if BOKEH_VERSION().major < 3:
         assert p.plot_width == 500
         assert p.plot_height == 300
     else:
@@ -258,7 +258,7 @@ def test_resource_profiler_plot():
         show=False,
         save=False,
     )
-    if BOKEH_VERSION.major < 3:
+    if BOKEH_VERSION().major < 3:
         assert p.plot_width == 500
         assert p.plot_height == 300
     else:
@@ -296,7 +296,7 @@ def test_cache_profiler_plot():
         show=False,
         save=False,
     )
-    if BOKEH_VERSION.major < 3:
+    if BOKEH_VERSION().major < 3:
         assert p.plot_width == 500
         assert p.plot_height == 300
     else:

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -6,6 +6,7 @@ from time import sleep
 import pytest
 
 from dask.diagnostics import CacheProfiler, Profiler, ResourceProfiler
+from dask.diagnostics.profile_visualize import BOKEH_VERSION
 from dask.threaded import get
 from dask.utils import apply, tmpfile
 
@@ -220,15 +221,19 @@ def test_profiler_plot():
     with prof:
         get(dsk, "e")
     p = prof.visualize(
-        plot_width=500,
-        plot_height=300,
+        width=500,
+        height=300,
         tools="hover",
         title="Not the default",
         show=False,
         save=False,
     )
-    assert p.plot_width == 500
-    assert p.plot_height == 300
+    if BOKEH_VERSION.major < 3:
+        assert p.plot_width == 500
+        assert p.plot_height == 300
+    else:
+        assert p.width == 500
+        assert p.height == 300
     assert len(p.tools) == 1
     assert isinstance(p.tools[0], bokeh.models.HoverTool)
     assert p.title.text == "Not the default"
@@ -246,15 +251,19 @@ def test_resource_profiler_plot():
     with ResourceProfiler(dt=0.01) as rprof:
         get(dsk2, "c")
     p = rprof.visualize(
-        plot_width=500,
-        plot_height=300,
+        width=500,
+        height=300,
         tools="hover",
         title="Not the default",
         show=False,
         save=False,
     )
-    assert p.plot_width == 500
-    assert p.plot_height == 300
+    if BOKEH_VERSION.major < 3:
+        assert p.plot_width == 500
+        assert p.plot_height == 300
+    else:
+        assert p.width == 500
+        assert p.height == 300
     assert len(p.tools) == 1
     assert isinstance(p.tools[0], bokeh.models.HoverTool)
     assert p.title.text == "Not the default"
@@ -280,15 +289,19 @@ def test_cache_profiler_plot():
     with CacheProfiler(metric_name="non-standard") as cprof:
         get(dsk, "e")
     p = cprof.visualize(
-        plot_width=500,
-        plot_height=300,
+        width=500,
+        height=300,
         tools="hover",
         title="Not the default",
         show=False,
         save=False,
     )
-    assert p.plot_width == 500
-    assert p.plot_height == 300
+    if BOKEH_VERSION.major < 3:
+        assert p.plot_width == 500
+        assert p.plot_height == 300
+    else:
+        assert p.width == 500
+        assert p.height == 300
     assert len(p.tools) == 1
     assert isinstance(p.tools[0], bokeh.models.HoverTool)
     assert p.title.text == "Not the default"


### PR DESCRIPTION
cc @jrbourbeau 

Bokeh 3.0 will also finally execute the deprecations of `plot_width` and `plot_height` and expose only `width` and `height` (consistent with every other layout-able). 

Ran relevant unit tests locally with several versions 2.1.1 to 3.0dev. @jrbourbeau can you remind me where these plots actually show up? Are they included in the dashboard? something else? If the dashboard, could this code be moved to the other repo?