### PR TITLE
Raise an error with `dataframe.convert_string=True` and `pandas<2.0`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -405,6 +405,11 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
                     "Using dask's `dataframe.convert_string` configuration "
                     "option requires `pyarrow` to be installed."
                 )
+            if not PANDAS_GT_200:
+                raise RuntimeError(
+                    "Using dask's `dataframe.convert_string` configuration "
+                    "option requires `pandas>=2.0` to be installed."
+                )
 
             from dask.dataframe._pyarrow import (
                 is_object_string_dataframe,

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -17,7 +17,7 @@ from dask.base import compute_as_if_collection
 from dask.bytes.core import read_bytes
 from dask.bytes.utils import compress
 from dask.core import flatten
-from dask.dataframe._compat import tm
+from dask.dataframe._compat import PANDAS_GT_200, tm
 from dask.dataframe.io.csv import (
     _infer_block_size,
     auto_blocksize,
@@ -360,6 +360,9 @@ def test_read_csv(dd_read, pd_read, text, sep):
         assert_eq(result, pd_read(fn, sep=sep))
 
 
+@pytest.mark.skipif(
+    not PANDAS_GT_200, reason="dataframe.convert_string requires pandas>=2.0"
+)
 def test_read_csv_convert_string_config():
     pytest.importorskip("pyarrow", reason="Requires pyarrow strings")
     with filetext(csv_text) as fn:

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -9,7 +9,7 @@ import dask.array as da
 import dask.dataframe as dd
 from dask import config
 from dask.blockwise import Blockwise
-from dask.dataframe._compat import tm
+from dask.dataframe._compat import PANDAS_GT_200, tm
 from dask.dataframe.io.io import _meta_from_array
 from dask.dataframe.optimize import optimize
 from dask.dataframe.utils import assert_eq
@@ -307,6 +307,23 @@ def test_from_pandas_convert_string_config():
     df_pyarrow.index = df_pyarrow.index.astype("string[pyarrow]")
     assert_eq(s_pyarrow, ds)
     assert_eq(df_pyarrow, ddf)
+
+
+@pytest.mark.skipif(PANDAS_GT_200, reason="Requires pandas<2.0")
+def test_from_pandas_convert_string_config_raises():
+    df = pd.DataFrame(
+        {
+            "x": [1, 2, 3, 4],
+            "y": [5.0, 6.0, 7.0, 8.0],
+            "z": ["foo", "bar", "ricky", "bobby"],
+        },
+        index=["a", "b", "c", "d"],
+    )
+    with dask.config.set({"dataframe.convert_string": True}):
+        with pytest.raises(
+            RuntimeError, match="requires `pandas>=2.0` to be installed"
+        ):
+            dd.from_pandas(df, npartitions=2)
 
 
 @pytest.mark.gpu

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4654,7 +4654,9 @@ def test_select_filtered_column(tmp_path, engine):
 
 @PYARROW_MARK
 @pytest.mark.parametrize("convert_string", [True, False])
-@pytest.mark.skipif(not PANDAS_GT_150, reason="requires pd.ArrowDtype")
+@pytest.mark.skipif(
+    not PANDAS_GT_200, reason="dataframe.convert_string requires pandas>=2.0"
+)
 def test_read_parquet_convert_string(tmp_path, convert_string, engine):
     df = pd.DataFrame(
         {"A": ["def", "abc", "ghi"], "B": [5, 2, 3], "C": ["x", "y", "z"]}
@@ -4676,7 +4678,9 @@ def test_read_parquet_convert_string(tmp_path, convert_string, engine):
 
 
 @PYARROW_MARK
-@pytest.mark.skipif(not PANDAS_GT_150, reason="requires pd.ArrowDtype")
+@pytest.mark.skipif(
+    not PANDAS_GT_200, reason="dataframe.convert_string requires pandas>=2.0"
+)
 def test_read_parquet_convert_string_nullable_mapper(tmp_path, engine):
     """Make sure that when convert_string, use_nullable_dtypes and types_mapper are set,
     all three are used."""
@@ -4717,6 +4721,9 @@ def test_read_parquet_convert_string_nullable_mapper(tmp_path, engine):
 
 
 @FASTPARQUET_MARK
+@pytest.mark.skipif(
+    not PANDAS_GT_200, reason="dataframe.convert_string requires pandas>=2.0"
+)
 def test_read_parquet_convert_string_fastparquet_warns(tmp_path):
     df = pd.DataFrame({"A": ["def", "abc", "ghi"], "B": [5, 2, 3]})
     outfile = tmp_path / "out.parquet"


### PR DESCRIPTION
Follow-up for https://github.com/dask/dask/pull/10000.

Part of https://github.com/dask/dask/issues/9946.

Raise an error if `dataframe.convert_string` is set, and `pandas<2.0`. Lots of things are not supported for `pyarrow` strings on lower `pandas` versions.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
