### PR TITLE
Temporarily xfail graphviz tests on windows

### DIFF
--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1009,6 +1009,10 @@ def test_compute_nested():
 @pytest.mark.skipif(
     sys.flags.optimize, reason="graphviz exception with Python -OO flag"
 )
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="graphviz/pango on conda-forge currently broken for windows",
+)
 def test_visualize():
     pytest.importorskip("graphviz")
     with tmpdir() as d:

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1012,6 +1012,7 @@ def test_compute_nested():
 @pytest.mark.xfail(
     sys.platform == "win32",
     reason="graphviz/pango on conda-forge currently broken for windows",
+    strict=False,
 )
 def test_visualize():
     pytest.importorskip("graphviz")

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -178,6 +178,10 @@ def test_to_graphviz_with_unconnected_node():
         pytest.param("svg", SVG, marks=ipython_not_installed_mark),
     ],
 )
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="graphviz/pango on conda-forge currently broken for windows",
+)
 def test_dot_graph(tmpdir, format, typ):
     # Use a name that the shell would interpret specially to ensure that we're
     # not vulnerable to shell injection when interacting with `dot`.
@@ -211,6 +215,10 @@ def test_dot_graph(tmpdir, format, typ):
         pytest.param("svg", SVG, marks=ipython_not_installed_mark),
     ],
 )
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="graphviz/pango on conda-forge currently broken for windows",
+)
 def test_dot_graph_no_filename(tmpdir, format, typ):
     before = tmpdir.listdir()
     result = dot_graph(dsk, filename=None, format=format)
@@ -221,6 +229,10 @@ def test_dot_graph_no_filename(tmpdir, format, typ):
 
 
 @ipython_not_installed_mark
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="graphviz/pango on conda-forge currently broken for windows",
+)
 def test_dot_graph_defaults():
     # Test with default args.
     default_name = "mydask"
@@ -257,6 +269,10 @@ def test_dot_graph_defaults():
             marks=ipython_not_installed_mark,
         ),
     ],
+)
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="graphviz/pango on conda-forge currently broken for windows",
 )
 def test_filenames_and_formats(tmpdir, filename, format, target, expected_result_type):
     result = dot_graph(dsk, filename=str(tmpdir.join(filename)), format=format)

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -181,6 +181,7 @@ def test_to_graphviz_with_unconnected_node():
 @pytest.mark.xfail(
     sys.platform == "win32",
     reason="graphviz/pango on conda-forge currently broken for windows",
+    strict=False,
 )
 def test_dot_graph(tmpdir, format, typ):
     # Use a name that the shell would interpret specially to ensure that we're
@@ -218,6 +219,7 @@ def test_dot_graph(tmpdir, format, typ):
 @pytest.mark.xfail(
     sys.platform == "win32",
     reason="graphviz/pango on conda-forge currently broken for windows",
+    strict=False,
 )
 def test_dot_graph_no_filename(tmpdir, format, typ):
     before = tmpdir.listdir()
@@ -232,6 +234,7 @@ def test_dot_graph_no_filename(tmpdir, format, typ):
 @pytest.mark.xfail(
     sys.platform == "win32",
     reason="graphviz/pango on conda-forge currently broken for windows",
+    strict=False,
 )
 def test_dot_graph_defaults():
     # Test with default args.
@@ -273,6 +276,7 @@ def test_dot_graph_defaults():
 @pytest.mark.xfail(
     sys.platform == "win32",
     reason="graphviz/pango on conda-forge currently broken for windows",
+    strict=False,
 )
 def test_filenames_and_formats(tmpdir, filename, format, target, expected_result_type):
     result = dot_graph(dsk, filename=str(tmpdir.join(filename)), format=format)


### PR DESCRIPTION
Something in the recent pango or graphviz builds on conda-forge broke,
and now these tests are failing. Xfail these tests temporarily until the
upstream issue is resolved.
