### PR TITLE
`xfail` `ttest_1samp` for upstream `scipy`

### DIFF
--- a/dask/array/tests/test_stats.py
+++ b/dask/array/tests/test_stats.py
@@ -1,6 +1,7 @@
 import warnings
 
 import pytest
+from packaging.version import parse as parse_version
 
 scipy = pytest.importorskip("scipy")
 import numpy as np
@@ -67,7 +68,16 @@ def test_one(kind):
     [
         ("ttest_ind", {}),
         ("ttest_ind", {"equal_var": False}),
-        ("ttest_1samp", {}),
+        pytest.param(
+            "ttest_1samp",
+            {},
+            marks=pytest.mark.xfail(
+                # NOTE: using nested `parse_version` calls here to handle night scipy releases
+                parse_version(parse_version(scipy.__version__).base_version)
+                >= parse_version("1.10.0"),
+                reason="https://github.com/dask/dask/issues/9499",
+            ),
+        ),
         ("ttest_rel", {}),
         ("chisquare", {}),
         ("power_divergence", {}),


### PR DESCRIPTION
This PR proposes we `xfail` `dask/array/tests/test_stats.py::test_two[ttest_1samp-kwargs2]` for upstream versions of `scipy`, which is a known failure (xref https://github.com/dask/dask/issues/9499). This is so we can have a "passing" upstream build and get pinged when a new, yet unknown failure crops up. 

cc @charlesbluca @ncclementi 