### PR TITLE
Add note about limiting thread oversubscription by default

### DIFF
--- a/docs/source/array-best-practices.rst
+++ b/docs/source/array-best-practices.rst
@@ -70,7 +70,7 @@ Avoid Oversubscribing Threads
 
    When using the ``distributed`` scheduler, the ``OMP_NUM_THREADS``,
    ``MKL_NUM_THREADS``, and ``OPENBLAS_NUM_THREADS`` environment variables
-   will all automatically be set to ``1`` when using :ref:`nanny` workers.
+   are automatically set to ``1`` when using :ref:`nanny` workers.
    This helps avoid oversubscribing threads in common cases.
 
 By default Dask will run as many concurrent tasks as you have logical cores.

--- a/docs/source/array-best-practices.rst
+++ b/docs/source/array-best-practices.rst
@@ -66,6 +66,13 @@ Note that if you provide ``chunks='auto'`` then Dask Array will look for a
 Avoid Oversubscribing Threads
 -----------------------------
 
+.. tip::
+
+   When using the ``distributed`` scheduler, the ``OMP_NUM_THREADS``,
+   ``MKL_NUM_THREADS``, and ``OPENBLAS_NUM_THREADS`` environment variables
+   will all automatically be set to ``1`` when using :ref:`nanny` workers.
+   This helps avoid oversubscribing threads in common cases.
+
 By default Dask will run as many concurrent tasks as you have logical cores.
 It assumes that each task will consume about one core.  However, many
 array-computing libraries are themselves multi-threaded, which can cause

--- a/docs/source/deploying-python-advanced.rst
+++ b/docs/source/deploying-python-advanced.rst
@@ -166,6 +166,8 @@ In this example we don't wait on ``s.finished()``, so this will terminate
 relatively quickly.  You could have called ``await s.finished()`` though if you
 wanted this to run forever.
 
+.. _nanny:
+
 Nanny
 -----
 


### PR DESCRIPTION
I suspect users interested in this topic would also find it useful to know these environment variables are set by default when using the `distributed` scheduler. This is a small follow-up to https://github.com/dask/distributed/pull/7177