### PR TITLE
Remove duplicated `encoding` kwarg in docstring for `to_json`

### DIFF
--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -59,8 +59,6 @@ def to_json(
         objects, which can be computed at a later time.
     compute_kwargs : dict, optional
         Options to be passed in to the compute method
-    encoding, errors:
-        Text conversion, ``see str.encode()``
     compression : string or None
         String like 'gzip' or 'xz'.
     name_function : callable, default None


### PR DESCRIPTION
- [x] No related issue found
- [x] No tests added
- [ ] Passes `pre-commit run --all-files`

Currently this fails due to an issue with another docstring (dd.to_sql), which is being fixed in https://github.com/dask/dask/issues/9799