### PR TITLE
Fix `merge` with emtpy left DataFrame

### DIFF
--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1001,6 +1001,23 @@ def test_merge(how, shuffle_method):
     #         pd.merge(A, B, left_index=True, right_on='y'))
 
 
+@pytest.mark.parametrize("how", ["right", "outer"])
+def test_merge_empty_left_df(shuffle_method, how):
+    # We're merging on "a", but in a situation where the left
+    # frame is missing some values, so some of the blocked merges
+    # will involve an empty left frame.
+    # https://github.com/pandas-dev/pandas/issues/9937
+    left = pd.DataFrame({"a": [1, 1, 2, 2], "val": [5, 6, 7, 8]})
+    right = pd.DataFrame({"a": [2, 2, 3, 3], "val": [11, 12, 13, 14]})
+
+    dd_left = dd.from_pandas(left, npartitions=4)
+    dd_right = dd.from_pandas(right, npartitions=4)
+
+    result = dd_left.merge(dd_right, on="a", how=how)
+    expected = left.merge(right, on="a", how=how)
+    assert_eq(result, expected)
+
+
 def test_merge_how_raises():
     left = pd.DataFrame(
         {

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1013,9 +1013,12 @@ def test_merge_empty_left_df(shuffle_method, how):
     dd_left = dd.from_pandas(left, npartitions=4)
     dd_right = dd.from_pandas(right, npartitions=4)
 
-    result = dd_left.merge(dd_right, on="a", how=how)
+    merged = dd_left.merge(dd_right, on="a", how=how)
     expected = left.merge(right, on="a", how=how)
-    assert_eq(result, expected, check_index=False)
+    assert_eq(merged, expected, check_index=False)
+
+    # Check that the individual partitions have the expected shape
+    merged.map_partitions(lambda x: x, meta=merged._meta).compute()
 
 
 def test_merge_how_raises():

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1015,7 +1015,7 @@ def test_merge_empty_left_df(shuffle_method, how):
 
     result = dd_left.merge(dd_right, on="a", how=how)
     expected = left.merge(right, on="a", how=how)
-    assert_eq(result, expected)
+    assert_eq(result, expected, check_index=False)
 
 
 def test_merge_how_raises():

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1008,7 +1008,7 @@ def test_merge_empty_left_df(shuffle_method, how):
     # will involve an empty left frame.
     # https://github.com/pandas-dev/pandas/issues/9937
     left = pd.DataFrame({"a": [1, 1, 2, 2], "val": [5, 6, 7, 8]})
-    right = pd.DataFrame({"a": [2, 2, 3, 3], "val": [11, 12, 13, 14]})
+    right = pd.DataFrame({"a": [0, 0, 3, 3], "val": [11, 12, 13, 14]})
 
     dd_left = dd.from_pandas(left, npartitions=4)
     dd_right = dd.from_pandas(right, npartitions=4)


### PR DESCRIPTION
Fixes #9577. The issue over there is that when the left df in a merge is empty, pandas can give back columns in the wrong order, resulting in a meta mismatch. This just identifies that case and re-orders the columns.

- [x] Closes #9577 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
