### PR TITLE
Bind loop variables in function definitions (`B023`)

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1785,7 +1785,7 @@ def test_coerce():
     a2 = np.arange(2)
     d2 = da.from_array(a2, chunks=(2,))
     for func in (int, float, complex):
-        pytest.raises(TypeError, lambda func: func(d2))
+        pytest.raises(TypeError, lambda func=func: func(d2))
 
 
 def test_bool():
@@ -1873,9 +1873,9 @@ def test_store_delayed_target():
         assert_eq(st[0], a)
         assert_eq(st[1], b)
 
-        pytest.raises(ValueError, lambda at, bt: store([a], [at, bt]))
-        pytest.raises(ValueError, lambda at: store(at, at))
-        pytest.raises(ValueError, lambda at, bt: store([at, bt], [at, bt]))
+        pytest.raises(ValueError, lambda at=at, bt=bt: store([a], [at, bt]))
+        pytest.raises(ValueError, lambda at=at: store(at, at))
+        pytest.raises(ValueError, lambda at=at, bt=bt: store([at, bt], [at, bt]))
 
 
 def test_store():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1785,7 +1785,7 @@ def test_coerce():
     a2 = np.arange(2)
     d2 = da.from_array(a2, chunks=(2,))
     for func in (int, float, complex):
-        pytest.raises(TypeError, lambda: func(d2))
+        pytest.raises(TypeError, lambda func: func(d2))
 
 
 def test_bool():
@@ -1873,9 +1873,9 @@ def test_store_delayed_target():
         assert_eq(st[0], a)
         assert_eq(st[1], b)
 
-        pytest.raises(ValueError, lambda: store([a], [at, bt]))
-        pytest.raises(ValueError, lambda: store(at, at))
-        pytest.raises(ValueError, lambda: store([at, bt], [at, bt]))
+        pytest.raises(ValueError, lambda at, bt: store([a], [at, bt]))
+        pytest.raises(ValueError, lambda at: store(at, at))
+        pytest.raises(ValueError, lambda at, bt: store([at, bt], [at, bt]))
 
 
 def test_store():

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -148,7 +148,9 @@ def optimize_dataframe_getitem(dsk, keys):
                 return True
             deps = dependents[key]
             if deps:  # noqa: B023
-                return all(_walk_deps(dependents, dep, success) for dep in deps)  # noqa: B023
+                return all(
+                    _walk_deps(dependents, dep, success) for dep in deps
+                )  # noqa: B023
             else:
                 return False
 

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -147,8 +147,8 @@ def optimize_dataframe_getitem(dsk, keys):
             if key == success:
                 return True
             deps = dependents[key]
-            if deps:
-                return all(_walk_deps(dependents, dep, success) for dep in deps)
+            if deps:  # noqa: B023
+                return all(_walk_deps(dependents, dep, success) for dep in deps)  # noqa: B023
             else:
                 return False
 

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -149,8 +149,8 @@ def optimize_dataframe_getitem(dsk, keys):
             deps = dependents[key]
             if deps:  # noqa: B023
                 return all(
-                    _walk_deps(dependents, dep, success) for dep in deps
-                )  # noqa: B023
+                    _walk_deps(dependents, dep, success) for dep in deps  # noqa: B023
+                )
             else:
                 return False
 

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -636,7 +636,7 @@ def test_frame_series_arithmetic_methods():
         assert_eq(l.rmod(r, axis=0), el.rmod(er, axis=0))
         assert_eq(l.rpow(r, axis=0), el.rpow(er, axis=0))
 
-        pytest.raises(ValueError, lambda: l.add(r, axis=1))
+        pytest.raises(ValueError, lambda l, r: l.add(r, axis=1))
 
     for l, r, el, er in [(ddf1, pdf2, pdf1, pdf2), (ddf1, ps3, pdf1, ps3)]:
         assert_eq(l, el)
@@ -967,17 +967,17 @@ def test_reduction_series_invalid_axis():
 
     for axis in [1, "columns"]:
         for s in [ddf1.a, pdf1.a]:  # both must behave the same
-            pytest.raises(ValueError, lambda: s.sum(axis=axis))
-            pytest.raises(ValueError, lambda: s.prod(axis=axis))
-            pytest.raises(ValueError, lambda: s.product(axis=axis))
-            pytest.raises(ValueError, lambda: s.min(axis=axis))
-            pytest.raises(ValueError, lambda: s.max(axis=axis))
+            pytest.raises(ValueError, lambda s, axis: s.sum(axis=axis))
+            pytest.raises(ValueError, lambda s, axis: s.prod(axis=axis))
+            pytest.raises(ValueError, lambda s, axis: s.product(axis=axis))
+            pytest.raises(ValueError, lambda s, axis: s.min(axis=axis))
+            pytest.raises(ValueError, lambda s, axis: s.max(axis=axis))
             # only count doesn't have axis keyword
-            pytest.raises(TypeError, lambda: s.count(axis=axis))
-            pytest.raises(ValueError, lambda: s.std(axis=axis))
-            pytest.raises(ValueError, lambda: s.var(axis=axis))
-            pytest.raises(ValueError, lambda: s.sem(axis=axis))
-            pytest.raises(ValueError, lambda: s.mean(axis=axis))
+            pytest.raises(TypeError, lambda s, axis: s.count(axis=axis))
+            pytest.raises(ValueError, lambda s, axis: s.std(axis=axis))
+            pytest.raises(ValueError, lambda s, axis: s.var(axis=axis))
+            pytest.raises(ValueError, lambda s, axis: s.sem(axis=axis))
+            pytest.raises(ValueError, lambda s, axis: s.mean(axis=axis))
 
 
 def test_reductions_non_numeric_dtypes():

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -636,7 +636,7 @@ def test_frame_series_arithmetic_methods():
         assert_eq(l.rmod(r, axis=0), el.rmod(er, axis=0))
         assert_eq(l.rpow(r, axis=0), el.rpow(er, axis=0))
 
-        pytest.raises(ValueError, lambda l, r: l.add(r, axis=1))
+        pytest.raises(ValueError, lambda l=l, r=r: l.add(r, axis=1))
 
     for l, r, el, er in [(ddf1, pdf2, pdf1, pdf2), (ddf1, ps3, pdf1, ps3)]:
         assert_eq(l, el)
@@ -967,17 +967,17 @@ def test_reduction_series_invalid_axis():
 
     for axis in [1, "columns"]:
         for s in [ddf1.a, pdf1.a]:  # both must behave the same
-            pytest.raises(ValueError, lambda s, axis: s.sum(axis=axis))
-            pytest.raises(ValueError, lambda s, axis: s.prod(axis=axis))
-            pytest.raises(ValueError, lambda s, axis: s.product(axis=axis))
-            pytest.raises(ValueError, lambda s, axis: s.min(axis=axis))
-            pytest.raises(ValueError, lambda s, axis: s.max(axis=axis))
+            pytest.raises(ValueError, lambda s=s, axis=axis: s.sum(axis=axis))
+            pytest.raises(ValueError, lambda s=s, axis=axis: s.prod(axis=axis))
+            pytest.raises(ValueError, lambda s=s, axis=axis: s.product(axis=axis))
+            pytest.raises(ValueError, lambda s=s, axis=axis: s.min(axis=axis))
+            pytest.raises(ValueError, lambda s=s, axis=axis: s.max(axis=axis))
             # only count doesn't have axis keyword
-            pytest.raises(TypeError, lambda s, axis: s.count(axis=axis))
-            pytest.raises(ValueError, lambda s, axis: s.std(axis=axis))
-            pytest.raises(ValueError, lambda s, axis: s.var(axis=axis))
-            pytest.raises(ValueError, lambda s, axis: s.sem(axis=axis))
-            pytest.raises(ValueError, lambda s, axis: s.mean(axis=axis))
+            pytest.raises(TypeError, lambda s=s, axis=axis: s.count(axis=axis))
+            pytest.raises(ValueError, lambda s=s, axis=axis: s.std(axis=axis))
+            pytest.raises(ValueError, lambda s=s, axis=axis: s.var(axis=axis))
+            pytest.raises(ValueError, lambda s=s, axis=axis: s.sem(axis=axis))
+            pytest.raises(ValueError, lambda s=s, axis=axis: s.mean(axis=axis))
 
 
 def test_reductions_non_numeric_dtypes():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -190,7 +190,7 @@ def test_Index():
     ]:
         ddf = dd.from_pandas(case, 3)
         assert_eq(ddf.index, case.index)
-        pytest.raises(AttributeError, lambda ddf: ddf.index.index)
+        pytest.raises(AttributeError, lambda ddf=ddf: ddf.index.index)
 
 
 def test_axes():
@@ -1952,7 +1952,7 @@ def test_repartition():
         [10, 10, 20, 60],
     ]:  # not unique (last element can be duplicated)
 
-        pytest.raises(ValueError, lambda div: a.repartition(divisions=div))
+        pytest.raises(ValueError, lambda div=div: a.repartition(divisions=div))
 
     pdf = pd.DataFrame(np.random.randn(7, 5), columns=list("abxyz"))
     for p in range(1, 7):
@@ -3321,25 +3321,25 @@ def test_nlargest_nsmallest():
     ddf = dd.from_pandas(df, npartitions=3)
 
     for m in ["nlargest", "nsmallest"]:
-        f = lambda df, m, *args, **kwargs: getattr(df, m)(*args, **kwargs)
+        f = lambda df=df, m=m, *args, **kwargs: getattr(df, m)(*args, **kwargs)
 
-        res = f(ddf, 5, "a")
-        res2 = f(ddf, 5, "a", split_every=2)
-        sol = f(df, 5, "a")
+        res = f(ddf, m, 5, "a")
+        res2 = f(ddf, m, 5, "a", split_every=2)
+        sol = f(df, m, 5, "a")
         assert_eq(res, sol)
         assert_eq(res2, sol)
         assert res._name != res2._name
 
-        res = f(ddf, 5, ["a", "c"])
-        res2 = f(ddf, 5, ["a", "c"], split_every=2)
-        sol = f(df, 5, ["a", "c"])
+        res = f(ddf, m, 5, ["a", "c"])
+        res2 = f(ddf, m, 5, ["a", "c"], split_every=2)
+        sol = f(df, m, 5, ["a", "c"])
         assert_eq(res, sol)
         assert_eq(res2, sol)
         assert res._name != res2._name
 
-        res = f(ddf.a, 5)
-        res2 = f(ddf.a, 5, split_every=2)
-        sol = f(df.a, 5)
+        res = f(ddf.a, m, 5)
+        res2 = f(ddf.a, m, 5, split_every=2)
+        sol = f(df.a, m, 5)
         assert_eq(res, sol)
         assert_eq(res2, sol)
         assert res._name != res2._name
@@ -4492,7 +4492,7 @@ def test_coerce():
     ddf = dd.from_pandas(df, npartitions=2)
     funcs = (int, float, complex)
     for d, t in product(funcs, (ddf, ddf[0])):
-        pytest.raises(TypeError, lambda t, d: t(d))
+        pytest.raises(TypeError, lambda t=t, d=d: t(d))
 
 
 def test_bool():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -190,7 +190,7 @@ def test_Index():
     ]:
         ddf = dd.from_pandas(case, 3)
         assert_eq(ddf.index, case.index)
-        pytest.raises(AttributeError, lambda: ddf.index.index)
+        pytest.raises(AttributeError, lambda ddf: ddf.index.index)
 
 
 def test_axes():
@@ -1952,7 +1952,7 @@ def test_repartition():
         [10, 10, 20, 60],
     ]:  # not unique (last element can be duplicated)
 
-        pytest.raises(ValueError, lambda: a.repartition(divisions=div))
+        pytest.raises(ValueError, lambda div: a.repartition(divisions=div))
 
     pdf = pd.DataFrame(np.random.randn(7, 5), columns=list("abxyz"))
     for p in range(1, 7):
@@ -3321,7 +3321,7 @@ def test_nlargest_nsmallest():
     ddf = dd.from_pandas(df, npartitions=3)
 
     for m in ["nlargest", "nsmallest"]:
-        f = lambda df, *args, **kwargs: getattr(df, m)(*args, **kwargs)
+        f = lambda df, m, *args, **kwargs: getattr(df, m)(*args, **kwargs)
 
         res = f(ddf, 5, "a")
         res2 = f(ddf, 5, "a", split_every=2)
@@ -4492,7 +4492,7 @@ def test_coerce():
     ddf = dd.from_pandas(df, npartitions=2)
     funcs = (int, float, complex)
     for d, t in product(funcs, (ddf, ddf[0])):
-        pytest.raises(TypeError, lambda: t(d))
+        pytest.raises(TypeError, lambda t, d: t(d))
 
 
 def test_bool():

--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -102,7 +102,7 @@ def test_threaded_within_thread():
 def test_dont_spawn_too_many_threads():
     before = threading.active_count()
 
-    dsk = {("x", i): (lambda: i,) for i in range(10)}
+    dsk = {("x", i): (lambda i: i,) for i in range(10)}
     dsk["x"] = (sum, list(dsk))
     for i in range(20):
         get(dsk, "x", num_workers=4)
@@ -115,7 +115,7 @@ def test_dont_spawn_too_many_threads():
 def test_dont_spawn_too_many_threads_CPU_COUNT():
     before = threading.active_count()
 
-    dsk = {("x", i): (lambda: i,) for i in range(10)}
+    dsk = {("x", i): (lambda i: i,) for i in range(10)}
     dsk["x"] = (sum, list(dsk))
     for i in range(20):
         get(dsk, "x")

--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -102,7 +102,7 @@ def test_threaded_within_thread():
 def test_dont_spawn_too_many_threads():
     before = threading.active_count()
 
-    dsk = {("x", i): (lambda i: i,) for i in range(10)}
+    dsk = {("x", i): (lambda i=i: i,) for i in range(10)}
     dsk["x"] = (sum, list(dsk))
     for i in range(20):
         get(dsk, "x", num_workers=4)
@@ -115,7 +115,7 @@ def test_dont_spawn_too_many_threads():
 def test_dont_spawn_too_many_threads_CPU_COUNT():
     before = threading.active_count()
 
-    dsk = {("x", i): (lambda i: i,) for i in range(10)}
+    dsk = {("x", i): (lambda i=i: i,) for i in range(10)}
     dsk["x"] = (sum, list(dsk))
     for i in range(20):
         get(dsk, "x")


### PR DESCRIPTION
### Summary of changes in this PR

- [x] One of the individual PRs per warning from `flake8-bugbear` that is required for #9457.
  - _**B023**: Functions defined inside a loop must not use variables redefined in the loop, because [late-binding closures are a classic gotcha](https://docs.python-guide.org/writing/gotchas/#late-binding-closures)._
  - Ran on whole repository using: `flake8 --select B023`

### General

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
