### PR TITLE
Adds region to to_zarr when using existing array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3361,6 +3361,7 @@ def to_zarr(
     component=None,
     storage_options=None,
     overwrite=False,
+    region=None,
     compute=True,
     return_stored=False,
     **kwargs,
@@ -3386,6 +3387,9 @@ def to_zarr(
     overwrite: bool
         If given array already exists, overwrite=False will cause an error,
         where overwrite=True will replace the existing data.
+    region: tuple of slices or None
+        The region of data that should be written if ``url`` is a zarr.Array.
+        Not to be used with other types of ``url``.
     compute: bool
         See :func:`~dask.array.store` for more details.
     return_stored: bool
@@ -3397,6 +3401,7 @@ def to_zarr(
     ------
     ValueError
         If ``arr`` has unknown chunk sizes, which is not supported by Zarr.
+        If ``region`` is specified and ``url`` is not a zarr.Array
 
     See Also
     --------
@@ -3422,7 +3427,13 @@ def to_zarr(
                 "the Distributed Scheduler."
             )
         arr = arr.rechunk(z.chunks)
-        return arr.store(z, lock=False, compute=compute, return_stored=return_stored)
+        regions = [region] if region is not None else None
+        return arr.store(
+            z, lock=False, regions=regions, compute=compute, return_stored=return_stored
+        )
+
+    if region is not None:
+        raise ValueError("Cannot use `region` keyword when url is not a `zarr.Array`.")
 
     if not _check_regular_chunks(arr.chunks):
         raise ValueError(

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4581,6 +4581,12 @@ def test_zarr_regions():
     assert_eq(a2, expected)
     assert a2.chunks == a.chunks
 
+    a[3:, 3:].to_zarr(z, region=(slice(2, 3), slice(1, 2)))
+    a2 = da.from_zarr(z)
+    expected = [[0, 1, 0, 0], [4, 5, 3, 0], [0, 15, 7, 0], [0, 0, 11, 0]]
+    assert_eq(a2, expected)
+    assert a2.chunks == a.chunks
+
     with pytest.raises(ValueError):
         with tmpdir() as d:
             a.to_zarr(d, region=(slice(2), slice(2)))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4563,6 +4563,29 @@ def test_zarr_nocompute():
         assert a2.chunks == a.chunks
 
 
+def test_zarr_regions():
+    zarr = pytest.importorskip("zarr")
+
+    a = da.arange(16).reshape((4, 4)).rechunk(2)
+    z = zarr.zeros_like(a, chunks=2)
+
+    a[:2, :2].to_zarr(z, region=(slice(2), slice(2)))
+    a2 = da.from_zarr(z)
+    expected = [[0, 1, 0, 0], [4, 5, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+    assert_eq(a2, expected)
+    assert a2.chunks == a.chunks
+
+    a[:3, 3:4].to_zarr(z, region=(slice(1, 4), slice(2, 3)))
+    a2 = da.from_zarr(z)
+    expected = [[0, 1, 0, 0], [4, 5, 3, 0], [0, 0, 7, 0], [0, 0, 11, 0]]
+    assert_eq(a2, expected)
+    assert a2.chunks == a.chunks
+
+    with pytest.raises(ValueError):
+        with tmpdir() as d:
+            a.to_zarr(d, region=(slice(2), slice(2)))
+
+
 def test_tiledb_roundtrip():
     tiledb = pytest.importorskip("tiledb")
     # 1) load with default chunking


### PR DESCRIPTION
The region keyword is forbidden when creating a new zarr array.

- [x] Closes #8577 
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

The added test passes when run singly, but fails most of the time when the entire test suite is run.  The failure seems to be due to setting `lock=False` in the following.  (If I set `lock=True`, the test seems to always pass.)

https://github.com/chrisroat/dask/blob/5ef111b14d6e77427def100cce6a87a76e6ce5d7/dask/array/core.py#L3431-L3433

Any thoughts as to why `lock=False` is set?  Could/should it be a parameter?