### PR TITLE
Update docs theme for rebranding

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 numpydoc
 sphinx>=4.0.0
-dask-sphinx-theme>=2.0.3
+dask-sphinx-theme>=3.0.0
 sphinx-click
 sphinx-copybutton
 sphinx-remove-toctrees

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,9 @@ exclude_patterns: list[str] = []
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "default"
+# Commenting this out for now, if we register dask pygments,
+# then eventually this line can be:
+# pygments_style = "dask"
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []


### PR DESCRIPTION
On Monday, June 6th, dask.org will go live with a new design (see https://github.com/dask/community/issues/220). This PR is in preparation for the theme update for `dask-sphinx-theme` and can be merged in *after* https://github.com/dask/dask-sphinx-theme/pull/67 on Monday.

cc @jacobtomlinson @jsignell
