### PR TITLE
Fix dtype inference for ``engine="pyarrow"`` in ``read_csv``

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -620,6 +620,9 @@ def read_pandas(
     # Use sample to infer dtypes and check for presence of include_path_column
     head_kwargs = kwargs.copy()
     head_kwargs.pop("skipfooter", None)
+    if head_kwargs.get("engine") == "pyarrow":
+        # Use c engine to infer since Arrow engine does not support nrows
+        head_kwargs["engine"] = "c"
     try:
         head = reader(BytesIO(b_sample), nrows=sample_rows, **head_kwargs)
     except pd.errors.ParserError as e:

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -622,7 +622,7 @@ def read_pandas(
     head_kwargs.pop("skipfooter", None)
     if head_kwargs.get("engine") == "pyarrow":
         # Use c engine to infer since Arrow engine does not support nrows
-        head_kwargs["engine"] = "c"
+        head_kwargs.pop("engine")
     try:
         head = reader(BytesIO(b_sample), nrows=sample_rows, **head_kwargs)
     except pd.errors.ParserError as e:

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -622,7 +622,7 @@ def read_pandas(
     head_kwargs.pop("skipfooter", None)
     if head_kwargs.get("engine") == "pyarrow":
         # Use c engine to infer since Arrow engine does not support nrows
-        head_kwargs.pop("engine")
+        head_kwargs["engine"] = "c"
     try:
         head = reader(BytesIO(b_sample), nrows=sample_rows, **head_kwargs)
     except pd.errors.ParserError as e:

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -17,7 +17,7 @@ from dask.base import compute_as_if_collection
 from dask.bytes.core import read_bytes
 from dask.bytes.utils import compress
 from dask.core import flatten
-from dask.dataframe._compat import PANDAS_GT_200, tm
+from dask.dataframe._compat import PANDAS_GT_140, PANDAS_GT_200, tm
 from dask.dataframe.io.csv import (
     _infer_block_size,
     auto_blocksize,
@@ -1251,6 +1251,7 @@ def test_read_csv_singleton_dtype():
         assert_eq(pd.read_csv(fn, dtype=float), dd.read_csv(fn, dtype=float))
 
 
+@pytest.mark.skipif(not PANDAS_GT_140, reason="arrow engine available from 1.4")
 def test_read_csv_arrow_engine():
     pytest.importorskip("pyarrow")
     sep_text = normalize_text(

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1251,6 +1251,19 @@ def test_read_csv_singleton_dtype():
         assert_eq(pd.read_csv(fn, dtype=float), dd.read_csv(fn, dtype=float))
 
 
+def test_read_csv_arrow_engine():
+    pytest.importorskip("pyarrow")
+    sep_text = normalize_text(
+        """
+    a,b
+    1,2
+    """
+    )
+
+    with filetext(sep_text) as fn:
+        assert_eq(pd.read_csv(fn, engine="pyarrow"), dd.read_csv(fn, engine="pyarrow"))
+
+
 def test_robust_column_mismatch():
     files = csv_files.copy()
     k = sorted(files)[-1]


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

this is raising right now