### PR TITLE
support sqlalchemy>=1.4.0

### DIFF
--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -28,9 +28,7 @@ dependencies:
   - tiledb>=2.5.0
   - xarray
   - fsspec
-  # sqlalchemy 1.4.0 causes deprecation warnings to be raised from pandas
-  # along with other issues https://github.com/pandas-dev/pandas/issues/40467
-  - sqlalchemy<1.4.0
+  - sqlalchemy>=1.4.0
   - pyarrow
   - coverage
   - jsonschema

--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -101,7 +101,7 @@ def read_sql_table(
     """
     import sqlalchemy as sa
     from sqlalchemy import sql
-    from sqlalchemy.sql import elements
+    from sqlalchemy.sql import elements, expression
 
     if index_col is None:
         raise ValueError("Must specify index column to partition on")
@@ -111,6 +111,13 @@ def read_sql_table(
     m = sa.MetaData()
     if isinstance(table, str):
         table = sa.Table(table, m, autoload=True, autoload_with=engine, schema=schema)
+
+    if (
+        isinstance(table, expression.SelectBase)
+        # sqlalchemy >= 1.4 https://github.com/sqlalchemy/sqlalchemy/issues/4617
+        and hasattr(table, "subquery")
+    ):
+        table = table.subquery()
 
     index = table.columns[index_col] if isinstance(index_col, str) else index_col
     if not isinstance(index_col, (str, elements.Label)):


### PR DESCRIPTION
- [x] Closes #7406 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

the deprecation warning comes from here: https://github.com/sqlalchemy/sqlalchemy/blob/eb716884a4abcabae84a6aaba105568e925b7d27/lib/sqlalchemy/sql/selectable.py#L2657-L2691 see https://github.com/sqlalchemy/sqlalchemy/issues/4617

a workaround to this is to explicitly create the subquery when "table" is really a SelectBase

```
diff --git a/dask/dataframe/io/sql.py b/dask/dataframe/io/sql.py
index 9c15360c..21cad90a 100644
--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -112,6 +112,9 @@ def read_sql_table(
     if isinstance(table, str):
         table = sa.Table(table, m, autoload=True, autoload_with=engine, schema=schema)
 
+    if isinstance(table, sa.sql.expression.SelectBase):
+        table = table.subquery()
+
     index = table.columns[index_col] if isinstance(index_col, str) else index_col
     if not isinstance(index_col, (str, elements.Label)):
         raise ValueError(
```

This should get the tests passing, but there are other issues eg
see also https://github.com/dask/dask/pull/8158 