### PR TITLE
Support arrays of delayed objects in `da.from_delayed`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3811,6 +3811,7 @@ def from_delayed(value, shape, dtype=None, meta=None, name=None):
 def from_delayed_arr(
     value,
     *,
+    shape=None,
     chunks=None,
     dtype=None,
     meta=None,
@@ -3838,7 +3839,7 @@ def from_delayed_arr(
         if meta is None:
             meta = like._meta
 
-    if chunks is None:
+    if chunks is None and shape is None:
         if not allow_unknown_chunksizes:
             raise ValueError(
                 "Chunksizes must be specified, either via `chunks=` or `like=`. "
@@ -3847,37 +3848,17 @@ def from_delayed_arr(
             )
         chunks = tuple((float("nan"),) * s for s in value.shape)
     else:
-        if isinstance(chunks, Number):
-            # NOTE: we can't use `normalize_chunks` here, since `normalize_chunks`
-            # only accepts `shape`, not `numblocks`.
-            chunks = tuple((chunks,) * s for s in value.shape)
-        if isinstance(chunks, np.ndarray):
-            chunks = chunks.tolist()
-        if isinstance(chunks, list):
-            chunks = tuple(chunks)
-        if not isinstance(chunks, tuple):
-            raise TypeError(
-                f"`chunks=` must be a number, tuple, or list, not {type(chunks)}"
-            )
-
-    numblocks = tuple(len(c) for c in chunks)
-    if value.shape != numblocks:
-        raise ValueError(
-            f"Provided chunks indicate a dask array with {numblocks=}, "
-            f"but the array of Delayed blocks has shape {value.shape}"
+        chunks = normalize_chunks(
+            chunks, shape=shape, numblocks=value.shape, dtype=dtype
         )
 
-    meta = meta_from_array(meta, ndim=value.ndim, dtype=dtype)
+    meta = meta_from_array(meta, ndim=len(chunks), dtype=dtype)
 
     name = (
         (name or "from-delayed")
         + "-"
         + tokenize(value, chunks, meta, allow_unknown_chunksizes)
     )
-
-    # If all keys are already correctly-formatted array keys, _and_ they're in the same HLG layer,
-    # we can represent them as an array without adding anything to the graph.
-    # Being in the same HLG layer is rare, but being correctly-formatted is feasible.
 
     iterator = np.nditer(value, flags=["refs_ok", "multi_index"])
     dependencies: list[Delayed] = []
@@ -3890,22 +3871,16 @@ def from_delayed_arr(
                 f"Element {idx} is not a dask delayed object: {delayed_chunk}"
             )
 
-        #     key = delayed_chunk.key
-        #     if not rename_lyr and isinstance(key, tuple) and len(key) == ndim + 1 and key == (name, *idx):
-        #         # Fastpath: looks like an array key matching the correct block index.
-        #         # No need for the ailiasing layer yet.
-        #         dependencies.append(delayed_chunk)
-        #         continue
-
-        #     # Delayed key names can't be used directly as array keys; need a layer renaming them to the right format.
-        #     if len(dependencies) > len(rename_lyr):
-        #         # We went down the fastpath a few times already. Rename all those keys now.
-        #         rename_lyr = {(name, *ix): dep.key for ix, dep in zip(np.ndindex(numblocks, dependencies))}
-
         dependencies.append(delayed_chunk)
         rename_lyr[(name, *idx)] = delayed_chunk.key
 
-    # TODO when every delayed object is a separate layer, this is probably quite inefficient.
+    # NOTE: if every Delayed object's key is already formatted properly as an array key,
+    # _and_ they all have the same `_layer`, then a we could take a fastpath and skip
+    # generating `rename_lyr` all together, by just referencing that `_layer`. However,
+    # this is only the case in the no-op `from_delayed(x.to_delayed(), like=x)`. If any
+    # of the delayed objects have been changed, they'll at least have a different layer.
+
+    # TODO when every delayed object is a separate layer, this is probably quite slow.
     dsk = HighLevelGraph.from_collections(name, rename_lyr, dependencies)
 
     return Array(dsk, name, chunks, meta=meta)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3951,12 +3951,13 @@ def from_delayed(
         rename_lyr[(name, *idx)] = delayed_chunk.key
 
     # NOTE: if every Delayed object's key is already formatted properly as an array key,
-    # _and_ they all have the same `_layer`, then a we could take a fastpath and skip
+    # _and_ they all have the same `_layer`, then we could take a fastpath and skip
     # generating `rename_lyr` all together, by just referencing that `_layer`. However,
     # this is only the case in the no-op `from_delayed(x.to_delayed(), like=x)`. If any
     # of the delayed objects have been changed, they'll at least have a different layer.
+    # So we don't currently optimize for this unlikely case.
 
-    # TODO when every delayed object is a separate layer, this is probably quite slow.
+    # NOTE: when every delayed object is a separate layer, may be quite slow.
     dsk = HighLevelGraph.from_collections(name, rename_lyr, dependencies)
 
     return Array(dsk, name, chunks, meta=meta)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3607,20 +3607,14 @@ def test_from_delayed_meta():
     assert isinstance(x._meta, np.ndarray)
 
 
-@pytest.mark.parametrize("like", [np.ones((5, 3)), da.ones((5, 3), chunks=-1)])
-def test_from_delayed_like(like):
+def test_from_delayed_like():
     v = delayed(np.ones)((5, 3))
+    like = da.ones((5, 3), chunks=-1)
     x = from_delayed(v, like=like)
     assert isinstance(x, Array)
     assert isinstance(x._meta, np.ndarray)
     assert x.shape == like.shape
     assert x.npartitions == 1
-
-
-def test_from_delayed_bad_like():
-    v = delayed(np.ones)((5, 3))
-    with pytest.raises(ValueError, match="must have only one chunk"):
-        from_delayed(v, like=da.ones((5, 3), chunks=1))
 
 
 def test_from_delayed_roundtrip():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3664,18 +3664,6 @@ def test_from_delayed_arr_bad_input():
     with pytest.raises(TypeError, match="must be a dask Array"):
         da.core.from_delayed_arr(delayed, like=np.arange(4))
 
-    with pytest.raises(TypeError, match="must be a number"):
-        da.core.from_delayed_arr(delayed, chunks="auto")
-
-    with pytest.raises(
-        ValueError,
-        match="indicate a dask array with numblocks=(1, 1), but the array of Delayed blocks has shape (3, 3)",
-    ):
-        da.core.from_delayed_arr(delayed, chunks=((1,), (2,)))
-
-    with pytest.raises(ValueError, match="must specify the meta or dtype of the array"):
-        da.core.from_delayed_arr(delayed, chunks=2)
-
 
 def test_from_delayed_arr_unknown_chunksizes():
     d = np.array([delayed(np.ones)(3), delayed(np.ones)(2), delayed(np.ones)(1)])


### PR DESCRIPTION
Requires https://github.com/dask/dask/pull/9416; I'll rebase when that's merged for an easier diff

cc @ian-r-rose @jsignell

- [x] Closes #9412
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
