### PR TITLE
Avoid collecting parquet metadata in pyarrow when write_metadata_file=False

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -72,6 +72,7 @@ def _write_partitioned(
     pandas_to_arrow_table,
     preserve_index,
     index_cols=(),
+    return_metadata=True,
     **kwargs,
 ):
     """Write table to a partitioned dataset with pyarrow.
@@ -106,6 +107,7 @@ def _write_partitioned(
             subschema = subschema.remove(subschema.get_field_index(col))
 
     md_list = []
+    metadata_collector = {"metadata_collector": md_list} if return_metadata else {}
     for keys, subgroup in data_df.groupby(partition_keys):
         if not isinstance(keys, tuple):
             keys = (keys,)
@@ -119,8 +121,9 @@ def _write_partitioned(
         fs.mkdirs(prefix, exist_ok=True)
         full_path = fs.sep.join([prefix, filename])
         with fs.open(full_path, "wb") as f:
-            pq.write_table(subtable, f, metadata_collector=md_list, **kwargs)
-        md_list[-1].set_file_path(fs.sep.join([subdir, filename]))
+            pq.write_table(subtable, f, **metadata_collector, **kwargs)
+        if return_metadata:
+            md_list[-1].set_file_path(fs.sep.join([subdir, filename]))
 
     return md_list
 
@@ -680,6 +683,7 @@ class ArrowDatasetEngine(Engine):
                 preserve_index,
                 index_cols=index_cols,
                 compression=compression,
+                return_metadata=return_metadata,
                 **kwargs,
             )
             if md_list:
@@ -688,12 +692,15 @@ class ArrowDatasetEngine(Engine):
                     _append_row_groups(_meta, md_list[i])
         else:
             md_list = []
+            metadata_collector = (
+                {"metadata_collector": md_list} if return_metadata else {}
+            )
             with fs.open(fs.sep.join([path, filename]), "wb") as fil:
                 pq.write_table(
                     t,
                     fil,
                     compression=compression,
-                    metadata_collector=md_list,
+                    **metadata_collector,
                     **kwargs,
                 )
             if md_list:

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -824,6 +824,11 @@ def to_parquet(
             )
         }
     else:
+        # NOTE: We still define a single task to tie everything together
+        # when we are not writing a _metadata file. We do not want to
+        # return `data_write` (or a `data_write.to_bag()`), because calling
+        # `compute()` on a multi-partition collection requires the overhead
+        # of trying to concatenate results on the client.
         final_name = "store-" + data_write._name
         dsk = {(final_name, 0): (lambda x: None, data_write.__dask_keys__())}
 


### PR DESCRIPTION
This should address #7977 for the case that `write_metadata_file=False` ([which may become the default soon anyway](https://github.com/dask/dask/issues/8901)).  There *may* still be an upstream issue in pyarrow,  but this change should allow Dask users to avoid it.

cc @jcrist 
