### PR TITLE
Add a docs page for dask & parquet

### DIFF
--- a/docs/source/dataframe-parquet.rst
+++ b/docs/source/dataframe-parquet.rst
@@ -4,9 +4,10 @@ Dask Dataframe and Parquet
 .. currentmodule:: dask.dataframe
 
 Parquet_ is a popular, columnar file format designed for efficient data storage
-and retrieval. Dask dataframe includes `read_parquet` and `to_parquet`
-functions/methods for reading and writing parquet files respectively. Here we
-document these methods, and provide some tips and best practices.
+and retrieval. Dask dataframe includes :func:`read_parquet` and
+:func:`to_parquet` functions/methods for reading and writing parquet files
+respectively. Here we document these methods, and provide some tips and best
+practices.
 
 Reading Parquet Files
 ---------------------
@@ -14,16 +15,16 @@ Reading Parquet Files
 .. autosummary::
     read_parquet
 
-Dask dataframe provides a `read_parquet` function for reading parquet files and
-datasets. Its first argument is one of:
+Dask dataframe provides a :func:`read_parquet` function for reading parquet
+files and datasets. Its first argument is one of:
 
 - A path to a single parquet file
 - A path to a directory of parquet files (files with ``.parquet`` or ``.parq`` extension)
 - A `glob string`_ expanding to one or more parquet file paths
 - A list of parquet file paths
 
-These paths can be local, or point to some remote filesystem (e.g. S3, HDFS,
-...) by prepending the path with a protocol.
+These paths can be local, or point to some remote filesystem (for example S3_
+or GCS_) by prepending the path with a protocol.
 
 .. code-block:: python
 
@@ -40,29 +41,33 @@ These paths can be local, or point to some remote filesystem (e.g. S3, HDFS,
 
 Note that for remote filesystems you many need to configure credentials. When
 possible we recommend handling these external to Dask through
-filesystem-specific configuration files/environment variables (e.g. the
-``~/.aws/config`` file for S3). Alternatively, you can pass configuration on to
-the fsspec_ backend through the ``storage_options`` kwarg:
+filesystem-specific configuration files/environment variables. For example, you
+may wish to store S3 credentials using `the standard AWS credentials file
+<https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#shared-credentials-file>`_.
+Alternatively, you can pass configuration on to the fsspec_ backend through the
+``storage_options`` keyword argument:
 
 .. code-block:: python
 
    >>> df = dd.read_parquet(
    ...      "s3://bucket-name/my/parquet/",
-   ...      storage_options={'anon': True}  # passed to `s3fs.S3FileSystem`
+   ...      storage_options={"anon": True}  # passed to `s3fs.S3FileSystem`
    ... )
 
-`read_parquet` has many configuration options affecting both behavior and
+For more information on connecting to remote data, see
+:doc:`how-to/connect-to-remote-data`.
+
+:func:`read_parquet` has many configuration options affecting both behavior and
 performance. Here we highlight a few common options.
 
 Engine
 ~~~~~~
 
-`read_parquet` supports two backend engines - ``fastparquet`` and ``pyarrow``.
-For historical reasons this defaults to ``fastparquet`` (if installed), and
-falls back to ``pyarrow``. We recommend using ``pyarrow`` when possible. This
-can be explicitly set by passing ``engine="pyarrow"``, but if ``fastparquet``
-is not installed this configuration is unnecessary since it will automatically
-fallback to ``pyarrow``.
+:func:`read_parquet` supports two backend engines - ``pyarrow`` and
+``fastparquet``.  For historical reasons this defaults to ``fastparquet`` if it
+is installed, and falls back to ``pyarrow`` otherwise. We recommend using
+``pyarrow`` when possible. This can be explicitly set by passing
+``engine="pyarrow"``.
 
 .. code-block:: python
 
@@ -74,22 +79,23 @@ fallback to ``pyarrow``.
 Metadata
 ~~~~~~~~
 
-When `read_parquet` is called, it first loads metadata about the file(s). This
-metadata may include:
+When :func:`read_parquet` is used to read *multiple files*, it first loads
+metadata about the files in the dataset. This metadata may include:
 
 - The dataset schema
-- How the dataset is partitioned into files (and those files into row-groups)
+- How the dataset is partitioned into files, and those files into row-groups
 
 Some parquet datasets include a ``_metadata`` file which aggregates per-file
 metadata into a single location. For small-to-medium sized datasets this *may*
-be useful - it makes accessing the row-group metadata possible without reading
-parts of *every* file in the dataset. Row-group metadata allows dask to split
-large files into smaller in-memory partitions, and merge many small files into
-larger partitions, possibly leading to higher performance.
+be useful because it makes accessing the row-group metadata possible without
+reading parts of *every* file in the dataset. Row-group metadata allows Dask to
+split large files into smaller in-memory partitions, and merge many small files
+into larger partitions, possibly leading to higher performance.
 
-However, for large datasets the ``_metadata`` file can be problematic - it may
-be too large for a single endpoint to parse! If this is true, you can disable
-loading the ``_metadata`` file by specifying ``ignore_metadata_file=True``.
+However, for large datasets the ``_metadata`` file can be problematic because
+it may be too large for a single endpoint to parse! If this is true, you can
+disable loading the ``_metadata`` file by specifying
+``ignore_metadata_file=True``.
 
 .. code-block:: python
 
@@ -98,26 +104,29 @@ loading the ``_metadata`` file by specifying ``ignore_metadata_file=True``.
    ...      ignore_metadata_file=True  # don't read the _metadata file
    ... )
 
-If no ``_metadata`` file is present, dask will load each parquet file
-individually as a partition in the larger dask dataframe (unless only a single
-file is specified). This is performant provided all files are of reasonable
-size (We recommend aiming for 10-250 MiB in-memory size per file once loaded
-into pandas). Too large files can lead to excessive memory usage on a single
-worker, while too small files can lead to poor performance as the overhead of
-dask dominates. If you need to read a parquet dataset composed of many large
-files (and lacking a ``_metadata`` file), you can pass
-``gather_statistics=True`` to have dask load the row-group metadata from all
-files in the dataset. Note that this can be *extremely* slow on some systems.
+If no ``_metadata`` file is present, Dask will load each parquet file
+individually as a partition in the Dask dataframe. This is performant provided
+all files are of reasonable size.
+
+We recommend aiming for 10-250 MiB in-memory size per file once loaded into
+pandas. Too large files can lead to excessive memory usage on a single worker,
+while too small files can lead to poor performance as the overhead of Dask
+dominates. If you need to read a parquet dataset composed of many large files
+and lacking a ``_metadata`` file, you can pass ``split_row_groups=True`` to
+have Dask partition your data by *row group* instead of by *file*. Note that
+this can be *extremely* slow in large datasets, as the a footer needs to be
+loaded from every file in the dataset.
 
 Column Selection
 ~~~~~~~~~~~~~~~~
 
 When loading parquet data, sometimes you don't need all the columns available
-in the dataset. In this case, you may want to specify the subset of columns you
-need via the ``columns`` kwarg. This is beneficial for two reasons:
+in the dataset. In this case, you likely want to specify the subset of columns
+you need via the ``columns`` keyword argument. This is beneficial for a few
+reasons:
 
-- It lets dask read less data from the backing filesystem, reducing IO costs
-- It lets dask load less data into memory, reducing memory usage
+- It lets Dask read less data from the backing filesystem, reducing IO costs
+- It lets Dask load less data into memory, reducing memory usage
 
 .. code-block:: python
 
@@ -134,12 +143,13 @@ Writing
     to_parquet
     DataFrame.to_parquet
 
-Dask dataframe provides a `to_parquet` function (as well as a method) for
-writing parquet files and datasets.
+Dask dataframe provides a :func:`to_parquet` function and method for writing
+parquet files and datasets.
 
 In its simplest usage, this takes a path to the directory in which to write the
-dataset. Just as with `read_parquet`, this path may be local, or point to some
-remote filesystem (e.g. S3, HDFS, ...) by prepending the path with a protocol.
+dataset. Just as with :func:`read_parquet`, this path may be local, or point to
+some remote filesystem (e.g. S3, GCS_, ...) by prepending the path with a
+protocol.
 
 .. code-block:: python
 
@@ -153,33 +163,35 @@ Note that for remote filesystems you many need to configure credentials. When
 possible we recommend handling these external to Dask through
 filesystem-specific configuration files/environment variables (e.g. the
 ``~/.aws/config`` file for S3). Alternatively, you can pass configuration on to
-the fsspec_ backend through the ``storage_options`` kwarg:
+the fsspec_ backend through the ``storage_options`` keyword argument:
 
 .. code-block:: python
 
    >>> df.to_parquet(
    ...     "s3://bucket-name/my/parquet/",
-   ...     storage_options={'anon': True}  # passed to `s3fs.S3FileSystem`
+   ...     storage_options={"anon": True}  # passed to `s3fs.S3FileSystem`
    ... )
 
-Dask will write one file per dask dataframe partition to this directory. To
+For more information on connecting to remote data, see
+:doc:`how-to/connect-to-remote-data`.
+
+Dask will write one file per Dask dataframe partition to this directory. To
 optimize access for downstream consumers, we recommend aiming for an in-memory
 size of 10-250 MiB per partition. This helps balance worker memory usage
-against dask overhead. You may find the `DataFrame.memory_usage_per_partition`
+against Dask overhead. You may find the `DataFrame.memory_usage_per_partition`
 method useful for determining if your data is partitioned optimally.
 
-`to_parquet` has many configuration options affecting both behavior and
+:func:`to_parquet` has many configuration options affecting both behavior and
 performance. Here we highlight a few common options.
 
 Engine
 ~~~~~~
 
-`to_parquet` supports two backend engines - ``fastparquet`` and ``pyarrow``.
-For historical reasons this defaults to ``fastparquet`` (if installed), and
-falls back to ``pyarrow``. We recommend using ``pyarrow`` when possible. This
-can be explicitly set by passing ``engine="pyarrow"``, but if ``fastparquet``
-is not installed this configuration is unnecessary since it will automatically
-fallback to ``pyarrow``.
+:func:`to_parquet` supports two backend engines - ``pyarrow`` and
+``fastparquet``.  For historical reasons this defaults to ``fastparquet`` if it
+is installed, and falls back to ``pyarrow`` otherwise. We recommend using
+``pyarrow`` when possible. This can be explicitly set by passing
+``engine="pyarrow"``.
 
 .. code-block:: python
 
@@ -191,10 +203,10 @@ fallback to ``pyarrow``.
 Metadata
 ~~~~~~~~
 
-By default dask will write a ``_metadata`` file aggregating row-group metadata
+By default Dask will write a ``_metadata`` file aggregating row-group metadata
 from all files together. While potentially useful when reading data later with
 Dask, for large datasets the generation of this file may result in excessive
-memory usage (and potentially killed dask workers). As such, we generally
+memory usage (and potentially killed Dask workers). As such, we generally
 recommend disabling creation of this file by passing in
 ``write_metadata_file=False``.
 
@@ -202,20 +214,20 @@ recommend disabling creation of this file by passing in
 
    >>> df.to_parquet(
    ...     "s3://bucket-name/my/parquet/",
-   ...     ignore_metadata_file=False  # disable writing the metadata file
+   ...     write_metadata_file=False  # disable writing the _metadata file
    ... )
 
 File Names
 ~~~~~~~~~~
 
-`to_parquet` will write one file per dask dataframe partition to the output
-directory. By default these files will have names like ``part.0.parquet``,
-``part.1.parquet``, etc. If you wish to alter this naming scheme, you can use
-the ``name_function`` keyword argument. This takes a function with the
-signature ``name_function(partition: int) -> str``, taking the partition index
-for each dask dataframe partition and returning a string to use as the
-filename. Note that names returned must sort in the same order as their
-partition indices.
+:func:`to_parquet` will write one file per Dask dataframe partition to the
+output directory. By default these files will have names like
+``part.0.parquet``, ``part.1.parquet``, etc. If you wish to alter this naming
+scheme, you can use the ``name_function`` keyword argument. This takes a
+function with the signature ``name_function(partition: int) -> str``, taking
+the partition index for each Dask dataframe partition and returning a string to
+use as the filename. Note that names returned must sort in the same order as
+their partition indices.
 
 .. code-block:: python
 
@@ -231,4 +243,4 @@ partition indices.
 .. _glob string: https://docs.python.org/3/library/glob.html
 .. _fsspec: https://filesystem-spec.readthedocs.io
 .. _s3: https://aws.amazon.com/s3/
-.. _hdfs: https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsDesign.html
+.. _gcs: https://cloud.google.com/storage

--- a/docs/source/dataframe-parquet.rst
+++ b/docs/source/dataframe-parquet.rst
@@ -42,8 +42,7 @@ or GCS_) by prepending the path with a protocol.
 Note that for remote filesystems you many need to configure credentials. When
 possible we recommend handling these external to Dask through
 filesystem-specific configuration files/environment variables. For example, you
-may wish to store S3 credentials using `the standard AWS credentials file
-<https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#shared-credentials-file>`_.
+may wish to store S3 credentials using the `AWS credentials file`_.
 Alternatively, you can pass configuration on to the fsspec_ backend through the
 ``storage_options`` keyword argument:
 
@@ -147,9 +146,8 @@ Dask dataframe provides a :func:`to_parquet` function and method for writing
 parquet files and datasets.
 
 In its simplest usage, this takes a path to the directory in which to write the
-dataset. Just as with :func:`read_parquet`, this path may be local, or point to
-some remote filesystem (e.g. S3, GCS_, ...) by prepending the path with a
-protocol.
+dataset. This path may be local, or point to some remote filesystem (for
+example S3_ or GCS_) by prepending the path with a protocol.
 
 .. code-block:: python
 
@@ -161,9 +159,10 @@ protocol.
 
 Note that for remote filesystems you many need to configure credentials. When
 possible we recommend handling these external to Dask through
-filesystem-specific configuration files/environment variables (e.g. the
-``~/.aws/config`` file for S3). Alternatively, you can pass configuration on to
-the fsspec_ backend through the ``storage_options`` keyword argument:
+filesystem-specific configuration files/environment variables For example, you
+may wish to store S3 credentials using the `AWS credentials file`_.
+Alternatively, you can pass configuration on to the fsspec_ backend through the
+``storage_options`` keyword argument:
 
 .. code-block:: python
 
@@ -178,8 +177,9 @@ For more information on connecting to remote data, see
 Dask will write one file per Dask dataframe partition to this directory. To
 optimize access for downstream consumers, we recommend aiming for an in-memory
 size of 10-250 MiB per partition. This helps balance worker memory usage
-against Dask overhead. You may find the `DataFrame.memory_usage_per_partition`
-method useful for determining if your data is partitioned optimally.
+against Dask overhead. You may find the
+:meth:`DataFrame.memory_usage_per_partition` method useful for determining if
+your data is partitioned optimally.
 
 :func:`to_parquet` has many configuration options affecting both behavior and
 performance. Here we highlight a few common options.
@@ -244,3 +244,4 @@ their partition indices.
 .. _fsspec: https://filesystem-spec.readthedocs.io
 .. _s3: https://aws.amazon.com/s3/
 .. _gcs: https://cloud.google.com/storage
+.. _AWS credentials file: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#shared-credentials-file>`_.

--- a/docs/source/dataframe-parquet.rst
+++ b/docs/source/dataframe-parquet.rst
@@ -15,8 +15,8 @@ Reading Parquet Files
 .. autosummary::
     read_parquet
 
-Dask dataframe provides a :func:`read_parquet` function for reading parquet
-files and datasets. Its first argument is one of:
+Dask dataframe provides a :func:`read_parquet` function for reading one or more
+parquet files. Its first argument is one of:
 
 - A path to a single parquet file
 - A path to a directory of parquet files (files with ``.parquet`` or ``.parq`` extension)
@@ -39,7 +39,7 @@ or GCS_) by prepending the path with a protocol.
     # Load a directory of parquet files from S3
     >>> df = dd.read_parquet("s3://bucket-name/my/parquet/")
 
-Note that for remote filesystems you many need to configure credentials. When
+Note that for remote filesystems you may need to configure credentials. When
 possible we recommend handling these external to Dask through
 filesystem-specific configuration files/environment variables. For example, you
 may wish to store S3 credentials using the `AWS credentials file`_.
@@ -143,7 +143,7 @@ Writing
     DataFrame.to_parquet
 
 Dask dataframe provides a :func:`to_parquet` function and method for writing
-parquet files and datasets.
+parquet files.
 
 In its simplest usage, this takes a path to the directory in which to write the
 dataset. This path may be local, or point to some remote filesystem (for
@@ -157,7 +157,7 @@ example S3_ or GCS_) by prepending the path with a protocol.
     # Write to S3
     >>> df.to_parquet("s3://bucket-name/my/parquet/")
 
-Note that for remote filesystems you many need to configure credentials. When
+Note that for remote filesystems you may need to configure credentials. When
 possible we recommend handling these external to Dask through
 filesystem-specific configuration files/environment variables For example, you
 may wish to store S3 credentials using the `AWS credentials file`_.

--- a/docs/source/dataframe-parquet.rst
+++ b/docs/source/dataframe-parquet.rst
@@ -1,0 +1,234 @@
+Dask Dataframe and Parquet
+==========================
+
+.. currentmodule:: dask.dataframe
+
+Parquet_ is a popular, columnar file format designed for efficient data storage
+and retrieval. Dask dataframe includes `read_parquet` and `to_parquet`
+functions/methods for reading and writing parquet files respectively. Here we
+document these methods, and provide some tips and best practices.
+
+Reading Parquet Files
+---------------------
+
+.. autosummary::
+    read_parquet
+
+Dask dataframe provides a `read_parquet` function for reading parquet files and
+datasets. Its first argument is one of:
+
+- A path to a single parquet file
+- A path to a directory of parquet files (files with ``.parquet`` or ``.parq`` extension)
+- A `glob string`_ expanding to one or more parquet file paths
+- A list of parquet file paths
+
+These paths can be local, or point to some remote filesystem (e.g. S3, HDFS,
+...) by prepending the path with a protocol.
+
+.. code-block:: python
+
+    >>> import dask.dataframe as dd
+
+    # Load a single local parquet file
+    >>> df = dd.read_parquet("path/to/mydata.parquet")
+
+    # Load a directory of local parquet files
+    >>> df = dd.read_parquet("path/to/my/parquet/")
+
+    # Load a directory of parquet files from S3
+    >>> df = dd.read_parquet("s3://bucket-name/my/parquet/")
+
+Note that for remote filesystems you many need to configure credentials. When
+possible we recommend handling these external to Dask through
+filesystem-specific configuration files/environment variables (e.g. the
+``~/.aws/config`` file for S3). Alternatively, you can pass configuration on to
+the fsspec_ backend through the ``storage_options`` kwarg:
+
+.. code-block:: python
+
+   >>> df = dd.read_parquet(
+   ...      "s3://bucket-name/my/parquet/",
+   ...      storage_options={'anon': True}  # passed to `s3fs.S3FileSystem`
+   ... )
+
+`read_parquet` has many configuration options affecting both behavior and
+performance. Here we highlight a few common options.
+
+Engine
+~~~~~~
+
+`read_parquet` supports two backend engines - ``fastparquet`` and ``pyarrow``.
+For historical reasons this defaults to ``fastparquet`` (if installed), and
+falls back to ``pyarrow``. We recommend using ``pyarrow`` when possible. This
+can be explicitly set by passing ``engine="pyarrow"``, but if ``fastparquet``
+is not installed this configuration is unnecessary since it will automatically
+fallback to ``pyarrow``.
+
+.. code-block:: python
+
+   >>> df = dd.read_parquet(
+   ...      "s3://bucket-name/my/parquet/",
+   ...      engine="pyarrow"  # explicitly specify the pyarrow engine
+   ... )
+
+Metadata
+~~~~~~~~
+
+When `read_parquet` is called, it first loads metadata about the file(s). This
+metadata may include:
+
+- The dataset schema
+- How the dataset is partitioned into files (and those files into row-groups)
+
+Some parquet datasets include a ``_metadata`` file which aggregates per-file
+metadata into a single location. For small-to-medium sized datasets this *may*
+be useful - it makes accessing the row-group metadata possible without reading
+parts of *every* file in the dataset. Row-group metadata allows dask to split
+large files into smaller in-memory partitions, and merge many small files into
+larger partitions, possibly leading to higher performance.
+
+However, for large datasets the ``_metadata`` file can be problematic - it may
+be too large for a single endpoint to parse! If this is true, you can disable
+loading the ``_metadata`` file by specifying ``ignore_metadata_file=True``.
+
+.. code-block:: python
+
+   >>> df = dd.read_parquet(
+   ...      "s3://bucket-name/my/parquet/",
+   ...      ignore_metadata_file=True  # don't read the _metadata file
+   ... )
+
+If no ``_metadata`` file is present, dask will load each parquet file
+individually as a partition in the larger dask dataframe (unless only a single
+file is specified). This is performant provided all files are of reasonable
+size (We recommend aiming for 10-250 MiB in-memory size per file once loaded
+into pandas). Too large files can lead to excessive memory usage on a single
+worker, while too small files can lead to poor performance as the overhead of
+dask dominates. If you need to read a parquet dataset composed of many large
+files (and lacking a ``_metadata`` file), you can pass
+``gather_statistics=True`` to have dask load the row-group metadata from all
+files in the dataset. Note that this can be *extremely* slow on some systems.
+
+Column Selection
+~~~~~~~~~~~~~~~~
+
+When loading parquet data, sometimes you don't need all the columns available
+in the dataset. In this case, you may want to specify the subset of columns you
+need via the ``columns`` kwarg. This is beneficial for two reasons:
+
+- It lets dask read less data from the backing filesystem, reducing IO costs
+- It lets dask load less data into memory, reducing memory usage
+
+.. code-block:: python
+
+    >>> dd.read_parquet(
+    ...     "s3://path/to/myparquet/",
+    ...     columns=["a", "b", "c"]  # Only read columns 'a', 'b', and 'c'
+    ... )
+
+
+Writing
+-------
+
+.. autosummary::
+    to_parquet
+    DataFrame.to_parquet
+
+Dask dataframe provides a `to_parquet` function (as well as a method) for
+writing parquet files and datasets.
+
+In its simplest usage, this takes a path to the directory in which to write the
+dataset. Just as with `read_parquet`, this path may be local, or point to some
+remote filesystem (e.g. S3, HDFS, ...) by prepending the path with a protocol.
+
+.. code-block:: python
+
+    # Write to a local directory
+    >>> df.to_parquet("path/to/my/parquet/")
+
+    # Write to S3
+    >>> df.to_parquet("s3://bucket-name/my/parquet/")
+
+Note that for remote filesystems you many need to configure credentials. When
+possible we recommend handling these external to Dask through
+filesystem-specific configuration files/environment variables (e.g. the
+``~/.aws/config`` file for S3). Alternatively, you can pass configuration on to
+the fsspec_ backend through the ``storage_options`` kwarg:
+
+.. code-block:: python
+
+   >>> df.to_parquet(
+   ...     "s3://bucket-name/my/parquet/",
+   ...     storage_options={'anon': True}  # passed to `s3fs.S3FileSystem`
+   ... )
+
+Dask will write one file per dask dataframe partition to this directory. To
+optimize access for downstream consumers, we recommend aiming for an in-memory
+size of 10-250 MiB per partition. This helps balance worker memory usage
+against dask overhead. You may find the `DataFrame.memory_usage_per_partition`
+method useful for determining if your data is partitioned optimally.
+
+`to_parquet` has many configuration options affecting both behavior and
+performance. Here we highlight a few common options.
+
+Engine
+~~~~~~
+
+`to_parquet` supports two backend engines - ``fastparquet`` and ``pyarrow``.
+For historical reasons this defaults to ``fastparquet`` (if installed), and
+falls back to ``pyarrow``. We recommend using ``pyarrow`` when possible. This
+can be explicitly set by passing ``engine="pyarrow"``, but if ``fastparquet``
+is not installed this configuration is unnecessary since it will automatically
+fallback to ``pyarrow``.
+
+.. code-block:: python
+
+   >>> df.to_parquet(
+   ...     "s3://bucket-name/my/parquet/",
+   ...     engine="pyarrow"  # explicitly specify the pyarrow engine
+   ... )
+
+Metadata
+~~~~~~~~
+
+By default dask will write a ``_metadata`` file aggregating row-group metadata
+from all files together. While potentially useful when reading data later with
+Dask, for large datasets the generation of this file may result in excessive
+memory usage (and potentially killed dask workers). As such, we generally
+recommend disabling creation of this file by passing in
+``write_metadata_file=False``.
+
+.. code-block:: python
+
+   >>> df.to_parquet(
+   ...     "s3://bucket-name/my/parquet/",
+   ...     ignore_metadata_file=False  # disable writing the metadata file
+   ... )
+
+File Names
+~~~~~~~~~~
+
+`to_parquet` will write one file per dask dataframe partition to the output
+directory. By default these files will have names like ``part.0.parquet``,
+``part.1.parquet``, etc. If you wish to alter this naming scheme, you can use
+the ``name_function`` keyword argument. This takes a function with the
+signature ``name_function(partition: int) -> str``, taking the partition index
+for each dask dataframe partition and returning a string to use as the
+filename. Note that names returned must sort in the same order as their
+partition indices.
+
+.. code-block:: python
+
+    >>> df.npartitions  # 3 partitions (0, 1, and 2)
+    3
+
+    >>> df.to_parquet("/path/to/output", name_function=lambda i: f"data-{i}.parquet")
+
+    >>> os.listdir("/path/to/parquet")
+    ["data-0.parquet", "data-1.parquet", "data-2.parquet"]
+
+.. _parquet: https://parquet.apache.org/
+.. _glob string: https://docs.python.org/3/library/glob.html
+.. _fsspec: https://filesystem-spec.readthedocs.io
+.. _s3: https://aws.amazon.com/s3/
+.. _hdfs: https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsDesign.html

--- a/docs/source/dataframe.rst
+++ b/docs/source/dataframe.rst
@@ -13,6 +13,7 @@ DataFrame
    dataframe-indexing.rst
    dataframe-categoricals.rst
    dataframe-extend.rst
+   dataframe-parquet.rst
    dataframe-sql.rst
 
 A Dask DataFrame is a large parallel DataFrame composed of many smaller Pandas


### PR DESCRIPTION
Adds a highlevel doc page for working with parquet and dask dataframe.
The goal here is to highlight some common options as well as some best
practices.