### PR TITLE
Fix typo in `_clean_ipython_traceback`

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -79,7 +79,7 @@ def _clean_ipython_traceback(self, etype, value, tb, tb_offset=None):
     stb = self.InteractiveTB.structured_traceback(
         etype, short_exc, short_tb, tb_offset=tb_offset
     )
-    self._showtraceback(type, short_exc, stb)
+    self._showtraceback(etype, short_exc, stb)
 
 
 try:


### PR DESCRIPTION
Regression from #10354 - exception types of unhandled exceptions in ipython contexts were mangled and always set to `type`.

To reproduce, run the following in a jupyter notebook cell with dask 2023.6.1:

```python
import dask
raise TypeError("wat")
```

Then, observe the websocket connection to jupyter; the message with `msg_type="error"` looks like this:

![image](https://github.com/dask/dask/assets/5778/088f3a13-de7f-4430-a01a-63fc9e6ac3ec)

Notice `content["ename"]` is set to `"type"`.

With dask 2023.6.0, `content["ename"]` is properly set to `"TypeError"`:

![image](https://github.com/dask/dask/assets/5778/095b740b-5a54-4ebd-8ae4-781bcd143b45)

These values aren't inconsequential - they end up being serialized into the `ipynb` file, and cause hard to debug issues.

(nb: I would prefer if this kind of issue was not something that can be caused by `import dask`, by opting in to this functionality by configuration or actively registering the hook functions)

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Thanks to @matbryan52 for the help debugging this.