### PR TITLE
Restrict `tiledb-py` version to avoid CI failures 

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -22,7 +22,7 @@ dependencies:
   - h5py
   - pytables
   - zarr
-  # Pinning `tiledb-py=0.17.5` lead to strange seg faults in CI.
+  # `tiledb-py=0.17.5` lead to strange seg faults in CI.
   # We should unpin when possible.
   # https://github.com/dask/dask/pull/9569
   - tiledb-py<0.17.4

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -22,7 +22,10 @@ dependencies:
   - h5py
   - pytables
   - zarr
-  - tiledb-py
+  # Pinning `tiledb-py=0.17.5` lead to strange seg faults in CI.
+  # We should unpin when possible.
+  # https://github.com/dask/dask/pull/9569
+  - tiledb-py<0.17.4
   - pyspark
   - tiledb>=2.5.0
   - xarray

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -22,7 +22,7 @@ dependencies:
   - h5py
   - pytables
   - zarr
-  # Pinning `tiledb-py=0.17.5` lead to strange seg faults in CI.
+  # `tiledb-py=0.17.5` lead to strange seg faults in CI.
   # We should unpin when possible.
   # https://github.com/dask/dask/pull/9569
   - tiledb-py<0.17.4

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -22,7 +22,10 @@ dependencies:
   - h5py
   - pytables
   - zarr
-  - tiledb-py
+  # Pinning `tiledb-py=0.17.5` lead to strange seg faults in CI.
+  # We should unpin when possible.
+  # https://github.com/dask/dask/pull/9569
+  - tiledb-py<0.17.4
   - pyspark
   - tiledb>=2.5.0
   - xarray

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -22,7 +22,7 @@ dependencies:
   - h5py
   - pytables
   - zarr
-  # Pinning `tiledb-py=0.17.5` lead to strange seg faults in CI.
+  # `tiledb-py=0.17.5` lead to strange seg faults in CI.
   # We should unpin when possible.
   # https://github.com/dask/dask/pull/9569
   - tiledb-py<0.17.4

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -22,7 +22,10 @@ dependencies:
   - h5py
   - pytables
   - zarr
-  - tiledb-py
+  # Pinning `tiledb-py=0.17.5` lead to strange seg faults in CI.
+  # We should unpin when possible.
+  # https://github.com/dask/dask/pull/9569
+  - tiledb-py<0.17.4
   - pyspark
   - tiledb>=2.5.0
   - xarray


### PR DESCRIPTION
I'm seeing some failures in other PRs I think is unrelated to the changes in those PRs. Let's see if they also pop up on `main` + an empty commit 