### PR TITLE
Add `network` marks to tests that fail without an internet connection

### DIFF
--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -48,6 +48,7 @@ def orc_files():
 
 
 @pytest.mark.parametrize("split_stripes", [1, 2])
+@pytest.mark.network
 def test_orc_single(orc_files, split_stripes):
     fn = orc_files[0]
     d = dd.read_orc(fn, split_stripes=split_stripes)
@@ -68,6 +69,7 @@ def test_orc_single(orc_files, split_stripes):
     assert set(graph.layers[key].columns) == set(columns)
 
 
+@pytest.mark.network
 def test_orc_multiple(orc_files):
     d = dd.read_orc(orc_files[0])
     d2 = dd.read_orc(orc_files)
@@ -134,6 +136,7 @@ def test_orc_roundtrip_aggregate_files(tmpdir, split_stripes):
     assert_eq(data, df2, check_index=False)
 
 
+@pytest.mark.network
 def test_orc_aggregate_files_offset(orc_files):
     # Default read should give back 16 partitions. Therefore,
     # specifying split_stripes=11 & aggregate_files=True should
@@ -148,6 +151,7 @@ def test_orc_aggregate_files_offset(orc_files):
     parse_version(pa.__version__) < parse_version("4.0.0"),
     reason=("PyArrow>=4.0.0 required for ORC write support."),
 )
+@pytest.mark.network
 def test_orc_names(orc_files, tmp_path):
     df = dd.read_orc(orc_files)
     assert df._name.startswith("read-orc")

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -606,7 +606,6 @@ async def test_map_partitions_da_input(c, s, a, b):
     await c.compute(df.map_partitions(f, arr, meta=df._meta))
 
 
-@pytest.mark.network
 def test_map_partitions_df_input():
     """
     Check that map_partitions can handle a delayed

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -606,6 +606,7 @@ async def test_map_partitions_da_input(c, s, a, b):
     await c.compute(df.map_partitions(f, arr, meta=df._meta))
 
 
+@pytest.mark.network
 def test_map_partitions_df_input():
     """
     Check that map_partitions can handle a delayed

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,8 @@ filterwarnings =
     error:::distributed[.*]
     # From https://github.com/numpy/numpy/issues/20225
     ignore:The distutils\.sysconfig module is deprecated, use sysconfig instead:DeprecationWarning:numpy
+    # With no network access, distributed raises a warning when detecting local IP address
+    ignore:Couldn't detect a suitable IP address:RuntimeWarning:distributed
 xfail_strict=true
 
 [metadata]


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Flying over to DC, I had the occasion to the run the test suite without the internet and think that a few more tests could benefit from the `@pytest.mark.network` decorator.
