### PR TITLE
Add `ucx-proc=*=cpu` to CI environments to block `cudatoolkit` install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,10 @@ jobs:
         uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0  # Needed by codecov.io
+      - name: Prevent cudatoolkit install on ubuntu
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sed -i 's/# - ucx-proc=\*=cpu/- ucx-proc=\*=cpu/g' continuous_integration/environment-${{ matrix.python-version }}.yaml
       - name: Setup Java
         uses: actions/setup-java@v3
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -68,6 +68,8 @@ dependencies:
   - python-xxhash
   - mmh3
   - jinja2
+  # prevent pyarrow from pulling in cudatoolkit
+  - ucx-proc=*=cpu
   - pip
   - pip:
     - git+https://github.com/dask/distributed

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -69,7 +69,7 @@ dependencies:
   - mmh3
   - jinja2
   # prevent pyarrow from pulling in cudatoolkit
-  - ucx-proc=*=cpu
+  # - ucx-proc=*=cpu
   - pip
   - pip:
     - git+https://github.com/dask/distributed

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -70,6 +70,8 @@ dependencies:
   - python-xxhash
   - mmh3
   - jinja2
+  # prevent pyarrow from pulling in cudatoolkit
+  - ucx-proc=*=cpu
   - pip
   - pip:
     - git+https://github.com/dask/distributed

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -71,7 +71,7 @@ dependencies:
   - mmh3
   - jinja2
   # prevent pyarrow from pulling in cudatoolkit
-  - ucx-proc=*=cpu
+  # - ucx-proc=*=cpu
   - pip
   - pip:
     - git+https://github.com/dask/distributed

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -68,6 +68,8 @@ dependencies:
   - python-xxhash
   - mmh3
   - jinja2
+  # prevent pyarrow from pulling in cudatoolkit
+  - ucx-proc=*=cpu
   - pip
   - pip:
     - git+https://github.com/dask/distributed

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -68,8 +68,8 @@ dependencies:
   - python-xxhash
   - mmh3
   - jinja2
-  # prevent pyarrow from pulling in cudatoolkit
-  - ucx-proc=*=cpu
+  # prevent pyarrow from pulling in cudatoolkit on linux
+  # - ucx-proc=*=cpu
   - pip
   - pip:
     - git+https://github.com/dask/distributed


### PR DESCRIPTION
Looks like newer versions of `pyarrow` pull in `ucx` and subsequently `cudatoolkit` unless we specify the CPU version of `ucx-proc`; given that the `cudatoolkit` package is quite large (~667MB), I'm interested in if we can get away with adding this constraint to prevent installing it in CPU testing.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
