### PR TITLE
Handle `dtype=None` correctly in `da.full`

### DIFF
--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -59,6 +59,11 @@ def test_full_detects_da_dtype():
     assert len(record) == 1
 
 
+def test_full_none_dtype():
+    a = da.full(shape=(3, 3), fill_value=100, dtype=None)
+    assert_eq(a, np.full(shape=(3, 3), fill_value=100, dtype=None))
+
+
 def test_full_like_error_nonscalar_fill_value():
     x = np.full((3, 3), 1, dtype="i8")
     with pytest.raises(ValueError, match="fill_value must be scalar"):

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -192,7 +192,7 @@ def full(shape, fill_value, *args, **kwargs):
         raise ValueError(
             f"fill_value must be scalar. Received {type(fill_value).__name__} instead."
         )
-    if "dtype" not in kwargs:
+    if kwargs.get("dtype", None) is None:
         if hasattr(fill_value, "dtype"):
             kwargs["dtype"] = fill_value.dtype
         else:


### PR DESCRIPTION
- [x] Closes #8947
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
