### PR TITLE
Replaced mutable data structures for default arguments (`B006`)

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -24,7 +24,6 @@ from itertools import product, zip_longest
 from numbers import Integral, Number
 from operator import add, mul
 from threading import Lock
-from types import MappingProxyType
 from typing import Any, TypeVar, Union, cast
 
 import numpy as np
@@ -355,7 +354,7 @@ def dotmany(A, B, leftfunc=None, rightfunc=None, **kwargs):
     return sum(map(partial(np.dot, **kwargs), A, B))
 
 
-def _concatenate2(arrays, axes=MappingProxyType([])):
+def _concatenate2(arrays, axes=None):
     """Recursively concatenate nested lists of arrays along axes
 
     Each entry in axes corresponds to each level of the nested list.  The
@@ -390,6 +389,9 @@ def _concatenate2(arrays, axes=MappingProxyType([])):
     array([[1, 2],
            [3, 4]])
     """
+    if axes is None:
+        axes = []
+
     if axes == ():
         if isinstance(arrays, list):
             return arrays[0]
@@ -530,7 +532,7 @@ def map_blocks(
     token=None,
     dtype=None,
     chunks=None,
-    drop_axis=MappingProxyType([]),
+    drop_axis=None,
     new_axis=None,
     enforce_ndim=False,
     meta=None,
@@ -771,6 +773,9 @@ def map_blocks(
     >>> da.map_blocks(lambda x: x[2], rs.random(5, dtype=dt), meta=cupy.array((), dtype=dt))  # doctest: +SKIP
     dask.array<lambda, shape=(5,), dtype=float32, chunksize=(5,), chunktype=cupy.ndarray>
     """
+    if drop_axis is None:
+        drop_axis = []
+
     if not callable(func):
         msg = (
             "First argument must be callable function, not %s\n"
@@ -3769,7 +3774,7 @@ def from_delayed(value, shape, dtype=None, meta=None, name=None):
     return Array(graph, name, chunks, dtype=dtype, meta=meta)
 
 
-def from_func(func, shape, dtype=None, name=None, args=(), kwargs=MappingProxyType({})):
+def from_func(func, shape, dtype=None, name=None, args=(), kwargs=None):
     """Create dask array in a single block by calling a function
 
     Calling the provided function with func(*args, **kwargs) should return a
@@ -3789,6 +3794,9 @@ def from_func(func, shape, dtype=None, name=None, args=(), kwargs=MappingProxyTy
     >>> stack(arrays).compute()
     array([0, 1, 2, 3, 4])
     """
+    if kwargs is None:
+        kwargs = {}
+
     name = name or "from_func-" + tokenize(func, shape, dtype, args, kwargs)
     if args or kwargs:
         func = partial(func, *args, **kwargs)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -24,6 +24,7 @@ from itertools import product, zip_longest
 from numbers import Integral, Number
 from operator import add, mul
 from threading import Lock
+from types import MappingProxyType
 from typing import Any, TypeVar, Union, cast
 
 import numpy as np
@@ -354,7 +355,7 @@ def dotmany(A, B, leftfunc=None, rightfunc=None, **kwargs):
     return sum(map(partial(np.dot, **kwargs), A, B))
 
 
-def _concatenate2(arrays, axes=[]):
+def _concatenate2(arrays, axes=MappingProxyType([])):
     """Recursively concatenate nested lists of arrays along axes
 
     Each entry in axes corresponds to each level of the nested list.  The
@@ -529,7 +530,7 @@ def map_blocks(
     token=None,
     dtype=None,
     chunks=None,
-    drop_axis=[],
+    drop_axis=MappingProxyType([]),
     new_axis=None,
     enforce_ndim=False,
     meta=None,
@@ -3768,7 +3769,7 @@ def from_delayed(value, shape, dtype=None, meta=None, name=None):
     return Array(graph, name, chunks, dtype=dtype, meta=meta)
 
 
-def from_func(func, shape, dtype=None, name=None, args=(), kwargs={}):
+def from_func(func, shape, dtype=None, name=None, args=(), kwargs=MappingProxyType({})):
     """Create dask array in a single block by calling a function
 
     Calling the provided function with func(*args, **kwargs) should return a

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -4,7 +4,6 @@ import operator
 import uuid
 import warnings
 from numbers import Integral
-from types import MappingProxyType
 
 import numpy as np
 import pandas as pd
@@ -1239,14 +1238,20 @@ class _GroupBy:
         meta=None,
         split_every=None,
         split_out=1,
-        chunk_kwargs=MappingProxyType({}),
-        aggregate_kwargs=MappingProxyType({}),
+        chunk_kwargs=None,
+        aggregate_kwargs=None,
     ):
         if aggfunc is None:
             aggfunc = func
 
         if meta is None:
             meta = func(self._meta_nonempty)
+
+        if chunk_kwargs is None:
+            chunk_kwargs = {}
+
+        if aggregate_kwargs is None:
+            aggregate_kwargs = {}
 
         columns = meta.name if is_series_like(meta) else meta.columns
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -4,6 +4,7 @@ import operator
 import uuid
 import warnings
 from numbers import Integral
+from types import MappingProxyType
 
 import numpy as np
 import pandas as pd
@@ -1238,8 +1239,8 @@ class _GroupBy:
         meta=None,
         split_every=None,
         split_out=1,
-        chunk_kwargs={},
-        aggregate_kwargs={},
+        chunk_kwargs=MappingProxyType({}),
+        aggregate_kwargs=MappingProxyType({}),
     ):
         if aggfunc is None:
             aggfunc = func

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -1,5 +1,3 @@
-from types import MappingProxyType
-
 import numpy as np
 import pandas as pd
 
@@ -124,7 +122,7 @@ def make_timeseries_part(start, end, dtypes, freq, state_data, kwargs):
 def make_timeseries(
     start="2000-01-01",
     end="2000-12-31",
-    dtypes=MappingProxyType({"name": str, "id": int, "x": float, "y": float}),
+    dtypes=None,
     freq="10s",
     partition_freq="1M",
     seed=None,
@@ -138,7 +136,7 @@ def make_timeseries(
         Start of time series
     end: datetime (or datetime-like string)
         End of time series
-    dtypes: dict
+    dtypes: dict (optional)
         Mapping of column names to types.
         Valid types include {float, int, str, 'category'}
     freq: string
@@ -165,6 +163,9 @@ def make_timeseries(
     2000-01-01 06:00:00   960   Charlie  0.788245
     2000-01-01 08:00:00  1031     Kevin  0.466002
     """
+    if dtypes is None:
+        dtypes = {"name": str, "id": int, "x": float, "y": float}
+
     divisions = list(pd.date_range(start=start, end=end, freq=partition_freq))
     npartitions = len(divisions) - 1
     if seed is None:

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -1,3 +1,5 @@
+from types import MappingProxyType
+
 import numpy as np
 import pandas as pd
 
@@ -122,7 +124,7 @@ def make_timeseries_part(start, end, dtypes, freq, state_data, kwargs):
 def make_timeseries(
     start="2000-01-01",
     end="2000-12-31",
-    dtypes={"name": str, "id": int, "x": float, "y": float},
+    dtypes=MappingProxyType({"name": str, "id": int, "x": float, "y": float}),
     freq="10s",
     partition_freq="1M",
     seed=None,

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -2,6 +2,7 @@ import os
 import uuid
 from fnmatch import fnmatch
 from glob import glob
+from types import MappingProxyType
 from warnings import warn
 
 import pandas as pd
@@ -48,7 +49,7 @@ def to_hdf(
     name_function=None,
     compute=True,
     lock=None,
-    dask_kwargs={},
+    dask_kwargs=MappingProxyType({}),
     **kwargs,
 ):
     """Store Dask Dataframe to Hierarchical Data Format (HDF) files

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -2,7 +2,6 @@ import os
 import uuid
 from fnmatch import fnmatch
 from glob import glob
-from types import MappingProxyType
 from warnings import warn
 
 import pandas as pd
@@ -49,7 +48,7 @@ def to_hdf(
     name_function=None,
     compute=True,
     lock=None,
-    dask_kwargs=MappingProxyType({}),
+    dask_kwargs=None,
     **kwargs,
 ):
     """Store Dask Dataframe to Hierarchical Data Format (HDF) files
@@ -138,6 +137,9 @@ def to_hdf(
     read_hdf:
     to_parquet:
     """
+    if dask_kwargs is None:
+        dask_kwargs = {}
+
     name = "to-hdf-" + uuid.uuid1().hex
 
     pd_to_hdf = getattr(df._partition_type, "to_hdf")

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -1,7 +1,6 @@
 import datetime
 import inspect
 from numbers import Integral
-from types import MappingProxyType
 
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype
@@ -592,7 +591,9 @@ class Rolling:
         )
 
     @derived_from(pd_Rolling)
-    def aggregate(self, func, args=(), kwargs=MappingProxyType({}), **kwds):
+    def aggregate(self, func, args=(), kwargs=None, **kwds):
+        if kwargs is None:
+            kwargs = {}
         return self._call_method("agg", func, args=args, kwargs=kwargs, **kwds)
 
     agg = aggregate

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -1,6 +1,7 @@
 import datetime
 import inspect
 from numbers import Integral
+from types import MappingProxyType
 
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype
@@ -591,7 +592,7 @@ class Rolling:
         )
 
     @derived_from(pd_Rolling)
-    def aggregate(self, func, args=(), kwargs={}, **kwds):
+    def aggregate(self, func, args=(), kwargs=MappingProxyType({}), **kwds):
         return self._call_method("agg", func, args=args, kwargs=kwargs, **kwds)
 
     agg = aggregate

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -1,5 +1,3 @@
-from types import MappingProxyType
-
 import numpy as np
 import pandas as pd
 from pandas.core.resample import Resampler as pd_Resampler
@@ -133,7 +131,7 @@ class Resampler:
         meta=None,
         fill_value=np.nan,
         how_args=(),
-        how_kwargs=MappingProxyType({}),
+        how_kwargs=None,
     ):
         """Aggregate using one or more operations
 
@@ -153,6 +151,9 @@ class Resampler:
         -------
         Dask DataFrame or Series
         """
+        if how_kwargs is None:
+            how_kwargs = {}
+
         rule = self._rule
         kwargs = self._kwargs
         name = "resample-" + tokenize(

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -1,3 +1,5 @@
+from types import MappingProxyType
+
 import numpy as np
 import pandas as pd
 from pandas.core.resample import Resampler as pd_Resampler
@@ -125,7 +127,14 @@ class Resampler:
         self._rule = pd.tseries.frequencies.to_offset(rule)
         self._kwargs = kwargs
 
-    def _agg(self, how, meta=None, fill_value=np.nan, how_args=(), how_kwargs={}):
+    def _agg(
+        self,
+        how,
+        meta=None,
+        fill_value=np.nan,
+        how_args=(),
+        how_kwargs=MappingProxyType({}),
+    ):
         """Aggregate using one or more operations
 
         Parameters

--- a/dask/datasets.py
+++ b/dask/datasets.py
@@ -1,5 +1,4 @@
 import random
-from types import MappingProxyType
 
 from dask.utils import import_required
 
@@ -9,7 +8,7 @@ def timeseries(
     end="2000-01-31",
     freq="1s",
     partition_freq="1d",
-    dtypes=MappingProxyType({"name": str, "id": int, "x": float, "y": float}),
+    dtypes=None,
     seed=None,
     **kwargs,
 ):
@@ -21,7 +20,7 @@ def timeseries(
         Start of time series
     end : datetime (or datetime-like string)
         End of time series
-    dtypes : dict
+    dtypes : dict (optional)
         Mapping of column names to types.
         Valid types include {float, int, str, 'category'}
     freq : string
@@ -53,6 +52,9 @@ def timeseries(
     ... )
     """
     from dask.dataframe.io.demo import make_timeseries
+
+    if dtypes is None:
+        dtypes = {"name": str, "id": int, "x": float, "y": float}
 
     return make_timeseries(
         start=start,

--- a/dask/datasets.py
+++ b/dask/datasets.py
@@ -1,4 +1,5 @@
 import random
+from types import MappingProxyType
 
 from dask.utils import import_required
 
@@ -8,7 +9,7 @@ def timeseries(
     end="2000-01-31",
     freq="1s",
     partition_freq="1d",
-    dtypes={"name": str, "id": int, "x": float, "y": float},
+    dtypes=MappingProxyType({"name": str, "id": int, "x": float, "y": float}),
     seed=None,
     **kwargs,
 ):


### PR DESCRIPTION
### Summary of changes in this PR

- [x] One of the individual PRs per warning from `flake8-bugbear` that is required for #9457.
  - _**B006**: Do not use mutable data structures for argument defaults. They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them._
  - Solution from [here](https://github.com/PyCQA/flake8-bugbear/blob/main/tests/b006_b008.py#L101-L104).
  - Ran on whole repository using: `flake8 --select B006`

### General

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
