### PR TITLE
Pass place-holder metadata to map_partitions in ACA code path

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5878,6 +5878,11 @@ def apply_concat_apply(
         chunk,
         *args,
         token=chunk_name,
+        # NOTE: We are NOT setting the correct
+        # `meta` here on purpose. We are using
+        # `map_partitions` as a convenient way
+        # to build a `Blockwise` layer, and need
+        # to avoid the metadata emulation step.
         meta=dfs[0],
         enforce_metadata=False,
         transform_divisions=False,
@@ -5894,6 +5899,11 @@ def apply_concat_apply(
             split_out_setup_kwargs,
             ignore_index,
             token="split-%s" % token_key,
+            # NOTE: We are NOT setting the correct
+            # `meta` here on purpose. We are using
+            # `map_partitions` as a convenient way
+            # to build a `Blockwise` layer, and need
+            # to avoid the metadata emulation step.
             meta=dfs[0],
             enforce_metadata=False,
             transform_divisions=False,

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5874,37 +5874,37 @@ def apply_concat_apply(
 
     # Blockwise Chunk Layer
     chunk_name = f"{token or funcname(chunk)}-chunk-{token_key}"
-    chunked = map_partitions(
-        chunk,
-        *args,
-        token=chunk_name,
-        enforce_metadata=False,
-        transform_divisions=False,
-        align_dataframes=False,
-        **chunk_kwargs,
+    graph = HighLevelGraph.from_collections(
+        chunk_name,
+        partitionwise_graph(
+            chunk,
+            chunk_name,
+            *args,
+            **chunk_kwargs,
+        ),
+        dependencies=dfs,
     )
+    layers = graph.layers.copy()
+    dependencies = graph.dependencies.copy()
+    last_name = chunk_name
 
     # Blockwise Split Layer
     if split_out and split_out > 1:
-        chunked = chunked.map_partitions(
+        split_name = "split-%s" % token_key
+        layers[split_name] = blockwise(
             hash_shard,
-            split_out,
-            split_out_setup,
-            split_out_setup_kwargs,
-            ignore_index,
-            token="split-%s" % token_key,
-            # We are not generating a valid
-            # DataFrame object here, so we want
-            # to avoid emulation by passing
-            # `chunked._meta` explicitly.
-            # Emulation is also a problem for
-            # non-empty geopandas metadata. (See
-            # https://github.com/dask/dask/issues/8611)
-            meta=chunked._meta,
-            enforce_metadata=False,
-            transform_divisions=False,
-            align_dataframes=False,
+            split_name,
+            "i",
+            *(last_name, "i"),
+            *(split_out, None),
+            numblocks={last_name: (npartitions,)},
+            concatenate=True,
+            split_out_setup=split_out_setup,
+            split_out_setup_kwargs=split_out_setup_kwargs,
+            ignore_index=ignore_index,
         )
+        dependencies[split_name] = {last_name}
+        last_name = split_name
 
     # Handle sort behavior
     if sort is not None:
@@ -5918,9 +5918,9 @@ def apply_concat_apply(
 
     # Tree-Reduction Layer
     final_name = f"{token or funcname(aggregate)}-agg-{token_key}"
-    layer = DataFrameTreeReduction(
+    layers[final_name] = DataFrameTreeReduction(
         final_name,
-        chunked._name,
+        last_name,
         npartitions,
         partial(_concat, ignore_index=ignore_index),
         partial(combine, **combine_kwargs) if combine_kwargs else combine,
@@ -5931,6 +5931,7 @@ def apply_concat_apply(
         split_out=split_out if (split_out and split_out > 1) else None,
         tree_node_name=f"{token or funcname(combine)}-combine-{token_key}",
     )
+    dependencies[final_name] = {last_name}
 
     if meta is no_default:
         meta_chunk = _emulate(chunk, *args, udf=True, **chunk_kwargs)
@@ -5943,7 +5944,7 @@ def apply_concat_apply(
         parent_meta=dfs[0]._meta,
     )
 
-    graph = HighLevelGraph.from_collections(final_name, layer, dependencies=(chunked,))
+    graph = HighLevelGraph(layers, dependencies)
     divisions = [None] * ((split_out or 1) + 1)
     return new_dd_object(graph, final_name, meta, divisions, parent_meta=dfs[0]._meta)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5893,6 +5893,14 @@ def apply_concat_apply(
             split_out_setup_kwargs,
             ignore_index,
             token="split-%s" % token_key,
+            # We are not generating a valid
+            # DataFrame object here, so we want
+            # to avoid emulation by passing
+            # `chunked._meta` explicitly.
+            # Emulation is also a problem for
+            # non-empty geopandas metadata. (See
+            # https://github.com/dask/dask/issues/8611)
+            meta=chunked._meta,
             enforce_metadata=False,
             transform_divisions=False,
             align_dataframes=False,


### PR DESCRIPTION
The introduction of `map_partitions` into ACA in #8468 was very convenient, but does not seem to work for all cases covered by ACA.  This PR revises the change in that PR to ~use the lower-level `partitionwise_graph` and `blockwise` APIs~ always define the `meta` argument to `map_partitions` (even though it is not the "correct" metadata) to avoid any "metadata emulation" logic within.

- [x] Closes #8636
- [x] Closes #8611
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @gjoseph92 (In case you have other suggestions)