### PR TITLE
Fix bug when repartitioning with tz-aware datetime index

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -7495,10 +7495,10 @@ def repartition_npartitions(df, npartitions):
         # value for min and max division
         original_divisions = divisions = pd.Series(df.divisions).drop_duplicates()
         if df.known_divisions and (
-            np.issubdtype(divisions.dtype, np.datetime64)
-            or np.issubdtype(divisions.dtype, np.number)
+            is_datetime64_any_dtype(divisions.dtype)
+            or is_numeric_dtype(divisions.dtype)
         ):
-            if np.issubdtype(divisions.dtype, np.datetime64):
+            if is_datetime64_any_dtype(divisions.dtype):
                 divisions = divisions.values.astype("float64")
 
             if is_series_like(divisions):
@@ -7510,7 +7510,7 @@ def repartition_npartitions(df, npartitions):
                 xp=np.linspace(0, n, n),
                 fp=divisions,
             )
-            if np.issubdtype(original_divisions.dtype, np.datetime64):
+            if is_datetime64_any_dtype(original_divisions.dtype):
                 divisions = methods.tolist(
                     pd.Series(divisions).astype(original_divisions.dtype)
                 )


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/8788

Originally, I was going to extend the test here to other extension index dtypes, but ran into an issue in `pandas`. Opened https://github.com/pandas-dev/pandas/issues/50161. 