### PR TITLE
Remove unused `skiprows` variable in `read_csv`

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -501,9 +501,9 @@ def read_pandas(
             "head(n=nrows)`".format(reader_name)
         )
     if isinstance(kwargs.get("skiprows"), int):
-        skiprows = lastskiprow = firstrow = kwargs.get("skiprows")
+        lastskiprow = firstrow = kwargs.get("skiprows")
     elif kwargs.get("skiprows") is None:
-        skiprows = lastskiprow = firstrow = 0
+        lastskiprow = firstrow = 0
     else:
         # When skiprows is a list, we expect more than max(skiprows) to
         # be included in the sample. This means that [0,2] will work well,


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Stumbled upon this, skiprows isn't used afterwards so safe to remove I guess