### PR TITLE
Improve performance of histogram when using scalar_bins

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -998,11 +998,7 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
     token = tokenize(a, bins, range, weights, density)
     name = "histogram-sum-" + token
 
-    if scalar_bins:
-        bins = _linspace_from_delayed(range[0], range[1], bins + 1)
-        # ^ NOTE `range[1]` is safe because of the above check, and the initial check
-        # that range must not be None if `scalar_bins`
-    else:
+    if not scalar_bins:
         if not isinstance(bins, (Array, np.ndarray)):
             bins = asarray(bins)
         if bins.ndim != 1:
@@ -1011,6 +1007,11 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
             )
 
     (bins_ref, range_ref), deps = unpack_collections([bins, range])
+
+    if scalar_bins:
+        bins = _linspace_from_delayed(range[0], range[1], bins + 1)
+        # ^ NOTE `range[1]` is safe because of the above check, and the initial check
+        # that range must not be None if `scalar_bins`
 
     # Map the histogram to all bins, forming a 2D array of histograms, stacked for each chunk
     if weights is None:


### PR DESCRIPTION
Hey all,

I did not first make this an issue for I feel I could provide a possible solution.
If it is better etiquette to first make an issue before creating a pull request, let me know and I will do so in the future.

~~- [ ] Closes #xxxx~~
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This pull request is inspired by this forum post:
https://dask.discourse.group/t/how-does-da-histogram-work/1907

The performance of `dask.array.histogram` is significantly worse than that of `numpy.histogram` when a scalar is supplied as the `bins`argument. I am assuming a single threaded case here, since the difference in performance can be overcome by solving lots of tasks in parallel.

It seems to me this difference in performance between scalars and arrays relates to an array being able have bins that are not equally spaced, though I am not familiar with the details of the Numpy implementation and I could be wrong about the reason. 

In the dask implementation any scalar is turned int an array at this line:
https://github.com/dask/dask/blob/453bd7031828f72e4602498c1a1f776280794bea/dask/array/routines.py#L1002
This happens before `_block_hist` is called. Therefore Dask always provides `_block_hist` (and thus by extension `numpy.histogram`) with an array, even when initially presented with a scalar.

In this pull request I move the call to `_linspace_from_delayed` after the call to `_block_hist`. The aim of this change is to provide a scalar to the Numpy implementation of `histogram` if a scalar was provided to the Dask implementation of histogram, but still return `bins` as an array from the `dask.array.histogram` function.

This seems to improve the performance. I ran a simple benchmark where I plot the number of samples vs the duration.
The Dask runs had access to 12 cores.
![image](https://github.com/dask/dask/assets/45204355/85a6eaac-7c98-4866-8e82-c5a169218730)

I understand a risk of my implementation is that the bins estimated by `_linspace_from_delayed` could be different than those estimated by Numpy when presented with a scalar. I would argue that the unit tests in dask/array/tests/test_routines.py are sufficient to verify this.

This is my first pull request and I am open to any feedback.

Cheers,
Timo
