### PR TITLE
Fix "physical" column bug in pyarrow-based read_parquet

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1051,6 +1051,7 @@ class ArrowDatasetEngine(Engine):
         # Set index and column names using
         # pandas metadata (when available)
         pandas_metadata = _get_pandas_metadata(schema)
+        physical_column_names = dataset_info.get("physical_schema", schema).names
         if pandas_metadata:
             (
                 index_names,
@@ -1068,7 +1069,7 @@ class ArrowDatasetEngine(Engine):
         else:
             # No pandas metadata implies no index, unless selected by the user
             index_names = []
-            column_names = dataset_info.get("physical_schema", schema).names
+            column_names = physical_column_names
             storage_name_mapping = {k: k for k in column_names}
             column_index_names = [None]
         if index is None and index_names:
@@ -1078,7 +1079,7 @@ class ArrowDatasetEngine(Engine):
         # Ensure that there is no overlap between partition columns
         # and explicit column storage
         if partitions:
-            _partitions = [p for p in partitions if p not in column_names]
+            _partitions = [p for p in partitions if p not in physical_column_names]
             if not _partitions:
                 partitions = []
                 dataset_info["partitions"] = None
@@ -1088,7 +1089,9 @@ class ArrowDatasetEngine(Engine):
                 raise ValueError(
                     "No partition-columns should be written in the \n"
                     "file unless they are ALL written in the file.\n"
-                    "columns: {} | partitions: {}".format(column_names, partitions)
+                    "physical columns: {} | partitions: {}".format(
+                        physical_column_names, partitions
+                    )
                 )
 
         column_names, index_names = _normalize_index_columns(

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1046,12 +1046,12 @@ class ArrowDatasetEngine(Engine):
         categories = dataset_info["categories"]
         partition_obj = dataset_info["partitions"]
         partitions = dataset_info["partition_names"]
+        physical_column_names = dataset_info.get("physical_schema", schema).names
         columns = None
 
         # Set index and column names using
         # pandas metadata (when available)
         pandas_metadata = _get_pandas_metadata(schema)
-        physical_column_names = dataset_info.get("physical_schema", schema).names
         if pandas_metadata:
             (
                 index_names,

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3955,11 +3955,11 @@ def test_custom_filename_with_partition(tmpdir, engine):
 def test_roundtrip_partitioned_pyarrow_dataset(tmpdir, engine):
     # See: https://github.com/dask/dask/issues/8650
 
-    from pyarrow.dataset import write_dataset, HivePartitioning
     import pyarrow.parquet as pq
+    from pyarrow.dataset import HivePartitioning, write_dataset
 
     # Sample data
-    df = pd.DataFrame({'col1': [1, 2], 'col2': ['a', 'b']})
+    df = pd.DataFrame({"col1": [1, 2], "col2": ["a", "b"]})
 
     # Write partitioned dataset with dask
     dask_path = tmpdir.mkdir("foo-dask")
@@ -3982,14 +3982,12 @@ def test_roundtrip_partitioned_pyarrow_dataset(tmpdir, engine):
     def _prep(x):
         return x.sort_values("col2")[["col1", "col2"]]
 
-    # Check that reading dask-written data is the same
-    # for pyarrow and dask
+    # Check that reading dask-written data is the same for pyarrow and dask
     df_read_dask = dd.read_parquet(dask_path, engine=engine)
     df_read_pa = pq.read_table(dask_path).to_pandas()
     assert_eq(_prep(df_read_dask), _prep(df_read_pa), check_index=False)
 
-    # Check that reading pyarrow-written data is the same
-    # for pyarrow and dask
+    # Check that reading pyarrow-written data is the same for pyarrow and dask
     df_read_dask = dd.read_parquet(pa_path, engine=engine)
     df_read_pa = pq.read_table(pa_path).to_pandas()
     assert_eq(_prep(df_read_dask), _prep(df_read_pa), check_index=False)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3945,3 +3945,51 @@ def test_custom_filename_with_partition(tmpdir, engine):
     assert_eq(
         pdf, actual, check_index=False, check_dtype=False, check_categorical=False
     )
+
+
+@PYARROW_MARK
+@pytest.mark.skipif(
+    pa_version < parse_version("5.0"),
+    reason="pyarrow write_dataset was added in version 5.0",
+)
+def test_roundtrip_partitioned_pyarrow_dataset(tmpdir, engine):
+    # See: https://github.com/dask/dask/issues/8650
+
+    from pyarrow.dataset import write_dataset, HivePartitioning
+    import pyarrow.parquet as pq
+
+    # Sample data
+    df = pd.DataFrame({'col1': [1, 2], 'col2': ['a', 'b']})
+
+    # Write partitioned dataset with dask
+    dask_path = tmpdir.mkdir("foo-dask")
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf.to_parquet(dask_path, engine=engine, partition_on=["col1"], write_index=False)
+
+    # Write partitioned dataset with pyarrow
+    pa_path = tmpdir.mkdir("foo-pyarrow")
+    table = pa.Table.from_pandas(df)
+    write_dataset(
+        data=table,
+        base_dir=pa_path,
+        basename_template="part.{i}.parquet",
+        format="parquet",
+        partitioning=HivePartitioning(pa.schema([("col1", pa.int32())])),
+    )
+
+    # Define simple function to ensure results should
+    # be comparable (same column and row order)
+    def _prep(x):
+        return x.sort_values("col2")[["col1", "col2"]]
+
+    # Check that reading dask-written data is the same
+    # for pyarrow and dask
+    df_read_dask = dd.read_parquet(dask_path, engine=engine)
+    df_read_pa = pq.read_table(dask_path).to_pandas()
+    assert_eq(_prep(df_read_dask), _prep(df_read_pa), check_index=False)
+
+    # Check that reading pyarrow-written data is the same
+    # for pyarrow and dask
+    df_read_dask = dd.read_parquet(pa_path, engine=engine)
+    df_read_pa = pq.read_table(pa_path).to_pandas()
+    assert_eq(_prep(df_read_dask), _prep(df_read_pa), check_index=False)


### PR DESCRIPTION
Starting with pyarrow-5.0, the `pyarrow.dataset` API can now be used to write parquet datasets. Using `pyarrow.dataset.write_dataset` to write partitioned data results in different "pandas metadata" than we get from a Dask-written dataset, because Dask will not include the partitioned column names in this metadata (since they are not "physical" columns), but pyarrow will. This exposed a bug in Dask, where we were conflating "pandas metadata"  column names with "physical" column names. This PR adds a small fix to ensure that Dask will only bail on reading partitioned columns if/when the partitioned columns are really "physical" columns.

- [x] Closes #8650
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
