### PR TITLE
``concat`` ignoring ``DataFrame`` withouth columns

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -1083,7 +1083,11 @@ def stack_partitions(dfs, divisions, join="outer", ignore_order=False, **kwargs)
 
     meta = make_meta(
         methods.concat(
-            [df._meta_nonempty for df in dfs],
+            [
+                df._meta_nonempty
+                for df in dfs
+                if not is_dataframe_like(df) or len(df._meta_nonempty.columns) > 0
+            ],
             join=join,
             filter_warning=False,
             **kwargs,
@@ -1268,12 +1272,14 @@ def concat(
         raise ValueError("'join' must be 'inner' or 'outer'")
 
     axis = DataFrame._validate_axis(axis)
-    try:
-        # remove any empty DataFrames
-        dfs = [df for df in dfs if bool(len(df.columns))]
-    except AttributeError:
-        # 'Series' object has no attribute 'columns'
-        pass
+
+    if axis == 1:
+        try:
+            # remove any empty DataFrames
+            dfs = [df for df in dfs if bool(len(df.columns))]
+        except AttributeError:
+            # 'Series' object has no attribute 'columns'
+            pass
     dasks = [df for df in dfs if isinstance(df, _Frame)]
     dfs = _maybe_from_pandas(dfs)
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -859,6 +859,8 @@ def test_concat_dataframe_empty():
 
     assert_eq(df_concat_with_col, ddf_concat_with_col, check_dtype=False)
 
+    assert_eq(dd.concat([ddf, ddf[[]]]), pd.concat([df, df[[]]]))
+
 
 @pytest.mark.parametrize(
     "value_1, value_2",


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

We found this in dask-expr. The check was implemented to ignore completely empty DataFrames, since it would coerce ints to floats, but we should keep DataFrames with no columns but an Index