### PR TITLE
DOC: add Domino Data Lab to Hosted / managed Dask clusters

### DIFF
--- a/docs/source/deploying.rst
+++ b/docs/source/deploying.rst
@@ -140,5 +140,7 @@ in more detail how to set up Dask on a variety of local and distributed hardware
 - Hosted / managed Dask clusters (listed in alphabetical order):
     - `Coiled <https://coiled.io/>`_ handles the creation and management of
       Dask clusters on cloud computing environments (AWS, Azure, and GCP).
+    - `Domino Data Lab <https://www.dominodatalab.com/> lets users create
+      Dask clusters in a hosted platform.
     - `Saturn Cloud <https://saturncloud.io/>`_ lets users create
       Dask clusters in a hosted platform or within their own AWS accounts.


### PR DESCRIPTION
Adding domino Data Lab as another option to hosted / managed Dask clusters.

I've just linked to the main page but there's more documentation on what they offer here: https://docs.dominodatalab.com/en/4.6/reference/dask/index.html#