### PR TITLE
Have codecov wait for more builds before reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ coverage:
   # but it is. Here we set a minimum number of builds before notifying in the
   # hopes that it will stop this behavior.
   notify:
-    after_n_builds: 3
+    after_n_builds: 10
 
   status:
     project:


### PR DESCRIPTION
I've noticed codecov is reporting a red "X" prematurely and then, after more CI builds finish with coverage reports, coverage changes to a green check. Let's bump the number of builds we have codecov wait for to avoid a premature red "X". 

xref https://github.com/dask/dask/pull/9031

EDIT: FWIW we recently starting running coverage on our `mindeps` CI jobs which is what I think caused the change in behavior here 