### PR TITLE
Fix division calculation in `dask.dataframe.io.from_dask_array`

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -534,16 +534,15 @@ def from_dask_array(x, columns=None, index=None, meta=None):
         chunksizes = pd.Series(x.chunks[0])
         chunk_divisions = chunksizes.cumsum()
         nrows = chunk_divisions.iloc[-1]
-        # Correctly index empty partitions at the end
-        chunk_divisions.loc[chunk_divisions == nrows] = nrows - 1
 
         divisions = [0]
         index_mapping = {}
         for i, increment in chunk_divisions.iteritems():
-            divisions.append(increment)
-            if i == len(chunk_divisions) - 1:
-                increment += 1
             index_mapping[(i,)] = (divisions[i], increment)
+            # Set division for the last chunk and all empty chunks at the end
+            if increment == nrows:
+                increment -= 1
+            divisions.append(increment)
 
         arrays_and_indices.extend([BlockwiseDepDict(mapping=index_mapping), "i"])
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -540,8 +540,10 @@ def from_dask_array(x, columns=None, index=None, meta=None):
         divisions = [0]
         index_mapping = {}
         for i, increment in chunk_divisions.iteritems():
-            index_mapping[(i,)] = (divisions[i], increment)
             divisions.append(increment)
+            if i == len(chunk_divisions) - 1:
+                increment += 1
+            index_mapping[(i,)] = (divisions[i], increment)
 
         arrays_and_indices.extend([BlockwiseDepDict(mapping=index_mapping), "i"])
 

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -553,27 +553,18 @@ def test_from_dask_array_unknown_chunks():
     assert_eq(df, pd.DataFrame(dx.compute()), check_index=False)
 
 
-def test_from_dask_array_empty_chunks():
-    # Empty chunks at the end
-    chunksizes = (1, 2, 3, 0)
-    monotonic_index = da.from_array(np.arange(sum(chunksizes)), chunks=chunksizes)
-
+@pytest.mark.parametrize(
+    "chunksizes, expected_divisions",
+    [
+        pytest.param((1, 2, 3, 0), (0, 1, 3, 5, 5)),
+        pytest.param((0, 1, 2, 3), (0, 0, 1, 3, 5)),
+        pytest.param((1, 0, 2, 3), (0, 1, 1, 3, 5)),
+    ],
+)
+def test_from_dask_array_empty_chunks(chunksizes, expected_divisions):
+    monotonic_index = da.from_array(np.arange(6), chunks=chunksizes)
     df = dd.from_dask_array(monotonic_index)
-    assert df.divisions == (0, 1, 3, 5, 5)
-
-    # Empty chunks at the beginning
-    chunksizes = (0, 1, 2, 3)
-    monotonic_index = da.from_array(np.arange(sum(chunksizes)), chunks=chunksizes)
-
-    df = dd.from_dask_array(monotonic_index)
-    assert df.divisions == (0, 0, 1, 3, 5)
-
-    # Empty chunks in the middle
-    chunksizes = (1, 0, 2, 3)
-    monotonic_index = da.from_array(np.arange(sum(chunksizes)), chunks=chunksizes)
-
-    df = dd.from_dask_array(monotonic_index)
-    assert df.divisions == (0, 1, 1, 3, 5)
+    assert df.divisions == expected_divisions
 
 
 def test_from_dask_array_unknown_width_error():

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -11,7 +11,7 @@ import dask.array as da
 import dask.dataframe as dd
 from dask.blockwise import Blockwise
 from dask.dataframe._compat import tm
-from dask.dataframe.io.io import _meta_from_array, from_dask_array
+from dask.dataframe.io.io import _meta_from_array
 from dask.dataframe.optimize import optimize
 from dask.dataframe.utils import assert_eq, is_categorical_dtype
 from dask.delayed import Delayed, delayed
@@ -555,23 +555,23 @@ def test_from_dask_array_unknown_chunks():
 
 def test_from_dask_array_empty_chunks():
     # Empty chunks at the end
-    chunksizes = (1,2,3,0)
+    chunksizes = (1, 2, 3, 0)
     monotonic_index = da.from_array(np.arange(sum(chunksizes)), chunks=chunksizes)
-    
+
     df = dd.from_dask_array(monotonic_index)
     assert df.divisions == (0, 1, 3, 5, 5)
 
     # Empty chunks at the beginning
-    chunksizes = (0,1,2,3)
+    chunksizes = (0, 1, 2, 3)
     monotonic_index = da.from_array(np.arange(sum(chunksizes)), chunks=chunksizes)
-    
+
     df = dd.from_dask_array(monotonic_index)
     assert df.divisions == (0, 0, 1, 3, 5)
 
     # Empty chunks in the middle
-    chunksizes = (1,0,2,3)
+    chunksizes = (1, 0, 2, 3)
     monotonic_index = da.from_array(np.arange(sum(chunksizes)), chunks=chunksizes)
-    
+
     df = dd.from_dask_array(monotonic_index)
     assert df.divisions == (0, 1, 1, 3, 5)
 


### PR DESCRIPTION
The divisions calculated in `dask.dataframe.io.from_dask_array` are incorrect if you pass in an array with empty chunks at the end.

E.g If you pass a dask array with `chunks = (1, 2, 3, 0)` to `from_dask_array` the divisions calculated are `(0, 1, 3, 6, 5)`.  This PR correctly handles the special case of empty chunks at the end and calculates the divisions as `[0, 1, 3, 5, 5]`.

I also added some tests to check empty chunks at the beginning and middle (these worked fined pre-PR).

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
