### PR TITLE
Support `dtype_backend="pandas|pyarrow"` configuration

### DIFF
--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -72,6 +72,14 @@ properties:
               task when reading a parquet dataset from a REMOTE file system.
               Specifying 0 will result in serial execution on the client.
 
+      nullable_backend:
+        enum:
+          - pandas
+          - pyarrow
+        description: |
+          The nullable dtype implementation to use. Must be either "pandas" or
+          "pyarrow". Default is "pandas".
+
   array:
     type: object
     properties:

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -72,7 +72,7 @@ properties:
               task when reading a parquet dataset from a REMOTE file system.
               Specifying 0 will result in serial execution on the client.
 
-      nullable_backend:
+      dtype_backend:
         enum:
           - pandas
           - pyarrow

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -12,6 +12,7 @@ dataframe:
   parquet:
     metadata-task-size-local: 512  # Number of files per local metadata-processing task
     metadata-task-size-remote: 16  # Number of files per remote metadata-processing task
+  nullable_backend: "pandas"  # Nullable dtype implementation to use
 
 array:
   backend: "numpy"  # Backend array library for input IO and data creation

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -12,7 +12,7 @@ dataframe:
   parquet:
     metadata-task-size-local: 512  # Number of files per local metadata-processing task
     metadata-task-size-remote: 16  # Number of files per remote metadata-processing task
-  nullable_backend: "pandas"  # Nullable dtype implementation to use
+  dtype_backend: "pandas"  # Dtype implementation to use
 
 array:
   backend: "numpy"  # Backend array library for input IO and data creation

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1581,9 +1581,10 @@ class ArrowDatasetEngine(Engine):
 
         if use_nullable_dtypes:
             # Determine is `pandas` or `pyarrow`-backed dtypes should be used
-            if use_nullable_dtypes in ("pandas", True):
+            if use_nullable_dtypes == "pandas":
                 default_types_mapper = PYARROW_NULLABLE_DTYPE_MAPPING.get
-            elif use_nullable_dtypes == "pyarrow":
+            else:
+                # use_nullable_dtypes == "pyarrow"
 
                 def default_types_mapper(pyarrow_dtype):  # type: ignore
                     # Special case pyarrow strings to use more feature complete dtype

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1580,19 +1580,30 @@ class ArrowDatasetEngine(Engine):
         _kwargs.update({"use_threads": False, "ignore_metadata": False})
 
         if use_nullable_dtypes:
+            # Determine is `pandas` or `pyarrow`-backed dtypes should be used
+            if use_nullable_dtypes in ("pandas", True):
+                default_types_mapper = PYARROW_NULLABLE_DTYPE_MAPPING.get
+            elif use_nullable_dtypes == "pyarrow":
+
+                def default_types_mapper(pyarrow_dtype):  # type: ignore
+                    return pd.ArrowDtype(pyarrow_dtype)
+
+            else:
+                raise ValueError(
+                    "Invalid `use_nullable_dtypes` received. Expected `True`, "
+                    f"`'pandas'`, or `'pyarrow'` but got {use_nullable_dtypes}."
+                )
             if "types_mapper" in _kwargs:
-                # User-provided entries take priority over PYARROW_NULLABLE_DTYPE_MAPPING
+                # User-provided entries take priority over default_types_mapper
                 types_mapper = _kwargs["types_mapper"]
 
                 def _types_mapper(pa_type):
-                    return types_mapper(pa_type) or PYARROW_NULLABLE_DTYPE_MAPPING.get(
-                        pa_type
-                    )
+                    return types_mapper(pa_type) or default_types_mapper(pa_type)
 
                 _kwargs["types_mapper"] = _types_mapper
 
             else:
-                _kwargs["types_mapper"] = PYARROW_NULLABLE_DTYPE_MAPPING.get
+                _kwargs["types_mapper"] = default_types_mapper
 
         return arrow_table.to_pandas(categories=categories, **_kwargs)
 

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1588,11 +1588,6 @@ class ArrowDatasetEngine(Engine):
                 def default_types_mapper(pyarrow_dtype):  # type: ignore
                     return pd.ArrowDtype(pyarrow_dtype)
 
-            else:
-                raise ValueError(
-                    "Invalid `use_nullable_dtypes` received. Expected `True`, "
-                    f"`'pandas'`, or `'pyarrow'` but got {use_nullable_dtypes}."
-                )
             if "types_mapper" in _kwargs:
                 # User-provided entries take priority over default_types_mapper
                 types_mapper = _kwargs["types_mapper"]

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1586,7 +1586,12 @@ class ArrowDatasetEngine(Engine):
             elif use_nullable_dtypes == "pyarrow":
 
                 def default_types_mapper(pyarrow_dtype):  # type: ignore
-                    return pd.ArrowDtype(pyarrow_dtype)
+                    # Special case pyarrow strings to use more feature complete dtype
+                    # See https://github.com/pandas-dev/pandas/issues/50074
+                    if pyarrow_dtype == pa.string():
+                        return pd.StringDtype("pyarrow")
+                    else:
+                        return pd.ArrowDtype(pyarrow_dtype)
 
             if "types_mapper" in _kwargs:
                 # User-provided entries take priority over default_types_mapper

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -366,6 +366,12 @@ def read_parquet(
     pyarrow.parquet.ParquetDataset
     """
 
+    if use_nullable_dtypes not in (True, False, "pandas", "pyarrow"):
+        raise ValueError(
+            "Invalid value for `use_nullable_dtypes` received. Expected `True`, `False`, "
+            f"`'pandas'`, or `'pyarrow'` but got {use_nullable_dtypes} instead."
+        )
+
     # "Pre-deprecation" warning for `chunksize`
     if chunksize:
         warnings.warn(

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -263,14 +263,14 @@ def read_parquet(
 
         .. note::
 
-            Use the ``dataframe.nullable_backend`` config option to select which
+            Use the ``dataframe.dtype_backend`` config option to select which
             dtype implementation to use.
 
-            ``dataframe.nullable_backend="pandas"`` (the default) will use
+            ``dataframe.dtype_backend="pandas"`` (the default) will use
             pandas' ``numpy``-backed nullable dtypes (e.g. ``Int64``,
-            ``string[python]``, etc.) while ``dataframe.nullable_backend="pyarrow"``
+            ``string[python]``, etc.) while ``dataframe.dtype_backend="pyarrow"``
             will use ``pyarrow``-backed extension dtypes (e.g. ``int64[pyarrow]``,
-            ``string[pyarrow]``, etc.). ``dataframe.nullable_backend="pyarrow"``
+            ``string[pyarrow]``, etc.). ``dataframe.dtype_backend="pyarrow"``
             requires ``pandas`` 1.5+.
 
     calculate_divisions : bool, default False
@@ -383,7 +383,7 @@ def read_parquet(
     """
 
     if use_nullable_dtypes:
-        use_nullable_dtypes = dask.config.get("dataframe.nullable_backend")
+        use_nullable_dtypes = dask.config.get("dataframe.dtype_backend")
 
     # "Pre-deprecation" warning for `chunksize`
     if chunksize:

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -624,7 +624,7 @@ def test_roundtrip_nullable_dtypes(tmp_path, write_engine, read_engine):
 
 @PYARROW_MARK
 @pytest.mark.parametrize(
-    "nullable_backend",
+    "dtype_backend",
     [
         "pandas",
         pytest.param(
@@ -635,16 +635,16 @@ def test_roundtrip_nullable_dtypes(tmp_path, write_engine, read_engine):
         ),
     ],
 )
-def test_use_nullable_dtypes(tmp_path, engine, nullable_backend):
+def test_use_nullable_dtypes(tmp_path, engine, dtype_backend):
     """
     Test reading a parquet file without pandas metadata,
     but forcing use of nullable dtypes where appropriate
     """
 
-    if nullable_backend == "pandas":
+    if dtype_backend == "pandas":
         dtype_extra = ""
     else:
-        # nullable_backend == "pyarrow"
+        # dtype_backend == "pyarrow"
         dtype_extra = "[pyarrow]"
     df = pd.DataFrame(
         {
@@ -669,7 +669,7 @@ def test_use_nullable_dtypes(tmp_path, engine, nullable_backend):
     partitions = ddf.to_delayed()
     dask.compute([write_partition(p, i) for i, p in enumerate(partitions)])
 
-    with dask.config.set({"dataframe.nullable_backend": nullable_backend}):
+    with dask.config.set({"dataframe.dtype_backend": dtype_backend}):
         # Not supported by fastparquet
         if engine == "fastparquet":
             with pytest.raises(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -618,17 +618,29 @@ def test_roundtrip_nullable_dtypes(tmp_path, write_engine, read_engine):
 
 
 @PYARROW_MARK
-def test_use_nullable_dtypes(tmp_path, engine):
+@pytest.mark.parametrize("use_nullable_dtypes", [True, "pandas", "pyarrow"])
+def test_use_nullable_dtypes(tmp_path, engine, use_nullable_dtypes):
     """
     Test reading a parquet file without pandas metadata,
     but forcing use of nullable dtypes where appropriate
     """
+
+    if use_nullable_dtypes in (True, "pandas"):
+        nullable_backend = ""
+    else:
+        nullable_backend = "[pyarrow]"
     df = pd.DataFrame(
         {
-            "a": pd.Series([1, 2, pd.NA, 3, 4], dtype="Int64"),
-            "b": pd.Series([True, pd.NA, False, True, False], dtype="boolean"),
-            "c": pd.Series([0.1, 0.2, 0.3, pd.NA, 0.4], dtype="Float64"),
-            "d": pd.Series(["a", "b", "c", "d", pd.NA], dtype="string"),
+            "a": pd.Series([1, 2, pd.NA, 3, 4], dtype=f"Int64{nullable_backend}"),
+            "b": pd.Series(
+                [True, pd.NA, False, True, False], dtype=f"boolean{nullable_backend}"
+            ),
+            "c": pd.Series(
+                [0.1, 0.2, 0.3, pd.NA, 0.4], dtype=f"Float64{nullable_backend}"
+            ),
+            "d": pd.Series(
+                ["a", "b", "c", "d", pd.NA], dtype=f"string{nullable_backend}"
+            ),
         }
     )
     ddf = dd.from_pandas(df, npartitions=2)
@@ -647,7 +659,9 @@ def test_use_nullable_dtypes(tmp_path, engine):
     # Not supported by fastparquet
     if engine == "fastparquet":
         with pytest.raises(ValueError, match="`use_nullable_dtypes` is not supported"):
-            dd.read_parquet(tmp_path, engine=engine, use_nullable_dtypes=True)
+            dd.read_parquet(
+                tmp_path, engine=engine, use_nullable_dtypes=use_nullable_dtypes
+            )
 
     # Works in pyarrow
     else:
@@ -657,8 +671,28 @@ def test_use_nullable_dtypes(tmp_path, engine):
             assert_eq(df, ddf2)
 
         # Round trip works when we use nullable dtypes
-        ddf2 = dd.read_parquet(tmp_path, engine=engine, use_nullable_dtypes=True)
+        ddf2 = dd.read_parquet(
+            tmp_path, engine=engine, use_nullable_dtypes=use_nullable_dtypes
+        )
         assert_eq(df, ddf2, check_index=False)
+
+
+def test_use_nullable_dtypes_raises(tmp_path, engine):
+    # Raise an informative error message when `use_nullable_dtypes` is invalid
+    df = pd.DataFrame({"a": pd.Series([1, 2, pd.NA, 3, 4], dtype="Int64")})
+    ddf = dd.from_pandas(df, npartitions=3)
+    ddf.to_parquet(tmp_path, engine=engine)
+
+    bad_use_nullable_dtypes = "not-a-valid-option"
+    with pytest.raises(ValueError) as excinfo:
+        dd.read_parquet(
+            tmp_path,
+            engine=engine,
+            use_nullable_dtypes=bad_use_nullable_dtypes,
+        )
+    msg = str(excinfo.value)
+    assert "Invalid value for `use_nullable_dtypes`" in msg
+    assert bad_use_nullable_dtypes in msg
 
 
 @pytest.mark.xfail(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -15,7 +15,12 @@ import dask
 import dask.dataframe as dd
 import dask.multiprocessing
 from dask.blockwise import Blockwise, optimize_blockwise
-from dask.dataframe._compat import PANDAS_GT_110, PANDAS_GT_121, PANDAS_GT_130
+from dask.dataframe._compat import (
+    PANDAS_GT_110,
+    PANDAS_GT_121,
+    PANDAS_GT_130,
+    PANDAS_GT_150,
+)
 from dask.dataframe.io.parquet.core import get_engine
 from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.dataframe.optimize import optimize_dataframe_getitem
@@ -618,7 +623,19 @@ def test_roundtrip_nullable_dtypes(tmp_path, write_engine, read_engine):
 
 
 @PYARROW_MARK
-@pytest.mark.parametrize("use_nullable_dtypes", [True, "pandas", "pyarrow"])
+@pytest.mark.parametrize(
+    "use_nullable_dtypes",
+    [
+        True,
+        "pandas",
+        pytest.param(
+            "pyarrow",
+            marks=pytest.mark.skipif(
+                not PANDAS_GT_150, reason="Requires pyarrow-backed nullable dtypes"
+            ),
+        ),
+    ],
+)
 def test_use_nullable_dtypes(tmp_path, engine, use_nullable_dtypes):
     """
     Test reading a parquet file without pandas metadata,

--- a/dask/tests/test_spark_compat.py
+++ b/dask/tests/test_spark_compat.py
@@ -180,7 +180,7 @@ def test_read_decimal_dtype_pyarrow(spark_session, tmpdir):
     # already exists (as tmpdir does) and we don't set overwrite
     sdf.repartition(npartitions).write.parquet(tmpdir, mode="overwrite")
 
-    with dask.config.set({"dataframe.nullable_backend": "pyarrow"}):
+    with dask.config.set({"dataframe.dtype_backend": "pyarrow"}):
         ddf = dd.read_parquet(tmpdir, engine="pyarrow", use_nullable_dtypes=True)
     assert ddf.b.dtype.pyarrow_dtype == pa.decimal128(7, 3)
     assert ddf.b.compute().dtype.pyarrow_dtype == pa.decimal128(7, 3)

--- a/dask/tests/test_spark_compat.py
+++ b/dask/tests/test_spark_compat.py
@@ -16,6 +16,7 @@ pytest.importorskip("fastparquet")
 import numpy as np
 import pandas as pd
 
+from dask.dataframe._compat import PANDAS_GT_150
 from dask.dataframe.utils import assert_eq
 
 pytestmark = pytest.mark.skipif(
@@ -153,6 +154,7 @@ def test_roundtrip_parquet_spark_to_dask_extension_dtypes(spark_session, tmpdir)
     assert_eq(ddf, pdf, check_index=False)
 
 
+@pytest.mark.skipif(not PANDAS_GT_150, reason="Requires pyarrow-backed nullable dtypes")
 def test_read_decimal_dtype_pyarrow(spark_session, tmpdir):
     tmpdir = str(tmpdir)
     npartitions = 3

--- a/dask/tests/test_spark_compat.py
+++ b/dask/tests/test_spark_compat.py
@@ -1,14 +1,16 @@
+import decimal
 import signal
 import sys
 import threading
 
 import pytest
 
+import dask
 from dask.datasets import timeseries
 
 dd = pytest.importorskip("dask.dataframe")
 pyspark = pytest.importorskip("pyspark")
-pytest.importorskip("pyarrow")
+pa = pytest.importorskip("pyarrow")
 pytest.importorskip("fastparquet")
 
 import numpy as np
@@ -149,3 +151,42 @@ def test_roundtrip_parquet_spark_to_dask_extension_dtypes(spark_session, tmpdir)
         [pd.api.types.is_extension_array_dtype(dtype) for dtype in ddf.dtypes]
     ), ddf.dtypes
     assert_eq(ddf, pdf, check_index=False)
+
+
+def test_read_decimal_dtype_pyarrow(spark_session, tmpdir):
+    tmpdir = str(tmpdir)
+    npartitions = 3
+    size = 6
+
+    decimal_data = [
+        decimal.Decimal("8093.234"),
+        decimal.Decimal("8094.234"),
+        decimal.Decimal("8095.234"),
+        decimal.Decimal("8096.234"),
+        decimal.Decimal("8097.234"),
+        decimal.Decimal("8098.234"),
+    ]
+    pdf = pd.DataFrame(
+        {
+            "a": range(size),
+            "b": decimal_data,
+        }
+    )
+    sdf = spark_session.createDataFrame(pdf)
+    sdf = sdf.withColumn("b", sdf["b"].cast(pyspark.sql.types.DecimalType(7, 3)))
+    # We are not overwriting any data, but spark complains if the directory
+    # already exists (as tmpdir does) and we don't set overwrite
+    sdf.repartition(npartitions).write.parquet(tmpdir, mode="overwrite")
+
+    with dask.config.set({"dataframe.nullable_backend": "pyarrow"}):
+        ddf = dd.read_parquet(tmpdir, engine="pyarrow", use_nullable_dtypes=True)
+    assert ddf.b.dtype.pyarrow_dtype == pa.decimal128(7, 3)
+    assert ddf.b.compute().dtype.pyarrow_dtype == pa.decimal128(7, 3)
+    expected = pdf.astype(
+        {
+            "a": "int64[pyarrow]",
+            "b": pd.ArrowDtype(pa.decimal128(7, 3)),
+        }
+    )
+
+    assert_eq(ddf, expected, check_index=False)


### PR DESCRIPTION
This PR updates the `use_nullable_dtypes=` keyword in `read_parquet` to accept `"pandas"` and `"pyarrow"` as valid inputs. The equivalent in `pandas` would be `use_nullable_dtypes=True` + the new `io.nullable_backend` `pandas` config option that's coming in `pandas=2.0`. I like `use_nullable_dtypes="pandas|pyarrow"` in Dask because

1. I find it a bit more ergonomic (my subjective opinion)
2. This functionality could be made available to Dask users quickly (actually, I'm not sure when `pandas=2.0` is scheduled for release -- I'm just guessing several `dask` releases will happen beforehand)
3. It let's us remain de-coupled from `pandas` config system

We might consider going with this over https://github.com/dask/dask/pull/9711 for having `read_parquet` support reading in pyarrow-backed dtypes

EDIT: The primary downside to this PR I see is that it's a deviation away from `pandas` API. The good news is that the logic is well isolated enough that it would be very easy to deprecate in the future, should we want to align on `io.nullable_backend` at some point. 

cc @rjzamora @mroeschke for visibility 

Closes https://github.com/dask/dask/issues/9631