### PR TITLE
Do not allow iterating a DataFrameGroupBy

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -37,8 +37,8 @@ from .utils import (
 #
 # Dask groupby supports reductions, i.e., mean, sum and alike, and apply. The
 # former do not shuffle the data and are efficiently implemented as tree
-# reductions. The latter is implemented by shuffling the underlying partiitons
-# such that all items of a group can be found in the same parititon.
+# reductions. The latter is implemented by shuffling the underlying partitions
+# such that all items of a group can be found in the same partition.
 #
 # The argument to ``.groupby`` (``by``), can be a ``str``, ``dd.DataFrame``,
 # ``dd.Series``, or a list thereof. In operations on the grouped object, the
@@ -1123,6 +1123,14 @@ class _GroupBy:
             "sort": self.sort,
             **self.observed,
         }
+
+    def __iter__(self):
+        raise NotImplementedError(
+            "Iteration of DataFrameGroupBy objects requires computing the groups which "
+            "may be slow. You probably want to use 'apply' to execute a function for "
+            "all the columns. To access individual groups, use 'get_group'. To list "
+            "all the group names, use 'df[<group column>].unique().compute()'."
+        )
 
     @property
     def _meta_nonempty(self):

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2608,3 +2608,18 @@ def test_groupby_multi_index_with_row_operations(operation):
     ddf = dd.from_pandas(df, npartitions=3)
     actual = caller(ddf.groupby(["A", ddf["A"].eq("a1")])["B"])
     assert_eq(expected, actual)
+
+
+def test_groupby_iter_fails():
+    df = pd.DataFrame(
+        data=[
+            ["a0", "b1"],
+            ["a1", "b1"],
+            ["a3", "b3"],
+            ["a5", "b5"],
+        ],
+        columns=["A", "B"],
+    )
+    ddf = dd.from_pandas(df, npartitions=1)
+    with pytest.raises(NotImplementedError, match="computing the groups"):
+        list(ddf.groupby("A"))


### PR DESCRIPTION
I ran into this issue yesterday (similar to #8695, a naive Pandas-aware mistake) and the fix seemed simple enough.

- [X] Closes #5124
- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`
