### PR TITLE
Improve multi dataframe join performance

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4944,7 +4944,7 @@ class DataFrame(_Frame):
             from .multi import _recursive_pairwise_outer_join
 
             # If its an outer join we can use the full recursive pairwise join.
-            if how is "outer":
+            if how == "outer":
                 full = [self] + other
 
                 return _recursive_pairwise_outer_join(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4943,8 +4943,8 @@ class DataFrame(_Frame):
 
             from .multi import _recursive_pairwise_outer_join
 
-            other = _recursive_pairwise_outer_join(
-                other,
+            return _recursive_pairwise_outer_join(
+                [self] + other,
                 on=on,
                 lsuffix=lsuffix,
                 rsuffix=rsuffix,

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4943,14 +4943,29 @@ class DataFrame(_Frame):
 
             from .multi import _recursive_pairwise_outer_join
 
-            return _recursive_pairwise_outer_join(
-                [self] + other,
-                on=on,
-                lsuffix=lsuffix,
-                rsuffix=rsuffix,
-                npartitions=npartitions,
-                shuffle=shuffle,
-            )
+            # If its an outer join we can use the full recursive pairwise join.
+            if how is "outer":
+                full = [self] + other
+
+                return _recursive_pairwise_outer_join(
+                    full,
+                    on=on,
+                    lsuffix=lsuffix,
+                    rsuffix=rsuffix,
+                    npartitions=npartitions,
+                    shuffle=shuffle,
+                )
+            else:
+                # Do recursive pairwise join on everything _except_ the last join
+                # where we need to do a left join.
+                other = _recursive_pairwise_outer_join(
+                    other,
+                    on=on,
+                    lsuffix=lsuffix,
+                    rsuffix=rsuffix,
+                    npartitions=npartitions,
+                    shuffle=shuffle,
+                )
 
         from .multi import merge
 


### PR DESCRIPTION
 by allowing recursive merge function to take also operate on the initial frame rather than a separate non-parallel merge.

- [ X ] Closes #8739
- [ X ] Tests added / passed (`py.test dask --verbose -k test_multi.py`)
- [ X ] Passes `pre-commit run --all-files`
