### PR TITLE
Skip rechunk when rechunking to the same chunks with unknown sizes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3129,7 +3129,9 @@ def normalize_chunks(chunks, shape=None, limit=None, dtype=None, previous_chunks
                 "Got chunks=%s, shape=%s" % (chunks, shape)
             )
 
-    return tuple(tuple(int(x) if not math.isnan(x) else x for x in c) for c in chunks)
+    return tuple(
+        tuple(int(x) if not math.isnan(x) else np.nan for x in c) for c in chunks
+    )
 
 
 def _compute_multiplier(limit: int, dtype, largest_block: int, result):

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -309,11 +309,12 @@ def rechunk(
     )
 
     # Now chunks are tuple of tuples
-    if not balance and (chunks == x.chunks):
-        return x
     ndim = x.ndim
     if not len(chunks) == ndim:
         raise ValueError("Provided chunks are not consistent with shape")
+
+    if not balance and (chunks == x.chunks):
+        return x
 
     if balance:
         chunks = tuple(_balance_chunksizes(chunk) for chunk in chunks)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2949,6 +2949,8 @@ def test_normalize_chunks():
     assert normalize_chunks(10, (30, 5)) == ((10, 10, 10), (5,))
     assert normalize_chunks((), (0, 0)) == ((0,), (0,))
     assert normalize_chunks(-1, (0, 3)) == ((0,), (3,))
+    assert normalize_chunks(((float("nan"),),)) == ((np.nan,),)
+
     assert normalize_chunks("auto", shape=(20,), limit=5, dtype="uint8") == (
         (5, 5, 5, 5),
     )

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -284,9 +284,11 @@ def test_rechunk_same():
 
 def test_rechunk_same_unknown():
     dd = pytest.importorskip("dask.dataframe")
-    x = da.ones(shape=(10, 10), chunks=(5, 2))
+    x = da.ones(shape=(10, 10), chunks=(5, 10))
     y = dd.from_array(x).values
-    result = y.rechunk(((np.nan, np.nan), (10,)))
+    new_chunks = ((np.nan, np.nan), (10,))
+    assert y.chunks == new_chunks
+    result = y.rechunk(new_chunks)
     assert y is result
 
 
@@ -295,9 +297,10 @@ def test_rechunk_same_unknown_floats():
     ``float("nan")`` is used instead of the recommended ``np.nan``
     """
     dd = pytest.importorskip("dask.dataframe")
-    x = da.ones(shape=(10, 10), chunks=(5, 2))
+    x = da.ones(shape=(10, 10), chunks=(5, 10))
     y = dd.from_array(x).values
-    result = y.rechunk(((float("nan"), float("nan")), (10,)))
+    new_chunks = ((float("nan"), float("nan")), (10,))
+    result = y.rechunk(new_chunks)
     assert y is result
 
 


### PR DESCRIPTION
This PR coerces NaNs to `np.nan` in `normalize_chunks` to eliminate unnecessary rechunks when using unknown dimensions.

- [x] Closes #10026
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
