### PR TITLE
Add ``pytest-timeout`` to distributed envs on CI

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-rerunfailures
+  - pytest-timeout
   - pytest-xdist
   - moto
   - flask

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-rerunfailures
+  - pytest-timeout
   - pytest-xdist
   - moto
   - flask

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-rerunfailures
+  - pytest-timeout
   - pytest-xdist
   - moto
   - flask

--- a/continuous_integration/environment-mindeps-distributed.yaml
+++ b/continuous_integration/environment-mindeps-distributed.yaml
@@ -20,4 +20,5 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-rerunfailures
+  - pytest-timeout
   - pytest-xdist

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -43,6 +43,9 @@ python -m pip install git+https://github.com/dask/distributed
 gpuci_logger "Install dask"
 python setup.py install
 
+gpuci_logger "Install pytest-timeout"
+python -m pip install pytest-timeout
+
 gpuci_logger "Check Python version"
 python --version
 


### PR DESCRIPTION
Dask tests have been failing since `pytest-timeout` was added on the distributed side. This adds the extension for CI envs that include distributed. Related to https://github.com/dask/distributed/pull/6224 but not mutually exclusive.