### PR TITLE
Fix for `Failed: DID NOT WARN` in `test_apply`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4319,7 +4319,7 @@ Dask Name: {name}, {layers}""".format(
             kwds["convert_dtype"] = convert_dtype
 
         # let pandas trigger any warnings, such as convert_dtype warning
-        self._meta.apply(func, args=args, **kwds)
+        self._meta_nonempty.apply(func, args=args, **kwds)
 
         if meta is no_default:
             with check_convert_dtype_deprecation():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3182,11 +3182,7 @@ def test_apply_convert_dtype(convert_dtype):
     kwargs = {} if convert_dtype is None else {"convert_dtype": convert_dtype}
     should_warn = PANDAS_GT_210 and convert_dtype is not None
 
-    meta_val = ddf.x._meta_nonempty.iloc[0]
-
     def func(x):
-        # meta check is a regression test for https://github.com/dask/dask/issues/10209
-        assert x != meta_val
         return x + 1
 
     with _check_warning(should_warn, FutureWarning, "the convert_dtype parameter"):


### PR DESCRIPTION
Fix for `Failed: DID NOT WARN` in `dask/dataframe/tests/test_dataframe.py::test_apply`.

In upstream, pandas doesn't trigger a warning when `apply` is done on empty Series meta.

Reverts changes done in https://github.com/dask/dask/pull/10212.

Xref https://github.com/dask/dask/issues/10089.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @phofl. I've seen https://github.com/dask/dask/issues/10209, but it looks like this is one of those cases where we do need non-empty meta. Yes, it may look odd if the user prints this data, but it helps us pass through the warnings.
