### PR TITLE
Add highlights section to 2022.04.2 release notes

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,25 @@ Changelog
 
 Released on April 29, 2022
 
+Highlights
+^^^^^^^^^^
+This release includes several deprecations/breaking API changes to
+``dask.dataframe.read_parquet`` and ``dask.dataframe.to_parquet``:
+
+- ``to_parquet`` no longer writes ``_metadata`` files by default. If you want to
+  write a ``_metadata`` file, you can pass in ``write_metadata_file=True``.
+- ``read_parquet`` now defaults to ``split_row_groups=False``, which results in one
+  Dask dataframe partition per parquet file when reading in a parquet dataset.
+  If you're working with large parquet files you may need to set
+  ``split_row_groups=True`` to reduce your partition size.
+- ``read_parquet`` no longer calculates divisions by default. If you require
+  ``read_parquet`` to return dataframes with known divisions, please set
+  ``calculate_divisions=True``.
+- ``read_parquet`` has deprecated the ``gather_statistics`` keyword argument.
+  Please use the ``calculate_divisions`` keyword argument instead.
+- ``read_parquet`` has deprecated the ``require_extensions`` keyword argument.
+  Please use the ``parquet_file_extension`` keyword argument instead.
+
 New Features
 ^^^^^^^^^^^^
 - Add ``removeprefix`` and ``removesuffix`` as ``StringMethods`` (:pr:`8912`) `Jorge López`_


### PR DESCRIPTION
This PR contains some highlights @jcrist sent me around Parquet-related breaking changes / deprecations in the last release which I totally forgot to include when making the changelog 