### PR TITLE
Allow `pyarrow` build to continue on failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,6 +97,12 @@ jobs:
           path: env.yaml
 
       - name: Run tests
+        # pyarrow strings currently require upstream pandas to be installed.
+        # This can lead to unrelated failures on PRs, so we allow continuing on error
+        # for that specific build.
+        # TODO: Remove the `continue-on-error` line below once `pandas=2.0` is out
+        # and we no longer need to rely on upstream pandas.
+        continue-on-error: ${{ matrix.extra == 'pyarrow' }}
         run: source continuous_integration/scripts/run_tests.sh
 
       - name: Coverage


### PR DESCRIPTION
Unrelated failures have popped up on PRs due to the `pyarrow` build needing the have upstream `pandas` installed. It's not ideal, but I'd rather add back `continue-on-error: true` for this build than have unrelated red Xs on PRs. We can remove this again once `pandas=2.0` is out and we no longer need to rely on upstream `pandas`. 

cc @j-bennet 