### PR TITLE
Fix typo in `map_partitions` `func` parameter description

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -737,7 +737,7 @@ Dask Name: {name}, {task} tasks"""
         ----------
         func : function
             The function applied to each partition. If this function accepts
-            the special ``partition_info`` keyword argument, it will recieve
+            the special ``partition_info`` keyword argument, it will receive
             information on the partition's relative location within the
             dataframe.
         args, kwargs :


### PR DESCRIPTION
Minor change that fixes a typo in the `map_partitions` docstring.