### PR TITLE
Temporarily remove `scipy` upstream CI build

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -10,14 +10,16 @@ if [[ ${UPSTREAM_DEV} ]]; then
     mamba install -y -c arrow-nightlies "pyarrow>5.0"
 
     # FIXME https://github.com/mamba-org/mamba/issues/412
-    # mamba uninstall --force numpy pandas scipy fastparquet
-    conda uninstall --force numpy pandas scipy fastparquet
+    # mamba uninstall --force numpy pandas fastparquet
+
+    # TODO: Add development version of scipy once
+    # https://github.com/dask/dask/issues/8682 is resolved
+    conda uninstall --force numpy pandas fastparquet
 
     python -m pip install --no-deps --pre \
         -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \
         numpy \
-        pandas \
-        scipy
+        pandas
 
     python -m pip install \
         --upgrade \


### PR DESCRIPTION
@ncclementi pointed out that our upstream CI build is [currently failing during test collection](https://github.com/dask/dask/runs/5203957060?check_suite_focus=true) due to https://github.com/dask/dask/issues/8682. This PR proposes we temporarily remove the development version of `scipy` from our upstream CI build until https://github.com/dask/dask/issues/8682 is resolved. This should help other folks, like @ncclementi, more easily debug other test failures in the upstream build 

cc @jsignell 