### PR TITLE
Consolidate dashboard diagnostics documentation

### DIFF
--- a/docs/source/10-minutes-to-dask.rst
+++ b/docs/source/10-minutes-to-dask.rst
@@ -541,4 +541,4 @@ see your tasks as they are processed.
    >>> client.dashboard_link
    'http://127.0.0.1:8787/status'
 
-To learn more about those graphs take a look at :doc:`diagnostics-distributed`.
+To learn more about those graphs take a look at :doc:`dashboard`.

--- a/docs/source/dashboard.rst
+++ b/docs/source/dashboard.rst
@@ -20,7 +20,7 @@ Dask's :doc:`distributed scheduler <scheduling>` makes this easier with live mon
 of your Dask computations. The dashboard is built with `Bokeh <https://docs.bokeh.org>`_
 and will start up automatically, returning a link to the dashboard whenever the scheduler is created.
 
-Locally, this is when you create a :meth:`Client <distributed.client.Client>` and connect the scheduler:
+Locally, this is when you create a :class:`Client <distributed.client.Client>` and connect the scheduler:
 
 .. code-block:: python
 
@@ -36,7 +36,7 @@ You can also query the address from ``client.dashboard_link`` (or for older vers
 
 By default, when starting a scheduler on your local machine the dashboard will be served at ``http://localhost:8787/status``. You can type this address into your browser to access the dashboard, but may be directed 
 elsewhere if port 8787 is taken. You can also configure the address using the ``dashboard_address``
-parameter (see :meth:`LocalCluster <distributed.deploy.local.LocalCluster>`).
+parameter (see :class:`LocalCluster <distributed.deploy.local.LocalCluster>`).
 
 There are numerous diagnostic plots available. In this guide you'll learn about some
 of the most commonly used plots shown on the entry point for the dashboard:

--- a/docs/source/dashboard.rst
+++ b/docs/source/dashboard.rst
@@ -1,31 +1,45 @@
 Dashboard Diagnostics
 =====================
 
-Profiling parallel code can be challenging, but the :doc:`Dask distributed scheduler <scheduling>` 
-provides live feedback via its interactive dashboard. A link that redirects to the dashboard will prompt 
-in the terminal where the scheduler is created, and it is also shown when you create a ``Client`` and connect 
-the scheduler.
+.. meta::
+   :description: The interactive Dask dashboard provides numerous diagnostic plots for live monitoring of your Dask computation. It includes information about task runtimes, communication, statistical profiling, load balancing, memory use, and much more.
+
+.. raw:: html
+
+    <iframe width="560"
+            height="315"
+            src="https://www.youtube.com/embed/N_GqzcuGLCY"
+            frameborder="0"
+            allow="autoplay; encrypted-media"
+            style="margin: 0 auto 20px auto; display: block;"
+            allowfullscreen>
+    </iframe>
+
+Profiling parallel code can be challenging, but the interactive dashboard provided with
+Dask's :doc:`distributed scheduler <scheduling>` makes this easier with live monitoring
+of your Dask computations. The dashboard is built with `Bokeh <https://docs.bokeh.org>`_
+and will start up automatically, returning a link to the dashboard whenever the scheduler is created.
+
+Locally, this is when you create a :meth:`Client <distributed.client.Client>` and connect the scheduler:
 
 .. code-block:: python
 
    from dask.distributed import Client
-   client = Client()  # start distributed scheduler locally. 
-   client            
+   client = Client()  # start distributed scheduler locally.
 
-In a Jupyter Notebook or JupyterLab session displaying the client object will show the dashboard address
-as following:
+In a Jupyter Notebook or JupyterLab session displaying the client object will show the dashboard address:
 
 .. figure:: images/dashboard_link.png
-    :alt: Client html repr displaying the dashboard link on a JupyterLab session. 
+    :alt: Client html repr displaying the dashboard link in a JupyterLab session.
 
-The address of the dashboard will be displayed if you are in a Jupyter Notebook,
-or, if you are in a terminal or IPython, it can be queried from ``client.dashboard_link``. By default, when starting a scheduler 
-on your local machine the dashboard will be served at ``http://localhost:8787/status``. You
-can type this address into your browser to access the dashboard, but may be directed 
-elsewhere if port 8787 is taken. You can also configure the address by passing options to the 
-scheduler, see ``dashboard_address`` in `LocalCluster <https://docs.dask.org/en/stable/deploying-python.html#reference>`__
+You can also query the address from ``client.dashboard_link`` (or for older versions of distributed, ``client.scheduler_info()['services']``).
 
-The dashboard link redirects you to the entry point of the dashboard with information on:
+By default, when starting a scheduler on your local machine the dashboard will be served at ``http://localhost:8787/status``. You can type this address into your browser to access the dashboard, but may be directed 
+elsewhere if port 8787 is taken. You can also configure the address using the ``dashboard_address``
+parameter (see :meth:`LocalCluster <distributed.deploy.local.LocalCluster>`).
+
+There are numerous diagnostic plots available. In this guide you'll learn about some
+of the most commonly used plots shown on the entry point for the dashboard:
 
 - :ref:`dashboard.memory`: Cluster memory and Memory per worker
 - :ref:`dashboard.proc-cpu-occ`:  Tasks being processed by each worker/ CPU Utilization per worker/ Expected runtime for all tasks currently on a worker.
@@ -34,7 +48,6 @@ The dashboard link redirects you to the entry point of the dashboard with inform
 
 .. figure:: images/dashboard_status.png
     :alt: Main dashboard with five panes arranged into two columns. In the left column there are three bar charts. The top two show total bytes stored and bytes per worker. The bottom has three tabs to toggle between task processing, CPU utilization, and occupancy. In the right column, there are two bar charts with corresponding colors showing task activity over time, referred to as task stream and progress.
-
 
 .. _dashboard.memory: 
 

--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -13,40 +13,7 @@ forms:
 Dashboard
 ---------
 
-.. raw:: html
-
-    <iframe width="560"
-            height="315"
-            src="https://www.youtube.com/embed/N_GqzcuGLCY"
-            frameborder="0"
-            allow="autoplay; encrypted-media"
-            allowfullscreen>
-    </iframe>
-
-If `Bokeh <https://docs.bokeh.org>`_ is installed
-then the dashboard will start up automatically whenever the scheduler is created.
-For local use this happens when you create a client with no arguments:
-
-.. code-block:: python
-
-   from dask.distributed import Client
-   client = Client()  # start distributed scheduler locally.  Launch dashboard
-
-It is typically served at ``http://localhost:8787/status`` ,
-but may be served elsewhere if this port is taken.
-The address of the dashboard will be displayed if you are in a Jupyter Notebook,
-or can be queried from ``client.dashboard_link``
-(or for older versions of distributed, ``client.scheduler_info()['services']``).
-
-There are numerous pages with information about task runtimes, communication,
-statistical profiling, load balancing, memory use, and much more.
-For more information we recommend the video guide above.
-
-.. currentmodule:: dask.distributed
-
-.. autosummary::
-   Client
-
+For information on the Dask dashboard see :doc:`dashboard`.
 
 Capture diagnostics
 -------------------

--- a/docs/source/diagnostics-distributed.rst
+++ b/docs/source/diagnostics-distributed.rst
@@ -18,6 +18,8 @@ For information on the Dask dashboard see :doc:`dashboard`.
 Capture diagnostics
 -------------------
 
+.. currentmodule:: dask.distributed
+
 .. autosummary::
    get_task_stream
    Client.profile

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -336,7 +336,7 @@ can be surprising.
 
 Our main solution to build this intuition, other than
 accumulated experience, is Dask's :doc:`Diagnostic Dashboard
-<diagnostics-distributed>`.
+<dashboard>`.
 The dashboard delivers a ton of visual feedback to users as they are running
 their computation to help them understand what is going on.  This both helps
 them to identify and resolve immediate bottlenecks, and also builds up that


### PR DESCRIPTION
These edits are tangentially related to improving SEO. Currently, https://docs.dask.org/en/stable/diagnostics-distributed.html ranks in the top spot for when people search for the diagnostics dashboard. Instead, I think we'd rather people find https://docs.dask.org/en/stable/dashboard.html. This PR consolidates the dashboard information onto https://docs.dask.org/en/stable/dashboard.html and updates some of the internal documentation references accordingly.

@ncclementi, would this be OK with you? Asking since it sounded like you had some thoughts on preserving the dashboard content in diagnostics-distributed [#8648 here](https://github.com/dask/dask/pull/8648#issuecomment-1028044453).

cc @jacobtomlinson @jsignell @jrbourbeau