### PR TITLE
Update `test_plot_multiple` for upcoming `bokeh` release

### DIFF
--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -330,7 +330,12 @@ def test_plot_multiple():
     p = visualize(
         [prof, rprof], label_size=50, title="Not the default", show=False, save=False
     )
-    figures = [r[0] for r in p.children[1].children]
+    # Grid plot layouts changed in Bokeh 3.
+    # See https://github.com/dask/dask/issues/9257 for more details
+    if BOKEH_VERSION().major < 3:
+        figures = [r[0] for r in p.children[1].children]
+    else:
+        figures = [r[0] for r in p.children]
     assert len(figures) == 2
     assert figures[0].title.text == "Not the default"
     assert figures[0].xaxis[0].axis_label is None


### PR DESCRIPTION
This PR updates `test_plot_multiple` in preparation for the upcoming `bokeh` release. Still keeping the older logic around to this test continues to pass when using older, but still supported versions of `bokeh`. 

- [x] Closes https://github.com/dask/dask/issues/9257
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

cc @bryevdv @pavithraes 