### PR TITLE
Type annotations, part 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,18 @@ repos:
       hooks:
       - id: flake8
         language_version: python3
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.931
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          # Type stubs
+          - types-docutils
+          - types-pkg_resources
+          - types-PyYAML
+          - types-requests
+          - types-setuptools
+          # Libraries exclusively imported under `if TYPE_CHECKING:`
+          - typing_extensions  # To be reviewed after dropping Python 3.7
+          # Typed libraries
+          - numpy

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include LICENSE.txt
 include MANIFEST.in
 include dask/dask.yaml
 include dask/dask-schema.yaml
+include dask/py.typed
 
 include versioneer.py
 include dask/_version.py

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -263,10 +263,10 @@ Docstring testing requires ``graphviz`` to be installed. This can be done via::
 Code Formatting
 ~~~~~~~~~~~~~~~
 
-Dask uses several code linters (flake8, black, isort, pyupgrade), which are enforced by
-CI. Developers should run them locally before they submit a PR, through the single
-command ``pre-commit run --all-files``. This makes sure that linter versions and options
-are aligned for all developers.
+Dask uses several code linters (flake8, black, isort, pyupgrade, mypy), which are
+enforced by CI. Developers should run them locally before they submit a PR, through the
+single command ``pre-commit run --all-files``. This makes sure that linter versions and
+options are aligned for all developers.
 
 Optionally, you may wish to setup the `pre-commit hooks <https://pre-commit.com/>`_ to
 run automatically when you make a git commit. This can be done by running::

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,10 @@ parentdir_prefix = dask-
 [aliases]
 test = pytest
 
+[options.package_data]
+dask =
+    py.typed
+
 [tool:pytest]
 markers:
   network: Test requires an internet connection

--- a/setup.py
+++ b/setup.py
@@ -83,5 +83,5 @@ setup(
     tests_require=["pytest"],
     extras_require=extras_require,
     include_package_data=True,
-    zip_safe=False,
+    zip_safe=False,  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 )


### PR DESCRIPTION
Continues from #8295.
Enable mypy in CI and let mypy use dask annotations when it runs on third party packages that import dask.

## TODO
several files still need tweaking