### PR TITLE
Add documentation for `GroupBy.transform`

### DIFF
--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -436,6 +436,7 @@ DataFrame Groupby
    DataFrameGroupBy.idxmin
    DataFrameGroupBy.idxmax
    DataFrameGroupBy.rolling
+   DataFrameGroupBy.transform
 
 
 Series Groupby
@@ -467,6 +468,7 @@ Series Groupby
    SeriesGroupBy.idxmin
    SeriesGroupBy.idxmax
    SeriesGroupBy.rolling
+   SeriesGroupBy.transform
 
 Custom Aggregation
 ******************


### PR DESCRIPTION
We don't have docs for `.transform` method on `GroupBy` object. Our `.transform` works differently from pandas though, so we should have it documented.

Xref https://github.com/dask/dask/issues/10035.

- [x] Passes `pre-commit run --all-files`
