### PR TITLE
Unpack `namedtuple`

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -33,7 +33,7 @@ from dask.core import literal, quote
 from dask.hashing import hash_buffer_hex
 from dask.system import CPU_COUNT
 from dask.typing import SchedulerGetCallable
-from dask.utils import Dispatch, apply, ensure_dict, key_split
+from dask.utils import Dispatch, apply, ensure_dict, is_namedtuple_instance, key_split
 
 __all__ = (
     "DaskMethodsMixin",
@@ -463,6 +463,8 @@ def unpack_collections(*args, traverse=True):
                         ],
                     ),
                 )
+            elif is_namedtuple_instance(expr):
+                tsk = (typ, *[_unpack(i) for i in expr])
             else:
                 return expr
 

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -4,7 +4,6 @@ import uuid
 import warnings
 from collections.abc import Iterator
 from dataclasses import fields, is_dataclass, replace
-from typing import Any
 
 from tlz import concat, curry, merge, unique
 
@@ -20,7 +19,13 @@ from dask.base import tokenize as _tokenize
 from dask.context import globalmethod
 from dask.core import flatten, quote
 from dask.highlevelgraph import HighLevelGraph
-from dask.utils import OperatorMethodMixin, apply, funcname, methodcaller
+from dask.utils import (
+    OperatorMethodMixin,
+    apply,
+    funcname,
+    is_namedtuple_instance,
+    methodcaller,
+)
 
 __all__ = ["Delayed", "delayed"]
 
@@ -45,16 +50,6 @@ def finalize(collection):
     layer = {name: (finalize, keys) + args}
     graph = HighLevelGraph.from_collections(name, layer, dependencies=[collection])
     return Delayed(name, graph)
-
-
-def is_namedtuple_instance(obj: Any) -> bool:
-    "Returns True if obj is an instance of a namedtuple."
-    return (
-        isinstance(obj, tuple)
-        and hasattr(obj, "_asdict")
-        and hasattr(obj, "_fields")
-        and hasattr(obj, "_replace")
-    )
 
 
 def unpack_collections(expr):

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -46,6 +46,15 @@ def finalize(collection):
     return Delayed(name, graph)
 
 
+def is_namedtuple_instance(obj):
+    return (
+        isinstance(obj, tuple)
+        and hasattr(obj, "_asdict")
+        and hasattr(obj, "_fields")
+        and hasattr(obj, "_replace")
+    )
+
+
 def unpack_collections(expr):
     """Normalize a python object and merge all sub-graphs.
 
@@ -137,6 +146,12 @@ def unpack_collections(expr):
                 f"Failed to unpack {typ} instance. "
                 "Note that using fields with `init=False` are not supported."
             ) from e
+        return (apply, typ, (), (dict, args)), collections
+
+    if is_namedtuple_instance(expr):
+        args, collections = unpack_collections(
+            [[k, v] for k, v in expr._asdict().items()]
+        )
         return (apply, typ, (), (dict, args)), collections
 
     return expr, ()

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from concurrent.futures import Executor
 from enum import Enum, Flag, IntEnum, IntFlag
 from operator import add, mul
-from typing import Union
+from typing import NamedTuple, Union
 
 import pytest
 from tlz import compose, curry, merge, partial
@@ -449,8 +449,14 @@ def test_tokenize_enum(enum_type):
     assert tokenize(Color.RED) != tokenize(Color.BLUE)
 
 
-ADataClass = dataclasses.make_dataclass("ADataClass", [("a", int)])
-BDataClass = dataclasses.make_dataclass("BDataClass", [("a", Union[int, float])])  # type: ignore
+@dataclasses.dataclass
+class ADataClass:
+    a: int
+
+
+@dataclasses.dataclass
+class BDataClass:
+    a: float
 
 
 def test_tokenize_dataclass():
@@ -584,6 +590,9 @@ def test_is_dask_collection():
 
 
 def test_unpack_collections():
+    class ANamedTuple(NamedTuple):
+        a: int
+
     a = delayed(1) + 5
     b = a + 1
     c = a + 2
@@ -600,12 +609,12 @@ def test_unpack_collections():
                 "d": (c, 2),  # tuple
                 "e": {a, 2, 3},  # set
                 "f": OrderedDict([("a", a)]),
+                "g": ADataClass(a=a),  # dataclass instance
+                "h": (ADataClass, a),  # dataclass constructor
+                "i": ANamedTuple(a=a),  # namedtuple instance
             },  # OrderedDict
             iterator,
         )  # Iterator
-
-        t[2]["f"] = ADataClass(a=a)
-        t[2]["g"] = (ADataClass, a)
 
         return t
 

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -54,11 +54,11 @@ def test_to_task_dask():
     assert task == (dict, [["b", 2], ["a", 1]]) or task == (dict, [["a", 1], ["b", 2]])
     assert dict(dask) == merge(a.dask, b.dask)
 
-    f = namedtuple("f", ["x", "y"])
-    x = f(1, 2)
+    f = namedtuple("f", ["a", "b", "c"])
+    x = f(a, b, 3)
     task, dask = to_task_dask(x)
-    assert task == x
-    assert dict(dask) == {}
+    assert task == (f, "a", "b", 3)
+    assert dict(dask) == merge(a.dask, b.dask)
 
     task, dask = to_task_dask(slice(a, b, 3))
     assert task == (slice, "a", "b", 3)

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from functools import partial
 from operator import add, matmul, setitem
 from random import random
+from typing import NamedTuple
 
 import cloudpickle
 import pytest
@@ -91,6 +92,21 @@ def test_delayed():
     assert 1 in a.dask.values()
     b = add2(add2(a, 2), 3)
     assert a.key in b.dask
+
+
+def test_delayed_with_namedtuple():
+    class ANamedTuple(NamedTuple):
+        a: int
+
+    literal = dask.delayed(3)
+    with_class = dask.delayed({"a": ANamedTuple(a=literal)})
+
+    def return_nested(obj):
+        return obj["a"].a
+
+    final = delayed(return_nested)(with_class)
+
+    assert final.compute() == 3
 
 
 @dataclass

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -2064,3 +2064,20 @@ def maybe_pluralize(count, noun, plural_form=None):
         return f"{count} {noun}"
     else:
         return f"{count} {plural_form or noun + 's'}"
+
+
+def is_namedtuple_instance(obj: Any) -> bool:
+    """Returns True if obj is an instance of a namedtuple.
+
+    Note: This function checks for the existence of the methods and
+    attributes that make up the namedtuple API, so it will return True
+    IFF obj's type implements that API.
+    """
+    return (
+        isinstance(obj, tuple)
+        and hasattr(obj, "_make")
+        and hasattr(obj, "_asdict")
+        and hasattr(obj, "_replace")
+        and hasattr(obj, "_fields")
+        and hasattr(obj, "_field_defaults")
+    )


### PR DESCRIPTION
This PR adds support for unpacking `namedtuple`s in `unpack_collections` and `to_task_graph`.

- [x] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
