### PR TITLE
Trigger `dask` / `distributed` pre-release builds on commits

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Upload conda package
         if: |
           github.event_name == 'push'
-          && github.ref == 'refs/heads/main'
           && github.repository == 'dask/dask'
         env:
           ANACONDA_API_TOKEN: ${{ secrets.DASK_CONDA_TOKEN }}
@@ -57,3 +56,13 @@ jobs:
           mamba install anaconda-client
 
           anaconda upload --label dev noarch/*.tar.bz2
+      - name: Trigger distributed build
+        uses: peter-evans/repository-dispatch@v1.1.3
+        if: |
+          github.event_name == 'push'
+          && github.repository == 'dask/dask'
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: dask/distributed
+          event: trigger-build
+          github_pat: ${{ secrets.pat_with_access }}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -64,5 +64,4 @@ jobs:
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: dask/distributed
-          event: trigger-build
-          github_pat: ${{ secrets.pat_with_access }}
+          event-type: trigger-build


### PR DESCRIPTION
As suggested by @jakirkham in this [review comment](https://github.com/dask/distributed/pull/5745#discussion_r798832528), a better implementation of https://github.com/dask/dask/pull/8654 (building all Dask pre-release packages locally on commits to this repo) is to trigger the builds of `dask` / `distributed` through a repository dispatch event.

This allows us to limit the number of builds/uploads happening concurrently to prevent duplicate packages from being uploaded to Anaconda, which can be problematic.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
