### PR TITLE
`DataFrame._data` deprecation in `pandas`

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -1098,8 +1098,6 @@ def normalize_dataclass(obj):
 def register_pandas():
     import pandas as pd
 
-    pandas_version = parse_version(pd.__version__)
-
     @normalize_token.register(pd.Index)
     def normalize_index(ind):
         values = ind.array
@@ -1143,8 +1141,7 @@ def register_pandas():
 
     @normalize_token.register(pd.DataFrame)
     def normalize_dataframe(df):
-        mgr = df._mgr if pandas_version.major >= 2 else df._data
-
+        mgr = df._mgr
         data = list(mgr.arrays) + [df.columns, df.index]
         return list(map(normalize_token, data))
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -1098,6 +1098,8 @@ def normalize_dataclass(obj):
 def register_pandas():
     import pandas as pd
 
+    pandas_version = parse_version(pd.__version__)
+
     @normalize_token.register(pd.Index)
     def normalize_index(ind):
         values = ind.array
@@ -1141,7 +1143,7 @@ def register_pandas():
 
     @normalize_token.register(pd.DataFrame)
     def normalize_dataframe(df):
-        mgr = df._data
+        mgr = df._mgr if pandas_version.major >= 2 else df._data
 
         data = list(mgr.arrays) + [df.columns, df.index]
         return list(map(normalize_token, data))


### PR DESCRIPTION
Fixes test failure in upstream:

```
FAILED dask/dataframe/tseries/tests/test_resample.py::test_series_resample[frame-ohlc-5-h-left-right] - FutureWarning: DataFrame._data is deprecated and will be removed in a future version. Use public APIs instead.
```

Xref https://github.com/pandas-dev/pandas/pull/52003.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
