### PR TITLE
Use `conda-incubator/setup-miniconda@v2.2.0`

### DIFF
--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-variant: Mambaforge
           use-mamba: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
           distribution: "zulu"
           java-version: "11"
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest


### PR DESCRIPTION
Pins to the latest `conda-incubator/setup-miniconda`. As Dependabot already checks for GH Actions updates ( https://github.com/dask/dask/pull/9542 ), updates to this action version can be handled automatically.

xref: https://github.com/dask/distributed/pull/7310

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
