### PR TITLE
Add require_extension to top-level read_parquet kwargs with doc-string coverage

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -792,7 +792,7 @@ class ArrowDatasetEngine(Engine):
 
         # Set require_extension option
         require_extension = _dataset_kwargs.pop(
-            "require_extension", (".parq", ".parquet")
+            "require_extension", (".parq", ".parquet", ".pq")
         )
 
         # Case-dependent pyarrow.dataset creation

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -300,6 +300,10 @@ def read_parquet(
                 └── └── 04.parquet
 
         Note that the default behavior of ``aggregate_files`` is False.
+    require_extension: str or tuple(str), default (".parq", ".parquet", ".pq")
+        Required file extension for all parquet data files. Other file
+        extensions will be ignored. Note that ``require_extension=False``
+        will skip the file-extension check altogether.
     **kwargs: dict (of dicts)
         Passthrough key-word arguments for read backend.
         The top-level keys correspond to the appropriate operation type, and
@@ -330,6 +334,14 @@ def read_parquet(
             "`read_from_paths` is no longer supported and will be ignored.",
             FutureWarning,
         )
+
+    # We allow the user to pass a `require_extension` kwarg, but
+    # need to "move" it into the engine-specific "dataset" kwargs
+    # (since the engine handles path inspection)
+    if "require_extension" in kwargs:
+        if "dataset" not in kwargs:
+            kwargs["dataset"] = {}
+        kwargs["dataset"]["require_extension"] = kwargs.pop("require_extension")
 
     # Store initial function arguments
     input_kwargs = {

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -392,7 +392,7 @@ class FastParquetEngine(Engine):
         parts = []
         _metadata_exists = False
         require_extension = dataset_kwargs.pop(
-            "require_extension", (".parq", ".parquet")
+            "require_extension", (".parq", ".parquet", ".pq")
         )
         if len(paths) == 1 and fs.isdir(paths[0]):
 


### PR DESCRIPTION
This PR makes `require_extension` an explcit (and documented) key-word argument for `read_parquet`.

- [x] Closes #8491 (Doesn't address the `dataset_options` idea, but resolves to original issue)
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
