### PR TITLE
Remove unnecessary `pyyaml` `importorskip`

### DIFF
--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 
 import pytest
+import yaml
 
 import dask.config
 from dask.config import (
@@ -26,8 +27,6 @@ from dask.config import (
     update_defaults,
 )
 from dask.utils import tmpfile
-
-yaml = pytest.importorskip("yaml")
 
 
 def test_canonical_name():


### PR DESCRIPTION
This `importorskip` is no longer needed since `pyyaml` is a required dependency for `dask` 

https://github.com/dask/dask/blob/725110f9367931291a3e68c9d582544cdb032f77/setup.py#L37