### PR TITLE
Validate that rechunking is possible earlier in graph generation

### DIFF
--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -723,6 +723,9 @@ def test_rechunk_unknown_raises():
         y.rechunk((None, (5, 5, 5)))
 
     with pytest.raises(ValueError, match="Chunks must be unchanging"):
+        y.rechunk(((np.nan, np.nan, np.nan), (5, 5)))
+
+    with pytest.raises(ValueError, match="Chunks must be unchanging"):
         y.rechunk(((5, 5), (5, 5)))
 
     with pytest.raises(ValueError, match="Chunks must be unchanging"):

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -772,13 +772,6 @@ def test_old_to_new_large():
     assert result == expected
 
 
-def test_changing_raises():
-    with pytest.raises(ValueError) as record:
-        old_to_new(((np.nan, np.nan), (4, 4)), ((np.nan, np.nan, np.nan), (4, 4)))
-
-    assert "unchanging" in str(record.value)
-
-
 def test_old_to_new_known():
     old = ((10, 10, 10, 10, 10),)
     new = ((25, 5, 20),)


### PR DESCRIPTION
This PR consolidates (almost) all validation and moves it to an earlier point in graph generation to avoid duplication between task-based and P2P-based rechunking (https://github.com/dask/distributed/pull/7856/files#r1205195557)

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
