### PR TITLE
Shuffle-based groupby for single functions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -562,7 +562,7 @@ Dask Name: {name}, {layers}"""
         return self.map_partitions(
             getattr,
             "index",
-            token=self._name + "-index",
+            token=key_split(self._name) + "-index",
             meta=self._meta.index,
             enforce_metadata=False,
         )

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1300,11 +1300,19 @@ class _GroupBy:
             return _shuffle_aggregate(
                 [self.obj] + by,
                 chunk=_apply_chunk,
-                chunk_kwargs={"chunk": func, "columns": columns, **chunk_kwargs},
+                chunk_kwargs={
+                    "chunk": func,
+                    "columns": columns,
+                    **self.observed,
+                    **self.dropna,
+                    **chunk_kwargs,
+                },
                 aggregate=_groupby_aggregate,
                 aggregate_kwargs={
                     "aggfunc": aggfunc,
                     "levels": levels,
+                    **self.observed,
+                    **self.dropna,
                     **aggregate_kwargs,
                 },
                 token=token,
@@ -1577,7 +1585,8 @@ class _GroupBy:
 
     @derived_from(pd.core.groupby.GroupBy)
     def median(self, split_every=None, split_out=1):
-        meta = self._meta_nonempty.median()
+        with check_numeric_only_deprecation():
+            meta = self._meta_nonempty.median()
         columns = meta.name if is_series_like(meta) else meta.columns
         chunk_args = (
             [self.obj, self.by]
@@ -1593,6 +1602,8 @@ class _GroupBy:
             aggregate_kwargs={
                 "aggfunc": M.median,
                 "levels": _determine_levels(self.by),
+                **self.observed,
+                **self.dropna,
             },
             split_every=split_every,
             split_out=split_out,

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -338,7 +338,7 @@ def _set_index_chunk(df, *by, columns=None):
     else:
         if isinstance(columns, (tuple, list, set, pd.Index)):
             columns = list(columns)
-        return df[columns].set_index(list(by))
+        return df.set_index(list(by))[columns]
 
 
 def _apply_chunk(df, *by, dropna=None, observed=None, **kwargs):
@@ -1577,7 +1577,7 @@ class _GroupBy:
 
     @derived_from(pd.core.groupby.GroupBy)
     def median(self, split_every=None, split_out=1):
-        meta = self.obj._meta
+        meta = self._meta_nonempty.median()
         columns = meta.name if is_series_like(meta) else meta.columns
         chunk_args = (
             [self.obj, self.by]

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1535,14 +1535,13 @@ class _GroupBy:
         if shuffle:
             # Shuffle-based aggregation
             meta = self.obj._meta
-            columns = meta.name if is_series_like(meta) else meta.columns
-            chunk_args = (
-                [self.obj, self.by]
-                if not isinstance(self.by, list)
-                else [self.obj] + self.by
-            )
+            by = self.by if isinstance(self.by, list) else [self.by]
+            if is_series_like(meta):
+                columns = meta.name
+            else:
+                columns = [c for c in meta.columns if c not in by]
             return _shuffle_aggregate(
-                chunk_args,
+                [self.obj] + by,
                 chunk=_apply_chunk,
                 chunk_kwargs={"chunk": func, "columns": columns},
                 aggregate=_groupby_aggregate,

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -480,7 +480,7 @@ D       ...
 G       ...
 H       ...
 dtype: object
-Dask Name: from_pandas, 2 graph layers"""
+Dask Name: from_pandas-index, 2 graph layers"""
     assert repr(ds.index) == exp
     assert str(ds.index) == exp
 
@@ -498,7 +498,7 @@ Dask Name: from_pandas, 2 graph layers"""
     7                ...
     8                ...
     Name: YYY, dtype: category
-    Dask Name: from_pandas, 2 graph layers"""
+    Dask Name: from_pandas-index, 2 graph layers"""
     )
     assert repr(ds.index) == exp
     assert str(ds.index) == exp

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2775,8 +2775,8 @@ def test_groupby_sort_true_split_out():
     M.sum(ddf.groupby("x"), split_out=2)
 
     with pytest.raises(NotImplementedError):
-        # Cannot use sort=True with split_out>1 (for now)
-        M.sum(ddf.groupby("x", sort=True), split_out=2)
+        # Cannot use sort=True with split_out>1 using non-shuffle-based approach
+        M.sum(ddf.groupby("x", sort=True), shuffle=False, split_out=2)
 
     # Can use sort=True with split_out>1 with agg() if shuffle=True
     ddf.groupby("x", sort=True).agg("sum", split_out=2, shuffle=True)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -30,7 +30,6 @@ if dd._compat.PANDAS_GT_110:
 AGG_FUNCS = [
     "sum",
     "mean",
-    "median",
     "min",
     "max",
     "count",

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -30,6 +30,7 @@ if dd._compat.PANDAS_GT_110:
 AGG_FUNCS = [
     "sum",
     "mean",
+    "median",
     "min",
     "max",
     "count",
@@ -2785,10 +2786,10 @@ def test_groupby_sort_true_split_out():
 @pytest.mark.skipif(
     not PANDAS_GT_110, reason="observed only supported for newer pandas"
 )
-@pytest.mark.parametrize("known_cats", [True, False])
-@pytest.mark.parametrize("ordered_cats", [True, False])
+@pytest.mark.parametrize("known_cats", [True, False], ids=["known", "unknown"])
+@pytest.mark.parametrize("ordered_cats", [True, False], ids=["ordered", "unordererd"])
 @pytest.mark.parametrize("groupby", ["cat_1", ["cat_1", "cat_2"]])
-@pytest.mark.parametrize("observed", [True, False])
+@pytest.mark.parametrize("observed", [True, False], ids=["observed", "unobserved"])
 def test_groupby_aggregate_categorical_observed(
     known_cats, ordered_cats, agg_func, groupby, observed
 ):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -635,7 +635,7 @@ def assert_sane_keynames(ddf):
         while isinstance(k, tuple):
             k = k[0]
         assert isinstance(k, (str, bytes))
-        assert len(k) < 150
+        assert len(k) < 100
         assert " " not in k
         assert k.split("-")[0].isidentifier(), k
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -635,7 +635,7 @@ def assert_sane_keynames(ddf):
         while isinstance(k, tuple):
             k = k[0]
         assert isinstance(k, (str, bytes))
-        assert len(k) < 100
+        assert len(k) < 150
         assert " " not in k
         assert k.split("-")[0].isidentifier(), k
 


### PR DESCRIPTION
This includes the new `shuffle` kwarg in more of the groupby aggregations, and enables shuffle-based aggregation in those places. So now `df.groupby("a").sum()` and `df.groupby("a").agg("sum")` both have access to the same aggregations.

New functions with shuffling:
* sum
* prod
* min
* max
* idxmin
* idxmax
* count
* mean
* size
* first
* last
* head
* tail

~~While I'm here, I also added `groupby().median()`. This one is a bit unusual, in that I'm skipping the initial agg step before the shuffle (there is a dummy `set_index` step instead).~~ (Leaving for a follow-up)

- [x] Closes #9487
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

TODO 
- [x] add some more tests.
- [ ] ~~Possibly add `cov`, `var`, `nunique`, which need special treatment~~