### PR TITLE
Revert `.grouper` related changes

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -3056,8 +3056,8 @@ def _unique_aggregate(series_gb, name=None):
     ret = type(series_gb.obj)(
         {k: v.explode().unique() for k, v in series_gb},
         name=name,
-        index=series_gb.grouper.result_index,
     )
+    ret.index.names = series_gb.obj.index.names
     return ret
 
 
@@ -3072,7 +3072,8 @@ def _value_counts(x, **kwargs):
 
 def _value_counts_aggregate(series_gb):
     return pd.concat(
-        [v.groupby(by=series_gb.grouper.axis.names).sum() for _, v in series_gb],
+        {k: v.groupby(level=-1).sum() for k, v in series_gb},
+        names=series_gb.obj.index.names,
     )
 
 


### PR DESCRIPTION
As part of https://github.com/dask/dask/pull/10154/, unique and value_counts aggregate calculation was changed to `.grouper` approach with which index was being extracted. However, `grouper` seems to be an internal implementation detail for pandas and is not documented. `cudf` doesn't have support for `grouper` and hence `dask-cudf` is currently failing at these places.

cc: @j-bennet @phofl @jrbourbeau I have only reverted the change because of no better approach, let me know what you think.