### PR TITLE
Fix `test_groupby_dropna_with_agg` for `pandas` 2.0

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2868,12 +2868,9 @@ def test_groupby_dropna_with_agg(sort):
     else:
         # before 2.0, sort=False appears to be disregarded, but only when
         # grouping on index columns, which is what we do in dask groupby.
+        # So we should expect sorted index levels even with sort=False.
         # Fixed in 2.0, possibly by https://github.com/pandas-dev/pandas/pull/49613
-        expected = (
-            df.set_index(["id1", "id2"])
-            .groupby(["id1", "id2"], dropna=False, sort=sort)
-            .agg("sum")
-        )
+        expected = df.groupby(["id1", "id2"], dropna=False, sort=True).agg("sum")
 
     ddf = dd.from_pandas(df, 1)
     actual = ddf.groupby(["id1", "id2"], dropna=False, sort=sort).agg("sum")

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2863,7 +2863,12 @@ def test_groupby_dropna_with_agg(sort):
     df = pd.DataFrame(
         {"id1": ["a", None, "b"], "id2": [1, 2, None], "v1": [4.5, 5.5, None]}
     )
-    expected = df.groupby(["id1", "id2"], dropna=False, sort=sort).agg("sum")
+    if PANDAS_GT_200:
+        expected = df.groupby(["id1", "id2"], dropna=False, sort=sort).agg("sum")
+    else:
+        # before 2.0, sort=False appears to be disregarded.
+        # https://github.com/pandas-dev/pandas/pull/49613
+        expected = df.groupby(["id1", "id2"], dropna=False, sort=True).agg("sum")
 
     ddf = dd.from_pandas(df, 1)
     actual = ddf.groupby(["id1", "id2"], dropna=False, sort=sort).agg("sum")

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2857,15 +2857,16 @@ def test_groupby_grouper_dispatch(key):
     assert_eq(expect, got)
 
 
-def test_groupby_dropna_with_agg():
+@pytest.mark.parametrize("sort", [True, False])
+def test_groupby_dropna_with_agg(sort):
     # https://github.com/dask/dask/issues/6986
     df = pd.DataFrame(
         {"id1": ["a", None, "b"], "id2": [1, 2, None], "v1": [4.5, 5.5, None]}
     )
-    expected = df.groupby(["id1", "id2"], dropna=False).agg("sum")
+    expected = df.groupby(["id1", "id2"], dropna=False, sort=sort).agg("sum")
 
-    ddf = dd.from_pandas(df, 1, sort=False)
-    actual = ddf.groupby(["id1", "id2"], dropna=False).agg("sum")
+    ddf = dd.from_pandas(df, 1)
+    actual = ddf.groupby(["id1", "id2"], dropna=False, sort=sort).agg("sum")
     assert_eq(expected, actual)
 
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2866,9 +2866,14 @@ def test_groupby_dropna_with_agg(sort):
     if PANDAS_GT_200:
         expected = df.groupby(["id1", "id2"], dropna=False, sort=sort).agg("sum")
     else:
-        # before 2.0, sort=False appears to be disregarded.
-        # https://github.com/pandas-dev/pandas/pull/49613
-        expected = df.groupby(["id1", "id2"], dropna=False, sort=True).agg("sum")
+        # before 2.0, sort=False appears to be disregarded, but only when
+        # grouping on index columns, which is what we do in dask groupby.
+        # Fixed in 2.0, possibly by https://github.com/pandas-dev/pandas/pull/49613
+        expected = (
+            df.set_index(["id1", "id2"])
+            .groupby(["id1", "id2"], dropna=False, sort=sort)
+            .agg("sum")
+        )
 
     ddf = dd.from_pandas(df, 1)
     actual = ddf.groupby(["id1", "id2"], dropna=False, sort=sort).agg("sum")

--- a/dask/dataframe/tests/test_pyarrow_compat.py
+++ b/dask/dataframe/tests/test_pyarrow_compat.py
@@ -24,7 +24,7 @@ def data(dtype):
         data = [1.0, 0.0] * 4 + [None] + [-2.0, -1.0] * 44 + [None] + [0.5, 99.5]
     elif pa.types.is_signed_integer(pa_dtype):
         data = [1, 0] * 4 + [None] + [-2, -1] * 44 + [None] + [1, 99]
-    elif pa.types.is_unsigned_integer(pa_dtype):
+    elif pa.types.is_unsigned_integer(pa_dtype) or pa.types.is_decimal(pa_dtype):
         data = [1, 0] * 4 + [None] + [2, 1] * 44 + [None] + [1, 99]
     elif pa.types.is_date(pa_dtype):
         data = (

--- a/dask/dataframe/tests/test_pyarrow_compat.py
+++ b/dask/dataframe/tests/test_pyarrow_compat.py
@@ -24,7 +24,7 @@ def data(dtype):
         data = [1.0, 0.0] * 4 + [None] + [-2.0, -1.0] * 44 + [None] + [0.5, 99.5]
     elif pa.types.is_signed_integer(pa_dtype):
         data = [1, 0] * 4 + [None] + [-2, -1] * 44 + [None] + [1, 99]
-    elif pa.types.is_unsigned_integer(pa_dtype) or pa.types.is_decimal(pa_dtype):
+    elif pa.types.is_unsigned_integer(pa_dtype):
         data = [1, 0] * 4 + [None] + [2, 1] * 44 + [None] + [1, 99]
     elif pa.types.is_date(pa_dtype):
         data = (


### PR DESCRIPTION
Attempt to fix the following error with upstream `pandas` 2.0:

```
dask/dataframe/tests/test_groupby.py::test_groupby_dropna_with_agg[disk]: AssertionError: MultiIndex level [0] are different

MultiIndex level [0] values are different (66.66667 %)
[left]:  Index(['a', 'b', nan], dtype='object', name='id1')
[right]: Index(['a', nan, 'b'], dtype='object', name='id1')
At positional index 1, first diff: b != nan
dask/dataframe/tests/test_groupby.py::test_groupby_dropna_with_agg[tasks]: AssertionError: MultiIndex level [0] are different

MultiIndex level [0] values are different (66.66667 %)
[left]:  Index(['a', 'b', nan], dtype='object', name='id1')
[right]: Index(['a', nan, 'b'], dtype='object', name='id1')
At positional index 1, first diff: b != nan
```

The first attempt to fix the problem was different:

* https://github.com/dask/dask/pull/9965

This PR implements a different approach, after digging up a PR from Ian Rose:

* https://github.com/dask/dask/pull/9486

Ian's PR among other things added the `SORT_SPLIT_OUT_WARNING`:

https://github.com/dask/dask/blob/46c47be15661dd885e32d81f34d6d2bf114d52c8/dask/dataframe/groupby.py#L82-L86

Which tells me we were planning to, at some point, to bring the `sort` behavior in line with `pandas`. Ultimately, we didn't change the default `sort` for `groupby` to `true`, even though `pandas` did. Until 2.0, it didn't break the tests though, I believe because `pandas` had a bug in `groupby` that disregarded `sort=False` that we were explicitly passing in. And then the bug was fixed in 2.0:

* https://github.com/pandas-dev/pandas/pull/49613

From the discussion in https://github.com/dask/dask/pull/9486, sounds like we might still want to have a different default for performance reasons.

This PR fixes the test by verifying that when we explicitly provide the same `sort` value to `dask` and `pandas`, the result is the same (at least in 2.0). The default value remains different.

If this approach is acceptable, we should consider removing `SORT_SPLIT_OUT_WARNING`, because while `pandas` defaults to `True` for `groupby` `sort`, we don't. We explicitly default to `False`:

https://github.com/dask/dask/blob/46c47be15661dd885e32d81f34d6d2bf114d52c8/dask/dataframe/groupby.py#L440

(and in a few more places).

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @rjzamora, would you be able to review? I see you worked on https://github.com/dask/dask/pull/9486.