### PR TITLE
Blockwise cull numpy dtype

### DIFF
--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -791,10 +791,10 @@ class Blockwise(Layer):
         # collect a set of required output blocks (tuples), and
         # only construct graph for these blocks in `make_blockwise_graph`
 
-        output_blocks = set()
+        output_blocks: set[tuple[int, ...]] = set()
         for key in keys:
             if key[0] == self.output:
-                output_blocks.add(key[1:])
+                output_blocks.add(tuple(map(int, key[1:])))
         culled_deps = self._cull_dependencies(all_hlg_keys, output_blocks)
         out_size_iter = (self.dims[i] for i in self.output_indices)
         if prod(out_size_iter) != len(culled_deps):


### PR DESCRIPTION
This is was a tricky blockwise serialization bug. Briefly, if other keys in subsequent operations referred to blockwise keys using `np.intxx` dtypes, those dtypes could get embedded in the high-level-graph, then fail to serialize. This is not the only possible fix for the issue. @jorisvandenbossche's fix in https://github.com/geopandas/dask-geopandas/pull/113 also works, but I don't think we want to put the onus on downstream projects to cast all numpy-ish integers to python ones. Another possible fix could be in `distributed`'s serialization protocol. As in, do we expect the following to work?

```python
import numpy
from distributed.protocol import dumps

dumps(("a", numpy.int64(1)))  # fails
```
It seems like the answer is currently "no".

Of course, the HLG-serialization protocol is likely going away soon, but this fix seemed harmless enough.

- [x] Closes #9072
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
