### PR TITLE
Update `tokenize` to treat `dict` and `kwargs` differently

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -850,9 +850,10 @@ def tokenize(*args, **kwargs):
     >>> tokenize('Hello') == tokenize('Hello')
     True
     """
+    token = str(tuple(map(normalize_token, args)))
     if kwargs:
-        args = args + (kwargs,)
-    return md5(str(tuple(map(normalize_token, args))).encode()).hexdigest()
+        token += str(tuple(map(normalize_token, (kwargs,))))
+    return md5(token.encode()).hexdigest()
 
 
 normalize_token = Dispatch()

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -338,6 +338,7 @@ def test_tokenize_kwargs():
     assert tokenize(5) != tokenize(5, x=1)
     assert tokenize(5, x=1) != tokenize(5, x=2)
     assert tokenize(5, x=1) != tokenize(5, y=1)
+    assert tokenize(5, foo="bar") != tokenize(5, {"foo": "bar"})
 
 
 def test_tokenize_same_repr():


### PR DESCRIPTION
This ensures, for example, `tokenize(5, foo="bar")` and `tokenize(5, {"foo": "bar"})` yield different hashes.

cc @graingert

- [x] Closes https://github.com/dask/dask/issues/8632
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
