### PR TITLE
Cleaning up misc tests for pandas compat

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1500,10 +1500,12 @@ Dask Name: {name}, {task} tasks"""
 
     @derived_from(pd.DataFrame)
     def replace(self, to_replace=None, value=None, regex=False):
+        # In PANDAS_GT_140 pandas starts using no_default instead of None
+        value_kwarg = {"value": value} if value is not None else {}
         return self.map_partitions(
             M.replace,
             to_replace=to_replace,
-            value=value,
+            **value_kwarg,
             regex=regex,
             enforce_metadata=False,
         )
@@ -1970,6 +1972,7 @@ Dask Name: {name}, {task} tasks"""
             chunk_kwargs={"dropna": dropna},
             aggregate_kwargs={"dropna": dropna},
         )
+        mode_series.name = self.name
         return mode_series
 
     @_numeric_only
@@ -5181,7 +5184,6 @@ class DataFrame(_Frame):
             mode_series = Series.mode(
                 col_series, dropna=dropna, split_every=split_every
             )
-            mode_series.name = col_series.name
             mode_series_list.append(mode_series)
 
         name = "concat-" + tokenize(*mode_series_list)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -16,7 +16,7 @@ import dask.dataframe.groupby
 from dask.base import compute_as_if_collection
 from dask.blockwise import fuse_roots
 from dask.dataframe import _compat, methods
-from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_120, tm
+from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_120, PANDAS_GT_140, tm
 from dask.dataframe.core import (
     Scalar,
     _concat,
@@ -4174,7 +4174,8 @@ def test_dataframe_mode():
     ddf = dd.from_pandas(df, npartitions=3)
 
     assert_eq(ddf.mode(), df.mode())
-    assert_eq(ddf.Name.mode(), df.Name.mode())
+    # name is not preserved in older pandas
+    assert_eq(ddf.Name.mode(), df.Name.mode(), check_names=PANDAS_GT_140)
 
     # test empty
     df = pd.DataFrame(columns=["a", "b"])

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -59,14 +59,10 @@ def test_get_dummies_kwargs():
     ds = dd.from_pandas(s, 2)
     res = dd.get_dummies(ds, prefix="X", prefix_sep="-")
     assert_eq(res, exp)
-    tm.assert_index_equal(res.columns, pd.Index(["X-1", "X-2", "X-3", "X-4"]))
 
     exp = pd.get_dummies(s, drop_first=True)
-
-    ds = dd.from_pandas(s, 2)
     res = dd.get_dummies(ds, drop_first=True)
     assert_eq(res, exp)
-    tm.assert_index_equal(res.columns, exp.columns)
 
     # nan
     s = pd.Series([1, 1, 1, 2, np.nan, 3, np.nan, 5], dtype="category")
@@ -75,15 +71,11 @@ def test_get_dummies_kwargs():
     ds = dd.from_pandas(s, 2)
     res = dd.get_dummies(ds)
     assert_eq(res, exp)
-    tm.assert_index_equal(res.columns, exp.columns)
 
     # dummy_na
     exp = pd.get_dummies(s, dummy_na=True)
-
-    ds = dd.from_pandas(s, 2)
     res = dd.get_dummies(ds, dummy_na=True)
     assert_eq(res, exp)
-    tm.assert_index_equal(res.columns, pd.Index([1, 2, 3, 5, np.nan]))
 
 
 @pytest.mark.filterwarnings(


### PR DESCRIPTION
This fixes:
- dask/dataframe/tests/test_dataframe.py::test_replace
- dask/dataframe/tests/test_dataframe.py::test_dataframe_mode
- dask/dataframe/tests/test_reshape.py::test_get_dummies_kwargs

