### PR TITLE
[DNM] Flush out extension dtype issues

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -271,6 +271,9 @@ def from_pandas(
             "Please provide chunksize as an int, or possibly as None if you specify npartitions."
         )
 
+    if isinstance(data, pd.DataFrame):
+        for c in data.columns:
+            data[c] = data[c].convert_dtypes()
     name = name or ("from_pandas-" + tokenize(data, chunksize, npartitions))
 
     if not nrows:


### PR DESCRIPTION
Mutate pandas dataframes in `dd.from_pandas()` to nullable dtypes to see what in the dask test suite fails.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
