### PR TITLE
Fix bug for cumsum on cupy chunked dask arrays

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -37,7 +37,14 @@ from dask.array.wrap import ones, zeros
 from dask.base import tokenize
 from dask.blockwise import lol_tuples
 from dask.highlevelgraph import HighLevelGraph
-from dask.utils import deepmap, derived_from, funcname, getargspec, is_series_like
+from dask.utils import (
+    apply,
+    deepmap,
+    derived_from,
+    funcname,
+    getargspec,
+    is_series_like,
+)
 
 
 def divide(a, b, dtype=None):
@@ -1512,7 +1519,12 @@ def cumreduction(
     dsk = dict()
     for ind in indices:
         shape = tuple(x.chunks[i][ii] if i != axis else 1 for i, ii in enumerate(ind))
-        dsk[(name, "extra") + ind] = (np.full, shape, ident, m.dtype)
+        dsk[(name, "extra") + ind] = (
+            apply,
+            np.full,
+            (shape, ident, m.dtype),
+            {"like": x._meta},
+        )
         dsk[(name,) + ind] = (m.name,) + ind
 
     for i in range(1, n):
@@ -1532,7 +1544,7 @@ def cumreduction(
             dsk[(name,) + ind] = (binop, this_slice, (m.name,) + ind)
 
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[m])
-    result = Array(graph, name, x.chunks, m.dtype)
+    result = Array(graph, name, x.chunks, m.dtype, meta=x._meta)
     return handle_out(out, result)
 
 

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1521,9 +1521,9 @@ def cumreduction(
         shape = tuple(x.chunks[i][ii] if i != axis else 1 for i, ii in enumerate(ind))
         dsk[(name, "extra") + ind] = (
             apply,
-            np.full,
-            (shape, ident, m.dtype),
-            {"like": x._meta},
+            np.full_like,
+            (x._meta, ident, m.dtype),
+            {"shape": shape},
         )
         dsk[(name,) + ind] = (m.name,) + ind
 

--- a/dask/array/tests/test_cupy_reductions.py
+++ b/dask/array/tests/test_cupy_reductions.py
@@ -70,3 +70,11 @@ def test_nanarg_reductions(dfunc, func):
         a = da.from_array(x, chunks=(3, 4, 5))
         with pytest.raises(ValueError):
             dfunc(a).compute()
+
+
+@pytest.mark.parametrize("func", [np.cumsum, np.cumprod])
+def test_cumreduction_with_cupy(func):
+    a = cupy.ones((10, 10))
+    b = da.from_array(a, chunks=(4, 4))
+    result = func(b, axis=0)
+    assert_eq(result, func(a, axis=0))

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -583,6 +583,15 @@ def test_array_cumreduction_out(func):
     assert_eq(x, func(np.ones((10, 10)), axis=0))
 
 
+@pytest.mark.parametrize("func", [np.cumsum, np.cumprod])
+def test_cumreduction_with_cupy(func):
+    cupy = pytest.importorskip("cupy")
+    a = cupy.ones((10, 10))
+    b = da.from_array(a, chunks=(4, 4))
+    result = func(b, axis=0)
+    assert_eq(result, func(a, axis=0))
+
+
 @pytest.mark.parametrize(
     "npfunc,daskfunc", [(np.sort, da.topk), (np.argsort, da.argtopk)]
 )

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -583,15 +583,6 @@ def test_array_cumreduction_out(func):
     assert_eq(x, func(np.ones((10, 10)), axis=0))
 
 
-@pytest.mark.parametrize("func", [np.cumsum, np.cumprod])
-def test_cumreduction_with_cupy(func):
-    cupy = pytest.importorskip("cupy")
-    a = cupy.ones((10, 10))
-    b = da.from_array(a, chunks=(4, 4))
-    result = func(b, axis=0)
-    assert_eq(result, func(a, axis=0))
-
-
 @pytest.mark.parametrize(
     "npfunc,daskfunc", [(np.sort, da.topk), (np.argsort, da.argtopk)]
 )


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/9315

And very likely, it fixes cumsum for a broader range of array types than just copy (but I haven't tested that here).

- [x] Closes https://github.com/dask/dask/issues/9315
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
