### PR TITLE
Better error message for unsupported numpy operations on dask.dataframe objects.

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3378,8 +3378,14 @@ class Series(_Frame):
             else:
                 index = context[1][0].index
         else:
+            try:
+                import inspect
+
+                method_name = f"`{inspect.stack()[3][3]}`"
+            except IndexError:
+                method_name = "This method"
             raise NotImplementedError(
-                "This method is not implemented for `dask.dataframe.Series`."
+                f"{method_name} is not implemented for `dask.dataframe.Series`."
             )
 
         return pd.Series(array, index=index, name=self.name)
@@ -4317,8 +4323,15 @@ class DataFrame(_Frame):
             else:
                 index = context[1][0].index
         else:
+            try:
+                import inspect
+
+                method_name = f"`{inspect.stack()[3][3]}`"
+            except IndexError:
+                method_name = "This method"
+
             raise NotImplementedError(
-                "This method is not implemented for `dask.dataframe.DataFrame`."
+                f"{method_name} is not implemented for `dask.dataframe.DataFrame`."
             )
 
         return pd.DataFrame(array, index=index, columns=self.columns)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3377,6 +3377,10 @@ class Series(_Frame):
                 index = None
             else:
                 index = context[1][0].index
+        else:
+            raise NotImplementedError(
+                "This method is not implemented for `dask.dataframe.Series`."
+            )
 
         return pd.Series(array, index=index, name=self.name)
 
@@ -4312,6 +4316,10 @@ class DataFrame(_Frame):
                 index = None
             else:
                 index = context[1][0].index
+        else:
+            raise NotImplementedError(
+                "This method is not implemented for `dask.dataframe.DataFrame`."
+            )
 
         return pd.DataFrame(array, index=index, columns=self.columns)
 

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -218,7 +218,7 @@ def test_ufunc_wrapped_not_implemented():
         np.random.randint(1, 100, size=20), index=list("abcdefghijklmnopqrst")
     )
     ds = dd.from_pandas(s, 3)
-    with pytest.raises(NotImplementedError, match="This method is not implemented"):
+    with pytest.raises(NotImplementedError, match="`repeat` is not implemented"):
         np.repeat(ds, 10)
 
     df = pd.DataFrame(
@@ -231,7 +231,7 @@ def test_ufunc_wrapped_not_implemented():
     )
     ddf = dd.from_pandas(df, 3)
 
-    with pytest.raises(NotImplementedError, match="This method is not implemented"):
+    with pytest.raises(NotImplementedError, match="`repeat` is not implemented"):
         np.repeat(ddf, 10)
 
 

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -213,6 +213,28 @@ def test_ufunc_wrapped(ufunc):
     np.testing.assert_array_equal(dafunc(df), npfunc(df))
 
 
+def test_ufunc_wrapped_not_implemented():
+    s = pd.Series(
+        np.random.randint(1, 100, size=20), index=list("abcdefghijklmnopqrst")
+    )
+    ds = dd.from_pandas(s, 3)
+    with pytest.raises(NotImplementedError, match="This method is not implemented"):
+        np.repeat(ds, 10)
+
+    df = pd.DataFrame(
+        {
+            "A": np.random.randint(1, 100, size=20),
+            "B": np.random.randint(1, 100, size=20),
+            "C": np.abs(np.random.randn(20)),
+        },
+        index=list("abcdefghijklmnopqrst"),
+    )
+    ddf = dd.from_pandas(df, 3)
+
+    with pytest.raises(NotImplementedError, match="This method is not implemented"):
+        np.repeat(ddf, 10)
+
+
 _UFUNCS_2ARG = [
     "logaddexp",
     "logaddexp2",


### PR DESCRIPTION
- [x] Closes #6954
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
