### PR TITLE
Revise column-projection optimization to capture common dask-sql patterns

### DIFF
--- a/dask/layers.py
+++ b/dask/layers.py
@@ -10,7 +10,7 @@ from typing import Any
 import tlz as toolz
 from tlz.curried import map
 
-from .base import tokenize
+from .base import is_dask_collection, tokenize
 from .blockwise import Blockwise, BlockwiseDep, BlockwiseDepDict, blockwise_token
 from .core import flatten, keys_in_tasks
 from .highlevelgraph import Layer
@@ -1541,3 +1541,53 @@ class DataFrameTreeReduction(Layer):
         # `Serialized` functions nested within them should be deserialzed
         # automatically by the comm.
         return {"dsk": toolz.valmap(to_serialize, raw), "deps": deps}
+
+
+class SelectionLayer(Blockwise):
+    """DataFrame-based Column or Row-Selection Layer"""
+
+    def __init__(
+        self,
+        name,
+        frame,
+        selection,
+        annotations=None,
+    ):
+        self.name = name
+        self.frame = frame
+        self.selection = selection
+        self.annotations = annotations
+
+        # Initialize `inputs`, `inputs_indices` & `numblocks`
+        # for target `frame` collection
+        inputs = [frame._name]
+        inputs_indices = ["i"]
+        numblocks = {frame._name: (frame.npartitions,)}
+
+        # Update `inputs`, `inputs_indices` & `numblocks`
+        # for getitem `selection`
+        if is_dask_collection(selection) and hasattr(selection, "npartitions"):
+            inputs.append(selection._name)
+            numblocks[selection._name] = (selection.npartitions,)
+            inputs_indices.append("i")
+            self.kind = "row-selection"
+        else:
+            inputs.append(selection)
+            inputs_indices.append(None)
+            self.kind = "column-selection"
+
+        # Initalize Blockwise backend
+        indices = [(k, v) for k, v in zip(inputs, inputs_indices)]
+        keys = map(blockwise_token, range(len(inputs)))
+        super().__init__(
+            output=self.name,
+            output_indices="i",
+            dsk={self.name: (operator.getitem,) + tuple(keys)},
+            indices=indices,
+            numblocks=numblocks,
+            concatenate=True,
+            annotations=annotations,
+        )
+
+    def __repr__(self):
+        return f"SelectionLayer<name='{self.name}', kind={self.kind}, selection={self.selection}>"


### PR DESCRIPTION
This PR adds a simple (but convenient) `SelectionLayer`, and revises `optimize_dataframe_getitem` (column projection) to capture common Dask-SQL queries (where `SELECT` is used with a `WHERE` filter statement).

**TODO**: Add thorough write-up

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
