### PR TITLE
Updated reshape error output

### DIFF
--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -44,7 +44,11 @@ def reshape_rechunk(inshape, outshape, inchunks):
             ):  # 4 < 64, 4*4 < 64, 4*4*4 == 64
                 ileft -= 1
             if reduce(mul, inshape[ileft : ii + 1]) != dout:
-                raise ValueError("Shapes not compatible")
+                raise NotImplementedError("""Dask reshaping currently only supports collapsing/merging array dimensions. For example, reshaping a 6x2 dimensional array into a 12x1 array.
+       
+                In the interim, if this operation is required, utilise the Numpy version of reshape.
+
+                Also note that performance of this reshape implementation varies depending on how the input array is chunked. Please read the official Dask array documentation section for further details on how Dask implements Reshaping""")
 
             # Special case to avoid intermediate rechunking:
             # When all the lower axis are completely chunked (chunksize=1) then
@@ -74,7 +78,11 @@ def reshape_rechunk(inshape, outshape, inchunks):
             while oleft >= 0 and reduce(mul, outshape[oleft : oi + 1]) < din:
                 oleft -= 1
             if reduce(mul, outshape[oleft : oi + 1]) != din:
-                raise ValueError("Shapes not compatible")
+                raise NotImplementedError("""Dask reshaping currently only supports collapsing/merging array dimensions. For example, reshaping a 6x2 dimensional array into a 12x1 array.
+       
+                In the interim, if this operation is required, utilise the Numpy version of reshape.
+
+                Also note that performance of this reshape implementation varies depending on how the input array is chunked. Please read the official Dask array documentation section for further details on how Dask implements Reshaping""")
 
             # TODO: don't coalesce shapes unnecessarily
             cs = reduce(mul, outshape[oleft + 1 : oi + 1])


### PR DESCRIPTION
This is a fix for #8634 to provide more clarity on the limitations of Dask's reshape as well as convert it from a ValueError to a NotImplementedError to contextualise that functionality is still to be added here. Summary of changes

- Utilised docstrings to add more detail as per Dask development guidelines
- Added reference to using Numpy's reshape if the operation is still required
- Added reference to original documentation in the event there is a need to understand how Chunking approach can affect performance 