### PR TITLE
Remove obsolete LocalFileSystem tests that fail for fsspec>=2022.1.0

### DIFF
--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -6,12 +6,10 @@ from functools import partial
 from time import sleep
 
 import cloudpickle
-import fsspec
 import pytest
 from fsspec.compression import compr
 from fsspec.core import open_files
 from fsspec.implementations.local import LocalFileSystem
-from packaging.version import parse as parse_version
 from tlz import concat, valmap
 
 from dask import compute
@@ -353,16 +351,3 @@ def test_abs_paths(tmpdir):
     with fs.open(out[0], "r") as f:
         res = f.read()
     assert res == "hi"
-
-
-def test_get_pyarrow_filesystem():
-    from fsspec.implementations.local import LocalFileSystem
-
-    pa = pytest.importorskip("pyarrow")
-    if parse_version(pa.__version__).major >= 2:
-        pytest.skip("fsspec no loger inherits from pyarrow>=2.0.")
-    if parse_version(fsspec.__version__).major > 2021:
-        pytest.skip("fsspec>=2022.1 no loger inherits from pyarrow")
-
-    fs = LocalFileSystem()
-    assert isinstance(fs, pa.filesystem.FileSystem)

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -6,6 +6,7 @@ from functools import partial
 from time import sleep
 
 import cloudpickle
+import fsspec
 import pytest
 from fsspec.compression import compr
 from fsspec.core import open_files
@@ -360,6 +361,8 @@ def test_get_pyarrow_filesystem():
     pa = pytest.importorskip("pyarrow")
     if parse_version(pa.__version__).major >= 2:
         pytest.skip("fsspec no loger inherits from pyarrow>=2.0.")
+    if parse_version(fsspec.__version__).major > 2021:
+        pytest.skip("fsspec>=2022.1 no loger inherits from pyarrow")
 
     fs = LocalFileSystem()
     assert isinstance(fs, pa.filesystem.FileSystem)

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -16,6 +16,7 @@ moto = pytest.importorskip("moto", minversion="1.3.14")
 pytest.importorskip("flask")  # server mode needs flask too
 requests = pytest.importorskip("requests")
 
+import fsspec
 from fsspec.compression import compr
 from fsspec.core import open_files
 from s3fs import S3FileSystem as DaskS3FileSystem
@@ -564,5 +565,7 @@ def test_get_pyarrow_fs_s3(s3):
     pa = pytest.importorskip("pyarrow")
     if parse_version(pa.__version__).major >= 2:
         pytest.skip("fsspec no loger inherits from pyarrow>=2.0.")
+    if parse_version(fsspec.__version__).major > 2021:
+        pytest.skip("fsspec>=2022.1 no loger inherits from pyarrow")
     fs = DaskS3FileSystem(anon=True)
     assert isinstance(fs, pa.filesystem.FileSystem)

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -16,7 +16,6 @@ moto = pytest.importorskip("moto", minversion="1.3.14")
 pytest.importorskip("flask")  # server mode needs flask too
 requests = pytest.importorskip("requests")
 
-import fsspec
 from fsspec.compression import compr
 from fsspec.core import open_files
 from s3fs import S3FileSystem as DaskS3FileSystem
@@ -559,13 +558,3 @@ def test_parquet_wstoragepars(s3, s3so):
     assert s3.current().default_block_size == 2 ** 20
     with s3.current().open(url + "/_metadata") as f:
         assert f.blocksize == 2 ** 20
-
-
-def test_get_pyarrow_fs_s3(s3):
-    pa = pytest.importorskip("pyarrow")
-    if parse_version(pa.__version__).major >= 2:
-        pytest.skip("fsspec no loger inherits from pyarrow>=2.0.")
-    if parse_version(fsspec.__version__).major > 2021:
-        pytest.skip("fsspec>=2022.1 no loger inherits from pyarrow")
-    fs = DaskS3FileSystem(anon=True)
-    assert isinstance(fs, pa.filesystem.FileSystem)


### PR DESCRIPTION
I believe that the latest release of fsspec is cause CI failures for Python-3.7, where the pyarrow version is <2.0. My understanding is that [fsspec#880](https://github.com/fsspec/filesystem_spec/pull/880) makes it so fsspec will no longer try to inherit `LocalFileSystem` from pyarrow (even when it is <2.0).  Feel free to correct me if my understanding is wrong @martindurant 

My first pass at this PR (311d8a7) skipped the failing tests for newer versions of fsspec. However, since this test will **always** be skipped in CI moving forward, I propose we just remove these tests altogether.


