### PR TITLE
Ignore warnings on `persist` call in `test_setitem_extended_API_2d_mask`

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4172,7 +4172,7 @@ def test_setitem_extended_API_2d_mask(index, value):
             message="invalid value encountered in cast",
         )
         x[index] = value
-    dx = dx.persist()
+        dx = dx.persist()
     assert_eq(x, dx.compute())
     assert_eq(x.mask, da.ma.getmaskarray(dx).compute())
 


### PR DESCRIPTION
Follow up to https://github.com/dask/dask/pull/9828; it looks like the numpy warning in question also gets emitted on the `dx.persist()` call ([relevant test failure](https://github.com/dask/dask/actions/runs/3940768260/jobs/6742298698)), so should probably also catch it there.

cc @jrbourbeau 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
