### PR TITLE
Spark compatibility with pandas extension dtypes

### DIFF
--- a/continuous_integration/scripts/run_tests.sh
+++ b/continuous_integration/scripts/run_tests.sh
@@ -11,6 +11,6 @@ if [[ $COVERAGE == 'true' ]]; then
 fi
 
 echo "py.test dask --runslow $XTRATESTARGS"
-py.test dask --runslow $XTRATESTARGS
+py.test dask/tests/test_spark_compat.py --runslow $XTRATESTARGS
 
 set +e

--- a/dask/tests/test_spark_compat.py
+++ b/dask/tests/test_spark_compat.py
@@ -92,7 +92,9 @@ def test_roundtrip_parquet_spark_to_dask_extension_dtypes(
         }
     )
     # Ensure all columns are extension dtypes
-    assert all([pd.api.types.is_extension_array_dtype(dtype) for dtype in pdf.dtypes])
+    assert all(
+        [pd.api.types.is_extension_array_dtype(dtype) for dtype in pdf.dtypes]
+    ), pdf.dtypes
 
     sdf = spark_session.createDataFrame(pdf)
     # We are not overwriting any data, but spark complains if the directory
@@ -100,8 +102,10 @@ def test_roundtrip_parquet_spark_to_dask_extension_dtypes(
     sdf.repartition(npartitions).write.parquet(tmpdir, mode="overwrite")
 
     ddf = dd.read_parquet(tmpdir, engine=engine)
-    assert all([pd.api.types.is_extension_array_dtype(dtype) for dtype in ddf.dtypes])
     assert ddf.npartitions == npartitions
+    assert all(
+        [pd.api.types.is_extension_array_dtype(dtype) for dtype in ddf.dtypes]
+    ), ddf.dtypes
     assert_eq(ddf, pdf, check_index=False)
 
 


### PR DESCRIPTION
This test demonstrates that, when Parquet datasets with extension dtypes are written with Spark, Dask isn't currently able to read in extension dtypes as expected. Instead, things get dtypes get downcasted (e.g. a column that starts out as `Float64` is read in by Dask as `float`) 