### PR TITLE
fixed broadcast of array chunks containing a scalar during `compute()`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -478,7 +478,7 @@ def apply_infer_dtype(func, args, kwargs, funcname, suggest_dtype="dtype", nout=
         msg = None
     if msg is not None:
         raise ValueError(msg)
-    return o.dtype if nout is None else tuple(e.dtype for e in o)
+    return getattr(o, "dtype", type(o)) if nout is None else tuple(e.dtype for e in o)
 
 
 def normalize_arg(x):
@@ -523,6 +523,7 @@ def map_blocks(
     chunks=None,
     drop_axis=[],
     new_axis=None,
+    enforce_ndim=False,
     meta=None,
     **kwargs,
 ):
@@ -555,6 +556,11 @@ def map_blocks(
     new_axis : number or iterable, optional
         New dimensions created by the function. Note that these are applied
         after ``drop_axis`` (if present).
+    enforce_ndim : bool, default True
+        Whether to enforce at runtime that the dimensionality of the array
+        produced by ``func`` actually matches that of the array returned by
+        ``map_blocks``.
+        This will raise an error if there is a mismatch.
     token : string, optional
         The key prefix to use for the output array. If not provided, will be
         determined from the function name.
@@ -834,19 +840,36 @@ def map_blocks(
     else:
         adjust_chunks = None
 
-    out = blockwise(
-        func,
-        out_ind,
-        *concat(argpairs),
-        name=name,
-        new_axes=new_axes,
-        dtype=dtype,
-        concatenate=True,
-        align_arrays=False,
-        adjust_chunks=adjust_chunks,
-        meta=meta,
-        **kwargs,
-    )
+    if enforce_ndim:
+        out = blockwise(
+            apply_and_enforce,
+            out_ind,
+            *concat(argpairs),
+            expected_ndim=len(out_ind),
+            _func=func,
+            name=name,
+            new_axes=new_axes,
+            dtype=dtype,
+            concatenate=True,
+            align_arrays=False,
+            adjust_chunks=adjust_chunks,
+            meta=meta,
+            **kwargs,
+        )
+    else:
+        out = blockwise(
+            func,
+            out_ind,
+            *concat(argpairs),
+            name=name,
+            new_axes=new_axes,
+            dtype=dtype,
+            concatenate=True,
+            align_arrays=False,
+            adjust_chunks=adjust_chunks,
+            meta=meta,
+            **kwargs,
+        )
 
     extra_argpairs = []
     extra_names = []
@@ -968,6 +991,22 @@ def map_blocks(
             **kwargs,
         )
 
+    return out
+
+
+def apply_and_enforce(*args, **kwargs):
+    """Apply a function, and enforce the output.ndim to match expected_ndim
+
+    Ensures the output has the expected dimensionality."""
+    func = kwargs.pop("_func")
+    expected_ndim = kwargs.pop("expected_ndim")
+    out = func(*args, **kwargs)
+    if getattr(out, "ndim", 0) != expected_ndim:
+        out_ndim = getattr(out, "ndim", 0)
+        raise ValueError(
+            f"Dimension mismatch: expected output of {func} "
+            f"to have dims = {expected_ndim}.  Got {out_ndim} instead."
+        )
     return out
 
 
@@ -4905,7 +4944,7 @@ def chunks_from_arrays(arrays):
 
     def shape(x):
         try:
-            return x.shape
+            return x.shape if x.shape else (1,)
         except AttributeError:
             return (1,)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -5236,3 +5236,61 @@ def test_len_object_with_unknown_size():
     b = a[a < 0.5]
     with pytest.raises(ValueError, match="on object with unknown chunk size"):
         assert len(b)
+
+
+@pytest.mark.parametrize("ndim", [0, 1, 3, 8])
+def test_chunk_shape_broadcast(ndim):
+    from functools import partial
+
+    def f(x, ndim=0):
+        # Ignore `x` and return arbitrary one-element array of dimensionality `ndim`
+        # For example,
+        # f(x, 0) = array(5)
+        # f(x, 1) = array([5])
+        # f(x, 2) = array([[5]])
+        # f(x, 3) = array([[[5]]])
+        return np.array(5)[(np.newaxis,) * ndim]
+
+    array = da.from_array([1] + [2, 2] + [3, 3, 3], chunks=((1, 2, 3),))
+    out_chunks = ((1, 1, 1),)
+
+    # check ``enforce_ndim`` keyword parameter of ``map_blocks()``
+    out = array.map_blocks(partial(f, ndim=ndim), chunks=out_chunks, enforce_ndim=True)
+
+    if ndim != 1:
+        with pytest.raises(ValueError, match="Dimension mismatch:"):
+            out.compute()
+    else:
+        out.compute()  # should not raise an exception
+
+    # check ``check_ndim`` keyword parameter of ``assert_eq()``
+    out = array.map_blocks(partial(f, ndim=ndim), chunks=out_chunks)
+    expected = np.array([5, 5, 5])
+    try:
+        assert_eq(out, expected)
+    except AssertionError:
+        assert_eq(out, expected, check_ndim=False)
+    else:
+        if ndim != 1:
+            raise AssertionError("Expected a ValueError: Dimension mismatch")
+
+
+def test_chunk_non_array_like():
+    array = da.from_array([1] + [2, 2] + [3, 3, 3], chunks=((1, 2, 3),))
+    out_chunks = ((1, 1, 1),)
+
+    # check ``enforce_ndim`` keyword parameter of ``map_blocks()``
+    out = array.map_blocks(lambda x: 5, chunks=out_chunks, enforce_ndim=True)
+
+    with pytest.raises(ValueError, match="Dimension mismatch:"):
+        out.compute()
+
+    expected = np.array([5, 5, 5])
+    # check ``check_ndim`` keyword parameter of ``assert_eq()``
+    out = array.map_blocks(lambda x: 5, chunks=out_chunks)
+    try:
+        assert_eq(out, expected)
+    except AssertionError:
+        assert_eq(out, expected, check_chunks=False)
+    else:
+        raise AssertionError("Expected a ValueError: Dimension mismatch")

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -210,7 +210,10 @@ def _check_dsk(dsk):
     assert not non_one, non_one
 
 
-def assert_eq_shape(a, b, check_nan=True):
+def assert_eq_shape(a, b, check_ndim=True, check_nan=True):
+    if check_ndim:
+        assert len(a) == len(b)
+
     for aa, bb in zip(a, b):
         if math.isnan(aa) or math.isnan(bb):
             if check_nan:
@@ -219,7 +222,7 @@ def assert_eq_shape(a, b, check_nan=True):
             assert aa == bb
 
 
-def _check_chunks(x, scheduler=None):
+def _check_chunks(x, check_ndim=True, scheduler=None):
     x = x.persist(scheduler=scheduler)
     for idx in itertools.product(*(range(len(c)) for c in x.chunks)):
         chunk = x.dask[(x.name,) + idx]
@@ -228,7 +231,9 @@ def _check_chunks(x, scheduler=None):
         if not hasattr(chunk, "dtype"):
             chunk = np.array(chunk, dtype="O")
         expected_shape = tuple(c[i] for c, i in zip(x.chunks, idx))
-        assert_eq_shape(expected_shape, chunk.shape, check_nan=False)
+        assert_eq_shape(
+            expected_shape, chunk.shape, check_ndim=check_ndim, check_nan=False
+        )
         assert (
             chunk.dtype == x.dtype
         ), "maybe you forgot to pass the scheduler to `assert_eq`?"
@@ -236,7 +241,12 @@ def _check_chunks(x, scheduler=None):
 
 
 def _get_dt_meta_computed(
-    x, check_shape=True, check_graph=True, check_chunks=True, scheduler=None
+    x,
+    check_shape=True,
+    check_graph=True,
+    check_chunks=True,
+    check_ndim=True,
+    scheduler=None,
 ):
     x_original = x
     x_meta = None
@@ -250,7 +260,7 @@ def _get_dt_meta_computed(
         x_meta = getattr(x, "_meta", None)
         if check_chunks:
             # Replace x with persisted version to avoid computing it twice.
-            x = _check_chunks(x, scheduler=scheduler)
+            x = _check_chunks(x, check_ndim=check_ndim, scheduler=scheduler)
         x = x.compute(scheduler=scheduler)
         x_computed = x
         if hasattr(x, "todense"):
@@ -276,6 +286,7 @@ def assert_eq(
     check_graph=True,
     check_meta=True,
     check_chunks=True,
+    check_ndim=True,
     check_type=True,
     check_dtype=True,
     equal_nan=True,
@@ -295,6 +306,7 @@ def assert_eq(
         check_shape=check_shape,
         check_graph=check_graph,
         check_chunks=check_chunks,
+        check_ndim=check_ndim,
         scheduler=scheduler,
     )
     b, bdt, b_meta, b_computed = _get_dt_meta_computed(
@@ -302,6 +314,7 @@ def assert_eq(
         check_shape=check_shape,
         check_graph=check_graph,
         check_chunks=check_chunks,
+        check_ndim=check_ndim,
         scheduler=scheduler,
     )
 


### PR DESCRIPTION
- [x] Closes #8822 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

I decided, somewhat reluctantly, to create this PR after thinking long and hard about Issue #8822 .  I was reluctant because this PR runs counter to PR #8847 .  But I hope @jsignell doesn't mind. :smile:  In any case, if this PR is not approved, then I hope it would have at least sparked a helpful discussion.

In principle, in `dask.array`, the content of any chunk must be an array whose number of dimensions matches that of the `dask` array possessing that chunk.

In practice, however, there appears to be room for grace, as under certain conditions, `dask` is able to work seamlessly with chunks whose contents violate this rule.

For example, consider the following chunk-function:
```python
import numpy as np


def f(x, ndim=0):
    """
	Ignore `x` and return arbitrary one-element array of dimensionality `ndim`
	
	For example,
	f(x, 0) = array(5)
	f(x, 1) = array([5])
	f(x, 2) = array([[5]])
	f(x, 3) = array([[[5]]])
	"""
    return np.array(5)[(np.newaxis,) * ndim]
```
which is applied, when `ndim = 1`, to the following `dask` array using `map_blocks()`: 
```python
import dask.array as da
from functools import partial


array = da.from_array([1] + [2, 2] + [3, 3, 3], chunks=((1, 2, 3),))
out_chunks = ((1, 1, 1),)

array.map_blocks(partial(f, ndim=1), chunks=out_chunks).compute()
# returns array([5, 5, 5])
```

The return value is as expected.  However, the following calls also return the same value:
```python
array.map_blocks(partial(f, ndim=2), chunks=out_chunks).compute()
# returns array([5, 5, 5])
array.map_blocks(partial(f, ndim=8), chunks=out_chunks).compute()
# returns array([5, 5, 5])
```
IMO, this attests to `dask`'s powerful ability to recognize what the dimensionality of each chunk should be and correct it.  But oddly, as first reported by @dcherian in #8822 , currently this behavior does not to extend to `ndim = 0`:
```python
array.map_blocks(partial(f, ndim=0), chunks=out_chunks).compute()
# currently raises a confusing error
```

This PR fixes this issue allowing the latter to return the same value as in the former cases.  It also fixes the following case, in which the chunk function returns a non-array-like type: 
```python
array.map_blocks(lambda x: 5, chunks=out_chunks).compute()
# currently raises a confusing error
```
allowing `map_blocks()` to return the same value as in the former cases.