### PR TITLE
offered a fix for rechunking with zero-size-chunks

### DIFF
--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -84,6 +84,7 @@ def _intersect_1d(breaks):
     last_end = 0
     old_idx = 0
     last_o_br = 0
+    last_o_end = 0
     ret = []
     ret_next = []
     for idx in range(1, len(breaks)):
@@ -103,14 +104,15 @@ def _intersect_1d(breaks):
             if label == "o":
                 old_idx += 1
             if label == "n" and last_label == "n":
-                if last_o_br == br:
-                    ret_next.append((old_idx - 1, slice(start, end)))
+                if last_o_br == br and old_idx > 0:
+                    ret_next.append((old_idx - 1, slice(last_o_end, last_o_end)))
                 else:
                     ret_next.append((old_idx, slice(start, end)))
             continue
         ret_next.append((old_idx, slice(start, end)))
         if label == "o":
             last_o_br = br
+            last_o_end = end
             old_idx += 1
             start = 0
 

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -102,6 +102,8 @@ def _intersect_1d(breaks):
         last_end = end
         if br == last_br:
             if label == "o":
+                last_o_br = br
+                last_o_end = end
                 old_idx += 1
             if label == "n" and last_label == "n":
                 if last_o_br == br and old_idx > 0:

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -75,48 +75,77 @@ def _intersect_1d(breaks):
     breaks: list of tuples
         Each tuple is ('o', 8) or ('n', 8)
         These are pairs of 'o' old or new 'n'
-        indicator with a corresponding cumulative sum.
-
+        indicator with a corresponding cumulative sum,
+        or breakpoint (a position along the chunking axis).
+        The list of pairs is already ordered by breakpoint.
+        Note that an 'o' pair always occurs BEFORE
+        an 'n' pair if both share the same breakpoint.
     Uses 'o' and 'n' to make new tuples of slices for
     the new block crosswalk to old blocks.
     """
-    start = 0
+    # EXPLANATION:
+    # We know each new chunk is obtained from the old chunks, but
+    # from which ones and how? This function provides the answer.
+    # On return, each new chunk is represented as a list of slices
+    # of the old chunks. Therefore,  paired with each slice is the
+    # index of the old chunk to which that slice refers.
+    # NOTE: if any nonzero-size new chunks extend beyond the total
+    #    span of the old chunks, then those new chunks are assumed
+    #    to be obtained from an imaginary old chunk that extends
+    #    from the end of that total span to infinity. The chunk-
+    #    index of this imaginary chunk follows in consecutive order
+    #    from the chunk-indices of the actual old chunks.
+
+    # First, let us determine the index of the last old_chunk:
+    o_pairs = [pair for pair in breaks if pair[0] == "o"]
+    last_old_chunk_idx = len(o_pairs) - 2
+    last_o_br = o_pairs[-1][1]  # end of range spanning all old chunks
+
+    start = 0  # start of a slice of an old chunk
     last_end = 0
-    old_idx = 0
-    last_o_br = 0
+    old_idx = 0  # index of old chunk
     last_o_end = 0
-    ret = []
-    ret_next = []
-    for idx in range(1, len(breaks)):
+    ret = []  # will hold the list of new chunks
+    ret_next = []  # will hold the list of slices comprising one new chunk
+    for idx in range(1, len(breaks)):  # Note start from the 2nd pair
+        # the interval between any two consecutive breakpoints is a potential
+        # new chunk:
         label, br = breaks[idx]
         last_label, last_br = breaks[idx - 1]
         if last_label == "n":
+            # This always denotes the end of a new chunk or the start
+            # of the next new chunk or both
+            start = last_end
             if ret_next:
                 ret.append(ret_next)
                 ret_next = []
-        if last_label == "o":
-            start = 0
         else:
-            start = last_end
-        end = br - last_br + start
+            start = 0
+        end = br - last_br + start  # end of a slice of an old chunk
         last_end = end
         if br == last_br:
+            # Here we have a zero-size interval between the previous and
+            # current breakpoints. This should not result in a slice unless
+            # this interval's end-points (`last_label` and `label`) are both
+            # equal to 'n'
             if label == "o":
-                last_o_br = br
-                last_o_end = end
                 old_idx += 1
+                last_o_end = end
             if label == "n" and last_label == "n":
-                if last_o_br == br and old_idx > 0:
-                    ret_next.append((old_idx - 1, slice(last_o_end, last_o_end)))
-                else:
-                    ret_next.append((old_idx, slice(start, end)))
-            continue
+                if br == last_o_br:
+                    # zero-size new chunks located at the edge of the range
+                    # spanning all the old chunks are assumed to come from the
+                    # end of the last old chunk:
+                    slc = slice(last_o_end, last_o_end)
+                    ret_next.append((last_old_chunk_idx, slc))
+                    continue
+            else:
+                continue
         ret_next.append((old_idx, slice(start, end)))
         if label == "o":
-            last_o_br = br
-            last_o_end = end
             old_idx += 1
             start = 0
+            last_o_end = end
 
     if ret_next:
         ret.append(ret_next)

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -83,6 +83,7 @@ def _intersect_1d(breaks):
     start = 0
     last_end = 0
     old_idx = 0
+    last_o_br = 0
     ret = []
     ret_next = []
     for idx in range(1, len(breaks)):
@@ -101,9 +102,15 @@ def _intersect_1d(breaks):
         if br == last_br:
             if label == "o":
                 old_idx += 1
+            if label == "n" and last_label == "n":
+                if last_o_br == br:
+                    ret_next.append((old_idx - 1, slice(start, end)))
+                else:
+                    ret_next.append((old_idx, slice(start, end)))
             continue
         ret_next.append((old_idx, slice(start, end)))
         if label == "o":
+            last_o_br = br
             old_idx += 1
             start = 0
 

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -799,3 +799,15 @@ def test_auto_chunks():
     with dask.config.set({"array.chunk-size": "50 MiB"}):
         x = da.ones((10000, 10000))
         assert 4 < x.npartitions < 32
+
+
+def test_diagonal_zero_chunks():
+    x = da.ones((8, 8), chunks=(4, 4))
+    dd = da.ones((8, 8), chunks=(4, 4))
+    d = da.diagonal(dd)
+
+    expected = np.ones((8,))
+    assert_eq(d, expected)
+    assert_eq(d + d, 2 * expected)
+    A = d + x
+    assert_eq(A, np.full((8, 8), 2.0))

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -1017,3 +1017,11 @@ def test_old_to_new_with_zero():
     result = _old_to_new(old, new)
     expected = [[[(0, slice(0, 4))], [(0, slice(4, 4))], [(1, slice(0, 4))]]]
     assert result == expected
+
+    old = ((4, 0, 4),)
+    new = ((4, 0, 2, 2),)
+    result = _old_to_new(old, new)
+    expected = [
+        [[(0, slice(0, 4))], [(1, slice(0, 0))], [(2, slice(0, 2))], [(2, slice(2, 4))]]
+    ]
+    assert result == expected

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -939,13 +939,48 @@ def test_intersect_chunks_empty():
     old = ((4, 4), (2,))
     new = ((4, 0, 0, 4), (1, 1))
     result = list(intersect_chunks(old, new))
+
     expected = [
         (((0, slice(0, 4, None)), (0, slice(0, 1, None))),),
         (((0, slice(0, 4, None)), (0, slice(1, 2, None))),),
+        (((0, slice(4, 4, None)), (0, slice(0, 1, None))),),
+        (((0, slice(4, 4, None)), (0, slice(1, 2, None))),),
+        (((0, slice(4, 4, None)), (0, slice(0, 1, None))),),
+        (((0, slice(4, 4, None)), (0, slice(1, 2, None))),),
+        (((1, slice(0, 4, None)), (0, slice(0, 1, None))),),
+        (((1, slice(0, 4, None)), (0, slice(1, 2, None))),),
+    ]
+
+    assert result == expected
+
+    old = ((4, 4), (2,))
+    new = ((2, 0, 0, 2, 4), (1, 1))
+    result = list(intersect_chunks(old, new))
+    expected = [
+        (((0, slice(0, 2, None)), (0, slice(0, 1, None))),),
+        (((0, slice(0, 2, None)), (0, slice(1, 2, None))),),
+        (((0, slice(2, 2, None)), (0, slice(0, 1, None))),),
+        (((0, slice(2, 2, None)), (0, slice(1, 2, None))),),
+        (((0, slice(2, 2, None)), (0, slice(0, 1, None))),),
+        (((0, slice(2, 2, None)), (0, slice(1, 2, None))),),
+        (((0, slice(2, 4, None)), (0, slice(0, 1, None))),),
+        (((0, slice(2, 4, None)), (0, slice(1, 2, None))),),
+        (((1, slice(0, 4, None)), (0, slice(0, 1, None))),),
+        (((1, slice(0, 4, None)), (0, slice(1, 2, None))),),
+    ]
+
+    assert result == expected
+
+    old = ((4, 4), (2,))
+    new = ((0, 0, 4, 4), (1, 1))
+    result = list(intersect_chunks(old, new))
+    expected = [
         (((0, slice(0, 0, None)), (0, slice(0, 1, None))),),
         (((0, slice(0, 0, None)), (0, slice(1, 2, None))),),
         (((0, slice(0, 0, None)), (0, slice(0, 1, None))),),
         (((0, slice(0, 0, None)), (0, slice(1, 2, None))),),
+        (((0, slice(0, 4, None)), (0, slice(0, 1, None))),),
+        (((0, slice(0, 4, None)), (0, slice(1, 2, None))),),
         (((1, slice(0, 4, None)), (0, slice(0, 1, None))),),
         (((1, slice(0, 4, None)), (0, slice(1, 2, None))),),
     ]
@@ -959,5 +994,5 @@ def test_old_to_new_empty():
     old = ((4, 4),)
     new = ((4, 0, 4),)
     result = _old_to_new(old, new)
-    expected = [[[(0, slice(0, 4))], [(0, slice(0, 0))], [(1, slice(0, 4))]]]
+    expected = [[[(0, slice(0, 4))], [(0, slice(4, 4))], [(1, slice(0, 4))]]]
     assert result == expected

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -60,6 +60,37 @@ def test_rechunk_internals_1():
     ]
     assert i1d[1] == answer4
 
+    new = cumdims_label(((1, 1, 2), (1, 5, 1, 0)), "n")
+    breaks = tuple(_breakpoints(o, n) for o, n in zip(old, new))
+    answer5 = (
+        ("o", 0),
+        ("n", 0),
+        ("o", 1),
+        ("n", 1),
+        ("o", 2),
+        ("o", 3),
+        ("o", 4),
+        ("o", 5),
+        ("n", 6),
+        ("n", 7),
+        ("n", 7),
+    )
+    assert breaks[1] == answer5
+    i1d = [_intersect_1d(b) for b in breaks]
+    answer6 = [
+        [(0, slice(0, 1))],
+        [
+            (1, slice(0, 1)),
+            (2, slice(0, 1)),
+            (3, slice(0, 1)),
+            (4, slice(0, 1)),
+            (5, slice(0, 1)),
+        ],
+        [(5, slice(1, 2))],
+        [(5, slice(2, 2))],
+    ]
+    assert i1d[1] == answer6
+
 
 def test_intersect_1():
     """Convert 1 D chunks"""
@@ -947,10 +978,10 @@ def test_intersect_chunks_with_zero():
     expected = [
         (((0, slice(0, 4, None)), (0, slice(0, 1, None))),),
         (((0, slice(0, 4, None)), (0, slice(1, 2, None))),),
-        (((0, slice(4, 4, None)), (0, slice(0, 1, None))),),
-        (((0, slice(4, 4, None)), (0, slice(1, 2, None))),),
-        (((0, slice(4, 4, None)), (0, slice(0, 1, None))),),
-        (((0, slice(4, 4, None)), (0, slice(1, 2, None))),),
+        (((1, slice(0, 0, None)), (0, slice(0, 1, None))),),
+        (((1, slice(0, 0, None)), (0, slice(1, 2, None))),),
+        (((1, slice(0, 0, None)), (0, slice(0, 1, None))),),
+        (((1, slice(0, 0, None)), (0, slice(1, 2, None))),),
         (((1, slice(0, 4, None)), (0, slice(0, 1, None))),),
         (((1, slice(0, 4, None)), (0, slice(1, 2, None))),),
     ]
@@ -1015,13 +1046,19 @@ def test_old_to_new_with_zero():
     old = ((4, 4),)
     new = ((4, 0, 4),)
     result = _old_to_new(old, new)
-    expected = [[[(0, slice(0, 4))], [(0, slice(4, 4))], [(1, slice(0, 4))]]]
+    expected = [[[(0, slice(0, 4))], [(1, slice(0, 0))], [(1, slice(0, 4))]]]
+    assert result == expected
+
+    old = ((4,),)
+    new = ((4, 0),)
+    result = _old_to_new(old, new)
+    expected = [[[(0, slice(0, 4))], [(0, slice(4, 4))]]]
     assert result == expected
 
     old = ((4, 0, 4),)
     new = ((4, 0, 2, 2),)
     result = _old_to_new(old, new)
     expected = [
-        [[(0, slice(0, 4))], [(1, slice(0, 0))], [(2, slice(0, 2))], [(2, slice(2, 4))]]
+        [[(0, slice(0, 4))], [(2, slice(0, 0))], [(2, slice(0, 2))], [(2, slice(2, 4))]]
     ]
     assert result == expected

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -907,14 +907,18 @@ def test_balance_split_into_n_chunks():
             assert len(y.chunks[0]) == nchunks
 
 
-def test_rechunk_with_empty():
+def test_rechunk_with_zero():
     a = da.ones((8, 8), chunks=(4, 4))
     result = a.rechunk(((4, 4), (4, 0, 0, 4)))
     expected = da.ones((8, 8), chunks=((4, 4), (4, 0, 0, 4)))
+
+    # reverse:
+    a, expected = expected, a
+    result = a.rechunk((4, 4))
     assert_eq(result, expected)
 
 
-def test_intersect_chunks_nonempty():
+def test_intersect_chunks_with_nonzero():
     from dask.array.rechunk import intersect_chunks
 
     old = ((4, 4), (2,))
@@ -933,7 +937,7 @@ def test_intersect_chunks_nonempty():
     assert result == expected
 
 
-def test_intersect_chunks_empty():
+def test_intersect_chunks_with_zero():
     from dask.array.rechunk import intersect_chunks
 
     old = ((4, 4), (2,))
@@ -949,6 +953,23 @@ def test_intersect_chunks_empty():
         (((0, slice(4, 4, None)), (0, slice(1, 2, None))),),
         (((1, slice(0, 4, None)), (0, slice(0, 1, None))),),
         (((1, slice(0, 4, None)), (0, slice(1, 2, None))),),
+    ]
+
+    assert result == expected
+
+    old = ((4, 0, 0, 4), (1, 1))
+    new = ((4, 4), (2,))
+    result = list(intersect_chunks(old, new))
+
+    expected = [
+        (
+            ((0, slice(0, 4, None)), (0, slice(0, 1, None))),
+            ((0, slice(0, 4, None)), (1, slice(0, 1, None))),
+        ),
+        (
+            ((3, slice(0, 4, None)), (0, slice(0, 1, None))),
+            ((3, slice(0, 4, None)), (1, slice(0, 1, None))),
+        ),
     ]
 
     assert result == expected
@@ -988,7 +1009,7 @@ def test_intersect_chunks_empty():
     assert result == expected
 
 
-def test_old_to_new_empty():
+def test_old_to_new_with_zero():
     from dask.array.rechunk import _old_to_new
 
     old = ((4, 4),)


### PR DESCRIPTION
- [x] Closes #5661
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

@TomAugspurger 
I copied your tests (with a few modifications) which you recommended in #5661 to this PR.  These proved very useful in bringing about this fix.  

@TAdeJong, may I invite you to test whether this PR fixes your problem with `diagonal(A, k)` or not.
To clarify: as you've mentioned already, `diag(A, k)` of #8689 does not depend on `diagonal(A, k)`.  Nevertheless, since `diagonal(A, k)` depends on how `dask` handles zero-size-chunks, it would be prudent to check that `diagonal(A, k)` works under this PR.