### PR TITLE
More retries when writing parquet to remote filesystem

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import math
 import warnings
 
@@ -8,6 +9,7 @@ from fsspec.core import get_fs_token_paths
 from fsspec.utils import stringify_path
 from packaging.version import parse as parse_version
 
+import dask
 from dask.base import tokenize
 from dask.blockwise import BlockIndex
 from dask.dataframe.core import DataFrame, Scalar
@@ -531,21 +533,32 @@ def read_parquet(
             common_kwargs,
         )
 
-    # Construct the output collection with from_map
-    return from_map(
-        io_func,
-        parts,
-        meta=meta,
-        divisions=divisions,
-        label="read-parquet",
-        token=tokenize(path, **input_kwargs),
-        enforce_metadata=False,
-        creation_info={
-            "func": read_parquet,
-            "args": (path,),
-            "kwargs": input_kwargs,
-        },
-    )
+    # If we are using a remote filesystem and retries is not set, bump it
+    # to be more fault tolerant, as transient transport errors can occur.
+    # The specific number 5 isn't hugely motivated: it's less than ten and more
+    # than two.
+    annotations = dask.config.get("annotations", {})
+    if "retries" not in annotations and not _is_local_fs(fs):
+        ctx = dask.annotate(retries=5)
+    else:
+        ctx = contextlib.nullcontext()
+
+    with ctx:
+        # Construct the output collection with from_map
+        return from_map(
+            io_func,
+            parts,
+            meta=meta,
+            divisions=divisions,
+            label="read-parquet",
+            token=tokenize(path, **input_kwargs),
+            enforce_metadata=False,
+            creation_info={
+                "func": read_parquet,
+                "args": (path,),
+                "kwargs": input_kwargs,
+            },
+        )
 
 
 def check_multi_support(engine):
@@ -869,32 +882,43 @@ def to_parquet(
         if len(set(filenames)) < len(filenames):
             raise ValueError("``name_function`` must produce unique filenames.")
 
+    # If we are using a remote filesystem and retries is not set, bump it
+    # to be more fault tolerant, as transient transport errors can occur.
+    # The specific number 5 isn't hugely motivated: it's less than ten and more
+    # than two.
+    annotations = dask.config.get("annotations", {})
+    if "retries" not in annotations and not _is_local_fs(fs):
+        ctx = dask.annotate(retries=5)
+    else:
+        ctx = contextlib.nullcontext()
+
     # Create Blockwise layer for parquet-data write
-    data_write = df.map_partitions(
-        ToParquetFunctionWrapper(
-            engine,
-            path,
-            fs,
-            partition_on,
-            write_metadata_file,
-            i_offset,
-            name_function,
-            toolz.merge(
-                kwargs,
-                {"compression": compression, "custom_metadata": custom_metadata},
-                extra_write_kwargs,
+    with ctx:
+        data_write = df.map_partitions(
+            ToParquetFunctionWrapper(
+                engine,
+                path,
+                fs,
+                partition_on,
+                write_metadata_file,
+                i_offset,
+                name_function,
+                toolz.merge(
+                    kwargs,
+                    {"compression": compression, "custom_metadata": custom_metadata},
+                    extra_write_kwargs,
+                ),
             ),
-        ),
-        BlockIndex((df.npartitions,)),
-        # Pass in the original metadata to avoid
-        # metadata emulation in `map_partitions`.
-        # This is necessary, because we are not
-        # expecting a dataframe-like output.
-        meta=df._meta,
-        enforce_metadata=False,
-        transform_divisions=False,
-        align_dataframes=False,
-    )
+            BlockIndex((df.npartitions,)),
+            # Pass in the original metadata to avoid
+            # metadata emulation in `map_partitions`.
+            # This is necessary, because we are not
+            # expecting a dataframe-like output.
+            meta=df._meta,
+            enforce_metadata=False,
+            transform_divisions=False,
+            align_dataframes=False,
+        )
 
     # Collect metadata and write _metadata.
     # TODO: Use tree-reduction layer (when available)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4202,6 +4202,7 @@ def test_gpu_write_parquet_simple(tmpdir):
     assert_eq(df, got)
 
 
+@PYARROW_MARK
 def test_retries_on_remote_filesystem(tmpdir):
     # Fake a remote filesystem with a cached one
     fn = str(tmpdir)


### PR DESCRIPTION
When writing partitioned parquet to remote filesystems (often over protocols like HTTP), things happen. It can be very frustrating to a user who is writing thousands of partitions to have one of them fail due to a transient network hiccup. Both s3fs and boto have some functionality for retrying things, but even then stuff can bubble up to the dask scheduler level. Such network hiccups are tough to reproduce in a unit test context, but I have seen them in some of the parquet-related stress testing I've been doing of late.

This bumps the default retries for parquet I/O using annotations. If the user has already set retries in an outer scope, those are respected. cc @mrocklin 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
