### PR TITLE
Satisfy broadcast argument in DataFrame merge

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -674,7 +674,7 @@ def merge(
         n_small = min(left.npartitions, right.npartitions)
         n_big = max(left.npartitions, right.npartitions)
         if (
-            shuffle == "tasks"
+            shuffle in ("tasks", None)
             and how in ("inner", "left", "right")
             and how != bcast_side
             and broadcast is not False


### PR DESCRIPTION
Minimal change needed to ensure `broadcast=True` will be satisfied when the broadcast algorithm is not prohibited by the `how` or `shuffle` arguments.

- [x] Closes #9851
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
