### PR TITLE
Use general `kwargs` in `pyarrow_table_dispatch` functions

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -216,15 +216,17 @@ def get_pyarrow_schema_pandas(obj):
 
 
 @to_pyarrow_table_dispatch.register((pd.DataFrame,))
-def get_pyarrow_table_from_pandas(obj, preserve_index=True):
+def get_pyarrow_table_from_pandas(obj, **kwargs):
+    # `kwargs` must be supported by `pyarrow.Table.to_pandas`
     import pyarrow as pa
 
-    return pa.Table.from_pandas(obj, preserve_index=preserve_index)
+    return pa.Table.from_pandas(obj, **kwargs)
 
 
 @from_pyarrow_table_dispatch.register((pd.DataFrame,))
-def get_pandas_dataframe_from_pyarrow(_, table, self_destruct=False):
-    return table.to_pandas(self_destruct=self_destruct)
+def get_pandas_dataframe_from_pyarrow(_, table, **kwargs):
+    # `kwargs` must be supported by `pyarrow.Table.to_pandas`
+    return table.to_pandas(**kwargs)
 
 
 @meta_nonempty.register(pd.DatetimeTZDtype)


### PR DESCRIPTION
Follow-up to https://github.com/dask/dask/pull/10312, where we added `to`/`from_pyarrow_table_dispatch`.

In that PR, we decided to be explicit about the specific set of key-word arguments to support within the new pyarrow-conversion functions. However, https://github.com/dask/distributed/pull/7896 quickly demonstrated (to me) that we are probably going to end up wasting a lot of time adding key-word arguments one-by-one to `dask/dask` as the p2p algorithm evolves in `dask/distributed`.

In this PR, I propose that we go back to using  `kwargs`, and simply require any non-pandas backends to account for the fact that `pyarrow.Table.to_pandas` and `pyarrow.Table.to_pandas` key-word arguments are "allowed".