### PR TITLE
Support split_out>1 for groupby().cov()

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2199,7 +2199,8 @@ def test_groupby_group_keys(group_keys):
     "columns",
     [["a", "b", "c"], np.array([1.0, 2.0, 3.0]), ["1", "2", "3"], ["", "a", "b"]],
 )
-def test_groupby_cov(columns):
+@pytest.mark.parametrize("split_out", [1, 2])
+def test_groupby_cov(columns, split_out):
     rows = 20
     cols = 3
     data = np.random.randn(rows, cols)
@@ -2208,7 +2209,7 @@ def test_groupby_cov(columns):
     ddf = dd.from_pandas(df, npartitions=3)
 
     expected = df.groupby("key").cov()
-    result = ddf.groupby("key").cov()
+    result = ddf.groupby("key", sort=split_out == 1).cov(split_out=split_out)
     # when using numerical values for columns
     # the column mapping and stacking leads to a float typed
     # MultiIndex.  Pandas will normally create a object typed


### PR DESCRIPTION
Possible solution for the current lack of support for `groupby(...).cov(split_out>1)`.

The current problem is that the apply-concat-apply (`aca`) code path assumes that the output of `chunk` is "frame-like" (i.e. a pandas/cudf Series or DataFrame object) when `split_out>1`. This PR proposes that we allow the `chunk` function to handle hash-based sharding by skipping the `hash_shard` call in `aca` when the output of `chunk` is already a `dict` with the expected keys (e.g. `[0, split_out)`).

- [x] Closes #9509
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
