### PR TITLE
Lazy computation of array shape for statistical tests

### DIFF
--- a/dask/array/stats.py
+++ b/dask/array/stats.py
@@ -229,8 +229,8 @@ def skewtest(a, axis=0, nan_policy="propagate"):
 
     b2 = skew(a, axis)
     n = _lazy_shape(a, axis)
-    if a.shape[axis] < 8: 
-        # fails to catch nan dimensional inputs with <8 samples 
+    if a.shape[axis] < 8:
+        # fails to catch nan dimensional inputs with <8 samples
         raise ValueError(
             "skewtest is not valid with less than 8 samples; %i samples"
             " were given." % int(n)
@@ -437,12 +437,13 @@ def _count(x, axis=None):
 
 
 def _lazy_shape(x, axis):
-    """ lazy evaluation of array shape along the specified axis """
+    """lazy evaluation of array shape along the specified axis"""
+
     @delayed
     def delayed_shape(x, axis):
         return x.shape[axis]
 
-    return da.from_delayed( delayed_shape(x, axis), shape=(1,), dtype=int )
+    return da.from_delayed(delayed_shape(x, axis), shape=(1,), dtype=int)
 
 
 def _sum_of_squares(a, axis=0):

--- a/dask/array/tests/test_stats.py
+++ b/dask/array/tests/test_stats.py
@@ -174,5 +174,7 @@ def test_nan_dimensional_inputs():
     inputs = da.random.random(100)
     outputs = da.random.random(100)
 
-    result_ttest = dask.array.stats.ttest_ind( outputs[ inputs > 0.5], outputs[ inputs < 0.5]).compute()
-    assert not da.isnan( result_ttest.pvalue )
+    result_ttest = dask.array.stats.ttest_ind(
+        outputs[inputs > 0.5], outputs[inputs < 0.5]
+    ).compute()
+    assert not da.isnan(result_ttest.pvalue)

--- a/dask/array/tests/test_stats.py
+++ b/dask/array/tests/test_stats.py
@@ -166,3 +166,13 @@ def test_kurtosis_single_return_type():
     result_non_fisher = dask.array.stats.kurtosis(dask_array, fisher=False).compute()
     assert isinstance(result, np.float64)
     assert isinstance(result_non_fisher, np.float64)
+
+
+def test_nan_dimensional_inputs():
+    """This function tests to ensure that the ttest can handle input arrays with nan dimensions"""
+    da.random.seed(1337)
+    inputs = da.random.random(100)
+    outputs = da.random.random(100)
+
+    result_ttest = dask.array.stats.ttest_ind( outputs[ inputs > 0.5], outputs[ inputs < 0.5]).compute()
+    assert not da.isnan( result_ttest.pvalue )


### PR DESCRIPTION
Updates the computation of the number of data points in statistical tests to be lazy, allowing them to handle nan dimensional inputs

- [x] Closes #9546
- [x] Tests added / passed: 3728 passed, 230 skipped, 8 xfailed, 40 xpassed, 1 warning
- [x] Passes `pre-commit run --all-files`
