### PR TITLE
Relax `assert_eq` checks on `Scalar`-like objects

### DIFF
--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -503,9 +503,13 @@ def _check_dask(dsk, check_names=True, check_dtypes=True, result=None, scheduler
                 result=result.index,
             )
         else:
-            assert np.isscalar(result) or isinstance(
+            if not np.isscalar(result) and not isinstance(
                 result, (pd.Timestamp, pd.Timedelta)
-            )
+            ):
+                raise TypeError(
+                    "Expected object of type dataframe, series, index, or scalar.\n"
+                    "    Got: " + str(type(result))
+                )
             if check_dtypes:
                 assert_dask_dtypes(dsk, result)
         return result

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -502,15 +502,12 @@ def _check_dask(dsk, check_names=True, check_dtypes=True, result=None, scheduler
                 check_dtypes=check_dtypes,
                 result=result.index,
             )
-        elif isinstance(dsk, dd.core.Scalar):
+        else:
             assert np.isscalar(result) or isinstance(
                 result, (pd.Timestamp, pd.Timedelta)
             )
             if check_dtypes:
                 assert_dask_dtypes(dsk, result)
-        else:
-            msg = f"Unsupported dask instance {type(dsk)} found"
-            raise AssertionError(msg)
         return result
     return dsk
 


### PR DESCRIPTION
This is part of an effort to reuse assert_eq on other objects that are similar to Dask Dataframe, but not exactly Dask dataframe objects.

This was done previously with Series/Dataframe types above, now we allow any object that isn't a Series/DataFrame/Index to be interpretted as a Scalar.  Previously this would raise an exception.
