### PR TITLE
advised not to use `map_block()`'s `drop_axis` on chunked axes of an array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -624,6 +624,12 @@ def map_blocks(
 
     .. image:: /images/map_blocks_drop_axis.png
 
+    Due to memory-size-constraints, it is often not advisable to use ``drop_axis``
+    on an axis that is chunked.  In that case, it is better not to use
+    ``map_blocks`` but rather
+    ``dask.array.reduction(..., axis=dropped_axes, concatenate=False)`` which
+    maintains a leaner memory footprint while it drops any axis.
+
     Map_blocks aligns blocks by block positions without regard to shape. In the
     following example we have two arrays with the same number of blocks but
     with different shape and chunk sizes.


### PR DESCRIPTION
- [x] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc: @jsignell 

I forgot to add one important detail when describing `map_blocks()`'s `drop_axis` option in the docs.