### PR TITLE
Support pyarrow strings in `MultiIndex`

### DIFF
--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -9,6 +9,7 @@ _np_version = parse_version(np.__version__)
 _numpy_122 = _np_version >= parse_version("1.22.0")
 _numpy_123 = _np_version >= parse_version("1.23.0")
 _numpy_124 = _np_version >= parse_version("1.24.0")
+_numpy_125 = _np_version.release >= (1, 25, 0)
 
 
 # Taken from scikit-learn:

--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -73,17 +73,15 @@ def to_pyarrow_string(df):
         df.index
     ):
         if isinstance(df.index, pd.MultiIndex):
-            levels_to_set = []
-            level_indices = []
-            for i, level in enumerate(df.index.levels):
-                if is_object_string_dtype(level.dtype):
-                    levels_to_set.append(level.astype(pd.StringDtype("pyarrow")))
-                    level_indices.append(i)
-            if levels_to_set:
-                # set verify_integrity=False to preserve index codes
-                df.index = df.index.set_levels(
-                    levels_to_set, level=level_indices, verify_integrity=False
-                )
+            levels = {
+                i: level.astype(pd.StringDtype("pyarrow"))
+                for i, level in enumerate(df.index.levels)
+                if is_object_string_dtype(level.dtype)
+            }
+            # set verify_integrity=False to preserve index codes
+            df.index = df.index.set_levels(
+                levels.values(), level=levels.keys(), verify_integrity=False
+            )
         else:
             df.index = df.index.astype(pd.StringDtype("pyarrow"))
     return df

--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -76,7 +76,10 @@ def to_pyarrow_string(df):
             for i, level in enumerate(df.index.levels):
                 if is_object_string_dtype(level.dtype):
                     new_level = level.astype(pd.StringDtype("pyarrow"))
-                    df.index = df.index.set_levels(new_level, level=i)
+                    # set verify_integrity=False to preserve index codes
+                    df.index = df.index.set_levels(
+                        new_level, level=i, verify_integrity=False
+                    )
         else:
             df.index = df.index.astype(pd.StringDtype("pyarrow"))
     return df

--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -73,13 +73,17 @@ def to_pyarrow_string(df):
         df.index
     ):
         if isinstance(df.index, pd.MultiIndex):
+            levels_to_set = []
+            level_indices = []
             for i, level in enumerate(df.index.levels):
                 if is_object_string_dtype(level.dtype):
-                    new_level = level.astype(pd.StringDtype("pyarrow"))
-                    # set verify_integrity=False to preserve index codes
-                    df.index = df.index.set_levels(
-                        new_level, level=i, verify_integrity=False
-                    )
+                    levels_to_set.append(level.astype(pd.StringDtype("pyarrow")))
+                    level_indices.append(i)
+            if levels_to_set:
+                # set verify_integrity=False to preserve index codes
+                df.index = df.index.set_levels(
+                    levels_to_set, level=level_indices, verify_integrity=False
+                )
         else:
             df.index = df.index.astype(pd.StringDtype("pyarrow"))
     return df

--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -32,13 +32,9 @@ def is_object_string_dtype(dtype):
 
 
 def is_object_string_index(x):
-    return (
-        isinstance(x, pd.Index)
-        and is_object_string_dtype(x.dtype)
-        and not isinstance(
-            x, pd.MultiIndex
-        )  # Ignoring MultiIndex for now. Can be included in follow-up work.
-    )
+    if isinstance(x, pd.MultiIndex):
+        return any(is_object_string_index(level) for level in x.levels)
+    return isinstance(x, pd.Index) and is_object_string_dtype(x.dtype)
 
 
 def is_object_string_series(x):
@@ -76,5 +72,11 @@ def to_pyarrow_string(df):
     if (is_dataframe_like(df) or is_series_like(df)) and is_object_string_index(
         df.index
     ):
-        df.index = df.index.astype(pd.StringDtype("pyarrow"))
+        if isinstance(df.index, pd.MultiIndex):
+            for i, level in enumerate(df.index.levels):
+                if is_object_string_dtype(level.dtype):
+                    new_level = level.astype(pd.StringDtype("pyarrow"))
+                    df.index = df.index.set_levels(new_level, level=i)
+        else:
+            df.index = df.index.astype(pd.StringDtype("pyarrow"))
     return df

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -685,8 +685,9 @@ def test_use_nullable_dtypes_with_types_mapper(tmp_path, engine):
         arrow_to_pandas={"types_mapper": types_mapper.get},
     )
     expected = df.astype({"a": pd.Float32Dtype()})
-    if pyarrow_version >= parse_version("12.0.0.dev216"):
-        # https://github.com/apache/arrow/issues/34283 is fixed in nightly
+    if pyarrow_version.major >= 12:
+        # types_mapper impacts index
+        # https://github.com/apache/arrow/issues/34283
         expected.index = expected.index.astype(pd.Float32Dtype())
     assert_eq(result, expected)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -36,8 +36,11 @@ else:
 
 try:
     import pyarrow as pa
+
+    pyarrow_version = parse_version(pa.__version__)
 except ImportError:
     pa = False
+    pyarrow_version = parse_version("0")
 
 try:
     import pyarrow.parquet as pq
@@ -682,6 +685,9 @@ def test_use_nullable_dtypes_with_types_mapper(tmp_path, engine):
         arrow_to_pandas={"types_mapper": types_mapper.get},
     )
     expected = df.astype({"a": pd.Float32Dtype()})
+    if pyarrow_version >= parse_version("12.0.0.dev216"):
+        # https://github.com/apache/arrow/issues/34283 is fixed in nightly
+        expected.index = expected.index.astype(pd.Float32Dtype())
     assert_eq(result, expected)
 
 

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -869,7 +869,10 @@ def test_reductions_out(frame, axis, out, redfunc):
     if out is not None:
         dsk_out = dd.from_pandas(out, 3)
 
-    np_redfunc = getattr(np, redfunc)
+    # `product` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0.
+    # Please use `prod` instead
+    np_functions = {"product": "prod"}
+    np_redfunc = getattr(np, np_functions.get(redfunc, redfunc))
     pd_redfunc = getattr(frame.__class__, redfunc)
     dsk_redfunc = getattr(dsk_in.__class__, redfunc)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2211,7 +2211,7 @@ def test_repartition_partition_size(use_index, n, partition_size, transform):
     a = dd.from_pandas(df, npartitions=n, sort=use_index)
     b = a.repartition(partition_size=partition_size)
     assert_eq(a, b, check_divisions=False)
-    assert np.alltrue(b.map_partitions(total_mem_usage, deep=True).compute() <= 1024)
+    assert np.all(b.map_partitions(total_mem_usage, deep=True).compute() <= 1024)
     parts = dask.get(b.dask, b.__dask_keys__())
     assert all(map(len, parts))
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3235,7 +3235,6 @@ def test_groupby_with_pd_grouper():
 # TODO: Remove filter once https://github.com/pandas-dev/pandas/issues/46814 is resolved
 @pytest.mark.filterwarnings("ignore:Invalid value encountered:RuntimeWarning")
 @pytest.mark.parametrize("operation", ["head", "tail"])
-@pytest.mark.xfail_with_pyarrow_strings  # https://github.com/pandas-dev/pandas/issues/51734
 def test_groupby_empty_partitions_with_rows_operation(operation):
     df = pd.DataFrame(
         data=[

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3209,10 +3209,7 @@ def test_empty_partitions_with_value_counts(by):
         ],
         columns=["A", "B", "C"],
     )
-    if pyarrow_strings_enabled():
-        # have to convert before value_counts, to
-        # count pyarrow string vs objects
-        df = to_pyarrow_string(df)
+    df = df.convert_dtypes()
     expected = df.groupby(by).C.value_counts()
     ddf = dd.from_pandas(df, npartitions=3)
     actual = ddf.groupby(by).C.value_counts()

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -20,9 +20,15 @@ from dask.dataframe._compat import (
     check_numeric_only_deprecation,
     tm,
 )
+from dask.dataframe._pyarrow import to_pyarrow_string
 from dask.dataframe.backends import grouper_dispatch
 from dask.dataframe.groupby import NUMERIC_ONLY_NOT_IMPLEMENTED
-from dask.dataframe.utils import assert_dask_graph, assert_eq, assert_max_deps
+from dask.dataframe.utils import (
+    assert_dask_graph,
+    assert_eq,
+    assert_max_deps,
+    pyarrow_strings_enabled,
+)
 from dask.utils import M
 from dask.utils_test import _check_warning, hlg_layer
 
@@ -996,7 +1002,6 @@ def test_groupby_apply_tasks(shuffle_method):
         assert not any("partd" in k[0] for k in b.dask)
 
 
-@pytest.mark.xfail_with_pyarrow_strings  # TODO: https://github.com/dask/dask/issues/10025
 def test_groupby_multiprocessing():
     df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": ["1", "1", "a", "a", "a"]})
 
@@ -2866,7 +2871,6 @@ def test_groupby_grouper_dispatch(key):
     assert_eq(expect, got)
 
 
-@pytest.mark.xfail_with_pyarrow_strings  # TODO: https://github.com/dask/dask/issues/10025
 @pytest.mark.parametrize("sort", [True, False])
 def test_groupby_dropna_with_agg(sort):
     # https://github.com/dask/dask/issues/6986
@@ -2964,19 +2968,8 @@ def test_groupby_large_ints_exception(backend):
     )
 
 
+@pytest.mark.parametrize("by", ["a", "b", "c", ["a", "b"], ["a", "c"]])
 # TODO: Remove the need for `strict=False` below
-@pytest.mark.parametrize(
-    "by",
-    [
-        "a",
-        "b",
-        "c",
-        ["a", "b"],
-        pytest.param(
-            ["a", "c"], marks=pytest.mark.xfail_with_pyarrow_strings
-        ),  # TODO: https://github.com/dask/dask/issues/10025
-    ],
-)
 @pytest.mark.parametrize(
     "agg",
     [
@@ -3198,7 +3191,6 @@ def test_series_named_agg(shuffle, agg):
 
 
 @pytest.mark.parametrize("by", ["A", ["A", "B"]])
-@pytest.mark.xfail_with_pyarrow_strings  # https://github.com/dask/dask/issues/10025
 def test_empty_partitions_with_value_counts(by):
     # https://github.com/dask/dask/issues/7065
     df = pd.DataFrame(
@@ -3215,6 +3207,10 @@ def test_empty_partitions_with_value_counts(by):
         ],
         columns=["A", "B", "C"],
     )
+    if pyarrow_strings_enabled():
+        # have to convert before value_counts, to
+        # count pyarrow string vs objects
+        df = to_pyarrow_string(df)
     expected = df.groupby(by).C.value_counts()
     ddf = dd.from_pandas(df, npartitions=3)
     actual = ddf.groupby(by).C.value_counts()
@@ -3331,15 +3327,7 @@ def test_groupby_None_split_out_warns():
         ddf.groupby("a").agg({"b": "max"}, split_out=None)
 
 
-@pytest.mark.parametrize(
-    "by",
-    [
-        "key1",
-        pytest.param(
-            ["key1", "key2"], marks=pytest.mark.xfail_with_pyarrow_strings
-        ),  # TODO: https://github.com/dask/dask/issues/10025
-    ],
-)
+@pytest.mark.parametrize("by", ["key1", ["key1", "key2"]])
 @pytest.mark.parametrize(
     "slice_key",
     [

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3209,7 +3209,8 @@ def test_empty_partitions_with_value_counts(by):
         ],
         columns=["A", "B", "C"],
     )
-    df = df.convert_dtypes()
+    if pyarrow_strings_enabled():
+        df = df.convert_dtypes()
     expected = df.groupby(by).C.value_counts()
     ddf = dd.from_pandas(df, npartitions=3)
     actual = ddf.groupby(by).C.value_counts()

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1007,9 +1007,11 @@ def test_groupby_multiprocessing():
 
     ddf = dd.from_pandas(df, npartitions=3)
     expected = df.groupby("B").apply(lambda x: x)
+    # since we explicitly provide meta, we have to convert it to pyarrow strings
+    meta = to_pyarrow_string(expected) if pyarrow_strings_enabled() else expected
     with dask.config.set(scheduler="processes"):
         assert_eq(
-            ddf.groupby("B").apply(lambda x: x, meta=expected),
+            ddf.groupby("B").apply(lambda x: x, meta=meta),
             expected,
         )
 

--- a/dask/dataframe/tests/test_pyarrow.py
+++ b/dask/dataframe/tests/test_pyarrow.py
@@ -94,6 +94,36 @@ def test_is_object_string_dtype(dtype, expected):
         (pd.Index([1, 2], dtype=int), False),
         (pd.Index([1, 2], dtype=float), False),
         (pd.Series(["a", "b"], dtype=object), False),
+        (
+            pd.MultiIndex.from_arrays(
+                [
+                    pd.Index(["a", "a"], dtype="string[pyarrow]"),
+                    pd.Index(["a", "b"], dtype=object),
+                ]
+            ),
+            True,
+        ),
+        (
+            pd.MultiIndex.from_arrays(
+                [
+                    pd.Index(["a", "a"], dtype="string[pyarrow]"),
+                    pd.Index(["a", "b"], dtype="string[pyarrow]"),
+                ]
+            ),
+            False,
+        ),
+        (
+            pd.MultiIndex.from_arrays(
+                [pd.Index(["a", "a"], dtype=object), pd.Index([1, 2], dtype=int)]
+            ),
+            True,
+        ),
+        (
+            pd.MultiIndex.from_arrays(
+                [pd.Index([1, 1], dtype=int), pd.Index([1, 2], dtype=float)]
+            ),
+            False,
+        ),
     ],
 )
 def test_is_object_string_index(index, expected):
@@ -151,6 +181,30 @@ def test_is_object_string_series(series, expected):
         ),
         (pd.Series({"x": ["a", "b"]}, dtype=object), False),
         (pd.Index({"x": ["a", "b"]}, dtype=object), False),
+        (
+            pd.MultiIndex.from_arrays(
+                [pd.Index(["a", "a"], dtype=object), pd.Index(["a", "b"], dtype=object)]
+            ),
+            False,
+        ),
+        (
+            pd.MultiIndex.from_arrays(
+                [
+                    pd.Index(["a", "a"], dtype="string[python]"),
+                    pd.Index(["a", "b"], dtype="string[pyarrow]"),
+                ]
+            ),
+            False,
+        ),
+        (
+            pd.MultiIndex.from_arrays(
+                [
+                    pd.Index(["a", "a"], dtype=object),
+                    pd.Index(["a", "b"], dtype="string[pyarrow]"),
+                ]
+            ),
+            False,
+        ),
     ],
 )
 def tests_is_object_string_dataframe(series, expected):

--- a/dask/dataframe/tests/test_pyarrow.py
+++ b/dask/dataframe/tests/test_pyarrow.py
@@ -103,6 +103,7 @@ def test_is_object_string_dtype(dtype, expected):
             ),
             True,
         ),
+        # Prior to pandas=1.4, Index couldn't contain extension dtypes
         (
             pd.MultiIndex.from_arrays(
                 [
@@ -110,7 +111,7 @@ def test_is_object_string_dtype(dtype, expected):
                     pd.Index(["a", "b"], dtype="string[pyarrow]"),
                 ]
             ),
-            False,
+            False if PANDAS_GT_140 else True,
         ),
         (
             pd.MultiIndex.from_arrays(

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -534,7 +534,6 @@ def test_rolling_numba_engine():
     )
 
 
-@pytest.mark.xfail_with_pyarrow_strings  # TODO: https://github.com/dask/dask/issues/10025
 def test_groupby_rolling():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
Support for pyarrow strings in `MultiIndex`.

- [x] Closes https://github.com/dask/dask/issues/10025
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
