### PR TITLE
Fix groupby-aggregation when grouping on an index by name

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1984,7 +1984,14 @@ class _GroupBy:
         # aggregation involves implicit column projection.
         # This makes it possible for the column-projection
         # to be pushed into the IO layer
-        _obj = self.obj[list(column_projection)] if column_projection else self.obj
+        _obj = (
+            self.obj[
+                # Make sure we only include column names
+                list(column_projection.intersection(self.obj.columns))
+            ]
+            if column_projection
+            else self.obj
+        )
 
         if not isinstance(self.by, list):
             chunk_args = [_obj, self.by]

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -296,6 +296,11 @@ def test_groupby_on_index(scheduler):
     pdf2 = pdf.set_index("a")
     assert_eq(ddf.groupby("a").b.mean(), ddf2.groupby(ddf2.index).b.mean())
 
+    # Check column projection for `groupby().agg`
+    agg = ddf.groupby("a").agg({"b": "mean"})
+    assert_eq(ddf.groupby("a").b.mean(), agg.b)
+    assert hlg_layer(agg.dask, "getitem")
+
     def func(df):
         return df.assign(b=df.b - df.b.mean())
 


### PR DESCRIPTION
Simple fix for groupby-aggregation column-projection bug (leave out index names in explicit `getitem` operation).

- [x] Closes #9643
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
