### PR TITLE
Clarify chunking in `imread` docstring

### DIFF
--- a/dask/array/image.py
+++ b/dask/array/image.py
@@ -41,8 +41,8 @@ def imread(filename, imread=None, preprocess=None):
     Returns
     -------
 
-    Dask array of all images stacked along the first dimension.  All images
-    will be treated as individual chunks
+    Dask array of all images stacked along the first dimension.
+    Each separate image file will be treated as an individual chunk.
     """
     imread = imread or sk_imread
     filenames = sorted(glob(filename))


### PR DESCRIPTION
@ParticularMiner has brought up the fact that the `dask.array.image.imread` function docstring is slightly misleading. This PR attempts to make the docstring more accurate (suggestions for better phrasing are welcome!)

Ref: https://github.com/dask/dask-image/issues/262#issuecomment-1125063820

> I did not expect it in the first place since imread()'s docstring says that a "dask array of all images stacked along the first dimension" will be returned. Besides, the array had only one chunk, ...

- [ ] Closes #xxxx
- [ ] Tests passed
- [x] Passes `pre-commit run --all-files`
