### PR TITLE
Upload environment file artifact for each CI build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,14 @@ jobs:
         shell: bash -l {0}
         run: source continuous_integration/scripts/install.sh
 
+      # This environment file is created in continuous_integration/scripts/install.sh
+      # and can be useful when debugging locally
+      - name: Upload environment file
+        uses: actions/upload-artifact@v3
+        with:
+          name: env-${{ matrix.os }}-Python-${{ matrix.python-version }}
+          path: env.yaml
+
       - name: Run tests
         shell: bash -l {0}
         run: source continuous_integration/scripts/run_tests.sh

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -44,6 +44,7 @@ mamba list
 
 # For debugging
 echo -e "--\n--Conda Environment (re-create this with \`conda env create --name <name> -f <output_file>\`)\n--"
-mamba env export | grep -E -v '^prefix:.*$'
+mamba env export | grep -E -v '^prefix:.*$' > env.yaml
+cat env.yaml
 
 set +xe


### PR DESCRIPTION
Sometimes when debugging a CI failure I want to recreate the same environment locally on my laptop that's used in CI. Today we have a nice `mamba env export` which prints out the contents of the environment which I can then copy to a local file and use `mamba env create ...` to get my environment. This PR adds a new step to our CI builds to actually upload the contents of our `mamba env export` output as a file artifact. This is solely for convenience when debugging locally, but seems like a reasonable nice-to-have. 

cc @ian-r-rose @jsignell for thoughts 