### PR TITLE
Stringify BlockwiseDepDict mapping values when produces_keys=True

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -196,7 +196,12 @@ class BlockwiseDepDict(BlockwiseDep):
             required_indices = tuple(self.mapping.keys())
 
         return {
-            "mapping": {k: to_serialize(self.mapping[k]) for k in required_indices},
+            "mapping": {
+                k: stringify(self.mapping[k])
+                if self.produces_keys
+                else to_serialize(self.mapping[k])
+                for k in required_indices
+            },
             "numblocks": self.numblocks,
             "produces_tasks": self.produces_tasks,
             "produces_keys": self._produces_keys,
@@ -1098,8 +1103,8 @@ def make_blockwise_graph(
 
     # Apply Culling.
     # Only need to construct the specified set of output blocks
-    output_blocks = output_blocks or itertools.product(
-        *[range(dims[i]) for i in out_indices]
+    output_blocks = output_blocks or list(
+        itertools.product(*[range(dims[i]) for i in out_indices])
     )
 
     dsk = {}

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1102,7 +1102,11 @@ def make_blockwise_graph(
             kwargs2 = kwargs
 
     # Apply Culling.
-    # Only need to construct the specified set of output blocks
+    # Only need to construct the specified set of output blocks.
+    # Note that we must convert itertools.product to list,
+    # because we may need to loop through output_blocks more than
+    # once below (itertools.product already uses an internal list,
+    # so this is not a memory regression)
     output_blocks = output_blocks or list(
         itertools.product(*[range(dims[i]) for i in out_indices])
     )

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -590,7 +590,7 @@ async def test_futures_in_subgraphs(c, s, a, b):
     ddf = await c.submit(dd.categorical.categorize, ddf, columns=["day"], index=False)
 
 
-# @pytest.mark.flaky(reruns=5, reruns_delay=5)
+@pytest.mark.flaky(reruns=5, reruns_delay=5)
 @gen_cluster(client=True)
 async def test_shuffle_priority(c, s, a, b):
     pd = pytest.importorskip("pandas")

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -101,6 +101,18 @@ def test_futures_to_delayed_dataframe(c):
         ddf = dd.from_delayed([1, 2])
 
 
+def test_from_delayed_dataframe(c):
+    # Check that Delayed keys in the form of a tuple
+    # are properly serialized in `from_delayed`
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    df = pd.DataFrame({"x": range(20)})
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = dd.from_delayed(ddf.to_delayed())
+    dd.utils.assert_eq(ddf, df, scheduler=c)
+
+
 @pytest.mark.parametrize("fuse", [True, False])
 def test_fused_blockwise_dataframe_merge(c, fuse):
     pd = pytest.importorskip("pandas")
@@ -578,7 +590,7 @@ async def test_futures_in_subgraphs(c, s, a, b):
     ddf = await c.submit(dd.categorical.categorize, ddf, columns=["day"], index=False)
 
 
-@pytest.mark.flaky(reruns=5, reruns_delay=5)
+# @pytest.mark.flaky(reruns=5, reruns_delay=5)
 @gen_cluster(client=True)
 async def test_shuffle_priority(c, s, a, b):
     pd = pytest.importorskip("pandas")


### PR DESCRIPTION
Follow-up bug fix for #8852 - The recent `from_delayed` change ended up [causing a CI failure in dask_cudf](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cudf/job/prb/job/cudf-gpu-test/CUDA=11.2,GPU_LABEL=driver-495,LINUX_VER=ubuntu18.04,PYTHON=3.9/7667/testReport/dask_cudf.tests/test_distributed/test_basic_True_/), because the `Delayed` object keys (those defined in the `BlockwiseDepDict` mapping) are never "stringified" before making it to the scheduler.  This is fine when the `Delayed`-object key is already a string. However, it is **not** okay when the `Delayed` object is created from a `DataFrame.from_delayed()` call, because the keys will be tuples in this case. 

This PR adds a step to stringify the the values in the `BlockwiseDepDict` mapping when `produces_keys=True`. It also adds a relevant test.