### PR TITLE
Fail if meta is not a pandas object

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6068,8 +6068,10 @@ def map_partitions(
             # different type
             meta = make_meta(_concat([meta]), index=meta_index)
         else:
-            raise UserWarning(
-                "Meta is not valid, `map_partitions` expects output to be a pandas object."
+            raise ValueError(
+                "Meta is not valid, `map_partitions` expects output to be a pandas object. "
+                "Try passing a pandas object as meta or a dict or tuple representing the "
+                "(name, dtype) of the columns."
             )
 
     # Ensure meta is empty series

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3005,6 +3005,16 @@ def test_apply_warns():
     assert "int64" in str(w[0].message)
 
 
+def test_apply_fails_with_invalid_meta():
+    df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    func = lambda row: row["x"] + row["y"]
+
+    with pytest.raises(ValueError, match="Meta is not valid"):
+        ddf.apply(func, axis=1, meta=int)
+
+
 def test_applymap():
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})
     ddf = dd.from_pandas(df, npartitions=2)


### PR DESCRIPTION
- [x] Closes #8537
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Still need to add a test to prove it. 