### PR TITLE
Nested annotations collide with config 

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -153,13 +153,7 @@ def annotate(**annotations):
             % annotations["allow_other_workers"]
         )
 
-    prev_annotations = config.get("annotations", {})
-    new_annotations = {
-        **prev_annotations,
-        **{f"annotations.{k}": v for k, v in annotations.items()},
-    }
-
-    with config.set(new_annotations):
+    with config.set({f"annotations.{k}": v for k, v in annotations.items()}):
         yield
 
 

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -182,6 +182,16 @@ def test_multiple_annotations():
     assert clayer.annotations is None
 
 
+def test_annotation_and_config_collision():
+    with dask.config.set({"foo": 1}):
+        with dask.annotate(foo=2):
+            assert dask.config.get("foo") == 1
+            assert dask.config.get("annotations") == {"foo": 2}
+            with dask.annotate(bar=3):
+                assert dask.config.get("foo") == 1
+                assert dask.config.get("annotations") == {"foo": 2, "bar": 3}
+
+
 def test_materializedlayer_cull_preserves_annotations():
     layer = MaterializedLayer(
         {"a": 42, "b": 3.14},


### PR DESCRIPTION
Fix a bug where, if anything tries reading the dask config from inside two layers of `dask.annotate` context managers, the config may not be there at all!

e.g.
```python
with dask.annotate(optimization=123):
    with dask.annotate(foo=1):
        dask.config.get("optimization.fuse.active")  # TypeError
```