### PR TITLE
Remove source and target optimization in array.store

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1184,7 +1184,7 @@ def store(
 
     if targets_dsks:
         targets_hlg = HighLevelGraph.merge(*targets_dsks)
-        targets_layer = Delayed.__dask_optimize__(targets_hlg, targets_keys)
+        targets_layer = targets_hlg.cull(targets_keys)
         targets_name = "store-targets-" + tokenize(targets_keys)
         layers[targets_name] = targets_layer
         dependencies[targets_name] = set()

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1164,16 +1164,15 @@ def store(
             )
     del regions
 
-    # Optimize all sources together
+    # Merge source graphs together
     sources_hlg = HighLevelGraph.merge(*[e.__dask_graph__() for e in sources])
-    sources_layer = Array.__dask_optimize__(
-        sources_hlg, list(core.flatten([e.__dask_keys__() for e in sources]))
-    )
+    sources_keys = set(core.flatten([e.__dask_keys__() for e in sources]))
+    sources_layer = sources_hlg.cull(sources_keys)
     sources_name = "store-sources-" + tokenize(sources)
     layers = {sources_name: sources_layer}
     dependencies: dict[str, set[str]] = {sources_name: set()}
 
-    # Optimize all targets together
+    # Merge target graphs together
     targets_keys = []
     targets_dsks = []
     for t in targets:


### PR DESCRIPTION
As discussed in #8380, there are cases where a user may want to store multiple sources or store to multiple targets that share tasks somewhere in their history. In current `main` calling `da.store` with `compute=False` results in the individual dask graphs being optimized (fused tasks, renamed tasks, etc) which means future computations won't be able to combine/share tasks any more. In simplified code this looks like:

```python
src1 = ...
src2 = ...  # <- shares tasks with src1
store1 = da.store(src1, target1, compute=False)
store2 = da.store(src2, target2, compute=False)
da.compute(store1, store2)  # <- this will compute shared tasks twice
```

As I was working on a fix for this, I realized that I don't think there is any need for `da.store` to optimize anything before final computation. I *think* all computation will optimize the graphs anyway so the only benefit to early optimization is to reduce the graphs/dictionaries that are passed around internally in `da.store` (a small benefit if I'm not mistaken).

Lastly a question on dask PR best practice: What are the feelings about including refactorings in a PR alongside bug fixes? For example, the `da.store` function could be split into a lot of sub-functions that would reduce cyclomatic complexity of the function and make it easier to read. But for overall appearance of the PR it could make it harder to review.

- [x] Closes #8380
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
