### PR TITLE
Add dispatching mechanisms for `pyarrow.Table` conversion

### DIFF
--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -106,15 +106,17 @@ def check_pyarrow_string_supported():
 
 def df_from_pyarrow_table(table):
     """Converts a pyarrow Table into a pandas-like dataframe object
-    
+
     If the `b"dataframe_backend"` field in the table metadata is
     empty, the table will be converted to `pandas.DataFrame`.
     If the field returns `b"foo.bar"`, then the dataframe
     conversion will be dispatched to the function registered
     for the `bar` class of the `foo` module.
     """
-    backend = table.schema.metadata.get(
-        b"dataframe_backend", b"pandas.DataFrame"
-    ).decode("utf8").split(".")
+    backend = (
+        table.schema.metadata.get(b"dataframe_backend", b"pandas.DataFrame")
+        .decode("utf8")
+        .split(".")
+    )
     backend = getattr(import_module(".".join(backend[:-1])), backend[-1])
     return from_pyarrow_table_dispatch(backend(), table)

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -27,6 +27,8 @@ from dask.dataframe.dispatch import (
     meta_lib_from_array,
     meta_nonempty,
     pyarrow_schema_dispatch,
+    to_pyarrow_table_dispatch,
+    from_pyarrow_table_dispatch,
     to_pandas_dispatch,
     tolist_dispatch,
     union_categoricals_dispatch,
@@ -211,6 +213,18 @@ def get_pyarrow_schema_pandas(obj):
     import pyarrow as pa
 
     return pa.Schema.from_pandas(obj)
+
+
+@to_pyarrow_table_dispatch.register((pd.DataFrame,))
+def get_pyarrow_table_pandas(obj, preserve_index=True):
+    import pyarrow as pa
+
+    return pa.Table.from_pandas(obj, preserve_index=preserve_index)
+
+
+@from_pyarrow_table_dispatch.register((pd.DataFrame,))
+def get_pandas_dataframe_pyarrow(obj, table):
+    return table.to_pandas()
 
 
 @meta_nonempty.register(pd.DatetimeTZDtype)

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -17,6 +17,7 @@ from dask.dataframe.dispatch import (
     categorical_dtype_dispatch,
     concat,
     concat_dispatch,
+    from_pyarrow_table_dispatch,
     get_parallel_type,
     group_split_dispatch,
     grouper_dispatch,
@@ -27,9 +28,8 @@ from dask.dataframe.dispatch import (
     meta_lib_from_array,
     meta_nonempty,
     pyarrow_schema_dispatch,
-    to_pyarrow_table_dispatch,
-    from_pyarrow_table_dispatch,
     to_pandas_dispatch,
+    to_pyarrow_table_dispatch,
     tolist_dispatch,
     union_categoricals_dispatch,
 )

--- a/dask/dataframe/dispatch.py
+++ b/dask/dataframe/dispatch.py
@@ -24,6 +24,8 @@ is_categorical_dtype_dispatch = Dispatch("is_categorical_dtype")
 union_categoricals_dispatch = Dispatch("union_categoricals")
 grouper_dispatch = Dispatch("grouper")
 pyarrow_schema_dispatch = Dispatch("pyarrow_schema_dispatch")
+from_pyarrow_table_dispatch = Dispatch("from_pyarrow_table_dispatch")
+to_pyarrow_table_dispatch = Dispatch("to_pyarrow_table_dispatch")
 to_pandas_dispatch = Dispatch("to_pandas_dispatch")
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -6027,6 +6027,7 @@ def test_mask_where_callable():
 def test_pyarrow_conversion_dispatch():
     from dask.dataframe._pyarrow import df_from_pyarrow_table
     from dask.dataframe.dispatch import to_pyarrow_table_dispatch
+
     pytest.importorskip("pyarrow")
 
     df1 = pd.DataFrame(np.random.randn(10, 3), columns=list("abc"))
@@ -6042,7 +6043,11 @@ def test_pyarrow_conversion_dispatch_cudf():
     # the to_pyarrow_table_dispatch and from_pyarrow_table_dispatch
     # are registered to `cudf` in `dask_cudf`.
     from dask.dataframe._pyarrow import df_from_pyarrow_table
-    from dask.dataframe.dispatch import to_pyarrow_table_dispatch, from_pyarrow_table_dispatch
+    from dask.dataframe.dispatch import (
+        from_pyarrow_table_dispatch,
+        to_pyarrow_table_dispatch,
+    )
+
     cudf = pytest.importorskip("cudf")
 
     @to_pyarrow_table_dispatch.register(cudf.DataFrame)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -6022,3 +6022,43 @@ def test_mask_where_callable():
 
     #  series
     assert_eq(pdf.x.where(lambda d: d == 1, 2), ddf.x.where(lambda d: d == 1, 2))
+
+
+def test_pyarrow_conversion_dispatch():
+    from dask.dataframe._pyarrow import df_from_pyarrow_table
+    from dask.dataframe.dispatch import to_pyarrow_table_dispatch
+    pytest.importorskip("pyarrow")
+
+    df1 = pd.DataFrame(np.random.randn(10, 3), columns=list("abc"))
+    df2 = df_from_pyarrow_table(to_pyarrow_table_dispatch(df1))
+
+    assert type(df1) == type(df2)
+    assert_eq(df1, df2)
+
+
+@pytest.mark.gpu
+def test_pyarrow_conversion_dispatch_cudf():
+    # NOTE: This test can probably be removed (or simplified) once
+    # the to_pyarrow_table_dispatch and from_pyarrow_table_dispatch
+    # are registered to `cudf` in `dask_cudf`.
+    from dask.dataframe._pyarrow import df_from_pyarrow_table
+    from dask.dataframe.dispatch import to_pyarrow_table_dispatch, from_pyarrow_table_dispatch
+    cudf = pytest.importorskip("cudf")
+
+    @to_pyarrow_table_dispatch.register(cudf.DataFrame)
+    def _cudf_to_table(obj, preserve_index=True):
+        t = obj.to_arrow(preserve_index=preserve_index)
+        t = t.replace_schema_metadata(
+            t.schema.metadata | {b"dataframe_backend": "cudf.DataFrame"}
+        )
+        return t
+
+    @from_pyarrow_table_dispatch.register(cudf.DataFrame)
+    def _table_to_cudf(obj, table):
+        return obj.from_arrow(table)
+
+    df1 = cudf.DataFrame(np.random.randn(10, 3), columns=list("abc"))
+    df2 = df_from_pyarrow_table(to_pyarrow_table_dispatch(df1))
+
+    assert type(df1) == type(df2)
+    assert_eq(df1, df2)


### PR DESCRIPTION
Supports https://github.com/dask/distributed/pull/7743

The "p2p" shuffling algorithm is very useful for pandas-backed collections. However, does not support cudf-backed collections, because it uses pandas-specific logic to convert between `DataFrame` and `pyarrow.Table` objects. This approach was likely motivated by the fact that dask does not provide any dispatching mechanisms for this kind of conversion. This PR proposes such a mechanism.

**NOTE**: Although it is relatively simple to dispatch `DataFrame`-to-`pyarrow.Table` conversion, the reverse logic is much less obvious. If a task/worker only has access to a `pyarrow.Table` object, there is no way for the `pyarrow.Table` type alone to dictate which `from_pyarrow_table_dispatch` function should be used to create a `DataFrame` object. The solution proposed in this PR is to convert to `pd.DataFrame` by default, but to use the path defined in the tables metadata for the `b"dataframe_backend"` field (when present).
