### PR TITLE
Warn that cloudpickle is not always deterministic

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -1061,12 +1061,19 @@ def _normalize_function(func: Callable) -> tuple | str | bytes:
                 return result
         except Exception:
             pass
-        try:
-            import cloudpickle
+        if not config.get("tokenize.ensure-deterministic"):
+            try:
+                import cloudpickle
 
-            return cloudpickle.dumps(func, protocol=4)
-        except Exception:
-            return str(func)
+                return cloudpickle.dumps(func, protocol=4)
+            except Exception:
+                return str(func)
+        else:
+            raise RuntimeError(
+                f"Function {str(func)} may not be deterministically hashed by "
+                "cloudpickle. See: https://github.com/cloudpipe/cloudpickle/issues/385 "
+                "for more information."
+            )
 
 
 def normalize_dataclass(obj):

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -257,12 +257,12 @@ def test_tokenize_object():
 
 def test_tokenize_function_cloudpickle():
     a, b = (lambda x: x, lambda x: x)
-    assert tokenize(a) == tokenize(b)
+    # No error by default
+    tokenize(a)
 
-    a1, b1 = (lambda x: x, lambda x: x)
     with dask.config.set({"tokenize.ensure-deterministic": True}):
         with pytest.raises(RuntimeError, match="may not be deterministically hashed"):
-            normalize_token(a1) == normalize_token(b1)
+            tokenize(b)
 
 
 def test_tokenize_callable():

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -248,11 +248,21 @@ def test_normalize_base():
 def test_tokenize_object():
     o = object()
     # Defaults to non-deterministic tokenization
-    assert normalize_token(o) != normalize_token(o)
+    # assert normalize_token(o) != normalize_token(o)
 
     with dask.config.set({"tokenize.ensure-deterministic": True}):
         with pytest.raises(RuntimeError, match="cannot be deterministically hashed"):
             normalize_token(o)
+
+
+def test_tokenize_function_cloudpickle():
+    a, b = (lambda x: x, lambda x: x)
+    assert tokenize(a) == tokenize(b)
+
+    a1, b1 = (lambda x: x, lambda x: x)
+    with dask.config.set({"tokenize.ensure-deterministic": True}):
+        with pytest.raises(RuntimeError, match="may not be deterministically hashed"):
+            normalize_token(a1) == normalize_token(b1)
 
 
 def test_tokenize_callable():

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -248,7 +248,7 @@ def test_normalize_base():
 def test_tokenize_object():
     o = object()
     # Defaults to non-deterministic tokenization
-    # assert normalize_token(o) != normalize_token(o)
+    assert normalize_token(o) != normalize_token(o)
 
     with dask.config.set({"tokenize.ensure-deterministic": True}):
         with pytest.raises(RuntimeError, match="cannot be deterministically hashed"):


### PR DESCRIPTION
If `tokenize` takes the cloudpickle path, it may not always get deterministic tokens. It'll be nice to warn about this if the `tokenize.ensure-deterministic` config is set to True.

- [x] Closes #9135
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
