### PR TITLE
Fix `test_null_partition_pyarrow` in `pyarrow` CI build

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -3697,6 +3697,12 @@ def test_null_partition_pyarrow(tmpdir, scheduler):
             },
         },
     )
+
+    if pyarrow_version.major >= 12:
+        # pyarrow>=12 would also convert index dtype to nullable
+        # see https://github.com/apache/arrow/pull/34445
+        ddf.index = ddf.index.astype("Int64")
+
     assert_eq(
         ddf[["x", "id"]],
         ddf_read[["x", "id"]],


### PR DESCRIPTION
Fixed `test_null_partition_pyarrow` that breaks in pyarrow build.

* Xref https://github.com/apache/arrow/pull/34445.

Thanks a lot to @phofl for the tip.

```
FAILED dask/dataframe/io/tests/test_parquet.py::test_null_partition_pyarrow[None] - AssertionError: DataFrame.index are different

Attribute "dtype" are different
[left]:  int64
[right]: Int64
FAILED dask/dataframe/io/tests/test_parquet.py::test_null_partition_pyarrow[processes] - AssertionError: DataFrame.index are different

Attribute "dtype" are different
[left]:  int64
[right]: Int64
```

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
