### PR TITLE
`iteritems` compatibility for `pandas` 2.0

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3763,24 +3763,26 @@ Dask Name: {name}, {layers}""".format(
     def _get_numeric_data(self, how="any", subset=None):
         return self
 
-    @derived_from(pd.Series)
-    def iteritems(self):
-        if PANDAS_GT_150:
-            warnings.warn(
-                "iteritems is deprecated and will be removed in a future version. "
-                "Use .items instead.",
-                FutureWarning,
-            )
-        # We use the `_` generator below to ensure the deprecation warning above
-        # is raised when `.iteritems()` is called, not when the first `next(<generator>)`
-        # iteration happens
+    if not PANDAS_GT_200:
 
-        def _(self):
-            for i in range(self.npartitions):
-                s = self.get_partition(i).compute()
-                yield from s.items()
+        @derived_from(pd.Series)
+        def iteritems(self):
+            if PANDAS_GT_150:
+                warnings.warn(
+                    "iteritems is deprecated and will be removed in a future version. "
+                    "Use .items instead.",
+                    FutureWarning,
+                )
+            # We use the `_` generator below to ensure the deprecation warning above
+            # is raised when `.iteritems()` is called, not when the first `next(<generator>)`
+            # iteration happens
 
-        return _(self)
+            def _(self):
+                for i in range(self.npartitions):
+                    s = self.get_partition(i).compute()
+                    yield from s.items()
+
+            return _(self)
 
     @derived_from(pd.Series)
     def __iter__(self):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3543,6 +3543,7 @@ def test_contains_series_raises_deprecated_warning_preserves_behavior():
     assert not output
 
 
+@pytest.mark.skipif(PANDAS_GT_200, reason="iteritems has been removed")
 def test_series_iteritems():
     df = pd.DataFrame({"x": [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)

--- a/dask/tests/test_spark_compat.py
+++ b/dask/tests/test_spark_compat.py
@@ -16,13 +16,19 @@ pytest.importorskip("fastparquet")
 import numpy as np
 import pandas as pd
 
-from dask.dataframe._compat import PANDAS_GT_150
+from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200
 from dask.dataframe.utils import assert_eq
 
-pytestmark = pytest.mark.skipif(
-    sys.platform != "linux",
-    reason="Unnecessary, and hard to get spark working on non-linux platforms",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="Unnecessary, and hard to get spark working on non-linux platforms",
+    ),
+    pytest.mark.skipif(
+        PANDAS_GT_200,
+        reason="pyspark doesn't yet have support for pandas 2.0",
+    ),
+]
 
 # pyspark auto-converts timezones -- round-tripping timestamps is easier if
 # we set everything to UTC.


### PR DESCRIPTION
`Series.iteritems` and `DataFrame.iteritems` were removed in `pandas` 2.0. This PR does the same here (note we only implement `Series.iteritems`). 

Additionally, our `pyspark`-related tests are failing due to the `pyspark` not having support for `pandas` 2.0 yet. There's a fix already included upstream (xref https://github.com/apache/spark/pull/37947) but it hasn't been included in a release yet. Let's skip these tests until there's a release with the fix. 

xref https://github.com/dask/dask/issues/9736