### PR TITLE
Fix `test_numeric_column_names` for `pandas` 2.0

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6951,6 +6951,7 @@ def _rename(columns, df):
         if (
             len(columns) == len(df.columns)
             and type(columns) is type(df.columns)
+            and columns.dtype == df.columns.dtype
             and columns.equals(df.columns)
         ):
             # if target is identical, rename is not necessary


### PR DESCRIPTION
Fixes the following upstream failure with pandas 2.0:

```
FAILED dask/dataframe/tests/test_groupby.py::test_numeric_column_names[disk] - AssertionError: Index are different
FAILED dask/dataframe/tests/test_groupby.py::test_numeric_column_names[tasks] - AssertionError: Index are different
```

It appears that `apply` on `groupby` would lose `dtype` of `columns`. Oddly, this didn't happen with 1.5, might be because default index `dtype` has changed.

Xref https://github.com/dask/dask/issues/9736.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
