### PR TITLE
Adjust for deprecated ``is_interval_dtype`` and ``is_datetime64tz_dtype``

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -7,8 +7,6 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import (
     is_categorical_dtype,
-    is_datetime64tz_dtype,
-    is_interval_dtype,
     is_period_dtype,
     is_scalar,
     is_sparse,
@@ -401,7 +399,7 @@ def _nonempty_series(s, idx=None):
     if len(s) > 0:
         # use value from meta if provided
         data = [s.iloc[0]] * 2
-    elif is_datetime64tz_dtype(dtype):
+    elif isinstance(dtype, pd.DatetimeTZDtype):
         entry = pd.Timestamp("1970-01-01", tz=dtype.tz)
         data = [entry, entry]
     elif is_categorical_dtype(dtype):
@@ -423,7 +421,7 @@ def _nonempty_series(s, idx=None):
     elif is_sparse(dtype):
         entry = _scalar_from_dtype(dtype.subtype)
         data = pd.array([entry, entry], dtype=dtype)
-    elif is_interval_dtype(dtype):
+    elif isinstance(dtype, pd.IntervalDtype):
         entry = _scalar_from_dtype(dtype.subtype)
         data = pd.array([entry, entry], dtype=dtype)
     elif type(dtype) in make_array_nonempty._lookup:

--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -72,11 +72,7 @@ import math
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import (
-    is_datetime64_dtype,
-    is_datetime64tz_dtype,
-    is_integer_dtype,
-)
+from pandas.api.types import is_datetime64_dtype, is_integer_dtype
 from tlz import merge, merge_sorted, take
 
 from dask.base import tokenize
@@ -378,7 +374,7 @@ def process_val_weights(vals_and_weights, npartitions, dtype_info):
 
     if is_categorical_dtype(dtype):
         rv = pd.Categorical.from_codes(rv, info[0], info[1])
-    elif is_datetime64tz_dtype(dtype):
+    elif isinstance(dtype, pd.DatetimeTZDtype):
         rv = pd.DatetimeIndex(rv).tz_localize(dtype.tz)
     elif "datetime64" in str(dtype):
         rv = pd.DatetimeIndex(rv, dtype=dtype)


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

Not sure if they are already failing on our upstream build. Will start failing tomorrow at the latest

https://github.com/pandas-dev/pandas/pull/52607