### PR TITLE
Add `include_path_column` arg to `read_json`

### DIFF
--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -117,6 +117,7 @@ def read_json(
     meta=None,
     engine=pd.read_json,
     include_path_column=False,
+    path_converter=None,
     **kwargs,
 ):
     """Create a dataframe from a set of JSON files
@@ -196,10 +197,6 @@ def read_json(
     storage_options = storage_options or {}
     if include_path_column is True:
         include_path_column = "path"
-    if isinstance(kwargs.get("converters"), dict) and include_path_column:
-        path_converter = kwargs["converters"].get(include_path_column, None)
-    else:
-        path_converter = None
 
     if path_converter is None:
         path_converter = lambda x: x

--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -152,7 +152,7 @@ def read_json(
         newline character.
     sample: int
         Number of bytes to pre-load, to provide an empty dataframe structure
-        to any blocks without data. Only relevant is using blocksize.
+        to any blocks without data. Only relevant when using blocksize.
     encoding, errors:
         Text conversion, ``see bytes.decode()``
     compression : string or None
@@ -160,6 +160,14 @@ def read_json(
     engine : function object, default ``pd.read_json``
         The underlying function that dask will use to read JSON files. By
         default, this will be the pandas JSON reader (``pd.read_json``).
+    include_path_column : bool or str, optional
+        Include a column with the file path where each row in the dataframe
+        originated. If ``True``, a new column is added to the dataframe called
+        ``path``. If ``str``, sets new column name. Default is ``False``.
+    path_converter : function or None, optional
+        A function that takes one argument and returns a string. Used to convert
+        paths in the ``path`` column, for instance, to strip a common prefix from
+        all the paths.
     $META
 
     Returns

--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -314,6 +314,6 @@ def add_path_column(df, column_name, path, dtype):
         raise ValueError(
             f"Files already contain the column name: '{column_name}', so the path "
             "column cannot use this name. Please set `include_path_column` to a "
-            "`include_path_column` to a unique name."
+            "unique name."
         )
     return df.assign(**{column_name: pd.Series([path] * len(df), dtype=dtype)})

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -24,7 +24,7 @@ def test_read_json_with_path_column(orient):
         assert_eq(out, actual_pd)
 
 
-@pytest.mark.parametrize("blocksize", [None, 5])
+@pytest.mark.parametrize("blocksize", [None, 5, 50, 5000])
 def test_read_json_multiple_files_with_path_column(blocksize, tmpdir):
     fil1 = str(tmpdir.join("fil1.json"))
     fil2 = str(tmpdir.join("fil2.json"))

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -20,10 +20,10 @@ def test_read_json_with_path_column(orient):
         actual = dd.read_json(f, orient=orient, lines=False, include_path_column=True)
         actual_pd = pd.read_json(f, orient=orient, lines=False)
         # The default column name when include_path_colum is True is "path"
-        # The paths on Windows are normalized somewhere in the file reading
-        # chain in Dask, so we have to do the same here.
+        # The paths on Windows are converted to forward slash somewhere in the file
+        # reading chain in Dask, so we have to do the same here.
         actual_pd["path"] = pd.Series(
-            (os.path.normpath(f),) * len(actual_pd), dtype="category"
+            (f.replace(os.sep, "/"),) * len(actual_pd), dtype="category"
         )
         assert actual.path.dtype == "category"
         assert_eq(actual, actual_pd)

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -71,8 +71,8 @@ def test_write_orient_not_records_and_lines():
 
 @pytest.mark.parametrize("blocksize", [5, 15, 33, 200, 90000])
 def test_read_json_multiple_files_with_path_column(blocksize, tmpdir):
-    fil1 = str(tmpdir.join("fil1.json"))
-    fil2 = str(tmpdir.join("fil2.json"))
+    fil1 = str(tmpdir.join("fil1.json")).replace(os.sep, "/")
+    fil2 = str(tmpdir.join("fil2.json")).replace(os.sep, "/")
     df = pd.DataFrame({"x": range(5), "y": ["a", "b", "c", "d", "e"]})
     df2 = df.assign(x=df.x + 0.5)
     orient = "records"

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -20,11 +20,12 @@ def test_read_json_with_path_column(orient):
         actual = dd.read_json(f, orient=orient, lines=False, include_path_column=True)
         actual_pd = pd.read_json(f, orient=orient, lines=False)
         actual_pd["path"] = pd.Series((str(f),) * len(actual_pd), dtype="category")
+        assert actual.path.dtype == "category"
         out = actual.compute()
         assert_eq(out, actual_pd)
 
 
-def test_read_json_path_column_present():
+def test_read_json_path_column_with_duplicate_name_is_error():
     with tmpfile("json") as f:
         df.to_json(f, orient="records", lines=False)
         with pytest.raises(ValueError, match="Files already contain"):
@@ -53,8 +54,9 @@ def test_read_orient_not_records_and_lines():
 
 
 def test_write_orient_not_records_and_lines():
-    with pytest.raises(ValueError, match="Line-delimited JSON"):
-        dd.to_json(df, "nofile.json", orient="split", lines=True)
+    with tmpfile("json") as f:
+        with pytest.raises(ValueError, match="Line-delimited JSON"):
+            dd.to_json(df, str(f), orient="split", lines=True)
 
 
 @pytest.mark.parametrize("blocksize", [5, 15, 33, 200, 90000])


### PR DESCRIPTION
As suggested in #8539, this adds the `include_path_column` argument to `dd.read_json()`. The paths can be munged using the `path_converter` argument, which is slightly different from the `dd.read_csv()` case, because `pd.read_json()` does not support the `converters` argument.

- [X] Closes #8539 
- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`
