### PR TITLE
Fixes related to `group_keys` default change in `pandas` 2.0

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -98,7 +98,13 @@ DEFAULT_GET = named_schedulers.get("threads", named_schedulers["sync"])
 
 no_default = "__no_default__"
 
-GROUP_KEYS_DEFAULT = None if PANDAS_GT_150 else True
+GROUP_KEYS_DEFAULT = None
+if PANDAS_GT_200:
+    GROUP_KEYS_DEFAULT = True
+elif PANDAS_GT_150:
+    GROUP_KEYS_DEFAULT = None
+else:
+    GROUP_KEYS_DEFAULT = True
 
 pd.set_option("compute.use_numexpr", False)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -98,13 +98,9 @@ DEFAULT_GET = named_schedulers.get("threads", named_schedulers["sync"])
 
 no_default = "__no_default__"
 
-GROUP_KEYS_DEFAULT = None
-if PANDAS_GT_200:
-    GROUP_KEYS_DEFAULT = True
-elif PANDAS_GT_150:
+GROUP_KEYS_DEFAULT: bool | None = True
+if PANDAS_GT_150 and not PANDAS_GT_200:
     GROUP_KEYS_DEFAULT = None
-else:
-    GROUP_KEYS_DEFAULT = True
 
 pd.set_option("compute.use_numexpr", False)
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -931,9 +931,10 @@ def test_numeric_column_names():
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf.groupby(0).sum(), df.groupby(0).sum())
     assert_eq(ddf.groupby([0, 2]).sum(), df.groupby([0, 2]).sum())
+    expected = df.groupby(0).apply(lambda x: x)
     assert_eq(
-        ddf.groupby(0).apply(lambda x: x, meta={0: int, 1: int, 2: int}),
-        df.groupby(0).apply(lambda x: x),
+        ddf.groupby(0).apply(lambda x: x, meta=expected),
+        expected,
     )
 
 
@@ -963,10 +964,11 @@ def test_groupby_apply_tasks(shuffle_method):
 def test_groupby_multiprocessing():
     df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": ["1", "1", "a", "a", "a"]})
     ddf = dd.from_pandas(df, npartitions=3)
+    expected = df.groupby("B").apply(lambda x: x)
     with dask.config.set(scheduler="processes"):
         assert_eq(
-            ddf.groupby("B").apply(lambda x: x, meta={"A": int, "B": object}),
-            df.groupby("B").apply(lambda x: x),
+            ddf.groupby("B").apply(lambda x: x, meta=expected),
+            expected,
         )
 
 


### PR DESCRIPTION
Related: https://github.com/dask/dask/issues/9736.

In pandas 2.0, `groupby` adds group keys to index.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
