### PR TITLE
Make sure 'order' kwarg will not crash the 'astype' method in dask

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2232,7 +2232,6 @@ class Array(DaskMethodsMixin):
             is set to False and the `dtype` requirement is satisfied, the input
             array is returned instead of a copy.
 
-
             .. note::
 
                 Dask does not respect the contiguous memory layout of the array,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2231,10 +2231,15 @@ class Array(DaskMethodsMixin):
             By default, astype always returns a newly allocated array. If this
             is set to False and the `dtype` requirement is satisfied, the input
             array is returned instead of a copy.
+        order : {‘C’, ‘F’, ‘A’, ‘K’}, optional
+            Memory layout. ‘A’ and ‘K’ depend on the order of input array a.
+            ‘C’ row-major (C-style), ‘F’ column-major (Fortran-style) memory
+            representation. ‘A’ (any) means ‘F’ if a is Fortran contiguous, ‘C’
+            otherwise ‘K’ (keep) preserve input order. Defaults to ‘C’.
         """
-        # Scalars don't take `casting` or `copy` kwargs - as such we only pass
+        # Scalars don't take `casting`, `copy` or `order`` kwargs - as such we only pass
         # them to `map_blocks` if specified by user (different than defaults).
-        extra = set(kwargs) - {"casting", "copy"}
+        extra = set(kwargs) - {"casting", "copy", "order"}
         if extra:
             raise TypeError(
                 f"astype does not take the following keyword arguments: {list(extra)}"

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2231,15 +2231,18 @@ class Array(DaskMethodsMixin):
             By default, astype always returns a newly allocated array. If this
             is set to False and the `dtype` requirement is satisfied, the input
             array is returned instead of a copy.
-        order : {‘C’, ‘F’, ‘A’, ‘K’}, optional
-            Memory layout. ‘A’ and ‘K’ depend on the order of input array a.
-            ‘C’ row-major (C-style), ‘F’ column-major (Fortran-style) memory
-            representation. ‘A’ (any) means ‘F’ if a is Fortran contiguous, ‘C’
-            otherwise ‘K’ (keep) preserve input order. Defaults to ‘C’.
+
+
+            .. note::
+
+                Dask does not respect the contiguous memory layout of the array,
+                and will ignore the ``order`` keyword argument.
+                The default order is 'C' contiguous.
         """
-        # Scalars don't take `casting`, `copy` or `order`` kwargs - as such we only pass
+        kwargs.pop("order", None)  # `order` is not respected, so we remove this kwarg
+        # Scalars don't take `casting` or `copy` kwargs - as such we only pass
         # them to `map_blocks` if specified by user (different than defaults).
-        extra = set(kwargs) - {"casting", "copy", "order"}
+        extra = set(kwargs) - {"casting", "copy"}
         if extra:
             raise TypeError(
                 f"astype does not take the following keyword arguments: {list(extra)}"

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2296,12 +2296,9 @@ def test_astype_gh9318():
     # `order`` kwarg in `astype` should not cause an error
     a = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], order="C")
     b = da.from_array(a, chunks=(2, 2))
-    a.astype(float, order="F")
-    b.astype(float, order="F")  # if no error at this line, pytest passes
-    # This assertion currently failing because of issue https://github.com/dask/dask/issues/9316
-    # result = b.compute()
-    # assert a.flags.c_contiguous == result.flags.c_contiguous
-    # assert a.flags.f_contiguous == result.flags.f_contiguous
+    result_a = a.astype(float, order="F")
+    result_b = b.astype(float, order="F")  # if no error at this line, pytest passes
+    assert_eq(result_a, result_b)  # won't check the order matches, but checks results
 
 
 def test_arithmetic():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2301,6 +2301,19 @@ def test_astype_gh9318():
     assert_eq(result_a, result_b)  # won't check the order matches, but checks results
 
 
+@pytest.mark.xfail(reason="Github issue https://github.com/dask/dask/issues/9316")
+def test_astype_gh9316():
+    # Issue https://github.com/dask/dask/issues/9316
+    # Can be combined with test_astype_gh9318 above when XFAIL marker is removed
+    a = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], order="C")
+    b = da.from_array(a, chunks=(2, 2))
+    result_a = a.astype(float, order="F")
+    result_b = b.astype(float, order="F")
+    result_b = result_b.compute()
+    assert result_a.flags.c_contiguous == result_b.flags.c_contiguous
+    assert result_a.flags.f_contiguous == result_b.flags.f_contiguous
+
+
 def test_arithmetic():
     x = np.arange(5).astype("f4") + 2
     y = np.arange(5).astype("i8") + 2

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3575,6 +3575,18 @@ def test_astype_gh1151():
     assert_eq(a.astype(np.int16), b.astype(np.int16))
 
 
+def test_astype_gh9318():
+    # `order`` kwarg in `astype` should not cause an error
+    a = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], order="C")
+    b = da.from_array(a, chunks=(2, 2))
+    a.astype(float, order="F")
+    b.astype(float, order="F")  # if no error at this line, pytest passes
+    # This assertion currently failing because of issue https://github.com/dask/dask/issues/9316
+    # result = b.compute()
+    # assert a.flags.c_contiguous == result.flags.c_contiguous
+    # assert a.flags.f_contiguous == result.flags.f_contiguous
+
+
 def test_elemwise_name():
     assert (da.ones(5, chunks=2) + 1).name.startswith("add-")
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2286,6 +2286,24 @@ def test_astype():
     assert d.astype("f8") is d
 
 
+def test_astype_gh1151():
+    a = np.arange(5).astype(np.int32)
+    b = da.from_array(a, (1,))
+    assert_eq(a.astype(np.int16), b.astype(np.int16))
+
+
+def test_astype_gh9318():
+    # `order`` kwarg in `astype` should not cause an error
+    a = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], order="C")
+    b = da.from_array(a, chunks=(2, 2))
+    a.astype(float, order="F")
+    b.astype(float, order="F")  # if no error at this line, pytest passes
+    # This assertion currently failing because of issue https://github.com/dask/dask/issues/9316
+    # result = b.compute()
+    # assert a.flags.c_contiguous == result.flags.c_contiguous
+    # assert a.flags.f_contiguous == result.flags.f_contiguous
+
+
 def test_arithmetic():
     x = np.arange(5).astype("f4") + 2
     y = np.arange(5).astype("i8") + 2
@@ -3567,24 +3585,6 @@ def test_copy_mutate():
 def test_npartitions():
     assert da.ones(5, chunks=(2,)).npartitions == 3
     assert da.ones((5, 5), chunks=(2, 3)).npartitions == 6
-
-
-def test_astype_gh1151():
-    a = np.arange(5).astype(np.int32)
-    b = da.from_array(a, (1,))
-    assert_eq(a.astype(np.int16), b.astype(np.int16))
-
-
-def test_astype_gh9318():
-    # `order`` kwarg in `astype` should not cause an error
-    a = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], order="C")
-    b = da.from_array(a, chunks=(2, 2))
-    a.astype(float, order="F")
-    b.astype(float, order="F")  # if no error at this line, pytest passes
-    # This assertion currently failing because of issue https://github.com/dask/dask/issues/9316
-    # result = b.compute()
-    # assert a.flags.c_contiguous == result.flags.c_contiguous
-    # assert a.flags.f_contiguous == result.flags.f_contiguous
 
 
 def test_elemwise_name():


### PR DESCRIPTION
This PR allows the `order` kwarg to be passed in to the dask `astype` method without triggering an error.

Our friends over at zarr have found a small bug in dask. While the numpy `astype` method allows the user to use an `order` keyword argument ([docs here](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.astype.html)), the corresponding dask `astype` method produces an error 

Why I think we should do this:
1. It's not always as obvious as telling the user to edit the line in their code that uses `astype`, since it's often used very indirectly. Here's one example: https://github.com/zarr-developers/zarr-python/issues/962#issuecomment-1040545707
2.  It reflects better on dask not to have odd errors popping up, even if this PR won't completely solve the issue being discussed over at zarr https://github.com/zarr-developers/zarr-python/issues/962

- [x] Closes https://github.com/dask/dask/issues/9318
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Additional links: related to issue https://github.com/zarr-developers/zarr-python/issues/962