### PR TITLE
Handle pandas deprecation warnings for `to_pydatetime` and `apply`

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -162,6 +162,34 @@ def check_convert_dtype_deprecation():
         yield
 
 
+@contextlib.contextmanager
+def check_to_pydatetime_deprecation(catch_deprecation_warnings: bool):
+    if PANDAS_GT_210 and catch_deprecation_warnings:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Series containing python datetime",
+                category=FutureWarning,
+            )
+            yield
+    else:
+        yield
+
+
+@contextlib.contextmanager
+def check_apply_dataframe_deprecation():
+    if PANDAS_GT_210:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Returning a DataFrame",
+                category=FutureWarning,
+            )
+            yield
+    else:
+        yield
+
+
 if PANDAS_GT_150:
     IndexingError = pd.errors.IndexingError
 else:

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -168,7 +168,7 @@ def check_to_pydatetime_deprecation(catch_deprecation_warnings: bool):
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
-                message="Series containing python datetime",
+                message=".*DatetimeProperties.to_pydatetime is deprecated",
                 category=FutureWarning,
             )
             yield

--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
+from dask.dataframe._compat import check_to_pydatetime_deprecation
 from dask.utils import derived_from
 
 
@@ -85,12 +86,15 @@ class Accessor:
         return maybe_wrap_pandas(obj, out)
 
     @staticmethod
-    def _delegate_method(obj, accessor, attr, args, kwargs):
-        with warnings.catch_warnings():
-            # Falling back on a non-pyarrow code path which may decrease performance
-            warnings.simplefilter("ignore", pd.errors.PerformanceWarning)
-            out = getattr(getattr(obj, accessor, obj), attr)(*args, **kwargs)
-            return maybe_wrap_pandas(obj, out)
+    def _delegate_method(
+        obj, accessor, attr, args, kwargs, catch_deprecation_warnings: bool = False
+    ):
+        with check_to_pydatetime_deprecation(catch_deprecation_warnings):
+            with warnings.catch_warnings():
+                # Falling back on a non-pyarrow code path which may decrease performance
+                warnings.simplefilter("ignore", pd.errors.PerformanceWarning)
+                out = getattr(getattr(obj, accessor, obj), attr)(*args, **kwargs)
+                return maybe_wrap_pandas(obj, out)
 
     def _property_map(self, attr):
         meta = self._delegate_property(self._series._meta, self._accessor_name, attr)
@@ -113,6 +117,7 @@ class Accessor:
             attr,
             args,
             kwargs,
+            catch_deprecation_warnings=True,
             meta=meta,
             token=token,
         )

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -9,6 +9,7 @@ from tlz import partition
 from dask.dataframe._compat import (
     PANDAS_GT_131,
     PANDAS_GT_200,
+    check_apply_dataframe_deprecation,
     check_convert_dtype_deprecation,
     check_observed_deprecation,
 )
@@ -52,7 +53,8 @@ def iloc(df, cindexer=None):
 
 def apply(df, *args, **kwargs):
     with check_convert_dtype_deprecation():
-        return df.apply(*args, **kwargs)
+        with check_apply_dataframe_deprecation():
+            return df.apply(*args, **kwargs)
 
 
 def try_loc(df, iindexer, cindexer=None):

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -104,10 +104,11 @@ def test_dt_accessor(df_ddf):
     # to_pydatetime returns a numpy array in pandas, but a Series in dask
     # pandas will start returning a Series with 3.0 as well
     with pytest.warns(warning, match="Series containing python datetime"):
-        assert_eq(
-            ddf.dt_col.dt.to_pydatetime(),
-            pd.Series(df.dt_col.dt.to_pydatetime(), index=df.index, dtype=object),
+        ddf_result = ddf.dt_col.dt.to_pydatetime()
+        pd_result = pd.Series(
+            df.dt_col.dt.to_pydatetime(), index=df.index, dtype=object
         )
+    assert_eq(ddf_result, pd_result)
 
     assert set(ddf.dt_col.dt.date.dask) == set(ddf.dt_col.dt.date.dask)
     with pytest.warns(warning, match="Series containing python datetime"):

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -101,15 +101,18 @@ def test_dt_accessor(df_ddf):
     assert_eq(ddf.dt_col.dt.date, df.dt_col.dt.date, check_names=False)
 
     # to_pydatetime returns a numpy array in pandas, but a Series in dask
-    assert_eq(
-        ddf.dt_col.dt.to_pydatetime(),
-        pd.Series(df.dt_col.dt.to_pydatetime(), index=df.index, dtype=object),
-    )
+    # pandas will start returning a Series with 3.0 as well
+    with pytest.warns(FutureWarning, match="Series containing python datetime"):
+        assert_eq(
+            ddf.dt_col.dt.to_pydatetime(),
+            pd.Series(df.dt_col.dt.to_pydatetime(), index=df.index, dtype=object),
+        )
 
     assert set(ddf.dt_col.dt.date.dask) == set(ddf.dt_col.dt.date.dask)
-    assert set(ddf.dt_col.dt.to_pydatetime().dask) == set(
-        ddf.dt_col.dt.to_pydatetime().dask
-    )
+    with pytest.warns(FutureWarning, match="Series containing python datetime"):
+        assert set(ddf.dt_col.dt.to_pydatetime().dask) == set(
+            ddf.dt_col.dt.to_pydatetime().dask
+        )
 
 
 def test_dt_accessor_not_available(df_ddf):

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -103,16 +103,16 @@ def test_dt_accessor(df_ddf):
     warning = FutureWarning if PANDAS_GT_210 else None
     # to_pydatetime returns a numpy array in pandas, but a Series in dask
     # pandas will start returning a Series with 3.0 as well
-    with pytest.warns(warning, match="Series containing python datetime"):
+    with pytest.warns(warning, match="will return a Series"):
         ddf_result = ddf.dt_col.dt.to_pydatetime()
-    with pytest.warns(warning, match="Returning a DataFrame"):
+    with pytest.warns(warning, match="will return a Series"):
         pd_result = pd.Series(
             df.dt_col.dt.to_pydatetime(), index=df.index, dtype=object
         )
     assert_eq(ddf_result, pd_result)
 
     assert set(ddf.dt_col.dt.date.dask) == set(ddf.dt_col.dt.date.dask)
-    with pytest.warns(warning, match="Series containing python datetime"):
+    with pytest.warns(warning, match="will return a Series"):
         assert set(ddf.dt_col.dt.to_pydatetime().dask) == set(
             ddf.dt_col.dt.to_pydatetime().dask
         )

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -92,7 +92,6 @@ def df_ddf():
 
 
 def test_dt_accessor(df_ddf):
-    warning = FutureWarning if PANDAS_GT_210 else None
     df, ddf = df_ddf
 
     assert "date" in dir(ddf.dt_col.dt)
@@ -101,6 +100,7 @@ def test_dt_accessor(df_ddf):
     # see https://github.com/pydata/pandas/issues/10712
     assert_eq(ddf.dt_col.dt.date, df.dt_col.dt.date, check_names=False)
 
+    warning = FutureWarning if PANDAS_GT_210 else None
     # to_pydatetime returns a numpy array in pandas, but a Series in dask
     # pandas will start returning a Series with 3.0 as well
     with pytest.warns(warning, match="Series containing python datetime"):

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -5,7 +5,7 @@ import pytest
 
 pd = pytest.importorskip("pandas")
 import dask.dataframe as dd
-from dask.dataframe._compat import PANDAS_GT_140
+from dask.dataframe._compat import PANDAS_GT_140, PANDAS_GT_210
 from dask.dataframe._pyarrow import to_pyarrow_string
 from dask.dataframe.utils import assert_eq, pyarrow_strings_enabled
 
@@ -92,6 +92,7 @@ def df_ddf():
 
 
 def test_dt_accessor(df_ddf):
+    warning = FutureWarning if PANDAS_GT_210 else None
     df, ddf = df_ddf
 
     assert "date" in dir(ddf.dt_col.dt)
@@ -102,14 +103,14 @@ def test_dt_accessor(df_ddf):
 
     # to_pydatetime returns a numpy array in pandas, but a Series in dask
     # pandas will start returning a Series with 3.0 as well
-    with pytest.warns(FutureWarning, match="Series containing python datetime"):
+    with pytest.warns(warning, match="Series containing python datetime"):
         assert_eq(
             ddf.dt_col.dt.to_pydatetime(),
             pd.Series(df.dt_col.dt.to_pydatetime(), index=df.index, dtype=object),
         )
 
     assert set(ddf.dt_col.dt.date.dask) == set(ddf.dt_col.dt.date.dask)
-    with pytest.warns(FutureWarning, match="Series containing python datetime"):
+    with pytest.warns(warning, match="Series containing python datetime"):
         assert set(ddf.dt_col.dt.to_pydatetime().dask) == set(
             ddf.dt_col.dt.to_pydatetime().dask
         )

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -105,6 +105,7 @@ def test_dt_accessor(df_ddf):
     # pandas will start returning a Series with 3.0 as well
     with pytest.warns(warning, match="Series containing python datetime"):
         ddf_result = ddf.dt_col.dt.to_pydatetime()
+    with pytest.warns(warning, match="Returning a DataFrame"):
         pd_result = pd.Series(
             df.dt_col.dt.to_pydatetime(), index=df.index, dtype=object
         )

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3552,6 +3552,7 @@ def test_autocorr():
 
 
 def test_apply_infer_columns():
+    warning = FutureWarning if PANDAS_GT_210 else None
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})
     ddf = dd.from_pandas(df, npartitions=2)
 
@@ -3581,11 +3582,11 @@ def test_apply_infer_columns():
     # Series to completely different DataFrame
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        with pytest.warns(FutureWarning, match="Returning a DataFrame"):
+        with pytest.warns(warning, match="Returning a DataFrame"):
             result = ddf.x.apply(return_df2)
     assert isinstance(result, dd.DataFrame)
     tm.assert_index_equal(result.columns, pd.Index(["x2", "x3"]))
-    with pytest.warns(FutureWarning, match="Returning a DataFrame"):
+    with pytest.warns(warning, match="Returning a DataFrame"):
         assert_eq(result, df.x.apply(return_df2))
 
     # Series to Series

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3124,7 +3124,6 @@ def test_apply():
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})
     ddf = dd.from_pandas(df, npartitions=2)
 
-    func = lambda row: row["x"] + row["y"]
     assert_eq(
         ddf.x.apply(lambda x: x + 1, meta=("x", int)), df.x.apply(lambda x: x + 1)
     )
@@ -3150,13 +3149,20 @@ def test_apply():
         warnings.simplefilter("ignore", UserWarning)
         assert_eq(ddf.apply(lambda xy: xy, axis=1), df.apply(lambda xy: xy, axis=1))
 
-    # specify meta
-    func = lambda x: pd.Series([x, x])
-    assert_eq(ddf.x.apply(func, meta=[(0, int), (1, int)]), df.x.apply(func))
-    # inference
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        assert_eq(ddf.x.apply(func), df.x.apply(func))
+    if not PANDAS_GT_210:
+        # specify meta
+        func = lambda x: pd.Series([x, x])
+        assert_eq(ddf.x.apply(func, meta=[(0, int), (1, int)]), df.x.apply(func))
+        # inference
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            assert_eq(ddf.x.apply(func), df.x.apply(func))
+    else:
+        func = lambda x: pd.DataFrame({0: x, 1: x})
+        # inference
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            assert_eq(ddf.x.pipe(func), df.x.pipe(func))
 
     # axis=0
     with pytest.raises(NotImplementedError):
@@ -3575,10 +3581,12 @@ def test_apply_infer_columns():
     # Series to completely different DataFrame
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        result = ddf.x.apply(return_df2)
+        with pytest.warns(FutureWarning, match="Returning a DataFrame"):
+            result = ddf.x.apply(return_df2)
     assert isinstance(result, dd.DataFrame)
     tm.assert_index_equal(result.columns, pd.Index(["x2", "x3"]))
-    assert_eq(result, df.x.apply(return_df2))
+    with pytest.warns(FutureWarning, match="Returning a DataFrame"):
+        assert_eq(result, df.x.apply(return_df2))
 
     # Series to Series
     with warnings.catch_warnings():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3149,20 +3149,16 @@ def test_apply():
         warnings.simplefilter("ignore", UserWarning)
         assert_eq(ddf.apply(lambda xy: xy, axis=1), df.apply(lambda xy: xy, axis=1))
 
-    if not PANDAS_GT_210:
-        # specify meta
-        func = lambda x: pd.Series([x, x])
+    warning = FutureWarning if PANDAS_GT_210 else None
+    # specify meta
+    func = lambda x: pd.Series([x, x])
+    with pytest.warns(warning, match="Returning a DataFrame"):
         assert_eq(ddf.x.apply(func, meta=[(0, int), (1, int)]), df.x.apply(func))
-        # inference
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
+    # inference
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        with pytest.warns(warning, match="Returning a DataFrame"):
             assert_eq(ddf.x.apply(func), df.x.apply(func))
-    else:
-        func = lambda x: pd.DataFrame({0: x, 1: x})
-        # inference
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
-            assert_eq(ddf.x.pipe(func), df.x.pipe(func))
 
     # axis=0
     with pytest.raises(NotImplementedError):
@@ -3552,7 +3548,6 @@ def test_autocorr():
 
 
 def test_apply_infer_columns():
-    warning = FutureWarning if PANDAS_GT_210 else None
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})
     ddf = dd.from_pandas(df, npartitions=2)
 
@@ -3579,6 +3574,7 @@ def test_apply_infer_columns():
     def return_df2(x):
         return pd.Series([x * 2, x * 3], index=["x2", "x3"])
 
+    warning = FutureWarning if PANDAS_GT_210 else None
     # Series to completely different DataFrame
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3153,12 +3153,16 @@ def test_apply():
     # specify meta
     func = lambda x: pd.Series([x, x])
     with pytest.warns(warning, match="Returning a DataFrame"):
-        assert_eq(ddf.x.apply(func, meta=[(0, int), (1, int)]), df.x.apply(func))
+        ddf_result = ddf.x.apply(func, meta=[(0, int), (1, int)])
+        pdf_result = df.x.apply(func)
+    assert_eq(ddf_result, pdf_result)
     # inference
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         with pytest.warns(warning, match="Returning a DataFrame"):
-            assert_eq(ddf.x.apply(func), df.x.apply(func))
+            ddf_result = ddf.x.apply(func)
+            pdf_result = df.x.apply(func)
+        assert_eq(ddf_result, pdf_result)
 
     # axis=0
     with pytest.raises(NotImplementedError):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3154,6 +3154,7 @@ def test_apply():
     func = lambda x: pd.Series([x, x])
     with pytest.warns(warning, match="Returning a DataFrame"):
         ddf_result = ddf.x.apply(func, meta=[(0, int), (1, int)])
+    with pytest.warns(warning, match="Returning a DataFrame"):
         pdf_result = df.x.apply(func)
     assert_eq(ddf_result, pdf_result)
     # inference
@@ -3161,6 +3162,7 @@ def test_apply():
         warnings.simplefilter("ignore", UserWarning)
         with pytest.warns(warning, match="Returning a DataFrame"):
             ddf_result = ddf.x.apply(func)
+        with pytest.warns(warning, match="Returning a DataFrame"):
             pdf_result = df.x.apply(func)
         assert_eq(ddf_result, pdf_result)
 


### PR DESCRIPTION
- [x] xref #10089
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
