### PR TITLE
Fix documentation build with `pandas` 2.0

### DIFF
--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -15,7 +15,6 @@ Dataframe
     DataFrame.align
     DataFrame.all
     DataFrame.any
-    DataFrame.append
     DataFrame.apply
     DataFrame.applymap
     DataFrame.assign
@@ -153,7 +152,6 @@ Series
    Series.align
    Series.all
    Series.any
-   Series.append
    Series.apply
    Series.astype
    Series.autocorr
@@ -194,7 +192,6 @@ Series
    Series.isin
    Series.isna
    Series.isnull
-   Series.iteritems
    Series.known_divisions
    Series.last
    Series.le


### PR DESCRIPTION
Our documentation build is currently failing since the `pandas=2.0` release came out earlier today (see [this build](https://readthedocs.org/projects/dask/builds/20000850/)). This is because a few methods in the DataFrame API were removed

```
/home/docs/checkouts/readthedocs.org/user_builds/dask/checkouts/10137/docs/source/dataframe-api.rst:9: WARNING: autosummary: failed to import DataFrame.append.
Possible hints:
* AttributeError: type object 'DataFrame' has no attribute 'append'
* ModuleNotFoundError: No module named 'dask.dataframe.DataFrame'
* ModuleNotFoundError: No module named 'DataFrame'
* KeyError: 'DataFrame'
* ImportError: 
/home/docs/checkouts/readthedocs.org/user_builds/dask/checkouts/10137/docs/source/dataframe-api.rst:148: WARNING: autosummary: failed to import Series.append.
Possible hints:
* ModuleNotFoundError: No module named 'dask.dataframe.Series'
* KeyError: 'Series'
* AttributeError: type object 'Series' has no attribute 'append'
* ModuleNotFoundError: No module named 'Series'
* ImportError: 
/home/docs/checkouts/readthedocs.org/user_builds/dask/checkouts/10137/docs/source/dataframe-api.rst:148: WARNING: autosummary: failed to import Series.iteritems.
Possible hints:
* ModuleNotFoundError: No module named 'dask.dataframe.Series'
* KeyError: 'Series'
* ModuleNotFoundError: No module named 'Series'
* ImportError: 
* AttributeError: type object 'Series' has no attribute 'iteritems'
```

This PR removes those corresponding methods from our API docs. 

cc @j-bennet @phofl 