### PR TITLE
Add support for grouping by tuple keys

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -88,7 +88,7 @@ SORT_SPLIT_OUT_WARNING = (
 
 def _determine_levels(by):
     """Determine the correct levels argument to groupby."""
-    if isinstance(by, (tuple, list)) and len(by) > 1:
+    if isinstance(by, list) and len(by) > 1:
         return list(range(len(by)))
     else:
         return 0
@@ -1295,7 +1295,7 @@ class _GroupBy:
         observed=False,
     ):
 
-        by_ = by if isinstance(by, (tuple, list)) else [by]
+        by_ = by if isinstance(by, list) else [by]
         if any(isinstance(key, pd.Grouper) for key in by_):
             raise NotImplementedError("pd.Grouper is currently not supported by Dask.")
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3190,3 +3190,23 @@ def test_groupby_slice_getitem(by, slice_key):
     # column projection after read_parquet etc
     assert hlg_layer(got.dask, "getitem")
     assert_eq(expect, got)
+
+
+def test_groupby_tuple_key():
+    df = pd.DataFrame(
+        {
+            ("a", "b"): [1, 1, 2, 2],
+            "a": [1, 1, 1, 2],
+            "b": [1, 2, 2, 2],
+            "c": [1, 1, 1, 1],
+        }
+    )
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    result = ddf.groupby(("a", "b")).c.count()
+    expected = df.groupby(("a", "b")).c.count()
+    assert_eq(result, expected)
+
+    result = ddf.groupby(["a", "b"]).c.count()
+    expected = df.groupby(["a", "b"]).c.count()
+    assert_eq(result, expected)


### PR DESCRIPTION
It looks like we've been allowing the `by` columns of a groupby to be specified in a list or tuple, but expected pandas behavior treats a tuple as a column key; this PR attempts to align us with pandas behavior, marking this as a draft as I imagine this will break a few tests.

Also noting that the added tests seem to be failing due to numpy warnings getting emitted in pandas while trying to index an empty dataframe with a tuple column key:

```python
import pandas as pd

df = pd.DataFrame(columns=[('a', 'b'), 'a', 'b', 'c'])
df[[('a', 'b'), 'c']]
# /raid/charlesb/mambaforge/envs/groupby-tuple/lib/python3.9/site-packages/pandas/core/common.py:241: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
#   result = np.asarray(values, dtype=dtype)
```

Will file an issue to track this if it doesn't already exist.

cc @quasiben 

- [ ] Closes #2893
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
