### PR TITLE
Add `pandas[test]` to `test` extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ extras_require: dict[str, list[str]] = {
 extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
 # after complete is set, add in test
 extras_require["test"] = [
+    "pandas[test]",
     "pytest",
     "pytest-rerunfailures",
     "pytest-xdist",


### PR DESCRIPTION
Since the tests use `pandas.test` (the actual Pandas test suite), not only `pandas.testing`, it makes sense to rely on the Pandas `test` extra.

- [x] Closes (no issue filed)
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This is mostly a formality, but it could possibly avoid any practical issues with new Pandas test dependencies in the future.

[Currently](https://github.com/pandas-dev/pandas/blob/1be9d3868f4b9cfd083839cf39eecfd881f387ad/setup.cfg#L48), this change brings in:

```ini
[options.extras_require]
test =
    hypothesis>=5.5.3
    pytest>=6.0
    pytest-xdist>=1.31
```

which adds minimum versions to the `pytest` and `pytest-xdist` dependencies Dask’s tests already have, and a (technically unnecessary in this case) test dependency on `hypothesis`.

Additionally—and this is my personal motivation for this PR—the `python-pandas` package in Fedora Linux is splitting off `pandas.tests` from the main `python3-pandas` package and installing them with `python3-pandas+test` package. So those few dependent packages that need `pandas.tests` for their own tests (currently, `python-dask` and `python-geopandas`) will have to require `pandas[test]` at build/test time, not just `pandas`. We can do this downstream in the Fedora package if this PR is not accepted.