### PR TITLE
Filter out All-NaN RuntimeWarning at the chunk level for `nanmin` and `nanmax`

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -2,6 +2,7 @@ import builtins
 import contextlib
 import math
 import operator
+import warnings
 from collections.abc import Iterable
 from functools import partial
 from itertools import product, repeat
@@ -608,7 +609,11 @@ def nanmin(a, axis=None, keepdims=False, split_every=None, out=None):
 
 def _nanmin_skip(x_chunk, axis, keepdims):
     if x_chunk.size > 0:
-        return np.nanmin(x_chunk, axis=axis, keepdims=keepdims)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", "All-NaN slice encountered", RuntimeWarning
+            )
+            return np.nanmin(x_chunk, axis=axis, keepdims=keepdims)
     else:
         return asarray_safe(
             np.array([], dtype=x_chunk.dtype), like=meta_from_array(x_chunk)
@@ -637,7 +642,11 @@ def nanmax(a, axis=None, keepdims=False, split_every=None, out=None):
 
 def _nanmax_skip(x_chunk, axis, keepdims):
     if x_chunk.size > 0:
-        return np.nanmax(x_chunk, axis=axis, keepdims=keepdims)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", "All-NaN slice encountered", RuntimeWarning
+            )
+            return np.nanmax(x_chunk, axis=axis, keepdims=keepdims)
     else:
         return asarray_safe(
             np.array([], dtype=x_chunk.dtype), like=meta_from_array(x_chunk)

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -270,6 +270,19 @@ def test_arg_reductions(dfunc, func):
 
 
 @pytest.mark.parametrize(
+    ["dfunc", "func"], [(da.nanmin, np.nanmin), (da.nanmax, np.nanmax)]
+)
+def test_nan_reduction_warnings(dfunc, func):
+    x = np.random.random((10, 10, 10))
+    x[5] = np.nan
+    a = da.from_array(x, chunks=(3, 4, 5))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)  # All-NaN slice encountered
+        expected = func(x, 1)
+    assert_eq(dfunc(a, 1), expected)
+
+
+@pytest.mark.parametrize(
     ["dfunc", "func"], [(da.nanargmin, np.nanargmin), (da.nanargmax, np.nanargmax)]
 )
 def test_nanarg_reductions(dfunc, func):


### PR DESCRIPTION
I am opening this up because I just ran into an issue where I was flooded with this warning. This is not a general solution, it is just a fix for some specific chunk reductions that can be very noisy if you have sparse data. 

- [ ] Partially addresses #3245
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
