### PR TITLE
Avoid using `dd.shuffle` in groupby-apply

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1730,15 +1730,12 @@ class _GroupBy:
 
         if isinstance(self.by, DataFrame):  # add by columns to dataframe
             df2 = df.assign(**{"_by_" + c: self.by[c] for c in self.by.columns})
-            by = self.by
         elif isinstance(self.by, Series):
             df2 = df.assign(_by=self.by)
-            by = self.by
         else:
             df2 = df
-            by = self.by
 
-        df3 = df2.shuffle(by)  # shuffle dataframe and index
+        df3 = df2.shuffle(self.by)  # shuffle dataframe and index
 
         if isinstance(self.by, DataFrame):
             # extract by from dataframe

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1736,7 +1736,7 @@ class _GroupBy:
             by = self.by
         else:
             df2 = df
-            by = df._select_columns_or_index(self.by)
+            by = self.by
 
         df3 = df2.shuffle(by)  # shuffle dataframe and index
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -32,7 +32,6 @@ from dask.dataframe.core import (
 )
 from dask.dataframe.dispatch import grouper_dispatch
 from dask.dataframe.methods import concat, drop_columns
-from dask.dataframe.shuffle import shuffle
 from dask.dataframe.utils import (
     insert_meta_param_description,
     is_dataframe_like,
@@ -1739,7 +1738,7 @@ class _GroupBy:
             df2 = df
             by = df._select_columns_or_index(self.by)
 
-        df3 = shuffle(df2, by)  # shuffle dataframe and index
+        df3 = df2.shuffle(by)  # shuffle dataframe and index
 
         if isinstance(self.by, DataFrame):
             # extract by from dataframe

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1735,7 +1735,7 @@ class _GroupBy:
         else:
             df2 = df
 
-        df3 = df2.shuffle(self.by)  # shuffle dataframe and index
+        df3 = df2.shuffle(on=self.by)  # shuffle dataframe and index
 
         if isinstance(self.by, DataFrame):
             # extract by from dataframe

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -401,6 +401,7 @@ def shuffle(
     shuffle_disk
     """
     list_like = pd.api.types.is_list_like(index) and not is_dask_collection(index)
+    shuffle = shuffle or get_default_shuffle_algorithm()
     if shuffle == "tasks" and (isinstance(index, str) or list_like):
         # Avoid creating the "_partitions" column if possible.
         # We currently do this if the user is passing in

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2871,6 +2871,10 @@ def test_groupby_apply_cudf():
     # Check that groupby-apply is consistent between
     # 'pandas' and 'cudf' backends, and that the
     # implied shuffle works for the `cudf` backend
+
+    # Make sure test is skipped without dask_cudf
+    pytest.importorskip("dask_cudf")  # noqa: F841
+
     df = pd.DataFrame({"a": [1, 2, 3, 1, 2, 3], "b": [4, 5, 6, 7, 8, 9]})
     ddf = dd.from_pandas(df, npartitions=2)
     dcdf = ddf.to_backend("cudf")

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3004,7 +3004,6 @@ def test_groupby_apply_cudf(group_keys):
     assert_eq(res_dd, res_dc)
 
 
-@pytest.mark.xfail_with_pyarrow_strings  # TODO: https://github.com/dask/dask/issues/10025
 @pytest.mark.parametrize("sort", [True, False])
 def test_groupby_dropna_with_agg(sort):
     # https://github.com/dask/dask/issues/6986

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2874,7 +2874,19 @@ def test_groupby_grouper_dispatch(key):
 
 
 @pytest.mark.gpu
-@pytest.mark.parametrize("group_keys", [True, False])
+@pytest.mark.parametrize(
+    "group_keys",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not PANDAS_GT_150,
+                reason="cudf and pandas behave differently",
+            ),
+        ),
+        False,
+    ],
+)
 def test_groupby_apply_cudf(group_keys):
     # Check that groupby-apply is consistent between
     # 'pandas' and 'cudf' backends, and that the
@@ -2894,7 +2906,7 @@ def test_groupby_apply_cudf(group_keys):
     dc_meta = dcdf._meta.groupby("a", group_keys=group_keys).apply(func)
     res_dc = dcdf.groupby("a", group_keys=group_keys).apply(func, meta=dc_meta)
 
-    # Compute required for MultiIndex result
+    # Compute required for ordering and MultiIndex validation
     res_dd = res_dd.compute()
     res_dc = res_dc.compute()
     assert_eq(res_pd, res_dd)


### PR DESCRIPTION
Some RAPIDS developers have been seing p2p errors while using the "cudf" backend (which does not support the p2p method just yet). This PR tweaks `_GroupBy._shuffle` to effectively use `self.obj.shuffle` instead of `dd.shuffle` to make sure `dask_cudf` has the opportunity to set the appropriate default algorithm.

cc @charlesbluca 
