### PR TITLE
Warn users that `engine='auto'` will change in future

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -357,7 +357,7 @@ def read_parquet(
         columns = list(columns)
 
     if isinstance(engine, str):
-        engine = get_engine(engine)
+        engine = get_engine(engine, bool(kwargs))
 
     if hasattr(path, "name"):
         path = stringify_path(path)
@@ -664,7 +664,7 @@ def to_parquet(
         )
 
     if isinstance(engine, str):
-        engine = get_engine(engine)
+        engine = get_engine(engine, bool(kwargs))
 
     if hasattr(path, "name"):
         path = stringify_path(path)
@@ -985,7 +985,9 @@ def create_metadata_file(
 _ENGINES: dict[str, Engine] = {}
 
 
-def get_engine(engine):
+# TODO: remove _warn_engine_default_changing once the default has changed to
+# pyarrow.
+def get_engine(engine, _warn_engine_default_changing=False):
     """Get the parquet engine backend implementation.
 
     Parameters
@@ -1007,12 +1009,12 @@ def get_engine(engine):
     if engine == "auto":
         try:
             engine = get_engine("fastparquet")
-            if importlib.util.find_spec("pyarrow"):
+            if _warn_engine_default_changing and importlib.util.find_spec("pyarrow"):
                 warnings.warn(
-                    "engine='auto' will switch to using `pyarrow` by default in "
-                    "a future version. To continue using `fastparquet` even if "
-                    "`pyarrow` is installed in the future please explicitly "
-                    "specify `engine='fastparquet'`.",
+                    "engine='auto' will switch to using pyarrow by default in "
+                    "a future version. To continue using fastparquet even if "
+                    "pyarrow is installed in the future please explicitly "
+                    "specify engine='fastparquet'.",
                     FutureWarning,
                 )
             return engine

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import math
 import warnings
 
@@ -232,12 +233,12 @@ def read_parquet(
         ``"precache_options"`` key. Also, a custom file-open function can be
         used (instead of ``AbstractFileSystem.open``), by specifying the
         desired function under the ``"open_file_func"`` key.
-    engine : str, default 'auto'
-        Parquet reader library to use. Options include: 'auto', 'fastparquet',
-        and 'pyarrow'. Defaults to 'auto', which selects FastParquetEngine
-        if fastparquet is installed (and ArrowDatasetEngine otherwise). If
-        'pyarrow' is specified, ArrowDatasetEngine (which leverages the
-        pyarrow.dataset API) will be used.
+    engine : {'auto', 'fastparquet', 'pyarrow'}, default 'auto'
+        Parquet library to use. Options include: 'auto', 'fastparquet', and
+        'pyarrow'. Defaults to 'auto', which uses ``fastparquet`` if it is
+        installed, and falls back to ``pyarrow`` otherwise. Note that in the
+        future this default ordering for 'auto' will switch, with ``pyarrow``
+        being used if it is installed, and falling back to ``fastparquet``.
     gather_statistics : bool, default None
         Gather the statistics for each dataset partition. By default,
         this will only be done if the _metadata file is available. Otherwise,
@@ -547,8 +548,11 @@ def to_parquet(
         Destination directory for data.  Prepend with protocol like ``s3://``
         or ``hdfs://`` for remote data.
     engine : {'auto', 'fastparquet', 'pyarrow'}, default 'auto'
-        Parquet library to use. If only one library is installed, it will use
-        that one; if both, it will use 'fastparquet'.
+        Parquet library to use. Options include: 'auto', 'fastparquet', and
+        'pyarrow'. Defaults to 'auto', which uses ``fastparquet`` if it is
+        installed, and falls back to ``pyarrow`` otherwise. Note that in the
+        future this default ordering for 'auto' will switch, with ``pyarrow``
+        being used if it is installed, and falling back to ``fastparquet``.
     compression : string or dict, default 'snappy'
         Either a string like ``"snappy"`` or a dictionary mapping column names
         to compressors like ``{"name": "gzip", "values": "snappy"}``. Defaults
@@ -987,12 +991,11 @@ def get_engine(engine):
     Parameters
     ----------
     engine : str, default 'auto'
-        Backend parquet library to use. Options include: 'auto', 'fastparquet',
-        and 'pyarrow'. Defaults to 'auto', which selects the FastParquetEngine
-        if fastparquet is installed (and ArrowDatasetEngine otherwise).
-        If 'pyarrow' is specified, the ArrowDatasetEngine (which leverages the
-        pyarrow.dataset API) will be used.
-    gather_statistics : bool or None (default).
+        Parquet library to use. Options include: 'auto', 'fastparquet', and
+        'pyarrow'. Defaults to 'auto', which uses ``fastparquet`` if it is
+        installed, and falls back to ``pyarrow`` otherwise. Note that in the
+        future this default ordering for 'auto' will switch, with ``pyarrow``
+        being used if it is installed, and falling back to ``fastparquet``.
 
     Returns
     -------
@@ -1002,13 +1005,24 @@ def get_engine(engine):
         return _ENGINES[engine]
 
     if engine == "auto":
-        for eng in ["fastparquet", "pyarrow"]:
-            try:
-                return get_engine(eng)
-            except RuntimeError:
-                pass
-        else:
-            raise RuntimeError("Please install either fastparquet or pyarrow")
+        try:
+            engine = get_engine("fastparquet")
+            if importlib.util.find_spec("pyarrow"):
+                warnings.warn(
+                    "engine='auto' will switch to using `pyarrow` by default in "
+                    "a future version. To continue using `fastparquet` even if "
+                    "`pyarrow` is installed in the future please explicitly "
+                    "specify `engine='fastparquet'`.",
+                    FutureWarning,
+                )
+            return engine
+        except RuntimeError:
+            pass
+
+        try:
+            return get_engine("pyarrow")
+        except RuntimeError:
+            raise RuntimeError("Please install either fastparquet or pyarrow") from None
 
     elif engine == "fastparquet":
         import_required("fastparquet", "`fastparquet` not installed")
@@ -1018,7 +1032,6 @@ def get_engine(engine):
         return eng
 
     elif engine in ("pyarrow", "arrow", "pyarrow-dataset"):
-
         pa = import_required("pyarrow", "`pyarrow` not installed")
         pa_version = parse_version(pa.__version__)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -15,6 +15,7 @@ import dask.dataframe as dd
 import dask.multiprocessing
 from dask.blockwise import Blockwise, optimize_blockwise
 from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_121, PANDAS_GT_130
+from dask.dataframe.io.parquet.core import get_engine
 from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.dataframe.optimize import optimize_dataframe_getitem
 from dask.dataframe.utils import assert_eq
@@ -59,12 +60,6 @@ else:
     SKIP_PYARROW = not pq
     SKIP_PYARROW_REASON = "pyarrow not found"
 PYARROW_MARK = pytest.mark.skipif(SKIP_PYARROW, reason=SKIP_PYARROW_REASON)
-
-ANY_ENGINE_MARK = pytest.mark.skipif(
-    SKIP_FASTPARQUET and SKIP_PYARROW,
-    reason="No parquet engine (fastparquet or pyarrow) found",
-)
-
 
 nrows = 40
 npartitions = 15
@@ -153,14 +148,28 @@ else:
 
 
 @PYARROW_MARK
-def test_pyarrow_getengine():
+def test_get_engine_pyarrow():
     from dask.dataframe.io.parquet.arrow import ArrowDatasetEngine
-    from dask.dataframe.io.parquet.core import get_engine
 
-    # Check that the default engine for "pyarrow"/"arrow"
-    # is the `pyarrow.dataset`-based engine
     assert get_engine("pyarrow") == ArrowDatasetEngine
     assert get_engine("arrow") == ArrowDatasetEngine
+
+
+@FASTPARQUET_MARK
+def test_get_engine_fastparquet():
+    from dask.dataframe.io.parquet.fastparquet import FastParquetEngine
+
+    assert get_engine("fastparquet") == FastParquetEngine
+
+
+@PYARROW_MARK
+@FASTPARQUET_MARK
+def test_get_engine_auto_warning_if_both_installed():
+    from dask.dataframe.io.parquet.fastparquet import FastParquetEngine
+
+    with pytest.warns(FutureWarning, match="engine='auto' will switch"):
+        engine = get_engine("auto")
+        assert engine == FastParquetEngine
 
 
 @write_read_engines()
@@ -1041,15 +1050,15 @@ def test_timestamp_index(tmpdir, engine):
     assert_eq(ddf, ddf2)
 
 
-@FASTPARQUET_MARK
 @PYARROW_MARK
-def test_to_parquet_default_writes_nulls(tmpdir):
+@FASTPARQUET_MARK
+def test_to_parquet_fastparquet_default_writes_nulls(tmpdir):
     fn = str(tmpdir.join("test.parquet"))
 
     df = pd.DataFrame({"c1": [1.0, np.nan, 2, np.nan, 3]})
     ddf = dd.from_pandas(df, npartitions=1)
 
-    ddf.to_parquet(fn)
+    ddf.to_parquet(fn, engine="fastparquet")
     table = pq.read_table(fn)
     assert table[1].null_count == 2
 
@@ -1580,10 +1589,10 @@ def test_timestamp96(tmpdir):
     fn = str(tmpdir)
     df = pd.DataFrame({"a": [pd.to_datetime("now", utc=True)]})
     ddf = dd.from_pandas(df, 1)
-    ddf.to_parquet(fn, write_index=False, times="int96")
+    ddf.to_parquet(fn, engine="fastparquet", write_index=False, times="int96")
     pf = fastparquet.ParquetFile(fn)
     assert pf._schema[1].type == fastparquet.parquet_thrift.Type.INT96
-    out = dd.read_parquet(fn, index=False).compute()
+    out = dd.read_parquet(fn, engine="fastparquet", index=False).compute()
     assert_eq(out, df)
 
 
@@ -1603,7 +1612,7 @@ def test_drill_scheme(tmpdir):
     fastparquet.write(files[0], df1)
     fastparquet.write(files[1], df2)
 
-    df = dd.read_parquet(files)
+    df = dd.read_parquet(files, engine="fastparquet")
     assert "dir0" in df.columns
     out = df.compute()
     assert "dir0" in out
@@ -2020,8 +2029,7 @@ def test_writing_parquet_with_unknown_kwargs(tmpdir, engine):
         ddf.to_parquet(fn, engine=engine, unknown_key="unknown_value")
 
 
-@ANY_ENGINE_MARK
-def test_to_parquet_with_get(tmpdir):
+def test_to_parquet_with_get(tmpdir, engine):
     from dask.multiprocessing import get as mp_get
 
     tmpdir = str(tmpdir)
@@ -2035,10 +2043,10 @@ def test_to_parquet_with_get(tmpdir):
     df = pd.DataFrame({"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)
 
-    ddf.to_parquet(tmpdir, compute_kwargs={"scheduler": my_get})
+    ddf.to_parquet(tmpdir, engine=engine, compute_kwargs={"scheduler": my_get})
     assert flag[0]
 
-    result = dd.read_parquet(os.path.join(tmpdir, "*"))
+    result = dd.read_parquet(os.path.join(tmpdir, "*"), engine=engine)
     assert_eq(result, df, check_index=False)
 
 
@@ -2416,14 +2424,13 @@ def test_layer_creation_info(tmpdir, engine):
     assert_eq(ddf1, ddf3)
 
 
-@ANY_ENGINE_MARK
-def test_blockwise_parquet_annotations(tmpdir):
+def test_blockwise_parquet_annotations(tmpdir, engine):
     df = pd.DataFrame({"a": np.arange(40, dtype=np.int32)})
     expect = dd.from_pandas(df, npartitions=2)
-    expect.to_parquet(str(tmpdir))
+    expect.to_parquet(str(tmpdir), engine=engine)
 
     with dask.annotate(foo="bar"):
-        ddf = dd.read_parquet(str(tmpdir))
+        ddf = dd.read_parquet(str(tmpdir), engine=engine)
 
     # `ddf` should now have ONE Blockwise layer
     layers = ddf.__dask_graph__().layers
@@ -2433,15 +2440,14 @@ def test_blockwise_parquet_annotations(tmpdir):
     assert layer.annotations == {"foo": "bar"}
 
 
-@ANY_ENGINE_MARK
-def test_optimize_blockwise_parquet(tmpdir):
+def test_optimize_blockwise_parquet(tmpdir, engine):
     size = 40
     npartitions = 2
     tmp = str(tmpdir)
     df = pd.DataFrame({"a": np.arange(size, dtype=np.int32)})
     expect = dd.from_pandas(df, npartitions=npartitions)
-    expect.to_parquet(tmp)
-    ddf = dd.read_parquet(tmp)
+    expect.to_parquet(tmp, engine=engine)
+    ddf = dd.read_parquet(tmp, engine=engine)
 
     # `ddf` should now have ONE Blockwise layer
     layers = ddf.__dask_graph__().layers
@@ -2614,29 +2620,27 @@ def test_split_row_groups_filter(tmpdir, engine):
     )
 
 
-@ANY_ENGINE_MARK
-def test_optimize_getitem_and_nonblockwise(tmpdir):
+def test_optimize_getitem_and_nonblockwise(tmpdir, engine):
     path = os.path.join(tmpdir, "path.parquet")
     df = pd.DataFrame(
         {"a": [3, 4, 2], "b": [1, 2, 4], "c": [5, 4, 2], "d": [1, 2, 3]},
         index=["a", "b", "c"],
     )
-    df.to_parquet(path)
+    df.to_parquet(path, engine=engine)
 
-    df2 = dd.read_parquet(path)
+    df2 = dd.read_parquet(path, engine=engine)
     df2[["a", "b"]].rolling(3).max().compute()
 
 
-@ANY_ENGINE_MARK
-def test_optimize_and_not(tmpdir):
+def test_optimize_and_not(tmpdir, engine):
     path = os.path.join(tmpdir, "path.parquet")
     df = pd.DataFrame(
         {"a": [3, 4, 2], "b": [1, 2, 4], "c": [5, 4, 2], "d": [1, 2, 3]},
         index=["a", "b", "c"],
     )
-    df.to_parquet(path)
+    df.to_parquet(path, engine=engine)
 
-    df2 = dd.read_parquet(path)
+    df2 = dd.read_parquet(path, engine=engine)
     df2a = df2["a"].groupby(df2["c"]).first().to_delayed()
     df2b = df2["b"].groupby(df2["c"]).first().to_delayed()
     df2c = df2[["a", "b"]].rolling(2).max().to_delayed()
@@ -3783,6 +3787,7 @@ def test_custom_filename_with_partition(tmpdir, engine):
     df = dd.from_pandas(pdf, npartitions=4)
     df.to_parquet(
         fn,
+        engine=engine,
         partition_on=["country"],
         name_function=lambda x: f"{x}-cool.parquet",
         write_index=False,

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -168,7 +168,7 @@ def test_get_engine_auto_warning_if_both_installed():
     from dask.dataframe.io.parquet.fastparquet import FastParquetEngine
 
     with pytest.warns(FutureWarning, match="engine='auto' will switch"):
-        engine = get_engine("auto")
+        engine = get_engine("auto", True)
         assert engine == FastParquetEngine
 
 


### PR DESCRIPTION
Adds a warning to `read_parquet` and `to_parquet` that the meaning of
`engine='auto'` will change in the future (switching to using `pyarrow`
if it is installed, and falling back to `fastparquet`). This warning is
only raised for users that have both libraries installed and have
`engine='auto'`. Users without both libraries installed or that already
specify an engine will not see this warning.

First part of #8900.
