### PR TITLE
Don't allow Array slice `np.nan` assignment with integer dtypes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1876,6 +1876,10 @@ class Array(DaskMethodsMixin):
         if value is np.ma.masked:
             value = np.ma.masked_all((), dtype=self.dtype)
 
+        if not is_dask_collection(value) and np.isnan(value).any():
+            if issubclass(self.dtype.type, Integral):
+                raise ValueError("cannot convert float NaN to integer")
+
         ## Use the "where" method for cases when key is an Array
         if isinstance(key, Array):
             from dask.array.routines import where

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4271,6 +4271,11 @@ def test_setitem_errs():
     with pytest.raises(ValueError, match="Arrays chunk sizes are unknown"):
         dx[0] = 0
 
+    # np.nan assigned to integer array
+    x = da.ones((3, 3), dtype=int)
+    with pytest.raises(ValueError, match="cannot convert float NaN to integer"):
+        x[:, 1] = np.nan
+
 
 def test_zero_slice_dtypes():
     x = da.arange(5, chunks=1)


### PR DESCRIPTION
- [x] Closes #9526
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
