### PR TITLE
Collection Protocol

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import itertools
 import math

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -5,7 +5,7 @@ import operator
 import uuid
 import warnings
 from collections import defaultdict
-from collections.abc import Iterable, Iterator
+from collections.abc import Hashable, Iterable, Iterator, Mapping
 from functools import partial, reduce, wraps
 from random import Random
 from urllib.request import urlopen
@@ -459,7 +459,7 @@ class Bag(DaskMethodsMixin):
     30
     """
 
-    def __init__(self, dsk, name, npartitions):
+    def __init__(self, dsk: Mapping, name: str, npartitions: int):
         if not isinstance(dsk, HighLevelGraph):
             dsk = HighLevelGraph.from_collections(name, dsk, dependencies=[])
         self.dask = dsk
@@ -469,7 +469,7 @@ class Bag(DaskMethodsMixin):
     def __dask_graph__(self):
         return self.dask
 
-    def __dask_keys__(self):
+    def __dask_keys__(self) -> list[Hashable]:
         return [(self.name, i) for i in range(self.npartitions)]
 
     def __dask_layers__(self):

--- a/dask/base.py
+++ b/dask/base.py
@@ -160,7 +160,7 @@ def annotate(**annotations):
 
 def is_dask_collection(x) -> bool:
     """Returns ``True`` if ``x`` is a dask collection"""
-    return hasattr(x, "__dask_graph__")
+    return hasattr(x, "__dask_graph__") and callable(x.__dask_graph__)
 
 
 class DaskMethodsMixin:

--- a/dask/base.py
+++ b/dask/base.py
@@ -158,12 +158,9 @@ def annotate(**annotations):
         yield
 
 
-def is_dask_collection(x):
+def is_dask_collection(x) -> bool:
     """Returns ``True`` if ``x`` is a dask collection"""
-    try:
-        return x.__dask_graph__() is not None
-    except (AttributeError, TypeError):
-        return False
+    return hasattr(x, "__dask_graph__")
 
 
 class DaskMethodsMixin:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import operator
 import warnings
-from collections.abc import Iterator, Sequence
+from collections.abc import Hashable, Iterator, Sequence
 from functools import partial, wraps
 from numbers import Integral, Number
 from operator import getitem
@@ -331,7 +331,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
     def __dask_graph__(self):
         return self.dask
 
-    def __dask_keys__(self):
+    def __dask_keys__(self) -> list[Hashable]:
         return [(self._name, i) for i in range(self.npartitions)]
 
     def __dask_layers__(self):

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -541,8 +541,6 @@ def test_is_dask_collection():
     assert is_dask_collection(x)
     assert not is_dask_collection(2)
     assert is_dask_collection(DummyCollection({}))
-    assert not is_dask_collection(DummyCollection(None))
-    assert not is_dask_collection(DummyCollection)
 
 
 def test_unpack_collections():
@@ -616,8 +614,6 @@ def test_get_collection_names():
 
     with pytest.raises(TypeError):
         get_collection_names(object())
-    with pytest.raises(TypeError):
-        get_collection_names(DummyCollection(None, []))
     # Keys must either be a string or a tuple where the first element is a string
     with pytest.raises(TypeError):
         get_collection_names(DummyCollection({1: 2}, [1]))

--- a/dask/tests/test_typing.py
+++ b/dask/tests/test_typing.py
@@ -20,7 +20,6 @@ da = pytest.importorskip("dask.array")
 db = pytest.importorskip("dask.bag")
 dds = pytest.importorskip("dask.datasets")
 dd = pytest.importorskip("dask.dataframe")
-pandas = pytest.importorskip("pandas")
 
 
 def finalize(x: Sequence[Any]) -> Any:

--- a/dask/tests/test_typing.py
+++ b/dask/tests/test_typing.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Hashable, Mapping, MutableMapping, Sequence
 from typing import Any
 
-import pandas as pd
 import pytest
 
 import dask.array as da
@@ -18,6 +17,8 @@ from dask.typing import (
     PostComputeCallable,
     PostPersistCallable,
 )
+
+pandas = pytest.importorskip("pandas")
 
 
 class HLGCollection(DaskMethodsMixin):
@@ -89,7 +90,7 @@ def test_isinstance_core(protocol: Any) -> None:
     arr = da.ones(10)
     bag = db.from_sequence([1, 2, 3, 4, 5], npartitions=2)
     df = dd.from_pandas(
-        pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}),
+        pandas.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}),
         npartitions=2,
     )
     dobj = increment(2)

--- a/dask/tests/test_typing.py
+++ b/dask/tests/test_typing.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from collections.abc import Hashable, Mapping, MutableMapping, Sequence
+from typing import Any
+
+import pandas as pd
+import pytest
+
+import dask.array as da
+import dask.bag as db
+import dask.dataframe as dd
+import dask.threaded
+from dask.base import DaskMethodsMixin, dont_optimize, tokenize
+from dask.delayed import delayed
+from dask.typing import (
+    DaskCollection,
+    HLGDaskCollection,
+    PostComputeCallable,
+    PostPersistCallable,
+)
+
+
+class HLGCollection(DaskMethodsMixin):
+    def __init__(self, based_on: HLGDaskCollection) -> None:
+        self.based_on = based_on
+
+    def __dask_graph__(self) -> Mapping | None:
+        return self.based_on.__dask_graph__()
+
+    def __dask_layers__(self) -> Sequence[str]:
+        return self.based_on.__dask_layers__()
+
+    def __dask_keys__(self) -> list[Hashable]:
+        return self.based_on.__dask_keys__()
+
+    def __dask_postcompute__(self) -> tuple[PostComputeCallable, tuple]:
+        return self.based_on.__dask_postcompute__()
+
+    def __dask_postpersist__(self) -> tuple[PostPersistCallable, tuple]:
+        return self.based_on.__dask_postpersist__()
+
+    def __dask_tokenize__(self) -> Hashable:
+        return tokenize(self.based_on)
+
+    __dask_scheduler__ = staticmethod(dask.threaded.get)
+
+    @staticmethod
+    def __dask_optimize__(
+        dsk: MutableMapping, keys: Sequence[Hashable], **kwargs: Any
+    ) -> MutableMapping:
+        return dont_optimize(dsk, keys, **kwargs)
+
+
+class NotHLGCollection(DaskMethodsMixin):
+    def __init__(self, based_on: DaskCollection) -> None:
+        self.based_on = based_on
+
+    def __dask_graph__(self) -> Mapping | None:
+        return self.based_on.__dask_graph__()
+
+    def __dask_keys__(self) -> list[Hashable]:
+        return self.based_on.__dask_keys__()
+
+    def __dask_postcompute__(self) -> tuple[PostComputeCallable, tuple]:
+        return self.based_on.__dask_postcompute__()
+
+    def __dask_postpersist__(self) -> tuple[PostPersistCallable, tuple]:
+        return self.based_on.__dask_postpersist__()
+
+    def __dask_tokenize__(self) -> Hashable:
+        return tokenize(self.based_on)
+
+    __dask_scheduler__ = staticmethod(dask.threaded.get)
+
+    @staticmethod
+    def __dask_optimize__(
+        dsk: MutableMapping, keys: Sequence[Hashable], **kwargs: Any
+    ) -> MutableMapping:
+        return dont_optimize(dsk, keys, **kwargs)
+
+
+@delayed
+def increment(x: int) -> int:
+    return x + 1
+
+
+@pytest.mark.parametrize("protocol", [DaskCollection, HLGDaskCollection])
+def test_isinstance_core(protocol: Any) -> None:
+    arr = da.ones(10)
+    bag = db.from_sequence([1, 2, 3, 4, 5], npartitions=2)
+    df = dd.from_pandas(
+        pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}),
+        npartitions=2,
+    )
+    dobj = increment(2)
+
+    assert isinstance(arr, protocol)
+    assert isinstance(bag, protocol)
+    assert isinstance(df, protocol)
+    assert isinstance(dobj, protocol)
+
+
+def test_isinstance_custom() -> None:
+    a = da.ones(10)
+    hlgc = HLGCollection(a)
+    nhlgc = NotHLGCollection(a)
+
+    assert isinstance(hlgc, DaskCollection)
+    assert isinstance(nhlgc, DaskCollection)
+
+    assert isinstance(nhlgc, DaskCollection)
+    assert not isinstance(nhlgc, HLGDaskCollection)
+
+
+def test_parameter_passing() -> None:
+    def compute(coll: DaskCollection) -> Any:
+        return coll.compute()
+
+    a = increment(2)
+    hlgc = HLGCollection(a)
+    assert compute(hlgc) == 3
+
+    d = increment(3)
+    assert compute(d) == 4

--- a/dask/tests/test_typing.py
+++ b/dask/tests/test_typing.py
@@ -132,4 +132,4 @@ def test_parameter_passing() -> None:
     assert compute(d) == 4
 
     array: da.Array = da.ones(10)
-    assert compute(array).shape == (1,)
+    assert compute(array).shape == (10,)

--- a/dask/tests/test_typing.py
+++ b/dask/tests/test_typing.py
@@ -7,11 +7,9 @@ import pytest
 
 import dask.array as da
 import dask.bag as db
-import dask.dataframe as dd
 import dask.threaded
 from dask.base import DaskMethodsMixin, dont_optimize, tokenize
 from dask.context import globalmethod
-from dask.datasets import timeseries
 from dask.delayed import Delayed, delayed
 from dask.typing import (
     DaskCollection,
@@ -20,6 +18,8 @@ from dask.typing import (
     PostPersistCallable,
 )
 
+dds = pytest.importorskip("dask.datasets")
+dd = pytest.importorskip("dask.dataframe")
 pandas = pytest.importorskip("pandas")
 
 
@@ -99,9 +99,11 @@ def assert_isinstance(coll: DaskCollection, protocol: Any):
 
 @pytest.mark.parametrize("protocol", [DaskCollection, HLGDaskCollection])
 def test_isinstance_core(protocol: Any) -> None:
+    from dask.dataframe import DataFrame
+
     arr: da.Array = da.ones(10)
     bag: db.Bag = db.from_sequence([1, 2, 3, 4, 5], npartitions=2)
-    df: dd.DataFrame = timeseries()
+    df: DataFrame = dds.timeseries()
     dobj: Delayed = increment(2)
 
     assert_isinstance(arr, protocol)

--- a/dask/tests/test_typing.py
+++ b/dask/tests/test_typing.py
@@ -5,8 +5,6 @@ from typing import Any
 
 import pytest
 
-import dask.array as da
-import dask.bag as db
 import dask.threaded
 from dask.base import DaskMethodsMixin, dont_optimize, tokenize
 from dask.context import globalmethod
@@ -18,6 +16,8 @@ from dask.typing import (
     PostPersistCallable,
 )
 
+da = pytest.importorskip("dask.array")
+db = pytest.importorskip("dask.bag")
 dds = pytest.importorskip("dask.datasets")
 dd = pytest.importorskip("dask.dataframe")
 pandas = pytest.importorskip("pandas")
@@ -99,10 +99,12 @@ def assert_isinstance(coll: DaskCollection, protocol: Any):
 
 @pytest.mark.parametrize("protocol", [DaskCollection, HLGDaskCollection])
 def test_isinstance_core(protocol: Any) -> None:
+    from dask.array import Array
+    from dask.bag import Bag
     from dask.dataframe import DataFrame
 
-    arr: da.Array = da.ones(10)
-    bag: db.Bag = db.from_sequence([1, 2, 3, 4, 5], npartitions=2)
+    arr: Array = da.ones(10)
+    bag: Bag = db.from_sequence([1, 2, 3, 4, 5], npartitions=2)
     df: DataFrame = dds.timeseries()
     dobj: Delayed = increment(2)
 
@@ -125,6 +127,8 @@ def test_isinstance_custom() -> None:
 
 
 def test_parameter_passing() -> None:
+    from dask.array import Array
+
     def compute(coll: DaskCollection) -> Any:
         return coll.compute()
 
@@ -135,5 +139,5 @@ def test_parameter_passing() -> None:
     d: Delayed = increment(3)
     assert compute(d) == 4
 
-    array: da.Array = da.ones(10)
+    array: Array = da.ones(10)
     assert compute(array).shape == (10,)

--- a/dask/tests/test_typing.py
+++ b/dask/tests/test_typing.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+import dask
 import dask.threaded
 from dask.base import DaskMethodsMixin, dont_optimize, tokenize
 from dask.context import globalmethod
@@ -16,6 +17,12 @@ from dask.typing import (
     PostPersistCallable,
 )
 
+try:
+    from IPython.display import DisplayObject
+except ImportError:
+    DisplayObject = Any
+
+
 da = pytest.importorskip("dask.array")
 db = pytest.importorskip("dask.bag")
 dds = pytest.importorskip("dask.datasets")
@@ -24,6 +31,63 @@ dd = pytest.importorskip("dask.dataframe")
 
 def finalize(x: Sequence[Any]) -> Any:
     return x[0]
+
+
+def get1(dsk: Mapping, keys: Sequence[Hashable] | Hashable, **kwargs: Any) -> Any:
+    return dask.threaded.get(dsk, keys, **kwargs)
+
+
+def get2(dsk: Mapping, keys: Sequence[Hashable] | Hashable, **kwargs: Any) -> Any:
+    return dask.get(dsk, keys, **kwargs)
+
+
+class Inheriting(DaskCollection):
+    def __init__(self, based_on: DaskCollection) -> None:
+        self.based_on = based_on
+
+    def __dask_graph__(self) -> Mapping:
+        return self.based_on.__dask_graph__()
+
+    def __dask_keys__(self) -> list[Hashable]:
+        return self.based_on.__dask_keys__()
+
+    def __dask_postcompute__(self) -> tuple[PostComputeCallable, tuple]:
+        return finalize, ()
+
+    def __dask_postpersist__(self) -> tuple[PostPersistCallable, tuple]:
+        return self.based_on.__dask_postpersist__()
+
+    def __dask_tokenize__(self) -> Hashable:
+        return tokenize(self.based_on)
+
+    __dask_scheduler__ = staticmethod(dask.threaded.get)
+
+    __dask_optimize__ = globalmethod(
+        dont_optimize,
+        key="hlgcollection_optim",
+        falsey=dont_optimize,
+    )
+
+    def compute(self, **kwargs) -> Any:
+        return dask.compute(self, **kwargs)
+
+    def persist(self, **kwargs) -> Inheriting:
+        return Inheriting(self.based_on.persist(**kwargs))
+
+    def visualize(
+        self,
+        filename: str = "mydask",
+        format: str | None = None,
+        optimize_graph: bool = False,
+        **kwargs: Any,
+    ) -> DisplayObject | None:
+        return dask.visualize(
+            self,
+            filename=filename,
+            format=format,
+            optimize_graph=optimize_graph,
+            **kwargs,
+        )
 
 
 class HLGCollection(DaskMethodsMixin):
@@ -48,7 +112,7 @@ class HLGCollection(DaskMethodsMixin):
     def __dask_tokenize__(self) -> Hashable:
         return tokenize(self.based_on)
 
-    __dask_scheduler__ = staticmethod(dask.threaded.get)
+    __dask_scheduler__ = staticmethod(get1)
 
     __dask_optimize__ = globalmethod(
         dont_optimize,
@@ -76,7 +140,7 @@ class NotHLGCollection(DaskMethodsMixin):
     def __dask_tokenize__(self) -> Hashable:
         return tokenize(self.based_on)
 
-    __dask_scheduler__ = staticmethod(dask.threaded.get)
+    __dask_scheduler__ = staticmethod(get2)
 
     __dask_optimize__ = globalmethod(
         dont_optimize,
@@ -85,14 +149,14 @@ class NotHLGCollection(DaskMethodsMixin):
     )
 
 
-def increment_(x):
+def increment_(x: int) -> int:
     return x + 1
 
 
 increment: Delayed = delayed(increment_)
 
 
-def assert_isinstance(coll: DaskCollection, protocol: Any):
+def assert_isinstance(coll: DaskCollection, protocol: Any) -> None:
     assert isinstance(coll, protocol)
 
 
@@ -125,18 +189,30 @@ def test_isinstance_custom() -> None:
     assert not isinstance(nhlgc, HLGDaskCollection)
 
 
+def compute(coll: DaskCollection) -> Any:
+    return coll.compute()
+
+
+def compute2(coll: DaskCollection) -> Any:
+    return coll.compute()
+
+
 def test_parameter_passing() -> None:
     from dask.array import Array
-
-    def compute(coll: DaskCollection) -> Any:
-        return coll.compute()
 
     a: Delayed = increment(2)
     hlgc = HLGCollection(a)
     assert compute(hlgc) == 3
+    assert compute2(hlgc) == 3
 
     d: Delayed = increment(3)
     assert compute(d) == 4
+    assert compute2(d) == 4
 
     array: Array = da.ones(10)
     assert compute(array).shape == (10,)
+    assert compute2(array).shape == (10,)
+
+
+def test_inheriting_class() -> Inheriting:
+    return Inheriting(increment(2))

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -22,18 +22,67 @@ CollectionType = TypeVar("CollectionType", bound="DaskCollection")
 
 
 class PostComputeCallable(Protocol):
-    def __call__(self, partitions: Sequence[Any], *args) -> Any:
-        """ """
+    """Protocol defining the signature of a __dask_postcompute__ method."""
+
+    def __call__(self, parts: Sequence[Any], *args: Any) -> Any:
+        """Method called after the keys of a collection are computed.
+
+        Parameters
+        ----------
+        parts : Sequence[Any]
+            The sequence of computed results on each partition (key).
+        *args : Any
+            Additional optional arguments If no extra arguments are
+            necessary, it must be an empty tuple.
+
+        Returns
+        -------
+        Any
+            The final result of the computed collection. For example,
+            the finalize function for ``dask.array.Array``
+            concatenates all the individual array chunks into one
+            large NumPy array, which is then the result of compute.
+
+        """
 
 
 class PostPersistCallable(Protocol[CollectionType]):
+    """Protocol defining the signature of a __dask_postpersist__ method."""
+
     def __call__(
         self,
         dsk: Mapping,
         *args,
         rename: Mapping[str, str] | None = None,
     ) -> CollectionType:
-        """ """
+        """Method called to rebuild a persisted collection.
+
+        Parameters
+        ----------
+        dsk: Mapping
+            A mapping which contains at least the output keys returned
+            by __dask_keys__().
+        *args : Any
+            Additional optional arguments If no extra arguments are
+            necessary, it must be an empty tuple.
+        rename : Mapping[str, str], optional
+            If defined, it indicates that output keys may be changing
+            too; e.g. if the previous output of :meth:`__dask_keys__`
+            was ``[("a", 0), ("a", 1)]``, after calling
+            ``rebuild(dsk, *extra_args, rename={"a": "b"})``
+            it must become ``[("b", 0), ("b", 1)]``.
+            The ``rename`` mapping may not contain the collection
+            name(s); in such case the associated keys do not change.
+            It may contain replacements for unexpected names, which
+            must be ignored.
+
+        Returns
+        -------
+        CollectionType
+            An equivalent Dask collection with the same keys as
+            computed through a different graph.
+
+        """
 
 
 @runtime_checkable
@@ -81,7 +130,7 @@ class DaskCollection(Protocol):
         Returns
         -------
         PostComputeCallable
-            Function that takes the sequence of the results of each
+            Callable that recieves the sequence of the results of each
             final key along with optional arguments. The signure must
             be ``finalize(results: Sequence[Any], *args)``.
         tuple[Any, ...]
@@ -98,16 +147,16 @@ class DaskCollection(Protocol):
         Returns
         -------
         PostPersistCallable
-            Function that rebuilds the collection. The signature
+            Callable that rebuilds the collection. The signature
             should be
             ``rebuild(dsk: Mapping, *args: Any, rename: Mapping[str, str] | None)``.
             The callable should return an equivalent Dask collection
-            with the same keys as `self`, but with the results that
-            are computed through a different graph. In the case of
+            with the same keys as `self`, but with results that are
+            computed through a different graph. In the case of
             :py:func:`dask.persist`, the new graph will have just the
             output keys and the values already computed.
         tuple[Any, ...]
-            Optional arugments passed toe the rebuild function. If no
+            Optional arugments passed to the rebuild callable. If no
             additional arguments are to be passed then this must be an
             empty tuple.
 
@@ -118,24 +167,185 @@ class DaskCollection(Protocol):
 
     @staticmethod
     def __dask_optimize__(
-        dsk: MutableMapping, keys: Sequence[Hashable], **kwargs
+        dsk: MutableMapping,
+        keys: Sequence[Hashable],
+        **kwargs,
     ) -> MutableMapping:
-        """Given a graph and keys, return a new optimized graph."""
+        """Given a graph and keys, return a new optimized graph.
+
+        This method can be either a ``staticmethod`` or a
+        ``classmethod``, but not an ``instancemethod``.
+
+        Note that graphs and keys are merged before calling
+        ``__dask_optimize__``; as such, the graph and keys passed to
+        this method may represent more than one collection sharing the
+        same optimize method.
+
+        Parameters
+        ----------
+        dsk : MutableMapping
+            The merged graphs from all collections sharing the same
+            ``__dask_optimize__`` method.
+        keys : Sequence[Hashable]
+            A list of the outputs from ``__dask_keys__`` from all
+            collections sharing the same ``__dask_optimize__`` method.
+        **kwargs : Any
+            Extra keyword arguments forwarded from the call to
+           ``compute`` or ``persist``. Can be used or ignored as
+           needed.
+
+        Returns
+        -------
+        MutableMapping
+            The optimized Dask graph.
+
+        """
 
     @staticmethod
     def __dask_scheduler__(dsk: Mapping, keys: Sequence[Hashable], **kwargs) -> Any:
-        """The default scheduler get to use for this object."""
+        """The default scheduler ``get`` to use for this object.
+
+        Usually attached to the class as a staticmethod, e.g.:
+
+        >>> import dask.threaded
+        >>> class MyCollection:
+        ...     # Use the threaded scheduler by default
+        ...     __dask_scheduler__ = staticmethod(dask.threaded.get)
+
+        """
 
     def compute(self, **kwargs) -> Any:
-        """TODO"""
+        """Compute this dask collection.
+
+        This turns a lazy Dask collection into its in-memory
+        equivalent. For example a Dask array turns into a NumPy array
+        and a Dask dataframe turns into a Pandas dataframe. The entire
+        dataset must fit into memory before calling this operation.
+
+        Parameters
+        ----------
+        scheduler : string, optional
+            Which scheduler to use like "threads", "synchronous" or
+            "processes". If not provided, the default is to check the
+            global settings first, and then fall back to the
+            collection defaults.
+        optimize_graph : bool, optional
+            If True [default], the graph is optimized before
+            computation. Otherwise the graph is run as is. This can be
+            useful for debugging.
+        kwargs
+            Extra keywords to forward to the scheduler function.
+
+        Returns
+        -------
+        The collection's computed result.
+
+        See Also
+        --------
+        dask.base.compute
+
+        """
 
     def persist(self: CollectionType, **kwargs) -> CollectionType:
-        """TODO"""
+        """Persist this dask collection into memory
 
-    def visualize(self, **kwargs) -> DisplayObject:
-        """TODO"""
+        This turns a lazy Dask collection into a Dask collection with
+        the same metadata, but now with the results fully computed or
+        actively computing in the background.
+
+        The action of function differs significantly depending on the
+        active task scheduler. If the task scheduler supports
+        asynchronous computing, such as is the case of the
+        dask.distributed scheduler, then persist will return
+        *immediately* and the return value's task graph will contain
+        Dask Future objects. However if the task scheduler only
+        supports blocking computation then the call to persist will
+        *block* and the return value's task graph will contain
+        concrete Python results.
+
+        This function is particularly useful when using distributed
+        systems, because the results will be kept in distributed
+        memory, rather than returned to the local process as with
+        compute.
+
+        Parameters
+        ----------
+        scheduler : string, optional
+            Which scheduler to use like "threads", "synchronous" or
+            "processes". If not provided, the default is to check the
+            global settings first, and then fall back to the
+            collection defaults.
+        optimize_graph : bool, optional
+            If True [default], the graph is optimized before
+            computation. Otherwise the graph is run as is. This can be
+            useful for debugging.
+        **kwargs
+            Extra keywords to forward to the scheduler function.
+
+        Returns
+        -------
+        New dask collections backed by in-memory data
+
+        See Also
+        --------
+        dask.base.persist
+
+        """
+
+    def visualize(
+        self,
+        filename: str = "mydask",
+        format: str | None = None,
+        optimize_graph: bool = False,
+        **kwargs: Any,
+    ) -> DisplayObject | None:
+        """Render the computation of this object's task graph using graphviz.
+
+        Requires ``graphviz`` to be installed.
+
+        Parameters
+        ----------
+        filename : str or None, optional
+            The name of the file to write to disk. If the provided
+            `filename` doesn't include an extension, '.png' will be
+            used by default. If `filename` is None, no file will be
+            written, and we communicate with dot using only pipes.
+        format : {'png', 'pdf', 'dot', 'svg', 'jpeg', 'jpg'}, optional
+            Format in which to write output file. Default is 'png'.
+        optimize_graph : bool, optional
+            If True, the graph is optimized before rendering.
+            Otherwise, the graph is displayed as is. Default is False.
+        color: {None, 'order'}, optional
+            Options to color nodes. Provide ``cmap=`` keyword for
+            additional colormap
+        **kwargs
+           Additional keyword arguments to forward to ``to_graphviz``.
+
+        Examples
+        --------
+        >>> x.visualize(filename='dask.pdf')  # doctest: +SKIP
+        >>> x.visualize(filename='dask.pdf', color='order')  # doctest: +SKIP
+
+        Returns
+        -------
+        result : IPython.diplay.Image, IPython.display.SVG, or None
+            See dask.dot.dot_graph for more information.
+
+        See Also
+        --------
+        dask.base.visualize
+        dask.dot.dot_graph
+
+        Notes
+        -----
+        For more information on optimization see here:
+
+        https://docs.dask.org/en/latest/optimize.html
+
+        """
 
 
+@runtime_checkable
 class HLGDaskCollection(DaskCollection):
     def __dask_layers__(self) -> Sequence[str]:
-        """TODO"""
+        """Names of the HighLevelGraph layers."""

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from typing import (
     Any,
-    Callable,
     Hashable,
     Mapping,
     MutableMapping,
     Protocol,
+    Sequence,
+    TypeVar,
     runtime_checkable,
 )
 
@@ -16,36 +17,123 @@ except ImportError:
     DisplayObject = object
 
 
+T = TypeVar("T")
+CollectionType = TypeVar("CollectionType", bound="DaskCollection")
+
+
+class PostComputeCallable(Protocol):
+    def __call__(self, partitions: Sequence[Any], *args) -> Any:
+        """ """
+
+
+class PostPersistCallable(Protocol):
+    def __call__(
+        self,
+        dsk: Mapping,
+        *args,
+        rename: Mapping[str, str] | None = None,
+    ) -> DaskCollection:
+        """ """
+
+
 @runtime_checkable
 class DaskCollection(Protocol):
+    """Protocal defining the interface of a Dask collection."""
+
     def __dask_graph__(self) -> Mapping | None:
-        pass
+        """The Dask task graph.
+
+        The core Dask collections (Array, DatFrame, Bag, and Delayed)
+        use a :py:class:`HighLevelGraph` to represent the collection
+        task graph. It is also possible to represent the task graph as
+        a low level graph using a Python dictionary.
+
+        Returns
+        -------
+        Mapping or None
+            The Dask tash graph. If the task graph is ``None`` then
+            the instance will not be interpreted as a Dask collection.
+            If the instance returns a
+            :py:class:`dask.highlevelgraph.HighLevelGraph` then the
+            :py:func:`__dask_layers__` method must be defined.
+
+        """
 
     def __dask_keys__(self) -> list[Hashable]:
-        pass
+        """The output keys of the task graph.
 
-    def __dask_postcompute__(self) -> tuple[Callable, tuple]:
-        pass
+        Returns
+        -------
+        list
+            The output keys of the collection's task graph.
 
-    def __dask_postpersist__(self) -> tuple[Callable, tuple]:
-        pass
+        """
+
+    def __dask_postcompute__(self) -> tuple[PostComputeCallable, tuple]:
+        """Finalizer function and optional arguments to construct final result.
+
+        Upon computation each key in the collection will have an in
+        memory result, the postcompute function combines each key's
+        result into a final in memory representation. For example,
+        dask.array.Array concatenates the arrays at each chunk into a
+        final in-memory array.
+
+        Returns
+        -------
+        PostComputeCallable
+            Function that takes the sequence of the results of each
+            final key along with optional arguments. The signure must
+            be ``finalize(results: Sequence[Any], *args)``.
+        tuple[Any, ...]
+            Optional arguments passed to the function following the
+            key results (the `*args` part of the
+            ``PostComputeCallable``. If no additional arguments are to
+            be passed then this must be an empty tuple.
+
+        """
+
+    def __dask_postpersist__(self) -> tuple[PostPersistCallable, tuple]:
+        """Rebuilder function and optional arguments to contruct a persisted collection.
+
+        Returns
+        -------
+        PostPersistCallable
+            Function that rebuilds the collection. The signature
+            should be
+            ``rebuild(dsk: Mapping, *args: Any, rename: Mapping[str, str] | None)``.
+            The callable should return an equivalent Dask collection
+            with the same keys as `self`, but with the results that
+            are computed through a different graph. In the case of
+            :py:func:`dask.persist`, the new graph will have just the
+            output keys and the values already computed.
+        tuple[Any, ...]
+            Optional arugments passed toe the rebuild function. If no
+            additional arguments are to be passed then this must be an
+            empty tuple.
+
+        """
 
     def __dask_tokenize__(self) -> Hashable:
-        pass
+        """Value that must fully represent the object."""
 
     @staticmethod
     def __dask_optimize__(dsk: MutableMapping, keys: Any, **kwargs) -> MutableMapping:
-        pass
+        """Given a graph and keys, return a new optimized graph."""
 
     @staticmethod
     def __dask_scheduler__(dsk: Mapping, keys: Any, **kwargs) -> Any:
-        pass
+        """The default scheduler get to use for this object."""
 
     def compute(self, **kwargs) -> Any:
-        pass
+        """TODO"""
 
-    def persist(self, **kwargs) -> Any:
-        pass
+    def persist(self, **kwargs) -> CollectionType:
+        """TODO"""
 
     def visualize(self, **kwargs) -> DisplayObject:
-        pass
+        """TODO"""
+
+
+class HLGDaskCollection(DaskCollection):
+    def __dask_layers__(self) -> list[str]:
+        """TODO"""

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping, MutableMapping, Protocol, runtime_checkable
+from typing import (
+    Any,
+    Callable,
+    Hashable,
+    Mapping,
+    MutableMapping,
+    Protocol,
+    runtime_checkable,
+)
 
 try:
     from IPython.display import DisplayObject

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -1,16 +1,7 @@
 from __future__ import annotations
 
-from typing import (
-    Any,
-    Callable,
-    Hashable,
-    Mapping,
-    MutableMapping,
-    Protocol,
-    Sequence,
-    TypeVar,
-    runtime_checkable,
-)
+from collections.abc import Hashable, Mapping, MutableMapping, Sequence
+from typing import Any, Protocol, TypeVar, runtime_checkable
 
 try:
     from IPython.display import DisplayObject
@@ -20,6 +11,34 @@ except ImportError:
 
 T = TypeVar("T")
 CollectionType = TypeVar("CollectionType", bound="DaskCollection", covariant=True)
+
+
+class SchedulerStaticMethod(Protocol):
+    """Protocol for defining the __dask_scheduler__ staticmethod attribute."""
+
+    def __call__(
+        self,
+        dsk: Mapping,
+        keys: Sequence[Hashable] | Hashable,
+        **kwargs: Any,
+    ) -> Any:
+        """Default dask.get method.
+
+        Parameters
+        ----------
+        dsk : Mapping
+            The task graph.
+        keys : Sequence[Hashable] | Hashable
+            The keys of the task graph to get.
+        **kwargs : Any
+            Arguments passed to the get method.
+
+        Returns
+        -------
+        Any
+            The result.
+
+        """
 
 
 class PostComputeCallable(Protocol):
@@ -202,22 +221,17 @@ class DaskCollection(Protocol):
 
         """
 
-    @staticmethod
-    def __dask_scheduler__(
-        dsk: Mapping,
-        keys: Sequence[Hashable],
-        **kwargs: Any,
-    ) -> Callable:
-        """The default scheduler ``get`` to use for this object.
+    __dask_scheduler__: staticmethod[SchedulerStaticMethod]
+    """The default scheduler ``get`` to use for this object.
 
-        Usually attached to the class as a staticmethod, e.g.:
+    Usually attached to the class as a staticmethod, e.g.:
 
-        >>> import dask.threaded
-        >>> class MyCollection:
-        ...     # Use the threaded scheduler by default
-        ...     __dask_scheduler__ = staticmethod(dask.threaded.get)
+    >>> import dask.threaded
+    >>> class MyCollection:
+    ...     # Use the threaded scheduler by default
+    ...     __dask_scheduler__ = staticmethod(dask.threaded.get)
 
-        """
+    """
 
     def compute(self: CollectionType, **kwargs: Any) -> Any:
         """Compute this dask collection.

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -18,7 +18,12 @@ PostComputeCallable = Callable
 class SchedulerGetCallable(Protocol):
     """Protocol defining the signature of a __dask_scheduler__ callable."""
 
-    def __call__(self, dask: Mapping, keys: Sequence[Hashable] | Hashable, **kwargs) -> Any:
+    def __call__(
+        self,
+        dask: Mapping,
+        keys: Sequence[Hashable] | Hashable,
+        **kwargs: Any,
+    ) -> Any:
         """Method called as the default scheduler for a collection.
 
         Parameters

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -86,7 +86,7 @@ class PostPersistCallable(Protocol[CollType_co]):
 
 @runtime_checkable
 class DaskCollection(Protocol):
-    """Protocal defining the interface of a Dask collection."""
+    """Protocol defining the interface of a Dask collection."""
 
     @abc.abstractmethod
     def __dask_graph__(self) -> Mapping:
@@ -246,7 +246,7 @@ class DaskCollection(Protocol):
 
         See Also
         --------
-        dask.base.compute
+        dask.compute
 
         """
         raise NotImplementedError("Inheriting class must implement this method.")
@@ -294,7 +294,7 @@ class DaskCollection(Protocol):
 
         See Also
         --------
-        dask.base.persist
+        dask.persist
 
         """
         raise NotImplementedError("Inheriting class must implement this method.")
@@ -341,7 +341,7 @@ class DaskCollection(Protocol):
 
         See Also
         --------
-        dask.base.visualize
+        dask.visualize
         dask.dot.dot_graph
 
         Notes

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -26,13 +26,13 @@ class PostComputeCallable(Protocol):
         """ """
 
 
-class PostPersistCallable(Protocol):
+class PostPersistCallable(Protocol[CollectionType]):
     def __call__(
         self,
         dsk: Mapping,
         *args,
         rename: Mapping[str, str] | None = None,
-    ) -> DaskCollection:
+    ) -> CollectionType:
         """ """
 
 

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -135,5 +135,5 @@ class DaskCollection(Protocol):
 
 
 class HLGDaskCollection(DaskCollection):
-    def __dask_layers__(self) -> list[str]:
+    def __dask_layers__(self) -> Sequence[str]:
         """TODO"""

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -117,7 +117,9 @@ class DaskCollection(Protocol):
         """Value that must fully represent the object."""
 
     @staticmethod
-    def __dask_optimize__(dsk: MutableMapping, keys: Sequence[Hashable], **kwargs) -> MutableMapping:
+    def __dask_optimize__(
+        dsk: MutableMapping, keys: Sequence[Hashable], **kwargs
+    ) -> MutableMapping:
         """Given a graph and keys, return a new optimized graph."""
 
     @staticmethod

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -121,7 +121,7 @@ class DaskCollection(Protocol):
         """Given a graph and keys, return a new optimized graph."""
 
     @staticmethod
-    def __dask_scheduler__(dsk: Mapping, keys: Any, **kwargs) -> Any:
+    def __dask_scheduler__(dsk: Mapping, keys: Sequence[Hashable], **kwargs) -> Any:
         """The default scheduler get to use for this object."""
 
     def compute(self, **kwargs) -> Any:

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -30,7 +30,7 @@ class DaskCollection(Protocol):
     def __dask_postpersist__(self) -> tuple[Callable, tuple]:
         pass
 
-    def __dask_tokenize__(self) -> Any:
+    def __dask_tokenize__(self) -> Hashable:
         pass
 
     @staticmethod

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, MutableMapping, Protocol, runtime_checkable
+
+try:
+    from IPython.display import DisplayObject
+except ImportError:
+    DisplayObject = object
+
+
+@runtime_checkable
+class DaskCollection(Protocol):
+    def __dask_graph__(self) -> Mapping | None:
+        pass
+
+    def __dask_keys__(self) -> list:
+        pass
+
+    def __dask_postcompute__(self) -> tuple[Callable, tuple]:
+        pass
+
+    def __dask_postpersist__(self) -> tuple[Callable, tuple]:
+        pass
+
+    def __dask_tokenize__(self) -> Any:
+        pass
+
+    @staticmethod
+    def __dask_optimize__(dsk: MutableMapping, keys: Any, **kwargs) -> MutableMapping:
+        pass
+
+    @staticmethod
+    def __dask_scheduler__(dsk: Mapping, keys: Any, **kwargs) -> Any:
+        pass
+
+    def compute(self, **kwargs) -> Any:
+        pass
+
+    def persist(self, **kwargs) -> Any:
+        pass
+
+    def visualize(self, **kwargs) -> DisplayObject:
+        pass

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -6,7 +6,7 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 try:
     from IPython.display import DisplayObject
 except ImportError:
-    DisplayObject = object
+    DisplayObject = Any
 
 
 T = TypeVar("T")

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import (
     Any,
+    Callable,
     Hashable,
     Mapping,
     MutableMapping,
@@ -169,7 +170,7 @@ class DaskCollection(Protocol):
     def __dask_optimize__(
         dsk: MutableMapping,
         keys: Sequence[Hashable],
-        **kwargs,
+        **kwargs: Any,
     ) -> MutableMapping:
         """Given a graph and keys, return a new optimized graph.
 
@@ -202,7 +203,11 @@ class DaskCollection(Protocol):
         """
 
     @staticmethod
-    def __dask_scheduler__(dsk: Mapping, keys: Sequence[Hashable], **kwargs) -> Any:
+    def __dask_scheduler__(
+        dsk: Mapping,
+        keys: Sequence[Hashable],
+        **kwargs: Any,
+    ) -> Callable:
         """The default scheduler ``get`` to use for this object.
 
         Usually attached to the class as a staticmethod, e.g.:
@@ -214,7 +219,7 @@ class DaskCollection(Protocol):
 
         """
 
-    def compute(self, **kwargs) -> Any:
+    def compute(self: CollectionType, **kwargs: Any) -> Any:
         """Compute this dask collection.
 
         This turns a lazy Dask collection into its in-memory
@@ -246,7 +251,7 @@ class DaskCollection(Protocol):
 
         """
 
-    def persist(self: CollectionType, **kwargs) -> CollectionType:
+    def persist(self: CollectionType, **kwargs: Any) -> CollectionType:
         """Persist this dask collection into memory
 
         This turns a lazy Dask collection into a Dask collection with
@@ -347,5 +352,7 @@ class DaskCollection(Protocol):
 
 @runtime_checkable
 class HLGDaskCollection(DaskCollection):
+    """Protocal defining a Dask collection that uses HighLevelGraphs."""
+
     def __dask_layers__(self) -> Sequence[str]:
         """Names of the HighLevelGraph layers."""

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -51,7 +51,7 @@ class DaskCollection(Protocol):
         Returns
         -------
         Mapping or None
-            The Dask tash graph. If the task graph is ``None`` then
+            The Dask task graph. If the task graph is ``None`` then
             the instance will not be interpreted as a Dask collection.
             If the instance returns a
             :py:class:`dask.highlevelgraph.HighLevelGraph` then the

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -351,7 +351,7 @@ class DaskCollection(Protocol):
 
 
 @runtime_checkable
-class HLGDaskCollection(DaskCollection):
+class HLGDaskCollection(DaskCollection, Protocol):
     """Protocal defining a Dask collection that uses HighLevelGraphs."""
 
     def __dask_layers__(self) -> Sequence[str]:

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -18,7 +18,7 @@ except ImportError:
 
 
 T = TypeVar("T")
-CollectionType = TypeVar("CollectionType", bound="DaskCollection")
+CollectionType = TypeVar("CollectionType", bound="DaskCollection", covariant=True)
 
 
 class PostComputeCallable(Protocol):

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -127,7 +127,7 @@ class DaskCollection(Protocol):
     def compute(self, **kwargs) -> Any:
         """TODO"""
 
-    def persist(self, **kwargs) -> CollectionType:
+    def persist(self: CollectionType, **kwargs) -> CollectionType:
         """TODO"""
 
     def visualize(self, **kwargs) -> DisplayObject:

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -117,7 +117,7 @@ class DaskCollection(Protocol):
         """Value that must fully represent the object."""
 
     @staticmethod
-    def __dask_optimize__(dsk: MutableMapping, keys: Any, **kwargs) -> MutableMapping:
+    def __dask_optimize__(dsk: MutableMapping, keys: Sequence[Hashable], **kwargs) -> MutableMapping:
         """Given a graph and keys, return a new optimized graph."""
 
     @staticmethod

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -13,7 +13,7 @@ class DaskCollection(Protocol):
     def __dask_graph__(self) -> Mapping | None:
         pass
 
-    def __dask_keys__(self) -> list:
+    def __dask_keys__(self) -> list[Hashable]:
         pass
 
     def __dask_postcompute__(self) -> tuple[Callable, tuple]:

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -104,8 +104,8 @@ class DaskCollection(Protocol):
         -------
         PostComputeCallable
             Callable that recieves the sequence of the results of each
-            final key along with optional arguments. The signure must
-            be ``finalize(results: Sequence[Any], *args)``.
+            final key along with optional arguments. An example signature
+            would be ``finalize(results: Sequence[Any], *args)``.
         tuple[Any, ...]
             Optional arguments passed to the function following the
             key results (the `*args` part of the
@@ -146,8 +146,10 @@ class DaskCollection(Protocol):
     __dask_optimize__: Any
     """Given a graph and keys, return a new optimized graph.
 
-    This method can be either a ``staticmethod`` or a
-    ``classmethod``, but not an ``instancemethod``.
+    This method can be either a ``staticmethod`` or a ``classmethod``,
+    but not an ``instancemethod``. For example implementations see the
+    definitions of ``__dask_optimize__`` in the core Dask collections:
+    ``dask.array.Array``, ``dask.dataframe.DataFrame``, etc.
 
     Note that graphs and keys are merged before calling
     ``__dask_optimize__``; as such, the graph and keys passed to

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -12,7 +12,7 @@ except ImportError:
 
 CollType_co = TypeVar("CollType_co", bound="DaskCollection")
 CollType_contra = TypeVar("CollType_contra", bound="DaskCollection", covariant=True)
-PostComputeCallable = Callable[..., Any]
+PostComputeCallable = Callable
 
 
 class PostPersistCallable(Protocol[CollType_contra]):

--- a/setup.py
+++ b/setup.py
@@ -92,5 +92,6 @@ setup(
     tests_require=["pytest"],
     extras_require=extras_require,
     include_package_data=True,
+    package_data={"dask": ["py.typed"]},
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,4 @@ setup(
     tests_require=["pytest"],
     extras_require=extras_require,
     include_package_data=True,
-    package_data={"dask": ["py.typed"]},
-    zip_safe=False,
 )


### PR DESCRIPTION
[PEP 544](https://www.python.org/dev/peps/pep-0544/) introduces the `Protocol` class to the `typing` module in Python 3.8 (the soon be the minimum supported version, https://github.com/dask/community/issues/213). Writing new Dask collections for [dask-awkward](https://github.com/ContinuumIO/dask-awkward/) has had me thinking about working on a `DaskCollection` protocol. I imagine the benefits to be:

- usage with static type checkers
  - other activity in this area at
    - #8295 
    - #8706 
    -  #8854
  - Python supporting IDEs take advantage of typing
- self-documenting; some improvements to [the custom collections page](https://docs.dask.org/en/latest/custom-collections.html) of the docs. The protocol docs can be autogenerated and added to that page.
- purely opt-in feature

The `typing.runtime_checkable` decorator allows use of `isinstance(x, DaskCollection)` in any code base
that uses Dask collections; for example:

```python
>>> from dask.typing import DaskCollection
>>> import dask.array as da
>>> x = da.zeros((10, 3))
>>> isinstance(x, DaskCollection)
True
```
(though this is an order of magnitude slower than `dask.base.is_dask_collection` which only checks for `x.__dask_graph__() is not None`; static typing checking & built-in interface documentation are the core benefits IMO)

Something else that came up in the brief discussion on a call last week was having `{Scheduler,Worker,Nanny}Plugin` protocols in `distributed`; and perhaps those are better places to start introducing protocols to Dask since on the user side typically more folks would write plugins than new collections.