### PR TITLE
Fix pandas 1.5+ `FutureWarning` in `.str.split(..., expand=True)`

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -265,7 +265,7 @@ class StringAccessor(Accessor):
                 delimiter = " " if pat is None else pat
                 meta = self._series._meta._constructor(
                     [delimiter.join(["a"] * (n + 1))],
-                    index=self._series._meta_nonempty[:1].index,
+                    index=self._series._meta_nonempty.iloc[:1].index,
                 )
                 meta = getattr(meta.str, method)(n=n, expand=expand, pat=pat)
         else:

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -294,6 +294,17 @@ def test_str_accessor_split_expand_more_columns():
     ds.str.split(n=10, expand=True).compute()
 
 
+@pytest.mark.parametrize("index", [None, [0]], ids=["range_index", "other index"])
+def test_str_split_no_warning(index):
+    df = pd.DataFrame({"a": ["a\nb"]}, index=index)
+    ddf = dd.from_pandas(df, npartitions=1)
+
+    pd_a = df["a"].str.split("\n", n=1, expand=True)
+    dd_a = ddf["a"].str.split("\n", n=1, expand=True)
+
+    assert_eq(dd_a, pd_a)
+
+
 def test_string_nullable_types(df_ddf):
     df, ddf = df_ddf
     assert_eq(ddf.string_col.str.count("A"), df.string_col.str.count("A"))


### PR DESCRIPTION
- [x] Closes #9703
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

I confirmed manually that this removed the warning with the repro code in #9703, but didn't add an explicit test for it.