### PR TITLE
Deprecate ``DataFrame.first`` and ``Series.first``

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3614,7 +3614,7 @@ Dask Name: {name}, {layers}"""
     @derived_from(pd.DataFrame)
     def last(self, offset):
         # Let pandas error on bad args
-        self._meta_nonempty.first(offset)
+        self._meta_nonempty.last(offset)
 
         if not self.known_divisions:
             raise ValueError("`last` is not implemented for unknown divisions")

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4532,10 +4532,7 @@ def test_first_and_last(method):
     f = lambda x, offset: getattr(x, method)(offset)
     freqs = ["12h", "D"]
     offsets = ["0d", "100h", "20d", "20B", "3W", "3M", "400d", "13M"]
-    if PANDAS_GT_210 and method == "first":
-        ctx = pytest.warns(FutureWarning, match="first is deprecated")
-    else:
-        ctx = contextlib.nullcontext()
+    should_warn = PANDAS_GT_210 and method == "first"
 
     for freq in freqs:
         index = pd.date_range("1/1/2000", "1/1/2001", freq=freq)[::4]
@@ -4544,15 +4541,15 @@ def test_first_and_last(method):
         )
         ddf = dd.from_pandas(df, npartitions=10)
         for offset in offsets:
-            with ctx:
+            with _check_warning(should_warn, FutureWarning, "first"):
                 expected = f(df, offset)
-            with ctx:
+            with _check_warning(should_warn, FutureWarning, "first"):
                 actual = f(ddf, offset)
             assert_eq(actual, expected)
 
-            with ctx:
+            with _check_warning(should_warn, FutureWarning, "first"):
                 expected = f(df.A, offset)
-            with ctx:
+            with _check_warning(should_warn, FutureWarning, "first"):
                 actual = f(ddf.A, offset)
             assert_eq(actual, expected)
 


### PR DESCRIPTION
See https://github.com/dask/dask/issues/10347.

Fixes this deprecation:

```
FAILED dask/dataframe/tests/test_dataframe.py::test_first_and_last[first] - FutureWarning: first is deprecated and will be removed in a future version. Please create a mask and filter using `.loc` instead
FAILED dask/dataframe/tests/test_dataframe.py::test_first_and_last[last] - FutureWarning: first is deprecated and will be removed in a future version. Please create a mask and filter using `.loc` instead
```

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
