### PR TITLE
Deprecate `DataFrame.fillna`/`Series.fillna` with `method`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1654,12 +1654,6 @@ Dask Name: {name}, {layers}"""
             compute=compute,
         )
 
-    def _fillna_test_value(self, value):
-        if isinstance(value, (_Frame, Scalar)):
-            return value._meta_nonempty
-        else:
-            return value
-
     def _limit_fillna(self, method=None, *, limit=None, skip_check=None, meta=None):
         if limit is None:
             name = "fillna-chunk-" + tokenize(self, method)
@@ -1683,7 +1677,9 @@ Dask Name: {name}, {layers}"""
             raise NotImplementedError("fillna with set limit and method=None")
 
         axis = self._validate_axis(axis)
-        test_value = self._fillna_test_value(value)
+        test_value = (
+            value._meta_nonempty if isinstance(value, (_Frame, Scalar)) else value
+        )
 
         # let it raise a FutureWarning if `method` is not None
         meta = self._meta_nonempty.fillna(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1654,49 +1654,13 @@ Dask Name: {name}, {layers}"""
             compute=compute,
         )
 
-    @derived_from(pd.DataFrame)
-    def fillna(self, value=None, method=None, limit=None, axis=None):
-        axis = self._validate_axis(axis)
-        if method is None and limit is not None:
-            raise NotImplementedError("fillna with set limit and method=None")
+    def _fillna_test_value(self, value):
         if isinstance(value, (_Frame, Scalar)):
-            test_value = value._meta_nonempty
+            return value._meta_nonempty
         else:
-            test_value = value
-        meta = self._meta_nonempty.fillna(
-            value=test_value, method=method, limit=limit, axis=axis
-        )
+            return value
 
-        if axis == 1 or method is None:
-            # Control whether or not dask's partition alignment happens.
-            # We don't want for a pandas Series.
-            # We do want it for a dask Series
-            if is_series_like(value) and not is_dask_collection(value):
-                args = ()
-                kwargs = {"value": value}
-            else:
-                args = (value,)
-                kwargs = {}
-            return self.map_partitions(
-                M.fillna,
-                *args,
-                method=method,
-                limit=limit,
-                axis=axis,
-                meta=meta,
-                enforce_metadata=False,
-                **kwargs,
-            )
-
-        if method in ("pad", "ffill"):
-            method = "ffill"
-            skip_check = 0
-            before, after = 1 if limit is None else limit, 0
-        else:
-            method = "bfill"
-            skip_check = self.npartitions - 1
-            before, after = 0, 1 if limit is None else limit
-
+    def _limit_fillna(self, method=None, *, limit=None, skip_check=None, meta=None):
         if limit is None:
             name = "fillna-chunk-" + tokenize(self, method)
             dsk = {
@@ -1709,21 +1673,77 @@ Dask Name: {name}, {layers}"""
                 for i in range(self.npartitions)
             }
             graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
-            parts = new_dd_object(graph, name, meta, self.divisions)
+            return new_dd_object(graph, name, meta, self.divisions)
         else:
-            parts = self
+            return self
 
-        return parts.map_overlap(
-            M.fillna, before, after, method=method, limit=limit, meta=meta
+    @derived_from(pd.DataFrame)
+    def fillna(self, value=None, method=None, limit=None, axis=None):
+        if method is None and limit is not None:
+            raise NotImplementedError("fillna with set limit and method=None")
+
+        axis = self._validate_axis(axis)
+        test_value = self._fillna_test_value(value)
+
+        # let it raise a FutureWarning if `method` is not None
+        meta = self._meta_nonempty.fillna(
+            value=test_value, method=method, limit=limit, axis=axis
         )
+
+        if method is None:
+            # Control whether or not dask's partition alignment happens.
+            # We don't want for a pandas Series.
+            # We do want it for a dask Series
+            if is_series_like(value) and not is_dask_collection(value):
+                args = ()
+                kwargs = {"value": value}
+            else:
+                args = (value,)
+                kwargs = {}
+
+            return self.map_partitions(
+                M.fillna,
+                *args,
+                limit=limit,
+                axis=axis,
+                meta=meta,
+                enforce_metadata=False,
+                **kwargs,
+            )
+        elif method in ("pad", "ffill"):
+            return self.ffill(limit=limit, axis=axis)
+        else:
+            return self.bfill(limit=limit, axis=axis)
 
     @derived_from(pd.DataFrame)
     def ffill(self, axis=None, limit=None):
-        return self.fillna(method="ffill", limit=limit, axis=axis)
+        axis = self._validate_axis(axis)
+        meta = self._meta_nonempty.ffill(limit=limit, axis=axis)
+
+        if axis == 1:
+            return self.map_partitions(
+                M.ffill, limit=limit, axis=axis, meta=meta, enforce_metadata=False
+            )
+
+        before, after = 1 if limit is None else limit, 0
+        parts = self._limit_fillna("ffill", limit=limit, skip_check=0, meta=meta)
+        return parts.map_overlap(M.ffill, before, after, limit=limit, meta=meta)
 
     @derived_from(pd.DataFrame)
     def bfill(self, axis=None, limit=None):
-        return self.fillna(method="bfill", limit=limit, axis=axis)
+        axis = self._validate_axis(axis)
+        meta = self._meta_nonempty.bfill(limit=limit, axis=axis)
+
+        if axis == 1:
+            return self.map_partitions(
+                M.bfill, limit=limit, axis=axis, meta=meta, enforce_metadata=False
+            )
+
+        before, after = 0, 1 if limit is None else limit
+        parts = self._limit_fillna(
+            "bfill", limit=limit, skip_check=self.npartitions - 1, meta=meta
+        )
+        return parts.map_overlap(M.bfill, before, after, limit=limit, meta=meta)
 
     def sample(self, n=None, frac=None, replace=False, random_state=None):
         """Random sample of items

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1315,11 +1315,9 @@ def _cumcount_aggregate(a, b, fill_value=None):
     return a.add(b, fill_value=fill_value) + 1
 
 
-def _fillna_group(group, by, value, method, limit, fillna_axis):
-    # apply() conserves the grouped-by columns, so drop them to stay consistent with pandas groupby-fillna
-    return group.drop(columns=by).fillna(
-        value=value, method=method, limit=limit, axis=fillna_axis
-    )
+def _drop_apply(group, *, by, what, **kwargs):
+    # apply keeps the grouped-by columns, so drop them to stay consistent with pandas groupby-fillna
+    return getattr(group.drop(columns=by), what)(**kwargs)
 
 
 def _aggregate_docstring(based_on=None):
@@ -2830,21 +2828,23 @@ class _GroupBy:
                 "groupby-fillna with value=dict/Series/DataFrame is currently not supported"
             )
         meta = self._meta_nonempty.apply(
-            _fillna_group,
+            _drop_apply,
             by=self.by,
+            what="fillna",
             value=value,
             method=method,
             limit=limit,
-            fillna_axis=axis,
+            axis=axis,
         )
 
         result = self.apply(
-            _fillna_group,
+            _drop_apply,
             by=self.by,
+            what="fillna",
             value=value,
             method=method,
             limit=limit,
-            fillna_axis=axis,
+            axis=axis,
             meta=meta,
         )
 
@@ -2855,11 +2855,27 @@ class _GroupBy:
 
     @derived_from(pd.core.groupby.GroupBy)
     def ffill(self, limit=None):
-        return self.fillna(method="ffill", limit=limit)
+        meta = self._meta_nonempty.apply(
+            _drop_apply, by=self.by, what="ffill", limit=limit
+        )
+        result = self.apply(
+            _drop_apply, by=self.by, what="ffill", limit=limit, meta=meta
+        )
+        if PANDAS_GT_150 and self.group_keys:
+            return result.map_partitions(M.droplevel, self.by)
+        return result
 
     @derived_from(pd.core.groupby.GroupBy)
     def bfill(self, limit=None):
-        return self.fillna(method="bfill", limit=limit)
+        meta = self._meta_nonempty.apply(
+            _drop_apply, by=self.by, what="bfill", limit=limit
+        )
+        result = self.apply(
+            _drop_apply, by=self.by, what="bfill", limit=limit, meta=meta
+        )
+        if PANDAS_GT_150 and self.group_keys:
+            return result.map_partitions(M.droplevel, self.by)
+        return result
 
 
 class DataFrameGroupBy(_GroupBy):

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -415,7 +415,10 @@ def drop_columns(df, columns, dtype):
 
 
 def fillna_check(df, method, check=True):
-    out = df.fillna(method=method)
+    if method:
+        out = getattr(df, method)()
+    else:
+        out = df.fillna()
     if check and out.isnull().values.all(axis=0).any():
         raise ValueError(
             "All NaN partition encountered in `fillna`. Try "

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -90,8 +90,8 @@ def _calculate_divisions(
             list(divisions.iloc[: n - 1].unique()) + divisions.iloc[n - 1 :].tolist()
         )
 
-    mins = mins.fillna(method="bfill")
-    maxes = maxes.fillna(method="bfill")
+    mins = mins.bfill()
+    maxes = maxes.bfill()
     if isinstance(partition_col.dtype, pd.CategoricalDtype):
         dtype = partition_col.dtype
         mins = mins.astype(dtype)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -1029,8 +1029,8 @@ def _compute_partition_stats(
     maxes = column.map_partitions(M.max, meta=column)
     lens = column.map_partitions(len, meta=column)
     mins, maxes, lens = compute(mins, maxes, lens, **kwargs)
-    mins = mins.fillna(method="bfill").tolist()
-    maxes = maxes.fillna(method="bfill").tolist()
+    mins = mins.bfill().tolist()
+    maxes = maxes.bfill().tolist()
     non_empty_mins = [m for m, length in zip(mins, lens) if length != 0]
     non_empty_maxes = [m for m, length in zip(maxes, lens) if length != 0]
     if (

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2477,26 +2477,21 @@ def test_fillna():
     assert_eq(ddf.A.fillna(100), df.A.fillna(100))
     assert_eq(ddf.A.fillna(ddf["A"].mean()), df.A.fillna(df["A"].mean()))
 
-    assert_eq(ddf.fillna(method="pad"), df.fillna(method="pad"))
-    assert_eq(ddf.A.fillna(method="pad"), df.A.fillna(method="pad"))
+    assert_eq(ddf.ffill(), df.ffill())
+    assert_eq(ddf.A.ffill(), df.A.ffill())
 
-    assert_eq(ddf.fillna(method="bfill"), df.fillna(method="bfill"))
-    assert_eq(ddf.A.fillna(method="bfill"), df.A.fillna(method="bfill"))
+    assert_eq(ddf.bfill(), df.bfill())
+    assert_eq(ddf.A.bfill(), df.A.bfill())
 
-    assert_eq(ddf.fillna(method="pad", limit=2), df.fillna(method="pad", limit=2))
-    assert_eq(ddf.A.fillna(method="pad", limit=2), df.A.fillna(method="pad", limit=2))
+    assert_eq(ddf.ffill(limit=2), df.ffill(limit=2))
+    assert_eq(ddf.A.ffill(limit=2), df.A.ffill(limit=2))
 
-    assert_eq(ddf.fillna(method="bfill", limit=2), df.fillna(method="bfill", limit=2))
-    assert_eq(
-        ddf.A.fillna(method="bfill", limit=2), df.A.fillna(method="bfill", limit=2)
-    )
+    assert_eq(ddf.bfill(limit=2), df.bfill(limit=2))
+    assert_eq(ddf.A.bfill(limit=2), df.A.bfill(limit=2))
 
     assert_eq(ddf.fillna(100, axis=1), df.fillna(100, axis=1))
-    assert_eq(ddf.fillna(method="pad", axis=1), df.fillna(method="pad", axis=1))
-    assert_eq(
-        ddf.fillna(method="pad", limit=2, axis=1),
-        df.fillna(method="pad", limit=2, axis=1),
-    )
+    assert_eq(ddf.ffill(axis=1), df.ffill(axis=1))
+    assert_eq(ddf.ffill(limit=2, axis=1), df.ffill(limit=2, axis=1))
 
     pytest.raises(ValueError, lambda: ddf.A.fillna(0, axis=1))
     pytest.raises(NotImplementedError, lambda: ddf.fillna(0, limit=10))
@@ -2505,8 +2500,8 @@ def test_fillna():
     df = _compat.makeMissingDataframe()
     df.iloc[:15, 0] = np.nan  # all NaN partition
     ddf = dd.from_pandas(df, npartitions=5, sort=False)
-    pytest.raises(ValueError, lambda: ddf.fillna(method="pad").compute())
-    assert_eq(df.fillna(method="pad", limit=3), ddf.fillna(method="pad", limit=3))
+    pytest.raises(ValueError, lambda: ddf.ffill().compute())
+    assert_eq(df.ffill(limit=3), ddf.ffill(limit=3))
 
 
 @pytest.mark.parametrize("optimize", [True, False])

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2476,32 +2476,46 @@ def test_fillna():
     assert_eq(ddf.fillna(100), df.fillna(100))
     assert_eq(ddf.A.fillna(100), df.A.fillna(100))
     assert_eq(ddf.A.fillna(ddf["A"].mean()), df.A.fillna(df["A"].mean()))
-
-    assert_eq(ddf.ffill(), df.ffill())
-    assert_eq(ddf.A.ffill(), df.A.ffill())
-
-    assert_eq(ddf.bfill(), df.bfill())
-    assert_eq(ddf.A.bfill(), df.A.bfill())
-
-    assert_eq(ddf.ffill(limit=2), df.ffill(limit=2))
-    assert_eq(ddf.A.ffill(limit=2), df.A.ffill(limit=2))
-
-    assert_eq(ddf.bfill(limit=2), df.bfill(limit=2))
-    assert_eq(ddf.A.bfill(limit=2), df.A.bfill(limit=2))
-
     assert_eq(ddf.fillna(100, axis=1), df.fillna(100, axis=1))
-    assert_eq(ddf.ffill(axis=1), df.ffill(axis=1))
-    assert_eq(ddf.ffill(limit=2, axis=1), df.ffill(limit=2, axis=1))
 
     pytest.raises(ValueError, lambda: ddf.A.fillna(0, axis=1))
     pytest.raises(NotImplementedError, lambda: ddf.fillna(0, limit=10))
     pytest.raises(NotImplementedError, lambda: ddf.fillna(0, limit=10, axis=1))
+
+
+def test_ffill():
+    df = _compat.makeMissingDataframe()
+    ddf = dd.from_pandas(df, npartitions=5, sort=False)
+
+    assert_eq(ddf.ffill(), df.ffill())
+    assert_eq(ddf.A.ffill(), df.A.ffill())
+    assert_eq(ddf.ffill(limit=2), df.ffill(limit=2))
+    assert_eq(ddf.A.ffill(limit=2), df.A.ffill(limit=2))
+    assert_eq(ddf.ffill(axis=1), df.ffill(axis=1))
+    assert_eq(ddf.ffill(limit=2, axis=1), df.ffill(limit=2, axis=1))
 
     df = _compat.makeMissingDataframe()
     df.iloc[:15, 0] = np.nan  # all NaN partition
     ddf = dd.from_pandas(df, npartitions=5, sort=False)
     pytest.raises(ValueError, lambda: ddf.ffill().compute())
     assert_eq(df.ffill(limit=3), ddf.ffill(limit=3))
+
+
+def test_bfill():
+    df = _compat.makeMissingDataframe()
+    ddf = dd.from_pandas(df, npartitions=5, sort=False)
+
+    assert_eq(ddf.bfill(), df.bfill())
+    assert_eq(ddf.A.bfill(), df.A.bfill())
+
+    assert_eq(ddf.bfill(limit=2), df.bfill(limit=2))
+    assert_eq(ddf.A.bfill(limit=2), df.A.bfill(limit=2))
+
+    df = _compat.makeMissingDataframe()
+    df.iloc[:15, 0] = np.nan  # all NaN partition
+    ddf = dd.from_pandas(df, npartitions=5, sort=False)
+    pytest.raises(ValueError, lambda: ddf.bfill().compute())
+    assert_eq(df.bfill(limit=3), ddf.bfill(limit=3))
 
 
 @pytest.mark.parametrize("optimize", [True, False])

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1299,9 +1299,8 @@ def test_aggregate_median(spec, keys, shuffle_method):
 
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("group_keys", [True, False, None])
-@pytest.mark.parametrize("method", ["ffill", "bfill"])
 @pytest.mark.parametrize("limit", [None, 1, 4])
-def test_fillna(axis, group_keys, method, limit):
+def test_fillna(axis, group_keys, limit):
     df = pd.DataFrame(
         {
             "A": [1, 1, 2, 2],
@@ -1312,9 +1311,6 @@ def test_fillna(axis, group_keys, method, limit):
         }
     )
     ddf = dd.from_pandas(df, npartitions=2)
-
-    def f(obj, *args, **kwargs):
-        return getattr(obj, method)(*args, **kwargs)
 
     with groupby_axis_deprecated():
         expected = df.groupby("A", group_keys=group_keys).fillna(0, axis=axis)
@@ -1330,14 +1326,6 @@ def test_fillna(axis, group_keys, method, limit):
         ddf.groupby(["A", "B"], group_keys=group_keys).fillna(0),
     )
 
-    expected = f(df.groupby("A", group_keys=group_keys), limit=limit)
-    result = f(ddf.groupby("A", group_keys=group_keys), limit=limit)
-    assert_eq(expected, result)
-
-    expected = f(df.groupby(["A", "B"], group_keys=group_keys), limit=limit)
-    result = f(ddf.groupby(["A", "B"], group_keys=group_keys), limit=limit)
-    assert_eq(expected, result)
-
     with pytest.raises(NotImplementedError):
         ddf.groupby("A").fillna({"A": 0})
 
@@ -1348,7 +1336,9 @@ def test_fillna(axis, group_keys, method, limit):
         ddf.groupby("A").fillna(pd.DataFrame)
 
 
-def test_ffill():
+@pytest.mark.parametrize("group_keys", [True, False, None])
+@pytest.mark.parametrize("limit", [None, 1, 4])
+def test_ffill(group_keys, limit):
     df = pd.DataFrame(
         {
             "A": [1, 1, 2, 2],
@@ -1360,20 +1350,22 @@ def test_ffill():
     )
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(
-        df.groupby("A").ffill(),
-        ddf.groupby("A").ffill(),
+        df.groupby("A", group_keys=group_keys).ffill(limit=limit),
+        ddf.groupby("A", group_keys=group_keys).ffill(limit=limit),
     )
     assert_eq(
-        df.groupby("A").B.ffill(),
-        ddf.groupby("A").B.ffill(),
+        df.groupby("A", group_keys=group_keys).B.ffill(limit=limit),
+        ddf.groupby("A", group_keys=group_keys).B.ffill(limit=limit),
     )
     assert_eq(
-        df.groupby(["A", "B"]).ffill(),
-        ddf.groupby(["A", "B"]).ffill(),
+        df.groupby(["A", "B"], group_keys=group_keys).ffill(limit=limit),
+        ddf.groupby(["A", "B"], group_keys=group_keys).ffill(limit=limit),
     )
 
 
-def test_bfill():
+@pytest.mark.parametrize("group_keys", [True, False, None])
+@pytest.mark.parametrize("limit", [None, 1, 4])
+def test_bfill(group_keys, limit):
     df = pd.DataFrame(
         {
             "A": [1, 1, 2, 2],
@@ -1385,16 +1377,16 @@ def test_bfill():
     )
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(
-        df.groupby("A").bfill(),
-        ddf.groupby("A").bfill(),
+        df.groupby("A", group_keys=group_keys).bfill(limit=limit),
+        ddf.groupby("A", group_keys=group_keys).bfill(limit=limit),
     )
     assert_eq(
-        df.groupby("A").B.bfill(),
-        ddf.groupby("A").B.bfill(),
+        df.groupby("A", group_keys=group_keys).B.bfill(limit=limit),
+        ddf.groupby("A", group_keys=group_keys).B.bfill(limit=limit),
     )
     assert_eq(
-        df.groupby(["A", "B"]).bfill(),
-        ddf.groupby(["A", "B"]).bfill(),
+        df.groupby(["A", "B"], group_keys=group_keys).bfill(limit=limit),
+        ddf.groupby(["A", "B"], group_keys=group_keys).bfill(limit=limit),
     )
 
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1313,6 +1313,9 @@ def test_fillna(axis, group_keys, method, limit):
     )
     ddf = dd.from_pandas(df, npartitions=2)
 
+    def f(obj, *args, **kwargs):
+        return getattr(obj, method)(*args, **kwargs)
+
     with groupby_axis_deprecated():
         expected = df.groupby("A", group_keys=group_keys).fillna(0, axis=axis)
     with groupby_axis_deprecated():
@@ -1326,23 +1329,13 @@ def test_fillna(axis, group_keys, method, limit):
         df.groupby(["A", "B"], group_keys=group_keys).fillna(0),
         ddf.groupby(["A", "B"], group_keys=group_keys).fillna(0),
     )
-    with groupby_axis_deprecated():
-        expected = df.groupby("A", group_keys=group_keys).fillna(
-            method=method, limit=limit, axis=axis
-        )
-    with groupby_axis_deprecated():
-        result = ddf.groupby("A", group_keys=group_keys).fillna(
-            method=method, limit=limit, axis=axis
-        )
+
+    expected = f(df.groupby("A", group_keys=group_keys), limit=limit)
+    result = f(ddf.groupby("A", group_keys=group_keys), limit=limit)
     assert_eq(expected, result)
-    with groupby_axis_deprecated():
-        expected = df.groupby(["A", "B"], group_keys=group_keys).fillna(
-            method=method, limit=limit, axis=axis
-        )
-    with groupby_axis_deprecated():
-        result = ddf.groupby(["A", "B"], group_keys=group_keys).fillna(
-            method=method, limit=limit, axis=axis
-        )
+
+    expected = f(df.groupby(["A", "B"], group_keys=group_keys), limit=limit)
+    result = f(ddf.groupby(["A", "B"], group_keys=group_keys), limit=limit)
     assert_eq(expected, result)
 
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
See https://github.com/dask/dask/issues/10347.

Handles `fillna` deprecations like this one:

```
FAILED dask/dataframe/tests/test_dataframe.py::test_fillna - FutureWarning: DataFrame.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.
```

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

The remaining failures are not the same issue.
