### PR TITLE
Add compat code for unsupported groupby `dropna` cases

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3694,7 +3694,7 @@ Dask Name: {name}, {layers}""".format(
         ):
             warnings.warn(
                 "Grouping by multiple columns with dropna=False is not supported with pandas<1.5.0 and may give "
-                "unexpected results"
+                "unexpected results; see https://github.com/dask/dask/issues/8817"
             )
 
         from dask.dataframe.groupby import SeriesGroupBy
@@ -4929,7 +4929,7 @@ class DataFrame(_Frame):
         ):
             warnings.warn(
                 "Grouping by multiple columns with dropna=False is not supported with pandas<1.5.0 and may give "
-                "unexpected results"
+                "unexpected results; see https://github.com/dask/dask/issues/8817"
             )
 
         from dask.dataframe.groupby import DataFrameGroupBy

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3684,6 +3684,17 @@ Dask Name: {name}, {layers}""".format(
         dropna=None,
         **kwargs,
     ):
+        if (
+            self._partition_type is pd.Series
+            and not PANDAS_GT_150
+            and len(by) > 1
+            and dropna is False
+        ):
+            warnings.warn(
+                "Grouping by multiple columns with dropna=False is not supported with pandas<1.5.0 and may give "
+                "unexpected results"
+            )
+
         from dask.dataframe.groupby import SeriesGroupBy
 
         return SeriesGroupBy(
@@ -4906,6 +4917,17 @@ class DataFrame(_Frame):
         dropna=None,
         **kwargs,
     ):
+        if (
+            self._partition_type is pd.DataFrame
+            and not PANDAS_GT_150
+            and len(by) > 1
+            and dropna is False
+        ):
+            warnings.warn(
+                "Grouping by multiple columns with dropna=False is not supported with pandas<1.5.0 and may give "
+                "unexpected results"
+            )
+
         from dask.dataframe.groupby import DataFrameGroupBy
 
         return DataFrameGroupBy(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3685,8 +3685,10 @@ Dask Name: {name}, {layers}""".format(
         **kwargs,
     ):
         if (
-            self._partition_type is pd.Series
+            self.npartitions > 1
+            and self._partition_type is pd.DataFrame
             and not PANDAS_GT_150
+            and isinstance(by, list)
             and len(by) > 1
             and dropna is False
         ):
@@ -4918,8 +4920,10 @@ class DataFrame(_Frame):
         **kwargs,
     ):
         if (
-            self._partition_type is pd.DataFrame
+            self.npartitions > 1
+            and self._partition_type is pd.DataFrame
             and not PANDAS_GT_150
+            and isinstance(by, list)
             and len(by) > 1
             and dropna is False
         ):


### PR DESCRIPTION
Adds warnings when we attempt to use `dropna=False` for groupby cases where it would fail as outlined in #8817 - this should be fixed as of pandas 1.5.0.

- [x] Closes #8817
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
