### PR TITLE
Add copy button to docs

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -2,6 +2,7 @@ numpydoc
 sphinx>=4.0.0
 dask-sphinx-theme>=2.0.3
 sphinx-click
+sphinx-copybutton
 sphinx-remove-toctrees
 sphinx_autosummary_accessors
 sphinx-tabs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,7 +47,11 @@ extensions = [
     "sphinx_remove_toctrees",
     "IPython.sphinxext.ipython_console_highlighting",
     "IPython.sphinxext.ipython_directive",
+    "sphinx_copybutton",
 ]
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 numpydoc_show_class_members = False
 


### PR DESCRIPTION
This uses `sphinx-copybutton` to add a copy button to our code snippets throughout the docs

<img width="1552" alt="Screen Shot 2022-04-20 at 10 19 24 AM" src="https://user-images.githubusercontent.com/11656932/164265290-9c3d19a1-8aa6-4b90-a5a8-f6a4dd3c057c.png">
 