### PR TITLE
Fix flaky `modf` operation in `test_arithmetic` 

### DIFF
--- a/dask/array/ufunc.py
+++ b/dask/array/ufunc.py
@@ -327,7 +327,7 @@ def modf(x):
         for key in core.flatten(tmp.__dask_keys__())
     }
 
-    a = np.empty_like(getattr(x, "_meta", x), shape=(1,) * x.ndim, dtype=x.dtype)
+    a = np.ones_like(getattr(x, "_meta", x), shape=(1,) * x.ndim, dtype=x.dtype)
     l, r = np.modf(a)
 
     graph = HighLevelGraph.from_collections(left, ldsk, dependencies=[tmp])


### PR DESCRIPTION
Possibly fix an intermittent failure:

`FAILED dask/array/tests/test_array_core.py::test_arithmetic - RuntimeWarning: invalid value encountered in modf`

- [x] Passes `pre-commit run --all-files`
