### PR TITLE
Update nightly recipe with CLI entrypoint

### DIFF
--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -15,12 +15,13 @@ build:
   noarch: python
   string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - dask = dask.__main__:main
 
 requirements:
   host:
     - python >=3.8
     - pip
-    - setuptools
 
   run:
     - python >=3.8
@@ -36,8 +37,12 @@ test:
     - dask
   commands:
     - pip check
+    - dask docs --help
+    - dask info --help
+    - dask info versions --help
   requires:
     - pip
+    - click
 
 about:
   home: https://github.com/dask/dask/


### PR DESCRIPTION
Following up on recent work around the CLI (xref https://github.com/conda-forge/dask-core-feedstock/pull/146), this PR adds the CLI entrypoint to the nightly recipe.

cc @jakirkham 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
