### PR TITLE
Array.vindex performance improvements

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -28,8 +28,7 @@ from typing import Any, TypeVar, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike
-from tlz import accumulate, concat, first, frequencies, groupby, partition
-from tlz.curried import pluck
+from tlz import accumulate, concat, first, frequencies, partition
 
 from dask import compute, config, core
 from dask.array import chunk
@@ -5456,7 +5455,7 @@ def _vindex(x, *indexes):
     array_indexes = {}
     for i, (ind, size) in enumerate(zip(reduced_indexes, x.shape)):
         if not isinstance(ind, slice):
-            ind = np.array(ind, copy=True)
+            ind = np.array(ind, copy=False)
             if ind.dtype.kind == "b":
                 raise IndexError("vindex does not support indexing with boolean arrays")
             if ((ind >= size) | (ind < -size)).any():
@@ -5464,7 +5463,8 @@ def _vindex(x, *indexes):
                     "vindex key has entries out of bounds for "
                     "indexing along axis %s of size %s: %r" % (i, size, ind)
                 )
-            ind %= size
+            if (ind < 0).any():
+                ind = ind % size
             array_indexes[i] = ind
 
     if array_indexes:
@@ -5488,112 +5488,134 @@ def _vindex_array(x, dict_indexes):
     broadcast_shape = broadcast_indexes[0].shape
 
     lookup = dict(zip(dict_indexes, broadcast_indexes))
-    flat_indexes = [
-        lookup[i].ravel().tolist() if i in lookup else None for i in range(x.ndim)
-    ]
-    flat_indexes.extend([None] * (x.ndim - len(flat_indexes)))
+    indexed_axes = [i for i in range(x.ndim) if i in lookup]
+    index_arrs = [lookup[i].ravel() for i in indexed_axes]
 
-    flat_indexes = [
-        list(index) if index is not None else index for index in flat_indexes
+    bounds = [
+        list(accumulate(add, (0,) + c))
+        for i, c in enumerate(x.chunks)
+        if i in indexed_axes
     ]
-    bounds = [list(accumulate(add, (0,) + c)) for c in x.chunks]
-    bounds2 = [b for i, b in zip(flat_indexes, bounds) if i is not None]
-    axis = _get_axis(flat_indexes)
-    token = tokenize(x, flat_indexes)
+    axis = _get_axis(indexed_axes)
+    token = tokenize(x, index_arrs)
     out_name = "vindex-merge-" + token
 
-    points = list()
-    for i, idx in enumerate(zip(*[i for i in flat_indexes if i is not None])):
-        block_idx = [bisect(b, ind) - 1 for b, ind in zip(bounds2, idx)]
-        inblock_idx = [
-            ind - bounds2[k][j] for k, (ind, j) in enumerate(zip(idx, block_idx))
-        ]
-        points.append((i, tuple(block_idx), tuple(inblock_idx)))
+    # identify which blocks are being indexed
+    block_dims = tuple(d for i, d in enumerate(x.numblocks) if i in indexed_axes)
+    block_idxs = []
+    for block_idx in np.ndindex(*block_dims):
+        in_block = _check_block_bounds(index_arrs, _get_block_bounds(block_idx, bounds))
+        if in_block.any():
+            block_idxs.append(block_idx)
 
-    chunks = [c for i, c in zip(flat_indexes, x.chunks) if i is None]
-    chunks.insert(0, (len(points),) if points else (0,))
-    chunks = tuple(chunks)
+    chunks = (index_arrs[0].shape,) + tuple(
+        c for i, c in enumerate(x.chunks) if i not in indexed_axes
+    )
 
-    if points:
-        per_block = groupby(1, points)
-        per_block = {k: v for k, v in per_block.items() if v}
+    if index_arrs[0].size == 0:
+        # output has a zero dimension, just create a new zero-shape array
+        # with the same dtype
+        from dask.array.wrap import empty
 
-        other_blocks = list(
-            product(
-                *[
-                    list(range(len(c))) if i is None else [None]
-                    for i, c in zip(flat_indexes, x.chunks)
-                ]
-            )
-        )
-
-        full_slices = [slice(None, None) if i is None else None for i in flat_indexes]
-
-        name = "vindex-slice-" + token
-        vindex_merge_name = "vindex-merge-" + token
-        dsk = {}
-        for okey in other_blocks:
-            for i, key in enumerate(per_block):
-                dsk[keyname(name, i, okey)] = (
-                    _vindex_transpose,
-                    (
-                        _vindex_slice,
-                        (x.name,) + interleave_none(okey, key),
-                        interleave_none(
-                            full_slices, list(zip(*pluck(2, per_block[key])))
-                        ),
-                    ),
-                    axis,
-                )
-            dsk[keyname(vindex_merge_name, 0, okey)] = (
-                _vindex_merge,
-                [list(pluck(0, per_block[key])) for key in per_block],
-                [keyname(name, i, okey) for i in range(len(per_block))],
-            )
-
-        result_1d = Array(
-            HighLevelGraph.from_collections(out_name, dsk, dependencies=[x]),
-            out_name,
-            chunks,
-            x.dtype,
-            meta=x._meta,
+        result_1d = empty(
+            tuple(map(sum, chunks)), chunks=chunks, dtype=x.dtype, name=out_name
         )
         return result_1d.reshape(broadcast_shape + result_1d.shape[1:])
 
-    # output has a zero dimension, just create a new zero-shape array with the
-    # same dtype
-    from dask.array.wrap import empty
+    other_blocks = list(
+        product(
+            *[
+                list(range(len(c))) if i not in indexed_axes else [None]
+                for i, c in enumerate(x.chunks)
+            ]
+        )
+    )
 
-    result_1d = empty(
-        tuple(map(sum, chunks)), chunks=chunks, dtype=x.dtype, name=out_name
+    name = "vindex-slice-" + token
+    vindex_merge_name = "vindex-merge-" + token
+    dsk = {}
+    for okey in other_blocks:
+        for i, key in enumerate(block_idxs):
+            dsk[keyname(name, i, okey)] = (
+                _vindex_transpose,
+                (
+                    _vindex_slice,
+                    (x.name,) + interleave_none(okey, key),
+                    index_arrs,
+                    _get_block_bounds(key, bounds),
+                    indexed_axes,
+                ),
+                axis,
+            )
+        dsk[keyname(vindex_merge_name, 0, okey)] = (
+            _vindex_merge,
+            [keyname(name, i, okey) for i in range(len(block_idxs))],
+            index_arrs,
+            block_idxs,
+            bounds,
+        )
+
+    result_1d = Array(
+        HighLevelGraph.from_collections(out_name, dsk, dependencies=[x]),
+        out_name,
+        chunks,
+        x.dtype,
+        meta=x._meta,
     )
     return result_1d.reshape(broadcast_shape + result_1d.shape[1:])
 
 
-def _get_axis(indexes):
+def _get_block_bounds(block_idx, bounds):
+    """Return a list of [start_idx, stop_idx] pairs for `block_idx`"""
+    return [b[i : i + 2] for i, b in zip(block_idx, bounds)]
+
+
+def _check_block_bounds(index_arrs, block_bounds):
+    """Identify which index points are in-block
+
+    `bounds` describes the extent of the block as a list of
+    [start_idx, stop_idx] pairs for each indexed dimension.
+    """
+    in_block = np.ones(index_arrs[0].shape, "?")
+    for dim_index_arr, dim_bounds in zip(index_arrs, block_bounds):
+        in_block &= dim_index_arr >= dim_bounds[0]
+        in_block &= dim_index_arr < dim_bounds[1]
+    return in_block
+
+
+def _get_axis(indexed_axes):
     """Get axis along which point-wise slicing results lie
 
-    This is mostly a hack because I can't figure out NumPy's rule on this and
-    can't be bothered to go reading.
+    From https://numpy.org/doc/stable/user/basics.indexing.html, when advanced
+    indexes are all applied to adjacent axes, the dimensions resulting from the
+    advanced indexing are inserted into ihe result array at the same spot as they
+    were in the initial array. Otherwise, they come first in the result array.
 
-    >>> _get_axis([[1, 2], None, [1, 2], None])
+    >>> _get_axis([0, 2])
     0
-    >>> _get_axis([None, [1, 2], [1, 2], None])
+    >>> _get_axis([1, 2])
     1
-    >>> _get_axis([None, None, [1, 2], [1, 2]])
+    >>> _get_axis([2, 3])
     2
     """
-    ndim = len(indexes)
-    indexes = [slice(None, None) if i is None else [0] for i in indexes]
-    x = np.empty((2,) * ndim)
-    x2 = x[tuple(indexes)]
-    return x2.shape.index(1)
+    if indexed_axes[-1] - indexed_axes[0] == len(indexed_axes) - 1:
+        return indexed_axes[0]
+    else:
+        return 0
 
 
-def _vindex_slice(block, points):
+def _vindex_slice(block, index_arrs, block_bounds, indexed_axes):
     """Pull out point-wise slices from block"""
-    points = [p if isinstance(p, slice) else list(p) for p in points]
-    return block[tuple(points)]
+    in_block = _check_block_bounds(index_arrs, block_bounds)
+    block_index_arr = [
+        dim_index_arr[in_block] - dim_bounds[0]
+        for dim_index_arr, dim_bounds in zip(index_arrs, block_bounds)
+    ]
+    block_index_arr = tuple(
+        block_index_arr.pop(0) if i in indexed_axes else slice(None)
+        for i in range(block.ndim)
+    )
+    return block[block_index_arr]
 
 
 def _vindex_transpose(block, axis):
@@ -5602,36 +5624,13 @@ def _vindex_transpose(block, axis):
     return block.transpose(axes)
 
 
-def _vindex_merge(locations, values):
-    """
-
-    >>> locations = [0], [2, 1]
-    >>> values = [np.array([[1, 2, 3]]),
-    ...           np.array([[10, 20, 30], [40, 50, 60]])]
-
-    >>> _vindex_merge(locations, values)
-    array([[ 1,  2,  3],
-           [40, 50, 60],
-           [10, 20, 30]])
-    """
-    locations = list(map(list, locations))
-    values = list(values)
-
-    n = sum(map(len, locations))
-
-    shape = list(values[0].shape)
-    shape[0] = n
-    shape = tuple(shape)
-
-    dtype = values[0].dtype
-
-    x = np.empty_like(values[0], dtype=dtype, shape=shape)
-
-    ind = [slice(None, None) for i in range(x.ndim)]
-    for loc, val in zip(locations, values):
-        ind[0] = loc
-        x[tuple(ind)] = val
-
+def _vindex_merge(sliced_arrs, index_arrs, block_idxs, bounds):
+    x = np.empty_like(
+        sliced_arrs[0], shape=(index_arrs[0].shape + sliced_arrs[0].shape[1:])
+    )
+    for sliced_arr, block_idx in zip(sliced_arrs, block_idxs):
+        in_block = _check_block_bounds(index_arrs, _get_block_bounds(block_idx, bounds))
+        x[in_block] = sliced_arr
     return x
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3083,7 +3083,7 @@ def test_point_slicing_with_full_slice():
         result = d.vindex[tuple(slc)]
 
         # Rotate the expected result accordingly
-        axis = _get_axis(ind)
+        axis = _get_axis([a for a, i in enumerate(ind) if i is not None])
         expected = _vindex_transpose(x[tuple(slc)], axis)
 
         assert_eq(result, expected)
@@ -3171,18 +3171,6 @@ def test_vindex_errors():
     pytest.raises(IndexError, lambda: d.vindex[[0], [-6]])
     with pytest.raises(IndexError, match="does not support indexing with dask objects"):
         d.vindex[[0], [0], da.array([0])]
-
-
-def test_vindex_merge():
-    from dask.array.core import _vindex_merge
-
-    locations = [1], [2, 0]
-    values = [np.array([[1, 2, 3]]), np.array([[10, 20, 30], [40, 50, 60]])]
-
-    assert (
-        _vindex_merge(locations, values)
-        == np.array([[40, 50, 60], [1, 2, 3], [10, 20, 30]])
-    ).all()
 
 
 def test_vindex_identity():


### PR DESCRIPTION
This is a patch to `Array.vindex` that aims to:
1. Cut down on how long it takes to build the task graph
2. Reduce memory usage in some cases by avoiding copies of the index arrays

For execute time, I used the following code as a simple benchmark:
```python
import dask.array as da
import numpy as np
arr_1 = da.ones([6000, 6000], chunks=[3000, 3000])  # 36M elements in 4 chunks
idx = np.repeat(np.arange(0, 6000, 6), 1000)  # 1M index points
arr_2 = arr_1.vindex[idx, idx[::-1]]
```

Before this change the last line took 2.47s of wall clock time to execute. With this change it takes 22.1ms.

Regarding memory usage, I was motivated by my use case which involves accessing NetCDF files via Xarray and using `xarray.Dataset.isel`, which under the hood calls `da.Array.vindex` on many arrays using the same index values. The current `vindex` implementation always stores copies of the index arrays in the task graph, so an `isel` call could cause many index array copies to accumulate. This change stores the passed-in index arrays directly in the task graph, if possible.

This implementation essentially works the same way as the existing one, it just handles the bookkeeping data structures a bit differently. One consequence is that some of the index processing that used to happen when building the graph now happens at graph execution time. Nonetheless, in my testing graph execution performance also seems to have improved a bit: wall time for `arr_2.compute()` from the snippet above dropped from 632ms to 118ms.

I don't have much experience with Dask internals, but I hope this is a workable solution. Also, a couple questions:
1. Is it ok to store the passed-in index arrays directly in the task graph like this? If the caller goes on to mutate these arrays, this could cause surprising results. If it's not ok it'd be easy to change the code to make a copy and still benefit from the speedup. But I suspect it is ok, since a similar situation results just from calling `da.from_array` on a NumPy array.
2. From profing `vindex` I can see that more than half its time is now being spent hashing the index arrays in order to assign key names to graph nodes. Are there any alternatives for generating keys in this type of situation?