### PR TITLE
Fix temporary API breakage in dask_cudf groupby

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2223,9 +2223,12 @@ class DataFrameGroupBy(_GroupBy):
         )
 
     @_aggregate_docstring(based_on="pd.core.groupby.DataFrameGroupBy.agg")
-    def agg(self, arg, split_every=None, split_out=1, shuffle=None):
+    def agg(self, arg, split_every=None, split_out=1, **kwargs):
         return self.aggregate(
-            arg, split_every=split_every, split_out=split_out, shuffle=shuffle
+            arg,
+            split_every=split_every,
+            split_out=split_out,
+            **kwargs,
         )
 
 
@@ -2306,9 +2309,12 @@ class SeriesGroupBy(_GroupBy):
         return result
 
     @_aggregate_docstring(based_on="pd.core.groupby.SeriesGroupBy.agg")
-    def agg(self, arg, split_every=None, split_out=1, shuffle=None):
+    def agg(self, arg, split_every=None, split_out=1, **kwargs):
         return self.aggregate(
-            arg, split_every=split_every, split_out=split_out, shuffle=shuffle
+            arg,
+            split_every=split_every,
+            split_out=split_out,
+            **kwargs,
         )
 
     @derived_from(pd.core.groupby.SeriesGroupBy)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1765,7 +1765,6 @@ class _GroupBy:
             chunk=_groupby_apply_funcs,
             chunk_kwargs=dict(
                 funcs=chunk_funcs,
-                sort=self.sort,
                 **self.observed,
                 **self.dropna,
             ),

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2222,9 +2222,12 @@ class DataFrameGroupBy(_GroupBy):
         )
 
     @_aggregate_docstring(based_on="pd.core.groupby.DataFrameGroupBy.agg")
-    def agg(self, arg, split_every=None, split_out=1, **kwargs):
+    def agg(self, arg, split_every=None, split_out=1, shuffle=None):
         return self.aggregate(
-            arg, split_every=split_every, split_out=split_out, **kwargs
+            arg,
+            split_every=split_every,
+            split_out=split_out,
+            **({} if shuffle is None else {"shuffle": shuffle}),
         )
 
 
@@ -2305,9 +2308,12 @@ class SeriesGroupBy(_GroupBy):
         return result
 
     @_aggregate_docstring(based_on="pd.core.groupby.SeriesGroupBy.agg")
-    def agg(self, arg, split_every=None, split_out=1, **kwargs):
+    def agg(self, arg, split_every=None, split_out=1, shuffle=None):
         return self.aggregate(
-            arg, split_every=split_every, split_out=split_out, **kwargs
+            arg,
+            split_every=split_every,
+            split_out=split_out,
+            **({} if shuffle is None else {"shuffle": shuffle}),
         )
 
     @derived_from(pd.core.groupby.SeriesGroupBy)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2224,10 +2224,7 @@ class DataFrameGroupBy(_GroupBy):
     @_aggregate_docstring(based_on="pd.core.groupby.DataFrameGroupBy.agg")
     def agg(self, arg, split_every=None, split_out=1, **kwargs):
         return self.aggregate(
-            arg,
-            split_every=split_every,
-            split_out=split_out,
-            **kwargs,
+            arg, split_every=split_every, split_out=split_out, **kwargs
         )
 
 
@@ -2310,10 +2307,7 @@ class SeriesGroupBy(_GroupBy):
     @_aggregate_docstring(based_on="pd.core.groupby.SeriesGroupBy.agg")
     def agg(self, arg, split_every=None, split_out=1, **kwargs):
         return self.aggregate(
-            arg,
-            split_every=split_every,
-            split_out=split_out,
-            **kwargs,
+            arg, split_every=split_every, split_out=split_out, **kwargs
         )
 
     @derived_from(pd.core.groupby.SeriesGroupBy)


### PR DESCRIPTION
Minor follow-up to #9302

That PR modifies the `aggregate` method that is inherited in dask_cudf. This PR adds minimal changes to avoid breaking dask_cudf CI.