### PR TITLE
Un-``xfail`` ``test_categories`` with ``pyarrow`` strings and ``pyarrow>=12``

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1184,7 +1184,6 @@ def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
         assert_eq(ddf, ddf2, check_divisions=False)
 
 
-@pytest.mark.xfail_with_pyarrow_strings  # https://github.com/apache/arrow/issues/33727
 def test_categories(tmpdir, engine):
     fn = str(tmpdir)
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": list("caaab")})

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1215,6 +1215,7 @@ def test_categories(tmpdir, engine):
         dd.read_parquet(fn, categories=["foo"], engine=engine)
 
 
+@pytest.mark.xfail_with_pyarrow_strings  # https://github.com/apache/arrow/issues/33727
 def test_categories_unnamed_index(tmpdir, engine):
     # Check that we can handle an unnamed categorical index
     # https://github.com/dask/dask/issues/6885

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1184,13 +1184,10 @@ def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
         assert_eq(ddf, ddf2, check_divisions=False)
 
 
-pytest.mark.xfail(
-    bool(dask.config.get("dataframe.convert-string"))
-    and pyarrow_version < parse_version("12.0.0"),
+@pytest.mark.xfail(
+    pyarrow_strings_enabled() and pyarrow_version < parse_version("12.0.0"),
     reason="Known failure with pyarrow strings: https://github.com/apache/arrow/issues/33727",
 )
-
-
 def test_categories(tmpdir, engine):
     fn = str(tmpdir)
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": list("caaab")})

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1215,7 +1215,6 @@ def test_categories(tmpdir, engine):
         dd.read_parquet(fn, categories=["foo"], engine=engine)
 
 
-@pytest.mark.xfail_with_pyarrow_strings  # https://github.com/apache/arrow/issues/33727
 def test_categories_unnamed_index(tmpdir, engine):
     # Check that we can handle an unnamed categorical index
     # https://github.com/dask/dask/issues/6885

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1184,6 +1184,13 @@ def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
         assert_eq(ddf, ddf2, check_divisions=False)
 
 
+pytest.mark.xfail(
+    bool(dask.config.get("dataframe.convert-string"))
+    and pyarrow_version < parse_version("12.0.0"),
+    reason="Known failure with pyarrow strings: https://github.com/apache/arrow/issues/33727",
+)
+
+
 def test_categories(tmpdir, engine):
     fn = str(tmpdir)
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": list("caaab")})


### PR DESCRIPTION
https://github.com/apache/arrow/issues/33727 has been fixed in pyarrow via https://github.com/apache/arrow/pull/34289.

Already available in nightly, so this fixes a failure in pyarrow build.

- [x] Passes `pre-commit run --all-files`
