### PR TITLE
Mention `align_dataframes=False` option in `map_partitions` error

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6393,7 +6393,13 @@ def map_partitions(
 
     if align_dataframes:
         args = _maybe_from_pandas(args)
-        args = _maybe_align_partitions(args)
+        try:
+            args = _maybe_align_partitions(args)
+        except ValueError as e:
+            raise ValueError(
+                f"{e}. If you don't want the partitions to be aligned, and are "
+                "calling `map_partitions` directly, pass `align_dataframes=False`."
+            ) from e
 
     dfs = [df for df in args if isinstance(df, _Frame)]
     meta_index = getattr(make_meta(dfs[0]), "index", None) if dfs else None


### PR DESCRIPTION
If you call `map_partitions` and don't want your DataFrames aligned, the error you get won't lead you to the `align_dataframes=False` option.
https://github.com/dask/dask/blob/a308c3e9aa8b876fc1f29b6a55fb2cab515d7c77/dask/dataframe/multi.py#L127-L131

Especially in situations where you have a single-partition dataframe you want to broadcast against a multi-partition dataframe, `align_dataframes=False` is what you'd want, not `set_index`.

The downside with this PR is that now all methods that use `map_partitions` internally (most of them) will now show this message, which isn't relevant. I'm not sure if that tradeoff is worth it.

We could also make `align_dataframes=None` the default, and change every internal usage to pass `align_dataframes=True`, then only show the exra message when it's None. That's a bit of refactoring work, but doable.

cc @jsignell 

- [x] Passes `pre-commit run --all-files`
