### PR TITLE
Disallow array input in mask/where

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -22,6 +22,7 @@ from tlz import first, merge, partition_all, remove, unique
 
 import dask
 import dask.array as da
+import dask.dataframe as dd
 from dask import core
 from dask.array.core import Array, normalize_arg
 from dask.bag import map_partitions as map_bag_partitions
@@ -3348,14 +3349,23 @@ Dask Name: {name}, {layers}"""
             out=out,
         )
 
+    def _condition_as_frame(self, cond):
+        if isinstance(cond, (list, np.ndarray)):
+            cond = dd.from_pandas(
+                pd.DataFrame(cond, columns=self.columns), npartitions=self.npartitions
+            ).set_index(self.index)
+        return cond
+
     @derived_from(pd.DataFrame)
     def where(self, cond, other=np.nan):
         # cond and other may be dask instance,
         # passing map_partitions via keyword will not be aligned
+        cond = self._condition_as_frame(cond)
         return map_partitions(M.where, self, cond, other, enforce_metadata=False)
 
     @derived_from(pd.DataFrame)
     def mask(self, cond, other=np.nan):
+        cond = self._condition_as_frame(cond)
         return map_partitions(M.mask, self, cond, other, enforce_metadata=False)
 
     @derived_from(pd.DataFrame)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3349,7 +3349,12 @@ Dask Name: {name}, {layers}"""
         )
 
     def _validate_condition(self, cond):
-        if isinstance(cond, (list, np.ndarray)):
+        if not (
+            is_dask_collection(cond)
+            or is_dataframe_like(cond)
+            or is_series_like(cond)
+            or is_index_like(cond)
+        ):
             raise ValueError(
                 f"Condition should be an object that can be aligned with {self.__class__}, "
                 f" which includes Dask or pandas collections, DataFrames or Series."

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5819,10 +5819,19 @@ def test_mask_where_array_like(df, cond):
     """
     ddf = dd.from_pandas(df, npartitions=2)
 
+    # ensure raises when list is provided
+    with pytest.raises(ValueError, match="can be aligned"):
+        ddf.mask(cond=cond, other=5)
+
+    with pytest.raises(ValueError, match="can be aligned"):
+        ddf.where(cond=cond, other=5)
+
+    # but works when DataFrame is provided, with matching index
+    dd_cond = pd.DataFrame(cond, index=df.index, columns=df.columns)
     expected = df.mask(cond=cond, other=5)
-    result = ddf.mask(cond=cond, other=5)
+    result = ddf.mask(cond=dd_cond, other=5)
     assert_eq(expected, result)
 
     expected = df.where(cond=cond, other=5)
-    result = ddf.where(cond=cond, other=5)
+    result = ddf.where(cond=dd_cond, other=5)
     assert_eq(expected, result)


### PR DESCRIPTION
Related to https://github.com/dask/dask/issues/9848.

The author had problem when applying a mask on a Dask dataframe with single-row partitions. Looks like the problem was not the partition size. If the provided condition is a Dask series/Dask dataframe/Pandas series/Pandas dataframe, Dask is able to align such input with the dataframe, but it won't align an array.

In this PR, the behavior is to raise an error and not accept array-like input, asking the user to provide a pandas or dask dataframe instead.

- [x] Closes https://github.com/dask/dask/issues/9848
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
