### PR TITLE
Un-`xfail` `test_groupby_grouper_dispatch`

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2455,7 +2455,6 @@ def test_groupby_dropna_cudf(dropna, by, group_keys):
     assert_eq(dask_result, cudf_result)
 
 
-@pytest.mark.xfail
 @pytest.mark.gpu
 @pytest.mark.parametrize("key", ["a", "b"])
 def test_groupby_grouper_dispatch(key):


### PR DESCRIPTION
Resolves: https://github.com/dask/dask/pull/9074#issuecomment-1137176593

We had to `xfail` since associated `cudf` PR https://github.com/rapidsai/cudf/pull/10838 wasn't merged. Now that it is merged, it is safe to remove `xfail`
