### PR TITLE
Update Docker images to use ghcr.io

### DIFF
--- a/docs/source/deploying-docker.rst
+++ b/docs/source/deploying-docker.rst
@@ -1,8 +1,7 @@
 Docker Images
 =============
 
-Example docker images are maintained at https://github.com/dask/dask-docker
-and https://hub.docker.com/r/daskdev/ .
+Example docker images are maintained at https://github.com/dask/dask-docker .
 
 Each image installs the full Dask conda environment (including the distributed
 scheduler), Numpy, and Pandas on top of a Miniconda installation on top of
@@ -10,11 +9,11 @@ a Debian image.
 
 These images are large, around 1GB.
 
--   ``daskdev/dask``: This a normal debian + miniconda image with the full Dask
+-   ``ghcr.io/dask/dask``: This a normal debian + miniconda image with the full Dask
     conda package (including the distributed scheduler), Numpy, and Pandas.
     This image is about 1GB in size.
 
--   ``daskdev/dask-notebook``: This is based on the
+-   ``ghcr.io/dask/dask-notebook``: This is based on the
     `Jupyter base-notebook image <https://hub.docker.com/r/jupyter/base-notebook/>`_
     and so it is suitable for use both normally as a Jupyter server, and also as
     part of a JupyterHub deployment.  It also includes a matching Dask software
@@ -29,13 +28,13 @@ Here is a simple example on a dedicated virtual network
 
    docker network create dask
 
-   docker run --network dask -p 8787:8787 --name scheduler daskdev/dask dask-scheduler  # start scheduler
+   docker run --network dask -p 8787:8787 --name scheduler ghcr.io/dask/dask dask-scheduler  # start scheduler
 
-   docker run --network dask daskdev/dask dask-worker scheduler:8786 # start worker
-   docker run --network dask daskdev/dask dask-worker scheduler:8786 # start worker
-   docker run --network dask daskdev/dask dask-worker scheduler:8786 # start worker
+   docker run --network dask ghcr.io/dask/dask dask-worker scheduler:8786 # start worker
+   docker run --network dask ghcr.io/dask/dask dask-worker scheduler:8786 # start worker
+   docker run --network dask ghcr.io/dask/dask dask-worker scheduler:8786 # start worker
 
-   docker run --network dask -p 8888:8888 daskdev/dask-notebook  # start Jupyter server
+   docker run --network dask -p 8888:8888 ghcr.io/dask/dask-notebook  # start Jupyter server
 
 Then from within the notebook environment you can connect to the Dask cluster like this:
 
@@ -62,7 +61,7 @@ the Dask worker software environment:
 
 .. code-block:: bash
 
-   docker run --network dask -e EXTRA_CONDA_PACKAGES="joblib" daskdev/dask dask-worker scheduler:8786
+   docker run --network dask -e EXTRA_CONDA_PACKAGES="joblib" ghcr.io/dask/dask dask-worker scheduler:8786
 
 Note that using these can significantly delay the container from starting,
 especially when using ``apt``, or ``conda`` (``pip`` is relatively fast).


### PR DESCRIPTION
Companion to https://github.com/dask/dask-docker/pull/207.

We are beginning to publish Docker images to the GitHub Container Registry in addition to Docker Hub, but are switching up documentation to refer to the `ghcr.io` images as we may want to stop publishing to Docker Hub at some point in the future.

For discussion see https://github.com/dask/dask-docker/issues/177