### PR TITLE
Collections with HLG must always implement __dask_layers__ 

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -1,6 +1,5 @@
 import abc
 import collections.abc
-import contextlib
 import copy
 import html
 from typing import (
@@ -645,20 +644,19 @@ class HighLevelGraph(Mapping):
     @classmethod
     def _from_collection(cls, name, layer, collection):
         """`from_collections` optimized for a single collection"""
-        if is_dask_collection(collection):
-            graph = collection.__dask_graph__()
-            if isinstance(graph, HighLevelGraph):
-                layers = ensure_dict(graph.layers, copy=True)
-                layers.update({name: layer})
-                deps = ensure_dict(graph.dependencies, copy=True)
-                with contextlib.suppress(AttributeError):
-                    deps.update({name: set(collection.__dask_layers__())})
-            else:
-                key = _get_some_layer_name(collection)
-                layers = {name: layer, key: graph}
-                deps = {name: {key}, key: set()}
-        else:
+        if not is_dask_collection(collection):
             raise TypeError(type(collection))
+
+        graph = collection.__dask_graph__()
+        if isinstance(graph, HighLevelGraph):
+            layers = ensure_dict(graph.layers, copy=True)
+            layers[name] = layer
+            deps = ensure_dict(graph.dependencies, copy=True)
+            deps[name] = set(collection.__dask_layers__())
+        else:
+            key = _get_some_layer_name(collection)
+            layers = {name: layer, key: graph}
+            deps = {name: {key}, key: set()}
 
         return cls(layers, deps)
 
@@ -707,8 +705,7 @@ class HighLevelGraph(Mapping):
                 if isinstance(graph, HighLevelGraph):
                     layers.update(graph.layers)
                     deps.update(graph.dependencies)
-                    with contextlib.suppress(AttributeError):
-                        deps[name] |= set(collection.__dask_layers__())
+                    deps[name] |= set(collection.__dask_layers__())
                 else:
                     key = _get_some_layer_name(collection)
                     layers[key] = graph

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -21,6 +21,8 @@ from threading import Lock
 from typing import TypeVar
 from weakref import WeakValueDictionary
 
+import tlz as toolz
+
 from .core import get_deps
 
 K = TypeVar("K")
@@ -1161,9 +1163,8 @@ def ensure_dict(d: Mapping[K, V], *, copy: bool = False) -> dict[K, V]:
     except AttributeError:
         return dict(d)
 
-    unique_layers = {id(layer): layer for layer in layers.values()}
     result = {}
-    for layer in unique_layers.values():
+    for layer in toolz.unique(layers.values(), key=id):
         result.update(layer)
     return result
 

--- a/docs/source/custom-collections.rst
+++ b/docs/source/custom-collections.rst
@@ -82,7 +82,7 @@ interface is used inside Dask.
 
 .. method:: __dask_layers__(self)
 
-    This method should only be implemented if the collection uses
+    This method only needs to be implemented if the collection uses
     :class:`~dask.highlevelgraph.HighLevelGraph` to implement its dask graph.
 
     **Returns**


### PR DESCRIPTION
Without ``__dask_layers__``, ``HighLevelGraph.from_collections`` will produce a broken layer dependency graph and things will fall apart down the line. This makes me deduce that none of our users should have the use case in production, so I think it should be safe not to have a deprecation cycle here.