### PR TITLE
Fix `test_to_timestamp` for `pandas` 2.0

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -63,7 +63,7 @@ d = dd.DataFrame(dsk, "x", meta, [0, 5, 9, 9])
 full = d.compute()
 
 CHECK_FREQ = {}
-if dd._compat.PANDAS_GT_110:
+if PANDAS_GT_110:
     CHECK_FREQ["check_freq"] = False
 
 
@@ -3065,7 +3065,7 @@ def test_to_timestamp():
         df.to_timestamp(freq="M", how="s"),
         **CHECK_FREQ,
     )
-    assert_eq(ddf.x.to_timestamp(), df.x.to_timestamp())
+    assert_eq(ddf.x.to_timestamp(), df.x.to_timestamp(), **CHECK_FREQ)
     assert_eq(
         ddf.x.to_timestamp(freq="M", how="s").compute(),
         df.x.to_timestamp(freq="M", how="s"),


### PR DESCRIPTION
Fixes an upstream failure with pandas 2.0:

```
dask/dataframe/tests/test_dataframe.py::test_to_timestamp: AssertionError: (None, <YearBegin: month=1>)
```

Xref https://github.com/dask/dask/issues/9736.
Opened https://github.com/pandas-dev/pandas/issues/51256.

Oddly, this seems like this test should have failed with 1.5 too, but it didn't. This is because we sort series before comparing them with `dask.dataframe.utils._maybe_sort`. The utility method applies `sort_values` to series, and with pandas == 1.5, `sort_values` was stripping `freq` information from the index. This was probably a bug, and in 2.0 it's fixed, and so now we have a legitimate difference.

I'm not quite sure why the test has a workaround to skip checking `freq`. A proper fix is probably to stop losing `freq` information, if we can.

Update:

The problem is our test data being so small. We chunk it into even smaller separate `Series`. If a `Series` is only 1 or 2 records long, it doesn't infer index frequency. After `Dask` computes and concatenates the chunks, the resulting dataframe won't have `freq` information either. I lean towards accepting this as an edge case. In the real world, chunks would be large enough to preserve the info after concatenation.

I filed https://github.com/pandas-dev/pandas/issues/51256, losing frequency when it existed in initial index still feels like a bug.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
