### PR TITLE
Remove no longer supported ``clip_lower`` and ``clip_upper``

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4996,14 +4996,6 @@ class DataFrame(_Frame):
         return self._meta.dtypes
 
     @derived_from(pd.DataFrame)
-    def get_dtype_counts(self):
-        return self._meta.get_dtype_counts()
-
-    @derived_from(pd.DataFrame)
-    def get_ftype_counts(self):
-        return self._meta.get_ftype_counts()
-
-    @derived_from(pd.DataFrame)
     def select_dtypes(self, include=None, exclude=None):
         cs = self._meta.select_dtypes(include=include, exclude=exclude)
         indexer = self._get_columns_indexes_based_on_dtypes(cs)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4253,18 +4253,6 @@ Dask Name: {name}, {layers}""".format(
         )
 
     @derived_from(pd.Series)
-    def clip_lower(self, threshold):
-        return self.map_partitions(
-            M.clip_lower, threshold=threshold, enforce_metadata=False
-        )
-
-    @derived_from(pd.Series)
-    def clip_upper(self, threshold):
-        return self.map_partitions(
-            M.clip_upper, threshold=threshold, enforce_metadata=False
-        )
-
-    @derived_from(pd.Series)
     def align(self, other, join="outer", axis=None, fill_value=None):
         return super().align(other, join=join, axis=axis, fill_value=fill_value)
 
@@ -5505,18 +5493,6 @@ class DataFrame(_Frame):
             raise ValueError("'out' must be None")
         return self.map_partitions(
             M.clip, lower=lower, upper=upper, enforce_metadata=False
-        )
-
-    @derived_from(pd.DataFrame)
-    def clip_lower(self, threshold):
-        return self.map_partitions(
-            M.clip_lower, threshold=threshold, enforce_metadata=False
-        )
-
-    @derived_from(pd.DataFrame)
-    def clip_upper(self, threshold):
-        return self.map_partitions(
-            M.clip_upper, threshold=threshold, enforce_metadata=False
         )
 
     @derived_from(pd.DataFrame)

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -161,8 +161,6 @@ Series
    Series.bfill
    Series.clear_divisions
    Series.clip
-   Series.clip_lower
-   Series.clip_upper
    Series.compute
    Series.copy
    Series.corr
@@ -279,8 +277,6 @@ Index
    Index.bfill
    Index.clear_divisions
    Index.clip
-   Index.clip_lower
-   Index.clip_upper
    Index.compute
    Index.copy
    Index.corr


### PR DESCRIPTION
- [x] Passes `pre-commit run --all-files`

These have been removed ages ago (pandas 1.0 or even earlier). They don't work anymore, so no need to keep them around

Same for ``get_dtype_counts`` and ``get_ftype_counts``