### PR TITLE
Avoid race condition in lazy dispatch registration

### DIFF
--- a/dask/utils.py
+++ b/dask/utils.py
@@ -628,7 +628,7 @@ class Dispatch:
                 pass
             else:
                 register()
-                self._lazy.pop(toplevel)
+                self._lazy.pop(toplevel, None)
                 return self.dispatch(cls)  # recurse
         raise TypeError(f"No dispatch for {cls}")
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -623,11 +623,12 @@ class Dispatch:
             # Is a lazy registration function present?
             toplevel, _, _ = cls2.__module__.partition(".")
             try:
-                register = self._lazy.pop(toplevel)
+                register = self._lazy[toplevel]
             except KeyError:
                 pass
             else:
                 register()
+                self._lazy.pop(toplevel)
                 return self.dispatch(cls)  # recurse
         raise TypeError(f"No dispatch for {cls}")
 


### PR DESCRIPTION
This makes it so we delete the `toplevel` entry from the `_lazy` lookup dictionary only after we're registered the corresponding dispatch method

Closes https://github.com/dask/dask/issues/9181, closes https://github.com/dask/distributed/issues/7061