### PR TITLE
fixed bug in dask.array.roll() for roll-shifts the size of the input array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4058,7 +4058,7 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
         except TypeError:
             return wrap.empty(shape, chunks=shape, dtype=meta.dtype)
     elif n == 1:
-        return seq2[0].copy()
+        return seq2[0]
 
     if not allow_unknown_chunksizes and not all(
         i == axis or all(x.shape[i] == seq2[0].shape[i] for x in seq2)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4058,7 +4058,7 @@ def concatenate(seq, axis=0, allow_unknown_chunksizes=False):
         except TypeError:
             return wrap.empty(shape, chunks=shape, dtype=meta.dtype)
     elif n == 1:
-        return seq2[0]
+        return seq2[0].copy()
 
     if not allow_unknown_chunksizes and not all(
         i == axis or all(x.shape[i] == seq2[0].shape[i] for x in seq2)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1865,6 +1865,7 @@ def roll(array, shift, axis=None):
         result = concatenate([result[sl1], result[sl2]], axis=i)
 
     result = result.reshape(array.shape)
+    result = result.copy() if result is array else result
 
     return result
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1865,6 +1865,7 @@ def roll(array, shift, axis=None):
         result = concatenate([result[sl1], result[sl2]], axis=i)
 
     result = result.reshape(array.shape)
+    # Ensure that the output is always a new array object
     result = result.copy() if result is array else result
 
     return result

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1329,6 +1329,14 @@ def test_roll(chunks, shift, axis):
         assert_eq(np.roll(x, shift, axis), da.roll(a, shift, axis))
 
 
+def test_roll_bug():
+    # This bug was exposed in GitHub Issue #8723
+    x = da.arange(2, 3)
+    y = da.roll(x, 1)
+    y[0] = 0
+    assert x[0].compute() == 2
+
+
 @pytest.mark.parametrize("shape", [(10,), (5, 10), (5, 10, 10)])
 def test_shape_and_ndim(shape):
     x = da.random.random(shape)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1329,12 +1329,10 @@ def test_roll(chunks, shift, axis):
         assert_eq(np.roll(x, shift, axis), da.roll(a, shift, axis))
 
 
-def test_roll_bug():
-    # This bug was exposed in GitHub Issue #8723
+def test_roll_always_results_in_a_new_array():
     x = da.arange(2, 3)
     y = da.roll(x, 1)
-    y[0] = 0
-    assert x[0].compute() == 2
+    assert y is not x
 
 
 @pytest.mark.parametrize("shape", [(10,), (5, 10), (5, 10, 10)])


### PR DESCRIPTION
- [x] Closes (not applicable)
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Discovered a bug while working with `dask.array.roll()`:

```python
x = da.arange(2, 3)
y = da.roll(x, 1)
y[0] = 0
x.compute(), y.compute()
```

Output:
```python
(array([0]), array([0]))
```

Should have been:
```python
(array([2]), array([0]))
```
