### PR TITLE
Temporarily import `cleanup` fixture from `distributed`

### DIFF
--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -8,10 +8,10 @@ import sys
 from functools import partial
 from operator import add
 
-from distributed.utils_test import client as c  # noqa F401
+from distributed.utils_test import cleanup  # noqa F401
 from distributed.utils_test import cluster_fixture  # noqa F401
-from distributed.utils_test import loop  # noqa F401
-from distributed.utils_test import cluster, gen_cluster, inc, varying
+from distributed.utils_test import client as c  # noqa F401
+from distributed.utils_test import cluster, gen_cluster, inc, loop, varying  # noqa F401
 
 import dask
 import dask.bag as db


### PR DESCRIPTION
This is a temporary fix for https://github.com/dask/dask/issues/9137, but doesn't feel like a great long-term solution 

cc @graingert 