### PR TITLE
Extend `complete` extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ extras_require: dict[str, list[str]] = {
     ],
     "delayed": [],  # keeping for backwards compatibility
 }
-extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
+extras_require["complete"] = sorted(
+    {v for req in extras_require.values() for v in req}
+) + ["pyarrow >= 7.0"]
 # after complete is set, add in test
 extras_require["test"] = [
     "pandas[test]",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extras_require: dict[str, list[str]] = {
 }
 extras_require["complete"] = sorted(
     {v for req in extras_require.values() for v in req}
-) + ["pyarrow >= 7.0"]
+) + ["pyarrow >= 7.0", "lz4 >= 4.3.2"]
 # after complete is set, add in test
 extras_require["test"] = [
     "pandas[test]",


### PR DESCRIPTION
I think this makes sense given the new shuffling default value. Users are much more likely to have a better experience (by default) if `pyarrow` is installed. Eventually I can see us moving this into the `dataframe` extra (especially once `pyarrow` strings are a smoother experience) but for now the `complete` extra + `dask` conda-forge metapackage seems fine. 

Re: `lz4`, the `dask` conda-forge metapackage [already has `lz4` included](https://github.com/conda-forge/dask-feedstock/blob/0292675723a2e77dadd9f30b99fafd7ca2635bb6/recipe/meta.yaml#L26). Looking at `lz4` on PyPI, there are a bunch of wheels for common platforms already built (xref https://pypi.org/project/lz4/4.3.2/#files). For reference, version 4.3.0 (~2 month old) is when macOS M1 wheels were included. 

Closes https://github.com/dask/dask/issues/10012