### PR TITLE
Improve error message for failed backend dispatch call

### DIFF
--- a/dask/backends.py
+++ b/dask/backends.py
@@ -126,7 +126,7 @@ class CreationDispatch(Generic[BackendEntrypointType]):
                 except Exception as e:
                     raise RuntimeError(
                         f"An error occurred while calling the {funcname(func)} "
-                        f"method registered to the {backend} backend.\n"
+                        f"method registered to the {self.backend} backend.\n"
                         f"Original Message: {e}"
                     ) from e
 

--- a/dask/backends.py
+++ b/dask/backends.py
@@ -122,8 +122,14 @@ class CreationDispatch(Generic[BackendEntrypointType]):
                 try:
                     return getattr(self, dispatch_name)(*args, **kwargs)
                 except Exception as e:
+                    fullname = ".".join(
+                        [
+                            getattr(self, dispatch_name).__module__,
+                            getattr(self, dispatch_name).__qualname__,
+                        ]
+                    )
                     raise type(e)(
-                        f"Dispatch call failed in {getattr(self, dispatch_name)}\n"
+                        f"Backend dispatch to {fullname} failed.\n"
                         f"Original Message: {e}"
                     )
 

--- a/dask/backends.py
+++ b/dask/backends.py
@@ -119,7 +119,13 @@ class CreationDispatch(Generic[BackendEntrypointType]):
 
             @wraps(fn)
             def wrapper(*args, **kwargs):
-                return getattr(self, dispatch_name)(*args, **kwargs)
+                try:
+                    return getattr(self, dispatch_name)(*args, **kwargs)
+                except Exception as e:
+                    raise type(e)(
+                        f"Dispatch call failed in {getattr(self, dispatch_name)}\n"
+                        f"Original Message: {e}"
+                    )
 
             wrapper.__name__ = dispatch_name
             return wrapper

--- a/dask/backends.py
+++ b/dask/backends.py
@@ -124,7 +124,7 @@ class CreationDispatch(Generic[BackendEntrypointType]):
                 try:
                     return func(*args, **kwargs)
                 except Exception as e:
-                    raise RuntimeError(
+                    raise type(e)(
                         f"An error occurred while calling the {funcname(func)} "
                         f"method registered to the {self.backend} backend.\n"
                         f"Original Message: {e}"

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -987,13 +987,3 @@ def test_from_dict_backends(backend):
         # Check from_dict classmethod
         got_classmethod = got.from_dict(data, npartitions=2)
         assert_eq(expected, got_classmethod)
-
-        # Check that passing unsupported kwargs results
-        # in a reasonable error message
-        funcname = (
-            "dask_cudf.backends.CudfBackendEntrypoint.from_dict"
-            if backend == "cudf"
-            else "dask.dataframe.io.io.from_dict"
-        )
-        with pytest.raises(TypeError, match=f"dispatch to {funcname} failed"):
-            dd.from_dict(data, npartitions=2, unsupported_kwarg=True)

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -987,3 +987,8 @@ def test_from_dict_backends(backend):
         # Check from_dict classmethod
         got_classmethod = got.from_dict(data, npartitions=2)
         assert_eq(expected, got_classmethod)
+
+        # Check that passing unsupported kwargs results
+        # in a reasonable error message
+        with pytest.raises(TypeError, match="Dispatch call failed in"):
+            dd.from_dict(data, npartitions=2, unsupported_kwarg=True)

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -990,5 +990,10 @@ def test_from_dict_backends(backend):
 
         # Check that passing unsupported kwargs results
         # in a reasonable error message
-        with pytest.raises(TypeError, match="Dispatch call failed in"):
+        funcname = (
+            "dask_cudf.backends.CudfBackendEntrypoint.from_dict"
+            if backend == "cudf"
+            else "dask.dataframe.io.io.from_dict"
+        )
+        with pytest.raises(TypeError, match=f"dispatch to {funcname} failed"):
             dd.from_dict(data, npartitions=2, unsupported_kwarg=True)

--- a/dask/tests/test_backends.py
+++ b/dask/tests/test_backends.py
@@ -1,0 +1,20 @@
+import pytest
+
+import dask
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize("backend", ["pandas", "cudf"])
+def test_CreationDispatch_error_informative_message(backend):
+    # Check that an informative error is emitted when a backend dispatch
+    # method fails
+    pytest.importorskip(backend)
+    dd = pytest.importorskip("dask.dataframe")
+    data = {"a": [1, 2, 3, 4], "B": [10, 11, 12, 13]}
+    with dask.config.set({"dataframe.backend": backend}):
+        with pytest.raises(RuntimeError) as excinfo:
+            dd.from_dict(data, npartitions=2, unsupported_kwarg=True)
+
+        msg = str(excinfo.value)
+        assert "error occurred while calling the from_dict method" in msg
+        assert backend in msg

--- a/dask/tests/test_backends.py
+++ b/dask/tests/test_backends.py
@@ -12,7 +12,7 @@ def test_CreationDispatch_error_informative_message(backend):
     dd = pytest.importorskip("dask.dataframe")
     data = {"a": [1, 2, 3, 4], "B": [10, 11, 12, 13]}
     with dask.config.set({"dataframe.backend": backend}):
-        with pytest.raises(RuntimeError) as excinfo:
+        with pytest.raises(TypeError) as excinfo:
             dd.from_dict(data, npartitions=2, unsupported_kwarg=True)
 
         msg = str(excinfo.value)


### PR DESCRIPTION
Minor change to improve error message for cases like https://github.com/dask/dask/issues/9676

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
