### PR TITLE
Better error for failed wildcard path in `dd.read_csv()` (fixes #8878)

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -519,7 +519,7 @@ def read_pandas(
 
         # Check for at least one valid path
         if len(paths) == 0:
-            raise OSError("%s resolved to no files" % urlpath)
+            raise OSError(f"{urlpath} resolved to no files")
 
         # Infer compression from first path
         compression = infer_compression(paths[0])

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -517,6 +517,10 @@ def read_pandas(
             2
         ]
 
+        # Check for at least one valid path
+        if len(paths) == 0:
+            raise OSError("%s resolved to no files" % urlpath)
+
         # Infer compression from first path
         compression = infer_compression(paths[0])
 


### PR DESCRIPTION
Makes an empty wildcard path URL specification in `dd.read_csv(compression='infer')` fail with `OSError: [urlpath] resolved to no files` instead of `IndexError: list index out of range`

- [X] Closes #8878
- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`
