### PR TITLE
Document minimum `zarr`

### DIFF
--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -30,7 +30,7 @@ dependencies:
   - fastparquet
   - h5py
   - pytables
-  - zarr
+  - zarr=2.12.0  # Only tested here
   # `tiledb-py=0.17.5` lead to strange seg faults in CI.
   # We should unpin when possible.
   # https://github.com/dask/dask/pull/9569

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -30,7 +30,7 @@ dependencies:
   - fastparquet
   - h5py
   - pytables
-  - zarr=2.12.0  # Only tested here
+  - zarr
   # `tiledb-py=0.17.5` lead to strange seg faults in CI.
   # We should unpin when possible.
   # https://github.com/dask/dask/pull/9569

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -135,6 +135,8 @@ These optional dependencies and their minimum supported versions are listed belo
 +---------------+----------+--------------------------------------------------------------+
 |    xxhash     |          |                  Faster hashing of arrays                    |
 +---------------+----------+--------------------------------------------------------------+
+|     zarr      | >=2.12.0 |                Reading and writing with Zarr                 |
++---------------+----------+--------------------------------------------------------------+
 
 \* Note that ``toolz`` is a mandatory dependency but it can be transparently replaced with
 ``cytoolz``.


### PR DESCRIPTION
Offline I saw a user run into the following issue with the latest `dask` release and an old version of `zarr` (in this example I was using `zarr=2.7.1`):

```python
In [1]: import dask.array as da

In [2]: da.to_zarr(da.ones(3), 'tmp.zarr', overwrite=True)

In [3]: da.from_zarr('tmp.zarr')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[3], line 1
----> 1 da.from_zarr('tmp.zarr')

File ~/projects/dask/dask/dask/array/core.py:3593, in from_zarr(url, component, storage_options, chunks, name, inline_array, **kwargs)
   3591     else:
   3592         store = url
-> 3593     z = zarr.Array(store, read_only=True, path=component, **kwargs)
   3594 else:
   3595     z = zarr.Array(url, read_only=True, path=component, **kwargs)

File ~/mambaforge/envs/dask-py39/lib/python3.9/site-packages/zarr/core.py:158, in Array.__init__(self, store, path, read_only, chunk_store, synchronizer, cache_metadata, cache_attrs, partial_decompress)
    155 self._partial_decompress = partial_decompress
    157 # initialize metadata
--> 158 self._load_metadata()
    160 # initialize attributes
    161 akey = self._key_prefix + attrs_key

File ~/mambaforge/envs/dask-py39/lib/python3.9/site-packages/zarr/core.py:175, in Array._load_metadata(self)
    173 """(Re)load metadata from store."""
    174 if self._synchronizer is None:
--> 175     self._load_metadata_nosync()
    176 else:
    177     mkey = self._key_prefix + array_meta_key

File ~/mambaforge/envs/dask-py39/lib/python3.9/site-packages/zarr/core.py:184, in Array._load_metadata_nosync(self)
    182 try:
    183     mkey = self._key_prefix + array_meta_key
--> 184     meta_bytes = self._store[mkey]
    185 except KeyError:
    186     raise ArrayNotFoundError(self._path)

TypeError: string indices must be integers
```

This is due to `dask` not supporting `zarr` versions that old. I tried a more recent version (`zarr=2.12.0` -- released June 23, 2022) and the example worked. 

I've documented `zarr=2.12.0` as our current minimum version in our install docs and pinned to `2.12.0` in our Python 3.8 build (this is a fine, but low-effort measure -- https://github.com/dask/dask/issues/10038 would be more complete).

@rabernat @joshmoore do you have any recommendations on a better minimum `zarr` version? 