### PR TITLE
Do not ravel array when slicing with same shape

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1142,8 +1142,9 @@ def slice_with_bool_dask_array(x, index):
 
     if len(index) == 1 and index[0].ndim == x.ndim:
         if not np.isnan(x.shape).any() and not np.isnan(index[0].shape).any():
-            x = x.ravel()
-            index = tuple(i.ravel() for i in index)
+            if x.shape != index[0].shape:
+                x = x.ravel()
+                index = tuple(i.ravel() for i in index)
         elif x.ndim > 1:
             warnings.warn(
                 "When slicing a Dask array of unknown chunks with a boolean mask "

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -1051,3 +1051,11 @@ def test_slice_array_null_dimension():
     array = da.from_array(np.zeros((3, 0)))
     expected = np.zeros((3, 0))[[0]]
     assert_eq(array[[0]], expected)
+
+
+def test_slicing_bool_same_shape():
+    x = da.arange(200).reshape((10, 10, 2))
+    gt = x > 100
+    np_arr = x.compute()
+    assert_eq(x[gt], np_arr[np_arr > 100])
+    assert not any("rechunk" in l for l in x[gt].dask.layers)


### PR DESCRIPTION
I'm not very familiar with the array API so I might be missing something obvious. However, I encountered a troubling complex graph when doing an operation like `array[array > 100]`

```python
import dask.array as da
arr = da.random.random((200,200,200), chunks=(20, 20, 20))
arr[arr > 1].dask
```

![image](https://user-images.githubusercontent.com/8629629/217204020-daa896a5-0005-4ee9-861d-23a52cb5b167.png)

This is under the hood raveling the arrays before indexing. Raveling is effectively a rechunking operation which is relatively expensive, specifically for an operation that should be elemwise.

I'm wondering if I'm missing anything here or why there is a reason for this complexity