### PR TITLE
Unpin `coverage` in CI

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -30,7 +30,7 @@ dependencies:
   - fsspec
   - sqlalchemy>=1.4.0
   - pyarrow=1.0
-  - coverage<6.3 # https://github.com/nedbat/coveragepy/issues/1310
+  - coverage
   - jsonschema
   # other -- IO
   - bcolz

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -30,7 +30,7 @@ dependencies:
   - fsspec
   - sqlalchemy>=1.4.0
   - pyarrow=4.0
-  - coverage<6.3 # https://github.com/nedbat/coveragepy/issues/1310
+  - coverage
   - jsonschema
   # other -- IO
   - bcolz

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -30,7 +30,7 @@ dependencies:
   - fsspec
   - sqlalchemy>=1.4.0
   - pyarrow
-  - coverage<6.3 # https://github.com/nedbat/coveragepy/issues/1310
+  - coverage
   - jsonschema
   # other -- IO
   # Not available for Python 3.9 on conda-forge


### PR DESCRIPTION
This is the companion PR to https://github.com/dask/distributed/pull/5770 and reverts the pinning added in https://github.com/dask/dask/pull/8631 as it's no longer needed with the `coverage=6.3.1` release