### PR TITLE
`mask` and `where` should accept a `callable`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3322,7 +3322,6 @@ Dask Name: {name}, {layers}"""
             or is_dataframe_like(cond_res)
             or is_series_like(cond_res)
             or is_index_like(cond_res)
-            or callable(cond_res)
         ):
             raise ValueError(
                 f"Condition should be an object that can be aligned with {self.__class__}, "

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3316,26 +3316,18 @@ Dask Name: {name}, {layers}"""
         )
 
     def _validate_condition(self, cond):
-        def is_alignable_collection(x):
-            return (
-                is_dask_collection(x)
-                or is_dataframe_like(x)
-                or is_series_like(x)
-                or is_index_like(x)
-            )
-
-        if not (is_alignable_collection(cond) or callable(cond)):
+        cond_res = cond(self._meta) if callable(cond) else cond
+        if not (
+            is_dask_collection(cond_res)
+            or is_dataframe_like(cond_res)
+            or is_series_like(cond_res)
+            or is_index_like(cond_res)
+            or callable(cond_res)
+        ):
             raise ValueError(
                 f"Condition should be an object that can be aligned with {self.__class__}, "
                 f" which includes Dask or pandas collections, DataFrames or Series, or a Callable."
             )
-        if callable(cond):
-            result = cond(self._meta)
-            if not is_alignable_collection(result):
-                raise ValueError(
-                    f"Condition should be an object that can be aligned with {self.__class__}, "
-                    f" which includes Dask or pandas collections, DataFrames or Series, or a Callable."
-                )
 
     @derived_from(pd.DataFrame)
     def where(self, cond, other=np.nan):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3321,10 +3321,11 @@ Dask Name: {name}, {layers}"""
             or is_dataframe_like(cond)
             or is_series_like(cond)
             or is_index_like(cond)
+            or callable(cond)
         ):
             raise ValueError(
                 f"Condition should be an object that can be aligned with {self.__class__}, "
-                f" which includes Dask or pandas collections, DataFrames or Series."
+                f" which includes Dask or pandas collections, DataFrames or Series, or a Callable."
             )
 
     @derived_from(pd.DataFrame)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5877,3 +5877,15 @@ def test_mask_where_array_like(df, cond):
     expected = df.where(cond=cond, other=5)
     result = ddf.where(cond=dd_cond, other=5)
     assert_eq(expected, result)
+
+
+def test_mask_where_callable():
+    """https://github.com/dask/dask/issues/10282"""
+    pdf = pd.DataFrame({"x": [1, None]})
+    ddf = dd.from_pandas(pdf, npartitions=1)
+
+    # dataframe
+    assert_eq(pdf.where(lambda d: d.isna(), 3), ddf.where(lambda d: d.isna(), 3))
+
+    #  series
+    assert_eq(pdf.x.where(lambda d: d == 1, 2), ddf.x.where(lambda d: d == 1, 2))


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/dask/dask/pull/10163.

- [x] Closes [#xxxx](https://github.com/dask/dask/issues/10282)
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
