### PR TITLE
Allow passing index_col=False in dd.read_csv

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -484,10 +484,8 @@ def read_pandas(
         lineterminator = "\n"
     if include_path_column and isinstance(include_path_column, bool):
         include_path_column = "path"
-    if (
-            "index" in kwargs or
-            ("index_col" in kwargs and
-             kwargs.get("index_col") is not False)
+    if "index" in kwargs or (
+        "index_col" in kwargs and kwargs.get("index_col") is not False
     ):
         raise ValueError(
             "Keywords 'index' and 'index_col' not supported (except for "

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -484,10 +484,15 @@ def read_pandas(
         lineterminator = "\n"
     if include_path_column and isinstance(include_path_column, bool):
         include_path_column = "path"
-    if "index" in kwargs or "index_col" in kwargs:
+    if (
+            "index" in kwargs or
+            ("index_col" in kwargs and
+             kwargs.get("index_col") is not False)
+    ):
         raise ValueError(
-            "Keywords 'index' and 'index_col' not supported. "
-            f"Use dd.{reader_name}(...).set_index('my-index') instead"
+            "Keywords 'index' and 'index_col' not supported (except for "
+            "'index_col=False' to force pandas to not use the first column as "
+            f"the index). Use dd.{reader_name}(...).set_index('my-index') instead"
         )
     for kw in ["iterator", "chunksize"]:
         if kw in kwargs:

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -488,9 +488,8 @@ def read_pandas(
         "index_col" in kwargs and kwargs.get("index_col") is not False
     ):
         raise ValueError(
-            "Keywords 'index' and 'index_col' not supported (except for "
-            "'index_col=False' to force pandas to not use the first column as "
-            f"the index). Use dd.{reader_name}(...).set_index('my-index') instead"
+            "Keywords 'index' and 'index_col' not supported, except for "
+            "'index_col=False'. Use dd.{reader_name}(...).set_index('my-index') instead"
         )
     for kw in ["iterator", "chunksize"]:
         if kw in kwargs:

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1081,6 +1081,10 @@ def test_index_col():
         except ValueError as e:
             assert "set_index" in str(e)
 
+        df = pd.read_csv(fn, index_col=False)
+        ddf = dd.read_csv(fn, blocksize=30, index_col=False)
+        assert_eq(df, ddf, check_index=False)
+
 
 def test_read_csv_with_datetime_index_partitions_one():
     with filetext(timeseries) as fn:


### PR DESCRIPTION
For some malformed CSVs, it's necessary to pass `index_col=False` to `pd.read_csv` to get them to load successfully. Otherwise, pandas fails to handle index assignment properly. A silent failure occurs where the load appears to happen nominally, but some columns in the raw file will be shifted incorrectly with respect to their headers in the final dataframe ([example](https://stackoverflow.com/questions/32884044/in-python-pandas-is-loading-csv-file-incorrectly-python-for-data-analysis-book.)).

Dask completely blocks passing `index` and `index_col` down to pandas. That's a problem if you want to load one of these malformed CSVs. Proposed solution is to continue blocking `index` and `index_col`, unless `index_col=False`.

[pandas docs](https://github.com/pandas-dev/pandas/blob/main/pandas/io/parsers/readers.py#L125-L132) on this:
```
index_col : int, str, sequence of int / str, or False, optional, default ``None``
  Column(s) to use as the row labels of the ``DataFrame``, either given as
  string name or column index. If a sequence of int / str is given, a
  MultiIndex is used.
  Note: ``index_col=False`` can be used to force pandas to *not* use the first
  column as the index, e.g. when you have a malformed file with delimiters at
  the end of each line.
```