### PR TITLE
[WIP] Revise aggregate_files behavior in read_parquet

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1565,7 +1565,7 @@ def aggregate_by_files(parts, stats, partition_size_files):
             "file_group", False
         )
 
-        if multi_path_allowed and len(next_part) <= partition_size_files:
+        if multi_path_allowed and len(next_part) < partition_size_files:
 
             # Update part list
             next_part.append(part)

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -742,3 +742,31 @@ def _set_gather_statistics(
         gather_statistics = False
 
     return bool(gather_statistics)
+
+
+class FileGroupLookup:
+    def __init__(self, path_depth=1):
+        self._mapping = {}
+        self._path_depth = path_depth
+
+    def __getitem__(self, path):
+        if not isinstance(path, str):
+            raise ValueError
+
+        key = tuple(path.split("/")[-self._path_depth :])
+        return self._mapping[key]
+
+    def get(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __setitem__(self, path, group):
+        if not isinstance(path, str):
+            raise ValueError
+        if not isinstance(group, int):
+            raise ValueError
+
+        key = tuple(path.split("/")[-self._path_depth :])
+        self._mapping[key] = group

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -392,8 +392,9 @@ def _normalize_index_columns(user_columns, data_columns, user_index, data_index)
     return column_names, index_names
 
 
-def _sort_and_analyze_paths(file_list, fs, root=False):
-    file_list = sorted(file_list, key=natural_sort_key)
+def _sort_and_analyze_paths(file_list, fs, sort=True, root=False):
+    if sort:
+        file_list = sorted(file_list, key=natural_sort_key)
     base, fns = _analyze_paths(file_list, fs, root=root)
     return file_list, base, fns
 
@@ -554,10 +555,10 @@ def _aggregate_stats(
 def _row_groups_to_parts(
     gather_statistics,
     split_row_groups,
-    aggregation_depth,
     file_row_groups,
     file_row_group_stats,
     file_row_group_column_stats,
+    file_aggregation_groups,
     stat_col_indices,
     make_part_func,
     make_part_kwargs,
@@ -571,7 +572,16 @@ def _row_groups_to_parts(
         # limiting the number of row_groups in each piece
         split_row_groups = int(split_row_groups)
         residual = 0
-        for filename, row_groups in file_row_groups.items():
+        file_row_groups_items = list(file_row_groups.items())
+        for file_i, (filename, row_groups) in enumerate(file_row_groups_items):
+            this_agg_group = file_aggregation_groups.get(filename, 0)
+            try:
+                leave_residual = this_agg_group == file_aggregation_groups.get(
+                    file_row_groups_items[file_i + 1][0], None
+                )
+            except IndexError:
+                leave_residual = False
+
             row_group_count = len(row_groups)
             if residual:
                 _rgs = [0] + list(range(residual, row_group_count, split_row_groups))
@@ -581,7 +591,10 @@ def _row_groups_to_parts(
             for i in _rgs:
 
                 i_end = i + split_row_groups
-                if aggregation_depth is True:
+                if leave_residual:
+                    # Only leave residual if we know we will be
+                    # able to aggregate row-groups from this file
+                    # with row-groups from the next file
                     if residual and i == 0:
                         i_end = residual
                         residual = 0
@@ -594,6 +607,7 @@ def _row_groups_to_parts(
                 part = make_part_func(
                     filename,
                     rg_list,
+                    this_agg_group,
                     **make_part_kwargs,
                 )
                 if part is None:
@@ -614,6 +628,7 @@ def _row_groups_to_parts(
             part = make_part_func(
                 filename,
                 row_groups,
+                file_aggregation_groups.get(filename, 0),
                 **make_part_kwargs,
             )
             if part is None:
@@ -630,39 +645,6 @@ def _row_groups_to_parts(
                 stats.append(stat)
 
     return parts, stats
-
-
-def _get_aggregation_depth(aggregate_files, partition_names):
-    # Use `aggregate_files` to set `aggregation_depth`
-    #
-    # Note that `partition_names` must be ordered. `True` means that we allow
-    # aggregation of any two files. `False` means that we will never aggregate
-    # files.  If a string is specified, it must be the name of a partition
-    # column, and the "partition depth" of that column will be used for
-    # aggregation.  Note that we always convert the string into the partition
-    # "depth" to simplify the aggregation logic.
-
-    # Summary of output `aggregation_depth` settings:
-    #
-    # True  : Free-for-all aggregation (any two files may be aggregated)
-    # False : No file aggregation allowed
-    # <int> : Allow aggregation within this partition-hierarchy depth
-
-    aggregation_depth = aggregate_files
-    if isinstance(aggregate_files, str):
-        if aggregate_files in partition_names:
-            # aggregate_files corresponds to a partition column. Reset the
-            # value of this variable to reflect the partition "depth" (in the
-            # range of 1 to the total number of partition levels)
-            aggregation_depth = len(partition_names) - partition_names.index(
-                aggregate_files
-            )
-        else:
-            raise ValueError(
-                f"{aggregate_files} is not a recognized directory partition."
-            )
-
-    return aggregation_depth
 
 
 def _set_metadata_task_size(metadata_task_size, fs):
@@ -738,7 +720,6 @@ def _set_gather_statistics(
     gather_statistics,
     chunksize,
     split_row_groups,
-    aggregation_depth,
     filter_columns,
     stat_columns,
 ):
@@ -748,11 +729,7 @@ def _set_gather_statistics(
 
     # If the user has specified `calculate_divisions=True`, then
     # we will be starting with `gather_statistics=True` here.
-    if (
-        chunksize
-        or (int(split_row_groups) > 1 and aggregation_depth)
-        or filter_columns.intersection(stat_columns)
-    ):
+    if chunksize or filter_columns.intersection(stat_columns):
         # Need to gather statistics if we are aggregating files
         # or filtering
         # NOTE: Should avoid gathering statistics when the agg


### PR DESCRIPTION
Closes #9043
Closes #9051 
Closes #8829

This PR (mostly) preserves the existing `chunksize`/`aggregate_files` options in `read_parquet` by adding two new arguments:

- `sort_input_paths` (default `True`): Whether or not Dask should re-order the files in the dataset to use "natural" ordering. Note that this new feature *could* be added in a separate PR, but I wanted to make sure that the new design allows for such an argument to exist.
- `partition_boundary` (default `None`): A list of directory-partitioned-column names that must match for two or more files to be aggregated into the same output partition. Files within the same "partition boundary" are said to belong to the same "file group."  The engines are always allowed to reorder paths by file group to improve file-aggregation behavior (even if sort_input_paths=False`).  Note that I added this option in order to drop support for `str` arguments to `aggregate_files` in favor of `int` support (explained below).

In addition to these new arguments, I also modified the existing `aggregate_files` argument to only accept `bool` or `int` types. That is, the `aggregate_files` option is now the "file equivalent" of `split_row_groups`. Specifying `aggregate_files=100` means that 100 files from the same file group may be aggregated into the same output partition.

The most important result of this PR is likely the support for `aggregate_files=<int>` (in combination with `partition_boundary=`). For example. In `main`, one would need to use `chunksize` (or `split_row_groups`) with `aggregate_files="year"` to read in a single large partition for each distinct year in a partitioned NYC-taxi dataset:

```python
import dask.dataframe as dd

ddf = dd.read_parquet(
    "s3://ursa-labs-taxi-data/",
    engine="pyarrow",
    storage_options={"anon": True},
    dataset={
        "partitioning": ["year", "month"],
        "partition_base_dir": "ursa-labs-taxi-data",
    },
    chunksize="6GB",
    aggregate_files="year",
)
# (takes several seconds on my workstation - but scales poorly with the total number of row groups)
```

However, with this branch, file aggregation *can* be much faster if the desired number of files per partition is known apriori:

```python
ddf = dd.read_parquet(
    "s3://ursa-labs-taxi-data/",
    engine="pyarrow",
    storage_options={"anon": True},
    dataset={
        "partitioning": ["year", "month"],
        "partition_base_dir": "ursa-labs-taxi-data",
    },
    partition_boundary=["year"],
    aggregate_files=12,  # (or larger)
)
# (takes less than 1s on my workstation)
```

