### PR TITLE
Fix ``test_groupby_numeric_only_supported`` and ``test_groupby_aggregate_categorical_observed`` upstream errors 

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -515,10 +515,10 @@ def _non_agg_chunk(df, *by, key, dropna=None, observed=None, **kwargs):
             # frame.
             new_cats = full_index[~full_index.isin(result.index)]
             empty_data = {
-                col: pd.Series([None], name=col, dtype=result[col].dtype)
-                for col in result.columns
+                c: pd.Series(index=new_cats, dtype=result[c].dtype)
+                for c in result.columns
             }
-            empty = pd.DataFrame(empty_data, index=new_cats)
+            empty = pd.DataFrame(empty_data)
             result = pd.concat([result, empty])
 
     return result

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -514,7 +514,11 @@ def _non_agg_chunk(df, *by, key, dropna=None, observed=None, **kwargs):
             # If we found any categoricals, append unobserved values to the end of the
             # frame.
             new_cats = full_index[~full_index.isin(result.index)]
-            empty = pd.DataFrame(pd.NA, index=new_cats, columns=result.columns)
+            empty_data = {
+                col: pd.Series([None], name=col, dtype=result[col].dtype)
+                for col in result.columns
+            }
+            empty = pd.DataFrame(empty_data, index=new_cats)
             result = pd.concat([result, empty])
 
     return result

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3558,7 +3558,9 @@ def test_groupby_numeric_only_supported(func, numeric_only):
     except TypeError:
         # Make sure dask and pandas raise the same error message
         # We raise the error on _meta_nonempty, actual element may differ
-        ctx = pytest.raises(TypeError, match="Cannot convert|does not support")
+        ctx = pytest.raises(
+            TypeError, match="Cannot convert|could not convert|does not support"
+        )
         successful_compute = False
 
     # Here's where we check that dask behaves the same as pandas

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3555,12 +3555,10 @@ def test_groupby_numeric_only_supported(func, numeric_only):
         with ctx:
             expected = getattr(pdf.groupby("ints"), func)(**kwargs)
         successful_compute = True
-    except TypeError as e:
+    except TypeError:
         # Make sure dask and pandas raise the same error message
         # We raise the error on _meta_nonempty, actual element may differ
-        ctx = pytest.raises(
-            TypeError, match=f"{str(e)[:-5]}|does not support reduction"
-        )
+        ctx = pytest.raises(TypeError, match="Cannot convert|does not support")
         successful_compute = False
 
     # Here's where we check that dask behaves the same as pandas


### PR DESCRIPTION
Fixes the following upstream errors:

```
FutureWarning: The behavior of DataFrame concatenation with all-NA entries
NotImplementedError: function is not implemented for this dtype: [how->median,dtype->object]
```

Xref https://github.com/dask/dask/issues/10089
Xref https://github.com/pandas-dev/pandas/pull/52613.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
