### PR TITLE
Introduce support for directory-specific Dask config

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -28,13 +28,31 @@ def _get_paths():
         os.path.join(sys.prefix, "etc", "dask"),
         *[os.path.join(prefix, "etc", "dask") for prefix in site.PREFIXES],
         os.path.join(os.path.expanduser("~"), ".config", "dask"),
-        os.path.join(os.getcwd(), ".dask"),
     ]
     if "DASK_CONFIG" in os.environ:
-        paths.insert(-1, os.environ["DASK_CONFIG"])
+        paths.append(os.environ["DASK_CONFIG"])
+    dot_file_paths = _get_dot_file_paths()
+    if dot_file_paths:
+        paths.append(*dot_file_paths)
 
     # Remove duplicate paths while preserving ordering
     paths = list(reversed(list(dict.fromkeys(reversed(paths)))))
+
+    return paths
+
+
+def _get_dot_file_paths():
+    """Get locations of existing `.dask` configuration files from current directory to root."""
+
+    current_path = os.getcwd()
+    paths = []
+    while True:
+        config_file = os.path.join(current_path, ".dask")
+        if os.path.isfile(config_file):
+            paths.insert(0, config_file)
+        if current_path == "/":
+            break
+        current_path = os.path.dirname(current_path)
 
     return paths
 


### PR DESCRIPTION
Adds directory-specific `.dask` config files (name chosen arbitrarily) to the top of Dask's config precedence, with those closest to the current working directory prioritized, making it so users can configure Dask on a per-[sub]directory level.

- [ ] Closes #9702 
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
