### PR TITLE
`infer_datetime_format` compatibility for `pandas` 2.0 

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -7783,6 +7783,16 @@ def to_datetime(arg, meta=None, **kwargs):
             meta = meta_series_constructor(arg)([pd.Timestamp("2000", **tz_kwarg)])
             meta.index = meta.index.astype(arg.index.dtype)
             meta.index.name = arg.index.name
+    if PANDAS_GT_200 and "infer_datetime_format" in kwargs:
+        warnings.warn(
+            "The argument 'infer_datetime_format' is deprecated and will be removed in a future version. "
+            "A strict version of it is now the default, see "
+            "https://pandas.pydata.org/pdeps/0004-consistent-to-datetime-parsing.html. "
+            "You can safely remove this argument.",
+            UserWarning,
+        )
+        kwargs.pop("infer_datetime_format")
+
     return map_partitions(pd.to_datetime, arg, meta=meta, **kwargs)
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,3 +1,4 @@
+import contextlib
 import decimal
 import platform
 import warnings
@@ -4518,15 +4519,23 @@ def test_to_datetime():
     s.index = s.values
     ds = dd.from_pandas(s, npartitions=10, sort=False)
 
-    assert_eq(
-        pd.to_datetime(s, infer_datetime_format=True),
-        dd.to_datetime(ds, infer_datetime_format=True),
-    )
-    assert_eq(
-        pd.to_datetime(s.index, infer_datetime_format=True),
-        dd.to_datetime(ds.index, infer_datetime_format=True),
-        check_divisions=False,
-    )
+    if PANDAS_GT_200:
+        ctx = pytest.warns(UserWarning, match="'infer_datetime_format' is deprecated")
+    else:
+        ctx = contextlib.nullcontext()
+
+    with ctx:
+        expected = pd.to_datetime(s, infer_datetime_format=True)
+    with ctx:
+        result = dd.to_datetime(ds, infer_datetime_format=True)
+    assert_eq(expected, result)
+
+    with ctx:
+        expected = pd.to_datetime(s.index, infer_datetime_format=True)
+    with ctx:
+        result = dd.to_datetime(ds.index, infer_datetime_format=True)
+    assert_eq(expected, result, check_divisions=False)
+
     assert_eq(
         pd.to_datetime(s, utc=True),
         dd.to_datetime(ds, utc=True),


### PR DESCRIPTION
In `pandas=2.0` the `infer_datetime_format` kwarg is deprecated and also no longer had any effect when specified

xref https://github.com/dask/dask/issues/9736