### PR TITLE
Only test on Python 3.9 on macos

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,11 @@ jobs:
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.8", "3.9", "3.10"]
+        exclude:
+            - os: "macos-latest"
+              python-version: "3.8"
+            - os: "macos-latest"
+              python-version: "3.10"
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}


### PR DESCRIPTION
The macos builds consistently take the longest to run, and have a lower
org-level concurrency limit than windows or linux. In `dask/dask` we
have no logic specific to macos, so testing on every python version on
this platform doesn't seem necessary. To reduce CI delay, we change
github actions to only test macos on python 3.9.

Fixes #8888.