### PR TITLE
Add typing to common methods

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -24,7 +24,7 @@ from itertools import product, zip_longest
 from numbers import Integral, Number
 from operator import add, mul
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 import numpy as np
 from fsspec import get_mapper
@@ -85,13 +85,7 @@ from dask.utils import (
 )
 from dask.widgets import get_template
 
-if TYPE_CHECKING:
-    from enum import Enum
-
-    class _Nan(Enum):
-        nan: np.nan
-
-    T_IntOrNaN = Union[int, Literal[_Nan.nan]]
+T_IntOrNaN = Union[int, float]  # Should be Union[int, Literal[np.nan]]
 
 DEFAULT_GET = named_schedulers.get("threads", named_schedulers["sync"])
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -85,7 +85,14 @@ from dask.utils import (
 )
 from dask.widgets import get_template
 
-T_IntOrNaN = Union[int, Literal[np.nan]]
+if TYPE_CHECKING:
+    from enum import Enum
+
+    class _Nan(Enum):
+        nan: np.nan
+
+
+    T_IntOrNaN = Union[int, Literal[_Nan.nan]]
 
 DEFAULT_GET = named_schedulers.get("threads", named_schedulers["sync"])
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -24,7 +24,7 @@ from itertools import product, zip_longest
 from numbers import Integral, Number
 from operator import add, mul
 from threading import Lock
-from typing import Any, Literal, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast
 
 import numpy as np
 from fsspec import get_mapper

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -24,7 +24,7 @@ from itertools import product, zip_longest
 from numbers import Integral, Number
 from operator import add, mul
 from threading import Lock
-from typing import Any, TypeVar, cast
+from typing import Any, Literal, TypeVar, Union, cast
 
 import numpy as np
 from fsspec import get_mapper
@@ -84,6 +84,8 @@ from dask.utils import (
     typename,
 )
 from dask.widgets import get_template
+
+T_IntOrNaN = Union[int, Literal[np.nan]]
 
 DEFAULT_GET = named_schedulers.get("threads", named_schedulers["sync"])
 
@@ -1499,11 +1501,11 @@ class Array(DaskMethodsMixin):
         return x
 
     @cached_property
-    def shape(self) -> tuple[int, ...]:
+    def shape(self) -> tuple[T_IntOrNaN, ...]:
         return tuple(cached_cumsum(c, initial_zero=True)[-1] for c in self.chunks)
 
     @property
-    def chunksize(self):
+    def chunksize(self) -> tuple[T_IntOrNaN, ...]:
         return tuple(max(c) for c in self.chunks)
 
     @property
@@ -1641,12 +1643,12 @@ class Array(DaskMethodsMixin):
         return len(self.shape)
 
     @cached_property
-    def size(self) -> int:
+    def size(self) -> T_IntOrNaN:
         """Number of elements in array"""
         return reduce(mul, self.shape, 1)
 
     @property
-    def nbytes(self) -> int:
+    def nbytes(self) -> T_IntOrNaN:
         """Number of bytes in array"""
         return self.size * self.dtype.itemsize
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -91,7 +91,6 @@ if TYPE_CHECKING:
     class _Nan(Enum):
         nan: np.nan
 
-
     T_IntOrNaN = Union[int, Literal[_Nan.nan]]
 
 DEFAULT_GET = named_schedulers.get("threads", named_schedulers["sync"])

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1499,7 +1499,7 @@ class Array(DaskMethodsMixin):
         return x
 
     @cached_property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         return tuple(cached_cumsum(c, initial_zero=True)[-1] for c in self.chunks)
 
     @property
@@ -1637,21 +1637,21 @@ class Array(DaskMethodsMixin):
         )
 
     @cached_property
-    def ndim(self):
+    def ndim(self) -> int:
         return len(self.shape)
 
     @cached_property
-    def size(self):
+    def size(self) -> int:
         """Number of elements in array"""
         return reduce(mul, self.shape, 1)
 
     @property
-    def nbytes(self):
+    def nbytes(self) -> int:
         """Number of bytes in array"""
         return self.size * self.dtype.itemsize
 
     @property
-    def itemsize(self):
+    def itemsize(self) -> int:
         """Length of one array element in bytes"""
         return self.dtype.itemsize
 


### PR DESCRIPTION
Type a few common methods.

Usually `shape` will only contain (positive) integers, but if you mask dask arrays with boolean arrays the will become undefined and NaN is used to indicate that. 
```python
import dask.array as da

a = da.array([1, 2, 3])
m = a > 1
b = a[m]

b.shape
Out[118]: (nan,)
```

Unfortunately it appears to not  be possible to use `Literal[np.nan]`, the solution seems to be just allow floats as well. This issue seems relevant: https://github.com/python/typing/issues/1160 