### PR TITLE
Fix groupby.cumsum with series grouped by index

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1282,9 +1282,12 @@ class _GroupBy:
                 aggregate,
                 initial,
             )
-        graph = HighLevelGraph.from_collections(
-            name, dask, dependencies=[cumpart_raw, cumpart_ext, cumlast]
-        )
+
+        dependencies = [cumpart_raw]
+        if self.obj.npartitions > 1:
+            dependencies += [cumpart_ext, cumlast]
+
+        graph = HighLevelGraph.from_collections(name, dask, dependencies=dependencies)
         return new_dd_object(graph, name, chunk(self._meta), self.obj.divisions)
 
     def _shuffle(self, meta):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1231,7 +1231,7 @@ class _GroupBy:
         cumpart_ext = cumpart_raw_frame.assign(
             **{
                 i: self.obj[i]
-                if np.isscalar(i) and i in self.obj.columns
+                if np.isscalar(i) and i in getattr(self.obj, "columns", [])
                 else self.obj.index
                 for i in by
             }

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -430,11 +430,16 @@ def test_series_groupby_propagates_names():
     assert_eq(result, expected)
 
 
-def test_series_groupby_with_named_index():
-    df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}).set_index("x")
-    ddf = dd.from_pandas(df, 2)
-    expected = df["y"].groupby("x").cumsum()
-    result = ddf["y"].groupby("x").cumsum()
+@pytest.mark.parametrize("npartitions", (1, 2))
+@pytest.mark.parametrize("func", ("cumsum", "cumprod", "cumcount"))
+def test_series_groupby_cumfunc_with_named_index(npartitions, func):
+    df = pd.DataFrame(
+        {"x": [1, 2, 3, 4, 5, 6, 7], "y": [8, 9, 6, 2, 3, 5, 6]}
+    ).set_index("x")
+    ddf = dd.from_pandas(df, npartitions)
+    assert ddf.npartitions == npartitions
+    expected = getattr(df["y"].groupby("x"), func)()
+    result = getattr(ddf["y"].groupby("x"), func)()
     assert_eq(result, expected)
 
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -430,6 +430,14 @@ def test_series_groupby_propagates_names():
     assert_eq(result, expected)
 
 
+def test_series_groupby_with_named_index():
+    df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}).set_index("x")
+    ddf = dd.from_pandas(df, 2)
+    expected = df["y"].groupby("x").cumsum()
+    result = ddf["y"].groupby("x").cumsum()
+    assert_eq(result, expected)
+
+
 def test_series_groupby():
     s = pd.Series([1, 2, 2, 1, 1])
     pd_group = s.groupby(s)


### PR DESCRIPTION
- [x] Closes #8578
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

I need some help figuring out what is making the test fail - maybe @ian-r-rose can provide a second set of eyes. 

Here's an example of the failure:

```python-traceback
_____________________ test_series_groupby_with_named_index[disk] ______________________

    def test_series_groupby_with_named_index():
        df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}).set_index("x")
        ddf = dd.from_pandas(df, 2)
    
        expected = df["y"].groupby("x").cumsum()
        result = ddf["y"].groupby("x").cumsum()
        breakpoint()
    
>       assert_eq(result, expected)

dask/dataframe/tests/test_groupby.py:441: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
dask/dataframe/utils.py:543: in assert_eq
    a = _check_dask(
dask/dataframe/utils.py:453: in _check_dask
    graph.validate()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = HighLevelGraph with 8 layers.
<dask.highlevelgraph.HighLevelGraph object at 0x7fb7a0f66790>
 0. from_pandas-67819a5ba8...s-groupby-cumsum-take-last-5afb376059afe4fed9ae470398b312d5
 7. series-groupby-cumsum-c2a355e10b84617b49c2c62c6d084b7a


    def validate(self):
        # Check dependencies
        for layer_name, deps in self.dependencies.items():
            if layer_name not in self.layers:
                raise ValueError(
                    f"dependencies[{repr(layer_name)}] not found in layers"
                )
            for dep in deps:
                if dep not in self.dependencies:
                    raise ValueError(f"{repr(dep)} not found in dependencies")
    
        for layer in self.layers.values():
            assert hasattr(layer, "annotations")
    
        # Re-calculate all layer dependencies
        dependencies = compute_layer_dependencies(self.layers)
    
        # Check keys
        dep_key1 = self.dependencies.keys()
        dep_key2 = dependencies.keys()
        if dep_key1 != dep_key2:
            raise ValueError(
                f"incorrect dependencies keys {set(dep_key1)!r} "
                f"expected {set(dep_key2)!r}"
            )
    
        # Check values
        for k in dep_key1:
            if self.dependencies[k] != dependencies[k]:
>               raise ValueError(
                    f"incorrect dependencies[{repr(k)}]: {repr(self.dependencies[k])} "
                    f"expected {repr(dependencies[k])}"
                )
E               ValueError: incorrect dependencies['series-groupby-cumsum-c2a355e10b84617b49c2c62c6d084b7a']: {'assign-e925ccbf6d5a86174f1180eea0696a25', 'series-groupby-cumsum-take-last-5afb376059afe4fed9ae470398b312d5', 'series-groupby-cumsum-map-797524ad685aa1db670af58d96e53cc2'} expected {'series-groupby-cumsum-map-797524ad685aa1db670af58d96e53cc2'}

dask/highlevelgraph.py:1035: ValueError

```