### PR TITLE
Subgraph Callable Getter

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -283,14 +283,14 @@ def graph_from_arraylike(
         and has_keyword(getitem, "lock")
         and (not asarray or lock)
     ):
-        getter = partial(getitem, asarray=asarray, lock=lock)
+        kwargs = {"asarray": asarray, "lock": lock}
     else:
         # Common case, drop extra parameters
-        getter = getitem
+        kwargs = {}
 
     if inline_array:
         layer = core_blockwise(
-            getter,
+            getitem,
             name,
             out_ind,
             arr,
@@ -298,6 +298,7 @@ def graph_from_arraylike(
             ArraySliceDep(chunks),
             out_ind,
             numblocks={},
+            **kwargs,
         )
         return HighLevelGraph.from_collections(name, layer)
     else:
@@ -314,6 +315,7 @@ def graph_from_arraylike(
             ArraySliceDep(chunks),
             out_ind,
             numblocks={},
+            **kwargs,
         )
 
         deps = {

--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -101,14 +101,14 @@ def hold_keys(dsk, dependencies):
             # when there's either more than one dependent, or the dependent is
             # no longer a get* function or an alias. We then add the final
             # key to the list of keys not to fuse.
-            if type(task) is tuple and task and task[0] in GETTERS:
+            if _is_getter_task(task):
                 try:
                     while len(dependents[dep]) == 1:
                         new_dep = next(iter(dependents[dep]))
                         new_task = dsk[new_dep]
                         # If the task is a get* or an alias, continue up the
                         # linear chain
-                        if new_task[0] in GETTERS or new_task in dsk:
+                        if _is_getter_task(new_task) or new_task in dsk:
                             dep = new_dep
                         else:
                             break

--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -127,7 +127,8 @@ def _is_getter_task(
     2. Is it a SubgraphCallable with a single element in its
        dsk which is a known getter.
 
-    Returns the relevant getter function if it is found, otherwise returns None
+    If a getter is found, it returns a tuple with (getter, array, index, asarray, lock).
+    Otherwise it returns ``None``.
 
     TODO: the second check is a hack to allow for slice fusion between tasks produced
     from blockwise layers and slicing operations. Once slicing operations have
@@ -140,6 +141,9 @@ def _is_getter_task(
     get = None
     if first in GETTERS:
         get = first
+    # We only accept SubgraphCallables with a single sub-task right now as it's
+    # not clear which task to inspect if there is more than one, or how to resolve
+    # conflicts if they occur.
     elif isinstance(first, SubgraphCallable) and len(first.dsk) == 1:
         v = next(iter(first.dsk.values()))
         if type(v) is tuple and len(v) > 1 and v[0] in GETTERS:


### PR DESCRIPTION
Possible short-term fix for #8753. For more context, see especially https://github.com/dask/dask/issues/8753#issuecomment-1072792646.

Basically slicing fusion can fail where it used to succeed because the optimizer doesn't recognize that the `SubgraphCallable` tasks produced by a blockwise layer look like slices. This makes them look like slices.

I *don't* like this solution, and a better one would be to implement slicing as a HighLevelGraph layer and ensure that it can interact well with blockwise layers. But I'm not sure I see a better way to fix this in the short term. Marking as a draft as this is missing tests, and it almost certainly gets some of the logic around locks and `asarray` wrong right now (though they seem fairly untested).

@espenairmine, if you get the chance can you see if this fixes #8753 for you?

- [x] Closes #8753
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
