### PR TITLE
Add `xarray` back to Python 3.11 CI builds

### DIFF
--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -36,9 +36,7 @@ dependencies:
   # - tiledb-py # crashes on Python 3.11
   # - pyspark
   # - tiledb>=2.5.0 # crashes on Python 3.11
-  # Temporarily not including `xarray` until they have `pandas=2` support
-  # (xref https://github.com/pydata/xarray/issues/7716, https://github.com/pydata/xarray/pull/7724)
-  # - xarray
+  - xarray
   # Pin until sqlalchemy 2 support is added https://github.com/dask/dask/issues/9896
   - sqlalchemy>=1.4.0,<2
   - pyarrow>=11


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/10152

This currently doesn't pass but will once `xarray=2023.4.0` is on conda-forge (xref https://github.com/pydata/xarray/issues/7716, https://github.com/conda-forge/xarray-feedstock/pull/86) 