### PR TITLE
Enable `drop` to support mismatched partitions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5587,9 +5587,13 @@ class DataFrame(_Frame):
         axis = self._validate_axis(axis)
         if axis == 0 and columns is not None:
             # Columns must be specified if axis==0
-            return self.map_partitions(drop_by_shallow_copy, columns, errors=errors)
+            return self.map_partitions(
+                drop_by_shallow_copy, columns, errors=errors, enforce_metadata=False
+            )
         elif axis == 1:
-            return self.map_partitions(drop_by_shallow_copy, labels, errors=errors)
+            return self.map_partitions(
+                drop_by_shallow_copy, labels, errors=errors, enforce_metadata=False
+            )
         raise NotImplementedError(
             "Drop currently only works for axis=1 or when columns is not None"
         )

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3022,6 +3022,18 @@ def test_drop_columns(columns):
     assert_eq(df.drop(columns=columns), ddf2)
 
 
+def test_drop_meta_mismatch():
+    # Ensure `drop()` works when partitions have mismatching columns
+    # (e.g. as is possible with `read_csv`)
+    df1 = pd.DataFrame({"x": [1, 2, 3], "y": [4.5, 6, 7]})
+    df2 = pd.DataFrame({"x": [4, 5, 6]})
+    df = pd.concat([df1, df2])
+    ddf = dd.from_delayed(
+        [dask.delayed(df1), dask.delayed(df2)], meta=df, verify_meta=False
+    )
+    assert_eq(df.drop(columns=["x"]), ddf.drop(columns=["x"]))
+
+
 def test_gh580():
     df = pd.DataFrame({"x": np.arange(10, dtype=float)})
     ddf = dd.from_pandas(df, 2)


### PR DESCRIPTION
This PR sets `enforce_metadata=False` in `drop` (as we do in several other methods) to allow for cases where some partitions are missing columns (as happens sometimes with CSV data)