### PR TITLE
Modify pip install command for development

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -104,7 +104,8 @@ pip or conda_
 
 ``pip``::
 
-  python -m pip install -e ".[complete,test]"
+  python -m pip install git+https://github.com/dask/distributed
+  python -m pip install -e ".[array,dataframe,diagnostics,test]"
 
 ``conda``::
 


### PR DESCRIPTION
Changes the `pip install` command used to set up a dev environment, in a way which should avoid the potential for the dependency conflicts seen in https://github.com/dask/dask/issues/9862 while also installing Distributed from source, which better matches what is being done in the conda dev environments.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
