### PR TITLE
Partial functions in aggs may have arguments

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -942,15 +942,15 @@ def _build_agg_args_var(result_column, func, func_args, func_kwargs, input_colum
     # we don't expect positional args here
     if func_args:
         raise TypeError(
-            f"aggregate function '{func}' got unexpected positional arguments {func_args}"
+            f"aggregate function '{func}' doesn't support positional arguments, but got {func_args}"
         )
 
     # and we only expect ddof=N in kwargs
     expected_kwargs = {"ddof"}
     unexpected_kwargs = set(func_kwargs.keys()) - expected_kwargs
-    for arg in unexpected_kwargs:
+    if unexpected_kwargs:
         raise TypeError(
-            f"aggregate function '{func}' got an unexpected keyword argument '{arg}'"
+            f"aggregate function '{func}' supports {expected_kwargs} keyword arguments, but got {unexpected_kwargs}"
         )
 
     return dict(

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -942,7 +942,7 @@ def _build_agg_args_var(result_column, func, func_args, func_kwargs, input_colum
     # we don't expect positional args here
     if func_args:
         raise TypeError(
-            f"aggregate function '{func}' got unexpected positional arguments: {func_args}"
+            f"aggregate function '{func}' got unexpected positional arguments {func_args}"
         )
 
     # and we only expect ddof=N in kwargs
@@ -950,7 +950,7 @@ def _build_agg_args_var(result_column, func, func_args, func_kwargs, input_colum
     unexpected_kwargs = set(func_kwargs.keys()) - expected_kwargs
     for arg in unexpected_kwargs:
         raise TypeError(
-            f"aggregate function '{func}' got an unexpected keyword argument: {arg}"
+            f"aggregate function '{func}' got an unexpected keyword argument '{arg}'"
         )
 
     return dict(

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -838,7 +838,7 @@ def _build_agg_args(spec):
     aggs = {}
     finalizers = []
 
-    # a partial may contain some arguments, pass then down
+    # a partial may contain some arguments, pass them down
     # https://github.com/dask/dask/issues/9615
     for (result_column, func, input_column) in spec:
         func_args = ()

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -3,6 +3,7 @@ import itertools as it
 import operator
 import uuid
 import warnings
+from functools import partial
 from numbers import Integral
 
 import numpy as np
@@ -815,7 +816,13 @@ def _build_agg_args(spec):
         applied after the ``agg_funcs``. They are used to create final results
         from intermediate representations.
     """
-    known_np_funcs = {np.min: "min", np.max: "max", np.median: "median"}
+    known_np_funcs = {
+        np.min: "min",
+        np.max: "max",
+        np.median: "median",
+        np.std: "std",
+        np.var: "var",
+    }
 
     # check that there are no name conflicts for a single input column
     by_name = {}
@@ -831,11 +838,20 @@ def _build_agg_args(spec):
     aggs = {}
     finalizers = []
 
+    # a partial may contain some arguments, pass then down
+    # https://github.com/dask/dask/issues/9615
     for (result_column, func, input_column) in spec:
+        func_args = ()
+        func_kwargs = {}
+        if isinstance(func, partial):
+            func_args, func_kwargs = func.args, func.keywords
+
         if not isinstance(func, Aggregation):
             func = funcname(known_np_funcs.get(func, func))
 
-        impls = _build_agg_args_single(result_column, func, input_column)
+        impls = _build_agg_args_single(
+            result_column, func, func_args, func_kwargs, input_column
+        )
 
         # overwrite existing result-columns, generate intermediates only once
         for spec in impls["chunk_funcs"]:
@@ -851,7 +867,7 @@ def _build_agg_args(spec):
     return chunks, aggs, finalizers
 
 
-def _build_agg_args_single(result_column, func, input_column):
+def _build_agg_args_single(result_column, func, func_args, func_kwargs, input_column):
     simple_impl = {
         "sum": (M.sum, M.sum),
         "min": (M.min, M.min),
@@ -873,10 +889,14 @@ def _build_agg_args_single(result_column, func, input_column):
         )
 
     elif func == "var":
-        return _build_agg_args_var(result_column, func, input_column)
+        return _build_agg_args_var(
+            result_column, func, func_args, func_kwargs, input_column
+        )
 
     elif func == "std":
-        return _build_agg_args_std(result_column, func, input_column)
+        return _build_agg_args_std(
+            result_column, func, func_args, func_kwargs, input_column
+        )
 
     elif func == "mean":
         return _build_agg_args_mean(result_column, func, input_column)
@@ -914,7 +934,7 @@ def _build_agg_args_simple(result_column, func, input_column, impl_pair):
     )
 
 
-def _build_agg_args_var(result_column, func, input_column):
+def _build_agg_args_var(result_column, func, func_args, func_kwargs, input_column):
     int_sum = _make_agg_id("sum", input_column)
     int_sum2 = _make_agg_id("sum2", input_column)
     int_count = _make_agg_id("count", input_column)
@@ -932,13 +952,21 @@ def _build_agg_args_var(result_column, func, input_column):
         finalizer=(
             result_column,
             _finalize_var,
-            dict(sum_column=int_sum, count_column=int_count, sum2_column=int_sum2),
+            dict(
+                sum_column=int_sum,
+                count_column=int_count,
+                sum2_column=int_sum2,
+                *func_args,
+                **func_kwargs,
+            ),
         ),
     )
 
 
-def _build_agg_args_std(result_column, func, input_column):
-    impls = _build_agg_args_var(result_column, func, input_column)
+def _build_agg_args_std(result_column, func, func_args, func_kwargs, input_column):
+    impls = _build_agg_args_var(
+        result_column, func, func_args, func_kwargs, input_column
+    )
 
     result_column, _, kwargs = impls["finalizer"]
     impls["finalizer"] = (result_column, _finalize_std, kwargs)
@@ -1118,7 +1146,8 @@ def _finalize_mean(df, sum_column, count_column):
     return df[sum_column] / df[count_column]
 
 
-def _finalize_var(df, count_column, sum_column, sum2_column, ddof=1):
+def _finalize_var(df, count_column, sum_column, sum2_column, **kwargs):
+    ddof = kwargs.get("ddof", 1)
     n = df[count_column]
     x = df[sum_column]
     x2 = df[sum2_column]
@@ -1132,8 +1161,8 @@ def _finalize_var(df, count_column, sum_column, sum2_column, ddof=1):
     return result
 
 
-def _finalize_std(df, count_column, sum_column, sum2_column, ddof=1):
-    result = _finalize_var(df, count_column, sum_column, sum2_column, ddof)
+def _finalize_std(df, count_column, sum_column, sum2_column, **kwargs):
+    result = _finalize_var(df, count_column, sum_column, sum2_column, **kwargs)
     return np.sqrt(result)
 
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -947,7 +947,7 @@ def _build_agg_args_var(result_column, func, func_args, func_kwargs, input_colum
 
     # and we only expect ddof=N in kwargs
     expected_kwargs = {"ddof"}
-    unexpected_kwargs = set(func_kwargs.keys()) - expected_kwargs
+    unexpected_kwargs = func_kwargs.keys() - expected_kwargs
     if unexpected_kwargs:
         raise TypeError(
             f"aggregate function '{func}' supports {expected_kwargs} keyword arguments, but got {unexpected_kwargs}"

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2599,6 +2599,31 @@ def test_groupby_aggregate_categoricals(grouping, agg):
     assert_eq(agg(grouping(pdf)["value"]), agg(grouping(ddf)["value"]))
 
 
+@pytest.mark.parametrize(
+    "agg",
+    [
+        lambda grp: grp.agg(partial(np.std, ddof=1)),
+        lambda grp: grp.agg(partial(np.std, ddof=-2)),
+        lambda grp: grp.agg(partial(np.var, ddof=1)),
+        lambda grp: grp.agg(partial(np.var, ddof=-2)),
+    ],
+)
+def test_groupby_aggregate_partial_function(agg):
+    pdf = pd.DataFrame(
+        {
+            "a": [5, 4, 3, 5, 4, 2, 3, 2],
+            "b": [1, 2, 5, 6, 9, 2, 6, 8],
+        }
+    )
+    ddf = dd.from_pandas(pdf, 1)
+
+    # DataFrameGroupBy
+    assert_eq(agg(pdf.groupby("a")), agg(ddf.groupby("a")))
+
+    # SeriesGroupBy
+    assert_eq(agg(pdf.groupby("a")["b"]), agg(ddf.groupby("a")["b"]))
+
+
 @pytest.mark.xfail(
     not dask.dataframe.utils.PANDAS_GT_110,
     reason="dropna kwarg not supported in pandas < 1.1.0.",

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2631,6 +2631,30 @@ def test_groupby_aggregate_partial_function(agg):
         lambda grp: grp.agg(partial(np.var, unexpected_arg=1)),
     ],
 )
+def test_groupby_aggregate_partial_function_unexpected_kwargs(agg):
+    pdf = pd.DataFrame(
+        {
+            "a": [5, 4, 3, 5, 4, 2, 3, 2],
+            "b": [1, 2, 5, 6, 9, 2, 6, 8],
+        }
+    )
+    ddf = dd.from_pandas(pdf, npartitions=2)
+
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        agg(ddf.groupby("a")).compute()
+
+    # SeriesGroupBy
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        agg(ddf.groupby("a")["b"]).compute()
+
+
+@pytest.mark.parametrize(
+    "agg",
+    [
+        lambda grp: grp.agg(partial(np.std, "positional_arg")),
+        lambda grp: grp.agg(partial(np.var, "positional_arg")),
+    ],
+)
 def test_groupby_aggregate_partial_function_unexpected_args(agg):
     pdf = pd.DataFrame(
         {
@@ -2640,18 +2664,12 @@ def test_groupby_aggregate_partial_function_unexpected_args(agg):
     )
     ddf = dd.from_pandas(pdf, npartitions=2)
 
-    with pytest.raises((FutureWarning, TypeError)):
-        agg(pdf.groupby("a"))
-
-    with pytest.raises((FutureWarning, TypeError)):
+    with pytest.raises(TypeError, match="unexpected positional arguments"):
         agg(ddf.groupby("a")).compute()
 
     # SeriesGroupBy
-    with pytest.raises((FutureWarning, TypeError)):
-        agg(pdf.groupby("a")["b"])
-
-    with pytest.raises((FutureWarning, TypeError)):
-        agg(ddf.groupby("a")["b"])
+    with pytest.raises(TypeError, match="unexpected positional arguments"):
+        agg(ddf.groupby("a")["b"]).compute()
 
 
 @pytest.mark.xfail(

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2640,11 +2640,17 @@ def test_groupby_aggregate_partial_function_unexpected_kwargs(agg):
     )
     ddf = dd.from_pandas(pdf, npartitions=2)
 
-    with pytest.raises(TypeError, match="unexpected keyword argument"):
+    with pytest.raises(
+        TypeError,
+        match="supports {'ddof'} keyword arguments, but got {'unexpected_arg'}",
+    ):
         agg(ddf.groupby("a"))
 
     # SeriesGroupBy
-    with pytest.raises(TypeError, match="unexpected keyword argument"):
+    with pytest.raises(
+        TypeError,
+        match="supports {'ddof'} keyword arguments, but got {'unexpected_arg'}",
+    ):
         agg(ddf.groupby("a")["b"])
 
 
@@ -2664,11 +2670,11 @@ def test_groupby_aggregate_partial_function_unexpected_args(agg):
     )
     ddf = dd.from_pandas(pdf, npartitions=2)
 
-    with pytest.raises(TypeError, match="unexpected positional arguments"):
+    with pytest.raises(TypeError, match="doesn't support positional arguments"):
         agg(ddf.groupby("a"))
 
     # SeriesGroupBy
-    with pytest.raises(TypeError, match="unexpected positional arguments"):
+    with pytest.raises(TypeError, match="doesn't support positional arguments"):
         agg(ddf.groupby("a")["b"])
 
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2641,11 +2641,11 @@ def test_groupby_aggregate_partial_function_unexpected_kwargs(agg):
     ddf = dd.from_pandas(pdf, npartitions=2)
 
     with pytest.raises(TypeError, match="unexpected keyword argument"):
-        agg(ddf.groupby("a")).compute()
+        agg(ddf.groupby("a"))
 
     # SeriesGroupBy
     with pytest.raises(TypeError, match="unexpected keyword argument"):
-        agg(ddf.groupby("a")["b"]).compute()
+        agg(ddf.groupby("a")["b"])
 
 
 @pytest.mark.parametrize(
@@ -2665,11 +2665,11 @@ def test_groupby_aggregate_partial_function_unexpected_args(agg):
     ddf = dd.from_pandas(pdf, npartitions=2)
 
     with pytest.raises(TypeError, match="unexpected positional arguments"):
-        agg(ddf.groupby("a")).compute()
+        agg(ddf.groupby("a"))
 
     # SeriesGroupBy
     with pytest.raises(TypeError, match="unexpected positional arguments"):
-        agg(ddf.groupby("a")["b"]).compute()
+        agg(ddf.groupby("a")["b"])
 
 
 @pytest.mark.xfail(

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2615,7 +2615,7 @@ def test_groupby_aggregate_partial_function(agg):
             "b": [1, 2, 5, 6, 9, 2, 6, 8],
         }
     )
-    ddf = dd.from_pandas(pdf, 1)
+    ddf = dd.from_pandas(pdf, npartitions=2)
 
     # DataFrameGroupBy
     assert_eq(agg(pdf.groupby("a")), agg(ddf.groupby("a")))


### PR DESCRIPTION
When the user passes a partial function into an aggregation, parameters should not be lost.

- [x] Closes https://github.com/dask/dask/issues/9615
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

TODOs:

- [x] make sure documentation matches the behavior
- [x] handle positional args
- [x] what is `known_np_funcs` being used for?
- [x] anything else from kwargs besides `ddof` that `std` needs?
- [x] do other agg functions need args passed down?

This fixes the incorrect calculation, but may need a follow-up. In Pandas [std](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.std.html) and [var](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.var.html) accept another parameter that I'm not handling here: `numeric_only`. I'm not sure how to handle it here - would need more digging into what Pandas does with it.