### PR TITLE
[DNM] Avoid implicit compute in `Array.__bool__`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1836,7 +1836,7 @@ class Array(DaskMethodsMixin):
                 "Use a.any() or a.all()."
             )
         else:
-            return bool(self.compute())
+            raise RuntimeError("asdfasdf")
 
     __nonzero__ = __bool__  # python 2
 


### PR DESCRIPTION
When looking through https://github.com/dask/dask/pull/9351 I noticed that we're currently triggering implicit `compute`s in `Array.__bool__` for Dask arrays with size 1. This is particularly confusing as it can be easy to trigger these (potentially large) computations when using in an `if`-statement. 

I'm curious to see how much of our test suite fails when we don't allow this type of implicit compute. 

Also cc @jakirkham who has previously commented on this behavior https://github.com/dask/dask/pull/2958#issuecomment-349061303 and may have thoughts on this topic 

