### PR TITLE
Update flake8-bugbear with 'upadup'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         additional_dependencies:
           # NOTE: autoupdate does not pick up flake8-bugbear since it is a transitive
           #  dependency. Make sure to update flake8-bugbear manually on a regular basis.
-          - flake8-bugbear==22.8.23
+          - flake8-bugbear==22.10.27
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -17,7 +17,7 @@ def keepdims_wrapper(a_callable):
 
     @wraps(a_callable)
     def keepdims_wrapped_callable(x, axis=None, keepdims=None, *args, **kwargs):
-        r = a_callable(x, axis=axis, *args, **kwargs)
+        r = a_callable(x, axis=axis, *args, **kwargs)  # noqa: B026
 
         if not keepdims:
             return r

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -135,7 +135,9 @@ def _broadcast_trick_inner(func, shape, meta=(), *args, **kwargs):
     # cupy-specific hack. numpy is happy with hardcoded shape=().
     null_shape = () if shape == () else 1
 
-    return np.broadcast_to(func(meta, shape=null_shape, *args, **kwargs), shape)
+    return np.broadcast_to(
+        func(meta, shape=null_shape, *args, **kwargs), shape  # noqa: B026
+    )
 
 
 def broadcast_trick(func):
@@ -220,7 +222,7 @@ def full(shape, fill_value, *args, **kwargs):
             kwargs["dtype"] = fill_value.dtype
         else:
             kwargs["dtype"] = type(fill_value)
-    return _full(shape=shape, fill_value=fill_value, *args, **kwargs)
+    return _full(shape=shape, fill_value=fill_value, *args, **kwargs)  # noqa: B026
 
 
 def full_like(a, fill_value, *args, **kwargs):
@@ -231,7 +233,7 @@ def full_like(a, fill_value, *args, **kwargs):
     return _full_like(
         a=a,
         fill_value=fill_value,
-        *args,
+        *args,  # noqa: B026
         **kwargs,
     )
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2195,7 +2195,7 @@ class _GroupBy:
             self._slice,
             func,
             token=funcname(func),
-            *args,
+            *args,  # noqa: B026
             group_keys=self.group_keys,
             **self.observed,
             **self.dropna,
@@ -2281,7 +2281,7 @@ class _GroupBy:
             self._slice,
             func,
             token=funcname(func),
-            *args,
+            *args,  # noqa: B026
             group_keys=self.group_keys,
             **self.observed,
             **self.dropna,


### PR DESCRIPTION
👋 Hi there!

I've recently been tinkering on [a tool to complement `pre-commit autoupdate` and take care of `flake8-bugbear`](https://pypi.org/project/upadup/) and related `additional_dependencies` problems.

`pipx run upadup` is sufficient to see how it behaves on the `dask` config.

The tool is brand new, so it might have some rough edges, but I figured it would be nice to introduce it by means of PRs on projects to show that it works on their config. If you like it, it could go into the `flake8-bugbear` comment!