### PR TITLE
Refactor config default search path retrieval

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -14,7 +14,10 @@ no_default = "__no_default__"
 
 
 def _get_paths():
-    """Get locations to search for config files"""
+    """Get locations to search for YAML configuration files.
+
+    This logic exists as a separate function for testing purposes.
+    """
 
     paths = [
         os.getenv("DASK_ROOT_CONFIG", "/etc/dask"),

--- a/dask/config.py
+++ b/dask/config.py
@@ -20,7 +20,6 @@ def _get_paths():
         os.getenv("DASK_ROOT_CONFIG", "/etc/dask"),
         os.path.join(sys.prefix, "etc", "dask"),
         os.path.join(os.path.expanduser("~"), ".config", "dask"),
-        os.path.join(os.path.expanduser("~"), ".dask"),
     ]
     if "DASK_CONFIG" in os.environ:
         paths.append(os.environ["DASK_CONFIG"])

--- a/dask/config.py
+++ b/dask/config.py
@@ -13,16 +13,25 @@ import yaml
 no_default = "__no_default__"
 
 
-paths = [
-    os.getenv("DASK_ROOT_CONFIG", "/etc/dask"),
-    os.path.join(sys.prefix, "etc", "dask"),
-    os.path.join(os.path.expanduser("~"), ".config", "dask"),
-    os.path.join(os.path.expanduser("~"), ".dask"),
-]
+def _get_paths():
+    """Get locations to search for config files"""
+
+    paths = [
+        os.getenv("DASK_ROOT_CONFIG", "/etc/dask"),
+        os.path.join(sys.prefix, "etc", "dask"),
+        os.path.join(os.path.expanduser("~"), ".config", "dask"),
+        os.path.join(os.path.expanduser("~"), ".dask"),
+    ]
+    if "DASK_CONFIG" in os.environ:
+        paths.append(os.environ["DASK_CONFIG"])
+
+    return paths
+
+
+paths = _get_paths()
 
 if "DASK_CONFIG" in os.environ:
     PATH = os.environ["DASK_CONFIG"]
-    paths.append(PATH)
 else:
     PATH = os.path.join(os.path.expanduser("~"), ".config", "dask")
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -517,7 +517,6 @@ def test__get_paths(monkeypatch):
         "/etc/dask",
         os.path.join(sys.prefix, "etc", "dask"),
         os.path.join(os.path.expanduser("~"), ".config", "dask"),
-        os.path.join(os.path.expanduser("~"), ".dask"),
     ]
     assert _get_paths() == expected
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -23,7 +23,6 @@ from dask.config import (
     refresh,
     rename,
     serialize,
-    set,
     update,
     update_defaults,
 )
@@ -239,47 +238,47 @@ def test_ensure_file(tmpdir):
 
 
 def test_set():
-    with set(abc=123):
+    with dask.config.set(abc=123):
         assert config["abc"] == 123
-        with set(abc=456):
+        with dask.config.set(abc=456):
             assert config["abc"] == 456
         assert config["abc"] == 123
 
     assert "abc" not in config
 
-    with set({"abc": 123}):
+    with dask.config.set({"abc": 123}):
         assert config["abc"] == 123
     assert "abc" not in config
 
-    with set({"abc.x": 1, "abc.y": 2, "abc.z.a": 3}):
+    with dask.config.set({"abc.x": 1, "abc.y": 2, "abc.z.a": 3}):
         assert config["abc"] == {"x": 1, "y": 2, "z": {"a": 3}}
     assert "abc" not in config
 
     d = {}
-    set({"abc.x": 123}, config=d)
+    dask.config.set({"abc.x": 123}, config=d)
     assert d["abc"]["x"] == 123
 
 
 def test_set_kwargs():
-    with set(foo__bar=1, foo__baz=2):
+    with dask.config.set(foo__bar=1, foo__baz=2):
         assert config["foo"] == {"bar": 1, "baz": 2}
     assert "foo" not in config
 
     # Mix kwargs and dict, kwargs override
-    with set({"foo.bar": 1, "foo.baz": 2}, foo__buzz=3, foo__bar=4):
+    with dask.config.set({"foo.bar": 1, "foo.baz": 2}, foo__buzz=3, foo__bar=4):
         assert config["foo"] == {"bar": 4, "baz": 2, "buzz": 3}
     assert "foo" not in config
 
     # Mix kwargs and nested dict, kwargs override
-    with set({"foo": {"bar": 1, "baz": 2}}, foo__buzz=3, foo__bar=4):
+    with dask.config.set({"foo": {"bar": 1, "baz": 2}}, foo__buzz=3, foo__bar=4):
         assert config["foo"] == {"bar": 4, "baz": 2, "buzz": 3}
     assert "foo" not in config
 
 
 def test_set_nested():
-    with set({"abc": {"x": 123}}):
+    with dask.config.set({"abc": {"x": 123}}):
         assert config["abc"] == {"x": 123}
-        with set({"abc.y": 456}):
+        with dask.config.set({"abc.y": 456}):
             assert config["abc"] == {"x": 123, "y": 456}
         assert config["abc"] == {"x": 123}
     assert "abc" not in config
@@ -288,8 +287,8 @@ def test_set_nested():
 def test_set_hard_to_copyables():
     import threading
 
-    with set(x=threading.Lock()):
-        with set(y=1):
+    with dask.config.set(x=threading.Lock()):
+        with dask.config.set(y=1):
             pass
 
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -507,8 +507,6 @@ def test_config_inheritance():
 
 
 def test__get_paths(monkeypatch):
-    from builtins import set
-
     # These environment variables are used by Dask's config system.
     # We temporarily remove them to avoid interference from the
     # machine where tests are being run.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -91,9 +91,6 @@ The contents of these YAML files are merged together, allowing different
 Dask subprojects like ``dask-kubernetes`` or ``dask-ml`` to manage configuration
 files separately, but have them merge into the same global configuration.
 
-*Note: for historical reasons we also look in the ``~/.dask`` directory for
-config files.  This is deprecated and will soon be removed.*
-
 
 Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is _mostly_ a cleanup PR which moves the logic for how our config system determines the places to look for config YAML files into its own function which makes it easier to write tests for. 

Additionally, I noticed that we currently look in `~/.dask` for config files but state in the docs that this is deprecated and will be removed shortly. Since this notice was added ~3.5 years ago (xref https://github.com/dask/dask/pull/3432) I decided to go ahead and stop looking in `~/.dask`. This is the only functional change in this PR. 