### PR TITLE
Added `flake8-bugbear` to `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# NOTE: autoupdate does not pick up flake8-bugbear since it is a transitive
+#  dependency. Make sure to update flake8-bugbear manually on a regular basis.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
@@ -33,7 +35,7 @@ repos:
       - id: flake8
         language_version: python3
         additional_dependencies:
-          - flake8-bugbear==22.8.23
+          - flake8-bugbear==22.8.23  # NOTE: manually update this
   -   repo: https://github.com/codespell-project/codespell
       rev: v2.1.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,8 @@ repos:
       hooks:
       - id: flake8
         language_version: python3
+        additional_dependencies:
+          - flake8-bugbear==22.8.23
   -   repo: https://github.com/codespell-project/codespell
       rev: v2.1.0
       hooks:

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -1235,4 +1235,4 @@ def pad(array, pad_width, mode="constant", **kwargs):
     elif mode in ["reflect", "symmetric", "wrap"]:
         return pad_reuse(array, pad_width, mode, **kwargs)
 
-    assert False, "unreachable"
+    raise RuntimeError("unreachable")

--- a/dask/array/tests/test_dispatch.py
+++ b/dask/array/tests/test_dispatch.py
@@ -230,7 +230,7 @@ def test_direct_deferral_wrapping_override():
     b = WrappedArray(np.arange(4))
     assert a.__add__(b) is NotImplemented
     # Note: remove dask_graph to be able to wrap b in a dask array
-    setattr(b, "__dask_graph__", None)
+    b.__dask_graph__ = None
     res = a + da.from_array(b)
     assert isinstance(res, da.Array)
     assert_eq(res, 2 * np.arange(4), check_type=False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,10 @@ ignore =
     W504,  # line break after binary operator
     F811,  # redefinition of unused 'loop' from line 10
 max-line-length = 120
+per-file-ignores =
+    **/tests/*:
+        # Do not call assert False since python -O removes these calls
+        B011,
 
 [isort]
 sections = FUTURE,STDLIB,THIRDPARTY,DISTRIBUTED,FIRSTPARTY,LOCALFOLDER

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,9 @@ ignore =
     F811,  # redefinition of unused 'loop' from line 10
 max-line-length = 120
 per-file-ignores =
+    *_test.py:
+        # Do not call assert False since python -O removes these calls
+        B011,
     **/tests/*:
         # Do not call assert False since python -O removes these calls
         B011,


### PR DESCRIPTION
### Summary of changes in this PR

- [x] `.pre-commit-config.yaml`: added `flake8-bugbear` hook for `pre-commit`
- [x] `setup.cfg`: excluded `B011` for tests following https://github.com/dask/distributed/pull/6809
- [x] Misc. warnings:
  - [x] `dask/array/creation.py`: replaced assert False with raise error
    - _**B011**: Do not call assert False since python -O removes these calls. Instead callers should raise `AssertionError()`._
  - [x] `dask/array/tests/test_dispatch.py`: replaced `setattr` for constant attribute
    - _**B010**: Do not call `setattr(x, 'attr', val)`, instead use normal property access: `x.attr = val`. There is no additional safety in using `setattr` if you know the attribute name ahead of time._ 

### Depends on these PRs merging first

- [x] Individual PRs per warning from `flake8-bugbear`:
  - [x] #9458
  - [x] #9459
  - [x] #9460
  - [x] #9461   
  - [x] #9462 

### General

- [x] Closes #9369 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
