### PR TITLE
Reduce size of expected DoK sparse matrix

### DIFF
--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -82,7 +82,7 @@ def test_sparse_matrix():
     assert sizeof(sp.tocoo()) >= 240
     assert sizeof(sp.tocsc()) >= 232
     assert sizeof(sp.tocsr()) >= 232
-    assert sizeof(sp.todok()) >= 192
+    assert sizeof(sp.todok()) >= 188
     assert sizeof(sp.tolil()) >= 204
 
 


### PR DESCRIPTION
Apparently, SciPy was not available on 32-bit in Fedora, and this test was skipped, but it's recently become available again, and this test value is too large.

- [n/a] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
