### PR TITLE
Make `datetime.datetime` tokenize idempotantly

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -947,6 +947,8 @@ normalize_token.register(
         complex,
         type(Ellipsis),
         datetime.date,
+        datetime.time,
+        datetime.datetime,
         datetime.timedelta,
         pathlib.PurePath,
     ),

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -434,9 +434,10 @@ def test_tokenize_ordered_dict():
     assert tokenize(a) != tokenize(c)
 
 
-def test_tokenize_timedelta():
+def test_tokenize_time_timedelta():
     assert tokenize(datetime.timedelta(days=1)) == tokenize(datetime.timedelta(days=1))
     assert tokenize(datetime.timedelta(days=1)) != tokenize(datetime.timedelta(days=2))
+    assert tokenize(datetime.time(1, 2, 3)) == tokenize(datetime.time(1, 2, 3))
 
 
 @pytest.mark.parametrize("enum_type", [Enum, IntEnum, IntFlag, Flag])

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -437,7 +437,6 @@ def test_tokenize_ordered_dict():
 def test_tokenize_time_timedelta():
     assert tokenize(datetime.timedelta(days=1)) == tokenize(datetime.timedelta(days=1))
     assert tokenize(datetime.timedelta(days=1)) != tokenize(datetime.timedelta(days=2))
-    assert tokenize(datetime.time(1, 2, 3)) == tokenize(datetime.time(1, 2, 3))
 
 
 @pytest.mark.parametrize("enum_type", [Enum, IntEnum, IntFlag, Flag])
@@ -603,6 +602,48 @@ def test_tokenize_datetime_time():
     assert tokenize(datetime.time(1, 2, 3, 4, datetime.timezone.utc)) != tokenize(
         datetime.time(1, 2, 3, 4)
     )
+
+
+def test_tokenize_datetime_datetime():
+    # Same datetime
+    required = [1, 2, 3]  # year, month, day
+    optional = [4, 5, 6, 7, datetime.timezone.utc]
+    for i in range(len(optional) + 1):
+        args = required + optional[:i]
+        assert tokenize(datetime.datetime(*args)) == tokenize(datetime.datetime(*args))
+
+    # Different year
+    assert tokenize(
+        datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc)
+    ) != tokenize(datetime.datetime(2, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
+    # Different month
+    assert tokenize(
+        datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc)
+    ) != tokenize(datetime.datetime(1, 1, 3, 4, 5, 6, 7, datetime.timezone.utc))
+    # Different day
+    assert tokenize(
+        datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc)
+    ) != tokenize(datetime.datetime(1, 2, 2, 4, 5, 6, 7, datetime.timezone.utc))
+    # Different hour
+    assert tokenize(
+        datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc)
+    ) != tokenize(datetime.datetime(1, 2, 3, 3, 5, 6, 7, datetime.timezone.utc))
+    # Different minute
+    assert tokenize(
+        datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc)
+    ) != tokenize(datetime.datetime(1, 2, 3, 4, 4, 6, 7, datetime.timezone.utc))
+    # Different second
+    assert tokenize(
+        datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc)
+    ) != tokenize(datetime.datetime(1, 2, 3, 4, 5, 5, 7, datetime.timezone.utc))
+    # Different micros
+    assert tokenize(
+        datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc)
+    ) != tokenize(datetime.datetime(1, 2, 3, 4, 5, 6, 6, datetime.timezone.utc))
+    # Different tz
+    assert tokenize(
+        datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc)
+    ) != tokenize(datetime.datetime(1, 2, 3, 4, 5, 6, 7, None))
 
 
 def test_is_dask_collection():

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -434,7 +434,7 @@ def test_tokenize_ordered_dict():
     assert tokenize(a) != tokenize(c)
 
 
-def test_tokenize_time_timedelta():
+def test_tokenize_timedelta():
     assert tokenize(datetime.timedelta(days=1)) == tokenize(datetime.timedelta(days=1))
     assert tokenize(datetime.timedelta(days=1)) != tokenize(datetime.timedelta(days=2))
 


### PR DESCRIPTION
- [x] Closes #9527
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
