### PR TITLE
Let ``get_dummies`` use ``meta`` computation in ``map_partitions``

### DIFF
--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -147,21 +147,8 @@ def get_dummies(
         if not all(has_known_categories(data[c]) for c in columns):
             raise NotImplementedError(unknown_cat_msg)
 
-    # We explicitly create `meta` on `data._meta` (the empty version) to
-    # work around https://github.com/pandas-dev/pandas/issues/21993
     package_name = data._meta.__class__.__module__.split(".")[0]
     dummies = sys.modules[package_name].get_dummies
-    meta = dummies(
-        data._meta,
-        prefix=prefix,
-        prefix_sep=prefix_sep,
-        dummy_na=dummy_na,
-        columns=columns,
-        sparse=sparse,
-        drop_first=drop_first,
-        dtype=dtype,
-        **kwargs,
-    )
 
     return map_partitions(
         dummies,
@@ -172,7 +159,6 @@ def get_dummies(
         columns=columns,
         sparse=sparse,
         drop_first=drop_first,
-        meta=meta,
         dtype=dtype,
         **kwargs,
     )


### PR DESCRIPTION
- [x] Closes #8894
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Based on the note that I am deleting here, I suspect that this is no longer necessary. Let's see if the tests pass :crossed_fingers: 
