### PR TITLE
Small fix for timestamp index divisions in `pandas` 2.0

### DIFF
--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1110,7 +1110,7 @@ def test_set_index_timestamp():
     df2 = df.set_index("A")
     ddf_new_div = ddf.set_index("A", divisions=divisions)
     for (ts1, ts2) in zip(divisions, ddf_new_div.divisions):
-        assert ts1.value == ts2.value
+        assert ts1.timetuple() == ts2.timetuple()
         assert ts1.tz == ts2.tz
 
     assert_eq(df2, ddf_new_div, **CHECK_FREQ)

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -290,7 +290,7 @@ def test_meta_nonempty_index():
     assert res.freq == idx.freq
     assert res.name == idx.name
 
-    idx = pd.timedelta_range("1 Day", periods=1, freq="1D")
+    idx = pd.TimedeltaIndex([np.timedelta64(1, "D")], freq="d", name="foo")
     res = meta_nonempty(idx)
     assert type(res) is pd.TimedeltaIndex
     assert res.freq == idx.freq

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -290,7 +290,7 @@ def test_meta_nonempty_index():
     assert res.freq == idx.freq
     assert res.name == idx.name
 
-    idx = pd.TimedeltaIndex([np.timedelta64(1, "D")], freq="d", name="foo")
+    idx = pd.timedelta_range("1 Day", periods=1, freq="1D")
     res = meta_nonempty(idx)
     assert type(res) is pd.TimedeltaIndex
     assert res.freq == idx.freq


### PR DESCRIPTION
Default timestamp unit is now `ns`, previously `s`, so we can't compare timestamp values.

Xref https://github.com/dask/dask/issues/9736.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
