### PR TITLE
avoid adding data.h5 to worktree during tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,5 @@ coverage.xml
 .cache/
 hdfs-initialized-indicator
 .ipynb_checkpoints
-mydask.png
 .vscode/
 .history

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -910,12 +910,12 @@ def test_hdf_nonpandas_keys():
         dd.read_hdf(path, "/bar")
 
 
-def test_hdf_empty_dataframe():
+def test_hdf_empty_dataframe(tmp_path):
     pytest.importorskip("tables")
     # https://github.com/dask/dask/issues/8707
     from dask.dataframe.io.hdf import dont_use_fixed_error_message
 
     df = pd.DataFrame({"A": [], "B": []}, index=[])
-    df.to_hdf("data.h5", format="fixed", key="df", mode="w")
+    df.to_hdf(tmp_path / "data.h5", format="fixed", key="df", mode="w")
     with pytest.raises(TypeError, match=dont_use_fixed_error_message):
-        dd.read_hdf("data.h5", "df")
+        dd.read_hdf(tmp_path / "data.h5", "df")

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -111,10 +111,11 @@ def test_to_graphviz_custom():
     assert set(shapes) == {"box", "circle", "square", "ellipse"}
 
 
-def test_cytoscape_graph_custom():
+def test_cytoscape_graph_custom(tmp_path):
     # Check that custom styling and layout propagates through
     g = cytoscape_graph(
         dsk,
+        filename=os.fsdecode(tmp_path / "mydask.html"),
         rankdir="LR",
         node_sep=20,
         edge_sep=30,


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
