### PR TITLE
Loosen optional `distributed` dependency to allow for patch releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dataframe = [
     "numpy >= 1.21",
     "pandas >= 1.3",
 ]
-distributed = ["distributed == 2023.3.2"]
+distributed = ["distributed == 2023.3.2.*"]
 diagnostics = [
     "bokeh >= 2.4.2, <3",
     "jinja2 >= 2.10.3",


### PR DESCRIPTION
This should make it such that future patch releases of distributed are picked up with `pip install dask[distributed]`

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
