### PR TITLE
Deprecate `dataframe.tseries.resample.getnanos`

### DIFF
--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -4,12 +4,13 @@ from pandas.core.resample import Resampler as pd_Resampler
 
 from ...base import tokenize
 from ...highlevelgraph import HighLevelGraph
-from ...utils import derived_from
+from ...utils import _deprecated, derived_from
 from .. import methods
 from .._compat import PANDAS_GT_140
 from ..core import DataFrame, Series
 
 
+@_deprecated()
 def getnanos(rule):
     try:
         return getattr(rule, "nanos", None)

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -10,7 +10,7 @@ from .._compat import PANDAS_GT_140
 from ..core import DataFrame, Series
 
 
-@_deprecated()
+@_deprecated(after_version="2022.02.0")
 def getnanos(rule):
     try:
         return getattr(rule, "nanos", None)

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import dask.dataframe as dd
+from dask.dataframe.tseries.resample import getnanos
 from dask.dataframe.utils import assert_eq
 
 CHECK_FREQ = {}
@@ -213,3 +214,8 @@ def test_common_aggs(agg):
     expected = f(ds.resample("1d"))
 
     assert_eq(res, expected, check_dtype=False)
+
+
+def test_getnanos_deprecated():
+    with pytest.warns(FutureWarning, match="getnanos is deprecated"):
+        getnanos(None)

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -217,5 +217,5 @@ def test_common_aggs(agg):
 
 
 def test_getnanos_deprecated():
-    with pytest.warns(FutureWarning, match="getnanos is deprecated"):
+    with pytest.warns(FutureWarning, match="getnanos was deprecated"):
         getnanos(None)


### PR DESCRIPTION
- [X] addresses #8688 
- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`
