### PR TITLE
`numpy=1.24` compatability 

### DIFF
--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -45,7 +45,9 @@ dependencies:
   - s3fs>=2021.8.0
   - click
   - cloudpickle
-  - crick
+  # Need a new `crick` release with support for `numpy=1.24+`
+  # https://github.com/dask/crick/issues/25
+  # - crick
   - cytoolz
   - distributed
   - ipython

--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -10,6 +10,7 @@ _numpy_120 = _np_version >= parse_version("1.20.0")
 _numpy_121 = _np_version >= parse_version("1.21.0")
 _numpy_122 = _np_version >= parse_version("1.22.0")
 _numpy_123 = _np_version >= parse_version("1.23.0")
+_numpy_124 = _np_version >= parse_version("1.24.0")
 
 
 # Taken from scikit-learn:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -8140,7 +8140,13 @@ def _convert_to_numeric(series, skipna):
 
 def _sqrt_and_convert_to_timedelta(partition, axis, *args, **kwargs):
     if axis == 1:
-        return pd.to_timedelta(M.std(partition, axis=axis, *args, **kwargs))
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=RuntimeWarning,
+                message="invalid value encountered in cast",
+            )
+            return pd.to_timedelta(M.std(partition, axis=axis, *args, **kwargs))
 
     is_df_like, time_cols = kwargs["is_df_like"], kwargs["time_cols"]
 

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -1,3 +1,4 @@
+import contextlib
 import warnings
 
 import numpy as np
@@ -109,6 +110,19 @@ def check_pandas_issue_45618_warning(test_func):
     return decorator
 
 
+@contextlib.contextmanager
+def ignore_numpy_bool8_deprecation():
+    # This warning comes from inside `pandas`. We can't do anything about it, so we ignore the warning.
+    # Note it's been fixed upstream in `pandas` https://github.com/pandas-dev/pandas/pull/49886.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message="`np.bool8` is a deprecated alias for `np.bool_`",
+        )
+        yield
+
+
 @check_pandas_issue_45618_warning
 def test_get_dummies_sparse():
     s = pd.Series(pd.Categorical(["a", "b", "a"], categories=["a", "b", "c"]))
@@ -116,14 +130,16 @@ def test_get_dummies_sparse():
 
     exp = pd.get_dummies(s, sparse=True)
     res = dd.get_dummies(ds, sparse=True)
-    assert_eq(exp, res)
+    with ignore_numpy_bool8_deprecation():
+        assert_eq(exp, res)
 
     assert res.compute().a.dtype == "Sparse[uint8, 0]"
     assert pd.api.types.is_sparse(res.a.compute())
 
     exp = pd.get_dummies(s.to_frame(name="a"), sparse=True)
     res = dd.get_dummies(ds.to_frame(name="a"), sparse=True)
-    assert_eq(exp, res)
+    with ignore_numpy_bool8_deprecation():
+        assert_eq(exp, res)
     assert pd.api.types.is_sparse(res.a_a.compute())
 
 
@@ -139,7 +155,9 @@ def test_get_dummies_sparse_mix():
 
     exp = pd.get_dummies(df, sparse=True)
     res = dd.get_dummies(ddf, sparse=True)
-    assert_eq(exp, res)
+
+    with ignore_numpy_bool8_deprecation():
+        assert_eq(exp, res)
 
     assert res.compute().A_a.dtype == "Sparse[uint8, 0]"
     assert pd.api.types.is_sparse(res.A_a.compute())

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -369,10 +369,14 @@ def test_saves_file_path_deprecated():
         with pytest.warns(FutureWarning) as record:
             prof.visualize(show=False, file_path=fn)
 
-        assert len(record) == 1
-        assert os.path.exists(fn)
-        with open(fn) as f:
-            assert "html" in f.read().lower()
+        assert 1 <= len(record) <= 2
+        assert "file_path keyword argument is deprecated" in str(record[-1].message)
+        # This additional warning comes from inside `bokeh`. There's a fix upstream
+        # https://github.com/bokeh/bokeh/pull/12690 so for now we just ignore it.
+        if len(record) == 2:
+            assert "`np.bool8` is a deprecated alias for `np.bool_`" in str(
+                record[0].message
+            )
 
 
 @pytest.mark.skipif("not bokeh")


### PR DESCRIPTION
This is popping up in https://github.com/dask/dask/issues/9736 and `fastparquet` https://github.com/dask/fastparquet/pull/833

cc @martindurant 