### PR TITLE
Improve to_parquet error for appended divisions overlap

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -620,20 +620,22 @@ class ArrowDatasetEngine(Engine):
                     tail_metadata.row_group(i)
                     for i in range(tail_metadata.num_row_groups)
                 )
+                index_col_i = names.index(division_info["name"])
                 for row_group in row_groups:
-                    for i, name in enumerate(names):
-                        if name != division_info["name"]:
-                            continue
-                        column = row_group.column(i)
-                        if column.statistics:
-                            if not old_end:
-                                old_end = column.statistics.max
-                            else:
-                                old_end = max(old_end, column.statistics.max)
+                    column = row_group.column(index_col_i)
+                    if column.statistics:
+                        if old_end is None:
+                            old_end = column.statistics.max
+                        elif column.statistics.max > old_end:
+                            old_end = column.statistics.max
+                        else:
+                            # Existing column on disk isn't sorted, set
+                            # `old_end = None` to skip check below
+                            old_end = None
                             break
 
                 divisions = division_info["divisions"]
-                if divisions[0] <= old_end:
+                if old_end is not None and divisions[0] <= old_end:
                     raise ValueError(
                         "The divisions of the appended dataframe overlap with "
                         "previously written divisions. If this is desired, set "

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -635,9 +635,11 @@ class ArrowDatasetEngine(Engine):
                 divisions = division_info["divisions"]
                 if divisions[0] <= old_end:
                     raise ValueError(
-                        "Appended divisions overlapping with the previous ones"
-                        " (set ignore_divisions=True to append anyway).\n"
-                        "Previous: {} | New: {}".format(old_end, divisions[0])
+                        "The divisions of the appended dataframe overlap with "
+                        "previously written divisions. If this is desired, set "
+                        "``ignore_divisions=True`` to append anyway.\n"
+                        "- End of last written partition: {old_end}\n"
+                        "- Start of first new partition: {divisions[0]}"
                     )
 
         extra_write_kwargs = {"schema": schema, "index_cols": index_cols}

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -1179,11 +1179,13 @@ class FastParquetEngine(Engine):
                     else None
                 )
                 divisions = division_info["divisions"]
-                if old_end is None or divisions[0] <= old_end:
+                if old_end is not None and divisions[0] <= old_end:
                     raise ValueError(
-                        "Appended divisions overlapping with previous ones."
-                        "\n"
-                        "Previous: {} | New: {}".format(old_end, divisions[0])
+                        "The divisions of the appended dataframe overlap with "
+                        "previously written divisions. If this is desired, set "
+                        "``ignore_divisions=True`` to append anyway.\n"
+                        "- End of last written partition: {old_end}\n"
+                        "- Start of first new partition: {divisions[0]}"
                     )
         else:
             fmd = fastparquet.writer.make_metadata(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -873,9 +873,8 @@ def test_append_overlapping_divisions(tmpdir, engine, metadata_file, index, offs
     ddf2 = dd.from_pandas(df.set_index(df.index + offset), chunksize=100)
     ddf1.to_parquet(tmp, engine=engine, write_metadata_file=metadata_file)
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="overlap with previously written divisions"):
         ddf2.to_parquet(tmp, engine=engine, append=True)
-    assert "Appended divisions" in str(excinfo.value)
 
     ddf2.to_parquet(tmp, engine=engine, append=True, ignore_divisions=True)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -879,6 +879,30 @@ def test_append_overlapping_divisions(tmpdir, engine, metadata_file, index, offs
     ddf2.to_parquet(tmp, engine=engine, append=True, ignore_divisions=True)
 
 
+def test_append_known_divisions_to_unknown_divisions_works(tmpdir, engine):
+    tmp = str(tmpdir)
+
+    df1 = pd.DataFrame(
+        {"x": np.arange(100), "y": np.arange(100, 200)}, index=np.arange(100, 0, -1)
+    )
+    ddf1 = dd.from_pandas(df1, npartitions=3, sort=False)
+
+    df2 = pd.DataFrame({"x": np.arange(100, 200), "y": np.arange(200, 300)})
+    ddf2 = dd.from_pandas(df2, npartitions=3)
+
+    # fastparquet always loads all metadata when appending, pyarrow only does
+    # if a `_metadata` file exists. If we know the existing divisions aren't
+    # sorted, then we want to skip erroring for overlapping divisions. Setting
+    # `write_metadata_file=True` ensures this test works the same across both
+    # engines.
+    ddf1.to_parquet(tmp, engine=engine, write_metadata_file=True)
+    ddf2.to_parquet(tmp, engine=engine, append=True)
+
+    res = dd.read_parquet(tmp, engine=engine)
+    sol = pd.concat([df1, df2])
+    assert_eq(res, sol)
+
+
 @pytest.mark.parametrize("metadata_file", [False, True])
 def test_append_different_columns(tmpdir, engine, metadata_file):
     """Test raising of error when non equal columns."""


### PR DESCRIPTION
Small tweak to the error message for appended overlapping divisions in
`to_parquet`.

Fixes #8145.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
