### PR TITLE
Use custom timeout in CI builds

### DIFF
--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -10,6 +10,7 @@ defaults:
 jobs:
   mindeps:
     runs-on: "ubuntu-latest"
+    timeout-minutes: 90
     strategy:
       matrix:
         environment: ["mindeps-array", "mindeps-dataframe", "mindeps-non-optional", "mindeps-distributed"]
@@ -38,6 +39,7 @@ jobs:
 
   doctest:
     runs-on: "ubuntu-latest"
+    timeout-minutes: 90
     steps:
       - name: Checkout source
         uses: actions/checkout@v3.3.0
@@ -62,6 +64,7 @@ jobs:
 
   imports:
     runs-on: "ubuntu-latest"
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ defaults:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -36,6 +36,7 @@ jobs:
           needs.check.outputs.test-upstream == 'true'
           || (github.repository == 'dask/dask' && github.event_name != 'pull_request')
       )
+    timeout-minutes: 90
 
     env:
       COVERAGE: "true"


### PR DESCRIPTION
When a CI build stalls, it will keep running until it hits the GitHub actions timeout limit (6 hours). Our CI takes a lot less time than that to run (when it doesn't stall) and it'd be nice to not have to wait the full 6 hours to hit the timeout limit. This PR proposes we use a timeout limit of 90 minutes instead (based on the runtimes of some recent CI builds on `main`). 

cc @charlesbluca 