### PR TITLE
Add engine_kwargs support to dask.dataframe.to_sql

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1572,6 +1572,7 @@ Dask Name: {name}, {task} tasks"""
         method=None,
         compute=True,
         parallel=False,
+        engine_kwargs=None,
     ):
         """See dd.to_sql docstring for more information"""
         from .io import to_sql
@@ -1589,6 +1590,7 @@ Dask Name: {name}, {task} tasks"""
             method=method,
             compute=compute,
             parallel=parallel,
+            engine_kwargs=engine_kwargs,
         )
 
     def to_json(self, filename, *args, **kwargs):

--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -678,6 +678,7 @@ def to_sql(
     method=None,
     compute=True,
     parallel=False,
+    engine_kwargs=None,
 ):
     """Store Dask Dataframe to a SQL table
 
@@ -734,6 +735,8 @@ def to_sql(
         When true, have each block append itself to the DB table concurrently. This can result in DB rows being in a
         different order than the source DataFrame's corresponding rows. When false, load each block into the SQL DB in
         sequence.
+    engine_kwargs : dict or None
+        Specific db engine parameters for sqlalchemy
 
     Raises
     ------
@@ -786,13 +789,18 @@ def to_sql(
     >>> result
     [(0, 0, '00'), (1, 1, '11'), (2, 2, '22'), (3, 3, '33')]
     """
+    import sqlalchemy as sa
+
     if not isinstance(uri, str):
         raise ValueError(f"Expected URI to be a string, got {type(uri)}.")
+
+    engine_kwargs = {} if engine_kwargs is None else engine_kwargs
+    engine = sa.create_engine(uri, **engine_kwargs)
 
     # This is the only argument we add on top of what Pandas supports
     kwargs = dict(
         name=name,
-        con=uri,
+        con=engine,
         schema=schema,
         if_exists=if_exists,
         index=index,

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -555,8 +555,17 @@ def test_to_sql_kwargs():
 
 
 def test_to_sql_engine_kwargs(caplog):
-    ddf = dd.from_pandas(df, 1)
+    ddf = dd.from_pandas(df, 2)
+    with tmp_db_uri() as uri:
+        ddf.to_sql("test", uri, engine_kwargs={"echo": False})
+        logs = "\n".join(r.message for r in caplog.records)
+        assert logs == ""
+        assert_eq(df, read_sql_table("test", uri, "number"))
+
     with tmp_db_uri() as uri:
         ddf.to_sql("test", uri, engine_kwargs={"echo": True})
         logs = "\n".join(r.message for r in caplog.records)
         assert "CREATE" in logs
+        assert "INSERT" in logs
+
+        assert_eq(df, read_sql_table("test", uri, "number"))

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -552,3 +552,11 @@ def test_to_sql_kwargs():
             TypeError, match="to_sql\\(\\) got an unexpected keyword argument 'unknown'"
         ):
             ddf.to_sql("test", uri, unknown=None)
+
+
+def test_to_sql_engine_kwargs(capsys):
+    ddf = dd.from_pandas(df, 1)
+    with tmp_db_uri() as uri:
+        ddf.to_sql("test", uri, engine_kwargs={"echo": True})
+        out, err = capsys.readouterr()
+        assert "CREATE" in out


### PR DESCRIPTION
- [x] Closes #8596 
- [x] Closes #8622
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

### What's tested

A new test case covers `to_sql(..., engine_kwargs=...)` using `echo=True` as the engine argument.

### Use case: SSL

This was the original [use case] that motivated #8596: to force SSL on the db connection. Whether the new `engine_kwargs` argument is helpful/necessary for this use case depends on the db driver used by SQLAlchemy:

* [MySQL] (helpful): either use `connect_args={'ssl': ...}` as engine kwarg or add `?ssl_cert=...&ssl_key=...` to URI.
* [psycopg2] (not helpful): must use `?sslmode=require` in connection URI, not supported as engine argument.
* [pg8000] (necessary): must use `connect_args={'ssl_context': ...}` as engine kwarg.

[use case]: https://github.com/coiled/dask-community/issues/186
[MySQL]: https://docs.sqlalchemy.org/en/14/dialects/mysql.html#ssl-connections
[psycopg2]: https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#ssl-connections
[pg8000]: https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#pg8000-ssl