### PR TITLE
Fix issue with ``header`` passed to ``read_csv``

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -604,7 +604,9 @@ def read_pandas(
             if len(parts) > need:
                 break
     else:
-        parts = b_sample.split(b_lineterminator, max(lastskiprow + need, firstrow+need))
+        parts = b_sample.split(
+            b_lineterminator, max(lastskiprow + need, firstrow + need)
+        )
 
     # If the last partition is empty, don't count it
     nparts = 0 if not parts else len(parts) - int(not parts[-1])

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -588,7 +588,8 @@ def read_pandas(
     names = kwargs.get("names", None)
     header = kwargs.get("header", "infer" if names is None else None)
     need = 1 if header is None else 2
-
+    if isinstance(header, int):
+        firstrow += header
     if kwargs.get("comment"):
         # if comment is provided, step through lines of b_sample and strip out comments
         parts = []
@@ -603,7 +604,7 @@ def read_pandas(
             if len(parts) > need:
                 break
     else:
-        parts = b_sample.split(b_lineterminator, lastskiprow + need)
+        parts = b_sample.split(b_lineterminator, max(lastskiprow + need, firstrow+need))
 
     # If the last partition is empty, don't count it
     nparts = 0 if not parts else len(parts) - int(not parts[-1])
@@ -615,8 +616,6 @@ def read_pandas(
             "in `sample` in the call to `read_csv`/`read_table`"
         )
 
-    if isinstance(header, int):
-        firstrow += header
     header = b"" if header is None else parts[firstrow] + b_lineterminator
 
     # Use sample to infer dtypes and check for presence of include_path_column

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -827,7 +827,8 @@ def test_windows_line_terminator():
         assert df.a.sum().compute() == 1 + 2 + 3 + 4 + 5 + 6
 
 
-def test_header_int():
+@pytest.mark.parametrize("header", [1, 2, 3])
+def test_header_int(header):
     text = (
         "id0,name0,x0,y0\n"
         "id,name,x,y\n"
@@ -838,8 +839,8 @@ def test_header_int():
         "989,Zelda,-0.04,0.03\n"
     )
     with filetexts({"test_header_int.csv": text}):
-        df = dd.read_csv("test_header_int.csv", header=1, blocksize=64)
-        expected = pd.read_csv("test_header_int.csv", header=1)
+        df = dd.read_csv("test_header_int.csv", header=header, blocksize=64)
+        expected = pd.read_csv("test_header_int.csv", header=header)
         assert_eq(df, expected, check_index=False)
 
 


### PR DESCRIPTION
We currently have an issue in `read_csv` where the following types of inputs fail:
```python
In [1]: import dask.dataframe as dd

In [2]: !cat ../s.csv
x
x
x
A, B, C, D
1, 2, 3, 4
2, 3, 5, 1
4, 5, 2, 5


In [3]: dd.read_csv("../s.csv", header=3).compute()
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
File /nvme/0/pgali/cudf/dask/dask/backends.py:136, in CreationDispatch.register_inplace.<locals>.decorator.<locals>.wrapper(*args, **kwargs)
    135 try:
--> 136     return func(*args, **kwargs)
    137 except Exception as e:

File /nvme/0/pgali/cudf/dask/dask/dataframe/io/csv.py:760, in make_reader.<locals>.read(urlpath, blocksize, lineterminator, compression, sample, sample_rows, enforce, assume_missing, storage_options, include_path_column, **kwargs)
    747 def read(
    748     urlpath,
    749     blocksize="default",
   (...)
    758     **kwargs,
    759 ):
--> 760     return read_pandas(
    761         reader,
    762         urlpath,
    763         blocksize=blocksize,
    764         lineterminator=lineterminator,
    765         compression=compression,
    766         sample=sample,
    767         sample_rows=sample_rows,
    768         enforce=enforce,
    769         assume_missing=assume_missing,
    770         storage_options=storage_options,
    771         include_path_column=include_path_column,
    772         **kwargs,
    773     )

File /nvme/0/pgali/cudf/dask/dask/dataframe/io/csv.py:620, in read_pandas(reader, urlpath, blocksize, lineterminator, compression, sample, sample_rows, enforce, assume_missing, storage_options, include_path_column, **kwargs)
    619     firstrow += header
--> 620 header = b"" if header is None else parts[firstrow] + b_lineterminator
    622 # Use sample to infer dtypes and check for presence of include_path_column

IndexError: list index out of range

The above exception was the direct cause of the following exception:

IndexError                                Traceback (most recent call last)
Cell In[3], line 1
----> 1 dd.read_csv("../s.csv", header=3).compute()

File /nvme/0/pgali/cudf/dask/dask/backends.py:138, in CreationDispatch.register_inplace.<locals>.decorator.<locals>.wrapper(*args, **kwargs)
    136     return func(*args, **kwargs)
    137 except Exception as e:
--> 138     raise type(e)(
    139         f"An error occurred while calling the {funcname(func)} "
    140         f"method registered to the {self.backend} backend.\n"
    141         f"Original Message: {e}"
    142     ) from e

IndexError: An error occurred while calling the read_csv method registered to the pandas backend.
Original Message: list index out of range

In [4]: import pandas as pd

In [5]: pd.read_csv("../s.csv", header=3)
Out[5]: 
   A   B   C   D
0  1   2   3   4
1  2   3   5   1
2  4   5   2   5
```

This PR fixes the issue by factoring in the `header` & `firstrow` parameters while making the parts split.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
