### PR TITLE
[DNM] Find `pyarrow` dtype-related failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,8 @@ defaults:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    # TODO: Revert this temporary change
+    # timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/conftest.py
+++ b/conftest.py
@@ -68,3 +68,16 @@ pytest.register_assert_rewrite(
 def shuffle_method(request):
     with dask.config.set(shuffle=request.param):
         yield request.param
+
+
+# Temporary changes to look for pyarrow dtype failures
+import dask
+from dask.dataframe._compat import PANDAS_GT_150
+
+try:
+    import pyarrow
+except ImportError:
+    pyarrow = False
+
+if PANDAS_GT_150 and pyarrow:
+    dask.config.set({"dataframe.dtype_backend": "pyarrow"})

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -416,6 +416,8 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
             ):
 
                 def to_pyarrow_dtypes(df):
+                    if not isinstance(df, (pd.DataFrame, pd.Series, pd.Index)):
+                        return df
                     if is_dataframe_like(df):
                         dtypes = {
                             col: _convert_to_pyarrow_dtype(df[col].dtype) for col in df

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -55,8 +55,12 @@ except ImportError:
     pq = False
 
 
-SKIP_FASTPARQUET = not fastparquet
-FASTPARQUET_MARK = pytest.mark.skipif(SKIP_FASTPARQUET, reason="fastparquet not found")
+# SKIP_FASTPARQUET = not fastparquet
+# FASTPARQUET_MARK = pytest.mark.skipif(SKIP_FASTPARQUET, reason="fastparquet not found")
+SKIP_FASTPARQUET = True
+FASTPARQUET_MARK = pytest.mark.skipif(
+    SKIP_FASTPARQUET, reason="Skipping fastparquet for now..."
+)
 
 if sys.platform == "win32" and pa and pa_version == parse_version("2.0.0"):
     SKIP_PYARROW = True

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -337,6 +337,9 @@ def _nonempty_scalar(x):
         dtype = x.dtype if hasattr(x, "dtype") else np.dtype(type(x))
         return make_scalar(dtype)
 
+    if x is pd.NA:
+        return pd.NA
+
     raise TypeError(f"Can't handle meta of type '{typename(type(x))}'")
 
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -541,6 +541,24 @@ def assert_eq(
     scheduler="sync",
     **kwargs,
 ):
+    # Temporary changes to look for pyarrow dtype failures
+    import dask
+
+    if dask.config.get("dataframe.dtype_backend") == "pyarrow":
+        from dask.dataframe.core import _convert_to_pyarrow_dtype
+
+        if isinstance(a, pd.DataFrame):
+            dtypes = {col: _convert_to_pyarrow_dtype(a[col].dtype) for col in a}
+            a = a.astype(dtypes)
+        elif isinstance(a, (pd.Series, pd.Index)):
+            a = a.astype(_convert_to_pyarrow_dtype(a.dtype))
+
+        if isinstance(b, pd.DataFrame):
+            dtypes = {col: _convert_to_pyarrow_dtype(b[col].dtype) for col in b}
+            b = b.astype(dtypes)
+        elif isinstance(b, (pd.Series, pd.Index)):
+            b = b.astype(_convert_to_pyarrow_dtype(b.dtype))
+
     if check_divisions:
         assert_divisions(a, scheduler=scheduler)
         assert_divisions(b, scheduler=scheduler)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -725,6 +725,9 @@ def valid_divisions(divisions):
     if not isinstance(divisions, (tuple, list)):
         return False
 
+    if pd.isnull(divisions).any():
+        return False
+
     for i, x in enumerate(divisions[:-2]):
         if x >= divisions[i + 1]:
             return False

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -452,7 +452,15 @@ def test_blockwise_array_creation(c, io, fuse):
 )
 @pytest.mark.parametrize(
     "io",
-    ["parquet-pyarrow", "parquet-fastparquet", "csv", "hdf"],
+    [
+        "parquet-pyarrow",
+        pytest.param(
+            "parquet-fastparquet",
+            marks=pytest.mark.skip("Skipping fastparquet for now..."),
+        ),
+        "csv",
+        "hdf",
+    ],
 )
 @pytest.mark.parametrize("fuse", [True, False, None])
 @pytest.mark.parametrize("from_futures", [True, False])

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,8 @@ markers:
   network: Test requires an internet connection
   slow: Skipped unless --runslow passed
   gpu: marks tests we want to run on GPUs
-addopts = -v -rsxfE --durations=10 --color=yes
+addopts = -v -rsxfE --durations=10
+# addopts = -v -rsxfE --durations=10 --color=yes
 filterwarnings =
     # From Cython-1753
     ignore:can't resolve:ImportWarning


### PR DESCRIPTION
Currently we have initial support for `pyarrow`-backed dtypes. We know lots of operations work great, but some are broken. Figuring out what's broken has so far been a pretty manual process. Try some specific DataFrame method on `pyarrow`-backed data and see if it breaks.

This PR builds on https://github.com/dask/dask/pull/9883 and sets `dataframe.dtype_backend = "pyarrow"` in CI to see what tests fail when run on `pyarrow`-backed DataFrames. The hope here is to more systematically uncover where things aren't working today. 