### PR TITLE
Avoid `PytestReturnNotNoneWarning` in `test_inheriting_class`

### DIFF
--- a/dask/tests/test_typing.py
+++ b/dask/tests/test_typing.py
@@ -210,5 +210,6 @@ def test_parameter_passing() -> None:
     assert compute2(array).shape == (10,)
 
 
-def test_inheriting_class() -> Inheriting:
-    return Inheriting(increment(2))
+def test_inheriting_class() -> None:
+    inheriting: Inheriting = Inheriting(increment(2))
+    assert isinstance(inheriting, Inheriting)


### PR DESCRIPTION
```
dask/tests/test_typing.py::test_inheriting_class
  /home/graingert/anaconda3/envs/dask-310/lib/python3.10/site-packages/_pytest/python.py:199: PytestReturnNotNoneWarning: Expected None, but dask/tests/test_typing.py::test_inheriting_class returned <dask.tests.test_typing.Inheriting object at 0x7ff3eff7bee0>, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(
```


- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
