### PR TITLE
Use pre_buffer=True for "pyarrow" parquet engine

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -221,14 +221,14 @@ def _read_table_from_path(
         **open_file_options,
     )[0] as fil:
         if row_groups == [None]:
-            return pq.ParquetFile(fil).read(
+            return pq.ParquetFile(fil, pre_buffer=True).read(
                 columns=columns,
                 use_threads=False,
                 use_pandas_metadata=True,
                 **read_kwargs,
             )
         else:
-            return pq.ParquetFile(fil).read_row_groups(
+            return pq.ParquetFile(fil, pre_buffer=True).read_row_groups(
                 row_groups,
                 columns=columns,
                 use_threads=False,

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -214,6 +214,7 @@ def _read_table_from_path(
         ),
     )
 
+    pre_buffer = read_kwargs.pop("pre_buffer", True)
     with _open_input_files(
         [path],
         fs=fs,
@@ -221,14 +222,14 @@ def _read_table_from_path(
         **open_file_options,
     )[0] as fil:
         if row_groups == [None]:
-            return pq.ParquetFile(fil, pre_buffer=True).read(
+            return pq.ParquetFile(fil, pre_buffer=pre_buffer).read(
                 columns=columns,
                 use_threads=False,
                 use_pandas_metadata=True,
                 **read_kwargs,
             )
         else:
-            return pq.ParquetFile(fil, pre_buffer=True).read_row_groups(
+            return pq.ParquetFile(fil, pre_buffer=pre_buffer).read_row_groups(
                 row_groups,
                 columns=columns,
                 use_threads=False,


### PR DESCRIPTION
Thanks to @ian-r-rose for writing up #8946 - I was able to investigate the differences between `pq.ParquetFile` and `pq.to_table`, and found that the most important difference is that `pq.to_table` **always** sets `pre_buffer=True`, while `pq.ParquetFile` does not. The pyarrow documentation for `pre_buffer` is:

>Coalesce and issue file reads in parallel to improve performance on high-latency filesystems (e.g. S3). If True, Arrow will use a background I/O thread pool.

This PR simply makes `pre_buffer=True` the default for internal `pq.ParquetFile` usage.  The user is technically still able to set this option to `False` by passing `read={"pre_buffer":  False}` to `read_parquet`, but it seems that `pre_buffer=True` should be *fine* for most (if not all) cases.

- [x] Closes #8946
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
