### PR TITLE
Fix ``divisions`` construction for ``to_timestamp``

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3959,10 +3959,10 @@ Dask Name: {name}, {layers}""".format(
     def round(self, decimals=0):
         return elemwise(M.round, self, decimals)
 
-    @derived_from(pd.DataFrame)
+    @derived_from(pd.Series)
     def to_timestamp(self, freq=None, how="start", axis=0):
         df = elemwise(M.to_timestamp, self, freq, how, axis)
-        df.divisions = tuple(pd.Index(self.divisions).to_timestamp())
+        df.divisions = tuple(pd.Index(self.divisions).to_timestamp(freq=freq, how=how))
         return df
 
     def quantile(self, q=0.5, method="default"):
@@ -5511,7 +5511,7 @@ class DataFrame(_Frame):
     @derived_from(pd.DataFrame)
     def to_timestamp(self, freq=None, how="start", axis=0):
         df = elemwise(M.to_timestamp, self, freq, how, axis)
-        df.divisions = tuple(pd.Index(self.divisions).to_timestamp())
+        df.divisions = tuple(pd.Index(self.divisions).to_timestamp(how=how, freq=freq))
         return df
 
     @derived_from(pd.DataFrame)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3070,6 +3070,10 @@ def test_to_timestamp():
         check_freq=False,
     )
 
+    ddf = dd.from_pandas(df, npartitions=4)
+    assert_eq(ddf.to_timestamp(how="end"), df.to_timestamp(how="end"))
+    assert_eq(ddf.x.to_timestamp(how="end"), df.x.to_timestamp(how="end"))
+
 
 def test_to_frame():
     s = pd.Series([1, 2, 3], name="foo")


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

The added tests were failing before