### PR TITLE
Fix flaky `RuntimeWarning` during array reductions

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -410,7 +410,7 @@ def prod(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None):
     if dtype is not None:
         dt = dtype
     else:
-        dt = getattr(np.empty((1,), dtype=a.dtype).prod(), "dtype", object)
+        dt = getattr(np.ones((1,), dtype=a.dtype).prod(), "dtype", object)
     return reduction(
         a,
         chunk.prod,
@@ -504,7 +504,7 @@ def nansum(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None)
     if dtype is not None:
         dt = dtype
     else:
-        dt = getattr(chunk.nansum(np.empty((1,), dtype=a.dtype)), "dtype", object)
+        dt = getattr(chunk.nansum(np.ones((1,), dtype=a.dtype)), "dtype", object)
     return reduction(
         a,
         chunk.nansum,
@@ -522,7 +522,7 @@ def nanprod(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None
     if dtype is not None:
         dt = dtype
     else:
-        dt = getattr(chunk.nansum(np.empty((1,), dtype=a.dtype)), "dtype", object)
+        dt = getattr(chunk.nansum(np.ones((1,), dtype=a.dtype)), "dtype", object)
     return reduction(
         a,
         chunk.nanprod,
@@ -731,7 +731,7 @@ def nanmean(a, axis=None, dtype=None, keepdims=False, split_every=None, out=None
     if dtype is not None:
         dt = dtype
     else:
-        dt = getattr(np.mean(np.empty(shape=(1,), dtype=a.dtype)), "dtype", object)
+        dt = getattr(np.mean(np.ones(shape=(1,), dtype=a.dtype)), "dtype", object)
     return reduction(
         a,
         partial(mean_chunk, sum=chunk.nansum, numel=nannumel),
@@ -1352,7 +1352,7 @@ def prefixscan_blelloch(func, preop, binop, x, axis=None, dtype=None, out=None):
         x = x.flatten().rechunk(chunks=x.npartitions)
         axis = 0
     if dtype is None:
-        dtype = getattr(func(np.empty((0,), dtype=x.dtype)), "dtype", object)
+        dtype = getattr(func(np.ones((0,), dtype=x.dtype)), "dtype", object)
     assert isinstance(axis, Integral)
     axis = validate_axis(axis, x.ndim)
     name = f"{func.__name__}-{tokenize(func, axis, preop, binop, x, dtype)}"
@@ -1499,7 +1499,7 @@ def cumreduction(
         x = x.flatten().rechunk(chunks=x.npartitions)
         axis = 0
     if dtype is None:
-        dtype = getattr(func(np.empty((0,), dtype=x.dtype)), "dtype", object)
+        dtype = getattr(func(np.ones((0,), dtype=x.dtype)), "dtype", object)
     assert isinstance(axis, Integral)
     axis = validate_axis(axis, x.ndim)
 


### PR DESCRIPTION
This is sort of a shot in the dark. We've got some (pretty rare) flaky `RuntimeWarning: invalid value encountered in reduce` warnings being emitted in `test_reductions_2D` (see full traceback below). The warning occurs when we're determining the output meta dtype using `np.empty`. This PR suggests we use `np.ones` instead of `np.empty` to make things more deterministic. Again, not totally sure if this actually solves the flaky warning, but it might, and the change here seems harmless anyways.

I'll run CI here a few times to see if we encounter the `test_reductions_2D` error 

<details>
<summary>Traceback:</summary>

```
____________________________ test_reductions_2D[f4] ____________________________
[gw3] linux -- Python 3.8.16 /usr/share/miniconda3/envs/test-environment/bin/python3.8

dtype = 'f4'

    @pytest.mark.slow
    @pytest.mark.parametrize("dtype", ["f4", "i4"])
    def test_reductions_2D(dtype):
        x = np.arange(1, 122).reshape((11, 11)).astype(dtype)
        a = da.from_array(x, chunks=(4, 4))
    
        b = a.sum(keepdims=True)
        assert b.__dask_keys__() == [[(b.name, 0, 0)]]
    
        reduction_2d_test(da.sum, a, np.sum, x)
        reduction_2d_test(da.mean, a, np.mean, x)
        reduction_2d_test(da.var, a, np.var, x, False)  # Difference in dtype algo
        reduction_2d_test(da.std, a, np.std, x, False)  # Difference in dtype algo
        reduction_2d_test(da.min, a, np.min, x, False)
        reduction_2d_test(da.max, a, np.max, x, False)
        reduction_2d_test(da.any, a, np.any, x, False)
        reduction_2d_test(da.all, a, np.all, x, False)
    
        reduction_2d_test(da.nansum, a, np.nansum, x)
>       reduction_2d_test(da.nanmean, a, np.mean, x)

dask/array/tests/test_reductions.py:219: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
dask/array/tests/test_reductions.py:158: in reduction_2d_test
    assert same_keys(da_func(darr, axis=1), da_func(darr, axis=1))
dask/array/reductions.py:734: in nanmean
    dt = getattr(np.mean(np.empty(shape=(1,), dtype=a.dtype)), "dtype", object)
<__array_function__ internals>:5: in mean
    ???
/usr/share/miniconda3/envs/test-environment/lib/python3.8/site-packages/numpy/core/fromnumeric.py:3440: in mean
    return _methods._mean(a, axis=axis, dtype=dtype,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

a = array([nan], dtype=float32), axis = None, dtype = None, out = None
keepdims = False

    def _mean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
        arr = asanyarray(a)
    
        is_float16_result = False
    
        rcount = _count_reduce_items(arr, axis, keepdims=keepdims, where=where)
        if rcount == 0 if where is True else umr_any(rcount == 0, axis=None):
            warnings.warn("Mean of empty slice.", RuntimeWarning, stacklevel=2)
    
        # Cast bool, unsigned int, and int to float64 by default
        if dtype is None:
            if issubclass(arr.dtype.type, (nt.integer, nt.bool_)):
                dtype = mu.dtype('f8')
            elif issubclass(arr.dtype.type, nt.float16):
                dtype = mu.dtype('f4')
                is_float16_result = True
    
>       ret = umr_sum(arr, axis, dtype, out, keepdims, where=where)
E       RuntimeWarning: invalid value encountered in reduce

/usr/share/miniconda3/envs/test-environment/lib/python3.8/site-packages/numpy/core/_methods.py:179: RuntimeWarning
```

</details>

EDIT: Also xref https://github.com/dask/dask/issues/8892, which is related