### PR TITLE
Add `python-cityhash` to CI environments

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -72,6 +72,7 @@ dependencies:
   - cachey
   - python-graphviz
   - python-xxhash
+  - python-cityhash
   - mmh3
   - jinja2
   - pip

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -75,6 +75,7 @@ dependencies:
   # - sparse  needs numba
   - cachey
   - python-graphviz
+  - python-cityhash
   - python-xxhash
   - mmh3
   - jinja2

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -73,6 +73,7 @@ dependencies:
   - cachey
   - python-graphviz
   - python-xxhash
+  - python-cityhash
   - mmh3
   - jinja2
   - pip

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -72,6 +72,7 @@ dependencies:
   - cachey
   - python-graphviz
   - python-xxhash
+  - python-cityhash
   - mmh3
   - jinja2
   - pip

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -1,11 +1,5 @@
 set -xe
 
-# TODO: Add cityhash back
-# We don't have a conda-forge package for cityhash
-# We don't include it in the conda environment.yaml, since that may
-# make things harder for contributors that don't have a C++ compiler
-# python -m pip install --no-deps cityhash
-
 if [[ ${UPSTREAM_DEV} ]]; then
 
     # NOTE: `dask/tests/test_ci.py::test_upstream_packages_installed` should up be


### PR DESCRIPTION
Now that `python-cityhash` is on conda-forge, we should be good to add this to our CI environments along with the other hasher libraries.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
