### PR TITLE
Un-`xfail` `test_set_index_overlap_2` for `pandas` 2.0

### DIFF
--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -20,7 +20,6 @@ from dask.base import compute_as_if_collection
 from dask.dataframe._compat import (
     PANDAS_GT_120,
     PANDAS_GT_140,
-    PANDAS_GT_200,
     assert_categorical_equal,
     tm,
 )
@@ -1207,23 +1206,18 @@ def test_set_index_overlap():
     assert_eq(a, b)
 
 
-@pytest.mark.xfail(
-    PANDAS_GT_200, reason="In pandas 2.0, empty dataframe has columns=RangeIndex"
-)
-# When Dask creates an empty DataFrame, columns=Index(dtype="object").
-# In 2.0, Pandas creates a RangeIndex instead.
-# https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#empty-dataframes-series-will-now-default-to-have-a-rangeindex
 def test_set_index_overlap_2():
-    data = pd.DataFrame(
+    df = pd.DataFrame(
         index=pd.Index(
             ["A", "A", "A", "A", "A", "A", "A", "A", "A", "B", "B", "B", "C"],
             name="index",
         )
     )
-    ddf1 = dd.from_pandas(data, npartitions=2)
-    ddf2 = ddf1.reset_index().repartition(8).set_index("index", sorted=True)
-    assert_eq(ddf1, ddf2)
-    assert ddf2.npartitions == 8
+    ddf = dd.from_pandas(df, npartitions=2)
+    result = ddf.reset_index().repartition(8).set_index("index", sorted=True)
+    expected = df.reset_index().set_index("index")
+    assert_eq(result, expected)
+    assert result.npartitions == 8
 
 
 def test_set_index_overlap_does_not_drop_rows_when_divisions_overlap():


### PR DESCRIPTION
In https://github.com/dask/dask/pull/9930 we `xfail`ed `test_set_index_overlap_2` when `pandas=2.0` is being used due to a change in the default index/columns when creating an empty `Series`/`DataFrame` (see https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#empty-dataframes-series-will-now-default-to-have-a-rangeindex). However, I think the right thing to do is to slightly modify the test to compare equivalent `pandas` and `dask` operations. This should generalize the test to work with `pandas` 2.0 while still retaining the original intent of the test (xref https://github.com/dask/dask/pull/6980). 

cc @rjzamora as you added this test originally -- though I appreciate it's been a while : ) 
cc @j-bennet 