### PR TITLE
Update Docstring for 'from_delayed' Function 

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -572,8 +572,8 @@ def from_delayed(
     ----------
     dfs : list of Delayed or Future
         An iterable of ``dask.delayed.Delayed`` objects, such as come from
-        ``dask.delayed`` or an iterable of ``concurrent.futures.Future`` objects,
-        such as come from ``concurrent.futures``. These comprise the individual
+        ``dask.delayed`` or an iterable of ``distributed.Future`` objects,
+        such as come from ``client.submit`` interface. These comprise the individual
         partitions of the resulting dataframe.
     $META
     divisions : tuple, str, optional

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -573,7 +573,7 @@ def from_delayed(
     dfs : list of Delayed or Future
         An iterable of ``dask.delayed.Delayed`` objects, such as come from
         ``dask.delayed`` or an iterable of ``concurrent.futures.Future`` objects,
-        such as come from ``concurrent.futures``. These comprise the individual 
+        such as come from ``concurrent.futures``. These comprise the individual
         partitions of the resulting dataframe.
     $META
     divisions : tuple, str, optional

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -570,10 +570,11 @@ def from_delayed(
 
     Parameters
     ----------
-    dfs : list of Delayed
+    dfs : list of Delayed or Future
         An iterable of ``dask.delayed.Delayed`` objects, such as come from
-        ``dask.delayed`` These comprise the individual partitions of the
-        resulting dataframe.
+        ``dask.delayed`` or an iterable of ``concurrent.futures.Future`` objects,
+        such as come from ``concurrent.futures``. These comprise the individual 
+        partitions of the resulting dataframe.
     $META
     divisions : tuple, str, optional
         Partition boundaries along the index.


### PR DESCRIPTION
- [x] Closes #8568
~~- [ ] Tests added / passed~~
- [x] Passes `pre-commit run --all-files`

Updated the docstring for `from_delayed` function in `"dask/dataframe/io.io.py"` file, documenting the `dask.DataFrame.from_delayed` compatibility for both `Delayed` and  `Future` objects.