### PR TITLE
Include known inconsistency in DataFrame `str.split` accessor docstring 

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -274,9 +274,7 @@ class StringAccessor(Accessor):
 
     @derived_from(pd.core.strings.StringMethods)
     def split(self, pat=None, n=-1, expand=False):
-        """
-        Known inconsistencies: ``expand=True`` with unknown ``n`` will raise a NotImplementedError.
-        """
+        """Known inconsistencies: ``expand=True`` with unknown ``n`` will raise a ``NotImplementedError``."""
         return self._split("split", pat=pat, n=n, expand=expand)
 
     @derived_from(pd.core.strings.StringMethods)

--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -274,6 +274,9 @@ class StringAccessor(Accessor):
 
     @derived_from(pd.core.strings.StringMethods)
     def split(self, pat=None, n=-1, expand=False):
+        """
+        Known inconsistencies: ``expand=True`` with unknown ``n`` will raise a NotImplementedError.
+        """
         return self._split("split", pat=pat, n=n, expand=expand)
 
     @derived_from(pd.core.strings.StringMethods)


### PR DESCRIPTION
This PR expands the docstring for `split` in acccessor.py to identify a known inconsistency with the pandas method to better guide users.

- [X] Closes #9176 
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
