### PR TITLE
Temporarily skip `pyarrow_compat` tests with `pandas` 2.0

### DIFF
--- a/dask/dataframe/tests/test_pyarrow_compat.py
+++ b/dask/dataframe/tests/test_pyarrow_compat.py
@@ -8,7 +8,12 @@ import pytest
 
 pa = pytest.importorskip("pyarrow")
 
-from dask.dataframe._compat import PANDAS_GT_150
+from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200
+
+# Known failure due to upstream change in `pandas`.
+pytestmark = pytest.mark.skipif(
+    PANDAS_GT_200, reason="https://github.com/dask/dask/issues/10036"
+)
 
 # Tests are from https://github.com/pandas-dev/pandas/pull/49078
 


### PR DESCRIPTION
As this is causing unrelated failures on PRs, let's skip for now and continue to track in https://github.com/dask/dask/issues/10036