### PR TITLE
masked scalars input to `da.from_array`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3303,7 +3303,7 @@ def from_array(
     if lock is True:
         lock = SerializableLock()
 
-    is_ndarray = type(x) is np.ndarray
+    is_ndarray = type(x) in (np.ndarray, np.ma.core.MaskedArray)
     is_single_block = all(len(c) == 1 for c in chunks)
     # Always use the getter for h5py etc. Not using isinstance(x, np.ndarray)
     # because np.matrix is a subclass of np.ndarray.

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2572,13 +2572,23 @@ def test_from_array_tasks_always_call_getter(x, chunks, inline_array):
     assert_eq(x, dx)
 
 
-def test_from_array_ndarray_onechunk():
+@pytest.mark.parametrize(
+    "x",
+    [
+        np.array([[1, 2], [3, 4]]),
+        np.ma.array([[1, 2], [3, 4]], mask=[[True, False], [False, False]]),
+        np.ma.array([1], mask=[True]),
+        np.ma.array([1.5], mask=[True]),
+        np.ma.array(1, mask=True),
+        np.ma.array(1.5, mask=True),
+    ],
+)
+def test_from_array_ndarray_onechunk(x):
     """ndarray with a single chunk produces a minimal single key dict"""
-    x = np.array([[1, 2], [3, 4]])
     dx = da.from_array(x, chunks=-1)
     assert_eq(x, dx)
     assert len(dx.dask) == 1
-    assert dx.dask[dx.name, 0, 0] is x
+    assert dx.dask[(dx.name,) + (0,) * dx.ndim] is x
 
 
 def test_from_array_ndarray_getitem():

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -88,6 +88,8 @@ def meta_from_array(x, ndim=None, dtype=None):
                 meta = meta.sum()
             else:
                 meta = meta.reshape((0,) * ndim)
+        if meta is np.ma.masked:
+            meta = np.ma.array(np.empty((0,) * ndim, dtype=dtype or x.dtype), mask=True)
     except Exception:
         meta = np.empty((0,) * ndim, dtype=dtype or x.dtype)
 
@@ -171,7 +173,10 @@ def allclose(a, b, equal_nan=False, **kwargs):
     a = normalize_to_array(a)
     b = normalize_to_array(b)
     if getattr(a, "dtype", None) != "O":
-        return np.allclose(a, b, equal_nan=equal_nan, **kwargs)
+        if hasattr(a, "mask") or hasattr(b, "mask"):
+            return np.ma.allclose(a, b, masked_equal=True, **kwargs)
+        else:
+            return np.allclose(a, b, equal_nan=equal_nan, **kwargs)
     if equal_nan:
         return a.shape == b.shape and all(
             np.isnan(b) if np.isnan(a) else a == b for (a, b) in zip(a.flat, b.flat)


### PR DESCRIPTION
- [x] Closes #8866
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

The changes to `utils.allclose` (ensuring that masked arrays whose data are different under masked points are still all close) and  `utils.meta_from_array` (ensuring that meta has the correct type) were needed so that `utils.assert_eq` in the new tests passes for the size-1 masked arrays.