### PR TITLE
[WIP] Support `pandas` `mode.string_storage` option in `read_parquet`

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -4,6 +4,7 @@ import contextlib
 import math
 import warnings
 
+import pandas as pd
 import tlz as toolz
 from fsspec.core import get_fs_token_paths
 from fsspec.utils import stringify_path
@@ -365,6 +366,8 @@ def read_parquet(
     to_parquet
     pyarrow.parquet.ParquetDataset
     """
+
+    kwargs["string_storage"] = pd.get_option("mode.string_storage")
 
     # "Pre-deprecation" warning for `chunksize`
     if chunksize:

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -624,6 +624,10 @@ def test_pandas_string_storage_option(
     tmp_path, write_engine, read_engine, string_storage, scheduler
 ):
     # Ensure Dask respects pandas' `string_storage` option
+
+    if read_engine == "fastparquet" or write_engine == "fastparquet":
+        pytest.xfail("https://github.com/dask/fastparquet/issues/465")
+
     pd.set_option("mode.string_storage", string_storage)
 
     df = pd.DataFrame(


### PR DESCRIPTION
Pushing up a quick diff to help aid the conversation happening here https://github.com/dask/dask/issues/9631#issuecomment-1334433767. The `test_pandas_string_storage_option` added here demonstrates the behavior we ultimately want, but the actual changes to `read_parquet` are still preliminary (I suspect we'll need more changes). 