### PR TITLE
Deprecate `iteritems`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3425,9 +3425,22 @@ Dask Name: {name}, {task} tasks""".format(
 
     @derived_from(pd.Series)
     def iteritems(self):
-        for i in range(self.npartitions):
-            s = self.get_partition(i).compute()
-            yield from s.iteritems()
+        if PANDAS_GT_150:
+            warnings.warn(
+                "iteritems is deprecated and will be removed in a future version. "
+                "Use .items instead.",
+                FutureWarning,
+            )
+        # We use the `_` generator below to ensure the deprecation warning above
+        # is raised when `.iteritems()` is called, not when the first `next(<generator>)`
+        # iteration happens
+
+        def _(self):
+            for i in range(self.npartitions):
+                s = self.get_partition(i).compute()
+                yield from s.items()
+
+        return _(self)
 
     @derived_from(pd.Series)
     def __iter__(self):
@@ -5312,8 +5325,7 @@ class DataFrame(_Frame):
 
         lines.extend(column_info)
         dtype_counts = [
-            "%s(%d)" % k
-            for k in sorted(self.dtypes.value_counts().iteritems(), key=str)
+            "%s(%d)" % k for k in sorted(self.dtypes.value_counts().items(), key=str)
         ]
         lines.append("dtypes: {}".format(", ".join(dtype_counts)))
 
@@ -5438,7 +5450,7 @@ class DataFrame(_Frame):
             series_df = pd.DataFrame([[]] * len(index), columns=cols, index=index)
         else:
             series_df = pd.concat(
-                [_repr_data_series(s, index=index) for _, s in meta.iteritems()], axis=1
+                [_repr_data_series(s, index=index) for _, s in meta.items()], axis=1
             )
         return series_df
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -510,7 +510,7 @@ def _df_to_bag(df, index=False, format="tuple"):
                 return df.to_dict(orient="records")
     elif isinstance(df, pd.Series):
         if format == "tuple":
-            return list(df.iteritems()) if index else list(df)
+            return list(df.items()) if index else list(df)
         elif format == "dict":
             return df.to_frame().to_dict(orient="records")
 

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -650,7 +650,7 @@ class ArrowDatasetEngine(Engine):
                 # TODO Coerce values for compatible but different dtypes
                 raise ValueError(
                     "Appended dtypes differ.\n{}".format(
-                        set(dtypes.items()) ^ set(df.dtypes.iteritems())
+                        set(dtypes.items()) ^ set(df.dtypes.items())
                     )
                 )
 

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -1181,7 +1181,7 @@ class FastParquetEngine(Engine):
             elif (pd.Series(pf.dtypes).loc[pf.columns] != df[pf.columns].dtypes).any():
                 raise ValueError(
                     "Appended dtypes differ.\n{}".format(
-                        set(pf.dtypes.items()) ^ set(df.dtypes.iteritems())
+                        set(pf.dtypes.items()) ^ set(df.dtypes.items())
                     )
                 )
             else:

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -524,7 +524,7 @@ def test_to_bag():
         {"index": 3.0, "x": "c", "y": 4},
         {"index": 4.0, "x": "d", "y": 5},
     ]
-    assert ddf.x.to_bag(True).compute() == list(a.x.iteritems())
+    assert ddf.x.to_bag(True).compute() == list(a.x.items())
     assert ddf.x.to_bag().compute() == list(a.x)
 
     assert ddf.x.to_bag(True, format="dict").compute() == [

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,4 +1,3 @@
-import contextlib
 import warnings
 import weakref
 import xml.etree.ElementTree
@@ -37,7 +36,7 @@ from dask.dataframe.core import (
 from dask.dataframe.utils import assert_eq, assert_max_deps, make_meta
 from dask.datasets import timeseries
 from dask.utils import M, is_dataframe_like, is_series_like, put_lines
-from dask.utils_test import hlg_layer
+from dask.utils_test import _check_warning, hlg_layer
 
 dsk = {
     ("x", 0): pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=[0, 1, 3]),
@@ -3369,7 +3368,16 @@ def test_contains_series_raises_deprecated_warning_preserves_behavior():
 def test_series_iteritems():
     df = pd.DataFrame({"x": [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)
-    for (a, b) in zip(df["x"].iteritems(), ddf["x"].iteritems()):
+    # `iteritems` was deprecated starting in `pandas=1.5.0`
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"
+    ):
+        pd_items = df["x"].iteritems()
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"
+    ):
+        dd_items = ddf["x"].iteritems()
+    for (a, b) in zip(pd_items, dd_items):
         assert a == b
 
 
@@ -5009,24 +5017,18 @@ def test_use_of_weakref_proxy():
     isinstance(res.compute(), pd.Series)
 
 
-@contextlib.contextmanager
-def check_is_monotonic_warning():
-    # `is_monotonic` was deprecated starting in `pandas=1.5.0`
-    if not PANDAS_GT_150:
-        with contextlib.nullcontext() as ctx:
-            yield ctx
-    else:
-        with pytest.warns(FutureWarning, match="is_monotonic is deprecated") as ctx:
-            yield ctx
-
-
 def test_is_monotonic_numeric():
     s = pd.Series(range(20))
     ds = dd.from_pandas(s, npartitions=5)
     assert_eq(s.is_monotonic_increasing, ds.is_monotonic_increasing)
-    with check_is_monotonic_warning():
+    # `is_monotonic` was deprecated starting in `pandas=1.5.0`
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         expected = s.is_monotonic
-    with check_is_monotonic_warning():
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         result = ds.is_monotonic
     assert_eq(expected, result)
 
@@ -5054,9 +5056,14 @@ def test_index_is_monotonic_numeric():
     s = pd.Series(1, index=range(20))
     ds = dd.from_pandas(s, npartitions=5, sort=False)
     assert_eq(s.index.is_monotonic_increasing, ds.index.is_monotonic_increasing)
-    with check_is_monotonic_warning():
+    # `is_monotonic` was deprecated starting in `pandas=1.5.0`
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         expected = s.index.is_monotonic
-    with check_is_monotonic_warning():
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         result = ds.index.is_monotonic
     assert_eq(expected, result)
 

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -148,7 +148,7 @@ def register_pandas():
     @sizeof.register(pd.DataFrame)
     def sizeof_pandas_dataframe(df):
         p = sizeof(df.index)
-        for name, col in df.iteritems():
+        for name, col in df.items():
             p += col.memory_usage(index=False)
             if col.dtype == object:
                 p += object_size(col._values)

--- a/dask/utils_test.py
+++ b/dask/utils_test.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 import importlib
 from typing import TYPE_CHECKING
+
+import pytest
 
 if TYPE_CHECKING:
     from .highlevelgraph import HighLevelGraph, Layer
@@ -142,3 +145,16 @@ def hlg_layer(hlg: HighLevelGraph, prefix: str) -> Layer:
 def hlg_layer_topological(hlg: HighLevelGraph, i: int) -> Layer:
     "Get the layer from a HighLevelGraph at position ``i``, topologically"
     return hlg.layers[hlg._toposort_layers()[i]]
+
+
+@contextlib.contextmanager
+def _check_warning(
+    condition: bool, category: type[Warning], message: str | None = None
+):
+    """Conditionally check is a warning is raised"""
+    if condition:
+        with pytest.warns(category, match=message) as ctx:
+            yield ctx
+    else:
+        with contextlib.nullcontext() as ctx:
+            yield ctx


### PR DESCRIPTION
This PR deprecates `iteritems` to follow what pandas is doing upstream (xref https://github.com/pandas-dev/pandas/pull/45321). This also resolves some test failures in our upstream build.