### PR TITLE
Add Groupby.rank for DataFrame and Series GroupBy

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1918,7 +1918,7 @@ class _GroupBy:
         )
         return result
 
-    @insert_meta_param_description(pad=12)
+    @derived_from(pd.core.groupby.DataFrameGroupBy)
     def rank(
         self,
         method="average",
@@ -1928,26 +1928,7 @@ class _GroupBy:
         axis=0,
         meta=no_default,
     ):
-        """Parallel version of pandas GroupBy.rank
-
-        This mimics the pandas version except for the following:
-
-        If the grouper does not align with the index then this causes a full
-        shuffle.  The order of rows within each group may not be preserved.
-
-        Parameters
-        ----------
-        method : {‘average’, ‘min’, ‘max’, ‘first’, ‘dense’}, default ‘average’
-        ascending : bool, default True
-        na_option: {‘keep’, ‘top’, ‘bottom’}, default ‘keep’
-        pct: bool, default False
-        axis : int, default 0
-        $META
-
-        Returns
-        -------
-        ranked : Series or DataFrame with ranking of values within each group.
-
+        """
         Examples
         --------
         >>> import dask

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1917,9 +1917,17 @@ class _GroupBy:
             **self.dropna,
         )
         return result
-    
+
     @insert_meta_param_description(pad=12)
-    def rank(self, method='average', ascending=True, na_option='keep', pct=False, axis=0, meta=no_default):
+    def rank(
+        self,
+        method="average",
+        ascending=True,
+        na_option="keep",
+        pct=False,
+        axis=0,
+        meta=no_default,
+    ):
         """Parallel version of pandas GroupBy.rank
 
         This mimics the pandas version except for the following:

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1929,14 +1929,11 @@ class _GroupBy:
 
         Parameters
         ----------
-        method : Delayed, Scalar or int, default 1
-            Number of periods to shift.
-        ascending : Delayed, Scalar or str, optional
-            Frequency string.
-        na_option:
-        pct:
-        axis : axis to shift, default 0
-            Shift direction.
+        method : {‘average’, ‘min’, ‘max’, ‘first’, ‘dense’}, default ‘average’
+        ascending : bool, default True
+        na_option: {‘keep’, ‘top’, ‘bottom’}, default ‘keep’
+        pct: bool, default False
+        axis : int, default 0
         $META
 
         Returns
@@ -1947,7 +1944,7 @@ class _GroupBy:
         --------
         >>> import dask
         >>> ddf = dask.datasets.timeseries(freq="1H")
-        >>> result = ddf.rank("name").shift(1, meta={"id": int, "x": float, "y": float})
+        >>> result = ddf.groupby("name").rank(method="average", meta={"id": int, "x": float, "y": float})
         """
         if meta is no_default:
             with raise_on_meta_error("groupby.rank()", udf=False):

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2225,6 +2225,7 @@ def test_groupby_rank_series(npartitions, method, pct):
         {
             "a": [0, 0, 1, 1, 2, 2, 3, 3, 3],
             "b": [4, 5, 6, 3, 2, 1, 0, 0, 0],
+            "c": ["a", "a", "b", "b", "b", "c", "c", "b", "a"],
         },
     )
     ddf = dd.from_pandas(pdf, npartitions=3)
@@ -2232,6 +2233,13 @@ def test_groupby_rank_series(npartitions, method, pct):
         assert_eq(
             pdf.groupby("a")["b"].rank(method, pct=pct),
             ddf.groupby("a")["b"].rank(method, pct=pct),
+        )
+
+    # string
+    with pytest.warns(UserWarning):
+        assert_eq(
+            pdf.groupby("a")["c"].rank(method, pct=pct),
+            ddf.groupby("a")["c"].rank(method, pct=pct),
         )
 
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2156,28 +2156,64 @@ def test_groupby_shift_with_freq():
 @pytest.mark.parametrize("axis", [0, 1])
 def test_groupby_rank_dataframe(npartitions, method, ascending, na_option, pct, axis):
     pdf = pd.DataFrame(
-    {
-        "a": [0, 0, 1, 1, 2, 2, 3, 3, 3],
-        "b": [4, 4, 6, 3, 2, 1, None, 0, 0],
-        "c": [0, 0, 0, 0, 0, 1, 1, 1, 1],
-    },
-)
+        {
+            "a": [0, 0, 1, 1, 2, 2, 3, 3, 3],
+            "b": [4, 4, 6, 3, 2, 1, None, 0, 0],
+            "c": [0, 0, 0, 0, 0, 1, 1, 1, 1],
+        },
+    )
     ddf = dd.from_pandas(pdf, npartitions=npartitions)
 
     with pytest.warns(UserWarning):
         assert_eq(
-            pdf.groupby(["a", "c"]).rank(method=method, ascending=ascending, na_option=na_option, pct=pct, axis=axis),
-            ddf.groupby(["a", "c"]).rank(method=method, ascending=ascending, na_option=na_option, pct=pct, axis=axis),
+            pdf.groupby(["a", "c"]).rank(
+                method=method,
+                ascending=ascending,
+                na_option=na_option,
+                pct=pct,
+                axis=axis,
+            ),
+            ddf.groupby(["a", "c"]).rank(
+                method=method,
+                ascending=ascending,
+                na_option=na_option,
+                pct=pct,
+                axis=axis,
+            ),
         )
     with pytest.warns(UserWarning):
         assert_eq(
-            pdf.groupby(["a"]).rank(method=method, ascending=ascending, na_option=na_option, pct=pct, axis=axis),
-            ddf.groupby(["a"]).rank(method=method, ascending=ascending, na_option=na_option, pct=pct, axis=axis),
+            pdf.groupby(["a"]).rank(
+                method=method,
+                ascending=ascending,
+                na_option=na_option,
+                pct=pct,
+                axis=axis,
+            ),
+            ddf.groupby(["a"]).rank(
+                method=method,
+                ascending=ascending,
+                na_option=na_option,
+                pct=pct,
+                axis=axis,
+            ),
         )
     with pytest.warns(UserWarning):
         assert_eq(
-            pdf.groupby(pdf.c).rank(method=method, ascending=ascending, na_option=na_option, pct=pct, axis=axis),
-            ddf.groupby(ddf.c).rank(method=method, ascending=ascending, na_option=na_option, pct=pct, axis=axis),
+            pdf.groupby(pdf.c).rank(
+                method=method,
+                ascending=ascending,
+                na_option=na_option,
+                pct=pct,
+                axis=axis,
+            ),
+            ddf.groupby(ddf.c).rank(
+                method=method,
+                ascending=ascending,
+                na_option=na_option,
+                pct=pct,
+                axis=axis,
+            ),
         )
 
 


### PR DESCRIPTION
This PR implements `{Series, DataFrame}.groupby.rank` based on the same hash partition pattern used by `groupby.{shift, transform, apply}`.

- [x] Closes #8658
- [x] Tests added / passed (locally)
- [x] Passes `pre-commit run --all-files` (locally)

Quick question: It seems like there is a fair bit of duplication of semantics in the various `_groupby_slice_*` functions. Perhaps some of this could be refactored into an internal utility? If desired, please let me know.
