### PR TITLE
Add LeafObject layer for simple Delayed objects

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1624,7 +1624,7 @@ class Array(DaskMethodsMixin):
             cbytes = None
         elif not math.isnan(self.nbytes):
             nbytes = format_bytes(self.nbytes)
-            cbytes = format_bytes(np.prod(self.chunksize) * self.dtype.itemsize)
+            cbytes = format_bytes(math.prod(self.chunksize) * self.dtype.itemsize)
         else:
             nbytes = "unknown"
             cbytes = "unknown"
@@ -3017,7 +3017,7 @@ def _compute_multiplier(limit: int, dtype, largest_block: int, result):
         limit
         / dtype.itemsize
         / largest_block
-        / np.prod(list(r if r != 0 else 1 for r in result.values()))
+        / math.prod(r for r in result.values() if r)
     )
 
 
@@ -3083,8 +3083,8 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
 
     limit = max(1, limit)
 
-    largest_block = np.prod(
-        [cs if isinstance(cs, Number) else max(cs) for cs in chunks if cs != "auto"]
+    largest_block = math.prod(
+        cs if isinstance(cs, Number) else max(cs) for cs in chunks if cs != "auto"
     )
 
     if previous_chunks:
@@ -3831,7 +3831,7 @@ def unify_chunks(*args, **kwargs):
             nameinds.append((a, ind))
 
     chunkss = broadcast_dimensions(nameinds, blockdim_dict, consolidate=common_blockdim)
-    nparts = np.prod(list(map(len, chunkss.values())))
+    nparts = math.prod(map(len, chunkss.values()))
 
     if warn and nparts and nparts >= max_parts * 10:
         warnings.warn(
@@ -5686,7 +5686,7 @@ class BlockView:
         """
         The total number of blocks in the array.
         """
-        return np.prod(self.shape)
+        return math.prod(self.shape)
 
     @property
     def shape(self) -> tuple[int, ...]:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3086,7 +3086,10 @@ Dask Name: {name}, {task} tasks"""
         # - avoid serializing data in every task
         # - avoid cost of traversal of large list in optimizations
         return self.map_partitions(
-            M.isin, delayed(values), meta=meta, enforce_metadata=False
+            M.isin,
+            delayed(values),
+            meta=meta,
+            enforce_metadata=False,
         )
 
     @derived_from(pd.DataFrame)

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -457,9 +457,11 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
             name = f"{prefix}-{token}"
         return DelayedLeaf(obj, name, pure=pure, nout=nout)
     else:
+        from dask.layers import LeafObject
+
         if not name:
             name = f"{type(obj).__name__}-{tokenize(task, pure=pure)}"
-        layer = {name: task}
+        layer = {name: task} if collections else LeafObject(name, task)
         graph = HighLevelGraph.from_collections(name, layer, dependencies=collections)
         return Delayed(name, graph, nout)
 
@@ -655,8 +657,10 @@ class DelayedLeaf(Delayed):
 
     @property
     def dask(self):
+        from dask.layers import LeafObject
+
         return HighLevelGraph.from_collections(
-            self._key, {self._key: self._obj}, dependencies=()
+            self._key, LeafObject(self._key, self._obj), dependencies=()
         )
 
     def __call__(self, *args, **kwargs):

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -1563,8 +1563,8 @@ class DataFrameTreeReduction(Layer):
 class LeafObject(Layer):
     """LeafObject Layer
 
-    This layer class is used by `delayed` to wrap
-    explicit "leaf" objects.
+    This class is used by ``dask.delayed`` to represent
+    an explicit Python object as a un-materialized Layer.
 
     Parameters
     ----------
@@ -1620,7 +1620,7 @@ class LeafObject(Layer):
         # a new LeafObject wrapping `None`.
         # There are no dependencies to return
         if self.name not in keys:
-            return LeafObject('empty-'+self.name, None), {}
+            return LeafObject("empty-" + self.name, None), {}
         return self, {}
 
     def __dask_distributed_pack__(self, *args, **kwargs):
@@ -1638,8 +1638,6 @@ class LeafObject(Layer):
 
         # Must use `to_serialize` on the entire task
         # and return empty deps
-        dsk = {
-            state["name"]: to_serialize(state["object"])
-        }
+        dsk = {state["name"]: to_serialize(state["object"])}
         deps = {k: set() for k in dsk.keys()}
         return {"dsk": dsk, "deps": deps}


### PR DESCRIPTION
Although new `Layer` developent is currently ["frozen"](https://github.com/dask/dask/issues/9159), I feel that the addition of a simple `LeafObject` layer (for `delayed(<input-object>)` usage) is worthwhile.  This PR will avoid producing a `MaterializedLayer` for simple `Delayed` patterns, and will instead produce simpler `LeafObject` layers.

Note that this simple change makes https://github.com/dask-contrib/dask-sql/issues/607 significant easier to address.
