### PR TITLE
Fix `test_groupby_dropna_with_agg` for `pandas` 2.0 compatibility

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2325,7 +2325,7 @@ class _GroupBy:
                     chunk=_groupby_apply_funcs,
                     chunk_kwargs={
                         "funcs": chunk_funcs,
-                        "sort": sort,
+                        "sort": self.sort,
                         **self.observed,
                         **self.dropna,
                     },

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2273,6 +2273,12 @@ class _GroupBy:
                 "aggregation (e.g., shuffle='tasks')"
             )
 
+        sort = self.sort
+        if sort is None:
+            # in pandas, default sort is True. If we can, use the same default
+            if split_out == 1 or (split_out > 1 and shuffle):
+                sort = True
+
         if shuffle:
             # Shuffle-based aggregation
             #
@@ -2311,7 +2317,7 @@ class _GroupBy:
                     split_every=split_every,
                     split_out=split_out,
                     shuffle=shuffle,
-                    sort=self.sort,
+                    sort=sort,
                 )
             else:
                 result = _shuffle_aggregate(
@@ -2319,7 +2325,7 @@ class _GroupBy:
                     chunk=_groupby_apply_funcs,
                     chunk_kwargs={
                         "funcs": chunk_funcs,
-                        "sort": self.sort,
+                        "sort": sort,
                         **self.observed,
                         **self.dropna,
                     },
@@ -2335,14 +2341,14 @@ class _GroupBy:
                     split_every=split_every,
                     split_out=split_out,
                     shuffle=shuffle,
-                    sort=self.sort,
+                    sort=sort,
                 )
         else:
-            if self.sort is None and split_out > 1:
+            if sort is None and split_out > 1:
                 warnings.warn(SORT_SPLIT_OUT_WARNING, FutureWarning)
 
             # Check sort behavior
-            if self.sort and split_out > 1:
+            if sort and split_out > 1:
                 raise NotImplementedError(
                     "Cannot guarantee sorted keys for `split_out>1` and `shuffle=False`"
                     " Try using `shuffle=True` if you are grouping on a single column."
@@ -2378,7 +2384,7 @@ class _GroupBy:
                 split_every=split_every,
                 split_out=split_out,
                 split_out_setup=split_out_on_index,
-                sort=self.sort,
+                sort=sort,
             )
 
         if relabeling and result is not None:

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2868,6 +2868,9 @@ def test_groupby_dropna_with_agg():
     actual = ddf.groupby(["id1", "id2"], dropna=False).agg("sum")
     assert_eq(expected, actual)
 
+    actual2 = ddf.groupby(["id1", "id2"], dropna=False).sum()
+    assert_eq(expected, actual2)
+
 
 def test_groupby_observed_with_agg():
     df = pd.DataFrame(


### PR DESCRIPTION
Fixes an upstream failure with pandas 2.0:

```
dask/dataframe/tests/test_groupby.py::test_groupby_dropna_with_agg[disk]: AssertionError: MultiIndex level [0] are different

MultiIndex level [0] values are different (66.66667 %)
[left]:  Index(['a', 'b', nan], dtype='object', name='id1')
[right]: Index(['a', nan, 'b'], dtype='object', name='id1')
At positional index 1, first diff: b != nan
dask/dataframe/tests/test_groupby.py::test_groupby_dropna_with_agg[tasks]: AssertionError: MultiIndex level [0] are different

MultiIndex level [0] values are different (66.66667 %)
[left]:  Index(['a', 'b', nan], dtype='object', name='id1')
[right]: Index(['a', nan, 'b'], dtype='object', name='id1')
At positional index 1, first diff: b != nan
```

In [pandas `DataFrameGroupBy`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html), default `sort` is `True`, but Dask has `None` as default. This is because we can't use `True` with `split_out>1` and non-shuffle-based approach.

This fix sets the default `sort` to be `True` when we can. The difference didn't seem to matter with 1.5, even though in 1.5 default is `True` as well. With 2.0 though, we get a different `MultiIndex` unless we provide the same `sort`.

* Xref https://github.com/pandas-dev/pandas/pull/51346.
* Xref https://github.com/dask/dask/issues/9736.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`