### PR TITLE
Avoid ``pandas`` ``Series.__getitem__`` deprecation in tests

### DIFF
--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -451,8 +451,8 @@ def test_to_hdf_lock_delays():
     # adding artificial delays to make sure last tasks finish first
     # that's a way to simulate last tasks finishing last
     def delayed_nop(i):
-        if i[1] < 10:
-            sleep(0.1 * (10 - i[1]))
+        if i.iloc[1] < 10:
+            sleep(0.1 * (10 - i.iloc[1]))
         return i
 
     # saving to multiple hdf nodes

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3157,20 +3157,20 @@ def test_apply():
 
     # specify meta
     assert_eq(
-        ddf.apply(lambda xy: xy[0] + xy[1], axis=1, meta=(None, int)),
-        df.apply(lambda xy: xy[0] + xy[1], axis=1),
+        ddf.apply(lambda xy: xy.iloc[0] + xy.iloc[1], axis=1, meta=(None, int)),
+        df.apply(lambda xy: xy.iloc[0] + xy.iloc[1], axis=1),
     )
     assert_eq(
-        ddf.apply(lambda xy: xy[0] + xy[1], axis="columns", meta=(None, int)),
-        df.apply(lambda xy: xy[0] + xy[1], axis="columns"),
+        ddf.apply(lambda xy: xy.iloc[0] + xy.iloc[1], axis="columns", meta=(None, int)),
+        df.apply(lambda xy: xy.iloc[0] + xy.iloc[1], axis="columns"),
     )
 
     # inference
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         assert_eq(
-            ddf.apply(lambda xy: xy[0] + xy[1], axis=1),
-            df.apply(lambda xy: xy[0] + xy[1], axis=1),
+            ddf.apply(lambda xy: xy.iloc[0] + xy.iloc[1], axis=1),
+            df.apply(lambda xy: xy.iloc[0] + xy.iloc[1], axis=1),
         )
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
@@ -5741,7 +5741,7 @@ def test_index_is_monotonic_dt64():
     ds = dd.from_pandas(s, npartitions=10, sort=False)
     assert_eq(s.index.is_monotonic_increasing, ds.index.is_monotonic_increasing)
 
-    s_2 = pd.Series(1, index=list(reversed(s)))
+    s_2 = s[::-1]
     ds_2 = dd.from_pandas(s_2, npartitions=10, sort=False)
     assert_eq(s_2.index.is_monotonic_decreasing, ds_2.index.is_monotonic_decreasing)
 


### PR DESCRIPTION
We're seeing 

```python
FAILED dask/dataframe/tests/test_dataframe.py::test_index_is_monotonic_dt64 - FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
FAILED dask/dataframe/io/tests/test_hdf.py::test_to_hdf_lock_delays - FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
FAILED dask/dataframe/tests/test_dataframe.py::test_apply - FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
```

in our `upstream` build due to https://github.com/pandas-dev/pandas/pull/53201 (e.g. see [this CI build](https://github.com/dask/dask/actions/runs/5048901305/jobs/9057682944?pr=10307))

This PR moves to `iloc` based selections to avoid the deprecation without changing the intent of any tests 

cc @phofl 