### PR TITLE
Make `repartition` a no-op when divisions match

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -7696,6 +7696,10 @@ def repartition(df, divisions=None, force=False):
     >>> ddf = dd.repartition(df, [0, 5, 10, 20])  # doctest: +SKIP
     """
 
+    # no-op fastpath for when we already have matching divisions
+    if is_dask_collection(df) and df.divisions == divisions:
+        return df
+
     token = tokenize(df, divisions)
     if isinstance(df, _Frame):
         tmp = "repartition-split-" + token

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2344,6 +2344,18 @@ def test_repartition_freq_day():
     )
 
 
+def test_repartition_noop():
+    df = pd.DataFrame({"x": [1, 2, 4, 5], "y": [6, 7, 8, 9]}, index=[-1, 0, 2, 7])
+    ddf = dd.from_pandas(df, npartitions=2)
+    # DataFrame method
+    ddf2 = ddf.repartition(divisions=ddf.divisions)
+    assert ddf2 is ddf
+
+    # Top-level dask.dataframe method
+    ddf3 = dd.repartition(ddf, divisions=ddf.divisions)
+    assert ddf3 is ddf
+
+
 @pytest.mark.parametrize(
     "freq, expected_freq",
     [


### PR DESCRIPTION
No need to actually repartition anything if the input divisions are already equal to the existing divisions