### PR TITLE
Improve ``sizeof`` for ``pd.MultiIndex``

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -204,7 +204,7 @@ def register_pandas():
 
     @sizeof.register(pd.MultiIndex)
     def sizeof_pandas_multiindex(i):
-        p = 400 + object_size(*i.levels)
+        p = sum(sizeof_pandas_index(lev) for lev in i.levels)
         for c in i.codes:
             p += c.nbytes
         return p

--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -204,7 +204,7 @@ def register_pandas():
 
     @sizeof.register(pd.MultiIndex)
     def sizeof_pandas_multiindex(i):
-        p = sum(sizeof_pandas_index(lev) for lev in i.levels)
+        p = sum(sizeof(lev) for lev in i.levels)
         for c in i.codes:
             p += c.nbytes
         return p


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This is significantly closer to ``sys.getsizeof`` when the MultiIndex gets larger. Every MultiIndex level is a new Index itself.

cc @crusaderky 