### PR TITLE
Fix gpuCI GHA version

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -45,7 +45,7 @@ jobs:
           echo NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-10} >> $GITHUB_ENV
 
       - name: Update RAPIDS version
-        uses: jacobtomlinson/gha-find-replace@2
+        uses: jacobtomlinson/gha-find-replace@v2
         with:
           include: 'continuous_integration\/gpuci\/axis\.yaml'
           find: "${{ env.RAPIDS_VER }}"


### PR DESCRIPTION
We erroneously set `gha-find-replace` to version `2` instead of `v2` - this should resolve the failures caused by that.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
