### PR TITLE
Call `fs.invalidate_cache` in `to_parquet`

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -871,8 +871,15 @@ def to_parquet(
     # Convert data_write + dsk to computable collection
     graph = HighLevelGraph.from_collections(final_name, dsk, dependencies=(data_write,))
     out = Scalar(graph, final_name, "")
+
     if compute:
-        return out.compute(**compute_kwargs)
+        out = out.compute(**compute_kwargs)
+
+    # Invalidate the filesystem listing cache for the output path after write.
+    # We do this before returning, even if `compute=False`. This helps ensure
+    # that reading files that were just written succeeds.
+    fs.invalidate_cache(path)
+
     return out
 
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4,6 +4,7 @@ import os
 import sys
 import warnings
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
@@ -1609,6 +1610,18 @@ def test_to_parquet_lazy(tmpdir, scheduler, engine):
     ddf2 = dd.read_parquet(tmpdir, engine=engine)
 
     assert_eq(ddf, ddf2, check_divisions=False)
+
+
+@PYARROW_MARK
+@pytest.mark.parametrize("compute", [False, True])
+def test_to_parquet_calls_invalidate_cache(tmpdir, monkeypatch, compute):
+    from fsspec.implementations.local import LocalFileSystem
+
+    invalidate_cache = MagicMock()
+    monkeypatch.setattr(LocalFileSystem, "invalidate_cache", invalidate_cache)
+    ddf.to_parquet(tmpdir, compute=compute, engine="pyarrow")
+    assert invalidate_cache.called
+    assert invalidate_cache.call_args.args[0] == str(tmpdir)
 
 
 @FASTPARQUET_MARK

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1620,8 +1620,9 @@ def test_to_parquet_calls_invalidate_cache(tmpdir, monkeypatch, compute):
     invalidate_cache = MagicMock()
     monkeypatch.setattr(LocalFileSystem, "invalidate_cache", invalidate_cache)
     ddf.to_parquet(tmpdir, compute=compute, engine="pyarrow")
+    path = LocalFileSystem._strip_protocol(str(tmpdir))
     assert invalidate_cache.called
-    assert invalidate_cache.call_args.args[0] == str(tmpdir)
+    assert invalidate_cache.call_args.args[0] == path
 
 
 @FASTPARQUET_MARK


### PR DESCRIPTION
Invalidate the client-side filesystem listings cache before returning
from `to_parquet`. This helps ensure that doing a write followed by an
immediate read works - without it the filesystem might use outdated
cache information when reading recently written files resulting in
`FileNotFound` errors.

There's not really a good way to test this, so using a mock for now.

Fixes #8028
Fixes #7965

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
