### PR TITLE
[WIP] Add parquet-statistics utility and optimize __len__

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4549,6 +4549,13 @@ class DataFrame(_Frame):
         return _iLocIndexer(self)
 
     def __len__(self):
+        from dask.dataframe.io.parquet.core import _parquet_statistics
+
+        # Try using Parquet statistics before reading in real data
+        pq_stats = _parquet_statistics(self)
+        if pq_stats:
+            return pd.DataFrame.from_dict(pq_stats)["num-rows"].sum()
+
         try:
             s = self.iloc[:, 0]
         except IndexError:

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -2,6 +2,7 @@ import json
 import textwrap
 from collections import defaultdict
 from datetime import datetime
+from functools import lru_cache
 
 import numpy as np
 import pandas as pd
@@ -1613,3 +1614,62 @@ class ArrowDatasetEngine(Engine):
             return None
         else:
             return meta
+
+    @classmethod
+    def _read_partition_stats(cls, part, fs, columns=None):
+        """Read Parquet-metadata statistics for a single partition"""
+
+        if not isinstance(part, list):
+            part = [part]
+
+        column_stats = {}
+        num_rows = 0
+        columns = columns or []
+        for p in part:
+            piece = p["piece"]
+            path = piece[0]
+            row_groups = piece[1]
+            # TODO: Include partitioned-column stats (if requested)
+            if row_groups == [None]:
+                row_groups = None
+
+            md = _get_md(path, fs)
+            if row_groups is None:
+                row_groups = list(range(md.num_row_groups))
+            for rg in row_groups:
+                row_group = md.row_group(rg)
+                num_rows += row_group.num_rows
+                for i in range(row_group.num_columns):
+                    col = row_group.column(i)
+                    name = col.path_in_schema
+                    if name in columns:
+                        if col.statistics and col.statistics.has_min_max:
+                            if name in column_stats:
+                                column_stats[name]["min"] = min(
+                                    column_stats[name]["min"], col.statistics.min
+                                )
+                                column_stats[name]["max"] = max(
+                                    column_stats[name]["max"], col.statistics.max
+                                )
+                            else:
+                                column_stats[name] = {
+                                    "min": col.statistics.min,
+                                    "max": col.statistics.max,
+                                }
+
+        column_stats_list = [
+            {
+                "name": name,
+                "min": column_stats[name]["min"],
+                "max": column_stats[name]["max"],
+            }
+            for name in column_stats.keys()
+        ]
+        return {"num-rows": num_rows, "columns": column_stats_list}
+
+
+@lru_cache(maxsize=1)
+def _get_md(path, fs):
+    # Caching utility used by ArrowDatasetEngine._read_partition_stats
+    with fs.open(path, default_cache="none") as f:
+        return pq.ParquetFile(f).metadata


### PR DESCRIPTION
Adds a new (experimental) `_parquet_statistics` utility to the `dask.dataframe.io.parquet` module.  When passed a `DataFrame` collection, this utility extracts the partition-wise path/row-group mapping from the high-level graph, and then generates a list of statistics for each partition.

This PR also shows how the new utility can be used to optimize `DataFrame.__len__` without explicitly tracking partition lens in the `DataFrame` class itself.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
- [ ] Support fastparquet engine
- [ ] Cleanup
