### PR TITLE
Fix bug when filtering on partitioned column with pyarrow

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1160,7 +1160,7 @@ class ArrowDatasetEngine(Engine):
 
         # Check if this is a very simple case where we can just return
         # the path names
-        if gather_statistics is False and not split_row_groups:
+        if gather_statistics is False and not (split_row_groups or filters):
             return (
                 [
                     {"piece": (full_path, None, None)}

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3442,7 +3442,7 @@ def test_pyarrow_dataset_filter_on_partitioned(tmpdir, engine):
     read_ddf["part"] = read_ddf["part"].astype("object")
     assert_eq(df.iloc[2:3], read_ddf)
 
-    # Check that List[List[Tuple]] filter are aplied.
+    # Check that List[List[Tuple]] filters are aplied.
     # (fastparquet doesn't support this format)
     if engine == "pyarrow":
         read_ddf = dd.read_parquet(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3430,7 +3430,6 @@ def test_pyarrow_dataset_filter_on_partitioned(tmpdir, engine):
         lambda x: pd.DataFrame({"a": [x], "b": [x]}),
         "abcdefg",
     )
-    ddf["b"] = ddf["b"].astype("category")
     ddf.to_parquet(tmpdir, engine=engine, partition_on=["b"])
 
     # Check List[Tuple] filters
@@ -3440,10 +3439,12 @@ def test_pyarrow_dataset_filter_on_partitioned(tmpdir, engine):
         filters=[("b", "==", "c")],
     )
     assert read_ddf.npartitions == 1
+    # Select column "a" to avoid an
+    # unnecessary object-category comparison
     assert_eq(read_ddf["a"], ddf.partitions[2]["a"])
 
-    # Check List[List[Tuple]] filters
-    # for "pyarrow" engine only
+    # Check List[List[Tuple]] filter for pyarrow only
+    # (fastparquet doesn't support this format)
     if engine == "pyarrow":
         read_ddf = dd.read_parquet(
             tmpdir,

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3427,7 +3427,6 @@ def test_pyarrow_dataset_filter_partitioned(tmpdir, split_row_groups):
 def test_pyarrow_dataset_filter_on_partitioned(tmpdir, engine):
     # See: https://github.com/dask/dask/issues/9246
     df = pd.DataFrame({"val": range(7), "part": list("abcdefg")})
-    df["part"] = df["part"].astype("category")
     ddf = dd.from_map(
         lambda i: df.iloc[i : i + 1],
         range(7),
@@ -3440,6 +3439,7 @@ def test_pyarrow_dataset_filter_on_partitioned(tmpdir, engine):
         engine=engine,
         filters=[("part", "==", "c")],
     )
+    read_ddf["part"] = read_ddf["part"].astype("object")
     assert_eq(df.iloc[2:3], read_ddf)
 
     # Check that List[List[Tuple]] filter are aplied.
@@ -3450,6 +3450,7 @@ def test_pyarrow_dataset_filter_on_partitioned(tmpdir, engine):
             engine=engine,
             filters=[[("part", "==", "c")]],
         )
+        read_ddf["part"] = read_ddf["part"].astype("object")
         assert_eq(df.iloc[2:3], read_ddf)
 
 


### PR DESCRIPTION
- [x] Closes #9246
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Adds test coverage for filtering on a partitioned column, and fixes #9246