### PR TITLE
Correct dtypes when `concat` with an empty dataframe

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -1237,6 +1237,12 @@ def concat(
         raise ValueError("'join' must be 'inner' or 'outer'")
 
     axis = DataFrame._validate_axis(axis)
+    try:
+        # remove any empty DataFrames
+        dfs = [df for df in dfs if bool(len(df.columns))]
+    except AttributeError:
+        # 'Series' object has no attribute 'columns'
+        pass
     dasks = [df for df in dfs if isinstance(df, _Frame)]
     dfs = _maybe_from_pandas(dfs)
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -804,13 +804,13 @@ def test_concat_dataframe_empty():
     ddf = dd.from_pandas(df, npartitions=1)
     empty_ddf = dd.from_pandas(empty_df, npartitions=1)
     ddf_concat = dd.concat([ddf, empty_ddf])
-    assert all(df_concat.dtypes == ddf_concat.dtypes)
+    assert_eq(df_concat, ddf_concat)
 
     empty_df_with_col = pd.DataFrame([], columns=["x"], dtype="int64")
     df_concat_with_col = pd.concat([df, empty_df_with_col])
     empty_ddf_with_col = dd.from_pandas(empty_df_with_col, npartitions=1)
     ddf_concat_with_col = dd.concat([ddf, empty_ddf_with_col])
-    assert all(df_concat_with_col.dtypes == ddf_concat_with_col.dtypes)
+    assert_eq(df_concat_with_col, ddf_concat_with_col)
 
 
 @pytest.mark.parametrize(

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -796,6 +796,23 @@ def test_concat_with_operation_remains_hlg():
     assert_eq(result, expected)
 
 
+def test_concat_dataframe_empty():
+    df = pd.DataFrame({"a": [100, 200, 300]}, dtype="int64")
+    empty_df = pd.DataFrame([], dtype="int64")
+    df_concat = pd.concat([df, empty_df])
+
+    ddf = dd.from_pandas(df, npartitions=1)
+    empty_ddf = dd.from_pandas(empty_df, npartitions=1)
+    ddf_concat = dd.concat([ddf, empty_ddf])
+    assert all(df_concat.dtypes == ddf_concat.dtypes)
+
+    empty_df_with_col = pd.DataFrame([], columns=["x"], dtype="int64")
+    df_concat_with_col = pd.concat([df, empty_df_with_col])
+    empty_ddf_with_col = dd.from_pandas(empty_df_with_col, npartitions=1)
+    ddf_concat_with_col = dd.concat([ddf, empty_ddf_with_col])
+    assert all(df_concat_with_col.dtypes == ddf_concat_with_col.dtypes)
+
+
 @pytest.mark.parametrize(
     "value_1, value_2",
     [

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -810,7 +810,13 @@ def test_concat_dataframe_empty():
     df_concat_with_col = pd.concat([df, empty_df_with_col])
     empty_ddf_with_col = dd.from_pandas(empty_df_with_col, npartitions=1)
     ddf_concat_with_col = dd.concat([ddf, empty_ddf_with_col])
-    assert_eq(df_concat_with_col, ddf_concat_with_col)
+    # NOTE: empty_ddf_with_col.index.dtype == dtype('O') while ddf.index.dtype == dtype('int64')
+    # when we concatenate the resulting ddf_concat_with_col.index.dtype == dtype('O'). However,
+    # the pandas version is smart enough to identify the empty rows and assign dtype('int64'),
+    # which causes assert_eq to fail when checking dtype. Hence the follwoing line.
+    ddf_concat_with_col._meta.index = ddf_concat_with_col._meta.index.astype("int64")
+
+    assert_eq(df_concat_with_col, ddf_concat_with_col, check_dtype=False)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] Closes #9046
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
