### PR TITLE
Make `test__get_paths` robust to `site.PREFIXES` being set

### DIFF
--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -506,11 +506,12 @@ def test_config_inheritance():
 
 
 def test__get_paths(monkeypatch):
-    # These environment variables are used by Dask's config system.
-    # We temporarily remove them to avoid interference from the
-    # machine where tests are being run.
+    # These settings are used by Dask's config system. We temporarily
+    # remove them to avoid interference from the machine where tests
+    # are being run.
     monkeypatch.delenv("DASK_CONFIG", raising=False)
     monkeypatch.delenv("DASK_ROOT_CONFIG", raising=False)
+    monkeypatch.setattr(site, "PREFIXES", [])
 
     expected = [
         "/etc/dask",


### PR DESCRIPTION
This ensures `test__get_paths` passes, regardless of what `site.PREFIXES` is set to on the machine that's running the test

- [x] Closes https://github.com/dask/dask/issues/8639
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
