### PR TITLE
Broaden exception catching for `sqlalchemy.exc.RemovedIn20Warning`

### DIFF
--- a/dask/tests/warning_aliases.py
+++ b/dask/tests/warning_aliases.py
@@ -1,6 +1,6 @@
 try:
     from sqlalchemy.exc import RemovedIn20Warning
-except ModuleNotFoundError:
+except ImportError:
 
     class _RemovedIn20Warning(Warning):
         pass


### PR DESCRIPTION
Previously we wanted to catch `ModuleNotFoundError` but with the `sqlalchemy=2` release this will now raise an `ImportError`. Let's start catching `ImportError`s instead, which will still be backwards compatible as `ModuleNotFoundError` is a subclass of `ImportError`. This will make running subsets of the dask test suite easier for downstream project (e.g. `fsspec`) that run portions of our test suite.

Note sql-related tests will still fail when using `sqlalchemy=2` (xref https://github.com/dask/dask/issues/9896) but this change will at least make it so the entire test suite doesn't fall over. 

cc @martindurant @j-bennet who recently ran into this 