### PR TITLE
Fix flaky `test_dataframe_aggregations_multilevel`

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -533,7 +533,7 @@ def _mul_cols(df, cols):
     # https://github.com/pandas-dev/pandas/issues/43568
     # Make sure index dtype is "int64" (even if _df is empty)
     # https://github.com/dask/dask/pull/9701
-    _df.index = np.repeat(np.array([0], dtype="int64"), len(_df))
+    _df.index = np.zeros(len(_df), dtype=int)
     return _df
 
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -531,7 +531,7 @@ def _mul_cols(df, cols):
     # Fix index in a groupby().apply() context
     # https://github.com/dask/dask/issues/8137
     # https://github.com/pandas-dev/pandas/issues/43568
-    _df.index = [0] * len(_df)
+    _df.index = np.repeat(np.array([0], dtype="int64"), len(_df))
     return _df
 
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -531,6 +531,8 @@ def _mul_cols(df, cols):
     # Fix index in a groupby().apply() context
     # https://github.com/dask/dask/issues/8137
     # https://github.com/pandas-dev/pandas/issues/43568
+    # Make sure index dtype is "int64" (even if _df is empty)
+    # https://github.com/dask/dask/pull/9701
     _df.index = np.repeat(np.array([0], dtype="int64"), len(_df))
     return _df
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -531,7 +531,7 @@ def _mul_cols(df, cols):
     # Fix index in a groupby().apply() context
     # https://github.com/dask/dask/issues/8137
     # https://github.com/pandas-dev/pandas/issues/43568
-    # Make sure index dtype is "int64" (even if _df is empty)
+    # Make sure index dtype is int (even if _df is empty)
     # https://github.com/dask/dask/pull/9701
     _df.index = np.zeros(len(_df), dtype=int)
     return _df
@@ -642,8 +642,10 @@ def _drop_duplicates_reindex(df):
     # Fix index in a groupby().apply() context
     # https://github.com/dask/dask/issues/8137
     # https://github.com/pandas-dev/pandas/issues/43568
+    # Make sure index dtype is int (even if result is empty)
+    # https://github.com/dask/dask/pull/9701
     result = df.drop_duplicates()
-    result.index = [0] * len(result)
+    result.index = np.zeros(len(result), dtype=int)
     return result
 
 


### PR DESCRIPTION
I'm struggling to reproduce the [recent groupby CI failures](https://github.com/dask/dask/actions/runs/3576903148/jobs/6015263282) locally. However, it seems possible that these errors could be the result of `_mul_cols` being passed an empty group within `apply`. This PR adds a possible fix if this happens to be the root cause.
