### PR TITLE
Add `pre-commit` hook to catch `breakpoint()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: end-of-file-fixer
+      - id: debug-statements
   - repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1
     hooks:


### PR DESCRIPTION
Sometimes I forget to remove `breakpoint()`s I add when debugging locally. This PR adds a pre-commit hook which will check for `breakpoint()` calls in Python code, which will make sure folks don't accidentally commit code with `breakpoint()`s in them