### PR TITLE
enable PEP 597 EncodingWarnings

### DIFF
--- a/continuous_integration/scripts/run_tests.sh
+++ b/continuous_integration/scripts/run_tests.sh
@@ -10,7 +10,7 @@ if [[ $COVERAGE == 'true' ]]; then
     export XTRATESTARGS="--cov=dask --cov-report=xml $XTRATESTARGS"
 fi
 
-echo "py.test dask --runslow $XTRATESTARGS"
-py.test dask --runslow $XTRATESTARGS
+echo "PYTHONWARNDEFAULTENCODING=1 pytest dask --runslow $XTRATESTARGS"
+PYTHONWARNDEFAULTENCODING=1 pytest dask --runslow $XTRATESTARGS
 
 set +e

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -644,7 +644,7 @@ def test_from_url():
 
 
 def test_read_text():
-    with filetexts({"a1.log": "A\nB", "a2.log": "C\nD"}) as fns:
+    with filetexts({"a1.log": b"A\nB", "a2.log": b"C\nD"}, mode="b") as fns:
         assert {line.strip() for line in db.read_text(fns)} == set("ABCD")
         assert {line.strip() for line in db.read_text("a*.log")} == set("ABCD")
 
@@ -1014,7 +1014,7 @@ def test_to_textfiles_endlines():
     with tmpfile() as fn:
         for last_endline in False, True:
             b.to_textfiles([fn], last_endline=last_endline)
-            with open(fn) as f:
+            with open(fn, encoding="utf8") as f:
                 result = f.readlines()
             assert result == ["a\n", "b\n", "c\n" if last_endline else "c"]
 

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -339,7 +339,7 @@ def test_abs_paths(tmpdir):
     tmpdir = str(tmpdir)
     here = os.getcwd()
     os.chdir(tmpdir)
-    with open("tmp", "w") as f:
+    with open("tmp", "w", encoding="utf8") as f:
         f.write("hi")
     out = LocalFileSystem().glob("*")
     assert len(out) == 1

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -207,7 +207,7 @@ def s3_with_yellow_tripdata(s3):
     sample = pd.DataFrame(data)
     df = sample.take(np.arange(5).repeat(10000))
     file = io.BytesIO()
-    sfile = io.TextIOWrapper(file)
+    sfile = io.TextIOWrapper(file, encoding="utf8")
     df.to_csv(sfile, index=False)
 
     key = "nyc-taxi/2015/yellow_tripdata_2015-01.csv"

--- a/dask/config.py
+++ b/dask/config.py
@@ -148,7 +148,7 @@ def _load_config_file(path: str) -> dict | None:
     """A helper for loading a config file from a path, and erroring
     appropriately if the file is malformed."""
     try:
-        with open(path) as f:
+        with open(path, "rb") as f:
             config = yaml.safe_load(f.read())
     except OSError:
         # Ignore permission errors
@@ -282,17 +282,17 @@ def ensure_file(
             # a race condition where a process can be busy creating the
             # destination while another process reads an empty config file.
             tmp = "%s.tmp.%d" % (destination, os.getpid())
-            with open(source) as f:
+            with open(source, "rb") as f:
                 lines = list(f)
 
             if comment:
                 lines = [
-                    "# " + line if line.strip() and not line.startswith("#") else line
+                    b"# " + line if line.strip() and not line.startswith(b"#") else line
                     for line in lines
                 ]
 
-            with open(tmp, "w") as f:
-                f.write("".join(lines))
+            with open(tmp, "wb") as f:
+                f.write(b"".join(lines))
 
             try:
                 os.rename(tmp, destination)
@@ -709,7 +709,7 @@ def deserialize(data: str) -> Any:
 def _initialize() -> None:
     fn = os.path.join(os.path.dirname(__file__), "dask.yaml")
 
-    with open(fn) as f:
+    with open(fn, "rb") as f:
         _defaults = yaml.safe_load(f)
 
     update_defaults(_defaults)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4015,8 +4015,8 @@ def test_ignore_metadata_file(tmpdir, engine, calculate_divisions):
 
     # Copy "bad" metadata into `dataset_with_bad_metadata`
     assert "_metadata" not in os.listdir(dataset_with_bad_metadata)
-    with open(os.path.join(dataset_with_bad_metadata, "_metadata"), "w") as f:
-        f.write("INVALID METADATA")
+    with open(os.path.join(dataset_with_bad_metadata, "_metadata"), "wb") as f:
+        f.write(b"INVALID METADATA")
     assert "_metadata" in os.listdir(dataset_with_bad_metadata)
     assert "_metadata" not in os.listdir(dataset_without_metadata)
 
@@ -4089,8 +4089,8 @@ def test_extra_file(tmpdir, engine, partition_on):
         write_metadata_file=True,
         partition_on=partition_on,
     )
-    open(os.path.join(tmpdir, "_SUCCESS"), "w").close()
-    open(os.path.join(tmpdir, "part.0.parquet.crc"), "w").close()
+    open(os.path.join(tmpdir, "_SUCCESS"), "wb").close()
+    open(os.path.join(tmpdir, "part.0.parquet.crc"), "wb").close()
     os.remove(os.path.join(tmpdir, "_metadata"))
     out = dd.read_parquet(tmpdir, engine=engine, calculate_divisions=True)
     # Weird two-step since that we don't care if category ordering changes

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -356,7 +356,7 @@ def test_saves_file():
         prof.visualize(show=False, filename=fn)
 
         assert os.path.exists(fn)
-        with open(fn) as f:
+        with open(fn, encoding="utf8") as f:
             assert "html" in f.read().lower()
 
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -70,9 +70,9 @@ def test_collect_yaml_paths():
 
     with tmpfile(extension="yaml") as fn1:
         with tmpfile(extension="yaml") as fn2:
-            with open(fn1, "w") as f:
+            with open(fn1, "w", encoding="utf8") as f:
                 yaml.dump(a, f)
-            with open(fn2, "w") as f:
+            with open(fn2, "w", encoding="utf8") as f:
                 yaml.dump(b, f)
 
             config = merge(*collect_yaml(paths=[fn1, fn2]))
@@ -87,9 +87,9 @@ def test_collect_yaml_dir():
 
     with tmpfile() as dirname:
         os.mkdir(dirname)
-        with open(os.path.join(dirname, "a.yaml"), mode="w") as f:
+        with open(os.path.join(dirname, "a.yaml"), mode="w", encoding="utf8") as f:
             yaml.dump(a, f)
-        with open(os.path.join(dirname, "b.yaml"), mode="w") as f:
+        with open(os.path.join(dirname, "b.yaml"), mode="w", encoding="utf8") as f:
             yaml.dump(b, f)
 
         config = merge(*collect_yaml(paths=[dirname]))
@@ -119,9 +119,9 @@ def test_collect_yaml_permission_errors(tmpdir, kind):
     a_path = os.path.join(dir_path, "a.yaml")
     b_path = os.path.join(dir_path, "b.yaml")
 
-    with open(a_path, mode="w") as f:
+    with open(a_path, mode="w", encoding="utf8") as f:
         yaml.dump(a, f)
-    with open(b_path, mode="w") as f:
+    with open(b_path, mode="w", encoding="utf8") as f:
         yaml.dump(b, f)
 
     if kind == "directory":
@@ -198,9 +198,9 @@ def test_collect():
 
     with tmpfile(extension="yaml") as fn1:
         with tmpfile(extension="yaml") as fn2:
-            with open(fn1, "w") as f:
+            with open(fn1, "w", encoding="utf8") as f:
                 yaml.dump(a, f)
-            with open(fn2, "w") as f:
+            with open(fn2, "w", encoding="utf8") as f:
                 yaml.dump(b, f)
 
             config = collect([fn1, fn2], env=env)
@@ -231,22 +231,22 @@ def test_ensure_file(tmpdir):
     dest = os.path.join(str(tmpdir), "dest")
     destination = os.path.join(dest, "source.yaml")
 
-    with open(source, "w") as f:
+    with open(source, "w", encoding="utf8") as f:
         yaml.dump(a, f)
 
     ensure_file(source=source, destination=dest, comment=False)
 
-    with open(destination) as f:
+    with open(destination, "rb") as f:
         result = yaml.safe_load(f)
     assert result == a
 
     # don't overwrite old config files
-    with open(source, "w") as f:
+    with open(source, "w", encoding="utf8") as f:
         yaml.dump(b, f)
 
     ensure_file(source=source, destination=dest, comment=False)
 
-    with open(destination) as f:
+    with open(destination, "rb") as f:
         result = yaml.safe_load(f)
     assert result == a
 
@@ -255,11 +255,11 @@ def test_ensure_file(tmpdir):
     # Write again, now with comments
     ensure_file(source=source, destination=dest, comment=True)
 
-    with open(destination) as f:
+    with open(destination, encoding="utf8") as f:
         text = f.read()
     assert "123" in text
 
-    with open(destination) as f:
+    with open(destination, "rb") as f:
         result = yaml.safe_load(f)
     assert not result
 
@@ -326,7 +326,7 @@ def test_ensure_file_directory(mkdir, tmpdir):
     source = os.path.join(str(tmpdir), "source.yaml")
     dest = os.path.join(str(tmpdir), "dest")
 
-    with open(source, "w") as f:
+    with open(source, "w", encoding="utf8") as f:
         yaml.dump(a, f)
 
     if mkdir:
@@ -341,7 +341,7 @@ def test_ensure_file_directory(mkdir, tmpdir):
 def test_ensure_file_defaults_to_DASK_CONFIG_directory(tmpdir):
     a = {"x": 1, "y": {"a": 1}}
     source = os.path.join(str(tmpdir), "source.yaml")
-    with open(source, "w") as f:
+    with open(source, "w", encoding="utf8") as f:
         yaml.dump(a, f)
 
     destination = os.path.join(str(tmpdir), "dask")
@@ -449,10 +449,10 @@ def test_schema():
     config_fn = os.path.join(os.path.dirname(__file__), "..", "dask.yaml")
     schema_fn = os.path.join(os.path.dirname(__file__), "..", "dask-schema.yaml")
 
-    with open(config_fn) as f:
+    with open(config_fn, "rb") as f:
         config = yaml.safe_load(f)
 
-    with open(schema_fn) as f:
+    with open(schema_fn, "rb") as f:
         schema = yaml.safe_load(f)
 
     jsonschema.validate(config, schema)
@@ -462,10 +462,10 @@ def test_schema_is_complete():
     config_fn = os.path.join(os.path.dirname(__file__), "..", "dask.yaml")
     schema_fn = os.path.join(os.path.dirname(__file__), "..", "dask-schema.yaml")
 
-    with open(config_fn) as f:
+    with open(config_fn, "rb") as f:
         config = yaml.safe_load(f)
 
-    with open(schema_fn) as f:
+    with open(schema_fn, "rb") as f:
         schema = yaml.safe_load(f)
 
     def test_matches(c, s):

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -276,9 +276,9 @@ def tmpdir(dir=None):
 
 
 @contextmanager
-def filetext(text, extension="", open=open, mode="w"):
+def filetext(text, extension="", open=open, mode="w", **kwargs):
     with tmpfile(extension=extension) as filename:
-        f = open(filename, mode=mode)
+        f = open(filename, mode=mode, **kwargs)
         try:
             f.write(text)
         finally:


### PR DESCRIPTION
This PR enables https://peps.python.org/pep-0597/ EncodingWarnings, these warnings are issued when a call to `subprocess.Popen(text=True, ...` or `open(...` where the `encoding` kwarg is absent

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
