### PR TITLE
Ensure that ``df`` is immutable after ``from_pandas``

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -289,12 +289,16 @@ def from_pandas(
     if sort:
         if not data.index.is_monotonic_increasing:
             data = data.sort_index(ascending=True)
+        else:
+            # sort_index copies as well
+            data = data.copy()
         divisions, locations = sorted_division_locations(
             data.index,
             npartitions=npartitions,
             chunksize=chunksize,
         )
     else:
+        data = data.copy()
         if chunksize is None:
             assert isinstance(npartitions, int)
             chunksize = int(ceil(nrows / npartitions))

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -335,6 +335,16 @@ def test_from_pandas_convert_string_config_raises():
             dd.from_pandas(df, npartitions=2)
 
 
+@pytest.mark.parametrize("index", [[1, 2, 3], [3, 2, 1]])
+@pytest.mark.parametrize("sort", [True, False])
+def test_from_pandas_immutable(sort, index):
+    pdf = pd.DataFrame({"a": [1, 2, 3]}, index=index)
+    expected = pdf.copy()
+    df = dd.from_pandas(pdf, npartitions=2, sort=sort)
+    pdf.iloc[0, 0] = 100
+    assert_eq(df, expected)
+
+
 @pytest.mark.gpu
 def test_gpu_from_pandas_npartitions_duplicates():
     cudf = pytest.importorskip("cudf")

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5592,7 +5592,7 @@ def test_attrs_series_in_dataframes():
     # the attrs dict for series in a dataframe. Dask uses df.iloc[:0]
     # when creating the _meta dataframe in make_meta_pandas(x, index=None).
     # Should start xpassing when df.iloc works. Remove the xfail then.
-    assert df.A.attrs == ddf.A.attrs
+    assert {"unit": "KG"} == ddf.A.attrs
 
 
 def test_join_series():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5579,22 +5579,6 @@ def test_attrs_series():
     assert s.fillna(1).attrs == ds.fillna(1).attrs
 
 
-@pytest.mark.xfail(
-    not PANDAS_GT_150 or pd.options.mode.copy_on_write is False,
-    reason="df.iloc[:0] does not keep the series attrs without CoW",
-)
-def test_attrs_series_in_dataframes():
-    df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
-    df.A.attrs["unit"] = "kg"
-    ddf = dd.from_pandas(df, 2)
-
-    # Fails because the pandas iloc method doesn't currently persist
-    # the attrs dict for series in a dataframe. Dask uses df.iloc[:0]
-    # when creating the _meta dataframe in make_meta_pandas(x, index=None).
-    # Should start xpassing when df.iloc works. Remove the xfail then.
-    assert {"unit": "KG"} == ddf.A.attrs
-
-
 def test_join_series():
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7, 8]})
     ddf = dd.from_pandas(df, npartitions=1)


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

We had a similar problem in dask-expr