### PR TITLE
Retries on read/to csv [WIP]

### DIFF
--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1785,3 +1785,46 @@ def test_select_with_include_path_column(tmpdir):
     ddf = dd.read_csv(temp_path + "*.csv", include_path_column=True)
 
     assert_eq(ddf.col1, pd.concat([df.col1] * 6))
+
+
+def test_retries_on_remote_filesystem_csv(tmpdir):
+    # Fake a remote filesystem with a cached one
+    fn = str(tmpdir)
+    remote_fn = f"simplecache://{tmpdir}"
+    storage_options = {"target_protocol": "file"}
+
+    df = pd.DataFrame({"a": range(10)})
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf.to_csv(fn)
+
+    # Check that we set retries for reading and writing to parquet when not otherwise set
+    scalar = ddf.to_csv(remote_fn, compute=False, storage_options=storage_options)
+    layer = hlg_layer(scalar.dask, "to-csv")
+    assert layer.annotations
+    assert layer.annotations["retries"] == 5
+
+    ddf2 = dd.read_csv(remote_fn, storage_options=storage_options)
+    layer = hlg_layer(ddf2.dask, "read-csv")
+    assert layer.annotations
+    assert layer.annotations["retries"] == 5
+
+    # But not for a local filesystem
+    scalar = ddf.to_csv(fn, compute=False, storage_options=storage_options)
+    layer = hlg_layer(scalar.dask, "to-csv")
+    assert not layer.annotations
+
+    ddf2 = dd.read_csv(fn, storage_options=storage_options)
+    layer = hlg_layer(ddf2.dask, "read-csv")
+    assert not layer.annotations
+
+    # And we don't overwrite existing retries
+    with dask.annotate(retries=2):
+        scalar = ddf.to_csv(remote_fn, compute=False, storage_options=storage_options)
+        layer = hlg_layer(scalar.dask, "to-csv")
+        assert layer.annotations
+        assert layer.annotations["retries"] == 2
+
+        ddf2 = dd.read_csv(remote_fn, storage_options=storage_options)
+        layer = hlg_layer(ddf2.dask, "read-csv")
+        assert layer.annotations
+        assert layer.annotations["retries"] == 2


### PR DESCRIPTION
- [x] Closes #9594
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This is a draft PR, I'm having some issues but I though I'll push it to get more eyes on it.

- I had to pass storage options to `text_blocks_to_pandas` to be able to check the filesystem. but I'm not sure this is the correct thing to do.
- I'm getting an error that I do not quite understand:
```python
>       annotations = dask.config.get("annotations", {})
E       UnboundLocalError: local variable 'dask' referenced before assignment

../csv.py:953: UnboundLocalError
```

cc: @jrbourbeau 