### PR TITLE
`from_dask_array` uses `blockwise` instead of merging graphs

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -35,7 +35,7 @@ class BlockwiseDep:
     ``Blockwise`` layer.
 
     All ``BlockwiseDep`` instances must define a ``numblocks``
-    attribute to speficy the number of blocks/partitions the
+    attribute to specify the number of blocks/partitions the
     object can support along each dimension. The object should
     also define a ``produces_tasks`` attribute to specify if
     any nested tasks will be passed to the Blockwise function.
@@ -129,7 +129,7 @@ class BlockwiseDepDict(BlockwiseDep):
     ...     }
     ... )
 
-    Construct a Blockwise Layer with ``dep`` speficied
+    Construct a Blockwise Layer with ``dep`` specified
     in the ``indices`` list:
 
     >>> layer = Blockwise(

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -407,7 +407,7 @@ def dataframe_from_ctable(x, slc, columns=None, categories=None, lock=lock):
     return result
 
 
-def _partition_from_array(data, index=None, **kwargs):
+def _partition_from_array(data, index=None, initializer=None, **kwargs):
     """Create a Dask partition for either a DataFrame or Series.
 
     Designed to be used with :func:`dask.blockwise.blockwise`. ``data`` is the array
@@ -417,14 +417,13 @@ def _partition_from_array(data, index=None, **kwargs):
     2. a `tuple` with two elements, the start and stop values for a RangeIndex for
        this partition, which gives a continuously varying RangeIndex over the
        whole Dask DataFrame
-    3. or an instance of a :class:`dask.dataframe.Index`.
+    3. an instance of a ``pandas.Index`` or a subclass thereof
 
     The ``kwargs`` _must_ contain an ``initializer`` key which is set by calling
     ``type(meta)``.
     """
     if isinstance(index, tuple):
         index = pd.RangeIndex(*index)
-    initializer = kwargs.pop("initializer")
     return initializer(data, index=index, **kwargs)
 
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 from math import ceil
 from operator import getitem

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -465,8 +465,6 @@ def from_dask_array(x, columns=None, index=None, meta=None):
         kwargs = {"columns": meta.columns}
 
     if index is not None:
-        if not isinstance(index, Index):
-            raise ValueError("'index' must be an instance of dask.dataframe.Index")
         if index.npartitions != x.numblocks[0]:
             msg = (
                 "The index and array have different numbers of blocks. "

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -371,10 +371,12 @@ def test_DataFrame_from_dask_array_with_blockwise_ops():
     x *= 2
     pdf = pd.DataFrame(np.ones((10, 3)) * 2, columns=["a", "b", "c"])
     df = dd.from_dask_array(x, ["a", "b", "c"])
-    # The last layer is the conversion to DataFrame
-    assert not hlg_layer_topological(df.dask, -1).is_materialized()
-    # The second to last layer is the multiplication, which should still be blockwise
-    assert not hlg_layer_topological(df.dask, -2).is_materialized()
+    # None of the layers in this graph should be materialized, everything should
+    # be a HighLevelGraph still.
+    assert all(
+        not hlg_layer_topological(df.dask, i).is_materialized()
+        for i in range(len(df.dask.layers))
+    )
     assert_eq(df, pdf)
 
 

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -355,15 +355,15 @@ def test_from_pandas_with_datetime_index():
 
 def test_DataFrame_from_dask_array():
     x = da.ones((10, 3), chunks=(4, 2))
-
+    pdf = pd.DataFrame(np.ones((10, 3)), columns=["a", "b", "c"])
     df = dd.from_dask_array(x, ["a", "b", "c"])
-    assert isinstance(df, dd.DataFrame)
-    tm.assert_index_equal(df.columns, pd.Index(["a", "b", "c"]))
-    assert list(df.divisions) == [0, 4, 8, 9]
-    assert (df.compute(scheduler="sync").values == x.compute(scheduler="sync")).all()
+    assert not hlg_layer_topological(df.dask, -1).is_materialized()
+    assert_eq(df, pdf)
 
     # dd.from_array should re-route to from_dask_array
     df2 = dd.from_array(x, columns=["a", "b", "c"])
+    assert not hlg_layer_topological(df2.dask, -1).is_materialized()
+    assert_eq(df, df2)
 
 
 def test_DataFrame_from_dask_array_with_blockwise_ops():
@@ -380,20 +380,18 @@ def test_DataFrame_from_dask_array_with_blockwise_ops():
 
 def test_Series_from_dask_array():
     x = da.ones(10, chunks=4)
+    pser = pd.Series(np.ones(10), name="a")
 
     ser = dd.from_dask_array(x, "a")
-    assert isinstance(ser, dd.Series)
-    assert ser.name == "a"
-    assert list(ser.divisions) == [0, 4, 8, 9]
-    assert (ser.compute(scheduler="sync").values == x.compute(scheduler="sync")).all()
+    assert_eq(ser, pser)
 
+    # Not passing a name should result in the name == None
+    pser = pd.Series(np.ones(10))
     ser = dd.from_dask_array(x)
-    assert isinstance(ser, dd.Series)
-    assert ser.name is None
+    assert_eq(ser, pser)
 
     # dd.from_array should re-route to from_dask_array
     ser2 = dd.from_array(x)
-    assert isinstance(ser2, dd.Series)
     assert_eq(ser, ser2)
 
 
@@ -408,91 +406,91 @@ def test_from_dask_array_index(as_frame):
 
 def test_from_dask_array_index_raises():
     x = da.random.uniform(size=(10,), chunks=(5,))
-    with pytest.raises(ValueError) as m:
+    with pytest.raises(ValueError, match="must be an instance"):
         dd.from_dask_array(x, index=pd.Index(np.arange(10)))
-    assert m.match("must be an instance")
 
     a = dd.from_pandas(pd.Series(range(12)), npartitions=2)
     b = dd.from_pandas(pd.Series(range(12)), npartitions=4)
-    with pytest.raises(ValueError) as m:
+    with pytest.raises(ValueError, match=".*index.*numbers of blocks.*4 != 2"):
         dd.from_dask_array(a.values, index=b.index)
 
-    assert m.match("index")
-    assert m.match("number")
-    assert m.match("blocks")
-    assert m.match("4 != 2")
+
+def test_from_array_raises_more_than_2D():
+    x = da.ones((3, 3, 3), chunks=2)
+    y = np.ones((3, 3, 3))
+
+    with pytest.raises(ValueError, match="more than 2D array"):
+        dd.from_dask_array(x)  # dask
+
+    with pytest.raises(ValueError, match="more than 2D array"):
+        dd.from_array(y)  # numpy
 
 
 def test_from_dask_array_compat_numpy_array():
-    x = da.ones((3, 3, 3), chunks=2)
-
-    with pytest.raises(ValueError):
-        dd.from_dask_array(x)  # dask
-
-    with pytest.raises(ValueError):
-        dd.from_array(x.compute())  # numpy
-
     x = da.ones((10, 3), chunks=(3, 3))
+    y = np.ones((10, 3))
     d1 = dd.from_dask_array(x)  # dask
-    assert isinstance(d1, dd.DataFrame)
-    assert (d1.compute().values == x.compute()).all()
-    tm.assert_index_equal(d1.columns, pd.Index([0, 1, 2]))
+    p1 = pd.DataFrame(y)
+    assert_eq(d1, p1)
 
-    d2 = dd.from_array(x.compute())  # numpy
-    assert isinstance(d1, dd.DataFrame)
-    assert (d2.compute().values == x.compute()).all()
-    tm.assert_index_equal(d2.columns, pd.Index([0, 1, 2]))
+    d2 = dd.from_array(y)  # numpy
+    assert_eq(d2, d1)
 
-    with pytest.raises(ValueError):
+
+def test_from_array_wrong_column_shape_error():
+    x = da.ones((10, 3), chunks=(3, 3))
+    with pytest.raises(ValueError, match="names must match width"):
         dd.from_dask_array(x, columns=["a"])  # dask
 
-    with pytest.raises(ValueError):
-        dd.from_array(x.compute(), columns=["a"])  # numpy
+    y = np.ones((10, 3))
+    with pytest.raises(ValueError, match="names must match width"):
+        dd.from_array(y, columns=["a"])  # numpy
 
+
+def test_from_array_with_column_names():
+    x = da.ones((10, 3), chunks=(3, 3))
+    y = np.ones((10, 3))
     d1 = dd.from_dask_array(x, columns=["a", "b", "c"])  # dask
-    assert isinstance(d1, dd.DataFrame)
-    assert (d1.compute().values == x.compute()).all()
-    tm.assert_index_equal(d1.columns, pd.Index(["a", "b", "c"]))
+    p1 = pd.DataFrame(y, columns=["a", "b", "c"])
+    assert_eq(d1, p1)
 
-    d2 = dd.from_array(x.compute(), columns=["a", "b", "c"])  # numpy
-    assert isinstance(d1, dd.DataFrame)
-    assert (d2.compute().values == x.compute()).all()
-    tm.assert_index_equal(d2.columns, pd.Index(["a", "b", "c"]))
+    d2 = dd.from_array(y, columns=["a", "b", "c"])  # numpy
+    assert_eq(d1, d2)
 
 
 def test_from_dask_array_compat_numpy_array_1d():
 
     x = da.ones(10, chunks=3)
+    y = np.ones(10)
     d1 = dd.from_dask_array(x)  # dask
-    assert isinstance(d1, dd.Series)
-    assert (d1.compute().values == x.compute()).all()
-    assert d1.name is None
+    p1 = pd.Series(y)
+    assert_eq(d1, p1)
 
-    d2 = dd.from_array(x.compute())  # numpy
-    assert isinstance(d1, dd.Series)
-    assert (d2.compute().values == x.compute()).all()
-    assert d2.name is None
+    d2 = dd.from_array(y)  # numpy
+    assert_eq(d2, d1)
 
+
+def test_from_array_1d_with_column_names():
+    x = da.ones(10, chunks=3)
+    y = np.ones(10)
     d1 = dd.from_dask_array(x, columns="name")  # dask
-    assert isinstance(d1, dd.Series)
-    assert (d1.compute().values == x.compute()).all()
-    assert d1.name == "name"
+    p1 = pd.Series(y, name="name")
+    assert_eq(d1, p1)
 
     d2 = dd.from_array(x.compute(), columns="name")  # numpy
-    assert isinstance(d1, dd.Series)
-    assert (d2.compute().values == x.compute()).all()
-    assert d2.name == "name"
+    assert_eq(d2, d1)
 
+
+def test_from_array_1d_list_of_columns_gives_dataframe():
+    x = da.ones(10, chunks=3)
+    y = np.ones(10)
     # passing list via columns results in DataFrame
     d1 = dd.from_dask_array(x, columns=["name"])  # dask
-    assert isinstance(d1, dd.DataFrame)
-    assert (d1.compute().values == x.compute()).all()
-    tm.assert_index_equal(d1.columns, pd.Index(["name"]))
+    p1 = pd.DataFrame(y, columns=["name"])
+    assert_eq(d1, p1)
 
-    d2 = dd.from_array(x.compute(), columns=["name"])  # numpy
-    assert isinstance(d1, dd.DataFrame)
-    assert (d2.compute().values == x.compute()).all()
-    tm.assert_index_equal(d2.columns, pd.Index(["name"]))
+    d2 = dd.from_array(y, columns=["name"])  # numpy
+    assert_eq(d2, d1)
 
 
 def test_from_dask_array_struct_dtype():
@@ -528,10 +526,12 @@ def test_from_dask_array_unknown_chunks():
     assert not df.known_divisions
     assert_eq(df, pd.DataFrame(dx.compute()), check_index=False)
 
-    # Unknown width
+
+def test_from_dask_array_unknown_width_error():
+    dsk = {("x", 0, 0): np.random.random((2, 3)), ("x", 1, 0): np.random.random((5, 3))}
     dx = da.Array(dsk, "x", ((np.nan, np.nan), (np.nan,)), np.float64)
-    with pytest.raises(ValueError):
-        df = dd.from_dask_array(dx)
+    with pytest.raises(ValueError, match="Shape along axis 1 must be known"):
+        dd.from_dask_array(dx)
 
 
 def test_to_bag():


### PR DESCRIPTION
- [x] Closes #8496 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This change uses `dask.blockwise` to generate the high-level graph for `dask.dataframe.from_dask_array`. If no index is given and the chunks are known, the graph to generate an index is still created directly. I don't see a way around this, but suggestions are very welcome! cc @ian-r-rose @gjoseph92 @rjzamora 