### PR TITLE
Enable column projection for `DataFrame.index` and further optimize `DataFrame.__len__`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4771,12 +4771,10 @@ class DataFrame(_Frame):
         return _iLocIndexer(self)
 
     def __len__(self):
-        try:
-            s = self.iloc[:, 0]
-        except IndexError:
-            return super().__len__()
-        else:
-            return len(s)
+        # Project to an empty column list so we will avoid
+        # reading real data if we are calling len immediately
+        # after a DataFrameIOLayer
+        return len((self[[]] if hasattr(self, "columns") else self).index)
 
     def __contains__(self, key):
         return key in self._meta


### PR DESCRIPTION
While experimenting with https://github.com/dask/dask/pull/10067, I realized that we are not taking full advantage of `DataFrameIOLayer` column-projection within `DataFrame.index` or `DataFrame.__len__`. That is, there is no reason we need to read in **any** column data to do something like `len(dd.read_parquet(path))` unless one of the columns is being used as the index. Instead, we can just project an empty column-list into the read-parquet layer, and find the global length of the index (which may not require us to read in **any** file data at all).

The performance bump is most obvious for cases in which it is expensive to read a single column for each partition. For example, there is a 40x improvement for the 266GB Criteo dataset:

```python
import dask.dataframe as dd

ddf = dd.read_parquet("/data/crit_pq_int", blocksize="1GiB")
%time len(ddf)
```

New result:
```
CPU times: user 4.28 s, sys: 377 ms, total: 4.66 s
Wall time: 1.23 s
4373472305
```

Old result:
```
CPU times: user 1min 8s, sys: 2min 59s, total: 4min 8s
Wall time: 47.8 s
4373472305
```

The speedup is much less significant when you have many small partitions, because we still need to access the the file(s) for each partition.  However, we may be able to improve that case in the future as well.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
