### PR TITLE
Include `NUMPY_LICENSE.txt` in license files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,6 @@ include docs/Makefile docs/make.bat
 
 include setup.py
 include README.rst
-include LICENSE.txt
 include MANIFEST.in
 include dask/dask.yaml
 include dask/dask-schema.yaml

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -42,7 +42,9 @@ test:
 about:
   home: https://github.com/dask/dask/
   license: BSD-3-Clause
-  license_file: LICENSE.txt
+  license_file:
+    - LICENSE.txt
+    - dask/array/NUMPY_LICENSE.txt
   summary: Parallel Python with task scheduling
   doc_url: https://dask.org/
   dev_url: https://github.com/dask/dask

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,9 @@ filterwarnings =
 xfail_strict=true
 
 [metadata]
-license_files = LICENSE.txt
+license_files =
+    LICENSE.txt
+    dask/array/NUMPY_LICENSE.txt
 
 [mypy]
 # Silence errors about Python 3.9-style delayed type annotations on Python 3.8


### PR DESCRIPTION
This ensures it is present in source and binary distributions such as PyPI sdists and wheels.

In addition to being installed at its original location `dask/array/NUMPY_LICENSE.txt`, it will be [automatically copied into the dist-info directory](https://wheel.readthedocs.io/en/stable/user_guide.html?highlight=license_files#including-license-files-in-the-generated-wheel-file) of wheels.

- [x] Closes #9112
- [x] Tests added / passed **None required**
- [x] Passes `pre-commit run --all-files`
