### PR TITLE
Update Docker example to use current best practices

### DIFF
--- a/docs/source/deploying-docker.rst
+++ b/docs/source/deploying-docker.rst
@@ -23,18 +23,27 @@ These images are large, around 1GB.
 Example
 -------
 
-Here is a simple example on the local host network
+Here is a simple example on a dedicated virtual network
 
 .. code-block:: bash
 
-   docker run -it --network host daskdev/dask dask-scheduler  # start scheduler
+   docker network create dask
 
-   docker run -it --network host daskdev/dask dask-worker localhost:8786 # start worker
-   docker run -it --network host daskdev/dask dask-worker localhost:8786 # start worker
-   docker run -it --network host daskdev/dask dask-worker localhost:8786 # start worker
+   docker run --network dask --name scheduler daskdev/dask dask-scheduler  # start scheduler
 
-   docker run -it --network host daskdev/dask-notebook  # start Jupyter server
+   docker run --network dask daskdev/dask dask-worker scheduler:8786 # start worker
+   docker run --network dask daskdev/dask dask-worker scheduler:8786 # start worker
+   docker run --network dask daskdev/dask dask-worker scheduler:8786 # start worker
 
+   docker run --network dask -p 8888:8888 daskdev/dask-notebook  # start Jupyter server
+
+Then from within the notebook environment you can connect to the Dask cluster like this:
+
+.. code-block:: python
+
+   from dask.distributed import Client
+   client = Client("scheduler:8786")
+   client
 
 Extensibility
 -------------
@@ -53,7 +62,7 @@ the Dask worker software environment:
 
 .. code-block:: bash
 
-   docker run -it -e EXTRA_CONDA_PACKAGES="joblib" daskdev/dask dask-worker localhost:8786
+   docker run --network dask -e EXTRA_CONDA_PACKAGES="joblib" daskdev/dask dask-worker scheduler:8786
 
 Note that using these can significantly delay the container from starting,
 especially when using ``apt``, or ``conda`` (``pip`` is relatively fast).

--- a/docs/source/deploying-docker.rst
+++ b/docs/source/deploying-docker.rst
@@ -29,7 +29,7 @@ Here is a simple example on a dedicated virtual network
 
    docker network create dask
 
-   docker run --network dask --name scheduler daskdev/dask dask-scheduler  # start scheduler
+   docker run --network dask -p 8787:8787 --name scheduler daskdev/dask dask-scheduler  # start scheduler
 
    docker run --network dask daskdev/dask dask-worker scheduler:8786 # start worker
    docker run --network dask daskdev/dask dask-worker scheduler:8786 # start worker


### PR DESCRIPTION
Closes #8704
Supersedes #8729

This PR updates the Dask Docker example to follow best practices and also to work on all platforms as the previous host based example was linux only.

- Containers are now created on their own network
- Workers and notebook use DNS to connect to the scheduler by name
- Added Python snippet for connecting within Jupyter
- Added port exposure for Jupyter and Dask dashboard