### PR TITLE
Remove `dask/gpu` from gpuCI update reviewers

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -61,7 +61,6 @@ jobs:
           draft: true
           commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`"
           title: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`"
-          team-reviewers: "dask/gpu"
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: "upgrade-gpuci-rapids"
           body: |


### PR DESCRIPTION
Resolves failures that started cropping up in the gpuCI updating workflow due to the fact that the dask/gpu team isn't a collaborator on this repo - alternatively, we could add this team as a repo collaborator.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
