### PR TITLE
Fix `pyarrow.StringArray` pickle

### DIFF
--- a/dask/dataframe/_pyarrow_compat.py
+++ b/dask/dataframe/_pyarrow_compat.py
@@ -86,7 +86,7 @@ def pyarrow_stringarray_to_parts(array):
         # elements so the mask array can always be serialized zero copy.
         npad = array.offset % 8
         mask_start = array.offset // 8
-        mask_stop = mask_start + math.ceil(nitems / 8)
+        mask_stop = math.ceil((array.offset + nitems) / 8)
         mask = mask[mask_start:mask_stop]
 
     # Subtract the offset of the starting element from every used offset in the

--- a/dask/dataframe/tests/test_pyarrow_compat.py
+++ b/dask/dataframe/tests/test_pyarrow_compat.py
@@ -25,10 +25,20 @@ def randstr(i):
     )
 
 
-@pytest.mark.parametrize("length", [6, 8, 12, 17])
+@pytest.mark.parametrize("length", [6, 8, 12, 20])
 @pytest.mark.parametrize(
     "slc",
-    [slice(None), slice(0, 5), slice(2), slice(2, 5), slice(2, None, 2), slice(0, 0)],
+    [
+        slice(None),
+        slice(0, 5),
+        slice(2),
+        slice(2, 5),
+        slice(2, None, 2),
+        slice(0, 0),
+        slice(7, 10),
+        slice(7, 19),
+        slice(15, 19),
+    ],
 )
 @pytest.mark.parametrize("has_mask", [True, False])
 def test_roundtrip_stringarray(length, slc, has_mask):
@@ -51,7 +61,7 @@ def test_roundtrip_stringarray(length, slc, has_mask):
     assert bytes(data) == expected_data
 
     if mask is not None:
-        assert len(mask) == math.ceil(nitems / 8)
+        assert len(mask) == math.ceil((nitems + offset) / 8)
         assert x.offset % 8 == offset
 
     # Test rebuilding from components works


### PR DESCRIPTION
Previously there was a bug when serializing arrays when a mask was present *and* the array was sliced crossing a multiple-of-eight boundary (e.g. `x[7:9]`). This fixes that bug and expands the test suite to cover this case.

Fixes #9163.