### PR TITLE
Fix read_csv behavior for `header=0` and `names`

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -116,7 +116,7 @@ class CSVFunctionWrapper(DataFrameIOFunction):
         write_header = False
         rest_kwargs = self.kwargs.copy()
         if not is_first:
-            if "names" not in rest_kwargs:
+            if rest_kwargs.get("names", None) is None:
                 write_header = True
             rest_kwargs.pop("skiprows", None)
             if rest_kwargs.get("header", 0) is not None:

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -116,7 +116,8 @@ class CSVFunctionWrapper(DataFrameIOFunction):
         write_header = False
         rest_kwargs = self.kwargs.copy()
         if not is_first:
-            write_header = True
+            if "names" not in rest_kwargs:
+                write_header = True
             rest_kwargs.pop("skiprows", None)
             if rest_kwargs.get("header", 0) is not None:
                 rest_kwargs.pop("header", None)

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1787,7 +1787,8 @@ def test_select_with_include_path_column(tmpdir):
     assert_eq(ddf.col1, pd.concat([df.col1] * 6))
 
 
-def test_names_with_header_0(tmpdir):
+@pytest.mark.parametrize("use_names", [True, False])
+def test_names_with_header_0(tmpdir, use_names):
     # This test sets `blocksize` so that we will
     # get two partitions in `dd.read_csv`. We are
     # testing that `header=0` results in the expected
@@ -1805,16 +1806,20 @@ def test_names_with_header_0(tmpdir):
     """
     )
 
+    if use_names:
+        names = ["city", "date", "sales"]
+        usecols = ["city", "sales"]
+    else:
+        names = usecols = None
+
     path = os.path.join(str(tmpdir), "input.csv")
     pd.read_csv(csv, header=None).to_csv(path, index=False, header=False)
-    df = pd.read_csv(
-        path, header=0, names=["city", "date", "sales"], usecols=["city", "sales"]
-    )
+    df = pd.read_csv(path, header=0, names=names, usecols=usecols)
     ddf = dd.read_csv(
         path,
         header=0,
-        names=["city", "date", "sales"],
-        usecols=["city", "sales"],
+        names=names,
+        usecols=usecols,
         blocksize=60,
     )
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1,7 +1,7 @@
 import gzip
 import os
 import warnings
-from io import BytesIO
+from io import BytesIO, StringIO
 from unittest import mock
 
 import pytest
@@ -1785,3 +1785,38 @@ def test_select_with_include_path_column(tmpdir):
     ddf = dd.read_csv(temp_path + "*.csv", include_path_column=True)
 
     assert_eq(ddf.col1, pd.concat([df.col1] * 6))
+
+
+def test_names_with_header_0(tmpdir):
+    # This test sets `blocksize` so that we will
+    # get two partitions in `dd.read_csv`. We are
+    # testing that `header=0` results in the expected
+    # behavior when `names` is also specified.
+    # See: https://github.com/dask/dask/issues/9610
+
+    csv = StringIO(
+        """\
+    city1,1992-09-13,10
+    city2,1992-09-13,14
+    city3,1992-09-13,98
+    city4,1992-09-13,13
+    city5,1992-09-13,45
+    city6,1992-09-13,64
+    """
+    )
+
+    path = os.path.join(str(tmpdir), "input.csv")
+    pd.read_csv(csv, header=None).to_csv(path, index=False, header=False)
+    df = pd.read_csv(
+        path, header=0, names=["city", "date", "sales"], usecols=["city", "sales"]
+    )
+    ddf = dd.read_csv(
+        path,
+        header=0,
+        names=["city", "date", "sales"],
+        usecols=["city", "sales"],
+        blocksize=60,
+    )
+
+    # Result should only leave out 0th row
+    assert_eq(df, ddf, check_index=False)


### PR DESCRIPTION
This PR modifies the behavior of `read_csv` to avoid prepending the header to byte-ranges when `names` is specified.

- [x] Closes #9610
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
