### PR TITLE
[EXPERIMENTAL] Add general from_dataset API to DataFrame

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -17,6 +17,7 @@ try:
         from_array,
         from_bcolz,
         from_dask_array,
+        from_dataset,
         from_delayed,
         from_pandas,
         read_csv,

--- a/dask/dataframe/io/__init__.py
+++ b/dask/dataframe/io/__init__.py
@@ -1,6 +1,6 @@
 from dask.dataframe.io import demo
 from dask.dataframe.io.csv import read_csv, read_fwf, read_table, to_csv
-from dask.dataframe.io.dataset import DatasetSource, from_dataset
+from dask.dataframe.io.dataset import from_dataset
 from dask.dataframe.io.hdf import read_hdf, to_hdf
 from dask.dataframe.io.io import (
     dataframe_from_ctable,

--- a/dask/dataframe/io/__init__.py
+++ b/dask/dataframe/io/__init__.py
@@ -1,5 +1,6 @@
 from dask.dataframe.io import demo
 from dask.dataframe.io.csv import read_csv, read_fwf, read_table, to_csv
+from dask.dataframe.io.dataset import from_dataset
 from dask.dataframe.io.hdf import read_hdf, to_hdf
 from dask.dataframe.io.io import (
     dataframe_from_ctable,

--- a/dask/dataframe/io/__init__.py
+++ b/dask/dataframe/io/__init__.py
@@ -1,6 +1,6 @@
 from dask.dataframe.io import demo
 from dask.dataframe.io.csv import read_csv, read_fwf, read_table, to_csv
-from dask.dataframe.io.dataset import from_dataset
+from dask.dataframe.io.dataset import DatasetSource, from_dataset
 from dask.dataframe.io.hdf import read_hdf, to_hdf
 from dask.dataframe.io.io import (
     dataframe_from_ctable,

--- a/dask/dataframe/io/dataset/__init__.py
+++ b/dask/dataframe/io/dataset/__init__.py
@@ -1,0 +1,1 @@
+from dask.dataframe.io.dataset.core import from_dataset

--- a/dask/dataframe/io/dataset/__init__.py
+++ b/dask/dataframe/io/dataset/__init__.py
@@ -1,1 +1,1 @@
-from dask.dataframe.io.dataset.core import DatasetSource, from_dataset
+from dask.dataframe.io.dataset.core import from_dataset

--- a/dask/dataframe/io/dataset/__init__.py
+++ b/dask/dataframe/io/dataset/__init__.py
@@ -1,1 +1,1 @@
-from dask.dataframe.io.dataset.core import from_dataset
+from dask.dataframe.io.dataset.core import DatasetSource, from_dataset

--- a/dask/dataframe/io/dataset/arrow.py
+++ b/dask/dataframe/io/dataset/arrow.py
@@ -1,0 +1,213 @@
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
+from fsspec.core import get_fs_token_paths
+
+from dask.dataframe.io.dataset.core import DatasetEngine, ReadFunction
+
+
+class ReadArrowFileFragment(ReadFunction):
+    """Wrapper-function class for reading pyarrow fragments"""
+
+    def __init__(self, columns, filters, index, dataset_options):
+        self.columns = columns
+        ds_filters = None
+        if filters is not None:
+            ds_filters = pq._filters_to_expression(filters)
+        self.filters = ds_filters
+        self.index = index
+        self.dataset_options = dataset_options
+
+    def __call__(self, fragment):
+        if isinstance(fragment, str):
+            df = (
+                ds.dataset(fragment, **self.dataset_options)
+                .to_table(filter=self.filters, columns=self.columns)
+                .to_pandas()
+            )
+        else:
+            df = fragment.to_table(
+                filter=self.filters, columns=self.columns
+            ).to_pandas()
+
+        if len(df.index.names) > 1:
+            # Dask-DataFrame cannot handle multi-index
+            df.reset_index(inplace=True)
+
+        if self.index and self.index != df.index.name:
+            if df.index.name is not None:
+                df.reset_index(inplace=True)
+            df.set_index(self.index, inplace=True)
+
+        if self.columns is not None:
+            return df[self.columns]
+        return df
+
+
+class ArrowDataset(DatasetEngine):
+    def __init__(
+        self,
+        partitioning="hive",
+        filesystem=None,
+        **dataset_options,
+    ):
+        self.dataset_options = dataset_options
+        self.partitioning = partitioning
+        self.filesystem = filesystem
+
+    def get_dataset(self, path, columns, filters, storage_options, mode="rb"):
+        """Returns an engine-specific dataset object"""
+
+        # Check if we already have a file-system object
+        if self.filesystem is None:
+            self.filesystem = get_fs_token_paths(
+                path, mode=mode, storage_options=storage_options
+            )[0]
+
+        return ds.dataset(
+            path,
+            partitioning=self.partitioning,
+            filesystem=self.filesystem,
+            **self.dataset_options,
+        )
+
+    def create_meta(self, dataset, index, columns):
+        """Returns an empty-DataFrame meta object"""
+
+        # Start with simple schema -> pandas mapping
+        meta = dataset.schema.empty_table().to_pandas()
+
+        # Check if we have a multi-index
+        if len(meta.index.names) > 1:
+            # Dask-DataFrame cannot handle multi-index
+            meta.reset_index(inplace=True)
+
+        # Set index if necessary
+        if index and index != meta.index.name:
+            if meta.index.name is not None:
+                meta.reset_index(inplace=True)
+            meta.set_index(index, inplace=True)
+
+        if columns is not None:
+            return meta[columns]
+        return meta
+
+    def get_read_function(self, columns, filters, index):
+        """Returns a function to convert a fragment to a DataFrame partition"""
+
+        return ReadArrowFileFragment(
+            columns,
+            filters,
+            index,
+            dataset_options={
+                "partitioning": self.partitioning,
+                "filesystem": self.filesystem,
+                **self.dataset_options,
+            },
+        )
+
+    def get_fragments(self, dataset, filters, meta, index, calculate_divisions):
+        ds_filters = None
+        if filters is not None:
+            ds_filters = pq._filters_to_expression(filters)
+        fragments = list(dataset.get_fragments(ds_filters))
+
+        if calculate_divisions:
+            raise ValueError(f"calculate_divisions=True not supported for {type(self)}")
+        return fragments, None
+
+    def get_collection_mapping(
+        self, path, columns, filters, index, calculate_divisions, storage_options
+    ):
+
+        # Get dataset
+        dataset = self.get_dataset(path, columns, filters, storage_options)
+
+        # Create meta
+        meta = self.create_meta(dataset, index, columns)
+
+        # Get fragments and divisions
+        fragments, divisions = self.get_fragments(
+            dataset, filters, meta, index, calculate_divisions
+        )
+
+        # Get IO function
+        io_func = self.get_read_function(columns, filters, index)
+
+        return io_func, fragments, meta, divisions or (None,) * (len(fragments) + 1)
+
+
+class ArrowParquetDataset(ArrowDataset):
+    def __init__(self, split_row_groups=False, **kwargs):
+        super().__init__(format="parquet", **kwargs)
+        self.split_row_groups = split_row_groups
+
+    def _caclulate_divisions(self, fragments, index):
+        divisions = None
+
+        def _stat(rg, kind):
+            val = rg.statistics.get(index, {}).get(kind, None)
+            if val is None:
+                raise ValueError(f"Missing {kind} statistic")
+            return val
+
+        def _frag_stats(frag):
+            frag_min = _stat(frag.row_groups[0], "min")
+            frag_max = _stat(frag.row_groups[0], "max")
+            for rg in frag.row_groups[1:]:
+                frag_min = min(_stat(rg, "min"), frag_min)
+                frag_max = max(_stat(rg, "max"), frag_max)
+            return frag_min, frag_max
+
+        try:
+            mins, maxes = [], []
+            frag_min, frag_max = _frag_stats(fragments[0])
+            mins.append(frag_min)
+            maxes.append(frag_max)
+            for frag in fragments[1:]:
+                frag_min, frag_max = _frag_stats(frag)
+                if frag_min < maxes[-1]:
+                    return divisions
+                mins.append(frag_min)
+                maxes.append(frag_max)
+            divisions = (mins[0],) + tuple(maxes)
+        except ValueError:
+            pass
+        return divisions
+
+    def get_fragments(self, dataset, filters, meta, index, calculate_divisions):
+
+        if index is None and len(meta.index.names) > 1:
+            index = False
+
+        file_fragments, file_divisions = super().get_fragments(
+            dataset, filters, meta, index, False
+        )
+        if self.split_row_groups:
+            raise ValueError("split_row_groups is not yet supported")
+            fragments = []
+            ds_filters = None
+            if filters is not None:
+                ds_filters = pq._filters_to_expression(filters)
+            for file_frag in file_fragments:
+                for frag in file_frag.split_by_row_group(
+                    ds_filters, schema=dataset.schema
+                ):
+                    fragments.append(frag)
+            divisions = [None] * (len(fragments) + 1)
+        else:
+            fragments = file_fragments
+            divisions = file_divisions
+
+        # For Parquet, we can convert fragments back to paths
+        # to avoid large graph sizes
+        path_fragments = [f.path for f in fragments]
+
+        # Check if we have an index column
+        # to calculate statistics for
+        if index is None and meta.index.name in dataset.schema.names:
+            index = meta.index.name
+
+        if index and calculate_divisions:
+            divisions = self._caclulate_divisions(fragments, index) or divisions
+
+        return path_fragments, divisions

--- a/dask/dataframe/io/dataset/arrow.py
+++ b/dask/dataframe/io/dataset/arrow.py
@@ -437,12 +437,15 @@ class ArrowParquetDataset(ArrowDataset):
 
         # If path is a _metadata file, use ds.parquet_dataset
         ds_api = ds.dataset
-        if (len(paths) == 1 and isinstance(paths[0], str)) and path.endswith("_metadata"):
+        if (len(paths) == 1 and isinstance(paths[0], str)) and path.endswith(
+            "_metadata"
+        ):
             self.using_global_metadata = True
             ds_api = ds.parquet_dataset
         else:
             self.using_global_metadata = False
 
+        # Avoid list for single path
         if len(paths) == 1:
             paths = paths[0]
 

--- a/dask/dataframe/io/dataset/arrow.py
+++ b/dask/dataframe/io/dataset/arrow.py
@@ -597,6 +597,7 @@ class ArrowParquetDataset(ArrowDataset):
             not self.using_global_metadata
             and (self.split_row_groups or calculate_divisions)
             and (len(file_fragments) >= self.metadata_task_size)
+            and self.metadata_task_size  # metadata_task_size=0 to skip
         ):
             ntasks = math.ceil(len(file_fragments) / self.metadata_task_size)
             task_size = len(file_fragments) // ntasks

--- a/dask/dataframe/io/dataset/arrow.py
+++ b/dask/dataframe/io/dataset/arrow.py
@@ -15,8 +15,8 @@ from dask.utils import natural_sort_key
 class ReadArrowFileFragment(ReadFunction):
     """Wrapper-function class for reading pyarrow fragments"""
 
-    def __init__(self, dataset, columns, filters, index, dataset_options):
-        self.schema = dataset.schema
+    def __init__(self, schema, columns, filters, index, dataset_options):
+        self.schema = schema
         self.columns = columns
         ds_filters = None
         if filters is not None:
@@ -158,11 +158,11 @@ class ArrowDataset(DatasetEngine):
             return meta[columns]
         return meta
 
-    def get_read_function(self, dataset, columns, filters, index):
+    def get_read_function(self, schema, columns, filters, index):
         """Returns a function to convert a fragment to a DataFrame partition"""
 
         return ReadArrowFileFragment(
-            dataset,
+            schema,
             columns,
             filters,
             index,
@@ -244,7 +244,7 @@ class ArrowDataset(DatasetEngine):
         fragments, divisions = self.get_fragments(dataset, filters, meta, index)
 
         # Get IO function
-        io_func = self.get_read_function(dataset, columns, filters, index)
+        io_func = self.get_read_function(dataset.schema, columns, filters, index)
 
         return io_func, fragments, meta, divisions or (None,) * (len(fragments) + 1)
 

--- a/dask/dataframe/io/dataset/arrow.py
+++ b/dask/dataframe/io/dataset/arrow.py
@@ -1,15 +1,22 @@
+from itertools import chain
+
+import numpy as np
+import pandas as pd
 import pyarrow as pa
 import pyarrow.dataset as ds
 import pyarrow.parquet as pq
 from fsspec.core import get_fs_token_paths
+from pyarrow.fs import FileSystem as PaFileSystem
 
 from dask.dataframe.io.dataset.core import DatasetEngine, ReadFunction
+from dask.utils import natural_sort_key
 
 
 class ReadArrowFileFragment(ReadFunction):
     """Wrapper-function class for reading pyarrow fragments"""
 
-    def __init__(self, columns, filters, index, dataset_options):
+    def __init__(self, dataset, columns, filters, index, dataset_options):
+        self.schema = dataset.schema
         self.columns = columns
         ds_filters = None
         if filters is not None:
@@ -27,7 +34,8 @@ class ReadArrowFileFragment(ReadFunction):
         elif isinstance(fragment, str):
             # fragment is a path name
             return ds.dataset(fragment, **self.dataset_options).to_table(
-                filter=self.filters, columns=self.columns
+                filter=self.filters,
+                columns=self.columns,
             )
         elif isinstance(fragment, tuple):
             # fragment is a (path, row_groups) tuple
@@ -38,10 +46,17 @@ class ReadArrowFileFragment(ReadFunction):
                 old_frag.filesystem,
                 old_frag.partition_expression,
                 row_groups=row_groups,
-            ).to_table(filter=self.filters, columns=self.columns)
+            ).to_table(
+                filter=self.filters,
+                columns=self.columns,
+            )
         else:
             # fragment is a pyarrow Fragment object
-            return fragment.to_table(filter=self.filters, columns=self.columns)
+            return fragment.to_table(
+                filter=self.filters,
+                columns=self.columns,
+                schema=self.schema,
+            )
 
     def __call__(self, fragment):
         # Convert fragment to pandas DataFrame
@@ -67,9 +82,17 @@ class ArrowDataset(DatasetEngine):
 
     Parameters
     ----------
-    calculate_divisions : dict, default False
-        Whether file metadata should be used to calculate output divisions.
-        This option is not currently supported for the default engine.
+    format : str or pyarrow.dataset.FileFormat
+        File-format label or object (passed to the pyarrow datast API).
+    partitioning : str or pyarrow object, default "hive"
+        Dataset partitioning option to pass to the pyarrow datast API.
+    filesystem : pyarrow.fs.FileSystem or fsspec.AbstractFileSystem, default None
+        PyArrow or Fsspec-based filesystem object.
+    aggregate_files : int, default None
+        How many adjacent files should be aggregated into the same
+        output partition.
+    sort_paths : bool, default True
+        Whether to apply natural sorting order to dataset paths.
     storage_options : dict, default None
         Key/value pairs to be passed on to the file-system backend, if any.
     **dataset_options :
@@ -78,20 +101,27 @@ class ArrowDataset(DatasetEngine):
 
     def __init__(
         self,
+        format=None,
         partitioning="hive",
         filesystem=None,
         aggregate_files=False,
+        sort_paths=True,
         storage_options=None,
         **dataset_options,
     ):
+        self.format = format
         self.partitioning = partitioning
         self.filesystem = filesystem
         self.aggregate_files = aggregate_files
+        self.sort_paths = sort_paths
         self.storage_options = storage_options or {}
         self.dataset_options = dataset_options
 
     def get_dataset(self, path, columns, filters, mode="rb"):
         """Returns an engine-specific dataset object"""
+
+        # TODO: Handle glob ordering? Apply sorting only for
+        # glob or directory?
 
         # Check if we already have a file-system object
         if self.filesystem is None:
@@ -101,6 +131,7 @@ class ArrowDataset(DatasetEngine):
 
         return ds.dataset(
             path,
+            format=self.format,
             partitioning=self.partitioning,
             filesystem=self.filesystem,
             **self.dataset_options,
@@ -127,19 +158,52 @@ class ArrowDataset(DatasetEngine):
             return meta[columns]
         return meta
 
-    def get_read_function(self, columns, filters, index):
+    def get_read_function(self, dataset, columns, filters, index):
         """Returns a function to convert a fragment to a DataFrame partition"""
 
         return ReadArrowFileFragment(
+            dataset,
             columns,
             filters,
             index,
             dataset_options={
+                "format": self.format,
                 "partitioning": self.partitioning,
                 "filesystem": self.filesystem,
                 **self.dataset_options,
             },
         )
+
+    def _aggregate_files(self, fragments):
+        aggregate_files = int(self.aggregate_files)
+        if aggregate_files > 1 and fragments:
+            # Assume we can only aggregate files within the same
+            # directory. Custom Engines will be required for
+            # more-complex logic here (this is just basic aggregation)
+            if isinstance(fragments[0], str):
+                exprs = ["/".join(frag.split("/")[:-1]) for frag in fragments]
+            elif isinstance(fragments[0], tuple):
+                exprs = ["/".join(frag[0].split("/")[:-1]) for frag in fragments]
+            else:
+                exprs = [str(frag.partition_expression) for frag in fragments]
+            frag_df = pd.DataFrame(
+                {
+                    "fragments": range(len(fragments)),
+                    "partition": exprs,
+                }
+            )
+            frag_groups = frag_df.groupby("partition").agg(list)["fragments"]
+
+            aggregated_fragments = []
+            for group in frag_groups:
+                for i in range(0, len(group), aggregate_files):
+                    frag_indices = group[i : i + aggregate_files]
+                    new_item = [fragments[ind] for ind in frag_indices]
+                    if new_item:
+                        aggregated_fragments.append(new_item)
+            return aggregated_fragments
+
+        return fragments
 
     def get_fragments(self, dataset, filters, meta, index):
         """Returns dataset fragments and divisions"""
@@ -149,19 +213,18 @@ class ArrowDataset(DatasetEngine):
             # Filters are defined - Use real fragments
             ds_filters = pq._filters_to_expression(filters)
             fragments = list(dataset.get_fragments(ds_filters))
+            # TODO: How to sort paths when .path is not available
+            # on the fragment?
         else:
             # Just use list of files
             fragments = dataset.files
+            if self.sort_paths:
+                fragments = sorted(fragments, key=natural_sort_key)
 
         # Check if we are aggregating files
-        aggregate_files = int(self.aggregate_files)
-        if aggregate_files:
-            aggregated_fragments = []
-            for i in range(0, len(fragments), aggregate_files):
-                aggregated_fragments.append(fragments[i : i + aggregate_files])
-            fragments = aggregated_fragments
+        fragments = self._aggregate_files(fragments)
 
-        return fragments, None
+        return fragments, (None,) * (len(fragments) + 1)
 
     def get_collection_mapping(
         self,
@@ -181,22 +244,82 @@ class ArrowDataset(DatasetEngine):
         fragments, divisions = self.get_fragments(dataset, filters, meta, index)
 
         # Get IO function
-        io_func = self.get_read_function(columns, filters, index)
+        io_func = self.get_read_function(dataset, columns, filters, index)
 
         return io_func, fragments, meta, divisions or (None,) * (len(fragments) + 1)
 
 
 class ArrowParquetDataset(ArrowDataset):
-    def __init__(self, split_row_groups=False, calculate_divisions=False, **kwargs):
-        super().__init__(format="parquet", **kwargs)
+    """
+    Pyarrow dataset engine for Parquet data
+
+    Parameters
+    ----------
+    split_row_groups : bool or int, default False
+        If True, then each output dataframe partition will correspond to a single
+        parquet-file row-group. If False, each partition will correspond to a
+        complete file.  If a positive integer value is given, each dataframe
+        partition will correspond to that number of parquet row-groups (or fewer).
+        Cannot be combined with ``aggregate_files``.
+    calculate_divisions : bool, default False
+        Whether parquet metadata should be used to calculate output divisions.
+        This argument will be ignored if there is no active index column.
+    ignore_metadata_file : bool, default False
+        Whether to ignore the global _metadata file (if one is present).
+    """
+
+    def __init__(
+        self,
+        split_row_groups=False,
+        calculate_divisions=False,
+        ignore_metadata_file=False,
+        format=None,
+        **dataset_options,
+    ):
+        super().__init__(format=format or ds.ParquetFileFormat(), **dataset_options)
         self.split_row_groups = split_row_groups
         self.calculate_divisions = calculate_divisions
+        self.ignore_metadata_file = ignore_metadata_file
         if bool(self.split_row_groups) and bool(self.aggregate_files):
             raise ValueError(
                 "aggregate_files only supported when split_row_groups=False"
             )
 
-    def _caclulate_divisions(self, fragments, index):
+    def get_dataset(self, path, columns, filters, mode="rb"):
+
+        # Check if we already have a file-system object
+        if self.filesystem is None:
+            self.filesystem = get_fs_token_paths(
+                path, mode=mode, storage_options=self.storage_options
+            )[0]
+
+        # Check for _metadata file if path is a directory name
+        if (
+            not self.ignore_metadata_file
+            and isinstance(path, str)
+            and not path.endswith("_metadata")
+        ):
+            meta_path = "/".join([path, "_metadata"])
+            if isinstance(self.filesystem, PaFileSystem):
+                if self.filesystem.get_file_info(meta_path).is_file:
+                    path = meta_path
+            else:
+                if self.filesystem.exists(meta_path):
+                    path = meta_path
+
+        # If path is a _metadata file, use ds.parquet_dataset
+        ds_api = ds.dataset
+        if isinstance(path, str) and path.endswith("_metadata"):
+            ds_api = ds.parquet_dataset
+
+        return ds_api(
+            path,
+            partitioning=self.partitioning,
+            filesystem=self.filesystem,
+            **self.dataset_options,
+        )
+
+    def _calculate_divisions(self, fragments, index):
         divisions = None
 
         def _stat(rg, kind):
@@ -215,16 +338,29 @@ class ArrowParquetDataset(ArrowDataset):
 
         try:
             mins, maxes = [], []
-            frag_min, frag_max = _frag_stats(fragments[0])
-            mins.append(frag_min)
-            maxes.append(frag_max)
-            for frag in fragments[1:]:
+            if isinstance(fragments[0], list):
+                aggregations = [len(f) for f in fragments]
+                use_fragments = list(chain(*fragments))
+            else:
+                aggregations = [1] * len(fragments)
+                use_fragments = fragments
+            aggregations = np.cumsum(aggregations)
+
+            divisions = []
+            div = 0
+            for f, frag in enumerate(use_fragments):
                 frag_min, frag_max = _frag_stats(frag)
-                if frag_min < maxes[-1]:
-                    return divisions
                 mins.append(frag_min)
                 maxes.append(frag_max)
-            divisions = (mins[0],) + tuple(maxes)
+                if (f + 1) == aggregations[div]:
+                    if not divisions:
+                        divisions = [np.min(mins)]
+                    elif np.min(mins) < divisions[-1]:
+                        return None
+                    divisions.append(np.max(maxes))
+                    mins, maxes = [], []
+                    div += 1
+
         except ValueError:
             pass
         return divisions
@@ -235,16 +371,26 @@ class ArrowParquetDataset(ArrowDataset):
         if index is None and len(meta.index.names) > 1:
             index = False
 
+        # Check if we have a "default" index-column name
+        if index is None and meta.index.name in dataset.schema.names:
+            index = meta.index.name
+
+        # Collect fragments
         ds_filters = None
         if filters is not None:
             ds_filters = pq._filters_to_expression(filters)
         if ds_filters is not None or self.split_row_groups or self.calculate_divisions:
             # One or more options require real fragments
             file_fragments = list(dataset.get_fragments(ds_filters))
+            if self.sort_paths:
+                file_fragments = sorted(
+                    file_fragments, key=lambda x: natural_sort_key(x.path)
+                )
         else:
             # Just use list of files
             file_fragments = dataset.files
-        file_divisions = None
+            if self.sort_paths:
+                file_fragments = sorted(file_fragments, key=natural_sort_key)
 
         def _new_frag(old_frag, row_groups):
             return old_frag.format.make_fragment(
@@ -269,33 +415,32 @@ class ArrowParquetDataset(ArrowDataset):
                     frag = _new_frag(file_frag, rgs)
                     fragments.append(frag)
                     path_fragments.append((frag.path, rgs))
-            divisions = [None] * (len(fragments) + 1)
         else:
             # For Parquet, we can convert fragments back to paths
             # to avoid large graph sizes
             fragments = file_fragments
-            divisions = file_divisions
-            path_fragments = [f.path for f in fragments]
+            if fragments and isinstance(fragments[0], str):
+                path_fragments = fragments
+            else:
+                path_fragments = [f.path for f in fragments]
 
-        # Check if we have an index column
-        # to calculate statistics for
-        if index is None and meta.index.name in dataset.schema.names:
-            index = meta.index.name
-
-        # Calculate divisions if necessary
-        if index and self.calculate_divisions:
-            divisions = self._caclulate_divisions(fragments, index) or divisions
-        divisions = divisions or (None,) * (len(path_fragments) + 1)
-
-        # Check if we are aggregating files
+        # Aggregate files
         aggregate_files = int(self.aggregate_files)
-        if aggregate_files:
-            aggregated_fragments = []
-            aggregated_divisions = []
-            for i in range(0, len(path_fragments), aggregate_files):
-                aggregated_fragments.append(path_fragments[i : i + aggregate_files])
-                aggregated_divisions.append(divisions[i])
-            aggregated_divisions.append(divisions[-1])
-            return aggregated_fragments, aggregated_divisions
+        if aggregate_files > 1 and fragments:
+            fragments = self._aggregate_files(fragments)
+            if isinstance(fragments[0], str):
+                path_fragments = fragments
+            elif isinstance(fragments[0], list):
+                if fragments[0] and not isinstance(fragments[0][0], str):
+                    path_fragments = [[f.path for f in frag] for frag in fragments]
+                else:
+                    path_fragments = fragments
+            else:
+                path_fragments = [f.path for f in fragments]
 
-        return path_fragments, divisions
+        # Calculate divisions
+        divisions = None
+        if index and self.calculate_divisions:
+            divisions = self._calculate_divisions(fragments, index)
+
+        return path_fragments, divisions or (None,) * (len(path_fragments) + 1)

--- a/dask/dataframe/io/dataset/arrow.py
+++ b/dask/dataframe/io/dataset/arrow.py
@@ -19,13 +19,10 @@ from dask.utils import natural_sort_key
 class ReadArrowFileFragment(ReadFunction):
     """Wrapper-function class for reading pyarrow fragments"""
 
-    def __init__(self, schema, columns, filters, index, dataset_options):
+    def __init__(self, schema, columns, ds_filters, index, dataset_options):
         self.schema = schema
         self.columns = columns
-        ds_filters = None
-        if filters is not None:
-            ds_filters = pq._filters_to_expression(filters)
-        self.filters = ds_filters
+        self.ds_filters = ds_filters
         self.index = index
         self.dataset_options = dataset_options
 
@@ -38,7 +35,7 @@ class ReadArrowFileFragment(ReadFunction):
         elif isinstance(fragment, str):
             # fragment is a path name
             return ds.dataset(fragment, **self.dataset_options).to_table(
-                filter=self.filters,
+                filter=self.ds_filters,
                 columns=self.columns,
             )
         elif isinstance(fragment, tuple):
@@ -51,13 +48,13 @@ class ReadArrowFileFragment(ReadFunction):
                 old_frag.partition_expression,
                 row_groups=row_groups,
             ).to_table(
-                filter=self.filters,
+                filter=self.ds_filters,
                 columns=self.columns,
             )
         else:
             # fragment is a pyarrow Fragment object
             return fragment.to_table(
-                filter=self.filters,
+                filter=self.ds_filters,
                 columns=self.columns,
                 schema=self.schema,
             )
@@ -92,19 +89,22 @@ class ArrowDataset(DatasetEngine):
         Dataset partitioning option to pass to the pyarrow datast API.
     filesystem : pyarrow.fs.FileSystem or fsspec.AbstractFileSystem, default None
         PyArrow or Fsspec-based filesystem object.
-    aggregate_files : int, default None
+    aggregate_files : int, default 1
         How many adjacent files should be aggregated into the same
         output partition.
     aggregation_boundary : list[str], default None
         List of partitioned-column names that must have matching values in
         adjacent files for aggregation to occur. By default, any two files
-        may be aggregated if ``aggregate_files>1``.
+        may be aggregated if ``aggregate_files>1``. Note that using this
+        option will typically result in re-sorting of input paths. Therefore,
+        the order of input path lists will not be preserved.
     sort_paths : bool, default True
         Whether to apply natural sorting order to dataset paths.
     storage_options : dict, default None
-        Key/value pairs to be passed on to the file-system backend, if any.
+        Key/value pairs to be passed on to the file-system backend if
+        ``filesystem`` is not specified.
     **dataset_options :
-        Key-value arguments to pass along to the ``pyarrow.dataset`` API.
+        Other key-value arguments to pass along to the ``pyarrow.dataset`` API.
     """
 
     def __init__(
@@ -112,7 +112,7 @@ class ArrowDataset(DatasetEngine):
         format=None,
         partitioning="hive",
         filesystem=None,
-        aggregate_files=False,
+        aggregate_files=1,
         aggregation_boundary=None,
         sort_paths=True,
         storage_options=None,
@@ -121,11 +121,17 @@ class ArrowDataset(DatasetEngine):
         self.format = format
         self.partitioning = partitioning
         self.filesystem = filesystem
-        self.aggregate_files = aggregate_files
         self.sort_paths = sort_paths
         self.aggregation_boundary = aggregation_boundary or []
         self.storage_options = storage_options or {}
         self.dataset_options = dataset_options
+        self.aggregate_files = aggregate_files
+        if not isinstance(aggregate_files, int):
+            # NOTE: We may convert aggregate_files to a list internally,
+            # but only integer input is supported from the user
+            raise ValueError(
+                f"aggregate_files must be an integer, got {aggregate_files}"
+            )
 
     def get_dataset(self, path, columns, filters, mode="rb"):
         """Returns an engine-specific dataset object"""
@@ -135,7 +141,7 @@ class ArrowDataset(DatasetEngine):
 
         # Check if source is a list of lists
         if isinstance(path, list) and path and isinstance(path[0], list):
-            if int(self.aggregate_files) > 1:
+            if self.aggregate_files > 1:
                 raise ValueError(
                     "aggregate_files argument not supported when file "
                     "aggregation is already encoded in the source input. "
@@ -186,13 +192,13 @@ class ArrowDataset(DatasetEngine):
             return meta[columns]
         return meta
 
-    def get_read_function(self, schema, columns, filters, index):
+    def get_read_function(self, schema, columns, ds_filters, index):
         """Returns a function to convert a fragment to a DataFrame partition"""
 
         return ReadArrowFileFragment(
             schema,
             columns,
-            filters,
+            ds_filters,
             index,
             dataset_options={
                 "format": self.format,
@@ -203,6 +209,7 @@ class ArrowDataset(DatasetEngine):
         )
 
     def _aggregate_files(self, fragments):
+        """Aggregate adjacent file fragments into the same output partition"""
 
         if fragments and (
             isinstance(self.aggregate_files, list) and self.aggregate_files
@@ -221,7 +228,6 @@ class ArrowDataset(DatasetEngine):
         ):
             # Aggregating files by integer "stride". However, we
             # also need to satisfy the `aggregation_boundary` option
-            aggregate_files = int(self.aggregate_files)
             if self.aggregation_boundary:
                 assert not isinstance(fragments[0], (str, tuple))
 
@@ -251,8 +257,8 @@ class ArrowDataset(DatasetEngine):
 
             aggregated_fragments = []
             for group in frag_groups:
-                for i in range(0, len(group), aggregate_files):
-                    frag_indices = group[i : i + aggregate_files]
+                for i in range(0, len(group), self.aggregate_files):
+                    frag_indices = group[i : i + self.aggregate_files]
                     new_item = [fragments[ind] for ind in frag_indices]
                     if new_item:
                         aggregated_fragments.append(new_item)
@@ -260,8 +266,12 @@ class ArrowDataset(DatasetEngine):
 
         return fragments
 
-    def get_fragments(self, dataset, ds_filters, meta, index):
-        """Returns fragments aand divisions"""
+    def get_fragments(self, dataset, ds_filters, meta, index, calculate_divisions):
+        """Returns fragments and divisions"""
+
+        if calculate_divisions:
+            raise ValueError(f"calculate_divisions=True not supported for {type(self)}")
+
         if ds_filters is not None or self.aggregation_boundary:
             # Filters are defined - Use real fragments
             fragments = list(dataset.get_fragments(ds_filters))
@@ -284,7 +294,9 @@ class ArrowDataset(DatasetEngine):
         columns=None,
         filters=None,
         index=None,
+        calculate_divisions=False,
     ):
+        """Returns required inputs for a DataFrame collection"""
 
         # Get dataset
         dataset = self.get_dataset(source, columns, filters)
@@ -298,11 +310,15 @@ class ArrowDataset(DatasetEngine):
             ds_filters = pq._filters_to_expression(filters)
 
         # Get fragments and divisions
-        fragments, divisions = self.get_fragments(dataset, ds_filters, meta, index)
+        fragments, divisions = self.get_fragments(
+            dataset, ds_filters, meta, index, calculate_divisions
+        )
         divisions = divisions or (None,) * (len(fragments) + 1)
 
         # Get IO function
-        io_func = self.get_read_function(dataset.schema, columns, filters, index)
+        io_func = self.get_read_function(dataset.schema, columns, ds_filters, index)
+
+        # Return all requirements for DataFrame-collection creation
         return fragments, divisions, meta, io_func
 
 
@@ -312,6 +328,21 @@ class ArrowParquetDataset(ArrowDataset):
 
     Parameters
     ----------
+    format : str or pyarrow.dataset.FileFormat, default pyarrow.dataset.ParquetFileFormat()
+        File-format label or object (passed to the pyarrow datast API).
+    partitioning : str or pyarrow object, default "hive"
+        Dataset partitioning option to pass to the pyarrow datast API.
+    filesystem : pyarrow.fs.FileSystem or fsspec.AbstractFileSystem, default None
+        PyArrow or Fsspec-based filesystem object.
+    aggregate_files : int, default 1
+        How many adjacent files should be aggregated into the same
+        output partition.
+    aggregation_boundary : list[str], default None
+        List of partitioned-column names that must have matching values in
+        adjacent files for aggregation to occur. By default, any two files
+        may be aggregated if ``aggregate_files>1``.
+    sort_paths : bool, default True
+        Whether to apply natural sorting order to dataset paths.
     split_row_groups : bool or int, default False
         If True, then each output dataframe partition will correspond to a single
         parquet-file row-group. If False, each partition will correspond to a
@@ -319,17 +350,18 @@ class ArrowParquetDataset(ArrowDataset):
         partition will correspond to that number of parquet row-groups (or fewer).
         This option cannot be combined with ``aggregate_files``, or be used when
         file aggregation is already encoded in the source input.
-    calculate_divisions : bool, default False
-        Whether parquet metadata should be used to calculate output divisions.
-        This argument will be ignored if there is no active index column.
     ignore_metadata_file : bool, default False
-        Whether to ignore the global _metadata file (if one is present).
+        Whether to ignore the global Parquet _metadata file (if one is present).
+    storage_options : dict, default None
+        Key/value pairs to be passed on to the file-system backend if
+        ``filesystem`` is not specified.
+    **dataset_options :
+        Other key-value arguments to pass along to the ``pyarrow.dataset`` API.
     """
 
     def __init__(
         self,
         split_row_groups=False,
-        calculate_divisions=False,
         ignore_metadata_file=False,
         metadata_task_size=32,
         format=None,
@@ -337,7 +369,6 @@ class ArrowParquetDataset(ArrowDataset):
     ):
         super().__init__(format=format or ds.ParquetFileFormat(), **dataset_options)
         self.split_row_groups = split_row_groups
-        self.calculate_divisions = calculate_divisions
         self.ignore_metadata_file = ignore_metadata_file
         self.using_global_metadata = False
         self.metadata_task_size = metadata_task_size
@@ -350,7 +381,7 @@ class ArrowParquetDataset(ArrowDataset):
 
         # Check if source is a list of lists
         if isinstance(path, list) and path and isinstance(path[0], list):
-            if int(self.aggregate_files) > 1:
+            if self.aggregate_files > 1:
                 raise ValueError(
                     "aggregate_files argument not supported when file "
                     "aggregation is already encoded in the source input. "
@@ -453,7 +484,7 @@ class ArrowParquetDataset(ArrowDataset):
             pass
         return divisions
 
-    def get_fragments(self, dataset, ds_filters, meta, index):
+    def get_fragments(self, dataset, ds_filters, meta, index, calculate_divisions):
 
         # Avoid index handling/divisions for default multi-index
         if index is None and len(meta.index.names) > 1:
@@ -467,7 +498,7 @@ class ArrowParquetDataset(ArrowDataset):
         if (
             ds_filters is not None
             or self.split_row_groups
-            or self.calculate_divisions
+            or calculate_divisions
             or self.aggregation_boundary
         ):
             # One or more options require real fragments
@@ -485,7 +516,7 @@ class ArrowParquetDataset(ArrowDataset):
         # Process the parquet metadata in parallel
         if (
             not self.using_global_metadata
-            and (self.split_row_groups or self.calculate_divisions)
+            and (self.split_row_groups or calculate_divisions)
             and (len(file_fragments) >= self.metadata_task_size)
         ):
             ntasks = math.ceil(len(file_fragments) / self.metadata_task_size)
@@ -501,6 +532,7 @@ class ArrowParquetDataset(ArrowDataset):
                     file_fragments[i : i + task_size],
                     ds_filters,
                     index,
+                    calculate_divisions,
                 )
             dsk["final-" + meta_name] = (_finalize_plan, list(dsk.keys()))
             return Delayed("final-" + meta_name, dsk).compute()
@@ -510,9 +542,10 @@ class ArrowParquetDataset(ArrowDataset):
             file_fragments,
             ds_filters,
             index,
+            calculate_divisions,
         )
 
-    def process_fragments(self, file_fragments, ds_filters, index):
+    def process_fragments(self, file_fragments, ds_filters, index, calculate_divisions):
         """Returns processed fragments and divisions"""
 
         def _new_frag(old_frag, row_groups):
@@ -562,13 +595,14 @@ class ArrowParquetDataset(ArrowDataset):
 
         # Calculate divisions
         divisions = None
-        if index and self.calculate_divisions:
+        if index and calculate_divisions:
             divisions = self._calculate_divisions(fragments, index)
 
         return path_fragments, divisions or (None,) * (len(path_fragments) + 1)
 
 
 def _finalize_plan(plan_list):
+    """Finalize fragment/divisions for multiple metadata tasks"""
     fragments, divisions = plan_list[0]
 
     if None in divisions:

--- a/dask/dataframe/io/dataset/core.py
+++ b/dask/dataframe/io/dataset/core.py
@@ -19,6 +19,7 @@ class ReadFunction:
 class DatasetEngine:
     def get_collection_mapping(
         self,
+        path,
         columns=None,
         filters=None,
         index=None,

--- a/dask/dataframe/io/dataset/core.py
+++ b/dask/dataframe/io/dataset/core.py
@@ -1,196 +1,211 @@
-# def read_dataset(
-#     path,
-#     columns=None,
-#     filters=None,
-#     index=None,
-#     calculate_divisions=False,
-#     storage_options=None,
-#     file_format="parquet",
-#     engine="pyarrow",
-# ):
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
+from fsspec.core import get_fs_token_paths
 
-#     engine = get_engine(engine)
-
-#     # Store initial function arguments
-#     input_kwargs = {
-#         "columns": columns,
-#         "filters": filters,
-#         "categories": categories,
-#         "index": index,
-#         "storage_options": storage_options,
-#         "engine": engine,
-#         "gather_statistics": gather_statistics,
-#         "ignore_metadata_file": ignore_metadata_file,
-#         "metadata_task_size": metadata_task_size,
-#         "split_row_groups": split_row_groups,
-#         "chunksize=": chunksize,
-#         "aggregate_files": aggregate_files,
-#         **kwargs,
-#     }
-
-#     if isinstance(columns, str):
-#         input_kwargs["columns"] = [columns]
-#         df = read_parquet(path, **input_kwargs)
-#         return df[columns]
-
-#     if columns is not None:
-#         columns = list(columns)
-
-#     if isinstance(engine, str):
-#         engine = get_engine(engine, bool(kwargs))
-
-#     if hasattr(path, "name"):
-#         path = stringify_path(path)
-
-#     # Update input_kwargs and tokenize inputs
-#     label = "read-parquet-"
-#     input_kwargs.update({"columns": columns, "engine": engine})
-#     output_name = label + tokenize(path, **input_kwargs)
-
-#     fs, _, paths = get_fs_token_paths(path, mode="rb", storage_options=storage_options)
-#     paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
-
-#     auto_index_allowed = False
-#     if index is None:
-#         # User is allowing auto-detected index
-#         auto_index_allowed = True
-#     if index and isinstance(index, str):
-#         index = [index]
-
-#     if chunksize or (
-#         split_row_groups and int(split_row_groups) > 1 and aggregate_files
-#     ):
-#         # Require `gather_statistics=True` if `chunksize` is used,
-#         # or if `split_row_groups>1` and we are aggregating files.
-#         if gather_statistics is False:
-#             raise ValueError("read_parquet options require gather_statistics=True")
-#         gather_statistics = True
-
-#     read_metadata_result = engine.read_metadata(
-#         fs,
-#         paths,
-#         categories=categories,
-#         index=index,
-#         gather_statistics=gather_statistics,
-#         filters=filters,
-#         split_row_groups=split_row_groups,
-#         chunksize=chunksize,
-#         aggregate_files=aggregate_files,
-#         ignore_metadata_file=ignore_metadata_file,
-#         metadata_task_size=metadata_task_size,
-#         **kwargs,
-#     )
-
-#     # In the future, we may want to give the engine the
-#     # option to return a dedicated element for `common_kwargs`.
-#     # However, to avoid breaking the API, we just embed this
-#     # data in the first element of `parts` for now.
-#     # The logic below is inteded to handle backward and forward
-#     # compatibility with a user-defined engine.
-#     meta, statistics, parts, index = read_metadata_result[:4]
-#     common_kwargs = {}
-#     aggregation_depth = False
-#     if len(parts):
-#         # For now, `common_kwargs` and `aggregation_depth`
-#         # may be stored in the first element of `parts`
-#         common_kwargs = parts[0].pop("common_kwargs", {})
-#         aggregation_depth = parts[0].pop("aggregation_depth", aggregation_depth)
-
-#     # Parse dataset statistics from metadata (if available)
-#     parts, divisions, index, index_in_columns = process_statistics(
-#         parts,
-#         statistics,
-#         filters,
-#         index,
-#         chunksize,
-#         split_row_groups,
-#         fs,
-#         aggregation_depth,
-#     )
-
-#     # Account for index and columns arguments.
-#     # Modify `meta` dataframe accordingly
-#     meta, index, columns = set_index_columns(
-#         meta, index, columns, index_in_columns, auto_index_allowed
-#     )
-#     if meta.index.name == NONE_LABEL:
-#         meta.index.name = None
-
-#     # Set the index that was previously treated as a column
-#     if index_in_columns:
-#         meta = meta.set_index(index)
-#         if meta.index.name == NONE_LABEL:
-#             meta.index.name = None
-
-#     if len(divisions) < 2:
-#         # empty dataframe - just use meta
-#         graph = {(output_name, 0): meta}
-#         divisions = (None, None)
-#     else:
-#         # Create Blockwise layer
-#         layer = DataFrameIOLayer(
-#             output_name,
-#             columns,
-#             parts,
-#             ParquetFunctionWrapper(
-#                 engine,
-#                 fs,
-#                 meta,
-#                 columns,
-#                 index,
-#                 {},  # All kwargs should now be in `common_kwargs`
-#                 common_kwargs,
-#             ),
-#             label=label,
-#             creation_info={
-#                 "func": read_parquet,
-#                 "args": (path,),
-#                 "kwargs": input_kwargs,
-#             },
-#         )
-#         graph = HighLevelGraph({output_name: layer}, {output_name: set()})
-
-#     return new_dd_object(graph, output_name, meta, divisions)
+from dask.base import tokenize
+from dask.dataframe.core import new_dd_object
+from dask.highlevelgraph import HighLevelGraph
+from dask.layers import DataFrameIOLayer
 
 
-# def check_multi_support(engine):
-#     # Helper function to check that the engine
-#     # supports a multi-partition read
-#     return hasattr(engine, "multi_support") and engine.multi_support()
+class DatasetEngine:
+    def get_collection_mapping(
+        self, columns, filters, index, calculate_divisions, storage_options
+    ):
+        """Returns required inputs to from_map"""
+        raise NotImplementedError
 
 
-# def read_parquet_part(fs, engine, meta, part, columns, index, kwargs):
-#     """Read a part of a parquet dataset
+class ReadArrowFileFragment:
+    """Generic class for converting pyarrow file fragments to partitions"""
 
-#     This function is used by `read_parquet`."""
-#     if isinstance(part, list):
-#         if len(part) == 1 or part[0][1] or not check_multi_support(engine):
-#             # Part kwargs expected
-#             func = engine.read_partition
-#             dfs = [
-#                 func(fs, rg, columns.copy(), index, **toolz.merge(kwargs, kw))
-#                 for (rg, kw) in part
-#             ]
-#             df = concat(dfs, axis=0) if len(dfs) > 1 else dfs[0]
-#         else:
-#             # No part specific kwargs, let engine read
-#             # list of parts at once
-#             df = engine.read_partition(
-#                 fs, [p[0] for p in part], columns.copy(), index, **kwargs
-#             )
-#     else:
-#         # NOTE: `kwargs` are the same for all parts, while `part_kwargs` may
-#         #       be different for each part.
-#         rg, part_kwargs = part
-#         df = engine.read_partition(
-#             fs, rg, columns, index, **toolz.merge(kwargs, part_kwargs)
-#         )
+    def __init__(self, columns, filters, index, dataset_options):
+        self.columns = columns
+        ds_filters = None
+        if filters is not None:
+            ds_filters = pq._filters_to_expression(filters)
+        self.filters = ds_filters
+        self.index = index
+        self.dataset_options = dataset_options
 
-#     if meta.columns.name:
-#         df.columns.name = meta.columns.name
-#     columns = columns or []
-#     index = index or []
-#     df = df[[c for c in columns if c not in index]]
-#     if index == [NONE_LABEL]:
-#         df.index.name = None
-#     return df
+    def project_columns(self, columns):
+        if columns == self.columns:
+            return self
+        return type(self)(columns, self.filters)
+
+    def __call__(self, fragment):
+        if isinstance(fragment, str):
+            df = (
+                ds.dataset(fragment, **self.dataset_options)
+                .to_table(filter=self.filters, columns=self.columns)
+                .to_pandas()
+            )
+        else:
+            df = fragment.to_table(
+                filter=self.filters, columns=self.columns
+            ).to_pandas()
+        if self.index:
+            return df.set_index(self.index)
+        return df
+
+
+class ArrowEngine:
+    def __init__(
+        self,
+        partitioning="hive",
+        filesystem=None,
+        **dataset_options,
+    ):
+        self.dataset_options = dataset_options
+        self.partitioning = partitioning
+        self.filesystem = filesystem
+
+    def get_dataset(self, path, columns, filters, storage_options, mode="rb"):
+        """Returns an engine-specific dataset object"""
+
+        # Check if we already have a file-system object
+        if self.filesystem is None:
+            self.filesystem = get_fs_token_paths(
+                path, mode=mode, storage_options=storage_options
+            )[0]
+
+        return ds.dataset(
+            path,
+            partitioning=self.partitioning,
+            filesystem=self.filesystem,
+            **self.dataset_options,
+        )
+
+    def create_meta(self, dataset, index):
+        """Returns an empty-DataFrame meta object"""
+
+        # Start with simple schema -> pandas mapping
+        meta = dataset.schema.empty_table().to_pandas()
+        # Set index if necessary
+        if index:
+            return meta.set_index(index)
+        return meta
+
+    def get_read_function(self, columns, filters, index):
+        """Returns a function to convert a fragment to a DataFrame partition"""
+
+        return ReadArrowFileFragment(
+            columns,
+            filters,
+            index,
+            dataset_options={
+                "partitioning": self.partitioning,
+                "filesystem": self.filesystem,
+                **self.dataset_options,
+            },
+        )
+
+    def get_fragments(self, dataset, filters):
+        ds_filters = None
+        if filters is not None:
+            ds_filters = pq._filters_to_expression(filters)
+        return dataset.get_fragments(ds_filters)
+
+    def get_collection_mapping(
+        self, path, columns, filters, index, calculate_divisions, storage_options
+    ):
+
+        # Get dataset
+        dataset = self.get_dataset(path, columns, filters, storage_options)
+
+        # Create meta
+        meta = self.create_meta(dataset, index)
+
+        # Get fragments
+        fragments = self.get_fragments(dataset, filters)
+
+        # Get IO function
+        io_func = self.get_read_function(columns, filters, index)
+
+        # Extract divisions
+        if calculate_divisions:
+            raise ValueError("calculate_divisions=True is not supported.")
+        divisions = (None,) * (len(dataset.files) + 1)
+
+        return io_func, fragments, meta, divisions
+
+
+class ArrowParquetEngine(ArrowEngine):
+    def __init__(self, **kwargs):
+        super().__init__(format="parquet", **kwargs)
+
+    def get_fragments(self, dataset, filters):
+        # For Parquet, we can convert fragments back to paths
+        # to avoid large graph sizes
+        return [f.path for f in super().get_fragments(dataset, filters)]
+
+
+def get_engine(engine, **engine_options):
+    if engine in ("parquet", "pyarrow-parquet"):
+        return ArrowParquetEngine(**engine_options)
+    elif engine in ("orc", "pyarrow-orc"):
+        return ArrowEngine(format="orc", **engine_options)
+    elif not isinstance(engine, DatasetEngine):
+        raise ValueError
+    return engine
+
+
+def from_dataset(
+    path,
+    columns=None,
+    filters=None,
+    index=None,
+    calculate_divisions=False,
+    engine="pyarrow-parquet",
+    engine_options=None,
+    storage_options=None,
+):
+
+    # Create output-collection name
+    label = "from-dataset-"
+    input_kwargs = {
+        "columns": columns,
+        "filters": filters,
+        "index": index,
+        "calculate_divisions": calculate_divisions,
+        "engine": engine,
+        "engine_options": engine_options,
+        "storage_options": storage_options,
+    }
+    output_name = label + tokenize(path, **input_kwargs)
+
+    # Get dataset engine
+    engine = get_engine(engine, **(engine_options or {}))
+
+    # Get collection-mapping information
+    io_func, fragments, meta, divisions = engine.get_collection_mapping(
+        path,
+        columns,
+        filters,
+        index,
+        calculate_divisions,
+        storage_options,
+    )
+
+    # Special Case (Empty DataFrame)
+    if len(divisions) < 2:
+        io_func = lambda x: x
+        fragments = [meta]
+        divisions = (None, None)
+
+    # Create Blockwise layer
+    # TODO: use `from_map`
+    layer = DataFrameIOLayer(
+        output_name,
+        columns,
+        fragments,
+        io_func,
+        label=label,
+        creation_info={
+            "func": from_dataset,
+            "args": (path,),
+            "kwargs": input_kwargs,
+        },
+    )
+    graph = HighLevelGraph({output_name: layer}, {output_name: set()})
+    return new_dd_object(graph, output_name, meta, divisions)

--- a/dask/dataframe/io/dataset/core.py
+++ b/dask/dataframe/io/dataset/core.py
@@ -104,7 +104,10 @@ class ArrowDataset(DatasetEngine):
         ds_filters = None
         if filters is not None:
             ds_filters = pq._filters_to_expression(filters)
-        return dataset.get_fragments(ds_filters)
+        return list(dataset.get_fragments(ds_filters))
+
+    def get_divisions(self, fragments, index):
+        raise ValueError(f"calculate_divisions=True not supported for {type(self)}")
 
     def get_collection_mapping(
         self, path, columns, filters, index, calculate_divisions, storage_options
@@ -119,13 +122,14 @@ class ArrowDataset(DatasetEngine):
         # Get fragments
         fragments = self.get_fragments(dataset, filters)
 
-        # Get IO function
-        io_func = self.get_read_function(columns, filters, index)
-
         # Extract divisions
         if calculate_divisions:
-            raise ValueError("calculate_divisions=True is not supported.")
-        divisions = (None,) * (len(dataset.files) + 1)
+            divisions = self.get_divisions(fragments, index)
+        else:
+            divisions = (None,) * (len(fragments) + 1)
+
+        # Get IO function
+        io_func = self.get_read_function(columns, filters, index)
 
         return io_func, fragments, meta, divisions
 

--- a/dask/dataframe/io/dataset/core.py
+++ b/dask/dataframe/io/dataset/core.py
@@ -1,0 +1,196 @@
+# def read_dataset(
+#     path,
+#     columns=None,
+#     filters=None,
+#     index=None,
+#     calculate_divisions=False,
+#     storage_options=None,
+#     file_format="parquet",
+#     engine="pyarrow",
+# ):
+
+#     engine = get_engine(engine)
+
+#     # Store initial function arguments
+#     input_kwargs = {
+#         "columns": columns,
+#         "filters": filters,
+#         "categories": categories,
+#         "index": index,
+#         "storage_options": storage_options,
+#         "engine": engine,
+#         "gather_statistics": gather_statistics,
+#         "ignore_metadata_file": ignore_metadata_file,
+#         "metadata_task_size": metadata_task_size,
+#         "split_row_groups": split_row_groups,
+#         "chunksize=": chunksize,
+#         "aggregate_files": aggregate_files,
+#         **kwargs,
+#     }
+
+#     if isinstance(columns, str):
+#         input_kwargs["columns"] = [columns]
+#         df = read_parquet(path, **input_kwargs)
+#         return df[columns]
+
+#     if columns is not None:
+#         columns = list(columns)
+
+#     if isinstance(engine, str):
+#         engine = get_engine(engine, bool(kwargs))
+
+#     if hasattr(path, "name"):
+#         path = stringify_path(path)
+
+#     # Update input_kwargs and tokenize inputs
+#     label = "read-parquet-"
+#     input_kwargs.update({"columns": columns, "engine": engine})
+#     output_name = label + tokenize(path, **input_kwargs)
+
+#     fs, _, paths = get_fs_token_paths(path, mode="rb", storage_options=storage_options)
+#     paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
+
+#     auto_index_allowed = False
+#     if index is None:
+#         # User is allowing auto-detected index
+#         auto_index_allowed = True
+#     if index and isinstance(index, str):
+#         index = [index]
+
+#     if chunksize or (
+#         split_row_groups and int(split_row_groups) > 1 and aggregate_files
+#     ):
+#         # Require `gather_statistics=True` if `chunksize` is used,
+#         # or if `split_row_groups>1` and we are aggregating files.
+#         if gather_statistics is False:
+#             raise ValueError("read_parquet options require gather_statistics=True")
+#         gather_statistics = True
+
+#     read_metadata_result = engine.read_metadata(
+#         fs,
+#         paths,
+#         categories=categories,
+#         index=index,
+#         gather_statistics=gather_statistics,
+#         filters=filters,
+#         split_row_groups=split_row_groups,
+#         chunksize=chunksize,
+#         aggregate_files=aggregate_files,
+#         ignore_metadata_file=ignore_metadata_file,
+#         metadata_task_size=metadata_task_size,
+#         **kwargs,
+#     )
+
+#     # In the future, we may want to give the engine the
+#     # option to return a dedicated element for `common_kwargs`.
+#     # However, to avoid breaking the API, we just embed this
+#     # data in the first element of `parts` for now.
+#     # The logic below is inteded to handle backward and forward
+#     # compatibility with a user-defined engine.
+#     meta, statistics, parts, index = read_metadata_result[:4]
+#     common_kwargs = {}
+#     aggregation_depth = False
+#     if len(parts):
+#         # For now, `common_kwargs` and `aggregation_depth`
+#         # may be stored in the first element of `parts`
+#         common_kwargs = parts[0].pop("common_kwargs", {})
+#         aggregation_depth = parts[0].pop("aggregation_depth", aggregation_depth)
+
+#     # Parse dataset statistics from metadata (if available)
+#     parts, divisions, index, index_in_columns = process_statistics(
+#         parts,
+#         statistics,
+#         filters,
+#         index,
+#         chunksize,
+#         split_row_groups,
+#         fs,
+#         aggregation_depth,
+#     )
+
+#     # Account for index and columns arguments.
+#     # Modify `meta` dataframe accordingly
+#     meta, index, columns = set_index_columns(
+#         meta, index, columns, index_in_columns, auto_index_allowed
+#     )
+#     if meta.index.name == NONE_LABEL:
+#         meta.index.name = None
+
+#     # Set the index that was previously treated as a column
+#     if index_in_columns:
+#         meta = meta.set_index(index)
+#         if meta.index.name == NONE_LABEL:
+#             meta.index.name = None
+
+#     if len(divisions) < 2:
+#         # empty dataframe - just use meta
+#         graph = {(output_name, 0): meta}
+#         divisions = (None, None)
+#     else:
+#         # Create Blockwise layer
+#         layer = DataFrameIOLayer(
+#             output_name,
+#             columns,
+#             parts,
+#             ParquetFunctionWrapper(
+#                 engine,
+#                 fs,
+#                 meta,
+#                 columns,
+#                 index,
+#                 {},  # All kwargs should now be in `common_kwargs`
+#                 common_kwargs,
+#             ),
+#             label=label,
+#             creation_info={
+#                 "func": read_parquet,
+#                 "args": (path,),
+#                 "kwargs": input_kwargs,
+#             },
+#         )
+#         graph = HighLevelGraph({output_name: layer}, {output_name: set()})
+
+#     return new_dd_object(graph, output_name, meta, divisions)
+
+
+# def check_multi_support(engine):
+#     # Helper function to check that the engine
+#     # supports a multi-partition read
+#     return hasattr(engine, "multi_support") and engine.multi_support()
+
+
+# def read_parquet_part(fs, engine, meta, part, columns, index, kwargs):
+#     """Read a part of a parquet dataset
+
+#     This function is used by `read_parquet`."""
+#     if isinstance(part, list):
+#         if len(part) == 1 or part[0][1] or not check_multi_support(engine):
+#             # Part kwargs expected
+#             func = engine.read_partition
+#             dfs = [
+#                 func(fs, rg, columns.copy(), index, **toolz.merge(kwargs, kw))
+#                 for (rg, kw) in part
+#             ]
+#             df = concat(dfs, axis=0) if len(dfs) > 1 else dfs[0]
+#         else:
+#             # No part specific kwargs, let engine read
+#             # list of parts at once
+#             df = engine.read_partition(
+#                 fs, [p[0] for p in part], columns.copy(), index, **kwargs
+#             )
+#     else:
+#         # NOTE: `kwargs` are the same for all parts, while `part_kwargs` may
+#         #       be different for each part.
+#         rg, part_kwargs = part
+#         df = engine.read_partition(
+#             fs, rg, columns, index, **toolz.merge(kwargs, part_kwargs)
+#         )
+
+#     if meta.columns.name:
+#         df.columns.name = meta.columns.name
+#     columns = columns or []
+#     index = index or []
+#     df = df[[c for c in columns if c not in index]]
+#     if index == [NONE_LABEL]:
+#         df.index.name = None
+#     return df

--- a/dask/dataframe/io/dataset/core.py
+++ b/dask/dataframe/io/dataset/core.py
@@ -140,7 +140,7 @@ def from_dataset(
         "filters": filters,
         "index": index,
         "engine": engine,
-        "engine_options": engine_options,
+        **engine_options,
     }
     token = tokenize(path, **input_kwargs)
     output_name = label + token

--- a/dask/dataframe/io/dataset/core.py
+++ b/dask/dataframe/io/dataset/core.py
@@ -23,8 +23,6 @@ class DatasetEngine:
         columns=None,
         filters=None,
         index=None,
-        calculate_divisions=False,
-        storage_options=None,
     ):
         """Returns required inputs to from_map"""
         raise NotImplementedError
@@ -39,9 +37,17 @@ def get_engine(engine, **engine_options):
         from dask.dataframe.io.dataset.arrow import ArrowParquetDataset
 
         return ArrowParquetDataset(**engine_options)
-    elif not isinstance(engine, DatasetEngine):
-        raise ValueError
-    return engine
+    elif isinstance(engine, DatasetEngine):
+        # DatasetEngine class is already initialized
+        if engine_options:
+            raise ValueError(
+                f"engine_options not supported if the engine is already "
+                f"intialized. Pass in the engine class name, or remove "
+                f"the engine_options: {engine_options}."
+            )
+        return engine
+
+    return engine(**engine_options)
 
 
 def from_dataset(
@@ -49,11 +55,51 @@ def from_dataset(
     columns=None,
     filters=None,
     index=None,
-    calculate_divisions=False,
     engine="pyarrow",
-    storage_options=None,
     **engine_options,
 ):
+    """Create a Dask-DataFrame collection from a stored dataset
+
+    WARNING: This API is completely unstable and experimental!!
+
+    Parameters
+    ----------
+    path : str or list
+        Source directory for data, or path(s) to individual parquet files.
+        Prefix with a protocol like ``s3://`` to read from alternative
+        filesystems. To read from multiple files you can pass a globstring or a
+        list of paths, with the caveat that they must all have the same
+        protocol.
+    columns : str or list, default None
+        Field name(s) to read in as columns in the output. By default all
+        non-index fields will be read (as determined by the pandas parquet
+        metadata, if present). Provide a single field name instead of a list to
+        read in the data as a Series.
+    filters : Union[List[Tuple[str, str, Any]], List[List[Tuple[str, str, Any]]]], default None
+        List of filters to apply, like ``[[('col1', '==', 0), ...], ...]``.
+        Predicates should be expressed in disjunctive normal form (DNF). This
+        means that the innermost tuple describes a single column predicate.
+        These inner predicates are combined with an AND conjunction into a
+        larger predicate. The outer-most list then combines all of the
+        combined filters with an OR disjunction.
+    index : str or False, default None
+        Field name to use as the output frame index. By default, the index may
+        be inferred from file metadata (if present). Use False to read all
+        fields as columns.
+    engine : str or DatasetEngine, default 'pyarrow'
+        DatasetEngine class to use. Defaults to `ArrowDataset`, which supports
+        “parquet”, “ipc”/”arrow”/”feather”, “csv”, and “orc” (the specific
+        file format should be specified with the ``format=`` argument). For
+        Parquet-formatted data, `engine="pyarrow-parquet"` is recommended
+        (which is the same as `engine=ArrowParquetDataset`).
+    **engine_options :
+        Engine-specific options to use to initialize ``engine``.
+
+    See Also
+    --------
+    dask.dataframe.io.dataset.arrow.ArrowDataset
+    dask.dataframe.io.dataset.arrow.ArrowParquetDataset
+    """
 
     # Create output-collection name
     label = "from-dataset-"
@@ -61,10 +107,8 @@ def from_dataset(
         "columns": columns,
         "filters": filters,
         "index": index,
-        "calculate_divisions": calculate_divisions,
         "engine": engine,
         "engine_options": engine_options,
-        "storage_options": storage_options,
     }
     output_name = label + tokenize(path, **input_kwargs)
 
@@ -74,11 +118,9 @@ def from_dataset(
     # Get collection-mapping information
     io_func, fragments, meta, divisions = engine.get_collection_mapping(
         path,
-        columns,
-        filters,
-        index,
-        calculate_divisions,
-        storage_options,
+        columns=columns,
+        filters=filters,
+        index=index,
     )
 
     # Special Case (Empty DataFrame)

--- a/dask/dataframe/io/dataset/core.py
+++ b/dask/dataframe/io/dataset/core.py
@@ -1,9 +1,7 @@
 from dask.base import tokenize
 from dask.dataframe.core import new_dd_object
-from dask.delayed import Delayed
 from dask.highlevelgraph import HighLevelGraph
 from dask.layers import DataFrameIOLayer
-from dask.utils import apply
 
 
 class ReadFunction:
@@ -18,12 +16,6 @@ class ReadFunction:
         raise NotImplementedError
 
 
-class DatasetSource:
-    def __init__(self, path, partition_base_dir=None):
-        self.path = path  # Directory path, file path, list of paths, or glob
-        self.partition_base_dir = partition_base_dir  # Required if this DatasetSource is part of partitioned dataset
-
-
 class DatasetEngine:
     def get_collection_mapping(
         self,
@@ -31,7 +23,6 @@ class DatasetEngine:
         columns=None,
         filters=None,
         index=None,
-        full_return=True,
     ):
         """Returns required inputs to from_map"""
         raise NotImplementedError
@@ -84,7 +75,6 @@ def from_dataset(
     filters=None,
     index=None,
     engine="pyarrow",
-    compute_options=None,
     **engine_options,
 ):
     """Create a Dask-DataFrame collection from a stored dataset
@@ -121,9 +111,6 @@ def from_dataset(
         file format should be specified with the ``format=`` argument). For
         Parquet-formatted data, `engine="pyarrow-parquet"` is recommended
         (which is the same as `engine=ArrowParquetDataset`).
-    compute_options : dict, optional
-        Dictionary of compute options for internal metadata parsing. This option
-        only applies when ``path`` is a list of ``DatasetSource`` objects.
     **engine_options :
         Engine-specific options to use to initialize ``engine``.
 
@@ -148,44 +135,13 @@ def from_dataset(
     # Get dataset engine
     engine = get_engine(engine, **(engine_options or {}))
 
-    # If path is DatasetSource, covernt to single-lngth
-    # list to execute on worker
-    if isinstance(path, DatasetSource):
-        path = [path]
-
     # Get collection-mapping information
-    if isinstance(path, list) and all(isinstance(v, DatasetSource) for v in path):
-        # We have a list of DatasetSource objects,
-        # so we can parallelize over these objects and
-        # construct the collection plan on the workers
-        meta_name = "parse-metadata-" + token
-        dsk = {}
-        for i, source in enumerate(path):
-            dsk[(meta_name, i)] = (
-                apply,
-                engine.get_collection_mapping,
-                [source],
-                {
-                    "columns": columns,
-                    "filters": filters,
-                    "index": index,
-                    "full_return": i == 0,
-                },
-            )
-        dsk["final-" + meta_name] = (_finalize_plan, list(dsk.keys()))
-        fragments, divisions, meta, io_func = Delayed(
-            "final-" + meta_name, dsk
-        ).compute(**(compute_options or {}))
-    else:
-        # Not operating on a list of DatasetSource objects,
-        # wo we will construct our collection plan on the client
-        fragments, divisions, meta, io_func = engine.get_collection_mapping(
-            path if isinstance(path, DatasetSource) else DatasetSource(path),
-            columns=columns,
-            filters=filters,
-            index=index,
-            full_return=True,
-        )
+    fragments, divisions, meta, io_func = engine.get_collection_mapping(
+        path,
+        columns=columns,
+        filters=filters,
+        index=index,
+    )
 
     # Special Case (Empty DataFrame)
     if len(divisions) < 2:

--- a/dask/dataframe/io/dataset/core.py
+++ b/dask/dataframe/io/dataset/core.py
@@ -1,240 +1,42 @@
-import pyarrow.dataset as ds
-import pyarrow.parquet as pq
-from fsspec.core import get_fs_token_paths
-
 from dask.base import tokenize
 from dask.dataframe.core import new_dd_object
 from dask.highlevelgraph import HighLevelGraph
 from dask.layers import DataFrameIOLayer
 
 
-class DatasetEngine:
-    def get_collection_mapping(
-        self, columns, filters, index, calculate_divisions, storage_options
-    ):
-        """Returns required inputs to from_map"""
-        raise NotImplementedError
-
-
-class ReadArrowFileFragment:
-    """Generic class for converting pyarrow file fragments to partitions"""
-
-    def __init__(self, columns, filters, index, dataset_options):
-        self.columns = columns
-        ds_filters = None
-        if filters is not None:
-            ds_filters = pq._filters_to_expression(filters)
-        self.filters = ds_filters
-        self.index = index
-        self.dataset_options = dataset_options
+class ReadFunction:
+    """Wrapper-function class for reading data"""
 
     def project_columns(self, columns):
         if columns == self.columns:
             return self
         return type(self)(columns, self.filters)
 
-    def __call__(self, fragment):
-        if isinstance(fragment, str):
-            df = (
-                ds.dataset(fragment, **self.dataset_options)
-                .to_table(filter=self.filters, columns=self.columns)
-                .to_pandas()
-            )
-        else:
-            df = fragment.to_table(
-                filter=self.filters, columns=self.columns
-            ).to_pandas()
-
-        if len(df.index.names) > 1:
-            # Dask-DataFrame cannot handle multi-index
-            df.reset_index(inplace=True)
-
-        if self.index and self.index != df.index.name:
-            if df.index.name is not None:
-                df.reset_index(inplace=True)
-            df.set_index(self.index, inplace=True)
-
-        if self.columns is not None:
-            return df[self.columns]
-        return df
+    def __call__(self, source):
+        raise NotImplementedError
 
 
-class ArrowDataset(DatasetEngine):
-    def __init__(
-        self,
-        partitioning="hive",
-        filesystem=None,
-        **dataset_options,
-    ):
-        self.dataset_options = dataset_options
-        self.partitioning = partitioning
-        self.filesystem = filesystem
-
-    def get_dataset(self, path, columns, filters, storage_options, mode="rb"):
-        """Returns an engine-specific dataset object"""
-
-        # Check if we already have a file-system object
-        if self.filesystem is None:
-            self.filesystem = get_fs_token_paths(
-                path, mode=mode, storage_options=storage_options
-            )[0]
-
-        return ds.dataset(
-            path,
-            partitioning=self.partitioning,
-            filesystem=self.filesystem,
-            **self.dataset_options,
-        )
-
-    def create_meta(self, dataset, index, columns):
-        """Returns an empty-DataFrame meta object"""
-
-        # Start with simple schema -> pandas mapping
-        meta = dataset.schema.empty_table().to_pandas()
-
-        # Check if we have a multi-index
-        if len(meta.index.names) > 1:
-            # Dask-DataFrame cannot handle multi-index
-            meta.reset_index(inplace=True)
-
-        # Set index if necessary
-        if index and index != meta.index.name:
-            if meta.index.name is not None:
-                meta.reset_index(inplace=True)
-            meta.set_index(index, inplace=True)
-
-        if columns is not None:
-            return meta[columns]
-        return meta
-
-    def get_read_function(self, columns, filters, index):
-        """Returns a function to convert a fragment to a DataFrame partition"""
-
-        return ReadArrowFileFragment(
-            columns,
-            filters,
-            index,
-            dataset_options={
-                "partitioning": self.partitioning,
-                "filesystem": self.filesystem,
-                **self.dataset_options,
-            },
-        )
-
-    def get_fragments(self, dataset, filters, meta, index, calculate_divisions):
-        ds_filters = None
-        if filters is not None:
-            ds_filters = pq._filters_to_expression(filters)
-        fragments = list(dataset.get_fragments(ds_filters))
-
-        if calculate_divisions:
-            raise ValueError(f"calculate_divisions=True not supported for {type(self)}")
-        return fragments, None
-
+class DatasetEngine:
     def get_collection_mapping(
-        self, path, columns, filters, index, calculate_divisions, storage_options
+        self,
+        columns=None,
+        filters=None,
+        index=None,
+        calculate_divisions=False,
+        storage_options=None,
     ):
-
-        # Get dataset
-        dataset = self.get_dataset(path, columns, filters, storage_options)
-
-        # Create meta
-        meta = self.create_meta(dataset, index, columns)
-
-        # Get fragments and divisions
-        fragments, divisions = self.get_fragments(
-            dataset, filters, meta, index, calculate_divisions
-        )
-
-        # Get IO function
-        io_func = self.get_read_function(columns, filters, index)
-
-        return io_func, fragments, meta, divisions or (None,) * (len(fragments) + 1)
-
-
-class ArrowParquetDataset(ArrowDataset):
-    def __init__(self, split_row_groups=False, **kwargs):
-        super().__init__(format="parquet", **kwargs)
-        self.split_row_groups = split_row_groups
-
-    def _caclulate_divisions(self, fragments, index):
-        divisions = None
-
-        def _stat(rg, kind):
-            val = rg.statistics.get(index, {}).get(kind, None)
-            if val is None:
-                raise ValueError(f"Missing {kind} statistic")
-            return val
-
-        def _frag_stats(frag):
-            frag_min = _stat(frag.row_groups[0], "min")
-            frag_max = _stat(frag.row_groups[0], "max")
-            for rg in frag.row_groups[1:]:
-                frag_min = min(_stat(rg, "min"), frag_min)
-                frag_max = max(_stat(rg, "max"), frag_max)
-            return frag_min, frag_max
-
-        try:
-            mins, maxes = [], []
-            frag_min, frag_max = _frag_stats(fragments[0])
-            mins.append(frag_min)
-            maxes.append(frag_max)
-            for frag in fragments[1:]:
-                frag_min, frag_max = _frag_stats(frag)
-                if frag_min < maxes[-1]:
-                    return divisions
-                mins.append(frag_min)
-                maxes.append(frag_max)
-            divisions = (mins[0],) + tuple(maxes)
-        except ValueError:
-            pass
-        return divisions
-
-    def get_fragments(self, dataset, filters, meta, index, calculate_divisions):
-
-        if index is None and len(meta.index.names) > 1:
-            index = False
-
-        file_fragments, file_divisions = super().get_fragments(
-            dataset, filters, meta, index, False
-        )
-        if self.split_row_groups:
-            raise ValueError("split_row_groups is not yet supported")
-            fragments = []
-            ds_filters = None
-            if filters is not None:
-                ds_filters = pq._filters_to_expression(filters)
-            for file_frag in file_fragments:
-                for frag in file_frag.split_by_row_group(
-                    ds_filters, schema=dataset.schema
-                ):
-                    fragments.append(frag)
-            divisions = [None] * (len(fragments) + 1)
-        else:
-            fragments = file_fragments
-            divisions = file_divisions
-
-        # For Parquet, we can convert fragments back to paths
-        # to avoid large graph sizes
-        path_fragments = [f.path for f in fragments]
-
-        # Check if we have an index column
-        # to calculate statistics for
-        if index is None and meta.index.name in dataset.schema.names:
-            index = meta.index.name
-
-        if index and calculate_divisions:
-            divisions = self._caclulate_divisions(fragments, index) or divisions
-
-        return path_fragments, divisions
+        """Returns required inputs to from_map"""
+        raise NotImplementedError
 
 
 def get_engine(engine, **engine_options):
     if engine == "pyarrow":
+        from dask.dataframe.io.dataset.arrow import ArrowDataset
+
         return ArrowDataset(**engine_options)
-    elif engine in ("orc", "pyarrow-orc"):
-        return ArrowDataset(format="orc", **engine_options)
-    elif engine in ("parquet", "pyarrow-parquet"):
+    elif engine == "pyarrow-parquet":
+        from dask.dataframe.io.dataset.arrow import ArrowParquetDataset
+
         return ArrowParquetDataset(**engine_options)
     elif not isinstance(engine, DatasetEngine):
         raise ValueError
@@ -248,8 +50,8 @@ def from_dataset(
     index=None,
     calculate_divisions=False,
     engine="pyarrow",
-    engine_options=None,
     storage_options=None,
+    **engine_options,
 ):
 
     # Create output-collection name

--- a/dask/dataframe/io/dataset/core.py
+++ b/dask/dataframe/io/dataset/core.py
@@ -49,7 +49,7 @@ class ReadArrowFileFragment:
         return df
 
 
-class ArrowEngine:
+class ArrowDataset(DatasetEngine):
     def __init__(
         self,
         partitioning="hive",
@@ -130,7 +130,7 @@ class ArrowEngine:
         return io_func, fragments, meta, divisions
 
 
-class ArrowParquetEngine(ArrowEngine):
+class ArrowParquetDataset(ArrowDataset):
     def __init__(self, **kwargs):
         super().__init__(format="parquet", **kwargs)
 
@@ -141,10 +141,12 @@ class ArrowParquetEngine(ArrowEngine):
 
 
 def get_engine(engine, **engine_options):
-    if engine in ("parquet", "pyarrow-parquet"):
-        return ArrowParquetEngine(**engine_options)
+    if engine == "pyarrow":
+        return ArrowDataset(**engine_options)
     elif engine in ("orc", "pyarrow-orc"):
-        return ArrowEngine(format="orc", **engine_options)
+        return ArrowDataset(format="orc", **engine_options)
+    elif engine in ("parquet", "pyarrow-parquet"):
+        return ArrowParquetDataset(**engine_options)
     elif not isinstance(engine, DatasetEngine):
         raise ValueError
     return engine
@@ -156,7 +158,7 @@ def from_dataset(
     filters=None,
     index=None,
     calculate_divisions=False,
-    engine="pyarrow-parquet",
+    engine="pyarrow",
     engine_options=None,
     storage_options=None,
 ):

--- a/dask/dataframe/io/dataset/core.py
+++ b/dask/dataframe/io/dataset/core.py
@@ -44,8 +44,18 @@ class ReadArrowFileFragment:
             df = fragment.to_table(
                 filter=self.filters, columns=self.columns
             ).to_pandas()
-        if self.index:
-            return df.set_index(self.index)
+
+        if len(df.index.names) > 1:
+            # Dask-DataFrame cannot handle multi-index
+            df.reset_index(inplace=True)
+
+        if self.index and self.index != df.index.name:
+            if df.index.name is not None:
+                df.reset_index(inplace=True)
+            df.set_index(self.index, inplace=True)
+
+        if self.columns is not None:
+            return df[self.columns]
         return df
 
 
@@ -76,14 +86,25 @@ class ArrowDataset(DatasetEngine):
             **self.dataset_options,
         )
 
-    def create_meta(self, dataset, index):
+    def create_meta(self, dataset, index, columns):
         """Returns an empty-DataFrame meta object"""
 
         # Start with simple schema -> pandas mapping
         meta = dataset.schema.empty_table().to_pandas()
+
+        # Check if we have a multi-index
+        if len(meta.index.names) > 1:
+            # Dask-DataFrame cannot handle multi-index
+            meta.reset_index(inplace=True)
+
         # Set index if necessary
-        if index:
-            return meta.set_index(index)
+        if index and index != meta.index.name:
+            if meta.index.name is not None:
+                meta.reset_index(inplace=True)
+            meta.set_index(index, inplace=True)
+
+        if columns is not None:
+            return meta[columns]
         return meta
 
     def get_read_function(self, columns, filters, index):
@@ -100,14 +121,15 @@ class ArrowDataset(DatasetEngine):
             },
         )
 
-    def get_fragments(self, dataset, filters):
+    def get_fragments(self, dataset, filters, meta, index, calculate_divisions):
         ds_filters = None
         if filters is not None:
             ds_filters = pq._filters_to_expression(filters)
-        return list(dataset.get_fragments(ds_filters))
+        fragments = list(dataset.get_fragments(ds_filters))
 
-    def get_divisions(self, fragments, index):
-        raise ValueError(f"calculate_divisions=True not supported for {type(self)}")
+        if calculate_divisions:
+            raise ValueError(f"calculate_divisions=True not supported for {type(self)}")
+        return fragments, None
 
     def get_collection_mapping(
         self, path, columns, filters, index, calculate_divisions, storage_options
@@ -117,31 +139,94 @@ class ArrowDataset(DatasetEngine):
         dataset = self.get_dataset(path, columns, filters, storage_options)
 
         # Create meta
-        meta = self.create_meta(dataset, index)
+        meta = self.create_meta(dataset, index, columns)
 
-        # Get fragments
-        fragments = self.get_fragments(dataset, filters)
-
-        # Extract divisions
-        if calculate_divisions:
-            divisions = self.get_divisions(fragments, index)
-        else:
-            divisions = (None,) * (len(fragments) + 1)
+        # Get fragments and divisions
+        fragments, divisions = self.get_fragments(
+            dataset, filters, meta, index, calculate_divisions
+        )
 
         # Get IO function
         io_func = self.get_read_function(columns, filters, index)
 
-        return io_func, fragments, meta, divisions
+        return io_func, fragments, meta, divisions or (None,) * (len(fragments) + 1)
 
 
 class ArrowParquetDataset(ArrowDataset):
-    def __init__(self, **kwargs):
+    def __init__(self, split_row_groups=False, **kwargs):
         super().__init__(format="parquet", **kwargs)
+        self.split_row_groups = split_row_groups
 
-    def get_fragments(self, dataset, filters):
+    def _caclulate_divisions(self, fragments, index):
+        divisions = None
+
+        def _stat(rg, kind):
+            val = rg.statistics.get(index, {}).get(kind, None)
+            if val is None:
+                raise ValueError(f"Missing {kind} statistic")
+            return val
+
+        def _frag_stats(frag):
+            frag_min = _stat(frag.row_groups[0], "min")
+            frag_max = _stat(frag.row_groups[0], "max")
+            for rg in frag.row_groups[1:]:
+                frag_min = min(_stat(rg, "min"), frag_min)
+                frag_max = max(_stat(rg, "max"), frag_max)
+            return frag_min, frag_max
+
+        try:
+            mins, maxes = [], []
+            frag_min, frag_max = _frag_stats(fragments[0])
+            mins.append(frag_min)
+            maxes.append(frag_max)
+            for frag in fragments[1:]:
+                frag_min, frag_max = _frag_stats(frag)
+                if frag_min < maxes[-1]:
+                    return divisions
+                mins.append(frag_min)
+                maxes.append(frag_max)
+            divisions = (mins[0],) + tuple(maxes)
+        except ValueError:
+            pass
+        return divisions
+
+    def get_fragments(self, dataset, filters, meta, index, calculate_divisions):
+
+        if index is None and len(meta.index.names) > 1:
+            index = False
+
+        file_fragments, file_divisions = super().get_fragments(
+            dataset, filters, meta, index, False
+        )
+        if self.split_row_groups:
+            raise ValueError("split_row_groups is not yet supported")
+            fragments = []
+            ds_filters = None
+            if filters is not None:
+                ds_filters = pq._filters_to_expression(filters)
+            for file_frag in file_fragments:
+                for frag in file_frag.split_by_row_group(
+                    ds_filters, schema=dataset.schema
+                ):
+                    fragments.append(frag)
+            divisions = [None] * (len(fragments) + 1)
+        else:
+            fragments = file_fragments
+            divisions = file_divisions
+
         # For Parquet, we can convert fragments back to paths
         # to avoid large graph sizes
-        return [f.path for f in super().get_fragments(dataset, filters)]
+        path_fragments = [f.path for f in fragments]
+
+        # Check if we have an index column
+        # to calculate statistics for
+        if index is None and meta.index.name in dataset.schema.names:
+            index = meta.index.name
+
+        if index and calculate_divisions:
+            divisions = self._caclulate_divisions(fragments, index) or divisions
+
+        return path_fragments, divisions
 
 
 def get_engine(engine, **engine_options):


### PR DESCRIPTION
 **WARNING: Very much a WIP - Do not merge!**

This PR adds an experimental `from_dataset` API for reading general on-disk tabular data into a Dask-DataFrame collection. This PR only adds engines based on the `pyarrow.dataset` API, but they already support Parquet, ORC, Feather / Arrow IPC, and CSV (and other engines can certainly be added).  My primary goal is to come up with a single **scalable** design for tabular data formats like Parquet.  I am hoping to use this code base as a "sandbox" for exploring the best default settings and algorithms for reading formats like Parquet. 

One **possible** (but far-off) outcome of this work is that the current `read_parquet` implementation could be refactored to simply call `from_dataset`.  However, such a move would require us to (1) revise/simplify default arguments and features in read_parquet until they are aligned with those in from_dataset, and (2) ultimately deprecate the existing Engine classes used in `dd.io.parquet` (no small task).

So... **Why not just explore defaults and algorithms in the existing `read_parquet` code?**

The simple answer to this is that the current `read_parquet` design is no-longer well-suited for the `Engine` classes it is meant to support.  When the "pluggable" `Engine` design was first implemented (nearly three years ago), there was no `pyarrow.dataset` API, and even cudf and  fastparquet had very different features and limitations.  For example, at the time, none of the Engines supported row-group or row-wise filtering, and so the engine-agnostic `read_parquet` code was written in a way that is inefficient when the engine actual **can** take care of file/row-group filtering. Another “pain point” is that requiring the Engine to expose multiple “static”/“class” methods requires a giant dictionary of options to be passed all over the code base (creating an apparent “spaghetti code” situation).

In contrast to the current `read_parquet` organization, I think it makes a lot more sense for the `Engine` to operate as an “object” (not as a class), and for the engine-agnostic code to simply ask the engine to return everything it needs to generate the new collection (an IO function, meta, a list of IO-function inputs, and divisions).  This way, all engine-specific options can be clearly documented and validated at the engine level, and the engine can use temporary “state” to avoid passing around a laundry-list of options everywhere.

To clarify, I propose that the top-level function only support a very limited set of options. In fact, I don’t believe that the engine-agnostic code should do **any** path/filesystem handling at all.  The top-level API should only include a minimum set of common options (and the engine can still raise an error for something like `calculate_divisions=True` for formats without min/max statistics support):  

```python
def from_dataset(
    path,
    columns=None,
    filters=None,
    index=None,
    calculate_divisions=False,  # To avoid the need for `gather_statistics`
    engine="pyarrow",
    **engine_options,  # ALL other options belong to the engine itself
):
```

For example, the current (still in flux) docstring is:

```python
    """Create a Dask-DataFrame collection from a stored dataset

    WARNING: This API is completely unstable and experimental!!

    Parameters
    ----------
    path : str or list[str] or list[list[str]]
        Source directory for data, or path(s) to individual parquet files.
        Prefix with a protocol like ``s3://`` to read from alternative
        filesystems. To read from multiple files you can pass a list of paths,
        with the caveat that they must all have the same protocol. In order to
        directly map groups of files to output dataframe partitions, ``path``
        may also be a list of path lists. In this case, the paths within each
        inner list will be aggregated into the same output partition.
    columns : str or list, default None
        Field name(s) to read in as columns in the output. By default all
        non-index fields will be read (as determined by the pandas parquet
        metadata, if present). Provide a single field name instead of a list to
        read in the data as a Series.
    filters : Union[List[Tuple[str, str, Any]], List[List[Tuple[str, str, Any]]]], default None
        List of filters to apply, like ``[[('col1', '==', 0), ...], ...]``.
        Predicates should be expressed in disjunctive normal form (DNF). This
        means that the innermost tuple describes a single column predicate.
        These inner predicates are combined with an AND conjunction into a
        larger predicate. The outer-most list then combines all of the
        combined filters with an OR disjunction.
    index : str or False, default None
        Field name to use as the output frame index. By default, the index may
        be inferred from file metadata (if present). Use False to read all
        fields as columns.
    calculate_divisions : bool, default False
        Whether parquet metadata should be used to calculate output divisions.
        This argument will be ignored if there is no active index column.
        WARNING: Setting this option to True may be expensive for large datasets
        stored in remote storage!
    engine : str or DatasetEngine, default 'pyarrow'
        DatasetEngine class to use. Defaults to `ArrowDataset`, which supports
        “parquet”, “ipc”/”arrow”/”feather”, “csv”, and “orc” (the specific
        file format should be specified with the ``format=`` argument). For
        Parquet-formatted data, `engine="pyarrow-parquet"` is recommended
        (which is the same as `engine=ArrowParquetDataset`).
    **engine_options :
        Engine-specific options to use to initialize ``engine``.

    See Also
    --------
    dask.dataframe.io.dataset.arrow.ArrowDataset
    dask.dataframe.io.dataset.arrow.ArrowParquetDataset
    """
```