### PR TITLE
Only import IPython if type checking

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5682,7 +5682,7 @@ class BlockView:
             return NotImplemented
 
     @property
-    def size(self) -> int:
+    def size(self) -> int | np.signedinteger:
         """
         The total number of blocks in the array.
         """

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Callable, Hashable, Mapping, Sequence
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
 
-try:
-    from IPython.display import DisplayObject
-except ImportError:
-    DisplayObject = Any
+if TYPE_CHECKING:
+    # IPython import is relatively slow. Avoid if not necessary
+    try:
+        from IPython.display import DisplayObject
+    except ImportError:
+        DisplayObject = Any
 
 
 CollType = TypeVar("CollType", bound="DaskCollection")

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -6,10 +6,7 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
 
 if TYPE_CHECKING:
     # IPython import is relatively slow. Avoid if not necessary
-    try:
-        from IPython.display import DisplayObject
-    except ImportError:
-        DisplayObject = Any
+    from IPython.display import DisplayObject
 
 
 CollType = TypeVar("CollType", bound="DaskCollection")


### PR DESCRIPTION
IPython is a relatively heavy import. In distributed I noticed this while profiling tests and CLI startup time. 

On my machine this reduces CLI startup time (e.g. `dask-scheduler --help`) by about 150ms of a total of 500ms, i.e. ~30% reduction.

Import time of dask itself is reduced from about 180ms to about 20ms, i.e. a reduction of about 90%