### PR TITLE
Fix eye inconsistency with NumPy for dtype=None (#8669)

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -539,6 +539,8 @@ def eye(N, chunks="auto", M=None, k=0, dtype=float):
     eye = {}
     if M is None:
         M = N
+    if dtype is None:
+        dtype = float
 
     if not isinstance(chunks, (int, str)):
         raise ValueError("chunks must be an int or string")

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -401,6 +401,7 @@ def test_eye():
     assert_eq(da.eye(9, chunks=3, dtype=int), np.eye(9, dtype=int))
     assert_eq(da.eye(10, chunks=3, dtype=int), np.eye(10, dtype=int))
     assert_eq(da.eye(10, chunks=-1, dtype=int), np.eye(10, dtype=int))
+    assert_eq(da.eye(9, chunks=3, dtype=None), np.eye(9, dtype=None))
 
     with dask.config.set({"array.chunk-size": "50 MiB"}):
         x = da.eye(10000, "auto")


### PR DESCRIPTION
- [x] Closes #8669
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
