### PR TITLE
[TEST CI] Test sqlalchemy>=1.4.0

### DIFF
--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -28,9 +28,7 @@ dependencies:
   - tiledb>=2.5.0
   - xarray
   - fsspec
-  # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
-  # along with other issues https://github.com/pandas-dev/pandas/issues/40467
-  - sqlalchemy<1.4.0
+  - sqlalchemy>=1.4.0
   - pyarrow
   - coverage
   - jsonschema


### PR DESCRIPTION
This is just a test to see what fails if we just bump sqlalchemy to 1.4.0

There is just one failure:

```python-traceback
=================================== FAILURES ===================================
___________________________ test_select_from_select ____________________________
[gw1] linux -- Python 3.9.9 /usr/share/miniconda3/envs/test-environment/bin/python

db = 'sqlite:////tmp/tmpuw2l_s1z.'

    def test_select_from_select(db):
        from sqlalchemy import sql
    
        s1 = sql.select([sql.column("number"), sql.column("name")]).select_from(
            sql.table("test")
        )
>       out = read_sql_table(s1, db, npartitions=2, index_col="number")

dask/dataframe/io/tests/test_sql.py:406: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
dask/dataframe/io/sql.py:115: in read_sql_table
    index = table.columns[index_col] if isinstance(index_col, str) else index_col
/usr/share/miniconda3/envs/test-environment/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:3113: in columns
    return self.c
<string>:2: in c
    ???
/usr/share/miniconda3/envs/test-environment/lib/python3.9/site-packages/sqlalchemy/util/deprecations.py:400: in warned
    _warn_with_version(message, version, wtype, stacklevel=3)
/usr/share/miniconda3/envs/test-environment/lib/python3.9/site-packages/sqlalchemy/util/deprecations.py:39: in _warn_with_version
    _warnings_warn(warn, stacklevel=stacklevel + 1)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

message = SADeprecationWarning('The SelectBase.c and SelectBase.columns attributes are deprecated and will be removed in a futur... columns that this SELECT object SELECTs from, use the SelectBase.selected_columns attribute. (deprecated since: 1.4)')
category = None, stacklevel = 5

    def _warnings_warn(message, category=None, stacklevel=2):
    
        # adjust the given stacklevel to be outside of SQLAlchemy
        try:
            frame = sys._getframe(stacklevel)
        except ValueError:
            # being called from less than 3 (or given) stacklevels, weird,
            # but don't crash
            stacklevel = 0
        except:
            # _getframe() doesn't work, weird interpreter issue, weird,
            # ok, but don't crash
            stacklevel = 0
        else:
            # using __name__ here requires that we have __name__ in the
            # __globals__ of the decorated string functions we make also.
            # we generate this using {"__name__": fn.__module__}
            while frame is not None and re.match(
                r"^(?:sqlalchemy\.|alembic\.)", frame.f_globals.get("__name__", "")
            ):
                frame = frame.f_back
                stacklevel += 1
    
        if category is not None:
            warnings.warn(message, category, stacklevel=stacklevel + 1)
        else:
>           warnings.warn(message, stacklevel=stacklevel + 1)
E           sqlalchemy.exc.SADeprecationWarning: The SelectBase.c and SelectBase.columns attributes are deprecated and will be removed in a future release; these attributes implicitly create a subquery that should be explicit.  Please call SelectBase.subquery() first in order to create a subquery, which then contains this attribute.  To access the columns that this SELECT object SELECTs from, use the SelectBase.selected_columns attribute. (deprecated since: 1.4)

/usr/share/miniconda3/envs/test-environment/lib/python3.9/site-packages/sqlalchemy/util/langhelpers.py:1675: SADeprecationWarning
```