### PR TITLE
Deflate sizeof() of duplicate references to pandas object types

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -97,3 +97,12 @@ def check_numeric_only_deprecation():
             yield
     else:
         yield
+
+
+def dtype_eq(a: type, b: type) -> bool:
+    # CategoricalDtype in pandas <1.3 cannot be compared to numpy dtypes
+    if not PANDAS_GT_130 and isinstance(a, pd.CategoricalDtype) != isinstance(
+        b, pd.CategoricalDtype
+    ):
+        return False
+    return a == b


### PR DESCRIPTION
Fix bugs where sizeof() would return a severely inflated result:

1. when a Series is duplicated, e.g.
```python
df[["x", "x", "x"]]
```

2. when a pandas object dtype Series contains multiple references to the same Python objects. This is for example the case of the output of `dd.read_parquet`.

2. when the same Python object is referenced from multiple Series, e.g.
```python
x = "x" * 10_000
DataFrame([[x, "y"], ["y", x]])
```

# Demo
```python
cluster = coiled.Cluster(n_workers=5, worker_vm_types=["t3.xlarge"])
client = distributed.Client(cluster)
df = dd.read_parquet(
    "s3://coiled-datasets/dask-book/nyc-tlc/2009",
    storage_options={"anon": True},
).persist()
```

### Before:
![image](https://user-images.githubusercontent.com/6213168/208681640-aaf82140-4745-4ab8-87e7-6ac246487e3f.png)

### After:
**Note 1:** Memory usage after releasing the keys is ~200MiB per worker.
**Note 2:** the overall memory usage is lower before because this data is highly compressible - so it takes a lot less space on disk than in memory.

![image](https://user-images.githubusercontent.com/6213168/208688167-881acb87-c34b-482e-ab71-09141be32158.png)

