### PR TITLE
Generalize array checking and remove `pd.Index` call in `_get_partitions`

### DIFF
--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -193,7 +193,6 @@ class _LocIndexer(_IndexerBase):
         name = "loc-%s" % tokenize(iindexer, self.obj)
         part = self._get_partitions(iindexer)
 
-        breakpoint()
         if iindexer < self.obj.divisions[0] or iindexer > self.obj.divisions[-1]:
             raise KeyError("the label [%s] is not in the index" % str(iindexer))
 

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -13,6 +13,7 @@ from dask.dataframe._compat import PANDAS_GT_130
 from dask.dataframe.core import Series, new_dd_object
 from dask.dataframe.utils import is_index_like, is_series_like, meta_nonempty
 from dask.highlevelgraph import HighLevelGraph
+from dask.utils import is_arraylike
 
 
 class _IndexerBase:
@@ -209,7 +210,7 @@ class _LocIndexer(_IndexerBase):
         return new_dd_object(graph, name, meta=meta, divisions=[iindexer, iindexer])
 
     def _get_partitions(self, keys):
-        if isinstance(keys, (list, np.ndarray)):
+        if isinstance(keys, (list, np.ndarray)) or is_arraylike(keys):
             return _partitions_of_index_values(self.obj.divisions, keys)
         else:
             # element
@@ -343,7 +344,6 @@ def _partitions_of_index_values(divisions, values):
         raise ValueError(msg)
 
     results = defaultdict(list)
-    values = pd.Index(values, dtype=object)
     for val in values:
         i = bisect.bisect_right(divisions, val)
         div = min(len(divisions) - 2, max(0, i - 1))

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -117,10 +117,10 @@ class _LocIndexer(_IndexerBase):
 
             if isinstance(iindexer, slice):
                 return self._loc_slice(iindexer, cindexer)
-            elif isinstance(iindexer, (list, np.ndarray)):
-                return self._loc_list(iindexer, cindexer)
             elif is_series_like(iindexer) and not is_bool_dtype(iindexer.dtype):
                 return self._loc_list(iindexer.values, cindexer)
+            elif isinstance(iindexer, list) or is_arraylike(iindexer):
+                return self._loc_list(iindexer, cindexer)
             else:
                 # element should raise KeyError
                 return self._loc_element(iindexer, cindexer)
@@ -193,6 +193,7 @@ class _LocIndexer(_IndexerBase):
         name = "loc-%s" % tokenize(iindexer, self.obj)
         part = self._get_partitions(iindexer)
 
+        breakpoint()
         if iindexer < self.obj.divisions[0] or iindexer > self.obj.divisions[-1]:
             raise KeyError("the label [%s] is not in the index" % str(iindexer))
 
@@ -210,7 +211,7 @@ class _LocIndexer(_IndexerBase):
         return new_dd_object(graph, name, meta=meta, divisions=[iindexer, iindexer])
 
     def _get_partitions(self, keys):
-        if isinstance(keys, (list, np.ndarray)) or is_arraylike(keys):
+        if isinstance(keys, list) or is_arraylike(keys):
             return _partitions_of_index_values(self.obj.divisions, keys)
         else:
             # element

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -724,3 +724,18 @@ def test_deterministic_hashing_dataframe():
 
     ddf2 = dask_df.iloc[:, [0, 2]]
     assert tokenize(ddf1) != tokenize(ddf2)
+
+
+@pytest.mark.gpu
+def test_gpu_loc():
+    cudf = pytest.importorskip("cudf")
+    cupy = pytest.importorskip("cupy")
+
+    index = [1, 5, 10, 11, 12, 100, 200, 300]
+    df = cudf.DataFrame({"a": range(8), "index": index}).set_index("index")
+    ddf = dd.from_pandas(df, npartitions=3)
+    cdf_index = cudf.Series([1, 100, 300])
+    cupy_index = cupy.array([1, 100, 300])
+
+    assert_eq(ddf.loc[cdf_index], df.loc[cupy_index])
+    assert_eq(ddf.loc[cupy_index], df.loc[cupy_index])


### PR DESCRIPTION
This PR does two things:
1) Generalizes the array checking using is_arraylike as well as the list check 
2) Removes what I _think_ is an unnecessary `pd.Index` call . 

This fixes an issue for dask-cudf where users want to index a Dask Dataframe with a cudf/cupy object:
> df.loc[cudf.Series([0,10,50], dtype=np.int32)]

The `pd.Index` call is quite old (https://github.com/dask/dask/pull/1913) and was originally written to handle indexing with lists.  Locally I ran  `dask/dataframe/tests/test_indexing.py` and all tests still pass as well as verifying manually that lists are still supported

- [x] Closes #[xxxx](https://github.com/rapidsai/cudf/issues/11877)
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @VibhuJawa @rjzamora 
