### PR TITLE
Bag must not pick p2p as shuffle default

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1527,6 +1527,9 @@ class Bag(DaskMethodsMixin):
             raise Exception("The method= keyword has been moved to shuffle=")
         if shuffle is None:
             shuffle = get_default_shuffle_algorithm()
+            if shuffle == "p2p":
+                # Not implemented for Bags
+                shuffle = "tasks"
         if shuffle == "disk":
             return groupby_disk(
                 self, grouper, npartitions=npartitions, blocksize=blocksize

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -917,3 +917,10 @@ def test_get_scheduler_with_distributed_active_reset_config(c):
             assert get_scheduler() != c.get
         with dask.config.set(scheduler=None):
             assert get_scheduler() == c.get
+
+
+@gen_cluster(client=True)
+async def test_bag_groupby_default(c, s, a, b):
+    b = db.range(100, npartitions=10)
+    b2 = b.groupby(lambda x: x % 13)
+    assert not any("partd" in k[0] for k in b2.dask)


### PR DESCRIPTION
This is a regression introduced by https://github.com/dask/dask/pull/9991

P2P is not implemented for bags, yet.

See https://github.com/dask/distributed/issues/7591