### PR TITLE
Added assert for comparisons (`B015`)

### DIFF
--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1399,7 +1399,7 @@ def test_reduction_with_sparse_matrices():
 
 
 def test_empty():
-    list(db.from_sequence([])) == []
+    assert list(db.from_sequence([])) == []
 
 
 def test_bag_picklable():

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -1096,7 +1096,7 @@ def stack_partitions(dfs, divisions, join="outer", ignore_order=False, **kwargs)
         # this case we need to pass along the meta object to transform each
         # partition, so they're all equivalent.
         try:
-            df._meta == meta
+            assert df._meta == meta
             match = True
         except (ValueError, TypeError):
             match = False

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2720,7 +2720,10 @@ def test_reduction_method():
 
     # Test with keywords
     res2 = ddf.reduction(chunk, aggregate=agg, chunk_kwargs={"val": 25})
-    assert res2._name == ddf.reduction(chunk, aggregate=agg, chunk_kwargs={"val": 25})._name
+    assert (
+        res2._name
+        == ddf.reduction(chunk, aggregate=agg, chunk_kwargs={"val": 25})._name
+    )
     assert res2._name != res._name
     assert_eq(res2, (df >= 25).sum())
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2720,7 +2720,7 @@ def test_reduction_method():
 
     # Test with keywords
     res2 = ddf.reduction(chunk, aggregate=agg, chunk_kwargs={"val": 25})
-    res2._name == ddf.reduction(chunk, aggregate=agg, chunk_kwargs={"val": 25})._name
+    assert res2._name == ddf.reduction(chunk, aggregate=agg, chunk_kwargs={"val": 25})._name
     assert res2._name != res._name
     assert_eq(res2, (df >= 25).sum())
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2068,7 +2068,7 @@ def test_concat_categorical(known, cat_index, divisions):
                 dd.DataFrame, res.dask, res.__dask_keys__()
             )
             for p in [i.iloc[:0] for i in parts]:
-                res._meta == p  # will error if schemas don't align
+                assert res._meta == p  # will error if schemas don't align
         assert not cat_index or has_known_categories(res.index) == known
         return res
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2068,7 +2068,10 @@ def test_concat_categorical(known, cat_index, divisions):
                 dd.DataFrame, res.dask, res.__dask_keys__()
             )
             for p in [i.iloc[:0] for i in parts]:
-                assert res._meta == p  # will error if schemas don't align
+                if isinstance(p, pd.DataFrame):
+                    pd.testing.assert_frame_equal(res._meta, p)
+                elif isinstance(p, pd.Series):
+                    pd.testing.assert_series_equal(res._meta, p)
         assert not cat_index or has_known_categories(res.index) == known
         return res
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -749,7 +749,7 @@ def test_set_index_timezone():
         assert not d2.divisions[0] == s2badtype[0]
     else:
         with pytest.raises(TypeError):
-            d2.divisions[0] == s2badtype[0]
+            assert d2.divisions[0] == s2badtype[0]
 
 
 def test_set_index_npartitions():


### PR DESCRIPTION
### Summary of changes in this PR

- [x] One of the individual PRs per warning from `flake8-bugbear` that is required for #9457.
  - _B015: Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend assert or remove it._
  - Ran on whole repository using: `flake8 --select B015`

### General

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
