### PR TITLE
`pyarrow` 8.0 partitioning fix

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -909,7 +909,11 @@ class ArrowDatasetEngine(Engine):
                     k: hive_categories[k] for k in cat_keys if k in hive_categories
                 }
 
-        if partitioning_supported and ds.partitioning.dictionaries:
+        if (
+            partitioning_supported
+            and ds.partitioning.dictionaries
+            and all(ds.partitioning.dictionaries)
+        ):
             # Use ds.partitioning for pyarrow>=5.0.0
             partition_names = list(ds.partitioning.schema.names)
             for i, name in enumerate(partition_names):


### PR DESCRIPTION
In `pyarrow=8` `ds.partitioning.dictionaries` started returning a list of `None`s instead of just `None` (xref https://github.com/apache/arrow/pull/12791). This PR contains compatibility code so things work both with `pyarrow<8` and `pyarrow>=8`

Closes https://github.com/dask/dask/issues/9142

cc @rjzamora @jcrist @jorisvandenbossche 