### PR TITLE
fix(merge_asof): drop index column if left_on == right_on

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -946,10 +946,7 @@ def merge_asof(
     if not is_dask_collection(right):
         right = from_pandas(right, npartitions=1)
     if right_on is not None:
-        if on:
-            right = right.set_index(right_on, sorted=True)
-        else:
-            right = right.set_index(right_on, drop=False, sorted=True)
+        right = right.set_index(right_on, drop=(left_on == right_on), sorted=True)
 
     if by is not None:
         kwargs["left_by"] = kwargs["right_by"] = by

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -636,26 +636,27 @@ def test_merge_asof_with_empty():
     assert_eq(result_dd, result_df, check_index=False)
 
 
-def test_merge_asof_on_left_right():
+@pytest.mark.parametrize(
+    "left_col, right_col", [("endofweek", "timestamp"), ("endofweek", "endofweek")]
+)
+def test_merge_asof_on_left_right(left_col, right_col):
     df1 = pd.DataFrame(
         {
-            "endofweek": [1, 1, 2, 2, 3, 4],
+            left_col: [1, 1, 2, 2, 3, 4],
             "GroupCol": [1234, 8679, 1234, 8679, 1234, 8679],
         }
     )
-    df2 = pd.DataFrame(
-        {"timestamp": [0, 0, 1, 3], "GroupVal": [1234, 1234, 8679, 1234]}
-    )
+    df2 = pd.DataFrame({right_col: [0, 0, 1, 3], "GroupVal": [1234, 1234, 8679, 1234]})
 
     # pandas
-    result_df = pd.merge_asof(df1, df2, left_on="endofweek", right_on="timestamp")
+    result_df = pd.merge_asof(df1, df2, left_on=left_col, right_on=right_col)
 
     # dask
     result_dd = dd.merge_asof(
         dd.from_pandas(df1, npartitions=2),
         dd.from_pandas(df2, npartitions=2),
-        left_on="endofweek",
-        right_on="timestamp",
+        left_on=left_col,
+        right_on=right_col,
     )
 
     assert_eq(result_df, result_dd, check_index=False)


### PR DESCRIPTION
Addresses a small regression in the recent `merge_asof` fix (#8857) when the
`left_on` and `right_on` columns have the same name.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
