### PR TITLE
Avoid checking the returned sqlite dtype on all 32 bit platforms.

### DIFF
--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -440,7 +440,7 @@ def test_query_with_meta(db):
     ).select_from(sql.table("test"))
     out = read_sql_query(s1, db, npartitions=2, index_col="number", meta=meta)
     # Don't check dtype for windows https://github.com/dask/dask/issues/8620
-    assert_eq(out, df[["name", "age"]], check_dtype=sys.platform != "win32")
+    assert_eq(out, df[["name", "age"]], check_dtype=sys.int_info.sizeof_digit != 2)
 
 
 def test_no_character_index_without_divisions(db):


### PR DESCRIPTION
There's still some 32-bit linux targets in addition to win32.

- [X] Closes? #8620 It's really more of a work around, the problem of sqlite's data types not being consistent between 64 and 32 bit architectures is not fixed. This patch ignores that difference because it's pretty likely to not be that important.
- [n/a] Tests added / passed
  (test_query_with_meta was made slightly weaker on 32-bit architectures by not requiring the same dtype)
- [?] Passes `pre-commit run --all-files`

I made the patch pushed it to my own branch on github and waited for the tests to run. There's (now) one test failure that looks unrelated to this change. I think that's equivalent to the pre-commit run --all-files

(On my first try I typoed the name of int_info and there were two test failures, so I'm pretty sure the test is actually running.)
