### PR TITLE
Band-aid for `compute_as_if_collection`

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -314,8 +314,13 @@ def compute_as_if_collection(cls, dsk, keys, scheduler=None, get=None, **kwargs)
     """Compute a graph as if it were of type cls.
 
     Allows for applying the same optimizations and default scheduler."""
+    from dask.highlevelgraph import HighLevelGraph
+
     schedule = get_scheduler(scheduler=scheduler, cls=cls, get=get)
     dsk2 = optimization_function(cls)(dsk, keys, **kwargs)
+    # see https://github.com/dask/dask/issues/8991.
+    # This merge should be removed once the underlying issue is fixed.
+    dsk2 = HighLevelGraph.merge(dsk2)
     return schedule(dsk2, keys, **kwargs)
 
 

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -781,11 +781,11 @@ def test_set_index_no_resursion_error(c):
 @gen_cluster(client=True)
 async def test_gh_8991(c, s, a, b):
     # Test illustrating something amiss with HighLevelGraph.key_dependencies.
-    # The intention is for this to be a chache, so if we clear it, things
+    # The intention is for this to be a cache, so if we clear it, things
     # should still work.
 
-    # This is a bad test, and we should rethink/remove it as soon as the issue is,
-    # resolved whether it's fixing the underlying problem or removing
+    # This is a bad test, and we should rethink/remove it as soon as the issue is
+    # resolved whether, it's fixing the underlying problem or removing
     # HighLevelGraph.key_dependencies alltogether.
     datasets = pytest.importorskip("dask.datasets")
     result = datasets.timeseries().shuffle("x").to_orc("tmp", compute=False)

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -775,3 +775,36 @@ def test_set_index_no_resursion_error(c):
         ddf.compute()
     except RecursionError:
         pytest.fail("dd.set_index triggered a recursion error")
+
+
+@pytest.mark.xfail(reason="https://github.com/dask/dask/issues/8991", strict=True)
+@gen_cluster(client=True)
+async def test_gh_8991(c, s, a, b):
+    # Test illustrating something amiss with HighLevelGraph.key_dependencies.
+    # The intention is for this to be a chache, so if we clear it, things
+    # should still work.
+
+    # This is a bad test, and we should rethink/remove it as soon as the issue is,
+    # resolved whether it's fixing the underlying problem or removing
+    # HighLevelGraph.key_dependencies alltogether.
+    datasets = pytest.importorskip("dask.datasets")
+    result = datasets.timeseries().shuffle("x").to_orc("tmp", compute=False)
+
+    # Create a dsk and mock sending it to the scheduler.
+    dsk_opt = result.__dask_optimize__(result.dask, result.key)
+    unpacked = HighLevelGraph.__dask_distributed_unpack__(
+        dsk_opt.__dask_distributed_pack__(c, result.key)
+    )
+    deps = unpacked["deps"]
+
+    # Create a version of the dsk without the key_dependencies and mock sending it to
+    # the scheduler as well.
+    dsk_opt_nokeys = dsk_opt.copy()
+    dsk_opt_nokeys.key_dependencies.clear()
+    unpacked_nokeys = HighLevelGraph.__dask_distributed_unpack__(
+        dsk_opt_nokeys.__dask_distributed_pack__(c, result.key)
+    )
+    deps_nokeys = unpacked_nokeys["deps"]
+
+    # The recalculated dependencies should still be the same!
+    assert deps == deps_nokeys


### PR DESCRIPTION
Temporary band-aid for #8991 to force the deletion of `dsk.key_dependencies`, which could result in bad dependency information and thereby bad scheduling when used in `compute_as_if_collection`. I'm agnostic as to whether this should ever be merged. The test doesn't really even directly probe the fix, I've mostly included it for illustrative purposes.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
