### PR TITLE
ignore sqlalchemy.exc.RemovedIn20Warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ filterwarnings =
     # Ignore FutureWarning for change in group_keys behavior: no changes required on the dask side.
     # https://pandas.pydata.org/docs/dev/whatsnew/v1.5.0.html#using-group-keys-with-transformers-in-groupby-apply
     ignore:Not prepending group keys:FutureWarning
+    ignore:.*:sqlalchemy.exc.RemovedIn20Warning
 xfail_strict=true
 
 [metadata]


### PR DESCRIPTION
pandas only supports sqlalchemy 1.x so the warning isn't useful yet

- [x] Closes #9799
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
