### PR TITLE
Pin `pyyaml` version in mindeps testing

### DIFF
--- a/continuous_integration/environment-mindeps-array.yaml
+++ b/continuous_integration/environment-mindeps-array.yaml
@@ -5,7 +5,7 @@ dependencies:
   # required dependencies
   - packaging=20.0
   - python=3.8
-  - pyyaml>=5.3.1
+  - pyyaml=5.3.1
   - click=7.0
   - cloudpickle=1.1.1
   - partd=0.3.10

--- a/continuous_integration/environment-mindeps-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-dataframe.yaml
@@ -5,7 +5,7 @@ dependencies:
   # required dependencies
   - packaging=20.0
   - python=3.8
-  - pyyaml>=5.3.1
+  - pyyaml=5.3.1
   - click=7.0
   - cloudpickle=1.1.1
   - partd=0.3.10

--- a/continuous_integration/environment-mindeps-distributed.yaml
+++ b/continuous_integration/environment-mindeps-distributed.yaml
@@ -5,7 +5,7 @@ dependencies:
   # required dependencies
   - packaging=20.0
   - python=3.8
-  - pyyaml>=5.3.1
+  - pyyaml=5.3.1
   - click=7.0
   - cloudpickle=1.5.0 # this is in the min from distributed
   - partd=0.3.10

--- a/continuous_integration/environment-mindeps-non-optional.yaml
+++ b/continuous_integration/environment-mindeps-non-optional.yaml
@@ -5,7 +5,7 @@ dependencies:
   # required dependencies
   - packaging=20.0
   - python=3.8
-  - pyyaml>=5.3.1
+  - pyyaml=5.3.1
   - click=7.0
   - cloudpickle=1.1.1
   - partd=0.3.10


### PR DESCRIPTION
It looks like when a minimum version was introduced to `pyyaml` in https://github.com/dask/dask/pull/8545, we left the pinning loose in the mindeps environment files, meaning that we end up pulling a newer version in CI.

This PR pins `pyyaml` in the mindeps files so that we can verify that 5.3.1 is still the working minimum version.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
