### PR TITLE
Fix bug when applying "not equal" predicate in read_parquet

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1152,6 +1152,8 @@ def apply_filters(parts, statistics, filters):
                     if (
                         operator in ("==", "=")
                         and min <= value <= max
+                        or operator == "!="
+                        and (min != value or max != value)
                         or operator == "<"
                         and min < value
                         or operator == "<="

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1399,6 +1399,9 @@ def test_filters(tmpdir, write_engine, read_engine):
     assert len(f)
     assert (f.y == "c").all().compute()
 
+    g = dd.read_parquet(tmp_path, engine=read_engine, filters=[("x", "!=", 1)])
+    assert g.npartitions == 5
+
 
 @write_read_engines()
 def test_filters_v0(tmpdir, write_engine, read_engine):


### PR DESCRIPTION
The logic for `"!="` is currently missing from the filtering code in `read_parquet`.  This currently results in **all** data being dropped when `"!="` is included in the `filters` argument. This PR includes a simple fix and adds test coverage.
