### PR TITLE
Fix custom getter in `da.from_array` when `inline_array=False`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -307,7 +307,7 @@ def graph_from_arraylike(
         layers = {}
         layers[original_name] = MaterializedLayer({original_name: arr})
         layers[name] = core_blockwise(
-            getter,
+            getitem,
             name,
             out_ind,
             original_name,


### PR DESCRIPTION
- [x] Closes #8902
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
