### PR TITLE
Replace `index.is_numeric` with `is_any_real_numeric_dtype` for `pandas` 2.0 compatibility

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -112,3 +112,18 @@ if PANDAS_GT_150:
     IndexingError = pd.errors.IndexingError
 else:
     IndexingError = pd.core.indexing.IndexingError
+
+
+def is_any_real_numeric_dtype(arr_or_dtype) -> bool:
+    try:
+        # `is_any_real_numeric_dtype` was added in PANDAS_GT_200.
+        # We can remove this compatibility utility once we only support `pandas>=2.0`
+        return pd.api.types.is_any_real_numeric_dtype(arr_or_dtype)
+    except AttributeError:
+        from pandas.api.types import is_bool_dtype, is_complex_dtype, is_numeric_dtype
+
+        return (
+            is_numeric_dtype(arr_or_dtype)
+            and not is_complex_dtype(arr_or_dtype)
+            and not is_bool_dtype(arr_or_dtype)
+        )

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -9,7 +9,6 @@ from pandas.api.types import (
     is_categorical_dtype,
     is_datetime64tz_dtype,
     is_interval_dtype,
-    is_numeric_dtype,
     is_period_dtype,
     is_scalar,
     is_sparse,
@@ -20,6 +19,7 @@ from dask.array.core import Array
 from dask.array.dispatch import percentile_lookup
 from dask.array.percentile import _percentile
 from dask.backends import CreationDispatch, DaskBackendEntrypoint
+from dask.dataframe._compat import is_any_real_numeric_dtype
 from dask.dataframe.core import DataFrame, Index, Scalar, Series, _Frame
 from dask.dataframe.dispatch import (
     categorical_dtype_dispatch,
@@ -331,8 +331,8 @@ def _nonempty_index(idx):
     typ = type(idx)
     if typ is pd.RangeIndex:
         return pd.RangeIndex(2, name=idx.name)
-    elif is_numeric_dtype(idx):
-        return typ([0, 1], name=idx.name, dtype=idx.dtype)
+    elif is_any_real_numeric_dtype(idx):
+        return typ([1, 2], name=idx.name, dtype=idx.dtype)
     elif typ is pd.Index:
         if idx.dtype == bool:
             # pd 1.5 introduce bool dtypes and respect non-uniqueness

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -332,7 +332,7 @@ def _nonempty_index(idx):
     if typ is pd.RangeIndex:
         return pd.RangeIndex(2, name=idx.name)
     elif is_numeric_dtype(idx):
-        return typ([1, 2], name=idx.name, dtype=idx.dtype)
+        return typ([0, 1], name=idx.name, dtype=idx.dtype)
     elif typ is pd.Index:
         if idx.dtype == bool:
             # pd 1.5 introduce bool dtypes and respect non-uniqueness

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -9,6 +9,7 @@ from pandas.api.types import (
     is_categorical_dtype,
     is_datetime64tz_dtype,
     is_interval_dtype,
+    is_numeric_dtype,
     is_period_dtype,
     is_scalar,
     is_sparse,
@@ -330,7 +331,7 @@ def _nonempty_index(idx):
     typ = type(idx)
     if typ is pd.RangeIndex:
         return pd.RangeIndex(2, name=idx.name)
-    elif idx.is_numeric():
+    elif is_numeric_dtype(idx):
         return typ([1, 2], name=idx.name, dtype=idx.dtype)
     elif typ is pd.Index:
         if idx.dtype == bool:

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Iterable, Literal, overload
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_numeric_dtype
 
 import dask.array as da
 from dask.base import is_dask_collection, tokenize
@@ -279,7 +280,7 @@ def from_pandas(
     if not nrows:
         return new_dd_object({(name, 0): data}, name, data, [None, None])
 
-    if data.index.isna().any() and not data.index.is_numeric():
+    if data.index.isna().any() and not is_numeric_dtype(data.index):
         raise NotImplementedError(
             "Index in passed data is non-numeric and contains nulls, which Dask does not entirely support.\n"
             "Consider passing `data.loc[~data.isna()]` instead."

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -9,11 +9,11 @@ from typing import TYPE_CHECKING, Iterable, Literal, overload
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_numeric_dtype
 
 import dask.array as da
 from dask.base import is_dask_collection, tokenize
 from dask.blockwise import BlockwiseDepDict, blockwise
+from dask.dataframe._compat import is_any_real_numeric_dtype
 from dask.dataframe.backends import dataframe_creation_dispatch
 from dask.dataframe.core import (
     DataFrame,
@@ -280,7 +280,7 @@ def from_pandas(
     if not nrows:
         return new_dd_object({(name, 0): data}, name, data, [None, None])
 
-    if data.index.isna().any() and not is_numeric_dtype(data.index):
+    if data.index.isna().any() and not is_any_real_numeric_dtype(data.index):
         raise NotImplementedError(
             "Index in passed data is non-numeric and contains nulls, which Dask does not entirely support.\n"
             "Consider passing `data.loc[~data.isna()]` instead."


### PR DESCRIPTION
Resolve a deprecation to fix an upstream failure:

```
dask/dataframe/io/tests/test_parquet.py::test_empty[fastparquet-fastparquet-True]: FutureWarning: Index.is_numeric is deprecated. Use pandas.api.types.is_numeric_dtype instead
```

- [x] Passes `pre-commit run --all-files`
