### PR TITLE
Feature/prevent dupl col names

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import operator
 import warnings
-from collections.abc import Hashable, Iterator, Sequence
+from collections.abc import Iterator, Sequence
 from functools import partial, wraps
 from numbers import Integral, Number
 from operator import getitem
 from pprint import pformat
-from typing import Any, Callable, ClassVar, Literal, Mapping
+from typing import Any, Callable, ClassVar, Iterable, Literal, Mapping
 
 import numpy as np
 import pandas as pd
@@ -340,16 +340,16 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
         self._meta = meta
         self.divisions = tuple(divisions)
 
-    def __dask_graph__(self):
+    def __dask_graph__(self) -> HighLevelGraph:
         return self.dask
 
-    def __dask_keys__(self) -> list[Hashable]:
+    def __dask_keys__(self) -> list[tuple[str, int]]:
         return [(self._name, i) for i in range(self.npartitions)]
 
-    def __dask_layers__(self):
+    def __dask_layers__(self) -> tuple[str]:
         return (self._name,)
 
-    def __dask_tokenize__(self):
+    def __dask_tokenize__(self) -> str:
         return self._name
 
     __dask_optimize__ = globalmethod(
@@ -573,7 +573,7 @@ Dask Name: {name}, {layers}"""
         self._name = result._name
         self._meta = result._meta
 
-    def reset_index(self, drop=False):
+    def reset_index(self, drop=False) -> _Frame:
         """Reset the index to the default index.
 
         Note that unlike in ``pandas``, the reset ``dask.dataframe`` index will
@@ -598,11 +598,11 @@ Dask Name: {name}, {layers}"""
         ).clear_divisions()
 
     @property
-    def known_divisions(self):
+    def known_divisions(self) -> bool:
         """Whether divisions are already known"""
         return len(self.divisions) > 0 and self.divisions[0] is not None
 
-    def clear_divisions(self):
+    def clear_divisions(self) -> _Frame:
         """Forget division information"""
         divisions = (None,) * (self.npartitions + 1)
         return type(self)(self.dask, self._name, self._meta, divisions)
@@ -707,12 +707,12 @@ Dask Name: {name}, {layers}"""
             **kwargs,
         )
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.reduction(
             len, np.sum, token="len", meta=int, split_every=False
         ).compute()
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         raise ValueError(
             f"The truth value of a {self.__class__.__name__} is ambiguous. "
             "Use a.any() or a.all()."
@@ -726,15 +726,15 @@ Dask Name: {name}, {layers}"""
 
         return wrapper
 
-    def __float__(self):
+    def __float__(self) -> float:
         return self._scalarfunc(float)
 
-    def __int__(self):
+    def __int__(self) -> int:
         return self._scalarfunc(int)
 
     __long__ = __int__  # python 2
 
-    def __complex__(self):
+    def __complex__(self) -> complex:
         return self._scalarfunc(complex)
 
     @insert_meta_param_description(pad=12)
@@ -3434,11 +3434,11 @@ class Series(_Frame):
         return [self.index]
 
     @property
-    def name(self):
+    def name(self) -> str | None:
         return self._meta.name
 
     @name.setter
-    def name(self, name):
+    def name(self, name: str):
         self._meta.name = name
         renamed = _rename_dask(self, name)
         # update myself
@@ -3446,7 +3446,7 @@ class Series(_Frame):
         self._name = renamed._name
 
     @property
-    def ndim(self):
+    def ndim(self) -> int:
         """Return dimensionality"""
         return 1
 
@@ -3487,13 +3487,13 @@ class Series(_Frame):
         return list(o)
 
     @property
-    def nbytes(self):
+    def nbytes(self) -> Scalar:
         """Number of bytes"""
         return self.reduction(
             methods.nbytes, np.sum, token="nbytes", meta=int, split_every=False
         )
 
-    def _repr_data(self):
+    def _repr_data(self) -> Series:
         return _repr_data_series(self._meta, self._repr_divisions)
 
     def __repr__(self):
@@ -3514,7 +3514,7 @@ Dask Name: {name}, {layers}""".format(
             layers=maybe_pluralize(len(self.dask.layers), "graph layer"),
         )
 
-    def rename(self, index=None, inplace=False, sorted_index=False):
+    def rename(self, index=None, inplace=False, sorted_index=False) -> Series:
         """Alter Series index labels or name
 
         Function / dict values must be unique (1-to-1). Labels not contained in
@@ -4337,36 +4337,53 @@ class DataFrame(_Frame):
     _token_prefix = "dataframe-"
     _accessors: ClassVar[set[str]] = set()
 
-    def __init__(self, dsk, name, meta, divisions):
-        super().__init__(dsk, name, meta, divisions)
-        if self.dask.layers[name].collection_annotations is None:
-            self.dask.layers[name].collection_annotations = {
-                "npartitions": self.npartitions,
-                "columns": [col for col in self.columns],
-                "type": typename(type(self)),
-                "dataframe_type": typename(type(self._meta)),
-                "series_dtypes": {
-                    col: self._meta[col].dtype
-                    if hasattr(self._meta[col], "dtype")
-                    else None
-                    for col in self._meta.columns
-                },
-            }
-        else:
-            self.dask.layers[name].collection_annotations.update(
-                {
-                    "npartitions": self.npartitions,
-                    "columns": [col for col in self.columns],
-                    "type": typename(type(self)),
-                    "dataframe_type": typename(type(self._meta)),
-                    "series_dtypes": {
-                        col: self._meta[col].dtype
-                        if hasattr(self._meta[col], "dtype")
-                        else None
-                        for col in self._meta.columns
-                    },
-                }
+    @staticmethod
+    def _prevent_dupl_col_names(
+        meta: pd.DataFrame, allow_index_name_in_cols: bool = True
+    ):
+        """Makes sure not to build a frame with duplicated column names.
+        The index is allowed by default to have the same name as a column, but this can also be prevented.
+        """
+        cols = list(meta.columns)
+        if (
+            not allow_index_name_in_cols
+            and (index_name := meta.index.name) is not None
+            and index_name in cols
+        ):
+            raise ValueError(
+                f"The index in this dataframe has the same name '{index_name}' as one of its columns.\n"
+                "Please rename it by calling `df.index.rename()`, or unname it with `df.index.name = None`."
             )
+        if len(set(cols)) < len(cols):
+            dupl_cols = {c for c in cols if cols.count(c) > 1}
+            raise ValueError(
+                f"The following columns in this dataframe have duplicate names: {sorted(dupl_cols)}.\n"
+                "This is allowed in Pandas, but not in Dask, which requires each column to have a unique name.\n"
+                "Please rename the dataframe columns by setting `df.columns = new_unique_columns`."
+            )
+
+    def __init__(self, dsk, name: str, meta: pd.DataFrame, divisions: Iterable):
+        # Call super
+        super().__init__(dsk, name, meta, divisions)
+
+        # Prevent column name duplicity
+        self._prevent_dupl_col_names(meta)
+
+        # If OK, set or update annotations in graph
+        annotations = {
+            "npartitions": self.npartitions,
+            "columns": list(meta.columns),
+            "type": typename(type(self)),
+            "dataframe_type": typename(type(meta)),
+            "series_dtypes": {
+                col_name: col_series.dtype if hasattr(col_series, "dtype") else None
+                for col_name, col_series in meta.items()
+            },
+        }
+        if (cur_annotations := self.dask.layers[name].collection_annotations) is None:
+            self.dask.layers[name].collection_annotations = annotations
+        else:
+            cur_annotations.update(annotations)
 
     def __array_wrap__(self, array, context=None):
         if isinstance(context, tuple) and len(context) > 0:
@@ -4393,11 +4410,12 @@ class DataFrame(_Frame):
         return [self.index, self.columns]
 
     @property
-    def columns(self):
+    def columns(self) -> pd.Index:
         return self._meta.columns
 
     @columns.setter
-    def columns(self, columns):
+    def columns(self, columns: Iterable):
+        # _rename_dask calls new_dd_object, which will fail if there are duplicate column names
         renamed = _rename_dask(self, columns)
         self._meta = renamed._meta
         self._name = renamed._name
@@ -4421,7 +4439,7 @@ class DataFrame(_Frame):
         # For dataframes with unique column names, this will be transformed into a __getitem__ call
         return _iLocIndexer(self)
 
-    def __len__(self):
+    def __len__(self) -> int:
         try:
             s = self.iloc[:, 0]
         except IndexError:
@@ -4429,11 +4447,11 @@ class DataFrame(_Frame):
         else:
             return len(s)
 
-    def __contains__(self, key):
+    def __contains__(self, key) -> bool:
         return key in self._meta
 
     @property
-    def empty(self):
+    def empty(self) -> bool:
         # __getattr__ will be called after we raise this, so we'll raise it again from there
         raise AttributeNotImplementedError(
             "Checking whether a Dask DataFrame has any rows may be expensive. "
@@ -4543,7 +4561,7 @@ class DataFrame(_Frame):
         else:
             object.__setattr__(self, key, value)
 
-    def __getattr__(self, key):
+    def __getattr__(self, key) -> Any:
         if key in self.columns:
             return self[key]
         elif key == "empty":
@@ -4556,20 +4574,20 @@ class DataFrame(_Frame):
         else:
             raise AttributeError("'DataFrame' object has no attribute %r" % key)
 
-    def __dir__(self):
+    def __dir__(self) -> list[str]:
         o = set(dir(type(self)))
         o.update(self.__dict__)
         o.update(c for c in self.columns if (isinstance(c, str) and c.isidentifier()))
         return list(o)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator:
         return iter(self._meta)
 
-    def _ipython_key_completions_(self):
+    def _ipython_key_completions_(self) -> list:
         return methods.tolist(self.columns)
 
     @property
-    def ndim(self):
+    def ndim(self) -> int:
         """Return dimensionality"""
         return 2
 
@@ -4671,7 +4689,7 @@ class DataFrame(_Frame):
         divisions: Sequence | None = None,
         inplace: bool = False,
         **kwargs,
-    ):
+    ) -> DataFrame:
         """Set the DataFrame index (row labels) using an existing column.
 
         This realigns the dataset to be sorted by a new column. This can have a
@@ -4969,6 +4987,7 @@ class DataFrame(_Frame):
             raise ValueError("Cannot rename index.")
 
         # *args here is index, columns but columns arg is already used
+        # map_partitions calls new_dd_object, so duplicate column names are also checked
         return self.map_partitions(M.rename, None, columns=columns)
 
     def query(self, expr, **kwargs):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -7702,8 +7702,6 @@ def new_dd_object(dsk, name, meta, divisions, parent_meta=None):
     if has_parallel_type(meta):
         return get_parallel_type(meta)(dsk, name, meta, divisions)
     elif is_arraylike(meta) and meta.shape:
-        import dask.array as da
-
         chunks = ((np.nan,) * (len(divisions) - 1),) + tuple(
             (d,) for d in meta.shape[1:]
         )
@@ -7716,7 +7714,7 @@ def new_dd_object(dsk, name, meta, divisions, parent_meta=None):
                 suffix = (0,) * (len(chunks) - 1)
                 for i in range(len(chunks[0])):
                     layer[(name, i) + suffix] = layer.pop((name, i))
-        return da.Array(dsk, name=name, chunks=chunks, dtype=meta.dtype)
+        return Array(dsk, name=name, chunks=chunks, dtype=meta.dtype)
     else:
         return get_parallel_type(meta)(dsk, name, meta, divisions)
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -264,19 +264,10 @@ def from_pandas(
         raise NotImplementedError("Dask does not support MultiIndex Dataframes.")
 
     # Check data has no duplicate column names
-    # Even if this also checked during construction, it's faster to check it at this point
+    # Even if this is eventually checked during construction, it's faster to check it at this point
     if is_dataframe_like(data):
-        data_cols = list(data.columns)
-        if (index_name := data.index.name) is not None:
-            # if index has a name, it's assumed to be a column originally
-            data_cols.append(index_name)
-        if len(set(data_cols)) < len(data_cols):
-            dupl_cols = {c for c in data_cols if data_cols.count(c) > 1}
-            raise ValueError(
-                f"The following columns have duplicate names in provided data: {sorted(dupl_cols)}\n"
-                "This is allowed in Pandas, but not in Dask, which requires each column to have a unique name."
-                "Please rename the above duplicate columns before calling this method."
-            )
+        # Here it's assumed that a named index was originally a column, so we prevent a name clash
+        DataFrame._prevent_dupl_col_names(data, allow_index_name_in_cols=False)
 
     # Check we have either chunksize or npartitions to know how to partition
     if (npartitions is None) == (chunksize is None):

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1705,8 +1705,8 @@ def test_csv_getitem_column_order(tmpdir):
     df1 = pd.DataFrame([{c: v for c, v in zip(columns, values)}])
     df1.to_csv(path)
 
-    # Use disordered and duplicated column selection
-    columns = list("hczzkylaape")
+    # Use disordered column selection
+    columns = list("hczkylape")
     df2 = dd.read_csv(path)[columns].head(1)
     assert_eq(df1[columns], df2)
 

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -360,7 +360,7 @@ def test_from_pandas_with_datetime_index():
 def test_from_pandas_with_index_nulls(null_value):
     df = pd.DataFrame({"x": [1, 2, 3]}, index=["C", null_value, "A"])
     with pytest.raises(NotImplementedError, match="is non-numeric and contains nulls"):
-        dd.from_pandas(df, npartitions=2, sort=False)
+        dd.from_pandas(df, npartitions=2)
 
 
 def test_from_pandas_with_wrong_args():
@@ -375,6 +375,10 @@ def test_from_pandas_with_wrong_args():
         dd.from_pandas(df, npartitions=5.2, sort=False)
     with pytest.raises(TypeError, match="provide chunksize as an int"):
         dd.from_pandas(df, chunksize=18.27)
+    with pytest.raises(ValueError, match="duplicate names"):
+        dd.from_pandas(
+            pd.concat([df, df], axis="columns"), npartitions=1
+        )  # concat yields 2 columns named 'x'
 
 
 def test_from_pandas_chunksize_one():

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -325,7 +325,7 @@ def test_categorical_accessor_presence():
     assert hasattr(ddf.x, "cat")
     assert not hasattr(ddf.y, "cat")
 
-    df2 = df.set_index(df.x)
+    df2 = df.set_index(df.x.rename("z"))
     ddf2 = dd.from_pandas(df2, npartitions=2, sort=False)
     assert hasattr(ddf2.index, "categories")
     assert not hasattr(ddf.index, "categories")

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2869,11 +2869,19 @@ def test_gh6305():
 def test_rename_dict():
     renamer = {"a": "A", "b": "B"}
     assert_eq(d.rename(columns=renamer), full.rename(columns=renamer))
+    with pytest.raises(
+        ValueError, match="columns in this dataframe have duplicate names"
+    ):
+        d.rename(columns={"a": "A", "b": "A"})
 
 
 def test_rename_function():
     renamer = lambda x: x.upper()
     assert_eq(d.rename(columns=renamer), full.rename(columns=renamer))
+    with pytest.raises(
+        ValueError, match="columns in this dataframe have duplicate names"
+    ):
+        d.rename(columns=lambda _: "A")
 
 
 def test_rename_index():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -311,20 +311,24 @@ def test_rename_columns():
     tm.assert_index_equal(ddf._meta.columns, pd.Index(["x", "y"]))
     assert_eq(ddf, df)
 
-    msg = r"Length mismatch: Expected axis has 2 elements, new values have 4 elements"
-    with pytest.raises(ValueError) as err:
+    msg = "Length mismatch: Expected axis has 2 elements, new values have 4 elements"
+    with pytest.raises(ValueError, match=msg):
         ddf.columns = [1, 2, 3, 4]
-    assert msg in str(err.value)
+    msg = "columns in this dataframe have duplicate names"
+    with pytest.raises(ValueError, match=msg):
+        ddf.columns = ["x", "x"]
 
     # Multi-index columns
     df = pd.DataFrame({("A", "0"): [1, 2, 2, 3], ("B", 1): [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)
 
-    df.columns = ["x", "y"]
     ddf.columns = ["x", "y"]
+    df.columns = ["x", "y"]
     tm.assert_index_equal(ddf.columns, pd.Index(["x", "y"]))
     tm.assert_index_equal(ddf._meta.columns, pd.Index(["x", "y"]))
     assert_eq(ddf, df)
+    with pytest.raises(ValueError, match=msg):
+        ddf.columns = ["x", "x"]
 
 
 def test_rename_series():
@@ -1305,8 +1309,6 @@ def test_len():
     assert len(d.a) == len(full.a)
     assert len(dd.from_pandas(pd.DataFrame(), npartitions=1)) == 0
     assert len(dd.from_pandas(pd.DataFrame(columns=[1, 2]), npartitions=1)) == 0
-    # Regression test for https://github.com/dask/dask/issues/6110
-    assert len(dd.from_pandas(pd.DataFrame(columns=["foo", "foo"]), npartitions=1)) == 0
 
 
 def test_size():
@@ -3179,6 +3181,7 @@ def test_corr():
     pytest.raises(TypeError, lambda: da.corr(ddf))
 
 
+@pytest.mark.xfail(reason="Dataframe does no longer support duplicate column names")
 def test_corr_same_name():
     # Series with same names (see https://github.com/dask/dask/issues/4906)
 
@@ -3437,7 +3440,6 @@ def test_dataframe_itertuples():
     "columns",
     [
         ("x", "y"),
-        ("x", "x"),
         pd.MultiIndex.from_tuples([("x", 1), ("x", 2)], names=("letter", "number")),
     ],
 )
@@ -4290,7 +4292,7 @@ def test_dataframe_reductions_arithmetic(reduction):
 def test_dataframe_mode():
     data = [["Tom", 10, 7], ["Farahn", 14, 7], ["Julie", 14, 5], ["Nick", 10, 10]]
 
-    df = pd.DataFrame(data, columns=["Name", "Num", "Num"])
+    df = pd.DataFrame(data, columns=["Name", "Num", "Num2"])
     ddf = dd.from_pandas(df, npartitions=3)
 
     assert_eq(ddf.mode(), df.mode())

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -528,6 +528,7 @@ def test_categorical_format():
     assert repr(unknown) == exp
 
 
+@pytest.mark.xfail(reason="Dataframe does no longer support duplicate column names")
 def test_duplicate_columns_repr():
     arr = da.from_array(np.arange(10).reshape(5, 2), chunks=(5, 2))
     frame = dd.from_dask_array(arr, columns=["a", "a"])

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -240,6 +240,7 @@ def test_loc2d_with_unknown_divisions():
     assert_eq(ddf.loc["a":"o", ["A"]], df.loc["a":"o", ["A"]])
 
 
+@pytest.mark.xfail(reason="Dataframe does no longer support duplicate column names")
 def test_loc2d_duplicated_columns():
     df = pd.DataFrame(
         np.random.randn(20, 5),
@@ -612,6 +613,7 @@ def test_iloc_raises():
         ddf.iloc[:, [5, 6]]
 
 
+@pytest.mark.xfail(reason="Dataframe does no longer support duplicate column names")
 def test_iloc_duplicate_columns():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
     ddf = dd.from_pandas(df, 2)
@@ -703,7 +705,7 @@ def test_deterministic_hashing_series():
 
 def test_deterministic_hashing_dataframe():
     # Add duplicate column names in order to use _iLocIndexer._iloc path
-    obj = pd.DataFrame([[0, 1, 2, 3], [4, 5, 6, 7]], columns=["a", "b", "c", "c"])
+    obj = pd.DataFrame([[0, 1, 2, 3], [4, 5, 6, 7]], columns=["a", "b", "c", "d"])
 
     dask_df = dd.from_pandas(obj, npartitions=1)
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1942,21 +1942,9 @@ def test_concat5():
     cases = [
         [ddf1, ddf2],
         [ddf1, ddf3],
-        [ddf1, ddf4],
-        [ddf1, ddf5],
-        [ddf3, ddf4],
-        [ddf3, ddf5],
-        [ddf5, ddf1, ddf4],
-        [ddf5, ddf3],
-        [ddf1.A, ddf4.A],
-        [ddf2.F, ddf3.F],
-        [ddf4.A, ddf5.A],
         [ddf1.A, ddf4.F],
         [ddf2.F, ddf3.H],
         [ddf4.A, ddf5.B],
-        [ddf1, ddf4.A],
-        [ddf3.F, ddf2],
-        [ddf5, ddf1.A, ddf2],
     ]
 
     for case in cases:
@@ -1980,16 +1968,7 @@ def test_concat5():
         )
 
     # Dask + pandas
-    cases = [
-        [ddf1, pdf2],
-        [ddf1, pdf3],
-        [pdf1, ddf4],
-        [pdf1.A, ddf4.A],
-        [ddf2.F, pdf3.F],
-        [ddf1, pdf4.A],
-        [ddf3.F, pdf2],
-        [ddf2, pdf1, ddf3.F],
-    ]
+    cases = [[ddf1, pdf2], [ddf1, pdf3]]
 
     for case in cases:
         pdcase = [c.compute() if isinstance(c, _Frame) else c for c in case]
@@ -2052,7 +2031,7 @@ def test_concat_categorical(known, cat_index, divisions):
         df.y = df.y.astype("category")
 
     if cat_index:
-        frames = [df.set_index(df.y) for df in frames]
+        frames = [df.set_index(df.y.rename("y2")) for df in frames]
 
     dframes = [dd.from_pandas(p, npartitions=2, sort=divisions) for p in frames]
 
@@ -2241,8 +2220,8 @@ def test_append_categorical():
         df.y = df.y.astype("category")
         df2 = df.copy()
         df2.y = df2.y.cat.set_categories(list("abc"))
-        df.index = df.y
-        frames2.append(df2.set_index(df2.y))
+        df.index = df.y.rename("y2")
+        frames2.append(df2.set_index(df2.y.rename("y2")))
 
     df1, df2 = frames2
 


### PR DESCRIPTION
- [x] Closes #9331 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This PR prevents building frames with duplicate column names, raising a `ValueError` and informing about the duplicities. 

To do so, it relies on a new internal method `DataFrame._prevent_dupl_col_names` which is invoked by the `__init__` method. This internal method has a `allow_index_name_in_cols` flag that controls whether the index is indeed allowed to have the same name as a column, or whether this is also forbidden. 

By default it IS allowed, because some join methods in `dataframe.multi` rely on this. However, when called by `from_pandas`, it is called with `False`, because it is assumed that if your Pandas dataframe index has a name, that's because it was originally a column; eventually you could reset that index to be again a column, and things should keep on working (see this [related discussion ](https://github.com/dask/dask/issues/9380)).

NOTE 1: because this is called during construction,it also works when trying to rename columns, either via `ddf.rename(columns=new_columns)` or setting columns directly via `ddf.columns = new_columns`. Explicit tests were added to check this indeed happens.

NOTE 2: there were some tests that explicitly tested what happens with column name duplicity. I followed this approach:
* If the test was exclusively intended to check behavior with duplicate columns, that test now XFAILs with the explicit message `dataframe does no longer support duplicate column names`.
* If the test only checked duplicate columns as a marginal case, either I deleted that particular check, or I eliminated duplicities by using unique column names, so the test keeps on working.
