### PR TITLE
Rename shuffle/rechunk config option/kwarg to `method`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -66,5 +66,5 @@ pytest.register_assert_rewrite(
 
 @pytest.fixture(params=["disk", "tasks"])
 def shuffle_method(request):
-    with dask.config.set({"dataframe.shuffle.algorithm": request.param}):
+    with dask.config.set({"dataframe.shuffle.method": request.param}):
         yield request.param

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2752,7 +2752,7 @@ class Array(DaskMethodsMixin):
         threshold=None,
         block_size_limit=None,
         balance=False,
-        algorithm=None,
+        method=None,
     ):
         """Convert blocks in dask array x for new chunks.
 
@@ -2764,7 +2764,7 @@ class Array(DaskMethodsMixin):
         """
         from dask.array.rechunk import rechunk  # avoid circular import
 
-        return rechunk(self, chunks, threshold, block_size_limit, balance, algorithm)
+        return rechunk(self, chunks, threshold, block_size_limit, balance, method)
 
     @property
     def real(self):

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -231,7 +231,7 @@ def rechunk(
     threshold=None,
     block_size_limit=None,
     balance=False,
-    algorithm=None,
+    method=None,
 ):
     """
     Convert blocks in dask array x for new chunks.
@@ -256,8 +256,8 @@ def rechunk(
         This means ``balance=True`` will remove any small leftover chunks, so
         using ``x.rechunk(chunks=len(x) // N, balance=True)``
         will almost certainly result in ``N`` chunks.
-    algorithm: {'tasks', 'p2p'}, optional.
-        Algorithm to use.
+    method: {'tasks', 'p2p'}, optional.
+        Rechunking method to use.
 
 
     Examples
@@ -324,9 +324,9 @@ def rechunk(
         if new != old and not math.isnan(old) and not math.isnan(new):
             raise ValueError("Provided chunks are not consistent with shape")
 
-    algorithm = algorithm or config.get("array.rechunk.algorithm")
+    method = method or config.get("array.rechunk.method")
 
-    if algorithm == "tasks":
+    if method == "tasks":
         steps = plan_rechunk(
             x.chunks, chunks, x.dtype.itemsize, threshold, block_size_limit
         )
@@ -335,13 +335,13 @@ def rechunk(
 
         return x
 
-    elif algorithm == "p2p":
+    elif method == "p2p":
         from distributed.shuffle import rechunk_p2p
 
         return rechunk_p2p(x, chunks)
 
     else:
-        raise NotImplementedError(f"Unknown rechunking algorithm '{algorithm}'")
+        raise NotImplementedError(f"Unknown rechunking method '{method}'")
 
 
 def _number_of_blocks(chunks):

--- a/dask/config.py
+++ b/dask/config.py
@@ -622,6 +622,7 @@ deprecations = {
     "ucx.reuse-endpoints": "distributed.ucx.reuse-endpoints",
     "rmm.pool-size": "distributed.rmm.pool-size",
     "shuffle": "dataframe.shuffle.algorithm",
+    "dataframe.shuffle.algorithm": "dataframe.shuffle.method",
     "dataframe.shuffle-compression": "dataframe.shuffle.compression",
 }
 

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -50,13 +50,13 @@ properties:
         type: object
         properties:
 
-          algorithm:
+          method:
             type:
             - string
             - "null"
             description: |
-              The default shuffle algorithm to choose. Possible values are disk,
-              tasks, p2p. If null, pick best algorithm depending on application.
+              The default shuffle method to choose. Possible values are disk,
+              tasks, p2p. If null, pick best method depending on application.
 
           compression:
             type:
@@ -113,10 +113,10 @@ properties:
       rechunk:
         type: object
         properties:
-          algorithm:
+          method:
             type: string
             description: |
-              The algorithm to use for rechunking. Must be either "tasks" or "p2p";
+              The method to use for rechunking. Must be either "tasks" or "p2p";
               default is "tasks". Using "p2p" requires a distributed cluster.
 
       svg:

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -9,7 +9,7 @@ tokenize:
 dataframe:
   backend: "pandas"  # Backend dataframe library for input IO and data creation
   shuffle:
-    algorithm: null
+    method: null
     compression: null  # compression for on disk-shuffling. Partd supports ZLib, BZ2, SNAPPY
   parquet:
     metadata-task-size-local: 512  # Number of files per local metadata-processing task
@@ -20,7 +20,7 @@ dataframe:
 array:
   backend: "numpy"  # Backend array library for input IO and data creation
   rechunk:
-    algorithm: "tasks"  # Rechunking algorithm to use
+    method: "tasks"  # Rechunking algorithm to use
   svg:
     size: 120  # pixels
   slicing:

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -20,7 +20,7 @@ dataframe:
 array:
   backend: "numpy"  # Backend array library for input IO and data creation
   rechunk:
-    method: "tasks"  # Rechunking algorithm to use
+    method: "tasks"  # Rechunking method to use
   svg:
     size: 120  # pixels
   slicing:

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -115,7 +115,7 @@ def _determine_shuffle(shuffle, split_out):
             # For more context, see
             # https://github.com/dask/dask/pull/9826/files#r1072395307
             # https://github.com/dask/distributed/issues/5502
-            return config.get("dataframe.shuffle.algorithm", None) or "tasks"
+            return config.get("dataframe.shuffle.method", None) or "tasks"
         else:
             return False
     return shuffle
@@ -1974,7 +1974,7 @@ class _GroupBy:
         # understood why this is a better choice. For more context, see
         # https://github.com/dask/dask/pull/9826/files#r1072395307
         # https://github.com/dask/distributed/issues/5502
-        shuffle = shuffle or config.get("dataframe.shuffle.algorithm", None) or "tasks"
+        shuffle = shuffle or config.get("dataframe.shuffle.method", None) or "tasks"
 
         with check_numeric_only_deprecation():
             meta = self._meta_nonempty.median()
@@ -2288,7 +2288,7 @@ class _GroupBy:
             # https://github.com/dask/dask/pull/9826/files#r1072395307
             # https://github.com/dask/distributed/issues/5502
             if not isinstance(shuffle, str):
-                shuffle = config.get("dataframe.shuffle.algorithm", None) or "tasks"
+                shuffle = config.get("dataframe.shuffle.method", None) or "tasks"
             if has_median:
                 result = _shuffle_aggregate(
                     chunk_args,

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1045,7 +1045,7 @@ def test_gh_2730():
     dd_left = dd.from_pandas(small, npartitions=3)
     dd_right = dd.from_pandas(large, npartitions=257)
 
-    with dask.config.set({"dataframe.shuffle.algorithm": "tasks", "scheduler": "sync"}):
+    with dask.config.set({"dataframe.shuffle.method": "tasks", "scheduler": "sync"}):
         dd_merged = dd_left.merge(dd_right, how="inner", on="KEY")
         result = dd_merged.compute()
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -2086,7 +2086,7 @@ def is_namedtuple_instance(obj: Any) -> bool:
 
 
 def get_default_shuffle_algorithm() -> str:
-    if d := config.get("dataframe.shuffle.algorithm", None):
+    if d := config.get("dataframe.shuffle.method", None):
         return d
     try:
         from distributed import default_client

--- a/docs/source/dataframe-groupby.rst
+++ b/docs/source/dataframe-groupby.rst
@@ -97,12 +97,12 @@ Client as default:
     client = Client('scheduler:8786', set_as_default=True)
 
 Alternatively, if you prefer to avoid defaults, you can configure the global
-shuffling method with the ``dataframe.shuffle.algorithm`` configuration option.
+shuffling method with the ``dataframe.shuffle.method`` configuration option.
 This can be done globally:
 
 .. code-block:: python
 
-    dask.config.set({"dataframe.shuffle.algorithm": "p2p"})
+    dask.config.set({"dataframe.shuffle.method": "p2p"})
 
     ddf.groupby(...).apply(...)
 
@@ -110,7 +110,7 @@ or as a context manager:
 
 .. code-block:: python
 
-    with dask.config.set({"dataframe.shuffle.algorithm": "p2p"}):
+    with dask.config.set({"dataframe.shuffle.method": "p2p"}):
         ddf.groupby(...).apply(...)
 
 


### PR DESCRIPTION
This PR changes the term `algorithm` to `method` for specifying which shuffle/rechunk method should be used 

xref https://github.com/dask/dask/pull/10008#issuecomment-1448732558

cc @fjetter @hendrikmakait @wence- 