### PR TITLE
Generalize some NumPy vs CuPy logic

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1700,7 +1700,7 @@ class Array(DaskMethodsMixin):
         if dtype and x.dtype != dtype:
             x = x.astype(dtype)
         if not isinstance(x, np.ndarray):
-            x = np.array(x)
+            x = np.array(x.get())
         return x
 
     def __array_function__(self, func, types, args, kwargs):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1700,7 +1700,10 @@ class Array(DaskMethodsMixin):
         if dtype and x.dtype != dtype:
             x = x.astype(dtype)
         if not isinstance(x, np.ndarray):
-            x = np.array(x.get())
+            try:
+                x = np.array(x)
+            except TypeError:
+                x = np.array(x.get())
         return x
 
     def __array_function__(self, func, types, args, kwargs):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -500,7 +500,10 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
 
     def __array__(self, dtype=None, **kwargs):
         self._computed = self.compute()
-        x = np.array(self._computed)
+        try:
+            x = np.array(self._computed)
+        except TypeError:
+            x = np.array(self._computed.to_cupy().get())
         return x
 
     def __array_wrap__(self, array, context=None):


### PR DESCRIPTION
These changes fix some of our GPU ML bugs on the Dask-SQL side: https://github.com/dask-contrib/dask-sql/issues/943 and https://github.com/dask-contrib/dask-sql/issues/1020

I tried using the `get_serial_module` introduced by @charlesbluca in https://github.com/dask/dask/pull/9881, but was having trouble getting it to work properly in these functions and I don't think the same logic can really be applied in this case.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
