### PR TITLE
Repartitioning raises with extension dtype when truncating floats

### DIFF
--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -383,6 +383,9 @@ def process_val_weights(vals_and_weights, npartitions, dtype_info):
     elif "datetime64" in str(dtype):
         rv = pd.DatetimeIndex(rv, dtype=dtype)
     elif rv.dtype != dtype:
+        if is_integer_dtype(dtype):
+            # pandas EA raises instead of truncating
+            rv = np.floor(rv)
         rv = pd.array(rv, dtype=dtype)
     return rv
 

--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -383,7 +383,7 @@ def process_val_weights(vals_and_weights, npartitions, dtype_info):
     elif "datetime64" in str(dtype):
         rv = pd.DatetimeIndex(rv, dtype=dtype)
     elif rv.dtype != dtype:
-        if is_integer_dtype(dtype):
+        if is_integer_dtype(dtype) and pd.api.types.is_float_dtype(rv.dtype):
             # pandas EA raises instead of truncating
             rv = np.floor(rv)
         rv = pd.array(rv, dtype=dtype)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1082,6 +1082,14 @@ def test_set_index_timestamp():
     assert_eq(df2, ddf.set_index("A"), check_freq=False)
 
 
+def test_set_index_ea_dtype():
+    pdf = pd.DataFrame({"a": 1, "b": pd.Series([1, 2], dtype="Int64")})
+    ddf = dd.from_pandas(pdf, npartitions=2)
+    pdf_result = pdf.set_index("b")
+    ddf_result = ddf.set_index("b")
+    assert_eq(ddf_result, pdf_result)
+
+
 @pytest.mark.parametrize("compression", [None, "ZLib"])
 def test_disk_shuffle_with_compression_option(compression):
     # test if dataframe shuffle works both with and without compression

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1082,6 +1082,7 @@ def test_set_index_timestamp():
     assert_eq(df2, ddf.set_index("A"), check_freq=False)
 
 
+@pytest.mark.skipif(not PANDAS_GT_140, reason="EA Indexes not supported before")
 def test_set_index_ea_dtype():
     pdf = pd.DataFrame({"a": 1, "b": pd.Series([1, 2], dtype="Int64")})
     ddf = dd.from_pandas(pdf, npartitions=2)


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

``Int64`` and ``ArrowDtype(pa.int64())`` both raise instead of truncating, so should take care of this ourselves.