### PR TITLE
Bump diagnostics bokeh dependency to 2.4.2

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -85,7 +85,7 @@ These optional dependencies and their minimum supported versions are listed belo
 +---------------+----------+--------------------------------------------------------------+
 | Dependency    | Version  |                          Description                         |
 +===============+==========+==============================================================+
-|     bokeh     | >=2.1.1  |                Visualizing dask diagnostics                  |
+|     bokeh     | >=2.4.2  |                Visualizing dask diagnostics                  |
 +---------------+----------+--------------------------------------------------------------+
 |   cityhash    |          |                  Faster hashing of arrays                    |
 +---------------+----------+--------------------------------------------------------------+

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require: dict[str, list[str]] = {
     "dataframe": ["numpy >= 1.18", "pandas >= 1.0"],
     "distributed": ["distributed == 2022.02.1"],
     "diagnostics": [
-        "bokeh >= 2.1.1",
+        "bokeh >= 2.4.2",
         "jinja2",
     ],
     "delayed": [],  # keeping for backwards compatibility


### PR DESCRIPTION
Bumps `dask.diagnostics` bokeh dependency to 2.4.2, to match up with the proposed version bump in https://github.com/dask/distributed/pull/4614.

cc @quasiben @jacobtomlinson

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
