### PR TITLE
Require Click 7.0+ in Dask

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -44,6 +44,7 @@ dependencies:
   # Need recent version of s3fs to support newer aiobotocore versions
   # https://github.com/dask/s3fs/issues/514
   - s3fs>=2021.8.0
+  - click
   - cloudpickle
   - crick
   - cytoolz

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -44,6 +44,7 @@ dependencies:
   # Need recent version of s3fs to support newer aiobotocore versions
   # https://github.com/dask/s3fs/issues/514
   - s3fs>=2021.8.0
+  - click
   - cloudpickle
   - crick
   - cytoolz

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -44,6 +44,7 @@ dependencies:
   # Need recent version of s3fs to support newer aiobotocore versions
   # https://github.com/dask/s3fs/issues/514
   - s3fs>=2021.8.0
+  - click
   - cloudpickle
   - crick
   - cytoolz

--- a/continuous_integration/environment-mindeps-array.yaml
+++ b/continuous_integration/environment-mindeps-array.yaml
@@ -6,7 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
-  - click=6.6
+  - click=7.0
   - cloudpickle=1.1.1
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/environment-mindeps-array.yaml
+++ b/continuous_integration/environment-mindeps-array.yaml
@@ -6,7 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
-  - click>=6.6
+  - click=6.6
   - cloudpickle=1.1.1
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/environment-mindeps-array.yaml
+++ b/continuous_integration/environment-mindeps-array.yaml
@@ -6,6 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
+  - click>=6.6
   - cloudpickle=1.1.1
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/environment-mindeps-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-dataframe.yaml
@@ -6,7 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
-  - click=6.6
+  - click=7.0
   - cloudpickle=1.1.1
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/environment-mindeps-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-dataframe.yaml
@@ -6,7 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
-  - click>=6.6
+  - click=6.6
   - cloudpickle=1.1.1
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/environment-mindeps-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-dataframe.yaml
@@ -6,6 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
+  - click>=6.6
   - cloudpickle=1.1.1
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/environment-mindeps-distributed.yaml
+++ b/continuous_integration/environment-mindeps-distributed.yaml
@@ -6,7 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
-  - click=6.6
+  - click=7.0
   - cloudpickle=1.5.0 # this is in the min from distributed
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/environment-mindeps-distributed.yaml
+++ b/continuous_integration/environment-mindeps-distributed.yaml
@@ -6,7 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
-  - click>=6.6
+  - click=6.6
   - cloudpickle=1.5.0 # this is in the min from distributed
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/environment-mindeps-distributed.yaml
+++ b/continuous_integration/environment-mindeps-distributed.yaml
@@ -6,6 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
+  - click>=6.6
   - cloudpickle=1.5.0 # this is in the min from distributed
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/environment-mindeps-non-optional.yaml
+++ b/continuous_integration/environment-mindeps-non-optional.yaml
@@ -6,7 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
-  - click=6.6
+  - click=7.0
   - cloudpickle=1.1.1
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/environment-mindeps-non-optional.yaml
+++ b/continuous_integration/environment-mindeps-non-optional.yaml
@@ -6,7 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
-  - click>=6.6
+  - click=6.6
   - cloudpickle=1.1.1
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/environment-mindeps-non-optional.yaml
+++ b/continuous_integration/environment-mindeps-non-optional.yaml
@@ -6,6 +6,7 @@ dependencies:
   - packaging=20.0
   - python=3.8
   - pyyaml>=5.3.1
+  - click>=6.6
   - cloudpickle=1.1.1
   - partd=0.3.10
   - fsspec=0.6.0

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
 
   run:
     - python >=3.8
-    - click >=6.6
+    - click >=7.0
     - cloudpickle >=1.1.1
     - fsspec >=0.6.0
     - packaging >=20.0

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
 
   run:
     - python >=3.8
+    - click >=6.6
     - cloudpickle >=1.1.1
     - fsspec >=0.6.0
     - packaging >=20.0

--- a/continuous_integration/scripts/test_imports.sh
+++ b/continuous_integration/scripts/test_imports.sh
@@ -5,7 +5,7 @@ set -o errexit
 test_import () {
     echo "Create environment: python=$PYTHON_VERSION $1"
     # Create an empty environment
-    mamba create -q -y -n test-imports -c conda-forge python=$PYTHON_VERSION packaging pyyaml fsspec toolz partd cloudpickle $1
+    mamba create -q -y -n test-imports -c conda-forge python=$PYTHON_VERSION packaging pyyaml fsspec toolz partd click cloudpickle $1
     conda activate test-imports
     if [[ $1 =~ "distributed" ]]; then
         # dask[distributed] depends on the latest version of distributed

--- a/dask/__main__.py
+++ b/dask/__main__.py
@@ -1,25 +1,7 @@
-import sys
-
-try:
-    import click
-except ImportError:
-    click = None
+from dask.cli import run_cli
 
 
 def main():
-
-    if click is None:
-        msg = (
-            "The dask command requires click to be installed.\n\n"
-            "Install with conda or pip:\n\n"
-            " conda install click\n"
-            " pip install click\n"
-        )
-        print(msg, file=sys.stderr)
-        return 1
-
-    from dask.cli import run_cli
-
     run_cli()
 
 

--- a/dask/cli.py
+++ b/dask/cli.py
@@ -1,19 +1,9 @@
 import warnings
 
+import click
+
 from dask import __version__
 from dask.compatibility import entry_points
-
-try:
-    import click
-except ImportError as e:
-    msg = (
-        "The dask.cli module requires click to be installed.\n\n"
-        "Install with conda or pip:\n\n"
-        " conda install click\n"
-        " pip install click\n"
-    )
-    raise ImportError(msg) from e
-
 
 CONTEXT_SETTINGS = {
     "help_option_names": ["-h", "--help"],

--- a/dask/tests/test_cli.py
+++ b/dask/tests/test_cli.py
@@ -40,7 +40,7 @@ def test_info_versions():
     assert table["distributed"] == distributed_version
 
 
-@click.group
+@click.group()
 def dummy_cli():
     pass
 
@@ -82,7 +82,7 @@ def test_register_command_ep():
     assert dummy_cli.commands["good"] is good_command
 
 
-@click.group
+@click.group()
 def dummy_cli_2():
     pass
 

--- a/dask/tests/test_cli.py
+++ b/dask/tests/test_cli.py
@@ -1,12 +1,10 @@
-import pytest
-
-click = pytest.importorskip("click")
-
 import importlib.metadata
 import json
 import platform
 import sys
 
+import click
+import pytest
 from click.testing import CliRunner
 
 import dask

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extras_require["test"] = [
 ]
 
 install_requires = [
-    "click >= 6.6",
+    "click >= 7.0",
     "cloudpickle >= 1.1.1",
     "fsspec >= 0.6.0",
     "packaging >= 20.0",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ extras_require["test"] = [
 ]
 
 install_requires = [
+    "click >= 6.6",
     "cloudpickle >= 1.1.1",
     "fsspec >= 0.6.0",
     "packaging >= 20.0",


### PR DESCRIPTION
Given the recent pain around the move to the new entry points ( https://github.com/dask/distributed/issues/7176 ) and discussion in the fix ( https://github.com/conda-forge/dask-core-feedstock/pull/146 ), would like to propose making Click a hard requirement in Dask.

<hr>

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
