### PR TITLE
Handle inconsistent nullability during read_parquet file aggregation

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -534,7 +534,7 @@ class ArrowDatasetEngine(Engine):
                 tables.append(arrow_table)
 
         if multi_read:
-            arrow_table = pa.concat_tables(tables)
+            arrow_table = pa.concat_tables(tables, promote=True)
 
         # Convert to pandas
         df = cls._arrow_table_to_pandas(


### PR DESCRIPTION
cudf will typically include a "not null" distinction in the row-group schema for columns that do not contain any null values. `dd.read_parquet` will currently raise an error when aggregating multiple files with inconsistent nullability (even if the types are compatible). This PR adds the necessary change to handle inconsistent nullabilities.

Note that this error was illustrated in https://github.com/rapidsai/cudf/issues/12702

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
