### PR TITLE
Fix `to_frame` `name` to not pass None

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3656,7 +3656,8 @@ Dask Name: {name}, {task} tasks""".format(
 
     @derived_from(pd.Series)
     def to_frame(self, name=None):
-        return self.map_partitions(M.to_frame, name, meta=self._meta.to_frame(name))
+        args = [] if name is None else [name]
+        return self.map_partitions(M.to_frame, *args, meta=self._meta.to_frame(*args))
 
     @derived_from(pd.Series)
     def to_string(self, max_rows=5):
@@ -3990,12 +3991,12 @@ class Index(Series):
     def to_frame(self, index=True, name=None):
         if not index:
             raise NotImplementedError()
+        args = [index] if name is None else [index, name]
 
         return self.map_partitions(
             M.to_frame,
-            index,
-            name,
-            meta=self._meta.to_frame(index, name),
+            *args,
+            meta=self._meta.to_frame(index, *args),
             transform_divisions=False,
         )
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3996,7 +3996,7 @@ class Index(Series):
         return self.map_partitions(
             M.to_frame,
             *args,
-            meta=self._meta.to_frame(index, *args),
+            meta=self._meta.to_frame(*args),
             transform_divisions=False,
         )
 


### PR DESCRIPTION
This fixes some of the groupby tests on pandas upstream, but I'm not sure if it's the right approach. 

The issue is that pandas treats `None` differently than it used to. This is the behavior in nightly pandas:

```python
import pandas as pd

s = pd.Series([1,3,4], name="foo")
s.to_frame()
#    foo
# 0    1
# 1    3
# 2    4

s.to_frame(name=None)
#    NaN
# 0    1
# 1    3
# 2    4
