### PR TITLE
Restore `describe` compatibility for `pandas` 2.0

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3028,20 +3028,24 @@ Dask Name: {name}, {layers}"""
         if PANDAS_GT_200:
             if datetime_is_numeric is no_default:
                 datetime_is_numeric = True
+                datetime_is_numeric_kwarg = {}
             else:
                 raise TypeError(
                     "datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be "
                     "summarized as numeric"
                 )
         else:
-            datetime_is_numeric = False if datetime_is_numeric is no_default else True
+            datetime_is_numeric = (
+                False if datetime_is_numeric is no_default else datetime_is_numeric
+            )
+            datetime_is_numeric_kwarg = {"datetime_is_numeric": datetime_is_numeric}
 
         if self._meta.ndim == 1:
             meta = self._meta_nonempty.describe(
                 percentiles=percentiles,
                 include=include,
                 exclude=exclude,
-                datetime_is_numeric=datetime_is_numeric,
+                **datetime_is_numeric_kwarg,
             )
             output = self._describe_1d(
                 self, split_every, percentiles, percentiles_method, datetime_is_numeric
@@ -3096,7 +3100,7 @@ Dask Name: {name}, {layers}"""
         layer = {(name, 0): (methods.describe_aggregate, stats_names)}
         graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
         meta = self._meta_nonempty.describe(
-            include=include, exclude=exclude, datetime_is_numeric=datetime_is_numeric
+            include=include, exclude=exclude, **datetime_is_numeric_kwarg
         )
         return new_dd_object(graph, name, meta, divisions=[None, None])
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -489,13 +489,13 @@ def test_describe(include, exclude, percentiles, subset):
         include=include,
         exclude=exclude,
         percentiles=percentiles,
-        datetime_is_numeric=True,
+        **datetime_is_numeric_kwarg,
     )
     expected = df.describe(
         include=include,
         exclude=exclude,
         percentiles=percentiles,
-        datetime_is_numeric=True,
+        **datetime_is_numeric_kwarg,
     )
 
     if "e" in expected and (datetime_is_numeric_kwarg or PANDAS_GT_200):
@@ -507,12 +507,12 @@ def test_describe(include, exclude, percentiles, subset):
     if subset is None:
         for col in ["a", "c", "e", "g"]:
             expected = df[col].describe(
-                include=include, exclude=exclude, datetime_is_numeric=True
+                include=include, exclude=exclude, **datetime_is_numeric_kwarg
             )
             if col == "e" and (datetime_is_numeric_kwarg or PANDAS_GT_200):
                 expected = _drop_mean(expected)
             actual = ddf[col].describe(
-                include=include, exclude=exclude, datetime_is_numeric=True
+                include=include, exclude=exclude, **datetime_is_numeric_kwarg
             )
             assert_eq(expected, actual)
 


### PR DESCRIPTION
Unfortunately https://github.com/dask/dask/pull/9950 undid some of the `describe`-related `pandas` 2.0 compatibility changes we added in https://github.com/dask/dask/pull/9868, so we're seeing [test failures in our `upstream` CI build again](https://github.com/dask/dask/actions/runs/4226631424/jobs/7340276147)

```
FAILED dask/dataframe/tests/test_dataframe.py::test_describe_numeric[dask-test_values1] - TypeError: NDFrame.describe() got an unexpected keyword argument 'datetime_is_numeric'
FAILED dask/dataframe/tests/test_dataframe.py::test_describe[None-None-None-subset0] - TypeError: datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be summarized as numeric
FAILED dask/dataframe/tests/test_dataframe.py::test_describe[None-None-None-subset1] - TypeError: datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be summarized as numeric
FAILED dask/dataframe/tests/test_dataframe.py::test_describe[None-None-None-subset2] - TypeError: datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be summarized as numeric
FAILED dask/dataframe/tests/test_dataframe.py::test_describe[None-None-None-subset3] - TypeError: datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be summarized as numeric
FAILED dask/dataframe/tests/test_dataframe.py::test_describe[None-None-None-subset4] - TypeError: datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be summarized as numeric
FAILED dask/dataframe/tests/test_dataframe.py::test_describe[all-None-None-None] - TypeError: datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be summarized as numeric
FAILED dask/dataframe/tests/test_dataframe.py::test_describe[include6-None-percentiles6-None] - TypeError: datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be summarized as numeric
FAILED dask/dataframe/tests/test_dataframe.py::test_describe[include7-None-None-None] - TypeError: datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be summarized as numeric
FAILED dask/dataframe/tests/test_dataframe.py::test_describe[include8-None-percentiles8-None] - TypeError: datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be summarized as numeric
FAILED dask/dataframe/tests/test_dataframe.py::test_describe[None-exclude9-None-None] - TypeError: datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be summarized as numeric
FAILED dask/dataframe/tests/test_dataframe.py::test_describe[include10-None-None-None] - TypeError: datetime_is_numeric is removed in pandas>=2.0.0, datetime data will always be summarized as numeric
FAILED dask/dataframe/tests/test_dataframe.py::test_describe_without_datetime_is_numeric - TypeError: NDFrame.describe() got an unexpected keyword argument 'datetime_is_numeric'
FAILED dask/dataframe/tests/test_dataframe.py::test_describe_empty - TypeError: NDFrame.describe() got an unexpected keyword argument 'datetime_is_numeric'
FAILED dask/dataframe/tests/test_dataframe.py::test_describe_for_possibly_unsorted_q - TypeError: NDFrame.describe() got an unexpected keyword argument 'datetime_is_numeric'
```

This PR adds those compatibility changes back. 

cc @j-bennet 