### PR TITLE
Resolve `sqlalchemy` import failures in mindeps testing

### DIFF
--- a/dask/tests/warning_aliases.py
+++ b/dask/tests/warning_aliases.py
@@ -5,5 +5,4 @@ except ModuleNotFoundError:
     class _RemovedIn20Warning(Warning):
         pass
 
-
-RemovedIn20Warning = RemovedIn20Warning or _RemovedIn20Warning
+    RemovedIn20Warning = _RemovedIn20Warning

--- a/dask/tests/warning_aliases.py
+++ b/dask/tests/warning_aliases.py
@@ -1,0 +1,9 @@
+try:
+    from sqlalchemy.exc import RemovedIn20Warning
+except ModuleNotFoundError:
+
+    class _RemovedIn20Warning(Warning):
+        pass
+
+
+RemovedIn20Warning = RemovedIn20Warning or _RemovedIn20Warning

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ filterwarnings =
     # Ignore FutureWarning for change in group_keys behavior: no changes required on the dask side.
     # https://pandas.pydata.org/docs/dev/whatsnew/v1.5.0.html#using-group-keys-with-transformers-in-groupby-apply
     ignore:Not prepending group keys:FutureWarning
-    ignore:.*These feature\(s\) are not compatible with SQLAlchemy 2\.0\..*
+    ignore:.*:dask.tests.warning_aliases.RemovedIn20Warning
 xfail_strict=true
 
 [metadata]

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ filterwarnings =
     # Ignore FutureWarning for change in group_keys behavior: no changes required on the dask side.
     # https://pandas.pydata.org/docs/dev/whatsnew/v1.5.0.html#using-group-keys-with-transformers-in-groupby-apply
     ignore:Not prepending group keys:FutureWarning
-    ignore:.*::sqlalchemy.exc.RemovedIn20Warning
+    ignore:.*These feature\(s\) are not compatible with SQLAlchemy 2\.0\..*
 xfail_strict=true
 
 [metadata]

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ filterwarnings =
     # Ignore FutureWarning for change in group_keys behavior: no changes required on the dask side.
     # https://pandas.pydata.org/docs/dev/whatsnew/v1.5.0.html#using-group-keys-with-transformers-in-groupby-apply
     ignore:Not prepending group keys:FutureWarning
-    ignore:.*:sqlalchemy.exc.RemovedIn20Warning
+    ignore:.*::sqlalchemy.exc.RemovedIn20Warning
 xfail_strict=true
 
 [metadata]


### PR DESCRIPTION
https://github.com/dask/dask/pull/9801 added a warning filter for `sqlalchemy.exc.RemovedIn20Warning` that referred to the module directly, raising failures in our mindeps testing since `sqlalchemy` is not installed in that environment.

This PR modifies the warning filter to match for the warning using regex, which doesn't require `sqlalchemy` to be installed and resolves the mindeps failures.

cc @graingert 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
