### PR TITLE
Include conftest.py in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,3 +13,5 @@ include dask/py.typed
 
 include versioneer.py
 include dask/_version.py
+
+include conftest.py


### PR DESCRIPTION
Since sdists include the tests, and `conftest.py` is needed to run them, it should be included.

- [x] Closes #8475 
- [x] Tests added / passed **None required**
- [x] Passes `pre-commit run --all-files`
