### PR TITLE
Un-`xfail` `test_different_columns_are_allowed` with `pyarrow` strings active

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -440,7 +440,9 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
                 ):
                     return
 
-                result = self.map_partitions(to_pyarrow_string)
+                # this is an internal call, and if we enforce metadata,
+                # it may interfere when reading csv with enforce=False
+                result = self.map_partitions(to_pyarrow_string, enforce_metadata=False)
                 self.dask = result.dask
                 self._name = result._name
                 self._meta = result._meta

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1264,7 +1264,6 @@ def test_robust_column_mismatch():
         assert_eq(ddf, ddf)
 
 
-@pytest.mark.xfail_with_pyarrow_strings  # needs a follow-up
 def test_different_columns_are_allowed():
     files = csv_files.copy()
     k = sorted(files)[-1]


### PR DESCRIPTION
Unxfail `dask/dataframe/io/tests/test_csv.py::test_different_columns_are_allowed`.

Part of https://github.com/dask/dask/issues/10029.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
