### PR TITLE
Add ``numeric_only`` support to ``GroupBy.median``

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -83,7 +83,7 @@ def makeMixedDataFrame():
 
 @contextlib.contextmanager
 def check_numeric_only_deprecation(name=None, show_nuisance_warning: bool = False):
-    supported_funcs = ["sum"]
+    supported_funcs = ["sum", "median"]
     if name not in supported_funcs and PANDAS_GT_150 and not PANDAS_GT_200:
         with warnings.catch_warnings():
             warnings.filterwarnings(

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -94,7 +94,6 @@ NUMERIC_ONLY_NOT_IMPLEMENTED = [
     "cumprod",
     "cumsum",
     "mean",
-    "median",
     "std",
     "var",
 ]
@@ -1986,7 +1985,6 @@ class _GroupBy:
         return s / c
 
     @derived_from(pd.core.groupby.GroupBy)
-    @numeric_only_not_implemented
     def median(
         self, split_every=None, split_out=1, shuffle=None, numeric_only=no_default
     ):
@@ -2005,7 +2003,7 @@ class _GroupBy:
             {"numeric_only": numeric_only} if numeric_only is not no_default else {}
         )
 
-        with check_numeric_only_deprecation():
+        with check_numeric_only_deprecation(name="median"):
             meta = self._meta_nonempty.median(**numeric_only_kwargs)
         columns = meta.name if is_series_like(meta) else meta.columns
         by = self.by if isinstance(self.by, list) else [self.by]
@@ -2024,6 +2022,7 @@ class _GroupBy:
                 "levels": _determine_levels(self.by),
                 **self.observed,
                 **self.dropna,
+                **numeric_only_kwargs,
             },
             split_every=split_every,
             split_out=split_out,

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -44,14 +44,7 @@ AGG_FUNCS = [
             strict=False,
         ),
     ),
-    pytest.param(
-        "median",
-        marks=pytest.mark.xfail(
-            condition=PANDAS_GT_200,
-            reason="numeric_only=False not implemented",
-            strict=False,
-        ),
-    ),
+    "median",
     "min",
     "max",
     "count",
@@ -3226,6 +3219,8 @@ def test_groupby_aggregate_categorical_observed(
 ):
     if agg_func in ["cov", "corr", "nunique"]:
         pytest.skip("Not implemented for DataFrameGroupBy yet.")
+    if agg_func == "median" and isinstance(groupby, str):
+        pytest.skip("Can't calculate median over categorical")
     if agg_func in ["sum", "count", "prod"] and groupby != "cat_1":
         pytest.skip("Gives zeros rather than nans.")
     if agg_func in ["std", "var"] and observed:
@@ -3512,6 +3507,7 @@ def test_groupby_slice_getitem(by, slice_key):
         "prod",
         "first",
         "last",
+        "median",
         pytest.param(
             "idxmax",
             marks=pytest.mark.skip(reason="https://github.com/dask/dask/issues/9882"),
@@ -3547,7 +3543,7 @@ def test_groupby_numeric_only_supported(func, numeric_only):
     # dask and panadas have similar behavior
     ctx = contextlib.nullcontext()
     if PANDAS_GT_150 and not PANDAS_GT_200:
-        if func in ("sum", "prod"):
+        if func in ("sum", "prod", "median"):
             if numeric_only is None:
                 ctx = pytest.warns(
                     FutureWarning, match="The default value of numeric_only"
@@ -3561,7 +3557,8 @@ def test_groupby_numeric_only_supported(func, numeric_only):
         successful_compute = True
     except TypeError as e:
         # Make sure dask and pandas raise the same error message
-        ctx = pytest.raises(TypeError, match=str(e))
+        # We raise the error on _meta_nonempty, actual element may differ
+        ctx = pytest.raises(TypeError, match=str(e)[:-5])
         successful_compute = False
 
     # Here's where we check that dask behaves the same as pandas

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3558,7 +3558,7 @@ def test_groupby_numeric_only_supported(func, numeric_only):
     except TypeError as e:
         # Make sure dask and pandas raise the same error message
         # We raise the error on _meta_nonempty, actual element may differ
-        ctx = pytest.raises(TypeError, match=str(e)[:-5])
+        ctx = pytest.raises(TypeError, match=f"{str(e)[:-5]}|ArrowStringArray")
         successful_compute = False
 
     # Here's where we check that dask behaves the same as pandas

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3558,7 +3558,9 @@ def test_groupby_numeric_only_supported(func, numeric_only):
     except TypeError as e:
         # Make sure dask and pandas raise the same error message
         # We raise the error on _meta_nonempty, actual element may differ
-        ctx = pytest.raises(TypeError, match=f"{str(e)[:-5]}|ArrowStringArray")
+        ctx = pytest.raises(
+            TypeError, match=f"{str(e)[:-5]}|does not support reduction"
+        )
         successful_compute = False
 
     # Here's where we check that dask behaves the same as pandas


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
