### PR TITLE
Organize diagnostic and performance docs

### DIFF
--- a/docs/source/debugging-performance.rst
+++ b/docs/source/debugging-performance.rst
@@ -1,8 +1,7 @@
-Diagnostic and Performance
+Debugging and Performance
 ==========================
 
-This section contains resources to help you debug, obtain diagnostic and understand
-performance.
+This section contains resources to help you debug and understand performance.
 
 
 .. toctree::

--- a/docs/source/debugging-performance.rst
+++ b/docs/source/debugging-performance.rst
@@ -8,8 +8,8 @@ This section contains resources to help you debug and understand performance.
    :maxdepth: 1
 
    how-to/debug.rst
-   Visualize Task graphs <graphviz.rst>
-   Diagnostics Local <diagnostics-local.rst>
+   Visualize task graphs <graphviz.rst>
    Dashboard <dashboard.rst> 
-   Diagnostics Distributed <diagnostics-distributed.rst>
+   diagnostics-local.rst
+   diagnostics-distributed.rst
    Phases of computation <phases-of-computation.rst>

--- a/docs/source/diagnostics-performance.rst
+++ b/docs/source/diagnostics-performance.rst
@@ -1,0 +1,16 @@
+Diagnostic and Performance
+==========================
+
+This section contains resources to help you debug, obtain diagnostic and understand
+performance.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   how-to/debug.rst
+   Visualize Task graphs <graphviz.rst>
+   Diagnostics Local <diagnostics-local.rst>
+   Dashboard <dashboard.rst> 
+   Diagnostics Distributed <diagnostics-distributed.rst>
+   Phases of computation <phases-of-computation.rst>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -149,11 +149,11 @@ messy situations in everyday problems.
    array.rst
    bag.rst
    dataframe.rst
-   dashboard.rst
    delayed.rst
    futures.rst
    scheduling.rst
    graphs.rst
+   diagnostics-performance.rst
    deploying.rst
    internals.rst
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -153,7 +153,7 @@ messy situations in everyday problems.
    futures.rst
    scheduling.rst
    graphs.rst
-   diagnostics-performance.rst
+   debugging-performance.rst
    deploying.rst
    internals.rst
 


### PR DESCRIPTION
- [x] Closes #8841
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This PR is an attempt to organize the docs related to Diagnostic and Performance to make them more visible. There is some material repeated and duplicated. Eventually, we should clean this up. 

Couple of things to decide:
- Should we completely move the `debug` tab from How to ... and only keep it in Diagnostic and distributed.
-  After I push I realize that Understanding performance under Dask-Internals points to similar links as the new  Diagnostic and Performance tab. (what should we do here)
