### PR TITLE
Fix `test_groupby_unaligned_index` for `pandas` 2.0

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1789,13 +1789,11 @@ def test_groupby_unaligned_index():
         return x + 1
 
     df_group = filtered.groupby(df.a)
-    good = [
-        (ddf_group.apply(add1, meta=ddf), df_group.apply(add1)),
-        (ddf_group.b.apply(add1, meta=ddf.b), df_group.b.apply(add1)),
-    ]
+    expected = df_group.apply(add1)
+    assert_eq(ddf_group.apply(add1, meta=expected), expected)
 
-    for res, sol in good:
-        assert_eq(res, sol)
+    expected = df_group.b.apply(add1)
+    assert_eq(ddf_group.b.apply(add1, meta=expected), expected)
 
 
 def test_groupby_string_label():


### PR DESCRIPTION
Fixes an upstream failure with Pandas 2.0:

```
dask/dataframe/tests/test_groupby.py::test_groupby_unaligned_index[disk]: AssertionError: assert FrozenList(['a', None]) == FrozenList([None])
  At index 0 diff: 'a' != None
  Left contains one more item: None
  Full diff:
  - FrozenList([None])
  + FrozenList(['a', None])
  ?             +++++
dask/dataframe/tests/test_groupby.py::test_groupby_unaligned_index[tasks]: AssertionError: assert FrozenList(['a', None]) == FrozenList([None])
  At index 0 diff: 'a' != None
  Left contains one more item: None
  Full diff:
  - FrozenList([None])
  + FrozenList(['a', None])
  ?             +++++
```

* Xref https://github.com/dask/dask/pull/9855.
* Xref https://github.com/dask/dask/issues/9736.
* Xref https://github.com/pandas-dev/pandas/pull/34998.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
