### PR TITLE
Prevent nulls in index for non-numeric dtypes

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4391,7 +4391,9 @@ class DataFrame(_Frame):
             this can be expensive.
             Note that if ``sorted=True``, specified divisions are assumed to match
             the existing partitions in the data; if this is untrue you should
-            leave divisi := e DataFrame in place is not supported by Dask.
+            leave divisions empty and call ``repartition`` after ``set_index``.
+        inplace: bool, optional
+            Modifying the DataFrame in place is not supported by Dask.
             Defaults to False.
         shuffle: string, 'disk' or 'tasks', optional
             Either ``'disk'`` for single-node operation or ``'tasks'`` for

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -93,7 +93,9 @@ def _numeric_only(func):
     def wrapper(self, *args, **kwargs):
         # numeric_only is None by default - in that case self = self.
         if kwargs.get("numeric_only") is False:
-            raise NotImplementedError("'numeric_only=False' is not implemented in Dask.")
+            raise NotImplementedError(
+                "'numeric_only=False' is not implemented in Dask."
+            )
         elif kwargs.get("numeric_only") is True:
             self = self._get_numeric_data()
         return func(self, *args, **kwargs)
@@ -116,7 +118,11 @@ def _concat(args, ignore_index=False):
     # Ideally this would be handled locally for each operation, but in practice
     # this seems easier. TODO: don't do this.
     args2 = [i for i in args if len(i)]
-    return args[0] if not args2 else methods.concat(args2, uniform=True, ignore_index=ignore_index)
+    return (
+        args[0]
+        if not args2
+        else methods.concat(args2, uniform=True, ignore_index=ignore_index)
+    )
 
 
 def finalize(results):
@@ -137,7 +143,9 @@ class Scalar(DaskMethodsMixin, OperatorMethodMixin):
 
         meta = make_meta(meta, parent_meta=self._parent_meta)
         if is_dataframe_like(meta) or is_series_like(meta) or is_index_like(meta):
-            raise TypeError(f"Expected meta to specify scalar, got {typename(type(meta))}")
+            raise TypeError(
+                f"Expected meta to specify scalar, got {typename(type(meta))}"
+            )
         self._meta = meta
 
     def __dask_graph__(self):
@@ -152,7 +160,9 @@ class Scalar(DaskMethodsMixin, OperatorMethodMixin):
     def __dask_layers__(self):
         return (self._name,)
 
-    __dask_optimize__ = globalmethod(optimize, key="dataframe_optimize", falsey=dont_optimize)
+    __dask_optimize__ = globalmethod(
+        optimize, key="dataframe_optimize", falsey=dont_optimize
+    )
     __dask_scheduler__ = staticmethod(threaded.get)
 
     def __dask_postcompute__(self):
@@ -271,7 +281,9 @@ def _scalar_binary(op, self, other, inv=False):
     else:
         other_key = other
 
-    dsk[(name, 0)] = (op, other_key, (self._name, 0)) if inv else (op, (self._name, 0), other_key)
+    dsk[(name, 0)] = (
+        (op, other_key, (self._name, 0)) if inv else (op, (self._name, 0), other_key)
+    )
 
     other_meta = make_meta(other, parent_meta=self._parent_meta)
     other_meta_nonempty = meta_nonempty(other_meta)
@@ -312,7 +324,8 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
         meta = make_meta(meta)
         if not self._is_partition_type(meta):
             raise TypeError(
-                f"Expected meta to specify type {type(self).__name__}, got type " f"{typename(type(meta))}"
+                f"Expected meta to specify type {type(self).__name__}, got type "
+                f"{typename(type(meta))}"
             )
         self._meta = meta
         self.divisions = tuple(divisions)
@@ -329,7 +342,9 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
     def __dask_tokenize__(self):
         return self._name
 
-    __dask_optimize__ = globalmethod(optimize, key="dataframe_optimize", falsey=dont_optimize)
+    __dask_optimize__ = globalmethod(
+        optimize, key="dataframe_optimize", falsey=dont_optimize
+    )
     __dask_scheduler__ = staticmethod(threaded.get)
 
     def __dask_postcompute__(self):
@@ -386,7 +401,9 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
 
         if None in value:
             if any(v is not None for v in value):
-                raise ValueError("divisions may not contain a mix of None and non-None values")
+                raise ValueError(
+                    "divisions may not contain a mix of None and non-None values"
+                )
         else:
             # Known divisions, check monotonically increasing
 
@@ -422,7 +439,9 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
         >>> series.size  # doctest: +SKIP
         dd.Scalar<size-ag..., dtype=int64>
         """
-        return self.reduction(methods.size, np.sum, token="size", meta=int, split_every=False)
+        return self.reduction(
+            methods.size, np.sum, token="size", meta=int, split_every=False
+        )
 
     @property
     def _meta_nonempty(self):
@@ -473,7 +492,9 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
             # so we don't want to raise NotImplemented
             if isinstance(x, np.ndarray) and x.shape == ():
                 continue
-            elif not isinstance(x, (Number, Scalar, _Frame, Array, pd.DataFrame, pd.Series, pd.Index)):
+            elif not isinstance(
+                x, (Number, Scalar, _Frame, Array, pd.DataFrame, pd.Series, pd.Index)
+            ):
                 return NotImplemented
 
         if method == "__call__":
@@ -535,7 +556,9 @@ Dask Name: {name}, {task} tasks"""
     @index.setter
     def index(self, value):
         self.divisions = value.divisions
-        result = map_partitions(methods.assign_index, self, value, enforce_metadata=False)
+        result = map_partitions(
+            methods.assign_index, self, value, enforce_metadata=False
+        )
         self.dask = result.dask
         self._name = result._name
         self._meta = result._meta
@@ -560,7 +583,9 @@ Dask Name: {name}, {task} tasks"""
         drop : boolean, default False
             Do not try to insert index into dataframe columns.
         """
-        return self.map_partitions(M.reset_index, drop=drop, enforce_metadata=False).clear_divisions()
+        return self.map_partitions(
+            M.reset_index, drop=drop, enforce_metadata=False
+        ).clear_divisions()
 
     @property
     def known_divisions(self):
@@ -641,7 +666,9 @@ Dask Name: {name}, {task} tasks"""
             raise ValueError(msg)
 
     @derived_from(pd.DataFrame)
-    def drop_duplicates(self, subset=None, split_every=None, split_out=1, ignore_index=False, **kwargs):
+    def drop_duplicates(
+        self, subset=None, split_every=None, split_out=1, ignore_index=False, **kwargs
+    ):
         if subset is not None:
             # Let pandas error on bad inputs
             self._meta_nonempty.drop_duplicates(subset=subset, **kwargs)
@@ -671,10 +698,15 @@ Dask Name: {name}, {task} tasks"""
         )
 
     def __len__(self):
-        return self.reduction(len, np.sum, token="len", meta=int, split_every=False).compute()
+        return self.reduction(
+            len, np.sum, token="len", meta=int, split_every=False
+        ).compute()
 
     def __bool__(self):
-        raise ValueError(f"The truth value of a {self.__class__.__name__} is ambiguous. " "Use a.any() or a.all().")
+        raise ValueError(
+            f"The truth value of a {self.__class__.__name__} is ambiguous. "
+            "Use a.any() or a.all()."
+        )
 
     __nonzero__ = __bool__  # python 2
 
@@ -943,7 +975,9 @@ Dask Name: {name}, {task} tasks"""
             A Series whose index is the partition number and whose values
             are the memory usage of each partition in bytes.
         """
-        return self.map_partitions(total_mem_usage, index=index, deep=deep).clear_divisions()
+        return self.map_partitions(
+            total_mem_usage, index=index, deep=deep
+        ).clear_divisions()
 
     @insert_meta_param_description(pad=12)
     def reduction(
@@ -1097,7 +1131,9 @@ Dask Name: {name}, {task} tasks"""
         if isinstance(func, tuple):
             func, target = func
             if target in kwargs:
-                raise ValueError("%s is both the pipe target and a keyword argument" % target)
+                raise ValueError(
+                    "%s is both the pipe target and a keyword argument" % target
+                )
             kwargs[target] = self
             return func(*args, **kwargs)
         else:
@@ -1137,13 +1173,20 @@ Dask Name: {name}, {task} tasks"""
         state_data = random_state_data(self.npartitions, random_state)
         token = tokenize(self, frac, random_state)
         name = "split-" + token
-        layer = {(name, i): (pd_split, (self._name, i), frac, state, shuffle) for i, state in enumerate(state_data)}
+        layer = {
+            (name, i): (pd_split, (self._name, i), frac, state, shuffle)
+            for i, state in enumerate(state_data)
+        }
 
         out = []
         for i in range(len(frac)):
             name2 = "split-%d-%s" % (i, token)
-            dsk2 = {(name2, j): (getitem, (name, j), i) for j in range(self.npartitions)}
-            graph = HighLevelGraph.from_collections(name2, merge(dsk2, layer), dependencies=[self])
+            dsk2 = {
+                (name2, j): (getitem, (name, j), i) for j in range(self.npartitions)
+            }
+            graph = HighLevelGraph.from_collections(
+                name2, merge(dsk2, layer), dependencies=[self]
+            )
             out_df = type(self)(graph, name2, self._meta, self.divisions)
             out.append(out_df)
         return out
@@ -1173,7 +1216,9 @@ Dask Name: {name}, {task} tasks"""
         if npartitions <= -1:
             npartitions = self.npartitions
         if npartitions > self.npartitions:
-            raise ValueError(f"only {self.npartitions} partitions, head received {npartitions}")
+            raise ValueError(
+                f"only {self.npartitions} partitions, head received {npartitions}"
+            )
 
         name = f"head-{npartitions}-{n}-{self._name}"
         if safe:
@@ -1194,7 +1239,9 @@ Dask Name: {name}, {task} tasks"""
             dsk = {(name, 0): (head, (self._name, 0), n)}
 
         graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
-        result = new_dd_object(graph, name, self._meta, [self.divisions[0], self.divisions[npartitions]])
+        result = new_dd_object(
+            graph, name, self._meta, [self.divisions[0], self.divisions[npartitions]]
+        )
 
         if compute:
             result = result.compute()
@@ -1236,7 +1283,9 @@ Dask Name: {name}, {task} tasks"""
         name = "blocks-" + tokenize(self, index)
         new_keys = np.array(self.__dask_keys__(), dtype=object)[index].tolist()
 
-        divisions = [self.divisions[i] for _, i in new_keys] + [self.divisions[new_keys[-1][1] + 1]]
+        divisions = [self.divisions[i] for _, i in new_keys] + [
+            self.divisions[new_keys[-1][1] + 1]
+        ]
         dsk = {(name, i): tuple(key) for i, key in enumerate(new_keys)}
 
         graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
@@ -1424,7 +1473,9 @@ Dask Name: {name}, {task} tasks"""
             test_value = value._meta_nonempty
         else:
             test_value = value
-        meta = self._meta_nonempty.fillna(value=test_value, method=method, limit=limit, axis=axis)
+        meta = self._meta_nonempty.fillna(
+            value=test_value, method=method, limit=limit, axis=axis
+        )
 
         if axis == 1 or method is None:
             # Control whether or not dask's partition alignment happens.
@@ -1472,7 +1523,9 @@ Dask Name: {name}, {task} tasks"""
         else:
             parts = self
 
-        return parts.map_overlap(M.fillna, before, after, method=method, limit=limit, meta=meta)
+        return parts.map_overlap(
+            M.fillna, before, after, method=method, limit=limit, meta=meta
+        )
 
     @derived_from(pd.DataFrame)
     def ffill(self, axis=None, limit=None):
@@ -1529,7 +1582,8 @@ Dask Name: {name}, {task} tasks"""
 
         state_data = random_state_data(self.npartitions, random_state)
         dsk = {
-            (name, i): (methods.sample, (self._name, i), state, frac, replace) for i, state in enumerate(state_data)
+            (name, i): (methods.sample, (self._name, i), state, frac, replace)
+            for i, state in enumerate(state_data)
         }
 
         graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
@@ -1739,7 +1793,9 @@ Dask Name: {name}, {task} tasks"""
             raise TypeError("periods must be an integer")
 
         if axis == 1:
-            return self.map_partitions(M.diff, token="diff", periods=periods, axis=1, enforce_metadata=False)
+            return self.map_partitions(
+                M.diff, token="diff", periods=periods, axis=1, enforce_metadata=False
+            )
 
         before, after = (periods, 0) if periods > 0 else (0, -periods)
         return self.map_overlap(M.diff, before, after, token="diff", periods=periods)
@@ -1762,7 +1818,9 @@ Dask Name: {name}, {task} tasks"""
 
         if freq is None:
             before, after = (periods, 0) if periods > 0 else (0, -periods)
-            return self.map_overlap(M.shift, before, after, token="shift", periods=periods)
+            return self.map_overlap(
+                M.shift, before, after, token="shift", periods=periods
+            )
 
         # Let pandas error on invalid arguments
         meta = self._meta_nonempty.shift(periods, freq=freq)
@@ -1785,7 +1843,9 @@ Dask Name: {name}, {task} tasks"""
 
         method = getattr(M, name)
         if axis == 1:
-            result = self.map_partitions(method, meta=meta, token=token, skipna=skipna, axis=axis)
+            result = self.map_partitions(
+                method, meta=meta, token=token, skipna=skipna, axis=axis
+            )
             return handle_out(out, result)
         else:
             result = self.reduction(
@@ -1822,11 +1882,15 @@ Dask Name: {name}, {task} tasks"""
 
     @derived_from(pd.DataFrame)
     def all(self, axis=None, skipna=True, split_every=False, out=None):
-        return self._reduction_agg("all", axis=axis, skipna=skipna, split_every=split_every, out=out)
+        return self._reduction_agg(
+            "all", axis=axis, skipna=skipna, split_every=split_every, out=out
+        )
 
     @derived_from(pd.DataFrame)
     def any(self, axis=None, skipna=True, split_every=False, out=None):
-        return self._reduction_agg("any", axis=axis, skipna=skipna, split_every=split_every, out=out)
+        return self._reduction_agg(
+            "any", axis=axis, skipna=skipna, split_every=split_every, out=out
+        )
 
     @_numeric_only
     @derived_from(pd.DataFrame)
@@ -1840,13 +1904,17 @@ Dask Name: {name}, {task} tasks"""
         min_count=None,
         numeric_only=None,
     ):
-        result = self._reduction_agg("sum", axis=axis, skipna=skipna, split_every=split_every, out=out)
+        result = self._reduction_agg(
+            "sum", axis=axis, skipna=skipna, split_every=split_every, out=out
+        )
         if min_count:
             cond = self.notnull().sum(axis=axis) >= min_count
             if is_series_like(cond):
                 return result.where(cond, other=np.NaN)
             else:
-                return _scalar_binary(lambda x, y: result if x is y else np.NaN, cond, True)
+                return _scalar_binary(
+                    lambda x, y: result if x is y else np.NaN, cond, True
+                )
         else:
             return result
 
@@ -1862,13 +1930,17 @@ Dask Name: {name}, {task} tasks"""
         min_count=None,
         numeric_only=None,
     ):
-        result = self._reduction_agg("prod", axis=axis, skipna=skipna, split_every=split_every, out=out)
+        result = self._reduction_agg(
+            "prod", axis=axis, skipna=skipna, split_every=split_every, out=out
+        )
         if min_count:
             cond = self.notnull().sum(axis=axis) >= min_count
             if is_series_like(cond):
                 return result.where(cond, other=np.NaN)
             else:
-                return _scalar_binary(lambda x, y: result if x is y else np.NaN, cond, True)
+                return _scalar_binary(
+                    lambda x, y: result if x is y else np.NaN, cond, True
+                )
         else:
             return result
 
@@ -1876,13 +1948,21 @@ Dask Name: {name}, {task} tasks"""
 
     @_numeric_only
     @derived_from(pd.DataFrame)
-    def max(self, axis=None, skipna=True, split_every=False, out=None, numeric_only=None):
-        return self._reduction_agg("max", axis=axis, skipna=skipna, split_every=split_every, out=out)
+    def max(
+        self, axis=None, skipna=True, split_every=False, out=None, numeric_only=None
+    ):
+        return self._reduction_agg(
+            "max", axis=axis, skipna=skipna, split_every=split_every, out=out
+        )
 
     @_numeric_only
     @derived_from(pd.DataFrame)
-    def min(self, axis=None, skipna=True, split_every=False, out=None, numeric_only=None):
-        return self._reduction_agg("min", axis=axis, skipna=skipna, split_every=split_every, out=out)
+    def min(
+        self, axis=None, skipna=True, split_every=False, out=None, numeric_only=None
+    ):
+        return self._reduction_agg(
+            "min", axis=axis, skipna=skipna, split_every=split_every, out=out
+        )
 
     @derived_from(pd.DataFrame)
     def idxmax(self, axis=None, skipna=True, split_every=False):
@@ -1957,7 +2037,9 @@ Dask Name: {name}, {task} tasks"""
         token = self._token_prefix + "count"
         if axis == 1:
             meta = self._meta_nonempty.count(axis=axis)
-            return self.map_partitions(M.count, meta=meta, token=token, axis=axis, enforce_metadata=False)
+            return self.map_partitions(
+                M.count, meta=meta, token=token, axis=axis, enforce_metadata=False
+            )
         else:
             meta = self._meta_nonempty.count()
 
@@ -2089,17 +2171,22 @@ Dask Name: {name}, {task} tasks"""
         layer = {(name, 0): (methods.wrap_var_reduction, array_var_name, cols)}
         graph = HighLevelGraph.from_collections(name, layer, dependencies=[array_var])
 
-        return new_dd_object(graph, name, num._meta_nonempty.var(), divisions=[None, None])
+        return new_dd_object(
+            graph, name, num._meta_nonempty.var(), divisions=[None, None]
+        )
 
     def _var_timedeltas(self, skipna=True, ddof=1, split_every=False):
         timedeltas = self.select_dtypes(include=[np.timedelta64])
 
         var_timedeltas = [
-            self._var_1d(timedeltas[col_idx], skipna, ddof, split_every) for col_idx in timedeltas._meta.columns
+            self._var_1d(timedeltas[col_idx], skipna, ddof, split_every)
+            for col_idx in timedeltas._meta.columns
         ]
         var_timedelta_names = [(v._name, 0) for v in var_timedeltas]
 
-        name = self._token_prefix + "var-timedeltas-" + tokenize(timedeltas, split_every)
+        name = (
+            self._token_prefix + "var-timedeltas-" + tokenize(timedeltas, split_every)
+        )
 
         layer = {
             (name, 0): (
@@ -2108,9 +2195,13 @@ Dask Name: {name}, {task} tasks"""
                 timedeltas._meta.columns,
             )
         }
-        graph = HighLevelGraph.from_collections(name, layer, dependencies=var_timedeltas)
+        graph = HighLevelGraph.from_collections(
+            name, layer, dependencies=var_timedeltas
+        )
 
-        return new_dd_object(graph, name, timedeltas._meta_nonempty.var(), divisions=[None, None])
+        return new_dd_object(
+            graph, name, timedeltas._meta_nonempty.var(), divisions=[None, None]
+        )
 
     def _var_mixed(self, skipna=True, ddof=1, split_every=False):
         data = self.select_dtypes(include=["number", "bool", np.timedelta64])
@@ -2129,8 +2220,12 @@ Dask Name: {name}, {task} tasks"""
             )
         }
 
-        graph = HighLevelGraph.from_collections(name, layer, dependencies=[numeric_vars, timedelta_vars])
-        return new_dd_object(graph, name, self._meta_nonempty.var(), divisions=[None, None])
+        graph = HighLevelGraph.from_collections(
+            name, layer, dependencies=[numeric_vars, timedelta_vars]
+        )
+        return new_dd_object(
+            graph, name, self._meta_nonempty.var(), divisions=[None, None]
+        )
 
     def _var_1d(self, column, skipna=True, ddof=1, split_every=False):
         is_timedelta = is_timedelta64_dtype(column._meta)
@@ -2157,7 +2252,9 @@ Dask Name: {name}, {task} tasks"""
         layer = {(name, 0): (methods.wrap_var_reduction, (array_var._name,), None)}
         graph = HighLevelGraph.from_collections(name, layer, dependencies=[array_var])
 
-        return new_dd_object(graph, name, column._meta_nonempty.var(), divisions=[None, None])
+        return new_dd_object(
+            graph, name, column._meta_nonempty.var(), divisions=[None, None]
+        )
 
     @_numeric_only
     @derived_from(pd.DataFrame)
@@ -2269,7 +2366,9 @@ Dask Name: {name}, {task} tasks"""
 
     @_numeric_only
     @derived_from(pd.DataFrame)
-    def skew(self, axis=None, bias=True, nan_policy="propagate", out=None, numeric_only=None):
+    def skew(
+        self, axis=None, bias=True, nan_policy="propagate", out=None, numeric_only=None
+    ):
         """
         .. note::
 
@@ -2324,12 +2423,16 @@ Dask Name: {name}, {task} tasks"""
 
         name = self._token_prefix + "skew-1d-" + tokenize(column)
 
-        array_skew = da_stats.skew(column.values, axis=0, bias=bias, nan_policy=nan_policy)
+        array_skew = da_stats.skew(
+            column.values, axis=0, bias=bias, nan_policy=nan_policy
+        )
 
         layer = {(name, 0): (methods.wrap_skew_reduction, (array_skew._name,), None)}
         graph = HighLevelGraph.from_collections(name, layer, dependencies=[array_skew])
 
-        return new_dd_object(graph, name, column._meta_nonempty.skew(), divisions=[None, None])
+        return new_dd_object(
+            graph, name, column._meta_nonempty.skew(), divisions=[None, None]
+        )
 
     def _skew_numeric(self, bias=True, nan_policy="propagate"):
         """Method for dataframes with numeric columns.
@@ -2347,7 +2450,9 @@ Dask Name: {name}, {task} tasks"""
         if not np.issubdtype(values_dtype, np.number):
             array_values = num.values.astype("f8")
 
-        array_skew = da_stats.skew(array_values, axis=0, bias=bias, nan_policy=nan_policy)
+        array_skew = da_stats.skew(
+            array_values, axis=0, bias=bias, nan_policy=nan_policy
+        )
 
         name = self._token_prefix + "var-numeric" + tokenize(num)
         cols = num._meta.columns if is_dataframe_like(num) else None
@@ -2358,7 +2463,9 @@ Dask Name: {name}, {task} tasks"""
         layer = {(name, 0): (methods.wrap_skew_reduction, array_skew_name, cols)}
         graph = HighLevelGraph.from_collections(name, layer, dependencies=[array_skew])
 
-        return new_dd_object(graph, name, num._meta_nonempty.skew(), divisions=[None, None])
+        return new_dd_object(
+            graph, name, num._meta_nonempty.skew(), divisions=[None, None]
+        )
 
     @_numeric_only
     @derived_from(pd.DataFrame)
@@ -2398,10 +2505,14 @@ Dask Name: {name}, {task} tasks"""
             return handle_out(out, result)
         else:
             if self.ndim == 1:
-                result = self._kurtosis_1d(self, fisher=fisher, bias=bias, nan_policy=nan_policy)
+                result = self._kurtosis_1d(
+                    self, fisher=fisher, bias=bias, nan_policy=nan_policy
+                )
                 return handle_out(out, result)
             else:
-                result = self._kurtosis_numeric(fisher=fisher, bias=bias, nan_policy=nan_policy)
+                result = self._kurtosis_numeric(
+                    fisher=fisher, bias=bias, nan_policy=nan_policy
+                )
 
             if isinstance(self, DataFrame):
                 result.divisions = (self.columns.min(), self.columns.max())
@@ -2424,12 +2535,20 @@ Dask Name: {name}, {task} tasks"""
 
         name = self._token_prefix + "kurtosis-1d-" + tokenize(column)
 
-        array_kurtosis = da_stats.kurtosis(column.values, axis=0, fisher=fisher, bias=bias, nan_policy=nan_policy)
+        array_kurtosis = da_stats.kurtosis(
+            column.values, axis=0, fisher=fisher, bias=bias, nan_policy=nan_policy
+        )
 
-        layer = {(name, 0): (methods.wrap_kurtosis_reduction, (array_kurtosis._name,), None)}
-        graph = HighLevelGraph.from_collections(name, layer, dependencies=[array_kurtosis])
+        layer = {
+            (name, 0): (methods.wrap_kurtosis_reduction, (array_kurtosis._name,), None)
+        }
+        graph = HighLevelGraph.from_collections(
+            name, layer, dependencies=[array_kurtosis]
+        )
 
-        return new_dd_object(graph, name, column._meta_nonempty.kurtosis(), divisions=[None, None])
+        return new_dd_object(
+            graph, name, column._meta_nonempty.kurtosis(), divisions=[None, None]
+        )
 
     def _kurtosis_numeric(self, fisher=True, bias=True, nan_policy="propagate"):
         """Method for dataframes with numeric columns.
@@ -2447,7 +2566,9 @@ Dask Name: {name}, {task} tasks"""
         if not np.issubdtype(values_dtype, np.number):
             array_values = num.values.astype("f8")
 
-        array_kurtosis = da_stats.kurtosis(array_values, axis=0, fisher=fisher, bias=bias, nan_policy=nan_policy)
+        array_kurtosis = da_stats.kurtosis(
+            array_values, axis=0, fisher=fisher, bias=bias, nan_policy=nan_policy
+        )
 
         name = self._token_prefix + "kurtosis-numeric" + tokenize(num)
         cols = num._meta.columns if is_dataframe_like(num) else None
@@ -2455,10 +2576,16 @@ Dask Name: {name}, {task} tasks"""
         kurtosis_shape = num._meta_nonempty.values.var(axis=0).shape
         array_kurtosis_name = (array_kurtosis._name,) + (0,) * len(kurtosis_shape)
 
-        layer = {(name, 0): (methods.wrap_kurtosis_reduction, array_kurtosis_name, cols)}
-        graph = HighLevelGraph.from_collections(name, layer, dependencies=[array_kurtosis])
+        layer = {
+            (name, 0): (methods.wrap_kurtosis_reduction, array_kurtosis_name, cols)
+        }
+        graph = HighLevelGraph.from_collections(
+            name, layer, dependencies=[array_kurtosis]
+        )
 
-        return new_dd_object(graph, name, num._meta_nonempty.kurtosis(), divisions=[None, None])
+        return new_dd_object(
+            graph, name, num._meta_nonempty.kurtosis(), divisions=[None, None]
+        )
 
     @_numeric_only
     @derived_from(pd.DataFrame)
@@ -2535,13 +2662,19 @@ Dask Name: {name}, {task} tasks"""
             qnames = [(_q._name, 0) for _q in quantiles]
 
             if isinstance(quantiles[0], Scalar):
-                layer = {(keyname, 0): (type(meta), qnames, num.columns, None, meta.name)}
-                graph = HighLevelGraph.from_collections(keyname, layer, dependencies=quantiles)
+                layer = {
+                    (keyname, 0): (type(meta), qnames, num.columns, None, meta.name)
+                }
+                graph = HighLevelGraph.from_collections(
+                    keyname, layer, dependencies=quantiles
+                )
                 divisions = (min(num.columns), max(num.columns))
                 return Series(graph, keyname, meta, divisions)
             else:
                 layer = {(keyname, 0): (methods.concat, qnames, 1)}
-                graph = HighLevelGraph.from_collections(keyname, layer, dependencies=quantiles)
+                graph = HighLevelGraph.from_collections(
+                    keyname, layer, dependencies=quantiles
+                )
                 return DataFrame(graph, keyname, meta, quantiles[0].divisions)
 
     @derived_from(pd.DataFrame)
@@ -2558,7 +2691,9 @@ Dask Name: {name}, {task} tasks"""
         if PANDAS_GT_110:
             datetime_is_numeric_kwarg = {"datetime_is_numeric": datetime_is_numeric}
         elif datetime_is_numeric:
-            raise NotImplementedError("datetime_is_numeric=True is only supported for pandas >= 1.1.0")
+            raise NotImplementedError(
+                "datetime_is_numeric=True is only supported for pandas >= 1.1.0"
+            )
         else:
             datetime_is_numeric_kwarg = {}
 
@@ -2570,7 +2705,9 @@ Dask Name: {name}, {task} tasks"""
                 exclude=exclude,
                 **datetime_is_numeric_kwarg,
             )
-            output = self._describe_1d(self, split_every, percentiles, percentiles_method, datetime_is_numeric)
+            output = self._describe_1d(
+                self, split_every, percentiles, percentiles_method, datetime_is_numeric
+            )
             output._meta = meta
             return output
         elif (include is None) and (exclude is None):
@@ -2620,7 +2757,9 @@ Dask Name: {name}, {task} tasks"""
         name = "describe--" + tokenize(self, split_every)
         layer = {(name, 0): (methods.describe_aggregate, stats_names)}
         graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
-        meta = self._meta_nonempty.describe(include=include, exclude=exclude, **datetime_is_numeric_kwarg)
+        meta = self._meta_nonempty.describe(
+            include=include, exclude=exclude, **datetime_is_numeric_kwarg
+        )
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
     def _describe_1d(
@@ -2632,7 +2771,9 @@ Dask Name: {name}, {task} tasks"""
         datetime_is_numeric=False,
     ):
         if is_bool_dtype(data._meta):
-            return self._describe_nonnumeric_1d(data, split_every=split_every, datetime_is_numeric=datetime_is_numeric)
+            return self._describe_nonnumeric_1d(
+                data, split_every=split_every, datetime_is_numeric=datetime_is_numeric
+            )
         elif is_numeric_dtype(data._meta):
             return self._describe_numeric(
                 data,
@@ -2657,7 +2798,9 @@ Dask Name: {name}, {task} tasks"""
                 is_datetime_column=True,
             )
         else:
-            return self._describe_nonnumeric_1d(data, split_every=split_every, datetime_is_numeric=datetime_is_numeric)
+            return self._describe_nonnumeric_1d(
+                data, split_every=split_every, datetime_is_numeric=datetime_is_numeric
+            )
 
     def _describe_numeric(
         self,
@@ -2714,7 +2857,9 @@ Dask Name: {name}, {task} tasks"""
         meta = num._meta_nonempty.describe()
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
-    def _describe_nonnumeric_1d(self, data, split_every=False, datetime_is_numeric=False):
+    def _describe_nonnumeric_1d(
+        self, data, split_every=False, datetime_is_numeric=False
+    ):
         from dask.dataframe.numeric import to_numeric
 
         vcounts = data.value_counts(split_every=split_every)
@@ -2739,20 +2884,26 @@ Dask Name: {name}, {task} tasks"""
         colname = data._meta.name
 
         name = "describe-nonnumeric-1d--" + tokenize(data, split_every)
-        layer = {(name, 0): (methods.describe_nonnumeric_aggregate, stats_names, colname)}
+        layer = {
+            (name, 0): (methods.describe_nonnumeric_aggregate, stats_names, colname)
+        }
         graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
 
         if PANDAS_GT_110:
             datetime_is_numeric_kwarg = {"datetime_is_numeric": datetime_is_numeric}
         elif datetime_is_numeric:
-            raise NotImplementedError("datetime_is_numeric=True is only supported for pandas >= 1.1.0")
+            raise NotImplementedError(
+                "datetime_is_numeric=True is only supported for pandas >= 1.1.0"
+            )
         else:
             datetime_is_numeric_kwarg = {}
 
         meta = data._meta_nonempty.describe(**datetime_is_numeric_kwarg)
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
-    def _cum_agg(self, op_name, chunk, aggregate, axis, skipna=True, chunk_kwargs=None, out=None):
+    def _cum_agg(
+        self, op_name, chunk, aggregate, axis, skipna=True, chunk_kwargs=None, out=None
+    ):
         """Wrapper for cumulative operation"""
 
         axis = self._validate_axis(axis)
@@ -2764,7 +2915,9 @@ Dask Name: {name}, {task} tasks"""
         else:
             # cumulate each partitions
             name1 = f"{self._token_prefix}{op_name}-map"
-            cumpart = map_partitions(chunk, self, token=name1, meta=self, **chunk_kwargs)
+            cumpart = map_partitions(
+                chunk, self, token=name1, meta=self, **chunk_kwargs
+            )
 
             name2 = f"{self._token_prefix}{op_name}-take-last"
             cumlast = map_partitions(
@@ -2796,7 +2949,9 @@ Dask Name: {name}, {task} tasks"""
                         (cumlast._name, i - 1),
                     )
                 layer[(name, i)] = (aggregate, (cumpart._name, i), (cname, i))
-            graph = HighLevelGraph.from_collections(name, layer, dependencies=[cumpart, cumlast])
+            graph = HighLevelGraph.from_collections(
+                name, layer, dependencies=[cumpart, cumlast]
+            )
             result = new_dd_object(graph, name, chunk(self._meta), self.divisions)
             return handle_out(out, result)
 
@@ -2872,7 +3027,9 @@ Dask Name: {name}, {task} tasks"""
             return self.map_partitions(M.isna, enforce_metadata=False)
         else:
             raise NotImplementedError(
-                "Need more recent version of Pandas " "to support isna. " "Please use isnull instead."
+                "Need more recent version of Pandas "
+                "to support isna. "
+                "Please use isnull instead."
             )
 
     @derived_from(pd.DataFrame)
@@ -2888,7 +3045,9 @@ Dask Name: {name}, {task} tasks"""
         # We wrap values in a delayed for two reasons:
         # - avoid serializing data in every task
         # - avoid cost of traversal of large list in optimizations
-        return self.map_partitions(M.isin, delayed(values), meta=meta, enforce_metadata=False)
+        return self.map_partitions(
+            M.isin, delayed(values), meta=meta, enforce_metadata=False
+        )
 
     @derived_from(pd.DataFrame)
     def astype(self, dtype):
@@ -2902,12 +3061,16 @@ Dask Name: {name}, {task} tasks"""
             meta = self._meta.astype(dtype)
         if hasattr(dtype, "items"):
             set_unknown = [
-                k for k, v in dtype.items() if is_categorical_dtype(v) and getattr(v, "categories", None) is None
+                k
+                for k, v in dtype.items()
+                if is_categorical_dtype(v) and getattr(v, "categories", None) is None
             ]
             meta = clear_known_categories(meta, cols=set_unknown)
         elif is_categorical_dtype(dtype) and getattr(dtype, "categories", None) is None:
             meta = clear_known_categories(meta)
-        return self.map_partitions(M.astype, dtype=dtype, meta=meta, enforce_metadata=False)
+        return self.map_partitions(
+            M.astype, dtype=dtype, meta=meta, enforce_metadata=False
+        )
 
     @derived_from(pd.Series)
     def append(self, other, interleave_partitions=False):
@@ -2925,7 +3088,9 @@ Dask Name: {name}, {task} tasks"""
             msg = "append doesn't support list or dict input"
             raise NotImplementedError(msg)
 
-        return concat([self, other], join="outer", interleave_partitions=interleave_partitions)
+        return concat(
+            [self, other], join="outer", interleave_partitions=interleave_partitions
+        )
 
     @derived_from(pd.Series)
     def dot(self, other, meta=no_default):
@@ -2934,18 +3099,24 @@ Dask Name: {name}, {task} tasks"""
 
         if isinstance(other, DataFrame):
             s = self.map_partitions(M.dot, other, token="dot", meta=meta)
-            return s.groupby(by=s.index).apply(lambda x: x.sum(skipna=False), meta=s._meta_nonempty)
+            return s.groupby(by=s.index).apply(
+                lambda x: x.sum(skipna=False), meta=s._meta_nonempty
+            )
 
         def _dot_series(*args, **kwargs):
             # .sum() is invoked on each partition before being applied to all
             # partitions. The return type is expected to be a series, not a numpy object
             return pd.Series(M.dot(*args, **kwargs))
 
-        return self.map_partitions(_dot_series, other, token="dot", meta=meta).sum(skipna=False)
+        return self.map_partitions(_dot_series, other, token="dot", meta=meta).sum(
+            skipna=False
+        )
 
     @derived_from(pd.DataFrame)
     def align(self, other, join="outer", axis=None, fill_value=None):
-        meta1, meta2 = _emulate(M.align, self, other, join, axis=axis, fill_value=fill_value)
+        meta1, meta2 = _emulate(
+            M.align, self, other, join, axis=axis, fill_value=fill_value
+        )
         aligned = self.map_partitions(
             M.align,
             other,
@@ -2958,12 +3129,18 @@ Dask Name: {name}, {task} tasks"""
         token = tokenize(self, other, join, axis, fill_value)
 
         name1 = "align1-" + token
-        dsk1 = {(name1, i): (getitem, key, 0) for i, key in enumerate(aligned.__dask_keys__())}
+        dsk1 = {
+            (name1, i): (getitem, key, 0)
+            for i, key in enumerate(aligned.__dask_keys__())
+        }
         dsk1.update(aligned.dask)
         result1 = new_dd_object(dsk1, name1, meta1, aligned.divisions)
 
         name2 = "align2-" + token
-        dsk2 = {(name2, i): (getitem, key, 1) for i, key in enumerate(aligned.__dask_keys__())}
+        dsk2 = {
+            (name2, i): (getitem, key, 1)
+            for i, key in enumerate(aligned.__dask_keys__())
+        }
         dsk2.update(aligned.dask)
         result2 = new_dd_object(dsk2, name2, meta2, aligned.divisions)
 
@@ -2971,7 +3148,9 @@ Dask Name: {name}, {task} tasks"""
 
     @derived_from(pd.DataFrame)
     def combine(self, other, func, fill_value=None, overwrite=True):
-        return self.map_partitions(M.combine, other, func, fill_value=fill_value, overwrite=overwrite)
+        return self.map_partitions(
+            M.combine, other, func, fill_value=fill_value, overwrite=overwrite
+        )
 
     @derived_from(pd.DataFrame)
     def combine_first(self, other):
@@ -3040,7 +3219,10 @@ Dask Name: {name}, {task} tasks"""
             divs = (date,) + self.divisions[start + 1 :]
 
         name = "last-" + tokenize(self, offset)
-        dsk = {(name, i + 1): (self._name, j + 1) for i, j in enumerate(range(start, self.npartitions))}
+        dsk = {
+            (name, i + 1): (self._name, j + 1)
+            for i, j in enumerate(range(start, self.npartitions))
+        }
         dsk[(name, 0)] = (
             methods.boundary_slice,
             (self._name, start),
@@ -3248,7 +3430,9 @@ class Series(_Frame):
     @property
     def nbytes(self):
         """Number of bytes"""
-        return self.reduction(methods.nbytes, np.sum, token="nbytes", meta=int, split_every=False)
+        return self.reduction(
+            methods.nbytes, np.sum, token="nbytes", meta=int, split_every=False
+        )
 
     def _repr_data(self):
         return _repr_data_series(self._meta, self._repr_divisions)
@@ -3310,7 +3494,11 @@ Dask Name: {name}, {task} tasks""".format(
 
         import dask.dataframe as dd
 
-        if is_scalar(index) or (is_list_like(index) and not is_dict_like(index) and not isinstance(index, dd.Series)):
+        if is_scalar(index) or (
+            is_list_like(index)
+            and not is_dict_like(index)
+            and not isinstance(index, dd.Series)
+        ):
 
             if inplace:
                 warnings.warn(
@@ -3326,7 +3514,10 @@ Dask Name: {name}, {task} tasks""".format(
                     old = pd.Series(range(self.npartitions + 1), index=self.divisions)
                     new = old.rename(index).index
                     if not new.is_monotonic_increasing:
-                        msg = "sorted_index=True, but the transformed index " "isn't monotonic_increasing"
+                        msg = (
+                            "sorted_index=True, but the transformed index "
+                            "isn't monotonic_increasing"
+                        )
                         raise ValueError(msg)
                     res._divisions = tuple(methods.tolist(new))
                 else:
@@ -3385,7 +3576,8 @@ Dask Name: {name}, {task} tasks""".format(
     def iteritems(self):
         if PANDAS_GT_150:
             warnings.warn(
-                "iteritems is deprecated and will be removed in a future version. " "Use .items instead.",
+                "iteritems is deprecated and will be removed in a future version. "
+                "Use .items instead.",
                 FutureWarning,
             )
         # We use the `_` generator below to ensure the deprecation warning above
@@ -3512,7 +3704,9 @@ Dask Name: {name}, {task} tasks""".format(
 
         aggregate_kwargs = {"normalize": normalize}
         if split_out > 1:
-            aggregate_kwargs["total_length"] = len(self) if dropna is False else len(self.dropna())
+            aggregate_kwargs["total_length"] = (
+                len(self) if dropna is False else len(self.dropna())
+            )
 
         return aca(
             self,
@@ -3562,10 +3756,20 @@ Dask Name: {name}, {task} tasks""".format(
     def map(self, arg, na_action=None, meta=no_default):
         if is_series_like(arg) and is_dask_collection(arg):
             return series_map(self, arg)
-        if not (isinstance(arg, dict) or callable(arg) or is_series_like(arg) and not is_dask_collection(arg)):
-            raise TypeError(f"arg must be pandas.Series, dict or callable. Got {type(arg)}")
+        if not (
+            isinstance(arg, dict)
+            or callable(arg)
+            or is_series_like(arg)
+            and not is_dask_collection(arg)
+        ):
+            raise TypeError(
+                f"arg must be pandas.Series, dict or callable. Got {type(arg)}"
+            )
         name = "map-" + tokenize(self, arg, na_action)
-        dsk = {(name, i): (M.map, k, arg, na_action) for i, k in enumerate(self.__dask_keys__())}
+        dsk = {
+            (name, i): (M.map, k, arg, na_action)
+            for i, k in enumerate(self.__dask_keys__())
+        }
         graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
         if meta is no_default:
             meta = _emulate(M.map, self, arg, na_action=na_action, udf=True)
@@ -3584,22 +3788,30 @@ Dask Name: {name}, {task} tasks""".format(
 
     @derived_from(pd.Series)
     def between(self, left, right, inclusive="both"):
-        return self.map_partitions(M.between, left=left, right=right, inclusive=inclusive)
+        return self.map_partitions(
+            M.between, left=left, right=right, inclusive=inclusive
+        )
 
     @derived_from(pd.Series)
     def clip(self, lower=None, upper=None, out=None):
         if out is not None:
             raise ValueError("'out' must be None")
         # np.clip may pass out
-        return self.map_partitions(M.clip, lower=lower, upper=upper, enforce_metadata=False)
+        return self.map_partitions(
+            M.clip, lower=lower, upper=upper, enforce_metadata=False
+        )
 
     @derived_from(pd.Series)
     def clip_lower(self, threshold):
-        return self.map_partitions(M.clip_lower, threshold=threshold, enforce_metadata=False)
+        return self.map_partitions(
+            M.clip_lower, threshold=threshold, enforce_metadata=False
+        )
 
     @derived_from(pd.Series)
     def clip_upper(self, threshold):
-        return self.map_partitions(M.clip_upper, threshold=threshold, enforce_metadata=False)
+        return self.map_partitions(
+            M.clip_upper, threshold=threshold, enforce_metadata=False
+        )
 
     @derived_from(pd.Series)
     def align(self, other, join="outer", axis=None, fill_value=None):
@@ -3642,7 +3854,9 @@ Dask Name: {name}, {task} tasks""".format(
                 raise NotImplementedError("level must be None")
             axis = self._validate_axis(axis)
             meta = _emulate(op, self, other, axis=axis, fill_value=fill_value)
-            return map_partitions(op, self, other, meta=meta, axis=axis, fill_value=fill_value)
+            return map_partitions(
+                op, self, other, meta=meta, axis=axis, fill_value=fill_value
+            )
 
         meth.__name__ = name
         setattr(cls, name, derived_from(original)(meth))
@@ -3731,7 +3945,9 @@ Dask Name: {name}, {task} tasks""".format(
             )
             warnings.warn(meta_warning(meta))
 
-        return map_partitions(M.apply, self, func, convert_dtype, args, meta=meta, **kwds)
+        return map_partitions(
+            M.apply, self, func, convert_dtype, args, meta=meta, **kwds
+        )
 
     @derived_from(pd.Series)
     def cov(self, other, min_periods=None, split_every=False):
@@ -3751,7 +3967,9 @@ Dask Name: {name}, {task} tasks""".format(
         if method != "pearson":
             raise NotImplementedError("Only Pearson correlation has been implemented")
         df = concat([self, other], axis=1)
-        return cov_corr(df, min_periods, corr=True, scalar=True, split_every=split_every)
+        return cov_corr(
+            df, min_periods, corr=True, scalar=True, split_every=split_every
+        )
 
     @derived_from(pd.Series)
     def autocorr(self, lag=1, split_every=False):
@@ -3761,7 +3979,9 @@ Dask Name: {name}, {task} tasks""".format(
 
     @derived_from(pd.Series)
     def memory_usage(self, index=True, deep=False):
-        result = self.map_partitions(M.memory_usage, index=index, deep=deep, enforce_metadata=False)
+        result = self.map_partitions(
+            M.memory_usage, index=index, deep=deep, enforce_metadata=False
+        )
         return delayed(sum)(result.to_delayed())
 
     def __divmod__(self, other):
@@ -3879,7 +4099,9 @@ class Index(Series):
     # Typing: https://github.com/python/mypy/issues/4125
     @property  # type: ignore
     def index(self):
-        raise AttributeError(f"{self.__class__.__name__!r} object has no attribute 'index'")
+        raise AttributeError(
+            f"{self.__class__.__name__!r} object has no attribute 'index'"
+        )
 
     def __array_wrap__(self, array, context=None):
         return pd.Index(array, name=self.name)
@@ -3932,7 +4154,9 @@ class Index(Series):
             if freq is not None:
                 raise ValueError("PeriodIndex doesn't accept `freq` argument")
             meta = self._meta_nonempty.shift(periods)
-            out = self.map_partitions(M.shift, periods, meta=meta, token="shift", transform_divisions=False)
+            out = self.map_partitions(
+                M.shift, periods, meta=meta, token="shift", transform_divisions=False
+            )
         else:
             # Pandas will raise for other index types that don't implement shift
             meta = self._meta_nonempty.shift(periods, freq=freq)
@@ -3982,7 +4206,9 @@ class Index(Series):
         """
         applied = super().map(arg, na_action=na_action, meta=meta)
         if is_monotonic and self.known_divisions:
-            applied.divisions = tuple(pd.Series(self.divisions).map(arg, na_action=na_action))
+            applied.divisions = tuple(
+                pd.Series(self.divisions).map(arg, na_action=na_action)
+            )
         else:
             applied = applied.clear_divisions()
         return applied
@@ -4046,7 +4272,9 @@ class DataFrame(_Frame):
                 "type": typename(type(self)),
                 "dataframe_type": typename(type(self._meta)),
                 "series_dtypes": {
-                    col: self._meta[col].dtype if hasattr(self._meta[col], "dtype") else None
+                    col: self._meta[col].dtype
+                    if hasattr(self._meta[col], "dtype")
+                    else None
                     for col in self._meta.columns
                 },
             }
@@ -4058,7 +4286,9 @@ class DataFrame(_Frame):
                     "type": typename(type(self)),
                     "dataframe_type": typename(type(self._meta)),
                     "series_dtypes": {
-                        col: self._meta[col].dtype if hasattr(self._meta[col], "dtype") else None
+                        col: self._meta[col].dtype
+                        if hasattr(self._meta[col], "dtype")
+                        else None
                         for col in self._meta.columns
                     },
                 }
@@ -4150,7 +4380,9 @@ class DataFrame(_Frame):
         elif isinstance(key, slice):
             from pandas.api.types import is_float_dtype
 
-            is_integer_slice = any(isinstance(i, Integral) for i in (key.start, key.step, key.stop))
+            is_integer_slice = any(
+                isinstance(i, Integral) for i in (key.start, key.step, key.stop)
+            )
             # Slicing with integer labels is always iloc based except for a
             # float indexer for some reason
             if is_integer_slice and not is_float_dtype(self.index.dtype):
@@ -4191,7 +4423,11 @@ class DataFrame(_Frame):
         elif isinstance(key, pd.Index) and not isinstance(value, DataFrame):
             key = list(key)
             df = self.assign(**{k: value for k in key})
-        elif is_dataframe_like(key) or is_series_like(key) or isinstance(key, (DataFrame, Series)):
+        elif (
+            is_dataframe_like(key)
+            or is_series_like(key)
+            or isinstance(key, (DataFrame, Series))
+        ):
             df = self.where(~key, value)
         elif not isinstance(key, str):
             raise NotImplementedError(f"Item assignment with {type(key)} not supported")
@@ -4287,7 +4523,7 @@ class DataFrame(_Frame):
         npartitions: int | Literal["auto"] | None = None,
         ascending: bool = True,
         na_position: Literal["first"] | Literal["last"] = "last",
-        sort_function: Callable | None = None,
+        sort_function: Callable[[pd.DataFrame], pd.DataFrame] | None = None,
         sort_function_kwargs: Mapping[str, Any] | None = None,
         **kwargs,
     ) -> DataFrame:
@@ -4446,7 +4682,6 @@ class DataFrame(_Frame):
         >>> # ddf2 = ddf.set_index("name", divisions=["Alice", "Laura", "Ursula", "Zelda"])
         """
 
-        # Deal with bool params
         if inplace:
             raise NotImplementedError("The inplace= keyword is not supported")
         pre_sorted = sorted
@@ -4456,7 +4691,9 @@ class DataFrame(_Frame):
         if not isinstance(other, str):
             if isinstance(other, Sequence):
                 # Accept ["a"], but not [["a"]]
-                if len(other) == 1 and (isinstance(other[0], str) or not isinstance(other[0], Sequence)):
+                if len(other) == 1 and (
+                    isinstance(other[0], str) or not isinstance(other[0], Sequence)
+                ):
                     other = other[0]
                 else:
                     raise NotImplementedError(
@@ -4474,59 +4711,63 @@ class DataFrame(_Frame):
                 )
 
         # If already a series
-        index, columns = self.index, self.columns
         if is_series := isinstance(other, Series):
             # If it's already the index, there's nothing to do
-            if other._name == index._name:
+            if other._name == self.index._name:
                 return self
             # Otherwise, check length matches when other isn't one of the data columns
             s = other
-            if not any(
-                s._name == col_series._name for _, col_series in self.items()
-            ) and (  # for cases with other=df.column
-                len_index := len(s)
-            ) != (
-                len_self := len(self)
-            ):
+            if not any(s._name == self[c]._name for c in self.columns) and len(
+                s
+            ) != len(self):
                 raise ValueError(
-                    f"Length mismatch: series to become index has {len_index} rows, but data have {len_self} rows"
+                    f"Length mismatch: series to become index has {len(s)} rows, but data have {len(self)} rows"
                 )
 
         # If the name of a column/index
         else:
-            # If the index, no additional checks
-            if other == index.name:  # here it's name that should be checked, instead of _name
+            # If already the index, no additional checks
+            if other == self.index.name:
                 return self
             # If a missing column, KeyError
-            if other not in columns:
+            if other not in self.columns:
                 raise KeyError(
-                    f"Data has no column '{other}': use either index '{index.name}' or any column of {list(columns)}"
+                    f"Data has no column '{other}': use any column of {list(self.columns)}"
                 )
             s = self[other]
 
-        # Ensure there are no nulls
         if s.isna().any().compute():
-            suggested_method = f"`.dropna(subset=[{other}])`" if not is_series else "`other[other.notna()]`"
+            suggested_method = (
+                f"`.dropna(subset=['{other}']).set_index('{other}')`"
+                if not is_series
+                else "`.loc[index[~index.isna()]]`"
+            )
             raise NotImplementedError(
                 f"Column passed to set_index contains nulls, but Dask does not currently support nulls in the index.\n"
-                f"Consider calling {suggested_method} first."
+                f"Consider calling {suggested_method} instead."
             )
 
         # Check divisions
         if divisions is not None:
             check_divisions(divisions)
-        elif isinstance(other, Index) and other.known_divisions and other.npartitions == self.npartitions:
+        elif (
+            isinstance(other, Index)
+            and other.known_divisions
+            and other.npartitions == self.npartitions
+        ):
             # If the index has the same number of partitions and known
             # divisions, then we can treat it as pre-sorted with known
             # divisions
             pre_sorted = True
             divisions = other.divisions
 
-        # Branch according to sortedness
+        # If index is already sorted, take advantage of that with set_sorted_index
         if pre_sorted:
             from dask.dataframe.shuffle import set_sorted_index
 
-            return set_sorted_index(self, other, drop=drop, divisions=divisions, **kwargs)
+            return set_sorted_index(
+                self, other, drop=drop, divisions=divisions, **kwargs
+            )
         else:
             from dask.dataframe.shuffle import set_index
 
@@ -4597,7 +4838,9 @@ class DataFrame(_Frame):
 
     @wraps(categorize)
     def categorize(self, columns=None, index=None, split_every=None, **kwargs):
-        return categorize(self, columns=columns, index=index, split_every=split_every, **kwargs)
+        return categorize(
+            self, columns=columns, index=index, split_every=split_every, **kwargs
+        )
 
     @derived_from(pd.DataFrame)
     def assign(self, **kwargs):
@@ -4611,7 +4854,9 @@ class DataFrame(_Frame):
                 or is_index_like(v)
                 or isinstance(v, Array)
             ):
-                raise TypeError(f"Column assignment doesn't support type {typename(type(v))}")
+                raise TypeError(
+                    f"Column assignment doesn't support type {typename(type(v))}"
+                )
             if callable(v):
                 kwargs[k] = v(data)
             if isinstance(v, Array):
@@ -4620,13 +4865,18 @@ class DataFrame(_Frame):
                 if len(v.shape) > 1:
                     raise ValueError("Array assignment only supports 1-D arrays")
                 if v.npartitions != data.npartitions:
-                    raise ValueError("Number of partitions do not match " f"({v.npartitions} != {data.npartitions})")
+                    raise ValueError(
+                        "Number of partitions do not match "
+                        f"({v.npartitions} != {data.npartitions})"
+                    )
                 kwargs[k] = from_dask_array(v, index=data.index, meta=data._meta)
 
             pairs = [k, kwargs[k]]
 
             # Figure out columns of the output
-            df2 = data._meta_nonempty.assign(**_extract_meta({k: kwargs[k]}, nonempty=True))
+            df2 = data._meta_nonempty.assign(
+                **_extract_meta({k: kwargs[k]}, nonempty=True)
+            )
             data = elemwise(methods.assign, data, *pairs, meta=df2)
 
         return data
@@ -4716,27 +4966,37 @@ class DataFrame(_Frame):
         if inplace is None:
             inplace = False
         if "=" in expr and inplace in (True, None):
-            raise NotImplementedError("Inplace eval not supported. Please use inplace=False")
+            raise NotImplementedError(
+                "Inplace eval not supported. Please use inplace=False"
+            )
         meta = self._meta.eval(expr, inplace=inplace, **kwargs)
         return self.map_partitions(M.eval, expr, meta=meta, inplace=inplace, **kwargs)
 
     @derived_from(pd.DataFrame)
     def dropna(self, how="any", subset=None, thresh=None):
-        return self.map_partitions(M.dropna, how=how, subset=subset, thresh=thresh, enforce_metadata=False)
+        return self.map_partitions(
+            M.dropna, how=how, subset=subset, thresh=thresh, enforce_metadata=False
+        )
 
     @derived_from(pd.DataFrame)
     def clip(self, lower=None, upper=None, out=None):
         if out is not None:
             raise ValueError("'out' must be None")
-        return self.map_partitions(M.clip, lower=lower, upper=upper, enforce_metadata=False)
+        return self.map_partitions(
+            M.clip, lower=lower, upper=upper, enforce_metadata=False
+        )
 
     @derived_from(pd.DataFrame)
     def clip_lower(self, threshold):
-        return self.map_partitions(M.clip_lower, threshold=threshold, enforce_metadata=False)
+        return self.map_partitions(
+            M.clip_lower, threshold=threshold, enforce_metadata=False
+        )
 
     @derived_from(pd.DataFrame)
     def clip_upper(self, threshold):
-        return self.map_partitions(M.clip_upper, threshold=threshold, enforce_metadata=False)
+        return self.map_partitions(
+            M.clip_upper, threshold=threshold, enforce_metadata=False
+        )
 
     @derived_from(pd.DataFrame)
     def squeeze(self, axis=None):
@@ -4747,7 +5007,9 @@ class DataFrame(_Frame):
                 return self
 
         elif axis == 0:
-            raise NotImplementedError(f"{type(self)} does not support squeeze along axis 0")
+            raise NotImplementedError(
+                f"{type(self)} does not support squeeze along axis 0"
+            )
 
         elif axis not in [0, 1, None]:
             raise ValueError(f"No axis {axis} for object type {type(self)}")
@@ -4824,7 +5086,9 @@ class DataFrame(_Frame):
             return self.map_partitions(drop_by_shallow_copy, columns, errors=errors)
         elif axis == 1:
             return self.map_partitions(drop_by_shallow_copy, labels, errors=errors)
-        raise NotImplementedError("Drop currently only works for axis=1 or when columns is not None")
+        raise NotImplementedError(
+            "Drop currently only works for axis=1 or when columns is not None"
+        )
 
     def merge(
         self,
@@ -4966,7 +5230,9 @@ class DataFrame(_Frame):
             other = other.to_frame()
 
         if not is_dataframe_like(other):
-            if not isinstance(other, list) or not all([is_dataframe_like(o) for o in other]):
+            if not isinstance(other, list) or not all(
+                [is_dataframe_like(o) for o in other]
+            ):
                 raise ValueError("other must be DataFrame or list of DataFrames")
             if how not in ["outer", "left"]:
                 raise ValueError("merge_multi only supports left or outer joins")
@@ -5014,7 +5280,10 @@ class DataFrame(_Frame):
     @derived_from(pd.DataFrame)
     def append(self, other, interleave_partitions=False):
         if isinstance(other, Series):
-            msg = "Unable to appending dd.Series to dd.DataFrame." "Use pd.Series to append as row."
+            msg = (
+                "Unable to appending dd.Series to dd.DataFrame."
+                "Use pd.Series to append as row."
+            )
             raise ValueError(msg)
         elif is_series_like(other):
             other = other.to_frame().T
@@ -5059,7 +5328,9 @@ class DataFrame(_Frame):
                 elif is_series_like(other):
                     # Special case for pd.Series to avoid unwanted partitioning
                     # of other. We pass it in as a kwarg to prevent this.
-                    meta = _emulate(op, self, other=other, axis=axis, fill_value=fill_value)
+                    meta = _emulate(
+                        op, self, other=other, axis=axis, fill_value=fill_value
+                    )
                     return map_partitions(
                         op,
                         self,
@@ -5173,7 +5444,8 @@ class DataFrame(_Frame):
 
         if broadcast is not None:
             warnings.warn(
-                "The `broadcast` argument is no longer used/supported. " "It will be dropped in a future release.",
+                "The `broadcast` argument is no longer used/supported. "
+                "It will be dropped in a future release.",
                 category=FutureWarning,
             )
 
@@ -5183,11 +5455,16 @@ class DataFrame(_Frame):
         kwds.update(pandas_kwargs)
 
         if axis == 0:
-            msg = "dd.DataFrame.apply only supports axis=1\n" "  Try: df.apply(func, axis=1)"
+            msg = (
+                "dd.DataFrame.apply only supports axis=1\n"
+                "  Try: df.apply(func, axis=1)"
+            )
             raise NotImplementedError(msg)
 
         if meta is no_default:
-            meta = _emulate(M.apply, self._meta_nonempty, func, args=args, udf=True, **kwds)
+            meta = _emulate(
+                M.apply, self._meta_nonempty, func, args=args, udf=True, **kwds
+            )
             warnings.warn(meta_warning(meta))
         kwds.update({"parent_meta": self._meta})
         return map_partitions(M.apply, self, func, args=args, meta=meta, **kwds)
@@ -5214,7 +5491,10 @@ class DataFrame(_Frame):
                 enforce_metadata=False,
             )
         else:
-            nunique_list = [self[col].nunique(split_every=split_every, dropna=dropna) for col in self.columns]
+            nunique_list = [
+                self[col].nunique(split_every=split_every, dropna=dropna)
+                for col in self.columns
+            ]
             name = "series-" + tokenize(*nunique_list)
             dsk = {
                 (name, 0): (
@@ -5224,7 +5504,9 @@ class DataFrame(_Frame):
                     {"index": self.columns},
                 )
             }
-            graph = HighLevelGraph.from_collections(name, dsk, dependencies=nunique_list)
+            graph = HighLevelGraph.from_collections(
+                name, dsk, dependencies=nunique_list
+            )
             return Series(graph, name, self._meta.nunique(), (None, None))
 
     @derived_from(pd.DataFrame)
@@ -5232,7 +5514,9 @@ class DataFrame(_Frame):
         mode_series_list = []
         for col_index in range(len(self.columns)):
             col_series = self.iloc[:, col_index]
-            mode_series = Series.mode(col_series, dropna=dropna, split_every=split_every)
+            mode_series = Series.mode(
+                col_series, dropna=dropna, split_every=split_every
+            )
             mode_series_list.append(mode_series)
 
         name = "concat-" + tokenize(*mode_series_list)
@@ -5247,7 +5531,9 @@ class DataFrame(_Frame):
         }
 
         meta = methods.concat([df._meta for df in mode_series_list], axis=1)
-        graph = HighLevelGraph.from_collections(name, dsk, dependencies=mode_series_list)
+        graph = HighLevelGraph.from_collections(
+            name, dsk, dependencies=mode_series_list
+        )
         ddf = new_dd_object(graph, name, meta, divisions=(None, None))
 
         return ddf
@@ -5289,8 +5575,12 @@ class DataFrame(_Frame):
             memory_usage = True
             computations.update({"index": self.index, "count": self.count()})
         if memory_usage:
-            computations.update({"memory_usage": self.map_partitions(M.memory_usage, index=True)})
-        computations = dict(zip(computations.keys(), da.compute(*computations.values())))
+            computations.update(
+                {"memory_usage": self.map_partitions(M.memory_usage, index=True)}
+            )
+        computations = dict(
+            zip(computations.keys(), da.compute(*computations.values()))
+        )
 
         if verbose:
             import textwrap
@@ -5327,14 +5617,18 @@ class DataFrame(_Frame):
                     count=pprint_thing(count),
                     dtype=pprint_thing(dtype),
                 )
-                for i, (name, count, dtype) in enumerate(zip(self.columns, counts, self.dtypes))
+                for i, (name, count, dtype) in enumerate(
+                    zip(self.columns, counts, self.dtypes)
+                )
             ]
             lines.extend(header.split("\n"))
         else:
             column_info = [index_summary(self.columns, name="Columns")]
 
         lines.extend(column_info)
-        dtype_counts = ["%s(%d)" % k for k in sorted(self.dtypes.value_counts().items(), key=str)]
+        dtype_counts = [
+            "%s(%d)" % k for k in sorted(self.dtypes.value_counts().items(), key=str)
+        ]
         lines.append("dtypes: {}".format(", ".join(dtype_counts)))
 
         if memory_usage:
@@ -5371,7 +5665,9 @@ class DataFrame(_Frame):
         """
         from dask.dataframe.reshape import pivot_table
 
-        return pivot_table(self, index=index, columns=columns, values=values, aggfunc=aggfunc)
+        return pivot_table(
+            self, index=index, columns=columns, values=values, aggfunc=aggfunc
+        )
 
     def melt(
         self,
@@ -5444,7 +5740,9 @@ class DataFrame(_Frame):
     def to_html(self, max_rows=5):
         # pd.Series doesn't have html repr
         data = self._repr_data().to_html(max_rows=max_rows, show_dimensions=False)
-        return get_template("dataframe.html.j2").render(data=data, name=self._name, task=self.dask)
+        return get_template("dataframe.html.j2").render(
+            data=data, name=self._name, task=self.dask
+        )
 
     def _repr_data(self):
         meta = self._meta
@@ -5453,12 +5751,18 @@ class DataFrame(_Frame):
         if len(cols) == 0:
             series_df = pd.DataFrame([[]] * len(index), columns=cols, index=index)
         else:
-            series_df = pd.concat([_repr_data_series(s, index=index) for _, s in meta.items()], axis=1)
+            series_df = pd.concat(
+                [_repr_data_series(s, index=index) for _, s in meta.items()], axis=1
+            )
         return series_df
 
     def _repr_html_(self):
-        data = self._repr_data().to_html(max_rows=5, show_dimensions=False, notebook=True)
-        return get_template("dataframe.html.j2").render(data=data, name=self._name, task=self.dask)
+        data = self._repr_data().to_html(
+            max_rows=5, show_dimensions=False, notebook=True
+        )
+        return get_template("dataframe.html.j2").render(
+            data=data, name=self._name, task=self.dask
+        )
 
     def _select_columns_or_index(self, columns_or_index):
         """
@@ -5476,9 +5780,15 @@ class DataFrame(_Frame):
         """
 
         # Ensure columns_or_index is a list
-        columns_or_index = columns_or_index if isinstance(columns_or_index, list) else [columns_or_index]
+        columns_or_index = (
+            columns_or_index
+            if isinstance(columns_or_index, list)
+            else [columns_or_index]
+        )
 
-        column_names = [n for n in columns_or_index if self._is_column_label_reference(n)]
+        column_names = [
+            n for n in columns_or_index if self._is_column_label_reference(n)
+        ]
 
         selected_df = self[column_names]
         if self._contains_index_name(columns_or_index):
@@ -5494,7 +5804,11 @@ class DataFrame(_Frame):
         To be considered a column label reference, `key` must match the name of at
         least one column.
         """
-        return not is_dask_collection(key) and (np.isscalar(key) or isinstance(key, tuple)) and key in self.columns
+        return (
+            not is_dask_collection(key)
+            and (np.isscalar(key) or isinstance(key, tuple))
+            and key in self.columns
+        )
 
 
 # bind operators
@@ -5564,7 +5878,11 @@ def is_broadcastable(dfs, s):
         isinstance(s, Series)
         and s.npartitions == 1
         and s.known_divisions
-        and any(s.divisions == (df.columns.min(), df.columns.max()) for df in dfs if isinstance(df, DataFrame))
+        and any(
+            s.divisions == (df.columns.min(), df.columns.max())
+            for df in dfs
+            if isinstance(df, DataFrame)
+        )
     )
 
 
@@ -5639,7 +5957,11 @@ def elemwise(op, *args, meta=no_default, out=None, transform_divisions=True, **k
     _is_broadcastable = partial(is_broadcastable, dfs)
     dfs = list(remove(_is_broadcastable, dfs))
 
-    other = [(i, arg) for i, arg in enumerate(args) if not isinstance(arg, (_Frame, Scalar, Array))]
+    other = [
+        (i, arg)
+        for i, arg in enumerate(args)
+        if not isinstance(arg, (_Frame, Scalar, Array))
+    ]
 
     # adjust the key length of Scalar
     dsk = partitionwise_graph(op, _name, *args, **kwargs)
@@ -5704,9 +6026,13 @@ def handle_out(out, result):
         if not isinstance(out, Scalar):
             out._divisions = result.divisions
     elif out is not None:
-        msg = "The out parameter is not fully supported." " Received type %s, expected %s " % (
-            typename(type(out)),
-            typename(type(result)),
+        msg = (
+            "The out parameter is not fully supported."
+            " Received type %s, expected %s "
+            % (
+                typename(type(out)),
+                typename(type(result)),
+            )
         )
         raise NotImplementedError(msg)
     else:
@@ -5717,13 +6043,17 @@ def _maybe_from_pandas(dfs):
     from dask.dataframe.io import from_pandas
 
     dfs = [
-        from_pandas(df, 1) if (is_series_like(df) or is_dataframe_like(df)) and not is_dask_collection(df) else df
+        from_pandas(df, 1)
+        if (is_series_like(df) or is_dataframe_like(df)) and not is_dask_collection(df)
+        else df
         for df in dfs
     ]
     return dfs
 
 
-def hash_shard(df, nparts, split_out_setup=None, split_out_setup_kwargs=None, ignore_index=False):
+def hash_shard(
+    df, nparts, split_out_setup=None, split_out_setup_kwargs=None, ignore_index=False
+):
     if split_out_setup:
         h = split_out_setup(df, **(split_out_setup_kwargs or {}))
     else:
@@ -5879,7 +6209,10 @@ def apply_concat_apply(
     chunked = map_bag_partitions(
         chunk,
         # Convert _Frame collections to Bag
-        *[arg.to_bag(format="frame") if isinstance(arg, _Frame) else arg for arg in args],
+        *[
+            arg.to_bag(format="frame") if isinstance(arg, _Frame) else arg
+            for arg in args
+        ],
         token=chunk_name,
         **chunk_kwargs,
     )
@@ -5918,7 +6251,9 @@ def apply_concat_apply(
         npartitions,
         partial(_concat, ignore_index=ignore_index),
         partial(combine, **combine_kwargs) if combine_kwargs else combine,
-        finalize_func=partial(aggregate, **aggregate_kwargs) if aggregate_kwargs else aggregate,
+        finalize_func=partial(aggregate, **aggregate_kwargs)
+        if aggregate_kwargs
+        else aggregate,
         split_every=split_every,
         split_out=split_out if (split_out and split_out > 1) else None,
         tree_node_name=f"{token or funcname(combine)}-combine-{token_key}",
@@ -5926,7 +6261,9 @@ def apply_concat_apply(
 
     if meta is no_default:
         meta_chunk = _emulate(chunk, *args, udf=True, **chunk_kwargs)
-        meta = _emulate(aggregate, _concat([meta_chunk], ignore_index), udf=True, **aggregate_kwargs)
+        meta = _emulate(
+            aggregate, _concat([meta_chunk], ignore_index), udf=True, **aggregate_kwargs
+        )
     meta = make_meta(
         meta,
         index=(getattr(make_meta(dfs[0]), "index", None) if dfs else None),
@@ -5957,7 +6294,9 @@ def _extract_meta(x, nonempty=False):
             res[k] = _extract_meta(x[k], nonempty)
         return res
     elif isinstance(x, Delayed):
-        raise ValueError("Cannot infer dataframe metadata with a `dask.delayed` argument")
+        raise ValueError(
+            "Cannot infer dataframe metadata with a `dask.delayed` argument"
+        )
     else:
         return x
 
@@ -6103,7 +6442,9 @@ def map_partitions(
 
     if transform_divisions and isinstance(dfs[0], Index) and len(dfs) == 1:
         try:
-            divisions = func(*[pd.Index(a.divisions) if a is dfs[0] else a for a in args], **kwargs)
+            divisions = func(
+                *[pd.Index(a.divisions) if a is dfs[0] else a for a in args], **kwargs
+            )
             if isinstance(divisions, pd.Index):
                 divisions = methods.tolist(divisions)
         except Exception:
@@ -6113,7 +6454,10 @@ def map_partitions(
                 divisions = [None] * (dfs[0].npartitions + 1)
 
     if has_keyword(func, "partition_info"):
-        partition_info = {(i,): {"number": i, "division": division} for i, division in enumerate(divisions[:-1])}
+        partition_info = {
+            (i,): {"number": i, "division": division}
+            for i, division in enumerate(divisions[:-1])
+        }
 
         args2.insert(0, BlockwiseDepDict(partition_info))
         orig_func = func
@@ -6133,7 +6477,9 @@ def map_partitions(
         )
     else:
         kwargs4 = kwargs if simple else kwargs3
-        dsk = partitionwise_graph(func, name, *args2, **kwargs4, dependencies=dependencies)
+        dsk = partitionwise_graph(
+            func, name, *args2, **kwargs4, dependencies=dependencies
+        )
 
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=dependencies)
     return new_dd_object(graph, name, meta, divisions)
@@ -6184,7 +6530,11 @@ def _rename(columns, df):
             columns = columns.columns
         if not isinstance(columns, pd.Index):
             columns = pd.Index(columns)
-        if len(columns) == len(df.columns) and type(columns) is type(df.columns) and columns.equals(df.columns):
+        if (
+            len(columns) == len(df.columns)
+            and type(columns) is type(df.columns)
+            and columns.equals(df.columns)
+        ):
             # if target is identical, rename is not necessary
             return df
         # deep=False doesn't doesn't copy any data/indices, so this is cheap
@@ -6270,16 +6620,10 @@ def quantile(df, q, method="default"):
     if is_series_like(meta):
         # Index.quantile(list-like) must be pd.Series, not pd.Index
         df_name = df.name
-
-        def finalize_tsk(tsk):
-            return (series_typ, tsk, q, None, df_name)
-
+        finalize_tsk = lambda tsk: (series_typ, tsk, q, None, df_name)
         return_type = Series
     else:
-
-        def finalize_tsk(tsk):
-            return (getitem, tsk, 0)
-
+        finalize_tsk = lambda tsk: (getitem, tsk, 0)
         return_type = Scalar
         q = [q]
 
@@ -6303,19 +6647,28 @@ def quantile(df, q, method="default"):
 
     df = df.dropna()
 
-    if internal_method == "tdigest" and (np.issubdtype(df.dtype, np.floating) or np.issubdtype(df.dtype, np.integer)):
+    if internal_method == "tdigest" and (
+        np.issubdtype(df.dtype, np.floating) or np.issubdtype(df.dtype, np.integer)
+    ):
 
         from dask.utils import import_required
 
-        import_required("crick", "crick is a required dependency for using the t-digest method.")
+        import_required(
+            "crick", "crick is a required dependency for using the t-digest method."
+        )
 
         from dask.array.percentile import _percentiles_from_tdigest, _tdigest_chunk
 
         name = "quantiles_tdigest-1-" + token
-        val_dsk = {(name, i): (_tdigest_chunk, (getattr, key, "values")) for i, key in enumerate(df.__dask_keys__())}
+        val_dsk = {
+            (name, i): (_tdigest_chunk, (getattr, key, "values"))
+            for i, key in enumerate(df.__dask_keys__())
+        }
 
         name2 = "quantiles_tdigest-2-" + token
-        merge_dsk = {(name2, 0): finalize_tsk((_percentiles_from_tdigest, qs, sorted(val_dsk)))}
+        merge_dsk = {
+            (name2, 0): finalize_tsk((_percentiles_from_tdigest, qs, sorted(val_dsk)))
+        }
     else:
 
         from dask.array.dispatch import percentile_lookup as _percentile
@@ -6325,7 +6678,10 @@ def quantile(df, q, method="default"):
         calc_qs = np.pad(qs, 1, mode="constant")
         calc_qs[-1] = 100
         name = "quantiles-1-" + token
-        val_dsk = {(name, i): (_percentile, key, calc_qs) for i, key in enumerate(df.__dask_keys__())}
+        val_dsk = {
+            (name, i): (_percentile, key, calc_qs)
+            for i, key in enumerate(df.__dask_keys__())
+        }
 
         name2 = "quantiles-2-" + token
         merge_dsk = {
@@ -6389,7 +6745,9 @@ def cov_corr(df, min_periods=None, corr=False, scalar=False, split_every=False):
 
     funcname = "corr" if corr else "cov"
     a = f"{funcname}-chunk-{df._name}"
-    dsk = {(a, i): (cov_corr_chunk, f, corr) for (i, f) in enumerate(df.__dask_keys__())}
+    dsk = {
+        (a, i): (cov_corr_chunk, f, corr) for (i, f) in enumerate(df.__dask_keys__())
+    }
 
     prefix = f"{funcname}-combine-{df._name}-"
     k = df.npartitions
@@ -6415,7 +6773,9 @@ def cov_corr(df, min_periods=None, corr=False, scalar=False, split_every=False):
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[df])
     if scalar:
         return Scalar(graph, name, "f8")
-    meta = make_meta([(c, "f8") for c in df.columns], index=df.columns, parent_meta=df._meta)
+    meta = make_meta(
+        [(c, "f8") for c in df.columns], index=df.columns, parent_meta=df._meta
+    )
     return DataFrame(graph, name, meta, (df.columns.min(), df.columns.max()))
 
 
@@ -6439,7 +6799,9 @@ def cov_corr_chunk(df, corr=False):
         mask = df.isnull().values
         for idx, x in enumerate(df):
             # Avoid using ufunc.outer (not supported by cupy)
-            mu_discrepancy = np.subtract(df.iloc[:, idx].values[:, None], mu[idx][None, :]) ** 2
+            mu_discrepancy = (
+                np.subtract(df.iloc[:, idx].values[:, None], mu[idx][None, :]) ** 2
+            )
             mu_discrepancy[mask] = np.nan
             m[idx] = np.nansum(mu_discrepancy, axis=0)
         m = m.T
@@ -6472,7 +6834,9 @@ def cov_corr_combine(data_in, corr=False):
     n2 = counts[1:]
     with np.errstate(invalid="ignore"):
         d = (s2 / n2) - (s1 / n1)
-        C = np.nansum((n1 * n2) / (n1 + n2) * (d * d.transpose((0, 2, 1))), 0) + np.nansum(data["cov"], 0)
+        C = np.nansum(
+            (n1 * n2) / (n1 + n2) * (d * d.transpose((0, 2, 1))), 0
+        ) + np.nansum(data["cov"], 0)
 
     out = {"sum": cum_sums[-1], "count": cum_counts[-1], "cov": C}
 
@@ -6565,7 +6929,9 @@ def _take_last(a, skipna=True):
             series_typ = type(a.iloc[0:1, 0])
             if a.empty:
                 return series_typ([], dtype="float")
-            return series_typ({col: _last_valid(a[col]) for col in a.columns}, index=a.columns)
+            return series_typ(
+                {col: _last_valid(a[col]) for col in a.columns}, index=a.columns
+            )
         else:
             return _last_valid(a)
 
@@ -6590,12 +6956,7 @@ def repartition_divisions(a, b, name, out1, out2, force=False):
     ----------
     a : tuple
         old divisions
-    b : tuple, list
-        new divisions
-    name : str
-        name of old dataframe
-    out1 : str
-        name of temporary splits
+    b : tuple, listmypy
     out2 : str
         name of new dataframe
     force : bool, default False
@@ -6623,10 +6984,16 @@ def repartition_divisions(a, b, name, out1, out2, force=False):
 
     if force:
         if a[0] < b[0]:
-            msg = "left side of the new division must be equal or smaller " "than old division"
+            msg = (
+                "left side of the new division must be equal or smaller "
+                "than old division"
+            )
             raise ValueError(msg)
         if a[-1] > b[-1]:
-            msg = "right side of the new division must be equal or larger " "than old division"
+            msg = (
+                "right side of the new division must be equal or larger "
+                "than old division"
+            )
             raise ValueError(msg)
     else:
         if a[0] != b[0]:
@@ -6701,7 +7068,12 @@ def repartition_divisions(a, b, name, out1, out2, force=False):
         while c[i] < b[j]:
             tmp.append((out1, i))
             i += 1
-        while last_elem and c[i] == b[-1] and (b[-1] != b[-2] or j == len(b) - 1) and i < k:
+        while (
+            last_elem
+            and c[i] == b[-1]
+            and (b[-1] != b[-2] or j == len(b) - 1)
+            and i < k
+        ):
             # append if last split is not included
             tmp.append((out1, i))
             i += 1
@@ -6733,7 +7105,9 @@ def repartition_freq(df, freq=None):
         start = df.divisions[0].ceil(freq)
     except ValueError:
         start = df.divisions[0]
-    divisions = methods.tolist(pd.date_range(start=start, end=df.divisions[-1], freq=freq))
+    divisions = methods.tolist(
+        pd.date_range(start=start, end=df.divisions[-1], freq=freq)
+    )
     if not len(divisions):
         divisions = [df.divisions[0], df.divisions[-1]]
     else:
@@ -6827,13 +7201,15 @@ def repartition_npartitions(df, npartitions):
     elif df.npartitions > npartitions:
         npartitions_ratio = df.npartitions / npartitions
         new_partitions_boundaries = [
-            int(new_partition_index * npartitions_ratio) for new_partition_index in range(npartitions + 1)
+            int(new_partition_index * npartitions_ratio)
+            for new_partition_index in range(npartitions + 1)
         ]
         return _repartition_from_boundaries(df, new_partitions_boundaries, new_name)
     else:
         original_divisions = divisions = pd.Series(df.divisions)
         if df.known_divisions and (
-            np.issubdtype(divisions.dtype, np.datetime64) or np.issubdtype(divisions.dtype, np.number)
+            np.issubdtype(divisions.dtype, np.datetime64)
+            or np.issubdtype(divisions.dtype, np.number)
         ):
             if np.issubdtype(divisions.dtype, np.datetime64):
                 divisions = divisions.values.astype("float64")
@@ -6848,7 +7224,9 @@ def repartition_npartitions(df, npartitions):
                 fp=divisions,
             )
             if np.issubdtype(original_divisions.dtype, np.datetime64):
-                divisions = methods.tolist(pd.Series(divisions).astype(original_divisions.dtype))
+                divisions = methods.tolist(
+                    pd.Series(divisions).astype(original_divisions.dtype)
+                )
             elif np.issubdtype(original_divisions.dtype, np.integer):
                 divisions = divisions.astype(original_divisions.dtype)
 
@@ -6877,7 +7255,9 @@ def _repartition_from_boundaries(df, new_partitions_boundaries, new_name):
     if new_partitions_boundaries[-1] < df.npartitions:
         new_partitions_boundaries.append(df.npartitions)
     dsk = {}
-    for i, (start, end) in enumerate(zip(new_partitions_boundaries, new_partitions_boundaries[1:])):
+    for i, (start, end) in enumerate(
+        zip(new_partitions_boundaries, new_partitions_boundaries[1:])
+    ):
         dsk[new_name, i] = (methods.concat, [(df._name, j) for j in range(start, end)])
     divisions = [df.divisions[i] for i in new_partitions_boundaries]
     graph = HighLevelGraph.from_collections(new_name, dsk, dependencies=[df])
@@ -6955,7 +7335,9 @@ def repartition(df, divisions=None, force=False):
     if isinstance(df, _Frame):
         tmp = "repartition-split-" + token
         out = "repartition-merge-" + token
-        dsk = repartition_divisions(df.divisions, divisions, df._name, tmp, out, force=force)
+        dsk = repartition_divisions(
+            df.divisions, divisions, df._name, tmp, out, force=force
+        )
         graph = HighLevelGraph.from_collections(out, dsk, dependencies=[df])
         return new_dd_object(graph, out, df._meta, divisions)
     elif is_dataframe_like(df) or is_series_like(df):
@@ -7014,7 +7396,11 @@ def idxmaxmin_row(x, fn=None, skipna=True):
 def idxmaxmin_combine(x, fn=None, skipna=True):
     if len(x) <= 1:
         return x
-    return x.groupby(level=0).apply(idxmaxmin_row, fn=fn, skipna=skipna).reset_index(level=1, drop=True)
+    return (
+        x.groupby(level=0)
+        .apply(idxmaxmin_row, fn=fn, skipna=skipna)
+        .reset_index(level=1, drop=True)
+    )
 
 
 def idxmaxmin_agg(x, fn=None, skipna=True, scalar=False):
@@ -7031,7 +7417,10 @@ def _mode_aggregate(df, dropna):
     value_count_series = df.sum()
     max_val = value_count_series.max(skipna=dropna)
     mode_series = (
-        value_count_series[value_count_series == max_val].index.to_series().sort_values().reset_index(drop=True)
+        value_count_series[value_count_series == max_val]
+        .index.to_series()
+        .sort_values()
+        .reset_index(drop=True)
     )
     return mode_series
 
@@ -7091,7 +7480,8 @@ def to_datetime(arg, meta=None, **kwargs):
             meta.name = arg.name
         elif not (is_dataframe_like(arg) or is_series_like(arg)):
             raise NotImplementedError(
-                "dask.dataframe.to_datetime does not support " "non-index-able arguments (like scalars)"
+                "dask.dataframe.to_datetime does not support "
+                "non-index-able arguments (like scalars)"
             )
         else:
             meta = pd.Series([pd.Timestamp("2000", **tz_kwarg)])
@@ -7141,7 +7531,9 @@ def new_dd_object(dsk, name, meta, divisions, parent_meta=None):
     elif is_arraylike(meta) and meta.shape:
         import dask.array as da
 
-        chunks = ((np.nan,) * (len(divisions) - 1),) + tuple((d,) for d in meta.shape[1:])
+        chunks = ((np.nan,) * (len(divisions) - 1),) + tuple(
+            (d,) for d in meta.shape[1:]
+        )
         if len(chunks) > 1:
             layer = dsk.layers[name]
             if isinstance(layer, Blockwise):
@@ -7222,7 +7614,9 @@ def partitionwise_graph(func, layer_name, *args, **kwargs):
                 )
         else:
             pairs.extend([arg, None])
-    return blockwise(func, layer_name, "i", *pairs, numblocks=numblocks, concatenate=True, **kwargs)
+    return blockwise(
+        func, layer_name, "i", *pairs, numblocks=numblocks, concatenate=True, **kwargs
+    )
 
 
 def meta_warning(df):
@@ -7244,7 +7638,11 @@ def meta_warning(df):
         "apply function that you are using."
     )
     if meta_str:
-        msg += "\n" "  Before: .apply(func)\n" "  After:  .apply(func, meta=%s)\n" % str(meta_str)
+        msg += (
+            "\n"
+            "  Before: .apply(func)\n"
+            "  After:  .apply(func, meta=%s)\n" % str(meta_str)
+        )
     return msg
 
 
@@ -7435,7 +7833,9 @@ def series_map(base_series, map_series):
     meta = make_meta(meta)
 
     dependencies = [base_series, map_series, base_series.index]
-    graph = HighLevelGraph.from_collections(final_prefix, dsk, dependencies=dependencies)
+    graph = HighLevelGraph.from_collections(
+        final_prefix, dsk, dependencies=dependencies
+    )
     divisions = list(base_series.divisions)
 
     return new_dd_object(graph, final_prefix, meta, divisions)
@@ -7473,4 +7873,7 @@ def _raise_if_not_series_or_dataframe(x, funcname):
     Utility function to raise an error if an object is not a Series or DataFrame
     """
     if not is_series_like(x) and not is_dataframe_like(x):
-        raise NotImplementedError("`%s` is only supported with objects that are Dataframes or Series" % funcname)
+        raise NotImplementedError(
+            "`%s` is only supported with objects that are Dataframes or Series"
+            % funcname
+        )

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4391,9 +4391,7 @@ class DataFrame(_Frame):
             this can be expensive.
             Note that if ``sorted=True``, specified divisions are assumed to match
             the existing partitions in the data; if this is untrue you should
-            leave divisions empty and call ``repartition`` after ``set_index``.
-        inplace: bool, optional
-            Modifying the DataFrame in place is not supported by Dask.
+            leave divisi := e DataFrame in place is not supported by Dask.
             Defaults to False.
         shuffle: string, 'disk' or 'tasks', optional
             Either ``'disk'`` for single-node operation or ``'tasks'`` for
@@ -6117,9 +6115,7 @@ def map_partitions(
 
         args2.insert(0, BlockwiseDepDict(partition_info))
         orig_func = func
-
-        def func(partition_info, *args, **kwargs):
-            return orig_func(*args, **kwargs, partition_info=partition_info)
+        func = lambda partition_info, *args, **kwargs: orig_func(*args, **kwargs, partition_info=partition_info)
 
     if enforce_metadata:
         dsk = partitionwise_graph(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4716,9 +4716,8 @@ class DataFrame(_Frame):
             if other._name == self.index._name:
                 return self
             # Otherwise, check length matches when other isn't one of the data columns
-            if not any(other._name == self[c]._name for c in self) and len(
-                other
-            ) != len(self):
+            is_column = any(other._name == self[c]._name for c in self)
+            if not is_column and len(other) != len(self):
                 raise ValueError(
                     f"Length mismatch: series to become index has {len(other)} rows, but data have {len(self)} rows"
                 )

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4689,6 +4689,8 @@ class DataFrame(_Frame):
 
         # Check other can be translated to column name or column object, possibly flattening it
         if not isinstance(other, str):
+
+            # It may refer to several columns
             if isinstance(other, Sequence):
                 # Accept ["a"], but not [["a"]]
                 if len(other) == 1 and (
@@ -4702,7 +4704,7 @@ class DataFrame(_Frame):
                         "Indexes must be single columns only."
                     )
 
-            # Can also be a frame
+            # Or be a frame directly
             elif isinstance(other, DataFrame):
                 raise NotImplementedError(
                     "Dask dataframe does not yet support multi-indexes.\n"
@@ -4715,18 +4717,13 @@ class DataFrame(_Frame):
             # If it's already the index, there's nothing to do
             if other._name == self.index._name:
                 return self
-            # Otherwise, check length matches when other isn't one of the data columns
-            is_column = any(other._name == self[c]._name for c in self)
-            if not is_column and len(other) != len(self):
-                raise ValueError(
-                    f"Length mismatch: series to become index has {len(other)} rows, but data have {len(self)} rows"
-                )
 
         # If the name of a column/index
         else:
-            # If already the index, no additional checks
+            # With the same name as the index, there's nothing to do either
             if other == self.index.name:
                 return self
+
             # If a missing column, KeyError
             if other not in self.columns:
                 raise KeyError(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6115,7 +6115,9 @@ def map_partitions(
 
         args2.insert(0, BlockwiseDepDict(partition_info))
         orig_func = func
-        func = lambda partition_info, *args, **kwargs: orig_func(*args, **kwargs, partition_info=partition_info)
+
+        def func(partition_info, *args, **kwargs):
+            return orig_func(*args, **kwargs, partition_info=partition_info)
 
     if enforce_metadata:
         dsk = partitionwise_graph(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4711,17 +4711,16 @@ class DataFrame(_Frame):
                 )
 
         # If already a series
-        if is_series := isinstance(other, Series):
+        if isinstance(other, Series):
             # If it's already the index, there's nothing to do
             if other._name == self.index._name:
                 return self
             # Otherwise, check length matches when other isn't one of the data columns
-            s = other
-            if not any(s._name == self[c]._name for c in self.columns) and len(
-                s
+            if not any(other._name == self[c]._name for c in self) and len(
+                other
             ) != len(self):
                 raise ValueError(
-                    f"Length mismatch: series to become index has {len(s)} rows, but data have {len(self)} rows"
+                    f"Length mismatch: series to become index has {len(other)} rows, but data have {len(self)} rows"
                 )
 
         # If the name of a column/index
@@ -4734,18 +4733,6 @@ class DataFrame(_Frame):
                 raise KeyError(
                     f"Data has no column '{other}': use any column of {list(self.columns)}"
                 )
-            s = self[other]
-
-        if s.isna().any().compute():
-            suggested_method = (
-                f"`.dropna(subset=['{other}']).set_index('{other}')`"
-                if not is_series
-                else "`.loc[index[~index.isna()]]`"
-            )
-            raise NotImplementedError(
-                f"Column passed to set_index contains nulls, but Dask does not currently support nulls in the index.\n"
-                f"Consider calling {suggested_method} instead."
-            )
 
         # Check divisions
         if divisions is not None:

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -227,9 +227,15 @@ def from_pandas(data, npartitions=None, chunksize=None, sort=True, name=None):
     if not nrows:
         return new_dd_object({(name, 0): data}, name, data, [None, None])
 
-    if sort and not data.index.is_monotonic_increasing:
-        data = data.sort_index(ascending=True)
+    if data.index.isna().any():
+        raise NotImplementedError(
+            "Index in passed data contains nulls, but Dask does not currently support nulls in the index.\n"
+            "Consider passing `data.loc[data.notna()]` instead."
+        )
+
     if sort:
+        if not data.index.is_monotonic_increasing:
+            data = data.sort_index(ascending=True)
         divisions, locations = sorted_division_locations(
             data.index, chunksize=chunksize
         )

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -215,11 +215,11 @@ def from_pandas(
     from_array : Construct a dask.DataFrame from an array that has record dtype
     read_csv : Construct a dask.DataFrame from a CSV file
     """
+    if isinstance(getattr(data, "index", None), pd.MultiIndex):
+        raise NotImplementedError("Dask does not support MultiIndex Dataframes.")
+
     if not has_parallel_type(data):
         raise TypeError("Input must be a pandas DataFrame or Series.")
-
-    if isinstance(data.index, pd.MultiIndex):
-        raise NotImplementedError("Dask does not support MultiIndex Dataframes.")
 
     if (npartitions is None) == (none_chunksize := (chunksize is None)):
         raise ValueError("Exactly one of npartitions and chunksize must be specified.")

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -242,9 +242,9 @@ def from_pandas(
     if not nrows:
         return new_dd_object({(name, 0): data}, name, data, [None, None])
 
-    if data.index.isna().any():
+    if data.index.isna().any() and not data.index.is_numeric():
         raise NotImplementedError(
-            "Index in passed data contains nulls, but Dask does not currently support nulls in the index.\n"
+            "Index in passed data contains nulls and is non-numeric, which Dask does not currently support.\n"
             "Consider passing `data.loc[~data.isna()]` instead."
         )
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -244,7 +244,7 @@ def from_pandas(
 
     if data.index.isna().any() and not data.index.is_numeric():
         raise NotImplementedError(
-            "Index in passed data contains nulls and is non-numeric, which Dask does not currently support.\n"
+            "Index in passed data is non-numeric and contains nulls, which Dask does not entirely support.\n"
             "Consider passing `data.loc[~data.isna()]` instead."
         )
 

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -355,10 +355,10 @@ def test_from_pandas_with_datetime_index():
     assert_eq(df, ddf)
 
 
-@pytest.mark.parametrize("null_value", [None, pd.NaT, pd.NA, np.nan, float("nan")])
+@pytest.mark.parametrize("null_value", [None, pd.NaT, pd.NA])
 def test_from_pandas_with_index_nulls(null_value):
-    df = pd.DataFrame({"x": [1, 2, 3]}, index=[3, null_value, 2])
-    with pytest.raises(NotImplementedError, match="contains nulls"):
+    df = pd.DataFrame({"x": [1, 2, 3]}, index=["3", null_value, "2"])
+    with pytest.raises(NotImplementedError, match="contains nulls and is non-numeric"):
         dd.from_pandas(df, npartitions=2, sort=False)
 
 

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -355,6 +355,13 @@ def test_from_pandas_with_datetime_index():
     assert_eq(df, ddf)
 
 
+@pytest.mark.parametrize("null_value", [None, pd.NaT, pd.NA, np.nan, float("nan")])
+def test_from_pandas_with_index_nulls(null_value):
+    df = pd.DataFrame({"x": [1, 2, 3]}, index=[3, null_value, 2])
+    with pytest.raises(NotImplementedError, match="contains nulls"):
+        dd.from_pandas(df, npartitions=2, sort=False)
+
+
 def test_DataFrame_from_dask_array():
     x = da.ones((10, 3), chunks=(4, 2))
     pdf = pd.DataFrame(np.ones((10, 3)), columns=["a", "b", "c"])

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -357,8 +357,8 @@ def test_from_pandas_with_datetime_index():
 
 @pytest.mark.parametrize("null_value", [None, pd.NaT, pd.NA])
 def test_from_pandas_with_index_nulls(null_value):
-    df = pd.DataFrame({"x": [1, 2, 3]}, index=["3", null_value, "2"])
-    with pytest.raises(NotImplementedError, match="contains nulls and is non-numeric"):
+    df = pd.DataFrame({"x": [1, 2, 3]}, index=["C", null_value, "A"])
+    with pytest.raises(NotImplementedError, match="is non-numeric and contains nulls"):
         dd.from_pandas(df, npartitions=2, sort=False)
 
 

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -362,6 +362,20 @@ def test_from_pandas_with_index_nulls(null_value):
         dd.from_pandas(df, npartitions=2, sort=False)
 
 
+def test_from_pandas_with_wrong_args():
+    df = pd.DataFrame({"x": [1, 2, 3]}, index=[3, 2, 1])
+    with pytest.raises(TypeError, match="must be a pandas DataFrame or Series"):
+        dd.from_pandas("foo")
+    with pytest.raises(
+        ValueError, match="one of npartitions and chunksize must be specified"
+    ):
+        dd.from_pandas(df)
+    with pytest.raises(TypeError, match="provide npartitions as an int"):
+        dd.from_pandas(df, npartitions=5.2, sort=False)
+    with pytest.raises(TypeError, match="provide chunksize as an int"):
+        dd.from_pandas(df, chunksize=18.27)
+
+
 def test_DataFrame_from_dask_array():
     x = da.ones((10, 3), chunks=(4, 2))
     pdf = pd.DataFrame(np.ones((10, 3)), columns=["a", "b", "c"])

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -85,7 +85,7 @@ def sort_values(
     na_position: Union[Literal["first"], Literal["last"]] = "last",
     upsample: float = 1.0,
     partition_size: float = 128e6,
-    sort_function: Optional[Callable] = None,
+    sort_function: Optional[Callable[[pd.DataFrame], pd.DataFrame]] = None,
     sort_function_kwargs: Optional[Mapping[str, Any]] = None,
     **kwargs,
 ) -> DataFrame:

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -42,12 +42,9 @@ def _calculate_divisions(
     divisions = partition_col._repartition_quantiles(npartitions, upsample=upsample)
     mins = partition_col.map_partitions(M.min)
     maxes = partition_col.map_partitions(M.max)
-    nulls_presence = partition_col.map_partitions(M.isna)
 
     try:
-        divisions, sizes, mins, maxes, nulls_presence = compute(
-            divisions, sizes, mins, maxes, nulls_presence
-        )
+        divisions, sizes, mins, maxes = compute(divisions, sizes, mins, maxes)
     except TypeError as e:
         # When there are nulls and a column is non-numeric, a TypeError is sometimes raised as a result of
         # 1) computing mins/maxes above, 2) every null being switched to NaN, and 3) NaN being a float.

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3699,12 +3699,12 @@ def test_index_nulls(null_value):
     ddf = dd.from_pandas(df.reset_index(drop=False), npartitions=2).assign(
         **{"foo": null_value}
     )
-    with pytest.raises(NotImplementedError, match="contains nulls and is non-numeric"):
+    with pytest.raises(NotImplementedError, match="presence of nulls"):
         ddf.set_index("foo")  # a column all set to nulls
     aux = ddf["index"].map(
         {df.index[0]: df.index[0], df.index[1]: df.index[1]}
     )  # all nulls except first two values
-    with pytest.raises(NotImplementedError, match="contains nulls and is non-numeric"):
+    with pytest.raises(NotImplementedError, match="presence of nulls"):
         ddf.set_index(aux)
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3701,19 +3701,20 @@ def test_index_nulls(null_value):
     )
     with pytest.raises(NotImplementedError, match="contains nulls"):
         ddf.set_index("foo")  # a column all set to nulls
+    aux = ddf["index"].map(
+        {df.index[0]: 0, df.index[1]: 1}
+    )  # all nulls except two first positions
     with pytest.raises(NotImplementedError, match="contains nulls"):
-        ddf.set_index(
-            ddf["index"].map({df.index[0]: 0, df.index[1]: 1})
-        )  # all nulls except two first positions
+        ddf.set_index(aux)
 
 
 def test_set_index_with_index():
-    "Setting the index with the existing index is a no-op (same object returned)"
+    "Setting the index with the existing index is a no-op"
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [1, 0, 1, 0]}).set_index("x")
     ddf = dd.from_pandas(df, npartitions=2)
     ddf2 = ddf.set_index(ddf.index)
     assert ddf2 is ddf
-    ddf = ddf.set_index("x")
+    ddf = ddf.set_index("x", drop=False)
     assert ddf2 is ddf
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3692,9 +3692,9 @@ def test_index_errors():
         ddf.set_index(ddf.partitions[0]["A"])  # only 1st partition, so too short
 
 
-@pytest.mark.parametrize("null_value", [None, pd.NaT, pd.NA, np.nan, float("nan")])
+@pytest.mark.parametrize("null_value", [None, pd.NaT, pd.NA])
 def test_index_nulls(null_value):
-    "Setting the index with some null raises error"
+    "Setting the index with some non-numeric null raises error"
     df = _compat.makeTimeDataFrame()
     ddf = dd.from_pandas(df.reset_index(drop=False), npartitions=2).assign(
         **{"foo": null_value}
@@ -3702,8 +3702,8 @@ def test_index_nulls(null_value):
     with pytest.raises(NotImplementedError, match="contains nulls"):
         ddf.set_index("foo")  # a column all set to nulls
     aux = ddf["index"].map(
-        {df.index[0]: 0, df.index[1]: 1}
-    )  # all nulls except two first positions
+        {df.index[0]: df.index[0], df.index[1]: df.index[1]}
+    )  # all nulls except first two values
     with pytest.raises(NotImplementedError, match="contains nulls"):
         ddf.set_index(aux)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -45,9 +45,7 @@ dsk = {
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
 }
-meta = make_meta(
-    {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
-)
+meta = make_meta({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
 d = dd.DataFrame(dsk, "x", meta, [0, 5, 9, 9])
 full = d.compute()
 CHECK_FREQ = {}
@@ -83,9 +81,7 @@ def test_dataframe_doc_from_non_pandas():
 
 
 def test_Dataframe():
-    expected = pd.Series(
-        [2, 3, 4, 5, 6, 7, 8, 9, 10], index=[0, 1, 3, 5, 6, 8, 9, 9, 9], name="a"
-    )
+    expected = pd.Series([2, 3, 4, 5, 6, 7, 8, 9, 10], index=[0, 1, 3, 5, 6, 8, 9, 9, 9], name="a")
 
     assert_eq(d["a"] + 1, expected)
 
@@ -110,12 +106,8 @@ def test_head_tail():
     assert_eq(d["a"].head(2), full["a"].head(2))
     assert_eq(d["a"].head(3), full["a"].head(3))
     assert_eq(d["a"].head(2), dsk[("x", 0)]["a"].head(2))
-    assert sorted(d.head(2, compute=False).dask) == sorted(
-        d.head(2, compute=False).dask
-    )
-    assert sorted(d.head(2, compute=False).dask) != sorted(
-        d.head(3, compute=False).dask
-    )
+    assert sorted(d.head(2, compute=False).dask) == sorted(d.head(2, compute=False).dask)
+    assert sorted(d.head(2, compute=False).dask) != sorted(d.head(3, compute=False).dask)
 
     assert_eq(d.tail(2), full.tail(2))
     assert_eq(d.tail(3), full.tail(3))
@@ -123,12 +115,8 @@ def test_head_tail():
     assert_eq(d["a"].tail(2), full["a"].tail(2))
     assert_eq(d["a"].tail(3), full["a"].tail(3))
     assert_eq(d["a"].tail(2), dsk[("x", 2)]["a"].tail(2))
-    assert sorted(d.tail(2, compute=False).dask) == sorted(
-        d.tail(2, compute=False).dask
-    )
-    assert sorted(d.tail(2, compute=False).dask) != sorted(
-        d.tail(3, compute=False).dask
-    )
+    assert sorted(d.tail(2, compute=False).dask) == sorted(d.tail(2, compute=False).dask)
+    assert sorted(d.tail(2, compute=False).dask) != sorted(d.tail(3, compute=False).dask)
 
 
 def test_head_npartitions():
@@ -285,9 +273,7 @@ def test_index_names():
         1,
         pytest.param(
             2,
-            marks=pytest.mark.xfail(
-                not dd._compat.PANDAS_GT_110, reason="Fixed upstream."
-            ),
+            marks=pytest.mark.xfail(not dd._compat.PANDAS_GT_110, reason="Fixed upstream."),
         ),
     ],
 )
@@ -390,9 +376,7 @@ def test_rename_series_method_2():
     assert_eq(ds, s)
 
 
-@pytest.mark.parametrize(
-    "method,test_values", [("tdigest", (6, 10)), ("dask", (4, 20))]
-)
+@pytest.mark.parametrize("method,test_values", [("tdigest", (6, 10)), ("dask", (4, 20))])
 def test_describe_numeric(method, test_values):
     if method == "tdigest":
         pytest.importorskip("crick")
@@ -511,14 +495,10 @@ def test_describe(include, exclude, percentiles, subset):
     # Check series
     if subset is None:
         for col in ["a", "c", "e", "g"]:
-            expected = df[col].describe(
-                include=include, exclude=exclude, **datetime_is_numeric_kwarg
-            )
+            expected = df[col].describe(include=include, exclude=exclude, **datetime_is_numeric_kwarg)
             if col == "e" and datetime_is_numeric_kwarg:
                 expected.drop("mean", inplace=True)
-            actual = ddf[col].describe(
-                include=include, exclude=exclude, **datetime_is_numeric_kwarg
-            )
+            actual = ddf[col].describe(include=include, exclude=exclude, **datetime_is_numeric_kwarg)
             assert_eq(expected, actual)
 
 
@@ -551,9 +531,7 @@ def test_describe_without_datetime_is_numeric():
     if PANDAS_GT_110:
         with pytest.warns(
             FutureWarning,
-            match=(
-                "Treating datetime data as categorical rather than numeric in `.describe` is deprecated"
-            ),
+            match=("Treating datetime data as categorical rather than numeric in `.describe` is deprecated"),
         ):
             ddf.e.describe()
     else:
@@ -574,9 +552,7 @@ def test_describe_empty():
 
     # Pandas have different dtypes for resulting describe dataframe if there are only
     # None-values, pre-compute dask df to bypass _meta check
-    assert_eq(
-        df_none.describe(), ddf_none.describe(percentiles_method="dask").compute()
-    )
+    assert_eq(df_none.describe(), ddf_none.describe(percentiles_method="dask").compute())
 
     with pytest.warns(RuntimeWarning):
         ddf_len0.describe(percentiles_method="dask").compute()
@@ -596,9 +572,7 @@ def test_describe_empty_tdigest():
 
     # Pandas have different dtypes for resulting describe dataframe if there are only
     # None-values, pre-compute dask df to bypass _meta check
-    assert_eq(
-        df_none.describe(), ddf_none.describe(percentiles_method="tdigest").compute()
-    )
+    assert_eq(df_none.describe(), ddf_none.describe(percentiles_method="tdigest").compute())
     with warnings.catch_warnings():
         # dask.dataframe should probably filter this, to match pandas, but
         # it seems quite difficult.
@@ -711,19 +685,11 @@ def test_cumulative():
         M.cumprod,
         pytest.param(
             M.cummin,
-            marks=[
-                pytest.mark.xfail(
-                    reason="ValueError: Can only compare identically-labeled Series objects"
-                )
-            ],
+            marks=[pytest.mark.xfail(reason="ValueError: Can only compare identically-labeled Series objects")],
         ),
         pytest.param(
             M.cummax,
-            marks=[
-                pytest.mark.xfail(
-                    reason="ValueError: Can only compare identically-labeled Series objects"
-                )
-            ],
+            marks=[pytest.mark.xfail(reason="ValueError: Can only compare identically-labeled Series objects")],
         ),
     ],
 )
@@ -786,9 +752,7 @@ def test_dropna():
 @pytest.mark.parametrize("lower, upper", [(2, 5), (2.5, 3.5)])
 def test_clip(lower, upper):
 
-    df = pd.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
-    )
+    df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
     ddf = dd.from_pandas(df, 3)
 
     s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9])
@@ -833,9 +797,7 @@ def test_squeeze():
 
 
 def test_where_mask():
-    pdf1 = pd.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
-    )
+    pdf1 = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
     ddf1 = dd.from_pandas(pdf1, 2)
     pdf2 = pd.DataFrame({"a": [True, False, True] * 3, "b": [False, False, True] * 3})
     ddf2 = dd.from_pandas(pdf2, 2)
@@ -907,9 +869,7 @@ def test_where_mask():
 
 def test_map_partitions_multi_argument():
     assert_eq(dd.map_partitions(lambda a, b: a + b, d.a, d.b), full.a + full.b)
-    assert_eq(
-        dd.map_partitions(lambda a, b, c: a + b + c, d.a, d.b, 1), full.a + full.b + 1
-    )
+    assert_eq(dd.map_partitions(lambda a, b, c: a + b + c, d.a, d.b, 1), full.a + full.b + 1)
 
 
 def test_map_partitions():
@@ -957,17 +917,13 @@ def test_map_partitions_partition_info():
 
 def test_map_partitions_names():
     func = lambda x: x
-    assert sorted(dd.map_partitions(func, d, meta=d).dask) == sorted(
-        dd.map_partitions(func, d, meta=d).dask
-    )
+    assert sorted(dd.map_partitions(func, d, meta=d).dask) == sorted(dd.map_partitions(func, d, meta=d).dask)
     assert sorted(dd.map_partitions(lambda x: x, d, meta=d, token=1).dask) == sorted(
         dd.map_partitions(lambda x: x, d, meta=d, token=1).dask
     )
 
     func = lambda x, y: x
-    assert sorted(dd.map_partitions(func, d, d, meta=d).dask) == sorted(
-        dd.map_partitions(func, d, d, meta=d).dask
-    )
+    assert sorted(dd.map_partitions(func, d, d, meta=d).dask) == sorted(dd.map_partitions(func, d, d, meta=d).dask)
 
 
 def test_map_partitions_column_info():
@@ -1082,15 +1038,11 @@ def test_align_dataframes():
     ddf1 = dd.from_pandas(df1, npartitions=2)
     ddf2 = dd.from_pandas(df2, npartitions=1)
 
-    actual = ddf1.map_partitions(
-        pd.merge, df2, align_dataframes=False, left_on="A", right_on="A", how="left"
-    )
+    actual = ddf1.map_partitions(pd.merge, df2, align_dataframes=False, left_on="A", right_on="A", how="left")
     expected = pd.merge(df1, df2, left_on="A", right_on="A", how="left")
     assert_eq(actual, expected, check_index=False, check_divisions=False)
 
-    actual = ddf2.map_partitions(
-        pd.merge, ddf1, align_dataframes=False, left_on="A", right_on="A", how="right"
-    )
+    actual = ddf2.map_partitions(pd.merge, ddf1, align_dataframes=False, left_on="A", right_on="A", how="right")
     expected = pd.merge(df2, df1, left_on="A", right_on="A", how="right")
     assert_eq(actual, expected, check_index=False, check_divisions=False)
 
@@ -1413,9 +1365,7 @@ def test_empty_quantile(method):
 
 
 # TODO: un-filter once https://github.com/dask/dask/issues/8960 is resolved.
-@pytest.mark.filterwarnings(
-    "ignore:In future versions of pandas, numeric_only will be set to False:FutureWarning"
-)
+@pytest.mark.filterwarnings("ignore:In future versions of pandas, numeric_only will be set to False:FutureWarning")
 @pytest.mark.parametrize(
     "method,expected",
     [
@@ -1610,9 +1560,7 @@ def test_assign_callable():
 
 def test_assign_dtypes():
     ddf = dd.from_pandas(
-        pd.DataFrame(
-            data={"col1": ["a", "b"], "col2": [1, 2]}, columns=["col1", "col2"]
-        ),
+        pd.DataFrame(data={"col1": ["a", "b"], "col2": [1, 2]}, columns=["col1", "col2"]),
         npartitions=2,
     )
 
@@ -1818,9 +1766,7 @@ def test_combine():
             assert_eq(dda.combine(ddb, func, fill_value=fill_value), sol)
             assert_eq(dda.combine(b, func, fill_value=fill_value), sol)
 
-    assert_eq(
-        ddf1.combine(ddf2, add, overwrite=False), df1.combine(df2, add, overwrite=False)
-    )
+    assert_eq(ddf1.combine(ddf2, add, overwrite=False), df1.combine(df2, add, overwrite=False))
     assert dda.combine(ddb, add)._name == dda.combine(ddb, add)._name
 
 
@@ -1928,15 +1874,11 @@ def test_repartition():
         """Check data is split properly"""
         keys = [k for k in d.dask if k[0].startswith("repartition-split")]
         keys = sorted(keys)
-        sp = pd.concat(
-            [compute_as_if_collection(dd.DataFrame, d.dask, k) for k in keys]
-        )
+        sp = pd.concat([compute_as_if_collection(dd.DataFrame, d.dask, k) for k in keys])
         assert_eq(orig, sp)
         assert_eq(orig, d)
 
-    df = pd.DataFrame(
-        {"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60]
-    )
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60])
     a = dd.from_pandas(df, 2)
 
     b = a.repartition(divisions=[10, 20, 50, 60])
@@ -2055,9 +1997,7 @@ def test_repartition_divisions():
 
 
 def test_repartition_on_pandas_dataframe():
-    df = pd.DataFrame(
-        {"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60]
-    )
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60])
     ddf = dd.repartition(df, divisions=[10, 20, 50, 60])
     assert isinstance(ddf, dd.DataFrame)
     assert ddf.divisions == (10, 20, 50, 60)
@@ -2156,12 +2096,8 @@ def test_repartition_object_index():
 @pytest.mark.slow
 @pytest.mark.parametrize("npartitions", [1, 20, 243])
 @pytest.mark.parametrize("freq", ["1D", "7D", "28h", "1h"])
-@pytest.mark.parametrize(
-    "end", ["2000-04-15", "2000-04-15 12:37:01", "2000-01-01 12:37:00"]
-)
-@pytest.mark.parametrize(
-    "start", ["2000-01-01", "2000-01-01 12:30:00", "2000-01-01 12:30:00"]
-)
+@pytest.mark.parametrize("end", ["2000-04-15", "2000-04-15 12:37:01", "2000-01-01 12:37:00"])
+@pytest.mark.parametrize("start", ["2000-01-01", "2000-01-01 12:30:00", "2000-01-01 12:30:00"])
 def test_repartition_freq(npartitions, freq, start, end):
     start = pd.Timestamp(start)
     end = pd.Timestamp(end)
@@ -2200,9 +2136,7 @@ def test_repartition_freq_errors():
 
 def test_repartition_freq_month():
     ts = pd.date_range("2015-01-01 00:00", "2015-05-01 23:50", freq="10min")
-    df = pd.DataFrame(
-        np.random.randint(0, 100, size=(len(ts), 4)), columns=list("ABCD"), index=ts
-    )
+    df = pd.DataFrame(np.random.randint(0, 100, size=(len(ts), 4)), columns=list("ABCD"), index=ts)
     ddf = dd.from_pandas(df, npartitions=1).repartition(freq="MS")
 
     assert_eq(df, ddf)
@@ -2316,9 +2250,7 @@ def test_fillna():
     assert_eq(ddf.A.fillna(method="pad", limit=2), df.A.fillna(method="pad", limit=2))
 
     assert_eq(ddf.fillna(method="bfill", limit=2), df.fillna(method="bfill", limit=2))
-    assert_eq(
-        ddf.A.fillna(method="bfill", limit=2), df.A.fillna(method="bfill", limit=2)
-    )
+    assert_eq(ddf.A.fillna(method="bfill", limit=2), df.A.fillna(method="bfill", limit=2))
 
     assert_eq(ddf.fillna(100, axis=1), df.fillna(100, axis=1))
     assert_eq(ddf.fillna(method="pad", axis=1), df.fillna(method="pad", axis=1))
@@ -2344,9 +2276,7 @@ def test_delayed_roundtrip(optimize):
     delayed = df1.to_delayed(optimize_graph=optimize)
 
     for x in delayed:
-        assert x.__dask_layers__() == (
-            "delayed-" + df1._name if optimize else df1._name,
-        )
+        assert x.__dask_layers__() == ("delayed-" + df1._name if optimize else df1._name,)
         x.dask.validate()
 
     assert len(delayed) == df1.npartitions
@@ -2550,12 +2480,8 @@ def test_deterministic_apply_concat_apply_names():
     # Test aca without passing in token string
     f = lambda a: a.nlargest(5)
     f2 = lambda a: a.nlargest(3)
-    assert sorted(aca(a.x, f, f, a.x._meta).dask) != sorted(
-        aca(a.x, f2, f2, a.x._meta).dask
-    )
-    assert sorted(aca(a.x, f, f, a.x._meta).dask) == sorted(
-        aca(a.x, f, f, a.x._meta).dask
-    )
+    assert sorted(aca(a.x, f, f, a.x._meta).dask) != sorted(aca(a.x, f2, f2, a.x._meta).dask)
+    assert sorted(aca(a.x, f, f, a.x._meta).dask) == sorted(aca(a.x, f, f, a.x._meta).dask)
 
     # Test aca with keywords
     def chunk(x, c_key=0, both_key=0):
@@ -2615,9 +2541,7 @@ def test_aca_meta_infer():
     assert_eq(res, sol)
 
     # Should infer as a scalar
-    res = aca(
-        [ddf.x], chunk=lambda x: pd.Series([x.sum()]), aggregate=lambda x: x.sum()
-    )
+    res = aca([ddf.x], chunk=lambda x: pd.Series([x.sum()]), aggregate=lambda x: x.sum())
     assert isinstance(res, Scalar)
     assert res.compute() == df.x.sum()
 
@@ -2758,9 +2682,7 @@ def test_reduction_method_split_every():
     # Keywords are different for each step
     assert f(3).compute() == 60 + 15 + 7 * (2 + 1) + (3 + 2)
     # Keywords are same for each step
-    res = ddf.reduction(
-        chunk, aggregate=agg, combine=combine, constant=3.0, split_every=3
-    )
+    res = ddf.reduction(chunk, aggregate=agg, combine=combine, constant=3.0, split_every=3)
     assert res.compute() == 60 + 15 * 3 + 7 * (3 + 1) + (3 + 2)
     # No combine provided, combine is agg
     res = ddf.reduction(chunk, aggregate=agg, constant=3.0, split_every=3)
@@ -2962,9 +2884,7 @@ def test_apply():
     ddf = dd.from_pandas(df, npartitions=2)
 
     func = lambda row: row["x"] + row["y"]
-    assert_eq(
-        ddf.x.apply(lambda x: x + 1, meta=("x", int)), df.x.apply(lambda x: x + 1)
-    )
+    assert_eq(ddf.x.apply(lambda x: x + 1, meta=("x", int)), df.x.apply(lambda x: x + 1))
 
     # specify meta
     assert_eq(
@@ -3386,13 +3306,9 @@ def test_series_iteritems():
     df = pd.DataFrame({"x": [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)
     # `iteritems` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"):
         pd_items = df["x"].iteritems()
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"):
         dd_items = ddf["x"].iteritems()
     for (a, b) in zip(pd_items, dd_items):
         assert a == b
@@ -3455,9 +3371,7 @@ def test_dataframe_itertuples_with_name_none():
 
 
 def test_astype():
-    df = pd.DataFrame(
-        {"x": [1, 2, 3, None], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
-    )
+    df = pd.DataFrame({"x": [1, 2, 3, None], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40])
     a = dd.from_pandas(df, 2)
 
     assert_eq(a.astype(float), df.astype(float))
@@ -3578,9 +3492,7 @@ def test_info():
     # Verbose=False
     ddf.info(buf=buf, verbose=False)
     assert buf.getvalue() == (
-        "<class 'dask.dataframe.core.DataFrame'>\n"
-        "Columns: 2 entries, x to y\n"
-        "dtypes: int64(2)"
+        "<class 'dask.dataframe.core.DataFrame'>\n" "Columns: 2 entries, x to y\n" "dtypes: int64(2)"
     )
 
     # buf=None
@@ -3603,9 +3515,7 @@ def test_groupby_multilevel_info():
     buf = StringIO()
     g.info(buf, verbose=False)
     assert buf.getvalue() == (
-        "<class 'dask.dataframe.core.DataFrame'>\n"
-        "Columns: 1 entries, C to C\n"
-        "dtypes: int64(1)"
+        "<class 'dask.dataframe.core.DataFrame'>\n" "Columns: 1 entries, C to C\n" "dtypes: int64(1)"
     )
 
     # multilevel
@@ -3686,9 +3596,7 @@ def test_index_errors():
     with pytest.raises(KeyError, match="has no column"):
         ddf.set_index("foo")  # a column that doesn't exist
     with pytest.raises(KeyError, match="has no column"):
-        ddf.set_index(
-            0
-        )  # a column that doesn't exist, even if the column "name" isn't a string (Pandas admits this)
+        ddf.set_index(0)  # a column that doesn't exist, even if the column "name" isn't a string (Pandas admits this)
     with pytest.raises(ValueError, match="Length mismatch"):
         ddf.set_index(ddf.partitions[0]["A"])  # only 1st partition, so too short
 
@@ -3698,9 +3606,7 @@ def test_index_nulls(null_value):
     df = _compat.makeTimeDataFrame()
     ddf = dd.from_pandas(df.reset_index(), npartitions=2)
     with pytest.raises(NotImplementedError, match="contains nulls"):
-        ddf.assign(**{"foo": null_value}).set_index(
-            "foo"
-        )  # now foo exists, but it's a null column
+        ddf.assign(**{"foo": null_value}).set_index("foo")  # now foo exists, but it's a null column
 
 
 def test_column_assignment():
@@ -3794,69 +3700,42 @@ def test_idxmaxmin(idx, skipna):
     ddf = dd.from_pandas(df, npartitions=3)
 
     # https://github.com/pandas-dev/pandas/issues/43587
-    check_dtype = not all(
-        (_compat.PANDAS_GT_133, skipna is False, isinstance(idx, pd.DatetimeIndex))
-    )
+    check_dtype = not all((_compat.PANDAS_GT_133, skipna is False, isinstance(idx, pd.DatetimeIndex)))
 
     with warnings.catch_warnings(record=True):
         assert_eq(df.idxmax(axis=1, skipna=skipna), ddf.idxmax(axis=1, skipna=skipna))
         assert_eq(df.idxmin(axis=1, skipna=skipna), ddf.idxmin(axis=1, skipna=skipna))
 
-        assert_eq(
-            df.idxmax(skipna=skipna), ddf.idxmax(skipna=skipna), check_dtype=check_dtype
-        )
+        assert_eq(df.idxmax(skipna=skipna), ddf.idxmax(skipna=skipna), check_dtype=check_dtype)
         assert_eq(
             df.idxmax(skipna=skipna),
             ddf.idxmax(skipna=skipna, split_every=2),
             check_dtype=check_dtype,
         )
-        assert (
-            ddf.idxmax(skipna=skipna)._name
-            != ddf.idxmax(skipna=skipna, split_every=2)._name
-        )
+        assert ddf.idxmax(skipna=skipna)._name != ddf.idxmax(skipna=skipna, split_every=2)._name
 
-        assert_eq(
-            df.idxmin(skipna=skipna), ddf.idxmin(skipna=skipna), check_dtype=check_dtype
-        )
+        assert_eq(df.idxmin(skipna=skipna), ddf.idxmin(skipna=skipna), check_dtype=check_dtype)
         assert_eq(
             df.idxmin(skipna=skipna),
             ddf.idxmin(skipna=skipna, split_every=2),
             check_dtype=check_dtype,
         )
-        assert (
-            ddf.idxmin(skipna=skipna)._name
-            != ddf.idxmin(skipna=skipna, split_every=2)._name
-        )
+        assert ddf.idxmin(skipna=skipna)._name != ddf.idxmin(skipna=skipna, split_every=2)._name
 
         assert_eq(df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna))
-        assert_eq(
-            df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna, split_every=2)
-        )
-        assert (
-            ddf.a.idxmax(skipna=skipna)._name
-            != ddf.a.idxmax(skipna=skipna, split_every=2)._name
-        )
+        assert_eq(df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna, split_every=2))
+        assert ddf.a.idxmax(skipna=skipna)._name != ddf.a.idxmax(skipna=skipna, split_every=2)._name
 
         assert_eq(df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna))
-        assert_eq(
-            df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna, split_every=2)
-        )
-        assert (
-            ddf.a.idxmin(skipna=skipna)._name
-            != ddf.a.idxmin(skipna=skipna, split_every=2)._name
-        )
+        assert_eq(df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna, split_every=2))
+        assert ddf.a.idxmin(skipna=skipna)._name != ddf.a.idxmin(skipna=skipna, split_every=2)._name
 
 
 def test_idxmaxmin_empty_partitions():
-    df = pd.DataFrame(
-        {"a": [1, 2, 3], "b": [1.5, 2, 3], "c": [np.NaN] * 3, "d": [1, 2, np.NaN]}
-    )
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [1.5, 2, 3], "c": [np.NaN] * 3, "d": [1, 2, np.NaN]})
     empty = df.iloc[:0]
 
-    ddf = dd.concat(
-        [dd.from_pandas(df, npartitions=1)]
-        + [dd.from_pandas(empty, npartitions=1)] * 10
-    )
+    ddf = dd.concat([dd.from_pandas(df, npartitions=1)] + [dd.from_pandas(empty, npartitions=1)] * 10)
 
     for skipna in [True, False]:
         assert_eq(ddf.idxmin(skipna=skipna, split_every=3), df.idxmin(skipna=skipna))
@@ -4049,9 +3928,7 @@ def test_first_and_last(method):
     offsets = ["0d", "100h", "20d", "20B", "3W", "3M", "400d", "13M"]
     for freq in freqs:
         index = pd.date_range("1/1/2000", "1/1/2001", freq=freq)[::4]
-        df = pd.DataFrame(
-            np.random.random((len(index), 4)), index=index, columns=["A", "B", "C", "D"]
-        )
+        df = pd.DataFrame(np.random.random((len(index), 4)), index=index, columns=["A", "B", "C", "D"])
         ddf = dd.from_pandas(df, npartitions=10)
         for offset in offsets:
             assert_eq(f(ddf, offset), f(df, offset))
@@ -4093,9 +3970,7 @@ def test_split_out_drop_duplicates(split_every):
 
     for subset, keep in product([None, ["x", "z"]], ["first", "last"]):
         sol = df.drop_duplicates(subset=subset, keep=keep)
-        res = ddf.drop_duplicates(
-            subset=subset, keep=keep, split_every=split_every, split_out=10
-        )
+        res = ddf.drop_duplicates(subset=subset, keep=keep, split_every=split_every, split_out=10)
         assert res.npartitions == 10
         assert_eq(sol, res)
 
@@ -4106,9 +3981,7 @@ def test_split_out_value_counts(split_every):
     ddf = dd.from_pandas(df, npartitions=5)
 
     assert ddf.x.value_counts(split_out=10, split_every=split_every).npartitions == 10
-    assert_eq(
-        ddf.x.value_counts(split_out=10, split_every=split_every), df.x.value_counts()
-    )
+    assert_eq(ddf.x.value_counts(split_out=10, split_every=split_every), df.x.value_counts())
 
 
 def test_values():
@@ -4139,8 +4012,7 @@ def test_copy():
     assert_eq(c, df)
 
     deep_err = (
-        "The `deep` value must be False. This is strictly a shallow copy "
-        "of the underlying computational graph."
+        "The `deep` value must be False. This is strictly a shallow copy " "of the underlying computational graph."
     )
     for deep in [True, None, ""]:
         with pytest.raises(ValueError, match=deep_err):
@@ -4172,10 +4044,7 @@ def test_memory_usage(index, deep):
         df.memory_usage(index=index, deep=deep),
         ddf.memory_usage(index=index, deep=deep),
     )
-    assert (
-        df.x.memory_usage(index=index, deep=deep)
-        == ddf.x.memory_usage(index=index, deep=deep).compute()
-    )
+    assert df.x.memory_usage(index=index, deep=deep) == ddf.x.memory_usage(index=index, deep=deep).compute()
 
 
 @pytest.mark.parametrize("index", [True, False])
@@ -4191,17 +4060,12 @@ def test_memory_usage_per_partition(index, deep):
     ddf = dd.from_pandas(df, npartitions=2)
 
     # DataFrame.memory_usage_per_partition
-    expected = pd.Series(
-        part.compute().memory_usage(index=index, deep=deep).sum()
-        for part in ddf.partitions
-    )
+    expected = pd.Series(part.compute().memory_usage(index=index, deep=deep).sum() for part in ddf.partitions)
     result = ddf.memory_usage_per_partition(index=index, deep=deep)
     assert_eq(expected, result)
 
     # Series.memory_usage_per_partition
-    expected = pd.Series(
-        part.x.compute().memory_usage(index=index, deep=deep) for part in ddf.partitions
-    )
+    expected = pd.Series(part.x.compute().memory_usage(index=index, deep=deep) for part in ddf.partitions)
     result = ddf.x.memory_usage_per_partition(index=index, deep=deep)
     assert_eq(expected, result)
 
@@ -4227,9 +4091,7 @@ def test_dataframe_reductions_arithmetic(reduction):
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [1.1, 2.2, 3.3, 4.4, 5.5]})
     ddf = dd.from_pandas(df, npartitions=3)
 
-    assert_eq(
-        ddf - (getattr(ddf, reduction)() + 1), df - (getattr(df, reduction)() + 1)
-    )
+    assert_eq(ddf - (getattr(ddf, reduction)() + 1), df - (getattr(df, reduction)() + 1))
 
 
 def test_dataframe_mode():
@@ -4531,9 +4393,7 @@ def test_mixed_dask_array_operations_errors():
 
 
 def test_mixed_dask_array_multi_dimensional():
-    df = pd.DataFrame(
-        {"x": [1, 2, 3, 4, 5], "y": [5.0, 6.0, 7.0, 8.0, 9.0]}, columns=["x", "y"]
-    )
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [5.0, 6.0, 7.0, 8.0, 9.0]}, columns=["x", "y"])
     ddf = dd.from_pandas(df, npartitions=2)
 
     x = (df.values + 1).astype(float)
@@ -4781,9 +4641,7 @@ def test_dtype_cast():
 @pytest.mark.parametrize("sorted_index", [False, True])
 @pytest.mark.parametrize("sorted_map_index", [False, True])
 def test_series_map(base_npart, map_npart, sorted_index, sorted_map_index):
-    base = pd.Series(
-        ["".join(np.random.choice(["a", "b", "c"], size=3)) for x in range(100)]
-    )
+    base = pd.Series(["".join(np.random.choice(["a", "b", "c"], size=3)) for x in range(100)])
     if not sorted_index:
         index = np.arange(100)
         np.random.shuffle(index)
@@ -4833,14 +4691,10 @@ def test_pop():
 @pytest.mark.parametrize("dropna", [True, False])
 @pytest.mark.parametrize("axis", [0, 1])
 def test_nunique(dropna, axis):
-    df = pd.DataFrame(
-        {"x": ["a", "a", "c"], "y": [None, 1, 2], "c": np.arange(0, 1, 0.4)}
-    )
+    df = pd.DataFrame({"x": ["a", "a", "c"], "y": [None, 1, 2], "c": np.arange(0, 1, 0.4)})
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf["y"].nunique(dropna=dropna), df["y"].nunique(dropna=dropna))
-    assert_eq(
-        ddf.nunique(dropna=dropna, axis=axis), df.nunique(dropna=dropna, axis=axis)
-    )
+    assert_eq(ddf.nunique(dropna=dropna, axis=axis), df.nunique(dropna=dropna, axis=axis))
 
 
 def test_view():
@@ -4898,9 +4752,7 @@ def test_dataframe_groupby_cumprod_agg_empty_partitions():
 
 
 def test_fuse_roots():
-    pdf1 = pd.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
-    )
+    pdf1 = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
     ddf1 = dd.from_pandas(pdf1, 2)
     pdf2 = pd.DataFrame({"a": [True, False, True] * 3, "b": [False, False, True] * 3})
     ddf2 = dd.from_pandas(pdf2, 2)
@@ -4980,9 +4832,7 @@ def test_repr_html_dataframe_highlevelgraph():
         assert xml.etree.ElementTree.fromstring(layer._repr_html_()) is not None
 
 
-@pytest.mark.skipif(
-    not dd._compat.PANDAS_GT_120, reason="Float64 was introduced in pandas>=1.2"
-)
+@pytest.mark.skipif(not dd._compat.PANDAS_GT_120, reason="Float64 was introduced in pandas>=1.2")
 def test_assign_na_float_columns():
     # See https://github.com/dask/dask/issues/7156
     df_pandas = pd.DataFrame({"a": [1.1]}, dtype="Float64")
@@ -5074,13 +4924,9 @@ def test_is_monotonic_numeric():
     ds = dd.from_pandas(s, npartitions=5)
     assert_eq(s.is_monotonic_increasing, ds.is_monotonic_increasing)
     # `is_monotonic` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
         expected = s.is_monotonic
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
         result = ds.is_monotonic
     assert_eq(expected, result)
 
@@ -5109,13 +4955,9 @@ def test_index_is_monotonic_numeric():
     ds = dd.from_pandas(s, npartitions=5, sort=False)
     assert_eq(s.index.is_monotonic_increasing, ds.index.is_monotonic_increasing)
     # `is_monotonic` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
         expected = s.index.is_monotonic
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
         result = ds.index.is_monotonic
     assert_eq(expected, result)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -45,7 +45,9 @@ dsk = {
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
 }
-meta = make_meta({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
+meta = make_meta(
+    {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
+)
 d = dd.DataFrame(dsk, "x", meta, [0, 5, 9, 9])
 full = d.compute()
 CHECK_FREQ = {}
@@ -81,7 +83,9 @@ def test_dataframe_doc_from_non_pandas():
 
 
 def test_Dataframe():
-    expected = pd.Series([2, 3, 4, 5, 6, 7, 8, 9, 10], index=[0, 1, 3, 5, 6, 8, 9, 9, 9], name="a")
+    expected = pd.Series(
+        [2, 3, 4, 5, 6, 7, 8, 9, 10], index=[0, 1, 3, 5, 6, 8, 9, 9, 9], name="a"
+    )
 
     assert_eq(d["a"] + 1, expected)
 
@@ -106,8 +110,12 @@ def test_head_tail():
     assert_eq(d["a"].head(2), full["a"].head(2))
     assert_eq(d["a"].head(3), full["a"].head(3))
     assert_eq(d["a"].head(2), dsk[("x", 0)]["a"].head(2))
-    assert sorted(d.head(2, compute=False).dask) == sorted(d.head(2, compute=False).dask)
-    assert sorted(d.head(2, compute=False).dask) != sorted(d.head(3, compute=False).dask)
+    assert sorted(d.head(2, compute=False).dask) == sorted(
+        d.head(2, compute=False).dask
+    )
+    assert sorted(d.head(2, compute=False).dask) != sorted(
+        d.head(3, compute=False).dask
+    )
 
     assert_eq(d.tail(2), full.tail(2))
     assert_eq(d.tail(3), full.tail(3))
@@ -115,8 +123,12 @@ def test_head_tail():
     assert_eq(d["a"].tail(2), full["a"].tail(2))
     assert_eq(d["a"].tail(3), full["a"].tail(3))
     assert_eq(d["a"].tail(2), dsk[("x", 2)]["a"].tail(2))
-    assert sorted(d.tail(2, compute=False).dask) == sorted(d.tail(2, compute=False).dask)
-    assert sorted(d.tail(2, compute=False).dask) != sorted(d.tail(3, compute=False).dask)
+    assert sorted(d.tail(2, compute=False).dask) == sorted(
+        d.tail(2, compute=False).dask
+    )
+    assert sorted(d.tail(2, compute=False).dask) != sorted(
+        d.tail(3, compute=False).dask
+    )
 
 
 def test_head_npartitions():
@@ -273,7 +285,9 @@ def test_index_names():
         1,
         pytest.param(
             2,
-            marks=pytest.mark.xfail(not dd._compat.PANDAS_GT_110, reason="Fixed upstream."),
+            marks=pytest.mark.xfail(
+                not dd._compat.PANDAS_GT_110, reason="Fixed upstream."
+            ),
         ),
     ],
 )
@@ -376,7 +390,9 @@ def test_rename_series_method_2():
     assert_eq(ds, s)
 
 
-@pytest.mark.parametrize("method,test_values", [("tdigest", (6, 10)), ("dask", (4, 20))])
+@pytest.mark.parametrize(
+    "method,test_values", [("tdigest", (6, 10)), ("dask", (4, 20))]
+)
 def test_describe_numeric(method, test_values):
     if method == "tdigest":
         pytest.importorskip("crick")
@@ -495,10 +511,14 @@ def test_describe(include, exclude, percentiles, subset):
     # Check series
     if subset is None:
         for col in ["a", "c", "e", "g"]:
-            expected = df[col].describe(include=include, exclude=exclude, **datetime_is_numeric_kwarg)
+            expected = df[col].describe(
+                include=include, exclude=exclude, **datetime_is_numeric_kwarg
+            )
             if col == "e" and datetime_is_numeric_kwarg:
                 expected.drop("mean", inplace=True)
-            actual = ddf[col].describe(include=include, exclude=exclude, **datetime_is_numeric_kwarg)
+            actual = ddf[col].describe(
+                include=include, exclude=exclude, **datetime_is_numeric_kwarg
+            )
             assert_eq(expected, actual)
 
 
@@ -531,7 +551,9 @@ def test_describe_without_datetime_is_numeric():
     if PANDAS_GT_110:
         with pytest.warns(
             FutureWarning,
-            match=("Treating datetime data as categorical rather than numeric in `.describe` is deprecated"),
+            match=(
+                "Treating datetime data as categorical rather than numeric in `.describe` is deprecated"
+            ),
         ):
             ddf.e.describe()
     else:
@@ -552,7 +574,9 @@ def test_describe_empty():
 
     # Pandas have different dtypes for resulting describe dataframe if there are only
     # None-values, pre-compute dask df to bypass _meta check
-    assert_eq(df_none.describe(), ddf_none.describe(percentiles_method="dask").compute())
+    assert_eq(
+        df_none.describe(), ddf_none.describe(percentiles_method="dask").compute()
+    )
 
     with pytest.warns(RuntimeWarning):
         ddf_len0.describe(percentiles_method="dask").compute()
@@ -572,7 +596,9 @@ def test_describe_empty_tdigest():
 
     # Pandas have different dtypes for resulting describe dataframe if there are only
     # None-values, pre-compute dask df to bypass _meta check
-    assert_eq(df_none.describe(), ddf_none.describe(percentiles_method="tdigest").compute())
+    assert_eq(
+        df_none.describe(), ddf_none.describe(percentiles_method="tdigest").compute()
+    )
     with warnings.catch_warnings():
         # dask.dataframe should probably filter this, to match pandas, but
         # it seems quite difficult.
@@ -685,11 +711,19 @@ def test_cumulative():
         M.cumprod,
         pytest.param(
             M.cummin,
-            marks=[pytest.mark.xfail(reason="ValueError: Can only compare identically-labeled Series objects")],
+            marks=[
+                pytest.mark.xfail(
+                    reason="ValueError: Can only compare identically-labeled Series objects"
+                )
+            ],
         ),
         pytest.param(
             M.cummax,
-            marks=[pytest.mark.xfail(reason="ValueError: Can only compare identically-labeled Series objects")],
+            marks=[
+                pytest.mark.xfail(
+                    reason="ValueError: Can only compare identically-labeled Series objects"
+                )
+            ],
         ),
     ],
 )
@@ -752,7 +786,9 @@ def test_dropna():
 @pytest.mark.parametrize("lower, upper", [(2, 5), (2.5, 3.5)])
 def test_clip(lower, upper):
 
-    df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
+    df = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
+    )
     ddf = dd.from_pandas(df, 3)
 
     s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9])
@@ -797,7 +833,9 @@ def test_squeeze():
 
 
 def test_where_mask():
-    pdf1 = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
+    pdf1 = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
+    )
     ddf1 = dd.from_pandas(pdf1, 2)
     pdf2 = pd.DataFrame({"a": [True, False, True] * 3, "b": [False, False, True] * 3})
     ddf2 = dd.from_pandas(pdf2, 2)
@@ -869,7 +907,9 @@ def test_where_mask():
 
 def test_map_partitions_multi_argument():
     assert_eq(dd.map_partitions(lambda a, b: a + b, d.a, d.b), full.a + full.b)
-    assert_eq(dd.map_partitions(lambda a, b, c: a + b + c, d.a, d.b, 1), full.a + full.b + 1)
+    assert_eq(
+        dd.map_partitions(lambda a, b, c: a + b + c, d.a, d.b, 1), full.a + full.b + 1
+    )
 
 
 def test_map_partitions():
@@ -917,13 +957,17 @@ def test_map_partitions_partition_info():
 
 def test_map_partitions_names():
     func = lambda x: x
-    assert sorted(dd.map_partitions(func, d, meta=d).dask) == sorted(dd.map_partitions(func, d, meta=d).dask)
+    assert sorted(dd.map_partitions(func, d, meta=d).dask) == sorted(
+        dd.map_partitions(func, d, meta=d).dask
+    )
     assert sorted(dd.map_partitions(lambda x: x, d, meta=d, token=1).dask) == sorted(
         dd.map_partitions(lambda x: x, d, meta=d, token=1).dask
     )
 
     func = lambda x, y: x
-    assert sorted(dd.map_partitions(func, d, d, meta=d).dask) == sorted(dd.map_partitions(func, d, d, meta=d).dask)
+    assert sorted(dd.map_partitions(func, d, d, meta=d).dask) == sorted(
+        dd.map_partitions(func, d, d, meta=d).dask
+    )
 
 
 def test_map_partitions_column_info():
@@ -1038,11 +1082,15 @@ def test_align_dataframes():
     ddf1 = dd.from_pandas(df1, npartitions=2)
     ddf2 = dd.from_pandas(df2, npartitions=1)
 
-    actual = ddf1.map_partitions(pd.merge, df2, align_dataframes=False, left_on="A", right_on="A", how="left")
+    actual = ddf1.map_partitions(
+        pd.merge, df2, align_dataframes=False, left_on="A", right_on="A", how="left"
+    )
     expected = pd.merge(df1, df2, left_on="A", right_on="A", how="left")
     assert_eq(actual, expected, check_index=False, check_divisions=False)
 
-    actual = ddf2.map_partitions(pd.merge, ddf1, align_dataframes=False, left_on="A", right_on="A", how="right")
+    actual = ddf2.map_partitions(
+        pd.merge, ddf1, align_dataframes=False, left_on="A", right_on="A", how="right"
+    )
     expected = pd.merge(df2, df1, left_on="A", right_on="A", how="right")
     assert_eq(actual, expected, check_index=False, check_divisions=False)
 
@@ -1562,7 +1610,9 @@ def test_assign_callable():
 
 def test_assign_dtypes():
     ddf = dd.from_pandas(
-        pd.DataFrame(data={"col1": ["a", "b"], "col2": [1, 2]}, columns=["col1", "col2"]),
+        pd.DataFrame(
+            data={"col1": ["a", "b"], "col2": [1, 2]}, columns=["col1", "col2"]
+        ),
         npartitions=2,
     )
 
@@ -1768,7 +1818,9 @@ def test_combine():
             assert_eq(dda.combine(ddb, func, fill_value=fill_value), sol)
             assert_eq(dda.combine(b, func, fill_value=fill_value), sol)
 
-    assert_eq(ddf1.combine(ddf2, add, overwrite=False), df1.combine(df2, add, overwrite=False))
+    assert_eq(
+        ddf1.combine(ddf2, add, overwrite=False), df1.combine(df2, add, overwrite=False)
+    )
     assert dda.combine(ddb, add)._name == dda.combine(ddb, add)._name
 
 
@@ -1876,11 +1928,15 @@ def test_repartition():
         """Check data is split properly"""
         keys = [k for k in d.dask if k[0].startswith("repartition-split")]
         keys = sorted(keys)
-        sp = pd.concat([compute_as_if_collection(dd.DataFrame, d.dask, k) for k in keys])
+        sp = pd.concat(
+            [compute_as_if_collection(dd.DataFrame, d.dask, k) for k in keys]
+        )
         assert_eq(orig, sp)
         assert_eq(orig, d)
 
-    df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60])
+    df = pd.DataFrame(
+        {"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60]
+    )
     a = dd.from_pandas(df, 2)
 
     b = a.repartition(divisions=[10, 20, 50, 60])
@@ -1999,7 +2055,9 @@ def test_repartition_divisions():
 
 
 def test_repartition_on_pandas_dataframe():
-    df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60])
+    df = pd.DataFrame(
+        {"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60]
+    )
     ddf = dd.repartition(df, divisions=[10, 20, 50, 60])
     assert isinstance(ddf, dd.DataFrame)
     assert ddf.divisions == (10, 20, 50, 60)
@@ -2098,8 +2156,12 @@ def test_repartition_object_index():
 @pytest.mark.slow
 @pytest.mark.parametrize("npartitions", [1, 20, 243])
 @pytest.mark.parametrize("freq", ["1D", "7D", "28h", "1h"])
-@pytest.mark.parametrize("end", ["2000-04-15", "2000-04-15 12:37:01", "2000-01-01 12:37:00"])
-@pytest.mark.parametrize("start", ["2000-01-01", "2000-01-01 12:30:00", "2000-01-01 12:30:00"])
+@pytest.mark.parametrize(
+    "end", ["2000-04-15", "2000-04-15 12:37:01", "2000-01-01 12:37:00"]
+)
+@pytest.mark.parametrize(
+    "start", ["2000-01-01", "2000-01-01 12:30:00", "2000-01-01 12:30:00"]
+)
 def test_repartition_freq(npartitions, freq, start, end):
     start = pd.Timestamp(start)
     end = pd.Timestamp(end)
@@ -2138,7 +2200,9 @@ def test_repartition_freq_errors():
 
 def test_repartition_freq_month():
     ts = pd.date_range("2015-01-01 00:00", "2015-05-01 23:50", freq="10min")
-    df = pd.DataFrame(np.random.randint(0, 100, size=(len(ts), 4)), columns=list("ABCD"), index=ts)
+    df = pd.DataFrame(
+        np.random.randint(0, 100, size=(len(ts), 4)), columns=list("ABCD"), index=ts
+    )
     ddf = dd.from_pandas(df, npartitions=1).repartition(freq="MS")
 
     assert_eq(df, ddf)
@@ -2252,7 +2316,9 @@ def test_fillna():
     assert_eq(ddf.A.fillna(method="pad", limit=2), df.A.fillna(method="pad", limit=2))
 
     assert_eq(ddf.fillna(method="bfill", limit=2), df.fillna(method="bfill", limit=2))
-    assert_eq(ddf.A.fillna(method="bfill", limit=2), df.A.fillna(method="bfill", limit=2))
+    assert_eq(
+        ddf.A.fillna(method="bfill", limit=2), df.A.fillna(method="bfill", limit=2)
+    )
 
     assert_eq(ddf.fillna(100, axis=1), df.fillna(100, axis=1))
     assert_eq(ddf.fillna(method="pad", axis=1), df.fillna(method="pad", axis=1))
@@ -2278,7 +2344,9 @@ def test_delayed_roundtrip(optimize):
     delayed = df1.to_delayed(optimize_graph=optimize)
 
     for x in delayed:
-        assert x.__dask_layers__() == ("delayed-" + df1._name if optimize else df1._name,)
+        assert x.__dask_layers__() == (
+            "delayed-" + df1._name if optimize else df1._name,
+        )
         x.dask.validate()
 
     assert len(delayed) == df1.npartitions
@@ -2482,8 +2550,12 @@ def test_deterministic_apply_concat_apply_names():
     # Test aca without passing in token string
     f = lambda a: a.nlargest(5)
     f2 = lambda a: a.nlargest(3)
-    assert sorted(aca(a.x, f, f, a.x._meta).dask) != sorted(aca(a.x, f2, f2, a.x._meta).dask)
-    assert sorted(aca(a.x, f, f, a.x._meta).dask) == sorted(aca(a.x, f, f, a.x._meta).dask)
+    assert sorted(aca(a.x, f, f, a.x._meta).dask) != sorted(
+        aca(a.x, f2, f2, a.x._meta).dask
+    )
+    assert sorted(aca(a.x, f, f, a.x._meta).dask) == sorted(
+        aca(a.x, f, f, a.x._meta).dask
+    )
 
     # Test aca with keywords
     def chunk(x, c_key=0, both_key=0):
@@ -2543,7 +2615,9 @@ def test_aca_meta_infer():
     assert_eq(res, sol)
 
     # Should infer as a scalar
-    res = aca([ddf.x], chunk=lambda x: pd.Series([x.sum()]), aggregate=lambda x: x.sum())
+    res = aca(
+        [ddf.x], chunk=lambda x: pd.Series([x.sum()]), aggregate=lambda x: x.sum()
+    )
     assert isinstance(res, Scalar)
     assert res.compute() == df.x.sum()
 
@@ -2684,7 +2758,9 @@ def test_reduction_method_split_every():
     # Keywords are different for each step
     assert f(3).compute() == 60 + 15 + 7 * (2 + 1) + (3 + 2)
     # Keywords are same for each step
-    res = ddf.reduction(chunk, aggregate=agg, combine=combine, constant=3.0, split_every=3)
+    res = ddf.reduction(
+        chunk, aggregate=agg, combine=combine, constant=3.0, split_every=3
+    )
     assert res.compute() == 60 + 15 * 3 + 7 * (3 + 1) + (3 + 2)
     # No combine provided, combine is agg
     res = ddf.reduction(chunk, aggregate=agg, constant=3.0, split_every=3)
@@ -2886,7 +2962,9 @@ def test_apply():
     ddf = dd.from_pandas(df, npartitions=2)
 
     func = lambda row: row["x"] + row["y"]
-    assert_eq(ddf.x.apply(lambda x: x + 1, meta=("x", int)), df.x.apply(lambda x: x + 1))
+    assert_eq(
+        ddf.x.apply(lambda x: x + 1, meta=("x", int)), df.x.apply(lambda x: x + 1)
+    )
 
     # specify meta
     assert_eq(
@@ -3308,9 +3386,13 @@ def test_series_iteritems():
     df = pd.DataFrame({"x": [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)
     # `iteritems` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"
+    ):
         pd_items = df["x"].iteritems()
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"
+    ):
         dd_items = ddf["x"].iteritems()
     for (a, b) in zip(pd_items, dd_items):
         assert a == b
@@ -3373,7 +3455,9 @@ def test_dataframe_itertuples_with_name_none():
 
 
 def test_astype():
-    df = pd.DataFrame({"x": [1, 2, 3, None], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40])
+    df = pd.DataFrame(
+        {"x": [1, 2, 3, None], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
+    )
     a = dd.from_pandas(df, 2)
 
     assert_eq(a.astype(float), df.astype(float))
@@ -3494,7 +3578,9 @@ def test_info():
     # Verbose=False
     ddf.info(buf=buf, verbose=False)
     assert buf.getvalue() == (
-        "<class 'dask.dataframe.core.DataFrame'>\n" "Columns: 2 entries, x to y\n" "dtypes: int64(2)"
+        "<class 'dask.dataframe.core.DataFrame'>\n"
+        "Columns: 2 entries, x to y\n"
+        "dtypes: int64(2)"
     )
 
     # buf=None
@@ -3517,7 +3603,9 @@ def test_groupby_multilevel_info():
     buf = StringIO()
     g.info(buf, verbose=False)
     assert buf.getvalue() == (
-        "<class 'dask.dataframe.core.DataFrame'>\n" "Columns: 1 entries, C to C\n" "dtypes: int64(1)"
+        "<class 'dask.dataframe.core.DataFrame'>\n"
+        "Columns: 1 entries, C to C\n"
+        "dtypes: int64(1)"
     )
 
     # multilevel
@@ -3598,7 +3686,9 @@ def test_index_errors():
     with pytest.raises(KeyError, match="has no column"):
         ddf.set_index("foo")  # a column that doesn't exist
     with pytest.raises(KeyError, match="has no column"):
-        ddf.set_index(0)  # a column that doesn't exist, even if the column "name" isn't a string (Pandas admits this)
+        ddf.set_index(
+            0
+        )  # a column that doesn't exist, even if the column "name" isn't a string (Pandas admits this)
     with pytest.raises(ValueError, match="Length mismatch"):
         ddf.set_index(ddf.partitions[0]["A"])  # only 1st partition, so too short
 
@@ -3608,7 +3698,9 @@ def test_index_nulls(null_value):
     df = _compat.makeTimeDataFrame()
     ddf = dd.from_pandas(df.reset_index(), npartitions=2)
     with pytest.raises(NotImplementedError, match="contains nulls"):
-        ddf.assign(**{"foo": null_value}).set_index("foo")  # now foo exists, but it's a null column
+        ddf.assign(**{"foo": null_value}).set_index(
+            "foo"
+        )  # now foo exists, but it's a null column
 
 
 def test_column_assignment():
@@ -3702,42 +3794,69 @@ def test_idxmaxmin(idx, skipna):
     ddf = dd.from_pandas(df, npartitions=3)
 
     # https://github.com/pandas-dev/pandas/issues/43587
-    check_dtype = not all((_compat.PANDAS_GT_133, skipna is False, isinstance(idx, pd.DatetimeIndex)))
+    check_dtype = not all(
+        (_compat.PANDAS_GT_133, skipna is False, isinstance(idx, pd.DatetimeIndex))
+    )
 
     with warnings.catch_warnings(record=True):
         assert_eq(df.idxmax(axis=1, skipna=skipna), ddf.idxmax(axis=1, skipna=skipna))
         assert_eq(df.idxmin(axis=1, skipna=skipna), ddf.idxmin(axis=1, skipna=skipna))
 
-        assert_eq(df.idxmax(skipna=skipna), ddf.idxmax(skipna=skipna), check_dtype=check_dtype)
+        assert_eq(
+            df.idxmax(skipna=skipna), ddf.idxmax(skipna=skipna), check_dtype=check_dtype
+        )
         assert_eq(
             df.idxmax(skipna=skipna),
             ddf.idxmax(skipna=skipna, split_every=2),
             check_dtype=check_dtype,
         )
-        assert ddf.idxmax(skipna=skipna)._name != ddf.idxmax(skipna=skipna, split_every=2)._name
+        assert (
+            ddf.idxmax(skipna=skipna)._name
+            != ddf.idxmax(skipna=skipna, split_every=2)._name
+        )
 
-        assert_eq(df.idxmin(skipna=skipna), ddf.idxmin(skipna=skipna), check_dtype=check_dtype)
+        assert_eq(
+            df.idxmin(skipna=skipna), ddf.idxmin(skipna=skipna), check_dtype=check_dtype
+        )
         assert_eq(
             df.idxmin(skipna=skipna),
             ddf.idxmin(skipna=skipna, split_every=2),
             check_dtype=check_dtype,
         )
-        assert ddf.idxmin(skipna=skipna)._name != ddf.idxmin(skipna=skipna, split_every=2)._name
+        assert (
+            ddf.idxmin(skipna=skipna)._name
+            != ddf.idxmin(skipna=skipna, split_every=2)._name
+        )
 
         assert_eq(df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna))
-        assert_eq(df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna, split_every=2))
-        assert ddf.a.idxmax(skipna=skipna)._name != ddf.a.idxmax(skipna=skipna, split_every=2)._name
+        assert_eq(
+            df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna, split_every=2)
+        )
+        assert (
+            ddf.a.idxmax(skipna=skipna)._name
+            != ddf.a.idxmax(skipna=skipna, split_every=2)._name
+        )
 
         assert_eq(df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna))
-        assert_eq(df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna, split_every=2))
-        assert ddf.a.idxmin(skipna=skipna)._name != ddf.a.idxmin(skipna=skipna, split_every=2)._name
+        assert_eq(
+            df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna, split_every=2)
+        )
+        assert (
+            ddf.a.idxmin(skipna=skipna)._name
+            != ddf.a.idxmin(skipna=skipna, split_every=2)._name
+        )
 
 
 def test_idxmaxmin_empty_partitions():
-    df = pd.DataFrame({"a": [1, 2, 3], "b": [1.5, 2, 3], "c": [np.NaN] * 3, "d": [1, 2, np.NaN]})
+    df = pd.DataFrame(
+        {"a": [1, 2, 3], "b": [1.5, 2, 3], "c": [np.NaN] * 3, "d": [1, 2, np.NaN]}
+    )
     empty = df.iloc[:0]
 
-    ddf = dd.concat([dd.from_pandas(df, npartitions=1)] + [dd.from_pandas(empty, npartitions=1)] * 10)
+    ddf = dd.concat(
+        [dd.from_pandas(df, npartitions=1)]
+        + [dd.from_pandas(empty, npartitions=1)] * 10
+    )
 
     for skipna in [True, False]:
         assert_eq(ddf.idxmin(skipna=skipna, split_every=3), df.idxmin(skipna=skipna))
@@ -3930,7 +4049,9 @@ def test_first_and_last(method):
     offsets = ["0d", "100h", "20d", "20B", "3W", "3M", "400d", "13M"]
     for freq in freqs:
         index = pd.date_range("1/1/2000", "1/1/2001", freq=freq)[::4]
-        df = pd.DataFrame(np.random.random((len(index), 4)), index=index, columns=["A", "B", "C", "D"])
+        df = pd.DataFrame(
+            np.random.random((len(index), 4)), index=index, columns=["A", "B", "C", "D"]
+        )
         ddf = dd.from_pandas(df, npartitions=10)
         for offset in offsets:
             assert_eq(f(ddf, offset), f(df, offset))
@@ -3972,7 +4093,9 @@ def test_split_out_drop_duplicates(split_every):
 
     for subset, keep in product([None, ["x", "z"]], ["first", "last"]):
         sol = df.drop_duplicates(subset=subset, keep=keep)
-        res = ddf.drop_duplicates(subset=subset, keep=keep, split_every=split_every, split_out=10)
+        res = ddf.drop_duplicates(
+            subset=subset, keep=keep, split_every=split_every, split_out=10
+        )
         assert res.npartitions == 10
         assert_eq(sol, res)
 
@@ -3983,7 +4106,9 @@ def test_split_out_value_counts(split_every):
     ddf = dd.from_pandas(df, npartitions=5)
 
     assert ddf.x.value_counts(split_out=10, split_every=split_every).npartitions == 10
-    assert_eq(ddf.x.value_counts(split_out=10, split_every=split_every), df.x.value_counts())
+    assert_eq(
+        ddf.x.value_counts(split_out=10, split_every=split_every), df.x.value_counts()
+    )
 
 
 def test_values():
@@ -4014,7 +4139,8 @@ def test_copy():
     assert_eq(c, df)
 
     deep_err = (
-        "The `deep` value must be False. This is strictly a shallow copy " "of the underlying computational graph."
+        "The `deep` value must be False. This is strictly a shallow copy "
+        "of the underlying computational graph."
     )
     for deep in [True, None, ""]:
         with pytest.raises(ValueError, match=deep_err):
@@ -4046,7 +4172,10 @@ def test_memory_usage(index, deep):
         df.memory_usage(index=index, deep=deep),
         ddf.memory_usage(index=index, deep=deep),
     )
-    assert df.x.memory_usage(index=index, deep=deep) == ddf.x.memory_usage(index=index, deep=deep).compute()
+    assert (
+        df.x.memory_usage(index=index, deep=deep)
+        == ddf.x.memory_usage(index=index, deep=deep).compute()
+    )
 
 
 @pytest.mark.parametrize("index", [True, False])
@@ -4062,12 +4191,17 @@ def test_memory_usage_per_partition(index, deep):
     ddf = dd.from_pandas(df, npartitions=2)
 
     # DataFrame.memory_usage_per_partition
-    expected = pd.Series(part.compute().memory_usage(index=index, deep=deep).sum() for part in ddf.partitions)
+    expected = pd.Series(
+        part.compute().memory_usage(index=index, deep=deep).sum()
+        for part in ddf.partitions
+    )
     result = ddf.memory_usage_per_partition(index=index, deep=deep)
     assert_eq(expected, result)
 
     # Series.memory_usage_per_partition
-    expected = pd.Series(part.x.compute().memory_usage(index=index, deep=deep) for part in ddf.partitions)
+    expected = pd.Series(
+        part.x.compute().memory_usage(index=index, deep=deep) for part in ddf.partitions
+    )
     result = ddf.x.memory_usage_per_partition(index=index, deep=deep)
     assert_eq(expected, result)
 
@@ -4093,7 +4227,9 @@ def test_dataframe_reductions_arithmetic(reduction):
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [1.1, 2.2, 3.3, 4.4, 5.5]})
     ddf = dd.from_pandas(df, npartitions=3)
 
-    assert_eq(ddf - (getattr(ddf, reduction)() + 1), df - (getattr(df, reduction)() + 1))
+    assert_eq(
+        ddf - (getattr(ddf, reduction)() + 1), df - (getattr(df, reduction)() + 1)
+    )
 
 
 def test_dataframe_mode():
@@ -4395,7 +4531,9 @@ def test_mixed_dask_array_operations_errors():
 
 
 def test_mixed_dask_array_multi_dimensional():
-    df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [5.0, 6.0, 7.0, 8.0, 9.0]}, columns=["x", "y"])
+    df = pd.DataFrame(
+        {"x": [1, 2, 3, 4, 5], "y": [5.0, 6.0, 7.0, 8.0, 9.0]}, columns=["x", "y"]
+    )
     ddf = dd.from_pandas(df, npartitions=2)
 
     x = (df.values + 1).astype(float)
@@ -4643,7 +4781,9 @@ def test_dtype_cast():
 @pytest.mark.parametrize("sorted_index", [False, True])
 @pytest.mark.parametrize("sorted_map_index", [False, True])
 def test_series_map(base_npart, map_npart, sorted_index, sorted_map_index):
-    base = pd.Series(["".join(np.random.choice(["a", "b", "c"], size=3)) for x in range(100)])
+    base = pd.Series(
+        ["".join(np.random.choice(["a", "b", "c"], size=3)) for x in range(100)]
+    )
     if not sorted_index:
         index = np.arange(100)
         np.random.shuffle(index)
@@ -4693,10 +4833,14 @@ def test_pop():
 @pytest.mark.parametrize("dropna", [True, False])
 @pytest.mark.parametrize("axis", [0, 1])
 def test_nunique(dropna, axis):
-    df = pd.DataFrame({"x": ["a", "a", "c"], "y": [None, 1, 2], "c": np.arange(0, 1, 0.4)})
+    df = pd.DataFrame(
+        {"x": ["a", "a", "c"], "y": [None, 1, 2], "c": np.arange(0, 1, 0.4)}
+    )
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf["y"].nunique(dropna=dropna), df["y"].nunique(dropna=dropna))
-    assert_eq(ddf.nunique(dropna=dropna, axis=axis), df.nunique(dropna=dropna, axis=axis))
+    assert_eq(
+        ddf.nunique(dropna=dropna, axis=axis), df.nunique(dropna=dropna, axis=axis)
+    )
 
 
 def test_view():
@@ -4754,7 +4898,9 @@ def test_dataframe_groupby_cumprod_agg_empty_partitions():
 
 
 def test_fuse_roots():
-    pdf1 = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
+    pdf1 = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
+    )
     ddf1 = dd.from_pandas(pdf1, 2)
     pdf2 = pd.DataFrame({"a": [True, False, True] * 3, "b": [False, False, True] * 3})
     ddf2 = dd.from_pandas(pdf2, 2)
@@ -4834,7 +4980,9 @@ def test_repr_html_dataframe_highlevelgraph():
         assert xml.etree.ElementTree.fromstring(layer._repr_html_()) is not None
 
 
-@pytest.mark.skipif(not dd._compat.PANDAS_GT_120, reason="Float64 was introduced in pandas>=1.2")
+@pytest.mark.skipif(
+    not dd._compat.PANDAS_GT_120, reason="Float64 was introduced in pandas>=1.2"
+)
 def test_assign_na_float_columns():
     # See https://github.com/dask/dask/issues/7156
     df_pandas = pd.DataFrame({"a": [1.1]}, dtype="Float64")
@@ -4926,9 +5074,13 @@ def test_is_monotonic_numeric():
     ds = dd.from_pandas(s, npartitions=5)
     assert_eq(s.is_monotonic_increasing, ds.is_monotonic_increasing)
     # `is_monotonic` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         expected = s.is_monotonic
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         result = ds.is_monotonic
     assert_eq(expected, result)
 
@@ -4957,9 +5109,13 @@ def test_index_is_monotonic_numeric():
     ds = dd.from_pandas(s, npartitions=5, sort=False)
     assert_eq(s.index.is_monotonic_increasing, ds.index.is_monotonic_increasing)
     # `is_monotonic` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         expected = s.index.is_monotonic
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         result = ds.index.is_monotonic
     assert_eq(expected, result)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3699,12 +3699,12 @@ def test_index_nulls(null_value):
     ddf = dd.from_pandas(df.reset_index(drop=False), npartitions=2).assign(
         **{"foo": null_value}
     )
-    with pytest.raises(NotImplementedError, match="contains nulls"):
+    with pytest.raises(NotImplementedError, match="contains nulls and is non-numeric"):
         ddf.set_index("foo")  # a column all set to nulls
     aux = ddf["index"].map(
         {df.index[0]: df.index[0], df.index[1]: df.index[1]}
     )  # all nulls except first two values
-    with pytest.raises(NotImplementedError, match="contains nulls"):
+    with pytest.raises(NotImplementedError, match="contains nulls and is non-numeric"):
         ddf.set_index(aux)
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3695,17 +3695,17 @@ def test_index_errors():
 @pytest.mark.parametrize("null_value", [None, pd.NaT, pd.NA])
 def test_index_nulls(null_value):
     "Setting the index with some non-numeric null raises error"
-    df = _compat.makeTimeDataFrame()
-    ddf = dd.from_pandas(df.reset_index(drop=False), npartitions=2).assign(
-        **{"foo": null_value}
+    df = pd.DataFrame(
+        {"numeric": [1, 2, 3, 4], "non_numeric": ["foo", "bar", "foo", "bar"]}
     )
+    # an object column all set to nulls fails
+    ddf = dd.from_pandas(df, npartitions=2).assign(**{"non_numeric": null_value})
     with pytest.raises(NotImplementedError, match="presence of nulls"):
-        ddf.set_index("foo")  # a column all set to nulls
-    aux = ddf["index"].map(
-        {df.index[0]: df.index[0], df.index[1]: df.index[1]}
-    )  # all nulls except first two values
+        ddf.set_index("non_numeric")
+    # an object column with only some nulls also fails
+    ddf = dd.from_pandas(df, npartitions=2)
     with pytest.raises(NotImplementedError, match="presence of nulls"):
-        ddf.set_index(aux)
+        ddf.set_index(ddf["non_numeric"].map({"foo": "foo", "bar": null_value}))
 
 
 def test_set_index_with_index():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -45,9 +45,7 @@ dsk = {
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
 }
-meta = make_meta(
-    {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
-)
+meta = make_meta({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
 d = dd.DataFrame(dsk, "x", meta, [0, 5, 9, 9])
 full = d.compute()
 CHECK_FREQ = {}
@@ -83,9 +81,7 @@ def test_dataframe_doc_from_non_pandas():
 
 
 def test_Dataframe():
-    expected = pd.Series(
-        [2, 3, 4, 5, 6, 7, 8, 9, 10], index=[0, 1, 3, 5, 6, 8, 9, 9, 9], name="a"
-    )
+    expected = pd.Series([2, 3, 4, 5, 6, 7, 8, 9, 10], index=[0, 1, 3, 5, 6, 8, 9, 9, 9], name="a")
 
     assert_eq(d["a"] + 1, expected)
 
@@ -110,12 +106,8 @@ def test_head_tail():
     assert_eq(d["a"].head(2), full["a"].head(2))
     assert_eq(d["a"].head(3), full["a"].head(3))
     assert_eq(d["a"].head(2), dsk[("x", 0)]["a"].head(2))
-    assert sorted(d.head(2, compute=False).dask) == sorted(
-        d.head(2, compute=False).dask
-    )
-    assert sorted(d.head(2, compute=False).dask) != sorted(
-        d.head(3, compute=False).dask
-    )
+    assert sorted(d.head(2, compute=False).dask) == sorted(d.head(2, compute=False).dask)
+    assert sorted(d.head(2, compute=False).dask) != sorted(d.head(3, compute=False).dask)
 
     assert_eq(d.tail(2), full.tail(2))
     assert_eq(d.tail(3), full.tail(3))
@@ -123,12 +115,8 @@ def test_head_tail():
     assert_eq(d["a"].tail(2), full["a"].tail(2))
     assert_eq(d["a"].tail(3), full["a"].tail(3))
     assert_eq(d["a"].tail(2), dsk[("x", 2)]["a"].tail(2))
-    assert sorted(d.tail(2, compute=False).dask) == sorted(
-        d.tail(2, compute=False).dask
-    )
-    assert sorted(d.tail(2, compute=False).dask) != sorted(
-        d.tail(3, compute=False).dask
-    )
+    assert sorted(d.tail(2, compute=False).dask) == sorted(d.tail(2, compute=False).dask)
+    assert sorted(d.tail(2, compute=False).dask) != sorted(d.tail(3, compute=False).dask)
 
 
 def test_head_npartitions():
@@ -285,9 +273,7 @@ def test_index_names():
         1,
         pytest.param(
             2,
-            marks=pytest.mark.xfail(
-                not dd._compat.PANDAS_GT_110, reason="Fixed upstream."
-            ),
+            marks=pytest.mark.xfail(not dd._compat.PANDAS_GT_110, reason="Fixed upstream."),
         ),
     ],
 )
@@ -390,9 +376,7 @@ def test_rename_series_method_2():
     assert_eq(ds, s)
 
 
-@pytest.mark.parametrize(
-    "method,test_values", [("tdigest", (6, 10)), ("dask", (4, 20))]
-)
+@pytest.mark.parametrize("method,test_values", [("tdigest", (6, 10)), ("dask", (4, 20))])
 def test_describe_numeric(method, test_values):
     if method == "tdigest":
         pytest.importorskip("crick")
@@ -511,14 +495,10 @@ def test_describe(include, exclude, percentiles, subset):
     # Check series
     if subset is None:
         for col in ["a", "c", "e", "g"]:
-            expected = df[col].describe(
-                include=include, exclude=exclude, **datetime_is_numeric_kwarg
-            )
+            expected = df[col].describe(include=include, exclude=exclude, **datetime_is_numeric_kwarg)
             if col == "e" and datetime_is_numeric_kwarg:
                 expected.drop("mean", inplace=True)
-            actual = ddf[col].describe(
-                include=include, exclude=exclude, **datetime_is_numeric_kwarg
-            )
+            actual = ddf[col].describe(include=include, exclude=exclude, **datetime_is_numeric_kwarg)
             assert_eq(expected, actual)
 
 
@@ -551,9 +531,7 @@ def test_describe_without_datetime_is_numeric():
     if PANDAS_GT_110:
         with pytest.warns(
             FutureWarning,
-            match=(
-                "Treating datetime data as categorical rather than numeric in `.describe` is deprecated"
-            ),
+            match=("Treating datetime data as categorical rather than numeric in `.describe` is deprecated"),
         ):
             ddf.e.describe()
     else:
@@ -574,9 +552,7 @@ def test_describe_empty():
 
     # Pandas have different dtypes for resulting describe dataframe if there are only
     # None-values, pre-compute dask df to bypass _meta check
-    assert_eq(
-        df_none.describe(), ddf_none.describe(percentiles_method="dask").compute()
-    )
+    assert_eq(df_none.describe(), ddf_none.describe(percentiles_method="dask").compute())
 
     with pytest.warns(RuntimeWarning):
         ddf_len0.describe(percentiles_method="dask").compute()
@@ -596,9 +572,7 @@ def test_describe_empty_tdigest():
 
     # Pandas have different dtypes for resulting describe dataframe if there are only
     # None-values, pre-compute dask df to bypass _meta check
-    assert_eq(
-        df_none.describe(), ddf_none.describe(percentiles_method="tdigest").compute()
-    )
+    assert_eq(df_none.describe(), ddf_none.describe(percentiles_method="tdigest").compute())
     with warnings.catch_warnings():
         # dask.dataframe should probably filter this, to match pandas, but
         # it seems quite difficult.
@@ -711,19 +685,11 @@ def test_cumulative():
         M.cumprod,
         pytest.param(
             M.cummin,
-            marks=[
-                pytest.mark.xfail(
-                    reason="ValueError: Can only compare identically-labeled Series objects"
-                )
-            ],
+            marks=[pytest.mark.xfail(reason="ValueError: Can only compare identically-labeled Series objects")],
         ),
         pytest.param(
             M.cummax,
-            marks=[
-                pytest.mark.xfail(
-                    reason="ValueError: Can only compare identically-labeled Series objects"
-                )
-            ],
+            marks=[pytest.mark.xfail(reason="ValueError: Can only compare identically-labeled Series objects")],
         ),
     ],
 )
@@ -786,9 +752,7 @@ def test_dropna():
 @pytest.mark.parametrize("lower, upper", [(2, 5), (2.5, 3.5)])
 def test_clip(lower, upper):
 
-    df = pd.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
-    )
+    df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
     ddf = dd.from_pandas(df, 3)
 
     s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9])
@@ -833,9 +797,7 @@ def test_squeeze():
 
 
 def test_where_mask():
-    pdf1 = pd.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
-    )
+    pdf1 = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
     ddf1 = dd.from_pandas(pdf1, 2)
     pdf2 = pd.DataFrame({"a": [True, False, True] * 3, "b": [False, False, True] * 3})
     ddf2 = dd.from_pandas(pdf2, 2)
@@ -907,9 +869,7 @@ def test_where_mask():
 
 def test_map_partitions_multi_argument():
     assert_eq(dd.map_partitions(lambda a, b: a + b, d.a, d.b), full.a + full.b)
-    assert_eq(
-        dd.map_partitions(lambda a, b, c: a + b + c, d.a, d.b, 1), full.a + full.b + 1
-    )
+    assert_eq(dd.map_partitions(lambda a, b, c: a + b + c, d.a, d.b, 1), full.a + full.b + 1)
 
 
 def test_map_partitions():
@@ -957,17 +917,13 @@ def test_map_partitions_partition_info():
 
 def test_map_partitions_names():
     func = lambda x: x
-    assert sorted(dd.map_partitions(func, d, meta=d).dask) == sorted(
-        dd.map_partitions(func, d, meta=d).dask
-    )
+    assert sorted(dd.map_partitions(func, d, meta=d).dask) == sorted(dd.map_partitions(func, d, meta=d).dask)
     assert sorted(dd.map_partitions(lambda x: x, d, meta=d, token=1).dask) == sorted(
         dd.map_partitions(lambda x: x, d, meta=d, token=1).dask
     )
 
     func = lambda x, y: x
-    assert sorted(dd.map_partitions(func, d, d, meta=d).dask) == sorted(
-        dd.map_partitions(func, d, d, meta=d).dask
-    )
+    assert sorted(dd.map_partitions(func, d, d, meta=d).dask) == sorted(dd.map_partitions(func, d, d, meta=d).dask)
 
 
 def test_map_partitions_column_info():
@@ -1082,15 +1038,11 @@ def test_align_dataframes():
     ddf1 = dd.from_pandas(df1, npartitions=2)
     ddf2 = dd.from_pandas(df2, npartitions=1)
 
-    actual = ddf1.map_partitions(
-        pd.merge, df2, align_dataframes=False, left_on="A", right_on="A", how="left"
-    )
+    actual = ddf1.map_partitions(pd.merge, df2, align_dataframes=False, left_on="A", right_on="A", how="left")
     expected = pd.merge(df1, df2, left_on="A", right_on="A", how="left")
     assert_eq(actual, expected, check_index=False, check_divisions=False)
 
-    actual = ddf2.map_partitions(
-        pd.merge, ddf1, align_dataframes=False, left_on="A", right_on="A", how="right"
-    )
+    actual = ddf2.map_partitions(pd.merge, ddf1, align_dataframes=False, left_on="A", right_on="A", how="right")
     expected = pd.merge(df2, df1, left_on="A", right_on="A", how="right")
     assert_eq(actual, expected, check_index=False, check_divisions=False)
 
@@ -1610,9 +1562,7 @@ def test_assign_callable():
 
 def test_assign_dtypes():
     ddf = dd.from_pandas(
-        pd.DataFrame(
-            data={"col1": ["a", "b"], "col2": [1, 2]}, columns=["col1", "col2"]
-        ),
+        pd.DataFrame(data={"col1": ["a", "b"], "col2": [1, 2]}, columns=["col1", "col2"]),
         npartitions=2,
     )
 
@@ -1818,9 +1768,7 @@ def test_combine():
             assert_eq(dda.combine(ddb, func, fill_value=fill_value), sol)
             assert_eq(dda.combine(b, func, fill_value=fill_value), sol)
 
-    assert_eq(
-        ddf1.combine(ddf2, add, overwrite=False), df1.combine(df2, add, overwrite=False)
-    )
+    assert_eq(ddf1.combine(ddf2, add, overwrite=False), df1.combine(df2, add, overwrite=False))
     assert dda.combine(ddb, add)._name == dda.combine(ddb, add)._name
 
 
@@ -1928,15 +1876,11 @@ def test_repartition():
         """Check data is split properly"""
         keys = [k for k in d.dask if k[0].startswith("repartition-split")]
         keys = sorted(keys)
-        sp = pd.concat(
-            [compute_as_if_collection(dd.DataFrame, d.dask, k) for k in keys]
-        )
+        sp = pd.concat([compute_as_if_collection(dd.DataFrame, d.dask, k) for k in keys])
         assert_eq(orig, sp)
         assert_eq(orig, d)
 
-    df = pd.DataFrame(
-        {"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60]
-    )
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60])
     a = dd.from_pandas(df, 2)
 
     b = a.repartition(divisions=[10, 20, 50, 60])
@@ -2055,9 +1999,7 @@ def test_repartition_divisions():
 
 
 def test_repartition_on_pandas_dataframe():
-    df = pd.DataFrame(
-        {"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60]
-    )
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60])
     ddf = dd.repartition(df, divisions=[10, 20, 50, 60])
     assert isinstance(ddf, dd.DataFrame)
     assert ddf.divisions == (10, 20, 50, 60)
@@ -2156,12 +2098,8 @@ def test_repartition_object_index():
 @pytest.mark.slow
 @pytest.mark.parametrize("npartitions", [1, 20, 243])
 @pytest.mark.parametrize("freq", ["1D", "7D", "28h", "1h"])
-@pytest.mark.parametrize(
-    "end", ["2000-04-15", "2000-04-15 12:37:01", "2000-01-01 12:37:00"]
-)
-@pytest.mark.parametrize(
-    "start", ["2000-01-01", "2000-01-01 12:30:00", "2000-01-01 12:30:00"]
-)
+@pytest.mark.parametrize("end", ["2000-04-15", "2000-04-15 12:37:01", "2000-01-01 12:37:00"])
+@pytest.mark.parametrize("start", ["2000-01-01", "2000-01-01 12:30:00", "2000-01-01 12:30:00"])
 def test_repartition_freq(npartitions, freq, start, end):
     start = pd.Timestamp(start)
     end = pd.Timestamp(end)
@@ -2200,9 +2138,7 @@ def test_repartition_freq_errors():
 
 def test_repartition_freq_month():
     ts = pd.date_range("2015-01-01 00:00", "2015-05-01 23:50", freq="10min")
-    df = pd.DataFrame(
-        np.random.randint(0, 100, size=(len(ts), 4)), columns=list("ABCD"), index=ts
-    )
+    df = pd.DataFrame(np.random.randint(0, 100, size=(len(ts), 4)), columns=list("ABCD"), index=ts)
     ddf = dd.from_pandas(df, npartitions=1).repartition(freq="MS")
 
     assert_eq(df, ddf)
@@ -2316,9 +2252,7 @@ def test_fillna():
     assert_eq(ddf.A.fillna(method="pad", limit=2), df.A.fillna(method="pad", limit=2))
 
     assert_eq(ddf.fillna(method="bfill", limit=2), df.fillna(method="bfill", limit=2))
-    assert_eq(
-        ddf.A.fillna(method="bfill", limit=2), df.A.fillna(method="bfill", limit=2)
-    )
+    assert_eq(ddf.A.fillna(method="bfill", limit=2), df.A.fillna(method="bfill", limit=2))
 
     assert_eq(ddf.fillna(100, axis=1), df.fillna(100, axis=1))
     assert_eq(ddf.fillna(method="pad", axis=1), df.fillna(method="pad", axis=1))
@@ -2344,9 +2278,7 @@ def test_delayed_roundtrip(optimize):
     delayed = df1.to_delayed(optimize_graph=optimize)
 
     for x in delayed:
-        assert x.__dask_layers__() == (
-            "delayed-" + df1._name if optimize else df1._name,
-        )
+        assert x.__dask_layers__() == ("delayed-" + df1._name if optimize else df1._name,)
         x.dask.validate()
 
     assert len(delayed) == df1.npartitions
@@ -2550,12 +2482,8 @@ def test_deterministic_apply_concat_apply_names():
     # Test aca without passing in token string
     f = lambda a: a.nlargest(5)
     f2 = lambda a: a.nlargest(3)
-    assert sorted(aca(a.x, f, f, a.x._meta).dask) != sorted(
-        aca(a.x, f2, f2, a.x._meta).dask
-    )
-    assert sorted(aca(a.x, f, f, a.x._meta).dask) == sorted(
-        aca(a.x, f, f, a.x._meta).dask
-    )
+    assert sorted(aca(a.x, f, f, a.x._meta).dask) != sorted(aca(a.x, f2, f2, a.x._meta).dask)
+    assert sorted(aca(a.x, f, f, a.x._meta).dask) == sorted(aca(a.x, f, f, a.x._meta).dask)
 
     # Test aca with keywords
     def chunk(x, c_key=0, both_key=0):
@@ -2615,9 +2543,7 @@ def test_aca_meta_infer():
     assert_eq(res, sol)
 
     # Should infer as a scalar
-    res = aca(
-        [ddf.x], chunk=lambda x: pd.Series([x.sum()]), aggregate=lambda x: x.sum()
-    )
+    res = aca([ddf.x], chunk=lambda x: pd.Series([x.sum()]), aggregate=lambda x: x.sum())
     assert isinstance(res, Scalar)
     assert res.compute() == df.x.sum()
 
@@ -2758,9 +2684,7 @@ def test_reduction_method_split_every():
     # Keywords are different for each step
     assert f(3).compute() == 60 + 15 + 7 * (2 + 1) + (3 + 2)
     # Keywords are same for each step
-    res = ddf.reduction(
-        chunk, aggregate=agg, combine=combine, constant=3.0, split_every=3
-    )
+    res = ddf.reduction(chunk, aggregate=agg, combine=combine, constant=3.0, split_every=3)
     assert res.compute() == 60 + 15 * 3 + 7 * (3 + 1) + (3 + 2)
     # No combine provided, combine is agg
     res = ddf.reduction(chunk, aggregate=agg, constant=3.0, split_every=3)
@@ -2962,9 +2886,7 @@ def test_apply():
     ddf = dd.from_pandas(df, npartitions=2)
 
     func = lambda row: row["x"] + row["y"]
-    assert_eq(
-        ddf.x.apply(lambda x: x + 1, meta=("x", int)), df.x.apply(lambda x: x + 1)
-    )
+    assert_eq(ddf.x.apply(lambda x: x + 1, meta=("x", int)), df.x.apply(lambda x: x + 1))
 
     # specify meta
     assert_eq(
@@ -3386,13 +3308,9 @@ def test_series_iteritems():
     df = pd.DataFrame({"x": [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)
     # `iteritems` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"):
         pd_items = df["x"].iteritems()
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"):
         dd_items = ddf["x"].iteritems()
     for (a, b) in zip(pd_items, dd_items):
         assert a == b
@@ -3455,9 +3373,7 @@ def test_dataframe_itertuples_with_name_none():
 
 
 def test_astype():
-    df = pd.DataFrame(
-        {"x": [1, 2, 3, None], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
-    )
+    df = pd.DataFrame({"x": [1, 2, 3, None], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40])
     a = dd.from_pandas(df, 2)
 
     assert_eq(a.astype(float), df.astype(float))
@@ -3578,9 +3494,7 @@ def test_info():
     # Verbose=False
     ddf.info(buf=buf, verbose=False)
     assert buf.getvalue() == (
-        "<class 'dask.dataframe.core.DataFrame'>\n"
-        "Columns: 2 entries, x to y\n"
-        "dtypes: int64(2)"
+        "<class 'dask.dataframe.core.DataFrame'>\n" "Columns: 2 entries, x to y\n" "dtypes: int64(2)"
     )
 
     # buf=None
@@ -3603,9 +3517,7 @@ def test_groupby_multilevel_info():
     buf = StringIO()
     g.info(buf, verbose=False)
     assert buf.getvalue() == (
-        "<class 'dask.dataframe.core.DataFrame'>\n"
-        "Columns: 1 entries, C to C\n"
-        "dtypes: int64(1)"
+        "<class 'dask.dataframe.core.DataFrame'>\n" "Columns: 1 entries, C to C\n" "dtypes: int64(1)"
     )
 
     # multilevel
@@ -3674,6 +3586,29 @@ def test_timeseries_sorted():
     ddf = dd.from_pandas(df.reset_index(), npartitions=2)
     df.index.name = "index"
     assert_eq(ddf.set_index("index", sorted=True, drop=True), df)
+
+
+def test_index_errors():
+    df = _compat.makeTimeDataFrame()
+    ddf = dd.from_pandas(df.reset_index(), npartitions=2)
+    with pytest.raises(NotImplementedError, match="You tried to index with this index"):
+        ddf.set_index([["A"]])  # should index with ["A"] instead of [["A"]]
+    with pytest.raises(NotImplementedError, match="You tried to index with a frame"):
+        ddf.set_index(ddf[["A"]])  # should index with ddf["A"] instead of ddf[["A"]]
+    with pytest.raises(KeyError, match="has no column"):
+        ddf.set_index("foo")  # a column that doesn't exist
+    with pytest.raises(KeyError, match="has no column"):
+        ddf.set_index(0)  # a column that doesn't exist, even if the column "name" isn't a string (Pandas admits this)
+    with pytest.raises(ValueError, match="Length mismatch"):
+        ddf.set_index(ddf.partitions[0]["A"])  # only 1st partition, so too short
+
+
+@pytest.mark.parametrize("null_value", [None, pd.NaT, pd.NA, np.nan, float("nan")])
+def test_index_nulls(null_value):
+    df = _compat.makeTimeDataFrame()
+    ddf = dd.from_pandas(df.reset_index(), npartitions=2)
+    with pytest.raises(NotImplementedError, match="contains nulls"):
+        ddf.assign(**{"foo": null_value}).set_index("foo")  # now foo exists, but it's a null column
 
 
 def test_column_assignment():
@@ -3767,69 +3702,42 @@ def test_idxmaxmin(idx, skipna):
     ddf = dd.from_pandas(df, npartitions=3)
 
     # https://github.com/pandas-dev/pandas/issues/43587
-    check_dtype = not all(
-        (_compat.PANDAS_GT_133, skipna is False, isinstance(idx, pd.DatetimeIndex))
-    )
+    check_dtype = not all((_compat.PANDAS_GT_133, skipna is False, isinstance(idx, pd.DatetimeIndex)))
 
     with warnings.catch_warnings(record=True):
         assert_eq(df.idxmax(axis=1, skipna=skipna), ddf.idxmax(axis=1, skipna=skipna))
         assert_eq(df.idxmin(axis=1, skipna=skipna), ddf.idxmin(axis=1, skipna=skipna))
 
-        assert_eq(
-            df.idxmax(skipna=skipna), ddf.idxmax(skipna=skipna), check_dtype=check_dtype
-        )
+        assert_eq(df.idxmax(skipna=skipna), ddf.idxmax(skipna=skipna), check_dtype=check_dtype)
         assert_eq(
             df.idxmax(skipna=skipna),
             ddf.idxmax(skipna=skipna, split_every=2),
             check_dtype=check_dtype,
         )
-        assert (
-            ddf.idxmax(skipna=skipna)._name
-            != ddf.idxmax(skipna=skipna, split_every=2)._name
-        )
+        assert ddf.idxmax(skipna=skipna)._name != ddf.idxmax(skipna=skipna, split_every=2)._name
 
-        assert_eq(
-            df.idxmin(skipna=skipna), ddf.idxmin(skipna=skipna), check_dtype=check_dtype
-        )
+        assert_eq(df.idxmin(skipna=skipna), ddf.idxmin(skipna=skipna), check_dtype=check_dtype)
         assert_eq(
             df.idxmin(skipna=skipna),
             ddf.idxmin(skipna=skipna, split_every=2),
             check_dtype=check_dtype,
         )
-        assert (
-            ddf.idxmin(skipna=skipna)._name
-            != ddf.idxmin(skipna=skipna, split_every=2)._name
-        )
+        assert ddf.idxmin(skipna=skipna)._name != ddf.idxmin(skipna=skipna, split_every=2)._name
 
         assert_eq(df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna))
-        assert_eq(
-            df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna, split_every=2)
-        )
-        assert (
-            ddf.a.idxmax(skipna=skipna)._name
-            != ddf.a.idxmax(skipna=skipna, split_every=2)._name
-        )
+        assert_eq(df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna, split_every=2))
+        assert ddf.a.idxmax(skipna=skipna)._name != ddf.a.idxmax(skipna=skipna, split_every=2)._name
 
         assert_eq(df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna))
-        assert_eq(
-            df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna, split_every=2)
-        )
-        assert (
-            ddf.a.idxmin(skipna=skipna)._name
-            != ddf.a.idxmin(skipna=skipna, split_every=2)._name
-        )
+        assert_eq(df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna, split_every=2))
+        assert ddf.a.idxmin(skipna=skipna)._name != ddf.a.idxmin(skipna=skipna, split_every=2)._name
 
 
 def test_idxmaxmin_empty_partitions():
-    df = pd.DataFrame(
-        {"a": [1, 2, 3], "b": [1.5, 2, 3], "c": [np.NaN] * 3, "d": [1, 2, np.NaN]}
-    )
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [1.5, 2, 3], "c": [np.NaN] * 3, "d": [1, 2, np.NaN]})
     empty = df.iloc[:0]
 
-    ddf = dd.concat(
-        [dd.from_pandas(df, npartitions=1)]
-        + [dd.from_pandas(empty, npartitions=1)] * 10
-    )
+    ddf = dd.concat([dd.from_pandas(df, npartitions=1)] + [dd.from_pandas(empty, npartitions=1)] * 10)
 
     for skipna in [True, False]:
         assert_eq(ddf.idxmin(skipna=skipna, split_every=3), df.idxmin(skipna=skipna))
@@ -4022,9 +3930,7 @@ def test_first_and_last(method):
     offsets = ["0d", "100h", "20d", "20B", "3W", "3M", "400d", "13M"]
     for freq in freqs:
         index = pd.date_range("1/1/2000", "1/1/2001", freq=freq)[::4]
-        df = pd.DataFrame(
-            np.random.random((len(index), 4)), index=index, columns=["A", "B", "C", "D"]
-        )
+        df = pd.DataFrame(np.random.random((len(index), 4)), index=index, columns=["A", "B", "C", "D"])
         ddf = dd.from_pandas(df, npartitions=10)
         for offset in offsets:
             assert_eq(f(ddf, offset), f(df, offset))
@@ -4066,9 +3972,7 @@ def test_split_out_drop_duplicates(split_every):
 
     for subset, keep in product([None, ["x", "z"]], ["first", "last"]):
         sol = df.drop_duplicates(subset=subset, keep=keep)
-        res = ddf.drop_duplicates(
-            subset=subset, keep=keep, split_every=split_every, split_out=10
-        )
+        res = ddf.drop_duplicates(subset=subset, keep=keep, split_every=split_every, split_out=10)
         assert res.npartitions == 10
         assert_eq(sol, res)
 
@@ -4079,9 +3983,7 @@ def test_split_out_value_counts(split_every):
     ddf = dd.from_pandas(df, npartitions=5)
 
     assert ddf.x.value_counts(split_out=10, split_every=split_every).npartitions == 10
-    assert_eq(
-        ddf.x.value_counts(split_out=10, split_every=split_every), df.x.value_counts()
-    )
+    assert_eq(ddf.x.value_counts(split_out=10, split_every=split_every), df.x.value_counts())
 
 
 def test_values():
@@ -4112,8 +4014,7 @@ def test_copy():
     assert_eq(c, df)
 
     deep_err = (
-        "The `deep` value must be False. This is strictly a shallow copy "
-        "of the underlying computational graph."
+        "The `deep` value must be False. This is strictly a shallow copy " "of the underlying computational graph."
     )
     for deep in [True, None, ""]:
         with pytest.raises(ValueError, match=deep_err):
@@ -4145,10 +4046,7 @@ def test_memory_usage(index, deep):
         df.memory_usage(index=index, deep=deep),
         ddf.memory_usage(index=index, deep=deep),
     )
-    assert (
-        df.x.memory_usage(index=index, deep=deep)
-        == ddf.x.memory_usage(index=index, deep=deep).compute()
-    )
+    assert df.x.memory_usage(index=index, deep=deep) == ddf.x.memory_usage(index=index, deep=deep).compute()
 
 
 @pytest.mark.parametrize("index", [True, False])
@@ -4164,17 +4062,12 @@ def test_memory_usage_per_partition(index, deep):
     ddf = dd.from_pandas(df, npartitions=2)
 
     # DataFrame.memory_usage_per_partition
-    expected = pd.Series(
-        part.compute().memory_usage(index=index, deep=deep).sum()
-        for part in ddf.partitions
-    )
+    expected = pd.Series(part.compute().memory_usage(index=index, deep=deep).sum() for part in ddf.partitions)
     result = ddf.memory_usage_per_partition(index=index, deep=deep)
     assert_eq(expected, result)
 
     # Series.memory_usage_per_partition
-    expected = pd.Series(
-        part.x.compute().memory_usage(index=index, deep=deep) for part in ddf.partitions
-    )
+    expected = pd.Series(part.x.compute().memory_usage(index=index, deep=deep) for part in ddf.partitions)
     result = ddf.x.memory_usage_per_partition(index=index, deep=deep)
     assert_eq(expected, result)
 
@@ -4200,9 +4093,7 @@ def test_dataframe_reductions_arithmetic(reduction):
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [1.1, 2.2, 3.3, 4.4, 5.5]})
     ddf = dd.from_pandas(df, npartitions=3)
 
-    assert_eq(
-        ddf - (getattr(ddf, reduction)() + 1), df - (getattr(df, reduction)() + 1)
-    )
+    assert_eq(ddf - (getattr(ddf, reduction)() + 1), df - (getattr(df, reduction)() + 1))
 
 
 def test_dataframe_mode():
@@ -4504,9 +4395,7 @@ def test_mixed_dask_array_operations_errors():
 
 
 def test_mixed_dask_array_multi_dimensional():
-    df = pd.DataFrame(
-        {"x": [1, 2, 3, 4, 5], "y": [5.0, 6.0, 7.0, 8.0, 9.0]}, columns=["x", "y"]
-    )
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [5.0, 6.0, 7.0, 8.0, 9.0]}, columns=["x", "y"])
     ddf = dd.from_pandas(df, npartitions=2)
 
     x = (df.values + 1).astype(float)
@@ -4754,9 +4643,7 @@ def test_dtype_cast():
 @pytest.mark.parametrize("sorted_index", [False, True])
 @pytest.mark.parametrize("sorted_map_index", [False, True])
 def test_series_map(base_npart, map_npart, sorted_index, sorted_map_index):
-    base = pd.Series(
-        ["".join(np.random.choice(["a", "b", "c"], size=3)) for x in range(100)]
-    )
+    base = pd.Series(["".join(np.random.choice(["a", "b", "c"], size=3)) for x in range(100)])
     if not sorted_index:
         index = np.arange(100)
         np.random.shuffle(index)
@@ -4806,14 +4693,10 @@ def test_pop():
 @pytest.mark.parametrize("dropna", [True, False])
 @pytest.mark.parametrize("axis", [0, 1])
 def test_nunique(dropna, axis):
-    df = pd.DataFrame(
-        {"x": ["a", "a", "c"], "y": [None, 1, 2], "c": np.arange(0, 1, 0.4)}
-    )
+    df = pd.DataFrame({"x": ["a", "a", "c"], "y": [None, 1, 2], "c": np.arange(0, 1, 0.4)})
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf["y"].nunique(dropna=dropna), df["y"].nunique(dropna=dropna))
-    assert_eq(
-        ddf.nunique(dropna=dropna, axis=axis), df.nunique(dropna=dropna, axis=axis)
-    )
+    assert_eq(ddf.nunique(dropna=dropna, axis=axis), df.nunique(dropna=dropna, axis=axis))
 
 
 def test_view():
@@ -4871,9 +4754,7 @@ def test_dataframe_groupby_cumprod_agg_empty_partitions():
 
 
 def test_fuse_roots():
-    pdf1 = pd.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
-    )
+    pdf1 = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
     ddf1 = dd.from_pandas(pdf1, 2)
     pdf2 = pd.DataFrame({"a": [True, False, True] * 3, "b": [False, False, True] * 3})
     ddf2 = dd.from_pandas(pdf2, 2)
@@ -4953,9 +4834,7 @@ def test_repr_html_dataframe_highlevelgraph():
         assert xml.etree.ElementTree.fromstring(layer._repr_html_()) is not None
 
 
-@pytest.mark.skipif(
-    not dd._compat.PANDAS_GT_120, reason="Float64 was introduced in pandas>=1.2"
-)
+@pytest.mark.skipif(not dd._compat.PANDAS_GT_120, reason="Float64 was introduced in pandas>=1.2")
 def test_assign_na_float_columns():
     # See https://github.com/dask/dask/issues/7156
     df_pandas = pd.DataFrame({"a": [1.1]}, dtype="Float64")
@@ -5047,13 +4926,9 @@ def test_is_monotonic_numeric():
     ds = dd.from_pandas(s, npartitions=5)
     assert_eq(s.is_monotonic_increasing, ds.is_monotonic_increasing)
     # `is_monotonic` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
         expected = s.is_monotonic
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
         result = ds.is_monotonic
     assert_eq(expected, result)
 
@@ -5082,13 +4957,9 @@ def test_index_is_monotonic_numeric():
     ds = dd.from_pandas(s, npartitions=5, sort=False)
     assert_eq(s.index.is_monotonic_increasing, ds.index.is_monotonic_increasing)
     # `is_monotonic` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
         expected = s.index.is_monotonic
-    with _check_warning(
-        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
-    ):
+    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
         result = ds.index.is_monotonic
     assert_eq(expected, result)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -45,7 +45,9 @@ dsk = {
     ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}, index=[5, 6, 8]),
     ("x", 2): pd.DataFrame({"a": [7, 8, 9], "b": [0, 0, 0]}, index=[9, 9, 9]),
 }
-meta = make_meta({"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame())
+meta = make_meta(
+    {"a": "i8", "b": "i8"}, index=pd.Index([], "i8"), parent_meta=pd.DataFrame()
+)
 d = dd.DataFrame(dsk, "x", meta, [0, 5, 9, 9])
 full = d.compute()
 CHECK_FREQ = {}
@@ -81,7 +83,9 @@ def test_dataframe_doc_from_non_pandas():
 
 
 def test_Dataframe():
-    expected = pd.Series([2, 3, 4, 5, 6, 7, 8, 9, 10], index=[0, 1, 3, 5, 6, 8, 9, 9, 9], name="a")
+    expected = pd.Series(
+        [2, 3, 4, 5, 6, 7, 8, 9, 10], index=[0, 1, 3, 5, 6, 8, 9, 9, 9], name="a"
+    )
 
     assert_eq(d["a"] + 1, expected)
 
@@ -106,8 +110,12 @@ def test_head_tail():
     assert_eq(d["a"].head(2), full["a"].head(2))
     assert_eq(d["a"].head(3), full["a"].head(3))
     assert_eq(d["a"].head(2), dsk[("x", 0)]["a"].head(2))
-    assert sorted(d.head(2, compute=False).dask) == sorted(d.head(2, compute=False).dask)
-    assert sorted(d.head(2, compute=False).dask) != sorted(d.head(3, compute=False).dask)
+    assert sorted(d.head(2, compute=False).dask) == sorted(
+        d.head(2, compute=False).dask
+    )
+    assert sorted(d.head(2, compute=False).dask) != sorted(
+        d.head(3, compute=False).dask
+    )
 
     assert_eq(d.tail(2), full.tail(2))
     assert_eq(d.tail(3), full.tail(3))
@@ -115,8 +123,12 @@ def test_head_tail():
     assert_eq(d["a"].tail(2), full["a"].tail(2))
     assert_eq(d["a"].tail(3), full["a"].tail(3))
     assert_eq(d["a"].tail(2), dsk[("x", 2)]["a"].tail(2))
-    assert sorted(d.tail(2, compute=False).dask) == sorted(d.tail(2, compute=False).dask)
-    assert sorted(d.tail(2, compute=False).dask) != sorted(d.tail(3, compute=False).dask)
+    assert sorted(d.tail(2, compute=False).dask) == sorted(
+        d.tail(2, compute=False).dask
+    )
+    assert sorted(d.tail(2, compute=False).dask) != sorted(
+        d.tail(3, compute=False).dask
+    )
 
 
 def test_head_npartitions():
@@ -273,7 +285,9 @@ def test_index_names():
         1,
         pytest.param(
             2,
-            marks=pytest.mark.xfail(not dd._compat.PANDAS_GT_110, reason="Fixed upstream."),
+            marks=pytest.mark.xfail(
+                not dd._compat.PANDAS_GT_110, reason="Fixed upstream."
+            ),
         ),
     ],
 )
@@ -376,7 +390,9 @@ def test_rename_series_method_2():
     assert_eq(ds, s)
 
 
-@pytest.mark.parametrize("method,test_values", [("tdigest", (6, 10)), ("dask", (4, 20))])
+@pytest.mark.parametrize(
+    "method,test_values", [("tdigest", (6, 10)), ("dask", (4, 20))]
+)
 def test_describe_numeric(method, test_values):
     if method == "tdigest":
         pytest.importorskip("crick")
@@ -495,10 +511,14 @@ def test_describe(include, exclude, percentiles, subset):
     # Check series
     if subset is None:
         for col in ["a", "c", "e", "g"]:
-            expected = df[col].describe(include=include, exclude=exclude, **datetime_is_numeric_kwarg)
+            expected = df[col].describe(
+                include=include, exclude=exclude, **datetime_is_numeric_kwarg
+            )
             if col == "e" and datetime_is_numeric_kwarg:
                 expected.drop("mean", inplace=True)
-            actual = ddf[col].describe(include=include, exclude=exclude, **datetime_is_numeric_kwarg)
+            actual = ddf[col].describe(
+                include=include, exclude=exclude, **datetime_is_numeric_kwarg
+            )
             assert_eq(expected, actual)
 
 
@@ -531,7 +551,9 @@ def test_describe_without_datetime_is_numeric():
     if PANDAS_GT_110:
         with pytest.warns(
             FutureWarning,
-            match=("Treating datetime data as categorical rather than numeric in `.describe` is deprecated"),
+            match=(
+                "Treating datetime data as categorical rather than numeric in `.describe` is deprecated"
+            ),
         ):
             ddf.e.describe()
     else:
@@ -552,7 +574,9 @@ def test_describe_empty():
 
     # Pandas have different dtypes for resulting describe dataframe if there are only
     # None-values, pre-compute dask df to bypass _meta check
-    assert_eq(df_none.describe(), ddf_none.describe(percentiles_method="dask").compute())
+    assert_eq(
+        df_none.describe(), ddf_none.describe(percentiles_method="dask").compute()
+    )
 
     with pytest.warns(RuntimeWarning):
         ddf_len0.describe(percentiles_method="dask").compute()
@@ -572,7 +596,9 @@ def test_describe_empty_tdigest():
 
     # Pandas have different dtypes for resulting describe dataframe if there are only
     # None-values, pre-compute dask df to bypass _meta check
-    assert_eq(df_none.describe(), ddf_none.describe(percentiles_method="tdigest").compute())
+    assert_eq(
+        df_none.describe(), ddf_none.describe(percentiles_method="tdigest").compute()
+    )
     with warnings.catch_warnings():
         # dask.dataframe should probably filter this, to match pandas, but
         # it seems quite difficult.
@@ -685,11 +711,19 @@ def test_cumulative():
         M.cumprod,
         pytest.param(
             M.cummin,
-            marks=[pytest.mark.xfail(reason="ValueError: Can only compare identically-labeled Series objects")],
+            marks=[
+                pytest.mark.xfail(
+                    reason="ValueError: Can only compare identically-labeled Series objects"
+                )
+            ],
         ),
         pytest.param(
             M.cummax,
-            marks=[pytest.mark.xfail(reason="ValueError: Can only compare identically-labeled Series objects")],
+            marks=[
+                pytest.mark.xfail(
+                    reason="ValueError: Can only compare identically-labeled Series objects"
+                )
+            ],
         ),
     ],
 )
@@ -752,7 +786,9 @@ def test_dropna():
 @pytest.mark.parametrize("lower, upper", [(2, 5), (2.5, 3.5)])
 def test_clip(lower, upper):
 
-    df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
+    df = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
+    )
     ddf = dd.from_pandas(df, 3)
 
     s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9])
@@ -797,7 +833,9 @@ def test_squeeze():
 
 
 def test_where_mask():
-    pdf1 = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
+    pdf1 = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
+    )
     ddf1 = dd.from_pandas(pdf1, 2)
     pdf2 = pd.DataFrame({"a": [True, False, True] * 3, "b": [False, False, True] * 3})
     ddf2 = dd.from_pandas(pdf2, 2)
@@ -869,7 +907,9 @@ def test_where_mask():
 
 def test_map_partitions_multi_argument():
     assert_eq(dd.map_partitions(lambda a, b: a + b, d.a, d.b), full.a + full.b)
-    assert_eq(dd.map_partitions(lambda a, b, c: a + b + c, d.a, d.b, 1), full.a + full.b + 1)
+    assert_eq(
+        dd.map_partitions(lambda a, b, c: a + b + c, d.a, d.b, 1), full.a + full.b + 1
+    )
 
 
 def test_map_partitions():
@@ -917,13 +957,17 @@ def test_map_partitions_partition_info():
 
 def test_map_partitions_names():
     func = lambda x: x
-    assert sorted(dd.map_partitions(func, d, meta=d).dask) == sorted(dd.map_partitions(func, d, meta=d).dask)
+    assert sorted(dd.map_partitions(func, d, meta=d).dask) == sorted(
+        dd.map_partitions(func, d, meta=d).dask
+    )
     assert sorted(dd.map_partitions(lambda x: x, d, meta=d, token=1).dask) == sorted(
         dd.map_partitions(lambda x: x, d, meta=d, token=1).dask
     )
 
     func = lambda x, y: x
-    assert sorted(dd.map_partitions(func, d, d, meta=d).dask) == sorted(dd.map_partitions(func, d, d, meta=d).dask)
+    assert sorted(dd.map_partitions(func, d, d, meta=d).dask) == sorted(
+        dd.map_partitions(func, d, d, meta=d).dask
+    )
 
 
 def test_map_partitions_column_info():
@@ -1038,11 +1082,15 @@ def test_align_dataframes():
     ddf1 = dd.from_pandas(df1, npartitions=2)
     ddf2 = dd.from_pandas(df2, npartitions=1)
 
-    actual = ddf1.map_partitions(pd.merge, df2, align_dataframes=False, left_on="A", right_on="A", how="left")
+    actual = ddf1.map_partitions(
+        pd.merge, df2, align_dataframes=False, left_on="A", right_on="A", how="left"
+    )
     expected = pd.merge(df1, df2, left_on="A", right_on="A", how="left")
     assert_eq(actual, expected, check_index=False, check_divisions=False)
 
-    actual = ddf2.map_partitions(pd.merge, ddf1, align_dataframes=False, left_on="A", right_on="A", how="right")
+    actual = ddf2.map_partitions(
+        pd.merge, ddf1, align_dataframes=False, left_on="A", right_on="A", how="right"
+    )
     expected = pd.merge(df2, df1, left_on="A", right_on="A", how="right")
     assert_eq(actual, expected, check_index=False, check_divisions=False)
 
@@ -1560,7 +1608,9 @@ def test_assign_callable():
 
 def test_assign_dtypes():
     ddf = dd.from_pandas(
-        pd.DataFrame(data={"col1": ["a", "b"], "col2": [1, 2]}, columns=["col1", "col2"]),
+        pd.DataFrame(
+            data={"col1": ["a", "b"], "col2": [1, 2]}, columns=["col1", "col2"]
+        ),
         npartitions=2,
     )
 
@@ -1766,7 +1816,9 @@ def test_combine():
             assert_eq(dda.combine(ddb, func, fill_value=fill_value), sol)
             assert_eq(dda.combine(b, func, fill_value=fill_value), sol)
 
-    assert_eq(ddf1.combine(ddf2, add, overwrite=False), df1.combine(df2, add, overwrite=False))
+    assert_eq(
+        ddf1.combine(ddf2, add, overwrite=False), df1.combine(df2, add, overwrite=False)
+    )
     assert dda.combine(ddb, add)._name == dda.combine(ddb, add)._name
 
 
@@ -1874,11 +1926,15 @@ def test_repartition():
         """Check data is split properly"""
         keys = [k for k in d.dask if k[0].startswith("repartition-split")]
         keys = sorted(keys)
-        sp = pd.concat([compute_as_if_collection(dd.DataFrame, d.dask, k) for k in keys])
+        sp = pd.concat(
+            [compute_as_if_collection(dd.DataFrame, d.dask, k) for k in keys]
+        )
         assert_eq(orig, sp)
         assert_eq(orig, d)
 
-    df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60])
+    df = pd.DataFrame(
+        {"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60]
+    )
     a = dd.from_pandas(df, 2)
 
     b = a.repartition(divisions=[10, 20, 50, 60])
@@ -1997,7 +2053,9 @@ def test_repartition_divisions():
 
 
 def test_repartition_on_pandas_dataframe():
-    df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60])
+    df = pd.DataFrame(
+        {"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60]
+    )
     ddf = dd.repartition(df, divisions=[10, 20, 50, 60])
     assert isinstance(ddf, dd.DataFrame)
     assert ddf.divisions == (10, 20, 50, 60)
@@ -2096,8 +2154,12 @@ def test_repartition_object_index():
 @pytest.mark.slow
 @pytest.mark.parametrize("npartitions", [1, 20, 243])
 @pytest.mark.parametrize("freq", ["1D", "7D", "28h", "1h"])
-@pytest.mark.parametrize("end", ["2000-04-15", "2000-04-15 12:37:01", "2000-01-01 12:37:00"])
-@pytest.mark.parametrize("start", ["2000-01-01", "2000-01-01 12:30:00", "2000-01-01 12:30:00"])
+@pytest.mark.parametrize(
+    "end", ["2000-04-15", "2000-04-15 12:37:01", "2000-01-01 12:37:00"]
+)
+@pytest.mark.parametrize(
+    "start", ["2000-01-01", "2000-01-01 12:30:00", "2000-01-01 12:30:00"]
+)
 def test_repartition_freq(npartitions, freq, start, end):
     start = pd.Timestamp(start)
     end = pd.Timestamp(end)
@@ -2136,7 +2198,9 @@ def test_repartition_freq_errors():
 
 def test_repartition_freq_month():
     ts = pd.date_range("2015-01-01 00:00", "2015-05-01 23:50", freq="10min")
-    df = pd.DataFrame(np.random.randint(0, 100, size=(len(ts), 4)), columns=list("ABCD"), index=ts)
+    df = pd.DataFrame(
+        np.random.randint(0, 100, size=(len(ts), 4)), columns=list("ABCD"), index=ts
+    )
     ddf = dd.from_pandas(df, npartitions=1).repartition(freq="MS")
 
     assert_eq(df, ddf)
@@ -2250,7 +2314,9 @@ def test_fillna():
     assert_eq(ddf.A.fillna(method="pad", limit=2), df.A.fillna(method="pad", limit=2))
 
     assert_eq(ddf.fillna(method="bfill", limit=2), df.fillna(method="bfill", limit=2))
-    assert_eq(ddf.A.fillna(method="bfill", limit=2), df.A.fillna(method="bfill", limit=2))
+    assert_eq(
+        ddf.A.fillna(method="bfill", limit=2), df.A.fillna(method="bfill", limit=2)
+    )
 
     assert_eq(ddf.fillna(100, axis=1), df.fillna(100, axis=1))
     assert_eq(ddf.fillna(method="pad", axis=1), df.fillna(method="pad", axis=1))
@@ -2276,7 +2342,9 @@ def test_delayed_roundtrip(optimize):
     delayed = df1.to_delayed(optimize_graph=optimize)
 
     for x in delayed:
-        assert x.__dask_layers__() == ("delayed-" + df1._name if optimize else df1._name,)
+        assert x.__dask_layers__() == (
+            "delayed-" + df1._name if optimize else df1._name,
+        )
         x.dask.validate()
 
     assert len(delayed) == df1.npartitions
@@ -2480,8 +2548,12 @@ def test_deterministic_apply_concat_apply_names():
     # Test aca without passing in token string
     f = lambda a: a.nlargest(5)
     f2 = lambda a: a.nlargest(3)
-    assert sorted(aca(a.x, f, f, a.x._meta).dask) != sorted(aca(a.x, f2, f2, a.x._meta).dask)
-    assert sorted(aca(a.x, f, f, a.x._meta).dask) == sorted(aca(a.x, f, f, a.x._meta).dask)
+    assert sorted(aca(a.x, f, f, a.x._meta).dask) != sorted(
+        aca(a.x, f2, f2, a.x._meta).dask
+    )
+    assert sorted(aca(a.x, f, f, a.x._meta).dask) == sorted(
+        aca(a.x, f, f, a.x._meta).dask
+    )
 
     # Test aca with keywords
     def chunk(x, c_key=0, both_key=0):
@@ -2541,7 +2613,9 @@ def test_aca_meta_infer():
     assert_eq(res, sol)
 
     # Should infer as a scalar
-    res = aca([ddf.x], chunk=lambda x: pd.Series([x.sum()]), aggregate=lambda x: x.sum())
+    res = aca(
+        [ddf.x], chunk=lambda x: pd.Series([x.sum()]), aggregate=lambda x: x.sum()
+    )
     assert isinstance(res, Scalar)
     assert res.compute() == df.x.sum()
 
@@ -2682,7 +2756,9 @@ def test_reduction_method_split_every():
     # Keywords are different for each step
     assert f(3).compute() == 60 + 15 + 7 * (2 + 1) + (3 + 2)
     # Keywords are same for each step
-    res = ddf.reduction(chunk, aggregate=agg, combine=combine, constant=3.0, split_every=3)
+    res = ddf.reduction(
+        chunk, aggregate=agg, combine=combine, constant=3.0, split_every=3
+    )
     assert res.compute() == 60 + 15 * 3 + 7 * (3 + 1) + (3 + 2)
     # No combine provided, combine is agg
     res = ddf.reduction(chunk, aggregate=agg, constant=3.0, split_every=3)
@@ -2884,7 +2960,9 @@ def test_apply():
     ddf = dd.from_pandas(df, npartitions=2)
 
     func = lambda row: row["x"] + row["y"]
-    assert_eq(ddf.x.apply(lambda x: x + 1, meta=("x", int)), df.x.apply(lambda x: x + 1))
+    assert_eq(
+        ddf.x.apply(lambda x: x + 1, meta=("x", int)), df.x.apply(lambda x: x + 1)
+    )
 
     # specify meta
     assert_eq(
@@ -3306,9 +3384,13 @@ def test_series_iteritems():
     df = pd.DataFrame({"x": [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)
     # `iteritems` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"
+    ):
         pd_items = df["x"].iteritems()
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="iteritems is deprecated"
+    ):
         dd_items = ddf["x"].iteritems()
     for (a, b) in zip(pd_items, dd_items):
         assert a == b
@@ -3371,7 +3453,9 @@ def test_dataframe_itertuples_with_name_none():
 
 
 def test_astype():
-    df = pd.DataFrame({"x": [1, 2, 3, None], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40])
+    df = pd.DataFrame(
+        {"x": [1, 2, 3, None], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
+    )
     a = dd.from_pandas(df, 2)
 
     assert_eq(a.astype(float), df.astype(float))
@@ -3492,7 +3576,9 @@ def test_info():
     # Verbose=False
     ddf.info(buf=buf, verbose=False)
     assert buf.getvalue() == (
-        "<class 'dask.dataframe.core.DataFrame'>\n" "Columns: 2 entries, x to y\n" "dtypes: int64(2)"
+        "<class 'dask.dataframe.core.DataFrame'>\n"
+        "Columns: 2 entries, x to y\n"
+        "dtypes: int64(2)"
     )
 
     # buf=None
@@ -3515,7 +3601,9 @@ def test_groupby_multilevel_info():
     buf = StringIO()
     g.info(buf, verbose=False)
     assert buf.getvalue() == (
-        "<class 'dask.dataframe.core.DataFrame'>\n" "Columns: 1 entries, C to C\n" "dtypes: int64(1)"
+        "<class 'dask.dataframe.core.DataFrame'>\n"
+        "Columns: 1 entries, C to C\n"
+        "dtypes: int64(1)"
     )
 
     # multilevel
@@ -3596,7 +3684,9 @@ def test_index_errors():
     with pytest.raises(KeyError, match="has no column"):
         ddf.set_index("foo")  # a column that doesn't exist
     with pytest.raises(KeyError, match="has no column"):
-        ddf.set_index(0)  # a column that doesn't exist, even if the column "name" isn't a string (Pandas admits this)
+        ddf.set_index(
+            0
+        )  # a column that doesn't exist, even if the column "name" isn't a string (Pandas admits this)
     with pytest.raises(ValueError, match="Length mismatch"):
         ddf.set_index(ddf.partitions[0]["A"])  # only 1st partition, so too short
 
@@ -3606,7 +3696,9 @@ def test_index_nulls(null_value):
     df = _compat.makeTimeDataFrame()
     ddf = dd.from_pandas(df.reset_index(), npartitions=2)
     with pytest.raises(NotImplementedError, match="contains nulls"):
-        ddf.assign(**{"foo": null_value}).set_index("foo")  # now foo exists, but it's a null column
+        ddf.assign(**{"foo": null_value}).set_index(
+            "foo"
+        )  # now foo exists, but it's a null column
 
 
 def test_column_assignment():
@@ -3700,42 +3792,69 @@ def test_idxmaxmin(idx, skipna):
     ddf = dd.from_pandas(df, npartitions=3)
 
     # https://github.com/pandas-dev/pandas/issues/43587
-    check_dtype = not all((_compat.PANDAS_GT_133, skipna is False, isinstance(idx, pd.DatetimeIndex)))
+    check_dtype = not all(
+        (_compat.PANDAS_GT_133, skipna is False, isinstance(idx, pd.DatetimeIndex))
+    )
 
     with warnings.catch_warnings(record=True):
         assert_eq(df.idxmax(axis=1, skipna=skipna), ddf.idxmax(axis=1, skipna=skipna))
         assert_eq(df.idxmin(axis=1, skipna=skipna), ddf.idxmin(axis=1, skipna=skipna))
 
-        assert_eq(df.idxmax(skipna=skipna), ddf.idxmax(skipna=skipna), check_dtype=check_dtype)
+        assert_eq(
+            df.idxmax(skipna=skipna), ddf.idxmax(skipna=skipna), check_dtype=check_dtype
+        )
         assert_eq(
             df.idxmax(skipna=skipna),
             ddf.idxmax(skipna=skipna, split_every=2),
             check_dtype=check_dtype,
         )
-        assert ddf.idxmax(skipna=skipna)._name != ddf.idxmax(skipna=skipna, split_every=2)._name
+        assert (
+            ddf.idxmax(skipna=skipna)._name
+            != ddf.idxmax(skipna=skipna, split_every=2)._name
+        )
 
-        assert_eq(df.idxmin(skipna=skipna), ddf.idxmin(skipna=skipna), check_dtype=check_dtype)
+        assert_eq(
+            df.idxmin(skipna=skipna), ddf.idxmin(skipna=skipna), check_dtype=check_dtype
+        )
         assert_eq(
             df.idxmin(skipna=skipna),
             ddf.idxmin(skipna=skipna, split_every=2),
             check_dtype=check_dtype,
         )
-        assert ddf.idxmin(skipna=skipna)._name != ddf.idxmin(skipna=skipna, split_every=2)._name
+        assert (
+            ddf.idxmin(skipna=skipna)._name
+            != ddf.idxmin(skipna=skipna, split_every=2)._name
+        )
 
         assert_eq(df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna))
-        assert_eq(df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna, split_every=2))
-        assert ddf.a.idxmax(skipna=skipna)._name != ddf.a.idxmax(skipna=skipna, split_every=2)._name
+        assert_eq(
+            df.a.idxmax(skipna=skipna), ddf.a.idxmax(skipna=skipna, split_every=2)
+        )
+        assert (
+            ddf.a.idxmax(skipna=skipna)._name
+            != ddf.a.idxmax(skipna=skipna, split_every=2)._name
+        )
 
         assert_eq(df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna))
-        assert_eq(df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna, split_every=2))
-        assert ddf.a.idxmin(skipna=skipna)._name != ddf.a.idxmin(skipna=skipna, split_every=2)._name
+        assert_eq(
+            df.a.idxmin(skipna=skipna), ddf.a.idxmin(skipna=skipna, split_every=2)
+        )
+        assert (
+            ddf.a.idxmin(skipna=skipna)._name
+            != ddf.a.idxmin(skipna=skipna, split_every=2)._name
+        )
 
 
 def test_idxmaxmin_empty_partitions():
-    df = pd.DataFrame({"a": [1, 2, 3], "b": [1.5, 2, 3], "c": [np.NaN] * 3, "d": [1, 2, np.NaN]})
+    df = pd.DataFrame(
+        {"a": [1, 2, 3], "b": [1.5, 2, 3], "c": [np.NaN] * 3, "d": [1, 2, np.NaN]}
+    )
     empty = df.iloc[:0]
 
-    ddf = dd.concat([dd.from_pandas(df, npartitions=1)] + [dd.from_pandas(empty, npartitions=1)] * 10)
+    ddf = dd.concat(
+        [dd.from_pandas(df, npartitions=1)]
+        + [dd.from_pandas(empty, npartitions=1)] * 10
+    )
 
     for skipna in [True, False]:
         assert_eq(ddf.idxmin(skipna=skipna, split_every=3), df.idxmin(skipna=skipna))
@@ -3928,7 +4047,9 @@ def test_first_and_last(method):
     offsets = ["0d", "100h", "20d", "20B", "3W", "3M", "400d", "13M"]
     for freq in freqs:
         index = pd.date_range("1/1/2000", "1/1/2001", freq=freq)[::4]
-        df = pd.DataFrame(np.random.random((len(index), 4)), index=index, columns=["A", "B", "C", "D"])
+        df = pd.DataFrame(
+            np.random.random((len(index), 4)), index=index, columns=["A", "B", "C", "D"]
+        )
         ddf = dd.from_pandas(df, npartitions=10)
         for offset in offsets:
             assert_eq(f(ddf, offset), f(df, offset))
@@ -3970,7 +4091,9 @@ def test_split_out_drop_duplicates(split_every):
 
     for subset, keep in product([None, ["x", "z"]], ["first", "last"]):
         sol = df.drop_duplicates(subset=subset, keep=keep)
-        res = ddf.drop_duplicates(subset=subset, keep=keep, split_every=split_every, split_out=10)
+        res = ddf.drop_duplicates(
+            subset=subset, keep=keep, split_every=split_every, split_out=10
+        )
         assert res.npartitions == 10
         assert_eq(sol, res)
 
@@ -3981,7 +4104,9 @@ def test_split_out_value_counts(split_every):
     ddf = dd.from_pandas(df, npartitions=5)
 
     assert ddf.x.value_counts(split_out=10, split_every=split_every).npartitions == 10
-    assert_eq(ddf.x.value_counts(split_out=10, split_every=split_every), df.x.value_counts())
+    assert_eq(
+        ddf.x.value_counts(split_out=10, split_every=split_every), df.x.value_counts()
+    )
 
 
 def test_values():
@@ -4012,7 +4137,8 @@ def test_copy():
     assert_eq(c, df)
 
     deep_err = (
-        "The `deep` value must be False. This is strictly a shallow copy " "of the underlying computational graph."
+        "The `deep` value must be False. This is strictly a shallow copy "
+        "of the underlying computational graph."
     )
     for deep in [True, None, ""]:
         with pytest.raises(ValueError, match=deep_err):
@@ -4044,7 +4170,10 @@ def test_memory_usage(index, deep):
         df.memory_usage(index=index, deep=deep),
         ddf.memory_usage(index=index, deep=deep),
     )
-    assert df.x.memory_usage(index=index, deep=deep) == ddf.x.memory_usage(index=index, deep=deep).compute()
+    assert (
+        df.x.memory_usage(index=index, deep=deep)
+        == ddf.x.memory_usage(index=index, deep=deep).compute()
+    )
 
 
 @pytest.mark.parametrize("index", [True, False])
@@ -4060,12 +4189,17 @@ def test_memory_usage_per_partition(index, deep):
     ddf = dd.from_pandas(df, npartitions=2)
 
     # DataFrame.memory_usage_per_partition
-    expected = pd.Series(part.compute().memory_usage(index=index, deep=deep).sum() for part in ddf.partitions)
+    expected = pd.Series(
+        part.compute().memory_usage(index=index, deep=deep).sum()
+        for part in ddf.partitions
+    )
     result = ddf.memory_usage_per_partition(index=index, deep=deep)
     assert_eq(expected, result)
 
     # Series.memory_usage_per_partition
-    expected = pd.Series(part.x.compute().memory_usage(index=index, deep=deep) for part in ddf.partitions)
+    expected = pd.Series(
+        part.x.compute().memory_usage(index=index, deep=deep) for part in ddf.partitions
+    )
     result = ddf.x.memory_usage_per_partition(index=index, deep=deep)
     assert_eq(expected, result)
 
@@ -4091,7 +4225,9 @@ def test_dataframe_reductions_arithmetic(reduction):
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [1.1, 2.2, 3.3, 4.4, 5.5]})
     ddf = dd.from_pandas(df, npartitions=3)
 
-    assert_eq(ddf - (getattr(ddf, reduction)() + 1), df - (getattr(df, reduction)() + 1))
+    assert_eq(
+        ddf - (getattr(ddf, reduction)() + 1), df - (getattr(df, reduction)() + 1)
+    )
 
 
 def test_dataframe_mode():
@@ -4393,7 +4529,9 @@ def test_mixed_dask_array_operations_errors():
 
 
 def test_mixed_dask_array_multi_dimensional():
-    df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [5.0, 6.0, 7.0, 8.0, 9.0]}, columns=["x", "y"])
+    df = pd.DataFrame(
+        {"x": [1, 2, 3, 4, 5], "y": [5.0, 6.0, 7.0, 8.0, 9.0]}, columns=["x", "y"]
+    )
     ddf = dd.from_pandas(df, npartitions=2)
 
     x = (df.values + 1).astype(float)
@@ -4641,7 +4779,9 @@ def test_dtype_cast():
 @pytest.mark.parametrize("sorted_index", [False, True])
 @pytest.mark.parametrize("sorted_map_index", [False, True])
 def test_series_map(base_npart, map_npart, sorted_index, sorted_map_index):
-    base = pd.Series(["".join(np.random.choice(["a", "b", "c"], size=3)) for x in range(100)])
+    base = pd.Series(
+        ["".join(np.random.choice(["a", "b", "c"], size=3)) for x in range(100)]
+    )
     if not sorted_index:
         index = np.arange(100)
         np.random.shuffle(index)
@@ -4691,10 +4831,14 @@ def test_pop():
 @pytest.mark.parametrize("dropna", [True, False])
 @pytest.mark.parametrize("axis", [0, 1])
 def test_nunique(dropna, axis):
-    df = pd.DataFrame({"x": ["a", "a", "c"], "y": [None, 1, 2], "c": np.arange(0, 1, 0.4)})
+    df = pd.DataFrame(
+        {"x": ["a", "a", "c"], "y": [None, 1, 2], "c": np.arange(0, 1, 0.4)}
+    )
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf["y"].nunique(dropna=dropna), df["y"].nunique(dropna=dropna))
-    assert_eq(ddf.nunique(dropna=dropna, axis=axis), df.nunique(dropna=dropna, axis=axis))
+    assert_eq(
+        ddf.nunique(dropna=dropna, axis=axis), df.nunique(dropna=dropna, axis=axis)
+    )
 
 
 def test_view():
@@ -4752,7 +4896,9 @@ def test_dataframe_groupby_cumprod_agg_empty_partitions():
 
 
 def test_fuse_roots():
-    pdf1 = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]})
+    pdf1 = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
+    )
     ddf1 = dd.from_pandas(pdf1, 2)
     pdf2 = pd.DataFrame({"a": [True, False, True] * 3, "b": [False, False, True] * 3})
     ddf2 = dd.from_pandas(pdf2, 2)
@@ -4832,7 +4978,9 @@ def test_repr_html_dataframe_highlevelgraph():
         assert xml.etree.ElementTree.fromstring(layer._repr_html_()) is not None
 
 
-@pytest.mark.skipif(not dd._compat.PANDAS_GT_120, reason="Float64 was introduced in pandas>=1.2")
+@pytest.mark.skipif(
+    not dd._compat.PANDAS_GT_120, reason="Float64 was introduced in pandas>=1.2"
+)
 def test_assign_na_float_columns():
     # See https://github.com/dask/dask/issues/7156
     df_pandas = pd.DataFrame({"a": [1.1]}, dtype="Float64")
@@ -4924,9 +5072,13 @@ def test_is_monotonic_numeric():
     ds = dd.from_pandas(s, npartitions=5)
     assert_eq(s.is_monotonic_increasing, ds.is_monotonic_increasing)
     # `is_monotonic` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         expected = s.is_monotonic
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         result = ds.is_monotonic
     assert_eq(expected, result)
 
@@ -4955,9 +5107,13 @@ def test_index_is_monotonic_numeric():
     ds = dd.from_pandas(s, npartitions=5, sort=False)
     assert_eq(s.index.is_monotonic_increasing, ds.index.is_monotonic_increasing)
     # `is_monotonic` was deprecated starting in `pandas=1.5.0`
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         expected = s.index.is_monotonic
-    with _check_warning(PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"):
+    with _check_warning(
+        PANDAS_GT_150, FutureWarning, message="is_monotonic is deprecated"
+    ):
         result = ds.index.is_monotonic
     assert_eq(expected, result)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3688,8 +3688,6 @@ def test_index_errors():
     with pytest.raises(KeyError, match="has no column"):
         # column name doesn't need to be a string, but anyhow a KeyError should be raised if not found
         ddf.set_index(0)
-    with pytest.raises(ValueError, match="Length mismatch"):
-        ddf.set_index(ddf.partitions[0]["A"])  # only 1st partition, so too short
 
 
 @pytest.mark.parametrize("null_value", [None, pd.NaT, pd.NA])

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -367,11 +367,7 @@ def test_set_index_with_explicit_divisions():
 
     ddf = dd.from_pandas(df, npartitions=2)
 
-    def throw(*args, **kwargs):
-        raise Exception()
-
-    with dask.config.set(get=throw):
-        ddf2 = ddf.set_index("x", divisions=[1, 3, 5])
+    ddf2 = ddf.set_index("x", divisions=[1, 3, 5])
     assert ddf2.divisions == (1, 3, 5)
 
     df2 = df.set_index("x")
@@ -431,15 +427,10 @@ def test_set_index_divisions_sorted():
     )
     df = ddf.compute()
 
-    def throw(*args, **kwargs):
-        raise Exception("Shouldn't have computed")
-
-    with dask.config.set(get=throw):
-        res = ddf.set_index("x", divisions=[10, 13, 16, 18], sorted=True)
+    res = ddf.set_index("x", divisions=[10, 13, 16, 18], sorted=True)
     assert_eq(res, df.set_index("x"))
 
-    with dask.config.set(get=throw):
-        res = ddf.set_index("y", divisions=["a", "b", "d", "e"], sorted=True)
+    res = ddf.set_index("y", divisions=["a", "b", "d", "e"], sorted=True)
     assert_eq(res, df.set_index("y"))
 
     # with sorted=True, divisions must be same length as df.divisions
@@ -1042,7 +1033,9 @@ def test_set_index_does_not_repeat_work_due_to_optimizations(npartitions):
 
     ddf.set_index("x", npartitions=npartitions)
     ntimes = next(count)
-    assert ntimes == nparts
+    assert (
+        ntimes == 2 * nparts
+    )  # twice because of the aditional .compute() for checking nulls
 
 
 def test_set_index_errors_with_inplace_kwarg():

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -367,7 +367,11 @@ def test_set_index_with_explicit_divisions():
 
     ddf = dd.from_pandas(df, npartitions=2)
 
-    ddf2 = ddf.set_index("x", divisions=[1, 3, 5])
+    def throw(*args, **kwargs):
+        raise Exception()
+
+    with dask.config.set(get=throw):
+        ddf2 = ddf.set_index("x", divisions=[1, 3, 5])
     assert ddf2.divisions == (1, 3, 5)
 
     df2 = df.set_index("x")
@@ -427,10 +431,15 @@ def test_set_index_divisions_sorted():
     )
     df = ddf.compute()
 
-    res = ddf.set_index("x", divisions=[10, 13, 16, 18], sorted=True)
+    def throw(*args, **kwargs):
+        raise Exception("Shouldn't have computed")
+
+    with dask.config.set(get=throw):
+        res = ddf.set_index("x", divisions=[10, 13, 16, 18], sorted=True)
     assert_eq(res, df.set_index("x"))
 
-    res = ddf.set_index("y", divisions=["a", "b", "d", "e"], sorted=True)
+    with dask.config.set(get=throw):
+        res = ddf.set_index("y", divisions=["a", "b", "d", "e"], sorted=True)
     assert_eq(res, df.set_index("y"))
 
     # with sorted=True, divisions must be same length as df.divisions

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1033,8 +1033,7 @@ def test_set_index_does_not_repeat_work_due_to_optimizations(npartitions):
 
     ddf.set_index("x", npartitions=npartitions)
     ntimes = next(count)
-    # twice the time because of the aditional .compute() for checking nulls
-    assert ntimes == 2 * nparts
+    assert ntimes == nparts
 
 
 def test_set_index_errors_with_inplace_kwarg():

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -367,11 +367,7 @@ def test_set_index_with_explicit_divisions():
 
     ddf = dd.from_pandas(df, npartitions=2)
 
-    def throw(*args, **kwargs):
-        raise Exception()
-
-    with dask.config.set(get=throw):
-        ddf2 = ddf.set_index("x", divisions=[1, 3, 5])
+    ddf2 = ddf.set_index("x", divisions=[1, 3, 5])
     assert ddf2.divisions == (1, 3, 5)
 
     df2 = df.set_index("x")
@@ -431,15 +427,10 @@ def test_set_index_divisions_sorted():
     )
     df = ddf.compute()
 
-    def throw(*args, **kwargs):
-        raise Exception("Shouldn't have computed")
-
-    with dask.config.set(get=throw):
-        res = ddf.set_index("x", divisions=[10, 13, 16, 18], sorted=True)
+    res = ddf.set_index("x", divisions=[10, 13, 16, 18], sorted=True)
     assert_eq(res, df.set_index("x"))
 
-    with dask.config.set(get=throw):
-        res = ddf.set_index("y", divisions=["a", "b", "d", "e"], sorted=True)
+    res = ddf.set_index("y", divisions=["a", "b", "d", "e"], sorted=True)
     assert_eq(res, df.set_index("y"))
 
     # with sorted=True, divisions must be same length as df.divisions

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1033,9 +1033,8 @@ def test_set_index_does_not_repeat_work_due_to_optimizations(npartitions):
 
     ddf.set_index("x", npartitions=npartitions)
     ntimes = next(count)
-    assert (
-        ntimes == 2 * nparts
-    )  # twice because of the aditional .compute() for checking nulls
+    # twice the time because of the aditional .compute() for checking nulls
+    assert ntimes == 2 * nparts
 
 
 def test_set_index_errors_with_inplace_kwarg():

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -367,7 +367,11 @@ def test_set_index_with_explicit_divisions():
 
     ddf = dd.from_pandas(df, npartitions=2)
 
-    ddf2 = ddf.set_index("x", divisions=[1, 3, 5])
+    def throw(*args, **kwargs):
+        raise Exception()
+
+    with dask.config.set(scheduler=throw):
+        ddf2 = ddf.set_index("x", divisions=[1, 3, 5])
     assert ddf2.divisions == (1, 3, 5)
 
     df2 = df.set_index("x")
@@ -427,10 +431,15 @@ def test_set_index_divisions_sorted():
     )
     df = ddf.compute()
 
-    res = ddf.set_index("x", divisions=[10, 13, 16, 18], sorted=True)
+    def throw(*args, **kwargs):
+        raise Exception("Shouldn't have computed")
+
+    with dask.config.set(scheduler=throw):
+        res = ddf.set_index("x", divisions=[10, 13, 16, 18], sorted=True)
     assert_eq(res, df.set_index("x"))
 
-    res = ddf.set_index("y", divisions=["a", "b", "d", "e"], sorted=True)
+    with dask.config.set(scheduler=throw):
+        res = ddf.set_index("y", divisions=["a", "b", "d", "e"], sorted=True)
     assert_eq(res, df.set_index("y"))
 
     # with sorted=True, divisions must be same length as df.divisions


### PR DESCRIPTION
- [x] Closes #8347 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
- [x] Passes `mypy` for type annotations

## Major changes

* Moved all checks made on `index` to `DataFrame.set_index`, so that `shuffle.set_index` and `shuffle.set_sorted_index` use `index` directly with no checks.
* Besides the former checks, two other checks are performed:
    * Non-existence of nulls. If there are nulls, an informative `NotImplementedError` is raised.
    * Matching lengths (only if the series provided isn't a current column). If there's no match, an informative `ValueError` is raised. 
* Added a `test_index_errors` test that checks former errors and mismatching lengths.
* Added a `test_index_nulls` test that ensures no `NaN`s are allowed, with different null values (`NaT`, `NA`, `None`, etc.).
* Type annotations added to:
    * `DataFrame.set_index` and `DataFrame.sort_values`
    * Several methods in `shuffle.py`.
* Analogous checks and tests in `io` for `from_pandas`, where the dataframe passed as argument is checked against this.

## Minor changes

* Instead of checking for a `list` or a `tuple` of columns to index with, the more general `Sequence` is allowed.
* Eliminated context managers in tests that used `get` as a keyword (a `DeprecationError` was raised otherwise).
* Modified an assertion in a test that checks for non-repeated computations, since now there's an additional `compute()` call for the `NaN` checks.