### PR TITLE
Update test status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ LICENSE
 New BSD. See `License File <https://github.com/dask/dask/blob/main/LICENSE.txt>`__.
 
 .. _documentation: https://dask.org
-.. |Build Status| image:: https://github.com/dask/dask/workflows/CI/badge.svg?branch=main
-   :target: https://github.com/dask/dask/actions?query=workflow%3A%22CI%22
+.. |Build Status| image:: https://github.com/dask/dask/actions/workflows/tests.yml/badge.svg
+   :target: https://github.com/dask/dask/actions/workflows/tests.yml
 .. |Coverage| image:: https://codecov.io/gh/dask/dask/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/dask/dask/branch/main
    :alt: Coverage status


### PR DESCRIPTION
In https://github.com/dask/dask/pull/7422 we changed the names of some of GitHub actions workflows, but forgot to update the corresponding status badge on the README which resulted in the badge being red. This PR updates to badge to point to the correct workflow (which is green 🎉 )