### PR TITLE
increased performance of k-diagonal extraction in da.diag() and da.diagonal()

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -565,6 +565,9 @@ def eye(N, chunks="auto", M=None, k=0, dtype=float):
 
 @derived_from(np)
 def diag(v, k=0):
+    if not isinstance(v, np.ndarray) and not isinstance(v, Array):
+        raise TypeError(f"v must be a dask array or numpy array, got {type(v)}")
+
     name = "diag-" + tokenize(v, k)
 
     meta = meta_from_array(v, 2 if v.ndim == 1 else 1)
@@ -585,9 +588,10 @@ def diag(v, k=0):
         else:
             raise ValueError("Array must be 1d or 2d only")
         return Array(dsk, name, chunks, meta=meta)
-    if not isinstance(v, Array):
-        raise TypeError(f"v must be a dask array or numpy array, got {type(v)}")
+
     if v.ndim != 1:
+        if v.ndim != 2:
+            raise ValueError("Array must be 1d or 2d only")
         if k == 0 and v.chunks[0] == v.chunks[1]:
             dsk = {
                 (name, i): (np.diag, row[i]) for i, row in enumerate(v.__dask_keys__())

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -9,7 +9,7 @@ from tlz import sliding_window
 
 from ..base import tokenize
 from ..highlevelgraph import HighLevelGraph
-from ..utils import cached_cumsum, derived_from
+from ..utils import cached_cumsum, derived_from, is_cupy_type
 from . import chunk
 from .core import (
     Array,
@@ -669,6 +669,13 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     len_kdiag = kdiag_row_stop - kdiag_row_start
 
     if len_kdiag <= 0:
+        xp = np
+
+        if is_cupy_type(a._meta):
+            import cupy
+
+            xp = cupy
+
         out_chunks = pop_axes(a.chunks, axis1, axis2) + ((0,),)
         dsk = dict()
         for free_idx in free_indices:
@@ -676,7 +683,7 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
                 out_chunks[axis][free_idx[axis]] for axis in range(ndims_free)
             )
             dsk[(name,) + free_idx + (0,)] = (
-                partial(np.empty, dtype=a.dtype),
+                partial(xp.empty, dtype=a.dtype),
                 shape + (0,),
             )
 

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -623,10 +623,14 @@ def diag(v, k=0):
             out_chunks = ()
             while kdiag_row_start < v.shape[0] and kdiag_col_start < v.shape[1]:
                 # locate intersecting chunk:
-                row_filter = (row_starts <= kdiag_row_start) & (kdiag_row_start < row_stops_)
-                col_filter = (col_starts <= kdiag_col_start) & (kdiag_col_start < col_stops_)
-                I, = row_blockid[row_filter]
-                J, = col_blockid[col_filter]
+                row_filter = (row_starts <= kdiag_row_start) & (
+                    kdiag_row_start < row_stops_
+                )
+                col_filter = (col_starts <= kdiag_col_start) & (
+                    kdiag_col_start < col_stops_
+                )
+                (I,) = row_blockid[row_filter]
+                (J,) = col_blockid[col_filter]
                 # localize block info:
                 nrows, ncols = v.chunks[0][I], v.chunks[1][J]
                 kdiag_row_start -= row_starts[I]

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -407,7 +407,7 @@ def test_eye():
         assert 4 < x.npartitions < 32
 
 
-@pytest.mark.parametrize("k", [0, 3, -3])
+@pytest.mark.parametrize("k", [0, 3, -3, 8])
 def test_diag(k):
     v = np.arange(11)
     assert_eq(da.diag(v, k), np.diag(v, k))

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -429,10 +429,10 @@ def test_diag():
     assert sorted(da.diag(v).dask) == sorted(da.diag(v).dask)
 
     x = np.arange(64).reshape((8, 8))
-    assert_eq(da.diag(x), np.diag(x))
-
     d = da.from_array(x, chunks=(4, 4))
-    assert_eq(da.diag(d), np.diag(x))
+    for k in range(-8, 8):
+        assert_eq(da.diag(x, k), np.diag(x, k))
+        assert_eq(da.diag(d, k), np.diag(x, k))
 
 
 def test_diagonal():

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -407,34 +407,34 @@ def test_eye():
         assert 4 < x.npartitions < 32
 
 
-def test_diag():
+@pytest.mark.parametrize("k", [0, 3, -3])
+def test_diag(k):
     v = np.arange(11)
-    assert_eq(da.diag(v), np.diag(v))
+    assert_eq(da.diag(v, k), np.diag(v, k))
 
     v = da.arange(11, chunks=3)
-    darr = da.diag(v)
-    nparr = np.diag(v)
+    darr = da.diag(v, k)
+    nparr = np.diag(v, k)
     assert_eq(darr, nparr)
-    assert sorted(da.diag(v).dask) == sorted(da.diag(v).dask)
+    assert sorted(da.diag(v, k).dask) == sorted(da.diag(v, k).dask)
 
     v = v + v + 3
-    darr = da.diag(v)
-    nparr = np.diag(v)
+    darr = da.diag(v, k)
+    nparr = np.diag(v, k)
     assert_eq(darr, nparr)
 
     v = da.arange(11, chunks=11)
-    darr = da.diag(v)
-    nparr = np.diag(v)
+    darr = da.diag(v, k)
+    nparr = np.diag(v, k)
     assert_eq(darr, nparr)
-    assert sorted(da.diag(v).dask) == sorted(da.diag(v).dask)
+    assert sorted(da.diag(v, k).dask) == sorted(da.diag(v, k).dask)
 
     x = np.arange(64).reshape((8, 8))
+    assert_eq(da.diag(x, k), np.diag(x, k))
     d = da.from_array(x, chunks=(4, 4))
-    d2 = da.from_array(x, chunks=((3, 2, 3), (4, 4)))
-    for k in range(-8, 8):
-        assert_eq(da.diag(x, k), np.diag(x, k))
-        assert_eq(da.diag(d, k), np.diag(x, k))
-        assert_eq(da.diag(d2, k), np.diag(x, k))
+    assert_eq(da.diag(d, k), np.diag(x, k))
+    d = da.from_array(x, chunks=((3, 2, 3), (4, 4)))
+    assert_eq(da.diag(d, k), np.diag(x, k))
 
 
 def test_diagonal():

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -430,9 +430,11 @@ def test_diag():
 
     x = np.arange(64).reshape((8, 8))
     d = da.from_array(x, chunks=(4, 4))
+    d2 = da.from_array(x, chunks=((3, 2, 3), (4, 4)))
     for k in range(-8, 8):
         assert_eq(da.diag(x, k), np.diag(x, k))
         assert_eq(da.diag(d, k), np.diag(x, k))
+        assert_eq(da.diag(d2, k), np.diag(x, k))
 
 
 def test_diagonal():


### PR DESCRIPTION
- [x] Closes #2726 (and maybe #5683)
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Perhaps you might find this useful.  It mirrors the `dask-grblas` implementation, which supports rectangular  chunks.  

It follows the straight path of the k-diagonal through the rectangular chunks of the input matrix , constructing the dask graph along the way.  So chunks untouched by the diagonal end up not being part of the final dask graph, reducing the algorithmic complexity of `diagonal(A, offset, axis1, axis2)` from 

O(*M*&nbsp;*N*<sub>axis1</sub>&nbsp;*N*<sub>axis2</sub>) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; O(*M*&nbsp;max(1, *N*<sub>*k*</sub>)) ,

where *N*<sub>axis1</sub> (*N*<sub>axis2</sub>) is the number of chunks along `axis1` (`axis2`) of array `A`; *M* is the total number of chunks of `A` after `axis1` and `axis2` have been removed; while *N*<sub>*k*</sub> is the number of chunks touched by the k-diagonal after all axes, except `axis1` and `axis2`, have been removed. 

Relevant test-units have been modified to reflect this change. 

Critique is welcome.

NB: It might be worth comparing this with #5683 (which I only discovered after pushing this commit).