### PR TITLE
Document `map_partitions` handling of args vs kwargs, usage of `partition_info`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -736,14 +736,20 @@ Dask Name: {name}, {task} tasks"""
         Parameters
         ----------
         func : function
-            Map function applied to each partition. If this function accepts the special ``partition_info`` keyword
-            argument, it will recieve information on the partition's relative location within the dataframe.
+            The function applied to each partition. If this function accepts
+            the special ``partition_info`` keyword argument, it will recieve
+            information on the partition's relative location within the
+            dataframe.
         args, kwargs :
-            Positional and keyword arguments to pass to the function. Positional arguments are computed on a
-            per-partition basis, while keyword arguments are shared across all partitions. The partition itself will be
-            the first positional argument, with all other arguments passed *after*. Arguments can be ``Scalar``,
-            ``Delayed``, or regular Python objects. DataFrame-like args (both dask and pandas) will be repartitioned to
-            align (if necessary) before applying the function; see ``align_dataframes`` to control this behavior.
+            Positional and keyword arguments to pass to the function.
+            Positional arguments are computed on a per-partition basis, while
+            keyword arguments are shared across all partitions. The partition
+            itself will be the first positional argument, with all other
+            arguments passed *after*. Arguments can be ``Scalar``, ``Delayed``,
+            or regular Python objects. DataFrame-like args (both dask and
+            pandas) will be repartitioned to align (if necessary) before
+            applying the function; see ``align_dataframes`` to control this
+            behavior.
         enforce_metadata : bool, default True
             Whether to enforce at runtime that the structure of the DataFrame
             produced by ``func`` actually matches the structure of ``meta``.

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -736,7 +736,8 @@ Dask Name: {name}, {task} tasks"""
         Parameters
         ----------
         func : function
-            Function applied to each partition.
+            Map function applied to each partition. If this function accepts the special ``partition_info`` keyword
+            argument, it will recieve information on the partition's relative location within the dataframe.
         args, kwargs :
             Positional and keyword arguments to pass to the function. Positional arguments are computed on a
             per-partition basis, while keyword arguments are shared across all partitions. The partition itself will be

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -738,12 +738,11 @@ Dask Name: {name}, {task} tasks"""
         func : function
             Function applied to each partition.
         args, kwargs :
-            Arguments and keywords to pass to the function. The partition will
-            be the first argument, and these will be passed *after*. Arguments
-            and keywords may contain ``Scalar``, ``Delayed``, ``partition_info``
-            or regular python objects. DataFrame-like args (both dask and
-            pandas) will be repartitioned to align  (if necessary) before
-            applying the function (see ``align_dataframes`` to control).
+            Positional and keyword arguments to pass to the function. Positional arguments are computed on a
+            per-partition basis, while keyword arguments are shared across all partitions. The partition itself will be
+            the first positional argument, with all other arguments passed *after*. Arguments can be ``Scalar``,
+            ``Delayed``, or regular Python objects. DataFrame-like args (both dask and pandas) will be repartitioned to
+            align (if necessary) before applying the function; see ``align_dataframes`` to control this behavior.
         enforce_metadata : bool, default True
             Whether to enforce at runtime that the structure of the DataFrame
             produced by ``func`` actually matches the structure of ``meta``.


### PR DESCRIPTION
After some minor confusion around using `map_partitions` in https://github.com/dask-contrib/dask-sql/pull/517, I saw some motivation to better document the different handling around positional vs. keyword arguments, as well as making the use of `partition_info` more prominent.

Would still like to:

- [ ] update the docstring for `Bag.map_partitions` if necessary
- [ ] update the documentation itself if necessary

cc @rjzamora since we chatted internally around the different handling of args vs. kwargs
