### PR TITLE
Make sure transform output has the same index as input

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2498,7 +2498,7 @@ class _GroupBy:
 
         .. warning::
 
-           Pandas' groupby-transform can be used to to apply arbitrary functions,
+           Pandas' groupby-transform can be used to apply arbitrary functions,
            including aggregations that result in one row per group. Dask's
            groupby-transform will apply ``func`` once on each group, doing a shuffle
            if needed, such that each group is contained in one partition.
@@ -2568,6 +2568,9 @@ class _GroupBy:
             **self.dropna,
             **kwargs,
         )
+
+        df3 = df3.reset_index().set_index("index")
+        df3.index = df3.index.rename(None)
 
         return df3
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2570,8 +2570,9 @@ class _GroupBy:
         )
 
         if isinstance(self, DataFrameGroupBy):
-            df3 = df3.reset_index().set_index("index")
-            df3.index = df3.index.rename(None)
+            index_name = df3.index.name
+            df3 = df3.reset_index().set_index(index_name or "index")
+            df3.index = df3.index.rename(index_name)
 
         return df3
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -2569,8 +2569,9 @@ class _GroupBy:
             **kwargs,
         )
 
-        df3 = df3.reset_index().set_index("index")
-        df3.index = df3.index.rename(None)
+        if isinstance(self, DataFrameGroupBy):
+            df3 = df3.reset_index().set_index("index")
+            df3.index = df3.index.rename(None)
 
         return df3
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2705,7 +2705,7 @@ def test_groupby_transform_funcs(transformation):
 
 
 @pytest.mark.parametrize("npartitions", list(range(1, 10)))
-@pytest.mark.parametrize("indexed", [True, False])
+@pytest.mark.parametrize("indexed", [True, False], ids=["indexed", "not_indexed"])
 def test_groupby_transform_ufunc_partitioning(npartitions, indexed):
     pdf = pd.DataFrame({"group": [1, 2, 3, 4, 5] * 20, "value": np.random.randn(100)})
 


### PR DESCRIPTION
Transform output needs to have the same index as input, so the user can assign a result to a column in the original dataframe.

This should work ([but currently breaks](https://github.com/dask/dask/issues/10035)):

```python

import pandas as pd
import dask.dataframe as dd

df = pd.DataFrame({'ints': [1, 2, 3], 'grouper': [0, 1, 0]})

ddf = dd.from_pandas(df, npartitions=2)
ddf["new"] = df.groupby("grouper").transform("first")

ddf.compute()
```

Note that the result of `first` will be different from pandas in the above example, because of shuffle.

- [x] Closes https://github.com/dask/dask/issues/10035
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
