### PR TITLE
Fix `fsspec` closed file I/O use (`fsspec==2022.8.0`)

### DIFF
--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -148,7 +148,9 @@ def read_bytes(
         keys = [f"read-block-{o}-{token}" for o in offset]
         values = [
             delayed_read(
-                OpenFile(fs, path, compression=compression),
+                fs,
+                path,
+                compression,
                 o,
                 l,
                 delimiter,
@@ -185,8 +187,8 @@ def read_bytes(
     return sample, out
 
 
-def read_block_from_file(lazy_file, off, bs, delimiter):
-    with copy.copy(lazy_file) as f:
+def read_block_from_file(fs, path, compression, off, bs, delimiter):
+    with OpenFile(fs, path, compression=compression) as f:
         if off == 0 and bs is None:
             return f.read()
         return read_block(f, off, bs, delimiter)

--- a/dask/bytes/core.py
+++ b/dask/bytes/core.py
@@ -1,4 +1,3 @@
-import copy
 import os
 
 from fsspec.core import OpenFile, get_fs_token_paths


### PR DESCRIPTION
`fsspec` version 2022.8.0 doesn't allow more I/O of OpenFile() created objects that are closed;

- [x] fixed use in `dask.bytes`
- [ ] fixed use in `dask.dataframe.io.csv`

(see https://github.com/fsspec/filesystem_spec/pull/1024) cc @martindurant 