### PR TITLE
Fix Hetzner typo in documentation

### DIFF
--- a/docs/source/deploying.rst
+++ b/docs/source/deploying.rst
@@ -150,7 +150,7 @@ See :doc:`deploying-cloud` for more details.
 - `Dask-Yarn <https://yarn.dask.org>`_
     Deploy Dask on YARN clusters, such as are found in traditional Hadoop installations.
 - `Dask Cloud Provider <https://cloudprovider.dask.org/en/latest/>`_
-    Constructing and managing ephemeral Dask clusters on AWS, DigitalOcean, GCP, Azure, and Hertzner
+    Constructing and managing ephemeral Dask clusters on AWS, DigitalOcean, Google Cloud, Azure, and Hetzner
 - You can use `Coiled <https://coiled.io?utm_source=dask-docs&utm_medium=deploying>`_, a commercial Dask deployment option, to handle the creation and management of Dask clusters on cloud computing environments (AWS and GCP).
 
 Ad-hoc deployments


### PR DESCRIPTION
Was pointed out to me that this should be [Hetzner](https://www.hetzner.com/cloud) (not Hertzner).
