### PR TITLE
Move after_n_builds to new section

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ codecov:
   # but it is. Here we set a minimum number of builds before notifying in the
   # hopes that it will stop this behavior.
   notify:
-    after_n_builds: 15
+    after_n_builds: 11
 
 coverage:
   precision: 2

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,6 @@
 codecov:
   require_ci_to_pass: yes
 
-coverage:
-  precision: 2
-  round: down
-  range: "90...100"
-
   # codecov pushes a failing status update to github actions before all the
   # test runs have completed (this is later updated to passing after more test
   # runs pass, but the initial red X is annoying). As far as I can tell from
@@ -14,6 +9,12 @@ coverage:
   # hopes that it will stop this behavior.
   notify:
     after_n_builds: 10
+
+coverage:
+  precision: 2
+  round: down
+  range: "90...100"
+
 
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ codecov:
   # but it is. Here we set a minimum number of builds before notifying in the
   # hopes that it will stop this behavior.
   notify:
-    after_n_builds: 10
+    after_n_builds: 15
 
 coverage:
   precision: 2

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,15 +1,6 @@
 codecov:
   require_ci_to_pass: yes
 
-  # codecov pushes a failing status update to github actions before all the
-  # test runs have completed (this is later updated to passing after more test
-  # runs pass, but the initial red X is annoying). As far as I can tell from
-  # https://docs.codecov.com/docs/merging-reports this shouldn't be happening,
-  # but it is. Here we set a minimum number of builds before notifying in the
-  # hopes that it will stop this behavior.
-  notify:
-    after_n_builds: 11
-
 coverage:
   precision: 2
   round: down


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

Their validation endpoint was happy with this file, lets see if it works