### PR TITLE
Shuffle groupby default

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -7,6 +7,7 @@ from numbers import Integral
 import numpy as np
 import pandas as pd
 
+from dask import config
 from dask.base import tokenize
 from dask.dataframe._compat import PANDAS_GT_150
 from dask.dataframe.core import (
@@ -1654,6 +1655,12 @@ class _GroupBy:
 
     @_aggregate_docstring()
     def aggregate(self, arg, split_every=None, split_out=1, shuffle=None):
+        if shuffle is None:
+            if split_out > 1:
+                shuffle = shuffle or config.get("shuffle", None) or "disk"
+            else:
+                shuffle = False
+
         column_projection = None
         if isinstance(self.obj, DataFrame):
             if isinstance(self.by, tuple) or np.isscalar(self.by):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1085,12 +1085,13 @@ def _aggregate_docstring(based_on=None):
             Number of output partitions. Default is 1.
         shuffle : bool or str, optional
             Whether a shuffle-based algorithm should be used. A specific
-            algorithm name may also be specified (e.g. `"tasks"` or `"p2p"`).
+            algorithm name may also be specified (e.g. ``"tasks"`` or ``"p2p"``).
             The shuffle-based algorithm is likely to be more efficient than
             ``shuffle=False`` when ``split_out>1`` and the number of unique
             groups is large (high cardinality). Default is ``False`` when
-            ``split_out = 1``. When ``split_out > 1``, it chooses the default
-            shuffling algorithm (disk or tasks).
+            ``split_out = 1``. When ``split_out > 1``, it chooses the algorithm
+            set by the ``shuffle`` option in the dask config system, or ``"tasks"``
+            if nothing is set.
         """
         return func
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1078,8 +1078,7 @@ def _aggregate_docstring(based_on=None):
             - dict of column names -> function, function name or list of such.
         split_every : int, optional
             Number of intermediate partitions that may be aggregated at once.
-            For ``shuffle=False``, this defaults to 8. If shuffling is enabled,
-            it defaults to 1. If your intermediate partitions are likely to
+            This defaults to 8. If your intermediate partitions are likely to
             be small (either due to a small number of groups or a small initial
             partition size), consider increasing this number for better performance.
         split_out : int, optional
@@ -2462,9 +2461,9 @@ def _shuffle_aggregate(
         Keywords for the aggregate function only.
     split_every : int, optional
         Number of partitions to aggregate into a shuffle partition.
-        Defaults to one, meaning that the initial partitioning is used in
-        the shuffle. Shuffling scales with the number of partitions, so it may
-        be helpful to repartition into fewer before shuffling as a performance
+        Defaults to eight, meaning that the initial partitions are repartitioned
+        into groups of eight before the shuffle. Shuffling scales with the number
+        of partitions, so it may be helpful to increase this number as a performance
         optimization, but only when the aggregated partition can comfortably
         fit in worker memory.
     split_out : int, optional
@@ -2493,7 +2492,7 @@ def _shuffle_aggregate(
     npartitions = npartitions.pop()
 
     if split_every is None:
-        split_every = 1
+        split_every = 8
     elif split_every is False:
         split_every = npartitions
     elif split_every < 1 or not isinstance(split_every, Integral):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1661,7 +1661,7 @@ class _GroupBy:
     def aggregate(self, arg, split_every=None, split_out=1, shuffle=None):
         if shuffle is None:
             if split_out > 1:
-                shuffle = shuffle or config.get("shuffle", None) or "disk"
+                shuffle = shuffle or config.get("shuffle", None) or "tasks"
             else:
                 shuffle = False
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1106,8 +1106,9 @@ def test_aggregate_dask():
                 assert len(other.dask) == len(result2.dask)
 
 
+@pytest.mark.parametrize("split_every", [1, 8])
 @pytest.mark.parametrize("split_out", [2, 32])
-def test_shuffle_aggregate(shuffle_method, split_out):
+def test_shuffle_aggregate(shuffle_method, split_out, split_every):
 
     pdf = pd.DataFrame(
         {
@@ -1122,7 +1123,7 @@ def test_shuffle_aggregate(shuffle_method, split_out):
 
     spec = {"b": "mean", "c": ["min", "max"]}
     result = ddf.groupby(["a", "b"]).agg(
-        spec, split_out=split_out, shuffle=shuffle_method
+        spec, split_out=split_out, split_every=split_every, shuffle=shuffle_method
     )
     expect = pdf.groupby(["a", "b"]).agg(spec)
 
@@ -1161,6 +1162,33 @@ def test_shuffle_aggregate_sort(shuffle_method, sort):
             ddf.groupby(["a", "b"], sort=sort).agg(
                 spec, split_out=2, shuffle=shuffle_method
             )
+
+
+def test_shuffle_aggregate_defaults(shuffle_method):
+    pdf = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 1, 1, 2, 4, 3, 7] * 100,
+            "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100,
+            "c": [0, 1, 2, 3, 4, 5, 6, 7, 8] * 100,
+            "d": [3, 2, 1, 3, 2, 1, 2, 6, 4] * 100,
+        },
+        columns=["c", "b", "a", "d"],
+    )
+    ddf = dd.from_pandas(pdf, npartitions=100)
+
+    spec = {"b": "mean", "c": ["min", "max"]}
+
+    # No shuffle layer when  split_out = 1
+    dsk = ddf.groupby("a").agg(spec, split_out=1).dask
+    assert not any("shuffle" in l for l in dsk.layers)
+
+    # split_every=1 is invalid for tree reduction
+    with pytest.raises(ValueError):
+        ddf.groupby("a").agg(spec, split_out=1, split_every=1)
+
+    # If split_out > 1, default to shuffling.
+    dsk = ddf.groupby("a").agg(spec, split_out=2, split_every=1).dask
+    assert any("shuffle" in l for l in dsk.layers)
 
 
 @pytest.mark.parametrize("axis", [0, 1])


### PR DESCRIPTION
I expect this to conflict significantly with the proposed alternative in #9446, though this PR has much less ambition. I'm just trying to select some defaults that are *likely* to have better performance based on some of the investigations in https://github.com/dask/dask/issues/9406#issuecomment-1234875036

I feel pretty good about the choice of having shuffle on-by-default when `split_out > 1`. I'm less sure about what to do about `split_every`. When we have fewer, larger partitions, we probably want it to be close to one. When we have many smaller partitions, it probably makes sense for it to be eight or sixteen, as @rjzamora was finding (note that in this context `split_every` is more of a repartitioning granularity rather than a tree-reduction width). I am not sure if there really is a great solution short of the things that @rjzamora is trying in #9446, since we don't typically know partition sizes ahead of time. (Though we could in some instances, like with parquet!)

- [x] Closes #9406 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
