### PR TITLE
Fix numeric `meta_nonempty` index creation for `pandas` 2.0

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -331,7 +331,7 @@ def _nonempty_index(idx):
     if typ is pd.RangeIndex:
         return pd.RangeIndex(2, name=idx.name)
     elif idx.is_numeric():
-        return typ([1, 2], name=idx.name)
+        return typ([1, 2], name=idx.name, dtype=idx.dtype)
     elif typ is pd.Index:
         if idx.dtype == bool:
             # pd 1.5 introduce bool dtypes and respect non-uniqueness


### PR DESCRIPTION
This PR fixes `dask/dataframe/tests/test_utils_dataframe.py::test_meta_nonempty_uint64index` in the `upstream` build which was failing with

```python
________________________ test_meta_nonempty_uint64index ________________________
[gw1] linux -- Python 3.10.8 /usr/share/miniconda3/envs/test-environment/bin/python3.10

    def test_meta_nonempty_uint64index():
        idx = pd.Index([1], name="foo", dtype="uint64")
        res = meta_nonempty(idx)
        assert type(res) is type(idx)
>       assert res.dtype == "uint64"
E       AssertionError: assert dtype('int64') == 'uint64'
E        +  where dtype('int64') = Index([1, 2], dtype='int64', name='foo').dtype

dask/dataframe/tests/test_utils_dataframe.py:343: AssertionError
```

cc @j-bennet 