### PR TITLE
[Experiment][WIP] Perform culling optimization before fuse_roots

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -46,8 +46,8 @@ def optimize(
         dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
 
     dsk = optimize_blockwise(dsk, keys=keys)
-    dsk = fuse_roots(dsk, keys=keys)
     dsk = dsk.cull(set(keys))
+    dsk = fuse_roots(dsk, keys=keys)
 
     # Perform low-level fusion unless the user has
     # specified False explicitly.

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -17,12 +17,13 @@ def optimize(dsk, keys, **kwargs):
 
     if not isinstance(dsk, HighLevelGraph):
         dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
+        dsk = dsk.cull(set(keys))
     else:
         # Perform Blockwise optimizations for HLG input
         dsk = optimize_dataframe_getitem(dsk, keys=keys)
         dsk = optimize_blockwise(dsk, keys=keys)
+        dsk = dsk.cull(set(keys))
         dsk = fuse_roots(dsk, keys=keys)
-    dsk = dsk.cull(set(keys))
 
     # Do not perform low-level fusion unless the user has
     # specified True explicitly. The configuration will


### PR DESCRIPTION
While working on a PR to move Dask-DataFrame's `from_delayed` to `Blockwise` @ian-r-rose [pointed out that `fuse_roots`
will always materialize a Blockwise layer when root-fusion is successful](https://github.com/dask/dask/pull/8852#discussion_r854625813).  My intuition is that this is probably okay if we move things around so that culling is performed while the Layer is still `Blockwise`.  This PR makes this small change for `dask.array` and `dask.dataframe`.