### PR TITLE
`da.coarsen` doesn't trim an empty chunk in meta

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -2317,8 +2317,10 @@ def coarsen(reduction, x, axes, trim_excess=False, **kwargs):
         + key[1:]: (apply, chunk.coarsen, [reduction, key, axes, trim_excess], kwargs)
         for key in flatten(x.__dask_keys__())
     }
+
     chunks = tuple(
-        tuple(int(bd // axes.get(i, 1)) for bd in bds) for i, bds in enumerate(x.chunks)
+        tuple(int(bd // axes.get(i, 1)) for bd in bds if int(bd // axes.get(i, 1)) > 0)
+        for i, bds in enumerate(x.chunks)
     )
 
     meta = reduction(np.empty((1,) * x.ndim, dtype=x.dtype), **kwargs)

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -2318,8 +2318,9 @@ def coarsen(reduction, x, axes, trim_excess=False, **kwargs):
         for key in flatten(x.__dask_keys__())
     }
 
+    coarsen_dim = lambda dim, ax: int(dim // axes.get(ax, 1))
     chunks = tuple(
-        tuple(int(bd // axes.get(i, 1)) for bd in bds if int(bd // axes.get(i, 1)) > 0)
+        tuple(coarsen_dim(bd, i) for bd in bds if coarsen_dim(bd, i) > 0)
         for i, bds in enumerate(x.chunks)
     )
 

--- a/dask/array/tests/test_chunk.py
+++ b/dask/array/tests/test_chunk.py
@@ -99,6 +99,7 @@ def test_coarsen():
 
 
 def test_coarsen_unaligned_shape():
+    """https://github.com/dask/dask/issues/10274"""
     x = da.random.random(100)
     res = da.coarsen(np.mean, x, {0: 3}, trim_excess=True)
     assert res.chunks == ((33,),)

--- a/dask/array/tests/test_chunk.py
+++ b/dask/array/tests/test_chunk.py
@@ -98,6 +98,12 @@ def test_coarsen():
     assert y[0, 0] == np.sum(x[:2, :4])
 
 
+def test_coarsen_unaligned_shape():
+    x = da.random.random(100)
+    res = da.coarsen(np.mean, x, {0: 3}, trim_excess=True)
+    assert res.chunks == ((33,),)
+
+
 """
 def test_coarsen_on_uneven_shape():
     x = np.random.randint(10, size=(23, 24))


### PR DESCRIPTION
`da.coarsen` with unaligned shape reports an empty chunk, but it's lying, it actually trims it.

- [x] Closes https://github.com/dask/dask/issues/10274
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
