### PR TITLE
Fix flaky `test_reductions_2D`

### DIFF
--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -185,7 +185,6 @@ def test_reduction_errors():
 
 
 @pytest.mark.slow
-@pytest.mark.filterwarnings("ignore:overflow encountered in reduce:RuntimeWarning")
 @pytest.mark.parametrize("dtype", ["f4", "i4"])
 def test_reductions_2D(dtype):
     x = np.arange(1, 122).reshape((11, 11)).astype(dtype)
@@ -195,9 +194,6 @@ def test_reductions_2D(dtype):
     assert b.__dask_keys__() == [[(b.name, 0, 0)]]
 
     reduction_2d_test(da.sum, a, np.sum, x)
-    if x.dtype.kind != "i":
-        # prod overflows integers at this size
-        reduction_2d_test(da.prod, a, np.prod, x)
     reduction_2d_test(da.mean, a, np.mean, x)
     reduction_2d_test(da.var, a, np.var, x, False)  # Difference in dtype algo
     reduction_2d_test(da.std, a, np.std, x, False)  # Difference in dtype algo
@@ -207,14 +203,18 @@ def test_reductions_2D(dtype):
     reduction_2d_test(da.all, a, np.all, x, False)
 
     reduction_2d_test(da.nansum, a, np.nansum, x)
-    if x.dtype.kind != "i":
-        # prod overflows integers at this size
-        reduction_2d_test(da.nanprod, a, np.nanprod, x)
     reduction_2d_test(da.nanmean, a, np.mean, x)
     reduction_2d_test(da.nanvar, a, np.nanvar, x, False)  # Difference in dtype algo
     reduction_2d_test(da.nanstd, a, np.nanstd, x, False)  # Difference in dtype algo
     reduction_2d_test(da.nanmin, a, np.nanmin, x, False)
     reduction_2d_test(da.nanmax, a, np.nanmax, x, False)
+
+    # prod/nanprod overflow for data at this size, leading to warnings about
+    # overflow/invalid values.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        reduction_2d_test(da.prod, a, np.prod, x)
+        reduction_2d_test(da.nanprod, a, np.nanprod, x)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`prod`/`nanprod` overflow for data at this size. It's not clear why
numpy only raises these warnings _sometimes_, but it makes sense why
they're there. We filter `RuntimeWarning` now for `prod`/`nanprod` (and
only these operations) now to fix this.

Closes https://github.com/dask/dask/issues/8892