### PR TITLE
Make the labeler not delete labels, and fix docs location

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,8 +11,8 @@ io:
   - dask/dataframe/io/**/*
 
 documentation:
-  - dask/docs/*
-  - dask/docs/**/*
+  - docs/*
+  - docs/**/*
 
 dispatch:
   - dask/array/backends.py

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,4 +9,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true
+        sync-labels: false


### PR DESCRIPTION
- [x] Closes #8744


It was a couple things:

1. The `documentation` label was not pointing to the right spot. 
2. The labeler should not delete labels
