### PR TITLE
Handle `None` column name when checking if columns are all numeric

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2860,10 +2860,9 @@ class DataFrameGroupBy(_GroupBy):
     def _all_numeric(self):
         """Are all columns that we're not grouping on numeric?"""
         numerics = self.obj._meta._get_numeric_data()
-        non_numerics = (
-            set(self.obj._meta.dtypes.index) - set(self._meta.grouper.names)
-        ) - set(numerics.columns)
-        return len(non_numerics) == 0
+        # This computes a groupby but only on the empty meta
+        post_group_columns = self._meta.count().columns
+        return len(set(post_group_columns) - set(numerics.columns)) == 0
 
     @_aggregate_docstring(based_on="pd.core.groupby.DataFrameGroupBy.aggregate")
     def aggregate(

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3267,6 +3267,15 @@ def test_groupby_aggregate_categorical_observed(
     )
 
 
+@pytest.mark.xfail(reason="https://github.com/dask/dask/issues/10127")
+@pytest.mark.skipif(not PANDAS_GT_150, reason="requires pandas >= 1.5.0")
+def test_groupby_numeric_only_None_column_name():
+    df = pd.DataFrame({"a": [1, 2, 3], None: ["a", "b", "c"]})
+    ddf = dd.from_pandas(df, npartitions=1)
+    with pytest.raises(NotImplementedError):
+        ddf.groupby(lambda x: x).mean(numeric_only=False)
+
+
 @pytest.mark.skipif(not PANDAS_GT_140, reason="requires pandas >= 1.4.0")
 @pytest.mark.parametrize("shuffle", [True, False])
 def test_dataframe_named_agg(shuffle):

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3267,7 +3267,6 @@ def test_groupby_aggregate_categorical_observed(
     )
 
 
-@pytest.mark.xfail(reason="https://github.com/dask/dask/issues/10127")
 @pytest.mark.skipif(not PANDAS_GT_150, reason="requires pandas >= 1.5.0")
 def test_groupby_numeric_only_None_column_name():
     df = pd.DataFrame({"a": [1, 2, 3], None: ["a", "b", "c"]})


### PR DESCRIPTION
We cannot ask for the names of the grouper since if the data frame has
a column named None we cannot distinguish it as a grouping column from
the case where the groupby argument is not a column selection (e.g. a
function that assigns rows to groups). To fix this, just perform the
groupby on meta and see what we get out.

Closes #10127.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
