### PR TITLE
Fix conversion from ``Categorical`` to ``pa.dictionary`` in ``read_parquet``

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1256,7 +1256,9 @@ class ArrowDatasetEngine(Engine):
             # Make sure all categories are set to "unknown".
             # Cannot include index names in the `cols` argument.
             meta = clear_known_categories(
-                meta, cols=[c for c in categories if c not in meta.index.names]
+                meta,
+                cols=[c for c in categories if c not in meta.index.names],
+                dtype_backend=dtype_backend,
             )
 
         if partition_obj:

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4904,3 +4904,23 @@ def test_read_parquet_preserve_categorical_column_dtype(tmp_path):
         index=[0, 0],
     )
     assert_eq(ddf, expected)
+
+
+@PYARROW_MARK
+@pytest.mark.skipif(not PANDAS_GT_150, reason="Requires pd.ArrowDtype")
+def test_dtype_backend_categoricals(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+    df = pd.DataFrame({"a": pd.Series(["x", "y"], dtype="category"), "b": [1, 2]})
+    outdir = tmp_path / "out.parquet"
+    df.to_parquet(outdir, engine="pyarrow")
+    ddf = dd.read_parquet(outdir, engine="pyarrow", dtype_backend="pyarrow")
+    expected = pd.DataFrame(
+        {
+            "a": pd.Series(
+                ["x", "y"], dtype=pd.ArrowDtype(pa.dictionary(pa.int32(), pa.string()))
+            ),
+            "b": pd.Series([1, 2], dtype="int64[pyarrow]"),
+        }
+    )
+    # Set sort_results=False because of pandas bug
+    assert_eq(ddf, expected, sort_results=False)

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -261,7 +261,7 @@ def strip_unknown_categories(x, just_drop_unknown=False):
     return x
 
 
-def clear_known_categories(x, cols=None, index=True):
+def clear_known_categories(x, cols=None, index=True, dtype_backend=None):
     """Set categories to be unknown.
 
     Parameters
@@ -273,7 +273,15 @@ def clear_known_categories(x, cols=None, index=True):
     index : bool, optional
         If True and x is a Series or DataFrame, set the clear known categories
         in the index as well.
+    dtype_backend : string, optional
+        If set to PyArrow, the categorical dtype is implemented as a PyArrow
+        dictionary
     """
+    if dtype_backend == "pyarrow":
+        # Right now Categorical with PyArrow is implemented as dictionary and
+        # categorical accessor is not yet available
+        return x
+
     if isinstance(x, (pd.Series, pd.DataFrame)):
         x = x.copy()
         if isinstance(x, pd.DataFrame):


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Came across this when working on the blog post. 