### PR TITLE
Add a CLI command to `list` and `get` a value from dask config

### DIFF
--- a/dask/cli.py
+++ b/dask/cli.py
@@ -40,6 +40,35 @@ def versions():
     show_versions()
 
 
+@cli.group()
+def config():
+    """Dask config settings"""
+    pass
+
+
+@config.command()
+@click.argument("key", default=None, required=False)
+def get(key=None):
+    """Print config key, or the whole config."""
+    from functools import reduce
+
+    from yaml import dump
+
+    from dask.config import config
+
+    if key is None:
+        click.echo_via_pager(dump(config))
+    else:
+        try:
+            data = reduce(lambda d, k: d[k], key.split("."), config)
+            if isinstance(data, (list, dict)):
+                click.echo_via_pager(dump(data))
+            else:
+                click.echo(data)
+        except KeyError:
+            click.echo(click.style(f"Section not found: {key}", fg="red"), err=True)
+
+
 def _register_command_ep(interface, entry_point):
     """Add `entry_point` command to `interface`.
 

--- a/dask/cli.py
+++ b/dask/cli.py
@@ -67,6 +67,7 @@ def get(key=None):
                 click.echo(data)
         except KeyError:
             click.echo(click.style(f"Section not found: {key}", fg="red"), err=True)
+            exit(1)
 
 
 def _register_command_ep(interface, entry_point):

--- a/dask/tests/test_cli.py
+++ b/dask/tests/test_cli.py
@@ -13,23 +13,30 @@ import dask.cli
 
 def test_config_get():
     runner = CliRunner()
-    result = runner.invoke(dask.cli.get)
-    assert result.exit_code == 0
-    assert result.output.startswith("array:")
+    result = runner.invoke(dask.cli.config_get)
+    assert result.exit_code == 1
+    assert result.output.startswith("Config key not specified")
 
 
 def test_config_get_value():
     runner = CliRunner()
-    result = runner.invoke(dask.cli.get, ["array"])
+    result = runner.invoke(dask.cli.config_get, ["array"])
     assert result.exit_code == 0
     assert result.output.startswith("backend:")
 
 
 def test_config_get_bad_value():
     runner = CliRunner()
-    result = runner.invoke(dask.cli.get, ["bad_key"])
+    result = runner.invoke(dask.cli.config_get, ["bad_key"])
     assert result.exit_code != 0
     assert result.output.startswith("Section not found")
+
+
+def test_config_list():
+    runner = CliRunner()
+    result = runner.invoke(dask.cli.config_list)
+    assert result.exit_code == 0
+    assert result.output.startswith("array:")
 
 
 def test_version():

--- a/dask/tests/test_cli.py
+++ b/dask/tests/test_cli.py
@@ -11,6 +11,27 @@ import dask
 import dask.cli
 
 
+def test_config_get():
+    runner = CliRunner()
+    result = runner.invoke(dask.cli.get)
+    assert result.exit_code == 0
+    assert result.output.startswith("array:")
+
+
+def test_config_get_value():
+    runner = CliRunner()
+    result = runner.invoke(dask.cli.get, ["array"])
+    assert result.exit_code == 0
+    assert result.output.startswith("backend:")
+
+
+def test_config_get_bad_value():
+    runner = CliRunner()
+    result = runner.invoke(dask.cli.get, ["bad_key"])
+    assert result.exit_code != 0
+    assert result.output.startswith("Section not found")
+
+
 def test_version():
     runner = CliRunner()
     result = runner.invoke(dask.cli.cli, ["--version"])


### PR DESCRIPTION
Adds two cli commands, `git config get` to get a value from dask config:

```yaml
> dask config get distributed.scheduler.dashboard
bokeh-application:
  allow_websocket_origin:
  - '*'
  check_unused_sessions_milliseconds: 500
  keep_alive_milliseconds: 500
status:
  task-stream-length: 1000
tasks:
  task-stream-length: 100000
tls:
  ca-file: null
  cert: null
  key: null
```

or `git config list` to print the whole config:

```yaml
> dask config list
array:
  backend: numpy
  slicing:
    split-large-chunks: null
  svg:
    size: 120
coiled:
...
```

Partially implements #9746.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
