### PR TITLE
Fuse compatible annotations

### DIFF
--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -358,8 +358,13 @@ def test_optimize_blockwise_control_annotations():
     assert annotations["priority"] == 4  # max
     assert annotations["retries"] == 5  # max
     assert annotations["allow_other_workers"] is False  # More restrictive
-    assert annotations["workers"] == ["b", "c"]  # intersection
+    assert set(annotations["workers"]) == {"b", "c"}  # intersection
     assert annotations["resources"] == {"GPU": 5, "Memory": 10}  # Max of resources
+
+    # If we disable blockwise annotation fusion, we can only fuse the first two layers.
+    with dask.config.set({"optimization.fuse.blockwise-annotations": False}):
+        dsk = da.optimization.optimize_blockwise(g.dask)
+        assert len(dsk.layers) == 6
 
 
 def test_optimize_blockwise_custom_annotations():

--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -366,7 +366,7 @@ def test_optimize_blockwise_control_annotations():
     assert annotations["resources"] == {"GPU": 5, "Memory": 10}  # Max of resources
 
     # If we disable blockwise annotation fusion, we can only fuse the first two layers.
-    with dask.config.set({"optimization.fuse.blockwise-annotations": False}):
+    with dask.config.set({"optimization.annotations.fuse": False}):
         dsk = da.optimization.optimize_blockwise(h.dask)
         assert len(dsk.layers) == 7
 

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1420,7 +1420,7 @@ def _can_fuse_annotations(a: dict | None, b: dict | None) -> bool:
     if a == b:
         return True
 
-    if dask.config.get("optimization.fuse.blockwise-annotations") is False:
+    if dask.config.get("optimization.annotations.fuse") is False:
         return False
 
     fusable = {"retries", "priority", "resources", "workers", "allow_other_workers"}

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1417,7 +1417,7 @@ def _can_fuse_annotations(a: dict | None, b: dict | None) -> bool:
     rules to capture their intent in a fused layer.
     """
     # TODO: add rules for workers, allow_other_workers, resources
-    fusable = {"retries", "priority", "workers", "resources"}
+    fusable = {"retries", "priority"}
     if (not a or all(k in fusable for k in a)) and (
         not b or all(k in fusable for k in b)
     ):
@@ -1435,7 +1435,10 @@ def _fuse_annotations(*args: dict) -> dict:
     Currently only handles "retries" and "priority"
     """
     # TODO: add rules for workers, allow_other_workers, resources
-    anno = {}
+
+    # First, do a basic dict merge -- we are presuming that these have already
+    # been gated by `_can_fuse_annotations`.
+    anno = toolz.merge(*args)
     # Max of layer retries
     retries = [a["retries"] for a in args if "retries" in a]
     if retries:

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1439,31 +1439,31 @@ def _fuse_annotations(*args: dict) -> dict:
     """
     # First, do a basic dict merge -- we are presuming that these have already
     # been gated by `_can_fuse_annotations`.
-    anno = toolz.merge(*args)
+    annotations = toolz.merge(*args)
     # Max of layer retries
     retries = [a["retries"] for a in args if "retries" in a]
     if retries:
-        anno["retries"] = max(retries)
+        annotations["retries"] = max(retries)
     # Max of layer priorities
     priorities = [a["priority"] for a in args if "priority" in a]
     if priorities:
-        anno["priority"] = max(priorities)
+        annotations["priority"] = max(priorities)
     # Max of all the layer resources
     resources = [a["resources"] for a in args if "resources" in a]
     if resources:
-        anno["resources"] = toolz.merge_with(max, *resources)
+        annotations["resources"] = toolz.merge_with(max, *resources)
     # Intersection of all the worker restrictions
     workers = [a["workers"] for a in args if "workers" in a]
     if workers:
-        anno["workers"] = list(set.intersection(*[set(w) for w in workers]))
+        annotations["workers"] = list(set.intersection(*[set(w) for w in workers]))
     # More restrictive of allow_other_workers
     allow_other_workers = [
         a["allow_other_workers"] for a in args if "allow_other_workers" in a
     ]
     if allow_other_workers:
-        anno["allow_other_workers"] = all(allow_other_workers)
+        annotations["allow_other_workers"] = all(allow_other_workers)
 
-    return anno
+    return annotations
 
 
 def rewrite_blockwise(inputs):

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -1436,11 +1436,7 @@ def _fuse_annotations(*args: dict) -> dict:
     """
     Given an iterable of annotations dictionaries, fuse them according
     to some simple rules.
-
-    Currently only handles "retries" and "priority"
     """
-    # TODO: add rules for workers, allow_other_workers, resources
-
     # First, do a basic dict merge -- we are presuming that these have already
     # been gated by `_can_fuse_annotations`.
     anno = toolz.merge(*args)

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -93,17 +93,19 @@ properties:
     properties:
 
       annotations:
-        fuse:
-          type: boolean
-          description: |
-            If adjacent blockwise layers have different annotations (e.g., one has
-            retries=3 and another has retries=4), Dask can make an attempt to merge
-            those annotations according to some simple rules. ``retries`` is set to
-            the max of the layers, ``priority`` is set to the max of the layers,
-            ``resources`` are set to the max of all the resources, ``workers`` is
-            set to the intersection of the requested workers. If this setting is
-            disabled, then adjacent blockwise layers with different annotations
-            will *not* be fused.
+        type: object
+        properties:
+          fuse:
+            type: boolean
+            description: |
+              If adjacent blockwise layers have different annotations (e.g., one has
+              retries=3 and another has retries=4), Dask can make an attempt to merge
+              those annotations according to some simple rules. ``retries`` is set to
+              the max of the layers, ``priority`` is set to the max of the layers,
+              ``resources`` are set to the max of all the resources, ``workers`` is
+              set to the intersection of the requested workers. If this setting is
+              disabled, then adjacent blockwise layers with different annotations
+              will *not* be fused.
 
       fuse:
         type: object

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -147,3 +147,15 @@ properties:
               comprehensible, but it comes at the cost of additional processing. If
               False, then the top-most key will be used. For advanced usage, a function
               to create the new name is also accepted.
+
+          blockwise-annotations:
+            type: boolean
+            description: |
+              If adjacent blockwise layers have different annotations (e.g., one has
+              retries=3 and another has retries=4), Dask can make an attempt to merge
+              those anotations according to some simple rules. ``retries`` is set to
+              the max of the layers, ``priority`` is set to the max of the layers,
+              ``resources`` are set to the max of all the resources, ``workers`` is
+              set to the intersection of the requested workers. If this setting is
+              disabled, then adjacent blockwise layers with different annotations
+              will *not* be fused.

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -153,7 +153,7 @@ properties:
             description: |
               If adjacent blockwise layers have different annotations (e.g., one has
               retries=3 and another has retries=4), Dask can make an attempt to merge
-              those anotations according to some simple rules. ``retries`` is set to
+              those annotations according to some simple rules. ``retries`` is set to
               the max of the layers, ``priority`` is set to the max of the layers,
               ``resources`` are set to the max of all the resources, ``workers`` is
               set to the intersection of the requested workers. If this setting is

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -92,6 +92,19 @@ properties:
     type: object
     properties:
 
+      annotations:
+        fuse:
+          type: boolean
+          description: |
+            If adjacent blockwise layers have different annotations (e.g., one has
+            retries=3 and another has retries=4), Dask can make an attempt to merge
+            those annotations according to some simple rules. ``retries`` is set to
+            the max of the layers, ``priority`` is set to the max of the layers,
+            ``resources`` are set to the max of all the resources, ``workers`` is
+            set to the intersection of the requested workers. If this setting is
+            disabled, then adjacent blockwise layers with different annotations
+            will *not* be fused.
+
       fuse:
         type: object
         description: Options for Dask's task fusion optimizations
@@ -147,15 +160,3 @@ properties:
               comprehensible, but it comes at the cost of additional processing. If
               False, then the top-most key will be used. For advanced usage, a function
               to create the new name is also accepted.
-
-          blockwise-annotations:
-            type: boolean
-            description: |
-              If adjacent blockwise layers have different annotations (e.g., one has
-              retries=3 and another has retries=4), Dask can make an attempt to merge
-              those annotations according to some simple rules. ``retries`` is set to
-              the max of the layers, ``priority`` is set to the max of the layers,
-              ``resources`` are set to the max of all the resources, ``workers`` is
-              set to the intersection of the requested workers. If this setting is
-              disabled, then adjacent blockwise layers with different annotations
-              will *not* be fused.

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -19,6 +19,8 @@ array:
     split-large-chunks: null  # How to handle large output chunks in slicing. Warns by default.
 
 optimization:
+  annotations:
+    fuse: true  # Automatically fuse compatible annotations on layers
   fuse:
     active: null  # Treat as false for dask.dataframe, true for everything else
     ave-width: 1
@@ -27,4 +29,3 @@ optimization:
     max-depth-new-edges: null  # ave_width * 1.5
     subgraphs: null  # true for dask.dataframe, false for everything else
     rename-keys: true
-    blockwise-annotations: true

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -27,3 +27,4 @@ optimization:
     max-depth-new-edges: null  # ave_width * 1.5
     subgraphs: null  # true for dask.dataframe, false for everything else
     rename-keys: true
+    blockwise-annotations: true


### PR DESCRIPTION
New functionality for allowing fusing compatible annotations when optimizing Blockwise layers. Possible alternative to #9398.

The basic idea here is that we can use some simple rules to merge different blockwise layers with roughly compatible annotations. For instance, if one has `retries=4`, and the next has `retries=5`, it is okay to merge them with the max of the two. The rules I have here are:

* **retries**: max of layers
* **priority**: max of layers
* **workers**: intersection of layer workers
* **allow_other_workers**: only `True` if all are layers are `True`
* **resources**: max of all the resources of all the layers.

This behavior can be turned off with `optimization.fuse.blockwise-annotations`.

- [x] Closes #9397 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
