### PR TITLE
Install `mimesis` in CI environments

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -23,6 +23,7 @@ dependencies:
   - pytest-xdist
   - moto
   # Optional dependencies
+  - mimesis
   - numpy=1.23
   - pandas=1.5
   - flask

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -23,6 +23,7 @@ dependencies:
   - pytest-xdist
   - moto
   # Optional dependencies
+  - mimesis
   - numpy
   - pandas
   - flask

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -23,6 +23,7 @@ dependencies:
   - pytest-xdist
   - moto
   # Optional dependencies
+  - mimesis
   - numpy=1.21
   - pandas=1.3
   - flask

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -23,6 +23,7 @@ dependencies:
   - pytest-xdist
   - moto
   # Optional dependencies
+  - mimesis
   - numpy=1.22
   - pandas=1.4
   - flask

--- a/dask/tests/test_datasets.py
+++ b/dask/tests/test_datasets.py
@@ -41,4 +41,4 @@ def test_deterministic():
     pytest.importorskip("mimesis")
 
     b = dask.datasets.make_people(seed=123)
-    assert b.take(1)[0]["name"] == ("Leandro", "Orr")
+    assert b.take(1)[0]["name"] == ("Milda", "Ellis")


### PR DESCRIPTION
In https://github.com/dask/dask/issues/10090, we noticed that `dask/tests/test_datasets.py::test_deterministic` had been failing for some time but had gone unnoticed since `mimesis` wasn't being installed in our CI environments.

This PR adds `mimesis` to the environment files and resolves the test.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
