### PR TITLE
Temporarily pin `werkzeug` in CI to avoid test suite hanging 

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -37,7 +37,7 @@ dependencies:
   - blosc
   - boto3
   - botocore
-  - aws-sam-translator=1.47.0
+  - werkzeug=2.1.2
   - bokeh
   - httpretty
   - aiohttp

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -37,6 +37,7 @@ dependencies:
   - blosc
   - boto3
   - botocore
+  - aws-sam-translator=1.47.0
   - bokeh
   - httpretty
   - aiohttp

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -37,7 +37,10 @@ dependencies:
   - blosc
   - boto3
   - botocore
-  - werkzeug=2.1.2
+  # `werkzeug=2.2.0` caused S3-related tests to hang. Temporarily
+  # pinning as a workaround. See https://github.com/dask/dask/issues/9323
+  # for more details.
+  - werkzeug<2.2.0
   - bokeh
   - httpretty
   - aiohttp

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -36,6 +36,7 @@ dependencies:
   - blosc
   - boto3
   - botocore
+  - aws-sam-translator=1.47.0
   - bokeh
   - httpretty
   - aiohttp

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -36,7 +36,10 @@ dependencies:
   - blosc
   - boto3
   - botocore
-  - werkzeug=2.1.2
+  # `werkzeug=2.2.0` caused S3-related tests to hang. Temporarily
+  # pinning as a workaround. See https://github.com/dask/dask/issues/9323
+  # for more details.
+  - werkzeug<2.2.0
   - bokeh
   - httpretty
   - aiohttp

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -36,7 +36,7 @@ dependencies:
   - blosc
   - boto3
   - botocore
-  - aws-sam-translator=1.47.0
+  - werkzeug=2.1.2
   - bokeh
   - httpretty
   - aiohttp

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -37,7 +37,7 @@ dependencies:
   - blosc
   - boto3
   - botocore
-  - aws-sam-translator=1.47.0
+  - werkzeug=2.1.2
   - bokeh
   - httpretty
   - aiohttp

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -37,6 +37,7 @@ dependencies:
   - blosc
   - boto3
   - botocore
+  - aws-sam-translator=1.47.0
   - bokeh
   - httpretty
   - aiohttp

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -37,7 +37,10 @@ dependencies:
   - blosc
   - boto3
   - botocore
-  - werkzeug=2.1.2
+  # `werkzeug=2.2.0` caused S3-related tests to hang. Temporarily
+  # pinning as a workaround. See https://github.com/dask/dask/issues/9323
+  # for more details.
+  - werkzeug<2.2.0
   - bokeh
   - httpretty
   - aiohttp

--- a/continuous_integration/scripts/run_tests.sh
+++ b/continuous_integration/scripts/run_tests.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ $PARALLEL == 'true' ]]; then
-    export XTRATESTARGS="-n4 $XTRATESTARGS"
+    export XTRATESTARGS="$XTRATESTARGS"
 fi
 
 if [[ $COVERAGE == 'true' ]]; then

--- a/continuous_integration/scripts/run_tests.sh
+++ b/continuous_integration/scripts/run_tests.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ $PARALLEL == 'true' ]]; then
-    export XTRATESTARGS="$XTRATESTARGS"
+    export XTRATESTARGS="-n4 $XTRATESTARGS"
 fi
 
 if [[ $COVERAGE == 'true' ]]; then


### PR DESCRIPTION
Towards debugging https://github.com/dask/dask/issues/9323