### PR TITLE
Add minimum version to optional `jinja2` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require: dict[str, list[str]] = {
     "distributed": ["distributed == 2023.2.1"],
     "diagnostics": [
         "bokeh >= 2.4.2, <3",
-        "jinja2",
+        "jinja2 >= 2.10.3",
     ],
     "delayed": [],  # keeping for backwards compatibility
 }


### PR DESCRIPTION
Somewhat overdue, this updates the optional `jinja2` dependency to match the minimum version set for it in https://github.com/dask/distributed/pull/7285 (xref https://github.com/conda-forge/dask-feedstock/pull/215#discussion_r1117630378).

cc @jakirkham @jrbourbeau 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
