### PR TITLE
Allow p2p shuffle kwarg for DataFrame merges

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -345,6 +345,19 @@ def hash_join(
 
     >>> hash_join(lhs, 'id', rhs, 'id', how='left', npartitions=10)  # doctest: +SKIP
     """
+    if shuffle == "p2p":
+        from distributed.shuffle._merge import hash_join_p2p
+
+        return hash_join_p2p(
+            lhs=lhs,
+            left_on=left_on,
+            rhs=rhs,
+            right_on=right_on,
+            how=how,
+            npartitions=npartitions,
+            suffixes=suffixes,
+            indicator=indicator,
+        )
     if npartitions is None:
         npartitions = max(lhs.npartitions, rhs.npartitions)
 

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -687,7 +687,7 @@ def merge(
         n_small = min(left.npartitions, right.npartitions)
         n_big = max(left.npartitions, right.npartitions)
         if (
-            shuffle in ("tasks", None)
+            shuffle in ("tasks", "p2p", None)
             and how in ("inner", "left", "right")
             and how != bcast_side
             and broadcast is not False
@@ -703,6 +703,11 @@ def merge(
             # more likely to select the `broadcast_join` code path.  If
             # the user specifies a floating-point value for the `broadcast`
             # kwarg, that value will be used as the `broadcast_bias`.
+
+            # FIXME: We never evaluated how P2P compares against broadcast and
+            # where a suitable cutoff point is. While scaling likely still
+            # depends on number of partitions, the broadcast bias should likely
+            # be different
             if broadcast or (n_small < math.log2(n_big) * broadcast_bias):
                 return broadcast_join(
                     left,

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -346,7 +346,7 @@ def hash_join(
     >>> hash_join(lhs, 'id', rhs, 'id', how='left', npartitions=10)  # doctest: +SKIP
     """
     if shuffle == "p2p":
-        from distributed.shuffle._merge import hash_join_p2p
+        from distributed.shuffle import hash_join_p2p
 
         return hash_join_p2p(
             lhs=lhs,

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -96,7 +96,7 @@ from dask.dataframe.utils import (
 )
 from dask.highlevelgraph import HighLevelGraph
 from dask.layers import BroadcastJoinLayer
-from dask.utils import M, apply
+from dask.utils import M, apply, get_default_shuffle_algorithm
 
 
 def align_partitions(*dfs):
@@ -345,6 +345,8 @@ def hash_join(
 
     >>> hash_join(lhs, 'id', rhs, 'id', how='left', npartitions=10)  # doctest: +SKIP
     """
+    if shuffle is None:
+        shuffle = get_default_shuffle_algorithm()
     if shuffle == "p2p":
         from distributed.shuffle import hash_join_p2p
 


### PR DESCRIPTION
Symmetric change to https://github.com/dask/distributed/pull/7514 that will use a specialized HashJoin layer.

Not sure how to test this, yet. Suggestions welcome

TODO:
- [x] This is not respecting the dask.config("shuffle") value