### PR TITLE
Fix `da.fft.fft` for array-like inputs

### DIFF
--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     scipy = None
 
+from dask.array.core import asarray
 from dask.array.core import concatenate as _concatenate
 from dask.array.creation import arange as _arange
 from dask.utils import derived_from, skip_doctest
@@ -154,6 +155,7 @@ def fft_wrap(fft_func, kind=None, dtype=None):
         raise ValueError("Given unknown `kind` %s." % kind)
 
     def func(a, s=None, axes=None):
+        a = asarray(a)
         if axes is None:
             if kind.endswith("2"):
                 axes = (-2, -1)

--- a/dask/array/tests/test_xarray.py
+++ b/dask/array/tests/test_xarray.py
@@ -35,3 +35,13 @@ def test_asarray_xarray_intersphinx_workaround():
         assert_eq(y, y)
     finally:
         xr.DataArray.__module__ = module
+
+
+def test_fft():
+    # Regression test for https://github.com/dask/dask/issues/9679
+    coord = da.arange(8, chunks=-1)
+    data = da.random.random((8, 8), chunks=-1) + 1
+    x = xr.DataArray(data, coords={"x": coord, "y": coord}, dims=["x", "y"])
+    result = da.fft.fft(x)
+    expected = da.fft.fft(x.data)
+    assert_eq(result, expected)


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/9679

cc @ncclementi 