### PR TITLE
[POC] Introduce partition_metadata attribute to DataFrame

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -606,6 +606,22 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
         return new_dd_object
 
     @property
+    def _divisions(self):
+        # _divisions Compatability
+        raise FutureWarning(
+            "_Frame._divisions is depracated. " "Please use _Frame.divisions"
+        )
+        return self.divisions
+
+    @_divisions.setter
+    def _divisions(self, value):
+        # _divisions Compatability
+        raise FutureWarning(
+            "_Frame._divisions is depracated. " "Please use _Frame.divisions"
+        )
+        self.divisions = value
+
+    @property
     def divisions(self):
         """
         Tuple of ``npartitions + 1`` values, in ascending order, marking the
@@ -634,9 +650,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
         if not isinstance(value, tuple):
             raise TypeError("divisions must be a tuple")
 
-        if hasattr(self, "_divisions") and len(value) != len(
-            self.partition_metadata.divisions
-        ):
+        if len(value) != len(self.partition_metadata.divisions):
             n = len(self.partition_metadata.divisions)
             raise ValueError(
                 f"This dataframe has npartitions={n - 1}, divisions should be a "

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -626,7 +626,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
                 # If the DataFrame is partitioned by ("A",), then
                 # it is also partitioned by ("A", "B", ...)
                 if _by[: len(group)] == group:
-                    return True
+                    return self.partition_metadata.partitioning[group]
         return False
 
     @property

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -609,6 +609,14 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
     def partition_metadata(self):
         return self._partition_metadata
 
+    def set_partition_metadata(self, value):
+        if isinstance(value, PartitionMetadata):
+            self._partition_metadata = value
+        else:
+            raise ValueError(
+                f"Expected PartitionMetadata object, " f" got {type(value)}"
+            )
+
     def partitioned_by(self, columns):
         """Whether the DataFrame is partitioned by the specified columns"""
         if isinstance(columns, (str, list, tuple)):
@@ -3895,7 +3903,10 @@ Dask Name: {name}, {layers}""".format(
             if inplace:
                 self.dask = res.dask
                 self._name = res._name
-                self._partition_metadata = res.partition_metadata
+                self._partition_metadata = PartitionMetadata(
+                    meta=res._meta,
+                    divisions=res.divisions,
+                )
                 res = self
         return res
 
@@ -4841,10 +4852,9 @@ class DataFrame(_Frame):
 
         self.dask = df.dask
         self._name = df._name
-        self._partition_metadata = df.partition_metadata.copy(
+        self._partition_metadata = PartitionMetadata(
             meta=df._meta,
             divisions=df.divisions,
-            statistics=None,
         )
 
     def __delitem__(self, key):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3863,8 +3863,7 @@ Dask Name: {name}, {layers}""".format(
             if inplace:
                 self.dask = res.dask
                 self._name = res._name
-                self.divisions = res.divisions
-                self._meta = res._meta
+                self._partition_metadata = res.partition_metadata
                 res = self
         return res
 
@@ -4810,8 +4809,12 @@ class DataFrame(_Frame):
 
         self.dask = df.dask
         self._name = df._name
-        self._meta = df._meta
-        self.divisions = df.divisions
+        self._partition_metadata = df.partition_metadata.copy(
+            meta=df._meta,
+            divisions=df.divisions,
+            statistics=None,
+            lazy_statistics=None,
+        )
 
     def __delitem__(self, key):
         result = self.drop([key], axis=1)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -363,7 +363,7 @@ class PartitionMetadata:
             self._partitioned_by = [("__index__",)] if divisions else []
 
         # Optional partition-wise statistics:
-        #   - "num-rows": Series of partition row counts
+        #   - "__num_rows__": Series of partition row counts
         #   - <column-name>: DataFrame of partition stats for the column
         #     - Required DataFrame columns: "min" and "max"
         self._statistics = statistics or {}
@@ -4664,7 +4664,9 @@ class DataFrame(_Frame):
     def __len__(self):
         try:
             # Use partition statistics if they are available
-            part_sizes = self.partition_metadata.get_stats({"num-rows"})["num-rows"]
+            part_sizes = self.partition_metadata.get_stats({"__num_rows__"})[
+                "__num_rows__"
+            ]
             if part_sizes:
                 return sum(part_sizes)
         except KeyError:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4643,6 +4643,18 @@ class DataFrame(_Frame):
         self._name = renamed._name
         self.dask = renamed.dask
 
+    def _partitioned_by(self, columns):
+        """Whether the DataFrame is partitioned by the specified columns"""
+        if isinstance(columns, (str, list, tuple)):
+            _by = (columns,) if isinstance(columns, str) else tuple(columns)
+            for group in self.partition_metadata.partitioned_by:
+                # Don't need all columns from _by to match group.
+                # If the DataFrame is partitioned by ("A",), then
+                # it is also partitioned by ("A", "B", ...)
+                if _by[: len(group)] == group:
+                    return True
+        return False
+
     @property
     def iloc(self):
         """Purely integer-location based indexing for selection by position.

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -395,7 +395,7 @@ class PartitionStatistics:
 
         # Perform update
         new_stats = {}
-        for _func, _keyset in _lazy_stats:
+        for _func, _keyset in _lazy_stats.items():
             new_stats.update(_func(keys=_keyset))
         self._statistics.update(new_stats)
 
@@ -407,7 +407,7 @@ class PartitionStatistics:
 
 class PartitionMetadata:
     """
-    Container for DataFrame-collection partition metadata
+    Container for DataFrame partition metadata
     """
 
     _meta: Any

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1884,7 +1884,9 @@ class _GroupBy:
             )
 
         df = self.obj
-        should_shuffle = not (df.known_divisions and df._contains_index_name(self.by))
+        should_shuffle = not (
+            df.known_divisions and df._contains_index_name(self.by)
+        ) and not df._partitioned_by(self.by)
 
         if should_shuffle:
             df2, by = self._shuffle(meta)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1886,7 +1886,7 @@ class _GroupBy:
         df = self.obj
         should_shuffle = not (
             df.known_divisions and df._contains_index_name(self.by)
-        ) and not df._partitioned_by(self.by)
+        ) and not df.partitioned_by(self.by)
 
         if should_shuffle:
             df2, by = self._shuffle(meta)

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -307,7 +307,9 @@ def from_pandas(
 
     # Define partition metadata
     _partition_stats = {
-        "num-rows": [stop - start for start, stop in zip(locations[:-1], locations[1:])]
+        "__num_rows__": [
+            stop - start for start, stop in zip(locations[:-1], locations[1:])
+        ]
     }
     partition_metadata = PartitionMetadata(
         meta=data,

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -303,7 +303,10 @@ def from_pandas(
         (name, i): data.iloc[start:stop]
         for i, (start, stop) in enumerate(zip(locations[:-1], locations[1:]))
     }
-    return new_dd_object(dsk, name, data, divisions)
+    partition_stats = {
+        "num-rows": [stop - start for start, stop in zip(locations[:-1], locations[1:])]
+    }
+    return new_dd_object(dsk, name, data, divisions, partition_stats=partition_stats)
 
 
 @_deprecated(after_version="2022.02.1")
@@ -962,6 +965,7 @@ def from_map(
     label=None,
     token=None,
     enforce_metadata=True,
+    partition_stats=None,
     **kwargs,
 ):
     """Create a DataFrame collection from a custom function map
@@ -1183,7 +1187,7 @@ def from_map(
     # Return new DataFrame-collection object
     divisions = divisions or [None] * (len(inputs) + 1)
     graph = HighLevelGraph.from_collections(name, layer, dependencies=[])
-    return new_dd_object(graph, name, meta, divisions)
+    return new_dd_object(graph, name, meta, divisions, partition_stats=partition_stats)
 
 
 DataFrame.to_records.__doc__ = to_records.__doc__

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -374,6 +374,39 @@ class ArrowDatasetEngine(Engine):
         return cls == ArrowDatasetEngine
 
     @classmethod
+    def read_partition_stats(cls, part, columns, fs):
+
+        if not isinstance(part, list):
+            part = [part]
+
+        column_stats = {}
+        num_rows = 0
+        for p in part:
+            piece = p["piece"]
+            path = piece[0]
+            row_groups = piece[1]
+            if row_groups == [None]:
+                row_groups = None
+            with fs.open(path, default_cache="none") as f:
+                md = pq.ParquetFile(f).metadata
+            if row_groups is None:
+                row_groups = list(range(md.num_row_groups))
+            for rg in row_groups:
+                row_group = md.row_group(rg)
+                num_rows += row_group.num_rows
+                for i in range(row_group.num_columns):
+                    col = row_group.column(i)
+                    name = col.path_in_schema
+                    if name in columns:
+                        if col.statistics and col.statistics.has_min_max:
+                            column_stats[name] = {
+                                "min": col.statistics.min,
+                                "max": col.statistics.max,
+                            }
+
+        return {"num-rows": num_rows, **column_stats}
+
+    @classmethod
     def read_partition(
         cls,
         fs,

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -561,7 +561,7 @@ def read_parquet(
         _partition_stats = _pq_partition_stats(processed_stats)
     elif hasattr(engine, "read_partition_stats"):
         _lazy_partition_stats = (
-            {"num-rows"} | set(columns),
+            {"__num_rows__"} | set(columns),
             partial(_lazy_pq_partition_stats, parts, columns, engine, fs),
         )
     partition_metadata = PartitionMetadata(
@@ -1595,6 +1595,9 @@ def _pq_partition_stats(stats):
             results[key].append(stat[key])
     for k in set(results.keys()) - {"num-rows"}:
         results[k] = pd.DataFrame(results[k])
+    if "num-rows" in results:
+        # Convert "num-rows" key to "__num_rows__"
+        results["__num_rows__"] = results.pop("num-rows")
 
     return results
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -556,19 +556,16 @@ def read_parquet(
 
     # Define partition_metadata, using callback if necessary
     _partition_stats = None
-    _lazy_partition_stats = None
     if processed_stats:
         _partition_stats = _pq_partition_stats(processed_stats)
     elif hasattr(engine, "read_partition_stats"):
-        _lazy_partition_stats = (
-            {"__num_rows__"} | set(columns),
-            partial(_lazy_pq_partition_stats, parts, columns, engine, fs),
-        )
+        _func = partial(_lazy_pq_partition_stats, parts, columns, engine, fs)
+        _partition_stats = {k: _func for k in {"__num_rows__"} | set(columns)}
+
     partition_metadata = PartitionMetadata(
         meta=meta,
         divisions=divisions,
         statistics=_partition_stats,
-        lazy_statistics=_lazy_partition_stats,
     )
 
     with ctx:

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -380,7 +380,7 @@ def hash_join(
         partition_metadata = PartitionMetadata(
             meta=meta,
             npartitions=lhs2.npartitions,
-            partitioned_by=[tuple(col for col in _left_on)],
+            partitioning={tuple(col for col in _left_on): "hash"},
         )
     else:
         partition_metadata = None

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -702,13 +702,13 @@ def rearrange_by_column_tasks(
 
     # Track output partitioning
     if isinstance(column, list) and "_partitions" not in column:
-        _partitioned_by = [tuple(column)]
+        _partitioning = {tuple(column): "hash"}
     else:
-        _partitioned_by = None
+        _partitioning = None
     partition_metadata = PartitionMetadata(
         meta=df._meta,
         npartitions=(npartitions or df.npartitions),
-        partitioned_by=_partitioned_by,
+        partitioning=_partitioning,
     )
 
     if (npartitions or df.npartitions) <= max_branch:

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -1118,7 +1118,7 @@ def set_sorted_index(
         meta=meta,
         align_dataframes=False,
         transform_divisions=False,
-        partition_stats=df.metadata.copy_partition_stats(),
+        partition_metadata=df.partition_metadata.copy(meta=meta),
     )
 
     if not divisions:

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -1124,7 +1124,7 @@ def compute_divisions(df: DataFrame, col: Optional[Any] = None, **kwargs) -> Tup
 def compute_and_set_divisions(df: DataFrame, **kwargs) -> DataFrame:
     mins, maxes, lens = _compute_partition_stats(df.index, allow_overlap=True, **kwargs)
     if len(mins) == len(df.divisions) - 1:
-        df._divisions = tuple(mins) + (maxes[-1],)
+        df.divisions = tuple(mins) + (maxes[-1],)
         if not any(mins[i] >= maxes[i - 1] for i in range(1, len(mins))):
             return df
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -1118,6 +1118,7 @@ def set_sorted_index(
         meta=meta,
         align_dataframes=False,
         transform_divisions=False,
+        partition_stats=df.metadata.copy_partition_stats(),
     )
 
     if not divisions:


### PR DESCRIPTION
This is a rough POC intended to illustrate how new `PartitionMetadata` and `PartitionStatistics` classes can be used to accomplish a few impactful goals in Dask-DataFrame **The Goals**:

1. Isolate DataFrame-collection metadata (`meta` and `divisions`) in one place (simplifying future expansion and possible movement into HLG/Layer)
2. Add a mechanism to track column partitioning **beyond** the conventional `divisions`. **Motivation**: #9425
3. Add a mechanism to track partition-wise statistics (e.g. row-count and min/max of each column). **Motivation**: #5633, #6387, #7912 

If we ultimately decide that a change like this make sense, I suggest that we break the work into three distinct stages:

1. Move `meta` and `divisions` management into a new/distinct "partition_metadata" attribute using a new `PartitionMetadata` class (specific attribute and class names are up for debate)
2. Add `partitioned_by` functionality to `PartitionMetadata` (and therefore `DataFrame`/`Series`)
3. Add mechanism to track partition statistics to `PartitionMetadata`


**TODO**: Add a clearer breakdown of the proposed design changes, and include some explicit user-code examples.