### PR TITLE
Multi-column support for `DataFrame.sort_values`

### DIFF
--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1402,7 +1402,7 @@ def test_set_index_with_series_uses_fastpath():
 
 
 @pytest.mark.parametrize("ascending", [True, False])
-@pytest.mark.parametrize("by", ["a", "b"])
+@pytest.mark.parametrize("by", ["a", "b", ["a", "b"]])
 @pytest.mark.parametrize("nelem", [10, 500])
 def test_sort_values(nelem, by, ascending):
     np.random.seed(0)
@@ -1437,7 +1437,7 @@ def test_sort_values_single_partition(nelem, by, ascending):
 
 @pytest.mark.parametrize("na_position", ["first", "last"])
 @pytest.mark.parametrize("ascending", [True, False])
-@pytest.mark.parametrize("by", ["a", "b"])
+@pytest.mark.parametrize("by", ["a", "b", ["a", "b"]])
 @pytest.mark.parametrize("nparts", [1, 5])
 @pytest.mark.parametrize(
     "data",


### PR DESCRIPTION
Currently we allow for sorting by multiple columns only if `npartitions == 1`. This PR allows for multi-partition sorting.

cc @charlesbluca @rjzamora who were interested in this previously

Closes https://github.com/dask/dask/issues/958