### PR TITLE
If file is empty, don't fail on meta creation

### DIFF
--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -409,7 +409,10 @@ def read_hdf(
     # Build metadata
     with pd.HDFStore(paths[0], mode=mode) as hdf:
         meta_key = _expand_key(key, hdf)[0]
-    meta = pd.read_hdf(paths[0], meta_key, mode=mode, stop=0)
+    try:
+        meta = pd.read_hdf(paths[0], meta_key, mode=mode, stop=0)
+    except IndexError:  # if file is empty, don't set stop
+        meta = pd.read_hdf(paths[0], meta_key, mode=mode)
     if columns is not None:
         meta = meta[columns]
 

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -908,3 +908,13 @@ def test_hdf_nonpandas_keys():
         dd.read_hdf(path, "/group/table2")
         dd.read_hdf(path, "/group/table3")
         dd.read_hdf(path, "/bar")
+
+
+def test_hdf_empty_dataframe():
+    # https://github.com/dask/dask/issues/8707
+    from dask.dataframe.io.hdf import dont_use_fixed_error_message
+
+    df = pd.DataFrame({"A": [], "B": []}, index=[])
+    df.to_hdf("data.h5", format="fixed", key="df", mode="w")
+    with pytest.raises(TypeError, match=dont_use_fixed_error_message):
+        dd.read_hdf("data.h5", "df")


### PR DESCRIPTION
- [x] Closes #8707
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Note that the scenario described in #8707 still raises an error, it is just a different and more descriptive error explaining why the action is not supported.