### PR TITLE
Remove `randomgen` from docs and tests

### DIFF
--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -488,8 +488,7 @@ class RandomState:
         A callable that, when provided with a ``seed`` keyword provides an
         object that operates identically to ``np.random.RandomState`` (the
         default).  This might also be a function that returns a
-        ``randomgen.RandomState``, ``mkl_random``, or
-        ``cupy.random.RandomState`` object.
+        ``mkl_random``, or ``cupy.random.RandomState`` object.
 
     Examples
     --------

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -407,31 +407,6 @@ def test_permutation(generator_class):
     assert x.shape == (100,)
 
 
-def test_external_randomstate_class():
-    randomgen = pytest.importorskip("randomgen")
-
-    with pytest.raises(FutureWarning):
-        rs = da.random.RandomState(
-            RandomState=lambda seed: randomgen.Generator(randomgen.DSFMT(seed))
-        )
-        x = rs.normal(0, 1, size=10, chunks=(5,))
-        assert_eq(x, x)
-
-    with pytest.raises(FutureWarning):
-        rs = da.random.RandomState(
-            RandomState=lambda seed: randomgen.Generator(randomgen.DSFMT(seed)),
-            seed=123,
-        )
-        a = rs.normal(0, 1, size=10, chunks=(5,))
-        rs = da.random.RandomState(
-            RandomState=lambda seed: randomgen.Generator(randomgen.DSFMT(seed)),
-            seed=123,
-        )
-        b = rs.normal(0, 1, size=10, chunks=(5,))
-        assert a.name == b.name
-        assert_eq(a, b)
-
-
 def test_auto_chunks(generator_class):
     with dask.config.set({"array.chunk-size": "50 MiB"}):
         x = generator_class().random((10000, 10000))


### PR DESCRIPTION
As noted in https://bashtage.github.io/randomgen/change-log.html:

	Generator and RandomState have been REMOVED in 1.23. You should
	be using numpy.random.Generator or numpy.random.RandomState
	which are maintained.

Remove `randomgen` from docs and tests since it did not work anyway since randomgen-1.23 which was released in July 2022. Moreover
- `RandomState` is in maintenance mode and is unlikely to get any updates
- Both `Generator` and `RandomState` classes already get tested with alternative backends with `CuPy`

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
