### PR TITLE
to_parquet default to `compression="snappy"`

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -19,14 +19,6 @@ from ...methods import concat
 from ..utils import _is_local_fs
 from .utils import Engine, _sort_and_analyze_paths
 
-try:
-    import snappy
-
-    snappy.compress
-except (ImportError, AttributeError):
-    snappy = None
-
-
 __all__ = ("read_parquet", "to_parquet")
 
 NONE_LABEL = "__null_dask_index__"
@@ -528,7 +520,7 @@ def to_parquet(
     df,
     path,
     engine="auto",
-    compression="default",
+    compression="snappy",
     write_index=True,
     append=False,
     overwrite=False,
@@ -558,11 +550,10 @@ def to_parquet(
     engine : {'auto', 'fastparquet', 'pyarrow'}, default 'auto'
         Parquet library to use. If only one library is installed, it will use
         that one; if both, it will use 'fastparquet'.
-    compression : string or dict, default 'default'
+    compression : string or dict, default 'snappy'
         Either a string like ``"snappy"`` or a dictionary mapping column names
-        to compressors like ``{"name": "gzip", "values": "snappy"}``. The
-        default is ``"default"``, which uses the default compression for
-        whichever engine is selected.
+        to compressors like ``{"name": "gzip", "values": "snappy"}``. Defaults
+        to ``"snappy"``.
     write_index : boolean, default True
         Whether or not to write the index. Defaults to True.
     append : bool, default False
@@ -651,10 +642,12 @@ def to_parquet(
     compute_kwargs = compute_kwargs or {}
 
     if compression == "default":
-        if snappy is not None:
-            compression = "snappy"
-        else:
-            compression = None
+        warnings.warn(
+            "compression='default' is deprecated and will be removed in a "
+            "future version, the default for all engines is 'snappy' now.",
+            FutureWarning,
+        )
+        compression = "snappy"
 
     partition_on = partition_on or []
     if isinstance(partition_on, str):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1735,11 +1735,24 @@ def check_compression(engine, filename, compression):
                     )
 
 
-@pytest.mark.parametrize("compression,", ["default", None, "gzip", "snappy"])
+def test_explicit_compression_default_deprecated(tmpdir, engine):
+    """TODO: remove this test when `compression="default"` is fully removed"""
+    fn = str(tmpdir)
+
+    df = pd.DataFrame({"x": ["a", "b", "c"] * 10, "y": [1, 2, 3] * 10})
+    df.index.name = "index"
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    with pytest.warns(FutureWarning, match="compression='default'"):
+        ddf.to_parquet(fn, compression="default", engine=engine)
+    out = dd.read_parquet(fn, engine=engine)
+    assert_eq(out, ddf)
+    check_compression(engine, fn, "default")
+
+
+@pytest.mark.parametrize("compression,", [None, "gzip", "snappy"])
 def test_writing_parquet_with_compression(tmpdir, compression, engine):
     fn = str(tmpdir)
-    if compression in ["snappy", "default"]:
-        pytest.importorskip("snappy")
 
     df = pd.DataFrame({"x": ["a", "b", "c"] * 10, "y": [1, 2, 3] * 10})
     df.index.name = "index"
@@ -1751,11 +1764,9 @@ def test_writing_parquet_with_compression(tmpdir, compression, engine):
     check_compression(engine, fn, compression)
 
 
-@pytest.mark.parametrize("compression,", ["default", None, "gzip", "snappy"])
+@pytest.mark.parametrize("compression,", [None, "gzip", "snappy"])
 def test_writing_parquet_with_partition_on_and_compression(tmpdir, compression, engine):
     fn = str(tmpdir)
-    if compression in ["snappy", "default"]:
-        pytest.importorskip("snappy")
 
     df = pd.DataFrame({"x": ["a", "b", "c"] * 10, "y": [1, 2, 3] * 10})
     df.index.name = "index"
@@ -2030,7 +2041,6 @@ def test_writing_parquet_with_kwargs(tmpdir, engine):
     fn = str(tmpdir)
     path1 = os.path.join(fn, "normal")
     path2 = os.path.join(fn, "partitioned")
-    pytest.importorskip("snappy")
 
     df = pd.DataFrame(
         {
@@ -2096,8 +2106,6 @@ def test_to_parquet_with_get(tmpdir):
 
 
 def test_select_partitioned_column(tmpdir, engine):
-    pytest.importorskip("snappy")
-
     fn = str(tmpdir)
     size = 20
     d = {


### PR DESCRIPTION
Previously `to_parquet` had `compression="default"` as the default. In
this case, `"snappy"` was used if `import snappy` succeeded, otherwise
`None` was used.

This may have been correct when written, but is no longer correct.

- `fastparquet` uses `cramjam` for compression support (changed ~1 year
   ago). This library is not optional, so `fastparquet` always supports
   snappy.
- `pyarrow` uses the snappy c library directly (and it's always
  included), whether `snappy` (the python library) successfully imports
  is irrelevant.

As such we chose to deprecate `compression="default"` in favor of using
`"snappy"` everywhere for consistency across engines.