### PR TITLE
Un-`xfail` more `pyarrow` tests

### DIFF
--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -18,7 +18,7 @@ from dask.utils import dependency_depth, tmpdir, tmpfile
 
 # there's no support in upstream for writing HDF with extension dtypes yet.
 # see https://github.com/pandas-dev/pandas/issues/31199
-pytestmark = pytest.mark.skip_with_pyarrow_strings
+pytestmark = pytest.mark.skip_with_pyarrow_strings  # no support for hdf yet
 
 
 def test_to_hdf():

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 import pytest
 
 from dask.dataframe.io.sql import read_sql, read_sql_query, read_sql_table
-from dask.dataframe.utils import assert_eq, get_string_dtype, pyarrow_strings_enabled
+from dask.dataframe.utils import assert_eq, get_string_dtype
 from dask.utils import tmpfile
 
 pd = pytest.importorskip("pandas")
@@ -271,6 +271,7 @@ def test_divisions(db):
     assert_eq(data, df[["name"]][df.index <= 4])
 
 
+@pytest.mark.xfail_with_pyarrow_strings  # TODO: make read_sql_table aware of pyarrow strings
 def test_division_or_partition(db):
     with pytest.raises(TypeError):
         read_sql_table(
@@ -286,11 +287,7 @@ def test_division_or_partition(db):
     m = out.map_partitions(
         lambda d: d.memory_usage(deep=True, index=True).sum()
     ).compute()
-    if pyarrow_strings_enabled():
-        lo, hi = 20, 100
-    else:
-        lo, hi = 50, 200
-    assert (m > lo).all() and (m < hi).all()
+    assert (50 < m).all() and (m < 200).all()
     assert_eq(out, df)
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -39,7 +39,6 @@ from dask.dataframe.utils import (
     assert_eq,
     assert_eq_dtypes,
     assert_max_deps,
-    format_string_dtype,
     get_string_dtype,
     make_meta,
     pyarrow_strings_enabled,
@@ -3934,7 +3933,10 @@ def test_categorize_info():
     buf = StringIO()
     ddf.info(buf=buf, verbose=True)
 
-    string_dtype = format_string_dtype()
+    string_dtype = get_string_dtype()
+    string_dtype = getattr(string_dtype, "name", None) or getattr(
+        string_dtype, "__name__", "object"
+    )
     if platform.architecture()[0] == "32bit":
         memory_usage = "312.0"
     else:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -7,6 +7,7 @@ import xml.etree.ElementTree
 from datetime import datetime, timedelta
 from itertools import product
 from operator import add
+from textwrap import dedent
 
 import numpy as np
 import pandas as pd
@@ -23,6 +24,7 @@ from dask.base import compute_as_if_collection
 from dask.blockwise import fuse_roots
 from dask.dataframe import _compat, methods
 from dask.dataframe._compat import PANDAS_GT_140, PANDAS_GT_150, PANDAS_GT_200, tm
+from dask.dataframe._pyarrow import to_pyarrow_string
 from dask.dataframe.core import (
     Scalar,
     _concat,
@@ -37,6 +39,7 @@ from dask.dataframe.utils import (
     assert_eq,
     assert_eq_dtypes,
     assert_max_deps,
+    format_string_dtype,
     get_string_dtype,
     make_meta,
     pyarrow_strings_enabled,
@@ -3904,7 +3907,6 @@ def test_groupby_multilevel_info():
     assert buf.getvalue() == expected
 
 
-@pytest.mark.skip_with_pyarrow_strings  # expected is different
 def test_categorize_info():
     # assert that we can call info after categorize
     # workaround for: https://github.com/pydata/pandas/issues/14368
@@ -3932,22 +3934,30 @@ def test_categorize_info():
     buf = StringIO()
     ddf.info(buf=buf, verbose=True)
 
+    string_dtype = format_string_dtype()
     if platform.architecture()[0] == "32bit":
         memory_usage = "312.0"
     else:
-        memory_usage = "496.0"
+        memory_usage = "463.0" if pyarrow_strings_enabled() else "496.0"
 
-    expected = (
-        "<class 'dask.dataframe.core.DataFrame'>\n"
-        f"{type(ddf._meta.index).__name__}: 4 entries, 0 to 3\n"
-        "Data columns (total 3 columns):\n"
-        " #   Column  Non-Null Count  Dtype\n"
-        "---  ------  --------------  -----\n"
-        " 0   x       4 non-null      int64\n"
-        " 1   y       4 non-null      category\n"
-        " 2   z       4 non-null      object\n"
-        "dtypes: category(1), object(1), int64(1)\n"
-        "memory usage: {} bytes\n".format(memory_usage)
+    if pyarrow_strings_enabled():
+        dtypes = f"category(1), int64(1), {string_dtype}(1)"
+    else:
+        dtypes = f"category(1), {string_dtype}(1), int64(1)"
+
+    expected = dedent(
+        f"""\
+        <class 'dask.dataframe.core.DataFrame'>
+        {type(ddf._meta.index).__name__}: 4 entries, 0 to 3
+        Data columns (total 3 columns):
+         #   Column  Non-Null Count  Dtype
+        ---  ------  --------------  -----
+         0   x       4 non-null      int64
+         1   y       4 non-null      category
+         2   z       4 non-null      {string_dtype}
+        dtypes: {dtypes}
+        memory usage: {memory_usage} bytes
+        """
     )
     assert buf.getvalue() == expected
 
@@ -4503,7 +4513,6 @@ def test_del():
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("deep", [True, False])
-@pytest.mark.skip_with_pyarrow_strings
 def test_memory_usage_dataframe(index, deep):
     df = pd.DataFrame(
         {"x": [1, 2, 3], "y": [1.0, 2.0, 3.0], "z": ["a", "b", "c"]},
@@ -4511,6 +4520,9 @@ def test_memory_usage_dataframe(index, deep):
         # RangeIndex, so we must set an index explicitly
         index=[1, 2, 3],
     )
+    if pyarrow_strings_enabled():
+        # pandas should measure memory usage of pyarrow strings
+        df = to_pyarrow_string(df)
     ddf = dd.from_pandas(df, npartitions=2)
     expected = df.memory_usage(index=index, deep=deep)
     result = ddf.memory_usage(index=index, deep=deep)
@@ -4519,9 +4531,11 @@ def test_memory_usage_dataframe(index, deep):
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("deep", [True, False])
-@pytest.mark.skip_with_pyarrow_strings
 def test_memory_usage_series(index, deep):
     s = pd.Series([1, 2, 3, 4], index=["a", "b", "c", "d"])
+    if pyarrow_strings_enabled():
+        # pandas should measure memory usage of pyarrow strings
+        s = to_pyarrow_string(s)
     ds = dd.from_pandas(s, npartitions=2)
 
     expected = s.memory_usage(index=index, deep=deep)
@@ -4530,9 +4544,11 @@ def test_memory_usage_series(index, deep):
 
 
 @pytest.mark.parametrize("deep", [True, False])
-@pytest.mark.skip_with_pyarrow_strings
 def test_memory_usage_index(deep):
     s = pd.Series([1, 2, 3, 4], index=["a", "b", "c", "d"])
+    if pyarrow_strings_enabled():
+        # pandas should measure memory usage of pyarrow strings
+        s = to_pyarrow_string(s)
     expected = s.index.memory_usage(deep=deep)
     ds = dd.from_pandas(s, npartitions=2)
     result = ds.index.memory_usage(deep=deep)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3933,10 +3933,7 @@ def test_categorize_info():
     buf = StringIO()
     ddf.info(buf=buf, verbose=True)
 
-    string_dtype = get_string_dtype()
-    string_dtype = getattr(string_dtype, "name", None) or getattr(
-        string_dtype, "__name__", "object"
-    )
+    string_dtype = "object" if get_string_dtype() is object else "string"
     if platform.architecture()[0] == "32bit":
         memory_usage = "312.0"
     else:

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -7,7 +7,7 @@ import pytest
 
 import dask.array as da
 import dask.dataframe as dd
-from dask.dataframe.utils import get_string_dtype
+from dask.dataframe.utils import get_string_dtype, pyarrow_strings_enabled
 from dask.utils import maybe_pluralize
 
 style = """<style scoped>
@@ -27,14 +27,11 @@ style = """<style scoped>
 
 
 def _format_string_dtype():
-    string_dtype = get_string_dtype()
-    return getattr(string_dtype, "name", None) or getattr(
-        string_dtype, "__name__", "object"
-    )
+    return "object" if get_string_dtype() is object else "string"
 
 
 def _format_footer(suffix="", layers=1):
-    if dd.utils.pyarrow_strings_enabled():
+    if pyarrow_strings_enabled():
         return f"Dask Name: to_pyarrow_string{suffix}, {maybe_pluralize(layers + 1, 'graph layer')}"
     return f"Dask Name: from_pandas{suffix}, {maybe_pluralize(layers, 'graph layer')}"
 

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -7,7 +7,7 @@ import pytest
 
 import dask.array as da
 import dask.dataframe as dd
-from dask.dataframe.utils import format_string_dtype
+from dask.dataframe.utils import get_string_dtype
 from dask.utils import maybe_pluralize
 
 style = """<style scoped>
@@ -24,6 +24,13 @@ style = """<style scoped>
     }
 </style>
 """
+
+
+def _format_string_dtype():
+    string_dtype = get_string_dtype()
+    return getattr(string_dtype, "name", None) or getattr(
+        string_dtype, "__name__", "object"
+    )
 
 
 def _format_footer(suffix="", layers=1):
@@ -61,7 +68,7 @@ def test_dataframe_format():
         }
     )
     ddf = dd.from_pandas(df, 3)
-    string_dtype = format_string_dtype()
+    string_dtype = _format_string_dtype()
     footer = _format_footer()
     exp = dedent(
         f"""\
@@ -157,7 +164,7 @@ def test_dataframe_format_with_index():
         index=list("ABCDEFGH"),
     )
     ddf = dd.from_pandas(df, 3)
-    string_dtype = format_string_dtype()
+    string_dtype = _format_string_dtype()
     footer = _format_footer()
     exp = dedent(
         f"""\
@@ -243,7 +250,7 @@ def test_dataframe_format_unknown_divisions():
     ddf = ddf.clear_divisions()
     assert not ddf.known_divisions
 
-    string_dtype = format_string_dtype()
+    string_dtype = _format_string_dtype()
     footer = _format_footer()
 
     exp = dedent(
@@ -337,7 +344,7 @@ def test_dataframe_format_long():
             "C": pd.Categorical(list("AAABBBCC") * 10),
         }
     )
-    string_dtype = format_string_dtype()
+    string_dtype = _format_string_dtype()
     footer = _format_footer()
     ddf = dd.from_pandas(df, 10)
     exp = dedent(
@@ -508,7 +515,7 @@ def test_series_format_long():
 def test_index_format():
     s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8], index=list("ABCDEFGH"))
     ds = dd.from_pandas(s, 3)
-    string_dtype = format_string_dtype()
+    string_dtype = _format_string_dtype()
     footer = _format_footer("-index", 2)
     exp = dedent(
         f"""\

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -8,6 +8,7 @@ import pytest
 import dask.array as da
 import dask.dataframe as dd
 from dask.dataframe.utils import format_string_dtype
+from dask.utils import maybe_pluralize
 
 style = """<style scoped>
     .dataframe tbody tr th:only-of-type {
@@ -27,9 +28,8 @@ style = """<style scoped>
 
 def _format_footer(suffix="", layers=1):
     if dd.utils.pyarrow_strings_enabled():
-        return f"Dask Name: to_pyarrow_string{suffix}, {layers + 1} graph layers"
-    ending = "s" if layers > 1 else ""
-    return f"Dask Name: from_pandas{suffix}, {layers} graph layer{ending}"
+        return f"Dask Name: to_pyarrow_string{suffix}, {maybe_pluralize(layers + 1, 'graph layer')}"
+    return f"Dask Name: from_pandas{suffix}, {maybe_pluralize(layers, 'graph layer')}"
 
 
 def test_repr():

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1697,10 +1697,10 @@ def test_cheap_single_partition_merge(flip):
     assert not hlg_layer_topological(cc.dask, -1).is_materialized()
     assert all("shuffle" not in k[0] for k in cc.dask)
 
-    aa_keys = [k for k, _ in aa.dask if not k.startswith("to_pyarrow_string-")]
-    bb_keys = [k for k, _ in bb.dask if not k.startswith("to_pyarrow_string-")]
-    cc_keys = [k for k, _ in cc.dask if not k.startswith("to_pyarrow_string-")]
-    assert len(cc_keys) == len(aa_keys) * 2 + len(bb_keys)
+    # Merge is input layers + a single merge operation
+    input_layers = aa.dask.layers.keys() | bb.dask.layers.keys()
+    output_layers = cc.dask.layers.keys()
+    assert len(output_layers - input_layers) == 1
 
     list_eq(cc, pd.merge(*pd_inputs, on="x", how="inner"))
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1681,7 +1681,6 @@ def test_cheap_inner_merge_with_pandas_object():
 
 
 @pytest.mark.parametrize("flip", [False, True])
-@pytest.mark.skip_with_pyarrow_strings  # test checks dask layers
 def test_cheap_single_partition_merge(flip):
     a = pd.DataFrame(
         {"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60]
@@ -1697,7 +1696,11 @@ def test_cheap_single_partition_merge(flip):
     cc = dd.merge(*inputs, on="x", how="inner")
     assert not hlg_layer_topological(cc.dask, -1).is_materialized()
     assert all("shuffle" not in k[0] for k in cc.dask)
-    assert len(cc.dask) == len(aa.dask) * 2 + len(bb.dask)
+
+    aa_keys = [k for k, _ in aa.dask if not k.startswith("to_pyarrow_string-")]
+    bb_keys = [k for k, _ in bb.dask if not k.startswith("to_pyarrow_string-")]
+    cc_keys = [k for k, _ in cc.dask if not k.startswith("to_pyarrow_string-")]
+    assert len(cc_keys) == len(aa_keys) * 2 + len(bb_keys)
 
     list_eq(cc, pd.merge(*pd_inputs, on="x", how="inner"))
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -812,10 +812,16 @@ def meta_series_constructor(like):
 def get_string_dtype():
     """Depending on config setting, we might convert objects to pyarrow strings"""
     return (
-        pd.StringDtype("pyarrow") if config.get("dataframe.convert_string") else object
+        pd.StringDtype("pyarrow")
+        if bool(config.get("dataframe.convert_string"))
+        else object
     )
 
 
 def pyarrow_strings_enabled():
     """Config setting to convert objects to pyarrow strings"""
     return bool(config.get("dataframe.convert_string"))
+
+
+def format_string_dtype():
+    return "string" if pyarrow_strings_enabled() else "object"

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -821,7 +821,3 @@ def get_string_dtype():
 def pyarrow_strings_enabled():
     """Config setting to convert objects to pyarrow strings"""
     return bool(config.get("dataframe.convert_string"))
-
-
-def format_string_dtype():
-    return "string" if pyarrow_strings_enabled() else "object"

--- a/dask/tests/test_spark_compat.py
+++ b/dask/tests/test_spark_compat.py
@@ -29,7 +29,7 @@ pytestmark = [
         reason="pyspark doesn't yet have support for pandas 2.0",
     ),
     # we only test with pyarrow strings and pandas 2.0
-    pytest.mark.skip_with_pyarrow_strings,
+    pytest.mark.skip_with_pyarrow_strings,  # pyspark doesn't support pandas 2.0
 ]
 
 # pyspark auto-converts timezones -- round-tripping timestamps is easier if


### PR DESCRIPTION
Related to https://github.com/dask/dask/issues/10029.

Unxfail some of the tests by providing an expected value with pyarrow strings:

```
dask/dataframe/io/tests/test_io.py::test_from_map_simple
dask/dataframe/io/tests/test_io.py::test_from_map_custom_name
dask/dataframe/tests/test_format.py
dask/dataframe/tests/test_dataframe.py::test_categorize_info
dask/dataframe/tests/test_dataframe.py::test_memory_usage_dataframe
dask/dataframe/tests/test_dataframe.py::test_memory_usage_series
dask/dataframe/tests/test_dataframe.py::test_memory_usage_index
dask/dataframe/tests/test_multi.py::test_cheap_single_partition_merge
```

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
