### PR TITLE
Handle enumerate and generator inputs to from_map

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -944,6 +944,7 @@ def from_map(
     if not callable(func):
         raise ValueError("`func` argument must be `callable`")
     lengths = set()
+    iterables = list(iterables)
     for i, iterable in enumerate(iterables):
         if not isinstance(iterable, Iterable):
             raise ValueError(
@@ -951,7 +952,7 @@ def from_map(
             )
         try:
             lengths.add(len(iterable))
-        except AttributeError:
+        except (AttributeError, TypeError):
             iterables[i] = list(iterable)
             lengths.add(len(iterables[i]))
     if len(lengths) == 0:

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -943,6 +943,21 @@ def test_from_map_meta():
     assert_eq(ddf.compute(), expect)
 
 
+def test_from_map_custom_name():
+    # Test that `label` and `token` arguments to
+    # `from_map` works as expected
+
+    func = lambda x: pd.DataFrame({"x": [x] * 2})
+    iterable = ["A", "B"]
+    label = "my-label"
+    token = "8675309"
+    expect = pd.DataFrame({"x": ["A", "A", "B", "B"]}, index=[0, 1, 0, 1])
+
+    ddf = dd.from_map(func, iterable, label=label, token=token)
+    assert ddf._name == label + "-" + token
+    assert_eq(ddf, expect)
+
+
 def _generator():
     # Simple generator for test_from_map_other_iterables
     yield from enumerate(["A", "B", "C"])


### PR DESCRIPTION
The new `from_map` API does not correclty handle when elements of `iterables` are not of type `list`. This PR should allow us to handle `enumerate` and generator objects correctly.

- [x] Closes #9064
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
