### PR TITLE
Fix stack overflow by resetting recursion limit after IPython import.

### DIFF
--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -547,11 +547,6 @@ def test_tokenize_dense_sparse_array(cls_name):
     b = b.asformat(cls_name)
     assert tokenize(a) != tokenize(b)
 
-
-@pytest.mark.skipif(
-    sys.platform == "win32" and sys.version_info[:2] == (3, 9),
-    reason="https://github.com/ipython/ipython/issues/12197",
-)
 def test_tokenize_object_with_recursion_error():
     cycle = dict(a=None)
     cycle["a"] = cycle

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -547,6 +547,7 @@ def test_tokenize_dense_sparse_array(cls_name):
     b = b.asformat(cls_name)
     assert tokenize(a) != tokenize(b)
 
+
 def test_tokenize_object_with_recursion_error():
     cycle = dict(a=None)
     cycle["a"] = cycle

--- a/dask/tests/test_typing.py
+++ b/dask/tests/test_typing.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Hashable, Mapping, Sequence
 from typing import Any
 
 import pytest
-import sys
 
 import dask
 import dask.threaded
@@ -20,6 +20,7 @@ from dask.typing import (
 
 try:
     from IPython.display import DisplayObject
+
     # IPython imports jedi by default, which improperly raises this value, leading to stack overflows
     sys.setrecursionlimit(1000)
 except ImportError:

--- a/dask/tests/test_typing.py
+++ b/dask/tests/test_typing.py
@@ -4,6 +4,7 @@ from collections.abc import Hashable, Mapping, Sequence
 from typing import Any
 
 import pytest
+import sys
 
 import dask
 import dask.threaded
@@ -19,6 +20,8 @@ from dask.typing import (
 
 try:
     from IPython.display import DisplayObject
+    # IPython imports jedi by default, which improperly raises this value, leading to stack overflows
+    sys.setrecursionlimit(1000)
 except ImportError:
     DisplayObject = Any
 


### PR DESCRIPTION
- [] Closes #9804 
- [] Tests passed
- [] Passes `pre-commit run --all-files`
