### PR TITLE
Switch default bitgenerator from PCG64 to PCG64DXSM

### DIFF
--- a/dask/array/backends.py
+++ b/dask/array/backends.py
@@ -398,7 +398,7 @@ class NumpyBackendEntrypoint(ArrayBackendEntrypoint):
 
     @property
     def default_bit_generator(self):
-        return np.random.PCG64
+        return np.random.PCG64DXSM
 
 
 array_creation_dispatch = CreationDispatch(

--- a/dask/array/tests/test_cupy_random.py
+++ b/dask/array/tests/test_cupy_random.py
@@ -131,7 +131,7 @@ def test_cupy_unsupported():
     with config.set({"array.backend": "cupy"}):
         # permutation supported for np-backed BitGenerator
         x = da.arange(12, chunks=3)
-        da.random.default_rng(np.random.PCG64()).permutation(x).compute()
+        da.random.default_rng(np.random.PCG64DXSM()).permutation(x).compute()
 
         # permutation not supported for default cupy BitGenerator
         with pytest.raises(NotImplementedError):

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -28,7 +28,9 @@ def test_generators(generator_class):
 
 
 @pytest.mark.parametrize(
-    "sd", [None, 42, np.random.PCG64, da.random.Generator(np.random.PCG64)], ids=type
+    "sd",
+    [None, 42, np.random.PCG64DXSM, da.random.Generator(np.random.PCG64DXSM)],
+    ids=type,
 )
 def test_default_rng(sd):
     rng = da.random.default_rng(seed=sd)


### PR DESCRIPTION
https://numpy.org/doc/stable/reference/random/upgrading-pcg64.html

    Uses of the PCG64 BitGenerator in a massively-parallel context have
    been shown to have statistical weaknesses that were not apparent at
    the first release in numpy 1.17. Most users will never observe this
    weakness and are safe to continue to use PCG64. We have introduced a
    new PCG64DXSM BitGenerator that will eventually become the new
    default BitGenerator implementation used by default_rng in future
    releases.  PCG64DXSM solves the statistical weakness while
    preserving the performance and the features of PCG64.

We were using PCG64 as PCG64DXSM was introduced in numpy-1.21. Switch to PCG64DXSM and update documentation since minimum numpy version in dask was updated to 1.21 via bbaac13

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
