### PR TITLE
Fix handling of missing min/max parquet statistics during filtering

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1361,7 +1361,7 @@ def apply_filters(parts, statistics, filters):
                         missing_stats = True
                         warnings.warn(
                             f"Column {column} is missing min/max statistics. "
-                            f"Do not expect proper row-group filtering."
+                            f"Do not expect effective predicate pushdown!"
                         )
 
                     if (


### PR DESCRIPTION
Tweaks logic in `apply_filters`, and improves test coverage for filtering on columns with missing min/max statistics.

- [x] Closes #9975
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
