### PR TITLE
Change `to_parquet` default to `write_metadata_file=None`

### DIFF
--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -573,6 +573,7 @@ def test_parquet_append(s3, engine, s3so):
         engine=engine,
         storage_options=s3so,
         write_index=False,
+        write_metadata_file=True,
     )
     df.to_parquet(
         url,
@@ -613,7 +614,13 @@ def test_parquet_wstoragepars(s3, s3so, engine):
 
     data = pd.DataFrame({"i32": np.array([0, 5, 2, 5])})
     df = dd.from_pandas(data, chunksize=500)
-    df.to_parquet(url, engine=engine, write_index=False, storage_options=s3so)
+    df.to_parquet(
+        url,
+        engine=engine,
+        write_index=False,
+        storage_options=s3so,
+        write_metadata_file=True,
+    )
 
     dd.read_parquet(
         url,

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -569,7 +569,9 @@ class ArrowDatasetEngine(Engine):
                     metadata_file_exists = True
                 except OSError:
                     try:
-                        with fs.open(sorted(ds.files)[-1], mode="rb") as fil:
+                        with fs.open(
+                            sorted(ds.files, key=natural_sort_key)[-1], mode="rb"
+                        ) as fil:
                             tail_metadata = pq.read_metadata(fil)
                     except OSError:
                         pass

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -561,7 +561,7 @@ def to_parquet(
     partition_on=None,
     storage_options=None,
     custom_metadata=None,
-    write_metadata_file=True,
+    write_metadata_file=None,
     compute=True,
     compute_kwargs=None,
     schema=None,

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -1161,11 +1161,13 @@ class FastParquetEngine(Engine):
                 "because this required data in memory."
             )
 
+        metadata_file_exists = False
         if append:
             try:
                 # to append to a dataset without _metadata, need to load
                 # _common_metadata or any data file here
                 pf = fastparquet.api.ParquetFile(path, open_with=fs.open)
+                metadata_file_exists = fs.exists(fs.sep.join([path, "_metadata"]))
             except (OSError, ValueError):
                 # append for create
                 append = False
@@ -1224,8 +1226,8 @@ class FastParquetEngine(Engine):
             )
             fmd.key_value_metadata = kvm
 
-        schema = None  # ArrowEngine compatibility
-        return (fmd, schema, i_offset)
+        extra_write_kwargs = {"fmd": fmd}
+        return i_offset, fmd, metadata_file_exists, extra_write_kwargs
 
     @classmethod
     def write_partition(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -173,7 +173,8 @@ def test_get_engine_auto_warning_if_both_installed():
 
 
 @write_read_engines()
-def test_local(tmpdir, write_engine, read_engine):
+@pytest.mark.parametrize("has_metadata", [False, True])
+def test_local(tmpdir, write_engine, read_engine, has_metadata):
     tmp = str(tmpdir)
     data = pd.DataFrame(
         {
@@ -187,11 +188,12 @@ def test_local(tmpdir, write_engine, read_engine):
     )
     df = dd.from_pandas(data, chunksize=500)
 
-    df.to_parquet(tmp, write_index=False, engine=write_engine)
+    kwargs = {"write_metadata_file": True} if has_metadata else {}
+    df.to_parquet(tmp, write_index=False, engine=write_engine, **kwargs)
 
     files = os.listdir(tmp)
-    assert "_common_metadata" in files
-    assert "_metadata" in files
+    assert ("_common_metadata" in files) == has_metadata
+    assert ("_metadata" in files) == has_metadata
     assert "part.0.parquet" in files
 
     df2 = dd.read_parquet(tmp, index=False, engine=read_engine)
@@ -213,7 +215,7 @@ def test_empty(tmpdir, write_engine, read_engine, index):
         df.set_index("a", inplace=True, drop=True)
     ddf = dd.from_pandas(df, npartitions=2)
 
-    ddf.to_parquet(fn, write_index=index, engine=write_engine)
+    ddf.to_parquet(fn, write_index=index, engine=write_engine, write_metadata_file=True)
     read_df = dd.read_parquet(fn, engine=read_engine)
     assert_eq(ddf, read_df)
 
@@ -228,8 +230,9 @@ def test_simple(tmpdir, write_engine, read_engine):
     df.set_index("a", inplace=True, drop=True)
     ddf = dd.from_pandas(df, npartitions=2)
     ddf.to_parquet(fn, engine=write_engine)
-    read_df = dd.read_parquet(fn, index=["a"], engine=read_engine)
-    assert_eq(ddf, read_df)
+    res = dd.read_parquet(fn, index=["a"], engine=read_engine)
+    sol = ddf.compute()
+    assert_eq(res, sol)
 
 
 @write_read_engines()
@@ -314,10 +317,12 @@ def test_columns_auto_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=write_engine)
 
-    # XFAIL, auto index selection no longer supported (for simplicity)
     # ### Empty columns ###
     # With divisions if supported
-    assert_eq(dd.read_parquet(fn, columns=[], engine=read_engine), ddf[[]])
+    assert_eq(
+        dd.read_parquet(fn, columns=[], engine=read_engine, gather_statistics=True),
+        ddf[[]],
+    )
 
     # No divisions
     assert_eq(
@@ -328,7 +333,10 @@ def test_columns_auto_index(tmpdir, write_engine, read_engine):
 
     # ### Single column, auto select index ###
     # With divisions if supported
-    assert_eq(dd.read_parquet(fn, columns=["x"], engine=read_engine), ddf[["x"]])
+    assert_eq(
+        dd.read_parquet(fn, columns=["x"], engine=read_engine, gather_statistics=True),
+        ddf[["x"]],
+    )
 
     # No divisions
     assert_eq(
@@ -348,7 +356,10 @@ def test_columns_index(tmpdir, write_engine, read_engine):
     # ### Empty columns, specify index ###
     # With divisions if supported
     assert_eq(
-        dd.read_parquet(fn, columns=[], engine=read_engine, index="myindex"), ddf[[]]
+        dd.read_parquet(
+            fn, columns=[], engine=read_engine, index="myindex", gather_statistics=True
+        ),
+        ddf[[]],
     )
 
     # No divisions
@@ -363,7 +374,13 @@ def test_columns_index(tmpdir, write_engine, read_engine):
     # ### Single column, specify index ###
     # With divisions if supported
     assert_eq(
-        dd.read_parquet(fn, index="myindex", columns=["x"], engine=read_engine),
+        dd.read_parquet(
+            fn,
+            index="myindex",
+            columns=["x"],
+            engine=read_engine,
+            gather_statistics=True,
+        ),
         ddf[["x"]],
     )
 
@@ -383,7 +400,13 @@ def test_columns_index(tmpdir, write_engine, read_engine):
     # ### Two columns, specify index ###
     # With divisions if supported
     assert_eq(
-        dd.read_parquet(fn, index="myindex", columns=["x", "y"], engine=read_engine),
+        dd.read_parquet(
+            fn,
+            index="myindex",
+            columns=["x", "y"],
+            engine=read_engine,
+            gather_statistics=True,
+        ),
         ddf,
     )
 
@@ -540,11 +563,13 @@ def test_no_index(tmpdir, write_engine, read_engine):
 def test_read_series(tmpdir, engine):
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=engine)
+    sol = ddf.compute()
+
     ddf2 = dd.read_parquet(fn, columns=["x"], index="myindex", engine=engine)
-    assert_eq(ddf[["x"]], ddf2)
+    assert_eq(sol[["x"]], ddf2)
 
     ddf2 = dd.read_parquet(fn, columns="x", index="myindex", engine=engine)
-    assert_eq(ddf.x, ddf2)
+    assert_eq(sol.x, ddf2)
 
 
 def test_names(tmpdir, engine):
@@ -601,7 +626,8 @@ def test_categorical(tmpdir, write_engine, read_engine):
     assert (df.x == ddf2.x.compute()).all()
 
 
-def test_append(tmpdir, engine):
+@pytest.mark.parametrize("metadata_file", [False, True])
+def test_append(tmpdir, engine, metadata_file):
     """Test that appended parquet equal to the original one."""
     tmp = str(tmpdir)
     df = pd.DataFrame(
@@ -619,8 +645,15 @@ def test_append(tmpdir, engine):
     half = len(df) // 2
     ddf1 = dd.from_pandas(df.iloc[:half], chunksize=100)
     ddf2 = dd.from_pandas(df.iloc[half:], chunksize=100)
-    ddf1.to_parquet(tmp, engine=engine)
+    ddf1.to_parquet(tmp, engine=engine, write_metadata_file=metadata_file)
+    if metadata_file:
+        with open(str(tmpdir.join("_metadata")), "rb") as f:
+            metadata1 = f.read()
     ddf2.to_parquet(tmp, append=True, engine=engine)
+    if metadata_file:
+        with open(str(tmpdir.join("_metadata")), "rb") as f:
+            metadata2 = f.read()
+        assert metadata2 != metadata1  # 2nd write updated the metadata file
 
     ddf3 = dd.read_parquet(tmp, engine=engine)
     assert_eq(df, ddf3)
@@ -759,7 +792,8 @@ def test_partition_on_cats_2(tmpdir, engine):
     assert set(df.cat.categories) == {"x", "y", "z"}
 
 
-def test_append_wo_index(tmpdir, engine):
+@pytest.mark.parametrize("metadata_file", [False, True])
+def test_append_wo_index(tmpdir, engine, metadata_file):
     """Test append with write_index=False."""
     tmp = str(tmpdir.join("tmp1.parquet"))
     df = pd.DataFrame(
@@ -775,21 +809,24 @@ def test_append_wo_index(tmpdir, engine):
     half = len(df) // 2
     ddf1 = dd.from_pandas(df.iloc[:half], chunksize=100)
     ddf2 = dd.from_pandas(df.iloc[half:], chunksize=100)
-    ddf1.to_parquet(tmp, engine=engine)
+    ddf1.to_parquet(tmp, engine=engine, write_metadata_file=metadata_file)
 
     with pytest.raises(ValueError) as excinfo:
         ddf2.to_parquet(tmp, write_index=False, append=True, engine=engine)
     assert "Appended columns" in str(excinfo.value)
 
     tmp = str(tmpdir.join("tmp2.parquet"))
-    ddf1.to_parquet(tmp, write_index=False, engine=engine)
+    ddf1.to_parquet(
+        tmp, write_index=False, engine=engine, write_metadata_file=metadata_file
+    )
     ddf2.to_parquet(tmp, write_index=False, append=True, engine=engine)
 
     ddf3 = dd.read_parquet(tmp, index="f", engine=engine)
     assert_eq(df.set_index("f"), ddf3)
 
 
-def test_append_overlapping_divisions(tmpdir, engine):
+@pytest.mark.parametrize("metadata_file", [False, True])
+def test_append_overlapping_divisions(tmpdir, engine, metadata_file):
     """Test raising of error when divisions overlapping."""
     tmp = str(tmpdir)
     df = pd.DataFrame(
@@ -805,7 +842,7 @@ def test_append_overlapping_divisions(tmpdir, engine):
     half = len(df) // 2
     ddf1 = dd.from_pandas(df.iloc[:half], chunksize=100)
     ddf2 = dd.from_pandas(df.iloc[half - 10 :], chunksize=100)
-    ddf1.to_parquet(tmp, engine=engine)
+    ddf1.to_parquet(tmp, engine=engine, write_metadata_file=metadata_file)
 
     with pytest.raises(ValueError) as excinfo:
         ddf2.to_parquet(tmp, engine=engine, append=True)
@@ -814,7 +851,8 @@ def test_append_overlapping_divisions(tmpdir, engine):
     ddf2.to_parquet(tmp, engine=engine, append=True, ignore_divisions=True)
 
 
-def test_append_different_columns(tmpdir, engine):
+@pytest.mark.parametrize("metadata_file", [False, True])
+def test_append_different_columns(tmpdir, engine, metadata_file):
     """Test raising of error when non equal columns."""
     tmp = str(tmpdir)
     df1 = pd.DataFrame({"i32": np.arange(100, dtype=np.int32)})
@@ -825,7 +863,7 @@ def test_append_different_columns(tmpdir, engine):
     ddf2 = dd.from_pandas(df2, chunksize=2)
     ddf3 = dd.from_pandas(df3, chunksize=2)
 
-    ddf1.to_parquet(tmp, engine=engine)
+    ddf1.to_parquet(tmp, engine=engine, write_metadata_file=metadata_file)
 
     with pytest.raises(ValueError) as excinfo:
         ddf2.to_parquet(tmp, engine=engine, append=True)
@@ -893,7 +931,7 @@ def test_read_parquet_custom_columns(tmpdir, engine):
     df.to_parquet(tmp, engine=engine)
 
     df2 = dd.read_parquet(tmp, columns=["i32", "f"], engine=engine)
-    assert_eq(df[["i32", "f"]], df2, check_index=False)
+    assert_eq(df[["i32", "f"]], df2, check_index=False, check_divisions=False)
 
     fns = glob.glob(os.path.join(tmp, "*.parquet"))
     df2 = dd.read_parquet(fns, columns=["i32"], engine=engine).compute()
@@ -901,7 +939,7 @@ def test_read_parquet_custom_columns(tmpdir, engine):
     assert_eq(df[["i32"]], df2, check_index=False, check_divisions=False)
 
     df3 = dd.read_parquet(tmp, columns=["f", "i32"], engine=engine)
-    assert_eq(df[["f", "i32"]], df3, check_index=False)
+    assert_eq(df[["f", "i32"]], df3, check_index=False, check_divisions=False)
 
 
 @pytest.mark.parametrize(
@@ -974,9 +1012,9 @@ def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
     if str(ddf2.dtypes.get("x")) == "UInt16" and engine == "fastparquet":
         # fastparquet choooses to use masked type to be able to get true repr of
         # 16-bit int
-        assert_eq(ddf.astype("UInt16"), ddf2)
+        assert_eq(ddf.astype("UInt16"), ddf2, check_divisions=False)
     else:
-        assert_eq(ddf, ddf2)
+        assert_eq(ddf, ddf2, check_divisions=False)
 
 
 def test_categories(tmpdir, engine):
@@ -1035,7 +1073,6 @@ def test_empty_partition(tmpdir, engine):
     ddf2.to_parquet(fn, engine=engine)
 
     ddf3 = dd.read_parquet(fn, engine=engine)
-    assert ddf3.npartitions < 5
     sol = ddf2.compute()
     assert_eq(sol, ddf3, check_names=False, check_index=False)
 
@@ -1045,7 +1082,7 @@ def test_timestamp_index(tmpdir, engine):
     df = dd._compat.makeTimeDataFrame()
     df.index.name = "foo"
     ddf = dd.from_pandas(df, npartitions=5)
-    ddf.to_parquet(fn, engine=engine)
+    ddf.to_parquet(fn, engine=engine, write_metadata_file=True)
     ddf2 = dd.read_parquet(fn, engine=engine)
     assert_eq(ddf, ddf2)
 
@@ -1183,18 +1220,8 @@ def test_pyarrow_schema_inference(tmpdir, index, engine, schema):
         df = dd.from_pandas(df, npartitions=2)
 
     df.to_parquet(tmpdir, engine="pyarrow", schema=schema)
-    df_out = dd.read_parquet(tmpdir, engine=engine)
-    df_out.compute()
-
-    if index and engine == "fastparquet":
-        # Fastparquet fails to detect int64 from _metadata
-        df_out["amount"] = df_out["amount"].astype("int64")
-
-        # Fastparquet not handling divisions for
-        # pyarrow-written dataset with string index
-        assert_eq(df, df_out, check_divisions=False)
-    else:
-        assert_eq(df, df_out)
+    df_out = dd.read_parquet(tmpdir, engine=engine, gather_statistics=True)
+    assert_eq(df, df_out)
 
 
 def test_partition_on(tmpdir, engine):
@@ -1305,7 +1332,7 @@ def test_filters(tmpdir, write_engine, read_engine):
     ddf = dd.from_pandas(df, npartitions=5)
     assert ddf.npartitions == 5
 
-    ddf.to_parquet(tmp_path, engine=write_engine)
+    ddf.to_parquet(tmp_path, engine=write_engine, write_metadata_file=True)
 
     a = dd.read_parquet(tmp_path, engine=read_engine, filters=[("x", ">", 4)])
     assert a.npartitions == 3
@@ -1409,7 +1436,7 @@ def test_filtering_pyarrow_dataset(tmpdir, engine):
     fn = str(tmpdir)
     df = pd.DataFrame({"aa": range(100), "bb": ["cat", "dog"] * 50})
     ddf = dd.from_pandas(df, npartitions=10)
-    ddf.to_parquet(fn, write_index=False, engine=engine)
+    ddf.to_parquet(fn, write_index=False, engine=engine, write_metadata_file=True)
 
     # Filtered read
     aa_lim = 40
@@ -1581,7 +1608,7 @@ def test_to_parquet_lazy(tmpdir, scheduler, engine):
 
     ddf2 = dd.read_parquet(tmpdir, engine=engine)
 
-    assert_eq(ddf, ddf2)
+    assert_eq(ddf, ddf2, check_divisions=False)
 
 
 @FASTPARQUET_MARK
@@ -1691,7 +1718,9 @@ def test_explicit_compression_default_deprecated(tmpdir, engine):
     ddf = dd.from_pandas(df, npartitions=3)
 
     with pytest.warns(FutureWarning, match="compression='default'"):
-        ddf.to_parquet(fn, compression="default", engine=engine)
+        ddf.to_parquet(
+            fn, compression="default", engine=engine, write_metadata_file=True
+        )
     out = dd.read_parquet(fn, engine=engine)
     assert_eq(out, ddf)
     check_compression(engine, fn, "default")
@@ -1705,7 +1734,7 @@ def test_writing_parquet_with_compression(tmpdir, compression, engine):
     df.index.name = "index"
     ddf = dd.from_pandas(df, npartitions=3)
 
-    ddf.to_parquet(fn, compression=compression, engine=engine)
+    ddf.to_parquet(fn, compression=compression, engine=engine, write_metadata_file=True)
     out = dd.read_parquet(fn, engine=engine)
     assert_eq(out, ddf)
     check_compression(engine, fn, compression)
@@ -1719,7 +1748,13 @@ def test_writing_parquet_with_partition_on_and_compression(tmpdir, compression, 
     df.index.name = "index"
     ddf = dd.from_pandas(df, npartitions=3)
 
-    ddf.to_parquet(fn, compression=compression, engine=engine, partition_on=["x"])
+    ddf.to_parquet(
+        fn,
+        compression=compression,
+        engine=engine,
+        partition_on=["x"],
+        write_metadata_file=True,
+    )
     check_compression(engine, fn, compression)
 
 
@@ -2008,7 +2043,9 @@ def test_writing_parquet_with_kwargs(tmpdir, engine):
         "fastparquet": {"compression": "snappy", "times": "int64", "fixed_text": None},
     }
 
-    ddf.to_parquet(path1, engine=engine, **engine_kwargs[engine])
+    ddf.to_parquet(
+        path1, engine=engine, write_metadata_file=True, **engine_kwargs[engine]
+    )
     out = dd.read_parquet(path1, engine=engine)
     assert_eq(out, ddf, check_index=(engine != "fastparquet"))
 
@@ -2178,7 +2215,7 @@ def test_datasets_timeseries(tmpdir, engine):
     ).persist()
     df.to_parquet(tmp_path, engine=engine)
 
-    df2 = dd.read_parquet(tmp_path, engine=engine)
+    df2 = dd.read_parquet(tmp_path, engine=engine, gather_statistics=True)
     assert_eq(df, df2)
 
 
@@ -2191,7 +2228,7 @@ def test_pathlib_path(tmpdir, engine):
     path = pathlib.Path(str(tmpdir))
     ddf.to_parquet(path, engine=engine)
     ddf2 = dd.read_parquet(path, engine=engine)
-    assert_eq(ddf, ddf2)
+    assert_eq(ddf, ddf2, check_divisions=False)
 
 
 @FASTPARQUET_MARK
@@ -2222,7 +2259,7 @@ def test_read_glob_no_meta(tmpdir, write_engine, read_engine):
 @write_read_engines()
 def test_read_glob_yes_meta(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
-    ddf.to_parquet(tmp_path, engine=write_engine)
+    ddf.to_parquet(tmp_path, engine=write_engine, write_metadata_file=True)
     paths = glob.glob(os.path.join(tmp_path, "*.parquet"))
     paths.append(os.path.join(tmp_path, "_metadata"))
     ddf2 = dd.read_parquet(paths, engine=read_engine, gather_statistics=False)
@@ -2234,7 +2271,7 @@ def test_read_glob_yes_meta(tmpdir, write_engine, read_engine):
 @write_read_engines()
 def test_read_dir_nometa(tmpdir, write_engine, read_engine, statistics, remove_common):
     tmp_path = str(tmpdir)
-    ddf.to_parquet(tmp_path, engine=write_engine)
+    ddf.to_parquet(tmp_path, engine=write_engine, write_metadata_file=True)
     if os.path.exists(os.path.join(tmp_path, "_metadata")):
         os.unlink(os.path.join(tmp_path, "_metadata"))
     files = os.listdir(tmp_path)
@@ -2446,7 +2483,7 @@ def test_optimize_blockwise_parquet(tmpdir, engine):
     tmp = str(tmpdir)
     df = pd.DataFrame({"a": np.arange(size, dtype=np.int32)})
     expect = dd.from_pandas(df, npartitions=npartitions)
-    expect.to_parquet(tmp, engine=engine)
+    expect.to_parquet(tmp, engine=engine, write_metadata_file=True)
     ddf = dd.read_parquet(tmp, engine=engine)
 
     # `ddf` should now have ONE Blockwise layer
@@ -2661,7 +2698,7 @@ def test_optimize_and_not(tmpdir, engine):
 def test_chunksize_empty(tmpdir, write_engine, read_engine):
     df = pd.DataFrame({"a": pd.Series(dtype="int"), "b": pd.Series(dtype="float")})
     ddf1 = dd.from_pandas(df, npartitions=1)
-    ddf1.to_parquet(tmpdir, engine=write_engine)
+    ddf1.to_parquet(tmpdir, engine=write_engine, write_metadata_file=True)
     ddf2 = dd.read_parquet(tmpdir, engine=read_engine, chunksize="1MiB")
     assert_eq(ddf1, ddf2, check_index=False)
 
@@ -2914,7 +2951,7 @@ def test_pandas_metadata_nullable_pyarrow(tmpdir):
         ),
         npartitions=1,
     )
-    ddf1.to_parquet(tmpdir, engine="pyarrow")
+    ddf1.to_parquet(tmpdir, engine="pyarrow", write_metadata_file=True)
     ddf2 = dd.read_parquet(tmpdir, engine="pyarrow")
 
     assert_eq(ddf1, ddf2, check_index=False)
@@ -3170,8 +3207,7 @@ def test_pyarrow_dataset_simple(tmpdir, engine):
     df.set_index("a", inplace=True, drop=True)
     ddf = dd.from_pandas(df, npartitions=2)
     ddf.to_parquet(fn, engine=engine)
-    read_df = dd.read_parquet(fn, engine="pyarrow")
-    read_df.compute()
+    read_df = dd.read_parquet(fn, engine="pyarrow", gather_statistics=True)
     assert_eq(ddf, read_df)
 
 
@@ -3182,7 +3218,7 @@ def test_pyarrow_dataset_partitioned(tmpdir, engine, test_filter):
     df = pd.DataFrame({"a": [4, 5, 6], "b": ["a", "b", "b"]})
     df["b"] = df["b"].astype("category")
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf.to_parquet(fn, engine=engine, partition_on="b")
+    ddf.to_parquet(fn, engine=engine, partition_on="b", write_metadata_file=True)
     read_df = dd.read_parquet(
         fn,
         engine="pyarrow",
@@ -3266,17 +3302,13 @@ def test_parquet_pyarrow_write_empty_metadata(tmpdir):
     )
 
     df = dd.from_delayed([df_a, df_b, df_c])
-
-    try:
-        df.to_parquet(
-            tmpdir,
-            engine="pyarrow",
-            partition_on=["x"],
-            append=False,
-        )
-
-    except AttributeError:
-        pytest.fail("Unexpected AttributeError")
+    df.to_parquet(
+        tmpdir,
+        engine="pyarrow",
+        partition_on=["x"],
+        append=False,
+        write_metadata_file=True,
+    )
 
     # Check that metadata files where written
     files = os.listdir(tmpdir)
@@ -3310,6 +3342,7 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
         engine="pyarrow",
         partition_on=["x"],
         append=False,
+        write_metadata_file=True,
     )
 
     df_c = dask.delayed(pd.DataFrame.from_dict)(
@@ -3326,6 +3359,7 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
         partition_on=["x"],
         append=True,
         ignore_divisions=True,
+        write_metadata_file=True,
     )
 
 
@@ -3543,6 +3577,7 @@ def test_custom_metadata(tmpdir, engine):
         path,
         engine=engine,
         custom_metadata=custom_metadata,
+        write_metadata_file=True,
     )
 
     # Check that data is correct
@@ -3654,7 +3689,7 @@ def test_extra_file(tmpdir, engine):
     tmpdir = str(tmpdir)
     df = pd.DataFrame({"a": range(100), "b": ["dog", "cat"] * 50})
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf.to_parquet(tmpdir, engine=engine)
+    ddf.to_parquet(tmpdir, engine=engine, write_metadata_file=True)
     open(os.path.join(tmpdir, "_SUCCESS"), "w").close()
     open(os.path.join(tmpdir, "part.0.parquet.crc"), "w").close()
     os.remove(os.path.join(tmpdir, "_metadata"))
@@ -3717,7 +3752,12 @@ def test_unsupported_extension_dir(tmpdir, engine):
     # (Related to: https://github.com/dask/dask/issues/8349)
     path = str(tmpdir)
     ddf0 = dd.from_pandas(pd.DataFrame({"a": range(10)}), 1)
-    ddf0.to_parquet(path, engine=engine, name_function=lambda i: f"part.{i}.foo")
+    ddf0.to_parquet(
+        path,
+        engine=engine,
+        write_metadata_file=True,
+        name_function=lambda i: f"part.{i}.foo",
+    )
     assert_eq(ddf0, dd.read_parquet(path, engine=engine))
 
 
@@ -3727,7 +3767,12 @@ def test_custom_filename(tmpdir, engine):
         {"num1": [1, 2, 3, 4], "num2": [7, 8, 9, 10]},
     )
     df = dd.from_pandas(pdf, npartitions=2)
-    df.to_parquet(fn, name_function=lambda x: f"hi-{x}.parquet", engine=engine)
+    df.to_parquet(
+        fn,
+        write_metadata_file=True,
+        name_function=lambda x: f"hi-{x}.parquet",
+        engine=engine,
+    )
 
     files = os.listdir(fn)
     assert "_common_metadata" in files
@@ -3743,7 +3788,12 @@ def test_custom_filename_works_with_pyarrow_when_append_is_true(tmpdir, engine):
         {"num1": [1, 2, 3, 4], "num2": [7, 8, 9, 10]},
     )
     df = dd.from_pandas(pdf, npartitions=2)
-    df.to_parquet(fn, name_function=lambda x: f"hi-{x * 2}.parquet", engine=engine)
+    df.to_parquet(
+        fn,
+        write_metadata_file=True,
+        name_function=lambda x: f"hi-{x * 2}.parquet",
+        engine=engine,
+    )
 
     pdf = pd.DataFrame(
         {"num1": [33], "num2": [44]},


### PR DESCRIPTION
This changes `to_parquet` to default to `write_metadata_file=None`. If `None`, a `_metadata` file is only written when `append=True` and the dataset has an existing `_metadata` file, otherwise it defaults to False.

If a `_metadata` file doesn't exist when appending, the last file in the dataset is used to validate schema and divisions.

There are also some adjacent changes to simplify the generated `to_parquet` graph (in particular, the full dataset metadata isn't actually needed in each `to_parquet` task, but was previously included, bloating graph size).

The majority of this PR is modifying the tests to not fail after this change, since many of them were implicitly relying on the existence of a `_metadata` file.

Fixes #8901.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
