### PR TITLE
Avoid `np.bool8` deprecation warning

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -684,7 +684,7 @@ def gradient(f, *varargs, axis=None, **kwargs):
             "Spacing must either be a single scalar, or a scalar / 1d-array per axis"
         )
 
-    if issubclass(f.dtype.type, (np.bool8, Integral)):
+    if issubclass(f.dtype.type, (np.bool_, Integral)):
         f = f.astype(float)
     elif issubclass(f.dtype.type, Real) and f.dtype.itemsize < 4:
         f = f.astype(float)


### PR DESCRIPTION
This appears to handle the `dask/array` failures in https://github.com/dask/dask/issues/9736

EDIT: FYI "DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`" is what we're getting in the `upstream` build. 