### PR TITLE
Handle string-based engine argument to `read_json`

### DIFF
--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -1,5 +1,6 @@
 import io
 import os
+from functools import partial
 from itertools import zip_longest
 
 import pandas as pd
@@ -157,9 +158,11 @@ def read_json(
         Text conversion, ``see bytes.decode()``
     compression : string or None
         String like 'gzip' or 'xz'.
-    engine : function object, default ``pd.read_json``
+    engine : callable or str, default ``pd.read_json``
         The underlying function that dask will use to read JSON files. By
         default, this will be the pandas JSON reader (``pd.read_json``).
+        If a string is specified, this value will be passed under the ``engine``
+        key-word argument to ``pd.read_json`` (only supported for Pandas-2.0).
     include_path_column : bool or str, optional
         Include a column with the file path where each row in the dataframe
         originated. If ``True``, a new column is added to the dataframe called
@@ -208,6 +211,9 @@ def read_json(
 
     if path_converter is None:
         path_converter = lambda x: x
+
+    # Handle engine string (Pandas>=2.0)
+    engine = engine if callable(engine) else partial(pd.read_json, engine=engine)
 
     if blocksize:
         b_out = read_bytes(

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -3,10 +3,10 @@ import os
 
 import pandas as pd
 import pytest
-from packaging.version import parse as parse_version
 
 import dask
 import dask.dataframe as dd
+from dask.dataframe._compat import PANDAS_GT_200
 from dask.dataframe.utils import assert_eq
 from dask.utils import tmpdir, tmpfile
 
@@ -127,7 +127,7 @@ def test_read_json_fkeyword(fkeyword):
         pytest.param(
             "ujson",
             marks=pytest.mark.skipif(
-                parse_version(pd.__version__) < parse_version("2.0"),
+                not PANDAS_GT_200,
                 reason="Pandas>=2.0 required for str engine argument",
             ),
         ),

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -121,24 +121,16 @@ def test_read_json_fkeyword(fkeyword):
         assert_eq(actual, actual_pd)
 
 
-@pytest.mark.parametrize(
-    "engine",
-    [
-        pytest.param(
-            "ujson",
-            marks=pytest.mark.skipif(
-                not PANDAS_GT_200,
-                reason="Pandas>=2.0 required for str engine argument",
-            ),
-        ),
-        pd.read_json,
-    ],
-)
+@pytest.mark.parametrize("engine", ["ujson", pd.read_json])
 def test_read_json_engine_str(engine):
     with tmpfile("json") as f:
         df.to_json(f, lines=False)
-        got = dd.read_json(f, engine=engine, lines=False)
-        assert_eq(got, df)
+        if isinstance(engine, str) and not PANDAS_GT_200:
+            with pytest.raises(ValueError, match="Pandas>=2.0 is required"):
+                dd.read_json(f, engine=engine, lines=False)
+        else:
+            got = dd.read_json(f, engine=engine, lines=False)
+            assert_eq(got, df)
 
 
 @pytest.mark.parametrize("orient", ["split", "records", "index", "columns", "values"])


### PR DESCRIPTION
~**TODO**: Still haven't tested this locally with a pandas nightly~

- [x] Closes https://github.com/dask/dask/issues/9943
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
