### PR TITLE
Don't test `da.prod` on large integer data

### DIFF
--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -194,7 +194,9 @@ def test_reductions_2D(dtype):
     assert b.__dask_keys__() == [[(b.name, 0, 0)]]
 
     reduction_2d_test(da.sum, a, np.sum, x)
-    reduction_2d_test(da.prod, a, np.prod, x)
+    if x.dtype.kind != "i":
+        # prod overflows integers at this size
+        reduction_2d_test(da.prod, a, np.prod, x)
     reduction_2d_test(da.mean, a, np.mean, x)
     reduction_2d_test(da.var, a, np.var, x, False)  # Difference in dtype algo
     reduction_2d_test(da.std, a, np.std, x, False)  # Difference in dtype algo
@@ -204,7 +206,9 @@ def test_reductions_2D(dtype):
     reduction_2d_test(da.all, a, np.all, x, False)
 
     reduction_2d_test(da.nansum, a, np.nansum, x)
-    reduction_2d_test(da.nanprod, a, np.nanprod, x)
+    if x.dtype.kind != "i":
+        # prod overflows integers at this size
+        reduction_2d_test(da.nanprod, a, np.nanprod, x)
     reduction_2d_test(da.nanmean, a, np.mean, x)
     reduction_2d_test(da.nanvar, a, np.nanvar, x, False)  # Difference in dtype algo
     reduction_2d_test(da.nanstd, a, np.nanstd, x, False)  # Difference in dtype algo


### PR DESCRIPTION
Not sure why this test only periodically fails (perhaps something numpy internal?), but in retrospect this was never a good test. `np.arange(1, 122).prod()` will overflow for all integer data - in this case `prod` overflows enough to hit 0 at `np.arange(1, 67).prod()`, meaning any larger values will also go to zero. It's not a good test.

Since the large array is mainly used to validate the reduction code (tree reductions, chunk/combine/aggregate), skipping testing prod on integral data seems fine to me. Should hopefully fix the flakiness of this test on windows CI.