### PR TITLE
Add sanity checks to divisions setter

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -19,6 +19,7 @@ from ..utils import M, digit
 from . import methods
 from .core import DataFrame, Series, _Frame, map_partitions, new_dd_object
 from .dispatch import group_split_dispatch, hash_object_dispatch
+from .utils import UNKNOWN_CATEGORIES
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,9 @@ def _calculate_divisions(
         except (TypeError, ValueError):  # str type
             indexes = np.linspace(0, n - 1, npartitions + 1).astype(int)
             divisions = [divisions[i] for i in indexes]
+    else:
+        # Drop duplicate divisions returned by partition quantiles
+        divisions = list(toolz.unique(divisions[:-1])) + [divisions[-1]]
 
     mins = remove_nans(mins)
     maxes = remove_nans(maxes)
@@ -307,6 +311,12 @@ def set_partition(
 
     if pd.isna(divisions).any() and pd.api.types.is_integer_dtype(dtype):
         # Can't construct a Series[int64] when any / all of the divisions are NaN.
+        divisions = df._meta._constructor_sliced(divisions)
+    elif (
+        pd.api.types.is_categorical_dtype(dtype)
+        and UNKNOWN_CATEGORIES in dtype.categories
+    ):
+        # If categories are unknown, leave as a string dtype instead.
         divisions = df._meta._constructor_sliced(divisions)
     else:
         divisions = df._meta._constructor_sliced(divisions, dtype=dtype)
@@ -1055,7 +1065,7 @@ def compute_divisions(df, col=None, **kwargs) -> tuple:
 def compute_and_set_divisions(df, **kwargs):
     mins, maxes, lens = _compute_partition_stats(df.index, allow_overlap=True, **kwargs)
     if len(mins) == len(df.divisions) - 1:
-        df.divisions = tuple(mins) + (maxes[-1],)
+        df._divisions = tuple(mins) + (maxes[-1],)
         if not any(mins[i] >= maxes[i - 1] for i in range(1, len(mins))):
             return df
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1078,15 +1078,19 @@ def test_align_dataframes():
     df1 = pd.DataFrame({"A": [1, 2, 3, 3, 2, 3], "B": [1, 2, 3, 4, 5, 6]})
     df2 = pd.DataFrame({"A": [3, 1, 2], "C": [1, 2, 3]})
 
-    def merge(a, b):
-        res = pd.merge(a, b, left_on="A", right_on="A", how="left")
-        return res
-
-    expected = merge(df1, df2)
-
     ddf1 = dd.from_pandas(df1, npartitions=2)
-    actual = ddf1.map_partitions(merge, df2, align_dataframes=False)
+    ddf2 = dd.from_pandas(df2, npartitions=1)
 
+    actual = ddf1.map_partitions(
+        pd.merge, df2, align_dataframes=False, left_on="A", right_on="A", how="left"
+    )
+    expected = pd.merge(df1, df2, left_on="A", right_on="A", how="left")
+    assert_eq(actual, expected, check_index=False, check_divisions=False)
+
+    actual = ddf2.map_partitions(
+        pd.merge, ddf1, align_dataframes=False, left_on="A", right_on="A", how="right"
+    )
+    expected = pd.merge(df2, df1, left_on="A", right_on="A", how="right")
     assert_eq(actual, expected, check_index=False, check_divisions=False)
 
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -669,7 +669,7 @@ def test_set_index_interpolate(engine):
         d = dd.from_pandas(df, 2)
 
     d1 = d.set_index("x", npartitions=3)
-    assert d1.npartitions == 3
+    assert d1.npartitions <= 3
     assert set(d1.divisions) == {1, 2, 4}
 
     d2 = d.set_index("y", npartitions=3)


### PR DESCRIPTION
Adds a few sanity checks to the divisions property setter, motivated by #8802 (fixes #8802).

- New divisions are compatible with the existing `npartitions`
- New divisions don't mix None and non-None values
- New divisions are sorted (except for ordered categorical dtypes, where that's not easily doable given our current datastructures)
- New divisions are unique except for the last value

These sanity checks turned up a number of bugs that needed to be fixed.
- `map_partitions` with `align_dataframes=False` would select the wrong output divisions, any use of this was relying on the caller manually fixing things later.

- `set_index` could result in non-unique divisions being used in certain cases (e.g. `(0, 0, 0, 1, 2, 3, 3)`). We now deduplicate values in places where divisions are computed as needed. Note that this means that certain operations can result in <= the number of npartitions requested (e.g. now `df.repartition(npartitions=npartitions).npartitions <= npartitions`). I think this is still fine - before we'd have the requested number of partitions, but some partitions may be completely empty. This *may* be considered a fix for https://github.com/dask/dask/issues/8437? (cc @gjoseph92).
 
- A few category-dtype related fixes. Category dtypes are leaky abstractions, all of this feels a little hacky, but tests seem to pass.

Note that this removes the deprecation warnings added in https://github.com/dask/dask/pull/8393, I believe those have been released long enough now to remove them.