### PR TITLE
Make sure nullable dtypes are cast to non-nullable in `partition_quantiles`

### DIFF
--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -416,6 +416,8 @@ def percentiles_summary(df, num_old, num_new, upsample, state):
     data = df
     interpolation = "linear"
 
+    if data.dtype.na_value is pd.NA:
+        data = data.astype("float64")
     if is_categorical_dtype(data):
         data = data.cat.codes
         interpolation = "nearest"
@@ -444,6 +446,8 @@ def percentiles_summary(df, num_old, num_new, upsample, state):
 
 def dtype_info(df):
     info = None
+    if df.dtype.na_value is pd.NA:
+        return "float64", info
     if is_categorical_dtype(df):
         data = df.values
         info = (data.categories, data.ordered)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1538,3 +1538,14 @@ def test_sort_values_timestamp(npartitions):
     result = ddf.sort_values("time")
     expected = df.sort_values("time")
     assert_eq(result, expected)
+
+
+def test_sort_values_with_null_partition():
+    df = pd.DataFrame({"a": [2, 3, 1, 2, None, None]})
+    df["a"] = df["a"].astype("Int64")
+    # note the partition size means we will have one partition with only pd.NA
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    result = ddf.sort_values("a")
+    expected = df.sort_values("a")
+    assert_eq(result, expected)


### PR DESCRIPTION
It looks like the `sort_values` codepath doesn't have support for quantile divisions containing `pd.NA`, which occurs when we attempt to sort by a nullable column with an entirely null partition.

This PR attempts to cast nullable columns to their non-nullable equivalent as part of `partition_quantiles`, which should unblock this edge case.

- [ ] Closes #9765
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
