### PR TITLE
docs: Fix a few typos

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1302,7 +1302,7 @@ class ArrowDatasetEngine(Engine):
         aggregation_depth = dataset_info_kwargs["aggregation_depth"]
         chunksize = dataset_info_kwargs["chunksize"]
 
-        # Intialize row-group and statistiscs data structures
+        # Intialize row-group and statistics data structures
         file_row_groups = defaultdict(list)
         file_row_group_stats = defaultdict(list)
         file_row_group_column_stats = defaultdict(list)
@@ -1492,7 +1492,7 @@ class ArrowDatasetEngine(Engine):
                 )
 
                 # Extract hive-partition keys, and make sure they
-                # are orderd the same as they are in `partitions`
+                # are ordered the same as they are in `partitions`
                 raw_keys = pa_ds._get_partition_keys(frag.partition_expression)
                 partition_keys = [
                     (hive_part.name, raw_keys[hive_part.name])

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -221,7 +221,7 @@ def read_parquet(
         of the combined filters with an OR disjunction.
 
         Predicates can also be expressed as a ``List[Tuple]``. These are evaluated
-        as an AND conjunction. To express OR in predictates, one must use the
+        as an AND conjunction. To express OR in predicates, one must use the
         (preferred for "pyarrow") ``List[List[Tuple]]`` notation.
 
         Note that the "fastparquet" engine does not currently support DNF for
@@ -1241,7 +1241,7 @@ def apply_filters(parts, statistics, filters):
         filters with an OR disjunction.
 
         Predicates can also be expressed as a List[Tuple]. These are evaluated
-        as an AND conjunction. To express OR in predictates, one must use the
+        as an AND conjunction. To express OR in predicates, one must use the
         (preferred) List[List[Tuple]] notation.
 
         Note that the "fastparquet" engine does not currently support DNF for

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3604,7 +3604,7 @@ def test_read_write_overwrite_is_true(tmpdir, engine):
     ddf = ddf.reset_index(drop=True)
     dd.to_parquet(ddf, tmpdir, engine=engine, overwrite=True)
 
-    # Keep the contents of the DataFrame constatn but change the # of partitions
+    # Keep the contents of the DataFrame constant but change the # of partitions
     ddf2 = ddf.repartition(npartitions=3)
 
     # Overwrite the existing Dataset with the new dataframe and evaluate

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1328,7 +1328,7 @@ def is_arraylike(x) -> bool:
         and hasattr(x, "dtype")
         and not any(is_dask_collection(n) for n in x.shape)
         # We special case scipy.sparse and cupyx.scipy.sparse arrays as having partial
-        # support for them is useful in scenerios where we mostly call `map_partitions`
+        # support for them is useful in scenarios where we mostly call `map_partitions`
         # or `map_blocks` with scikit-learn functions on dask arrays and dask dataframes.
         # https://github.com/dask/dask/pull/3738
         and (is_duck_array or "scipy.sparse" in typename(type(x)))


### PR DESCRIPTION
There are small typos in:
- dask/dataframe/io/parquet/arrow.py
- dask/dataframe/io/parquet/core.py
- dask/dataframe/io/tests/test_parquet.py
- dask/utils.py

Fixes:
- Should read `predicates` rather than `predictates`.
- Should read `statistics` rather than `statistiscs`.
- Should read `scenarios` rather than `scenerios`.
- Should read `ordered` rather than `orderd`.
- Should read `constant` rather than `constatn`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md