### PR TITLE
Disable dashboard in `test_map_partitions_df_input`

### DIFF
--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -698,7 +698,8 @@ def test_map_partitions_df_input():
         # elevated to errors until `bokeh=3` is fully supported.
         # See https://github.com/dask/dask/issues/9686 and
         # https://github.com/dask/distributed/issues/7173 for details.
-        dashboard_address=None,
+        dashboard_address=":0",
+        scheduler_kwargs={"dashboard": False},
         asynchronous=False,
         n_workers=1,
         nthreads=1,

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -694,7 +694,11 @@ def test_map_partitions_df_input():
 
     with distributed.LocalCluster(
         scheduler_port=0,
-        dashboard_address=":0",
+        # Explicitly disabling dashboard to prevent related warnings being
+        # elevated to errors until `bokeh=3` is fully supported.
+        # See https://github.com/dask/dask/issues/9686 and
+        # https://github.com/dask/distributed/issues/7173 for details.
+        dashboard_address=None,
         asynchronous=False,
         n_workers=1,
         nthreads=1,


### PR DESCRIPTION
Currently this warning

```python
E       UserWarning:
E       Dask needs bokeh >= 2.4.2, < 3 for the dashboard.
E       You have bokeh==3.0.2.
E       Continuing without the dashboard.
```

is being elevated to an error. This PR suggests we just disable the dashboard for this test as it's not relevant to the content of this test. 

Closes https://github.com/dask/dask/issues/9686