### PR TITLE
[WIP]Add include_path_column to read_parquet

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4280,6 +4280,7 @@ def test_retries_on_remote_filesystem(tmpdir):
 
 
 def test_read_parquet_multiple_files_with_path_column(tmpdir, engine):
+    tmpdir = str(tmpdir)
     file1 = os.path.join(tmpdir, "file1.parquet")
     file2 = os.path.join(tmpdir, "file2.parquet")
     df1 = pd.DataFrame({"x": range(5), "y": ["a", "b", "c", "d", "e"]})

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4284,8 +4284,8 @@ def test_read_parquet_multiple_files_with_path_column(tmpdir, engine):
     file2 = os.path.join(tmpdir, "file2.parquet")
     df1 = pd.DataFrame({"x": range(5), "y": ["a", "b", "c", "d", "e"]})
     df2 = df1.assign(x=df1.x + 0.5)
-    df1.to_parquet(file1, index=False)
-    df2.to_parquet(file2, index=False)
+    df1.to_parquet(file1, index=False, engine=engine)
+    df2.to_parquet(file2, index=False, engine=engine)
 
     df1["path"] = pd.Series((file1,) * len(df1))
     df2["path"] = pd.Series((file2,) * len(df2))

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4280,8 +4280,8 @@ def test_retries_on_remote_filesystem(tmpdir):
 
 
 def test_read_parquet_multiple_files_with_path_column(tmpdir):
-    file1 = str(tmpdir.join("file1.parquet"))
-    file2 = str(tmpdir.join("file2.parquet"))
+    file1 = os.path.join(tmpdir, "file1.parquet")
+    file2 = os.path.join(tmpdir, "file2.parquet")
     df1 = pd.DataFrame({"x": range(5), "y": ["a", "b", "c", "d", "e"]})
     df2 = df1.assign(x=df1.x + 0.5)
     df1.to_parquet(file1, index=False)
@@ -4291,7 +4291,9 @@ def test_read_parquet_multiple_files_with_path_column(tmpdir):
     df2["path"] = pd.Series((file2,) * len(df2))
     sol = pd.concat([df1, df2])
 
-    res = dd.read_parquet(tmpdir.join("file*.parquet"), include_path_column="path")
+    res = dd.read_parquet(
+        os.path.join(tmpdir, "file*.parquet"), include_path_column="path"
+    )
     res = res.compute()
 
     assert_eq(res, sol, check_index=False)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4279,7 +4279,7 @@ def test_retries_on_remote_filesystem(tmpdir):
         assert layer.annotations["retries"] == 2
 
 
-def test_read_parquet_multiple_files_with_path_column(tmpdir):
+def test_read_parquet_multiple_files_with_path_column(tmpdir, engine):
     file1 = os.path.join(tmpdir, "file1.parquet")
     file2 = os.path.join(tmpdir, "file2.parquet")
     df1 = pd.DataFrame({"x": range(5), "y": ["a", "b", "c", "d", "e"]})
@@ -4292,7 +4292,7 @@ def test_read_parquet_multiple_files_with_path_column(tmpdir):
     sol = pd.concat([df1, df2])
 
     res = dd.read_parquet(
-        os.path.join(tmpdir, "file*.parquet"), include_path_column="path"
+        os.path.join(tmpdir, "file*.parquet"), include_path_column="path", engine=engine
     )
     res = res.compute()
 


### PR DESCRIPTION
- [ ] Closes #6575 
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

### ToDo

- [ ] Update docstring.
- [ ] Raise error if path column name already exists in parquet file like [here](https://github.com/dask/dask/blob/main/dask/dataframe/io/json.py#L312).
- [ ] Change path column dtype to be a `pd.CategoricalDtype` like [here](https://github.com/dask/dask/blob/main/dask/dataframe/io/json.py#L225)
- [ ] Add more tests.

This is a WIP. I would be grateful if anybody could give some initial feedback.