### PR TITLE
Support ``DataFrame.set_index(..., sort=False)``

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5087,11 +5087,9 @@ class DataFrame(_Frame):
         Often we ``set_index`` once directly after data ingest and filtering and
         then perform many cheap computations off of the sorted dataset.
 
-        This function operates exactly like ``pandas.set_index`` except with
-        different performance costs (dask dataframe ``set_index`` is much more expensive
-        when ``sort=True`` (default)).
-        Under normal operation this function does an initial pass over the index column
-        to compute approximate quantiles to serve as future divisions. It then passes
+        With ``sort=True``, this function is much more expensive. Under normal
+        operation this function does an initial pass over the index column to
+        compute approximate quantiles to serve as future divisions. It then passes
         over the data a second time, splitting up each input partition into several
         pieces and sharing those pieces to all of the output partitions now in
         sorted order.

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5181,6 +5181,10 @@ class DataFrame(_Frame):
         ["Alice", "Laura", "Ursula", "Zelda"]
         >>> # ^ Now copy-paste this and edit the line above to:
         >>> # ddf2 = ddf.set_index("name", divisions=["Alice", "Laura", "Ursula", "Zelda"])
+
+        Lastly, setting ``sort=False`` will negate the performance impact above
+        by only setting the index on the existing partitions. Trade-off being
+        partition sort and divisions will not be known.
         """
 
         if inplace:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5073,6 +5073,7 @@ class DataFrame(_Frame):
         npartitions: int | Literal["auto"] | None = None,
         divisions: Sequence | None = None,
         inplace: bool = False,
+        sort: bool = True,
         **kwargs,
     ):
         """Set the DataFrame index (row labels) using an existing column.
@@ -5127,6 +5128,10 @@ class DataFrame(_Frame):
         inplace: bool, optional
             Modifying the DataFrame in place is not supported by Dask.
             Defaults to False.
+        sort: bool, optional
+            Determine new divisions and repartition according to new index, otherwise
+            simply set the index on the individual existing partitions.
+            Defaults to True.
         shuffle: string, 'disk' or 'tasks', optional
             Either ``'disk'`` for single-node operation or ``'tasks'`` for
             distributed operation.  Will be inferred by your current scheduler.
@@ -5261,6 +5266,7 @@ class DataFrame(_Frame):
                 drop=drop,
                 npartitions=npartitions,
                 divisions=divisions,
+                sort=sort,
                 **kwargs,
             )
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5079,8 +5079,8 @@ class DataFrame(_Frame):
         """Set the DataFrame index (row labels) using an existing column.
 
         If ``sort=False``, this function operates exactly like ``pandas.set_index``
-        and sets the index on the dataframe. If ``sort=True`` (default),
-        this function also sorts the dataframe by the new index. This can have a
+        and sets the index on the DataFrame. If ``sort=True`` (default),
+        this function also sorts the DataFrame by the new index. This can have a
         significant impact on performance, because joins, groupbys, lookups, etc.
         are all much faster on that column. However, this performance increase
         comes with a cost, sorting a parallel dataset requires expensive shuffles.
@@ -5130,9 +5130,9 @@ class DataFrame(_Frame):
             Modifying the DataFrame in place is not supported by Dask.
             Defaults to False.
         sort: bool, optional
-            If True, sort the dataframe by the new index. Otherwise
+            If ``True``, sort the DataFrame by the new index. Otherwise
             set the index on the individual existing partitions.
-            Defaults to True.
+            Defaults to ``True``.
         shuffle: string, 'disk' or 'tasks', optional
             Either ``'disk'`` for single-node operation or ``'tasks'`` for
             distributed operation.  Will be inferred by your current scheduler.

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5129,8 +5129,8 @@ class DataFrame(_Frame):
             Modifying the DataFrame in place is not supported by Dask.
             Defaults to False.
         sort: bool, optional
-            Determine new divisions and repartition according to new index, otherwise
-            simply set the index on the individual existing partitions.
+            If True, sort the dataframe by the new index. Otherwise
+            set the index on the individual existing partitions.
             Defaults to True.
         shuffle: string, 'disk' or 'tasks', optional
             Either ``'disk'`` for single-node operation or ``'tasks'`` for

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5078,7 +5078,9 @@ class DataFrame(_Frame):
     ):
         """Set the DataFrame index (row labels) using an existing column.
 
-        This realigns the dataset to be sorted by a new column. This can have a
+        If ``sort=False``, this function operates exactly like ``pandas.set_index``
+        and sets the index on the dataframe. If ``sort=True`` (default),
+        this function also sorts the dataframe by the new index. This can have a
         significant impact on performance, because joins, groupbys, lookups, etc.
         are all much faster on that column. However, this performance increase
         comes with a cost, sorting a parallel dataset requires expensive shuffles.
@@ -5086,7 +5088,8 @@ class DataFrame(_Frame):
         then perform many cheap computations off of the sorted dataset.
 
         This function operates exactly like ``pandas.set_index`` except with
-        different performance costs (dask dataframe ``set_index`` is much more expensive).
+        different performance costs (dask dataframe ``set_index`` is much more expensive
+        when ``sort=True`` (default)).
         Under normal operation this function does an initial pass over the index column
         to compute approximate quantiles to serve as future divisions. It then passes
         over the data a second time, splitting up each input partition into several
@@ -5181,10 +5184,6 @@ class DataFrame(_Frame):
         ["Alice", "Laura", "Ursula", "Zelda"]
         >>> # ^ Now copy-paste this and edit the line above to:
         >>> # ddf2 = ddf.set_index("name", divisions=["Alice", "Laura", "Ursula", "Zelda"])
-
-        Lastly, setting ``sort=False`` will negate the performance impact above
-        by only setting the index on the existing partitions. Trade-off being
-        partition sort and divisions will not be known.
         """
 
         if inplace:

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -218,10 +218,7 @@ def set_index(
     if not sort:
         df.divisions = tuple(None for _ in df.divisions)
 
-        def _(df):
-            return df.set_index(index)
-
-        return df.map_partitions(_, align_dataframes=False)
+        return df.map_partitions(M.set_index, index, align_dataframes=False)
 
     if npartitions == "auto":
         repartition = True

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -216,9 +216,9 @@ def set_index(
 ) -> DataFrame:
     """See _Frame.set_index for docstring"""
     if not sort:
-        df.divisions = tuple(None for _ in df.divisions)
-
-        return df.map_partitions(M.set_index, index, align_dataframes=False)
+        return df.map_partitions(
+            M.set_index, index, align_dataframes=False
+        ).clear_divisions()
 
     if npartitions == "auto":
         repartition = True

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -217,7 +217,7 @@ def set_index(
     """See _Frame.set_index for docstring"""
     if not sort:
         return df.map_partitions(
-            M.set_index, index, align_dataframes=False
+            M.set_index, index, align_dataframes=False, drop=drop, **kwargs
         ).clear_divisions()
 
     if npartitions == "auto":

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -211,9 +211,18 @@ def set_index(
     upsample: float = 1.0,
     divisions: Sequence | None = None,
     partition_size: float = 128e6,
+    sort: bool = True,
     **kwargs,
 ) -> DataFrame:
     """See _Frame.set_index for docstring"""
+    if not sort:
+        df.divisions = tuple(None for _ in df.divisions)
+
+        def _(df):
+            return df.set_index(index)
+
+        return df.map_partitions(_, align_dataframes=False)
+
     if npartitions == "auto":
         repartition = True
         npartitions = max(100, df.npartitions)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4144,12 +4144,12 @@ def test_set_index_no_sort():
 
     # Default is sort=True
     result = df.set_index("col1")
-    assert result.divisions == (1, 2, 5)
+    assert result.known_divisions
     assert result.index.compute().tolist() == [1, 2, 3, 4, 5]
 
     # Unknown divisions and index remains unsorted when sort is False
     result = df.set_index("col1", sort=False)
-    assert result.divisions == (None, None, None)
+    assert not result.known_divisions
     assert result.index.compute().tolist() == [2, 4, 1, 3, 5]
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4135,30 +4135,6 @@ def test_set_index_with_index():
     assert ddf2 is ddf
 
 
-def test_set_index_no_sort():
-    """
-    GH10333 - Allow setting index on existing partitions without
-    computing new divisions and repartitioning.
-    """
-    df = pd.DataFrame({"col1": [2, 4, 1, 3, 5], "col2": [1, 2, 3, 4, 5]})
-    ddf = dd.from_pandas(df, npartitions=2)
-
-    assert ddf.npartitions > 1
-    df_result = df.set_index("col1")
-
-    # Default is sort=True
-    # Index in ddf will be same values, but sorted
-    ddf_result = ddf.set_index("col1")
-    assert ddf_result.known_divisions
-    assert ddf_result.index.compute().tolist() == [1, 2, 3, 4, 5]
-
-    # Unknown divisions and index remains unsorted when sort is False
-    # and thus equal to pandas set_index
-    ddf_result = ddf.set_index("col1", sort=False)
-    assert not ddf_result.known_divisions
-    assert_eq(ddf_result, df_result)
-
-
 def test_column_assignment():
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [1, 0, 1, 0]})
     ddf = dd.from_pandas(df, npartitions=2)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4140,17 +4140,23 @@ def test_set_index_no_sort():
     GH10333 - Allow setting index on existing partitions without
     computing new divisions and repartitioning.
     """
-    df = dd.from_dict({"col1": [2, 4, 1, 3, 5], "col2": [1, 2, 3, 4, 5]}, npartitions=2)
+    df = pd.DataFrame({"col1": [2, 4, 1, 3, 5], "col2": [1, 2, 3, 4, 5]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    assert ddf.npartitions > 1
+    df_result = df.set_index("col1")
 
     # Default is sort=True
-    result = df.set_index("col1")
-    assert result.known_divisions
-    assert result.index.compute().tolist() == [1, 2, 3, 4, 5]
+    # Index in ddf will be same values, but sorted
+    ddf_result = ddf.set_index("col1")
+    assert ddf_result.known_divisions
+    assert ddf_result.index.compute().tolist() == [1, 2, 3, 4, 5]
 
     # Unknown divisions and index remains unsorted when sort is False
-    result = df.set_index("col1", sort=False)
-    assert not result.known_divisions
-    assert result.index.compute().tolist() == [2, 4, 1, 3, 5]
+    # and thus equal to pandas set_index
+    ddf_result = ddf.set_index("col1", sort=False)
+    assert not ddf_result.known_divisions
+    assert_eq(ddf_result, df_result)
 
 
 def test_column_assignment():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4140,16 +4140,17 @@ def test_set_index_no_sort():
     GH10333 - Allow setting index on existing partitions without
     computing new divisions and repartitioning.
     """
-    df = dd.from_dict({"col1": range(10), "col2": range(10, 20)}, npartitions=2)
+    df = dd.from_dict({"col1": [2, 4, 1, 3, 5], "col2": [1, 2, 3, 4, 5]}, npartitions=2)
 
     # Default is sort=True
     result = df.set_index("col1")
-    assert result.divisions == (0, 5, 9)
-    assert len(result.__dask_graph__().layers) == 3
+    assert result.divisions == (1, 2, 5)
+    assert result.index.compute().tolist() == [1, 2, 3, 4, 5]
 
+    # Unknown divisions and index remains unsorted when sort is False
     result = df.set_index("col1", sort=False)
     assert result.divisions == (None, None, None)
-    assert len(result.__dask_graph__().layers) == 2
+    assert result.index.compute().tolist() == [2, 4, 1, 3, 5]
 
 
 def test_column_assignment():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4135,6 +4135,23 @@ def test_set_index_with_index():
     assert ddf2 is ddf
 
 
+def test_set_index_no_sort():
+    """
+    GH10333 - Allow setting index on existing partitions without
+    computing new divisions and repartitioning.
+    """
+    df = dd.from_dict({"col1": range(10), "col2": range(10, 20)}, npartitions=2)
+
+    # Default is sort=True
+    result = df.set_index("col1")
+    assert result.divisions == (0, 5, 9)
+    assert len(result.__dask_graph__().layers) == 3
+
+    result = df.set_index("col1", sort=False)
+    assert result.divisions == (None, None, None)
+    assert len(result.__dask_graph__().layers) == 2
+
+
 def test_column_assignment():
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [1, 0, 1, 0]})
     ddf = dd.from_pandas(df, npartitions=2)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -325,7 +325,7 @@ def test_set_index_no_sort():
     # and thus equal to pandas set_index
     ddf_result = ddf.set_index("col1", sort=False)
     assert not ddf_result.known_divisions
-    assert_eq(ddf_result, df_result)
+    assert_eq(ddf_result, df_result, sort_results=False)
 
 
 def test_shuffle_sort(shuffle_method):

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -304,6 +304,30 @@ def test_set_index_3(shuffle_method):
     assert ddf2.npartitions == ddf.npartitions
 
 
+def test_set_index_no_sort():
+    """
+    GH10333 - Allow setting index on existing partitions without
+    computing new divisions and repartitioning.
+    """
+    df = pd.DataFrame({"col1": [2, 4, 1, 3, 5], "col2": [1, 2, 3, 4, 5]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    assert ddf.npartitions > 1
+    df_result = df.set_index("col1")
+
+    # Default is sort=True
+    # Index in ddf will be same values, but sorted
+    ddf_result = ddf.set_index("col1")
+    assert ddf_result.known_divisions
+    assert ddf_result.index.compute().tolist() == [1, 2, 3, 4, 5]
+
+    # Unknown divisions and index remains unsorted when sort is False
+    # and thus equal to pandas set_index
+    ddf_result = ddf.set_index("col1", sort=False)
+    assert not ddf_result.known_divisions
+    assert_eq(ddf_result, df_result)
+
+
 def test_shuffle_sort(shuffle_method):
     df = pd.DataFrame({"x": [1, 2, 3, 2, 1], "y": [9, 8, 7, 1, 5]})
     ddf = dd.from_pandas(df, npartitions=3)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -319,7 +319,7 @@ def test_set_index_no_sort():
     # Index in ddf will be same values, but sorted
     ddf_result = ddf.set_index("col1")
     assert ddf_result.known_divisions
-    assert ddf_result.index.compute().tolist() == [1, 2, 3, 4, 5]
+    assert_eq(ddf_result, df_result.sort_index(), sort_results=False)
 
     # Unknown divisions and index remains unsorted when sort is False
     # and thus equal to pandas set_index

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -304,7 +304,9 @@ def test_set_index_3(shuffle_method):
     assert ddf2.npartitions == ddf.npartitions
 
 
-def test_set_index_no_sort():
+@pytest.mark.parametrize("drop", (True, False))
+@pytest.mark.parametrize("append", (True, False))
+def test_set_index_no_sort(drop, append):
     """
     GH10333 - Allow setting index on existing partitions without
     computing new divisions and repartitioning.
@@ -313,17 +315,19 @@ def test_set_index_no_sort():
     ddf = dd.from_pandas(df, npartitions=2)
 
     assert ddf.npartitions > 1
-    df_result = df.set_index("col1")
 
     # Default is sort=True
     # Index in ddf will be same values, but sorted
+    df_result = df.set_index("col1")
     ddf_result = ddf.set_index("col1")
     assert ddf_result.known_divisions
     assert_eq(ddf_result, df_result.sort_index(), sort_results=False)
 
     # Unknown divisions and index remains unsorted when sort is False
-    # and thus equal to pandas set_index
-    ddf_result = ddf.set_index("col1", sort=False)
+    # and thus equal to pandas set_index, adding extra kwargs also supported by
+    # pandas set_index to ensure they're forwarded.
+    df_result = df.set_index("col1", drop=drop, append=append)
+    ddf_result = ddf.set_index("col1", sort=False, drop=drop, append=append)
     assert not ddf_result.known_divisions
     assert_eq(ddf_result, df_result, sort_results=False)
 


### PR DESCRIPTION
Ability to avoid repartitioning and new divisions when setting index.

- [x] Closes #10333 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
