### PR TITLE
Fix type annotations for `dd.from_pandas` and `dd.from_delayed`

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -6,7 +6,7 @@ from functools import partial
 from math import ceil
 from operator import getitem
 from threading import Lock
-from typing import TYPE_CHECKING, Iterable, Literal
+from typing import TYPE_CHECKING, Iterable, Literal, overload
 
 import numpy as np
 import pandas as pd
@@ -151,6 +151,16 @@ def from_array(x, chunksize=50000, columns=None, meta=None):
         else:
             dsk[name, i] = (type(meta), data, None, meta.columns)
     return new_dd_object(dsk, name, meta, divisions)
+
+
+@overload
+def from_pandas(data: pd.DataFrame) -> DataFrame:
+    ...
+
+
+@overload
+def from_pandas(data: pd.Series) -> Series:
+    ...
 
 
 def from_pandas(

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -159,7 +159,7 @@ def from_pandas(
     chunksize: int | None = None,
     sort: bool = True,
     name: str | None = None,
-) -> DataFrame | Series:
+) -> DataFrame:
     """
     Construct a Dask DataFrame from a Pandas DataFrame
 
@@ -671,7 +671,7 @@ def from_delayed(
     divisions: tuple | Literal["sorted"] | None = None,
     prefix: str = "from-delayed",
     verify_meta: bool = True,
-) -> DataFrame | Series:
+) -> DataFrame:
     """Create Dask DataFrame from many Dask Delayed objects
 
     Parameters

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -154,12 +154,24 @@ def from_array(x, chunksize=50000, columns=None, meta=None):
 
 
 @overload
-def from_pandas(data: pd.DataFrame) -> DataFrame:
+def from_pandas(
+    data: pd.DataFrame,
+    npartitions: int | None = None,
+    chunksize: int | None = None,
+    sort: bool = True,
+    name: str | None = None,
+) -> DataFrame:
     ...
 
 
 @overload
-def from_pandas(data: pd.Series) -> Series:
+def from_pandas(
+    data: pd.Series,
+    npartitions: int | None = None,
+    chunksize: int | None = None,
+    sort: bool = True,
+    name: str | None = None,
+) -> Series:
     ...
 
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -156,10 +156,10 @@ def from_array(x, chunksize=50000, columns=None, meta=None):
 @overload
 def from_pandas(
     data: pd.DataFrame,
-    npartitions: int | None = ...,
-    chunksize: int | None = ...,
-    sort: bool = ...,
-    name: str | None = ...,
+    npartitions: int | None = None,
+    chunksize: int | None = None,
+    sort: bool = True,
+    name: str | None = None,
 ) -> DataFrame:
     ...
 
@@ -169,10 +169,10 @@ def from_pandas(
 @overload
 def from_pandas(  # type: ignore
     data: pd.Series,
-    npartitions: int | None = ...,
-    chunksize: int | None = ...,
-    sort: bool = ...,
-    name: str | None = ...,
+    npartitions: int | None = None,
+    chunksize: int | None = None,
+    sort: bool = True,
+    name: str | None = None,
 ) -> Series:
     ...
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -156,21 +156,23 @@ def from_array(x, chunksize=50000, columns=None, meta=None):
 @overload
 def from_pandas(
     data: pd.DataFrame,
-    npartitions: int | None = None,
-    chunksize: int | None = None,
-    sort: bool = True,
-    name: str | None = None,
+    npartitions: int | None = ...,
+    chunksize: int | None = ...,
+    sort: bool = ...,
+    name: str | None = ...,
 ) -> DataFrame:
     ...
 
 
+# We ignore this overload for now until pandas-stubs can be added.
+# See https://github.com/dask/dask/issues/9220
 @overload
-def from_pandas(
+def from_pandas(  # type: ignore
     data: pd.Series,
-    npartitions: int | None = None,
-    chunksize: int | None = None,
-    sort: bool = True,
-    name: str | None = None,
+    npartitions: int | None = ...,
+    chunksize: int | None = ...,
+    sort: bool = ...,
+    name: str | None = ...,
 ) -> Series:
     ...
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -159,7 +159,7 @@ def from_pandas(
     chunksize: int | None = None,
     sort: bool = True,
     name: str | None = None,
-) -> DataFrame:
+) -> DataFrame | Series:
     """
     Construct a Dask DataFrame from a Pandas DataFrame
 
@@ -671,7 +671,7 @@ def from_delayed(
     divisions: tuple | Literal["sorted"] | None = None,
     prefix: str = "from-delayed",
     verify_meta: bool = True,
-) -> DataFrame:
+) -> DataFrame | Series:
     """Create Dask DataFrame from many Dask Delayed objects
 
     Parameters


### PR DESCRIPTION
Reverting the change introduced in: https://github.com/dask/dask/pull/9237

Returning a union of types is breaking mypy. If you run mypy on the example below you get the error `test.py:9: error: Argument 1 to "foo" has incompatible type "Union[DataFrame, Series]"; expected "DataFrame"`

```
import dask
import pandas as pd

test_ddf = dask.dataframe.io.from_pandas(pd.DataFrame([]))

def foo(ddf: dask.dataframe.DataFrame) -> dask.dataframe.DataFrame:
    return ddf

foo(test_ddf)
```

I don't think this is the how it should stay but reverting the change unblocks mypy.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
