### PR TITLE
Update Dask configuration reference with undocumented options

### DIFF
--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -1,4 +1,69 @@
 properties:
+  array_optimize:
+    type: object
+    description: |
+      ...
+
+  array_plugins:
+    type: object
+    description: |
+      ...
+
+  chunksize:
+    type: object
+    description: |
+      ...
+
+  delayed_pure:
+    type: boolean
+    description: |
+      ...
+
+  func_dumps:
+    type: object
+    description: |
+      ...
+
+  func_loads:
+    type: object
+    description: |
+      ...
+
+  get:
+    type: string
+    description: |
+      ...
+
+  num_workers:
+    type: integer
+    description: |
+      ...
+
+  optimizations:
+    type: object
+    description: |
+      ...
+
+  pool:
+    type: object
+    description: |
+      ...
+
+  scheduler:
+    type: string
+    description: |
+      ...
+
+  shuffle:
+    type: string
+    description: |
+      ...
+
+  split_every:
+    type: integer
+    description: |
+      ...    
+
   temporary-directory:
     type:
     - string
@@ -9,6 +74,14 @@ properties:
 
       When the value is "null" (default), dask will create a directory from
       where dask was launched: `cwd/dask-worker-space`
+
+  multiprocessing:
+    type: object
+    properties:
+      context:
+        type: object
+        description: |
+          ...
 
   tokenize:
     type: object
@@ -54,6 +127,11 @@ properties:
   array:
     type: object
     properties:
+
+      chunk-size:
+        type: string
+        description: |
+          ...
 
       svg:
         type: object


### PR DESCRIPTION
I noticed that there are a lot of configuration options that are used throughout Dask's code that aren't actually mentioned on the configuration reference page, which is where I'd imagine a lot of users would go immediately to see what a specific option controls.

This PR is an attempt to enumerate all of those undocumented options, and give them descriptions / a default value in the config YAML if that makes sense. Some other out of scope, but also useful things that could be done:

- making sure that all `config.get`/`set` calls are using an existing / consistent config option; in looking through the codebase, I noticed [some typos](https://github.com/dask/dask/blob/4e5dfe7463028a39a90e026c7fb9220969093ab3/dask/dataframe/tests/test_shuffle.py#L301) when setting config options, and others that are referred to by different names (i.e. `array.slicing.split-large-chunks` vs `array.slicing.split_large_chunks`)
- Adding a simple Python test (or, if mandatory, CI job) to check that if a new config option is added, it is referenced in the schema

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
