### PR TITLE
Import `loop_in_thread` fixture in tests

### DIFF
--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -9,9 +9,15 @@ from functools import partial
 from operator import add
 
 from distributed.utils_test import cleanup  # noqa F401
-from distributed.utils_test import cluster_fixture  # noqa F401
 from distributed.utils_test import client as c  # noqa F401
-from distributed.utils_test import cluster, gen_cluster, inc, loop, varying  # noqa F401
+from distributed.utils_test import (  # noqa F401
+    cluster,
+    cluster_fixture,
+    gen_cluster,
+    loop,
+    loop_in_thread,
+    varying,
+)
 
 import dask
 import dask.bag as db
@@ -21,6 +27,7 @@ from dask.delayed import Delayed
 from dask.distributed import futures_of, wait
 from dask.highlevelgraph import HighLevelGraph, MaterializedLayer
 from dask.utils import get_named_args, tmpdir, tmpfile
+from dask.utils_test import inc
 
 if "should_check_state" in get_named_args(gen_cluster):
     gen_cluster = partial(gen_cluster, should_check_state=False)


### PR DESCRIPTION
Following https://github.com/dask/distributed/pull/6680 we started seeing failures like 

```python
 ____________ ERROR at setup of test_blockwise_fusion_after_compute _____________
[gw2] linux -- Python 3.10.5 /usr/share/miniconda3/envs/test-environment/bin/python
file /home/runner/work/dask/dask/dask/tests/test_distributed.py, line 416
  def test_blockwise_fusion_after_compute(c):
file /usr/share/miniconda3/envs/test-environment/lib/python3.10/site-packages/distributed/utils_test.py, line 596
  @pytest.fixture
  def client(loop, cluster_fixture):
file /usr/share/miniconda3/envs/test-environment/lib/python3.10/site-packages/distributed/utils_test.py, line 145
  @pytest.fixture
  def loop(loop_in_thread):
E       fixture 'loop_in_thread' not found
>       available fixtures: c, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, cleanup, cluster_fixture, cov, doctest_namespace, loop, monkeypatch, no_cover, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, shuffle_method, testrun_uid, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, worker_id
>       use 'pytest --fixtures [testpath]' for help on them.

/usr/share/miniconda3/envs/test-environment/lib/python3.10/site-packages/distributed/utils_test.py:145
```

in [CI builds](https://github.com/pavithraes/dask/runs/7619890993?check_suite_focus=true). 

xref https://github.com/dask/distributed/issues/6806 for a related conversation around what testing utilities in `distributed` should be considered public. This PR just imports the missing pytest fixture as a quickfix to unblock CI

cc @hendrikmakait for visibility 