### PR TITLE
keepdims keyword for average

### DIFF
--- a/dask/array/ma.py
+++ b/dask/array/ma.py
@@ -170,8 +170,8 @@ def set_fill_value(a, fill_value):
 
 
 @derived_from(np.ma)
-def average(a, axis=None, weights=None, returned=False):
-    return _average(a, axis, weights, returned, is_masked=True)
+def average(a, axis=None, weights=None, returned=False, keepdims=False):
+    return _average(a, axis, weights, returned, is_masked=True, keepdims=keepdims)
 
 
 def _chunk_count(x, axis=None, keepdims=None):

--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -9,6 +9,7 @@ _np_version = parse_version(np.__version__)
 _numpy_120 = _np_version >= parse_version("1.20.0")
 _numpy_121 = _np_version >= parse_version("1.21.0")
 _numpy_122 = _np_version >= parse_version("1.22.0")
+_numpy_123 = _np_version >= parse_version("1.23.0")
 
 
 # Taken from scikit-learn:

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -2435,7 +2435,9 @@ def append(arr, values, axis=None):
     return concatenate((arr, values), axis=axis)
 
 
-def _average(a, axis=None, weights=None, returned=False, is_masked=False):
+def _average(
+    a, axis=None, weights=None, returned=False, is_masked=False, keepdims=False
+):
     # This was minimally modified from numpy.average
     # See numpy license at https://github.com/numpy/numpy/blob/master/LICENSE.txt
     # or NUMPY_LICENSE.txt within this directory
@@ -2443,7 +2445,7 @@ def _average(a, axis=None, weights=None, returned=False, is_masked=False):
     a = asanyarray(a)
 
     if weights is None:
-        avg = a.mean(axis)
+        avg = a.mean(axis, keepdims=keepdims)
         scl = avg.dtype.type(a.size / avg.size)
     else:
         wgt = asanyarray(weights)
@@ -2475,8 +2477,8 @@ def _average(a, axis=None, weights=None, returned=False, is_masked=False):
             from dask.array.ma import getmaskarray
 
             wgt = wgt * (~getmaskarray(a))
-        scl = wgt.sum(axis=axis, dtype=result_dtype)
-        avg = multiply(a, wgt, dtype=result_dtype).sum(axis) / scl
+        scl = wgt.sum(axis=axis, dtype=result_dtype, keepdims=keepdims)
+        avg = multiply(a, wgt, dtype=result_dtype).sum(axis, keepdims=keepdims) / scl
 
     if returned:
         if scl.shape != avg.shape:
@@ -2487,8 +2489,8 @@ def _average(a, axis=None, weights=None, returned=False, is_masked=False):
 
 
 @derived_from(np)
-def average(a, axis=None, weights=None, returned=False):
-    return _average(a, axis, weights, returned, is_masked=False)
+def average(a, axis=None, weights=None, returned=False, keepdims=False):
+    return _average(a, axis, weights, returned, is_masked=False, keepdims=keepdims)
 
 
 @derived_from(np)

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -369,7 +369,8 @@ def test_set_fill_value():
         da.ma.set_fill_value(dmx, dx)
 
 
-def test_average_weights_with_masked_array():
+@pytest.mark.parametrize("keepdims", [False, True])
+def test_average_weights_with_masked_array(keepdims):
     mask = np.array([[True, False], [True, True], [False, True]])
     data = np.arange(6).reshape((3, 2))
     a = np.ma.array(data, mask=mask)
@@ -379,7 +380,11 @@ def test_average_weights_with_masked_array():
     d_weights = da.from_array(weights, chunks=2)
 
     np_avg = np.ma.average(a, weights=weights, axis=1)
-    da_avg = da.ma.average(d_a, weights=d_weights, axis=1)
+    if keepdims:
+        # np.average only takes keepdims keyword from v1.23, so use reshape to
+        # form the expected array.
+        np_avg = np_avg.reshape((3, 1))
+    da_avg = da.ma.average(d_a, weights=d_weights, axis=1, keepdims=keepdims)
 
     assert_eq(np_avg, da_avg)
 

--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import dask.array as da
+from dask.array.numpy_compat import _numpy_123
 from dask.array.utils import assert_eq
 from dask.base import tokenize
 
@@ -379,14 +380,12 @@ def test_average_weights_with_masked_array(keepdims):
     weights = np.array([0.25, 0.75])
     d_weights = da.from_array(weights, chunks=2)
 
-    np_avg = np.ma.average(a, weights=weights, axis=1)
-    if keepdims:
-        # np.average only takes keepdims keyword from v1.23, so use reshape to
-        # form the expected array.
-        np_avg = np_avg.reshape((3, 1))
     da_avg = da.ma.average(d_a, weights=d_weights, axis=1, keepdims=keepdims)
 
-    assert_eq(np_avg, da_avg)
+    if _numpy_123:
+        assert_eq(da_avg, np.ma.average(a, weights=weights, axis=1, keepdims=keepdims))
+    elif not keepdims:
+        assert_eq(da_avg, np.ma.average(a, weights=weights, axis=1))
 
 
 def test_arithmetic_results_in_masked():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -2565,7 +2565,21 @@ def test_average(a, returned):
     assert_eq(np_avg, da_avg)
 
 
-def test_average_weights():
+@pytest.mark.parametrize("a", [np.arange(11), np.arange(6).reshape((3, 2))])
+def test_average_keepdims(a):
+    d_a = da.from_array(a, chunks=2)
+
+    # np.average only takes keepdims keyword from v1.23, so use reshape to form
+    # the expected array.
+    expected_shape = (1,) * a.ndim
+    np_avg = np.average(a).reshape(expected_shape)
+    da_avg = da.average(d_a, keepdims=True)
+
+    assert_eq(np_avg, da_avg)
+
+
+@pytest.mark.parametrize("keepdims", [False, True])
+def test_average_weights(keepdims):
     a = np.arange(6).reshape((3, 2))
     d_a = da.from_array(a, chunks=2)
 
@@ -2573,7 +2587,12 @@ def test_average_weights():
     d_weights = da.from_array(weights, chunks=2)
 
     np_avg = np.average(a, weights=weights, axis=1)
-    da_avg = da.average(d_a, weights=d_weights, axis=1)
+    if keepdims:
+        # np.average only takes keepdims keyword from v1.23, so use reshape to
+        # form the expected array.
+        np_avg = np_avg.reshape((3, 1))
+
+    da_avg = da.average(d_a, weights=d_weights, axis=1, keepdims=keepdims)
 
     assert_eq(np_avg, da_avg)
 


### PR DESCRIPTION
Passes the `keepdims` keyword through `dask.array.average` and `dask.array.ma.average`, similar to the recent change in `numpy`:
https://github.com/numpy/numpy/pull/21485
https://github.com/numpy/numpy/pull/21868

- [N/A] Closes #xxxx
- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`
