### PR TITLE
Fix bag sampling when there are some smaller partitions

### DIFF
--- a/dask/bag/tests/test_random.py
+++ b/dask/bag/tests/test_random.py
@@ -121,6 +121,13 @@ def test_sample_k_equal_bag_size_with_unbalanced_partitions():
     assert len(set(li)) == len(li)
 
 
+def test_sample_k_larger_than_partitions():
+    bag = db.from_sequence(range(10), partition_size=3)
+    bag2 = random.sample(bag, k=8, split_every=2)
+    seq = bag2.compute()
+    assert len(seq) == 8
+
+
 def test_weighted_sampling_without_replacement():
     population = range(4)
     p = [0.01, 0.33, 0.33, 0.33]

--- a/dask/bag/tests/test_random.py
+++ b/dask/bag/tests/test_random.py
@@ -86,9 +86,7 @@ def test_sample_k_bigger_than_bag_size():
     seq = range(3)
     sut = db.from_sequence(seq, npartitions=3)
     # should raise: Sample larger than population or is negative
-    with pytest.raises(
-        ValueError, match="Sample larger than population or is negative"
-    ):
+    with pytest.raises(ValueError, match="Sample larger than population"):
         random.sample(sut, k=4).compute()
 
 


### PR DESCRIPTION
Fixes the rest of #9249. Currently, if you have some imbalanced partitions in a bag such that some of them are small, and then sample from that bag with a `k` larger than those partitions, you can run into the error in #9249. The error message isn't correct in that case.

I still need to write some tests and also sit down with a pencil and paper to convince myself and others that this doesn't bias the sampling, so marking as a draft until I can get around to that.

- [x] Closes #9249
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
