### PR TITLE
[WIP] Avoid intermediate sorting in groupby ACA

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1676,7 +1676,10 @@ class _GroupBy:
             chunk_args,
             chunk=_groupby_apply_funcs,
             chunk_kwargs=dict(
-                funcs=chunk_funcs, sort=False, **self.observed, **self.dropna
+                funcs=chunk_funcs,
+                sort=False,
+                **self.observed,
+                **self.dropna,
             ),
             combine=_groupby_apply_funcs,
             combine_kwargs=dict(

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1675,10 +1675,16 @@ class _GroupBy:
         return aca(
             chunk_args,
             chunk=_groupby_apply_funcs,
-            chunk_kwargs=dict(funcs=chunk_funcs, **self.observed, **self.dropna),
+            chunk_kwargs=dict(
+                funcs=chunk_funcs, sort=False, **self.observed, **self.dropna
+            ),
             combine=_groupby_apply_funcs,
             combine_kwargs=dict(
-                funcs=aggregate_funcs, level=levels, **self.observed, **self.dropna
+                funcs=aggregate_funcs,
+                sort=False,
+                level=levels,
+                **self.observed,
+                **self.dropna,
             ),
             aggregate=_agg_finalize,
             aggregate_kwargs=dict(


### PR DESCRIPTION
While working on #9302 I discovered that the performance of memory-constrained groupby aggregations (those requiring significant spilling) can be improved by setting `sort=False` for intermediate aggregations. While this simple change does **not** improve performance when the aggregation fits comfortably in memory (and may even introduce a slight regression), avoiding the sort seems to change some problematic cases from failures to successes.

Note that this is marked as WIP, because I am still unsure if this particular change is the best way to improve groupby stability.