### PR TITLE
Only run `test_development_guidelines_matches_ci` on editable install

### DIFF
--- a/dask/tests/test_docs.py
+++ b/dask/tests/test_docs.py
@@ -1,27 +1,14 @@
-import os
-import sys
 from pathlib import Path
 
 import pytest
 
 
-# borrowing from https://github.com/pypa/pip/blob/0964c9797c1e8de901b045f66fe4d91502cc9877/pip/utils/__init__.py
-def is_editable_install():
-    """Is distribution an editable install?"""
-    for path_item in sys.path:
-        egg_link = os.path.join(path_item, "dask.egg-link")
-        if os.path.isfile(egg_link):
-            return True
-    return False
-
-
-@pytest.mark.skipif(
-    not is_editable_install(),
-    reason="Requires tests to be ran from an editable install",
-)
 def test_development_guidelines_matches_ci():
     """When the environment.yaml changes in CI, make sure to change it in the docs as well"""
     root_dir = Path(__file__).parent.parent.parent
+
+    if not (root_dir / ".github" / "workflows").exists():
+        pytest.skip("Test can only be run on an editable install")
 
     development_doc_file = root_dir / "docs" / "source" / "develop.rst"
     additional_ci_file = root_dir / ".github" / "workflows" / "additional.yml"

--- a/dask/tests/test_docs.py
+++ b/dask/tests/test_docs.py
@@ -1,6 +1,24 @@
+import os
+import sys
 from pathlib import Path
 
+import pytest
 
+
+# borrowing from https://github.com/pypa/pip/blob/0964c9797c1e8de901b045f66fe4d91502cc9877/pip/utils/__init__.py
+def is_editable_install():
+    """Is distribution an editable install?"""
+    for path_item in sys.path:
+        egg_link = os.path.join(path_item, "dask.egg-link")
+        if os.path.isfile(egg_link):
+            return True
+    return False
+
+
+@pytest.mark.skipif(
+    not is_editable_install(),
+    reason="Requires tests to be ran from an editable install",
+)
 def test_development_guidelines_matches_ci():
     """When the environment.yaml changes in CI, make sure to change it in the docs as well"""
     root_dir = Path(__file__).parent.parent.parent


### PR DESCRIPTION
It was pointed out in #10090 that `test_development_guidelines_matches_ci` fails when running from a non-editable install, as docs and GHA workflows are not included in Dask's wheel.

This PR resolves this failure by skipping the test if we detect that Dask is not an editable install.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
