### PR TITLE
Add missing `append` in `delayed` best practices example

### DIFF
--- a/docs/source/delayed-best-practices.rst
+++ b/docs/source/delayed-best-practices.rst
@@ -158,6 +158,7 @@ find good places to break up a computation.
 |            data = load(filename)   |            data = load(filename)     |
 |            data = process(data)    |            data = process(data)      |
 |            result = save(data)     |            result = save(data)       |
+|            results.append(result)  |            results.append(result)    |
 |                                    |                                      |
 |        return results              |        return results                |
 |                                    |                                      |


### PR DESCRIPTION
Updated code block in delayed best practices docs
- added appending result to the results list before return in Break up computations into many pieces Do
- added appending result to the results list before return in Break up computations into many pieces Don't
