### PR TITLE
Reverse precedence between collection and distributed default

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -1345,7 +1345,8 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
 
     1.  Passing in scheduler= parameters
     2.  Passing these into global configuration
-    3.  Using defaults of a dask collection
+    3.  Using a dask.distributed default Client
+    4.  Using defaults of a dask collection
 
     This function centralizes the logic to determine the right scheduler to use
     from those many options
@@ -1407,15 +1408,15 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
     if config.get("get", None):
         raise ValueError(get_err_msg)
 
-    if cls is not None:
-        return cls.__dask_scheduler__
-
     try:
         from distributed import get_client
 
         return get_client().get
     except (ImportError, ValueError):
         pass
+
+    if cls is not None:
+        return cls.__dask_scheduler__
 
     if collections:
         collections = [c for c in collections if c is not None]


### PR DESCRIPTION
This reverses the precedence change introduced in https://github.com/dask/dask/pull/9808/files/524009275e21394892f6161c53c6d250e3cd4a2a#r1062672836

Basically this determines if a collection is supposed to use its default executor or the available distributed cluster when being computed on a worker.

I can see arguments for both sides. This PR reverses the behavior to pre https://github.com/dask/dask/pull/9808