### PR TITLE
Make `dask.compatibility` private

### DIFF
--- a/dask/_compatibility.py
+++ b/dask/_compatibility.py
@@ -1,0 +1,19 @@
+import sys
+import warnings
+
+from importlib_metadata import entry_points as _entry_points
+from packaging.version import parse as parse_version
+
+_PY_VERSION = parse_version(".".join(map(str, sys.version_info[:3])))
+
+_EMSCRIPTEN = sys.platform == "emscripten"
+
+
+def entry_points(group=None):
+    warnings.warn(
+        "`dask._compatibility.entry_points` has been replaced by `importlib_metadata.entry_points` and will be removed "
+        "in a future version. Please use `importlib_metadata.entry_points` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _entry_points(group=group)

--- a/dask/_compatibility.py
+++ b/dask/_compatibility.py
@@ -4,9 +4,9 @@ import warnings
 from importlib_metadata import entry_points as _entry_points
 from packaging.version import parse as parse_version
 
-_PY_VERSION = parse_version(".".join(map(str, sys.version_info[:3])))
+PY_VERSION = parse_version(".".join(map(str, sys.version_info[:3])))
 
-_EMSCRIPTEN = sys.platform == "emscripten"
+EMSCRIPTEN = sys.platform == "emscripten"
 
 
 def entry_points(group=None):

--- a/dask/base.py
+++ b/dask/base.py
@@ -25,7 +25,7 @@ from tlz import curry, groupby, identity, merge
 from tlz.functoolz import Compose
 
 from dask import config, local
-from dask.compatibility import _EMSCRIPTEN, _PY_VERSION
+from dask._compatibility import _EMSCRIPTEN, _PY_VERSION
 from dask.core import flatten
 from dask.core import get as simple_get
 from dask.core import literal, quote

--- a/dask/base.py
+++ b/dask/base.py
@@ -25,7 +25,7 @@ from tlz import curry, groupby, identity, merge
 from tlz.functoolz import Compose
 
 from dask import config, local
-from dask._compatibility import _EMSCRIPTEN, _PY_VERSION
+from dask._compatibility import EMSCRIPTEN, PY_VERSION
 from dask.core import flatten
 from dask.core import get as simple_get
 from dask.core import literal, quote
@@ -909,7 +909,7 @@ def persist(*args, traverse=True, optimize_graph=True, scheduler=None, **kwargs)
 
 # Pass `usedforsecurity=False` for Python 3.9+ to support FIPS builds of Python
 _md5: Callable
-if _PY_VERSION >= parse_version("3.9"):
+if PY_VERSION >= parse_version("3.9"):
 
     def _md5(x, _hashlib_md5=hashlib.md5):
         return _hashlib_md5(x, usedforsecurity=False)
@@ -1292,7 +1292,7 @@ named_schedulers: dict[str, SchedulerGetCallable] = {
     "single-threaded": local.get_sync,
 }
 
-if not _EMSCRIPTEN:
+if not EMSCRIPTEN:
     from dask import threaded
 
     named_schedulers.update(

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -1,19 +1,15 @@
-import sys
 import warnings
 
-from importlib_metadata import entry_points as _entry_points
-from packaging.version import parse as parse_version
+from dask._compatibility import (  # noqa
+    _EMSCRIPTEN,
+    _PY_VERSION,
+    entry_points,
+    parse_version,
+)
 
-_PY_VERSION = parse_version(".".join(map(str, sys.version_info[:3])))
-
-_EMSCRIPTEN = sys.platform == "emscripten"
-
-
-def entry_points(group=None):
-    warnings.warn(
-        "`dask.compatibility.entry_points` has been replaced by `importlib_metadata.entry_points` and will be removed "
-        "in a future version. Please use `importlib_metadata.entry_points` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _entry_points(group=group)
+warnings.warn(
+    "`dask.compatibility` is not intended for external use and has been renamed to `dask._compatibility`. "
+    "This backward-compatible shim will be removed in a future release. Please find an alternative.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -1,11 +1,8 @@
 import warnings
 
-from dask._compatibility import (  # noqa
-    _EMSCRIPTEN,
-    _PY_VERSION,
-    entry_points,
-    parse_version,
-)
+from dask._compatibility import EMSCRIPTEN as _EMSCRIPTEN  # noqa
+from dask._compatibility import PY_VERSION as _PY_VERSION  # noqa
+from dask._compatibility import entry_points, parse_version  # noqa
 
 warnings.warn(
     "`dask.compatibility` is not intended for external use and has been renamed to `dask._compatibility`. "

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 
 import dask
 import dask.dataframe as dd
-from dask._compatibility import _PY_VERSION
+from dask._compatibility import PY_VERSION
 from dask.dataframe._compat import tm
 from dask.dataframe.optimize import optimize_dataframe_getitem
 from dask.dataframe.utils import assert_eq
@@ -53,7 +53,7 @@ def test_to_hdf():
 
 
 @pytest.mark.skipif(
-    _PY_VERSION >= Version("3.11"),
+    PY_VERSION >= Version("3.11"),
     reason="segfaults due to https://github.com/PyTables/PyTables/issues/977",
 )
 def test_to_hdf_multiple_nodes():
@@ -399,7 +399,7 @@ def test_to_hdf_link_optimizations():
 
 
 @pytest.mark.skipif(
-    _PY_VERSION >= Version("3.11"),
+    PY_VERSION >= Version("3.11"),
     reason="segfaults due to https://github.com/PyTables/PyTables/issues/977",
 )
 @pytest.mark.slow
@@ -493,7 +493,7 @@ def test_to_hdf_exceptions():
 
 
 @pytest.mark.skipif(
-    _PY_VERSION >= Version("3.11"),
+    PY_VERSION >= Version("3.11"),
     reason="segfaults due to https://github.com/PyTables/PyTables/issues/977",
 )
 @pytest.mark.parametrize("scheduler", ["sync", "threads", "processes"])
@@ -698,7 +698,7 @@ def test_read_hdf_multiply_open():
 
 
 @pytest.mark.skipif(
-    _PY_VERSION >= Version("3.11"),
+    PY_VERSION >= Version("3.11"),
     reason="segfaults due to https://github.com/PyTables/PyTables/issues/977",
 )
 def test_read_hdf_multiple():

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 
 import dask
 import dask.dataframe as dd
-from dask.compatibility import _PY_VERSION
+from dask._compatibility import _PY_VERSION
 from dask.dataframe._compat import tm
 from dask.dataframe.optimize import optimize_dataframe_getitem
 from dask.dataframe.utils import assert_eq

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1678,7 +1678,7 @@ def check_default_scheduler(module, collection, expected, emscripten):
         "'dask.bag', 'Bag', 'processes', False",
     ),
 )
-def testEMSCRIPTEN_default_scheduler(params):
+def test_emscripten_default_scheduler(params):
     pytest.importorskip("dask.array")
     pytest.importorskip("dask.dataframe")
     proc = subprocess.run(

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1638,7 +1638,7 @@ def test_compute_as_if_collection_low_level_task_graph():
     da.utils.assert_eq(x, result)
 
 
-# A function designed to be run in a subprocess with dask.compatibility._EMSCRIPTEN
+# A function designed to be run in a subprocess with dask._compatibility._EMSCRIPTEN
 # patched. This allows for checking for different default schedulers depending on the
 # platform. One might prefer patching `sys.platform` for a more direct test, but that
 # causes problems in other libraries.

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -1638,7 +1638,7 @@ def test_compute_as_if_collection_low_level_task_graph():
     da.utils.assert_eq(x, result)
 
 
-# A function designed to be run in a subprocess with dask._compatibility._EMSCRIPTEN
+# A function designed to be run in a subprocess with dask._compatibility.EMSCRIPTEN
 # patched. This allows for checking for different default schedulers depending on the
 # platform. One might prefer patching `sys.platform` for a more direct test, but that
 # causes problems in other libraries.
@@ -1678,7 +1678,7 @@ def check_default_scheduler(module, collection, expected, emscripten):
         "'dask.bag', 'Bag', 'processes', False",
     ),
 )
-def test_emscripten_default_scheduler(params):
+def testEMSCRIPTEN_default_scheduler(params):
     pytest.importorskip("dask.array")
     pytest.importorskip("dask.dataframe")
     proc = subprocess.run(

--- a/dask/tests/test_compatibility.py
+++ b/dask/tests/test_compatibility.py
@@ -1,6 +1,11 @@
 import pytest
 
-from dask.compatibility import entry_points
+from dask._compatibility import entry_points
+
+
+def test_deprecation():
+    with pytest.warns(DeprecationWarning):
+        from dask.compatibility import _EMSCRIPTEN  # noqa
 
 
 def test_entry_points():


### PR DESCRIPTION
xref https://github.com/dask/dask/pull/10113#pullrequestreview-1354876683

In `dask-kubernetes` we were using `dask.compatibility.entry_points` which were recently removed (#10070) and restored again (#10113). @jrbourbeau mentioned that `dask.compatibility` is not intended to be used outside of `dask` so opening this PR to rename it to `dask._compatibility` with a fallback shim and deprecation warning.

_Side note: This could probably be done for a bunch of code throughout `dask` and `distributed` to reduce maintenance burden and avoid future breakages. If other folks think this would be helpful I'd be happy to help with this effort._