### PR TITLE
Add deprecation warning for pyarow-legacy engine

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1036,7 +1036,7 @@ def get_engine(engine):
         if engine == "pyarrow-dataset":
             if pa_version.major < 1:
                 raise ImportError(
-                    f"pyarrow-{pa_version.major} does not suppot the "
+                    f"pyarrow-{pa_version.major} does not support the "
                     f"pyarrow.dataset API. Please install pyarrow>=1."
                 )
 
@@ -1051,6 +1051,7 @@ def get_engine(engine):
                 "and will be removed in the near future. Please use "
                 "`engine='pyarrow'` instead.",
                 FutureWarning,
+                stacklevel=3,
             )
             _ENGINES[engine] = eng = ArrowLegacyEngine
         return eng

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -242,14 +242,11 @@ def read_parquet(
         desired function under the ``"open_file_func"`` key.
     engine : str, default 'auto'
         Parquet reader library to use. Options include: 'auto', 'fastparquet',
-        'pyarrow', 'pyarrow-dataset', and 'pyarrow-legacy'. Defaults to 'auto',
-        which selects the FastParquetEngine if fastparquet is installed (and
-        ArrowDatasetEngine otherwise).  If 'pyarrow' or 'pyarrow-dataset' is
-        specified, the ArrowDatasetEngine (which leverages the pyarrow.dataset
-        API) will be used. If 'pyarrow-legacy' is specified, ArrowLegacyEngine
-        will be used (which leverages the pyarrow.parquet.ParquetDataset API).
-        NOTE: The 'pyarrow-legacy' option (ArrowLegacyEngine) is deprecated
-        for pyarrow>=5.
+        and 'pyarrow'. Defaults to 'auto', which selects FastParquetEngine
+        if fastparquet is installed (and ArrowDatasetEngine otherwise). If
+        'pyarrow' is specified, ArrowDatasetEngine (which leverages the
+        pyarrow.dataset API) will be used.
+        NOTE: The 'pyarrow-legacy' option (ArrowLegacyEngine) is deprecated.
     gather_statistics : bool, default None
         Gather the statistics for each dataset partition. By default,
         this will only be done if the _metadata file is available. Otherwise,
@@ -999,17 +996,10 @@ def get_engine(engine):
     ----------
     engine : str, default 'auto'
         Backend parquet library to use. Options include: 'auto', 'fastparquet',
-        'pyarrow', 'pyarrow-dataset', and 'pyarrow-legacy'. Defaults to 'auto',
-        which selects the FastParquetEngine if fastparquet is installed (and
-        ArrowLegacyEngine otherwise).  If 'pyarrow-dataset' is specified, the
-        ArrowDatasetEngine (which leverages the pyarrow.dataset API) will be used
-        for newer PyArrow versions (>=1.0.0). If 'pyarrow' or 'pyarrow-legacy' are
-        specified, the ArrowLegacyEngine will be used (which leverages the
-        pyarrow.parquet.ParquetDataset API).
-        NOTE: 'pyarrow-dataset' enables row-wise filtering, but requires
-        pyarrow>=1.0. The behavior of 'pyarrow' will most likely change to
-        ArrowDatasetEngine in a future release, and the 'pyarrow-legacy'
-        option will be deprecated once the ParquetDataset API is deprecated.
+        and 'pyarrow'. Defaults to 'auto', which selects the FastParquetEngine
+        if fastparquet is installed (and ArrowDatasetEngine otherwise).
+        If 'pyarrow' is specified, the ArrowDatasetEngine (which leverages the
+        pyarrow.dataset API) will be used.
     gather_statistics : bool or None (default).
 
     Returns
@@ -1042,21 +1032,26 @@ def get_engine(engine):
 
         if engine in ("pyarrow", "arrow"):
             engine = "pyarrow-dataset"
-        elif pa_version.major >= 5 and engine == "pyarrow-legacy":
-            warnings.warn(
-                "`ArrowLegacyEngine` ('pyarrow-legacy') is deprecated for "
-                "pyarrow>=5 and will be removed in a future release. Please "
-                "use `engine='pyarrow'` or `engine='pyarrow-dataset'`.",
-                FutureWarning,
-            )
 
         if engine == "pyarrow-dataset":
+            if pa_version.major < 1:
+                raise ImportError(
+                    f"pyarrow-{pa_version.major} does not suppot the "
+                    f"pyarrow.dataset API. Please install pyarrow>=1."
+                )
+
             from .arrow import ArrowDatasetEngine
 
             _ENGINES[engine] = eng = ArrowDatasetEngine
         else:
             from .arrow import ArrowLegacyEngine
 
+            warnings.warn(
+                "`ArrowLegacyEngine` ('pyarrow-legacy') is deprecated "
+                "and will be removed in the near future. Please use "
+                "`engine='pyarrow'` instead.",
+                FutureWarning,
+            )
             _ENGINES[engine] = eng = ArrowLegacyEngine
         return eng
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -65,7 +65,7 @@ SKIP_PYARROW_LE = SKIP_PYARROW
 SKIP_PYARROW_LE_REASON = "pyarrow not found"
 SKIP_PYARROW_DS = SKIP_PYARROW
 SKIP_PYARROW_DS_REASON = "pyarrow not found"
-if pa_version.major >= 5 and not SKIP_PYARROW:
+if not SKIP_PYARROW_LE:
     # NOTE: We should use PYARROW_LE_MARK to skip
     # pyarrow-legacy tests once pyarrow officially
     # removes ParquetDataset support in the future.


### PR DESCRIPTION
I'd like to work on some parquet cleanup and documentation, and dropping support for `ArrowLegacyEngine` will certainly simplify things. This PR adds a deprecation warning for `engine="pyarrow-legacy"`.

I plan to submit a follow-up PR after 1-2 releases to remove `ArrowLegacyEngine` altogether.

- [x] Addresses first step of #8243 (second step is to remove ArrowLegacyEngine)
- [x] Passes `pre-commit run --all-files`
