### PR TITLE
Fix for incorrect `value_counts`

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -3121,13 +3121,7 @@ def _value_counts(x, **kwargs):
 
 def _value_counts_aggregate(series_gb):
     data = {k: v.groupby(level=-1).sum() for k, v in series_gb}
-    res = pd.concat(data, names=series_gb.obj.index.names)
-    levels = {i: level for i, level in enumerate(series_gb.obj.index.levels)}
-    # verify_integrity=False to preserve index codes
-    res.index = res.index.set_levels(
-        levels.values(), level=levels.keys(), verify_integrity=False
-    )
-    return res
+    return pd.concat(data, names=series_gb.obj.index.names)
 
 
 def _tail_chunk(series_gb, **kwargs):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -3121,7 +3121,15 @@ def _value_counts(x, **kwargs):
 
 def _value_counts_aggregate(series_gb):
     data = {k: v.groupby(level=-1).sum() for k, v in series_gb}
-    return pd.concat(data, names=series_gb.obj.index.names)
+    res = pd.concat(data, names=series_gb.obj.index.names)
+    typed_levels = {
+        i: res.index.levels[i].astype(series_gb.obj.index.levels[i].dtype)
+        for i in range(len(res.index.levels))
+    }
+    res.index = res.index.set_levels(
+        typed_levels.values(), level=typed_levels.keys(), verify_integrity=False
+    )
+    return res
 
 
 def _tail_chunk(series_gb, **kwargs):

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2550,6 +2550,20 @@ def test_groupby_value_counts(by, int_dtype):
     assert_eq(dd_gb, pd_gb)
 
 
+def test_groupby_value_counts_10322():
+    """Repro case for https://github.com/dask/dask/issues/10322."""
+    df = pd.DataFrame(
+        {
+            "x": [10] * 5 + [6] * 5 + [3] * 5,
+            "y": [1] * 3 + [2] * 3 + [4] * 3 + [5] * 3 + [2] * 3,
+        }
+    )
+    counts = df.groupby("x")["y"].value_counts()
+    ddf = dd.from_pandas(df, npartitions=3)
+    dcounts = ddf.groupby("x")["y"].value_counts()
+    assert_eq(counts, dcounts)
+
+
 @contextlib.contextmanager
 def groupby_axis_and_meta():
     # Because we're checking for multiple warnings, we need to record


### PR DESCRIPTION
Reverts changes from https://github.com/dask/dask/pull/10182.

https://github.com/dask/dask/pull/10182 was fixing https://github.com/dask/dask/issues/10146. In this PR, the same fix is done another way, and this way correctly calculates value counts. Might not be the most performant; perhaps @phofl could advise.

- [x] Closes https://github.com/dask/dask/issues/10322
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
