### PR TITLE
Avoid re-opening hdf file multiple times in `read_hdf`

### DIFF
--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -436,10 +436,10 @@ def read_hdf(
     # Build metadata
     with pd.HDFStore(paths[0], mode=mode) as hdf:
         meta_key = _expand_key(key, hdf)[0]
-    try:
-        meta = pd.read_hdf(paths[0], meta_key, mode=mode, stop=0)
-    except IndexError:  # if file is empty, don't set stop
-        meta = pd.read_hdf(paths[0], meta_key, mode=mode)
+        try:
+            meta = pd.read_hdf(hdf, meta_key, stop=0)
+        except IndexError:  # if file is empty, don't set stop
+            meta = pd.read_hdf(hdf, meta_key)
     if columns is not None:
         meta = meta[columns]
 


### PR DESCRIPTION
this is a performance optimization that also bypasses the pandas bug https://github.com/pandas-dev/pandas/issues/52781

- [x] Closes #10204
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
