### PR TITLE
Docs - Update page on creating and storing Dask DataFrames

### DIFF
--- a/docs/source/dataframe-create.rst
+++ b/docs/source/dataframe-create.rst
@@ -4,11 +4,13 @@ Create and Store Dask DataFrames
 Dask can create DataFrames from various data storage formats like CSV, HDF,
 Apache Parquet, and others.  For most formats, this data can live on various
 storage systems including local disk, network file systems (NFS), the Hadoop
-File System (HDFS), Google Cloud Storage, and Amazon's S3
+Distributed File System (HDFS), Google Cloud Storage, and Amazon S3
 (excepting HDF, which is only available on POSIX like file systems).
 
 See the :doc:`DataFrame overview page <dataframe>` for more on
-``dask.dataframe`` scope, use, and limitations.
+``dask.dataframe`` scope, use, and limitations and
+:doc:`DataFrame Best Practices <dataframe-best-practices>` for more tips
+and solutions to common problems.
 
 API
 ---
@@ -64,29 +66,33 @@ You can use :func:`read_csv` to read one or more CSV files into a Dask DataFrame
 It supports loading multiple files at once:
   
 .. code-block:: python
+
    >>> df = dd.read_csv('myfiles.*.csv')
 
-Or you can break up large files with the ``blocksize`` parameter:
+Or you can break up a single large file with the ``blocksize`` parameter:
 
 .. code-block:: python
+
    >>> df = dd.read_csv('largefile.csv', blocksize=25e6)  # 25MB chunks  
 
 Changing the ``blocksize`` parameter will change the number of partitions (see the explanation on
-:doc:`partitions <dataframe-design-partitions>`). A good rule of thumb when working with
+:ref:`partitions <dataframe-design-partitions>`). A good rule of thumb when working with
 Dask DataFrames is to keep your partitions under 100MB in size.
 
 Read from Parquet
 ~~~~~~~~~~~~~~~~~
 
-Similarly, you can use :func:`read_parquet` to reading one or more Parquet files.
+Similarly, you can use :func:`read_parquet` for reading one or more Parquet files.
 You can read in a single Parquet file:
 
 .. code-block:: python
+
    >>> df = dd.read_parquet("path/to/mydata.parquet")
 
 Or multiple Parquet files:
 
 .. code-block:: python
+
    >>> df = dd.read_parquet("path/to/my/parquet/")
 
 For more details on working with Parquet files, including tips and best practices, see the documentation
@@ -95,8 +101,9 @@ on :doc:`dataframe-parquet`.
 Read from cloud storage
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Dask can read data from a variety of data stores including network file systems, cloud object stores, and Hadoop.
-You can usually do this by prepending a protocol to the paths:
+Dask can read data from a variety of data stores including cloud object stores.
+You can do this by prepending a protocol like ``s3://`` to paths
+used in common data access functions like ``dd.read_csv``:
 
 .. code-block:: python
 
@@ -104,8 +111,9 @@ You can usually do this by prepending a protocol to the paths:
    >>> df = dd.read_parquet('gcs://bucket/path/to/data-*.parq')
 
 For remote systems like Amazon S3 or Google Cloud Storage, you may need to provide credentials.
-These are usually handled by a configuration file.
-In some cases you may want to pass storage-specific options through to the storage backend. You can do this with the ``storage_options=`` keyword:
+These are usually stored in a configuration file, but in some cases you may want to pass
+storage-specific options through to the storage backend.
+You can do this with the ``storage_options`` parameter:
 
 .. code-block:: python
 
@@ -114,8 +122,8 @@ In some cases you may want to pass storage-specific options through to the stora
    >>> df = dd.read_parquet('gs://dask-nyc-taxi/yellowtrip.parquet',
    ...                      storage_options={'token': 'anon'})
 
-See the documentation on connecting to :doc:`Amazon S3 <how-to/connect-to-remote-data-s3>` or
-:doc:`Google Cloud Storage <how-to/connect-to-remote-data-gc>`.
+See the documentation on connecting to :ref:`Amazon S3 <connect-to-remote-data-s3>` or
+:ref:`Google Cloud Storage <connect-to-remote-data-gc>`.
 
 Mapping from a function
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -148,7 +156,8 @@ Storing
 Writing files locally
 ~~~~~~~~~~~~~~~~~~~~~
 
-You can save files locally, assuming each worker can access the same file system. Either the workers are located on the same machine, or a network file system is mounted and referenced at the same path location for every worker node.
+You can save files locally, assuming each worker can access the same file system. The workers could be located on the same machine, or a network file system can be mounted and referenced at the same path location for every worker node.
+See the documentation on :ref:`accessing data locally <connect-to-remote-data-local>`.
 
 Writing to remote locations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -165,11 +174,4 @@ For example, you can write a ``dask.dataframe`` to an Azure storage blob as:
    ...               storage_options={'account_name': 'ACCOUNT_NAME',
    ...                                'account_key': 'ACCOUNT_KEY'}
 
-See the :doc:`how to connect to remote data <how-to/connect-to-remote-data>`
-for more information.
-
-Next Steps
-----------
-
-See the :doc:`DataFrame Best Practices <dataframe-best-practices>` for more tips
-on how to use Dask DataFrame and solutions to common problems.
+See the :doc:`how-to guide on connecting to remote data <how-to/connect-to-remote-data>`.

--- a/docs/source/dataframe-create.rst
+++ b/docs/source/dataframe-create.rst
@@ -63,13 +63,13 @@ Read from CSV
 ~~~~~~~~~~~~~
 
 You can use :func:`read_csv` to read one or more CSV files into a Dask DataFrame.
-It supports loading multiple files at once:
+It supports loading multiple files at once using globstrings:
   
 .. code-block:: python
 
    >>> df = dd.read_csv('myfiles.*.csv')
 
-Or you can break up a single large file with the ``blocksize`` parameter:
+You can break up a single large file with the ``blocksize`` parameter:
 
 .. code-block:: python
 
@@ -89,7 +89,7 @@ You can read in a single Parquet file:
 
    >>> df = dd.read_parquet("path/to/mydata.parquet")
 
-Or multiple Parquet files:
+Or a directory of local Parquet files:
 
 .. code-block:: python
 

--- a/docs/source/dataframe-create.rst
+++ b/docs/source/dataframe-create.rst
@@ -4,11 +4,11 @@ Create and Store Dask DataFrames
 Dask can create DataFrames from various data storage formats like CSV, HDF,
 Apache Parquet, and others.  For most formats, this data can live on various
 storage systems including local disk, network file systems (NFS), the Hadoop
-File System (HDFS), and Amazon's S3 (excepting HDF, which is only available on
-POSIX like file systems).
+File System (HDFS), Google Cloud Storage, and Amazon's S3
+(excepting HDF, which is only available on POSIX like file systems).
 
-See the :doc:`DataFrame overview page <dataframe>` for an in depth
-discussion of ``dask.dataframe`` scope, use, and limitations.
+See the :doc:`DataFrame overview page <dataframe>` for more on
+``dask.dataframe`` scope, use, and limitations.
 
 API
 ---
@@ -57,23 +57,55 @@ Pandas:
 Creating
 --------
 
-Reading from various locations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Read from CSV
+~~~~~~~~~~~~~
 
-For text, CSV, and Apache Parquet formats, data can come from local disk,
-the Hadoop File System, S3FS, or other sources, by prepending the filenames with
-a protocol:
+You can use :func:`read_csv` to read one or more CSV files into a Dask DataFrame.
+It supports loading multiple files at once:
+  
+.. code-block:: python
+   >>> df = dd.read_csv('myfiles.*.csv')
+
+Or you can break up large files with the ``blocksize`` parameter:
+
+.. code-block:: python
+   >>> df = dd.read_csv('largefile.csv', blocksize=25e6)  # 25MB chunks  
+
+Changing the ``blocksize`` parameter will change the number of partitions (see the explanation on
+:doc:`partitions <dataframe-design-partitions>`). A good rule of thumb when working with
+Dask DataFrames is to keep your partitions under 100MB in size.
+
+Read from Parquet
+~~~~~~~~~~~~~~~~~
+
+Similarly, you can use :func:`read_parquet` to reading one or more Parquet files.
+You can read in a single Parquet file:
+
+.. code-block:: python
+   >>> df = dd.read_parquet("path/to/mydata.parquet")
+
+Or multiple Parquet files:
+
+.. code-block:: python
+   >>> df = dd.read_parquet("path/to/my/parquet/")
+
+For more details on working with Parquet files, including tips and best practices, see the documentation
+on :doc:`dataframe-parquet`.
+
+Read from cloud storage
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Dask can read data from a variety of data stores including network file systems, cloud object stores, and Hadoop.
+You can usually do this by prepending a protocol to the paths:
 
 .. code-block:: python
 
-   >>> df = dd.read_csv('my-data-*.csv')
-   >>> df = dd.read_csv('hdfs:///path/to/my-data-*.csv')
-   >>> df = dd.read_csv('s3://bucket-name/my-data-*.csv')
+   >>> df = dd.read_csv('s3://bucket/path/to/data-*.csv')
+   >>> df = dd.read_parquet('gcs://bucket/path/to/data-*.parq')
 
-For remote systems like HDFS, S3 or GS credentials may be an issue.  Usually, these
-are handled by configuration files on disk (such as a ``.boto`` file for S3),
-but in some cases you may want to pass storage-specific options through to the
-storage backend.  You can do this with the ``storage_options=`` keyword:
+For remote systems like Amazon S3 or Google Cloud Storage, you may need to provide credentials.
+These are usually handled by a configuration file.
+In some cases you may want to pass storage-specific options through to the storage backend. You can do this with the ``storage_options=`` keyword:
 
 .. code-block:: python
 
@@ -82,12 +114,14 @@ storage backend.  You can do this with the ``storage_options=`` keyword:
    >>> df = dd.read_parquet('gs://dask-nyc-taxi/yellowtrip.parquet',
    ...                      storage_options={'token': 'anon'})
 
+See the documentation on connecting to :doc:`Amazon S3 <how-to/connect-to-remote-data-s3>` or
+:doc:`Google Cloud Storage <how-to/connect-to-remote-data-gc>`.
 
 Mapping from a function
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 For cases that are not covered by the functions above, but *can* be
-captured by a simple ``map`` operation, :doc:`from_map` is likely to be
+captured by a simple ``map`` operation, :func:`from_map` is likely to be
 the most convenient means for DataFrame creation. For example, this
 API can be used to convert an arbitrary PyArrow ``Dataset`` object into a
 DataFrame collection by mapping fragments to DataFrame partitions:
@@ -104,66 +138,17 @@ DataFrame collection by mapping fragments to DataFrame partitions:
 Dask Delayed
 ~~~~~~~~~~~~
 
-For more complex situations not covered by the functions above, you may want to
-use :doc:`dask.delayed<delayed>`, which lets you construct Dask DataFrames out
-of arbitrary Python function calls that load DataFrames.  This can allow you to
-handle new formats easily or bake in particular logic around loading data if,
-for example, your data is stored with some special format.
-
-See :doc:`documentation on using dask.delayed with
-collections<delayed-collections>` or an `example notebook
-<https://gist.github.com/mrocklin/e7b7b3a65f2835cda813096332ec73ca>`_ showing
-how to create a Dask DataFrame from a nested directory structure of Feather
-files (as a stand in for any custom file format).
-
-Dask delayed is particularly useful when simple ``map`` operations aren't
-sufficient to capture the complexity of your data layout.
-
-From Raw Dask Graphs
-~~~~~~~~~~~~~~~~~~~~
-
-This section is mainly for developers wishing to extend ``dask.dataframe``.  It
-discusses internal API not normally needed by users.  Everything below can be
-done just as effectively with :doc:`dask.delayed<delayed>`  described
-just above.  You should never need to create a DataFrame object by hand.
-
-To construct a DataFrame manually from a dask graph you need the following
-information:
-
-1.  Dask: a Dask graph with keys like ``{(name, 0): ..., (name, 1): ...}`` as
-    well as any other tasks on which those tasks depend.  The tasks
-    corresponding to ``(name, i)`` should produce ``pandas.DataFrame`` objects
-    that correspond to the columns and divisions information discussed below
-2.  Name: the special name used above
-3.  Meta: an empty pandas DataFrame with names, dtypes and index matching
-    the expected output. Can also be a list of tuples where each tuple defines
-    a ``(name, dtype)`` pair referring to one column.
-4.  Divisions: a list of index values that separate the different partitions.
-    Alternatively, if you don't know the divisions (this is common), you can
-    provide a list of ``[None, None, None, ...]`` with as many partitions as
-    you have plus one.  For more information, see the Partitions section in the
-    :doc:`DataFrame documentation <dataframe>`
-
-As an example, we build a DataFrame manually that reads several CSV files that
-have a datetime index separated by day.  Note that you should **never** do this.
-The ``dd.read_csv`` function does this for you:
-
-.. code-block:: Python
-
-   dsk = {('mydf', 0): (pd.read_csv, 'data/2000-01-01.csv'),
-          ('mydf', 1): (pd.read_csv, 'data/2000-01-02.csv'),
-          ('mydf', 2): (pd.read_csv, 'data/2000-01-03.csv')}
-   name = 'mydf'
-   meta = [('price', float), ('name', str), ('id', int)]
-   divisions = [Timestamp('2000-01-01 00:00:00'),
-                Timestamp('2000-01-02 00:00:00'),
-                Timestamp('2000-01-03 00:00:00'),
-                Timestamp('2000-01-03 23:59:59')]
-
-   df = dd.DataFrame(dsk, name, meta, divisions)
+:doc:`Dask delayed<delayed>` is particularly useful when simple ``map`` operations aren’t sufficient to capture the complexity of your data layout. It lets you construct Dask DataFrames out of arbitrary Python function calls, which can be
+helpful to handle custom data formats or bake in particular logic around loading data.
+See the :doc:`documentation on using dask.delayed with collections<delayed-collections>`.
 
 Storing
 -------
+
+Writing files locally
+~~~~~~~~~~~~~~~~~~~~~
+
+You can save files locally, assuming each worker can access the same file system. Either the workers are located on the same machine, or a network file system is mounted and referenced at the same path location for every worker node.
 
 Writing to remote locations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -182,3 +167,9 @@ For example, you can write a ``dask.dataframe`` to an Azure storage blob as:
 
 See the :doc:`how to connect to remote data <how-to/connect-to-remote-data>`
 for more information.
+
+Next Steps
+----------
+
+See the :doc:`DataFrame Best Practices <dataframe-best-practices>` for more tips
+on how to use Dask DataFrame and solutions to common problems.

--- a/docs/source/how-to/connect-to-remote-data.rst
+++ b/docs/source/how-to/connect-to-remote-data.rst
@@ -133,6 +133,7 @@ variables. For more information on these, see the `PyArrow documentation`_.
 
 .. _PyArrow documentation: https://arrow.apache.org/docs/python/filesystems_deprecated.html#hadoop-file-system-hdfs
 
+.. _connect-to-remote-data-s3:
 
 Amazon S3
 ---------
@@ -209,6 +210,8 @@ for example, using `AlibabaCloud OSS`:
             #   `addressing_style` is required by AlibabaCloud, other services may not
             "config_kwargs": {"s3": {"addressing_style": "virtual"}},
         })
+
+.. _connect-to-remote-data-gc:
 
 Google Cloud Storage
 --------------------

--- a/docs/source/how-to/connect-to-remote-data.rst
+++ b/docs/source/how-to/connect-to-remote-data.rst
@@ -87,6 +87,8 @@ to import, you can do
 Note that some backends appear twice, if they can be referenced with multiple
 protocol strings, like "http" and "https".
 
+.. _connect-to-remote-data-local:
+
 Local File System
 -----------------
 


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This is a PR for updating the docs page on creating + storing Dask DataFrames. For context, this was driven by taking a look at google analytics and noticing this page is in the top 10 in terms of page views, but there was some outdated content on it (screenshot below for the past month):

<img width="998" alt="Screen Shot 2022-05-04 at 5 06 26 PM" src="https://user-images.githubusercontent.com/8620816/166833441-a84c98a8-121c-4dc9-8a85-d6640944f767.png">

