### PR TITLE
Enable automatic column projection for groupby aggregations

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1684,7 +1684,7 @@ class _GroupBy:
 
             # Check if the aggregation involves implicit column projection
             if isinstance(arg, dict):
-                column_projection = group_columns | set(arg.keys())
+                column_projection = group_columns | arg.keys()
 
         elif isinstance(self.obj, Series):
             if isinstance(arg, (list, tuple, dict)):


### PR DESCRIPTION
While looking at the [h2o benchmark queries](https://github.com/coiled/coiled-runtime/blob/main/tests/benchmarks/h2o/test_h2o_benchmarks.py) in `coiled-runtime`, I noticed that **every** query includes an explicit column selection operation right before the groupby-aggregation. **There is nothing wrong with this - Explicit column selection is GOOD Dask-DataFrame practice**. Doing this produces a `getitem`-based `Blockwise` layer in the high-level graph that can often be projected into the IO Layer at graph-optimization time. 

The "problem" I see here is that most Dask users are unlikley to **know** about optimization oportunities like this.

This PR proposes that Dask **automatically** add explicit column-selection operations for groupby aggregations with `dict`-based aggregation specs.  This change is relatively simple, but results in significant performance boost for naive user code. For example:

```python
import dask.dataframe as dd
from dask.datasets import timeseries

ddf = timeseries(end='2003-01-31')
filtered = ddf[ddf['x'] > 0.5]
aggregated = filtered.groupby('id').agg({'x':'mean'})

%time aggregated.compute()
```
**This PR**: `Wall time: 7.58 s`
**`main`**: `Wall time: 18.8 s`

Note that this PR will effectively change `filtered.groupby('id').agg({'x':'mean'})` to `filtered[['id', 'x']].groupby('id').agg({'x':'mean'})`



- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
