### PR TITLE
Pandas compat: Filter sparse warnings

### DIFF
--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -86,6 +86,9 @@ def test_get_dummies_kwargs():
     tm.assert_index_equal(res.columns, pd.Index([1, 2, 3, 5, np.nan]))
 
 
+@pytest.mark.filterwarnings(
+    "ignore::FutureWarning"
+)  # https://github.com/pandas-dev/pandas/issues/45618
 def test_get_dummies_sparse():
     s = pd.Series(pd.Categorical(["a", "b", "a"], categories=["a", "b", "c"]))
     ds = dd.from_pandas(s, 2)
@@ -103,6 +106,9 @@ def test_get_dummies_sparse():
     assert pd.api.types.is_sparse(res.a_a.compute())
 
 
+@pytest.mark.filterwarnings(
+    "ignore::FutureWarning"
+)  # https://github.com/pandas-dev/pandas/issues/45618
 def test_get_dummies_sparse_mix():
     df = pd.DataFrame(
         {

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -87,7 +87,7 @@ def test_get_dummies_kwargs():
 
 
 @pytest.mark.filterwarnings(
-    "ignore::FutureWarning"
+    "ignore:In a future version, passing a SparseArray:FutureWarning"
 )  # https://github.com/pandas-dev/pandas/issues/45618
 def test_get_dummies_sparse():
     s = pd.Series(pd.Categorical(["a", "b", "a"], categories=["a", "b", "c"]))
@@ -107,7 +107,7 @@ def test_get_dummies_sparse():
 
 
 @pytest.mark.filterwarnings(
-    "ignore::FutureWarning"
+    "ignore:In a future version, passing a SparseArray:FutureWarning"
 )  # https://github.com/pandas-dev/pandas/issues/45618
 def test_get_dummies_sparse_mix():
     df = pd.DataFrame(


### PR DESCRIPTION
I think these warnings should not be cropping up from pandas, so this PR just filters them out. 