### PR TITLE
Added check on dtype.itemsize in order to produce an useful error mes…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ hdfs-initialized-indicator
 .ipynb_checkpoints
 mydask.png
 .vscode/
+.history

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3066,7 +3066,10 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
 
     else:
         # Check if dtype.itemsize is greater than 0
-        assert dtype.itemsize > 0, "dtype.itemsize must be > 0"
+        if dtype.itemsize == 0:
+            raise ValueError(
+                "auto-chunking with dtype.itemsize == 0 is not supported, please pass in `chunks` explicitly"
+            )
         size = (limit / dtype.itemsize / largest_block) ** (1 / len(autos))
         small = [i for i in autos if shape[i] < size]
         if small:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3065,6 +3065,8 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
         return tuple(chunks)
 
     else:
+        # Check if dtype.itemsize is greater than 0
+        assert dtype.itemsize > 0, "dtype.itemsize must be > 0"
         size = (limit / dtype.itemsize / largest_block) ** (1 / len(autos))
         small = [i for i in autos if shape[i] < size]
         if small:

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -863,6 +863,7 @@ def test_auto_chunks():
         x = da.ones((10000, 10000))
         assert 4 < x.npartitions < 32
 
+
 def test_string_auto_chunk():
     with pytest.raises(ValueError):
         da.full((10000, 10000), "auto_chunk", chunks="auto")

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -863,6 +863,10 @@ def test_auto_chunks():
         x = da.ones((10000, 10000))
         assert 4 < x.npartitions < 32
 
+def test_string_auto_chunk():
+    with pytest.raises(ValueError):
+        da.full((10000, 10000), "auto_chunk", chunks="auto")
+
 
 def test_diagonal_zero_chunks():
     x = da.ones((8, 8), chunks=(4, 4))


### PR DESCRIPTION
…sage

- [x] Closes #8856 
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
