### PR TITLE
Add docs on running Dask in a standalone Python script

### DIFF
--- a/docs/source/custom-graphs.rst
+++ b/docs/source/custom-graphs.rst
@@ -52,21 +52,8 @@ analyze pipeline:
           'analyze': (analyze, ['clean-%d' % i for i in [1, 2, 3]]),
           'store': (store, 'analyze')}
 
-   from dask.multiprocessing import get
+   from dask.threaded import get
    get(dsk, 'store')  # executes in parallel
-
-If the above example is not being run inside a notebook, the ``get(dsk, 'store')``
-command should be placed inside an ``if __name__ == '__main__':`` block:
-
-.. code-block:: python
-
-   if __name__ == '__main__':
-       get(dsk, "store")
-       
-For an explanation of why ``if __name__ == '__main__'`` is necessary, see the
-standard `multiprocessing guidelines <https://docs.python.org/3/library/multiprocessing.html#programming-guidelines>`_
-for Python.
-
 
 
 Keyword arguments in custom Dask graphs

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -262,8 +262,10 @@ and eventually an error is raised.
       The "freeze_support()" line can be omitted if the program
       is not going to be frozen to produce an executable.
 
-To avoid this types of error, you should place your Dask code inside a ``if __name__ == "__main__":``
-block to ensure subprocesses are only created when your script is run as the main program.
+To avoid this types of error, you should place any Dask code that create subprocesses
+(for example, all ``compute()`` calls that use the multiprocessing scheduler, or when creating
+a local distributed cluster) inside a ``if __name__ == "__main__":`` block. This ensures
+subprocesses are only created when your script is run as the main program.
 
 For example, running ``python myscript.py`` with the script below will raise an error:
 


### PR DESCRIPTION
This PR adds a section about using `if __name__ == "__main__":` when running Dask in a Python script. This is a common, and confusing, users run into.

Closes https://github.com/dask/distributed/issues/6267 

xref https://github.com/dask/dask/pull/9511#issuecomment-1256346748, https://github.com/dask/distributed/issues/6816, https://github.com/dask/distributed/issues/2708 (keeping this one open as it's about trying to raise a more informative error), https://github.com/dask/distributed/issues/2520

cc @rjzamora @ian-r-rose in case you have thoughts on the content here

@djhoese you've run into this issue before. Would these docs have helped you? 