### PR TITLE
Fix `test_melt` with `pyarrow` strings active

### DIFF
--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like, is_scalar
 
-from dask import config
+import dask
 from dask.dataframe import methods
 from dask.dataframe._compat import PANDAS_GT_200
 from dask.dataframe.core import DataFrame, Series, apply_concat_apply, map_partitions
@@ -360,7 +360,7 @@ def melt(
     from dask.dataframe.core import no_default
 
     # let pandas do upcasting as needed during melt
-    with config.set({"dataframe.convert_string": False}):
+    with dask.config.set({"dataframe.convert_string": False}):
         return frame.map_partitions(
             M.melt,
             meta=no_default,

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like, is_scalar
 
+from dask import config
 from dask.dataframe import methods
 from dask.dataframe._compat import PANDAS_GT_200
 from dask.dataframe.core import DataFrame, Series, apply_concat_apply, map_partitions
@@ -358,13 +359,15 @@ def melt(
 
     from dask.dataframe.core import no_default
 
-    return frame.map_partitions(
-        M.melt,
-        meta=no_default,
-        id_vars=id_vars,
-        value_vars=value_vars,
-        var_name=var_name,
-        value_name=value_name,
-        col_level=col_level,
-        token="melt",
-    )
+    # let pandas do upcasting as needed during melt
+    with config.set({"dataframe.convert_string": False}):
+        return frame.map_partitions(
+            M.melt,
+            meta=no_default,
+            id_vars=id_vars,
+            value_vars=value_vars,
+            var_name=var_name,
+            value_name=value_name,
+            col_level=col_level,
+            token="melt",
+        )

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1627,38 +1627,35 @@ def test_merge_by_multiple_columns(how, shuffle_method):
             )
 
 
-@pytest.mark.xfail_with_pyarrow_strings  # https://github.com/dask/dask/issues/10029
-def test_melt():
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        dict(id_vars="int"),
+        dict(value_vars="int"),
+        dict(value_vars=["obj", "int"], var_name="myvar"),
+        dict(id_vars="s1", value_vars=["obj", "int"], value_name="myval"),
+        dict(value_vars=["obj", "s1"]),
+        dict(value_vars=["s1", "s2"]),
+    ],
+)
+def test_melt(kwargs):
     pdf = pd.DataFrame(
-        {"A": list("abcd") * 5, "B": list("XY") * 10, "C": np.random.randn(20)}
+        {
+            "obj": list("abcd") * 5,
+            "s1": list("XY") * 10,
+            "s2": list("abcde") * 4,
+            "int": np.random.randn(20),
+        }
     )
+    pdf.s1 = pdf.s1.astype(pd.StringDtype("pyarrow"))
+    pdf.s2 = pdf.s2.astype(pd.StringDtype("pyarrow"))
+
     ddf = dd.from_pandas(pdf, 4)
 
-    list_eq(dd.melt(ddf), pd.melt(pdf))
-
-    list_eq(dd.melt(ddf, id_vars="C"), pd.melt(pdf, id_vars="C"))
-    list_eq(dd.melt(ddf, value_vars="C"), pd.melt(pdf, value_vars="C"))
-    list_eq(
-        dd.melt(ddf, value_vars=["A", "C"], var_name="myvar"),
-        pd.melt(pdf, value_vars=["A", "C"], var_name="myvar"),
-    )
-    list_eq(
-        dd.melt(ddf, id_vars="B", value_vars=["A", "C"], value_name="myval"),
-        pd.melt(pdf, id_vars="B", value_vars=["A", "C"], value_name="myval"),
-    )
-
+    list_eq(dd.melt(ddf, **kwargs), pd.melt(pdf, **kwargs))
     # test again as DataFrame method
-    list_eq(ddf.melt(), pdf.melt())
-    list_eq(ddf.melt(id_vars="C"), pdf.melt(id_vars="C"))
-    list_eq(ddf.melt(value_vars="C"), pdf.melt(value_vars="C"))
-    list_eq(
-        ddf.melt(value_vars=["A", "C"], var_name="myvar"),
-        pdf.melt(value_vars=["A", "C"], var_name="myvar"),
-    )
-    list_eq(
-        ddf.melt(id_vars="B", value_vars=["A", "C"], value_name="myval"),
-        pdf.melt(id_vars="B", value_vars=["A", "C"], value_name="myval"),
-    )
+    list_eq(ddf.melt(**kwargs), pdf.melt(**kwargs))
 
 
 def test_cheap_inner_merge_with_pandas_object():

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -28,6 +28,11 @@ from dask.dataframe.utils import (
 )
 from dask.utils_test import hlg_layer, hlg_layer_topological
 
+try:
+    import pyarrow as pa
+except ImportError:
+    pa = None
+
 
 def test_align_partitions():
     A = pd.DataFrame(
@@ -1640,7 +1645,6 @@ def test_merge_by_multiple_columns(how, shuffle_method):
     ],
 )
 def test_melt(kwargs):
-    pytest.importorskip("pyarrow")
     pdf = pd.DataFrame(
         {
             "obj": list("abcd") * 5,
@@ -1649,7 +1653,10 @@ def test_melt(kwargs):
             "int": np.random.randn(20),
         }
     )
-    pdf = pdf.astype({"s1": "string[pyarrow]", "s2": "string[pyarrow]"})
+    if pa:
+        # If pyarrow is installed, test that `string[pyarrow]` dtypes
+        # give the same result with `pandas` and `dask`
+        pdf = pdf.astype({"s1": "string[pyarrow]", "s2": "string[pyarrow]"})
 
     ddf = dd.from_pandas(pdf, 4)
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1640,6 +1640,7 @@ def test_merge_by_multiple_columns(how, shuffle_method):
     ],
 )
 def test_melt(kwargs):
+    pytest.importorskip("pyarrow")
     pdf = pd.DataFrame(
         {
             "obj": list("abcd") * 5,
@@ -1648,8 +1649,7 @@ def test_melt(kwargs):
             "int": np.random.randn(20),
         }
     )
-    pdf.s1 = pdf.s1.astype(pd.StringDtype("pyarrow"))
-    pdf.s2 = pdf.s2.astype(pd.StringDtype("pyarrow"))
+    pdf = pdf.astype({"s1": "string[pyarrow]", "s2": "string[pyarrow]"})
 
     ddf = dd.from_pandas(pdf, 4)
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -216,6 +216,17 @@ def list_eq(aa, bb):
         b = bb
     tm.assert_index_equal(a.columns, b.columns)
 
+    import dask
+
+    if dask.config.get("dataframe.convert_string"):
+        from dask.dataframe._pyarrow import to_pyarrow_string
+
+        if isinstance(a, (pd.DataFrame, pd.Series, pd.Index)):
+            a = to_pyarrow_string(a)
+
+        if isinstance(b, (pd.DataFrame, pd.Series, pd.Index)):
+            b = to_pyarrow_string(b)
+
     if isinstance(a, pd.DataFrame):
         av = a.sort_values(list(a.columns)).values
         bv = b.sort_values(list(b.columns)).values
@@ -1627,38 +1638,30 @@ def test_merge_by_multiple_columns(how, shuffle_method):
             )
 
 
-@pytest.mark.xfail_with_pyarrow_strings  # https://github.com/dask/dask/issues/10029
-def test_melt():
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(),
+        dict(id_vars="C"),
+        dict(value_vars="C"),
+        dict(value_vars=["A", "C"], var_name="myvar"),
+        dict(id_vars="B", value_vars=["A", "C"], value_name="myval"),
+    ],
+)
+def test_melt(kwargs):
     pdf = pd.DataFrame(
         {"A": list("abcd") * 5, "B": list("XY") * 10, "C": np.random.randn(20)}
     )
     ddf = dd.from_pandas(pdf, 4)
 
-    list_eq(dd.melt(ddf), pd.melt(pdf))
-
-    list_eq(dd.melt(ddf, id_vars="C"), pd.melt(pdf, id_vars="C"))
-    list_eq(dd.melt(ddf, value_vars="C"), pd.melt(pdf, value_vars="C"))
-    list_eq(
-        dd.melt(ddf, value_vars=["A", "C"], var_name="myvar"),
-        pd.melt(pdf, value_vars=["A", "C"], var_name="myvar"),
-    )
-    list_eq(
-        dd.melt(ddf, id_vars="B", value_vars=["A", "C"], value_name="myval"),
-        pd.melt(pdf, id_vars="B", value_vars=["A", "C"], value_name="myval"),
-    )
+    expected = pd.melt(pdf, **kwargs)
+    actual = dd.melt(ddf, **kwargs)
+    list_eq(actual, expected)
 
     # test again as DataFrame method
-    list_eq(ddf.melt(), pdf.melt())
-    list_eq(ddf.melt(id_vars="C"), pdf.melt(id_vars="C"))
-    list_eq(ddf.melt(value_vars="C"), pdf.melt(value_vars="C"))
-    list_eq(
-        ddf.melt(value_vars=["A", "C"], var_name="myvar"),
-        pdf.melt(value_vars=["A", "C"], var_name="myvar"),
-    )
-    list_eq(
-        ddf.melt(id_vars="B", value_vars=["A", "C"], value_name="myval"),
-        pdf.melt(id_vars="B", value_vars=["A", "C"], value_name="myval"),
-    )
+    expected = pdf.melt(**kwargs)
+    actual = ddf.melt(**kwargs)
+    list_eq(actual, expected)
 
 
 def test_cheap_inner_merge_with_pandas_object():

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -547,10 +547,7 @@ def _maybe_convert_string(a, b):
 
 
 def assert_eq_dtypes(a, b):
-    (
-        a,
-        b,
-    ) = _maybe_convert_string(a, b)
+    a, b = _maybe_convert_string(a, b)
     tm.assert_series_equal(a.dtypes.value_counts(), b.dtypes.value_counts())
 
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -537,10 +537,10 @@ def _maybe_convert_string(a, b):
     if dask.config.get("dataframe.convert_string"):
         from dask.dataframe._pyarrow import to_pyarrow_string
 
-        if isinstance(a, (pd.DataFrame, pd.Series)):
+        if isinstance(a, (pd.DataFrame, pd.Series, pd.Index)):
             a = to_pyarrow_string(a)
 
-        if isinstance(b, (pd.DataFrame, pd.Series)):
+        if isinstance(b, (pd.DataFrame, pd.Series, pd.Index)):
             b = to_pyarrow_string(b)
 
     return a, b

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -531,8 +531,7 @@ def _maybe_sort(a, check_index: bool):
     return a.sort_index() if check_index else a
 
 
-def assert_eq_dtypes(a, b):
-    # Temporary changes to look for pyarrow dtype failures
+def _maybe_convert_string(a, b):
     import dask
 
     if dask.config.get("dataframe.convert_string"):
@@ -544,6 +543,14 @@ def assert_eq_dtypes(a, b):
         if isinstance(b, (pd.DataFrame, pd.Series)):
             b = to_pyarrow_string(b)
 
+    return a, b
+
+
+def assert_eq_dtypes(a, b):
+    (
+        a,
+        b,
+    ) = _maybe_convert_string(a, b)
     tm.assert_series_equal(a.dtypes.value_counts(), b.dtypes.value_counts())
 
 
@@ -578,17 +585,7 @@ def assert_eq(
     if hasattr(b, "to_pandas"):
         b = b.to_pandas()
 
-    # Temporary changes to look for pyarrow dtype failures
-    import dask
-
-    if dask.config.get("dataframe.convert_string"):
-        from dask.dataframe._pyarrow import to_pyarrow_string
-
-        if isinstance(a, (pd.DataFrame, pd.Series, pd.Index)):
-            a = to_pyarrow_string(a)
-
-        if isinstance(b, (pd.DataFrame, pd.Series, pd.Index)):
-            b = to_pyarrow_string(b)
+    a, b = _maybe_convert_string(a, b)
 
     if isinstance(a, (pd.DataFrame, pd.Series)) and sort_results:
         a = _maybe_sort(a, check_index)


### PR DESCRIPTION
Part of https://github.com/dask/dask/issues/10029.

Follow-up for https://github.com/dask/dask/pull/10000.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
