### PR TITLE
Add support for simple operation with `pyarrow`-backed extension dtypes

### DIFF
--- a/dask/dataframe/_dtypes.py
+++ b/dask/dataframe/_dtypes.py
@@ -1,5 +1,6 @@
 import pandas as pd
 
+from dask.dataframe._compat import PANDAS_GT_150
 from dask.dataframe.extensions import make_array_nonempty, make_scalar
 
 
@@ -18,9 +19,11 @@ def _(dtype):
     return pd.array(["a", pd.NA], dtype=dtype)
 
 
-@make_array_nonempty.register(pd.ArrowDtype)
-def _(dtype):
-    return dtype.empty(2)
+if PANDAS_GT_150:
+
+    @make_array_nonempty.register(pd.ArrowDtype)
+    def _make_array_nonempty_pyarrow_dtype(dtype):
+        return dtype.empty(2)
 
 
 @make_scalar.register(str)

--- a/dask/dataframe/_dtypes.py
+++ b/dask/dataframe/_dtypes.py
@@ -18,6 +18,11 @@ def _(dtype):
     return pd.array(["a", pd.NA], dtype=dtype)
 
 
+@make_array_nonempty.register(pd.ArrowDtype)
+def _(dtype):
+    return dtype.empty(2)
+
+
 @make_scalar.register(str)
 def _(x):
     return "s"

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,3 +1,4 @@
+import decimal
 import platform
 import warnings
 import weakref
@@ -5462,3 +5463,53 @@ def test_repr_materialize():
     s.__repr__()
     s.to_frame().__repr__()
     assert all([not l.is_materialized() for l in s.dask.layers.values()])
+
+
+@pytest.mark.skipif(
+    not PANDAS_GT_150, reason="Requires native PyArrow-backed ExtensionArrays"
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "int64[pyarrow]",
+        "int32[pyarrow]",
+        "float64[pyarrow]",
+        "float32[pyarrow]",
+        "uint8[pyarrow]",
+        "date64[pyarrow]",
+    ],
+)
+def test_pyarrow_extension_dtype(dtype):
+    # Ensure simple Dask DataFrame operations work with pyarrow extension dtypes
+    pytest.importorskip("pyarrow")
+    df = pd.DataFrame({"x": range(10)}, dtype="int64[pyarrow]")
+    ddf = dd.from_pandas(df, npartitions=3)
+    expected = (df.x + df.x) * 2
+    result = (ddf.x + ddf.x) * 2
+    assert_eq(expected, result)
+
+
+@pytest.mark.skipif(
+    not PANDAS_GT_150, reason="Requires native PyArrow-backed ExtensionArrays"
+)
+def test_pyarrow_decimal_extension_dtype():
+    # Similar to `test_pyarrow_extension_dtype` but for pyarrow decimal dtypes
+    pa = pytest.importorskip("pyarrow")
+    pa_dtype = pa.decimal128(precision=7, scale=3)
+
+    data = pa.array(
+        [
+            decimal.Decimal("8093.234"),
+            decimal.Decimal("8094.234"),
+            decimal.Decimal("8095.234"),
+            decimal.Decimal("8096.234"),
+            decimal.Decimal("8097.234"),
+            decimal.Decimal("8098.234"),
+        ],
+        type=pa_dtype,
+    )
+    df = pd.DataFrame({"x": data}, dtype=pd.ArrowDtype(pa_dtype))
+    ddf = dd.from_pandas(df, npartitions=3)
+    expected = (df.x + df.x) * 2
+    result = (ddf.x + ddf.x) * 2
+    assert_eq(expected, result)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5476,13 +5476,12 @@ def test_repr_materialize():
         "float64[pyarrow]",
         "float32[pyarrow]",
         "uint8[pyarrow]",
-        "date64[pyarrow]",
     ],
 )
 def test_pyarrow_extension_dtype(dtype):
     # Ensure simple Dask DataFrame operations work with pyarrow extension dtypes
     pytest.importorskip("pyarrow")
-    df = pd.DataFrame({"x": range(10)}, dtype="int64[pyarrow]")
+    df = pd.DataFrame({"x": range(10)}, dtype=dtype)
     ddf = dd.from_pandas(df, npartitions=3)
     expected = (df.x + df.x) * 2
     result = (ddf.x + ddf.x) * 2


### PR DESCRIPTION
I was playing around with using `pandas` new `pyarrow`-backed extension dtypes (e.g. `int64[pyarrow]`) and saw that trying simple operations failed. For example, with the current `main` branch 

```python
import pandas as pd
import dask.dataframe as dd

df = pd.DataFrame({"x": range(10)}, dtype="int64[pyarrow]")
ddf = dd.from_pandas(df, npartitions=3)
expected = df.x + df.x
result = ddf.x + ddf.x
dd.utils.assert_eq(expected, result)
```

fails with 

```
Traceback (most recent call last):
  File "/Users/james/projects/dask/dask/test2.py", line 7, in <module>
    result = ddf.x + ddf.x
  File "/Users/james/projects/dask/dask/dask/dataframe/core.py", line 1784, in <lambda>
    return lambda self, other: elemwise(op, self, other)
  File "/Users/james/projects/dask/dask/dask/dataframe/core.py", line 6228, in elemwise
    parts = [
  File "/Users/james/projects/dask/dask/dask/dataframe/core.py", line 6233, in <listcomp>
    else d._meta_nonempty
  File "/Users/james/projects/dask/dask/dask/dataframe/core.py", line 465, in _meta_nonempty
    return meta_nonempty(self._meta)
  File "/Users/james/projects/dask/dask/dask/utils.py", line 640, in __call__
    return meth(arg, *args, **kwargs)
  File "/Users/james/projects/dask/dask/dask/dataframe/backends.py", line 428, in _nonempty_series
    entry = _scalar_from_dtype(dtype)
  File "/Users/james/projects/dask/dask/dask/dataframe/utils.py", line 322, in _scalar_from_dtype
    return dtype.type(1)
TypeError: __init__() takes exactly 0 positional arguments (1 given)
```

due to Dask not knowing how to generate a non-empty `meta` object for `pd.Series` that contain these dtypes. 

This PR adds a new `make_array_nonempty` dispatch entry for `pyarrow`-backed dtypes and a couple of small tests. 

cc @rjzamora @mroeschke as this may be something you find interesting 