### PR TITLE
[pyarrow strings] Fix `Decimal` roundtip

### DIFF
--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -41,7 +41,7 @@ def is_object_string_dtype(dtype, sample=None):
     return (
         pd.api.types.is_string_dtype(dtype)
         and not is_pyarrow_string_dtype(dtype)
-        and not pd.api.types.is_numeric_dtype(dtype)
+        and not pd.api.types.is_dtype_equal(dtype, "decimal")
         and inferred_dtype in ("mixed", "string")
     )
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4051,7 +4051,6 @@ def test_dir_filter(tmpdir, engine):
 
 
 @PYARROW_MARK
-@pytest.mark.xfail_with_pyarrow_strings  # https://github.com/dask/dask/issues/10029
 def test_roundtrip_decimal_dtype(tmpdir):
     # https://github.com/dask/dask/issues/6948
     tmpdir = str(tmpdir)


### PR DESCRIPTION
Part of https://github.com/dask/dask/issues/10029.

Attempt to fix the `decimal.Decimal` roundtrip with `pyarrow` strings:

```
FAILED dask/dataframe/io/tests/test_parquet.py::test_roundtrip_decimal_dtype - AssertionError: DataFrame.iloc[:, 1] (column name="col1") NA mask are different
```

This will most likely need more work. To properly determine whether we should or should not convert an `object` column to `string[pyarrow]`, `dtype` is not enough. We would need to propagate a sample of data throughout the multiple ways we may use to create a dataframe, i.e. from collections, `from_pandas`, from csv, parquet. json etc, to see what actual data type is stored within.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
