### PR TITLE
Change Dask Bag partitioning scheme

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1772,7 +1772,10 @@ def from_sequence(seq, partition_size=None, npartitions=None):
     """
     seq = list(seq)
     if npartitions and not partition_size:
-        partition_size = max(1, int(math.floor(len(seq) / npartitions)))
+        if len(seq) <= 100:
+            partition_size = int(math.ceil(len(seq) / npartitions))
+        else:
+            partition_size = max(1, int(math.floor(len(seq) / npartitions)))
     if npartitions is None and partition_size is None:
         if len(seq) <= 100:
             partition_size = 1

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1772,12 +1772,12 @@ def from_sequence(seq, partition_size=None, npartitions=None):
     """
     seq = list(seq)
     if npartitions and not partition_size:
-        partition_size = int(math.ceil(len(seq) / npartitions))
+        partition_size = max(1, len(seq) // npartitions)
     if npartitions is None and partition_size is None:
-        if len(seq) < 100:
+        if len(seq) <= 100:
             partition_size = 1
         else:
-            partition_size = int(len(seq) / 100)
+            partition_size = max(1, math.ceil(math.sqrt(len(seq)) / math.sqrt(100)))
 
     parts = list(partition_all(partition_size, seq))
     name = "from_sequence-" + tokenize(seq, partition_size)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1772,7 +1772,7 @@ def from_sequence(seq, partition_size=None, npartitions=None):
     """
     seq = list(seq)
     if npartitions and not partition_size:
-        partition_size = max(1, len(seq) // npartitions)
+        partition_size = max(1, int(math.floor(len(seq) / npartitions)))
     if npartitions is None and partition_size is None:
         if len(seq) <= 100:
             partition_size = 1

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1190,9 +1190,8 @@ def test_zip(npartitions, hi=1000):
     evens = db.from_sequence(range(0, hi, 2), npartitions=npartitions)
     odds = db.from_sequence(range(1, hi, 2), npartitions=npartitions)
     pairs = db.zip(evens, odds)
-    assert (
-        pairs.npartitions == evens.npartitions and pairs.npartitions == odds.npartitions
-    )
+    assert pairs.npartitions == evens.npartitions
+    assert pairs.npartitions == odds.npartitions
     assert list(pairs) == list(zip(range(0, hi, 2), range(1, hi, 2)))
 
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1656,3 +1656,25 @@ def test_to_dataframe_optimize_graph():
     assert hlg_layer_topological(d2.dask, 1).annotations == {"foo": True}
 
     assert_eq_df(d, d2)
+
+
+@pytest.mark.parametrize("nworkers", [1, 5, 10, 50, 100, 250, 500, 1000])
+def test_default_partitioning_worker_saturation(nworkers):
+    # Ensure that Dask Bag can saturate any number of workers with concurrent tasks.
+    # The default partitioning scheme partitions items to keep the task to item ratio sensible
+    # but it should always be possible to saturate any number of workers given enough items in the bag.
+    ntasks = 0
+    nitems = 1
+    while ntasks < nworkers:
+        ntasks = len(db.from_sequence(range(nitems)).dask)
+        nitems += math.floor(max(1, nworkers / 10))
+        assert nitems < 20_000
+
+
+@pytest.mark.parametrize("nworkers", [1, 5, 10, 50, 100, 250, 500, 1000])
+def test_npartitions_saturation(nworkers):
+    # If npartitions is set the bag should always contain at least that number of tasks
+    for nitems in range(nworkers, 10 * nworkers, max(1, math.floor(nworkers / 10))):
+        assert (
+            len(db.from_sequence(range(nitems), npartitions=nworkers).dask) >= nworkers
+        )

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1190,7 +1190,9 @@ def test_zip(npartitions, hi=1000):
     evens = db.from_sequence(range(0, hi, 2), npartitions=npartitions)
     odds = db.from_sequence(range(1, hi, 2), npartitions=npartitions)
     pairs = db.zip(evens, odds)
-    assert pairs.npartitions == npartitions
+    assert (
+        pairs.npartitions == evens.npartitions and pairs.npartitions == odds.npartitions
+    )
     assert list(pairs) == list(zip(range(0, hi, 2), range(1, hi, 2)))
 
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1658,7 +1658,7 @@ def test_to_dataframe_optimize_graph():
     assert_eq_df(d, d2)
 
 
-@pytest.mark.parametrize("nworkers", [1, 5, 10, 50, 100, 250, 500, 1000])
+@pytest.mark.parametrize("nworkers", [100, 250, 500, 1000])
 def test_default_partitioning_worker_saturation(nworkers):
     # Ensure that Dask Bag can saturate any number of workers with concurrent tasks.
     # The default partitioning scheme partitions items to keep the task to item ratio sensible
@@ -1671,7 +1671,7 @@ def test_default_partitioning_worker_saturation(nworkers):
         assert nitems < 20_000
 
 
-@pytest.mark.parametrize("nworkers", [1, 5, 10, 50, 100, 250, 500, 1000])
+@pytest.mark.parametrize("nworkers", [100, 250, 500, 1000])
 def test_npartitions_saturation(nworkers):
     # If npartitions is set the bag should always contain at least that number of tasks
     for nitems in range(nworkers, 10 * nworkers, max(1, math.floor(nworkers / 10))):


### PR DESCRIPTION
- [x] Closes #10291
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

in #10291 we discuss two challenges we are seeing with scaling Dask Bag to large numbers of workers (200+). This PR addresses both of them.

### Problem 1

The default partitioning scheme of `dask.bag.from_sequence` limits the number of potential tasks at 199 (if the number of items in the bag is 199) and trends towards 100.

![image](https://github.com/dask/dask/assets/1610850/f3ae4ab6-4c00-4ad2-a474-d71647657610)

As discussed with @fjetter it would be nice if this default scheme continued to increase the number of tasks, just at a non-exponential rate.

This change uses `math.sqrt` to grow the number of tasks a the rate of a square root.

This allows any number of workers to be saturated with tasks given enough items in the bag.

![image](https://github.com/dask/dask/assets/1610850/6d6f6c9a-2a28-482d-96ec-bfa6adfd2e44)

### Problem 2

Setting the number of partitions equal to the number of workers feels like it would be a good way to explicitly ensure Dask Bag scales to utilize all workers. However, due to the rounding done in the current scheme, this doesn't actually saturate all of the workers unless `nitems % workers == 0`.

![image](https://github.com/dask/dask/assets/1610850/7bb7dba1-77cd-48c9-98db-5297040df6c6)

This change switches the `partition_size` calculation to use floor instead of ceil to ensure that the number of tasks overshoots the desired partition size and trends towards the desired size, rather than undershooting by up to 50%. It feels better to have too many tasks rather than not enough tasks.

![image](https://github.com/dask/dask/assets/1610850/3ebc49a8-cd13-4517-b71d-2629e5457093)
