### PR TITLE
Config converter: replace all dashes with underscores

### DIFF
--- a/docs/source/_static/config_converter.js
+++ b/docs/source/_static/config_converter.js
@@ -252,7 +252,7 @@ function walkCode(config, prefix = "") {
  * // returns "hello-world"
  */
 function toKey(str) {
-    return str.toLowerCase().replace("_", "-")
+    return str.toLowerCase().replaceAll("_", "-")
 }
 
 /**
@@ -266,7 +266,7 @@ function toKey(str) {
  * // returns "HELLO_WORLD"
  */
 function fromKey(key) {
-    return key.toUpperCase().replace("-", "_")
+    return key.toUpperCase().replaceAll("-", "_")
 }
 
 /**
@@ -310,6 +310,7 @@ function mergeDeep(...objects) {
  */
 function runTests() {
     console.assert(dumpEnv(parseYAML("distributed:\n  logging:\n    distributed: info\n")) == 'export DASK_DISTRIBUTED__LOGGING__DISTRIBUTED="info"')
+    console.assert(dumpEnv(parseYAML("distributed:\n    deploy:\n      lost-worker-timeout: 15s")) == 'export DASK_DISTRIBUTED__DEPLOY__LOST_WORKER_TIMEOUT="15s"')
     console.assert(dumpCode(parseYAML("distributed:\n  logging:\n    distributed: info\n")) == '>>> dask.config.set({"distributed.logging.distributed": "info"})')
     console.assert(dumpYAML(parseEnv('export DASK_DISTRIBUTED__LOGGING__DISTRIBUTED="info"')) == "distributed:\n  logging:\n    distributed: info\n")
     console.assert(dumpCode(parseEnv('export DASK_DISTRIBUTED__LOGGING__DISTRIBUTED="info"')) == '>>> dask.config.set({"distributed.logging.distributed": "info"})')


### PR DESCRIPTION
Closes #9929

`replace` => `replaceAll` and added a test based on the example from @jbusecke gave in #9929.

_Note that these tests are not run by CI and need to be run manually in the browser developer console. I can confirm I've ran them and they are passing._

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
