### PR TITLE
Add note about `importlib_metadata` backport

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ dependencies = [
     "partd >= 1.2.0",
     "pyyaml >= 5.3.1",
     "toolz >= 0.10.0",
+    # importlib.metadata has the following bugs fixed in 3.10.9 and 3.11.1
+    # https://github.com/python/cpython/issues/99130
+    # https://github.com/python/cpython/issues/98706
+    # TODO: when Python 3.12 is support is added this could be a
+    # conditional dependency
     "importlib_metadata >= 4.13.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
This PR adds a note with some context around the need for including the `importlib_metadata` backport. This note was added in https://github.com/dask/dask/pull/10070 but it looks like it didn't survive the recent switch over to `pyproject.toml` 

cc @graingert 

Closes https://github.com/dask/dask/issues/10206