### PR TITLE
Fix `DataFrame.info()` tests for `pandas` 2.0

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5831,7 +5831,7 @@ class DataFrame(_Frame):
         lines = [str(type(self))]
 
         if len(self.columns) == 0:
-            lines.append("Index: 0 entries")
+            lines.append(f"{type(self.index._meta).__name__}: 0 entries")
             lines.append(f"Empty {type(self).__name__}")
             if PANDAS_GT_150:
                 # pandas dataframe started adding a newline when info is called.

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3907,7 +3907,7 @@ def test_categorize_info():
 
     expected = (
         "<class 'dask.dataframe.core.DataFrame'>\n"
-        "Int64Index: 4 entries, 0 to 3\n"
+        f"{type(ddf._meta.index).__name__}: 4 entries, 0 to 3\n"
         "Data columns (total 3 columns):\n"
         " #   Column  Non-Null Count  Dtype\n"
         "---  ------  --------------  -----\n"


### PR DESCRIPTION
`dask/dataframe/tests/test_dataframe.py::test_info` and `dask/dataframe/tests/test_dataframe.py::test_categorize_info` are failing in our `upstream` build due to the use of hard-coded expected output that is slightly different when using `pandas` 2.0. This PR generalizes the hard-coded value a bit to make things work. 

Note that I think we could probably re-work our `info`-related tests to not use hard-coded values at all, but that will take more time, so I'm going with the simple fix here. 

cc @j-bennet 