### PR TITLE
Update nightly wheel index for pandas/numpy/scipy

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -36,7 +36,7 @@ if [[ ${UPSTREAM_DEV} ]]; then
     # mamba uninstall --force ...
     conda uninstall --force numpy pandas scipy
     python -m pip install --no-deps --pre --retries 10 \
-        -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \
+        -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
         numpy \
         pandas \
         scipy


### PR DESCRIPTION
pandas, numpy and scipy recently changed their nightly location to https://anaconda.org/scientific-python-nightly-wheels so updating the index here