### PR TITLE
Improve `dataclass` handling in `unpack_collections`

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -3,7 +3,7 @@ import types
 import uuid
 import warnings
 from collections.abc import Iterator
-from dataclasses import fields, is_dataclass
+from dataclasses import fields, is_dataclass, replace
 
 from tlz import concat, curry, merge, unique
 
@@ -111,6 +111,23 @@ def unpack_collections(expr):
         return (slice,) + tuple(args), collections
 
     if is_dataclass(expr):
+        try:
+            _fields = {
+                f.name: getattr(expr, f.name)
+                for f in fields(expr)
+                if hasattr(expr, f.name)
+            }
+            replace(expr, **_fields)
+        except TypeError as e:
+            raise TypeError(
+                f"Failed to unpack {typ} instance. "
+                "Note that using a custom __init__ is not supported."
+            ) from e
+        except ValueError as e:
+            raise ValueError(
+                f"Failed to unpack {typ} instance. "
+                "Note that using fields with `init=False` are not supported."
+            ) from e
         args, collections = unpack_collections(
             [
                 [f.name, getattr(expr, f.name)]

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -3,7 +3,7 @@ import types
 import uuid
 import warnings
 from collections.abc import Iterator
-from dataclasses import FrozenInstanceError, fields, is_dataclass
+from dataclasses import fields, is_dataclass, replace
 
 from tlz import concat, curry, merge, unique
 
@@ -111,40 +111,33 @@ def unpack_collections(expr):
         return (slice,) + tuple(args), collections
 
     if is_dataclass(expr):
-        args = {}
-        collections = ()
-        for field in fields(expr):
-            if not hasattr(expr, field.name):
-                continue
-            field_args, field_collections = unpack_collections(
-                getattr(expr, field.name)
-            )
-            if not field_collections:
-                continue
-            args[field.name] = field_args
-            collections += field_collections
+        args, collections = unpack_collections(
+            [
+                [f.name, getattr(expr, f.name)]
+                for f in fields(expr)
+                if hasattr(expr, f.name)  # if init=False, field might not exist
+            ]
+        )
         if not collections:
             return expr, ()
-
         try:
-            for key in args:
-                expr.__setattr__(key, None)
-        except FrozenInstanceError as e:
-            raise FrozenInstanceError(
+            _fields = {
+                f.name: getattr(expr, f.name)
+                for f in fields(expr)
+                if hasattr(expr, f.name)
+            }
+            replace(expr, **_fields)
+        except TypeError as e:
+            raise TypeError(
                 f"Failed to unpack {typ} instance. "
-                "Note that frozen dataclasses are not supported."
+                "Note that using a custom __init__ is not supported."
             ) from e
-
-        def reconstitute_dataclass(obj, changes):
-            for key, val in changes.items():
-                expr.__setattr__(key, val)
-            return obj
-
-        return (
-            reconstitute_dataclass,
-            expr,
-            (dict, [[k, v] for k, v in args.items()]),
-        ), collections
+        except ValueError as e:
+            raise ValueError(
+                f"Failed to unpack {typ} instance. "
+                "Note that using fields with `init=False` are not supported."
+            ) from e
+        return (apply, typ, (), (dict, args)), collections
 
     return expr, ()
 

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -138,7 +138,10 @@ def test_delayed_with_dataclass_with_eager_custom_init():
     class ADataClass:
         a: int
 
-    with_class = delayed({"data": ADataClass(a=3)})
+        def __init__(self, b: int):
+            self.a = b
+
+    with_class = delayed({"data": ADataClass(b=3)})
 
     def return_nested(obj):
         return obj["data"].a


### PR DESCRIPTION
This PR changes the way `dataclass` instances are handled in `unpack_collections` as follows:
* If unpacking does not reveal any embedded dask collections, we return the untouched object.
* Instead of relying on the `__init__` function to reconstitute the instance after evaluation, we mutate the existing object and replace all attributes that contained embedded collections. This avoids issues with custom `__init__` functions and fields with `init=False` that have already been set. **Note that this means that `unpack_collections` now mutates its input!**


- [x] Closes #9324
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
