### PR TITLE
`GroupBy.__getitem__` compatibility for `pandas` 2.0

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2594,7 +2594,9 @@ class DataFrameGroupBy(_GroupBy):
                 self.obj, by=self.by, slice=key, sort=self.sort, **self.dropna
             )
 
-        # error is raised from pandas
+        # Need a list otherwise pandas will warn/error
+        if isinstance(key, tuple):
+            key = list(key)
         g._meta = g._meta[key]
         return g
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -739,10 +739,7 @@ def test_split_apply_combine_on_series(empty):
     pytest.raises(KeyError, lambda: ddf.groupby("x"))
     pytest.raises(KeyError, lambda: ddf.groupby(["a", "x"]))
     pytest.raises(KeyError, lambda: ddf.groupby("a")["x"])
-    with warnings.catch_warnings():
-        # pandas warns about using tuples before throwing the KeyError
-        warnings.simplefilter("ignore", FutureWarning)
-        pytest.raises(KeyError, lambda: ddf.groupby("a")["b", "x"])
+    pytest.raises(KeyError, lambda: ddf.groupby("a")["b", "x"])
     pytest.raises(KeyError, lambda: ddf.groupby("a")[["b", "x"]])
 
     # test graph node labels


### PR DESCRIPTION
This avoids 

```
ValueError: Cannot subset columns with a tuple with more than one element. Use a list instead.
```

being raised from inside `pandas` which is happening in `dask/dataframe/tests/test_groupby.py::test_split_apply_combine_on_series` 

xref https://github.com/dask/dask/issues/9736