### PR TITLE
Increase retries when installing nightly `pandas`

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -16,7 +16,7 @@ if [[ ${UPSTREAM_DEV} ]]; then
     # https://github.com/dask/dask/issues/8682 is resolved
     conda uninstall --force numpy pandas fastparquet
 
-    python -m pip install --no-deps --pre \
+    python -m pip install --no-deps --pre --retries 10 \
         -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \
         numpy \
         pandas


### PR DESCRIPTION
We're occasionally running into http timeout errors when installing nightly pandas in our upstream build

```
++ python -m pip install --no-deps --pre -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy pandas
Looking in indexes: https://pypi.anaconda.org/scipy-wheels-nightly/simple
Collecting numpy
  Downloading https://pypi.anaconda.org/scipy-wheels-nightly/simple/numpy/1.23.0.dev0%2B1192.g02d1204b0/numpy-1.23.0.dev0%2B1192.g02d1204b0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 17.1/17.1 MB 25.2 MB/s eta 0:00:00
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='pypi.anaconda.org', port=443): Read timed out. (read timeout=15)")': /scipy-wheels-nightly/simple/pandas/
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='pypi.anaconda.org', port=443): Read timed out. (read timeout=15)")': /scipy-wheels-nightly/simple/pandas/
WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='pypi.anaconda.org', port=443): Read timed out. (read timeout=15)")': /scipy-wheels-nightly/simple/pandas/
WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='pypi.anaconda.org', port=443): Read timed out. (read timeout=15)")': /scipy-wheels-nightly/simple/pandas/
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='pypi.anaconda.org', port=443): Read timed out. (read timeout=15)")': /scipy-wheels-nightly/simple/pandas/
ERROR: Could not find a version that satisfies the requirement pandas (from versions: none)
ERROR: No matching distribution found for pandas
```

This PR increases the number of retries `pip install` will attempt. Not totally sure if this will fix the issue, but it seems worth trying 