### PR TITLE
Specify scheduler in DataFrame `assert_eq`

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -537,14 +537,14 @@ def test_assert_eq_scheduler():
             using_custom_scheduler = False
 
     def check_custom_scheduler(part: pd.DataFrame) -> pd.DataFrame:
-        assert using_custom_scheduler
+        assert using_custom_scheduler, "not using custom scheduler"
         return part + 1
 
     df = pd.DataFrame({"x": [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)
     ddf2 = ddf.map_partitions(check_custom_scheduler, meta=ddf)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="not using custom scheduler"):
         assert_eq(ddf2, ddf2)
 
     assert_eq(ddf2, ddf2, scheduler=custom_scheduler)

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -545,6 +545,7 @@ def test_assert_eq_scheduler():
     ddf2 = ddf.map_partitions(check_custom_scheduler, meta=ddf)
 
     with pytest.raises(AssertionError, match="not using custom scheduler"):
+        # NOTE: we compare `ddf2` to itself in order to test both sides of the `assert_eq` logic.
         assert_eq(ddf2, ddf2)
 
     assert_eq(ddf2, ddf2, scheduler=custom_scheduler)

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import dask
 import dask.dataframe as dd
 from dask.dataframe._compat import tm
 from dask.dataframe.core import apply_and_enforce
@@ -21,6 +22,7 @@ from dask.dataframe.utils import (
     raise_on_meta_error,
     shard_df_on_index,
 )
+from dask.local import get_sync
 
 
 def test_shard_df_on_index():
@@ -521,3 +523,30 @@ def test_assert_eq_sorts():
     assert_eq(df1, df2_r, check_index=False)
     with pytest.raises(AssertionError):
         assert_eq(df1, df2_r)
+
+
+def test_assert_eq_scheduler():
+    using_custom_scheduler = False
+
+    def custom_scheduler(*args, **kwargs):
+        nonlocal using_custom_scheduler
+        try:
+            using_custom_scheduler = True
+            return get_sync(*args, **kwargs)
+        finally:
+            using_custom_scheduler = False
+
+    def check_custom_scheduler(part: pd.DataFrame) -> pd.DataFrame:
+        assert using_custom_scheduler
+        return part + 1
+
+    df = pd.DataFrame({"x": [1, 2, 3, 4]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf2 = ddf.map_partitions(check_custom_scheduler, meta=ddf)
+
+    with pytest.raises(AssertionError):
+        assert_eq(ddf2, ddf2)
+
+    assert_eq(ddf2, ddf2, scheduler=custom_scheduler)
+    with dask.config.set(scheduler=custom_scheduler):
+        assert_eq(ddf2, ddf2, scheduler=custom_scheduler)

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -549,4 +549,4 @@ def test_assert_eq_scheduler():
 
     assert_eq(ddf2, ddf2, scheduler=custom_scheduler)
     with dask.config.set(scheduler=custom_scheduler):
-        assert_eq(ddf2, ddf2, scheduler=custom_scheduler)
+        assert_eq(ddf2, ddf2, scheduler=None)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -12,9 +12,8 @@ import pandas as pd
 from pandas.api.types import is_scalar  # noqa: F401
 from pandas.api.types import is_categorical_dtype, is_dtype_equal
 
-from ..base import is_dask_collection
+from ..base import get_scheduler, is_dask_collection
 from ..core import get_deps
-from ..local import get_sync
 from ..utils import is_arraylike  # noqa: F401
 from ..utils import asciitable
 from ..utils import is_dataframe_like as dask_is_dataframe_like
@@ -445,7 +444,7 @@ def index_summary(idx, name=None):
 ###############################################################
 
 
-def _check_dask(dsk, check_names=True, check_dtypes=True, result=None):
+def _check_dask(dsk, check_names=True, check_dtypes=True, result=None, scheduler=None):
     import dask.dataframe as dd
 
     if hasattr(dsk, "__dask_graph__"):
@@ -453,7 +452,7 @@ def _check_dask(dsk, check_names=True, check_dtypes=True, result=None):
         if hasattr(graph, "validate"):
             graph.validate()
         if result is None:
-            result = dsk.compute(scheduler="sync")
+            result = dsk.compute(scheduler=scheduler)
         if isinstance(dsk, dd.Index):
             assert "Index" in type(result).__name__, type(result)
             # assert type(dsk._meta) == type(result), type(dsk._meta)
@@ -529,19 +528,24 @@ def assert_eq(
     check_dtype=True,
     check_divisions=True,
     check_index=True,
+    scheduler="sync",
     **kwargs,
 ):
     if check_divisions:
-        assert_divisions(a)
-        assert_divisions(b)
+        assert_divisions(a, scheduler=scheduler)
+        assert_divisions(b, scheduler=scheduler)
         if hasattr(a, "divisions") and hasattr(b, "divisions"):
             at = type(np.asarray(a.divisions).tolist()[0])  # numpy to python
             bt = type(np.asarray(b.divisions).tolist()[0])  # scalar conversion
             assert at == bt, (at, bt)
     assert_sane_keynames(a)
     assert_sane_keynames(b)
-    a = _check_dask(a, check_names=check_names, check_dtypes=check_dtype)
-    b = _check_dask(b, check_names=check_names, check_dtypes=check_dtype)
+    a = _check_dask(
+        a, check_names=check_names, check_dtypes=check_dtype, scheduler=scheduler
+    )
+    b = _check_dask(
+        b, check_names=check_names, check_dtypes=check_dtype, scheduler=scheduler
+    )
     if hasattr(a, "to_pandas"):
         a = a.to_pandas()
     if hasattr(b, "to_pandas"):
@@ -585,7 +589,7 @@ def assert_dask_graph(dask, label):
     raise AssertionError(f"given dask graph doesn't contain label: {label}")
 
 
-def assert_divisions(ddf):
+def assert_divisions(ddf, scheduler=None):
     if not hasattr(ddf, "divisions"):
         return
 
@@ -602,7 +606,8 @@ def assert_divisions(ddf):
         except AttributeError:
             return x.index
 
-    results = get_sync(ddf.dask, ddf.__dask_keys__())
+    get = get_scheduler(scheduler=scheduler, collections=[type(ddf)])
+    results = get(ddf.dask, ddf.__dask_keys__())
     for i, df in enumerate(results[:-1]):
         if len(df):
             assert index(df).min() >= ddf.divisions[i]


### PR DESCRIPTION
Support passing `scheduler=` to `dask.dataframe.utils.assert_eq`. By default, `assert_eq` continues to use the `sync` scheduler, but this allows specific tests to override that as necessary.

Split out from https://github.com/dask/dask/pull/8392.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`