### PR TITLE
Let arg reductions pass ``keepdims``

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2343,16 +2343,20 @@ class Array(DaskMethodsMixin):
         return max(self, axis=axis, keepdims=keepdims, split_every=split_every, out=out)
 
     @derived_from(np.ndarray)
-    def argmin(self, axis=None, split_every=None, out=None):
+    def argmin(self, axis=None, *, keepdims=False, split_every=None, out=None):
         from dask.array.reductions import argmin
 
-        return argmin(self, axis=axis, split_every=split_every, out=out)
+        return argmin(
+            self, axis=axis, keepdims=keepdims, split_every=split_every, out=out
+        )
 
     @derived_from(np.ndarray)
-    def argmax(self, axis=None, split_every=None, out=None):
+    def argmax(self, axis=None, *, keepdims=False, split_every=None, out=None):
         from dask.array.reductions import argmax
 
-        return argmax(self, axis=axis, split_every=split_every, out=out)
+        return argmax(
+            self, axis=axis, keepdims=keepdims, split_every=split_every, out=out
+        )
 
     @derived_from(np.ndarray)
     def sum(self, axis=None, dtype=None, keepdims=False, split_every=None, out=None):

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -10,6 +10,7 @@ import itertools
 
 import dask.array as da
 import dask.config as config
+from dask.array.numpy_compat import _numpy_122
 from dask.array.utils import assert_eq, same_keys
 from dask.core import get_deps
 
@@ -238,6 +239,8 @@ def test_arg_reductions(dfunc, func):
         assert_eq(dfunc(a, 0), func(x, 0))
         assert_eq(dfunc(a, 1), func(x, 1))
         assert_eq(dfunc(a, 2), func(x, 2))
+    if _numpy_122:
+        assert_eq(dfunc(a, keepdims=True), func(x, keepdims=True))
 
     pytest.raises(ValueError, lambda: dfunc(a, 3))
     pytest.raises(TypeError, lambda: dfunc(a, (0, 1)))


### PR DESCRIPTION
- [x] Closes #8916
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

As part of this work I moved off using a wrapper to construct these methods. I think the code is clearer this way, but please just let me know if you think this should be a more minimal change.