### PR TITLE
Fixing enforce_metadata doc, not checking for dtypes

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -764,7 +764,8 @@ Dask Name: {name}, {layers}"""
             Whether to enforce at runtime that the structure of the DataFrame
             produced by ``func`` actually matches the structure of ``meta``.
             This will rename and reorder columns for each partition,
-            and will raise an error if this doesn't work or types don't match.
+            and will raise an error if this doesn't work,
+            but it won't raise if dtypes don't match.
         transform_divisions : bool, default True
             Whether to apply the function onto the divisions and apply those
             transformed divisions to the output.
@@ -897,7 +898,8 @@ Dask Name: {name}, {layers}"""
             Whether to enforce at runtime that the structure of the DataFrame
             produced by ``func`` actually matches the structure of ``meta``.
             This will rename and reorder columns for each partition,
-            and will raise an error if this doesn't work or types don't match.
+            and will raise an error if this doesn't work,
+            but it won't raise if dtypes don't match.
         transform_divisions : bool, default True
             Whether to apply the function onto the divisions and apply those
             transformed divisions to the output.
@@ -6476,7 +6478,8 @@ def map_partitions(
         Whether to enforce at runtime that the structure of the DataFrame
         produced by ``func`` actually matches the structure of ``meta``.
         This will rename and reorder columns for each partition,
-        and will raise an error if this doesn't work or types don't match.
+        and will raise an error if this doesn't work,
+        but it won't raise if dtypes don't match.
     transform_divisions : bool, default True
         Whether to apply the function onto the divisions and apply those
         transformed divisions to the output.

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -999,7 +999,8 @@ def from_map(
         Whether to enforce at runtime that the structure of the DataFrame
         produced by ``func`` actually matches the structure of ``meta``.
         This will rename and reorder columns for each partition,
-        and will raise an error if this doesn't work or types don't match.
+        and will raise an error if this doesn't work,
+        but it won't raise if dtypes don't match.
     **kwargs:
         Key-word arguments to broadcast to each output partition. These
         same arguments will be passed to ``func`` for every output partition.

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -119,7 +119,8 @@ def map_overlap(
         Whether to enforce at runtime that the structure of the DataFrame
         produced by ``func`` actually matches the structure of ``meta``.
         This will rename and reorder columns for each partition,
-        and will raise an error if this doesn't work or types don't match.
+        and will raise an error if this doesn't work,
+        but it won't raise if dtypes don't match.
     before : int or timedelta
         The rows to prepend to partition ``i`` from the end of
         partition ``i - 1``.


### PR DESCRIPTION
The current apply_and_enforce() implementation does not raise on mismatching dtypes so we need to update the doc accordingly

- [x] Closes #9466
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
