### PR TITLE
Fix `test_pickle_roundtrip` for `pandas` 2.0

### DIFF
--- a/dask/dataframe/tests/test_pyarrow_compat.py
+++ b/dask/dataframe/tests/test_pyarrow_compat.py
@@ -1,5 +1,6 @@
 import pickle
 from datetime import date, datetime, time, timedelta
+from decimal import Decimal
 
 import pandas as pd
 import pandas._testing as tm
@@ -26,6 +27,14 @@ def data(dtype):
         data = [1, 0] * 4 + [None] + [-2, -1] * 44 + [None] + [1, 99]
     elif pa.types.is_unsigned_integer(pa_dtype):
         data = [1, 0] * 4 + [None] + [2, 1] * 44 + [None] + [1, 99]
+    elif pa.types.is_decimal(pa_dtype):
+        data = (
+            [Decimal("1"), Decimal("0.0")] * 4
+            + [None]
+            + [Decimal("-2.0"), Decimal("-1.0")] * 44
+            + [None]
+            + [Decimal("0.5"), Decimal("33.123")]
+        )
     elif pa.types.is_date(pa_dtype):
         data = (
             [date(2022, 1, 1), date(1999, 12, 31)] * 4


### PR DESCRIPTION
@j-bennet pointed out that `dask/dataframe/tests/test_pyarrow_compat.py::test_pickle_roundtrip[decimal128(7, 3)]` has started failing in our `upstream` build because `pyarrow` decimals were recently added to `ALL_PYARROW_DTYPES` upstream in `pandas` (xref https://github.com/pandas-dev/pandas/commit/2230bad6fcfda4d04a3d0b309473708b43025822). This PR accounts for this in our `test_pickle_roundtrip` test.