### PR TITLE
[WIP] Improve engine-option handling in read_parquet

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -2421,7 +2421,7 @@ class ArrowDatasetOptions(EngineOptions):
         Supported parameters can be passed to ``read_parquet``
         using the ``dataset_options`` argument. For example::
 
-        >>> df = dd.read_parquet(path, dataset_options={exclude_invalid_files: True})  # doctest: +SKIP
+        >>> df = dd.read_parquet(...,dataset_options={"exclude_invalid_files": True})  # doctest: +SKIP
         """
 
         # Use pyarrow.dataset API
@@ -2431,9 +2431,7 @@ class ArrowDatasetOptions(EngineOptions):
         require_extension = dataset_options.pop("require_extension", None)
         if require_extension is None:
             require_extension = (
-                (".parquet", ".parq", ".pq")
-                if dataset_options.get("filesystem", None) is None
-                else False
+                (".parquet", ".parq", ".pq") if filesystem is None else False
             )
 
         # Pop supported dataset options

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -348,6 +348,14 @@ class ArrowDatasetEngine(Engine):
     #
 
     @classmethod
+    def validate_engine_options(cls, core_options: dict, **engine_options):
+
+        # TODO: Check and rewrite engine_options here
+        _, paths, fs = super().validate_engine_options(core_options)
+
+        return fs, paths, engine_options
+
+    @classmethod
     def read_metadata(
         cls,
         fs,

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -179,7 +179,6 @@ def read_parquet(
     split_row_groups=None,
     chunksize=None,
     aggregate_files=None,
-    require_extension=(".parquet", ".parq", ".pq"),
     **kwargs,
 ):
     """
@@ -372,7 +371,6 @@ def read_parquet(
         "split_row_groups": split_row_groups,
         "chunksize": chunksize,
         "aggregate_files": aggregate_files,
-        "require_extension": require_extension,
     }
     engine_options = kwargs.copy()
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -313,19 +313,30 @@ def read_parquet(
         Required file extension for all parquet data files. Other file
         extensions will be ignored. Note that ``require_extension=False``
         will skip the file-extension check altogether.
-    **kwargs: dict (of dicts)
-        Passthrough key-word arguments for read backend.
-        The top-level keys correspond to the appropriate operation type, and
-        the second level corresponds to the kwargs that will be passed on to
-        the underlying ``pyarrow`` or ``fastparquet`` function.
-        Supported top-level keys: 'dataset' (for opening a ``pyarrow`` dataset),
-        'file' or 'dataset' (for opening a ``fastparquet.ParquetFile``), 'read'
-        (for the backend read function), 'arrow_to_pandas' (for controlling the
-        arguments passed to convert from a ``pyarrow.Table.to_pandas()``).
-        Any element of kwargs that is not defined under these top-level keys
-        will be passed through to the `engine.read_partitions` classmethod as a
-        stand-alone argument (and will be ignored by the engine implementations
-        defined in ``dask.dataframe``).
+    dataset_options: dict, default None
+        Dictionary of engine-specific key-work arguments for initializing a
+        "dataset" object for metadata processing and possibly for reading data.
+        For the "pyarrow" engine, these arguments will be used to initialize a
+        ``pyarrow.dataset.Dataset`` object using the ``pyarrow.dataset.dataset``
+        function (or ``pyarrow.dataset.parquet_dataset`` if a ``_metadata`` file
+        is detected). For "fastparquet", these arguments will be used with the
+        ``fastparquet.ParquetFile`` constructor. See ``arrow.ArrowDatasetEngine``
+        and ``fastparquet.FastParquetEngine`` for more details.
+    read_options: dict, default None
+        Dictionary of engine-specific key-work arguments to be passed through
+        to the backend-IO function when reading data. Since the specific IO
+        function may vary (depending on dataset properties and other options),
+        passing options in this way is NOT typically recommended. However,
+        specific read options with explicit support may be documented in the
+        engine's docstsring.
+    **kwargs: dict, default None
+        Dictionary of key-work arguments to be be passed through to the engine
+        backend. For example, 'arrow_to_pandas' can be used with the "pyarrow"
+        engine to control the arguments used to convert from ``pyarrow.Table``
+        to pandas (with ``pyarrow.Table.to_pandas()``). By default, these
+        arguments will be passed through to the ``engine.read_partition``
+        classmethod, but will not be passed through to the backend IO funciton.
+        Options with known support will be documented in engine's docstsring.
 
     Examples
     --------
@@ -334,7 +345,8 @@ def read_parquet(
     See Also
     --------
     to_parquet
-    pyarrow.parquet.ParquetDataset
+    arrow.ArrowDatasetEngine
+    fastparquet.FastParquetEngine
     """
 
     if "read_from_paths" in kwargs:

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -179,6 +179,7 @@ def read_parquet(
     split_row_groups=None,
     chunksize=None,
     aggregate_files=None,
+    require_extension=(".parquet", ".parq", ".pq"),
     **kwargs,
 ):
     """
@@ -308,6 +309,10 @@ def read_parquet(
                 └── └── 04.parquet
 
         Note that the default behavior of ``aggregate_files`` is False.
+    require_extension: str or tuple(str), default (".parq", ".parquet". ".pq")
+        Required file extension for all parquet data files. Other file
+        extensions will be ignored. Note that ``require_extension=False``
+        will skip the file-extension check altogether.
     **kwargs: dict (of dicts)
         Passthrough key-word arguments for read backend.
         The top-level keys correspond to the appropriate operation type, and
@@ -355,6 +360,7 @@ def read_parquet(
         "split_row_groups": split_row_groups,
         "chunksize": chunksize,
         "aggregate_files": aggregate_files,
+        "require_extension": require_extension,
     }
     engine_options = kwargs.copy()
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -443,7 +443,6 @@ def read_parquet(
         index,
         chunksize,
         split_row_groups,
-        fs,
         aggregation_depth,
     )
 
@@ -1206,7 +1205,6 @@ def process_statistics(
     index,
     chunksize,
     split_row_groups,
-    fs,
     aggregation_depth,
 ):
     """Process row-group column statistics in metadata
@@ -1244,7 +1242,7 @@ def process_statistics(
         # Aggregate parts/statistics if we are splitting by row-group
         if chunksize or (split_row_groups and int(split_row_groups) > 1):
             parts, statistics = aggregate_row_groups(
-                parts, statistics, chunksize, split_row_groups, fs, aggregation_depth
+                parts, statistics, chunksize, split_row_groups, aggregation_depth
             )
 
         out = sorted_columns(statistics)
@@ -1350,9 +1348,7 @@ def set_index_columns(meta, index, columns, index_in_columns, auto_index_allowed
     return meta, index, columns
 
 
-def aggregate_row_groups(
-    parts, stats, chunksize, split_row_groups, fs, aggregation_depth
-):
+def aggregate_row_groups(parts, stats, chunksize, split_row_groups, aggregation_depth):
     if not stats or not stats[0].get("file_path_0", None):
         return parts, stats
 
@@ -1388,10 +1384,8 @@ def aggregate_row_groups(
                     multi_path_allowed = True
                 elif isinstance(aggregation_depth, int):
                     # Make sure files share the same directory
-                    root = stat["file_path_0"].split(fs.sep)[:-aggregation_depth]
-                    next_root = next_stat["file_path_0"].split(fs.sep)[
-                        :-aggregation_depth
-                    ]
+                    root = stat["file_path_0"].split("/")[:-aggregation_depth]
+                    next_root = next_stat["file_path_0"].split("/")[:-aggregation_depth]
                     multi_path_allowed = root == next_root
                 else:
                     raise ValueError(

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -1324,7 +1324,7 @@ class FastparquetOptions(EngineOptions):
         Supported parameters can be passed to ``read_parquet``
         using the ``dataset_options`` argument. For example::
 
-        >>> df = dd.read_parquet(path, dataset_options={pandas_nulls: False})  # doctest: +SKIP
+        >>> df = dd.read_parquet(...,dataset_options={"pandas_nulls": False})  # doctest: +SKIP
         """
 
         # Extract require_extension

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -387,7 +387,7 @@ class FastParquetEngine(Engine):
 
         # Extract "supported" key-word arguments from `kwargs`.
         # Split items into `dataset_kwargs` and `read_kwargs`
-        dataset_kwargs, read_kwargs, user_kwargs = _split_user_options(**kwargs)
+        dataset_kwargs, read_kwargs, other_kwargs = _split_user_options(**kwargs)
 
         parts = []
         _metadata_exists = False
@@ -516,7 +516,7 @@ class FastParquetEngine(Engine):
             "kwargs": {
                 "dataset": dataset_kwargs,
                 "read": read_kwargs,
-                **user_kwargs,
+                **other_kwargs,
             },
         }
 
@@ -845,7 +845,7 @@ class FastParquetEngine(Engine):
     def validate_engine_options(cls, core_options: dict, **engine_options):
 
         # TODO: Check and rewrite engine_options here
-        _, paths, fs = super().validate_engine_options(core_options)
+        fs, paths, _ = super().validate_engine_options(core_options)
 
         return fs, paths, engine_options
 

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -842,6 +842,14 @@ class FastParquetEngine(Engine):
         return parts, stats
 
     @classmethod
+    def validate_engine_options(cls, core_options: dict, **engine_options):
+
+        # TODO: Check and rewrite engine_options here
+        _, paths, fs = super().validate_engine_options(core_options)
+
+        return fs, paths, engine_options
+
+    @classmethod
     def read_metadata(
         cls,
         fs,

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -71,9 +71,6 @@ class EngineOptions:
 
     def validate_dataset_options(self, **dataset_options):
         """Return valid dataset options"""
-        # Extract require_extension
-        # Pop
-        dataset_options.pop("require_extension", None)
         return dataset_options
 
     def validate_read_options(self, **read_options):

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -1,6 +1,7 @@
 import re
 
 import pandas as pd
+from fsspec.core import get_fs_token_paths
 
 from .... import config
 from ....core import flatten
@@ -10,6 +11,22 @@ from ..utils import _is_local_fs
 
 class Engine:
     """The API necessary to provide a new Parquet reader/writer"""
+
+    @classmethod
+    def validate_engine_options(cls, core_options: dict, **engine_options):
+
+        # Base class doesnt support any engine options
+        if engine_options:
+            raise ValueError(f"{engine_options.keys()} not supported for {cls}")
+
+        # Use fsspec for filesystem and path handling
+        fs, _, paths = get_fs_token_paths(
+            core_options.get("path"),
+            mode="rb",
+            storage_options=core_options.get("storage_options"),
+        )
+        paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
+        return fs, paths, {}
 
     @classmethod
     def read_metadata(

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 import pandas as pd
 from fsspec.core import get_fs_token_paths
@@ -749,14 +750,26 @@ def _split_user_options(**kwargs):
     # Check user-defined options.
     # Split into "file" and "dataset"-specific kwargs
     user_kwargs = kwargs.copy()
+
+    # Warn the user if they are still using a deprecated key-word.
+    # TODO: Uncomment these warnings after tests are modified.
+    # NOTE: We don't "need" to explicity deprecate these key-words.
+    if False:  # "file" or "dataset" in user_kwargs:
+        warnings.warn(
+            "Please use the `dataset_options` key-word to specify "
+            "engine-specific options for datset initialization. "
+            "Using `dataset` and `file` is now deprecated.",
+            FutureWarning,
+        )
+
+    # Extract all "dataset" arguments
     dataset_options = {
         **user_kwargs.pop("file", {}).copy(),
         **user_kwargs.pop("dataset", {}).copy(),
+        **user_kwargs.pop("dataset_options", {}).copy(),
     }
+
+    # Extract all "read" arguments
     read_options = user_kwargs.pop("read", {}).copy()
-    read_options["open_file_options"] = user_kwargs.pop("open_file_options", {}).copy()
-    return (
-        dataset_options,
-        read_options,
-        user_kwargs,
-    )
+
+    return (dataset_options, read_options, user_kwargs)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1113,7 +1113,7 @@ def test_to_parquet_pyarrow_w_inconsistent_schema_by_partition_fails_by_default(
             str(tmpdir),
             engine="pyarrow-legacy",
             gather_statistics=False,
-            dataset={"validate_schema": True},
+            dataset_options={"validate_schema": True},
         ).compute()
         assert e_info.message.contains("ValueError: Schema in partition")
         assert e_info.message.contains("was different")
@@ -2339,7 +2339,7 @@ def test_timeseries_nulls_in_schema(tmpdir, engine, schema):
     # Note: `append_row_groups` will fail with pyarrow>0.17.1 for _metadata write
     dataset = {"validate_schema": False} if engine == "pyarrow-legacy" else {}
     ddf2.to_parquet(tmp_path, engine=engine, write_metadata_file=False, schema=schema)
-    ddf_read = dd.read_parquet(tmp_path, engine=engine, dataset=dataset)
+    ddf_read = dd.read_parquet(tmp_path, engine=engine, dataset_options=dataset)
 
     assert_eq(ddf_read, ddf2, check_divisions=False, check_index=False)
 
@@ -2380,7 +2380,7 @@ def test_timeseries_nulls_in_schema_pyarrow(tmpdir, timestamp, numerical):
     assert_eq(
         dd.read_parquet(
             tmp_path,
-            dataset={"validate_schema": True},
+            dataset_options={"validate_schema": True},
             index=False,
             engine="pyarrow-legacy",
         ),
@@ -2414,14 +2414,14 @@ def test_read_inconsistent_schema_pyarrow(tmpdir):
 
     # Read Directory
     check = dd.read_parquet(
-        str(tmpdir), dataset={"validate_schema": False}, engine="pyarrow-legacy"
+        str(tmpdir), dataset_options={"validate_schema": False}, engine="pyarrow-legacy"
     )
     assert_eq(check.compute(), df_expect, check_index=False)
 
     # Read List
     check = dd.read_parquet(
         os.path.join(tmpdir, "*.parquet"),
-        dataset={"validate_schema": False},
+        dataset_options={"validate_schema": False},
         engine="pyarrow-legacy",
     )
     assert_eq(check.compute(), df_expect, check_index=False)
@@ -3800,9 +3800,7 @@ def test_extra_file(tmpdir, engine):
         # by passing False. Check here that this works:
 
         # Should Work
-        out = dd.read_parquet(
-            tmpdir, engine=engine, dataset={"require_extension": ".parquet"}
-        )
+        out = dd.read_parquet(tmpdir, engine=engine, require_extension=".parquet")
         assert_eq(out, df)
 
         # Should Fail (for not capturing the _SUCCESS and crc files)
@@ -3814,9 +3812,7 @@ def test_extra_file(tmpdir, engine):
         # Should Fail (for filtering out all files)
         # (Related to: https://github.com/dask/dask/issues/8349)
         with pytest.raises(ValueError):
-            dd.read_parquet(
-                tmpdir, engine=engine, dataset={"require_extension": ".foo"}
-            ).compute()
+            dd.read_parquet(tmpdir, engine=engine, require_extension=".foo").compute()
 
 
 def test_unsupported_extension_file(tmpdir, engine):


### PR DESCRIPTION
Adds clear `dataset_options=` and `read_options=` to `read_parquet` API, and exposes distinct `pyarrow.dataset.dataste` and `fastparquet.ParquetFile` arguments to the user. 

Note that the current implementation also leverages a new `EngineOptions` class (for now).

**TODO**: Add writeup

- [x] Addresses #8491
- [x] Addresses #8677
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
