### PR TITLE
Fix default fused key renamer

### DIFF
--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -414,9 +414,8 @@ def default_fused_keys_renamer(keys, max_fused_key_length=120):
         if max_fused_key_length:
             key_name_keep = max_fused_key_length - len(first_key_name) - 1
             if key_name_keep <= 0:
-                # even first_key_name is too long; only keep a prefix of this key and
-                # a hash taken over the full key name. Using a hash
-                # over the full key name avoids making assumptions about the key name structure.
+                # even first_key_name is too long; only keep a prefix of first_key_name
+                # and its hash.
                 token = tokenize(first_key_name)
                 first_key_name_keep = max_fused_key_length - len(token) - 1
                 if first_key_name_keep <= 0:

--- a/dask/tests/test_optimization.py
+++ b/dask/tests/test_optimization.py
@@ -1474,3 +1474,15 @@ def test_default_fused_keys_renamer():
     assert renamed_long_last_key[1:] == (15,)
     assert len(renamed_long_last_key[0]) == 120
     assert renamed_long_last_key[0].startswith("c" * 80)
+
+
+def test_default_fused_key_renamer_has_low_hash_collision_probability():
+    # See also https://github.com/dask/dask/issues/9964
+    fused_key_names = set()
+    for i in range(1_000):
+        keys_to_fuse = ["a" * 120 + str(i), "b" * 120 + str(i)]
+        fused_key_name = default_fused_keys_renamer(keys_to_fuse)
+        assert (
+            fused_key_name not in fused_key_names
+        ), f"Found hash collision for key {fused_key_name}"
+        fused_key_names.add(fused_key_name)


### PR DESCRIPTION
To avoid hash collisions, keep the full 'first_key' is possible. If even 'first_key' is too long, keep a full hash of that key.

For keys shorter than `max_fused_key_length`, the renamed key does not change.

- [x] Closes #9964
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`


Update: Note that this PR assumes that the current key name choice of `fuse` with `rename_keys=False` is valid. If this is a problem it needs to be addressed separately from this PR.