### PR TITLE
Increase minimum supported `pyarrow` to 7.0

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -32,7 +32,7 @@ dependencies:
   - fsspec
   # Pin until sqlalchemy 2 support is added https://github.com/dask/dask/issues/9896
   - sqlalchemy>=1.4.0,<2
-  - pyarrow
+  - pyarrow=10
   - coverage
   - jsonschema
   # other -- IO

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -31,7 +31,7 @@ dependencies:
   - fsspec
   # Pin until sqlalchemy 2 support is added https://github.com/dask/dask/issues/9896
   - sqlalchemy>=1.4.0,<2
-  - pyarrow>=10
+  - pyarrow>=11
   - coverage
   - jsonschema
   # # other -- IO

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -32,7 +32,7 @@ dependencies:
   - fsspec
   # Pin until sqlalchemy 2 support is added https://github.com/dask/dask/issues/9896
   - sqlalchemy>=1.4.0,<2
-  - pyarrow=4.0
+  - pyarrow=7
   - coverage
   - jsonschema
   # other -- IO

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -32,7 +32,7 @@ dependencies:
   - fsspec
   # Pin until sqlalchemy 2 support is added https://github.com/dask/dask/issues/9896
   - sqlalchemy>=1.4.0,<2
-  - pyarrow
+  - pyarrow=9
   - coverage
   - jsonschema
   # other -- IO

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -8,7 +8,6 @@ from contextlib import contextmanager
 from functools import partial
 
 import pytest
-from packaging.version import parse as parse_version
 
 s3fs = pytest.importorskip("s3fs")
 boto3 = pytest.importorskip("boto3")
@@ -441,25 +440,12 @@ def test_modification_time_read_bytes(s3, s3so):
 @pytest.mark.parametrize("engine", ["pyarrow", "fastparquet"])
 @pytest.mark.parametrize("metadata_file", [True, False])
 def test_parquet(s3, engine, s3so, metadata_file):
-    import s3fs
-
     dd = pytest.importorskip("dask.dataframe")
     pd = pytest.importorskip("pandas")
     np = pytest.importorskip("numpy")
-
-    lib = pytest.importorskip(engine)
-    lib_version = parse_version(lib.__version__)
-    if engine == "pyarrow" and lib_version < parse_version("0.13.1"):
-        pytest.skip("pyarrow < 0.13.1 not supported for parquet")
-    if (
-        engine == "pyarrow"
-        and lib_version.major == 2
-        and parse_version(s3fs.__version__) > parse_version("0.5.0")
-    ):
-        pytest.skip("#7056 - new s3fs not supported before pyarrow 3.0")
+    pytest.importorskip(engine)
 
     url = "s3://%s/test.parquet" % test_bucket_name
-
     data = pd.DataFrame(
         {
             "i32": np.arange(1000, dtype=np.int32),

--- a/dask/dataframe/io/orc/core.py
+++ b/dask/dataframe/io/orc/core.py
@@ -2,7 +2,6 @@ import copy
 
 from fsspec.core import get_fs_token_paths
 from fsspec.utils import stringify_path
-from packaging.version import parse as parse_version
 
 from dask.base import compute_as_if_collection, tokenize
 from dask.dataframe.backends import dataframe_creation_dispatch
@@ -57,12 +56,7 @@ class ORCFunctionWrapper(DataFrameIOFunction):
 def _get_engine(engine, write=False):
     # Get engine
     if engine == "pyarrow":
-        import pyarrow as pa
-
         from dask.dataframe.io.orc.arrow import ArrowORCEngine
-
-        if write and parse_version(pa.__version__) < parse_version("4.0.0"):
-            raise ValueError("to_orc is not supported for pyarrow<4.0.0")
 
         return ArrowORCEngine
     elif not isinstance(engine, ORCEngine):

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -7,7 +7,6 @@ import warnings
 import tlz as toolz
 from fsspec.core import get_fs_token_paths
 from fsspec.utils import stringify_path
-from packaging.version import parse as parse_version
 
 import dask
 from dask.base import tokenize
@@ -1238,19 +1237,12 @@ def get_engine(engine):
         return eng
 
     elif engine in ("pyarrow", "arrow", "pyarrow-dataset"):
-        pa = import_required("pyarrow", "`pyarrow` not installed")
-        pa_version = parse_version(pa.__version__)
+        import_required("pyarrow", "`pyarrow` not installed")
 
         if engine in ("pyarrow-dataset", "arrow"):
             engine = "pyarrow"
 
         if engine == "pyarrow":
-            if pa_version.major < 1:
-                raise ImportError(
-                    f"pyarrow-{pa_version.major} does not support the "
-                    f"pyarrow.dataset API. Please install pyarrow>=1."
-                )
-
             from dask.dataframe.io.parquet.arrow import ArrowDatasetEngine
 
             _ENGINES[engine] = eng = ArrowDatasetEngine

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -6,7 +6,6 @@ import tempfile
 import numpy as np
 import pandas as pd
 import pytest
-from packaging.version import parse as parse_version
 
 import dask.dataframe as dd
 from dask.dataframe.optimize import optimize_dataframe_getitem
@@ -78,10 +77,6 @@ def test_orc_multiple(orc_files):
     assert_eq(d2[columns], dd.concat([d, d])[columns], check_index=False)
 
 
-@pytest.mark.skipif(
-    parse_version(pa.__version__) < parse_version("4.0.0"),
-    reason=("PyArrow>=4.0.0 required for ORC write support."),
-)
 @pytest.mark.parametrize("index", [None, "i32"])
 @pytest.mark.parametrize("columns", [None, ["i32", "i64", "f"]])
 def test_orc_roundtrip(tmpdir, index, columns):
@@ -110,10 +105,6 @@ def test_orc_roundtrip(tmpdir, index, columns):
     assert_eq(data, df2, check_index=bool(index))
 
 
-@pytest.mark.skipif(
-    parse_version(pa.__version__) < parse_version("4.0.0"),
-    reason=("PyArrow>=4.0.0 required for ORC write support."),
-)
 @pytest.mark.parametrize("split_stripes", [True, False, 2, 4])
 def test_orc_roundtrip_aggregate_files(tmpdir, split_stripes):
     tmp = str(tmpdir)
@@ -147,10 +138,6 @@ def test_orc_aggregate_files_offset(orc_files):
     assert len(df2.partitions[0].index) > len(df2.index) // 2
 
 
-@pytest.mark.skipif(
-    parse_version(pa.__version__) < parse_version("4.0.0"),
-    reason=("PyArrow>=4.0.0 required for ORC write support."),
-)
 @pytest.mark.network
 def test_orc_names(orc_files, tmp_path):
     df = dd.read_orc(orc_files)
@@ -159,10 +146,6 @@ def test_orc_names(orc_files, tmp_path):
     assert out._name.startswith("to-orc")
 
 
-@pytest.mark.skipif(
-    parse_version(pa.__version__) < parse_version("4.0.0"),
-    reason=("PyArrow>=4.0.0 required for ORC write support."),
-)
 def test_to_orc_delayed(tmp_path):
     # See: https://github.com/dask/dask/issues/8022
     df = pd.DataFrame(np.random.randn(100, 4), columns=["a", "b", "c", "d"])

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2,7 +2,6 @@ import contextlib
 import glob
 import math
 import os
-import sys
 import warnings
 from decimal import Decimal
 from unittest.mock import MagicMock
@@ -39,9 +38,6 @@ try:
     import pyarrow as pa
 except ImportError:
     pa = False
-    pa_version = parse_version("0")
-else:
-    pa_version = parse_version(pa.__version__)
 
 try:
     import pyarrow.parquet as pq
@@ -52,16 +48,8 @@ except ImportError:
 SKIP_FASTPARQUET = not fastparquet
 FASTPARQUET_MARK = pytest.mark.skipif(SKIP_FASTPARQUET, reason="fastparquet not found")
 
-if sys.platform == "win32" and pa and pa_version == parse_version("2.0.0"):
-    SKIP_PYARROW = True
-    SKIP_PYARROW_REASON = (
-        "skipping pyarrow 2.0.0 on windows: "
-        "https://github.com/dask/dask/issues/6093"
-        "|https://github.com/dask/dask/issues/6754"
-    )
-else:
-    SKIP_PYARROW = not pq
-    SKIP_PYARROW_REASON = "pyarrow not found"
+SKIP_PYARROW = not pq
+SKIP_PYARROW_REASON = "pyarrow not found"
 PYARROW_MARK = pytest.mark.skipif(SKIP_PYARROW, reason=SKIP_PYARROW_REASON)
 
 nrows = 40
@@ -1031,8 +1019,6 @@ def test_append_dict_column(tmpdir, engine):
 
     if engine == "fastparquet":
         pytest.xfail("Fastparquet engine is missing dict-column support")
-    elif pa_version < parse_version("1.0.1"):
-        pytest.skip("PyArrow 1.0.1+ required for dict-column support.")
 
     tmp = str(tmpdir)
     dts = pd.date_range("2020-01-01", "2021-01-01")
@@ -4351,10 +4337,6 @@ def test_custom_filename_with_partition(tmpdir, engine):
 
 @PYARROW_MARK
 @pytest.mark.xfail(PANDAS_GT_200, reason="https://github.com/dask/dask/issues/9966")
-@pytest.mark.skipif(
-    pa_version < parse_version("5.0"),
-    reason="pyarrow write_dataset was added in version 5.0",
-)
 def test_roundtrip_partitioned_pyarrow_dataset(tmpdir, engine):
     # See: https://github.com/dask/dask/issues/8650
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2881,7 +2881,7 @@ def test_filter_nulls(tmpdir, filters, op, length, split_row_groups, engine):
 @PYARROW_MARK
 @pytest.mark.parametrize("split_row_groups", [True, False])
 def test_filter_isna(tmpdir, split_row_groups):
-    if engine == "pyarrow" and parse_version(pa.__version__) < parse_version("8.0.0"):
+    if parse_version(pa.__version__) < parse_version("8.0.0"):
         # See: https://issues.apache.org/jira/browse/ARROW-15312
         pytest.skip("pyarrow>=8.0.0 needed for correct null filtering")
     path = tmpdir.join("test.parquet")

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2855,6 +2855,9 @@ def test_split_row_groups_int_aggregate_files(tmpdir, engine, split_row_groups):
 )
 @pytest.mark.parametrize("split_row_groups", [True, False])
 def test_filter_nulls(tmpdir, filters, op, length, split_row_groups, engine):
+    if engine == "pyarrow" and parse_version(pa.__version__) < parse_version("8.0.0"):
+        # See: https://issues.apache.org/jira/browse/ARROW-15312
+        pytest.skip("pyarrow>=8.0.0 needed for correct null filtering")
     path = tmpdir.join("test.parquet")
     df = pd.DataFrame(
         {
@@ -2878,6 +2881,9 @@ def test_filter_nulls(tmpdir, filters, op, length, split_row_groups, engine):
 @PYARROW_MARK
 @pytest.mark.parametrize("split_row_groups", [True, False])
 def test_filter_isna(tmpdir, split_row_groups):
+    if engine == "pyarrow" and parse_version(pa.__version__) < parse_version("8.0.0"):
+        # See: https://issues.apache.org/jira/browse/ARROW-15312
+        pytest.skip("pyarrow>=8.0.0 needed for correct null filtering")
     path = tmpdir.join("test.parquet")
     pd.DataFrame({"a": [1, None] * 5 + [None] * 5}).to_parquet(
         path, engine="pyarrow", row_group_size=10

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -123,7 +123,7 @@ These optional dependencies and their minimum supported versions are listed belo
 +---------------+----------+--------------------------------------------------------------+
 |     psutil    |          |             Enables a more accurate CPU count                |
 +---------------+----------+--------------------------------------------------------------+
-|     pyarrow   | >=1.0    |               Python library for Apache Arrow                |
+|     pyarrow   | >=7.0    |               Python library for Apache Arrow                |
 +---------------+----------+--------------------------------------------------------------+
 |     s3fs      | >=0.4.0  |                    Reading from Amazon S3                    |
 +---------------+----------+--------------------------------------------------------------+


### PR DESCRIPTION
It's been a while since we've updated our minimum `pyarrow` version. This PR proposes we make `pyarrow=7` the new minimum. This version is over a year old and is the minimum version required for the new default P2P shuffling method. As a side benefit, this also let's us remove some older compatibility code. 

xref https://github.com/dask/dask/pull/10023

cc @rjzamora @fjetter @hendrikmakait for visibility 