### PR TITLE
Use label for `upstream` build on pull requests

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -35,6 +35,7 @@ jobs:
       always()
       && (
           needs.check.outputs.test-upstream == 'true'
+          || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'upstream'))
           || (github.repository == 'dask/dask' && github.event_name != 'pull_request')
       )
     timeout-minutes: 90


### PR DESCRIPTION
While fixing the `upstream` CI build it's easy to forget to include `test-upstream` in the commit message. This PR proposes we also allow the `upstream` label to indicate the `upstream` build should run on PRs. This way one doesn't need to remember to always include `test-upstream` in commit messages. 

cc @j-bennet @charlesbluca 