### PR TITLE
Add `sort_results` argument to assert_eq

### DIFF
--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1361,7 +1361,7 @@ def test_sort_values(nelem, by, ascending):
     with dask.config.set(scheduler="single-threaded"):
         got = ddf.sort_values(by=by, ascending=ascending)
     expect = df.sort_values(by=by, ascending=ascending)
-    dd.assert_eq(got, expect, check_index=False)
+    dd.assert_eq(got, expect, check_index=False, sort_results=False)
 
 
 @pytest.mark.parametrize("ascending", [True, False, [False, True], [True, False]])

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -551,21 +551,23 @@ def test_assert_eq_sorts():
         assert_eq(df1, df2_r)
 
 
-# def test_assert_eq_order():
-#     df = pd.DataFrame({"a": [5, 4, 3, 2, 1] * 2, "b": range(10, 20)})
-#     df_s = df.sort_values(["a"])
-#     ddf = dd.from_pandas(df, npartitions=2)
-#     ddf_s = ddf.sort_values(["a"])
-#     assert_eq(df, df_s)
-#     assert_eq(df, ddf_s)
-#     with pytest.raises(AssertionError):
-#         assert_eq(df, df_s, check_order=True)
-#         assert_eq(df, ddf_s, check_order=True)
+def test_assert_eq_sort_result():
+    df = pd.DataFrame({"a": [5, 4, 3, 2, 1] * 2, "b": range(10, 20)})
+    df_s = df.sort_values(["a"])
+    assert_eq(df, df_s)
+    with pytest.raises(AssertionError):
+        assert_eq(df, df_s, sort_results=False)
 
-#     ddf_r = ddf_s.reset_index(drop=True)
-#     assert_eq(df, ddf_r, check_index=False)
-#     with pytest.raises(AssertionError):
-#         assert_eq(df, ddf_r, check_index=False, check_order=True)
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf_s = ddf.sort_values(["a"])
+    assert_eq(df, ddf_s)
+    with pytest.raises(AssertionError):
+        assert_eq(df, ddf_s, sort_results=False)
+
+    ddf_r = ddf_s.reset_index(drop=True)
+    assert_eq(df, ddf_r, check_index=False)
+    with pytest.raises(AssertionError):
+        assert_eq(df, ddf_r, check_index=False, sort_results=False)
 
 
 def test_assert_eq_scheduler():

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -551,21 +551,21 @@ def test_assert_eq_sorts():
         assert_eq(df1, df2_r)
 
 
-def test_assert_eq_order():
-    df = pd.DataFrame({"a": [5, 4, 3, 2, 1] * 2, "b": range(10, 20)})
-    df_s = df.sort_values(["a"])
-    ddf = dd.from_pandas(df, npartitions=2)
-    ddf_s = ddf.sort_values(["a"])
-    assert_eq(df, df_s)
-    assert_eq(df, ddf_s)
-    with pytest.raises(AssertionError):
-        assert_eq(df, df_s, check_order=True)
-        assert_eq(df, ddf_s, check_order=True)
+# def test_assert_eq_order():
+#     df = pd.DataFrame({"a": [5, 4, 3, 2, 1] * 2, "b": range(10, 20)})
+#     df_s = df.sort_values(["a"])
+#     ddf = dd.from_pandas(df, npartitions=2)
+#     ddf_s = ddf.sort_values(["a"])
+#     assert_eq(df, df_s)
+#     assert_eq(df, ddf_s)
+#     with pytest.raises(AssertionError):
+#         assert_eq(df, df_s, check_order=True)
+#         assert_eq(df, ddf_s, check_order=True)
 
-    ddf_r = ddf_s.reset_index(drop=True)
-    assert_eq(df, ddf_r, check_index=False)
-    with pytest.raises(AssertionError):
-        assert_eq(df, ddf_r, check_index=False, check_order=True)
+#     ddf_r = ddf_s.reset_index(drop=True)
+#     assert_eq(df, ddf_r, check_index=False)
+#     with pytest.raises(AssertionError):
+#         assert_eq(df, ddf_r, check_index=False, check_order=True)
 
 
 def test_assert_eq_scheduler():

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -551,6 +551,17 @@ def test_assert_eq_sorts():
         assert_eq(df1, df2_r)
 
 
+def test_assert_eq_ordering():
+    df = pd.DataFrame({"a": [5, 4, 3, 2, 1] * 20, "b": range(100, 200)})
+    ddf = dd.from_pandas(df, npartitions=10)
+    sorted_ddf = ddf.sort_values(["a"])
+
+    assert_eq(df, sorted_ddf)
+
+    with pytest.raises(AssertionError):
+        assert_eq(df, sorted_ddf, ignore_ordering=False)
+
+
 def test_assert_eq_scheduler():
     using_custom_scheduler = False
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -562,6 +562,11 @@ def test_assert_eq_order():
         assert_eq(df, df_s, check_order=True)
         assert_eq(df, ddf_s, check_order=True)
 
+    ddf_r = ddf_s.reset_index(drop=True)
+    assert_eq(df, ddf_r, check_index=False)
+    with pytest.raises(AssertionError):
+        assert_eq(df, ddf_r, check_index=False, check_order=True)
+
 
 def test_assert_eq_scheduler():
     using_custom_scheduler = False

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -542,32 +542,29 @@ def test_nonempty_series_nullable_float():
 
 
 def test_assert_eq_sorts():
-    df1 = pd.DataFrame({"A": np.linspace(0, 1, 10), "B": np.random.random(10)})
-    df2 = df1.sort_values("B")
-    df2_r = df2.reset_index(drop=True)
-    assert_eq(df1, df2)
-    assert_eq(df1, df2_r, check_index=False)
-    with pytest.raises(AssertionError):
-        assert_eq(df1, df2_r)
-
-
-def test_assert_eq_sort_result():
-    df = pd.DataFrame({"a": [5, 4, 3, 2, 1] * 2, "b": range(10, 20)})
-    df_s = df.sort_values(["a"])
+    df = pd.DataFrame({"A": np.linspace(0, 1, 10), "B": np.random.random(10)})
+    df_s = df.sort_values("B")
     assert_eq(df, df_s)
     with pytest.raises(AssertionError):
         assert_eq(df, df_s, sort_results=False)
 
+    df_sr = df_s.reset_index(drop=True)
+    assert_eq(df, df_sr, check_index=False)
+    with pytest.raises(AssertionError):
+        assert_eq(df, df_sr)
+    with pytest.raises(AssertionError):
+        assert_eq(df, df_sr, check_index=False, sort_results=False)
+
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf_s = ddf.sort_values(["a"])
+    ddf_s = ddf.sort_values(["B"])
     assert_eq(df, ddf_s)
     with pytest.raises(AssertionError):
         assert_eq(df, ddf_s, sort_results=False)
 
-    ddf_r = ddf_s.reset_index(drop=True)
-    assert_eq(df, ddf_r, check_index=False)
+    ddf_sr = ddf_s.reset_index(drop=True)
+    assert_eq(df, ddf_sr, check_index=False)
     with pytest.raises(AssertionError):
-        assert_eq(df, ddf_r, check_index=False, sort_results=False)
+        assert_eq(df, ddf_sr, check_index=False, sort_results=False)
 
 
 def test_assert_eq_scheduler():

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -551,15 +551,16 @@ def test_assert_eq_sorts():
         assert_eq(df1, df2_r)
 
 
-def test_assert_eq_ordering():
-    df = pd.DataFrame({"a": [5, 4, 3, 2, 1] * 20, "b": range(100, 200)})
-    ddf = dd.from_pandas(df, npartitions=10)
-    sorted_ddf = ddf.sort_values(["a"])
-
-    assert_eq(df, sorted_ddf)
-
+def test_assert_eq_order():
+    df = pd.DataFrame({"a": [5, 4, 3, 2, 1] * 2, "b": range(10, 20)})
+    df_s = df.sort_values(["a"])
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf_s = ddf.sort_values(["a"])
+    assert_eq(df, df_s)
+    assert_eq(df, ddf_s)
     with pytest.raises(AssertionError):
-        assert_eq(df, sorted_ddf, ignore_ordering=False)
+        assert_eq(df, df_s, check_order=True)
+        assert_eq(df, ddf_s, check_order=True)
 
 
 def test_assert_eq_scheduler():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -523,7 +523,7 @@ def assert_eq(
     check_dtype=True,
     check_divisions=True,
     check_index=False,
-    sort_results=False,
+    sort_results=True,
     scheduler="sync",
     **kwargs,
 ):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -523,6 +523,7 @@ def assert_eq(
     check_dtype=True,
     check_divisions=True,
     check_index=True,
+    ignore_ordering=True,
     scheduler="sync",
     **kwargs,
 ):
@@ -545,7 +546,7 @@ def assert_eq(
         a = a.to_pandas()
     if hasattr(b, "to_pandas"):
         b = b.to_pandas()
-    if isinstance(a, (pd.DataFrame, pd.Series)):
+    if isinstance(a, (pd.DataFrame, pd.Series)) and ignore_ordering:
         a = _maybe_sort(a, check_index)
         b = _maybe_sort(b, check_index)
     if not check_index:

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -522,7 +522,7 @@ def assert_eq(
     check_names=True,
     check_dtype=True,
     check_divisions=True,
-    check_index=False,
+    check_index=True,
     sort_results=True,
     scheduler="sync",
     **kwargs,

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -522,8 +522,8 @@ def assert_eq(
     check_names=True,
     check_dtype=True,
     check_divisions=True,
-    check_index=True,
-    check_order=False,
+    check_index=False,
+    sort_results=False,
     scheduler="sync",
     **kwargs,
 ):
@@ -546,7 +546,7 @@ def assert_eq(
         a = a.to_pandas()
     if hasattr(b, "to_pandas"):
         b = b.to_pandas()
-    if isinstance(a, (pd.DataFrame, pd.Series)) and not check_order:
+    if isinstance(a, (pd.DataFrame, pd.Series)) and sort_results:
         a = _maybe_sort(a, check_index)
         b = _maybe_sort(b, check_index)
     if not check_index:

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -523,7 +523,7 @@ def assert_eq(
     check_dtype=True,
     check_divisions=True,
     check_index=True,
-    ignore_ordering=True,
+    check_order=False,
     scheduler="sync",
     **kwargs,
 ):
@@ -546,7 +546,7 @@ def assert_eq(
         a = a.to_pandas()
     if hasattr(b, "to_pandas"):
         b = b.to_pandas()
-    if isinstance(a, (pd.DataFrame, pd.Series)) and ignore_ordering:
+    if isinstance(a, (pd.DataFrame, pd.Series)) and not check_order:
         a = _maybe_sort(a, check_index)
         b = _maybe_sort(b, check_index)
     if not check_index:


### PR DESCRIPTION
- [x] Closes #9018
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

TODO:
- [x]  Run test suite with `sort_results=True`
- [x] Open new issue to use `sort_results` where relevant, done: `https://github.com/dask/dask/issues/9158`
- [x] Add test for interaction with `check_index`