### PR TITLE
Update `xarray-contrib/issue-from-pytest-log` to version 1.2.6

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -75,7 +75,7 @@ jobs:
           && github.event_name != 'pull_request'
           && github.repository == 'dask/dask'
           && steps.run_tests.outcome == 'failure'
-        uses: xarray-contrib/issue-from-pytest-log@v1.2.5
+        uses: xarray-contrib/issue-from-pytest-log@v1.2.6
         with:
           log-path: output-log.jsonl
           issue-title: ⚠️ Upstream CI failed ⚠️


### PR DESCRIPTION
Should fix the error in the `report` step of the `upstream` build we've been seeing recently (xref https://github.com/xarray-contrib/issue-from-pytest-log/issues/14) 

cc @charlesbluca 

EDIT: Note I'm skipping CI here since this change will only have an impact when running on `main` and won't interact with anything other than the `upstream` build anyways 