### PR TITLE
Fix broken link in changelog

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6680,3 +6680,4 @@ Other
 .. _`Miles`: https://github.com/milesgranger
 .. _`Anton Loukianov`: https://github.com/antonl
 .. _`Brian Phillips`: https://github.com/bphillips-exos
+.. _`hotpotato`: https://github.com/novdanody


### PR DESCRIPTION
Fixes docs build.

Even though the docs build in this PR is green, there's another issue when building docs locally:

```
/Users/jbennet/src/dask/docs/source/array-api.rst:9: WARNING: autosummary: stub file not found 'dask.array.array'. Check your autosummary_generate setting.
```

I suspect a circular import in `dask/array/__init__.py`, specifically `random`, but didn't find a way to fix it.