### PR TITLE
Avoid deprecated `GroupBy.dtypes`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -42,7 +42,6 @@ from dask.dataframe._compat import (
     PANDAS_VERSION,
     check_nuisance_columns_warning,
     check_numeric_only_deprecation,
-    is_any_real_numeric_dtype,
 )
 from dask.dataframe.accessor import CachedAccessor, DatetimeAccessor, StringAccessor
 from dask.dataframe.categorical import CategoricalAccessor, categorize
@@ -3970,9 +3969,6 @@ Dask Name: {name}, {layers}""".format(
     def _get_numeric_data(self, how="any", subset=None):
         return self
 
-    def _all_numerics(self):
-        return is_any_real_numeric_dtype(self._meta.dtype)
-
     if not PANDAS_GT_200:
 
         @derived_from(pd.Series)
@@ -5501,9 +5497,6 @@ class DataFrame(_Frame):
     def to_string(self, max_rows=5):
         # option_context doesn't affect
         return self._repr_data().to_string(max_rows=max_rows, show_dimensions=False)
-
-    def _all_numerics(self):
-        return self._meta.dtypes.apply(is_any_real_numeric_dtype).all()
 
     def _get_numeric_data(self, how="any", subset=None):
         # calculate columns to avoid unnecessary calculation

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -42,6 +42,7 @@ from dask.dataframe._compat import (
     PANDAS_VERSION,
     check_nuisance_columns_warning,
     check_numeric_only_deprecation,
+    is_any_real_numeric_dtype,
 )
 from dask.dataframe.accessor import CachedAccessor, DatetimeAccessor, StringAccessor
 from dask.dataframe.categorical import CategoricalAccessor, categorize
@@ -3969,6 +3970,9 @@ Dask Name: {name}, {layers}""".format(
     def _get_numeric_data(self, how="any", subset=None):
         return self
 
+    def _all_numerics(self):
+        return is_any_real_numeric_dtype(self._meta.dtype)
+
     if not PANDAS_GT_200:
 
         @derived_from(pd.Series)
@@ -5497,6 +5501,9 @@ class DataFrame(_Frame):
     def to_string(self, max_rows=5):
         # option_context doesn't affect
         return self._repr_data().to_string(max_rows=max_rows, show_dimensions=False)
+
+    def _all_numerics(self):
+        return self._meta.dtypes.apply(is_any_real_numeric_dtype).all()
 
     def _get_numeric_data(self, how="any", subset=None):
         # calculate columns to avoid unnecessary calculation

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2858,11 +2858,15 @@ class DataFrameGroupBy(_GroupBy):
         except KeyError as e:
             raise AttributeError(e) from e
 
+    def _by_names(self):
+        by_items = self.by if isinstance(self.by, list) else [self.by]
+        return [x.name if isinstance(x, Series) else x for x in by_items]
+
     def _all_numeric(self):
         """Are all columns that we're not grouping on numeric?"""
         all_dtypes = self._meta.head(1).dtypes
-        drop_cols = self.by if isinstance(self.by, list) else [self.by]
-        return all_dtypes.drop(drop_cols).apply(is_any_real_numeric_dtype).all()
+        ungrouped = all_dtypes.drop(self._by_names(), errors="ignore")
+        return ungrouped.apply(is_any_real_numeric_dtype).all()
 
     @_aggregate_docstring(based_on="pd.core.groupby.DataFrameGroupBy.aggregate")
     def aggregate(

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -310,8 +310,7 @@ def numeric_only_deprecate_default(func):
                 raise NotImplementedError(
                     "'numeric_only=False' is not implemented in Dask."
                 )
-            numerics = self.obj._meta._get_numeric_data()
-            has_non_numerics = set(self._meta.dtypes.columns) - set(numerics.columns)
+            has_non_numerics = not self.obj._all_numerics()
             if has_non_numerics and PANDAS_GT_150 and not PANDAS_GT_200:
                 if numeric_only is no_default:
                     warnings.warn(
@@ -350,10 +349,7 @@ def numeric_only_not_implemented(func):
                     raise NotImplementedError(
                         "'numeric_only=False' is not implemented in Dask."
                     )
-                numerics = self.obj._meta._get_numeric_data()
-                has_non_numerics = set(self._meta.dtypes.columns) - set(
-                    numerics.columns
-                )
+                has_non_numerics = not self.obj._all_numerics()
                 if has_non_numerics:
                     if numeric_only is False or (
                         PANDAS_GT_200 and numeric_only is no_default

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1848,23 +1848,7 @@ def test_groupby_string_label():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "op",
-    [
-        pytest.param(
-            "cumsum",
-            marks=pytest.mark.xfail(
-                PANDAS_GT_200, reason="numeric_only=False not implemented"
-            ),
-        ),
-        pytest.param(
-            "cumprod",
-            marks=pytest.mark.xfail(
-                PANDAS_GT_200, reason="numeric_only=False not implemented"
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("op", ["cumsum", "cumprod"])
 def test_groupby_dataframe_cum_caching(op):
     """Test caching behavior of cumulative operations on grouped dataframes.
 
@@ -2291,7 +2275,6 @@ def test_std_columns_int():
     ddf.groupby(by).std()
 
 
-@pytest.mark.xfail(PANDAS_GT_200, reason="numeric_only=False not implemented")
 def test_timeseries():
     df = dask.datasets.timeseries().partitions[:2]
     assert_eq(df.groupby("name").std(), df.groupby("name").std())
@@ -2785,12 +2768,7 @@ def test_groupby_aggregate_categoricals(grouping, agg):
         if PANDAS_GT_210
         else contextlib.nullcontext()
     )
-    numeric_ctx = (
-        pytest.raises(NotImplementedError, match="numeric_only=False")
-        if PANDAS_GT_200
-        else contextlib.nullcontext()
-    )
-    with observed_ctx, numeric_ctx:
+    with observed_ctx:
         result = agg(grouping(ddf))
         assert_eq(result, expected)
 


### PR DESCRIPTION
Following this change in upstream:

* https://github.com/pandas-dev/pandas/pull/51997

Xref https://github.com/dask/dask/issues/10089.

Fixes this failure in upstream build:

```
FutureWarning: DataFrameGroupBy.dtypes is deprecated and will be removed in a future version. Check the dtypes on the base object instead
```

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
