### PR TITLE
Restore Entrypoints compatibility

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -9,10 +9,10 @@ _PY_VERSION = parse_version(".".join(map(str, sys.version_info[:3])))
 _EMSCRIPTEN = sys.platform == "emscripten"
 
 
-def entry_points(*args, **kwargs):
+def entry_points(group=None):
     warnings.warn(
         "`dask.compatibility.entry_points` has been replaced by `importlib_metadata.entry_points` and will be removed "
         "in a future version. Please use `importlib_metadata.entry_points` instead.",
         DeprecationWarning,
     )
-    return _entry_points(*args, **kwargs)
+    return _entry_points(group=group)

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -1,8 +1,18 @@
 import sys
+import warnings
 
-from importlib_metadata import entry_points  # noqa
+from importlib_metadata import entry_points as _entry_points
 from packaging.version import parse as parse_version
 
 _PY_VERSION = parse_version(".".join(map(str, sys.version_info[:3])))
 
 _EMSCRIPTEN = sys.platform == "emscripten"
+
+
+def entry_points(*args, **kwargs):
+    warnings.warn(
+        "`dask.compatibility.entry_points` has been replaced by `importlib_metadata.entry_points` and will be removed "
+        "in a future version. Please use `importlib_metadata.entry_points` instead.",
+        DeprecationWarning,
+    )
+    return _entry_points(*args, **kwargs)

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -1,5 +1,6 @@
 import sys
 
+from importlib_metadata import entry_points  # noqa
 from packaging.version import parse as parse_version
 
 _PY_VERSION = parse_version(".".join(map(str, sys.version_info[:3])))

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -14,5 +14,6 @@ def entry_points(group=None):
         "`dask.compatibility.entry_points` has been replaced by `importlib_metadata.entry_points` and will be removed "
         "in a future version. Please use `importlib_metadata.entry_points` instead.",
         DeprecationWarning,
+        stacklevel=2,
     )
     return _entry_points(group=group)

--- a/dask/tests/test_compatibility.py
+++ b/dask/tests/test_compatibility.py
@@ -1,0 +1,5 @@
+from dask.compatibility import entry_points
+
+
+def test_entry_points():
+    assert "pytest" in [ep.name for ep in entry_points(group="console_scripts")]

--- a/dask/tests/test_compatibility.py
+++ b/dask/tests/test_compatibility.py
@@ -4,5 +4,5 @@ from dask.compatibility import entry_points
 
 
 def test_entry_points():
-    with pytest.raises(DeprecationWarning):
+    with pytest.warns(DeprecationWarning):
         assert "pytest" in [ep.name for ep in entry_points(group="console_scripts")]

--- a/dask/tests/test_compatibility.py
+++ b/dask/tests/test_compatibility.py
@@ -1,5 +1,8 @@
+import pytest
+
 from dask.compatibility import entry_points
 
 
 def test_entry_points():
-    assert "pytest" in [ep.name for ep in entry_points(group="console_scripts")]
+    with pytest.raises(DeprecationWarning):
+        assert "pytest" in [ep.name for ep in entry_points(group="console_scripts")]


### PR DESCRIPTION
- [x] Closes #10112
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Restored the test that was removed in #10070 and then imported `importlib_metadata.entry_point` to replace the old implementation. 

I added an extra commit that adds a deprecation warning so that this can be removed again in the future. But we can pop that commit off if we just want to leave it as it is.