### PR TITLE
Update deploying-python.rst

### DIFF
--- a/docs/source/deploying-python.rst
+++ b/docs/source/deploying-python.rst
@@ -96,3 +96,4 @@ Reference
 
 .. autoclass:: LocalCluster
    :members:
+   :undoc-members: memory_limit


### PR DESCRIPTION
Since memory_limit is not part of the member args, I took a look at the sphinx documentation and found that :undoc-members: generates a doc for members not having docstrings (which I believe there is no docstring for memory_limit). Please let me know if I'm on the right track - the changes don't reflect when running `make html` however. I'm still fairly new to sphinx as well as dask but eager to work on this issue!

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
