### PR TITLE
Check that values for the `in` predicate in `read_parquet` are correct

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1145,16 +1145,17 @@ class ArrowDatasetEngine(Engine):
             gather_statistics = False
 
         # Make sure that any `in`-predicate filters have iterable values
+        filter_columns = set()
         if filters is not None:
-            for filter in filters:
-                _, op, val = filter
+            for filter in flatten(filters, container=list):
+                col, op, val = filter
                 if op == "in" and not isinstance(val, (set, list, tuple)):
                     raise TypeError(
                         "Value of 'in' filter must be a list, set or tuple."
                     )
+                filter_columns.add(col)
 
         # Determine which columns need statistics.
-        filter_columns = {t[0] for t in flatten(filters or [], container=list)}
         stat_col_indices = {}
         for i, name in enumerate(schema.names):
             if name in index_cols or name in filter_columns:

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1124,6 +1124,8 @@ def apply_filters(parts, statistics, filters):
 
     def apply_conjunction(parts, statistics, conjunction):
         for column, operator, value in conjunction:
+            if operator == "in" and not isinstance(value, (list, set, tuple)):
+                raise TypeError("Value of 'in' filter must be a list, set, or tuple.")
             out_parts = []
             out_statistics = []
             for part, stats in zip(parts, statistics):

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -10,6 +10,8 @@ import pandas as pd
 import tlz as toolz
 from packaging.version import parse as parse_version
 
+from dask.core import flatten
+
 try:
     import fastparquet
     from fastparquet import ParquetFile
@@ -25,7 +27,6 @@ from dask.base import tokenize
 #########################
 from dask.dataframe.io.parquet.utils import (
     Engine,
-    _flatten_filters,
     _get_aggregation_depth,
     _normalize_index_columns,
     _parse_pandas_metadata,
@@ -663,10 +664,10 @@ class FastParquetEngine(Engine):
                 gather_statistics = True
 
         # Determine which columns need statistics.
-        flat_filters = _flatten_filters(filters)
+        filter_columns = {t[0] for t in flatten(filters or [], container=list)}
         stat_col_indices = {}
         for i, name in enumerate(pf.columns):
-            if name in index_cols or name in flat_filters:
+            if name in index_cols or name in filter_columns:
                 stat_col_indices[name] = i
 
         # If the user has not specified `gather_statistics`,

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -3,7 +3,6 @@ import re
 import pandas as pd
 
 from dask import config
-from dask.core import flatten
 from dask.dataframe.io.utils import _is_local_fs
 from dask.utils import natural_sort_key
 
@@ -487,15 +486,6 @@ def _analyze_paths(file_list, fs, root=False):
         "/".join(basepath),
         out_list,
     )  # use '/'.join() instead of _join_path to be consistent with split('/')
-
-
-def _flatten_filters(filters):
-    """Flatten DNF-formatted filters (list of tuples)"""
-    return (
-        set(flatten(tuple(flatten(filters, container=list)), container=tuple))
-        if filters
-        else []
-    )
 
 
 def _aggregate_stats(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1408,7 +1408,7 @@ def test_filtering_pyarrow_dataset(tmpdir, engine):
     filters = [[("aa", "<", aa_lim), ("bb", "==", bb_val)]]
     ddf2 = dd.read_parquet(fn, index=False, engine="pyarrow", filters=filters)
 
-    # Check that partitions are filetered for "aa" filter
+    # Check that partitions are filtered for "aa" filter
     nonempty = 0
     for part in ddf[ddf["aa"] < aa_lim].partitions:
         nonempty += int(len(part.compute()) > 0)


### PR DESCRIPTION
- Requires parquet in predicate to be iterable

This is rebased on #8835 that removes the `pyarrow-legacy` engine. The tests added here were failing with `pyarrow-legacy`, but as that will be removed soon, I opted to just remove that case by rebasing. This should then be rebased again and merged after #8835 is merged.

- [x] Closes #8720
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
