### PR TITLE
Adjust empty `Index` from `fastparquet` to `object` dtype

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -12,6 +12,7 @@ PANDAS_GT_133 = PANDAS_VERSION >= Version("1.3.3")
 PANDAS_GT_140 = PANDAS_VERSION >= Version("1.4.0")
 PANDAS_GT_150 = PANDAS_VERSION >= Version("1.5.0")
 PANDAS_GT_200 = PANDAS_VERSION.major >= 2
+PANDAS_GT_201 = PANDAS_VERSION.release >= (2, 0, 1)
 PANDAS_GT_210 = PANDAS_VERSION.release >= (2, 1, 0)
 
 import pandas.testing as tm

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -1116,6 +1116,11 @@ class FastParquetEngine(Engine):
         rgs = pf.row_groups
         size = sum(rg.num_rows for rg in rgs)
         df, views = pf.pre_allocate(size, columns, categories, index)
+        if (
+            parse_version(fastparquet.__version__) <= parse_version("2023.02.0")
+            and df.columns.empty
+        ):
+            df.columns = pd.Index([], dtype=object)
         start = 0
 
         # Get a map of file names -> row-groups

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -11,6 +11,7 @@ import tlz as toolz
 from packaging.version import parse as parse_version
 
 from dask.core import flatten
+from dask.dataframe._compat import PANDAS_GT_201
 
 try:
     import fastparquet
@@ -1118,6 +1119,7 @@ class FastParquetEngine(Engine):
         df, views = pf.pre_allocate(size, columns, categories, index)
         if (
             parse_version(fastparquet.__version__) <= parse_version("2023.02.0")
+            and PANDAS_GT_201
             and df.columns.empty
         ):
             df.columns = pd.Index([], dtype=object)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -16,7 +16,7 @@ import dask.dataframe as dd
 import dask.multiprocessing
 from dask.array.numpy_compat import _numpy_124
 from dask.blockwise import Blockwise, optimize_blockwise
-from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200
+from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200, PANDAS_GT_201
 from dask.dataframe.io.parquet.core import get_engine
 from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.dataframe.optimize import optimize_dataframe_getitem
@@ -272,6 +272,9 @@ def test_read_list(tmpdir, write_engine, read_engine):
 
 @write_read_engines()
 def test_columns_auto_index(tmpdir, write_engine, read_engine):
+    if read_engine == "fastparquet" and PANDAS_GT_201:
+        pytest.xfail("fastparquet returns RangeIndex instead of object Index")
+
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=write_engine)
 
@@ -310,6 +313,9 @@ def test_columns_auto_index(tmpdir, write_engine, read_engine):
 
 @write_read_engines()
 def test_columns_index(tmpdir, write_engine, read_engine):
+    if read_engine == "fastparquet" and PANDAS_GT_201:
+        pytest.xfail("fastparquet returns RangeIndex instead of object Index")
+
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=write_engine)
 
@@ -2600,6 +2606,9 @@ def test_getitem_optimization(tmpdir, engine, preserve_index, index):
 
 
 def test_getitem_optimization_empty(tmpdir, engine):
+    if engine == "fastparquet" and PANDAS_GT_201:
+        pytest.xfail("fastparquet returns RangeIndex instead of object Index")
+
     df = pd.DataFrame({"A": [1] * 100, "B": [2] * 100, "C": [3] * 100, "D": [4] * 100})
     ddf = dd.from_pandas(df, 2, sort=False)
     fn = os.path.join(str(tmpdir))

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -16,7 +16,7 @@ import dask.dataframe as dd
 import dask.multiprocessing
 from dask.array.numpy_compat import _numpy_124
 from dask.blockwise import Blockwise, optimize_blockwise
-from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200, PANDAS_GT_201
+from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200
 from dask.dataframe.io.parquet.core import get_engine
 from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.dataframe.optimize import optimize_dataframe_getitem
@@ -272,9 +272,6 @@ def test_read_list(tmpdir, write_engine, read_engine):
 
 @write_read_engines()
 def test_columns_auto_index(tmpdir, write_engine, read_engine):
-    if read_engine == "fastparquet" and PANDAS_GT_201:
-        pytest.xfail("fastparquet returns RangeIndex instead of object Index")
-
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=write_engine)
 
@@ -313,9 +310,6 @@ def test_columns_auto_index(tmpdir, write_engine, read_engine):
 
 @write_read_engines()
 def test_columns_index(tmpdir, write_engine, read_engine):
-    if read_engine == "fastparquet" and PANDAS_GT_201:
-        pytest.xfail("fastparquet returns RangeIndex instead of object Index")
-
     fn = str(tmpdir)
     ddf.to_parquet(fn, engine=write_engine)
 
@@ -2606,9 +2600,6 @@ def test_getitem_optimization(tmpdir, engine, preserve_index, index):
 
 
 def test_getitem_optimization_empty(tmpdir, engine):
-    if engine == "fastparquet" and PANDAS_GT_201:
-        pytest.xfail("fastparquet returns RangeIndex instead of object Index")
-
     df = pd.DataFrame({"A": [1] * 100, "B": [2] * 100, "C": [3] * 100, "D": [4] * 100})
     ddf = dd.from_pandas(df, 2, sort=False)
     fn = os.path.join(str(tmpdir))


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @jrbourbeau 

As expected, fix was relatively easy. I opened https://github.com/dask/fastparquet/pull/859 to fix in fastparquet