### PR TITLE
Avoid `pytest.warns(None)` in `test_multi.py`

### DIFF
--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2010,7 +2010,7 @@ def test_concat_datetimeindex():
 
 
 def check_with_warning(dask_obj, dask_append, pandas_obj, pandas_append):
-    with pytest.warns(None) as record:
+    with pytest.warns() as record:
         expected = pandas_obj.append(pandas_append)
         result = dask_obj.append(dask_append)
         assert_eq(result, expected)


### PR DESCRIPTION
Partially addresses, but does not fully resolve, https://github.com/dask/dask/issues/8673. However this should unblock CI as `dask/dataframe/tests/test_multi.py` is the only module in `main` raising an error (instead of just a deprecation warning)

EDIT: To be clear, I'm not sure why `test_multi.py` is elevating the deprecation warning to an error and other test modules aren't. We should follow up with another PR that removes all our usages of `pytest.warns(None)` -- this PR is just focused on unblocking CI