### PR TITLE
Temporarily ignore `RuntimeWarning` in `test_setitem_extended_API_2d_mask`

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4164,7 +4164,14 @@ def test_setitem_extended_API_2d_mask(index, value):
     x = np.ma.arange(60).reshape((6, 10))
     dx = da.from_array(x.data, chunks=(2, 3))
     dx[index] = value
-    x[index] = value
+    # See https://github.com/numpy/numpy/issues/23000 for the `RuntimeWarning`
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=RuntimeWarning,
+            message="invalid value encountered in cast",
+        )
+        x[index] = value
     dx = dx.persist()
     assert_eq(x, dx.compute())
     assert_eq(x.mask, da.ma.getmaskarray(dx).compute())


### PR DESCRIPTION
This appears to be coming from `numpy` directly. I've opened https://github.com/numpy/numpy/issues/23000 upstream to see if `numpy` devs have any thoughts on why this may be happening. I'll suggest we ignore the warning in this test for now. 

xref https://github.com/dask/dask/issues/9793

cc @hendrikmakait 