### PR TITLE
Allow ArrowDatasetEngine subclass to override pandas->arrow conversion also for partitioned write

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -75,6 +75,7 @@ def _write_partitioned(
     filename,
     partition_cols,
     fs,
+    pandas_to_arrow_table,
     preserve_index,
     index_cols=(),
     **kwargs,
@@ -120,12 +121,8 @@ def _write_partitioned(
         subdir = fs.sep.join(
             [f"{name}={val}" for name, val in zip(partition_cols, keys)]
         )
-        subtable = pa.Table.from_pandas(
-            subgroup,
-            nthreads=1,
-            preserve_index=preserve_index,
-            schema=subschema,
-            safe=False,
+        subtable = pandas_to_arrow_table(
+            subgroup, preserve_index=preserve_index, schema=subschema
         )
         prefix = fs.sep.join([root_path, subdir])
         fs.mkdirs(prefix, exist_ok=True)
@@ -730,6 +727,7 @@ class ArrowDatasetEngine(Engine):
                 filename,
                 partition_on,
                 fs,
+                cls._pandas_to_arrow_table,
                 preserve_index,
                 index_cols=index_cols,
                 compression=compression,


### PR DESCRIPTION
This is basically a follow-up on https://github.com/dask/dask/pull/6505, ensuring that we use the custom `_pandas_to_arrow_table` class method of the engine also in the case of a partitioned write.

Context: https://github.com/geopandas/dask-geopandas/issues/167

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
