### PR TITLE
Set top-level default shell in CI workflows

### DIFF
--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -2,10 +2,14 @@ name: Additional
 
 on: [push, pull_request]
 
+# Required shell entrypoint to have properly activated conda environments
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   mindeps:
     runs-on: "ubuntu-latest"
-
     strategy:
       matrix:
         environment: ["mindeps-array", "mindeps-dataframe", "mindeps-non-optional", "mindeps-distributed"]
@@ -27,11 +31,9 @@ jobs:
           auto-activate-base: false
 
       - name: Install
-        shell: bash -l {0}
         run: source continuous_integration/scripts/install.sh
 
       - name: Run tests
-        shell: bash -l {0}
         run: source continuous_integration/scripts/run_tests.sh
 
   doctest:
@@ -53,11 +55,9 @@ jobs:
           auto-activate-base: false
 
       - name: Install
-        shell: bash -l {0}
         run: source continuous_integration/scripts/install.sh
 
       - name: Run tests
-        shell: bash -l {0}
         run: pytest -v --doctest-modules --ignore-glob='*/test_*.py' dask
 
   imports:
@@ -82,7 +82,6 @@ jobs:
           auto-activate-base: false
 
       - name: Run import tests
-        shell: bash -l {0}
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: source continuous_integration/scripts/test_imports.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,11 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+# Required shell entrypoint to have properly activated conda environments
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -55,7 +60,6 @@ jobs:
           auto-activate-base: false
 
       - name: Install
-        shell: bash -l {0}
         run: source continuous_integration/scripts/install.sh
 
       # This environment file is created in continuous_integration/scripts/install.sh
@@ -67,7 +71,6 @@ jobs:
           path: env.yaml
 
       - name: Run tests
-        shell: bash -l {0}
         run: source continuous_integration/scripts/run_tests.sh
 
       - name: Coverage

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -6,6 +6,11 @@ on:
   push:
   pull_request:
 
+# Required shell entrypoint to have properly activated conda environments
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
 
   check:
@@ -52,14 +57,12 @@ jobs:
           auto-activate-base: false
 
       - name: Install
-        shell: bash -l {0}
         env:
           UPSTREAM_DEV: 1
         run: source continuous_integration/scripts/install.sh
 
       - name: Run tests
         id: run_tests
-        shell: bash -l {0}
         run: source continuous_integration/scripts/run_tests.sh
 
       - name: Coverage


### PR DESCRIPTION
This sets the default shell needed by `conda-incubator/setup-miniconda` at the top-level of each needed GHA workflow instead of on each individual job step. This is purely cosmetic -- not a functional change. 