### PR TITLE
Fix toposort cycle detection

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -415,6 +415,7 @@ def _toposort(dsk, keys=None, returncycle=False, dependencies=None):
                             cycle = "->".join(str(x) for x in cycle)
                             raise RuntimeError("Cycle detected in Dask: %s" % cycle)
                     next_nodes.append(nxt)
+                    break
 
             if next_nodes:
                 nodes.extend(next_nodes)


### PR DESCRIPTION
Toposort cycle detection return wrong cycle:

```python
>>> dsk = {'a': ['c', 'b'], 'c': 'a', 'b': 1}
>>> _toposort(dsk, 'a', dependencies={'a': ['b', 'c'], 'c': ['a'], 'b': []})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../dask/core.py", line 409, in _toposort
    raise RuntimeError("Cycle detected in Dask: %s" % cycle)
RuntimeError: Cycle detected in Dask: a->b->c->a
```

The correct cycle would be `a->c->a`