### PR TITLE
Replaced `getattr` calls for constant attributes (`B009`)

### DIFF
--- a/dask/array/tests/test_cupy_creation.py
+++ b/dask/array/tests/test_cupy_creation.py
@@ -158,14 +158,12 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
     ],
 )
 def test_tri_like(xp, N, M, k, dtype, chunks):
-    xp_tri = xp.tri
-
     args = [N, M, k, dtype]
 
     cp_a = cupy.tri(*args)
 
     if xp is da:
         args.append(chunks)
-    xp_a = xp_tri(*args, like=da.from_array(cupy.array(())))
+    xp_a = xp.tri(*args, like=da.from_array(cupy.array(())))
 
     assert_eq(xp_a, cp_a)

--- a/dask/array/tests/test_cupy_creation.py
+++ b/dask/array/tests/test_cupy_creation.py
@@ -158,7 +158,7 @@ def test_pad(shape, chunks, pad_width, mode, kwargs):
     ],
 )
 def test_tri_like(xp, N, M, k, dtype, chunks):
-    xp_tri = getattr(xp, "tri")
+    xp_tri = xp.tri
 
     args = [N, M, k, dtype]
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -245,8 +245,8 @@ def test_rot90(kwargs, shape):
     np_a = np.random.random(shape)
     da_a = da.from_array(np_a, chunks=1)
 
-    np_func = getattr(np, "rot90")
-    da_func = getattr(da, "rot90")
+    np_func = np.rot90
+    da_func = da.rot90
 
     try:
         for axis in axes[:2]:

--- a/dask/base.py
+++ b/dask/base.py
@@ -1187,7 +1187,7 @@ def register_numpy():
                 offset = 0  # root memmap's have mmap object as base
             if hasattr(
                 x, "offset"
-            ):  # offset numpy used while opening, and not the offset to the beginning of the file
+            ):  # offset numpy used while opening, and not the offset to the beginning of file
                 offset += x.offset
             return (
                 x.filename,

--- a/dask/base.py
+++ b/dask/base.py
@@ -1188,7 +1188,7 @@ def register_numpy():
             if hasattr(
                 x, "offset"
             ):  # offset numpy used while opening, and not the offset to the beginning of the file
-                offset += getattr(x, "offset")
+                offset += x.offset
             return (
                 x.filename,
                 os.path.getmtime(x.filename),

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -139,7 +139,7 @@ def to_hdf(
     """
     name = "to-hdf-" + uuid.uuid1().hex
 
-    pd_to_hdf = getattr(df._partition_type, "to_hdf")
+    pd_to_hdf = df._partition_type.to_hdf
 
     single_file = True
     single_node = True


### PR DESCRIPTION
### Summary of changes in this PR

- [x] One of the individual PRs per warning from `flake8-bugbear` that is required for #9457.
  - _**B009**: Do not call `getattr(x, 'attr')`, instead use normal property access: `x.attr`. Missing a default to `getattr` will cause an `AttributeError` to be raised for non-existent properties. There is no additional safety in using `getattr` if you know the attribute name ahead of time._
  - Ran on whole repository using: `flake8 --select B009`

### General

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
