### PR TITLE
Workaround for parquet writing failure using some datetime series but not others

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -845,9 +845,9 @@ def test_append_wo_index(tmpdir, engine, metadata_file):
     ("index", "offset"),
     [
         (
-            pd.date_range("2022-01-01", "2022-01-02", periods=500)
-            .to_series()
-            .astype("datetime64[ms]"),
+            # There is some odd behavior with date ranges and pyarrow in some cirucmstances!
+            # https://github.com/pandas-dev/pandas/issues/48573
+            pd.date_range("2022-01-01", "2022-01-31", freq="D"),
             pd.Timedelta(days=1),
         ),
         (pd.RangeIndex(0, 500, 1), 499),


### PR DESCRIPTION
This fixes one of the remaining test failures with the upcoming pandas 1.5 release. It's a small workaround for a weird pandas-or-pyarrow bug: https://github.com/pandas-dev/pandas/issues/48573

