### PR TITLE
CI environment file cleanup

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -7,8 +7,13 @@ dependencies:
   # required dependencies
   - python=3.10
   - packaging
-  - numpy=1.23
-  - pandas=1.5
+  - pyyaml
+  - click
+  - cloudpickle
+  - partd
+  - fsspec
+  - importlib_metadata
+  - toolz
   # test dependencies
   - pre-commit
   - pytest
@@ -17,6 +22,9 @@ dependencies:
   - pytest-timeout
   - pytest-xdist
   - moto
+  # Optional dependencies
+  - numpy=1.23
+  - pandas=1.5
   - flask
   - fastparquet>=0.8.0
   - h5py
@@ -29,7 +37,6 @@ dependencies:
   - pyspark
   - tiledb>=2.5.0
   - xarray
-  - fsspec
   # Pin until sqlalchemy 2 support is added https://github.com/dask/dask/issues/9896
   - sqlalchemy>=1.4.0,<2
   - pyarrow=10
@@ -45,23 +52,18 @@ dependencies:
   # Need recent version of s3fs to support newer aiobotocore versions
   # https://github.com/dask/s3fs/issues/514
   - s3fs>=2021.8.0
-  - click
-  - cloudpickle
   - crick
   - cytoolz
   - distributed
-  - importlib-metadata>=4.13.0
   - ipython
   - ipycytoscape
   - lz4
   - numba
-  - partd
   - psutil
   - requests
   - scikit-image
   - scikit-learn
   - scipy
-  - toolz
   - python-snappy
   - sparse
   - cachey

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -7,8 +7,13 @@ dependencies:
   # required dependencies
   - python=3.11
   - packaging
-  - numpy
-  - pandas
+  - pyyaml
+  - click
+  - cloudpickle
+  - partd
+  - fsspec
+  - importlib_metadata
+  - toolz
   # test dependencies
   - pre-commit
   - pytest
@@ -17,6 +22,9 @@ dependencies:
   - pytest-timeout
   - pytest-xdist
   - moto
+  # Optional dependencies
+  - numpy
+  - pandas
   - flask
   - fastparquet>=0.8.0
   - h5py
@@ -28,7 +36,6 @@ dependencies:
   # - pyspark
   # - tiledb>=2.5.0 # crashes on Python 3.11
   - xarray
-  - fsspec
   # Pin until sqlalchemy 2 support is added https://github.com/dask/dask/issues/9896
   - sqlalchemy>=1.4.0,<2
   - pyarrow>=11
@@ -44,26 +51,21 @@ dependencies:
   # # Need recent version of s3fs to support newer aiobotocore versions
   # # https://github.com/dask/s3fs/issues/514
   - s3fs>=2021.8.0
-  - click
-  - cloudpickle
   # Need a new `crick` release with support for `numpy=1.24+`
   # https://github.com/dask/crick/issues/25
   # - crick
   - cytoolz
   - distributed
-  - importlib-metadata>=4.13.0
   - ipython
   - ipycytoscape
   - lz4
   # https://github.com/numba/numba/issues/8304
   # - numba  # not supported on 3.11
-  - partd
   - psutil
   - requests
   - scikit-image
   - scikit-learn
   - scipy
-  - toolz
   - python-snappy
   # - sparse  needs numba
   - cachey

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -7,8 +7,13 @@ dependencies:
   # required dependencies
   - python=3.8
   - packaging
-  - numpy=1.21
-  - pandas=1.3
+  - pyyaml
+  - click
+  - cloudpickle
+  - partd
+  - fsspec
+  - importlib_metadata
+  - toolz
   # test dependencies
   - pre-commit
   - pytest
@@ -17,6 +22,9 @@ dependencies:
   - pytest-timeout
   - pytest-xdist
   - moto
+  # Optional dependencies
+  - numpy=1.21
+  - pandas=1.3
   - flask
   - fastparquet
   - h5py
@@ -29,7 +37,6 @@ dependencies:
   - pyspark
   - tiledb>=2.5.0
   - xarray
-  - fsspec
   # Pin until sqlalchemy 2 support is added https://github.com/dask/dask/issues/9896
   - sqlalchemy>=1.4.0,<2
   - pyarrow=7
@@ -45,8 +52,6 @@ dependencies:
   # Need recent version of s3fs to support newer aiobotocore versions
   # https://github.com/dask/s3fs/issues/514
   - s3fs>=2021.8.0
-  - click
-  - cloudpickle
   - crick
   - cytoolz
   - distributed
@@ -55,13 +60,11 @@ dependencies:
   - ipycytoscape
   - lz4
   - numba
-  - partd
   - psutil
   - requests
   - scikit-image
   - scikit-learn
   - scipy
-  - toolz
   - python-snappy
   - sparse
   - cachey

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -7,8 +7,13 @@ dependencies:
   # required dependencies
   - python=3.9
   - packaging
-  - numpy=1.22
-  - pandas=1.4
+  - pyyaml
+  - click
+  - cloudpickle
+  - partd
+  - fsspec
+  - importlib_metadata
+  - toolz
   # test dependencies
   - pre-commit
   - pytest
@@ -17,6 +22,9 @@ dependencies:
   - pytest-timeout
   - pytest-xdist
   - moto
+  # Optional dependencies
+  - numpy=1.22
+  - pandas=1.4
   - flask
   - fastparquet
   - h5py
@@ -29,7 +37,6 @@ dependencies:
   - pyspark
   - tiledb>=2.5.0
   - xarray
-  - fsspec
   # Pin until sqlalchemy 2 support is added https://github.com/dask/dask/issues/9896
   - sqlalchemy>=1.4.0,<2
   - pyarrow=9
@@ -45,23 +52,18 @@ dependencies:
   # Need recent version of s3fs to support newer aiobotocore versions
   # https://github.com/dask/s3fs/issues/514
   - s3fs>=2021.8.0
-  - click
-  - cloudpickle
   - crick
   - cytoolz
   - distributed
-  - importlib-metadata>=4.13.0
   - ipython
   - ipycytoscape
   - lz4
   - numba
-  - partd
   - psutil
   - requests
   - scikit-image
   - scikit-learn
   - scipy
-  - toolz
   - python-snappy
   - sparse
   - cachey


### PR DESCRIPTION
This PR is just cleans up our conda env files a bit (e.g. moves `cloudpickle`, etc. into the `# required dependencies` section and `numpy` + `pandas` into `# Optional dependencies`) 