### PR TITLE
Use `entry_points` utility in `sizeof`

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -15,10 +15,10 @@ def entry_points(group=None):
     In 3.10 the return type changed from a dict to an ``importlib.metadata.EntryPoints``.
     This compatibility utility can be removed once Python 3.10 is the minimum.
     """
-    eps = importlib.metadata.entry_points()
-    if group:
-        try:
-            return eps.select(group=group)
-        except AttributeError:
+    if _PY_VERSION >= parse_version("3.10"):
+        return importlib.metadata.entry_points(group=group)
+    else:
+        eps = importlib.metadata.entry_points()
+        if group:
             return eps.get(group, [])
-    return eps
+        return eps

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -1,10 +1,10 @@
-import importlib.metadata
 import itertools
 import logging
 import random
 import sys
 from array import array
 
+from dask.compatibility import entry_points
 from dask.utils import Dispatch
 
 sizeof = Dispatch(name="sizeof")
@@ -216,11 +216,7 @@ def register_pyarrow():
 
 def _register_entry_point_plugins():
     """Register sizeof implementations exposed by the entry_point mechanism."""
-    if sys.version_info >= (3, 10):
-        sizeof_entry_points = importlib.metadata.entry_points(group="dask.sizeof")
-    else:
-        sizeof_entry_points = importlib.metadata.entry_points().get("dask.sizeof", [])
-
+    sizeof_entry_points = entry_points(group="dask.sizeof")
     for entry_point in sizeof_entry_points:
         registrar = entry_point.load()
         try:

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -216,8 +216,7 @@ def register_pyarrow():
 
 def _register_entry_point_plugins():
     """Register sizeof implementations exposed by the entry_point mechanism."""
-    sizeof_entry_points = entry_points(group="dask.sizeof")
-    for entry_point in sizeof_entry_points:
+    for entry_point in entry_points(group="dask.sizeof"):
         registrar = entry_point.load()
         try:
             registrar(sizeof)


### PR DESCRIPTION
Following https://github.com/dask/dask/pull/9388, I remembered that we're using entrypoints in `sizeof`. This PR makes use of our new utility when handling `dask.sizeof` entrypoints. 

cc @jacobtomlinson 