### PR TITLE
specify dtype when deciding division using np.linspace in read_sql_query

### DIFF
--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -156,7 +156,7 @@ def read_sql_query(
             divisions[0] = mini
             divisions[-1] = maxi
         elif dtype.kind in ["i", "u", "f"]:
-            divisions = np.linspace(mini, maxi, npartitions + 1).tolist()
+            divisions = np.linspace(mini, maxi, npartitions + 1, dtype=dtype).tolist()
         else:
             raise TypeError(
                 'Provided index column is of type "{}".  If divisions is not provided the '


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

The current logic on deciding the `divisions` in `dd.read_sql_query` will result in a `float` array by default, without any possible way of specifying the `dtype` that we want, that is generally bad when filtering on the usual `integer` index of a sql database. 

Fix:
Specifying the `dype` in `np.linspace` so that the `divisions` array will be the same `dtype` as the `limits` or the `index_col`.
