### PR TITLE
Modify nightly version strings to avoid clashing with stable pinnings

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build conda package
         run: |
           # suffix for nightly package versions
-          export VERSION_SUFFIX=a`date +%y%m%d`
+          export VERSION_SUFFIX=`date +%y%m%d`
 
           conda mambabuild continuous_integration/recipe \
                            --no-anaconda-upload \

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set major_minor_patch = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').split('.') %}
 {% set new_patch = major_minor_patch[2] | int + 1 %}
-{% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
+{% set version = (major_minor_patch[:2] + [new_patch, 'a']) | join('.') %}
+{% set date_string = environ.get('VERSION_SUFFIX', '') %}
 
 
 package:
@@ -13,7 +14,7 @@ source:
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
   noarch: python
-  string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: py_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - dask = dask.__main__:main


### PR DESCRIPTION
Modifies the version/build strings of the published nightlies like so:

```
dask-core-2023.3.3a230410-py_g011f170f6_27 => dask-core-2023.3.3.a-py_230410_g011f170f6_27
```

The reasoning here is to get nightly versions parsed as `=2023.3.3.0a0`, which will prevent them from getting installed if we specify `dask==2023.3.2`.

xref https://github.com/dask/distributed/pull/7769

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
