### PR TITLE
Avoid scalar conversion deprecation warning in ``numpy=1.25``

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1873,7 +1873,7 @@ class Array(DaskMethodsMixin):
         if self.size > 1:
             raise TypeError("Only length-1 arrays can be converted to Python scalars")
         else:
-            return cast_type(self.compute())
+            return cast_type(self.compute().item())
 
     def __int__(self):
         return self._scalarfunc(int)


### PR DESCRIPTION
This PR fixes this deprecation warning we're seeing in the `upstream` build with `numpy=1.25`

```python
_________________________________ test_coerce __________________________________
[gw0] linux -- Python 3.10.10 /usr/share/miniconda3/envs/test-environment/bin/python3.10

    def test_coerce():
        d0 = da.from_array(np.array(1), chunks=(1,))
        d1 = da.from_array(np.array([1]), chunks=(1,))
        with dask.config.set(scheduler="sync"):
            for d in d0, d1:
                assert bool(d) is True
>               assert int(d) == 1

dask/array/tests/test_array_core.py:1778: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
dask/array/core.py:1879: in __int__
    return self._scalarfunc(int)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = dask.array<array, shape=(1,), dtype=int64, chunksize=(1,), chunktype=numpy.ndarray>
cast_type = <class 'int'>

    def _scalarfunc(self, cast_type):
        if self.size > 1:
            raise TypeError("Only length-1 arrays can be converted to Python scalars")
        else:
>           return cast_type(self.compute())
E           DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
```

We now pluck off the item from the size-1 ndarray before passing to `cast_type` (this should also be backwards compatible with older versions of `numpy`) 

xref https://github.com/dask/dask/issues/10089