### PR TITLE
Avoid pre_buffer=True when an fsspec precache method is specified

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -215,11 +215,16 @@ def _read_table_from_path(
         ),
     )
 
+    # Use `pre_buffer=True` if the option is supported and an optimized
+    # "pre-caching" method isn't already specified in `precache_options`
+    # (The distinct fsspec and pyarrow optimizations will conflict)
+    pre_buffer_default = precache_options.get("method", None) is None
     pre_buffer = (
-        {"pre_buffer": read_kwargs.pop("pre_buffer", True)}
+        {"pre_buffer": read_kwargs.pop("pre_buffer", pre_buffer_default)}
         if pre_buffer_supported
         else {}
     )
+
     with _open_input_files(
         [path],
         fs=fs,


### PR DESCRIPTION
This is a small follow-up to #8952, where the `pre_buffer=True` option was added to the "pyarrow" parquet engine.
After that PR was merged, I was experimenting with fsspec pre-caching (by adding `open_file_options={"precache_options": {"method": "parquet"}}` to the `dd.read_parquet` call to the benchmark code in #8946), and I ran into an Error:

```
2022-04-20 10:23:45,599 - distributed.worker - WARNING - Compute Failed
Key:       ('read-parquet-1cf5073fb5ff1c76f997f0383e69073f', 0)
Function:  subgraph_callable-7500d0e9-22a1-4851-b868-712f9b34
args:      ({'piece': ('ursa-labs-taxi-data/2009/01/data.parquet', None, None)})
kwargs:    {}
Exception: 'OSError("Couldn\'t deserialize thrift: TProtocolException: Invalid data\\nDeserializing page header failed.\\n")'
```

It seems that pyarrow's pre_buffer optimization does not play well with fsspec's `open_paruqet_file` code path. Therefore, this PR adds a small change to check the `precache_options` dict before setting `pre_buffer` to `True`.

Note that I am not sure if there is a reasonable to add test coverage for this change. The existing `open_file_options` test in `test_s3.py` did not catch the bug, so it may be difficult to reproduce the motivating bug with small/toy data.