### PR TITLE
Deprecate `convert_dtype` in `Series.apply`

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -148,6 +148,20 @@ def check_axis_keyword_deprecation():
         yield
 
 
+@contextlib.contextmanager
+def check_convert_dtype_deprecation():
+    if PANDAS_GT_210:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="the convert_dtype parameter",
+                category=FutureWarning,
+            )
+            yield
+    else:
+        yield
+
+
 if PANDAS_GT_150:
     IndexingError = pd.errors.IndexingError
 else:

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -9,6 +9,7 @@ from tlz import partition
 from dask.dataframe._compat import (
     PANDAS_GT_131,
     PANDAS_GT_200,
+    check_convert_dtype_deprecation,
     check_observed_deprecation,
 )
 
@@ -47,6 +48,11 @@ def loc(df, iindexer, cindexer=None):
 
 def iloc(df, cindexer=None):
     return df.iloc[:, cindexer]
+
+
+def apply(df, *args, **kwargs):
+    with check_convert_dtype_deprecation():
+        return df.apply(*args, **kwargs)
 
 
 def try_loc(df, iindexer, cindexer=None):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3173,12 +3173,14 @@ def test_apply_convert_dtype(convert_dtype):
     ddf = dd.from_pandas(df, npartitions=2)
     if PANDAS_GT_210:
         ctx = pytest.warns(FutureWarning, match="the convert_dtype parameter")
+        with ctx:
+            expected = df.x.apply(lambda x: x + 1, convert_dtype=convert_dtype)
+        with ctx:
+            result = ddf.x.apply(lambda x: x + 1, convert_dtype=convert_dtype)
     else:
-        ctx = contextlib.nullcontext()
-    with ctx:
         expected = df.x.apply(lambda x: x + 1, convert_dtype=convert_dtype)
-    with ctx:
-        result = ddf.x.apply(lambda x: x + 1, convert_dtype=convert_dtype)
+        with pytest.warns(UserWarning, match="You did not provide metadata"):
+            result = ddf.x.apply(lambda x: x + 1, convert_dtype=convert_dtype)
     assert_eq(result, expected)
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3168,6 +3168,7 @@ def test_apply():
 
 @pytest.mark.parametrize("convert_dtype", [True, False])
 def test_apply_convert_dtype(convert_dtype):
+    """Make sure that explicit convert_dtype raises a warning with pandas>=2.1"""
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})
     ddf = dd.from_pandas(df, npartitions=2)
     if PANDAS_GT_210:


### PR DESCRIPTION
* Xref https://github.com/pandas-dev/pandas/pull/52257.

Fixes the following upstream failures:

```
dask/dataframe/tests/test_dataframe.py::test_apply: FutureWarning: the convert_dtype parameter is deprecated and will be removed in a future version.  Do ``ser.astype(object).apply()`` instead if you want ``convert_dtype=False``.
dask/dataframe/tests/test_dataframe.py::test_apply_infer_columns: FutureWarning: the convert_dtype parameter is deprecated and will be removed in a future version.  Do ``ser.astype(object).apply()`` instead if you want ``convert_dtype=False``.
```

- [x] Closes https://github.com/dask/dask/issues/10089
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
