### PR TITLE
Add archived gpuCI docs link to developer docs

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -376,5 +376,8 @@ Dask Maintainers can then approve gpuCI builds for these PRs with following choi
 - To only approve the PR contributor for the current PR, leave a comment which states ``ok to test``
 - To approve the current PR and all future PRs from the contributor, leave a comment which states ``add to allowlist``
 
+For more information about gpuCI please consult the `docs page
+<https://deploy-preview-320--docs-rapids-ai.netlify.app/gpuci>`_
+
 
 .. _Sphinx: https://www.sphinx-doc.org/


### PR DESCRIPTION
Adds an archive of the Jenkins-based gpuCI docs to the developer page to replace the broken link of the original page; intend to remove this once the migration to GHA is complete.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
