### PR TITLE
[WIP][POC] Rough implementation of HLG/Layer Alternative

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -680,9 +680,11 @@ def visualize(
     """
     from dask.dot import dot_graph
 
-    args, _ = unpack_collections(*args, traverse=traverse)
-
-    dsk = dict(collections_to_dsk(args, optimize_graph=optimize_graph))
+    if len(args) == 1 and isinstance(args[0], dict):
+        dsk = args[0]
+    else:
+        args, _ = unpack_collections(*args, traverse=traverse)
+        dsk = dict(collections_to_dsk(args, optimize_graph=optimize_graph))
 
     color = kwargs.get("color")
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -36,7 +36,7 @@ from dask.dataframe.dispatch import (
     hash_object_dispatch,
     meta_nonempty,
 )
-from dask.dataframe.operation import CompatFrameOperation
+from dask.dataframe.operation import CompatFrameOperation, DataFrameMapOperation
 from dask.dataframe.optimize import optimize
 from dask.dataframe.utils import (
     PANDAS_GT_110,
@@ -541,7 +541,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
                 "The `deep` value must be False. This is strictly a shallow copy "
                 "of the underlying computational graph."
             )
-        return new_dd_object(self.dask, self._name, self._meta, self.divisions)
+        return new_dd_object(operation=self.operation)
 
     def __array__(self, dtype=None, **kwargs):
         self._computed = self.compute()
@@ -4415,8 +4415,28 @@ class DataFrame(_Frame):
             "`len(df.index) == 0` or `len(df.columns) == 0`"
         )
 
+    def _getitem_operation(self, meta, key, key_dependency):
+        if isinstance(self.operation, CompatFrameOperation):
+            name = f"getitem-{tokenize(self, key)}"
+            deps = [self, key] if key_dependency else [self]
+            dsk = partitionwise_graph(operator.getitem, name, self, key)
+            graph = HighLevelGraph.from_collections(
+                name, dsk, dependencies=deps
+            )
+            return new_dd_object(graph, name, meta, self.divisions)
+        else:
+            operation = DataFrameMapOperation(
+                operator.getitem,
+                meta,
+                self.operation,
+                key.operation if key_dependency else key,
+                label="getitem",
+                token=tokenize(self, key),
+                divisions=self.divisions,
+            )
+            return new_dd_object(operation=operation)
+
     def __getitem__(self, key):
-        name = "getitem-%s" % tokenize(self, key)
         if np.isscalar(key) or isinstance(key, (tuple, str)):
 
             if isinstance(self._meta.index, (pd.DatetimeIndex, pd.PeriodIndex)):
@@ -4433,9 +4453,7 @@ class DataFrame(_Frame):
 
             # error is raised from pandas
             meta = self._meta[_extract_meta(key)]
-            dsk = partitionwise_graph(operator.getitem, name, self, key)
-            graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
-            return new_dd_object(graph, name, meta, self.divisions)
+            return self._getitem_operation(meta, key, False)
         elif isinstance(key, slice):
             from pandas.api.types import is_float_dtype
 
@@ -4457,19 +4475,15 @@ class DataFrame(_Frame):
         ):
             # error is raised from pandas
             meta = self._meta[_extract_meta(key)]
+            return self._getitem_operation(meta, key, False)
 
-            dsk = partitionwise_graph(operator.getitem, name, self, key)
-            graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
-            return new_dd_object(graph, name, meta, self.divisions)
         if isinstance(key, Series):
             # do not perform dummy calculation, as columns will not be changed.
             if self.divisions != key.divisions:
                 from dask.dataframe.multi import _maybe_align_partitions
 
                 self, key = _maybe_align_partitions([self, key])
-            dsk = partitionwise_graph(operator.getitem, name, self, key)
-            graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self, key])
-            return new_dd_object(graph, name, self, self.divisions)
+            return self._getitem_operation(self, key, True)
         if isinstance(key, DataFrame):
             return self.where(key, np.nan)
 
@@ -5966,11 +5980,6 @@ def elemwise(op, *args, meta=no_default, out=None, transform_divisions=True, **k
         if not isinstance(arg, (_Frame, Scalar, Array))
     ]
 
-    # adjust the key length of Scalar
-    dsk = partitionwise_graph(op, _name, *args, **kwargs)
-
-    graph = HighLevelGraph.from_collections(_name, dsk, dependencies=deps)
-
     if meta is no_default:
         if len(dfs) >= 2 and not all(hasattr(d, "npartitions") for d in dasks):
             # should not occur in current funcs
@@ -5988,7 +5997,29 @@ def elemwise(op, *args, meta=no_default, out=None, transform_divisions=True, **k
         with raise_on_meta_error(funcname(op)):
             meta = partial_by_order(*parts, function=op, other=other)
 
-    result = new_dd_object(graph, _name, meta, divisions)
+    is_legacy_collection = [
+        isinstance(df.operation, CompatFrameOperation)
+        if hasattr(df, "operation")
+        else True
+        for df in dfs
+    ]
+    if any(is_legacy_collection):
+        # adjust the key length of Scalar
+        dsk = partitionwise_graph(op, _name, *args, **kwargs)
+        graph = HighLevelGraph.from_collections(_name, dsk, dependencies=deps)
+        result = new_dd_object(graph, _name, meta, divisions)
+    else:
+        operation = DataFrameMapOperation(
+            op,
+            meta,
+            *[x.operation if hasattr(x, "operation") else x for x in args],
+            label=funcname(op),
+            token=tokenize(op, *args, **kwargs),
+            divisions=divisions,
+            **kwargs,
+        )
+        result = new_dd_object(operation=operation)
+
     return handle_out(out, result)
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4438,7 +4438,7 @@ class DataFrame(_Frame):
             )
             operation = op_cls(
                 operator.getitem,
-                meta,
+                make_meta(meta),
                 self.operation,
                 key.operation if key_dependency else key,
                 label="getitem",

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4420,9 +4420,7 @@ class DataFrame(_Frame):
             name = f"getitem-{tokenize(self, key)}"
             deps = [self, key] if key_dependency else [self]
             dsk = partitionwise_graph(operator.getitem, name, self, key)
-            graph = HighLevelGraph.from_collections(
-                name, dsk, dependencies=deps
-            )
+            graph = HighLevelGraph.from_collections(name, dsk, dependencies=deps)
             return new_dd_object(graph, name, meta, self.divisions)
         else:
             operation = DataFrameMapOperation(

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -22,6 +22,7 @@ from dask.dataframe.core import (
     new_dd_object,
 )
 from dask.dataframe.io.utils import DataFrameIOFunction
+from dask.dataframe.operation import DataFrameCreation
 from dask.dataframe.shuffle import set_partition
 from dask.dataframe.utils import (
     check_meta,
@@ -828,6 +829,7 @@ def from_map(
     label=None,
     token=None,
     enforce_metadata=True,
+    use_operation_api=False,
     **kwargs,
 ):
     """Create a DataFrame collection from a custom function map
@@ -1034,21 +1036,40 @@ def from_map(
     else:
         io_func = func
 
-    # Construct DataFrameIOLayer
-    layer = DataFrameIOLayer(
-        name,
-        column_projection,
-        inputs,
-        io_func,
-        label=label,
-        produces_tasks=produces_tasks,
-        creation_info=creation_info,
-    )
+    divisions = divisions or [None] * (len(inputs) + 1)
+    if use_operation_api:
+        operation = DataFrameCreation(
+            io_func,
+            meta,
+            inputs,
+            label=label,
+            token=token,
+            columns=column_projection,
+            creation_info=creation_info,
+            divisions=divisions,
+        )
+        dd_kwargs = {"operation": operation}
+
+    else:
+        # Construct DataFrameIOLayer
+        layer = DataFrameIOLayer(
+            name,
+            column_projection,
+            inputs,
+            io_func,
+            label=label,
+            produces_tasks=produces_tasks,
+            creation_info=creation_info,
+        )
+        dd_kwargs = {
+            "dsk": HighLevelGraph.from_collections(name, layer, dependencies=[]),
+            "name": name,
+            "meta": meta,
+            "divisions": divisions,
+        }
 
     # Return new DataFrame-collection object
-    divisions = divisions or [None] * (len(inputs) + 1)
-    graph = HighLevelGraph.from_collections(name, layer, dependencies=[])
-    return new_dd_object(graph, name, meta, divisions)
+    return new_dd_object(**dd_kwargs)
 
 
 DataFrame.to_records.__doc__ = to_records.__doc__

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -795,7 +795,7 @@ class _PackedArgCallable(DataFrameIOFunction):
                 self.func.project_columns(columns),
                 args=self.args,
                 kwargs=self.kwargs,
-                meta=self.meta,
+                meta=self.meta[columns],
                 packed=self.packed,
                 enforce_metadata=self.enforce_metadata,
             )

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -1045,7 +1045,6 @@ def from_map(
             label=label,
             token=token,
             columns=column_projection,
-            creation_info=creation_info,
             divisions=divisions,
         )
         dd_kwargs = {"operation": operation}

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -177,6 +177,7 @@ def read_parquet(
     chunksize=None,
     aggregate_files=None,
     parquet_file_extension=(".parq", ".parquet", ".pq"),
+    use_operation_api=False,
     **kwargs,
 ):
     """
@@ -548,6 +549,7 @@ def read_parquet(
             "args": (path,),
             "kwargs": input_kwargs,
         },
+        use_operation_api=use_operation_api,
     )
 
 

--- a/dask/dataframe/operation.py
+++ b/dask/dataframe/operation.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from dask.base import tokenize
+from dask.dataframe.utils import make_meta
+from dask.highlevelgraph import HighLevelGraph
+
+
+class CollectionOperation:
+
+    # TODO: Move this out of dataframe module
+    _dask: HighLevelGraph | None = None
+
+    @property
+    def dask(self) -> HighLevelGraph | None:
+        if self._dask is None:
+            self._dask = HighLevelGraph.from_collections(
+                self.name,
+                self.generate_graph(self.collection_keys),
+                dependencies=[],
+            )
+        return self._dask
+
+    def generate_graph(self, keys: list[tuple]):  # -> dict:
+        raise NotImplementedError
+
+    @property
+    def name(self) -> str:
+        raise NotImplementedError
+
+    @name.setter
+    def name(self, value):
+        raise NotImplementedError
+
+    @property
+    def collection_keys(self) -> list[tuple]:
+        raise NotImplementedError
+
+    @property
+    def dependencies(self) -> Mapping[str, CollectionOperation]:
+        raise NotImplementedError
+
+
+class DataFrameOperation(CollectionOperation):
+
+    _name: str
+    _meta: Any
+    _divisions: tuple
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+    @property
+    def meta(self):
+        return self._meta
+
+    @meta.setter
+    def meta(self, value):
+        self._meta = value
+
+    @property
+    def divisions(self) -> tuple:
+        return self._divisions
+
+    @divisions.setter
+    def divisions(self, value):
+        self._divisions = value
+
+    @property
+    def npartitions(self) -> int:
+        return len(self.divisions) - 1
+
+    @property
+    def collection_keys(self) -> list[tuple]:
+        return [(self.name, i) for i in range(self.npartitions)]
+
+
+class CompatFrameOperation(DataFrameOperation):
+    def __init__(self, dsk, name, meta, divisions, parent_meta=None):
+        if not isinstance(dsk, HighLevelGraph):
+            dsk = HighLevelGraph.from_collections(name, dsk, dependencies=[])
+        self._dask = dsk
+        self._name = name
+        self._parent_meta = parent_meta
+        self._meta = make_meta(meta, parent_meta=self._parent_meta)
+        self._divisions = tuple(divisions) if divisions is not None else None
+
+    @property
+    def dask(self) -> HighLevelGraph | None:
+        return self._dask
+
+    def generate_graph(self, keys: list[tuple]):  # -> dict:
+        return dict(self.dask)
+
+    @property
+    def dependencies(self) -> Mapping[str, CollectionOperation]:
+        return {}
+
+
+class DataFrameCreation(DataFrameOperation):
+    def __init__(
+        self,
+        io_func,
+        meta,
+        inputs,
+        columns=None,
+        divisions=None,
+        label=None,
+        token=None,
+        creation_info=None,
+    ):
+        label = label or "create-frame"
+        token = token or tokenize(
+            io_func, meta, inputs, columns, divisions, creation_info
+        )
+        self._name = f"{label}-{token}"
+        self.io_func = io_func
+        self._meta = meta
+        self.inputs = inputs
+        self.columns = columns
+        divisions = divisions or (None,) * (len(inputs) + 1)
+        self._divisions = tuple(divisions)
+        self.creation_info = creation_info
+
+    def generate_graph(self, keys: list[tuple]):  # -> dict:
+        dsk = {}
+        for key in keys:
+            name, index = key
+            assert name == self.name
+            dsk[key] = (self.io_func, self.inputs[index])
+        return dsk
+
+    @property
+    def dependencies(self) -> Mapping[str, CollectionOperation]:
+        return {}
+
+
+class DataFrameMapOperation(DataFrameOperation):
+    def __init__(
+        self,
+        func,
+        meta,
+        *inputs,
+        divisions=None,
+        label=None,
+        token=None,
+        creation_info=None,
+    ):
+        label = label or "map-partitions"
+        token = token or tokenize(func, meta, inputs, divisions, creation_info)
+        self._name = f"{label}-{token}"
+        self.func = func
+        self._meta = meta
+        assert len(inputs)
+        self.inputs = inputs
+        self._dependencies = {inp.name: inp for inp in inputs}
+        divisions = divisions or (None,) * (len(next(iter(inputs))) + 1)
+        self._divisions = tuple(divisions)
+        self.creation_info = creation_info
+
+    @property
+    def dependencies(self) -> Mapping[str, CollectionOperation]:
+        return self._dependencies
+
+    def generate_graph(self, keys: list[tuple]):  # -> dict:
+        dsk = {}
+        dependency_graph = {}
+        for name, dep in self.dependencies.items():
+            if isinstance(dep, (DataFrameMapOperation, DataFrameCreation)):
+                dependency_graph.update(
+                    dep.generate_graph([(name, key[1]) for key in keys])
+                )
+            else:
+                # Not fusing these dependencies, so include them in dsk
+                dsk.update(dep.generate_graph([(name, key[1]) for key in keys]))
+
+        for key in keys:
+            name, index = key
+            assert name == self.name
+
+            task = [self.func]
+            for name in self.dependencies:
+                dep_key = (name, index)
+                task.append(dependency_graph.pop(dep_key, dep_key))
+            dsk[key] = tuple(task)
+
+        return dsk


### PR DESCRIPTION
**WARNING: DO NOT MERGE**

This is a rough/experimental implementation of the plan suggested in [here](https://github.com/dask/dask/issues/8980#issuecomment-1122832415) in https://github.com/dask/dask/issues/8980. The specific design needs a lot of work, but I am hoping this PR will eventually serve as a basic reference implementation for the general "plan" if we eventually decide to pursue it.

**General Idea**: Rather than depending on the `HighLevelGraph`/`Layer` for graph optimization and materialization, this PR proposes that we add a `Layer`-like class, called `CollectionOperation`, and use it to manage collection metadata **and** graph materialization/optimization logic.  The key advantage being that we resolve the longstanding challenge of having the HLG know nothing about the  collection that created it.

**What this POC has so far**:

So far, this PR only implements `CollectionOperation` support for DataFrame collections, and it only supports `read_parquet`, `from_map`, and element-wise operations (via `elemwise`). The following limitations are also important to consider:

- In order to use the `CollectionOperation` backend, `use_operation_api=True` must be passed to the IO function.
- After the collection is already created, the other supported operations will automatically use the `CollectionOperation` backend if is not a place-holder `CompatFrameOperation` (which simply wraps a traditional `HighLevelGraph`. Operations that do **not** support the `CollectionOperation` backend will simply force input collection(s) to generate an HLG (with a single `MaterializedLayer`) (when their `dask` attribute is called). In the future, when HLG-Pickle support is finished, we can define a special compatibiliy `Layer` object to avoid premature materialization.
- When the `dask` attribute is called on a `CollectionOperation`-based collection, the raw graph is materialized with culling and fusion baked into the `generate_graph` logic defined in the `CollectionOperation`. In the future, it probably makes sense to add an option to avoid fusion, but the long-term plan is to avoid the need for an explicit `cull` operation.
- The current PR enables column porjection, but does not include predicate pusdown yet.

Basic usage example:

```python
import dask.dataframe as dd
from dask.datasets import timeseries

timeseries().to_parquet("timeseries")
ddf = dd.read_parquet(
    ["timeseries/part.0.parquet", "timeseries/part.1.parquet"],
    use_operation_api=True,
)

# Various elemwise operations
ddf2 = ddf[operator.and_(ddf["id"] > 995, ddf["id"] < 1005)]
ddf3 = ddf2[["id"]]
ddf3 += 1
ddf4 = ddf3.assign(new="A")

# Visualize underlying CollectionOperation
ddf4.operation.visualize()
```

![Screen Shot 2022-05-12 at 2 01 02 PM](https://user-images.githubusercontent.com/20461013/168149146-3da1f5ff-fa2f-478c-8c92-9b1427458a5b.png)

Note that, since element-wise operations will be automatically fused at graph materialization time, using `ddf4.visualize()` shows something a bit different:

![Screen Shot 2022-05-12 at 2 02 11 PM](https://user-images.githubusercontent.com/20461013/168149351-e0c01664-773a-444d-bfb7-37c313242fef.png)

Note that we can also call `optimize_operation` on the `CollectionOperation`-based collection to perform column projection:

```python
ddf4 = ddf4.optimize_operation()
ddf4.operation.projected_columns
```

```
{'id'}
```

**What is still missing**:

A lot. This is not even close to ready.

Still need to iterate on this design (probably a lot) to get an idea if it will both simplify development **and** enable useful graph optimizations in the future. I could certainly use help from people with expertise related to high-level expressions (cc @eriknw)