### PR TITLE
Add arrow schema extraction dispatch

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -81,15 +81,12 @@ try:
 except ImportError:
     pass
 
-try:
+
+@pyarrow_schema_dispatch.register((pd.DataFrame,))
+def get_pyarrow_schema_pandas(obj):
     import pyarrow as pa
 
-    @pyarrow_schema_dispatch.register((pd.DataFrame,))
-    def get_pyarrow_schema_pandas(obj):
-        return pa.Schema.from_pandas(obj)
-
-except ImportError:
-    pass
+    return pa.Schema.from_pandas(obj)
 
 
 @meta_nonempty.register(pd.DatetimeTZDtype)

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -5,7 +5,7 @@ from typing import Iterable
 
 import numpy as np
 import pandas as pd
-import pyarrow as pa
+
 from pandas.api.types import (
     is_categorical_dtype,
     is_datetime64tz_dtype,
@@ -79,6 +79,16 @@ try:
     import scipy.sparse as sp
 
     meta_object_types += (sp.spmatrix,)
+except ImportError:
+    pass
+
+try:
+    import pyarrow as pa
+
+    @pyarrow_schema_dispatch.register((pd.DataFrame,))
+    def get_pyarrow_schema_pandas(obj):
+        return pa.Schema.from_pandas(obj)
+
 except ImportError:
     pass
 
@@ -541,11 +551,6 @@ def is_categorical_dtype_pandas(obj):
 @grouper_dispatch.register((pd.DataFrame, pd.Series))
 def get_grouper_pandas(obj):
     return pd.core.groupby.Grouper
-
-
-@pyarrow_schema_dispatch.register((pd.DataFrame,))
-def get_pyarrow_schema_pandas(obj):
-    return pa.Schema.from_pandas(obj)
 
 
 @percentile_lookup.register((pd.Series, pd.Index))

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -5,7 +5,6 @@ from typing import Iterable
 
 import numpy as np
 import pandas as pd
-
 from pandas.api.types import (
     is_categorical_dtype,
     is_datetime64tz_dtype,

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -5,6 +5,7 @@ from typing import Iterable
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 from pandas.api.types import (
     is_categorical_dtype,
     is_datetime64tz_dtype,
@@ -30,6 +31,7 @@ from dask.dataframe.dispatch import (
     make_meta_dispatch,
     make_meta_obj,
     meta_nonempty,
+    pyarrow_schema_dispatch,
     tolist_dispatch,
     union_categoricals_dispatch,
 )
@@ -539,6 +541,11 @@ def is_categorical_dtype_pandas(obj):
 @grouper_dispatch.register((pd.DataFrame, pd.Series))
 def get_grouper_pandas(obj):
     return pd.core.groupby.Grouper
+
+
+@pyarrow_schema_dispatch.register((pd.DataFrame,))
+def get_pyarrow_schema_pandas(obj):
+    return pa.Schema.from_pandas(obj)
 
 
 @percentile_lookup.register((pd.Series, pd.Index))

--- a/dask/dataframe/dispatch.py
+++ b/dask/dataframe/dispatch.py
@@ -22,6 +22,7 @@ tolist_dispatch = Dispatch("tolist")
 is_categorical_dtype_dispatch = Dispatch("is_categorical_dtype")
 union_categoricals_dispatch = Dispatch("union_categoricals")
 grouper_dispatch = Dispatch("grouper")
+pyarrow_schema_dispatch = Dispatch("pyarrow_schema_dispatch")
 
 
 def concat(

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -11,6 +11,7 @@ from packaging.version import parse as parse_version
 
 from dask.base import tokenize
 from dask.core import flatten
+from dask.dataframe.backends import pyarrow_schema_dispatch
 from dask.dataframe.io.parquet.utils import (
     Engine,
     _get_aggregation_depth,
@@ -512,7 +513,7 @@ class ArrowDatasetEngine(Engine):
     ):
         if schema == "infer" or isinstance(schema, dict):
             # Start with schema from _meta_nonempty
-            inferred_schema = pa.Schema.from_pandas(
+            inferred_schema = pyarrow_schema_dispatch(
                 df._meta_nonempty.set_index(index_cols)
                 if index_cols
                 else df._meta_nonempty

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4179,12 +4179,17 @@ def test_deprecate_gather_statistics(tmp_path, engine):
     assert_eq(out, df)
 
 
-@pytest.mark.xfail
 @pytest.mark.gpu
 def test_gpu_write_parquet_simple(tmpdir):
     fn = str(tmpdir)
     cudf = pytest.importorskip("cudf")
     dask_cudf = pytest.importorskip("dask_cudf")
+    from dask.dataframe.dispatch import pyarrow_schema_dispatch
+
+    @pyarrow_schema_dispatch.register((cudf.DataFrame,))
+    def get_pyarrow_schema_cudf(obj):
+        return obj.to_arrow().schema
+
     df = cudf.DataFrame(
         {
             "a": ["abc", "def"],

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4177,3 +4177,20 @@ def test_deprecate_gather_statistics(tmp_path, engine):
             gather_statistics=True,
         )
     assert_eq(out, df)
+
+
+@pytest.mark.gpu
+def test_gpu_write_parquet_simple(tmpdir):
+    fn = str(tmpdir)
+    cudf = pytest.importorskip("cudf")
+    dask_cudf = pytest.importorskip("dask_cudf")
+    df = cudf.DataFrame(
+        {
+            "a": ["abc", "def"],
+            "b": ["a", "z"],
+        }
+    )
+    ddf = dask_cudf.from_cudf(df, 3)
+    ddf.to_parquet(fn)
+    got = dask_cudf.read_parquet(fn).compute()
+    assert_eq(df, got)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4179,6 +4179,7 @@ def test_deprecate_gather_statistics(tmp_path, engine):
     assert_eq(out, df)
 
 
+@pytest.mark.xfail
 @pytest.mark.gpu
 def test_gpu_write_parquet_simple(tmpdir):
     fn = str(tmpdir)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4193,5 +4193,5 @@ def test_gpu_write_parquet_simple(tmpdir):
     )
     ddf = dask_cudf.from_cudf(df, 3)
     ddf.to_parquet(fn)
-    got = dask_cudf.read_parquet(fn).compute()
+    got = dask_cudf.read_parquet(fn)
     assert_eq(df, got)


### PR DESCRIPTION
After https://github.com/dask/dask/pull/9131 was merged, it brought in a change to default parameter `schema` from `None` to `"infer"`, this results in a failure when we try to use parquet writer in `dask_cudf` because of pandas specific code. This PR adds a `pyarrow_schema_dispatch` that will handle the pyarrow schema extraction for their respective backends. 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
