### PR TITLE
[WIP][Experimental] Attach default RangeIndex metadata to read_parquet tasks

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1515,7 +1515,7 @@ class ArrowDatasetEngine(Engine):
                                 "total_byte_size": row_group.total_byte_size,
                             }
                         cstats = []
-                        for name in stat_col_indices.keys():
+                        for name in list(stat_col_indices.keys()):
                             if name in statistics:
                                 cmin = statistics[name]["min"]
                                 cmax = statistics[name]["max"]
@@ -1541,15 +1541,20 @@ class ArrowDatasetEngine(Engine):
                                     if cmin is None or (last and cmin < last):
                                         # We are collecting statistics for divisions
                                         # only (no filters) - Column isn't sorted, or
-                                        # we have an all-null partition, so lets bail.
+                                        # we have an all-null partition, so lets bail
+                                        # on column-stat collection.
                                         #
                                         # Note: This assumes ascending order.
                                         #
-                                        gather_statistics = False
-                                        file_row_group_stats = {}
-                                        file_row_group_column_stats = {}
-                                        break
+                                        stat_col_indices.pop(name)
+                                        for k in file_row_group_column_stats.keys():
+                                            file_row_group_column_stats[k] = [
+                                                None,
+                                                None,
+                                                None,
+                                            ]
 
+                            if name in stat_col_indices:
                                 if single_rg_parts:
                                     s["columns"].append(
                                         {

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1425,14 +1425,14 @@ def _attach_range(parts, statistics):
         offset = 0
         for i, part_stat in enumerate(statistics):
             num_rows = part_stat.get("num-rows", None)
-            if isinstance(num_rows, int):
+            if num_rows is None:
+                # Bail
+                return parts
+            else:
                 new_part = parts[i].copy()
                 new_part["range"] = (offset, num_rows)
                 new_parts.append(new_part)
                 offset += num_rows
-            else:
-                # Bail
-                return parts
         return new_parts
     return parts
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1675,10 +1675,10 @@ def aggregate_row_groups(
                 and this_piece[1] != [None]
             ):
                 next_piece[1].extend(this_piece[1])
-                if _range and "range" in next_part:
-                    next_part["range"] = (
-                        next_part["range"][0],
-                        next_part["range"][1] + _range[1],
+                if _range and "range" in next_part[-1]:
+                    next_part[-1]["range"] = (
+                        next_part[-1]["range"][0],
+                        next_part[-1]["range"][1] + _range[1],
                     )
             else:
                 next_part.append(part)

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -93,7 +93,7 @@ class ParquetFunctionWrapper(DataFrameIOFunction):
         if not isinstance(part, list):
             part = [part]
 
-        return read_parquet_part(
+        df = read_parquet_part(
             self.fs,
             self.engine,
             self.meta,
@@ -110,6 +110,15 @@ class ParquetFunctionWrapper(DataFrameIOFunction):
             self.use_nullable_dtypes,
             self.common_kwargs,
         )
+
+        if not self.index and "range" in part[0]:
+            offset = part[0]["range"][0]
+            row_count = part[0]["range"][1]
+            for p in part[1:]:
+                row_count += p["range"][1]
+            return df.set_index(pd.RangeIndex(offset, offset + len(df)))
+
+        return df
 
 
 class ToParquetFunctionWrapper:
@@ -582,6 +591,7 @@ def read_parquet(
         split_row_groups,
         fs,
         aggregation_depth,
+        calculate_divisions=calculate_divisions,
     )
 
     # Account for index and columns arguments.
@@ -1409,6 +1419,24 @@ def apply_filters(parts, statistics, filters):
     return out_parts, out_statistics
 
 
+def _attach_range(parts, statistics):
+    if statistics:
+        new_parts = []
+        offset = 0
+        for i, part_stat in enumerate(statistics):
+            num_rows = part_stat.get("num-rows", None)
+            if isinstance(num_rows, int):
+                new_part = parts[i].copy()
+                new_part["range"] = (offset, num_rows)
+                new_parts.append(new_part)
+                offset += num_rows
+            else:
+                # Bail
+                return parts
+        return new_parts
+    return parts
+
+
 def process_statistics(
     parts,
     statistics,
@@ -1418,6 +1446,7 @@ def process_statistics(
     split_row_groups,
     fs,
     aggregation_depth,
+    calculate_divisions=False,
 ):
     """Process row-group column statistics in metadata
     Used in read_parquet.
@@ -1450,6 +1479,9 @@ def process_statistics(
         parts, statistics = result or [[], []]
         if filters:
             parts, statistics = apply_filters(parts, statistics, filters)
+
+        # Use statistics to attach row-count metadata
+        parts = _attach_range(parts, statistics)
 
         # Aggregate parts/statistics if we are splitting by row-group
         if blocksize or (split_row_groups and int(split_row_groups) > 1):
@@ -1489,8 +1521,30 @@ def process_statistics(
                     UserWarning,
                 )
 
-    divisions = divisions or (None,) * (len(parts) + 1)
-    return parts, divisions, index
+    return parts, _set_divisions(divisions, parts, index, calculate_divisions), index
+
+
+def _set_divisions(divisions, parts, index, calculate_divisions):
+    npartitions = len(parts)
+    if divisions or index or not calculate_divisions:
+        return divisions or (None,) * (npartitions + 1)
+    else:
+        divisions = []
+        for part in parts:
+            offset, size = None, 0
+            for p in part if isinstance(part, list) else [part]:
+                _range = p.get("range", None)
+                if _range:
+                    if offset is None:
+                        offset = _range[0]
+                        divisions.append(offset)
+                    size += _range[1]
+                else:
+                    return (None,) * (npartitions + 1)
+        if divisions:
+            divisions.append(divisions[-1] + size)
+            return tuple(divisions)
+        return (None,) * (npartitions + 1)
 
 
 def set_index_columns(meta, index, columns, auto_index_allowed):
@@ -1556,6 +1610,7 @@ def aggregate_row_groups(
     next_part, next_stat = [parts[0].copy()], stats[0].copy()
     for i in range(1, len(parts)):
         stat, part = stats[i], parts[i]
+        _range = part.get("range", None)
 
         # Criteria #1 for aggregating parts: parts are within the same file
         same_path = stat["file_path_0"] == next_stat["file_path_0"]
@@ -1620,6 +1675,11 @@ def aggregate_row_groups(
                 and this_piece[1] != [None]
             ):
                 next_piece[1].extend(this_piece[1])
+                if _range and "range" in next_part:
+                    next_part["range"] = (
+                        next_part["range"][0],
+                        next_part["range"][1] + _range[1],
+                    )
             else:
                 next_part.append(part)
 
@@ -1643,6 +1703,29 @@ def aggregate_row_groups(
     stats_agg.append(next_stat)
 
     return parts_agg, stats_agg
+
+
+def _pq_range_index_length(layer):
+    # Simple utility to use range information in the layer
+    # to calculate the number of rows in a Dask-DataFrame
+    _len = None
+    if (
+        isinstance(layer, DataFrameIOLayer)
+        and isinstance(layer.io_func, ParquetFunctionWrapper)
+        and layer.io_func.common_kwargs.get("filters", None) is None
+    ):
+        _len = 0
+        for part in layer.inputs:
+            for p in part if isinstance(part, list) else [part]:
+                _range = p.get("range", None)
+                if _range:
+                    _len += _range[1]
+                else:
+                    _len = None
+                    break
+            if _len is None:
+                break
+    return _len
 
 
 DataFrame.to_parquet.__doc__ = to_parquet.__doc__

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -888,11 +888,11 @@ def _set_gather_statistics(
         # NOTE: Should avoid gathering statistics when the agg
         # does not depend on a row-group statistic
         gather_statistics = True
-    elif not stat_columns:
-        # Not aggregating files/row-groups.
-        # We only need to gather statistics if `stat_columns`
-        # is populated
-        gather_statistics = False
+    # elif not stat_columns:
+    #     # Not aggregating files/row-groups.
+    #     # We only need to gather statistics if `stat_columns`
+    #     # is populated
+    #     gather_statistics = False
 
     return bool(gather_statistics)
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -413,7 +413,7 @@ def test_columns_no_index(tmpdir, write_engine, read_engine):
     # --------
     # All columns, none as index
     assert_eq(
-        dd.read_parquet(fn, index=False, engine=read_engine, calculate_divisions=True),
+        dd.read_parquet(fn, index=False, engine=read_engine, calculate_divisions=False),
         ddf2,
         check_index=False,
         check_divisions=True,
@@ -426,7 +426,7 @@ def test_columns_no_index(tmpdir, write_engine, read_engine):
             index=False,
             columns=["x", "y"],
             engine=read_engine,
-            calculate_divisions=True,
+            calculate_divisions=False,
         ),
         ddf2[["x", "y"]],
         check_index=False,
@@ -440,7 +440,7 @@ def test_columns_no_index(tmpdir, write_engine, read_engine):
             index=False,
             columns=["myindex", "x"],
             engine=read_engine,
-            calculate_divisions=True,
+            calculate_divisions=False,
         ),
         ddf2[["myindex", "x"]],
         check_index=False,


### PR DESCRIPTION
Experimental PR to start adding the necessary information to construct a global `RangeIndex` whenever `calculate_divisions=True`. This range information is also collected if/when the parquet metadata is parsed for other purposes, because it can be used to optimize `DataFrame.__len__`.

**Example Behavior**:

```python
import dask.dataframe as dd
from dask.datasets import timeseries

path = "/datasets/rzamora/timeseries_test"
timeseries().to_parquet(path, overwrite=True)

# Get global RangeIndex if `index=False` and `calculate_divisions=True`
print(dd.read_parquet(path, index=False, calculate_divisions=True))
```
```
Dask DataFrame Structure:
                     timestamp    name     id        x        y
npartitions=30                                                 
0               datetime64[ns]  object  int64  float64  float64
86400                      ...     ...    ...      ...      ...
...                        ...     ...    ...      ...      ...
2505600                    ...     ...    ...      ...      ...
2592000                    ...     ...    ...      ...      ...
Dask Name: read-parquet, 1 graph layer
```
```python
# The default RangeIndex information is used to optimize length
# (even when the index is set to a parquet-data column)
ddf = dd.read_parquet(path, index="timestamp", calculate_divisions=True)
%time len(ddf)  # Optimized time is ~500x faster for this case
```
```
CPU times: user 26 µs, sys: 6 µs, total: 32 µs
Wall time: 39.3 µs
2592000
```


- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
