### PR TITLE
Add dependabot for GitHub actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,9 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "weekly"


### PR DESCRIPTION
This is a companion PR to https://github.com/dask/distributed/pull/7101. With the changes here, on a weekly cadence, dependabot will check for new versions of the various GitHub actions we use and, if there are new releases, will open a PR updating to the latest release. 

cc @jacobtomlinson as this seems like the kind of thing you might like : ) 