### PR TITLE
Fix assigning Series to column when `ddf.columns.min()` raises

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6017,15 +6017,18 @@ def is_broadcastable(dfs, s):
     """
     This Series is broadcastable against another dataframe in the sequence
     """
+
+    def compare(s, df):
+        try:
+            return s.divisions == (df.columns.min(), df.columns.max())
+        except TypeError:
+            return False
+
     return (
         isinstance(s, Series)
         and s.npartitions == 1
         and s.known_divisions
-        and any(
-            s.divisions == (df.columns.min(), df.columns.max())
-            for df in dfs
-            if isinstance(df, DataFrame)
-        )
+        and any(compare(s, df) for df in dfs if isinstance(df, DataFrame))
     )
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1623,6 +1623,14 @@ def test_assign_dtypes():
     )
 
 
+def test_assign_pandas_series():
+    # Make sure we handle when `df.columns.min()` raises TypeError
+    df = pd.DataFrame({"a": [1, 2], 1: [5, 6]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = ddf.assign(c=df["a"])
+    assert_eq(ddf, df.assign(c=df["a"]))
+
+
 def test_map():
     df = pd.DataFrame(
         {"a": range(9), "b": [4, 5, 6, 1, 2, 3, 0, 0, 0]},


### PR DESCRIPTION
`ddf[col] = s` was raising when the column name types can't be compared such as when they are a mix of strings and integers.

I'm surprised this edge case hasn't been caught and fixed earlier.

- [X] ~Closes #xxxx~
- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`