### PR TITLE
Ensure pickle-able binops in `delayed`

### DIFF
--- a/continuous_integration/scripts/test_imports.sh
+++ b/continuous_integration/scripts/test_imports.sh
@@ -15,6 +15,8 @@ test_import () {
     mamba list
     echo "python -c '$2'"
     python -c "$2"
+    echo "python -c '$2' (ensure deterministic)"
+    DASK_TOKENIZE__ENSURE_DETERMINISTIC=True python -c "$2"
     conda deactivate
     mamba env remove -n test-imports
 }

--- a/continuous_integration/scripts/test_imports.sh
+++ b/continuous_integration/scripts/test_imports.sh
@@ -15,6 +15,8 @@ test_import () {
     mamba list
     echo "python -c '$2'"
     python -c "$2"
+    # Ensure that no non-deterministic objects are tokenized at init time,
+    # which can prevent the library from being imported at all.
     echo "python -c '$2' (ensure deterministic)"
     DASK_TOKENIZE__ENSURE_DETERMINISTIC=True python -c "$2"
     conda deactivate

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -4,6 +4,7 @@ import uuid
 import warnings
 from collections.abc import Iterator
 from dataclasses import fields, is_dataclass, replace
+from functools import partial
 
 from tlz import concat, curry, merge, unique
 
@@ -496,13 +497,13 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
         return Delayed(name, graph, nout)
 
 
+def _swap(method, self, other):
+    return method(other, self)
+
+
 def right(method):
     """Wrapper to create 'right' version of operator given left version"""
-
-    def _inner(self, other):
-        return method(other, self)
-
-    return _inner
+    return partial(_swap, method)
 
 
 def optimize(dsk, keys, **kwargs):


### PR DESCRIPTION
Avoid un-pickle-able local functions in delayed. Adds a new CI check to avoid breaking this.

- [x] Closes #9536 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
