### PR TITLE
Fix link to partitions docs in `read_parquet` docstring

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -261,7 +261,7 @@ def read_parquet(
         metadata. Note that ``calculate_divisions=True`` may be extremely slow
         when no global ``_metadata`` file is present, especially when reading
         from remote storage. Set this to ``True`` only when known divisions
-        are needed for your workload (see :ref:`dataframe-design-partitions).
+        are needed for your workload (see :ref:`dataframe-design-partitions`).
     ignore_metadata_file : bool, default False
         Whether to ignore the global ``_metadata`` file (when one is present).
         If ``True``, or if the global ``_metadata`` file is missing, the parquet


### PR DESCRIPTION
Fix link in dask.dataframe.read_parquet function docstring

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
