### PR TITLE
Improve `NotImplementedError` message for da.reshape

### DIFF
--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -14,6 +14,20 @@ from dask.core import flatten
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import M, parse_bytes
 
+_not_implemented_message = """
+Dask's reshape only supports operations that merge or split existing dimensions
+evenly. For example:
+
+>>> x = da.ones((6, 5, 4), chunks=(3, 2, 2))
+>>> x.reshape((3, 2, 5, 4))  # supported, splits 6 into 3 & 2
+>>> x.reshape((30, 4))       # supported, merges 6 & 5 into 30
+>>> x.reshape((4, 5, 6))     # unsupported, existing dimensions split unevenly
+
+To work around this you may call reshape in multiple passes, or (if your data
+is small enough) call ``compute`` first and handle reshaping in ``numpy``
+directly.
+"""
+
 
 def reshape_rechunk(inshape, outshape, inchunks):
     assert all(isinstance(c, tuple) for c in inchunks)
@@ -44,12 +58,7 @@ def reshape_rechunk(inshape, outshape, inchunks):
             ):  # 4 < 64, 4*4 < 64, 4*4*4 == 64
                 ileft -= 1
             if reduce(mul, inshape[ileft : ii + 1]) != dout:
-                raise NotImplementedError("""Dask reshaping currently only supports collapsing/merging array dimensions. For example, reshaping a 6x2 dimensional array into a 12x1 array.
-       
-                In the interim, if this operation is required, utilise the Numpy version of reshape.
-
-                Also note that performance of this reshape implementation varies depending on how the input array is chunked. Please read the official Dask array documentation section for further details on how Dask implements Reshaping""")
-
+                raise NotImplementedError(_not_implemented_message)
             # Special case to avoid intermediate rechunking:
             # When all the lower axis are completely chunked (chunksize=1) then
             # we're simply moving around blocks.
@@ -78,12 +87,7 @@ def reshape_rechunk(inshape, outshape, inchunks):
             while oleft >= 0 and reduce(mul, outshape[oleft : oi + 1]) < din:
                 oleft -= 1
             if reduce(mul, outshape[oleft : oi + 1]) != din:
-                raise NotImplementedError("""Dask reshaping currently only supports collapsing/merging array dimensions. For example, reshaping a 6x2 dimensional array into a 12x1 array.
-       
-                In the interim, if this operation is required, utilise the Numpy version of reshape.
-
-                Also note that performance of this reshape implementation varies depending on how the input array is chunked. Please read the official Dask array documentation section for further details on how Dask implements Reshaping""")
-
+                raise NotImplementedError(_not_implemented_message)
             # TODO: don't coalesce shapes unnecessarily
             cs = reduce(mul, outshape[oleft + 1 : oi + 1])
 

--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -44,7 +44,11 @@ def reshape_rechunk(inshape, outshape, inchunks):
             ):  # 4 < 64, 4*4 < 64, 4*4*4 == 64
                 ileft -= 1
             if reduce(mul, inshape[ileft : ii + 1]) != dout:
-                raise ValueError("Shapes not compatible")
+                raise NotImplementedError("""Dask reshaping currently only supports collapsing/merging array dimensions. For example, reshaping a 6x2 dimensional array into a 12x1 array.
+       
+                In the interim, if this operation is required, utilise the Numpy version of reshape.
+
+                Also note that performance of this reshape implementation varies depending on how the input array is chunked. Please read the official Dask array documentation section for further details on how Dask implements Reshaping""")
 
             # Special case to avoid intermediate rechunking:
             # When all the lower axis are completely chunked (chunksize=1) then
@@ -74,7 +78,11 @@ def reshape_rechunk(inshape, outshape, inchunks):
             while oleft >= 0 and reduce(mul, outshape[oleft : oi + 1]) < din:
                 oleft -= 1
             if reduce(mul, outshape[oleft : oi + 1]) != din:
-                raise ValueError("Shapes not compatible")
+                raise NotImplementedError("""Dask reshaping currently only supports collapsing/merging array dimensions. For example, reshaping a 6x2 dimensional array into a 12x1 array.
+       
+                In the interim, if this operation is required, utilise the Numpy version of reshape.
+
+                Also note that performance of this reshape implementation varies depending on how the input array is chunked. Please read the official Dask array documentation section for further details on how Dask implements Reshaping""")
 
             # TODO: don't coalesce shapes unnecessarily
             cs = reduce(mul, outshape[oleft + 1 : oi + 1])

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1212,14 +1212,11 @@ def test_reshape_splat():
     assert_eq(x.reshape((25,)), x.reshape(25))
 
 
-def test_reshape_fails_for_dask_only():
-    cases = [((3, 4), (4, 3), 2)]
-    for original_shape, new_shape, chunks in cases:
-        x = np.random.randint(10, size=original_shape)
-        a = from_array(x, chunks=chunks)
-        assert x.reshape(new_shape).shape == new_shape
-        with pytest.raises(ValueError):
-            da.reshape(a, new_shape)
+def test_reshape_not_implemented_error():
+    a = da.ones((4, 5, 6), chunks=(2, 2, 3))
+    for new_shape in [(2, 10, 6), (5, 4, 6), (6, 5, 4)]:
+        with pytest.raises(NotImplementedError):
+            a.reshape(new_shape)
 
 
 def test_reshape_unknown_dimensions():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1,6 +1,7 @@
 import contextlib
 import copy
 import pathlib
+import re
 import xml.etree.ElementTree
 from unittest import mock
 
@@ -47,6 +48,7 @@ from dask.array.core import (
     stack,
     store,
 )
+from dask.array.reshape import _not_implemented_message
 from dask.array.tests.test_dispatch import EncapsulateNDArray
 from dask.array.utils import assert_eq, same_keys
 from dask.base import compute_as_if_collection, tokenize
@@ -1215,7 +1217,9 @@ def test_reshape_splat():
 def test_reshape_not_implemented_error():
     a = da.ones((4, 5, 6), chunks=(2, 2, 3))
     for new_shape in [(2, 10, 6), (5, 4, 6), (6, 5, 4)]:
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(
+            NotImplementedError, match=re.escape(_not_implemented_message)
+        ):
             a.reshape(new_shape)
 
 


### PR DESCRIPTION
Originally I was trying to push up a small fix to #8905, but they've disabled pushing to their branch so using a new PR instead.

Supersedes #8905, closes #8634.