### PR TITLE
Add numeric_only to other groupby aggs, pandas 2.0 compatibility

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1978,8 +1978,13 @@ class _GroupBy:
         return result
 
     @derived_from(pd.core.groupby.GroupBy)
-    def std(self, ddof=1, split_every=None, split_out=1):
-        v = self.var(ddof, split_every=split_every, split_out=split_out)
+    def std(self, ddof=1, split_every=None, split_out=1, numeric_only=no_default):
+        v = self.var(
+            ddof,
+            split_every=split_every,
+            split_out=split_out,
+            numeric_only=numeric_only,
+        )
         result = map_partitions(np.sqrt, v, meta=v)
         return result
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1874,7 +1874,10 @@ class _GroupBy:
         return s / c
 
     @derived_from(pd.core.groupby.GroupBy)
-    def median(self, split_every=None, split_out=1, shuffle=None):
+    @numeric_only_enforced
+    def median(
+        self, split_every=None, split_out=1, shuffle=None, numeric_only=no_default
+    ):
         if shuffle is False:
             raise ValueError(
                 "In order to aggregate with 'median', you must use shuffling-based "
@@ -1897,6 +1900,7 @@ class _GroupBy:
             chunk=_non_agg_chunk,
             chunk_kwargs={
                 "key": columns,
+                "numeric_only": numeric_only,
                 **self.observed,
                 **self.dropna,
             },
@@ -1904,6 +1908,7 @@ class _GroupBy:
             aggregate_kwargs={
                 "aggfunc": _median_aggregate,
                 "levels": _determine_levels(self.by),
+                "numeric_only": numeric_only,
                 **self.observed,
                 **self.dropna,
             },

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1733,14 +1733,22 @@ class _GroupBy:
             )
 
     @derived_from(pd.core.groupby.GroupBy)
-    def cumprod(self, axis=0):
+    @numeric_only_enforced
+    def cumprod(self, axis=0, numeric_only=no_default):
+        chunk_kwargs = {"numeric_only": numeric_only}
         if axis:
             if isinstance(self, SeriesGroupBy):
                 raise ValueError("No axis named 1 for object type Series")
             else:
                 return self.obj.cumprod(axis=axis)
         else:
-            return self._cum_agg("cumprod", chunk=M.cumprod, aggregate=M.mul, initial=1)
+            return self._cum_agg(
+                "cumprod",
+                chunk=M.cumprod,
+                aggregate=M.mul,
+                initial=1,
+                chunk_kwargs=chunk_kwargs,
+            )
 
     @derived_from(pd.core.groupby.GroupBy)
     def cumcount(self, axis=no_default):

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3192,7 +3192,7 @@ def test_groupby_slice_getitem(by, slice_key):
     assert_eq(expect, got)
 
 
-@pytest.mark.parametrize("func", ["cumsum", "cumprod", "mean", "median", "var"])
+@pytest.mark.parametrize("func", ["cumsum", "cumprod", "mean", "median", "var", "std"])
 @pytest.mark.parametrize("numeric_only", [None, True, False])
 @pytest.mark.parametrize(
     "df",
@@ -3227,7 +3227,7 @@ def test_groupby_numeric_only_enforced(func, numeric_only, df):
                 ctx = pytest.warns(FutureWarning)
     except FutureWarning:
         ctx = pytest.warns(FutureWarning)
-    except (TypeError, NotImplementedError):
+    except (TypeError, NotImplementedError, ValueError):
         ctx = pytest.raises(TypeError)
 
     with ctx:

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3192,7 +3192,7 @@ def test_groupby_slice_getitem(by, slice_key):
     assert_eq(expect, got)
 
 
-@pytest.mark.parametrize("func", ["cumsum"])
+@pytest.mark.parametrize("func", ["cumsum", "cumprod"])
 @pytest.mark.parametrize("numeric_only", [None, True, False])
 @pytest.mark.parametrize(
     "df",
@@ -3217,7 +3217,7 @@ def test_groupby_numeric_only_enforced(func, numeric_only, df):
                 expect_future_warning = True
     except FutureWarning:
         expect_future_warning = True
-    except TypeError:
+    except (TypeError, NotImplementedError):
         expect_type_error = True
 
     if expect_type_error:

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3192,7 +3192,7 @@ def test_groupby_slice_getitem(by, slice_key):
     assert_eq(expect, got)
 
 
-@pytest.mark.parametrize("func", ["cumsum", "cumprod"])
+@pytest.mark.parametrize("func", ["cumsum", "cumprod", "mean"])
 @pytest.mark.parametrize("numeric_only", [None, True, False])
 @pytest.mark.parametrize(
     "df",

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3192,7 +3192,7 @@ def test_groupby_slice_getitem(by, slice_key):
     assert_eq(expect, got)
 
 
-@pytest.mark.parametrize("func", ["cumsum", "cumprod", "mean", "median"])
+@pytest.mark.parametrize("func", ["cumsum", "cumprod", "mean", "median", "var"])
 @pytest.mark.parametrize("numeric_only", [None, True, False])
 @pytest.mark.parametrize(
     "df",

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3192,13 +3192,24 @@ def test_groupby_slice_getitem(by, slice_key):
     assert_eq(expect, got)
 
 
-@pytest.mark.parametrize("func", ["cumsum", "cumprod", "mean"])
+@pytest.mark.parametrize("func", ["cumsum", "cumprod", "mean", "median"])
 @pytest.mark.parametrize("numeric_only", [None, True, False])
 @pytest.mark.parametrize(
     "df",
     [
-        pd.DataFrame({"A": [1, 1, 2], "B": [3, 4, 3]}),
-        pd.DataFrame({"A": [1, 1, 2], "B": [3, 4, 3], "C": ["a", "b", "c"]}),
+        pd.DataFrame(
+            {
+                "A": [1, 1, 1, 1, 2, 2, 2, 2],
+                "B": [1, 2, 3, 4, 4, 5, 6, 7],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "A": [1, 1, 1, 1, 2, 2, 2, 2],
+                "B": [1, 2, 3, 4, 4, 5, 6, 7],
+                "C": ["a", "a", "b", "b", "c", "c", "d", "d"],
+            }
+        ),
     ],
 )
 def test_groupby_numeric_only_enforced(func, numeric_only, df):


### PR DESCRIPTION
Follow-up for https://github.com/dask/dask/pull/9889.

Adds `numeric_only` to other groupby aggregate functions, namely:

- [x] cumsum
- [x] cumprod
- [x] mean
- [x] median
- [x] var
- [x] std
- [x] corr
- [x] cov

Xref https://github.com/dask/dask/issues/9736.
Xref https://github.com/dask/dask/issues/9471.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
