### PR TITLE
Fix: support `pathlib.PurePath` in `normalize_token`

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -951,7 +951,7 @@ normalize_token.register(
         type(Ellipsis),
         datetime.date,
         datetime.timedelta,
-        pathlib.Path,
+        pathlib.PurePath,
     ),
     identity,
 )

--- a/dask/base.py
+++ b/dask/base.py
@@ -5,6 +5,7 @@ import datetime
 import hashlib
 import inspect
 import os
+import pathlib
 import pickle
 import threading
 import uuid
@@ -950,6 +951,7 @@ normalize_token.register(
         type(Ellipsis),
         datetime.date,
         datetime.timedelta,
+        pathlib.Path,
     ),
     identity,
 )

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1,8 +1,8 @@
 import dataclasses
 import datetime
 import inspect
-import pathlib
 import os
+import pathlib
 import subprocess
 import sys
 import time
@@ -244,7 +244,14 @@ def test_tokenize_partial_func_args_kwargs_consistent():
 
 
 def test_normalize_base():
-    for i in [1, 1.1, "1", slice(1, 2, 3), datetime.date(2021, 6, 25), pathlib.PurePath("/this/that")]:
+    for i in [
+        1,
+        1.1,
+        "1",
+        slice(1, 2, 3),
+        datetime.date(2021, 6, 25),
+        pathlib.PurePath("/this/that"),
+    ]:
         assert normalize_token(i) is i
 
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1,6 +1,7 @@
 import dataclasses
 import datetime
 import inspect
+import pathlib
 import os
 import subprocess
 import sys
@@ -243,7 +244,7 @@ def test_tokenize_partial_func_args_kwargs_consistent():
 
 
 def test_normalize_base():
-    for i in [1, 1.1, "1", slice(1, 2, 3), datetime.date(2021, 6, 25)]:
+    for i in [1, 1.1, "1", slice(1, 2, 3), datetime.date(2021, 6, 25), pathlib.PurePath("/this/that")]:
         assert normalize_token(i) is i
 
 


### PR DESCRIPTION
`dask.base.tokenize` does not produce the same string for repeat invocations on the same path. This is because the tokenizer defaults to the object tokenizer.

This PR registers the identity function for the `pathlib.PurePath` type. I believe this is reasonable, as the default str / repr is a good description of the path. I'm not a Dask expert, though, so there may be reasons that an explicit tokenization is better.

I haven't profiled the startup-time change by importing `pathlib`, but I assume we're not worrying about that here.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
