### PR TITLE
Add `dataframe.nullable_dtypes` configuration option

### DIFF
--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -72,6 +72,12 @@ properties:
               task when reading a parquet dataset from a REMOTE file system.
               Specifying 0 will result in serial execution on the client.
 
+      nullable_dtypes:
+        type: boolean
+        description: |
+          If nullable dtypes should be returned. This is only applicable to
+          functions where the ``use_nullable_dtypes`` keyword is supported.
+
       dtype_backend:
         enum:
           - pandas

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -12,6 +12,7 @@ dataframe:
   parquet:
     metadata-task-size-local: 512  # Number of files per local metadata-processing task
     metadata-task-size-remote: 16  # Number of files per remote metadata-processing task
+  nullable_dtypes: false  # If nullable dtypes should be returned
   dtype_backend: "pandas"  # Dtype implementation to use
 
 array:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import operator
 import warnings
 from collections.abc import Hashable, Iterator, Sequence
+from enum import Enum
 from functools import partial, wraps
 from numbers import Integral, Number
 from operator import getitem
 from pprint import pformat
-from typing import Any, Callable, ClassVar, Literal, Mapping
+from typing import Any, Callable, ClassVar, Final, Literal, Mapping
 
 import numpy as np
 import pandas as pd
@@ -96,7 +97,13 @@ from dask.widgets import get_template
 
 DEFAULT_GET = named_schedulers.get("threads", named_schedulers["sync"])
 
-no_default = "__no_default__"
+
+class _NoDefault(Enum):
+    no_default = ...
+
+
+no_default: Final = _NoDefault.no_default
+NoDefault = Literal[_NoDefault.no_default]
 
 GROUP_KEYS_DEFAULT: bool | None = True
 if PANDAS_GT_150 and not PANDAS_GT_200:
@@ -5712,7 +5719,7 @@ class DataFrame(_Frame):
         return map_partitions(M.apply, self, func, args=args, meta=meta, **kwds)
 
     @derived_from(pd.DataFrame)
-    def applymap(self, func, meta="__no_default__"):
+    def applymap(self, func, meta=no_default):
         return elemwise(M.applymap, self, func, meta=meta)
 
     @derived_from(pd.DataFrame)

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -13,7 +13,7 @@ import dask
 from dask.base import tokenize
 from dask.blockwise import BlockIndex
 from dask.dataframe.backends import dataframe_creation_dispatch
-from dask.dataframe.core import DataFrame, Scalar
+from dask.dataframe.core import DataFrame, NoDefault, Scalar, no_default
 from dask.dataframe.io.io import from_map
 from dask.dataframe.io.parquet.utils import (
     Engine,
@@ -189,7 +189,7 @@ def read_parquet(
     index=None,
     storage_options=None,
     engine="auto",
-    use_nullable_dtypes: bool = False,
+    use_nullable_dtypes: bool | NoDefault = no_default,
     calculate_divisions=None,
     ignore_metadata_file=False,
     metadata_task_size=None,
@@ -267,6 +267,8 @@ def read_parquet(
     use_nullable_dtypes : {False, True}
         Whether to use extension dtypes for the resulting ``DataFrame``.
         ``use_nullable_dtypes=True`` is only supported when ``engine="pyarrow"``.
+        Can also be specified via the ``dataframe.nullable_dtypes``
+        configuration option.
 
         .. note::
 
@@ -396,6 +398,9 @@ def read_parquet(
     to_parquet
     pyarrow.parquet.ParquetDataset
     """
+
+    if use_nullable_dtypes is no_default:
+        use_nullable_dtypes = dask.config.get("dataframe.nullable_dtypes")
 
     if use_nullable_dtypes:
         use_nullable_dtypes = dask.config.get("dataframe.dtype_backend")


### PR DESCRIPTION
This PR adds a new `dataframe.nullable_dtype` configuration option similar to what `pandas` is doing in https://github.com/pandas-dev/pandas/pull/50748. This should both make alignment between `pandas` and `dask.dataframe` better and make it easier for folks to opt into using `pyarrow`-backed dtypes.

cc @phofl for visibility 