### PR TITLE
Fix parquet overwrite behavior after an adaptive `read_parquet` operation

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -869,11 +869,13 @@ def to_parquet(
                 ):
                     path_with_slash = path.rstrip("/") + "/"  # ensure trailing slash
                     for input in layer.inputs:
-                        if input["piece"][0].startswith(path_with_slash):
-                            raise ValueError(
-                                "Reading and writing to the same parquet file within the "
-                                "same task graph is not supported."
-                            )
+                        # Note that `input` may be either `dict` or `List[dict]`
+                        for piece_dict in input if isinstance(input, list) else [input]:
+                            if piece_dict["piece"][0].startswith(path_with_slash):
+                                raise ValueError(
+                                    "Reading and writing to the same parquet file within "
+                                    "the same task graph is not supported."
+                                )
 
             # Don't remove the directory if it's the current working directory
             if _is_local_fs(fs):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3885,6 +3885,29 @@ def test_read_write_partition_on_overwrite_is_true(tmpdir, engine):
     assert len(files2) < len(files)
 
 
+def test_to_parquet_overwrite_adaptive_round_trip(tmpdir, engine):
+    df = pd.DataFrame({"a": range(128)})
+    ddf = dd.from_pandas(df, npartitions=8)
+    path = os.path.join(str(tmpdir), "path")
+    ddf.to_parquet(path, engine=engine)
+    ddf2 = dd.read_parquet(
+        path,
+        engine=engine,
+        split_row_groups="adaptive",
+    ).repartition(partition_size="1GB")
+    path_new = os.path.join(str(tmpdir), "path_new")
+    ddf2.to_parquet(path_new, engine=engine, overwrite=True)
+    ddf2.to_parquet(path_new, engine=engine, overwrite=True)
+    assert_eq(
+        ddf2,
+        dd.read_parquet(
+            path_new,
+            engine=engine,
+            split_row_groups=False,
+        ),
+    )
+
+
 def test_to_parquet_overwrite_raises(tmpdir, engine):
     # https://github.com/dask/dask/issues/6824
     # Check that overwrite=True will raise an error if the


### PR DESCRIPTION
After #9637, users may get adaptive partitioning by default (when the dataset contains larger files).  When partitioning is adaptive, the `inputs` of the `DataFrameIOLayer` may be `List[List]`. This PR updates `to_parquet`'s overwrite logic to account for this possibility.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
