### PR TITLE
pre-commit: Update isort version to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: absolufy-imports
         name: absolufy-imports
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         language_version: python3


### PR DESCRIPTION
poetry version 1.5.0 broke installs of isort prior to 5.11.5 (see pycqa/isort#2077 and pycqa/isort#2078), so we need to upgrade.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
