### PR TITLE
Stable demo column projection

### DIFF
--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -120,12 +120,8 @@ def make_timeseries_part(start, end, dtypes, columns, freq, state_data, kwargs):
         }
         # Note: we compute data for all dtypes in order, not just those in the output
         # columns. This ensures the same output given the same state_data, regardless
-        # of whether there is any column projection. So there is extra work done for
-        # the demo dataset in the presence of projection.
-        # It might be nice to use the internal `advance(n_samples)` method on the random
-        # state to avoid that extra work, but that is probably unreliable as different
-        # internal distributions reserve the right to advance the state as much as
-        # they want (e.g., for rejection sampling).
+        # of whether there is any column projection.
+        # cf. https://github.com/dask/dask/pull/9538#issuecomment-1267461887
         result = make[dt](len(index), state, **kws)
         if k in columns:
             data[k] = result

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -72,7 +72,7 @@ class MakeTimeseriesPart(DataFrameIOFunction):
 
     def __init__(self, dtypes, freq, kwargs, columns=None):
         self._columns = columns or list(dtypes.keys())
-        self.dtypes = {c: dtypes[c] for c in self.columns}
+        self.dtypes = dtypes
         self.freq = freq
         self.kwargs = kwargs
 
@@ -98,22 +98,38 @@ class MakeTimeseriesPart(DataFrameIOFunction):
         if isinstance(state_data, int):
             state_data = random_state_data(1, state_data)
         return make_timeseries_part(
-            divisions[0], divisions[1], self.dtypes, self.freq, state_data, self.kwargs
+            divisions[0],
+            divisions[1],
+            self.dtypes,
+            self.columns,
+            self.freq,
+            state_data,
+            self.kwargs,
         )
 
 
-def make_timeseries_part(start, end, dtypes, freq, state_data, kwargs):
+def make_timeseries_part(start, end, dtypes, columns, freq, state_data, kwargs):
     index = pd.date_range(start=start, end=end, freq=freq, name="timestamp")
     state = np.random.RandomState(state_data)
-    columns = {}
+    data = {}
     for k, dt in dtypes.items():
         kws = {
             kk.rsplit("_", 1)[1]: v
             for kk, v in kwargs.items()
             if kk.rsplit("_", 1)[0] == k
         }
-        columns[k] = make[dt](len(index), state, **kws)
-    df = pd.DataFrame(columns, index=index, columns=sorted(columns))
+        # Note: we compute data for all dtypes in order, not just those in the output
+        # columns. This ensures the same output given the same state_data, regardless
+        # of whether there is any column projection. So there is extra work done for
+        # the demo dataset in the presence of projection.
+        # It might be nice to use the internal `advance(n_samples)` method on the random
+        # state to avoid that extra work, but that is probably unreliable as different
+        # internal distributions reserve the right to advance the state as much as
+        # they want (e.g., for rejection sampling).
+        result = make[dt](len(index), state, **kws)
+        if k in columns:
+            data[k] = result
+    df = pd.DataFrame(data, index=index, columns=columns)
     if df.index[-1] == end:
         df = df.iloc[:-1]
     return df
@@ -184,7 +200,9 @@ def make_timeseries(
     return from_map(
         MakeTimeseriesPart(dtypes, freq, kwargs),
         parts,
-        meta=make_timeseries_part("2000", "2000", dtypes, "1H", state_data[0], kwargs),
+        meta=make_timeseries_part(
+            "2000", "2000", dtypes, list(dtypes.keys()), "1H", state_data[0], kwargs
+        ),
         divisions=divisions,
         label="make-timeseries",
         token=tokenize(start, end, dtypes, freq, partition_freq, state_data),

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -5,6 +5,7 @@ import dask.dataframe as dd
 from dask.blockwise import Blockwise, optimize_blockwise
 from dask.dataframe._compat import tm
 from dask.dataframe.optimize import optimize_dataframe_getitem
+from dask.dataframe.utils import assert_eq
 
 
 def test_make_timeseries():
@@ -157,3 +158,15 @@ def test_make_timeseries_getitem_compute():
     df3 = df2.compute()
     assert df3["y"].min() > 0
     assert list(df.columns) == list(df3.columns)
+
+
+def test_make_timeseries_column_projection():
+    ddf = dd.demo.make_timeseries(
+        "2001", "2002", freq="1D", partition_freq="3M", seed=42
+    )
+
+    assert_eq(ddf[["x"]].compute(), ddf.compute()[["x"]])
+    assert_eq(
+        ddf.groupby("name").aggregate({"x": "sum", "y": "max"}).compute(),
+        ddf.compute().groupby("name").aggregate({"x": "sum", "y": "max"}),
+    )


### PR DESCRIPTION
- [x] Closes #9535, closes #9514 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This fix should result in making the timeseries dataset lose a lot of the benefit of column projection. However, I thought that correctness was more important than performance here, and I don't think we have a more reliable way of advancing the random state.