### PR TITLE
The `axis` keyword in `DataFrame.rolling/Series.rolling` is deprecated

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -12,6 +12,7 @@ PANDAS_GT_133 = PANDAS_VERSION >= Version("1.3.3")
 PANDAS_GT_140 = PANDAS_VERSION >= Version("1.4.0")
 PANDAS_GT_150 = PANDAS_VERSION >= Version("1.5.0")
 PANDAS_GT_200 = PANDAS_VERSION.major >= 2  # Also true for nightly builds
+PANDAS_GT_210 = PANDAS_VERSION.release >= (2, 1, 0)
 
 import pandas.testing as tm
 
@@ -99,6 +100,20 @@ def check_nuisance_columns_warning():
         with warnings.catch_warnings(record=True):
             warnings.filterwarnings(
                 "ignore", "Dropping of nuisance columns", FutureWarning
+            )
+            yield
+    else:
+        yield
+
+
+@contextlib.contextmanager
+def check_axis_keyword_deprecation():
+    if PANDAS_GT_210:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="The 'axis' keyword|Support for axis",
+                category=FutureWarning,
             )
             yield
     else:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1958,8 +1958,8 @@ Dask Name: {name}, {layers}"""
         win_type : string, default None
             Provide a window type. The recognized window types are identical
             to pandas.
-        axis : int | str| None, default 0
-            This parameter is deprecated with pandas>=2.1.
+        axis : int, str, None, default 0
+            This parameter is deprecated with ``pandas>=2.1``.
 
         Returns
         -------

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1932,7 +1932,9 @@ Dask Name: {name}, {layers}"""
         else:
             return lambda self, other: elemwise(op, self, other)
 
-    def rolling(self, window, min_periods=None, center=False, win_type=None, axis=0):
+    def rolling(
+        self, window, min_periods=None, center=False, win_type=None, axis=no_default
+    ):
         """Provides rolling transformations.
 
         Parameters
@@ -1956,7 +1958,8 @@ Dask Name: {name}, {layers}"""
         win_type : string, default None
             Provide a window type. The recognized window types are identical
             to pandas.
-        axis : int, default 0
+        axis : int | str| None, default 0
+            This parameter is deprecated with pandas>=2.1.
 
         Returns
         -------

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -328,20 +328,13 @@ def test_rolling_raises():
         {"a": np.random.randn(25).cumsum(), "b": np.random.randint(100, size=(25,))}
     )
     ddf = dd.from_pandas(df, 3)
-    ctx = (
-        pytest.warns(FutureWarning, match="The 'axis' keyword|Support for axis")
-        if PANDAS_GT_210
-        else contextlib.nullcontext()
-    )
 
     pytest.raises(ValueError, lambda: ddf.rolling(1.5))
     pytest.raises(ValueError, lambda: ddf.rolling(-1))
     pytest.raises(ValueError, lambda: ddf.rolling(3, min_periods=1.2))
     pytest.raises(ValueError, lambda: ddf.rolling(3, min_periods=-2))
-    with ctx:
-        pytest.raises(ValueError, lambda: ddf.rolling(3, axis=10))
-    with ctx:
-        pytest.raises(ValueError, lambda: ddf.rolling(3, axis="coulombs"))
+    pytest.raises(ValueError, lambda: ddf.rolling(3, axis=10))
+    pytest.raises(ValueError, lambda: ddf.rolling(3, axis="coulombs"))
     pytest.raises(NotImplementedError, lambda: ddf.rolling(100).mean().compute())
 
 


### PR DESCRIPTION
Following this change in upstream:

* https://github.com/pandas-dev/pandas/pull/51997

Xref https://github.com/dask/dask/issues/10089.

Fixes upstream CI build failures related to the `axis` keyword in `.rolling`, such as:

```
dask/dataframe/io/tests/test_parquet.py::test_optimize_getitem_and_nonblockwise[2 failing variants]: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/io/tests/test_parquet.py::test_optimize_and_not[2 failing variants]: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_time_rolling_methods[48 failing variants]: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_rolling_methods[96 failing variants]: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_time_rolling_cov[4 failing variants]: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_time_rolling_large_window_fixed_chunks[6 failing variants]: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_time_rolling_large_window_variable_chunks[4 failing variants]: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_rolling_agg_aggregate: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_groupby_rolling: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_rolling_cov[8 failing variants]: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_rolling_raises: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_rolling_names: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_rolling_axis: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_rolling_partition_size: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_rolling_repr: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_time_rolling_repr: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
dask/dataframe/tests/test_rolling.py::test_time_rolling_constructor: FutureWarning: The 'axis' keyword in DataFrame.rolling is deprecated and will be removed in a future version. Call the method without the axis keyword instead.
```

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
