### PR TITLE
Simplify partitioning logic in pyarrow parquet engine

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3163,6 +3163,30 @@ def test_partitioned_no_pandas_metadata(tmpdir, engine, write_cols):
     assert_eq(result[list(expect.columns)], expect, check_index=False)
 
 
+@PYARROW_MARK
+def test_pyarrow_directory_partitioning(tmpdir):
+
+    # Manually construct directory-partitioned dataset
+    path1 = tmpdir.mkdir("a")
+    path2 = tmpdir.mkdir("b")
+    path1 = os.path.join(path1, "data.parquet")
+    path2 = os.path.join(path2, "data.parquet")
+    _df1 = pd.DataFrame({"part": "a", "col": range(5)})
+    _df2 = pd.DataFrame({"part": "b", "col": range(5)})
+    _df1.to_parquet(path1, engine="pyarrow")
+    _df2.to_parquet(path2, engine="pyarrow")
+
+    # Check results
+    expect = pd.concat([_df1, _df2], ignore_index=True)
+    result = dd.read_parquet(
+        str(tmpdir),
+        engine="pyarrow",
+        dataset={"partitioning": ["part"], "partition_base_dir": str(tmpdir)},
+    )
+    result["part"] = result["part"].astype("object")
+    assert_eq(result[list(expect.columns)], expect, check_index=False)
+
+
 @fp_pandas_xfail
 def test_partitioned_preserve_index(tmpdir, write_engine, read_engine):
     tmp = str(tmpdir)


### PR DESCRIPTION
This PR makes a small simplification (and generalization) to the partitioning logic used in the pyarrow engine for `read_parquet`. After this change, the user can pass in an arbitrary partitioning rule (under the `dataset=` kwargs), and is no longer limited to "hive-flavor" partitioning.

Once Dask requires pyarrow>=5.0.0, we can delete the ~40-ish lines of code that are still there to handle earlier versions.
