### PR TITLE
Respect ``dropna`` and ``observed`` in ``GroupBy.var`` and ``GroupBy.std``

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -538,14 +538,14 @@ def _apply_chunk(df, *by, dropna=None, observed=None, **kwargs):
         return func(g[columns], **kwargs)
 
 
-def _var_chunk(df, *by, numeric_only=no_default):
+def _var_chunk(df, *by, numeric_only=no_default, observed=False, dropna=True):
     numeric_only_kwargs = get_numeric_only_kwargs(numeric_only)
     if is_series_like(df):
         df = df.to_frame()
 
     df = df.copy()
 
-    g = _groupby_raise_unaligned(df, by=by)
+    g = _groupby_raise_unaligned(df, by=by, observed=observed, dropna=dropna)
     with check_numeric_only_deprecation():
         x = g.sum(**numeric_only_kwargs)
 
@@ -554,7 +554,7 @@ def _var_chunk(df, *by, numeric_only=no_default):
     cols = x.columns
     df[cols] = df[cols] ** 2
 
-    g2 = _groupby_raise_unaligned(df, by=by)
+    g2 = _groupby_raise_unaligned(df, by=by, observed=observed, dropna=dropna)
     with check_numeric_only_deprecation():
         x2 = g2.sum(**numeric_only_kwargs).rename(columns=lambda c: (c, "-x2"))
 
@@ -565,9 +565,13 @@ def _var_combine(g, levels, sort=False):
     return g.groupby(level=levels, sort=sort).sum()
 
 
-def _var_agg(g, levels, ddof, sort=False, numeric_only=no_default):
+def _var_agg(
+    g, levels, ddof, sort=False, numeric_only=no_default, observed=False, dropna=True
+):
     numeric_only_kwargs = get_numeric_only_kwargs(numeric_only)
-    g = g.groupby(level=levels, sort=sort).sum(**numeric_only_kwargs)
+    g = g.groupby(level=levels, sort=sort, observed=observed, dropna=dropna).sum(
+        **numeric_only_kwargs
+    )
     nc = len(g.columns)
     x = g[g.columns[: nc // 3]]
     # chunks columns are tuples (value, name), so we just keep the value part
@@ -2069,8 +2073,10 @@ class _GroupBy:
                 "ddof": ddof,
                 "levels": levels,
                 "numeric_only": numeric_only,
+                **self.observed,
+                **self.dropna,
             },
-            chunk_kwargs={"numeric_only": numeric_only},
+            chunk_kwargs={"numeric_only": numeric_only, **self.observed, **self.dropna},
             combine_kwargs={"levels": levels},
             split_every=split_every,
             split_out=split_out,

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3717,3 +3717,19 @@ def test_groupby_numeric_only_false(func):
         with ctx:
             pd_result = getattr(df.groupby("A"), func)()
         assert_eq(dd_result, pd_result)
+
+
+@pytest.mark.parametrize("func", ["var", "std"])
+@pytest.mark.parametrize("observed", [True, False])
+@pytest.mark.parametrize("dropna", [True, False])
+def test_groupby_var_dropna_observed(dropna, observed, func):
+    df = pd.DataFrame(
+        {
+            "a": [11, 12, 31, 1, 2, 3, 4, 5, 6, 10],
+            "b": pd.Categorical(values=[1] * 9 + [np.nan], categories=[1, 2]),
+        }
+    )
+    ddf = dd.from_pandas(df, npartitions=3)
+    dd_result = getattr(ddf.groupby("b", observed=observed, dropna=dropna), func)()
+    pdf_result = getattr(df.groupby("b", observed=observed, dropna=dropna), func)()
+    assert_eq(dd_result, pdf_result)


### PR DESCRIPTION

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

Found this when working on dask-expr