### PR TITLE
Deprecate extra `format_time` utility

### DIFF
--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -12,9 +12,9 @@ from dask.utils import _deprecated
 def format_time(t):
     """Format seconds into a human readable form.
 
-    >>> format_time(10.4)
+    >>> format_time(10.4)  # doctest: +SKIP
     '10.4s'
-    >>> format_time(1000.4)
+    >>> format_time(1000.4)  # doctest: +SKIP
     '16min 40.4s'
     """
     m, s = divmod(t, 60)

--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -5,8 +5,10 @@ import time
 from timeit import default_timer
 
 from dask.callbacks import Callback
+from dask.utils import _deprecated
 
 
+@_deprecated(after_version="2022.6.0", use_instead="dask.utils.format_time")
 def format_time(t):
     """Format seconds into a human readable form.
 

--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -137,6 +137,8 @@ class ProgressBar(Callback):
             self._draw_bar(ndone / ntasks if ntasks else 0, elapsed)
 
     def _draw_bar(self, frac, elapsed):
+        from dask.utils import format_time
+
         bar = "#" * int(self._width * frac)
         percent = int(100 * frac)
         elapsed = format_time(elapsed)

--- a/dask/diagnostics/tests/test_progress.py
+++ b/dask/diagnostics/tests/test_progress.py
@@ -59,11 +59,14 @@ def test_clean_exit(get):
 
 
 def test_format_time():
-    assert format_time(1.4) == " 1.4s"
-    assert format_time(10.4) == "10.4s"
-    assert format_time(100.4) == " 1min 40.4s"
-    assert format_time(1000.4) == "16min 40.4s"
-    assert format_time(10000.4) == " 2hr 46min 40.4s"
+    with pytest.warns(FutureWarning, match="dask.utils.format_time") as record:
+        assert format_time(1.4) == " 1.4s"
+        assert format_time(10.4) == "10.4s"
+        assert format_time(100.4) == " 1min 40.4s"
+        assert format_time(1000.4) == "16min 40.4s"
+        assert format_time(10000.4) == " 2hr 46min 40.4s"
+
+    assert len(record) == 5  # Each `assert` above warns
 
 
 def test_register(capsys):


### PR DESCRIPTION
This is a small follow-up to https://github.com/dask/dask/pull/9116 that deprecates `dask.diagnostics.progress.format_time` in favor of `dask.utils.format_time` 

cc @jacobtomlinson 