### PR TITLE
Raise an error if you try to use `vindex` with a dask object

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1929,6 +1929,11 @@ class Array(DaskMethodsMixin):
                 "when the slices are not over the entire array (i.e, x[:]). "
                 "Use normal slicing instead when only using slices. Got: {}".format(key)
             )
+        elif any(is_dask_collection(k) for k in key):
+            raise IndexError(
+                "vindex does not support indexing with dask objects. Call compute "
+                "on the indexer first to get an evalurated array. Got: {}".format(key)
+            )
         return _vindex(self, *key)
 
     @property

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3143,6 +3143,8 @@ def test_vindex_errors():
     pytest.raises(IndexError, lambda: d.vindex[[True] * 5])
     pytest.raises(IndexError, lambda: d.vindex[[0], [5]])
     pytest.raises(IndexError, lambda: d.vindex[[0], [-6]])
+    with pytest.raises(IndexError, match="does not support indexing with dask objects"):
+        d.vindex[[0], [0], da.array([0])]
 
 
 def test_vindex_merge():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -7,6 +7,7 @@ from numbers import Number
 import pytest
 from numpy import AxisError
 
+import dask
 from dask.delayed import delayed
 
 np = pytest.importorskip("numpy")
@@ -2012,7 +2013,7 @@ def test_unravel_index():
         for i in range(len(indices)):
             assert_eq(d_indices[i], indices[i])
 
-        assert_eq(darr.vindex[d_indices], arr[indices])
+        assert_eq(darr.vindex[dask.compute(*d_indices)], arr[indices])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [ ] Closes #8928
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
