### PR TITLE
Make scheduler kwarg pass though to sub functions in `da.assert_eq`

### DIFF
--- a/dask/array/tests/test_array_utils.py
+++ b/dask/array/tests/test_array_utils.py
@@ -111,6 +111,7 @@ def test_assert_eq_scheduler(a, b):
     assert counter == 0
 
     assert_eq(a, b, scheduler=custom_scheduler)
-    # `custom_scheduler` should be executed twice if `a` and `b` are Arrays.
-    n_da_arrays = len([x for x in [a, b] if isinstance(x, Array)])
+    # `custom_scheduler` should be executed 2x the number of arrays.
+    # Once in `persist` and once in `compute`
+    n_da_arrays = len([x for x in [a, b] if isinstance(x, Array)]) * 2
     assert counter == n_da_arrays

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -214,15 +214,19 @@ def assert_eq_shape(a, b, check_nan=True):
             assert aa == bb
 
 
-def _check_chunks(x):
-    x = x.persist(scheduler="sync")
+def _check_chunks(x, scheduler=None):
+    x = x.persist(scheduler=scheduler)
     for idx in itertools.product(*(range(len(c)) for c in x.chunks)):
         chunk = x.dask[(x.name,) + idx]
+        if hasattr(chunk, "result"):  # it's a future
+            chunk = chunk.result()
         if not hasattr(chunk, "dtype"):
             chunk = np.array(chunk, dtype="O")
         expected_shape = tuple(c[i] for c, i in zip(x.chunks, idx))
         assert_eq_shape(expected_shape, chunk.shape, check_nan=False)
-        assert chunk.dtype == x.dtype
+        assert (
+            chunk.dtype == x.dtype
+        ), "maybe you forgot to pass the scheduler to `assert_eq`?"
     return x
 
 
@@ -241,7 +245,7 @@ def _get_dt_meta_computed(
         x_meta = getattr(x, "_meta", None)
         if check_chunks:
             # Replace x with persisted version to avoid computing it twice.
-            x = _check_chunks(x)
+            x = _check_chunks(x, scheduler=scheduler)
         x = x.compute(scheduler=scheduler)
         x_computed = x
         if hasattr(x, "todense"):


### PR DESCRIPTION
Follow on to #8700

I noticed while running these tests that when the distributed tests are run in parallel they often `xfail`. I'm wondering if it would be worth adding a separate job that just runs the distributed test without `nauto`

EDIT - I'm not seeing the xfail behavior on CI. It's possible that I was doing something weird locally.