### PR TITLE
Array optimization: cull before `fuse_roots`

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -43,8 +43,8 @@ def optimize(
         dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
 
     dsk = optimize_blockwise(dsk, keys=keys)
-    dsk = fuse_roots(dsk, keys=keys)
     dsk = dsk.cull(set(keys))
+    dsk = fuse_roots(dsk, keys=keys)
 
     # Perform low-level fusion unless the user has
     # specified False explicitly.


### PR DESCRIPTION
Because `fuse_roots` materializes Blockwise layers, if you have a situation where you're sub-selecting a few items out of a large initial Blockwise array, culling the graph (cheap) before materializing it (slow) can be massively more performant. As more becomes Blockwise (https://github.com/dask/dask/pull/7417), this will become more relevant. For example:

```python
a = da.from_zarr("s3://10-trillion-chunk-dataset/a")
b = da.from_zarr("s3://10-trillion-chunk-dataset/b")
metric = a / b
tiny_part = metric[:10]
# Without this PR, optimizing `tiny_part` could require materializing the 10-trillion-chunk
# `from_array` graphs, just to cull them down to nothing a moment later
``` 

I doubt this is exactly correct—maybe we need to cull again after `fuse_roots`? (Culling is cheap but not _that_ cheap; I'd like to not do it twice if possible.)

Because it materializes, I also think `fuse_roots` should perhaps go after the `if config.get("optimization.fuse.active") is False: return dsk` bailout.

Frankly, I don't understand `fuse_roots`. The situation described in https://github.com/dask/dask/pull/5451#issuecomment-552983458, and the test for it, are already handled by plain Blockwise fusion. In fact, if I remove `fuse_roots` entirely, `test_fuse_roots` still passes!

cc @rjzamora @ian-r-rose 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
