### PR TITLE
Stateless co-groups algorithm based on `dask.order` priorities

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -647,6 +647,7 @@ def visualize(
         - 'order', colors the nodes' border based on the order they appear in the graph.
         - 'cogroup', which tasks are in the same "coassignment group" and should be
            scheduled on the same worker.
+        - 'cogroup-name', same as 'cogroup', but print task names instead of priority numbers.
         - 'ages', how long the data of a node is held.
         - 'freed', the number of dependencies released after running a node.
         - 'memoryincreases', how many more outputs are held after the lifetime of a node.
@@ -710,6 +711,7 @@ def visualize(
         "memorydecreases",
         "memorypressure",
         "cogroup",
+        "cogroup-name",
     }:
         import matplotlib.pyplot as plt
 
@@ -735,7 +737,7 @@ def visualize(
             return str(values[x])
 
         data_values = None
-        if color == "cogroup":
+        if color.startswith("cogroup"):
             from dask.cogroups import cogroup
 
             groups = {
@@ -749,12 +751,21 @@ def visualize(
                 k: g if not isolated else 0 for k, (g, isolated) in groups.items()
             }
 
-            def label(x):
-                return str(o[x]) + f" ({groups[x][0]})"
-
             def style(x) -> str | None:
                 return None if groups[x][1] else "dashed"
 
+            if color == "cogroup":
+
+                def label(x):
+                    return str(o[x]) + f" ({groups[x][0]})"
+
+            elif color == "cogroup-name":
+
+                def label(x):
+                    return key_split(x) + f" ({groups[x][0]})"
+
+            else:
+                raise NotImplementedError("Unknown value color=%s" % color)
         elif color != "order":
             info = diagnostics(dsk, o)[0]
             if color.endswith("age"):

--- a/dask/base.py
+++ b/dask/base.py
@@ -29,7 +29,7 @@ from dask.compatibility import _EMSCRIPTEN, _PY_VERSION
 from dask.context import thread_state
 from dask.core import flatten
 from dask.core import get as simple_get
-from dask.core import get_dependencies, literal, quote, reverse_dict
+from dask.core import get_dependencies, literal, quote
 from dask.hashing import hash_buffer_hex
 from dask.system import CPU_COUNT
 from dask.typing import SchedulerGetCallable
@@ -718,9 +718,7 @@ def visualize(
         from dask.order import diagnostics, order
 
         dependencies = {k: get_dependencies(dsk, k) for k in dsk}
-        dependents = reverse_dict(dependencies)
-
-        o = order(dsk, dependencies=dependencies, dependents=dependents)
+        o = order(dsk, dependencies=dependencies)
         try:
             cmap = kwargs.pop("cmap")
         except KeyError:
@@ -742,9 +740,7 @@ def visualize(
 
             groups = {
                 k: (i, isolated)
-                for i, (keys, isolated) in enumerate(
-                    cogroup(o, dependencies, dependents), start=1
-                )
+                for i, (keys, isolated) in enumerate(cogroup(o, dependencies), start=1)
                 for k in keys
             }
             values = {

--- a/dask/base.py
+++ b/dask/base.py
@@ -712,6 +712,7 @@ def visualize(
         "memorypressure",
         "cogroup",
         "cogroup-name",
+        "cogroup-nonrec",
     }:
         import matplotlib.pyplot as plt
 
@@ -736,7 +737,10 @@ def visualize(
 
         data_values = None
         if color.startswith("cogroup"):
-            from dask.cogroups import cogroup
+            if color == "cogroup-nonrec":
+                from dask.cogroups import cogroup
+            else:
+                from dask.cogroups import cogroup_recursive as cogroup  # type: ignore
 
             groups = {
                 k: (i, isolated)
@@ -749,7 +753,7 @@ def visualize(
                 g, isolated = groups[x]
                 return None if isolated else "dashed"
 
-            if color == "cogroup":
+            if color in ("cogroup", "cogroup-nonrec"):
 
                 def label(x):
                     return str(o[x]) + f" ({groups[x][0]})"

--- a/dask/base.py
+++ b/dask/base.py
@@ -807,7 +807,8 @@ def visualize(
             for k, v in colors.items()
         }
         kwargs["data_attributes"] = {
-            k: {"color": v, "style": style(k)} for k, v in data_colors.items()
+            k: {"color": v, "label": label(k), "style": style(k)}
+            for k, v in data_colors.items()
         }
     elif color:
         raise NotImplementedError("Unknown value color=%s" % color)

--- a/dask/base.py
+++ b/dask/base.py
@@ -743,12 +743,11 @@ def visualize(
                 for i, (keys, isolated) in enumerate(cogroup(o, dependencies), start=1)
                 for k in keys
             }
-            values = {
-                k: g if not isolated else 0 for k, (g, isolated) in groups.items()
-            }
+            values = {k: g for k, (g, isolated) in groups.items()}
 
             def style(x) -> str | None:
-                return None if groups[x][1] else "dashed"
+                g, isolated = groups[x]
+                return None if isolated else "dashed"
 
             if color == "cogroup":
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -738,26 +738,19 @@ def visualize(
         if color.startswith("cogroup"):
             from dask.cogroups import cogroup
 
-            groups = {
-                k: (i, isolated)
-                for i, (keys, isolated) in enumerate(cogroup(o, dependencies))
-                for k in keys
+            values = {
+                k: i for i, keys in enumerate(cogroup(o, dependencies)) for k in keys
             }
-            values = {k: g for k, (g, isolated) in groups.items()}
-
-            def style(x) -> str | None:
-                g, isolated = groups[x]
-                return None if isolated else "dashed"
 
             if color == "cogroup":
 
                 def label(x):
-                    return str(o[x]) + f" ({groups[x][0]})"
+                    return str(o[x]) + f" ({values[x]})"
 
             elif color == "cogroup-name":
 
                 def label(x):
-                    return key_split(x) + f" ({groups[x][0]})"
+                    return key_split(x) + f" ({values[x]})"
 
             else:
                 raise NotImplementedError("Unknown value color=%s" % color)

--- a/dask/base.py
+++ b/dask/base.py
@@ -712,7 +712,6 @@ def visualize(
         "memorypressure",
         "cogroup",
         "cogroup-name",
-        "cogroup-nonrec",
     }:
         import matplotlib.pyplot as plt
 
@@ -737,12 +736,7 @@ def visualize(
 
         data_values = None
         if color.startswith("cogroup"):
-            if color == "cogroup-nonrec":
-                from dask.cogroups import cogroup
-
-                cogroup = partial(cogroup, max_chain=kwargs.pop("max_chain", None))
-            else:
-                from dask.cogroups import cogroup_recursive as cogroup  # type: ignore
+            from dask.cogroups import cogroup
 
             groups = {
                 k: (i, isolated)
@@ -755,7 +749,7 @@ def visualize(
                 g, isolated = groups[x]
                 return None if isolated else "dashed"
 
-            if color in ("cogroup", "cogroup-nonrec"):
+            if color == "cogroup":
 
                 def label(x):
                     return str(o[x]) + f" ({groups[x][0]})"

--- a/dask/base.py
+++ b/dask/base.py
@@ -739,6 +739,8 @@ def visualize(
         if color.startswith("cogroup"):
             if color == "cogroup-nonrec":
                 from dask.cogroups import cogroup
+
+                cogroup = partial(cogroup, max_chain=kwargs.pop("max_chain", None))
             else:
                 from dask.cogroups import cogroup_recursive as cogroup  # type: ignore
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -740,7 +740,7 @@ def visualize(
 
             groups = {
                 k: (i, isolated)
-                for i, (keys, isolated) in enumerate(cogroup(o, dependencies), start=1)
+                for i, (keys, isolated) in enumerate(cogroup(o, dependencies))
                 for k in keys
             }
             values = {k: g for k, (g, isolated) in groups.items()}

--- a/dask/cogroups.py
+++ b/dask/cogroups.py
@@ -33,6 +33,7 @@ def cogroup(
             if (
                 # linear chain
                 (was_chain := (current_prio == prev_prio + 1))
+                # TODO update this comment:
                 # where inputs don't already belong to a different cogroup.
                 # If a task has multiple families as inputs, we don't know how to group
                 # it yet---that's a `decide_worker` choice based on data size at
@@ -41,7 +42,10 @@ def cogroup(
                 # TODO can we just more broadly say linear chains have 1 dependency?
                 # IDEA: if it depends on exactly 1 other cogroup, then roll this cogroup
                 # into that previous cogroup?
-                and all(priorities[dk] >= start_prio for dk in dependencies[key])
+                and not any(
+                    priorities[dk] < start_prio and len(dependents[dk]) == 1
+                    for dk in dependencies[key]
+                )
             ):
                 # TODO if this chain is all linear, try again from the start with the next-smallest dependent
                 prev_prio = current_prio

--- a/dask/cogroups.py
+++ b/dask/cogroups.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import operator
+from typing import Hashable, Iterator
+
+
+def cogroup(
+    priorities: dict[Hashable, int],
+    dependencies: dict[Hashable, set[Hashable]],
+    dependents: dict[Hashable, set[Hashable]],
+) -> Iterator[tuple[list[Hashable], bool]]:
+    kps = sorted(priorities.items(), key=operator.itemgetter(1))
+
+    # Assume priorities are consecutive, starting from 0
+    assert all(kp[1] == i for kp, i in zip(kps, range(len(kps)))), kps
+
+    cogroup_start_i = 0
+    while cogroup_start_i < len(kps):
+        key, current_prio = kps[cogroup_start_i]
+        prev_prio = start_prio = current_prio
+        assert start_prio == cogroup_start_i, (start_prio, cogroup_start_i)
+        # TODO `start_prio` and `cogroup_start_i` are redundant if prios are consecutive from 0
+        isolated_cogroup: bool = False
+
+        # Walk linear chains of consecutive priority, either until we hit a priority jump,
+        # or a task with dependencies that are outside of our group.
+        while downstream := dependents[key]:
+            key = min(downstream, key=priorities.__getitem__)
+            current_prio = priorities[key]
+
+            if (
+                # linear chain
+                (was_chain := (current_prio == prev_prio + 1))
+                # where inputs don't already belong to a different cogroup.
+                # If a task has multiple families as inputs, we don't know how to group
+                # it yet---that's a `decide_worker` choice based on data size at
+                # runtime. This prevents multi-stage fan-in tasks from "eating" the
+                # whole graph.
+                # TODO can we just more broadly say linear chains have 1 dependency?
+                # IDEA: if it depends on exactly 1 other cogroup, then roll this cogroup
+                # into that previous cogroup?
+                and all(priorities[dk] >= start_prio for dk in dependencies[key])
+            ):
+                # TODO if this chain is all linear, try again from the start with the next-smallest dependent
+                prev_prio = current_prio
+            else:
+                # non-consecutive priority jump. this is our max node.
+
+                # check if we've jumped over a fully disjoint part of the graph
+                i = cogroup_start_i + (current_prio - start_prio)
+                if kps[i - 1][0] in dependencies[key]:
+                    # Seems connected
+
+                    if not was_chain:
+                        # ended up in this branch because `was_chain` was false, not because
+                        # inputs belonged to a different cogroup. so this is an isolated cogroup
+                        # because it doesn't need to consider the location of any inputs.
+                        isolated_cogroup = True
+                        assert current_prio > start_prio + 1, (
+                            current_prio,
+                            start_prio,
+                            key,
+                        )
+                else:
+                    # If we've jumped over a disjoint subgraph, don't eat it.
+                    # Roll back and just take the linear chain.
+                    current_prio = prev_prio
+
+                break
+
+        # all tasks from the start to the max (inclusive) belong to the cogroup.
+        next_start_i = cogroup_start_i + (current_prio - start_prio) + 1
+        yield [kp[0] for kp in kps[cogroup_start_i:next_start_i]], isolated_cogroup
+        cogroup_start_i = next_start_i

--- a/dask/cogroups.py
+++ b/dask/cogroups.py
@@ -12,27 +12,31 @@ def cogroup(
 ) -> Iterator[tuple[list[Hashable], bool]]:
     dependents: dict[Hashable, set[Hashable]] = reverse_dict(dependencies)
     kps = sorted(priorities.items(), key=operator.itemgetter(1))
+    # ^ can't `zip(*sorted...)` because of mypy: https://github.com/python/mypy/issues/5247
+    keys = [kp[0] for kp in kps]
+    prios = [kp[1] for kp in kps]
+    del kps
 
-    # Assume priorities are consecutive, starting from 0
-    assert all(kp[1] == i for kp, i in zip(kps, range(len(kps)))), kps
+    # Assume priorities are consecutive, starting from 0.
+    # This makes priorities and indices interchangeable: `keys[i]` has priority `i`.
+    assert all(p == i for p, i in zip(prios, range(len(keys)))), prios
+    del prios
 
-    cogroup_start_i = 0
-    while cogroup_start_i < len(kps):
-        key, current_prio = kps[cogroup_start_i]
-        prev_prio = start_prio = current_prio
-        assert start_prio == cogroup_start_i, (start_prio, cogroup_start_i)
-        # TODO `start_prio` and `cogroup_start_i` are redundant if prios are consecutive from 0
+    i = 0
+    while i < len(keys):
+        start_i = prev_i = i
+        key = keys[i]
         isolated_cogroup: bool = False
 
         # Walk linear chains of consecutive priority, either until we hit a priority jump,
         # or a task with dependencies that are outside of our group.
         while downstream := dependents[key]:
             key = min(downstream, key=priorities.__getitem__)
-            current_prio = priorities[key]
+            i = priorities[key]
 
             if (
                 # linear chain
-                (was_chain := (current_prio == prev_prio + 1))
+                (was_chain := (i == prev_i + 1))
                 # TODO update this comment:
                 # where inputs don't already belong to a different cogroup.
                 # If a task has multiple families as inputs, we don't know how to group
@@ -43,12 +47,14 @@ def cogroup(
                 # IDEA: if it depends on exactly 1 other cogroup, then roll this cogroup
                 # into that previous cogroup?
                 and not any(
-                    priorities[dk] < start_prio and len(dependents[dk]) == 1
+                    priorities[dk] < start_i and len(dependents[dk]) == 1
                     for dk in dependencies[key]
                 )
             ):
-                # TODO if this chain is all linear, try again from the start with the next-smallest dependent
-                prev_prio = current_prio
+                # walk up the linear chain
+                # TODO if we reach the top without a jump, try again from the start with
+                # the next-smallest dependent
+                prev_i = i
             else:
                 # non-consecutive priority jump. this is our max node.
 
@@ -57,15 +63,14 @@ def cogroup(
                     # inputs belonged to a different cogroup. so this is an isolated cogroup
                     # because it doesn't need to consider the location of any inputs.
                     isolated_cogroup = True
-                    assert current_prio > start_prio + 1, (
-                        current_prio,
-                        start_prio,
+                    assert i > start_i + 1, (
+                        i,
+                        start_i,
                         key,
                     )
 
                 break
 
-        # all tasks from the start to the max (inclusive) belong to the cogroup.
-        next_start_i = cogroup_start_i + (current_prio - start_prio) + 1
-        yield [kp[0] for kp in kps[cogroup_start_i:next_start_i]], isolated_cogroup
-        cogroup_start_i = next_start_i
+        # all tasks from the start to the current (inclusive) belong to the cogroup.
+        i = i + 1
+        yield keys[start_i:i], isolated_cogroup

--- a/dask/cogroups.py
+++ b/dask/cogroups.py
@@ -37,15 +37,8 @@ def cogroup(
             if (
                 # linear chain
                 (was_chain := (i == prev_i + 1))
-                # TODO update this comment:
-                # where inputs don't already belong to a different cogroup.
-                # If a task has multiple families as inputs, we don't know how to group
-                # it yet---that's a `decide_worker` choice based on data size at
-                # runtime. This prevents multi-stage fan-in tasks from "eating" the
-                # whole graph.
-                # TODO can we just more broadly say linear chains have 1 dependency?
-                # IDEA: if it depends on exactly 1 other cogroup, then roll this cogroup
-                # into that previous cogroup?
+                # If an input comes from a different cogroup, and it's only
+                # used in this group, don't walk past it.
                 and not any(
                     priorities[dk] < start_i and len(dependents[dk]) == 1
                     for dk in dependencies[key]

--- a/dask/cogroups.py
+++ b/dask/cogroups.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
 import operator
-from typing import Hashable, Iterator
+from bisect import bisect_right
+from typing import Hashable, Iterator, NewType, TypeVar
 
+import dask
 from dask.core import reverse_dict
+from dask.delayed import Delayed
+from dask.order import order
+
+KT = TypeVar("KT", bound=Hashable)
 
 
 def cogroup(
-    priorities: dict[Hashable, int],
-    dependencies: dict[Hashable, set[Hashable]],
-) -> Iterator[tuple[list[Hashable], bool]]:
-    dependents: dict[Hashable, set[Hashable]] = reverse_dict(dependencies)
+    priorities: dict[KT, int],
+    dependencies: dict[KT, set[KT]],
+) -> Iterator[tuple[list[KT], bool]]:
+    dependents: dict[KT, set[KT]] = reverse_dict(dependencies)
     kps = sorted(priorities.items(), key=operator.itemgetter(1))
     # ^ can't `zip(*sorted...)` because of mypy: https://github.com/python/mypy/issues/5247
     keys = [kp[0] for kp in kps]
@@ -75,3 +81,109 @@ def cogroup(
         # all tasks from the start to the current (inclusive) belong to the cogroup.
         i = i + 1
         yield keys[start_i:i], isolated_cogroup
+
+
+CogroupID = NewType("CogroupID", int)
+
+
+def f(*args):
+    pass
+
+
+def _cogroup_recursive(
+    priorities: dict[KT, int],
+    dependencies: dict[KT, set[KT]],
+    prev_n_groups: int | None,
+    min_groups: int | None,
+    depth: int,
+) -> tuple[list[tuple[list[KT], bool]], dict[CogroupID, set[CogroupID]]] | None:
+
+    dsk = {k: (f, *deps) for k, deps in dependencies.items()}
+    dask.visualize(
+        [Delayed(k, dsk) for k in dsk],
+        filename=f"cogroup-l{depth}.png",
+        color="cogroup-nonrec",
+        optimize_graph=False,
+        collapse_outputs=True,
+    )
+
+    groups: list[tuple[list[KT], bool]] = []
+    group_deps: dict[CogroupID, set[CogroupID]] = {}
+    group_end_idxs: list[int] = []
+
+    def cogroup_of(key: KT) -> CogroupID:
+        return CogroupID(bisect_right(group_end_idxs, priorities[key]))
+
+    for group_id, (keys, isolated) in enumerate(cogroup(priorities, dependencies)):
+        deps: set[CogroupID]
+        group_deps[CogroupID(group_id)] = deps = set()
+        groups.append((keys, isolated))
+        group_end_idxs.append((group_end_idxs[-1] if group_end_idxs else 0) + len(keys))
+        assert group_end_idxs[-1] == priorities[keys[-1]] + 1
+
+        for key in keys:
+            deps.update(
+                dg for dk in dependencies[key] if (dg := cogroup_of(dk)) != group_id
+            )
+
+    # `cogroup` guarantees keys are in continuous priority order from 0
+    assert (ks := [k for (g, i) in groups for k in g]) == (
+        s := sorted(ks, key=priorities.__getitem__)
+    ), (ks, s)
+    assert (kps := [priorities[k] for k in ks]) == list(range(len(ks))), kps
+
+    if (prev_n_groups and len(groups) == prev_n_groups) or (
+        min_groups and len(groups) < min_groups
+    ):
+        # Terminal case: no more change, or we've collapsed too much.
+        return None
+
+    if min_groups is None:
+        # Calculate the number of output groups (groups with no dependents) at depth 0.
+        # We shouldn't consolidate more than this (otherwise unrelated outputs be getting
+        # bundled together).
+        min_groups = sum(len(d) == 0 for d in reverse_dict(group_deps).values())
+
+    # HACK: `order` doesn't actually care if `dsk` is a dask; just uses it to calculate dependencies.
+    # if you don't pass them in. We can pass any collection as long as it's the right length.
+    new_order = order(group_deps, dependencies=group_deps)
+
+    if r := _cogroup_recursive(
+        new_order,
+        group_deps,
+        len(groups),
+        min_groups,
+        depth + 1,
+    ):
+        # Recursive case: a subsequent co-grouping reduced the number of groups without collapsing too much.
+        # Translate the keys back, and return it.
+        # The new groups can only be supersets of the old ones, so this just means grouping the old keys
+        # by the new group boundaries
+        new_groups, new_group_deps = r
+
+        assert len(new_groups) <= len(groups)
+
+        translated_groups = [
+            ([k for gid in sorted(group) for k in groups[gid][0]], isolated)
+            for (group, isolated) in new_groups
+        ]
+
+        assert len(translated_groups) == len(new_group_deps)
+        # After translating, keys are _not_ guaranteed to be in priority order any more??
+
+        # assert ks == (nks := [k for (g, i) in translated_groups for k in g]), (ks, nks)
+        # assert (kps := [priorities[k] for k in ks]) == list(range(len(ks))), kps
+
+        return translated_groups, new_group_deps
+
+    # Recursing went too far. Use what we have.
+    return groups, group_deps
+
+
+def cogroup_recursive(
+    priorities: dict[KT, int],
+    dependencies: dict[KT, set[KT]],
+) -> list[tuple[list[KT], bool]]:
+    r = _cogroup_recursive(priorities, dependencies, None, None, 0)
+    assert r
+    return r[0]

--- a/dask/cogroups.py
+++ b/dask/cogroups.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import operator
 from typing import Hashable, Iterator
 
+from dask.core import reverse_dict
+
 
 def cogroup(
     priorities: dict[Hashable, int],
     dependencies: dict[Hashable, set[Hashable]],
-    dependents: dict[Hashable, set[Hashable]],
 ) -> Iterator[tuple[list[Hashable], bool]]:
+    dependents: dict[Hashable, set[Hashable]] = reverse_dict(dependencies)
     kps = sorted(priorities.items(), key=operator.itemgetter(1))
 
     # Assume priorities are consecutive, starting from 0

--- a/dask/cogroups.py
+++ b/dask/cogroups.py
@@ -48,25 +48,16 @@ def cogroup(
             else:
                 # non-consecutive priority jump. this is our max node.
 
-                # check if we've jumped over a fully disjoint part of the graph
-                i = cogroup_start_i + (current_prio - start_prio)
-                if kps[i - 1][0] in dependencies[key]:
-                    # Seems connected
-
-                    if not was_chain:
-                        # ended up in this branch because `was_chain` was false, not because
-                        # inputs belonged to a different cogroup. so this is an isolated cogroup
-                        # because it doesn't need to consider the location of any inputs.
-                        isolated_cogroup = True
-                        assert current_prio > start_prio + 1, (
-                            current_prio,
-                            start_prio,
-                            key,
-                        )
-                else:
-                    # If we've jumped over a disjoint subgraph, don't eat it.
-                    # Roll back and just take the linear chain.
-                    current_prio = prev_prio
+                if not was_chain:
+                    # ended up in this branch because `was_chain` was false, not because
+                    # inputs belonged to a different cogroup. so this is an isolated cogroup
+                    # because it doesn't need to consider the location of any inputs.
+                    isolated_cogroup = True
+                    assert current_prio > start_prio + 1, (
+                        current_prio,
+                        start_prio,
+                        key,
+                    )
 
                 break
 

--- a/dask/cogroups.py
+++ b/dask/cogroups.py
@@ -164,7 +164,10 @@ def _cogroup_recursive(
         assert len(new_groups) <= len(groups)
 
         translated_groups = [
-            ([k for gid in sorted(group) for k in groups[gid][0]], isolated)
+            (
+                [k for gid in sorted(group) for k in groups[gid][0]],
+                any(groups[gid][1] for gid in group),
+            )
             for (group, isolated) in new_groups
         ]
 

--- a/dask/cogroups.py
+++ b/dask/cogroups.py
@@ -58,16 +58,24 @@ def cogroup(
             else:
                 # non-consecutive priority jump. this is our max node.
 
-                if not was_chain:
-                    # ended up in this branch because `was_chain` was false, not because
-                    # inputs belonged to a different cogroup. so this is an isolated cogroup
-                    # because it doesn't need to consider the location of any inputs.
-                    isolated_cogroup = True
-                    assert i > start_i + 1, (
-                        i,
-                        start_i,
-                        key,
-                    )
+                # check if we've jumped over a fully disjoint part of the graph
+                if keys[i - 1] in dependencies[key]:
+                    # Seems connected
+
+                    if not was_chain:
+                        # ended up in this branch because `was_chain` was false, not because
+                        # inputs belonged to a different cogroup. so this is an isolated cogroup
+                        # because it doesn't need to consider the location of any inputs.
+                        isolated_cogroup = True
+                        assert i > start_i + 1, (
+                            i,
+                            start_i,
+                            key,
+                        )
+                else:
+                    # If we've jumped over a disjoint subgraph, don't eat it.
+                    # Roll back and just take the linear chain.
+                    i = prev_i
 
                 break
 

--- a/dask/cogroups.py
+++ b/dask/cogroups.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 import operator
-from bisect import bisect_right
-from typing import Hashable, Iterator, NewType, TypeVar
+from typing import Hashable, Iterator, TypeVar
 
-import dask
 from dask.core import reverse_dict
-from dask.delayed import Delayed
-from dask.order import graph_metrics, ndependencies, order
 
 KT = TypeVar("KT", bound=Hashable)
 
@@ -15,7 +11,6 @@ KT = TypeVar("KT", bound=Hashable)
 def cogroup(
     priorities: dict[KT, int],
     dependencies: dict[KT, set[KT]],
-    max_chain: int | None = None,
 ) -> Iterator[tuple[list[KT], bool]]:
     dependents: dict[KT, set[KT]] = reverse_dict(dependencies)
     kps = sorted(priorities.items(), key=operator.itemgetter(1))
@@ -31,7 +26,6 @@ def cogroup(
 
     i = 0
     while i < len(keys):
-        chain_len = 0
         start_i = prev_i = i
         key = keys[i]
         isolated_cogroup: bool = False
@@ -56,9 +50,6 @@ def cogroup(
                 # TODO if we reach the top without a jump, try again from the start with
                 # the next-smallest dependent
                 prev_i = i
-                chain_len += 1
-                if max_chain is not None and chain_len == max_chain:
-                    break
             else:
                 # non-consecutive priority jump. this is our max node.
 
@@ -87,139 +78,3 @@ def cogroup(
         # all tasks from the start to the current (inclusive) belong to the cogroup.
         i = i + 1
         yield keys[start_i:i], isolated_cogroup
-
-
-CogroupID = NewType("CogroupID", int)
-
-
-def f(*args):
-    pass
-
-
-def _cogroup_recursive(
-    *,
-    priorities: dict[KT, int],
-    dependencies: dict[KT, set[KT]],
-    prev_n_groups: int | None,
-    min_groups: int | None,
-    max_chain: int | None,
-    depth: int,
-) -> tuple[list[tuple[list[KT], bool]], dict[CogroupID, set[CogroupID]]] | None:
-
-    dsk = {k: (f, *deps) for k, deps in dependencies.items()}
-    dask.visualize(
-        [Delayed(k, dsk) for k in dsk],
-        filename=f"cogroup-l{depth}.png",
-        color="cogroup-nonrec",
-        optimize_graph=False,
-        collapse_outputs=True,
-        max_chain=max_chain,
-    )
-
-    groups: list[tuple[list[KT], bool]] = []
-    group_deps: dict[CogroupID, set[CogroupID]] = {}
-    group_end_idxs: list[int] = []
-
-    def cogroup_of(key: KT) -> CogroupID:
-        return CogroupID(bisect_right(group_end_idxs, priorities[key]))
-
-    for group_id, (keys, isolated) in enumerate(
-        cogroup(priorities, dependencies, max_chain)
-    ):
-        deps: set[CogroupID]
-        group_deps[CogroupID(group_id)] = deps = set()
-        groups.append((keys, isolated))
-        group_end_idxs.append((group_end_idxs[-1] if group_end_idxs else 0) + len(keys))
-        assert group_end_idxs[-1] == priorities[keys[-1]] + 1
-
-        for key in keys:
-            deps.update(
-                dg for dk in dependencies[key] if (dg := cogroup_of(dk)) != group_id
-            )
-
-    # `cogroup` guarantees keys are in continuous priority order from 0
-    assert (ks := [k for (g, i) in groups for k in g]) == (
-        s := sorted(ks, key=priorities.__getitem__)
-    ), (ks, s)
-    assert (kps := [priorities[k] for k in ks]) == list(range(len(ks))), kps
-
-    if (prev_n_groups and len(groups) == prev_n_groups) or (
-        min_groups and len(groups) < min_groups
-    ):
-        # Terminal case: no more change, or we've collapsed too much.
-        return None
-
-    if min_groups is None:
-        # Calculate the number of output groups (groups with no dependents) at depth 0.
-        # We shouldn't consolidate more than this (otherwise unrelated outputs be getting
-        # bundled together).
-        n_output_groups = sum(len(d) == 0 for d in reverse_dict(group_deps).values())
-        # If there's just 1 output, don't let it get overly collapsed.
-        min_groups = max(2, n_output_groups)
-
-    if max_chain is None:
-        dependents = reverse_dict(dependencies)
-        num_needed, total_dependencies = ndependencies(dependencies, dependents)
-        metrics = graph_metrics(dependencies, dependents, total_dependencies)
-
-        # item 5: **max_height**: The maximum height from a root node
-        # TODO don't generalize over the whole graph; different sections might have
-        # different heights.
-        max_chain = max(m[4] for m in metrics.values()) - 1
-
-    # HACK: `order` doesn't actually care if `dsk` is a dask; just uses it to calculate dependencies.
-    # if you don't pass them in. We can pass any collection as long as it's the right length.
-    new_order = order(group_deps, dependencies=group_deps)
-
-    assert min_groups is not None
-    assert max_chain is not None
-    if r := _cogroup_recursive(
-        priorities=new_order,
-        dependencies=group_deps,
-        prev_n_groups=len(groups),
-        min_groups=min_groups,
-        max_chain=max_chain - 1,
-        depth=depth + 1,
-    ):
-        # Recursive case: a subsequent co-grouping reduced the number of groups without collapsing too much.
-        # Translate the keys back, and return it.
-        # The new groups can only be supersets of the old ones, so this just means grouping the old keys
-        # by the new group boundaries
-        new_groups, new_group_deps = r
-
-        assert len(new_groups) <= len(groups)
-
-        translated_groups = [
-            (
-                [k for gid in sorted(group) for k in groups[gid][0]],
-                any(groups[gid][1] for gid in group),
-            )
-            for (group, isolated) in new_groups
-        ]
-
-        assert len(translated_groups) == len(new_group_deps)
-        # After translating, keys are _not_ guaranteed to be in priority order any more??
-
-        # assert ks == (nks := [k for (g, i) in translated_groups for k in g]), (ks, nks)
-        # assert (kps := [priorities[k] for k in ks]) == list(range(len(ks))), kps
-
-        return translated_groups, new_group_deps
-
-    # Recursing went too far. Use what we have.
-    return groups, group_deps
-
-
-def cogroup_recursive(
-    priorities: dict[KT, int],
-    dependencies: dict[KT, set[KT]],
-) -> list[tuple[list[KT], bool]]:
-    r = _cogroup_recursive(
-        priorities=priorities,
-        dependencies=dependencies,
-        prev_n_groups=None,
-        min_groups=None,
-        max_chain=None,
-        depth=0,
-    )
-    assert r
-    return r[0]

--- a/dask/cogroups.py
+++ b/dask/cogroups.py
@@ -144,7 +144,7 @@ def _cogroup_recursive(
     assert (kps := [priorities[k] for k in ks]) == list(range(len(ks))), kps
 
     if (prev_n_groups and len(groups) == prev_n_groups) or (
-        min_groups and len(groups) <= min_groups
+        min_groups and len(groups) < min_groups
     ):
         # Terminal case: no more change, or we've collapsed too much.
         return None
@@ -153,7 +153,9 @@ def _cogroup_recursive(
         # Calculate the number of output groups (groups with no dependents) at depth 0.
         # We shouldn't consolidate more than this (otherwise unrelated outputs be getting
         # bundled together).
-        min_groups = sum(len(d) == 0 for d in reverse_dict(group_deps).values())
+        n_output_groups = sum(len(d) == 0 for d in reverse_dict(group_deps).values())
+        # If there's just 1 output, don't let it get overly collapsed.
+        min_groups = max(2, n_output_groups)
 
     if max_chain is None:
         dependents = reverse_dict(dependencies)

--- a/dask/order.py
+++ b/dask/order.py
@@ -81,7 +81,7 @@ from math import log
 from dask.core import get_dependencies, get_deps, getcycle, reverse_dict
 
 
-def order(dsk, dependencies=None, dependents=None):
+def order(dsk, dependencies=None):
     """Order nodes in dask graph
 
     This produces an ordering over our tasks that we use to break ties when
@@ -112,8 +112,7 @@ def order(dsk, dependencies=None, dependents=None):
     if dependencies is None:
         dependencies = {k: get_dependencies(dsk, k) for k in dsk}
 
-    if dependents is None:
-        dependents = reverse_dict(dependencies)
+    dependents = reverse_dict(dependencies)
     num_needed, total_dependencies = ndependencies(dependencies, dependents)
     metrics = graph_metrics(dependencies, dependents, total_dependencies)
 

--- a/dask/order.py
+++ b/dask/order.py
@@ -81,7 +81,7 @@ from math import log
 from dask.core import get_dependencies, get_deps, getcycle, reverse_dict
 
 
-def order(dsk, dependencies=None):
+def order(dsk, dependencies=None, dependents=None):
     """Order nodes in dask graph
 
     This produces an ordering over our tasks that we use to break ties when
@@ -112,7 +112,8 @@ def order(dsk, dependencies=None):
     if dependencies is None:
         dependencies = {k: get_dependencies(dsk, k) for k in dsk}
 
-    dependents = reverse_dict(dependencies)
+    if dependents is None:
+        dependents = reverse_dict(dependencies)
     num_needed, total_dependencies = ndependencies(dependencies, dependents)
     metrics = graph_metrics(dependencies, dependents, total_dependencies)
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1196,6 +1196,21 @@ def test_visualize_order():
         assert 'color="#' in text
 
 
+@pytest.mark.skipif("not da")
+@pytest.mark.skipif(
+    bool(sys.flags.optimize), reason="graphviz exception with Python -OO flag"
+)
+def test_visualize_cogroup():
+    pytest.importorskip("graphviz")
+    pytest.importorskip("matplotlib.pyplot")
+    x = da.arange(5, chunks=2).mean()
+    with tmpfile(extension="dot") as fn:
+        x.visualize(color="cogroup", filename=fn, cmap="RdBu")
+        with open(fn) as f:
+            text = f.read()
+        assert 'color="#' in text
+
+
 def test_use_cloudpickle_to_tokenize_functions_in__main__():
     from textwrap import dedent
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -42,7 +42,7 @@ from dask.core import literal
 from dask.delayed import Delayed, delayed
 from dask.diagnostics import Profiler
 from dask.highlevelgraph import HighLevelGraph
-from dask.utils import tmpdir, tmpfile
+from dask.utils import key_split, tmpdir, tmpfile
 from dask.utils_test import dec, import_or_none, inc
 
 da = import_or_none("dask.array")
@@ -1209,6 +1209,22 @@ def test_visualize_cogroup():
         with open(fn) as f:
             text = f.read()
         assert 'color="#' in text
+
+
+@pytest.mark.skipif("not da")
+@pytest.mark.skipif(
+    bool(sys.flags.optimize), reason="graphviz exception with Python -OO flag"
+)
+def test_visualize_cogroup_name():
+    pytest.importorskip("graphviz")
+    pytest.importorskip("matplotlib.pyplot")
+    x = da.arange(5, chunks=2).mean()
+    with tmpfile(extension="dot") as fn:
+        x.visualize(color="cogroup-name", filename=fn, cmap="RdBu")
+        with open(fn) as f:
+            text = f.read()
+        assert 'color="#' in text
+        assert key_split(x.name) in text
 
 
 def test_use_cloudpickle_to_tokenize_functions_in__main__():

--- a/dask/tests/test_cogroups.py
+++ b/dask/tests/test_cogroups.py
@@ -726,11 +726,20 @@ def test_actual_select_threshold():
 
 def test_actual_select_threshold_from_zarr():
     da = pytest.importorskip("dask.array")
-    open_zarr = tsk("open-zzarr")
+    open_zarr = tsk("open-zarr")
     # _arr = da.random.random((30, 30, 30, 30, 30, 30), chunks=(10, 10, 10, 10, 10, 10))
     _arr = da.random.random((30, 30, 30), chunks=(10, 10, 10))
     # _arr = da.random.random((30, 30), chunks=(10, 10))
     arr = graph_manipulation.bind(_arr, open_zarr)
     result = arr[arr > 1]
 
+    cogroups, prios = get_cogroups(result)
+
+
+def test_actual_double_diff():
+    da = pytest.importorskip("dask.array")
+    a = da.ones((30, 30), chunks=(10, 10))
+    b = da.zeros((30, 30), chunks=(10, 10))
+
+    result = a[1:, 1:] - b[:-1, :-1]
     cogroups, prios = get_cogroups(result)

--- a/dask/tests/test_cogroups.py
+++ b/dask/tests/test_cogroups.py
@@ -41,7 +41,7 @@ def tskchain(input, *names):
 
 def get_cogroups(
     xs: Delayed | list[Delayed],
-) -> tuple[list[tuple[list[Hashable], bool]], dict[Hashable, int]]:
+) -> tuple[list[list[Hashable]], dict[Hashable, int]]:
     if not isinstance(xs, list):
         xs = [xs]
 

--- a/dask/tests/test_cogroups.py
+++ b/dask/tests/test_cogroups.py
@@ -7,7 +7,7 @@ from tlz import partition_all
 
 import dask
 from dask.base import collections_to_dsk, get_dependencies, tokenize
-from dask.cogroups import cogroup
+from dask.cogroups import cogroup_recursive
 from dask.delayed import Delayed
 from dask.order import order
 
@@ -52,7 +52,7 @@ def get_cogroups(
 
     priorities: dict[Hashable, int] = order(dsk, dependencies=dependencies)
 
-    cogroups = list(cogroup(priorities, dependencies))
+    cogroups = cogroup_recursive(priorities, dependencies)
 
     return cogroups, priorities
 
@@ -580,10 +580,7 @@ def test_map_overlap(abcde):
     [
         "linear",
         "sibling",
-        pytest.param(
-            "tree-sib",
-            marks=pytest.mark.xfail(reason="consecutive-sibling logic very brittle"),
-        ),
+        "tree-sib",
     ],
 )
 def test_vorticity(abcde, substructure):

--- a/dask/tests/test_cogroups.py
+++ b/dask/tests/test_cogroups.py
@@ -46,7 +46,9 @@ def get_cogroups(
     if not isinstance(xs, list):
         xs = [xs]
 
-    dask.visualize(xs, color="cogroup", optimize_graph=False, collapse_outputs=True)
+    dask.visualize(
+        xs, color="cogroup-name", optimize_graph=False, collapse_outputs=True
+    )
 
     dsk = collections_to_dsk(xs, optimize_graph=False)
     dependencies = {k: get_dependencies(dsk, k) for k in dsk}
@@ -700,3 +702,13 @@ def test_actual_shuffle():
     dfs = df.shuffle("id", shuffle="tasks")
 
     cogroups, prios = get_cogroups(dfs)
+
+
+def test_actual_select_threshold():
+    da = pytest.importorskip("dask.array")
+    # arr = da.random.random((30, 30, 30, 30, 30, 30), chunks=(10, 10, 10, 10, 10, 10))
+    arr = da.random.random((30, 30, 30), chunks=(10, 10, 10))
+    # arr = da.random.random((30, 30), chunks=(10, 10))
+    result = arr[arr > 1]
+
+    cogroups, prios = get_cogroups(result)

--- a/dask/tests/test_cogroups.py
+++ b/dask/tests/test_cogroups.py
@@ -7,7 +7,7 @@ from tlz import partition_all
 
 import dask
 from dask.base import collections_to_dsk, get_dependencies, tokenize
-from dask.cogroups import cogroup_recursive
+from dask.cogroups import cogroup
 from dask.delayed import Delayed
 from dask.order import order
 
@@ -52,7 +52,7 @@ def get_cogroups(
 
     priorities: dict[Hashable, int] = order(dsk, dependencies=dependencies)
 
-    cogroups = cogroup_recursive(priorities, dependencies)
+    cogroups = list(cogroup(priorities, dependencies))
 
     return cogroups, priorities
 

--- a/dask/tests/test_cogroups.py
+++ b/dask/tests/test_cogroups.py
@@ -6,6 +6,7 @@ import pytest
 from tlz import partition_all
 
 import dask
+from dask import graph_manipulation
 from dask.base import collections_to_dsk, tokenize
 from dask.cogroups import cogroup
 from dask.core import get_dependencies
@@ -704,11 +705,32 @@ def test_actual_shuffle():
     cogroups, prios = get_cogroups(dfs)
 
 
+def test_actual_tree_reduce_from_zarr():
+    da = pytest.importorskip("dask.array")
+    open_zarr = tsk("open-zzarr")
+    arr = graph_manipulation.bind(da.ones((30, 30, 30), chunks=(10, 10, 10)), open_zarr)
+    result = arr.sum()
+
+    cogroups, prios = get_cogroups(result)
+
+
 def test_actual_select_threshold():
     da = pytest.importorskip("dask.array")
     # arr = da.random.random((30, 30, 30, 30, 30, 30), chunks=(10, 10, 10, 10, 10, 10))
     arr = da.random.random((30, 30, 30), chunks=(10, 10, 10))
     # arr = da.random.random((30, 30), chunks=(10, 10))
+    result = arr[arr > 1]
+
+    cogroups, prios = get_cogroups(result)
+
+
+def test_actual_select_threshold_from_zarr():
+    da = pytest.importorskip("dask.array")
+    open_zarr = tsk("open-zzarr")
+    # _arr = da.random.random((30, 30, 30, 30, 30, 30), chunks=(10, 10, 10, 10, 10, 10))
+    _arr = da.random.random((30, 30, 30), chunks=(10, 10, 10))
+    # _arr = da.random.random((30, 30), chunks=(10, 10))
+    arr = graph_manipulation.bind(_arr, open_zarr)
     result = arr[arr > 1]
 
     cogroups, prios = get_cogroups(result)

--- a/dask/tests/test_cogroups.py
+++ b/dask/tests/test_cogroups.py
@@ -107,6 +107,7 @@ def test_two_step_reduction(abcde):
     """
     a, b, c, d, e = abcde
 
+    # TODO parametrize to also be widely-shared
     ats = [tsk((a, i)) for i in range(3)]
     bts = [tsk((b, i)) for i in range(3)]
     cts = [tsk((c, i)) for i in range(3)]

--- a/dask/tests/test_cogroups.py
+++ b/dask/tests/test_cogroups.py
@@ -1,0 +1,602 @@
+from __future__ import annotations
+
+from typing import Hashable
+
+import pytest
+from tlz import partition_all
+
+import dask
+from dask.base import collections_to_dsk, get_dependencies, tokenize
+from dask.cogroups import cogroup
+from dask.delayed import Delayed
+from dask.order import order
+
+
+@pytest.fixture(params=["abcde"])
+def abcde(request):
+    return request.param
+
+
+def f(*args):
+    return None
+
+
+df = dask.delayed(f, pure=True)
+
+
+def tsk(name: str, *args):
+    "Syntactic sugar for calling dummy delayed function"
+    return df(*args, dask_key_name=name)
+
+
+def tskchain(input, *names):
+    token = tokenize(input, names)[:6]
+    out = input
+    for i, name in enumerate(names):
+        if name is _:
+            name = (i, token)
+        out = tsk(name, out)
+    return out
+
+
+def get_cogroups(xs: Delayed | list[Delayed]):
+    if not isinstance(xs, list):
+        xs = [xs]
+
+    dask.visualize(xs, color="cogroup", optimize_graph=False, collapse_outputs=True)
+
+    dsk = collections_to_dsk(xs, optimize_graph=False)
+    dependencies = {k: get_dependencies(dsk, k) for k in dsk}
+
+    priorities = order(dsk, dependencies=dependencies)
+
+    cogroups = list(cogroup(priorities, dependencies))
+
+    return cogroups, priorities
+
+
+_ = "_"
+
+
+def assert_cogroup(
+    cogroup: tuple[list[Hashable], bool],
+    pattern: list[Hashable],
+    *,
+    isolated: bool,
+) -> None:
+    keys, is_isolated = cogroup
+    assert is_isolated == isolated
+    assert len(keys) == len(pattern)
+    for k, p in zip(keys, pattern):
+        if p != "_":
+            assert k == p
+
+
+def assert_cogroup_priority_range(
+    cogroup: tuple[list[Hashable], bool],
+    start: int,
+    stop_inclusive: int,
+    priorities: dict[Hashable, int],
+    *,
+    isolated: bool,
+) -> None:
+    keys, is_isolated = cogroup
+    assert is_isolated == isolated
+    assert [priorities[k] for k in keys] == list(range(start, stop_inclusive + 1))
+
+
+def test_two_step_reduction(abcde):
+    r"""
+                  final
+              /     |      \
+          e         e         e
+        /  |      /  |      /  |
+      d    |    d    |    d    |
+     / \   |   / \   |   / \   |
+    a   b  c  a   b  c  a   b  c
+    """
+    a, b, c, d, e = abcde
+
+    ats = [tsk((a, i)) for i in range(3)]
+    bts = [tsk((b, i)) for i in range(3)]
+    cts = [tsk((c, i)) for i in range(3)]
+
+    ets = [
+        tsk((e, i), tsk((d, i), at, bt), ct)
+        for i, (at, bt, ct) in enumerate(zip(ats, bts, cts))
+    ]
+    final = tsk("final", *ets)
+
+    cogroups, prios = get_cogroups(final)
+
+    assert len(cogroups) == 7
+
+    for i in range(len(ats)):
+        assert_cogroup(cogroups[2 * i], [(a, i), (b, i), (d, i)], isolated=True)
+        assert_cogroup(cogroups[2 * i + 1], [(c, i), (e, i)], isolated=False)
+
+    assert_cogroup(cogroups[-1], ["final"], isolated=False)
+
+
+def test_two_step_reduction_linear_chains(abcde):
+    r"""
+                          final
+                     /              \               \
+                    /                \               \
+            --------------
+            |    s2      |            s2              s2
+            | /      \   |          /     \         /     \
+            |/______  \  |         |       |       |       |
+     -------------  |  | |         |       |       |       |
+     |     s1    |  |  | |         s1      |       s1      |
+     | /   |  \  |  |  | |     /   |  \    |   /   |  \    |
+     | x   |   | |  |  | |     x   |   |   |   x   |   |   |
+     | |   |   | |  |  | |     |   |   |   |   |   |   |   |
+     | x   |   x |  |  x |     x   |   x   x   x   |   x   x
+     | |   |   | |  |  | |     |   |   |   |   |   |   |   |
+     | a   b   c |  |  d |     a   b   c   d   a   b   c   d
+     -------------  ------    /   /   /  /   /   /    /   /
+       \   \   \   \   \  \  /   /   /  /   /   /    /   /
+                            r
+    """
+    a, b, c, d, e = abcde
+    root = tsk(name="root")
+    ats = [tskchain(root, (a, i), _, _) for i in range(3)]  # 2-chain(z)
+    bts = [tskchain(root, (b, i)) for i in range(3)]  # 0-chain
+    cts = [tskchain(root, (c, i), _) for i in range(3)]  # 1-chain
+
+    s1ts = [
+        tsk(("s1", i), at, bt, ct) for i, (at, bt, ct) in enumerate(zip(ats, bts, cts))
+    ]
+
+    dts = [tskchain(root, (d, i), ("dx1", i)) for i in range(3)]  # 1-chain
+    s2ts = [tsk(("s2", i), s1t, dt) for i, (s1t, dt) in enumerate(zip(s1ts, dts))]
+
+    final = tsk("final", *s2ts)
+
+    cogroups, prios = get_cogroups(final)
+
+    assert len(cogroups) == 7
+
+    assert_cogroup(
+        cogroups[0],
+        # TODO ideally `root` wouldn't be in there
+        ["root", (a, 0), _, _, (c, 0), _, (b, 0), ("s1", 0)],
+        isolated=True,
+    )
+    # TODO `isolated=False` right now but probably should be considered a proper group??
+    assert_cogroup(cogroups[1], [(d, 0), _, ("s2", 0)], isolated=False)
+
+    assert_cogroup(
+        cogroups[2],
+        [(a, 1), _, _, (c, 1), _, (b, 1), ("s1", 1)],
+        isolated=True,
+    )
+    # TODO `isolated=False` right now but probably should be considered a proper group??
+    assert_cogroup(cogroups[3], [(d, 1), _, ("s2", 1)], isolated=False)
+
+    assert_cogroup(
+        cogroups[4],
+        [(a, 2), _, _, (c, 2), _, (b, 2), ("s1", 2)],
+        isolated=True,
+    )
+    # TODO `isolated=False` right now but probably should be considered a proper group??
+    assert_cogroup(cogroups[5], [(d, 2), _, ("s2", 2)], isolated=False)
+
+    assert_cogroup(cogroups[6], ["final"], isolated=False)
+
+
+@pytest.mark.xfail(reason="widely shared dependencies mess everything up")
+def test_cogroup_linear_chains_plus_widely_shared(abcde):
+    r"""
+      c     c    c
+     /|\   /|\   /\
+    b b b b b b b b
+    |\|\|\|\|/|/|/|
+    | | | | s | | |
+    a a a a a a a a
+    """
+    a, b, c, d, e = abcde
+    shared = tsk("shared")
+    roots = [tsk((a, i)) for i in range(9)]
+    bts = [tsk((b, i), r, shared) for i, r in enumerate(roots)]
+    cts = [tsk((c, i), axs) for i, axs in enumerate(partition_all(3, bts))]
+
+    cogroups, prios = get_cogroups(cts)
+    assert len(cogroups) == 4
+
+    assert_cogroup(cogroups[0], ["shared"], isolated=False)
+    assert_cogroup(
+        cogroups[1],
+        [(a, 0), (b, 0), (a, 1), (b, 1), (a, 2), (b, 2), (c, 0)],
+        isolated=True,
+    )
+    assert_cogroup(
+        cogroups[2],
+        [(a, 3), (b, 3), (a, 4), (b, 4), (a, 5), (b, 5), (c, 1)],
+        isolated=True,
+    )
+    assert_cogroup(
+        cogroups[3],
+        [(a, 6), (b, 6), (a, 7), (b, 7), (c, 3)],
+        isolated=True,
+    )
+
+
+# # @gen_cluster(nthreads=[], client=True)
+# # async def test_cogroup_triangle(c, s):
+# #     r"""
+# #       z
+# #      /|
+# #     y |
+# #     \ |
+# #       x
+# #     """
+# #     x = dask.delayed(0, name="x")
+# #     y = inc(x, dask_key_name="y")
+# #     z = add(x, y, dask_key_name="z")
+
+# #     futs = await submit_delayed(c, s, z)
+
+# #     x = s.tasks["x"]
+# #     y = s.tasks["y"]
+# #     z = s.tasks["z"]
+
+# #     cogroup = cogroup(x, 1000, 1000)
+# #     assert cogroup
+# #     sibs, downstream = cogroup
+# #     assert sibs == set()
+# #     assert downstream == {z}  # `y` is just a linear chain, not downstream
+
+# #     cogroup = cogroup(y, 1000, 1000)
+# #     assert cogroup
+# #     sibs, downstream = cogroup
+# #     assert sibs == {x}
+# #     assert downstream == {z}
+
+
+# # @gen_cluster(nthreads=[], client=True)
+# # async def test_cogroup_wide_gather_downstream(c, s):
+# #     r"""
+# #             s
+# #      / / / /|\ \ \
+# #     i i i i i i i i
+# #     | | | | | | | |
+# #     r r r r r r r r
+# #     """
+# #     roots = [dask.delayed(i, name=f"r-{i}") for i in range(8)]
+# #     incs = [inc(r, dask_key_name=f"i-{i}") for i, r in enumerate(roots)]
+# #     sum = dsum(incs, dask_key_name="sum")
+
+# #     futs = await submit_delayed(c, s, sum)
+
+# #     rts = [s.tasks[r.key] for r in roots]
+# #     sts = s.tasks["sum"]
+
+# #     cogroup = cogroup(rts[0], 4, 1000)
+# #     assert cogroup
+# #     sibs, downstream = cogroup
+# #     assert sibs == set()
+# #     assert downstream == set()  # `sum` not downstream because it's too large
+
+# #     cogroup = cogroup(rts[0], 1000, 1000)
+# #     assert cogroup
+# #     sibs, downstream = cogroup
+# #     assert sibs == set(rts[1:])
+# #     assert downstream == {sts}
+
+
+# # # TODO test cogroup commutativity. Given any node X in any graph, calculate `cogroup(X)`.
+# # # For each sibling S, `cogroup(S)` should give the same cogroup, regardless of the
+# # # starting node.
+# # # EXECPT THIS ISN'T TRUE
+
+
+# # @gen_cluster(nthreads=[], client=True)
+# # async def test_cogroup_non_commutative(c, s):
+# #     roots = [dask.delayed(i, name=f"r-{i}") for i in range(16)]
+# #     aggs = [dsum(rs) for rs in partition(4, roots)]
+# #     extra = dsum([roots[::4]], dask_key_name="extra")
+
+# #     futs = await submit_delayed(c, s, aggs + [extra])
+
+# #     rts = [s.tasks[r.key] for r in roots]
+# #     ats = [s.tasks[a.key] for a in aggs]
+# #     ets = s.tasks["extra"]
+
+# #     cogroup = cogroup(rts[0], 1000, 1000)
+# #     assert cogroup
+# #     sibs, downstream = cogroup
+# #     assert sibs == set(rts[1:4]) | {rts[4], rts[8], rts[12]}
+# #     assert downstream == {ats[0], ets}
+
+# #     cogroup = cogroup(rts[1], 1000, 1000)
+# #     assert cogroup
+# #     sibs, downstream = cogroup
+# #     assert sibs == {rts[0], rts[2], rts[3]}
+# #     assert downstream == {ats[0]}
+
+
+# # @gen_cluster(nthreads=[], client=True)
+# # async def test_reuse(c, s):
+# #     r"""
+# #     a + (a + 1).mean()
+# #     """
+# #     roots = [dask.delayed(i, name=f"r-{i}") for i in range(6)]
+# #     incs = [inc(r, name=f"i-{i}") for i, r in enumerate(roots)]
+# #     mean = dsum([dsum(incs[:3]), dsum(incs[3:])])
+# #     deltas = [add(r, mean, dask_key_name=f"d-{i}") for i, r in enumerate(roots)]
+
+# #     futs = await submit_delayed(c, s, deltas)
+
+
+# # @gen_cluster(nthreads=[], client=True)
+# # async def test_common_with_trees(c, s):
+# #     r"""
+# #      x       x        x      x
+# #      /|\    /|\      /|\    /|\
+# #     a | b  c | d    e | f  g | h
+# #       |      |        |      |
+# #        ---------- c ----------
+# #     """
+# #     pass
+
+
+# # @gen_cluster(nthreads=[], client=True)
+# # async def test_zigzag(c, s):
+# #     r"""
+# #     x  x  x  x
+# #     | /| /| /|
+# #     r  r  r  r
+# #     """
+# #     roots = [dask.delayed(i, name=f"r-{i}") for i in range(4)]
+# #     others = [
+# #         inc(roots[0]),
+# #         add(roots[0], roots[1]),
+# #         add(roots[1], roots[2]),
+# #         add(roots[2], roots[3]),
+# #     ]
+
+# #     futs = await submit_delayed(c, s, others)
+
+
+# # @gen_cluster(nthreads=[], client=True)
+# # async def test_overlap(c, s):
+# #     r"""
+# #     x  x  x  x
+# #     |\/|\/|\/|
+# #     |/\|/\|/\|
+# #     r  r  r  r
+# #     """
+# #     roots = [dask.delayed(i, name=f"r-{i}") for i in range(4)]
+# #     others = [
+# #         add(roots[0], roots[1]),
+# #         dsum(roots[0], roots[1], roots[2]),
+# #         dsum(roots[1], roots[2], roots[3]),
+# #         add(roots[2], roots[3]),
+# #     ]
+
+# #     futs = await submit_delayed(c, s, others)
+
+
+def test_tree_reduce(abcde):
+    r"""
+                c
+          /     |      \
+       b        b        b
+     / | \    / | \    / | \
+    a  a  a  a  a  a  a  a  a
+    """
+    a, b, c, _, _ = abcde
+    a1, a2, a3, a4, a5, a6, a7, a8, a9 = (a + i for i in "123456789")
+    b1, b2, b3, b4 = (b + i for i in "1234")
+    dsk = {
+        a1: (f,),
+        a2: (f,),
+        a3: (f,),
+        b1: (f, a1, a2, a3),
+        a4: (f,),
+        a5: (f,),
+        a6: (f,),
+        b2: (f, a4, a5, a6),
+        a7: (f,),
+        a8: (f,),
+        a9: (f,),
+        b3: (f, a7, a8, a9),
+        c: (f, b1, b2, b3),
+    }
+
+    cogroups, prios = get_cogroups(Delayed(c, dsk))
+
+    assert len(cogroups) == 4
+
+    assert_cogroup(cogroups[0], [a1, a2, a3, b1], isolated=True)
+    assert_cogroup(cogroups[1], [a4, a5, a6, b2], isolated=True)
+    assert_cogroup(cogroups[2], [a7, a8, a9, b3], isolated=True)
+    assert_cogroup(cogroups[3], [c], isolated=False)
+
+
+# TODO not sure what the best behavior here is?
+def test_nearest_neighbor(abcde):
+    r"""
+    a1  a2  a3  a4  a5  a6  a7 a8  a9
+     \  |  /  \ |  /  \ |  / \ |  /
+        b1      b2      b3     b4
+
+    No co-groups
+    """
+    a, b, c, _, _ = abcde
+    a1, a2, a3, a4, a5, a6, a7, a8, a9 = (a + i for i in "123456789")
+    b1, b2, b3, b4 = (b + i for i in "1234")
+
+    dsk = {
+        b1: (f,),
+        b2: (f,),
+        b3: (f,),
+        b4: (f,),
+        a1: (f, b1),
+        a2: (f, b1),
+        a3: (f, b1, b2),
+        a4: (f, b2),
+        a5: (f, b2, b3),
+        a6: (f, b3),
+        a7: (f, b3, b4),
+        a8: (f, b4),
+        a9: (f, b4),
+    }
+
+    cogroups, prios = get_cogroups([Delayed(k, dsk) for k in dsk])
+
+    # no isolated cogroups
+    assert len([f for f in cogroups if f[1]]) == 0
+
+
+# @gen_cluster(nthreads=[], client=True)
+# async def test_deep_bases_win_over_dependents(client, s, abcde):
+#     r"""
+#     It's not clear who should run first, e or d
+
+#     1.  d is nicer because it exposes parallelism
+#     2.  e is nicer (hypothetically) because it will be sooner released
+#         (though in this case we need d to run first regardless)
+
+#     Regardless of e or d first, we should run b before c.
+
+#             a
+#           / | \   .
+#          b  c |
+#         / \ | /
+#        e    d
+#     """
+#     a, b, c, d, e = abcde
+#     dsk = {a: (f, b, c, d), b: (f, d, e), c: (f, d), d: (f,), e: (f,)}
+
+#     futs = await submit_delayed(client, s, Delayed(a, dsk))
+#     cogroups = list(cogroup(s.tasks.values()))
+
+#     assert len([f for f in cogroups if f[1]]) == 1
+#     assert_cogroup(cogroups[0], [e, d, b], isolated=True, scheduler=s)
+
+
+@pytest.mark.xfail(reason="widely-shared dep, plus idk how this should even look")
+def test_base_of_reduce_preferred(abcde):
+    r"""
+             a3
+            /|
+          a2 |
+         /|  |
+       a1 |  |
+      /|  |  |
+    a0 |  |  |
+    |  |  |  |
+    b0 b1 b2 b3
+      \ \ / /
+         c
+
+    """
+    a, b, c, d, e = abcde
+    dsk = {(a, i): (f, (a, i - 1), (b, i)) for i in [1, 2, 3]}
+    dsk[(a, 0)] = (f, (b, 0))
+    dsk.update({(b, i): (f, c) for i in [0, 1, 2, 3]})
+    dsk[c] = (f,)
+
+    cogroups, prios = get_cogroups(Delayed((a, 3), dsk))
+
+    assert len(cogroups) == 2
+    assert_cogroup(
+        cogroups[0],
+        [
+            c,
+            (b, 0),
+            (a, 0),
+            (b, 1),
+            (a, 1),
+        ],
+        isolated=True,
+    )
+    assert_cogroup(
+        cogroups[1],
+        [
+            c,
+            (b, 2),
+            (a, 2),
+            (b, 3),
+            (a, 3),
+        ],
+        isolated=True,
+    )
+
+
+# TODO not sure what the best behavior here is?
+def test_map_overlap(abcde):
+    r"""
+      b1      b3      b5
+       |\    / | \  / |
+      c1  c2  c3  c4  c5
+       |/  | \ | / | \|
+      d1  d2  d3  d4  d5
+       |       |      |
+      e1      e3      e5
+
+    Want to finish b1 before we start on e5
+    """
+    a, b, c, d, e = abcde
+    dsk = {
+        (e, 1): (f,),
+        (d, 1): (f, (e, 1)),
+        (c, 1): (f, (d, 1)),
+        (b, 1): (f, (c, 1), (c, 2)),
+        (d, 2): (f,),
+        (c, 2): (f, (d, 1), (d, 2), (d, 3)),
+        (e, 3): (f,),
+        (d, 3): (f, (e, 3)),
+        (c, 3): (f, (d, 3)),
+        (b, 3): (f, (c, 2), (c, 3), (c, 4)),
+        (d, 4): (f,),
+        (c, 4): (f, (d, 3), (d, 4), (d, 5)),
+        (e, 5): (f,),
+        (d, 5): (f, (e, 5)),
+        (c, 5): (f, (d, 5)),
+        (b, 5): (f, (c, 4), (c, 5)),
+    }
+
+    cogroups, prios = get_cogroups([Delayed(k, dsk) for k in dsk])
+
+    assert len([f for f in cogroups if f[1]]) == 2
+
+    # TODO `b` tasks aren't captured right now, maybe that's ok?
+    assert_cogroup_priority_range(cogroups[0], 0, 6, prios, isolated=True)
+    # b1 is its own group
+    assert_cogroup_priority_range(cogroups[2], 8, 12, prios, isolated=True)
+    # b2 is its own group
+    # assert_cogroup_priority_range(cogroups[1], 14, 15, prios, isolated=False)
+
+    # assert_cogroup(
+    #     cogroups[0],
+    #     [
+    #         (e, 1),
+    #         (d, 1),
+    #         (c, 1),
+    #         (c, 2),
+    #         (d, 3),
+    #         (d, 2),
+    #         (e, 3),
+    #     ],
+    #     isolated=True,
+    #     scheduler=s,
+    # )
+
+    # assert_cogroup(
+    #     cogroups[1],
+    #     [
+    #         # Why is this not part of the group? Maybe linked to order output
+    #         # (b, 5),
+    #         (c, 5),
+    #         (d, 5),
+    #         (e, 5),
+    #         (c, 4),
+    #         (d, 4),
+    #     ],
+    #     isolated=True,
+    #     scheduler=s,
+    # )


### PR DESCRIPTION
This implements the co-grouping algorithm described in https://github.com/dask/distributed/issues/7298 / https://github.com/dask/distributed/pull/7141, to identify related tasks which should run on the same worker.

Two differences from the described algorithm:
1. After a priority jump, it checks that the jump doesn't include a totally disjoint part of the graph. Because of oddities in the ordering `dask.order` chooses, this can happen.
1. If it reaches the end of a linear chain without a priority jump, it doesn't try again from the next dependent. I never came across a test case that required this.

By implementing this in dask/dask, I also added `visualize(color="cogroup")`, which has been invaluable in debugging the algorithm and understanding what it's actually doing.

It works, but still has a tendency to sometimes make too large of groups.

Opening this as a PR just for posterity and future reference; not planning to merge (and please don't review).

An example that does well (`test_two_step_reduction_linear_chains`):
![mydask](https://user-images.githubusercontent.com/3309802/207204908-3bd489dd-300e-4038-826c-ea4f3d93f89e.png)

An example that does poorly (`test_actual_anom_mean`). Some of the groups are too big. It's looking at a priority jump too high up the graph:
![mydask](https://user-images.githubusercontent.com/3309802/207206443-dd556f1c-bfc6-4259-9a4d-03f7efdf6b42.png)