### PR TITLE
Add a dispatch for  non-pandas `Grouper` objects and use it in GroupBy

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -536,7 +536,7 @@ def is_categorical_dtype_pandas(obj):
     return pd.api.types.is_categorical_dtype(obj)
 
 
-@grouper_dispatch.register((pd.DataFrame,))
+@grouper_dispatch.register((pd.DataFrame, pd.Series))
 def get_grouper_pandas(obj):
     return pd.core.groupby.Grouper
 

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -24,6 +24,7 @@ from dask.dataframe.dispatch import (
     concat_dispatch,
     get_parallel_type,
     group_split_dispatch,
+    grouper_dispatch,
     hash_object_dispatch,
     is_categorical_dtype_dispatch,
     make_meta_dispatch,
@@ -533,6 +534,11 @@ def tolist_pandas(obj):
 )
 def is_categorical_dtype_pandas(obj):
     return pd.api.types.is_categorical_dtype(obj)
+
+
+@grouper_dispatch.register((pd.DataFrame,))
+def get_grouper_pandas(obj):
+    return pd.core.groupby.Grouper
 
 
 @percentile_lookup.register((pd.Series, pd.Index))

--- a/dask/dataframe/dispatch.py
+++ b/dask/dataframe/dispatch.py
@@ -80,11 +80,6 @@ def categorical_dtype(meta, categories=None, ordered=False):
     return func(categories=categories, ordered=ordered)
 
 
-def get_grouper(obj):
-    grouper = grouper_dispatch.dispatch(type(obj))
-    return grouper
-
-
 def tolist(obj):
     func = tolist_dispatch.dispatch(type(obj))
     return func(obj)

--- a/dask/dataframe/dispatch.py
+++ b/dask/dataframe/dispatch.py
@@ -21,6 +21,7 @@ concat_dispatch = Dispatch("concat")
 tolist_dispatch = Dispatch("tolist")
 is_categorical_dtype_dispatch = Dispatch("is_categorical_dtype")
 union_categoricals_dispatch = Dispatch("union_categoricals")
+grouper_dispatch = Dispatch("grouper")
 
 
 def concat(
@@ -77,6 +78,11 @@ def is_categorical_dtype(obj):
 def categorical_dtype(meta, categories=None, ordered=False):
     func = categorical_dtype_dispatch.dispatch(type(meta))
     return func(categories=categories, ordered=ordered)
+
+
+def get_grouper(obj):
+    grouper = grouper_dispatch.dispatch(type(obj))
+    return grouper
 
 
 def tolist(obj):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1284,9 +1284,7 @@ class _GroupBy:
         # Otherwise, pandas will throw an ambiguity warning if the
         # DataFrame's index (self.obj.index) was included in the grouping
         # specification (self.by). See pandas #14432
-        breakpoint()
         grouper = grouper_dispatch(self._meta.obj)
-        breakpoint()
         by_groupers = [grouper(key=ind) for ind in by]
         cumlast = map_partitions(
             _apply_chunk,

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -20,6 +20,7 @@ from dask.dataframe.core import (
     no_default,
     split_out_on_index,
 )
+from dask.dataframe.dispatch import grouper_dispatch
 from dask.dataframe.methods import concat, drop_columns
 from dask.dataframe.shuffle import shuffle
 from dask.dataframe.utils import (
@@ -1283,7 +1284,10 @@ class _GroupBy:
         # Otherwise, pandas will throw an ambiguity warning if the
         # DataFrame's index (self.obj.index) was included in the grouping
         # specification (self.by). See pandas #14432
-        by_groupers = [pd.Grouper(key=ind) for ind in by]
+        breakpoint()
+        grouper = grouper_dispatch(self._meta.obj)
+        breakpoint()
+        by_groupers = [grouper(key=ind) for ind in by]
         cumlast = map_partitions(
             _apply_chunk,
             cumpart_ext,

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2455,6 +2455,7 @@ def test_groupby_dropna_cudf(dropna, by, group_keys):
     assert_eq(dask_result, cudf_result)
 
 
+@pytest.mark.xfail
 @pytest.mark.gpu
 @pytest.mark.parametrize("key", ["a", "b"])
 def test_groupby_grouper_dispatch(key):

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2462,7 +2462,7 @@ def test_groupby_grouper_dispatch(key):
     cudf = pytest.importorskip("cudf")
 
     # not directly used but must be imported
-    dask_cudf = pytest.importorskip("dask_cudf")  # noqa: f401
+    dask_cudf = pytest.importorskip("dask_cudf")  # noqa: F841
 
     pdf = pd.DataFrame(
         {

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -11,6 +11,7 @@ import dask
 import dask.dataframe as dd
 from dask.dataframe import _compat
 from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_150, tm
+from dask.dataframe.backends import grouper_dispatch
 from dask.dataframe.utils import assert_dask_graph, assert_eq, assert_max_deps
 from dask.utils import M
 
@@ -2452,6 +2453,32 @@ def test_groupby_dropna_cudf(dropna, by, group_keys):
         dask_result.index.name = cudf_result.index.name
 
     assert_eq(dask_result, cudf_result)
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize("key", ["a", "b"])
+def test_groupby_grouper_dispatch(key):
+    cudf = pytest.importorskip("cudf")
+
+    # not directly used but must be imported
+    dask_cudf = pytest.importorskip("dask_cudf")  # noqa: f401
+
+    pdf = pd.DataFrame(
+        {
+            "a": ["a", "b", "c", "d", "e", "f", "g", "h"],
+            "b": [1, 2, 3, 4, 5, 6, 7, 8],
+            "c": [1.0, 2.0, 3.5, 4.1, 5.5, 6.6, 7.9, 8.8],
+        }
+    )
+    gdf = cudf.from_pandas(pdf)
+
+    pd_grouper = grouper_dispatch(pdf)(key=key)
+    gd_grouper = grouper_dispatch(gdf)(key=key)
+
+    expect = pdf.groupby(pd_grouper).sum()
+    got = gdf.groupby(gd_grouper).sum()
+
+    assert_eq(expect, got)
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This PR creates a dispatch for use with the pandas `Grouper` object and plumbs it into a particular area of `groupby`. The motivation for this change is so that non-pandas backends implementing their own `Grouper` class can use it with dask rather than modifying that backend to work with pandas objects. 

As such I didn't see an open issue specifically requesting this, rather I ran into it trying to get certain cumulative groupby aggregations to work using a different backend. 