### PR TITLE
Add `to_backend` methods to API docs

### DIFF
--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -289,6 +289,7 @@ Array
    Array.store
    Array.sum
    Array.swapaxes
+   Array.to_backend
    Array.to_dask_dataframe
    Array.to_delayed
    Array.to_hdf5

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -123,6 +123,7 @@ Dataframe
     DataFrame.sub
     DataFrame.sum
     DataFrame.tail
+    DataFrame.to_backend
     DataFrame.to_bag
     DataFrame.to_csv
     DataFrame.to_dask_array
@@ -244,6 +245,7 @@ Series
    Series.std
    Series.sub
    Series.sum
+   Series.to_backend
    Series.to_bag
    Series.to_csv
    Series.to_dask_array


### PR DESCRIPTION
I noticed this while intersphinxing and trying to link to `to_backend`.

cc @rjzamora.