### PR TITLE
Additional check on is_dask_collection

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -160,7 +160,11 @@ def annotate(**annotations):
 
 def is_dask_collection(x) -> bool:
     """Returns ``True`` if ``x`` is a dask collection"""
-    return hasattr(x, "__dask_graph__") and callable(x.__dask_graph__)
+    return (
+        hasattr(x, "__dask_graph__")
+        and callable(x.__dask_graph__)
+        and not inspect.isclass(x)
+    )
 
 
 class DaskMethodsMixin:

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -541,7 +541,7 @@ def test_is_dask_collection():
     assert is_dask_collection(x)
     assert not is_dask_collection(2)
     assert is_dask_collection(DummyCollection({}))
-    assert not is_dask_collection(da.Array)
+    assert not is_dask_collection(DummyCollection)
 
 
 def test_unpack_collections():

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -541,6 +541,7 @@ def test_is_dask_collection():
     assert is_dask_collection(x)
     assert not is_dask_collection(2)
     assert is_dask_collection(DummyCollection({}))
+    assert not is_dask_collection(da.Array)
 
 
 def test_unpack_collections():


### PR DESCRIPTION
- [x] Closes https://github.com/dask/distributed/pull/6299
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

There's a test in distributed that checks `is_dask_collection` on a class instead of an instance. Should it only return true for instances? cc @jakirkham 