### PR TITLE
Filter by list

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3097,14 +3097,15 @@ Dask Name: {name}, {layers}"""
         if isinstance(values, list):
             # Motivated by https://github.com/dask/dask/issues/9411.  This appears to be a
             # result of serializing a Python list with pickle, while numpy arrays
-            # leverage Dask's custom serializer.  We can reduce serialization costs by 
+            # leverage Dask's custom serializer.  We can reduce serialization costs by
             # deduplicating the list and, if all dtypes in the list are the same,
-            # converting to an array.  If dtypes are not consistent, we must leave 
+            # converting to an array.  If dtypes are not consistent, we must leave
             # as a list
             values = list(set(values))
             dtype = type(values[0])
             if all(isinstance(v, dtype) for v in values):
                 import numpy as np
+
                 values = np.array(values)
         return self.map_partitions(
             M.isin, delayed(values), meta=meta, enforce_metadata=False

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3094,6 +3094,18 @@ Dask Name: {name}, {layers}"""
         # We wrap values in a delayed for two reasons:
         # - avoid serializing data in every task
         # - avoid cost of traversal of large list in optimizations
+        if isinstance(values, list):
+            # Motivated by https://github.com/dask/dask/issues/9411.  This appears to be a
+            # result of serializing a Python list with pickle, while numpy arrays
+            # leverage Dask's custom serializer.  We can reduce serialization costs by 
+            # deduplicating the list and, if all dtypes in the list are the same,
+            # converting to an array.  If dtypes are not consistent, we must leave 
+            # as a list
+            values = list(set(values))
+            dtype = type(values[0])
+            if all(isinstance(v, dtype) for v in values):
+                import numpy as np
+                values = np.array(values)
         return self.map_partitions(
             M.isin, delayed(values), meta=meta, enforce_metadata=False
         )
@@ -6517,7 +6529,6 @@ def map_partitions(
     dfs = [df for df in args if isinstance(df, _Frame)]
 
     meta = _get_meta_map_partitions(args, dfs, func, kwargs, meta, parent_meta)
-
     if all(isinstance(arg, Scalar) for arg in args):
         layer = {
             (name, 0): (


### PR DESCRIPTION
- [ X ] Closes #9411 
- [ X ] Tests added / passed
- [ X ] Passes `pre-commit run --all-files`

This PR addresses the fact that filtering a Dask DataFrame with `ddf.isin(L)` if L is a large list, is much slower than if L is a numpy array.  This appears to be a result of serializing lists with pickle, while serializing a numpy array uses dask's custom serializer.

Here we do a few things to reduce the serialization cost if L is a list:

1. If L is a list, we remove duplicate
2. If all the elements in L are of the same datatype, we convert L to a numpy array, otherwise we are forced to incur the serialization cost
