### PR TITLE
Fix small typo in 10 minutes to Dask page

### DIFF
--- a/docs/source/10-minutes-to-dask.rst
+++ b/docs/source/10-minutes-to-dask.rst
@@ -57,7 +57,7 @@ including information about how the chunks should be structured.
       Now we have a Dask DataFrame with 2 columns and 2400 rows composed of 10 partitions where
       each partition has 240 rows. Each partition represents a piece of the data.
 
-      Here are some key properties of an DataFrame:
+      Here are some key properties of a DataFrame:
 
       .. code-block:: python
 


### PR DESCRIPTION
"**an** DataFrame" has changed to "**a** DataFrame" in the _10 minutes to Dask_ file.