### PR TITLE
Update test_groupby_dropna_cudf based on cudf support for group_keys

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2513,14 +2513,8 @@ def test_groupby_dropna_pandas(dropna):
     "group_keys",
     [
         True,
-        pytest.param(
-            False,
-            marks=pytest.mark.xfail(reason="cudf hasn't updated group_keys default"),
-        ),
-        pytest.param(
-            None,
-            marks=pytest.mark.xfail(reason="cudf hasn't updated group_keys default"),
-        ),
+        False,
+        None,
     ],
 )
 def test_groupby_dropna_cudf(dropna, by, group_keys):


### PR DESCRIPTION
It looks like `cudf` now supports `group_keys` (xref https://github.com/rapidsai/cudf/pull/11659). We should be able to un-`xfail` these parameters now

cc @galipremsagar