### PR TITLE
Move `cached_cumsum` imports to be from `dask.utils`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -52,6 +52,7 @@ from ..utils import (
     IndexCallable,
     M,
     SerializableLock,
+    cached_cumsum,
     cached_property,
     concrete,
     derived_from,
@@ -77,7 +78,7 @@ from .chunk_types import is_valid_array_chunk, is_valid_chunk_type
 # Keep einsum_lookup and tensordot_lookup here for backwards compatibility
 from .dispatch import concatenate_lookup, einsum_lookup, tensordot_lookup  # noqa: F401
 from .numpy_compat import _numpy_120, _Recurser
-from .slicing import cached_cumsum, replace_ellipsis, setitem_array, slice_array
+from .slicing import replace_ellipsis, setitem_array, slice_array
 
 config.update_defaults({"array": {"chunk-size": "128MiB", "rechunk-threshold": 4}})
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -10,7 +10,7 @@ from tlz import sliding_window
 
 from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
-from ..utils import derived_from
+from ..utils import cached_cumsum, derived_from
 from . import chunk
 from .core import (
     Array,
@@ -19,7 +19,6 @@ from .core import (
     blockwise,
     broadcast_arrays,
     broadcast_to,
-    cached_cumsum,
     concatenate,
     normalize_chunks,
     stack,

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -11,7 +11,6 @@ from dask import config
 from dask.array.slicing import (
     _sanitize_index_element,
     _slice_1d,
-    cached_cumsum,
     make_block_sorted_slices,
     new_blockdim,
     normalize_index,
@@ -975,29 +974,6 @@ def test_pathological_unsorted_slicing():
 
     assert "10" in str(info.list[0])
     assert "out-of-order" in str(info.list[0])
-
-
-def test_cached_cumsum():
-    a = (1, 2, 3, 4)
-    x = cached_cumsum(a)
-    y = cached_cumsum(a, initial_zero=True)
-    assert x == (1, 3, 6, 10)
-    assert y == (0, 1, 3, 6, 10)
-
-
-def test_cached_cumsum_nan():
-    a = (1, np.nan, 3)
-    x = cached_cumsum(a)
-    y = cached_cumsum(a, initial_zero=True)
-    np.testing.assert_equal(x, (1, np.nan, np.nan))
-    np.testing.assert_equal(y, (0, 1, np.nan, np.nan))
-
-
-def test_cached_cumsum_non_tuple():
-    a = [1, 2, 3]
-    assert cached_cumsum(a) == (1, 3, 6)
-    a[1] = 4
-    assert cached_cumsum(a) == (1, 5, 8)
 
 
 @pytest.mark.parametrize("params", [(2, 2, 1), (5, 3, 2)])

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -15,6 +15,7 @@ from dask.utils import (
     SerializableLock,
     _deprecated,
     asciitable,
+    cached_cumsum,
     derived_from,
     ensure_dict,
     extra_titles,
@@ -778,3 +779,27 @@ class MyType:
 def test_typename_on_instances():
     instance = MyType()
     assert typename(instance) == typename(MyType)
+
+
+def test_cached_cumsum():
+    a = (1, 2, 3, 4)
+    x = cached_cumsum(a)
+    y = cached_cumsum(a, initial_zero=True)
+    assert x == (1, 3, 6, 10)
+    assert y == (0, 1, 3, 6, 10)
+
+
+def test_cached_cumsum_nan():
+    np = pytest.importorskip("numpy")
+    a = (1, np.nan, 3)
+    x = cached_cumsum(a)
+    y = cached_cumsum(a, initial_zero=True)
+    np.testing.assert_equal(x, (1, np.nan, np.nan))
+    np.testing.assert_equal(y, (0, 1, np.nan, np.nan))
+
+
+def test_cached_cumsum_non_tuple():
+    a = [1, 2, 3]
+    assert cached_cumsum(a) == (1, 3, 6)
+    a[1] = 4
+    assert cached_cumsum(a) == (1, 5, 8)


### PR DESCRIPTION
This is a small follow-up to https://github.com/dask/dask/pull/7417 which moves `import`s of `cached_cumsum` to be from `dask.utils` (its new location) instead of `dask.array.slicing` (where it used to be)

cc @ian-r-rose 