### PR TITLE
Only run pre-release builds for PRs that affect relevant files

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - setup.py
+      - continuous_integration/recipe/**
+      - .github/workflows/conda.yml
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch


### PR DESCRIPTION
As discussed in https://github.com/dask/distributed/pull/5831#pullrequestreview-891819095, the Dask/Distributed pre-release builds can take up a lot of time in CI that may not be necessary if files impacting the building are not affected.

This PR applies the same solution we decided on there by only triggering pre-release builds in PRs that change build-relevant files:

- `setup.py`
- the pre-release recipe(s)
- the build workflow itself

cc @jrbourbeau @jakirkham

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
