### PR TITLE
Resolve `importlib`-related failures in upstream CI

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -1,4 +1,6 @@
 import sys
+
+# FIXME importing importlib.metadata fails when running the entire test suite with UPSTREAM_DEV=1
 from importlib import metadata as importlib_metadata
 
 from packaging.version import parse as parse_version

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -1,5 +1,5 @@
-import importlib.metadata
 import sys
+from importlib import metadata as importlib_metadata
 
 from packaging.version import parse as parse_version
 
@@ -16,9 +16,9 @@ def entry_points(group=None):
     This compatibility utility can be removed once Python 3.10 is the minimum.
     """
     if _PY_VERSION >= parse_version("3.10"):
-        return importlib.metadata.entry_points(group=group)
+        return importlib_metadata.entry_points(group=group)
     else:
-        eps = importlib.metadata.entry_points()
+        eps = importlib_metadata.entry_points()
         if group:
             return eps.get(group, [])
         return eps

--- a/dask/tests/test_cli.py
+++ b/dask/tests/test_cli.py
@@ -2,10 +2,10 @@ import pytest
 
 click = pytest.importorskip("click")
 
-import importlib.metadata
 import json
 import platform
 import sys
+from importlib import metadata as importlib_metadata
 
 from click.testing import CliRunner
 
@@ -64,13 +64,13 @@ def good_command_2():
 def test_register_command_ep():
     from dask.cli import _register_command_ep
 
-    bad_ep = importlib.metadata.EntryPoint(
+    bad_ep = importlib_metadata.EntryPoint(
         name="bad",
         value="dask.tests.test_cli:bad_command",
         group="dask_cli",
     )
 
-    good_ep = importlib.metadata.EntryPoint(
+    good_ep = importlib_metadata.EntryPoint(
         name="good",
         value="dask.tests.test_cli:good_command",
         group="dask_cli",
@@ -92,13 +92,13 @@ def dummy_cli_2():
 def test_repeated_name_registration_warn():
     from dask.cli import _register_command_ep
 
-    one = importlib.metadata.EntryPoint(
+    one = importlib_metadata.EntryPoint(
         name="one",
         value="dask.tests.test_cli:good_command",
         group="dask_cli",
     )
 
-    two = importlib.metadata.EntryPoint(
+    two = importlib_metadata.EntryPoint(
         name="two",
         value="dask.tests.test_cli:good_command_2",
         group="dask_cli",

--- a/dask/tests/test_cli.py
+++ b/dask/tests/test_cli.py
@@ -5,6 +5,8 @@ click = pytest.importorskip("click")
 import json
 import platform
 import sys
+
+# FIXME importing importlib.metadata fails when running the entire test suite with UPSTREAM_DEV=1
 from importlib import metadata as importlib_metadata
 
 from click.testing import CliRunner


### PR DESCRIPTION
For some reason, importing `importlib.metadata` was causing failures when running through the entire test suite with `UPSTREAM_DEV=1` (xref https://github.com/dask/dask/issues/9204#issuecomment-1293649051).

It was difficult to track down what tests in particular caused this issue, so opted to switch to `from importlib import metadata`, which still seems to work.

cc @jrbourbeau 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
