### PR TITLE
Temporarily `xfail` `test_upstream_packages_installed`

### DIFF
--- a/dask/tests/test_ci.py
+++ b/dask/tests/test_ci.py
@@ -5,6 +5,7 @@ import pytest
 from packaging.version import Version
 
 
+@pytest.mark.xfail(reason="https://github.com/dask/dask/issues/9735", strict=False)
 @pytest.mark.skipif(
     not os.environ.get("UPSTREAM_DEV", False),
     reason="Only check for dev packages in `upstream` CI build",


### PR DESCRIPTION
This test is known to not be robust and is occasionally failing in the upstream and pyarrow CI builds. Let's `xfail` for now, but keep https://github.com/dask/dask/issues/9735 open 