### PR TITLE
Remove support for PyPy

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -5,21 +5,12 @@ from array import array
 
 from dask.utils import Dispatch
 
-try:  # PyPy does not support sys.getsizeof
-    sys.getsizeof(1)
-    getsizeof = sys.getsizeof
-except (AttributeError, TypeError):  # Monkey patch
-
-    def getsizeof(x):  # type: ignore
-        return 100
-
-
 sizeof = Dispatch(name="sizeof")
 
 
 @sizeof.register(object)
 def sizeof_default(o):
-    return getsizeof(o)
+    return sys.getsizeof(o)
 
 
 @sizeof.register(bytes)
@@ -53,9 +44,11 @@ def sizeof_python_collection(seq):
             samples = itertools.islice(seq, num_samples)
         else:
             samples = random.sample(seq, num_samples)
-        return getsizeof(seq) + int(num_items / num_samples * sum(map(sizeof, samples)))
+        return sys.getsizeof(seq) + int(
+            num_items / num_samples * sum(map(sizeof, samples))
+        )
     else:
-        return getsizeof(seq) + sum(map(sizeof, seq))
+        return sys.getsizeof(seq) + sum(map(sizeof, seq))
 
 
 class SimpleSizeof:
@@ -78,13 +71,13 @@ class SimpleSizeof:
 
 @sizeof.register(SimpleSizeof)
 def sizeof_blocked(d):
-    return getsizeof(d)
+    return sys.getsizeof(d)
 
 
 @sizeof.register(dict)
 def sizeof_python_dict(d):
     return (
-        getsizeof(d)
+        sys.getsizeof(d)
         + sizeof(list(d.keys()))
         + sizeof(list(d.values()))
         - 2 * sizeof(list())

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -3,12 +3,12 @@ from array import array
 
 import pytest
 
-from dask.sizeof import getsizeof, sizeof
+from dask.sizeof import sizeof
 from dask.utils import funcname
 
 
 def test_base():
-    assert sizeof(1) == getsizeof(1)
+    assert sizeof(1) == sys.getsizeof(1)
 
 
 def test_name():
@@ -16,7 +16,7 @@ def test_name():
 
 
 def test_containers():
-    assert sizeof([1, 2, [3]]) > (getsizeof(3) * 3 + getsizeof([]))
+    assert sizeof([1, 2, [3]]) > (sys.getsizeof(3) * 3 + sys.getsizeof([]))
 
 
 def test_bytes_like():


### PR DESCRIPTION
Companion PR to https://github.com/dask/distributed/pull/6029 to drop support for PyPy (xref https://github.com/dask/distributed/issues/5681). The only change here is to remove some no-longer-needed compatibility code around `sys.getsizeof`
