### PR TITLE
Fix running S3 tests locally

### DIFF
--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -78,6 +78,9 @@ def s3_base():
     with ensure_safe_environment_variables():
         os.environ["AWS_ACCESS_KEY_ID"] = "foobar_key"
         os.environ["AWS_SECRET_ACCESS_KEY"] = "foobar_secret"
+        # Ignore any local AWS credentials/config files as they can interfere with moto
+        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = ""
+        os.environ["AWS_CONFIG_FILE"] = ""
 
         # pipe to null to avoid logging in terminal
         proc = subprocess.Popen(


### PR DESCRIPTION
I ran into the same issue reported in https://github.com/dask/dask/issues/9794 when running these tests locally. When I removed my local AWS credentials / configuration files then things ran successfully. This PR suggests we tell boto to ignore local credentials for our S3 tests, which seems reasonable to me anyways. 

Closes https://github.com/dask/dask/issues/9794

cc @mrocklin @martindurant 