### PR TITLE
mypy support for numpy 1.25

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1566,7 +1566,7 @@ def corrcoef(x, y=None, rowvar=1):
     return (c / sqr_d) / sqr_d.T
 
 
-@implements(np.round, np.round_)
+@implements(np.round)
 @derived_from(np)
 def round(a, decimals=0):
     return a.map_blocks(np.round, decimals=decimals, dtype=a.dtype)


### PR DESCRIPTION
mypy has started failing (not in CI yet, since CI is still using a cache with numpy 1.24):
```
dask/array/routines.py:1569: error: Module has no attribute "round_"  [attr-defined]
Found 1 error in 1 file (checked 255 source files)
```