### PR TITLE
Update empty ``describe`` top and freq values

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -266,7 +266,7 @@ def describe_nonnumeric_aggregate(stats, name):
         data = [0, 0]
         index = ["count", "unique"]
         dtype = None
-        data.extend([None, None])
+        data.extend([np.nan, np.nan])
         index.extend(["top", "freq"])
         dtype = object
         result = pd.Series(data, index=index, dtype=dtype, name=name)


### PR DESCRIPTION
Currently, on an empty DataFrame, `dask` will return `None` for `top` and `freq` values, while `pandas` returns `np.nan`. This mismatch has been around for a while, but went unnoticed because `pandas` testing utilities treated `None` and `np.nan` as equivalent. With https://github.com/pandas-dev/pandas/pull/52081, we now get an error. 

This PR updates `dask` to match `pandas` in this case and return `np.nan` instead of `None`

Closes https://github.com/dask/dask/issues/10317

cc @phofl 