### PR TITLE
Patch around pandas ArrowStringArray pickling

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -41,6 +41,11 @@ try:
     from dask.dataframe.utils import assert_eq
 
     try:
+        import dask.dataframe._pyarrow_compat
+    except ImportError:
+        pass
+
+    try:
         from dask.dataframe.io import read_parquet, to_parquet
     except ImportError:
         pass

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -1,4 +1,5 @@
 try:
+    import dask.dataframe._pyarrow_compat
     from dask.base import compute
     from dask.dataframe import backends, dispatch, rolling
     from dask.dataframe.core import (
@@ -39,11 +40,6 @@ try:
     from dask.dataframe.optimize import optimize
     from dask.dataframe.reshape import get_dummies, melt, pivot_table
     from dask.dataframe.utils import assert_eq
-
-    try:
-        import dask.dataframe._pyarrow_compat
-    except ImportError:
-        pass
 
     try:
         from dask.dataframe.io import read_parquet, to_parquet

--- a/dask/dataframe/_pyarrow_compat.py
+++ b/dask/dataframe/_pyarrow_compat.py
@@ -1,0 +1,123 @@
+import copyreg
+import math
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+
+# Pickling of pyarrow arrays is effectively broken - pickling a slice of an
+# array ends up pickling the entire backing array. This comes up when using
+# pandas `string[pyarrow]` dtypes, which are backed by a `pyarrow.StringArray`.
+# To fix this, we register a *global* override for pickling
+# `pandas.core.arrays.ArrowStringArray` types. We do this at the pandas level
+# rather than the pyarrow level for efficiency reasons (a pandas
+# ArrowStringArray may contain many small pyarrow StringArray objects).
+#
+# This pickling implementation manually mucks with the backing buffers in a
+# fairly efficient way:
+#
+# - The data buffer is never copied
+# - The offsets buffer is only copied if the array is sliced with a start index
+#   (x[start:])
+# - The mask buffer is never copied
+#
+# This implementation works with pickle protocol 5, allowing support for true
+# zero-copy sends.
+#
+# XXX: Once pyarrow (or pandas) has fixed this bug, we should skip registering
+# with copyreg for versions that lack this issue.
+
+
+def pyarrow_stringarray_to_parts(array):
+    """Decompose a ``pyarrow.StringArray`` into a tuple of components.
+
+    The resulting tuple can be passed to
+    ``pyarrow_stringarray_from_parts(*components)`` to reconstruct the
+    ``pyarrow.StringArray``.
+    """
+    # Access the backing buffers
+    # - mask: None, or a bitmask of length ceil(nitems / 8). 0 bits mark NULL
+    #   elements, only present if NULL data is present, commonly None.
+    # - offsets: A uint32 array of nitems + 1 items marking the start/stop
+    #   indices for the individual elements in `data`
+    # - data: All the utf8 string data concatenated together
+    mask, offsets, data = array.buffers()
+    nitems = len(array)
+
+    if not array.offset:
+        # No leading offset, only need to slice any unnecessary data from the
+        # backing buffers
+        offsets = offsets[: 4 * (nitems + 1)]
+        data_stop = int.from_bytes(offsets[-4:], "little")
+        data = data[:data_stop]
+        if mask is None:
+            return nitems, offsets, data
+        else:
+            mask = mask[: math.ceil(nitems / 8)]
+            return nitems, offsets, data, mask
+
+    # There is a leading offset. This complicates things a bit.
+    offsets_start = array.offset * 4
+    offsets_stop = offsets_start + (nitems + 1) * 4
+    data_start = int.from_bytes(offsets[offsets_start : offsets_start + 4], "little")
+    data_stop = int.from_bytes(offsets[offsets_stop - 4 : offsets_stop], "little")
+    data = data[data_start:data_stop]
+
+    if mask is None:
+        npad = 0
+    else:
+        # Since the mask is a bitmask, it can only represent even units of 8
+        # elements.  To avoid shifting any bits, we pad the array with up to 7
+        # elements so the mask array can always be serialized zero copy.
+        npad = array.offset % 8
+        mask_start = array.offset // 8
+        mask_stop = mask_start + math.ceil(nitems / 8)
+        mask = mask[mask_start:mask_stop]
+
+    # Subtract the offset of the starting element from the every used offset in
+    # the offsets array, ensuring the first element in the serialized `offsets`
+    # array is always 0.
+    offsets_array = np.frombuffer(offsets, dtype="i4")
+    offsets_array = (
+        offsets_array[array.offset : array.offset + nitems + 1]
+        - offsets_array[array.offset]
+    )
+    # Pad the new offsets by `npad` offsets of 0 (see the `mask` comment above). We wrap
+    # this in a `pyarrow.py_buffer`, since this type transparently supports pickle 5,
+    # avoiding an extra copy inside the pickler.
+    offsets = pa.py_buffer(
+        b"\x00" * (4 * npad) + offsets_array.data if npad else offsets_array.data
+    )
+
+    if mask is None:
+        return nitems, offsets, data
+    else:
+        return nitems, offsets, data, mask, npad
+
+
+def pyarrow_stringarray_from_parts(nitems, data_offsets, data, mask=None, offset=0):
+    """Reconstruct a ``pyarrow.StringArray`` from the parts returned by
+    ``pyarrow_stringarray_to_parts``."""
+    return pa.StringArray.from_buffers(nitems, data_offsets, data, mask, offset=offset)
+
+
+def rebuild_arrowstringarray(*chunk_parts):
+    """Rebuild a ``pandas.core.arrays.ArrowStringArray``"""
+    array = pa.chunked_array(
+        [pyarrow_stringarray_from_parts(*parts) for parts in chunk_parts]
+    )
+    return pd.core.arrays.ArrowStringArray(array)
+
+
+def reduce_arrowstringarray(x):
+    """A pickle override for ``pandas.core.arrays.ArrowStringArray`` that avoids
+    serializing unnecessary data, while also avoiding/minimizing data copies"""
+    chunks = tuple(
+        pyarrow_stringarray_to_parts(chunk)
+        for chunk in x._data.chunks
+        if len(chunk) > 0
+    )
+    return (rebuild_arrowstringarray, chunks)
+
+
+copyreg.dispatch_table[pd.core.arrays.ArrowStringArray] = reduce_arrowstringarray

--- a/dask/dataframe/_pyarrow_compat.py
+++ b/dask/dataframe/_pyarrow_compat.py
@@ -3,14 +3,21 @@ import math
 
 import numpy as np
 import pandas as pd
-import pyarrow as pa
+
+try:
+    import pyarrow as pa
+except ImportError:
+    pa = None
 
 # Pickling of pyarrow arrays is effectively broken - pickling a slice of an
-# array ends up pickling the entire backing array. This comes up when using
-# pandas `string[pyarrow]` dtypes, which are backed by a `pyarrow.StringArray`.
-# To fix this, we register a *global* override for pickling
-# `pandas.core.arrays.ArrowStringArray` types. We do this at the pandas level
-# rather than the pyarrow level for efficiency reasons (a pandas
+# array ends up pickling the entire backing array.
+#
+# See https://issues.apache.org/jira/browse/ARROW-10739
+#
+# This comes up when using pandas `string[pyarrow]` dtypes, which are backed by
+# a `pyarrow.StringArray`.  To fix this, we register a *global* override for
+# pickling `pandas.core.arrays.ArrowStringArray` types. We do this at the
+# pandas level rather than the pyarrow level for efficiency reasons (a pandas
 # ArrowStringArray may contain many small pyarrow StringArray objects).
 #
 # This pickling implementation manually mucks with the backing buffers in a
@@ -74,8 +81,8 @@ def pyarrow_stringarray_to_parts(array):
         mask_stop = mask_start + math.ceil(nitems / 8)
         mask = mask[mask_start:mask_stop]
 
-    # Subtract the offset of the starting element from the every used offset in
-    # the offsets array, ensuring the first element in the serialized `offsets`
+    # Subtract the offset of the starting element from every used offset in the
+    # offsets array, ensuring the first element in the serialized `offsets`
     # array is always 0.
     offsets_array = np.frombuffer(offsets, dtype="i4")
     offsets_array = (
@@ -106,7 +113,7 @@ def rebuild_arrowstringarray(*chunk_parts):
     array = pa.chunked_array(
         [pyarrow_stringarray_from_parts(*parts) for parts in chunk_parts]
     )
-    return pd.core.arrays.ArrowStringArray(array)
+    return pd.arrays.ArrowStringArray(array)
 
 
 def reduce_arrowstringarray(x):
@@ -120,4 +127,5 @@ def reduce_arrowstringarray(x):
     return (rebuild_arrowstringarray, chunks)
 
 
-copyreg.dispatch_table[pd.core.arrays.ArrowStringArray] = reduce_arrowstringarray
+if hasattr(pd.arrays, "ArrowStringArray") and pa is not None:
+    copyreg.dispatch_table[pd.arrays.ArrowStringArray] = reduce_arrowstringarray

--- a/dask/dataframe/tests/test_pyarrow_compat.py
+++ b/dask/dataframe/tests/test_pyarrow_compat.py
@@ -27,7 +27,8 @@ def randstr(i):
 
 @pytest.mark.parametrize("length", [6, 8, 12, 17])
 @pytest.mark.parametrize(
-    "slc", [slice(None), slice(0, 5), slice(2), slice(2, 5), slice(2, None, 2)]
+    "slc",
+    [slice(None), slice(0, 5), slice(2), slice(2, 5), slice(2, None, 2), slice(0, 0)],
 )
 @pytest.mark.parametrize("has_mask", [True, False])
 def test_roundtrip_stringarray(length, slc, has_mask):

--- a/dask/dataframe/tests/test_pyarrow_compat.py
+++ b/dask/dataframe/tests/test_pyarrow_compat.py
@@ -13,6 +13,9 @@ from dask.dataframe._pyarrow_compat import (
     pyarrow_stringarray_to_parts,
 )
 
+if not hasattr(pd.arrays, "ArrowStringArray"):
+    pytestmark = pytest.mark.skip("pandas.arrays.ArrowStringArray is not available")
+
 
 def randstr(i):
     """A random string, prefixed with the index number to make it clearer what the data
@@ -55,7 +58,7 @@ def test_roundtrip_stringarray(length, slc, has_mask):
     assert x == x2
 
     # Test pickle roundtrip works
-    pd_x = pd.core.arrays.ArrowStringArray(x)
+    pd_x = pd.arrays.ArrowStringArray(x)
     pd_x2 = pickle.loads(pickle.dumps(pd_x))
     assert pd_x.equals(pd_x2)
 

--- a/dask/dataframe/tests/test_pyarrow_compat.py
+++ b/dask/dataframe/tests/test_pyarrow_compat.py
@@ -1,0 +1,96 @@
+import math
+import pickle
+import random
+import string
+
+import pandas as pd
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+
+from dask.dataframe._pyarrow_compat import (
+    pyarrow_stringarray_from_parts,
+    pyarrow_stringarray_to_parts,
+)
+
+
+def randstr(i):
+    """A random string, prefixed with the index number to make it clearer what the data
+    boundaries are"""
+    return str(i) + "".join(
+        random.choices(string.ascii_letters, k=random.randint(3, 8))
+    )
+
+
+@pytest.mark.parametrize("length", [6, 8, 12, 17])
+@pytest.mark.parametrize(
+    "slc", [slice(None), slice(0, 5), slice(2), slice(2, 5), slice(2, None, 2)]
+)
+@pytest.mark.parametrize("has_mask", [True, False])
+def test_roundtrip_stringarray(length, slc, has_mask):
+    x = pa.array(
+        [randstr(i) if (not has_mask or i % 3) else None for i in range(length)],
+    )[slc]
+
+    def unpack(nitems, offsets, data, mask=None, offset=0):
+        return nitems, offsets, data, mask, offset
+
+    parts = pyarrow_stringarray_to_parts(x)
+    nitems, offsets, data, mask, offset = unpack(*parts)
+
+    # Check individual serialized components are correct
+    assert nitems == len(x)
+
+    assert len(offsets) == 4 * (nitems + offset + 1)
+
+    expected_data = "".join(x.drop_null().tolist()).encode("utf-8")
+    assert bytes(data) == expected_data
+
+    if mask is not None:
+        assert len(mask) == math.ceil(nitems / 8)
+        assert x.offset % 8 == offset
+
+    # Test rebuilding from components works
+    x2 = pyarrow_stringarray_from_parts(*parts)
+    assert x == x2
+
+    # Test pickle roundtrip works
+    pd_x = pd.core.arrays.ArrowStringArray(x)
+    pd_x2 = pickle.loads(pickle.dumps(pd_x))
+    assert pd_x.equals(pd_x2)
+
+
+@pytest.mark.parametrize("has_mask", [True, False])
+@pytest.mark.parametrize("start,end", [(None, -1), (1, None), (1, -1)])
+def test_pickle_stringarray_slice_doesnt_serialize_whole_array(has_mask, start, end):
+    x = pd.array(
+        ["apple", "banana", "carrot", "durian", "eggplant", "fennel", "grape"],
+        dtype="string[pyarrow]",
+    )
+    if has_mask:
+        x[3] = None
+
+    x_sliced = x[start:end]
+    buf = pickle.dumps(x_sliced)
+    loaded = pickle.loads(buf)
+    assert loaded.equals(x_sliced)
+
+    if start is not None:
+        assert b"apple" not in buf
+    if end is not None:
+        assert b"grape" not in buf
+
+
+@pytest.mark.parametrize("has_mask", [True, False])
+def test_pickle_stringarray_supports_pickle_5(has_mask):
+    x = pd.array(
+        ["apple", "banana", "carrot", "durian", "eggplant", "fennel", "grape"],
+        dtype="string[pyarrow]",
+    )
+    x[3] = None
+
+    buffers = []
+    buf = pickle.dumps(x, protocol=5, buffer_callback=buffers.append)
+    assert buffers
+    x2 = pickle.loads(buf, buffers=buffers)
+    assert x.equals(x2)


### PR DESCRIPTION
The (experimental) pandas `string[pyarrow]` dtype has some major
performance benefits that we'd like to experiment with in dask. However,
currently `pyarrow.StringArray` objects have a bug in their pickle
implementation where a small slice of the array still serializes the
full (potentially very large) backing buffers (see
https://issues.apache.org/jira/browse/ARROW-10739). Hopefully this is
fixed upstream in pyarrow at some point, but for now we patch around it
by overriding the pickling implementation for `ArrowStringArray` in
pandas. This implementation is efficient, resulting in zero-copy
serialization in most cases.

There is still more work to do to fully support the `string[pyarrow]`
dtype, but I think this PR can go in as is for now.

Part of #8842.