### PR TITLE
Check for ucx-py nightlies when updating gpuCI

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -13,39 +13,57 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Parse current axis YAML
+        uses: the-coding-turtle/ga-yaml-parser@v0.1.1
+        with:
+          file: continuous_integration/gpuci/axis.yaml
+
       - name: Get latest cuDF nightly version
-        id: latest_version
+        id: cudf_latest
         uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
         with:
           org: "rapidsai-nightly"
           package: "cudf"
           version_system: "CalVer"
 
-      - name: Strip git tags from versions
-        env:
-          FULL_RAPIDS_VER: ${{ steps.latest_version.outputs.version }}
-        run: echo "RAPIDS_VER=${FULL_RAPIDS_VER::-10}" >> $GITHUB_ENV
+      - name: Get latest UCX-Py nightly version
+        id: ucx_py_latest
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
+        with:
+          org: "rapidsai-nightly"
+          package: "ucx-py"
+          version_system: "CalVer"
 
-      - name: Find and Replace Release
-        uses: jacobtomlinson/gha-find-replace@0.1.4
+      - name: Get old RAPIDS / UCX-Py versions
+        env:
+          FULL_RAPIDS_VER: ${{ steps.cudf_latest.outputs.version }}
+          FULL_UCX_PY_VER: ${{ steps.ucx_py_latest.outputs.version }}
+        run: |
+          echo RAPIDS_VER=$RAPIDS_VER_0 >> $GITHUB_ENV
+          echo UCX_PY_VER=$(curl -sL https://version.gpuci.io/rapids/$RAPIDS_VER_0) >> $GITHUB_ENV
+          echo NEW_RAPIDS_VER=${FULL_RAPIDS_VER::-10} >> $GITHUB_ENV
+          echo NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-10} >> $GITHUB_ENV
+
+      - name: Update RAPIDS version
+        uses: jacobtomlinson/gha-find-replace@2
         with:
           include: 'continuous_integration\/gpuci\/axis\.yaml'
-          find: "RAPIDS_VER:\n- .*"
-          replace: |-
-            RAPIDS_VER:
-            - "${{ env.RAPIDS_VER }}"
+          find: "${{ env.RAPIDS_VER }}"
+          replace: "${{ env.NEW_RAPIDS_VER }}"
+          regex: false
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
+        if: ${{ env.UCX_PY_VER != env.NEW_UCX_PY_VER }}  # make sure new ucx-py nightlies are available
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
-          commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.RAPIDS_VER }}`"
-          title: "Update gpuCI `RAPIDS_VER` to `${{ env.RAPIDS_VER }}`"
+          commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`"
+          title: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`"
           team-reviewers: "dask/gpu"
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: "upgrade-gpuci-rapids"
           body: |
-            A new cuDF nightly version has been detected.
+            New cuDF and ucx-py nightly versions have been detected.
 
-            Updated `axis.yaml` to use `${{ env.RAPIDS_VER }}`.
+            Updated `axis.yaml` to use `${{ env.NEW_RAPIDS_VER }}`.


### PR DESCRIPTION
Modifies the logic of the gpuCI updating workflow to only open a PR when both cuDF _and_ ucx-py nightlies are available - this should reduce the amount of lag between the PR getting opened and gpuCI images being readily available.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
