### PR TITLE
Remove `dd.from_bcolz`

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -32,8 +32,6 @@ dependencies:
   - coverage
   - jsonschema
   # other -- IO
-  # Not available for Python 3.9+ on conda-forge
-  # - bcolz
   - blosc
   - boto3
   - botocore

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -32,7 +32,6 @@ dependencies:
   - coverage
   - jsonschema
   # other -- IO
-  - bcolz
   - blosc
   - boto3
   - botocore

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -32,8 +32,6 @@ dependencies:
   - coverage
   - jsonschema
   # other -- IO
-  # Not available for Python 3.9 on conda-forge
-  # - bcolz
   - blosc
   - boto3
   - botocore

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -16,7 +16,6 @@ try:
     from dask.dataframe.io import (
         demo,
         from_array,
-        from_bcolz,
         from_dask_array,
         from_delayed,
         from_map,

--- a/dask/dataframe/io/__init__.py
+++ b/dask/dataframe/io/__init__.py
@@ -2,9 +2,7 @@ from dask.dataframe.io import demo
 from dask.dataframe.io.csv import read_csv, read_fwf, read_table, to_csv
 from dask.dataframe.io.hdf import read_hdf, to_hdf
 from dask.dataframe.io.io import (
-    dataframe_from_ctable,
     from_array,
-    from_bcolz,
     from_dask_array,
     from_delayed,
     from_map,

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from collections.abc import Iterable
 from functools import partial
 from math import ceil
@@ -25,7 +24,6 @@ from dask.dataframe.core import (
     new_dd_object,
 )
 from dask.dataframe.io.utils import DataFrameIOFunction
-from dask.dataframe.shuffle import set_partition
 from dask.dataframe.utils import (
     check_meta,
     insert_meta_param_description,
@@ -35,7 +33,7 @@ from dask.dataframe.utils import (
 from dask.delayed import Delayed, delayed
 from dask.highlevelgraph import HighLevelGraph
 from dask.layers import DataFrameIOLayer
-from dask.utils import M, _deprecated, funcname, is_arraylike
+from dask.utils import M, funcname, is_arraylike
 
 if TYPE_CHECKING:
     import distributed
@@ -304,171 +302,6 @@ def from_pandas(
         for i, (start, stop) in enumerate(zip(locations[:-1], locations[1:]))
     }
     return new_dd_object(dsk, name, data, divisions)
-
-
-@_deprecated(after_version="2022.02.1")
-def from_bcolz(x, chunksize=None, categorize=True, index=None, lock=lock, **kwargs):
-    """Read BColz CTable into a Dask Dataframe
-
-    BColz is a fast on-disk compressed column store with careful attention
-    given to compression.  https://bcolz.readthedocs.io/en/latest/
-
-    Parameters
-    ----------
-    x : bcolz.ctable
-    chunksize : int, optional
-        The size(rows) of blocks to pull out from ctable.
-    categorize : bool, defaults to True
-        Automatically categorize all string dtypes
-    index : string, optional
-        Column to make the index
-    lock: bool or Lock
-        Lock to use when reading or False for no lock (not-thread-safe)
-
-    See Also
-    --------
-    from_array: more generic function not optimized for bcolz
-    """
-    if lock is True:
-        lock = Lock()
-
-    import bcolz
-
-    import dask.array as da
-
-    if isinstance(x, str):
-        x = bcolz.ctable(rootdir=x)
-    bc_chunklen = max(x[name].chunklen for name in x.names)
-    if chunksize is None and bc_chunklen > 10000:
-        chunksize = bc_chunklen
-
-    categories = dict()
-    if categorize:
-        for name in x.names:
-            if (
-                np.issubdtype(x.dtype[name], np.string_)
-                or np.issubdtype(x.dtype[name], np.unicode_)
-                or np.issubdtype(x.dtype[name], np.object_)
-            ):
-                a = da.from_array(x[name], chunks=(chunksize * len(x.names),))
-                categories[name] = da.unique(a).compute()
-
-    columns = tuple(x.dtype.names)
-    divisions = tuple(range(0, len(x), chunksize))
-    divisions = divisions + (len(x) - 1,)
-    if x.rootdir:
-        token = tokenize(
-            (x.rootdir, os.path.getmtime(x.rootdir)),
-            chunksize,
-            categorize,
-            index,
-            kwargs,
-        )
-    else:
-        token = tokenize(
-            (id(x), x.shape, x.dtype), chunksize, categorize, index, kwargs
-        )
-    new_name = "from_bcolz-" + token
-
-    dsk = {
-        (new_name, i): (
-            dataframe_from_ctable,
-            x,
-            (slice(i * chunksize, (i + 1) * chunksize),),
-            columns,
-            categories,
-            lock,
-        )
-        for i in range(0, int(ceil(len(x) / chunksize)))
-    }
-
-    meta = dataframe_from_ctable(x, slice(0, 0), columns, categories, lock)
-    result = DataFrame(dsk, new_name, meta, divisions)
-
-    if index:
-        assert index in x.names
-        a = da.from_array(x[index], chunks=(chunksize * len(x.names),))
-        q = np.linspace(0, 100, len(x) // chunksize + 2)
-        divisions = tuple(da.percentile(a, q).compute())
-        return set_partition(result, index, divisions, **kwargs)
-    else:
-        return result
-
-
-def dataframe_from_ctable(x, slc, columns=None, categories=None, lock=lock):
-    """Get DataFrame from bcolz.ctable
-
-    Parameters
-    ----------
-    x: bcolz.ctable
-    slc: slice
-    columns: list of column names or None
-
-    >>> import bcolz
-    >>> x = bcolz.ctable([[1, 2, 3, 4], [10, 20, 30, 40]], names=['a', 'b'])
-    >>> dataframe_from_ctable(x, slice(1, 3))
-       a   b
-    1  2  20
-    2  3  30
-
-    >>> dataframe_from_ctable(x, slice(1, 3), columns=['b'])
-        b
-    1  20
-    2  30
-
-    >>> dataframe_from_ctable(x, slice(1, 3), columns='b')
-    1    20
-    2    30
-    Name: b, dtype: int...
-
-    """
-    import bcolz
-
-    if columns is None:
-        columns = x.dtype.names
-    if isinstance(columns, tuple):
-        columns = list(columns)
-
-    x = x[columns]
-    if type(slc) is slice:
-        start = slc.start
-        stop = slc.stop if slc.stop < len(x) else len(x)
-    else:
-        start = slc[0].start
-        stop = slc[0].stop if slc[0].stop < len(x) else len(x)
-    idx = pd.Index(range(start, stop))
-
-    if lock:
-        lock.acquire()
-    try:
-        if isinstance(x, bcolz.ctable):
-            chunks = [x[name][slc] for name in columns]
-            if categories is not None:
-                chunks = [
-                    pd.Categorical.from_codes(
-                        np.searchsorted(categories[name], chunk), categories[name], True
-                    )
-                    if name in categories
-                    else chunk
-                    for name, chunk in zip(columns, chunks)
-                ]
-            result = pd.DataFrame(
-                dict(zip(columns, chunks)), columns=columns, index=idx
-            )
-
-        elif isinstance(x, bcolz.carray):
-            chunk = x[slc]
-            if categories is not None and columns and columns in categories:
-                chunk = pd.Categorical.from_codes(
-                    np.searchsorted(categories[columns], chunk),
-                    categories[columns],
-                    True,
-                )
-            result = pd.Series(chunk, name=columns, index=idx)
-    finally:
-        if lock:
-            lock.release()
-    return result
 
 
 def _partition_from_array(data, index=None, initializer=None, **kwargs):

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -523,7 +523,6 @@ Create DataFrames
    read_sql_query
    read_sql
    from_array
-   from_bcolz
    from_dask_array
    from_delayed
    from_map

--- a/docs/source/dataframe-create.rst
+++ b/docs/source/dataframe-create.rst
@@ -36,7 +36,6 @@ File Formats:
     read_sql
     read_table
     read_fwf
-    from_bcolz
     from_array
     to_csv
     to_parquet


### PR DESCRIPTION
`dd.from_bcolz` has been deprecated for 7 months -- I think it's safe to remove it at this point 

cc @rjzamora in case you have thoughts 