### PR TITLE
Fix ``test_first_and_last`` to accommodate deprecated ``last``

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4541,7 +4541,6 @@ def test_first_and_last(method):
     f = lambda x, offset: getattr(x, method)(offset)
     freqs = ["12h", "D"]
     offsets = ["0d", "100h", "20d", "20B", "3W", "3M", "400d", "13M"]
-    should_warn = PANDAS_GT_210 and method == "first"
 
     for freq in freqs:
         index = pd.date_range("1/1/2000", "1/1/2001", freq=freq)[::4]
@@ -4550,15 +4549,15 @@ def test_first_and_last(method):
         )
         ddf = dd.from_pandas(df, npartitions=10)
         for offset in offsets:
-            with _check_warning(should_warn, FutureWarning, "first"):
+            with _check_warning(PANDAS_GT_210, FutureWarning, method):
                 expected = f(df, offset)
-            with _check_warning(should_warn, FutureWarning, "first"):
+            with _check_warning(PANDAS_GT_210, FutureWarning, method):
                 actual = f(ddf, offset)
             assert_eq(actual, expected)
 
-            with _check_warning(should_warn, FutureWarning, "first"):
+            with _check_warning(PANDAS_GT_210, FutureWarning, method):
                 expected = f(df.A, offset)
-            with _check_warning(should_warn, FutureWarning, "first"):
+            with _check_warning(PANDAS_GT_210, FutureWarning, method):
                 actual = f(ddf.A, offset)
             assert_eq(actual, expected)
 


### PR DESCRIPTION
This fixes 

```
FAILED dask/dataframe/tests/test_dataframe.py::test_first_and_last[last] - FutureWarning: last is deprecated and will be removed in a future version. Please create a mask and filter using `.loc` instead
```

which we're currently seeing in the upstream build (xref https://github.com/dask/dask/issues/10347). 

Note that we were already emitting a `FutureWarning` for `DataFrame.last`, so this is a tests-only PR 

cc @j-bennet @phofl 