### PR TITLE
Prevent codecov from notifying of failure too soon

### DIFF
--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -10,9 +10,6 @@ jobs:
       matrix:
         environment: ["mindeps-array", "mindeps-dataframe", "mindeps-non-optional", "mindeps-distributed"]
 
-    env:
-      COVERAGE: "true"
-
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -36,9 +33,6 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: source continuous_integration/scripts/run_tests.sh
-
-      - name: Coverage
-        uses: codecov/codecov-action@v1
 
   check-hdfs:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,15 @@ coverage:
   round: down
   range: "90...100"
 
+  # codecov pushes a failing status update to github actions before all the
+  # test runs have completed (this is later updated to passing after more test
+  # runs pass, but the initial red X is annoying). As far as I can tell from
+  # https://docs.codecov.com/docs/merging-reports this shouldn't be happening,
+  # but it is. Here we set a minimum number of builds before notifying in the
+  # hopes that it will stop this behavior.
+  notify:
+    after_n_builds: 3
+
   status:
     project:
       default:


### PR DESCRIPTION
Currently codecov pushes an initial failing status on every PR that is
later updated to passing once more CI builds finish. This is annoying.

As far as I can tell from https://docs.codecov.com/docs/merging-reports
this shouldn't be happening, but it is. Here we attempt to stop this
behavior by:

- Only running code coverage on the main test suite that hits most of
  the codebase.
- Setting a minimum number of builds before codecov should push a status
  update.

Hopefully this fixes the problem.