### PR TITLE
Ouput CSV files with the csv file extension

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -915,6 +915,8 @@ def to_csv(
         values = [value]
         files = [first_file]
     else:
+        if os.path.isdir(filename) and "*" not in filename:
+            filename = os.path.join(filename, "part-*.csv")
         files = open_files(
             filename,
             mode=mode,

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -916,7 +916,7 @@ def to_csv(
         files = [first_file]
     else:
         if os.path.isdir(filename) and "*" not in filename:
-            filename = os.path.join(filename, "part-*.csv")
+            filename = os.path.join(filename, "part.*.csv")
         files = open_files(
             filename,
             mode=mode,

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1311,7 +1311,7 @@ def test_to_csv():
             paths = dask.compute(*r, scheduler="sync")
             # this is a tuple rather than a list since it's the output of dask.compute
             assert paths == tuple(
-                os.path.join(dn, f"{n}.part") for n in range(npartitions)
+                os.path.join(dn, f"part-{n}.csv") for n in range(npartitions)
             )
             result = dd.read_csv(os.path.join(dn, "*")).compute().reset_index(drop=True)
             assert_eq(result, df)

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1311,7 +1311,7 @@ def test_to_csv():
             paths = dask.compute(*r, scheduler="sync")
             # this is a tuple rather than a list since it's the output of dask.compute
             assert paths == tuple(
-                os.path.join(dn, f"part-{n}.csv") for n in range(npartitions)
+                os.path.join(dn, f"part.{n}.csv") for n in range(npartitions)
             )
             result = dd.read_csv(os.path.join(dn, "*")).compute().reset_index(drop=True)
             assert_eq(result, df)


### PR DESCRIPTION
- [X] Closes #9044 
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This PR causes Dask to output files like `part-1.csv` and `part-2.csv` by default instead of `0.part` and `1.part` when `ddf.to_csv("some/folder")` is run.  This PR should not change the behavior when the user specifies a globstring like `ddf.to_csv("some/folder/whatever-*.csv")`.

Users that still want the `.part` file extension can run `ddf.to_csv("some/folder/*.part")`.  They'll need to update their code, but this can be made backwards compatible for legacy systems.

The implementation in this PR was suggested by @martindurant in [this issue](https://github.com/dask/dask/issues/9044): "the quick fix for dask is to add its own "*" into the path".

Feel free to leave thoughts / suggestions.  The high level motivation for this PR is that I'm writing blog posts / a Dask book and the default behavior is hard to explain.  Users are confused that their CSV files aren't being output with the right file extension.  Hopefully this new default file extension is more intuitive.