### PR TITLE
Update `ga-yaml-parser` step in gpuCI updating workflow 

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -1,7 +1,6 @@
 name: Check for gpuCI updates
 
 on:
-  pull_request:
   schedule:
     - cron: "0 0 * * *" # Daily “At 00:00” UTC
   workflow_dispatch:
@@ -56,7 +55,7 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
-        if: ${{ env.UCX_PY_VER != env.NEW_UCX_PY_VER && github.event_name != 'pull_request' }}  # make sure new ucx-py nightlies are available
+        if: ${{ env.UCX_PY_VER != env.NEW_UCX_PY_VER }}  # make sure new ucx-py nightlies are available
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -1,6 +1,7 @@
 name: Check for gpuCI updates
 
 on:
+  pull_request:
   schedule:
     - cron: "0 0 * * *" # Daily “At 00:00” UTC
   workflow_dispatch:
@@ -14,6 +15,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
 
       - name: Parse current axis YAML
+        id: rapids_current
         uses: the-coding-turtle/ga-yaml-parser@v0.1.2
         with:
           file: continuous_integration/gpuci/axis.yaml
@@ -39,8 +41,8 @@ jobs:
           FULL_RAPIDS_VER: ${{ steps.cudf_latest.outputs.version }}
           FULL_UCX_PY_VER: ${{ steps.ucx_py_latest.outputs.version }}
         run: |
-          echo RAPIDS_VER=$RAPIDS_VER_0 >> $GITHUB_ENV
-          echo UCX_PY_VER=$(curl -sL https://version.gpuci.io/rapids/$RAPIDS_VER_0) >> $GITHUB_ENV
+          echo RAPIDS_VER=${{ steps.rapids_current.outputs.RAPIDS_VER_0 }} >> $GITHUB_ENV
+          echo UCX_PY_VER=$(curl -sL https://version.gpuci.io/rapids/${{ steps.rapids_current.outputs.RAPIDS_VER_0 }}) >> $GITHUB_ENV
           echo NEW_RAPIDS_VER=${FULL_RAPIDS_VER::-10} >> $GITHUB_ENV
           echo NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-10} >> $GITHUB_ENV
 
@@ -54,7 +56,7 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
-        if: ${{ env.UCX_PY_VER != env.NEW_UCX_PY_VER }}  # make sure new ucx-py nightlies are available
+        if: ${{ env.UCX_PY_VER != env.NEW_UCX_PY_VER && github.event_name != 'pull_request' }}  # make sure new ucx-py nightlies are available
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true


### PR DESCRIPTION
Looks like the auto-bump of `ga-yaml-parser` in https://github.com/dask/dask/pull/9553 changed the behavior of the action, making it so we haven't been running the gpuCI updating workflow in a while; this PR makes modifications that should unblock it.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
