### PR TITLE
Update `value_counts` to return correct name in `pandas` 2.0

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -357,8 +357,8 @@ def value_counts_aggregate(
         out /= total_length if total_length is not None else out.sum()
     if sort:
         out = out.sort_values(ascending=ascending)
-    if PANDAS_GT_200:
-        out.name = "proportion" if normalize else "count"
+    if PANDAS_GT_200 and normalize:
+        out.name = "proportion"
     return out
 
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 from tlz import partition
 
-from dask.dataframe._compat import PANDAS_GT_131
+from dask.dataframe._compat import PANDAS_GT_131, PANDAS_GT_200
 
 #  preserve compatibility while moving dispatch objects
 from dask.dataframe.dispatch import (  # noqa: F401
@@ -356,7 +356,9 @@ def value_counts_aggregate(
     if normalize:
         out /= total_length if total_length is not None else out.sum()
     if sort:
-        return out.sort_values(ascending=ascending)
+        out = out.sort_values(ascending=ascending)
+    if PANDAS_GT_200:
+        out.name = "proportion" if normalize else "count"
     return out
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1270,24 +1270,25 @@ def test_value_counts_with_normalize():
 
 
 @pytest.mark.skipif(not PANDAS_GT_110, reason="dropna implemented in pandas 1.1.0")
-def test_value_counts_with_normalize_and_dropna():
+@pytest.mark.parametrize("normalize", [True, False])
+def test_value_counts_with_normalize_and_dropna(normalize):
     df = pd.DataFrame({"x": [1, 2, 1, 3, np.nan, 1, 4]})
     ddf = dd.from_pandas(df, npartitions=3)
 
-    result = ddf.x.value_counts(dropna=False, normalize=True)
-    expected = df.x.value_counts(dropna=False, normalize=True)
+    result = ddf.x.value_counts(dropna=False, normalize=normalize)
+    expected = df.x.value_counts(dropna=False, normalize=normalize)
     assert_eq(result, expected)
 
-    result2 = ddf.x.value_counts(split_every=2, dropna=False, normalize=True)
+    result2 = ddf.x.value_counts(split_every=2, dropna=False, normalize=normalize)
     assert_eq(result2, expected)
     assert result._name != result2._name
 
-    result3 = ddf.x.value_counts(split_out=2, dropna=False, normalize=True)
+    result3 = ddf.x.value_counts(split_out=2, dropna=False, normalize=normalize)
     assert_eq(result3, expected)
     assert result._name != result3._name
 
-    result4 = ddf.x.value_counts(dropna=True, normalize=True, split_out=2)
-    expected4 = df.x.value_counts(dropna=True, normalize=True)
+    result4 = ddf.x.value_counts(dropna=True, normalize=normalize, split_out=2)
+    expected4 = df.x.value_counts(dropna=True, normalize=normalize)
     assert_eq(result4, expected4)
 
 


### PR DESCRIPTION
Fix for an upstream failure:

```
2023-02-03T20:50:29.9817830Z FAILED dask/dataframe/tests/test_dataframe.py::test_value_counts_with_normalize_and_dropna - AssertionError: ('proportion', 'count')
2023-02-03T20:50:29.9817961Z assert 'proportion' == 'count'
2023-02-03T20:50:29.9818058Z   - count
2023-02-03T20:50:29.9818135Z   + proportion
```

In pandas 2.0, the result Series produced by `value_counts()` has a different name.

See https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#value-counts-sets-the-resulting-name-to-count.

Xref https://github.com/dask/dask/issues/9736.
Xref https://github.com/pandas-dev/pandas/pull/49912.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
