### PR TITLE
Deprecate `observed=False` for `groupby` with categoricals

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -112,7 +112,7 @@ def check_observed_deprecation():
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
-                message="The default of observed",
+                message=".*observed",
                 category=FutureWarning,
             )
             yield

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -112,7 +112,7 @@ def check_observed_deprecation():
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
-                message=".*observed",
+                message="The default of observed=False",
                 category=FutureWarning,
             )
             yield

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -12,6 +12,7 @@ PANDAS_GT_133 = PANDAS_VERSION >= Version("1.3.3")
 PANDAS_GT_140 = PANDAS_VERSION >= Version("1.4.0")
 PANDAS_GT_150 = PANDAS_VERSION >= Version("1.5.0")
 PANDAS_GT_200 = PANDAS_VERSION.major >= 2  # Also true for nightly builds
+PANDAS_GT_210 = PANDAS_VERSION.release >= (2, 1, 0)
 
 import pandas.testing as tm
 
@@ -99,6 +100,20 @@ def check_nuisance_columns_warning():
         with warnings.catch_warnings(record=True):
             warnings.filterwarnings(
                 "ignore", "Dropping of nuisance columns", FutureWarning
+            )
+            yield
+    else:
+        yield
+
+
+@contextlib.contextmanager
+def check_observed_deprecation():
+    if PANDAS_GT_210:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="The default of observed",
+                category=FutureWarning,
             )
             yield
     else:

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1377,7 +1377,7 @@ class _GroupBy:
     sort: bool
         Passed along to aggregation methods. If allowed,
         the output aggregation will have sorted keys.
-    observed: bool, default None
+    observed: bool, default False
         This only applies if any of the groupers are Categoricals.
         If True: only show observed values for categorical groupers.
         If False: show all values for categorical groupers.
@@ -2788,24 +2788,25 @@ class DataFrameGroupBy(_GroupBy):
     _token_prefix = "dataframe-groupby-"
 
     def __getitem__(self, key):
-        if isinstance(key, list):
-            g = DataFrameGroupBy(
-                self.obj,
-                by=self.by,
-                slice=key,
-                sort=self.sort,
-                **self.dropna,
-                **self.observed,
-            )
-        else:
-            g = SeriesGroupBy(
-                self.obj,
-                by=self.by,
-                slice=key,
-                sort=self.sort,
-                **self.dropna,
-                **self.observed,
-            )
+        with check_observed_deprecation():
+            if isinstance(key, list):
+                g = DataFrameGroupBy(
+                    self.obj,
+                    by=self.by,
+                    slice=key,
+                    sort=self.sort,
+                    **self.dropna,
+                    **self.observed,
+                )
+            else:
+                g = SeriesGroupBy(
+                    self.obj,
+                    by=self.by,
+                    slice=key,
+                    sort=self.sort,
+                    **self.dropna,
+                    **self.observed,
+                )
 
         # Need a list otherwise pandas will warn/error
         if isinstance(key, tuple):
@@ -2824,8 +2825,7 @@ class DataFrameGroupBy(_GroupBy):
 
     def __getattr__(self, key):
         try:
-            with check_observed_deprecation():
-                return self[key]
+            return self[key]
         except KeyError as e:
             raise AttributeError(e) from e
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -781,7 +781,8 @@ def _nunique_df_combine(df, levels, sort=False):
 
 
 def _nunique_df_aggregate(df, levels, name, sort=False):
-    return df.groupby(level=levels, sort=sort)[name].nunique()
+    with check_observed_deprecation():
+        return df.groupby(level=levels, sort=sort)[name].nunique()
 
 
 def _nunique_series_chunk(df, *by, **_ignored_):

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -19,6 +19,7 @@ from pyarrow import fs as pa_fs
 from dask import config
 from dask.base import tokenize
 from dask.core import flatten
+from dask.dataframe._compat import check_observed_deprecation
 from dask.dataframe.backends import pyarrow_schema_dispatch
 from dask.dataframe.io.parquet.utils import (
     Engine,
@@ -126,27 +127,28 @@ def _write_partitioned(
 
     md_list = []
     partition_keys = partition_keys[0] if len(partition_keys) == 1 else partition_keys
-    for keys, subgroup in data_df.groupby(partition_keys):
-        if not isinstance(keys, tuple):
-            keys = (keys,)
-        subdir = fs.sep.join(
-            [f"{name}={val}" for name, val in zip(partition_cols, keys)]
-        )
-        subtable = pandas_to_arrow_table(
-            subgroup, preserve_index=preserve_index, schema=subschema
-        )
-        prefix = fs.sep.join([root_path, subdir])
-        fs.mkdirs(prefix, exist_ok=True)
-        full_path = fs.sep.join([prefix, filename])
-        with fs.open(full_path, "wb") as f:
-            pq.write_table(
-                subtable,
-                f,
-                metadata_collector=md_list if return_metadata else None,
-                **kwargs,
+    with check_observed_deprecation():
+        for keys, subgroup in data_df.groupby(partition_keys):
+            if not isinstance(keys, tuple):
+                keys = (keys,)
+            subdir = fs.sep.join(
+                [f"{name}={val}" for name, val in zip(partition_cols, keys)]
             )
-        if return_metadata:
-            md_list[-1].set_file_path(fs.sep.join([subdir, filename]))
+            subtable = pandas_to_arrow_table(
+                subgroup, preserve_index=preserve_index, schema=subschema
+            )
+            prefix = fs.sep.join([root_path, subdir])
+            fs.mkdirs(prefix, exist_ok=True)
+            full_path = fs.sep.join([prefix, filename])
+            with fs.open(full_path, "wb") as f:
+                pq.write_table(
+                    subtable,
+                    f,
+                    metadata_collector=md_list if return_metadata else None,
+                    **kwargs,
+                )
+            if return_metadata:
+                md_list[-1].set_file_path(fs.sep.join([subdir, filename]))
 
     return md_list
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -6,7 +6,11 @@ import pandas as pd
 from pandas.api.types import is_extension_array_dtype
 from tlz import partition
 
-from dask.dataframe._compat import PANDAS_GT_131, PANDAS_GT_200
+from dask.dataframe._compat import (
+    PANDAS_GT_131,
+    PANDAS_GT_200,
+    check_observed_deprecation,
+)
 
 #  preserve compatibility while moving dispatch objects
 from dask.dataframe.dispatch import (  # noqa: F401
@@ -347,7 +351,8 @@ def unique(x, series_name=None):
 
 def value_counts_combine(x, sort=True, ascending=False, **groupby_kwargs):
     # sort and ascending don't actually matter until the agg step
-    return x.groupby(level=0, **groupby_kwargs).sum()
+    with check_observed_deprecation():
+        return x.groupby(level=0, **groupby_kwargs).sum()
 
 
 def value_counts_aggregate(

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -150,6 +150,7 @@ def test_concat_unions_categoricals():
     ],
 )
 @pytest.mark.filterwarnings("ignore:The default value of numeric_only")
+@pytest.mark.filterwarnings("ignore:The default of observed")
 @pytest.mark.filterwarnings("ignore:Dropping")
 def test_unknown_categoricals(shuffle_method, numeric_only):
     ddf = dd.DataFrame(

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -1,3 +1,4 @@
+import contextlib
 import operator
 import warnings
 
@@ -8,7 +9,7 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.dataframe import _compat
-from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200, tm
+from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200, PANDAS_GT_210, tm
 from dask.dataframe._pyarrow import to_pyarrow_string
 from dask.dataframe.core import _concat
 from dask.dataframe.utils import (
@@ -167,11 +168,29 @@ def test_unknown_categoricals(shuffle_method, numeric_only):
     assert_eq(ddf.w.value_counts(), df.w.value_counts())
     assert_eq(ddf.w.nunique(), df.w.nunique())
 
+    ctx = (
+        pytest.warns(FutureWarning, match="The default of observed=False")
+        if PANDAS_GT_210
+        else contextlib.nullcontext()
+    )
     numeric_kwargs = {} if numeric_only is None else {"numeric_only": numeric_only}
-    expected = df.groupby(df.w).sum(**numeric_kwargs)
-    assert_eq(ddf.groupby(ddf.w).sum(**numeric_kwargs), expected)
-    assert_eq(ddf.groupby(ddf.w).y.nunique(), df.groupby(df.w).y.nunique())
-    assert_eq(ddf.y.groupby(ddf.w).count(), df.y.groupby(df.w).count())
+    with ctx:
+        expected = df.groupby(df.w).sum(**numeric_kwargs)
+    with ctx:
+        result = ddf.groupby(ddf.w).sum(**numeric_kwargs)
+    assert_eq(result, expected)
+
+    with ctx:
+        expected = df.groupby(df.w).y.nunique()
+    with ctx:
+        result = ddf.groupby(ddf.w).y.nunique()
+    assert_eq(result, expected)
+
+    with ctx:
+        expected = df.y.groupby(df.w).count()
+    with ctx:
+        result = ddf.y.groupby(ddf.w).count()
+    assert_eq(result, expected)
 
 
 def test_is_categorical_dtype():

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -150,7 +150,6 @@ def test_concat_unions_categoricals():
     ],
 )
 @pytest.mark.filterwarnings("ignore:The default value of numeric_only")
-@pytest.mark.filterwarnings("ignore:The default of observed")
 @pytest.mark.filterwarnings("ignore:Dropping")
 def test_unknown_categoricals(shuffle_method, numeric_only):
     ddf = dd.DataFrame(

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2732,12 +2732,7 @@ def test_groupby_aggregate_categoricals(grouping, agg):
     with check_observed_deprecation():
         expected = agg(grouping(pdf)["value"])
 
-    if PANDAS_GT_210:
-        ctx = pytest.warns(FutureWarning, match="observed")
-    else:
-        ctx = contextlib.nullcontext()
-
-    with ctx:
+    with observed_ctx:
         result = agg(grouping(ddf)["value"])
     assert_eq(result, expected)
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2706,7 +2706,7 @@ def test_groupby_aggregate_categoricals(grouping, agg):
         expected = agg(grouping(pdf))
 
     if PANDAS_GT_210:
-        with pytest.warns(FutureWarning, match="value of `observed`"):
+        with pytest.warns(FutureWarning, match="observed"):
             with pytest.raises(NotImplementedError, match="numeric_only=False"):
                 result = agg(grouping(ddf))
                 assert_eq(result, expected)
@@ -2722,7 +2722,7 @@ def test_groupby_aggregate_categoricals(grouping, agg):
         expected = agg(grouping(pdf)["value"])
 
     if PANDAS_GT_210:
-        ctx = pytest.warns(FutureWarning, match="value of `observed`")
+        ctx = pytest.warns(FutureWarning, match="observed")
     else:
         ctx = contextlib.nullcontext()
 
@@ -2952,7 +2952,7 @@ def test_groupby_split_out_multiindex(split_out, column):
     ddf = dd.from_pandas(df, npartitions=3)
 
     if column == ["b", "e"] and PANDAS_GT_210:
-        ctx = pytest.warns(FutureWarning, match="value of `observed`")
+        ctx = pytest.warns(FutureWarning, match="observed")
     else:
         ctx = contextlib.nullcontext()
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -462,6 +462,7 @@ def test_groupby_multilevel_agg():
 
 
 @pytest.mark.parametrize("categoricals", [True, False])
+@pytest.mark.filterwarnings("ignore:.*observed")
 def test_groupby_get_group(categoricals):
     dsk = {
         ("x", 0): pd.DataFrame({"a": [1, 2, 6], "b": [4, 2, 7]}, index=[0, 1, 3]),


### PR DESCRIPTION
Fixes upstream deprecation of `observed=False`:

```
dask/dataframe/tests/test_groupby.py::test_groupby_aggregate_categoricals[disk-<lambda>-<lambda>0]: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.

dask/dataframe/tests/test_groupby.py::test_groupby_split_out_multiindex[disk-column2-2]: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.

dask/dataframe/io/tests/test_parquet.py::test_filters_categorical[pyarrow-fastparquet]: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.

dask/dataframe/io/tests/test_parquet.py::test_extra_file[pyarrow-b]: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.

dask/dataframe/io/tests/test_parquet.py::test_partitioned_preserve_index[pyarrow-fastparquet]: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.

dask/dataframe/io/tests/test_parquet.py::test_pyarrow_dataset_partitioned[pyarrow-True]: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.

dask/dataframe/io/tests/test_parquet.py::test_pyarrow_dataset_read_from_paths: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.

dask/dataframe/io/tests/test_parquet.py::test_pyarrow_dataset_filter_partitioned[True]: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
```

* Xref https://github.com/dask/dask/issues/10089.
* Xref https://github.com/pandas-dev/pandas/pull/51811.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
