### PR TITLE
Test doc build

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 numpydoc
 sphinx>=4.0.0
-dask-sphinx-theme>=3.0.0
+dask-sphinx-theme==3.0.3
 sphinx-click
 sphinx-copybutton
 sphinx-remove-toctrees


### PR DESCRIPTION
Seeing some apparently unrelated doc build failures in https://github.com/dask/dask/pull/10246. Not sure if this is related to a change in `distributed` or the new `dask-sphinx-theme` release that happened yesterday. Pinning to the old release to see if that helps 