### PR TITLE
Add initial support for converting pandas extension dtypes to arrays

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -14,6 +14,7 @@ import pandas as pd
 from pandas.api.types import (
     is_bool_dtype,
     is_datetime64_any_dtype,
+    is_extension_array_dtype,
     is_numeric_dtype,
     is_timedelta64_dtype,
 )
@@ -3627,6 +3628,12 @@ Dask Name: {name}, {layers}"""
         Operations that depend on shape information, like slicing or reshaping,
         will not work.
         """
+        if is_extension_array_dtype(self._meta.values):
+            warnings.warn(
+                "Dask currently has limited support for converting pandas extension dtypes "
+                f"to arrays. Converting {self._meta.values.dtype} to object dtype.",
+                UserWarning,
+            )
         return self.map_partitions(methods.values)
 
     def _validate_chunks(self, arr, lengths):

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -3,6 +3,7 @@ from functools import partial
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_extension_array_dtype
 from tlz import partition
 
 from dask.dataframe._compat import PANDAS_GT_131, PANDAS_GT_200
@@ -371,7 +372,12 @@ def size(x):
 
 
 def values(df):
-    return df.values
+    values = df.values
+    # We currently only offer limited support for converting pandas extension
+    # dtypes to arrays. For now we simply convert to `object` dtype.
+    if is_extension_array_dtype(values):
+        values = values.astype(object)
+    return values
 
 
 def sample(df, state, frac, replace):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4416,6 +4416,22 @@ def test_values():
     assert_eq(df.index.values, ddf.index.values)
 
 
+def test_values_extension_dtypes():
+    from dask.array.utils import assert_eq
+
+    df = pd.DataFrame(
+        {"x": ["a", "b", "c", "d"], "y": [2, 3, 4, 5]},
+        index=pd.Index([1.0, 2.0, 3.0, 4.0], dtype="Float64", name="ind"),
+    )
+    df = df.astype({"x": "string[python]", "y": "Int64"})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    assert_eq(df.values, ddf.values)
+    assert_eq(df.x.values.astype(object), ddf.x.values)
+    assert_eq(df.y.values.astype(object), ddf.y.values)
+    assert_eq(df.index.values.astype(object), ddf.index.values)
+
+
 def test_copy():
     df = pd.DataFrame({"x": [1, 2, 3]})
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4427,9 +4427,21 @@ def test_values_extension_dtypes():
     ddf = dd.from_pandas(df, npartitions=2)
 
     assert_eq(df.values, ddf.values)
-    assert_eq(df.x.values.astype(object), ddf.x.values)
-    assert_eq(df.y.values.astype(object), ddf.y.values)
-    assert_eq(df.index.values.astype(object), ddf.index.values)
+    with pytest.warns(UserWarning, match="object dtype"):
+        result = ddf.x.values
+    assert_eq(result, df.x.values.astype(object))
+
+    with pytest.warns(UserWarning, match="object dtype"):
+        result = ddf.y.values
+    assert_eq(result, df.y.values.astype(object))
+
+    # Prior to pandas=1.4, `pd.Index` couldn't hold extension dtypes
+    ctx = contextlib.nullcontext()
+    if PANDAS_GT_140:
+        ctx = pytest.warns(UserWarning, match="object dtype")
+    with ctx:
+        result = ddf.index.values
+    assert_eq(result, df.index.values.astype(object))
 
 
 def test_copy():


### PR DESCRIPTION
Currently when one calls `.values` on a Dask Series / Index that holds extension dtypes, an error along the lines of `TypeError: Cannot interpret 'Float32Dtype()' as a data type` is raised because `numpy` doesn't know how to handle pandas extension dtypes (xref https://github.com/dask/dask/issues/9401).

This PR proposes we add initial support for this case by just converting extension dtypes we encounter to `object`s before handing off to `numpy`. There are other approaches we could take, for example something like https://github.com/dask/dask/pull/7375, that would give better parity with `pandas` behavior, but casting to `object` feels like reasonable progress over the status quo of throwing an error. 

cc @rjzamora @j-bennet for thoughts 