### PR TITLE
CI: pin libprotobuf to allow nightly pyarrow in the upstream CI build

### DIFF
--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -65,6 +65,9 @@ dependencies:
   - python-xxhash
   - mmh3
   - jinja2
+  # The nightly pyarrow / arrow-cpp packages currently don't install with latest
+  # protobuf / abseil, see https://github.com/dask/dask/issues/9449
+  - libprotobuf=3.19
   - pip
   - pip:
     - git+https://github.com/dask/distributed

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -65,9 +65,6 @@ dependencies:
   - python-xxhash
   - mmh3
   - jinja2
-  # The nightly pyarrow / arrow-cpp packages currently don't install with latest
-  # protobuf / abseil, see https://github.com/dask/dask/issues/9449
-  - libprotobuf=3.19
   - pip
   - pip:
     - git+https://github.com/dask/distributed

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -7,6 +7,9 @@ set -xe
 # python -m pip install --no-deps cityhash
 
 if [[ ${UPSTREAM_DEV} ]]; then
+    # The nightly pyarrow / arrow-cpp packages currently don't install with latest
+    # protobuf / abseil, see https://github.com/dask/dask/issues/9449
+    mamba install -y -c conda-forge libprotobuf=3.19
     # FIXME workaround for https://github.com/mamba-org/mamba/issues/1682
     arr=($(mamba search --override-channels -c arrow-nightlies pyarrow | tail -n 1))
     export PYARROW_VERSION=${arr[1]}

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -7,9 +7,6 @@ set -xe
 # python -m pip install --no-deps cityhash
 
 if [[ ${UPSTREAM_DEV} ]]; then
-    # The nightly pyarrow / arrow-cpp packages currently don't install with latest
-    # protobuf / abseil, see https://github.com/dask/dask/issues/9449
-    mamba install -y -c conda-forge libprotobuf=3.19
     # FIXME workaround for https://github.com/mamba-org/mamba/issues/1682
     arr=($(mamba search --override-channels -c arrow-nightlies pyarrow | tail -n 1))
     export PYARROW_VERSION=${arr[1]}


### PR DESCRIPTION
See https://github.com/dask/dask/issues/9449, https://github.com/dask/dask/pull/9452