### PR TITLE
Enable column projection for groupby slicing

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1251,11 +1251,10 @@ class _GroupBy:
         # Check if we can project columns
         projection = None
         if isinstance(self._slice, (str, list)):
-            projection = list(
-                set(by_)
-                .union({self._slice} if isinstance(self._slice, str) else self._slice)
-                .intersection(df.columns)
+            projection = set(by_).union(
+                {self._slice} if isinstance(self._slice, str) else self._slice
             )
+            projection = [c for c in df.columns if c in projection]
 
         assert isinstance(df, (DataFrame, Series))
         self.group_keys = group_keys

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1250,7 +1250,7 @@ class _GroupBy:
 
         # Check if we can project columns
         projection = None
-        if isinstance(self._slice, (str, list)):
+        if isinstance(self._slice, (str, list, tuple)):
             projection = set(by_).union(
                 {self._slice} if isinstance(self._slice, str) else self._slice
             )

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3073,10 +3073,25 @@ def test_groupby_None_split_out_warns():
 
 
 @pytest.mark.parametrize("by", ["key1", ["key1", "key2"]])
-@pytest.mark.parametrize("slice_key", ["value", ["value"], ("value",)])
+@pytest.mark.parametrize(
+    "slice_key",
+    [
+        3,
+        "value",
+        ["value"],
+        ("value",),
+        pd.Index(["value"]),
+        pd.Series(["value"]),
+    ],
+)
 def test_groupby_slice_getitem(by, slice_key):
     pdf = pd.DataFrame(
-        {"key1": ["a", "b", "a"], "key2": ["c", "c", "c"], "value": [1, 2, 3]}
+        {
+            "key1": ["a", "b", "a"],
+            "key2": ["c", "c", "c"],
+            "value": [1, 2, 3],
+            3: [1, 2, 3],
+        }
     )
     ddf = dd.from_pandas(pdf, npartitions=3)
     expect = pdf.groupby(by)[slice_key].count()

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3073,7 +3073,7 @@ def test_groupby_None_split_out_warns():
 
 
 @pytest.mark.parametrize("by", ["key1", ["key1", "key2"]])
-@pytest.mark.parametrize("slice_key", ["value", ["value"]])
+@pytest.mark.parametrize("slice_key", ["value", ["value"], ("value",)])
 def test_groupby_slice_getitem(by, slice_key):
     pdf = pd.DataFrame(
         {"key1": ["a", "b", "a"], "key2": ["c", "c", "c"], "value": [1, 2, 3]}

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3070,3 +3070,19 @@ def test_groupby_None_split_out_warns():
     ddf = dd.from_pandas(df, npartitions=1)
     with pytest.warns(FutureWarning, match="split_out=None"):
         ddf.groupby("a").agg({"b": "max"}, split_out=None)
+
+
+@pytest.mark.parametrize("by", ["key1", ["key1", "key2"]])
+@pytest.mark.parametrize("slice_key", ["value", ["value"]])
+def test_groupby_slice_getitem(by, slice_key):
+    pdf = pd.DataFrame(
+        {"key1": ["a", "b", "a"], "key2": ["c", "c", "c"], "value": [1, 2, 3]}
+    )
+    ddf = dd.from_pandas(pdf, npartitions=3)
+    expect = pdf.groupby(by)[slice_key].mean()
+    got = ddf.groupby(by)[slice_key].mean()
+
+    # We should have a getitem layer, enabling
+    # column projection after read_parquet etc
+    assert hlg_layer(got.dask, "getitem")
+    assert_eq(expect, got)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3079,8 +3079,8 @@ def test_groupby_slice_getitem(by, slice_key):
         {"key1": ["a", "b", "a"], "key2": ["c", "c", "c"], "value": [1, 2, 3]}
     )
     ddf = dd.from_pandas(pdf, npartitions=3)
-    expect = pdf.groupby(by)[slice_key].mean()
-    got = ddf.groupby(by)[slice_key].mean()
+    expect = pdf.groupby(by)[slice_key].count()
+    got = ddf.groupby(by)[slice_key].count()
 
     # We should have a getitem layer, enabling
     # column projection after read_parquet etc


### PR DESCRIPTION
After https://github.com/dask/dask/pull/9442, dask will insert a `getitem` operation to enable column projection for operations like `groupby().agg`. As pointed out in [this external commit](https://github.com/EthanRosenthal/medium-data-bakeoff/commit/6b7452e0d4d17c98162f7abdc200307ba6b0ad62), dask does not yet capture a simple `groupby().[<slice>]` case.

This PR simply adds a `getitem` operation for groupby slicing.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
