### PR TITLE
[WIP] Add groupby support when grouping by all columns

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1628,6 +1628,14 @@ class _GroupBy:
                     col for col in self.obj.columns if col not in group_columns
                 ]
 
+            if not non_group_columns:
+                return self._aca_agg(
+                    token="no_op",
+                    func=M.sum,
+                    split_every=split_every,
+                    split_out=split_out,
+                )
+
             spec = _normalize_spec(arg, non_group_columns)
 
         elif isinstance(self.obj, Series):

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2788,3 +2788,63 @@ def test_groupby_iter_fails():
     ddf = dd.from_pandas(df, npartitions=1)
     with pytest.raises(NotImplementedError, match="computing the groups"):
         list(ddf.groupby("A"))
+
+
+def test_groupby_method_all_columns(agg_func):
+    pdf = pd.DataFrame(
+        {
+            "x": list(range(10)),
+        }
+    )
+    ddf = dd.from_pandas(pdf, npartitions=5)
+
+    pandas_group = pdf.groupby(["x"])
+    dask_group = ddf.groupby(["x"])
+
+    expect = getattr(pandas_group, agg_func)()
+    actual = getattr(dask_group, agg_func)()
+
+    assert_eq(expect, actual)
+
+    pdf = pd.DataFrame(
+        {
+            "x": list(range(10)),
+            "y": list(range(10, 20)),
+        }
+    )
+    ddf = dd.from_pandas(pdf, npartitions=5)
+
+    pandas_group = pdf.groupby(["x", "y"])
+    dask_group = ddf.groupby(["x", "y"])
+
+    expect = getattr(pandas_group, agg_func)()
+    actual = getattr(dask_group, agg_func)()
+
+    assert_eq(expect, actual)
+
+
+def test_groupby_agg_all_columns(agg_func):
+    pdf = pd.DataFrame(
+        {
+            "x": list(range(10)),
+        }
+    )
+    ddf = dd.from_pandas(pdf, npartitions=5)
+
+    expect = pdf.groupby(["x"]).agg(agg_func)
+    actual = ddf.groupby(["x"]).agg(agg_func)
+
+    assert_eq(expect, actual)
+
+    pdf = pd.DataFrame(
+        {
+            "x": list(range(10)),
+            "y": list(range(10, 20)),
+        }
+    )
+    ddf = dd.from_pandas(pdf, npartitions=5)
+
+    expect = pdf.groupby(["x", "y"]).agg(agg_func)
+    actual = ddf.groupby(["x", "y"]).agg(agg_func)
+
+    assert_eq(expect, actual)


### PR DESCRIPTION
Attempts to unblock issues with `_GroupBy.agg` when grouping on all of a dataframe's columns.

Right now this is done by just using `_GroupBy._aca_agg` in cases where we have no non-group columns, as the aggregation function doesn't really matter much past this point (we should be returning an empty DataFrame and are more concerned with the index); we might find it better to do a refactor of `_groupby_apply_funcs`/`_agg_finalize` instead so that we're still using the expected `agg` codepath, just didn't see any immediate solutions with that approach.

- [x] Closes #9093
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
