### PR TITLE
[DNM] Re-introduce `gather_statistics` to `read_parquet`

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1340,7 +1340,7 @@ class ArrowDatasetEngine(Engine):
                 filter_columns.add(col)
 
         # Check if the user requested specific statistics
-        need_row_count = bool(gather_statistics)
+        require_statistics = bool(gather_statistics)
         if not isinstance(gather_statistics, (list, tuple, set)):
             gather_statistics = []
 
@@ -1364,7 +1364,7 @@ class ArrowDatasetEngine(Engine):
                 stat_col_indices[name] = i
 
         # Decide final `gather_statistics` setting
-        gather_statistics = need_row_count or _reset_gather_statistics(
+        gather_statistics = require_statistics or _reset_gather_statistics(
             calculate_divisions,
             blocksize,
             split_row_groups,
@@ -1404,6 +1404,7 @@ class ArrowDatasetEngine(Engine):
             "fs": fs,
             "split_row_groups": split_row_groups,
             "gather_statistics": gather_statistics,
+            "require_statistics": require_statistics,
             "filters": filters,
             "ds_filters": ds_filters,
             "schema": schema,
@@ -1528,6 +1529,7 @@ class ArrowDatasetEngine(Engine):
         ds_filters = dataset_info_kwargs["ds_filters"]
         schema = dataset_info_kwargs["schema"]
         stat_col_indices = dataset_info_kwargs["stat_col_indices"]
+        require_statistics = dataset_info_kwargs["require_statistics"]
         aggregation_depth = dataset_info_kwargs["aggregation_depth"]
         blocksize = dataset_info_kwargs["blocksize"]
 
@@ -1599,6 +1601,7 @@ class ArrowDatasetEngine(Engine):
                                 last = cmax_last.get(name, None)
                                 if not (
                                     filters
+                                    or require_statistics
                                     or (blocksize and split_row_groups is True)
                                     or aggregation_depth
                                 ):

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -28,8 +28,8 @@ from dask.dataframe.io.parquet.utils import (
     _infer_split_row_groups,
     _normalize_index_columns,
     _process_open_file_options,
-    _reset_gather_statistics,
     _row_groups_to_parts,
+    _set_gather_statistics,
     _set_metadata_task_size,
     _sort_and_analyze_paths,
 )
@@ -1339,10 +1339,14 @@ class ArrowDatasetEngine(Engine):
                     )
                 filter_columns.add(col)
 
-        # Check if the user requested specific statistics
+        # Check if the user has explicitly requested
+        # that statistics be gathered
         require_statistics = bool(gather_statistics)
-        if not isinstance(gather_statistics, (list, tuple, set)):
-            gather_statistics = []
+        require_column_statistics = (
+            gather_statistics
+            if isinstance(gather_statistics, (list, tuple, set))
+            else []
+        )
 
         # Check if the user want to calculate divisions
         calculate_divisions = kwargs.get("calculate_divisions", None)
@@ -1354,7 +1358,7 @@ class ArrowDatasetEngine(Engine):
         )
         for i, name in enumerate(schema.names):
             if (
-                name in gather_statistics
+                name in require_column_statistics
                 or name in _index_cols
                 or name in filter_columns
             ):
@@ -1364,7 +1368,7 @@ class ArrowDatasetEngine(Engine):
                 stat_col_indices[name] = i
 
         # Decide final `gather_statistics` setting
-        gather_statistics = require_statistics or _reset_gather_statistics(
+        gather_statistics: bool = require_statistics or _set_gather_statistics(
             calculate_divisions,
             blocksize,
             split_row_groups,

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -288,10 +288,10 @@ def read_parquet(
         from remote storage. Set this to ``True`` only when known divisions
         are needed for your workload (see :ref:`dataframe-design-partitions`).
     gather_statistics : bool or list, default False
-        List of specific columns to collect Parquet statistics for (when
-        available). Specifying ``True`` will guarantee the collection of
-        row-count statistics only. Note that ``calculate_divisions`` and
-        ``filters`` will also affect which column statistics are collected.
+        List of columns to collect Parquet statistics for (when available).
+        Specifying ``True`` will ensure the collection of row-count statistics
+        only. Note that ``calculate_divisions`` and ``filters`` will also
+        affect which column statistics are collected.
     ignore_metadata_file : bool, default False
         Whether to ignore the global ``_metadata`` file (when one is present).
         If ``True``, or if the global ``_metadata`` file is missing, the parquet

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -289,7 +289,7 @@ def read_parquet(
         are needed for your workload (see :ref:`dataframe-design-partitions`).
     gather_statistics : bool or list, default False
         List of specific columns to collect Parquet statistics for (when
-        available). Specifying ``True`` will guarentee the collection of
+        available). Specifying ``True`` will guarantee the collection of
         row-count statistics only. Note that ``calculate_divisions`` and
         ``filters`` will also affect which column statistics are collected.
     ignore_metadata_file : bool, default False

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -291,7 +291,8 @@ def read_parquet(
         List of columns to collect Parquet statistics for (when available).
         Specifying ``True`` will ensure the collection of row-count statistics
         only. Note that ``calculate_divisions`` and ``filters`` will also
-        affect which column statistics are collected.
+        affect which column statistics are collected. Therefore, specifying
+        ``False`` will not skip statistics gathering in all cases.
     ignore_metadata_file : bool, default False
         Whether to ignore the global ``_metadata`` file (when one is present).
         If ``True``, or if the global ``_metadata`` file is missing, the parquet

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -287,6 +287,11 @@ def read_parquet(
         when no global ``_metadata`` file is present, especially when reading
         from remote storage. Set this to ``True`` only when known divisions
         are needed for your workload (see :ref:`dataframe-design-partitions`).
+    collect_statistics : bool or list, default False
+        List of specific columns to collect Parquet statistics for (when
+        available). Specifying ``True`` will guarentee the collection of
+        row-count statistics only. Note that ``calculate_divisions`` and
+        ``filters`` will also affect which column statistics are collected.
     ignore_metadata_file : bool, default False
         Whether to ignore the global ``_metadata`` file (when one is present).
         If ``True``, or if the global ``_metadata`` file is missing, the parquet

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -122,6 +122,7 @@ class FastParquetEngine(Engine):
         pf,
         split_row_groups,
         gather_statistics,
+        require_statistics,
         stat_col_indices,
         filters,
         dtypes,
@@ -249,6 +250,7 @@ class FastParquetEngine(Engine):
 
                         if not (
                             filters
+                            or require_statistics
                             or (blocksize and split_row_groups is True)
                             or aggregation_depth
                         ):
@@ -695,7 +697,7 @@ class FastParquetEngine(Engine):
         )
 
         # Check if the user requested specific statistics
-        need_row_count = bool(gather_statistics)
+        require_statistics = bool(gather_statistics)
         if not isinstance(gather_statistics, (list, tuple, set)):
             gather_statistics = []
 
@@ -719,7 +721,7 @@ class FastParquetEngine(Engine):
         # Decide final `gather_statistics` setting.
         # NOTE: The "fastparquet" engine requires statistics for
         # filtering even if the filter is on a paritioned column
-        gather_statistics = need_row_count or _reset_gather_statistics(
+        gather_statistics = require_statistics or _reset_gather_statistics(
             calculate_divisions,
             blocksize,
             split_row_groups,
@@ -758,6 +760,7 @@ class FastParquetEngine(Engine):
             "fs": fs,
             "split_row_groups": split_row_groups,
             "gather_statistics": gather_statistics,
+            "require_statistics": require_statistics,
             "filters": filters,
             "dtypes": dtypes,
             "stat_col_indices": stat_col_indices,
@@ -823,6 +826,7 @@ class FastParquetEngine(Engine):
         fs = dataset_info_kwargs["fs"]
         split_row_groups = dataset_info_kwargs["split_row_groups"]
         gather_statistics = dataset_info_kwargs["gather_statistics"]
+        require_statistics = dataset_info_kwargs["require_statistics"]
         stat_col_indices = dataset_info_kwargs["stat_col_indices"]
         filters = dataset_info_kwargs["filters"]
         dtypes = dataset_info_kwargs["dtypes"]
@@ -860,6 +864,7 @@ class FastParquetEngine(Engine):
             pf,
             split_row_groups,
             gather_statistics,
+            require_statistics,
             stat_col_indices,
             filters,
             dtypes,

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -868,7 +868,7 @@ def _split_user_options(**kwargs):
     )
 
 
-def _reset_gather_statistics(
+def _set_gather_statistics(
     calculate_divisions,
     blocksize,
     split_row_groups,

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -868,8 +868,8 @@ def _split_user_options(**kwargs):
     )
 
 
-def _set_gather_statistics(
-    gather_statistics,
+def _reset_gather_statistics(
+    calculate_divisions,
     blocksize,
     split_row_groups,
     aggregation_depth,
@@ -882,6 +882,7 @@ def _set_gather_statistics(
 
     # If the user has specified `calculate_divisions=True`, then
     # we will be starting with `gather_statistics=True` here.
+    gather_statistics = bool(calculate_divisions)
     if (
         (blocksize and split_row_groups is True)
         or (int(split_row_groups) > 1 and aggregation_depth)
@@ -898,7 +899,7 @@ def _set_gather_statistics(
         # is populated
         gather_statistics = False
 
-    return bool(gather_statistics)
+    return gather_statistics
 
 
 def _infer_split_row_groups(row_group_sizes, blocksize, aggregate_files=False):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4574,23 +4574,6 @@ def test_in_predicate_requires_an_iterable(tmp_path, engine, filter_value):
         dd.read_parquet(path, engine=engine, filters=filter_value)
 
 
-def test_deprecate_gather_statistics(tmp_path, engine):
-    # The `gather_statistics` deprecation warning
-    # (and this test) should be removed after a
-    # "sufficient" deprecation period.
-    # See: https://github.com/dask/dask/pull/8992
-    df = pd.DataFrame({"a": range(10)})
-    path = tmp_path / "test_deprecate_gather_statistics.parquet"
-    df.to_parquet(path, engine=engine)
-    with pytest.warns(FutureWarning, match="deprecated"):
-        out = dd.read_parquet(
-            path,
-            engine=engine,
-            gather_statistics=True,
-        )
-    assert_eq(out, df)
-
-
 @pytest.mark.gpu
 def test_gpu_write_parquet_simple(tmpdir):
     fn = str(tmpdir)


### PR DESCRIPTION
Recent/ongoing work in dask-expr *should* make it significantly easier to leverage parquet statistics to optimize operations like `len`, `groupby`, and `set_index`.  This PR re-introduces the deprecated `gather_statistics` argument (with a slightly-modified meaning) so that the user can specify an explicit set of columns to collect parquet statistics for. When `gather_statistic` is simply set to `True`, we only ensure that row-count statistics will be gathered.
