### PR TITLE
Filter out `numeric_only` warnings from `pandas`

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -91,9 +91,11 @@ def check_numeric_only_deprecation():
 
     if PANDAS_GT_150:
         with warnings.catch_warnings():
-            # warnings.filterwarnings("ignore", message="The default value of numeric_only in", category=FutureWarning)
-            warnings.filterwarnings("ignore", category=FutureWarning)
-
+            warnings.filterwarnings(
+                "ignore",
+                message="The default value of numeric_only in",
+                category=FutureWarning,
+            )
             yield
     else:
         yield

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -1,4 +1,6 @@
+import contextlib
 import string
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -82,3 +84,16 @@ def makeMixedDataFrame():
         }
     )
     return df
+
+
+@contextlib.contextmanager
+def check_numeric_only_deprecation():
+
+    if PANDAS_GT_150:
+        with warnings.catch_warnings():
+            # warnings.filterwarnings("ignore", message="The default value of numeric_only in", category=FutureWarning)
+            warnings.filterwarnings("ignore", category=FutureWarning)
+
+            yield
+    else:
+        yield

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1933,7 +1933,6 @@ Dask Name: {name}, {layers}"""
                 _name=name,
                 **numeric_only_kwargs,
             )
-            # breakpoint()
             if isinstance(self, DataFrame):
                 result.divisions = (self.columns.min(), self.columns.max())
             return handle_out(out, result)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2013,7 +2013,6 @@ Dask Name: {name}, {layers}"""
             skipna=skipna,
             split_every=split_every,
             out=out,
-            numeric_only=numeric_only,
         )
         if min_count:
             cond = self.notnull().sum(axis=axis) >= min_count
@@ -2731,6 +2730,7 @@ Dask Name: {name}, {layers}"""
                 result.divisions = (self.columns.min(), self.columns.max())
             return result
 
+    @_numeric_only
     def quantile(self, q=0.5, axis=0, numeric_only=True, method="default"):
         """Approximate row-wise and precise column-wise quantiles of DataFrame
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1917,7 +1917,7 @@ Dask Name: {name}, {layers}"""
                 token=token,
                 skipna=skipna,
                 axis=axis,
-                method_name=name,
+                _dask_method_name=name,
                 **numeric_only_kwargs,
             )
             return handle_out(out, result)
@@ -1929,7 +1929,7 @@ Dask Name: {name}, {layers}"""
                 skipna=skipna,
                 axis=axis,
                 split_every=split_every,
-                method_name=name,
+                _dask_method_name=name,
                 **numeric_only_kwargs,
             )
             if isinstance(self, DataFrame):
@@ -8111,6 +8111,6 @@ def _raise_if_not_series_or_dataframe(x, funcname):
         )
 
 
-def _getattr_numeric_only(*args, method_name, **kwargs):
+def _getattr_numeric_only(*args, _dask_method_name, **kwargs):
     with check_numeric_only_deprecation():
-        return getattr(M, method_name)(*args, **kwargs)
+        return getattr(M, _dask_method_name)(*args, **kwargs)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6519,7 +6519,7 @@ def _emulate(func, *args, udf=False, **kwargs):
     Apply a function using args / kwargs. If arguments contain dd.DataFrame /
     dd.Series, using internal cache (``_meta``) for calculation
     """
-    with raise_on_meta_error(funcname(func), udf=udf):
+    with raise_on_meta_error(funcname(func), udf=udf), check_numeric_only_deprecation():
         return func(*_extract_meta(args, True), **_extract_meta(kwargs, True))
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1904,7 +1904,6 @@ Dask Name: {name}, {layers}"""
         else:
             numeric_only_kwargs = {}
 
-        # TODO: maybe we should warn here?
         with check_numeric_only_deprecation():
             meta = getattr(self._meta_nonempty, name)(
                 axis=axis, skipna=skipna, **numeric_only_kwargs
@@ -2219,7 +2218,6 @@ Dask Name: {name}, {layers}"""
     ):
         axis = self._validate_axis(axis)
         _raise_if_object_series(self, "var")
-        # TODO: warn here
         with check_numeric_only_deprecation():
             meta = self._meta_nonempty.var(
                 axis=axis, skipna=skipna, numeric_only=numeric_only
@@ -2695,7 +2693,6 @@ Dask Name: {name}, {layers}"""
     def sem(self, axis=None, skipna=True, ddof=1, split_every=False, numeric_only=None):
         axis = self._validate_axis(axis)
         _raise_if_object_series(self, "sem")
-        # TODO: maybe we should raise here
         with check_numeric_only_deprecation():
             meta = self._meta_nonempty.sem(
                 axis=axis, skipna=skipna, ddof=ddof, numeric_only=numeric_only

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -110,8 +110,8 @@ def _numeric_only(func):
             raise NotImplementedError(
                 "'numeric_only=False' is not implemented in Dask."
             )
-        # elif kwargs.get("numeric_only") is True:
-        #     self = self._get_numeric_data()
+        elif kwargs.get("numeric_only") is True:
+            self = self._get_numeric_data()
         return func(self, *args, **kwargs)
 
     return wrapper
@@ -1911,12 +1911,6 @@ Dask Name: {name}, {layers}"""
             )
 
         token = self._token_prefix + name
-
-        # method = getattr(M, name)
-        # def method(*args, **kwargs):
-        #     with check_numeric_only_deprecation():
-        #         return getattr(M, name)(*args, **kwargs)
-
         if axis == 1:
             result = self.map_partitions(
                 _getattr_numeric_only,
@@ -1929,7 +1923,6 @@ Dask Name: {name}, {layers}"""
             )
             return handle_out(out, result)
         else:
-            # breakpoint()
             result = self.reduction(
                 _getattr_numeric_only,
                 meta=meta,
@@ -1938,7 +1931,6 @@ Dask Name: {name}, {layers}"""
                 axis=axis,
                 split_every=split_every,
                 _name=name,
-                # numeric_only=Fase,
                 **numeric_only_kwargs,
             )
             # breakpoint()
@@ -2048,7 +2040,6 @@ Dask Name: {name}, {layers}"""
             skipna=skipna,
             split_every=split_every,
             out=out,
-            numeric_only=numeric_only,
         )
 
     @_numeric_only
@@ -2062,7 +2053,6 @@ Dask Name: {name}, {layers}"""
             skipna=skipna,
             split_every=split_every,
             out=out,
-            numeric_only=numeric_only,
         )
 
     @derived_from(pd.DataFrame)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1924,6 +1924,7 @@ Dask Name: {name}, {layers}"""
                 token=token,
                 skipna=skipna,
                 axis=axis,
+                _name=name,
                 **numeric_only_kwargs,
             )
             return handle_out(out, result)
@@ -1936,6 +1937,7 @@ Dask Name: {name}, {layers}"""
                 skipna=skipna,
                 axis=axis,
                 split_every=split_every,
+                _name=name,
                 # numeric_only=Fase,
                 **numeric_only_kwargs,
             )
@@ -8124,5 +8126,6 @@ def _raise_if_not_series_or_dataframe(x, funcname):
 
 
 def _getattr_numeric_only(*args, **kwargs):
+    name = kwargs.pop("_name")
     with check_numeric_only_deprecation():
         return getattr(M, name)(*args, **kwargs)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1917,7 +1917,7 @@ Dask Name: {name}, {layers}"""
                 token=token,
                 skipna=skipna,
                 axis=axis,
-                _name=name,
+                method_name=name,
                 **numeric_only_kwargs,
             )
             return handle_out(out, result)
@@ -1929,7 +1929,7 @@ Dask Name: {name}, {layers}"""
                 skipna=skipna,
                 axis=axis,
                 split_every=split_every,
-                _name=name,
+                method_name=name,
                 **numeric_only_kwargs,
             )
             if isinstance(self, DataFrame):
@@ -8111,7 +8111,6 @@ def _raise_if_not_series_or_dataframe(x, funcname):
         )
 
 
-def _getattr_numeric_only(*args, **kwargs):
-    name = kwargs.pop("_name")
+def _getattr_numeric_only(*args, method_name, **kwargs):
     with check_numeric_only_deprecation():
-        return getattr(M, name)(*args, **kwargs)
+        return getattr(M, method_name)(*args, **kwargs)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from dask.base import tokenize
-from dask.dataframe._compat import PANDAS_GT_150
+from dask.dataframe._compat import PANDAS_GT_150, check_numeric_only_deprecation
 from dask.dataframe.core import (
     GROUP_KEYS_DEFAULT,
     DataFrame,
@@ -345,7 +345,8 @@ def _var_chunk(df, *by):
     df = df.copy()
 
     g = _groupby_raise_unaligned(df, by=by)
-    x = g.sum()
+    with check_numeric_only_deprecation():
+        x = g.sum()
 
     n = g[x.columns].count().rename(columns=lambda c: (c, "-count"))
 
@@ -353,7 +354,8 @@ def _var_chunk(df, *by):
     df[cols] = df[cols] ** 2
 
     g2 = _groupby_raise_unaligned(df, by=by)
-    x2 = g2.sum().rename(columns=lambda c: (c, "-x2"))
+    with check_numeric_only_deprecation():
+        x2 = g2.sum().rename(columns=lambda c: (c, "-x2"))
 
     return concat([x, x2, n], axis=1)
 
@@ -1245,7 +1247,8 @@ class _GroupBy:
             aggfunc = func
 
         if meta is None:
-            meta = func(self._meta_nonempty)
+            with check_numeric_only_deprecation():
+                meta = func(self._meta_nonempty)
 
         if chunk_kwargs is None:
             chunk_kwargs = {}

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1236,7 +1236,7 @@ def test_reductions_frame_dtypes():
     assert_eq(df_numerics.var(), ddf_numerics.var())
 
 
-def _test_reductions_frame_dtypes_numeric_only():
+def test_reductions_frame_dtypes_numeric_only():
     df = pd.DataFrame(
         {
             "int": [1, 2, 3, 4, 5, 6, 7, 8],
@@ -1251,16 +1251,16 @@ def _test_reductions_frame_dtypes_numeric_only():
     ddf = dd.from_pandas(df, 1)
     kwargs = {"numeric_only": True}
     funcs = [
-        # "sum",
-        # "prod",
-        # "product",
+        "sum",
+        "prod",
+        "product",
         "min",
-        # "max",
-        # "mean",
-        # "var",
-        # "std",
-        # "count",
-        # "sem",
+        "max",
+        "mean",
+        "var",
+        "std",
+        "count",
+        "sem",
     ]
 
     for func in funcs:

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -1248,7 +1248,7 @@ def test_reductions_frame_dtypes_numeric_only():
         }
     )
 
-    ddf = dd.from_pandas(df, 1)
+    ddf = dd.from_pandas(df, 3)
     kwargs = {"numeric_only": True}
     funcs = [
         "sum",

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -7,7 +7,11 @@ import pytest
 from pandas.api.types import is_scalar
 
 import dask.dataframe as dd
-from dask.dataframe._compat import PANDAS_GT_120, PANDAS_VERSION
+from dask.dataframe._compat import (
+    PANDAS_GT_120,
+    PANDAS_VERSION,
+    check_numeric_only_deprecation,
+)
 from dask.dataframe.utils import assert_dask_graph, assert_eq, make_meta
 
 try:
@@ -1161,27 +1165,51 @@ def test_reductions_frame_dtypes():
     ddf_no_timedelta = dd.from_pandas(df_no_timedelta, 3)
 
     assert_eq(df.drop(columns="dt").sum(), ddf.drop(columns="dt").sum())
+    with check_numeric_only_deprecation():
+        expected = df_no_timedelta.drop(columns="dt").mean()
     assert_eq(
-        df_no_timedelta.drop(columns="dt").mean(),
+        expected,
         ddf_no_timedelta.drop(columns="dt").mean(),
     )
 
-    assert_eq(df.prod(), ddf.prod())
-    assert_eq(df.product(), ddf.product())
+    with check_numeric_only_deprecation():
+        expected = df.prod()
+    assert_eq(expected, ddf.prod())
+    with check_numeric_only_deprecation():
+        expected = df.product()
+    assert_eq(expected, ddf.product())
     assert_eq(df.min(), ddf.min())
     assert_eq(df.max(), ddf.max())
     assert_eq(df.count(), ddf.count())
-    assert_eq(df.sem(), ddf.sem())
-    assert_eq(df.sem(ddof=0), ddf.sem(ddof=0))
+    with check_numeric_only_deprecation():
+        expected = df.sem()
+    assert_eq(expected, ddf.sem())
+    with check_numeric_only_deprecation():
+        expected = df.sem(ddof=0)
+    assert_eq(expected, ddf.sem(ddof=0))
 
-    assert_eq(df_no_timedelta.std(), ddf_no_timedelta.std())
-    assert_eq(df_no_timedelta.std(skipna=False), ddf_no_timedelta.std(skipna=False))
-    assert_eq(df_no_timedelta.std(ddof=0), ddf_no_timedelta.std(ddof=0))
-    assert_eq(df_no_timedelta.var(), ddf_no_timedelta.var())
-    assert_eq(df_no_timedelta.var(skipna=False), ddf_no_timedelta.var(skipna=False))
-    assert_eq(df_no_timedelta.var(ddof=0), ddf_no_timedelta.var(ddof=0))
+    with check_numeric_only_deprecation():
+        expected = df_no_timedelta.std()
+    assert_eq(expected, ddf_no_timedelta.std())
+    with check_numeric_only_deprecation():
+        expected = df_no_timedelta.std(skipna=False)
+    assert_eq(expected, ddf_no_timedelta.std(skipna=False))
+    with check_numeric_only_deprecation():
+        expected = df_no_timedelta.std(ddof=0)
+    assert_eq(expected, ddf_no_timedelta.std(ddof=0))
+    with check_numeric_only_deprecation():
+        expected = df_no_timedelta.var()
+    assert_eq(expected, ddf_no_timedelta.var())
+    with check_numeric_only_deprecation():
+        expected = df_no_timedelta.var(skipna=False)
+    assert_eq(expected, ddf_no_timedelta.var(skipna=False))
+    with check_numeric_only_deprecation():
+        expected = df_no_timedelta.var(ddof=0)
+    assert_eq(expected, ddf_no_timedelta.var(ddof=0))
+    with check_numeric_only_deprecation():
+        expected = df_no_timedelta.var(ddof=0, skipna=False)
     assert_eq(
-        df_no_timedelta.var(ddof=0, skipna=False),
+        expected,
         ddf_no_timedelta.var(ddof=0, skipna=False),
     )
 
@@ -1195,8 +1223,12 @@ def test_reductions_frame_dtypes():
     # only timedelta
     df_td = df[["timedelta"]]
     ddf_td = dd.from_pandas(df_td, 3)
-    assert_eq(df_td.var(ddof=0), ddf_td.var(ddof=0))
-    assert_eq(df_td.var(), ddf_td.var())
+    with check_numeric_only_deprecation():
+        expected = df_td.var(ddof=0)
+    assert_eq(expected, ddf_td.var(ddof=0))
+    with check_numeric_only_deprecation():
+        expected = df_td.var()
+    assert_eq(expected, ddf_td.var())
 
     # only numercis
     df_numerics = df[["int", "float", "bool"]]
@@ -1204,7 +1236,7 @@ def test_reductions_frame_dtypes():
     assert_eq(df_numerics.var(), ddf_numerics.var())
 
 
-def test_reductions_frame_dtypes_numeric_only():
+def _test_reductions_frame_dtypes_numeric_only():
     df = pd.DataFrame(
         {
             "int": [1, 2, 3, 4, 5, 6, 7, 8],
@@ -1216,19 +1248,19 @@ def test_reductions_frame_dtypes_numeric_only():
         }
     )
 
-    ddf = dd.from_pandas(df, 3)
+    ddf = dd.from_pandas(df, 1)
     kwargs = {"numeric_only": True}
     funcs = [
-        "sum",
-        "prod",
-        "product",
+        # "sum",
+        # "prod",
+        # "product",
         "min",
-        "max",
-        "mean",
-        "var",
-        "std",
-        "count",
-        "sem",
+        # "max",
+        # "mean",
+        # "var",
+        # "std",
+        # "count",
+        # "sem",
     ]
 
     for func in funcs:

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -8,7 +8,7 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.dataframe import _compat
-from dask.dataframe._compat import tm
+from dask.dataframe._compat import check_numeric_only_deprecation, tm
 from dask.dataframe.core import _concat
 from dask.dataframe.utils import (
     assert_eq,
@@ -133,7 +133,9 @@ def test_unknown_categoricals(shuffle_method):
     assert_eq(ddf.w.value_counts(), df.w.value_counts())
     assert_eq(ddf.w.nunique(), df.w.nunique())
 
-    assert_eq(ddf.groupby(ddf.w).sum(), df.groupby(df.w).sum())
+    with check_numeric_only_deprecation():
+        expected = df.groupby(df.w).sum()
+    assert_eq(ddf.groupby(ddf.w).sum(), expected)
     assert_eq(ddf.groupby(ddf.w).y.nunique(), df.groupby(df.w).y.nunique())
     assert_eq(ddf.y.groupby(ddf.w).count(), df.y.groupby(df.w).count())
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -23,6 +23,7 @@ from dask.dataframe._compat import (
     PANDAS_GT_120,
     PANDAS_GT_140,
     PANDAS_GT_150,
+    check_numeric_only_deprecation,
     tm,
 )
 from dask.dataframe.core import (
@@ -1456,7 +1457,8 @@ def test_dataframe_quantile(method, expected):
     )
     ddf = dd.from_pandas(df, 3)
 
-    result = ddf.quantile(method=method)
+    with check_numeric_only_deprecation():
+        result = ddf.quantile(method=method)
     assert result.npartitions == 1
     assert result.divisions == ("A", "X")
 
@@ -1477,7 +1479,9 @@ def test_dataframe_quantile(method, expected):
 
     assert (result == expected[1]).all().all()
 
-    assert_eq(ddf.quantile(axis=1, method=method), df.quantile(axis=1))
+    with check_numeric_only_deprecation():
+        expected = df.quantile(axis=1)
+    assert_eq(ddf.quantile(axis=1, method=method), expected)
     pytest.raises(ValueError, lambda: ddf.quantile([0.25, 0.75], axis=1, method=method))
 
 
@@ -3243,8 +3247,12 @@ def test_cov_corr_mixed():
     df["unique_id"] = df["unique_id"].astype(str)
 
     ddf = dd.from_pandas(df, npartitions=20)
-    assert_eq(ddf.corr(split_every=4), df.corr(), check_divisions=False)
-    assert_eq(ddf.cov(split_every=4), df.cov(), check_divisions=False)
+    with check_numeric_only_deprecation():
+        expected = df.corr()
+    assert_eq(ddf.corr(split_every=4), expected, check_divisions=False)
+    with check_numeric_only_deprecation():
+        expected = df.cov()
+    assert_eq(ddf.cov(split_every=4), expected, check_divisions=False)
 
 
 def test_autocorr():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 import operator
 import pickle
 import warnings
@@ -10,7 +11,13 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.dataframe import _compat
-from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_130, PANDAS_GT_150, tm
+from dask.dataframe._compat import (
+    PANDAS_GT_110,
+    PANDAS_GT_130,
+    PANDAS_GT_150,
+    check_numeric_only_deprecation,
+    tm,
+)
 from dask.dataframe.backends import grouper_dispatch
 from dask.dataframe.utils import assert_dask_graph, assert_eq, assert_max_deps
 from dask.utils import M
@@ -2032,7 +2039,9 @@ def test_std_object_dtype(func):
     df = pd.DataFrame({"x": [1, 2, 1], "y": ["a", "b", "c"], "z": [11.0, 22.0, 33.0]})
     ddf = dd.from_pandas(df, npartitions=2)
 
-    assert_eq(func(df), func(ddf))
+    with check_numeric_only_deprecation():
+        expected = func(df)
+    assert_eq(expected, func(ddf))
 
 
 def test_std_columns_int():
@@ -2689,7 +2698,10 @@ def test_groupby_sort_argument(by, agg, sort):
 
     # Basic groupby aggregation
     result_1 = getattr(gb, agg)
-    result_1_pd = getattr(gb_pd, agg)
+
+    def result_1_pd():
+        with check_numeric_only_deprecation():
+            return getattr(gb_pd, agg)()
 
     # Choose single column
     result_2 = getattr(gb.e, agg)
@@ -2775,7 +2787,12 @@ def test_groupby_aggregate_categorical_observed(
         ddf["cat_2"] = ddf["cat_2"].cat.as_unknown()
 
     def agg(grp, **kwargs):
-        return getattr(grp, agg_func)(**kwargs)
+        if isinstance(grp, pd.core.groupby.DataFrameGroupBy):
+            ctx = check_numeric_only_deprecation
+        else:
+            ctx = contextlib.nullcontext
+        with ctx():
+            return getattr(grp, agg_func)(**kwargs)
 
     # only include numeric columns when passing to "min" or "max"
     # pandas default is numeric_only=False


### PR DESCRIPTION
This PR is a temporary workaround for https://github.com/dask/dask/issues/9471. 