### PR TITLE
Fix an error with `groupby` `value_counts` for `pandas` 2.0 compatibility

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1543,7 +1543,17 @@ class _GroupBy:
             with check_numeric_only_deprecation():
                 meta = func(self._meta_nonempty, **chunk_kwargs)
 
-        columns = meta.name if is_series_like(meta) else meta.columns
+        if is_series_like(meta):
+            # in pandas 2.0, Series returned from value_counts have a name
+            # different from original object, but here, column name should
+            # still reflect the original object name
+            if func is _value_counts:
+                columns = self._meta.apply(pd.Series).name
+            else:
+                columns = meta.name
+        else:
+            columns = meta.columns
+
         args = [self.obj] + (self.by if isinstance(self.by, list) else [self.by])
 
         token = self._token_prefix + token

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1539,14 +1539,15 @@ class _GroupBy:
         if aggregate_kwargs is None:
             aggregate_kwargs = {}
 
-        if "columns" in chunk_kwargs:
-            columns = chunk_kwargs.pop("columns")
-        else:
-            columns = meta.name if is_series_like(meta) else meta.columns
+        # this is for us, can't pass it on to pandas
+        columns = chunk_kwargs.pop("columns", None)
 
         if meta is None:
             with check_numeric_only_deprecation():
                 meta = func(self._meta_nonempty, **chunk_kwargs)
+
+        if columns is None:
+            columns = meta.name if is_series_like(meta) else meta.columns
 
         args = [self.obj] + (self.by if isinstance(self.by, list) else [self.by])
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1520,6 +1520,7 @@ class _GroupBy:
         shuffle=None,
         chunk_kwargs=None,
         aggregate_kwargs=None,
+        columns=None,
     ):
         """
         Aggregation with a single function/aggfunc rather than a compound spec
@@ -1538,9 +1539,6 @@ class _GroupBy:
 
         if aggregate_kwargs is None:
             aggregate_kwargs = {}
-
-        # this is for us, can't pass it on to pandas
-        columns = chunk_kwargs.pop("columns", None)
 
         if meta is None:
             with check_numeric_only_deprecation():
@@ -2952,10 +2950,6 @@ class SeriesGroupBy(_GroupBy):
 
     @derived_from(pd.core.groupby.SeriesGroupBy)
     def value_counts(self, split_every=None, split_out=1, shuffle=None):
-        # in pandas 2.0, Series returned from value_counts have a name
-        # different from original object, but here, column name should
-        # still reflect the original object name
-        chunk_kwargs = {"columns": self._meta.apply(pd.Series).name}
         return self._single_agg(
             func=_value_counts,
             token="value_counts",
@@ -2963,7 +2957,10 @@ class SeriesGroupBy(_GroupBy):
             split_every=split_every,
             split_out=split_out,
             shuffle=shuffle,
-            chunk_kwargs=chunk_kwargs,
+            # in pandas 2.0, Series returned from value_counts have a name
+            # different from original object, but here, column name should
+            # still reflect the original object name
+            columns=self._meta.apply(pd.Series).name,
         )
 
     @derived_from(pd.core.groupby.SeriesGroupBy)

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1539,14 +1539,14 @@ class _GroupBy:
         if aggregate_kwargs is None:
             aggregate_kwargs = {}
 
+        if "columns" in chunk_kwargs:
+            columns = chunk_kwargs.pop("columns")
+        else:
+            columns = meta.name if is_series_like(meta) else meta.columns
+
         if meta is None:
             with check_numeric_only_deprecation():
                 meta = func(self._meta_nonempty, **chunk_kwargs)
-
-        if "columns" not in chunk_kwargs:
-            chunk_kwargs["columns"] = (
-                meta.name if is_series_like(meta) else meta.columns
-            )
 
         args = [self.obj] + (self.by if isinstance(self.by, list) else [self.by])
 
@@ -1559,6 +1559,7 @@ class _GroupBy:
                 chunk=_apply_chunk,
                 chunk_kwargs={
                     "chunk": func,
+                    "columns": columns,
                     **self.observed,
                     **self.dropna,
                     **chunk_kwargs,
@@ -1583,6 +1584,7 @@ class _GroupBy:
             chunk=_apply_chunk,
             chunk_kwargs=dict(
                 chunk=func,
+                columns=columns,
                 **self.observed,
                 **chunk_kwargs,
                 **self.dropna,


### PR DESCRIPTION
Fix an upstream error with Pandas 2.0:

```
dask/dataframe/tests/test_groupby.py::test_groupby_value_counts[disk-foo]: KeyError: 'Column not found: count'
```

Related to the following change in pandas:

https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#value-counts-sets-the-resulting-name-to-count

- [x] Passes `pre-commit run --all-files`