### PR TITLE
Fix for no module named `ipykernel`

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -57,6 +57,9 @@ dependencies:
   - distributed
   - ipython
   - ipycytoscape
+  # until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is fixed
+  - ipywidgets<7.7.4
+  - ipykernel<6.22.0
   - lz4
   - numba
   - psutil

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -58,7 +58,7 @@ dependencies:
   - ipython
   - ipycytoscape
   # until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is fixed
-  - ipywidgets<7.7.4
+  - ipywidgets<8.0.5
   - ipykernel<6.22.0
   - lz4
   - numba

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -59,7 +59,7 @@ dependencies:
   - ipython
   - ipycytoscape
   # until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is fixed
-  - ipywidgets<7.7.4
+  - ipywidgets<8.0.5
   - ipykernel<6.22.0
   - lz4
   # https://github.com/numba/numba/issues/8304

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -58,6 +58,9 @@ dependencies:
   - distributed
   - ipython
   - ipycytoscape
+  # until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is fixed
+  - ipywidgets<7.7.4
+  - ipykernel<6.22.0
   - lz4
   # https://github.com/numba/numba/issues/8304
   # - numba  # not supported on 3.11

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -58,6 +58,9 @@ dependencies:
   - importlib-metadata>=4.13.0
   - ipython
   - ipycytoscape
+  # until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is fixed
+  - ipywidgets<7.7.4
+  - ipykernel<6.22.0
   - lz4
   - numba
   - psutil

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -59,7 +59,7 @@ dependencies:
   - ipython
   - ipycytoscape
   # until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is fixed
-  - ipywidgets<7.7.4
+  - ipywidgets<8.0.5
   - ipykernel<6.22.0
   - lz4
   - numba

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -57,6 +57,9 @@ dependencies:
   - distributed
   - ipython
   - ipycytoscape
+  # until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is fixed
+  - ipywidgets<7.7.4
+  - ipykernel<6.22.0
   - lz4
   - numba
   - psutil

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -58,7 +58,7 @@ dependencies:
   - ipython
   - ipycytoscape
   # until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is fixed
-  - ipywidgets<7.7.4
+  - ipywidgets<8.0.5
   - ipykernel<6.22.0
   - lz4
   - numba


### PR DESCRIPTION
Fixes CI failures because of a change in `ipywidgets`.

Xref https://github.com/jupyter-widgets/ipywidgets/issues/3731.

- [x] Closes https://github.com/dask/dask/issues/10100
- [x] Passes `pre-commit run --all-files`
