### PR TITLE
Update custom collection documentation (leverage new collection protocol)

### DIFF
--- a/dask/typing.py
+++ b/dask/typing.py
@@ -92,7 +92,7 @@ class DaskCollection(Protocol):
     def __dask_graph__(self) -> Mapping:
         """The Dask task graph.
 
-        The core Dask collections (Array, DatFrame, Bag, and Delayed)
+        The core Dask collections (Array, DataFrame, Bag, and Delayed)
         use a :py:class:`HighLevelGraph` to represent the collection
         task graph. It is also possible to represent the task graph as
         a low level graph using a Python dictionary.

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -383,7 +383,7 @@ class DaskCollection(Protocol):
 
 @runtime_checkable
 class HLGDaskCollection(DaskCollection, Protocol):
-    """Protocal defining a Dask collection that uses HighLevelGraphs.
+    """Protocol defining a Dask collection that uses HighLevelGraphs.
 
     This protocol is nearly identical to
     :py:class:`~dask.typing.DaskCollection`, with the addition of the

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -16,7 +16,7 @@ PostComputeCallable = Callable
 
 
 class SchedulerGetCallable(Protocol):
-    """Protocol defining the signature of a __dask_scheduler__ callable."""
+    """Protocol defining the signature of a ``__dask_scheduler__`` callable."""
 
     def __call__(
         self,
@@ -45,7 +45,7 @@ class SchedulerGetCallable(Protocol):
 
 
 class PostPersistCallable(Protocol[CollType_co]):
-    """Protocol defining the signature of a __dask_postpersist__ callable."""
+    """Protocol defining the signature of a ``__dask_postpersist__`` callable."""
 
     def __call__(
         self,
@@ -93,16 +93,19 @@ class DaskCollection(Protocol):
         """The Dask task graph.
 
         The core Dask collections (Array, DataFrame, Bag, and Delayed)
-        use a :py:class:`HighLevelGraph` to represent the collection
-        task graph. It is also possible to represent the task graph as
-        a low level graph using a Python dictionary.
+        use a :py:class:`~dask.highlevelgraph.HighLevelGraph` to
+        represent the collection task graph. It is also possible to
+        represent the task graph as a low level graph using a Python
+        dictionary.
 
         Returns
         -------
         Mapping
             The Dask task graph. If the instance returns a
             :py:class:`dask.highlevelgraph.HighLevelGraph` then the
-            :py:func:`__dask_layers__` method must be defined.
+            :py:func:`__dask_layers__` method must be implemented, as
+            defined by the :py:class:`~dask.typing.HLGDaskCollection`
+            protocol.
 
         """
         raise NotImplementedError("Inheriting class must implement this method.")
@@ -111,10 +114,30 @@ class DaskCollection(Protocol):
     def __dask_keys__(self) -> list[Hashable]:
         """The output keys of the task graph.
 
+        Note that there are additional constraints on keys for a Dask
+        collection than those described in the :doc:`task graph
+        specification documentation <spec>`. These additional
+        constraints are described below.
+
+        All keys must either be non-empty strings or tuples where the
+        first element is a non-empty string, followed by zero or more
+        arbitrary hashables. The non-empty string is commonly known as
+        the *collection name*. All collections embedded in the dask
+        package have exactly one name, but this is not a requirement.
+
+        These are all valid outputs:
+
+        - ``[]``
+        - ``["x", "y"]``
+        - ``[[("y", "a", 0), ("y", "a", 1)], [("y", "b", 0), ("y", "b", 1)]``
+
         Returns
         -------
         list
-            The output keys of the collection's task graph.
+            A possibly nested list of keys that represent the outputs
+            of the graph. After computation, the results will be
+            returned in the same layout, with the keys replaced with
+            their corresponding outputs.
 
         """
         raise NotImplementedError("Inheriting class must implement this method.")
@@ -148,12 +171,16 @@ class DaskCollection(Protocol):
     def __dask_postpersist__(self) -> tuple[PostPersistCallable, tuple]:
         """Rebuilder function and optional arguments to contruct a persisted collection.
 
+        See also the documentation for :py:class:`dask.typing.PostPersistCallable`.
+
         Returns
         -------
         PostPersistCallable
             Callable that rebuilds the collection. The signature
             should be
-            ``rebuild(dsk: Mapping, *args: Any, rename: Mapping[str, str] | None)``.
+            ``rebuild(dsk: Mapping, *args: Any, rename: Mapping[str, str] | None)``
+            (as defined by the
+            :py:class:`~dask.typing.PostPersistCallable` protocol).
             The callable should return an equivalent Dask collection
             with the same keys as `self`, but with results that are
             computed through a different graph. In the case of
@@ -356,7 +383,14 @@ class DaskCollection(Protocol):
 
 @runtime_checkable
 class HLGDaskCollection(DaskCollection, Protocol):
-    """Protocal defining a Dask collection that uses HighLevelGraphs."""
+    """Protocal defining a Dask collection that uses HighLevelGraphs.
+
+    This protocol is nearly identical to
+    :py:class:`~dask.typing.DaskCollection`, with the addition of the
+    ``__dask_layers__`` method (required for collections backed by
+    high level graphs).
+
+    """
 
     @abc.abstractmethod
     def __dask_layers__(self) -> Sequence[str]:

--- a/docs/source/custom-collections.rst
+++ b/docs/source/custom-collections.rst
@@ -31,168 +31,49 @@ Before reading this you should read and understand:
 The Dask Collection Interface
 -----------------------------
 
-To create your own Dask collection, you need to fulfill the following
-interface. Note that there is no required base class.
+To create your own Dask collection, you need to fulfill the interface
+defined by the :py:class:`dask.typing.DaskCollection` protocol. Note
+that there is no required base class.
 
 It is recommended to also read :ref:`core-method-internals` to see how this
 interface is used inside Dask.
 
+Collection Protocol
+~~~~~~~~~~~~~~~~~~~~
 
-.. method:: __dask_graph__(self)
+.. autoclass:: dask.typing.DaskCollection
+   :members: __dask_graph__, __dask_keys__, __dask_postcompute__,
+             __dask_postpersist__, __dask_tokenize__,
+             __dask_optimize__, __dask_scheduler__, compute, persist,
+             visualize
 
-    The Dask graph.
+HLG Collection Protocol
+~~~~~~~~~~~~~~~~~~~~~~~
 
-    **Returns**
+Collections backed by Dask's :ref:`high-level-graphs` must implement
+an additional method, defined by this protocol:
 
-    dsk : Mapping, None
-        The Dask graph.  If ``None``, this instance will not be interpreted as a
-        Dask collection, and none of the remaining interface methods will be
-        called.
+.. autoclass:: dask.typing.HLGDaskCollection
+   :members: __dask_layers__
 
-    If the collection also specifies :meth:`__dask_layers__`, then ``dsk`` must be a
-    :class:`~dask.highlevelgraph.HighLevelGraph` or ``None``.
+Scheduler ``get`` Protocol
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The ``SchedulerGetProtocol`` defines the signature that a Dask
+collection's ``__dask_scheduler__`` definition must adhere to.
 
-.. method:: __dask_keys__(self)
+.. autoclass:: dask.typing.SchedulerGetCallable
+   :members: __call__
 
-    The output keys for the Dask graph.
+Post-persist Callable Protocol
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Note that there are additional constraints on keys for a Dask collection
-    than those described in the :doc:`task graph specification documentation <spec>`.
-    These additional constraints are described below.
+Collections must define a ``__dask_postpersist__`` method which
+returns a callable that adheres to the ``PostPersistCallable``
+interface.
 
-    **Returns**
-
-    keys : list
-        A possibly nested list of keys that represent the outputs of the graph.
-        After computation, the results will be returned in the same layout,
-        with the keys replaced with their corresponding outputs.
-
-    All keys must either be non-empty strings or tuples where the first element is a
-    non-empty string, followed by zero or more arbitrary hashables.
-    The non-empty string is commonly known as the *collection name*. All collections
-    embedded in the dask package have exactly one name, but this is not a requirement.
-
-    These are all valid outputs:
-
-    - ``[]``
-    - ``["x", "y"]``
-    - ``[[("y", "a", 0), ("y", "a", 1)], [("y", "b", 0), ("y", "b", 1)]``
-
-
-.. method:: __dask_layers__(self)
-
-    This method only needs to be implemented if the collection uses
-    :class:`~dask.highlevelgraph.HighLevelGraph` to implement its dask graph.
-
-    **Returns**
-
-    names : tuple
-        Tuple of names of the HighLevelGraph layers which contain all keys returned by
-        :meth:`__dask_keys__`.
-
-
-.. staticmethod:: __dask_optimize__(dsk, keys, \*\*kwargs)
-
-    Given a graph and keys, return a new optimized graph.
-
-    This method can be either a ``staticmethod`` or a ``classmethod``, but not
-    an ``instancemethod``.
-
-    Note that graphs and keys are merged before calling ``__dask_optimize__``;
-    as such, the graph and keys passed to this method may represent more than
-    one collection sharing the same optimize method.
-
-    If not implemented, defaults to returning the graph unchanged.
-
-    **Parameters**
-
-    dsk : MutableMapping
-        The merged graphs from all collections sharing the same
-        ``__dask_optimize__`` method.
-    keys : list
-        A list of the outputs from ``__dask_keys__`` from all collections
-        sharing the same ``__dask_optimize__`` method.
-    \*\*kwargs
-        Extra keyword arguments forwarded from the call to ``compute`` or
-        ``persist``. Can be used or ignored as needed.
-
-    **Returns**
-
-    optimized_dsk : MutableMapping
-        The optimized Dask graph.
-
-
-.. staticmethod:: __dask_scheduler__(dsk, keys, \*\*kwargs)
-
-    The default scheduler ``get`` to use for this object.
-
-    Usually attached to the class as a staticmethod, e.g.:
-
-    >>> import dask.threaded
-    >>> class MyCollection:
-    ...     # Use the threaded scheduler by default
-    ...     __dask_scheduler__ = staticmethod(dask.threaded.get)
-
-
-.. method:: __dask_postcompute__(self)
-
-    Return the finalizer and (optional) extra arguments to convert the computed
-    results into their in-memory representation.
-
-    Used to implement ``dask.compute``.
-
-    **Returns**
-
-    finalize : callable
-        A function with the signature ``finalize(results, *extra_args)``.
-        Called with the computed results in the same structure as the
-        corresponding keys from ``__dask_keys__``, as well as any extra
-        arguments as specified in ``extra_args``. Should perform any necessary
-        finalization before returning the corresponding in-memory collection
-        from ``compute``. For example, the ``finalize`` function for
-        ``dask.array.Array`` concatenates all the individual array chunks into
-        one large numpy array, which is then the result of ``compute``.
-    extra_args : tuple
-        Any extra arguments to pass to ``finalize`` after ``results``. If no
-        extra arguments should be an empty tuple.
-
-
-.. method:: __dask_postpersist__(self)
-
-    Return the rebuilder and (optional) extra arguments to rebuild an equivalent
-    Dask collection from a persisted or rebuilt graph.
-
-    Used to implement :func:`dask.persist`.
-
-    **Returns**
-
-    rebuild : callable
-        A function with the signature
-        ``rebuild(dsk, *extra_args, rename : Mapping[str, str] = None)``.
-        ``dsk`` is a Mapping which contains at least the output keys returned by
-        :meth:`__dask_keys__`. The callable should return an equivalent Dask collection
-        with the same keys as ``self``, but with the results that are computed through a
-        different graph. In the case of :func:`dask.persist`, the new graph will have
-        just the output keys and the values already computed.
-
-        If the optional parameter ``rename`` is specified, it indicates that output
-        keys may be changing too; e.g. if the previous output of :meth:`__dask_keys__`
-        was ``[("a", 0), ("a", 1)]``, after calling
-        ``rebuild(dsk, *extra_args, rename={"a": "b"})`` it must become
-        ``[("b", 0), ("b", 1)]``.
-        The ``rename`` mapping may not contain the collection name(s); in such case the
-        associated keys do not change. It may contain replacements for unexpected names,
-        which must be ignored.
-
-    extra_args : tuple
-        Any extra arguments to pass to ``rebuild`` after ``dsk``. If no extra
-        arguments are necessary, it must be an empty tuple.
-
-
-.. note:: It's also recommended to define ``__dask_tokenize__``,
-          see :ref:`deterministic-hashing`.
-
+.. autoclass:: dask.typing.PostPersistCallable
+   :members: __call__
 
 .. _core-method-internals:
 
@@ -480,8 +361,17 @@ elements of ``dask.delayed``:
     from dask.base import DaskMethodsMixin, replace_name_in_key
     from dask.optimization import cull
 
-    # We subclass from DaskMethodsMixin to add common dask methods to our
-    # class. This is nice but not necessary for creating a dask collection.
+    def tuple_optimize(dsk, keys, **kwargs):
+        # We cull unnecessary tasks here. See
+        # https://docs.dask.org/en/stable/optimize.html for more
+        # information on optimizations in Dask.
+        dsk2, _ = cull(dsk, keys)
+        return dsk2
+
+    # We subclass from DaskMethodsMixin to add common dask methods to
+    # our class (compute, persist, and visualize). This is nice but not
+    # necessary for creating a Dask collection (you can define them
+    # yourself).
     class Tuple(DaskMethodsMixin):
         def __init__(self, dsk, keys):
             # The init method takes in a dask graph and a set of keys to use
@@ -495,13 +385,8 @@ elements of ``dask.delayed``:
         def __dask_keys__(self):
             return self._keys
 
-        @staticmethod
-        def __dask_optimize__(dsk, keys, **kwargs):
-            # We cull unnecessary tasks here. See
-            # https://docs.dask.org/en/stable/optimize.html for more
-            # information on optimizations in Dask.
-            dsk2, _ = cull(dsk, keys)
-            return dsk2
+        # use the `tuple_optimize` function defined above
+        __dask_optimize__ = staticmethod(tuple_optimize)
 
         # Use the threaded scheduler by default.
         __dask_scheduler__ = staticmethod(dask.threaded.get)
@@ -562,6 +447,12 @@ Demonstrating this class:
     {('x', 'k1'): 2, ('x', 1): 3, ('x', 2): 4, ('x', 3): 5}
     >>> x2.compute()
     (2, 3, 4, 5)
+
+    # Run-time typechecking from Python 3.8's Protocol and
+    # typing.runtime_checkable decorator.
+    >>> from dask.typing import DaskCollection
+    >>> isinstance(x, DaskCollection)
+    True
 
 
 .. _is-dask-collection:

--- a/docs/source/custom-collections.rst
+++ b/docs/source/custom-collections.rst
@@ -448,8 +448,7 @@ Demonstrating this class:
     >>> x2.compute()
     (2, 3, 4, 5)
 
-    # Run-time typechecking from Python 3.8's Protocol and
-    # typing.runtime_checkable decorator.
+    # Run-time typechecking
     >>> from dask.typing import DaskCollection
     >>> isinstance(x, DaskCollection)
     True

--- a/docs/source/high-level-graphs.rst
+++ b/docs/source/high-level-graphs.rst
@@ -1,3 +1,5 @@
+.. _high-level-graphs:
+
 High Level Graphs
 =================
 


### PR DESCRIPTION
Follow up to #8674 - this PR updates the custom collection docs leveraging the inline documentation in the new `dask.typing.DaskCollection` protocol. I've cut out the "by hand" documentation of the collection methods (and in the process improved some of the protocol class docstrings). I also updated the example `Tuple` collection (now reflects the builtin collections a bit more, with a `__dask_optimize__` defined outside of the class).

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`