### PR TITLE
Changed `flake8` mirror in `pre-commit` and updated version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,8 @@ repos:
         exclude: versioneer.py
         args:
           - --target-version=py38
-  -   repo: https://gitlab.com/pycqa/flake8
-      rev: 3.9.2
+  -   repo: https://github.com/pycqa/flake8
+      rev: 5.0.4
       hooks:
       - id: flake8
         language_version: python3


### PR DESCRIPTION
### Summary of changes

- [x] `.pre-commit-config.yaml`
  - Changed `flake8` mirror in `pre-commit` from GitLab to GitHub and updated to the latest version. This is because the GitLab mirror is not updated anymore and the link was temporarily down (causing `pre-commit` initialisation errors).
- [x] Closes #9455 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
