### PR TITLE
Temporarily `xfail` `test_roundtrip_partitioned_pyarrow_dataset`

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4279,6 +4279,7 @@ def test_custom_filename_with_partition(tmpdir, engine):
 
 
 @PYARROW_MARK
+@pytest.mark.xfail(PANDAS_GT_200, reason="https://github.com/dask/dask/issues/9966")
 @pytest.mark.skipif(
     pa_version < parse_version("5.0"),
     reason="pyarrow write_dataset was added in version 5.0",


### PR DESCRIPTION
xref https://github.com/dask/dask/issues/9966

cc @j-bennet @rjzamora 