### PR TITLE
[pyarrow strings] Fix `test_set_index_on_empty`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -527,7 +527,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
             # sortedness check, since the order is dtype dependent
             index_dtype = getattr(self._meta, "index", self._meta).dtype
             if not (is_categorical_dtype(index_dtype) and index_dtype.ordered):
-                if not all(pd.isna(v) for v in value) and value != tuple(sorted(value)):
+                if value != tuple(sorted(value)):
                     raise ValueError("divisions must be sorted")
 
         self._divisions = value

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -527,7 +527,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
             # sortedness check, since the order is dtype dependent
             index_dtype = getattr(self._meta, "index", self._meta).dtype
             if not (is_categorical_dtype(index_dtype) and index_dtype.ordered):
-                if value != tuple(sorted(value)):
+                if not all(pd.isna(v) for v in value) and value != tuple(sorted(value)):
                     raise ValueError("divisions must be sorted")
 
         self._divisions = value

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -228,6 +228,11 @@ def set_index(
             df, index2, repartition, npartitions, upsample, partition_size
         )
 
+        if pd.isna(mins + maxes).all():
+            divisions = [np.nan] * len(divisions)
+            mins = [np.nan] * len(mins)
+            maxes = [np.nan] * len(maxes)
+
         if (
             mins == sorted(mins)
             and maxes == sorted(maxes)
@@ -845,6 +850,9 @@ def collect(p, part, meta, barrier_token):
 
 
 def set_partitions_pre(s, divisions, ascending=True, na_position="last"):
+    if pd.api.types.is_dtype_equal(divisions.dtype, "string"):
+        # with type "string" and pd.NA values, searchsorted will fail
+        divisions = divisions.astype(object)
     try:
         if ascending:
             partitions = divisions.searchsorted(s, side="right") - 1

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -228,6 +228,7 @@ def set_index(
             df, index2, repartition, npartitions, upsample, partition_size
         )
 
+        # pd.NA and None values are not sortable
         if pd.isna(mins + maxes).all():
             divisions = [np.nan] * len(divisions)
             mins = [np.nan] * len(mins)
@@ -375,7 +376,12 @@ def set_partition(
             column_dtype=df.columns.dtype,
         )
 
-    df4.divisions = tuple(methods.tolist(divisions))
+    # None and pd.NA values are not sortable
+    divisions = methods.tolist(divisions)
+    if pd.isna(divisions).all():
+        divisions = [np.nan] * len(divisions)
+
+    df4.divisions = tuple(divisions)
 
     return df4.map_partitions(M.sort_index)
 


### PR DESCRIPTION
Fixes a failure with pyarrow strings:

```
FAILED dask/dataframe/tests/test_shuffle.py::test_set_index_on_empty - TypeError: boolean value of NA is ambiguous
```

Part of https://github.com/dask/dask/issues/10029.

Follow-up for https://github.com/dask/dask/pull/10000.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
