### PR TITLE
Harden `test_repartition_npartitions`

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2142,15 +2142,14 @@ def test_repartition_on_pandas_dataframe():
 def test_repartition_npartitions(use_index, n, k, dtype, transform):
     df = pd.DataFrame(
         {"x": [1, 2, 3, 4, 5, 6] * 10, "y": list("abdabd") * 10},
-        index=pd.Series([10, 20, 30, 40, 50, 60] * 10, dtype=dtype),
+        index=pd.Series(list(range(0, 30)) * 2, dtype=dtype),
     )
     df = transform(df)
     a = dd.from_pandas(df, npartitions=n, sort=use_index)
     b = a.repartition(k)
     assert_eq(a, b)
     assert b.npartitions == k
-    parts = dask.get(b.dask, b.__dask_keys__())
-    assert all(map(len, parts))
+    assert all(map(len, b.partitions))
 
 
 @pytest.mark.parametrize("use_index", [True, False])


### PR DESCRIPTION
Adds more unique values to the index column used in `test_repartition_npartitions` to (hopefully) make the test less sensitive to numerical precision.

Motivated by [this thread](https://github.com/dask/dask/pull/9221#discussion_r945221110) (now https://github.com/dask/dask/issues/9582)