### PR TITLE
Deprecate `is_monotonic`

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -13,6 +13,10 @@ PANDAS_GT_130 = PANDAS_VERSION >= parse_version("1.3.0")
 PANDAS_GT_131 = PANDAS_VERSION >= parse_version("1.3.1")
 PANDAS_GT_133 = PANDAS_VERSION >= parse_version("1.3.3")
 PANDAS_GT_140 = PANDAS_VERSION >= parse_version("1.4.0")
+# FIXME: Using `.release` below as versions like `1.5.0.dev0+268.gbe8d1ec880`
+# are less than `1.5.0` with `packaging.version`. Update to use `parse_version("1.5.0")`
+# below once `pandas=1.5.0` is released
+PANDAS_GT_150 = PANDAS_VERSION.release >= (1, 5, 0)
 
 import pandas.testing as tm
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -48,7 +48,7 @@ from ..utils import (
 )
 from ..widgets import get_template
 from . import methods
-from ._compat import PANDAS_GT_140
+from ._compat import PANDAS_GT_140, PANDAS_GT_150
 from .accessor import DatetimeAccessor, StringAccessor
 from .categorical import CategoricalAccessor, categorize
 from .dispatch import (
@@ -3829,6 +3829,12 @@ Dask Name: {name}, {task} tasks""".format(
     @property
     @derived_from(pd.Series)
     def is_monotonic(self):
+        if PANDAS_GT_150:
+            warnings.warn(
+                "is_monotonic is deprecated and will be removed in a future version. "
+                "Use is_monotonic_increasing instead.",
+                FutureWarning,
+            )
         return self.is_monotonic_increasing
 
     @property
@@ -4041,6 +4047,12 @@ class Index(Series):
     @property
     @derived_from(pd.Index)
     def is_monotonic(self):
+        if PANDAS_GT_150:
+            warnings.warn(
+                "is_monotonic is deprecated and will be removed in a future version. "
+                "Use is_monotonic_increasing instead.",
+                FutureWarning,
+            )
         return super().is_monotonic_increasing
 
     @property

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -101,7 +101,7 @@ def boundary_slice(df, start, stop, right_boundary=True, left_boundary=True, kin
         kind = kind or "loc"
         kind_opts = {"kind": kind}
 
-    if kind == "loc" and not df.index.is_monotonic:
+    if kind == "loc" and not df.index.is_monotonic_increasing:
         # Pandas treats missing keys differently for label-slicing
         # on monotonic vs. non-monotonic indexes
         # If the index is monotonic, `df.loc[start:stop]` is fine.

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,3 +1,4 @@
+import contextlib
 import warnings
 import weakref
 import xml.etree.ElementTree
@@ -16,7 +17,13 @@ import dask.dataframe.groupby
 from dask.base import compute_as_if_collection
 from dask.blockwise import fuse_roots
 from dask.dataframe import _compat, methods
-from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_120, PANDAS_GT_140, tm
+from dask.dataframe._compat import (
+    PANDAS_GT_110,
+    PANDAS_GT_120,
+    PANDAS_GT_140,
+    PANDAS_GT_150,
+    tm,
+)
 from dask.dataframe.core import (
     Scalar,
     _concat,
@@ -5002,11 +5009,26 @@ def test_use_of_weakref_proxy():
     isinstance(res.compute(), pd.Series)
 
 
+@contextlib.contextmanager
+def check_is_monotonic_warning():
+    # `is_monotonic` was deprecated starting in `pandas=1.5.0`
+    if not PANDAS_GT_150:
+        with contextlib.nullcontext() as ctx:
+            yield ctx
+    else:
+        with pytest.warns(FutureWarning, match="is_monotonic is deprecated") as ctx:
+            yield ctx
+
+
 def test_is_monotonic_numeric():
     s = pd.Series(range(20))
     ds = dd.from_pandas(s, npartitions=5)
     assert_eq(s.is_monotonic_increasing, ds.is_monotonic_increasing)
-    assert_eq(s.is_monotonic, ds.is_monotonic)
+    with check_is_monotonic_warning():
+        expected = s.is_monotonic
+    with check_is_monotonic_warning():
+        result = ds.is_monotonic
+    assert_eq(expected, result)
 
     s_2 = pd.Series(range(20, 0, -1))
     ds_2 = dd.from_pandas(s_2, npartitions=5)
@@ -5032,7 +5054,11 @@ def test_index_is_monotonic_numeric():
     s = pd.Series(1, index=range(20))
     ds = dd.from_pandas(s, npartitions=5, sort=False)
     assert_eq(s.index.is_monotonic_increasing, ds.index.is_monotonic_increasing)
-    assert_eq(s.index.is_monotonic, ds.index.is_monotonic)
+    with check_is_monotonic_warning():
+        expected = s.index.is_monotonic
+    with check_is_monotonic_warning():
+        result = ds.index.is_monotonic
+    assert_eq(expected, result)
 
     s_2 = pd.Series(1, index=range(20, 0, -1))
     ds_2 = dd.from_pandas(s_2, npartitions=5, sort=False)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -588,7 +588,7 @@ def test_set_index_sorts():
         dfs.append(pd.DataFrame({"timestamp": vals[lo:hi]}, index=range(lo, hi)))
 
     ddf = dd.concat(dfs).clear_divisions()
-    assert ddf.set_index("timestamp").index.compute().is_monotonic is True
+    assert ddf.set_index("timestamp").index.compute().is_monotonic_increasing is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR deprecates `is_monotonic` to follow what `pandas` is doing upstream. This also resolves some test failures in our `upstream` build

cc @jsignell

EDIT: xref https://github.com/pandas-dev/pandas/pull/45422