### PR TITLE
[Experiment] Refactor HighLevelGraph Layers to use AbstractLayer

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -448,6 +448,13 @@ class Blockwise(AbstractLayer):
         self.concatenate = concatenate
         self.new_axes = new_axes or {}
 
+    @classmethod
+    def reconstructor(cls):
+        # Assume child classes want to down-cast to
+        # Blockwise after culling or construction
+        # on the scheduler
+        return Blockwise
+
     @property
     def layer_state(self):
         return {
@@ -585,7 +592,7 @@ class Blockwise(AbstractLayer):
             new_state = self.layer_state.copy()
             new_state["output_blocks"] = output_blocks
             new_state["annotations"] = self.annotations
-            culled_layer = self.__class__(**new_state)
+            culled_layer = self.reconstructor()(**new_state)
             return culled_layer, deps
         else:
             return self, deps

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -20,14 +20,13 @@ from .base import clone_key, get_name_from_key, tokenize
 from .compatibility import prod
 from .core import flatten, keys_in_tasks, reverse_dict
 from .delayed import unpack_collections
-from .highlevelgraph import HighLevelGraph, Layer
+from .highlevelgraph import AbstractLayer, HighLevelGraph, Layer
 from .optimization import SubgraphCallable, fuse
 from .utils import (
     _deprecated,
     apply,
     ensure_dict,
     homogeneous_deepmap,
-    stringify,
     stringify_collection_keys,
 )
 
@@ -338,7 +337,7 @@ def blockwise(
     return subgraph
 
 
-class Blockwise(Layer):
+class Blockwise(AbstractLayer):
     """Tensor Operation
 
     This is a lazily constructed mapping for tensor operation graphs.
@@ -450,6 +449,20 @@ class Blockwise(Layer):
         self.new_axes = new_axes or {}
 
     @property
+    def layer_state(self):
+        return {
+            "output": self.output,
+            "output_indices": self.output_indices,
+            "dsk": self.dsk,
+            "indices": self.indices,
+            "numblocks": self.numblocks,
+            "concatenate": self.concatenate,
+            "new_axes": self.new_axes,
+            "output_blocks": self.output_blocks,
+            "io_deps": self.io_deps,
+        }
+
+    @property
     def dims(self):
         """Returns a dictionary mapping between each index specified in
         `self.indices` and the number of output blocks for that indice.
@@ -461,30 +474,23 @@ class Blockwise(Layer):
     def __repr__(self):
         return f"Blockwise<{self.indices} -> {self.output}>"
 
-    @property
-    def _dict(self):
-        if hasattr(self, "_cached_dict"):
-            return self._cached_dict["dsk"]
-        else:
-            keys = tuple(map(blockwise_token, range(len(self.indices))))
-            dsk, _ = fuse(self.dsk, [self.output])
-            func = SubgraphCallable(dsk, self.output, keys)
+    def construct_graph(self):
+        keys = tuple(map(blockwise_token, range(len(self.indices))))
+        dsk, _ = fuse(self.dsk, [self.output])
+        func = SubgraphCallable(dsk, self.output, keys)
 
-            dsk = make_blockwise_graph(
-                func,
-                self.output,
-                self.output_indices,
-                *list(toolz.concat(self.indices)),
-                new_axes=self.new_axes,
-                numblocks=self.numblocks,
-                concatenate=self.concatenate,
-                output_blocks=self.output_blocks,
-                dims=self.dims,
-                io_deps=self.io_deps,
-            )
-
-            self._cached_dict = {"dsk": dsk}
-        return self._cached_dict["dsk"]
+        return make_blockwise_graph(
+            func,
+            self.output,
+            self.output_indices,
+            *list(toolz.concat(self.indices)),
+            new_axes=self.new_axes,
+            numblocks=self.numblocks,
+            concatenate=self.concatenate,
+            output_blocks=self.output_blocks,
+            dims=self.dims,
+            io_deps=self.io_deps,
+        )
 
     def get_output_keys(self):
         if self.output_blocks:
@@ -499,12 +505,6 @@ class Blockwise(Layer):
             )
         }
 
-    def __getitem__(self, key):
-        return self._dict[key]
-
-    def __iter__(self):
-        return iter(self._dict)
-
     def __len__(self) -> int:
         # same method as `get_output_keys`, without manifesting the keys themselves
         return (
@@ -513,165 +513,15 @@ class Blockwise(Layer):
             else prod(self.dims[i] for i in self.output_indices)
         )
 
-    def is_materialized(self):
-        return hasattr(self, "_cached_dict")
+    def layer_dependencies(self, keys, output_blocks=None):
 
-    def __dask_distributed_pack__(
-        self, all_hlg_keys, known_key_dependencies, client, client_keys
-    ):
-        from distributed.protocol import to_serialize
-        from distributed.utils import CancelledError
-        from distributed.utils_comm import unpack_remotedata
-        from distributed.worker import dumps_function
-
-        keys = tuple(map(blockwise_token, range(len(self.indices))))
-        dsk, _ = fuse(self.dsk, [self.output])
-
-        # Embed literals in `dsk`
-        keys2 = []
-        indices2 = []
-        global_dependencies = set()
-        for key, (val, index) in zip(keys, self.indices):
-            if index is None:
-                try:
-                    val_is_a_key = val in all_hlg_keys
-                except TypeError:  # not hashable
-                    val_is_a_key = False
-                if val_is_a_key:
-                    keys2.append(key)
-                    indices2.append((val, index))
-                    global_dependencies.add(stringify(val))
-                else:
-                    dsk[key] = val  # Literal
-            else:
-                keys2.append(key)
-                indices2.append((val, index))
-
-        dsk = (SubgraphCallable(dsk, self.output, tuple(keys2)),)
-        dsk, dsk_unpacked_futures = unpack_remotedata(dsk, byte_keys=True)
-
-        # Handle `io_deps` serialization. Assume each element
-        # is a `BlockwiseDep`-based object.
-        packed_io_deps = {}
-        inline_tasks = False
-        for name, blockwise_dep in self.io_deps.items():
-            packed_io_deps[name] = {
-                "__module__": blockwise_dep.__module__,
-                "__name__": type(blockwise_dep).__name__,
-                # TODO: Pass a `required_indices` list to __pack__
-                "state": blockwise_dep.__dask_distributed_pack__(),
-            }
-            inline_tasks = inline_tasks or blockwise_dep.produces_tasks
-
-        # Dump (pickle + cache) the function here if we know `make_blockwise_graph`
-        # will NOT be producing "nested" tasks (via `__dask_distributed_unpack__`).
-        #
-        # If `make_blockwise_graph` DOES need to produce nested tasks later on, it
-        # will need to call `to_serialize` on the entire task.  That will be a
-        # problem if the function was already pickled here. Therefore, we want to
-        # call `to_serialize` on the function if we know there will be nested tasks.
-        #
-        # We know there will be nested tasks if either:
-        #   (1) `concatenate=True`   # Check `self.concatenate`
-        #   (2) `inline_tasks=True`  # Check `BlockwiseDep.produces_tasks`
-        #
-        # We do not call `to_serialize` in ALL cases, because that code path does
-        # not cache the function on the scheduler or worker (or warn if there are
-        # large objects being passed into the graph).  However, in the future,
-        # single-pass serialization improvements should allow us to remove this
-        # special logic altogether.
-        func = (
-            to_serialize(dsk[0])
-            if (self.concatenate or inline_tasks)
-            else dumps_function(dsk[0])
-        )
-        func_future_args = dsk[1:]
-
-        indices = list(toolz.concat(indices2))
-        indices, indices_unpacked_futures = unpack_remotedata(indices, byte_keys=True)
-
-        # Check the legality of the unpacked futures
-        for future in itertools.chain(dsk_unpacked_futures, indices_unpacked_futures):
-            if future.client is not client:
-                raise ValueError(
-                    "Inputs contain futures that were created by another client."
-                )
-            if stringify(future.key) not in client.futures:
-                raise CancelledError(stringify(future.key))
-
-        # All blockwise tasks will depend on the futures in `indices`
-        global_dependencies |= {stringify(f.key) for f in indices_unpacked_futures}
-
-        return {
-            "output": self.output,
-            "output_indices": self.output_indices,
-            "func": func,
-            "func_future_args": func_future_args,
-            "global_dependencies": global_dependencies,
-            "indices": indices,
-            "is_list": [isinstance(x, list) for x in indices],
-            "numblocks": self.numblocks,
-            "concatenate": self.concatenate,
-            "new_axes": self.new_axes,
-            "output_blocks": self.output_blocks,
-            "dims": self.dims,
-            "io_deps": packed_io_deps,
-        }
-
-    @classmethod
-    def __dask_distributed_unpack__(cls, state, dsk, dependencies):
-        from distributed.protocol.serialize import import_allowed_module
-
-        # Make sure we convert list items back from tuples in `indices`.
-        # The msgpack serialization will have converted lists into
-        # tuples, and tuples may be stringified during graph
-        # materialization (bad if the item was not a key).
-        indices = [
-            list(ind) if is_list else ind
-            for ind, is_list in zip(state["indices"], state["is_list"])
-        ]
-
-        # Unpack io_deps state
-        io_deps = {}
-        for replace_name, packed_dep in state["io_deps"].items():
-            mod = import_allowed_module(packed_dep["__module__"])
-            dep_cls = getattr(mod, packed_dep["__name__"])
-            io_deps[replace_name] = dep_cls.__dask_distributed_unpack__(
-                packed_dep["state"]
-            )
-
-        layer_dsk, layer_deps = make_blockwise_graph(
-            state["func"],
-            state["output"],
-            state["output_indices"],
-            *indices,
-            new_axes=state["new_axes"],
-            numblocks=state["numblocks"],
-            concatenate=state["concatenate"],
-            output_blocks=state["output_blocks"],
-            dims=state["dims"],
-            return_key_deps=True,
-            deserializing=True,
-            func_future_args=state["func_future_args"],
-            io_deps=io_deps,
-        )
-        g_deps = state["global_dependencies"]
-
-        # Stringify layer graph and dependencies
-        layer_dsk = {
-            stringify(k): stringify_collection_keys(v) for k, v in layer_dsk.items()
-        }
-        deps = {
-            stringify(k): {stringify(d) for d in v} | g_deps
-            for k, v in layer_deps.items()
-        }
-        return {"dsk": layer_dsk, "deps": deps}
-
-    def _cull_dependencies(self, all_hlg_keys, output_blocks):
-        """Determine the necessary dependencies to produce `output_blocks`.
-
-        This method does not require graph materialization.
-        """
+        # Make sure `output_blocks is populated`
+        output_blocks = output_blocks or self.output_blocks
+        if output_blocks is None:
+            output_blocks = set()
+            for key in keys:
+                if key[0] == self.output:
+                    output_blocks.add(key[1:])
 
         # Check `concatenate` option
         concatenate = None
@@ -693,7 +543,7 @@ class Blockwise(Layer):
         for (arg, ind) in self.indices:
             if ind is None:
                 try:
-                    if arg in all_hlg_keys:
+                    if arg in keys:
                         const_deps.add(arg)
                 except TypeError:
                     pass  # unhashable
@@ -718,20 +568,6 @@ class Blockwise(Layer):
 
         return key_deps
 
-    def _cull(self, output_blocks):
-        return Blockwise(
-            self.output,
-            self.output_indices,
-            self.dsk,
-            self.indices,
-            self.numblocks,
-            concatenate=self.concatenate,
-            new_axes=self.new_axes,
-            output_blocks=output_blocks,
-            annotations=self.annotations,
-            io_deps=self.io_deps,
-        )
-
     def cull(
         self, keys: set, all_hlg_keys: Iterable
     ) -> Tuple[Layer, Mapping[Hashable, set]]:
@@ -743,13 +579,16 @@ class Blockwise(Layer):
         for key in keys:
             if key[0] == self.output:
                 output_blocks.add(key[1:])
-        culled_deps = self._cull_dependencies(all_hlg_keys, output_blocks)
+        deps = self.layer_dependencies(all_hlg_keys, output_blocks)
         out_size_iter = (self.dims[i] for i in self.output_indices)
-        if prod(out_size_iter) != len(culled_deps):
-            culled_layer = self._cull(output_blocks)
-            return culled_layer, culled_deps
+        if prod(out_size_iter) != len(deps):
+            new_state = self.layer_state.copy()
+            new_state["output_blocks"] = output_blocks
+            new_state["annotations"] = self.annotations
+            culled_layer = self.__class__(**new_state)
+            return culled_layer, deps
         else:
-            return self, culled_deps
+            return self, deps
 
     def clone(
         self,

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -394,7 +394,6 @@ def text_blocks_to_pandas(
             kwargs,
         ),
         label=label,
-        produces_tasks=True,
     )
     graph = HighLevelGraph({name: layer}, {name: set()})
     return new_dd_object(graph, name, head, (None,) * (len(blocks) + 1))

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -538,9 +538,6 @@ class AbstractLayer(Layer):
     def construct_graph(self):
         raise NotImplementedError
 
-    def output_keys(self):
-        raise NotImplementedError
-
     def cull_dependencies(self, keys, output_blocks=None):
         """Determine the necessary dependencies to produce `keys`"""
         raise NotImplementedError
@@ -581,7 +578,7 @@ class AbstractLayer(Layer):
         if hasattr(self, "_cached_output_keys"):
             return self._cached_output_keys
         else:
-            output_keys = self.output_keys()
+            output_keys = {(self.name, block) for block in self.output_blocks}
             self._cached_output_keys = output_keys
         return self._cached_output_keys
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -659,21 +659,18 @@ class AbstractLayer(Layer):
         return iter(self._dict)
 
     def __dask_distributed_pack__(self, all_hlg_keys, *args, **kwargs):
+        # from distributed.protocol.serialize import ToPickle
         import cloudpickle
-
-        from distributed.protocol.serialize import ToPickle
 
         # Save "pre-stringified" key dependencies
         # TODO: Is there a better way to do this?
         state = self.layer_state.copy()
         state["layer_dependencies"] = self.layer_dependencies(all_hlg_keys)
 
-        # TODO: Figure out why ToPickle sometimes fails...
-        try:
-            return cloudpickle.dumps(state)
-        except AttributeError:
-            # Probably shouldn't ever get here
-            return ToPickle(state)
+        # TODO: Use ToPickle - The current implementation
+        # sometimes fails.
+        # return ToPickle(state)
+        return cloudpickle.dumps(state)
 
     @classmethod
     def __dask_distributed_unpack__(cls, state, dsk, dependencies):

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -12,16 +12,9 @@ from tlz.curried import map
 
 from .base import tokenize
 from .blockwise import Blockwise, BlockwiseDep, BlockwiseDepDict, blockwise_token
-from .core import flatten, keys_in_tasks
+from .core import flatten
 from .highlevelgraph import AbstractLayer, Layer
-from .utils import (
-    apply,
-    cached_cumsum,
-    concrete,
-    insert,
-    stringify,
-    stringify_collection_keys,
-)
+from .utils import apply, cached_cumsum, concrete, insert, stringify
 
 #
 ##
@@ -343,7 +336,7 @@ def fractional_slice(task, axes):
 #
 
 
-class SimpleShuffleLayer(Layer):
+class SimpleShuffleLayer(AbstractLayer):
     """Simple HighLevelGraph Shuffle layer
 
     High-level graph layer for a simple shuffle operation in which
@@ -414,6 +407,19 @@ class SimpleShuffleLayer(Layer):
         self.annotations["priority"]["__expanded_annotations__"] = None
         self.annotations["priority"].update({_key: 1 for _key in self.get_split_keys()})
 
+    @property
+    def required_kwargs(self):
+        return {
+            "name": self.name,
+            "column": self.column,
+            "npartitions": self.npartitions,
+            "npartitions_input": self.npartitions_input,
+            "ignore_index": self.ignore_index,
+            "name_input": self.name_input,
+            "meta_input": self.meta_input,
+            "parts_out": list(self.parts_out),
+        }
+
     def get_split_keys(self):
         # Return SimpleShuffleLayer "split" keys
         return [
@@ -422,48 +428,13 @@ class SimpleShuffleLayer(Layer):
             for part_out in self.parts_out
         ]
 
-    def get_output_keys(self):
+    def output_keys(self):
         return {(self.name, part) for part in self.parts_out}
 
     def __repr__(self):
         return "SimpleShuffleLayer<name='{}', npartitions={}>".format(
             self.name, self.npartitions
         )
-
-    def is_materialized(self):
-        return hasattr(self, "_cached_dict")
-
-    @property
-    def _dict(self):
-        """Materialize full dict representation"""
-        if hasattr(self, "_cached_dict"):
-            return self._cached_dict
-        else:
-            dsk = self._construct_graph()
-            self._cached_dict = dsk
-        return self._cached_dict
-
-    def __getitem__(self, key):
-        return self._dict[key]
-
-    def __iter__(self):
-        return iter(self._dict)
-
-    def __len__(self):
-        return len(self._dict)
-
-    def _keys_to_parts(self, keys):
-        """Simple utility to convert keys to partition indices."""
-        parts = set()
-        for key in keys:
-            try:
-                _name, _part = key
-            except ValueError:
-                continue
-            if _name != self.name:
-                continue
-            parts.add(_part)
-        return parts
 
     def _cull_dependencies(self, keys, parts_out=None):
         """Determine the necessary dependencies to produce `keys`.
@@ -473,24 +444,12 @@ class SimpleShuffleLayer(Layer):
         materialization.
         """
         deps = defaultdict(set)
-        parts_out = parts_out or self._keys_to_parts(keys)
+        parts_out = parts_out or self._keys_to_indices(keys)
         for part in parts_out:
             deps[(self.name, part)] |= {
                 (self.name_input, i) for i in range(self.npartitions_input)
             }
         return deps
-
-    def _cull(self, parts_out):
-        return SimpleShuffleLayer(
-            self.name,
-            self.column,
-            self.npartitions,
-            self.npartitions_input,
-            self.ignore_index,
-            self.name_input,
-            self.meta_input,
-            parts_out=parts_out,
-        )
 
     def cull(self, keys, all_keys):
         """Cull a SimpleShuffleLayer HighLevelGraph layer.
@@ -500,85 +459,26 @@ class SimpleShuffleLayer(Layer):
         Therefore, "culling" the layer only requires us to reset this
         parameter.
         """
-        parts_out = self._keys_to_parts(keys)
+        parts_out = self._keys_to_indices(keys)
         culled_deps = self._cull_dependencies(keys, parts_out=parts_out)
         if parts_out != set(self.parts_out):
-            culled_layer = self._cull(parts_out)
+            new_state = self.required_kwargs.copy()
+            new_state["parts_out"] = parts_out
+            new_state["annotations"] = self.annotations
+            culled_layer = self.__class__(**new_state)
             return culled_layer, culled_deps
         else:
             return self, culled_deps
 
-    def __reduce__(self):
-        attrs = [
-            "name",
-            "column",
-            "npartitions",
-            "npartitions_input",
-            "ignore_index",
-            "name_input",
-            "meta_input",
-            "parts_out",
-            "annotations",
-        ]
-        return (SimpleShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
-
-    def __dask_distributed_pack__(
-        self, all_hlg_keys, known_key_dependencies, client, client_keys
-    ):
-        from distributed.protocol.serialize import to_serialize
-
-        return {
-            "name": self.name,
-            "column": self.column,
-            "npartitions": self.npartitions,
-            "npartitions_input": self.npartitions_input,
-            "ignore_index": self.ignore_index,
-            "name_input": self.name_input,
-            "meta_input": to_serialize(self.meta_input),
-            "parts_out": list(self.parts_out),
-        }
-
-    @classmethod
-    def __dask_distributed_unpack__(cls, state, dsk, dependencies):
-        from distributed.worker import dumps_task
-
-        # msgpack will convert lists into tuples, here
-        # we convert them back to lists
-        if isinstance(state["column"], tuple):
-            state["column"] = list(state["column"])
-        if "inputs" in state:
-            state["inputs"] = list(state["inputs"])
-
-        # Materialize the layer
-        layer_dsk = cls(**state)._construct_graph(deserializing=True)
-
-        # Convert all keys to strings and dump tasks
-        layer_dsk = {
-            stringify(k): stringify_collection_keys(v) for k, v in layer_dsk.items()
-        }
-        keys = layer_dsk.keys() | dsk.keys()
-
-        # TODO: use shuffle-knowledge to calculate dependencies more efficiently
-        deps = {k: keys_in_tasks(keys, [v]) for k, v in layer_dsk.items()}
-
-        return {"dsk": toolz.valmap(dumps_task, layer_dsk), "deps": deps}
-
-    def _construct_graph(self, deserializing=False):
+    def construct_graph(self):
         """Construct graph for a simple shuffle operation."""
 
         shuffle_group_name = "group-" + self.name
 
-        if deserializing:
-            # Use CallableLazyImport objects to avoid importing dataframe
-            # module on the scheduler
-            concat_func = CallableLazyImport("dask.dataframe.core._concat")
-            shuffle_group_func = CallableLazyImport(
-                "dask.dataframe.shuffle.shuffle_group"
-            )
-        else:
-            # Not running on distributed scheduler - Use explicit functions
-            from dask.dataframe.core import _concat as concat_func
-            from dask.dataframe.shuffle import shuffle_group as shuffle_group_func
+        # Use CallableLazyImport objects to avoid importing dataframe
+        # module on the scheduler
+        concat_func = CallableLazyImport("dask.dataframe.core._concat")
+        shuffle_group_func = CallableLazyImport("dask.dataframe.shuffle.shuffle_group")
 
         dsk = {}
         for part_out in self.parts_out:
@@ -610,6 +510,20 @@ class SimpleShuffleLayer(Layer):
                     )
 
         return dsk
+
+    # def __reduce__(self):
+    #     attrs = [
+    #         "name",
+    #         "column",
+    #         "npartitions",
+    #         "npartitions_input",
+    #         "ignore_index",
+    #         "name_input",
+    #         "meta_input",
+    #         "parts_out",
+    #         "annotations",
+    #     ]
+    #     return (SimpleShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
 
 
 class ShuffleLayer(SimpleShuffleLayer):
@@ -679,6 +593,22 @@ class ShuffleLayer(SimpleShuffleLayer):
             annotations=annotations,
         )
 
+    @property
+    def required_kwargs(self):
+        return {
+            "name": self.name,
+            "column": self.column,
+            "inputs": self.inputs,
+            "stage": self.stage,
+            "npartitions": self.npartitions,
+            "npartitions_input": self.npartitions_input,
+            "nsplits": self.nsplits,
+            "ignore_index": self.ignore_index,
+            "name_input": self.name_input,
+            "meta_input": self.meta_input,
+            "parts_out": list(self.parts_out),
+        }
+
     def get_split_keys(self):
         # Return ShuffleLayer "split" keys
         keys = []
@@ -701,30 +631,23 @@ class ShuffleLayer(SimpleShuffleLayer):
             self.name, self.stage, self.nsplits, self.npartitions
         )
 
-    def __reduce__(self):
-        attrs = [
-            "name",
-            "column",
-            "inputs",
-            "stage",
-            "npartitions",
-            "npartitions_input",
-            "nsplits",
-            "ignore_index",
-            "name_input",
-            "meta_input",
-            "parts_out",
-            "annotations",
-        ]
+    # def __reduce__(self):
+    #     attrs = [
+    #         "name",
+    #         "column",
+    #         "inputs",
+    #         "stage",
+    #         "npartitions",
+    #         "npartitions_input",
+    #         "nsplits",
+    #         "ignore_index",
+    #         "name_input",
+    #         "meta_input",
+    #         "parts_out",
+    #         "annotations",
+    #     ]
 
-        return (ShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
-
-    def __dask_distributed_pack__(self, *args, **kwargs):
-        ret = super().__dask_distributed_pack__(*args, **kwargs)
-        ret["inputs"] = self.inputs
-        ret["stage"] = self.stage
-        ret["nsplits"] = self.nsplits
-        return ret
+    #     return (ShuffleLayer, tuple(getattr(self, attr) for attr in attrs))
 
     def _cull_dependencies(self, keys, parts_out=None):
         """Determine the necessary dependencies to produce `keys`.
@@ -732,7 +655,7 @@ class ShuffleLayer(SimpleShuffleLayer):
         Does not require graph materialization.
         """
         deps = defaultdict(set)
-        parts_out = parts_out or self._keys_to_parts(keys)
+        parts_out = parts_out or self._keys_to_indices(keys)
         inp_part_map = {inp: i for i, inp in enumerate(self.inputs)}
         for part in parts_out:
             out = self.inputs[part]
@@ -745,37 +668,15 @@ class ShuffleLayer(SimpleShuffleLayer):
                     deps[(self.name, part)].add((self.name_input, _part))
         return deps
 
-    def _cull(self, parts_out):
-        return ShuffleLayer(
-            self.name,
-            self.column,
-            self.inputs,
-            self.stage,
-            self.npartitions,
-            self.npartitions_input,
-            self.nsplits,
-            self.ignore_index,
-            self.name_input,
-            self.meta_input,
-            parts_out=parts_out,
-        )
-
-    def _construct_graph(self, deserializing=False):
+    def construct_graph(self):
         """Construct graph for a "rearrange-by-column" stage."""
 
         shuffle_group_name = "group-" + self.name
 
-        if deserializing:
-            # Use CallableLazyImport objects to avoid importing dataframe
-            # module on the scheduler
-            concat_func = CallableLazyImport("dask.dataframe.core._concat")
-            shuffle_group_func = CallableLazyImport(
-                "dask.dataframe.shuffle.shuffle_group"
-            )
-        else:
-            # Not running on distributed scheduler - Use explicit functions
-            from dask.dataframe.core import _concat as concat_func
-            from dask.dataframe.shuffle import shuffle_group as shuffle_group_func
+        # Use CallableLazyImport objects to avoid importing dataframe
+        # module on the scheduler
+        concat_func = CallableLazyImport("dask.dataframe.core._concat")
+        shuffle_group_func = CallableLazyImport("dask.dataframe.shuffle.shuffle_group")
 
         dsk = {}
         inp_part_map = {inp: i for i, inp in enumerate(self.inputs)}
@@ -834,7 +735,7 @@ class ShuffleLayer(SimpleShuffleLayer):
         return dsk
 
 
-class BroadcastJoinLayer(Layer):
+class BroadcastJoinLayer(AbstractLayer):
     """Broadcast-based Join Layer
 
     High-level graph layer for a join operation requiring the
@@ -890,48 +791,11 @@ class BroadcastJoinLayer(Layer):
         if isinstance(self.right_on, list):
             self.right_on = (list, tuple(self.right_on))
 
-    def get_output_keys(self):
+    def output_keys(self):
         return {(self.name, part) for part in self.parts_out}
 
-    def __repr__(self):
-        return "BroadcastJoinLayer<name='{}', how={}, lhs={}, rhs={}>".format(
-            self.name, self.how, self.lhs_name, self.rhs_name
-        )
-
-    def is_materialized(self):
-        return hasattr(self, "_cached_dict")
-
     @property
-    def _dict(self):
-        """Materialize full dict representation"""
-        if hasattr(self, "_cached_dict"):
-            return self._cached_dict
-        else:
-            dsk = self._construct_graph()
-            self._cached_dict = dsk
-        return self._cached_dict
-
-    def __getitem__(self, key):
-        return self._dict[key]
-
-    def __iter__(self):
-        return iter(self._dict)
-
-    def __len__(self):
-        return len(self._dict)
-
-    def __dask_distributed_pack__(self, *args, **kwargs):
-        import pickle
-
-        # Pickle complex merge_kwargs elements. Also
-        # tuples, which may be confused with keys.
-        _merge_kwargs = {}
-        for k, v in self.merge_kwargs.items():
-            if not isinstance(v, (str, list, bool)):
-                _merge_kwargs[k] = pickle.dumps(v)
-            else:
-                _merge_kwargs[k] = v
-
+    def required_kwargs(self):
         return {
             "name": self.name,
             "npartitions": self.npartitions,
@@ -940,39 +804,13 @@ class BroadcastJoinLayer(Layer):
             "rhs_name": self.rhs_name,
             "rhs_npartitions": self.rhs_npartitions,
             "parts_out": self.parts_out,
-            "merge_kwargs": _merge_kwargs,
+            **self.merge_kwargs,
         }
 
-    @classmethod
-    def __dask_distributed_unpack__(cls, state, dsk, dependencies):
-        from distributed.worker import dumps_task
-
-        # Expand merge_kwargs
-        merge_kwargs = state.pop("merge_kwargs", {})
-        state.update(merge_kwargs)
-
-        # Materialize the layer
-        raw = cls(**state)._construct_graph(deserializing=True)
-
-        # Convert all keys to strings and dump tasks
-        raw = {stringify(k): stringify_collection_keys(v) for k, v in raw.items()}
-        keys = raw.keys() | dsk.keys()
-        deps = {k: keys_in_tasks(keys, [v]) for k, v in raw.items()}
-
-        return {"dsk": toolz.valmap(dumps_task, raw), "deps": deps}
-
-    def _keys_to_parts(self, keys):
-        """Simple utility to convert keys to partition indices."""
-        parts = set()
-        for key in keys:
-            try:
-                _name, _part = key
-            except ValueError:
-                continue
-            if _name != self.name:
-                continue
-            parts.add(_part)
-        return parts
+    def __repr__(self):
+        return "BroadcastJoinLayer<name='{}', how={}, lhs={}, rhs={}>".format(
+            self.name, self.how, self.lhs_name, self.rhs_name
+        )
 
     @property
     def _broadcast_plan(self):
@@ -1011,26 +849,13 @@ class BroadcastJoinLayer(Layer):
         bcast_name, bcast_size, other_name = self._broadcast_plan[:3]
 
         deps = defaultdict(set)
-        parts_out = parts_out or self._keys_to_parts(keys)
+        parts_out = parts_out or self._keys_to_indices(keys)
         for part in parts_out:
             deps[(self.name, part)] |= {(bcast_name, i) for i in range(bcast_size)}
             deps[(self.name, part)] |= {
                 (other_name, part),
             }
         return deps
-
-    def _cull(self, parts_out):
-        return BroadcastJoinLayer(
-            self.name,
-            self.npartitions,
-            self.lhs_name,
-            self.lhs_npartitions,
-            self.rhs_name,
-            self.rhs_npartitions,
-            annotations=self.annotations,
-            parts_out=parts_out,
-            **self.merge_kwargs,
-        )
 
     def cull(self, keys, all_keys):
         """Cull a BroadcastJoinLayer HighLevelGraph layer.
@@ -1040,35 +865,32 @@ class BroadcastJoinLayer(Layer):
         Therefore, "culling" the layer only requires us to reset this
         parameter.
         """
-        parts_out = self._keys_to_parts(keys)
+        parts_out = self._keys_to_indices(keys)
         culled_deps = self._cull_dependencies(keys, parts_out=parts_out)
         if parts_out != set(self.parts_out):
-            culled_layer = self._cull(parts_out)
+            new_state = self.required_kwargs.copy()
+            new_state["parts_out"] = parts_out
+            new_state["annotations"] = self.annotations
+            culled_layer = BroadcastJoinLayer(**new_state)
             return culled_layer, culled_deps
         else:
             return self, culled_deps
 
-    def _construct_graph(self, deserializing=False):
+    def construct_graph(self):
         """Construct graph for a broadcast join operation."""
 
         inter_name = "inter-" + self.name
         split_name = "split-" + self.name
 
-        if deserializing:
-            # Use CallableLazyImport objects to avoid importing dataframe
-            # module on the scheduler
-            split_partition_func = CallableLazyImport(
-                "dask.dataframe.multi._split_partition"
-            )
-            concat_func = CallableLazyImport("dask.dataframe.multi._concat_wrapper")
-            merge_chunk_func = CallableLazyImport(
-                "dask.dataframe.multi._merge_chunk_wrapper"
-            )
-        else:
-            # Not running on distributed scheduler - Use explicit functions
-            from dask.dataframe.multi import _concat_wrapper as concat_func
-            from dask.dataframe.multi import _merge_chunk_wrapper as merge_chunk_func
-            from dask.dataframe.multi import _split_partition as split_partition_func
+        # Use CallableLazyImport objects to avoid importing dataframe
+        # module on the scheduler
+        split_partition_func = CallableLazyImport(
+            "dask.dataframe.multi._split_partition"
+        )
+        concat_func = CallableLazyImport("dask.dataframe.multi._concat_wrapper")
+        merge_chunk_func = CallableLazyImport(
+            "dask.dataframe.multi._merge_chunk_wrapper"
+        )
 
         # Get broadcast "plan"
         bcast_name, bcast_size, other_name, other_on = self._broadcast_plan
@@ -1442,19 +1264,6 @@ class DataFrameTreeReduction(AbstractLayer):
             return tree_size + self.npartitions_input * len(self.output_partitions)
         return tree_size
 
-    def _keys_to_output_partitions(self, keys):
-        """Simple utility to convert keys to output partition indices."""
-        splits = set()
-        for key in keys:
-            try:
-                _name, _split = key
-            except ValueError:
-                continue
-            if _name != self.name:
-                continue
-            splits.add(_split)
-        return splits
-
     def cull(self, keys, all_keys):
         """Cull a DataFrameTreeReduction HighLevelGraph layer"""
         deps = {
@@ -1462,10 +1271,11 @@ class DataFrameTreeReduction(AbstractLayer):
                 (self.name_input, i) for i in range(self.npartitions_input)
             }
         }
-        output_partitions = self._keys_to_output_partitions(keys)
+        output_partitions = self._keys_to_indices(keys)
         if output_partitions != set(self.output_partitions):
             new_state = self.required_kwargs.copy()
             new_state["output_partitions"] = output_partitions
+            new_state["annotations"] = self.annotations
             culled_layer = DataFrameTreeReduction(**new_state)
             return culled_layer, deps
         else:

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -410,7 +410,7 @@ class SimpleShuffleLayer(AbstractLayer):
         )
 
     @property
-    def required_kwargs(self):
+    def layer_state(self):
         return {
             "name": self.name,
             "column": self.column,
@@ -560,7 +560,7 @@ class ShuffleLayer(SimpleShuffleLayer):
         )
 
     @property
-    def required_kwargs(self):
+    def layer_state(self):
         return {
             "name": self.name,
             "column": self.column,
@@ -740,7 +740,7 @@ class BroadcastJoinLayer(AbstractLayer):
             self.right_on = (list, tuple(self.right_on))
 
     @property
-    def required_kwargs(self):
+    def layer_state(self):
         return {
             "name": self.name,
             "npartitions": self.npartitions,
@@ -1071,7 +1071,7 @@ class DataFrameTreeReduction(AbstractLayer):
         self.height = len(self.widths)
 
     @property
-    def required_kwargs(self):
+    def layer_state(self):
         return {
             "name": self.name,
             "name_input": self.name_input,

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -542,7 +542,7 @@ async def test_futures_in_subgraphs(c, s, a, b):
     ddf = await c.submit(dd.categorical.categorize, ddf, columns=["day"], index=False)
 
 
-@pytest.mark.flaky(reruns=5, reruns_delay=5)
+# @pytest.mark.flaky(reruns=5, reruns_delay=5)
 @gen_cluster(client=True)
 async def test_shuffle_priority(c, s, a, b):
     pd = pytest.importorskip("pandas")

--- a/dask/tests/test_layers.py
+++ b/dask/tests/test_layers.py
@@ -94,7 +94,7 @@ def _dataframe_broadcast_join(tmpdir):
     # Perform a computation using an HLG-based broadcast join
     df = pd.DataFrame({"a": range(10), "b": range(10, 20)})
     ddf1 = dd.from_pandas(df, npartitions=4)
-    ddf2 = dd.from_pandas(df, npartitions=1)
+    ddf2 = dd.from_pandas(df, npartitions=2)
     return ddf1.merge(ddf2, how="left", broadcast=True, shuffle="tasks")
 
 

--- a/dask/tests/test_layers.py
+++ b/dask/tests/test_layers.py
@@ -202,26 +202,27 @@ def test_scheduler_highlevel_graph_unpack_import(op, lib, optimize_graph, loop, 
     # Test that array/dataframe-specific modules are not imported
     # on the scheduler when an HLG layers are unpacked/materialized.
 
-    with cluster(scheduler_kwargs={"plugins": [SchedulerImportCheck(lib)]}) as (
-        scheduler,
-        workers,
-    ):
+    # with cluster(scheduler_kwargs={"plugins": [SchedulerImportCheck(lib)]}) as (
+    #     scheduler,
+    #     workers,
+    # ):
+    with cluster() as (scheduler, workers):
         with Client(scheduler["address"], loop=loop) as c:
             # Perform a computation using a HighLevelGraph Layer
             c.compute(op(tmpdir), optimize_graph=optimize_graph)
 
-            # Get the new modules which were imported on the scheduler during the computation
-            end_modules = c.run_on_scheduler(lambda: set(sys.modules))
-            start_modules = c.run_on_scheduler(
-                lambda dask_scheduler: dask_scheduler.plugins[
-                    SchedulerImportCheck.name
-                ].start_modules
-            )
-            new_modules = end_modules - start_modules
+            # # Get the new modules which were imported on the scheduler during the computation
+            # end_modules = c.run_on_scheduler(lambda: set(sys.modules))
+            # start_modules = c.run_on_scheduler(
+            #     lambda dask_scheduler: dask_scheduler.plugins[
+            #         SchedulerImportCheck.name
+            #     ].start_modules
+            # )
+            # new_modules = end_modules - start_modules
 
-            # Check that the scheduler didn't start with `lib`
-            # (otherwise we arent testing anything)
-            assert not any(module.startswith(lib) for module in start_modules)
+            # # Check that the scheduler didn't start with `lib`
+            # # (otherwise we arent testing anything)
+            # assert not any(module.startswith(lib) for module in start_modules)
 
-            # Check whether we imported `lib` on the scheduler
-            assert not any(module.startswith(lib) for module in new_modules)
+            # # Check whether we imported `lib` on the scheduler
+            # assert not any(module.startswith(lib) for module in new_modules)


### PR DESCRIPTION
**DO NOT MERGE!!**

This is an experimental refactoring of the existing HLG-`Layer` definitions. It changes most implementations to inherit from a single `AbstractLayer` class, where all serialization and most culling and graph-caching logic is defined.

This PR was motivated by the serialization change in [distributed#5728](https://github.com/dask/distributed/pull/5728) (which proposes a new `ToPickle` protocol for serialization).  That change would effectively establish that the scheduler has the same environment as the client and worker processes, and that the scheduler is allowed to call `pickle.loads`. My personal opinion is that this assumption makes sense for most (if not all) users, and that we can just add a simple config option to materialize the Layers on the client in the rare case that this is not true.

This PR demonstrates that the environment/pickle assumptions in [distributed#5728](https://github.com/dask/distributed/pull/5728) enable significant cleanup in `dask.layers.py` and `dask.blockwise.py`.  In fact, since `Layer` materialization is now allowed to require pandas/numpy/etc, we can also move the collection-specific logic in `layer.py` into appropriate locations in the source tree.  However, this redistribution of the code in `layers.py` is **not** yet covered in this PR.

**TODO**:

- [x] Define central `AbstractLayer` class that implements general serialization, culling, and graph-caching logic.
- [x] Revise all DataFrame-specific Layers to inherit from `AbstractLayer`
- [x] Revise `Blockwise` to inherit from `AbstractLayer`
- [ ] (**MAJOR BLOCKER**) Gather feedback here (or in [distributed#5581](https://github.com/dask/distributed/issues/5581) and/or [distributed#5728](https://github.com/dask/distributed/pull/5728)).  We probably need to agree that (1) the scheduler must have the same environment as the client/workers, and that (2) the scheduler may unpickle data.  If either of these assumptions is **not** met, we must restrict the scheduler from receiving anything other than `MaterializedLayer` objects from the client.
- [ ] (**MAJOR BLOCKER**) Resolve `ToPickle` limitations in distributed. This initial version of the PR uses `cloudpickle` for serializations, because `ToPickle` sometimes fails to serialize the `layer_state` dictionary.
- [ ] Establish if/how backward compatibility (pre-`ToPickle`) should be handled (I am thinking we can just convert all Layers to `MaterializedLayer` objects on the client).
- [ ] Establish clear configuration option for scheduler- vs client-side materialization. The indirect nature of the current `"optimization.fuse.active"` option is confusing.
- [ ] Revise test coverage - `test_layers.py` no longer needs to check for scheduler imports, but we need to make sure scheduler-side materialization is properly/thoroughly tested.
- [ ] Code review

**Follow-up Work**:

- [ ] Revise `ArrayOverlapLayer` to inherit from `AbstractLayer`
- [ ] Redistribute the collection-specific code defined in `layers.py`
- [ ] Add/Revise "how-to" developer documentation for implementing a new `AbstractLayer`

**Final Note**: If we are unable to agree that a `ToPickle`-like approach is the future, some parts of the `AbstractLayer` concept can still be used to remove boilerplate code from the existing Layer definitions.