### PR TITLE
Temporarily exclude nightly `pyarrow` from `upstream` CI build

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -7,10 +7,13 @@ set -xe
 # python -m pip install --no-deps cityhash
 
 if [[ ${UPSTREAM_DEV} ]]; then
-    # FIXME workaround for https://github.com/mamba-org/mamba/issues/1682
-    arr=($(mamba search --override-channels -c arrow-nightlies pyarrow | tail -n 1))
-    export PYARROW_VERSION=${arr[1]}
-    mamba install -y -c arrow-nightlies "pyarrow=$PYARROW_VERSION"
+    # TODO: restore the `pyarrow` installation lines below after
+    # https://github.com/dask/dask/issues/9449 has been closed.
+
+    # # FIXME workaround for https://github.com/mamba-org/mamba/issues/1682
+    # arr=($(mamba search --override-channels -c arrow-nightlies pyarrow | tail -n 1))
+    # export PYARROW_VERSION=${arr[1]}
+    # mamba install -y -c arrow-nightlies "pyarrow=$PYARROW_VERSION"
 
     # FIXME https://github.com/mamba-org/mamba/issues/412
     # mamba uninstall --force ...


### PR DESCRIPTION
This is a temporary workaround for https://github.com/dask/dask/issues/9449 

cc @ncclementi @jorisvandenbossche 