### PR TITLE
Make filesystem-backend configurable in `read_parquet`

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -377,6 +377,7 @@ class ArrowDatasetEngine(Engine):
             fsspec_fs = ArrowFSWrapper(fs)
             if urlpath[0].startswith("C:") and isinstance(fs, pa_fs.LocalFileSystem):
                 # ArrowFSWrapper._strip_protocol not reliable on windows
+                # See: https://github.com/fsspec/filesystem_spec/issues/1137
                 from fsspec.implementations.local import LocalFileSystem
 
                 fs_strip = LocalFileSystem()

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -345,10 +345,9 @@ def read_parquet(
         It may be necessary to change this argument if the data files in your
         parquet dataset do not end in ".parq", ".parquet", or ".pq".
     filesystem: "fsspec", "arrow", fsspec.AbstractFileSystem, or pyarrow.fs.FileSystem
-        Filesystem backend to use. Default is "fsspec", unless reading from s3
-        storage with the "pyarrow" engine and ``open_file_options=None`` (in
-        which case the default is "arrow"). Note that the "fastparquet" engine
-        only supports "fsspec" or an explicit ``pyarrow.fs.FileSystem`` object.
+        Filesystem backend to use. Note that the "fastparquet" engine only
+        supports "fsspec" or an explicit ``pyarrow.fs.FileSystem`` object.
+        Default is "fsspec".
     dataset: dict, default None
         Dictionary of options to use when creating a ``pyarrow.dataset.Dataset``
         or ``fastparquet.ParquetFile`` object. These options may include a
@@ -362,7 +361,7 @@ def read_parquet(
         Dictionary of options to use when converting from ``pyarrow.Table`` to
         a pandas ``DataFrame`` object. Only used by the "arrow" engine.
     **kwargs: dict (of dicts)
-        Options to pass through to ``engine.read_partitions`` as staand-alone
+        Options to pass through to ``engine.read_partitions`` as stand-alone
         key-word arguments. Note that these options will be ignored by the
         engines defined in ``dask.dataframe``, but may be used by other custom
         implementations.

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -180,6 +180,7 @@ def read_parquet(
     categories=None,
     index=None,
     storage_options=None,
+    filesystem=None,
     engine="auto",
     calculate_divisions=None,
     ignore_metadata_file=False,
@@ -431,6 +432,7 @@ def read_parquet(
         "filters": filters,
         "categories": categories,
         "index": index,
+        "filesystem": filesystem,
         "storage_options": storage_options,
         "engine": engine,
         "calculate_divisions": calculate_divisions,
@@ -460,7 +462,10 @@ def read_parquet(
     # Update input_kwargs
     input_kwargs.update({"columns": columns, "engine": engine})
 
-    fs, _, paths = get_fs_token_paths(path, mode="rb", storage_options=storage_options)
+    # Get fsspec-compatible filesystem and paths
+    fs, paths, kwargs["open_file_options"] = engine.get_filesystem(
+        path, filesystem, storage_options
+    )
     paths = sorted(paths, key=natural_sort_key)  # numeric rather than glob ordering
 
     auto_index_allowed = False

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -35,7 +35,6 @@ from dask.dataframe.io.parquet.utils import (
     _set_gather_statistics,
     _set_metadata_task_size,
     _sort_and_analyze_paths,
-    _split_user_options,
 )
 from dask.dataframe.io.utils import _is_local_fs, _meta_from_dtypes, _open_input_files
 from dask.dataframe.utils import UNKNOWN_CATEGORIES
@@ -383,9 +382,8 @@ class FastParquetEngine(Engine):
         # then each part will correspond to a file.  Otherwise, each part will
         # correspond to a row group (populated later).
 
-        # Extract "supported" key-word arguments from `kwargs`.
-        # Split items into `dataset_kwargs` and `read_kwargs`
-        dataset_kwargs, read_kwargs, user_kwargs = _split_user_options(**kwargs)
+        # Extract dataset-specific options
+        dataset_kwargs = kwargs.pop("dataset", {})
 
         parts = []
         _metadata_exists = False
@@ -512,8 +510,7 @@ class FastParquetEngine(Engine):
             "metadata_task_size": metadata_task_size,
             "kwargs": {
                 "dataset": dataset_kwargs,
-                "read": read_kwargs,
-                **user_kwargs,
+                **kwargs,
             },
         }
 

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -55,8 +55,14 @@ class Engine:
         """
 
         # Check if fs was specified as a dataset option
-        fs = dataset_options.pop("fs", "fsspec")
-        if filesystem is not None:
+        if filesystem is None:
+            fs = dataset_options.pop("fs", "fsspec")
+        else:
+            if "fs" in dataset_options:
+                raise ValueError(
+                    "Cannot specify a filesystem argument if the "
+                    "'fs' dataset option is also defined."
+                )
             fs = filesystem
 
         if fs in (None, "fsspec"):
@@ -76,7 +82,10 @@ class Engine:
             if storage_options:
                 # The filesystem was already specified. Can't pass in
                 # any storage options
-                warnings.warn(f"Ignoring storage_options: {storage_options}")
+                raise ValueError(
+                    f"Cannot specify storage_options when an explicit "
+                    f"filesystem object is specified. Got: {storage_options}"
+                )
 
             if isinstance(urlpath, (list, tuple, set)):
                 if not urlpath:

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -792,14 +792,14 @@ def _process_open_file_options(
 
 def _split_user_options(**kwargs):
     # Check user-defined options.
-    # Split into "file" and "dataset"-specific kwargs
+    # Split into "dataset"-specific kwargs
     user_kwargs = kwargs.copy()
 
     if "file" in user_kwargs:
         # Deprecation warning to move toward a single `dataset` key
         warnings.warn(
-            "Passing user options under the 'file' key is now deprecated. "
-            "Please use 'dataset' instead.",
+            "Passing user options with the 'file' argument is now deprecated."
+            " Please use 'dataset' instead.",
             FutureWarning,
         )
 

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -69,7 +69,9 @@ class Engine:
         else:
             # Check that an initialized filesystem object was provided
             if not isinstance(fs, AbstractFileSystem):
-                raise ValueError(f"Expected fsspec.AbstractFileSystem. Got {type(fs)}")
+                raise ValueError(
+                    f"Expected fsspec.AbstractFileSystem or 'fsspec'. Got {fs}"
+                )
 
             if storage_options:
                 # The filesystem was already specified. Can't pass in

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4411,7 +4411,7 @@ def test_filesystem_option(tmpdir, engine):
     fs = LocalFileSystem()
     fs._myfs = True
     ddf = dd.read_parquet(
-        tmpdir,
+        str(tmpdir),
         engine=engine,
         filesystem=fs,
     )
@@ -4430,7 +4430,7 @@ def test_pyarrow_filesystem_option(tmpdir, fs):
     dd.from_pandas(df, npartitions=2).to_parquet(tmpdir)
     fs = fs or LocalFileSystem()
     ddf = dd.read_parquet(
-        tmpdir,
+        str(tmpdir),
         engine="pyarrow",
         filesystem=fs,
     )

--- a/dask/dataframe/io/utils.py
+++ b/dask/dataframe/io/utils.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 
 import fsspec
 import pandas as pd
-from fsspec.implementations.arrow import ArrowFSWrapper
 from fsspec.implementations.local import LocalFileSystem
 from packaging.version import parse as parse_version
 
@@ -26,7 +25,7 @@ def _is_local_fs(fs):
 def _is_local_fs_pyarrow(fs):
     """Check if a pyarrow-based file-system is local"""
     if fs:
-        if isinstance(fs, ArrowFSWrapper):
+        if hasattr(fs, "fs"):
             # ArrowFSWrapper will have an "fs" attribute
             return _is_local_fs_pyarrow(fs.fs)
         elif hasattr(fs, "type_name"):

--- a/dask/dataframe/io/utils.py
+++ b/dask/dataframe/io/utils.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import fsspec
 import pandas as pd
+from fsspec.implementations.arrow import ArrowFSWrapper
 from fsspec.implementations.local import LocalFileSystem
 from packaging.version import parse as parse_version
 
@@ -25,7 +26,7 @@ def _is_local_fs(fs):
 def _is_local_fs_pyarrow(fs):
     """Check if a pyarrow-based file-system is local"""
     if fs:
-        if hasattr(fs, "fs"):
+        if isinstance(fs, ArrowFSWrapper):
             # ArrowFSWrapper will have an "fs" attribute
             return _is_local_fs_pyarrow(fs.fs)
         elif hasattr(fs, "type_name"):


### PR DESCRIPTION
Basic implementation of the plan discussed in [this comment](https://github.com/dask/dask/pull/9669#issuecomment-1334126562).

This PR adds better documentation for `read_parquet(..., dataset=)`, and allows the user to configure the filesystem-backend using a `dataset` option (as one would do with `pyarrow.dataset.Dataset` or `fastparquet.ParquetFile`). ~In order to address https://github.com/dask/dask/issues/9619, the default "filesystem" argument is set to "arrow" for s3 storage (and "fsspec" otherwise).~

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
