### PR TITLE
Correctly handle dict-specification for rechunk.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args:
           - --py38-plus
   -   repo: https://github.com/psf/black
-      rev: 22.1.0
+      rev: 22.3.0
       hooks:
       - id: black
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args:
           - --py38-plus
   -   repo: https://github.com/psf/black
-      rev: 22.3.0
+      rev: 22.1.0
       hooks:
       - id: black
         language_version: python3

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -290,6 +290,8 @@ def rechunk(x, chunks="auto", threshold=None, block_size_limit=None, balance=Fal
         for i in range(x.ndim):
             if i not in chunks:
                 chunks[i] = x.chunks[i]
+            elif chunks[i] is None:
+                chunks[i] = x.chunks[i]
     if isinstance(chunks, (tuple, list)):
         chunks = tuple(lc if lc is not None else rc for lc, rc in zip(chunks, x.chunks))
     chunks = normalize_chunks(

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -212,6 +212,10 @@ def test_rechunk_with_dict():
     y = x.rechunk(chunks={0: -1})
     assert y.chunks == ((24,), (8, 8, 8))
 
+    x = da.ones((24, 24), chunks=(4, 8))
+    y = x.rechunk(chunks={0: None, 1: 'auto'})
+    assert y.chunks == ((4, 4, 4, 4, 4, 4), (24,))
+
 
 def test_rechunk_with_empty_input():
     x = da.ones((24, 24), chunks=(4, 8))

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -226,6 +226,10 @@ def test_rechunk_with_empty_input():
 def test_rechunk_with_null_dimensions():
     x = da.from_array(np.ones((24, 24)), chunks=(4, 8))
     assert x.rechunk(chunks=(None, 4)).chunks == da.ones((24, 24), chunks=(4, 4)).chunks
+    assert (
+        x.rechunk(chunks={0: None, 1: 4}).chunks
+        == da.ones((24, 24), chunks=(4, 4)).chunks
+    )
 
 
 def test_rechunk_with_integer():

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -213,7 +213,7 @@ def test_rechunk_with_dict():
     assert y.chunks == ((24,), (8, 8, 8))
 
     x = da.ones((24, 24), chunks=(4, 8))
-    y = x.rechunk(chunks={0: None, 1: 'auto'})
+    y = x.rechunk(chunks={0: None, 1: "auto"})
     assert y.chunks == ((4, 4, 4, 4, 4, 4), (24,))
 
 


### PR DESCRIPTION
If a dictionary is used to specify rechunk behaviour of a dask array, and
`None` is specified for a particular axis, the correct behaviour should be
to leave that axis with its current chunk specification. This PR ensures
that `rechunk` does that, in line with the documentation (and tuple or 
list specification).

```python
>>> import dask
>>> import dask.array as da
>>> import numpy as np

# Create a dask array with an arbitrary chunking scheme
>>> a = da.from_array(np.zeros((20,24)), chunks=((5,5,5,5),(8,8,8)))
>>> print(a.chunks)
((5, 5, 5, 5), (8, 8, 8))

# If `None` is specified for an axis in the dictionary specification, `rechunk` should not automatically rechunk that index, but does:
>>> print(a.rechunk({0: None, 1: 'auto'}).chunks)
((20,), (24,))

# However, if `None` is specified for an axis in the tuple specification, `rechunk` behaves as expected/documented:
>>> print(a.rechunk((None, 'auto')).chunks)
((5, 5, 5, 5), (24,))

# If the index is not specified at all (i.e. not specifically set `None`), then behaviour in the dictionary specification is as expected:
>>> print(a.rechunk({1: 'auto'}).chunks)
((5, 5, 5, 5), (24,))

>>> dask.__version__
'2022.03.0'
```
