### PR TITLE
Implement ma.where and ma.nonzero

### DIFF
--- a/dask/array/tests/test_masked.py
+++ b/dask/array/tests/test_masked.py
@@ -462,7 +462,12 @@ def test_nonzero():
     ]:
         sol = np.ma.nonzero(c1)
         res = da.ma.nonzero(c2)
-        assert_eq(sol, res)
+
+        assert isinstance(res, type(sol))
+        assert len(res) == len(sol)
+
+        for i in range(len(sol)):
+            assert_eq(res[i], sol[i])
 
 
 def test_where():
@@ -478,7 +483,8 @@ def test_where():
     # Nonzero test
     sol = np.ma.where(x)
     res = da.ma.where(d)
-    assert_eq(res, sol)
+    for i in range(len(sol)):
+        assert_eq(res[i], sol[i])
 
     for c1, c2 in [
         (d > 5, x > 5),

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -373,8 +373,10 @@ Masked Arrays
    ma.masked_outside
    ma.masked_values
    ma.masked_where
+   ma.nonzero
    ma.ones_like
    ma.set_fill_value
+   ma.where
    ma.zeros_like
 
 Random


### PR DESCRIPTION
Implements `da.ma.where` and `da.ma.nonzero`. Essentially follows the implementation of `da.where`.

- [x] Closes #9759 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
