### PR TITLE
[WIP][Experiment] Expose `left_shuffled` and `right_shuffled` options in `DataFrame.merge`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5550,8 +5550,8 @@ class DataFrame(_Frame):
         npartitions=None,
         shuffle=None,
         broadcast=None,
-        left_shuffled_by=None,
-        right_shuffled_by=None,
+        left_shuffled=False,
+        right_shuffled=False,
     ):
         """Merge the DataFrame with another DataFrame
 
@@ -5615,6 +5615,25 @@ class DataFrame(_Frame):
             within the simple heuristic (a large number makes Dask more likely
             to choose the ``broacast_join`` code path). See ``broadcast_join``
             for more information.
+        left_shuffled : bool, optional
+            Whether the left DataFrame is already shuffled by the exact
+            column(s) specified by ``on`` (or ``left_on``). Default is
+            ``False``.
+
+            WARNING: Use at your own risk. This option corresponds to a
+            promise from the user to Dask that the collection was already
+            shuffled using a preceeding ``DataFrame.shuffle`` or
+            ``DataFrame.merge`` operation, and that the shuffle index was
+            exactly the same as the current merge index. Specifying ``True``
+            incorrectly is likely to produce invalid results.
+            Default is ``False``.
+        right_shuffle : bool, optional
+            Whether the right DataFrame is already shuffled by the exact
+            column(s) specified by ``on`` (or ``right_on``). Default is
+            ``False``.
+
+            WARNING: Use at your own risk. See ``left_shuffled`` for more
+            information.
 
         Notes
         -----
@@ -5661,8 +5680,8 @@ class DataFrame(_Frame):
             indicator=indicator,
             shuffle=shuffle,
             broadcast=broadcast,
-            left_shuffled_by=left_shuffled_by,
-            right_shuffled_by=right_shuffled_by,
+            left_shuffled=left_shuffled,
+            right_shuffled=right_shuffled,
         )
 
     @derived_from(pd.DataFrame)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5550,6 +5550,8 @@ class DataFrame(_Frame):
         npartitions=None,
         shuffle=None,
         broadcast=None,
+        left_shuffled_by=None,
+        right_shuffled_by=None,
     ):
         """Merge the DataFrame with another DataFrame
 
@@ -5659,6 +5661,8 @@ class DataFrame(_Frame):
             indicator=indicator,
             shuffle=shuffle,
             broadcast=broadcast,
+            left_shuffled_by=left_shuffled_by,
+            right_shuffled_by=right_shuffled_by,
         )
 
     @derived_from(pd.DataFrame)

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -336,8 +336,8 @@ def hash_join(
     shuffle=None,
     indicator=False,
     max_branch=None,
-    left_shuffled_by=None,
-    right_shuffled_by=None,
+    left_shuffled=False,
+    right_shuffled=False,
 ):
     """Join two DataFrames on particular columns with hash join
 
@@ -349,28 +349,11 @@ def hash_join(
     if shuffle is None:
         shuffle = get_default_shuffle_algorithm()
 
-    # Use `shuffled_by` to check if we can skip the shuffle
-    def _need_shuffle(ddf, shuffled_by, merge_on):
-        # Must have the correct number of partitions, and
-        # shuffled_by/on must be column name or column list
-        if (
-            ddf.npartitions != max(lhs.npartitions, rhs.npartitions)
-            or not isinstance(shuffled_by, (list, tuple, str))
-            or not isinstance(merge_on, (list, tuple, str))
-        ):
-            return True
-
-        # Must be shuffled by the same columns we are joining on
-        by = shuffled_by if isinstance(shuffled_by, (list, tuple)) else [shuffled_by]
-        on = merge_on if isinstance(merge_on, (list, tuple)) else [merge_on]
-        if list(by) != list(on):
-            return True
-
-        # If we get here, we don't need to shuffle
-        return False
-
-    need_shuffle_left = _need_shuffle(lhs, left_shuffled_by, left_on)
-    need_shuffle_right = _need_shuffle(rhs, right_shuffled_by, right_on)
+    # Check if we can skip the shuffle for either side
+    if npartitions is None:
+        npartitions = max(lhs.npartitions, rhs.npartitions)
+    need_shuffle_left = not (left_shuffled and lhs.npartitions == npartitions)
+    need_shuffle_right = not (right_shuffled and rhs.npartitions == npartitions)
 
     if shuffle == "p2p" and need_shuffle_left and need_shuffle_right:
         from distributed.shuffle import hash_join_p2p
@@ -385,8 +368,6 @@ def hash_join(
             suffixes=suffixes,
             indicator=indicator,
         )
-    if npartitions is None:
-        npartitions = max(lhs.npartitions, rhs.npartitions)
 
     lhs2 = (
         shuffle_func(
@@ -564,8 +545,8 @@ def merge(
     shuffle=None,
     max_branch=None,
     broadcast=None,
-    left_shuffled_by=None,
-    right_shuffled_by=None,
+    left_shuffled=False,
+    right_shuffled=False,
 ):
     for o in [on, left_on, right_on]:
         if isinstance(o, _Frame):
@@ -763,6 +744,8 @@ def merge(
                     npartitions,
                     suffixes,
                     indicator=indicator,
+                    left_shuffled=left_shuffled,
+                    right_shuffled=right_shuffled,
                 )
 
         return hash_join(
@@ -776,8 +759,8 @@ def merge(
             shuffle=shuffle,
             indicator=indicator,
             max_branch=max_branch,
-            left_shuffled_by=left_shuffled_by,
-            right_shuffled_by=right_shuffled_by,
+            left_shuffled=left_shuffled,
+            right_shuffled=right_shuffled,
         )
 
 
@@ -1489,6 +1472,8 @@ def broadcast_join(
     shuffle=None,
     indicator=False,
     parts_out=None,
+    left_shuffled=False,
+    right_shuffled=False,
 ):
     """Join two DataFrames on particular columns by broadcasting
 
@@ -1497,6 +1482,8 @@ def broadcast_join(
     and then concatenates the new data for each output partition.
     """
 
+    left_npartitions_input = lhs.npartitions
+    right_npartitions_input = rhs.npartitions
     if npartitions:
         # Repartition the larger collection before the merge
         if lhs.npartitions < rhs.npartitions:
@@ -1531,20 +1518,32 @@ def broadcast_join(
         # joined by `merge_chunk`.  The local hash and
         # split of lhs is in `_split_partition`.
         if lhs.npartitions < rhs.npartitions:
-            lhs2 = shuffle_func(
-                lhs,
-                left_on,
-                shuffle="tasks",
+            left_shuffled = left_shuffled and lhs.npartitions == left_npartitions_input
+            lhs2 = (
+                shuffle_func(
+                    lhs,
+                    left_on,
+                    shuffle="tasks",
+                )
+                if not left_shuffled
+                else lhs
             )
             lhs_name = lhs2._name
             lhs_dep = lhs2
             rhs_name = rhs._name
             rhs_dep = rhs
         else:
-            rhs2 = shuffle_func(
-                rhs,
-                right_on,
-                shuffle="tasks",
+            right_shuffled = (
+                right_shuffled and rhs.npartitions == right_npartitions_input
+            )
+            rhs2 = (
+                shuffle_func(
+                    rhs,
+                    right_on,
+                    shuffle="tasks",
+                )
+                if not right_shuffled
+                else rhs
             )
             lhs_name = lhs._name
             lhs_dep = lhs

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1030,6 +1030,59 @@ def test_merge_empty_left_df(shuffle_method, how):
     merged.map_partitions(lambda x: x, meta=merged._meta).compute()
 
 
+@pytest.mark.parametrize("how", ["inner", "outer", "left", "right"])
+@pytest.mark.parametrize("broadcast", [None, True])
+def test_merge_shuffled(how, broadcast):
+    index = ["a", "b"]
+    lhs_i = dd.from_dict(
+        {
+            "a": [1, 2, 3, 4, 5] * 20,
+            "b": [1, 2] * 50,
+            "c": range(100),
+        },
+        npartitions=5,
+    )
+    lhs = lhs_i.shuffle(index)
+
+    rhs_i = dd.from_dict(
+        {
+            "a": [1, 2, 3, 4] * 25,
+            "b": [1, 2] * 50,
+            "d": range(100),
+        },
+        npartitions=4,
+    )
+    rhs = rhs_i.shuffle(index)
+    expect = lhs_i.merge(rhs_i, on=index, how=how, broadcast=broadcast)
+
+    # Use `left_shuffled`
+    got = lhs.merge(rhs_i, on=index, how=how, left_shuffled=True, broadcast=broadcast)
+    assert_eq(got, expect, check_index=False, check_divisions=not broadcast)
+
+    # Use `right_shuffled`
+    got = lhs_i.merge(rhs, on=index, how=how, right_shuffled=True, broadcast=broadcast)
+    assert_eq(got, expect, check_index=False, check_divisions=not broadcast)
+
+    # Use `left_shuffled` and `right_shuffled`
+    got = lhs.merge(
+        rhs,
+        on=index,
+        how=how,
+        left_shuffled=True,
+        right_shuffled=True,
+        broadcast=broadcast,
+    )
+    assert_eq(got, expect, check_index=False, check_divisions=not broadcast)
+
+    # Use `left_shuffled` after shuffle-based merge
+    merged = lhs_i.merge(rhs_i, on=index, how=how, broadcast=False)
+    expect = merged.merge(rhs_i, on=index, how=how, broadcast=broadcast)
+    got = merged.merge(
+        rhs_i, on=index, how=how, left_shuffled=True, broadcast=broadcast
+    )
+    assert_eq(got, expect, check_index=False, check_divisions=not broadcast)
+
+
 def test_merge_how_raises():
     left = pd.DataFrame(
         {

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1031,7 +1031,7 @@ def test_merge_empty_left_df(shuffle_method, how):
 
 
 @pytest.mark.parametrize("how", ["inner", "outer", "left", "right"])
-@pytest.mark.parametrize("broadcast", [None, True])
+@pytest.mark.parametrize("broadcast", [False, True])
 def test_merge_shuffled(how, broadcast):
     index = ["a", "b"]
     lhs_i = dd.from_dict(


### PR DESCRIPTION
I have heard meany times in off-line discussion that Dask ends up shuffling the same data multiple times for real-world workflows requiring multiple merge operations. Although there are certainly ways for users to optimize their code to avoid doing this. It may also be useful to expose a `DataFrame.merge` argument through which the user can make a "promise" to Dask that a particular collection is already shuffled by the necessary columns. This PR is intended as a POC for such an option.