### PR TITLE
Revert "Prepare drop packunpack (#9994)"

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -470,13 +470,7 @@ class Layer(Mapping):
 
     def __reduce__(self):
         """Default serialization implementation, which materializes the Layer"""
-        return (
-            MaterializedLayer,
-            (
-                dict(self),
-                dict(self.annotations or {}),
-            ),
-        )
+        return (MaterializedLayer, (dict(self),))
 
     def __copy__(self):
         """Default shallow copy implementation"""

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -1,5 +1,4 @@
 import os
-import pickle
 import xml.etree.ElementTree
 from collections.abc import Set
 
@@ -179,22 +178,6 @@ def test_multiple_annotations():
     assert alayer.annotations == {"resources": {"GPU": 1}, "block_id": annot_map_fn}
     assert blayer.annotations == {"block_id": annot_map_fn}
     assert clayer.annotations is None
-
-
-def test_annotations_pickle_roundtrip():
-    layer = MaterializedLayer({"n": 42}, annotations={"workers": ("alice",)})
-    layer2 = pickle.loads(pickle.dumps(layer))
-    assert layer.annotations == layer2.annotations
-
-
-def test_annotations_roundtrip_HLG():
-    da = pytest.importorskip("dask.array")
-    with dask.annotate(block_id=annot_map_fn):
-        with dask.annotate(resources={"GPU": 1}):
-            A = da.ones((10, 10), chunks=(5, 5))
-    A2 = pickle.loads(pickle.dumps(A))
-    for orig, roundtrip in zip(A.dask.layers.values(), A2.dask.layers.values()):
-        assert orig.annotations == roundtrip.annotations
 
 
 def test_annotation_pack_unpack():


### PR DESCRIPTION
This reverts commit 4574dc5a0fe2745f411fc4b4cf6ff47d85b63f47.

Apparently there was a significant performance regression with https://github.com/dask/dask/pull/9994 so I suggest reverting it until we figured this out.

cc @hendrikmakait 