### PR TITLE
Make sure ``da.roll`` works even if shape is 0

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1870,11 +1870,8 @@ def roll(array, shift, axis=None):
         raise ValueError("Must have the same number of shifts as axes.")
 
     for i, s in zip(axis, shift):
-        if result.shape[i] == 0:
-            s = 0
-        else:
-            s = -s
-            s %= result.shape[i]
+        shape = result.shape[i]
+        s = 0 if shape == 0 else -s % shape
 
         sl1 = result.ndim * [slice(None)]
         sl2 = result.ndim * [slice(None)]

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1870,8 +1870,11 @@ def roll(array, shift, axis=None):
         raise ValueError("Must have the same number of shifts as axes.")
 
     for i, s in zip(axis, shift):
-        s = -s
-        s %= result.shape[i]
+        if result.shape[i] == 0:
+            s = 0
+        else:
+            s = -s
+            s %= result.shape[i]
 
         sl1 = result.ndim * [slice(None)]
         sl2 = result.ndim * [slice(None)]

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1351,6 +1351,12 @@ def test_roll_always_results_in_a_new_array():
     assert y is not x
 
 
+def test_roll_works_even_if_shape_is_0():
+    expected = np.roll(np.zeros(0), 0)
+    actual = da.roll(da.zeros(0), 0)
+    assert_eq(expected, actual)
+
+
 @pytest.mark.parametrize("shape", [(10,), (5, 10), (5, 10, 10)])
 def test_shape_and_ndim(shape):
     x = da.random.random(shape)


### PR DESCRIPTION
- [x] Closes #8914
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
