### PR TITLE
HOTFIX: Add missing user link

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6680,3 +6680,4 @@ Other
 .. _`Miles`: https://github.com/milesgranger
 .. _`Anton Loukianov`: https://github.com/antonl
 .. _`Brian Phillips`: https://github.com/bphillips-exos
+.. _`hotpotato`: https://github.com/hotpotato


### PR DESCRIPTION
I missed a user link when releasing `2023.5.0`. Pushing in a hotfix commit and updating the tag to unblock RTD builds.