### PR TITLE
Custom collection example docs fix (remove comment about automatic optimizations)

### DIFF
--- a/docs/source/custom-collections.rst
+++ b/docs/source/custom-collections.rst
@@ -497,9 +497,9 @@ elements of ``dask.delayed``:
 
         @staticmethod
         def __dask_optimize__(dsk, keys, **kwargs):
-            # We cull unnecessary tasks here. Note that this isn't necessary,
-            # dask will do this automatically, this just shows one optimization
-            # you could do.
+            # We cull unncessary tasks here. See
+            # https://docs.dask.org/en/stable/optimize.html for more
+            # information on optimizations in Dask.
             dsk2, _ = cull(dsk, keys)
             return dsk2
 


### PR DESCRIPTION
Looks like a note about automatic optimizations performed by the scheduler was removed in https://github.com/dask/dask/pull/4752 (this was specific to the optimization docs). There is an inline code comment note in the custom collections docs that mentions automatic optimizations happen. This PR fixes that. The discussion in the issue (from 2019, https://github.com/dask/dask/issues/4585) mentions that now the recommendation is to cull on your own.