### PR TITLE
Fix `valid_divisions` when passed a `tuple`

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -24,6 +24,7 @@ from dask.dataframe.utils import (
     meta_series_constructor,
     raise_on_meta_error,
     shard_df_on_index,
+    valid_divisions,
 )
 from dask.local import get_sync
 
@@ -648,3 +649,19 @@ def test_meta_constructor_utilities_raise(data):
         meta_series_constructor(data)
     with pytest.raises(TypeError, match="not supported by meta_frame"):
         meta_frame_constructor(data)
+
+
+@pytest.mark.parametrize(
+    "divisions, valid",
+    [
+        ([1, 2, 3], True),
+        ([3, 2, 1], False),
+        ([1, 1, 1], False),
+        ([0, 1, 1], True),
+        ((1, 2, 3), True),
+        (123, False),
+        ([0, float("nan"), 1], False),
+    ],
+)
+def test_valid_divisions(divisions, valid):
+    assert valid_divisions(divisions) == valid

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -737,6 +737,7 @@ def valid_divisions(divisions):
     # https://github.com/pandas-dev/pandas/issues/52283
     if isinstance(divisions, tuple):
         divisions = list(divisions)
+
     if pd.isnull(divisions).any():
         return False
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -723,6 +723,8 @@ def valid_divisions(divisions):
     False
     >>> valid_divisions([0, 1, 1])
     True
+    >>> valid_divisions((1, 2, 3))
+    True
     >>> valid_divisions(123)
     False
     >>> valid_divisions([0, float('nan'), 1])
@@ -731,7 +733,7 @@ def valid_divisions(divisions):
     if not isinstance(divisions, (tuple, list)):
         return False
 
-    if pd.isnull(divisions).any():
+    if pd.Series(divisions).isnull().any():
         return False
 
     for i, x in enumerate(divisions[:-2]):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -733,7 +733,11 @@ def valid_divisions(divisions):
     if not isinstance(divisions, (tuple, list)):
         return False
 
-    if pd.Series(divisions).isnull().any():
+    # Cast tuples to lists as `pd.isnull` treats them differently
+    # https://github.com/pandas-dev/pandas/issues/52283
+    if isinstance(divisions, tuple):
+        divisions = list(divisions)
+    if pd.isnull(divisions).any():
         return False
 
     for i, x in enumerate(divisions[:-2]):


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

`pd.isnull(tuple)` returns a bool not a series so the valid_divisions function fails with the following error if a tuple is passed.

```
if pd.isnull(divisions).any():
    AttributeError: 'bool' object has no attribute 'any'
```