### PR TITLE
Fix PANDAS_GT_140

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -12,7 +12,7 @@ PANDAS_GT_121 = PANDAS_VERSION >= parse_version("1.2.1")
 PANDAS_GT_130 = PANDAS_VERSION >= parse_version("1.3.0")
 PANDAS_GT_131 = PANDAS_VERSION >= parse_version("1.3.1")
 PANDAS_GT_133 = PANDAS_VERSION >= parse_version("1.3.3")
-PANDAS_GT_140 = PANDAS_VERSION.release == (1, 4, 0)  # include pre-release
+PANDAS_GT_140 = PANDAS_VERSION >= parse_version("1.4.0")
 
 import pandas.testing as tm
 


### PR DESCRIPTION
Now that the pands nightly build is 1.5.0, I realized that the work from #8213 was not following the correct path. This does not fix upstream, but it takes the failure count from 361 down to 104...