### PR TITLE
Avoid calling ``Series.apply`` with ``_meta_nonempty``

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4341,7 +4341,7 @@ Dask Name: {name}, {layers}""".format(
             kwds["convert_dtype"] = convert_dtype
 
         # let pandas trigger any warnings, such as convert_dtype warning
-        self._meta_nonempty.apply(func, args=args, **kwds)
+        self._meta_nonempty.iloc[:0].apply(func, args=args, **kwds)
 
         if meta is no_default:
             with check_convert_dtype_deprecation():

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4341,7 +4341,7 @@ Dask Name: {name}, {layers}""".format(
             kwds["convert_dtype"] = convert_dtype
 
         # let pandas trigger any warnings, such as convert_dtype warning
-        self._meta_nonempty.iloc[:0].apply(func, args=args, **kwds)
+        self._meta.apply(func, args=args, **kwds)
 
         if meta is no_default:
             with check_convert_dtype_deprecation():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3177,13 +3177,15 @@ def test_apply():
 @pytest.mark.parametrize("convert_dtype", [None, True, False])
 def test_apply_convert_dtype(convert_dtype):
     """Make sure that explicit convert_dtype raises a warning with pandas>=2.1"""
-    df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})
+    df = pd.DataFrame({"x": [2, 3, 4, 5], "y": [10, 20, 30, 40]})
     ddf = dd.from_pandas(df, npartitions=2)
     kwargs = {} if convert_dtype is None else {"convert_dtype": convert_dtype}
     should_warn = PANDAS_GT_210 and convert_dtype is not None
 
+    meta_val = ddf.x._meta_nonempty.iloc[0]
+
     def func(x):
-        if x == "foo":
+        if x == meta_val:
             raise ValueError
         return x + 1
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3181,10 +3181,16 @@ def test_apply_convert_dtype(convert_dtype):
     ddf = dd.from_pandas(df, npartitions=2)
     kwargs = {} if convert_dtype is None else {"convert_dtype": convert_dtype}
     should_warn = PANDAS_GT_210 and convert_dtype is not None
+
+    def func(x):
+        if x == "foo":
+            raise ValueError
+        return x + 1
+
     with _check_warning(should_warn, FutureWarning, "the convert_dtype parameter"):
-        expected = df.x.apply(lambda x: x + 1, **kwargs)
+        expected = df.x.apply(func, **kwargs)
     with _check_warning(should_warn, FutureWarning, "the convert_dtype parameter"):
-        result = ddf.x.apply(lambda x: x + 1, **kwargs, meta=expected)
+        result = ddf.x.apply(func, **kwargs, meta=expected)
     assert_eq(result, expected)
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3185,6 +3185,7 @@ def test_apply_convert_dtype(convert_dtype):
     meta_val = ddf.x._meta_nonempty.iloc[0]
 
     def func(x):
+        # meta check is a regression test for https://github.com/dask/dask/issues/10209
         if x == meta_val:
             raise ValueError
         return x + 1

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3186,8 +3186,7 @@ def test_apply_convert_dtype(convert_dtype):
 
     def func(x):
         # meta check is a regression test for https://github.com/dask/dask/issues/10209
-        if x == meta_val:
-            raise ValueError
+        assert x != meta_val
         return x + 1
 
     with _check_warning(should_warn, FutureWarning, "the convert_dtype parameter"):


### PR DESCRIPTION
- [x] Closes #10209
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @j-bennet 