### PR TITLE
Fix `test_rolling_agg_aggregate` for `pandas` 2.0 compatibility

### DIFF
--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -496,7 +496,9 @@ class Rolling:
     @staticmethod
     def pandas_rolling_method(df, rolling_kwargs, name, *args, **kwargs):
         rolling = df.rolling(**rolling_kwargs)
-        return getattr(rolling, name)(*args, **kwargs)
+        pd_args = kwargs.get("args", None) or ()
+        pd_kwargs = kwargs.get("kwargs", None) or {}
+        return getattr(rolling, name)(*args, *pd_args, **pd_kwargs)
 
     def _call_method(self, method_name, *args, **kwargs):
         rolling_kwargs = self._rolling_kwargs()

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -496,9 +496,7 @@ class Rolling:
     @staticmethod
     def pandas_rolling_method(df, rolling_kwargs, name, *args, **kwargs):
         rolling = df.rolling(**rolling_kwargs)
-        pd_args = kwargs.get("args", None) or ()
-        pd_kwargs = kwargs.get("kwargs", None) or {}
-        return getattr(rolling, name)(*args, *pd_args, **pd_kwargs)
+        return getattr(rolling, name)(*args, **kwargs)
 
     def _call_method(self, method_name, *args, **kwargs):
         rolling_kwargs = self._rolling_kwargs()
@@ -614,10 +612,8 @@ class Rolling:
         )
 
     @derived_from(pd_Rolling)
-    def aggregate(self, func, args=(), kwargs=None, **kwds):
-        if kwargs is None:
-            kwargs = {}
-        return self._call_method("agg", func, args=args, kwargs=kwargs, **kwds)
+    def aggregate(self, func, *args, **kwargs):
+        return self._call_method("agg", func, *args, **kwargs)
 
     agg = aggregate
 


### PR DESCRIPTION
Fixes an error in upstream:

```
dask/dataframe/tests/test_rolling.py::test_rolling_agg_aggregate: TypeError: _mean_dispatcher() got an unexpected keyword argument 'args'
```

Pandas 2.0 fixes a bug where args passed to applied aggs were ignored. We need the same fix.

Xref https://github.com/pandas-dev/pandas/pull/50863.
Xref https://github.com/dask/dask/issues/9736.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
