### PR TITLE
Tweak: "RuntimeWarning: invalid value encountered in reciprocal"

### DIFF
--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -980,7 +980,7 @@ def test_svd_incompatible_dimensions(ndim):
         da.linalg.svd(x)
 
 
-@pytest.mark.xfail(  # Remove after NumPy 1.22 release is out
+@pytest.mark.xfail(
     sys.platform == "darwin" and _np_version < parse_version("1.22"),
     reason="https://github.com/dask/dask/issues/7189",
     strict=False,

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -1002,7 +1002,7 @@ def test_norm_any_ndim(shape, chunks, axis, norm, keepdims):
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(  # Remove after NumPy 1.22 release is out
+@pytest.mark.xfail(
     sys.platform == "darwin" and _np_version < parse_version("1.22"),
     reason="https://github.com/dask/dask/issues/7189",
     strict=False,


### PR DESCRIPTION
Closes #7189

As we're adding unit tests for minimum versions, we'll need to keep the xfail decorator until numpy 1.22 is the bare minimum we support - which will take quite a while.
However, I think we can close the issue now.
Note that as of today our CI uses numpy 1.18. We're closing the ticket on the trust that our reproducer POC thoroughly covers the issue.