### PR TITLE
Apply eager predicate-pushdown optimizations in Dask-DataFrame

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -57,7 +57,7 @@ from .dispatch import (
     hash_object_dispatch,
     meta_nonempty,
 )
-from .optimize import optimize
+from .optimize import eager_predicate_pushdown, optimize
 from .utils import (
     PANDAS_GT_110,
     PANDAS_GT_120,
@@ -4225,7 +4225,10 @@ class DataFrame(_Frame):
                 self, key = _maybe_align_partitions([self, key])
             dsk = partitionwise_graph(operator.getitem, name, self, key)
             graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self, key])
-            return new_dd_object(graph, name, self, self.divisions)
+            # TODO: Add/Check predicate-pushdown config option
+            return eager_predicate_pushdown(
+                new_dd_object(graph, name, self, self.divisions)
+            )
         if isinstance(key, DataFrame):
             return self.where(key, np.nan)
 

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -94,7 +94,7 @@ def eager_predicate_pushdown(ddf):
     dependencies = dsk.dependencies.copy()
     dependents = dsk.dependents.copy()
     old = layers[io_layer_name]
-    creation_info_kwargs = getattr(old, "creation_info", None).get(
+    creation_info_kwargs = (getattr(old, "creation_info", None) or {}).get(
         "kwargs", {"filters": True}
     ) or {"filters": True}
     if creation_info_kwargs.get("filters", True) is not None:


### PR DESCRIPTION
**WARNING**: This PR is still rough and requires cleanup.

This PR adds a new `eager_predicate_pushdown` function to `dask.dataframe.optimize`. What is special about this optimization (when compared to other "graph" optimizations like `optimize_dataframe_getitem`), is that the optimization   is designed for eager execution on a `DataFrame` collection from within the `dask.dataframe` API.  In contrast to column projection, predicate pushdown can completely change the number of partitions and `divisions` in the underlying DataFrame collection.  This means we cannot simply wait until the full graph is generated untile predicate pushdown is applied - We must do it immediately when a simple comparison (like `ddf[ddf["x"] == 1]`) is performed.

In the future, an expanded HighLevelGraph (or high-level expression) system may make it possible to regenerate a full graph. However, until then, eager optimization is likely the only reliable approach.

TODO:

- [ ] General cleanup
- [ ] Allow for user configuration
- [ ] Try to expand the complexity of supported filters
