### PR TITLE
Basic support for scipy.sparse array classes

### DIFF
--- a/dask/array/backends.py
+++ b/dask/array/backends.py
@@ -212,7 +212,16 @@ def register_scipy_sparse():
             )
             raise ValueError(msg)
 
+    # scipy.sparse.hstack and vstack coerce to matrix classes as of scipy 1.11.0, so we
+    # wrap and unwrap here
+    def _concatenate_array_class(L, axis=0):
+        cls = type(L[0])
+        mtx_cls = getattr(scipy.sparse, f"{L[0].format}_matrix")
+        result = _concatenate([mtx_cls(x) for x in L], axis=axis)
+        return cls(result)
+
     concatenate_lookup.register(scipy.sparse.spmatrix, _concatenate)
+    concatenate_lookup.register(scipy.sparse.sparray, _concatenate_array_class)
     tensordot_lookup.register(scipy.sparse.spmatrix, _tensordot_scipy_sparse)
 
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -1328,10 +1328,17 @@ def register_scipy():
         (sp.csr_matrix, ("data", "indices", "indptr", "shape")),
         (sp.csc_matrix, ("data", "indices", "indptr", "shape")),
         (sp.lil_matrix, ("data", "rows", "shape")),
+        (sp.dia_array, ("data", "offsets", "shape")),
+        (sp.bsr_array, ("data", "indices", "indptr", "blocksize", "shape")),
+        (sp.coo_array, ("data", "row", "col", "shape")),
+        (sp.csr_array, ("data", "indices", "indptr", "shape")),
+        (sp.csc_array, ("data", "indices", "indptr", "shape")),
+        (sp.lil_array, ("data", "rows", "shape")),
     ]:
         normalize_token.register(cls, partial(normalize_sparse_matrix, attrs=attrs))
 
     @normalize_token.register(sp.dok_matrix)
+    @normalize_token.register(sp.dok_array)
     def normalize_dok_matrix(x):
         return type(x).__name__, normalize_token(sorted(x.items()))
 


### PR DESCRIPTION
- [x] Closes #10375
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This PR adds basic support for the scipy sparse array classes. Currently, this just implements tokenization and concatenation.

These classes are currently under development, so some less than ideal code has been needed for concatenation. Ideally this could be removed once scipy allows concatenating sparse arrays such that an array (and not a matrix) is returned. However, I'm not totally clear on how dask does minimum versions of its dependencies.

Update: I have found some info on minimum test versions via failing tests 😅