### PR TITLE
Fix read_parquet index preservation when pyarrow-schema is specified

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -596,22 +596,20 @@ class ArrowDatasetEngine(Engine):
         index_cols=None,
         **kwargs,
     ):
-        if schema == "infer" or isinstance(schema, dict):
-            # Start with schema from _meta_nonempty
-            inferred_schema = pyarrow_schema_dispatch(
-                df._meta_nonempty.set_index(index_cols)
-                if index_cols
-                else df._meta_nonempty
-            ).remove_metadata()
 
-            # Use dict to update our inferred schema
-            if isinstance(schema, dict):
-                schema = pa.schema(schema)
-                for name in schema.names:
-                    i = inferred_schema.get_field_index(name)
-                    j = schema.get_field_index(name)
-                    inferred_schema = inferred_schema.set(i, schema.field(j))
-            schema = inferred_schema
+        # Start with inferred schema from _meta_nonempty
+        inferred_schema = pyarrow_schema_dispatch(
+            df._meta_nonempty.set_index(index_cols) if index_cols else df._meta_nonempty
+        ).remove_metadata()
+
+        # Use optional input schema to update our inferred schema
+        if isinstance(schema, (dict, pa.Schema)):
+            schema = pa.schema(schema)
+            for name in schema.names:
+                i = inferred_schema.get_field_index(name)
+                j = schema.get_field_index(name)
+                inferred_schema = inferred_schema.set(i, schema.field(j))
+        schema = inferred_schema
 
         # Check that target directory exists
         fs.mkdirs(path, exist_ok=True)


### PR DESCRIPTION
- [ ] Closes #9773
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
