### PR TITLE
Change split_row_groups default to False in read_parquet

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -324,7 +324,7 @@ class ArrowDatasetEngine(Engine):
         index=None,
         gather_statistics=None,
         filters=None,
-        split_row_groups=None,
+        split_row_groups=False,
         chunksize=None,
         aggregate_files=None,
         ignore_metadata_file=False,
@@ -897,11 +897,6 @@ class ArrowDatasetEngine(Engine):
         # be avoided at all costs.
         if gather_statistics is None:
             gather_statistics = False
-        if split_row_groups is None:
-            if gather_statistics:
-                split_row_groups = True
-            else:
-                split_row_groups = False
 
         # Deal with directory partitioning
         # Get all partition keys (without filters) to populate partition_obj
@@ -1153,8 +1148,6 @@ class ArrowDatasetEngine(Engine):
         # want to apply any filters or calculate divisions. Note
         # that the `ArrowDatasetEngine` doesn't even require
         # `gather_statistics=True` for filtering.
-        if split_row_groups is None:
-            split_row_groups = False
         _need_aggregation_stats = chunksize or (
             int(split_row_groups) > 1 and aggregation_depth
         )
@@ -1403,6 +1396,16 @@ class ArrowDatasetEngine(Engine):
                             if name in statistics:
                                 cmin = statistics[name]["min"]
                                 cmax = statistics[name]["max"]
+                                cmin = (
+                                    pd.Timestamp(cmin)
+                                    if isinstance(cmin, datetime)
+                                    else cmin
+                                )
+                                cmax = (
+                                    pd.Timestamp(cmax)
+                                    if isinstance(cmax, datetime)
+                                    else cmax
+                                )
                                 last = cmax_last.get(name, None)
                                 if not (filters or chunksize or aggregation_depth):
                                     # Only think about bailing if we don't need
@@ -1423,12 +1426,8 @@ class ArrowDatasetEngine(Engine):
                                     s["columns"].append(
                                         {
                                             "name": name,
-                                            "min": pd.Timestamp(cmin)
-                                            if isinstance(cmin, datetime)
-                                            else cmin,
-                                            "max": pd.Timestamp(cmax)
-                                            if isinstance(cmax, datetime)
-                                            else cmax,
+                                            "min": cmin,
+                                            "max": cmax,
                                         }
                                     )
                                 else:

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -169,7 +169,7 @@ def read_parquet(
     gather_statistics=None,
     ignore_metadata_file=False,
     metadata_task_size=None,
-    split_row_groups=None,
+    split_row_groups=False,
     chunksize=None,
     aggregate_files=None,
     parquet_file_extension=(".parq", ".parquet", ".pq"),
@@ -258,9 +258,7 @@ def read_parquet(
         The default values for local and remote filesystems can be specified
         with the "metadata-task-size-local" and "metadata-task-size-remote"
         config fields, respectively (see "dataframe.parquet").
-    split_row_groups : bool or int, default None
-        Default is True if a _metadata file is available or if
-        the dataset is composed of a single file (otherwise defult is False).
+    split_row_groups : bool or int, default False
         If True, then each output dataframe partition will correspond to a single
         parquet-file row-group. If False, each partition will correspond to a
         complete file.  If a positive integer value is given, each dataframe

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -639,8 +639,6 @@ class FastParquetEngine(Engine):
         # We don't "need" to gather statistics if we don't
         # want to apply filters, aggregate files, or calculate
         # divisions.
-        if split_row_groups is None:
-            split_row_groups = False
         _need_aggregation_stats = chunksize or (
             int(split_row_groups) > 1 and aggregation_depth
         )
@@ -851,7 +849,7 @@ class FastParquetEngine(Engine):
         index=None,
         gather_statistics=None,
         filters=None,
-        split_row_groups=True,
+        split_row_groups=False,
         chunksize=None,
         aggregate_files=None,
         ignore_metadata_file=False,

--- a/docs/source/dataframe-parquet.rst
+++ b/docs/source/dataframe-parquet.rst
@@ -103,18 +103,20 @@ disable loading the ``_metadata`` file by specifying
    ...      ignore_metadata_file=True  # don't read the _metadata file
    ... )
 
-If no ``_metadata`` file is present, Dask will load each parquet file
-individually as a partition in the Dask dataframe. This is performant provided
-all files are of reasonable size.
+Partition Size
+~~~~~~~~~~~~~~
+
+By default, Dask will load each parquet file individually as a partition in
+the Dask dataframe. This is performant provided all files are of reasonable size.
 
 We recommend aiming for 10-250 MiB in-memory size per file once loaded into
 pandas. Too large files can lead to excessive memory usage on a single worker,
 while too small files can lead to poor performance as the overhead of Dask
-dominates. If you need to read a parquet dataset composed of many large files
-and lacking a ``_metadata`` file, you can pass ``split_row_groups=True`` to
-have Dask partition your data by *row group* instead of by *file*. Note that
-this can be *extremely* slow in large datasets, as the a footer needs to be
-loaded from every file in the dataset.
+dominates. If you need to read a parquet dataset composed of many large files,
+you can pass ``split_row_groups=True`` to have Dask partition your data by
+*row group* instead of by *file*. Note that this can be *extremely* slow in
+large datasets, as the a footer needs to be loaded from every file in the
+dataset if a global ``_metadata`` file is not available.
 
 Column Selection
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As discussed in #8937, there are many reasons to simplify the confusing logic around the defaults used for `split_row_groups` and `gather_statistics` (and their relation to `_metadata`) in `read_parquet`.  The current plan is to simplify default behavior and remove any "magic switches."

This PR changes the `split_row_groups` default to `False` (no matter the setting of `gather_statistics`).

The follow-up to this PR will remove `gather_statistics` in favor of `calculate_divisions` (with a consistent default of `False`). 

- [x] Addresses part of #8937
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

cc @jcrist 