### PR TITLE
POC - Add basic shim layer class for expressions

### DIFF
--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -5,7 +5,7 @@ from pandas.core.resample import Resampler as pd_Resampler
 from dask.base import tokenize
 from dask.dataframe import methods
 from dask.dataframe._compat import PANDAS_GT_140
-from dask.dataframe.core import DataFrame, Series
+from dask.dataframe.core import DataFrame, new_dd_object
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import derived_from
 
@@ -194,7 +194,7 @@ class Resampler:
         graph = HighLevelGraph.from_collections(name, dsk, dependencies=[partitioned])
         if isinstance(meta, pd.DataFrame):
             return DataFrame(graph, name, meta, outdivs)
-        return Series(graph, name, meta, outdivs)
+        return new_dd_object(graph, name, meta, outdivs)
 
     @derived_from(pd_Resampler)
     def agg(self, agg_funcs, *args, **kwargs):

--- a/dask/expressions.py
+++ b/dask/expressions.py
@@ -1,0 +1,10 @@
+class Expression:
+    pass
+
+
+class Opaque(Expression):
+    def __init__(self, graph, name, meta, divisions):
+        self.dask = graph
+        self._name = name
+        self._meta = meta
+        self.divisions = divisions


### PR DESCRIPTION
This is for demonstration purposes only.

This experiment introduces a non-functional expression layer in between the DataFrame/Series classes and meta/divisions/name/graph generation. This expression layer doesn't do anything, in only holds a single opaque type, but it demonstrates the ease/pain with which we could introduce a new abstraction and slowly phase out immediate metadata construction.

Most of the pain here was about being careful with attribute assignment / properties / getters and setters.  I didn't bother with all of this so about half of the test suite fails.  This is enough though, I think, to show a path.

This is part of an ongoing conversation with @jrbourbeau @fjetter @rjzamora 