### PR TITLE
Fix overlapping divisions error on append

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -633,7 +633,7 @@ class ArrowDatasetEngine(Engine):
                             break
 
                 divisions = division_info["divisions"]
-                if divisions[0] < old_end:
+                if divisions[0] <= old_end:
                     raise ValueError(
                         "Appended divisions overlapping with the previous ones"
                         " (set ignore_divisions=True to append anyway).\n"

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -1171,9 +1171,15 @@ class FastParquetEngine(Engine):
                     ignore_divisions = True
             if not ignore_divisions:
                 minmax = fastparquet.api.sorted_partitioned_columns(pf)
-                old_end = minmax[index_cols[0]]["max"][-1]
+                # If fastparquet detects that a partitioned column isn't sorted, it won't
+                # appear in the resulting min/max dictionary
+                old_end = (
+                    minmax[index_cols[0]]["max"][-1]
+                    if index_cols[0] in minmax
+                    else None
+                )
                 divisions = division_info["divisions"]
-                if divisions[0] < old_end:
+                if old_end is None or divisions[0] <= old_end:
                     raise ValueError(
                         "Appended divisions overlapping with previous ones."
                         "\n"

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -857,8 +857,6 @@ def test_append_wo_index(tmpdir, engine, metadata_file):
 def test_append_overlapping_divisions(tmpdir, engine, metadata_file, index, offset):
     """Test raising of error when divisions overlapping."""
     tmp = str(tmpdir)
-    # index = pd.date_range("2022-01-01", "2022-01-02", periods=500, inclusive="both")
-    # offset = pd.Timedelta(days=1)
 
     df = pd.DataFrame(
         {


### PR DESCRIPTION
- [x] Closes #3098
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

We were not being as picky as we should have been when it comes to overlapping divisions upon appending to an existing parquet dataset. Here we also raise if they *slightly* overlap (that is to say, if the first index value in the new partition == the last index value of the previous partition).