### PR TITLE
Use `pyarrow` S3 file system at read time for arrow parquet engine

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -483,6 +483,7 @@ def read_parquet(
         ignore_metadata_file=ignore_metadata_file,
         metadata_task_size=metadata_task_size,
         parquet_file_extension=parquet_file_extension,
+        storage_options=storage_options,
         **kwargs,
     )
 

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -828,6 +828,7 @@ class FastParquetEngine(Engine):
         ignore_metadata_file=False,
         metadata_task_size=None,
         parquet_file_extension=None,
+        storage_options=None,
         **kwargs,
     ):
 


### PR DESCRIPTION
As discussed in https://github.com/dask/dask/issues/9619, there seem to be some performance benefits of using `pyarrow.fs.S3FileSystem` to open s3-based Parquet files for data ingest. This PR proposes a simple change to the defaults `open_file_options` contents for the "arrow" `read_parquet` engine.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
