### PR TITLE
Warn user about eager compute when they do ``len(ddf)``

### DIFF
--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -335,7 +335,7 @@ def test_enforce_columns(reader, blocks):
     header = blocks[0][0].split(b"\n")[0] + b"\n"
     with pytest.raises(ValueError):
         dfs = text_blocks_to_pandas(reader, blocks, header, head, {}, enforce=True)
-        dask.compute(*dfs, scheduler="sync")
+        dask.compute(dfs, scheduler="sync")
 
 
 #############################
@@ -1189,9 +1189,7 @@ def test_parse_dates_multi_column():
     with filetext(pdmc_text) as fn:
         ddf = dd.read_csv(fn, parse_dates=[["date", "time"]])
         df = pd.read_csv(fn, parse_dates=[["date", "time"]])
-
-        assert (df.columns == ddf.columns).all()
-        assert len(df) == len(ddf)
+        assert_eq(ddf, df)
 
 
 def test_read_csv_sep():
@@ -1206,9 +1204,7 @@ def test_read_csv_sep():
     with filetext(sep_text) as fn:
         ddf = dd.read_csv(fn, sep="###", engine="python")
         df = pd.read_csv(fn, sep="###", engine="python")
-
-        assert (df.columns == ddf.columns).all()
-        assert len(df) == len(ddf)
+        assert_eq(ddf, df)
 
 
 def test_read_csv_slash_r():

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -857,7 +857,7 @@ def test_read_hdf_doesnt_segfault():
             store.append("/x", df)
 
         ddf = dd.read_hdf(fn, "/x", chunksize=2)
-        assert len(ddf) == N
+        assert ddf.shape[0].compute() == N
 
 
 def test_hdf_filenames():

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -29,7 +29,7 @@ def test_orc_with_backend():
     pytest.importorskip("requests")
     d = dd.read_orc(url)
     assert set(d.columns) == {"time", "date"}  # order is not guaranteed
-    assert len(d) == 70000
+    assert d.shape[0].compute() == 70000
 
 
 @pytest.fixture(scope="module")
@@ -52,7 +52,7 @@ def orc_files():
 def test_orc_single(orc_files, split_stripes):
     fn = orc_files[0]
     d = dd.read_orc(fn, split_stripes=split_stripes)
-    assert len(d) == 70000
+    assert d.shape[0].compute() == 70000
     assert d.npartitions == 8 / split_stripes
     d2 = dd.read_orc(fn, columns=["time", "date"])
     assert_eq(d[columns], d2[columns], check_index=False)
@@ -144,7 +144,9 @@ def test_orc_aggregate_files_offset(orc_files):
     # the second)
     df2 = dd.read_orc(orc_files[:2], split_stripes=11, aggregate_files=True)
     assert df2.npartitions == 2
-    assert len(df2.partitions[0].index) > len(df2.index) // 2
+    assert (
+        df2.partitions[0].index.shape[0].compute() > df2.index.shape[0].compute() // 2
+    )
 
 
 @pytest.mark.skipif(

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2393,7 +2393,6 @@ def test_multi_duplicate_divisions():
     ddf1 = dd.from_pandas(df1, npartitions=2).set_index("x")
     ddf2 = dd.from_pandas(df2, npartitions=1).set_index("x")
     assert ddf1.npartitions <= 2
-    assert len(ddf1) == len(df1)
 
     r1 = ddf1.merge(ddf2, how="left", left_index=True, right_index=True)
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -955,7 +955,7 @@ def test_set_index_categorical():
     df = pd.DataFrame({"A": pd.Categorical(values, dtype=dtype), "B": 1})
 
     result = dd.from_pandas(df, npartitions=2).set_index("A")
-    assert len(result) == len(df)
+    assert result.shape[0].compute() == df.shape[0]
 
     # sorted with the metric defined by the Categorical
     divisions = pd.Categorical(result.divisions, dtype=dtype)

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -517,7 +517,8 @@ def test_blockwise_fusion_after_compute(c):
     # Trigger an optimization of the `series` graph
     # (which `result` depends on), then compute `result`.
     # This is essentially a test of `rewrite_blockwise`.
-    series_len = len(series)
+    with pytest.warns(dd.core.EagerWarning):
+        series_len = len(series)
     assert series_len == 15
     assert df.x[result.compute()].sum() == 15
 


### PR DESCRIPTION
- [x] Closes #9857
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Note this PR warns every time `len(ddf)` is called. It also warns when `list(ddf)`. I don't quite know why that is but I assume `list` calls `len` internally.

```python
In [1]: from dask.dataframe.io.demo import make_timeseries
   ...: 
   ...: ddf = make_timeseries()
   ...: len(ddf)
/home/jsignell/dask/dask/dataframe/core.py:846: EagerWarning: Calling ``len()`` on a dask.dataframe object triggers ``compute()``. It is better practice to use ``.shape[0]`` so that compute can be scheduled and intermediary results can be reused
  warnings.warn(
Out[1]: 2894400
In [2]: list(ddf)
/home/jsignell/dask/dask/dataframe/core.py:846: EagerWarning: Calling ``len()`` on a dask.dataframe object triggers ``compute()``. It is better practice to use ``.shape[0]`` so that compute can be scheduled and intermediary results can be reused
  warnings.warn(
Out[2]: ['name', 'id', 'x', 'y']
```