### PR TITLE
Add regression test for merging with ea and numpy

### DIFF
--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2729,6 +2729,7 @@ def test_pairwise_merge_results_in_identical_output_df(
     assert_eq(ddf_pairwise, ddf_loop)
 
 
+@pytest.mark.xfail(not PANDAS_GT_200, reason="Errored below pandas 2.0")
 @pytest.mark.parametrize("value", [2, pd.NA])
 def test_merge_numpy_dtype_with_ea(value):
     # GH#6018

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2727,3 +2727,18 @@ def test_pairwise_merge_results_in_identical_output_df(
     ddf_pairwise = ddf_pairwise.join(dfs_to_merge, how=how)
 
     assert_eq(ddf_pairwise, ddf_loop)
+
+
+@pytest.mark.parametrize("value", [2, pd.NA])
+def test_merge_numpy_dtype_with_ea(value):
+    # GH#6018
+    # TODO: Expand this to arrow dtype (int32[pyarrow]) when
+    # https://github.com/pandas-dev/pandas/issues/52406 is fixed
+    df1 = pd.DataFrame({"a": pd.Series([1, value, 3], dtype="Int32"), "b": 1})
+    df2 = pd.DataFrame({"a": pd.Series([1, 2, 3], dtype="int32")})
+    ddf1 = dd.from_pandas(df1, npartitions=1)
+    ddf2 = dd.from_pandas(df2, npartitions=1)
+
+    pd_result = df1.merge(df2, on="a")
+    dd_result = ddf1.merge(ddf2, on="a")
+    assert_eq(dd_result, pd_result)


### PR DESCRIPTION
- [x] Closes #6018
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

I think this is a useful test to have. There is still some work going on on the pandas side for merge (especially for arrow dtypes) and this would enable us to catch failures on our side early