### PR TITLE
Fix annotations and spans leaking between threads

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -5,6 +5,7 @@ from dask._version import get_versions
 from dask.base import (
     annotate,
     compute,
+    get_annotation,
     get_annotations,
     is_dask_collection,
     optimize,

--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -5,7 +5,6 @@ from dask._version import get_versions
 from dask.base import (
     annotate,
     compute,
-    get_annotation,
     get_annotations,
     is_dask_collection,
     optimize,

--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -5,6 +5,7 @@ from dask._version import get_versions
 from dask.base import (
     annotate,
     compute,
+    get_annotations,
     is_dask_collection,
     optimize,
     persist,

--- a/dask/base.py
+++ b/dask/base.py
@@ -21,7 +21,7 @@ from enum import Enum
 from functools import partial, wraps
 from numbers import Integral, Number
 from operator import getitem
-from typing import TYPE_CHECKING, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from tlz import curry, groupby, identity, merge
 from tlz.functoolz import Compose
@@ -100,22 +100,25 @@ def _restore_excepthook():
 original_excepthook = sys.excepthook
 sys.excepthook = _clean_traceback_hook(sys.excepthook)
 
-_annotations: ContextVar[dict] = ContextVar("annotations", default={})
+_annotations: ContextVar[dict[str, Any]] = ContextVar("annotations", default={})
 
 
-def get_annotations() -> dict:
+def get_annotations() -> dict[str, Any]:
     """Get current annotations.
 
     Returns
     -------
-    result : dict
-        Dict of annotations
+    Dict of all current annotations
+
+    See Also
+    --------
+    annotate
     """
     return _annotations.get()
 
 
 @contextmanager
-def annotate(**annotations):
+def annotate(**annotations: Any) -> Iterator[None]:
     """Context Manager for setting HighLevelGraph Layer annotations.
 
     Annotations are metadata or soft constraints associated with
@@ -157,6 +160,10 @@ def annotate(**annotations):
     ...     with dask.annotate(retries=3):
     ...         A = da.ones((1000, 1000))
     ...     B = A + 1
+
+    See Also
+    --------
+    get_annotations
     """
 
     # Sanity check annotations used in place of

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -616,7 +616,7 @@ def read_parquet(
     # to be more fault tolerant, as transient transport errors can occur.
     # The specific number 5 isn't hugely motivated: it's less than ten and more
     # than two.
-    annotations = dask.get_annotations() or {}
+    annotations = dask.get_annotations()
     if "retries" not in annotations and not _is_local_fs(fs):
         ctx = dask.annotate(retries=5)
     else:
@@ -992,7 +992,7 @@ def to_parquet(
     # to be more fault tolerant, as transient transport errors can occur.
     # The specific number 5 isn't hugely motivated: it's less than ten and more
     # than two.
-    annotations = dask.get_annotations({})
+    annotations = dask.get_annotations()
     if "retries" not in annotations and not _is_local_fs(fs):
         ctx = dask.annotate(retries=5)
     else:

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -616,7 +616,7 @@ def read_parquet(
     # to be more fault tolerant, as transient transport errors can occur.
     # The specific number 5 isn't hugely motivated: it's less than ten and more
     # than two.
-    annotations = dask.config.get("annotations", {})
+    annotations = dask.get_annotations() or {}
     if "retries" not in annotations and not _is_local_fs(fs):
         ctx = dask.annotate(retries=5)
     else:
@@ -992,7 +992,7 @@ def to_parquet(
     # to be more fault tolerant, as transient transport errors can occur.
     # The specific number 5 isn't hugely motivated: it's less than ten and more
     # than two.
-    annotations = dask.config.get("annotations", {})
+    annotations = dask.get_annotations({})
     if "retries" not in annotations and not _is_local_fs(fs):
         ctx = dask.annotate(retries=5)
     else:

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import tlz as toolz
 
+import dask
 from dask import config
 from dask.base import clone_key, flatten, is_dask_collection
 from dask.core import keys_in_tasks, reverse_dict
@@ -72,7 +73,7 @@ class Layer(Mapping):
             characteristics of Dask computations.
             These annotations are *not* passed to the distributed scheduler.
         """
-        self.annotations = annotations or copy.copy(config.get("annotations", None))
+        self.annotations = annotations or copy.copy(dask.get_annotations())
         self.collection_annotations = collection_annotations or copy.copy(
             config.get("collection_annotations", None)
         )

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -73,7 +73,7 @@ class Layer(Mapping):
             characteristics of Dask computations.
             These annotations are *not* passed to the distributed scheduler.
         """
-        self.annotations = annotations or copy.copy(dask.get_annotations())
+        self.annotations = annotations or dask.get_annotations().copy() or None
         self.collection_annotations = collection_annotations or copy.copy(
             config.get("collection_annotations", None)
         )

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -1104,3 +1104,37 @@ with Client() as client: client.submit(f3).result()
     assert "In[4]" in lines[1] or "<ipython-input-4-" in lines[1]
     assert "In[3]" in lines[2] or "<ipython-input-3-" in lines[2]
     assert "In[2]" in lines[3] or "<ipython-input-2-" in lines[3]
+
+
+def test_annotations_threaded():
+    """Annotations shouldn't leak between threads.
+    See https://github.com/dask/dask/issues/10340."""
+    from distributed import get_client, secede
+
+    with distributed.LocalCluster(
+        scheduler_port=0,
+        dashboard_address=":0",
+        scheduler_kwargs={"dashboard": False},
+        asynchronous=False,
+        n_workers=1,
+        nthreads=2,
+        processes=False,
+    ) as cluster:
+        with Client(cluster, asynchronous=False) as client:
+
+            def f():
+                with dask.annotate(foo=1):
+                    val = dask.delayed(dask.get_annotations)
+                    _ = get_client()
+                    secede()
+                    return val.compute()()
+
+            def g():
+                with dask.annotate(foo=2):
+                    val = dask.delayed(dask.get_annotations)
+                    _ = get_client()
+                    secede()
+                    return val.compute()()
+
+            result = client.gather([client.submit(f), client.submit(g)])
+            assert result == [{"foo": 1}, {"foo": 2}]

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -159,7 +159,7 @@ def test_single_annotation(annotation):
 
     alayer = A.__dask_graph__().layers[A.name]
     assert alayer.annotations == annotation
-    assert dask.config.get("annotations", None) is None
+    assert dask.get_annotations() is None
 
 
 def test_multiple_annotations():
@@ -172,7 +172,7 @@ def test_multiple_annotations():
 
     C = B + 1
 
-    assert dask.config.get("annotations", None) is None
+    assert dask.get_annotations() is None
 
     alayer = A.__dask_graph__().layers[A.name]
     blayer = B.__dask_graph__().layers[B.name]
@@ -186,10 +186,10 @@ def test_annotation_and_config_collision():
     with dask.config.set({"foo": 1}):
         with dask.annotate(foo=2):
             assert dask.config.get("foo") == 1
-            assert dask.config.get("annotations") == {"foo": 2}
+            assert dask.get_annotations() == {"foo": 2}
             with dask.annotate(bar=3):
                 assert dask.config.get("foo") == 1
-                assert dask.config.get("annotations") == {"foo": 2, "bar": 3}
+                assert dask.get_annotations() == {"foo": 2, "bar": 3}
 
 
 def test_materializedlayer_cull_preserves_annotations():

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -159,7 +159,7 @@ def test_single_annotation(annotation):
 
     alayer = A.__dask_graph__().layers[A.name]
     assert alayer.annotations == annotation
-    assert dask.get_annotations() is None
+    assert not dask.get_annotations()
 
 
 def test_multiple_annotations():
@@ -172,7 +172,7 @@ def test_multiple_annotations():
 
     C = B + 1
 
-    assert dask.get_annotations() is None
+    assert not dask.get_annotations()
 
     alayer = A.__dask_graph__().layers[A.name]
     blayer = B.__dask_graph__().layers[B.name]
@@ -190,6 +190,15 @@ def test_annotation_and_config_collision():
             with dask.annotate(bar=3):
                 assert dask.config.get("foo") == 1
                 assert dask.get_annotations() == {"foo": 2, "bar": 3}
+
+
+def test_annotation_cleared_on_error():
+    with dask.annotate(banana=5):
+        with dask.annotate(apple=3):
+            with pytest.raises(ZeroDivisionError):
+                _ = 1 / 0
+        assert dask.get_annotations() == {"banana": 5}
+    assert not dask.get_annotations()
 
 
 def test_materializedlayer_cull_preserves_annotations():

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -182,22 +182,13 @@ def test_multiple_annotations():
     assert clayer.annotations is None
 
 
-def test_annotation_and_config_collision():
-    with dask.config.set({"foo": 1}):
-        with dask.annotate(foo=2):
-            assert dask.config.get("foo") == 1
-            assert dask.get_annotations() == {"foo": 2}
-            with dask.annotate(bar=3):
-                assert dask.config.get("foo") == 1
-                assert dask.get_annotations() == {"foo": 2, "bar": 3}
-
-
 def test_annotation_cleared_on_error():
-    with dask.annotate(banana=5):
-        with dask.annotate(apple=3):
-            with pytest.raises(ZeroDivisionError):
-                _ = 1 / 0
-        assert dask.get_annotations() == {"banana": 5}
+    with dask.annotate(x=1):
+        with pytest.raises(ZeroDivisionError):
+            with dask.annotate(x=2):
+                assert dask.get_annotations() == {"x": 2}
+                1 / 0
+        assert dask.get_annotations() == {"x": 1}
     assert not dask.get_annotations()
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -47,7 +47,6 @@ This more advanced API is available in the `Dask distributed documentation
 .. autofunction:: annotate
 .. autofunction:: get_annotations
 .. autofunction:: compute
-.. autofunction:: get_annotations
 .. autofunction:: is_dask_collection
 .. autofunction:: optimize
 .. autofunction:: persist

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -47,6 +47,7 @@ This more advanced API is available in the `Dask distributed documentation
 .. autofunction:: annotate
 .. autofunction:: get_annotations
 .. autofunction:: compute
+.. autofunction:: get_annotations
 .. autofunction:: is_dask_collection
 .. autofunction:: optimize
 .. autofunction:: persist

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -45,6 +45,7 @@ This more advanced API is available in the `Dask distributed documentation
 <https://distributed.dask.org/en/latest/api.html>`_
 
 .. autofunction:: annotate
+.. autofunction:: get_annotations
 .. autofunction:: compute
 .. autofunction:: is_dask_collection
 .. autofunction:: optimize


### PR DESCRIPTION
Switch global annotations to use `ContextVar` instead of setting values in dask config.

Dependent PR in distributed: https://github.com/dask/distributed/pull/7935

- [x] Closes https://github.com/dask/dask/issues/10340
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @fjetter @crusaderky 