### PR TITLE
Downgrade `meta` error in #8563 to warning

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6052,16 +6052,16 @@ def map_partitions(
         graph = HighLevelGraph.from_collections(name, layer, dependencies=args)
         return Scalar(graph, name, meta)
     elif not (has_parallel_type(meta) or is_arraylike(meta) and meta.shape):
-        if meta_is_emulated:
-            # If `meta` is not a pandas object, the concatenated results will be a
-            # different type
-            meta = make_meta(_concat([meta]), index=meta_index)
-        else:
-            raise ValueError(
+        if not meta_is_emulated:
+            warnings.warn(
                 "Meta is not valid, `map_partitions` expects output to be a pandas object. "
                 "Try passing a pandas object as meta or a dict or tuple representing the "
-                "(name, dtype) of the columns."
+                "(name, dtype) of the columns. In the future the meta you passed will not work.",
+                FutureWarning,
             )
+        # If `meta` is not a pandas object, the concatenated results will be a
+        # different type
+        meta = make_meta(_concat([meta]), index=meta_index)
 
     # Ensure meta is empty series
     meta = make_meta(meta, parent_meta=parent_meta)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3005,13 +3005,13 @@ def test_apply_warns():
     assert "int64" in str(w[0].message)
 
 
-def test_apply_fails_with_invalid_meta():
+def test_apply_warns_with_invalid_meta():
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})
     ddf = dd.from_pandas(df, npartitions=2)
 
     func = lambda row: row["x"] + row["y"]
 
-    with pytest.raises(ValueError, match="Meta is not valid"):
+    with pytest.warns(FutureWarning, match="Meta is not valid"):
         ddf.apply(func, axis=1, meta=int)
 
 


### PR DESCRIPTION
Since there was a test on distributed that used dtype as a meta and since there has already been an issue raised, let's walk this back to a warning and do a deprecation cycle.