### PR TITLE
Fix `dask/dataframe/tests/test_utils_dataframe.py` tests for `pandas` 2.0

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -233,7 +233,7 @@ def test_meta_duplicated():
 
     exp = pd.DataFrame(
         [["foo", "foo", "foo"], ["foo", "foo", "foo"]],
-        index=["a", "b"],
+        index=meta_nonempty(df.index),
         columns=["A", "A", "B"],
     )
     tm.assert_frame_equal(res, exp)
@@ -290,7 +290,7 @@ def test_meta_nonempty_index():
     assert res.freq == idx.freq
     assert res.name == idx.name
 
-    idx = pd.TimedeltaIndex([np.timedelta64(1, "D")], freq="d", name="foo")
+    idx = pd.TimedeltaIndex([pd.Timedelta(1, "D")], freq="d", name="foo")
     res = meta_nonempty(idx)
     assert type(res) is pd.TimedeltaIndex
     assert res.freq == idx.freq


### PR DESCRIPTION
This PR fixes a couple of tests-only failures due to `pandas` 2.0 changes in `dask/dataframe/tests/test_utils_dataframe.py` 