### PR TITLE
`to_parquet` errors for non-string column names

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -694,6 +694,9 @@ def to_parquet(
             "columns=%s" % (str(partition_on), str(list(df.columns)))
         )
 
+    if df.columns.inferred_type not in {"string", "empty"}:
+        raise ValueError("parquet doesn't support non-string column names")
+
     if isinstance(engine, str):
         engine = get_engine(engine, bool(kwargs))
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3463,6 +3463,13 @@ def test_to_parquet_overwrite_raises(tmpdir, engine):
         dd.to_parquet(ddf, tmpdir, engine=engine, append=True, overwrite=True)
 
 
+def test_to_parquet_errors_non_string_column_names(tmpdir, engine):
+    df = pd.DataFrame({"x": range(10), 1: range(10)})
+    ddf = dd.from_pandas(df, npartitions=2)
+    with pytest.raises(ValueError, match="non-string column names"):
+        ddf.to_parquet(str(tmpdir.join("temp")), engine=engine)
+
+
 def test_dir_filter(tmpdir, engine):
     # github #6898
     df = pd.DataFrame.from_dict(


### PR DESCRIPTION
Parquet doesn't support non-string column names. We mirror pandas'
behavior here and error if `to_parquet` is called on a dataframe with
non-string column names.

Fixes #8010.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
