### PR TITLE
Rename columns correctly in case of `SeriesGroupby`

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1688,7 +1688,6 @@ def test_cumulative(func, key, sel):
             dg.cumcount(axis=0)
 
 
-@pytest.mark.xfail(reason="https://github.com/dask/dask/issues/9715")
 def test_series_groupby_multi_character_column_name():
     df = pd.DataFrame({"aa": [1, 2, 1, 3, 4, 1, 2]})
     ddf = dd.from_pandas(df, npartitions=3)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1688,6 +1688,13 @@ def test_cumulative(func, key, sel):
             dg.cumcount(axis=0)
 
 
+@pytest.mark.xfail(reason="https://github.com/dask/dask/issues/9715")
+def test_series_groupby_multi_character_column_name():
+    df = pd.DataFrame({"aa": [1, 2, 1, 3, 4, 1, 2]})
+    ddf = dd.from_pandas(df, npartitions=3)
+    assert_eq(df.groupby("aa").aa.cumsum(), ddf.groupby("aa").aa.cumsum())
+
+
 @pytest.mark.parametrize("func", ["cumsum", "cumprod"])
 def test_cumulative_axis1(func):
     df = pd.DataFrame(


### PR DESCRIPTION
When aggregating on a SeriesGroupby, the column we handle is only a
single string (rather than a list of column names), so we must be
careful not to explode into a set of characters when checking if we
should internally rename the grouping column.

While we're here, only rename those columns that need it.

- Closes #9715.
- Closes #9313.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

(cc @brandon-b-miller, @ncclementi, @pavithraes)