### PR TITLE
Temporarily pin `scipy < 1.8.0` in CI

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -56,7 +56,7 @@ dependencies:
   - requests
   - scikit-image
   - scikit-learn
-  - scipy
+  - scipy<1.8.0 # See https://github.com/dask/dask/issues/8682
   - toolz
   - python-snappy
   - sparse

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -55,7 +55,7 @@ dependencies:
   - requests
   - scikit-image
   - scikit-learn
-  - scipy
+  - scipy<1.8.0 # See https://github.com/dask/dask/issues/8682
   - toolz
   - python-snappy
   - sparse

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -56,7 +56,7 @@ dependencies:
   - requests
   - scikit-image
   - scikit-learn
-  - scipy
+  - scipy<1.8.0 # See https://github.com/dask/dask/issues/8682
   - toolz
   - python-snappy
   - sparse


### PR DESCRIPTION
Related to https://github.com/dask/dask/issues/8682. If someone has the time to provide a fix that would be appreciated. Otherwise this PR will temporarily unblock CI and we can continue to track `scipy=1.8.0` compatibility over in https://github.com/dask/dask/issues/8682
