### PR TITLE
Add ``DataFrame.reduction`` to API docs

### DIFF
--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -97,6 +97,7 @@ Dataframe
     DataFrame.radd
     DataFrame.random_split
     DataFrame.rdiv
+    DataFrame.reduction
     DataFrame.rename
     DataFrame.repartition
     DataFrame.replace


### PR DESCRIPTION
I noticed `Series.reduction` is included, but not `DataFrame.reduction`. This PR adds `DataFrame.reduction` 