### PR TITLE
Fix array copy not being a no-op

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -63,7 +63,6 @@ from dask.layers import ArraySliceDep, reshapelist
 from dask.sizeof import sizeof
 from dask.utils import (
     IndexCallable,
-    M,
     SerializableLock,
     cached_cumsum,
     cached_property,
@@ -2857,10 +2856,7 @@ class Array(DaskMethodsMixin):
         """
         Copy array.  This is a no-op for dask.arrays, which are immutable
         """
-        if self.npartitions == 1:
-            return self.map_blocks(M.copy)
-        else:
-            return Array(self.dask, self.name, self.chunks, meta=self)
+        return Array(self.dask, self.name, self.chunks, meta=self)
 
     def __deepcopy__(self, memo):
         c = self.copy()

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2709,14 +2709,14 @@ def test_from_array_minus_one():
     assert_eq(x, y)
 
 
-def test_from_array_copy():
-    # Regression test for https://github.com/dask/dask/issues/3751
+@pytest.mark.parametrize("chunks", [-1, 2])
+def test_array_copy_noop(chunks):
+    # Regression test for https://github.com/dask/dask/issues/9533
+    # Which is a revert of the solution for https://github.com/dask/dask/issues/3751
     x = np.arange(10)
-    y = da.from_array(x, -1)
-    assert y.npartitions == 1
+    y = da.from_array(x, chunks=chunks)
     y_c = y.copy()
-    assert y is not y_c
-    assert y.compute() is not y_c.compute()
+    assert y.name == y_c.name
 
 
 def test_from_array_dask_array():


### PR DESCRIPTION
- [x] Closes #9533
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

See #9533 for details. This reverts the logic implemented in #3754 which was a fix for #3751.

CC @DPeterK who made the original #3751 issue.

The summary is that users shouldn't assume anything about a dask Array's memory allocation or usage. Doing an `Array.copy` may return the same block of allocated memory once computed as its `from_array` input or it may return a newly allocated block of memory. Dask has the possibility of using memory however it deems is the most efficient or at least that's the idea. The thing that should be consistent is that doing a no-op operation (like `.copy` is currently documented as) should not add additional tasks to the dask graph.

```
    x = np.arange(10)
    y = da.from_array(x, chunks=chunks)
    y_c = y.copy()
    assert y.name == y_c.name
```

