### PR TITLE
Fix `get_group` with categoricals

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1118,7 +1118,7 @@ class _GroupBy:
         the output aggregation will have sorted keys.
     observed: bool, default False
         This only applies if any of the groupers are Categoricals.
-        If True: only show observed values for p#cal groupers.
+        If True: only show observed values for categorical groupers.
         If False: show all values for categorical groupers.
     """
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -234,11 +234,7 @@ def _groupby_get_group(df, by_key, get_key, columns):
     # SeriesGroupBy may pass df which includes group key
     grouped = _groupby_raise_unaligned(df, by=by_key)
 
-    if is_series_like(by_key):
-        check = by_key
-    else:
-        check = df[by_key]
-
+    check = by_key if is_series_like(by_key) else df[by_key]
     if check.isin([get_key]).any():
         if is_dataframe_like(df):
             grouped = grouped[columns]

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -234,7 +234,7 @@ def _groupby_get_group(df, by_key, get_key, columns):
     # SeriesGroupBy may pass df which includes group key
     grouped = _groupby_raise_unaligned(df, by=by_key)
 
-    if get_key in grouped.groups:
+    if df[by_key].isin([get_key]).any():
         if is_dataframe_like(df):
             grouped = grouped[columns]
         return grouped.get_group(get_key)
@@ -1113,7 +1113,7 @@ class _GroupBy:
         the output aggregation will have sorted keys.
     observed: bool, default False
         This only applies if any of the groupers are Categoricals.
-        If True: only show observed values for categorical groupers.
+        If True: only show observed values for p#cal groupers.
         If False: show all values for categorical groupers.
     """
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -234,13 +234,11 @@ def _groupby_get_group(df, by_key, get_key, columns):
     # SeriesGroupBy may pass df which includes group key
     grouped = _groupby_raise_unaligned(df, by=by_key)
 
-    check = by_key if is_series_like(by_key) else df[by_key]
-    if check.isin([get_key]).any():
+    try:
         if is_dataframe_like(df):
             grouped = grouped[columns]
         return grouped.get_group(get_key)
-
-    else:
+    except KeyError:
         # to create empty DataFrame/Series, which has the same
         # dtype as the original
         if is_dataframe_like(df):
@@ -1634,7 +1632,10 @@ class _GroupBy:
             token="last", func=M.last, split_every=split_every, split_out=split_out
         )
 
-    @derived_from(pd.core.groupby.GroupBy)
+    @derived_from(
+        pd.core.groupby.GroupBy,
+        inconsistencies="If the group is not present, Dask will return an empty Series/DataFrame.",
+    )
     def get_group(self, key):
         token = self._token_prefix + "get_group"
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -234,7 +234,12 @@ def _groupby_get_group(df, by_key, get_key, columns):
     # SeriesGroupBy may pass df which includes group key
     grouped = _groupby_raise_unaligned(df, by=by_key)
 
-    if df[by_key].isin([get_key]).any():
+    if is_series_like(by_key):
+        check = by_key
+    else:
+        check = df[by_key]
+
+    if check.isin([get_key]).any():
         if is_dataframe_like(df):
             grouped = grouped[columns]
         return grouped.get_group(get_key)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -419,6 +419,18 @@ def test_groupby_get_group():
         assert_eq(ddgrouped.a.get_group(2), pdgrouped.a.get_group(2))
 
 
+def test_groupby_get_group_with_categories():
+    df = pd.DataFrame(
+        {"make": ["a", "b", "c", "d", "e", "f"], "model": [2, 5, 7, 9, 11, 13]}
+    )
+    df["make"] = df["make"].astype("category")
+    ddf = dd.from_pandas(df, npartitions=2)
+    expected = df.groupby("make").get_group("a")
+    actual = ddf.groupby("make").get_group("a")
+
+    assert_eq(expected, actual)
+
+
 def test_dataframe_groupby_nunique():
     strings = list("aaabbccccdddeee")
     data = np.random.randn(len(strings))


### PR DESCRIPTION
- [x] Closes #9359
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

TODO before merging:
- open a new issue around raising a KeyError early if the group is not present