### PR TITLE
`tmpfile` does not end files with period on empty extension

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -43,6 +43,7 @@ from dask.utils import (
     stringify,
     stringify_collection_keys,
     takes_multiple_arguments,
+    tmpfile,
     typename,
 )
 from dask.utils_test import inc
@@ -888,3 +889,17 @@ def test_factors():
     assert factors(2) == {1, 2}
     assert factors(12) == {1, 2, 3, 4, 6, 12}
     assert factors(15) == {1, 3, 5, 15}
+
+
+def test_tmpfile_naming():
+    with tmpfile() as fn:
+        # Do not end file or directory name with a period.
+        #  This causes issues on Windows.
+        assert fn[-1] != "."
+
+    with tmpfile(extension="jpg") as fn:
+        assert fn[-4:] == ".jpg"
+
+    with tmpfile(extension=".jpg") as fn:
+        assert fn[-4:] == ".jpg"
+        assert fn[-5] != "."

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -203,7 +203,7 @@ def tmpfile(extension="", dir=None):
 
     Parameters
     ----------
-    extension : str | None
+    extension : str
         The extension of the temporary file to be created
     dir : str
         If ``dir`` is not None, the file will be created in that directory; otherwise,

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -203,7 +203,7 @@ def tmpfile(extension="", dir=None):
 
     Parameters
     ----------
-    extension : str
+    extension : str | None
         The extension of the temporary file to be created
     dir : str
         If ``dir`` is not None, the file will be created in that directory; otherwise,
@@ -223,7 +223,9 @@ def tmpfile(extension="", dir=None):
     -----
     This context manager is particularly useful on Windows for opening temporary files multiple times.
     """
-    extension = "." + extension.lstrip(".")
+    extension = extension.lstrip(".")
+    if extension:
+        extension = "." + extension
     handle, filename = tempfile.mkstemp(extension, dir=dir)
     os.close(handle)
     os.remove(filename)


### PR DESCRIPTION
As it turns out, when not specifying an extension, `tmpfile` ends the filename with a period, which is discouraged on Windows (https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file) and caused issues fixed in dask/distributed#6954 as other system utilities strip the period away.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`