### PR TITLE
Use math.prod instead of np.prod on lists, tuples, and iters

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1624,7 +1624,7 @@ class Array(DaskMethodsMixin):
             cbytes = None
         elif not math.isnan(self.nbytes):
             nbytes = format_bytes(self.nbytes)
-            cbytes = format_bytes(np.prod(self.chunksize) * self.dtype.itemsize)
+            cbytes = format_bytes(math.prod(self.chunksize) * self.dtype.itemsize)
         else:
             nbytes = "unknown"
             cbytes = "unknown"
@@ -3017,7 +3017,7 @@ def _compute_multiplier(limit: int, dtype, largest_block: int, result):
         limit
         / dtype.itemsize
         / largest_block
-        / np.prod(list(r if r != 0 else 1 for r in result.values()))
+        / math.prod(r for r in result.values() if r != 0)
     )
 
 
@@ -3083,8 +3083,8 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
 
     limit = max(1, limit)
 
-    largest_block = np.prod(
-        [cs if isinstance(cs, Number) else max(cs) for cs in chunks if cs != "auto"]
+    largest_block = math.prod(
+        cs if isinstance(cs, Number) else max(cs) for cs in chunks if cs != "auto"
     )
 
     if previous_chunks:
@@ -3831,7 +3831,7 @@ def unify_chunks(*args, **kwargs):
             nameinds.append((a, ind))
 
     chunkss = broadcast_dimensions(nameinds, blockdim_dict, consolidate=common_blockdim)
-    nparts = np.prod(list(map(len, chunkss.values())))
+    nparts = math.prod(map(len, chunkss.values()))
 
     if warn and nparts and nparts >= max_parts * 10:
         warnings.warn(
@@ -5682,11 +5682,11 @@ class BlockView:
             return NotImplemented
 
     @property
-    def size(self) -> int | np.signedinteger:
+    def size(self) -> int:
         """
         The total number of blocks in the array.
         """
-        return np.prod(self.shape)
+        return math.prod(self.shape)
 
     @property
     def shape(self) -> tuple[int, ...]:

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -496,7 +496,7 @@ def indices(dimensions, dtype=int, chunks="auto"):
         xi.append(arange(dimensions[i], dtype=dtype, chunks=(chunks[i],)))
 
     grid = []
-    if np.prod(dimensions):
+    if all(dimensions):
         grid = meshgrid(*xi, indexing="ij")
 
     if grid:

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1,10 +1,10 @@
 import builtins
 import contextlib
+import math
 import operator
 from collections.abc import Iterable
 from functools import partial
 from itertools import product, repeat
-from math import ceil, factorial, log, log2
 from numbers import Integral, Number
 
 import numpy as np
@@ -266,7 +266,7 @@ def _tree_reduce(
     depth = 1
     for i, n in enumerate(x.numblocks):
         if i in split_every and split_every[i] != 1:
-            depth = int(builtins.max(depth, ceil(log(n, split_every[i]))))
+            depth = int(builtins.max(depth, math.ceil(math.log(n, split_every[i]))))
     func = partial(combine or aggregate, axis=axis, keepdims=True)
     if concatenate:
         func = compose(func, partial(_concatenate2, axes=sorted(axis)))
@@ -624,7 +624,7 @@ def numel(x, **kwargs):
     dtype = kwargs.get("dtype", np.float64)
 
     if axis is None:
-        prod = np.prod(shape, dtype=dtype)
+        prod = math.prod(shape, dtype=dtype)
         return (
             np.full_like(x, prod, shape=(1,) * len(shape), dtype=dtype)
             if keepdims is True
@@ -634,7 +634,7 @@ def numel(x, **kwargs):
     if not isinstance(axis, tuple or list):
         axis = [axis]
 
-    prod = np.prod([shape[dim] for dim in axis])
+    prod = math.prod(shape[dim] for dim in axis)
     if keepdims is True:
         new_shape = tuple(
             shape[dim] if dim not in axis else 1 for dim in range(len(shape))
@@ -763,7 +763,7 @@ def _moment_helper(Ms, ns, inner_term, order, sum, axis, kwargs):
         ns * inner_term**order, axis=axis, **kwargs
     )
     for k in range(1, order - 1):
-        coeff = factorial(order) / (factorial(k) * factorial(order - k))
+        coeff = math.factorial(order) / (math.factorial(k) * math.factorial(order - k))
         M += coeff * sum(Ms[..., order - k - 2] * inner_term**k, axis=axis, **kwargs)
     return M
 
@@ -1355,7 +1355,7 @@ def prefixscan_blelloch(func, preop, binop, x, axis=None, dtype=None, out=None):
         # Downsweep
         # With `n_vals == 3`, we would have `stride = 1` and `stride = 0`, but we need
         # to do a downsweep iteration, so make sure stride2 is at least 2.
-        stride2 = builtins.max(2, 2 ** ceil(log2(n_vals // 2)))
+        stride2 = builtins.max(2, 2 ** math.ceil(math.log2(n_vals // 2)))
         stride = stride2 // 2
         while stride > 0:
             for i in range(stride2 + stride - 1, n_vals, stride2):
@@ -1433,7 +1433,8 @@ def cumreduction(
           This method may be faster or more memory efficient depending on workload,
           scheduler, and hardware.  More benchmarking is necessary.
     preop: callable, optional
-        Function used by 'blelloch' method like ``np.cumsum->np.sum`` or ``np.cumprod->np.prod``
+        Function used by 'blelloch' method,
+        like ``np.cumsum->np.sum`` or ``np.cumprod->np.prod``
 
     Returns
     -------

--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 from collections import Counter
 from functools import reduce
@@ -65,8 +66,8 @@ def reshape_rechunk(inshape, outshape, inchunks):
             if all(len(inchunks[i]) == inshape[i] for i in range(ii)):
                 for i in range(ii + 1):
                     result_inchunks[i] = inchunks[i]
-                result_outchunks[oi] = inchunks[ii] * np.prod(
-                    list(map(len, inchunks[ileft:ii]))
+                result_outchunks[oi] = inchunks[ii] * math.prod(
+                    map(len, inchunks[ileft:ii])
                 )
             else:
                 for i in range(ileft + 1, ii + 1):  # need single-shape dimensions

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -639,7 +639,7 @@ def take(outname, inname, chunks, index, itemsize, axis=0):
     # configured chunk size.
     nbytes = utils.parse_bytes(config.get("array.chunk-size"))
     other_chunks = [chunks[i] for i in range(len(chunks)) if i != axis]
-    other_numel = np.prod([sum(x) for x in other_chunks])
+    other_numel = math.prod(sum(x) for x in other_chunks)
 
     if math.isnan(other_numel) or other_numel == 0:
         warnsize = maxsize = math.inf

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -9,6 +9,7 @@ import pytest
 
 np = pytest.importorskip("numpy")
 
+import math
 import operator
 import os
 import time
@@ -18,7 +19,6 @@ from io import StringIO
 from operator import add, sub
 from threading import Lock
 
-from numpy import nancumprod, nancumsum
 from tlz import concat, countby, merge
 from tlz.curried import identity
 
@@ -2103,7 +2103,7 @@ def test_store_locks():
             assert False
 
     # Verify number of lock calls
-    nchunks = np.sum([np.prod([len(c) for c in e.chunks]) for e in [a, b]])
+    nchunks = sum(math.prod(map(len, e.chunks)) for e in (a, b))
     for c in (False, True):
         at = np.zeros(shape=(10, 10))
         bt = np.zeros(shape=(10, 10))
@@ -3474,15 +3474,15 @@ def test_cumulative():
     assert_eq(x.cumsum(axis=0), np.arange(20).cumsum())
     assert_eq(x.cumprod(axis=0), np.arange(20).cumprod())
 
-    assert_eq(da.nancumsum(x, axis=0), nancumsum(np.arange(20)))
-    assert_eq(da.nancumprod(x, axis=0), nancumprod(np.arange(20)))
+    assert_eq(da.nancumsum(x, axis=0), np.nancumsum(np.arange(20)))
+    assert_eq(da.nancumprod(x, axis=0), np.nancumprod(np.arange(20)))
 
     a = np.random.random(20)
     rs = np.random.RandomState(0)
     a[rs.rand(*a.shape) < 0.5] = np.nan
     x = da.from_array(a, chunks=5)
-    assert_eq(da.nancumsum(x, axis=0), nancumsum(a))
-    assert_eq(da.nancumprod(x, axis=0), nancumprod(a))
+    assert_eq(da.nancumsum(x, axis=0), np.nancumsum(a))
+    assert_eq(da.nancumprod(x, axis=0), np.nancumprod(a))
 
     a = np.random.random((20, 24))
     x = da.from_array(a, chunks=(6, 5))
@@ -3491,19 +3491,19 @@ def test_cumulative():
     assert_eq(x.cumprod(axis=0), a.cumprod(axis=0))
     assert_eq(x.cumprod(axis=1), a.cumprod(axis=1))
 
-    assert_eq(da.nancumsum(x, axis=0), nancumsum(a, axis=0))
-    assert_eq(da.nancumsum(x, axis=1), nancumsum(a, axis=1))
-    assert_eq(da.nancumprod(x, axis=0), nancumprod(a, axis=0))
-    assert_eq(da.nancumprod(x, axis=1), nancumprod(a, axis=1))
+    assert_eq(da.nancumsum(x, axis=0), np.nancumsum(a, axis=0))
+    assert_eq(da.nancumsum(x, axis=1), np.nancumsum(a, axis=1))
+    assert_eq(da.nancumprod(x, axis=0), np.nancumprod(a, axis=0))
+    assert_eq(da.nancumprod(x, axis=1), np.nancumprod(a, axis=1))
 
     a = np.random.random((20, 24))
     rs = np.random.RandomState(0)
     a[rs.rand(*a.shape) < 0.5] = np.nan
     x = da.from_array(a, chunks=(6, 5))
-    assert_eq(da.nancumsum(x, axis=0), nancumsum(a, axis=0))
-    assert_eq(da.nancumsum(x, axis=1), nancumsum(a, axis=1))
-    assert_eq(da.nancumprod(x, axis=0), nancumprod(a, axis=0))
-    assert_eq(da.nancumprod(x, axis=1), nancumprod(a, axis=1))
+    assert_eq(da.nancumsum(x, axis=0), np.nancumsum(a, axis=0))
+    assert_eq(da.nancumsum(x, axis=1), np.nancumsum(a, axis=1))
+    assert_eq(da.nancumprod(x, axis=0), np.nancumprod(a, axis=0))
+    assert_eq(da.nancumprod(x, axis=1), np.nancumprod(a, axis=1))
 
     a = np.random.random((20, 24, 13))
     x = da.from_array(a, chunks=(6, 5, 4))
@@ -3511,16 +3511,16 @@ def test_cumulative():
         assert_eq(x.cumsum(axis=axis), a.cumsum(axis=axis))
         assert_eq(x.cumprod(axis=axis), a.cumprod(axis=axis))
 
-        assert_eq(da.nancumsum(x, axis=axis), nancumsum(a, axis=axis))
-        assert_eq(da.nancumprod(x, axis=axis), nancumprod(a, axis=axis))
+        assert_eq(da.nancumsum(x, axis=axis), np.nancumsum(a, axis=axis))
+        assert_eq(da.nancumprod(x, axis=axis), np.nancumprod(a, axis=axis))
 
     a = np.random.random((20, 24, 13))
     rs = np.random.RandomState(0)
     a[rs.rand(*a.shape) < 0.5] = np.nan
     x = da.from_array(a, chunks=(6, 5, 4))
     for axis in [0, 1, 2, -1, -2, -3]:
-        assert_eq(da.nancumsum(x, axis=axis), nancumsum(a, axis=axis))
-        assert_eq(da.nancumprod(x, axis=axis), nancumprod(a, axis=axis))
+        assert_eq(da.nancumsum(x, axis=axis), np.nancumsum(a, axis=axis))
+        assert_eq(da.nancumprod(x, axis=axis), np.nancumprod(a, axis=axis))
 
     with pytest.raises(ValueError):
         x.cumsum(axis=3)
@@ -4758,7 +4758,7 @@ def test_blockview():
     assert_eq(blockview[[0, 1, 2]], x[:6])
     assert_eq(blockview[[3, 0, 2]], np.array([6, 7, 0, 1, 4, 5]))
     assert_eq(blockview.shape, tuple(map(len, x.chunks)))
-    assert_eq(blockview.size, np.prod(blockview.shape))
+    assert_eq(blockview.size, math.prod(blockview.shape))
     assert_eq(
         blockview.ravel(), [blockview[idx] for idx in np.ndindex(blockview.shape)]
     )
@@ -4769,7 +4769,7 @@ def test_blockview():
     assert_eq(blockview[0, :3], x[:4, :15])
     assert_eq(blockview[:, :3], x[:, :15])
     assert_eq(blockview.shape, tuple(map(len, x.chunks)))
-    assert_eq(blockview.size, np.prod(blockview.shape))
+    assert_eq(blockview.size, math.prod(blockview.shape))
     assert_eq(
         blockview.ravel(), [blockview[idx] for idx in np.ndindex(blockview.shape)]
     )
@@ -4778,7 +4778,7 @@ def test_blockview():
     blockview = BlockView(x)
     assert_eq(blockview[0, :, 0], np.ones((10, 40, 10)))
     assert_eq(blockview.shape, tuple(map(len, x.chunks)))
-    assert_eq(blockview.size, np.prod(blockview.shape))
+    assert_eq(blockview.size, math.prod(blockview.shape))
     assert_eq(
         blockview.ravel(), [blockview[idx] for idx in np.ndindex(blockview.shape)]
     )


### PR DESCRIPTION
math.prod requires Python 3.8+, so historically it wasn't used in the codebase.
It's 20~40x faster than numpy.prod on pure python lists and tuples, and it doesn't need to convert iterators to lists, resulting in cleaner code.

```
>>> a = (1,2,3)
>>> %timeit numpy.prod(a)
3.27 µs ± 51.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
>>> %timeit math.prod(a)
92.5 ns ± 0.38 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
>>> %timeit numpy.prod(list(range(1, 4)))
3.42 µs ± 19.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
>>> %timeit math.prod(range(1, 4))
159 ns ± 0.677 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```