### PR TITLE
More Backend dispatch class type annotations

### DIFF
--- a/dask/backends.py
+++ b/dask/backends.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import lru_cache, wraps
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
+from typing import TYPE_CHECKING, Callable, Generic, TypeVar
 
 from dask import config
 from dask.compatibility import entry_points
@@ -37,7 +37,6 @@ BackendEntrypointType = TypeVar(
     "BackendEntrypointType",
     bound="DaskBackendEntrypoint",
 )
-BackendFuncType = TypeVar("BackendFuncType", bound=Callable[..., Any])
 
 
 class CreationDispatch(Generic[BackendEntrypointType]):


### PR DESCRIPTION
Follow-up to #9475, making a few of the type annotations there more precise, and removing the need for some type casts.

Principally, this allows some of the decorated functions from #9475 to maintain their signatures for type checkers and editors. For more details see https://github.com/dask/dask/pull/9475#discussion_r995163007 .