### PR TITLE
Attempt to turn unclosed file warning into error.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ filterwarnings = [
     "error:::pandas[.*]",
     "error:::numpy[.*]",
     "error:::distributed[.*]",
+    "error::pytest.PytestUnraisableExceptionWarning",
     # From https://github.com/numpy/numpy/issues/20225
     'ignore:The distutils\.sysconfig module is deprecated, use sysconfig instead:DeprecationWarning:numpy',
     # With no network access, distributed raises a warning when detecting local IP address


### PR DESCRIPTION
Surface and fix warnings:

```
dask/dataframe/io/tests/test_parquet.py::test_retries_on_remote_filesystem
  /usr/share/miniconda3/envs/test-environment/lib/python3.10/site-packages/_pytest/unraisableexception.py:78: PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO [closed]>
  
  Traceback (most recent call last):
    File "/home/runner/work/dask/dask/dask/dataframe/io/parquet/arrow.py", line 1005, in _collect_dataset_info
      physical_schema = file_frag.physical_schema
  ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/tmp57eq_7ze/d549ad8b59c1797315fcb393c08f3fb30bf1195da24aabd1b0dca178e4f34afd'>
  
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
```

* Xref https://github.com/dask/dask/issues/7167.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
