### PR TITLE
Ignore zero sized chunks in auto_chunks

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3186,7 +3186,10 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
 
     if previous_chunks:
         # Base ideal ratio on the median chunk size of the previous chunks
-        result = {a: np.median(previous_chunks[a]) for a in autos}
+        result = {}
+        for a in autos:
+            prev_chunks = [x for x in previous_chunks[a] if x > 0]
+            result[a] = np.median(prev_chunks) if len(prev_chunks) else prev_chunks
 
         ideal_shape = []
         for i, s in enumerate(shape):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3189,7 +3189,11 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
         result = {}
         for a in autos:
             prev_chunks = [x for x in previous_chunks[a] if x > 0]
-            result[a] = np.median(prev_chunks) if len(prev_chunks) else prev_chunks
+            result[a] = (
+                np.median(prev_chunks)
+                if len(prev_chunks)
+                else np.median(previous_chunks[a])
+            )
 
         ideal_shape = []
         for i, s in enumerate(shape):


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

When an array is interspersed with empty chunks, the zero-valued chunks skew the median; this accounts for that while maintaining original behavior if the array only contains empty chunks.

Test cases are yet to be added.