### PR TITLE
Avoid invalid metadata emulation in DataFrame ACA

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5893,6 +5893,14 @@ def apply_concat_apply(
             split_out_setup_kwargs,
             ignore_index,
             token="split-%s" % token_key,
+            # We are not generating a valid
+            # DataFrame object here, so we want
+            # to avoid emulation by passing
+            # `chunked._meta` explicitly.
+            # Emulation is also a problem for
+            # non-empty geopandas metadata. (See
+            # https://github.com/dask/dask/issues/8611)
+            meta=chunked._meta,
             enforce_metadata=False,
             transform_divisions=False,
             align_dataframes=False,


### PR DESCRIPTION
This PR makes a minor change to the `apply_concat_apply` (ACA) implementation for the case that `split_out>1`. The PR does not include a test, because I am having trouble creating a reproducer that won't add unnecessary confusion to the test suite. For now, I only left a comment to explain why the `meta=` argument **must** be specified for the sharding phase of ACA.

After #8468, both the initial chunkwise logic and the following sharding (`hash_shard`) logic have been rewritten as `map_partition` operations. This change is good, because it enables task fusion at the `HighLevelGraph` (HLG) level with preceeding blockwise operations (which are common). However, using `map_partitions` for the sharding logic is technically "invalid", because the output of each partition is not a DataFrame object (but a dictionary of DataFrame objects). For geopandas, the more-important problem is that the input to the sharding operation is already invalid, because the column names have changed (which is not always allowed in geopandas).

My proposal for a simple fix is to explicitly pass in `meta=chunked._meta` for the partition-wise `hash_shard` operation. Although this metadata does not technically match the sharding output, it avoids problematic metadata emulation within the `map_partitions` call.  Also, this approach should be "safe," because the output of this layer will always be consumed by tree-reduction logic (and will never be used to produce a public DataFrame collection).

**Possible alternative**: Add option to avoid nonempty metadata emulation in `map_partitions` (see [this branch](https://github.com/rjzamora/dask/tree/empty-meta-emulation)).

- [ ] Closes #8611
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
