### PR TITLE
fix groupby shift bug caused by unsorted partitions after shuffle

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -189,12 +189,14 @@ def _groupby_slice_transform(
 
 
 def _groupby_slice_shift(
-    df, grouper, key, group_keys=True, dropna=None, observed=None, **kwargs
+    df, grouper, key, shuffled, group_keys=True, dropna=None, observed=None, **kwargs
 ):
     # No need to use raise if unaligned here - this is only called after
     # shuffling, which makes everything aligned already
     dropna = {"dropna": dropna} if dropna is not None else {}
     observed = {"observed": observed} if observed is not None else {}
+    if shuffled:
+        df = df.sort_index()
     g = df.groupby(grouper, group_keys=group_keys, **observed, **dropna)
     if key:
         g = g[key]
@@ -1908,6 +1910,7 @@ class _GroupBy:
             df2,
             by,
             self._slice,
+            should_shuffle,
             periods=periods,
             freq=freq,
             axis=axis,

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2143,24 +2143,25 @@ def test_groupby_shift_lazy_input():
         )
 
 
+@pytest.mark.filterwarnings("ignore:`meta` is not specified")
 def test_groupby_shift_within_partition_sorting():
     # Result is non-deterministic. We run the assertion a few times to keep
     # the probability of false pass low.
     for _ in range(10):
         df = pd.DataFrame(
             {
-                "a": [1, 2, 3, 4, 5, 6],
-                "b": [2, 1, 2, 1, 2, 1],
-                "c": [None, None, 10, 20, 30, 40],
+                "a": range(60),
+                "b": [2, 4, 3, 1] * 15,
+                "c": [None, 10, 20, None, 30, 40] * 10,
             }
         )
         df = df.set_index("a").sort_index()
         ddf = dd.from_pandas(df, npartitions=6)
-        with pytest.warns(UserWarning):
-            assert_eq(
-                df.groupby("b")["c"].shift(1),
-                ddf.groupby("b")["c"].shift(1).compute().sort_index(),
-            )
+        assert_eq(
+            df.groupby("b")["c"].shift(1),
+            ddf.groupby("b")["c"].shift(1),
+            scheduler="threads",
+        )
 
 
 def test_groupby_shift_with_freq():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2143,6 +2143,26 @@ def test_groupby_shift_lazy_input():
         )
 
 
+def test_groupby_shift_within_partition_sorting():
+    # Result is non-deterministic. We run the assertion a few times to keep
+    # the probability of false pass low.
+    for _ in range(10):
+        df = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6],
+                "b": [2, 1, 2, 1, 2, 1],
+                "c": [None, None, 10, 20, 30, 40],
+            }
+        )
+        df = df.set_index("a").sort_index()
+        ddf = dd.from_pandas(df, npartitions=6)
+        with pytest.warns(UserWarning):
+            assert_eq(
+                df.groupby("b")["c"].shift(1),
+                ddf.groupby("b")["c"].shift(1).compute().sort_index(),
+            )
+
+
 def test_groupby_shift_with_freq():
     pdf = pd.DataFrame(
         dict(a=[1, 2, 3, 4, 5, 6], b=[0, 0, 0, 1, 1, 1]),


### PR DESCRIPTION
We now apply sort_index to each partition if dataframe is shuffled

- [x] Closes ##8749
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

I have run the assertion 10 times since the result was non-deterministic. Probability of passing with the previous implementation should be low. If you have a better idea, I can improve the test. 