### PR TITLE
Followup to PR 8397 map_overlap default boundary kwarg

### DIFF
--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -741,7 +741,7 @@ def coerce_depth_type(ndim, depth):
 def coerce_boundary(ndim, boundary):
     default = "none"
     if boundary is None:
-        boundary = default
+        pass
     if not isinstance(boundary, (tuple, dict)):
         boundary = (boundary,) * ndim
     if isinstance(boundary, tuple):

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -741,7 +741,7 @@ def coerce_depth_type(ndim, depth):
 def coerce_boundary(ndim, boundary):
     default = "none"
     if boundary is None:
-        pass
+        boundary = default
     if not isinstance(boundary, (tuple, dict)):
         boundary = (boundary,) * ndim
     if isinstance(boundary, tuple):

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -637,17 +637,6 @@ def map_overlap(
         trim = get(sig.index("trim"), args, trim)
         func, args = args[0], [func]
 
-    if boundary is None:
-        # Default boundary value is set in the function named "coerce_boundary"
-        warnings.warn(
-            "Default 'boundary' argument value will change from 'reflect' "
-            "to 'none' in future versions from 2022.03.0 onwards. "
-            "Use 'boundary=\"none\"' to opt into the future behavior now "
-            "or set 'boundary=\"reflect\"' to maintain the current behavior "
-            "going forward.",
-            FutureWarning,
-        )
-
     if not callable(func):
         raise TypeError(
             "First argument must be callable function, not {}\n"
@@ -750,7 +739,7 @@ def coerce_depth_type(ndim, depth):
 
 
 def coerce_boundary(ndim, boundary):
-    default = "reflect"
+    default = None
     if boundary is None:
         boundary = default
     if not isinstance(boundary, (tuple, dict)):

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -739,7 +739,7 @@ def coerce_depth_type(ndim, depth):
 
 
 def coerce_boundary(ndim, boundary):
-    default = None
+    default = "none"
     if boundary is None:
         boundary = default
     if not isinstance(boundary, (tuple, dict)):

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -82,8 +82,7 @@ def trim_overlap(x, depth, boundary=None):
 
     # parameter to be passed to trim_internal
     axes = coerce_depth(x.ndim, depth)
-    boundary2 = coerce_boundary(x.ndim, boundary)
-    return trim_internal(x, axes=axes, boundary=boundary2)
+    return trim_internal(x, axes=axes, boundary=boundary)
 
 
 def trim_internal(x, axes, boundary=None):

--- a/dask/array/tests/test_cupy_overlap.py
+++ b/dask/array/tests/test_cupy_overlap.py
@@ -42,7 +42,7 @@ def test_overlap_internal():
 def test_trim_internal():
     x = cupy.ones((40, 60))
     d = da.from_array(x, chunks=(10, 10), asarray=False)
-    e = da.overlap.trim_internal(d, axes={0: 1, 1: 2})
+    e = da.overlap.trim_internal(d, axes={0: 1, 1: 2}, boundary="reflect")
 
     assert e.chunks == ((8, 8, 8, 8), (6, 6, 6, 6, 6, 6))
 

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -780,7 +780,7 @@ def test_overlap_few_dimensions():
 
 
 @pytest.mark.parametrize("boundary", ["reflect", "periodic", "nearest", "none"])
-def test_trim_boundry(boundary):
+def test_trim_boundary(boundary):
     x = da.from_array(np.arange(24).reshape(4, 6), chunks=(2, 3))
     x_overlaped = da.overlap.overlap(x, 2, boundary={0: "reflect", 1: boundary})
     x_trimmed = da.overlap.trim_overlap(

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -332,15 +332,8 @@ def test_map_overlap_escapes_to_map_blocks_when_depth_is_zero():
 )
 def test_map_overlap_no_depth(boundary):
     x = da.arange(10, chunks=5)
-    if boundary is None:
-        # Can be removed after boundary default argument is changed to "none"
-        # See https://github.com/dask/dask/issues/8391
-        with pytest.raises(FutureWarning):
-            y = x.map_overlap(lambda i: i, depth=0, boundary=boundary, dtype=x.dtype)
-            assert_eq(y, x)
-    else:
-        y = x.map_overlap(lambda i: i, depth=0, boundary=boundary, dtype=x.dtype)
-        assert_eq(y, x)
+    y = x.map_overlap(lambda i: i, depth=0, boundary=boundary, dtype=x.dtype)
+    assert_eq(y, x)
 
 
 def test_map_overlap_multiarray():

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -119,7 +119,7 @@ def test_overlap_internal_asymmetric_small():
 
 def test_trim_internal():
     d = da.ones((40, 60), chunks=(10, 10))
-    e = trim_internal(d, axes={0: 1, 1: 2})
+    e = trim_internal(d, axes={0: 1, 1: 2}, boundary="reflect")
 
     assert e.chunks == ((8, 8, 8, 8), (6, 6, 6, 6, 6, 6))
 
@@ -553,55 +553,38 @@ def test_nearest_overlap():
 
     darr = da.from_array(a, chunks=(6, 6))
     garr = overlap(darr, depth={0: 5, 1: 5}, boundary={0: "nearest", 1: "nearest"})
-    tarr = trim_internal(garr, {0: 5, 1: 5})
+    tarr = trim_internal(garr, {0: 5, 1: 5}, boundary="nearest")
     assert_array_almost_equal(tarr, a)
 
 
-def test_0_depth():
+@pytest.mark.parametrize(
+    "depth",
+    [
+        {0: 0, 1: 0},  # depth all zeros
+        {0: 4, 1: 0},  # depth with some zeros
+        {0: 5, 1: 5},  # depth equal to boundary length
+        {0: 8, 1: 7},  # depth greater than boundary length
+    ],
+)
+def test_different_depths_and_boundary_combinations(depth):
     expected = np.arange(100).reshape(10, 10)
     darr = da.from_array(expected, chunks=(5, 2))
 
-    depth = {0: 0, 1: 0}
-
     reflected = overlap(darr, depth=depth, boundary="reflect")
     nearest = overlap(darr, depth=depth, boundary="nearest")
     periodic = overlap(darr, depth=depth, boundary="periodic")
     constant = overlap(darr, depth=depth, boundary=42)
 
-    result = trim_internal(reflected, depth)
+    result = trim_internal(reflected, depth, boundary="reflect")
     assert_array_equal(result, expected)
 
-    result = trim_internal(nearest, depth)
+    result = trim_internal(nearest, depth, boundary="nearest")
     assert_array_equal(result, expected)
 
-    result = trim_internal(periodic, depth)
+    result = trim_internal(periodic, depth, boundary="periodic")
     assert_array_equal(result, expected)
 
-    result = trim_internal(constant, depth)
-    assert_array_equal(result, expected)
-
-
-def test_some_0_depth():
-    expected = np.arange(100).reshape(10, 10)
-    darr = da.from_array(expected, chunks=(5, 5))
-
-    depth = {0: 4, 1: 0}
-
-    reflected = overlap(darr, depth=depth, boundary="reflect")
-    nearest = overlap(darr, depth=depth, boundary="nearest")
-    periodic = overlap(darr, depth=depth, boundary="periodic")
-    constant = overlap(darr, depth=depth, boundary=42)
-
-    result = trim_internal(reflected, depth)
-    assert_array_equal(result, expected)
-
-    result = trim_internal(nearest, depth)
-    assert_array_equal(result, expected)
-
-    result = trim_internal(periodic, depth)
-    assert_array_equal(result, expected)
-
-    result = trim_internal(constant, depth)
+    result = trim_internal(constant, depth, boundary=42)
     assert_array_equal(result, expected)
 
 
@@ -617,54 +600,6 @@ def test_constant_boundaries():
     darr = da.from_array(a, chunks=((1,), (2, 2, 2, 3)))
     b = boundaries(darr, {0: 0, 1: 0}, {0: 0, 1: 0})
     assert b.chunks == darr.chunks
-
-
-def test_depth_equals_boundary_length():
-    expected = np.arange(100).reshape(10, 10)
-    darr = da.from_array(expected, chunks=(5, 5))
-
-    depth = {0: 5, 1: 5}
-
-    reflected = overlap(darr, depth=depth, boundary="reflect")
-    nearest = overlap(darr, depth=depth, boundary="nearest")
-    periodic = overlap(darr, depth=depth, boundary="periodic")
-    constant = overlap(darr, depth=depth, boundary=42)
-
-    result = trim_internal(reflected, depth)
-    assert_array_equal(result, expected)
-
-    result = trim_internal(nearest, depth)
-    assert_array_equal(result, expected)
-
-    result = trim_internal(periodic, depth)
-    assert_array_equal(result, expected)
-
-    result = trim_internal(constant, depth)
-    assert_array_equal(result, expected)
-
-
-def test_depth_greater_than_boundary_length():
-    expected = np.arange(100).reshape(10, 10)
-    darr = da.from_array(expected, chunks=(5, 5))
-
-    depth = {0: 8, 1: 7}
-
-    reflected = overlap(darr, depth=depth, boundary="reflect")
-    nearest = overlap(darr, depth=depth, boundary="nearest")
-    periodic = overlap(darr, depth=depth, boundary="periodic")
-    constant = overlap(darr, depth=depth, boundary=42)
-
-    result = trim_internal(reflected, depth)
-    assert_array_equal(result, expected)
-
-    result = trim_internal(nearest, depth)
-    assert_array_equal(result, expected)
-
-    result = trim_internal(periodic, depth)
-    assert_array_equal(result, expected)
-
-    result = trim_internal(constant, depth)
-    assert_array_equal(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Followup to PR https://github.com/dask/dask/pull/8397

We've had a FutureWarning up for a few months about an upcoming change to the default 'boundary' kwarg value in `map_overlap`, so now is the time to change it. Previous default was `"reflect"`, new default will be "None".

The reason for this change is that it makes the code run a lot faster, and for most people the overlap depth is sufficient and they should not require additional boundary handling. See https://github.com/dask/dask/issues/8391 for a full discussion.

- [x] Closes https://github.com/dask/dask/issues/8391
- [ ] Tests ~~added~~ / passed
- [ ] Passes `pre-commit run --all-files`
