### PR TITLE
#9238: _meta is lost during serialization.

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1376,7 +1376,7 @@ class Array(DaskMethodsMixin):
         return self
 
     def __reduce__(self):
-        return (Array, (self.dask, self.name, self.chunks, self.dtype))
+        return (Array, (self.dask, self.name, self.chunks, self.dtype, self._meta))
 
     def __dask_graph__(self):
         return self.dask

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3608,6 +3608,12 @@ def test_array_picklable(array):
     a2 = loads(dumps(array))
     assert_eq(array, a2)
 
+    a3 = da.ma.masked_equal(array, 0)
+    assert isinstance(a3._meta, np.ma.MaskedArray)
+    a4 = loads(dumps(a3))
+    assert_eq(a3, a4)
+    assert isinstance(a4._meta, np.ma.MaskedArray)
+
 
 def test_from_array_raises_on_bad_chunks():
     x = np.ones(10)


### PR DESCRIPTION
The `_meta` attribute is calculated from scratch after serialization. If the handled array is a masked array, the `_meta` attribute stores the wrong information about the type of array handled.

This pull request simply adds the `_meta` attribute to the result of the `__reduce__` method. The `test_array_picklable` test is enhanced to test the serialization of a masked array and to check that the `_meta` attribute remains constant in this situation.

- [X] Closes #9238
- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`
