### PR TITLE
Fix caching-related MaterializedLayer.cull performance regression

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -969,7 +969,9 @@ class HighLevelGraph(Mapping):
                     #
                     # Note that `MaterializedLayer` is "safe", because
                     # its `cull` method will return a complete dict of
-                    # direct dependencies for all keys in its subgraph
+                    # direct dependencies for all keys in its subgraph.
+                    # See: https://github.com/dask/dask/issues/9389
+                    # for performance motivation
                     ret_key_deps.update(culled_deps)
 
         # Converting dict_keys to a real set lets Python optimise the set

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -959,11 +959,14 @@ class HighLevelGraph(Mapping):
 
                 # Save the culled layer and its key dependencies
                 ret_layers[layer_name] = culled_layer
-                if isinstance(layer, Blockwise) or (
+                if isinstance(layer, Blockwise) or isinstance(layer, MaterializedLayer) or (
                     layer.is_materialized() and (len(layer) == len(culled_deps))
                 ):
                     # Don't use culled_deps to update ret_key_deps
-                    # unless they are "direct" key dependencies
+                    # unless they are "direct" key dependencies.
+                    # Note that `MaterializedLayer` is "safe", because
+                    # its `cull` method will return a complete dict of
+                    # direct dependencies for all keys in its subgraph
                     ret_key_deps.update(culled_deps)
 
         # Converting dict_keys to a real set lets Python optimise the set

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -959,11 +959,14 @@ class HighLevelGraph(Mapping):
 
                 # Save the culled layer and its key dependencies
                 ret_layers[layer_name] = culled_layer
-                if isinstance(layer, Blockwise) or isinstance(layer, MaterializedLayer) or (
-                    layer.is_materialized() and (len(layer) == len(culled_deps))
+                if (
+                    isinstance(layer, Blockwise)
+                    or isinstance(layer, MaterializedLayer)
+                    or (layer.is_materialized() and (len(layer) == len(culled_deps)))
                 ):
                     # Don't use culled_deps to update ret_key_deps
                     # unless they are "direct" key dependencies.
+                    #
                     # Note that `MaterializedLayer` is "safe", because
                     # its `cull` method will return a complete dict of
                     # direct dependencies for all keys in its subgraph

--- a/dask/tests/test_layers.py
+++ b/dask/tests/test_layers.py
@@ -253,8 +253,7 @@ def test_dataframe_cull_key_dependencies(op):
     assert graph.get_all_dependencies() == culled_graph.get_all_dependencies()
 
 
-@pytest.mark.parametrize("op", [_shuffle_op, _groupby_op])
-def test_dataframe_cull_key_dependencies_materialized(op):
+def test_dataframe_cull_key_dependencies_materialized():
     # Test that caching of MaterializedLayer
     # dependencies during culling doesn't break
     # the result of ``get_all_dependencies``
@@ -279,7 +278,12 @@ def test_dataframe_cull_key_dependencies_materialized(op):
     # HLG cull
     culled_keys = [k for k in result.__dask_keys__() if k != (name, 0)]
     culled_graph = graph.cull(culled_keys)
+
+    # Check that culled_deps are cached
+    # See: https://github.com/dask/dask/issues/9389
+    cached_deps = culled_graph.key_dependencies.copy()
     deps = culled_graph.get_all_dependencies()
+    assert cached_deps == deps
 
     # Manual cull
     deps0 = graph.get_all_dependencies()

--- a/dask/tests/test_layers.py
+++ b/dask/tests/test_layers.py
@@ -10,6 +10,7 @@ from operator import getitem
 from distributed import Client, SchedulerPlugin
 from distributed.utils_test import cluster, loop  # noqa F401
 
+from dask.highlevelgraph import HighLevelGraph
 from dask.layers import ArrayChunkShapeDep, ArraySliceDep, fractional_slice
 
 
@@ -257,10 +258,9 @@ def test_dataframe_cull_key_dependencies_materialized(op):
     # Test that caching of MaterializedLayer
     # dependencies during culling doesn't break
     # the result of ``get_all_dependencies``
-    from dask.dataframe.core import new_dd_object
-    from dask.highlevelgraph import HighLevelGraph
 
     datasets = pytest.importorskip("dask.datasets")
+    dd = pytest.importorskip("dask.dataframe")
 
     ddf = datasets.timeseries(end="2000-01-15")
 
@@ -273,7 +273,7 @@ def test_dataframe_cull_key_dependencies_materialized(op):
         dsk[(name_0, i)] = (lambda x: x, (ddf._name, i))
         dsk[(name, i)] = (lambda x: x, (name_0, i))
     dsk = HighLevelGraph.from_collections(name, dsk, dependencies=[ddf])
-    result = new_dd_object(dsk, name, ddf._meta, ddf.divisions)
+    result = dd.core.new_dd_object(dsk, name, ddf._meta, ddf.divisions)
     graph = result.dask
 
     # HLG cull


### PR DESCRIPTION
This PR fixes a performance regression introduced by #9267

In #9267, we stopped adding `culled_deps` (the  [output](https://github.com/dask/dask/blob/57ff5c2e9c550e3c76592b0affa0d45e88375e12/dask/highlevelgraph.py#L950) of `layer.cull`) to the cache of all known HLG key dependencies.  This is because `culled_deps` is typically meant to define **external** key dependencies rather than **direct** key dependencies in the low-level graph (which typically requires graph materialization to know). 

The problem with #9267 is that (1) `culled_deps` **does** correspond to direct dependencies for the special case of `MaterializedLayer`, and (2) skipping the `culled_deps` caching results in significant graph-optimization overhead. In other words, we went a bit too far in #9267, and stopped optimizing some cases that **should** be safe.

This PR introduces a simple fix: Allow `culled_deps` caching for the "safe" case of `MaterializedLayer.cull`.

- [x] Closes #9389 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
