### PR TITLE
`GroupBy.cov` raising for non-numeric grouping column

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -669,7 +669,7 @@ def _cov_chunk(df, *by):
     is_mask = any(is_series_like(s) for s in by)
     if not is_mask:
         by = [col_mapping[k] for k in by]
-        cols = cols.drop(np.array(by))
+        cols = cols.difference(pd.Index(by))
 
     g = _groupby_raise_unaligned(df, by=by)
     x = g.sum()

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3271,6 +3271,23 @@ def test_groupby_aggregate_categorical_observed(
     )
 
 
+def test_groupby_cov_non_numeric_grouping_column():
+    pdf = pd.DataFrame(
+        {
+            "a": 1,
+            "b": [
+                pd.Timestamp("2019-12-31"),
+                pd.Timestamp("2019-12-31"),
+                pd.Timestamp("2019-12-31"),
+            ],
+            "c": 2,
+        }
+    )
+
+    ddf = dd.from_pandas(pdf, npartitions=2)
+    assert_eq(ddf.groupby("b").cov(), pdf.groupby("b").cov())
+
+
 @pytest.mark.skipif(not PANDAS_GT_150, reason="requires pandas >= 1.5.0")
 def test_groupby_numeric_only_None_column_name():
     df = pd.DataFrame({"a": [1, 2, 3], None: ["a", "b", "c"]})


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Came across this when looking into non nano support in groupby