### PR TITLE
xfail/skip some flaky distributed tests

### DIFF
--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -31,7 +31,7 @@ if "should_check_state" in get_named_args(gen_cluster):
 # distributed codebase and is nested within other fixtures we use, it's hard to
 # patch it from the dask codebase. And since the error is during fixture
 # teardown, an xfail won't cut it. As a hack, for now we skip all these tests
-# on windows.
+# on windows. See https://github.com/dask/dask/issues/8877.
 pytestmark = pytest.mark.skipif(
     sys.platform == "win32",
     reason=(
@@ -360,7 +360,8 @@ def test_blockwise_dataframe_io(c, tmpdir, io, fuse, from_futures):
     dd = pytest.importorskip("dask.dataframe")
 
     # TODO: this configuration is flaky on osx in CI
-    if from_futures is True and fuse is False and sys.platform == "darwin":
+    # See https://github.com/dask/dask/issues/8816
+    if from_futures and sys.platform == "darwin":
         pytest.xfail("This test sometimes fails on osx in CI")
 
     df = pd.DataFrame({"x": [1, 2, 3] * 5, "y": range(15)})

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -4,6 +4,7 @@ distributed = pytest.importorskip("distributed")
 
 import asyncio
 import os
+import sys
 from functools import partial
 from operator import add
 
@@ -23,6 +24,21 @@ from dask.utils import get_named_args, tmpdir, tmpfile
 if "should_check_state" in get_named_args(gen_cluster):
     gen_cluster = partial(gen_cluster, should_check_state=False)
     cluster = partial(cluster, should_check_state=False)
+
+
+# TODO: the fixture teardown for `cluster_fixture` is failing periodically with
+# a PermissionError on windows only (in CI). Since this fixture lives in the
+# distributed codebase and is nested within other fixtures we use, it's hard to
+# patch it from the dask codebase. And since the error is during fixture
+# teardown, an xfail won't cut it. As a hack, for now we skip all these tests
+# on windows.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "The teardown of distributed.utils_test.cluster_fixture "
+        "fails on windows CI currently"
+    ),
+)
 
 
 def test_can_import_client():
@@ -342,6 +358,10 @@ def test_blockwise_array_creation(c, io, fuse):
 def test_blockwise_dataframe_io(c, tmpdir, io, fuse, from_futures):
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
+
+    # TODO: this configuration is flaky on osx in CI
+    if from_futures is True and fuse is False and sys.platform == "darwin":
+        pytest.xfail("This test sometimes fails on osx in CI")
 
     df = pd.DataFrame({"x": [1, 2, 3] * 5, "y": range(15)})
 


### PR DESCRIPTION
- xfail `test_blockwise_dataframe_io` on osx for hdf5
- skip all distributed tests on windows (the failure is due to a fixture
cleanup error that lives in `distributed.utils_test`. This isn't easy to
patch around, and `xfail` won't cut it).

Both of these should *not* be long term solutions, but will (hopefully)
get our CI green again.