### PR TITLE
Remove deprecated `numpy.compat`

### DIFF
--- a/dask/array/einsumfuncs.py
+++ b/dask/array/einsumfuncs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import numpy as np
-from numpy.compat import basestring
 
 from dask.array.core import asarray, blockwise, einsum_lookup
 from dask.utils import derived_from
@@ -53,7 +52,7 @@ def parse_einsum_input(operands):
     if len(operands) == 0:
         raise ValueError("No input operands")
 
-    if isinstance(operands[0], basestring):
+    if isinstance(operands[0], str):
         subscripts = operands[0].replace(" ", "")
         operands = [asarray(o) for o in operands[1:]]
 


### PR DESCRIPTION
Fixes deprecation with numpy.compat:

```
dask/array/tests/test_array_core.py: DeprecationWarning: `np.compat`, which was used during the Python 2 to 3 transition, is deprecated since 1.26.0, and will be removed
```

See https://github.com/dask/dask/issues/10347.

- [x] Passes `pre-commit run --all-files`
