### PR TITLE
Return dask array if all axes are squeezed

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1934,6 +1934,11 @@ def squeeze(a, axis=None):
 
     sl = tuple(0 if i in axis else slice(None) for i, s in enumerate(a.shape))
 
+    # Return 0d Dask Array if all axes are squeezed,
+    # to be consistent with NumPy
+    if sl == 0 and a.shape == (1,):
+        return a
+
     a = a[sl]
 
     return a

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1935,9 +1935,11 @@ def squeeze(a, axis=None):
     sl = tuple(0 if i in axis else slice(None) for i, s in enumerate(a.shape))
 
     # Return 0d Dask Array if all axes are squeezed,
-    # to be consistent with NumPy
-    if sl == 0 and a.shape == (1,):
-        return a
+    # to be consistent with NumPy. Ref: https://github.com/dask/dask/issues/9183#issuecomment-1155626619
+    if all(s == 0 for s in sl) and all(s == 1 for s in a.shape):
+        return a.map_blocks(
+            np.squeeze, meta=a._meta, drop_axis=tuple(range(len(a.shape)))
+        )
 
     a = a[sl]
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1489,13 +1489,14 @@ def test_squeeze(is_func, axis):
     assert d_s.chunks == exp_d_s_chunks
 
 
-def test_squeeze_1d_array():
-    a = np.empty(1)
-    a[0] = 2
+@pytest.mark.parametrize("shape", [(1,), (1, 1)])
+def test_squeeze_1d_array(shape):
+    a = np.full(shape=shape, fill_value=2)
     a_s = np.squeeze(a)
     d = da.from_array(a, chunks=(1))
     d_s = da.squeeze(d)
     assert isinstance(d_s, da.Array)
+    assert isinstance(d_s.compute(), np.ndarray)
     assert_eq(d_s, a_s)
 
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1489,6 +1489,16 @@ def test_squeeze(is_func, axis):
     assert d_s.chunks == exp_d_s_chunks
 
 
+def test_squeeze_1d_array():
+    a = np.empty(1)
+    a[0] = 2
+    a_s = np.squeeze(a)
+    d = da.from_array(a, chunks=(1))
+    d_s = da.squeeze(d)
+    assert isinstance(d_s, da.Array)
+    assert_eq(d_s, a_s)
+
+
 def test_vstack():
     x = np.arange(5)
     y = np.ones(5)


### PR DESCRIPTION
- [x] Closes #9183
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
