### PR TITLE
Ignore ``numpy.find_common_type`` warning from ``pandas``

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,9 @@ filterwarnings = [
     # https://pandas.pydata.org/docs/dev/whatsnew/v1.5.0.html#using-group-keys-with-transformers-in-groupby-apply
     "ignore:Not prepending group keys:FutureWarning",
     "ignore:.*:dask.tests.warning_aliases.RemovedIn20Warning",
+    # This is coming from pandas use of np.find_common_type
+    # See https://github.com/pandas-dev/pandas/issues/53236
+    "ignore:np.find_common_type is deprecated:DeprecationWarning",
 ]
 xfail_strict = true
 


### PR DESCRIPTION
`np.find_common_type` is deprecated in the upcoming `numpy=1.25` release. We don't use `np.find_common_type` ourselves, but `pandas` does and causes deprecations warnings to error in our `upstream` build. Given the source of these deprecations is outside of `dask`, let's just temporarily ignore for now. 

xref https://github.com/pandas-dev/pandas/issues/53236

cc @phofl for visibility here and upstream in `pandas` 