### PR TITLE
Fix rechunking behavior for dimensions with known and unknown chunk sizes

### DIFF
--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -169,7 +169,7 @@ def old_to_new(old_chunks, new_chunks):
     --------
     >>> old = ((10, 10, 10, 10, 10), )
     >>> new = ((25, 5, 20), )
-    >>> _old_to_new(old, new)  # doctest: +NORMALIZE_WHITESPACE
+    >>> old_to_new(old, new)  # doctest: +NORMALIZE_WHITESPACE
     [[[(0, slice(0, 10, None)), (1, slice(0, 10, None)), (2, slice(0, 5, None))],
       [(2, slice(5, 10, None))],
       [(3, slice(0, 10, None)), (4, slice(0, 10, None))]]]

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import heapq
 import math
 from functools import reduce
-from itertools import chain, count, product
+from itertools import chain, compress, count, product
 from operator import add, itemgetter, mul
 from warnings import warn
 
@@ -157,7 +157,7 @@ def _intersect_1d(breaks):
 def _old_to_new(old_chunks, new_chunks):
     """Helper to build old_chunks to new_chunks.
 
-    Handles missing values, as long as the missing dimension
+    Handles missing values, as long as the dimension with the missing chunk values
     is unchanged.
 
     Examples
@@ -169,31 +169,44 @@ def _old_to_new(old_chunks, new_chunks):
       [(2, slice(5, 10, None))],
       [(3, slice(0, 10, None)), (4, slice(0, 10, None))]]]
     """
-    old_known = [x for x in old_chunks if not any(math.isnan(y) for y in x)]
-    new_known = [x for x in new_chunks if not any(math.isnan(y) for y in x)]
 
-    n_missing = [sum(math.isnan(y) for y in x) for x in old_chunks]
-    n_missing2 = [sum(math.isnan(y) for y in x) for x in new_chunks]
+    def is_unknown(dim):
+        return any(math.isnan(chunk) for chunk in dim)
+
+    old_is_unknown = [is_unknown(dim) for dim in old_chunks]
+    new_is_unknown = [is_unknown(dim) for dim in new_chunks]
+
+    if old_is_unknown != new_is_unknown or any(
+        new != old for new, old in compress(zip(old_chunks, new_chunks), old_is_unknown)
+    ):
+        raise ValueError(
+            "Chunks must be unchanging along dimensions with missing values.\n\n"
+            "A possible solution:\n  x.compute_chunk_sizes()"
+        )
+
+    old_known = [dim for dim, unknown in zip(old_chunks, old_is_unknown) if not unknown]
+    new_known = [dim for dim, unknown in zip(new_chunks, new_is_unknown) if not unknown]
+
+    old_sizes = [sum(o) for o in old_known]
+    new_sizes = [sum(n) for n in new_known]
+
+    if not old_sizes == new_sizes:
+        raise ValueError(
+            f"Cannot change dimensions from {old_sizes!r} to {new_sizes!r}"
+        )
 
     cmo = cumdims_label(old_known, "o")
     cmn = cumdims_label(new_known, "n")
 
-    sums = [sum(o) for o in old_known]
-    sums2 = [sum(n) for n in new_known]
-
-    if not sums == sums2:
-        raise ValueError(f"Cannot change dimensions from {sums!r} to {sums2!r}")
-    if not n_missing == n_missing2:
-        raise ValueError(
-            "Chunks must be unchanging along unknown dimensions.\n\n"
-            "A possible solution:\n  x.compute_chunk_sizes()"
-        )
-
     old_to_new = [_intersect_1d(_breakpoints(cm[0], cm[1])) for cm in zip(cmo, cmn)]
-    for idx, missing in enumerate(n_missing):
-        if missing:
-            # Missing dimensions are always unchanged, so old -> new is everything
-            extra = [[(i, slice(0, None))] for i in range(missing)]
+    for idx, unknown in enumerate(old_is_unknown):
+        if unknown:
+            dim = old_chunks[idx]
+            # Unknown dimensions are always unchanged, so old -> new is everything
+            extra = [
+                [(i, slice(0, size if not math.isnan(size) else None))]
+                for i, size in enumerate(dim)
+            ]
             old_to_new.insert(idx, extra)
     return old_to_new
 

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -161,9 +161,9 @@ def old_to_new(old_chunks, new_chunks):
     is unchanged.
 
     This function expects that the arguments have been pre-processed by
-    ``normalize_chunks``. In particular any ``nan`` values should have
-    been replaced (and are so by ``normalize_chunks``) by the canonical
-    ``np.nan``.
+    :func:`dask.array.normalize_chunks`. In particular any ``nan`` values should
+    have been replaced (and are so by :func:`dask.array.normalize_chunks`)
+    by the canonical ``np.nan``.
 
     Examples
     --------

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -190,7 +190,7 @@ def _old_to_new(old_chunks, new_chunks):
     old_sizes = [sum(o) for o in old_known]
     new_sizes = [sum(n) for n in new_known]
 
-    if not old_sizes == new_sizes:
+    if old_sizes != new_sizes:
         raise ValueError(
             f"Cannot change dimensions from {old_sizes!r} to {new_sizes!r}"
         )

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -154,7 +154,7 @@ def _intersect_1d(breaks):
     return ret
 
 
-def _old_to_new(old_chunks, new_chunks):
+def old_to_new(old_chunks, new_chunks):
     """Helper to build old_chunks to new_chunks.
 
     Handles missing values, as long as the dimension with the missing chunk values
@@ -231,9 +231,7 @@ def intersect_chunks(old_chunks, new_chunks):
     new_chunks: iterable of tuples
         block sizes along each dimension (converts to new_chunks)
     """
-    old_to_new = _old_to_new(old_chunks, new_chunks)
-
-    cross1 = product(*old_to_new)
+    cross1 = product(*old_to_new(old_chunks, new_chunks))
     cross = chain(tuple(product(*cr)) for cr in cross1)
     return cross
 

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -161,8 +161,8 @@ def old_to_new(old_chunks, new_chunks):
     is unchanged.
 
     This function expects that the arguments have been pre-processed by
-    :func:`dask.array.normalize_chunks`. In particular any ``nan`` values should
-    have been replaced (and are so by :func:`dask.array.normalize_chunks`)
+    :func:`dask.array.core.normalize_chunks`. In particular any ``nan`` values should
+    have been replaced (and are so by :func:`dask.array.core.normalize_chunks`)
     by the canonical ``np.nan``.
 
     Examples

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -4,6 +4,7 @@ from itertools import product
 import pytest
 
 np = pytest.importorskip("numpy")
+import math
 
 import dask
 import dask.array as da
@@ -669,7 +670,12 @@ def test_rechunk_with_partially_unknown_dimension(x, chunks):
 
 
 @pytest.mark.parametrize(
-    "new_chunks", [((np.nan, np.nan), (5, 5)), ((float("nan"), float("nan")), (5, 5))]
+    "new_chunks",
+    [
+        ((np.nan, np.nan), (5, 5)),
+        ((math.nan, math.nan), (5, 5)),
+        ((float("nan"), float("nan")), (5, 5)),
+    ],
 )
 def test_rechunk_with_fully_unknown_dimension_explicit(new_chunks):
     dd = pytest.importorskip("dask.dataframe")
@@ -683,7 +689,11 @@ def test_rechunk_with_fully_unknown_dimension_explicit(new_chunks):
 
 @pytest.mark.parametrize(
     "new_chunks",
-    [((5, 5, np.nan, np.nan), (5, 5)), ((5, 5, float("nan"), float("nan")), (5, 5))],
+    [
+        ((5, 5, np.nan, np.nan), (5, 5)),
+        ((5, 5, math.nan, math.nan), (5, 5)),
+        ((5, 5, float("nan"), float("nan")), (5, 5)),
+    ],
 )
 def test_rechunk_with_partially_unknown_dimension_explicit(new_chunks):
     dd = pytest.importorskip("dask.dataframe")

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -10,12 +10,12 @@ import dask.array as da
 from dask.array.rechunk import (
     _breakpoints,
     _intersect_1d,
-    _old_to_new,
     cumdims_label,
     divide_to_width,
     intersect_chunks,
     merge_to_number,
     normalize_chunks,
+    old_to_new,
     plan_rechunk,
     rechunk,
 )
@@ -714,7 +714,7 @@ def test_rechunk_unknown_raises():
 def test_old_to_new_single():
     old = ((np.nan, np.nan), (8,))
     new = ((np.nan, np.nan), (4, 4))
-    result = _old_to_new(old, new)
+    result = old_to_new(old, new)
 
     expected = [
         [[(0, slice(0, None, None))], [(1, slice(0, None, None))]],
@@ -727,7 +727,7 @@ def test_old_to_new_single():
 def test_old_to_new():
     old = ((np.nan,), (10,))
     new = ((np.nan,), (5, 5))
-    result = _old_to_new(old, new)
+    result = old_to_new(old, new)
     expected = [
         [[(0, slice(0, None, None))]],
         [[(0, slice(0, 5, None))], [(0, slice(5, 10, None))]],
@@ -740,7 +740,7 @@ def test_old_to_new_large():
     old = (tuple([np.nan] * 4), (10,))
     new = (tuple([np.nan] * 4), (5, 5))
 
-    result = _old_to_new(old, new)
+    result = old_to_new(old, new)
     expected = [
         [
             [(0, slice(0, None, None))],
@@ -755,7 +755,7 @@ def test_old_to_new_large():
 
 def test_changing_raises():
     with pytest.raises(ValueError) as record:
-        _old_to_new(((np.nan, np.nan), (4, 4)), ((np.nan, np.nan, np.nan), (4, 4)))
+        old_to_new(((np.nan, np.nan), (4, 4)), ((np.nan, np.nan, np.nan), (4, 4)))
 
     assert "unchanging" in str(record.value)
 
@@ -763,7 +763,7 @@ def test_changing_raises():
 def test_old_to_new_known():
     old = ((10, 10, 10, 10, 10),)
     new = ((25, 5, 20),)
-    result = _old_to_new(old, new)
+    result = old_to_new(old, new)
     expected = [
         [
             [(0, slice(0, 10, None)), (1, slice(0, 10, None)), (2, slice(0, 5, None))],
@@ -1127,23 +1127,23 @@ def test_intersect_chunks_with_zero():
 
 
 def test_old_to_new_with_zero():
-    from dask.array.rechunk import _old_to_new
+    from dask.array.rechunk import old_to_new
 
     old = ((4, 4),)
     new = ((4, 0, 4),)
-    result = _old_to_new(old, new)
+    result = old_to_new(old, new)
     expected = [[[(0, slice(0, 4))], [(1, slice(0, 0))], [(1, slice(0, 4))]]]
     assert result == expected
 
     old = ((4,),)
     new = ((4, 0),)
-    result = _old_to_new(old, new)
+    result = old_to_new(old, new)
     expected = [[[(0, slice(0, 4))], [(0, slice(4, 4))]]]
     assert result == expected
 
     old = ((4, 0, 4),)
     new = ((4, 0, 2, 2),)
-    result = _old_to_new(old, new)
+    result = old_to_new(old, new)
     expected = [
         [[(0, slice(0, 4))], [(2, slice(0, 0))], [(2, slice(0, 2))], [(2, slice(2, 4))]]
     ]

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -668,23 +668,30 @@ def test_rechunk_with_partially_unknown_dimension(x, chunks):
     assert_eq(result, expected)
 
 
-def test_rechunk_with_fully_unknown_dimension_explicit():
+@pytest.mark.parametrize(
+    "new_chunks", [((np.nan, np.nan), (5, 5)), ((float("nan"), float("nan")), (5, 5))]
+)
+def test_rechunk_with_fully_unknown_dimension_explicit(new_chunks):
     dd = pytest.importorskip("dask.dataframe")
     x = da.ones(shape=(10, 10), chunks=(5, 2))
     y = dd.from_array(x).values
-    result = y.rechunk(((np.nan, np.nan), (5, 5)))
+    result = y.rechunk(new_chunks)
     expected = x.rechunk((None, (5, 5)))
     assert_chunks_match(result.chunks, expected.chunks)
     assert_eq(result, expected)
 
 
-def test_rechunk_with_partially_unknown_dimension_explicit():
+@pytest.mark.parametrize(
+    "new_chunks",
+    [((5, 5, np.nan, np.nan), (5, 5)), ((5, 5, float("nan"), float("nan")), (5, 5))],
+)
+def test_rechunk_with_partially_unknown_dimension_explicit(new_chunks):
     dd = pytest.importorskip("dask.dataframe")
     x = da.ones(shape=(10, 10), chunks=(5, 2))
     y = dd.from_array(x).values
     z = da.concatenate([x, y])
     xx = da.concatenate([x, x])
-    result = z.rechunk(((5, 5, np.nan, np.nan), (5, 5)))
+    result = z.rechunk(new_chunks)
     expected = xx.rechunk((None, (5, 5)))
     assert_chunks_match(result.chunks, expected.chunks)
     assert_eq(result, expected)


### PR DESCRIPTION
Fixes rechunking for dimensions with known and unknown chunk sizes if the dimension is not touched; raises a useful error otherwise.

- [x] Closes #10028
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
