### PR TITLE
WIP/RFC: In the insert_to_ooc function, only fuse the slices if there are non-empty regions

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4403,7 +4403,10 @@ def insert_to_ooc(
 
     slices = slices_from_chunks(chunks)
     if region:
-        slices = [fuse_slice(region, slc) for slc in slices]
+        if not all(
+            map(lambda s: s.start is None and s.stop is None and s.step is None, region)
+        ):
+            slices = [fuse_slice(region, slc) for slc in slices]
 
     if return_stored and load_stored:
         func = load_store_chunk


### PR DESCRIPTION
This improves performance when writing out arrays with a very large number of chunks.

I made this change based on profiling and debugging. I found that in my case, where `regions = (<empty slice>, <empty slice>, <empty slice>)`, `[fuse_slice(region, slc) for slc in slices]` appears to be an identity (`slices == [fuse_slice(region, slc) for slc in slices]`). However, it takes a very long time to run.

That said, **I don't have a good grasp on either `fuse_slice`, or `insert_to_ooc`, so I'm not sure if this is correct in the first place, and if so, if this is the right place to put this logic.** So I created this PR mainly to solicit feedback from someone who understands this in better detail. Thank you!

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
