### PR TITLE
Fix serialization bug in DataFrameTreeReduction

### DIFF
--- a/dask/layers.py
+++ b/dask/layers.py
@@ -1515,6 +1515,7 @@ class DataFrameTreeReduction(Layer):
             "concat_func": _concat_func,
             "tree_node_func": _tree_node_func,
             "finalize_func": _finalize_func,
+            "split_every": self.split_every,
             "split_out": self.split_out,
             "output_partitions": self.output_partitions,
             "tree_node_name": self.tree_node_name,

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -698,3 +698,28 @@ async def test_to_sql_engine_kwargs(c, s, a, b):
             dd.read_sql_table("test", uri, "index"),
             check_divisions=False,
         )
+
+
+@gen_cluster(client=True)
+async def test_non_recursive_df_reduce(c, s, a, b):
+    # See https://github.com/dask/dask/issues/8773
+
+    dd = pytest.importorskip("dask.dataframe")
+    pd = pytest.importorskip("pandas")
+
+    class SomeObject:
+        def __init__(self, val):
+            self.val = val
+
+    N = 170
+    series = pd.Series(data=[1] * N, index=range(2, N + 2))
+    dask_series = dd.from_pandas(series, npartitions=34)
+    result = dask_series.reduction(
+        chunk=lambda x: x,
+        aggregate=lambda x: SomeObject(x.sum().sum()),
+        split_every=False,
+        token="commit-dataset",
+        meta=object,
+    )
+
+    assert (await c.compute(result)).val == 170


### PR DESCRIPTION
Adds missing `split_every` attribute to `DataFrameTreeReduction.__dask_distributed_pack__`.  Further motivation for the simplification proposed in #8672 :)

- [x] Closes #8773
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
