### PR TITLE
Add AttributeNotImplementedError for properties so IPython glob search works

### DIFF
--- a/dask/dataframe/categorical.py
+++ b/dask/dataframe/categorical.py
@@ -13,7 +13,11 @@ from dask.dataframe.dispatch import (  # noqa: F401
     categorical_dtype_dispatch,
     is_categorical_dtype,
 )
-from dask.dataframe.utils import clear_known_categories, has_known_categories
+from dask.dataframe.utils import (
+    AttributeNotImplementedError,
+    clear_known_categories,
+    has_known_categories,
+)
 
 
 def _categorize_block(df, categories, index):
@@ -235,7 +239,7 @@ class CategoricalAccessor(Accessor):
                 "supported.  Please use `column.cat.as_known()` or "
                 "`df.categorize()` beforehand to ensure known categories"
             )
-            raise NotImplementedError(msg)
+            raise AttributeNotImplementedError(msg)
         return self._delegate_property(self._series._meta, "cat", "categories")
 
     @property
@@ -249,7 +253,7 @@ class CategoricalAccessor(Accessor):
                 "supported.  Please use `column.cat.as_known()` or "
                 "`df.categorize()` beforehand to ensure known categories"
             )
-            raise NotImplementedError(msg)
+            raise AttributeNotImplementedError(msg)
         return self._property_map("codes")
 
     def remove_unused_categories(self):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -46,6 +46,7 @@ from dask.dataframe.optimize import optimize
 from dask.dataframe.utils import (
     PANDAS_GT_110,
     PANDAS_GT_120,
+    AttributeNotImplementedError,
     check_matching_columns,
     clear_known_categories,
     drop_by_shallow_copy,
@@ -4412,7 +4413,7 @@ class DataFrame(_Frame):
 
     @property
     def empty(self):
-        raise NotImplementedError(
+        raise AttributeNotImplementedError(
             "Checking whether a Dask DataFrame has any rows may be expensive. "
             "However, checking the number of columns is fast. "
             "Depending on which of these results you need, use either "

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -435,6 +435,11 @@ class TestCategoricalAccessor:
             da.cat.categories
         with pytest.raises(NotImplementedError):
             da.cat.codes
+        # Also AttributeError so glob searching in IPython such as `da.cat.*?` works
+        with pytest.raises(AttributeError):
+            da.cat.categories
+        with pytest.raises(AttributeError):
+            da.cat.codes
 
         db = da.cat.set_categories(["a", "b", "c"])
         assert db.cat.known

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -714,3 +714,7 @@ def drop_by_shallow_copy(df, columns, errors="raise"):
         columns = [columns]
     df2.drop(columns=columns, inplace=True, errors=errors)
     return df2
+
+
+class AttributeNotImplementedError(NotImplementedError, AttributeError):
+    """NotImplementedError and AttributeError"""


### PR DESCRIPTION
I sometimes like to use glob search in IPython/Jupyter and am annoyed when it doesn't work.  It currently doesn't work for dask dataframes:
```python
In [1]: import dask

In [2]: df = dask.datasets.timeseries()

In [3]: df.*?
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
File ~/miniconda3/envs/dask39/lib/python3.9/site-packages/IPython/core/oinspect.py:1008, in Inspector.psearch(self, pattern, ns_table, ns_search, ignore_case, show_all, list_types)
   1006         continue
   1007     namespaces_seen.add(id(ns))
-> 1008     tmp_res = list_namespace(ns, type_pattern, filter,
   1009                             ignore_case=ignore_case, show_all=show_all)
   1010     search_result.update(tmp_res)
   1012 page.page('\n'.join(sorted(search_result)))

File ~/miniconda3/envs/dask39/lib/python3.9/site-packages/IPython/utils/wildcard.py:106, in list_namespace(namespace, type_pattern, filter, ignore_case, show_all)
    104 results = {}
    105 for name, obj in filtered.items():
--> 106     ns = list_namespace(dict_dir(obj), type_pattern,
    107                         ".".join(pattern_list[1:]),
    108                         ignore_case=ignore_case, show_all=show_all)
    109     for inner_name, inner_obj in ns.items():
    110         results["%s.%s"%(name,inner_name)] = inner_obj

File ~/miniconda3/envs/dask39/lib/python3.9/site-packages/IPython/utils/wildcard.py:70, in dict_dir(obj)
     62 for key in dir2(obj):
     63    # This seemingly unnecessary try/except is actually needed
     64    # because there is code out there with metaclasses that
   (...)
     67    # object's dictionary.  Properties can actually do the same
     68    # thing.  In particular, Traits use this pattern
     69    try:
---> 70        ns[key] = getattr(obj, key)
     71    except AttributeError:
     72        pass

File ~/git/dask/dask/dataframe/core.py:4417, in DataFrame.empty(self)
   4414 @property
   4415 def empty(self):
   4416     # raise AttributeNotImplementedError(
-> 4417     raise NotImplementedError(
   4418         "Checking whether a Dask DataFrame has any rows may be expensive. "
   4419         "However, checking the number of columns is fast. "
   4420         "Depending on which of these results you need, use either "
   4421         "`len(df.index) == 0` or `len(df.columns) == 0`"
   4422     )

NotImplementedError: Checking whether a Dask DataFrame has any rows may be expensive. However, checking the number of columns is fast. Depending on which of these results you need, use either `len(df.index) == 0` or `len(df.columns) == 0`
```
So, this PR introduces `AttributeNotImplementedError`, which is derived from both `AttributeError` and `NotImplementedError`, and now IPython glob search works :tada:

I wasn't sure where to put `AttributeNotImplementedError` 🤷‍♂️ 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
  - **Note:** I have mypy errors locally that look unrelated.

Fun fact: `df.dtypes.at.*?` doesn't work with pandas or dask dataframes.