### PR TITLE
Fix column-projection with enforce_metadata=True in from_map

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -815,7 +815,7 @@ class _PackedArgCallable(DataFrameIOFunction):
                 self.func.project_columns(columns),
                 args=self.args,
                 kwargs=self.kwargs,
-                meta=self.meta,
+                meta=self.meta[columns],
                 packed=self.packed,
                 enforce_metadata=self.enforce_metadata,
             )


### PR DESCRIPTION
Fixes a small bug related to a combination of metadata enforcement and column projection in `from_map`.