### PR TITLE
Generic delayed

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -61,7 +61,6 @@ from dask.delayed import Delayed, delayed
 from dask.highlevelgraph import HighLevelGraph, MaterializedLayer
 from dask.layers import ArraySliceDep, reshapelist
 from dask.sizeof import sizeof
-from dask.typing import DaskCollection
 from dask.utils import (
     IndexCallable,
     M,
@@ -1211,7 +1210,9 @@ def store(
         store_dsk = HighLevelGraph(layers, dependencies)
         load_store_dsk: HighLevelGraph | dict[tuple, Any] = store_dsk
         if compute:
-            store_dlyds: Iterable[Delayed] = [Delayed(k, store_dsk, layer=k[0]) for k in map_keys]
+            store_dlyds: Iterable[Delayed] = [
+                Delayed(k, store_dsk, layer=k[0]) for k in map_keys
+            ]
             store_dlyds = persist(*store_dlyds, **kwargs)
             store_dsk_2 = HighLevelGraph.merge(*[e.dask for e in store_dlyds])
             load_store_dsk = retrieve_from_ooc(map_keys, store_dsk, store_dsk_2)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -61,6 +61,7 @@ from dask.delayed import Delayed, delayed
 from dask.highlevelgraph import HighLevelGraph, MaterializedLayer
 from dask.layers import ArraySliceDep, reshapelist
 from dask.sizeof import sizeof
+from dask.typing import DaskCollection
 from dask.utils import (
     IndexCallable,
     M,
@@ -1210,7 +1211,7 @@ def store(
         store_dsk = HighLevelGraph(layers, dependencies)
         load_store_dsk: HighLevelGraph | dict[tuple, Any] = store_dsk
         if compute:
-            store_dlyds = [Delayed(k, store_dsk, layer=k[0]) for k in map_keys]
+            store_dlyds: Iterable[Delayed] = [Delayed(k, store_dsk, layer=k[0]) for k in map_keys]
             store_dlyds = persist(*store_dlyds, **kwargs)
             store_dsk_2 = HighLevelGraph.merge(*[e.dask for e in store_dlyds])
             load_store_dsk = retrieve_from_ooc(map_keys, store_dsk, store_dsk_2)

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -180,7 +180,7 @@ _full_like = w_like(np.full, func_like=np.full_like)
 
 # workaround for numpy doctest failure: https://github.com/numpy/numpy/pull/17472
 
-_full.__doc__ = _full.__doc__.replace( # type: ignore[union-attr]
+_full.__doc__ = _full.__doc__.replace(  # type: ignore[union-attr]
     "array([0.1,  0.1,  0.1,  0.1,  0.1,  0.1])",
     "array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])",
 )

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -179,7 +179,8 @@ _full = w(broadcast_trick(np.full_like))
 _full_like = w_like(np.full, func_like=np.full_like)
 
 # workaround for numpy doctest failure: https://github.com/numpy/numpy/pull/17472
-_full.__doc__ = _full.__doc__.replace(
+
+_full.__doc__ = _full.__doc__.replace( # type: ignore[union-attr]
     "array([0.1,  0.1,  0.1,  0.1,  0.1,  0.1])",
     "array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])",
 )

--- a/dask/bag/text.py
+++ b/dask/bag/text.py
@@ -6,10 +6,10 @@ from tlz import concat
 
 from dask.bag.core import from_delayed
 from dask.bytes import read_bytes
-from dask.delayed import delayed
+from dask.delayed import delayed as original_delayed
 from dask.utils import parse_bytes, system_encoding
 
-delayed = delayed(pure=True)
+delayed = original_delayed(pure=True)
 
 
 def read_text(

--- a/dask/base.py
+++ b/dask/base.py
@@ -16,7 +16,7 @@ from concurrent.futures import Executor
 from contextlib import contextmanager
 from enum import Enum
 from functools import partial
-from numbers import Integral, Number, Real
+from numbers import Number
 from operator import getitem
 from typing import (
     TYPE_CHECKING,
@@ -33,9 +33,9 @@ from typing import (
 )
 
 from packaging.version import parse as parse_version
-from tlz import Curry, curry, groupby, identity, merge
+from tlz import curry, groupby, identity, merge
 from tlz.functoolz import Compose
-from typing_extensions import Self, TypeAlias, TypeGuard, Unpack
+from typing_extensions import TypeAlias, TypeGuard
 
 from dask import config, local
 from dask.compatibility import _EMSCRIPTEN, _PY_VERSION
@@ -894,7 +894,13 @@ def visualize(
         raise ValueError(f"Visualization engine {engine} not recognized")
 
 
-def persist(*args: Any, traverse: bool=True, optimize_graph: bool=True, scheduler=None, **kwargs) -> Iterable:
+def persist(
+    *args: Any,
+    traverse: bool = True,
+    optimize_graph: bool = True,
+    scheduler=None,
+    **kwargs,
+) -> Iterable:
     """Persist multiple Dask collections into memory
 
     This turns lazy Dask collections into Dask collections with the same
@@ -1432,24 +1438,46 @@ or with a Dask client
     x.compute(scheduler=client)
 """.strip()
 
+
 class Client(Protocol):
     def get(self) -> Any:
         ...
+
 
 def is_client(val) -> TypeGuard[Client]:
     return "Client" in type(val).__name__ and hasattr(val, "get")
 
 
 @overload
-def get_scheduler(get:None = None, scheduler: None = None, collections: None=None, cls=None) -> None:
+def get_scheduler(
+    get: None = None, scheduler: None = None, collections: None = None, cls=None
+) -> None:
     ...
+
+
 @overload
-def get_scheduler(*, get=None, scheduler: Callable | Client | str | Executor, collections: Collection[DaskCollection] | None=None, cls=None) -> Callable:
+def get_scheduler(
+    *,
+    get=None,
+    scheduler: Callable | Client | str | Executor,
+    collections: Collection[DaskCollection] | None = None,
+    cls=None,
+) -> Callable:
     ...
+
+
 @overload
-def get_scheduler(*, get=None, scheduler: Callable | Client | str | Executor |None= None, collections: Collection[DaskCollection], cls=None) -> Callable:
+def get_scheduler(
+    *,
+    get=None,
+    scheduler: Callable | Client | str | Executor | None = None,
+    collections: Collection[DaskCollection],
+    cls=None,
+) -> Callable:
     ...
-def get_scheduler(get=None, scheduler = None, collections=None, cls=None):
+
+
+def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
     """Get scheduler function
 
     There are various ways to specify the scheduler to use:

--- a/dask/core.py
+++ b/dask/core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Generic, NewType, TypeVar, overload
+from typing import Any, TypeVar, overload
 
 from typing_extensions import TypeGuard
 

--- a/dask/core.py
+++ b/dask/core.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 from collections import defaultdict
-from typing import Any, overload, NewType, TypeVar, Generic
+from typing import Any, Generic, NewType, TypeVar, overload
+
 from typing_extensions import TypeGuard
 
 from dask.base import DaskGraph
@@ -85,18 +87,26 @@ def lists_to_tuples(res, keys):
         return tuple(lists_to_tuples(r, k) for r, k in zip(res, keys))
     return res
 
+
 T = TypeVar("T")
+
 
 @overload
 def _execute_task(arg: list, cache: dict, dsk: None = None) -> list:
     ...
+
+
 @overload
 def _execute_task(arg: Task, cache: dict, dsk: None = None) -> Any:
     ...
+
+
 @overload
 def _execute_task(arg: T, cache: dict, dsk: None = None) -> T:
     ...
-def _execute_task(arg, cache, dsk = None):
+
+
+def _execute_task(arg, cache, dsk=None):
     """Do the actual work of collecting data and executing a function
 
     Examples
@@ -143,11 +153,15 @@ def _execute_task(arg, cache, dsk = None):
 
 
 @overload
-def get(dsk: DaskGraph, out: list, cache: dict | None=None) -> tuple:
+def get(dsk: DaskGraph, out: list, cache: dict | None = None) -> tuple:
     ...
+
+
 @overload
-def get(dsk: DaskGraph, out: Any, cache: dict | None=None) -> Any:
+def get(dsk: DaskGraph, out: Any, cache: dict | None = None) -> Any:
     ...
+
+
 def get(dsk, out, cache=None):
     """Get value from Dask
 

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -16,7 +16,7 @@ PANDAS_GT_140 = PANDAS_VERSION >= parse_version("1.4.0")
 # FIXME: Using `.release` below as versions like `1.5.0.dev0+268.gbe8d1ec880`
 # are less than `1.5.0` with `packaging.version`. Update to use `parse_version("1.5.0")`
 # below once `pandas=1.5.0` is released
-PANDAS_GT_150 = PANDAS_VERSION.release >= (1, 5, 0)
+PANDAS_GT_150 = PANDAS_VERSION.release is not None and PANDAS_VERSION.release >= (1, 5, 0)
 
 import pandas.testing as tm
 

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -16,7 +16,11 @@ PANDAS_GT_140 = PANDAS_VERSION >= parse_version("1.4.0")
 # FIXME: Using `.release` below as versions like `1.5.0.dev0+268.gbe8d1ec880`
 # are less than `1.5.0` with `packaging.version`. Update to use `parse_version("1.5.0")`
 # below once `pandas=1.5.0` is released
-PANDAS_GT_150 = PANDAS_VERSION.release is not None and PANDAS_VERSION.release >= (1, 5, 0)
+PANDAS_GT_150 = PANDAS_VERSION.release is not None and PANDAS_VERSION.release >= (
+    1,
+    5,
+    0,
+)
 
 import pandas.testing as tm
 

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -4,7 +4,7 @@ import uuid
 import warnings
 from collections.abc import Iterator
 from dataclasses import fields, is_dataclass
-from typing import Generic, TypeVar, Any, Optional
+from typing import Any, Callable, Generic, Optional, TypeVar, overload
 
 from tlz import concat, curry, merge, unique
 
@@ -211,7 +211,7 @@ def to_task_dask(expr):
     return expr, {}
 
 
-def tokenize(*args: Any, pure: Optional[bool]=None, **kwargs: Any) -> str:
+def tokenize(*args: Any, pure: Optional[bool] = None, **kwargs: Any) -> str:
     """Mapping function from task -> consistent name.
 
     Parameters
@@ -231,8 +231,36 @@ def tokenize(*args: Any, pure: Optional[bool]=None, **kwargs: Any) -> str:
     else:
         return str(uuid.uuid4())
 
+T = TypeVar("T")
 
-def delayed(obj, name: Optional[str]=None, pure: Optional[bool]=None, nout: Optional[int]=None, traverse: bool=True):
+@overload
+def delayed(
+        obj: Callable[..., T],
+        name: Optional[str] = None,
+        pure: Optional[bool] = None,
+        nout: Optional[int] = None,
+        traverse: bool = True,
+) -> "Delayed[T]":
+    ...
+@overload
+def delayed(
+        name: Optional[str] = None,
+        pure: Optional[bool] = None,
+        nout: Optional[int] = None,
+        traverse: bool = True,
+) -> curry["Delayed"]:
+    ...
+@overload
+def delayed(
+        obj: T,
+        name: Optional[str] = None,
+        pure: Optional[bool] = None,
+        nout: Optional[int] = None,
+        traverse: bool = True,
+) -> "Delayed[T]":
+    ...
+@curry
+def delayed(obj, name= None, pure = None, nout = None, traverse= True):
     """Wraps a function or object to produce a ``Delayed``.
 
     ``Delayed`` objects act as proxies for the object they wrap, but all
@@ -482,12 +510,12 @@ def optimize(dsk, keys, **kwargs):
     return dsk
 
 
-T = TypeVar("T")
 
 class Delayed(DaskMethodsMixin[T], OperatorMethodMixin):
     """Represents a value to be computed by dask.
 
     Equivalent to the output from a single key in a dask graph.
+    The generic type parameter T represents the return value of the ``compute`` method
     """
 
     __slots__ = ("_key", "_dask", "_length", "_layer")

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -4,7 +4,7 @@ import uuid
 import warnings
 from collections.abc import Iterator
 from dataclasses import fields, is_dataclass
-from typing import Any, Callable, Generic, Optional, TypeVar, overload
+from typing import Any, Callable, Optional, TypeVar, overload
 
 from tlz import concat, curry, merge, unique
 
@@ -231,36 +231,44 @@ def tokenize(*args: Any, pure: Optional[bool] = None, **kwargs: Any) -> str:
     else:
         return str(uuid.uuid4())
 
+
 T = TypeVar("T")
+
 
 @overload
 def delayed(
-        obj: Callable[..., T],
-        name: Optional[str] = None,
-        pure: Optional[bool] = None,
-        nout: Optional[int] = None,
-        traverse: bool = True,
+    obj: Callable[..., T],
+    name: Optional[str] = None,
+    pure: Optional[bool] = None,
+    nout: Optional[int] = None,
+    traverse: bool = True,
 ) -> "Delayed[T]":
     ...
+
+
 @overload
 def delayed(
-        name: Optional[str] = None,
-        pure: Optional[bool] = None,
-        nout: Optional[int] = None,
-        traverse: bool = True,
+    name: Optional[str] = None,
+    pure: Optional[bool] = None,
+    nout: Optional[int] = None,
+    traverse: bool = True,
 ) -> curry["Delayed"]:
     ...
+
+
 @overload
 def delayed(
-        obj: T,
-        name: Optional[str] = None,
-        pure: Optional[bool] = None,
-        nout: Optional[int] = None,
-        traverse: bool = True,
+    obj: T,
+    name: Optional[str] = None,
+    pure: Optional[bool] = None,
+    nout: Optional[int] = None,
+    traverse: bool = True,
 ) -> "Delayed[T]":
     ...
+
+
 @curry
-def delayed(obj, name= None, pure = None, nout = None, traverse= True):
+def delayed(obj, name=None, pure=None, nout=None, traverse=True):
     """Wraps a function or object to produce a ``Delayed``.
 
     ``Delayed`` objects act as proxies for the object they wrap, but all
@@ -508,7 +516,6 @@ def optimize(dsk, keys, **kwargs):
         dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
     dsk = dsk.cull(set(flatten(keys)))
     return dsk
-
 
 
 class Delayed(DaskMethodsMixin[T], OperatorMethodMixin):

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -4,6 +4,7 @@ import uuid
 import warnings
 from collections.abc import Iterator
 from dataclasses import fields, is_dataclass
+from typing import Generic, TypeVar, Any, Optional
 
 from tlz import concat, curry, merge, unique
 
@@ -210,7 +211,7 @@ def to_task_dask(expr):
     return expr, {}
 
 
-def tokenize(*args, pure=None, **kwargs):
+def tokenize(*args: Any, pure: Optional[bool]=None, **kwargs: Any) -> str:
     """Mapping function from task -> consistent name.
 
     Parameters
@@ -231,8 +232,7 @@ def tokenize(*args, pure=None, **kwargs):
         return str(uuid.uuid4())
 
 
-@curry
-def delayed(obj, name=None, pure=None, nout=None, traverse=True):
+def delayed(obj, name: Optional[str]=None, pure: Optional[bool]=None, nout: Optional[int]=None, traverse: bool=True):
     """Wraps a function or object to produce a ``Delayed``.
 
     ``Delayed`` objects act as proxies for the object they wrap, but all
@@ -482,7 +482,9 @@ def optimize(dsk, keys, **kwargs):
     return dsk
 
 
-class Delayed(DaskMethodsMixin, OperatorMethodMixin):
+T = TypeVar("T")
+
+class Delayed(DaskMethodsMixin[T], OperatorMethodMixin):
     """Represents a value to be computed by dask.
 
     Equivalent to the output from a single key in a dask graph.

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 import re
 from functools import partial
-from typing import TYPE_CHECKING, Type, Callable, Literal, Union, Optional
+from typing import TYPE_CHECKING, Callable, Literal, Optional, Type, Union
+
 from typing_extensions import TypeAlias
 
 from dask.base import DaskGraph
@@ -11,9 +12,9 @@ from dask.core import get_dependencies, ishashable, istask
 from dask.utils import apply, funcname, import_required, key_split
 
 if TYPE_CHECKING:
-    from IPython.core.display import DisplayObject
-    from ipycytoscape import CytoscapeWidget
     import graphviz
+    from ipycytoscape import CytoscapeWidget
+    from IPython.core.display import DisplayObject
 
 
 def task_label(task):
@@ -128,12 +129,12 @@ def box_label(key, verbose=False):
 
 def to_graphviz(
     dsk: DaskGraph,
-    data_attributes: Optional[dict]=None,
-    function_attributes: Optional[dict]=None,
+    data_attributes: dict | None = None,
+    function_attributes: dict | None = None,
     rankdir=Literal["TB", "BT", "LR", "RL"],
-    graph_attr: Optional[dict]=None,
-    node_attr: Optional[dict]=None,
-    edge_attr: Optional[dict]=None,
+    graph_attr: dict | None = None,
+    node_attr: dict | None = None,
+    edge_attr: dict | None = None,
     collapse_outputs=False,
     verbose=False,
     **kwargs,
@@ -209,10 +210,12 @@ def to_graphviz(
 IPYTHON_IMAGE_FORMATS = frozenset(["jpeg", "png"])
 IPYTHON_NO_DISPLAY_FORMATS = frozenset(["dot", "pdf"])
 
-FormatOption: TypeAlias = Union[Literal["png", "pdf", "dot", "svg", "jpeg", "jpg"], None]
+FormatOption: TypeAlias = Union[
+    Literal["png", "pdf", "dot", "svg", "jpeg", "jpg"], None
+]
 
 
-def _get_display_cls(format: FormatOption) -> Callable[..., Optional[DisplayObject]]:
+def _get_display_cls(format: FormatOption) -> Callable[..., DisplayObject | None]:
     """
     Get the appropriate IPython display class for `format`.
 
@@ -242,7 +245,9 @@ def _get_display_cls(format: FormatOption) -> Callable[..., Optional[DisplayObje
         raise ValueError("Unknown format '%s' passed to `dot_graph`" % format)
 
 
-def dot_graph(dsk: DaskGraph, filename: str="mydask", format: FormatOption=None, **kwargs) -> Optional[DisplayObject]:
+def dot_graph(
+    dsk: DaskGraph, filename: str = "mydask", format: FormatOption = None, **kwargs
+) -> DisplayObject | None:
     """
     Render a task graph using dot.
 
@@ -284,7 +289,7 @@ def dot_graph(dsk: DaskGraph, filename: str="mydask", format: FormatOption=None,
     return graphviz_to_file(g, filename, format)
 
 
-def graphviz_to_file(g, filename, format) -> Optional[DisplayObject]:
+def graphviz_to_file(g, filename, format) -> DisplayObject | None:
     fmts = [".png", ".pdf", ".dot", ".svg", ".jpeg", ".jpg"]
 
     if (

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Literal, Optional, Type, Union
+from typing import TYPE_CHECKING, Callable, Literal, Union
 
 from typing_extensions import TypeAlias
 

--- a/dask/graph_manipulation.py
+++ b/dask/graph_manipulation.py
@@ -58,12 +58,12 @@ def checkpoint(
         if split_every < 2:
             raise ValueError("split_every must be False, None, or >= 2")
 
-    collections, _ = unpack_collections(*collections)
-    if len(collections) == 1:
-        return _checkpoint_one(collections[0], split_every)
+    unpacked, _ = unpack_collections(*collections)
+    if len(unpacked) == 1:
+        return _checkpoint_one(unpacked[0], split_every)
     else:
         return delayed(chunks.checkpoint)(
-            *(_checkpoint_one(c, split_every) for c in collections)
+            *(_checkpoint_one(c, split_every) for c in unpacked)
         )
 
 

--- a/dask/tests/test_typing.py
+++ b/dask/tests/test_typing.py
@@ -10,6 +10,7 @@ import dask.threaded
 from dask.base import DaskMethodsMixin, dont_optimize, tokenize
 from dask.context import globalmethod
 from dask.delayed import Delayed, delayed
+from dask.dot import FormatOption
 from dask.typing import (
     DaskCollection,
     HLGDaskCollection,
@@ -77,7 +78,7 @@ class Inheriting(DaskCollection):
     def visualize(
         self,
         filename: str = "mydask",
-        format: str | None = None,
+        format: FormatOption = None,
         optimize_graph: bool = False,
         **kwargs: Any,
     ) -> DisplayObject | None:

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Callable, Hashable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable, NewType
 
 if TYPE_CHECKING:
     # IPython import is relatively slow. Avoid if not necessary
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 CollType = TypeVar("CollType", bound="DaskCollection")
 CollType_co = TypeVar("CollType_co", bound="DaskCollection", covariant=True)
 PostComputeCallable = Callable
+DaskGraph = NewType("DaskGraph", dict[str, Any])
 
 
 class SchedulerGetCallable(Protocol):

--- a/dask/typing.py
+++ b/dask/typing.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Callable, Hashable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable, NewType
+from typing import TYPE_CHECKING, Any, NewType, Protocol, TypeVar, runtime_checkable
+
+from dask.dot import FormatOption
 
 if TYPE_CHECKING:
     # IPython import is relatively slow. Avoid if not necessary
@@ -330,7 +332,7 @@ class DaskCollection(Protocol):
     def visualize(
         self,
         filename: str = "mydask",
-        format: str | None = None,
+        format: FormatOption = None,
         optimize_graph: bool = False,
         **kwargs: Any,
     ) -> DisplayObject | None:

--- a/dask/widgets/__init__.py
+++ b/dask/widgets/__init__.py
@@ -1,3 +1,5 @@
+from jinja2 import Environment, Template
+
 try:
     from dask.widgets.widgets import (
         FILTERS,
@@ -17,8 +19,8 @@ except ImportError as e:
     FILTERS = {}
     TEMPLATE_PATHS = []
 
-    def get_environment():
+    def get_environment() -> Environment:
         raise ImportError(msg) from exception
 
-    def get_template(name: str):
+    def get_template(name: str) -> Template:
         raise ImportError(msg) from exception

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ show_error_codes = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unreachable = true
+mypy_path = stubs
 
 [codespell]
 ignore-words-list = coo,nd

--- a/stubs/tlz.pyi
+++ b/stubs/tlz.pyi
@@ -35,105 +35,83 @@ InstancePropertyInstanceRet = TypeVar("InstancePropertyInstanceRet")
 InstancePropertyClassRet = TypeVar("InstancePropertyClassRet")
 
 @overload
-def instanceproperty(fget:Callable[[InstancePropertyParent], InstancePropertyInstanceRet], fset=None, fdel=None, doc=None, classval: Optional[InstancePropertyClassRet]=None) -> "InstanceProperty"[
-    InstancePropertyParent,
-    InstancePropertyInstanceRet,
-    InstancePropertyClassRet
-]:
-    ...
+def instanceproperty(
+    fget: Callable[[InstancePropertyParent], InstancePropertyInstanceRet],
+    fset=None,
+    fdel=None,
+    doc=None,
+    classval: Optional[InstancePropertyClassRet] = None,
+) -> "InstanceProperty"[
+    InstancePropertyParent, InstancePropertyInstanceRet, InstancePropertyClassRet
+]: ...
 @overload
-def instanceproperty(fset=None, fdel=None, doc=None, classval=None) -> partial:
-    ...
+def instanceproperty(fset=None, fdel=None, doc=None, classval=None) -> partial: ...
+
 # def instanceproperty(fget=None, fset=None, fdel=None, doc=None, classval=None):
 #     ...
 
-
-class InstanceProperty(property, Generic[InstancePropertyParent, InstancePropertyInstanceRet, InstancePropertyClassRet]):
-    def __init__(self, fget: Optional[Callable[[InstancePropertyParent], InstancePropertyInstanceRet]]=None, fset: Optional[Callable[[InstancePropertyParent, InstancePropertyInstanceRet], None]]=None, fdel: Optional[Callable[[InstancePropertyParent], None]]=None, doc: Optional[str]=None, classval: Optional[InstancePropertyClassRet]=None):
-        ...
-
+class InstanceProperty(
+    property,
+    Generic[
+        InstancePropertyParent, InstancePropertyInstanceRet, InstancePropertyClassRet
+    ],
+):
+    def __init__(
+        self,
+        fget: Optional[
+            Callable[[InstancePropertyParent], InstancePropertyInstanceRet]
+        ] = None,
+        fset: Optional[
+            Callable[[InstancePropertyParent, InstancePropertyInstanceRet], None]
+        ] = None,
+        fdel: Optional[Callable[[InstancePropertyParent], None]] = None,
+        doc: Optional[str] = None,
+        classval: Optional[InstancePropertyClassRet] = None,
+    ): ...
     @overload
-    def __get__(self, obj: InstancePropertyParent, type=None) -> InstancePropertyInstanceRet: ...
-
+    def __get__(
+        self, obj: InstancePropertyParent, type=None
+    ) -> InstancePropertyInstanceRet: ...
     @overload
-    def __get__(self, obj: Type[InstanceProperty], type=None) -> InstancePropertyClassRet:
-        ...
-
+    def __get__(
+        self, obj: Type[InstanceProperty], type=None
+    ) -> InstancePropertyClassRet: ...
     def __reduce__(self):
         state = (self.fget, self.fset, self.fdel, self.__doc__, self.classval)
         return instanceproperty, state
 
-
 class curry(Generic[CurryRet]):
-    def __init__(self, func: Callable[..., CurryRet], *args, **kwargs):
-        ...
-
+    def __init__(self, func: Callable[..., CurryRet], *args, **kwargs): ...
     @instanceproperty
-    def func(self) -> CurryCall:
-        ...
-
+    def func(self) -> CurryCall: ...
     @instanceproperty
-    def __signature__(self) -> inspect.Signature:
-        ...
-
+    def __signature__(self) -> inspect.Signature: ...
     @instanceproperty
-    def args(self) -> tuple:
-        ...
-
+    def args(self) -> tuple: ...
     @instanceproperty
-    def keywords(self) -> dict:
-        ...
-
+    def keywords(self) -> dict: ...
     @instanceproperty
-    def func_name(self) -> str:
-        ...
-
-    def __str__(self):
-        ...
-
-    def __repr__(self):
-        ...
-
-    def __hash__(self):
-        ...
-
-    def __eq__(self, other):
-        ...
-
-    def __ne__(self, other):
-        ...
-
-    def __call__(self, *args, **kwargs) -> Union[CurryRet, "curry"]:
-        ...
-
-    def _should_curry(self, args, kwargs, exc: Any=None) -> bool:
-        ...
-
-    def bind(self, *args, **kwargs) -> "curry":
-        ...
-
-    def call(self, *args, **kwargs) -> CurryRet:
-        ...
+    def func_name(self) -> str: ...
+    def __str__(self): ...
+    def __repr__(self): ...
+    def __hash__(self): ...
+    def __eq__(self, other): ...
+    def __ne__(self, other): ...
+    def __call__(self, *args, **kwargs) -> Union[CurryRet, "curry"]: ...
+    def _should_curry(self, args, kwargs, exc: Any = None) -> bool: ...
+    def bind(self, *args, **kwargs) -> "curry": ...
+    def call(self, *args, **kwargs) -> CurryRet: ...
 
     # Should return Self, once supported by mypy
     @overload
-    def __get__(self, instance: None, owner: Any) -> "curry":
-        ...
+    def __get__(self, instance: None, owner: Any) -> "curry": ...
     @overload
-    def __get__(self, instance: Any, owner: Any) -> "curry":
-        ...
-
-    def __reduce__(self) -> Tuple[
+    def __get__(self, instance: Any, owner: Any) -> "curry": ...
+    def __reduce__(
+        self,
+    ) -> Tuple[
         Callable,
-        Tuple[
-            Type["curry"],
-            Union[CurryCall, str],
-            tuple,
-            dict,
-            tuple,
-            Optional[bool]
-        ]
-    ]:
-        ...
+        Tuple[Type["curry"], Union[CurryCall, str], tuple, dict, tuple, Optional[bool]],
+    ]: ...
 
 def __getattr__(name) -> Any: ...

--- a/stubs/tlz.pyi
+++ b/stubs/tlz.pyi
@@ -1,17 +1,139 @@
 from __future__ import annotations
-from typing import TypeVar, Iterable, Generic, Callable, Any
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    Iterable,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
+
+if TYPE_CHECKING:
+    import inspect
+
+    # from functools import partial
+
+partial: Any
 
 S = TypeVar("S")
 T = TypeVar("T")
 
-def concat(*args: Iterable[T]) -> Iterable[T]:
-    ...
+CurryRet = TypeVar("CurryRet")
+CurryCall = Callable[..., CurryRet]
 
-class curry(Generic[T]):
-    def __init__(self, fn: Callable[..., T]):
+#: The type of instances of the class being annotated
+InstancePropertyParent = TypeVar("InstancePropertyParent")
+#: The type returned by this property, if invoked on an instance
+InstancePropertyInstanceRet = TypeVar("InstancePropertyInstanceRet")
+#: The type returned by this property, if invoked on a class
+InstancePropertyClassRet = TypeVar("InstancePropertyClassRet")
+
+@overload
+def instanceproperty(fget:Callable[[InstancePropertyParent], InstancePropertyInstanceRet], fset=None, fdel=None, doc=None, classval: Optional[InstancePropertyClassRet]=None) -> "InstanceProperty"[
+    InstancePropertyParent,
+    InstancePropertyInstanceRet,
+    InstancePropertyClassRet
+]:
+    ...
+@overload
+def instanceproperty(fset=None, fdel=None, doc=None, classval=None) -> partial:
+    ...
+# def instanceproperty(fget=None, fset=None, fdel=None, doc=None, classval=None):
+#     ...
+
+
+class InstanceProperty(property, Generic[InstancePropertyParent, InstancePropertyInstanceRet, InstancePropertyClassRet]):
+    def __init__(self, fget: Optional[Callable[[InstancePropertyParent], InstancePropertyInstanceRet]]=None, fset: Optional[Callable[[InstancePropertyParent, InstancePropertyInstanceRet], None]]=None, fdel: Optional[Callable[[InstancePropertyParent], None]]=None, doc: Optional[str]=None, classval: Optional[InstancePropertyClassRet]=None):
         ...
 
-    def __call__(self, *args, **kwargs) -> Curry | T:
+    @overload
+    def __get__(self, obj: InstancePropertyParent, type=None) -> InstancePropertyInstanceRet: ...
+
+    @overload
+    def __get__(self, obj: Type[InstanceProperty], type=None) -> InstancePropertyClassRet:
+        ...
+
+    def __reduce__(self):
+        state = (self.fget, self.fset, self.fdel, self.__doc__, self.classval)
+        return instanceproperty, state
+
+
+class curry(Generic[CurryRet]):
+    def __init__(self, func: Callable[..., CurryRet], *args, **kwargs):
+        ...
+
+    @instanceproperty
+    def func(self) -> CurryCall:
+        ...
+
+    @instanceproperty
+    def __signature__(self) -> inspect.Signature:
+        ...
+
+    @instanceproperty
+    def args(self) -> tuple:
+        ...
+
+    @instanceproperty
+    def keywords(self) -> dict:
+        ...
+
+    @instanceproperty
+    def func_name(self) -> str:
+        ...
+
+    def __str__(self):
+        ...
+
+    def __repr__(self):
+        ...
+
+    def __hash__(self):
+        ...
+
+    def __eq__(self, other):
+        ...
+
+    def __ne__(self, other):
+        ...
+
+    def __call__(self, *args, **kwargs) -> Union[CurryRet, "curry"]:
+        ...
+
+    def _should_curry(self, args, kwargs, exc: Any=None) -> bool:
+        ...
+
+    def bind(self, *args, **kwargs) -> "curry":
+        ...
+
+    def call(self, *args, **kwargs) -> CurryRet:
+        ...
+
+    # Should return Self, once supported by mypy
+    @overload
+    def __get__(self, instance: None, owner: Any) -> "curry":
+        ...
+    @overload
+    def __get__(self, instance: Any, owner: Any) -> "curry":
+        ...
+
+    def __reduce__(self) -> Tuple[
+        Callable,
+        Tuple[
+            Type["curry"],
+            Union[CurryCall, str],
+            tuple,
+            dict,
+            tuple,
+            Optional[bool]
+        ]
+    ]:
         ...
 
 def __getattr__(name) -> Any: ...

--- a/stubs/tlz.pyi
+++ b/stubs/tlz.pyi
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from typing import TypeVar, Iterable, Generic, Callable, Any
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+def concat(*args: Iterable[T]) -> Iterable[T]:
+    ...
+
+class curry(Generic[T]):
+    def __init__(self, fn: Callable[..., T]):
+        ...
+
+    def __call__(self, *args, **kwargs) -> Curry | T:
+        ...
+
+def __getattr__(name) -> Any: ...


### PR DESCRIPTION
- [x] Closes #7779
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

I added a *large* number of type annotations in the process of doing this. Feel free to enquire about some of the decisions I made in this process.

I had to reduce the precision of many of the annotations because mypy (as opposed to say pyright) doesn't yet support a lot of the advanced type objects like `Self`, `Unpack`, `ParamSpec` etc. One specific example of this is the `DaskTask` tuples, which are of the form `(func, *args)`. I would love to define it as `tuple[Callable[T, U], *tuple]` so that we can propagate `U`, the function's return value, and also type check that a function is actually present. However this isn't currently possible.