### PR TITLE
Allow `split_out` to be `None`, which then defaults to `1` in `groupby().aggregate()`

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1681,12 +1681,11 @@ class _GroupBy:
 
     @_aggregate_docstring()
     def aggregate(self, arg, split_every=None, split_out=1, shuffle=None):
-        split_out = 1 if split_out is None else split_out
         if split_out is None:
             warnings.warn(
                 "split_out=None is deprecated, please use a positive integer, "
                 "or allow the default of 1",
-                category=DeprecationWarning,
+                category=FutureWarning,
             )
             split_out = 1
         if shuffle is None:

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1681,6 +1681,7 @@ class _GroupBy:
 
     @_aggregate_docstring()
     def aggregate(self, arg, split_every=None, split_out=1, shuffle=None):
+        split_out = 1 if split_out is None else split_out
         if shuffle is None:
             if split_out > 1:
                 shuffle = shuffle or config.get("shuffle", None) or "tasks"

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1682,6 +1682,13 @@ class _GroupBy:
     @_aggregate_docstring()
     def aggregate(self, arg, split_every=None, split_out=1, shuffle=None):
         split_out = 1 if split_out is None else split_out
+        if split_out is None:
+            warnings.warn(
+                "split_out=None is deprecated, please use a positive integer, "
+                "or allow the default of 1",
+                category=DeprecationWarning,
+            )
+            split_out = 1
         if shuffle is None:
             if split_out > 1:
                 shuffle = shuffle or config.get("shuffle", None) or "tasks"

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2941,3 +2941,10 @@ def test_groupby_iter_fails():
     ddf = dd.from_pandas(df, npartitions=1)
     with pytest.raises(NotImplementedError, match="computing the groups"):
         list(ddf.groupby("A"))
+
+
+def test_groupby_None_split_out_warns():
+    df = pd.DataFrame({"a": [1, 1, 2], "b": [2, 3, 4]})
+    ddf = dd.from_pandas(df, npartitions=1)
+    with pytest.warns(FutureWarning, match="split_out=None"):
+        ddf.groupby("a").agg({"b": "max"}, split_out=None)


### PR DESCRIPTION
- [x] Closes #9490 
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
