### PR TITLE
Generalize `from_dict` implementation to allow usage from other backends

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6037,7 +6037,9 @@ class DataFrame(_Frame):
         )
 
     @classmethod
-    def from_dict(cls, data, *, npartitions, orient="columns", dtype=None, columns=None):
+    def from_dict(
+        cls, data, *, npartitions, orient="columns", dtype=None, columns=None
+    ):
         """
         Construct a Dask DataFrame from a Python Dictionary
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6036,8 +6036,8 @@ class DataFrame(_Frame):
             and key in self.columns
         )
 
-    @staticmethod
-    def from_dict(data, *, npartitions, orient="columns", dtype=None, columns=None):
+    @classmethod
+    def from_dict(cls, data, *, npartitions, orient="columns", dtype=None, columns=None):
         """
         Construct a Dask DataFrame from a Python Dictionary
 
@@ -6053,6 +6053,7 @@ class DataFrame(_Frame):
             orient=orient,
             dtype=dtype,
             columns=columns,
+            constructor=cls._partition_type,
         )
 
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -306,7 +306,14 @@ def from_pandas(
 
 
 @dataframe_creation_dispatch.register_inplace("pandas")
-def from_dict(data, npartitions, orient="columns", dtype=None, columns=None, constructor=pd.DataFrame):
+def from_dict(
+    data,
+    npartitions,
+    orient="columns",
+    dtype=None,
+    columns=None,
+    constructor=pd.DataFrame,
+):
     """
     Construct a Dask DataFrame from a Python Dictionary
 

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -306,7 +306,7 @@ def from_pandas(
 
 
 @dataframe_creation_dispatch.register_inplace("pandas")
-def from_dict(data, npartitions, orient="columns", dtype=None, columns=None):
+def from_dict(data, npartitions, orient="columns", dtype=None, columns=None, constructor=pd.DataFrame):
     """
     Construct a Dask DataFrame from a Python Dictionary
 
@@ -329,6 +329,8 @@ def from_dict(data, npartitions, orient="columns", dtype=None, columns=None):
     columns: string, optional
         Column labels to use when ``orient='index'``. Raises a ValueError
         if used with ``orient='columns'`` or ``orient='tight'``.
+    constructor: class, default pd.DataFrame
+        Class with which ``from_dict`` should be called with.
 
     Examples
     --------
@@ -344,7 +346,7 @@ def from_dict(data, npartitions, orient="columns", dtype=None, columns=None):
         )
 
     return from_pandas(
-        pd.DataFrame.from_dict(data, orient, dtype, columns),
+        constructor.from_dict(data, orient, dtype, columns),
         npartitions,
     )
 

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -6,6 +6,7 @@ import pytest
 
 import dask.array as da
 import dask.dataframe as dd
+from dask import config
 from dask.blockwise import Blockwise
 from dask.dataframe._compat import tm
 from dask.dataframe.io.io import _meta_from_array
@@ -982,7 +983,7 @@ def test_from_dict_backends(backend):
         # Check dd.from_dict API
         got = dd.from_dict(data, npartitions=2)
         assert_eq(expected, got)
-        
+
         # Check from_dict classmethod
         got_classmethod = got.from_dict(data, npartitions=2)
         assert_eq(expected, got_classmethod)

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -969,3 +969,13 @@ def test_from_map_column_projection():
     assert_eq(ddf["A"], expect["A"])
     assert set(projected) == {"A"}
     assert_eq(ddf, expect)
+
+
+@pytest.mark.gpu
+def test_dataframe_from_dict():
+    cudf = pytest.importorskip("cudf")
+    dask_cudf = pytest.importorskip("dask_cudf")
+    data = {"a": cudf.Series([1, 2, 3, 4]), "B": cudf.Series([10, 11, 12, 13])}
+    expected = cudf.DataFrame(data)
+    actual = dask_cudf.DataFrame.from_dict(data, npartitions=2)
+    assert_eq(expected, actual.compute())


### PR DESCRIPTION
This PR generalizes `from_dict` implementation such that other backends(`cudf`, etc) can re-use the same API without re-implementing it.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

