### PR TITLE
Add manual trigger for running test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch


### PR DESCRIPTION
This will add a button to GitHub's UI which lets us manually trigger our test suite. This is useful, for example, when we see unrelated test failures on a PR and there hasn't been a recent push to `main`