### PR TITLE
Clarify custom-graph multiprocessing example

### DIFF
--- a/docs/source/custom-graphs.rst
+++ b/docs/source/custom-graphs.rst
@@ -55,14 +55,17 @@ analyze pipeline:
    from dask.multiprocessing import get
    get(dsk, 'store')  # executes in parallel
 
-In the above example, while multiprocessing, if a notebook is not being 
-used to run, the ``get(dsk, 'store')`` command needs to be run inside an 
-``if __name__ == '__main__':`` block as shown below:
+If the above example is not being run inside a notebook, the ``get(dsk, 'store')``
+command should be placed inside an ``if __name__ == '__main__':`` block:
 
 .. code-block:: python
 
    if __name__ == '__main__':
-      get(dsk, "store")
+       get(dsk, "store")
+       
+For an explanation of why ``if __name__ == '__main__'`` is necessary, see the
+standard `multiprocessing guidelines <https://docs.python.org/3/library/multiprocessing.html#programming-guidelines>`_
+for Python.
 
 
 

--- a/docs/source/custom-graphs.rst
+++ b/docs/source/custom-graphs.rst
@@ -55,6 +55,15 @@ analyze pipeline:
    from dask.multiprocessing import get
    get(dsk, 'store')  # executes in parallel
 
+In the above example, while multiprocessing, if a notebook is not being 
+used to run, the ``get(dsk, 'store')`` command needs to be run inside an 
+``if __name__ == '__main__':`` block as shown below:
+
+.. code-block:: python
+
+   if __name__ == '__main__':
+      get(dsk, "store")
+
 
 
 Keyword arguments in custom Dask graphs


### PR DESCRIPTION
While multiprocessing, if a notebook is not being used, it is required that the `get` command in the given example needs to be run inside a `if __name__ == '__main__':` block. Added clarification regarding this in the documentation.

- [x] Closes #9438 
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
